### PR TITLE
feat: add regime diagnostics sidecar

### DIFF
--- a/agent/backtesting/engine.py
+++ b/agent/backtesting/engine.py
@@ -12,6 +12,7 @@ from typing import Any, Callable, Optional
 import numpy as np
 import pandas as pd
 
+from agent.backtesting.regime import UNKNOWN, build_regime_frame, normalize_regime_config
 from data.contracts import Instrument
 from data.repository import DataUnavailableError, MarketRepository
 
@@ -74,6 +75,7 @@ class FoldLeakageError(EvaluationScheduleError):
 class AssetContext:
     asset: str
     frame: pd.DataFrame
+    regime_frame: pd.DataFrame
     folds: list[Fold]
 
 
@@ -237,12 +239,14 @@ class BacktestEngine:
         transactiekosten: float = 0.005,
         max_sweep_cells: int = MAX_SWEEP_CELLS,
         evaluation_config: Optional[dict[str, Any]] = None,
+        regime_config: Optional[dict[str, Any]] = None,
     ):
         self.start = start_datum
         self.eind = eind_datum
         self.kosten_per_kant = transactiekosten / 2 + 0.001
         self.max_sweep_cells = max_sweep_cells
         self.evaluation_config = normalize_evaluation_config(evaluation_config)
+        self.regime_config = normalize_regime_config(regime_config)
         self.min_trades = MIN_TRADES
         self._provenance_events: list[Any] = []
         self.last_evaluation_report: Optional[dict[str, Any]] = None
@@ -368,7 +372,8 @@ class BacktestEngine:
                 log.warning(f"[BT] Te weinig data: {asset}")
                 continue
             folds = build_evaluation_folds(len(df), self.evaluation_config)
-            asset_contexts.append(AssetContext(asset=asset, frame=df, folds=folds))
+            regime_frame = build_regime_frame(df, self.regime_config)
+            asset_contexts.append(AssetContext(asset=asset, frame=df, regime_frame=regime_frame, folds=folds))
         return asset_contexts
 
     def _evaluate_windows(
@@ -381,16 +386,37 @@ class BacktestEngine:
         dag_returns: list[float] = []
         maand_returns: list[float] = []
         oos_daily_return_stream: list[dict[str, Any]] = []
+        oos_bar_return_stream: list[dict[str, Any]] = []
+        oos_trade_events: list[dict[str, Any]] = []
 
         for context in asset_contexts:
-            for train_bounds, test_bounds in context.folds:
+            for fold_index, (train_bounds, test_bounds) in enumerate(context.folds):
                 start_idx, end_idx = train_bounds if use_train else test_bounds
                 df_window = context.frame.iloc[start_idx : end_idx + 1].copy()
-                trades, dag, maand = self._simuleer(df_window, strategie_func, context.asset)
+                regime_window = context.regime_frame.iloc[start_idx : end_idx + 1].copy()
+                trades, dag, maand, trade_events = self._simuleer_detailed(
+                    df_window,
+                    strategie_func,
+                    context.asset,
+                    regime_window=regime_window,
+                    fold_index=fold_index,
+                    include_trade_events=not use_train,
+                )
                 trade_pnls.extend(trades)
                 dag_returns.extend(dag)
                 maand_returns.extend(maand)
-                oos_daily_return_stream.extend(self._serialize_daily_return_stream(df_window, dag))
+                if not use_train:
+                    oos_daily_return_stream.extend(self._serialize_daily_return_stream(df_window, dag))
+                    oos_bar_return_stream.extend(
+                        self._serialize_bar_return_stream(
+                            df_window=df_window,
+                            regime_window=regime_window,
+                            period_returns=dag,
+                            asset=context.asset,
+                            fold_index=fold_index,
+                        )
+                    )
+                    oos_trade_events.extend(trade_events)
 
         self._last_window_samples = {
             "daily_returns": list(dag_returns),
@@ -399,6 +425,8 @@ class BacktestEngine:
         }
         self._last_window_streams = {
             "oos_daily_returns": oos_daily_return_stream,
+            "oos_bar_returns": oos_bar_return_stream,
+            "oos_trade_events": oos_trade_events,
         }
 
         if len(trade_pnls) < self.min_trades:
@@ -491,6 +519,53 @@ class BacktestEngine:
         ]
 
     @staticmethod
+    def _serialize_bar_return_stream(
+        df_window: pd.DataFrame,
+        regime_window: pd.DataFrame,
+        period_returns: list[float],
+        asset: str,
+        fold_index: int,
+    ) -> list[dict[str, Any]]:
+        timestamps = [pd.Timestamp(timestamp) for timestamp in df_window.index[1 : len(period_returns) + 1]]
+        labels = regime_window.iloc[1 : len(period_returns) + 1]
+        stream: list[dict[str, Any]] = []
+        for timestamp, value, (_, label_row) in zip(timestamps, period_returns, labels.iterrows()):
+            if timestamp.tzinfo is None:
+                timestamp = timestamp.tz_localize(UTC)
+            else:
+                timestamp = timestamp.tz_convert(UTC)
+            stream.append(
+                {
+                    "timestamp_utc": timestamp.isoformat(),
+                    "asset": asset,
+                    "fold_index": fold_index,
+                    "return": float(value),
+                    "trend_regime": BacktestEngine._label_or_unknown(label_row, "trend_regime"),
+                    "volatility_regime": BacktestEngine._label_or_unknown(label_row, "volatility_regime"),
+                    "combined_regime": BacktestEngine._label_or_unknown(label_row, "combined_regime"),
+                }
+            )
+        return stream
+
+    @staticmethod
+    def _timestamp_to_utc_iso(timestamp: Any) -> str:
+        ts = pd.Timestamp(timestamp)
+        if ts.tzinfo is None:
+            ts = ts.tz_localize(UTC)
+        else:
+            ts = ts.tz_convert(UTC)
+        return ts.isoformat()
+
+    @staticmethod
+    def _label_or_unknown(row: pd.Series | None, key: str) -> str:
+        if row is None:
+            return UNKNOWN
+        value = row.get(key, UNKNOWN)
+        if pd.isna(value):
+            return UNKNOWN
+        return str(value)
+
+    @staticmethod
     def _summary_payload(metrics: dict[str, Any]) -> dict[str, Any]:
         return {key: metrics.get(key) for key in METRIC_KEYS}
 
@@ -551,6 +626,25 @@ class BacktestEngine:
         return timestamp.tz_convert(UTC)
 
     def _simuleer(self, df: pd.DataFrame, strategie_func: Callable, asset: str) -> tuple[list, list, list]:
