### PR TITLE
feat: add research progress observability

### DIFF
--- a/research/observability.py
+++ b/research/observability.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import json
+import os
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Callable
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _run_id(started_at_utc: datetime) -> str:
+    return started_at_utc.astimezone(UTC).strftime("%Y%m%dT%H%M%S%fZ")
+
+
+class ProgressTracker:
+    """Lightweight progress sidecar + sparse console logging for research runs."""
+
+    def __init__(
+        self,
+        *,
+        path: Path,
+        started_at_utc: datetime | None = None,
+        now_source: Callable[[], datetime] | None = None,
+        monotonic_source: Callable[[], float] | None = None,
+        log_fn: Callable[[str], None] | None = None,
+    ) -> None:
+        self.path = path
+        self._now_source = now_source or _utc_now
+        self._monotonic_source = monotonic_source or time.monotonic
+        self._log_fn = log_fn or print
+        self.started_at_utc = (started_at_utc or self._now_source()).astimezone(UTC)
+        self.run_id = _run_id(self.started_at_utc)
+        self.status = "running"
+        self.current_stage = "starting"
+        self.current_item: dict[str, str | None] = {
+            "strategy": None,
+            "asset": None,
+            "interval": None,
+        }
+        self.completed = 0
+        self.total = 0
+        self.failure: dict[str, str | None] | None = None
+        self._stage_started_at_utc = self.started_at_utc
+        self._stage_started_monotonic = self._monotonic_source()
+        self._run_started_monotonic = self._stage_started_monotonic
+        self._last_updated_at_utc = self.started_at_utc
+        self._last_emitted_completed = -1
+        self._write_sidecar()
+
+    def start_stage(self, stage: str, *, total: int | None = None, **log_fields: Any) -> None:
+        self.current_stage = stage
+        self._stage_started_at_utc = self._now_source().astimezone(UTC)
+        self._stage_started_monotonic = self._monotonic_source()
+        if total is not None:
+            self.total = int(total)
+        self._last_updated_at_utc = self._stage_started_at_utc
+        self._write_sidecar()
+        self._log("stage", stage=stage, status="started", **log_fields)
+
+    def mark_stage_completed(self, **log_fields: Any) -> None:
+        self._last_updated_at_utc = self._now_source().astimezone(UTC)
+        self._write_sidecar()
+        self._log("stage", stage=self.current_stage, status="completed", **log_fields)
+
+    def begin_item(self, *, strategy: str, asset: str, interval: str) -> None:
+        self.current_item = {
+            "strategy": strategy,
+            "asset": asset,
+            "interval": interval,
+        }
+
+    def advance(self, *, completed: int | None = None, total: int | None = None) -> None:
+        if completed is not None:
+            self.completed = int(completed)
+        else:
+            self.completed += 1
+        if total is not None:
+            self.total = int(total)
+        if not self._should_emit_progress():
+            return
+        self._last_updated_at_utc = self._now_source().astimezone(UTC)
+        self._write_sidecar()
+        self._last_emitted_completed = self.completed
+        self._log(
+            "progress",
+            stage=self.current_stage,
+            progress=f"{self.completed}/{self.total}",
+            percent=self._percent(),
+            elapsed_s=self._elapsed_seconds(),
+            eta_s=self._eta_seconds(),
+            current=self._current_item_label(),
+        )
+
+    def complete(self) -> None:
+        self.status = "completed"
+        self.current_stage = "completed"
+        self.completed = self.total
+        self.current_item = {
+            "strategy": None,
+            "asset": None,
+            "interval": None,
+        }
+        self._last_updated_at_utc = self._now_source().astimezone(UTC)
+        self._write_sidecar()
+        self._log("stage", stage="completed", status="completed", elapsed_s=self._elapsed_seconds())
+
+    def fail(self, error: Exception, *, failure_stage: str | None = None) -> None:
+        self.status = "failed"
+        self.current_stage = "failed"
+        self.failure = {
+            "failure_stage": failure_stage or self.current_stage,
+            "error_type": type(error).__name__,
+            "error_message": str(error),
+        }
+        self._last_updated_at_utc = self._now_source().astimezone(UTC)
+        self._write_sidecar()
+        self._log(
+            "stage",
+            stage="failed",
+            status="failed",
+            failure_stage=self.failure["failure_stage"],
+            error_type=self.failure["error_type"],
+        )
+
+    def _should_emit_progress(self) -> bool:
+        if self.total <= 0:
+            return False
+        if self.completed == self._last_emitted_completed:
+            return False
+        if self.total <= 10:
+            return True
+        if self.completed in {1, self.total}:
+            return True
+        stride = max(1, (self.total + 9) // 10)
+        return self.completed % stride == 0
+
+    def _percent(self) -> float:
+        if self.total <= 0:
+            return 0.0
+        return round((self.completed / self.total) * 100.0, 2)
+
+    def _elapsed_seconds(self) -> int:
+        return max(0, int(round(self._monotonic_source() - self._run_started_monotonic)))
+
+    def _stage_elapsed_seconds(self) -> int:
+        return max(0, int(round(self._monotonic_source() - self._stage_started_monotonic)))
+
+    def _eta_seconds(self) -> int | None:
+        if self.status != "running" or self.current_stage != "evaluation":
+            return None
+        if self.completed <= 0 or self.total <= self.completed:
+            return 0 if self.total > 0 and self.completed >= self.total else None
+        pace = self._elapsed_seconds() / self.completed
+        return max(0, int(round(pace * (self.total - self.completed))))
+
+    def _current_item_label(self) -> str | None:
+        strategy = self.current_item["strategy"]
+        asset = self.current_item["asset"]
+        interval = self.current_item["interval"]
+        if not strategy or not asset or not interval:
+            return None
+        return f"{strategy} {asset} {interval}"
+
+    def _payload(self) -> dict[str, Any]:
+        return {
+            "version": "v1",
+            "status": self.status,
+            "run_id": self.run_id,
+            "current_stage": self.current_stage,
+            "started_at_utc": self.started_at_utc.isoformat(),
+            "last_updated_at_utc": self._last_updated_at_utc.isoformat(),
+            "progress": {
+                "completed": int(self.completed),
+                "total": int(self.total),
+                "percent": self._percent(),
+            },
+            "current_item": dict(self.current_item),
+            "timing": {
+                "elapsed_seconds": self._elapsed_seconds(),
+                "stage_elapsed_seconds": self._stage_elapsed_seconds(),
+                "eta_seconds": self._eta_seconds(),
+            },
+            "failure": self.failure,
+        }
+
+    def _write_sidecar(self) -> None:
+        payload = self._payload()
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = self.path.with_suffix(f"{self.path.suffix}.tmp")
+        with tmp_path.open("w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2)
+        try:
+            os.replace(tmp_path, self.path)
+        except PermissionError:
+            with self.path.open("w", encoding="utf-8") as handle:
+                json.dump(payload, handle, indent=2)
+            if tmp_path.exists():
+                tmp_path.unlink()
+
+    def _log(self, event: str, **fields: Any) -> None:
+        parts = [f"[research] {event}"]
+        for key, value in fields.items():
+            if value is None:
+                continue
+            parts.append(f"{key}={value}")
+        self._log_fn(" ".join(parts))

--- a/research/run_research.py
+++ b/research/run_research.py
@@ -8,7 +8,7 @@ import hashlib
 import json
 import os
 import subprocess
-from datetime import timezone
+from datetime import UTC, datetime, timezone
 from pathlib import Path
 
 import yaml
@@ -24,6 +24,7 @@ from research.empty_run_reporting import (
     DegenerateResearchRunError,
     build_empty_run_diagnostics_payload,
 )
+from research.observability import ProgressTracker
 from research.registry import get_enabled_strategies
 from research.results import make_result_row, write_latest_json, write_results_to_csv
 from research.portfolio_reporting import build_portfolio_aggregation_payload
@@ -39,6 +40,7 @@ UNIVERSE_SNAPSHOT_PATH = Path("research/universe_snapshot_latest.v1.json")
 PORTFOLIO_AGGREGATION_PATH = Path("research/portfolio_aggregation_latest.v1.json")
 REGIME_DIAGNOSTICS_PATH = Path("research/regime_diagnostics_latest.v1.json")
 EMPTY_RUN_DIAGNOSTICS_PATH = Path("research/empty_run_diagnostics_latest.v1.json")
+RUN_PROGRESS_PATH = Path("research/run_progress_latest.v1.json")
 
 
 def load_research_config(config_path="config/config.yaml"):
@@ -400,177 +402,201 @@ def _raise_degenerate_run(
 
 
 def run_research():
+    tracker = ProgressTracker(
+        path=RUN_PROGRESS_PATH,
+        started_at_utc=datetime.now(UTC),
+    )
     rows = []
     evaluations = []
     walk_forward_reports = []
     provenance_events = []
-    research_config = load_research_config()
-    regime_count, regime_count_source = regime_count_settings(research_config)
-    evaluation_config = normalize_evaluation_config(research_config.get("evaluation"))
-    assets, intervals, get_date_range, as_of_utc, universe_snapshot = build_research_universe(research_config)
-    _write_universe_snapshot_sidecar(universe_snapshot)
-    interval_ranges = {}
-    strategies = get_enabled_strategies()
+    try:
+        research_config = load_research_config()
+        regime_count, regime_count_source = regime_count_settings(research_config)
+        evaluation_config = normalize_evaluation_config(research_config.get("evaluation"))
+        assets, intervals, get_date_range, as_of_utc, universe_snapshot = build_research_universe(research_config)
+        _write_universe_snapshot_sidecar(universe_snapshot)
+        interval_ranges = {}
+        strategies = get_enabled_strategies()
+        total_items = len(strategies) * len(intervals) * len(assets)
 
-    for interval in intervals:
-        start_datum, eind_datum = get_date_range(interval)
-        interval_ranges[interval] = {"start": start_datum, "end": eind_datum}
-
-    pair_diagnostics: list[dict] = []
-    for interval in intervals:
-        start_datum = interval_ranges[interval]["start"]
-        eind_datum = interval_ranges[interval]["end"]
-        engine = _build_engine(
-            start_datum=start_datum,
-            eind_datum=eind_datum,
-            evaluation_config=evaluation_config,
-            regime_config=research_config.get("regime_diagnostics"),
-        )
-        pair_diagnostics.extend(_inspect_engine_readiness(engine, assets, interval))
-
-    evaluable_pair_count = sum(
-        1 for item in pair_diagnostics if item.get("status") == "evaluable"
-    )
-    if evaluable_pair_count == 0:
-        _raise_degenerate_run(
-            as_of_utc=as_of_utc,
-            failure_stage="preflight_no_evaluable_pairs",
-            assets=assets,
-            intervals=intervals,
-            interval_ranges=interval_ranges,
-            pair_diagnostics=pair_diagnostics,
-        )
-
-    for strategy in strategies:
+        tracker.start_stage("preflight", total=total_items)
         for interval in intervals:
-            for asset in assets:
-                start_datum = interval_ranges[interval]["start"]
-                eind_datum = interval_ranges[interval]["end"]
+            start_datum, eind_datum = get_date_range(interval)
+            interval_ranges[interval] = {"start": start_datum, "end": eind_datum}
 
-                engine = _build_engine(
-                    start_datum=start_datum,
-                    eind_datum=eind_datum,
-                    evaluation_config=evaluation_config,
-                    regime_config=research_config.get("regime_diagnostics"),
-                )
-                try:
-                    metrics = engine.grid_search(
-                        strategie_factory=strategy["factory"],
-                        param_grid=strategy["params"],
-                        assets=[asset.symbol],
-                        interval=interval,
-                    )
-                    params_used = metrics.get("beste_params", {})
-                    row = make_result_row(
-                        strategy=strategy,
+        pair_diagnostics: list[dict] = []
+        for interval in intervals:
+            start_datum = interval_ranges[interval]["start"]
+            eind_datum = interval_ranges[interval]["end"]
+            engine = _build_engine(
+                start_datum=start_datum,
+                eind_datum=eind_datum,
+                evaluation_config=evaluation_config,
+                regime_config=research_config.get("regime_diagnostics"),
+            )
+            pair_diagnostics.extend(_inspect_engine_readiness(engine, assets, interval))
+
+        evaluable_pair_count = sum(
+            1 for item in pair_diagnostics if item.get("status") == "evaluable"
+        )
+        tracker.mark_stage_completed(evaluable_pairs=evaluable_pair_count)
+        if evaluable_pair_count == 0:
+            _raise_degenerate_run(
+                as_of_utc=as_of_utc,
+                failure_stage="preflight_no_evaluable_pairs",
+                assets=assets,
+                intervals=intervals,
+                interval_ranges=interval_ranges,
+                pair_diagnostics=pair_diagnostics,
+            )
+
+        tracker.start_stage("evaluation", total=total_items, total_items=total_items)
+        completed_items = 0
+        for strategy in strategies:
+            for interval in intervals:
+                for asset in assets:
+                    tracker.begin_item(
+                        strategy=strategy["name"],
                         asset=asset.symbol,
                         interval=interval,
-                        params=params_used,
-                        as_of_utc=as_of_utc,
-                        metrics=metrics,
                     )
-                    evaluation_report = getattr(engine, "last_evaluation_report", None)
-                    if evaluation_report is not None:
-                        walk_forward_reports.append(
-                            _sidecar_strategy_entry(
-                                strategy=strategy,
-                                asset=asset.symbol,
-                                interval=interval,
-                                report=evaluation_report,
+                    start_datum = interval_ranges[interval]["start"]
+                    eind_datum = interval_ranges[interval]["end"]
+
+                    engine = _build_engine(
+                        start_datum=start_datum,
+                        eind_datum=eind_datum,
+                        evaluation_config=evaluation_config,
+                        regime_config=research_config.get("regime_diagnostics"),
+                    )
+                    try:
+                        metrics = engine.grid_search(
+                            strategie_factory=strategy["factory"],
+                            param_grid=strategy["params"],
+                            assets=[asset.symbol],
+                            interval=interval,
+                        )
+                        params_used = metrics.get("beste_params", {})
+                        row = make_result_row(
+                            strategy=strategy,
+                            asset=asset.symbol,
+                            interval=interval,
+                            params=params_used,
+                            as_of_utc=as_of_utc,
+                            metrics=metrics,
+                        )
+                        evaluation_report = getattr(engine, "last_evaluation_report", None)
+                        if evaluation_report is not None:
+                            walk_forward_reports.append(
+                                _sidecar_strategy_entry(
+                                    strategy=strategy,
+                                    asset=asset.symbol,
+                                    interval=interval,
+                                    report=evaluation_report,
+                                )
                             )
+                            evaluations.append(
+                                {
+                                    "family": strategy["family"],
+                                    "interval": interval,
+                                    "selected_params": json.loads(row["params_json"]),
+                                    "evaluation_report": evaluation_report,
+                                    "row": row,
+                                }
+                            )
+                    except (EvaluationScheduleError, FoldLeakageError):
+                        raise
+                    except Exception as e:
+                        row = make_result_row(
+                            strategy=strategy,
+                            asset=asset.symbol,
+                            interval=interval,
+                            params={},
+                            as_of_utc=as_of_utc,
+                            metrics={},
+                            error=str(e),
                         )
-                        evaluations.append(
-                            {
-                                "family": strategy["family"],
-                                "interval": interval,
-                                "selected_params": json.loads(row["params_json"]),
-                                "evaluation_report": evaluation_report,
-                                "row": row,
-                            }
-                        )
-                except (EvaluationScheduleError, FoldLeakageError):
-                    raise
-                except Exception as e:
-                    row = make_result_row(
-                        strategy=strategy,
-                        asset=asset.symbol,
-                        interval=interval,
-                        params={},
-                        as_of_utc=as_of_utc,
-                        metrics={},
-                        error=str(e),
-                    )
 
-                provenance_events.extend(getattr(engine, "_provenance_events", []))
-                rows.append(row)
-    evaluable_oos_daily_return_count = _count_evaluable_oos_daily_return_evaluations(
-        evaluations
-    )
-    if evaluations and evaluable_oos_daily_return_count == 0:
-        _raise_degenerate_run(
+                    provenance_events.extend(getattr(engine, "_provenance_events", []))
+                    rows.append(row)
+                    completed_items += 1
+                    tracker.advance(completed=completed_items, total=total_items)
+
+        tracker.mark_stage_completed(completed_items=completed_items)
+        evaluable_oos_daily_return_count = _count_evaluable_oos_daily_return_evaluations(
+            evaluations
+        )
+        if evaluations and evaluable_oos_daily_return_count == 0:
+            _raise_degenerate_run(
+                as_of_utc=as_of_utc,
+                failure_stage="postrun_no_oos_daily_returns",
+                assets=assets,
+                intervals=intervals,
+                interval_ranges=interval_ranges,
+                pair_diagnostics=pair_diagnostics,
+                evaluations_count=len(evaluations),
+                evaluations_with_oos_daily_returns=evaluable_oos_daily_return_count,
+            )
+
+        tracker.start_stage("writing_outputs", total=total_items)
+        write_results_to_csv(rows)
+        write_latest_json(rows, as_of_utc=as_of_utc)
+
+        if any(not report["leakage_checks_ok"] for report in walk_forward_reports):
+            raise FoldLeakageError("Leakage check failed; walk-forward sidecar will not be written")
+
+        _write_walk_forward_sidecar(
             as_of_utc=as_of_utc,
-            failure_stage="postrun_no_oos_daily_returns",
-            assets=assets,
-            intervals=intervals,
+            evaluation_config=evaluation_config,
+            strategy_reports=walk_forward_reports,
+        )
+        _write_provenance_sidecar(
+            research_config=research_config,
+            as_of_utc=as_of_utc,
             interval_ranges=interval_ranges,
-            pair_diagnostics=pair_diagnostics,
-            evaluations_count=len(evaluations),
-            evaluations_with_oos_daily_returns=evaluable_oos_daily_return_count,
+            provenance_events=provenance_events,
         )
 
-    write_results_to_csv(rows)
-    write_latest_json(rows, as_of_utc=as_of_utc)
+        successful_rows = [row for row in rows if row["success"]]
+        if evaluations and len(evaluations) != len(successful_rows):
+            raise RuntimeError(
+                "successful research rows are missing evaluation samples for statistical defensibility"
+            )
+        if evaluations and len(evaluations) == len(successful_rows):
+            _write_statistical_defensibility_sidecar(
+                evaluations=evaluations,
+                as_of_utc=as_of_utc,
+                intervals=intervals,
+                market_count=len(assets),
+                regime_count=regime_count,
+                regime_count_source=regime_count_source,
+            )
 
-    if any(not report["leakage_checks_ok"] for report in walk_forward_reports):
-        raise FoldLeakageError("Leakage check failed; walk-forward sidecar will not be written")
-
-    _write_walk_forward_sidecar(
-        as_of_utc=as_of_utc,
-        evaluation_config=evaluation_config,
-        strategy_reports=walk_forward_reports,
-    )
-    _write_provenance_sidecar(
-        research_config=research_config,
-        as_of_utc=as_of_utc,
-        interval_ranges=interval_ranges,
-        provenance_events=provenance_events,
-    )
-
-    successful_rows = [row for row in rows if row["success"]]
-    if evaluations and len(evaluations) != len(successful_rows):
-        raise RuntimeError(
-            "successful research rows are missing evaluation samples for statistical defensibility"
+        _write_candidate_registry(
+            rows=rows,
+            walk_forward_reports=walk_forward_reports,
+            research_config=research_config,
+            as_of_utc=as_of_utc,
         )
-    if evaluations and len(evaluations) == len(successful_rows):
-        _write_statistical_defensibility_sidecar(
+        _write_portfolio_aggregation_sidecar(
             evaluations=evaluations,
             as_of_utc=as_of_utc,
-            intervals=intervals,
-            market_count=len(assets),
-            regime_count=regime_count,
-            regime_count_source=regime_count_source,
         )
+        _write_regime_diagnostics_sidecar(
+            evaluations=evaluations,
+            as_of_utc=as_of_utc,
+            research_config=research_config,
+            evaluation_config=evaluation_config,
+            provenance_events=provenance_events,
+        )
+        tracker.mark_stage_completed()
+        tracker.complete()
+        print(f"Klaar. {len(rows)} resultaten geschreven.")
+    except Exception as exc:
+        tracker.fail(exc, failure_stage=tracker.current_stage)
+        raise
 
-    _write_candidate_registry(
-        rows=rows,
-        walk_forward_reports=walk_forward_reports,
-        research_config=research_config,
-        as_of_utc=as_of_utc,
-    )
-    _write_portfolio_aggregation_sidecar(
-        evaluations=evaluations,
-        as_of_utc=as_of_utc,
-    )
-    _write_regime_diagnostics_sidecar(
-        evaluations=evaluations,
-        as_of_utc=as_of_utc,
-        research_config=research_config,
-        evaluation_config=evaluation_config,
-        provenance_events=provenance_events,
-    )
-
-    print(f"Klaar. {len(rows)} resultaten geschreven.")
-    
 if __name__ == "__main__":
     run_research()
 

--- a/tests/unit/test_research_observability.py
+++ b/tests/unit/test_research_observability.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from research.observability import ProgressTracker
+
+
+class FakeClock:
+    def __init__(self, start: datetime) -> None:
+        self.current = start
+        self.mono = 0.0
+
+    def now(self) -> datetime:
+        return self.current
+
+    def monotonic(self) -> float:
+        return self.mono
+
+    def advance(self, seconds: int) -> None:
+        self.current += timedelta(seconds=seconds)
+        self.mono += float(seconds)
+
+
+def _load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_progress_sidecar_has_deterministic_structure_and_eta(tmp_path: Path):
+    start = datetime(2026, 4, 13, 12, 0, 0, tzinfo=UTC)
+    clock = FakeClock(start)
+    logs: list[str] = []
+    path = tmp_path / "research" / "run_progress_latest.v1.json"
+    tracker = ProgressTracker(
+        path=path,
+        started_at_utc=start,
+        now_source=clock.now,
+        monotonic_source=clock.monotonic,
+        log_fn=logs.append,
+    )
+
+    tracker.start_stage("evaluation", total=4, total_items=4)
+    tracker.begin_item(strategy="sma_crossover", asset="BTC-USD", interval="1h")
+    clock.advance(5)
+    tracker.advance(completed=1, total=4)
+
+    payload = _load_json(path)
+    assert payload == {
+        "version": "v1",
+        "status": "running",
+        "run_id": "20260413T120000000000Z",
+        "current_stage": "evaluation",
+        "started_at_utc": "2026-04-13T12:00:00+00:00",
+        "last_updated_at_utc": "2026-04-13T12:00:05+00:00",
+        "progress": {
+            "completed": 1,
+            "total": 4,
+            "percent": 25.0,
+        },
+        "current_item": {
+            "strategy": "sma_crossover",
+            "asset": "BTC-USD",
+            "interval": "1h",
+        },
+        "timing": {
+            "elapsed_seconds": 5,
+            "stage_elapsed_seconds": 5,
+            "eta_seconds": 15,
+        },
+        "failure": None,
+    }
+    assert logs[0] == "[research] stage stage=evaluation status=started total_items=4"
+    assert logs[1] == (
+        "[research] progress stage=evaluation progress=1/4 percent=25.0 "
+        "elapsed_s=5 eta_s=15 current=sma_crossover BTC-USD 1h"
+    )
+
+
+def test_completed_state_is_written_correctly(tmp_path: Path):
+    start = datetime(2026, 4, 13, 12, 0, 0, tzinfo=UTC)
+    clock = FakeClock(start)
+    path = tmp_path / "research" / "run_progress_latest.v1.json"
+    tracker = ProgressTracker(
+        path=path,
+        started_at_utc=start,
+        now_source=clock.now,
+        monotonic_source=clock.monotonic,
+        log_fn=lambda message: None,
+    )
+
+    tracker.start_stage("writing_outputs", total=3)
+    clock.advance(9)
+    tracker.complete()
+
+    payload = _load_json(path)
+    assert payload["status"] == "completed"
+    assert payload["current_stage"] == "completed"
+    assert payload["progress"] == {"completed": 3, "total": 3, "percent": 100.0}
+    assert payload["failure"] is None
+    assert payload["timing"]["elapsed_seconds"] == 9
+
+
+def test_failed_state_is_written_correctly(tmp_path: Path):
+    start = datetime(2026, 4, 13, 12, 0, 0, tzinfo=UTC)
+    clock = FakeClock(start)
+    path = tmp_path / "research" / "run_progress_latest.v1.json"
+    tracker = ProgressTracker(
+        path=path,
+        started_at_utc=start,
+        now_source=clock.now,
+        monotonic_source=clock.monotonic,
+        log_fn=lambda message: None,
+    )
+
+    tracker.start_stage("preflight", total=10)
+    clock.advance(2)
+    tracker.fail(RuntimeError("boom"), failure_stage="preflight")
+
+    payload = _load_json(path)
+    assert payload["status"] == "failed"
+    assert payload["current_stage"] == "failed"
+    assert payload["failure"] == {
+        "failure_stage": "preflight",
+        "error_type": "RuntimeError",
+        "error_message": "boom",
+    }
+    assert payload["timing"]["elapsed_seconds"] == 2
+
+
+def test_large_evaluation_progress_is_throttled(tmp_path: Path):
+    start = datetime(2026, 4, 13, 12, 0, 0, tzinfo=UTC)
+    clock = FakeClock(start)
+    path = tmp_path / "research" / "run_progress_latest.v1.json"
+    tracker = ProgressTracker(
+        path=path,
+        started_at_utc=start,
+        now_source=clock.now,
+        monotonic_source=clock.monotonic,
+        log_fn=lambda message: None,
+    )
+
+    tracker.start_stage("evaluation", total=100)
+    tracker.begin_item(strategy="rsi", asset="BTC-USD", interval="1h")
+    clock.advance(1)
+    tracker.advance(completed=1, total=100)
+    first = _load_json(path)
+
+    tracker.begin_item(strategy="rsi", asset="ETH-USD", interval="1h")
+    clock.advance(1)
+    tracker.advance(completed=2, total=100)
+    second = _load_json(path)
+
+    assert first["progress"]["completed"] == 1
+    assert second["progress"]["completed"] == 1

--- a/tests/unit/test_run_research_observability.py
+++ b/tests/unit/test_run_research_observability.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import csv
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from research import run_research as run_research_module
+from research.empty_run_reporting import DegenerateResearchRunError
+from research.results import make_result_row, write_latest_json, write_results_to_csv
+
+
+AS_OF_UTC = datetime(2026, 4, 13, 12, 0, 0, tzinfo=UTC)
+ROW_SCHEMA = list(
+    make_result_row(
+        strategy={"name": "schema", "family": "trend", "hypothesis": "schema"},
+        asset="BTC-USD",
+        interval="1d",
+        params={},
+        as_of_utc=AS_OF_UTC,
+        metrics={},
+    ).keys()
+)
+
+
+def _load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _patch_common_runner(monkeypatch, tmp_path: Path, engine_cls) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "research").mkdir()
+    monkeypatch.setattr(run_research_module, "BacktestEngine", engine_cls)
+    monkeypatch.setattr(
+        run_research_module,
+        "get_enabled_strategies",
+        lambda: [
+            {
+                "name": "fake_strategy",
+                "family": "trend",
+                "hypothesis": "Fixture hypothesis",
+                "factory": lambda **params: None,
+                "params": {"periode": [14]},
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        run_research_module,
+        "build_research_universe",
+        lambda config: (
+            [SimpleNamespace(symbol="BTC-USD")],
+            ["1d"],
+            lambda interval: ("2026-01-01", "2026-02-01"),
+            AS_OF_UTC,
+            {"version": "v1", "resolved_count": 1},
+        ),
+    )
+    monkeypatch.setattr(
+        run_research_module,
+        "load_research_config",
+        lambda config_path="config/config.yaml": {},
+    )
+    monkeypatch.setattr(run_research_module, "_git_revision", lambda: "deadbeef")
+    monkeypatch.setattr(run_research_module, "_write_provenance_sidecar", lambda **kwargs: None)
+    monkeypatch.setattr(run_research_module, "_write_statistical_defensibility_sidecar", lambda **kwargs: None)
+    monkeypatch.setattr(run_research_module, "_write_candidate_registry", lambda **kwargs: None)
+    monkeypatch.setattr(run_research_module, "_write_portfolio_aggregation_sidecar", lambda **kwargs: None)
+    monkeypatch.setattr(run_research_module, "_write_regime_diagnostics_sidecar", lambda **kwargs: None)
+    monkeypatch.setattr(
+        run_research_module,
+        "write_results_to_csv",
+        lambda rows: write_results_to_csv(rows, path=tmp_path / "research" / "strategy_matrix.csv"),
+    )
+    monkeypatch.setattr(
+        run_research_module,
+        "write_latest_json",
+        lambda rows, as_of_utc: write_latest_json(
+            rows,
+            as_of_utc=as_of_utc,
+            path=tmp_path / "research" / "research_latest.json",
+        ),
+    )
+
+
+class _HealthyEngine:
+    def __init__(self, start_datum, eind_datum, evaluation_config=None, regime_config=None):
+        self.start = start_datum
+        self.end = eind_datum
+        self._provenance_events = []
+        self.last_evaluation_report = None
+
+    def inspect_asset_readiness(self, assets, interval):
+        return [
+            {
+                "asset": asset,
+                "interval": interval,
+                "requested_start": self.start,
+                "requested_end": self.end,
+                "bar_count": 700,
+                "fold_count": 2,
+                "status": "evaluable",
+                "drop_reason": None,
+            }
+            for asset in assets
+        ]
+
+    def grid_search(self, strategie_factory, param_grid, assets, interval="1d"):
+        self.last_evaluation_report = {
+            "evaluation_config": {
+                "mode": "anchored",
+                "selection_metric": "sharpe",
+                "initial_train_bars": 500,
+                "test_bars": 100,
+                "step_bars": 100,
+            },
+            "selection_metric": "sharpe",
+            "selected_params": {"periode": 14},
+            "is_summary": {
+                "win_rate": 0.6,
+                "sharpe": 1.2,
+                "deflated_sharpe": 1.0,
+                "max_drawdown": 0.1,
+                "trades_per_maand": 3.0,
+                "consistentie": 0.7,
+                "totaal_trades": 12,
+                "goedgekeurd": True,
+                "criteria_checks": {},
+            },
+            "oos_summary": {
+                "win_rate": 0.55,
+                "sharpe": 1.1,
+                "deflated_sharpe": 0.9,
+                "max_drawdown": 0.12,
+                "trades_per_maand": 2.5,
+                "consistentie": 0.65,
+                "totaal_trades": 12,
+                "goedgekeurd": True,
+                "criteria_checks": {},
+            },
+            "folds": [{"train": [0, 499], "test": [500, 599], "leakage_ok": True}],
+            "leakage_checks_ok": True,
+            "evaluation_samples": {
+                "daily_returns": [0.01, -0.005, 0.003],
+                "trade_pnls": [0.02, -0.01],
+                "monthly_returns": [0.008],
+            },
+            "evaluation_streams": {
+                "oos_daily_returns": [
+                    {"timestamp_utc": "2026-01-02T00:00:00+00:00", "return": 0.01},
+                    {"timestamp_utc": "2026-01-03T00:00:00+00:00", "return": -0.005},
+                    {"timestamp_utc": "2026-01-04T00:00:00+00:00", "return": 0.003},
+                ],
+                "oos_bar_returns": [],
+                "oos_trade_events": [],
+            },
+            "sample_statistics": {
+                "daily_returns": {"count": 3, "mean": 0.0027, "std": 0.006, "skew": 0.0, "kurt": 3.0},
+            },
+        }
+        return {
+            "beste_params": {"periode": 14},
+            "win_rate": 0.55,
+            "sharpe": 1.1,
+            "deflated_sharpe": 0.9,
+            "max_drawdown": 0.12,
+            "trades_per_maand": 2.5,
+            "consistentie": 0.65,
+            "totaal_trades": 12,
+            "goedgekeurd": True,
+            "criteria_checks": {},
+            "reden": "",
+        }
+
+
+class _DegenerateEngine:
+    def __init__(self, start_datum, eind_datum, evaluation_config=None, regime_config=None):
+        self.start = start_datum
+        self.eind = eind_datum
+        self._provenance_events = []
+        self.last_evaluation_report = None
+
+    def inspect_asset_readiness(self, assets, interval):
+        return [
+            {
+                "asset": asset,
+                "interval": interval,
+                "requested_start": self.start,
+                "requested_end": self.eind,
+                "bar_count": 0,
+                "fold_count": 0,
+                "status": "dropped",
+                "drop_reason": "empty_dataset",
+            }
+            for asset in assets
+        ]
+
+    def grid_search(self, strategie_factory, param_grid, assets, interval="1d"):
+        raise AssertionError("grid_search should not run for preflight failure")
+
+
+def test_run_research_writes_completed_progress_sidecar_and_keeps_public_schema(monkeypatch, tmp_path: Path):
+    _patch_common_runner(monkeypatch, tmp_path, _HealthyEngine)
+
+    run_research_module.run_research()
+
+    progress = _load_json(tmp_path / "research" / "run_progress_latest.v1.json")
+    public_json = _load_json(tmp_path / "research" / "research_latest.json")
+    with (tmp_path / "research" / "strategy_matrix.csv").open(encoding="utf-8", newline="") as handle:
+        csv_rows = list(csv.DictReader(handle))
+
+    assert progress["version"] == "v1"
+    assert progress["status"] == "completed"
+    assert progress["current_stage"] == "completed"
+    assert progress["progress"] == {"completed": 1, "total": 1, "percent": 100.0}
+    assert progress["failure"] is None
+    assert list(public_json["results"][0].keys()) == ROW_SCHEMA
+    assert list(csv_rows[0].keys()) == ROW_SCHEMA
+
+
+def test_run_research_marks_failed_progress_sidecar_on_degenerate_run(monkeypatch, tmp_path: Path):
+    _patch_common_runner(monkeypatch, tmp_path, _DegenerateEngine)
+
+    with pytest.raises(DegenerateResearchRunError, match="preflight_no_evaluable_pairs"):
+        run_research_module.run_research()
+
+    progress = _load_json(tmp_path / "research" / "run_progress_latest.v1.json")
+    assert progress["status"] == "failed"
+    assert progress["current_stage"] == "failed"
+    assert progress["failure"]["failure_stage"] == "preflight"
+    assert progress["failure"]["error_type"] == "DegenerateResearchRunError"


### PR DESCRIPTION
## Summary

Adds runtime observability to the research pipeline via a dedicated ProgressTracker helper.

This introduces progress tracking, stage-level logging, and an additive progress sidecar without modifying any public output schemas.

## Key Changes

- New module: `research/observability.py`
  - ProgressTracker class
  - deterministic progress sidecar
  - sparse console logging

- Runner integration (`run_research.py`)
  - stage lifecycle:
    - preflight
    - evaluation
    - writing_outputs
    - completed / failed
  - throttled progress updates during evaluation

- New sidecar:
  - `research/run_progress_latest.v1.json`
  - includes:
    - status, run_id, stage
    - progress (completed/total/percent)
    - current item
    - timing (elapsed + ETA)
    - failure metadata

## Guarantees

- No changes to:
  - `research_latest.json`
  - `strategy_matrix.csv`
- Runner remains thin
- No logic moved across layers
- Observability is fully additive

## Validation

- Observability unit tests: ✅
- Runner integration tests: ✅
- Schema stability tests: ✅
- Full test suite: `368 passed, 1 skipped`

## Notes

- Progress writes are throttled to avoid I/O overhead
- Windows-safe file replace fallback implemented