### PR TITLE
Fix/v3.15.15.14 agent audit visibility verification

### DIFF
--- a/docs/governance/agent_audit_inspection.md
+++ b/docs/governance/agent_audit_inspection.md
@@ -1,0 +1,161 @@
+# Agent Audit Inspection — Operator Runbook
+
+Three sources together let you answer the question *"which agent did
+what, when, on which branch?"*. This runbook lists each source, the
+exact command to inspect it, and the limitations you must keep in
+mind.
+
+> The actual gate is `verify_chain()` plus reviewer discipline plus
+> CODEOWNERS plus branch protection. The diagnostics below help you
+> *see* state quickly; they do not *enforce* state.
+
+## At a glance
+
+| Question | Source | Command |
+|---|---|---|
+| Is the governance layer present and intact? | live snapshot | `python -m reporting.governance_status` |
+| What did agents do today? (operator-friendly) | runtime ledger | `python -m reporting.agent_audit_summary` |
+| Tail one event verbatim | runtime ledger | `python -m reporting.agent_audit tail logs/agent_audit.<UTC date>.jsonl` |
+| Is today's hash chain intact? | runtime ledger | `python -m reporting.agent_audit verify logs/agent_audit.<UTC date>.jsonl` |
+| What did agents do across an entire session? | committed run summary | open `docs/governance/agent_run_summaries/<session_id>.md` |
+| Were the release-stage gates met? | release-gate report | open `docs/governance/release_gates/<version>/<UTC>.md` |
+| What was deployed? | build provenance | open `artifacts/build_provenance-<version>.json` (gitignored runtime) |
+
+## The runtime ledger — `logs/agent_audit.<UTC date>.jsonl`
+
+* One file per UTC day. Hash-chained. Gitignored. Schema in
+  [`docs/governance/audit_chain.md`](audit_chain.md).
+* Every Edit / Write / MultiEdit / Bash and every deny-hook decision
+  appends one event.
+* Sealed by `event_sha256`; tampering produces a chain break that
+  `verify_chain()` reports.
+
+### Read it the operator-friendly way
+
+```sh
+python -m reporting.agent_audit_summary
+```
+
+That command prints two views as JSON:
+
+* **`timeline`** — last 50 events, sorted by `sequence_id`. Each row
+  carries `sequence_id`, `timestamp_utc`, `actor`, `event`, `tool`,
+  `outcome`, `block_reason`, `branch`, `head_sha`, `session_id`,
+  `target_dir`, `redaction_status`. Anything missing in the source is
+  surfaced as `"unknown"`.
+* **`groups`** — counts by actor, outcome, tool, branch, session, plus
+  the earliest and latest timestamps and chain status.
+
+Useful flags:
+
+* `--limit N` — show last N timeline rows (default 50).
+* `--view timeline` / `--view groups` / `--view both` (default).
+* `--format table` — render the timeline as a fixed-width table.
+* `--actor claude:hook` — filter timeline by actor.
+* `--outcome blocked_by_hook` — filter timeline by outcome.
+* `--date 2026-04-29` — read a different day's file.
+* `--path logs/agent_audit.2026-04-29.jsonl` — explicit file path.
+
+The CLI exits 0 even when the chain is broken, the file is missing, or
+some lines are malformed. Status is reported as a field; it is not the
+exit code. Use `verify` if you need an exit-code gate.
+
+### What the summary does NOT show (by design)
+
+* **`target_path` is collapsed to `target_dir`** — only the parent
+  directory is exposed. The full filename can carry information the
+  operator did not explicitly ask about.
+* **`command_summary` is omitted** — the writer redacts credential
+  patterns, but the summary view drops the field entirely.
+* **`diff_summary` is omitted** — the writer caps it at `{lines_added,
+  lines_removed, content_sha256}`, but the summary view drops it too.
+* **No raw payloads, ever.** If a credential-shaped string somehow
+  reaches a kept field, it is replaced with `[REDACTED]` at projection
+  time and the safety self-check refuses to print it.
+
+### Known limitations of the source
+
+These are limitations of the *writer*, not of the summary view. They
+are documented here so operators do not infer guarantees that do not
+hold today.
+
+| Field | Where it is set | Where it is NULL |
+|---|---|---|
+| `actor` | `claude:audit_emit` for PostToolUse, `claude:hook` for deny hooks, `claude:precompact_preserve` for PreCompact | per-subagent identity is **not** captured today (no `claude:planner`, `claude:test-agent` etc. — that requires a writer change in `audit_emit.py`, which is a no-touch path; an ADR amendment + governance-bootstrap PR would be needed). |
+| `branch`, `head_sha` | Enriched by `_hook_runtime` on deny-hook events | NULL on PostToolUse events (the writer there does not call git). |
+| `session_id` | Set when the hook payload carries it (Claude Code sends it on PostToolUse) | NULL for synthetic / programmatic events. |
+
+If `branch` or `head_sha` is `null`, the timeline row reports
+`"unknown"`. The operator is expected to cross-reference with the
+session's run summary at
+`docs/governance/agent_run_summaries/<session_id>.md`, which does
+record branch and start/end SHAs.
+
+## The committed run summary — per session
+
+The runtime ledger is gitignored. The committed bridge is
+`docs/governance/agent_run_summaries/<session_id>.md`, written at the
+end of each session that produced a PR. The summary contains:
+
+* `session_id`, `start_utc`, `end_utc`, `branch`, `head_sha_at_start`,
+  `head_sha_at_end`;
+* subagent invocation counts;
+* tool-call counts;
+* paths touched (paths only, no content);
+* test results;
+* hook-event counts;
+* ledger event-id range covered (`seq=<lo>..<hi>`);
+* release-gate decision (if `/release-gate` was run);
+* linked PR.
+
+This is where you go for **per-session** context. The runtime ledger
+is for **per-event** context within a single day.
+
+The template lives at
+`docs/governance/agent_run_summaries/_template.md`.
+
+## When operator approval is still required
+
+Reading the ledger does not loosen any constraint. Every action that
+required operator approval before this view was added still requires
+it:
+
+1. Any change to `.claude/{settings.json,hooks/**,agents/**}`,
+   `.github/CODEOWNERS`, or `VERSION` — only via human-authored,
+   CODEOWNERS-reviewed `governance-bootstrap` PRs.
+2. Any merge to `main`, deploy of an image, unlock of Level 4 or 5,
+   regeneration of a frozen contract, or addition of a live connector.
+3. Any chain-break finding (`chain_status == "broken"`) — investigate
+   immediately; do not assume the diagnostic itself is faulty.
+
+## Failure modes
+
+* **`chain_status == "unreadable"`**: the ledger has bytes but no
+  valid events parse. The file may be partially overwritten. Run
+  `verify` on the previous day's file (it is sealed) and check the
+  process that writes the ledger (`audit_emit.py`).
+* **`malformed_line_count > 0`**: usually a half-written line at the
+  tail because a process was killed. The chain may still be intact;
+  the malformed line is skipped by `verify`. Investigate if it
+  persists.
+* **`by_actor` shows unexpected actors**: today the only legitimate
+  actors are `claude:audit_emit`, `claude:hook`, and
+  `claude:precompact_preserve`. Anything else is either a future
+  writer change (which should arrive via a governance-bootstrap PR)
+  or a tampering attempt.
+* **`by_branch` shows `main` for events that should have been on a
+  feature branch**: cross-reference with `git log --oneline` for that
+  range; the writer captures the branch active at event time.
+
+## Where it fits
+
+* **ADR-015 §Doctrine 5 — Audit-chain doctrine**: this runbook is the
+  operator-facing companion of `audit_chain.md`. The chain doctrine
+  remains canonical; this view just makes it easier to read.
+* **Doctrine 13 — Run-summary doctrine**: per-session run summaries
+  remain the authoritative bridge between runtime ledger and Git
+  history. The summary view is for ad-hoc inspection, not for the
+  PR record.
+* **v3.15.15.13 governance-status**: `governance_status` reports
+  *current* state of the layer; `agent_audit_summary` reports
+  *what happened* in a day. Different lenses, same source.

