### PR TITLE
feat: add screening observability and bounded candidate execution

### DIFF
--- a/research/observability.py
+++ b/research/observability.py
@@ -45,6 +45,7 @@ class ProgressTracker:
             "asset": None,
             "interval": None,
         }
+        self.screening: dict[str, Any] | None = None
         self.completed_items = 0
         self.total_items = 0
         self.failed_items = 0
@@ -70,6 +71,8 @@ class ProgressTracker:
 
     def start_stage(self, stage: str, *, total: int | None = None, **log_fields: Any) -> None:
         self.current_stage = stage
+        if stage != "screening":
+            self.screening = None
         self._stage_started_at_utc = self._now_source().astimezone(UTC)
         self._stage_started_monotonic = self._monotonic_source()
         if total is not None:
@@ -95,12 +98,26 @@ class ProgressTracker:
         self._log("stage", stage=self.current_stage, status="completed", **log_fields)
         self._log_event("stage_completed", stage=self.current_stage, **log_fields)
 
-    def begin_item(self, *, strategy: str, asset: str, interval: str) -> None:
+    def begin_item(self, *, strategy: str, asset: str, interval: str, persist: bool = False) -> None:
         self.current_item = {
             "strategy": strategy,
             "asset": asset,
             "interval": interval,
         }
+        if persist:
+            self.persist()
+
+    def set_screening(self, screening: dict[str, Any] | None, *, persist: bool = False) -> None:
+        self.screening = None if screening is None else dict(screening)
+        if persist:
+            self.persist()
+
+    def persist(self) -> None:
+        self._last_updated_at_utc = self._now_source().astimezone(UTC)
+        self._write_progress()
+
+    def emit_event(self, event: str, **fields: Any) -> None:
+        self._log_event(event, **fields)
 
     def advance(self, *, completed: int | None = None, total: int | None = None) -> None:
         if completed is not None:
@@ -145,6 +162,7 @@ class ProgressTracker:
             "asset": None,
             "interval": None,
         }
+        self.screening = None
         self._last_updated_at_utc = self._now_source().astimezone(UTC)
         self._write_progress()
         self.finalize_manifest("completed")
@@ -214,7 +232,7 @@ class ProgressTracker:
         return f"{strategy} {asset} {interval}"
 
     def _payload(self) -> dict[str, Any]:
-        return {
+        payload = {
             "version": "v1",
             "run_id": self.run_id,
             "status": self.status,
@@ -234,6 +252,9 @@ class ProgressTracker:
             "eta_seconds": self._eta_seconds(),
             "error": self.error,
         }
+        if self.screening is not None:
+            payload["screening"] = dict(self.screening)
+        return payload
 
     def _write_progress(self) -> None:
         write_json_atomic(self.path, self._payload())

--- a/research/run_research.py
+++ b/research/run_research.py
@@ -29,7 +29,6 @@ from research.candidate_pipeline import (
     build_filter_summary_payload,
     deduplicate_candidates,
     index_readiness,
-    normalize_screening_decision,
     plan_candidates,
     screening_candidates,
     screening_param_samples,
@@ -46,6 +45,15 @@ from research.promotion_reporting import build_candidate_registry_payload
 from research.regime_reporting import build_regime_diagnostics_payload
 from research.registry import get_enabled_strategies
 from research.results import make_result_row, write_latest_json, write_results_to_csv
+from research.screening_runtime import (
+    FINAL_STATUS_ERRORED,
+    FINAL_STATUS_PASSED,
+    FINAL_STATUS_REJECTED,
+    FINAL_STATUS_TIMED_OUT,
+    build_screening_runtime_records,
+    build_screening_sidecar_payload,
+    execute_screening_candidate,
+)
 from research.run_state import RunStateStore
 from research.statistical_reporting import build_statistical_defensibility_payload, regime_count_settings
 from research.universe import build_research_universe
@@ -59,12 +67,14 @@ REGIME_DIAGNOSTICS_PATH = Path("research/regime_diagnostics_latest.v1.json")
 EMPTY_RUN_DIAGNOSTICS_PATH = Path("research/empty_run_diagnostics_latest.v1.json")
 RUN_CANDIDATES_PATH = Path("research/run_candidates_latest.v1.json")
 RUN_FILTER_SUMMARY_PATH = Path("research/run_filter_summary_latest.v1.json")
+RUN_SCREENING_CANDIDATES_PATH = Path("research/run_screening_candidates_latest.v1.json")
 RUN_PROGRESS_PATH = Path("research/run_progress_latest.v1.json")
 RUN_STATE_PATH = Path("research/run_state.v1.json")
 RUN_MANIFEST_PATH = Path("research/run_manifest_latest.v1.json")
 RUN_LOG_DIR = Path("logs/research")
 RUN_HEARTBEAT_TIMEOUT_S = 300
 SCREENING_PARAM_SAMPLE_LIMIT = 3
+DEFAULT_SCREENING_CANDIDATE_BUDGET_SECONDS = 60
 
 
 def load_research_config(config_path="config/config.yaml"):
@@ -417,6 +427,7 @@ def _build_run_manifest_payload(
     total_candidate_count: int,
     strategies: list[dict],
     universe_snapshot_path: Path,
+    screening_candidate_budget_seconds: int,
 ) -> dict:
     asset_symbols = [asset.symbol if hasattr(asset, "symbol") else str(asset) for asset in assets]
     return {
@@ -461,9 +472,11 @@ def _build_run_manifest_payload(
             "mode": "representative_param_subset",
             "max_sampled_parameter_combinations": SCREENING_PARAM_SAMPLE_LIMIT,
         },
+        "screening_candidate_budget_seconds": int(screening_candidate_budget_seconds),
         "artifacts": {
             "run_candidates_path": RUN_CANDIDATES_PATH.as_posix(),
             "run_filter_summary_path": RUN_FILTER_SUMMARY_PATH.as_posix(),
+            "run_screening_candidates_path": RUN_SCREENING_CANDIDATES_PATH.as_posix(),
         },
     }
 
@@ -505,6 +518,44 @@ def _persist_candidate_pipeline_sidecars(*, run_id: str, as_of_utc: datetime, ca
     )
 
 
+def _persist_screening_candidate_sidecar(
+    *,
+    run_id: str,
+    as_of_utc: datetime,
+    screening_records: list[dict],
+) -> None:
+    payload = build_screening_sidecar_payload(
+        run_id=run_id,
+        as_of_utc=as_of_utc,
+        records=screening_records,
+    )
+    _write_json_with_history(
+        path=RUN_SCREENING_CANDIDATES_PATH,
+        payload=payload,
+        run_id=run_id,
+        history_name="run_screening_candidates.v1.json",
+    )
+
+
+def _screening_progress_payload(
+    *,
+    completed_candidates: int,
+    total_candidates: int,
+    record: dict | None,
+) -> dict:
+    return {
+        "completed_screening_candidates": int(completed_candidates),
+        "total_screening_candidates": int(total_candidates),
+        "candidate_id": None if record is None else record.get("candidate_id"),
+        "runtime_status": None if record is None else record.get("runtime_status"),
+        "final_status": None if record is None else record.get("final_status"),
+        "samples_completed": None if record is None else record.get("samples_completed"),
+        "samples_total": None if record is None else record.get("samples_total"),
+        "budget_seconds": None if record is None else record.get("budget_seconds"),
+        "candidate_elapsed_seconds": None if record is None else record.get("elapsed_seconds"),
+    }
+
+
 def _raise_degenerate_run(
     *,
     as_of_utc,
@@ -527,51 +578,6 @@ def _raise_degenerate_run(
         evaluations_with_oos_daily_returns=evaluations_with_oos_daily_returns,
     )
     raise DegenerateResearchRunError(payload["message"])
-
-
-def _screen_candidate(
-    *,
-    strategy: dict,
-    candidate: dict,
-    engine,
-) -> dict[str, str | None]:
-    if not hasattr(engine, "run"):
-        return {
-            "status": SCREENING_PROMOTED,
-            "reason": None,
-            "sampled_combination_count": 0,
-        }
-
-    sample_results: list[dict[str, str | None]] = []
-    for params in screening_param_samples(
-        strategy.get("params") or {},
-        max_samples=SCREENING_PARAM_SAMPLE_LIMIT,
-    ):
-        try:
-            metrics = engine.run(
-                strategy["factory"](**params),
-                assets=[candidate["asset"]],
-                interval=candidate["interval"],
-            )
-            report = getattr(engine, "last_evaluation_report", None) or {}
-            evaluation_samples = report.get("evaluation_samples") or {}
-            daily_returns = evaluation_samples.get("daily_returns") or []
-            if not isinstance(daily_returns, list) or not daily_returns:
-                sample_results.append({"status": "rejected_in_screening", "reason": "no_oos_samples"})
-                continue
-            min_trades = int(getattr(engine, "min_trades", 10))
-            if int(metrics.get("totaal_trades", 0)) < min_trades:
-                sample_results.append({"status": "rejected_in_screening", "reason": "insufficient_trades"})
-                continue
-            if not metrics.get("goedgekeurd", False):
-                sample_results.append({"status": "rejected_in_screening", "reason": "screening_criteria_not_met"})
-                continue
-            sample_results.append({"status": SCREENING_PROMOTED, "reason": None})
-        except Exception:
-            sample_results.append({"status": "rejected_in_screening", "reason": "screening_error"})
-
-    return normalize_screening_decision(sample_results)
-
 
 def run_research():
     lifecycle = RunStateStore(
@@ -606,6 +612,11 @@ def run_research():
         research_config = load_research_config()
         regime_count, regime_count_source = regime_count_settings(research_config)
         evaluation_config = normalize_evaluation_config(research_config.get("evaluation"))
+        screening_config = research_config.get("screening") or {}
+        screening_candidate_budget_seconds = max(
+            0,
+            int(screening_config.get("candidate_budget_seconds", DEFAULT_SCREENING_CANDIDATE_BUDGET_SECONDS)),
+        )
         assets, intervals, get_date_range, as_of_utc, universe_snapshot = build_research_universe(research_config)
         strategies = get_enabled_strategies()
         strategy_by_name = {strategy["name"]: strategy for strategy in strategies}
@@ -632,6 +643,7 @@ def run_research():
                 total_candidate_count=len(planned_candidates),
                 strategies=strategies,
                 universe_snapshot_path=UNIVERSE_SNAPSHOT_PATH,
+                screening_candidate_budget_seconds=screening_candidate_budget_seconds,
             )
         )
         tracker.mark_stage_completed(raw_candidate_count=len(planned_candidates))
@@ -700,23 +712,153 @@ def run_research():
 
         tracker.start_stage("screening", total=eligibility_summary["eligible_candidate_count"])
         screening_items = screening_candidates(candidates)
+        screening_records = build_screening_runtime_records(
+            candidates=screening_items,
+            budget_seconds=screening_candidate_budget_seconds,
+        )
+        screening_records_by_id = {
+            str(record["candidate_id"]): record
+            for record in screening_records
+        }
+        _persist_screening_candidate_sidecar(
+            run_id=state["run_id"],
+            as_of_utc=as_of_utc,
+            screening_records=screening_records,
+        )
+        tracker.set_screening(
+            _screening_progress_payload(
+                completed_candidates=0,
+                total_candidates=len(screening_items),
+                record=None,
+            ),
+            persist=True,
+        )
         for index, candidate in enumerate(screening_items, start=1):
+            strategy = strategy_by_name[candidate["strategy_name"]]
+            sampled_params = screening_param_samples(
+                strategy.get("params") or {},
+                max_samples=SCREENING_PARAM_SAMPLE_LIMIT,
+            )
+            runtime_record = screening_records_by_id[str(candidate["candidate_id"])]
+            runtime_record["runtime_status"] = "running"
+            runtime_record["final_status"] = None
+            runtime_record["started_at"] = datetime.now(UTC).isoformat()
+            runtime_record["finished_at"] = None
+            runtime_record["elapsed_seconds"] = 0
+            runtime_record["samples_completed"] = 0
+            runtime_record["samples_total"] = len(sampled_params)
+            runtime_record["decision"] = None
+            runtime_record["reason_code"] = None
+            runtime_record["reason_detail"] = None
             tracker.begin_item(
                 strategy=candidate["strategy_name"],
                 asset=candidate["asset"],
                 interval=candidate["interval"],
             )
-            strategy = strategy_by_name[candidate["strategy_name"]]
-            start_datum = interval_ranges[candidate["interval"]]["start"]
-            eind_datum = interval_ranges[candidate["interval"]]["end"]
-            engine = _build_engine(
-                start_datum=start_datum,
-                eind_datum=eind_datum,
-                evaluation_config=evaluation_config,
-                regime_config=research_config.get("regime_diagnostics"),
+            tracker.set_screening(
+                _screening_progress_payload(
+                    completed_candidates=index - 1,
+                    total_candidates=len(screening_items),
+                    record=runtime_record,
+                ),
+                persist=True,
             )
-            decision = _screen_candidate(strategy=strategy, candidate=candidate, engine=engine)
-            provenance_events.extend(getattr(engine, "_provenance_events", []))
+            _persist_screening_candidate_sidecar(
+                run_id=state["run_id"],
+                as_of_utc=as_of_utc,
+                screening_records=screening_records,
+            )
+            tracker.emit_event(
+                "screening_candidate_started",
+                candidate_id=candidate["candidate_id"],
+                strategy=candidate["strategy_name"],
+                asset=candidate["asset"],
+                interval=candidate["interval"],
+                elapsed_seconds=0,
+                samples_completed=0,
+                samples_total=runtime_record["samples_total"],
+            )
+
+            def _on_screening_progress(progress: dict[str, int]) -> None:
+                runtime_record["elapsed_seconds"] = int(progress["elapsed_seconds"])
+                runtime_record["samples_completed"] = int(progress["samples_completed"])
+                runtime_record["samples_total"] = int(progress["samples_total"])
+                tracker.set_screening(
+                    _screening_progress_payload(
+                        completed_candidates=index - 1,
+                        total_candidates=len(screening_items),
+                        record=runtime_record,
+                    ),
+                    persist=True,
+                )
+                _persist_screening_candidate_sidecar(
+                    run_id=state["run_id"],
+                    as_of_utc=as_of_utc,
+                    screening_records=screening_records,
+                )
+                tracker.emit_event(
+                    "screening_candidate_progress",
+                    candidate_id=candidate["candidate_id"],
+                    strategy=candidate["strategy_name"],
+                    asset=candidate["asset"],
+                    interval=candidate["interval"],
+                    elapsed_seconds=runtime_record["elapsed_seconds"],
+                    samples_completed=runtime_record["samples_completed"],
+                    samples_total=runtime_record["samples_total"],
+                )
+
+            engine = None
+            try:
+                start_datum = interval_ranges[candidate["interval"]]["start"]
+                eind_datum = interval_ranges[candidate["interval"]]["end"]
+                engine = _build_engine(
+                    start_datum=start_datum,
+                    eind_datum=eind_datum,
+                    evaluation_config=evaluation_config,
+                    regime_config=research_config.get("regime_diagnostics"),
+                )
+                runtime_record["samples_total"] = (
+                    0
+                    if not hasattr(engine, "run")
+                    else len(sampled_params)
+                )
+                outcome = execute_screening_candidate(
+                    strategy=strategy,
+                    candidate=candidate,
+                    engine=engine,
+                    budget_seconds=screening_candidate_budget_seconds,
+                    max_samples=SCREENING_PARAM_SAMPLE_LIMIT,
+                    on_progress=_on_screening_progress,
+                )
+            except Exception as exc:
+                outcome = {
+                    "legacy_decision": {
+                        "status": "rejected_in_screening",
+                        "reason": "screening_candidate_error",
+                        "sampled_combination_count": runtime_record["samples_completed"],
+                    },
+                    "runtime_status": "running",
+                    "final_status": FINAL_STATUS_ERRORED,
+                    "started_at": runtime_record["started_at"],
+                    "finished_at": datetime.now(UTC).isoformat(),
+                    "elapsed_seconds": int(runtime_record["elapsed_seconds"]),
+                    "samples_total": runtime_record["samples_total"],
+                    "samples_completed": runtime_record["samples_completed"],
+                    "decision": "rejected_in_screening",
+                    "reason_code": "screening_candidate_error",
+                    "reason_detail": str(exc),
+                }
+            if engine is not None:
+                provenance_events.extend(getattr(engine, "_provenance_events", []))
+
+            runtime_record.update(outcome)
+            if runtime_record["elapsed_seconds"] is None:
+                runtime_record["elapsed_seconds"] = 0
+            if runtime_record["samples_total"] is None:
+                runtime_record["samples_total"] = 0
+            if runtime_record["samples_completed"] is None:
+                runtime_record["samples_completed"] = 0
+            decision = dict(outcome["legacy_decision"])
             for item in candidates:
                 if item["candidate_id"] != candidate["candidate_id"]:
                     continue
@@ -726,7 +868,78 @@ def run_research():
                 else:
                     item["current_status"] = "screening_rejected"
                 break
+            _persist_candidate_pipeline_sidecars(
+                run_id=state["run_id"],
+                as_of_utc=as_of_utc,
+                candidates=candidates,
+            )
+            _persist_screening_candidate_sidecar(
+                run_id=state["run_id"],
+                as_of_utc=as_of_utc,
+                screening_records=screening_records,
+            )
+            if runtime_record["final_status"] in {FINAL_STATUS_PASSED, FINAL_STATUS_REJECTED}:
+                tracker.emit_event(
+                    "screening_candidate_decision",
+                    candidate_id=candidate["candidate_id"],
+                    strategy=candidate["strategy_name"],
+                    asset=candidate["asset"],
+                    interval=candidate["interval"],
+                    elapsed_seconds=runtime_record["elapsed_seconds"],
+                    samples_completed=runtime_record["samples_completed"],
+                    samples_total=runtime_record["samples_total"],
+                    decision=runtime_record["decision"],
+                    reason_code=runtime_record["reason_code"],
+                )
+            elif runtime_record["final_status"] == FINAL_STATUS_TIMED_OUT:
+                tracker.emit_event(
+                    "screening_candidate_timeout",
+                    candidate_id=candidate["candidate_id"],
+                    strategy=candidate["strategy_name"],
+                    asset=candidate["asset"],
+                    interval=candidate["interval"],
+                    elapsed_seconds=runtime_record["elapsed_seconds"],
+                    samples_completed=runtime_record["samples_completed"],
+                    samples_total=runtime_record["samples_total"],
+                    decision=runtime_record["decision"],
+                    reason_code=runtime_record["reason_code"],
+                )
+            elif runtime_record["final_status"] == FINAL_STATUS_ERRORED:
+                tracker.emit_event(
+                    "screening_candidate_error",
+                    candidate_id=candidate["candidate_id"],
+                    strategy=candidate["strategy_name"],
+                    asset=candidate["asset"],
+                    interval=candidate["interval"],
+                    elapsed_seconds=runtime_record["elapsed_seconds"],
+                    samples_completed=runtime_record["samples_completed"],
+                    samples_total=runtime_record["samples_total"],
+                    decision=runtime_record["decision"],
+                    reason_code=runtime_record["reason_code"],
+                    reason_detail=runtime_record["reason_detail"],
+                )
+            tracker.emit_event(
+                "screening_candidate_finished",
+                candidate_id=candidate["candidate_id"],
+                strategy=candidate["strategy_name"],
+                asset=candidate["asset"],
+                interval=candidate["interval"],
+                elapsed_seconds=runtime_record["elapsed_seconds"],
+                samples_completed=runtime_record["samples_completed"],
+                samples_total=runtime_record["samples_total"],
+                final_status=runtime_record["final_status"],
+                decision=runtime_record["decision"],
+                reason_code=runtime_record["reason_code"],
+            )
             tracker.advance(completed=index, total=len(screening_items))
+            tracker.set_screening(
+                _screening_progress_payload(
+                    completed_candidates=index,
+                    total_candidates=len(screening_items),
+                    record=runtime_record,
+                ),
+                persist=True,
+            )
 
         screening_summary = summarize_candidates(candidates)
         _persist_candidate_pipeline_sidecars(

--- a/research/screening_runtime.py
+++ b/research/screening_runtime.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import copy
+import time
+from collections import Counter
+from datetime import UTC, datetime
+from typing import Any, Callable
+
+from research.candidate_pipeline import (
+    SCREENING_PROMOTED,
+    SCREENING_REJECTED,
+    normalize_screening_decision,
+    screening_param_samples,
+)
+
+FINAL_STATUS_PASSED = "passed"
+FINAL_STATUS_REJECTED = "rejected"
+FINAL_STATUS_TIMED_OUT = "timed_out"
+FINAL_STATUS_ERRORED = "errored"
+FINAL_STATUS_SKIPPED = "skipped"
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _elapsed_seconds(monotonic_source: Callable[[], float], started_at_monotonic: float) -> int:
+    return max(0, int(round(monotonic_source() - started_at_monotonic)))
+
+
+def _elapsed_raw_seconds(monotonic_source: Callable[[], float], started_at_monotonic: float) -> float:
+    return max(0.0, monotonic_source() - started_at_monotonic)
+
+
+def _screening_sort_key(record: dict[str, Any]) -> tuple[str, str, str, str]:
+    return (
+        str(record["strategy"]),
+        str(record["asset"]),
+        str(record["interval"]),
+        str(record["candidate_id"]),
+    )
+
+
+def build_screening_runtime_records(
+    *,
+    candidates: list[dict[str, Any]],
+    budget_seconds: int,
+) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for candidate in sorted(candidates, key=lambda item: (item["strategy_name"], item["asset"], item["interval"], item["candidate_id"])):
+        records.append(
+            {
+                "candidate_id": str(candidate["candidate_id"]),
+                "strategy": str(candidate["strategy_name"]),
+                "asset": str(candidate["asset"]),
+                "interval": str(candidate["interval"]),
+                "stage": "screening",
+                "runtime_status": "pending",
+                "final_status": None,
+                "started_at": None,
+                "finished_at": None,
+                "elapsed_seconds": 0,
+                "budget_seconds": int(budget_seconds),
+                "samples_total": None,
+                "samples_completed": 0,
+                "decision": None,
+                "reason_code": None,
+                "reason_detail": None,
+            }
+        )
+    return records
+
+
+def build_screening_sidecar_payload(
+    *,
+    run_id: str,
+    as_of_utc: datetime,
+    records: list[dict[str, Any]],
+) -> dict[str, Any]:
+    ordered_records = sorted((copy.deepcopy(record) for record in records), key=_screening_sort_key)
+    runtime_counts = Counter(
+        str(record["runtime_status"])
+        for record in ordered_records
+        if record.get("final_status") is None
+    )
+    final_counts = Counter(str(record["final_status"]) for record in ordered_records if record.get("final_status"))
+    return {
+        "version": "v1",
+        "run_id": run_id,
+        "generated_at_utc": as_of_utc.astimezone(UTC).isoformat(),
+        "summary": {
+            "candidate_count": len(ordered_records),
+            "pending_count": int(runtime_counts.get("pending", 0)),
+            "running_count": int(runtime_counts.get("running", 0)),
+            "passed_count": int(final_counts.get(FINAL_STATUS_PASSED, 0)),
+            "rejected_count": int(final_counts.get(FINAL_STATUS_REJECTED, 0)),
+            "timed_out_count": int(final_counts.get(FINAL_STATUS_TIMED_OUT, 0)),
+            "errored_count": int(final_counts.get(FINAL_STATUS_ERRORED, 0)),
+            "skipped_count": int(final_counts.get(FINAL_STATUS_SKIPPED, 0)),
+        },
+        "candidates": ordered_records,
+    }
+
+
+def execute_screening_candidate(
+    *,
+    strategy: dict[str, Any],
+    candidate: dict[str, Any],
+    engine: Any,
+    budget_seconds: int,
+    max_samples: int,
+    now_source: Callable[[], datetime] | None = None,
+    monotonic_source: Callable[[], float] | None = None,
+    on_progress: Callable[[dict[str, int]], None] | None = None,
+) -> dict[str, Any]:
+    now = now_source or _utc_now
+    monotonic = monotonic_source or time.monotonic
+    started_at = now().astimezone(UTC)
+    started_at_monotonic = monotonic()
+
+    if not hasattr(engine, "run"):
+        return {
+            "legacy_decision": {
+                "status": SCREENING_PROMOTED,
+                "reason": None,
+                "sampled_combination_count": 0,
+            },
+            "runtime_status": "running",
+            "final_status": FINAL_STATUS_PASSED,
+            "started_at": started_at.isoformat(),
+            "finished_at": now().astimezone(UTC).isoformat(),
+            "elapsed_seconds": _elapsed_seconds(monotonic, started_at_monotonic),
+            "samples_total": 0,
+            "samples_completed": 0,
+            "decision": SCREENING_PROMOTED,
+            "reason_code": None,
+            "reason_detail": None,
+        }
+
+    sampled_params = screening_param_samples(strategy.get("params") or {}, max_samples=max_samples)
+    samples_total = len(sampled_params)
+    sample_results: list[dict[str, Any]] = []
+
+    for sample_index, params in enumerate(sampled_params, start=1):
+        if _elapsed_raw_seconds(monotonic, started_at_monotonic) > float(budget_seconds):
+            elapsed_seconds = _elapsed_seconds(monotonic, started_at_monotonic)
+            return {
+                "legacy_decision": {
+                    "status": SCREENING_REJECTED,
+                    "reason": "candidate_budget_exceeded",
+                    "sampled_combination_count": len(sample_results),
+                },
+                "runtime_status": "running",
+                "final_status": FINAL_STATUS_TIMED_OUT,
+                "started_at": started_at.isoformat(),
+                "finished_at": now().astimezone(UTC).isoformat(),
+                "elapsed_seconds": elapsed_seconds,
+                "samples_total": samples_total,
+                "samples_completed": len(sample_results),
+                "decision": SCREENING_REJECTED,
+                "reason_code": "candidate_budget_exceeded",
+                "reason_detail": f"candidate exceeded screening budget of {int(budget_seconds)} seconds",
+            }
+
+        try:
+            metrics = engine.run(
+                strategy["factory"](**params),
+                assets=[candidate["asset"]],
+                interval=candidate["interval"],
+            )
+        except Exception as exc:
+            elapsed_seconds = _elapsed_seconds(monotonic, started_at_monotonic)
+            return {
+                "legacy_decision": {
+                    "status": SCREENING_REJECTED,
+                    "reason": "screening_candidate_error",
+                    "sampled_combination_count": len(sample_results),
+                },
+                "runtime_status": "running",
+                "final_status": FINAL_STATUS_ERRORED,
+                "started_at": started_at.isoformat(),
+                "finished_at": now().astimezone(UTC).isoformat(),
+                "elapsed_seconds": elapsed_seconds,
+                "samples_total": samples_total,
+                "samples_completed": len(sample_results),
+                "decision": SCREENING_REJECTED,
+                "reason_code": "screening_candidate_error",
+                "reason_detail": str(exc),
+            }
+
+        report = getattr(engine, "last_evaluation_report", None) or {}
+        evaluation_samples = report.get("evaluation_samples") or {}
+        daily_returns = evaluation_samples.get("daily_returns") or []
+        if not isinstance(daily_returns, list) or not daily_returns:
+            sample_results.append({"status": SCREENING_REJECTED, "reason": "no_oos_samples"})
+        else:
+            min_trades = int(getattr(engine, "min_trades", 10))
+            if int(metrics.get("totaal_trades", 0)) < min_trades:
+                sample_results.append({"status": SCREENING_REJECTED, "reason": "insufficient_trades"})
+            elif not metrics.get("goedgekeurd", False):
+                sample_results.append({"status": SCREENING_REJECTED, "reason": "screening_criteria_not_met"})
+            else:
+                sample_results.append({"status": SCREENING_PROMOTED, "reason": None})
+
+        if on_progress is not None:
+            on_progress(
+                {
+                    "elapsed_seconds": _elapsed_seconds(monotonic, started_at_monotonic),
+                    "samples_completed": sample_index,
+                    "samples_total": samples_total,
+                }
+            )
+
+    legacy_decision = normalize_screening_decision(sample_results)
+    final_status = FINAL_STATUS_PASSED if legacy_decision["status"] == SCREENING_PROMOTED else FINAL_STATUS_REJECTED
+    reason_code = legacy_decision.get("reason")
+    reason_detail = None
+    if final_status == FINAL_STATUS_REJECTED and reason_code is not None:
+        reason_detail = f"screening rejected after {len(sample_results)} sampled parameter combinations"
+    return {
+        "legacy_decision": legacy_decision,
+        "runtime_status": "running",
+        "final_status": final_status,
+        "started_at": started_at.isoformat(),
+        "finished_at": now().astimezone(UTC).isoformat(),
+        "elapsed_seconds": _elapsed_seconds(monotonic, started_at_monotonic),
+        "samples_total": samples_total,
+        "samples_completed": len(sample_results),
+        "decision": legacy_decision["status"],
+        "reason_code": reason_code,
+        "reason_detail": reason_detail,
+    }

--- a/tests/unit/test_run_research_observability.py
+++ b/tests/unit/test_run_research_observability.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import csv
 import json
+import time
 from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
@@ -255,6 +256,47 @@ class _SelectiveScreeningEngine(_HealthyEngine):
         return super().grid_search(strategie_factory, param_grid, assets, interval=interval)
 
 
+class _ProgressCaptureEngine(_HealthyEngine):
+    captured_progress = None
+    captured_screening = None
+
+    def run(self, strategie_func, assets, interval="1d"):
+        if _ProgressCaptureEngine.captured_progress is None:
+            _ProgressCaptureEngine.captured_progress = json.loads(
+                Path("research/run_progress_latest.v1.json").read_text(encoding="utf-8")
+            )
+            _ProgressCaptureEngine.captured_screening = json.loads(
+                Path("research/run_screening_candidates_latest.v1.json").read_text(encoding="utf-8")
+            )
+        return super().run(strategie_func, assets, interval=interval)
+
+
+class _TimeoutIsolationEngine(_HealthyEngine):
+    validation_calls = 0
+
+    def run(self, strategie_func, assets, interval="1d"):
+        if getattr(strategie_func, "screen_tag", "") == "timeout":
+            time.sleep(1.1)
+        return super().run(strategie_func, assets, interval=interval)
+
+    def grid_search(self, strategie_factory, param_grid, assets, interval="1d"):
+        _TimeoutIsolationEngine.validation_calls += 1
+        return super().grid_search(strategie_factory, param_grid, assets, interval=interval)
+
+
+class _ErrorIsolationEngine(_HealthyEngine):
+    validation_calls = 0
+
+    def run(self, strategie_func, assets, interval="1d"):
+        if getattr(strategie_func, "screen_tag", "") == "error":
+            raise RuntimeError("boom during screening")
+        return super().run(strategie_func, assets, interval=interval)
+
+    def grid_search(self, strategie_factory, param_grid, assets, interval="1d"):
+        _ErrorIsolationEngine.validation_calls += 1
+        return super().grid_search(strategie_factory, param_grid, assets, interval=interval)
+
+
 def test_run_research_writes_completed_progress_sidecar_and_keeps_public_schema(monkeypatch, tmp_path: Path):
     _patch_common_runner(monkeypatch, tmp_path, _HealthyEngine)
 
@@ -265,6 +307,7 @@ def test_run_research_writes_completed_progress_sidecar_and_keeps_public_schema(
     manifest = _load_json(tmp_path / "research" / "run_manifest_latest.v1.json")
     candidates = _load_json(tmp_path / "research" / "run_candidates_latest.v1.json")
     filter_summary = _load_json(tmp_path / "research" / "run_filter_summary_latest.v1.json")
+    screening_candidates = _load_json(tmp_path / "research" / "run_screening_candidates_latest.v1.json")
     public_json = _load_json(tmp_path / "research" / "research_latest.json")
     with (tmp_path / "research" / "strategy_matrix.csv").open(encoding="utf-8", newline="") as handle:
         csv_rows = list(csv.DictReader(handle))
@@ -289,11 +332,15 @@ def test_run_research_writes_completed_progress_sidecar_and_keeps_public_schema(
     ]
     assert manifest["raw_candidate_count"] == 1
     assert manifest["validation_candidate_count"] == 1
+    assert manifest["artifacts"]["run_screening_candidates_path"] == "research/run_screening_candidates_latest.v1.json"
     assert candidates["summary"]["validation_candidate_count"] == 1
     assert filter_summary["screening_decisions"]["promoted_to_validation"] == 1
+    assert screening_candidates["summary"]["passed_count"] == 1
+    assert screening_candidates["candidates"][0]["final_status"] == "passed"
     assert (tmp_path / "logs" / "research" / f"{state['run_id']}.jsonl").exists()
     assert (tmp_path / "research" / "history" / state["run_id"] / "run_state.v1.json").exists()
     assert (tmp_path / "research" / "history" / state["run_id"] / "run_candidates.v1.json").exists()
+    assert (tmp_path / "research" / "history" / state["run_id"] / "run_screening_candidates.v1.json").exists()
     assert list(public_json["results"][0].keys()) == ROW_SCHEMA
     assert list(csv_rows[0].keys()) == ROW_SCHEMA
 
@@ -365,3 +412,144 @@ def test_only_screening_survivors_reach_validation(monkeypatch, tmp_path: Path):
     assert candidates["summary"]["screening_rejected_count"] == 1
     assert candidates["summary"]["validation_candidate_count"] == 1
     assert filter_summary["screening_rejection_reasons"] == {"screening_criteria_not_met": 1}
+
+
+def test_screening_progress_is_persisted_immediately_on_candidate_start(monkeypatch, tmp_path: Path):
+    _patch_common_runner(monkeypatch, tmp_path, _ProgressCaptureEngine)
+    _ProgressCaptureEngine.captured_progress = None
+    _ProgressCaptureEngine.captured_screening = None
+
+    run_research_module.run_research()
+
+    progress = _ProgressCaptureEngine.captured_progress
+    screening = _ProgressCaptureEngine.captured_screening
+    assert progress is not None
+    assert progress["current_stage"] == "screening"
+    assert progress["current_item"] == {
+        "strategy": "fake_strategy",
+        "asset": "BTC-USD",
+        "interval": "1d",
+    }
+    assert progress["screening"]["completed_screening_candidates"] == 0
+    assert progress["screening"]["total_screening_candidates"] == 1
+    assert progress["screening"]["runtime_status"] == "running"
+    assert progress["screening"]["candidate_id"] is not None
+    assert screening["candidates"][0]["runtime_status"] == "running"
+    assert screening["candidates"][0]["started_at"] is not None
+    assert screening["candidates"][0]["final_status"] is None
+
+
+def test_screening_timeout_is_persisted_and_run_continues(monkeypatch, tmp_path: Path):
+    _patch_common_runner(monkeypatch, tmp_path, _TimeoutIsolationEngine)
+    _TimeoutIsolationEngine.validation_calls = 0
+
+    def _factory(tag):
+        def _build(**params):
+            return SimpleNamespace(screen_tag=tag)
+
+        return _build
+
+    monkeypatch.setattr(
+        run_research_module,
+        "get_enabled_strategies",
+        lambda: [
+            {
+                "name": "timeout_strategy",
+                "family": "trend",
+                "strategy_family": "trend_following",
+                "position_structure": "outright",
+                "initial_lane_support": "supported",
+                "hypothesis": "timeout",
+                "factory": _factory("timeout"),
+                "params": {"periode": [14, 21, 28]},
+            },
+            {
+                "name": "survivor_strategy",
+                "family": "trend",
+                "strategy_family": "trend_following",
+                "position_structure": "outright",
+                "initial_lane_support": "supported",
+                "hypothesis": "survivor",
+                "factory": _factory("survivor"),
+                "params": {"periode": [14]},
+            },
+        ],
+    )
+    monkeypatch.setattr(
+        run_research_module,
+        "load_research_config",
+        lambda config_path="config/config.yaml": {"screening": {"candidate_budget_seconds": 1}},
+    )
+
+    run_research_module.run_research()
+
+    screening = _load_json(tmp_path / "research" / "run_screening_candidates_latest.v1.json")
+    filter_summary = _load_json(tmp_path / "research" / "run_filter_summary_latest.v1.json")
+    public_json = _load_json(tmp_path / "research" / "research_latest.json")
+    log_path = tmp_path / "logs" / "research" / f"{_load_json(tmp_path / 'research' / 'run_state.v1.json')['run_id']}.jsonl"
+    events = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()]
+
+    by_strategy = {item["strategy"]: item for item in screening["candidates"]}
+    assert by_strategy["timeout_strategy"]["final_status"] == "timed_out"
+    assert by_strategy["timeout_strategy"]["reason_code"] == "candidate_budget_exceeded"
+    assert by_strategy["survivor_strategy"]["final_status"] == "passed"
+    assert filter_summary["screening_rejection_reasons"] == {"candidate_budget_exceeded": 1}
+    assert _TimeoutIsolationEngine.validation_calls == 1
+    assert public_json["count"] == 1
+    assert any(event["event"] == "screening_candidate_timeout" for event in events)
+
+
+def test_screening_exception_is_persisted_and_run_continues(monkeypatch, tmp_path: Path):
+    _patch_common_runner(monkeypatch, tmp_path, _ErrorIsolationEngine)
+    _ErrorIsolationEngine.validation_calls = 0
+
+    def _factory(tag):
+        def _build(**params):
+            return SimpleNamespace(screen_tag=tag)
+
+        return _build
+
+    monkeypatch.setattr(
+        run_research_module,
+        "get_enabled_strategies",
+        lambda: [
+            {
+                "name": "error_strategy",
+                "family": "trend",
+                "strategy_family": "trend_following",
+                "position_structure": "outright",
+                "initial_lane_support": "supported",
+                "hypothesis": "error",
+                "factory": _factory("error"),
+                "params": {"periode": [14]},
+            },
+            {
+                "name": "survivor_strategy",
+                "family": "trend",
+                "strategy_family": "trend_following",
+                "position_structure": "outright",
+                "initial_lane_support": "supported",
+                "hypothesis": "survivor",
+                "factory": _factory("survivor"),
+                "params": {"periode": [14]},
+            },
+        ],
+    )
+
+    run_research_module.run_research()
+
+    screening = _load_json(tmp_path / "research" / "run_screening_candidates_latest.v1.json")
+    filter_summary = _load_json(tmp_path / "research" / "run_filter_summary_latest.v1.json")
+    public_json = _load_json(tmp_path / "research" / "research_latest.json")
+    log_path = tmp_path / "logs" / "research" / f"{_load_json(tmp_path / 'research' / 'run_state.v1.json')['run_id']}.jsonl"
+    events = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()]
+
+    by_strategy = {item["strategy"]: item for item in screening["candidates"]}
+    assert by_strategy["error_strategy"]["final_status"] == "errored"
+    assert by_strategy["error_strategy"]["reason_code"] == "screening_candidate_error"
+    assert by_strategy["error_strategy"]["reason_detail"] == "boom during screening"
+    assert by_strategy["survivor_strategy"]["final_status"] == "passed"
+    assert filter_summary["screening_rejection_reasons"] == {"screening_candidate_error": 1}
+    assert _ErrorIsolationEngine.validation_calls == 1
+    assert public_json["count"] == 1
+    assert any(event["event"] == "screening_candidate_error" for event in events)

--- a/tests/unit/test_screening_runtime.py
+++ b/tests/unit/test_screening_runtime.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+from research.screening_runtime import (
+    FINAL_STATUS_ERRORED,
+    FINAL_STATUS_TIMED_OUT,
+    build_screening_runtime_records,
+    build_screening_sidecar_payload,
+    execute_screening_candidate,
+)
+
+
+class FakeClock:
+    def __init__(self, start: datetime):
+        self.current = start
+        self.mono = 0.0
+
+    def now(self) -> datetime:
+        return self.current
+
+    def monotonic(self) -> float:
+        return self.mono
+
+    def advance(self, seconds: float) -> None:
+        self.mono += seconds
+        self.current += timedelta(seconds=seconds)
+
+
+def test_screening_sidecar_payload_counts_are_deterministic():
+    records = build_screening_runtime_records(
+        candidates=[
+            {"candidate_id": "b", "strategy_name": "beta", "asset": "ETH-USD", "interval": "1h"},
+            {"candidate_id": "a", "strategy_name": "alpha", "asset": "BTC-USD", "interval": "1d"},
+        ],
+        budget_seconds=30,
+    )
+    records[0]["final_status"] = "rejected"
+    records[1]["final_status"] = "passed"
+
+    payload = build_screening_sidecar_payload(
+        run_id="run-1",
+        as_of_utc=datetime(2026, 4, 13, 12, 0, 0, tzinfo=UTC),
+        records=records,
+    )
+
+    assert payload["summary"] == {
+        "candidate_count": 2,
+        "pending_count": 0,
+        "running_count": 0,
+        "passed_count": 1,
+        "rejected_count": 1,
+        "timed_out_count": 0,
+        "errored_count": 0,
+        "skipped_count": 0,
+    }
+    assert [item["candidate_id"] for item in payload["candidates"]] == ["a", "b"]
+
+
+def test_execute_screening_candidate_times_out_cooperatively():
+    clock = FakeClock(datetime(2026, 4, 13, 12, 0, 0, tzinfo=UTC))
+
+    class SlowEngine:
+        def __init__(self):
+            self.last_evaluation_report = None
+
+        def run(self, strategie_func, assets, interval="1d"):
+            clock.advance(2)
+            self.last_evaluation_report = {
+                "evaluation_samples": {
+                    "daily_returns": [0.01, -0.01],
+                }
+            }
+            return {
+                "totaal_trades": 12,
+                "goedgekeurd": True,
+            }
+
+    outcome = execute_screening_candidate(
+        strategy={
+            "factory": lambda **params: SimpleNamespace(params=params),
+            "params": {"periode": [14, 21, 28]},
+        },
+        candidate={"asset": "BTC-USD", "interval": "1d"},
+        engine=SlowEngine(),
+        budget_seconds=1,
+        max_samples=3,
+        now_source=clock.now,
+        monotonic_source=clock.monotonic,
+    )
+
+    assert outcome["final_status"] == FINAL_STATUS_TIMED_OUT
+    assert outcome["reason_code"] == "candidate_budget_exceeded"
+    assert outcome["samples_total"] == 3
+    assert outcome["samples_completed"] == 1
+    assert outcome["legacy_decision"]["reason"] == "candidate_budget_exceeded"
+
+
+def test_execute_screening_candidate_surfaces_candidate_error():
+    clock = FakeClock(datetime(2026, 4, 13, 12, 0, 0, tzinfo=UTC))
+
+    class BrokenEngine:
+        def run(self, strategie_func, assets, interval="1d"):
+            raise RuntimeError("boom")
+
+    outcome = execute_screening_candidate(
+        strategy={
+            "factory": lambda **params: None,
+            "params": {"periode": [14]},
+        },
+        candidate={"asset": "BTC-USD", "interval": "1d"},
+        engine=BrokenEngine(),
+        budget_seconds=30,
+        max_samples=3,
+        now_source=clock.now,
+        monotonic_source=clock.monotonic,
+    )
+
+    assert outcome["final_status"] == FINAL_STATUS_ERRORED
+    assert outcome["reason_code"] == "screening_candidate_error"
+    assert outcome["reason_detail"] == "boom"
+    assert outcome["samples_completed"] == 0


### PR DESCRIPTION
## Summary

Adds candidate-level observability and bounded execution to screening.

## Changes

* Introduces screening runtime sidecar:

  * `run_screening_candidates_latest.v1.json`
* Adds candidate lifecycle tracking:

  * started / progress / decision / timeout / error / finished
* Implements cooperative per-candidate time budgets
* Persists `current_item` immediately during screening
* Adds additive `screening` block to progress artifact
* Ensures failure isolation (timeouts/errors do not block run)

## Architecture

* No parallelization introduced
* Orchestrator remains thin
* Public outputs unchanged:

  * `research_latest.json`
  * `strategy_matrix.csv`
* All changes are additive

## Tests

* Added unit tests for screening runtime
* Added observability tests for:

  * progress persistence
  * timeout continuation
  * error isolation

## Notes

* Local Windows pytest tmp_path issue prevents full suite run
* CI should be used as source of truth for full validation
