### PR TITLE
fix(ci): authenticate sbom & scan jobs against GHCR

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -179,7 +179,19 @@ jobs:
     name: sbom
     needs: [build-grep-push]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
     steps:
+      # GHCR images are private by default. syft pulls via the local Docker
+      # daemon and the OCI registry; both require auth. Authenticate before
+      # invoking the SBOM action so it can resolve the image.
+      - name: Log in to GHCR (read-only) so syft can pull the image
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: anchore/sbom-action@d94f46e13c6c62f59525ac9a1e147a99dc0b9bf5
         with:
           image: "ghcr.io/roudjy/trading-agent-agent:${{ needs.build-grep-push.outputs.version }}"
@@ -191,8 +203,18 @@ jobs:
     needs: [build-grep-push]
     runs-on: ubuntu-latest
     continue-on-error: true
+    permissions:
+      contents: read
+      packages: read
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      # Same auth requirement as sbom: trivy pulls a private GHCR image.
+      - name: Log in to GHCR (read-only) so trivy can pull the image
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Trivy scan
         uses: aquasecurity/trivy-action@6e7b7d1fd3e4fef0c5fa8cce1229c54b2c9bd0d8
         with:


### PR DESCRIPTION
## Summary

The Docker workflow `sbom` job failed on main run 25247300561 with `UNAUTHORIZED: authentication required` from syft. The `scan (trivy alert-only)` job had the same root cause, masked by its pre-existing `continue-on-error: true`. This PR adds GHCR login to both jobs.

## Root cause

GHCR images are private by default. The `sbom` job runs on a fresh runner and never authenticates. The `build-grep-push` job logs in earlier, but credentials do not carry across jobs.

Failing log excerpt (run 25247300561):

```
[command] syft scan ghcr.io/roudjy/trading-agent-agent:<version> -o spdx-json
could not determine source: errors occurred attempting to resolve ...:
  - docker: pull failed: ... unauthorized
  - oci-registry: ... UNAUTHORIZED: authentication required
##[error]The process .../syft failed with exit code 1
```

## What changed

Single file: `.github/workflows/docker-build.yml`, only the `sbom` and `scan` jobs.

For BOTH jobs:

1. Per-job `permissions: { contents: read, packages: read }` block (tighter than the inherited top-level `packages: write`; sbom and scan only pull).
2. `docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567` step before the syft / trivy step. SHA-pinned, identical to the existing login on line 47 inside `build-grep-push`.

## What did NOT change

- No SHA pin changes anywhere.
- `sbom` remains blocking (no `continue-on-error` added).
- `scan` retains its pre-existing `continue-on-error: true` — unchanged.
- The `needs:` graph, artifact uploads, and SBOM coverage are byte-for-byte identical to before.
- No edits to no-touch paths, frozen contracts, or any non-CI code.

## Constraints respected

- Do not weaken required CI gates. Sbom kept blocking; scan kept its alert-only mode.
- Do not remove SBOM generation. Untouched.
- Do not skip Docker image checks. Untouched.
- Do not add broad allowlists. None added.
- Per-job permissions narrow the workflow attack surface (hardening).

## Test plan

- [x] `python scripts/governance_lint.py` — OK (15 agents, 3 workflows).
- [x] `pytest tests/smoke -q` — 14/14 pass.
- [x] Frozen-contract hashes unchanged:
  - `research/research_latest.json` = `4a567bd6feb98eb7aa32db4a90a3201456843088314936c5e484a2ae6a93666c`
  - `research/strategy_matrix.csv`   = `ff15b8c4f35cc37b6941b712106ae71a1b82a1b5043da197731d42518d258d66`
- [x] Adversarial review by `ci-guardian` agent — PASS, all five verification points clear including red-team checks on permission shape and artifact upload risk.
- [ ] CI `sbom` passes on this branch (only verifiable post-merge — workflow_run trigger filtered to main).

## Verification path post-merge

`docker-build.yml` is triggered by `workflow_run` on `Fast pre-merge gate` for `branches: [main]`, so the actual `sbom` job only runs after merge. After squash-merge: watch the docker-build run on main and confirm `sbom = success` and `build-grep-push = success`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)