### PR TITLE
feat: complete 02.06 candidate promotion framework wiring

### DIFF
--- a/config/config.template.yaml
+++ b/config/config.template.yaml
@@ -117,6 +117,15 @@ research:
     # test_bars: 100
     # step_bars: 100
     selection_metric: "sharpe"
+  promotion:
+    min_oos_sharpe: 0.3
+    max_oos_drawdown: 0.35
+    min_psr: 0.90
+    min_dsr_canonical: 0.0
+    noise_warning_escalates: true
+    require_leakage_checks_ok: true
+    require_goedgekeurd: false
+    min_oos_trades: 10
 
 leren:
   trade_geheugen: 1000

--- a/research/promotion.py
+++ b/research/promotion.py
@@ -1,0 +1,156 @@
+"""Pure decision functions for candidate promotion.
+
+Consumes evaluation outputs and statistical defensibility data.
+Classifies each strategy run as rejected / needs_investigation / candidate.
+No side effects, no IO, no randomness.
+"""
+
+import json
+from typing import Any
+
+STATUS_REJECTED = "rejected"
+STATUS_NEEDS_INVESTIGATION = "needs_investigation"
+STATUS_CANDIDATE = "candidate"
+
+DEFAULT_PROMOTION_CONFIG: dict[str, Any] = {
+    "min_oos_sharpe": 0.3,
+    "max_oos_drawdown": 0.35,
+    "min_psr": 0.90,
+    "min_dsr_canonical": 0.0,
+    "noise_warning_escalates": True,
+    "require_leakage_checks_ok": True,
+    "require_goedgekeurd": False,
+    "min_oos_trades": 10,
+}
+
+
+def normalize_promotion_config(config: dict[str, Any] | None) -> dict[str, Any]:
+    """Merge user overrides with defaults. Unknown keys are ignored."""
+    base = dict(DEFAULT_PROMOTION_CONFIG)
+    if config:
+        for key in DEFAULT_PROMOTION_CONFIG:
+            if key in config:
+                base[key] = config[key]
+    return base
+
+
+def build_strategy_id(
+    strategy_name: str,
+    asset: str,
+    interval: str,
+    selected_params: dict,
+) -> str:
+    """Deterministic composite key for a strategy run."""
+    params_json = json.dumps(selected_params, sort_keys=True)
+    return f"{strategy_name}|{asset}|{interval}|{params_json}"
+
+
+def classify_candidate(
+    oos_summary: dict[str, Any],
+    leakage_checks_ok: bool,
+    defensibility: dict[str, Any] | None,
+    config: dict[str, Any],
+) -> tuple[str, dict[str, list[str]]]:
+    """Classify a single strategy run.
+
+    Returns (status, reasoning) where reasoning has keys
+    'passed', 'failed', 'escalated'.
+    """
+    failed: list[str] = []
+    escalated: list[str] = []
+    passed: list[str] = []
+
+    # --- Rejection rules (hard gates) ---
+    _check_rejection_rules(oos_summary, leakage_checks_ok, config, failed, passed)
+
+    if failed:
+        return STATUS_REJECTED, {"passed": passed, "failed": failed, "escalated": []}
+
+    # --- Escalation rules (soft gates) ---
+    _check_escalation_rules(defensibility, config, escalated, passed)
+
+    if escalated:
+        return STATUS_NEEDS_INVESTIGATION, {"passed": passed, "failed": [], "escalated": escalated}
+
+    return STATUS_CANDIDATE, {"passed": passed, "failed": [], "escalated": []}
+
+
+def _check_rejection_rules(
+    oos_summary: dict[str, Any],
+    leakage_checks_ok: bool,
+    config: dict[str, Any],
+    failed: list[str],
+    passed: list[str],
+) -> None:
+    """Evaluate hard rejection rules."""
+    oos_sharpe = float(oos_summary.get("sharpe", 0.0))
+    if oos_sharpe < config["min_oos_sharpe"]:
+        failed.append("oos_sharpe_below_threshold")
+    else:
+        passed.append("oos_sharpe_above_threshold")
+
+    oos_dd = float(oos_summary.get("max_drawdown", 1.0))
+    if oos_dd > config["max_oos_drawdown"]:
+        failed.append("drawdown_above_limit")
+    else:
+        passed.append("drawdown_below_limit")
+
+    if config["require_leakage_checks_ok"] and not leakage_checks_ok:
+        failed.append("leakage_detected")
+    elif config["require_leakage_checks_ok"]:
+        passed.append("leakage_checks_ok")
+
+    oos_trades = int(oos_summary.get("totaal_trades", 0))
+    if oos_trades < config["min_oos_trades"]:
+        failed.append("insufficient_trades")
+    else:
+        passed.append("sufficient_trades")
+
+    if config["require_goedgekeurd"] and not oos_summary.get("goedgekeurd", False):
+        failed.append("goedgekeurd_required_but_false")
+    elif config["require_goedgekeurd"]:
+        passed.append("goedgekeurd_passed")
+
+
+def _check_escalation_rules(
+    defensibility: dict[str, Any] | None,
+    config: dict[str, Any],
+    escalated: list[str],
+    passed: list[str],
+) -> None:
+    """Evaluate soft escalation rules."""
+    if defensibility is None:
+        escalated.append("defensibility_data_missing")
+        return
+
+    noise_warning = defensibility.get("noise_warning", {})
+    if config["noise_warning_escalates"] and noise_warning.get("is_likely_noise", False):
+        escalated.append("noise_warning_fired")
+    elif config["noise_warning_escalates"]:
+        passed.append("noise_warning_clear")
+
+    psr = defensibility.get("psr")
+    if psr is None:
+        escalated.append("psr_unavailable")
+    elif psr < config["min_psr"]:
+        escalated.append("psr_below_threshold")
+    else:
+        passed.append("psr_above_threshold")
+
+    dsr = defensibility.get("dsr_canonical")
+    if dsr is None:
+        escalated.append("dsr_unavailable")
+    elif dsr < config["min_dsr_canonical"]:
+        escalated.append("dsr_canonical_below_threshold")
+    else:
+        passed.append("dsr_canonical_above_threshold")
+
+    bootstrap_ci = defensibility.get("bootstrap_ci", {})
+    sharpe_ci = bootstrap_ci.get("sharpe", {})
+    ci_low = sharpe_ci.get("low")
+    if ci_low is None:
+        escalated.append("bootstrap_sharpe_ci_unavailable")
+    elif ci_low <= 0.0:
+        escalated.append("bootstrap_sharpe_ci_includes_zero")
+    else:
+        passed.append("bootstrap_sharpe_ci_positive")

