### PR TITLE
feat: add batch-based research execution observability

### DIFF
--- a/research/batching.py
+++ b/research/batching.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import re
+from collections import Counter
+from datetime import UTC, datetime
+from typing import Any
+
+
+def _canonical_json(payload: Any) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def _hash_payload(payload: Any) -> str:
+    return hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+def _slug(value: str) -> str:
+    compact = re.sub(r"[^a-z0-9]+", "_", value.lower()).strip("_")
+    return compact or "unknown"
+
+
+def _batch_sort_key(record: dict[str, Any]) -> tuple[str, str, str]:
+    return (
+        str(record["strategy_family"]),
+        str(record["interval"]),
+        str(record["batch_id"]),
+    )
+
+
+def build_batch_id(*, strategy_family: str, interval: str, candidate_ids: list[str]) -> str:
+    payload = {
+        "strategy_family": strategy_family,
+        "interval": interval,
+        "candidate_ids": list(candidate_ids),
+    }
+    stable_hash = _hash_payload(payload)[:8]
+    return f"batch-{_slug(strategy_family)}-{_slug(interval)}-{stable_hash}"
+
+
+def partition_execution_batches(*, candidates: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    grouped: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for candidate in sorted(
+        candidates,
+        key=lambda item: (
+            str(item["strategy_family"]),
+            str(item["interval"]),
+            str(item["strategy_name"]),
+            str(item["asset"]),
+            str(item["candidate_id"]),
+        ),
+    ):
+        key = (str(candidate["strategy_family"]), str(candidate["interval"]))
+        grouped.setdefault(key, []).append(candidate)
+
+    batches: list[dict[str, Any]] = []
+    for batch_index, key in enumerate(sorted(grouped), start=1):
+        strategy_family, interval = key
+        batch_candidates = grouped[key]
+        candidate_ids = [str(candidate["candidate_id"]) for candidate in batch_candidates]
+        assets = sorted({str(candidate["asset"]) for candidate in batch_candidates})
+        strategy_names = sorted({str(candidate["strategy_name"]) for candidate in batch_candidates})
+        batches.append(
+            {
+                "batch_id": build_batch_id(
+                    strategy_family=strategy_family,
+                    interval=interval,
+                    candidate_ids=candidate_ids,
+                ),
+                "batch_index": int(batch_index),
+                "strategy_family": strategy_family,
+                "interval": interval,
+                "partition": {
+                    "strategy_family": strategy_family,
+                    "interval": interval,
+                },
+                "status": "pending",
+                "started_at": None,
+                "finished_at": None,
+                "elapsed_seconds": 0,
+                "candidate_count": len(candidate_ids),
+                "completed_candidate_count": 0,
+                "promoted_candidate_count": 0,
+                "validated_candidate_count": 0,
+                "screening_rejected_count": 0,
+                "timed_out_count": 0,
+                "errored_count": 0,
+                "validation_error_count": 0,
+                "result_success_count": 0,
+                "result_failed_count": 0,
+                "candidate_ids": candidate_ids,
+                "candidate_summary": {
+                    "asset_count": len(assets),
+                    "strategy_count": len(strategy_names),
+                    "assets": assets,
+                    "strategies": strategy_names,
+                },
+                "reason_code": None,
+                "reason_detail": None,
+            }
+        )
+    return sorted(batches, key=_batch_sort_key)
+
+
+def build_run_batches_payload(
+    *,
+    run_id: str,
+    as_of_utc: datetime,
+    batches: list[dict[str, Any]],
+) -> dict[str, Any]:
+    ordered_batches = sorted((copy.deepcopy(batch) for batch in batches), key=_batch_sort_key)
+    status_counts = Counter(str(batch["status"]) for batch in ordered_batches)
+    return {
+        "version": "v1",
+        "run_id": run_id,
+        "generated_at_utc": as_of_utc.astimezone(UTC).isoformat(),
+        "summary": {
+            "batch_count": len(ordered_batches),
+            "pending_count": int(status_counts.get("pending", 0)),
+            "running_count": int(status_counts.get("running", 0)),
+            "completed_count": int(status_counts.get("completed", 0)),
+            "partial_count": int(status_counts.get("partial", 0)),
+            "failed_count": int(status_counts.get("failed", 0)),
+            "skipped_count": int(status_counts.get("skipped", 0)),
+        },
+        "batches": ordered_batches,
+    }
+
+
+def build_batch_manifest_payload(
+    *,
+    run_id: str,
+    batch: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "version": "v1",
+        "run_id": run_id,
+        "batch_id": str(batch["batch_id"]),
+        "batch_index": int(batch["batch_index"]),
+        "partition": copy.deepcopy(batch["partition"]),
+        "status": str(batch["status"]),
+        "started_at": batch.get("started_at"),
+        "finished_at": batch.get("finished_at"),
+        "elapsed_seconds": int(batch.get("elapsed_seconds") or 0),
+        "candidate_count": int(batch.get("candidate_count") or 0),
+        "completed_candidate_count": int(batch.get("completed_candidate_count") or 0),
+        "promoted_candidate_count": int(batch.get("promoted_candidate_count") or 0),
+        "validated_candidate_count": int(batch.get("validated_candidate_count") or 0),
+        "screening_rejected_count": int(batch.get("screening_rejected_count") or 0),
+        "timed_out_count": int(batch.get("timed_out_count") or 0),
+        "errored_count": int(batch.get("errored_count") or 0),
+        "validation_error_count": int(batch.get("validation_error_count") or 0),
+        "result_success_count": int(batch.get("result_success_count") or 0),
+        "result_failed_count": int(batch.get("result_failed_count") or 0),
+        "candidate_summary": copy.deepcopy(batch.get("candidate_summary") or {}),
+        "candidate_ids": list(batch.get("candidate_ids") or []),
+        "reason_code": batch.get("reason_code"),
+        "reason_detail": batch.get("reason_detail"),
+    }

--- a/research/observability.py
+++ b/research/observability.py
@@ -45,6 +45,7 @@ class ProgressTracker:
             "asset": None,
             "interval": None,
         }
+        self.batch: dict[str, Any] | None = None
         self.screening: dict[str, Any] | None = None
         self.completed_items = 0
         self.total_items = 0
@@ -71,6 +72,8 @@ class ProgressTracker:
 
     def start_stage(self, stage: str, *, total: int | None = None, **log_fields: Any) -> None:
         self.current_stage = stage
+        if stage not in {"screening", "validation"}:
+            self.batch = None
         if stage != "screening":
             self.screening = None
         self._stage_started_at_utc = self._now_source().astimezone(UTC)
@@ -109,6 +112,11 @@ class ProgressTracker:
 
     def set_screening(self, screening: dict[str, Any] | None, *, persist: bool = False) -> None:
         self.screening = None if screening is None else dict(screening)
+        if persist:
+            self.persist()
+
+    def set_batch(self, batch: dict[str, Any] | None, *, persist: bool = False) -> None:
+        self.batch = None if batch is None else dict(batch)
         if persist:
             self.persist()
 
@@ -162,6 +170,7 @@ class ProgressTracker:
             "asset": None,
             "interval": None,
         }
+        self.batch = None
         self.screening = None
         self._last_updated_at_utc = self._now_source().astimezone(UTC)
         self._write_progress()
@@ -252,6 +261,8 @@ class ProgressTracker:
             "eta_seconds": self._eta_seconds(),
             "error": self.error,
         }
+        if self.batch is not None:
+            payload["batch"] = dict(self.batch)
         if self.screening is not None:
             payload["screening"] = dict(self.screening)
         return payload

--- a/research/run_research.py
+++ b/research/run_research.py
@@ -35,6 +35,11 @@ from research.candidate_pipeline import (
     summarize_candidates,
     validation_candidates,
 )
