### PR TITLE
feat: add research portfolio aggregation sidecar foundation

### DIFF
--- a/agent/backtesting/engine.py
+++ b/agent/backtesting/engine.py
@@ -247,6 +247,7 @@ class BacktestEngine:
         self._provenance_events: list[Any] = []
         self.last_evaluation_report: Optional[dict[str, Any]] = None
         self._last_window_samples: dict[str, list[float]] = {}
+        self._last_window_streams: dict[str, list[dict[str, Any]]] = {}
 
     def run(self, strategie_func: Callable, assets: list, interval: str = "1d") -> dict:
         """Run fixed-parameter evaluation and return public OOS metrics only."""
@@ -379,6 +380,7 @@ class BacktestEngine:
         trade_pnls: list[float] = []
         dag_returns: list[float] = []
         maand_returns: list[float] = []
+        oos_daily_return_stream: list[dict[str, Any]] = []
 
         for context in asset_contexts:
             for train_bounds, test_bounds in context.folds:
@@ -388,11 +390,15 @@ class BacktestEngine:
                 trade_pnls.extend(trades)
                 dag_returns.extend(dag)
                 maand_returns.extend(maand)
+                oos_daily_return_stream.extend(self._serialize_daily_return_stream(df_window, dag))
 
         self._last_window_samples = {
             "daily_returns": list(dag_returns),
             "trade_pnls": list(trade_pnls),
             "monthly_returns": list(maand_returns),
+        }
+        self._last_window_streams = {
+            "oos_daily_returns": oos_daily_return_stream,
         }
 
         if len(trade_pnls) < self.min_trades:
@@ -427,6 +433,7 @@ class BacktestEngine:
             "folds_by_asset": folds_by_asset,
             "leakage_checks_ok": leakage_checks_ok,
             "evaluation_samples": evaluation_samples,
+            "evaluation_streams": dict(self._last_window_streams),
             "sample_statistics": {
                 name: self._sample_statistics(values)
                 for name, values in evaluation_samples.items()
@@ -445,6 +452,42 @@ class BacktestEngine:
                 "leakage_ok": train_end < test_start,
             }
             for (train_start, train_end), (test_start, test_end) in folds
+        ]
+
+    @staticmethod
+    def _serialize_daily_return_stream(
+        df_window: pd.DataFrame,
+        period_returns: list[float],
+    ) -> list[dict[str, Any]]:
+        timestamps = [pd.Timestamp(timestamp) for timestamp in df_window.index[1 : len(period_returns) + 1]]
+        if not timestamps:
+            return []
+
+        normalized_index = []
+        for timestamp in timestamps:
+            if timestamp.tzinfo is None:
+                normalized_index.append(timestamp.tz_localize(UTC))
+            else:
+                normalized_index.append(timestamp.tz_convert(UTC))
+
+        equity_values: list[float] = []
+        equity = 1.0
+        for value in period_returns:
+            equity *= 1.0 + float(value)
+            equity_values.append(equity)
+
+        equity_series = pd.Series(equity_values, index=pd.DatetimeIndex(normalized_index), dtype=float)
+        daily_equity = equity_series.resample("1D").last().dropna()
+        if daily_equity.empty:
+            return []
+
+        daily_returns = daily_equity.pct_change().dropna()
+        return [
+            {
+                "timestamp_utc": pd.Timestamp(timestamp).tz_convert(UTC).isoformat(),
+                "return": float(value),
+            }
+            for timestamp, value in daily_returns.items()
         ]
 
     @staticmethod

