### PR TITLE
fix(ci): pre-pull image so trivy can scan and write SARIF

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -215,7 +215,27 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      # aquasecurity/trivy-action runs trivy inside a container that mounts
+      # the host /var/run/docker.sock. Trivy's "docker" backend asks the host
+      # daemon for the image — if it's not in the local cache, trivy falls
+      # back to "remote" mode using its OWN credential context (inside the
+      # trivy container) which does NOT see the host ~/.docker/config.json
+      # we just populated. Result: UNAUTHORIZED + "No such image", trivy
+      # exits before writing trivy-results.sarif, the upload step finds no
+      # file, and "alert-only" produces no actual alert.
+      #
+      # Pre-pulling on the host populates the daemon cache so trivy's
+      # docker backend resolves the image without falling back to remote.
+      # The host already has the GHCR creds from the login step above.
+      - name: Pull image to local daemon so trivy can scan it
+        run: docker pull "ghcr.io/roudjy/trading-agent-agent:${{ needs.build-grep-push.outputs.version }}"
       - name: Trivy scan
+        # Defense in depth: even though job-level continue-on-error already
+        # makes this job non-blocking, step-level continue-on-error keeps
+        # the SARIF upload step running on any future trivy non-zero exit
+        # (e.g. if an exit-code policy is ever added) without relying
+        # solely on `if: always()` on the upload step.
+        continue-on-error: true
         uses: aquasecurity/trivy-action@6e7b7d1fd3e4fef0c5fa8cce1229c54b2c9bd0d8
         with:
           image-ref: "ghcr.io/roudjy/trading-agent-agent:${{ needs.build-grep-push.outputs.version }}"
@@ -229,6 +249,7 @@ jobs:
           name: trivy-${{ needs.build-grep-push.outputs.version }}
           path: trivy-results.sarif
           retention-days: 30
+          if-no-files-found: warn
 
   provenance:
     name: provenance (build_provenance.json)


### PR DESCRIPTION
## Summary

The Docker workflow `scan (trivy alert-only)` job kept failing post-PR #61 — auth was fixed, but trivy still could not resolve the image and never wrote the SARIF file. This PR pre-pulls the image on the host runner so trivy's docker backend finds it.

## Root cause

`aquasecurity/trivy-action` runs trivy INSIDE its own Docker container (mounts `/var/run/docker.sock`). PR #61 put GHCR credentials in `~/.docker/config.json` on the HOST runner. When trivy's docker backend asks the host daemon for the image, the daemon says "no" because nothing actually pulled it. Trivy then falls back to its remote backend, which uses its own credential context inside the trivy container — credentials we never propagated.

Failing log excerpt (run 25250351160):

```
FATAL  image scan error: ... unable to find the specified image in
[docker containerd podman remote]:
  * docker error: ... No such image: ghcr.io/roudjy/...
  * remote error: ... UNAUTHORIZED: authentication required
##[warning] No files were found with the provided path: trivy-results.sarif.
```

## What changed

In the `scan` job ONLY (`.github/workflows/docker-build.yml` lines 209-252):

1. **Added a `docker pull` step** on the host runner, after the existing GHCR login (PR #61) and before the trivy step. The host already has GHCR creds, so the pull succeeds and populates the local daemon cache. Trivy's docker backend then resolves the image without falling back to remote.

2. **Added `continue-on-error: true` at the step level** on the Trivy scan step. The job already has `continue-on-error: true` at the job level, so this is defense-in-depth: if a future `exit-code` policy is added, the SARIF upload step is guaranteed to still execute regardless of the `if: always()` already on the upload.

3. **Added explicit `if-no-files-found: warn`** on the upload step. Default is `warn`, so this documents current behavior — explicit is better than implicit.

## What did NOT change

- No SHA pin downgrades; all `uses:` lines unchanged.
- `build-grep-push` and `sbom` retain their blocking semantics — untouched.
- `scan` retains its alert-only (job-level `continue-on-error: true`) — untouched.
- The `needs:` graph, severity filter (`CRITICAL,HIGH`), format (`sarif`), and output path (`trivy-results.sarif`) are unchanged.
- No suppression of real findings: trivy writes findings to the SARIF file regardless of exit code.

## Constraints respected

- Do not make `build-grep-push` or `sbom` non-blocking — untouched.
- Do not remove Trivy scan — untouched.
- Do not hide scan failures — step-level continue-on-error is paired with mandatory SARIF upload, so failures still surface as warnings.
- Keep Trivy alert-only semantics — preserved.
- Do not weaken scanner coverage — same image, same severity, same format.
- No broad allowlists; no edits to no-touch paths or frozen contracts.

## Test plan

- [x] `python scripts/governance_lint.py` — OK (15 agents, 3 workflows).
- [x] `pytest tests/smoke -q` — 14/14 pass.
- [x] Frozen-contract hashes unchanged (`research/research_latest.json`, `research/strategy_matrix.csv`).
- [x] Adversarial review by `ci-guardian` agent — **PASS** on all five verification points (SHA pins, required-status gates, scanner coverage, visibility tradeoff, race-condition red-team).
- [ ] Post-merge: `scan` job successfully pulls image, trivy writes SARIF, upload step uploads the artifact.

## Verification path post-merge

`docker-build.yml` only runs on main via `workflow_run`. After squash-merge: watch the docker-build run on main and confirm:
- `build-grep-push` = success (regression check)
- `sbom` = success (regression check)
- `scan` = uploads `trivy-${version}` artifact containing `trivy-results.sarif` (the actual deliverable of this fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)