--- a/research/promotion_reporting.py
+++ b/research/promotion_reporting.py
@@ -1,0 +1,135 @@
+"""Sidecar assembly for candidate promotion registry.
+
+Joins walk-forward, statistical defensibility, and research_latest
+artifacts to classify each strategy run and build the candidate
+registry payload. No IO — pure data transformation.
+"""
+
+import json
+from typing import Any
+
+from research.promotion import (
+    build_strategy_id,
+    classify_candidate,
+    normalize_promotion_config,
+)
+
+
+class ArtifactJoinError(Exception):
+    """Raised when required artifacts are missing or cannot be joined."""
+
+
+def build_candidate_registry_payload(
+    research_latest: dict[str, Any],
+    walk_forward: dict[str, Any],
+    statistical_defensibility: dict[str, Any] | None,
+    promotion_config: dict[str, Any] | None,
+    git_revision: str,
+) -> dict[str, Any]:
+    """Build the candidate_registry_latest.v1.json payload.
+
+    Raises ArtifactJoinError if a required artifact is malformed
+    or the join between artifacts fails.
+    """
+    config = normalize_promotion_config(promotion_config)
+    results = research_latest.get("results")
+    if not isinstance(results, list):
+        raise ArtifactJoinError("research_latest.results is missing or not a list")
+
+    wf_strategies = walk_forward.get("strategies")
+    if not isinstance(wf_strategies, list):
+        raise ArtifactJoinError("walk_forward.strategies is missing or not a list")
+
+    defensibility_index = _build_defensibility_index(statistical_defensibility)
+    wf_index = _build_walk_forward_index(wf_strategies)
+
+    candidates: list[dict[str, Any]] = []
+    for result in results:
+        if not result.get("success", False):
+            continue
+
+        strategy_name = result["strategy_name"]
+        asset = result["asset"]
+        interval = result["interval"]
+        selected_params = json.loads(result.get("params_json", "{}"))
+        strategy_id = build_strategy_id(strategy_name, asset, interval, selected_params)
+
+        wf_entry = wf_index.get((strategy_name, asset, interval))
+        if wf_entry is None:
+            raise ArtifactJoinError(
+                f"walk-forward entry missing for {strategy_name}|{asset}|{interval}"
+            )
+
+        oos_summary = wf_entry.get("oos_summary", {})
+        leakage_ok = wf_entry.get("leakage_checks_ok", False)
+        defensibility = defensibility_index.get((strategy_name, asset, interval))
+
+        status, reasoning = classify_candidate(
+            oos_summary=oos_summary,
+            leakage_checks_ok=leakage_ok,
+            defensibility=defensibility,
+            config=config,
+        )
+
+        candidates.append({
+            "strategy_id": strategy_id,
+            "strategy_name": strategy_name,
+            "asset": asset,
+            "interval": interval,
+            "selected_params": selected_params,
+            "status": status,
+            "reasoning": reasoning,
+        })
+
+    candidates.sort(key=lambda c: c["strategy_id"])
+
+    as_of_utc = research_latest.get("generated_at_utc", "")
+    return {
+        "version": "v1",
+        "generated_at_utc": as_of_utc,
+        "git_revision": git_revision,
+        "promotion_config": config,
+        "candidates": candidates,
+        "summary": _build_summary(candidates),
+    }
+
+
+def _build_summary(candidates: list[dict[str, Any]]) -> dict[str, int]:
+    """Count candidates by status."""
+    counts: dict[str, int] = {"rejected": 0, "needs_investigation": 0, "candidate": 0}
+    for entry in candidates:
+        status = entry["status"]
+        counts[status] = counts.get(status, 0) + 1
+    counts["total"] = len(candidates)
+    return counts
+
+
+def _build_walk_forward_index(
+    strategies: list[dict[str, Any]],
+) -> dict[tuple[str, str, str], dict[str, Any]]:
+    """Index walk-forward entries by (strategy_name, asset, interval)."""
+    index: dict[tuple[str, str, str], dict[str, Any]] = {}
+    for entry in strategies:
+        key = (entry["strategy_name"], entry["asset"], entry["interval"])
+        index[key] = entry
+    return index
+
+
+def _build_defensibility_index(
+    payload: dict[str, Any] | None,
+) -> dict[tuple[str, str, str], dict[str, Any]]:
+    """Index defensibility members by (strategy_name, asset, interval).
+
+    Returns empty dict if payload is None (defensibility is optional
+    for classification — classify_candidate handles None defensibility).
+    """
+    if payload is None:
+        return {}
+
+    index: dict[tuple[str, str, str], dict[str, Any]] = {}
+    for family_entry in payload.get("families", []):
+        interval = family_entry["interval"]
+        for member in family_entry.get("members", []):
+            key = (member["strategy_name"], member["asset"], interval)
+            index[key] = member
+    return index