+        trade_pnls, dag_returns, maand_returns, _ = self._simuleer_detailed(
+            df,
+            strategie_func,
+            asset,
+            regime_window=None,
+            fold_index=None,
+            include_trade_events=False,
+        )
+        return trade_pnls, dag_returns, maand_returns
+
+    def _simuleer_detailed(
+        self,
+        df: pd.DataFrame,
+        strategie_func: Callable,
+        asset: str,
+        regime_window: Optional[pd.DataFrame],
+        fold_index: Optional[int],
+        include_trade_events: bool,
+    ) -> tuple[list[float], list[float], list[float], list[dict[str, Any]]]:
         """
         Simuleer trades zonder lookahead bias.
         Signaal dag X -> uitvoering dag X+1.
@@ -563,10 +657,12 @@ class BacktestEngine:
         df["sig"] = sig.shift(1).fillna(0)
 
         trade_pnls: list[float] = []
+        trade_events: list[dict[str, Any]] = []
         equity = 1.0
         equity_serie: list[float] = [equity]
         positie = 0
         entry_prijs = 0.0
+        current_trade: Optional[dict[str, Any]] = None
 
         for i in range(1, len(df)):
             prijs = float(df["close"].iloc[i])
@@ -581,6 +677,11 @@ class BacktestEngine:
                 if entry_prijs > 0:
                     pnl = (prijs / entry_prijs - 1.0) * positie - self.kosten_per_kant
                     trade_pnls.append(pnl)
+                    if include_trade_events and current_trade is not None:
+                        current_trade["exit_timestamp_utc"] = self._timestamp_to_utc_iso(df.index[i])
+                        current_trade["pnl"] = pnl
+                        trade_events.append(current_trade)
+                        current_trade = None
                 equity *= 1.0 - self.kosten_per_kant
                 positie = 0
 
@@ -588,6 +689,21 @@ class BacktestEngine:
                 entry_prijs = prijs
                 equity *= 1.0 - self.kosten_per_kant
                 positie = signaal
+                if include_trade_events:
+                    decision_index = max(i - 1, 0)
+                    decision_row = None
+                    if regime_window is not None and len(regime_window) > decision_index:
+                        decision_row = regime_window.iloc[decision_index]
+                    current_trade = {
+                        "asset": asset,
+                        "fold_index": fold_index,
+                        "side": "long" if signaal > 0 else "short",
+                        "entry_decision_timestamp_utc": self._timestamp_to_utc_iso(df.index[decision_index]),
+                        "entry_timestamp_utc": self._timestamp_to_utc_iso(df.index[i]),
+                        "entry_trend_regime": self._label_or_unknown(decision_row, "trend_regime"),
+                        "entry_volatility_regime": self._label_or_unknown(decision_row, "volatility_regime"),
+                        "entry_combined_regime": self._label_or_unknown(decision_row, "combined_regime"),
+                    }
 
             equity_serie.append(equity)
 
@@ -596,7 +712,7 @@ class BacktestEngine:
             for i in range(1, len(equity_serie))
         ]
         maand_returns = self._maand_returns(pd.Series(equity_serie, dtype=float), df)
-        return trade_pnls, dag_returns, maand_returns
+        return trade_pnls, dag_returns, maand_returns, trade_events
 
     def _prepare_bollinger_regime_df(self, df: pd.DataFrame, strategie_func: Callable) -> pd.DataFrame:
         """Precompute regime gating only for bollinger_regime."""

--- a/agent/backtesting/regime.py
+++ b/agent/backtesting/regime.py
@@ -1,0 +1,163 @@
+"""Deterministic, point-in-time-safe regime diagnostics primitives.
+
+This module is the single source of truth for research regime feature
+computation and label assignment.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+TRENDING = "trending"
+NON_TRENDING = "non_trending"
+HIGH_VOL = "high_vol"
+LOW_VOL = "low_vol"
+UNKNOWN = "unknown"
+
+TREND_LABELS: tuple[str, ...] = (TRENDING, NON_TRENDING, UNKNOWN)
+VOLATILITY_LABELS: tuple[str, ...] = (HIGH_VOL, LOW_VOL, UNKNOWN)
+COMBINED_LABELS: tuple[str, ...] = (
+    f"{TRENDING}|{HIGH_VOL}",
+    f"{TRENDING}|{LOW_VOL}",
+    f"{NON_TRENDING}|{HIGH_VOL}",
+    f"{NON_TRENDING}|{LOW_VOL}",
+    UNKNOWN,
+)
+
+DEFAULT_REGIME_CONFIG: dict[str, Any] = {
+    "trend_lookback_bars": 20,
+    "volatility_lookback_bars": 20,
+    "volatility_baseline_lookback_bars": 100,
+    "trend_strength_threshold": 0.5,
+    "high_vol_ratio_threshold": 1.5,
+}
+
+EPSILON = 1e-12
+
+
+def normalize_regime_config(config: dict[str, Any] | None) -> dict[str, Any]:
+    """Normalize optional research.regime_diagnostics config."""
+    raw = dict(config or {})
+    normalized = dict(DEFAULT_REGIME_CONFIG)
+
+    for key in DEFAULT_REGIME_CONFIG:
+        if key in raw:
+            normalized[key] = raw[key]
+
+    for key in (
+        "trend_lookback_bars",
+        "volatility_lookback_bars",
+        "volatility_baseline_lookback_bars",
+    ):
+        value = int(normalized[key])
+        if value <= 0:
+            raise ValueError(f"research.regime_diagnostics.{key} must be > 0, got {value!r}")
+        normalized[key] = value
+
+    for key in ("trend_strength_threshold", "high_vol_ratio_threshold"):
+        value = float(normalized[key])
+        if value <= 0.0:
+            raise ValueError(f"research.regime_diagnostics.{key} must be > 0, got {value!r}")
+        normalized[key] = value
+
+    return normalized
+
+
+def regime_definition_payload(config: dict[str, Any] | None) -> dict[str, Any]:
+    """Return explicit regime definitions for sidecar lineage."""
+    normalized = normalize_regime_config(config)
+    return {
+        "trend_regime": {
+            "labels": list(TREND_LABELS),
+            "method": "abs(trailing_mean(log_return_1)) / trailing_std(log_return_1)",
+            "lookback_bars": normalized["trend_lookback_bars"],
+            "threshold": normalized["trend_strength_threshold"],
+            "point_in_time_safe": True,
+        },
+        "volatility_regime": {
+            "labels": list(VOLATILITY_LABELS),
+            "method": "trailing_realized_vol / trailing_vol_baseline",
+            "lookback_bars": normalized["volatility_lookback_bars"],
+            "baseline_lookback_bars": normalized["volatility_baseline_lookback_bars"],
+            "high_vol_ratio_threshold": normalized["high_vol_ratio_threshold"],
+            "point_in_time_safe": True,
+        },
+        "combined_regime": {
+            "labels": list(COMBINED_LABELS),
+            "method": "trend_regime + '|' + volatility_regime, else unknown",
+            "point_in_time_safe": True,
+        },
+    }
+
+
+def build_regime_frame(frame: pd.DataFrame, config: dict[str, Any] | None) -> pd.DataFrame:
+    """Compute deterministic trailing regime features and labels.
+
+    Uses only trailing windows ending at timestamp t. No future bars,
+    no full-run thresholds, and no cross-asset fitting.
+    """
+    normalized = normalize_regime_config(config)
+    close = pd.to_numeric(frame["close"], errors="coerce").astype(float)
+    safe_close = close.where(close > 0.0)
+    log_return_1 = np.log(safe_close).diff()
+
+    trend_mean = log_return_1.rolling(
+        window=normalized["trend_lookback_bars"],
+        min_periods=normalized["trend_lookback_bars"],
+    ).mean()
+    trend_std = log_return_1.rolling(
+        window=normalized["trend_lookback_bars"],
+        min_periods=normalized["trend_lookback_bars"],
+    ).std(ddof=0)
+    trend_strength = trend_mean.abs() / (trend_std + EPSILON)
+
+    realized_vol = log_return_1.rolling(
+        window=normalized["volatility_lookback_bars"],
+        min_periods=normalized["volatility_lookback_bars"],
+    ).std(ddof=0)
+    volatility_baseline = realized_vol.rolling(
+        window=normalized["volatility_baseline_lookback_bars"],
+        min_periods=normalized["volatility_baseline_lookback_bars"],
+    ).median()
+
+    trend_regime = pd.Series(UNKNOWN, index=frame.index, dtype="object")
+    trend_valid = trend_mean.notna() & trend_std.notna()
+    trend_regime.loc[trend_valid & (trend_strength >= normalized["trend_strength_threshold"])] = TRENDING
+    trend_regime.loc[trend_valid & (trend_strength < normalized["trend_strength_threshold"])] = NON_TRENDING
+
+    volatility_regime = pd.Series(UNKNOWN, index=frame.index, dtype="object")
+    vol_valid = realized_vol.notna() & volatility_baseline.notna()
+    baseline_zero = vol_valid & (volatility_baseline <= EPSILON)
+    non_zero_baseline = vol_valid & ~baseline_zero
+
+    volatility_regime.loc[baseline_zero & (realized_vol > EPSILON)] = HIGH_VOL
+    volatility_regime.loc[baseline_zero & (realized_vol <= EPSILON)] = LOW_VOL
+    volatility_ratio = realized_vol / volatility_baseline.where(volatility_baseline > EPSILON)
+    volatility_regime.loc[
+        non_zero_baseline & (volatility_ratio >= normalized["high_vol_ratio_threshold"])
+    ] = HIGH_VOL
+    volatility_regime.loc[
+        non_zero_baseline & (volatility_ratio < normalized["high_vol_ratio_threshold"])
+    ] = LOW_VOL
+
+    combined_regime = pd.Series(UNKNOWN, index=frame.index, dtype="object")
+    combined_valid = (trend_regime != UNKNOWN) & (volatility_regime != UNKNOWN)
+    combined_regime.loc[combined_valid] = (
+        trend_regime.loc[combined_valid] + "|" + volatility_regime.loc[combined_valid]
+    )
+
+    return pd.DataFrame(
+        {
+            "log_return_1": log_return_1,
+            "trend_strength": trend_strength,
+            "realized_volatility": realized_vol,
+            "volatility_baseline": volatility_baseline,
+            "trend_regime": trend_regime,
+            "volatility_regime": volatility_regime,
+            "combined_regime": combined_regime,
+        },
+        index=frame.index,
+    )