--- a/research/portfolio_reporting.py
+++ b/research/portfolio_reporting.py
@@ -1,0 +1,521 @@
+"""Pure helpers for research-side portfolio aggregation reporting."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import numpy as np
+
+from research.promotion import build_strategy_id
+
+VIEW_SPECS: tuple[tuple[str, str], ...] = (
+    ("all_included", "strategy_run"),
+    ("by_asset", "asset"),
+    ("by_family", "family"),
+)
+
+ALIGNMENT_POLICY = {
+    "basis": "timestamped_oos_daily_returns",
+    "cross_interval_mixing": False,
+    "ordering": "ascending_timestamp_utc",
+    "policy": "exact_timestamp_intersection",
+    "non_overlap_handling": (
+        "portfolio_results_only_on_common_support; "
+        "inactive_members_are_not_treated_as_cash_and_weights_are_not_redistributed"
+    ),
+}
+
+CONTRIBUTION_DEFINITION = {
+    "period_return_contribution": "sleeve_weight * sleeve_return_t",
+    "cumulative_period_return_contribution": (
+        "cumulative sum over aligned timestamps of period_return_contribution; "
+        "this explains the aggregated period-return path and is not drawdown attribution"
+    ),
+}
+
+
+def build_portfolio_aggregation_payload(
+    evaluations: list[dict[str, Any]],
+    as_of_utc,
+    git_revision: str,
+) -> dict[str, Any]:
+    """Build additive portfolio aggregation sidecar payload.
+
+    The payload is intentionally research-only:
+    - uses timestamped OOS daily returns only
+    - no cross-interval mixing
+    - no live sizing or optimizer assumptions
+    """
+    runs = [_normalize_run(evaluation) for evaluation in evaluations]
+    intervals = sorted({run["interval"] for run in runs})
+    views = [
+        _build_view(
+            runs=[run for run in runs if run["interval"] == interval],
+            interval=interval,
+            view_name=view_name,
+            sleeve_by=sleeve_by,
+        )
+        for interval in intervals
+        for view_name, sleeve_by in VIEW_SPECS
+    ]
+
+    return {
+        "version": "v1",
+        "generated_at_utc": as_of_utc.isoformat(),
+        "git_revision": git_revision,
+        "alignment_policy": dict(ALIGNMENT_POLICY),
+        "contribution_definition": dict(CONTRIBUTION_DEFINITION),
+        "summary": {
+            "input_run_count": len(runs),
+            "interval_count": len(intervals),
+            "view_count": len(views),
+            "views_with_portfolio_stream": sum(1 for view in views if view["summary"]["observation_count"] > 0),
+            "views_without_portfolio_stream": sum(1 for view in views if view["summary"]["observation_count"] == 0),
+        },
+        "views": views,
+    }
+
+
+def _build_view(
+    runs: list[dict[str, Any]],
+    interval: str,
+    view_name: str,
+    sleeve_by: str,
+) -> dict[str, Any]:
+    excluded_runs: list[dict[str, Any]] = []
+    valid_runs: list[dict[str, Any]] = []
+    seen_strategy_ids: set[str] = set()
+
+    for run in sorted(runs, key=lambda item: item["strategy_id"]):
+        if run["strategy_id"] in seen_strategy_ids:
+            excluded_runs.append(_excluded_run(run, "duplicate_strategy_id_in_view"))
+            continue
+        seen_strategy_ids.add(run["strategy_id"])
+
+        if run["stream_error"] is not None:
+            excluded_runs.append(_excluded_run(run, run["stream_error"]))
+            continue
+
+        valid_runs.append(run)
+
+    grouped_runs: dict[str, list[dict[str, Any]]] = {}
+    for run in valid_runs:
+        grouped_runs.setdefault(_sleeve_key(run, sleeve_by), []).append(run)
+
+    sleeves: list[dict[str, Any]] = []
+    for key in sorted(grouped_runs):
+        sleeve, sleeve_exclusions = _build_sleeve(
+            runs=grouped_runs[key],
+            sleeve_key=key,
+            sleeve_by=sleeve_by,
+            interval=interval,
+        )
+        excluded_runs.extend(sleeve_exclusions)
+        if sleeve is not None:
+            sleeves.append(sleeve)
+
+    included_runs = _included_runs_from_sleeves(sleeves)
+    portfolio_timestamps = _common_timestamps([sleeve["_timestamps"] for sleeve in sleeves]) if sleeves else []
+    portfolio_returns = [
+        float(np.mean([_aligned_return_map(sleeve)[timestamp] for sleeve in sleeves]))
+        for timestamp in portfolio_timestamps
+    ] if portfolio_timestamps else []
+    sleeve_weight = 1.0 / len(sleeves) if sleeves else 0.0
+
+    diversification = _diversification(sleeves, portfolio_timestamps)
+    finalized_sleeves = [
+        _finalize_sleeve_for_view(
+            sleeve=sleeve,
+            portfolio_timestamps=portfolio_timestamps,
+            sleeve_weight=sleeve_weight,
+        )
+        for sleeve in sleeves
+    ]
+
+    if sleeves and not portfolio_timestamps:
+        status = "insufficient_common_support_across_sleeves"
+    elif sleeves:
+        status = "ok"
+    else:
+        status = "no_valid_sleeves"
+
+    return {
+        "view_id": f"{interval}|{view_name}",
+        "view_name": view_name,
+        "interval": interval,
+        "sleeve_by": sleeve_by,
+        "weighting_method": "equal_weight",
+        "status": status,
+        "alignment": {
+            "policy": ALIGNMENT_POLICY["policy"],
+            "input_run_count": len(runs),
+            "eligible_run_count": len(valid_runs),
+            "included_run_count": len(included_runs),
+            "excluded_run_count": len(excluded_runs),
+            "sleeve_count": len(finalized_sleeves),
+            "common_window": _window_metadata(portfolio_timestamps),
+            "dropped_observations_total": sum(
+                max(0, len(sleeve["_timestamps"]) - len(portfolio_timestamps))
+                for sleeve in sleeves
+            ),
+            "consequence": (
+                "portfolio metrics reflect only timestamps shared by every included sleeve"
+                if portfolio_timestamps
+                else "no portfolio stream available because included sleeves do not share a common active window"
+            ),
+        },
+        "included_runs": included_runs,
+        "excluded_runs": sorted(
+            excluded_runs,
+            key=lambda item: (item["reason"], item["strategy_id"]),
+        ),
+        "summary": _return_summary(portfolio_returns, interval),
+        "portfolio_stream": _portfolio_stream(portfolio_timestamps, portfolio_returns),
+        "sleeves": [_public_sleeve(sleeve) for sleeve in finalized_sleeves],
+        "diversification": diversification,
+    }
+
+
+def _build_sleeve(
+    runs: list[dict[str, Any]],
+    sleeve_key: str,
+    sleeve_by: str,
+    interval: str,
+) -> tuple[dict[str, Any] | None, list[dict[str, Any]]]:
+    sleeve_timestamps = _common_timestamps([run["timestamps"] for run in runs])
+    if not sleeve_timestamps:
+        return None, [_excluded_run(run, "no_common_support_within_sleeve") for run in runs]
+
+    member_returns = [
+        _aligned_returns(run["stream"], sleeve_timestamps)
+        for run in runs
+    ]
+    sleeve_returns = [
+        float(np.mean(values))
+        for values in zip(*member_returns)
+    ]
+    aligned_count = len(sleeve_timestamps)
+
+    members = []
+    for run in sorted(runs, key=lambda item: item["strategy_id"]):
+        members.append({
+            "strategy_id": run["strategy_id"],
+            "strategy_name": run["strategy_name"],
+            "asset": run["asset"],
+            "family": run["family"],
+            "selected_params": run["selected_params"],
+            "original_window": _window_metadata(run["timestamps"]),
+            "sleeve_alignment": {
+                "aligned_observation_count": aligned_count,
+                "dropped_observation_count": max(0, len(run["timestamps"]) - aligned_count),
+            },
+        })
+
+    return {
+        "sleeve_key": sleeve_key,
+        "sleeve_by": sleeve_by,
+        "member_count": len(members),
+        "members": members,
+        "alignment": {
+            "policy": ALIGNMENT_POLICY["policy"],
+            "common_window": _window_metadata(sleeve_timestamps),
+            "included_member_count": len(members),
+            "dropped_observations_total": sum(
+                max(0, len(run["timestamps"]) - aligned_count)
+                for run in runs
+            ),
+        },
+        "standalone_summary": _return_summary(sleeve_returns, interval),
+        "_timestamps": sleeve_timestamps,
+        "_returns": sleeve_returns,
+    }, []
+
+
+def _finalize_sleeve_for_view(
+    sleeve: dict[str, Any],
+    portfolio_timestamps: list[str],
+    sleeve_weight: float,
+) -> dict[str, Any]:
+    aligned_returns = _aligned_returns_from_points(
+        timestamps=sleeve["_timestamps"],
+        returns=sleeve["_returns"],
+        target_timestamps=portfolio_timestamps,
+    )
+    contribution_stream = []
+    cumulative_contribution = 0.0
+    for timestamp, value in zip(portfolio_timestamps, aligned_returns):
+        period_contribution = sleeve_weight * value
+        cumulative_contribution += period_contribution
+        contribution_stream.append({
+            "timestamp_utc": timestamp,
+            "period_return_contribution": period_contribution,
+            "cumulative_period_return_contribution": cumulative_contribution,
+        })
+
+    return {
+        "sleeve_key": sleeve["sleeve_key"],
+        "sleeve_by": sleeve["sleeve_by"],
+        "weight": sleeve_weight,
+        "member_count": sleeve["member_count"],
+        "members": sleeve["members"],
+        "alignment": {
+            **sleeve["alignment"],
+            "view_aligned_observation_count": len(portfolio_timestamps),
+            "view_dropped_observations": max(0, len(sleeve["_timestamps"]) - len(portfolio_timestamps)),
+        },
+        "standalone_summary": sleeve["standalone_summary"],
+        "contribution": {
+            "final_cumulative_period_return_contribution": cumulative_contribution if contribution_stream else 0.0,
+            "contribution_stream": contribution_stream,
+        },
+        "_timestamps": list(sleeve["_timestamps"]),
+        "_returns": list(sleeve["_returns"]),
+    }
+
+
+def _diversification(sleeves: list[dict[str, Any]], portfolio_timestamps: list[str]) -> dict[str, Any]:
+    sleeve_keys = [sleeve["sleeve_key"] for sleeve in sleeves]
+    if not sleeves or not portfolio_timestamps:
+        return {
+            "sleeve_keys": sleeve_keys,
+            "correlation_matrix": [],
+            "average_pairwise_correlation": None,
+            "diversification_ratio": None,
+        }
+
+    aligned = np.asarray([
+        _aligned_returns_from_points(
+            timestamps=sleeve["_timestamps"],
+            returns=sleeve["_returns"],
+            target_timestamps=portfolio_timestamps,
+        )
+        for sleeve in sleeves
+    ], dtype=float)
+    vols = np.std(aligned, axis=1)
+    weights = np.full(len(sleeves), 1.0 / len(sleeves), dtype=float)
+    portfolio_returns = aligned.mean(axis=0)
+    portfolio_vol = float(np.std(portfolio_returns))
+
+    correlation_matrix: list[list[float | None]] = []
+    off_diagonal: list[float] = []
+    for i in range(len(sleeves)):
+        row: list[float | None] = []
+        for j in range(len(sleeves)):
+            if i == j:
+                row.append(1.0)
+                continue
+            if vols[i] == 0.0 or vols[j] == 0.0:
+                row.append(None)
+                continue
+            corr = float(np.corrcoef(aligned[i], aligned[j])[0, 1])
+            row.append(corr)
+            off_diagonal.append(corr)
+        correlation_matrix.append(row)
+
+    diversification_ratio = None
+    if portfolio_vol > 0.0:
+        diversification_ratio = float(np.dot(weights, vols) / portfolio_vol)
+
+    return {
+        "sleeve_keys": sleeve_keys,
+        "correlation_matrix": correlation_matrix,
+        "average_pairwise_correlation": float(np.mean(off_diagonal)) if off_diagonal else None,
+        "diversification_ratio": diversification_ratio,
+    }
+
+
+def _public_sleeve(sleeve: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: value
+        for key, value in sleeve.items()
+        if key not in {"_timestamps", "_returns"}
+    }
+
+
+def _portfolio_stream(timestamps: list[str], returns: list[float]) -> list[dict[str, Any]]:
+    equity = 1.0
+    stream = []
+    for timestamp, value in zip(timestamps, returns):
+        equity *= 1.0 + value
+        stream.append({
+            "timestamp_utc": timestamp,
+            "return": value,
+            "cumulative_return": equity - 1.0,
+        })
+    return stream
+
+
+def _return_summary(returns: list[float], interval: str) -> dict[str, Any]:
+    if not returns:
+        return {
+            "observation_count": 0,
+            "total_return": None,
+            "annualized_return": None,
+            "volatility": None,
+            "sharpe": None,
+            "max_drawdown": None,
+        }
+
+    values = np.asarray(returns, dtype=float)
+    total_return = float(np.prod(1.0 + values) - 1.0)
+    volatility = float(values.std() * math.sqrt(_annualization_factor(interval)))
+    sharpe = None
+    if values.size > 1 and values.std() > 0.0:
+        sharpe = float((values.mean() / values.std()) * math.sqrt(_annualization_factor(interval)))
+
+    annualized_return = None
+    periods = values.size
+    if periods > 0:
+        annualized_return = float((1.0 + total_return) ** (_annualization_factor(interval) / periods) - 1.0)
+
+    equity = np.cumprod(1.0 + values)
+    peaks = np.maximum.accumulate(equity)
+    drawdowns = (equity - peaks) / np.where(peaks > 0.0, peaks, 1.0)
+
+    return {
+        "observation_count": int(values.size),
+        "total_return": total_return,
+        "annualized_return": annualized_return,
+        "volatility": volatility,
+        "sharpe": sharpe,
+        "max_drawdown": float(abs(drawdowns.min())) if drawdowns.size else 0.0,
+    }
+
+
+def _normalize_run(evaluation: dict[str, Any]) -> dict[str, Any]:
+    row = evaluation.get("row", {})
+    selected_params = dict(evaluation.get("selected_params") or {})
+    strategy_id = build_strategy_id(
+        row.get("strategy_name", ""),
+        row.get("asset", ""),
+        row.get("interval", ""),
+        selected_params,
+    )
+
+    raw_stream = (((evaluation.get("evaluation_report") or {}).get("evaluation_streams") or {}).get("oos_daily_returns"))
+    stream, stream_error = _normalize_stream(raw_stream)
+    timestamps = [point["timestamp_utc"] for point in stream]
+
+    return {
+        "strategy_id": strategy_id,
+        "strategy_name": row.get("strategy_name", ""),
+        "asset": row.get("asset", ""),
+        "family": row.get("family", evaluation.get("family", "")),
+        "interval": row.get("interval", evaluation.get("interval", "")),
+        "selected_params": selected_params,
+        "stream": stream,
+        "timestamps": timestamps,
+        "stream_error": stream_error,
+    }
+
+
+def _normalize_stream(raw_stream: Any) -> tuple[list[dict[str, Any]], str | None]:
+    if not isinstance(raw_stream, list) or not raw_stream:
+        return [], "missing_oos_daily_return_stream"
+
+    stream: list[dict[str, Any]] = []
+    seen_timestamps: set[str] = set()
+    for point in raw_stream:
+        if not isinstance(point, dict):
+            return [], "malformed_oos_daily_return_stream"
+        timestamp = point.get("timestamp_utc")
+        value = point.get("return")
+        if not isinstance(timestamp, str) or not isinstance(value, (int, float)):
+            return [], "malformed_oos_daily_return_stream"
+        if timestamp in seen_timestamps:
+            return [], "duplicate_timestamp_in_oos_daily_return_stream"
+        seen_timestamps.add(timestamp)
+        stream.append({
+            "timestamp_utc": timestamp,
+            "return": float(value),
+        })
+
+    stream.sort(key=lambda item: item["timestamp_utc"])
+    return stream, None
+
+
+def _aligned_return_map(sleeve: dict[str, Any]) -> dict[str, float]:
+    return dict(zip(sleeve["_timestamps"], sleeve["_returns"]))
+
+
+def _aligned_returns(stream: list[dict[str, Any]], timestamps: list[str]) -> list[float]:
+    values = {point["timestamp_utc"]: float(point["return"]) for point in stream}
+    return [values[timestamp] for timestamp in timestamps]
+
+
+def _aligned_returns_from_points(
+    timestamps: list[str],
+    returns: list[float],
+    target_timestamps: list[str],
+) -> list[float]:
+    values = dict(zip(timestamps, returns))
+    return [float(values[timestamp]) for timestamp in target_timestamps]
+
+
+def _common_timestamps(timestamp_lists: list[list[str]]) -> list[str]:
+    if not timestamp_lists:
+        return []
+    common = set(timestamp_lists[0])
+    for timestamps in timestamp_lists[1:]:
+        common &= set(timestamps)
+    return sorted(common)
+
+
+def _included_runs_from_sleeves(sleeves: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    included = []
+    for sleeve in sleeves:
+        for member in sleeve["members"]:
+            included.append({
+                "strategy_id": member["strategy_id"],
+                "strategy_name": member["strategy_name"],
+                "asset": member["asset"],
+                "family": member["family"],
+                "selected_params": member["selected_params"],
+                "sleeve_key": sleeve["sleeve_key"],
+            })
+    return sorted(included, key=lambda item: item["strategy_id"])
+
+
+def _excluded_run(run: dict[str, Any], reason: str) -> dict[str, Any]:
+    return {
+        "strategy_id": run["strategy_id"],
+        "strategy_name": run["strategy_name"],
+        "asset": run["asset"],
+        "family": run["family"],
+        "interval": run["interval"],
+        "selected_params": run["selected_params"],
+        "reason": reason,
+    }
+
+
+def _sleeve_key(run: dict[str, Any], sleeve_by: str) -> str:
+    if sleeve_by == "strategy_run":
+        return run["strategy_id"]
+    if sleeve_by == "asset":
+        return run["asset"]
+    return run["family"]
+
+
+def _window_metadata(timestamps: list[str]) -> dict[str, Any]:
+    if not timestamps:
+        return {
+            "start_utc": None,
+            "end_utc": None,
+            "observation_count": 0,
+        }
+    return {
+        "start_utc": timestamps[0],
+        "end_utc": timestamps[-1],
+        "observation_count": len(timestamps),
+    }
+
+
+def _annualization_factor(interval: str) -> int:
+    return {
+        "1d": 252,
+        "1h": 252,
+        "4h": 252,
+        "15m": 252,
+        "5m": 252,
+    }.get(interval, 252)

--- a/research/run_research.py
+++ b/research/run_research.py
@@ -22,6 +22,7 @@ from agent.backtesting.engine import (
 )
 from research.registry import get_enabled_strategies
 from research.results import make_result_row, write_latest_json, write_results_to_csv
+from research.portfolio_reporting import build_portfolio_aggregation_payload
 from research.promotion_reporting import build_candidate_registry_payload
 from research.statistical_reporting import build_statistical_defensibility_payload, regime_count_settings
 from research.universe import build_research_universe
@@ -30,6 +31,7 @@ SIDE_CAR_PATH = Path("research/statistical_defensibility_latest.v1.json")
 WALK_FORWARD_PATH = "research/walk_forward_latest.v1.json"
 CANDIDATE_REGISTRY_PATH = Path("research/candidate_registry_latest.v1.json")
 UNIVERSE_SNAPSHOT_PATH = Path("research/universe_snapshot_latest.v1.json")
+PORTFOLIO_AGGREGATION_PATH = Path("research/portfolio_aggregation_latest.v1.json")
 
 
 def load_research_config(config_path="config/config.yaml"):
@@ -238,6 +240,20 @@ def _write_candidate_registry(
     _write_json_atomic(path, payload)
 
 
+def _write_portfolio_aggregation_sidecar(
+    *,
+    evaluations: list[dict],
+    as_of_utc,
+    path: Path = PORTFOLIO_AGGREGATION_PATH,
+) -> None:
+    payload = build_portfolio_aggregation_payload(
+        evaluations=evaluations,
+        as_of_utc=as_of_utc,
+        git_revision=_git_revision(),
+    )
+    _write_json_atomic(path, payload)
+
+
 def _build_engine(start_datum: str, eind_datum: str, evaluation_config: dict) -> BacktestEngine:
     try:
         return BacktestEngine(
@@ -370,6 +386,10 @@ def run_research():
         rows=rows,
         walk_forward_reports=walk_forward_reports,
         research_config=research_config,
+        as_of_utc=as_of_utc,
+    )
+    _write_portfolio_aggregation_sidecar(
+        evaluations=evaluations,
         as_of_utc=as_of_utc,
     )
 

--- a/tests/unit/test_research_portfolio_reporting.py
+++ b/tests/unit/test_research_portfolio_reporting.py
@@ -1,0 +1,320 @@
+import csv
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+from research import run_research as run_research_module
+from research.portfolio_reporting import build_portfolio_aggregation_payload
+from research.results import make_result_row, write_latest_json, write_results_to_csv
+
+AS_OF_UTC = datetime(2026, 4, 13, 8, 0, 0, tzinfo=UTC)
+ROW_SCHEMA = list(
+    make_result_row(
+        strategy={"name": "schema", "family": "trend", "hypothesis": "schema"},
+        asset="BTC-USD",
+        interval="1d",
+        params={},
+        as_of_utc=AS_OF_UTC,
+        metrics={},
+    ).keys()
+)
+
+
+def _stream(points):
+    return [
+        {"timestamp_utc": timestamp, "return": value}
+        for timestamp, value in points
+    ]
+
+
+def _evaluation(strategy_name, family, asset, params, stream_points):
+    row = make_result_row(
+        strategy={"name": strategy_name, "family": family, "hypothesis": f"{strategy_name} hypothesis"},
+        asset=asset,
+        interval="1d",
+        params=params,
+        as_of_utc=AS_OF_UTC,
+        metrics={
+            "win_rate": 0.6,
+            "sharpe": 0.5,
+            "deflated_sharpe": 0.4,
+            "max_drawdown": 0.1,
+            "trades_per_maand": 3.0,
+            "consistentie": 0.7,
+            "totaal_trades": 12,
+            "goedgekeurd": True,
+            "criteria_checks": {},
+            "reden": "",
+        },
+    )
+    return {
+        "family": family,
+        "interval": "1d",
+        "selected_params": params,
+        "row": row,
+        "evaluation_report": {
+            "evaluation_streams": {
+                "oos_daily_returns": _stream(stream_points),
+            }
+        },
+    }
+
+
+def test_build_portfolio_payload_creates_deterministic_views_and_alignment_metadata():
+    evaluations = [
+        _evaluation(
+            "trend_fast",
+            "trend",
+            "BTC-USD",
+            {"fast": 10},
+            [
+                ("2026-01-02T00:00:00+00:00", 0.01),
+                ("2026-01-03T00:00:00+00:00", 0.0),
+                ("2026-01-04T00:00:00+00:00", 0.02),
+            ],
+        ),
+        _evaluation(
+            "mean_basic",
+            "mean_reversion",
+            "BTC-USD",
+            {"period": 14},
+            [
+                ("2026-01-03T00:00:00+00:00", -0.01),
+                ("2026-01-04T00:00:00+00:00", 0.01),
+                ("2026-01-05T00:00:00+00:00", 0.0),
+            ],
+        ),
+        _evaluation(
+            "trend_slow",
+            "trend",
+            "ETH-USD",
+            {"window": 20},
+            [
+                ("2026-01-03T00:00:00+00:00", 0.02),
+                ("2026-01-04T00:00:00+00:00", -0.01),
+                ("2026-01-05T00:00:00+00:00", 0.01),
+            ],
+        ),
+        _evaluation(
+            "mean_regime",
+            "mean_reversion",
+            "ETH-USD",
+            {"period": 20},
+            [
+                ("2026-01-03T00:00:00+00:00", 0.0),
+                ("2026-01-04T00:00:00+00:00", 0.01),
+                ("2026-01-05T00:00:00+00:00", -0.02),
+            ],
+        ),
+    ]
+
+    first = build_portfolio_aggregation_payload(evaluations, AS_OF_UTC, git_revision="abc123")
+    second = build_portfolio_aggregation_payload(evaluations, AS_OF_UTC, git_revision="abc123")
+
+    assert first == second
+    assert first["alignment_policy"]["basis"] == "timestamped_oos_daily_returns"
+    assert first["summary"]["view_count"] == 3
+
+    all_included = next(view for view in first["views"] if view["view_name"] == "all_included")
+    assert all_included["status"] == "ok"
+    assert all_included["alignment"]["common_window"] == {
+        "start_utc": "2026-01-03T00:00:00+00:00",
+        "end_utc": "2026-01-04T00:00:00+00:00",
+        "observation_count": 2,
+    }
+    assert all_included["summary"]["observation_count"] == 2
+    assert len(all_included["portfolio_stream"]) == 2
+    assert round(all_included["portfolio_stream"][0]["return"], 6) == 0.0025
+    assert all_included["sleeves"][0]["contribution"]["contribution_stream"][0]["timestamp_utc"] == "2026-01-03T00:00:00+00:00"
+    assert all_included["alignment"]["dropped_observations_total"] == 4
+
+    by_asset = next(view for view in first["views"] if view["view_name"] == "by_asset")
+    assert [sleeve["sleeve_key"] for sleeve in by_asset["sleeves"]] == ["BTC-USD", "ETH-USD"]
+    assert by_asset["sleeves"][0]["alignment"]["common_window"]["observation_count"] == 2
+    assert by_asset["diversification"]["sleeve_keys"] == ["BTC-USD", "ETH-USD"]
+
+    by_family = next(view for view in first["views"] if view["view_name"] == "by_family")
+    assert [sleeve["sleeve_key"] for sleeve in by_family["sleeves"]] == ["mean_reversion", "trend"]
+    assert by_family["sleeves"][1]["alignment"]["common_window"]["observation_count"] == 2
+
+
+def test_build_portfolio_payload_makes_missing_streams_and_no_overlap_explicit():
+    evaluations = [
+        _evaluation(
+            "trend_fast",
+            "trend",
+            "BTC-USD",
+            {"fast": 10},
+            [("2026-01-02T00:00:00+00:00", 0.01), ("2026-01-03T00:00:00+00:00", 0.02)],
+        ),
+        _evaluation(
+            "trend_slow",
+            "trend",
+            "ETH-USD",
+            {"window": 20},
+            [("2026-02-02T00:00:00+00:00", 0.03), ("2026-02-03T00:00:00+00:00", -0.01)],
+        ),
+        {
+            "family": "mean_reversion",
+            "interval": "1d",
+            "selected_params": {"period": 14},
+            "row": make_result_row(
+                strategy={"name": "missing_stream", "family": "mean_reversion", "hypothesis": "missing"},
+                asset="SOL-USD",
+                interval="1d",
+                params={"period": 14},
+                as_of_utc=AS_OF_UTC,
+                metrics={"goedgekeurd": False, "criteria_checks": {}},
+            ),
+            "evaluation_report": {},
+        },
+    ]
+
+    payload = build_portfolio_aggregation_payload(evaluations, AS_OF_UTC, git_revision="abc123")
+    view = next(item for item in payload["views"] if item["view_name"] == "all_included")
+
+    assert view["status"] == "insufficient_common_support_across_sleeves"
+    assert view["summary"]["observation_count"] == 0
+    assert view["alignment"]["consequence"].startswith("no portfolio stream available")
+    assert any(item["reason"] == "missing_oos_daily_return_stream" for item in view["excluded_runs"])
+
+
+def test_build_portfolio_payload_excludes_duplicate_oos_daily_return_timestamps():
+    evaluations = [
+        _evaluation(
+            "trend_fast",
+            "trend",
+            "BTC-USD",
+            {"fast": 10},
+            [
+                ("2026-01-02T00:00:00+00:00", 0.01),
+                ("2026-01-02T00:00:00+00:00", 0.02),
+            ],
+        ),
+        _evaluation(
+            "trend_slow",
+            "trend",
+            "ETH-USD",
+            {"window": 20},
+            [
+                ("2026-01-02T00:00:00+00:00", 0.03),
+                ("2026-01-03T00:00:00+00:00", -0.01),
+            ],
+        ),
+    ]
+
+    payload = build_portfolio_aggregation_payload(evaluations, AS_OF_UTC, git_revision="abc123")
+    view = next(item for item in payload["views"] if item["view_name"] == "all_included")
+
+    assert any(item["reason"] == "duplicate_timestamp_in_oos_daily_return_stream" for item in view["excluded_runs"])
+    assert view["included_runs"][0]["asset"] == "ETH-USD"
+    assert view["summary"]["observation_count"] == 2
+
+
+class _PortfolioEngine:
+    def __init__(self, start_datum, eind_datum, evaluation_config=None):
+        self.start = start_datum
+        self.end = eind_datum
+        self.evaluation_config = evaluation_config or {}
+        self._provenance_events = []
+        self.last_evaluation_report = None
+
+    def grid_search(self, strategie_factory, param_grid, assets, interval="1d"):
+        self.last_evaluation_report = {
+            "selected_params": {"periode": 14},
+            "selection_metric": "sharpe",
+            "is_summary": {},
+            "oos_summary": {},
+            "folds": [],
+            "leakage_checks_ok": True,
+            "evaluation_samples": {
+                "daily_returns": [0.01, -0.005, 0.003],
+                "trade_pnls": [0.02, -0.01],
+                "monthly_returns": [0.01],
+            },
+            "evaluation_streams": {
+                "oos_daily_returns": _stream(
+                    [
+                        ("2026-01-02T00:00:00+00:00", 0.01),
+                        ("2026-01-03T00:00:00+00:00", -0.005),
+                        ("2026-01-04T00:00:00+00:00", 0.003),
+                    ]
+                )
+            },
+        }
+        return {
+            "beste_params": {"periode": 14},
+            "win_rate": 0.55,
+            "sharpe": 1.2,
+            "deflated_sharpe": 1.1,
+            "max_drawdown": 0.12,
+            "trades_per_maand": 2.5,
+            "consistentie": 0.75,
+            "totaal_trades": 30,
+            "goedgekeurd": True,
+            "criteria_checks": {},
+            "reden": "",
+        }
+
+
+def test_run_research_writes_additive_portfolio_sidecar_without_public_schema_changes(monkeypatch, tmp_path: Path):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "research").mkdir()
+    monkeypatch.setattr(run_research_module, "BacktestEngine", _PortfolioEngine)
+    monkeypatch.setattr(
+        run_research_module,
+        "get_enabled_strategies",
+        lambda: [
+            {
+                "name": "fake_strategy",
+                "family": "trend",
+                "hypothesis": "Fixture hypothesis",
+                "factory": lambda **params: None,
+                "params": {"periode": [14]},
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        run_research_module,
+        "build_research_universe",
+        lambda config: (
+            [type("Asset", (), {"symbol": "BTC-USD"})()],
+            ["1d"],
+            lambda interval: ("2026-01-01", "2026-02-01"),
+            AS_OF_UTC,
+            {"version": "v1", "resolved_count": 1},
+        ),
+    )
+    monkeypatch.setattr(run_research_module, "load_research_config", lambda config_path="config/config.yaml": {})
+    monkeypatch.setattr(run_research_module, "_git_revision", lambda: "deadbeef")
+    monkeypatch.setattr(run_research_module, "_write_provenance_sidecar", lambda **kwargs: None)
+    monkeypatch.setattr(run_research_module, "_write_walk_forward_sidecar", lambda **kwargs: None)
+    monkeypatch.setattr(run_research_module, "_write_statistical_defensibility_sidecar", lambda **kwargs: None)
+    monkeypatch.setattr(run_research_module, "_write_candidate_registry", lambda **kwargs: None)
+    monkeypatch.setattr(
+        run_research_module,
+        "write_results_to_csv",
+        lambda rows: write_results_to_csv(rows, path=tmp_path / "research" / "strategy_matrix.csv"),
+    )
+    monkeypatch.setattr(
+        run_research_module,
+        "write_latest_json",
+        lambda rows, as_of_utc: write_latest_json(
+            rows,
+            as_of_utc=as_of_utc,
+            path=tmp_path / "research" / "research_latest.json",
+        ),
+    )
+
+    run_research_module.run_research()
+
+    public_json = json.loads((tmp_path / "research" / "research_latest.json").read_text(encoding="utf-8"))
+    sidecar = json.loads((tmp_path / "research" / "portfolio_aggregation_latest.v1.json").read_text(encoding="utf-8"))
+    with (tmp_path / "research" / "strategy_matrix.csv").open(encoding="utf-8", newline="") as handle:
+        csv_rows = list(csv.DictReader(handle))
+
+    assert list(public_json["results"][0].keys()) == ROW_SCHEMA
+    assert list(csv_rows[0].keys()) == ROW_SCHEMA
+    assert sidecar["version"] == "v1"
+    assert sidecar["alignment_policy"]["policy"] == "exact_timestamp_intersection"
+    assert sidecar["views"][0]["view_name"] == "all_included"


### PR DESCRIPTION
Summary

Implements 02.09 — Portfolio / Aggregation Foundations as a research-only, additive capability.

This change adds a deterministic portfolio aggregation sidecar built from timestamped OOS return streams, while keeping:

research_latest.json unchanged
strategy_matrix.csv unchanged
promotion semantics unchanged
walk-forward semantics unchanged
orchestrator logic thin
What changed
New
research/portfolio_reporting.py
pure research-side aggregation/reporting module
builds portfolio views:
all_included
by_asset
by_family
computes:
aggregate return stream
total return
annualized return
volatility
Sharpe
max drawdown
sleeve contribution breakdown
correlation matrix
average pairwise correlation
diversification ratio
records explicit inclusion/exclusion and alignment metadata
Extended
agent/backtesting/engine.py
exposes timestamped evaluation_streams.oos_daily_returns
stream is additive to the evaluation report
existing evaluation/promotion behavior remains intact
Wired
research/run_research.py
adds thin writer wiring for:
research/portfolio_aggregation_latest.v1.json
Tests
tests/unit/test_research_portfolio_reporting.py
deterministic payload construction
alignment behavior
missing stream exclusions
duplicate timestamp exclusions
additive runner/sidecar behavior
Methodology
Alignment policy
basis: timestamped OOS daily returns
no cross-interval mixing
deterministic ascending timestamp order
exact timestamp intersection across included sleeves/views
inactive windows are not treated as cash
weights are not redistributed across non-overlapping periods
Why

This keeps 02.09 methodologically conservative and avoids introducing hidden allocation assumptions into the research layer.

Weighting
equal-weight only
Contribution definition
period return contribution
cumulative period-return contribution
Validation
Targeted
22 passed, 0 failed
Expanded targeted
32 passed, 0 failed
Full suite
344 passed, 1 skipped, 0 failed
Public schema status

Confirmed unchanged:

research_latest.json
strategy_matrix.csv

Regression tests green:

tests/regression/test_research_schema_stability.py
tests/regression/test_research_schema_guard.py
Scope deliberately deferred

Not part of this PR:

approved-only / candidate-only portfolio views
optimizer logic
dynamic rebalancing
live sizing / broker / deployment logic
drawdown attribution
cross-interval portfolio construction
union/cash-filled handling for non-overlapping active windows
Files changed
agent/backtesting/engine.py
research/run_research.py
research/portfolio_reporting.py
tests/unit/test_research_portfolio_reporting.py