--- a/docs/governance/agent_run_summaries/v3.15.15.14_pr_body.md
+++ b/docs/governance/agent_run_summaries/v3.15.15.14_pr_body.md
@@ -1,0 +1,110 @@
+## Summary
+
+Adds an operator-friendly read-only view over the agent audit ledger. Closes the gap between the existing `verify` (chain integrity only) and `tail` (one event verbatim) — operators can now see *which agent did what, when, on which branch* in a single command.
+
+This is the verification deliverable for the autonomy / audit visibility request: confirmation that the layer's history is inspectable without manual JSON spelunking, with documented limits.
+
+## Why
+
+After v3.15.15.12 the runtime ledger captures events deterministically, but the only operator commands are `verify` (yes/no on chain integrity) and `tail` (raw verbose JSON for the last event). To answer *"what happened in the last hour, grouped by actor, with redacted projections"* the operator had to read JSONL by hand. This PR closes that gap.
+
+## What this is NOT
+
+- Not a writer change. The ledger schema is unchanged; the no-touch hooks remain frozen.
+- Not a gate. CLI exits 0 even when chain is broken / file is missing / lines are malformed — chain status is a *field*. `verify` remains the actual gate.
+- Not a per-subagent identity capture. Today's writer records actor as `claude:audit_emit` / `claude:hook` / `claude:precompact_preserve` only. Per-subagent (`claude:planner`, `claude:test-agent`, …) attribution would require modifying `audit_emit.py`, which is no-touch. Documented as a known limitation.
+
+## Files
+
+- `reporting/agent_audit_summary.py` (new) — library + CLI.
+- `tests/unit/test_agent_audit_summary.py` (new) — 21 tests.
+- `docs/governance/agent_audit_inspection.md` (new) — operator runbook with which-source-answers-which-question table, exact commands, example output, and known limitations.
+
+No no-touch path edited. No frozen contract opened. No CI workflow changed. No new strategy. No threshold tuning. No live / shadow / paper enablement.
+
+## Operator commands
+
+```sh
+# Default — both views, last 50 events, JSON
+python -m reporting.agent_audit_summary
+
+# Compact text table of the timeline
+python -m reporting.agent_audit_summary --view timeline --format table
+
+# Just the aggregates
+python -m reporting.agent_audit_summary --view groups
+
+# Only blocked-by-hook events from a specific actor
+python -m reporting.agent_audit_summary --actor claude:hook \
+    --outcome blocked_by_hook --limit 100
+
+# Yesterday's ledger
+python -m reporting.agent_audit_summary --date 2026-04-29
+```
+
+## Audit / provenance source map (verified)
+
+| Question | Source | Command |
+|---|---|---|
+| Is the governance layer present and intact? | live snapshot | `python -m reporting.governance_status` (v3.15.15.13) |
+| What did agents do today? (operator-friendly) | runtime ledger | `python -m reporting.agent_audit_summary` (this PR) |
+| Tail one event verbatim | runtime ledger | `python -m reporting.agent_audit tail logs/agent_audit.<UTC date>.jsonl` |
+| Is today's hash chain intact? | runtime ledger | `python -m reporting.agent_audit verify logs/agent_audit.<UTC date>.jsonl` |
+| What did agents do across an entire session? | committed run summary | `docs/governance/agent_run_summaries/<session_id>.md` |
+| Were the release-stage gates met? | release-gate report | `docs/governance/release_gates/<version>/<UTC>.md` |
+| What was deployed? | build provenance | `artifacts/build_provenance-<version>.json` (gitignored) |
+
+## Test plan
+
+- [x] `pytest tests/unit/test_agent_audit_summary.py` — 21/21 pass
+- [x] `pytest tests/unit/test_agent_audit*.py tests/unit/test_hook_runtime.py tests/unit/test_hooks_*.py` — 261/261 pass
+- [x] `pytest tests/smoke` — 14/14 pass
+- [x] `pytest tests/regression` — 164 passed, 1 pre-existing skip
+- [x] `python scripts/governance_lint.py` — OK (15 agents, 3 workflows)
+- [x] `python -m reporting.agent_audit verify` — chain intact (533 events today)
+- [x] `python -m ruff check` (new files) — clean
+- [x] `python -m mypy --explicit-package-bases` (new files) — clean
+- [x] CLI dry-run on real ledger — 533-event groups view + filtered timeline both render correctly with branch/SHA captured for hook events and `unknown` everywhere else
+
+## Frozen-contract check
+
+Both contracts byte-identical before, during, and after the change:
+
+- `research/research_latest.json` → `4a567bd6feb98eb7aa32db4a90a3201456843088314936c5e484a2ae6a93666c`
+- `research/strategy_matrix.csv` → `ff15b8c4f35cc37b6941b712106ae71a1b82a1b5043da197731d42518d258d66`
+
+Test `test_collect_views_do_not_touch_frozen_contracts` re-asserts on every CI run.
+
+## Protected governance check
+
+`git diff` against HEAD on `.claude/`, `docs/governance/{no_touch_paths,audit_chain,permission_model,autonomy_ladder}.md`, `docs/adr/`, `VERSION`, `CHANGELOG.md` — empty.
+
+## Security check
+
+- `assert_no_secrets()` rejects credential-pattern strings (Anthropic / GitHub PAT / AWS / private-key markers) and sensitive-path fragments — tested directly.
+- Per-event projection drops `command_summary`, `diff_summary`, and `target_path` (collapsed to `target_dir`); credential-shaped strings inside kept fields are replaced with `[REDACTED]`.
+- Module is stdlib-only — no new dependency.
+
+## Documented gaps in the source (writer-level, not addressed in this PR)
+
+| Gap | Effect | Where to fix (future, governance-bootstrap PR) |
+|---|---|---|
+| No per-subagent identity in `actor` | Cannot distinguish `claude:planner` from `claude:test-agent` from generic `claude:audit_emit` | `.claude/hooks/audit_emit.py` writer change |
+| `branch` / `head_sha` NULL on 377/487 events | Most PostToolUse events lack git linkage | `.claude/hooks/audit_emit.py` enrichment |
+| `session_id` NULL for synthetic events | Some hook-fired events have no session attribution | depends on Claude Code payload |
+
+These are surfaced as `"unknown"` in this PR's view; the writer change is out of scope and would require an ADR amendment touching `.claude/hooks/**`.
+
+## Out of scope (explicit)
+
+- No live / paper / shadow connector activation.
+- No threshold tuning.
+- No new strategy or alpha logic.
+- No CI workflow edits.
+- No `.claude/{settings.json,hooks/**,agents/**}` edits.
+- No `VERSION` bump.
+- No `CHANGELOG.md` edit (ask-only path; deferred to a follow-up if needed).
+- No frozen contract regenerated.
+- No writer-level enrichment of `actor` / `branch` / `head_sha` (writer is no-touch).
+
+Co-Authored-By: Claude Opus 4.7 (1M context)

