### PR TITLE
fix(ci): track compatibility stub packages under data/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,22 @@ data/adapters/*
 !data/adapters/base.py
 !data/adapters/yfinance_adapter.py
 !data/adapters/fred_adapter.py
+!data/market/
+data/market/*
+!data/market/__init__.py
+!data/market/fetcher.py
+!data/sentiment/
+data/sentiment/*
+!data/sentiment/__init__.py
+!data/sentiment/scraper.py
+!data/botdetection/
+data/botdetection/*
+!data/botdetection/__init__.py
+!data/botdetection/detector.py
+!data/news/
+data/news/*
+!data/news/__init__.py
+!data/news/nieuws_fetcher.py
 data/cache/
 state/fred.secret
 

--- a/data/botdetection/__init__.py
+++ b/data/botdetection/__init__.py
@@ -1,0 +1,1 @@
+"""Compatibility stub package used for imports and test patching."""

--- a/data/botdetection/detector.py
+++ b/data/botdetection/detector.py
@@ -1,0 +1,18 @@
+"""Minimal bot detector stub used for imports and test patching."""
+
+
+class BotPatroon:
+    """Stub representation of an identified bot pattern."""
+
+    def __init__(self, naam: str = "", kenmerken: dict | None = None):
+        self.naam = naam
+        self.kenmerken = kenmerken or {}
+
+
+class BotDetector:
+    def __init__(self, config: dict):
+        self.config = config
+        self.herkende_patronen = {}
+
+    async def scan(self) -> dict:
+        return self.herkende_patronen

--- a/data/market/__init__.py
+++ b/data/market/__init__.py
@@ -1,0 +1,1 @@
+"""Compatibility stub package used for imports and test patching."""

--- a/data/market/fetcher.py
+++ b/data/market/fetcher.py
@@ -1,0 +1,9 @@
+"""Minimal market data fetcher stub used for imports and test patching."""
+
+
+class MarketDataFetcher:
+    def __init__(self, config: dict):
+        self.config = config
+
+    async def haal_alles_op(self) -> dict:
+        return {}

--- a/data/news/__init__.py
+++ b/data/news/__init__.py
@@ -1,0 +1,1 @@
+"""Compatibility stub package used for imports and test patching."""

--- a/data/news/nieuws_fetcher.py
+++ b/data/news/nieuws_fetcher.py
@@ -1,0 +1,9 @@
+"""Minimal news fetcher stub used for imports and test patching."""
+
+
+class NieuwsFetcher:
+    def __init__(self, config: dict):
+        self.config = config
+
+    async def update(self) -> None:
+        return None

--- a/data/sentiment/__init__.py
+++ b/data/sentiment/__init__.py
@@ -1,0 +1,1 @@
+"""Compatibility stub package used for imports and test patching."""

--- a/data/sentiment/scraper.py
+++ b/data/sentiment/scraper.py
@@ -1,0 +1,9 @@
+"""Minimal sentiment scraper stub used for imports and test patching."""
+
+
+class SentimentScraper:
+    def __init__(self, config: dict):
+        self.config = config
+
+    async def update(self) -> None:
+        return None


### PR DESCRIPTION
## Summary
Restore missing tracked compatibility stub packages under `data/` so CI can resolve the existing import paths used by orchestrator, agent, and smoke/integration tests.

## Root cause
`.gitignore` excluded `data/*`, so these local compatibility stubs existed on disk but were never tracked in git. CI checkouts therefore missed:
- `data.market.fetcher`
- `data.sentiment.scraper`
- `data.botdetection.detector`
- `data.news.nieuws_fetcher`

This broke:
- orchestrator imports
- smoke tests
- integration tests
- live gate import path

## Scope
- allowlist the new stub subpackages in `.gitignore`
- add the missing tracked compatibility stub packages
- include `BotPatroon` alongside `BotDetector` to close the adjacent latent import gap

## Validation
- CI-blocking tests now pass locally
- full suite: 186 passed, 1 skipped
- no Phase 3 branches touched
- no architecture refactor
- canonical research output files unchanged

## Not bundled
This PR is intentionally separate from Phase 3 prompts 02.01–02.05.