### PR TITLE
fix: fail fast on degenerate research runs

### DIFF
--- a/agent/backtesting/engine.py
+++ b/agent/backtesting/engine.py
@@ -79,6 +79,30 @@ class AssetContext:
     folds: list[Fold]
 
 
+@dataclass(frozen=True)
+class AssetReadiness:
+    asset: str
+    interval: str
+    requested_start: str
+    requested_end: str
+    bar_count: int
+    fold_count: int
+    status: str
+    drop_reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "asset": self.asset,
+            "interval": self.interval,
+            "requested_start": self.requested_start,
+            "requested_end": self.requested_end,
+            "bar_count": self.bar_count,
+            "fold_count": self.fold_count,
+            "status": self.status,
+            "drop_reason": self.drop_reason,
+        }
+
+
 def normalize_evaluation_config(evaluation_config: Optional[dict[str, Any]]) -> dict[str, Any]:
     config = dict(evaluation_config or {})
     mode = config.get("mode", DEFAULT_EVALUATION_MODE)
@@ -252,6 +276,7 @@ class BacktestEngine:
         self.last_evaluation_report: Optional[dict[str, Any]] = None
         self._last_window_samples: dict[str, list[float]] = {}
         self._last_window_streams: dict[str, list[dict[str, Any]]] = {}
+        self._last_asset_readiness: list[dict[str, Any]] = []
 
     def run(self, strategie_func: Callable, assets: list, interval: str = "1d") -> dict:
         """Run fixed-parameter evaluation and return public OOS metrics only."""
@@ -364,17 +389,93 @@ class BacktestEngine:
         asset_contexts = _asset_contexts or self._load_asset_contexts(assets, interval)
         return self._evaluate_windows(strategie_func, asset_contexts, use_train=train)
 
+    def inspect_asset_readiness(self, assets: list[str], interval: str) -> list[dict[str, Any]]:
+        """Inspect per-asset readiness via the same load/fold path used in execution."""
+        _, diagnostics = self._load_asset_contexts_with_diagnostics(
+            assets,
+            interval,
+            capture_schedule_errors=True,
+        )
+        return [item.to_dict() for item in diagnostics]
+
     def _load_asset_contexts(self, assets: list[str], interval: str) -> list[AssetContext]:
+        asset_contexts, diagnostics = self._load_asset_contexts_with_diagnostics(
+            assets,
+            interval,
+            capture_schedule_errors=False,
+        )
+        self._last_asset_readiness = [item.to_dict() for item in diagnostics]
+        return asset_contexts
+
+    def _load_asset_contexts_with_diagnostics(
+        self,
+        assets: list[str],
+        interval: str,
+        *,
+        capture_schedule_errors: bool,
+    ) -> tuple[list[AssetContext], list[AssetReadiness]]:
         asset_contexts: list[AssetContext] = []
+        diagnostics: list[AssetReadiness] = []
         for asset in assets:
             df = self._laad_data(asset, interval)
-            if df is None or len(df) < MIN_DATA_BARS:
+            bar_count = 0 if df is None else int(len(df))
+            readiness = AssetReadiness(
+                asset=asset,
+                interval=interval,
+                requested_start=self.start,
+                requested_end=self.eind,
+                bar_count=bar_count,
+                fold_count=0,
+                status="dropped",
+                drop_reason=None,
+            )
+            if df is None:
+                diagnostics.append(
+                    AssetReadiness(
+                        **{**readiness.__dict__, "drop_reason": "data_unavailable"}
+                    )
+                )
                 log.warning(f"[BT] Te weinig data: {asset}")
                 continue
