### PR TITLE
feat: introduce selective candidate pipeline with fit-prior gating, a…

### DIFF
--- a/research/asset_typing.py
+++ b/research/asset_typing.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import Any
+
+NORMALIZED_ASSET_TYPE_ALIASES: dict[str, str] = {
+    "crypto": "crypto",
+    "cryptocurrency": "crypto",
+    "equity": "equity",
+    "stock": "equity",
+    "stocks": "equity",
+    "future": "futures",
+    "futures": "futures",
+    "index": "index_like",
+    "index_like": "index_like",
+    "etf": "index_like",
+}
+
+
+def normalize_asset_type(*, asset_type: Any = None, asset_class: Any = None) -> str:
+    explicit_type = str(asset_type or "").strip().lower()
+    explicit_class = str(asset_class or "").strip().lower()
+    if explicit_type in NORMALIZED_ASSET_TYPE_ALIASES:
+        return NORMALIZED_ASSET_TYPE_ALIASES[explicit_type]
+    if explicit_class in NORMALIZED_ASSET_TYPE_ALIASES:
+        return NORMALIZED_ASSET_TYPE_ALIASES[explicit_class]
+    return "unknown"

--- a/research/candidate_pipeline.py
+++ b/research/candidate_pipeline.py
@@ -1,0 +1,418 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from collections import Counter
+from datetime import datetime
+from typing import Any
+
+from research.asset_typing import normalize_asset_type
+from research.registry import count_param_combinations, expand_param_grid
+
+FIT_ALLOWED = "allowed"
+FIT_DISCOURAGED = "discouraged"
+FIT_BLOCKED = "blocked"
+
+SCREENING_PROMOTED = "promoted_to_validation"
+SCREENING_REJECTED = "rejected_in_screening"
+
+SUPPORTED_INITIAL_LANE = "supported"
+BLOCKED_INITIAL_LANE = "blocked"
+POSITION_OUTRIGHT = "outright"
+POSITION_SPREAD = "spread"
+
+DEFAULT_FIT_PRIOR_MATRIX: dict[str, dict[str, tuple[str, str]]] = {
+    "futures": {
+        "trend_following": (FIT_ALLOWED, "empirical_fit_high"),
+        "breakout": (FIT_ALLOWED, "empirical_fit_high"),
+        "time_series_momentum": (FIT_ALLOWED, "empirical_fit_high"),
+    },
+    "index_like": {
+        "trend_following": (FIT_ALLOWED, "empirical_fit_high"),
+        "breakout": (FIT_ALLOWED, "empirical_fit_high"),
+        "time_series_momentum": (FIT_ALLOWED, "empirical_fit_high"),
+    },
+    "crypto": {
+        "trend_following": (FIT_ALLOWED, "empirical_fit_mixed"),
+        "breakout": (FIT_ALLOWED, "empirical_fit_mixed"),
+        "time_series_momentum": (FIT_ALLOWED, "empirical_fit_mixed"),
+        "mean_reversion": (FIT_DISCOURAGED, "insufficient_market_structure_fit"),
+    },
+    "equity": {
+        "mean_reversion": (FIT_DISCOURAGED, "microstructure_sensitive"),
+        "stat_arb": (FIT_BLOCKED, "requires_spread_not_outright"),
+    },
+    "unknown": {},
+}
+
+
+def _canonical_json(payload: Any) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def _hash_payload(payload: Any) -> str:
+    return hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+def _asset_metadata(asset: Any) -> tuple[str, str, str]:
+    raw_asset_type = str(getattr(asset, "asset_type", "") or "")
+    raw_asset_class = str(getattr(asset, "asset_class", "") or "")
+    return (
+        str(getattr(asset, "symbol", asset)),
+        normalize_asset_type(asset_type=raw_asset_type, asset_class=raw_asset_class),
+        raw_asset_class,
+    )
+
+
+def _strategy_family(strategy: dict[str, Any]) -> str:
+    return str(strategy.get("strategy_family") or strategy.get("family") or "unknown")
+
+
+def _candidate_sort_key(candidate: dict[str, Any]) -> tuple[str, str, str, str]:
+    return (
+        str(candidate["strategy_name"]),
+        str(candidate["asset"]),
+        str(candidate["interval"]),
+        str(candidate["candidate_id"]),
+    )
+
+
+def plan_candidates(
+    *,
+    strategies: list[dict[str, Any]],
+    assets: list[Any],
+    intervals: list[str],
+) -> list[dict[str, Any]]:
+    candidates: list[dict[str, Any]] = []
+    for strategy in sorted(strategies, key=lambda item: str(item["name"])):
+        strategy_name = str(strategy["name"])
+        strategy_family = _strategy_family(strategy)
+        param_grid = copy.deepcopy(strategy.get("params") or {})
+        param_grid_hash = _hash_payload(param_grid)
+        combination_count = count_param_combinations(strategy)
+        position_structure = str(strategy.get("position_structure") or POSITION_OUTRIGHT)
+        initial_lane_support = str(strategy.get("initial_lane_support") or SUPPORTED_INITIAL_LANE)
+
+        for interval in sorted(str(interval) for interval in intervals):
+            for asset in sorted(assets, key=lambda entry: _asset_metadata(entry)[0]):
+                symbol, asset_type, asset_class = _asset_metadata(asset)
+                candidate = {
+                    "candidate_id": _hash_payload(
+                        {
+                            "strategy_name": strategy_name,
+                            "strategy_family": strategy_family,
+                            "asset": symbol,
+                            "asset_type": asset_type,
+                            "asset_class": asset_class,
+                            "interval": interval,
+                            "param_grid_hash": param_grid_hash,
+                            "position_structure": position_structure,
+                            "initial_lane_support": initial_lane_support,
+                        }
+                    ),
+                    "current_status": "planned",
+                    "strategy_name": strategy_name,
+                    "family": str(strategy["family"]),
+                    "strategy_family": strategy_family,
+                    "asset": symbol,
+                    "asset_type": asset_type,
+                    "asset_class": asset_class,
+                    "interval": interval,
+                    "parameter_space_identity": {
+                        "param_grid_hash": param_grid_hash,
+                        "combination_count": int(combination_count),
+                    },
+                    "strategy_requirements": {
+                        "position_structure": position_structure,
+                        "initial_lane_support": initial_lane_support,
+                    },
+                    "fit_prior": {
+                        "status": "pending",
+                        "reason": None,
+                    },
+                    "dedupe": {
+                        "duplicate_removed": False,
+                        "raw_occurrences": 1,
+                    },
+                    "eligibility": {
+                        "status": "pending",
+                        "reason": None,
+                    },
+                    "screening": {
+                        "status": "pending",
+                        "reason": None,
+                        "sampled_combination_count": 0,
+                    },
+                    "validation": {
+                        "status": "pending",
+                        "result_success": None,
+                    },
+                }
+                candidates.append(candidate)
+    return sorted(candidates, key=_candidate_sort_key)
+
+
+def deduplicate_candidates(candidates: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], dict[str, int]]:
+    unique_by_id: dict[str, dict[str, Any]] = {}
+    for candidate in sorted(candidates, key=_candidate_sort_key):
+        candidate_id = str(candidate["candidate_id"])
+        if candidate_id not in unique_by_id:
+            unique_by_id[candidate_id] = copy.deepcopy(candidate)
+            continue
+        unique_by_id[candidate_id]["dedupe"]["raw_occurrences"] += 1
+
+    unique_candidates = []
+    for candidate_id in sorted(unique_by_id):
+        candidate = unique_by_id[candidate_id]
+        candidate["dedupe"]["duplicate_removed"] = candidate["dedupe"]["raw_occurrences"] > 1
+        candidate["current_status"] = "deduplicated"
+        unique_candidates.append(candidate)
+
+    raw_count = len(candidates)
+    deduplicated_count = len(unique_candidates)
+    return unique_candidates, {
+        "raw_candidate_count": int(raw_count),
+        "deduplicated_candidate_count": int(deduplicated_count),
+        "duplicates_removed": int(raw_count - deduplicated_count),
+    }
+
+
+def _normalized_asset_type(candidate: dict[str, Any]) -> str:
+    return normalize_asset_type(
+        asset_type=candidate.get("asset_type"),
+        asset_class=candidate.get("asset_class"),
+    )
+
+
+def assess_fit_prior(candidate: dict[str, Any]) -> tuple[str, str]:
+    requirements = candidate.get("strategy_requirements") or {}
+    if requirements.get("position_structure") == POSITION_SPREAD:
+        return FIT_BLOCKED, "requires_spread_not_outright"
+    if requirements.get("initial_lane_support") == BLOCKED_INITIAL_LANE:
+        return FIT_BLOCKED, "unsupported_for_initial_lane"
+
+    asset_type = _normalized_asset_type(candidate)
+    strategy_family = str(candidate.get("strategy_family") or "unknown")
+    mapping = DEFAULT_FIT_PRIOR_MATRIX.get(asset_type, {})
+    if strategy_family in mapping:
+        return mapping[strategy_family]
+    if asset_type == "unknown":
+        return FIT_DISCOURAGED, "unsupported_for_initial_lane"
+    return FIT_ALLOWED, "empirical_fit_mixed"
+
+
+def apply_fit_prior(candidates: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    updated: list[dict[str, Any]] = []
+    blocked_reasons: Counter[str] = Counter()
+    counts = {
+        "fit_allowed_count": 0,
+        "fit_discouraged_count": 0,
+        "fit_blocked_count": 0,
+    }
+    for candidate in sorted(candidates, key=_candidate_sort_key):
+        item = copy.deepcopy(candidate)
+        status, reason = assess_fit_prior(item)
+        item["fit_prior"] = {"status": status, "reason": reason}
+        if status == FIT_BLOCKED:
+            item["current_status"] = "fit_blocked"
+            counts["fit_blocked_count"] += 1
+            blocked_reasons[reason] += 1
+        elif status == FIT_DISCOURAGED:
+            item["current_status"] = "fit_discouraged"
+            counts["fit_discouraged_count"] += 1
+        else:
+            counts["fit_allowed_count"] += 1
+        updated.append(item)
+
+    return updated, {
+        **counts,
+        "fit_blocked_reasons": dict(sorted(blocked_reasons.items())),
+    }
+
+
+def index_readiness(pair_diagnostics: list[dict[str, Any]]) -> dict[tuple[str, str], dict[str, Any]]:
+    return {
+        (str(item["asset"]), str(item["interval"])): item
+        for item in pair_diagnostics
+    }
+
+
+def apply_eligibility(
+    *,
+    candidates: list[dict[str, Any]],
+    readiness_by_pair: dict[tuple[str, str], dict[str, Any]],
+    universe_symbols: set[str],
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    updated: list[dict[str, Any]] = []
+    rejection_reasons: Counter[str] = Counter()
+    eligible_count = 0
+    rejected_count = 0
+
+    for candidate in sorted(candidates, key=_candidate_sort_key):
+        item = copy.deepcopy(candidate)
+        if item["fit_prior"]["status"] == FIT_BLOCKED:
+            updated.append(item)
+            continue
+
+        reason: str | None = None
+        if not item.get("strategy_name") or not item.get("asset") or not item.get("interval"):
+            reason = "invalid_candidate_shape"
+        elif item["asset"] not in universe_symbols:
+            reason = "universe_membership_mismatch"
+        else:
+            readiness = readiness_by_pair.get((str(item["asset"]), str(item["interval"])))
+            if readiness is None:
+                reason = "invalid_asset_interval"
+            elif readiness.get("status") != "evaluable":
+                reason = str(readiness.get("drop_reason") or "invalid_asset_interval")
+
+        if reason is None:
+            item["eligibility"] = {"status": "eligible", "reason": None}
+            eligible_count += 1
+        else:
+            item["eligibility"] = {"status": "rejected", "reason": reason}
+            item["current_status"] = "eligibility_rejected"
+            rejected_count += 1
+            rejection_reasons[reason] += 1
+        updated.append(item)
+
+    return updated, {
+        "eligible_candidate_count": int(eligible_count),
+        "eligibility_rejected_count": int(rejected_count),
+        "eligibility_rejection_reasons": dict(sorted(rejection_reasons.items())),
+    }
+
+
+def screening_param_samples(param_grid: dict[str, Any], max_samples: int = 3) -> list[dict[str, Any]]:
+    combinations = expand_param_grid(param_grid)
+    if not combinations:
+        return [{}]
+    if len(combinations) <= max_samples:
+        return combinations
+
+    selected_indices = {0, len(combinations) // 2, len(combinations) - 1}
+    sampled = [combinations[index] for index in sorted(selected_indices)]
+    return sampled[:max_samples]
+
+
+def normalize_screening_decision(sample_results: list[dict[str, Any]]) -> dict[str, Any]:
+    if any(result.get("status") == SCREENING_PROMOTED for result in sample_results):
+        return {
+            "status": SCREENING_PROMOTED,
+            "reason": None,
+            "sampled_combination_count": len(sample_results),
+        }
+
+    reason_counts = Counter(str(result.get("reason") or "screening_error") for result in sample_results)
+    reason = sorted(
+        reason_counts.items(),
+        key=lambda item: (-item[1], item[0]),
+    )[0][0]
+    return {
+        "status": SCREENING_REJECTED,
+        "reason": reason,
+        "sampled_combination_count": len(sample_results),
+    }
+
+
+def screening_candidates(candidates: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        candidate
+        for candidate in sorted(candidates, key=_candidate_sort_key)
+        if candidate.get("eligibility", {}).get("status") == "eligible"
+    ]
+
+
+def validation_candidates(candidates: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        candidate
+        for candidate in sorted(candidates, key=_candidate_sort_key)
+        if candidate.get("screening", {}).get("status") == SCREENING_PROMOTED
+    ]
+
+
+def summarize_candidates(candidates: list[dict[str, Any]]) -> dict[str, int]:
+    raw_count = sum(int(candidate["dedupe"]["raw_occurrences"]) for candidate in candidates)
+    deduplicated_count = len(candidates)
+    fit_statuses = Counter(str(candidate["fit_prior"]["status"]) for candidate in candidates)
+    eligibility_statuses = Counter(str(candidate["eligibility"]["status"]) for candidate in candidates)
+    screening_statuses = Counter(str(candidate["screening"]["status"]) for candidate in candidates)
+    validated_count = sum(
+        1
+        for candidate in candidates
+        if candidate.get("validation", {}).get("status") == "validated"
+    )
+    return {
+        "raw_candidate_count": int(raw_count),
+        "fit_allowed_count": int(fit_statuses.get(FIT_ALLOWED, 0)),
+        "fit_discouraged_count": int(fit_statuses.get(FIT_DISCOURAGED, 0)),
+        "fit_blocked_count": int(fit_statuses.get(FIT_BLOCKED, 0)),
+        "deduplicated_candidate_count": int(deduplicated_count),
+        "duplicates_removed": int(raw_count - deduplicated_count),
+        "eligible_candidate_count": int(eligibility_statuses.get("eligible", 0)),
+        "eligibility_rejected_count": int(eligibility_statuses.get("rejected", 0)),
+        "screening_rejected_count": int(screening_statuses.get(SCREENING_REJECTED, 0)),
+        "validation_candidate_count": int(screening_statuses.get(SCREENING_PROMOTED, 0)),
+        "validated_count": int(validated_count),
+    }
+
+
+def build_candidate_artifact_payload(
+    *,
+    run_id: str,
+    as_of_utc: datetime,
+    candidates: list[dict[str, Any]],
+) -> dict[str, Any]:
+    ordered_candidates = sorted((copy.deepcopy(candidate) for candidate in candidates), key=_candidate_sort_key)
+    return {
+        "version": "v1",
+        "run_id": run_id,
+        "generated_at_utc": as_of_utc.isoformat(),
+        "summary": summarize_candidates(ordered_candidates),
+        "candidates": ordered_candidates,
+    }
+
+
+def build_filter_summary_payload(
+    *,
+    run_id: str,
+    as_of_utc: datetime,
+    candidates: list[dict[str, Any]],
+) -> dict[str, Any]:
+    fit_blocked_reasons = Counter(
+        str(candidate["fit_prior"]["reason"])
+        for candidate in candidates
+        if candidate.get("fit_prior", {}).get("status") == FIT_BLOCKED
+        and candidate.get("fit_prior", {}).get("reason")
+    )
+    eligibility_rejection_reasons = Counter(
+        str(candidate["eligibility"]["reason"])
+        for candidate in candidates
+        if candidate.get("eligibility", {}).get("status") == "rejected"
+        and candidate.get("eligibility", {}).get("reason")
+    )
+    screening_rejection_reasons = Counter(
+        str(candidate["screening"]["reason"])
+        for candidate in candidates
+        if candidate.get("screening", {}).get("status") == SCREENING_REJECTED
+        and candidate.get("screening", {}).get("reason")
+    )
+    screening_decisions = Counter(
+        str(candidate["screening"]["status"])
+        for candidate in candidates
+        if candidate.get("screening", {}).get("status") in {SCREENING_PROMOTED, SCREENING_REJECTED}
+    )
+    return {
+        "version": "v1",
+        "run_id": run_id,
+        "generated_at_utc": as_of_utc.isoformat(),
+        "summary": summarize_candidates(candidates),
+        "fit_blocked_reasons": dict(sorted(fit_blocked_reasons.items())),
+        "eligibility_rejection_reasons": dict(sorted(eligibility_rejection_reasons.items())),
+        "screening_decisions": {
+            SCREENING_PROMOTED: int(screening_decisions.get(SCREENING_PROMOTED, 0)),
+            SCREENING_REJECTED: int(screening_decisions.get(SCREENING_REJECTED, 0)),
+        },
+        "screening_rejection_reasons": dict(sorted(screening_rejection_reasons.items())),
+    }

--- a/research/observability.py
+++ b/research/observability.py
@@ -198,7 +198,7 @@ class ProgressTracker:
         return max(0, int(round(self._monotonic_source() - self._run_started_monotonic)))
 
     def _eta_seconds(self) -> int | None:
-        if self.status != "running" or self.current_stage != "evaluation":
+        if self.status != "running" or self.current_stage not in {"screening", "validation", "evaluation"}:
             return None
         if self.completed_items <= 0 or self.total_items <= self.completed_items:
             return 0 if self.total_items > 0 and self.completed_items >= self.total_items else None

--- a/research/registry.py
+++ b/research/registry.py
@@ -31,6 +31,9 @@ STRATEGIES = [
             "periode": [14],
         },
         "family": "mean_reversion",
+        "strategy_family": "mean_reversion",
+        "position_structure": "outright",
+        "initial_lane_support": "supported",
         "hypothesis": "RSI mean reversion werkt mogelijk alleen in niet-trending regimes.",
         "enabled": True,
     },
@@ -42,6 +45,9 @@ STRATEGIES = [
             "std": [2.0],
         },
         "family": "mean_reversion",
+        "strategy_family": "mean_reversion",
+        "position_structure": "outright",
+        "initial_lane_support": "supported",
         "hypothesis": "Bollinger mean reversion is waarschijnlijk zwak op intraday crypto.",
         "enabled": True,
     },
@@ -63,6 +69,9 @@ STRATEGIES = [
             "std": [2.0],
         },
         "family": "mean_reversion",
+        "strategy_family": "mean_reversion",
+        "position_structure": "outright",
+        "initial_lane_support": "supported",
         "hypothesis": "Regime filtering kan Bollinger verbeteren, maar lost zwakke MR-edge mogelijk niet op.",
         "enabled": True,
     },
