### PR TITLE
chore: harden pytest discovery and add canonical Windows test runners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ __pycache__/
 
 .env
 .venv/
+.tmp/
+tests_tmp/
 
 logs/
 reports/

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+testpaths = tests
+norecursedirs = .git .github .venv .tmp tests_tmp logs .codex .pytest_cache __pycache__ data/cache
+cache_dir = .tmp/pytest-cache

--- a/scripts/test_local.ps1
+++ b/scripts/test_local.ps1
@@ -1,0 +1,13 @@
+param()
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$tmpRoot = Join-Path $repoRoot ".tmp"
+$baseTemp = Join-Path $tmpRoot "pytest-basetemp-stable"
+
+New-Item -ItemType Directory -Force -Path $tmpRoot | Out-Null
+New-Item -ItemType Directory -Force -Path $baseTemp | Out-Null
+
+$env:TMP = $tmpRoot
+$env:TEMP = $tmpRoot
+
+python -m pytest --basetemp $baseTemp

--- a/scripts/test_targeted.ps1
+++ b/scripts/test_targeted.ps1
@@ -1,0 +1,16 @@
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$Targets
+)
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$tmpRoot = Join-Path $repoRoot ".tmp"
+$baseTemp = Join-Path $tmpRoot "pytest-basetemp-stable"
+
+New-Item -ItemType Directory -Force -Path $tmpRoot | Out-Null
+New-Item -ItemType Directory -Force -Path $baseTemp | Out-Null
+
+$env:TMP = $tmpRoot
+$env:TEMP = $tmpRoot
+
+python -m pytest --basetemp $baseTemp @Targets


### PR DESCRIPTION
## Summary

This PR hardens repo-level pytest execution and adds canonical local Windows test runners.

## What it fixes

Repo-side test execution improvements:
- adds `pytest.ini`
- restricts discovery to `tests`
- excludes scratch/cache/tool directories from recursion
- relocates pytest cache to a managed repo-owned location
- adds canonical PowerShell runners:
  - `scripts/test_local.ps1`
  - `scripts/test_targeted.ps1`

## Why this was needed

The repo previously had:
- no explicit pytest discovery boundary
- no canonical Windows test runner
- repo-local scratch/cache paths interfering with tooling
- an unreadable root `.pytest_cache` adding risk and noise

## Important scope note

This PR improves the repo-owned part of test execution.

It does **not** fully resolve a remaining local Windows `tmp_path` / tempdir PermissionError issue on this machine. After the repo-level hardening, the remaining failures appear to be host-environment specific rather than caused by research logic, assertions, or pytest discovery in this repo.

## Non-goals

- no research logic changes
- no strategy logic changes
- no dashboard changes
- no weakening of test coverage
- no monkeypatching of pytest or Python tempdir internals

## Result

After this PR:
- pytest discovery is cleaner and deterministic
- non-test directories are excluded
- local Windows runs have one canonical command path
- remaining tmpdir failures are clearly isolated as environment-level issues