### PR TITLE
Feature/dashboard control surface v1

### DIFF
--- a/dashboard/dashboard.py
+++ b/dashboard/dashboard.py
@@ -5,7 +5,16 @@ Flask-gebaseerd dashboard voor de JvR Trading Agent.
 Alle data via /api/ endpoints, geen extra packages.
 """
 
-from flask import Flask, send_from_directory, request, Response, jsonify, session, g
+from flask import (
+    Flask,
+    send_from_directory,
+    request,
+    Response,
+    jsonify,
+    session,
+    g,
+    render_template,
+)
 from functools import wraps
 import hmac
 import os
@@ -20,6 +29,7 @@ from datetime import datetime
 
 from data.contracts import Instrument
 from data.repository import MarketRepository
+from dashboard import research_artifacts, research_runner
 from reporting import audit_log
 
 app = Flask(__name__, template_folder="templates")
@@ -245,6 +255,45 @@ def index():
     if not html_pad.exists():
         html_pad = Path("templates/dashboard.html")
     return open(html_pad, encoding="utf-8").read()
+
+
+@app.route("/research")
+@requires_auth
+def research_control_surface():
+    return render_template("research_control_surface.html")
+
+
+@app.route("/api/research/run-status")
+@requires_auth
+def api_research_run_status():
+    artifact = research_artifacts.load_run_progress_artifact()
+    return jsonify(research_runner.build_run_status_response(artifact))
+
+
+@app.route("/api/research/latest")
+@requires_auth
+def api_research_latest():
+    return jsonify(research_artifacts.load_research_latest_artifact())
+
+
+@app.route("/api/research/empty-run-diagnostics")
+@requires_auth
+def api_research_empty_run_diagnostics():
+    return jsonify(research_artifacts.load_empty_run_diagnostics_artifact())
+
+
+@app.route("/api/research/universe")
+@requires_auth
+def api_research_universe():
+    return jsonify(research_artifacts.load_universe_snapshot_artifact())
+
+
+@app.route("/api/research/run", methods=["POST"])
+@require_operator_auth()
+def api_research_run():
+    artifact = research_artifacts.load_run_progress_artifact()
+    payload, status_code = research_runner.launch_research_run(artifact)
+    return jsonify(payload), status_code
 
 
 # ──────────────────────────────────────────────

--- a/dashboard/research_artifacts.py
+++ b/dashboard/research_artifacts.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from json import JSONDecodeError
+from pathlib import Path
+from typing import Any
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+RUN_PROGRESS_PATH = BASE_DIR / "research" / "run_progress_latest.v1.json"
+RESEARCH_LATEST_PATH = BASE_DIR / "research" / "research_latest.json"
+EMPTY_RUN_DIAGNOSTICS_PATH = (
+    BASE_DIR / "research" / "empty_run_diagnostics_latest.v1.json"
+)
+UNIVERSE_SNAPSHOT_PATH = BASE_DIR / "research" / "universe_snapshot_latest.v1.json"
+
+
+def _path_label(path: Path) -> str:
+    try:
+        return path.relative_to(BASE_DIR).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def _modified_at_utc(path: Path) -> str | None:
+    try:
+        return datetime.fromtimestamp(path.stat().st_mtime, tz=UTC).isoformat()
+    except OSError:
+        return None
+
+
+def _artifact_state_for_payload(payload: Any) -> str:
+    if payload is None:
+        return "empty"
+    if isinstance(payload, (dict, list, str)) and len(payload) == 0:
+        return "empty"
+    return "valid"
+
+
+def load_json_artifact(path: Path) -> dict[str, Any]:
+    response: dict[str, Any] = {
+        "artifact_path": _path_label(path),
+        "artifact_state": "absent",
+        "artifact_available": False,
+        "artifact_error": None,
+        "artifact_modified_at_utc": None,
+        "artifact": None,
+    }
+
+    if not path.exists():
+        return response
+
+    response["artifact_modified_at_utc"] = _modified_at_utc(path)
+
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        response["artifact_state"] = "unreadable"
+        response["artifact_error"] = str(exc)
+        return response
+
+    if raw.strip() == "":
+        response["artifact_state"] = "empty"
+        return response
+
+    try:
+        payload = json.loads(raw)
+    except JSONDecodeError as exc:
+        response["artifact_state"] = "invalid_json"
+        response["artifact_error"] = str(exc)
+        return response
+
+    response["artifact"] = payload
+    response["artifact_state"] = _artifact_state_for_payload(payload)
+    response["artifact_available"] = response["artifact_state"] == "valid"
+    return response
+
+
+def load_run_progress_artifact() -> dict[str, Any]:
+    return load_json_artifact(RUN_PROGRESS_PATH)
+
+
+def load_research_latest_artifact() -> dict[str, Any]:
+    return load_json_artifact(RESEARCH_LATEST_PATH)
+
+
+def load_empty_run_diagnostics_artifact() -> dict[str, Any]:
+    return load_json_artifact(EMPTY_RUN_DIAGNOSTICS_PATH)
+
+
+def load_universe_snapshot_artifact() -> dict[str, Any]:
+    return load_json_artifact(UNIVERSE_SNAPSHOT_PATH)

--- a/dashboard/research_runner.py
+++ b/dashboard/research_runner.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import threading
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+STALE_HEARTBEAT_SECONDS = 300
+
+_RUN_LOCK = threading.Lock()
+_ACTIVE_PROCESS: subprocess.Popen[str] | None = None
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _parse_iso_datetime(value: Any) -> datetime | None:
+    if not isinstance(value, str) or value.strip() == "":
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
+    except ValueError:
+        return None
+
+
+def _current_process() -> subprocess.Popen[str] | None:
+    with _RUN_LOCK:
+        process = _ACTIVE_PROCESS
+        if process is not None and process.poll() is not None:
+            return None
+        return process
+
+
+def local_process_active() -> bool:
+    return _current_process() is not None
+
+
+def dashboard_observations(
+    run_status_artifact: dict[str, Any],
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    artifact = run_status_artifact.get("artifact")
+    heartbeat_at = (
+        _parse_iso_datetime(artifact.get("last_updated_at_utc"))
+        if isinstance(artifact, dict)
+        else None
+    )
+    age_seconds = None
+    if heartbeat_at is not None:
+        age_seconds = max(0, int(round(((now or _utc_now()) - heartbeat_at).total_seconds())))
+
+    artifact_status = artifact.get("status") if isinstance(artifact, dict) else None
+    local_active = local_process_active()
+    recent_signal = (
+        artifact_status == "running"
+        and age_seconds is not None
+        and age_seconds <= STALE_HEARTBEAT_SECONDS
+    )
+    stale_signal = (
+        artifact_status == "running"
+        and not local_active
+        and (age_seconds is None or age_seconds > STALE_HEARTBEAT_SECONDS)
+    )
+    return {
+        "local_process_active": local_active,
+        "artifact_status": artifact_status,
+        "progress_heartbeat_age_seconds": age_seconds,
+        "recent_progress_signal": recent_signal,
+        "stale_progress_signal": stale_signal,
+        "stale_heartbeat_threshold_seconds": STALE_HEARTBEAT_SECONDS,
+    }
+
+
+def build_run_status_response(
+    run_status_artifact: dict[str, Any],
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    observations = dashboard_observations(run_status_artifact, now=now)
+    warnings: list[str] = []
+    if observations["stale_progress_signal"]:
+        warnings.append(
+            "Progress artifact reports running but no active local process was detected and the heartbeat appears stale."
+        )
+    return {
+        **run_status_artifact,
+        "dashboard_observations": observations,
+        "warnings": warnings,
+    }
+
+
+def launch_research_run(
+    run_status_artifact: dict[str, Any],
+    *,
+    now: datetime | None = None,
+) -> tuple[dict[str, Any], int]:
+    observations = dashboard_observations(run_status_artifact, now=now)
+    warnings: list[str] = []
+
+    if observations["local_process_active"] or observations["recent_progress_signal"]:
+        return (
+            {
+                "accepted": False,
+                "launch_state": "blocked_active_run",
+                "observations": observations,
+                "warnings": warnings,
+            },
+            409,
+        )
+
+    if observations["stale_progress_signal"]:
+        warnings.append(
+            "Stale running progress signal detected. Review run_progress_latest.v1.json before retrying."
+        )
+        return (
+            {
+                "accepted": False,
+                "launch_state": "blocked_stale_signal",
+                "observations": observations,
+                "warnings": warnings,
+            },
+            409,
+        )
+
+    try:
+        process = subprocess.Popen(
+            [sys.executable, "research/run_research.py"],
+            cwd=str(BASE_DIR),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except Exception as exc:
+        return (
+            {
+                "accepted": False,
+                "launch_state": "launch_failed",
+                "observations": observations,
+                "warnings": warnings,
+                "error": str(exc),
+            },
+            500,
+        )
+
+    with _RUN_LOCK:
+        global _ACTIVE_PROCESS
+        _ACTIVE_PROCESS = process
+
+    return (
+        {
+            "accepted": True,
+            "launch_state": "started",
+            "pid": process.pid,
+            "observations": dashboard_observations(run_status_artifact, now=now),
+            "warnings": warnings,
+        },
+        202,
+    )

--- a/dashboard/static/research_control_surface.js
+++ b/dashboard/static/research_control_surface.js
@@ -1,0 +1,254 @@
+(function () {
+  const state = {
+    results: [],
+    sortKey: "sharpe",
+    sortDirection: "desc",
+  };
+
+  function text(id, value) {
+    const node = document.getElementById(id);
+    if (node) {
+      node.textContent = value == null || value === "" ? "-" : String(value);
+    }
+  }
+
+  function renderWarning(containerId, messages, kind) {
+    const node = document.getElementById(containerId);
+    if (!node) {
+      return;
+    }
+    if (!messages || messages.length === 0) {
+      node.innerHTML = "";
+      return;
+    }
+    const cssClass = kind === "error" ? "error" : "warning";
+    node.innerHTML = `<div class="${cssClass}">${messages.join("<br>")}</div>`;
+  }
+
+  function currentItemLabel(item) {
+    if (!item) {
+      return "-";
+    }
+    const parts = [item.strategy, item.asset, item.interval].filter(Boolean);
+    return parts.length > 0 ? parts.join(" ") : "-";
+  }
+
+  async function fetchJson(url, options) {
+    const response = await fetch(url, options);
+    return response.json();
+  }
+
+  async function loadRunStatus() {
+    const payload = await fetchJson("/api/research/run-status");
+    const artifact = payload.artifact || {};
+    const progress = artifact.progress || {};
+    const timing = artifact.timing || {};
+    const observations = payload.dashboard_observations || {};
+
+    text("run-status", artifact.status || payload.artifact_state);
+    text("run-stage", artifact.current_stage);
+    text("run-progress", progress.percent != null ? `${progress.percent}%` : "-");
+    text("run-current-item", currentItemLabel(artifact.current_item));
+    text("run-completed", progress.total != null ? `${progress.completed}/${progress.total}` : "-");
+    text("run-elapsed", timing.elapsed_seconds);
+    text("run-eta", timing.eta_seconds);
+    text("run-updated", artifact.last_updated_at_utc || payload.artifact_modified_at_utc);
+
+    const observationText = [];
+    if (observations.local_process_active != null) {
+      observationText.push(`Local process active: ${observations.local_process_active}`);
+    }
+    if (observations.progress_heartbeat_age_seconds != null) {
+      observationText.push(`Heartbeat age: ${observations.progress_heartbeat_age_seconds}s`);
+    }
+    document.getElementById("run-observations").textContent = observationText.join(" | ");
+    renderWarning("run-warning", payload.warnings || [], "warning");
+
+    const button = document.getElementById("run-research-button");
+    if (button) {
+      button.disabled = Boolean(observations.local_process_active || observations.recent_progress_signal);
+    }
+  }
+
+  function renderFailureTable(rows) {
+    const body = document.getElementById("failure-table-body");
+    if (!body) {
+      return;
+    }
+    if (!rows || rows.length === 0) {
+      body.innerHTML = '<tr><td colspan="6" class="muted">No diagnostics available.</td></tr>';
+      return;
+    }
+    body.innerHTML = rows.map((row) => `
+      <tr>
+        <td>${row.asset || "-"}</td>
+        <td>${row.interval || "-"}</td>
+        <td>${row.status || "-"}</td>
+        <td>${row.bar_count ?? "-"}</td>
+        <td>${row.fold_count ?? "-"}</td>
+        <td>${row.drop_reason || "-"}</td>
+      </tr>
+    `).join("");
+  }
+
+  async function loadFailureDiagnostics() {
+    const payload = await fetchJson("/api/research/empty-run-diagnostics");
+    const artifact = payload.artifact || {};
+    const summary = artifact.summary || {};
+    if (payload.artifact_state !== "valid") {
+      document.getElementById("failure-summary").textContent = `Diagnostics state: ${payload.artifact_state}`;
+      renderWarning("failure-message", payload.artifact_error ? [payload.artifact_error] : [], "error");
+      renderFailureTable([]);
+      return;
+    }
+
+    const selectedAssets = (artifact.selected_assets || []).join(", ");
+    const selectedIntervals = (artifact.selected_intervals || []).join(", ");
+    document.getElementById("failure-summary").textContent =
+      `Stage: ${artifact.failure_stage || "-"} | Assets: ${selectedAssets || "-"} | Intervals: ${selectedIntervals || "-"} | Drop reasons: ${(summary.primary_drop_reasons || []).join(", ") || "-"}`;
+    renderWarning("failure-message", artifact.message ? [artifact.message] : [], "warning");
+    renderFailureTable(artifact.pairs || []);
+  }
+
+  function normalizeValue(value) {
+    if (typeof value === "boolean") {
+      return value ? 1 : 0;
+    }
+    if (value == null) {
+      return "";
+    }
+    return value;
+  }
+
+  function filteredResults() {
+    const search = (document.getElementById("results-search").value || "").toLowerCase();
+    const asset = document.getElementById("results-asset-filter").value;
+    const interval = document.getElementById("results-interval-filter").value;
+    return state.results
+      .filter((row) => !asset || row.asset === asset)
+      .filter((row) => !interval || row.interval === interval)
+      .filter((row) => {
+        if (!search) {
+          return true;
+        }
+        return [row.strategy_name, row.asset, row.interval]
+          .filter(Boolean)
+          .some((value) => String(value).toLowerCase().includes(search));
+      })
+      .sort((a, b) => {
+        const left = normalizeValue(a[state.sortKey]);
+        const right = normalizeValue(b[state.sortKey]);
+        if (left === right) {
+          return 0;
+        }
+        const comparison = left > right ? 1 : -1;
+        return state.sortDirection === "asc" ? comparison : -comparison;
+      });
+  }
+
+  function renderResults() {
+    const rows = filteredResults();
+    const body = document.getElementById("results-table-body");
+    if (!body) {
+      return;
+    }
+    if (rows.length === 0) {
+      body.innerHTML = '<tr><td colspan="9" class="muted">No matching research rows.</td></tr>';
+      return;
+    }
+    body.innerHTML = rows.map((row) => `
+      <tr>
+        <td>${row.strategy_name || "-"}</td>
+        <td>${row.asset || "-"}</td>
+        <td>${row.interval || "-"}</td>
+        <td>${row.sharpe ?? "-"}</td>
+        <td>${row.deflated_sharpe ?? "-"}</td>
+        <td>${row.max_drawdown ?? "-"}</td>
+        <td>${row.totaal_trades ?? "-"}</td>
+        <td><span class="pill">${row.goedgekeurd}</span></td>
+        <td><span class="pill">${row.success}</span></td>
+      </tr>
+    `).join("");
+  }
+
+  function populateFilterOptions(values, selectId, label) {
+    const select = document.getElementById(selectId);
+    if (!select) {
+      return;
+    }
+    const current = select.value;
+    const options = [`<option value="">All ${label}</option>`]
+      .concat(values.map((value) => `<option value="${value}">${value}</option>`));
+    select.innerHTML = options.join("");
+    select.value = current;
+  }
+
+  async function loadResults() {
+    const payload = await fetchJson("/api/research/latest");
+    const artifact = payload.artifact || {};
+    if (payload.artifact_state !== "valid") {
+      document.getElementById("results-meta").textContent = `Research artifact state: ${payload.artifact_state}`;
+      renderResults();
+      return;
+    }
+
+    state.results = Array.isArray(artifact.results) ? artifact.results : [];
+    const assetValues = [...new Set(state.results.map((row) => row.asset).filter(Boolean))].sort();
+    const intervalValues = [...new Set(state.results.map((row) => row.interval).filter(Boolean))].sort();
+    populateFilterOptions(assetValues, "results-asset-filter", "assets");
+    populateFilterOptions(intervalValues, "results-interval-filter", "intervals");
+    document.getElementById("results-meta").textContent =
+      `Generated: ${artifact.generated_at_utc || "-"} | Rows: ${artifact.count ?? state.results.length}`;
+    renderResults();
+  }
+
+  async function triggerRun() {
+    const payload = await fetchJson("/api/research/run", { method: "POST" });
+    const messages = [];
+    if (payload.launch_state) {
+      messages.push(`Launch state: ${payload.launch_state}`);
+    }
+    if (payload.error) {
+      messages.push(payload.error);
+    }
+    if (payload.warnings) {
+      messages.push(...payload.warnings);
+    }
+    renderWarning("run-warning", messages, payload.accepted ? "warning" : "error");
+    await loadRunStatus();
+  }
+
+  function bindEvents() {
+    document.getElementById("run-research-button").addEventListener("click", triggerRun);
+    document.getElementById("results-search").addEventListener("input", renderResults);
+    document.getElementById("results-asset-filter").addEventListener("change", renderResults);
+    document.getElementById("results-interval-filter").addEventListener("change", renderResults);
+    document.querySelectorAll("th[data-sort-key]").forEach((node) => {
+      node.addEventListener("click", () => {
+        const key = node.getAttribute("data-sort-key");
+        if (state.sortKey === key) {
+          state.sortDirection = state.sortDirection === "asc" ? "desc" : "asc";
+        } else {
+          state.sortKey = key;
+          state.sortDirection = "desc";
+        }
+        renderResults();
+      });
+    });
+  }
+
+  async function refreshSlowPanels() {
+    await Promise.all([loadFailureDiagnostics(), loadResults()]);
+  }
+
+  async function init() {
+    bindEvents();
+    await Promise.all([loadRunStatus(), refreshSlowPanels()]);
+    window.setInterval(loadRunStatus, 5000);
+    window.setInterval(refreshSlowPanels, 30000);
+  }
+
+  init().catch((error) => {
+    renderWarning("run-warning", [String(error)], "error");
+  });
+})();

--- a/dashboard/templates/research_control_surface.html
+++ b/dashboard/templates/research_control_surface.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Research Control Surface</title>
+  <style>
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: #f6f4ef;
+      color: #1d1b19;
+    }
+    .page { max-width: 1280px; margin: 0 auto; padding: 24px; }
+    .topbar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      margin-bottom: 24px;
+    }
+    .title h1 { margin: 0; font-size: 24px; font-weight: 600; }
+    .title p { margin: 6px 0 0; color: #6e6a63; font-size: 14px; }
+    .button {
+      border: 1px solid #d8d2c7;
+      background: #ffffff;
+      color: #1d1b19;
+      border-radius: 8px;
+      padding: 10px 14px;
+      font-size: 14px;
+      cursor: pointer;
+    }
+    .button:disabled { opacity: 0.6; cursor: not-allowed; }
+    .grid { display: grid; grid-template-columns: 1fr; gap: 16px; }
+    .card {
+      background: #ffffff;
+      border: 1px solid #e5dfd4;
+      border-radius: 12px;
+      padding: 18px;
+    }
+    .card h2 { margin: 0 0 14px; font-size: 16px; font-weight: 600; }
+    .status-grid {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 12px;
+      margin-bottom: 16px;
+    }
+    .metric { background: #f6f4ef; border-radius: 8px; padding: 12px; }
+    .metric-label { font-size: 12px; color: #6e6a63; margin-bottom: 6px; }
+    .metric-value { font-size: 18px; font-weight: 600; }
+    .warning {
+      background: #fff4db;
+      color: #8c5b00;
+      border: 1px solid #efddad;
+      border-radius: 8px;
+      padding: 10px 12px;
+      margin-top: 12px;
+    }
+    .error {
+      background: #fdecec;
+      color: #9a2d2d;
+      border: 1px solid #f2caca;
+      border-radius: 8px;
+      padding: 10px 12px;
+    }
+    .muted { color: #6e6a63; font-size: 13px; }
+    .controls { display: flex; gap: 12px; flex-wrap: wrap; margin-bottom: 12px; }
+    input, select {
+      border: 1px solid #d8d2c7;
+      border-radius: 8px;
+      padding: 8px 10px;
+      font-size: 14px;
+      background: #ffffff;
+    }
+    table { width: 100%; border-collapse: collapse; font-size: 13px; }
+    th, td {
+      text-align: left;
+      padding: 10px 8px;
+      border-bottom: 1px solid #ece7de;
+      vertical-align: top;
+    }
+    th { color: #6e6a63; font-size: 12px; font-weight: 600; cursor: pointer; }
+    .table-wrap { overflow-x: auto; }
+    .pill {
+      display: inline-block;
+      padding: 2px 8px;
+      border-radius: 999px;
+      font-size: 11px;
+      font-weight: 600;
+      background: #ebe7df;
+      color: #49443d;
+    }
+    @media (max-width: 900px) {
+      .status-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    }
+    @media (max-width: 640px) {
+      .page { padding: 16px; }
+      .topbar { flex-direction: column; align-items: flex-start; }
+      .status-grid { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <div class="topbar">
+      <div class="title">
+        <h1>Research Control Surface</h1>
+        <p>Artifact-driven monitor for research runs and latest research outputs.</p>
+      </div>
+      <button class="button" id="run-research-button">Run Research</button>
+    </div>
+
+    <div class="grid">
+      <section class="card">
+        <h2>Run Monitor</h2>
+        <div class="status-grid">
+          <div class="metric"><div class="metric-label">Status</div><div class="metric-value" id="run-status">-</div></div>
+          <div class="metric"><div class="metric-label">Stage</div><div class="metric-value" id="run-stage">-</div></div>
+          <div class="metric"><div class="metric-label">Progress</div><div class="metric-value" id="run-progress">-</div></div>
+          <div class="metric"><div class="metric-label">Current Item</div><div class="metric-value" id="run-current-item">-</div></div>
+        </div>
+        <div class="status-grid">
+          <div class="metric"><div class="metric-label">Completed / Total</div><div class="metric-value" id="run-completed">-</div></div>
+          <div class="metric"><div class="metric-label">Elapsed Seconds</div><div class="metric-value" id="run-elapsed">-</div></div>
+          <div class="metric"><div class="metric-label">ETA Seconds</div><div class="metric-value" id="run-eta">-</div></div>
+          <div class="metric"><div class="metric-label">Last Updated</div><div class="metric-value" id="run-updated">-</div></div>
+        </div>
+        <div id="run-observations" class="muted"></div>
+        <div id="run-warning"></div>
+      </section>
+
+      <section class="card">
+        <h2>Failure Diagnostics</h2>
+        <div id="failure-summary" class="muted">No diagnostics loaded.</div>
+        <div id="failure-message" style="margin:12px 0;"></div>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Asset</th>
+                <th>Interval</th>
+                <th>Status</th>
+                <th>Bars</th>
+                <th>Folds</th>
+                <th>Drop Reason</th>
+              </tr>
+            </thead>
+            <tbody id="failure-table-body">
+              <tr><td colspan="6" class="muted">No diagnostics available.</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="card">
+        <h2>Results Explorer</h2>
+        <div class="controls">
+          <input id="results-search" type="search" placeholder="Search strategy or asset">
+          <select id="results-asset-filter">
+            <option value="">All assets</option>
+          </select>
+          <select id="results-interval-filter">
+            <option value="">All intervals</option>
+          </select>
+        </div>
+        <div id="results-meta" class="muted" style="margin-bottom:12px;">No research results loaded.</div>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th data-sort-key="strategy_name">Strategy</th>
+                <th data-sort-key="asset">Asset</th>
+                <th data-sort-key="interval">Interval</th>
+                <th data-sort-key="sharpe">Sharpe</th>
+                <th data-sort-key="deflated_sharpe">Deflated Sharpe</th>
+                <th data-sort-key="max_drawdown">Max Drawdown</th>
+                <th data-sort-key="totaal_trades">Trades</th>
+                <th data-sort-key="goedgekeurd">Approved</th>
+                <th data-sort-key="success">Success</th>
+              </tr>
+            </thead>
+            <tbody id="results-table-body">
+              <tr><td colspan="9" class="muted">No research results available.</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  </div>
+
+  <script src="/static/research_control_surface.js"></script>
+</body>
+</html>

--- a/research/observability.py
+++ b/research/observability.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import json
+import os
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Callable
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _run_id(started_at_utc: datetime) -> str:
+    return started_at_utc.astimezone(UTC).strftime("%Y%m%dT%H%M%S%fZ")
+
+
+class ProgressTracker:
+    """Lightweight progress sidecar + sparse console logging for research runs."""
+
+    def __init__(
+        self,
+        *,
+        path: Path,
+        started_at_utc: datetime | None = None,
+        now_source: Callable[[], datetime] | None = None,
+        monotonic_source: Callable[[], float] | None = None,
+        log_fn: Callable[[str], None] | None = None,
+    ) -> None:
+        self.path = path
+        self._now_source = now_source or _utc_now
+        self._monotonic_source = monotonic_source or time.monotonic
+        self._log_fn = log_fn or print
+        self.started_at_utc = (started_at_utc or self._now_source()).astimezone(UTC)
+        self.run_id = _run_id(self.started_at_utc)
+        self.status = "running"
+        self.current_stage = "starting"
+        self.current_item: dict[str, str | None] = {
+            "strategy": None,
+            "asset": None,
+            "interval": None,
+        }
+        self.completed = 0
+        self.total = 0
+        self.failure: dict[str, str | None] | None = None
+        self._stage_started_at_utc = self.started_at_utc
+        self._stage_started_monotonic = self._monotonic_source()
+        self._run_started_monotonic = self._stage_started_monotonic
+        self._last_updated_at_utc = self.started_at_utc
+        self._last_emitted_completed = -1
+        self._write_sidecar()
+
+    def start_stage(self, stage: str, *, total: int | None = None, **log_fields: Any) -> None:
+        self.current_stage = stage
+        self._stage_started_at_utc = self._now_source().astimezone(UTC)
+        self._stage_started_monotonic = self._monotonic_source()
+        if total is not None:
+            self.total = int(total)
+        self._last_updated_at_utc = self._stage_started_at_utc
+        self._write_sidecar()
+        self._log("stage", stage=stage, status="started", **log_fields)
+
+    def mark_stage_completed(self, **log_fields: Any) -> None:
+        self._last_updated_at_utc = self._now_source().astimezone(UTC)
+        self._write_sidecar()
+        self._log("stage", stage=self.current_stage, status="completed", **log_fields)
+
+    def begin_item(self, *, strategy: str, asset: str, interval: str) -> None:
+        self.current_item = {
+            "strategy": strategy,
+            "asset": asset,
+            "interval": interval,
+        }
+
+    def advance(self, *, completed: int | None = None, total: int | None = None) -> None:
+        if completed is not None:
+            self.completed = int(completed)
+        else:
+            self.completed += 1
+        if total is not None:
+            self.total = int(total)
+        if not self._should_emit_progress():
+            return
+        self._last_updated_at_utc = self._now_source().astimezone(UTC)
+        self._write_sidecar()
+        self._last_emitted_completed = self.completed
+        self._log(
+            "progress",
+            stage=self.current_stage,
+            progress=f"{self.completed}/{self.total}",
+            percent=self._percent(),
+            elapsed_s=self._elapsed_seconds(),
+            eta_s=self._eta_seconds(),
+            current=self._current_item_label(),
+        )
+
+    def complete(self) -> None:
+        self.status = "completed"
+        self.current_stage = "completed"
+        self.completed = self.total
+        self.current_item = {
+            "strategy": None,
+            "asset": None,
+            "interval": None,
+        }
+        self._last_updated_at_utc = self._now_source().astimezone(UTC)
+        self._write_sidecar()
+        self._log("stage", stage="completed", status="completed", elapsed_s=self._elapsed_seconds())
+
+    def fail(self, error: Exception, *, failure_stage: str | None = None) -> None:
+        self.status = "failed"
+        self.current_stage = "failed"
+        self.failure = {
+            "failure_stage": failure_stage or self.current_stage,
+            "error_type": type(error).__name__,
+            "error_message": str(error),
+        }
+        self._last_updated_at_utc = self._now_source().astimezone(UTC)
+        self._write_sidecar()
+        self._log(
+            "stage",
+            stage="failed",
+            status="failed",
+            failure_stage=self.failure["failure_stage"],
+            error_type=self.failure["error_type"],
+        )
+
+    def _should_emit_progress(self) -> bool:
+        if self.total <= 0:
+            return False
+        if self.completed == self._last_emitted_completed:
+            return False
+        if self.total <= 10:
+            return True
+        if self.completed in {1, self.total}:
+            return True
+        stride = max(1, (self.total + 9) // 10)
+        return self.completed % stride == 0
+
+    def _percent(self) -> float:
+        if self.total <= 0:
+            return 0.0
+        return round((self.completed / self.total) * 100.0, 2)
+
+    def _elapsed_seconds(self) -> int:
+        return max(0, int(round(self._monotonic_source() - self._run_started_monotonic)))
+
+    def _stage_elapsed_seconds(self) -> int:
+        return max(0, int(round(self._monotonic_source() - self._stage_started_monotonic)))
+
+    def _eta_seconds(self) -> int | None:
+        if self.status != "running" or self.current_stage != "evaluation":
+            return None
+        if self.completed <= 0 or self.total <= self.completed:
+            return 0 if self.total > 0 and self.completed >= self.total else None
+        pace = self._elapsed_seconds() / self.completed
+        return max(0, int(round(pace * (self.total - self.completed))))
+
+    def _current_item_label(self) -> str | None:
+        strategy = self.current_item["strategy"]
+        asset = self.current_item["asset"]
+        interval = self.current_item["interval"]
+        if not strategy or not asset or not interval:
+            return None
+        return f"{strategy} {asset} {interval}"
+
+    def _payload(self) -> dict[str, Any]:
+        return {
+            "version": "v1",
+            "status": self.status,
+            "run_id": self.run_id,
+            "current_stage": self.current_stage,
+            "started_at_utc": self.started_at_utc.isoformat(),
+            "last_updated_at_utc": self._last_updated_at_utc.isoformat(),
+            "progress": {
+                "completed": int(self.completed),
+                "total": int(self.total),
+                "percent": self._percent(),
+            },
+            "current_item": dict(self.current_item),
+            "timing": {
+                "elapsed_seconds": self._elapsed_seconds(),
+                "stage_elapsed_seconds": self._stage_elapsed_seconds(),
+                "eta_seconds": self._eta_seconds(),
+            },
+            "failure": self.failure,
+        }
+
+    def _write_sidecar(self) -> None:
+        payload = self._payload()
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = self.path.with_suffix(f"{self.path.suffix}.tmp")
+        with tmp_path.open("w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2)
+        try:
+            os.replace(tmp_path, self.path)
+        except PermissionError:
+            with self.path.open("w", encoding="utf-8") as handle:
+                json.dump(payload, handle, indent=2)
+            if tmp_path.exists():
+                tmp_path.unlink()
+
+    def _log(self, event: str, **fields: Any) -> None:
+        parts = [f"[research] {event}"]
+        for key, value in fields.items():
+            if value is None:
+                continue
+            parts.append(f"{key}={value}")
+        self._log_fn(" ".join(parts))

--- a/research/run_research.py
+++ b/research/run_research.py
@@ -8,7 +8,7 @@ import hashlib
 import json
 import os
 import subprocess
-from datetime import timezone
+from datetime import UTC, datetime, timezone
 from pathlib import Path
 
 import yaml
@@ -24,6 +24,7 @@ from research.empty_run_reporting import (
     DegenerateResearchRunError,
     build_empty_run_diagnostics_payload,
 )
+from research.observability import ProgressTracker
 from research.registry import get_enabled_strategies
 from research.results import make_result_row, write_latest_json, write_results_to_csv
 from research.portfolio_reporting import build_portfolio_aggregation_payload
@@ -39,6 +40,7 @@ UNIVERSE_SNAPSHOT_PATH = Path("research/universe_snapshot_latest.v1.json")
 PORTFOLIO_AGGREGATION_PATH = Path("research/portfolio_aggregation_latest.v1.json")
 REGIME_DIAGNOSTICS_PATH = Path("research/regime_diagnostics_latest.v1.json")
 EMPTY_RUN_DIAGNOSTICS_PATH = Path("research/empty_run_diagnostics_latest.v1.json")
+RUN_PROGRESS_PATH = Path("research/run_progress_latest.v1.json")
 
 
 def load_research_config(config_path="config/config.yaml"):
@@ -400,177 +402,201 @@ def _raise_degenerate_run(
 
 
 def run_research():
+    tracker = ProgressTracker(
+        path=RUN_PROGRESS_PATH,
+        started_at_utc=datetime.now(UTC),
+    )
     rows = []
     evaluations = []
     walk_forward_reports = []
     provenance_events = []
-    research_config = load_research_config()
-    regime_count, regime_count_source = regime_count_settings(research_config)
-    evaluation_config = normalize_evaluation_config(research_config.get("evaluation"))
-    assets, intervals, get_date_range, as_of_utc, universe_snapshot = build_research_universe(research_config)
-    _write_universe_snapshot_sidecar(universe_snapshot)
-    interval_ranges = {}
-    strategies = get_enabled_strategies()
+    try:
+        research_config = load_research_config()
+        regime_count, regime_count_source = regime_count_settings(research_config)
+        evaluation_config = normalize_evaluation_config(research_config.get("evaluation"))
+        assets, intervals, get_date_range, as_of_utc, universe_snapshot = build_research_universe(research_config)
+        _write_universe_snapshot_sidecar(universe_snapshot)
+        interval_ranges = {}
+        strategies = get_enabled_strategies()
+        total_items = len(strategies) * len(intervals) * len(assets)
 
-    for interval in intervals:
-        start_datum, eind_datum = get_date_range(interval)
-        interval_ranges[interval] = {"start": start_datum, "end": eind_datum}
-
-    pair_diagnostics: list[dict] = []
-    for interval in intervals:
-        start_datum = interval_ranges[interval]["start"]
-        eind_datum = interval_ranges[interval]["end"]
-        engine = _build_engine(
-            start_datum=start_datum,
-            eind_datum=eind_datum,
-            evaluation_config=evaluation_config,
-            regime_config=research_config.get("regime_diagnostics"),
-        )
-        pair_diagnostics.extend(_inspect_engine_readiness(engine, assets, interval))
-
-    evaluable_pair_count = sum(
-        1 for item in pair_diagnostics if item.get("status") == "evaluable"
-    )
-    if evaluable_pair_count == 0:
-        _raise_degenerate_run(
-            as_of_utc=as_of_utc,
-            failure_stage="preflight_no_evaluable_pairs",
-            assets=assets,
-            intervals=intervals,
-            interval_ranges=interval_ranges,
-            pair_diagnostics=pair_diagnostics,
-        )
-
-    for strategy in strategies:
+        tracker.start_stage("preflight", total=total_items)
         for interval in intervals:
-            for asset in assets:
-                start_datum = interval_ranges[interval]["start"]
-                eind_datum = interval_ranges[interval]["end"]
+            start_datum, eind_datum = get_date_range(interval)
+            interval_ranges[interval] = {"start": start_datum, "end": eind_datum}
 
-                engine = _build_engine(
-                    start_datum=start_datum,
-                    eind_datum=eind_datum,
-                    evaluation_config=evaluation_config,
-                    regime_config=research_config.get("regime_diagnostics"),
-                )
-                try:
-                    metrics = engine.grid_search(
-                        strategie_factory=strategy["factory"],
-                        param_grid=strategy["params"],
-                        assets=[asset.symbol],
-                        interval=interval,
-                    )
-                    params_used = metrics.get("beste_params", {})
-                    row = make_result_row(
-                        strategy=strategy,
+        pair_diagnostics: list[dict] = []
+        for interval in intervals:
+            start_datum = interval_ranges[interval]["start"]
+            eind_datum = interval_ranges[interval]["end"]
+            engine = _build_engine(
+                start_datum=start_datum,
+                eind_datum=eind_datum,
+                evaluation_config=evaluation_config,
+                regime_config=research_config.get("regime_diagnostics"),
+            )
+            pair_diagnostics.extend(_inspect_engine_readiness(engine, assets, interval))
+
+        evaluable_pair_count = sum(
+            1 for item in pair_diagnostics if item.get("status") == "evaluable"
+        )
+        tracker.mark_stage_completed(evaluable_pairs=evaluable_pair_count)
+        if evaluable_pair_count == 0:
+            _raise_degenerate_run(
+                as_of_utc=as_of_utc,
+                failure_stage="preflight_no_evaluable_pairs",
+                assets=assets,
+                intervals=intervals,
+                interval_ranges=interval_ranges,
+                pair_diagnostics=pair_diagnostics,
+            )
+
+        tracker.start_stage("evaluation", total=total_items, total_items=total_items)
+        completed_items = 0
+        for strategy in strategies:
+            for interval in intervals:
+                for asset in assets:
+                    tracker.begin_item(
+                        strategy=strategy["name"],
                         asset=asset.symbol,
                         interval=interval,
-                        params=params_used,
-                        as_of_utc=as_of_utc,
-                        metrics=metrics,
                     )
-                    evaluation_report = getattr(engine, "last_evaluation_report", None)
-                    if evaluation_report is not None:
-                        walk_forward_reports.append(
-                            _sidecar_strategy_entry(
-                                strategy=strategy,
-                                asset=asset.symbol,
-                                interval=interval,
-                                report=evaluation_report,
+                    start_datum = interval_ranges[interval]["start"]
+                    eind_datum = interval_ranges[interval]["end"]
+
+                    engine = _build_engine(
+                        start_datum=start_datum,
+                        eind_datum=eind_datum,
+                        evaluation_config=evaluation_config,
+                        regime_config=research_config.get("regime_diagnostics"),
+                    )
+                    try:
+                        metrics = engine.grid_search(
+                            strategie_factory=strategy["factory"],
+                            param_grid=strategy["params"],
+                            assets=[asset.symbol],
+                            interval=interval,
+                        )
+                        params_used = metrics.get("beste_params", {})
+                        row = make_result_row(
+                            strategy=strategy,
+                            asset=asset.symbol,
+                            interval=interval,
+                            params=params_used,
+                            as_of_utc=as_of_utc,
+                            metrics=metrics,
+                        )
+                        evaluation_report = getattr(engine, "last_evaluation_report", None)
+                        if evaluation_report is not None:
+                            walk_forward_reports.append(
+                                _sidecar_strategy_entry(
+                                    strategy=strategy,
+                                    asset=asset.symbol,
+                                    interval=interval,
+                                    report=evaluation_report,
+                                )
                             )
+                            evaluations.append(
+                                {
+                                    "family": strategy["family"],
+                                    "interval": interval,
+                                    "selected_params": json.loads(row["params_json"]),
+                                    "evaluation_report": evaluation_report,
+                                    "row": row,
+                                }
+                            )
+                    except (EvaluationScheduleError, FoldLeakageError):
+                        raise
+                    except Exception as e:
+                        row = make_result_row(
+                            strategy=strategy,
+                            asset=asset.symbol,
+                            interval=interval,
+                            params={},
+                            as_of_utc=as_of_utc,
+                            metrics={},
+                            error=str(e),
                         )
-                        evaluations.append(
-                            {
-                                "family": strategy["family"],
-                                "interval": interval,
-                                "selected_params": json.loads(row["params_json"]),
-                                "evaluation_report": evaluation_report,
-                                "row": row,
-                            }
-                        )
-                except (EvaluationScheduleError, FoldLeakageError):
-                    raise
-                except Exception as e:
-                    row = make_result_row(
-                        strategy=strategy,
-                        asset=asset.symbol,
-                        interval=interval,
-                        params={},
-                        as_of_utc=as_of_utc,
-                        metrics={},
-                        error=str(e),
-                    )
 
-                provenance_events.extend(getattr(engine, "_provenance_events", []))
-                rows.append(row)
-    evaluable_oos_daily_return_count = _count_evaluable_oos_daily_return_evaluations(
-        evaluations
-    )
-    if evaluations and evaluable_oos_daily_return_count == 0:
-        _raise_degenerate_run(
+                    provenance_events.extend(getattr(engine, "_provenance_events", []))
+                    rows.append(row)
+                    completed_items += 1
+                    tracker.advance(completed=completed_items, total=total_items)
+
+        tracker.mark_stage_completed(completed_items=completed_items)
+        evaluable_oos_daily_return_count = _count_evaluable_oos_daily_return_evaluations(
+            evaluations
+        )
+        if evaluations and evaluable_oos_daily_return_count == 0:
+            _raise_degenerate_run(
+                as_of_utc=as_of_utc,
+                failure_stage="postrun_no_oos_daily_returns",
+                assets=assets,
+                intervals=intervals,
+                interval_ranges=interval_ranges,
+                pair_diagnostics=pair_diagnostics,
+                evaluations_count=len(evaluations),
+                evaluations_with_oos_daily_returns=evaluable_oos_daily_return_count,
+            )
+
+        tracker.start_stage("writing_outputs", total=total_items)
+        write_results_to_csv(rows)
+        write_latest_json(rows, as_of_utc=as_of_utc)
+
+        if any(not report["leakage_checks_ok"] for report in walk_forward_reports):
+            raise FoldLeakageError("Leakage check failed; walk-forward sidecar will not be written")
+
+        _write_walk_forward_sidecar(
             as_of_utc=as_of_utc,
-            failure_stage="postrun_no_oos_daily_returns",
-            assets=assets,
-            intervals=intervals,
+            evaluation_config=evaluation_config,
+            strategy_reports=walk_forward_reports,
+        )
+        _write_provenance_sidecar(
+            research_config=research_config,
+            as_of_utc=as_of_utc,
             interval_ranges=interval_ranges,
-            pair_diagnostics=pair_diagnostics,
-            evaluations_count=len(evaluations),
-            evaluations_with_oos_daily_returns=evaluable_oos_daily_return_count,
+            provenance_events=provenance_events,
         )
 
-    write_results_to_csv(rows)
-    write_latest_json(rows, as_of_utc=as_of_utc)
+        successful_rows = [row for row in rows if row["success"]]
+        if evaluations and len(evaluations) != len(successful_rows):
+            raise RuntimeError(
+                "successful research rows are missing evaluation samples for statistical defensibility"
+            )
+        if evaluations and len(evaluations) == len(successful_rows):
+            _write_statistical_defensibility_sidecar(
+                evaluations=evaluations,
+                as_of_utc=as_of_utc,
+                intervals=intervals,
+                market_count=len(assets),
+                regime_count=regime_count,
+                regime_count_source=regime_count_source,
+            )
 
-    if any(not report["leakage_checks_ok"] for report in walk_forward_reports):
-        raise FoldLeakageError("Leakage check failed; walk-forward sidecar will not be written")
-
-    _write_walk_forward_sidecar(
-        as_of_utc=as_of_utc,
-        evaluation_config=evaluation_config,
-        strategy_reports=walk_forward_reports,
-    )
-    _write_provenance_sidecar(
-        research_config=research_config,
-        as_of_utc=as_of_utc,
-        interval_ranges=interval_ranges,
-        provenance_events=provenance_events,
-    )
-
-    successful_rows = [row for row in rows if row["success"]]
-    if evaluations and len(evaluations) != len(successful_rows):
-        raise RuntimeError(
-            "successful research rows are missing evaluation samples for statistical defensibility"
+        _write_candidate_registry(
+            rows=rows,
+            walk_forward_reports=walk_forward_reports,
+            research_config=research_config,
+            as_of_utc=as_of_utc,
         )
-    if evaluations and len(evaluations) == len(successful_rows):
-        _write_statistical_defensibility_sidecar(
+        _write_portfolio_aggregation_sidecar(
             evaluations=evaluations,
             as_of_utc=as_of_utc,
-            intervals=intervals,
-            market_count=len(assets),
-            regime_count=regime_count,
-            regime_count_source=regime_count_source,
         )
+        _write_regime_diagnostics_sidecar(
+            evaluations=evaluations,
+            as_of_utc=as_of_utc,
+            research_config=research_config,
+            evaluation_config=evaluation_config,
+            provenance_events=provenance_events,
+        )
+        tracker.mark_stage_completed()
+        tracker.complete()
+        print(f"Klaar. {len(rows)} resultaten geschreven.")
+    except Exception as exc:
+        tracker.fail(exc, failure_stage=tracker.current_stage)
+        raise
 
-    _write_candidate_registry(
-        rows=rows,
-        walk_forward_reports=walk_forward_reports,
-        research_config=research_config,
-        as_of_utc=as_of_utc,
-    )
-    _write_portfolio_aggregation_sidecar(
-        evaluations=evaluations,
-        as_of_utc=as_of_utc,
-    )
-    _write_regime_diagnostics_sidecar(
-        evaluations=evaluations,
-        as_of_utc=as_of_utc,
-        research_config=research_config,
-        evaluation_config=evaluation_config,
-        provenance_events=provenance_events,
-    )
-
-    print(f"Klaar. {len(rows)} resultaten geschreven.")
-    
 if __name__ == "__main__":
     run_research()
 

--- a/tests/unit/test_dashboard_research_api.py
+++ b/tests/unit/test_dashboard_research_api.py
@@ -1,0 +1,326 @@
+from datetime import UTC, datetime, timedelta
+
+
+class _FakeProcess:
+    def __init__(self, pid=4321, returncode=None):
+        self.pid = pid
+        self._returncode = returncode
+
+    def poll(self):
+        return self._returncode
+
+
+def _set_operator_session(client):
+    with client.session_transaction() as sess:
+        sess["operator_authenticated"] = True
+        sess["operator_actor"] = "joery"
+
+
+class _UnreadablePath:
+    def exists(self):
+        return True
+
+    def stat(self):
+        return type("Stat", (), {"st_mtime": 0})()
+
+    def read_text(self, encoding="utf-8"):
+        raise OSError("cannot read")
+
+    def relative_to(self, _base):
+        raise ValueError
+
+    def __str__(self):
+        return "unreadable.json"
+
+
+def test_research_routes_require_auth():
+    from dashboard import dashboard as dash
+
+    dash.app.testing = True
+    client = dash.app.test_client()
+
+    for route in (
+        "/research",
+        "/api/research/run-status",
+        "/api/research/latest",
+        "/api/research/empty-run-diagnostics",
+        "/api/research/universe",
+    ):
+        response = client.get(route)
+        assert response.status_code == 401
+
+
+def test_research_run_status_endpoint_without_sidecar(monkeypatch, tmp_path):
+    from dashboard import dashboard as dash
+
+    monkeypatch.setattr(dash.research_artifacts, "RUN_PROGRESS_PATH", tmp_path / "missing.json")
+    monkeypatch.setattr(dash.research_runner, "_ACTIVE_PROCESS", None)
+
+    dash.app.testing = True
+    client = dash.app.test_client()
+    _set_operator_session(client)
+    response = client.get("/api/research/run-status")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["artifact_state"] == "absent"
+    assert payload["dashboard_observations"]["local_process_active"] is False
+    assert payload["artifact"] is None
+
+
+def test_research_run_status_endpoint_with_valid_sidecar(monkeypatch, tmp_path):
+    from dashboard import dashboard as dash
+
+    now = datetime.now(UTC)
+    path = tmp_path / "run_progress_latest.v1.json"
+    path.write_text(
+        (
+            "{"
+            "\"version\":\"v1\","
+            "\"status\":\"running\","
+            "\"run_id\":\"20260413T100000000000Z\","
+            "\"current_stage\":\"evaluation\","
+            f"\"started_at_utc\":\"{(now - timedelta(seconds=180)).isoformat()}\","
+            f"\"last_updated_at_utc\":\"{now.isoformat()}\","
+            "\"progress\":{\"completed\":5,\"total\":10,\"percent\":50.0},"
+            "\"current_item\":{\"strategy\":\"sma\",\"asset\":\"BTC-USD\",\"interval\":\"1h\"},"
+            "\"timing\":{\"elapsed_seconds\":180,\"stage_elapsed_seconds\":120,\"eta_seconds\":180},"
+            "\"failure\":null"
+            "}"
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(dash.research_artifacts, "RUN_PROGRESS_PATH", path)
+    monkeypatch.setattr(dash.research_runner, "_ACTIVE_PROCESS", None)
+
+    dash.app.testing = True
+    client = dash.app.test_client()
+    _set_operator_session(client)
+    response = client.get("/api/research/run-status")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["artifact_state"] == "valid"
+    assert payload["artifact"]["status"] == "running"
+    assert payload["dashboard_observations"]["recent_progress_signal"] is True
+
+
+def test_research_run_status_endpoint_with_stale_running_sidecar(monkeypatch, tmp_path):
+    from dashboard import dashboard as dash
+
+    now = datetime.now(UTC)
+    stale_at = (now - timedelta(seconds=601)).isoformat()
+    path = tmp_path / "run_progress_latest.v1.json"
+    path.write_text(
+        (
+            "{"
+            f"\"version\":\"v1\",\"status\":\"running\",\"last_updated_at_utc\":\"{stale_at}\""
+            "}"
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(dash.research_artifacts, "RUN_PROGRESS_PATH", path)
+    monkeypatch.setattr(dash.research_runner, "_ACTIVE_PROCESS", None)
+
+    dash.app.testing = True
+    client = dash.app.test_client()
+    _set_operator_session(client)
+    response = client.get("/api/research/run-status")
+
+    payload = response.get_json()
+    assert payload["dashboard_observations"]["stale_progress_signal"] is True
+    assert payload["warnings"]
+
+
+def test_research_run_status_endpoint_with_invalid_json(monkeypatch, tmp_path):
+    from dashboard import dashboard as dash
+
+    path = tmp_path / "run_progress_latest.v1.json"
+    path.write_text("{ invalid", encoding="utf-8")
+    monkeypatch.setattr(dash.research_artifacts, "RUN_PROGRESS_PATH", path)
+
+    dash.app.testing = True
+    client = dash.app.test_client()
+    _set_operator_session(client)
+    response = client.get("/api/research/run-status")
+
+    payload = response.get_json()
+    assert payload["artifact_state"] == "invalid_json"
+    assert payload["artifact_error"]
+
+
+def test_research_run_trigger_accepted_when_idle(monkeypatch, tmp_path):
+    from dashboard import dashboard as dash
+
+    monkeypatch.setattr(dash.research_artifacts, "RUN_PROGRESS_PATH", tmp_path / "missing.json")
+    monkeypatch.setattr(dash.research_runner, "_ACTIVE_PROCESS", None)
+    monkeypatch.setattr(
+        dash.research_runner.subprocess,
+        "Popen",
+        lambda *args, **kwargs: _FakeProcess(pid=999, returncode=None),
+    )
+
+    dash.app.testing = True
+    client = dash.app.test_client()
+    _set_operator_session(client)
+    response = client.post("/api/research/run")
+
+    assert response.status_code == 202
+    payload = response.get_json()
+    assert payload["accepted"] is True
+    assert payload["launch_state"] == "started"
+    assert payload["pid"] == 999
+
+
+def test_research_run_trigger_blocked_when_process_active(monkeypatch, tmp_path):
+    from dashboard import dashboard as dash
+
+    monkeypatch.setattr(dash.research_artifacts, "RUN_PROGRESS_PATH", tmp_path / "missing.json")
+    monkeypatch.setattr(dash.research_runner, "_ACTIVE_PROCESS", _FakeProcess(returncode=None))
+
+    dash.app.testing = True
+    client = dash.app.test_client()
+    _set_operator_session(client)
+    response = client.post("/api/research/run")
+
+    assert response.status_code == 409
+    payload = response.get_json()
+    assert payload["accepted"] is False
+    assert payload["launch_state"] == "blocked_active_run"
+
+
+def test_research_run_trigger_returns_stale_signal_behavior(monkeypatch, tmp_path):
+    from dashboard import dashboard as dash
+
+    stale_at = (datetime.now(UTC) - timedelta(seconds=600)).isoformat()
+    path = tmp_path / "run_progress_latest.v1.json"
+    path.write_text(
+        (
+            "{"
+            f"\"version\":\"v1\",\"status\":\"running\",\"last_updated_at_utc\":\"{stale_at}\""
+            "}"
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(dash.research_artifacts, "RUN_PROGRESS_PATH", path)
+    monkeypatch.setattr(dash.research_runner, "_ACTIVE_PROCESS", None)
+
+    dash.app.testing = True
+    client = dash.app.test_client()
+    _set_operator_session(client)
+    response = client.post("/api/research/run")
+
+    assert response.status_code == 409
+    payload = response.get_json()
+    assert payload["accepted"] is False
+    assert payload["launch_state"] == "blocked_stale_signal"
+
+
+def test_research_latest_endpoint_valid_artifact(monkeypatch, tmp_path):
+    from dashboard import dashboard as dash
+
+    path = tmp_path / "research_latest.json"
+    path.write_text(
+        '{"generated_at_utc":"2026-04-13T10:00:00+00:00","count":1,"results":[{"strategy_name":"sma"}]}',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(dash.research_artifacts, "RESEARCH_LATEST_PATH", path)
+
+    dash.app.testing = True
+    client = dash.app.test_client()
+    _set_operator_session(client)
+    response = client.get("/api/research/latest")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["artifact_state"] == "valid"
+    assert payload["artifact"]["count"] == 1
+    assert payload["artifact"]["results"][0]["strategy_name"] == "sma"
+
+
+def test_research_latest_endpoint_invalid_artifact(monkeypatch, tmp_path):
+    from dashboard import dashboard as dash
+
+    path = tmp_path / "research_latest.json"
+    path.write_text("{broken", encoding="utf-8")
+    monkeypatch.setattr(dash.research_artifacts, "RESEARCH_LATEST_PATH", path)
+
+    dash.app.testing = True
+    client = dash.app.test_client()
+    _set_operator_session(client)
+    response = client.get("/api/research/latest")
+
+    payload = response.get_json()
+    assert payload["artifact_state"] == "invalid_json"
+    assert payload["artifact"] is None
+
+
+def test_empty_run_diagnostics_endpoint_absent_and_present(monkeypatch, tmp_path):
+    from dashboard import dashboard as dash
+
+    missing = tmp_path / "missing.json"
+    monkeypatch.setattr(dash.research_artifacts, "EMPTY_RUN_DIAGNOSTICS_PATH", missing)
+
+    dash.app.testing = True
+    client = dash.app.test_client()
+    _set_operator_session(client)
+    absent_response = client.get("/api/research/empty-run-diagnostics")
+    assert absent_response.get_json()["artifact_state"] == "absent"
+
+    present = tmp_path / "empty_run_diagnostics_latest.v1.json"
+    present.write_text('{"version":"v1","failure_stage":"preflight","pairs":[]}', encoding="utf-8")
+    monkeypatch.setattr(dash.research_artifacts, "EMPTY_RUN_DIAGNOSTICS_PATH", present)
+
+    present_response = client.get("/api/research/empty-run-diagnostics")
+    payload = present_response.get_json()
+    assert payload["artifact_state"] == "valid"
+    assert payload["artifact"]["failure_stage"] == "preflight"
+
+
+def test_universe_endpoint_valid_artifact(monkeypatch, tmp_path):
+    from dashboard import dashboard as dash
+
+    path = tmp_path / "universe_snapshot_latest.v1.json"
+    path.write_text('{"version":"v1","intervals":["1h","4h"]}', encoding="utf-8")
+    monkeypatch.setattr(dash.research_artifacts, "UNIVERSE_SNAPSHOT_PATH", path)
+
+    dash.app.testing = True
+    client = dash.app.test_client()
+    _set_operator_session(client)
+    response = client.get("/api/research/universe")
+
+    payload = response.get_json()
+    assert payload["artifact_state"] == "valid"
+    assert payload["artifact"]["intervals"] == ["1h", "4h"]
+
+
+def test_research_latest_endpoint_unreadable_artifact(monkeypatch):
+    from dashboard import dashboard as dash
+
+    monkeypatch.setattr(dash.research_artifacts, "RESEARCH_LATEST_PATH", _UnreadablePath())
+
+    dash.app.testing = True
+    client = dash.app.test_client()
+    _set_operator_session(client)
+    response = client.get("/api/research/latest")
+
+    payload = response.get_json()
+    assert payload["artifact_state"] == "unreadable"
+    assert payload["artifact_error"] == "cannot read"
+
+
+def test_research_latest_endpoint_empty_artifact(monkeypatch, tmp_path):
+    from dashboard import dashboard as dash
+
+    path = tmp_path / "research_latest.json"
+    path.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(dash.research_artifacts, "RESEARCH_LATEST_PATH", path)
+
+    dash.app.testing = True
+    client = dash.app.test_client()
+    _set_operator_session(client)
+    response = client.get("/api/research/latest")
+
+    payload = response.get_json()
+    assert payload["artifact_state"] == "empty"
+    assert payload["artifact"] == {}

--- a/tests/unit/test_research_observability.py
+++ b/tests/unit/test_research_observability.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from research.observability import ProgressTracker
+
+
+class FakeClock:
+    def __init__(self, start: datetime) -> None:
+        self.current = start
+        self.mono = 0.0
+
+    def now(self) -> datetime:
+        return self.current
+
+    def monotonic(self) -> float:
+        return self.mono
+
+    def advance(self, seconds: int) -> None:
+        self.current += timedelta(seconds=seconds)
+        self.mono += float(seconds)
+
+
+def _load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_progress_sidecar_has_deterministic_structure_and_eta(tmp_path: Path):
+    start = datetime(2026, 4, 13, 12, 0, 0, tzinfo=UTC)
+    clock = FakeClock(start)
+    logs: list[str] = []
+    path = tmp_path / "research" / "run_progress_latest.v1.json"
+    tracker = ProgressTracker(
+        path=path,
+        started_at_utc=start,
+        now_source=clock.now,
+        monotonic_source=clock.monotonic,
+        log_fn=logs.append,
+    )
+
+    tracker.start_stage("evaluation", total=4, total_items=4)
+    tracker.begin_item(strategy="sma_crossover", asset="BTC-USD", interval="1h")
+    clock.advance(5)
+    tracker.advance(completed=1, total=4)
+
+    payload = _load_json(path)
+    assert payload == {
+        "version": "v1",
+        "status": "running",
+        "run_id": "20260413T120000000000Z",
+        "current_stage": "evaluation",
+        "started_at_utc": "2026-04-13T12:00:00+00:00",
+        "last_updated_at_utc": "2026-04-13T12:00:05+00:00",
+        "progress": {
+            "completed": 1,
+            "total": 4,
+            "percent": 25.0,
+        },
+        "current_item": {
+            "strategy": "sma_crossover",
+            "asset": "BTC-USD",
+            "interval": "1h",
+        },
+        "timing": {
+            "elapsed_seconds": 5,
+            "stage_elapsed_seconds": 5,
+            "eta_seconds": 15,
+        },
+        "failure": None,
+    }
+    assert logs[0] == "[research] stage stage=evaluation status=started total_items=4"
+    assert logs[1] == (
+        "[research] progress stage=evaluation progress=1/4 percent=25.0 "
+        "elapsed_s=5 eta_s=15 current=sma_crossover BTC-USD 1h"
+    )
+
+
+def test_completed_state_is_written_correctly(tmp_path: Path):
+    start = datetime(2026, 4, 13, 12, 0, 0, tzinfo=UTC)
+    clock = FakeClock(start)
+    path = tmp_path / "research" / "run_progress_latest.v1.json"
+    tracker = ProgressTracker(
+        path=path,
+        started_at_utc=start,
+        now_source=clock.now,
+        monotonic_source=clock.monotonic,
+        log_fn=lambda message: None,
+    )
+
+    tracker.start_stage("writing_outputs", total=3)
+    clock.advance(9)
+    tracker.complete()
+
+    payload = _load_json(path)
+    assert payload["status"] == "completed"
+    assert payload["current_stage"] == "completed"
+    assert payload["progress"] == {"completed": 3, "total": 3, "percent": 100.0}
+    assert payload["failure"] is None
+    assert payload["timing"]["elapsed_seconds"] == 9
+
+
+def test_failed_state_is_written_correctly(tmp_path: Path):
+    start = datetime(2026, 4, 13, 12, 0, 0, tzinfo=UTC)
+    clock = FakeClock(start)
+    path = tmp_path / "research" / "run_progress_latest.v1.json"
+    tracker = ProgressTracker(
+        path=path,
+        started_at_utc=start,
+        now_source=clock.now,
+        monotonic_source=clock.monotonic,
+        log_fn=lambda message: None,
+    )
+
+    tracker.start_stage("preflight", total=10)
+    clock.advance(2)
+    tracker.fail(RuntimeError("boom"), failure_stage="preflight")
+
+    payload = _load_json(path)
+    assert payload["status"] == "failed"
+    assert payload["current_stage"] == "failed"
+    assert payload["failure"] == {
+        "failure_stage": "preflight",
+        "error_type": "RuntimeError",
+        "error_message": "boom",
+    }
+    assert payload["timing"]["elapsed_seconds"] == 2
+
+
+def test_large_evaluation_progress_is_throttled(tmp_path: Path):
+    start = datetime(2026, 4, 13, 12, 0, 0, tzinfo=UTC)
+    clock = FakeClock(start)
+    path = tmp_path / "research" / "run_progress_latest.v1.json"
+    tracker = ProgressTracker(
+        path=path,
+        started_at_utc=start,
+        now_source=clock.now,
+        monotonic_source=clock.monotonic,
+        log_fn=lambda message: None,
+    )
+
+    tracker.start_stage("evaluation", total=100)
+    tracker.begin_item(strategy="rsi", asset="BTC-USD", interval="1h")
+    clock.advance(1)
+    tracker.advance(completed=1, total=100)
+    first = _load_json(path)
+
+    tracker.begin_item(strategy="rsi", asset="ETH-USD", interval="1h")
+    clock.advance(1)
+    tracker.advance(completed=2, total=100)
+    second = _load_json(path)
+
+    assert first["progress"]["completed"] == 1
+    assert second["progress"]["completed"] == 1

--- a/tests/unit/test_run_research_observability.py
+++ b/tests/unit/test_run_research_observability.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import csv
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from research import run_research as run_research_module
+from research.empty_run_reporting import DegenerateResearchRunError
+from research.results import make_result_row, write_latest_json, write_results_to_csv
+
+
+AS_OF_UTC = datetime(2026, 4, 13, 12, 0, 0, tzinfo=UTC)
+ROW_SCHEMA = list(
+    make_result_row(
+        strategy={"name": "schema", "family": "trend", "hypothesis": "schema"},
+        asset="BTC-USD",
+        interval="1d",
+        params={},
+        as_of_utc=AS_OF_UTC,
+        metrics={},
+    ).keys()
+)
+
+
+def _load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _patch_common_runner(monkeypatch, tmp_path: Path, engine_cls) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "research").mkdir()
+    monkeypatch.setattr(run_research_module, "BacktestEngine", engine_cls)
+    monkeypatch.setattr(
+        run_research_module,
+        "get_enabled_strategies",
+        lambda: [
+            {
+                "name": "fake_strategy",
+                "family": "trend",
+                "hypothesis": "Fixture hypothesis",
+                "factory": lambda **params: None,
+                "params": {"periode": [14]},
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        run_research_module,
+        "build_research_universe",
+        lambda config: (
+            [SimpleNamespace(symbol="BTC-USD")],
+            ["1d"],
+            lambda interval: ("2026-01-01", "2026-02-01"),
+            AS_OF_UTC,
+            {"version": "v1", "resolved_count": 1},
+        ),
+    )
+    monkeypatch.setattr(
+        run_research_module,
+        "load_research_config",
+        lambda config_path="config/config.yaml": {},
+    )
+    monkeypatch.setattr(run_research_module, "_git_revision", lambda: "deadbeef")
+    monkeypatch.setattr(run_research_module, "_write_provenance_sidecar", lambda **kwargs: None)
+    monkeypatch.setattr(run_research_module, "_write_statistical_defensibility_sidecar", lambda **kwargs: None)
+    monkeypatch.setattr(run_research_module, "_write_candidate_registry", lambda **kwargs: None)
+    monkeypatch.setattr(run_research_module, "_write_portfolio_aggregation_sidecar", lambda **kwargs: None)
+    monkeypatch.setattr(run_research_module, "_write_regime_diagnostics_sidecar", lambda **kwargs: None)
+    monkeypatch.setattr(
+        run_research_module,
+        "write_results_to_csv",
+        lambda rows: write_results_to_csv(rows, path=tmp_path / "research" / "strategy_matrix.csv"),
+    )
+    monkeypatch.setattr(
+        run_research_module,
+        "write_latest_json",
+        lambda rows, as_of_utc: write_latest_json(
+            rows,
+            as_of_utc=as_of_utc,
+            path=tmp_path / "research" / "research_latest.json",
+        ),
+    )
+
+
+class _HealthyEngine:
+    def __init__(self, start_datum, eind_datum, evaluation_config=None, regime_config=None):
+        self.start = start_datum
+        self.end = eind_datum
+        self._provenance_events = []
+        self.last_evaluation_report = None
+
+    def inspect_asset_readiness(self, assets, interval):
+        return [
+            {
+                "asset": asset,
+                "interval": interval,
+                "requested_start": self.start,
+                "requested_end": self.end,
+                "bar_count": 700,
+                "fold_count": 2,
+                "status": "evaluable",
+                "drop_reason": None,
+            }
+            for asset in assets
+        ]
+
+    def grid_search(self, strategie_factory, param_grid, assets, interval="1d"):
+        self.last_evaluation_report = {
+            "evaluation_config": {
+                "mode": "anchored",
+                "selection_metric": "sharpe",
+                "initial_train_bars": 500,
+                "test_bars": 100,
+                "step_bars": 100,
+            },
+            "selection_metric": "sharpe",
+            "selected_params": {"periode": 14},
+            "is_summary": {
+                "win_rate": 0.6,
+                "sharpe": 1.2,
+                "deflated_sharpe": 1.0,
+                "max_drawdown": 0.1,
+                "trades_per_maand": 3.0,
+                "consistentie": 0.7,
+                "totaal_trades": 12,
+                "goedgekeurd": True,
+                "criteria_checks": {},
+            },
+            "oos_summary": {
+                "win_rate": 0.55,
+                "sharpe": 1.1,
+                "deflated_sharpe": 0.9,
+                "max_drawdown": 0.12,
+                "trades_per_maand": 2.5,
+                "consistentie": 0.65,
+                "totaal_trades": 12,
+                "goedgekeurd": True,
+                "criteria_checks": {},
+            },
+            "folds": [{"train": [0, 499], "test": [500, 599], "leakage_ok": True}],
+            "leakage_checks_ok": True,
+            "evaluation_samples": {
+                "daily_returns": [0.01, -0.005, 0.003],
+                "trade_pnls": [0.02, -0.01],
+                "monthly_returns": [0.008],
+            },
+            "evaluation_streams": {
+                "oos_daily_returns": [
+                    {"timestamp_utc": "2026-01-02T00:00:00+00:00", "return": 0.01},
+                    {"timestamp_utc": "2026-01-03T00:00:00+00:00", "return": -0.005},
+                    {"timestamp_utc": "2026-01-04T00:00:00+00:00", "return": 0.003},
+                ],
+                "oos_bar_returns": [],
+                "oos_trade_events": [],
+            },
+            "sample_statistics": {
+                "daily_returns": {"count": 3, "mean": 0.0027, "std": 0.006, "skew": 0.0, "kurt": 3.0},
+            },
+        }
+        return {
+            "beste_params": {"periode": 14},
+            "win_rate": 0.55,
+            "sharpe": 1.1,
+            "deflated_sharpe": 0.9,
+            "max_drawdown": 0.12,
+            "trades_per_maand": 2.5,
+            "consistentie": 0.65,
+            "totaal_trades": 12,
+            "goedgekeurd": True,
+            "criteria_checks": {},
+            "reden": "",
+        }
+
+
+class _DegenerateEngine:
+    def __init__(self, start_datum, eind_datum, evaluation_config=None, regime_config=None):
+        self.start = start_datum
+        self.eind = eind_datum
+        self._provenance_events = []
+        self.last_evaluation_report = None
+
+    def inspect_asset_readiness(self, assets, interval):
+        return [
+            {
+                "asset": asset,
+                "interval": interval,
+                "requested_start": self.start,
+                "requested_end": self.eind,
+                "bar_count": 0,
+                "fold_count": 0,
+                "status": "dropped",
+                "drop_reason": "empty_dataset",
+            }
+            for asset in assets
+        ]
+
+    def grid_search(self, strategie_factory, param_grid, assets, interval="1d"):
+        raise AssertionError("grid_search should not run for preflight failure")
+
+
+def test_run_research_writes_completed_progress_sidecar_and_keeps_public_schema(monkeypatch, tmp_path: Path):
+    _patch_common_runner(monkeypatch, tmp_path, _HealthyEngine)
+
+    run_research_module.run_research()
+
+    progress = _load_json(tmp_path / "research" / "run_progress_latest.v1.json")
+    public_json = _load_json(tmp_path / "research" / "research_latest.json")
+    with (tmp_path / "research" / "strategy_matrix.csv").open(encoding="utf-8", newline="") as handle:
+        csv_rows = list(csv.DictReader(handle))
+
+    assert progress["version"] == "v1"
+    assert progress["status"] == "completed"
+    assert progress["current_stage"] == "completed"
+    assert progress["progress"] == {"completed": 1, "total": 1, "percent": 100.0}
+    assert progress["failure"] is None
+    assert list(public_json["results"][0].keys()) == ROW_SCHEMA
+    assert list(csv_rows[0].keys()) == ROW_SCHEMA
+
+
+def test_run_research_marks_failed_progress_sidecar_on_degenerate_run(monkeypatch, tmp_path: Path):
+    _patch_common_runner(monkeypatch, tmp_path, _DegenerateEngine)
+
+    with pytest.raises(DegenerateResearchRunError, match="preflight_no_evaluable_pairs"):
+        run_research_module.run_research()
+
+    progress = _load_json(tmp_path / "research" / "run_progress_latest.v1.json")
+    assert progress["status"] == "failed"
+    assert progress["current_stage"] == "failed"
+    assert progress["failure"]["failure_stage"] == "preflight"
+    assert progress["failure"]["error_type"] == "DegenerateResearchRunError"


### PR DESCRIPTION
Title:
feat: add dashboard research control surface

Summary:
This PR introduces a minimal, Flask-based research control surface integrated into the existing dashboard.

Key features:

* New authenticated page: /research
* Artifact-first research APIs:

  * GET /api/research/run-status
  * POST /api/research/run
  * GET /api/research/latest
  * GET /api/research/empty-run-diagnostics
  * GET /api/research/universe
* Run Monitor (progress sidecar driven)
* Failure Diagnostics (empty-run diagnostics)
* Results Explorer (research_latest.json)

Architecture:

* Dashboard remains a control surface (read + trigger only)
* Research layer remains the source of truth
* No changes to:

  * research/run_research.py
  * strategy / promotion / regime / portfolio logic
  * public research output schemas
* No new web stack or frontend framework

Observability:

* Fully aligned with artifact-first design
* Progress, diagnostics, and results are consumed directly from sidecars
* Dashboard adds only non-authoritative local observations

Validation:

* Dashboard tests:
  pytest tests/unit/test_dashboard_research_api.py tests/unit/test_dashboard_auth.py tests/unit/test_dashboard_prices.py -q
* Schema regressions:
  pytest tests/regression/test_research_schema_stability.py tests/regression/test_research_schema_guard.py -q
* Full suite:
  pytest -q

All tests passing:

* 382 passed, 1 skipped

Notes:

* All research endpoints are now auth-protected
* Artifact handling explicitly distinguishes absent/unreadable/invalid/empty/valid states
* Dashboard runner is intentionally thin and non-authoritative

Scope:

* Minimal V1 control surface only
* No portfolio/regime/analytics extensions
