### PR TITLE
Fix/v3.15.15.13 autonomy governance smoke

### DIFF
--- a/docs/governance/agent_run_summaries/v3.15.15.13_pr_body.md
+++ b/docs/governance/agent_run_summaries/v3.15.15.13_pr_body.md
@@ -1,0 +1,70 @@
+## Summary
+
+Adds a small read-only diagnostic surface on top of the v3.15.15.12 Claude Agent Governance & Safety Layer (ADR-015). Introduces `reporting.governance_status` — a stdlib-only library + CLI that reports policy / hook / ledger / version state, **decides nothing, mutates nothing**.
+
+This is the autonomous governance smoke release: the first test of fully autonomous programming under the new guardrails. Scope is intentionally tiny.
+
+## Why
+
+Operators currently have to read each governance artefact by hand to know whether the layer is intact. After v3.15.15.12 we have settings, hooks, audit ledger, autonomy ladder, build provenance, run summaries — but no single read-only surface that summarises them. CI and humans both benefit from a stable, redacted snapshot.
+
+## What this is NOT
+
+- Not a gate. CLI exits 0 even when state is degraded — diagnostics that gate themselves stop being diagnostics.
+- Not a replacement for `governance_lint.py`, `verify_chain()`, or `release_gate_checklist_runner.py`. Those remain the actual checks.
+- Not a loosening of any constraint. Every action that required operator approval before this diagnostic still requires it.
+
+## Files
+
+- `reporting/governance_status.py` (new) — library + CLI.
+- `tests/unit/test_governance_status.py` (new) — 17 tests.
+- `docs/governance/governance_status.md` (new) — meaning, non-meaning, when human approval is still required.
+
+No no-touch path edited. No frozen contract opened. No CI workflow changed. No new strategy. No threshold tuning. No live / shadow / paper enablement.
+
+## Behaviour
+
+`python -m reporting.governance_status` emits a JSON snapshot with stable top-level keys: `schema_version`, `report_kind`, `last_evaluation_at_utc`, `version`, `git`, `policy`, `hooks`, `autonomy`, `audit_ledger_today`, `autonomous_mode`.
+
+Unknown / missing state surfaces as `"unknown"` or `"not_available"`, never `"ok"`. The redacted ledger tail strips `command_summary`, `diff_summary`, and `target_path` so this surface cannot become a side channel into protected files.
+
+## Test plan
+
+- [x] `pytest tests/unit/test_governance_status.py` — 17/17 pass
+- [x] `pytest tests/unit/test_governance_status.py tests/unit/test_agent_audit.py tests/unit/test_hook_runtime.py tests/unit/test_hooks_*.py tests/unit/test_dashboard_api_*.py` — 305/305 pass
+- [x] `pytest tests/smoke` — 14/14 pass
+- [x] `pytest tests/regression` — 164 passed, 1 pre-existing skip
+- [x] `python scripts/governance_lint.py` — OK (15 agents, 3 workflows)
+- [x] `python -m reporting.agent_audit verify logs/agent_audit.<today>.jsonl` — chain intact
+- [x] `python -m ruff check reporting/governance_status.py tests/unit/test_governance_status.py` — clean
+- [x] `python -m mypy --explicit-package-bases reporting/governance_status.py tests/unit/test_governance_status.py` — clean
+- [x] frozen-contract checksums byte-identical pre and post change
+- [x] CLI run end-to-end on the real repo — emits a complete JSON snapshot
+
+## Frozen-contract check
+
+Both frozen contracts retained their pre-change SHA-256 across the entire change:
+
+- `research/research_latest.json`: `4a567bd6feb98eb7aa32db4a90a3201456843088314936c5e484a2ae6a93666c`
+- `research/strategy_matrix.csv`: `ff15b8c4f35cc37b6941b712106ae71a1b82a1b5043da197731d42518d258d66`
+
+A dedicated test (`test_collect_status_does_not_touch_frozen_contracts`) re-asserts this on every CI run.
+
+## Security check
+
+- `assert_no_secrets()` enforces no credential-pattern strings (Anthropic / GitHub PAT / AWS / private-key markers) and no sensitive-path fragments appear in any snapshot field. Tested in `test_assert_no_secrets_*`.
+- The redacted ledger tail strips user-controlled strings; tested in `test_intact_ledger_reports_intact_with_redacted_tail`.
+- Module is stdlib-only — no new dependency.
+
+## Out of scope (explicit)
+
+- No live / paper / shadow connector activation.
+- No threshold tuning.
+- No new strategy or alpha logic.
+- No CI workflow edits.
+- No `.claude/{settings.json,hooks/**,agents/**}` edits.
+- No `VERSION` bump.
+- No `CHANGELOG.md` edit (ask-only path; deferred to a follow-up if needed).
+- No frozen contract regenerated.
+
+Co-Authored-By: Claude Opus 4.7 (1M context)

