### PR TITLE
02.02 tier1: add baseline bundle strategies and unit coverage

### DIFF
--- a/agent/backtesting/strategies.py
+++ b/agent/backtesting/strategies.py
@@ -387,3 +387,97 @@ def polymarket_expiry_strategie():
     def func(df: pd.DataFrame) -> pd.Series:
         return pd.Series(0, index=df.index)
     return func
+
+
+# ── SMA Crossover (Trend Following) ───────────────────────────────────────
+
+def sma_crossover_strategie(fast_window: int = 20, slow_window: int = 50):
+    """
+    Classical SMA crossover trend-following strategy.
+    Long when fast SMA > slow SMA, flat otherwise.
+    Long-only per tier 1 baseline (orchestrator_brief §4.1).
+    """
+    def func(df: pd.DataFrame) -> pd.Series:
+        close = df["close"].astype(float)
+        min_bars = max(fast_window, slow_window) + 1
+        if len(close) < min_bars or fast_window >= slow_window:
+            return pd.Series(0, index=df.index)
+
+        sma_fast = close.rolling(window=fast_window).mean()
+        sma_slow = close.rolling(window=slow_window).mean()
+
+        sig = pd.Series(0, index=df.index)
+        sig[sma_fast > sma_slow] = 1
+        return sig
+    return func
+
+
+# ── Z-Score Mean Reversion ────────────────────────────────────────────────
+
+def zscore_mean_reversion_strategie(lookback: int = 20,
+                                    entry_z: float = 2.0,
+                                    exit_z: float = 0.5):
+    """
+    Classical price z-score mean reversion (orchestrator_brief §4.2).
+    Long when z <= -entry_z, short when z >= +entry_z,
+    flat when |z| <= exit_z (flatten-on-threshold exit).
+    """
+    def func(df: pd.DataFrame) -> pd.Series:
+        close = df["close"].astype(float)
+        if len(close) < lookback + 1 or entry_z <= exit_z:
+            return pd.Series(0, index=df.index)
+
+        mean = close.rolling(window=lookback).mean()
+        std = close.rolling(window=lookback).std(ddof=0)
+        z = (close - mean) / std.replace(0.0, np.nan)
+
+        sig = pd.Series(0, index=df.index)
+        sig[z <= -entry_z] = 1
+        sig[z >= entry_z] = -1
+        sig[z.abs() <= exit_z] = 0
+        return sig
+    return func
+
+
+# ── Pairs Trading Z-Score (Statistical Arbitrage) ─────────────────────────
+
+def pairs_zscore_strategie(lookback: int = 30,
+                           entry_z: float = 2.0,
+                           exit_z: float = 0.5,
+                           hedge_ratio: float = 1.0):
+    """
+    Pairs trading z-score strategy (orchestrator_brief §4.3).
+    Requires a DataFrame with BOTH 'close' and 'close_ref' columns.
+    Spread = close - hedge_ratio * close_ref.
+    Long pair when spread z <= -entry_z (long close, short close_ref).
+    Short pair when spread z >= +entry_z (short close, long close_ref).
+    Flat when |z| <= exit_z.
+
+    NOTE: the current backtest engine loads a single DataFrame per
+    asset and does not yet populate a 'close_ref' column. This
+    factory is therefore registered with enabled=False until a
+    separate multi-asset loader scaffold prompt wires in the
+    second price series. The function is independently
+    unit-testable on synthetic two-column frames.
+    """
+    def func(df: pd.DataFrame) -> pd.Series:
+        if "close" not in df.columns or "close_ref" not in df.columns:
+            return pd.Series(0, index=df.index)
+
+        close = df["close"].astype(float)
+        close_ref = df["close_ref"].astype(float)
+
+        if len(close) < lookback + 1 or entry_z <= exit_z:
+            return pd.Series(0, index=df.index)
+
+        spread = close - hedge_ratio * close_ref
+        mean = spread.rolling(window=lookback).mean()
+        std = spread.rolling(window=lookback).std(ddof=0)
+        z = (spread - mean) / std.replace(0.0, np.nan)
+
+        sig = pd.Series(0, index=df.index)
+        sig[z <= -entry_z] = 1
+        sig[z >= entry_z] = -1
+        sig[z.abs() <= exit_z] = 0
+        return sig
+    return func

