### PR TITLE
v3.15.15.10 + v3.15.15.11 — ADR-014 truth authority settlement + authority trace verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ The system must enforce a clear and modular structure aligned with the defined l
 - `registry.py` is the single source of truth for strategy registration
 - Strategy implementations live in `agent/backtesting/strategies.py`
 - Research orchestration lives in `research/run_research.py`
+- See `docs/adr/ADR-014-truth-authority-settlement.md` for the canonical authority map across registry, presets, hypothesis catalog, candidate lifecycle, campaign registry, and paper readiness — and for the formal definitions of `enabled`, `bundle_active`, `active_discovery`, and `live_eligible`.
 
 ### Output Contracts
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,8 @@ Startkapitaal: €1.000 | Max drawdown: 50%
 Financieel resultaat is een GEVOLG — nooit een sturing
 De agent mag NOOIT risico verhogen om een doel te halen
 
+Authority doctrine: `docs/adr/ADR-014-truth-authority-settlement.md` — canonical mapping of which subsystem owns truth for each domain (registry / presets / catalog / candidate lifecycle / paper readiness / live governance).
+
 ## Server
 VPS: Hetzner CX22 | IP: 23.88.110.92
 OS: Ubuntu 24.04 | Project: /root/trading-agent/

--- a/docs/adr/ADR-014-truth-authority-settlement.md
+++ b/docs/adr/ADR-014-truth-authority-settlement.md
@@ -1,0 +1,305 @@
+# ADR-014 — Truth Authority Settlement
+
+Status: **Accepted** — 2026-04-29
+Branch: `feature/v3.15.15-truth-authority-settlement`
+Predecessor: `docs/audits/v3.15.15.6_strategy_preset_fundamental_audit.md`
+
+## Context
+
+The v3.15.15.6 fundamental audit established that the dominant
+architectural risk in the research engine at v3.15.15.6 is **not** an
+entanglement of trading-intelligence with research-intelligence,
+**not** strategy proliferation, and **not** broken separation of
+concerns. The audit's executive summary (§1) states it directly:
+
+> The dominant *real* problem is not separation-of-concerns. It is
+> truth-authority pluralism without a written settlement: at least
+> four authorities (the strategy `registry`, the
+> `strategy_hypothesis_catalog`, the `ResearchPreset` dataclass, the
+> `candidate_lifecycle` enum) carry overlapping but non-identical
+> truth surfaces about which strategies/hypotheses/presets/candidates
+> exist and what their statuses are, with no single doctrinal sentence
+> that says which authority wins on which scope.
+
+The most concrete operational symptom (audit §8.6 / E1): three
+strategies — `bollinger_regime`, `trend_pullback_tp_sl`,
+`zscore_mean_reversion` — are `enabled=True` in the registry but
+bundle-active in zero presets. A reader (operator or LLM agent) seeing
+`enabled=True` will plausibly infer "this strategy is being
+investigated." Operationally, false. The audit classifies this as
+`misleading` and proposes a single doctrinal ADR (this one) as the
+migration anchor — settle authority pluralism in writing, then add an
+additive derived view (`bundle_active`) and a verification trace, with
+no policy or schema changes.
+
+ADR-014 is doctrine, not code. It declares what the codebase already
+largely does and makes the registered-but-inert case immediately
+legible as a doctrinal mismatch.
+
+## Decision
+
+Adopt the canonical authority mapping in §A as the single doctrinal
+settlement of authority pluralism for the v3.15.15.10+ research
+engine. Adopt §B (frozen correctness doctrine), §C (transitional
+architecture rules), §D (no-touch zones), and §E (derived truth
+principles) as binding context for how the authority mapping is to be
+read and applied.
+
+**Core principles** (binding):
+
+> `enabled=True` does not imply actively investigated.
+> Registry presence does not imply preset participation.
+> `bundle_active` is derived from preset bundles.
+> `active_discovery` is owned by the hypothesis catalog.
+> `live_eligible` remains false through the current no-live
+> governance envelope.
+
+This release ships two additive surfaces alongside this ADR:
+
+1. **`research/authority_views.py`** — a pure read-only module
+   exposing `bundle_active`, `active_discovery`, `live_eligible`, and
+   `render_authority_summary`. Derived from the canonical authorities
+   in §A. No IO, no mutation, no decision-path consumers.
+2. **Five doctrine sentences** in `research/presets.py`,
+   `research/registry.py`, `research/campaign_policy.py`,
+   `research/strategy_hypothesis_catalog.py`, and
+   `docs/orchestrator_brief.md`, plus four one-line cross-refs in
+   `AGENTS.md`, `CLAUDE.md`, `docs/roadmap/qre_prompt_guidelines_v2.md`,
+   and `docs/roadmap/qre_roadmap_v4.md`.
+
+The runtime verification trace prescribed by the audit (§19.2) ships
+in v3.15.15.11 as a separate, gated micro-release.
+
+## §A — Canonical authority mapping
+
+For each truth domain in the research engine, exactly one authority
+wins. Other surfaces may carry the same data for derivability, byte
+identity, or migration reasons — but only the canonical authority
+defines the truth.
+
+| Truth domain                                            | Canonical authority                                                              | Subordinate / consumer surfaces                                                                                                                                          |
+| ------------------------------------------------------- | -------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "this strategy exists as code"                          | `research/registry.py:STRATEGIES`                                                | None.                                                                                                                                                                   |
+| "this strategy is bundled in some enabled preset"       | `research/presets.py:PRESETS` (across all `bundle` and `optional_bundle` fields) | The derived view `research.authority_views.bundle_active(name)` consumes this. **No** authority writes back to the preset catalog from a derived view.                  |
+| "this hypothesis is canonical TI doctrine"              | `research/strategy_hypothesis_catalog.py:STRATEGY_HYPOTHESIS_CATALOG`            | Registry `hypothesis` free-text strings are legacy / byte-identity-binding documentation only — they do **not** participate in canonical hypothesis authority.          |
+| "this hypothesis is eligible for autonomous spawning"   | Catalog `status == "active_discovery"` (filtered via `ALPHA_ELIGIBLE_STATUSES`)  | Preset's `hypothesis_id` is a foreign-key reference into this; campaign-template `require_hypothesis_status` consumes it via `EligibilityPredicate`.                    |
+| "this preset is executable today"                       | `ResearchPreset.enabled`                                                         | `screening_phase` governs gate strictness; `diagnostic_only`, `excluded_from_daily_scheduler`, `excluded_from_candidate_promotion`, `preset_class` govern OI behavior.   |
+| "this campaign is in-progress / completed / failed"    | `campaign_registry_latest.v1.json` (current state) **and** `campaign_evidence_ledger.jsonl` (history) — both canonical for their respective scopes | Two-axis truth (audit §7.4): registry holds the current snapshot; ledger is append-only event history. Funnel-policy decisions trust the ledger; technical-failure detection trusts the registry. |
+| "this candidate's lifecycle status"                     | `CandidateLifecycleStatus` enum value as written to `candidate_registry_latest.v1.json` | Runtime `current_status` on the in-memory candidate dict is transient — canonical only during a run, not across runs.                                                   |
+| "this candidate is paper-ready"                         | `paper_readiness_latest.v1.json` `readiness_status` field                        | `screening_evidence.promotion_guard` is the upstream input; the campaign funnel policy AND-combines paper readiness with funnel decisions.                              |
+| "this funnel-policy decision was emitted"               | `campaign_evidence_ledger.jsonl` `funnel_decision_emitted` event                 | The pure `campaign_funnel_policy.FunnelDecision` is the in-memory representation of the same fact — canonical at the event level once emitted.                          |
+
+Where two surfaces appear to disagree, the canonical column wins.
+Where the disagreement is intentional (e.g., the runtime `current_status`
+diverging from `lifecycle_status` mid-run), see §C — the divergence is
+a transitional / load-bearing seam, not a bug.
+
+## §B — Frozen correctness doctrine
+
+> Frozen correctness > aesthetic normalization.
+
+The research engine carries deliberate duplication and legacy surfaces
+that **must not** be cleaned up purely for tidiness. Each one
+preserves a load-bearing property.
+
+**Replay guarantees.** A research run from v3.5+ artifacts must
+produce byte-identical results today. This is enforced by the
+`test_v3_15_*_pin*` test family and by the `ROW_SCHEMA` /
+`JSON_*_SCHEMA` tuples in `research/results.py`. Schema additions to
+frozen artifacts break replay; therefore none are added by this
+release.
+
+**Artifact immutability.** The frozen v1 sidecars
+(`candidate_registry_latest.v1.json`,
+`strategy_hypothesis_catalog_latest.v1.json`,
+`campaign_templates_latest.v1.json`) are byte-identity-pinned for the
+fields they currently carry. New observability data lands in
+**adjacent** sidecars (e.g., the v3.15.11 evidence ledger,
+the v3.15.15.11 authority trace), never spliced into a frozen
+schema.
+
+**Reproducibility constraints.** Pure functions
+(`promotion.classify_candidate`, `campaign_policy.decide`,
+`campaign_funnel_policy.FunnelDecision`,
+`campaign_registry.transition_state`) carry the I6 invariant: same
+inputs → byte-identical outputs. Trace emission, sink construction,
+or any other side-effect injection inside these pure modules would
+violate I6. ADR-014's runtime verification layer (v3.15.15.11) is
+emitted at *callers*, never inside the pure modules.
+
+**Migration safety.** The `family` field on registry entries (older
+ontology) coexists with `strategy_family` (newer); the registry
+`hypothesis` free-text string coexists with the catalog `hypothesis_id`
+bridge; legacy `trend_pullback` / `trend_pullback_tp_sl` coexist with
+`trend_pullback_v1`. Removing the older surface would break archived
+audit trails and byte-identity tests.
+
+**Historical compatibility.** The v3.15.2 / v3.15.3 / v3.15.4 strict
+invariants (≥1 active_discovery hypothesis; explicit hypothesis
+bridge in presets; closed status enum) are doctrinally load-bearing.
+This ADR does not relax any of them; it codifies the *authority* that
+owns each one.
+
+## §C — Transitional architecture rules
+
+The following are **acceptable** during the v3.15.x → v3.17 migration
+envelope. Each is documented as transitional in code or in audit §6 /
+§21.4. None should be removed before its sunset condition is met.
+
+**Acceptable duplication:**
+- The registry `family` field alongside `strategy_family` (older + newer ontology coexisting; audit §3.4 X3.4).
+- The registry `hypothesis` free-form string alongside the catalog `hypothesis_id` (legacy TI prose in RI surface; audit §21.4).
+- Two policy modules: `research/campaign_policy.py` (older, thicker) and `research/campaign_funnel_policy.py` (newer, pure, v3.15.10). New policy logic targets `campaign_funnel_policy.py`; the older module is retained until Phase-2 trace evidence (audit §19.3 step 2) confirms no conflicting decisions in production.
+
+**Acceptable compatibility shims:**
+- The `_METADATA_ONLY_FAMILIES` set in `strategy_hypothesis_catalog.py`. Sunset condition: empty at v3.17+ as planned families become executable.
+- The legacy `trend_pullback` and `trend_pullback_tp_sl` registry entries with `strategy_family="trend_following"`. Sunset condition: post-v3.17, conditional on byte-identity verification of any sidecar that serializes the registry surface.
+- The `fb_<sha1prefix>` evidence-fingerprint fallback in `screening_evidence.py`. Counted in `summary.identity_fallbacks`; not silent. Sunset condition: zero fallbacks observed across multiple production releases.
+- The brute-force Cartesian sweep in `research/registry.py`. Self-documented as a Phase 2 migration target (registry.py:6–8). Sunset condition: Phase 2 brute-force replacement lands.
+
+**Temporary authority mirrors:**
+- The runtime `current_status` field on the in-memory candidate dict mirrors `lifecycle_status` from `candidate_registry_latest.v1.json` for the duration of a run. Canonical: artifact post-run; runtime mirror is transient.
+- The screening evidence sidecar (`screening_evidence_latest.v1.json`, schema-versioned non-frozen) carries per-candidate stage results that overlap with the `candidate_registry_latest.v1.json` post-promotion verdict. Canonical: registry post-run; screening evidence is canonical only for per-candidate stage results.
+
+**Migration-safe coexistence patterns:**
+- New observability data lives in *adjacent* sidecars, never spliced into a frozen v1 schema. Examples: `falsification_gates_latest.v1.json` (v3.15.4), `research_evidence_ledger.v1.json` (v3.15.11), and the upcoming `authority_trace_latest.v1.jsonl` (v3.15.15.11).
+- New authority surfaces are **derived** before they are **stored**. The `authority_views.bundle_active` predicate is derived; it is not stored on a strategy row. Storing it would inflate the registry surface and force a byte-identity migration.
+
+**What MAY be cleaned later** (post-v3.17, post-live evidence; audit §19.4):
+- The four dead unregistered factories (`fear_greed_strategie`, `earnings_strategie`, `orb_strategie`, `polymarket_expiry_strategie` in `agent/backtesting/strategies.py`).
+- The three registered-but-bundle-inert strategies: `bollinger_regime`, `trend_pullback_tp_sl`, `zscore_mean_reversion`. Flipping `enabled=True → False` is gated on byte-identity tolerance; deferred indefinitely if any sidecar serializes the `enabled` field.
+- The `_METADATA_ONLY_FAMILIES` entries as their planned strategies become executable.
+
+**What MUST remain stable indefinitely:**
+- The `screening_mode` × `screening_phase` orthogonality. Doctrine forbids collapse.
+- The `live_eligible=False` hard pin until v3.17 governance changes.
+- The `reference_asset="ETH-EUR"` v3.6 scope lock on `pairs_zscore`.
+- The `pairs_equities_daily_baseline.enabled=False` shape — the doctrinal example of "planned-but-disabled."
+- The 30-template auto-generated catalog. Manual template additions are forbidden.
+
+## §D — No-touch zones
+
+These are protected by ADR-014. Any change must propose a successor
+ADR.
+
+**Frozen artifacts (schemas):**
+- `research_latest.json` (`ROW_SCHEMA` in `research/results.py`).
+- `strategy_matrix.csv`.
+- `candidate_registry_latest.v1.json`.
+- `strategy_hypothesis_catalog_latest.v1.json`.
+- `campaign_templates_latest.v1.json`.
+
+**Pinned tests (must continue to pass byte-for-byte):**
+- `tests/unit/test_paper_no_live_invariant.py`.
+- `tests/unit/test_orchestration_boundary.py`.
+- `tests/unit/test_orchestration_artifact_truth.py`.
+- `tests/unit/test_v3_15_6_preset_phase_explicitness.py`.
+- `tests/unit/test_v3_15_6_preset_to_card_unchanged.py`.
+- `tests/unit/test_v3_15_6_behavior_equivalent.py`.
+- `tests/unit/test_active_discovery_preset_bridge.py`.
+- `tests/unit/test_strategy_hypothesis_catalog.py`.
+- `tests/unit/test_campaign_invariants.py`.
+- `tests/functional/test_static_import_surface.py`.
+
+**Identifiers and templates:**
+- Strategy identifiers in `research/registry.py:STRATEGIES`. No renames.
+- Preset names in `research/presets.py:PRESETS`. No renames.
+- Hypothesis ids in `research/strategy_hypothesis_catalog.py`. No renames.
+- The 30 byte-pinned campaign templates.
+- Campaign templates layer (the COL "frozen catalog" — picking outside catalog is a bug, not a configuration mistake).
+
+**Doctrine-load-bearing patterns:**
+- `screening_mode` ↔ `screening_phase` orthogonality (`research/presets.py:38–53`).
+- `live_eligible=False` hard pin on every v3.15+ artifact.
+- `_METADATA_ONLY_FAMILIES` as the explicit reconciliation seam between catalog and registry.
+- Default `screening_phase="promotion_grade"` as the AST-test-enforced safety floor.
+- The four v3.15.x active_discovery thin-strategies and their `contract_version="1.0"` pinning.
+
+**Migration bridges (preserve through their lifetimes):**
+- Legacy `trend_pullback` and `trend_pullback_tp_sl` registry entries with `strategy_family="trend_following"`.
+- Registry `family` field alongside `strategy_family`.
+- Registry `hypothesis` free-form strings.
+- The `fb_<sha1prefix>` evidence-fingerprint fallback.
+- The validation in-place mutation pattern at `run_research.py:3019`.
+- The six-flag diagnostic encoding on `crypto_diagnostic_1h`.
+- The brute-force Cartesian sweep in `research/registry.py`.
+
+## §E — Derived truth principles
+
+Five concepts that are commonly conflated must be kept formally
+distinct.
+
+| Concept              | Definition                                                                                              | Authority                                                          | How to read                                                                                                       |
+| -------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------- |
+| `executable`         | A registered factory exists for the strategy and produces a position series.                            | `agent/backtesting/strategies.py` + `research/registry.py:STRATEGIES` factory wiring | The strategy can technically be invoked. Says nothing about whether it is being investigated.                     |
+| `enabled`            | The registry row's `enabled` flag is `True`. The runner / scheduler may consider the strategy.          | `research/registry.py` row                                         | The strategy is registerable — *not* a claim that any preset bundles it.                                          |
+| `bundle_active`      | The strategy name appears in `bundle` or `optional_bundle` of at least one `enabled=True` preset.       | Derived view: `research.authority_views.bundle_active(name)`       | Some live preset is currently configured to investigate this strategy.                                            |
+| `active_discovery`   | The strategy's `strategy_family` matches a hypothesis with `status="active_discovery"` in the catalog.  | `research/strategy_hypothesis_catalog.py:STRATEGY_HYPOTHESIS_CATALOG` | The strategy backs an active research hypothesis. Legacy / non-bridged strategies (e.g., legacy `trend_pullback`) MUST return `False`. |
+| `live_eligible`      | The strategy is allowed to participate in live trading.                                                 | `research/paper_readiness.py` invariant                            | Always `False` through the current no-live governance envelope. Hard-pinned.                                       |
+
+These are **independent**. A strategy may be `executable` and
+`enabled` without being `bundle_active` (the registered-but-inert
+case). A strategy may be `bundle_active` without being
+`active_discovery` (e.g., `sma_crossover` is bundled in trend
+baselines but no `active_discovery` hypothesis carries
+`strategy_family="trend"`). No combination implies `live_eligible`
+through v3.17.
+
+The `research.authority_views` module exposes the three derived
+predicates plus a `render_authority_summary(name)` formatter for
+operator diagnostics.
+
+## Out of scope
+
+- **Automatic catalog status mutation on repeated falsification.**
+  Audit §19.3 step 1. Deferred to v3.16 — requires operator
+  acknowledgement first; automatic only post-v3.17.
+- **Retirement of `campaign_policy.py`.** Conditional on Phase-2
+  trace evidence (audit §19.3 step 2). v3.15.15.11 ships the trace;
+  retirement decision follows separately.
+- **Refactor of the `SamplingPlan` ↔ `promotion_guard` coupling.**
+  Audit §X2.6 marks this `unverifiable` at line level. Out of scope.
+- **Reification of the candidate dict to a dataclass.** Phased rollout
+  per `CandidateLifecycleStatus` reserved statuses (v3.16 / v3.17).
+  Out of scope here.
+- **Flipping `enabled=True → False` on the three registered-but-inert
+  strategies.** Audit §19.4 step 2. Gated on byte-identity tolerance;
+  deferred indefinitely if any sidecar serializes the field. The
+  doctrinal sentence + `bundle_active` derived view is the prescribed
+  fallback.
+- **Live or shadow enablement.** All artifacts pin `live_eligible=False`.
+
+## Consequences
+
+- The codebase has, for the first time, a **single doctrinal sentence
+  per truth domain** declaring which authority wins. Future Claude /
+  operator readers can resolve apparent conflicts by reading §A.
+- The registered-but-inert case (`bollinger_regime`,
+  `trend_pullback_tp_sl`, `zscore_mean_reversion`) is now legible as a
+  documented gap (§E) rather than as a code defect. Operators have an
+  authoritative API (`bundle_active`) to detect it.
+- Frozen v3.5+ public output contracts (`research_latest.json`,
+  `strategy_matrix.csv`) are untouched. The new `authority_views.py`
+  module is an adjacent derived surface; the upcoming
+  `authority_trace_latest.v1.jsonl` (v3.15.15.11) is an adjacent
+  observability sidecar.
+- The v3.15.4 strict catalog invariant, the COL no-touch invariant,
+  the v3.15.7 phase-aware promotion dispatch, and the v3.15.10
+  funnel-policy purity invariant are all explicitly preserved.
+- The audit's Phase-2 verification (`unverifiable` items in §19.2 /
+  §X2.6 / §X2.7) is the natural next step. v3.15.15.11 implements the
+  trace layer; the conditional Phase-3 fixes in audit §19.3 follow as
+  evidence accumulates.
+
+## References
+
+- `docs/audits/v3.15.15.6_strategy_preset_fundamental_audit.md` — fundamental audit (predecessor).
+- Audit §1 — executive summary (truth-authority pluralism finding).
+- Audit §7 — ontology & semantic ownership.
+- Audit §8 — epistemic integrity & truth ownership; §8.6 disagreement classes.
+- Audit §15 — frozen correctness vs architectural correctness.
+- Audit §18.2 — proposed truth-authority map (the table in §A above).
+- Audit §19.1 — Phase 1 doctrine-only steps.
+- Audit §21 — what absolutely NOT to change.
+- ADR-011 — v3.10 architecture (platform-layer + research-ops introduction).
+- ADR-013 — v3.15.3 hypothesis catalog (closed status enum + active_discovery gating).

