### PR TITLE
feat: add file-driven research run state and observability

### DIFF
--- a/dashboard/dashboard.py
+++ b/dashboard/dashboard.py
@@ -266,8 +266,7 @@ def research_control_surface():
 @app.route("/api/research/run-status")
 @requires_auth
 def api_research_run_status():
-    artifact = research_artifacts.load_run_progress_artifact()
-    return jsonify(research_runner.build_run_status_response(artifact))
+    return jsonify(research_runner.build_run_status_response())
 
 
 @app.route("/api/research/latest")
@@ -291,8 +290,7 @@ def api_research_universe():
 @app.route("/api/research/run", methods=["POST"])
 @require_operator_auth()
 def api_research_run():
-    artifact = research_artifacts.load_run_progress_artifact()
-    payload, status_code = research_runner.launch_research_run(artifact)
+    payload, status_code = research_runner.launch_research_run()
     return jsonify(payload), status_code
 
 

--- a/dashboard/research_artifacts.py
+++ b/dashboard/research_artifacts.py
@@ -7,7 +7,9 @@ from pathlib import Path
 from typing import Any
 
 BASE_DIR = Path(__file__).resolve().parent.parent
+RUN_STATE_PATH = BASE_DIR / "research" / "run_state.v1.json"
 RUN_PROGRESS_PATH = BASE_DIR / "research" / "run_progress_latest.v1.json"