--- a/research/registry.py
+++ b/research/registry.py
@@ -13,9 +13,12 @@ from agent.backtesting.strategies import (
     bollinger_regime_strategie,
     bollinger_strategie,
     breakout_momentum_strategie,
+    pairs_zscore_strategie,
     rsi_strategie,
+    sma_crossover_strategie,
     trend_pullback_strategie,
     trend_pullback_tp_sl_strategie,
+    zscore_mean_reversion_strategie,
 )
 
 STRATEGIES = [
@@ -105,6 +108,63 @@ STRATEGIES = [
         "family": "trend",
         "hypothesis": "Crypto kan sterker reageren op breakout momentum dan op mean reversion.",
         "enabled": True,
+    },
+    {
+        "name": "sma_crossover",
+        "factory": sma_crossover_strategie,
+        "params": {
+            "fast_window": [10, 20],
+            "slow_window": [50, 100],
+        },
+        "family": "trend",
+        "hypothesis": (
+            "Klassieke SMA crossover capturet persistent directional moves "
+            "per orchestrator_brief §4.1 tier 1 baseline."
+        ),
+        "enabled": True,
+    },
+    {
+        "name": "zscore_mean_reversion",
+        "factory": zscore_mean_reversion_strategie,
+        "params": {
+            "lookback": [20, 30],
+            "entry_z": [2.0],
+            "exit_z": [0.5],
+        },
+        "family": "mean_reversion",
+        "hypothesis": (
+            "Price z-score mean reversion capturet deviations from "
+            "equilibrium per orchestrator_brief §4.2 tier 1 baseline."
+        ),
+        "enabled": True,
+    },
+    # -------------------------------------------------------------------
+    # pairs_zscore — enabled=False is intentional.
+    # Blocker: the backtest engine currently loads one DataFrame per
+    # asset (see agent/backtesting/engine.py:_run_op_split). A
+    # 'close_ref' column is never populated, so the pairs factory
+    # cannot run inside the existing pipeline. Wiring is deferred to
+    # a separate future multi-asset loader scaffold prompt. Do NOT
+    # flip this flag to True without that scaffold in place.
+    # -------------------------------------------------------------------
+    {
+        "name": "pairs_zscore",
+        "factory": pairs_zscore_strategie,
+        "params": {
+            "lookback": [30],
+            "entry_z": [2.0],
+            "exit_z": [0.5],
+            "hedge_ratio": [1.0],
+        },
+        "family": "stat_arb",
+        "hypothesis": (
+            "Spread z-score pairs trading per orchestrator_brief §4.3 "
+            "tier 1 baseline. enabled=False is intentional: the "
+            "current engine has no multi-asset loader to populate "
+            "'close_ref'. Pipeline wiring deferred to a separate "
+            "future multi-asset loader scaffold prompt."
+        ),
+        "enabled": False,
     },
 ]
 

