### PR TITLE
02.01 research schema guard: freeze contract + drift tests

### DIFF
--- a/research/results.py
+++ b/research/results.py
@@ -8,6 +8,49 @@ import json
 from datetime import datetime, timezone
 
 
+# Frozen public output contracts. Do NOT edit without an approved
+# contract change. These tuples are consumed by the guards below.
+ROW_SCHEMA: tuple[str, ...] = (
+    "timestamp_utc",
+    "strategy_name",
+    "family",
+    "hypothesis",
+    "asset",
+    "interval",
+    "params_json",
+    "success",
+    "error",
+    "win_rate",
+    "sharpe",
+    "deflated_sharpe",
+    "max_drawdown",
+    "trades_per_maand",
+    "consistentie",
+    "totaal_trades",
+    "goedgekeurd",
+    "criteria_checks_json",
+    "reden",
+)
+
+JSON_TOP_LEVEL_SCHEMA: tuple[str, ...] = (
+    "generated_at_utc",
+    "count",
+    "summary",
+    "results",
+)
+
+JSON_SUMMARY_SCHEMA: tuple[str, ...] = (
+    "success",
+    "failed",
+    "goedgekeurd",
+)
+
+
+class SchemaDriftError(RuntimeError):
+    """Raised when a research output row or payload drifts from the
+    frozen contract. Never catch broadly - drift must surface."""
+
+
 CSV_PATH = "research/strategy_matrix.csv"
 JSON_PATH = "research/research_latest.json"
 
@@ -46,21 +89,51 @@ def make_result_row(strategy, asset, interval, params, as_of_utc, metrics=None, 
     }
 
 
+def _assert_row_schema(row, index):
+    actual = tuple(row.keys())
+    if actual != ROW_SCHEMA:
+        missing = tuple(k for k in ROW_SCHEMA if k not in actual)
+        extra = tuple(k for k in actual if k not in ROW_SCHEMA)
+        raise SchemaDriftError(
+            f"row {index} schema drift: "
+            f"missing={missing} extra={extra} "
+            f"actual_order={actual}"
+        )
+
+
+def _assert_payload_schema(payload):
+    top = tuple(payload.keys())
+    if top != JSON_TOP_LEVEL_SCHEMA:
+        raise SchemaDriftError(
+            f"json top-level drift: actual_order={top} "
+            f"expected={JSON_TOP_LEVEL_SCHEMA}"
+        )
+    summary = tuple(payload["summary"].keys())
+    if summary != JSON_SUMMARY_SCHEMA:
+        raise SchemaDriftError(
+            f"json summary drift: actual_order={summary} "
+            f"expected={JSON_SUMMARY_SCHEMA}"
+        )
+
+
 def write_results_to_csv(rows, path=CSV_PATH):
     if not rows:
         return
 
-    fieldnames = list(rows[0].keys())
+    for i, row in enumerate(rows):
+        _assert_row_schema(row, i)
 
     with open(path, "w", newline="", encoding="utf-8") as f:
-        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer = csv.DictWriter(f, fieldnames=list(ROW_SCHEMA))
         writer.writeheader()
-
         for row in rows:
             writer.writerow(row)
 
 
 def write_latest_json(rows, as_of_utc, path=JSON_PATH):
+    for i, row in enumerate(rows):
+        _assert_row_schema(row, i)
+
     payload = {
         "generated_at_utc": format_utc_timestamp(as_of_utc),
         "count": len(rows),
@@ -71,6 +144,8 @@ def write_latest_json(rows, as_of_utc, path=JSON_PATH):
         },
         "results": rows,
     }
+
+    _assert_payload_schema(payload)
 
     with open(path, "w", encoding="utf-8") as f:
         json.dump(payload, f, indent=2)