-            folds = build_evaluation_folds(len(df), self.evaluation_config)
+            if bar_count == 0:
+                diagnostics.append(
+                    AssetReadiness(
+                        **{**readiness.__dict__, "drop_reason": "empty_dataset"}
+                    )
+                )
+                log.warning(f"[BT] Te weinig data: {asset}")
+                continue
+            if bar_count < MIN_DATA_BARS:
+                diagnostics.append(
+                    AssetReadiness(
+                        **{**readiness.__dict__, "drop_reason": "insufficient_data_bars"}
+                    )
+                )
+                log.warning(f"[BT] Te weinig data: {asset}")
+                continue
+            try:
+                folds = build_evaluation_folds(bar_count, self.evaluation_config)
+            except EvaluationScheduleError:
+                diagnostics.append(
+                    AssetReadiness(
+                        **{**readiness.__dict__, "drop_reason": "evaluation_schedule_invalid"}
+                    )
+                )
+                if not capture_schedule_errors:
+                    raise
+                continue
             regime_frame = build_regime_frame(df, self.regime_config)
             asset_contexts.append(AssetContext(asset=asset, frame=df, regime_frame=regime_frame, folds=folds))
-        return asset_contexts
+            diagnostics.append(
+                AssetReadiness(
+                    **{
+                        **readiness.__dict__,
+                        "fold_count": len(folds),
+                        "status": "evaluable",
+                    }
+                )
+            )
+        return asset_contexts, diagnostics
 
     def _evaluate_windows(
         self,

--- a/research/empty_run_reporting.py
+++ b/research/empty_run_reporting.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from collections import Counter
+from datetime import datetime
+from typing import Any
+
+
+class DegenerateResearchRunError(RuntimeError):
+    """Raised when a research run has no evaluable support."""
+
+
+def primary_drop_reasons(pair_diagnostics: list[dict[str, Any]]) -> list[str]:
+    counts = Counter(
+        str(item["drop_reason"])
+        for item in pair_diagnostics
+        if item.get("status") == "dropped" and item.get("drop_reason")
+    )
+    return [
+        reason
+        for reason, _ in sorted(
+            counts.items(),
+            key=lambda item: (-item[1], item[0]),
+        )
+    ]
+
+
+def build_degenerate_run_message(
+    *,
+    failure_stage: str,
+    evaluable_pair_count: int,
+    selected_assets: list[str],
+    selected_intervals: list[str],
+    primary_drop_reasons_list: list[str],
+    evaluations_with_oos_daily_returns: int | None = None,
+) -> str:
+    parts = [
+        f"Degenerate research run at stage={failure_stage}",
+        f"evaluable_pair_count={evaluable_pair_count}",
+        f"selected_assets={selected_assets}",
+        f"selected_intervals={selected_intervals}",
+        f"primary_drop_reasons={primary_drop_reasons_list}",
+    ]
+    if evaluations_with_oos_daily_returns is not None:
+        parts.append(
+            f"evaluations_with_oos_daily_returns={evaluations_with_oos_daily_returns}"
+        )
+    parts.append(
+        "public_outputs_written=False existing_public_outputs_may_be_stale=True"
+    )
+    return " ".join(parts)
+
+
+def build_empty_run_diagnostics_payload(
+    *,
+    as_of_utc: datetime,
+    failure_stage: str,
+    selected_assets: list[str],
+    selected_intervals: list[str],
+    interval_ranges: dict[str, dict[str, str]],
+    pair_diagnostics: list[dict[str, Any]],
+    evaluations_count: int = 0,
+    evaluations_with_oos_daily_returns: int = 0,
+) -> dict[str, Any]:
+    sorted_pairs = sorted(
+        (
+            {
+                "asset": str(item["asset"]),
+                "interval": str(item["interval"]),
+                "requested_start": str(item["requested_start"]),
+                "requested_end": str(item["requested_end"]),
+                "bar_count": int(item["bar_count"]),
+                "fold_count": int(item["fold_count"]),
+                "status": str(item["status"]),
+                "drop_reason": item.get("drop_reason"),
+            }
+            for item in pair_diagnostics
+        ),
+        key=lambda item: (item["interval"], item["asset"]),
+    )
+    evaluable_pair_count = sum(
+        1 for item in sorted_pairs if item["status"] == "evaluable"
+    )
+    drop_reasons = primary_drop_reasons(sorted_pairs)
+    message = build_degenerate_run_message(
+        failure_stage=failure_stage,
+        evaluable_pair_count=evaluable_pair_count,
+        selected_assets=list(selected_assets),
+        selected_intervals=list(selected_intervals),
+        primary_drop_reasons_list=drop_reasons,
+        evaluations_with_oos_daily_returns=evaluations_with_oos_daily_returns,
+    )
+    return {
+        "version": "v1",
+        "generated_at_utc": as_of_utc.isoformat(),
+        "failure_stage": failure_stage,
+        "message": message,
+        "selected_assets": list(selected_assets),
+        "selected_intervals": list(selected_intervals),
+        "interval_ranges": {
+            interval: {
+                "start": str(bounds["start"]),
+                "end": str(bounds["end"]),
+            }
+            for interval, bounds in interval_ranges.items()
+        },
+        "summary": {
+            "pair_count": len(sorted_pairs),
+            "evaluable_pair_count": evaluable_pair_count,
+            "dropped_pair_count": len(sorted_pairs) - evaluable_pair_count,
+            "evaluations_count": int(evaluations_count),
+            "evaluations_with_oos_daily_returns": int(
+                evaluations_with_oos_daily_returns
+            ),
+            "primary_drop_reasons": drop_reasons,
+        },
+        "pairs": sorted_pairs,
+        "public_output_status": {
+            "public_outputs_written": False,
+            "existing_public_outputs_may_be_stale": True,
+            "public_paths": [
+                "research/research_latest.json",
+                "research/strategy_matrix.csv",
+            ],
+        },
+    }

--- a/research/run_research.py
+++ b/research/run_research.py
@@ -20,6 +20,10 @@ from agent.backtesting.engine import (
     FoldLeakageError,
     normalize_evaluation_config,
 )
+from research.empty_run_reporting import (
+    DegenerateResearchRunError,
+    build_empty_run_diagnostics_payload,
+)
 from research.registry import get_enabled_strategies
 from research.results import make_result_row, write_latest_json, write_results_to_csv
 from research.portfolio_reporting import build_portfolio_aggregation_payload
@@ -34,6 +38,7 @@ CANDIDATE_REGISTRY_PATH = Path("research/candidate_registry_latest.v1.json")
 UNIVERSE_SNAPSHOT_PATH = Path("research/universe_snapshot_latest.v1.json")
 PORTFOLIO_AGGREGATION_PATH = Path("research/portfolio_aggregation_latest.v1.json")
 REGIME_DIAGNOSTICS_PATH = Path("research/regime_diagnostics_latest.v1.json")
+EMPTY_RUN_DIAGNOSTICS_PATH = Path("research/empty_run_diagnostics_latest.v1.json")
 
 
 def load_research_config(config_path="config/config.yaml"):
@@ -312,6 +317,88 @@ def _build_engine(
         )
 
 
+def _inspect_engine_readiness(engine, assets: list, interval: str) -> list[dict]:
+    asset_symbols = [asset.symbol if hasattr(asset, "symbol") else str(asset) for asset in assets]
+    if hasattr(engine, "inspect_asset_readiness"):
+        return list(engine.inspect_asset_readiness(asset_symbols, interval))
+    requested_start = getattr(engine, "start", "")
+    requested_end = getattr(engine, "eind", getattr(engine, "end", ""))
+    return [
+        {
+            "asset": asset,
+            "interval": interval,
+            "requested_start": requested_start,
+            "requested_end": requested_end,
+            "bar_count": 0,
+            "fold_count": 1,
+            "status": "evaluable",
+            "drop_reason": None,
+        }
+        for asset in asset_symbols
+    ]
+
+
+def _count_evaluable_oos_daily_return_evaluations(evaluations: list[dict]) -> int:
+    count = 0
+    for evaluation in evaluations:
+        report = evaluation.get("evaluation_report") or {}
+        samples = report.get("evaluation_samples") or {}
+        daily_returns = samples.get("daily_returns")
+        if isinstance(daily_returns, list) and daily_returns:
+            count += 1
+    return count
+
+
+def _write_empty_run_diagnostics_sidecar(
+    *,
+    as_of_utc,
+    failure_stage: str,
+    assets: list,
+    intervals: list[str],
+    interval_ranges: dict[str, dict[str, str]],
+    pair_diagnostics: list[dict],
+    evaluations_count: int = 0,
+    evaluations_with_oos_daily_returns: int = 0,
+    path: Path = EMPTY_RUN_DIAGNOSTICS_PATH,
+) -> dict:
+    payload = build_empty_run_diagnostics_payload(
+        as_of_utc=as_of_utc,
+        failure_stage=failure_stage,
+        selected_assets=[asset.symbol if hasattr(asset, "symbol") else str(asset) for asset in assets],
+        selected_intervals=list(intervals),
+        interval_ranges=interval_ranges,
+        pair_diagnostics=pair_diagnostics,
+        evaluations_count=evaluations_count,
+        evaluations_with_oos_daily_returns=evaluations_with_oos_daily_returns,
+    )
+    _write_json_atomic(path, payload)
+    return payload
+
+
+def _raise_degenerate_run(
+    *,
+    as_of_utc,
+    failure_stage: str,
+    assets: list,
+    intervals: list[str],
+    interval_ranges: dict[str, dict[str, str]],
+    pair_diagnostics: list[dict],
+    evaluations_count: int = 0,
+    evaluations_with_oos_daily_returns: int = 0,
+) -> None:
+    payload = _write_empty_run_diagnostics_sidecar(
+        as_of_utc=as_of_utc,
+        failure_stage=failure_stage,
+        assets=assets,
+        intervals=intervals,
+        interval_ranges=interval_ranges,
+        pair_diagnostics=pair_diagnostics,
+        evaluations_count=evaluations_count,
+        evaluations_with_oos_daily_returns=evaluations_with_oos_daily_returns,
+    )
+    raise DegenerateResearchRunError(payload["message"])
+
+
 def run_research():
     rows = []
     evaluations = []
@@ -328,6 +415,31 @@ def run_research():
     for interval in intervals:
         start_datum, eind_datum = get_date_range(interval)
         interval_ranges[interval] = {"start": start_datum, "end": eind_datum}
+
+    pair_diagnostics: list[dict] = []
+    for interval in intervals:
+        start_datum = interval_ranges[interval]["start"]
+        eind_datum = interval_ranges[interval]["end"]
+        engine = _build_engine(
+            start_datum=start_datum,
+            eind_datum=eind_datum,
+            evaluation_config=evaluation_config,
+            regime_config=research_config.get("regime_diagnostics"),
+        )
+        pair_diagnostics.extend(_inspect_engine_readiness(engine, assets, interval))
+
+    evaluable_pair_count = sum(
+        1 for item in pair_diagnostics if item.get("status") == "evaluable"
+    )
+    if evaluable_pair_count == 0:
+        _raise_degenerate_run(
+            as_of_utc=as_of_utc,
+            failure_stage="preflight_no_evaluable_pairs",
+            assets=assets,
+            intervals=intervals,
+            interval_ranges=interval_ranges,
+            pair_diagnostics=pair_diagnostics,
+        )
 
     for strategy in strategies:
         for interval in intervals:
@@ -391,6 +503,20 @@ def run_research():
 
                 provenance_events.extend(getattr(engine, "_provenance_events", []))
                 rows.append(row)
+    evaluable_oos_daily_return_count = _count_evaluable_oos_daily_return_evaluations(
+        evaluations
+    )
+    if evaluations and evaluable_oos_daily_return_count == 0:
+        _raise_degenerate_run(
+            as_of_utc=as_of_utc,
+            failure_stage="postrun_no_oos_daily_returns",
+            assets=assets,
+            intervals=intervals,
+            interval_ranges=interval_ranges,
+            pair_diagnostics=pair_diagnostics,
+            evaluations_count=len(evaluations),
+            evaluations_with_oos_daily_returns=evaluable_oos_daily_return_count,
+        )
 
     write_results_to_csv(rows)
     write_latest_json(rows, as_of_utc=as_of_utc)

--- a/tests/unit/test_empty_run_reporting.py
+++ b/tests/unit/test_empty_run_reporting.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pandas as pd
+
+from agent.backtesting.engine import BacktestEngine
+from research.empty_run_reporting import (
+    build_degenerate_run_message,
+    build_empty_run_diagnostics_payload,
+)
+
+
+AS_OF_UTC = datetime(2026, 4, 13, 12, 0, 0, tzinfo=UTC)
+
+
+def _frame(bar_count: int) -> pd.DataFrame:
+    index = pd.date_range("2026-01-01", periods=bar_count, freq="1h")
+    values = [100.0 + float(i) for i in range(bar_count)]
+    return pd.DataFrame(
+        {
+            "open": values,
+            "high": values,
+            "low": values,
+            "close": values,
+            "volume": [1.0] * bar_count,
+        },
+        index=index,
+    )
+
+
+def test_build_empty_run_payload_is_deterministic_and_explicit():
+    pair_diagnostics = [
+        {
+            "asset": "ETH-USD",
+            "interval": "4h",
+            "requested_start": "2024-05-13",
+            "requested_end": "2026-04-13",
+            "bar_count": 0,
+            "fold_count": 0,
+            "status": "dropped",
+            "drop_reason": "empty_dataset",
+        },
+        {
+            "asset": "BTC-USD",
+            "interval": "1h",
+            "requested_start": "2024-05-13",
+            "requested_end": "2026-04-13",
+            "bar_count": 0,
+            "fold_count": 0,
+            "status": "dropped",
+            "drop_reason": "empty_dataset",
+        },
+    ]
+
+    first = build_empty_run_diagnostics_payload(
+        as_of_utc=AS_OF_UTC,
+        failure_stage="preflight_no_evaluable_pairs",
+        selected_assets=["BTC-USD", "ETH-USD"],
+        selected_intervals=["1h", "4h"],
+        interval_ranges={
+            "1h": {"start": "2024-05-13", "end": "2026-04-13"},
+            "4h": {"start": "2024-05-13", "end": "2026-04-13"},
+        },
+        pair_diagnostics=pair_diagnostics,
+    )
+    second = build_empty_run_diagnostics_payload(
+        as_of_utc=AS_OF_UTC,
+        failure_stage="preflight_no_evaluable_pairs",
+        selected_assets=["BTC-USD", "ETH-USD"],
+        selected_intervals=["1h", "4h"],
+        interval_ranges={
+            "1h": {"start": "2024-05-13", "end": "2026-04-13"},
+            "4h": {"start": "2024-05-13", "end": "2026-04-13"},
+        },
+        pair_diagnostics=pair_diagnostics,
+    )
+
+    assert first == second
+    assert first["version"] == "v1"
+    assert first["summary"]["evaluable_pair_count"] == 0
+    assert first["summary"]["primary_drop_reasons"] == ["empty_dataset"]
+    assert first["pairs"][0]["asset"] == "BTC-USD"
+    assert "stage=preflight_no_evaluable_pairs" in first["message"]
+    assert "existing_public_outputs_may_be_stale=True" in first["message"]
+
+
+def test_engine_inspect_asset_readiness_reuses_load_and_fold_logic(monkeypatch):
+    engine = BacktestEngine(
+        start_datum="2026-01-01",
+        eind_datum="2026-04-01",
+        evaluation_config=None,
+    )
+    frames = {
+        "BTC-USD": pd.DataFrame(),
+        "ETH-USD": _frame(50),
+        "SOL-USD": _frame(150),
+        "BNB-USD": _frame(700),
+    }
+
+    monkeypatch.setattr(engine, "_laad_data", lambda asset, interval: frames[asset])
+
+    readiness = engine.inspect_asset_readiness(
+        ["BTC-USD", "ETH-USD", "SOL-USD", "BNB-USD"],
+        "1h",
+    )
+
+    assert readiness == [
+        {
+            "asset": "BTC-USD",
+            "interval": "1h",
+            "requested_start": "2026-01-01",
+            "requested_end": "2026-04-01",
+            "bar_count": 0,
+            "fold_count": 0,
+            "status": "dropped",
+            "drop_reason": "empty_dataset",
+        },
+        {
+            "asset": "ETH-USD",
+            "interval": "1h",
+            "requested_start": "2026-01-01",
+            "requested_end": "2026-04-01",
+            "bar_count": 50,
+            "fold_count": 0,
+            "status": "dropped",
+            "drop_reason": "insufficient_data_bars",
+        },
+        {
+            "asset": "SOL-USD",
+            "interval": "1h",
+            "requested_start": "2026-01-01",
+            "requested_end": "2026-04-01",
+            "bar_count": 150,
+            "fold_count": 0,
+            "status": "dropped",
+            "drop_reason": "evaluation_schedule_invalid",
+        },
+        {
+            "asset": "BNB-USD",
+            "interval": "1h",
+            "requested_start": "2026-01-01",
+            "requested_end": "2026-04-01",
+            "bar_count": 700,
+            "fold_count": 2,
+            "status": "evaluable",
+            "drop_reason": None,
+        },
+    ]
+
+
+def test_build_degenerate_run_message_includes_required_context():
+    message = build_degenerate_run_message(
+        failure_stage="postrun_no_oos_daily_returns",
+        evaluable_pair_count=2,
+        selected_assets=["BTC-USD", "ETH-USD"],
+        selected_intervals=["1h", "4h"],
+        primary_drop_reasons_list=["empty_dataset"],
+        evaluations_with_oos_daily_returns=0,
+    )
+
+    assert "stage=postrun_no_oos_daily_returns" in message
+    assert "evaluable_pair_count=2" in message
+    assert "selected_assets=['BTC-USD', 'ETH-USD']" in message
+    assert "selected_intervals=['1h', '4h']" in message
+    assert "primary_drop_reasons=['empty_dataset']" in message
+    assert "evaluations_with_oos_daily_returns=0" in message

--- a/tests/unit/test_research_regime_reporting.py
+++ b/tests/unit/test_research_regime_reporting.py
@@ -51,6 +51,11 @@ def _evaluation() -> dict:
             "oos_summary": {},
             "folds": [],
             "leakage_checks_ok": True,
+            "evaluation_samples": {
+                "daily_returns": [0.01, -0.02, 0.0],
+                "trade_pnls": [0.03, -0.01],
+                "monthly_returns": [-0.01],
+            },
             "evaluation_streams": {
                 "oos_bar_returns": [
                     {
@@ -107,7 +112,16 @@ def _evaluation() -> dict:
                         "entry_combined_regime": "non_trending|low_vol",
                     },
                 ],
-            }
+            },
+            "sample_statistics": {
+                "daily_returns": {
+                    "count": 3,
+                    "mean": -0.0033333333333333335,
+                    "std": 0.012472191289246473,
+                    "skew": 0.0,
+                    "kurt": 3.0,
+                }
+            },
         },
     }
 