--- a/reporting/agent_audit_summary.py
+++ b/reporting/agent_audit_summary.py
@@ -1,0 +1,538 @@
+"""Read-only operator view over the agent audit ledger.
+
+The canonical writer for ``logs/agent_audit.<UTC date>.jsonl`` is
+:mod:`reporting.agent_audit`. The existing CLI exposes
+``verify`` (chain integrity) and ``tail`` (last single event verbatim).
+Neither answers the operator's first-pass question:
+
+    "Which agent did what, when, on this branch?"
+
+This module fills that gap. It is read-only, stdlib-only, and never
+mutates the ledger. It does not change the writers — the per-event
+schema is whatever ``agent_audit.append_event`` produces.
+
+Two views
+---------
+
+1. ``timeline`` — last N events, one row per event, sorted by
+   ``sequence_id`` ascending. Each row is a *redacted* projection:
+
+       sequence_id, timestamp_utc, actor, event, tool, outcome,
+       block_reason, branch, head_sha, session_id, target_dir,
+       redaction_status
+
+   ``target_path`` is **never** surfaced verbatim — only its parent
+   directory ("``target_dir``") is shown, so the surface cannot leak
+   working-tree filenames the operator did not already know about.
+
+2. ``groups`` — per-actor / per-outcome counts plus per-session and
+   per-branch breakdowns. Pure aggregates; no payloads.
+
+Both views report fields that are missing in the source as ``"unknown"``
+or ``"not_available"``. Nothing is ever ``"ok"`` by default — ``ok``
+must come from the source.
+
+Usage
+-----
+
+::
+
+    python -m reporting.agent_audit_summary
+        # today's ledger, last 50 events, both views, JSON
+
+    python -m reporting.agent_audit_summary --limit 100 --view timeline
+
+    python -m reporting.agent_audit_summary --date 2026-04-30 \\
+        --view groups
+
+    python -m reporting.agent_audit_summary --path \\
+        logs/agent_audit.2026-04-30.jsonl --view timeline --format table
+
+The CLI exits 0 even when the chain is broken or the file is unreadable
+— this is a diagnostic, not a gate. Chain integrity is reported as a
+field; ``verify`` is the actual check.
+
+Stdlib-only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import re
+import sys
+from collections.abc import Iterable, Iterator
+from pathlib import Path
+from typing import Any
+
+from reporting import agent_audit
+
+REPO_ROOT: Path = Path(__file__).resolve().parent.parent
+
+# Fields we copy out of an event into the redacted timeline row. Anything
+# not in this list is dropped at projection time. command_summary,
+# diff_summary, and target_path are intentionally absent (they may carry
+# user-controlled strings even after writer-side redaction).
+_TIMELINE_KEEP_KEYS: tuple[str, ...] = (
+    "sequence_id",
+    "timestamp_utc",
+    "actor",
+    "event",
+    "tool",
+    "outcome",
+    "block_reason",
+    "branch",
+    "head_sha",
+    "session_id",
+    "redacted",
+    "autonomy_level_claimed",
+)
+
+# Patterns we treat as "do not surface even in redacted form". A match in
+# any string field of a projection causes the field to be replaced with
+# ``"[REDACTED]"`` in the row. This is defense in depth; the writer
+# already strips most of these.
+_FORBIDDEN_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"sk-ant-[A-Za-z0-9_\-]{8,}"),
+    re.compile(r"ghp_[A-Za-z0-9]{8,}"),
+    re.compile(r"github_pat_[A-Za-z0-9_]{8,}"),
+    re.compile(r"AKIA[0-9A-Z]{12,}"),
+    re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"),
+)
+
+
+def _utc_today() -> str:
+    return _dt.datetime.now(_dt.UTC).strftime("%Y-%m-%d")
+
+
+def _ledger_path_for(date_utc: str | None, explicit: str | None) -> Path:
+    if explicit is not None:
+        return Path(explicit)
+    if date_utc is None:
+        date_utc = _utc_today()
+    return REPO_ROOT / "logs" / f"agent_audit.{date_utc}.jsonl"
+
+
+def _is_valid_event(obj: Any) -> bool:
+    """A defensive structural check — anything that does not look like a
+    sealed event is treated as ``invalid``. We do **not** reject events
+    by chain validity here; chain breaks are a separate report."""
+    if not isinstance(obj, dict):
+        return False
+    if obj.get("schema_version") != 1:
+        return False
+    return isinstance(obj.get("sequence_id"), int)
+
+
+def _read_events(path: Path) -> tuple[list[dict[str, Any]], int]:
+    """Return ``(events, malformed_line_count)``.
+
+    Malformed lines (non-JSON, or JSON that does not look like a v1
+    event) are counted but never raised. The CLI must keep working on a
+    half-written or truncated file — the operator's job is to look at
+    the count, not to crash.
+    """
+    if not path.exists():
+        return ([], 0)
+    events: list[dict[str, Any]] = []
+    malformed = 0
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return ([], 0)
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            malformed += 1
+            continue
+        if not _is_valid_event(obj):
+            malformed += 1
+            continue
+        events.append(obj)
+    events.sort(key=lambda e: e.get("sequence_id", -1))
+    return (events, malformed)
+
+
+def _scrub(value: Any) -> Any:
+    """Replace credential-like strings with ``[REDACTED]``. Non-strings
+    pass through untouched. The writer already redacts these; this is
+    defense in depth at presentation time."""
+    if not isinstance(value, str):
+        return value
+    out = value
+    for pat in _FORBIDDEN_PATTERNS:
+        out = pat.sub("[REDACTED]", out)
+    return out
+
+
+def _project_target_dir(event: dict[str, Any]) -> str:
+    """Surface only the parent directory of ``target_path``. The full
+    filename can carry information that should not appear in operator
+    output (working-copy paths the operator did not explicitly ask
+    about). ``"unknown"`` if absent."""
+    raw = event.get("target_path")
+    if not isinstance(raw, str) or not raw.strip():
+        return "unknown"
+    p = raw.replace("\\", "/")
+    parent = p.rsplit("/", 1)[0] if "/" in p else "."
+    if not parent:
+        parent = "."
+    return parent
+
+
+def _redaction_status(event: dict[str, Any]) -> str:
+    """One of ``redacted_by_writer`` / ``not_redacted`` / ``unknown``."""
+    val = event.get("redacted")
+    if val is True:
+        return "redacted_by_writer"
+    if val is False:
+        return "not_redacted"
+    return "unknown"
+
+
+def _projection(event: dict[str, Any]) -> dict[str, Any]:
+    """Build the operator-facing redacted row for a single event."""
+    row: dict[str, Any] = {}
+    for k in _TIMELINE_KEEP_KEYS:
+        v = event.get(k)
+        if v is None:
+            # Distinguish "field absent in writer" from "field present and
+            # null". For booleans, None ⇒ unknown. For strings, None ⇒
+            # unknown. For ints, None ⇒ unknown.
+            row[k] = "unknown"
+        else:
+            row[k] = _scrub(v)
+    row["target_dir"] = _project_target_dir(event)
+    row["redaction_status"] = _redaction_status(event)
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def collect_timeline(
+    path: Path,
+    *,
+    limit: int = 50,
+    actor: str | None = None,
+    outcome: str | None = None,
+) -> dict[str, Any]:
+    """Return a redacted timeline of the last ``limit`` events.
+
+    Filters apply at the source level (full event), then the projection
+    is applied. The output shape is intentionally JSON-stable.
+    """
+    events, malformed = _read_events(path)
+    chain_status, first_corrupt = _chain_status(path)
+    if actor is not None:
+        events = [e for e in events if e.get("actor") == actor]
+    if outcome is not None:
+        events = [e for e in events if e.get("outcome") == outcome]
+    rows = [_projection(e) for e in events[-max(0, limit):]]
+    return {
+        "schema_version": 1,
+        "report_kind": "agent_audit_timeline",
+        "ledger_path": _rel(path),
+        "ledger_present": path.exists(),
+        "ledger_event_count": len(events),
+        "malformed_line_count": malformed,
+        "chain_status": chain_status,
+        "first_corrupt_index": first_corrupt,
+        "filters": {"actor": actor, "outcome": outcome, "limit": limit},
+        "rows": rows,
+    }
+
+
+def collect_groups(path: Path) -> dict[str, Any]:
+    """Aggregates: counts by actor, outcome, tool, branch, session.
+
+    Pure aggregates — no payloads, no command summaries, no diffs.
+    """
+    events, malformed = _read_events(path)
+    chain_status, first_corrupt = _chain_status(path)
+    by_actor: dict[str, int] = {}
+    by_outcome: dict[str, int] = {}
+    by_tool: dict[str, int] = {}
+    by_branch: dict[str, int] = {}
+    by_session: dict[str, int] = {}
+    earliest: str | None = None
+    latest: str | None = None
+    for e in events:
+        actor = e.get("actor") or "unknown"
+        outcome = e.get("outcome") or "unknown"
+        tool = e.get("tool") or "unknown"
+        branch = e.get("branch") or "unknown"
+        session = e.get("session_id") or "unknown"
+        by_actor[actor] = by_actor.get(actor, 0) + 1
+        by_outcome[outcome] = by_outcome.get(outcome, 0) + 1
+        by_tool[tool] = by_tool.get(tool, 0) + 1
+        by_branch[branch] = by_branch.get(branch, 0) + 1
+        by_session[session] = by_session.get(session, 0) + 1
+        ts = e.get("timestamp_utc")
+        if isinstance(ts, str):
+            if earliest is None or ts < earliest:
+                earliest = ts
+            if latest is None or ts > latest:
+                latest = ts
+    return {
+        "schema_version": 1,
+        "report_kind": "agent_audit_groups",
+        "ledger_path": _rel(path),
+        "ledger_present": path.exists(),
+        "ledger_event_count": len(events),
+        "malformed_line_count": malformed,
+        "chain_status": chain_status,
+        "first_corrupt_index": first_corrupt,
+        "earliest_timestamp_utc": earliest or "not_available",
+        "latest_timestamp_utc": latest or "not_available",
+        "by_actor": dict(sorted(by_actor.items())),
+        "by_outcome": dict(sorted(by_outcome.items())),
+        "by_tool": dict(sorted(by_tool.items())),
+        "by_branch": dict(sorted(by_branch.items())),
+        "by_session": dict(sorted(by_session.items())),
+    }
+
+
+def _chain_status(path: Path) -> tuple[str, int | None]:
+    """Run :func:`agent_audit.verify_chain` defensively. Failures on
+    any axis collapse to ``"unreadable"`` so the diagnostic stays
+    informative even if the writer module changes shape."""
+    if not path.exists():
+        return ("not_available", None)
+    if path.stat().st_size == 0:
+        return ("not_available", None)
+    try:
+        ok, idx = agent_audit.verify_chain(path)
+    except Exception:
+        return ("unreadable", None)
+    return ("intact" if ok else "broken", idx)
+
+
+def _rel(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(REPO_ROOT.resolve())).replace(
+            "\\", "/"
+        )
+    except ValueError:
+        return str(path).replace("\\", "/")
+
+
+# ---------------------------------------------------------------------------
+# Self-check (used by the CLI and the tests)
+# ---------------------------------------------------------------------------
+
+
+def _walk_strings(obj: Any) -> Iterator[str]:
+    if isinstance(obj, str):
+        yield obj
+        return
+    if isinstance(obj, dict):
+        for v in obj.values():
+            yield from _walk_strings(v)
+        return
+    if isinstance(obj, list | tuple):
+        for v in obj:
+            yield from _walk_strings(v)
+
+
+_SENSITIVE_FRAGMENTS: tuple[str, ...] = (
+    "config/config.yaml",
+    "live_gate.secret",
+    "fred.secret",
+    "operator_token.secret",
+    "dashboard_session.secret",
+)
+
+
+def assert_no_secrets(snapshot: dict[str, Any]) -> None:
+    """Raise ``AssertionError`` if any string in the snapshot matches a
+    forbidden credential pattern or sensitive-path fragment."""
+    for s in _walk_strings(snapshot):
+        for pat in _FORBIDDEN_PATTERNS:
+            if pat.search(s):
+                raise AssertionError(
+                    f"agent_audit_summary leaked credential-like string: pattern={pat.pattern!r}"
+                )
+        lowered = s.lower()
+        for frag in _SENSITIVE_FRAGMENTS:
+            if frag in lowered:
+                raise AssertionError(
+                    f"agent_audit_summary leaked sensitive path fragment: {frag!r}"
+                )
+
+
+# ---------------------------------------------------------------------------
+# Table rendering (operator-friendly text output)
+# ---------------------------------------------------------------------------
+
+
+_TIMELINE_COLUMNS: tuple[tuple[str, int], ...] = (
+    ("sequence_id", 6),
+    ("timestamp_utc", 22),
+    ("actor", 26),
+    ("outcome", 16),
+    ("tool", 12),
+    ("branch", 28),
+    ("session_id", 12),
+)
+
+
+def _trim(value: Any, width: int) -> str:
+    s = str(value) if value is not None else ""
+    if len(s) <= width:
+        return s.ljust(width)
+    return s[: max(0, width - 1)] + "…"
+
+
+def render_timeline_table(snapshot: dict[str, Any]) -> str:
+    """Render a timeline snapshot as a fixed-width text table.
+
+    Operator-friendly. Each row is one event. Columns are deliberately
+    narrow so the output fits a terminal."""
+    header_cells = [c for c, _ in _TIMELINE_COLUMNS]
+    widths = [w for _, w in _TIMELINE_COLUMNS]
+    sep = "  "
+    lines: list[str] = []
+    lines.append(
+        sep.join(name.ljust(w) for name, w in zip(header_cells, widths, strict=False))
+    )
+    lines.append(sep.join("-" * w for w in widths))
+    rows: Iterable[dict[str, Any]] = snapshot.get("rows", []) or []
+    for row in rows:
+        cells = [_trim(row.get(name), w) for name, w in zip(header_cells, widths, strict=False)]
+        lines.append(sep.join(cells))
+    lines.append("")
+    lines.append(
+        f"-- {snapshot.get('ledger_event_count', 0)} events total, "
+        f"chain={snapshot.get('chain_status')}, "
+        f"malformed={snapshot.get('malformed_line_count', 0)} --"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def render_groups_table(snapshot: dict[str, Any]) -> str:
+    lines: list[str] = []
+    lines.append(f"ledger: {snapshot.get('ledger_path')}")
+    lines.append(
+        f"events: {snapshot.get('ledger_event_count', 0)}  "
+        f"malformed: {snapshot.get('malformed_line_count', 0)}  "
+        f"chain: {snapshot.get('chain_status')}  "
+        f"earliest: {snapshot.get('earliest_timestamp_utc')}  "
+        f"latest: {snapshot.get('latest_timestamp_utc')}"
+    )
+    for header, key in (
+        ("by_actor", "by_actor"),
+        ("by_outcome", "by_outcome"),
+        ("by_tool", "by_tool"),
+        ("by_branch", "by_branch"),
+        ("by_session", "by_session"),
+    ):
+        lines.append("")
+        lines.append(f"[{header}]")
+        for k, v in (snapshot.get(key) or {}).items():
+            lines.append(f"  {k:<40} {v:>6}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m reporting.agent_audit_summary",
+        description=(
+            "Read-only operator view of the agent audit ledger. "
+            "Decides nothing; never mutates the ledger; never prints "
+            "secrets or full command/diff payloads."
+        ),
+    )
+    p.add_argument(
+        "--date",
+        default=None,
+        help="UTC date for the ledger file (default: today). Ignored when --path is given.",
+    )
+    p.add_argument(
+        "--path",
+        default=None,
+        help="Explicit ledger path (overrides --date).",
+    )
+    p.add_argument(
+        "--view",
+        choices=["timeline", "groups", "both"],
+        default="both",
+        help="Which view to render (default: both).",
+    )
+    p.add_argument(
+        "--format",
+        choices=["json", "table"],
+        default="json",
+        help="Output format (default: json).",
+    )
+    p.add_argument(
+        "--limit",
+        type=int,
+        default=50,
+        help="Number of events to include in timeline (default: 50).",
+    )
+    p.add_argument(
+        "--actor",
+        default=None,
+        help="Filter timeline by actor (e.g. claude:hook).",
+    )
+    p.add_argument(
+        "--outcome",
+        default=None,
+        help="Filter timeline by outcome (e.g. blocked_by_hook).",
+    )
+    p.add_argument(
+        "--indent",
+        type=int,
+        default=2,
+        help="JSON indentation (0 for compact). Ignored when --format=table.",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    path = _ledger_path_for(args.date, args.path)
+
+    out: dict[str, Any] = {}
+    if args.view in ("timeline", "both"):
+        out["timeline"] = collect_timeline(
+            path,
+            limit=args.limit,
+            actor=args.actor,
+            outcome=args.outcome,
+        )
+    if args.view in ("groups", "both"):
+        out["groups"] = collect_groups(path)
+
+    assert_no_secrets(out)
+
+    if args.format == "json":
+        indent = args.indent if args.indent and args.indent > 0 else None
+        json.dump(out, sys.stdout, indent=indent, sort_keys=True)
+        sys.stdout.write("\n")
+        return 0
+
+    # table
+    if "timeline" in out:
+        sys.stdout.write(render_timeline_table(out["timeline"]))
+    if "groups" in out:
+        sys.stdout.write(render_groups_table(out["groups"]))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/unit/test_agent_audit_summary.py
+++ b/tests/unit/test_agent_audit_summary.py
@@ -1,0 +1,385 @@
+"""Unit tests for ``reporting.agent_audit_summary``.
+
+Properties under test:
+
+* read-only — neither view writes to the ledger or any other path;
+* events are sorted by ``sequence_id`` ascending in the timeline view;
+* missing actor / branch / head_sha / session degrade to ``"unknown"``;
+* unknown chain status never reports ``"intact"`` and never ``"ok"``;
+* credential-pattern strings are redacted out of every projection;
+* sensitive-path fragments raise from ``assert_no_secrets``;
+* malformed lines are *counted*, never raised — the CLI keeps working;
+* ``target_path`` is **never** surfaced verbatim — only its parent
+  directory is exposed via ``target_dir``;
+* the CLI emits valid JSON in JSON mode and a non-empty text table in
+  table mode, exit code 0 in both cases;
+* frozen contracts (``research_latest.json``, ``strategy_matrix.csv``)
+  are not opened or modified.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from reporting import agent_audit, agent_audit_summary
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _file_sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _existence_and_sha(path: Path) -> tuple[bool, str | None]:
+    if not path.exists():
+        return (False, None)
+    return (True, _file_sha256(path))
+
+
+@pytest.fixture
+def ledger_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect both writers and the summary path-resolver to ``tmp_path``."""
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    monkeypatch.setattr(agent_audit, "_LEDGER_DIR", logs_dir)
+    monkeypatch.setattr(agent_audit_summary, "REPO_ROOT", tmp_path)
+    return agent_audit.current_ledger_path()
+
+
+def _seed_two_events(ledger_path: Path) -> None:
+    """Append one ok and one blocked event so each test can rely on a
+    canonical two-event fixture without re-stating it."""
+    agent_audit.append_event(
+        {
+            "event": "tool_use",
+            "tool": "Edit",
+            "outcome": "ok",
+            "actor": "claude:audit_emit",
+            "session_id": "sess-A",
+            "branch": "feat/x",
+            "head_sha": "abc123" * 6 + "abcd",
+            "command_summary": "should-not-leak",
+            "target_path": "dashboard/api_observability.py",
+        }
+    )
+    agent_audit.append_event(
+        {
+            "event": "blocked",
+            "tool": "Write",
+            "outcome": "blocked_by_hook",
+            "block_reason": "no_touch_path matched 'VERSION'",
+            "actor": "claude:hook",
+            "session_id": "sess-A",
+            "branch": "feat/x",
+            "head_sha": "abc123" * 6 + "abcd",
+            "command_summary": "DO_NOT_LEAK_payload",
+            "target_path": "VERSION",
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Read-only invariant
+# ---------------------------------------------------------------------------
+
+
+def test_views_do_not_mutate_the_ledger(ledger_path: Path) -> None:
+    _seed_two_events(ledger_path)
+    before = _file_sha256(ledger_path)
+    agent_audit_summary.collect_timeline(ledger_path, limit=10)
+    agent_audit_summary.collect_groups(ledger_path)
+    after = _file_sha256(ledger_path)
+    assert before == after, "summary views modified the ledger"
+
+
+# ---------------------------------------------------------------------------
+# Timeline shape & ordering
+# ---------------------------------------------------------------------------
+
+
+def test_timeline_events_sorted_by_sequence_id(ledger_path: Path) -> None:
+    _seed_two_events(ledger_path)
+    snap = agent_audit_summary.collect_timeline(ledger_path, limit=10)
+    seqs = [r["sequence_id"] for r in snap["rows"]]
+    assert seqs == sorted(seqs)
+    assert seqs == [0, 1]
+
+
+def test_timeline_redacts_target_path_to_directory_only(
+    ledger_path: Path,
+) -> None:
+    _seed_two_events(ledger_path)
+    snap = agent_audit_summary.collect_timeline(ledger_path, limit=10)
+    flat = json.dumps(snap)
+    # The full path must not appear anywhere in the projection.
+    assert "api_observability.py" not in flat
+    # But the parent directory ("dashboard") should be there as target_dir.
+    target_dirs = [r["target_dir"] for r in snap["rows"]]
+    assert "dashboard" in target_dirs
+
+
+def test_timeline_omits_command_and_diff_payloads(ledger_path: Path) -> None:
+    _seed_two_events(ledger_path)
+    snap = agent_audit_summary.collect_timeline(ledger_path, limit=10)
+    flat = json.dumps(snap)
+    assert "DO_NOT_LEAK_payload" not in flat
+    assert "should-not-leak" not in flat
+    # No keys named command_summary / diff_summary / target_path should
+    # appear inside any row.
+    for row in snap["rows"]:
+        assert "command_summary" not in row
+        assert "diff_summary" not in row
+        assert "target_path" not in row
+
+
+def test_timeline_filter_by_actor(ledger_path: Path) -> None:
+    _seed_two_events(ledger_path)
+    snap = agent_audit_summary.collect_timeline(
+        ledger_path, limit=10, actor="claude:hook"
+    )
+    assert all(r["actor"] == "claude:hook" for r in snap["rows"])
+    assert len(snap["rows"]) == 1
+
+
+def test_timeline_filter_by_outcome(ledger_path: Path) -> None:
+    _seed_two_events(ledger_path)
+    snap = agent_audit_summary.collect_timeline(
+        ledger_path, limit=10, outcome="blocked_by_hook"
+    )
+    assert all(r["outcome"] == "blocked_by_hook" for r in snap["rows"])
+    assert len(snap["rows"]) == 1
+
+
+def test_timeline_limit_returns_only_last_n(ledger_path: Path) -> None:
+    for i in range(5):
+        agent_audit.append_event(
+            {"event": "tool_use", "outcome": "ok", "actor": f"claude:test{i}"}
+        )
+    snap = agent_audit_summary.collect_timeline(ledger_path, limit=2)
+    seqs = [r["sequence_id"] for r in snap["rows"]]
+    assert seqs == [3, 4]
+
+
+# ---------------------------------------------------------------------------
+# Missing field handling — never "ok", always "unknown"
+# ---------------------------------------------------------------------------
+
+
+def test_missing_optional_fields_become_unknown(ledger_path: Path) -> None:
+    # Append an event with several fields explicitly absent. The writer
+    # fills `actor` with `claude:unknown` if not given, but branch /
+    # head_sha / session_id pass through as None and must surface as
+    # "unknown" in the projection.
+    agent_audit.append_event({"event": "tool_use", "outcome": "ok"})
+    snap = agent_audit_summary.collect_timeline(ledger_path, limit=10)
+    row = snap["rows"][0]
+    assert row["branch"] == "unknown"
+    assert row["head_sha"] == "unknown"
+    assert row["session_id"] == "unknown"
+    assert row["target_dir"] == "unknown"
+
+
+def test_chain_status_never_ok_when_file_missing(ledger_path: Path) -> None:
+    # File never created.
+    missing = ledger_path.parent / "agent_audit.1999-01-01.jsonl"
+    snap = agent_audit_summary.collect_timeline(missing, limit=10)
+    assert snap["chain_status"] == "not_available"
+    assert snap["chain_status"] != "ok"
+
+
+def test_chain_status_intact_when_chain_intact(ledger_path: Path) -> None:
+    _seed_two_events(ledger_path)
+    snap = agent_audit_summary.collect_groups(ledger_path)
+    assert snap["chain_status"] == "intact"
+    assert snap["first_corrupt_index"] is None
+
+
+def test_chain_status_broken_when_chain_broken(ledger_path: Path) -> None:
+    _seed_two_events(ledger_path)
+    # Corrupt the first event.
+    lines = ledger_path.read_text(encoding="utf-8").splitlines()
+    first = json.loads(lines[0])
+    first["event_sha256"] = "0" * 64
+    lines[0] = json.dumps(first, sort_keys=True)
+    ledger_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    snap = agent_audit_summary.collect_groups(ledger_path)
+    assert snap["chain_status"] == "broken"
+    assert snap["first_corrupt_index"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Malformed input safety
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_lines_are_counted_not_raised(ledger_path: Path) -> None:
+    _seed_two_events(ledger_path)
+    # Append two malformed lines: one non-JSON, one wrong-shape JSON.
+    with ledger_path.open("a", encoding="utf-8") as f:
+        f.write("not-json{{{\n")
+        f.write(json.dumps({"hello": "world"}) + "\n")  # missing schema
+    timeline = agent_audit_summary.collect_timeline(ledger_path, limit=10)
+    groups = agent_audit_summary.collect_groups(ledger_path)
+    assert timeline["malformed_line_count"] == 2
+    assert groups["malformed_line_count"] == 2
+    assert timeline["ledger_event_count"] == 2  # the two valid events
+
+
+# ---------------------------------------------------------------------------
+# Group view aggregates
+# ---------------------------------------------------------------------------
+
+
+def test_groups_aggregates_by_actor_outcome_branch_session(
+    ledger_path: Path,
+) -> None:
+    _seed_two_events(ledger_path)
+    snap = agent_audit_summary.collect_groups(ledger_path)
+    assert snap["by_actor"] == {"claude:audit_emit": 1, "claude:hook": 1}
+    assert snap["by_outcome"] == {"blocked_by_hook": 1, "ok": 1}
+    assert snap["by_branch"] == {"feat/x": 2}
+    assert snap["by_session"] == {"sess-A": 2}
+    # Sorted iteration — keys appear in deterministic order.
+    assert list(snap["by_actor"].keys()) == sorted(snap["by_actor"].keys())
+
+
+# ---------------------------------------------------------------------------
+# Secret-redaction safety
+# ---------------------------------------------------------------------------
+
+
+def test_assert_no_secrets_passes_on_clean_snapshot(ledger_path: Path) -> None:
+    _seed_two_events(ledger_path)
+    snap = agent_audit_summary.collect_timeline(ledger_path, limit=10)
+    agent_audit_summary.assert_no_secrets(snap)  # must not raise
+
+
+def test_assert_no_secrets_catches_credential_pattern() -> None:
+    leaky = {"some": "ghp_AAAAAAAAAAAAAAAAAAAAAAAAA"}
+    with pytest.raises(AssertionError, match="credential-like"):
+        agent_audit_summary.assert_no_secrets(leaky)
+
+
+def test_assert_no_secrets_catches_sensitive_path_fragment() -> None:
+    leaky = {"x": "config/config.yaml"}
+    with pytest.raises(AssertionError, match="sensitive path"):
+        agent_audit_summary.assert_no_secrets(leaky)
+
+
+def test_credential_string_in_event_is_scrubbed_in_projection(
+    ledger_path: Path,
+) -> None:
+    # Inject a credential-shaped value into an event field that the
+    # projection keeps. The writer will already redact some patterns,
+    # but for fields that bypass writer redaction (e.g. block_reason),
+    # the projection must still scrub.
+    agent_audit.append_event(
+        {
+            "event": "blocked",
+            "tool": "Bash",
+            "outcome": "blocked_by_hook",
+            "block_reason": "fake leak ghp_QQQQQQQQQQQQQQQQQQQQQQ here",
+            "actor": "claude:hook",
+        }
+    )
+    snap = agent_audit_summary.collect_timeline(ledger_path, limit=10)
+    flat = json.dumps(snap)
+    assert "ghp_QQQQQQQQQQQQQQQQQQQQQQ" not in flat
+    assert "[REDACTED]" in flat
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def test_cli_json_mode_returns_zero_and_valid_json(
+    ledger_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_two_events(ledger_path)
+    rc = agent_audit_summary.main(
+        ["--path", str(ledger_path), "--view", "both", "--format", "json", "--indent", "0"]
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    parsed = json.loads(out)
+    assert "timeline" in parsed
+    assert "groups" in parsed
+
+
+def test_cli_table_mode_renders_header_and_rows(
+    ledger_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _seed_two_events(ledger_path)
+    rc = agent_audit_summary.main(
+        ["--path", str(ledger_path), "--view", "timeline", "--format", "table"]
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "sequence_id" in out
+    assert "actor" in out
+    assert "claude:hook" in out
+
+
+def test_cli_returns_zero_on_missing_ledger(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    missing = tmp_path / "nope.jsonl"
+    rc = agent_audit_summary.main(
+        ["--path", str(missing), "--view", "groups", "--format", "json"]
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    parsed = json.loads(out)
+    assert parsed["groups"]["chain_status"] == "not_available"
+    assert parsed["groups"]["ledger_event_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Frozen-contract integrity
+# ---------------------------------------------------------------------------
+
+
+def test_collect_views_do_not_touch_frozen_contracts() -> None:
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    research_latest = repo_root / "research" / "research_latest.json"
+    strategy_matrix = repo_root / "research" / "strategy_matrix.csv"
+
+    before_a = _existence_and_sha(research_latest)
+    before_b = _existence_and_sha(strategy_matrix)
+
+    # Use today's real ledger if it exists; either way, the test must
+    # not write to the frozen contracts.
+    today = (
+        repo_root
+        / "logs"
+        / f"agent_audit.{_dt.datetime.now(_dt.UTC).strftime('%Y-%m-%d')}.jsonl"
+    )
+    timeline = agent_audit_summary.collect_timeline(today, limit=5)
+    groups = agent_audit_summary.collect_groups(today)
+    agent_audit_summary.assert_no_secrets({"timeline": timeline, "groups": groups})
+
+    after_a = _existence_and_sha(research_latest)
+    after_b = _existence_and_sha(strategy_matrix)
+    assert before_a == after_a, "research_latest.json was modified"
+    assert before_b == after_b, "strategy_matrix.csv was modified"
+
+    # And neither contract path appears in either view.
+    flat = json.dumps({"timeline": timeline, "groups": groups})
+    assert "research_latest.json" not in flat
+    assert "strategy_matrix.csv" not in flat


### PR DESCRIPTION
# Pull Request

## Summary

<!-- 1–3 bullet points on what changed and why. Avoid file-by-file recap. -->

-
-

## Linked roadmap item / ADR

<!-- e.g. v3.15.15.12.5 / ADR-015 §audit-chain -->

## Autonomy claim

> The PR author claims this PR was produced at autonomy level: **Level _**
> (0 = planning only, 1 = docs/tests/frontend, 2 = observability/CI,
> 3 = backend non-core. Level 4+ is not enabled in this project.)
> See [`docs/governance/autonomy_ladder.md`](../docs/governance/autonomy_ladder.md).

## Governance checklist

A PR cannot be merged until every applicable item is checked or marked N/A.

- [ ] No no-touch path was modified, **or** a new ADR is linked above.
- [ ] Determinism-pin job is green; no pin re-pinned.
- [ ] Authority surfaces unchanged (ADR-014).
- [ ] Evidence ledger schemas unchanged or extended-only (no field removals/renames).
- [ ] No tests skipped, marked `xfail`, or assertion-relaxed; no fixtures
      regenerated; no digest pins updated.
- [ ] No new live/broker connector files created.
- [ ] `VERSION` is unchanged in this PR, **or** the bump is explicitly recommended
      by a Release Gate report linked below.
- [ ] Build provenance attached as a workflow artifact, **or** N/A (non-image PR).
- [ ] Active nightly failures referenced in PR body, **or** none active.
- [ ] Agent run summary committed, **or** N/A (no agent involvement):
      `docs/governance/agent_run_summaries/<session_id>.md`
- [ ] Release Gate report (if applicable):
      `docs/governance/release_gates/<version>/<timestamp>.md`

## Test plan

<!-- What was actually run? Paste pytest summary lines, vitest summary, ruff/mypy
output. If a test was added, name it here. -->

-
-

## Risks & rollback

<!-- One sentence per item. -->

- Risk:
- Rollback:

---

> Anything that touches `automation/live_gate.py`, `config/config.yaml`,
> `state/*.secret`, frozen v1 schemas, or production posture files
> (`docker-compose.prod.yml`, `scripts/deploy.sh`, `ops/systemd/*`) requires
> CODEOWNERS review and a linked ADR amendment. See
> [`docs/governance/no_touch_paths.md`](../docs/governance/no_touch_paths.md).