@@ -78,6 +87,9 @@ STRATEGIES = [
             "max_volatility": [0.02, 0.03],
         },
         "family": "trend",
+        "strategy_family": "trend_following",
+        "position_structure": "outright",
+        "initial_lane_support": "supported",
         "hypothesis": "Crypto momentum maakt trend pullback plausibeler dan mean reversion.",
         "enabled": True,
     },
@@ -95,6 +107,9 @@ STRATEGIES = [
             "stop_loss": [0.01, 0.015, 0.02],
         },
         "family": "trend",
+        "strategy_family": "trend_following",
+        "position_structure": "outright",
+        "initial_lane_support": "supported",
         "hypothesis": "Trend pullback kan verbeteren met expliciete take-profit en stop-loss trade management.",
         "enabled": True,
     },
@@ -106,6 +121,9 @@ STRATEGIES = [
             "ema_exit": [10, 20],
         },
         "family": "trend",
+        "strategy_family": "breakout",
+        "position_structure": "outright",
+        "initial_lane_support": "supported",
         "hypothesis": "Crypto kan sterker reageren op breakout momentum dan op mean reversion.",
         "enabled": True,
     },
@@ -117,6 +135,9 @@ STRATEGIES = [
             "slow_window": [50, 100],
         },
         "family": "trend",