--- a/docs/governance/governance_status.md
+++ b/docs/governance/governance_status.md
@@ -1,0 +1,103 @@
+# Governance Status — Read-only Diagnostic
+
+`reporting.governance_status` is a read-only diagnostic surface for the
+v3.15.15.12 Claude Agent Governance & Safety Layer. It reports — never
+decides, never mutates — whether the policy / hook / agent layer is
+present, what the audit ledger for today looks like, and what version
+and branch are checked out.
+
+It is the first observability artefact added on top of the governance
+layer (introduced in v3.15.15.13). It exists so that operators and CI
+can see the state of the layer without having to read each artefact by
+hand.
+
+## What it reports
+
+`python -m reporting.governance_status` prints a JSON snapshot with
+these top-level fields:
+
+| Field | Meaning |
+|---|---|
+| `schema_version` | Snapshot schema version. Currently `1`. Additive only — fields may be added; never removed or renamed without an ADR amendment. |
+| `report_kind` | Always `"governance_status"`. Identifies the artefact for downstream parsers. |
+| `last_evaluation_at_utc` | ISO-8601 UTC timestamp of when the snapshot was produced. The only intentionally non-deterministic field. |
+| `version.file_version` | Contents of `VERSION` (or `null` if missing). |
+| `git.branch`, `git.head_sha`, `git.on_main_branch` | From `git rev-parse`. `on_main_branch` is `"unknown"` when git is unavailable. |
+| `policy.settings_present` | Whether `.claude/settings.json` exists. The hook layer is keyed off this file; absent ⇒ no hook policy is loaded. |
+| `policy.agents_present` | Whether `.claude/agents/` exists with at least one agent definition. |
+| `hooks.layer_state` | One of `installed`, `degraded`, `not_available`. Never `ok`. |
+| `hooks.inventory` | Per-hook `present` / `missing` map across the expected set. |
+| `autonomy.max_available_level` | Highest level marked operationally available in `docs/governance/autonomy_ladder.md`, or `"unknown"` if the doc cannot be parsed. |
+| `autonomy.available_levels` | Sorted list of levels currently available, or `"unknown"`. |
+| `autonomy.level_6_status` | Hard-coded `"permanently_disabled"` per ADR-015 §Doctrine 1. `"unknown"` only if the ladder doc is missing or unparseable. |
+| `audit_ledger_today.status` | One of `intact`, `broken`, `unreadable`, `not_available`. Never `ok`. |
+| `audit_ledger_today.first_corrupt_index` | Index of the first event that fails `verify_chain()`, or `null` if intact / not available. |
+| `audit_ledger_today.{event,allowed,blocked,other}_count` | Per-outcome counts for today's UTC ledger. |
+| `audit_ledger_today.last_event` | Redacted tail: `sequence_id`, `timestamp_utc`, `outcome`, `tool`, `block_reason`, `branch`, `head_sha`. **Never** carries `command_summary`, `diff_summary`, or `target_path`. |
+| `autonomous_mode.status` | Always `"not_machine_enforceable"`. Whether a session is operating autonomously is a per-event runtime claim recorded in the ledger's `autonomy_level_claimed` field, not a global state. |
+
+## What it does *not* mean
+
+* It does **not** prove the hook layer is active. It only reports
+  whether the hook *files* exist. A misconfigured `.claude/settings.json`
+  could prevent the hooks from being invoked even when every file is
+  present. The release-gate-agent and the `governance-lint` CI job are
+  the actual checks.
+* `audit_ledger_today.status == "intact"` does **not** mean previous
+  days are intact. The hash chain restarts daily; older files are
+  verified separately by `python -m reporting.agent_audit verify
+  logs/agent_audit.<date>.jsonl`.
+* `git.on_main_branch == false` does **not** mean main-branch
+  protection is configured. Branch protection lives in the GitHub UI
+  (see `docs/governance/branch_protection_checklist.md`); this report
+  only mirrors the local working-copy branch.
+* `autonomy.max_available_level == 2` does **not** authorise an agent
+  to act at Level 2. Per-agent caps in `.claude/agents/*.md`
+  frontmatter and reviewer discipline still apply.
+* `autonomous_mode.status == "not_machine_enforceable"` does **not**
+  mean autonomous execution is disabled — only that *whether* a given
+  session was autonomous is a runtime claim, not a global flag.
+
+## When operator approval is still required
+
+Producing this snapshot does not loosen any governance constraint.
+Every action that required operator approval before this diagnostic
+was added still requires it:
+
+1. Any change to `.claude/hooks/**`, `.claude/agents/**`,
+   `.claude/settings.json`, `.github/CODEOWNERS`, or `VERSION` — only
+   via human-authored, CODEOWNERS-reviewed `governance-bootstrap` PRs.
+2. Any change to a no-touch path (see
+   [`no_touch_paths.md`](no_touch_paths.md)).
+3. Any merge to `main` — humans only, mediated by branch protection.
+4. Any deploy of an image — humans only, by digest.
+5. Any unlock of Level 4 or Level 5 — ADR amendment plus the stability
+   window in ADR-015.
+6. Level 6 — permanently disabled.
+
+## Failure modes
+
+The CLI exits 0 even when the snapshot reports degraded state. This
+is intentional: a diagnostic that gates CI by its own findings is no
+longer a diagnostic, it is policy. Reading the snapshot and deciding
+what to do is the operator's responsibility.
+
+If `reporting.governance_status` itself raises (for example because a
+sensitive-path fragment somehow appeared in the snapshot), the
+`assert_no_secrets()` self-check raises an `AssertionError` and the
+CLI exits non-zero. That is a *bug*, not a governance state — file an
+issue and use the previous snapshot until it is fixed.
+
+## Where it fits
+
+* **ADR-015 §Doctrine 5 — Audit-chain doctrine**: this report
+  surfaces a daily summary of the chain. It does not replace
+  `verify_chain()`.
+* **Doctrine 7 — Self-protected layer**: the diagnostic deliberately
+  reports presence rather than content of `.claude/settings.json` and
+  `.claude/hooks/**`, so that exposing the snapshot does not create a
+  side channel into protected files.
+* **Doctrine 13 — Run-summary doctrine**: per-session run summaries
+  remain the canonical bridge between the runtime ledger and Git
+  history. This snapshot is operator-facing, not session-facing, and
+  is not committed.