--- a/tests/unit/test_tier1_strategies.py
+++ b/tests/unit/test_tier1_strategies.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from agent.backtesting.strategies import (
+    pairs_zscore_strategie,
+    sma_crossover_strategie,
+    zscore_mean_reversion_strategie,
+)
+from research.registry import STRATEGIES, get_enabled_strategies
+
+
+def make_ohlcv_frame(n: int = 300, seed: int = 7) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    returns = rng.normal(0.0005, 0.015, n)
+    close = 100.0 * np.cumprod(1 + returns)
+    return make_frame_from_close(close, seed=seed + 1)
+
+
+def make_frame_from_close(close: np.ndarray | list[float], seed: int = 11) -> pd.DataFrame:
+    close_arr = np.asarray(close, dtype=float)
+    rng = np.random.default_rng(seed)
+    high = close_arr * (1 + rng.uniform(0.0, 0.01, len(close_arr)))
+    low = close_arr * (1 - rng.uniform(0.0, 0.01, len(close_arr)))
+    open_ = close_arr * (1 + rng.normal(0.0, 0.003, len(close_arr)))
+    volume = rng.integers(1_000, 10_000, len(close_arr))
+    index = pd.date_range("2024-01-01", periods=len(close_arr), freq="D")
+    return pd.DataFrame(
+        {
+            "open": open_,
+            "high": high,
+            "low": low,
+            "close": close_arr,
+            "volume": volume,
+        },
+        index=index,
+    )
+
+
+def make_pairs_frame(n: int = 300, seed: int = 21) -> pd.DataFrame:
+    df = make_ohlcv_frame(n=n, seed=seed)
+    rng = np.random.default_rng(seed + 1)
+    df["close_ref"] = df["close"] * 0.99 + rng.normal(0.0, 0.2, n)
+    return df
+
+
+def test_sma_crossover_output_length():
+    df = make_ohlcv_frame(300, seed=1)
+    sig = sma_crossover_strategie()(df)
+
+    assert len(sig) == len(df)
+
+
+def test_sma_crossover_signal_values_in_valid_set():
+    df = make_ohlcv_frame(300, seed=2)
+    sig = sma_crossover_strategie()(df)
+
+    assert set(sig.unique()) <= {0, 1}
+
+
+def test_sma_crossover_returns_zeros_when_insufficient_bars():
+    df = make_ohlcv_frame(10, seed=3)
+    sig = sma_crossover_strategie()(df)
+
+    assert (sig == 0).all()
+
+
+def test_sma_crossover_rejects_inverted_windows():
+    df = make_ohlcv_frame(300, seed=4)
+    sig = sma_crossover_strategie(fast_window=50, slow_window=20)(df)
+
+    assert (sig == 0).all()
+
+
+def test_sma_crossover_detects_known_cross():
+    close = np.array([10, 10, 10, 10, 10, 11, 12, 13, 12, 11, 10], dtype=float)
+    df = make_frame_from_close(close)
+    sig = sma_crossover_strategie(fast_window=3, slow_window=5)(df)
+    sma_fast = df["close"].rolling(window=3).mean()
+    sma_slow = df["close"].rolling(window=5).mean()
+    active_mask = sma_fast > sma_slow
+
+    assert sig.iloc[5] == pytest.approx(1.0)
+    assert sig[active_mask].eq(1).all()
+
+
+def test_zscore_mr_output_length():
+    df = make_ohlcv_frame(300, seed=5)
+    sig = zscore_mean_reversion_strategie()(df)
+
+    assert len(sig) == len(df)
+
+
+def test_zscore_mr_signal_values_in_valid_set():
+    df = make_ohlcv_frame(300, seed=6)
+    sig = zscore_mean_reversion_strategie()(df)
+
+    assert set(sig.unique()) <= {-1, 0, 1}
+
+
+def test_zscore_mr_returns_zeros_when_insufficient_bars():
+    df = make_ohlcv_frame(10, seed=7)
+    sig = zscore_mean_reversion_strategie()(df)
+
+    assert (sig == 0).all()
+
+
+def test_zscore_mr_rejects_degenerate_thresholds():
+    df = make_ohlcv_frame(300, seed=8)
+    sig = zscore_mean_reversion_strategie(entry_z=0.5, exit_z=1.0)(df)
+
+    assert (sig == 0).all()
+
+
+def test_zscore_mr_detects_known_extreme():
+    close = np.array([10, 10, 10, 10, 10, 20, 10, 10, 10, 10], dtype=float)
+    df = make_frame_from_close(close)
+    sig = zscore_mean_reversion_strategie(
+        lookback=5,
+        entry_z=2.0,
+        exit_z=0.5,
+    )(df)
+
+    assert sig.iloc[5] == pytest.approx(-1.0)
+    assert sig.iloc[6] == pytest.approx(0.0)
+
+
+def test_pairs_zscore_output_length():
+    df = make_pairs_frame(300, seed=9)
+    sig = pairs_zscore_strategie()(df)
+
+    assert len(sig) == len(df)
+
+
+def test_pairs_zscore_signal_values_in_valid_set():
+    df = make_pairs_frame(300, seed=10)
+    sig = pairs_zscore_strategie()(df)
+
+    assert set(sig.unique()) <= {-1, 0, 1}
+
+
+def test_pairs_zscore_returns_zeros_when_close_ref_missing():
+    df = make_ohlcv_frame(300, seed=11)[["close"]]
+    sig = pairs_zscore_strategie()(df)
+
+    assert (sig == 0).all()
+
+
+def test_pairs_zscore_returns_zeros_when_insufficient_bars():
+    df = make_pairs_frame(10, seed=12)
+    sig = pairs_zscore_strategie()(df)
+
+    assert (sig == 0).all()
+
+
+def test_pairs_zscore_detects_known_spread_deviation():
+    close = np.array([100, 100, 100, 100, 100, 90, 100, 100], dtype=float)
+    close_ref = np.array([100, 100, 100, 100, 100, 100, 100, 100], dtype=float)
+    df = make_frame_from_close(close)
+    df["close_ref"] = close_ref
+    sig = pairs_zscore_strategie(
+        lookback=5,
+        entry_z=2.0,
+        exit_z=0.5,
+        hedge_ratio=1.0,
+    )(df)
+
+    assert sig.iloc[5] == pytest.approx(1.0)
+
+
+def test_registry_includes_all_tier1_baseline_names():
+    names = {strategy["name"] for strategy in STRATEGIES}
+
+    assert {"sma_crossover", "zscore_mean_reversion", "pairs_zscore"} <= names
+
+
+def test_tier1_enabled_flags_match_baseline_blocker():
+    lookup = {strategy["name"]: strategy["enabled"] for strategy in STRATEGIES}
+
+    assert lookup["sma_crossover"] is True
+    assert lookup["zscore_mean_reversion"] is True
+    assert lookup["pairs_zscore"] is False
+
+
+def test_get_enabled_strategies_excludes_pairs_zscore():
+    names = {strategy["name"] for strategy in get_enabled_strategies()}
+
+    assert "pairs_zscore" not in names
+    assert "sma_crossover" in names
+    assert "zscore_mean_reversion" in names
+
+
+def test_tier1_param_grids_fit_sweep_budget():
+    lookup = {
+        strategy["name"]: strategy
+        for strategy in STRATEGIES
+        if strategy["name"] in {"sma_crossover", "zscore_mean_reversion", "pairs_zscore"}
+    }
+
+    for strategy in lookup.values():
+        cells = math.prod(len(values) for values in strategy["params"].values())
+        assert cells <= 64