--- a/tests/regression/test_research_schema_guard.py
+++ b/tests/regression/test_research_schema_guard.py
@@ -1,0 +1,158 @@
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from research.results import (
+    JSON_SUMMARY_SCHEMA,
+    JSON_TOP_LEVEL_SCHEMA,
+    ROW_SCHEMA,
+    SchemaDriftError,
+    _assert_payload_schema,
+    make_result_row,
+    write_latest_json,
+    write_results_to_csv,
+)
+
+
+AS_OF_UTC = datetime(2026, 4, 8, 10, 59, 31, 381566, tzinfo=UTC)
+FIXTURE_CSV_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "fixtures"
+    / "research_schema_stability"
+    / "strategy_matrix.csv"
+)
+
+
+def _strategy():
+    return {
+        "name": "synthetic_strategy",
+        "family": "trend",
+        "hypothesis": "Synthetic hypothesis",
+    }
+
+
+def _metrics():
+    return {
+        "win_rate": 0.55,
+        "sharpe": 1.234,
+        "deflated_sharpe": 1.111,
+        "max_drawdown": 0.12,
+        "trades_per_maand": 2.5,
+        "consistentie": 0.75,
+        "totaal_trades": 12,
+        "goedgekeurd": True,
+        "criteria_checks": {
+            "consistentie": True,
+            "deflated_sharpe": True,
+            "max_drawdown": True,
+            "trades_per_maand": True,
+            "win_rate": True,
+        },
+        "reden": "",
+    }
+
+
+def _row():
+    return make_result_row(
+        strategy=_strategy(),
+        asset="BTC-USD",
+        interval="1d",
+        params={"periode": 14},
+        as_of_utc=AS_OF_UTC,
+        metrics=_metrics(),
+    )
+
+
+def test_row_schema_matches_make_result_row_keys():
+    row = _row()
+
+    assert tuple(row.keys()) == ROW_SCHEMA
+
+
+def test_json_top_level_schema_matches_write_latest_json(tmp_path):
+    path = tmp_path / "research_latest.json"
+    write_latest_json([_row()], as_of_utc=AS_OF_UTC, path=path)
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+
+    assert tuple(payload.keys()) == JSON_TOP_LEVEL_SCHEMA
+
+
+def test_json_summary_schema_matches_write_latest_json(tmp_path):
+    path = tmp_path / "research_latest.json"
+    write_latest_json([_row()], as_of_utc=AS_OF_UTC, path=path)
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+
+    assert tuple(payload["summary"].keys()) == JSON_SUMMARY_SCHEMA
+
+
+def test_write_csv_rejects_extra_row_key(tmp_path):
+    row = _row()
+    row["bogus_key"] = "unexpected"
+
+    with pytest.raises(SchemaDriftError, match="drift") as excinfo:
+        write_results_to_csv([row], path=tmp_path / "strategy_matrix.csv")
+
+    assert "bogus_key" in str(excinfo.value)
+
+
+def test_write_csv_rejects_missing_row_key(tmp_path):
+    row = _row()
+    row.pop("reden")
+
+    with pytest.raises(SchemaDriftError) as excinfo:
+        write_results_to_csv([row], path=tmp_path / "strategy_matrix.csv")
+
+    assert "reden" in str(excinfo.value)
+
+
+def test_write_json_rejects_reordered_top_level():
+    payload = {
+        "count": 1,
+        "generated_at_utc": AS_OF_UTC.isoformat(),
+        "summary": {
+            "success": 1,
+            "failed": 0,
+            "goedgekeurd": 1,
+        },
+        "results": [_row()],
+    }
+
+    with pytest.raises(SchemaDriftError):
+        _assert_payload_schema(payload)
+
+
+def test_csv_header_line_equals_row_schema_joined(tmp_path):
+    path = tmp_path / "strategy_matrix.csv"
+    write_results_to_csv([_row()], path=path)
+
+    header = path.read_text(encoding="utf-8").splitlines()[0]
+
+    assert header == ",".join(ROW_SCHEMA)
+
+
+def test_fixture_csv_header_matches_row_schema():
+    header = FIXTURE_CSV_PATH.read_text(encoding="utf-8").splitlines()[0]
+
+    assert header == ",".join(ROW_SCHEMA)
+
+
+def test_happy_path_real_make_result_row_roundtrip(tmp_path):
+    row = _row()
+    csv_path = tmp_path / "strategy_matrix.csv"
+    json_path = tmp_path / "research_latest.json"
+
+    write_results_to_csv([row], path=csv_path)
+    write_latest_json([row], as_of_utc=AS_OF_UTC, path=json_path)
+
+    csv_lines = csv_path.read_text(encoding="utf-8").splitlines()
+    payload = json.loads(json_path.read_text(encoding="utf-8"))
+
+    assert len(csv_lines) == 2
+    assert csv_lines[0] == ",".join(ROW_SCHEMA)
+    assert tuple(payload.keys()) == JSON_TOP_LEVEL_SCHEMA
+    assert tuple(payload["summary"].keys()) == JSON_SUMMARY_SCHEMA
+    assert tuple(payload["results"][0].keys()) == ROW_SCHEMA


### PR DESCRIPTION
## Summary
Freeze the research CSV/JSON public contract at the write boundary and add regression coverage for schema drift.

## Scope
- Add inline frozen schema constants and `SchemaDriftError` in `research/results.py`
- Validate every row before CSV and JSON writes
- Validate JSON top-level and summary key order before serialization
- Add nine regression tests covering drift failures, fixture-header enforcement, and a real happy-path roundtrip

## Why
The research outputs are a public contract for downstream review and automation. This change makes schema drift fail fast instead of silently changing CSV headers or JSON payload shape.

## Validation
- `tests/regression/test_research_schema_stability.py`: passed unchanged
- `tests/regression/test_research_schema_guard.py`: 9 passed
- `tests/`: 195 passed, 1 skipped
- `research/research_latest.json` SHA unchanged vs main
- `research/strategy_matrix.csv` SHA unchanged vs main

## Known caveats
- Guards enforce key order and presence, not field types or value semantics
- Embedded JSON strings are not schema-validated
- mypy and flake8 were not installed in this environment

## Not merging
This branch was pushed for review only. No merge to main performed.