--- a/config/config.template.yaml
+++ b/config/config.template.yaml
@@ -133,6 +133,12 @@ research:
     require_leakage_checks_ok: true
     require_goedgekeurd: false
     min_oos_trades: 10
+  regime_diagnostics:
+    trend_lookback_bars: 20
+    volatility_lookback_bars: 20
+    volatility_baseline_lookback_bars: 100
+    trend_strength_threshold: 0.5
+    high_vol_ratio_threshold: 1.5
 
 leren:
   trade_geheugen: 1000

--- a/research/regime_reporting.py
+++ b/research/regime_reporting.py
@@ -1,0 +1,530 @@
+"""Pure helpers for additive regime diagnostics sidecar assembly."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import numpy as np
+
+from agent.backtesting.regime import (
+    COMBINED_LABELS,
+    TREND_LABELS,
+    VOLATILITY_LABELS,
+    normalize_regime_config,
+    regime_definition_payload,
+)
+from research.promotion import build_strategy_id
+
+EVALUATION_VERSION = "regime_diagnostics_v1"
+
+
+def build_regime_diagnostics_payload(
+    evaluations: list[dict[str, Any]],
+    as_of_utc,
+    git_revision: str,
+    config_hash: str,
+    evaluation_config: dict[str, Any],
+    regime_config: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Build the additive regime diagnostics sidecar payload."""
+    normalized_regime_config = normalize_regime_config(regime_config)
+    runs = [_normalize_run(evaluation) for evaluation in evaluations]
+    strategies = [
+        _build_strategy_summary(run)
+        for run in sorted(runs, key=lambda item: item["strategy_id"])
+    ]
+    assets = _build_asset_summaries(runs)
+
+    return {
+        "version": "v1",
+        "generated_at_utc": as_of_utc.isoformat(),
+        "git_revision": git_revision,
+        "lineage": {
+            "config_hash": config_hash,
+            "data_snapshot_id": None,
+            "evaluation_version": EVALUATION_VERSION,
+            "evaluation_config": dict(evaluation_config),
+            "seed": None,
+        },
+        "config_used": normalized_regime_config,
+        "regime_definitions": regime_definition_payload(normalized_regime_config),
+        "summary": {
+            "strategy_run_count": len(strategies),
+            "asset_interval_count": len(assets),
+            "total_oos_bar_count": sum(item["totals"]["oos_bar_count"] for item in strategies),
+            "total_oos_trade_count": sum(item["totals"]["oos_trade_count"] for item in strategies),
+        },
+        "assets": assets,
+        "strategies": strategies,
+    }
+
+
+def _normalize_run(evaluation: dict[str, Any]) -> dict[str, Any]:
+    row = evaluation.get("row", {})
+    selected_params = dict(evaluation.get("selected_params") or {})
+    report = evaluation.get("evaluation_report") or {}
+    streams = report.get("evaluation_streams") or {}
+    bars = _normalize_bar_stream(streams.get("oos_bar_returns"))
+    trades = _normalize_trade_stream(streams.get("oos_trade_events"))
+    strategy_id = build_strategy_id(
+        row.get("strategy_name", ""),
+        row.get("asset", ""),
+        row.get("interval", ""),
+        selected_params,
+    )
+
+    return {
+        "strategy_id": strategy_id,
+        "strategy_name": row.get("strategy_name", ""),
+        "family": row.get("family", evaluation.get("family", "")),
+        "asset": row.get("asset", ""),
+        "interval": row.get("interval", evaluation.get("interval", "")),
+        "selected_params": selected_params,
+        "bars": bars,
+        "trades": trades,
+        "data_quality": {
+            "has_oos_bar_returns": bool(bars),
+            "has_oos_trade_events": bool(trades),
+        },
+    }
+
+
+def _normalize_bar_stream(raw_stream: Any) -> list[dict[str, Any]]:
+    if not isinstance(raw_stream, list):
+        return []
+
+    bars: list[dict[str, Any]] = []
+    for point in raw_stream:
+        if not isinstance(point, dict):
+            continue
+        timestamp = point.get("timestamp_utc")
+        asset = point.get("asset")
+        fold_index = point.get("fold_index")
+        value = point.get("return")
+        if not isinstance(timestamp, str) or not isinstance(asset, str):
+            continue
+        if not isinstance(fold_index, int) or not isinstance(value, (int, float)):
+            continue
+        bars.append(
+            {
+                "timestamp_utc": timestamp,
+                "asset": asset,
+                "fold_index": fold_index,
+                "return": float(value),
+                "trend_regime": str(point.get("trend_regime", "unknown")),
+                "volatility_regime": str(point.get("volatility_regime", "unknown")),
+                "combined_regime": str(point.get("combined_regime", "unknown")),
+            }
+        )
+
+    bars.sort(key=lambda item: (item["fold_index"], item["timestamp_utc"]))
+    return bars
+
+
+def _normalize_trade_stream(raw_stream: Any) -> list[dict[str, Any]]:
+    if not isinstance(raw_stream, list):
+        return []
+
+    trades: list[dict[str, Any]] = []
+    for event in raw_stream:
+        if not isinstance(event, dict):
+            continue
+        if not isinstance(event.get("asset"), str) or not isinstance(event.get("fold_index"), int):
+            continue
+        if not isinstance(event.get("entry_decision_timestamp_utc"), str):
+            continue
+        if not isinstance(event.get("entry_timestamp_utc"), str) or not isinstance(event.get("exit_timestamp_utc"), str):
+            continue
+        if not isinstance(event.get("side"), str) or not isinstance(event.get("pnl"), (int, float)):
+            continue
+        trades.append(
+            {
+                "asset": event["asset"],
+                "fold_index": int(event["fold_index"]),
+                "side": event["side"],
+                "entry_decision_timestamp_utc": event["entry_decision_timestamp_utc"],
+                "entry_timestamp_utc": event["entry_timestamp_utc"],
+                "exit_timestamp_utc": event["exit_timestamp_utc"],
+                "pnl": float(event["pnl"]),
+                "entry_trend_regime": str(event.get("entry_trend_regime", "unknown")),
+                "entry_volatility_regime": str(event.get("entry_volatility_regime", "unknown")),
+                "entry_combined_regime": str(event.get("entry_combined_regime", "unknown")),
+            }
+        )
+
+    trades.sort(key=lambda item: (item["fold_index"], item["entry_timestamp_utc"], item["exit_timestamp_utc"]))
+    return trades
+
+
+def _build_asset_summaries(runs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    grouped: dict[tuple[str, str], dict[tuple[int, str], dict[str, Any]]] = {}
+
+    for run in runs:
+        key = (run["asset"], run["interval"])
+        deduped = grouped.setdefault(key, {})
+        for bar in run["bars"]:
+            dedupe_key = (bar["fold_index"], bar["timestamp_utc"])
+            deduped.setdefault(dedupe_key, bar)
+
+    summaries = []
+    for (asset, interval), deduped in sorted(grouped.items()):
+        bars = [deduped[key] for key in sorted(deduped)]
+        summaries.append(
+            {
+                "asset": asset,
+                "interval": interval,
+                "oos_bar_count": len(bars),
+                "coverage": _coverage_breakdown(bars),
+                "fold_breakdown": _asset_fold_breakdown(bars),
+                "reconciliation": {
+                    "trend_coverage_matches_total": _coverage_sum_matches_total(_coverage_entries(bars, "trend_regime", TREND_LABELS), len(bars)),
+                    "volatility_coverage_matches_total": _coverage_sum_matches_total(_coverage_entries(bars, "volatility_regime", VOLATILITY_LABELS), len(bars)),
+                    "combined_coverage_matches_total": _coverage_sum_matches_total(_coverage_entries(bars, "combined_regime", COMBINED_LABELS), len(bars)),
+                },
+            }
+        )
+
+    return summaries
+
+
+def _asset_fold_breakdown(bars: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    grouped: dict[int, list[dict[str, Any]]] = {}
+    for bar in bars:
+        grouped.setdefault(bar["fold_index"], []).append(bar)
+
+    return [
+        {
+            "fold_index": fold_index,
+            "oos_bar_count": len(group),
+            "coverage": _coverage_breakdown(group),
+            "reconciliation": {
+                "combined_coverage_matches_total": _coverage_sum_matches_total(
+                    _coverage_entries(group, "combined_regime", COMBINED_LABELS),
+                    len(group),
+                )
+            },
+        }
+        for fold_index, group in sorted(grouped.items())
+    ]
+
+
+def _build_strategy_summary(run: dict[str, Any]) -> dict[str, Any]:
+    bars = run["bars"]
+    trades = run["trades"]
+    total_bar_count = len(bars)
+    total_trade_count = len(trades)
+    total_arithmetic_return_contribution = float(sum(bar["return"] for bar in bars)) if bars else 0.0
+
+    return {
+        "strategy_id": run["strategy_id"],
+        "strategy_name": run["strategy_name"],
+        "family": run["family"],
+        "asset": run["asset"],
+        "interval": run["interval"],
+        "selected_params": run["selected_params"],
+        "data_quality": dict(run["data_quality"]),
+        "totals": {
+            "oos_bar_count": total_bar_count,
+            "oos_trade_count": total_trade_count,
+            "arithmetic_return_contribution_total": total_arithmetic_return_contribution,
+            "return_metrics": _bar_metrics([bar["return"] for bar in bars], run["interval"]),
+        },
+        "regime_breakdown": {
+            "trend": _regime_breakdown(
+                bars=bars,
+                trades=trades,
+                bar_label_key="trend_regime",
+                trade_label_key="entry_trend_regime",
+                labels=TREND_LABELS,
+                interval=run["interval"],
+            ),
+            "volatility": _regime_breakdown(
+                bars=bars,
+                trades=trades,
+                bar_label_key="volatility_regime",
+                trade_label_key="entry_volatility_regime",
+                labels=VOLATILITY_LABELS,
+                interval=run["interval"],
+            ),
+            "combined": _regime_breakdown(
+                bars=bars,
+                trades=trades,
+                bar_label_key="combined_regime",
+                trade_label_key="entry_combined_regime",
+                labels=COMBINED_LABELS,
+                interval=run["interval"],
+            ),
+        },
+        "fold_breakdown": _strategy_fold_breakdown(run),
+        "reconciliation": {
+            "trend_coverage_matches_total": _coverage_sum_matches_total(
+                _coverage_entries(bars, "trend_regime", TREND_LABELS),
+                total_bar_count,
+            ),
+            "volatility_coverage_matches_total": _coverage_sum_matches_total(
+                _coverage_entries(bars, "volatility_regime", VOLATILITY_LABELS),
+                total_bar_count,
+            ),
+            "combined_coverage_matches_total": _coverage_sum_matches_total(
+                _coverage_entries(bars, "combined_regime", COMBINED_LABELS),
+                total_bar_count,
+            ),
+            "trend_trade_counts_match_total": _trade_count_matches_total(
+                trades,
+                "entry_trend_regime",
+                TREND_LABELS,
+                total_trade_count,
+            ),
+            "volatility_trade_counts_match_total": _trade_count_matches_total(
+                trades,
+                "entry_volatility_regime",
+                VOLATILITY_LABELS,
+                total_trade_count,
+            ),
+            "combined_trade_counts_match_total": _trade_count_matches_total(
+                trades,
+                "entry_combined_regime",
+                COMBINED_LABELS,
+                total_trade_count,
+            ),
+            "combined_return_contribution_matches_total": _return_contribution_matches_total(
+                bars,
+                "combined_regime",
+                COMBINED_LABELS,
+                total_arithmetic_return_contribution,
+            ),
+        },
+    }
+
+
+def _strategy_fold_breakdown(run: dict[str, Any]) -> list[dict[str, Any]]:
+    bars_by_fold: dict[int, list[dict[str, Any]]] = {}
+    trades_by_fold: dict[int, list[dict[str, Any]]] = {}
+    for bar in run["bars"]:
+        bars_by_fold.setdefault(bar["fold_index"], []).append(bar)
+    for trade in run["trades"]:
+        trades_by_fold.setdefault(trade["fold_index"], []).append(trade)
+
+    fold_indices = sorted(set(bars_by_fold) | set(trades_by_fold))
+    breakdown = []
+    for fold_index in fold_indices:
+        bars = bars_by_fold.get(fold_index, [])
+        trades = trades_by_fold.get(fold_index, [])
+        breakdown.append(
+            {
+                "fold_index": fold_index,
+                "oos_bar_count": len(bars),
+                "oos_trade_count": len(trades),
+                "combined": _regime_breakdown(
+                    bars=bars,
+                    trades=trades,
+                    bar_label_key="combined_regime",
+                    trade_label_key="entry_combined_regime",
+                    labels=COMBINED_LABELS,
+                    interval=run["interval"],
+                ),
+                "reconciliation": {
+                    "combined_coverage_matches_total": _coverage_sum_matches_total(
+                        _coverage_entries(bars, "combined_regime", COMBINED_LABELS),
+                        len(bars),
+                    ),
+                    "combined_trade_counts_match_total": _trade_count_matches_total(
+                        trades,
+                        "entry_combined_regime",
+                        COMBINED_LABELS,
+                        len(trades),
+                    ),
+                },
+            }
+        )
+    return breakdown
+
+
+def _coverage_breakdown(bars: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    return {
+        "trend": _coverage_entries(bars, "trend_regime", TREND_LABELS),
+        "volatility": _coverage_entries(bars, "volatility_regime", VOLATILITY_LABELS),
+        "combined": _coverage_entries(bars, "combined_regime", COMBINED_LABELS),
+    }
+
+
+def _coverage_entries(
+    bars: list[dict[str, Any]],
+    key: str,
+    labels: tuple[str, ...],
+) -> list[dict[str, Any]]:
+    total = len(bars)
+    counts = {label: 0 for label in labels}
+    for bar in bars:
+        label = str(bar.get(key, "unknown"))
+        counts[label if label in counts else "unknown"] += 1
+    return [
+        {
+            "label": label,
+            "count": counts[label],
+            "share": _share(counts[label], total),
+        }
+        for label in labels
+    ]
+
+
+def _regime_breakdown(
+    *,
+    bars: list[dict[str, Any]],
+    trades: list[dict[str, Any]],
+    bar_label_key: str,
+    trade_label_key: str,
+    labels: tuple[str, ...],
+    interval: str,
+) -> list[dict[str, Any]]:
+    total_bar_count = len(bars)
+    total_trade_count = len(trades)
+    entries = []
+    for label in labels:
+        bar_subset = [bar for bar in bars if bar.get(bar_label_key, "unknown") == label]
+        trade_subset = [trade for trade in trades if trade.get(trade_label_key, "unknown") == label]
+        entries.append(
+            {
+                "label": label,
+                "coverage_count": len(bar_subset),
+                "coverage_share": _share(len(bar_subset), total_bar_count),
+                "arithmetic_return_contribution": float(sum(bar["return"] for bar in bar_subset)) if bar_subset else 0.0,
+                "return_metrics": _bar_metrics([bar["return"] for bar in bar_subset], interval),
+                "trade_count": len(trade_subset),
+                "trade_share": _share(len(trade_subset), total_trade_count),
+                "trade_metrics": _trade_metrics([trade["pnl"] for trade in trade_subset]),
+            }
+        )
+    return entries
+
+
+def _bar_metrics(returns: list[float], interval: str) -> dict[str, Any]:
+    if not returns:
+        return {
+            "count": 0,
+            "compounded_return": None,
+            "mean_return": None,
+            "positive_return_rate": None,
+            "volatility": None,
+            "sharpe": None,
+            "max_drawdown": None,
+            "validity": {
+                "compounded_return_valid": False,
+                "mean_return_valid": False,
+                "positive_return_rate_valid": False,
+                "volatility_valid": False,
+                "sharpe_valid": False,
+                "max_drawdown_valid": False,
+            },
+        }
+
+    values = np.asarray(returns, dtype=float)
+    compounded_return = float(np.prod(1.0 + values) - 1.0)
+    mean_return = float(values.mean())
+    positive_return_rate = float(np.mean(values > 0.0))
+    volatility_valid = values.size >= 2
+    sharpe_valid = volatility_valid and float(values.std()) > 0.0
+    volatility = (
+        float(values.std() * math.sqrt(_annualization_factor(interval)))
+        if volatility_valid
+        else None
+    )
+    sharpe = (
+        float((values.mean() / values.std()) * math.sqrt(_annualization_factor(interval)))
+        if sharpe_valid
+        else None
+    )
+    equity = np.cumprod(1.0 + values)
+    peaks = np.maximum.accumulate(equity)
+    drawdowns = (equity - peaks) / np.where(peaks > 0.0, peaks, 1.0)
+
+    return {
+        "count": int(values.size),
+        "compounded_return": compounded_return,
+        "mean_return": mean_return,
+        "positive_return_rate": positive_return_rate,
+        "volatility": volatility,
+        "sharpe": sharpe,
+        "max_drawdown": float(abs(drawdowns.min())) if values.size >= 1 else None,
+        "validity": {
+            "compounded_return_valid": values.size >= 1,
+            "mean_return_valid": values.size >= 1,
+            "positive_return_rate_valid": values.size >= 1,
+            "volatility_valid": volatility_valid,
+            "sharpe_valid": sharpe_valid,
+            "max_drawdown_valid": values.size >= 1,
+        },
+    }
+
+
+def _trade_metrics(pnls: list[float]) -> dict[str, Any]:
+    if not pnls:
+        return {
+            "count": 0,
+            "total_pnl": 0.0,
+            "mean_pnl": None,
+            "win_rate": None,
+            "validity": {
+                "mean_pnl_valid": False,
+                "win_rate_valid": False,
+            },
+        }
+
+    values = np.asarray(pnls, dtype=float)
+    return {
+        "count": int(values.size),
+        "total_pnl": float(values.sum()),
+        "mean_pnl": float(values.mean()),
+        "win_rate": float(np.mean(values > 0.0)),
+        "validity": {
+            "mean_pnl_valid": True,
+            "win_rate_valid": True,
+        },
+    }
+
+
+def _annualization_factor(interval: str) -> int:
+    return {
+        "1d": 252,
+        "1h": 24 * 365,
+        "4h": 6 * 365,
+        "15m": 4 * 24 * 365,
+        "5m": 12 * 24 * 365,
+    }.get(interval, 252)
+
+
+def _share(count: int, total: int) -> float | None:
+    if total <= 0:
+        return None
+    return round(count / total, 4)
+
+
+def _coverage_sum_matches_total(entries: list[dict[str, Any]], total: int) -> bool:
+    return sum(int(entry["count"]) for entry in entries) == total
+
+
+def _trade_count_matches_total(
+    trades: list[dict[str, Any]],
+    key: str,
+    labels: tuple[str, ...],
+    total: int,
+) -> bool:
+    counts = {label: 0 for label in labels}
+    for trade in trades:
+        label = str(trade.get(key, "unknown"))
+        counts[label if label in counts else "unknown"] += 1
+    return sum(counts.values()) == total
+
+
+def _return_contribution_matches_total(
+    bars: list[dict[str, Any]],
+    key: str,
+    labels: tuple[str, ...],
+    total: float,
+) -> bool:
+    contributions = {label: 0.0 for label in labels}
+    for bar in bars:
+        label = str(bar.get(key, "unknown"))
+        contributions[label if label in contributions else "unknown"] += float(bar["return"])
+    return math.isclose(sum(contributions.values()), total, rel_tol=1e-9, abs_tol=1e-9)

--- a/research/run_research.py
+++ b/research/run_research.py
@@ -24,6 +24,7 @@ from research.registry import get_enabled_strategies
 from research.results import make_result_row, write_latest_json, write_results_to_csv
 from research.portfolio_reporting import build_portfolio_aggregation_payload
 from research.promotion_reporting import build_candidate_registry_payload
+from research.regime_reporting import build_regime_diagnostics_payload
 from research.statistical_reporting import build_statistical_defensibility_payload, regime_count_settings
 from research.universe import build_research_universe
 
@@ -32,6 +33,7 @@ WALK_FORWARD_PATH = "research/walk_forward_latest.v1.json"
 CANDIDATE_REGISTRY_PATH = Path("research/candidate_registry_latest.v1.json")
 UNIVERSE_SNAPSHOT_PATH = Path("research/universe_snapshot_latest.v1.json")
 PORTFOLIO_AGGREGATION_PATH = Path("research/portfolio_aggregation_latest.v1.json")
+REGIME_DIAGNOSTICS_PATH = Path("research/regime_diagnostics_latest.v1.json")
 
 
 def load_research_config(config_path="config/config.yaml"):
@@ -254,14 +256,54 @@ def _write_portfolio_aggregation_sidecar(
     _write_json_atomic(path, payload)
 
 
-def _build_engine(start_datum: str, eind_datum: str, evaluation_config: dict) -> BacktestEngine:
+def _write_regime_diagnostics_sidecar(
+    *,
+    evaluations: list[dict],
+    as_of_utc,
+    research_config: dict,
+    evaluation_config: dict,
+    provenance_events: list,
+    path: Path = REGIME_DIAGNOSTICS_PATH,
+) -> None:
+    payload = build_regime_diagnostics_payload(
+        evaluations=evaluations,
+        as_of_utc=as_of_utc,
+        git_revision=_git_revision(),
+        config_hash=_config_hash(research_config, provenance_events),
+        evaluation_config=evaluation_config,
+        regime_config=research_config.get("regime_diagnostics"),
+    )
+    _write_json_atomic(path, payload)
+
+
+def _build_engine(
+    start_datum: str,
+    eind_datum: str,
+    evaluation_config: dict,
+    regime_config: dict | None = None,
+) -> BacktestEngine:
     try:
         return BacktestEngine(
             start_datum=start_datum,
             eind_datum=eind_datum,
             evaluation_config=evaluation_config,
+            regime_config=regime_config,
         )
     except TypeError as exc:
+        if "regime_config" in str(exc):
+            try:
+                return BacktestEngine(
+                    start_datum=start_datum,
+                    eind_datum=eind_datum,
+                    evaluation_config=evaluation_config,
+                )
+            except TypeError as exc2:
+                if "evaluation_config" not in str(exc2):
+                    raise
+                return BacktestEngine(
+                    start_datum=start_datum,
+                    eind_datum=eind_datum,
+                )
         if "evaluation_config" not in str(exc):
             raise
         return BacktestEngine(
@@ -297,6 +339,7 @@ def run_research():
                     start_datum=start_datum,
                     eind_datum=eind_datum,
                     evaluation_config=evaluation_config,
+                    regime_config=research_config.get("regime_diagnostics"),
                 )
                 try:
                     metrics = engine.grid_search(
@@ -391,6 +434,13 @@ def run_research():
     _write_portfolio_aggregation_sidecar(
         evaluations=evaluations,
         as_of_utc=as_of_utc,
+    )
+    _write_regime_diagnostics_sidecar(
+        evaluations=evaluations,
+        as_of_utc=as_of_utc,
+        research_config=research_config,
+        evaluation_config=evaluation_config,
+        provenance_events=provenance_events,
     )
 
     print(f"Klaar. {len(rows)} resultaten geschreven.")

--- a/tests/unit/test_regime_diagnostics.py
+++ b/tests/unit/test_regime_diagnostics.py
@@ -1,0 +1,121 @@
+from datetime import UTC
+
+import numpy as np
+import pandas as pd
+
+from agent.backtesting.regime import (
+    HIGH_VOL,
+    LOW_VOL,
+    NON_TRENDING,
+    TRENDING,
+    UNKNOWN,
+    build_regime_frame,
+    normalize_regime_config,
+)
+
+
+def _frame(closes: list[float]) -> pd.DataFrame:
+    index = pd.date_range("2026-01-01", periods=len(closes), freq="D", tz=UTC)
+    return pd.DataFrame({"close": closes}, index=index)
+
+
+def test_build_regime_frame_is_deterministic_for_same_input_and_config():
+    frame = _frame([100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110])
+    config = {
+        "trend_lookback_bars": 3,
+        "volatility_lookback_bars": 3,
+        "volatility_baseline_lookback_bars": 3,
+        "trend_strength_threshold": 0.5,
+        "high_vol_ratio_threshold": 1.5,
+    }
+
+    first = build_regime_frame(frame, config)
+    second = build_regime_frame(frame, config)
+
+    pd.testing.assert_frame_equal(first, second)
+
+
+def test_regime_labels_do_not_change_when_future_shock_is_appended():
+    base = [100, 101, 102, 103, 104, 105, 106, 107]
+    shocked = base + [80, 81, 82]
+    config = {
+        "trend_lookback_bars": 3,
+        "volatility_lookback_bars": 3,
+        "volatility_baseline_lookback_bars": 3,
+        "trend_strength_threshold": 0.5,
+        "high_vol_ratio_threshold": 1.5,
+    }
+
+    truncated = build_regime_frame(_frame(base), config)
+    full = build_regime_frame(_frame(shocked), config).iloc[: len(base)]
+
+    pd.testing.assert_series_equal(
+        truncated["combined_regime"],
+        full["combined_regime"],
+        check_names=False,
+    )
+
+
+def test_flat_market_becomes_non_trending_low_vol_after_enough_history():
+    frame = _frame([100.0] * 12)
+    config = {
+        "trend_lookback_bars": 3,
+        "volatility_lookback_bars": 3,
+        "volatility_baseline_lookback_bars": 3,
+        "trend_strength_threshold": 0.5,
+        "high_vol_ratio_threshold": 1.5,
+    }
+
+    result = build_regime_frame(frame, config)
+
+    assert result["trend_regime"].iloc[0] == UNKNOWN
+    assert result["volatility_regime"].iloc[-1] == LOW_VOL
+    assert result["trend_regime"].iloc[-1] == NON_TRENDING
+
+
+def test_monotonic_uptrend_and_downtrend_are_labeled_trending():
+    config = {
+        "trend_lookback_bars": 3,
+        "volatility_lookback_bars": 3,
+        "volatility_baseline_lookback_bars": 3,
+        "trend_strength_threshold": 0.5,
+        "high_vol_ratio_threshold": 1.5,
+    }
+
+    up = build_regime_frame(_frame([100, 102, 104, 106, 108, 110, 112]), config)
+    down = build_regime_frame(_frame([112, 110, 108, 106, 104, 102, 100]), config)
+
+    assert up["trend_regime"].iloc[-1] == TRENDING
+    assert down["trend_regime"].iloc[-1] == TRENDING
+
+
+def test_volatility_shock_is_labeled_high_vol_when_baseline_exists():
+    closes = [100, 100.5, 101, 101.5, 102, 102.5, 103, 120, 90, 121, 89]
+    result = build_regime_frame(
+        _frame(closes),
+        {
+            "trend_lookback_bars": 3,
+            "volatility_lookback_bars": 3,
+            "volatility_baseline_lookback_bars": 3,
+            "trend_strength_threshold": 0.5,
+            "high_vol_ratio_threshold": 1.2,
+        },
+    )
+
+    assert HIGH_VOL in set(result["volatility_regime"].iloc[-3:])
+
+
+def test_missing_data_and_short_series_remain_unknown_without_crashing():
+    closes = [100, np.nan, 101, 102]
+    result = build_regime_frame(_frame(closes), None)
+
+    assert all(label == UNKNOWN for label in result["combined_regime"])
+
+
+def test_normalize_regime_config_rejects_non_positive_values():
+    try:
+        normalize_regime_config({"trend_lookback_bars": 0})
+    except ValueError as exc:
+        assert "trend_lookback_bars" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError for non-positive lookback")

--- a/tests/unit/test_research_regime_reporting.py
+++ b/tests/unit/test_research_regime_reporting.py
@@ -1,0 +1,259 @@
+import csv
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+from research import run_research as run_research_module
+from research.regime_reporting import build_regime_diagnostics_payload
+from research.results import make_result_row, write_latest_json, write_results_to_csv
+
+AS_OF_UTC = datetime(2026, 4, 14, 10, 0, 0, tzinfo=UTC)
+ROW_SCHEMA = list(
+    make_result_row(
+        strategy={"name": "schema", "family": "trend", "hypothesis": "schema"},
+        asset="BTC-USD",
+        interval="1d",
+        params={},
+        as_of_utc=AS_OF_UTC,
+        metrics={},
+    ).keys()
+)
+
+
+def _evaluation() -> dict:
+    row = make_result_row(
+        strategy={"name": "trend_fast", "family": "trend", "hypothesis": "trend hypothesis"},
+        asset="BTC-USD",
+        interval="1d",
+        params={"fast": 10},
+        as_of_utc=AS_OF_UTC,
+        metrics={
+            "win_rate": 0.6,
+            "sharpe": 0.5,
+            "deflated_sharpe": 0.4,
+            "max_drawdown": 0.1,
+            "trades_per_maand": 3.0,
+            "consistentie": 0.7,
+            "totaal_trades": 2,
+            "goedgekeurd": True,
+            "criteria_checks": {},
+            "reden": "",
+        },
+    )
+    return {
+        "family": "trend",
+        "interval": "1d",
+        "selected_params": {"fast": 10},
+        "row": row,
+        "evaluation_report": {
+            "selection_metric": "sharpe",
+            "is_summary": {},
+            "oos_summary": {},
+            "folds": [],
+            "leakage_checks_ok": True,
+            "evaluation_streams": {
+                "oos_bar_returns": [
+                    {
+                        "timestamp_utc": "2026-01-02T00:00:00+00:00",
+                        "asset": "BTC-USD",
+                        "fold_index": 0,
+                        "return": 0.01,
+                        "trend_regime": "trending",
+                        "volatility_regime": "low_vol",
+                        "combined_regime": "trending|low_vol",
+                    },
+                    {
+                        "timestamp_utc": "2026-01-03T00:00:00+00:00",
+                        "asset": "BTC-USD",
+                        "fold_index": 0,
+                        "return": -0.02,
+                        "trend_regime": "trending",
+                        "volatility_regime": "high_vol",
+                        "combined_regime": "trending|high_vol",
+                    },
+                    {
+                        "timestamp_utc": "2026-01-04T00:00:00+00:00",
+                        "asset": "BTC-USD",
+                        "fold_index": 1,
+                        "return": 0.0,
+                        "trend_regime": "non_trending",
+                        "volatility_regime": "low_vol",
+                        "combined_regime": "non_trending|low_vol",
+                    },
+                ],
+                "oos_trade_events": [
+                    {
+                        "asset": "BTC-USD",
+                        "fold_index": 0,
+                        "side": "long",
+                        "entry_decision_timestamp_utc": "2026-01-01T00:00:00+00:00",
+                        "entry_timestamp_utc": "2026-01-02T00:00:00+00:00",
+                        "exit_timestamp_utc": "2026-01-03T00:00:00+00:00",
+                        "pnl": 0.03,
+                        "entry_trend_regime": "trending",
+                        "entry_volatility_regime": "low_vol",
+                        "entry_combined_regime": "trending|low_vol",
+                    },
+                    {
+                        "asset": "BTC-USD",
+                        "fold_index": 1,
+                        "side": "long",
+                        "entry_decision_timestamp_utc": "2026-01-03T00:00:00+00:00",
+                        "entry_timestamp_utc": "2026-01-04T00:00:00+00:00",
+                        "exit_timestamp_utc": "2026-01-05T00:00:00+00:00",
+                        "pnl": -0.01,
+                        "entry_trend_regime": "non_trending",
+                        "entry_volatility_regime": "low_vol",
+                        "entry_combined_regime": "non_trending|low_vol",
+                    },
+                ],
+            }
+        },
+    }
+
+
+def test_build_regime_diagnostics_payload_is_deterministic_and_reconciles_totals():
+    evaluations = [_evaluation()]
+
+    first = build_regime_diagnostics_payload(
+        evaluations=evaluations,
+        as_of_utc=AS_OF_UTC,
+        git_revision="deadbeef",
+        config_hash="abc123",
+        evaluation_config={"mode": "anchored", "selection_metric": "sharpe"},
+        regime_config={
+            "trend_lookback_bars": 3,
+            "volatility_lookback_bars": 3,
+            "volatility_baseline_lookback_bars": 3,
+            "trend_strength_threshold": 0.5,
+            "high_vol_ratio_threshold": 1.5,
+        },
+    )
+    second = build_regime_diagnostics_payload(
+        evaluations=evaluations,
+        as_of_utc=AS_OF_UTC,
+        git_revision="deadbeef",
+        config_hash="abc123",
+        evaluation_config={"mode": "anchored", "selection_metric": "sharpe"},
+        regime_config={
+            "trend_lookback_bars": 3,
+            "volatility_lookback_bars": 3,
+            "volatility_baseline_lookback_bars": 3,
+            "trend_strength_threshold": 0.5,
+            "high_vol_ratio_threshold": 1.5,
+        },
+    )
+
+    assert first == second
+    assert first["version"] == "v1"
+    assert first["lineage"]["config_hash"] == "abc123"
+    assert first["regime_definitions"]["trend_regime"]["labels"] == ["trending", "non_trending", "unknown"]
+
+    asset_entry = first["assets"][0]
+    assert asset_entry["oos_bar_count"] == 3
+    assert asset_entry["reconciliation"]["combined_coverage_matches_total"] is True
+
+    strategy_entry = first["strategies"][0]
+    assert strategy_entry["totals"]["oos_bar_count"] == 3
+    assert strategy_entry["totals"]["oos_trade_count"] == 2
+    assert strategy_entry["reconciliation"]["combined_coverage_matches_total"] is True
+    assert strategy_entry["reconciliation"]["combined_trade_counts_match_total"] is True
+    assert strategy_entry["reconciliation"]["combined_return_contribution_matches_total"] is True
+    high_vol_entry = next(
+        item for item in strategy_entry["regime_breakdown"]["combined"] if item["label"] == "trending|high_vol"
+    )
+    assert high_vol_entry["coverage_count"] == 1
+    assert high_vol_entry["return_metrics"]["sharpe"] is None
+    assert high_vol_entry["return_metrics"]["validity"]["sharpe_valid"] is False
+
+
+class _RegimeEngine:
+    def __init__(self, start_datum, eind_datum, evaluation_config=None, regime_config=None):
+        self.start = start_datum
+        self.end = eind_datum
+        self._provenance_events = []
+        self.last_evaluation_report = None
+
+    def grid_search(self, strategie_factory, param_grid, assets, interval="1d"):
+        self.last_evaluation_report = _evaluation()["evaluation_report"]
+        return {
+            "beste_params": {"fast": 10},
+            "win_rate": 0.6,
+            "sharpe": 0.5,
+            "deflated_sharpe": 0.4,
+            "max_drawdown": 0.1,
+            "trades_per_maand": 3.0,
+            "consistentie": 0.7,
+            "totaal_trades": 2,
+            "goedgekeurd": True,
+            "criteria_checks": {},
+            "reden": "",
+        }
+
+
+def test_run_research_writes_regime_sidecar_without_public_schema_changes(monkeypatch, tmp_path: Path):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "research").mkdir()
+    monkeypatch.setattr(run_research_module, "BacktestEngine", _RegimeEngine)
+    monkeypatch.setattr(
+        run_research_module,
+        "get_enabled_strategies",
+        lambda: [
+            {
+                "name": "trend_fast",
+                "family": "trend",
+                "hypothesis": "trend hypothesis",
+                "factory": lambda **params: None,
+                "params": {"fast": [10]},
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        run_research_module,
+        "build_research_universe",
+        lambda config: (
+            [type("Asset", (), {"symbol": "BTC-USD"})()],
+            ["1d"],
+            lambda interval: ("2026-01-01", "2026-02-01"),
+            AS_OF_UTC,
+            {"version": "v1", "resolved_count": 1},
+        ),
+    )
+    monkeypatch.setattr(
+        run_research_module,
+        "load_research_config",
+        lambda config_path="config/config.yaml": {"regime_diagnostics": {"trend_lookback_bars": 3}},
+    )
+    monkeypatch.setattr(run_research_module, "_git_revision", lambda: "deadbeef")
+    monkeypatch.setattr(run_research_module, "_write_provenance_sidecar", lambda **kwargs: None)
+    monkeypatch.setattr(run_research_module, "_write_walk_forward_sidecar", lambda **kwargs: None)
+    monkeypatch.setattr(run_research_module, "_write_statistical_defensibility_sidecar", lambda **kwargs: None)
+    monkeypatch.setattr(run_research_module, "_write_candidate_registry", lambda **kwargs: None)
+    monkeypatch.setattr(run_research_module, "_write_portfolio_aggregation_sidecar", lambda **kwargs: None)
+    monkeypatch.setattr(
+        run_research_module,
+        "write_results_to_csv",
+        lambda rows: write_results_to_csv(rows, path=tmp_path / "research" / "strategy_matrix.csv"),
+    )
+    monkeypatch.setattr(
+        run_research_module,
+        "write_latest_json",
+        lambda rows, as_of_utc: write_latest_json(
+            rows,
+            as_of_utc=as_of_utc,
+            path=tmp_path / "research" / "research_latest.json",
+        ),
+    )
+
+    run_research_module.run_research()
+
+    public_json = json.loads((tmp_path / "research" / "research_latest.json").read_text(encoding="utf-8"))
+    sidecar = json.loads((tmp_path / "research" / "regime_diagnostics_latest.v1.json").read_text(encoding="utf-8"))
+    with (tmp_path / "research" / "strategy_matrix.csv").open(encoding="utf-8", newline="") as handle:
+        csv_rows = list(csv.DictReader(handle))
+
+    assert list(public_json["results"][0].keys()) == ROW_SCHEMA
+    assert list(csv_rows[0].keys()) == ROW_SCHEMA
+    assert sidecar["version"] == "v1"
+    assert sidecar["strategies"][0]["strategy_name"] == "trend_fast"
+    assert sidecar["strategies"][0]["reconciliation"]["combined_trade_counts_match_total"] is True


### PR DESCRIPTION
Scope:

* adds diagnostics-only regime layer
* adds deterministic regime source-of-truth module
* adds additive regime diagnostics sidecar
* keeps research_latest.json unchanged
* keeps strategy_matrix.csv unchanged

What changed:

* added agent/backtesting/regime.py as the source of truth for deterministic regime feature computation and labeling
* extended the backtesting engine with minimal additive OOS diagnostic streams:

  * oos_bar_returns
  * oos_trade_events
* added research/regime_reporting.py
* added research/regime_diagnostics_latest.v1.json sidecar wiring in run_research.py
* added focused unit coverage for regime diagnostics and regime reporting

Non-goals:

* no regime gating
* no dynamic allocation
* no promotion-rule changes
* no dashboard logic
* no ML/HMM classifiers

Validation:

* targeted affected tests passed
* full pytest suite passed: 353 passed, 1 skipped

Known limitation:

* the current real research run is blocked by upstream data availability on the default intraday universe/date-range request
* exact current 1h/4h fetches for the default crypto universe returned empty datasets, causing zero evaluable OOS activity
* statistical defensibility aborts before regime_diagnostics_latest.v1.json can be written in that runtime path
* root cause appears upstream of regime diagnostics; no evidence that 03.01 introduced the degenerate run behavior