--- a/reporting/governance_status.py
+++ b/reporting/governance_status.py
@@ -1,0 +1,483 @@
+"""Read-only governance status snapshot.
+
+This module reports — never decides, never mutates — the current state
+of the v3.15.15.12 Claude Agent Governance & Safety Layer. It exists so
+operators and CI can confirm at a glance:
+
+* whether the policy / hook / agent definitions are present;
+* whether the audit ledger for today is reachable and chain-intact;
+* how many actions the hooks denied or allowed in the current daily
+  ledger;
+* what version, branch, and head SHA are checked out;
+* whether the working copy is on ``main`` (a soft signal — branch
+  protection, not this report, is the actual guard).
+
+Anything the module cannot determine deterministically is reported as
+``"unknown"`` or ``"not_available"``. Nothing is ever reported as
+``"ok"`` by default — ``ok`` requires positive evidence.
+
+Stdlib-only. No imports from ``research``, ``automation``, ``execution``,
+``orchestration``, or any trading-flow module.
+
+Usage::
+
+    python -m reporting.governance_status
+    python -m reporting.governance_status --indent 2
+
+The CLI prints a JSON document to stdout and exits 0. The exit code
+does *not* reflect governance health — this is a diagnostic, not a
+gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import re
+import subprocess
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+from reporting import agent_audit
+
+REPO_ROOT: Path = Path(__file__).resolve().parent.parent
+
+VERSION_FILE: Path = REPO_ROOT / "VERSION"
+SETTINGS_FILE: Path = REPO_ROOT / ".claude" / "settings.json"
+HOOKS_DIR: Path = REPO_ROOT / ".claude" / "hooks"
+AGENTS_DIR: Path = REPO_ROOT / ".claude" / "agents"
+LADDER_DOC: Path = REPO_ROOT / "docs" / "governance" / "autonomy_ladder.md"
+LEDGER_DIR: Path = REPO_ROOT / "logs"
+
+# Hook files we expect to exist as part of the v3.15.15.12 layer. Each
+# missing file is reported individually rather than collapsed into a
+# single boolean, so the operator can see exactly which guard is gone.
+EXPECTED_HOOKS: tuple[str, ...] = (
+    "_hook_runtime.py",
+    "audit_emit.py",
+    "deny_config_read.py",
+    "deny_dangerous_bash.py",
+    "deny_live_connector.py",
+    "deny_no_touch.py",
+    "deny_outside_agent_allowlist.py",
+    "deny_test_weakening.py",
+    "precompact_preserve.py",
+)
+
+# Keys that can legitimately appear in the snapshot. Every public value
+# is one of: a string, an int, a list of strings, a dict of strings, or
+# ``None``. The CLI / tests assert this shape.
+# A 3+-column markdown table row whose first column is digits-only.
+# Group 1 = the level number; group 2 = the last column's content. We
+# constrain every wildcard to non-pipe, non-newline characters so the
+# match cannot accidentally cross lines (note that \s includes \n by
+# default, which is why we use [ \t] for inter-cell whitespace).
+_AUTONOMY_AVAILABLE_RE = re.compile(
+    r"^\|[ \t]*(\d+)[ \t]*\|[^\n]*\|[ \t]*([^|\n]*?)[ \t]*\|[ \t]*$",
+    re.MULTILINE,
+)
+
+
+def _is_available_marker(text: str) -> bool:
+    """Treat a ladder cell as 'level is operationally available'.
+
+    The ladder doc uses prose like 'Always available', 'Available after
+    v3.15.15.12.3 active', 'Available after v3.15.15.12.4 active', or
+    'NOT enabled', 'Locked', 'Permanently disabled'. We accept only the
+    explicit ``Always available`` / ``Available after`` forms; anything
+    else (including the bare word 'available' inside 'NOT available')
+    is rejected.
+    """
+    lowered = text.strip().lower()
+    if lowered.startswith("always available"):
+        return True
+    return lowered.startswith("available after")
+
+
+def _read_text(path: Path) -> str | None:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+
+def _read_version() -> str | None:
+    raw = _read_text(VERSION_FILE)
+    if raw is None:
+        return None
+    stripped = raw.strip()
+    return stripped or None
+
+
+def _git_capture(args: list[str]) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=str(REPO_ROOT),
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    out = (result.stdout or "").strip()
+    return out or None
+
+
+def _git_branch() -> str | None:
+    return _git_capture(["rev-parse", "--abbrev-ref", "HEAD"])
+
+
+def _git_head_sha() -> str | None:
+    return _git_capture(["rev-parse", "HEAD"])
+
+
+def _hook_inventory() -> dict[str, str]:
+    """Return ``{hook_name: 'present' | 'missing'}`` for every expected hook."""
+    inventory: dict[str, str] = {}
+    for name in EXPECTED_HOOKS:
+        inventory[name] = "present" if (HOOKS_DIR / name).is_file() else "missing"
+    return inventory
+
+
+def _hook_layer_state(inventory: dict[str, str]) -> str:
+    """Aggregate inventory + settings into one of:
+
+    ``installed`` — every expected hook + ``settings.json`` present.
+    ``degraded``  — settings.json present but at least one hook missing.
+    ``not_available`` — settings.json itself missing.
+
+    The string is intentionally not ``ok``: callers must read the full
+    inventory to know which guard is missing.
+    """
+    if not SETTINGS_FILE.is_file():
+        return "not_available"
+    if all(state == "present" for state in inventory.values()):
+        return "installed"
+    return "degraded"
+
+
+def _autonomy_levels_available() -> dict[str, Any]:
+    """Parse the autonomy ladder doc for which levels are operationally
+    available right now. Anything we cannot parse is ``unknown``.
+    """
+    text = _read_text(LADDER_DOC)
+    if text is None:
+        return {
+            "doc_path": _rel(LADDER_DOC),
+            "max_available_level": "unknown",
+            "available_levels": "unknown",
+            "level_6_status": "unknown",
+        }
+    available: list[int] = []
+    seen_levels: set[int] = set()
+    for match in _AUTONOMY_AVAILABLE_RE.finditer(text):
+        try:
+            level = int(match.group(1))
+        except ValueError:
+            continue
+        if level in seen_levels:
+            # The ladder table is followed by a per-agent caps table that
+            # also starts each row with a number; we want only the first
+            # occurrence of each level (the ladder).
+            continue
+        seen_levels.add(level)
+        if 0 <= level <= 6 and _is_available_marker(match.group(2)):
+            available.append(level)
+    available_sorted = sorted(set(available))
+    if not available_sorted:
+        # We could not confidently identify any available level. Report
+        # unknown rather than guessing.
+        return {
+            "doc_path": _rel(LADDER_DOC),
+            "max_available_level": "unknown",
+            "available_levels": "unknown",
+            "level_6_status": "unknown",
+        }
+    return {
+        "doc_path": _rel(LADDER_DOC),
+        "max_available_level": max(available_sorted),
+        "available_levels": available_sorted,
+        # Level 6 is permanently disabled per ADR-015. We do not parse this
+        # claim — we hard-code it, because if we ever fail to find that
+        # statement in the doc, we still want the report to say so.
+        "level_6_status": "permanently_disabled",
+    }
+
+
+def _ledger_summary() -> dict[str, Any]:
+    """Summarise today's UTC audit ledger.
+
+    Never opens any past day's ledger; per the audit-chain doctrine, only
+    today's file is the authoritative tail. Past days are sealed and
+    verified out-of-band.
+
+    Returns a dict with ``status`` set to one of:
+
+    * ``not_available`` — file missing or empty.
+    * ``intact``        — chain verifies end-to-end.
+    * ``broken``        — chain breaks at index ``first_corrupt_index``.
+    * ``unreadable``    — the ledger exists but cannot be parsed.
+
+    Also returns counts (``allowed_count``, ``blocked_count``,
+    ``other_count``) and a redacted tail (last sequence_id, timestamp,
+    outcome — never command_summary or target_path).
+    """
+    today_path = agent_audit.current_ledger_path()
+    out: dict[str, Any] = {
+        "ledger_path": _rel(today_path),
+        "ledger_date_utc": _dt.datetime.now(_dt.UTC).strftime("%Y-%m-%d"),
+        "status": "not_available",
+        "first_corrupt_index": None,
+        "event_count": 0,
+        "allowed_count": 0,
+        "blocked_count": 0,
+        "other_count": 0,
+        "last_event": None,
+    }
+    if not today_path.exists() or today_path.stat().st_size == 0:
+        return out
+    try:
+        ok, first_bad = agent_audit.verify_chain(today_path)
+    except Exception:
+        out["status"] = "unreadable"
+        return out
+    out["status"] = "intact" if ok else "broken"
+    out["first_corrupt_index"] = first_bad
+    last: dict[str, Any] | None = None
+    count = 0
+    allowed = 0
+    blocked = 0
+    other = 0
+    try:
+        for ev in agent_audit.iter_events(today_path):
+            count += 1
+            outcome = ev.get("outcome")
+            if outcome == "blocked_by_hook":
+                blocked += 1
+            elif outcome == "ok":
+                allowed += 1
+            else:
+                other += 1
+            last = ev
+    except Exception:
+        out["status"] = "unreadable"
+        return out
+    # File has bytes but iter_events parsed nothing => the JSON decoder
+    # silently dropped every line. verify_chain returned True only
+    # because it walked an empty stream. Surface this as unreadable so
+    # the operator sees the discrepancy.
+    if count == 0 and today_path.stat().st_size > 0:
+        out["status"] = "unreadable"
+        out["first_corrupt_index"] = 0
+        return out
+    out["event_count"] = count
+    out["allowed_count"] = allowed
+    out["blocked_count"] = blocked
+    out["other_count"] = other
+    if last is not None:
+        # Redacted tail — omit command_summary, diff_summary,
+        # target_path. These can carry user-controlled strings; even
+        # though agent_audit redacts them for the ledger, we do not
+        # surface them via this status snapshot.
+        out["last_event"] = {
+            "sequence_id": last.get("sequence_id"),
+            "timestamp_utc": last.get("timestamp_utc"),
+            "outcome": last.get("outcome"),
+            "tool": last.get("tool"),
+            "block_reason": last.get("block_reason"),
+            "branch": last.get("branch"),
+            "head_sha": last.get("head_sha"),
+        }
+    return out
+
+
+def _branch_state() -> dict[str, Any]:
+    branch = _git_branch()
+    head = _git_head_sha()
+    if branch is None and head is None:
+        on_main: bool | str = "unknown"
+    else:
+        on_main = branch == "main"
+    return {
+        "branch": branch,
+        "head_sha": head,
+        "on_main_branch": on_main,
+        "main_branch_protection_authority": "github_branch_protection_outside_this_process",
+    }
+
+
+def _autonomous_mode_state() -> dict[str, Any]:
+    """The autonomous-execution flag is policy, not machine-detectable.
+
+    Settings.json describes what the *operator* may delegate; whether a
+    given session is being driven autonomously is a runtime claim by the
+    agent and is recorded per-event in the audit ledger
+    (``autonomy_level_claimed``). We therefore do not infer it here; we
+    return ``not_machine_enforceable`` plus a pointer to the ledger
+    field.
+    """
+    return {
+        "status": "not_machine_enforceable",
+        "evidence_field": "autonomy_level_claimed",
+        "evidence_source": "logs/agent_audit.<UTC date>.jsonl per-event",
+        "settings_present": SETTINGS_FILE.is_file(),
+    }
+
+
+def _rel(path: Path) -> str:
+    """Return a forward-slash, repo-relative path string. Never raises."""
+    try:
+        rel = path.relative_to(REPO_ROOT)
+    except ValueError:
+        return str(path).replace("\\", "/")
+    return str(rel).replace("\\", "/")
+
+
+def _last_evaluation_timestamp() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def collect_status() -> dict[str, Any]:
+    """Return the read-only governance status snapshot.
+
+    Determinism note: the snapshot is a function of repo state plus a
+    timestamp. The ``last_evaluation_at_utc`` field is the only
+    intentionally non-deterministic value; tests should pin it via
+    monkeypatching or treat it as opaque.
+    """
+    inventory = _hook_inventory()
+    return {
+        "schema_version": 1,
+        "report_kind": "governance_status",
+        "last_evaluation_at_utc": _last_evaluation_timestamp(),
+        "version": {
+            "file_version": _read_version(),
+            "version_file": _rel(VERSION_FILE),
+        },
+        "git": _branch_state(),
+        "policy": {
+            "settings_file": _rel(SETTINGS_FILE),
+            "settings_present": SETTINGS_FILE.is_file(),
+            "agents_dir": _rel(AGENTS_DIR),
+            "agents_present": AGENTS_DIR.is_dir(),
+        },
+        "hooks": {
+            "layer_state": _hook_layer_state(inventory),
+            "expected": list(EXPECTED_HOOKS),
+            "inventory": inventory,
+            "hooks_dir": _rel(HOOKS_DIR),
+        },
+        "autonomy": _autonomy_levels_available(),
+        "audit_ledger_today": _ledger_summary(),
+        "autonomous_mode": _autonomous_mode_state(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Self-check helpers (used by tests)
+# ---------------------------------------------------------------------------
+
+
+# Patterns we never want to see leaving the snapshot. This is a defense
+# layer; the underlying agent_audit.append_event already redacts these
+# before they reach disk, but the status surface re-applies the check
+# at presentation time.
+_FORBIDDEN_VALUE_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"sk-ant-[A-Za-z0-9_\-]{8,}"),
+    re.compile(r"ghp_[A-Za-z0-9]{8,}"),
+    re.compile(r"github_pat_[A-Za-z0-9_]{8,}"),
+    re.compile(r"AKIA[0-9A-Z]{12,}"),
+    re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"),
+)
+
+_FORBIDDEN_VALUE_FRAGMENTS: tuple[str, ...] = (
+    "config/config.yaml",
+    "live_gate.secret",
+    "fred.secret",
+    "operator_token.secret",
+    "dashboard_session.secret",
+)
+
+
+def _walk_strings(obj: Any) -> Iterable[str]:
+    if isinstance(obj, str):
+        yield obj
+        return
+    if isinstance(obj, dict):
+        for v in obj.values():
+            yield from _walk_strings(v)
+        return
+    if isinstance(obj, list | tuple):
+        for v in obj:
+            yield from _walk_strings(v)
+
+
+def assert_no_secrets(snapshot: dict[str, Any]) -> None:
+    """Raise ``AssertionError`` if the snapshot contains a forbidden
+    string. The check is conservative: any high-entropy credential
+    pattern OR any literal sensitive-path fragment counts.
+
+    The snapshot is supposed to be entirely path/state metadata — there
+    is no legitimate reason for a credential or secret-path string to
+    appear in it.
+    """
+    for s in _walk_strings(snapshot):
+        for pat in _FORBIDDEN_VALUE_PATTERNS:
+            if pat.search(s):
+                raise AssertionError(
+                    f"governance_status leaked credential-like string: pattern={pat.pattern!r}"
+                )
+        lowered = s.lower()
+        for frag in _FORBIDDEN_VALUE_FRAGMENTS:
+            if frag in lowered:
+                raise AssertionError(
+                    f"governance_status leaked sensitive path fragment: {frag!r}"
+                )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m reporting.governance_status",
+        description=(
+            "Print a JSON snapshot of the v3.15.15.12 Claude Agent "
+            "Governance & Safety Layer state. Read-only; decides nothing."
+        ),
+    )
+    p.add_argument(
+        "--indent",
+        type=int,
+        default=2,
+        help="JSON indentation (default: 2). Pass 0 for compact output.",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    snapshot = collect_status()
+    assert_no_secrets(snapshot)
+    indent = args.indent if args.indent and args.indent > 0 else None
+    json.dump(snapshot, sys.stdout, indent=indent, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/unit/test_governance_status.py
+++ b/tests/unit/test_governance_status.py
@@ -1,0 +1,425 @@
+"""Unit tests for ``reporting.governance_status``.
+
+Properties under test:
+
+* the snapshot is a JSON-serialisable dict with a stable key shape;
+* missing inputs degrade to ``"unknown"`` / ``"not_available"`` rather
+  than ``"ok"``;
+* unknown audit-ledger / autonomy-ladder state never surfaces as
+  ``"intact"`` or as a numeric ``max_available_level``;
+* nothing in the snapshot leaks credentials or sensitive path
+  fragments;
+* the CLI prints the same JSON ``collect_status()`` returns and exits
+  zero;
+* frozen contracts (``research/research_latest.json`` and
+  ``research/strategy_matrix.csv``) are not opened by either path.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from reporting import agent_audit, governance_status
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _file_sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _existence_and_sha(path: Path) -> tuple[bool, str | None]:
+    if not path.exists():
+        return (False, None)
+    return (True, _file_sha256(path))
+
+
+@pytest.fixture
+def isolated_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect every governance_status path constant into ``tmp_path``.
+
+    Each test that uses this fixture starts from an empty governance
+    layer; tests opt-in to specific files (settings.json, hooks, etc.).
+    """
+    repo = tmp_path
+    (repo / ".claude").mkdir()
+    (repo / ".claude" / "hooks").mkdir()
+    (repo / ".claude" / "agents").mkdir()
+    (repo / "docs" / "governance").mkdir(parents=True)
+    (repo / "logs").mkdir()
+
+    monkeypatch.setattr(governance_status, "REPO_ROOT", repo)
+    monkeypatch.setattr(governance_status, "VERSION_FILE", repo / "VERSION")
+    monkeypatch.setattr(
+        governance_status, "SETTINGS_FILE", repo / ".claude" / "settings.json"
+    )
+    monkeypatch.setattr(
+        governance_status, "HOOKS_DIR", repo / ".claude" / "hooks"
+    )
+    monkeypatch.setattr(
+        governance_status, "AGENTS_DIR", repo / ".claude" / "agents"
+    )
+    monkeypatch.setattr(
+        governance_status,
+        "LADDER_DOC",
+        repo / "docs" / "governance" / "autonomy_ladder.md",
+    )
+    monkeypatch.setattr(governance_status, "LEDGER_DIR", repo / "logs")
+    # Redirect agent_audit's ledger writer too, so a synthesised ledger
+    # ends up where governance_status looks for it.
+    monkeypatch.setattr(agent_audit, "_LEDGER_DIR", repo / "logs")
+    # Make git calls deterministic — return None.
+    monkeypatch.setattr(governance_status, "_git_branch", lambda: None)
+    monkeypatch.setattr(governance_status, "_git_head_sha", lambda: None)
+    return repo
+
+
+# ---------------------------------------------------------------------------
+# Shape & determinism
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_has_stable_top_level_shape(isolated_repo: Path) -> None:
+    snap = governance_status.collect_status()
+    expected_keys = {
+        "schema_version",
+        "report_kind",
+        "last_evaluation_at_utc",
+        "version",
+        "git",
+        "policy",
+        "hooks",
+        "autonomy",
+        "audit_ledger_today",
+        "autonomous_mode",
+    }
+    assert set(snap.keys()) == expected_keys
+    assert snap["schema_version"] == 1
+    assert snap["report_kind"] == "governance_status"
+
+
+def test_snapshot_is_json_serialisable(isolated_repo: Path) -> None:
+    snap = governance_status.collect_status()
+    encoded = json.dumps(snap, sort_keys=True)
+    assert json.loads(encoded) == snap
+
+
+def test_two_back_to_back_calls_only_differ_in_timestamp(
+    isolated_repo: Path,
+) -> None:
+    a = governance_status.collect_status()
+    b = governance_status.collect_status()
+    a.pop("last_evaluation_at_utc")
+    b.pop("last_evaluation_at_utc")
+    assert a == b
+
+
+# ---------------------------------------------------------------------------
+# Empty / missing inputs degrade to unknown
+# ---------------------------------------------------------------------------
+
+
+def test_empty_repo_reports_not_available_or_unknown_not_ok(
+    isolated_repo: Path,
+) -> None:
+    snap = governance_status.collect_status()
+
+    # Hooks: settings.json missing => layer_state must be 'not_available'.
+    assert snap["hooks"]["layer_state"] == "not_available"
+
+    # Autonomy: ladder doc missing => 'unknown' on every field.
+    autonomy = snap["autonomy"]
+    assert autonomy["max_available_level"] == "unknown"
+    assert autonomy["available_levels"] == "unknown"
+    assert autonomy["level_6_status"] == "unknown"
+
+    # Ledger: file missing => not_available, no chain claim.
+    ledger = snap["audit_ledger_today"]
+    assert ledger["status"] == "not_available"
+    assert ledger["last_event"] is None
+    assert ledger["event_count"] == 0
+    assert ledger["allowed_count"] == 0
+    assert ledger["blocked_count"] == 0
+
+    # Autonomous-mode is *never* reported as 'ok'.
+    assert snap["autonomous_mode"]["status"] == "not_machine_enforceable"
+
+    # Version file missing.
+    assert snap["version"]["file_version"] is None
+
+    # Defensive: no top-level field uses the literal string 'ok' as its
+    # status when the underlying state is missing. This catches any
+    # future regression where a contributor types `"ok"` reflexively.
+    flat = json.dumps(snap)
+    assert '"status": "ok"' not in flat
+    assert '"layer_state": "ok"' not in flat
+
+
+def test_missing_some_hooks_reports_degraded_with_per_hook_inventory(
+    isolated_repo: Path,
+) -> None:
+    settings = isolated_repo / ".claude" / "settings.json"
+    settings.write_text("{}", encoding="utf-8")
+    (isolated_repo / ".claude" / "hooks" / "deny_no_touch.py").write_text(
+        "# stub", encoding="utf-8"
+    )
+
+    snap = governance_status.collect_status()
+    hooks = snap["hooks"]
+    assert hooks["layer_state"] == "degraded"
+    inventory = hooks["inventory"]
+    assert inventory["deny_no_touch.py"] == "present"
+    assert inventory["deny_dangerous_bash.py"] == "missing"
+
+
+def test_full_hook_set_reports_installed(isolated_repo: Path) -> None:
+    (isolated_repo / ".claude" / "settings.json").write_text(
+        "{}", encoding="utf-8"
+    )
+    for name in governance_status.EXPECTED_HOOKS:
+        (isolated_repo / ".claude" / "hooks" / name).write_text(
+            "# stub", encoding="utf-8"
+        )
+    snap = governance_status.collect_status()
+    assert snap["hooks"]["layer_state"] == "installed"
+
+
+# ---------------------------------------------------------------------------
+# Autonomy ladder parser
+# ---------------------------------------------------------------------------
+
+
+_LADDER_FIXTURE = """\
+# Autonomy Ladder
+
+| Level | Capability | Status in this project |
+|---|---|---|
+| 0 | **Plan / read only**. | Always available |
+| 1 | **Docs + tests + frontend**. | Available after v3.15.15.12.3 active |
+| 2 | **Observability + CI**. | Available after v3.15.15.12.4 active |
+| 3 | **Backend non-core**. | **NOT enabled** in this version. |
+| 4 | **Merge recommendation**. | Locked. Requires >=30 days. |
+| 5 | **Deploy recommendation**. | Locked. Requires >=60 days. |
+| 6 | **Autonomous merge / deploy**. | **Permanently disabled** in this project. |
+
+## Per-agent caps (current)
+
+| Agent | Cap |
+|---|---|
+| product-owner | 1 |
+"""
+
+
+def test_autonomy_ladder_parses_available_levels(isolated_repo: Path) -> None:
+    (isolated_repo / "docs" / "governance" / "autonomy_ladder.md").write_text(
+        _LADDER_FIXTURE, encoding="utf-8"
+    )
+    snap = governance_status.collect_status()
+    autonomy = snap["autonomy"]
+    assert autonomy["available_levels"] == [0, 1, 2]
+    assert autonomy["max_available_level"] == 2
+    assert autonomy["level_6_status"] == "permanently_disabled"
+
+
+def test_autonomy_ladder_with_unparseable_doc_reports_unknown(
+    isolated_repo: Path,
+) -> None:
+    (isolated_repo / "docs" / "governance" / "autonomy_ladder.md").write_text(
+        "no table here", encoding="utf-8"
+    )
+    snap = governance_status.collect_status()
+    autonomy = snap["autonomy"]
+    assert autonomy["max_available_level"] == "unknown"
+    assert autonomy["available_levels"] == "unknown"
+    assert autonomy["level_6_status"] == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Audit ledger summary
+# ---------------------------------------------------------------------------
+
+
+def test_intact_ledger_reports_intact_with_redacted_tail(
+    isolated_repo: Path,
+) -> None:
+    # Two events: one allowed, one blocked. The blocked event carries
+    # ``command_summary`` and ``target_path`` that we must NOT surface
+    # in ``last_event``.
+    agent_audit.append_event(
+        {
+            "event": "tool_use",
+            "tool": "Edit",
+            "outcome": "ok",
+            "actor": "claude:test",
+            "command_summary": "should not leak",
+            "target_path": "should/not/leak.py",
+        }
+    )
+    agent_audit.append_event(
+        {
+            "event": "blocked",
+            "tool": "Write",
+            "outcome": "blocked_by_hook",
+            "block_reason": "no_touch_path matched 'VERSION'",
+            "actor": "claude:hook",
+            "command_summary": "secret-looking-thing-DO_NOT_LEAK",
+            "target_path": "VERSION",
+        }
+    )
+    snap = governance_status.collect_status()
+    ledger = snap["audit_ledger_today"]
+    assert ledger["status"] == "intact"
+    assert ledger["event_count"] == 2
+    assert ledger["allowed_count"] == 1
+    assert ledger["blocked_count"] == 1
+    assert ledger["other_count"] == 0
+    last = ledger["last_event"]
+    assert last is not None
+    assert last["sequence_id"] == 1
+    assert last["outcome"] == "blocked_by_hook"
+    assert last["tool"] == "Write"
+    assert last["block_reason"] == "no_touch_path matched 'VERSION'"
+
+    # Redacted tail must NOT contain user-controlled strings.
+    flat = json.dumps(snap)
+    assert "should/not/leak.py" not in flat
+    assert "should not leak" not in flat
+    assert "DO_NOT_LEAK" not in flat
+
+
+def test_broken_ledger_reports_broken_with_first_corrupt_index(
+    isolated_repo: Path,
+) -> None:
+    agent_audit.append_event({"event": "tool_use", "outcome": "ok"})
+    agent_audit.append_event({"event": "tool_use", "outcome": "ok"})
+    # Corrupt the first event's hash field.
+    path = agent_audit.current_ledger_path()
+    lines = path.read_text(encoding="utf-8").splitlines()
+    first = json.loads(lines[0])
+    first["event_sha256"] = "0" * 64
+    lines[0] = json.dumps(first, sort_keys=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    snap = governance_status.collect_status()
+    ledger = snap["audit_ledger_today"]
+    assert ledger["status"] == "broken"
+    assert ledger["first_corrupt_index"] == 0
+
+
+def test_unreadable_ledger_reports_unreadable_or_broken(
+    isolated_repo: Path,
+) -> None:
+    path = agent_audit.current_ledger_path()
+    path.write_text("not-json{{{\n", encoding="utf-8")
+    snap = governance_status.collect_status()
+    assert snap["audit_ledger_today"]["status"] in {"unreadable", "broken"}
+
+
+# ---------------------------------------------------------------------------
+# Secrets / sensitive-path safety
+# ---------------------------------------------------------------------------
+
+
+def test_assert_no_secrets_passes_on_empty_snapshot(
+    isolated_repo: Path,
+) -> None:
+    snap = governance_status.collect_status()
+    governance_status.assert_no_secrets(snap)  # must not raise
+
+
+def test_assert_no_secrets_catches_credential_pattern() -> None:
+    leaky = {"some": "sk-ant-AAAAAAAAAAAAAAAAAAAAAAAAA"}
+    with pytest.raises(AssertionError, match="credential-like"):
+        governance_status.assert_no_secrets(leaky)
+
+
+def test_assert_no_secrets_catches_sensitive_path_fragment() -> None:
+    leaky = {"path": "config/config.yaml"}
+    with pytest.raises(AssertionError, match="sensitive path"):
+        governance_status.assert_no_secrets(leaky)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def test_cli_emits_same_snapshot_shape_as_collect(
+    isolated_repo: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rc = governance_status.main(["--indent", "0"])
+    assert rc == 0
+    out = capsys.readouterr().out.strip()
+    parsed = json.loads(out)
+    expected_keys = {
+        "schema_version",
+        "report_kind",
+        "last_evaluation_at_utc",
+        "version",
+        "git",
+        "policy",
+        "hooks",
+        "autonomy",
+        "audit_ledger_today",
+        "autonomous_mode",
+    }
+    assert set(parsed.keys()) == expected_keys
+
+
+def test_cli_default_indent_is_pretty(
+    isolated_repo: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rc = governance_status.main([])
+    assert rc == 0
+    out = capsys.readouterr().out
+    # Pretty JSON has newlines + 2-space indent.
+    assert "\n  " in out
+
+
+# ---------------------------------------------------------------------------
+# Frozen-contract integrity
+# ---------------------------------------------------------------------------
+
+
+def test_collect_status_does_not_touch_frozen_contracts() -> None:
+    """Run on the *real* repo and assert that the two frozen artifacts
+    are byte-identical (or equally absent) before and after the call.
+
+    The diagnostic must never write, rewrite, or even create either
+    contract. We capture (existed, sha256) before and after and require
+    equality — without skipping, so the test is informative whether or
+    not the contracts happen to be present in the working tree.
+    """
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    research_latest = repo_root / "research" / "research_latest.json"
+    strategy_matrix = repo_root / "research" / "strategy_matrix.csv"
+
+    before_a = _existence_and_sha(research_latest)
+    before_b = _existence_and_sha(strategy_matrix)
+
+    snapshot = governance_status.collect_status()
+    governance_status.assert_no_secrets(snapshot)
+
+    after_a = _existence_and_sha(research_latest)
+    after_b = _existence_and_sha(strategy_matrix)
+
+    assert before_a == after_a, "research_latest.json was modified or created"
+    assert before_b == after_b, "strategy_matrix.csv was modified or created"
+
+    # Neither contract path appears anywhere in the snapshot; downstream
+    # consumers cannot stumble onto them through this surface.
+    flat = json.dumps(snapshot)
+    assert "research_latest.json" not in flat
+    assert "strategy_matrix.csv" not in flat


### PR DESCRIPTION
# Pull Request

## Summary

<!-- 1–3 bullet points on what changed and why. Avoid file-by-file recap. -->

-
-

## Linked roadmap item / ADR

<!-- e.g. v3.15.15.12.5 / ADR-015 §audit-chain -->

## Autonomy claim

> The PR author claims this PR was produced at autonomy level: **Level _**
> (0 = planning only, 1 = docs/tests/frontend, 2 = observability/CI,
> 3 = backend non-core. Level 4+ is not enabled in this project.)
> See [`docs/governance/autonomy_ladder.md`](../docs/governance/autonomy_ladder.md).

## Governance checklist

A PR cannot be merged until every applicable item is checked or marked N/A.

- [ ] No no-touch path was modified, **or** a new ADR is linked above.
- [ ] Determinism-pin job is green; no pin re-pinned.
- [ ] Authority surfaces unchanged (ADR-014).
- [ ] Evidence ledger schemas unchanged or extended-only (no field removals/renames).
- [ ] No tests skipped, marked `xfail`, or assertion-relaxed; no fixtures
      regenerated; no digest pins updated.
- [ ] No new live/broker connector files created.
- [ ] `VERSION` is unchanged in this PR, **or** the bump is explicitly recommended
      by a Release Gate report linked below.
- [ ] Build provenance attached as a workflow artifact, **or** N/A (non-image PR).
- [ ] Active nightly failures referenced in PR body, **or** none active.
- [ ] Agent run summary committed, **or** N/A (no agent involvement):
      `docs/governance/agent_run_summaries/<session_id>.md`
- [ ] Release Gate report (if applicable):
      `docs/governance/release_gates/<version>/<timestamp>.md`

## Test plan

<!-- What was actually run? Paste pytest summary lines, vitest summary, ruff/mypy
output. If a test was added, name it here. -->

-
-

## Risks & rollback

<!-- One sentence per item. -->

- Risk:
- Rollback:

---

> Anything that touches `automation/live_gate.py`, `config/config.yaml`,
> `state/*.secret`, frozen v1 schemas, or production posture files
> (`docker-compose.prod.yml`, `scripts/deploy.sh`, `ops/systemd/*`) requires
> CODEOWNERS review and a linked ADR amendment. See
> [`docs/governance/no_touch_paths.md`](../docs/governance/no_touch_paths.md).