+from research.batching import (
+    build_batch_manifest_payload,
+    build_run_batches_payload,
+    partition_execution_batches,
+)
 from research.empty_run_reporting import (
     DegenerateResearchRunError,
     build_empty_run_diagnostics_payload,
@@ -67,6 +72,7 @@ REGIME_DIAGNOSTICS_PATH = Path("research/regime_diagnostics_latest.v1.json")
 EMPTY_RUN_DIAGNOSTICS_PATH = Path("research/empty_run_diagnostics_latest.v1.json")
 RUN_CANDIDATES_PATH = Path("research/run_candidates_latest.v1.json")
 RUN_FILTER_SUMMARY_PATH = Path("research/run_filter_summary_latest.v1.json")
+RUN_BATCHES_PATH = Path("research/run_batches_latest.v1.json")
 RUN_SCREENING_CANDIDATES_PATH = Path("research/run_screening_candidates_latest.v1.json")
 RUN_PROGRESS_PATH = Path("research/run_progress_latest.v1.json")
 RUN_STATE_PATH = Path("research/run_state.v1.json")
@@ -476,6 +482,7 @@ def _build_run_manifest_payload(
         "artifacts": {
             "run_candidates_path": RUN_CANDIDATES_PATH.as_posix(),
             "run_filter_summary_path": RUN_FILTER_SUMMARY_PATH.as_posix(),
+            "run_batches_path": RUN_BATCHES_PATH.as_posix(),
             "run_screening_candidates_path": RUN_SCREENING_CANDIDATES_PATH.as_posix(),
         },
     }
@@ -537,6 +544,52 @@ def _persist_screening_candidate_sidecar(
     )
 
 
+def _persist_run_batches_sidecar(
+    *,
+    run_id: str,
+    as_of_utc: datetime,
+    batches: list[dict],
+) -> None:
+    payload = build_run_batches_payload(
+        run_id=run_id,
+        as_of_utc=as_of_utc,
+        batches=batches,
+    )
+    _write_json_with_history(
+        path=RUN_BATCHES_PATH,
+        payload=payload,
+        run_id=run_id,
+        history_name="run_batches.v1.json",
+    )
+
+
+def _write_batch_manifest(*, run_id: str, batch: dict) -> None:
+    payload = build_batch_manifest_payload(
+        run_id=run_id,
+        batch=batch,
+    )
+    _write_json_atomic(
+        Path("research/history") / run_id / "batches" / str(batch["batch_id"]) / "run_batch_manifest.v1.json",
+        payload,
+    )
+
+
+def _batch_progress_payload(*, batch: dict | None, total_batches: int) -> dict | None:
+    if batch is None:
+        return None
+    return {
+        "batch_id": batch.get("batch_id"),
+        "batch_index": batch.get("batch_index"),
+        "total_batches": int(total_batches),
+        "strategy_family": batch.get("strategy_family"),
+        "interval": batch.get("interval"),
+        "status": batch.get("status"),
+        "completed_candidates": int(batch.get("completed_candidate_count") or 0),
+        "total_candidates": int(batch.get("candidate_count") or 0),
+        "elapsed_seconds": int(batch.get("elapsed_seconds") or 0),
+    }
+
+
 def _screening_progress_payload(
     *,
     completed_candidates: int,
@@ -554,6 +607,22 @@ def _screening_progress_payload(
         "budget_seconds": None if record is None else record.get("budget_seconds"),
         "candidate_elapsed_seconds": None if record is None else record.get("elapsed_seconds"),
     }
+
+
+def _result_row_sort_key(row: dict) -> tuple[str, str, str, str, str]:
+    return (
+        str(row["strategy_name"]),
+        str(row["asset"]),
+        str(row["interval"]),
+        str(row["params_json"]),
+        str(row["error"]),
+    )
+
+
+def _elapsed_from_started_at(started_at: str | None) -> int:
+    if not started_at:
+        return 0
+    return max(0, int(round((datetime.now(UTC) - datetime.fromisoformat(started_at)).total_seconds())))
 
 
 def _raise_degenerate_run(
@@ -608,6 +677,7 @@ def run_research():
     pair_diagnostics: list[dict] = []
     interval_ranges: dict[str, dict[str, str]] = {}
     candidates: list[dict] = []
+    batches: list[dict] = []
     try:
         research_config = load_research_config()
         regime_count, regime_count_source = regime_count_settings(research_config)
@@ -712,6 +782,28 @@ def run_research():
 
         tracker.start_stage("screening", total=eligibility_summary["eligible_candidate_count"])
         screening_items = screening_candidates(candidates)
+        batches = partition_execution_batches(candidates=screening_items)
+        candidate_to_batch_id = {
+            str(candidate_id): str(batch["batch_id"])
+            for batch in batches
+            for candidate_id in batch["candidate_ids"]
+        }
+        _persist_run_batches_sidecar(
+            run_id=state["run_id"],
+            as_of_utc=as_of_utc,
+            batches=batches,
+        )
+        for batch in batches:
+            _write_batch_manifest(run_id=state["run_id"], batch=batch)
+        _merge_manifest(
+            RUN_MANIFEST_PATH,
+            batching_enabled=True,
+            batch_partitioning={
+                "mode": "strategy_family_x_interval",
+                "batch_count": len(batches),
+            },
+        )
+        tracker.set_batch(None, persist=True)
         screening_records = build_screening_runtime_records(
             candidates=screening_items,
             budget_seconds=screening_candidate_budget_seconds,
@@ -733,213 +825,309 @@ def run_research():
             ),
             persist=True,
         )
-        for index, candidate in enumerate(screening_items, start=1):
-            strategy = strategy_by_name[candidate["strategy_name"]]
-            sampled_params = screening_param_samples(
-                strategy.get("params") or {},
-                max_samples=SCREENING_PARAM_SAMPLE_LIMIT,
-            )
-            runtime_record = screening_records_by_id[str(candidate["candidate_id"])]
-            runtime_record["runtime_status"] = "running"
-            runtime_record["final_status"] = None
-            runtime_record["started_at"] = datetime.now(UTC).isoformat()
-            runtime_record["finished_at"] = None
-            runtime_record["elapsed_seconds"] = 0
-            runtime_record["samples_completed"] = 0
-            runtime_record["samples_total"] = len(sampled_params)
-            runtime_record["decision"] = None
-            runtime_record["reason_code"] = None
-            runtime_record["reason_detail"] = None
-            tracker.begin_item(
-                strategy=candidate["strategy_name"],
-                asset=candidate["asset"],
-                interval=candidate["interval"],
-            )
-            tracker.set_screening(
-                _screening_progress_payload(
-                    completed_candidates=index - 1,
-                    total_candidates=len(screening_items),
-                    record=runtime_record,
-                ),
-                persist=True,
-            )
-            _persist_screening_candidate_sidecar(
-                run_id=state["run_id"],
-                as_of_utc=as_of_utc,
-                screening_records=screening_records,
-            )
+        screening_completed = 0
+        screening_items_by_id = {
+            str(candidate["candidate_id"]): candidate
+            for candidate in screening_items
+        }
+        for batch in batches:
+            batch_started_monotonic = time.monotonic()
+            batch["status"] = "running"
+            batch["started_at"] = batch.get("started_at") or datetime.now(UTC).isoformat()
+            batch["finished_at"] = None
+            tracker.set_batch(_batch_progress_payload(batch=batch, total_batches=len(batches)), persist=True)
+            _persist_run_batches_sidecar(run_id=state["run_id"], as_of_utc=as_of_utc, batches=batches)
+            _write_batch_manifest(run_id=state["run_id"], batch=batch)
             tracker.emit_event(
-                "screening_candidate_started",
-                candidate_id=candidate["candidate_id"],
-                strategy=candidate["strategy_name"],
-                asset=candidate["asset"],
-                interval=candidate["interval"],
+                "batch_started",
+                batch_id=batch["batch_id"],
+                batch_index=batch["batch_index"],
+                strategy_family=batch["strategy_family"],
+                interval=batch["interval"],
                 elapsed_seconds=0,
-                samples_completed=0,
-                samples_total=runtime_record["samples_total"],
+                candidate_count=batch["candidate_count"],
+                completed_candidate_count=batch["completed_candidate_count"],
             )
-
-            def _on_screening_progress(progress: dict[str, int]) -> None:
-                runtime_record["elapsed_seconds"] = int(progress["elapsed_seconds"])
-                runtime_record["samples_completed"] = int(progress["samples_completed"])
-                runtime_record["samples_total"] = int(progress["samples_total"])
-                tracker.set_screening(
-                    _screening_progress_payload(
-                        completed_candidates=index - 1,
-                        total_candidates=len(screening_items),
-                        record=runtime_record,
-                    ),
-                    persist=True,
-                )
-                _persist_screening_candidate_sidecar(
-                    run_id=state["run_id"],
-                    as_of_utc=as_of_utc,
-                    screening_records=screening_records,
-                )
-                tracker.emit_event(
-                    "screening_candidate_progress",
-                    candidate_id=candidate["candidate_id"],
-                    strategy=candidate["strategy_name"],
-                    asset=candidate["asset"],
-                    interval=candidate["interval"],
-                    elapsed_seconds=runtime_record["elapsed_seconds"],
-                    samples_completed=runtime_record["samples_completed"],
-                    samples_total=runtime_record["samples_total"],
-                )
-
-            engine = None
             try:
-                start_datum = interval_ranges[candidate["interval"]]["start"]
-                eind_datum = interval_ranges[candidate["interval"]]["end"]
-                engine = _build_engine(
-                    start_datum=start_datum,
-                    eind_datum=eind_datum,
-                    evaluation_config=evaluation_config,
-                    regime_config=research_config.get("regime_diagnostics"),
-                )
-                runtime_record["samples_total"] = (
-                    0
-                    if not hasattr(engine, "run")
-                    else len(sampled_params)
-                )
-                outcome = execute_screening_candidate(
-                    strategy=strategy,
-                    candidate=candidate,
-                    engine=engine,
-                    budget_seconds=screening_candidate_budget_seconds,
-                    max_samples=SCREENING_PARAM_SAMPLE_LIMIT,
-                    on_progress=_on_screening_progress,
-                )
-            except Exception as exc:
-                outcome = {
-                    "legacy_decision": {
-                        "status": "rejected_in_screening",
-                        "reason": "screening_candidate_error",
-                        "sampled_combination_count": runtime_record["samples_completed"],
-                    },
-                    "runtime_status": "running",
-                    "final_status": FINAL_STATUS_ERRORED,
-                    "started_at": runtime_record["started_at"],
-                    "finished_at": datetime.now(UTC).isoformat(),
-                    "elapsed_seconds": int(runtime_record["elapsed_seconds"]),
-                    "samples_total": runtime_record["samples_total"],
-                    "samples_completed": runtime_record["samples_completed"],
-                    "decision": "rejected_in_screening",
-                    "reason_code": "screening_candidate_error",
-                    "reason_detail": str(exc),
-                }
-            if engine is not None:
-                provenance_events.extend(getattr(engine, "_provenance_events", []))
+                for candidate_id in batch["candidate_ids"]:
+                    candidate = screening_items_by_id[str(candidate_id)]
+                    strategy = strategy_by_name[candidate["strategy_name"]]
+                    sampled_params = screening_param_samples(
+                        strategy.get("params") or {},
+                        max_samples=SCREENING_PARAM_SAMPLE_LIMIT,
+                    )
+                    runtime_record = screening_records_by_id[str(candidate["candidate_id"])]
+                    runtime_record["runtime_status"] = "running"
+                    runtime_record["final_status"] = None
+                    runtime_record["started_at"] = datetime.now(UTC).isoformat()
+                    runtime_record["finished_at"] = None
+                    runtime_record["elapsed_seconds"] = 0
+                    runtime_record["samples_completed"] = 0
+                    runtime_record["samples_total"] = len(sampled_params)
+                    runtime_record["decision"] = None
+                    runtime_record["reason_code"] = None
+                    runtime_record["reason_detail"] = None
+                    tracker.begin_item(
+                        strategy=candidate["strategy_name"],
+                        asset=candidate["asset"],
+                        interval=candidate["interval"],
+                    )
+                    batch["elapsed_seconds"] = max(0, int(round(time.monotonic() - batch_started_monotonic)))
+                    tracker.set_batch(_batch_progress_payload(batch=batch, total_batches=len(batches)), persist=True)
+                    tracker.set_screening(
+                        _screening_progress_payload(
+                            completed_candidates=screening_completed,
+                            total_candidates=len(screening_items),
+                            record=runtime_record,
+                        ),
+                        persist=True,
+                    )
+                    _persist_screening_candidate_sidecar(
+                        run_id=state["run_id"],
+                        as_of_utc=as_of_utc,
+                        screening_records=screening_records,
+                    )
+                    tracker.emit_event(
+                        "screening_candidate_started",
+                        candidate_id=candidate["candidate_id"],
+                        strategy=candidate["strategy_name"],
+                        asset=candidate["asset"],
+                        interval=candidate["interval"],
+                        elapsed_seconds=0,
+                        samples_completed=0,
+                        samples_total=runtime_record["samples_total"],
+                    )
 
-            runtime_record.update(outcome)
-            if runtime_record["elapsed_seconds"] is None:
-                runtime_record["elapsed_seconds"] = 0
-            if runtime_record["samples_total"] is None:
-                runtime_record["samples_total"] = 0
-            if runtime_record["samples_completed"] is None:
-                runtime_record["samples_completed"] = 0
-            decision = dict(outcome["legacy_decision"])
-            for item in candidates:
-                if item["candidate_id"] != candidate["candidate_id"]:
-                    continue
-                item["screening"] = dict(decision)
-                if decision["status"] == SCREENING_PROMOTED:
-                    item["current_status"] = "promoted_to_validation"
-                else:
-                    item["current_status"] = "screening_rejected"
-                break
-            _persist_candidate_pipeline_sidecars(
-                run_id=state["run_id"],
-                as_of_utc=as_of_utc,
-                candidates=candidates,
-            )
-            _persist_screening_candidate_sidecar(
-                run_id=state["run_id"],
-                as_of_utc=as_of_utc,
-                screening_records=screening_records,
-            )
-            if runtime_record["final_status"] in {FINAL_STATUS_PASSED, FINAL_STATUS_REJECTED}:
+                    def _on_screening_progress(progress: dict[str, int]) -> None:
+                        runtime_record["elapsed_seconds"] = int(progress["elapsed_seconds"])
+                        runtime_record["samples_completed"] = int(progress["samples_completed"])
+                        runtime_record["samples_total"] = int(progress["samples_total"])
+                        batch["elapsed_seconds"] = max(0, int(round(time.monotonic() - batch_started_monotonic)))
+                        tracker.set_batch(_batch_progress_payload(batch=batch, total_batches=len(batches)), persist=True)
+                        tracker.set_screening(
+                            _screening_progress_payload(
+                                completed_candidates=screening_completed,
+                                total_candidates=len(screening_items),
+                                record=runtime_record,
+                            ),
+                            persist=True,
+                        )
+                        _persist_screening_candidate_sidecar(
+                            run_id=state["run_id"],
+                            as_of_utc=as_of_utc,
+                            screening_records=screening_records,
+                        )
+                        _persist_run_batches_sidecar(run_id=state["run_id"], as_of_utc=as_of_utc, batches=batches)
+                        _write_batch_manifest(run_id=state["run_id"], batch=batch)
+                        tracker.emit_event(
+                            "screening_candidate_progress",
+                            candidate_id=candidate["candidate_id"],
+                            strategy=candidate["strategy_name"],
+                            asset=candidate["asset"],
+                            interval=candidate["interval"],
+                            elapsed_seconds=runtime_record["elapsed_seconds"],
+                            samples_completed=runtime_record["samples_completed"],
+                            samples_total=runtime_record["samples_total"],
+                        )
+
+                    engine = None
+                    try:
+                        start_datum = interval_ranges[candidate["interval"]]["start"]
+                        eind_datum = interval_ranges[candidate["interval"]]["end"]
+                        engine = _build_engine(
+                            start_datum=start_datum,
+                            eind_datum=eind_datum,
+                            evaluation_config=evaluation_config,
+                            regime_config=research_config.get("regime_diagnostics"),
+                        )
+                        runtime_record["samples_total"] = 0 if not hasattr(engine, "run") else len(sampled_params)
+                        outcome = execute_screening_candidate(
+                            strategy=strategy,
+                            candidate=candidate,
+                            engine=engine,
+                            budget_seconds=screening_candidate_budget_seconds,
+                            max_samples=SCREENING_PARAM_SAMPLE_LIMIT,
+                            on_progress=_on_screening_progress,
+                        )
+                    except Exception as exc:
+                        outcome = {
+                            "legacy_decision": {
+                                "status": "rejected_in_screening",
+                                "reason": "screening_candidate_error",
+                                "sampled_combination_count": runtime_record["samples_completed"],
+                            },
+                            "runtime_status": "running",
+                            "final_status": FINAL_STATUS_ERRORED,
+                            "started_at": runtime_record["started_at"],
+                            "finished_at": datetime.now(UTC).isoformat(),
+                            "elapsed_seconds": int(runtime_record["elapsed_seconds"]),
+                            "samples_total": runtime_record["samples_total"],
+                            "samples_completed": runtime_record["samples_completed"],
+                            "decision": "rejected_in_screening",
+                            "reason_code": "screening_candidate_error",
+                            "reason_detail": str(exc),
+                        }
+                    if engine is not None:
+                        provenance_events.extend(getattr(engine, "_provenance_events", []))
+
+                    runtime_record.update(outcome)
+                    runtime_record["elapsed_seconds"] = int(runtime_record.get("elapsed_seconds") or 0)
+                    runtime_record["samples_total"] = int(runtime_record.get("samples_total") or 0)
+                    runtime_record["samples_completed"] = int(runtime_record.get("samples_completed") or 0)
+                    decision = dict(outcome["legacy_decision"])
+                    for item in candidates:
+                        if item["candidate_id"] != candidate["candidate_id"]:
+                            continue
+                        item["screening"] = dict(decision)
+                        item["current_status"] = "promoted_to_validation" if decision["status"] == SCREENING_PROMOTED else "screening_rejected"
+                        break
+                    if runtime_record["final_status"] == FINAL_STATUS_TIMED_OUT:
+                        batch["timed_out_count"] += 1
+                        batch["completed_candidate_count"] += 1
+                    elif runtime_record["final_status"] == FINAL_STATUS_ERRORED:
+                        batch["errored_count"] += 1
+                        batch["completed_candidate_count"] += 1
+                    elif decision["status"] == SCREENING_PROMOTED:
+                        batch["promoted_candidate_count"] += 1
+                    else:
+                        batch["screening_rejected_count"] += 1
+                        batch["completed_candidate_count"] += 1
+                    _persist_candidate_pipeline_sidecars(run_id=state["run_id"], as_of_utc=as_of_utc, candidates=candidates)
+                    _persist_screening_candidate_sidecar(
+                        run_id=state["run_id"],
+                        as_of_utc=as_of_utc,
+                        screening_records=screening_records,
+                    )
+                    batch["elapsed_seconds"] = max(0, int(round(time.monotonic() - batch_started_monotonic)))
+                    _persist_run_batches_sidecar(run_id=state["run_id"], as_of_utc=as_of_utc, batches=batches)
+                    _write_batch_manifest(run_id=state["run_id"], batch=batch)
+                    if runtime_record["final_status"] in {FINAL_STATUS_PASSED, FINAL_STATUS_REJECTED}:
+                        tracker.emit_event(
+                            "screening_candidate_decision",
+                            candidate_id=candidate["candidate_id"],
+                            strategy=candidate["strategy_name"],
+                            asset=candidate["asset"],
+                            interval=candidate["interval"],
+                            elapsed_seconds=runtime_record["elapsed_seconds"],
+                            samples_completed=runtime_record["samples_completed"],
+                            samples_total=runtime_record["samples_total"],
+                            decision=runtime_record["decision"],
+                            reason_code=runtime_record["reason_code"],
+                        )
+                    elif runtime_record["final_status"] == FINAL_STATUS_TIMED_OUT:
+                        tracker.emit_event(
+                            "screening_candidate_timeout",
+                            candidate_id=candidate["candidate_id"],
+                            strategy=candidate["strategy_name"],
+                            asset=candidate["asset"],
+                            interval=candidate["interval"],
+                            elapsed_seconds=runtime_record["elapsed_seconds"],
+                            samples_completed=runtime_record["samples_completed"],
+                            samples_total=runtime_record["samples_total"],
+                            decision=runtime_record["decision"],
+                            reason_code=runtime_record["reason_code"],
+                        )
+                    elif runtime_record["final_status"] == FINAL_STATUS_ERRORED:
+                        tracker.emit_event(
+                            "screening_candidate_error",
+                            candidate_id=candidate["candidate_id"],
+                            strategy=candidate["strategy_name"],
+                            asset=candidate["asset"],
+                            interval=candidate["interval"],
+                            elapsed_seconds=runtime_record["elapsed_seconds"],
+                            samples_completed=runtime_record["samples_completed"],
+                            samples_total=runtime_record["samples_total"],
+                            decision=runtime_record["decision"],
+                            reason_code=runtime_record["reason_code"],
+                            reason_detail=runtime_record["reason_detail"],
+                        )
+                    tracker.emit_event(
+                        "screening_candidate_finished",
+                        candidate_id=candidate["candidate_id"],
+                        strategy=candidate["strategy_name"],
+                        asset=candidate["asset"],
+                        interval=candidate["interval"],
+                        elapsed_seconds=runtime_record["elapsed_seconds"],
+                        samples_completed=runtime_record["samples_completed"],
+                        samples_total=runtime_record["samples_total"],
+                        final_status=runtime_record["final_status"],
+                        decision=runtime_record["decision"],
+                        reason_code=runtime_record["reason_code"],
+                    )
+                    screening_completed += 1
+                    tracker.advance(completed=screening_completed, total=len(screening_items))
+                    tracker.set_batch(_batch_progress_payload(batch=batch, total_batches=len(batches)), persist=True)
+                    tracker.set_screening(
+                        _screening_progress_payload(
+                            completed_candidates=screening_completed,
+                            total_candidates=len(screening_items),
+                            record=runtime_record,
+                        ),
+                        persist=True,
+                    )
+
+                if batch["promoted_candidate_count"] == 0:
+                    batch["finished_at"] = datetime.now(UTC).isoformat()
+                    batch["elapsed_seconds"] = max(0, int(round(time.monotonic() - batch_started_monotonic)))
+                    if batch["timed_out_count"] > 0 or batch["errored_count"] > 0:
+                        batch["status"] = "partial"
+                        batch["reason_code"] = "isolated_candidate_execution_issues"
+                        batch["reason_detail"] = "batch completed with screening timeout/error isolation"
+                        tracker.emit_event(
+                            "batch_partial",
+                            batch_id=batch["batch_id"],
+                            batch_index=batch["batch_index"],
+                            strategy_family=batch["strategy_family"],
+                            interval=batch["interval"],
+                            elapsed_seconds=batch["elapsed_seconds"],
+                            candidate_count=batch["candidate_count"],
+                            completed_candidate_count=batch["completed_candidate_count"],
+                            reason_code=batch["reason_code"],
+                        )
+                    else:
+                        batch["status"] = "completed"
+                        tracker.emit_event(
+                            "batch_completed",
+                            batch_id=batch["batch_id"],
+                            batch_index=batch["batch_index"],
+                            strategy_family=batch["strategy_family"],
+                            interval=batch["interval"],
+                            elapsed_seconds=batch["elapsed_seconds"],
+                            candidate_count=batch["candidate_count"],
+                            completed_candidate_count=batch["completed_candidate_count"],
+                        )
+                    _persist_run_batches_sidecar(run_id=state["run_id"], as_of_utc=as_of_utc, batches=batches)
+                    _write_batch_manifest(run_id=state["run_id"], batch=batch)
+                    tracker.set_batch(_batch_progress_payload(batch=batch, total_batches=len(batches)), persist=True)
+            except Exception as exc:
+                batch["status"] = "failed"
+                batch["finished_at"] = datetime.now(UTC).isoformat()
+                batch["elapsed_seconds"] = max(0, int(round(time.monotonic() - batch_started_monotonic)))
+                batch["reason_code"] = "batch_execution_failed"
+                batch["reason_detail"] = str(exc)
+                for later_batch in batches:
+                    if later_batch["batch_index"] <= batch["batch_index"] or later_batch["status"] != "pending":
+                        continue
+                    later_batch["status"] = "skipped"
+                    later_batch["reason_code"] = "upstream_batch_failed"
+                    later_batch["reason_detail"] = f"skipped after failed batch {batch['batch_id']}"
+                    _write_batch_manifest(run_id=state["run_id"], batch=later_batch)
+                _persist_run_batches_sidecar(run_id=state["run_id"], as_of_utc=as_of_utc, batches=batches)
+                _write_batch_manifest(run_id=state["run_id"], batch=batch)
+                tracker.set_batch(_batch_progress_payload(batch=batch, total_batches=len(batches)), persist=True)
                 tracker.emit_event(
-                    "screening_candidate_decision",
-                    candidate_id=candidate["candidate_id"],
-                    strategy=candidate["strategy_name"],
-                    asset=candidate["asset"],
-                    interval=candidate["interval"],
-                    elapsed_seconds=runtime_record["elapsed_seconds"],
-                    samples_completed=runtime_record["samples_completed"],
-                    samples_total=runtime_record["samples_total"],
-                    decision=runtime_record["decision"],
-                    reason_code=runtime_record["reason_code"],
+                    "batch_failed",
+                    batch_id=batch["batch_id"],
+                    batch_index=batch["batch_index"],
+                    strategy_family=batch["strategy_family"],
+                    interval=batch["interval"],
+                    elapsed_seconds=batch["elapsed_seconds"],
+                    candidate_count=batch["candidate_count"],
+                    completed_candidate_count=batch["completed_candidate_count"],
+                    reason_code=batch["reason_code"],
+                    reason_detail=batch["reason_detail"],
                 )
-            elif runtime_record["final_status"] == FINAL_STATUS_TIMED_OUT:
-                tracker.emit_event(
-                    "screening_candidate_timeout",
-                    candidate_id=candidate["candidate_id"],
-                    strategy=candidate["strategy_name"],
-                    asset=candidate["asset"],
-                    interval=candidate["interval"],
-                    elapsed_seconds=runtime_record["elapsed_seconds"],
-                    samples_completed=runtime_record["samples_completed"],
-                    samples_total=runtime_record["samples_total"],
-                    decision=runtime_record["decision"],
-                    reason_code=runtime_record["reason_code"],
-                )
-            elif runtime_record["final_status"] == FINAL_STATUS_ERRORED:
-                tracker.emit_event(
-                    "screening_candidate_error",
-                    candidate_id=candidate["candidate_id"],
-                    strategy=candidate["strategy_name"],
-                    asset=candidate["asset"],
-                    interval=candidate["interval"],
-                    elapsed_seconds=runtime_record["elapsed_seconds"],
-                    samples_completed=runtime_record["samples_completed"],
-                    samples_total=runtime_record["samples_total"],
-                    decision=runtime_record["decision"],
-                    reason_code=runtime_record["reason_code"],
-                    reason_detail=runtime_record["reason_detail"],
-                )
-            tracker.emit_event(
-                "screening_candidate_finished",
-                candidate_id=candidate["candidate_id"],
-                strategy=candidate["strategy_name"],
-                asset=candidate["asset"],
-                interval=candidate["interval"],
-                elapsed_seconds=runtime_record["elapsed_seconds"],
-                samples_completed=runtime_record["samples_completed"],
-                samples_total=runtime_record["samples_total"],
-                final_status=runtime_record["final_status"],
-                decision=runtime_record["decision"],
-                reason_code=runtime_record["reason_code"],
-            )
-            tracker.advance(completed=index, total=len(screening_items))
-            tracker.set_screening(
-                _screening_progress_payload(
-                    completed_candidates=index,
-                    total_candidates=len(screening_items),
-                    record=runtime_record,
-                ),
-                persist=True,
-            )
+                raise
 
         screening_summary = summarize_candidates(candidates)
         _persist_candidate_pipeline_sidecars(
@@ -968,81 +1156,187 @@ def run_research():
 
         tracker.start_stage("validation", total=screening_summary["validation_candidate_count"])
         validation_items = validation_candidates(candidates)
-        for index, candidate in enumerate(validation_items, start=1):
-            strategy = strategy_by_name[candidate["strategy_name"]]
-            tracker.begin_item(
-                strategy=strategy["name"],
-                asset=candidate["asset"],
-                interval=candidate["interval"],
-            )
-            start_datum = interval_ranges[candidate["interval"]]["start"]
-            eind_datum = interval_ranges[candidate["interval"]]["end"]
-            engine = _build_engine(
-                start_datum=start_datum,
-                eind_datum=eind_datum,
-                evaluation_config=evaluation_config,
-                regime_config=research_config.get("regime_diagnostics"),
-            )
+        validation_completed = 0
+        for batch in batches:
+            if batch["status"] not in {"running", "pending"}:
+                continue
+            batch_validation_items = [
+                candidate
+                for candidate in validation_items
+                if candidate_to_batch_id.get(str(candidate["candidate_id"])) == str(batch["batch_id"])
+            ]
+            if not batch_validation_items:
+                continue
+            tracker.set_batch(_batch_progress_payload(batch=batch, total_batches=len(batches)), persist=True)
             try:
-                metrics = engine.grid_search(
-                    strategie_factory=strategy["factory"],
-                    param_grid=strategy["params"],
-                    assets=[candidate["asset"]],
-                    interval=candidate["interval"],
-                )
-                params_used = metrics.get("beste_params", {})
-                row = make_result_row(
-                    strategy=strategy,
-                    asset=candidate["asset"],
-                    interval=candidate["interval"],
-                    params=params_used,
-                    as_of_utc=as_of_utc,
-                    metrics=metrics,
-                )
-                evaluation_report = getattr(engine, "last_evaluation_report", None)
-                if evaluation_report is not None:
-                    walk_forward_reports.append(
-                        _sidecar_strategy_entry(
+                for candidate in batch_validation_items:
+                    strategy = strategy_by_name[candidate["strategy_name"]]
+                    tracker.begin_item(
+                        strategy=strategy["name"],
+                        asset=candidate["asset"],
+                        interval=candidate["interval"],
+                    )
+                    tracker.set_batch(_batch_progress_payload(batch=batch, total_batches=len(batches)), persist=True)
+                    start_datum = interval_ranges[candidate["interval"]]["start"]
+                    eind_datum = interval_ranges[candidate["interval"]]["end"]
+                    engine = _build_engine(
+                        start_datum=start_datum,
+                        eind_datum=eind_datum,
+                        evaluation_config=evaluation_config,
+                        regime_config=research_config.get("regime_diagnostics"),
+                    )
+                    try:
+                        metrics = engine.grid_search(
+                            strategie_factory=strategy["factory"],
+                            param_grid=strategy["params"],
+                            assets=[candidate["asset"]],
+                            interval=candidate["interval"],
+                        )
+                        params_used = metrics.get("beste_params", {})
+                        row = make_result_row(
                             strategy=strategy,
                             asset=candidate["asset"],
                             interval=candidate["interval"],
-                            report=evaluation_report,
+                            params=params_used,
+                            as_of_utc=as_of_utc,
+                            metrics=metrics,
                         )
-                    )
-                    evaluations.append(
-                        {
-                            "family": strategy["family"],
-                            "interval": candidate["interval"],
-                            "selected_params": json.loads(row["params_json"]),
-                            "evaluation_report": evaluation_report,
-                            "row": row,
-                        }
-                    )
-            except (EvaluationScheduleError, FoldLeakageError):
-                raise
-            except Exception as exc:
-                row = make_result_row(
-                    strategy=strategy,
-                    asset=candidate["asset"],
-                    interval=candidate["interval"],
-                    params={},
-                    as_of_utc=as_of_utc,
-                    metrics={},
-                    error=str(exc),
-                )
+                        evaluation_report = getattr(engine, "last_evaluation_report", None)
+                        if evaluation_report is not None:
+                            walk_forward_reports.append(
+                                _sidecar_strategy_entry(
+                                    strategy=strategy,
+                                    asset=candidate["asset"],
+                                    interval=candidate["interval"],
+                                    report=evaluation_report,
+                                )
+                            )
+                            evaluations.append(
+                                {
+                                    "family": strategy["family"],
+                                    "interval": candidate["interval"],
+                                    "selected_params": json.loads(row["params_json"]),
+                                    "evaluation_report": evaluation_report,
+                                    "row": row,
+                                }
+                            )
+                    except (EvaluationScheduleError, FoldLeakageError):
+                        raise
+                    except Exception as exc:
+                        row = make_result_row(
+                            strategy=strategy,
+                            asset=candidate["asset"],
+                            interval=candidate["interval"],
+                            params={},
+                            as_of_utc=as_of_utc,
+                            metrics={},
+                            error=str(exc),
+                        )
 
-            provenance_events.extend(getattr(engine, "_provenance_events", []))
-            rows.append(row)
-            for item in candidates:
-                if item["candidate_id"] != candidate["candidate_id"]:
-                    continue
-                item["validation"] = {
-                    "status": "validated",
-                    "result_success": bool(row["success"]),
-                }
-                item["current_status"] = "validated"
-                break
-            tracker.advance(completed=index, total=len(validation_items))
+                    provenance_events.extend(getattr(engine, "_provenance_events", []))
+                    rows.append(row)
+                    for item in candidates:
+                        if item["candidate_id"] != candidate["candidate_id"]:
+                            continue
+                        item["validation"] = {
+                            "status": "validated",
+                            "result_success": bool(row["success"]),
+                        }
+                        item["current_status"] = "validated"
+                        break
+                    batch["validated_candidate_count"] += 1
+                    batch["completed_candidate_count"] += 1
+                    if row["success"]:
+                        batch["result_success_count"] += 1
+                    else:
+                        batch["result_failed_count"] += 1
+                        batch["validation_error_count"] += 1
+                    _persist_candidate_pipeline_sidecars(
+                        run_id=state["run_id"],
+                        as_of_utc=as_of_utc,
+                        candidates=candidates,
+                    )
+                    _persist_run_batches_sidecar(
+                        run_id=state["run_id"],
+                        as_of_utc=as_of_utc,
+                        batches=batches,
+                    )
+                    _write_batch_manifest(run_id=state["run_id"], batch=batch)
+                    validation_completed += 1
+                    batch["elapsed_seconds"] = _elapsed_from_started_at(batch.get("started_at"))
+                    tracker.advance(completed=validation_completed, total=len(validation_items))
+                    tracker.set_batch(_batch_progress_payload(batch=batch, total_batches=len(batches)), persist=True)
+
+                batch["finished_at"] = datetime.now(UTC).isoformat()
+                batch["elapsed_seconds"] = _elapsed_from_started_at(batch.get("started_at"))
+                if batch["timed_out_count"] > 0 or batch["errored_count"] > 0 or batch["validation_error_count"] > 0:
+                    batch["status"] = "partial"
+                    if batch["reason_code"] is None:
+                        batch["reason_code"] = "isolated_candidate_execution_issues"
+                        batch["reason_detail"] = "batch completed with candidate-level timeout/error isolation"
+                    tracker.emit_event(
+                        "batch_partial",
+                        batch_id=batch["batch_id"],
+                        batch_index=batch["batch_index"],
+                        strategy_family=batch["strategy_family"],
+                        interval=batch["interval"],
+                        elapsed_seconds=batch["elapsed_seconds"],
+                        candidate_count=batch["candidate_count"],
+                        completed_candidate_count=batch["completed_candidate_count"],
+                        reason_code=batch["reason_code"],
+                    )
+                else:
+                    batch["status"] = "completed"
+                    tracker.emit_event(
+                        "batch_completed",
+                        batch_id=batch["batch_id"],
+                        batch_index=batch["batch_index"],
+                        strategy_family=batch["strategy_family"],
+                        interval=batch["interval"],
+                        elapsed_seconds=batch["elapsed_seconds"],
+                        candidate_count=batch["candidate_count"],
+                        completed_candidate_count=batch["completed_candidate_count"],
+                    )
+                _persist_run_batches_sidecar(
+                    run_id=state["run_id"],
+                    as_of_utc=as_of_utc,
+                    batches=batches,
+                )
+                _write_batch_manifest(run_id=state["run_id"], batch=batch)
+                tracker.set_batch(_batch_progress_payload(batch=batch, total_batches=len(batches)), persist=True)
+            except Exception as exc:
+                batch["status"] = "failed"
+                batch["finished_at"] = datetime.now(UTC).isoformat()
+                batch["elapsed_seconds"] = _elapsed_from_started_at(batch.get("started_at"))
+                batch["reason_code"] = "batch_execution_failed"
+                batch["reason_detail"] = str(exc)
+                for later_batch in batches:
+                    if later_batch["batch_index"] <= batch["batch_index"] or later_batch["status"] != "pending":
+                        continue
+                    later_batch["status"] = "skipped"
+                    later_batch["reason_code"] = "upstream_batch_failed"
+                    later_batch["reason_detail"] = f"skipped after failed batch {batch['batch_id']}"
+                    _write_batch_manifest(run_id=state["run_id"], batch=later_batch)
+                _persist_run_batches_sidecar(
+                    run_id=state["run_id"],
+                    as_of_utc=as_of_utc,
+                    batches=batches,
+                )
+                _write_batch_manifest(run_id=state["run_id"], batch=batch)
+                tracker.set_batch(_batch_progress_payload(batch=batch, total_batches=len(batches)), persist=True)
+                tracker.emit_event(
+                    "batch_failed",
+                    batch_id=batch["batch_id"],
+                    batch_index=batch["batch_index"],
+                    strategy_family=batch["strategy_family"],
+                    interval=batch["interval"],
+                    elapsed_seconds=batch["elapsed_seconds"],
+                    candidate_count=batch["candidate_count"],
+                    completed_candidate_count=batch["completed_candidate_count"],
+                    reason_code=batch["reason_code"],
+                    reason_detail=batch["reason_detail"],
+                )
+                raise
 
         _persist_candidate_pipeline_sidecars(
             run_id=state["run_id"],
@@ -1086,6 +1380,7 @@ def run_research():
             )
 
         tracker.start_stage("writing_outputs", total=len(rows))
+        rows = sorted(rows, key=_result_row_sort_key)
         write_results_to_csv(rows)
         write_latest_json(rows, as_of_utc=as_of_utc)
 

--- a/tests/unit/test_research_batching.py
+++ b/tests/unit/test_research_batching.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from research.batching import (
+    build_batch_manifest_payload,
+    build_run_batches_payload,
+    partition_execution_batches,
+)
+
+
+def _candidate(candidate_id: str, *, strategy_name: str, strategy_family: str, asset: str, interval: str) -> dict:
+    return {
+        "candidate_id": candidate_id,
+        "strategy_name": strategy_name,
+        "strategy_family": strategy_family,
+        "asset": asset,
+        "interval": interval,
+    }
+
+
+def test_partition_execution_batches_is_deterministic():
+    candidates = [
+        _candidate("c3", strategy_name="gamma", strategy_family="trend_following", asset="ETH-USD", interval="4h"),
+        _candidate("c1", strategy_name="alpha", strategy_family="breakout", asset="BTC-USD", interval="1d"),
+        _candidate("c2", strategy_name="beta", strategy_family="breakout", asset="ETH-USD", interval="1d"),
+    ]
+
+    first = partition_execution_batches(candidates=candidates)
+    second = partition_execution_batches(candidates=list(reversed(candidates)))
+
+    assert first == second
+    assert [batch["batch_index"] for batch in first] == [1, 2]
+    assert [batch["partition"] for batch in first] == [
+        {"strategy_family": "breakout", "interval": "1d"},
+        {"strategy_family": "trend_following", "interval": "4h"},
+    ]
+    assert first[0]["candidate_ids"] == ["c1", "c2"]
+    assert first[1]["candidate_ids"] == ["c3"]
+
+
+def test_batch_payloads_are_deterministic_and_summary_oriented():
+    batches = partition_execution_batches(
+        candidates=[
+            _candidate("c1", strategy_name="alpha", strategy_family="breakout", asset="BTC-USD", interval="1d"),
+            _candidate("c2", strategy_name="beta", strategy_family="breakout", asset="ETH-USD", interval="1d"),
+        ]
+    )
+    batches[0]["status"] = "partial"
+    batches[0]["started_at"] = "2026-04-13T12:00:00+00:00"
+    batches[0]["finished_at"] = "2026-04-13T12:01:00+00:00"
+    batches[0]["elapsed_seconds"] = 60
+    batches[0]["completed_candidate_count"] = 2
+    batches[0]["promoted_candidate_count"] = 1
+    batches[0]["validated_candidate_count"] = 1
+    batches[0]["timed_out_count"] = 1
+    batches[0]["result_success_count"] = 1
+    batches[0]["reason_code"] = "isolated_candidate_execution_issues"
+    batches[0]["reason_detail"] = "batch completed with candidate-level timeout/error isolation"
+
+    latest_payload = build_run_batches_payload(
+        run_id="run-1",
+        as_of_utc=datetime(2026, 4, 13, 12, 5, 0, tzinfo=UTC),
+        batches=batches,
+    )
+    manifest_payload = build_batch_manifest_payload(
+        run_id="run-1",
+        batch=batches[0],
+    )
+
+    assert latest_payload["summary"] == {
+        "batch_count": 1,
+        "pending_count": 0,
+        "running_count": 0,
+        "completed_count": 0,
+        "partial_count": 1,
+        "failed_count": 0,
+        "skipped_count": 0,
+    }
+    assert latest_payload["batches"][0]["candidate_summary"]["assets"] == ["BTC-USD", "ETH-USD"]
+    assert manifest_payload["batch_id"] == batches[0]["batch_id"]
+    assert manifest_payload["partition"] == {"strategy_family": "breakout", "interval": "1d"}
+    assert manifest_payload["candidate_ids"] == ["c1", "c2"]
+    assert manifest_payload["reason_code"] == "isolated_candidate_execution_issues"

--- a/tests/unit/test_run_research_observability.py
+++ b/tests/unit/test_run_research_observability.py
@@ -297,6 +297,58 @@ class _ErrorIsolationEngine(_HealthyEngine):
         return super().grid_search(strategie_factory, param_grid, assets, interval=interval)
 
 
+class _OrderedValidationEngine(_HealthyEngine):
+    def run(self, strategie_func, assets, interval="1d"):
+        self.last_evaluation_report = {
+            "evaluation_samples": {
+                "daily_returns": [0.01, -0.005, 0.003],
+                "trade_pnls": [0.02, -0.01],
+                "monthly_returns": [0.008],
+            }
+        }
+        return {
+            "win_rate": 0.55,
+            "sharpe": 1.1,
+            "deflated_sharpe": 0.9,
+            "max_drawdown": 0.12,
+            "trades_per_maand": 2.5,
+            "consistentie": 0.65,
+            "totaal_trades": 12,
+            "goedgekeurd": True,
+            "criteria_checks": {},
+            "reden": "",
+        }
+
+    def grid_search(self, strategie_factory, param_grid, assets, interval="1d"):
+        built = strategie_factory()
+        strategy_name = getattr(built, "name_hint", "unknown")
+        self.last_evaluation_report = {
+            "evaluation_config": {"mode": "anchored", "selection_metric": "sharpe", "initial_train_bars": 500, "test_bars": 100, "step_bars": 100},
+            "selection_metric": "sharpe",
+            "selected_params": {},
+            "is_summary": {"win_rate": 0.6, "sharpe": 1.2, "deflated_sharpe": 1.0, "max_drawdown": 0.1, "trades_per_maand": 3.0, "consistentie": 0.7, "totaal_trades": 12, "goedgekeurd": True, "criteria_checks": {}},
+            "oos_summary": {"win_rate": 0.55, "sharpe": 1.1, "deflated_sharpe": 0.9, "max_drawdown": 0.12, "trades_per_maand": 2.5, "consistentie": 0.65, "totaal_trades": 12, "goedgekeurd": True, "criteria_checks": {}},
+            "folds": [{"train": [0, 499], "test": [500, 599], "leakage_ok": True}],
+            "leakage_checks_ok": True,
+            "evaluation_samples": {"daily_returns": [0.01, -0.005, 0.003], "trade_pnls": [0.02, -0.01], "monthly_returns": [0.008]},
+            "evaluation_streams": {"oos_daily_returns": [{"timestamp_utc": "2026-01-02T00:00:00+00:00", "return": 0.01}], "oos_bar_returns": [], "oos_trade_events": []},
+            "sample_statistics": {"daily_returns": {"count": 3, "mean": 0.0027, "std": 0.006, "skew": 0.0, "kurt": 3.0}},
+        }
+        return {
+            "beste_params": {},
+            "win_rate": 0.55,
+            "sharpe": 1.1,
+            "deflated_sharpe": 0.9,
+            "max_drawdown": 0.12,
+            "trades_per_maand": 2.5,
+            "consistentie": 0.65,
+            "totaal_trades": 12,
+            "goedgekeurd": True,
+            "criteria_checks": {"strategy_name": strategy_name},
+            "reden": "",
+        }
+
+
 def test_run_research_writes_completed_progress_sidecar_and_keeps_public_schema(monkeypatch, tmp_path: Path):
     _patch_common_runner(monkeypatch, tmp_path, _HealthyEngine)
 
@@ -307,6 +359,7 @@ def test_run_research_writes_completed_progress_sidecar_and_keeps_public_schema(
     manifest = _load_json(tmp_path / "research" / "run_manifest_latest.v1.json")
     candidates = _load_json(tmp_path / "research" / "run_candidates_latest.v1.json")
     filter_summary = _load_json(tmp_path / "research" / "run_filter_summary_latest.v1.json")
+    batches = _load_json(tmp_path / "research" / "run_batches_latest.v1.json")
     screening_candidates = _load_json(tmp_path / "research" / "run_screening_candidates_latest.v1.json")
     public_json = _load_json(tmp_path / "research" / "research_latest.json")
     with (tmp_path / "research" / "strategy_matrix.csv").open(encoding="utf-8", newline="") as handle:
@@ -332,9 +385,12 @@ def test_run_research_writes_completed_progress_sidecar_and_keeps_public_schema(
     ]
     assert manifest["raw_candidate_count"] == 1
     assert manifest["validation_candidate_count"] == 1
+    assert manifest["artifacts"]["run_batches_path"] == "research/run_batches_latest.v1.json"
     assert manifest["artifacts"]["run_screening_candidates_path"] == "research/run_screening_candidates_latest.v1.json"
     assert candidates["summary"]["validation_candidate_count"] == 1
     assert filter_summary["screening_decisions"]["promoted_to_validation"] == 1
+    assert batches["summary"]["completed_count"] == 1
+    assert batches["batches"][0]["status"] == "completed"
     assert screening_candidates["summary"]["passed_count"] == 1
     assert screening_candidates["candidates"][0]["final_status"] == "passed"
     assert (tmp_path / "logs" / "research" / f"{state['run_id']}.jsonl").exists()
@@ -434,6 +490,9 @@ def test_screening_progress_is_persisted_immediately_on_candidate_start(monkeypa
     assert progress["screening"]["total_screening_candidates"] == 1
     assert progress["screening"]["runtime_status"] == "running"
     assert progress["screening"]["candidate_id"] is not None
+    assert progress["batch"]["batch_index"] == 1
+    assert progress["batch"]["total_batches"] == 1
+    assert progress["batch"]["status"] == "running"
     assert screening["candidates"][0]["runtime_status"] == "running"
     assert screening["candidates"][0]["started_at"] is not None
     assert screening["candidates"][0]["final_status"] is None
@@ -456,7 +515,7 @@ def test_screening_timeout_is_persisted_and_run_continues(monkeypatch, tmp_path:
             {
                 "name": "timeout_strategy",
                 "family": "trend",
-                "strategy_family": "trend_following",
+                "strategy_family": "a_timeout",
                 "position_structure": "outright",
                 "initial_lane_support": "supported",
                 "hypothesis": "timeout",
@@ -466,7 +525,7 @@ def test_screening_timeout_is_persisted_and_run_continues(monkeypatch, tmp_path:
             {
                 "name": "survivor_strategy",
                 "family": "trend",
-                "strategy_family": "trend_following",
+                "strategy_family": "z_survivor",
                 "position_structure": "outright",
                 "initial_lane_support": "supported",
                 "hypothesis": "survivor",
@@ -484,6 +543,7 @@ def test_screening_timeout_is_persisted_and_run_continues(monkeypatch, tmp_path:
     run_research_module.run_research()
 
     screening = _load_json(tmp_path / "research" / "run_screening_candidates_latest.v1.json")
+    batches = _load_json(tmp_path / "research" / "run_batches_latest.v1.json")
     filter_summary = _load_json(tmp_path / "research" / "run_filter_summary_latest.v1.json")
     public_json = _load_json(tmp_path / "research" / "research_latest.json")
     log_path = tmp_path / "logs" / "research" / f"{_load_json(tmp_path / 'research' / 'run_state.v1.json')['run_id']}.jsonl"
@@ -493,6 +553,7 @@ def test_screening_timeout_is_persisted_and_run_continues(monkeypatch, tmp_path:
     assert by_strategy["timeout_strategy"]["final_status"] == "timed_out"
     assert by_strategy["timeout_strategy"]["reason_code"] == "candidate_budget_exceeded"
     assert by_strategy["survivor_strategy"]["final_status"] == "passed"
+    assert [batch["status"] for batch in batches["batches"]] == ["partial", "completed"]
     assert filter_summary["screening_rejection_reasons"] == {"candidate_budget_exceeded": 1}
     assert _TimeoutIsolationEngine.validation_calls == 1
     assert public_json["count"] == 1
@@ -553,3 +614,49 @@ def test_screening_exception_is_persisted_and_run_continues(monkeypatch, tmp_pat
     assert _ErrorIsolationEngine.validation_calls == 1
     assert public_json["count"] == 1
     assert any(event["event"] == "screening_candidate_error" for event in events)
+
+
+def test_run_level_output_order_remains_deterministic_across_batches(monkeypatch, tmp_path: Path):
+    _patch_common_runner(monkeypatch, tmp_path, _OrderedValidationEngine)
+
+    def _factory(name_hint):
+        def _build(**params):
+            return SimpleNamespace(name_hint=name_hint)
+
+        return _build
+
+    monkeypatch.setattr(
+        run_research_module,
+        "get_enabled_strategies",
+        lambda: [
+            {
+                "name": "zeta_strategy",
+                "family": "trend",
+                "strategy_family": "a_family",
+                "position_structure": "outright",
+                "initial_lane_support": "supported",
+                "hypothesis": "zeta",
+                "factory": _factory("zeta_strategy"),
+                "params": {"periode": [14]},
+            },
+            {
+                "name": "alpha_strategy",
+                "family": "trend",
+                "strategy_family": "z_family",
+                "position_structure": "outright",
+                "initial_lane_support": "supported",
+                "hypothesis": "alpha",
+                "factory": _factory("alpha_strategy"),
+                "params": {"periode": [14]},
+            },
+        ],
+    )
+
+    run_research_module.run_research()
+
+    public_json = _load_json(tmp_path / "research" / "research_latest.json")
+    with (tmp_path / "research" / "strategy_matrix.csv").open(encoding="utf-8", newline="") as handle:
+        csv_rows = list(csv.DictReader(handle))
+
+    assert [row["strategy_name"] for row in public_json["results"]] == ["alpha_strategy", "zeta_strategy"]
+    assert [row["strategy_name"] for row in csv_rows] == ["alpha_strategy", "zeta_strategy"]


### PR DESCRIPTION
## Summary

This PR introduces a minimal batch-based execution layer for research runs.

The change is intentionally scoped to orchestration and observability only:

* planning / dedupe / fit-prior / eligibility remain global
* batching starts only at the expensive execution slice
* screening and validation now execute batch-by-batch
* public outputs remain unchanged and are still written once at the end

Batching is deterministic and currently partitions candidates by:

* `strategy_family × interval`

## What was added

### New additive artifacts

* `research/run_batches_latest.v1.json`
* per-batch history manifests at:

  * `research/history/<run_id>/batches/<batch_id>/run_batch_manifest.v1.json`

### Progress / observability

* additive optional `batch` block in `run_progress_latest.v1.json`
* minimal batch lifecycle events:

  * `batch_started`
  * `batch_completed`
  * `batch_partial`
  * `batch_failed`

### Determinism

* deterministic batch partitioning
* deterministic readable batch ids
* explicit final row sorting before writing public outputs so output order does not depend on batch execution order

## Compatibility

The following public outputs remain intact:

* `research_latest.json`
* `strategy_matrix.csv`

The following run-level artifacts remain global and compatible:

* `run_candidates_latest.v1.json`
* `run_filter_summary_latest.v1.json`
* `run_screening_candidates_latest.v1.json`

## Failure semantics

Default behavior is permissive and isolation-oriented:

* candidate timeout / error / validation issues degrade a batch to `partial`
* later batches continue by default
* `failed` / `skipped` are reserved for true batch-level orchestration failure paths

## Files changed

* `research/run_research.py`
* `research/observability.py`
* `research/batching.py`
* `tests/unit/test_run_research_observability.py`
* `tests/unit/test_research_batching.py`

## Validation

Passed locally:

* `python -m py_compile research/observability.py research/run_research.py research/batching.py tests/unit/test_research_batching.py tests/unit/test_run_research_observability.py`
* `pytest tests/unit/test_research_batching.py tests/unit/test_screening_runtime.py -q`

Blocked locally on Windows temp-dir permissions:

* `pytest tests/unit/test_run_research_observability.py -q`

Additional manual verification passed for:

* healthy batch execution
* partial batch followed by later completed batch
* deterministic final output ordering across batches

## Notes

This PR does **not** add:

* parallelization
* restart/resume logic
* dashboard work
* new strategies
* evaluation-layer changes