--- a/research/run_research.py
+++ b/research/run_research.py
@@ -21,11 +21,13 @@ from agent.backtesting.engine import (
 )
 from research.registry import get_enabled_strategies
 from research.results import make_result_row, write_latest_json, write_results_to_csv
+from research.promotion_reporting import build_candidate_registry_payload
 from research.statistical_reporting import build_statistical_defensibility_payload, regime_count_settings
 from research.universe import build_research_universe
 
 SIDE_CAR_PATH = Path("research/statistical_defensibility_latest.v1.json")
 WALK_FORWARD_PATH = "research/walk_forward_latest.v1.json"
+CANDIDATE_REGISTRY_PATH = Path("research/candidate_registry_latest.v1.json")
 
 
 def load_research_config(config_path="config/config.yaml"):
@@ -159,6 +161,42 @@ def _write_walk_forward_sidecar(
         json.dump(payload, handle, indent=2)
 
 
+def _write_candidate_registry(
+    *,
+    rows: list[dict],
+    walk_forward_reports: list[dict],
+    research_config: dict,
+    as_of_utc,
+    path: Path = CANDIDATE_REGISTRY_PATH,
+) -> None:
+    """Build and write candidate registry from in-memory artifacts.
+
+    Skips silently when walk_forward_reports is empty (no OOS data to promote).
+    """
+    if not walk_forward_reports:
+        return
+
+    research_latest = {
+        "generated_at_utc": as_of_utc.isoformat(),
+        "results": rows,
+    }
+    walk_forward = {"strategies": walk_forward_reports}
+
+    statistical_defensibility = None
+    if SIDE_CAR_PATH.exists():
+        with SIDE_CAR_PATH.open(encoding="utf-8") as handle:
+            statistical_defensibility = json.load(handle)
+
+    payload = build_candidate_registry_payload(
+        research_latest=research_latest,
+        walk_forward=walk_forward,
+        statistical_defensibility=statistical_defensibility,
+        promotion_config=research_config.get("promotion"),
+        git_revision=_git_revision(),
+    )
+    _write_json_atomic(path, payload)
+
+
 def _build_engine(start_datum: str, eind_datum: str, evaluation_config: dict) -> BacktestEngine:
     try:
         return BacktestEngine(
@@ -285,6 +323,13 @@ def run_research():
             regime_count=regime_count,
             regime_count_source=regime_count_source,
         )
+
+    _write_candidate_registry(
+        rows=rows,
+        walk_forward_reports=walk_forward_reports,
+        research_config=research_config,
+        as_of_utc=as_of_utc,
+    )
 
     print(f"Klaar. {len(rows)} resultaten geschreven.")
     

--- a/tests/regression/test_research_schema_stability.py
+++ b/tests/regression/test_research_schema_stability.py
@@ -70,6 +70,7 @@ def test_research_outputs_remain_schema_stable(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(run_research_module, "load_research_config", lambda config_path="config/config.yaml": {})
     monkeypatch.setattr(run_research_module, "_git_revision", lambda: "deadbeef")
+    monkeypatch.setattr(run_research_module, "_write_candidate_registry", lambda **kwargs: None)
     monkeypatch.chdir(tmp_path)
     (tmp_path / "research").mkdir()
 

--- a/tests/unit/test_candidate_promotion.py
+++ b/tests/unit/test_candidate_promotion.py
@@ -1,0 +1,461 @@
+"""Tests for candidate promotion decision logic and sidecar assembly."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from research import run_research as run_research_module
+from research.promotion import (
+    STATUS_CANDIDATE,
+    STATUS_NEEDS_INVESTIGATION,
+    STATUS_REJECTED,
+    build_strategy_id,
+    classify_candidate,
+    normalize_promotion_config,
+)
+from research.promotion_reporting import (
+    ArtifactJoinError,
+    build_candidate_registry_payload,
+)
+from research.results import write_latest_json, write_results_to_csv
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _good_oos() -> dict:
+    return {
+        "sharpe": 0.8,
+        "max_drawdown": 0.15,
+        "totaal_trades": 30,
+        "goedgekeurd": True,
+    }
+
+
+def _good_defensibility() -> dict:
+    return {
+        "psr": 0.95,
+        "dsr_canonical": 0.5,
+        "noise_warning": {"is_likely_noise": False, "reason": "clear"},
+        "bootstrap_ci": {"sharpe": {"low": 0.1, "high": 1.2}},
+    }
+
+
+def _research_latest(results: list[dict] | None = None) -> dict:
+    if results is None:
+        results = [
+            {
+                "strategy_name": "trend_fast",
+                "asset": "BTC-USD",
+                "interval": "1d",
+                "params_json": '{"fast": 20, "slow": 50}',
+                "success": True,
+            }
+        ]
+    return {"generated_at_utc": "2026-04-12T00:00:00+00:00", "results": results}
+
+
+def _walk_forward(strategies: list[dict] | None = None) -> dict:
+    if strategies is None:
+        strategies = [
+            {
+                "strategy_name": "trend_fast",
+                "asset": "BTC-USD",
+                "interval": "1d",
+                "oos_summary": _good_oos(),
+                "leakage_checks_ok": True,
+            }
+        ]
+    return {"strategies": strategies}
+
+
+def _stat_defensibility(members: list[dict] | None = None) -> dict:
+    if members is None:
+        members = [
+            {
+                "strategy_name": "trend_fast",
+                "asset": "BTC-USD",
+                "selected_params": {"fast": 20, "slow": 50},
+                **_good_defensibility(),
+            }
+        ]
+    return {
+        "families": [
+            {"family": "trend", "interval": "1d", "members": members},
+        ]
+    }
+
+
+# ---------------------------------------------------------------------------
+# normalize_promotion_config
+# ---------------------------------------------------------------------------
+
+class TestNormalizeConfig:
+    def test_defaults_returned_when_none(self):
+        config = normalize_promotion_config(None)
+        assert config["min_oos_sharpe"] == 0.3
+        assert config["require_goedgekeurd"] is False
+
+    def test_overrides_applied(self):
+        config = normalize_promotion_config({"min_oos_sharpe": 0.5})
+        assert config["min_oos_sharpe"] == 0.5
+        assert config["max_oos_drawdown"] == 0.35  # default preserved
+
+    def test_unknown_keys_ignored(self):
+        config = normalize_promotion_config({"unknown_key": 999})
+        assert "unknown_key" not in config
+
+
+# ---------------------------------------------------------------------------
+# build_strategy_id
+# ---------------------------------------------------------------------------
+
+class TestBuildStrategyId:
+    def test_deterministic(self):
+        sid1 = build_strategy_id("trend_fast", "BTC-USD", "1d", {"fast": 20, "slow": 50})
+        sid2 = build_strategy_id("trend_fast", "BTC-USD", "1d", {"slow": 50, "fast": 20})
+        assert sid1 == sid2  # sort_keys=True
+
+    def test_different_params_different_id(self):
+        sid1 = build_strategy_id("trend_fast", "BTC-USD", "1d", {"fast": 20})
+        sid2 = build_strategy_id("trend_fast", "BTC-USD", "1d", {"fast": 10})
+        assert sid1 != sid2
+
+
+# ---------------------------------------------------------------------------
+# classify_candidate — rejection paths
+# ---------------------------------------------------------------------------
+
+class TestClassifyRejection:
+    def test_low_sharpe_rejected(self):
+        oos = _good_oos()
+        oos["sharpe"] = 0.1
+        status, reasoning = classify_candidate(oos, True, _good_defensibility(), normalize_promotion_config(None))
+        assert status == STATUS_REJECTED
+        assert "oos_sharpe_below_threshold" in reasoning["failed"]
+
+    def test_high_drawdown_rejected(self):
+        oos = _good_oos()
+        oos["max_drawdown"] = 0.5
+        status, reasoning = classify_candidate(oos, True, _good_defensibility(), normalize_promotion_config(None))
+        assert status == STATUS_REJECTED
+        assert "drawdown_above_limit" in reasoning["failed"]
+
+    def test_leakage_rejected(self):
+        status, reasoning = classify_candidate(_good_oos(), False, _good_defensibility(), normalize_promotion_config(None))
+        assert status == STATUS_REJECTED
+        assert "leakage_detected" in reasoning["failed"]
+
+    def test_insufficient_trades_rejected(self):
+        oos = _good_oos()
+        oos["totaal_trades"] = 3
+        status, reasoning = classify_candidate(oos, True, _good_defensibility(), normalize_promotion_config(None))
+        assert status == STATUS_REJECTED
+        assert "insufficient_trades" in reasoning["failed"]
+
+    def test_goedgekeurd_required_but_false(self):
+        oos = _good_oos()
+        oos["goedgekeurd"] = False
+        config = normalize_promotion_config({"require_goedgekeurd": True})
+        status, reasoning = classify_candidate(oos, True, _good_defensibility(), config)
+        assert status == STATUS_REJECTED
+        assert "goedgekeurd_required_but_false" in reasoning["failed"]
+
+    def test_multiple_failures_all_recorded(self):
+        oos = {"sharpe": 0.0, "max_drawdown": 0.9, "totaal_trades": 0}
+        status, reasoning = classify_candidate(oos, False, None, normalize_promotion_config(None))
+        assert status == STATUS_REJECTED
+        assert len(reasoning["failed"]) >= 3
+
+
+# ---------------------------------------------------------------------------
+# classify_candidate — escalation paths
+# ---------------------------------------------------------------------------
+
+class TestClassifyEscalation:
+    def test_defensibility_missing_escalates(self):
+        status, reasoning = classify_candidate(_good_oos(), True, None, normalize_promotion_config(None))
+        assert status == STATUS_NEEDS_INVESTIGATION
+        assert "defensibility_data_missing" in reasoning["escalated"]
+
+    def test_noise_warning_escalates(self):
+        defensibility = _good_defensibility()
+        defensibility["noise_warning"]["is_likely_noise"] = True
+        status, reasoning = classify_candidate(_good_oos(), True, defensibility, normalize_promotion_config(None))
+        assert status == STATUS_NEEDS_INVESTIGATION
+        assert "noise_warning_fired" in reasoning["escalated"]
+
+    def test_psr_below_threshold_escalates(self):
+        defensibility = _good_defensibility()
+        defensibility["psr"] = 0.5
+        status, reasoning = classify_candidate(_good_oos(), True, defensibility, normalize_promotion_config(None))
+        assert status == STATUS_NEEDS_INVESTIGATION
+        assert "psr_below_threshold" in reasoning["escalated"]
+
+    def test_psr_none_escalates(self):
+        defensibility = _good_defensibility()
+        defensibility["psr"] = None
+        status, reasoning = classify_candidate(_good_oos(), True, defensibility, normalize_promotion_config(None))
+        assert status == STATUS_NEEDS_INVESTIGATION
+        assert "psr_unavailable" in reasoning["escalated"]
+
+    def test_dsr_none_escalates(self):
+        defensibility = _good_defensibility()
+        defensibility["dsr_canonical"] = None
+        status, reasoning = classify_candidate(_good_oos(), True, defensibility, normalize_promotion_config(None))
+        assert status == STATUS_NEEDS_INVESTIGATION
+        assert "dsr_unavailable" in reasoning["escalated"]
+
+    def test_dsr_below_threshold_escalates(self):
+        defensibility = _good_defensibility()
+        defensibility["dsr_canonical"] = -0.5
+        status, reasoning = classify_candidate(_good_oos(), True, defensibility, normalize_promotion_config(None))
+        assert status == STATUS_NEEDS_INVESTIGATION
+        assert "dsr_canonical_below_threshold" in reasoning["escalated"]
+
+    def test_bootstrap_ci_includes_zero_escalates(self):
+        defensibility = _good_defensibility()
+        defensibility["bootstrap_ci"]["sharpe"]["low"] = -0.1
+        status, reasoning = classify_candidate(_good_oos(), True, defensibility, normalize_promotion_config(None))
+        assert status == STATUS_NEEDS_INVESTIGATION
+        assert "bootstrap_sharpe_ci_includes_zero" in reasoning["escalated"]
+
+    def test_bootstrap_ci_unavailable_escalates(self):
+        defensibility = _good_defensibility()
+        defensibility["bootstrap_ci"] = {}
+        status, reasoning = classify_candidate(_good_oos(), True, defensibility, normalize_promotion_config(None))
+        assert status == STATUS_NEEDS_INVESTIGATION
+        assert "bootstrap_sharpe_ci_unavailable" in reasoning["escalated"]
+
+
+# ---------------------------------------------------------------------------
+# classify_candidate — candidate (happy path)
+# ---------------------------------------------------------------------------
+
+class TestClassifyCandidate:
+    def test_all_checks_pass(self):
+        status, reasoning = classify_candidate(
+            _good_oos(), True, _good_defensibility(), normalize_promotion_config(None)
+        )
+        assert status == STATUS_CANDIDATE
+        assert reasoning["failed"] == []
+        assert reasoning["escalated"] == []
+        assert len(reasoning["passed"]) > 0
+
+    def test_deterministic(self):
+        args = (_good_oos(), True, _good_defensibility(), normalize_promotion_config(None))
+        r1 = classify_candidate(*args)
+        r2 = classify_candidate(*args)
+        assert r1 == r2
+
+
+# ---------------------------------------------------------------------------
+# build_candidate_registry_payload — integration
+# ---------------------------------------------------------------------------
+
+class TestBuildPayload:
+    def test_happy_path_produces_v1_schema(self):
+        payload = build_candidate_registry_payload(
+            research_latest=_research_latest(),
+            walk_forward=_walk_forward(),
+            statistical_defensibility=_stat_defensibility(),
+            promotion_config=None,
+            git_revision="abc123",
+        )
+        assert payload["version"] == "v1"
+        assert payload["git_revision"] == "abc123"
+        assert len(payload["candidates"]) == 1
+        assert payload["candidates"][0]["status"] == STATUS_CANDIDATE
+        assert payload["summary"]["total"] == 1
+
+    def test_missing_walk_forward_entry_raises(self):
+        with pytest.raises(ArtifactJoinError, match="walk-forward entry missing"):
+            build_candidate_registry_payload(
+                research_latest=_research_latest(),
+                walk_forward=_walk_forward(strategies=[]),
+                statistical_defensibility=None,
+                promotion_config=None,
+                git_revision="abc123",
+            )
+
+    def test_malformed_research_latest_raises(self):
+        with pytest.raises(ArtifactJoinError, match="research_latest.results"):
+            build_candidate_registry_payload(
+                research_latest={"bad": True},
+                walk_forward=_walk_forward(),
+                statistical_defensibility=None,
+                promotion_config=None,
+                git_revision="abc123",
+            )
+
+    def test_malformed_walk_forward_raises(self):
+        with pytest.raises(ArtifactJoinError, match="walk_forward.strategies"):
+            build_candidate_registry_payload(
+                research_latest=_research_latest(),
+                walk_forward={"bad": True},
+                statistical_defensibility=None,
+                promotion_config=None,
+                git_revision="abc123",
+            )
+
+    def test_none_defensibility_still_classifies(self):
+        payload = build_candidate_registry_payload(
+            research_latest=_research_latest(),
+            walk_forward=_walk_forward(),
+            statistical_defensibility=None,
+            promotion_config=None,
+            git_revision="abc123",
+        )
+        assert payload["candidates"][0]["status"] == STATUS_NEEDS_INVESTIGATION
+
+    def test_failed_rows_excluded(self):
+        results = [
+            {"strategy_name": "a", "asset": "X", "interval": "1d", "params_json": "{}", "success": False},
+            {"strategy_name": "trend_fast", "asset": "BTC-USD", "interval": "1d", "params_json": '{"fast": 20, "slow": 50}', "success": True},
+        ]
+        payload = build_candidate_registry_payload(
+            research_latest=_research_latest(results),
+            walk_forward=_walk_forward(),
+            statistical_defensibility=_stat_defensibility(),
+            promotion_config=None,
+            git_revision="abc123",
+        )
+        assert payload["summary"]["total"] == 1
+
+    def test_candidates_sorted_by_strategy_id(self):
+        results = [
+            {"strategy_name": "z_strat", "asset": "BTC-USD", "interval": "1d", "params_json": "{}", "success": True},
+            {"strategy_name": "a_strat", "asset": "BTC-USD", "interval": "1d", "params_json": "{}", "success": True},
+        ]
+        wf = _walk_forward([
+            {"strategy_name": "z_strat", "asset": "BTC-USD", "interval": "1d", "oos_summary": _good_oos(), "leakage_checks_ok": True},
+            {"strategy_name": "a_strat", "asset": "BTC-USD", "interval": "1d", "oos_summary": _good_oos(), "leakage_checks_ok": True},
+        ])
+        payload = build_candidate_registry_payload(
+            research_latest=_research_latest(results),
+            walk_forward=wf,
+            statistical_defensibility=None,
+            promotion_config=None,
+            git_revision="abc123",
+        )
+        ids = [c["strategy_id"] for c in payload["candidates"]]
+        assert ids == sorted(ids)
+
+    def test_promotion_config_forwarded(self):
+        payload = build_candidate_registry_payload(
+            research_latest=_research_latest(),
+            walk_forward=_walk_forward(),
+            statistical_defensibility=_stat_defensibility(),
+            promotion_config={"min_oos_sharpe": 2.0},
+            git_revision="abc123",
+        )
+        assert payload["promotion_config"]["min_oos_sharpe"] == 2.0
+        assert payload["candidates"][0]["status"] == STATUS_REJECTED
+
+
+# ---------------------------------------------------------------------------
+# Wiring test — proves run_research() writes the sidecar file
+# ---------------------------------------------------------------------------
+
+AS_OF_UTC = datetime(2026, 4, 8, 10, 59, 31, 381566, tzinfo=UTC)
+
+
+class _WiringEngine:
+    """Minimal fake engine that returns walk-forward evaluation data."""
+
+    def __init__(self, start_datum, eind_datum, evaluation_config=None):
+        self._provenance_events = []
+        self.last_evaluation_report = None
+
+    def grid_search(self, strategie_factory, param_grid, assets, interval="1d"):
+        self.last_evaluation_report = {
+            "evaluation_config": {},
+            "selection_metric": "sharpe",
+            "selected_params": {"periode": 14},
+            "is_summary": {},
+            "oos_summary": _good_oos(),
+            "folds": [{"train": [0, 69], "test": [70, 99], "leakage_ok": True}],
+            "leakage_checks_ok": True,
+            "evaluation_samples": {
+                "daily_returns": [0.01, -0.005, 0.003],
+                "trade_pnls": [0.02, -0.01],
+                "monthly_returns": [0.008],
+            },
+            "sample_statistics": {
+                "daily_returns": {"count": 3, "mean": 0.003, "std": 0.006, "skew": 0.0, "kurt": 3.0},
+            },
+        }
+        return {
+            "beste_params": {"periode": 14},
+            "win_rate": 0.55,
+            "sharpe": 1.2,
+            "deflated_sharpe": 1.1,
+            "max_drawdown": 0.12,
+            "trades_per_maand": 2.5,
+            "consistentie": 0.75,
+            "totaal_trades": 30,
+            "goedgekeurd": True,
+            "criteria_checks": {},
+            "reden": "",
+        }
+
+
+class TestCandidateRegistryWiring:
+    def test_run_research_writes_candidate_registry(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "research").mkdir()
+        monkeypatch.setattr(run_research_module, "BacktestEngine", _WiringEngine)
+        monkeypatch.setattr(
+            run_research_module,
+            "get_enabled_strategies",
+            lambda: [
+                {
+                    "name": "fake_strategy",
+                    "family": "trend",
+                    "hypothesis": "Test",
+                    "factory": lambda **params: None,
+                    "params": {"periode": [14]},
+                }
+            ],
+        )
+        monkeypatch.setattr(
+            run_research_module,
+            "build_research_universe",
+            lambda config: (
+                [SimpleNamespace(symbol="BTC-USD")],
+                ["1d"],
+                lambda interval: ("2026-01-01", "2026-02-01"),
+                AS_OF_UTC,
+            ),
+        )
+        monkeypatch.setattr(run_research_module, "load_research_config", lambda config_path="config/config.yaml": {})
+        monkeypatch.setattr(run_research_module, "_git_revision", lambda: "abc123")
+        monkeypatch.setattr(run_research_module, "_write_provenance_sidecar", lambda **kwargs: None)
+        monkeypatch.setattr(run_research_module, "_write_statistical_defensibility_sidecar", lambda **kwargs: None)
+        monkeypatch.setattr(
+            run_research_module,
+            "write_results_to_csv",
+            lambda rows: write_results_to_csv(rows, path=tmp_path / "research" / "strategy_matrix.csv"),
+        )
+        monkeypatch.setattr(
+            run_research_module,
+            "write_latest_json",
+            lambda rows, as_of_utc: write_latest_json(rows, as_of_utc=as_of_utc, path=tmp_path / "research" / "research_latest.json"),
+        )
+
+        run_research_module.run_research()
+
+        registry_path = tmp_path / "research" / "candidate_registry_latest.v1.json"
+        assert registry_path.exists(), "candidate_registry_latest.v1.json was not written"
+        payload = json.loads(registry_path.read_text(encoding="utf-8"))
+        assert payload["version"] == "v1"
+        assert payload["git_revision"] == "abc123"
+        assert len(payload["candidates"]) > 0
+        assert "promotion_config" in payload
+        assert "summary" in payload

--- a/tests/unit/test_research_statistical_reporting.py
+++ b/tests/unit/test_research_statistical_reporting.py
@@ -160,6 +160,7 @@ def _run_reporting(monkeypatch, tmp_path, research_config=None):
     monkeypatch.setattr(run_research_module, "load_research_config", lambda config_path="config/config.yaml": research_config or {})
     monkeypatch.setattr(run_research_module, "_write_provenance_sidecar", lambda **kwargs: None)
     monkeypatch.setattr(run_research_module, "_write_walk_forward_sidecar", lambda **kwargs: None)
+    monkeypatch.setattr(run_research_module, "_write_candidate_registry", lambda **kwargs: None)
 
     tmp_path.mkdir(parents=True, exist_ok=True)
     monkeypatch.chdir(tmp_path)
@@ -306,6 +307,7 @@ def test_sidecar_atomic_write_no_partial_on_failure(monkeypatch, tmp_path):
     monkeypatch.setattr(run_research_module, "load_research_config", lambda config_path="config/config.yaml": {})
     monkeypatch.setattr(run_research_module, "_write_provenance_sidecar", lambda **kwargs: None)
     monkeypatch.setattr(run_research_module, "_write_walk_forward_sidecar", lambda **kwargs: None)
+    monkeypatch.setattr(run_research_module, "_write_candidate_registry", lambda **kwargs: None)
     monkeypatch.chdir(tmp_path)
     (tmp_path / "research").mkdir()
     monkeypatch.setattr(

--- a/tests/unit/test_research_walk_forward_reporting.py
+++ b/tests/unit/test_research_walk_forward_reporting.py
@@ -141,6 +141,7 @@ def _patch_runner(monkeypatch, tmp_path: Path, engine_cls=FakeEngine, research_c
     monkeypatch.setattr(run_research_module, "_git_revision", lambda: "deadbeef")
     monkeypatch.setattr(run_research_module, "_write_provenance_sidecar", lambda **kwargs: None)
     monkeypatch.setattr(run_research_module, "_write_statistical_defensibility_sidecar", lambda **kwargs: None)
+    monkeypatch.setattr(run_research_module, "_write_candidate_registry", lambda **kwargs: None)
     monkeypatch.setattr(
         run_research_module,
         "write_results_to_csv",


### PR DESCRIPTION
Wire candidate registry generation into run_research.py pipeline:
- Add _write_candidate_registry() that joins walk-forward and statistical defensibility artifacts post-hoc
- Skip silently when walk_forward_reports is empty
- Write deterministic candidate_registry_latest.v1.json sidecar
- Add promotion config section to config.template.yaml
- Add test stubs to existing test helpers
- Add wiring test proving the sidecar is actually produced

New files: research/promotion.py, research/promotion_reporting.py, tests/unit/test_candidate_promotion.py

No changes to public output schemas (research_latest.json, strategy_matrix.csv). No changes to engine.py or strategies.