--- a/tests/unit/test_run_research_empty_run_handling.py
+++ b/tests/unit/test_run_research_empty_run_handling.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from research import run_research as run_research_module
+from research.empty_run_reporting import DegenerateResearchRunError
+
+
+AS_OF_UTC = datetime(2026, 4, 13, 12, 0, 0, tzinfo=UTC)
+
+
+def _load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _patch_common_runner(monkeypatch, tmp_path: Path, engine_cls) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "research").mkdir()
+    monkeypatch.setattr(run_research_module, "BacktestEngine", engine_cls)
+    monkeypatch.setattr(
+        run_research_module,
+        "get_enabled_strategies",
+        lambda: [
+            {
+                "name": "fake_strategy",
+                "family": "trend",
+                "hypothesis": "Fixture hypothesis",
+                "factory": lambda **params: None,
+                "params": {"periode": [14]},
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        run_research_module,
+        "build_research_universe",
+        lambda config: (
+            [SimpleNamespace(symbol="BTC-USD")],
+            ["1h"],
+            lambda interval: ("2024-05-13", "2026-04-13"),
+            AS_OF_UTC,
+            {"version": "v1", "resolved_count": 1},
+        ),
+    )
+    monkeypatch.setattr(
+        run_research_module,
+        "load_research_config",
+        lambda config_path="config/config.yaml": {},
+    )
+    monkeypatch.setattr(run_research_module, "_git_revision", lambda: "deadbeef")
+
+
+class _PreflightDegenerateEngine:
+    def __init__(self, start_datum, eind_datum, evaluation_config=None, regime_config=None):
+        self.start = start_datum
+        self.eind = eind_datum
+        self._provenance_events = []
+        self.last_evaluation_report = None
+
+    def inspect_asset_readiness(self, assets, interval):
+        return [
+            {
+                "asset": asset,
+                "interval": interval,
+                "requested_start": self.start,
+                "requested_end": self.eind,
+                "bar_count": 0,
+                "fold_count": 0,
+                "status": "dropped",
+                "drop_reason": "empty_dataset",
+            }
+            for asset in assets
+        ]
+
+    def grid_search(self, strategie_factory, param_grid, assets, interval="1d"):
+        raise AssertionError("grid_search should not run when preflight has zero evaluable pairs")
+
+
+class _PostRunDegenerateEngine:
+    def __init__(self, start_datum, eind_datum, evaluation_config=None, regime_config=None):
+        self.start = start_datum
+        self.eind = eind_datum
+        self._provenance_events = []
+        self.last_evaluation_report = None
+
+    def inspect_asset_readiness(self, assets, interval):
+        return [
+            {
+                "asset": asset,
+                "interval": interval,
+                "requested_start": self.start,
+                "requested_end": self.eind,
+                "bar_count": 700,
+                "fold_count": 2,
+                "status": "evaluable",
+                "drop_reason": None,
+            }
+            for asset in assets
+        ]
+
+    def grid_search(self, strategie_factory, param_grid, assets, interval="1d"):
+        self.last_evaluation_report = {
+            "selection_metric": "sharpe",
+            "is_summary": {
+                "win_rate": 0.0,
+                "sharpe": 0.0,
+                "deflated_sharpe": 0.0,
+                "max_drawdown": 0.0,
+                "trades_per_maand": 0.0,
+                "consistentie": 0.0,
+                "totaal_trades": 0,
+                "goedgekeurd": False,
+                "criteria_checks": {},
+            },
+            "oos_summary": {
+                "win_rate": 0.0,
+                "sharpe": 0.0,
+                "deflated_sharpe": 0.0,
+                "max_drawdown": 0.0,
+                "trades_per_maand": 0.0,
+                "consistentie": 0.0,
+                "totaal_trades": 0,
+                "goedgekeurd": False,
+                "criteria_checks": {},
+            },
+            "folds": [{"train": [0, 499], "test": [500, 599], "leakage_ok": True}],
+            "leakage_checks_ok": True,
+            "evaluation_samples": {
+                "daily_returns": [],
+                "trade_pnls": [],
+                "monthly_returns": [],
+            },
+            "evaluation_streams": {
+                "oos_daily_returns": [],
+                "oos_bar_returns": [],
+                "oos_trade_events": [],
+            },
+            "sample_statistics": {
+                "daily_returns": {"count": 0, "mean": 0.0, "std": 0.0, "skew": 0.0, "kurt": 0.0},
+                "trade_pnls": {"count": 0, "mean": 0.0, "std": 0.0, "skew": 0.0, "kurt": 0.0},
+                "monthly_returns": {"count": 0, "mean": 0.0, "std": 0.0, "skew": 0.0, "kurt": 0.0},
+            },
+        }
+        return {
+            "beste_params": {"periode": 14},
+            "win_rate": 0.0,
+            "sharpe": 0.0,
+            "deflated_sharpe": 0.0,
+            "max_drawdown": 0.0,
+            "trades_per_maand": 0.0,
+            "consistentie": 0.0,
+            "totaal_trades": 0,
+            "goedgekeurd": False,
+            "criteria_checks": {},
+            "reden": "Te weinig trades: 0",
+        }
+
+
+def test_run_research_fails_fast_before_public_outputs_when_preflight_is_empty(monkeypatch, tmp_path):
+    _patch_common_runner(monkeypatch, tmp_path, _PreflightDegenerateEngine)
+
+    with pytest.raises(DegenerateResearchRunError, match="preflight_no_evaluable_pairs"):
+        run_research_module.run_research()
+
+    diagnostics = _load_json(tmp_path / "research" / "empty_run_diagnostics_latest.v1.json")
+    assert diagnostics["failure_stage"] == "preflight_no_evaluable_pairs"
+    assert diagnostics["summary"]["evaluable_pair_count"] == 0
+    assert diagnostics["summary"]["primary_drop_reasons"] == ["empty_dataset"]
+    assert not (tmp_path / "research" / "research_latest.json").exists()
+    assert not (tmp_path / "research" / "strategy_matrix.csv").exists()
+
+
+def test_run_research_fails_fast_before_public_outputs_when_oos_samples_are_empty(monkeypatch, tmp_path):
+    _patch_common_runner(monkeypatch, tmp_path, _PostRunDegenerateEngine)
+
+    with pytest.raises(DegenerateResearchRunError, match="postrun_no_oos_daily_returns"):
+        run_research_module.run_research()
+
+    diagnostics = _load_json(tmp_path / "research" / "empty_run_diagnostics_latest.v1.json")
+    assert diagnostics["failure_stage"] == "postrun_no_oos_daily_returns"
+    assert diagnostics["summary"]["evaluable_pair_count"] == 1
+    assert diagnostics["summary"]["evaluations_count"] == 1
+    assert diagnostics["summary"]["evaluations_with_oos_daily_returns"] == 0
+    assert not (tmp_path / "research" / "research_latest.json").exists()
+    assert not (tmp_path / "research" / "strategy_matrix.csv").exists()


### PR DESCRIPTION
Scope:

* adds fail-fast handling for degenerate research runs
* adds additive empty-run diagnostics sidecar
* prevents misleading public success outputs for empty runs
* keeps healthy-run public schemas unchanged

What changed:

* added shared asset-readiness diagnostics in the backtesting engine
* added research/empty_run_reporting.py with DegenerateResearchRunError and deterministic failure payload assembly
* added runner preflight failure when no evaluable asset/interval pairs exist
* added post-run failure when evaluations exist but all OOS daily-return samples are empty
* writes research/empty_run_diagnostics_latest.v1.json before raising
* does not write research_latest.json or strategy_matrix.csv for degenerate runs
* tightened one existing regime-reporting fixture to represent a truly healthy run

Non-goals:

* no strategy changes
* no regime logic changes
* no promotion changes
* no dashboard logic
* no retry or cache-policy redesign

Validation:

* full pytest suite passed: 358 passed, 1 skipped

Operational effect:

* degenerate runs now fail explicitly and transparently
* empty-run diagnostics sidecar becomes the primary artifact for failed runs
* existing public outputs may remain but are explicitly marked as stale in the failure context