+        "strategy_family": "trend_following",
+        "position_structure": "outright",
+        "initial_lane_support": "supported",
         "hypothesis": (
             "Klassieke SMA crossover capturet persistent directional moves "
             "per orchestrator_brief §4.1 tier 1 baseline."
@@ -132,6 +153,9 @@ STRATEGIES = [
             "exit_z": [0.5],
         },
         "family": "mean_reversion",
+        "strategy_family": "mean_reversion",
+        "position_structure": "outright",
+        "initial_lane_support": "supported",
         "hypothesis": (
             "Price z-score mean reversion capturet deviations from "
             "equilibrium per orchestrator_brief §4.2 tier 1 baseline."
@@ -157,6 +181,9 @@ STRATEGIES = [
             "hedge_ratio": [1.0],
         },
         "family": "stat_arb",
+        "strategy_family": "stat_arb",
+        "position_structure": "spread",
+        "initial_lane_support": "blocked",
         "hypothesis": (
             "Spread z-score pairs trading per orchestrator_brief §4.3 "
             "tier 1 baseline. enabled=False is intentional: the "

--- a/research/run_research.py
+++ b/research/run_research.py
@@ -8,6 +8,7 @@ import hashlib
 import json
 import os
 import subprocess
+import time
 from datetime import UTC, datetime, timezone
 from pathlib import Path
 
@@ -20,16 +21,31 @@ from agent.backtesting.engine import (
     FoldLeakageError,
     normalize_evaluation_config,
 )
+from research.candidate_pipeline import (
+    SCREENING_PROMOTED,
+    apply_eligibility,
+    apply_fit_prior,
+    build_candidate_artifact_payload,
+    build_filter_summary_payload,
+    deduplicate_candidates,
+    index_readiness,
+    normalize_screening_decision,
+    plan_candidates,
+    screening_candidates,
+    screening_param_samples,
+    summarize_candidates,
+    validation_candidates,
+)
 from research.empty_run_reporting import (
     DegenerateResearchRunError,
     build_empty_run_diagnostics_payload,
 )
 from research.observability import ProgressTracker
-from research.registry import get_enabled_strategies
-from research.results import make_result_row, write_latest_json, write_results_to_csv
 from research.portfolio_reporting import build_portfolio_aggregation_payload
 from research.promotion_reporting import build_candidate_registry_payload
 from research.regime_reporting import build_regime_diagnostics_payload
+from research.registry import get_enabled_strategies
+from research.results import make_result_row, write_latest_json, write_results_to_csv
 from research.run_state import RunStateStore
 from research.statistical_reporting import build_statistical_defensibility_payload, regime_count_settings
 from research.universe import build_research_universe
@@ -41,11 +57,14 @@ UNIVERSE_SNAPSHOT_PATH = Path("research/universe_snapshot_latest.v1.json")
 PORTFOLIO_AGGREGATION_PATH = Path("research/portfolio_aggregation_latest.v1.json")
 REGIME_DIAGNOSTICS_PATH = Path("research/regime_diagnostics_latest.v1.json")
 EMPTY_RUN_DIAGNOSTICS_PATH = Path("research/empty_run_diagnostics_latest.v1.json")
+RUN_CANDIDATES_PATH = Path("research/run_candidates_latest.v1.json")
+RUN_FILTER_SUMMARY_PATH = Path("research/run_filter_summary_latest.v1.json")
 RUN_PROGRESS_PATH = Path("research/run_progress_latest.v1.json")
 RUN_STATE_PATH = Path("research/run_state.v1.json")
 RUN_MANIFEST_PATH = Path("research/run_manifest_latest.v1.json")
 RUN_LOG_DIR = Path("logs/research")
 RUN_HEARTBEAT_TIMEOUT_S = 300
+SCREENING_PARAM_SAMPLE_LIMIT = 3
 
 
 def load_research_config(config_path="config/config.yaml"):
@@ -115,17 +134,28 @@ def _write_provenance_sidecar(
 
 def _write_json_atomic(path: Path, payload: dict) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_path = path.with_suffix(f"{path.suffix}.tmp")
+    tmp_path = path.with_suffix(f"{path.suffix}.{os.getpid()}.tmp")
     with tmp_path.open("w", encoding="utf-8") as handle:
         json.dump(payload, handle, indent=2, sort_keys=False)
-    os.replace(tmp_path, path)
+    for attempt in range(3):
+        try:
+            os.replace(tmp_path, path)
+            return
+        except PermissionError:
+            if attempt == 2:
+                raise
+            time.sleep(0.05)
+
+
+def _write_json_with_history(*, path: Path, payload: dict, run_id: str, history_name: str) -> None:
+    _write_json_atomic(path, payload)
+    _write_json_atomic(Path("research/history") / run_id / history_name, payload)
 
 
 def _write_universe_snapshot_sidecar(
     snapshot,
     path: Path = UNIVERSE_SNAPSHOT_PATH,
 ) -> None:
-    """Write the resolved universe snapshot for lineage."""
     _write_json_atomic(path, snapshot.to_dict() if hasattr(snapshot, "to_dict") else snapshot)
 
 
@@ -171,7 +201,6 @@ def _sidecar_strategy_entry(
 
 
 def _compute_robustness(folds: list[dict]) -> dict:
-    """Derive robustness metadata from serialized fold list."""
     fold_count = len(folds)
     oos_bars = sum(f["test"][1] - f["test"][0] + 1 for f in folds) if folds else 0
     total_bars_covered = 0
@@ -226,10 +255,6 @@ def _write_candidate_registry(
     as_of_utc,
     path: Path = CANDIDATE_REGISTRY_PATH,
 ) -> None:
-    """Build and write candidate registry from in-memory artifacts.
-
-    Skips silently when walk_forward_reports is empty (no OOS data to promote).
-    """
     if not walk_forward_reports:
         return
 
@@ -422,13 +447,62 @@ def _build_run_manifest_payload(
         },
         "stage_definitions": [
             "planning",
-            "preflight",
-            "evaluation",
+            "dedupe",
+            "fit_prior",
+            "eligibility_filter",
+            "screening",
+            "validation",
             "writing_outputs",
         ],
-        "screening_enabled": False,
+        "screening_enabled": True,
         "validation_enabled": True,
+        "screening_param_sample_limit": SCREENING_PARAM_SAMPLE_LIMIT,
+        "screening_cost_model": {
+            "mode": "representative_param_subset",
+            "max_sampled_parameter_combinations": SCREENING_PARAM_SAMPLE_LIMIT,
+        },
+        "artifacts": {
+            "run_candidates_path": RUN_CANDIDATES_PATH.as_posix(),
+            "run_filter_summary_path": RUN_FILTER_SUMMARY_PATH.as_posix(),
+        },
     }
+
+
+def _merge_manifest(path: Path, **fields) -> None:
+    if not path.exists():
+        return
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    for key, value in fields.items():
+        if isinstance(value, dict) and isinstance(payload.get(key), dict):
+            payload[key] = {**payload[key], **value}
+        else:
+            payload[key] = value
+    _write_json_atomic(path, payload)
+
+
+def _persist_candidate_pipeline_sidecars(*, run_id: str, as_of_utc: datetime, candidates: list[dict]) -> None:
+    candidate_payload = build_candidate_artifact_payload(
+        run_id=run_id,
+        as_of_utc=as_of_utc,
+        candidates=candidates,
+    )
+    filter_payload = build_filter_summary_payload(
+        run_id=run_id,
+        as_of_utc=as_of_utc,
+        candidates=candidates,
+    )
+    _write_json_with_history(
+        path=RUN_CANDIDATES_PATH,
+        payload=candidate_payload,
+        run_id=run_id,
+        history_name="run_candidates.v1.json",
+    )
+    _write_json_with_history(
+        path=RUN_FILTER_SUMMARY_PATH,
+        payload=filter_payload,
+        run_id=run_id,
+        history_name="run_filter_summary.v1.json",
+    )
 
 
 def _raise_degenerate_run(
@@ -455,6 +529,50 @@ def _raise_degenerate_run(
     raise DegenerateResearchRunError(payload["message"])
 
 
+def _screen_candidate(
+    *,
+    strategy: dict,
+    candidate: dict,
+    engine,
+) -> dict[str, str | None]:
+    if not hasattr(engine, "run"):
+        return {
+            "status": SCREENING_PROMOTED,
+            "reason": None,
+            "sampled_combination_count": 0,
+        }
+
+    sample_results: list[dict[str, str | None]] = []
+    for params in screening_param_samples(
+        strategy.get("params") or {},
+        max_samples=SCREENING_PARAM_SAMPLE_LIMIT,
+    ):
+        try:
+            metrics = engine.run(
+                strategy["factory"](**params),
+                assets=[candidate["asset"]],
+                interval=candidate["interval"],
+            )
+            report = getattr(engine, "last_evaluation_report", None) or {}
+            evaluation_samples = report.get("evaluation_samples") or {}
+            daily_returns = evaluation_samples.get("daily_returns") or []
+            if not isinstance(daily_returns, list) or not daily_returns:
+                sample_results.append({"status": "rejected_in_screening", "reason": "no_oos_samples"})
+                continue
+            min_trades = int(getattr(engine, "min_trades", 10))
+            if int(metrics.get("totaal_trades", 0)) < min_trades:
+                sample_results.append({"status": "rejected_in_screening", "reason": "insufficient_trades"})
+                continue
+            if not metrics.get("goedgekeurd", False):
+                sample_results.append({"status": "rejected_in_screening", "reason": "screening_criteria_not_met"})
+                continue
+            sample_results.append({"status": SCREENING_PROMOTED, "reason": None})
+        except Exception:
+            sample_results.append({"status": "rejected_in_screening", "reason": "screening_error"})
+
+    return normalize_screening_decision(sample_results)
+
+
 def run_research():
     lifecycle = RunStateStore(
         state_path=RUN_STATE_PATH,
@@ -477,20 +595,33 @@ def run_research():
         manifest_path=RUN_MANIFEST_PATH,
         log_path=Path(state["log_path"]),
     )
-    rows = []
-    evaluations = []
-    walk_forward_reports = []
-    provenance_events = []
+    rows: list[dict] = []
+    evaluations: list[dict] = []
+    walk_forward_reports: list[dict] = []
+    provenance_events: list = []
+    pair_diagnostics: list[dict] = []
+    interval_ranges: dict[str, dict[str, str]] = {}
+    candidates: list[dict] = []
     try:
-        tracker.start_stage("planning")
         research_config = load_research_config()
         regime_count, regime_count_source = regime_count_settings(research_config)
         evaluation_config = normalize_evaluation_config(research_config.get("evaluation"))
         assets, intervals, get_date_range, as_of_utc, universe_snapshot = build_research_universe(research_config)
-        _write_universe_snapshot_sidecar(universe_snapshot)
-        interval_ranges = {}
         strategies = get_enabled_strategies()
-        total_items = len(strategies) * len(intervals) * len(assets)
+        strategy_by_name = {strategy["name"]: strategy for strategy in strategies}
+
+        _write_universe_snapshot_sidecar(universe_snapshot)
+
+        for interval in intervals:
+            start_datum, eind_datum = get_date_range(interval)
+            interval_ranges[str(interval)] = {"start": start_datum, "end": eind_datum}
+
+        tracker.start_stage("planning")
+        planned_candidates = plan_candidates(
+            strategies=strategies,
+            assets=assets,
+            intervals=intervals,
+        )
         tracker.write_manifest(
             _build_run_manifest_payload(
                 run_id=state["run_id"],
@@ -498,120 +629,237 @@ def run_research():
                 research_config=research_config,
                 assets=assets,
                 intervals=intervals,
-                total_candidate_count=total_items,
+                total_candidate_count=len(planned_candidates),
                 strategies=strategies,
                 universe_snapshot_path=UNIVERSE_SNAPSHOT_PATH,
             )
         )
-        tracker.mark_stage_completed(total_items=total_items)
+        tracker.mark_stage_completed(raw_candidate_count=len(planned_candidates))
 
-        tracker.start_stage("preflight", total=total_items)
-        for interval in intervals:
-            start_datum, eind_datum = get_date_range(interval)
-            interval_ranges[interval] = {"start": start_datum, "end": eind_datum}
+        tracker.start_stage("dedupe", total=len(planned_candidates))
+        candidates, dedupe_summary = deduplicate_candidates(planned_candidates)
+        _persist_candidate_pipeline_sidecars(
+            run_id=state["run_id"],
+            as_of_utc=as_of_utc,
+            candidates=candidates,
+        )
+        _merge_manifest(RUN_MANIFEST_PATH, **dedupe_summary)
+        tracker.mark_stage_completed(**dedupe_summary)
 
-        pair_diagnostics: list[dict] = []
+        tracker.start_stage("fit_prior", total=len(candidates))
+        candidates, fit_summary = apply_fit_prior(candidates)
+        _persist_candidate_pipeline_sidecars(
+            run_id=state["run_id"],
+            as_of_utc=as_of_utc,
+            candidates=candidates,
+        )
+        _merge_manifest(RUN_MANIFEST_PATH, **fit_summary)
+        tracker.mark_stage_completed(
+            fit_allowed_count=fit_summary["fit_allowed_count"],
+            fit_discouraged_count=fit_summary["fit_discouraged_count"],
+            fit_blocked_count=fit_summary["fit_blocked_count"],
+        )
+
+        tracker.start_stage("eligibility_filter", total=len(candidates))
         for interval in intervals:
-            start_datum = interval_ranges[interval]["start"]
-            eind_datum = interval_ranges[interval]["end"]
+            start_datum = interval_ranges[str(interval)]["start"]
+            eind_datum = interval_ranges[str(interval)]["end"]
             engine = _build_engine(
                 start_datum=start_datum,
                 eind_datum=eind_datum,
                 evaluation_config=evaluation_config,
                 regime_config=research_config.get("regime_diagnostics"),
             )
-            pair_diagnostics.extend(_inspect_engine_readiness(engine, assets, interval))
+            pair_diagnostics.extend(_inspect_engine_readiness(engine, assets, str(interval)))
+            provenance_events.extend(getattr(engine, "_provenance_events", []))
 
-        evaluable_pair_count = sum(
-            1 for item in pair_diagnostics if item.get("status") == "evaluable"
+        candidates, eligibility_summary = apply_eligibility(
+            candidates=candidates,
+            readiness_by_pair=index_readiness(pair_diagnostics),
+            universe_symbols={asset.symbol if hasattr(asset, "symbol") else str(asset) for asset in assets},
         )
-        tracker.mark_stage_completed(evaluable_pairs=evaluable_pair_count)
-        if evaluable_pair_count == 0:
+        _persist_candidate_pipeline_sidecars(
+            run_id=state["run_id"],
+            as_of_utc=as_of_utc,
+            candidates=candidates,
+        )
+        _merge_manifest(RUN_MANIFEST_PATH, **eligibility_summary)
+        tracker.mark_stage_completed(
+            eligible_candidate_count=eligibility_summary["eligible_candidate_count"],
+            eligibility_rejected_count=eligibility_summary["eligibility_rejected_count"],
+        )
+        if eligibility_summary["eligible_candidate_count"] == 0:
             _raise_degenerate_run(
                 as_of_utc=as_of_utc,
-                failure_stage="preflight_no_evaluable_pairs",
+                failure_stage="eligibility_no_candidates",
                 assets=assets,
                 intervals=intervals,
                 interval_ranges=interval_ranges,
                 pair_diagnostics=pair_diagnostics,
             )
 
-        tracker.start_stage("evaluation", total=total_items, total_items=total_items)
-        completed_items = 0
-        for strategy in strategies:
-            for interval in intervals:
-                for asset in assets:
-                    tracker.begin_item(
-                        strategy=strategy["name"],
-                        asset=asset.symbol,
-                        interval=interval,
-                    )
-                    start_datum = interval_ranges[interval]["start"]
-                    eind_datum = interval_ranges[interval]["end"]
+        tracker.start_stage("screening", total=eligibility_summary["eligible_candidate_count"])
+        screening_items = screening_candidates(candidates)
+        for index, candidate in enumerate(screening_items, start=1):
+            tracker.begin_item(
+                strategy=candidate["strategy_name"],
+                asset=candidate["asset"],
+                interval=candidate["interval"],
+            )
+            strategy = strategy_by_name[candidate["strategy_name"]]
+            start_datum = interval_ranges[candidate["interval"]]["start"]
+            eind_datum = interval_ranges[candidate["interval"]]["end"]
+            engine = _build_engine(
+                start_datum=start_datum,
+                eind_datum=eind_datum,
+                evaluation_config=evaluation_config,
+                regime_config=research_config.get("regime_diagnostics"),
+            )
+            decision = _screen_candidate(strategy=strategy, candidate=candidate, engine=engine)
+            provenance_events.extend(getattr(engine, "_provenance_events", []))
+            for item in candidates:
+                if item["candidate_id"] != candidate["candidate_id"]:
+                    continue
+                item["screening"] = dict(decision)
+                if decision["status"] == SCREENING_PROMOTED:
+                    item["current_status"] = "promoted_to_validation"
+                else:
+                    item["current_status"] = "screening_rejected"
+                break
+            tracker.advance(completed=index, total=len(screening_items))
 
-                    engine = _build_engine(
-                        start_datum=start_datum,
-                        eind_datum=eind_datum,
-                        evaluation_config=evaluation_config,
-                        regime_config=research_config.get("regime_diagnostics"),
-                    )
-                    try:
-                        metrics = engine.grid_search(
-                            strategie_factory=strategy["factory"],
-                            param_grid=strategy["params"],
-                            assets=[asset.symbol],
-                            interval=interval,
-                        )
-                        params_used = metrics.get("beste_params", {})
-                        row = make_result_row(
-                            strategy=strategy,
-                            asset=asset.symbol,
-                            interval=interval,
-                            params=params_used,
-                            as_of_utc=as_of_utc,
-                            metrics=metrics,
-                        )
-                        evaluation_report = getattr(engine, "last_evaluation_report", None)
-                        if evaluation_report is not None:
-                            walk_forward_reports.append(
-                                _sidecar_strategy_entry(
-                                    strategy=strategy,
-                                    asset=asset.symbol,
-                                    interval=interval,
-                                    report=evaluation_report,
-                                )
-                            )
-                            evaluations.append(
-                                {
-                                    "family": strategy["family"],
-                                    "interval": interval,
-                                    "selected_params": json.loads(row["params_json"]),
-                                    "evaluation_report": evaluation_report,
-                                    "row": row,
-                                }
-                            )
-                    except (EvaluationScheduleError, FoldLeakageError):
-                        raise
-                    except Exception as e:
-                        row = make_result_row(
-                            strategy=strategy,
-                            asset=asset.symbol,
-                            interval=interval,
-                            params={},
-                            as_of_utc=as_of_utc,
-                            metrics={},
-                            error=str(e),
-                        )
-
-                    provenance_events.extend(getattr(engine, "_provenance_events", []))
-                    rows.append(row)
-                    completed_items += 1
-                    tracker.advance(completed=completed_items, total=total_items)
-
-        tracker.mark_stage_completed(completed_items=completed_items)
-        evaluable_oos_daily_return_count = _count_evaluable_oos_daily_return_evaluations(
-            evaluations
+        screening_summary = summarize_candidates(candidates)
+        _persist_candidate_pipeline_sidecars(
+            run_id=state["run_id"],
+            as_of_utc=as_of_utc,
+            candidates=candidates,
         )
+        _merge_manifest(
+            RUN_MANIFEST_PATH,
+            screening_rejected_count=screening_summary["screening_rejected_count"],
+            validation_candidate_count=screening_summary["validation_candidate_count"],
+        )
+        tracker.mark_stage_completed(
+            screening_rejected_count=screening_summary["screening_rejected_count"],
+            validation_candidate_count=screening_summary["validation_candidate_count"],
+        )
+        if screening_summary["validation_candidate_count"] == 0:
+            _raise_degenerate_run(
+                as_of_utc=as_of_utc,
+                failure_stage="screening_no_survivors",
+                assets=assets,
+                intervals=intervals,
+                interval_ranges=interval_ranges,
+                pair_diagnostics=pair_diagnostics,
+            )
+
+        tracker.start_stage("validation", total=screening_summary["validation_candidate_count"])
+        validation_items = validation_candidates(candidates)
+        for index, candidate in enumerate(validation_items, start=1):
+            strategy = strategy_by_name[candidate["strategy_name"]]
+            tracker.begin_item(
+                strategy=strategy["name"],
+                asset=candidate["asset"],
+                interval=candidate["interval"],
+            )
+            start_datum = interval_ranges[candidate["interval"]]["start"]
+            eind_datum = interval_ranges[candidate["interval"]]["end"]
+            engine = _build_engine(
+                start_datum=start_datum,
+                eind_datum=eind_datum,
+                evaluation_config=evaluation_config,
+                regime_config=research_config.get("regime_diagnostics"),
+            )
+            try:
+                metrics = engine.grid_search(
+                    strategie_factory=strategy["factory"],
+                    param_grid=strategy["params"],
+                    assets=[candidate["asset"]],
+                    interval=candidate["interval"],
+                )
+                params_used = metrics.get("beste_params", {})
+                row = make_result_row(
+                    strategy=strategy,
+                    asset=candidate["asset"],
+                    interval=candidate["interval"],
+                    params=params_used,
+                    as_of_utc=as_of_utc,
+                    metrics=metrics,
+                )
+                evaluation_report = getattr(engine, "last_evaluation_report", None)
+                if evaluation_report is not None:
+                    walk_forward_reports.append(
+                        _sidecar_strategy_entry(
+                            strategy=strategy,
+                            asset=candidate["asset"],
+                            interval=candidate["interval"],
+                            report=evaluation_report,
+                        )
+                    )
+                    evaluations.append(
+                        {
+                            "family": strategy["family"],
+                            "interval": candidate["interval"],
+                            "selected_params": json.loads(row["params_json"]),
+                            "evaluation_report": evaluation_report,
+                            "row": row,
+                        }
+                    )
+            except (EvaluationScheduleError, FoldLeakageError):
+                raise
+            except Exception as exc:
+                row = make_result_row(
+                    strategy=strategy,
+                    asset=candidate["asset"],
+                    interval=candidate["interval"],
+                    params={},
+                    as_of_utc=as_of_utc,
+                    metrics={},
+                    error=str(exc),
+                )
+
+            provenance_events.extend(getattr(engine, "_provenance_events", []))
+            rows.append(row)
+            for item in candidates:
+                if item["candidate_id"] != candidate["candidate_id"]:
+                    continue
+                item["validation"] = {
+                    "status": "validated",
+                    "result_success": bool(row["success"]),
+                }
+                item["current_status"] = "validated"
+                break
+            tracker.advance(completed=index, total=len(validation_items))
+
+        _persist_candidate_pipeline_sidecars(
+            run_id=state["run_id"],
+            as_of_utc=as_of_utc,
+            candidates=candidates,
+        )
+        validation_summary = summarize_candidates(candidates)
+        _merge_manifest(
+            RUN_MANIFEST_PATH,
+            validation_candidate_count=validation_summary["validation_candidate_count"],
+            validated_count=validation_summary["validated_count"],
+        )
+        tracker.mark_stage_completed(
+            validation_candidate_count=validation_summary["validation_candidate_count"],
+            validated_count=validation_summary["validated_count"],
+        )
+
+        successful_rows = [row for row in rows if row["success"]]
+        if validation_items and not successful_rows:
+            _raise_degenerate_run(
+                as_of_utc=as_of_utc,
+                failure_stage="validation_no_survivors",
+                assets=assets,
+                intervals=intervals,
+                interval_ranges=interval_ranges,
+                pair_diagnostics=pair_diagnostics,
+                evaluations_count=len(evaluations),
+            )
+
+        evaluable_oos_daily_return_count = _count_evaluable_oos_daily_return_evaluations(evaluations)
         if evaluations and evaluable_oos_daily_return_count == 0:
             _raise_degenerate_run(
                 as_of_utc=as_of_utc,
@@ -624,7 +872,7 @@ def run_research():
                 evaluations_with_oos_daily_returns=evaluable_oos_daily_return_count,
             )
 
-        tracker.start_stage("writing_outputs", total=total_items)
+        tracker.start_stage("writing_outputs", total=len(rows))
         write_results_to_csv(rows)
         write_latest_json(rows, as_of_utc=as_of_utc)
 
@@ -643,7 +891,6 @@ def run_research():
             provenance_events=provenance_events,
         )
 
-        successful_rows = [row for row in rows if row["success"]]
         if evaluations and len(evaluations) != len(successful_rows):
             raise RuntimeError(
                 "successful research rows are missing evaluation samples for statistical defensibility"
@@ -675,13 +922,13 @@ def run_research():
             evaluation_config=evaluation_config,
             provenance_events=provenance_events,
         )
-        tracker.mark_stage_completed()
+        tracker.mark_stage_completed(results_written=len(rows))
         tracker.complete()
         print(f"Klaar. {len(rows)} resultaten geschreven.")
     except Exception as exc:
         tracker.fail(exc, failure_stage=tracker.current_stage)
         raise
 
+
 if __name__ == "__main__":
     run_research()
-

--- a/tests/unit/test_candidate_pipeline.py
+++ b/tests/unit/test_candidate_pipeline.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+from research.candidate_pipeline import (
+    FIT_ALLOWED,
+    FIT_BLOCKED,
+    FIT_DISCOURAGED,
+    apply_fit_prior,
+    build_candidate_artifact_payload,
+    build_filter_summary_payload,
+    deduplicate_candidates,
+    plan_candidates,
+)
+
+
+AS_OF_UTC = datetime(2026, 4, 13, 12, 0, 0, tzinfo=UTC)
+
+
+def _strategy(name: str, *, family: str, strategy_family: str, position_structure: str = "outright", initial_lane_support: str = "supported"):
+    return {
+        "name": name,
+        "family": family,
+        "strategy_family": strategy_family,
+        "position_structure": position_structure,
+        "initial_lane_support": initial_lane_support,
+        "params": {"periode": [14, 21, 28]},
+        "factory": lambda **params: None,
+        "hypothesis": "fixture",
+    }
+
+
+def test_candidate_planning_is_deterministic():
+    strategies = [
+        _strategy(name="b", family="trend", strategy_family="breakout"),
+        _strategy(name="a", family="trend", strategy_family="trend_following"),
+    ]
+    assets = [
+        SimpleNamespace(symbol="ETH-USD", asset_type="crypto", asset_class="crypto"),
+        SimpleNamespace(symbol="BTC-USD", asset_type="crypto", asset_class="crypto"),
+    ]
+    intervals = ["4h", "1h"]
+
+    first = plan_candidates(strategies=strategies, assets=assets, intervals=intervals)
+    second = plan_candidates(strategies=strategies, assets=assets, intervals=intervals)
+
+    assert first == second
+    assert [candidate["strategy_name"] for candidate in first[:2]] == ["a", "a"]
+    assert first[0]["asset"] == "BTC-USD"
+    assert first[0]["interval"] == "1h"
+    assert first[0]["asset_type"] == "crypto"
+
+
+def test_deduplication_is_exact_and_reproducible():
+    strategies = [
+        _strategy(name="dup", family="trend", strategy_family="trend_following"),
+        _strategy(name="dup", family="trend", strategy_family="trend_following"),
+    ]
+    assets = [SimpleNamespace(symbol="BTC-USD", asset_type="crypto", asset_class="crypto")]
+    intervals = ["1h"]
+
+    planned = plan_candidates(strategies=strategies, assets=assets, intervals=intervals)
+    deduplicated, summary = deduplicate_candidates(planned)
+
+    assert summary == {
+        "raw_candidate_count": 2,
+        "deduplicated_candidate_count": 1,
+        "duplicates_removed": 1,
+    }
+    assert deduplicated[0]["dedupe"]["raw_occurrences"] == 2
+    assert deduplicated[0]["dedupe"]["duplicate_removed"] is True
+
+
+def test_fit_prior_gating_is_deterministic_and_explicit():
+    strategies = [
+        _strategy(name="trend", family="trend", strategy_family="trend_following"),
+        _strategy(name="mr", family="mean_reversion", strategy_family="mean_reversion"),
+        _strategy(
+            name="pairs",
+            family="stat_arb",
+            strategy_family="stat_arb",
+            position_structure="spread",
+            initial_lane_support="blocked",
+        ),
+    ]
+    assets = [
+        SimpleNamespace(symbol="BTC-USD", asset_type="crypto", asset_class="crypto"),
+        SimpleNamespace(symbol="AAPL", asset_type="equity", asset_class="equity"),
+    ]
+    planned = plan_candidates(strategies=strategies, assets=assets, intervals=["1h"])
+    deduplicated, _ = deduplicate_candidates(planned)
+
+    candidates, summary = apply_fit_prior(deduplicated)
+    fit_by_name_asset = {
+        (candidate["strategy_name"], candidate["asset"]): candidate["fit_prior"]["status"]
+        for candidate in candidates
+    }
+
+    assert fit_by_name_asset[("trend", "BTC-USD")] == FIT_ALLOWED
+    assert fit_by_name_asset[("mr", "BTC-USD")] == FIT_DISCOURAGED
+    assert fit_by_name_asset[("mr", "AAPL")] == FIT_DISCOURAGED
+    assert fit_by_name_asset[("pairs", "AAPL")] == FIT_BLOCKED
+    assert summary["fit_blocked_reasons"] == {"requires_spread_not_outright": 2}
+
+
+def test_candidate_sidecar_payloads_include_reduction_counts():
+    strategies = [
+        _strategy(name="trend", family="trend", strategy_family="trend_following"),
+        _strategy(name="pairs", family="stat_arb", strategy_family="stat_arb", position_structure="spread", initial_lane_support="blocked"),
+    ]
+    assets = [SimpleNamespace(symbol="BTC-USD", asset_type="crypto", asset_class="crypto")]
+    planned = plan_candidates(strategies=strategies, assets=assets, intervals=["1h"])
+    deduplicated, _ = deduplicate_candidates(planned)
+    fitted, _ = apply_fit_prior(deduplicated)
+    fitted[0]["eligibility"] = {"status": "eligible", "reason": None}
+    fitted[0]["screening"] = {"status": "promoted_to_validation", "reason": None}
+    fitted[0]["validation"] = {"status": "validated", "result_success": True}
+    fitted[0]["current_status"] = "validated"
+
+    candidate_payload = build_candidate_artifact_payload(
+        run_id="run-1",
+        as_of_utc=AS_OF_UTC,
+        candidates=fitted,
+    )
+    filter_payload = build_filter_summary_payload(
+        run_id="run-1",
+        as_of_utc=AS_OF_UTC,
+        candidates=fitted,
+    )
+
+    assert candidate_payload["summary"]["raw_candidate_count"] == 2
+    assert candidate_payload["summary"]["fit_blocked_count"] == 1
+    assert candidate_payload["summary"]["validation_candidate_count"] == 1
+    assert filter_payload["fit_blocked_reasons"] == {"requires_spread_not_outright": 1}
+    assert filter_payload["screening_decisions"]["promoted_to_validation"] == 1
+
+
+def test_asset_type_normalization_uses_explicit_mapping():
+    strategies = [_strategy(name="trend", family="trend", strategy_family="trend_following")]
+    assets = [SimpleNamespace(symbol="SPY", asset_type="ETF", asset_class="index")]
+
+    planned = plan_candidates(strategies=strategies, assets=assets, intervals=["1d"])
+
+    assert planned[0]["asset_type"] == "index_like"
+    assert planned[0]["asset_class"] == "index"

--- a/tests/unit/test_run_research_empty_run_handling.py
+++ b/tests/unit/test_run_research_empty_run_handling.py
@@ -29,6 +29,9 @@ def _patch_common_runner(monkeypatch, tmp_path: Path, engine_cls) -> None:
             {
                 "name": "fake_strategy",
                 "family": "trend",
+                "strategy_family": "trend_following",
+                "position_structure": "outright",
+                "initial_lane_support": "supported",
                 "hypothesis": "Fixture hypothesis",
                 "factory": lambda **params: None,
                 "params": {"periode": [14]},
@@ -39,7 +42,7 @@ def _patch_common_runner(monkeypatch, tmp_path: Path, engine_cls) -> None:
         run_research_module,
         "build_research_universe",
         lambda config: (
-            [SimpleNamespace(symbol="BTC-USD")],
+            [SimpleNamespace(symbol="BTC-USD", asset_type="crypto", asset_class="crypto")],
             ["1h"],
             lambda interval: ("2024-05-13", "2026-04-13"),
             AS_OF_UTC,
@@ -54,7 +57,7 @@ def _patch_common_runner(monkeypatch, tmp_path: Path, engine_cls) -> None:
     monkeypatch.setattr(run_research_module, "_git_revision", lambda: "deadbeef")
 
 
-class _PreflightDegenerateEngine:
+class _EligibilityDegenerateEngine:
     def __init__(self, start_datum, eind_datum, evaluation_config=None, regime_config=None):
         self.start = start_datum
         self.eind = eind_datum
@@ -77,7 +80,7 @@ class _PreflightDegenerateEngine:
         ]
 
     def grid_search(self, strategie_factory, param_grid, assets, interval="1d"):
-        raise AssertionError("grid_search should not run when preflight has zero evaluable pairs")
+        raise AssertionError("grid_search should not run when eligibility has zero candidates")
 
 
 class _PostRunDegenerateEngine:
@@ -160,16 +163,65 @@ class _PostRunDegenerateEngine:
         }
 
 
-def test_run_research_fails_fast_before_public_outputs_when_preflight_is_empty(monkeypatch, tmp_path):
-    _patch_common_runner(monkeypatch, tmp_path, _PreflightDegenerateEngine)
+class _ScreeningDegenerateEngine:
+    def __init__(self, start_datum, eind_datum, evaluation_config=None, regime_config=None):
+        self.start = start_datum
+        self.eind = eind_datum
+        self._provenance_events = []
+        self.last_evaluation_report = None
 
-    with pytest.raises(DegenerateResearchRunError, match="preflight_no_evaluable_pairs"):
+    def inspect_asset_readiness(self, assets, interval):
+        return [
+            {
+                "asset": asset,
+                "interval": interval,
+                "requested_start": self.start,
+                "requested_end": self.eind,
+                "bar_count": 700,
+                "fold_count": 2,
+                "status": "evaluable",
+                "drop_reason": None,
+            }
+            for asset in assets
+        ]
+
+    def run(self, strategie_func, assets, interval="1d"):
+        self.last_evaluation_report = {
+            "evaluation_samples": {
+                "daily_returns": [0.01, -0.005, 0.003],
+                "trade_pnls": [0.02, -0.01],
+                "monthly_returns": [0.008],
+            }
+        }
+        return {
+            "win_rate": 0.45,
+            "sharpe": -0.2,
+            "deflated_sharpe": -0.1,
+            "max_drawdown": 0.12,
+            "trades_per_maand": 2.5,
+            "consistentie": 0.3,
+            "totaal_trades": 12,
+            "goedgekeurd": False,
+            "criteria_checks": {},
+            "reden": "",
+        }
+
+    def grid_search(self, strategie_factory, param_grid, assets, interval="1d"):
+        raise AssertionError("grid_search should not run when screening has zero survivors")
+
+
+def test_run_research_fails_fast_before_public_outputs_when_eligibility_is_empty(monkeypatch, tmp_path):
+    _patch_common_runner(monkeypatch, tmp_path, _EligibilityDegenerateEngine)
+
+    with pytest.raises(DegenerateResearchRunError, match="eligibility_no_candidates"):
         run_research_module.run_research()
 
     diagnostics = _load_json(tmp_path / "research" / "empty_run_diagnostics_latest.v1.json")
-    assert diagnostics["failure_stage"] == "preflight_no_evaluable_pairs"
+    filter_summary = _load_json(tmp_path / "research" / "run_filter_summary_latest.v1.json")
+    assert diagnostics["failure_stage"] == "eligibility_no_candidates"
     assert diagnostics["summary"]["evaluable_pair_count"] == 0
     assert diagnostics["summary"]["primary_drop_reasons"] == ["empty_dataset"]
+    assert filter_summary["eligibility_rejection_reasons"] == {"empty_dataset": 1}
     assert not (tmp_path / "research" / "research_latest.json").exists()
     assert not (tmp_path / "research" / "strategy_matrix.csv").exists()
 
@@ -185,5 +237,20 @@ def test_run_research_fails_fast_before_public_outputs_when_oos_samples_are_empt
     assert diagnostics["summary"]["evaluable_pair_count"] == 1
     assert diagnostics["summary"]["evaluations_count"] == 1
     assert diagnostics["summary"]["evaluations_with_oos_daily_returns"] == 0
+    assert not (tmp_path / "research" / "research_latest.json").exists()
+    assert not (tmp_path / "research" / "strategy_matrix.csv").exists()
+
+
+def test_run_research_fails_fast_before_public_outputs_when_screening_has_no_survivors(monkeypatch, tmp_path):
+    _patch_common_runner(monkeypatch, tmp_path, _ScreeningDegenerateEngine)
+
+    with pytest.raises(DegenerateResearchRunError, match="screening_no_survivors"):
+        run_research_module.run_research()
+
+    diagnostics = _load_json(tmp_path / "research" / "empty_run_diagnostics_latest.v1.json")
+    filter_summary = _load_json(tmp_path / "research" / "run_filter_summary_latest.v1.json")
+    assert diagnostics["failure_stage"] == "screening_no_survivors"
+    assert filter_summary["summary"]["screening_rejected_count"] == 1
+    assert filter_summary["screening_rejection_reasons"] == {"screening_criteria_not_met": 1}
     assert not (tmp_path / "research" / "research_latest.json").exists()
     assert not (tmp_path / "research" / "strategy_matrix.csv").exists()

--- a/tests/unit/test_run_research_observability.py
+++ b/tests/unit/test_run_research_observability.py
@@ -41,6 +41,9 @@ def _patch_common_runner(monkeypatch, tmp_path: Path, engine_cls) -> None:
             {
                 "name": "fake_strategy",
                 "family": "trend",
+                "strategy_family": "trend_following",
+                "position_structure": "outright",
+                "initial_lane_support": "supported",
                 "hypothesis": "Fixture hypothesis",
                 "factory": lambda **params: None,
                 "params": {"periode": [14]},
@@ -51,7 +54,7 @@ def _patch_common_runner(monkeypatch, tmp_path: Path, engine_cls) -> None:
         run_research_module,
         "build_research_universe",
         lambda config: (
-            [SimpleNamespace(symbol="BTC-USD")],
+            [SimpleNamespace(symbol="BTC-USD", asset_type="crypto", asset_class="crypto")],
             ["1d"],
             lambda interval: ("2026-01-01", "2026-02-01"),
             AS_OF_UTC,
@@ -106,6 +109,27 @@ class _HealthyEngine:
             }
             for asset in assets
         ]
+
+    def run(self, strategie_func, assets, interval="1d"):
+        self.last_evaluation_report = {
+            "evaluation_samples": {
+                "daily_returns": [0.01, -0.005, 0.003],
+                "trade_pnls": [0.02, -0.01],
+                "monthly_returns": [0.008],
+            }
+        }
+        return {
+            "win_rate": 0.55,
+            "sharpe": 1.1,
+            "deflated_sharpe": 0.9,
+            "max_drawdown": 0.12,
+            "trades_per_maand": 2.5,
+            "consistentie": 0.65,
+            "totaal_trades": 12,
+            "goedgekeurd": True,
+            "criteria_checks": {},
+            "reden": "",
+        }
 
     def grid_search(self, strategie_factory, param_grid, assets, interval="1d"):
         self.last_evaluation_report = {
@@ -201,6 +225,36 @@ class _DegenerateEngine:
         raise AssertionError("grid_search should not run for preflight failure")
 
 
+class _SelectiveScreeningEngine(_HealthyEngine):
+    validation_calls = 0
+
+    def run(self, strategie_func, assets, interval="1d"):
+        promoted = getattr(strategie_func, "screen_tag", "promote") == "promote"
+        self.last_evaluation_report = {
+            "evaluation_samples": {
+                "daily_returns": [0.01, -0.005, 0.003],
+                "trade_pnls": [0.02, -0.01],
+                "monthly_returns": [0.008],
+            }
+        }
+        return {
+            "win_rate": 0.55 if promoted else 0.45,
+            "sharpe": 1.1 if promoted else -0.2,
+            "deflated_sharpe": 0.9 if promoted else -0.1,
+            "max_drawdown": 0.12,
+            "trades_per_maand": 2.5,
+            "consistentie": 0.65,
+            "totaal_trades": 12,
+            "goedgekeurd": promoted,
+            "criteria_checks": {},
+            "reden": "",
+        }
+
+    def grid_search(self, strategie_factory, param_grid, assets, interval="1d"):
+        _SelectiveScreeningEngine.validation_calls += 1
+        return super().grid_search(strategie_factory, param_grid, assets, interval=interval)
+
+
 def test_run_research_writes_completed_progress_sidecar_and_keeps_public_schema(monkeypatch, tmp_path: Path):
     _patch_common_runner(monkeypatch, tmp_path, _HealthyEngine)
 
@@ -209,6 +263,8 @@ def test_run_research_writes_completed_progress_sidecar_and_keeps_public_schema(
     progress = _load_json(tmp_path / "research" / "run_progress_latest.v1.json")
     state = _load_json(tmp_path / "research" / "run_state.v1.json")
     manifest = _load_json(tmp_path / "research" / "run_manifest_latest.v1.json")
+    candidates = _load_json(tmp_path / "research" / "run_candidates_latest.v1.json")
+    filter_summary = _load_json(tmp_path / "research" / "run_filter_summary_latest.v1.json")
     public_json = _load_json(tmp_path / "research" / "research_latest.json")
     with (tmp_path / "research" / "strategy_matrix.csv").open(encoding="utf-8", newline="") as handle:
         csv_rows = list(csv.DictReader(handle))
@@ -222,8 +278,22 @@ def test_run_research_writes_completed_progress_sidecar_and_keeps_public_schema(
     assert state["status"] == "completed"
     assert state["pid"] is None
     assert manifest["status"] == "completed"
+    assert manifest["stage_definitions"] == [
+        "planning",
+        "dedupe",
+        "fit_prior",
+        "eligibility_filter",
+        "screening",
+        "validation",
+        "writing_outputs",
+    ]
+    assert manifest["raw_candidate_count"] == 1
+    assert manifest["validation_candidate_count"] == 1
+    assert candidates["summary"]["validation_candidate_count"] == 1
+    assert filter_summary["screening_decisions"]["promoted_to_validation"] == 1
     assert (tmp_path / "logs" / "research" / f"{state['run_id']}.jsonl").exists()
     assert (tmp_path / "research" / "history" / state["run_id"] / "run_state.v1.json").exists()
+    assert (tmp_path / "research" / "history" / state["run_id"] / "run_candidates.v1.json").exists()
     assert list(public_json["results"][0].keys()) == ROW_SCHEMA
     assert list(csv_rows[0].keys()) == ROW_SCHEMA
 
@@ -231,14 +301,67 @@ def test_run_research_writes_completed_progress_sidecar_and_keeps_public_schema(
 def test_run_research_marks_failed_progress_sidecar_on_degenerate_run(monkeypatch, tmp_path: Path):
     _patch_common_runner(monkeypatch, tmp_path, _DegenerateEngine)
 
-    with pytest.raises(DegenerateResearchRunError, match="preflight_no_evaluable_pairs"):
+    with pytest.raises(DegenerateResearchRunError, match="eligibility_no_candidates"):
         run_research_module.run_research()
 
     progress = _load_json(tmp_path / "research" / "run_progress_latest.v1.json")
     state = _load_json(tmp_path / "research" / "run_state.v1.json")
+    filter_summary = _load_json(tmp_path / "research" / "run_filter_summary_latest.v1.json")
     assert progress["status"] == "failed"
     assert progress["current_stage"] == "failed"
-    assert progress["error"]["failure_stage"] == "preflight"
+    assert progress["error"]["failure_stage"] == "eligibility_filter"
     assert progress["error"]["error_type"] == "DegenerateResearchRunError"
     assert state["status"] == "failed"
-    assert state["status_reason"] == "research_run_failed:preflight"
+    assert state["status_reason"] == "research_run_failed:eligibility_filter"
+    assert filter_summary["summary"]["eligibility_rejected_count"] == 1
+    assert filter_summary["eligibility_rejection_reasons"] == {"empty_dataset": 1}
+
+
+def test_only_screening_survivors_reach_validation(monkeypatch, tmp_path: Path):
+    _patch_common_runner(monkeypatch, tmp_path, _SelectiveScreeningEngine)
+    _SelectiveScreeningEngine.validation_calls = 0
+
+    def _factory(tag):
+        def _build(**params):
+            return SimpleNamespace(screen_tag=tag)
+
+        return _build
+
+    monkeypatch.setattr(
+        run_research_module,
+        "get_enabled_strategies",
+        lambda: [
+            {
+                "name": "promoted_strategy",
+                "family": "trend",
+                "strategy_family": "trend_following",
+                "position_structure": "outright",
+                "initial_lane_support": "supported",
+                "hypothesis": "promoted",
+                "factory": _factory("promote"),
+                "params": {"periode": [14, 21, 28]},
+            },
+            {
+                "name": "rejected_strategy",
+                "family": "trend",
+                "strategy_family": "trend_following",
+                "position_structure": "outright",
+                "initial_lane_support": "supported",
+                "hypothesis": "rejected",
+                "factory": _factory("reject"),
+                "params": {"periode": [14, 21, 28]},
+            },
+        ],
+    )
+
+    run_research_module.run_research()
+
+    public_json = _load_json(tmp_path / "research" / "research_latest.json")
+    candidates = _load_json(tmp_path / "research" / "run_candidates_latest.v1.json")
+    filter_summary = _load_json(tmp_path / "research" / "run_filter_summary_latest.v1.json")
+
+    assert _SelectiveScreeningEngine.validation_calls == 1
+    assert public_json["count"] == 1
+    assert candidates["summary"]["screening_rejected_count"] == 1
+    assert candidates["summary"]["validation_candidate_count"] == 1
+    assert filter_summary["screening_rejection_reasons"] == {"screening_criteria_not_met": 1}


### PR DESCRIPTION
## Summary

This PR introduces a selective, staged candidate pipeline to improve research quality, reduce computational cost, and enforce deterministic candidate lifecycle tracking.

It replaces the previous brute-force evaluation flow with a structured pipeline:

planning → dedupe → fit_prior → eligibility_filter → screening → validation → writing_outputs

## Key Improvements

### 1. Asset Typing (research/asset_typing.py)
- Introduces deterministic normalization of asset types
- Removes reliance on implicit ticker heuristics
- Enables strategy ↔ asset fit reasoning

### 2. Fit-Prior Gating
- Adds an explicit "fit_prior" stage before expensive evaluation
- Prevents structurally invalid combinations (e.g. stat-arb without spreads)
- Introduces:
  - allowed
  - discouraged
  - blocked

### 3. Selective Candidate Pipeline (research/candidate_pipeline.py)
- Deterministic candidate planning and hashing
- Exact deduplication
- Eligibility filtering
- Screening decision normalization
- Additive sidecar generation

### 4. Screening Stage (Performance Optimization)
- Introduces low-cost pre-validation stage
- Uses representative parameter subset (first/middle/last)
- Reduces number of candidates entering full validation
- Explicitly tracked in manifest + candidate records

### 5. Observability Extensions
- Progress + ETA now includes screening and validation stages
- Adds new artifacts:
  - run_candidates_latest.v1.json
  - run_filter_summary_latest.v1.json

### 6. Strict Separation of Concerns
- Orchestrator remains thin (run_research.py)
- All logic stays in research layer
- Registry only contains metadata, not policy

## Non-Goals

- No multiprocessing yet
- No caching yet
- No dashboard changes
- No changes to public output schemas

## Risks

- Overly aggressive fit_prior gating may block valid strategies (kept conservative)
- Screening may still be non-trivial cost depending on grid size
- Windows pytest tmpdir issues currently affect full test suite execution

## Test Status

- Candidate pipeline tests: passing
- Some tests blocked due to Windows tmpdir permission issues (environmental, not assertion failures)

## Next Steps

- Fix pytest tempdir handling (test infra stability)
- Introduce parallel validation execution
- Expand asset-type taxonomy
- Optional: config-driven fit_prior overrides