+RUN_MANIFEST_PATH = BASE_DIR / "research" / "run_manifest_latest.v1.json"
 RESEARCH_LATEST_PATH = BASE_DIR / "research" / "research_latest.json"
 EMPTY_RUN_DIAGNOSTICS_PATH = (
     BASE_DIR / "research" / "empty_run_diagnostics_latest.v1.json"
@@ -78,6 +80,14 @@ def load_json_artifact(path: Path) -> dict[str, Any]:
 
 def load_run_progress_artifact() -> dict[str, Any]:
     return load_json_artifact(RUN_PROGRESS_PATH)
+
+
+def load_run_state_artifact() -> dict[str, Any]:
+    return load_json_artifact(RUN_STATE_PATH)
+
+
+def load_run_manifest_artifact() -> dict[str, Any]:
+    return load_json_artifact(RUN_MANIFEST_PATH)
 
 
 def load_research_latest_artifact() -> dict[str, Any]:

--- a/dashboard/research_runner.py
+++ b/dashboard/research_runner.py
@@ -2,23 +2,21 @@ from __future__ import annotations
 
 import subprocess
 import sys
-import threading
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-BASE_DIR = Path(__file__).resolve().parent.parent
-STALE_HEARTBEAT_SECONDS = 300
+from dashboard import research_artifacts
+from research.run_state import RunStateStore
 
-_RUN_LOCK = threading.Lock()
-_ACTIVE_PROCESS: subprocess.Popen[str] | None = None
+BASE_DIR = Path(__file__).resolve().parent.parent
 
 
 def _utc_now() -> datetime:
     return datetime.now(UTC)
 
 
-def _parse_iso_datetime(value: Any) -> datetime | None:
+def _parse_datetime(value: Any) -> datetime | None:
     if not isinstance(value, str) or value.strip() == "":
         return None
     try:
@@ -27,101 +25,74 @@ def _parse_iso_datetime(value: Any) -> datetime | None:
         return None
 
 
-def _current_process() -> subprocess.Popen[str] | None:
-    with _RUN_LOCK:
-        process = _ACTIVE_PROCESS
-        if process is not None and process.poll() is not None:
-            return None
-        return process
-
-
-def local_process_active() -> bool:
-    return _current_process() is not None
-
-
-def dashboard_observations(
-    run_status_artifact: dict[str, Any],
+def _build_observations(
     *,
-    now: datetime | None = None,
+    state_artifact: dict[str, Any],
+    repair_result: dict[str, Any],
 ) -> dict[str, Any]:
-    artifact = run_status_artifact.get("artifact")
-    heartbeat_at = (
-        _parse_iso_datetime(artifact.get("last_updated_at_utc"))
-        if isinstance(artifact, dict)
-        else None
-    )
-    age_seconds = None
-    if heartbeat_at is not None:
-        age_seconds = max(0, int(round(((now or _utc_now()) - heartbeat_at).total_seconds())))
-
-    artifact_status = artifact.get("status") if isinstance(artifact, dict) else None
-    local_active = local_process_active()
-    recent_signal = (
-        artifact_status == "running"
-        and age_seconds is not None
-        and age_seconds <= STALE_HEARTBEAT_SECONDS
-    )
-    stale_signal = (
-        artifact_status == "running"
-        and not local_active
-        and (age_seconds is None or age_seconds > STALE_HEARTBEAT_SECONDS)
-    )
+    artifact = state_artifact.get("artifact")
+    status = artifact.get("status") if isinstance(artifact, dict) else None
     return {
-        "local_process_active": local_active,
-        "artifact_status": artifact_status,
-        "progress_heartbeat_age_seconds": age_seconds,
-        "recent_progress_signal": recent_signal,
-        "stale_progress_signal": stale_signal,
-        "stale_heartbeat_threshold_seconds": STALE_HEARTBEAT_SECONDS,
+        "authoritative_status": status,
+        "pid_live": repair_result.get("pid_live"),
+        "heartbeat_age_seconds": repair_result.get("heartbeat_age_seconds"),
+        "stale_state_repaired": bool(repair_result.get("repaired")),
+        "repair_reason": repair_result.get("repair_reason"),
     }
 
 
-def build_run_status_response(
-    run_status_artifact: dict[str, Any],
-    *,
-    now: datetime | None = None,
-) -> dict[str, Any]:
-    observations = dashboard_observations(run_status_artifact, now=now)
+def build_run_status_response(*, now: datetime | None = None) -> dict[str, Any]:
+    lifecycle = RunStateStore(
+        state_path=research_artifacts.RUN_STATE_PATH,
+        history_root=research_artifacts.RUN_STATE_PATH.parent / "history",
+    )
+    repair_result = lifecycle.repair_stale_run()
+    state_artifact = research_artifacts.load_run_state_artifact()
+    progress_artifact = research_artifacts.load_run_progress_artifact()
     warnings: list[str] = []
-    if observations["stale_progress_signal"]:
+    if repair_result.get("repaired"):
         warnings.append(
-            "Progress artifact reports running but no active local process was detected and the heartbeat appears stale."
+            f"Recovered stale running state via {repair_result['repair_reason']}."
         )
     return {
-        **run_status_artifact,
-        "dashboard_observations": observations,
+        "run_state": state_artifact,
+        "run_progress": progress_artifact,
+        "dashboard_observations": _build_observations(
+            state_artifact=state_artifact,
+            repair_result=repair_result,
+        ),
         "warnings": warnings,
+        "as_of_utc": (now or _utc_now()).isoformat(),
     }
 
 
-def launch_research_run(
-    run_status_artifact: dict[str, Any],
-    *,
-    now: datetime | None = None,
-) -> tuple[dict[str, Any], int]:
-    observations = dashboard_observations(run_status_artifact, now=now)
+def launch_research_run(*, now: datetime | None = None) -> tuple[dict[str, Any], int]:
+    lifecycle = RunStateStore(
+        state_path=research_artifacts.RUN_STATE_PATH,
+        history_root=research_artifacts.RUN_STATE_PATH.parent / "history",
+    )
+    repair_result = lifecycle.repair_stale_run()
+    state_artifact = research_artifacts.load_run_state_artifact()
+    state_payload = state_artifact.get("artifact")
     warnings: list[str] = []
+    if repair_result.get("repaired"):
+        warnings.append(
+            f"Recovered stale running state via {repair_result['repair_reason']}."
+        )
 
-    if observations["local_process_active"] or observations["recent_progress_signal"]:
+    if (
+        state_artifact.get("artifact_state") == "valid"
+        and isinstance(state_payload, dict)
+        and state_payload.get("status") == "running"
+    ):
         return (
             {
                 "accepted": False,
                 "launch_state": "blocked_active_run",
-                "observations": observations,
-                "warnings": warnings,
-            },
-            409,
-        )
-
-    if observations["stale_progress_signal"]:
-        warnings.append(
-            "Stale running progress signal detected. Review run_progress_latest.v1.json before retrying."
-        )
-        return (
-            {
-                "accepted": False,
-                "launch_state": "blocked_stale_signal",
-                "observations": observations,
+                "observations": _build_observations(
+                    state_artifact=state_artifact,
+                    repair_result=repair_result,
+                ),
                 "warnings": warnings,
             },
             409,
@@ -139,24 +110,27 @@ def launch_research_run(
             {
                 "accepted": False,
                 "launch_state": "launch_failed",
-                "observations": observations,
+                "observations": _build_observations(
+                    state_artifact=state_artifact,
+                    repair_result=repair_result,
+                ),
                 "warnings": warnings,
                 "error": str(exc),
             },
             500,
         )
 
-    with _RUN_LOCK:
-        global _ACTIVE_PROCESS
-        _ACTIVE_PROCESS = process
-
     return (
         {
             "accepted": True,
             "launch_state": "started",
             "pid": process.pid,
-            "observations": dashboard_observations(run_status_artifact, now=now),
+            "observations": _build_observations(
+                state_artifact=state_artifact,
+                repair_result=repair_result,
+            ),
             "warnings": warnings,
+            "launched_at_utc": (now or _utc_now()).isoformat(),
         },
         202,
     )

--- a/dashboard/static/research_control_surface.js
+++ b/dashboard/static/research_control_surface.js
@@ -40,33 +40,34 @@
 
   async function loadRunStatus() {
     const payload = await fetchJson("/api/research/run-status");
-    const artifact = payload.artifact || {};
-    const progress = artifact.progress || {};
-    const timing = artifact.timing || {};
+    const stateArtifact = (payload.run_state || {}).artifact || {};
+    const progressArtifact = (payload.run_progress || {}).artifact || {};
+    const progress = progressArtifact.stage_progress || {};
     const observations = payload.dashboard_observations || {};
 
-    text("run-status", artifact.status || payload.artifact_state);
-    text("run-stage", artifact.current_stage);
+    text("run-status", stateArtifact.status || (payload.run_state || {}).artifact_state);
+    const authoritativeRunning = stateArtifact.status === "running";
+    text("run-stage", authoritativeRunning ? (progressArtifact.current_stage || stateArtifact.stage) : stateArtifact.stage);
     text("run-progress", progress.percent != null ? `${progress.percent}%` : "-");
-    text("run-current-item", currentItemLabel(artifact.current_item));
+    text("run-current-item", authoritativeRunning ? currentItemLabel(progressArtifact.current_item) : "-");
     text("run-completed", progress.total != null ? `${progress.completed}/${progress.total}` : "-");
-    text("run-elapsed", timing.elapsed_seconds);
-    text("run-eta", timing.eta_seconds);
-    text("run-updated", artifact.last_updated_at_utc || payload.artifact_modified_at_utc);
+    text("run-elapsed", progressArtifact.elapsed_seconds);
+    text("run-eta", progressArtifact.eta_seconds);
+    text("run-updated", stateArtifact.updated_at_utc || progressArtifact.updated_at_utc);
 
     const observationText = [];
-    if (observations.local_process_active != null) {
-      observationText.push(`Local process active: ${observations.local_process_active}`);
+    if (observations.pid_live != null) {
+      observationText.push(`PID live: ${observations.pid_live}`);
     }
-    if (observations.progress_heartbeat_age_seconds != null) {
-      observationText.push(`Heartbeat age: ${observations.progress_heartbeat_age_seconds}s`);
+    if (observations.heartbeat_age_seconds != null) {
+      observationText.push(`Heartbeat age: ${observations.heartbeat_age_seconds}s`);
     }
     document.getElementById("run-observations").textContent = observationText.join(" | ");
     renderWarning("run-warning", payload.warnings || [], "warning");
 
     const button = document.getElementById("run-research-button");
     if (button) {
-      button.disabled = Boolean(observations.local_process_active || observations.recent_progress_signal);
+      button.disabled = stateArtifact.status === "running";
     }
   }
 

--- a/research/observability.py
+++ b/research/observability.py
@@ -1,39 +1,43 @@
 from __future__ import annotations
 
 import json
-import os
 import time
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Callable
+
+from research.run_state import RunStateStore, write_json_atomic
 
 
 def _utc_now() -> datetime:
     return datetime.now(UTC)
 
 
-def _run_id(started_at_utc: datetime) -> str:
-    return started_at_utc.astimezone(UTC).strftime("%Y%m%dT%H%M%S%fZ")
-
-
 class ProgressTracker:
-    """Lightweight progress sidecar + sparse console logging for research runs."""
+    """Progress, manifest, and structured logging for research runs."""
 
     def __init__(
         self,
         *,
         path: Path,
-        started_at_utc: datetime | None = None,
+        lifecycle: RunStateStore,
+        run_id: str,
+        started_at_utc: datetime,
+        manifest_path: Path,
+        log_path: Path,
         now_source: Callable[[], datetime] | None = None,
         monotonic_source: Callable[[], float] | None = None,
         log_fn: Callable[[str], None] | None = None,
     ) -> None:
         self.path = path
+        self.lifecycle = lifecycle
+        self.run_id = run_id
+        self.manifest_path = manifest_path
+        self.log_path = log_path
         self._now_source = now_source or _utc_now
         self._monotonic_source = monotonic_source or time.monotonic
         self._log_fn = log_fn or print
-        self.started_at_utc = (started_at_utc or self._now_source()).astimezone(UTC)
-        self.run_id = _run_id(self.started_at_utc)
+        self.started_at_utc = started_at_utc.astimezone(UTC)
         self.status = "running"
         self.current_stage = "starting"
         self.current_item: dict[str, str | None] = {
@@ -41,30 +45,55 @@ class ProgressTracker:
             "asset": None,
             "interval": None,
         }
-        self.completed = 0
-        self.total = 0
-        self.failure: dict[str, str | None] | None = None
+        self.completed_items = 0
+        self.total_items = 0
+        self.failed_items = 0
+        self.error: dict[str, str | None] | None = None
         self._stage_started_at_utc = self.started_at_utc
         self._stage_started_monotonic = self._monotonic_source()
         self._run_started_monotonic = self._stage_started_monotonic
         self._last_updated_at_utc = self.started_at_utc
         self._last_emitted_completed = -1
-        self._write_sidecar()
+        self._write_progress()
+
+    def write_manifest(self, payload: dict[str, Any]) -> None:
+        write_json_atomic(self.manifest_path, payload)
+        self._log_event("manifest_written", status=payload.get("status"))
+
+    def finalize_manifest(self, status: str) -> None:
+        if not self.manifest_path.exists():
+            return
+        payload = json.loads(self.manifest_path.read_text(encoding="utf-8"))
+        payload["status"] = status
+        payload["finished_at_utc"] = self._now_source().astimezone(UTC).isoformat()
+        write_json_atomic(self.manifest_path, payload)
 
     def start_stage(self, stage: str, *, total: int | None = None, **log_fields: Any) -> None:
         self.current_stage = stage
         self._stage_started_at_utc = self._now_source().astimezone(UTC)
         self._stage_started_monotonic = self._monotonic_source()
         if total is not None:
-            self.total = int(total)
+            self.total_items = int(total)
         self._last_updated_at_utc = self._stage_started_at_utc
-        self._write_sidecar()
+        self.lifecycle.heartbeat(
+            run_id=self.run_id,
+            stage=stage,
+            status_reason=f"stage_started:{stage}",
+        )
+        self._write_progress()
         self._log("stage", stage=stage, status="started", **log_fields)
+        self._log_event("stage_started", stage=stage, **log_fields)
 
     def mark_stage_completed(self, **log_fields: Any) -> None:
         self._last_updated_at_utc = self._now_source().astimezone(UTC)
-        self._write_sidecar()
+        self.lifecycle.heartbeat(
+            run_id=self.run_id,
+            stage=self.current_stage,
+            status_reason=f"stage_completed:{self.current_stage}",
+        )
+        self._write_progress()
         self._log("stage", stage=self.current_stage, status="completed", **log_fields)
+        self._log_event("stage_completed", stage=self.current_stage, **log_fields)
 
     def begin_item(self, *, strategy: str, asset: str, interval: str) -> None:
         self.current_item = {
@@ -75,87 +104,106 @@ class ProgressTracker:
 
     def advance(self, *, completed: int | None = None, total: int | None = None) -> None:
         if completed is not None:
-            self.completed = int(completed)
+            self.completed_items = int(completed)
         else:
-            self.completed += 1
+            self.completed_items += 1
         if total is not None:
-            self.total = int(total)
+            self.total_items = int(total)
+        self.lifecycle.heartbeat(
+            run_id=self.run_id,
+            stage=self.current_stage,
+            status_reason=f"progress_update:{self.current_stage}",
+        )
         if not self._should_emit_progress():
             return
         self._last_updated_at_utc = self._now_source().astimezone(UTC)
-        self._write_sidecar()
-        self._last_emitted_completed = self.completed
+        self._write_progress()
+        self._last_emitted_completed = self.completed_items
         self._log(
             "progress",
             stage=self.current_stage,
-            progress=f"{self.completed}/{self.total}",
+            progress=f"{self.completed_items}/{self.total_items}",
             percent=self._percent(),
             elapsed_s=self._elapsed_seconds(),
             eta_s=self._eta_seconds(),
             current=self._current_item_label(),
         )
+        self._log_event(
+            "progress_update",
+            stage=self.current_stage,
+            completed_items=self.completed_items,
+            total_items=self.total_items,
+            percent=self._percent(),
+        )
 
     def complete(self) -> None:
         self.status = "completed"
         self.current_stage = "completed"
-        self.completed = self.total
+        self.completed_items = self.total_items
         self.current_item = {
             "strategy": None,
             "asset": None,
             "interval": None,
         }
         self._last_updated_at_utc = self._now_source().astimezone(UTC)
-        self._write_sidecar()
+        self._write_progress()
+        self.finalize_manifest("completed")
+        self.lifecycle.complete_run(run_id=self.run_id, status_reason="research_run_completed")
         self._log("stage", stage="completed", status="completed", elapsed_s=self._elapsed_seconds())
 
     def fail(self, error: Exception, *, failure_stage: str | None = None) -> None:
         self.status = "failed"
         self.current_stage = "failed"
-        self.failure = {
+        self.error = {
             "failure_stage": failure_stage or self.current_stage,
             "error_type": type(error).__name__,
             "error_message": str(error),
         }
         self._last_updated_at_utc = self._now_source().astimezone(UTC)
-        self._write_sidecar()
+        self.failed_items += 1
+        self._write_progress()
+        self.finalize_manifest("failed")
+        self.lifecycle.fail_run(
+            run_id=self.run_id,
+            status_reason=f"research_run_failed:{self.error['failure_stage']}",
+            error_type=self.error["error_type"] or "Exception",
+            error_message=self.error["error_message"] or "",
+        )
         self._log(
             "stage",
             stage="failed",
             status="failed",
-            failure_stage=self.failure["failure_stage"],
-            error_type=self.failure["error_type"],
+            failure_stage=self.error["failure_stage"],
+            error_type=self.error["error_type"],
         )
 
     def _should_emit_progress(self) -> bool:
-        if self.total <= 0:
+        if self.total_items <= 0:
             return False
-        if self.completed == self._last_emitted_completed:
+        if self.completed_items == self._last_emitted_completed:
             return False
-        if self.total <= 10:
+        if self.total_items <= 10:
             return True
-        if self.completed in {1, self.total}:
+        if self.completed_items in {1, self.total_items}:
             return True
-        stride = max(1, (self.total + 9) // 10)
-        return self.completed % stride == 0
+        stride = max(1, (self.total_items + 9) // 10)
+        return self.completed_items % stride == 0
 
     def _percent(self) -> float:
-        if self.total <= 0:
+        if self.total_items <= 0:
             return 0.0
-        return round((self.completed / self.total) * 100.0, 2)
+        return round((self.completed_items / self.total_items) * 100.0, 2)
 
     def _elapsed_seconds(self) -> int:
         return max(0, int(round(self._monotonic_source() - self._run_started_monotonic)))
 
-    def _stage_elapsed_seconds(self) -> int:
-        return max(0, int(round(self._monotonic_source() - self._stage_started_monotonic)))
-
     def _eta_seconds(self) -> int | None:
         if self.status != "running" or self.current_stage != "evaluation":
             return None
-        if self.completed <= 0 or self.total <= self.completed:
-            return 0 if self.total > 0 and self.completed >= self.total else None
-        pace = self._elapsed_seconds() / self.completed
-        return max(0, int(round(pace * (self.total - self.completed))))
+        if self.completed_items <= 0 or self.total_items <= self.completed_items:
+            return 0 if self.total_items > 0 and self.completed_items >= self.total_items else None
+        pace = self._elapsed_seconds() / self.completed_items
+        return max(0, int(round(pace * (self.total_items - self.completed_items))))
 
     def _current_item_label(self) -> str | None:
         strategy = self.current_item["strategy"]
@@ -168,38 +216,27 @@ class ProgressTracker:
     def _payload(self) -> dict[str, Any]:
         return {
             "version": "v1",
-            "status": self.status,
             "run_id": self.run_id,
+            "status": self.status,
             "current_stage": self.current_stage,
-            "started_at_utc": self.started_at_utc.isoformat(),
-            "last_updated_at_utc": self._last_updated_at_utc.isoformat(),
-            "progress": {
-                "completed": int(self.completed),
-                "total": int(self.total),
+            "stage_progress": {
+                "completed": int(self.completed_items),
+                "total": int(self.total_items),
                 "percent": self._percent(),
             },
+            "total_items": int(self.total_items),
+            "completed_items": int(self.completed_items),
+            "failed_items": int(self.failed_items),
             "current_item": dict(self.current_item),
-            "timing": {
-                "elapsed_seconds": self._elapsed_seconds(),
-                "stage_elapsed_seconds": self._stage_elapsed_seconds(),
-                "eta_seconds": self._eta_seconds(),
-            },
-            "failure": self.failure,
+            "started_at_utc": self.started_at_utc.isoformat(),
+            "updated_at_utc": self._last_updated_at_utc.isoformat(),
+            "elapsed_seconds": self._elapsed_seconds(),
+            "eta_seconds": self._eta_seconds(),
+            "error": self.error,
         }
 
-    def _write_sidecar(self) -> None:
-        payload = self._payload()
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        tmp_path = self.path.with_suffix(f"{self.path.suffix}.tmp")
-        with tmp_path.open("w", encoding="utf-8") as handle:
-            json.dump(payload, handle, indent=2)
-        try:
-            os.replace(tmp_path, self.path)
-        except PermissionError:
-            with self.path.open("w", encoding="utf-8") as handle:
-                json.dump(payload, handle, indent=2)
-            if tmp_path.exists():
-                tmp_path.unlink()
+    def _write_progress(self) -> None:
+        write_json_atomic(self.path, self._payload())
 
     def _log(self, event: str, **fields: Any) -> None:
         parts = [f"[research] {event}"]
@@ -208,3 +245,17 @@ class ProgressTracker:
                 continue
             parts.append(f"{key}={value}")
         self._log_fn(" ".join(parts))
+
+    def _log_event(self, event: str, **fields: Any) -> None:
+        payload = {
+            "timestamp_utc": self._now_source().astimezone(UTC).isoformat(),
+            "event": event,
+            "run_id": self.run_id,
+            "status": self.status,
+            "stage": self.current_stage,
+            **fields,
+        }
+        self.log_path.parent.mkdir(parents=True, exist_ok=True)
+        with self.log_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload, sort_keys=False))
+            handle.write("\n")

--- a/research/run_research.py
+++ b/research/run_research.py
@@ -30,6 +30,7 @@ from research.results import make_result_row, write_latest_json, write_results_t
 from research.portfolio_reporting import build_portfolio_aggregation_payload
 from research.promotion_reporting import build_candidate_registry_payload
 from research.regime_reporting import build_regime_diagnostics_payload
+from research.run_state import RunStateStore
 from research.statistical_reporting import build_statistical_defensibility_payload, regime_count_settings
 from research.universe import build_research_universe
 
@@ -41,6 +42,10 @@ PORTFOLIO_AGGREGATION_PATH = Path("research/portfolio_aggregation_latest.v1.json
 REGIME_DIAGNOSTICS_PATH = Path("research/regime_diagnostics_latest.v1.json")
 EMPTY_RUN_DIAGNOSTICS_PATH = Path("research/empty_run_diagnostics_latest.v1.json")
 RUN_PROGRESS_PATH = Path("research/run_progress_latest.v1.json")
+RUN_STATE_PATH = Path("research/run_state.v1.json")
+RUN_MANIFEST_PATH = Path("research/run_manifest_latest.v1.json")
+RUN_LOG_DIR = Path("logs/research")
+RUN_HEARTBEAT_TIMEOUT_S = 300
 
 
 def load_research_config(config_path="config/config.yaml"):
@@ -377,6 +382,55 @@ def _write_empty_run_diagnostics_sidecar(
     return payload
 
 
+def _build_run_manifest_payload(
+    *,
+    run_id: str,
+    started_at_utc,
+    research_config: dict,
+    assets: list,
+    intervals: list[str],
+    total_candidate_count: int,
+    strategies: list[dict],
+    universe_snapshot_path: Path,
+) -> dict:
+    asset_symbols = [asset.symbol if hasattr(asset, "symbol") else str(asset) for asset in assets]
+    return {
+        "version": "v1",
+        "run_id": run_id,
+        "created_at_utc": started_at_utc.isoformat(),
+        "started_at_utc": started_at_utc.isoformat(),
+        "status": "running",
+        "git_revision": _git_revision(),
+        "config_hash": _config_hash(research_config, []),
+        "universe_snapshot_path": universe_snapshot_path.as_posix(),
+        "resolved_universe_summary": {
+            "asset_count": len(asset_symbols),
+            "interval_count": len(intervals),
+            "assets": asset_symbols,
+            "intervals": list(intervals),
+        },
+        "total_candidate_count": int(total_candidate_count),
+        "candidate_grouping_summary": {
+            "by_strategy": {
+                strategy["name"]: len(asset_symbols) * len(intervals)
+                for strategy in strategies
+            },
+            "by_interval": {
+                interval: len(asset_symbols) * len(strategies)
+                for interval in intervals
+            },
+        },
+        "stage_definitions": [
+            "planning",
+            "preflight",
+            "evaluation",
+            "writing_outputs",
+        ],
+        "screening_enabled": False,
+        "validation_enabled": True,
+    }
+
+
 def _raise_degenerate_run(
     *,
     as_of_utc,
@@ -402,15 +456,33 @@ def _raise_degenerate_run(
 
 
 def run_research():
+    lifecycle = RunStateStore(
+        state_path=RUN_STATE_PATH,
+        history_root=Path("research/history"),
+    )
+    state = lifecycle.start_run(
+        progress_path=RUN_PROGRESS_PATH,
+        manifest_path=RUN_MANIFEST_PATH,
+        log_dir=RUN_LOG_DIR,
+        heartbeat_timeout_s=RUN_HEARTBEAT_TIMEOUT_S,
+        stage="starting",
+        status_reason="research_run_started",
+    )
+    started_at_utc = datetime.fromisoformat(state["started_at_utc"])
     tracker = ProgressTracker(
         path=RUN_PROGRESS_PATH,
-        started_at_utc=datetime.now(UTC),
+        lifecycle=lifecycle,
+        run_id=state["run_id"],
+        started_at_utc=started_at_utc,
+        manifest_path=RUN_MANIFEST_PATH,
+        log_path=Path(state["log_path"]),
     )
     rows = []
     evaluations = []
     walk_forward_reports = []
     provenance_events = []
     try:
+        tracker.start_stage("planning")
         research_config = load_research_config()
         regime_count, regime_count_source = regime_count_settings(research_config)
         evaluation_config = normalize_evaluation_config(research_config.get("evaluation"))
@@ -419,6 +491,19 @@ def run_research():
         interval_ranges = {}
         strategies = get_enabled_strategies()
         total_items = len(strategies) * len(intervals) * len(assets)
+        tracker.write_manifest(
+            _build_run_manifest_payload(
+                run_id=state["run_id"],
+                started_at_utc=started_at_utc,
+                research_config=research_config,
+                assets=assets,
+                intervals=intervals,
+                total_candidate_count=total_items,
+                strategies=strategies,
+                universe_snapshot_path=UNIVERSE_SNAPSHOT_PATH,
+            )
+        )
+        tracker.mark_stage_completed(total_items=total_items)
 
         tracker.start_stage("preflight", total=total_items)
         for interval in intervals:

--- a/research/run_state.py
+++ b/research/run_state.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from datetime import UTC, datetime
+from json import JSONDecodeError
+from pathlib import Path
+from typing import Any
+
+
+class ActiveResearchRunError(RuntimeError):
+    """Raised when a live research run already holds the lifecycle lock."""
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _run_id(started_at_utc: datetime) -> str:
+    return started_at_utc.astimezone(UTC).strftime("%Y%m%dT%H%M%S%fZ")
+
+
+def _path_label(path: Path) -> str:
+    return path.as_posix()
+
+
+def write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(f"{path.suffix}.tmp")
+    with tmp_path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, sort_keys=False)
+    os.replace(tmp_path, path)
+
+
+def _append_jsonl_event(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, sort_keys=False))
+        handle.write("\n")
+
+
+def _load_json(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, JSONDecodeError):
+        return None
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if not isinstance(value, str) or value.strip() == "":
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
+    except ValueError:
+        return None
+
+
+def _pid_is_live(pid: int | None) -> bool:
+    if not isinstance(pid, int) or pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+class RunStateStore:
+    def __init__(
+        self,
+        *,
+        state_path: Path = Path("research/run_state.v1.json"),
+        history_root: Path = Path("research/history"),
+        now_source=_utc_now,
+        pid_source=os.getpid,
+    ) -> None:
+        self.state_path = state_path
+        self.history_root = history_root
+        self._now_source = now_source
+        self._pid_source = pid_source
+
+    def load_state(self) -> dict[str, Any] | None:
+        return _load_json(self.state_path)
+
+    def repair_stale_run(self) -> dict[str, Any]:
+        state = self.load_state()
+        observations = {
+            "repaired": False,
+            "repair_reason": None,
+            "pid_live": None,
+            "heartbeat_age_seconds": None,
+        }
+        if not isinstance(state, dict) or state.get("status") != "running":
+            return observations
+
+        pid = state.get("pid")
+        pid_live = _pid_is_live(pid if isinstance(pid, int) else None)
+        observations["pid_live"] = pid_live
+
+        updated_at = _parse_datetime(state.get("updated_at_utc"))
+        timeout_s = int(state.get("heartbeat_timeout_s") or 0)
+        if updated_at is not None and timeout_s > 0:
+            observations["heartbeat_age_seconds"] = max(
+                0,
+                int(round((self._now_source() - updated_at).total_seconds())),
+            )
+
+        if not pid_live:
+            reason = "stale_recovery_dead_process"
+        elif updated_at is None:
+            reason = "stale_recovery_missing_heartbeat"
+        elif timeout_s > 0 and observations["heartbeat_age_seconds"] is not None and observations["heartbeat_age_seconds"] > timeout_s:
+            reason = "stale_recovery_heartbeat_timeout"
+        else:
+            return observations
+
+        self.abort_run(
+            run_id=str(state.get("run_id") or ""),
+            status_reason=reason,
+            stage="aborted",
+        )
+        observations["repaired"] = True
+        observations["repair_reason"] = reason
+        return observations
+
+    def start_run(
+        self,
+        *,
+        progress_path: Path,
+        manifest_path: Path,
+        log_dir: Path,
+        heartbeat_timeout_s: int,
+        stage: str = "starting",
+        status_reason: str = "research_run_started",
+    ) -> dict[str, Any]:
+        self.repair_stale_run()
+        current = self.load_state()
+        if isinstance(current, dict) and current.get("status") == "running":
+            pid = current.get("pid")
+            if _pid_is_live(pid if isinstance(pid, int) else None):
+                raise ActiveResearchRunError(
+                    f"active research run already exists run_id={current.get('run_id')} pid={pid}"
+                )
+
+        started_at = self._now_source()
+        run_id = _run_id(started_at)
+        log_path = log_dir / f"{run_id}.jsonl"
+        payload = {
+            "version": "v1",
+            "run_id": run_id,
+            "status": "running",
+            "pid": int(self._pid_source()),
+            "started_at_utc": started_at.isoformat(),
+            "updated_at_utc": started_at.isoformat(),
+            "stage": stage,
+            "status_reason": status_reason,
+            "heartbeat_timeout_s": int(heartbeat_timeout_s),
+            "progress_path": _path_label(progress_path),
+            "manifest_path": _path_label(manifest_path),
+            "log_path": _path_label(log_path),
+            "error": None,
+        }
+        write_json_atomic(self.state_path, payload)
+        self._log_event(
+            payload,
+            event="run_created",
+            status_reason=status_reason,
+            stage=stage,
+        )
+        return payload
+
+    def heartbeat(
+        self,
+        *,
+        run_id: str,
+        stage: str | None = None,
+        status_reason: str | None = None,
+    ) -> dict[str, Any]:
+        state = self.load_state()
+        if not isinstance(state, dict) or state.get("run_id") != run_id:
+            return state or {}
+        state["updated_at_utc"] = self._now_source().isoformat()
+        if stage is not None:
+            state["stage"] = stage
+        if status_reason is not None:
+            state["status_reason"] = status_reason
+        write_json_atomic(self.state_path, state)
+        return state
+
+    def complete_run(
+        self,
+        *,
+        run_id: str,
+        status_reason: str = "research_run_completed",
+        stage: str = "completed",
+    ) -> dict[str, Any]:
+        return self._write_terminal_state(
+            run_id=run_id,
+            status="completed",
+            status_reason=status_reason,
+            stage=stage,
+            error=None,
+            log_event="run_completed",
+        )
+
+    def fail_run(
+        self,
+        *,
+        run_id: str,
+        status_reason: str,
+        error_type: str,
+        error_message: str,
+        stage: str = "failed",
+    ) -> dict[str, Any]:
+        return self._write_terminal_state(
+            run_id=run_id,
+            status="failed",
+            status_reason=status_reason,
+            stage=stage,
+            error={
+                "error_type": error_type,
+                "error_message": error_message,
+            },
+            log_event="run_failed",
+        )
+
+    def abort_run(
+        self,
+        *,
+        run_id: str,
+        status_reason: str,
+        stage: str = "aborted",
+    ) -> dict[str, Any]:
+        return self._write_terminal_state(
+            run_id=run_id,
+            status="aborted",
+            status_reason=status_reason,
+            stage=stage,
+            error=None,
+            log_event="run_aborted",
+        )
+
+    def _write_terminal_state(
+        self,
+        *,
+        run_id: str,
+        status: str,
+        status_reason: str,
+        stage: str,
+        error: dict[str, Any] | None,
+        log_event: str,
+    ) -> dict[str, Any]:
+        state = self.load_state() or {}
+        if state.get("run_id") and state.get("run_id") != run_id:
+            return state
+        now = self._now_source()
+        state.update(
+            {
+                "version": "v1",
+                "run_id": run_id or str(state.get("run_id") or ""),
+                "status": status,
+                "pid": None,
+                "started_at_utc": state.get("started_at_utc") or now.isoformat(),
+                "updated_at_utc": now.isoformat(),
+                "stage": stage,
+                "status_reason": status_reason,
+                "heartbeat_timeout_s": int(state.get("heartbeat_timeout_s") or 0),
+                "progress_path": state.get("progress_path"),
+                "manifest_path": state.get("manifest_path"),
+                "log_path": state.get("log_path"),
+                "error": error,
+            }
+        )
+        write_json_atomic(self.state_path, state)
+        self._log_event(state, event=log_event, status_reason=status_reason, stage=stage, error=error)
+        self._write_history_copies(state)
+        return state
+
+    def _log_event(self, state: dict[str, Any], *, event: str, **fields: Any) -> None:
+        log_path_value = state.get("log_path")
+        if not isinstance(log_path_value, str) or log_path_value.strip() == "":
+            return
+        payload = {
+            "timestamp_utc": self._now_source().isoformat(),
+            "event": event,
+            "run_id": state.get("run_id"),
+            "status": state.get("status"),
+            "stage": state.get("stage"),
+            **fields,
+        }
+        _append_jsonl_event(Path(log_path_value), payload)
+
+    def _write_history_copies(self, state: dict[str, Any]) -> None:
+        run_id = str(state.get("run_id") or "")
+        if run_id == "":
+            return
+        target_dir = self.history_root / run_id
+        target_dir.mkdir(parents=True, exist_ok=True)
+        write_json_atomic(target_dir / "run_state.v1.json", state)
+
+        manifest_path = state.get("manifest_path")
+        progress_path = state.get("progress_path")
+        if isinstance(manifest_path, str) and Path(manifest_path).exists():
+            shutil.copy2(Path(manifest_path), target_dir / "run_manifest.v1.json")
+        if isinstance(progress_path, str) and Path(progress_path).exists():
+            shutil.copy2(Path(progress_path), target_dir / "run_progress.v1.json")

--- a/tests/unit/test_dashboard_research_api.py
+++ b/tests/unit/test_dashboard_research_api.py
@@ -1,13 +1,5 @@
+import json
 from datetime import UTC, datetime, timedelta
-
-
-class _FakeProcess:
-    def __init__(self, pid=4321, returncode=None):
-        self.pid = pid
-        self._returncode = returncode
-
-    def poll(self):
-        return self._returncode
 
 
 def _set_operator_session(client):
@@ -53,8 +45,8 @@ def test_research_routes_require_auth():
 def test_research_run_status_endpoint_without_sidecar(monkeypatch, tmp_path):
     from dashboard import dashboard as dash
 
+    monkeypatch.setattr(dash.research_artifacts, "RUN_STATE_PATH", tmp_path / "missing-state.json")
     monkeypatch.setattr(dash.research_artifacts, "RUN_PROGRESS_PATH", tmp_path / "missing.json")
-    monkeypatch.setattr(dash.research_runner, "_ACTIVE_PROCESS", None)
 
     dash.app.testing = True
     client = dash.app.test_client()
@@ -63,35 +55,61 @@ def test_research_run_status_endpoint_without_sidecar(monkeypatch, tmp_path):
 
     assert response.status_code == 200
     payload = response.get_json()
-    assert payload["artifact_state"] == "absent"
-    assert payload["dashboard_observations"]["local_process_active"] is False
-    assert payload["artifact"] is None
+    assert payload["run_state"]["artifact_state"] == "absent"
+    assert payload["run_progress"]["artifact_state"] == "absent"
+    assert payload["dashboard_observations"]["authoritative_status"] is None
 
 
 def test_research_run_status_endpoint_with_valid_sidecar(monkeypatch, tmp_path):
     from dashboard import dashboard as dash
 
     now = datetime.now(UTC)
-    path = tmp_path / "run_progress_latest.v1.json"
-    path.write_text(
+    state_path = tmp_path / "run_state.v1.json"
+    progress_path = tmp_path / "run_progress_latest.v1.json"
+    state_path.write_text(
         (
             "{"
             "\"version\":\"v1\","
             "\"status\":\"running\","
             "\"run_id\":\"20260413T100000000000Z\","
-            "\"current_stage\":\"evaluation\","
             f"\"started_at_utc\":\"{(now - timedelta(seconds=180)).isoformat()}\","
-            f"\"last_updated_at_utc\":\"{now.isoformat()}\","
-            "\"progress\":{\"completed\":5,\"total\":10,\"percent\":50.0},"
-            "\"current_item\":{\"strategy\":\"sma\",\"asset\":\"BTC-USD\",\"interval\":\"1h\"},"
-            "\"timing\":{\"elapsed_seconds\":180,\"stage_elapsed_seconds\":120,\"eta_seconds\":180},"
-            "\"failure\":null"
+            f"\"updated_at_utc\":\"{now.isoformat()}\","
+            "\"stage\":\"evaluation\","
+            "\"status_reason\":\"research_run_started\","
+            "\"heartbeat_timeout_s\":300,"
+            "\"progress_path\":\"research/run_progress_latest.v1.json\","
+            "\"manifest_path\":\"research/run_manifest_latest.v1.json\","
+            "\"log_path\":\"logs/research/20260413T100000000000Z.jsonl\","
+            "\"pid\":123,"
+            "\"error\":null"
             "}"
         ),
         encoding="utf-8",
     )
-    monkeypatch.setattr(dash.research_artifacts, "RUN_PROGRESS_PATH", path)
-    monkeypatch.setattr(dash.research_runner, "_ACTIVE_PROCESS", None)
+    progress_path.write_text(
+        (
+            "{"
+            "\"version\":\"v1\","
+            "\"run_id\":\"20260413T100000000000Z\","
+            "\"status\":\"running\","
+            "\"current_stage\":\"evaluation\","
+            "\"stage_progress\":{\"completed\":5,\"total\":10,\"percent\":50.0},"
+            "\"total_items\":10,"
+            "\"completed_items\":5,"
+            "\"failed_items\":0,"
+            "\"current_item\":{\"strategy\":\"sma\",\"asset\":\"BTC-USD\",\"interval\":\"1h\"},"
+            f"\"started_at_utc\":\"{(now - timedelta(seconds=180)).isoformat()}\","
+            f"\"updated_at_utc\":\"{now.isoformat()}\","
+            "\"elapsed_seconds\":180,"
+            "\"eta_seconds\":180,"
+            "\"error\":null"
+            "}"
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(dash.research_artifacts, "RUN_STATE_PATH", state_path)
+    monkeypatch.setattr(dash.research_artifacts, "RUN_PROGRESS_PATH", progress_path)
+    monkeypatch.setattr("research.run_state._pid_is_live", lambda pid: True)
 
     dash.app.testing = True
     client = dash.app.test_client()
@@ -100,9 +118,10 @@ def test_research_run_status_endpoint_with_valid_sidecar(monkeypatch, tmp_path):
 
     assert response.status_code == 200
     payload = response.get_json()
-    assert payload["artifact_state"] == "valid"
-    assert payload["artifact"]["status"] == "running"
-    assert payload["dashboard_observations"]["recent_progress_signal"] is True
+    assert payload["run_state"]["artifact_state"] == "valid"
+    assert payload["run_state"]["artifact"]["status"] == "running"
+    assert payload["run_progress"]["artifact"]["completed_items"] == 5
+    assert payload["dashboard_observations"]["pid_live"] is True
 
 
 def test_research_run_status_endpoint_with_stale_running_sidecar(monkeypatch, tmp_path):
@@ -110,17 +129,29 @@ def test_research_run_status_endpoint_with_stale_running_sidecar(monkeypatch, tm
 
     now = datetime.now(UTC)
     stale_at = (now - timedelta(seconds=601)).isoformat()
-    path = tmp_path / "run_progress_latest.v1.json"
-    path.write_text(
+    state_path = tmp_path / "run_state.v1.json"
+    state_path.write_text(
         (
             "{"
-            f"\"version\":\"v1\",\"status\":\"running\",\"last_updated_at_utc\":\"{stale_at}\""
+            "\"version\":\"v1\","
+            "\"run_id\":\"20260413T100000000000Z\","
+            "\"status\":\"running\","
+            "\"pid\":123,"
+            f"\"started_at_utc\":\"{(now - timedelta(seconds=900)).isoformat()}\","
+            f"\"updated_at_utc\":\"{stale_at}\","
+            "\"stage\":\"evaluation\","
+            "\"status_reason\":\"research_run_started\","
+            "\"heartbeat_timeout_s\":300,"
+            "\"progress_path\":\"research/run_progress_latest.v1.json\","
+            "\"manifest_path\":\"research/run_manifest_latest.v1.json\","
+            "\"log_path\":\"logs/research/20260413T100000000000Z.jsonl\","
+            "\"error\":null"
             "}"
         ),
         encoding="utf-8",
     )
-    monkeypatch.setattr(dash.research_artifacts, "RUN_PROGRESS_PATH", path)
-    monkeypatch.setattr(dash.research_runner, "_ACTIVE_PROCESS", None)
+    monkeypatch.setattr(dash.research_artifacts, "RUN_STATE_PATH", state_path)
+    monkeypatch.setattr("research.run_state._pid_is_live", lambda pid: True)
 
     dash.app.testing = True
     client = dash.app.test_client()
@@ -128,16 +159,18 @@ def test_research_run_status_endpoint_with_stale_running_sidecar(monkeypatch, tm
     response = client.get("/api/research/run-status")
 
     payload = response.get_json()
-    assert payload["dashboard_observations"]["stale_progress_signal"] is True
+    assert payload["dashboard_observations"]["stale_state_repaired"] is True
     assert payload["warnings"]
+    repaired = json.loads(state_path.read_text(encoding="utf-8"))
+    assert repaired["status"] == "aborted"
 
 
 def test_research_run_status_endpoint_with_invalid_json(monkeypatch, tmp_path):
     from dashboard import dashboard as dash
 
-    path = tmp_path / "run_progress_latest.v1.json"
-    path.write_text("{ invalid", encoding="utf-8")
-    monkeypatch.setattr(dash.research_artifacts, "RUN_PROGRESS_PATH", path)
+    state_path = tmp_path / "run_state.v1.json"
+    state_path.write_text("{ invalid", encoding="utf-8")
+    monkeypatch.setattr(dash.research_artifacts, "RUN_STATE_PATH", state_path)
 
     dash.app.testing = True
     client = dash.app.test_client()
@@ -145,19 +178,18 @@ def test_research_run_status_endpoint_with_invalid_json(monkeypatch, tmp_path):
     response = client.get("/api/research/run-status")
 
     payload = response.get_json()
-    assert payload["artifact_state"] == "invalid_json"
-    assert payload["artifact_error"]
+    assert payload["run_state"]["artifact_state"] == "invalid_json"
+    assert payload["run_state"]["artifact_error"]
 
 
 def test_research_run_trigger_accepted_when_idle(monkeypatch, tmp_path):
     from dashboard import dashboard as dash
 
-    monkeypatch.setattr(dash.research_artifacts, "RUN_PROGRESS_PATH", tmp_path / "missing.json")
-    monkeypatch.setattr(dash.research_runner, "_ACTIVE_PROCESS", None)
+    monkeypatch.setattr(dash.research_artifacts, "RUN_STATE_PATH", tmp_path / "missing.json")
     monkeypatch.setattr(
         dash.research_runner.subprocess,
         "Popen",
-        lambda *args, **kwargs: _FakeProcess(pid=999, returncode=None),
+        lambda *args, **kwargs: type("FakeProcess", (), {"pid": 999})(),
     )
 
     dash.app.testing = True
@@ -175,8 +207,30 @@ def test_research_run_trigger_accepted_when_idle(monkeypatch, tmp_path):
 def test_research_run_trigger_blocked_when_process_active(monkeypatch, tmp_path):
     from dashboard import dashboard as dash
 
-    monkeypatch.setattr(dash.research_artifacts, "RUN_PROGRESS_PATH", tmp_path / "missing.json")
-    monkeypatch.setattr(dash.research_runner, "_ACTIVE_PROCESS", _FakeProcess(returncode=None))
+    now = datetime.now(UTC)
+    state_path = tmp_path / "run_state.v1.json"
+    state_path.write_text(
+        (
+            "{"
+            "\"version\":\"v1\","
+            "\"run_id\":\"run-live\","
+            "\"status\":\"running\","
+            "\"pid\":123,"
+            f"\"started_at_utc\":\"{(now - timedelta(seconds=60)).isoformat()}\","
+            f"\"updated_at_utc\":\"{now.isoformat()}\","
+            "\"stage\":\"evaluation\","
+            "\"status_reason\":\"research_run_started\","
+            "\"heartbeat_timeout_s\":300,"
+            "\"progress_path\":\"research/run_progress_latest.v1.json\","
+            "\"manifest_path\":\"research/run_manifest_latest.v1.json\","
+            "\"log_path\":\"logs/research/run-live.jsonl\","
+            "\"error\":null"
+            "}"
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(dash.research_artifacts, "RUN_STATE_PATH", state_path)
+    monkeypatch.setattr("research.run_state._pid_is_live", lambda pid: True)
 
     dash.app.testing = True
     client = dash.app.test_client()
@@ -189,31 +243,49 @@ def test_research_run_trigger_blocked_when_process_active(monkeypatch, tmp_path)
     assert payload["launch_state"] == "blocked_active_run"
 
 
-def test_research_run_trigger_returns_stale_signal_behavior(monkeypatch, tmp_path):
+def test_research_run_trigger_repairs_stale_signal_and_starts(monkeypatch, tmp_path):
     from dashboard import dashboard as dash
 
     stale_at = (datetime.now(UTC) - timedelta(seconds=600)).isoformat()
-    path = tmp_path / "run_progress_latest.v1.json"
-    path.write_text(
+    state_path = tmp_path / "run_state.v1.json"
+    state_path.write_text(
         (
             "{"
-            f"\"version\":\"v1\",\"status\":\"running\",\"last_updated_at_utc\":\"{stale_at}\""
+            "\"version\":\"v1\","
+            "\"run_id\":\"run-stale\","
+            "\"status\":\"running\","
+            "\"pid\":123,"
+            "\"started_at_utc\":\"2026-04-13T10:00:00+00:00\","
+            f"\"updated_at_utc\":\"{stale_at}\","
+            "\"stage\":\"evaluation\","
+            "\"status_reason\":\"research_run_started\","
+            "\"heartbeat_timeout_s\":300,"
+            "\"progress_path\":\"research/run_progress_latest.v1.json\","
+            "\"manifest_path\":\"research/run_manifest_latest.v1.json\","
+            "\"log_path\":\"logs/research/run-stale.jsonl\","
+            "\"error\":null"
             "}"
         ),
         encoding="utf-8",
     )
-    monkeypatch.setattr(dash.research_artifacts, "RUN_PROGRESS_PATH", path)
-    monkeypatch.setattr(dash.research_runner, "_ACTIVE_PROCESS", None)
+    monkeypatch.setattr(dash.research_artifacts, "RUN_STATE_PATH", state_path)
+    monkeypatch.setattr("research.run_state._pid_is_live", lambda pid: True)
+    monkeypatch.setattr(
+        dash.research_runner.subprocess,
+        "Popen",
+        lambda *args, **kwargs: type("FakeProcess", (), {"pid": 888})(),
+    )
 
     dash.app.testing = True
     client = dash.app.test_client()
     _set_operator_session(client)
     response = client.post("/api/research/run")
 
-    assert response.status_code == 409
+    assert response.status_code == 202
     payload = response.get_json()
-    assert payload["accepted"] is False
-    assert payload["launch_state"] == "blocked_stale_signal"
+    assert payload["accepted"] is True
+    assert payload["launch_state"] == "started"
+    assert payload["warnings"]
 
 
 def test_research_latest_endpoint_valid_artifact(monkeypatch, tmp_path):

--- a/tests/unit/test_research_observability.py
+++ b/tests/unit/test_research_observability.py
@@ -27,14 +27,38 @@ def _load_json(path: Path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+class FakeLifecycle:
+    def __init__(self) -> None:
+        self.heartbeats: list[tuple[str, str | None, str | None]] = []
+        self.completed: list[str] = []
+        self.failed: list[tuple[str, str, str, str]] = []
+
+    def heartbeat(self, *, run_id: str, stage: str | None = None, status_reason: str | None = None):
+        self.heartbeats.append((run_id, stage, status_reason))
+        return {}
+
+    def complete_run(self, *, run_id: str, status_reason: str = "research_run_completed", stage: str = "completed"):
+        self.completed.append(run_id)
+        return {}
+
+    def fail_run(self, *, run_id: str, status_reason: str, error_type: str, error_message: str, stage: str = "failed"):
+        self.failed.append((run_id, status_reason, error_type, error_message))
+        return {}
+
+
 def test_progress_sidecar_has_deterministic_structure_and_eta(tmp_path: Path):
     start = datetime(2026, 4, 13, 12, 0, 0, tzinfo=UTC)
     clock = FakeClock(start)
     logs: list[str] = []
     path = tmp_path / "research" / "run_progress_latest.v1.json"
+    lifecycle = FakeLifecycle()
     tracker = ProgressTracker(
         path=path,
+        lifecycle=lifecycle,
+        run_id="20260413T120000000000Z",
         started_at_utc=start,
+        manifest_path=tmp_path / "research" / "run_manifest_latest.v1.json",
+        log_path=tmp_path / "logs" / "research" / "20260413T120000000000Z.jsonl",
         now_source=clock.now,
         monotonic_source=clock.monotonic,
         log_fn=logs.append,
@@ -48,32 +72,37 @@ def test_progress_sidecar_has_deterministic_structure_and_eta(tmp_path: Path):
     payload = _load_json(path)
     assert payload == {
         "version": "v1",
-        "status": "running",
         "run_id": "20260413T120000000000Z",
+        "status": "running",
         "current_stage": "evaluation",
-        "started_at_utc": "2026-04-13T12:00:00+00:00",
-        "last_updated_at_utc": "2026-04-13T12:00:05+00:00",
-        "progress": {
+        "stage_progress": {
             "completed": 1,
             "total": 4,
             "percent": 25.0,
         },
+        "total_items": 4,
+        "completed_items": 1,
+        "failed_items": 0,
         "current_item": {
             "strategy": "sma_crossover",
             "asset": "BTC-USD",
             "interval": "1h",
         },
-        "timing": {
-            "elapsed_seconds": 5,
-            "stage_elapsed_seconds": 5,
-            "eta_seconds": 15,
-        },
-        "failure": None,
+        "started_at_utc": "2026-04-13T12:00:00+00:00",
+        "updated_at_utc": "2026-04-13T12:00:05+00:00",
+        "elapsed_seconds": 5,
+        "eta_seconds": 15,
+        "error": None,
     }
     assert logs[0] == "[research] stage stage=evaluation status=started total_items=4"
     assert logs[1] == (
         "[research] progress stage=evaluation progress=1/4 percent=25.0 "
         "elapsed_s=5 eta_s=15 current=sma_crossover BTC-USD 1h"
+    )
+    assert lifecycle.heartbeats[0] == (
+        "20260413T120000000000Z",
+        "evaluation",
+        "stage_started:evaluation",
     )
 
 
@@ -81,9 +110,14 @@ def test_completed_state_is_written_correctly(tmp_path: Path):
     start = datetime(2026, 4, 13, 12, 0, 0, tzinfo=UTC)
     clock = FakeClock(start)
     path = tmp_path / "research" / "run_progress_latest.v1.json"
+    lifecycle = FakeLifecycle()
     tracker = ProgressTracker(
         path=path,
+        lifecycle=lifecycle,
+        run_id="20260413T120000000000Z",
         started_at_utc=start,
+        manifest_path=tmp_path / "research" / "run_manifest_latest.v1.json",
+        log_path=tmp_path / "logs" / "research" / "20260413T120000000000Z.jsonl",
         now_source=clock.now,
         monotonic_source=clock.monotonic,
         log_fn=lambda message: None,
@@ -96,18 +130,24 @@ def test_completed_state_is_written_correctly(tmp_path: Path):
     payload = _load_json(path)
     assert payload["status"] == "completed"
     assert payload["current_stage"] == "completed"
-    assert payload["progress"] == {"completed": 3, "total": 3, "percent": 100.0}
-    assert payload["failure"] is None
-    assert payload["timing"]["elapsed_seconds"] == 9
+    assert payload["stage_progress"] == {"completed": 3, "total": 3, "percent": 100.0}
+    assert payload["error"] is None
+    assert payload["elapsed_seconds"] == 9
+    assert lifecycle.completed == ["20260413T120000000000Z"]
 
 
 def test_failed_state_is_written_correctly(tmp_path: Path):
     start = datetime(2026, 4, 13, 12, 0, 0, tzinfo=UTC)
     clock = FakeClock(start)
     path = tmp_path / "research" / "run_progress_latest.v1.json"
+    lifecycle = FakeLifecycle()
     tracker = ProgressTracker(
         path=path,
+        lifecycle=lifecycle,
+        run_id="20260413T120000000000Z",
         started_at_utc=start,
+        manifest_path=tmp_path / "research" / "run_manifest_latest.v1.json",
+        log_path=tmp_path / "logs" / "research" / "20260413T120000000000Z.jsonl",
         now_source=clock.now,
         monotonic_source=clock.monotonic,
         log_fn=lambda message: None,
@@ -120,21 +160,27 @@ def test_failed_state_is_written_correctly(tmp_path: Path):
     payload = _load_json(path)
     assert payload["status"] == "failed"
     assert payload["current_stage"] == "failed"
-    assert payload["failure"] == {
+    assert payload["error"] == {
         "failure_stage": "preflight",
         "error_type": "RuntimeError",
         "error_message": "boom",
     }
-    assert payload["timing"]["elapsed_seconds"] == 2
+    assert payload["elapsed_seconds"] == 2
+    assert lifecycle.failed[0][0] == "20260413T120000000000Z"
 
 
 def test_large_evaluation_progress_is_throttled(tmp_path: Path):
     start = datetime(2026, 4, 13, 12, 0, 0, tzinfo=UTC)
     clock = FakeClock(start)
     path = tmp_path / "research" / "run_progress_latest.v1.json"
+    lifecycle = FakeLifecycle()
     tracker = ProgressTracker(
         path=path,
+        lifecycle=lifecycle,
+        run_id="20260413T120000000000Z",
         started_at_utc=start,
+        manifest_path=tmp_path / "research" / "run_manifest_latest.v1.json",
+        log_path=tmp_path / "logs" / "research" / "20260413T120000000000Z.jsonl",
         now_source=clock.now,
         monotonic_source=clock.monotonic,
         log_fn=lambda message: None,
@@ -151,5 +197,41 @@ def test_large_evaluation_progress_is_throttled(tmp_path: Path):
     tracker.advance(completed=2, total=100)
     second = _load_json(path)
 
-    assert first["progress"]["completed"] == 1
-    assert second["progress"]["completed"] == 1
+    assert first["completed_items"] == 1
+    assert second["completed_items"] == 1
+
+
+def test_manifest_and_structured_log_are_written(tmp_path: Path):
+    start = datetime(2026, 4, 13, 12, 0, 0, tzinfo=UTC)
+    clock = FakeClock(start)
+    path = tmp_path / "research" / "run_progress_latest.v1.json"
+    manifest_path = tmp_path / "research" / "run_manifest_latest.v1.json"
+    log_path = tmp_path / "logs" / "research" / "20260413T120000000000Z.jsonl"
+    tracker = ProgressTracker(
+        path=path,
+        lifecycle=FakeLifecycle(),
+        run_id="20260413T120000000000Z",
+        started_at_utc=start,
+        manifest_path=manifest_path,
+        log_path=log_path,
+        now_source=clock.now,
+        monotonic_source=clock.monotonic,
+        log_fn=lambda message: None,
+    )
+
+    tracker.write_manifest(
+        {
+            "version": "v1",
+            "run_id": "20260413T120000000000Z",
+            "created_at_utc": start.isoformat(),
+            "started_at_utc": start.isoformat(),
+            "status": "running",
+        }
+    )
+    tracker.start_stage("planning")
+
+    manifest = _load_json(manifest_path)
+    logs = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()]
+    assert manifest["status"] == "running"
+    assert logs[0]["event"] == "manifest_written"
+    assert logs[1]["event"] == "stage_started"

--- a/tests/unit/test_research_run_state.py
+++ b/tests/unit/test_research_run_state.py
@@ -35,7 +35,7 @@ def test_start_run_writes_authoritative_state(tmp_path: Path):
     assert _load_json(tmp_path / "research" / "run_state.v1.json")["run_id"] == payload["run_id"]
 
 
-def test_repair_stale_run_marks_aborted_on_dead_pid(tmp_path: Path):
+def test_repair_stale_run_marks_aborted_on_dead_pid(tmp_path: Path, monkeypatch):
     now = datetime(2026, 4, 13, 12, 5, tzinfo=UTC)
     state_path = tmp_path / "research" / "run_state.v1.json"
     write_json_atomic(
@@ -56,6 +56,7 @@ def test_repair_stale_run_marks_aborted_on_dead_pid(tmp_path: Path):
             "error": None,
         },
     )
+    monkeypatch.setattr("research.run_state._pid_is_live", lambda pid: False)
     store = RunStateStore(
         state_path=state_path,
         history_root=tmp_path / "research" / "history",

--- a/tests/unit/test_research_run_state.py
+++ b/tests/unit/test_research_run_state.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from research.run_state import ActiveResearchRunError, RunStateStore, write_json_atomic
+
+
+def _load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_start_run_writes_authoritative_state(tmp_path: Path):
+    start = datetime(2026, 4, 13, 12, 0, tzinfo=UTC)
+    store = RunStateStore(
+        state_path=tmp_path / "research" / "run_state.v1.json",
+        history_root=tmp_path / "research" / "history",
+        now_source=lambda: start,
+        pid_source=lambda: 321,
+    )
+
+    payload = store.start_run(
+        progress_path=tmp_path / "research" / "run_progress_latest.v1.json",
+        manifest_path=tmp_path / "research" / "run_manifest_latest.v1.json",
+        log_dir=tmp_path / "logs" / "research",
+        heartbeat_timeout_s=300,
+    )
+
+    assert payload["status"] == "running"
+    assert payload["pid"] == 321
+    assert payload["heartbeat_timeout_s"] == 300
+    assert _load_json(tmp_path / "research" / "run_state.v1.json")["run_id"] == payload["run_id"]
+
+
+def test_repair_stale_run_marks_aborted_on_dead_pid(tmp_path: Path):
+    now = datetime(2026, 4, 13, 12, 5, tzinfo=UTC)
+    state_path = tmp_path / "research" / "run_state.v1.json"
+    write_json_atomic(
+        state_path,
+        {
+            "version": "v1",
+            "run_id": "run-1",
+            "status": "running",
+            "pid": 999,
+            "started_at_utc": "2026-04-13T12:00:00+00:00",
+            "updated_at_utc": "2026-04-13T12:04:00+00:00",
+            "stage": "evaluation",
+            "status_reason": "research_run_started",
+            "heartbeat_timeout_s": 300,
+            "progress_path": str(tmp_path / "research" / "run_progress_latest.v1.json"),
+            "manifest_path": str(tmp_path / "research" / "run_manifest_latest.v1.json"),
+            "log_path": str(tmp_path / "logs" / "research" / "run-1.jsonl"),
+            "error": None,
+        },
+    )
+    store = RunStateStore(
+        state_path=state_path,
+        history_root=tmp_path / "research" / "history",
+        now_source=lambda: now,
+    )
+
+    result = store.repair_stale_run()
+
+    repaired = _load_json(state_path)
+    assert result["repaired"] is True
+    assert repaired["status"] == "aborted"
+    assert repaired["status_reason"] == "stale_recovery_dead_process"
+    assert repaired["pid"] is None
+
+
+def test_repair_stale_run_marks_aborted_on_heartbeat_timeout(tmp_path: Path, monkeypatch):
+    now = datetime(2026, 4, 13, 12, 10, tzinfo=UTC)
+    state_path = tmp_path / "research" / "run_state.v1.json"
+    write_json_atomic(
+        state_path,
+        {
+            "version": "v1",
+            "run_id": "run-2",
+            "status": "running",
+            "pid": 123,
+            "started_at_utc": "2026-04-13T12:00:00+00:00",
+            "updated_at_utc": "2026-04-13T12:00:00+00:00",
+            "stage": "evaluation",
+            "status_reason": "research_run_started",
+            "heartbeat_timeout_s": 300,
+            "progress_path": str(tmp_path / "research" / "run_progress_latest.v1.json"),
+            "manifest_path": str(tmp_path / "research" / "run_manifest_latest.v1.json"),
+            "log_path": str(tmp_path / "logs" / "research" / "run-2.jsonl"),
+            "error": None,
+        },
+    )
+    monkeypatch.setattr("research.run_state._pid_is_live", lambda pid: True)
+    store = RunStateStore(
+        state_path=state_path,
+        history_root=tmp_path / "research" / "history",
+        now_source=lambda: now,
+    )
+
+    result = store.repair_stale_run()
+    repaired = _load_json(state_path)
+    assert result["repaired"] is True
+    assert repaired["status"] == "aborted"
+    assert repaired["status_reason"] == "stale_recovery_heartbeat_timeout"
+
+
+def test_start_run_rejects_live_running_state(tmp_path: Path, monkeypatch):
+    state_path = tmp_path / "research" / "run_state.v1.json"
+    write_json_atomic(
+        state_path,
+        {
+            "version": "v1",
+            "run_id": "run-live",
+            "status": "running",
+            "pid": 123,
+            "started_at_utc": "2026-04-13T12:00:00+00:00",
+            "updated_at_utc": "2026-04-13T12:04:00+00:00",
+            "stage": "evaluation",
+            "status_reason": "research_run_started",
+            "heartbeat_timeout_s": 300,
+            "progress_path": "research/run_progress_latest.v1.json",
+            "manifest_path": "research/run_manifest_latest.v1.json",
+            "log_path": "logs/research/run-live.jsonl",
+            "error": None,
+        },
+    )
+    monkeypatch.setattr("research.run_state._pid_is_live", lambda pid: True)
+    store = RunStateStore(
+        state_path=state_path,
+        history_root=tmp_path / "research" / "history",
+        now_source=lambda: datetime(2026, 4, 13, 12, 4, 30, tzinfo=UTC),
+    )
+
+    with pytest.raises(ActiveResearchRunError):
+        store.start_run(
+            progress_path=tmp_path / "research" / "run_progress_latest.v1.json",
+            manifest_path=tmp_path / "research" / "run_manifest_latest.v1.json",
+            log_dir=tmp_path / "logs" / "research",
+            heartbeat_timeout_s=300,
+        )

--- a/tests/unit/test_run_research_observability.py
+++ b/tests/unit/test_run_research_observability.py
@@ -207,15 +207,23 @@ def test_run_research_writes_completed_progress_sidecar_and_keeps_public_schema(
     run_research_module.run_research()
 
     progress = _load_json(tmp_path / "research" / "run_progress_latest.v1.json")
+    state = _load_json(tmp_path / "research" / "run_state.v1.json")
+    manifest = _load_json(tmp_path / "research" / "run_manifest_latest.v1.json")
     public_json = _load_json(tmp_path / "research" / "research_latest.json")
     with (tmp_path / "research" / "strategy_matrix.csv").open(encoding="utf-8", newline="") as handle:
         csv_rows = list(csv.DictReader(handle))
 
     assert progress["version"] == "v1"
+    assert progress["run_id"] == state["run_id"]
     assert progress["status"] == "completed"
     assert progress["current_stage"] == "completed"
-    assert progress["progress"] == {"completed": 1, "total": 1, "percent": 100.0}
-    assert progress["failure"] is None
+    assert progress["stage_progress"] == {"completed": 1, "total": 1, "percent": 100.0}
+    assert progress["error"] is None
+    assert state["status"] == "completed"
+    assert state["pid"] is None
+    assert manifest["status"] == "completed"
+    assert (tmp_path / "logs" / "research" / f"{state['run_id']}.jsonl").exists()
+    assert (tmp_path / "research" / "history" / state["run_id"] / "run_state.v1.json").exists()
     assert list(public_json["results"][0].keys()) == ROW_SCHEMA
     assert list(csv_rows[0].keys()) == ROW_SCHEMA
 
@@ -227,7 +235,10 @@ def test_run_research_marks_failed_progress_sidecar_on_degenerate_run(monkeypatc
         run_research_module.run_research()
 
     progress = _load_json(tmp_path / "research" / "run_progress_latest.v1.json")
+    state = _load_json(tmp_path / "research" / "run_state.v1.json")
     assert progress["status"] == "failed"
     assert progress["current_stage"] == "failed"
-    assert progress["failure"]["failure_stage"] == "preflight"
-    assert progress["failure"]["error_type"] == "DegenerateResearchRunError"
+    assert progress["error"]["failure_stage"] == "preflight"
+    assert progress["error"]["error_type"] == "DegenerateResearchRunError"
+    assert state["status"] == "failed"
+    assert state["status_reason"] == "research_run_failed:preflight"


### PR DESCRIPTION
## Summary

This PR redesigns research run observability and lifecycle state to be deterministic, file-driven, and restart-safe.

## Problem

Research runs could become “zombie runs” after container or Flask restarts:
- dashboard could still show `running`
- no active process existed
- status was partially derived from in-memory dashboard state
- observability was incomplete and restart-unsafe

## Root cause

Run lifecycle truth was split across:
- partial filesystem artifacts
- dashboard-local in-memory process state

That made status derivation nondeterministic.

## What changed

### Authoritative lifecycle state
Added `research/run_state.py` as the sole lifecycle owner.

Introduced:
- `research/run_state.v1.json`
- single-run guard
- stale/dead-process recovery
- terminal state transitions
- history snapshots under `research/history/<run_id>/`

### Observability artifacts
Reworked research observability to add:
- progress-only `research/run_progress_latest.v1.json`
- setup/lineage `research/run_manifest_latest.v1.json`
- structured JSONL logs in `logs/research/<run_id>.jsonl`

### Runner wiring
Updated `research/run_research.py` so that:
- run state is acquired at startup
- heartbeats happen during planning / preflight / evaluation / output writing
- success/failure transitions are handled through the lifecycle store

### Dashboard status flow
Updated dashboard status/control flow so that:
- status is derived from disk on every call
- stale/zombie runs are repaired on status read
- dashboard no longer acts as lifecycle source of truth

## Guarantees

Public outputs remain unchanged:
- `research/research_latest.json`
- `research/strategy_matrix.csv`

## Validation

- Focused lifecycle/dashboard tests: 25 passed
- Runner/dashboard/schema regressions: 18 passed
- Full suite: 387 passed, 1 skipped

## Intentionally deferred

- manual abort controls
- run history UI
- candidate planner / screening lane
- multiprocessing / parallel evaluation
- cache / reuse optimizations

## Next step

Candidate planner + eligibility filtering + cheap screening lane.