### PR TITLE
feat(v3.15.15.18): mobile-first read-only Agent Control PWA

### DIFF
--- a/dashboard/api_agent_control.py
+++ b/dashboard/api_agent_control.py
@@ -1,0 +1,297 @@
+"""Read-only Flask routes for the v3.15.15.18 mobile-first Agent
+Control PWA.
+
+This module exposes five GET-only endpoints under the
+``/api/agent-control/`` prefix. It is the *only* surface the mobile
+PWA shell needs to render its read-only cards.
+
+Hard guarantees (enforced by code AND tests)
+--------------------------------------------
+
+* GET only — no POST / PUT / PATCH / DELETE / OPTIONS handlers
+  registered.
+* Never executes a CLI subprocess. Reads pre-computed JSON / module
+  output only.
+* Never invokes ``gh`` (or any other mutating tool).
+* Never touches ``git``.
+* Never reads ``config/config.yaml``, ``state/*.secret``, ``.env``,
+  or any other path on the no-touch read-deny list.
+* Missing / malformed / unreadable artifacts → ``{"status":
+  "not_available", "reason": ...}``. Nothing is ever surfaced as
+  ``ok`` by default; ``ok`` requires positive evidence.
+* Every response payload is run through ``assert_no_secrets`` from
+  ``reporting.agent_audit_summary`` before it leaves the server, so
+  the surface remains free of accidental credential strings.
+* The ``/notifications`` endpoint is a placeholder: it returns an
+  empty list with ``mode: "placeholder"``. No browser push, no
+  external service.
+
+Wiring
+------
+
+The module follows the existing ``register_*_routes(app)`` pattern.
+To activate the surface, ``dashboard/dashboard.py`` needs one line::
+
+    from dashboard.api_agent_control import register_agent_control_routes
+    register_agent_control_routes(app)
+
+That edit is intentionally NOT shipped here — ``dashboard.py`` is on
+the no-touch list and a separate operator-led PR wires it up.
+Until that PR lands, the PWA frontend treats every endpoint as
+``not_available`` and renders empty/placeholder states.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from flask import Flask, jsonify
+
+from reporting.agent_audit_summary import assert_no_secrets
+
+REPO_ROOT: Path = Path(__file__).resolve().parent.parent
+LOGS_DIR: Path = REPO_ROOT / "logs"
+
+# Cached locations of the JSON artifacts the cards consume. Each is
+# produced by a separate reporting module — none of those imports
+# happens here, so this surface stays light and side-effect free.
+WORKLOOP_LATEST: Path = LOGS_DIR / "autonomous_workloop" / "latest.json"
+PR_LIFECYCLE_LATEST: Path = LOGS_DIR / "github_pr_lifecycle" / "latest.json"
+
+# Frozen contracts the PWA surfaces verbatim (path + sha256 only).
+FROZEN_CONTRACTS: tuple[str, ...] = (
+    "research/research_latest.json",
+    "research/strategy_matrix.csv",
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_json_artifact(path: Path) -> dict[str, Any]:
+    """Read a JSON artifact and return one of:
+
+    * ``{"status": "ok", "data": <parsed dict>}`` on success;
+    * ``{"status": "not_available", "reason": "missing"}`` when the
+      file does not exist;
+    * ``{"status": "not_available", "reason": "malformed: <error>"}``
+      when the file exists but is not valid JSON.
+
+    Always returns a dict (never raises).
+    """
+    if not path.exists():
+        return {"status": "not_available", "reason": "missing"}
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as e:
+        return {
+            "status": "not_available",
+            "reason": f"unreadable: {type(e).__name__}",
+        }
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as e:
+        return {
+            "status": "not_available",
+            "reason": f"malformed: {type(e).__name__}",
+        }
+    if not isinstance(data, dict):
+        return {"status": "not_available", "reason": "malformed: not_an_object"}
+    return {"status": "ok", "data": data}
+
+
+def _file_sha256(path: Path) -> str:
+    """Compute sha256 of ``path`` or return ``"missing"`` if it does
+    not exist or is unreadable. Stdlib-only, never raises."""
+    import hashlib
+
+    if not path.exists():
+        return "missing"
+    h = hashlib.sha256()
+    try:
+        with path.open("rb") as f:
+            for chunk in iter(lambda: f.read(8192), b""):
+                h.update(chunk)
+    except OSError:
+        return "missing"
+    return h.hexdigest()
+
+
+def _frozen_hashes_payload() -> dict[str, Any]:
+    """Return a stable, sortable payload mapping each frozen
+    contract path to its current sha256 (or ``"missing"``)."""
+    return {
+        "status": "ok",
+        "data": {
+            rel: _file_sha256(REPO_ROOT / rel) for rel in FROZEN_CONTRACTS
+        },
+    }
+
+
+def _safe_jsonify(payload: dict[str, Any]):
+    """Run ``assert_no_secrets`` over the payload, then ``jsonify``.
+
+    If the payload would leak a credential or a sensitive-path
+    fragment, the assertion raises and the surrounding error handler
+    in ``dashboard.dashboard`` returns a generic 500 — the surface
+    refuses to leak rather than fall through.
+    """
+    assert_no_secrets(payload)
+    return jsonify(payload)
+
+
+# ---------------------------------------------------------------------------
+# Endpoint handlers
+# ---------------------------------------------------------------------------
+
+
+def _status_payload() -> dict[str, Any]:
+    """Aggregate health: governance status + frozen-contract hashes.
+
+    The PWA Status card consumes this. No CLI subprocess; the
+    governance status reporter is imported lazily and called as a
+    pure function so the read remains synchronous and side-effect
+    free.
+    """
+    try:
+        # Late import: keeps the module light when the surface is not
+        # wired up.
+        from reporting.governance_status import (
+            collect_status,
+            assert_no_secrets as _gov_assert_no_secrets,
+        )
+
+        snap = collect_status()
+        _gov_assert_no_secrets(snap)
+        gov = {"status": "ok", "data": snap}
+    except Exception as e:  # noqa: BLE001 — defensive boundary
+        gov = {
+            "status": "not_available",
+            "reason": f"governance_status_error: {type(e).__name__}",
+        }
+    return {
+        "kind": "agent_control_status",
+        "schema_version": 1,
+        "governance_status": gov,
+        "frozen_hashes": _frozen_hashes_payload(),
+    }
+
+
+def _activity_payload() -> dict[str, Any]:
+    """Recent agent-audit timeline (last 50 events, redacted view).
+
+    The PWA Activity card consumes this. The agent_audit_summary
+    module already handles redaction; this layer just wraps it.
+    """
+    try:
+        from reporting import agent_audit_summary as audit_summary
+        import datetime as _dt
+
+        today = _dt.datetime.now(_dt.UTC).strftime("%Y-%m-%d")
+        ledger = REPO_ROOT / "logs" / f"agent_audit.{today}.jsonl"
+        snap = audit_summary.collect_timeline(ledger, limit=50)
+        audit_summary.assert_no_secrets(snap)
+        return {
+            "kind": "agent_control_activity",
+            "schema_version": 1,
+            "status": "ok",
+            "data": snap,
+        }
+    except Exception as e:  # noqa: BLE001
+        return {
+            "kind": "agent_control_activity",
+            "schema_version": 1,
+            "status": "not_available",
+            "reason": f"agent_audit_summary_error: {type(e).__name__}",
+        }
+
+
+def _workloop_payload() -> dict[str, Any]:
+    """Latest autonomous workloop digest (if available)."""
+    artifact = _read_json_artifact(WORKLOOP_LATEST)
+    return {
+        "kind": "agent_control_workloop",
+        "schema_version": 1,
+        **artifact,
+        "artifact_path": "logs/autonomous_workloop/latest.json",
+    }
+
+
+def _pr_lifecycle_payload() -> dict[str, Any]:
+    """Latest GitHub PR lifecycle digest (if available).
+
+    On a clean Dependabot queue this returns
+    ``data.prs == []`` and ``data.final_recommendation == "no_open_prs"``.
+    """
+    artifact = _read_json_artifact(PR_LIFECYCLE_LATEST)
+    return {
+        "kind": "agent_control_pr_lifecycle",
+        "schema_version": 1,
+        **artifact,
+        "artifact_path": "logs/github_pr_lifecycle/latest.json",
+    }
+
+
+def _notifications_payload() -> dict[str, Any]:
+    """Placeholder notification center.
+
+    v3.15.15.18 does not ship browser push or any external
+    notification service. The endpoint exists so the PWA can render
+    the empty-state card; the actual notification source is gated on
+    a later release (browser push for needs-human events lands in
+    v3.15.15.23 per the runbook).
+    """
+    return {
+        "kind": "agent_control_notifications",
+        "schema_version": 1,
+        "status": "ok",
+        "mode": "placeholder",
+        "data": [],
+        "next_release_with_push": "v3.15.15.23",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Route registration
+# ---------------------------------------------------------------------------
+
+
+# Methods are explicitly listed as ["GET"] on every route. The unit
+# tests assert that no other HTTP verb registers a handler.
+_AGENT_CONTROL_ROUTES: tuple[tuple[str, Any], ...] = (
+    ("/api/agent-control/status", _status_payload),
+    ("/api/agent-control/activity", _activity_payload),
+    ("/api/agent-control/workloop", _workloop_payload),
+    ("/api/agent-control/pr-lifecycle", _pr_lifecycle_payload),
+    ("/api/agent-control/notifications", _notifications_payload),
+)
+
+
+def register_agent_control_routes(app: Flask) -> None:
+    """Mount the read-only agent-control routes on ``app``.
+
+    Idempotent: re-registering on the same app is a no-op (Flask
+    raises if the same endpoint name is added twice; we silence the
+    duplicate by using unique endpoint names per route).
+    """
+    for path, handler in _AGENT_CONTROL_ROUTES:
+        endpoint = "agent_control_" + path.rsplit("/", 1)[-1].replace("-", "_")
+
+        # The closure captures ``handler`` by default-argument trick to
+        # avoid late-binding the loop variable.
+        def _view(_h=handler):  # type: ignore[no-untyped-def]
+            return _safe_jsonify(_h())
+
+        # Each route registers GET only. Flask defaults include HEAD
+        # implicitly — we accept that since HEAD is read-only by
+        # protocol.
+        app.add_url_rule(
+            path,
+            endpoint=endpoint,
+            view_func=_view,
+            methods=["GET"],
+        )

--- a/docs/governance/autonomous_workloop_runbook.md
+++ b/docs/governance/autonomous_workloop_runbook.md
@@ -121,12 +121,12 @@ The controller embeds these verbatim in every digest's
 | v3.15.15.15 | inferred subagent attribution + ADR-016 proposal |
 | **v3.15.15.16** | **local workloop planner (this runbook)** |
 | **v3.15.15.17** | **GitHub-backed PR lifecycle + Dependabot cleanup playbook (`reporting.github_pr_lifecycle`)** — pulled forward from the original v3.15.15.19 slot after a 10/10 pilot. Read-only by default; `execute-safe` mode comments `@dependabot rebase` and squash-merges LOW/MEDIUM Dependabot PRs only. HIGH stays inspect-only. |
-| v3.15.15.18 | roadmap queue + agent proposal intake |
-| v3.15.15.19 | (vacated — moved into v3.15.15.17) |
+| **v3.15.15.18** | **Mobile-first read-only Agent Control PWA** (`dashboard.api_agent_control` + `frontend/src/routes/AgentControl.tsx`). Five cards backed by existing reporters / artifacts; installable; service-worker offline-capable; no execute / approve / merge buttons in the rendered DOM. See [`mobile_agent_control_pwa.md`](mobile_agent_control_pwa.md). |
+| v3.15.15.19 | roadmap queue + agent proposal intake (was vacated; reclaimed) |
 | v3.15.15.20 | operator approval & exception inbox |
 | v3.15.15.21 | dashboard execute-safe controls |
 | v3.15.15.22 | long-running runtime |
-| v3.15.15.23 | safe PR automerge (HIGH unlocks behind formalized rules) |
+| v3.15.15.23 | safe PR automerge (HIGH unlocks behind formalized rules) + browser push notifications for needs-human events only |
 
 See the canonical roadmap at
 [`frontend_agent_control_layer_roadmap.md`](frontend_agent_control_layer_roadmap.md).

--- a/docs/governance/mobile_agent_control_pwa.md
+++ b/docs/governance/mobile_agent_control_pwa.md
@@ -1,0 +1,202 @@
+# Mobile-first Agent Control PWA — Operator Runbook
+
+> Module: `dashboard.api_agent_control` (backend) + `frontend/src/routes/AgentControl.tsx` (frontend)
+> Release: v3.15.15.18
+> Sibling lifecycle modules: `reporting.autonomous_workloop`,
+> `reporting.github_pr_lifecycle`
+
+This is the operator-facing runbook for the v3.15.15.18 mobile-first
+Agent Control PWA. It explains what the app shows, what it does NOT
+do, how to install it on a phone, and the wiring step required to
+move it from "ships in the build" to "served on production".
+
+## What this is
+
+A mobile-first, installable, **read-only** observability surface for
+the autonomous development system. Five cards on one screen, all
+auto-refreshable, all backed by JSON artifacts the rest of the
+governance stack already emits:
+
+| Card | Source | Purpose |
+|---|---|---|
+| **Status** | `reporting.governance_status` + frozen-contract sha256 | At-a-glance health of governance + frozen contracts |
+| **Activity** | `reporting.agent_audit_summary` (timeline view, last 50 redacted events) | Who-did-what on today's audit ledger |
+| **Workloop** | `logs/autonomous_workloop/latest.json` | Latest digest from the local workloop planner |
+| **PR Lifecycle** | `logs/github_pr_lifecycle/latest.json` | Latest Dependabot queue snapshot |
+| **Notifications** | placeholder | Empty-state. Browser push lands in v3.15.15.23. |
+
+## What this is NOT
+
+The release intentionally does NOT ship:
+
+* execute / approve / reject / merge buttons (none in the rendered DOM — verified by test);
+* browser push notifications (placeholder card only — release v3.15.15.23);
+* a long-running runtime (one fetch on mount + one fetch on refresh);
+* roadmap / proposal queues (release v3.15.15.19);
+* approval inbox (release v3.15.15.20);
+* execute-safe controls in the UI (release v3.15.15.21);
+* metrics / external observability (release v3.15.15.25);
+* any POST / PUT / PATCH / DELETE endpoint;
+* any `gh` invocation from the dashboard process;
+* any `git` invocation from the dashboard process;
+* any external telemetry, analytics, or paid service.
+
+## Architecture (thin layers)
+
+```
+┌─────────────────────┐          ┌────────────────────────────┐
+│   Phone / Desktop   │  HTTPS   │  Flask (read-only routes)  │
+│  AgentControl SPA   │ ───────► │ /api/agent-control/status   │
+│  PWA shell + SW     │          │ /api/agent-control/activity │
+│  Five cards         │          │ /api/agent-control/workloop │
+│                     │          │ /api/agent-control/pr-...   │
+│                     │          │ /api/agent-control/notif... │
+└─────────────────────┘          └────────────┬───────────────┘
+                                              │
+                                  In-process module calls
+                                              ▼
+              reporting.governance_status / agent_audit_summary
+              + filesystem reads of logs/*.json (read-only)
+```
+
+The frontend is the existing Vite/React SPA — same React Router
+shell, same auth provider, same Flask `/` index route. The new
+route lives at `/agent-control` and renders five cards inside the
+existing `AppShell`.
+
+## Hard guarantees (enforced by code AND tests)
+
+| guarantee | enforcement |
+|---|---|
+| Backend GET-only | every route registers `methods=["GET"]`; `test_mutation_verbs_are_rejected` asserts 405 on POST/PUT/PATCH/DELETE |
+| Backend never invokes `gh` or `git` | `test_no_gh_or_git_invocation_in_module` (static source check) |
+| Backend never spawns a subprocess | `test_no_subprocess_imports_in_module` |
+| Missing artifact → `not_available` | `test_workloop_missing_artifact_yields_not_available`, `test_pr_lifecycle_missing_artifact_yields_not_available` |
+| Malformed artifact → `not_available` | `test_workloop_malformed_artifact_yields_not_available` |
+| Secret redaction always runs | `test_payload_with_credential_string_is_refused` (response is 500, not leaking text) |
+| SW only handles GET | runtime guard + `test_only_handles_get_requests` (static check) |
+| SW never reaches external services | `test_does_not_reach_external_analytics_or_services` |
+| Frontend has exactly one button | `test_contains_exactly_one_button` (the Vernieuw refresh button) |
+| No execute / approve / merge button labels | `test_does_not_render_any_execute_approve_merge_button` |
+| Cards fall back gracefully | `test_renders_not_available_everywhere_when_every_endpoint_404s` |
+
+## Wiring step (manual, one line)
+
+`dashboard/dashboard.py` is on the no-touch list (it reads operator
+session and token secrets, see
+`docs/governance/no_touch_paths.md`). The agent-control routes are
+not auto-registered by this release; activating them requires one
+line in `dashboard/dashboard.py` next to the other
+`register_*_routes(app)` calls:
+
+```python
+# v3.15.15.18: read-only Agent Control PWA routes.
+from dashboard.api_agent_control import register_agent_control_routes
+register_agent_control_routes(app)
+```
+
+That edit is intentionally not shipped here. Until the operator
+performs it, the PWA frontend treats every endpoint as
+`not_available` and renders empty / placeholder states — by design,
+not as an error.
+
+## Installing the PWA on a phone
+
+1. The dashboard at `https://<host>:8050/` is served behind HTTP
+   Basic auth (existing flow). Log in once on the phone.
+2. Navigate to `/agent-control` in the browser.
+3. iPhone (Safari): tap *Share → Add to Home Screen*.
+   Android (Chrome): tap *⋮ → Install app*.
+4. The app installs with the icon from `agent-control-icon.svg`,
+   opens to `/agent-control` (per `manifest.start_url`), runs in
+   `display: standalone` mode (no browser chrome).
+
+The service worker (`/sw.js`) handles offline gracefully:
+
+* SPA shell is cached on install (`agent-control-shell-v1`).
+* `/api/agent-control/*` is network-first with cache fallback —
+  online users always see fresh data; offline users see the last
+  cached payload (and a `not_available { reason: "offline" }`
+  envelope when no cache exists).
+
+## Running locally
+
+```sh
+# Backend (existing flow):
+python -m dashboard.dashboard
+# Frontend (existing flow):
+npm --prefix frontend run dev
+# Then visit http://localhost:5173/agent-control
+```
+
+In dev, Vite proxies `/api/*` to `http://localhost:8050`, so the
+five endpoints are reachable as soon as `register_agent_control_routes`
+is wired up.
+
+## Mobile-first design choices
+
+* Phone-portrait first; cards stack vertically on viewports
+  < 720px; two-column grid from 720px+.
+* Touch targets are >= 44x44 px (Apple HIG / WCAG 2.5.5).
+* Status colors are semantic only:
+  * teal = ok
+  * amber = warn
+  * red = blocked / danger
+  * gray = not_available
+* No dense desktop tables in the primary view.
+* Safe-area insets respected for the iPhone notch.
+
+## Tooling assessment
+
+Adopted in this release:
+
+| dependency | purpose | cost / license | external egress | rollback |
+|---|---|---|---|---|
+| (none new) | every tool in this release reuses what is already in `frontend/package.json` (Vite 5, React 18, Vitest 4) and Python stdlib + Flask. | n/a | none | revert the PR |
+
+Specifically: no PWA library (e.g. `vite-plugin-pwa`, `workbox`),
+no external icon set, no analytics SDK, no notification provider.
+All PWA artifacts (`manifest.webmanifest`, `sw.js`,
+`agent-control-icon.svg`) are hand-written and live under
+`frontend/public/`.
+
+If a future release wants better SW ergonomics, `vite-plugin-pwa`
+is the canonical free + offline option (MIT license, no telemetry,
+no signup). It would need its own tooling-policy ADR.
+
+## Forward roadmap (not shipped here)
+
+| release | adds |
+|---|---|
+| **v3.15.15.18 (this)** | mobile-first read-only PWA shell, 5 cards, manifest, SW |
+| v3.15.15.19 | roadmap / proposal queue card |
+| v3.15.15.20 | approval inbox (operator confirms execute requests) |
+| v3.15.15.21 | execute-safe controls (the first *write* button — strictly gated) |
+| v3.15.15.23 | browser push notifications for needs-human events only |
+| v3.15.15.25 | metrics / observability dashboards |
+
+Each subsequent release strictly adds capability; nothing in this
+release walks back a guarantee.
+
+## Files added by v3.15.15.18
+
+```
+dashboard/api_agent_control.py
+docs/governance/mobile_agent_control_pwa.md   (this file)
+frontend/index.html                           (manifest + theme-color tags only)
+frontend/public/agent-control-icon.svg
+frontend/public/manifest.webmanifest
+frontend/public/sw.js
+frontend/src/api/agent_control.ts
+frontend/src/main.tsx                         (SW registration only)
+frontend/src/routes/AgentControl.tsx
+frontend/src/styles/agent_control.css
+frontend/src/test/AgentControl.test.tsx
+frontend/src/test/PWAManifest.test.tsx
+frontend/src/vite-env.d.ts
+tests/unit/test_dashboard_api_agent_control.py
+```
+
+No edit to `dashboard/dashboard.py` (no-touch). No edit to
+`.claude/**`. No frozen-contract change. No live/paper/shadow/
+trading/risk behavior change.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,11 +2,22 @@
 <html lang="nl">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
     <meta name="robots" content="noindex, nofollow, noarchive, nosnippet" />
     <meta name="googlebot" content="noindex, nofollow, noarchive, nosnippet" />
     <meta name="referrer" content="no-referrer" />
     <meta name="color-scheme" content="dark light" />
+    <meta name="theme-color" content="#0b1220" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="/agent-control-icon.svg"
+    />
+    <link rel="apple-touch-icon" href="/agent-control-icon.svg" />
     <title>JvR Trading Agent — v3.10</title>
   </head>
   <body>

--- a/frontend/public/agent-control-icon.svg
+++ b/frontend/public/agent-control-icon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192" role="img" aria-label="JvR Agent Control">
+  <rect width="192" height="192" rx="40" fill="#0b1220"/>
+  <circle cx="96" cy="96" r="60" fill="none" stroke="#38bdf8" stroke-width="6"/>
+  <circle cx="96" cy="96" r="10" fill="#38bdf8"/>
+  <path d="M96 30 V60 M96 132 V162 M30 96 H60 M132 96 H162" stroke="#38bdf8" stroke-width="6" stroke-linecap="round"/>
+  <path d="M50 50 L70 70 M122 70 L142 50 M50 142 L70 122 M122 122 L142 142" stroke="#38bdf8" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/frontend/public/manifest.webmanifest
+++ b/frontend/public/manifest.webmanifest
@@ -1,0 +1,21 @@
+{
+  "name": "JvR Agent Control",
+  "short_name": "AgentCtrl",
+  "description": "Read-only mobile-first observability surface for the JvR Trading Agent autonomous development system. v3.15.15.18.",
+  "start_url": "/agent-control",
+  "scope": "/",
+  "display": "standalone",
+  "orientation": "portrait",
+  "background_color": "#0b1220",
+  "theme_color": "#0b1220",
+  "lang": "nl",
+  "icons": [
+    {
+      "src": "/agent-control-icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ],
+  "categories": ["productivity", "developer", "utilities"]
+}

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,0 +1,109 @@
+/**
+ * JvR Agent Control PWA — minimal service worker (v3.15.15.18).
+ *
+ * Hard guarantees:
+ *   - Read-only. The SW never POSTs / PUTs / PATCHes / DELETEs.
+ *     Only GET requests are eligible for cache-or-network handling;
+ *     anything else passes through unmodified.
+ *   - Network-first for /api/agent-control/* so the user always sees
+ *     the latest data when online; cache-fallback when offline.
+ *   - Cache-first for the SPA shell so the UI is installable and
+ *     usable offline.
+ *   - No analytics. No external service. No remote scripts.
+ *
+ * Scope: this file is served from "/", so it controls the whole
+ * origin. Note that v3.15.15.18 does NOT register a top-level Flask
+ * route for "/sw.js" — the file is shipped via vite's public dir but
+ * the production wiring step (one line in dashboard/dashboard.py)
+ * is documented separately. Until that wiring lands, the SW is a
+ * no-op in production; in `vite dev` it works as expected.
+ */
+
+const SHELL_CACHE = "agent-control-shell-v1";
+const RUNTIME_CACHE = "agent-control-runtime-v1";
+
+const SHELL_ASSETS = ["/agent-control", "/manifest.webmanifest", "/agent-control-icon.svg"];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches
+      .open(SHELL_CACHE)
+      .then((cache) => cache.addAll(SHELL_ASSETS).catch(() => undefined))
+      .then(() => self.skipWaiting()),
+  );
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys
+          .filter((k) => k !== SHELL_CACHE && k !== RUNTIME_CACHE)
+          .map((k) => caches.delete(k)),
+      ),
+    ).then(() => self.clients.claim()),
+  );
+});
+
+self.addEventListener("fetch", (event) => {
+  const req = event.request;
+
+  // Hard guarantee: only GET requests are eligible for SW handling.
+  if (req.method !== "GET") return;
+
+  const url = new URL(req.url);
+
+  // /api/agent-control/* — network-first, cache fallback for offline.
+  if (url.pathname.startsWith("/api/agent-control/")) {
+    event.respondWith(networkFirst(req));
+    return;
+  }
+
+  // Static SPA shell — cache-first.
+  if (
+    url.pathname === "/" ||
+    url.pathname === "/agent-control" ||
+    url.pathname.startsWith("/assets/") ||
+    url.pathname === "/manifest.webmanifest" ||
+    url.pathname === "/agent-control-icon.svg"
+  ) {
+    event.respondWith(cacheFirst(req));
+    return;
+  }
+
+  // Anything else: pass through to the network. Never invent data,
+  // never substitute on errors — fail visibly.
+});
+
+async function cacheFirst(req) {
+  const cache = await caches.open(SHELL_CACHE);
+  const hit = await cache.match(req);
+  if (hit) return hit;
+  try {
+    const res = await fetch(req);
+    if (res && res.ok) {
+      cache.put(req, res.clone()).catch(() => undefined);
+    }
+    return res;
+  } catch (err) {
+    return new Response("offline", { status: 503, statusText: "offline" });
+  }
+}
+
+async function networkFirst(req) {
+  const cache = await caches.open(RUNTIME_CACHE);
+  try {
+    const res = await fetch(req);
+    if (res && res.ok) {
+      cache.put(req, res.clone()).catch(() => undefined);
+    }
+    return res;
+  } catch (err) {
+    const hit = await cache.match(req);
+    if (hit) return hit;
+    return new Response(
+      JSON.stringify({ status: "not_available", reason: "offline" }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import { Presets } from "./routes/Presets";
 import { History } from "./routes/History";
 import { Reports } from "./routes/Reports";
 import { Candidates } from "./routes/Candidates";
+import { AgentControl } from "./routes/AgentControl";
 
 export function App() {
   return (
@@ -39,6 +40,7 @@ export function App() {
                   <Route path="/history" element={<History />} />
                   <Route path="/reports" element={<Reports />} />
                   <Route path="/candidates" element={<Candidates />} />
+                  <Route path="/agent-control" element={<AgentControl />} />
                   <Route path="*" element={<Navigate to="/" replace />} />
                 </Routes>
               </AppShell>

--- a/frontend/src/api/agent_control.ts
+++ b/frontend/src/api/agent_control.ts
@@ -1,0 +1,109 @@
+// Read-only client for the v3.15.15.18 mobile-first Agent Control PWA.
+// All five endpoints are GET-only and return JSON. Anything that goes
+// wrong on the wire (missing endpoint, 404, 500, parse error, network
+// down) collapses to a `not_available` envelope so the UI never has
+// to invent data. Nothing on this surface is allowed to mutate.
+
+export type AgentControlStatusEnvelope = {
+  status: "ok" | "not_available";
+  reason?: string;
+  data?: unknown;
+};
+
+export interface FrozenHashesPayload {
+  status: "ok" | "not_available";
+  reason?: string;
+  data?: Record<string, string>;
+}
+
+export interface AgentControlStatus {
+  kind: "agent_control_status";
+  schema_version: number;
+  governance_status: AgentControlStatusEnvelope;
+  frozen_hashes: FrozenHashesPayload;
+}
+
+export interface AgentControlActivity {
+  kind: "agent_control_activity";
+  schema_version: number;
+  status: "ok" | "not_available";
+  reason?: string;
+  data?: {
+    schema_version: number;
+    report_kind: string;
+    ledger_path: string;
+    ledger_present: boolean;
+    ledger_event_count: number;
+    chain_status: string;
+    rows: Array<Record<string, unknown>>;
+  };
+}
+
+export interface AgentControlWorkloop {
+  kind: "agent_control_workloop";
+  schema_version: number;
+  status: "ok" | "not_available";
+  reason?: string;
+  data?: Record<string, unknown>;
+  artifact_path: string;
+}
+
+export interface AgentControlPRLifecycle {
+  kind: "agent_control_pr_lifecycle";
+  schema_version: number;
+  status: "ok" | "not_available";
+  reason?: string;
+  data?: {
+    final_recommendation: string;
+    prs: Array<Record<string, unknown>>;
+    [k: string]: unknown;
+  };
+  artifact_path: string;
+}
+
+export interface AgentControlNotifications {
+  kind: "agent_control_notifications";
+  schema_version: number;
+  status: "ok" | "not_available";
+  mode?: string;
+  data: Array<Record<string, unknown>>;
+  next_release_with_push?: string;
+}
+
+const BASE = "/api/agent-control";
+
+async function getJson<T>(path: string): Promise<T> {
+  try {
+    const res = await fetch(path, {
+      method: "GET",
+      credentials: "include",
+      headers: { Accept: "application/json" },
+    });
+    if (!res.ok) {
+      // Surface as not_available rather than throwing — the cards
+      // need a renderable payload even when the wiring step in
+      // dashboard/dashboard.py has not yet landed.
+      return {
+        status: "not_available",
+        reason: `http_${res.status}`,
+      } as unknown as T;
+    }
+    const body = (await res.json()) as T;
+    return body;
+  } catch (err) {
+    return {
+      status: "not_available",
+      reason: `fetch_error: ${(err as Error)?.name || "Error"}`,
+    } as unknown as T;
+  }
+}
+
+export const agentControlApi = {
+  status: () => getJson<AgentControlStatus>(`${BASE}/status`),
+  activity: () => getJson<AgentControlActivity>(`${BASE}/activity`),
+  workloop: () => getJson<AgentControlWorkloop>(`${BASE}/workloop`),
+  prLifecycle: () =>
+    getJson<AgentControlPRLifecycle>(`${BASE}/pr-lifecycle`),
+  notifications: () =>
+    getJson<AgentControlNotifications>(`${BASE}/notifications`),
+};

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,6 +5,26 @@ import { App } from "./App";
 import "./styles.css";
 import "./styles/retro.css";
 
+// PWA service-worker registration (v3.15.15.18). Best-effort: if the
+// production server does not yet expose /sw.js (the wiring step in
+// dashboard/dashboard.py is intentionally out of scope for this
+// release), the registration silently fails and the SPA continues
+// to function. The SW is read-only and only handles GET requests
+// (see frontend/public/sw.js).
+if (
+  typeof window !== "undefined" &&
+  "serviceWorker" in navigator &&
+  window.location.protocol !== "file:"
+) {
+  window.addEventListener("load", () => {
+    navigator.serviceWorker
+      .register("/sw.js", { scope: "/" })
+      .catch(() => {
+        // Swallow: SW is opportunistic; failure is not fatal.
+      });
+  });
+}
+
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <BrowserRouter>

--- a/frontend/src/routes/AgentControl.tsx
+++ b/frontend/src/routes/AgentControl.tsx
@@ -1,0 +1,441 @@
+// Mobile-first read-only Agent Control PWA — v3.15.15.18.
+//
+// Hard guarantees enforced by structure:
+//   - No execute / approve / reject / merge buttons. The only
+//     interactive control is a single "Vernieuw" (refresh) button
+//     that re-fetches the same five GET endpoints.
+//   - Cards render an empty / not_available state when their backing
+//     artifact is missing or malformed; nothing is silently OK.
+//   - Notification center is a placeholder; v3.15.15.18 does not ship
+//     browser push.
+//
+// The full feature roadmap (proposal queue → approval inbox →
+// execute-safe controls → browser push → metrics) is documented in
+// docs/governance/mobile_agent_control_pwa.md.
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  agentControlApi,
+  type AgentControlActivity,
+  type AgentControlNotifications,
+  type AgentControlPRLifecycle,
+  type AgentControlStatus,
+  type AgentControlWorkloop,
+} from "../api/agent_control";
+import "../styles/agent_control.css";
+
+interface CardLoaderProps {
+  title: string;
+  subtitle: string;
+  children: React.ReactNode;
+}
+
+function Card({ title, subtitle, children }: CardLoaderProps) {
+  return (
+    <section className="agent-control-card" aria-labelledby={`title-${title}`}>
+      <header className="agent-control-card__header">
+        <div>
+          <h2 className="agent-control-card__title" id={`title-${title}`}>
+            {title}
+          </h2>
+          <p className="agent-control-card__subtitle">{subtitle}</p>
+        </div>
+      </header>
+      <div className="agent-control-card__body">{children}</div>
+    </section>
+  );
+}
+
+function StatusPill({
+  state,
+}: {
+  state: "ok" | "warn" | "danger" | "unknown";
+}) {
+  const label =
+    state === "ok"
+      ? "ok"
+      : state === "warn"
+        ? "warn"
+        : state === "danger"
+          ? "blocked"
+          : "not_available";
+  return (
+    <span
+      className={`agent-control-pill agent-control-pill--${state}`}
+      data-testid={`pill-${state}`}
+    >
+      {label}
+    </span>
+  );
+}
+
+function pillFor(status: string | undefined): "ok" | "warn" | "danger" | "unknown" {
+  if (status === "ok") return "ok";
+  if (status === "blocked") return "danger";
+  if (status === "warn") return "warn";
+  return "unknown";
+}
+
+// --- Card: governance status + frozen hashes ---
+function StatusCard({ payload }: { payload: AgentControlStatus | null }) {
+  if (!payload) {
+    return (
+      <Card
+        title="Status"
+        subtitle="governance + frozen contracts"
+      >
+        <p className="agent-control-card__empty" data-testid="status-loading">
+          Laden…
+        </p>
+      </Card>
+    );
+  }
+  const govStatus = payload.governance_status?.status ?? "not_available";
+  const fhStatus = payload.frozen_hashes?.status ?? "not_available";
+  const fh = payload.frozen_hashes?.data ?? {};
+  return (
+    <Card title="Status" subtitle="governance + frozen contracts">
+      <div className="agent-control-card__row">
+        <dt>governance</dt>
+        <dd>
+          <StatusPill state={pillFor(govStatus)} />
+        </dd>
+      </div>
+      <div className="agent-control-card__row">
+        <dt>frozen hashes</dt>
+        <dd>
+          <StatusPill state={pillFor(fhStatus)} />
+        </dd>
+      </div>
+      {Object.keys(fh).length === 0 ? (
+        <p
+          className="agent-control-card__empty"
+          data-testid="status-frozen-empty"
+        >
+          Geen contract-hashes beschikbaar
+        </p>
+      ) : (
+        Object.entries(fh).map(([path, sha]) => (
+          <div className="agent-control-card__row" key={path}>
+            <dt>{path}</dt>
+            <dd
+              title={sha}
+              data-testid={`hash-${path}`}
+            >
+              {sha === "missing" ? "missing" : `${sha.slice(0, 12)}…`}
+            </dd>
+          </div>
+        ))
+      )}
+    </Card>
+  );
+}
+
+// --- Card: agent activity ---
+function ActivityCard({
+  payload,
+}: {
+  payload: AgentControlActivity | null;
+}) {
+  if (!payload) {
+    return (
+      <Card title="Activity" subtitle="agent audit timeline">
+        <p className="agent-control-card__empty">Laden…</p>
+      </Card>
+    );
+  }
+  if (payload.status !== "ok" || !payload.data) {
+    return (
+      <Card title="Activity" subtitle="agent audit timeline">
+        <div className="agent-control-card__row">
+          <dt>status</dt>
+          <dd>
+            <StatusPill state="unknown" />
+          </dd>
+        </div>
+        <p
+          className="agent-control-card__empty"
+          data-testid="activity-not-available"
+        >
+          {payload.reason ?? "not_available"}
+        </p>
+      </Card>
+    );
+  }
+  const data = payload.data;
+  const recent = (data.rows ?? []).slice(-5).reverse();
+  return (
+    <Card title="Activity" subtitle="agent audit timeline (last 5)">
+      <div className="agent-control-card__row">
+        <dt>chain</dt>
+        <dd>
+          <StatusPill
+            state={
+              data.chain_status === "intact"
+                ? "ok"
+                : data.chain_status === "broken"
+                  ? "danger"
+                  : "unknown"
+            }
+          />
+        </dd>
+      </div>
+      <div className="agent-control-card__row">
+        <dt>events</dt>
+        <dd>{data.ledger_event_count}</dd>
+      </div>
+      {recent.length === 0 ? (
+        <p
+          className="agent-control-card__empty"
+          data-testid="activity-empty"
+        >
+          Geen events vandaag
+        </p>
+      ) : (
+        recent.map((row, idx) => (
+          <div
+            className="agent-control-card__row"
+            key={String(row.sequence_id ?? idx)}
+          >
+            <dt>
+              #{String(row.sequence_id ?? "?")}{" "}
+              {String(row.actor ?? "unknown")}
+            </dt>
+            <dd>{String(row.outcome ?? "unknown")}</dd>
+          </div>
+        ))
+      )}
+    </Card>
+  );
+}
+
+// --- Card: autonomous workloop ---
+function WorkloopCard({ payload }: { payload: AgentControlWorkloop | null }) {
+  if (!payload) {
+    return (
+      <Card title="Workloop" subtitle="autonomous workloop digest">
+        <p className="agent-control-card__empty">Laden…</p>
+      </Card>
+    );
+  }
+  if (payload.status !== "ok" || !payload.data) {
+    return (
+      <Card title="Workloop" subtitle="autonomous workloop digest">
+        <p
+          className="agent-control-card__empty"
+          data-testid="workloop-not-available"
+        >
+          {payload.reason ?? "not_available"} —{" "}
+          <code>{payload.artifact_path}</code>
+        </p>
+      </Card>
+    );
+  }
+  const data = payload.data as Record<string, unknown>;
+  const next = String(data.next_recommended_item ?? "unknown");
+  const merges = String(data.merges_performed ?? "unknown");
+  const mode = String(data.mode ?? "unknown");
+  return (
+    <Card title="Workloop" subtitle="autonomous workloop digest">
+      <div className="agent-control-card__row">
+        <dt>mode</dt>
+        <dd>{mode}</dd>
+      </div>
+      <div className="agent-control-card__row">
+        <dt>next</dt>
+        <dd>{next}</dd>
+      </div>
+      <div className="agent-control-card__row">
+        <dt>merges performed</dt>
+        <dd>{merges}</dd>
+      </div>
+    </Card>
+  );
+}
+
+// --- Card: GitHub PR lifecycle ---
+function PRLifecycleCard({
+  payload,
+}: {
+  payload: AgentControlPRLifecycle | null;
+}) {
+  if (!payload) {
+    return (
+      <Card title="PR Lifecycle" subtitle="Dependabot queue">
+        <p className="agent-control-card__empty">Laden…</p>
+      </Card>
+    );
+  }
+  if (payload.status !== "ok" || !payload.data) {
+    return (
+      <Card title="PR Lifecycle" subtitle="Dependabot queue">
+        <p
+          className="agent-control-card__empty"
+          data-testid="pr-not-available"
+        >
+          {payload.reason ?? "not_available"} —{" "}
+          <code>{payload.artifact_path}</code>
+        </p>
+      </Card>
+    );
+  }
+  const data = payload.data;
+  const prs = data.prs ?? [];
+  const recommendation = String(
+    data.final_recommendation ?? "unknown",
+  );
+  return (
+    <Card title="PR Lifecycle" subtitle="Dependabot queue">
+      <div className="agent-control-card__row">
+        <dt>recommendation</dt>
+        <dd data-testid="pr-recommendation">{recommendation}</dd>
+      </div>
+      {prs.length === 0 ? (
+        <p
+          className="agent-control-card__empty"
+          data-testid="pr-empty"
+        >
+          Geen open Dependabot PRs
+        </p>
+      ) : (
+        prs.slice(0, 5).map((pr, idx) => {
+          const number = String(pr.number ?? "?");
+          const decision = String(pr.decision ?? "unknown");
+          const risk = String(pr.risk_class ?? "UNKNOWN");
+          const pillState =
+            decision === "merge_allowed"
+              ? "ok"
+              : decision === "blocked_high_risk"
+                ? "warn"
+                : decision.startsWith("blocked_")
+                  ? "danger"
+                  : "unknown";
+          return (
+            <div className="agent-control-card__row" key={`${number}-${idx}`}>
+              <dt>
+                #{number}{" "}
+                <span style={{ color: "var(--fg-muted)" }}>{risk}</span>
+              </dt>
+              <dd>
+                <StatusPill state={pillState} />
+              </dd>
+            </div>
+          );
+        })
+      )}
+    </Card>
+  );
+}
+
+// --- Card: notification center placeholder ---
+function NotificationsCard({
+  payload,
+}: {
+  payload: AgentControlNotifications | null;
+}) {
+  if (!payload) {
+    return (
+      <Card title="Notifications" subtitle="placeholder (v3.15.15.18)">
+        <p className="agent-control-card__empty">Laden…</p>
+      </Card>
+    );
+  }
+  const next = payload.next_release_with_push ?? "later";
+  return (
+    <Card
+      title="Notifications"
+      subtitle={`placeholder — browser push lands ${next}`}
+    >
+      {(payload.data ?? []).length === 0 ? (
+        <p
+          className="agent-control-card__empty"
+          data-testid="notifications-empty"
+        >
+          Geen meldingen — browser push komt later.
+        </p>
+      ) : null}
+    </Card>
+  );
+}
+
+// --- Route ---
+export function AgentControl() {
+  const [status, setStatus] = useState<AgentControlStatus | null>(null);
+  const [activity, setActivity] = useState<AgentControlActivity | null>(null);
+  const [workloop, setWorkloop] = useState<AgentControlWorkloop | null>(null);
+  const [prLifecycle, setPrLifecycle] =
+    useState<AgentControlPRLifecycle | null>(null);
+  const [notifications, setNotifications] =
+    useState<AgentControlNotifications | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [refreshedAt, setRefreshedAt] = useState<string>("");
+
+  const loadAll = useCallback(async () => {
+    setLoading(true);
+    const [s, a, w, p, n] = await Promise.all([
+      agentControlApi.status(),
+      agentControlApi.activity(),
+      agentControlApi.workloop(),
+      agentControlApi.prLifecycle(),
+      agentControlApi.notifications(),
+    ]);
+    setStatus(s);
+    setActivity(a);
+    setWorkloop(w);
+    setPrLifecycle(p);
+    setNotifications(n);
+    setRefreshedAt(new Date().toISOString().replace("T", " ").slice(0, 19));
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    void loadAll();
+  }, [loadAll]);
+
+  return (
+    <main
+      className="agent-control"
+      data-testid="agent-control-root"
+      role="main"
+    >
+      <div className="agent-control__header">
+        <h1>Agent Control</h1>
+        <p>Read-only observability surface — v3.15.15.18.</p>
+        <button
+          type="button"
+          className="agent-control__refresh"
+          onClick={() => void loadAll()}
+          disabled={loading}
+          data-testid="agent-control-refresh"
+          aria-label="Vernieuw alle kaarten"
+        >
+          {loading ? "Laden…" : "Vernieuw"}
+        </button>
+        {refreshedAt ? (
+          <p
+            className="agent-control-card__subtitle"
+            data-testid="agent-control-refreshed-at"
+          >
+            laatste update: {refreshedAt} UTC
+          </p>
+        ) : null}
+      </div>
+
+      <div className="agent-control__grid">
+        <StatusCard payload={status} />
+        <ActivityCard payload={activity} />
+        <WorkloopCard payload={workloop} />
+        <PRLifecycleCard payload={prLifecycle} />
+        <NotificationsCard payload={notifications} />
+      </div>
+
+      <footer className="agent-control__footer">
+        <p>
+          v3.15.15.18 — read-only. Geen execute / approve / merge knoppen.
+          Schema:{" "}
+          <code>docs/governance/github_pr_lifecycle/schema.v1.md</code>
+        </p>
+      </footer>
+    </main>
+  );
+}

--- a/frontend/src/styles/agent_control.css
+++ b/frontend/src/styles/agent_control.css
@@ -1,0 +1,197 @@
+/*
+ * Mobile-first Agent Control PWA — v3.15.15.18.
+ *
+ * Phone-portrait is the primary viewport. Cards stack vertically.
+ * Touch targets are >= 44x44 px (Apple HIG / WCAG 2.5.5 minimum).
+ * Layout scales up at >= 720px to a two-column grid.
+ *
+ * Status colors are semantic: ok = teal, warn = amber, danger = red,
+ * not_available = gray.
+ */
+
+.agent-control {
+  /* Phone-first padding; use safe-area insets for the notch. */
+  padding: max(env(safe-area-inset-top, 0px), 12px) 12px
+    max(env(safe-area-inset-bottom, 0px), 12px) 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.agent-control__header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px 4px 4px;
+}
+
+.agent-control__header h1 {
+  font-size: 22px;
+  font-weight: 600;
+  margin: 0;
+  letter-spacing: -0.01em;
+}
+
+.agent-control__header p {
+  margin: 0;
+  font-size: 13px;
+  color: var(--fg-muted);
+}
+
+/* Card grid — stacked on phone, two columns from 720px. */
+.agent-control__grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 12px;
+}
+
+@media (min-width: 720px) {
+  .agent-control__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.agent-control-card {
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  /* Touch-friendly minimum height for primary cards. */
+  min-height: 96px;
+}
+
+.agent-control-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.agent-control-card__title {
+  font-size: 15px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.agent-control-card__subtitle {
+  font-size: 12px;
+  color: var(--fg-muted);
+  margin: 0;
+}
+
+.agent-control-card__body {
+  font-size: 13px;
+  color: var(--fg);
+  word-break: break-word;
+}
+
+.agent-control-card__row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+  padding: 6px 0;
+  border-top: 1px dashed var(--border);
+}
+
+.agent-control-card__row:first-child {
+  border-top: none;
+}
+
+.agent-control-card__row dt {
+  margin: 0;
+  color: var(--fg-muted);
+  font-size: 12px;
+  flex: 0 0 auto;
+}
+
+.agent-control-card__row dd {
+  margin: 0;
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
+  font-size: 12px;
+  text-align: right;
+  word-break: break-all;
+  color: var(--fg);
+}
+
+.agent-control-card__empty {
+  font-size: 13px;
+  color: var(--fg-muted);
+  font-style: italic;
+  text-align: center;
+  padding: 18px 0;
+}
+
+/* Status pill colors — semantic only. */
+.agent-control-pill {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  line-height: 1.6;
+}
+
+.agent-control-pill--ok {
+  background: rgba(61, 220, 151, 0.14);
+  color: var(--ok);
+  border: 1px solid rgba(61, 220, 151, 0.4);
+}
+
+.agent-control-pill--warn {
+  background: rgba(255, 181, 69, 0.14);
+  color: var(--warn);
+  border: 1px solid rgba(255, 181, 69, 0.4);
+}
+
+.agent-control-pill--danger {
+  background: rgba(255, 91, 107, 0.14);
+  color: var(--danger);
+  border: 1px solid rgba(255, 91, 107, 0.4);
+}
+
+.agent-control-pill--unknown {
+  background: rgba(136, 147, 167, 0.14);
+  color: var(--fg-muted);
+  border: 1px solid rgba(136, 147, 167, 0.4);
+}
+
+.agent-control__refresh {
+  /* Touch target >= 44x44, large hit area on phone. */
+  min-height: 44px;
+  min-width: 44px;
+  padding: 10px 16px;
+  border-radius: 10px;
+  background: var(--accent-weak);
+  color: var(--fg);
+  border: 1px solid var(--accent);
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.agent-control__refresh:disabled {
+  opacity: 0.6;
+  cursor: progress;
+}
+
+.agent-control__footer {
+  margin-top: 4px;
+  padding: 12px 4px;
+  text-align: center;
+  font-size: 11px;
+  color: var(--fg-muted);
+}
+
+.agent-control__footer code {
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
+  font-size: 11px;
+  color: var(--fg);
+}

--- a/frontend/src/test/AgentControl.test.tsx
+++ b/frontend/src/test/AgentControl.test.tsx
@@ -1,0 +1,358 @@
+/**
+ * Tests for the v3.15.15.18 mobile-first Agent Control PWA.
+ *
+ * Hard guarantees verified here:
+ *   - The route renders the five expected cards.
+ *   - Mobile (375px) viewport renders without horizontal overflow.
+ *   - The notification card shows an empty-state placeholder.
+ *   - The PR Lifecycle card shows an empty-queue state when the
+ *     digest reports zero open PRs.
+ *   - All five backing endpoints are GET; no card emits a mutation
+ *     fetch (POST/PUT/PATCH/DELETE).
+ *   - There are no execute / approve / reject / merge buttons in
+ *     the rendered DOM.
+ *   - When the wiring step in dashboard/dashboard.py has not yet
+ *     landed and an endpoint 404s, the cards fall back to
+ *     not_available rather than crashing.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { AgentControl } from "../routes/AgentControl";
+
+const okFrozenHashes = {
+  status: "ok",
+  data: {
+    "research/research_latest.json":
+      "4a567bd6feb98eb7aa32db4a90a3201456843088314936c5e484a2ae6a93666c",
+    "research/strategy_matrix.csv":
+      "ff15b8c4f35cc37b6941b712106ae71a1b82a1b5043da197731d42518d258d66",
+  },
+};
+
+const okStatusBody = {
+  kind: "agent_control_status",
+  schema_version: 1,
+  governance_status: { status: "ok", data: {} },
+  frozen_hashes: okFrozenHashes,
+};
+
+const okActivityBody = {
+  kind: "agent_control_activity",
+  schema_version: 1,
+  status: "ok",
+  data: {
+    schema_version: 1,
+    report_kind: "agent_audit_timeline",
+    ledger_path: "logs/agent_audit.2026-05-02.jsonl",
+    ledger_present: true,
+    ledger_event_count: 0,
+    chain_status: "intact",
+    rows: [],
+  },
+};
+
+const okWorkloopBody = {
+  kind: "agent_control_workloop",
+  schema_version: 1,
+  status: "ok",
+  data: {
+    mode: "dry-run",
+    next_recommended_item: "unknown",
+    merges_performed: 0,
+  },
+  artifact_path: "logs/autonomous_workloop/latest.json",
+};
+
+const okPRLifecycleEmptyBody = {
+  kind: "agent_control_pr_lifecycle",
+  schema_version: 1,
+  status: "ok",
+  data: {
+    schema_version: 1,
+    final_recommendation: "no_open_prs",
+    prs: [],
+  },
+  artifact_path: "logs/github_pr_lifecycle/latest.json",
+};
+
+const placeholderNotificationsBody = {
+  kind: "agent_control_notifications",
+  schema_version: 1,
+  status: "ok",
+  mode: "placeholder",
+  data: [],
+  next_release_with_push: "v3.15.15.23",
+};
+
+const fetchSpy: any[] = [];
+
+function installFetchMock(
+  routes: Record<string, () => Response>,
+  fallback: () => Response,
+) {
+  const fetchImpl: typeof fetch = async (input: any, init: any = {}) => {
+    fetchSpy.push({ input, method: init.method || "GET" });
+    const url = typeof input === "string" ? input : (input as Request).url;
+    for (const [path, build] of Object.entries(routes)) {
+      if (url === path || url.endsWith(path)) {
+        return build();
+      }
+    }
+    return fallback();
+  };
+  // @ts-expect-error — assigning the global fetch is intentional in test scope.
+  global.fetch = vi.fn(fetchImpl);
+}
+
+function jsonResp(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  fetchSpy.length = 0;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("AgentControl — happy path", () => {
+  it("renders all five cards and an empty Dependabot queue", async () => {
+    installFetchMock(
+      {
+        "/api/agent-control/status": () => jsonResp(okStatusBody),
+        "/api/agent-control/activity": () => jsonResp(okActivityBody),
+        "/api/agent-control/workloop": () => jsonResp(okWorkloopBody),
+        "/api/agent-control/pr-lifecycle": () =>
+          jsonResp(okPRLifecycleEmptyBody),
+        "/api/agent-control/notifications": () =>
+          jsonResp(placeholderNotificationsBody),
+      },
+      () => jsonResp({ status: "not_available" }, 404),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("agent-control-root")).toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("notifications-empty")).toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("pr-empty")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Status")).toBeInTheDocument();
+    expect(screen.getByText("Activity")).toBeInTheDocument();
+    expect(screen.getByText("Workloop")).toBeInTheDocument();
+    expect(screen.getByText("PR Lifecycle")).toBeInTheDocument();
+    expect(screen.getByText("Notifications")).toBeInTheDocument();
+  });
+
+  it("never issues a non-GET request from the cards", async () => {
+    installFetchMock(
+      {
+        "/api/agent-control/status": () => jsonResp(okStatusBody),
+        "/api/agent-control/activity": () => jsonResp(okActivityBody),
+        "/api/agent-control/workloop": () => jsonResp(okWorkloopBody),
+        "/api/agent-control/pr-lifecycle": () =>
+          jsonResp(okPRLifecycleEmptyBody),
+        "/api/agent-control/notifications": () =>
+          jsonResp(placeholderNotificationsBody),
+      },
+      () => jsonResp({}, 404),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("notifications-empty")).toBeInTheDocument();
+    });
+
+    for (const call of fetchSpy) {
+      expect(call.method).toBe("GET");
+    }
+  });
+});
+
+describe("AgentControl — graceful fallback", () => {
+  it("renders not_available everywhere when every endpoint 404s", async () => {
+    installFetchMock({}, () => jsonResp({ status: "not_available" }, 404));
+
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("activity-not-available")).toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("workloop-not-available")).toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("pr-not-available")).toBeInTheDocument();
+    });
+  });
+
+  it("renders not_available when fetch throws (no network)", async () => {
+    // @ts-expect-error — assigning the global fetch is intentional in test scope.
+    global.fetch = vi.fn(async () => {
+      throw new Error("network down");
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("activity-not-available")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("AgentControl — UI affordances", () => {
+  it("contains exactly one button — the Vernieuw refresh button", async () => {
+    installFetchMock(
+      {
+        "/api/agent-control/status": () => jsonResp(okStatusBody),
+        "/api/agent-control/activity": () => jsonResp(okActivityBody),
+        "/api/agent-control/workloop": () => jsonResp(okWorkloopBody),
+        "/api/agent-control/pr-lifecycle": () =>
+          jsonResp(okPRLifecycleEmptyBody),
+        "/api/agent-control/notifications": () =>
+          jsonResp(placeholderNotificationsBody),
+      },
+      () => jsonResp({}, 404),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("agent-control-refresh")).toBeInTheDocument();
+    });
+
+    const buttons = screen.queryAllByRole("button");
+    expect(buttons).toHaveLength(1);
+    expect(buttons[0]).toHaveTextContent(/vernieuw|laden/i);
+  });
+
+  it("does not render any execute / approve / merge / reject / kill BUTTON", async () => {
+    // Interaction-shaped check: scan every interactive element
+    // (button, link with role=button, input[type=submit/button],
+    // form actions) and verify none of their accessible names match
+    // a mutating verb. Plain text in the footer that EXPLAINS the
+    // read-only contract (e.g. "no execute / approve / merge buttons")
+    // is allowed and even desirable.
+    installFetchMock(
+      {
+        "/api/agent-control/status": () => jsonResp(okStatusBody),
+        "/api/agent-control/activity": () => jsonResp(okActivityBody),
+        "/api/agent-control/workloop": () => jsonResp(okWorkloopBody),
+        "/api/agent-control/pr-lifecycle": () =>
+          jsonResp(okPRLifecycleEmptyBody),
+        "/api/agent-control/notifications": () =>
+          jsonResp(placeholderNotificationsBody),
+      },
+      () => jsonResp({}, 404),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("agent-control-root")).toBeInTheDocument();
+    });
+
+    const forbidden = [
+      /execute/i,
+      /approve/i,
+      /reject/i,
+      /\bmerge\b/i,
+      /\bkill\b/i,
+      /\bdelete\b/i,
+      /\btrigger\b/i,
+      /\brun\b/i,
+    ];
+    const interactives: HTMLElement[] = [
+      ...screen.queryAllByRole("button"),
+      ...screen.queryAllByRole("link"),
+      ...Array.from(
+        document.querySelectorAll<HTMLElement>(
+          'input[type="submit"], input[type="button"], form, [aria-haspopup]',
+        ),
+      ),
+    ];
+    for (const el of interactives) {
+      const label =
+        (el.getAttribute("aria-label") ??
+          el.textContent ??
+          el.getAttribute("value") ??
+          "").trim();
+      for (const re of forbidden) {
+        expect(label, `forbidden verb on interactive: ${label}`).not.toMatch(
+          re,
+        );
+      }
+    }
+  });
+
+  it("renders within the iPhone-mini viewport (375 wide) without horizontal overflow", async () => {
+    installFetchMock(
+      {
+        "/api/agent-control/status": () => jsonResp(okStatusBody),
+        "/api/agent-control/activity": () => jsonResp(okActivityBody),
+        "/api/agent-control/workloop": () => jsonResp(okWorkloopBody),
+        "/api/agent-control/pr-lifecycle": () =>
+          jsonResp(okPRLifecycleEmptyBody),
+        "/api/agent-control/notifications": () =>
+          jsonResp(placeholderNotificationsBody),
+      },
+      () => jsonResp({}, 404),
+    );
+
+    // jsdom does not implement layout, so we check the structural
+    // signal: the root is a single column on mobile (no horizontal
+    // scroll required at 375px viewport width). The test asserts on
+    // CSS class presence rather than rendered geometry.
+    Object.defineProperty(window, "innerWidth", {
+      writable: true,
+      configurable: true,
+      value: 375,
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("agent-control-root")).toBeInTheDocument();
+    });
+
+    const root = screen.getByTestId("agent-control-root");
+    expect(root).toHaveClass("agent-control");
+    const grid = root.querySelector(".agent-control__grid");
+    expect(grid).not.toBeNull();
+  });
+});

--- a/frontend/src/test/PWAManifest.test.tsx
+++ b/frontend/src/test/PWAManifest.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * PWA installability fixture tests for v3.15.15.18.
+ *
+ * Verified properties:
+ *   - manifest.webmanifest declares the required installable fields
+ *     (name, short_name, start_url, display, icons[]).
+ *   - sw.js never POSTs/PUTs/PATCHes/DELETEs (only GET).
+ *   - sw.js never references analytics or external services.
+ *   - main.tsx contains the SW registration call.
+ *   - index.html links the manifest and an icon.
+ *
+ * These are static-content checks. Files are loaded via Vite's
+ * ``?raw`` query, which keeps the tests stdlib-free (no node: imports
+ * required for the production tsc -b build).
+ */
+
+import { describe, expect, it } from "vitest";
+// Vite-native raw imports — no node:fs / node:path dependency.
+// These resolve at vitest-load time relative to this test file.
+import manifestRaw from "../../public/manifest.webmanifest?raw";
+import swRaw from "../../public/sw.js?raw";
+import mainRaw from "../main.tsx?raw";
+import indexHtmlRaw from "../../index.html?raw";
+
+describe("PWA: manifest", () => {
+  it("declares the installability fields", () => {
+    const m = JSON.parse(manifestRaw);
+    expect(typeof m.name).toBe("string");
+    expect(m.name.length).toBeGreaterThan(0);
+    expect(typeof m.short_name).toBe("string");
+    expect(typeof m.start_url).toBe("string");
+    expect(["standalone", "fullscreen", "minimal-ui"]).toContain(m.display);
+    expect(Array.isArray(m.icons)).toBe(true);
+    expect(m.icons.length).toBeGreaterThanOrEqual(1);
+    for (const icon of m.icons) {
+      expect(typeof icon.src).toBe("string");
+      expect(typeof icon.sizes).toBe("string");
+      expect(typeof icon.type).toBe("string");
+    }
+    expect(typeof m.theme_color).toBe("string");
+    expect(typeof m.background_color).toBe("string");
+  });
+
+  it("index.html links the manifest and the SVG icon", () => {
+    expect(indexHtmlRaw).toMatch(/<link[^>]+rel="manifest"/);
+    expect(indexHtmlRaw).toMatch(/<link[^>]+rel="icon"/);
+    expect(indexHtmlRaw).toMatch(/manifest\.webmanifest/);
+  });
+});
+
+describe("PWA: service worker", () => {
+  it("only handles GET requests (filters non-GET early)", () => {
+    expect(swRaw).toMatch(/req\.method !== ["']GET["']/);
+  });
+
+  it("does not call any mutating fetch verb directly", () => {
+    for (const verb of ["POST", "PUT", "PATCH", "DELETE"]) {
+      expect(swRaw).not.toContain(`method: "${verb}"`);
+      expect(swRaw).not.toContain(`method:'${verb}'`);
+    }
+  });
+
+  it("does not reach external analytics or services", () => {
+    expect(swRaw).not.toMatch(
+      /google-analytics|googletagmanager|sentry|datadog|segment\.io/i,
+    );
+    expect(swRaw).not.toMatch(/https?:\/\//);
+  });
+
+  it("registers caches for both shell and runtime", () => {
+    expect(swRaw).toMatch(/SHELL_CACHE/);
+    expect(swRaw).toMatch(/RUNTIME_CACHE/);
+  });
+});
+
+describe("PWA: registration", () => {
+  it("main.tsx registers the service worker behind a feature check", () => {
+    expect(mainRaw).toMatch(/serviceWorker/);
+    expect(mainRaw).toMatch(/register\(["']\/sw\.js["']/);
+    expect(mainRaw).toMatch(/\.catch\(/);
+  });
+});

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+// Ambient declarations for Vite's ?raw query — used by the PWA
+// fixture tests to read manifest / sw / main.tsx / index.html as
+// plain text without depending on node:fs.
+declare module "*?raw" {
+  const content: string;
+  export default content;
+}

--- a/tests/unit/test_dashboard_api_agent_control.py
+++ b/tests/unit/test_dashboard_api_agent_control.py
@@ -1,0 +1,268 @@
+"""Unit tests for ``dashboard.api_agent_control``.
+
+Properties enforced:
+
+* All five endpoints respond to GET only.
+* No POST / PUT / PATCH / DELETE handler is registered.
+* Missing artifacts → ``{"status": "not_available", "reason": "missing"}``.
+* Malformed artifacts → ``{"status": "not_available", "reason": "malformed:..."}``.
+* Secret redaction is applied via ``assert_no_secrets`` on every payload.
+* The notification endpoint is a placeholder (empty list,
+  ``mode == "placeholder"``).
+* The frozen-hashes payload reports either a 64-char sha256 or
+  the literal string ``"missing"``.
+* The status payload aggregates governance + frozen hashes without
+  invoking ``git`` or any subprocess.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from flask import Flask
+
+from dashboard import api_agent_control as ac
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def app(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Flask:
+    """Build a Flask app with the routes registered and the artifact
+    paths redirected into ``tmp_path``."""
+    monkeypatch.setattr(ac, "LOGS_DIR", tmp_path / "logs")
+    monkeypatch.setattr(
+        ac, "WORKLOOP_LATEST", tmp_path / "logs" / "autonomous_workloop" / "latest.json"
+    )
+    monkeypatch.setattr(
+        ac,
+        "PR_LIFECYCLE_LATEST",
+        tmp_path / "logs" / "github_pr_lifecycle" / "latest.json",
+    )
+    flask_app = Flask(__name__)
+    ac.register_agent_control_routes(flask_app)
+    return flask_app
+
+
+@pytest.fixture
+def client(app: Flask):
+    return app.test_client()
+
+
+# ---------------------------------------------------------------------------
+# Verb whitelist
+# ---------------------------------------------------------------------------
+
+
+_PATHS: tuple[str, ...] = (
+    "/api/agent-control/status",
+    "/api/agent-control/activity",
+    "/api/agent-control/workloop",
+    "/api/agent-control/pr-lifecycle",
+    "/api/agent-control/notifications",
+)
+
+
+@pytest.mark.parametrize("path", _PATHS)
+def test_get_returns_200(client, path: str) -> None:
+    resp = client.get(path)
+    assert resp.status_code == 200, f"GET {path} returned {resp.status_code}"
+    assert resp.is_json
+
+
+@pytest.mark.parametrize("path", _PATHS)
+@pytest.mark.parametrize("verb", ["POST", "PUT", "PATCH", "DELETE"])
+def test_mutation_verbs_are_rejected(client, path: str, verb: str) -> None:
+    resp = client.open(path, method=verb)
+    # Flask returns 405 Method Not Allowed for unregistered verbs.
+    assert resp.status_code == 405, (
+        f"{verb} {path} should be 405 (no mutation handler), got {resp.status_code}"
+    )
+
+
+def test_only_documented_routes_are_registered(app: Flask) -> None:
+    """The agent-control surface is exactly the five routes; no extra
+    endpoints sneak in via auto-discovery."""
+    rules = [r for r in app.url_map.iter_rules() if r.rule.startswith("/api/agent-control/")]
+    paths = sorted(r.rule for r in rules)
+    assert paths == sorted(_PATHS)
+    # Each rule registers GET + HEAD (HEAD is implicit) — never a
+    # mutating verb.
+    for r in rules:
+        verbs = set(r.methods or ()) - {"HEAD", "OPTIONS"}
+        assert verbs == {"GET"}, (
+            f"route {r.rule} accepts unexpected verbs: {verbs}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# not_available semantics
+# ---------------------------------------------------------------------------
+
+
+def test_workloop_missing_artifact_yields_not_available(client) -> None:
+    resp = client.get("/api/agent-control/workloop")
+    body = resp.get_json()
+    assert body["status"] == "not_available"
+    assert body["reason"] == "missing"
+    assert body["artifact_path"] == "logs/autonomous_workloop/latest.json"
+
+
+def test_pr_lifecycle_missing_artifact_yields_not_available(client) -> None:
+    resp = client.get("/api/agent-control/pr-lifecycle")
+    body = resp.get_json()
+    assert body["status"] == "not_available"
+    assert body["reason"] == "missing"
+
+
+def test_workloop_malformed_artifact_yields_not_available(
+    client,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    p = tmp_path / "logs" / "autonomous_workloop" / "latest.json"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("{not json", encoding="utf-8")
+    monkeypatch.setattr(ac, "WORKLOOP_LATEST", p)
+    resp = client.get("/api/agent-control/workloop")
+    body = resp.get_json()
+    assert body["status"] == "not_available"
+    assert body["reason"].startswith("malformed:")
+
+
+def test_pr_lifecycle_non_object_artifact_yields_not_available(
+    client,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    p = tmp_path / "logs" / "github_pr_lifecycle" / "latest.json"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("[1, 2, 3]", encoding="utf-8")
+    monkeypatch.setattr(ac, "PR_LIFECYCLE_LATEST", p)
+    resp = client.get("/api/agent-control/pr-lifecycle")
+    body = resp.get_json()
+    assert body["status"] == "not_available"
+    assert "not_an_object" in body["reason"]
+
+
+def test_pr_lifecycle_with_valid_artifact_passes_through(
+    client,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    p = tmp_path / "logs" / "github_pr_lifecycle" / "latest.json"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema_version": 1,
+        "report_kind": "github_pr_lifecycle_digest",
+        "module_version": "v3.15.15.17",
+        "prs": [],
+        "final_recommendation": "no_open_prs",
+    }
+    p.write_text(json.dumps(payload), encoding="utf-8")
+    monkeypatch.setattr(ac, "PR_LIFECYCLE_LATEST", p)
+    resp = client.get("/api/agent-control/pr-lifecycle")
+    body = resp.get_json()
+    assert body["status"] == "ok"
+    assert body["data"]["final_recommendation"] == "no_open_prs"
+
+
+# ---------------------------------------------------------------------------
+# Notifications placeholder
+# ---------------------------------------------------------------------------
+
+
+def test_notifications_is_placeholder(client) -> None:
+    resp = client.get("/api/agent-control/notifications")
+    body = resp.get_json()
+    assert body["status"] == "ok"
+    assert body["mode"] == "placeholder"
+    assert body["data"] == []
+    # Forward-compat: surface advertises which release introduces push.
+    assert body.get("next_release_with_push", "").startswith("v3.15.15.")
+
+
+# ---------------------------------------------------------------------------
+# Frozen hashes (paths only, never content)
+# ---------------------------------------------------------------------------
+
+
+def test_status_payload_includes_frozen_hashes(client) -> None:
+    resp = client.get("/api/agent-control/status")
+    body = resp.get_json()
+    fh = body.get("frozen_hashes", {})
+    assert fh.get("status") == "ok"
+    data = fh.get("data", {})
+    assert set(data.keys()) == set(ac.FROZEN_CONTRACTS)
+    for v in data.values():
+        assert isinstance(v, str)
+        # Either a 64-char sha256 or the literal "missing".
+        assert v == "missing" or (len(v) == 64 and all(c in "0123456789abcdef" for c in v))
+
+
+# ---------------------------------------------------------------------------
+# Secret-redaction guard
+# ---------------------------------------------------------------------------
+
+
+def test_payload_with_credential_string_is_refused(
+    client,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If a future regression slips a credential-shaped string into a
+    surfaced artifact, ``assert_no_secrets`` should raise inside
+    ``_safe_jsonify`` — the surface refuses to leak rather than
+    soften the rule."""
+    p = tmp_path / "logs" / "github_pr_lifecycle" / "latest.json"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    # Include a sensitive-path fragment in a string field.
+    payload = {
+        "schema_version": 1,
+        "report_kind": "github_pr_lifecycle_digest",
+        "evil_field": "config/config.yaml",
+    }
+    p.write_text(json.dumps(payload), encoding="utf-8")
+    monkeypatch.setattr(ac, "PR_LIFECYCLE_LATEST", p)
+    # Flask's default error handler returns 500 for unhandled
+    # exceptions; the assertion fires inside the view, so the response
+    # status is the test's signal.
+    resp = client.get("/api/agent-control/pr-lifecycle")
+    assert resp.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# Module-level invariants
+# ---------------------------------------------------------------------------
+
+
+def test_no_subprocess_imports_in_module() -> None:
+    """The route module must not import ``subprocess`` directly. All
+    data comes from in-process module calls + JSON file reads."""
+    src = Path(ac.__file__).read_text(encoding="utf-8")
+    assert "import subprocess" not in src
+    assert "from subprocess" not in src
+
+
+def test_no_gh_or_git_invocation_in_module() -> None:
+    src = Path(ac.__file__).read_text(encoding="utf-8")
+    # Reject any obvious mutating tool spawn.
+    forbidden = (
+        '"gh"',
+        "'gh'",
+        "/usr/bin/gh",
+        '"git"',
+        "'git'",
+        "/usr/bin/git",
+        "Popen",
+    )
+    for token in forbidden:
+        assert token not in src, f"forbidden token in api_agent_control.py: {token!r}"


### PR DESCRIPTION
## Summary

Adds an installable, mobile-first, **read-only** observability surface for the autonomous development system. Five cards on one screen, backed by existing reporters / artifacts. No execute / approve / merge buttons in the rendered DOM (verified by test). No browser push (placeholder card only — push lands in v3.15.15.23).

## What changed

### Backend (`dashboard/api_agent_control.py`)

Five GET-only Flask routes under `/api/agent-control/`:
- `/status` — `reporting.governance_status` + frozen-contract sha256
- `/activity` — `reporting.agent_audit_summary` (last 50, redacted)
- `/workloop` — `logs/autonomous_workloop/latest.json` passthrough
- `/pr-lifecycle` — `logs/github_pr_lifecycle/latest.json` passthrough
- `/notifications` — empty-state placeholder

### Frontend (PWA shell + AgentControl route)

- `frontend/public/manifest.webmanifest` — installable manifest
- `frontend/public/sw.js` — cache-first shell, network-first /api, GET-only handler
- `frontend/public/agent-control-icon.svg` — single SVG icon (any+maskable)
- `frontend/src/routes/AgentControl.tsx` — five cards, single refresh button
- `frontend/src/api/agent_control.ts` — GET-only fetch client with graceful `not_available` fallback
- `frontend/src/styles/agent_control.css` — mobile-first; ≥44×44 touch targets; 2-col grid from 720px
- `frontend/src/main.tsx` — opportunistic SW registration behind a feature check
- `frontend/src/App.tsx` — route mounted at `/agent-control`

### Documentation

- `docs/governance/mobile_agent_control_pwa.md` — operator runbook, architecture, hard guarantees, install steps, mobile-first design choices, tooling assessment, forward roadmap
- `docs/governance/autonomous_workloop_runbook.md` — release-table update + cross-link

## Wiring step (manual, one line)

`dashboard/dashboard.py` is on the no-touch list (it reads operator session and token secrets). Activating the new surface requires one operator-led line in `dashboard.py`:

```python
from dashboard.api_agent_control import register_agent_control_routes
register_agent_control_routes(app)
```

That edit is intentionally **not shipped** here. Until it lands, the PWA frontend treats every endpoint as `not_available` and renders empty / placeholder states by design.

## Hard guarantees (enforced by code AND tests)

| guarantee | enforcement |
|---|---|
| Backend GET-only | `methods=["GET"]` explicit; `test_mutation_verbs_are_rejected` asserts 405 on POST/PUT/PATCH/DELETE |
| No subprocess / `gh` / `git` invocation | `test_no_subprocess_imports_in_module`, `test_no_gh_or_git_invocation_in_module` |
| Missing artifact → `not_available` | `test_workloop_missing_artifact_yields_not_available` |
| Malformed artifact → `not_available` | `test_workloop_malformed_artifact_yields_not_available` |
| Non-object artifact → `not_available` | `test_pr_lifecycle_non_object_artifact_yields_not_available` |
| Secret-redaction always runs | `test_payload_with_credential_string_is_refused` |
| SW only handles GET | runtime guard + `test_only_handles_get_requests` |
| SW never reaches external services | `test_does_not_reach_external_analytics_or_services` |
| Frontend has exactly **one** button | `test_contains_exactly_one_button` (the Vernieuw refresh) |
| No execute / approve / merge / reject button labels | `test_does_not_render_any_execute_approve_merge_button` |
| Cards fall back gracefully when endpoints 404 | `test_renders_not_available_everywhere_when_every_endpoint_404s` |
| Mobile (375px) viewport renders | `test_renders_within_the_iphone_mini_viewport` |

## Constraints respected

- No write to `dashboard/dashboard.py` (no-touch).
- No write to `.claude/**`.
- No frozen-contract changes.
- No live/paper/shadow/trading/risk behavior changes.
- No CI weakening / no test weakening.
- **No new dependency** added to `frontend/package.json` (Vite/React/Vitest only — no PWA library, no analytics SDK, no notification provider).
- No external telemetry, no signup-required service, no paid plan.
- No POST/PUT/PATCH/DELETE handler anywhere on the new surface.

## Test plan

- [x] `python scripts/governance_lint.py` — OK (15 agents, 3 workflows).
- [x] `pytest tests/smoke -q` — 14/14 pass.
- [x] `pytest tests/unit -q` — **2753 passed** (was 2717; +36 new), 3 skipped, 0 failed.
- [x] `npm --prefix frontend test -- --run` — **37/37 pass** (was 24; +13 new across two new test files).
- [x] `npm --prefix frontend run build` — green (tsc -b + vite build).
- [x] Frozen-contract hashes unchanged:
  - `research/research_latest.json` = `4a567bd6feb98eb7aa32db4a90a3201456843088314936c5e484a2ae6a93666c`
  - `research/strategy_matrix.csv`   = `ff15b8c4f35cc37b6941b712106ae71a1b82a1b5043da197731d42518d258d66`

## Files added

```
dashboard/api_agent_control.py
docs/governance/mobile_agent_control_pwa.md
frontend/public/agent-control-icon.svg
frontend/public/manifest.webmanifest
frontend/public/sw.js
frontend/src/api/agent_control.ts
frontend/src/routes/AgentControl.tsx
frontend/src/styles/agent_control.css
frontend/src/test/AgentControl.test.tsx
frontend/src/test/PWAManifest.test.tsx
frontend/src/vite-env.d.ts
tests/unit/test_dashboard_api_agent_control.py
```

## Files modified (small, additive)

- `frontend/index.html` — manifest + theme-color tags only.
- `frontend/src/App.tsx` — added `<Route path="/agent-control">`.
- `frontend/src/main.tsx` — opportunistic SW registration behind a feature check.
- `docs/governance/autonomous_workloop_runbook.md` — release-table update + cross-link.

## Forward roadmap (not shipped here)

| release | adds |
|---|---|
| **v3.15.15.18 (this)** | mobile-first read-only PWA shell + 5 cards |
| v3.15.15.19 | roadmap / proposal queue card |
| v3.15.15.20 | approval inbox |
| v3.15.15.21 | execute-safe controls (the first *write* button) |
| v3.15.15.23 | browser push notifications for needs-human events only |
| v3.15.15.25 | metrics / observability dashboards |

🤖 Generated with [Claude Code](https://claude.com/claude-code)