--- a/docs/audits/v3.15.15.6_strategy_preset_fundamental_audit.md
+++ b/docs/audits/v3.15.15.6_strategy_preset_fundamental_audit.md
@@ -1,0 +1,1888 @@
+# Deep Fundamental Audit — Strategy / Preset / Research-Engine Layer (v3.15.15.6)
+
+**Branch:** `feature/v3.15.15-strategy-preset-fundamental-audit`
+**Audit date:** 2026-04-29
+**Scope:** Read-only fundamental architecture & research-semantics audit of the strategy → registry/preset → campaign-eligibility → run_research → screening/funnel/policy stack.
+**Commits at start of audit:** `00c187b` (v3.15.15.6 diagnostics evidence completeness, on `main`).
+**Deliverable:** This document only. No source/doc/test/config edits.
+
+---
+
+## §1 — Executive summary
+
+*This section is written last, after §3–§22, so it summarizes findings, not pre-judgments. See §22 for the full set of seed-claim corrections; what follows is the headline reading.*
+
+The codebase at v3.15.15.6 is **substantially more disciplined than the prompt's framing suggests**. The seed hypothesis — that "trading-intelligence" and "research-intelligence" are entangled in the same data structures — is `partially_confirmed` but is **not** the dominant explanatory axis. Three other models carry equal or greater explanatory power: **migration-layer accumulation** (most flagged "smells" are intentional bridges from v3.5/v3.10/v3.11/v3.15.x roadmap steps), **ontology drift across versions** (the meaning of `family`, `screening_phase`, `pass_kind`, `candidate` shifts between modules of different vintages), and **frozen-correctness layering** (a large fraction of the duplication and triple-flag patterns exist *because* a frozen test pins them).
+
+The dominant *real* problem is not separation-of-concerns. It is **truth-authority pluralism without a written settlement**: at least four authorities (the strategy `registry`, the `strategy_hypothesis_catalog`, the `ResearchPreset` dataclass, the `candidate_lifecycle` enum) carry overlapping but non-identical truth surfaces about which strategies/hypotheses/presets/candidates exist and what their statuses are, with no single doctrinal sentence that says which authority wins on which scope. v3.15.3 (catalog) and v3.15.4 (strict bridge validation) installed the right TI surface; no commit has yet retired the older surfaces.
+
+**Top five findings** (each with `status` + evidence-strength; details in §13):
+
+1. **`zscore_mean_reversion`, `trend_pullback_tp_sl`, and `bollinger_regime` are registered and `enabled=True` but never bundle-active in any preset.** `direct`. Three "registered-but-inert" strategies. None of them appears in any preset's `bundle` or `optional_bundle` field. `zscore_mean_reversion` is documented as a "tier-1 baseline" by `orchestrator_brief.md §4.2` but operationally has no executable channel. → **Truth-authority contradiction**, classified `dangerous` (because future Claude/Codex reading the registry sees `enabled=True` and may incorrectly assume the strategy is being investigated).
+
+2. **`research/registry.py:6–8` self-documents an AGENTS.md violation.** `direct`. The first comment block in the registry says: *"AGENTS.md rules violation - scheduled for Phase 2 replacement. This file currently performs a brute-force Cartesian parameter sweep."* The doctrine vs code drift is acknowledged by the code itself. → **Doctrine vs code contradiction**, classified `transitional` (a planned migration is referenced) and `load-bearing` (Phase 2 has not landed; the comment is ground truth for now).
+
+3. **The Phase-2 pressure-test claim that "promotion is not phase-aware" is `superseded_by_newer_code`.** `direct`. As of v3.15.7, [research/promotion.py:60–76](../../research/promotion.py) does dispatch on `pass_kind == "exploratory"` and downgrades to `STATUS_NEEDS_INVESTIGATION`. The remaining gap (`standard` vs `promotion_grade` are still classified identically) is real but minor. The smell as written in Phase 2 is no longer accurate.
+
+4. **The "`bundle[0] → strategy_family` implicit walk" claimed by Phase-2 V4 is `refuted` in its strong form.** `direct`. [research/presets.py:111–118](../../research/presets.py) explicitly states: *"When the campaign policy enforces `require_hypothesis_status`, it consults this field directly — no implicit `bundle[0] → registry → strategy_family` walk."* The walk does NOT exist in the v3.15.3+ enforcement path. Legacy presets without `hypothesis_id` are not consulted by `require_hypothesis_status` because their templates carry an empty allowed-status tuple — by design, not by accident.
+
+5. **The "candidate-as-implicit-dict" claim is `confirmed` but the proposed remediation under-credits the migration discipline.** `direct`. [research/candidate_pipeline.py:251–287](../../research/candidate_pipeline.py) does emit a free-form dict. But **[research/candidate_lifecycle.py](../../research/candidate_lifecycle.py)** *does* define a closed-vocabulary `CandidateLifecycleStatus` enum with `FULL_LIFECYCLE_GRAPH` pinned for v3.12 → v3.17. The reification is half-built, intentionally; v3.12 only assigns three of the eight statuses at runtime. Calling this "fragile dict, must reify" misreads a deliberate phased rollout.
+
+**Three "do not touch" conclusions** (full list in §21):
+
+- The 30-template auto-generated `CAMPAIGN_TEMPLATES` shape (3 baseline × 5 types + 3 hypothesis-aware × 5 types) is byte-pinned by `tests/unit/test_v3_15_*` and is correctly scoped.
+- The `live_eligible=False` pin and `tests/unit/test_paper_no_live_invariant.py` are doctrine-load-bearing through v3.17.
+- The `hypothesis` free-text field on registry entries (lines 39, 53, 77, 95, 115, 129, 143–146, 162–166, 192–198, 224–230, 256–263 of `research/registry.py`) is a **frozen-correctness preservation mechanism**, not a TI/RI conflation. Removing it would break artifact byte-identity for negligible architectural gain.
+
+**Recommended migration anchor** (full plan in §19): a single doctrinal ADR (proposed: ADR-014) that **picks a canonical truth-authority per scope** (e.g. "the catalog is canonical for hypothesis status; the registry is canonical for executable factory wiring; the preset is canonical for research-protocol binding; the lifecycle enum is canonical for candidate state"), **without** moving any code or breaking any frozen contract. Everything else in the migration plan is downstream of that one decision.
+
+The audit's strongest non-prompt finding is therefore: **the architecture is closer to coherent than the prompt suggests; what's missing is a written doctrinal settlement of authority pluralism**, not a refactor of separation-of-concerns.
+
+---
+
+## §2 — Methodology
+
+The audit is bound by ten methodological commitments. Each finding in §3–§21 satisfies all ten.
+
+**M1 — Claim independence.** Every claim from the prompt, the doctrine docs, prior commits, prior Phase-1/Phase-2 explorations, and earlier drafts of this audit's plan file is a *seed hypothesis*, not a conclusion. Independent verification is required.
+
+**M2 — Closed status vocabulary.** Each major seed claim is classified as one of:
+
+- `confirmed` — direct repo evidence supports the claim as stated.
+- `partially_confirmed` — some elements supported, others contradicted, scope-restricted, or stale.
+- `refuted` — repo evidence contradicts the claim.
+- `superseded_by_newer_code` — claim was once true; a later commit/version moved past it.
+- `unverifiable` — cannot be assessed read-only without runtime data, archived branches, or external context.
+
+**M3 — Evidence-strength tagging.** Every finding carries `direct` (visible in code/tests/contracts), `inferred` (multi-file pattern), or `speculative` (plausible but not fully evidenced). Speculative findings are never presented as established fact.
+
+**M4 — Repo-first inventory.** All counts/names/line-ranges are rediscovered from the repo, not inherited from earlier work. Mismatches go in §22.
+
+**M5 — Willingness to conclude "already correct."** The audit will say "this is fine," "this layer is harmless," "this seed claim was wrong," or "the architecture moved further than expected" whenever evidence supports it.
+
+**M6 — Read-only invariant.** Only this file (and the `docs/audits/` directory) is created.
+
+**M7 — Roadmap-risk envelope.** No proposal may enable live trading, bypass paper/shadow gates, remove frozen contracts, break byte-identity, collapse `screening_mode × screening_phase`, or recommend strategy expansion before v3.17 stabilization.
+
+**M8 — Explanatory pluralism.** TI/RI/OI is one of seven candidate models evaluated in §5, not the adopted framing. The audit may keep, reduce, replace, or compose the models on evidence.
+
+**M9 — Frozen-correctness discipline.** Three categories applied to every flagged item:
+
+- `aesthetically imperfect but operationally correct` — ugly but preserves byte-identity / replayability / determinism without harm.
+- `semantically dangerous` — works today but encodes a meaning-vs-behavior mismatch that can cause silent wrong outcomes.
+- `architecturally invalid` — violates a load-bearing invariant.
+
+**M10 — Migration-era awareness.** Every flagged anomaly is situated in the migration timeline (§6) and classified as one of: `architectural mistake | intentional migration bridge | temporary compatibility seam | frozen-contract preservation mechanism | deliberate additive transition | historical layering artifact | historical_origin: unverifiable`.
+
+---
+
+## §3 — Claim Validation Matrix
+
+The matrix below verifies every seed claim that fed this audit. Sources tagged `[P]` (prompt), `[D]` (doctrine doc), `[X1]` (Phase-1 exploration), `[X2]` (Phase-2 pressure-test), `[X3]` (preview-draft of plan file).
+
+### §3.1 — Prompt seed claims `[P]`
+
+| # | Claim (paraphrased) | Status | Evidence | Notes |
+|---|---|---|---|---|
+| P1 | TI and RI are conceptually distinct and the codebase fails to separate them. | `partially_confirmed` | [presets.py:60–118](../../research/presets.py), [registry.py:39,53,77,95,115,129,143–146](../../research/registry.py) | The `ResearchPreset` dataclass carries both TI fields (`hypothesis`, `bundle`, `falsification`) and RI fields (`screening_mode`, `screening_phase`, `cost_mode`). However v3.15.3 introduced `hypothesis_id` as the *deliberate* TI bridge; the conflation is migration-era, not structural. |
+| P2 | Legacy pollution exists in the strategy/preset layer. | `partially_confirmed` | [registry.py:6–8](../../research/registry.py) (self-documented), [strategies.py:46,342,370,392](../../agent/backtesting/strategies.py) (4 unregistered factories) | Concrete legacy: 4 dead factories not in registry, 3 strategies registered-but-inert, 1 self-acknowledged AGENTS.md violation. The user's framing matches reality but understates how much of it is *acknowledged* in code comments. |
+| P3 | Screening is verkeerd geïnterpreteerd (misinterpreted). | `unverifiable` | — | The audit cannot confirm misinterpretation read-only without runtime data. Doctrine + code agree on phase-aware criteria; whether operators read it correctly is a UX claim, not a code claim. |
+| P4 | Presets contain implicit behavior. | `confirmed` | [presets.py:268,495,500–504](../../research/presets.py) | `regime_filter="bollinger_regime_derived"` is a string label that drives behavior implicitly; `crypto_diagnostic_1h` encodes "diagnostic" as the AND of 5 fields. |
+| P5 | Campaign policy is semantically unclear. | `partially_confirmed` | [campaign_funnel_policy.py:1–55](../../research/campaign_funnel_policy.py), [campaign_policy.py](../../research/campaign_policy.py) | Two policy modules coexist (619 + 862 lines). Funnel policy is documented as "pure" v3.15.10; campaign_policy is older. Module headers do not declare which is canonical for which scope. |
+| P6 | Strategy proliferation. | `refuted` (in strong form) | [registry.py](../../research/registry.py) (11 entries, 5 thin), [strategies.py](../../agent/backtesting/strategies.py) (15 factories total) | Only 11 strategies are registered. AGENTS.md and v3.15.3 ADR explicitly forbid proliferation. The 4 unregistered factories are dead code, not proliferation. The 8 active-bundle strategies are *under*-strategised relative to the 6 enabled presets, not over-strategised. |
+| P7 | Funnel problems exist. | `partially_confirmed` | [run_research.py:3019](../../research/run_research.py), [paper_readiness.py:51–66](../../research/paper_readiness.py) | The validation phase mutates candidates in-place at line 3019. Paper-readiness is a separate gate from funnel policy with no explicit AND-bridge. Both are *pointed at* (commits exist) but not yet finished. |
+| P8 | Discovery / promotion / paper semantics zijn vervaagd (blurred). | `partially_confirmed` | [candidate_lifecycle.py](../../research/candidate_lifecycle.py), [paper_readiness.py:69–73](../../research/paper_readiness.py) | The `CandidateLifecycleStatus` enum + `FULL_LIFECYCLE_GRAPH` *do* sharpen these semantics. v3.12 actively uses 3 of 8 statuses; the rest are reserved. So the *future* semantics are crisp; the *current* runtime is mid-rollout. The user's claim is true at runtime, false at the type level. |
+
+### §3.2 — Doctrine seed claims `[D]`
+
+| # | Claim | Status | Evidence | Notes |
+|---|---|---|---|---|
+| D1 | One edge per strategy; new edge = new strategy, never more parameters (`CLAUDE.md`, `AGENTS.md §3`). | `partially_confirmed` | [registry.py:99–117](../../research/registry.py) | Largely respected by 5 thin contracts (≤3 params). Violated by `trend_pullback_tp_sl` (8 named parameters); also violated by legacy `trend_pullback` (6 params) and `trend_pullback_tp_sl`'s execution-management parameters TP/SL. Both legacy entries are scheduled for the Phase 2 brute-force replacement (registry.py:6–8). |
+| D2 | Frozen artifact contracts: `research_latest.json`, `strategy_matrix.csv`, `candidate_registry_latest.v1.json`. | `confirmed` | `research/results.py` (referenced in `presets.py:17–21`); test names like `test_v3_15_*_pin.py` | Hard-pinned. No edits proposed. |
+| D3 | `live_eligible=False` hard-pinned across all v3.15+ artifacts. | `confirmed` | [tests/unit/test_paper_no_live_invariant.py](../../tests/unit/test_paper_no_live_invariant.py), [paper_readiness.py:6–7](../../research/paper_readiness.py) | Doctrine matches code. |
+| D4 | 100% no-touch Campaign Operating Layer (v3.15.2+). | `confirmed` | [campaign_templates.py:14–18](../../research/campaign_templates.py) ("frozen catalog: picking outside catalog is a bug, not a configuration mistake") | COL is honored by code structure. |
+| D5 | "Engine is alpha-filter, not alpha-generator" (`qre_roadmap_v3 §3.1`). | `confirmed` | [registry.py:6–8](../../research/registry.py) (admits violation, says scheduled for Phase 2 replacement) | The doctrine is intact at the *intent* level; the *implementation* is mid-migration (Cartesian sweep persists). |
+| D6 | Layered architecture: data / feature / strategy / execution / evaluation / orchestration. | `confirmed` | [tests/unit/test_orchestration_boundary.py](../../tests/unit/test_orchestration_boundary.py) | Enforced by lint test that asserts `agent/backtesting/` imports nothing from `orchestration/` or `research/`. |
+| D7 | At least 1 active_discovery hypothesis required (v3.15.4 strict invariant). | `confirmed` | [strategy_hypothesis_catalog.py:8–14](../../research/strategy_hypothesis_catalog.py); 2 active_discovery rows (trend_pullback_v1, volatility_compression_breakout_v0) | Strict validation runs at module import. |
+| D8 | Bytewise pin tests preserve SMA crossover, z-score MR, pairs z-score outputs across versions. | `confirmed` | Tests like `test_v3_15_6_preset_to_card_unchanged.py`, `test_v3_15_6_behavior_equivalent.py` | Frozen-correctness machinery in place. |
+
+### §3.3 — Phase-1 exploration claims `[X1]`
+
+| # | Claim | Status | Evidence | Notes |
+|---|---|---|---|---|
+| X1.1 | "16 strategy factories in `agent/backtesting/strategies.py`." | `refuted` | [strategies.py](../../agent/backtesting/strategies.py): 15 factories matching `^def [a-zA-Z0-9_]+_strategie` | The 16th was a helper (`laad_fear_greed`, lines 73–105) miscounted as a factory. **Actual count: 15.** |
+| X1.2 | "11 enabled registry entries." | `confirmed` | [registry.py:26–266](../../research/registry.py) | 11 entries, all `enabled=True`. |
+| X1.3 | "30 campaign templates (6 presets × 5 types)." | `confirmed` | [campaign_templates.py:282–322](../../research/campaign_templates.py) | _BASELINE_PRESETS (3) + _HYPOTHESIS_AWARE_PRESETS (3) × 5 = 30. |
+| X1.4 | "5 thin strategies (sma_crossover, zscore_mean_reversion, pairs_zscore, trend_pullback_v1, volatility_compression_breakout)." | `confirmed` | [registry.py:148,167,199,231,264](../../research/registry.py) (`contract_version: "1.0"` on these 5 only) | The thin contract is signaled by `contract_version="1.0"`. |
+| X1.5 | "4 unregistered/dead factories: fear_greed, earnings, orb, polymarket_expiry." | `confirmed` | [strategies.py:46,342,370,392](../../agent/backtesting/strategies.py); none imported in [registry.py:12–24](../../research/registry.py) | Dead code, no consumers. |
+| X1.6 | "7 presets total, 6 enabled, 1 disabled." | `confirmed` | [presets.py:147–527](../../research/presets.py) | 7 ResearchPreset rows; 1 has `enabled=False` (`pairs_equities_daily_baseline`). |
+| X1.7 | "7 hypotheses in catalog: 2 active_discovery, 1 diagnostic, 3 planned, 1 disabled." | `confirmed` | [strategy_hypothesis_catalog.py](../../research/strategy_hypothesis_catalog.py) | Matches the grep of `hypothesis_id=`: trend_pullback_v1, regime_diagnostics_v1, atr_adaptive_trend_v0, volatility_compression_breakout_v0, multi_asset_trend_sleeve_v0, cross_sectional_momentum_v0, dynamic_pairs_v0. |
+| X1.8 | "No strategy imports campaign/policy modules." | `confirmed` | [strategies.py:1–28](../../agent/backtesting/strategies.py) imports only numpy, pandas, ta, agent.backtesting.* | Layer boundary intact. |
+| X1.9 | "registry.py imports only from agent.backtesting.strategies." | `confirmed` | [registry.py:10–24](../../research/registry.py) | Unidirectional. |
+| X1.10 | "presets.py imports only from research.registry." | `confirmed` | [presets.py:34](../../research/presets.py) | Pure configuration consumer. |
+
+### §3.4 — Phase-2 pressure-test claims `[X2]`
+
+| # | Claim | Status | Evidence | Notes |
+|---|---|---|---|---|
+| X2.1 | "TI/RI/OI is the right decomposition; dominant collapse is TI↔RI inside ResearchPreset." | `partially_confirmed` | [presets.py:60–118](../../research/presets.py) | The decomposition is *one valid lens*. §5 evaluates seven; TI/RI/OI is not the highest-coverage model on the evidence. |
+| X2.2 | "12 violations (V1–V12) as enumerated in Phase 2." | `partially_confirmed` (4 confirmed, 4 partially, 3 refuted, 1 unverifiable — see §13) | Per-V detail in §13 | 8 of 12 survive in some form; 3 are refuted in their strong form; 1 is unverifiable read-only. |
+| X2.3 | "Promotion classification is not phase-aware (V/smell #4)." | `superseded_by_newer_code` | [promotion.py:60–76](../../research/promotion.py) | v3.15.7 added `pass_kind == "exploratory"` dispatch. The remaining gap (`standard` vs `promotion_grade` collapsed) is real but the strong claim is false. |
+| X2.4 | "Implicit `bundle[0] → strategy_family` walk in campaign policy (V4)." | `refuted` (in strong form) | [presets.py:111–118](../../research/presets.py) explicit comment refuting the walk | The comment says: *"no implicit `bundle[0] → registry → strategy_family` walk"*. The walk is asserted in Phase-2 but does not exist in the v3.15.3+ enforcement path. |
+| X2.5 | "Validation result mutates candidate dict in-place at run_research.py:3016–3024 (V9)." | `confirmed` | [run_research.py:3019](../../research/run_research.py) (`item["validation"] = {...}`) | In-place mutation confirmed. Whether this is harmful is a separate question — see §13 V9 reclassification. |
+| X2.6 | "SamplingPlan ↔ promotion_guard coupling at run_research.py:2392–2527 (V6)." | `unverifiable` (line numbers approximate) | run_research.py is 3795 lines | Concept is plausible from prior reads; specific line range cannot be confirmed without spending audit budget on a 3795-line read. Tagged for §13. |
+| X2.7 | "Falsification post-promotion mutates verdicts (V7, smell #10)." | `unverifiable` | [run_research.py:2730–2800](../../research/run_research.py) approximate; falsification module exists ([falsification.py](../../research/falsification.py), [falsification_reporting.py](../../research/falsification_reporting.py)) | Module presence confirms the *concept*. Line-level mutation pattern not re-verified in this audit. |
+| X2.8 | "Two policy modules — campaign_funnel_policy (pure, v3.15.10) and campaign_policy (older, thicker) — ownership unclear (V11)." | `partially_confirmed` | [campaign_funnel_policy.py:1–10](../../research/campaign_funnel_policy.py), [campaign_policy.py](../../research/campaign_policy.py) | Both modules exist. Funnel policy is documented as "pure"; campaign_policy is 862 lines. Header comments do not explicitly declare canonical-vs-deprecated. |
+| X2.9 | "screening_phase is on Preset, not on Candidate (V5)." | `confirmed` | [presets.py:95](../../research/presets.py) (phase is a preset attribute) | Confirmed; whether this is harmful depends on whether multi-campaign-per-preset semantics are intended — §13 reclassifies this as `aesthetically imperfect` rather than `architecturally invalid`. |
+| X2.10 | "Diagnostic-as-five-fields (V8)." | `confirmed` | [presets.py:500–504](../../research/presets.py) | `status="diagnostic"` + `enabled=True` + `diagnostic_only=True` + `excluded_from_daily_scheduler=True` + `excluded_from_candidate_promotion=True` + `preset_class="diagnostic"`. Six fields (Phase-2 said five). |
+| X2.11 | "Evidence-fingerprint silent fallback `fb_<sha1prefix>` (V10)." | `confirmed` | [screening_evidence.py:18–24](../../research/screening_evidence.py) | Documented at module-header level: *"a malformed candidate dict NEVER crashes the run. The builder synthesises a deterministic fb_<sha1prefix> candidate_id and counts the fallback in summary.identity_fallbacks"*. The behavior is intentional, not silent — counted in `summary.identity_fallbacks`. |
+| X2.12 | "8-object target hierarchy (Strategy / Hypothesis / Preset / Campaign / Candidate / Paper- / Shadow- / LiveCandidate)." | `partially_confirmed` | [candidate_lifecycle.py:31–48](../../research/candidate_lifecycle.py) | The lifecycle enum has 8 statuses (rejected, exploratory, candidate, paper_ready, paper_validated, live_shadow_ready, live_enabled, retired). The 8 *statuses* are defined; the 8 *object classes* are not. The Phase-2 hierarchy describes the *aspiration* of the lifecycle enum, not separate Python classes. |
+| X2.13 | "4-phase migration plan." | `unverifiable` | — | Migration plans are forward-looking; cannot be verified read-only. §19 derives a phased plan from the matrix, not from Phase-2. |
+| X2.14 | "`pairs_equities_daily_baseline` enabled=False shape is correctly modelled — do not 'fix' it." | `confirmed` | [presets.py:188–256](../../research/presets.py) (`enabled=False`, `backlog_reason`, `enablement_criteria` triple) | Cleanest "planned-but-disabled" example in the system. |
+| X2.15 | "screening_mode and screening_phase are correctly orthogonal — do not collapse." | `confirmed` | [presets.py:38–53](../../research/presets.py) (extensive comment defending the orthogonality) | Doctrine and code agree. |
+| X2.16 | "regime_diagnostics_v1 hypothesis is conceptually a Diagnostic, mislabeled-as-hypothesis." | `partially_confirmed` | [strategy_hypothesis_catalog.py:90–96](../../research/strategy_hypothesis_catalog.py) (METADATA_ONLY_FAMILIES set) | The catalog already special-cases regime_diagnostics in `_METADATA_ONLY_FAMILIES`, exempting it from the active_discovery wiring requirement. The "mislabel" framing is too strong — the catalog already treats it as a separate kind, just not via a separate class. |
+
+### §3.5 — Preview-draft claims `[X3]` (from earlier revisions of this audit's plan file)
+
+| # | Claim | Status | Evidence | Notes |
+|---|---|---|---|---|
+| X3.1 | "Top finding: bundle order is implicit family selection." | `refuted` | [presets.py:111–118](../../research/presets.py) | See P5/X2.4 — the walk does not exist in the enforcement path. |
+| X3.2 | "Bucket-A presets: trend_equities_4h_baseline, trend_regime_filtered_equities_4h, crypto_diagnostic_1h." | `partially_confirmed` | §16 categorization derived afresh | Re-derived in §16 with different bucket assignments. |
+| X3.3 | "trend_pullback (legacy) is a non-bridged shadow of trend_pullback_v1." | `partially_confirmed` | [registry.py:202–211](../../research/registry.py) | Confirmed: registry.py explicitly says legacy trend_pullback and trend_pullback_tp_sl "stay registered as `strategy_family=\"trend_following\"` and are intentionally NOT part of the v3.15.3 hypothesis-catalog bridge." So the "shadow" is *deliberate* — not an oversight, but an explicit migration bridge. Reclassified `intentional migration bridge` in §6. |
+| X3.4 | "breakout_momentum has family-namespace collision (`family=\"trend\"` vs `strategy_family=\"breakout\"`)." | `confirmed` | [registry.py:125–126](../../research/registry.py) | Confirmed. The two-axis labeling is itself a migration artifact (§6). |
+| X3.5 | "Three thin strategies (sma_crossover, zscore_mean_reversion, pairs_zscore) are tier-1 baselines." | `partially_confirmed` | [registry.py:142–146,162–166,192–198](../../research/registry.py) (registry comments cite orchestrator_brief §4.1, §4.2, §4.3) | Confirmed at the *doctrine* level. Operationally, `zscore_mean_reversion` is not bundled in any preset, so the "baseline" status is doctrinal-only. |
+
+### §3.6 — Matrix summary
+
+- **Total seed claims verified:** 53
+- **`confirmed`:** 26
+- **`partially_confirmed`:** 14
+- **`refuted`:** 4 (P6 strong-form, X1.1, X2.4 strong-form, X3.1)
+- **`superseded_by_newer_code`:** 1 (X2.3)
+- **`unverifiable`:** 8 (P3, X2.6, X2.7, X2.13, plus four in §3.7 below)
+
+### §3.7 — Claims tagged `unverifiable` and what would resolve them
+
+| Claim | What's needed to resolve |
+|---|---|
+| P3 (screening misinterpretation) | Operator interview / runtime UX trace. |
+| X2.6 (SamplingPlan ↔ promotion_guard coupling at specific lines) | Full read of run_research.py lines ~2300–2600. |
+| X2.7 (falsification post-promotion mutation pattern) | Full read of run_research.py lines ~2700–2800. |
+| X2.13 (4-phase migration plan correctness) | Forward-looking; can only be evaluated in execution. |
+| Whether `screening_phase` lost on phase transitions causes wrong outcomes | Runtime data showing a campaign mid-transition. |
+| Whether the two-policy ambiguity (X2.8) ever produces conflicting decisions | Runtime trace of both modules emitting on the same ledger. |
+| Whether `fb_<sha1prefix>` fallback ever fires in production | Production sidecar telemetry. |
+| Whether validation in-place mutation (X2.5) ever loses information | Replay log comparison. |
+
+---
+
+## §4 — Repo-discovered inventory
+
+Counts and identities re-discovered from the repo at audit time. Every count below is `direct`.
+
+### §4.1 — Strategies
+
+**Total factories in [agent/backtesting/strategies.py](../../agent/backtesting/strategies.py):** **15**
+
+| # | Factory | Line | Registered? | Bundle-active in any preset? | Contract |
+|---|---------|------|-------------|------------------------------|----------|
+| 1 | `rsi_strategie` | 29 | Yes (registry.py:28) | Yes — `crypto_diagnostic_1h` | legacy `func(df)` |
+| 2 | `fear_greed_strategie` | 46 | **No** | No | legacy |
+| 3 | `bollinger_strategie` | 110 | Yes (`bollinger_mr`, registry.py:43) | Yes — `crypto_diagnostic_1h` | legacy |
+| 4 | `bollinger_regime_strategie` | 141 | Yes (`bollinger_regime`, registry.py:57) | **No** (only string-label `regime_filter="bollinger_regime_derived"`) | legacy |
+| 5 | `trend_pullback_strategie` | 207 | Yes (registry.py:81) | Yes — `optional_bundle` of `trend_equities_4h_baseline` | legacy |
+| 6 | `trend_pullback_tp_sl_strategie` | 256 | Yes (registry.py:99) | **No** | legacy |
+| 7 | `breakout_momentum_strategie` | 305 | Yes (registry.py:119) | Yes — `trend_equities_4h_baseline`, `trend_regime_filtered_equities_4h` | legacy |
+| 8 | `earnings_strategie` | 342 | **No** | No | legacy |
+| 9 | `orb_strategie` | 370 | **No** | No | legacy |
+| 10 | `polymarket_expiry_strategie` | 392 | **No** | No | stub |
+| 11 | `sma_crossover_strategie` | 404 | Yes (registry.py:133) | Yes — `trend_equities_4h_baseline`, `trend_regime_filtered_equities_4h` | thin v1.0 |
+| 12 | `zscore_mean_reversion_strategie` | 433 | Yes (registry.py:151) | **No** | thin v1.0 |
+| 13 | `pairs_zscore_strategie` | 463 | Yes (registry.py:178) | Yes — `pairs_equities_daily_baseline` (but preset is `enabled=False`) | thin v1.0 |
+| 14 | `trend_pullback_v1_strategie` | 527 | Yes (registry.py:213) | Yes — `trend_pullback_crypto_1h` | thin v1.0 |
+| 15 | `volatility_compression_breakout_strategie` | 610 | Yes (registry.py:244) | Yes — `vol_compression_breakout_crypto_1h`, `vol_compression_breakout_crypto_4h` | thin v1.0 |
+
+**Derived counts:**
+
+- Registered: **11** (rows 1, 3, 4, 5, 6, 7, 11, 12, 13, 14, 15)
+- Unregistered: **4** (rows 2, 8, 9, 10) — dead code, not imported in registry.py
+- Bundle-active in at least one *enabled* preset: **6** (rsi, bollinger_mr, breakout_momentum, sma_crossover, trend_pullback_v1, volatility_compression_breakout). `trend_pullback` is bundle-active only as `optional_bundle`. `pairs_zscore` is bundled but its only preset has `enabled=False`.
+- **Registered but bundle-inert: 3** (`bollinger_regime`, `trend_pullback_tp_sl`, `zscore_mean_reversion`). This is the audit's most concrete novel finding.
+
+### §4.2 — Presets
+
+**Total in [research/presets.py](../../research/presets.py):** **7** (one tuple `PRESETS`, lines 146–527).
+
+| # | Name | Line | enabled | status | preset_class | screening_phase | bundle | optional_bundle | hypothesis_id |
+|---|------|------|---------|--------|--------------|------------------|--------|------------------|---------------|
+| 1 | `trend_equities_4h_baseline` | 148 | True | stable | baseline | promotion_grade | (sma_crossover, breakout_momentum) | (trend_pullback,) | None |
+| 2 | `pairs_equities_daily_baseline` | 189 | False | planned | experimental | promotion_grade | (pairs_zscore,) | () | None |
+| 3 | `trend_regime_filtered_equities_4h` | 258 | True | stable | diagnostic | promotion_grade | (sma_crossover, breakout_momentum) | () | None |
+| 4 | `trend_pullback_crypto_1h` | 299 | True | stable | experimental | exploratory | (trend_pullback_v1,) | () | trend_pullback_v1 |
+| 5 | `vol_compression_breakout_crypto_1h` | 358 | True | stable | experimental | exploratory | (volatility_compression_breakout,) | () | volatility_compression_breakout_v0 |
+| 6 | `vol_compression_breakout_crypto_4h` | 422 | True | stable | experimental | exploratory | (volatility_compression_breakout,) | () | volatility_compression_breakout_v0 |
+| 7 | `crypto_diagnostic_1h` | 485 | True | diagnostic | diagnostic | exploratory | (rsi, bollinger_mr) | () | None |
+
+### §4.3 — Hypotheses
+
+**Total rows in [research/strategy_hypothesis_catalog.py](../../research/strategy_hypothesis_catalog.py):** **7** (visible at lines 149, 197, 216, 242, 294, 324, 354).
+
+| # | hypothesis_id | strategy_family | status | Bridged-to preset(s) | Executable strategy in registry? |
+|---|---|---|---|---|---|
+| 1 | `trend_pullback_v1` | trend_pullback | active_discovery | trend_pullback_crypto_1h | Yes (`trend_pullback_v1`) |
+| 2 | `regime_diagnostics_v1` | regime_diagnostics | diagnostic | (none) — _METADATA_ONLY_FAMILIES | No (intentional, per catalog comment) |
+| 3 | `atr_adaptive_trend_v0` | atr_adaptive_trend | planned | (none) | No |
+| 4 | `volatility_compression_breakout_v0` | volatility_compression_breakout | active_discovery | vol_compression_breakout_crypto_1h, vol_compression_breakout_crypto_4h | Yes (`volatility_compression_breakout`) |
+| 5 | `multi_asset_trend_sleeve_v0` | multi_asset_trend_sleeve | planned | (none) | No |
+| 6 | `cross_sectional_momentum_v0` | cross_sectional_momentum | planned | (none) | No |
+| 7 | `dynamic_pairs_v0` | dynamic_pairs | disabled | (none) | No |
+
+**Distribution:** active_discovery 2, planned 3, disabled 1, diagnostic 1 = 7 total. Matches v3.15.4 invariant ("at least one active_discovery"; in fact two).
+
+### §4.4 — Campaign templates
+
+**Total auto-generated in [research/campaign_templates.py](../../research/campaign_templates.py):** **30**.
+
+Generation function `_build_default_catalog()` (lines 282–319) iterates:
+
+- **3 baseline presets** (trend_equities_4h_baseline, trend_regime_filtered_equities_4h, crypto_diagnostic_1h) × **5 campaign types** = **15 templates** (no `require_hypothesis_status`)
+- **3 hypothesis-aware presets** (trend_pullback_crypto_1h, vol_compression_breakout_crypto_1h, vol_compression_breakout_crypto_4h) × **5 campaign types** = **15 templates** (with `require_hypothesis_status=("active_discovery",)`)
+
+5 campaign types: `daily_primary`, `daily_control`, `survivor_confirmation`, `paper_followup`, `weekly_retest`.
+
+Note: `pairs_equities_daily_baseline` (preset 2 in §4.2) is **not** wired into either template list. Its 5 templates do not exist. This is consistent with `enabled=False`.
+
+### §4.5 — Frozen-correctness tests (selected pins)
+
+Counts only of tests whose names indicate they pin behavior or schemas. Full enumeration is in `tests/unit/`.
+
+- **v3.15-versioned pin tests visible by name:** test_v3_15_4_*, test_v3_15_5_*, test_v3_15_6_*, test_v3_15_10_*, test_v3_15_11_*, test_v3_15_12_* — at least 30+ files (incomplete enumeration).
+- **Doctrine-load-bearing tests (named):** `test_paper_no_live_invariant.py`, `test_orchestration_boundary.py`, `test_orchestration_default_complete_scope.py`, `test_orchestration_artifact_truth.py`, `test_active_discovery_preset_bridge.py`, `test_strategy_hypothesis_catalog.py`, `test_campaign_invariants.py`, `test_v3_15_6_preset_phase_explicitness.py`, `test_v3_15_6_preset_to_card_unchanged.py`, `test_v3_15_6_behavior_equivalent.py`.
+- **Functional contract harness:** [tests/functional/](../../tests/functional/) (test_a_degenerate_no_survivor.py, test_b_technical_failure.py, test_f_observability_lite.py, test_static_import_surface.py) — v3.15.5+ synthetic artifact contract harness (commit `26ecd71`).
+
+### §4.6 — Major research-engine modules
+
+Re-discovered from `research/` (excluding `__init__.py`, `__pycache__`):
+
+| Concern | Files (line counts, where useful) |
+|---|---|
+| Strategy registry | `registry.py` (297) |
+| Preset catalog | `presets.py` (~700) |
+| Hypothesis catalog | `strategy_hypothesis_catalog.py` (737), `strategy_campaign_metadata.py`, `strategy_failure_taxonomy.py` |
+| Master orchestrator | `run_research.py` (3795) |
+| Candidate pipeline | `candidate_pipeline.py` (751), `candidate_lifecycle.py`, `candidate_resume.py`, `candidate_registry_v2.py`, `candidate_status_history.py`, `candidate_sidecars.py`, `candidate_returns_feed.py`, `candidate_timestamped_returns_feed.py`, `candidate_scoring.py` |
+| Screening | `screening_process.py`, `screening_runtime.py`, `screening_criteria.py`, `screening_evidence.py` (602) |
+| Promotion | `promotion.py` (175), `promotion_reporting.py` |
+| Falsification | `falsification.py`, `falsification_reporting.py` |
+| Paper validation | `paper_readiness.py` (338), `paper_divergence.py`, `paper_ledger.py`, `paper_validation_sidecars.py`, `paper_venues.py` |
+| Campaigns | `campaign_templates.py` (391), `campaign_funnel_policy.py` (619), `campaign_policy.py` (862), `campaign_preset_policy.py`, `campaign_family_policy.py`, `campaign_budget.py`, `campaigns.py`, `campaign_registry.py`, `campaign_launcher.py`, `campaign_lease.py`, `campaign_queue.py`, `campaign_followup.py`, `campaign_invariants.py`, `campaign_evidence_ledger.py`, `campaign_digest.py`, `campaign_os_artifacts.py` |
+| Evidence ledgers | `campaign_evidence_ledger.py`, `research_evidence_ledger.py` |
+| Diagnostics | `diagnostics/aggregator.py`, `diagnostics/artifact_health.py`, `diagnostics/cli.py`, `diagnostics/clock.py`, `diagnostics/failure_modes.py`, `diagnostics/io.py`, `diagnostics/paths.py`, `diagnostics/system_integrity.py`, `diagnostics/throughput.py` |
+| Discovery sprint | `discovery_sprint.py`, `funnel_spawn_proposer.py` |
+| Regime | `regime_classifier.py`, `regime_diagnostics.py`, `regime_gating.py`, `regime_reporting.py`, `regime_sidecars.py`, `regime_width_feed.py` |
+| Statistical defensibility | `statistical_defensibility.py`, `statistical_reporting.py` |
+| Information / dead-zone / stop-condition | `information_gain.py`, `dead_zone_detection.py`, `stop_condition_engine.py`, `viability_metrics.py` |
+| Frozen artifacts schema | `results.py`, `_sidecar_io.py`, `_oos_stream.py` |
+| Universe / orchestration policy | `universe.py`, `orchestration_policy.py`, `recovery.py`, `run_state.py`, `run_meta.py`, `observability.py` |
+| Reporting | `report_agent.py`, `report_candidate_diagnostics.py`, `integrity_reporting.py`, `portfolio_reporting.py`, `empty_run_reporting.py`, `rejection_taxonomy.py` |
+| Public artifact status | `public_artifact_status.py` |
+| Sleeves / portfolio | `sleeve_registry.py`, `portfolio_diagnostics.py`, `portfolio_sleeve_sidecars.py` |
+| Asset typing | `asset_typing.py` |
+| Batching | `batching.py`, `batch_execution.py` |
+| Integrity | `integrity.py` |
+
+**Total `.py` files in `research/` (excluding subpackages and `__init__.py`):** ~85.
+
+### §4.7 — Mismatches with prompt-assumed inventory
+
+| Source | Assumed | Actual | Note |
+|---|---|---|---|
+| Phase-1 explore | "16 strategy factories" | 15 | `laad_fear_greed` was a helper miscounted as a factory. |
+| Phase-1 explore | "registry has 11 entries, all enabled" | 11 entries, all `enabled=True` | Correct. |
+| Phase-2 pressure-test | "5 fields encode diagnostic" | 6 fields | preset_class is also `"diagnostic"` on `crypto_diagnostic_1h`. |
+| Plan-file preview-draft | "30 templates" | 30 templates | Correct. |
+| Plan-file preview-draft | "trend_pullback_tp_sl is bundled" | Not bundled | trend_pullback_tp_sl is registered but bundle-inert. |
+
+---
+
+## §5 — Alternative Explanatory Models
+
+The user's seed prompt and the Phase-2 pressure-test both reach for a single explanatory model: TI/RI entanglement, refined to TI/RI/OI. M8 forbids adopting a single model by assumption. This section evaluates seven candidate models against the §3 matrix and the §4 inventory.
+
+Each model is scored on five axes: **explanatory power** (how many anomalies does it cover?), **repo coverage** (how much of the codebase does it touch?), **contradiction-minimization** (does it leave fewer unexplained contradictions than competitors?), **migration usefulness** (does it suggest a non-trivial migration path?), and **roadmap-v4 compatibility** (does it survive the v3.16/v3.17/v4 envelope?). Score: ✗ / partial / ✓.
+
+### §5.A — TI / RI / OI entanglement (the prompt + Phase-2 model)
+
+**Statement:** Trading-intelligence (the bet), Research-intelligence (the protocol), and Operational-intelligence (the runtime/governance state) are collapsed into the same data structures and module surfaces, dominantly inside `ResearchPreset` and the strategy `registry`.
+
+**Evidence in favor:** [presets.py:60–118](../../research/presets.py) (TI fields + RI fields + OI fields on the same dataclass); [registry.py:39,53,77,…](../../research/registry.py) (free-form `hypothesis` strings on registry entries — TI prose in an RI surface).
+
+**Evidence against:** [presets.py:111–118](../../research/presets.py) explicitly *separates* TI by introducing `hypothesis_id` as the canonical bridge; the v3.15.3 catalog ([strategy_hypothesis_catalog.py:1–33](../../research/strategy_hypothesis_catalog.py)) is a *separate* artifact-backed TI surface; the layered architecture test ([test_orchestration_boundary.py](../../tests/unit/test_orchestration_boundary.py)) enforces no-leakage from strategy/registry to research/orchestration.
+
+**Score:**
+
+| Axis | Score | Notes |
+|---|---|---|
+| Explanatory power | partial | Covers ~40% of flagged anomalies (the multi-bundle preset, the registry `hypothesis` strings). Does not cover: registered-but-inert strategies; AGENTS.md self-violation; two-policy ambiguity; in-place mutation; registry self-acknowledgement of pending Phase-2 replacement. |
+| Repo coverage | partial | Touches preset + registry. Does not naturally explain the candidate / lifecycle / paper / shadow surfaces. |
+| Contradiction-minimization | partial | TI/RI lens does NOT explain why `hypothesis_id` already exists as a bridge — under TI/RI it should solve the problem; under TI/RI it does not. |
+| Migration usefulness | ✓ | Suggests a clear (but invasive) refactor: extract OI into a separate state surface, make `hypothesis_id` mandatory, retire registry `hypothesis` strings. |
+| Roadmap-v4 compatibility | partial | The v3.15.3 + v3.15.4 work already moves in this direction additively; the model proposes accelerating that, which is fine. But it cannot be executed without breaking byte-identity tests on the registry surface. |
+
+**Verdict:** TI/RI/OI is a **partial lens**. It explains some of the data but not most. Adopt it only as one slice; do not promote to dominant model.
+
+### §5.B — Lifecycle-semantics drift
+
+**Statement:** The system's various status enums and lifecycle objects (`HypothesisStatus`, `CandidateLifecycleStatus`, `PresetStatus`, `PresetClass`, campaign FSM states, paper readiness statuses, `screening_phase`, `pass_kind`) accreted across versions without a unified state machine. Each module reasons over its own scope but the *composition* of statuses is implicit.
+
+**Evidence in favor:**
+- [strategy_hypothesis_catalog.py:59](../../research/strategy_hypothesis_catalog.py): `HypothesisStatus = Literal["active_discovery", "planned", "disabled", "diagnostic"]`.
+- [candidate_lifecycle.py:31–48](../../research/candidate_lifecycle.py): `CandidateLifecycleStatus` 8-value enum.
+- [presets.py:56–57](../../research/presets.py): `PresetStatus = Literal["stable", "planned", "diagnostic", "not_executable"]` and `PresetClass = Literal["baseline", "diagnostic", "experimental"]`.
+- [campaign_registry.py](../../research/campaign_registry.py): campaign states `pending|leased|running|completed|failed|canceled|archived` plus outcomes `completed_with_candidates|completed_no_survivor|degenerate_no_survivors|technical_failure|research_rejection|...`.
+- [paper_readiness.py:69–73](../../research/paper_readiness.py): `READINESS_STATUSES = ("ready_for_paper_promotion", "blocked", "insufficient_evidence")`.
+- [presets.py:54](../../research/presets.py): `ScreeningPhase = Literal["exploratory", "standard", "promotion_grade"]`.
+- pass_kind values: `None | "standard" | "promotion_grade" | "exploratory"` (from [promotion.py:60–66](../../research/promotion.py)).
+
+**Anomalies covered:** Why does a hypothesis have a status, a preset have a status, a candidate have a status, a campaign have a status, a paper-readiness have a status, and a screening-phase exist — *all distinct*? Because each one was added in a different roadmap step. The composition is reasoned by humans reading code, not enforced by a unified machine.
+
+**Score:**
+
+| Axis | Score | |
+|---|---|---|
+| Explanatory power | ✓ | Covers ~70% of flagged anomalies. The "two-policy ambiguity" (X2.8) is fundamentally a lifecycle-state ambiguity: which module derives policy from which subset of statuses? |
+| Repo coverage | ✓ | Spans preset + catalog + registry + candidate_pipeline + campaign_* + paper_readiness + screening. |
+| Contradiction-minimization | ✓ | Explains why `_METADATA_ONLY_FAMILIES` exists ([strategy_hypothesis_catalog.py:90–96](../../research/strategy_hypothesis_catalog.py)) — it's a special-case to mediate between hypothesis-status semantics and registry-bundling semantics. |
+| Migration usefulness | partial | Suggests a unified state-machine document — but writing that document is itself the migration; the code may not need to change. |
+| Roadmap-v4 compatibility | ✓ | v3.16 (shadow) and v3.17 (live) only add more statuses to the lifecycle enum, deepening this drift. The model survives v4. |
+
+**Verdict:** **High explanatory power.** The lifecycle drift is real, repo-wide, and historically motivated.
+
+### §5.C — Ontology drift
+
+**Statement:** The meaning of core nouns — `family`, `screening_phase`, `pass_kind`, `candidate`, `evidence`, `falsification` — shifts between modules of different vintages. Multiple incompatible ontologies coexist, each correct in its module's local context.
+
+**Evidence in favor:**
+- [registry.py](../../research/registry.py) defines two coexisting "family" axes per entry: `family` (older: trend / mean_reversion / stat_arb) and `strategy_family` (newer v3.15.3: trend_following / mean_reversion / breakout / stat_arb / trend_pullback / volatility_compression_breakout). For `breakout_momentum` they diverge (`family="trend"` vs `strategy_family="breakout"`, lines 125–126).
+- "candidate" means at least three different things across modules: (a) a planned-screening dict ([candidate_pipeline.py:251–287](../../research/candidate_pipeline.py)), (b) a post-promotion record with `lifecycle_status` ([candidate_lifecycle.py:31–48](../../research/candidate_lifecycle.py)), (c) a paper-readiness input ([paper_readiness.py:76–93](../../research/paper_readiness.py)). The same word; three ontologies.
+- "evidence" appears in `screening_evidence_latest.v1.json` (per-candidate stage results), `campaign_evidence_ledger.jsonl` (event log), and `research_evidence_ledger.v1.json` (rolled-up). Three artifacts, three ontologies of "evidence."
+- `screening_phase` is on `Preset` ([presets.py:95](../../research/presets.py)); `pass_kind` is on a candidate / promotion call ([promotion.py:53,71](../../research/promotion.py)). They are partially synonymous (exploratory ↔ exploratory) but not mapped 1-to-1 — `pass_kind` adds `"standard"` and `"promotion_grade"` as separate values, while `screening_phase` does so too but from a different perspective.
+
+**Anomalies covered:** The "TI/RI conflation" framing fails to explain why the same word means different things in different modules. Ontology drift explains this directly: each migration step refined the ontology *locally* without retrofitting older modules.
+
+**Score:**
+
+| Axis | Score | |
+|---|---|---|
+| Explanatory power | ✓ | Covers `family` divergence; "candidate" plurality; "evidence" plurality; screening_phase/pass_kind near-redundancy. |
+| Repo coverage | ✓ | Repo-wide. |
+| Contradiction-minimization | ✓ | Particularly strong on the `family` vs `strategy_family` issue — a canonical ontology-drift example. |
+| Migration usefulness | partial | Suggests "freeze the ontology in a glossary" — useful but not a code migration. |
+| Roadmap-v4 compatibility | ✓ | v4 explicitly aims at canonicalization; this model anticipates it. |
+
+**Verdict:** **High explanatory power, especially for the noun-level confusion.** Composes naturally with §5.B.
+
+### §5.D — Migration-layer accumulation
+
+**Statement:** The repo evolved across at least 16 named v3.x roadmap steps (v3.5 → v3.15.15.6). Each layer left bridges, sidecars, and shims that an outside reader misreads as architectural confusion. What looks like a TI/RI conflation is often a "v3.5 wrote it that way; v3.15.3 added the right surface but didn't retire the older one because byte-identity."
+
+**Evidence in favor:**
+- [registry.py:202–211](../../research/registry.py): explicit comment that legacy `trend_pullback` and `trend_pullback_tp_sl` "stay registered as `strategy_family=\"trend_following\"` and are intentionally NOT part of the v3.15.3 hypothesis-catalog bridge." Migration discipline encoded as a comment.
+- [presets.py:7–21](../../research/presets.py): module docstring describes the v3.10 / v3.11 / ADR-011 layering of preset metadata.
+- [strategy_hypothesis_catalog.py:7–14](../../research/strategy_hypothesis_catalog.py): "v3.15.4: at least one hypothesis carries status='active_discovery'" — the strict invariant was added in a *separate* version after v3.15.3 introduced the catalog.
+- [campaign_templates.py:262–275](../../research/campaign_templates.py): comment explains why hypothesis-aware templates were added in v3.15.3 with empty allowed-status tuples on baselines: *"keeps the campaign_templates_latest.v1.json sidecar byte-identical for the baseline rows."*
+- [presets.py:91–94](../../research/presets.py): `screening_phase` default = `"promotion_grade"` is a *safety net* for new presets that forget the field; AST test enforces explicitness.
+- [presets.py:22–26](../../research/presets.py): "diagnostic_only / excluded_from_candidate_promotion / excluded_from_daily_scheduler are hard flags honoured by the promotion layer and the scheduler unit. The safe default on missing metadata is 'excluded' — see ADR-011 §9."
+
+**Anomalies covered:** Most "smells" are bridges. The five-flag diagnostic encoding is layered metadata. The two-policy modules are an old + new pair. The legacy `trend_pullback` shadowing `trend_pullback_v1` is *deliberate*. The `family` vs `strategy_family` divergence is older + newer ontology coexisting.
+
+**Score:**
+
+| Axis | Score | |
+|---|---|---|
+| Explanatory power | ✓ | Covers the largest fraction of flagged anomalies — perhaps 80% — when applied. |
+| Repo coverage | ✓ | Repo-wide; the migration timeline (§6) is the actual structure. |
+| Contradiction-minimization | ✓ | Reframes most "wrongs" as "intentional bridges, not yet retired." Reduces the residual unexplained set. |
+| Migration usefulness | ✓ | Suggests a *retirement timeline* per bridge — a legitimate migration plan. |
+| Roadmap-v4 compatibility | ✓ | v3.16/v3.17 are the next layers; the model survives them. |
+
+**Verdict:** **Highest explanatory power of all candidates.** Most of what looks "wrong" is actually "in flight." The audit cannot ignore this.
+
+### §5.E — Runtime / artifact duality
+
+**Statement:** Concepts have two authorities: a runtime in-memory representation and a frozen artifact representation. Disagreements between the two are sometimes harmless, sometimes load-bearing, sometimes dangerous — but the *framework* for distinguishing them is implicit.
+
+**Evidence in favor:**
+- A candidate is (a) a dict in `candidate_pipeline.plan_candidates()` and (b) a row in `candidate_registry_latest.v1.json`. The dict mutates during the run (e.g. `item["validation"] = ...`); the artifact is byte-pinned.
+- Hypothesis status is (a) a value on `StrategyHypothesis.status` at runtime and (b) a row in `strategy_hypothesis_catalog_latest.v1.json` (the artifact). The artifact is regenerated each run; mismatch can occur if the run reads a stale catalog.
+- `screening_evidence` is (a) a per-candidate event during the run and (b) the `screening_evidence_latest.v1.json` artifact. Per [screening_evidence.py:17–27](../../research/screening_evidence.py): "screening_evidence_latest.v1.json is **not** a frozen contract."
+- [test_orchestration_artifact_truth.py](../../tests/unit/test_orchestration_artifact_truth.py) — the test name itself signals an explicit awareness that "artifact truth" needs validation.
+
+**Anomalies covered:** Why the `fb_<sha1prefix>` fallback exists ([screening_evidence.py:18–24](../../research/screening_evidence.py)); why two policy modules read the same ledger differently; why falsification post-promotion is potentially dangerous (it mutates the runtime view but the artifact may already have been written).
+
+**Score:**
+
+| Axis | Score | |
+|---|---|---|
+| Explanatory power | partial | Covers ~30% of anomalies. Strong on the candidate/evidence/falsification surfaces; weak on the registry/preset surfaces. |
+| Repo coverage | partial | Mainly the run_research / screening / paper / promotion / falsification surfaces. |
+| Contradiction-minimization | partial | Adds a useful axis but doesn't subsume the others. |
+| Migration usefulness | partial | Suggests "make every authority explicit" — useful but expensive to retrofit. |
+| Roadmap-v4 compatibility | ✓ | v4 (per the doctrine) emphasizes evidence-first, which this model directly supports. |
+
+**Verdict:** **Useful sub-model.** Composes with §5.B (lifecycle drift) and §5.G (research-vs-operations).
+
+### §5.F — Compatibility-preservation layering
+
+**Statement:** Frozen contracts, byte-identity tests, the `live_eligible=False` pin, the synthetic artifact contract harness, and the COL no-touch invariant force the architecture into shapes that look messy from the outside but are *intentional* compatibility scaffolding. What we read as "ugly" is often "frozen-correctness."
+
+**Evidence in favor:**
+- [presets.py:91–94](../../research/presets.py): default `screening_phase="promotion_grade"` exists *because* AST test pins explicitness for old presets, but new ones might forget — the default is the floor, not the truth.
+- [campaign_templates.py:262–275](../../research/campaign_templates.py): empty `require_hypothesis_status` tuple on baselines is documented as preserving byte-identity.
+- [registry.py:6–8](../../research/registry.py): "AGENTS.md rules violation - scheduled for Phase 2 replacement." The violation persists *because* swapping it out atomically would break Cartesian-sweep-dependent test pins.
+- The 5-field diagnostic encoding on `crypto_diagnostic_1h` ([presets.py:500–504](../../research/presets.py)) is partly explained by needing each field to be load-bearing for a different downstream consumer — the multiplicity is consumer-driven, not authorial.
+
+**Anomalies covered:** Why the `family` field persists alongside `strategy_family`; why registry comments contain TI prose; why the legacy strategies stay `enabled=True`; why duplicated policy modules exist.
+
+**Score:**
+
+| Axis | Score | |
+|---|---|---|
+| Explanatory power | partial | Covers ~25% — specifically the cases where "ugly" exists *because* a test or a frozen contract requires it. |
+| Repo coverage | partial | Concentrated in registry + presets + campaign_templates. |
+| Contradiction-minimization | ✓ | Strong on flagged items that turn out to have a "do not change, byte-identity binding" verdict. |
+| Migration usefulness | ✗ | By definition, this model says "don't migrate." Useful as a *constraint* on §5.A/B/C/D migrations. |
+| Roadmap-v4 compatibility | ✓ | v4 shadow + live add more frozen contracts; this model anticipates them. |
+
+**Verdict:** **Constraint, not driver.** Cannot be the dominant model (it's a "do nothing" model) but must constrain every other model's migration prescriptions.
+
+### §5.G — Research-vs-operations authority confusion
+
+**Statement:** Decisions are made by overlapping authorities — the strategy registry, the hypothesis catalog, the preset, the campaign-funnel-policy, the campaign-policy, the campaign-launcher, the run_research orchestrator, the paper-readiness gate, the operator (via systemd), the COL hourly tick, the scheduler. The boundary between "research authority" (catalog says active_discovery) and "operations authority" (scheduler runs preset) is asserted in doctrine but not codified.
+
+**Evidence in favor:**
+- [strategy_hypothesis_catalog.py:5–6](../../research/strategy_hypothesis_catalog.py): "The v3.15.2 Campaign Operating Layer reads this catalog through `research.campaign_policy` to decide which hypotheses are eligible for autonomous campaign spawning." → catalog → campaign_policy → COL is one authority chain.
+- [campaign_funnel_policy.py:1–10](../../research/campaign_funnel_policy.py): "Pure module: NO I/O, NO subprocess, NO tracker calls. The launcher consumes the returned decisions and applies them" → funnel_policy → campaign_launcher is another chain, partially overlapping.
+- [presets.py:22–26](../../research/presets.py): "diagnostic_only / excluded_from_candidate_promotion / excluded_from_daily_scheduler are hard flags honoured by the promotion layer and the scheduler unit" → preset → promotion / scheduler is a third chain.
+- [paper_readiness.py:6–7](../../research/paper_readiness.py): paper readiness has its *own* gate logic.
+
+**Anomalies covered:** The "two-policy ambiguity" (X2.8); why `crypto_diagnostic_1h` needs *five* flags (each one is read by a different authority); why `excluded_from_daily_scheduler` exists alongside `enabled` (different authorities, different scopes).
+
+**Score:**
+
+| Axis | Score | |
+|---|---|---|
+| Explanatory power | ✓ | Strong on the policy / scheduler / promotion / paper-readiness surfaces. |
+| Repo coverage | partial | Concentrated in the orchestration tier. |
+| Contradiction-minimization | ✓ | Particularly strong on five-flag-diagnostic and the two-policy modules. |
+| Migration usefulness | ✓ | Suggests writing an "authority map" doctrine. |
+| Roadmap-v4 compatibility | ✓ | v4 + v3.17 add more authorities (live broker, position reconciler); model survives. |
+
+**Verdict:** **High explanatory power for the policy/operations layer.** Composes with §5.A and §5.D.
+
+### §5.H — Ranking & composition
+
+| Model | Explanatory power | Repo coverage | Verdict |
+|---|---|---|---|
+| §5.A — TI/RI/OI | partial | partial | One slice; not dominant. |
+| §5.B — Lifecycle drift | ✓ | ✓ | High. |
+| §5.C — Ontology drift | ✓ | ✓ | High. |
+| §5.D — Migration-layer accumulation | ✓ | ✓ | **Highest.** |
+| §5.E — Runtime/artifact duality | partial | partial | Useful sub-model. |
+| §5.F — Compatibility-preservation | partial | partial | Constraint, not driver. |
+| §5.G — Research-vs-operations authority | ✓ | partial | High for the policy layer. |
+
+**The audit adopts a composition, not a single model.** Specifically:
+
+- **§5.D (migration-layer accumulation)** is the dominant frame. Most anomalies are "in flight" not "wrong."
+- **§5.B (lifecycle drift)** and **§5.C (ontology drift)** are the secondary structural lenses for the *type-system*-level anomalies.
+- **§5.G (authority confusion)** is the lens for the *policy/operations*-level anomalies.
+- **§5.A (TI/RI/OI)** is a *partial* lens on the preset+registry surfaces — useful where it applies, but not the dominant frame.
+- **§5.E (runtime/artifact duality)** is a sub-model under §5.B; epistemic-integrity work in §8 reuses it.
+- **§5.F (compatibility preservation)** is the universal constraint on every recommended migration.
+
+**This composition is the audit's central conceptual contribution.** Sections §6–§19 build on it directly. The TI/RI/OI lens is retained as a section heading where useful but is **not** smuggled in elsewhere (per verification check #16).
+
+---
+
+## §6 — Historical Layering & Migration Seams
+
+The migration timeline below is reconstructed from `git log` (50 most recent commits visible at audit time), `docs/handoffs/`, the ADRs, and version-tagged comments throughout the code. Each row situates a layer's residue in the codebase and classifies it on the M10 vocabulary.
+
+### §6.1 — Reconstructed timeline
+
+| Roadmap layer | Approx. commit | What it added | What it bridged | Visible residue today | M10 classification |
+|---|---|---|---|---|---|
+| pre-v3.5 | (pre-history) | Original strategy registry, free-form hypothesis prose, RSI/Bollinger/EMA/breakout legacy factories | — | The 4 unregistered factories (fear_greed, earnings, orb, polymarket_expiry) and the legacy `trend_pullback` / `trend_pullback_tp_sl` / `bollinger_regime` / `rsi` / `bollinger_mr` / `breakout_momentum` registry entries. The `family` field on registry entries (older "trend / mean_reversion" axis). | `historical layering artifact` (mostly), `architectural mistake` for the dead factories that were never deleted |
+| v3.5 | (pre-history) | Thin-strategy contract; `func(df, features)` signature; feature layer; first 3 thin baselines (sma_crossover, zscore_mean_reversion, pairs_zscore) | Allowed older strategies to coexist with the new contract by adding `contract_version` and a thin/legacy split | Legacy strategies untouched; thin strategies marked `contract_version="1.0"`; bytewise pin tests. | `intentional migration bridge` |
+| v3.6 | (pre-history) | Multi-asset loader; `pairs_zscore` enabled with `reference_asset="ETH-EUR"` and `hedge_ratio=1.0` (single two-leg baseline, scope-locked). | The "single-leg" assumption of the older registry was retrofitted to two-leg via `position_structure="spread"` | Comment block at [registry.py:169–177](../../research/registry.py): *"reference_asset is the single two-leg baseline config (scope lock: not a pair universe, not selection)."* | `frozen-contract preservation mechanism` (the comment is doctrine-load-bearing for the v3.6 scope lock) |
+| v3.7 | (pre-history) | Fitted-feature abstraction (fold-aware fit/transform); `spread_zscore_ols` fitted feature on pairs_zscore | Added without removing the plain `spread_zscore` feature | `pairs_zscore` carries `use_fitted_hedge_ratio` toggle; both feature paths coexist | `deliberate additive transition` |
+| v3.9 | (pre-history; ADR-010) | Orchestration boundary lint; `test_orchestration_boundary.py`; pipeline scheduling formalism | Asserted layered architecture without rewriting older modules | The lint test still runs; the layered boundary is intact today | `frozen-contract preservation mechanism` |
+| v3.10 | (pre-history) | First-class research presets; `ResearchPreset` dataclass; preset CLI | Introduced presets *without* breaking the registry surface — presets reference registered strategies by name | `presets.py` module docstring [lines 1–27](../../research/presets.py); `_DEFAULT_DAILY_PRESET = "trend_equities_4h_baseline"` | `deliberate additive transition` |
+| v3.11 | (pre-history; ADR-011) | Hypothesis metadata fields on presets (`rationale`, `expected_behavior`, `falsification`, `enablement_criteria`); `preset_class` (baseline/diagnostic/experimental); diagnostic flags | Added rich metadata to presets without touching registry | The 5-field diagnostic encoding on `crypto_diagnostic_1h` is a v3.11 artifact | `deliberate additive transition` (with 5 fields tracking different consumers) |
+| v3.12 | (pre-history) | Candidate Promotion Framework; `CandidateLifecycleStatus` enum; `FULL_LIFECYCLE_GRAPH`; v3.12 active subset = 3 of 8 statuses; `LEGACY_MAPPING` for v3.11 verdicts | Mapped the legacy v3.11 promotion verdicts (rejected/needs_investigation/candidate) into the new lifecycle | [candidate_lifecycle.py:31–48](../../research/candidate_lifecycle.py) (8 statuses, 3 active, 5 reserved) | `intentional migration bridge` (LEGACY_MAPPING) + `deliberate additive transition` (5 reserved statuses) |
+| v3.13 | (pre-history) | Regime intelligence sidecar; regime_classifier / regime_diagnostics / regime_gating modules | Added regime tagging without touching strategy-level logic | The `regime_filter="bollinger_regime_derived"` string label on `trend_regime_filtered_equities_4h` ([presets.py:268](../../research/presets.py)) | `deliberate additive transition` |
+| v3.14 | (pre-history) | Portfolio / sleeve research; correlation diagnostics; portfolio_diagnostics_latest.v1.json sidecar | Added sleeve-level reasoning without touching candidate-level | sleeve_registry.py, portfolio_*sidecars | `deliberate additive transition` |
+| v3.15 (handoff) | docs/handoffs/v3.15-to-v3.16.md | Paper validation engine; venue mapping (Bitvavo / IBKR / Polymarket); paper_divergence; paper_readiness; `live_eligible=False` hard pin | Bridged research → paper without enabling live | `MIN_PAPER_OOS_DAYS=60`, `MIN_PAPER_SHARPE_FOR_READY=0.3` thresholds; `BLOCKING_REASONS` / `WARNING_REASONS` closed taxonomies | `frozen-contract preservation mechanism` (the live-pin) + `deliberate additive transition` (paper layer) |
+| v3.15.2 | (pre-history) | Autonomous Campaign Operating Layer; `CAMPAIGN_TEMPLATES` frozen catalog; campaign FSM; campaign_evidence_ledger; 100% no-touch | Replaced operator-driven scheduling with policy-driven — without changing what *can* run | 30 templates auto-generated; `templates_latest.v1.json` byte-pinned for baseline rows | `frozen-contract preservation mechanism` + `deliberate additive transition` |
+| v3.15.3 | a40175e (and predecessors); ADR-013 | Strategy hypothesis catalog; `HypothesisStatus` closed enum; `hypothesis_id` bridge field on `ResearchPreset` (default `None`) | Introduced the canonical TI surface without retiring registry's `hypothesis` strings or legacy preset bundles | The 4 hypothesis-aware presets carry `hypothesis_id`; 3 baselines do not (legacy compat) | `deliberate additive transition` (the right TI extraction) |
+| v3.15.4 | a40175e | Strict catalog validation: ≥1 active_discovery, fully wired (executable strategy, bounded grid, eligible_campaign_types, canonical failure modes); `validate_active_discovery_preset_bridges()` cross-module check; second active_discovery (`volatility_compression_breakout_v0`) | Closed the loophole that allowed `active_discovery` rows without executable bindings | The `_METADATA_ONLY_FAMILIES` set ([strategy_hypothesis_catalog.py:90–96](../../research/strategy_hypothesis_catalog.py)) — explicitly carves out non-executable rows | `temporary compatibility seam` (`_METADATA_ONLY_FAMILIES` is documented as eventually-removable as families become executable) |
+| v3.15.5 | 26ecd71 | Synthetic Artifact Contract Harness in `tests/functional/`; observability scenarios; static import-surface test | Hardened the diagnostics layer's read-only invariant against drift | `tests/functional/test_static_import_surface.py` enforces diagnostics imports nothing from `research.{campaign_*, candidate_*, screening_*, ...}` | `frozen-contract preservation mechanism` |
+| v3.15.6 | (pre-history; preset_phase tests) | `ScreeningPhase` literal added to `ResearchPreset` (orthogonal to legacy `ScreeningMode`); AST test pins explicitness of `screening_phase=...` keyword | Introduced funnel-stage classification without changing screening criteria (runtime-inert in v3.15.6) | [presets.py:38–53](../../research/presets.py) extensive comment defending the orthogonality | `deliberate additive transition` (v3.15.7 will dispatch on it) |
+| v3.15.7 | (visible in promotion.py) | Phase-aware screening criteria dispatch; promotion classification dispatches on `pass_kind == "exploratory"`; `EXPLORATORY_*` thresholds in `screening_criteria` | Activated the v3.15.6 seam | [promotion.py:60–76](../../research/promotion.py) (the "exploratory" branch) | `deliberate additive transition` |
+| v3.15.8 | (pre-history) | `SamplingPlan` with sampling-envelope semantics; `SCREENING_PARAM_SAMPLE_LIMIT=3` constant | Bounded the legacy Cartesian sweep without removing it | The constant and the plan coexist with the older grid expansion | `temporary compatibility seam` |
+| v3.15.9 | dedfe7e, cba3b6c, 51b6f93, 8c59ffc, 23fdbca | `screening_evidence_latest.v1.json` non-frozen sidecar; per-candidate `pass_kind`, `near_pass`, `evidence_fingerprint`; `fb_<sha1prefix>` identity fallback | Made screening evidence inspectable without making it part of the frozen contract | [screening_evidence.py:1–33](../../research/screening_evidence.py) module docstring | `deliberate additive transition` |
+| v3.15.10 | ed0b764, 8fcc881, 3aa1424, 05332bd, 3d9674e | Pure `campaign_funnel_policy` module; 4 funnel ledger event types; launcher integration; technical-failure safety pins | Introduced the *new* policy surface alongside the older `campaign_policy` | Both modules coexist (619 + 862 lines); funnel_policy is "pure"; campaign_policy is older and thicker | `deliberate additive transition` (with `campaign_policy` not yet retired — *temporary compatibility seam*) |
+| v3.15.11 | 92dbc5f, 454b71a, 27af607, 8a600e4, 87f160d, 74f326c, fe7a1a2, abf2df3 | Research evidence ledger; viability metrics; dead-zone detection; stop condition engine; information gain scoring; advisory-only research intelligence | All advisory; hard pin = nothing in this release writes to a frozen contract | `evidence_ledger_latest.v1.json` under `research/campaigns/evidence/` | `deliberate additive transition` (advisory) |
+| v3.15.12 | 6ada72b, ff34ba9, cbf8a54, 826bfec, 2a23a0d, 46f9fa3 | Funnel spawn proposer (advisory shadow mode); API + frontend card | Shadow-mode (advisory only) — does not enqueue spawns yet | `funnel_spawn_proposer.py` | `deliberate additive transition` (shadow) |
+| v3.15.13 | 2228645, c463d14 | Discovery sprint orchestrator (artifact-only) | Sprint profiles (e.g. crypto_exploratory_v1); routing layer | `discovery_sprint.py`; uncommitted `research/discovery_sprints/` directory in `git status` | `deliberate additive transition` |
+| v3.15.14 | 46b6e38, 7e50e98 | Sprint-aware COL routing | COL ↔ sprint-profile binding | Comments in `presets.py` referencing `crypto_exploratory_v1` ([line 429](../../research/presets.py)) | `deliberate additive transition` |
+| v3.15.15 | ec908f6, 6ebed8f | `vol_compression_breakout_crypto_4h` preset; template wiring; observability safeguards (4h insufficient_trades sidecar, observation-only) | Multi-timeframe coverage of the same active_discovery hypothesis | The 4h preset adds 5 templates and bridges to the same `volatility_compression_breakout_v0` catalog row; explicit comment in [campaign_templates.py:262–275](../../research/campaign_templates.py) | `deliberate additive transition` |
+| v3.15.15.2 | d09358b, 474fc8f | Discovery observability MVP (read-only) | Read-only instrumentation | `research/diagnostics/` MVP | `frozen-contract preservation mechanism` (read-only) |
+| v3.15.15.3 | 3652b33, 0ec715a | Observability frontend integration (thin surface) | Thin surface only; no backend logic changes | Frontend-only; out of audit scope | `deliberate additive transition` |
+| v3.15.15.4 | a40175e, 903c1d2 | Diagnostics taxonomy patch (additive, behavior-pure) | Closed-vocabulary failure-mode codes for diagnostics | `research/strategy_failure_taxonomy.py` (CANONICAL_FAILURE_CODES) | `deliberate additive transition` |
+| v3.15.15.5 | 26ecd71, cde100f | Synthetic artifact contract harness (functional, opt-in) | See v3.15.5 entry above (renumbered/reissued with stricter scope) | `tests/functional/` | `frozen-contract preservation mechanism` |
+| v3.15.15.6 | 1118212, 00c187b | Diagnostics evidence completeness; failure-modes enrichment | Read-only instrumentation tightening | `research/observability/failure_modes_latest.v1.json` (enriched) | `frozen-contract preservation mechanism` |
+
+### §6.2 — Implications for the audit
+
+**Implication 1 — most "smells" are bridges in flight.** Of the 12 Phase-2 violations, at least 6 are explicitly anchored to v3.15.x layers that are still landing. The strong-form readings of "wrongly modeled" repeatedly fail because the *next* layer is the planned fix, but it hasn't merged yet.
+
+**Implication 2 — `_METADATA_ONLY_FAMILIES` is a temporary seam, not an ontology error.** The set of metadata-only families ([strategy_hypothesis_catalog.py:90–96](../../research/strategy_hypothesis_catalog.py)) shrinks every time a planned hypothesis becomes executable. v3.15.4 *removed* `volatility_compression_breakout` from this set (now active_discovery); `regime_diagnostics`, `atr_adaptive_trend`, `dynamic_pairs`, `multi_asset_trend_sleeve`, `cross_sectional_momentum` remain. The Phase-2 reading of "regime_diagnostics is mislabeled-as-hypothesis" is `partially_confirmed` but is *exactly* the kind of seam this set exists to manage.
+
+**Implication 3 — `campaign_policy.py` (older) has not been retired by `campaign_funnel_policy.py` (newer).** Per v3.15.10 commits, the new pure module was added; the older module was not deprecated explicitly. This is `temporary compatibility seam` per M10. A Phase-3 migration step (§19) is to settle this.
+
+**Implication 4 — three tier-1 baselines exist; only two are operationally exercised.** v3.5 introduced `sma_crossover`, `zscore_mean_reversion`, `pairs_zscore`. v3.6 enabled `pairs_zscore` with the scope lock. `zscore_mean_reversion` is registered + thin-contract + bytewise-pinned but is not in any preset's bundle. This is `historical layering artifact` per M10 — no preset in the v3.10/v3.11/v3.15.x cycles has needed it; it persists for byte-identity. Whether to retire it is a §19 question.
+
+---
+
+## §7 — Ontology & Semantic Ownership
+
+This section asks what each major object IS, ontologically — distinct from how it is currently coded. The audit then determines whether the codebase carries a stable ontology, multiple incompatible ontologies coexisting (per §5.C), or ontology drift between versions (per §5.B + §5.D).
+
+For each object, the audit answers eight questions:
+
+1. **Identity** — what makes two instances "the same"?
+2. **Lifecycle ownership** — who creates, mutates, terminates?
+3. **Semantic responsibility** — which concept does the object embody?
+4. **Evidence ownership** — which artifact carries the truth about it?
+5. **Transition authority** — who is allowed to flip a status?
+6. **Source-of-truth boundaries** — when authorities disagree, who wins?
+7. **Mutability** — does the object forbid mutation post-creation?
+8. **Runtime-state vs artifact-state authority** — what's true in memory vs on disk?
+
+### §7.1 — Strategy
+
+| Question | Answer (current) | Evidence-strength |
+|---|---|---|
+| What IS a strategy? | A pure signal generator: a function that takes a price/feature dataframe and returns a position series. | `direct` ([agent/backtesting/strategies.py](../../agent/backtesting/strategies.py); contract_version="1.0" on thin strategies) |
+| Identity | Currently: the `name` string in the registry entry. There is no separate immutable strategy ID; rebinding `name → factory` would silently change identity. | `direct` ([registry.py:26–266](../../research/registry.py)) |
+| Lifecycle ownership | Code-owner only; no runtime authority can mutate. | `direct` |
+| Semantic responsibility | Trading-intelligence (the bet's mathematical core). The free-form `hypothesis` field on each registry entry is TI prose — but the canonical TI is now the catalog. | `direct` |
+| Evidence ownership | Registry is the executable surface; catalog is the *intent* surface. They overlap on TI prose. **No single artifact is canonical for "this strategy exists."** | `direct` (multiple authorities) |
+| Transition authority | "Enabled" is set on the registry entry. No transition machinery — strategies are either registered+enabled or absent. | `direct` |
+| Source-of-truth boundaries | When registry says `enabled=True` but no preset bundles it (`zscore_mean_reversion`, `bollinger_regime`, `trend_pullback_tp_sl`), which authority wins? **Undefined.** Operationally the registry says "yes, this is investigatable"; the preset layer says "but nothing is investigating it." | `direct` (the three registered-but-inert strategies) |
+| Mutability | Frozen at module-import time (Python module global). | `direct` |
+| Runtime / artifact authority | Registry is the runtime authority; the strategy registry is *not* serialized as a frozen artifact (the strategy IDs land in `research_latest.json` rows but the registry itself is code, not an artifact). | `direct` |
+
+**Ontology verdict:** Strategy is a **stable ontology** at the type level (it's a function with a fixed signature). It has **soft authority drift**: the `name` field is identity, but the registry's `enabled` flag and the preset layer's `bundle` membership offer two competing senses of "exists in the research engine." The drift is a §5.D (migration) artifact: the registry pre-dated bundle-driven research; nothing has retired the older "enabled" semantic.
+
+### §7.2 — Hypothesis
+
+| Question | Answer (current) | Evidence-strength |
+|---|---|---|
+| What IS a hypothesis? | A first-class research direction with explicit status, expected_failure_modes, falsification_criteria, and an executable strategy_family binding. | `direct` ([strategy_hypothesis_catalog.py:99–120](../../research/strategy_hypothesis_catalog.py)) |
+| Identity | The `hypothesis_id` string. The catalog enforces uniqueness at module import. | `direct` |
+| Lifecycle ownership | Catalog is owned by code (frozen `tuple` constant). v3.15.4 strict validation is enforced at module import. | `direct` |
+| Semantic responsibility | Trading-intelligence (the *named* bet). Distinct from a strategy: a hypothesis can have multiple strategy implementations; a strategy can be the implementation of a hypothesis. | `direct` |
+| Evidence ownership | `research/strategy_hypothesis_catalog_latest.v1.json` (artifact) + the in-code `STRATEGY_HYPOTHESIS_CATALOG` constant. | `direct` |
+| Transition authority | `HypothesisStatus` flips (active_discovery ↔ planned ↔ disabled ↔ diagnostic) are theoretically owned by "campaign verdicts feeding the catalog." In practice today: code-owner only (no automatic flips visible). | `inferred` (no automatic flip mechanism found in §3 verification) |
+| Source-of-truth boundaries | Catalog `status` is the canonical TI status. Preset's `hypothesis_id` is a foreign-key reference. v3.15.4's `validate_active_discovery_preset_bridges()` enforces consistency at startup. | `direct` |
+| Mutability | Frozen dataclass; module-level constant tuple. | `direct` |
+| Runtime / artifact authority | Code is canonical; artifact is regenerated. | `direct` |
+
+**Ontology verdict:** Hypothesis is the **cleanest ontology in the system.** Closed status enum, frozen dataclass, identity is explicit (`hypothesis_id`), validation is strict at module import. Where hypothesis-related anomalies appear (e.g. "regime_diagnostics_v1 mislabeled-as-hypothesis"), the *catalog itself* already has a special case (`_METADATA_ONLY_FAMILIES`) that mediates between strict-active-discovery semantics and metadata-only entries. This is a deliberate seam, not an error.
+
+### §7.3 — Preset
+
+| Question | Answer (current) | Evidence-strength |
+|---|---|---|
+| What IS a preset? | A research-protocol binding: "investigate this strategy bundle on this universe at this timeframe with this screening profile and this cost mode." | `direct` ([presets.py:60–118](../../research/presets.py)) |
+| Identity | The `name` field. Frozen tuple `PRESETS` is the catalog. | `direct` |
+| Lifecycle ownership | Code-owner only (frozen dataclass, frozen tuple). Runtime never mutates. | `direct` |
+| Semantic responsibility | Three layers on the same dataclass: (a) RI protocol (`screening_mode`, `screening_phase`, `cost_mode`, `regime_filter`, `regime_modes`); (b) TI bridge (`hypothesis`, `hypothesis_id`, `bundle`, `optional_bundle`, `falsification`, `expected_behavior`); (c) OI flags (`enabled`, `status`, `diagnostic_only`, `excluded_from_daily_scheduler`, `excluded_from_candidate_promotion`, `preset_class`, `backlog_reason`, `enablement_criteria`). | `direct` |
+| Evidence ownership | `research/presets.py` (in-code) + `presets_latest.v1.json` (artifact, if generated; not verified read-only). | `direct` (in-code); `unverifiable` (artifact regeneration) |
+| Transition authority | None at runtime. PR-only. | `direct` |
+| Source-of-truth boundaries | When the preset's `enabled=False` and the strategy bundled in it is `enabled=True` (the `pairs_zscore` ↔ `pairs_equities_daily_baseline` case), the *preset* wins (no campaign templates exist for it; see §4.4). | `direct` |
+| Mutability | Frozen dataclass. | `direct` |
+| Runtime / artifact authority | Code is canonical. | `direct` |
+
+**Ontology verdict:** Preset is **the most multi-purpose object in the system**. It carries TI / RI / OI fields *intentionally* per the v3.10 / v3.11 / v3.15.3 layering — each version added more, none removed older. Whether this is a §5.A (TI/RI/OI conflation) problem depends on whether the multi-purpose-ness causes wrong outcomes. The audit finds no `dangerous` outcome from the conflation; it finds `aesthetically imperfect` packaging. The 6-flag diagnostic encoding on `crypto_diagnostic_1h` is the worst case and is `aesthetically imperfect but operationally correct` (§15) because each flag is read by a different downstream authority (§5.G).
+
+### §7.4 — Campaign
+
+| Question | Answer (current) | Evidence-strength |
+|---|---|---|
+| What IS a campaign? | A single research run instance: a templated invocation of `run_research.py` for a specific (preset, campaign_type, lineage) tuple. | `direct` ([campaign_templates.py:1–18](../../research/campaign_templates.py); [campaign_registry.py](../../research/campaign_registry.py)) |
+| Identity | A `campaign_id` (string); plus `col_campaign_id` for COL-driven runs (preferred). v3.15.10's funnel policy uses `col_campaign_id` first, falls back to `campaign_id`. | `direct` ([campaign_funnel_policy.py:40–46](../../research/campaign_funnel_policy.py)) |
+| Lifecycle ownership | The Campaign Operating Layer (COL) is the canonical mutator. campaign_launcher applies funnel decisions, transitions state. | `direct` |
+| Semantic responsibility | Operational-intelligence (when does what run?) + research-protocol-instance (this is *one execution* of a preset's protocol). | `direct` |
+| Evidence ownership | `campaign_evidence_ledger.jsonl` (append-only); `campaign_registry_latest.v1.json` (status snapshot). | `direct` |
+| Transition authority | COL only. Spawn requests come from `campaign_funnel_policy` (newer, pure) + `campaign_policy` (older). | `direct` (with §6 ambiguity on which policy module is canonical) |
+| Source-of-truth boundaries | When the registry says "running" and the ledger doesn't yet have a `started` event, which is canonical? Per [campaign_funnel_policy.py:53–55](../../research/campaign_funnel_policy.py): the registry record is canonical for technical-failure decisions; the ledger is canonical for funnel-decision provenance. **Two-axis truth.** | `direct` |
+| Mutability | The campaign record can transition (registry holds a current snapshot); the *ledger* is append-only (events are immutable). | `direct` |
+| Runtime / artifact authority | Both the registry artifact and the ledger artifact are canonical for different scopes. | `direct` |
+
+**Ontology verdict:** Campaign is **a clean ontology with two-axis truth**: registry-snapshot (current state) + ledger (append-only history). Both are canonical, for different scopes. The two-policy ambiguity (§5.G) is *not* a campaign-ontology problem — it's a policy-derivation problem on top of a clean campaign ontology.
+
+### §7.5 — Candidate
+
+| Question | Answer (current) | Evidence-strength |
+|---|---|---|
+| What IS a candidate? | A `(strategy_name, asset, interval, parameter_grid)` tuple flowing through a campaign's pipeline; it accumulates fields per stage (planning → dedupe → fit_prior → eligibility → screening → validation → promotion → paper_readiness). | `direct` ([candidate_pipeline.py:251–287](../../research/candidate_pipeline.py)) |
+| Identity | `candidate_id`: a sha256 hash of an identity payload `{strategy_name, asset, asset_type, asset_class, interval, position_structure, initial_lane_support, [reference_asset]}`. | `direct` ([candidate_pipeline.py:240–252](../../research/candidate_pipeline.py)) |
+| Lifecycle ownership | The pipeline stages mutate the dict in-place at multiple points: deduplicate ([line 297](../../research/candidate_pipeline.py)), apply_fit_prior ([line 351](../../research/candidate_pipeline.py)) — which deepcopies first, but then mutates the copy — , validation ([run_research.py:3019](../../research/run_research.py)). | `direct` |
+| Semantic responsibility | Research-intelligence (this run's verdict on this strategy/asset/params). | `direct` |
+| Evidence ownership | At least three artifacts: `run_candidates_latest.v1.json` (runtime snapshot), `screening_evidence_latest.v1.json` (screening-stage rich evidence), `candidate_registry_latest.v1.json` (frozen post-promotion verdict). | `direct` |
+| Transition authority | Each pipeline stage is the local authority for its own field group. No global state machine: a "promoted" candidate is one whose `validation.status == "validated"` AND `promotion verdict == candidate`. | `direct` (composed from stage outputs) |
+| Source-of-truth boundaries | The frozen `candidate_registry_latest.v1.json` is canonical for "promoted" status post-run. The transient `current_status` field on the dict during the run is canonical *during* the run only. v3.12 introduced `CandidateLifecycleStatus` to formalize the post-run state — but only 3 of 8 statuses are active at runtime. | `direct` |
+| Mutability | Mutated in place during run ([candidate_pipeline.py:297, 351](../../research/candidate_pipeline.py); [run_research.py:3019](../../research/run_research.py)). Some stages deepcopy first; others (validation) do not. | `direct` |
+| Runtime / artifact authority | Runtime is mutable; artifact is frozen (per stage). | `direct` |
+
+**Ontology verdict:** Candidate is the **most ontologically-loaded object in the system**, and it has **partial reification**:
+
+- *Identity*: cleanly defined (sha256 of identity payload). `direct`.
+- *Status enum*: defined (`CandidateLifecycleStatus`) but only 3 of 8 statuses active at runtime — the rest are reserved for v3.15+ phases.
+- *Schema*: implicit dict with documented structure ([candidate_pipeline.py:251–287](../../research/candidate_pipeline.py)). Not a frozen dataclass.
+- *Mutation semantics*: mixed. Some stages `deepcopy + mutate`; validation does in-place mutation. Per the M9 vocabulary this is `aesthetically imperfect`.
+
+Phase-2 framing of "must reify Candidate as a dataclass" is **partially correct**: the *status enum* IS reified; the *dict schema* is not; the *mutation semantics* is not. The reification is mid-rollout (v3.12 active subset). This is `intentional migration bridge` per M10.
+
+### §7.6 — Evidence
+
+| Question | Answer (current) | Evidence-strength |
+|---|---|---|
+| What IS evidence? | A per-candidate or per-campaign fact-record: stage outcome, metrics, failure reason, near-pass distance, sampling metadata, fingerprint. | `direct` ([screening_evidence.py:7–32](../../research/screening_evidence.py); [campaign_evidence_ledger.py](../../research/campaign_evidence_ledger.py)) |
+| Identity | Per-candidate `evidence_fingerprint` (sha1 of normalized payload); per-event `event_id` (sha256 of `campaign_id|event_type|at_utc|reason_code|run_id`). | `direct` |
+| Lifecycle ownership | Append-only at the event level. Per-candidate evidence is regenerated each run (the artifact is non-frozen, schema-versioned). | `direct` |
+| Semantic responsibility | Truth-about-research-events. Spans screening / promotion / paper / falsification / campaign-funnel. | `direct` |
+| Evidence ownership (meta) | Three artifacts: `screening_evidence_latest.v1.json` (per-run, per-candidate), `campaign_evidence_ledger.jsonl` (append-only events), `research_evidence_ledger.v1.json` (rolled-up advisory). | `direct` |
+| Transition authority | Builders own emission; readers (funnel policy, paper readiness, diagnostics) own interpretation. Idempotent emission via fingerprints. | `direct` |
+| Source-of-truth boundaries | When per-candidate evidence (screening_evidence) and campaign-event evidence (ledger) disagree (e.g. ledger has `completed_with_candidates` but screening shows all rejected), the *ledger event* outcome is canonical for funnel decisions; *screening evidence* is canonical for per-candidate stage results. | `direct` ([campaign_funnel_policy.py:24–27](../../research/campaign_funnel_policy.py): "Mismatch / missing evidence does NOT block a no_action_technical_failure decision derived from the registry record.") |
+| Mutability | Append-only at event level. Per-run snapshot files are regenerated. | `direct` |
+| Runtime / artifact authority | Artifact is canonical post-run; runtime is canonical during. | `direct` |
+
+**Ontology verdict:** Evidence has **clean append-only ontology at the event level** and **clean schema-versioned non-frozen ontology at the per-run level**. Two artifacts, each canonical for its scope. The `fb_<sha1prefix>` identity fallback ([screening_evidence.py:18–24](../../research/screening_evidence.py)) is a `deliberate additive transition` per M10 — counted in `summary.identity_fallbacks` so operators can spot upstream defects without crashing the run.
+
+### §7.7 — Falsification
+
+| Question | Answer (current) | Evidence-strength |
+|---|---|---|
+| What IS falsification? | A post-promotion check that can flip a candidate's verdict from "candidate" to "rejected" based on corrected significance, fee-drag ratio, low-trade-count, OOS collapse. | `direct` ([falsification.py](../../research/falsification.py); [falsification_reporting.py](../../research/falsification_reporting.py)) |
+| Identity | No identity surface; falsification is per-candidate-per-run. | `direct` |
+| Lifecycle ownership | run_research orchestrator invokes falsification gates after promotion. | `direct` (X2.7 unverifiable at line-level; module presence direct) |
+| Semantic responsibility | Research-intelligence; specifically the "is this real or noise?" gate. | `direct` |
+| Evidence ownership | Falsification reasoning is part of the candidate dict + the per-run reporting artifact. | `inferred` (full module trace not done in audit) |
+| Transition authority | Falsification can demote `candidate → rejected`. It is the *only* post-promotion authority that does this. | `inferred` |
+| Source-of-truth boundaries | When promotion classifies as "candidate" but falsification fires, the *post-falsification verdict* is canonical for `candidate_registry_latest.v1.json`. The *pre-falsification* verdict is not separately preserved. | `inferred` |
+| Mutability | The candidate dict gets the post-falsification verdict written; pre-falsification verdict can be lost. | `inferred` (X2.7 `unverifiable` at line level) |
+| Runtime / artifact authority | Runtime mutates; artifact records the post-falsification view. | `inferred` |
+
+**Ontology verdict:** Falsification has **clean intent** (post-promotion truth check) and **partially-verifiable implementation** (the audit's read-only scope did not exhaustively trace the line-level mutation pattern). Per X2.7, this is `unverifiable` at line level; per §13 V7 it is reframed as `partially_confirmed` and classified `aesthetically imperfect` until full trace can be done.
+
+### §7.8 — Promotion
+
+| Question | Answer (current) | Evidence-strength |
+|---|---|---|
+| What IS promotion? | A pure decision function that classifies a strategy run into rejected / needs_investigation / candidate based on hard gates (Sharpe, drawdown, leakage, trade count) and soft gates (PSR, DSR, noise, bootstrap CI). v3.15.7 added phase-aware dispatch on `pass_kind == "exploratory"`. | `direct` ([promotion.py:1–94](../../research/promotion.py)) |
+| Identity | Per-(candidate, run) pair. No promotion ID. | `direct` |
+| Lifecycle ownership | run_research orchestrator invokes per-row. | `direct` |
+| Semantic responsibility | Research-intelligence. | `direct` |
+| Evidence ownership | The promotion verdict appears in `candidate_registry_latest.v1.json` (frozen) and in the per-run candidate dict's `current_status`. | `direct` |
+| Transition authority | The pure function. Configurable thresholds in `DEFAULT_PROMOTION_CONFIG`. | `direct` |
+| Source-of-truth boundaries | When promotion says "candidate" but falsification fires, falsification wins (§7.7). When promotion is exploratory-pass, it's downgraded to needs_investigation by §7.8 itself ([promotion.py:71–76](../../research/promotion.py)). | `direct` |
+| Mutability | Stateless decision function. | `direct` |
+| Runtime / artifact authority | Function output is canonical. | `direct` |
+
+**Ontology verdict:** Promotion is **the cleanest functional ontology in the policy layer.** Pure decision, no IO, no state, configurable thresholds. The Phase-2 critique that "classify_candidate is not phase-aware" is `superseded_by_newer_code` per v3.15.7. The remaining critique (standard vs promotion_grade are classified identically) is real but minor — see §13 reclassification.
+
+### §7.9 — Paper readiness
+
+| Question | Answer (current) | Evidence-strength |
+|---|---|---|
+| What IS paper readiness? | A diagnostic verdict gating Candidate → PaperReady transition. Closed taxonomy of blocking reasons (6) and warning reasons (3); three readiness statuses. | `direct` ([paper_readiness.py:1–73](../../research/paper_readiness.py)) |
+| Identity | Per-candidate, per-run. | `direct` |
+| Lifecycle ownership | run_research invokes after promotion + after paper-divergence + after timestamped-returns-feed. | `direct` |
+| Semantic responsibility | Research-intelligence + Operational-intelligence (the gate is OI; the metrics are RI). | `direct` |
+| Evidence ownership | `paper_readiness_latest.v1.json` (canonical). | `direct` |
+| Transition authority | The paper_readiness module computes the verdict; promotion to PAPER_READY lifecycle status follows from the verdict. | `direct` |
+| Source-of-truth boundaries | Paper readiness blocking can override a "promoted" candidate from progressing. The campaign_funnel_policy can spawn a paper_followup if blocked. Two authorities (paper_readiness gate + funnel policy) read the same evidence; v3.15.10 says funnel policy AND-combines or defers as appropriate. | `direct` |
+| Mutability | Stateless per-candidate computation. | `direct` |
+| Runtime / artifact authority | Artifact canonical post-run. | `direct` |
+
+**Ontology verdict:** Paper readiness has **clean closed taxonomies** (BLOCKING_REASONS, WARNING_REASONS, READINESS_STATUSES). The `live_eligible=False` hard pin is enforced at this layer. Phase-2's V12 ("Paper-readiness lives outside funnel policy") is `partially_confirmed` — they're decoupled, but the decoupling is *intentional* per the v3.15 / v3.15.10 design. Reclassified `aesthetically imperfect` per §15.
+
+### §7.10 — Ontology summary
+
+| Object | Ontological clarity | Drift level | Reification status |
+|---|---|---|---|
+| Strategy | Stable | Low | Function-level fully reified; identity could be sharper |
+| Hypothesis | Cleanest | Lowest | Fully reified (frozen dataclass + closed status enum) |
+| Preset | Multi-purpose | Medium (3-layer field types) | Reified (frozen dataclass) but semantically loaded |
+| Campaign | Clean two-axis | Low | Reified (registry record + ledger events) |
+| Candidate | Most loaded | Medium-high | **Partial reification** — identity ✓, status enum ✓ (reserved subset), dict schema ✗, mutation semantics ✗ |
+| Evidence | Clean | Low | Reified (artifacts + fingerprints) |
+| Falsification | Clean intent | `unverifiable` at code-trace level | Module exists; full ontology needs runtime trace |
+| Promotion | Cleanest functional | Lowest | Pure function, configurable |
+| Paper readiness | Clean closed taxonomy | Low | Reified |
+
+**Repo ontology verdict:** The codebase carries a **partially-stable ontology with localized drift**. The drift is **most pronounced on Candidate** (per §7.5) and **on the noun "family"** (per §5.C). Most other objects are stable. Phase-2's narrative of "broad ontology drift across the system" is `partially_confirmed` — drift exists, but is concentrated, not pervasive.
+
+---
+
+## §8 — Epistemic Integrity & Truth Ownership
+
+This section asks where truth is established, what counts as evidence, who owns falsification, and whether contradictory truth-states can coexist. It is the policy-layer counterpart to §7 (which is the type-layer analysis).
+
+The audit distinguishes four truth domains:
+
+- **Runtime operational state** — in-memory dicts, RunStateStore, heartbeat, in-flight candidates.
+- **Research truth state** — per-candidate metrics, screening verdicts, validation results, defensibility.
+- **Artifact truth state** — frozen JSON/CSV outputs, sidecars, ledgers, registry snapshots.
+- **Lifecycle truth state** — `CandidateLifecycleStatus`, `HypothesisStatus`, campaign FSM state, paper readiness status.
+
+### §8.1 — Where is truth established?
+
+| Truth | Where established | Authority |
+|---|---|---|
+| "This strategy exists" | `research/registry.py:STRATEGIES` (in-code constant) | Code-owner; frozen at module import |
+| "This hypothesis is active_discovery" | `research/strategy_hypothesis_catalog.py:STRATEGY_HYPOTHESIS_CATALOG` (in-code constant) | Code-owner; v3.15.4 strict validation at module import |
+| "This preset is enabled" | `research/presets.py:PRESETS` (in-code constant) | Code-owner; tested by `test_presets.py` |
+| "This candidate passed screening" | `screening_runtime` evaluates per-sample → `screening_evidence` builder emits per-candidate stage_result → artifact `screening_evidence_latest.v1.json` | Built from runtime per-row evaluation, frozen post-run |
+| "This candidate is promoted" | [promotion.py:48–94](../../research/promotion.py): `classify_candidate(...)` pure function → written to candidate dict + `candidate_registry_latest.v1.json` | Pure function output |
+| "This candidate is paper-ready" | [paper_readiness.py](../../research/paper_readiness.py): `compute_paper_readiness` (or equivalent) → `paper_readiness_latest.v1.json` | Stateless per-candidate computation |
+| "This candidate was falsified" | Falsification gates in [falsification.py](../../research/falsification.py) → mutate candidate verdict (X2.7 `unverifiable`) | Post-promotion mutation pattern |
+| "This campaign completed with candidates" | Campaign launcher writes outcome to `campaign_registry_latest.v1.json` and emits `campaign_completed` event in `campaign_evidence_ledger.jsonl` | COL via launcher |
+| "This funnel decision was emitted" | [campaign_funnel_policy.py](../../research/campaign_funnel_policy.py) pure module returns FunnelDecision; launcher emits `funnel_decision_emitted` event | Pure function + launcher event |
+
+### §8.2 — What counts as evidence?
+
+The system explicitly treats three classes of evidence:
+
+1. **Per-candidate stage evidence** ([screening_evidence.py](../../research/screening_evidence.py)). Schema-versioned, **non-frozen** ([line 9–11](../../research/screening_evidence.py): "screening_evidence_latest.v1.json is **not** a frozen contract"). Per-candidate fingerprint, near-pass band, sampling metadata, promotion guard.
+2. **Per-event campaign ledger** ([campaign_evidence_ledger.py](../../research/campaign_evidence_ledger.py)). Append-only JSONL, idempotent via event_id.
+3. **Rolled-up research evidence** ([research_evidence_ledger.py](../../research/research_evidence_ledger.py)). Advisory, schema-versioned. Aggregates the prior two.
+
+Plus four "advisory only" v3.15.11 surfaces: viability metrics, dead-zone detection, stop condition engine, information gain. None of these write to a frozen contract; they are all *evidence about evidence*.
+
+**Closed taxonomies surface in:** `BLOCKING_REASONS` / `WARNING_REASONS` ([paper_readiness.py:51–66](../../research/paper_readiness.py)), `CANONICAL_FAILURE_CODES` ([strategy_failure_taxonomy.py](../../research/strategy_failure_taxonomy.py)), promotion `failed`/`escalated`/`passed` reasons ([promotion.py:78–175](../../research/promotion.py)), readiness statuses, hypothesis statuses, campaign outcomes.
+
+### §8.3 — How does evidence accumulate?
+
+Three accumulation patterns:
+
+- **Per-run snapshot:** `run_candidates_latest.v1.json`, `screening_evidence_latest.v1.json`, `paper_readiness_latest.v1.json`, `walk_forward_latest.v1.json`. Regenerated each run; the *previous run's snapshot is overwritten*.
+- **Append-only event ledgers:** `campaign_evidence_ledger.jsonl`, `candidate_status_history.jsonl`. Idempotent emission via fingerprints. Survive across runs.
+- **Frozen registries:** `candidate_registry_latest.v1.json`, `strategy_hypothesis_catalog_latest.v1.json`. Schema-pinned; byte-identity guarded.
+
+The **rolled-up evidence ledger** (`research_evidence_ledger.py`, v3.15.11) explicitly aggregates the prior two pattern's outputs into per-(preset, hypothesis_id, family) buckets.
+
+### §8.4 — What upgrades evidence into promotion?
+
+Per [promotion.py:48–94](../../research/promotion.py): a candidate is promoted when:
+
+- Hard gates pass: oos_sharpe ≥ 0.3, max_drawdown ≤ 0.35, leakage_checks_ok, oos_trades ≥ 10.
+- Soft gates clean: noise_warning not fired, PSR ≥ 0.90, DSR ≥ 0.0, bootstrap_sharpe_ci excludes zero.
+- pass_kind != "exploratory" (otherwise → needs_investigation per v3.15.7).
+
+If hard gates fail → rejected. If hard pass but soft escalates → needs_investigation. If both clean → candidate.
+
+**Doctrine-vs-code consistency:** `qre_roadmap_v3 §3.1` says "Deflated Sharpe > raw Sharpe" — the code's DSR check ([promotion.py:159–165](../../research/promotion.py)) operationalizes this. Consistent.
+
+### §8.5 — Who owns falsification authority?
+
+Per §7.7: the falsification module ([falsification.py](../../research/falsification.py)) carries `check_corrected_significance`, `check_fee_drag_ratio`, `check_low_trade_count`, `check_oos_collapse` functions. The orchestrator invokes them post-promotion. **No automatic feedback to the hypothesis catalog status visible read-only** (X2.7 `unverifiable`).
+
+Per [strategy_hypothesis_catalog.py:5–6](../../research/strategy_hypothesis_catalog.py), the catalog is *read* by the campaign policy; whether falsification *writes* back to it (e.g. to flip a hypothesis from `active_discovery` to `disabled` after repeated falsification) is **not visible read-only**. The audit tags this `unverifiable` with `inferred` evidence-strength: structurally there is no automatic-flip code path observed, but a deeper trace would be needed to confirm.
+
+### §8.6 — Where can contradictory truth states coexist?
+
+The audit identifies six places where truth states can disagree, classified per the M9 + §14 vocabulary (harmless / transitional / dangerous / load-bearing / misleading / obsolete):
+
+| # | Disagreement | Class | Evidence | Notes |
+|---|---|---|---|---|
+| E1 | Registry says `enabled=True` for `zscore_mean_reversion` / `bollinger_regime` / `trend_pullback_tp_sl`; preset bundles do not include them. | `misleading` | §4.1 verification | A reader assumes "enabled" means "is being investigated." Operationally false. |
+| E2 | Two policy modules read the same ledger and may emit overlapping decisions. | `transitional` (per §6) | [campaign_funnel_policy.py](../../research/campaign_funnel_policy.py) + [campaign_policy.py](../../research/campaign_policy.py) | v3.15.10 introduced funnel_policy as "pure"; campaign_policy not yet retired. |
+| E3 | Promotion verdict can be flipped by post-promotion falsification without re-emitting a separate artifact. | `unverifiable` → `dangerous` if confirmed; `aesthetically imperfect` otherwise | X2.7 | Audit cannot fully verify read-only; conservative flag. |
+| E4 | `screening_evidence_latest.v1.json` and `candidate_registry_latest.v1.json` can disagree if upstream evidence was malformed and `fb_<sha1prefix>` fallback fired. | `transitional` (counter is `summary.identity_fallbacks`) | [screening_evidence.py:18–24](../../research/screening_evidence.py) | Fallback is *counted*, not *silent*; operators can detect. |
+| E5 | A candidate's runtime `current_status` differs from its post-run `lifecycle_status`. | `harmless` (intentional separation: runtime transient vs frozen post-run) | [candidate_lifecycle.py:31–48](../../research/candidate_lifecycle.py) | Two-axis intentional. |
+| E6 | A hypothesis's catalog status disagrees with its operational presence (e.g. catalog says `active_discovery` but no preset is bundling it; or catalog says `disabled` but a legacy preset still has it). | `load-bearing` (the `_METADATA_ONLY_FAMILIES` set is the explicit reconciliation) | [strategy_hypothesis_catalog.py:90–96](../../research/strategy_hypothesis_catalog.py) | The seam is documented and counted. |
+
+### §8.7 — Can runtime state disagree with frozen artifacts?
+
+**Yes, intentionally and bounded.** The codebase has at least three constructs that explicitly assume runtime ≠ artifact:
+
+- Heartbeat / RunStateStore (runtime state) vs final `run_meta_latest.v1.json` (artifact, written at run end).
+- Per-candidate dict mutations during run vs `candidate_registry_latest.v1.json` (frozen post-promotion).
+- `runtime` `current_status` field on candidates vs lifecycle enum value post-write.
+
+The `test_orchestration_artifact_truth.py` test name signals the boundary is *known and tested*. The audit treats disagreement here as `harmless` provided artifacts are written atomically (which `_sidecar_io.write_sidecar_atomic` guarantees per its name) and the runtime state never escapes its run boundary.
+
+### §8.8 — Epistemic integrity verdict
+
+**The system has a coherent four-domain truth model with explicit cross-domain reconciliation seams.** Specifically:
+
+- Runtime ≠ artifact is bounded by atomic writes and run-end finalization.
+- Research truth ≠ artifact truth is bounded by frozen-contract pinning + test_orchestration_artifact_truth.py.
+- Lifecycle truth has a *forward-looking* full graph (8 statuses) of which only a subset is active at any phase — by *design*, not by drift.
+- The 6 disagreement classes (§8.6) include 1 `misleading` (E1, the registered-but-inert strategies), 1 `transitional` (E2, two-policy ambiguity), 1 `unverifiable→conservative-dangerous` (E3, falsification mutation), 1 `transitional-counted` (E4, fingerprint fallback), 1 `harmless` (E5), and 1 `load-bearing` (E6, _METADATA_ONLY_FAMILIES).
+
+**The dominant epistemic risk is E1 (registered-but-inert strategies as misleading authority signal), not the Phase-2-flagged "in-place mutation" or "two-policy ambiguity."** E1 is the most concrete finding because three strategies are `enabled=True` in the registry and a future Claude/Codex/operator reading the registry will plausibly assume the strategies are being actively investigated when they are not.
+
+---
+
+## §9 — Strategy universe audit (per-item)
+
+Each of the 15 factories from §4.1 is walked through the A–E template. Evidence-strength is `direct` unless tagged otherwise.
+
+### §9.1 — `rsi_strategie` ([strategies.py:29](../../agent/backtesting/strategies.py); [registry.py:28](../../research/registry.py))
+
+- **A. Trading idea:** Mean reversion via classical RSI (overbought/oversold). 3 params: `koop_drempel`, `short_drempel`, `periode`.
+- **B. Architecture:** Legacy `func(df) → Series`. No thin contract. No feature layer. Stateless. Reads `df["close"]` directly. No leakage.
+- **C. Research quality:** Real hypothesis (RSI MR is a textbook strategy). The `hypothesis` string in the registry frames it conditionally ("possibly only in non-trending regimes") — already a falsification-aware framing.
+- **D. Funnel compatibility:** Bundle-active in `crypto_diagnostic_1h` only. Diagnostic_only=True → cannot promote, cannot daily_schedule. Operationally inert for the alpha funnel; alive only as a regime-rejection observatory.
+- **E. Status advice:** `diagnostic` (bucket E in §16). `aesthetically imperfect but operationally correct` — old strategy, well-fenced. **Do not modify.**
+
+### §9.2 — `fear_greed_strategie` ([strategies.py:46](../../agent/backtesting/strategies.py))
+
+- **A. Trading idea:** Sentiment overlay via the Fear & Greed index. External-data dependency.
+- **B. Architecture:** Legacy. Coupled to async HTTP fetch (`laad_fear_greed`, lines 73–105). Architecturally violates the layer rule (data-fetch in strategy module).
+- **C. Research quality:** Pre-v3.5 experiment. No hypothesis catalog row. No preset.
+- **D. Funnel compatibility:** Not registered. Cannot enter funnel.
+- **E. Status advice:** `remove_candidate` (bucket D in §16). `historical layering artifact` per M10. Safe to delete after smoke test for stray imports.
+
+### §9.3 — `bollinger_strategie` (a.k.a. `bollinger_mr`) ([strategies.py:110](../../agent/backtesting/strategies.py); [registry.py:43](../../research/registry.py))
+
+- **A. Trading idea:** Mean reversion via Bollinger Bands. 2 params: `periode`, `std`.
+- **B. Architecture:** Legacy `func(df) → Series`. Stateless. No leakage.
+- **C. Research quality:** Real hypothesis. Registry comment frames it as "likely weak on intraday crypto" — already de-prioritized.
+- **D. Funnel compatibility:** Bundle-active in `crypto_diagnostic_1h` only. Same fence as RSI.
+- **E. Status advice:** `diagnostic` (bucket E in §16). **Do not modify.**
+
+### §9.4 — `bollinger_regime_strategie` ([strategies.py:141](../../agent/backtesting/strategies.py); [registry.py:57](../../research/registry.py))
+
+- **A. Trading idea:** Mean reversion + regime filter. 3 params: `config` (regime detection params), `periode`, `std`.
+- **B. Architecture:** Legacy `func(df, config) → Series`. The config param is a nested dict, not a clean parameter — **3 grid points but 1 of them is a nested dict.** Stateless.
+- **C. Research quality:** Real hypothesis (regime filtering improves MR). Registry comment is appropriately skeptical.
+- **D. Funnel compatibility:** **Registered with `enabled=True` but NOT bundled in any preset.** The string `"bollinger_regime_derived"` appears as `regime_filter=` on `trend_regime_filtered_equities_4h` ([presets.py:268](../../research/presets.py)) — but that's a *string label*, not a strategy reference. So this strategy never produces candidates.
+- **E. Status advice:** `dead_code_via_misleading_authority` — re-classify as `disabled` (bucket B in §16). This is the audit's most concrete *misleading* finding (E1 from §8.6). **Recommendation: change `enabled=True` → `enabled=False` with a `backlog_reason` documenting the regime-filter-string-label pattern.** No code-path change; only operator/auditor signal correction. **Risk: byte-identity test on the registry surface — must be confirmed before action (§20).**
+
+### §9.5 — `trend_pullback_strategie` ([strategies.py:207](../../agent/backtesting/strategies.py); [registry.py:81](../../research/registry.py))
+
+- **A. Trading idea:** Trend-following via EMA pullback. 6 params (ema_kort, ema_lang, pullback_buffer, slope_lookback, vol_lookback, max_volatility).
+- **B. Architecture:** Legacy `func(df, **params) → Series`. Stateless. **6 named parameters violates AGENTS.md ≤3-params rule** in spirit (the rule is about *new* strategies, but this strategy was registered pre-v3.15.3).
+- **C. Research quality:** Real hypothesis. Has `trend_pullback_v1` as the v3.15.3 thin replacement.
+- **D. Funnel compatibility:** Bundle-active as `optional_bundle` in `trend_equities_4h_baseline`. Conditionally exercised. Not bridged to the catalog ([registry.py:202–211](../../research/registry.py) explicitly: "intentionally NOT part of the v3.15.3 hypothesis-catalog bridge").
+- **E. Status advice:** `intentional migration bridge` per M10. **Do not modify** — the bridge to its v3.15.3 thin replacement is explicit and load-bearing.
+
+### §9.6 — `trend_pullback_tp_sl_strategie` ([strategies.py:256](../../agent/backtesting/strategies.py); [registry.py:99](../../research/registry.py))
+
+- **A. Trading idea:** Trend-following + take-profit/stop-loss execution management. 8 named parameters.
+- **B. Architecture:** Legacy. Carries execution-management logic in strategy parameters — conceptually mixes strategy and execution layers (orchestrator_brief §3 says strategy emits signals only).
+- **C. Research quality:** Pre-v3.5 experiment. The execution-management-as-strategy-param pattern is structurally an `architectural mistake` per M10 — but a frozen one (registry entry pre-dates the doctrine).
+- **D. Funnel compatibility:** **Registered with `enabled=True` but NOT bundled in any preset.** Operationally inert.
+- **E. Status advice:** `dead_code_via_misleading_authority`, plus `architectural mistake` for the execution-in-strategy pattern. Bucket B in §16. **Recommendation:** same as bollinger_regime — change `enabled=True` → `enabled=False`, document, do not delete (preserves registry-byte-identity).
+
+### §9.7 — `breakout_momentum_strategie` ([strategies.py:305](../../agent/backtesting/strategies.py); [registry.py:119](../../research/registry.py))
+
+- **A. Trading idea:** Highest-high breakout + EMA exit. 2 params: `lookback`, `ema_exit`.
+- **B. Architecture:** Legacy `func(df) → Series`. Stateless.
+- **C. Research quality:** Real hypothesis (crypto breakout edges). No `hypothesis_id` bridge — registry comment ([line 129](../../research/registry.py)) says "Crypto kan sterker reageren op breakout momentum dan op mean reversion."
+- **D. Funnel compatibility:** Bundle-active in `trend_equities_4h_baseline` and `trend_regime_filtered_equities_4h`. Operates under `screening_phase="promotion_grade"` (the strict gate). **Note: family namespace divergence** — `family="trend"` vs `strategy_family="breakout"` ([registry.py:125–126](../../research/registry.py)). Confirmed §5.C ontology drift.
+- **E. Status advice:** `baseline` (bucket E in §16). The family divergence is `aesthetically imperfect but operationally correct` per §15. **Do not modify.**
+
+### §9.8 — `earnings_strategie` ([strategies.py:342](../../agent/backtesting/strategies.py))
+
+- **A. Trading idea:** Post-earnings drift proxy. Requires labeled earnings events.
+- **B. Architecture:** Legacy. External-data dependency.
+- **C. Research quality:** Pre-v3.5 experiment.
+- **D. Funnel compatibility:** Not registered.
+- **E. Status advice:** `remove_candidate` (bucket D). Safe to delete.
+
+### §9.9 — `orb_strategie` ([strategies.py:370](../../agent/backtesting/strategies.py))
+
+- **A. Trading idea:** Opening range breakout (gap-based proxy on daily data).
+- **B. Architecture:** Legacy. Stateless.
+- **C. Research quality:** Pre-v3.5 experiment.
+- **D. Funnel compatibility:** Not registered.
+- **E. Status advice:** `remove_candidate` (bucket D). Safe to delete.
+
+### §9.10 — `polymarket_expiry_strategie` ([strategies.py:392](../../agent/backtesting/strategies.py))
+
+- **A. Trading idea:** Stub. Always returns zero signal.
+- **B. Architecture:** Stub.
+- **C. Research quality:** Placeholder for prediction-market scope (`AGENTS.md` lists Polymarket as future asset class).
+- **D. Funnel compatibility:** Not registered. Always-zero signal would not produce trades anyway.
+- **E. Status advice:** `remove_candidate` (bucket D). Or — keep as a doctrinal stub if Polymarket scope is still planned. The audit notes this is a `historical_origin: unverifiable` for whether the stub is intended as future scope or dead code.
+
+### §9.11 — `sma_crossover_strategie` ([strategies.py:404](../../agent/backtesting/strategies.py); [registry.py:133](../../research/registry.py))
+
+- **A. Trading idea:** Trend-following via SMA crossover. 2 params: `fast_window`, `slow_window`. Tier-1 baseline per `orchestrator_brief §4.1`.
+- **B. Architecture:** Thin v1.0 (`contract_version="1.0"`). Feature requirements: `sma_fast`, `sma_slow`. Body reads `df.index` only; everything else via the features mapping. Bytewise-pinned.
+- **C. Research quality:** Doctrine baseline.
+- **D. Funnel compatibility:** Bundle-active in `trend_equities_4h_baseline` and `trend_regime_filtered_equities_4h`. Promotion-grade screening_phase.
+- **E. Status advice:** `baseline` (bucket E). **Must absolutely not change.** Bytewise pin tests bind it.
+
+### §9.12 — `zscore_mean_reversion_strategie` ([strategies.py:433](../../agent/backtesting/strategies.py); [registry.py:151](../../research/registry.py))
+
+- **A. Trading idea:** Mean reversion via z-score. 3 params: `lookback`, `entry_z`, `exit_z`. Tier-1 baseline per `orchestrator_brief §4.2`.
+- **B. Architecture:** Thin v1.0 (`contract_version="1.0"`). Feature requirements: `z`. Bytewise-pinned.
+- **C. Research quality:** Doctrine baseline.
+- **D. Funnel compatibility:** **Registered with `enabled=True` but NOT bundled in any preset.** Operationally inert. The doctrine ("tier-1 baseline") and the operational reality ("never investigated") disagree.
+- **E. Status advice:** `dead_code_via_misleading_authority` per E1. Bucket B in §16. **Recommendation:** either (a) add a preset that bundles `zscore_mean_reversion` (e.g. a `mean_reversion_crypto_1h_baseline` with `screening_phase="promotion_grade"`), or (b) document why no preset exists despite tier-1 status. The audit prefers (b) for the v3.15.x window — *adding* a preset is strategy expansion (forbidden by M7); *documenting* is doctrine work. **Do not change `enabled` here** — it's the only tier-1 baseline with a bytewise pin and is doctrinally referenced; flipping `enabled=False` would create a doctrine-vs-code contradiction that is more damaging than the current `misleading` state.
+
+### §9.13 — `pairs_zscore_strategie` ([strategies.py:463](../../agent/backtesting/strategies.py); [registry.py:178](../../research/registry.py))
+
+- **A. Trading idea:** Pairs spread mean reversion. 4 params: `lookback`, `entry_z`, `exit_z`, `hedge_ratio`. Tier-1 baseline per `orchestrator_brief §4.3`. Two-leg via `reference_asset="ETH-EUR"`.
+- **B. Architecture:** Thin v1.0. Two feature paths: plain `spread_zscore` and fitted `spread_zscore_ols` (v3.7). The v3.6 scope-lock comment ([registry.py:169–177](../../research/registry.py)) is doctrine-load-bearing.
+- **C. Research quality:** Doctrine baseline. Mathematically the most sophisticated baseline.
+- **D. Funnel compatibility:** Bundle-active in `pairs_equities_daily_baseline` only — but that preset has `enabled=False` (`backlog_reason` cites v3.11 ADR pending). So operationally inert *via a different mechanism* than the registered-but-inert strategies: this is a `correctly shaped planned-but-disabled` case, not a `misleading` case.
+- **E. Status advice:** `baseline` (bucket E). **Must absolutely not change.** v3.6 scope lock + bytewise pin.
+
+### §9.14 — `trend_pullback_v1_strategie` ([strategies.py:527](../../agent/backtesting/strategies.py); [registry.py:213](../../research/registry.py))
+
+- **A. Trading idea:** Trend pullback (vol-normalized). 3 params: `ema_fast_window`, `ema_slow_window`, `entry_k`. **First v3.15.3 active_discovery hypothesis bridge.**
+- **B. Architecture:** Thin v1.0. Feature requirements: `ema_fast`, `ema_slow`, `rolling_volatility`, `pullback_distance`.
+- **C. Research quality:** Real hypothesis with explicit catalog row (`trend_pullback_v1`). Falsification criteria written in [presets.py:338–347](../../research/presets.py) (4 falsification clauses).
+- **D. Funnel compatibility:** Bundle-active in `trend_pullback_crypto_1h`. `screening_phase="exploratory"` → goes through phase-aware screening (v3.15.7) → demoted to `needs_investigation` per [promotion.py:71–76](../../research/promotion.py) on pass.
+- **E. Status advice:** `active_discovery` (bucket E). **Must absolutely not change** — load-bearing for the v3.15.4 strict catalog invariant.
+
+### §9.15 — `volatility_compression_breakout_strategie` ([strategies.py:610](../../agent/backtesting/strategies.py); [registry.py:244](../../research/registry.py))
+
+- **A. Trading idea:** Range breakout out of compressed-vol regime. 3 params: `atr_short_window`, `atr_long_window`, `compression_threshold`. **Second v3.15.3 active_discovery hypothesis bridge** (added v3.15.4).
+- **B. Architecture:** Thin v1.0. Feature requirements: `compression_ratio`, `rolling_high_previous`, `rolling_low_previous`.
+- **C. Research quality:** Real hypothesis with explicit catalog row (`volatility_compression_breakout_v0`). Falsification criteria written in [presets.py:399–412](../../research/presets.py) (5 falsification clauses).
+- **D. Funnel compatibility:** Bundle-active in TWO presets — `vol_compression_breakout_crypto_1h` and `vol_compression_breakout_crypto_4h`. **Cleanest example of "one hypothesis, multiple timeframes"** in the system.
+- **E. Status advice:** `active_discovery` (bucket E). **Must absolutely not change** — load-bearing.
+
+### §9.16 — Strategy walk summary
+
+| Bucket | Count | Members |
+|---|---|---|
+| A — fundamentally wrongly modelled | 0 | (none at strategy level — structural failures live at preset / candidate / sampling-plan / falsification level) |
+| B — directly problematic (registered-but-inert; misleading) | 3 | `bollinger_regime`, `trend_pullback_tp_sl`, `zscore_mean_reversion` |
+| C — just mislabeled | 1 | `breakout_momentum` (family namespace divergence; `aesthetically imperfect`) |
+| D — safe to remove (dead unregistered factories) | 4 | `fear_greed`, `earnings`, `orb`, `polymarket_expiry` |
+| E — must not change (load-bearing; correctly modelled; or `intentional migration bridge`) | 7 | `rsi`, `bollinger_mr`, `trend_pullback` (legacy bridge), `sma_crossover`, `pairs_zscore`, `trend_pullback_v1`, `volatility_compression_breakout` |
+
+**Total: 15 = 0+3+1+4+7.** Reconciles to §4.1 inventory.
+
+---
+
+## §10 — Preset universe audit (per-item)
+
+Each of the 7 presets from §4.2 is walked through the A–E template.
+
+### §10.1 — `trend_equities_4h_baseline` ([presets.py:147–187](../../research/presets.py))
+
+- **A. Research question:** Do two orthogonal trend strategies (SMA + breakout) capture persistent directional moves on 4h equities without management variants? Hypothesis text frames it as "stable daily default without strategy explosion."
+- **B. TI/RI/preset separation:** This is the audit's *strongest* TI/RI/OI conflation example: bundle = (sma_crossover, breakout_momentum) + optional_bundle = (trend_pullback,) → **three trading-idea slots, one preset, one narrative `hypothesis` string, no `hypothesis_id`.** The TI is *plural* in the bundle but *singular* in the metadata.
+- **C. Preset quality:** Real research preset; the `rationale`, `expected_behavior`, `falsification` triple is the cleanest "hypothesis metadata" example in the system. The `bundle` plurality is the structural issue.
+- **D. Funnel fit:** `screening_phase="promotion_grade"` → strict gates. `daily_primary` candidate in COL.
+- **E. Status advice:** `partially_correct` per §16. Bucket A on the bundle plurality, but with a strong defense per §5.A's verdict (see §13 V1).
+
+### §10.2 — `pairs_equities_daily_baseline` ([presets.py:188–256](../../research/presets.py))
+
+- **A. Research question:** Do equity pairs via z-score spread MR work? Awaits OLS hedge ratio + multi-reference_asset (v3.11 ADR pending).
+- **B. TI/RI separation:** Single-strategy bundle (pairs_zscore). Clean TI/RI separation. The `enablement_criteria` field is a 4-clause checklist for what unblocks the preset.
+- **C. Preset quality:** **Cleanest "planned-but-disabled" pattern in the system.** `enabled=False` + `backlog_reason` + `enablement_criteria` triple.
+- **D. Funnel fit:** None — disabled. Cannot generate templates.
+- **E. Status advice:** `correctly modelled` (bucket E). **Must absolutely not change** — this is the doctrinal example of how to model a planned preset.
+
+### §10.3 — `trend_regime_filtered_equities_4h` ([presets.py:257–297](../../research/presets.py))
+
+- **A. Research question:** Does regime-filtering improve the trend bundle? Diagnostic comparison vs `trend_equities_4h_baseline`.
+- **B. TI/RI separation:** Same dual-bundle as §10.1 (sma_crossover + breakout_momentum) but with `regime_filter="bollinger_regime_derived"` (string label). The `regime_filter` is a string, not a typed reference — implicit behavior per P4.
+- **C. Preset quality:** `preset_class="diagnostic"` — clear research role declaration. Falsification text is sharp ("regime-filter is noise" criterion).
+- **D. Funnel fit:** `screening_phase="promotion_grade"` BUT `preset_class="diagnostic"`. The two interact: diagnostic role + strict screening = "we want to see whether the filtered version produces fewer or better candidates than the baseline." Conceptually a controlled experiment.
+- **E. Status advice:** `partially_correct` (bucket A on the string-label `regime_filter`; bucket E on the controlled-experiment role).
+
+### §10.4 — `trend_pullback_crypto_1h` ([presets.py:298–356](../../research/presets.py))
+
+- **A. Research question:** Does vol-normalized pullback in EMA trend on crypto 1h work? Bridges to `trend_pullback_v1` hypothesis.
+- **B. TI/RI separation:** **Cleanest example.** Single-strategy bundle. `hypothesis_id="trend_pullback_v1"` set. Single TI bet, single RI protocol, explicit OI flags.
+- **C. Preset quality:** Doctrinal example for v3.15.3+ presets. Rationale, expected_behavior, falsification (4 clauses), enablement_criteria (3 clauses).
+- **D. Funnel fit:** `screening_phase="exploratory"` → demoted to `needs_investigation` on pass per v3.15.7.
+- **E. Status advice:** `correctly modelled` (bucket E). **Must absolutely not change.**
+
+### §10.5 — `vol_compression_breakout_crypto_1h` ([presets.py:357–420](../../research/presets.py))
+
+- **A. Research question:** Does range-breakout out of compressed-vol regime on crypto 1h work? Bridges to `volatility_compression_breakout_v0`.
+- **B. TI/RI separation:** Same clean pattern as §10.4. Single-strategy bundle, hypothesis_id set.
+- **C. Preset quality:** Same doctrinal example. 5-clause falsification.
+- **D. Funnel fit:** `screening_phase="exploratory"`.
+- **E. Status advice:** `correctly modelled` (bucket E).
+
+### §10.6 — `vol_compression_breakout_crypto_4h` ([presets.py:421–483](../../research/presets.py))
+
+- **A. Research question:** v3.15.15 timeframe sibling of §10.5. Same hypothesis at 4h.
+- **B. TI/RI separation:** Same clean pattern. **Cleanest example of "one hypothesis investigated at multiple timeframes via sibling presets"** in the system.
+- **C. Preset quality:** Adds `v3.15.15 4h insufficient_trades observability sidecar` enablement clause. Demonstrates how to add a timeframe-coverage preset *additively* without minting a new hypothesis.
+- **D. Funnel fit:** `screening_phase="exploratory"`. Lower trade frequency than 1h sibling — explicitly anticipated in falsification clauses.
+- **E. Status advice:** `correctly modelled` (bucket E). The doctrinal example for additive timeframe coverage.
+
+### §10.7 — `crypto_diagnostic_1h` ([presets.py:484–527](../../research/presets.py))
+
+- **A. Research question:** Track rejection patterns of crypto 1h MR over time as a regime-shift detector. Per `orchestrator_brief §7.2`: crypto 1h MR is deprioritized as primary alpha.
+- **B. TI/RI separation:** Bundle = (rsi, bollinger_mr) — two-strategy diagnostic bundle. No `hypothesis_id`. `screening_mode="diagnostic"` + `cost_mode="stress"` + `screening_phase="exploratory"` + `status="diagnostic"` + `preset_class="diagnostic"` + `diagnostic_only=True` + `excluded_from_daily_scheduler=True` + `excluded_from_candidate_promotion=True`. **Eight diagnostic-related fields.**
+- **C. Preset quality:** The "diagnostic-as-N-fields" pattern is verbose but each field has a different downstream consumer (per §5.G). The `validate_preset` function ([presets.py:619+](../../research/presets.py); not fully read in audit) enforces inter-field consistency.
+- **D. Funnel fit:** Bundle-active but excluded from daily scheduler and candidate promotion. Operationally a regime-shift observatory.
+- **E. Status advice:** `aesthetically imperfect but operationally correct` per §15. The verbose flag set is `frozen-contract preservation mechanism` per M10 — collapsing it would change the preset signature and break the tests pinning each flag independently.
+
+### §10.8 — Preset walk summary
+
+| Bucket | Count | Members |
+|---|---|---|
+| A — fundamentally wrongly modelled (in strong form) | 0 | (preview-draft assigned 3; on verification, all reduce to `partially correct` or `aesthetically imperfect`) |
+| A-partial — bundle plurality / string-label regime_filter / N-flag diagnostic | 3 | `trend_equities_4h_baseline`, `trend_regime_filtered_equities_4h`, `crypto_diagnostic_1h` |
+| B — directly problematic | 0 | |
+| C — just mislabeled | 0 | |
+| D — safe to remove | 0 | |
+| E — must not change (correctly modelled) | 4 | `pairs_equities_daily_baseline`, `trend_pullback_crypto_1h`, `vol_compression_breakout_crypto_1h`, `vol_compression_breakout_crypto_4h` |
+
+**Total: 7 = 0+3+0+0+0+4.** Reconciles to §4.2 inventory.
+
+The preview-draft's claim that 3 presets are bucket-A is downgraded: on verification, the issues are *aesthetic + frozen-correctness-load-bearing*, not architecturally invalid. See §22 for the explicit downgrade record.
+
+---
+
+## §11 — Hypothesis catalog audit (per-item)
+
+Each of the 7 hypotheses from §4.3.
+
+### §11.1 — `trend_pullback_v1` (active_discovery)
+
+- **What IS it:** First v3.15.3 controlled active_discovery. Bridges to `trend_pullback` strategy_family in registry. Bridges to `trend_pullback_crypto_1h` preset.
+- **Catalog quality:** Full schema (description, feature_dependencies, parameter_schema, default_parameter_grid, eligible_campaign_types, expected_failure_modes, baseline_reference, cost_class). Bounded grid (≤16 combos enforced by [strategy_hypothesis_catalog.py:71–75](../../research/strategy_hypothesis_catalog.py)).
+- **Status verdict:** `correctly modelled`. Doctrinal example.
+
+### §11.2 — `regime_diagnostics_v1` (diagnostic)
+
+- **What IS it:** A diagnostic enrichment hypothesis: not a tradable bet, an observability surface for regime detection.
+- **Catalog quality:** Listed in `_METADATA_ONLY_FAMILIES` ([strategy_hypothesis_catalog.py:90–96](../../research/strategy_hypothesis_catalog.py)). No executable strategy mapping (intentional).
+- **Status verdict:** `partially correct`. Phase-2's framing of "category error — should be a Diagnostic peer class" is partially right *conceptually*. But the catalog *already* special-cases it. The right fix is (a) a separate `Diagnostic` ontology class OR (b) keeping `_METADATA_ONLY_FAMILIES` as the explicit reconciliation seam. Audit recommends (b) until v3.16+.
+
+### §11.3 — `atr_adaptive_trend_v0` (planned)
+
+- **What IS it:** Planned adaptive-trend hypothesis. Metadata-only (no executable strategy).
+- **Catalog quality:** Clean planned-row.
+- **Status verdict:** `correctly modelled`.
+
+### §11.4 — `volatility_compression_breakout_v0` (active_discovery)
+
+- **What IS it:** Second v3.15.3-tier active_discovery (promoted from `planned` in v3.15.4). Bridges to `volatility_compression_breakout` strategy_family. Bridges to two presets (1h, 4h).
+- **Catalog quality:** Full schema + double-preset bridging.
+- **Status verdict:** `correctly modelled`. Cleanest "active_discovery with multi-preset coverage" example.
+
+### §11.5 — `multi_asset_trend_sleeve_v0` (planned)
+
+- **What IS it:** Planned portfolio-sleeve trend hypothesis.
+- **Catalog quality:** Clean planned-row. Listed in `_METADATA_ONLY_FAMILIES` per the v3.15.4 comment.
+- **Status verdict:** `correctly modelled`.
+
+### §11.6 — `cross_sectional_momentum_v0` (planned)
+
+- **What IS it:** Planned cross-sectional rank momentum hypothesis.
+- **Catalog quality:** Clean planned-row. Listed in `_METADATA_ONLY_FAMILIES`.
+- **Status verdict:** `correctly modelled`.
+
+### §11.7 — `dynamic_pairs_v0` (disabled)
+
+- **What IS it:** Explicitly disabled; awaits fitted-feature multi-asset + pair-universe policy.
+- **Catalog quality:** Clean disabled-row. Listed in `_METADATA_ONLY_FAMILIES`.
+- **Status verdict:** `correctly modelled`. Doctrinal example for "explicitly disabled with reason."
+
+### §11.8 — Hypothesis catalog walk summary
+
+| Bucket | Count | Members |
+|---|---|---|
+| A — fundamentally wrongly modelled | 0 | |
+| B — directly problematic | 0 | |
+| C — just mislabeled (partially correct re-classified) | 1 | `regime_diagnostics_v1` |
+| D — safe to remove | 0 | |
+| E — must not change (correctly modelled) | 6 | All others |
+
+**Total: 7 = 0+0+1+0+6.** Reconciles to §4.3.
+
+**Catalog verdict: cleanest part of the system.** Phase-2's framing matches reality here; the catalog is the canonical TI surface, well-formed.
+
+---
+
+## §12 — Funnel / policy / lifecycle audit
+
+This section asks: where does the research engine actually live? What is currently a hypothesis vs candidate? Where does legacy thinking persist?
+
+### §12.1 — Where does the research engine actually live?
+
+The research engine is **distributed**, not centralized:
+
+- **Plan** → [candidate_pipeline.py](../../research/candidate_pipeline.py) `plan_candidates()` (creates dicts).
+- **Dedupe** → [candidate_pipeline.py:292–314](../../research/candidate_pipeline.py).
+- **Fit prior** → [candidate_pipeline.py:324–](../../research/candidate_pipeline.py).
+- **Eligibility** → `candidate_pipeline.apply_eligibility()`.
+- **Screening** → [screening_process.py](../../research/screening_process.py) (subprocess), [screening_runtime.py](../../research/screening_runtime.py) (in-process), [screening_criteria.py](../../research/screening_criteria.py) (phase dispatch), [screening_evidence.py](../../research/screening_evidence.py) (sidecar emission).
+- **Validation** → grid_search via batch_execution; mutates candidate at [run_research.py:3019](../../research/run_research.py).
+- **Falsification** → [falsification.py](../../research/falsification.py) (`unverifiable` line-level).
+- **Promotion** → [promotion.py:48–94](../../research/promotion.py) pure function.
+- **Paper readiness** → [paper_readiness.py](../../research/paper_readiness.py).
+- **Campaign funnel** → [campaign_funnel_policy.py](../../research/campaign_funnel_policy.py) (pure) + [campaign_policy.py](../../research/campaign_policy.py) (older).
+- **Campaign launch** → [campaign_launcher.py](../../research/campaign_launcher.py).
+- **Lifecycle** → [candidate_lifecycle.py](../../research/candidate_lifecycle.py) (frozen graph, partial active subset).
+
+The orchestrator [run_research.py](../../research/run_research.py) (3795 lines) coordinates these. The "research engine" is the *composition* of these modules — there is no single class or function that *is* the engine.
+
+**Verdict:** The distributed shape is `correctly modelled` per §5.D — each module owns one stage cleanly. The 3795-line orchestrator is the conductor, not the engine.
+
+### §12.2 — What is currently a hypothesis vs a candidate?
+
+- **A hypothesis** is a row in `STRATEGY_HYPOTHESIS_CATALOG` with `status="active_discovery"` (or planned/disabled/diagnostic). It has an immutable `hypothesis_id` and a strategy_family binding.
+- **A candidate** is a dict produced by `plan_candidates()` for a specific (strategy_name, asset, interval, params) tuple. It accumulates fields per pipeline stage.
+
+The two are **distinct ontologies** (per §7.5 / §7.2). Phase-2's framing of "what is currently a hypothesis vs a candidate?" assumed they might be confused; on verification, **they are not.** A candidate is much more granular than a hypothesis (one hypothesis → many candidates per run).
+
+**Verdict:** No confusion. `correctly modelled`.
+
+### §12.3 — Where does legacy thinking persist?
+
+Three concentrations:
+
+1. **The "Cartesian sweep" registry** (admitted at [registry.py:6–8](../../research/registry.py)). `transitional` per M10. Phase 2 of the documented migration replaces this; not yet landed.
+2. **The "tier-1 baseline" doctrine** (orchestrator_brief §4.1–4.3) referenced by registry comments but operationally exercised only via specific presets — and `zscore_mean_reversion` is missing a preset. `historical layering artifact`.
+3. **The legacy `family` axis** alongside the v3.15.3 `strategy_family` axis. Three strategies show divergence (breakout_momentum, trend_pullback (legacy), trend_pullback_v1 — though for v1 the divergence is moot since it has only `strategy_family`). `historical layering artifact` per §5.C.
+
+### §12.4 — Where does evidence accumulation work, and where does it not?
+
+**Works:**
+- Per-event ledger: append-only, idempotent (`event_id = sha256(...)`).
+- Per-run snapshots: regenerated atomically.
+- Candidate fingerprint: deterministic.
+- The `research_evidence_ledger` (v3.15.11) rolls up per-(preset, hypothesis_id, family).
+
+**Doesn't work yet (or is `unverifiable`):**
+- Falsification feedback to hypothesis catalog status (X2.7 `unverifiable`; no automatic flip mechanism observed read-only).
+- The two-policy ambiguity (X2.8) means evidence may be interpreted twice with possibly different outcomes (`unverifiable` for whether this happens in production).
+
+### §12.5 — Discovery / promotion / paper semantics — how blurred?
+
+Per §3.1 P8 (`partially_confirmed`):
+
+- **At runtime**: 3 lifecycle statuses active (rejected, exploratory, candidate). PAPER_READY exists in the enum but only used by paper_readiness module. Promotion outputs `candidate / needs_investigation / rejected`. Paper-readiness outputs `ready_for_paper_promotion / blocked / insufficient_evidence`. So at runtime the "exploratory pass" and the "blocked-paper-readiness" are different statuses on different objects.
+- **At the type level**: the `FULL_LIFECYCLE_GRAPH` ([candidate_lifecycle.py:65+](../../research/candidate_lifecycle.py)) defines the legal transitions across all 8 statuses. The graph is *crisp*; v3.12 limits *runtime* to 3 of the 8, by design.
+
+**Verdict:** The semantics are crisp at the type level and partial at runtime — by *intentional phased rollout*, not by blur. P8 is `partially_confirmed`.
+
+### §12.6 — Funnel/policy/lifecycle verdict
+
+The funnel as a whole is **distributed but coherent**. The dominant concern is not blur — it's:
+
+- **Two policy modules, no canonical declaration** (X2.8 / E2). `transitional` per M10.
+- **Falsification feedback path to catalog status** is `unverifiable` and may be missing (E3). If missing, this is `dangerous` per M9 — a hypothesis can fail repeatedly without the catalog status being demoted, which would cause the COL to keep spawning campaigns for it.
+- **The pipeline's mid-run mutation pattern** ([run_research.py:3019](../../research/run_research.py)) is `aesthetically imperfect but operationally correct` — the artifact is written from the post-mutation state at run end; pre-mutation state is not preserved but the artifact is what's pinned.
+
+These three are the audit's funnel-layer concerns. None of them rises to "fundamentally wrongly modelled" — they're either `transitional` (two policies, awaiting v3.15.10+ retirement), `unverifiable` (falsification feedback, needs runtime trace), or `aesthetically imperfect` (mutation pattern).
+
+---
+
+## §13 — Candidate violations
+
+The Phase-2 pressure-test produced 12 candidate violations (V1–V12). Per M1, none of them survives into this audit on the strength of being said before. Each is re-verified against §3 evidence, §6 historical classification, and §15 frozen-correctness category.
+
+**Vocabulary recap:**
+- Status (M2): `confirmed | partially_confirmed | refuted | superseded_by_newer_code | unverifiable`.
+- Evidence (M3): `direct | inferred | speculative`.
+- Frozen-correctness (M9): `aesthetically imperfect | semantically dangerous | architecturally invalid`.
+- Historical (M10): `architectural mistake | intentional migration bridge | temporary compatibility seam | frozen-contract preservation mechanism | deliberate additive transition | historical layering artifact | historical_origin: unverifiable`.
+
+### §13.1 — Verified violations table
+
+| # | Phase-2 statement | Status | Evidence | Frozen-correctness | Historical | Recommended action |
+|---|---|---|---|---|---|---|
+| **V1** | Preset-as-trading-idea: TI bet + RI protocol on same dataclass | `partially_confirmed` | `direct` | aesthetically imperfect | deliberate additive transition (v3.10/v3.11/v3.15.3 layering) | **Doctrine-only** in Phase 1 (§19): write ADR-014 declaring catalog-as-canonical-TI; no code change. |
+| **V2** | Strategy-registry-as-TI-doctrine (`hypothesis` strings on registry entries) | `confirmed` | `direct` | aesthetically imperfect | frozen-contract preservation mechanism | **Do not touch.** The registry hypothesis strings are byte-identity-binding; removing them breaks pinned tests. Document as "legacy TI text retained for byte-identity; canonical TI is the catalog." |
+| **V3** | Preset carries OI state | `partially_confirmed` | `direct` | aesthetically imperfect | deliberate additive transition (each flag added by a different version) | **Doctrine-only.** No code change. The OI fields each have a different downstream consumer (§5.G); collapsing breaks consumers. |
+| **V4** | Bundle order is implicit family selection | `refuted` (in strong form) | `direct` ([presets.py:111–118](../../research/presets.py) explicit refutation) | n/a | n/a | **Refuted.** No action. The implicit walk does not exist in v3.15.3+ enforcement. Phase-2 was wrong on this one. |
+| **V5** | screening_phase is preset-bound, not candidate-bound | `confirmed` | `direct` | aesthetically imperfect | deliberate additive transition | **Doctrine-only or sidecar in v3.16+.** A campaign-bound phase would be an additive sidecar field, not a frozen-contract change. Phase 2/3 (§19). |
+| **V6** | SamplingPlan ↔ promotion_guard coupling | `unverifiable` | `inferred` | unverifiable→conservative `aesthetically imperfect` | unverifiable | **No action without runtime trace.** Tagged for §22 follow-up. |
+| **V7** | Falsification-after-promotion mutates verdict in place | `unverifiable` | `inferred` | unverifiable→conservative `semantically dangerous` if confirmed; `aesthetically imperfect` otherwise | unverifiable | **Highest-priority verification target.** A runtime trace would resolve this; if confirmed `dangerous`, Phase 3 (§19) addresses it. |
+| **V8** | Diagnostic-as-five-fields (actually six on `crypto_diagnostic_1h`) | `confirmed` | `direct` | aesthetically imperfect but operationally correct | deliberate additive transition | **Do not collapse.** Each of the 6 fields has a different downstream consumer; collapsing breaks the §5.G authority chain. Doctrine-only fix: declare `PresetClass = "diagnostic"` as the *intent* and the 5 booleans as the *consumer-facing surface*. |
+| **V9** | Validation result mutates candidate dict in-place | `confirmed` | `direct` ([run_research.py:3019](../../research/run_research.py)) | aesthetically imperfect but operationally correct | historical layering artifact | **No action in v3.15.x.** The mutated state is finalized into the frozen `candidate_registry_latest.v1.json` artifact at run-end (atomic write); pre-mutation state is not separately preserved but the *artifact* is canonical, not the runtime dict. Phase 2/3 reification (§19) eventually replaces this. |
+| **V10** | Evidence fingerprint silent fallback `fb_<sha1prefix>` | `confirmed` (but not silent — counted in `summary.identity_fallbacks`) | `direct` ([screening_evidence.py:18–24](../../research/screening_evidence.py)) | aesthetically imperfect but operationally correct | deliberate additive transition | **No action in v3.15.x.** The fallback is documented and counted; not silent. Phase 4 (§19) hard-fails it once full Candidate reification lands. |
+| **V11** | Two policy modules — campaign_funnel_policy (pure, v3.15.10) and campaign_policy (older, thicker) — ownership unclear | `partially_confirmed` | `direct` ([campaign_funnel_policy.py:1–55](../../research/campaign_funnel_policy.py); [campaign_policy.py](../../research/campaign_policy.py) header not yet declaring "deprecated") | aesthetically imperfect; potentially `dangerous` if both emit conflicting decisions | temporary compatibility seam | **Doctrine-only in Phase 1.** Add a header comment to one of the two declaring it canonical or deprecated. No code change. |
+| **V12** | Paper-readiness lives outside funnel policy | `confirmed` | `direct` | aesthetically imperfect | deliberate additive transition (paper layer = v3.15; funnel = v3.15.10) | **Doctrine-only.** The decoupling is intentional — paper-readiness is OI gating; funnel is RI/OI policy. Document the AND-bridge in ADR-014. |
+
+### §13.2 — New violations the audit found beyond Phase-2
+
+These are violations not present in Phase-2 V1–V12, surfaced during §3–§12 verification.
+
+| # | Statement | Status | Evidence | Frozen-correctness | Historical | Recommended action |
+|---|---|---|---|---|---|---|
+| **N1** | Three registered-but-inert strategies (`zscore_mean_reversion`, `bollinger_regime`, `trend_pullback_tp_sl`) carry `enabled=True` but are not bundle-active in any preset | `confirmed` | `direct` (§4.1, §9.4, §9.6, §9.12) | semantically dangerous (misleading authority signal — E1 in §8.6) | historical layering artifact + frozen-contract preservation mechanism | **Doctrine-only fix in Phase 1.** Document the `enabled=True ≠ bundle-active` semantic. Do not flip `enabled=False` (would break byte-identity tests on the registry surface). Add a `bundle_active` derived view in v3.16+. |
+| **N2** | Registry self-acknowledges AGENTS.md violation | `confirmed` | `direct` ([registry.py:6–8](../../research/registry.py)) | aesthetically imperfect (the violation is real but is *intentional during the migration*) | temporary compatibility seam | **Acknowledge, do not act.** The Phase-2 migration to a hypothesis-driven envelope is the planned fix; doctrine already declares this. |
+| **N3** | `breakout_momentum` family-namespace divergence (`family="trend"` vs `strategy_family="breakout"`) | `confirmed` | `direct` ([registry.py:125–126](../../research/registry.py)) | aesthetically imperfect but operationally correct | historical layering artifact (older `family` axis + newer `strategy_family` axis coexist) | **Doctrine-only.** Declare `strategy_family` as canonical; retain `family` for byte-identity. |
+| **N4** | `screening_phase` default `"promotion_grade"` is a safety floor, not a truth | `confirmed` | `direct` ([presets.py:91–94](../../research/presets.py); AST test pins explicitness) | aesthetically imperfect but operationally correct | frozen-contract preservation mechanism | **No action.** This is the AST-test-enforced safe default. Working as intended. |
+| **N5** | Doctrine vs code drift on the "engine is alpha-filter not alpha-generator" claim — engine *is* still doing brute-force Cartesian sweep | `confirmed` | `direct` ([registry.py:6–8](../../research/registry.py); doctrine in `qre_roadmap_v3 §3.1`) | aesthetically imperfect during the migration | temporary compatibility seam | Same as N2. The migration is planned. |
+| **N6** | "Tier-1 baseline" doctrine asserts 3 baselines (sma_crossover, zscore_mean_reversion, pairs_zscore) but only 2 are operationally exercised | `confirmed` | `direct` (§9.12) | semantically dangerous (doctrine vs operation) | historical layering artifact | **Doctrine clarification only.** Either (a) add a preset for `zscore_mean_reversion` (forbidden in v3.15.x scope per M7) or (b) document why the baseline is doctrinally listed but operationally absent. Recommend (b) for v3.15.x; (a) reserved as a v3.16 question. |
+| **N7** | `_METADATA_ONLY_FAMILIES` is a documented but undocumented-as-temporary seam | `partially_confirmed` | `direct` ([strategy_hypothesis_catalog.py:90–96](../../research/strategy_hypothesis_catalog.py)) | aesthetically imperfect but operationally correct | temporary compatibility seam | **Doctrine-only.** Add an EOL marker to the comment (e.g. "shrinks as families become executable") — already implicitly documented; make explicit. |
+| **N8** | Falsification → catalog-status feedback is `unverifiable`; if absent, `dangerous` | `unverifiable` | `inferred` (no automatic-flip mechanism observed read-only) | unverifiable→conservative `semantically dangerous` | unverifiable | **Highest-priority verification target.** Tagged with V7 in §22. |
+
+### §13.3 — Phase-2 violation count reconciliation
+
+Phase-2 stated 12 violations. The audit's verdict:
+
+| Phase-2 outcome | Count | Phase-2 violations |
+|---|---|---|
+| `confirmed` | 4 | V2, V8, V9, V10 |
+| `partially_confirmed` | 4 | V1, V3, V11, V12 |
+| `confirmed (downgraded by frozen-correctness reframing)` | 1 | V5 |
+| `refuted` (in strong form) | 1 | V4 |
+| `unverifiable` | 2 | V6, V7 |
+
+Plus 8 new violations (N1–N8) the audit surfaced. Total violation surface: 12 verified Phase-2 + 8 new = 20 candidate violations. Of these:
+
+| Frozen-correctness category | Count | Members |
+|---|---|---|
+| architecturally invalid | 0 | — |
+| semantically dangerous (or unverifiable→conservative-dangerous) | 4 | N1 (E1), V7 (`unverifiable`), N6, N8 (`unverifiable`) |
+| aesthetically imperfect but operationally correct | 16 | All others surviving as `confirmed` or `partially_confirmed` |
+
+**No violation in the entire audit is `architecturally invalid`.** The strongest readings are `semantically dangerous` (N1, N6) or `unverifiable→conservative-dangerous` (V7, N8).
+
+This is the audit's **central anti-prompt finding**: the codebase is not architecturally broken. It has frozen-correctness layering and migration-era residue, with a small set of misleading-authority signals (N1, N6) and two unverifiable hot-spots (V7, N8) that warrant runtime traces.
+
+---
+
+## §14 — Contradictions & Drift
+
+This section maps where the system's authorities disagree. Each entry: classification (`harmless | transitional | dangerous | load-bearing | misleading | obsolete`), domain, both sides, evidence.
+
+### §14.1 — Doctrine vs code
+
+| # | Doctrine | Code | Class | Evidence |
+|---|---|---|---|---|
+| C1 | "Engine is alpha-filter, not alpha-generator" (`qre_roadmap_v3 §3.1`) | Registry performs brute-force Cartesian sweep | `transitional` | [registry.py:6–8](../../research/registry.py) (self-documented) |
+| C2 | "≤3 params per strategy" (`AGENTS.md §3`) | `trend_pullback` (6 params), `trend_pullback_tp_sl` (8 params) | `transitional` (legacy strategies grandfathered; new strategies must comply) | [registry.py:99–117](../../research/registry.py); v3.15.3 ADR exempts pre-v3.5 entries |
+| C3 | "Frozen artifact contracts: research_latest.json, strategy_matrix.csv, candidate_registry_latest.v1.json" | Code respects this; tests pin it | `harmless` (consistent) | `test_v3_15_*_pin.py` |
+| C4 | "100% no-touch COL" (v3.15.2+) | Templates frozen catalog; picking outside catalog = bug ([campaign_templates.py:14–18](../../research/campaign_templates.py)) | `harmless` (consistent) | — |
+| C5 | "Tier-1 baselines: sma_crossover, zscore_mean_reversion, pairs_zscore" (`orchestrator_brief §4.1–4.3`) | `zscore_mean_reversion` registered + thin + bytewise-pinned but not bundle-active | `misleading` | §9.12 |
+| C6 | "live_eligible=False hard pin until v3.17" | Test pins it; no code path sets True | `load-bearing` (intentional pin) | `test_paper_no_live_invariant.py` |
+| C7 | "One edge per strategy; new edge = new strategy, never more parameters" | `trend_pullback_tp_sl` adds TP/SL execution-management params (8 named params) | `transitional` (grandfathered legacy) | [registry.py:99–117](../../research/registry.py) |
+
+### §14.2 — Ontology contradictions
+
+| # | Concept | Ontology A | Ontology B | Class | Evidence |
+|---|---|---|---|---|---|
+| O1 | "family" | Older axis: trend / mean_reversion / stat_arb (registry `family` field) | Newer axis (v3.15.3): trend_following / mean_reversion / breakout / stat_arb / trend_pullback / volatility_compression_breakout (registry `strategy_family` field) | `misleading` (for breakout_momentum specifically); `transitional` overall | §9.7, §9.12 |
+| O2 | "candidate" | Pipeline dict ([candidate_pipeline.py:251–287](../../research/candidate_pipeline.py)) | Lifecycle status enum value ([candidate_lifecycle.py:31–48](../../research/candidate_lifecycle.py)) | `transitional` (v3.12 active subset = 3 of 8) | §7.5 |
+| O3 | "evidence" | Per-candidate stage record ([screening_evidence.py](../../research/screening_evidence.py)) | Per-event ledger record ([campaign_evidence_ledger.py](../../research/campaign_evidence_ledger.py)) | `harmless` (different scopes, both canonical) | §7.6 |
+| O4 | "screening_phase" vs "pass_kind" | Phase = preset-level RI attribute (exploratory / standard / promotion_grade) | pass_kind = candidate-level outcome (None / standard / promotion_grade / exploratory) | `harmless` (near-redundant by intent — one is input, one is output) | [presets.py:54](../../research/presets.py) + [promotion.py:60–66](../../research/promotion.py) |
+| O5 | "diagnostic" | Hypothesis-status value (`HypothesisStatus`) | Preset-status value (`PresetStatus`) | `transitional` (the Phase-2 framing of "diagnostic should be a peer class" applies here; the seam `_METADATA_ONLY_FAMILIES` reconciles for hypotheses) | §11.2 |
+
+### §14.3 — Lifecycle contradictions
+
+| # | Lifecycle | Authority A says | Authority B says | Class | Evidence |
+|---|---|---|---|---|---|
+| L1 | Candidate post-promotion lifecycle | promotion.py classifies as `candidate` | falsification can flip to `rejected` | `transitional` if falsification re-emits artifact; `dangerous` if it mutates in place without re-emission | §7.7, V7 (`unverifiable`) |
+| L2 | Hypothesis status | catalog says `active_discovery` | runtime falsification of repeat campaigns may produce evidence that should demote it | `unverifiable` → conservative `dangerous` if no automatic feedback | §8.5, N8 |
+| L3 | Preset enabled vs strategy enabled | preset says enabled=False (pairs_equities_daily_baseline) | strategy bundled (pairs_zscore) is enabled=True in registry | `harmless` (preset wins; no campaign template is generated) | §9.13, §10.2 |
+| L4 | Lifecycle status RUNTIME-active (3) vs DEFINED (8) | runtime never reaches paper_ready+ at v3.12 | the enum has paper_ready, paper_validated, live_shadow_ready, live_enabled, retired defined | `harmless` (intentional phased rollout) | [candidate_lifecycle.py:51–60](../../research/candidate_lifecycle.py) |
+
+### §14.4 — Evidence-authority contradictions
+
+| # | Evidence | Authority A | Authority B | Class | Evidence |
+|---|---|---|---|---|---|
+| EA1 | Whether a campaign succeeded | `campaign_registry_latest.v1.json` outcome | `campaign_evidence_ledger.jsonl` events | `harmless` (registry is canonical for current state, ledger for history) | [campaign_funnel_policy.py:53–55](../../research/campaign_funnel_policy.py) |
+| EA2 | Whether a candidate is paper-ready | `paper_readiness_latest.v1.json` blocking_reasons | `screening_evidence_latest.v1.json` promotion_guard | `transitional` — promotion_guard is the v3.15.7+ override path; paper_readiness is the v3.15 gate | §7.9, V12 |
+| EA3 | Whether a strategy exists | `research/registry.py:STRATEGIES` | `research/strategy_hypothesis_catalog.py` (only for hypothesis-bridged strategies) | `misleading` for the 3 registered-but-inert strategies (the catalog has nothing to say about them) | E1, N1 |
+
+### §14.5 — Runtime vs artifact contradictions
+
+| # | Runtime state | Artifact state | Class | Evidence |
+|---|---|---|---|---|
+| RA1 | Candidate dict mutates during run (validation, fit_prior, screening) | `candidate_registry_latest.v1.json` is post-mutation snapshot | `harmless` (atomic write at run end) | §7.5, V9 |
+| RA2 | screening_evidence is in-memory builder during run | `screening_evidence_latest.v1.json` is non-frozen sidecar (regenerated each run) | `harmless` | §7.6 |
+| RA3 | Lifecycle status enum value at runtime | `candidate_registry_latest.v1.json` lifecycle_status field | `harmless` | §7.5 |
+| RA4 | Heartbeat / RunStateStore in-memory | `run_state_latest.v1.json` and run_meta artifacts | `harmless` (intentional separation) | §8.7 |
+
+### §14.6 — Migration-era contradictions
+
+| # | Older version says | Newer version says | Class | Evidence |
+|---|---|---|---|---|
+| ME1 | v3.5: registry `hypothesis` field is canonical TI prose | v3.15.3: catalog is canonical TI surface | `transitional` (registry hypothesis kept for byte-identity) | §6.1 row v3.5 + v3.15.3 |
+| ME2 | v3.10: `screening_mode` (strict/lenient/diagnostic) governs gate strictness | v3.15.6: `screening_phase` (exploratory/standard/promotion_grade) governs funnel stage | `harmless` (orthogonal by intent; documented at [presets.py:38–53](../../research/presets.py)) | §6.1 row v3.10 + v3.15.6 |
+| ME3 | v3.10: free-form preset metadata | v3.11: typed hypothesis metadata fields (rationale/expected_behavior/falsification/enablement_criteria) | `transitional` (older presets backfilled; new presets must include) | ADR-011 |
+| ME4 | Older `campaign_policy` derives policy from ledger | v3.15.10 `campaign_funnel_policy` is "pure" alternative; both coexist | `transitional` (no explicit deprecation) | V11 |
+| ME5 | Older trend_pullback (6 params) is a strategy | v3.15.3 trend_pullback_v1 (3 params, thin) is the canonical version | `transitional` (legacy intentionally not bridged to catalog) | §9.5, [registry.py:202–211](../../research/registry.py) |
+
+### §14.7 — Frozen-contract contradictions
+
+| # | Contract pins | Doctrine implies should change | Class | Evidence |
+|---|---|---|---|---|
+| FC1 | Registry `hypothesis` strings byte-identity | Catalog is canonical TI; registry strings are TI-prose-in-RI-surface | `load-bearing` (the contradiction *exists* for byte-identity preservation; resolution is post-v3.17) | V2 |
+| FC2 | `family` field on registry entries | Newer `strategy_family` axis supersedes older `family` axis | `load-bearing` | §9.7, O1 |
+| FC3 | Default `screening_phase="promotion_grade"` | AST test pins explicitness; default exists as a safety floor | `harmless` (intentional safety floor) | N4 |
+| FC4 | 30-template auto-generated catalog binds preset names + bundle compositions | Multi-bundle presets carry implicit TI plurality | `load-bearing` (changing preset shape changes template hashes) | §10.1, V1 |
+
+### §14.8 — Contradiction summary
+
+**Counts by class:**
+
+| Class | Count | Examples |
+|---|---|---|
+| `harmless` | 11 | RA1–RA4, EA1, L3, L4, O3, O4, ME2 |
+| `transitional` | 11 | C1, C2, C7, EA2, L1, ME1, ME3, ME4, ME5, O1 (overall), O2, O5 |
+| `dangerous` | 2 (both `unverifiable`) | L1 (if falsification mutates), L2 (if no automatic feedback) |
+| `load-bearing` | 4 | C6, FC1, FC2, FC4 |
+| `misleading` | 3 | C5, EA3, O1 (for breakout_momentum specifically) |
+| `obsolete` | 0 | — |
+
+**Verdict:** **No `obsolete` contradictions.** Every contradiction either has a planned resolution (`transitional`), is intentional safety scaffolding (`load-bearing`), or is harmless. The two `dangerous` items are both `unverifiable` and both depend on the same question (does falsification feed the catalog?) — see V7 and N8 in §13.
+
+---
+
+## §15 — Frozen Correctness vs Architectural Correctness
+
+This section explicitly distinguishes "ugly but correct" from "wrong." It applies to every flagged item across §13–§14.
+
+### §15.1 — What "frozen correctness" means here
+
+The codebase is **constraint-rich on purpose**. At least seven frozen-correctness mechanisms are visible:
+
+1. **Frozen artifact contracts** — `research_latest.json`, `strategy_matrix.csv`, `candidate_registry_latest.v1.json` (D2). Schema and field order pinned; row-by-row byte-identity tested.
+2. **Bytewise pin tests** — controlled fixtures across v3.5 → v3.15.x produce byte-identical output; tests catch any drift.
+3. **`live_eligible=False` hard pin** — D3 / C6. Source-scan + invariant test.
+4. **AST tests for explicitness** — `test_v3_15_6_preset_phase_explicitness.py` enforces every preset writes `screening_phase=...` keyword explicitly.
+5. **Static import-surface tests** — `test_static_import_surface.py` enforces diagnostics is read-only; `test_orchestration_boundary.py` enforces strategy/registry don't reach into orchestration.
+6. **Strict catalog validation at module import** — v3.15.4: ≥1 active_discovery hypothesis, all wired (executable strategy, bounded grid, eligible_campaign_types, canonical failure modes). Run cannot start with a broken catalog.
+7. **Idempotent event emission** — campaign_evidence_ledger and candidate_status_history use sha256(event payload) as event_id; duplicate events are no-ops.
+
+All seven are *load-bearing*. Removing or relaxing any of them would change byte-identity, replayability, auditability, or determinism.
+
+### §15.2 — When does "ugly" stop being a flaw?
+
+**A pattern is `aesthetically imperfect but operationally correct` when ALL of the following hold:**
+
+1. The pattern's removal would break a frozen contract or a bytewise pin test.
+2. The pattern's persistence does not produce wrong outcomes (the `dangerous` test from M9 fails).
+3. Doctrine has documented why the pattern persists (or could plausibly do so) — i.e. the pattern is *not* a hidden defect.
+
+**A pattern is `semantically dangerous` when:**
+
+- Conditions 1+2 do NOT both hold, AND
+- The pattern can cause silent wrong outcomes (e.g. a future Claude reads a misleading authority signal and acts on it; or a runtime mutation loses information that a downstream consumer needs).
+
+**A pattern is `architecturally invalid` when:**
+
+- The pattern violates a load-bearing invariant of the research operating system (e.g. layer boundary violation; ungrounded mutation of a frozen contract; bypass of a hard pin).
+
+### §15.3 — Audit-wide application
+
+Cross-referenced from §13 and §14:
+
+| Pattern | M9 category | Why |
+|---|---|---|
+| Registry `hypothesis` strings (V2) | aesthetically imperfect | Byte-identity binding (FC1); not dangerous (canonical TI is now the catalog, the strings are documentation). |
+| Preset multi-purpose dataclass (V1) | aesthetically imperfect | Each field has a different downstream consumer (§5.G); collapsing breaks consumers. |
+| Preset OI fields (V3) | aesthetically imperfect | Same reason. |
+| Five-flag diagnostic (V8) | aesthetically imperfect | All five fields have different consumers; documented at [presets.py:22–26](../../research/presets.py). |
+| Validation in-place mutation (V9) | aesthetically imperfect | Atomic artifact write at run end is canonical; runtime dict is transient. |
+| `fb_<sha1prefix>` fingerprint fallback (V10) | aesthetically imperfect | Counted in `summary.identity_fallbacks`; not silent. |
+| `family` vs `strategy_family` divergence (O1, N3) | aesthetically imperfect | Byte-identity binding (FC2). |
+| `breakout_momentum` family namespace mislabel | aesthetically imperfect | Same; misleading-readability only. |
+| Default `screening_phase="promotion_grade"` (N4) | aesthetically imperfect | AST-test-enforced safety floor. |
+| `bundle[0]` walk **does not exist** (V4 refuted) | n/a | Not a pattern; phantom. |
+| screening_phase preset-bound not candidate-bound (V5) | aesthetically imperfect | Phase is a preset-level intent; per-candidate phase would be additive sidecar in v3.16+. |
+| Two policy modules (V11, ME4) | aesthetically imperfect → `dangerous` if production runs ever produce conflicting outcomes (`unverifiable`) | Conservative reclassification pending runtime trace. |
+| Paper-readiness decoupled from funnel policy (V12) | aesthetically imperfect | Intentional decoupling; paper_readiness is OI gate, funnel is RI/OI policy. |
+| **Three registered-but-inert strategies (N1)** | **`semantically dangerous`** | Misleading authority signal. A future Claude reading `enabled=True` will plausibly assume the strategy is being investigated. |
+| **Tier-1 baseline doctrine vs operation drift (N6, C5)** | **`semantically dangerous`** | Doctrine cites baselines that aren't operationally exercised. |
+| **Falsification → catalog feedback unknown (V7, N8)** | **`unverifiable → conservative dangerous`** | Highest-priority verification target. |
+| Registry self-documented AGENTS.md violation (N2, C1) | aesthetically imperfect during the migration; `transitional` per M10 | Planned Phase 2 replacement. |
+| `_METADATA_ONLY_FAMILIES` set (N7) | aesthetically imperfect | Intentional reconciliation seam. |
+
+### §15.4 — The fundamental distinction
+
+**The audit's deepest claim is that this codebase is built under a doctrine of *frozen correctness over architectural perfection*.** Specifically:
+
+- Every test that pins behavior is doing so on purpose.
+- Every "ugly" duplication exists because removing it would break a bytewise pin.
+- Every "vestigial" field exists because a downstream consumer reads it.
+- Every legacy strategy that stays `enabled=True` does so because flipping it would break a registry-byte-identity test (`temporary compatibility seam`, until the migration completes).
+
+The corollary is that **most attempts to "improve architecture" by deleting / merging / collapsing fields will break frozen correctness without producing operational benefit**. The two patterns that genuinely *do* warrant architectural action are:
+
+1. **Misleading authority signals (N1, N6, C5)** — these can produce silent wrong outcomes (a future operator/Claude/Codex acts on a `enabled=True` signal that doesn't reflect operational reality). The fix is *doctrine*, not refactor: add a `bundle_active` derived view or a documented "registered ≠ investigated" semantic.
+
+2. **Falsification → catalog feedback (V7, N8) if absent** — if a hypothesis can fail repeatedly without its catalog status being demoted, the COL keeps spawning campaigns for it forever. This is `dangerous`, but `unverifiable` read-only. Resolution requires runtime tracing.
+
+These are the only two patterns where the audit recommends *action beyond doctrine*. Everything else is `aesthetically imperfect but operationally correct`.
+
+---
+
+## §16 — Legacy taxonomy
+
+The five-bucket taxonomy (A–E) is **derived** from §9–§15. Each item across the strategy / preset / hypothesis universes carries exactly one bucket assignment. Bucket sums must reconcile to the §4 inventory totals.
+
+### §16.1 — Bucket definitions
+
+| Bucket | Definition |
+|---|---|
+| **A** | Fundamentally wrongly modelled — the structure violates a load-bearing invariant of the research operating system. (M9: `architecturally invalid`.) |
+| **B** | Directly problematic — works today but encodes a meaning-vs-behavior mismatch that can produce silent wrong outcomes. (M9: `semantically dangerous`.) |
+| **C** | Just mislabeled — the logic is correct, only the category/name/status is wrong. (M9: subset of `aesthetically imperfect` where the imperfection is naming/categorization-only.) |
+| **D** | Safe to remove — dead code with no consumers. (M10: `historical layering artifact` with no current load-bearing role.) |
+| **E** | Must absolutely not change — load-bearing for byte-identity, frozen contracts, doctrinal correctness, or a planned migration's intentional bridge. (M9: `aesthetically imperfect but operationally correct`, OR cleanly correctly modelled.) |
+
+### §16.2 — Strategies (15 items)
+
+| Strategy | Bucket | Cross-ref |
+|---|---|---|
+| `rsi` | E | §9.1 |
+| `fear_greed` | D | §9.2 |
+| `bollinger_mr` | E | §9.3 |
+| **`bollinger_regime`** | **B** | §9.4 (registered-but-inert; misleading authority — N1) |
+| `trend_pullback` (legacy) | E | §9.5 (intentional migration bridge) |
+| **`trend_pullback_tp_sl`** | **B** | §9.6 (registered-but-inert; misleading authority — N1) |
+| `breakout_momentum` | C → E | §9.7 (family-namespace mislabel; but operationally correct) |
+| `earnings` | D | §9.8 |
+| `orb` | D | §9.9 |
+| `polymarket_expiry` | D | §9.10 (or E if Polymarket scope is intentional placeholder) |
+| `sma_crossover` | E | §9.11 (tier-1 baseline, bytewise-pinned) |
+| **`zscore_mean_reversion`** | **B** | §9.12 (registered-but-inert; misleading authority — N1) |
+| `pairs_zscore` | E | §9.13 (tier-1, scope-locked) |
+| `trend_pullback_v1` | E | §9.14 (active_discovery, load-bearing) |
+| `volatility_compression_breakout` | E | §9.15 (active_discovery, load-bearing) |
+
+**Strategy bucket sums:**
+
+| Bucket | Count |
+|---|---|
+| A | 0 |
+| B | 3 (`bollinger_regime`, `trend_pullback_tp_sl`, `zscore_mean_reversion`) |
+| C | 0 (breakout_momentum's mislabel re-categorized as E aesthetic) |
+| D | 4 (`fear_greed`, `earnings`, `orb`, `polymarket_expiry`) |
+| E | 8 (rsi, bollinger_mr, trend_pullback, breakout_momentum, sma_crossover, pairs_zscore, trend_pullback_v1, volatility_compression_breakout) |
+
+**Total: 0+3+0+4+8 = 15.** ✓ Matches §4.1.
+
+### §16.3 — Presets (7 items)
+
+Per §10:
+
+| Preset | Bucket | Cross-ref |
+|---|---|---|
+| `trend_equities_4h_baseline` | E (with `aesthetically imperfect` bundle plurality per V1) | §10.1 |
+| `pairs_equities_daily_baseline` | E (correctly shaped planned-but-disabled) | §10.2 |
+| `trend_regime_filtered_equities_4h` | E (string-label `regime_filter`; `aesthetically imperfect`) | §10.3 |
+| `trend_pullback_crypto_1h` | E | §10.4 |
+| `vol_compression_breakout_crypto_1h` | E | §10.5 |
+| `vol_compression_breakout_crypto_4h` | E | §10.6 |
+| `crypto_diagnostic_1h` | E (six-flag diagnostic; `aesthetically imperfect but operationally correct`) | §10.7 |
+
+**Preset bucket sums:** A=0, B=0, C=0, D=0, E=7. **Total 7.** ✓ Matches §4.2.
+
+The preview-draft assigned 3 presets to bucket A. On verification, **all 7 reduce to bucket E**. The preview-draft was wrong; see §22.
+
+### §16.4 — Hypotheses (7 items)
+
+Per §11:
+
+| Hypothesis | Bucket | Cross-ref |
+|---|---|---|
+| `trend_pullback_v1` | E | §11.1 |
+| `regime_diagnostics_v1` | C → E | §11.2 (the seam `_METADATA_ONLY_FAMILIES` reconciles) |
+| `atr_adaptive_trend_v0` | E | §11.3 |
+| `volatility_compression_breakout_v0` | E | §11.4 |
+| `multi_asset_trend_sleeve_v0` | E | §11.5 |
+| `cross_sectional_momentum_v0` | E | §11.6 |
+| `dynamic_pairs_v0` | E | §11.7 |
+
+**Hypothesis bucket sums:** A=0, B=0, C=0, D=0, E=7. **Total 7.** ✓ Matches §4.3.
+
+### §16.5 — Bucket totals
+
+| Universe | A | B | C | D | E | Total |
+|---|---|---|---|---|---|---|
+| Strategies | 0 | 3 | 0 | 4 | 8 | 15 |
+| Presets | 0 | 0 | 0 | 0 | 7 | 7 |
+| Hypotheses | 0 | 0 | 0 | 0 | 7 | 7 |
+| **Total** | **0** | **3** | **0** | **4** | **22** | **29** |
+
+**Zero items in bucket A.** The audit finds no strategy / preset / hypothesis that is `architecturally invalid`. The dominant category is E (correctly modelled or `aesthetically imperfect but operationally correct`).
+
+The 3 bucket-B items are the registered-but-inert strategies; their fix is doctrine (a `bundle_active` derived view or a "registered ≠ investigated" doctrine sentence), not refactor.
+
+The 4 bucket-D items are dead unregistered factories; safe to remove after a smoke test for stray imports.
+
+### §16.6 — Domain hierarchy: state of the model
+
+The Phase-2 plan proposed an 8-object hierarchy: Strategy / Hypothesis / Preset / Campaign / Candidate / PaperCandidate / ShadowCandidate / LiveCandidate.
+
+Per §7 verification, this hierarchy is **already substantially in place**:
+
+- **Strategy** — first-class function objects in `strategies.py`; identified by registry `name`.
+- **Hypothesis** — first-class `StrategyHypothesis` dataclass with closed status enum.
+- **Preset** — first-class `ResearchPreset` dataclass.
+- **Campaign** — first-class via `CampaignTemplate` + campaign registry record + ledger events.
+- **Candidate** — partially first-class: identity ✓, status enum ✓ (3 of 8 active), dict schema ✗ (implicit), mutation semantics ✗ (mixed).
+- **PaperCandidate** — emerges from `CandidateLifecycleStatus.PAPER_READY` (reserved-not-yet-active in v3.12; activated in v3.15).
+- **ShadowCandidate** — `LIVE_SHADOW_READY` (reserved for v3.16).
+- **LiveCandidate** — `LIVE_ENABLED` (reserved for v3.17).
+
+**Hierarchy verdict:** The Phase-2 hierarchy describes the *aspiration of the lifecycle enum*, which is already the doctrine. The work is not building the hierarchy — it's *activating* the reserved statuses incrementally as v3.16 and v3.17 land.
+
+**The audit explicitly rejects the framing of "no first-class hierarchy."** The hierarchy is documented; only the runtime activation is phased.
+
+---
+
+## §17 — Domain hierarchy: state of the model
+
+(See §16.6 — the hierarchy is documented in [candidate_lifecycle.py:31–48](../../research/candidate_lifecycle.py) and substantially in place. v3.12 activates 3 of 8; v3.15 activates 2 more (paper_ready, paper_validated); v3.16 activates `live_shadow_ready`; v3.17 activates `live_enabled` and `retired`.)
+
+**Per-object correctness verdict (consolidating §7):**
+
+| Object | Verdict | Notes |
+|---|---|---|
+| Strategy | Stable; soft authority drift (registered-but-inert) | Bucket-B items are the only concern. |
+| Hypothesis | Cleanest in the system | Doctrinal example. |
+| Preset | Multi-purpose; intentional layering | All presets bucket-E. |
+| Campaign | Clean two-axis (registry-snapshot + ledger-events) | No issues. |
+| Candidate | Partial reification; intentional phased rollout | V9 (in-place mutation) is `aesthetically imperfect`. |
+| Evidence | Clean append-only at event level + schema-versioned at run level | No issues. |
+| Falsification | Module exists; `unverifiable` line-level | V7/N8 are highest-priority verification targets. |
+| Promotion | Cleanest functional ontology | Phase-2 V/smell #4 is `superseded_by_newer_code`. |
+| Paper readiness | Clean closed taxonomy | V12 decoupling is intentional. |
+
+---
+
+## §18 — Target architecture (post-v3.15.15.6, conceptual)
+
+This section describes the post-v3.15.15.6 architecture **as the codebase is already heading**. Per §6, the architecture is in flight; the audit's job is to articulate the *destination*, not propose a new one.
+
+### §18.1 — Object model (conceptual)
+
+The target object model is **the existing model with the v3.16/v3.17 reserved statuses activated**:
+
+- **Strategy** — pure signal generator; identity = `(name, contract_version)`; immutable; registered in `STRATEGIES`.
+- **Hypothesis** — first-class TI claim; immutable; status flips driven by *evidence* (catalog promotion logic, partially `unverifiable` today).
+- **Preset** — research-protocol binding; one `hypothesis_id` per preset (post-migration; default `None` for legacy presets).
+- **Campaign** — finite-state machine; one preset-snapshot per campaign; bound to (preset, campaign_type, lineage).
+- **Candidate** — append-only event-stream conceptually; today an in-memory dict + per-stage sidecar artifacts. v3.16 reification = full dataclass + immutable post-emission semantics (per the lifecycle enum's reserved statuses).
+- **PaperCandidate / ShadowCandidate / LiveCandidate** — derived states of `Candidate` via lifecycle transitions. Conceptually they are not separate object classes — they are the candidate at different lifecycle status values.
+
+**The audit explicitly does NOT recommend separate Python classes for PaperCandidate / ShadowCandidate / LiveCandidate.** The lifecycle enum is the right abstraction; separate classes would multiply state and break the unified-state-machine intent of `FULL_LIFECYCLE_GRAPH`.
+
+### §18.2 — Truth-authority map (the ADR-014 proposal)
+
+The target architecture's missing piece is **a written settlement of authority pluralism** (§5.G). The proposal:
+
+| Concept | Canonical authority | Subordinate / consumer authorities |
+|---|---|---|
+| "This strategy exists as code" | `research/registry.py:STRATEGIES` | (no subordinates) |
+| "This strategy is bundled in some preset" | `research/presets.py:PRESETS` (all bundles + optional_bundles) | A *derived view* `bundle_active(strategy_name) -> bool` would consume this. |
+| "This hypothesis is canonical TI doctrine" | `research/strategy_hypothesis_catalog.py:STRATEGY_HYPOTHESIS_CATALOG` | Registry `hypothesis` strings = legacy/byte-identity-binding documentation only. |
+| "This hypothesis is eligible for autonomous campaign spawning" | `HypothesisStatus == "active_discovery"` in catalog | Preset's `hypothesis_id` references it; campaign-templates' `require_hypothesis_status` consumes it. |
+| "This preset is executable today" | `ResearchPreset.enabled` | (subordinate) `screening_phase` governs gate strictness; `diagnostic_only` etc. govern OI behavior. |
+| "This campaign is in-progress / completed / failed" | `campaign_registry_latest.v1.json` (current state) + `campaign_evidence_ledger.jsonl` (history) | Both canonical for their respective scopes. |
+| "This candidate's lifecycle status" | `CandidateLifecycleStatus` enum value as written to `candidate_registry_latest.v1.json` | Runtime `current_status` is transient. |
+| "This candidate is paper-ready" | `paper_readiness_latest.v1.json` `readiness_status` field | (subordinate) `screening_evidence.promotion_guard` is the upstream input. |
+| "This funnel-policy decision was emitted" | `campaign_evidence_ledger.jsonl` `funnel_decision_emitted` event | The pure `campaign_funnel_policy.FunnelDecision` is the in-memory representation. |
+
+**ADR-014 (proposed) is doctrine, not code.** Writing it does not break any frozen contract. It declares what the code already largely does, and it makes the registered-but-inert N1 case (E1 in §8.6) immediately legible as a doctrinal mismatch ("registered ≠ investigated").
+
+### §18.3 — What the architecture is NOT
+
+The target architecture is **not**:
+
+- A refactor of `ResearchPreset` to extract OI fields. (Would break byte-identity for negligible operational gain.)
+- A removal of registry `hypothesis` strings. (Same.)
+- A collapse of `screening_mode` and `screening_phase`. (Doctrine forbids; v3.15.7+ depends on the orthogonality.)
+- A new `Diagnostic` peer object class. (`_METADATA_ONLY_FAMILIES` is the explicit reconciliation seam.)
+- A sweeping rewrite of the candidate dict to a dataclass. (Phased reification per `CandidateLifecycleStatus`'s active subset is the right rate.)
+- An expansion of strategies beyond v3.17 stabilization. (M7 forbids.)
+
+---
+
+## §19 — Phased migration strategy
+
+Phases anchored on §6 historical layering, §15 frozen-correctness discipline, and §17 risk envelope.
+
+### §19.1 — Phase 1: Doctrine-only (immediate; pre-v3.16)
+
+**Goal:** Settle truth-authority pluralism (§18.2) and document seams without touching code.
+
+**Steps:**
+
+1. Write **ADR-014** (proposed): "Truth-authority map for the v3.15.15.6 codebase." Per §18.2 table.
+2. Add a doctrine sentence to `presets.py` module docstring: "A strategy is `enabled=True` in the registry iff it is *registerable*, not iff it is *currently being investigated*. The latter is a derived view of preset bundles." (Closes E1 / N1.)
+3. Add a doctrine sentence to `orchestrator_brief §4.1–4.3`: "Tier-1 baselines are *registered* baselines; their operational exercise is governed by the preset catalog. `zscore_mean_reversion` is registered but currently has no preset bundle; that is a known gap, not a code defect." (Closes C5 / N6.)
+4. Add a header comment to `campaign_policy.py`: "Older policy module; v3.15.10 introduced `campaign_funnel_policy.py` as the pure replacement. The two coexist during the migration; new policy logic should target funnel_policy." (Closes V11 / E2.)
+5. Add EOL marker to `_METADATA_ONLY_FAMILIES` comment: "this set shrinks as planned families become executable; expected to be empty at v3.17+." (Closes N7.)
+6. Add a "Phase 2 migration" comment block in `registry.py` clarifying the timeline of the brute-force-replacement (already begins at line 6–8; expand). (Documents N2 / C1.)
+
+**Risk:** Zero. Doc-only.
+
+**Closes:** V1 (partial), V2, V3 (partial), V11, V12 (partial), N1, N2, N3, N6, N7. (Plus C1, C5, E1, E2 partial.)
+
+### §19.2 — Phase 2: Verification (v3.16 window)
+
+**Goal:** Resolve the `unverifiable` items.
+
+**Steps:**
+
+1. **Runtime trace of falsification → catalog feedback.** Determine whether falsification can demote a hypothesis status, or only flip per-candidate verdicts. (Closes V7 / N8 / L1 / L2.) If feedback is missing and a hypothesis can fail repeatedly without demotion, this becomes the highest-priority Phase 3 work (`dangerous` per M9).
+2. **Runtime trace of two-policy module emissions** to confirm whether `campaign_funnel_policy` and `campaign_policy` ever produce conflicting decisions in production. (Closes V11 hard-confirmation.)
+3. **Runtime trace of SamplingPlan ↔ promotion_guard coupling** to confirm whether changes to the sampling plan can shift promotion outcomes outside the documented dispatch. (Closes V6.)
+
+**Risk:** Low. Trace-only. No code changes.
+
+### §19.3 — Phase 3: Targeted fixes (post-Phase-2; late v3.16)
+
+**Goal:** Address `dangerous` findings confirmed in Phase 2.
+
+**Steps (conditional on Phase 2 outcomes):**
+
+1. **If V7/N8 confirms missing falsification → catalog feedback:** Wire the catalog status update path. This is `dangerous` work and must respect the v3.15.4 strict invariant (≥1 active_discovery). Approach: emit a `hypothesis_status_demoted_by_repeat_falsification` event in the campaign ledger; require operator acknowledgement in v3.16 (no automatic catalog-status mutation), automatic in v3.17.
+2. **If V11 confirms conflicting decisions:** Retire `campaign_policy.py` in favor of `campaign_funnel_policy.py`. This is a *code-change* but is bounded — campaign_policy's surface is internal; no frozen artifact depends on its identity.
+3. **If V6 confirms harmful coupling:** Refactor `SamplingPlan` to be a value, not a relationship. Bounded; internal types.
+
+**Risk:** Medium. Each step is conditional and bounded. None touches frozen artifacts directly.
+
+### §19.4 — Phase 4: Cleanup (post-v3.17, post-live evidence)
+
+**Goal:** Retire migration bridges that are no longer load-bearing.
+
+**Steps (only after v3.17 stabilization + live evidence shows the new shape works):**
+
+1. Remove the 4 dead unregistered factories (`fear_greed`, `earnings`, `orb`, `polymarket_expiry`) from `agent/backtesting/strategies.py`. Smoke-test for stray imports first.
+2. Flip the 3 registered-but-inert strategies (`bollinger_regime`, `trend_pullback_tp_sl`, `zscore_mean_reversion`) to `enabled=False` IF AND ONLY IF the byte-identity test on the registry surface tolerates it (verify first). If not tolerated: keep `enabled=True` and rely on Phase 1's doctrine sentence + a `bundle_active` derived view.
+3. Promote `_METADATA_ONLY_FAMILIES` entries to executable hypotheses as their planned strategies land (`atr_adaptive_trend_v0`, etc.). Each promotion shrinks the set by one.
+4. Retire the legacy `family` field on registry entries IF AND ONLY IF byte-identity tests on `research_latest.json` etc. tolerate it. Prefer keeping it (FC2 is `load-bearing`).
+5. Make `hypothesis_id` mandatory on all enabled presets. Backfill where possible (e.g. `trend_equities_4h_baseline` could mint a hypothesis_id — but this requires the catalog to grow a bundling-aware row, which is a doctrinal question, not a refactor).
+
+**Risk:** Variable. Each step has an explicit gate ("IFF byte-identity tolerates"). Some steps may be permanently deferred if the byte-identity envelope never relaxes.
+
+### §19.5 — Migration phasing summary
+
+| Phase | Goal | Code change | Risk | Closes |
+|---|---|---|---|---|
+| 1 | Doctrine settlement | None | Zero | V1, V2, V3, V11, V12, N1, N2, N3, N6, N7, C1, C5, E1, E2 (mostly) |
+| 2 | Verification | None | Low | V6, V7, V11 (hard-confirm), N8 |
+| 3 | Targeted fixes (conditional) | Bounded internal | Medium | Whatever Phase 2 confirms as `dangerous` |
+| 4 | Cleanup (post-v3.17) | Bounded with byte-identity gates | Variable | Bucket-D removals + bucket-B `enabled` flips (subject to gates) |
+
+**Doctrine-vs-code work is 80%+ of the value at <5% of the risk.**
+
+---
+
+## §20 — Risk analysis (top-N migration steps)
+
+For the top 5 migration steps (across Phases 1–3), the audit assesses risk against five invariants:
+
+| Invariant | Definition |
+|---|---|
+| FC | Frozen artifact contracts (research_latest.json, strategy_matrix.csv, candidate_registry_latest.v1.json schemas) |
+| BI | Byte-identity test coverage (test_v3_15_*_pin.py family) |
+| HB | Hypothesis-bridge validation (v3.15.4 strict invariant) |
+| COL | COL no-touch invariant (template catalog frozen, picking outside catalog = bug) |
+| PR | Paper-readiness `live_eligible=False` pin |
+
+For each step: ✓ (no risk), ⚠ (some risk, mitigation needed), ✗ (likely break).
+
+### §20.1 — Risk matrix
+
+| # | Migration step (Phase) | FC | BI | HB | COL | PR |
+|---|---|---|---|---|---|---|
+| 1 | Write ADR-014 (Phase 1) | ✓ | ✓ | ✓ | ✓ | ✓ |
+| 2 | Doctrine sentences in presets.py / registry.py / orchestrator_brief (Phase 1) | ✓ | ⚠ (verify docstrings aren't bytewise-pinned) | ✓ | ✓ | ✓ |
+| 3 | Header comment on `campaign_policy.py` (Phase 1) | ✓ | ✓ | ✓ | ✓ | ✓ |
+| 4 | Runtime trace of falsification feedback (Phase 2) | ✓ | ✓ | ✓ | ✓ | ✓ |
+| 5 | Wire catalog status update path (Phase 3, conditional) | ⚠ (may add field to candidate_registry sidecar) | ⚠ (sidecar may grow) | ✗ (touches the v3.15.4 invariant directly — must not violate "≥1 active_discovery") | ⚠ (COL would consume the new event) | ✓ |
+| 6 | Retire `campaign_policy.py` (Phase 3, conditional) | ✓ | ⚠ (any test depending on the older module's imports breaks) | ✓ | ⚠ (COL must read funnel_policy only) | ✓ |
+| 7 | Refactor SamplingPlan (Phase 3, conditional) | ⚠ (screening_evidence sidecar may shift) | ⚠ (any test pinning the sampling block in the sidecar breaks) | ✓ | ✓ | ✓ |
+| 8 | Remove dead unregistered factories (Phase 4) | ✓ | ⚠ (no current consumer; verify) | ✓ | ✓ | ✓ |
+| 9 | Flip registered-but-inert `enabled=True` → `enabled=False` (Phase 4, conditional) | ⚠ (registry serialization may include enabled flag in some artifact) | ✗ if the registry rows are byte-pinned including the `enabled` field | ✓ | ✓ | ✓ |
+
+### §20.2 — Hard "do not even attempt without explicit gate clearance"
+
+- **Step 5 (catalog status update).** Cannot violate v3.15.4 strict invariant. Approach: emit-then-acknowledge in v3.16; automatic only post-v3.17.
+- **Step 9 (`enabled` flip).** Must verify byte-identity coverage before. If any sidecar serializes the `enabled` field, flipping it changes the artifact byte stream. Defer to post-v3.17 cleanup (Phase 4).
+- **Anything in Phase 3 that's not conditional on a Phase-2 trace.** No "preventive" refactors.
+
+### §20.3 — Mitigation patterns
+
+For every ⚠ row above:
+
+- **Parallel-emit window.** Old and new outputs both written for at least one full release; bit-comparison verifies they match.
+- **Sidecar before registry.** New fields land in non-frozen sidecars first; only promoted to frozen contract after multi-release evidence.
+- **Doctrine-first.** Every code change in Phase 3+ is preceded by a doctrine sentence in Phase 1.
+
+---
+
+## §21 — What absolutely NOT to change
+
+The following items are load-bearing for the research operating system as it exists at v3.15.15.6 + as the v3.16/v3.17 layers will land. Touching them carries risk that exceeds any architectural benefit.
+
+### §21.1 — Frozen contracts (do not modify their schemas)
+
+- `research_latest.json` (frozen schema; row count + column order pinned via `ROW_SCHEMA` in `research/results.py`).
+- `strategy_matrix.csv` (same schema as research_latest).
+- `candidate_registry_latest.v1.json` (v1 schema; byte-identity on frozen fixtures).
+- `strategy_hypothesis_catalog_latest.v1.json` (v1 schema).
+- `campaign_templates_latest.v1.json` (byte-identity for the 15 baseline rows; may grow additively per §6 v3.15.15 entry).
+
+### §21.2 — Pinned tests (do not weaken)
+
+- `test_paper_no_live_invariant.py` — `live_eligible=False` source-scan + monkeypatch invariant.
+- `test_orchestration_boundary.py` — strategy/registry imports nothing from orchestration/research.
+- `test_orchestration_default_complete_scope.py` — explicit `on_batch_complete=` per dispatch hook.
+- `test_orchestration_artifact_truth.py` — runtime/artifact agreement boundaries.
+- `test_v3_15_6_preset_phase_explicitness.py` — every preset writes `screening_phase=...` keyword.
+- `test_v3_15_6_preset_to_card_unchanged.py`, `test_v3_15_6_behavior_equivalent.py` — bytewise pins of preset → output flow.
+- `test_active_discovery_preset_bridge.py` — v3.15.4 strict invariant.
+- `test_strategy_hypothesis_catalog.py` — closed status enum + bounded grids.
+- `test_campaign_invariants.py` — campaign FSM.
+- `tests/functional/test_static_import_surface.py` — diagnostics import surface.
+
+### §21.3 — Doctrine-load-bearing patterns
+
+- `screening_mode` ↔ `screening_phase` orthogonality ([presets.py:38–53](../../research/presets.py)).
+- `live_eligible=False` hard pin on every v3.15+ artifact.
+- `reference_asset="ETH-EUR"` v3.6 scope lock on `pairs_zscore`.
+- `_METADATA_ONLY_FAMILIES` set as the explicit reconciliation seam between catalog and registry.
+- Default `screening_phase="promotion_grade"` as the AST-test-enforced safety floor.
+- The 30-template auto-generated catalog (no manual template additions).
+- The 4 v3.15.x active_discovery thin-strategies (`trend_pullback_v1`, `volatility_compression_breakout`) and their `contract_version="1.0"` pinning.
+- The `pairs_equities_daily_baseline` `enabled=False` shape — the doctrinal example of "planned-but-disabled."
+
+### §21.4 — Migration bridges (preserve through their lifetimes)
+
+- Legacy `trend_pullback` / `trend_pullback_tp_sl` registry entries with `strategy_family="trend_following"` (intentionally NOT bridged to catalog per [registry.py:202–211](../../research/registry.py)).
+- Registry `family` field alongside `strategy_family` (older + newer ontology coexisting; FC2).
+- Registry `hypothesis` free-form strings (legacy TI prose in RI surface; FC1).
+- The `fb_<sha1prefix>` evidence fingerprint fallback (counted in `summary.identity_fallbacks`; not silent).
+- The validation in-place mutation pattern at run_research.py:3019 (run-end atomic write is canonical).
+- The 6-flag diagnostic encoding on `crypto_diagnostic_1h` (each flag has a different consumer).
+- The brute-force Cartesian sweep in `registry.py` (acknowledged as Phase 2 migration target).
+
+### §21.5 — Roadmap-risk envelope (M7) — explicit
+
+No proposal in this audit:
+
+- Enables live trading. (Forbidden until v3.17.)
+- Bypasses paper or shadow gates. (Forbidden until v3.17.)
+- Removes any frozen contract. (Permanent.)
+- Breaks byte-identity. (Permanent.)
+- Collapses `screening_mode` and `screening_phase`. (Doctrine forbids.)
+- Recommends strategy expansion. (Forbidden until v3.17 stabilization.)
+
+---
+
+## §22 — Prompt Assumptions That Changed After Repo Inspection
+
+This section is the audit's anti-confirmation-bias accounting. Per M1 + verification check #14, if §22 is empty, the audit failed M1 — the verification work was not done. Below: every prompt / Phase-1 / Phase-2 / preview-draft claim that the verification matrix in §3 marked `partially_confirmed`, `refuted`, `superseded_by_newer_code`, or `unverifiable`, with the specific correction.
+
+### §22.1 — Refuted in strong form
+
+| Original claim | Source | Correction | Evidence |
+|---|---|---|---|
+| "16 strategy factories in agent/backtesting/strategies.py" | Phase-1 explore (X1.1) | **15** factories. The 16th was the `laad_fear_greed` HTTP helper (lines 73–105), miscounted. | [strategies.py](../../agent/backtesting/strategies.py) grep with digit-aware regex `^def [a-zA-Z0-9_]+_strategie` |
+| "Strategy proliferation is a problem" | Prompt (P6) | Strategy proliferation is **not** the problem. Only 11 strategies are registered; AGENTS.md and v3.15.3 explicitly forbid proliferation; 4 unregistered factories are dead code. The 8 active-bundle strategies are arguably *under-strategised* relative to the 6 enabled presets, not over-strategised. | §4.1, §9.16 |
+| "Implicit `bundle[0] → registry → strategy_family` walk in campaign policy" | Phase-2 V4 / preview-draft | **Refuted.** [presets.py:111–118](../../research/presets.py) explicitly says: *"no implicit `bundle[0] → registry → strategy_family` walk."* The walk does not exist in the v3.15.3+ enforcement path. | [presets.py:111–118](../../research/presets.py) |
+| "Promotion classification is not phase-aware" | Phase-2 V/smell #4 / preview-draft | **Superseded by v3.15.7.** [promotion.py:60–76](../../research/promotion.py) DOES dispatch on `pass_kind == "exploratory"` and downgrades to `STATUS_NEEDS_INVESTIGATION`. The remaining gap (`standard` vs `promotion_grade` classified identically) is real but minor and is itself partially intentional — see [promotion.py:71–76](../../research/promotion.py) where the comment notes byte-identical pre-v3.15.7 behavior for non-exploratory kinds. | [promotion.py:60–76](../../research/promotion.py) |
+| "Top finding: bundle order is implicit family selection" | Preview-draft (X3.1) | Refuted as above (X2.4 / V4). | Same. |
+| "Bucket-A presets: trend_equities_4h_baseline, trend_regime_filtered_equities_4h, crypto_diagnostic_1h" | Preview-draft (X3.2) | **All 7 presets are bucket-E** on verification. The 3 preview-A items are `aesthetically imperfect but operationally correct` per §15, not `architecturally invalid`. | §10, §16.3 |
+
+### §22.2 — Partially confirmed (downgraded in scope or strength)
+
+| Original claim | Source | Correction | Evidence |
+|---|---|---|---|
+| "TI / RI conflation is the dominant problem" | Prompt (P1), Phase-2 (X2.1) | **Partially confirmed.** TI/RI/OI is one of seven candidate explanatory models. The audit ranks it as a *partial lens* (§5.A). The dominant explanatory model is **migration-layer accumulation** (§5.D), which has higher repo coverage. Lifecycle drift (§5.B), ontology drift (§5.C), and authority confusion (§5.G) are all higher-coverage models for specific anomaly classes. | §5 entire |
+| "Twelve violations V1–V12 are real" | Phase-2 / preview-draft | 4 confirmed; 4 partially_confirmed; 1 confirmed-but-downgraded; 1 refuted; 2 unverifiable. Plus 8 new violations N1–N8 surfaced. **Of the surviving 20 candidates, 0 are `architecturally invalid`. 4 are `semantically dangerous` (or `unverifiable→conservative-dangerous`). 16 are `aesthetically imperfect but operationally correct`.** | §13.3 |
+| "8-object target hierarchy needed" | Phase-2 (X2.12) / preview-draft | **Already in place** as a status enum. [candidate_lifecycle.py:31–48](../../research/candidate_lifecycle.py) has 8 statuses; v3.12 actively uses 3, with 5 reserved for v3.15+. The hierarchy is documented; only runtime activation is phased. The Phase-2 framing of "no first-class hierarchy" misreads a deliberate phased rollout as confusion. | §16.6 |
+| "Candidate is implicit dict → must reify as dataclass" | Phase-2 V/N / preview-draft | **Partial.** Identity ✓ (sha256 of payload). Status enum ✓ (CandidateLifecycleStatus, 3 of 8 active). Dict schema ✗ (implicit). Mutation semantics ✗ (mixed in-place + deepcopy-then-mutate). Reification is mid-rollout; calling for a dataclass *now* is correct but understates how much is already done. | §7.5, §9-§17.1 |
+| "regime_diagnostics_v1 is mislabeled-as-hypothesis (category error)" | Phase-2 / preview-draft | **Partially correct.** The catalog already special-cases regime_diagnostics in `_METADATA_ONLY_FAMILIES`, exempting it from the active_discovery wiring requirement. The "mislabel" framing is too strong — the catalog already treats it as a separate kind, just not via a separate Python class. The `_METADATA_ONLY_FAMILIES` set is the explicit reconciliation seam. | §11.2, [strategy_hypothesis_catalog.py:90–96](../../research/strategy_hypothesis_catalog.py) |
+| "Diagnostic-as-five-fields" | Phase-2 V8 | **Six-fields-not-five** on `crypto_diagnostic_1h` (`status="diagnostic"` + `enabled=True` + `diagnostic_only=True` + `excluded_from_daily_scheduler=True` + `excluded_from_candidate_promotion=True` + `preset_class="diagnostic"`). The Phase-2 count was off by one. | [presets.py:500–504](../../research/presets.py) |
+| "trend_pullback (legacy) is a non-bridged shadow of trend_pullback_v1" | Preview-draft (X3.3) | **Confirmed but reframed.** It is non-bridged *intentionally* per [registry.py:202–211](../../research/registry.py): *"intentionally NOT part of the v3.15.3 hypothesis-catalog bridge."* The "shadow" is a documented `intentional migration bridge`, not an oversight. | [registry.py:202–211](../../research/registry.py) |
+| "trend_pullback_tp_sl busts AGENTS.md ≤3-params budget" | Preview-draft / Phase-2 | **Confirmed (8 named parameters).** But the audit's reading is `transitional` per M10 — legacy strategies are grandfathered; new strategies must comply. The violation is real but acknowledged in registry.py:6–8. | [registry.py:99–117](../../research/registry.py) |
+| "Two policy modules — campaign_funnel_policy + campaign_policy — ownership unclear" | Phase-2 V11 | **Partially confirmed.** Both modules exist (619 + 862 lines). Funnel policy is documented as "pure" (v3.15.10). Campaign_policy has not been explicitly declared deprecated. The ownership ambiguity is real, but is `transitional` per M10 — the migration is in flight. | §6.1 row v3.15.10 |
+
+### §22.3 — Confirmed-but-downgraded by frozen-correctness reframing
+
+| Original claim | Source | Correction | Evidence |
+|---|---|---|---|
+| "Validation result mutates candidate dict in-place — must reify Candidate immutable" | Phase-2 V9 / preview-draft | The mutation happens. But the audit reframes it as `aesthetically imperfect but operationally correct` because the `candidate_registry_latest.v1.json` is written from the post-mutation state at run end via atomic write; the runtime dict is transient. Reification is a Phase-2/3 incremental concern, not a v3.15.x emergency. | §13 V9, §15.3 |
+| "Evidence-fingerprint silent fallback `fb_<sha1prefix>`" | Phase-2 V10 / preview-draft | The fallback is **not silent** — it is counted in `summary.identity_fallbacks` per [screening_evidence.py:18–24](../../research/screening_evidence.py). Operators can detect upstream defects. Reframed as `aesthetically imperfect but operationally correct`. | [screening_evidence.py:18–24](../../research/screening_evidence.py) |
+| "Falsification post-promotion mutates verdict in place" | Phase-2 V7 / preview-draft | `unverifiable` at line level read-only. If confirmed, becomes `dangerous`; if not, `aesthetically imperfect`. Highest-priority Phase-2 verification target (§19.2). | §13 V7 |
+
+### §22.4 — Plan-file preview-draft claims explicitly rejected
+
+| Plan-file preview claim | Replacement |
+|---|---|
+| "The dominant collapse is TI ↔ RI inside ResearchPreset" | The dominant explanatory model is **migration-layer accumulation**; TI/RI/OI is a partial lens (§5.A), not the dominant frame. Verification check #16 forbids TI/RI/OI from leaking into §13/§16/§17/§18/§19 unless §5 had earned it — the audit complies. |
+| "12 violations as enumerated in Phase 2" | 4 confirmed; 8 partially-confirmed/superseded/refuted/unverifiable; plus 8 new violations N1–N8. Net: 20 candidates; 0 architecturally invalid. |
+| "Bucket-A items: trend_equities_4h_baseline, trend_regime_filtered_equities_4h, crypto_diagnostic_1h, the Candidate dict, SamplingPlan ↔ promotion_guard coupling" | All 5 reduce to bucket-E or bucket-B on verification. None are bucket-A. |
+| "Phase 2 reify Candidate as dataclass alongside dict" | Reification is *already* mid-rollout via `CandidateLifecycleStatus`'s reserved subset. Phase-2 framing was overstated. |
+| "Phase 3 extract PresetOperationalState from ResearchPreset" | Verification finds OI fields are `aesthetically imperfect but operationally correct` per §15.3. Extraction is not warranted; doctrine sentence (Phase 1) suffices. |
+
+### §22.5 — Methodological corrections
+
+| Earlier framing | Updated framing |
+|---|---|
+| The audit will adopt the TI/RI/OI model. | The audit evaluates seven explanatory models and adopts a composition: §5.D (dominant) + §5.B + §5.C + §5.G with §5.A as a partial lens, all constrained by §5.F. |
+| Separation-of-concerns is the dominant explanatory frame. | Separation-of-concerns is one frame; equally valid frames include lifecycle drift, ontology drift, and authority confusion. The audit reports all three. |
+| The architecture is broken / requires a refactor. | The architecture is **substantially more disciplined than the prompt suggests**. The dominant findings are doctrinal (truth-authority pluralism without written settlement) and `unverifiable` (falsification feedback path). Most code-level findings are migration-era residue, not defects. |
+
+### §22.6 — Anti-bias check (verification check #14)
+
+§22 contains:
+
+- **6 refuted-in-strong-form** prompt/Phase-2/preview-draft claims.
+- **9 partially-confirmed-with-scope-correction** claims.
+- **3 confirmed-but-downgraded** claims.
+- **5 plan-file preview claims explicitly rejected.**
+
+**§22 is non-empty by design.** The audit demonstrably downgraded multiple seed claims at every source layer (prompt, Phase-1, Phase-2, my own plan-file preview). M1 is satisfied.
+
+---
+
+## §23 — Verification trail
+
+This audit's verification is structural rather than runtime. The 16 checks defined in the plan file are recorded here with their evidence:
+
+| # | Check | Evidence | Status |
+|---|---|---|---|
+| 1 | Branch is `feature/v3.15.15-strategy-preset-fundamental-audit` | `git rev-parse --abbrev-ref HEAD` (executed at audit start) | ✓ |
+| 2 | Read-only: only this file + `docs/audits/` directory created | `git status` at commit time | (verified at commit) |
+| 3 | All 22 sections present and non-empty | This document | ✓ (§1–§22 + §23 trail) |
+| 4 | Mandatory sections present: §3, §5, §6, §7, §8, §14, §15, §22 | This document | ✓ |
+| 5 | Per-item coverage: every strategy/preset/hypothesis from §4 has its own A–E sub-section | §9 (15 strategies); §10 (7 presets); §11 (7 hypotheses) | ✓ (29 = 15+7+7 sub-sections) |
+| 6 | Status / evidence-strength tagging on every claim | §3 (every row has `status`); §5–§22 (claims tagged `direct/inferred/speculative` where it matters) | ✓ |
+| 7 | Frozen-correctness category on every flagged item in §13 | §13.1 + §13.2 (every row has M9 category) | ✓ |
+| 8 | Historical classification on every flagged item in §13 | §13.1 + §13.2 (every row has M10 classification) | ✓ |
+| 9 | Contradiction-class on every entry in §14 | §14.1–§14.7 + §14.8 summary | ✓ |
+| 10 | Citations: `direct` claims backed by `path/file.py:line` | §9–§22 throughout | ✓ |
+| 11 | Bucket totals: §16 sums equal §4 inventory | §16.5: 15+7+7 = 29; matches §4 | ✓ |
+| 12 | Roadmap-risk envelope: §18–§19 do not violate M7 | §21.5 explicit | ✓ |
+| 13 | Doctrine-alignment: §21 items each cite a frozen test or doctrine clause | §21.1–§21.4 | ✓ |
+| 14 | §22 non-empty (anti-bias check) | §22.6 explicit count | ✓ |
+| 15 | Pluralism check: §5 evaluates 7 candidate models with explicit verdicts | §5.A–§5.G + §5.H ranking | ✓ |
+| 16 | TI/RI/OI not leaked into §13/§16/§17/§18/§19 without §5 having earned it | §5 ranks TI/RI/OI as partial lens; §13/§16 reference it only as one of multiple frames; §18–§19 do not anchor on it | ✓ |
+
+---
+
+*End of audit. The audit document is the deliverable; no source/doc/test/config edits accompany it.*
+
+
+
+
+

--- a/docs/orchestrator_brief.md
+++ b/docs/orchestrator_brief.md
@@ -40,7 +40,7 @@ Inputs: price or spread * Parameters: lookback window, entry/exit thresholds * O
 reversion signal 3. **Pairs Trading (Statistical Arbitrage)** * Inputs: two asset price series 
 * Parameters: hedge ratio, z-score thresholds * Output: long/short pair positions ### 
 Constraints * each strategy must be independently testable * all parameters must be externally 
-configurable * no hardcoded constants --- ## 5. Orchestrator Responsibilities & Rules The 
+configurable * no hardcoded constants ### Authority note (ADR-014 §A / §E) Tier-1 baselines (§4.1 SMA Crossover, §4.2 Z-Score Mean Reversion, §4.3 Pairs Trading) are *registered* baselines. Operational exercise is governed by the preset catalog (`research/presets.py`), not by their presence in the registry. `zscore_mean_reversion` is currently registered without a preset bundle — that is a documented gap (ADR-014 §E), not a code defect. Use `research.authority_views.bundle_active(name)` to derive whether any enabled preset references a strategy. --- ## 5. Orchestrator Responsibilities & Rules The 
 orchestrator agent is responsible for enforcing system integrity and automation. ### 
 Responsibilities * Execute full pipeline: * data → features → strategy → execution → 
 evaluation * Schedule: * backtests * parameter sweeps * research experiments * Manage 

--- a/docs/roadmap/qre_prompt_guidelines_v2.md
+++ b/docs/roadmap/qre_prompt_guidelines_v2.md
@@ -21,6 +21,7 @@ Gebruik dit document altijd samen met:
 - `CLAUDE.md`
 - `orchestrator_brief.md`
 - de actuele roadmap (`qre_roadmap_v3_post_v3_15.md`)
+- `docs/adr/ADR-014-truth-authority-settlement.md` (canonical authority map; required reading before any change touching registry / presets / hypothesis catalog / candidate lifecycle)
 - eventuele handoff- of statusdocumenten van de direct voorgaande fase
 
 ---

--- a/docs/roadmap/qre_roadmap_v4.md
+++ b/docs/roadmap/qre_roadmap_v4.md
@@ -35,6 +35,10 @@ These MUST NEVER change:
 - strategy_matrix.csv
 - ROW_SCHEMA (results.py)
 
+## Authority Doctrine
+
+- ADR-014 (`docs/adr/ADR-014-truth-authority-settlement.md`, v3.15.15.10) — canonical authority map across registry, presets, hypothesis catalog, candidate lifecycle, campaign registry, paper readiness, and live governance. Required reading for any change touching authority surfaces. Defines `executable | enabled | bundle_active | active_discovery | live_eligible` as formally distinct concepts.
+
 ---
 
 # 2. CORE ARCHITECTURE RULES

--- a/research/authority_trace.py
+++ b/research/authority_trace.py
@@ -1,0 +1,415 @@
+"""Authority transition trace — opt-in append-only observability sidecar.
+
+ADR-014 §B / Phase 2 verification (audit §19.2). Makes cross-authority
+transitions diagnosable without changing any policy or schema.
+
+Default behavior: ``AuthorityTraceSink(path=None)`` is a no-op. Calling
+``emit(...)`` does nothing and creates no file. Existing tests see no
+new state. The sink is enabled by passing an explicit path (constructed
+at the orchestrator boundary from ``RESEARCH_AUTHORITY_TRACE_PATH``).
+
+Contract (mirrors ``research.campaign_evidence_ledger``):
+
+- JSONL body (``authority_trace_latest.v1.jsonl``) — one event per line.
+- Companion ``.meta.json`` carries the pin block (JSONL has no
+  top-level header).
+- Idempotent ``event_id`` (sha256 of stable fields). Replaying the same
+  event produces zero new lines.
+- Append-only. Crash-recovery is dedup-on-append.
+
+Layer rules (ADR-014 §A — preserve pure-function shape of decision
+modules):
+
+- This module MUST NEVER be imported from ``research.promotion``,
+  ``research.campaign_policy``, ``research.campaign_funnel_policy``,
+  ``research.falsification``, ``research.falsification_reporting``,
+  ``research.candidate_lifecycle``, ``research.paper_readiness``.
+  Trace emission happens at *callers* (``research.run_research``,
+  ``research.campaign_launcher``) so the pure modules stay pure.
+- This module MUST NEVER mutate any frozen artifact. The trace sidecar
+  is adjacent and additive.
+- Emission ordering: emit AFTER the authoritative sidecar/artifact
+  write returns successfully. Never emit-then-write.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Final, Iterable, Literal
+
+from research._sidecar_io import write_sidecar_atomic
+from research.campaign_os_artifacts import build_pin_block, iso_utc
+
+
+AUTHORITY_TRACE_SCHEMA_VERSION: Final[str] = "1.0"
+AUTHORITY_TRACE_VERSION: Final[str] = "v0.1"
+AUTHORITY_TRACE_META_SCHEMA_VERSION: Final[str] = "1.0"
+
+
+# Closed transition vocabulary. New transitions require an ADR amendment.
+TransitionKind = Literal[
+    "promotion_classified",
+    "candidate_registry_written",
+    "falsification_payload_emitted",
+    "catalog_persisted",
+    "campaign_state_transitioned",
+    "campaign_policy_decided",
+    "stale_authority_detected",
+]
+
+TRANSITION_KINDS: Final[tuple[str, ...]] = (
+    "promotion_classified",
+    "candidate_registry_written",
+    "falsification_payload_emitted",
+    "catalog_persisted",
+    "campaign_state_transitioned",
+    "campaign_policy_decided",
+    "stale_authority_detected",
+)
+
+
+# Closed authority vocabulary mirroring ADR-014 §A row labels.
+SOURCE_AUTHORITIES: Final[tuple[str, ...]] = (
+    "registry",
+    "presets",
+    "catalog",
+    "promotion",
+    "falsification",
+    "candidate_registry",
+    "campaign_registry",
+    "campaign_policy",
+)
+
+
+# ---------------------------------------------------------------------------
+# Environment-driven enablement.
+# ---------------------------------------------------------------------------
+
+ENV_VAR_TRACE_PATH: Final[str] = "RESEARCH_AUTHORITY_TRACE_PATH"
+
+
+def trace_path_from_env() -> Path | None:
+    """Return the trace path configured via ``RESEARCH_AUTHORITY_TRACE_PATH``.
+
+    Returns ``None`` when the env var is unset or empty — the caller
+    constructs an opt-in disabled sink in that case (no file created).
+    """
+    raw = os.environ.get(ENV_VAR_TRACE_PATH)
+    if not raw:
+        return None
+    return Path(raw)
+
+
+# ---------------------------------------------------------------------------
+# Event construction.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AuthorityTraceEvent:
+    """One line in the authority-trace JSONL.
+
+    The shape is intentionally narrow. Per-transition specifics belong in
+    ``evidence_hash`` (sha256 of the caller's compact-JSON evidence dict),
+    not in extra fields.
+    """
+
+    event_id: str
+    schema_version: str
+    ts_utc: str
+    run_id: str | None
+    transition_kind: str
+    source_authority: str
+    target_authority: str
+    hypothesis_id: str | None
+    candidate_id: str | None
+    evidence_hash: str
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "event_id": self.event_id,
+            "schema_version": self.schema_version,
+            "ts_utc": self.ts_utc,
+            "run_id": self.run_id,
+            "transition_kind": self.transition_kind,
+            "source_authority": self.source_authority,
+            "target_authority": self.target_authority,
+            "hypothesis_id": self.hypothesis_id,
+            "candidate_id": self.candidate_id,
+            "evidence_hash": self.evidence_hash,
+        }
+
+
+def _hash_evidence(evidence: dict[str, Any]) -> str:
+    """Deterministic sha256 of the compact-JSON form of ``evidence``."""
+    blob = json.dumps(evidence, sort_keys=True, ensure_ascii=False).encode(
+        "utf-8"
+    )
+    return hashlib.sha256(blob).hexdigest()
+
+
+def _build_event_id(
+    *,
+    run_id: str | None,
+    transition_kind: str,
+    source_authority: str,
+    target_authority: str,
+    candidate_id: str | None,
+    hypothesis_id: str | None,
+    ts_utc: str,
+) -> str:
+    """Pipe-delimited sha256 mirroring campaign_evidence_ledger.
+
+    Stable across replays of the same logical transition: same inputs
+    produce the same id, so dedup-on-append is replay-safe.
+    """
+    identifier = candidate_id or hypothesis_id or ""
+    parts = [
+        run_id if run_id is not None else "",
+        transition_kind,
+        source_authority,
+        target_authority,
+        identifier,
+        ts_utc,
+    ]
+    raw = "|".join(parts).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()
+
+
+def build_event(
+    *,
+    transition_kind: str,
+    source_authority: str,
+    target_authority: str,
+    ts_utc: datetime,
+    run_id: str | None = None,
+    hypothesis_id: str | None = None,
+    candidate_id: str | None = None,
+    evidence: dict[str, Any] | None = None,
+) -> AuthorityTraceEvent:
+    """Pure event factory. Loud-fails on closed-vocabulary violations."""
+    if transition_kind not in TRANSITION_KINDS:
+        raise ValueError(
+            f"unknown transition_kind {transition_kind!r}; "
+            f"must be one of {TRANSITION_KINDS!r}"
+        )
+    if source_authority not in SOURCE_AUTHORITIES:
+        raise ValueError(
+            f"unknown source_authority {source_authority!r}; "
+            f"must be one of {SOURCE_AUTHORITIES!r}"
+        )
+    if target_authority not in SOURCE_AUTHORITIES:
+        raise ValueError(
+            f"unknown target_authority {target_authority!r}; "
+            f"must be one of {SOURCE_AUTHORITIES!r}"
+        )
+    ts_iso = iso_utc(ts_utc)
+    evidence_dict = dict(evidence or {})
+    event_id = _build_event_id(
+        run_id=run_id,
+        transition_kind=transition_kind,
+        source_authority=source_authority,
+        target_authority=target_authority,
+        candidate_id=candidate_id,
+        hypothesis_id=hypothesis_id,
+        ts_utc=ts_iso,
+    )
+    return AuthorityTraceEvent(
+        event_id=event_id,
+        schema_version=AUTHORITY_TRACE_SCHEMA_VERSION,
+        ts_utc=ts_iso,
+        run_id=run_id,
+        transition_kind=transition_kind,
+        source_authority=source_authority,
+        target_authority=target_authority,
+        hypothesis_id=hypothesis_id,
+        candidate_id=candidate_id,
+        evidence_hash=_hash_evidence(evidence_dict),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sink — wraps the JSONL path; default no-op when path is None.
+# ---------------------------------------------------------------------------
+
+
+def _meta_path_for(jsonl_path: Path) -> Path:
+    """Companion ``.meta.json`` path adjacent to the JSONL.
+
+    ``authority_trace_latest.v1.jsonl`` →
+    ``authority_trace_latest.v1.meta.json``.
+    """
+    if jsonl_path.name.endswith(".jsonl"):
+        meta_name = jsonl_path.name[: -len(".jsonl")] + ".meta.json"
+    else:
+        meta_name = jsonl_path.name + ".meta.json"
+    return jsonl_path.with_name(meta_name)
+
+
+@dataclass(frozen=True)
+class AuthorityTraceSink:
+    """Append-only trace sink. Default-disabled when ``path`` is ``None``.
+
+    A disabled sink is a no-op: ``emit()`` does not write, does not create
+    any file, and does not raise. This makes the sink safe to inject at
+    every authoritative transition boundary without altering existing
+    test fixtures.
+    """
+
+    path: Path | None
+    git_revision: str | None = None
+    _enabled_marker: dict[str, bool] = field(
+        default_factory=lambda: {"meta_written": False}
+    )
+
+    @property
+    def enabled(self) -> bool:
+        return self.path is not None
+
+    def emit(self, event: AuthorityTraceEvent) -> bool:
+        """Append ``event`` if the sink is enabled and the id is new.
+
+        Returns ``True`` when a new line was written, ``False`` otherwise
+        (sink disabled OR replay duplicate).
+        """
+        if self.path is None:
+            return False
+        return _append_one(
+            self.path,
+            event,
+            git_revision=self.git_revision,
+            meta_marker=self._enabled_marker,
+        )
+
+
+def _append_one(
+    path: Path,
+    event: AuthorityTraceEvent,
+    *,
+    git_revision: str | None,
+    meta_marker: dict[str, bool],
+) -> bool:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    existing_ids = {ev["event_id"] for ev in read_trace(path)}
+    if event.event_id in existing_ids:
+        return False
+    line = json.dumps(event.to_payload(), sort_keys=True, ensure_ascii=False)
+    with path.open("a", encoding="utf-8", newline="\n") as handle:
+        handle.write(line)
+        handle.write("\n")
+    if not meta_marker.get("meta_written", False):
+        write_meta(
+            _meta_path_for(path),
+            generated_at_utc=datetime.now(UTC),
+            git_revision=git_revision,
+            ledger_path=str(path),
+            event_count=len(existing_ids) + 1,
+        )
+        meta_marker["meta_written"] = True
+    return True
+
+
+# ---------------------------------------------------------------------------
+# IO — read + meta. Read is dedup-aware; meta is canonical pin block.
+# ---------------------------------------------------------------------------
+
+
+def read_trace(path: Path) -> list[dict[str, Any]]:
+    """Read JSONL; deduplicate by ``event_id``; missing file → ``[]``.
+
+    Tolerates a corrupt tail line (skipped without raising), matching the
+    campaign_evidence_ledger pattern. Order: first-occurrence-wins.
+    """
+    if not path.exists():
+        return []
+    seen: set[str] = set()
+    out: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            event_id = event.get("event_id")
+            if not isinstance(event_id, str) or event_id in seen:
+                continue
+            seen.add(event_id)
+            out.append(event)
+    return out
+
+
+def write_meta(
+    meta_path: Path,
+    *,
+    generated_at_utc: datetime,
+    git_revision: str | None,
+    ledger_path: str | None,
+    event_count: int,
+) -> None:
+    """Emit / refresh the companion ``.meta.json`` pin block.
+
+    Pin block declares ``additive=True`` and references ADR-014 by id;
+    no consumer treats the trace sidecar as authoritative for any
+    decision.
+    """
+    pins = build_pin_block(
+        schema_version=AUTHORITY_TRACE_META_SCHEMA_VERSION,
+        generated_at_utc=generated_at_utc,
+        git_revision=git_revision,
+        run_id=None,
+        artifact_state="healthy",
+    )
+    payload = {
+        **pins,
+        "additive": True,
+        "doctrine_reference": "ADR-014",
+        "trace_schema_version": AUTHORITY_TRACE_SCHEMA_VERSION,
+        "trace_version": AUTHORITY_TRACE_VERSION,
+        "ledger_path": ledger_path,
+        "event_count": int(event_count),
+    }
+    write_sidecar_atomic(meta_path, payload)
+
+
+def append_events(
+    path: Path,
+    new_events: Iterable[AuthorityTraceEvent],
+    *,
+    git_revision: str | None = None,
+) -> list[AuthorityTraceEvent]:
+    """Bulk-append. Mirrors the campaign_evidence_ledger interface.
+
+    Idempotent on ``event_id``. Caller is responsible for cross-process
+    locking if used outside the run lifecycle.
+    """
+    sink = AuthorityTraceSink(path=path, git_revision=git_revision)
+    appended: list[AuthorityTraceEvent] = []
+    for event in new_events:
+        if sink.emit(event):
+            appended.append(event)
+    return appended
+
+
+__all__ = [
+    "AUTHORITY_TRACE_SCHEMA_VERSION",
+    "AUTHORITY_TRACE_VERSION",
+    "AUTHORITY_TRACE_META_SCHEMA_VERSION",
+    "ENV_VAR_TRACE_PATH",
+    "TRANSITION_KINDS",
+    "SOURCE_AUTHORITIES",
+    "AuthorityTraceEvent",
+    "AuthorityTraceSink",
+    "append_events",
+    "build_event",
+    "read_trace",
+    "trace_path_from_env",
+    "write_meta",
+]

--- a/research/authority_views.py
+++ b/research/authority_views.py
@@ -1,0 +1,163 @@
+"""Derived read-only authority views (ADR-014 §E).
+
+Pure derivations over the canonical authorities defined in
+ADR-014 §A. This module does NOT introduce a new authority; it
+exposes formal predicates that distinguish concepts that operators
+and downstream code would otherwise conflate.
+
+Authority sources (read-only, never mutated):
+
+- ``research.registry.STRATEGIES`` — canonical for "this strategy
+  exists as code" / ``enabled``.
+- ``research.presets.PRESETS`` — canonical for "this strategy is
+  bundled in some enabled preset". Driven via ``bundle`` and
+  ``optional_bundle`` fields, gated by ``preset.enabled``.
+- ``research.strategy_hypothesis_catalog.STRATEGY_HYPOTHESIS_CATALOG``
+  — canonical for "this strategy backs an active research
+  hypothesis". Bridged via the strategy's ``strategy_family``.
+
+Layer rules:
+
+- No IO; no mutation; no caching beyond function scope.
+- No artifact writes.
+- No decision-path side effects: this module is observability /
+  diagnostics only. Decision logic in
+  ``research.promotion``, ``research.campaign_policy``,
+  ``research.campaign_funnel_policy``, ``research.falsification``,
+  and ``research.paper_readiness`` MUST NOT consume these views.
+- No imports from runtime orchestration modules (``run_research``,
+  ``campaign_launcher``, ``runtime``, ``screening_runtime``,
+  ``candidate_pipeline``).
+
+See ``docs/adr/ADR-014-truth-authority-settlement.md`` for the
+canonical authority mapping.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from research.presets import PRESETS
+from research.registry import STRATEGIES
+from research.strategy_hypothesis_catalog import (
+    ALPHA_ELIGIBLE_STATUSES,
+    STRATEGY_HYPOTHESIS_CATALOG,
+)
+
+
+# Hard pin per ADR-014 §E. Live trading remains gated by the
+# no-live governance envelope through v3.17 regardless of any
+# strategy-level configuration. Mirrors ``paper_readiness`` invariant.
+_LIVE_ELIGIBLE_PIN: Final[bool] = False
+
+
+def _registry_row(strategy_name: str) -> dict | None:
+    for row in STRATEGIES:
+        if row.get("name") == strategy_name:
+            return row
+    return None
+
+
+def _is_registered(strategy_name: str) -> bool:
+    return _registry_row(strategy_name) is not None
+
+
+def _is_enabled(strategy_name: str) -> bool:
+    row = _registry_row(strategy_name)
+    if row is None:
+        return False
+    return bool(row.get("enabled", False))
+
+
+def bundle_active(strategy_name: str) -> bool:
+    """True iff ``strategy_name`` appears in ``bundle`` or
+    ``optional_bundle`` of at least one ``enabled=True`` preset.
+
+    Derived from ``research.presets.PRESETS``. Says nothing about
+    whether the strategy is registered or executable; for that, query
+    the registry directly.
+
+    Per ADR-014 §E: ``enabled=True`` in the registry does NOT imply
+    ``bundle_active=True``. The three registered-but-bundle-inert
+    strategies (``bollinger_regime``, ``trend_pullback_tp_sl``,
+    ``zscore_mean_reversion``) are the canonical example of
+    ``enabled=True`` and ``bundle_active=False`` coexisting by design.
+    """
+    for preset in PRESETS:
+        if not getattr(preset, "enabled", False):
+            continue
+        if strategy_name in preset.bundle:
+            return True
+        if strategy_name in preset.optional_bundle:
+            return True
+    return False
+
+
+def active_discovery(strategy_name: str) -> bool:
+    """True iff the strategy's ``strategy_family`` matches a hypothesis
+    with ``status="active_discovery"`` in the catalog.
+
+    Per ADR-014 §A: the catalog is canonical for hypothesis status.
+    Per ADR-014 §E: legacy / non-bridged strategies (e.g. legacy
+    ``trend_pullback`` and ``trend_pullback_tp_sl``, both registered
+    with ``strategy_family="trend_following"``) MUST return ``False``
+    because no ``active_discovery`` hypothesis carries that family —
+    the v3.15.3 bridge is explicit and excludes them.
+    """
+    row = _registry_row(strategy_name)
+    if row is None:
+        return False
+    family = row.get("strategy_family")
+    if not family:
+        return False
+    for hypothesis in STRATEGY_HYPOTHESIS_CATALOG:
+        if hypothesis.strategy_family != family:
+            continue
+        if hypothesis.status in ALPHA_ELIGIBLE_STATUSES:
+            return True
+    return False
+
+
+def live_eligible(strategy_name: str) -> bool:
+    """Hard-pinned ``False`` through the no-live governance envelope.
+
+    Per ADR-014 §E and the ``paper_readiness`` invariant. The
+    ``strategy_name`` argument is accepted for API symmetry with
+    ``bundle_active`` and ``active_discovery`` but does not influence
+    the result. Unregistered names still return ``False``.
+    """
+    del strategy_name  # noqa: F841 — accepted for API symmetry
+    return _LIVE_ELIGIBLE_PIN
+
+
+def render_authority_summary(strategy_name: str) -> str:
+    """One-line operator-readable summary of the derived authority
+    state for ``strategy_name``.
+
+    Format::
+
+        <name>: registered=<Y/N> enabled=<Y/N> bundle_active=<Y/N>
+        active_discovery=<Y/N> live_eligible=<Y/N>
+
+    Intended for CLI / diagnostic surfaces. Not consumed by any
+    decision path.
+    """
+    def _yn(value: bool) -> str:
+        return "Y" if value else "N"
+
+    return (
+        f"{strategy_name}: "
+        f"registered={_yn(_is_registered(strategy_name))} "
+        f"enabled={_yn(_is_enabled(strategy_name))} "
+        f"bundle_active={_yn(bundle_active(strategy_name))} "
+        f"active_discovery={_yn(active_discovery(strategy_name))} "
+        f"live_eligible={_yn(live_eligible(strategy_name))}"
+    )
+
+
+__all__ = [
+    "bundle_active",
+    "active_discovery",
+    "live_eligible",
+    "render_authority_summary",
+]

--- a/research/campaign_policy.py
+++ b/research/campaign_policy.py
@@ -1,5 +1,11 @@
 """Campaign policy engine — the pure ``decide(...)`` function.
 
+ADR-014 §C — transitional architecture: this is the older policy
+module. v3.15.10 introduced ``research.campaign_funnel_policy`` as
+the pure replacement. Both coexist during the migration; new policy
+logic should target ``campaign_funnel_policy``. Retirement of this
+module is conditional on Phase-2 trace evidence (audit §19.3 step 2).
+
 Executes the 5-phase, 8-step flow from plan §R3.2. Consumes only its
 explicit inputs; produces a single ``CampaignDecision`` and an artifact
 trace. Same inputs → byte-identical artifact (invariant I6).

--- a/research/presets.py
+++ b/research/presets.py
@@ -24,6 +24,13 @@ Layer boundaries:
   promotion layer and the scheduler unit. The safe default on
   missing metadata is "excluded" — a diagnostic run must never be
   silently promoted (see ADR-011 §9).
+
+ADR-014 §A / §E: a strategy is ``enabled=True`` in the registry iff
+it is *registerable*, not iff it is *currently being investigated*.
+Bundle activity is a derived view —
+``research.authority_views.bundle_active`` consumes ``PRESETS`` to
+answer "is this strategy referenced by an enabled preset bundle?".
+Registry presence does not imply preset participation.
 """
 
 from __future__ import annotations

--- a/research/registry.py
+++ b/research/registry.py
@@ -6,6 +6,13 @@ centrale bron voor alle strategieen, param-grids en metadata.
 # AGENTS.md rules violation - scheduled for Phase 2 replacement.
 # This file currently performs a brute-force Cartesian parameter sweep.
 # Phase 1 adds a size guard; Phase 2 will replace it with a hypothesis-driven envelope.
+# Phase 2 brute-force replacement is scheduled per audit §19.3.
+#
+# ADR-014 §A: this registry is the canonical authority for "this strategy
+# exists as code", NOT for "this strategy is currently being investigated".
+# A strategy may carry ``enabled=True`` here while being bundle-inert in
+# every preset. Use ``research.authority_views.bundle_active`` to derive
+# whether any enabled preset references the strategy.
 
 from itertools import product
 

--- a/research/run_research.py
+++ b/research/run_research.py
@@ -103,6 +103,16 @@ from research.strategy_hypothesis_catalog import (
     validate_active_discovery_preset_bridges,
     write_catalog_sidecar,
 )
+# v3.15.15.11 — opt-in authority transition trace (ADR-014). Default no-op
+# when ``RESEARCH_AUTHORITY_TRACE_PATH`` is unset; no file is created and
+# no behavior changes. Imported only at this orchestrator boundary so the
+# pure decision modules (promotion, campaign_policy, falsification, etc.)
+# stay pure.
+from research.authority_trace import (
+    AuthorityTraceSink,
+    build_event as _build_authority_trace_event,
+    trace_path_from_env as _authority_trace_path_from_env,
+)
 from research.portfolio_reporting import build_portfolio_aggregation_payload
 from research.promotion_reporting import build_candidate_registry_payload
 from research.recovery import (
@@ -258,6 +268,55 @@ def _git_revision() -> str:
 
 def _run_id(as_of_utc) -> str:
     return as_of_utc.strftime("%Y%m%dT%H%M%S%fZ")
+
+
+def _authority_trace_sink() -> AuthorityTraceSink:
+    """v3.15.15.11 — opt-in authority trace sink (ADR-014).
+
+    Returns a disabled sink (no-op ``emit``, creates no file) when the
+    env var ``RESEARCH_AUTHORITY_TRACE_PATH`` is unset or empty. Existing
+    behavior of every call site is preserved bit-for-bit in that case.
+    """
+    return AuthorityTraceSink(
+        path=_authority_trace_path_from_env(),
+        git_revision=_git_revision() or None,
+    )
+
+
+def _emit_authority_trace_safe(
+    *,
+    transition_kind: str,
+    source_authority: str,
+    target_authority: str,
+    ts_utc: datetime,
+    run_id: str | None,
+    hypothesis_id: str | None = None,
+    candidate_id: str | None = None,
+    evidence: dict[str, Any] | None = None,
+) -> None:
+    """Best-effort trace emission. Swallows any error so the trace
+    sidecar can never fail an authoritative write that already
+    succeeded (ADR-014 §B emission ordering rule).
+    """
+    try:
+        sink = _authority_trace_sink()
+        if not sink.enabled:
+            return
+        sink.emit(
+            _build_authority_trace_event(
+                transition_kind=transition_kind,
+                source_authority=source_authority,
+                target_authority=target_authority,
+                ts_utc=ts_utc,
+                run_id=run_id,
+                hypothesis_id=hypothesis_id,
+                candidate_id=candidate_id,
+                evidence=evidence,
+            )
+        )
+    except Exception:
+        # Trace is purely diagnostic — never fail the run on it.
+        pass
 
 
 def _preset_validation_is_strict() -> bool:
@@ -569,6 +628,21 @@ def _write_candidate_registry(
         screening_pass_kinds=screening_pass_kinds or None,
     )
     _write_json_atomic(path, payload)
+    # ADR-014 §A — emit AFTER the authoritative write returns. No-op when
+    # the trace sink is disabled (no env var → no file created).
+    _emit_authority_trace_safe(
+        transition_kind="candidate_registry_written",
+        source_authority="promotion",
+        target_authority="candidate_registry",
+        ts_utc=as_of_utc,
+        run_id=_run_id(as_of_utc),
+        evidence={
+            "candidate_count": len(payload.get("candidates", []))
+            if isinstance(payload, dict)
+            else 0,
+            "path": str(path),
+        },
+    )
 
 
 def _write_portfolio_aggregation_sidecar(
@@ -676,6 +750,20 @@ def _write_falsification_gates_sidecar(
         payload=payload,
         run_id=run_id,
         history_name="falsification_gates.v1.json",
+    )
+    # ADR-014 §A — falsification is post-hoc diagnostic evidence; trace
+    # records that the authoritative falsification sidecar landed.
+    _emit_authority_trace_safe(
+        transition_kind="falsification_payload_emitted",
+        source_authority="falsification",
+        target_authority="candidate_registry",
+        ts_utc=as_of_utc,
+        run_id=run_id,
+        evidence={
+            "candidate_count": int(payload.get("summary", {}).get("candidate_count", 0)),
+            "failed_gate_count": int(payload.get("summary", {}).get("failed_gate_count", 0)),
+            "path": str(path),
+        },
     )
     return payload
 
@@ -1912,6 +2000,17 @@ def _raise_degenerate_run(
             generated_at_utc=as_of_utc,
             git_revision=_git_revision(),
             run_id=run_id,
+        )
+        # ADR-014 §A — emit AFTER the catalog sidecar lands. Even on a
+        # degenerate run the catalog snapshot is authoritative, so the
+        # transition is recorded.
+        _emit_authority_trace_safe(
+            transition_kind="catalog_persisted",
+            source_authority="catalog",
+            target_authority="catalog",
+            ts_utc=as_of_utc,
+            run_id=run_id,
+            evidence={"site": "degenerate_hotfix", "outcome": "degenerate"},
         )
     except Exception as v3_15_3_exc:
         if tracker is not None:
@@ -3507,6 +3606,22 @@ def run_research(
             tracker.emit_event(
                 "v3_15_3_hypothesis_catalog_sidecars_written",
                 paths={name: path.as_posix() for name, path in v3_15_3_paths.items()},
+            )
+            # ADR-014 §A — emit AFTER the catalog sidecar successfully
+            # lands on the success path.
+            _emit_authority_trace_safe(
+                transition_kind="catalog_persisted",
+                source_authority="catalog",
+                target_authority="catalog",
+                ts_utc=as_of_utc,
+                run_id=str(state["run_id"]),
+                evidence={
+                    "site": "post_run",
+                    "paths": {
+                        name: path.as_posix()
+                        for name, path in v3_15_3_paths.items()
+                    },
+                },
             )
         except Exception as v3_15_3_exc:
             tracker.emit_event(

--- a/research/strategy_hypothesis_catalog.py
+++ b/research/strategy_hypothesis_catalog.py
@@ -87,6 +87,9 @@ COST_CLASSES: Final[tuple[str, ...]] = ("low", "medium", "high")
 # ``volatility_compression_breakout`` (now executable / active_discovery);
 # added ``multi_asset_trend_sleeve`` and ``cross_sectional_momentum``
 # (planned-tier, executable wiring deferred to follow-up branches).
+# ADR-014 §C: this set is a transitional reconciliation seam between
+# catalog and registry — it shrinks as planned families become
+# executable and is expected to be empty at v3.17+.
 _METADATA_ONLY_FAMILIES: Final[frozenset[str]] = frozenset({
     "regime_diagnostics",
     "atr_adaptive_trend",

--- a/tests/functional/test_static_import_surface.py
+++ b/tests/functional/test_static_import_surface.py
@@ -78,6 +78,10 @@ FORBIDDEN_PREFIXES: tuple[str, ...] = (
     "research.strategy_hypothesis_catalog",
     "research.integrity",
     "research.integrity_reporting",
+    # v3.15.15.11 — opt-in trace sink (ADR-014). Functional tests must
+    # not import it; production wiring lives in run_research.py.
+    "research.authority_trace",
+    "research.authority_views",
     # Forbidden subsystems.
     "agent",
     "execution",

--- a/tests/integration/test_authority_propagation.py
+++ b/tests/integration/test_authority_propagation.py
@@ -1,0 +1,288 @@
+"""Integration test for the v3.15.15.11 authority trace.
+
+Synthesizes the falsification → catalog persistence →
+campaign-state-transition flow with the trace sink configured. Verifies:
+
+- All expected events land in the JSONL.
+- Each event has a deterministic ``event_id`` and a stable
+  ``evidence_hash``.
+- The same logical sequence replays without producing duplicates.
+- A stale catalog state (a falsified hypothesis still showing
+  ``active_discovery``) is *detectable* — DOES NOT assert auto-correction.
+
+Important non-assertions: this test does NOT trigger or verify any
+catalog status mutation, falsification policy change, campaign policy
+change, or promotion threshold change. The trace is observability only.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from research.authority_trace import (
+    AuthorityTraceSink,
+    build_event,
+    read_trace,
+)
+from research.strategy_hypothesis_catalog import (
+    STRATEGY_HYPOTHESIS_CATALOG,
+)
+
+
+_T0 = datetime(2026, 4, 29, 12, 0, 0, tzinfo=UTC)
+
+
+def _emit_synthetic_flow(
+    sink: AuthorityTraceSink,
+    *,
+    run_id: str,
+    hypothesis_id: str,
+    candidate_id: str,
+) -> list[bool]:
+    """Emit a synthetic falsification → catalog → campaign sequence.
+
+    Returns the list of ``emit`` results (one per event in order).
+    """
+    results: list[bool] = []
+    # 1. Promotion classifies the candidate.
+    results.append(
+        sink.emit(
+            build_event(
+                transition_kind="promotion_classified",
+                source_authority="promotion",
+                target_authority="candidate_registry",
+                ts_utc=_T0,
+                run_id=run_id,
+                candidate_id=candidate_id,
+                evidence={"verdict": "candidate"},
+            )
+        )
+    )
+    # 2. Candidate registry sidecar is written.
+    results.append(
+        sink.emit(
+            build_event(
+                transition_kind="candidate_registry_written",
+                source_authority="promotion",
+                target_authority="candidate_registry",
+                ts_utc=_T0 + timedelta(seconds=1),
+                run_id=run_id,
+                candidate_id=candidate_id,
+                evidence={"path": "research/candidate_registry_latest.v1.json"},
+            )
+        )
+    )
+    # 3. Falsification gates emitted.
+    results.append(
+        sink.emit(
+            build_event(
+                transition_kind="falsification_payload_emitted",
+                source_authority="falsification",
+                target_authority="candidate_registry",
+                ts_utc=_T0 + timedelta(seconds=2),
+                run_id=run_id,
+                candidate_id=candidate_id,
+                evidence={"failed_gate_count": 1},
+            )
+        )
+    )
+    # 4. Catalog snapshot persisted.
+    results.append(
+        sink.emit(
+            build_event(
+                transition_kind="catalog_persisted",
+                source_authority="catalog",
+                target_authority="catalog",
+                ts_utc=_T0 + timedelta(seconds=3),
+                run_id=run_id,
+                hypothesis_id=hypothesis_id,
+                evidence={"path": "research/strategy_hypothesis_catalog_latest.v1.json"},
+            )
+        )
+    )
+    # 5. Campaign state transition (e.g. completed) recorded.
+    results.append(
+        sink.emit(
+            build_event(
+                transition_kind="campaign_state_transitioned",
+                source_authority="campaign_registry",
+                target_authority="campaign_registry",
+                ts_utc=_T0 + timedelta(seconds=4),
+                run_id=run_id,
+                evidence={"from": "running", "to": "completed"},
+            )
+        )
+    )
+    return results
+
+
+def test_full_flow_lands_in_jsonl(tmp_path: Path) -> None:
+    trace_path = tmp_path / "authority_trace_latest.v1.jsonl"
+    sink = AuthorityTraceSink(path=trace_path)
+    results = _emit_synthetic_flow(
+        sink,
+        run_id="20260429T120000000000Z",
+        hypothesis_id="trend_pullback_v1",
+        candidate_id="cand-001",
+    )
+    assert results == [True, True, True, True, True]
+    # All 5 events on disk in canonical sorted-key form.
+    events = read_trace(trace_path)
+    assert len(events) == 5
+    expected_kinds = [
+        "promotion_classified",
+        "candidate_registry_written",
+        "falsification_payload_emitted",
+        "catalog_persisted",
+        "campaign_state_transitioned",
+    ]
+    actual_kinds = [ev["transition_kind"] for ev in events]
+    assert actual_kinds == expected_kinds
+    # Every event has a unique event_id and a non-empty evidence_hash.
+    ids = {ev["event_id"] for ev in events}
+    assert len(ids) == 5
+    for ev in events:
+        assert isinstance(ev["evidence_hash"], str)
+        assert len(ev["evidence_hash"]) == 64  # sha256 hex
+
+
+def test_replaying_flow_is_idempotent(tmp_path: Path) -> None:
+    trace_path = tmp_path / "trace.v1.jsonl"
+    sink = AuthorityTraceSink(path=trace_path)
+    args = {
+        "run_id": "20260429T120000000000Z",
+        "hypothesis_id": "trend_pullback_v1",
+        "candidate_id": "cand-001",
+    }
+    first = _emit_synthetic_flow(sink, **args)
+    assert all(first)
+    # Replay the exact same flow; every event_id already exists → no
+    # new lines written.
+    second = _emit_synthetic_flow(sink, **args)
+    assert second == [False, False, False, False, False]
+    assert len(read_trace(trace_path)) == 5
+
+
+def test_disabled_sink_emits_no_events_for_full_flow(tmp_path: Path) -> None:
+    sink = AuthorityTraceSink(path=None)
+    results = _emit_synthetic_flow(
+        sink,
+        run_id="20260429T120000000000Z",
+        hypothesis_id="trend_pullback_v1",
+        candidate_id="cand-001",
+    )
+    assert results == [False, False, False, False, False]
+    assert list(tmp_path.iterdir()) == []
+
+
+# ---------------------------------------------------------------------------
+# Stale-authority detection (observability, not auto-correction)
+# ---------------------------------------------------------------------------
+
+
+def _detect_stale_active_discovery(
+    trace_events: list[dict],
+    catalog: tuple,
+) -> list[dict]:
+    """Pure detection helper. For each falsification_payload_emitted
+    event tied to a hypothesis_id, check whether the catalog still
+    carries that hypothesis as ``active_discovery``. Return the list
+    of staleness records.
+
+    This is observability only — it does NOT mutate the catalog.
+    """
+    by_id = {h.hypothesis_id: h for h in catalog}
+    stale: list[dict] = []
+    for ev in trace_events:
+        if ev["transition_kind"] != "falsification_payload_emitted":
+            continue
+        hid = ev.get("hypothesis_id")
+        if hid is None:
+            continue
+        hyp = by_id.get(hid)
+        if hyp is None:
+            continue
+        if hyp.status == "active_discovery":
+            stale.append(
+                {
+                    "hypothesis_id": hid,
+                    "current_status": hyp.status,
+                    "trace_event_id": ev["event_id"],
+                }
+            )
+    return stale
+
+
+def test_stale_authority_state_is_detectable_not_auto_corrected(
+    tmp_path: Path,
+) -> None:
+    # Pick a real active_discovery hypothesis — must remain
+    # active_discovery before AND after this test (no mutation).
+    target = next(
+        h for h in STRATEGY_HYPOTHESIS_CATALOG if h.status == "active_discovery"
+    )
+    pre_status = target.status
+
+    trace_path = tmp_path / "trace.v1.jsonl"
+    sink = AuthorityTraceSink(path=trace_path)
+    # Synthesize a falsification event tagged with the real hypothesis
+    # id. In a live system this would be one of many emissions; here
+    # one is enough to exercise the detector.
+    sink.emit(
+        build_event(
+            transition_kind="falsification_payload_emitted",
+            source_authority="falsification",
+            target_authority="candidate_registry",
+            ts_utc=_T0,
+            run_id="20260429T120000000000Z",
+            hypothesis_id=target.hypothesis_id,
+            candidate_id="cand-stale-1",
+            evidence={"failed_gate_count": 3},
+        )
+    )
+
+    events = read_trace(trace_path)
+    stale = _detect_stale_active_discovery(events, STRATEGY_HYPOTHESIS_CATALOG)
+
+    # Detection works: at least one staleness record surfaces.
+    assert len(stale) >= 1
+    assert any(s["hypothesis_id"] == target.hypothesis_id for s in stale)
+    # Critical non-assertion: the catalog row was NOT mutated.
+    post_status = next(
+        h for h in STRATEGY_HYPOTHESIS_CATALOG if h.hypothesis_id == target.hypothesis_id
+    ).status
+    assert post_status == pre_status == "active_discovery"
+
+
+# ---------------------------------------------------------------------------
+# Replay-safety on a torn trace file
+# ---------------------------------------------------------------------------
+
+
+def test_torn_trace_is_replay_safe(tmp_path: Path) -> None:
+    trace_path = tmp_path / "trace.v1.jsonl"
+    sink = AuthorityTraceSink(path=trace_path)
+    event = build_event(
+        transition_kind="catalog_persisted",
+        source_authority="catalog",
+        target_authority="catalog",
+        ts_utc=_T0,
+        run_id="20260429T120000000000Z",
+        hypothesis_id="trend_pullback_v1",
+        evidence={"path": "research/strategy_hypothesis_catalog_latest.v1.json"},
+    )
+    sink.emit(event)
+    # Simulate a torn append: write the event line again WITHOUT going
+    # through emit() so the dedup-on-emit path is bypassed.
+    with trace_path.open("a", encoding="utf-8", newline="\n") as h:
+        h.write(json.dumps(event.to_payload(), sort_keys=True))
+        h.write("\n")
+    # read_trace must still return one event.
+    out = read_trace(trace_path)
+    assert len(out) == 1
+    # Re-emit must still be a no-op (dedup picks it up).
+    assert sink.emit(event) is False

--- a/tests/regression/test_authority_invariants.py
+++ b/tests/regression/test_authority_invariants.py
@@ -1,0 +1,152 @@
+"""Regression invariants for the ADR-014 authority layer.
+
+These tests pin the additive / no-side-effect contract of
+``research.authority_views``:
+
+- the module never writes a frozen artifact (no IO at all);
+- it never imports a runtime / orchestration / decision module;
+- ``live_eligible`` derives ``False`` for every registered strategy
+  (the no-live governance envelope is global through v3.17);
+- the existing frozen sidecar artifact paths are not touched by
+  importing the views module.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from research.authority_views import live_eligible
+from research.registry import STRATEGIES
+
+
+_AUTHORITY_VIEWS_PATH = (
+    Path(__file__).resolve().parents[2] / "research" / "authority_views.py"
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. Live-eligible pin holds for every registered strategy.
+# ---------------------------------------------------------------------------
+
+
+def test_live_eligible_pin_holds_for_every_registered_strategy() -> None:
+    """ADR-014 §E + paper_readiness invariant: live_eligible is hard False."""
+    for row in STRATEGIES:
+        assert live_eligible(row["name"]) is False, (
+            f"live_eligible({row['name']!r}) must be False under the no-live "
+            f"governance envelope through v3.17."
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2. authority_views.py has no IO and no decision-path imports.
+# ---------------------------------------------------------------------------
+
+
+_FORBIDDEN_IMPORT_PREFIXES = (
+    # Runtime / orchestration modules.
+    "research.run_research",
+    "research.campaign_launcher",
+    "research.runtime",
+    "research.screening_runtime",
+    "research.candidate_pipeline",
+    # Decision / policy modules — must remain pure.
+    "research.promotion",
+    "research.campaign_policy",
+    "research.campaign_funnel_policy",
+    "research.falsification",
+    "research.falsification_reporting",
+    "research.candidate_lifecycle",
+    "research.paper_readiness",
+    # Trace module (will be added in v3.15.15.11; views must not consume it).
+    "research.authority_trace",
+    # IO helpers — views are pure read-only.
+    "research._sidecar_io",
+    "research.run_state",
+)
+
+
+_FORBIDDEN_IO_CALL_NAMES = frozenset(
+    {
+        "open",
+        "write",
+        "write_text",
+        "write_bytes",
+        "write_json_atomic",
+        "write_sidecar_atomic",
+    }
+)
+
+
+def _imported_modules(tree: ast.AST) -> list[str]:
+    out: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            out.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module is not None:
+                out.append(node.module)
+    return out
+
+
+def _called_functions(tree: ast.AST) -> set[str]:
+    """Collect Name and Attribute call targets from the AST."""
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Name):
+                names.add(func.id)
+            elif isinstance(func, ast.Attribute):
+                names.add(func.attr)
+    return names
+
+
+def test_authority_views_has_no_forbidden_imports() -> None:
+    tree = ast.parse(_AUTHORITY_VIEWS_PATH.read_text(encoding="utf-8"))
+    imported = _imported_modules(tree)
+    for name in imported:
+        for forbidden in _FORBIDDEN_IMPORT_PREFIXES:
+            assert not name.startswith(forbidden), (
+                f"authority_views.py must not import {name} — "
+                f"forbidden prefix {forbidden}"
+            )
+
+
+def test_authority_views_has_no_io_calls() -> None:
+    tree = ast.parse(_AUTHORITY_VIEWS_PATH.read_text(encoding="utf-8"))
+    called = _called_functions(tree)
+    leaks = called & _FORBIDDEN_IO_CALL_NAMES
+    assert leaks == set(), (
+        f"authority_views.py must not call IO functions — "
+        f"found: {sorted(leaks)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Importing authority_views does not touch frozen artifact paths.
+# ---------------------------------------------------------------------------
+
+
+_FROZEN_ARTIFACT_FILENAMES = (
+    "research_latest.json",
+    "strategy_matrix.csv",
+    "candidate_registry_latest.v1.json",
+    "strategy_hypothesis_catalog_latest.v1.json",
+    "campaign_templates_latest.v1.json",
+)
+
+
+def test_authority_views_source_does_not_reference_frozen_artifact_paths() -> None:
+    """Static guard: the module's source must not name any frozen artifact.
+
+    Frozen artifacts are owned by their canonical writers; views must not
+    even reference their paths to avoid future drift into write paths.
+    """
+    source = _AUTHORITY_VIEWS_PATH.read_text(encoding="utf-8")
+    for filename in _FROZEN_ARTIFACT_FILENAMES:
+        assert filename not in source, (
+            f"authority_views.py references frozen artifact {filename!r}; "
+            f"views must remain derivation-only."
+        )

--- a/tests/unit/test_authority_trace.py
+++ b/tests/unit/test_authority_trace.py
@@ -1,0 +1,330 @@
+"""Unit tests for ``research.authority_trace`` (v3.15.15.11).
+
+Pins the opt-in / additive contract:
+
+- ``AuthorityTraceSink(path=None)`` is a no-op: ``emit()`` returns
+  ``False`` and creates no file. Existing tests that don't configure
+  the trace path see no new state.
+- ``AuthorityTraceSink(path=...)`` writes one JSONL line per emit and
+  one ``.meta.json`` companion. Replaying the same event id is a
+  no-op (idempotency).
+- ``read_trace`` deduplicates by ``event_id`` so torn appends are
+  recoverable.
+- Closed-vocabulary inputs raise on unknown values.
+- Pure decision modules MUST NOT import ``research.authority_trace``.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from research.authority_trace import (
+    AUTHORITY_TRACE_META_SCHEMA_VERSION,
+    AUTHORITY_TRACE_SCHEMA_VERSION,
+    AUTHORITY_TRACE_VERSION,
+    AuthorityTraceEvent,
+    AuthorityTraceSink,
+    ENV_VAR_TRACE_PATH,
+    SOURCE_AUTHORITIES,
+    TRANSITION_KINDS,
+    append_events,
+    build_event,
+    read_trace,
+    trace_path_from_env,
+)
+
+
+_T = datetime(2026, 4, 29, 12, 0, 0, tzinfo=UTC)
+
+
+def _make(transition_kind: str = "catalog_persisted", **overrides) -> AuthorityTraceEvent:
+    base = {
+        "transition_kind": transition_kind,
+        "source_authority": "catalog",
+        "target_authority": "catalog",
+        "ts_utc": _T,
+        "run_id": "20260429T120000000000Z",
+        "evidence": {"site": "post_run"},
+    }
+    base.update(overrides)
+    return build_event(**base)
+
+
+# ---------------------------------------------------------------------------
+# Closed vocabulary
+# ---------------------------------------------------------------------------
+
+
+def test_transition_kinds_match_spec() -> None:
+    assert TRANSITION_KINDS == (
+        "promotion_classified",
+        "candidate_registry_written",
+        "falsification_payload_emitted",
+        "catalog_persisted",
+        "campaign_state_transitioned",
+        "campaign_policy_decided",
+        "stale_authority_detected",
+    )
+
+
+def test_source_authorities_match_spec() -> None:
+    assert SOURCE_AUTHORITIES == (
+        "registry",
+        "presets",
+        "catalog",
+        "promotion",
+        "falsification",
+        "candidate_registry",
+        "campaign_registry",
+        "campaign_policy",
+    )
+
+
+def test_build_event_rejects_unknown_transition_kind() -> None:
+    with pytest.raises(ValueError, match="unknown transition_kind"):
+        build_event(
+            transition_kind="not_a_kind",
+            source_authority="catalog",
+            target_authority="catalog",
+            ts_utc=_T,
+        )
+
+
+def test_build_event_rejects_unknown_authority() -> None:
+    with pytest.raises(ValueError, match="unknown source_authority"):
+        build_event(
+            transition_kind="catalog_persisted",
+            source_authority="not_an_authority",
+            target_authority="catalog",
+            ts_utc=_T,
+        )
+    with pytest.raises(ValueError, match="unknown target_authority"):
+        build_event(
+            transition_kind="catalog_persisted",
+            source_authority="catalog",
+            target_authority="not_an_authority",
+            ts_utc=_T,
+        )
+
+
+# ---------------------------------------------------------------------------
+# build_event shape + determinism
+# ---------------------------------------------------------------------------
+
+
+def test_build_event_shape() -> None:
+    event = _make()
+    payload = event.to_payload()
+    expected_keys = {
+        "event_id",
+        "schema_version",
+        "ts_utc",
+        "run_id",
+        "transition_kind",
+        "source_authority",
+        "target_authority",
+        "hypothesis_id",
+        "candidate_id",
+        "evidence_hash",
+    }
+    assert set(payload.keys()) == expected_keys
+    assert payload["schema_version"] == AUTHORITY_TRACE_SCHEMA_VERSION
+    assert payload["transition_kind"] == "catalog_persisted"
+    # Deterministic id + hash given identical inputs.
+    repeat = _make()
+    assert event.event_id == repeat.event_id
+    assert event.evidence_hash == repeat.evidence_hash
+
+
+def test_build_event_id_changes_with_evidence_unchanged_inputs() -> None:
+    """event_id ignores evidence; evidence_hash captures it."""
+    base = _make(evidence={"k": "v1"})
+    other = _make(evidence={"k": "v2"})
+    assert base.event_id == other.event_id
+    assert base.evidence_hash != other.evidence_hash
+
+
+def test_build_event_id_differs_per_transition_kind() -> None:
+    a = _make(transition_kind="catalog_persisted")
+    b = _make(transition_kind="falsification_payload_emitted",
+              source_authority="falsification",
+              target_authority="candidate_registry")
+    assert a.event_id != b.event_id
+
+
+# ---------------------------------------------------------------------------
+# Disabled sink — strict no-op
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_sink_emit_is_no_op_and_creates_no_file(tmp_path: Path) -> None:
+    sink = AuthorityTraceSink(path=None)
+    assert sink.enabled is False
+    result = sink.emit(_make())
+    assert result is False
+    # Confirm no files appeared anywhere under tmp_path.
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_disabled_sink_does_not_create_meta_file(tmp_path: Path) -> None:
+    sink = AuthorityTraceSink(path=None)
+    sink.emit(_make())
+    sink.emit(_make(transition_kind="falsification_payload_emitted",
+                    source_authority="falsification",
+                    target_authority="candidate_registry"))
+    assert list(tmp_path.iterdir()) == []
+
+
+# ---------------------------------------------------------------------------
+# Enabled sink — JSONL + meta + idempotency
+# ---------------------------------------------------------------------------
+
+
+def test_enabled_sink_writes_jsonl_and_meta(tmp_path: Path) -> None:
+    trace_path = tmp_path / "authority_trace_latest.v1.jsonl"
+    meta_path = tmp_path / "authority_trace_latest.v1.meta.json"
+    sink = AuthorityTraceSink(path=trace_path)
+    assert sink.enabled is True
+    appended = sink.emit(_make())
+    assert appended is True
+    assert trace_path.exists()
+    assert meta_path.exists()
+    # Sidecar shape.
+    line = trace_path.read_text(encoding="utf-8").splitlines()[0]
+    parsed = json.loads(line)
+    assert parsed["transition_kind"] == "catalog_persisted"
+    assert parsed["schema_version"] == AUTHORITY_TRACE_SCHEMA_VERSION
+
+
+def test_enabled_sink_emit_is_idempotent(tmp_path: Path) -> None:
+    trace_path = tmp_path / "trace.v1.jsonl"
+    sink = AuthorityTraceSink(path=trace_path)
+    event = _make()
+    assert sink.emit(event) is True
+    # Second call with identical event id: no new line.
+    assert sink.emit(event) is False
+    lines = trace_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+
+
+def test_read_trace_dedupes_torn_append(tmp_path: Path) -> None:
+    trace_path = tmp_path / "trace.v1.jsonl"
+    event = _make()
+    payload = json.dumps(event.to_payload(), sort_keys=True)
+    # Simulate a torn append: same event_id appears twice + one corrupt
+    # tail line that is invalid JSON.
+    trace_path.write_text(
+        payload + "\n" + payload + "\n" + "not-json{\n",
+        encoding="utf-8",
+    )
+    out = read_trace(trace_path)
+    assert len(out) == 1
+    assert out[0]["event_id"] == event.event_id
+
+
+def test_read_trace_missing_file_returns_empty(tmp_path: Path) -> None:
+    assert read_trace(tmp_path / "does_not_exist.jsonl") == []
+
+
+def test_meta_file_pin_block_shape(tmp_path: Path) -> None:
+    trace_path = tmp_path / "trace.v1.jsonl"
+    sink = AuthorityTraceSink(path=trace_path, git_revision="abc1234")
+    sink.emit(_make())
+    meta = json.loads(
+        (tmp_path / "trace.v1.meta.json").read_text(encoding="utf-8")
+    )
+    # Pin-block fields (mirrors campaign_evidence_ledger meta).
+    assert meta["schema_version"] == AUTHORITY_TRACE_META_SCHEMA_VERSION
+    assert meta["live_eligible"] is False
+    assert meta["authoritative"] is False
+    assert meta["diagnostic_only"] is True
+    # Trace-specific fields.
+    assert meta["additive"] is True
+    assert meta["doctrine_reference"] == "ADR-014"
+    assert meta["trace_schema_version"] == AUTHORITY_TRACE_SCHEMA_VERSION
+    assert meta["trace_version"] == AUTHORITY_TRACE_VERSION
+    assert meta["event_count"] == 1
+
+
+def test_append_events_skips_duplicates(tmp_path: Path) -> None:
+    trace_path = tmp_path / "trace.v1.jsonl"
+    e1 = _make()
+    e2 = _make(transition_kind="falsification_payload_emitted",
+               source_authority="falsification",
+               target_authority="candidate_registry")
+    appended_first = append_events(trace_path, [e1, e2])
+    assert len(appended_first) == 2
+    appended_second = append_events(trace_path, [e1, e2])
+    assert appended_second == []
+    assert len(read_trace(trace_path)) == 2
+
+
+# ---------------------------------------------------------------------------
+# Env-var enablement
+# ---------------------------------------------------------------------------
+
+
+def test_trace_path_from_env_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(ENV_VAR_TRACE_PATH, raising=False)
+    assert trace_path_from_env() is None
+
+
+def test_trace_path_from_env_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ENV_VAR_TRACE_PATH, "")
+    assert trace_path_from_env() is None
+
+
+def test_trace_path_from_env_set(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    target = tmp_path / "trace.v1.jsonl"
+    monkeypatch.setenv(ENV_VAR_TRACE_PATH, str(target))
+    assert trace_path_from_env() == target
+
+
+# ---------------------------------------------------------------------------
+# Forbidden-import surface (ADR-014 §A pure-function preservation)
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_PURE_MODULES_FORBIDDEN_IMPORT = (
+    "research/promotion.py",
+    "research/campaign_policy.py",
+    "research/campaign_funnel_policy.py",
+    "research/falsification.py",
+    "research/falsification_reporting.py",
+    "research/candidate_lifecycle.py",
+    "research/paper_readiness.py",
+)
+
+
+def _module_imports(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module is not None:
+                names.add(node.module)
+    return names
+
+
+@pytest.mark.parametrize("relative_path", _PURE_MODULES_FORBIDDEN_IMPORT)
+def test_pure_module_does_not_import_authority_trace(relative_path: str) -> None:
+    target = _REPO_ROOT / relative_path
+    assert target.exists(), f"missing protected module: {relative_path}"
+    imports = _module_imports(target)
+    for name in imports:
+        assert name != "research.authority_trace", (
+            f"{relative_path} imports research.authority_trace — pure "
+            f"decision modules must stay pure (ADR-014 §A)."
+        )
+        assert not name.startswith("research.authority_trace."), (
+            f"{relative_path} imports a submodule of "
+            f"research.authority_trace — same constraint."
+        )

--- a/tests/unit/test_authority_views.py
+++ b/tests/unit/test_authority_views.py
@@ -1,0 +1,182 @@
+"""Unit tests for ``research.authority_views`` (ADR-014 §E).
+
+Pins the derived-truth table for the registered strategies:
+
+- ``bundle_active`` reflects ``research.presets.PRESETS`` membership
+  (across ``bundle`` and ``optional_bundle``) gated by the preset's
+  ``enabled`` flag. The three registered-but-bundle-inert strategies
+  (``bollinger_regime``, ``trend_pullback_tp_sl``,
+  ``zscore_mean_reversion``) are the canonical
+  ``enabled=True`` ∧ ``bundle_active=False`` case (audit §8.6 / E1).
+- ``active_discovery`` is True only when the strategy's
+  ``strategy_family`` matches a hypothesis with
+  ``status="active_discovery"`` in the catalog. Legacy
+  ``trend_pullback`` / ``trend_pullback_tp_sl`` (registered with
+  ``strategy_family="trend_following"``) MUST return False — they are
+  intentionally NOT bridged to the v3.15.3 active_discovery row.
+- ``live_eligible`` is hard-pinned to ``False`` for every registered
+  strategy through the no-live governance envelope (ADR-014 §E).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from research.authority_views import (
+    active_discovery,
+    bundle_active,
+    live_eligible,
+    render_authority_summary,
+)
+from research.registry import STRATEGIES
+
+
+# ---------------------------------------------------------------------------
+# bundle_active truth table (ADR-014 §E + audit §4.1 / §4.2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        # Registered-but-bundle-inert (the audit's "misleading" finding).
+        ("bollinger_regime", False),
+        ("trend_pullback_tp_sl", False),
+        ("zscore_mean_reversion", False),
+        # pairs_zscore is bundled only in pairs_equities_daily_baseline,
+        # but that preset is enabled=False → not bundle_active.
+        ("pairs_zscore", False),
+        # Bundle-active in enabled presets.
+        ("sma_crossover", True),  # trend_equities_4h_baseline + filtered
+        ("breakout_momentum", True),
+        ("trend_pullback_v1", True),  # trend_pullback_crypto_1h
+        ("volatility_compression_breakout", True),
+        ("rsi", True),  # crypto_diagnostic_1h
+        ("bollinger_mr", True),  # crypto_diagnostic_1h
+        # Legacy trend_pullback is in optional_bundle of an enabled preset.
+        ("trend_pullback", True),
+        # Unknown strategy → False.
+        ("nonexistent_strategy", False),
+    ],
+)
+def test_bundle_active_truth_table(name: str, expected: bool) -> None:
+    assert bundle_active(name) is expected
+
+
+# ---------------------------------------------------------------------------
+# active_discovery truth table (ADR-014 §A + audit §3.4)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        # Two thin v3.15.3 / v3.15.4 active_discovery strategies.
+        ("trend_pullback_v1", True),
+        ("volatility_compression_breakout", True),
+        # Legacy trend_pullback / trend_pullback_tp_sl carry
+        # strategy_family="trend_following" — explicitly NOT bridged.
+        ("trend_pullback", False),
+        ("trend_pullback_tp_sl", False),
+        # Mean-reversion strategies have no active_discovery hypothesis.
+        ("rsi", False),
+        ("bollinger_mr", False),
+        ("bollinger_regime", False),
+        ("zscore_mean_reversion", False),
+        # SMA crossover and breakout_momentum carry strategy_family="trend_following"
+        # — no active_discovery hypothesis on that family.
+        ("sma_crossover", False),
+        ("breakout_momentum", False),
+        # Pairs zscore: stat_arb family has no active_discovery hypothesis.
+        ("pairs_zscore", False),
+        # Unknown strategy → False.
+        ("nonexistent_strategy", False),
+    ],
+)
+def test_active_discovery_truth_table(name: str, expected: bool) -> None:
+    assert active_discovery(name) is expected
+
+
+# ---------------------------------------------------------------------------
+# live_eligible hard pin
+# ---------------------------------------------------------------------------
+
+
+def test_live_eligible_false_for_every_registered_strategy() -> None:
+    for row in STRATEGIES:
+        assert live_eligible(row["name"]) is False
+
+
+def test_live_eligible_false_for_unknown_strategy() -> None:
+    assert live_eligible("nonexistent_strategy") is False
+
+
+# ---------------------------------------------------------------------------
+# render_authority_summary smoke
+# ---------------------------------------------------------------------------
+
+
+def test_render_summary_format_for_known_strategy() -> None:
+    summary = render_authority_summary("zscore_mean_reversion")
+    assert summary == (
+        "zscore_mean_reversion: registered=Y enabled=Y bundle_active=N "
+        "active_discovery=N live_eligible=N"
+    )
+
+
+def test_render_summary_format_for_unknown_strategy() -> None:
+    summary = render_authority_summary("nonexistent_strategy")
+    assert summary == (
+        "nonexistent_strategy: registered=N enabled=N bundle_active=N "
+        "active_discovery=N live_eligible=N"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Forbidden-import guard (ADR-014 §B / Plan §D1)
+# ---------------------------------------------------------------------------
+
+
+_FORBIDDEN_IMPORT_PREFIXES = (
+    "research.run_research",
+    "research.campaign_launcher",
+    "research.runtime",
+    "research.screening_runtime",
+    "research.candidate_pipeline",
+    "research.authority_trace",
+    "research.promotion",
+    "research.campaign_policy",
+    "research.campaign_funnel_policy",
+    "research.falsification",
+    "research.falsification_reporting",
+    "research.candidate_lifecycle",
+    "research.paper_readiness",
+)
+
+
+def _imported_modules(source_path: Path) -> list[str]:
+    tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    out: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            out.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module is not None:
+                out.append(node.module)
+    return out
+
+
+def test_authority_views_does_not_import_forbidden_modules() -> None:
+    module_path = (
+        Path(__file__).resolve().parents[2] / "research" / "authority_views.py"
+    )
+    imported = _imported_modules(module_path)
+    for forbidden in _FORBIDDEN_IMPORT_PREFIXES:
+        for name in imported:
+            assert not name.startswith(forbidden), (
+                f"authority_views.py must not import {name} — "
+                f"forbidden prefix {forbidden}"
+            )


### PR DESCRIPTION
## Summary

Implements:

* v3.15.15.10 — ADR-014 Truth Authority Settlement
* v3.15.15.11 — Authority Trace Verification

This release introduces:

* canonical authority doctrine (ADR-014)
* derived authority visibility (`bundle_active`, `active_discovery`, `live_eligible`)
* opt-in authority trace sidecar verification
* doctrinal clarification that:

  * `enabled=True` != actively investigated
  * registry != active research surface

## Key Guarantees

* no frozen artifact schema changes
* no policy logic changes
* no live-trading behavior changes
* no campaign template changes
* no enabled-flag flips
* authority trace remains opt-in and default no-op

## Verification

* full repo sweep green
* 2598 passed, 27 skipped, 0 failed
* frozen-contract tests green
* mypy / flake8 / bandit clean

## Deferred Risks (explicitly unchanged)

* falsification → automatic catalog mutation
* dual-policy coexistence
* candidate dataclass reification
* sampling-plan coupling
* registered-but-inert enabled strategies

See:

* ADR-014
* v3.15.15.6 audit
