### PR TITLE
feat: upgrade walk-forward evaluation robustness (02.07)

### DIFF
--- a/agent/backtesting/engine.py
+++ b/agent/backtesting/engine.py
@@ -25,6 +25,12 @@ GAMMA_EM = 0.5772
 MAX_SWEEP_CELLS = 64
 DEFAULT_SELECTION_METRIC = "sharpe"
 DEFAULT_TRAIN_RATIO = 0.7
+DEFAULT_EVALUATION_MODE = "anchored"
+DEFAULT_INITIAL_TRAIN_BARS = 500
+DEFAULT_TRAIN_BARS = 500
+DEFAULT_TEST_BARS = 100
+DEFAULT_STEP_BARS = 100
+MIN_ROBUSTNESS_FOLDS = 3
 
 CRITERIA = {
     "win_rate": ("gt", 0.50),
@@ -73,7 +79,7 @@ class AssetContext:
 
 def normalize_evaluation_config(evaluation_config: Optional[dict[str, Any]]) -> dict[str, Any]:
     config = dict(evaluation_config or {})
-    mode = config.get("mode", "single_split")
+    mode = config.get("mode", DEFAULT_EVALUATION_MODE)
     normalized: dict[str, Any] = {
         "mode": mode,
         "selection_metric": config.get("selection_metric", DEFAULT_SELECTION_METRIC),
@@ -89,15 +95,15 @@ def normalize_evaluation_config(evaluation_config: Optional[dict[str, Any]]) -> 
         return normalized
 
     if mode == "rolling":
-        normalized["train_bars"] = _require_positive_int(config, "train_bars")
-        normalized["test_bars"] = _require_positive_int(config, "test_bars")
-        normalized["step_bars"] = _require_positive_int(config, "step_bars")
+        normalized["train_bars"] = _positive_int_or_default(config, "train_bars", DEFAULT_TRAIN_BARS)
+        normalized["test_bars"] = _positive_int_or_default(config, "test_bars", DEFAULT_TEST_BARS)
+        normalized["step_bars"] = _positive_int_or_default(config, "step_bars", DEFAULT_STEP_BARS)
         return normalized
 
     if mode == "anchored":
-        normalized["initial_train_bars"] = _require_positive_int(config, "initial_train_bars")
-        normalized["test_bars"] = _require_positive_int(config, "test_bars")
-        normalized["step_bars"] = _require_positive_int(config, "step_bars")
+        normalized["initial_train_bars"] = _positive_int_or_default(config, "initial_train_bars", DEFAULT_INITIAL_TRAIN_BARS)
+        normalized["test_bars"] = _positive_int_or_default(config, "test_bars", DEFAULT_TEST_BARS)
+        normalized["step_bars"] = _positive_int_or_default(config, "step_bars", DEFAULT_STEP_BARS)
         return normalized
 
     raise EvaluationScheduleError(f"Unsupported evaluation mode: {mode!r}")
@@ -208,6 +214,14 @@ def _require_positive_int(config: dict[str, Any], key: str) -> int:
     if key not in config:
         raise EvaluationScheduleError(f"Missing required evaluation key: {key}")
     value = int(config[key])
+    if value <= 0:
+        raise EvaluationScheduleError(f"{key} must be > 0, got {value!r}")
+    return value
+
+
+def _positive_int_or_default(config: dict[str, Any], key: str, default: int) -> int:
+    """Return config[key] as positive int, or default if key is absent."""
+    value = int(config.get(key, default))
     if value <= 0:
         raise EvaluationScheduleError(f"{key} must be > 0, got {value!r}")
     return value

--- a/config/config.template.yaml
+++ b/config/config.template.yaml
@@ -109,14 +109,17 @@ research:
     "4h": 700
   default_lookback_days: 1500
   evaluation:
-    mode: "single_split" # one of: single_split, rolling, anchored
-    train_ratio: 0.7 # used by single_split
-    # rolling / anchored use bar counts:
-    # train_bars: 500
-    # initial_train_bars: 500
-    # test_bars: 100
-    # step_bars: 100
+    mode: "anchored" # one of: single_split, rolling, anchored
+    initial_train_bars: 500 # anchored: expanding train window starts here
+    test_bars: 100 # anchored/rolling: OOS window size
+    step_bars: 100 # anchored/rolling: step between folds
     selection_metric: "sharpe"
+    # single_split mode (1 fold only):
+    # mode: "single_split"
+    # train_ratio: 0.7
+    # rolling mode (fixed train window):
+    # mode: "rolling"
+    # train_bars: 500
   promotion:
     min_oos_sharpe: 0.3
     max_oos_drawdown: 0.35

--- a/research/run_research.py
+++ b/research/run_research.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import yaml
 
 from agent.backtesting.engine import (
+    MIN_ROBUSTNESS_FOLDS,
     BacktestEngine,
     EvaluationScheduleError,
     FoldLeakageError,
@@ -129,6 +130,7 @@ def _sidecar_strategy_entry(
     interval: str,
     report: dict,
 ) -> dict:
+    folds = report.get("folds", [])
     return {
         "strategy_name": strategy["name"],
         "asset": asset,
@@ -137,8 +139,28 @@ def _sidecar_strategy_entry(
         "selection_metric": report.get("selection_metric", "sharpe"),
         "is_summary": report.get("is_summary", {}),
         "oos_summary": report.get("oos_summary", {}),
-        "folds": report.get("folds", []),
+        "folds": folds,
         "leakage_checks_ok": report.get("leakage_checks_ok", False),
+        "robustness": _compute_robustness(folds),
+    }
+
+
+def _compute_robustness(folds: list[dict]) -> dict:
+    """Derive robustness metadata from serialized fold list."""
+    fold_count = len(folds)
+    oos_bars = sum(f["test"][1] - f["test"][0] + 1 for f in folds) if folds else 0
+    total_bars_covered = 0
+    if folds:
+        min_start = min(f["train"][0] for f in folds)
+        max_end = max(f["test"][1] for f in folds)
+        total_bars_covered = max_end - min_start + 1
+    oos_coverage_ratio = round(oos_bars / total_bars_covered, 4) if total_bars_covered > 0 else 0.0
+    return {
+        "fold_count": fold_count,
+        "oos_bar_coverage": oos_bars,
+        "total_bars_covered": total_bars_covered,
+        "oos_coverage_ratio": oos_coverage_ratio,
+        "robustness_sufficient": fold_count >= MIN_ROBUSTNESS_FOLDS,
     }
 
 
@@ -151,10 +173,20 @@ def _write_walk_forward_sidecar(
 ) -> None:
     target = Path(path)
     target.parent.mkdir(parents=True, exist_ok=True)
+    insufficient = [
+        r["strategy_name"] for r in strategy_reports
+        if not r.get("robustness", {}).get("robustness_sufficient", False)
+    ]
     payload = {
         "version": "v1",
         "generated_at_utc": as_of_utc.astimezone(timezone.utc).isoformat(),
         "evaluation_config": evaluation_config,
+        "robustness_summary": {
+            "min_robustness_folds": MIN_ROBUSTNESS_FOLDS,
+            "strategy_count": len(strategy_reports),
+            "insufficient_count": len(insufficient),
+            "all_strategies_sufficient": len(insufficient) == 0,
+        },
         "strategies": strategy_reports,
     }
     with target.open("w", encoding="utf-8") as handle:

--- a/tests/unit/test_research_walk_forward_reporting.py
+++ b/tests/unit/test_research_walk_forward_reporting.py
@@ -171,9 +171,11 @@ def test_sidecar_written_with_v1_schema_and_version_field(monkeypatch, tmp_path)
     assert payload["version"] == "v1"
     assert payload["generated_at_utc"] == AS_OF_UTC.isoformat()
     assert payload["evaluation_config"] == {
-        "mode": "single_split",
+        "mode": "anchored",
         "selection_metric": "sharpe",
-        "train_ratio": 0.7,
+        "initial_train_bars": 500,
+        "test_bars": 100,
+        "step_bars": 100,
     }
 
 
@@ -185,6 +187,29 @@ def test_sidecar_contains_folds_and_leakage_checks_ok(monkeypatch, tmp_path):
     strategy_entry = _load_json(tmp_path / "research" / "walk_forward_latest.v1.json")["strategies"][0]
     assert strategy_entry["folds"] == [{"train": [0, 69], "test": [70, 99], "leakage_ok": True}]
     assert strategy_entry["leakage_checks_ok"] is True
+
+
+def test_sidecar_contains_robustness_metadata(monkeypatch, tmp_path):
+    _patch_runner(monkeypatch, tmp_path)
+
+    run_research_module.run_research()
+
+    sidecar = _load_json(tmp_path / "research" / "walk_forward_latest.v1.json")
+    strategy_entry = sidecar["strategies"][0]
+    robustness = strategy_entry["robustness"]
+    assert "fold_count" in robustness
+    assert "oos_bar_coverage" in robustness
+    assert "total_bars_covered" in robustness
+    assert "oos_coverage_ratio" in robustness
+    assert "robustness_sufficient" in robustness
+    assert robustness["fold_count"] == len(strategy_entry["folds"])
+
+    summary = sidecar["robustness_summary"]
+    assert "min_robustness_folds" in summary
+    assert "strategy_count" in summary
+    assert "insufficient_count" in summary
+    assert "all_strategies_sufficient" in summary
+    assert summary["strategy_count"] == 1
 
 
 def test_sidecar_separates_is_and_oos_summaries(monkeypatch, tmp_path):

--- a/tests/unit/test_walk_forward_framework.py
+++ b/tests/unit/test_walk_forward_framework.py
@@ -6,11 +6,13 @@ import pandas as pd
 import pytest
 
 from agent.backtesting.engine import (
+    MIN_ROBUSTNESS_FOLDS,
     BacktestEngine,
     EvaluationScheduleError,
     FoldLeakageError,
     anchored_walk_forward,
     build_evaluation_folds,
+    normalize_evaluation_config,
     rolling_walk_forward,
     single_split,
     validate_no_leakage,
@@ -69,18 +71,47 @@ def test_schedule_raises_on_zero_train_or_test_folds():
         rolling_walk_forward(n=10, train_bars=10, test_bars=2, step_bars=1)
 
 
-def test_default_config_matches_current_70_30_split():
+def test_default_config_is_anchored_walk_forward():
     engine = BacktestEngine(
         start_datum="2024-01-01",
         eind_datum="2024-04-30",
     )
 
     assert engine.evaluation_config == {
-        "mode": "single_split",
+        "mode": "anchored",
         "selection_metric": "sharpe",
-        "train_ratio": 0.7,
+        "initial_train_bars": 500,
+        "test_bars": 100,
+        "step_bars": 100,
     }
-    assert build_evaluation_folds(100, None) == [((0, 69), (70, 99))]
+
+
+def test_default_anchored_produces_multiple_folds():
+    folds = build_evaluation_folds(1000, None)
+    assert len(folds) > 1
+    assert len(folds) >= MIN_ROBUSTNESS_FOLDS
+
+
+def test_explicit_single_split_still_produces_one_fold():
+    config = {"mode": "single_split", "train_ratio": 0.7}
+    folds = build_evaluation_folds(100, config)
+    assert folds == [((0, 69), (70, 99))]
+    assert len(folds) == 1
+
+
+def test_normalize_none_config_returns_anchored_defaults():
+    config = normalize_evaluation_config(None)
+    assert config["mode"] == "anchored"
+    assert config["initial_train_bars"] == 500
+    assert config["test_bars"] == 100
+    assert config["step_bars"] == 100
+
+
+def test_rolling_mode_uses_safe_defaults_when_bars_omitted():
+    config = normalize_evaluation_config({"mode": "rolling"})
+    assert config["train_bars"] == 500
+    assert config["test_bars"] == 100
+    assert config["step_bars"] == 100
 
 
 def test_grid_search_selection_uses_train_windows_only(monkeypatch):
@@ -89,6 +120,7 @@ def test_grid_search_selection_uses_train_windows_only(monkeypatch):
     engine = BacktestEngine(
         start_datum="2024-01-01",
         eind_datum="2024-04-30",
+        evaluation_config={"mode": "single_split", "train_ratio": 0.7},
     )
     engine.min_trades = 1
 


### PR DESCRIPTION
Change default evaluation mode from single_split (1 fold) to anchored walk-forward with safe defaults (initial_train=500, test=100, step=100), producing multiple folds for temporal stability validation.

Changes:
- Default mode: anchored (was single_split)
- Rolling/anchored modes now have safe defaults when bar counts are omitted (500/100/100) instead of raising errors
- Walk-forward sidecar entries include robustness metadata: fold_count, oos_bar_coverage, robustness_sufficient
- Walk-forward sidecar includes top-level robustness_summary
- MIN_ROBUSTNESS_FOLDS=3 constant for sufficiency threshold
- Config template updated to reflect anchored defaults

Not changed: public output schemas, promotion rules, statistical defensibility logic, strategy logic, leakage protections.