### PR DESCRIPTION
## Summary
Add the Tier 1 baseline bundle for Prompt 02.02: SMA crossover, z-score mean reversion, and deferred pairs z-score registry wiring, plus deterministic unit coverage.

## Scope
- `agent/backtesting/strategies.py`: append three new factory functions (SMA crossover, z-score MR, pairs z-score). No edits to existing strategies.
- `research/registry.py`: register `sma_crossover` (enabled), `zscore_mean_reversion` (enabled), `pairs_zscore` (disabled with named blocker).
- `tests/unit/test_tier1_strategies.py`: 19 deterministic pytest tests.

## Why
Completes the docs/orchestrator_brief.md §4 mandatory initial strategy set. SMA and price z-score run inside the existing single-asset engine loop immediately. Pairs is unit-test-complete but pipeline-wired only once a future multi-asset loader prompt is approved — the registry hypothesis and an inline comment both explicitly document this.

## Validation
- `tests/unit/test_tier1_strategies.py`: 19 passed
- `tests/regression/test_research_schema_stability.py`: passed unchanged
- Full suite: 205 passed, 1 skipped (up from 186)
- `research/research_latest.json` SHA unchanged vs main
- `research/strategy_matrix.csv` SHA unchanged vs main
- mypy / flake8 not installed in environment

## Known caveats
- `pairs_zscore` is registered disabled. Blocker: `_run_op_split` loads one DataFrame per asset and never populates `close_ref`. Flipping the flag without the future multi-asset loader prompt is a programming error.
- `hedge_ratio` is a fixed param, not estimated from data.
- No cointegration test gates the pairs entries.
- Sweep grids are deliberately small per AGENTS.md §2.

## Not merging
Branch pushed for review only. No merge to main performed.
