### PR TITLE
feat(v3.15.15.19): roadmap / proposal queue (intake-only)

### DIFF
--- a/dashboard/api_proposal_queue.py
+++ b/dashboard/api_proposal_queue.py
@@ -1,0 +1,111 @@
+"""Read-only Flask route for the v3.15.15.19 proposal queue.
+
+Single GET endpoint: ``/api/agent-control/proposals``. Reads the
+gitignored digest at ``logs/proposal_queue/latest.json`` and returns a
+``not_available`` envelope when the artifact is missing or malformed.
+
+Hard guarantees (enforced by code AND tests)
+--------------------------------------------
+
+* GET only. No POST / PUT / PATCH / DELETE handler is registered.
+* Never executes a CLI subprocess, never invokes ``gh`` or ``git``.
+* Never reads ``config/config.yaml``, ``state/*.secret``, ``.env``,
+  or any other path on the no-touch read-deny list.
+* Missing / malformed / unreadable artifacts → ``{"status":
+  "not_available", "reason": ...}``. ``ok`` requires positive
+  evidence.
+* The response payload is run through ``assert_no_secrets`` from
+  ``reporting.agent_audit_summary`` before it leaves the server.
+
+Wiring
+------
+
+Same pattern as ``dashboard.api_agent_control``. To activate the
+route, ``dashboard/dashboard.py`` needs one line::
+
+    from dashboard.api_proposal_queue import register_proposal_queue_routes
+    register_proposal_queue_routes(app)
+
+That edit is intentionally NOT shipped here — ``dashboard.py`` is
+on the no-touch list. Until that operator-led PR lands, the PWA
+treats the endpoint as ``not_available``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from flask import Flask, jsonify
+
+from reporting.agent_audit_summary import assert_no_secrets
+
+REPO_ROOT: Path = Path(__file__).resolve().parent.parent
+LOGS_DIR: Path = REPO_ROOT / "logs"
+PROPOSAL_QUEUE_LATEST: Path = LOGS_DIR / "proposal_queue" / "latest.json"
+
+
+def _read_json_artifact(path: Path) -> dict[str, Any]:
+    """Read a JSON artifact and return one of:
+
+    * ``{"status": "ok", "data": <parsed dict>}`` on success;
+    * ``{"status": "not_available", "reason": "missing"}``;
+    * ``{"status": "not_available", "reason": "malformed: ..."}``;
+    * ``{"status": "not_available", "reason": "unreadable: ..."}``;
+    * ``{"status": "not_available", "reason": "malformed: not_an_object"}``.
+    """
+    if not path.exists():
+        return {"status": "not_available", "reason": "missing"}
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as e:
+        return {
+            "status": "not_available",
+            "reason": f"unreadable: {type(e).__name__}",
+        }
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as e:
+        return {
+            "status": "not_available",
+            "reason": f"malformed: {type(e).__name__}",
+        }
+    if not isinstance(data, dict):
+        return {"status": "not_available", "reason": "malformed: not_an_object"}
+    return {"status": "ok", "data": data}
+
+
+def _proposals_payload() -> dict[str, Any]:
+    artifact = _read_json_artifact(PROPOSAL_QUEUE_LATEST)
+    return {
+        "kind": "agent_control_proposals",
+        "schema_version": 1,
+        **artifact,
+        "artifact_path": "logs/proposal_queue/latest.json",
+    }
+
+
+def _safe_jsonify(payload: dict[str, Any]):
+    assert_no_secrets(payload)
+    return jsonify(payload)
+
+
+_PROPOSAL_QUEUE_ROUTES: tuple[tuple[str, Any], ...] = (
+    ("/api/agent-control/proposals", _proposals_payload),
+)
+
+
+def register_proposal_queue_routes(app: Flask) -> None:
+    for path, handler in _PROPOSAL_QUEUE_ROUTES:
+        endpoint = "agent_control_proposals"
+
+        def _view(_h=handler):  # type: ignore[no-untyped-def]
+            return _safe_jsonify(_h())
+
+        app.add_url_rule(
+            path,
+            endpoint=endpoint,
+            view_func=_view,
+            methods=["GET"],
+        )

--- a/docs/governance/autonomous_workloop_runbook.md
+++ b/docs/governance/autonomous_workloop_runbook.md
@@ -122,7 +122,7 @@ The controller embeds these verbatim in every digest's
 | **v3.15.15.16** | **local workloop planner (this runbook)** |
 | **v3.15.15.17** | **GitHub-backed PR lifecycle + Dependabot cleanup playbook (`reporting.github_pr_lifecycle`)** — pulled forward from the original v3.15.15.19 slot after a 10/10 pilot. Read-only by default; `execute-safe` mode comments `@dependabot rebase` and squash-merges LOW/MEDIUM Dependabot PRs only. HIGH stays inspect-only. |
 | **v3.15.15.18** | **Mobile-first read-only Agent Control PWA** (`dashboard.api_agent_control` + `frontend/src/routes/AgentControl.tsx`). Five cards backed by existing reporters / artifacts; installable; service-worker offline-capable; no execute / approve / merge buttons in the rendered DOM. See [`mobile_agent_control_pwa.md`](mobile_agent_control_pwa.md). |
-| v3.15.15.19 | roadmap queue + agent proposal intake (was vacated; reclaimed) |
+| **v3.15.15.19** | **Roadmap / proposal queue** (`reporting.proposal_queue` + `dashboard.api_proposal_queue` + Proposals card on the PWA). Intake-only: large roadmap input → reviewable proposal queue, never direct execution. Strategic roadmap adoption is HIGH and `needs_human` by default. Tooling-intake risk follows [`tooling_intake_policy.md`](tooling_intake_policy.md). See [`roadmap_proposal_queue.md`](roadmap_proposal_queue.md). |
 | v3.15.15.20 | operator approval & exception inbox |
 | v3.15.15.21 | dashboard execute-safe controls |
 | v3.15.15.22 | long-running runtime |

--- a/docs/governance/proposal_queue/schema.v1.md
+++ b/docs/governance/proposal_queue/schema.v1.md
@@ -1,0 +1,132 @@
+# Proposal Queue Digest — Schema v1
+
+> Module: `reporting.proposal_queue`
+> Module version: `v3.15.15.19`
+> Schema version: `1`
+> Artifact path (gitignored): `logs/proposal_queue/latest.json`
+> Timestamped copies: `logs/proposal_queue/<UTC>.json`
+
+## Top-level fields
+
+| field | type | values | notes |
+|---|---|---|---|
+| `schema_version` | int | `1` | bump on breaking changes |
+| `report_kind` | string | `"proposal_queue_digest"` | constant |
+| `module_version` | string | `"v3.15.15.19"` etc. | source-of-truth |
+| `generated_at_utc` | string | RFC3339 UTC | seconds resolution |
+| `mode` | string | `"dry-run"` | only mode allowed in v3.15.15.19 |
+| `sources` | array | list of relative paths | files that produced proposals |
+| `missing_sources` | array | `[{path, reason}]` | requested roots that did not exist |
+| `proposals` | array | see "Proposal" below | one row per detected unit of work |
+| `counts` | object | totals + by-status / by-risk / by-type | aggregate view |
+| `final_recommendation` | string | see below | summary verdict |
+| `status` (optional) | string | `"refused"` if a non-dry-run mode was requested | only present in refused responses |
+
+## Proposal
+
+One entry per detected proposal.
+
+| field | type | values | notes |
+|---|---|---|---|
+| `proposal_id` | string | `"p_<sha8>"` | deterministic hash of source + title + line index |
+| `created_at` | string | RFC3339 UTC | snapshot timestamp (same for all rows in a snapshot) |
+| `source` | string | relative path | the markdown / text file the proposal came from |
+| `source_type` | enum | `"markdown_heading"` / `"markdown_preamble"` | how the segment was extracted |
+| `title` | string | heading text | trimmed |
+| `summary` | string | short summary | first bullet or sentence; truncated to 240 chars |
+| `rationale` | string | longer rationale | up to 600 chars |
+| `evidence` | object | `{heading_level, line_idx, body_chars}` | structural evidence for the operator |
+| `affected_files` | array | list of paths | extracted from backtick-quoted file references in the body |
+| `risk_class` | enum | `"LOW"` / `"MEDIUM"` / `"HIGH"` | per the policy below |
+| `risk_reason` | string | human-readable rationale | tied to `risk_class` |
+| `approval_required` | bool | true / false | true for HIGH risk, blocked, needs_human, or `approval_required` type |
+| `blocked_reason` | string \| null | e.g. `"blocked_protected_path: ..."` | only set when `status == blocked` |
+| `proposal_type` | enum | see "Proposal types" | first-match classifier |
+| `allowed_actions` | array | strings | advisory; the agent + hook layers enforce |
+| `forbidden_actions` | array | strings | always lists the universal hard-no actions |
+| `required_tests` | array | strings | tests an approval would gate on |
+| `suggested_branch_name` | string | e.g. `fix/approval-required-x` | review-only suggestion |
+| `suggested_release_id` | string \| null | e.g. `"v3.15.15.20"` | parsed from title if present |
+| `status` | enum | `"proposed"` / `"needs_human"` / `"approved"` / `"rejected"` / `"blocked"` / `"superseded"` | this release only emits the first three |
+| `parent_proposal_id` | string \| null | reserved for v3.15.15.20+ | always null in this release |
+| `dependencies` | array | reserved for v3.15.15.20+ | always empty in this release |
+| `operator_notes` | string | reserved for v3.15.15.20+ | always empty in this release |
+
+## Proposal types
+
+| type | meaning |
+|---|---|
+| `roadmap_adoption` | strategic-shape signal: full new roadmap proposed for canonical |
+| `roadmap_diff` | explicit diff against an existing canonical roadmap |
+| `release_candidate` | title contains a release tag (`v3.15.15.x`, etc.) |
+| `governance_change` | touches `.claude/`, CODEOWNERS, branch protection, governance docs |
+| `tooling_intake` | explicit "tool / library / package / dep" mention |
+| `ci_hygiene` | GH Actions, workflows, SHA pin, Dependabot |
+| `dependency_cleanup` | requirements bump / package-lock / deps cleanup |
+| `observability_gap` | observability / logging / metrics / audit log |
+| `testing_gap` | missing test, coverage gap, no tests |
+| `ux_gap` | UX / UI / frontend gap |
+| `approval_required` | catch-all when the segment looks like a proposal |
+| `blocked_unknown` | unparseable source (missing / unreadable / not_a_file) |
+
+## Risk policy (pinned)
+
+Decision order — first-match wins:
+
+1. `affected_files` touches a frozen contract or no-touch path → **HIGH**, `status=blocked`, `blocked_reason="blocked_protected_path: <hit>"`.
+2. `affected_files` touches a live / paper / shadow / trading path → **HIGH**, `status=blocked`, `blocked_reason="blocked_high_risk: live/trading path: <hit>"`.
+3. `proposal_type == "roadmap_adoption"` → **HIGH**, `status=needs_human`.
+4. `proposal_type == "governance_change"` → **HIGH**, `status=needs_human`.
+5. `proposal_type == "tooling_intake"` mentioning `api key`, `token`, `signup`, `oauth`, `telemetry`, `hosted service`, `paid plan`, `subscription`, etc. → **HIGH**, `status=needs_human`.
+6. `proposal_type == "tooling_intake"` mentioning `dev-only`, `stdlib-only`, `no telemetry`, `no signup`, `MIT license`, etc. → **LOW**, `status=proposed`.
+7. `proposal_type` is `tooling_intake` (with no explicit signal), `ci_hygiene`, `dependency_cleanup`, `release_candidate`, `observability_gap`, `testing_gap`, or `ux_gap` → **MEDIUM**, `status=proposed`.
+8. `proposal_type == "blocked_unknown"` → **MEDIUM**, `status=blocked`, `blocked_reason="blocked_unknown: ..."`.
+9. Anything else → **MEDIUM**, `status=proposed` (conservative).
+
+## `final_recommendation` enum
+
+* `"no_proposals"` — empty queue.
+* `"review_<n>_proposed_items"` — only `proposed` items.
+* `"needs_human_on_<n>_items"` — at least one `needs_human`.
+* `"blocked_on_<n>_items"` — at least one `blocked` (no `needs_human`).
+* `"needs_human"` — fallback.
+
+## Counts object
+
+```json
+{
+  "total": 12,
+  "by_status":  {"proposed": 9, "needs_human": 2, "blocked": 1},
+  "by_risk":    {"LOW": 1, "MEDIUM": 9, "HIGH": 2},
+  "by_type":    {"approval_required": 5, "release_candidate": 4, "tooling_intake": 2, "governance_change": 1}
+}
+```
+
+## Hard guarantees encoded in the schema
+
+* `proposal_id` is deterministic — re-running with the same source produces the same id.
+* `proposals` never embeds raw secrets (the parser only reads the source verbatim; if the operator stores a secret in a roadmap doc the source itself is the bug, not the queue — but the queue truncates at the segment level and never echoes file content beyond `summary` + `rationale`, both length-capped).
+* `forbidden_actions` always lists the universal "never" list (push to main, force-push, admin merge, edit `.claude/**`, edit frozen contracts, edit `automation/live_gate.py`, bump `VERSION`).
+* `allowed_actions` is empty for `approval_required` proposals (the operator decides what to unlock at approval time).
+* `mode != "dry-run"` is refused at the boundary in this release.
+
+## Wiring with the dashboard
+
+`dashboard/api_proposal_queue.py` exposes a single GET-only route
+`/api/agent-control/proposals`. It reads
+`logs/proposal_queue/latest.json` and returns a `not_available`
+envelope when the artifact is missing or malformed — same contract
+as the rest of the v3.15.15.18 surface. The PWA Proposal Queue card
+consumes this endpoint directly.
+
+## Next-release additions (informative, not part of v1 schema)
+
+Future schema additions are allowed in minor revisions; renames or
+removals require a new schema version.
+
+* `parent_proposal_id` / `dependencies` / `operator_notes` will
+  populate from v3.15.15.20 (approval inbox).
+* `status` may emit `"approved"` / `"rejected"` / `"superseded"`
+  starting v3.15.15.20.
+* A diffing layer that reports whether a proposal supersedes an
+  existing canonical roadmap section lands in v3.15.15.20.

--- a/docs/governance/roadmap_proposal_queue.md
+++ b/docs/governance/roadmap_proposal_queue.md
@@ -1,0 +1,174 @@
+# Roadmap / Proposal Queue — Operator Runbook
+
+> Module: `reporting.proposal_queue` (parser/classifier/planner)
+> + `dashboard.api_proposal_queue` (read-only GET route)
+> + `frontend/src/routes/AgentControl.tsx` (Proposals card)
+> Release: v3.15.15.19
+> Schema: [`proposal_queue/schema.v1.md`](proposal_queue/schema.v1.md)
+> Tooling policy: [`tooling_intake_policy.md`](tooling_intake_policy.md)
+
+This is the operator-facing runbook. It explains how the proposal
+queue turns large roadmap / spillover / agent-finding documents into
+**reviewable, scoped proposals** — never into direct execution.
+
+## Core design principle
+
+> Large roadmap / document upload **never** triggers direct
+> execution.
+>
+> Instead it triggers:
+> `intake → diff → proposal queue → approval → small scoped releases.`
+
+The module emits proposals; it does not adopt roadmaps, merge PRs,
+modify governance docs, or write to `main`. Adoption / rejection /
+release-creation belong to later releases (the approval inbox lands
+in v3.15.15.20).
+
+## TL;DR
+
+```sh
+# Default: scan docs/roadmap/, docs/backlog/, docs/spillovers/.
+python -m reporting.proposal_queue --mode dry-run
+
+# Or point at a specific file or directory.
+python -m reporting.proposal_queue --source docs/roadmap/qre_roadmap_v4.md --mode dry-run
+
+# Read the digest without persisting it.
+python -m reporting.proposal_queue --mode dry-run --no-write
+```
+
+The CLI defaults to `dry-run`. **It is the only allowed mode in
+v3.15.15.19** — any other mode is refused at the boundary so we
+never write outside the gitignored digest.
+
+## Hard guarantees (enforced by code AND tests)
+
+| guarantee | enforcement |
+|---|---|
+| Stdlib-only — no subprocess / no `gh` / no `git` / no network | `test_no_subprocess_import_in_module`, `test_no_gh_or_git_invocation_in_module` |
+| Reads source files only; never modifies them | `test_frozen_contracts_byte_identical_around_snapshot` |
+| Strategic roadmap adoption is HIGH and `needs_human` | `test_strategic_roadmap_adoption_is_high_and_needs_human`, `test_strategic_roadmap_doc_yields_high_needs_human` |
+| Tooling proposal mentioning secrets / signup / telemetry → HIGH and `needs_human` | `test_tooling_with_secrets_or_telemetry_is_high`, `test_tooling_intake_marked_secrets_is_high` |
+| Free, dev-only, no-telemetry tooling can be LOW and `proposed` | `test_tooling_marked_free_dev_only_is_low`, `test_tooling_intake_marked_free_is_low` |
+| Live / paper / shadow / trading scope is `blocked_high_risk` | `test_live_trading_path_is_blocked_high_risk` |
+| Frozen / no-touch path is `blocked_protected_path` | `test_protected_path_is_blocked_protected_path`, `test_frozen_contract_path_is_blocked_protected_path` |
+| Unknown source → `blocked_unknown` or `not_available` | `test_unknown_source_yields_blocked_unknown_or_missing` |
+| Malformed input does not crash | `test_malformed_input_does_not_crash` |
+| `proposal_id` is deterministic for the same input | `test_proposal_id_is_deterministic` |
+| `dry-run` is the only allowed mode | `test_non_dry_run_mode_is_refused` |
+
+## Proposal types
+
+| type | meaning |
+|---|---|
+| `roadmap_adoption` | strategic full-roadmap proposal — HIGH / `needs_human` |
+| `roadmap_diff` | explicit diff against an existing canonical roadmap — MEDIUM |
+| `release_candidate` | title contains a release tag (`v3.15.15.x`) — MEDIUM |
+| `governance_change` | touches `.claude/`, CODEOWNERS, branch protection, governance docs — HIGH / `needs_human` |
+| `tooling_intake` | proposed dev tool / dependency — risk depends on telemetry / signup |
+| `ci_hygiene` | GH Actions, workflows, SHA pin, Dependabot — MEDIUM |
+| `dependency_cleanup` | requirements bump / package-lock — MEDIUM |
+| `observability_gap` | observability / logging / metrics gap — MEDIUM |
+| `testing_gap` | missing tests / coverage gap — MEDIUM |
+| `ux_gap` | UX / UI / frontend gap — MEDIUM |
+| `approval_required` | catch-all when the segment looks like a proposal — MEDIUM |
+| `blocked_unknown` | unparseable source — `blocked` |
+
+## Risk policy (pinned)
+
+Decision order — first-match wins:
+
+1. `affected_files` touches a frozen contract or no-touch path → **HIGH**, `status=blocked`.
+2. `affected_files` touches a live / paper / shadow / trading path → **HIGH**, `status=blocked`.
+3. `proposal_type == "roadmap_adoption"` → **HIGH**, `status=needs_human`.
+4. `proposal_type == "governance_change"` → **HIGH**, `status=needs_human`.
+5. `proposal_type == "tooling_intake"` mentioning secrets / signup / telemetry / hosted service → **HIGH**, `status=needs_human`.
+6. `proposal_type == "tooling_intake"` mentioning `dev-only`, `MIT license`, `no telemetry`, etc. → **LOW**, `status=proposed`.
+7. `tooling_intake` (no marker) / `ci_hygiene` / `dependency_cleanup` / `release_candidate` / `observability_gap` / `testing_gap` / `ux_gap` → **MEDIUM**, `status=proposed`.
+8. `blocked_unknown` → **MEDIUM**, `status=blocked`.
+
+The negation-aware tooling check matters: `"no telemetry"` and
+`"no signup"` are explicit free-tool markers, not HIGH triggers.
+The substring "telemetry" inside the phrase "no telemetry" is
+deliberately NOT counted as a HIGH signal (regex strips
+`no <token>` / `no-<token>` before checking HIGH tokens).
+
+## Reading the JSON artifact
+
+```sh
+python -m reporting.proposal_queue --mode dry-run
+# writes logs/proposal_queue/latest.json + a timestamped copy
+
+# Quick triage: how many proposals would be needs_human right now?
+jq '[.proposals[] | select(.status == "needs_human")] | length' \
+   logs/proposal_queue/latest.json
+
+# Or just the final recommendation:
+jq -r '.final_recommendation' logs/proposal_queue/latest.json
+```
+
+## PWA integration
+
+The Agent Control PWA (v3.15.15.18) gains a sixth read-only card:
+**Proposals**. It hits `/api/agent-control/proposals` (GET only) and
+renders a one-line summary per proposal — `proposal_id`,
+`proposal_type`, risk pill — with no approve / reject / merge
+button.
+
+### Wiring step (manual, one line)
+
+`dashboard/dashboard.py` is on the no-touch list. Activating the new
+GET route requires one operator-led line in `dashboard.py`:
+
+```python
+# v3.15.15.19: read-only Proposal Queue route.
+from dashboard.api_proposal_queue import register_proposal_queue_routes
+register_proposal_queue_routes(app)
+```
+
+Until that PR lands, the PWA's Proposals card renders
+`not_available` (the route is 404 and the frontend client falls back
+gracefully — by design).
+
+## What this is NOT
+
+The release intentionally does NOT ship:
+
+* approve / reject / supersede buttons (release v3.15.15.20);
+* execute-safe controls (release v3.15.15.21);
+* canonical roadmap adoption — `roadmap_adoption` proposals stay
+  `needs_human` forever in this release;
+* a diff layer that flags whether a proposal supersedes an existing
+  canonical roadmap section (release v3.15.15.20);
+* any non-dry-run mode (refused at the CLI boundary);
+* any POST / PUT / PATCH / DELETE endpoint;
+* any browser push notification.
+
+## Forward roadmap (not shipped here)
+
+| release | adds |
+|---|---|
+| **v3.15.15.19 (this)** | proposal parser, queue, schema, GET route, read-only PWA card |
+| v3.15.15.20 | approval inbox: operator approves / rejects / supersedes; status emits `approved` / `rejected` / `superseded` |
+| v3.15.15.21 | execute-safe controls in the dashboard (the first *write* button) |
+| v3.15.15.23 | browser push notifications for `needs_human` proposals only |
+| v3.15.15.25 | metrics / observability dashboards |
+
+## Files added by v3.15.15.19
+
+```
+reporting/proposal_queue.py                              (parser/classifier/planner)
+dashboard/api_proposal_queue.py                          (GET-only Flask route)
+docs/governance/proposal_queue/schema.v1.md              (JSON schema)
+docs/governance/roadmap_proposal_queue.md                (this file)
+docs/governance/tooling_intake_policy.md                 (canonical tooling policy)
+frontend/src/api/agent_control.ts                        (extended with proposals())
+frontend/src/routes/AgentControl.tsx                     (Proposals card added)
+frontend/src/test/AgentControl.test.tsx                  (proposals tests)
+tests/unit/test_proposal_queue.py                        (39 cases)
+tests/unit/test_dashboard_api_proposal_queue.py          (13 cases)
+```
+
+No edits to `dashboard/dashboard.py` (no-touch). No edits to
+`.claude/**`. No frozen-contract changes. No live / paper / shadow /
+trading / risk behavior changes.

--- a/docs/governance/tooling_intake_policy.md
+++ b/docs/governance/tooling_intake_policy.md
@@ -1,0 +1,138 @@
+# Tooling Intake Policy
+
+> Owner: repo owner + `ci-guardian`, `architecture-guardian`,
+> `observability-guardian` agents.
+> Linked module: `reporting.proposal_queue` (v3.15.15.19) classifies
+> tooling proposals against this policy.
+
+This is the canonical decision rubric for whether a proposed tool /
+library / dependency may be integrated **without** routing through
+the approval inbox, and what evidence every proposal must carry.
+
+## TL;DR
+
+| classification | examples | route |
+|---|---|---|
+| **LOW** | dev-only, free, OSS, no telemetry, no signup, no token, MIT / Apache 2.0 / BSD / similar permissive license | safe to integrate as a normal release after the standard review |
+| **MEDIUM** | dev-only or runtime-adjacent, free, but lacking explicit free-tool markers | route via the proposal queue, normal review |
+| **HIGH** | hosted service, requires signup / API key / OAuth / paid plan / telemetry / SaaS / data egress | route to the approval inbox; `needs_human` |
+
+The classifier in `reporting.proposal_queue._classify_risk` encodes
+this rubric. The negation-aware substring check means "no telemetry"
+is a LOW marker, not a HIGH trigger.
+
+## When this policy applies
+
+* Any new entry in `frontend/package.json` `dependencies` or
+  `devDependencies`.
+* Any new entry in `requirements.txt`, `requirements-dev.txt`, or any
+  Python environment manifest.
+* Any new GitHub Action `uses:` reference (must remain SHA-pinned —
+  see `docs/governance/sha_pin_review.md`).
+* Any pre-commit hook addition.
+* Any container base-image change (these are governed additionally
+  by `docs/governance/no_touch_paths.md` — Dockerfile is no-touch).
+* Any external SaaS integration (Datadog, Sentry, Segment.io,
+  Google Analytics, Datadog APM, etc.) — all default to HIGH.
+
+## Required evidence per proposal
+
+Every tooling proposal must include the following in its rationale
+or runbook before integration:
+
+| field | what to capture |
+|---|---|
+| **purpose** | What problem does this tool solve? Which existing tool is insufficient? |
+| **license** | SPDX identifier (e.g. `MIT`, `Apache-2.0`, `BSD-3-Clause`). Reject anything unknown / non-permissive without an explicit ADR. |
+| **cost** | Free / paid / freemium. If freemium: explicit confirmation that the project will stay on the free tier. Anything paid → HIGH. |
+| **data egress / telemetry** | Does the tool phone home? What data is sent? To which host? Anything non-zero → HIGH. |
+| **secrets / accounts** | Any API key, OAuth token, account creation, or signup required? Anything required → HIGH. |
+| **runtime vs dev-only** | Is this a `devDependency` only, or does it run in production? Runtime-critical → ADR required. |
+| **files changed** | Exact list of files modified by integration (manifests, configs, workflows, lockfiles). |
+| **rollback plan** | Concrete revert steps. For pip: `pip uninstall <pkg> && git revert <sha>`. For workflow actions: pin SHA back. For runtime libs: confirm no schema migration. |
+| **tests / validation** | Test file(s) covering the new tool's surface, OR an explicit "operator runs `<command>` to validate" line. |
+| **owner / review surface** | Which agent / human is the maintenance owner. Default: repo owner + `architecture-guardian` for runtime-critical changes. |
+
+## Hard "no" — never integrate without approval
+
+* External account creation by the agent.
+* API keys / OAuth tokens / bearer tokens stored anywhere in repo or
+  CI without a documented secret-rotation plan.
+* Telemetry, analytics, error reporting that exfiltrates data to a
+  third party (Datadog, Sentry, Google Analytics, Segment.io, etc.).
+* Paid plans or subscriptions.
+* Hosted services that gate on signup.
+* Tools that touch live / paper / shadow / trading / risk behavior.
+* Tools that weaken governance (CODEOWNERS, branch protection,
+  required status checks, secret scanners, gitleaks, frozen contracts).
+* Tools that bypass the no-touch hook layer (`.claude/hooks/**`).
+
+## Allowed examples (LOW)
+
+These are illustrative — each one still goes through the proposal
+queue and the standard PR review, but carries no HIGH risk class.
+
+* `vite-plugin-pwa` — MIT, dev-only, no telemetry, no signup.
+* `ruff` — MIT, dev-only, OSS, no telemetry.
+* `prettier` — MIT, dev-only, OSS.
+* `pre-commit` — MIT, dev-only, OSS.
+* `mypy` / `pytest` / `vitest` — already present; minor / patch
+  bumps land via Dependabot, governed by
+  [`dependabot_cleanup_playbook.md`](dependabot_cleanup_playbook.md).
+* New `@types/*` packages — TypeScript type definitions, dev-only.
+
+## Approval-required examples (HIGH)
+
+* Any APM / observability SaaS (Datadog, New Relic, Honeycomb, etc.).
+* Any error-reporting SaaS (Sentry, Bugsnag, etc.).
+* Any analytics / telemetry SDK (Segment.io, Google Analytics,
+  Mixpanel, etc.).
+* Any auth provider that requires hosted-service signup.
+* Any hosted database / queue / cache (Redis Cloud, Supabase,
+  Firebase, etc.).
+* Any feature-flag SaaS (LaunchDarkly, Unleash Cloud, etc.).
+* Any AI / ML provider integration that adds a new credential vector
+  beyond what `config/config.yaml` already covers.
+
+## Container base-image changes
+
+Container base-image bumps (e.g. `python:3.11-slim` → `python:3.12-slim`)
+are a special case:
+
+* `Dockerfile` and `docker-compose.prod.yml` are on the no-touch
+  list — agent cannot author these changes directly.
+* Always require an ADR with: motivation, compatibility test plan,
+  rollback path (digest of previous image), and confirmation that
+  the new base image is reproducible (preferably SHA-digest pinned).
+* Even with all of the above, the change must land through a
+  human-authored PR with `architecture-guardian` review.
+
+## How `proposal_queue` enforces this
+
+The classifier looks at the proposal's title and body for two
+disjoint token sets:
+
+* `TOOLING_HIGH_TOKENS`: api key, signup, oauth, telemetry, datadog,
+  sentry, segment.io, google-analytics, googletagmanager, hosted
+  service, saas, paid plan, subscription.
+* `TOOLING_LOW_TOKENS`: dev-only, devdependency, stdlib-only,
+  no telemetry, no signup, open source, MIT license, Apache 2.0,
+  BSD license.
+
+LOW signals are checked first — so an explicit "no telemetry" /
+"no signup" marker never gets re-classified as HIGH by a substring
+match on the negated word.
+
+## Synchronization check
+
+When this policy changes:
+
+1. Update `TOOLING_HIGH_TOKENS` / `TOOLING_LOW_TOKENS` in
+   `reporting/proposal_queue.py`.
+2. Update the parametrized lists in
+   `tests/unit/test_proposal_queue.py`
+   (`test_tooling_with_secrets_or_telemetry_is_high` and
+   `test_tooling_marked_free_dev_only_is_low`).
+3. Update the table in `proposal_queue/schema.v1.md`.
+4. Open a PR with `architecture-guardian` review (this file lives in
+   `docs/governance/` and changes here are governance-shape).

--- a/frontend/src/api/agent_control.ts
+++ b/frontend/src/api/agent_control.ts
@@ -70,6 +70,20 @@ export interface AgentControlNotifications {
   next_release_with_push?: string;
 }
 
+export interface AgentControlProposals {
+  kind: "agent_control_proposals";
+  schema_version: number;
+  status: "ok" | "not_available";
+  reason?: string;
+  data?: {
+    final_recommendation: string;
+    proposals: Array<Record<string, unknown>>;
+    counts?: Record<string, unknown>;
+    [k: string]: unknown;
+  };
+  artifact_path: string;
+}
+
 const BASE = "/api/agent-control";
 
 async function getJson<T>(path: string): Promise<T> {
@@ -106,4 +120,5 @@ export const agentControlApi = {
     getJson<AgentControlPRLifecycle>(`${BASE}/pr-lifecycle`),
   notifications: () =>
     getJson<AgentControlNotifications>(`${BASE}/notifications`),
+  proposals: () => getJson<AgentControlProposals>(`${BASE}/proposals`),
 };

--- a/frontend/src/routes/AgentControl.tsx
+++ b/frontend/src/routes/AgentControl.tsx
@@ -19,6 +19,7 @@ import {
   type AgentControlActivity,
   type AgentControlNotifications,
   type AgentControlPRLifecycle,
+  type AgentControlProposals,
   type AgentControlStatus,
   type AgentControlWorkloop,
 } from "../api/agent_control";
@@ -327,6 +328,79 @@ function PRLifecycleCard({
   );
 }
 
+// --- Card: proposal queue (v3.15.15.19) ---
+function ProposalsCard({
+  payload,
+}: {
+  payload: AgentControlProposals | null;
+}) {
+  if (!payload) {
+    return (
+      <Card title="Proposals" subtitle="roadmap intake queue">
+        <p className="agent-control-card__empty">Laden…</p>
+      </Card>
+    );
+  }
+  if (payload.status !== "ok" || !payload.data) {
+    return (
+      <Card title="Proposals" subtitle="roadmap intake queue">
+        <p
+          className="agent-control-card__empty"
+          data-testid="proposals-not-available"
+        >
+          {payload.reason ?? "not_available"} —{" "}
+          <code>{payload.artifact_path}</code>
+        </p>
+      </Card>
+    );
+  }
+  const data = payload.data;
+  const proposals = data.proposals ?? [];
+  const recommendation = String(data.final_recommendation ?? "unknown");
+  return (
+    <Card title="Proposals" subtitle="roadmap intake queue">
+      <div className="agent-control-card__row">
+        <dt>recommendation</dt>
+        <dd data-testid="proposals-recommendation">{recommendation}</dd>
+      </div>
+      {proposals.length === 0 ? (
+        <p
+          className="agent-control-card__empty"
+          data-testid="proposals-empty"
+        >
+          Geen proposals — geen roadmap intake op dit moment.
+        </p>
+      ) : (
+        proposals.slice(0, 5).map((p, idx) => {
+          const id = String(p.proposal_id ?? "?");
+          const risk = String(p.risk_class ?? "UNKNOWN");
+          const status = String(p.status ?? "unknown");
+          const ptype = String(p.proposal_type ?? "unknown");
+          const pillState =
+            risk === "HIGH"
+              ? status === "blocked"
+                ? "danger"
+                : "warn"
+              : risk === "LOW"
+                ? "ok"
+                : "unknown";
+          return (
+            <div className="agent-control-card__row" key={`${id}-${idx}`}>
+              <dt>
+                {id}{" "}
+                <span style={{ color: "var(--fg-muted)" }}>{ptype}</span>
+              </dt>
+              <dd>
+                <StatusPill state={pillState} />
+              </dd>
+            </div>
+          );
+        })
+      )}
+    </Card>
+  );
+}
+
 // --- Card: notification center placeholder ---
 function NotificationsCard({
   payload,
@@ -367,23 +441,28 @@ export function AgentControl() {
     useState<AgentControlPRLifecycle | null>(null);
   const [notifications, setNotifications] =
     useState<AgentControlNotifications | null>(null);
+  const [proposals, setProposals] = useState<AgentControlProposals | null>(
+    null,
+  );
   const [loading, setLoading] = useState<boolean>(false);
   const [refreshedAt, setRefreshedAt] = useState<string>("");
 
   const loadAll = useCallback(async () => {
     setLoading(true);
-    const [s, a, w, p, n] = await Promise.all([
+    const [s, a, w, p, n, q] = await Promise.all([
       agentControlApi.status(),
       agentControlApi.activity(),
       agentControlApi.workloop(),
       agentControlApi.prLifecycle(),
       agentControlApi.notifications(),
+      agentControlApi.proposals(),
     ]);
     setStatus(s);
     setActivity(a);
     setWorkloop(w);
     setPrLifecycle(p);
     setNotifications(n);
+    setProposals(q);
     setRefreshedAt(new Date().toISOString().replace("T", " ").slice(0, 19));
     setLoading(false);
   }, []);
@@ -426,6 +505,7 @@ export function AgentControl() {
         <ActivityCard payload={activity} />
         <WorkloopCard payload={workloop} />
         <PRLifecycleCard payload={prLifecycle} />
+        <ProposalsCard payload={proposals} />
         <NotificationsCard payload={notifications} />
       </div>
 

--- a/frontend/src/test/AgentControl.test.tsx
+++ b/frontend/src/test/AgentControl.test.tsx
@@ -86,6 +86,43 @@ const placeholderNotificationsBody = {
   next_release_with_push: "v3.15.15.23",
 };
 
+const okProposalsEmptyBody = {
+  kind: "agent_control_proposals",
+  schema_version: 1,
+  status: "ok",
+  data: {
+    schema_version: 1,
+    final_recommendation: "no_proposals",
+    proposals: [],
+  },
+  artifact_path: "logs/proposal_queue/latest.json",
+};
+
+const okProposalsBody = {
+  kind: "agent_control_proposals",
+  schema_version: 1,
+  status: "ok",
+  data: {
+    schema_version: 1,
+    final_recommendation: "needs_human_on_1_items",
+    proposals: [
+      {
+        proposal_id: "p_abcdef01",
+        proposal_type: "roadmap_adoption",
+        risk_class: "HIGH",
+        status: "needs_human",
+      },
+      {
+        proposal_id: "p_abcdef02",
+        proposal_type: "tooling_intake",
+        risk_class: "LOW",
+        status: "proposed",
+      },
+    ],
+  },
+  artifact_path: "logs/proposal_queue/latest.json",
+};
+
 const fetchSpy: any[] = [];
 
 function installFetchMock(
@@ -121,6 +158,92 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+describe("AgentControl — proposals card", () => {
+  it("renders an empty-state when the proposal queue is empty", async () => {
+    installFetchMock(
+      {
+        "/api/agent-control/status": () => jsonResp(okStatusBody),
+        "/api/agent-control/activity": () => jsonResp(okActivityBody),
+        "/api/agent-control/workloop": () => jsonResp(okWorkloopBody),
+        "/api/agent-control/pr-lifecycle": () =>
+          jsonResp(okPRLifecycleEmptyBody),
+        "/api/agent-control/notifications": () =>
+          jsonResp(placeholderNotificationsBody),
+        "/api/agent-control/proposals": () => jsonResp(okProposalsEmptyBody),
+      },
+      () => jsonResp({}, 404),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("proposals-empty")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("proposals-recommendation")).toHaveTextContent(
+      "no_proposals",
+    );
+  });
+
+  it("renders not_available when the proposals endpoint 404s", async () => {
+    installFetchMock(
+      {
+        "/api/agent-control/status": () => jsonResp(okStatusBody),
+        "/api/agent-control/activity": () => jsonResp(okActivityBody),
+        "/api/agent-control/workloop": () => jsonResp(okWorkloopBody),
+        "/api/agent-control/pr-lifecycle": () =>
+          jsonResp(okPRLifecycleEmptyBody),
+        "/api/agent-control/notifications": () =>
+          jsonResp(placeholderNotificationsBody),
+      },
+      () => jsonResp({}, 404),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("proposals-not-available")).toBeInTheDocument();
+    });
+  });
+
+  it("renders proposal rows with risk pills and never an action button", async () => {
+    installFetchMock(
+      {
+        "/api/agent-control/status": () => jsonResp(okStatusBody),
+        "/api/agent-control/activity": () => jsonResp(okActivityBody),
+        "/api/agent-control/workloop": () => jsonResp(okWorkloopBody),
+        "/api/agent-control/pr-lifecycle": () =>
+          jsonResp(okPRLifecycleEmptyBody),
+        "/api/agent-control/notifications": () =>
+          jsonResp(placeholderNotificationsBody),
+        "/api/agent-control/proposals": () => jsonResp(okProposalsBody),
+      },
+      () => jsonResp({}, 404),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("proposals-recommendation")).toBeInTheDocument();
+    });
+    // Both proposal rows render their proposal_type label.
+    expect(screen.getAllByText(/roadmap_adoption|tooling_intake/)).not.toHaveLength(0);
+    // Still exactly one button on the page (the refresh).
+    expect(screen.queryAllByRole("button")).toHaveLength(1);
+  });
+});
+
 describe("AgentControl — happy path", () => {
   it("renders all five cards and an empty Dependabot queue", async () => {
     installFetchMock(
@@ -132,6 +255,7 @@ describe("AgentControl — happy path", () => {
           jsonResp(okPRLifecycleEmptyBody),
         "/api/agent-control/notifications": () =>
           jsonResp(placeholderNotificationsBody),
+        "/api/agent-control/proposals": () => jsonResp(okProposalsEmptyBody),
       },
       () => jsonResp({ status: "not_available" }, 404),
     );
@@ -168,6 +292,7 @@ describe("AgentControl — happy path", () => {
           jsonResp(okPRLifecycleEmptyBody),
         "/api/agent-control/notifications": () =>
           jsonResp(placeholderNotificationsBody),
+        "/api/agent-control/proposals": () => jsonResp(okProposalsEmptyBody),
       },
       () => jsonResp({}, 404),
     );
@@ -237,6 +362,7 @@ describe("AgentControl — UI affordances", () => {
           jsonResp(okPRLifecycleEmptyBody),
         "/api/agent-control/notifications": () =>
           jsonResp(placeholderNotificationsBody),
+        "/api/agent-control/proposals": () => jsonResp(okProposalsEmptyBody),
       },
       () => jsonResp({}, 404),
     );
@@ -271,6 +397,7 @@ describe("AgentControl — UI affordances", () => {
           jsonResp(okPRLifecycleEmptyBody),
         "/api/agent-control/notifications": () =>
           jsonResp(placeholderNotificationsBody),
+        "/api/agent-control/proposals": () => jsonResp(okProposalsEmptyBody),
       },
       () => jsonResp({}, 404),
     );
@@ -327,6 +454,7 @@ describe("AgentControl — UI affordances", () => {
           jsonResp(okPRLifecycleEmptyBody),
         "/api/agent-control/notifications": () =>
           jsonResp(placeholderNotificationsBody),
+        "/api/agent-control/proposals": () => jsonResp(okProposalsEmptyBody),
       },
       () => jsonResp({}, 404),
     );

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -14,7 +14,8 @@
     "skipLibCheck": true,
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true
   },
   "include": ["src"]
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,8 +5,17 @@ import react from "@vitejs/plugin-react";
 // image by the multi-stage Dockerfile. Flask serves it on "/" and
 // "/assets/*"; nginx terminates :8050 and proxies to dashboard:8050 (ADR-011
 // §2–3).
+//
+// resolve.extensions: .ts / .tsx come BEFORE .js so any untracked tsc-emit
+// artifacts that exist alongside source files (frontend/src/**/*.js is
+// not gitignored) never shadow a source .tsx/.ts. tsconfig.json has
+// `noEmit: true` so .js siblings are not regenerated; this resolution
+// order makes the bundler robust against any that still exist on disk.
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    extensions: [".mts", ".ts", ".mtsx", ".tsx", ".jsx", ".mjs", ".js", ".json"],
+  },
   build: {
     outDir: "dist",
     sourcemap: false,

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,8 +1,13 @@
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 
+// resolve.extensions ordering matches vite.config.ts so vitest never
+// resolves a stale tsc-emit .js sibling ahead of the source .ts/.tsx.
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    extensions: [".mts", ".ts", ".mtsx", ".tsx", ".jsx", ".mjs", ".js", ".json"],
+  },
   test: {
     environment: "jsdom",
     globals: true,

--- a/reporting/proposal_queue.py
+++ b/reporting/proposal_queue.py
@@ -1,0 +1,1036 @@
+"""Roadmap / Proposal Queue (v3.15.15.19).
+
+This module is the **intake** layer of the autonomous development
+loop. It takes one or more roadmap-shaped source documents (markdown,
+plain text, or repo paths) and produces a deterministic *queue* of
+review-ready proposals — one per detected unit of work.
+
+Core design principle
+---------------------
+
+Large roadmap / document upload **never** triggers direct execution.
+Instead it triggers:
+
+    intake → diff → proposal queue → approval → small scoped releases.
+
+The module emits proposals; it does not adopt roadmaps, merge PRs,
+modify governance docs, or write to ``main``. Adoption / rejection /
+release-creation belong to later releases (the approval inbox lands
+in v3.15.15.20).
+
+Hard guarantees (enforced by code AND tests)
+--------------------------------------------
+
+* Stdlib-only. No subprocess, no ``gh``, no ``git``, no network.
+* Reads the source paths the operator passes in. Reads existing
+  ``docs/roadmap/`` / ``docs/backlog/`` / ``docs/spillovers/`` only
+  when the operator opts in; the default scan list is conservative.
+* Never modifies any source document.
+* Strategic roadmap adoption is HIGH and ``needs_human`` by default.
+* Tooling proposals that mention secrets / tokens / accounts /
+  signup / hosted services / telemetry are HIGH and ``needs_human``.
+* Free, dev-only, no-telemetry tooling proposals can land at LOW or
+  MEDIUM; the canonical rules live in
+  ``docs/governance/tooling_intake_policy.md``.
+* Proposals touching live / paper / shadow / trading / risk paths
+  are HIGH and ``blocked_high_risk``.
+* Proposals touching frozen contracts or no-touch paths are HIGH and
+  ``blocked_protected_path``.
+* Unknown / malformed source → ``blocked_unknown`` (never silently OK).
+* Every ``proposal_id`` is a deterministic hash so the same input
+  produces the same queue.
+* The CLI defaults to ``dry-run``. ``execute-safe`` is *not* enabled
+  in this release — there is no execute path to enable yet. The
+  CLI rejects any non-dry-run mode.
+
+CLI
+---
+
+::
+
+    python -m reporting.proposal_queue --mode dry-run
+    python -m reporting.proposal_queue --source docs/roadmap --mode dry-run
+    python -m reporting.proposal_queue --source <path> --mode dry-run
+
+Stdlib-only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import fnmatch
+import hashlib
+import json
+import re
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT: Path = Path(__file__).resolve().parent.parent
+MODULE_VERSION: str = "v3.15.15.19"
+SCHEMA_VERSION: int = 1
+
+DIGEST_DIR_JSON: Path = REPO_ROOT / "logs" / "proposal_queue"
+
+# ---------------------------------------------------------------------------
+# Governance constants (mirror of autonomous_workloop / no_touch_paths.md)
+# ---------------------------------------------------------------------------
+
+FROZEN_CONTRACTS: tuple[str, ...] = (
+    "research/research_latest.json",
+    "research/strategy_matrix.csv",
+)
+
+# Path globs whose presence in a proposal's affected_files classifies
+# it as protected. Mirrors the canonical list in
+# ``docs/governance/no_touch_paths.md``. Kept local so this module
+# can be tested in isolation; sync via release notes when canonical.
+PROTECTED_GLOBS: tuple[str, ...] = (
+    ".claude/settings.json",
+    ".claude/hooks/*",
+    ".claude/hooks/**",
+    ".claude/agents/*",
+    ".claude/agents/**",
+    ".claude/commands/*",
+    ".claude/commands/**",
+    ".github/CODEOWNERS",
+    "VERSION",
+    "automation/live_gate.py",
+    "automation/*.secret",
+    "state/*.secret",
+    "config/config.yaml",
+    ".env",
+    ".env.*",
+    "*_latest.v1.json",
+    "*_latest.v1.jsonl",
+    "**/*_latest.v1.json",
+    "**/*_latest.v1.jsonl",
+    "docker-compose.prod.yml",
+    "scripts/deploy.sh",
+    "Dockerfile",
+    "Dockerfile.*",
+)
+
+LIVE_PATH_GLOBS: tuple[str, ...] = (
+    "execution/live/**",
+    "automation/live/**",
+    "agent/execution/live/**",
+    "**/live_*broker*.py",
+    "**/*live*broker*.py",
+    "**/*live_executor*.py",
+    "**/*live*executor*.py",
+    "**/*_live.py",
+    "automation/live_gate.py",
+    "automation/**",
+    "execution/**",
+    "strategies/**",
+    "agent/risk/**",
+    "agent/execution/**",
+)
+
+# Roadmap-adoption signals — phrases that suggest a *strategic*
+# roadmap-level change, not just a release-scoped item.
+STRATEGIC_ROADMAP_TOKENS: tuple[str, ...] = (
+    "canonical roadmap",
+    "new roadmap",
+    "roadmap adoption",
+    "rewrite roadmap",
+    "supersede roadmap",
+    "v4 roadmap",
+    "post-v3.15",
+)
+
+# Tooling-intake signals — anything mentioning these tokens elevates a
+# tooling proposal to HIGH per docs/governance/tooling_intake_policy.md.
+TOOLING_HIGH_TOKENS: tuple[str, ...] = (
+    "api key",
+    "api-key",
+    "api_key",
+    "signup",
+    "sign-up",
+    "create an account",
+    "create account",
+    "auth token",
+    "access token",
+    "bearer token",
+    "oauth",
+    "telemetry",
+    "datadog",
+    "sentry",
+    "segment.io",
+    "google-analytics",
+    "googletagmanager",
+    "hosted service",
+    "saas",
+    "paid plan",
+    "subscription",
+)
+
+TOOLING_LOW_TOKENS: tuple[str, ...] = (
+    "dev-only",
+    "devdependency",
+    "devdependencies",
+    "stdlib",
+    "stdlib-only",
+    "no telemetry",
+    "no-telemetry",
+    "no signup",
+    "no-signup",
+    "open source",
+    "open-source",
+    "mit license",
+    "apache 2.0",
+    "bsd license",
+)
+
+# Proposal-type taxonomy enumerated in the schema doc.
+PROPOSAL_TYPES: tuple[str, ...] = (
+    "roadmap_adoption",
+    "roadmap_diff",
+    "release_candidate",
+    "governance_change",
+    "tooling_intake",
+    "ci_hygiene",
+    "dependency_cleanup",
+    "observability_gap",
+    "testing_gap",
+    "ux_gap",
+    "approval_required",
+    "blocked_unknown",
+)
+
+# Status values.
+STATUS_PROPOSED: str = "proposed"
+STATUS_NEEDS_HUMAN: str = "needs_human"
+STATUS_APPROVED: str = "approved"
+STATUS_REJECTED: str = "rejected"
+STATUS_BLOCKED: str = "blocked"
+STATUS_SUPERSEDED: str = "superseded"
+
+# Risk classes.
+RISK_LOW: str = "LOW"
+RISK_MEDIUM: str = "MEDIUM"
+RISK_HIGH: str = "HIGH"
+
+
+# Default source roots scanned when no --source is provided. Each root
+# is parsed best-effort; missing roots are reported but do not abort.
+DEFAULT_SOURCE_ROOTS: tuple[str, ...] = (
+    "docs/roadmap",
+    "docs/backlog",
+    "docs/spillovers",
+)
+
+
+# ---------------------------------------------------------------------------
+# Time helpers
+# ---------------------------------------------------------------------------
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+# ---------------------------------------------------------------------------
+# Path matching
+# ---------------------------------------------------------------------------
+
+
+def _path_matches_any(path: str, globs: Iterable[str]) -> bool:
+    n = path.replace("\\", "/")
+    return any(fnmatch.fnmatchcase(n, g) for g in globs)
+
+
+def diff_touches_protected(files: Iterable[str]) -> tuple[bool, str | None]:
+    for f in files:
+        n = f.replace("\\", "/")
+        if n in FROZEN_CONTRACTS:
+            return (True, n)
+    for f in files:
+        if _path_matches_any(f, PROTECTED_GLOBS):
+            return (True, f)
+    return (False, None)
+
+
+def diff_touches_live_or_trading(files: Iterable[str]) -> tuple[bool, str | None]:
+    for f in files:
+        if _path_matches_any(f, LIVE_PATH_GLOBS):
+            return (True, f)
+    return (False, None)
+
+
+# ---------------------------------------------------------------------------
+# Source intake (markdown only — robust for missing/malformed input)
+# ---------------------------------------------------------------------------
+
+
+# A heading line in markdown: leading hash(es) + space + title.
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
+# A bullet line: leading "*", "-", "+", "1." etc.
+_BULLET_RE = re.compile(r"^\s*(?:[*\-+]|\d+\.)\s+(.+?)\s*$")
+# A release-candidate marker: "v3.15.15.x", "v4.0", etc.
+_RELEASE_TAG_RE = re.compile(r"\bv\d+(?:\.\d+){2,}(?:[.\-][^\s)]+)?\b")
+# A path-shaped token. We accept "**/path", "path/**", "path/file.ext",
+# "config/config.yaml", "research/...", etc. The regex is intentionally
+# narrow — we want clear filenames, not prose.
+_PATH_RE = re.compile(
+    r"`([A-Za-z0-9_./*\-]+(?:\.[a-zA-Z0-9]+|/[A-Za-z0-9_*\-]+(?:/\*\*?)?))`"
+)
+
+
+def _read_text_safe(path: Path) -> tuple[str | None, str | None]:
+    """Read a file as utf-8. Returns (text, None) on success or
+    (None, reason) on any error. Never raises."""
+    if not path.exists():
+        return (None, "missing")
+    if not path.is_file():
+        return (None, "not_a_file")
+    try:
+        return (path.read_text(encoding="utf-8"), None)
+    except (OSError, UnicodeDecodeError) as e:
+        return (None, f"unreadable: {type(e).__name__}")
+
+
+def _expand_source(source: Path) -> list[Path]:
+    """Expand a source argument into a list of markdown files.
+
+    * file → [file] if .md/.markdown/.txt, else [].
+    * dir  → recursive scan for .md/.markdown/.txt.
+    * missing → [] (caller reports).
+    """
+    if not source.exists():
+        return []
+    if source.is_file():
+        if source.suffix.lower() in (".md", ".markdown", ".txt"):
+            return [source]
+        return []
+    if source.is_dir():
+        out: list[Path] = []
+        for p in sorted(source.rglob("*")):
+            if p.is_file() and p.suffix.lower() in (".md", ".markdown", ".txt"):
+                out.append(p)
+        return out
+    return []
+
+
+def _heading_segments(text: str) -> list[tuple[int, int, str, str]]:
+    """Split text into (level, line_idx, heading, body_text) tuples.
+
+    The first heading absorbs everything between it and the next
+    heading. Lines before the first heading are reported as a level-0
+    preamble segment with title ``"<preamble>"``.
+    """
+    lines = text.splitlines()
+    headings: list[tuple[int, int, str]] = []  # (level, line_idx, title)
+    for idx, line in enumerate(lines):
+        m = _HEADING_RE.match(line)
+        if m:
+            level = len(m.group(1))
+            title = m.group(2).strip()
+            headings.append((level, idx, title))
+    segments: list[tuple[int, int, str, str]] = []
+    if not headings:
+        if text.strip():
+            segments.append((0, 0, "<preamble>", text))
+        return segments
+    # Preamble before the first heading.
+    if headings[0][1] > 0:
+        segments.append((0, 0, "<preamble>", "\n".join(lines[: headings[0][1]])))
+    for i, (lvl, idx, title) in enumerate(headings):
+        end = headings[i + 1][1] if i + 1 < len(headings) else len(lines)
+        body = "\n".join(lines[idx + 1 : end])
+        segments.append((lvl, idx, title, body))
+    return segments
+
+
+# ---------------------------------------------------------------------------
+# Classifier
+# ---------------------------------------------------------------------------
+
+
+def _proposal_id(source: str, title: str, line_idx: int) -> str:
+    """Deterministic 8-char id based on source path + title + line."""
+    raw = f"{source}|{title}|{line_idx}".encode("utf-8")
+    return "p_" + hashlib.sha256(raw).hexdigest()[:8]
+
+
+def _extract_paths(body: str) -> list[str]:
+    """Extract file-path-shaped tokens from a body block. Backtick-
+    quoted only — prose-shaped sentences do not produce paths."""
+    return [m.group(1) for m in _PATH_RE.finditer(body)]
+
+
+def _classify_type(title: str, body: str, source: str) -> str:
+    """Pick a proposal type by inspecting the title + body + source.
+
+    First-match wins: most specific signal first. ``approval_required``
+    is the catch-all when nothing else fits but the segment looks like
+    a proposal; ``blocked_unknown`` is reserved for malformed input.
+    """
+    text = (title + "\n" + body).lower()
+    src = source.replace("\\", "/").lower()
+
+    # roadmap_diff — title explicitly says "diff", or body mentions
+    # an explicit diff / supersede phrase. This is intentionally
+    # narrower than the strategic-adoption check below: "Replace the
+    # roadmap with the new canonical plan" reads as adoption, not a
+    # diff, even though the verb "replace" is present.
+    title_lower = title.lower()
+    if "roadmap" in text and (
+        "diff" in title_lower
+        or "diff against" in text
+        or "supersede the" in text
+        or "diff with" in text
+    ):
+        return "roadmap_diff"
+
+    # roadmap_adoption — strategic-shape signals.
+    if any(t in text for t in STRATEGIC_ROADMAP_TOKENS):
+        return "roadmap_adoption"
+
+    # release_candidate — title contains a release tag.
+    if _RELEASE_TAG_RE.search(title):
+        return "release_candidate"
+
+    # governance_change — touches the governance surface.
+    if any(
+        t in text
+        for t in (
+            "codeowners",
+            "branch protection",
+            ".claude/",
+            "no_touch_paths",
+            "agent governance",
+            "release gate",
+            "autonomy ladder",
+        )
+    ):
+        return "governance_change"
+
+    # tooling_intake — explicit "tool" / "library" / "package" / "dep",
+    # or any well-known dev-tool / SaaS name (Datadog / Sentry /
+    # Segment / etc.) — those names imply a tool decision is being
+    # proposed even when the heading does not say "tool" verbatim.
+    tooling_general_tokens = (
+        "tooling",
+        "tool intake",
+        "add a tool",
+        "add tool",
+        "new dependency",
+        "new package",
+        "library upgrade",
+        "devdependency",
+        "devdependencies",
+        "dev-only",
+        "stdlib-only",
+        # Well-known dev tools (free / open source).
+        "vite-plugin",
+        "eslint",
+        "prettier",
+        "ruff",
+        "mypy",
+        "pre-commit",
+        "pytest",
+        "vitest",
+        # Well-known SaaS / hosted-service names — surface as tooling
+        # intake so the risk classifier can elevate them to HIGH.
+        "datadog",
+        "sentry",
+        "segment.io",
+        "google-analytics",
+        "googletagmanager",
+    )
+    if any(t in text for t in tooling_general_tokens):
+        return "tooling_intake"
+
+    # ci_hygiene
+    if any(
+        t in text
+        for t in (
+            "ci hygiene",
+            "github action",
+            "github actions",
+            "workflow",
+            "sha pin",
+            "dependabot",
+        )
+    ):
+        return "ci_hygiene"
+
+    # dependency_cleanup
+    if any(
+        t in text
+        for t in (
+            "dependency cleanup",
+            "deps cleanup",
+            "requirements bump",
+            "package-lock",
+        )
+    ):
+        return "dependency_cleanup"
+
+    # observability_gap
+    if any(
+        t in text for t in ("observability", "logging", "metrics", "audit log")
+    ):
+        return "observability_gap"
+
+    # testing_gap
+    if any(
+        t in text
+        for t in (
+            "testing gap",
+            "missing test",
+            "coverage gap",
+            "no tests",
+            "add tests",
+            "pytest",
+            "vitest",
+        )
+    ):
+        return "testing_gap"
+
+    # ux_gap
+    if any(
+        t in text for t in ("ux", "user experience", "ui gap", "frontend gap")
+    ):
+        return "ux_gap"
+
+    # spillovers/backlog default to approval_required.
+    if "spillover" in src or "backlog" in src:
+        return "approval_required"
+
+    return "approval_required"
+
+
+def _classify_risk(
+    proposal_type: str,
+    title: str,
+    body: str,
+    affected_files: list[str],
+) -> tuple[str, str]:
+    """Return ``(risk_class, reason)``.
+
+    Decision order — first-match wins:
+      1. Affected files touch a frozen contract / no-touch path → HIGH.
+      2. Affected files touch a live-trading path             → HIGH.
+      3. Strategic roadmap adoption                           → HIGH.
+      4. Governance change                                    → HIGH.
+      5. Tooling intake mentions secrets / signup / telemetry → HIGH.
+      6. Tooling intake explicitly free / dev-only            → LOW.
+      7. CI hygiene / dependency cleanup                      → MEDIUM.
+      8. Observability / testing / UX / release_candidate     → MEDIUM.
+      9. Anything else                                        → MEDIUM (conservative).
+    """
+    touched, hit = diff_touches_protected(affected_files)
+    if touched:
+        return (RISK_HIGH, f"affected_files touches protected path: {hit}")
+
+    touched_l, hit_l = diff_touches_live_or_trading(affected_files)
+    if touched_l:
+        return (
+            RISK_HIGH,
+            f"affected_files touches live/trading path: {hit_l}",
+        )
+
+    if proposal_type == "roadmap_adoption":
+        return (
+            RISK_HIGH,
+            "strategic roadmap adoption is HIGH and needs_human by default",
+        )
+
+    if proposal_type == "governance_change":
+        return (RISK_HIGH, "governance changes require human approval")
+
+    text = (title + "\n" + body).lower()
+
+    if proposal_type == "tooling_intake":
+        # LOW signals win first: "no telemetry" / "no signup" are
+        # explicit negations and must not be re-classified as HIGH by
+        # a substring match on the negated word. Same for explicit
+        # license markers ("MIT license", "Apache 2.0 license", etc.).
+        if any(t in text for t in TOOLING_LOW_TOKENS):
+            return (RISK_LOW, "tooling intake is free / dev-only / no telemetry")
+        # HIGH signals only count when they are NOT negated. We strip
+        # any "no <token>" / "no-<token>" occurrence before checking,
+        # so "no telemetry" no longer triggers the "telemetry" rule.
+        # Note the dash position in the class: leading "-" avoids the
+        # \w-space "bad range" parse error.
+        scrubbed = re.sub(r"\bno[- ]\w[-\w ]*", " ", text)
+        if any(t in scrubbed for t in TOOLING_HIGH_TOKENS):
+            return (
+                RISK_HIGH,
+                "tooling intake mentions secrets / signup / telemetry / hosted service",
+            )
+        return (
+            RISK_MEDIUM,
+            "tooling intake without explicit free / dev-only marker",
+        )
+
+    if proposal_type in ("ci_hygiene", "dependency_cleanup"):
+        return (RISK_MEDIUM, "CI hygiene / dependency cleanup is MEDIUM")
+
+    if proposal_type == "release_candidate":
+        return (RISK_MEDIUM, "release candidate requires scoped review")
+
+    if proposal_type in ("observability_gap", "testing_gap", "ux_gap"):
+        return (RISK_MEDIUM, f"{proposal_type} is MEDIUM by default")
+
+    if proposal_type == "blocked_unknown":
+        # Caller decides via status; risk stays MEDIUM so it does not
+        # short-circuit the planner.
+        return (RISK_MEDIUM, "blocked_unknown classified MEDIUM conservatively")
+
+    return (RISK_MEDIUM, "default classification")
+
+
+def _decide_status(
+    proposal_type: str,
+    risk_class: str,
+    affected_files: list[str],
+) -> tuple[str, str | None]:
+    """Pick a status + optional blocked_reason.
+
+    Decision order:
+      * frozen / protected paths → blocked / blocked_protected_path.
+      * live trading             → blocked / blocked_high_risk.
+      * HIGH risk                → needs_human (blocked from auto).
+      * blocked_unknown type     → blocked / blocked_unknown.
+      * everything else          → proposed (review-ready, not adopted).
+    """
+    touched_p, hit_p = diff_touches_protected(affected_files)
+    if touched_p:
+        return (STATUS_BLOCKED, f"blocked_protected_path: {hit_p}")
+    touched_l, hit_l = diff_touches_live_or_trading(affected_files)
+    if touched_l:
+        return (STATUS_BLOCKED, f"blocked_high_risk: live/trading path: {hit_l}")
+    if proposal_type == "blocked_unknown":
+        return (STATUS_BLOCKED, "blocked_unknown: unparseable source")
+    if risk_class == RISK_HIGH:
+        return (STATUS_NEEDS_HUMAN, None)
+    return (STATUS_PROPOSED, None)
+
+
+def _allowed_actions(
+    proposal_type: str, risk_class: str
+) -> tuple[list[str], list[str]]:
+    """Per-proposal allowlists. The values are advisory — the actual
+    enforcement lives in the agent + hook layers. They are surfaced so
+    the operator can review at-a-glance what an approval would unlock.
+    """
+    forbidden = [
+        "git push origin main",
+        "git push --force",
+        "git push --force-with-lease",
+        "gh pr merge --admin",
+        "edit .claude/**",
+        "edit frozen contracts",
+        "edit automation/live_gate.py",
+        "modify VERSION",
+    ]
+    allowed: list[str] = []
+    if proposal_type == "release_candidate":
+        allowed.extend(
+            [
+                "open feature branch",
+                "open PR",
+                "run governance_lint",
+                "run smoke + unit tests",
+            ]
+        )
+    elif proposal_type == "tooling_intake" and risk_class == RISK_LOW:
+        allowed.extend(
+            [
+                "add devDependency to frontend/package.json",
+                "add Python dev dep to requirements-dev.txt",
+                "add governance ADR draft",
+            ]
+        )
+    elif proposal_type in ("ci_hygiene", "dependency_cleanup"):
+        allowed.extend(
+            [
+                "edit .github/workflows/** (ci-guardian only)",
+                "comment @dependabot rebase",
+            ]
+        )
+    elif proposal_type in ("observability_gap", "testing_gap"):
+        allowed.extend(["add reporting/* read-only module", "add tests/**"])
+    return allowed, forbidden
+
+
+def _required_tests(proposal_type: str) -> list[str]:
+    base = ["scripts/governance_lint.py", "tests/smoke", "frozen-hash check"]
+    if proposal_type == "release_candidate":
+        return base + ["tests/unit", "frontend tests if frontend/** changed"]
+    if proposal_type == "tooling_intake":
+        return base + [
+            "tests/unit covering the new tool surface",
+            "explicit data-egress assessment in the runbook",
+        ]
+    if proposal_type in ("ci_hygiene", "dependency_cleanup"):
+        return base + [
+            "all required GitHub checks green pre-merge",
+            "no SHA pin downgrades",
+        ]
+    if proposal_type in ("observability_gap", "testing_gap"):
+        return base + ["tests/unit"]
+    return base
+
+
+def _suggested_branch(proposal_type: str, title: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")[:48]
+    if not slug:
+        slug = "proposal"
+    prefix = (
+        "feat"
+        if proposal_type in ("release_candidate", "tooling_intake", "ux_gap")
+        else "fix"
+    )
+    return f"{prefix}/{proposal_type.replace('_', '-')}-{slug}"
+
+
+# ---------------------------------------------------------------------------
+# Build proposals from a parsed source
+# ---------------------------------------------------------------------------
+
+
+def _build_proposal_from_segment(
+    *,
+    source: str,
+    level: int,
+    line_idx: int,
+    title: str,
+    body: str,
+) -> dict[str, Any]:
+    affected_files = _extract_paths(body)
+    proposal_type = _classify_type(title, body, source)
+    risk_class, risk_reason = _classify_risk(
+        proposal_type, title, body, affected_files
+    )
+    status, blocked_reason = _decide_status(
+        proposal_type, risk_class, affected_files
+    )
+    allowed, forbidden = _allowed_actions(proposal_type, risk_class)
+    pid = _proposal_id(source, title, line_idx)
+    return {
+        "proposal_id": pid,
+        "created_at": _utcnow(),
+        "source": source,
+        "source_type": "markdown_heading" if level >= 1 else "markdown_preamble",
+        "title": title.strip(),
+        "summary": _summarize(body),
+        "rationale": _summarize(body, max_chars=600),
+        "evidence": {
+            "heading_level": level,
+            "line_idx": line_idx,
+            "body_chars": len(body),
+        },
+        "affected_files": affected_files,
+        "risk_class": risk_class,
+        "risk_reason": risk_reason,
+        "approval_required": (
+            status in (STATUS_NEEDS_HUMAN, STATUS_BLOCKED)
+            or risk_class == RISK_HIGH
+            or proposal_type == "approval_required"
+        ),
+        "blocked_reason": blocked_reason,
+        "proposal_type": proposal_type,
+        "allowed_actions": allowed,
+        "forbidden_actions": forbidden,
+        "required_tests": _required_tests(proposal_type),
+        "suggested_branch_name": _suggested_branch(proposal_type, title),
+        "suggested_release_id": (
+            _RELEASE_TAG_RE.search(title).group(0)
+            if _RELEASE_TAG_RE.search(title)
+            else None
+        ),
+        "status": status,
+        "parent_proposal_id": None,
+        "dependencies": [],
+        "operator_notes": "",
+    }
+
+
+def _summarize(body: str, *, max_chars: int = 240) -> str:
+    """Extract a short summary from a markdown body. Prefer the first
+    non-empty bullet or sentence; fall back to the first non-empty
+    line; truncate to ``max_chars``."""
+    body_stripped = body.strip()
+    if not body_stripped:
+        return ""
+    for line in body_stripped.splitlines():
+        m = _BULLET_RE.match(line)
+        if m:
+            return _trim(m.group(1), max_chars)
+    # First non-empty sentence.
+    for sentence in re.split(r"(?<=[.!?])\s+", body_stripped):
+        if sentence.strip():
+            return _trim(sentence.strip(), max_chars)
+    return _trim(body_stripped.splitlines()[0], max_chars)
+
+
+def _trim(s: str, max_chars: int) -> str:
+    s = s.strip()
+    if len(s) <= max_chars:
+        return s
+    return s[: max_chars - 1].rstrip() + "…"
+
+
+# ---------------------------------------------------------------------------
+# Top-level snapshot
+# ---------------------------------------------------------------------------
+
+
+def _resolve_source_paths(
+    source: str | None,
+) -> tuple[list[Path], list[dict[str, str]]]:
+    """Resolve the operator-supplied source(s) into a list of files.
+
+    Returns ``(files, missing_reports)`` where ``missing_reports`` lists
+    requested roots that did not exist.
+    """
+    files: list[Path] = []
+    missing: list[dict[str, str]] = []
+    if source is None:
+        roots = [REPO_ROOT / r for r in DEFAULT_SOURCE_ROOTS]
+    else:
+        roots = [Path(source) if Path(source).is_absolute() else REPO_ROOT / source]
+    for root in roots:
+        expanded = _expand_source(root)
+        if not expanded and not root.exists():
+            missing.append(
+                {
+                    "path": _rel(root),
+                    "reason": "missing",
+                }
+            )
+        files.extend(expanded)
+    return files, missing
+
+
+def collect_snapshot(
+    *,
+    mode: str = "dry-run",
+    source: str | None = None,
+    proposals_override: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build the full snapshot. ``proposals_override`` is for tests."""
+    if mode != "dry-run":
+        # Hard guarantee: this release exposes only dry-run. Refuse
+        # any other mode at the boundary so we never write outside
+        # the gitignored digest.
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "report_kind": "proposal_queue_digest",
+            "module_version": MODULE_VERSION,
+            "generated_at_utc": _utcnow(),
+            "mode": mode,
+            "status": "refused",
+            "reason": (
+                f"mode {mode!r} is not allowed in {MODULE_VERSION}; "
+                "only dry-run is supported. The approval inbox + execute path "
+                "land in v3.15.15.20 / v3.15.15.21."
+            ),
+            "sources": [],
+            "missing_sources": [],
+            "proposals": [],
+            "final_recommendation": "needs_human",
+        }
+
+    if proposals_override is not None:
+        proposals = proposals_override
+        sources_used: list[str] = []
+        missing: list[dict[str, str]] = []
+    else:
+        files, missing = _resolve_source_paths(source)
+        sources_used = [_rel(f) for f in files]
+        proposals = _build_all_proposals(files)
+
+    counts = _proposal_counts(proposals)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": "proposal_queue_digest",
+        "module_version": MODULE_VERSION,
+        "generated_at_utc": _utcnow(),
+        "mode": mode,
+        "sources": sources_used,
+        "missing_sources": missing,
+        "proposals": proposals,
+        "counts": counts,
+        "final_recommendation": _final_recommendation(counts, proposals),
+    }
+
+
+def _build_all_proposals(files: list[Path]) -> list[dict[str, Any]]:
+    proposals: list[dict[str, Any]] = []
+    for f in files:
+        text, err = _read_text_safe(f)
+        if text is None:
+            # Single blocked_unknown row representing the bad source.
+            proposals.append(
+                _build_proposal_from_segment(
+                    source=_rel(f),
+                    level=0,
+                    line_idx=0,
+                    title="<unparseable source>",
+                    body=err or "",
+                )
+                | {"proposal_type": "blocked_unknown", "status": STATUS_BLOCKED}
+            )
+            continue
+        if not text.strip():
+            # Empty file → no proposals (not a blocker).
+            continue
+        segments = _heading_segments(text)
+        for level, line_idx, title, body in segments:
+            # Skip the file-level title heading on a doc that consists
+            # only of a single H1 + index (very common in docs/).
+            if level == 1 and not body.strip():
+                continue
+            # Only H1/H2/H3 segments produce proposals; H4+ are sub-
+            # sections and would dilute the queue.
+            if level == 0 or level > 3:
+                # Preamble + deep sub-sections are surfaced as a single
+                # row only if they are non-empty AND look like a
+                # proposal heading. We elide deep sub-headings.
+                if level > 3:
+                    continue
+            proposals.append(
+                _build_proposal_from_segment(
+                    source=_rel(f),
+                    level=level,
+                    line_idx=line_idx,
+                    title=title,
+                    body=body,
+                )
+            )
+    return proposals
+
+
+def _proposal_counts(proposals: list[dict[str, Any]]) -> dict[str, int]:
+    counts: dict[str, int] = {
+        "total": len(proposals),
+        "by_status": {},
+        "by_risk": {},
+        "by_type": {},
+    }
+    for p in proposals:
+        status = p.get("status", "unknown")
+        risk = p.get("risk_class", "UNKNOWN")
+        ptype = p.get("proposal_type", "unknown")
+        counts["by_status"][status] = counts["by_status"].get(status, 0) + 1
+        counts["by_risk"][risk] = counts["by_risk"].get(risk, 0) + 1
+        counts["by_type"][ptype] = counts["by_type"].get(ptype, 0) + 1
+    return counts
+
+
+def _final_recommendation(
+    counts: dict[str, int], proposals: list[dict[str, Any]]
+) -> str:
+    if counts["total"] == 0:
+        return "no_proposals"
+    proposed = counts["by_status"].get(STATUS_PROPOSED, 0)
+    needs_human = counts["by_status"].get(STATUS_NEEDS_HUMAN, 0)
+    blocked = counts["by_status"].get(STATUS_BLOCKED, 0)
+    if proposed > 0 and needs_human == 0 and blocked == 0:
+        return f"review_{proposed}_proposed_items"
+    if needs_human > 0:
+        return f"needs_human_on_{needs_human}_items"
+    if blocked > 0:
+        return f"blocked_on_{blocked}_items"
+    return "needs_human"
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+
+def write_outputs(snapshot: dict[str, Any]) -> dict[str, str]:
+    DIGEST_DIR_JSON.mkdir(parents=True, exist_ok=True)
+    ts = snapshot["generated_at_utc"].replace(":", "-")
+    json_now = DIGEST_DIR_JSON / f"{ts}.json"
+    json_latest = DIGEST_DIR_JSON / "latest.json"
+    payload = json.dumps(snapshot, sort_keys=True, indent=2)
+    json_now.write_text(payload, encoding="utf-8")
+    json_latest.write_text(payload, encoding="utf-8")
+    return {
+        "json_now": _rel(json_now),
+        "json_latest": _rel(json_latest),
+    }
+
+
+def _rel(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(REPO_ROOT.resolve())).replace(
+            "\\", "/"
+        )
+    except ValueError:
+        return str(path).replace("\\", "/")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m reporting.proposal_queue",
+        description=(
+            "Roadmap / proposal queue (read-only intake). Reads "
+            "markdown / text source(s) and emits a deterministic queue "
+            "of review-ready proposals. NEVER triggers execution. "
+            "Strategic roadmap adoption is HIGH and needs_human by "
+            "default; v3.15.15.19 only supports --mode dry-run."
+        ),
+    )
+    p.add_argument(
+        "--mode",
+        choices=["dry-run"],
+        default="dry-run",
+        help="Operating mode (only dry-run is supported in this release).",
+    )
+    p.add_argument(
+        "--source",
+        type=str,
+        default=None,
+        help=(
+            "Source path (file or directory). Defaults to scanning "
+            "docs/roadmap, docs/backlog, docs/spillovers."
+        ),
+    )
+    p.add_argument(
+        "--no-write",
+        action="store_true",
+        help="Do not persist the JSON digest (stdout only).",
+    )
+    p.add_argument(
+        "--indent",
+        type=int,
+        default=2,
+        help="JSON indent (0 for compact).",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    snap = collect_snapshot(mode=args.mode, source=args.source)
+    if not args.no_write and snap.get("status") != "refused":
+        write_outputs(snap)
+    indent = args.indent if args.indent and args.indent > 0 else None
+    json.dump(snap, sys.stdout, indent=indent, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/unit/test_dashboard_api_proposal_queue.py
+++ b/tests/unit/test_dashboard_api_proposal_queue.py
@@ -1,0 +1,145 @@
+"""Unit tests for ``dashboard.api_proposal_queue``.
+
+Verifies the same hard guarantees as ``api_agent_control``:
+
+* GET only (POST/PUT/PATCH/DELETE return 405).
+* Missing artifact → ``not_available``.
+* Malformed artifact → ``not_available``.
+* Non-object artifact → ``not_available``.
+* Valid artifact passes through.
+* Secret-redaction guard refuses leaks.
+* No subprocess / no ``gh`` / no ``git`` token in the module source.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from flask import Flask
+
+from dashboard import api_proposal_queue as ac
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+@pytest.fixture
+def app(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Flask:
+    monkeypatch.setattr(ac, "LOGS_DIR", tmp_path / "logs")
+    monkeypatch.setattr(
+        ac,
+        "PROPOSAL_QUEUE_LATEST",
+        tmp_path / "logs" / "proposal_queue" / "latest.json",
+    )
+    flask_app = Flask(__name__)
+    ac.register_proposal_queue_routes(flask_app)
+    return flask_app
+
+
+@pytest.fixture
+def client(app: Flask):
+    return app.test_client()
+
+
+_PATH = "/api/agent-control/proposals"
+
+
+def test_get_returns_200(client) -> None:
+    resp = client.get(_PATH)
+    assert resp.status_code == 200
+    assert resp.is_json
+
+
+@pytest.mark.parametrize("verb", ["POST", "PUT", "PATCH", "DELETE"])
+def test_mutation_verbs_are_rejected(client, verb: str) -> None:
+    resp = client.open(_PATH, method=verb)
+    assert resp.status_code == 405
+
+
+def test_only_proposals_route_registered(app: Flask) -> None:
+    rules = [r for r in app.url_map.iter_rules() if r.rule.startswith("/api/agent-control/")]
+    paths = sorted(r.rule for r in rules)
+    assert paths == [_PATH]
+    for r in rules:
+        verbs = set(r.methods or ()) - {"HEAD", "OPTIONS"}
+        assert verbs == {"GET"}
+
+
+def test_missing_artifact_yields_not_available(client) -> None:
+    body = client.get(_PATH).get_json()
+    assert body["status"] == "not_available"
+    assert body["reason"] == "missing"
+    assert body["artifact_path"] == "logs/proposal_queue/latest.json"
+
+
+def test_malformed_artifact_yields_not_available(
+    client, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    p = tmp_path / "logs" / "proposal_queue" / "latest.json"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("{ not json", encoding="utf-8")
+    monkeypatch.setattr(ac, "PROPOSAL_QUEUE_LATEST", p)
+    body = client.get(_PATH).get_json()
+    assert body["status"] == "not_available"
+    assert body["reason"].startswith("malformed:")
+
+
+def test_non_object_artifact_yields_not_available(
+    client, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    p = tmp_path / "logs" / "proposal_queue" / "latest.json"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("[1, 2, 3]", encoding="utf-8")
+    monkeypatch.setattr(ac, "PROPOSAL_QUEUE_LATEST", p)
+    body = client.get(_PATH).get_json()
+    assert body["status"] == "not_available"
+    assert "not_an_object" in body["reason"]
+
+
+def test_valid_artifact_passes_through(
+    client, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    p = tmp_path / "logs" / "proposal_queue" / "latest.json"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema_version": 1,
+        "report_kind": "proposal_queue_digest",
+        "module_version": "v3.15.15.19",
+        "proposals": [],
+        "final_recommendation": "no_proposals",
+    }
+    p.write_text(json.dumps(payload), encoding="utf-8")
+    monkeypatch.setattr(ac, "PROPOSAL_QUEUE_LATEST", p)
+    body = client.get(_PATH).get_json()
+    assert body["status"] == "ok"
+    assert body["data"]["final_recommendation"] == "no_proposals"
+
+
+def test_credential_string_in_artifact_is_refused(
+    client, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    p = tmp_path / "logs" / "proposal_queue" / "latest.json"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema_version": 1,
+        "report_kind": "proposal_queue_digest",
+        "evil_field": "config/config.yaml",
+    }
+    p.write_text(json.dumps(payload), encoding="utf-8")
+    monkeypatch.setattr(ac, "PROPOSAL_QUEUE_LATEST", p)
+    resp = client.get(_PATH)
+    assert resp.status_code == 500
+
+
+def test_no_subprocess_imports_in_module() -> None:
+    src = Path(ac.__file__).read_text(encoding="utf-8")
+    assert "import subprocess" not in src
+    assert "from subprocess" not in src
+
+
+def test_no_gh_or_git_invocation_in_module() -> None:
+    src = Path(ac.__file__).read_text(encoding="utf-8")
+    forbidden = ('"gh"', "'gh'", '"git"', "'git'", "Popen")
+    for token in forbidden:
+        assert token not in src, f"forbidden token: {token!r}"

--- a/tests/unit/test_proposal_queue.py
+++ b/tests/unit/test_proposal_queue.py
@@ -1,0 +1,470 @@
+"""Unit tests for ``reporting.proposal_queue``.
+
+Properties enforced (verbatim from the v3.15.15.19 brief):
+
+* large roadmap input produces proposals, NOT execution;
+* strategic roadmap adoption is HIGH and ``needs_human``;
+* live trading / broker / capital scope is ``blocked_high_risk``;
+* free dev-only tooling proposal can be LOW/MEDIUM if no secrets /
+  accounts / telemetry;
+* hosted / telemetry / token tool proposal is HIGH and ``needs_human``;
+* protected paths produce HIGH / ``blocked_protected_path``;
+* unknown source produces ``blocked_unknown`` / ``not_available``;
+* malformed input does not crash;
+* dry-run is the only allowed mode in this release;
+* proposal_id is deterministic for the same input;
+* JSON snapshot carries every required top-level key.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from reporting import proposal_queue as pq
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _file_sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _write(path: Path, body: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Risk classifier
+# ---------------------------------------------------------------------------
+
+
+def test_strategic_roadmap_adoption_is_high_and_needs_human() -> None:
+    risk, reason = pq._classify_risk(
+        "roadmap_adoption",
+        "Adopt new canonical roadmap v4",
+        "Replace the canonical roadmap with the v4 plan.",
+        [],
+    )
+    assert risk == pq.RISK_HIGH
+    assert "strategic" in reason.lower()
+    status, blocked_reason = pq._decide_status("roadmap_adoption", risk, [])
+    assert status == pq.STATUS_NEEDS_HUMAN
+    assert blocked_reason is None
+
+
+def test_live_trading_path_is_blocked_high_risk() -> None:
+    files = ["agent/execution/live/broker.py", "automation/live_gate.py"]
+    risk, reason = pq._classify_risk(
+        "release_candidate",
+        "v3.15.15.20 — live broker",
+        "Wire live broker.",
+        files,
+    )
+    assert risk == pq.RISK_HIGH
+    assert "live" in reason.lower()
+    status, blocked_reason = pq._decide_status("release_candidate", risk, files)
+    assert status == pq.STATUS_BLOCKED
+    assert "live" in (blocked_reason or "").lower()
+
+
+def test_protected_path_is_blocked_protected_path() -> None:
+    files = [".claude/hooks/audit_emit.py"]
+    risk, reason = pq._classify_risk(
+        "governance_change", "Replace hook", "Replace.", files
+    )
+    assert risk == pq.RISK_HIGH
+    assert "protected" in reason.lower()
+    status, blocked_reason = pq._decide_status("governance_change", risk, files)
+    assert status == pq.STATUS_BLOCKED
+    assert "blocked_protected_path" in (blocked_reason or "")
+
+
+def test_frozen_contract_path_is_blocked_protected_path() -> None:
+    files = ["research/research_latest.json"]
+    risk, _ = pq._classify_risk(
+        "release_candidate", "Touch frozen", "x.", files
+    )
+    assert risk == pq.RISK_HIGH
+    status, blocked_reason = pq._decide_status("release_candidate", risk, files)
+    assert status == pq.STATUS_BLOCKED
+    assert "blocked_protected_path" in (blocked_reason or "")
+
+
+def test_governance_change_is_high_and_needs_human() -> None:
+    risk, _ = pq._classify_risk(
+        "governance_change",
+        "Edit branch protection",
+        "Change required-status rules.",
+        [],
+    )
+    assert risk == pq.RISK_HIGH
+    status, _ = pq._decide_status("governance_change", risk, [])
+    assert status == pq.STATUS_NEEDS_HUMAN
+
+
+# ---------------------------------------------------------------------------
+# Tooling-intake policy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "Add Datadog APM. Requires an API key.",
+        "Wire Sentry; needs auth token.",
+        "Use the hosted Segment.io ingestion endpoint with telemetry.",
+        "Add a paid plan for the SaaS observability service.",
+        "OAuth signup to integrate the third-party dashboard.",
+    ],
+)
+def test_tooling_with_secrets_or_telemetry_is_high(body: str) -> None:
+    risk, reason = pq._classify_risk(
+        "tooling_intake", "Tooling intake — risky", body, []
+    )
+    assert risk == pq.RISK_HIGH
+    assert "secrets" in reason.lower() or "telemetry" in reason.lower()
+    status, _ = pq._decide_status("tooling_intake", risk, [])
+    assert status == pq.STATUS_NEEDS_HUMAN
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "Add `vite-plugin-pwa`, MIT license, dev-only, no telemetry.",
+        "Bring in an open-source stdlib-only helper, no signup required.",
+        "Apache 2.0 dev dependency, no-telemetry.",
+    ],
+)
+def test_tooling_marked_free_dev_only_is_low(body: str) -> None:
+    risk, reason = pq._classify_risk(
+        "tooling_intake", "Add a free dev-only tool", body, []
+    )
+    assert risk == pq.RISK_LOW
+    assert "dev-only" in reason.lower() or "free" in reason.lower()
+    status, _ = pq._decide_status("tooling_intake", risk, [])
+    assert status == pq.STATUS_PROPOSED
+
+
+def test_tooling_without_explicit_marker_is_medium() -> None:
+    risk, _ = pq._classify_risk(
+        "tooling_intake",
+        "Add a tool",
+        "Some package that improves devx.",
+        [],
+    )
+    assert risk == pq.RISK_MEDIUM
+
+
+# ---------------------------------------------------------------------------
+# Proposal type classifier
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "title,body,expected",
+    [
+        (
+            "v3.15.15.30 — frontend refactor",
+            "Refactor.",
+            "release_candidate",
+        ),
+        (
+            "Adopt the new canonical roadmap",
+            "Strategic roadmap adoption.",
+            "roadmap_adoption",
+        ),
+        (
+            "Roadmap diff vs v3 plan",
+            "Diff against the existing canonical roadmap.",
+            "roadmap_diff",
+        ),
+        (
+            "Branch protection update",
+            "Change CODEOWNERS.",
+            "governance_change",
+        ),
+        (
+            "Add ruff",
+            "Add ruff as a tool. dev-only.",
+            "tooling_intake",
+        ),
+        (
+            "GitHub Actions SHA pin sweep",
+            "Update workflow pins.",
+            "ci_hygiene",
+        ),
+        (
+            "Requirements bump",
+            "dependency cleanup of requirements.txt.",
+            "dependency_cleanup",
+        ),
+        (
+            "More logging",
+            "observability gap in the workloop.",
+            "observability_gap",
+        ),
+        (
+            "Missing tests for X",
+            "testing gap; no tests cover Y.",
+            "testing_gap",
+        ),
+        (
+            "UX gap on mobile",
+            "frontend gap on the dashboard.",
+            "ux_gap",
+        ),
+    ],
+)
+def test_classify_type(title: str, body: str, expected: str) -> None:
+    assert pq._classify_type(title, body, "docs/roadmap/sample.md") == expected
+
+
+# ---------------------------------------------------------------------------
+# Snapshot — happy path on synthetic markdown
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_pq(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Path:
+    monkeypatch.setattr(pq, "DIGEST_DIR_JSON", tmp_path / "dq")
+    return tmp_path
+
+
+def test_dry_run_default_emits_required_top_level_fields(isolated_pq: Path) -> None:
+    snap = pq.collect_snapshot(
+        mode="dry-run",
+        source=None,
+        proposals_override=[],  # skip filesystem walk
+    )
+    required = {
+        "schema_version",
+        "report_kind",
+        "module_version",
+        "generated_at_utc",
+        "mode",
+        "sources",
+        "missing_sources",
+        "proposals",
+        "counts",
+        "final_recommendation",
+    }
+    assert required.issubset(snap.keys())
+    assert snap["schema_version"] == pq.SCHEMA_VERSION
+    assert snap["mode"] == "dry-run"
+    assert snap["report_kind"] == "proposal_queue_digest"
+    assert snap["final_recommendation"] == "no_proposals"
+
+
+def test_non_dry_run_mode_is_refused() -> None:
+    """Hard guarantee: only dry-run is allowed in v3.15.15.19."""
+    snap = pq.collect_snapshot(mode="execute-safe")
+    assert snap.get("status") == "refused"
+    assert "dry-run" in snap.get("reason", "")
+    assert snap["proposals"] == []
+
+
+def test_strategic_roadmap_doc_yields_high_needs_human(
+    isolated_pq: Path,
+) -> None:
+    src = isolated_pq / "roadmap_v4.md"
+    src.write_text(
+        "# Adopt canonical roadmap v4\n\n"
+        "Replace the existing roadmap with this new canonical roadmap.\n",
+        encoding="utf-8",
+    )
+    snap = pq.collect_snapshot(mode="dry-run", source=str(src))
+    assert any(
+        p["risk_class"] == "HIGH" and p["status"] == "needs_human"
+        for p in snap["proposals"]
+    ), snap["proposals"]
+
+
+def test_release_candidate_with_protected_path_is_blocked(
+    isolated_pq: Path,
+) -> None:
+    src = isolated_pq / "rc.md"
+    src.write_text(
+        "# v3.15.15.20 — touch live gate\n\n"
+        "Modify `automation/live_gate.py` to wire the broker.\n",
+        encoding="utf-8",
+    )
+    snap = pq.collect_snapshot(mode="dry-run", source=str(src))
+    rows = snap["proposals"]
+    assert rows, "expected at least one proposal"
+    blocking = [r for r in rows if r["status"] == "blocked"]
+    assert blocking, "expected the live-gate row to be blocked"
+    reasons = " ".join((r["blocked_reason"] or "") for r in blocking)
+    assert "live" in reasons or "protected" in reasons
+
+
+def test_tooling_intake_marked_secrets_is_high(isolated_pq: Path) -> None:
+    src = isolated_pq / "tooling.md"
+    src.write_text(
+        "# Add Datadog\n\nWire Datadog APM. Requires an API key.\n",
+        encoding="utf-8",
+    )
+    snap = pq.collect_snapshot(mode="dry-run", source=str(src))
+    assert any(
+        p["risk_class"] == "HIGH" and p["proposal_type"] == "tooling_intake"
+        for p in snap["proposals"]
+    )
+
+
+def test_tooling_intake_marked_free_is_low(isolated_pq: Path) -> None:
+    src = isolated_pq / "free_tool.md"
+    src.write_text(
+        "# Add ruff\n\nMIT license, dev-only, no telemetry.\n",
+        encoding="utf-8",
+    )
+    snap = pq.collect_snapshot(mode="dry-run", source=str(src))
+    rows = [p for p in snap["proposals"] if p["proposal_type"] == "tooling_intake"]
+    assert rows, snap
+    assert all(p["risk_class"] == "LOW" for p in rows)
+    assert all(p["status"] == "proposed" for p in rows)
+
+
+def test_unknown_source_yields_blocked_unknown_or_missing(
+    isolated_pq: Path,
+) -> None:
+    snap = pq.collect_snapshot(
+        mode="dry-run", source=str(isolated_pq / "does_not_exist.md")
+    )
+    # Either blocked_unknown row OR missing_sources entry — both are
+    # acceptable representations of "the operator pointed at nothing".
+    blocked_rows = [p for p in snap["proposals"] if p["status"] == "blocked"]
+    has_blocked = any(
+        (r.get("blocked_reason") or "").startswith("blocked_unknown")
+        or r.get("proposal_type") == "blocked_unknown"
+        for r in blocked_rows
+    )
+    has_missing = bool(snap["missing_sources"])
+    assert has_blocked or has_missing
+
+
+def test_malformed_input_does_not_crash(isolated_pq: Path) -> None:
+    src = isolated_pq / "garbled.md"
+    # Non-utf8 content via raw bytes that decode-error on utf-8.
+    src.write_bytes(b"\xff\xfe\xff\xfe# title\nbroken")
+    snap = pq.collect_snapshot(mode="dry-run", source=str(src))
+    # Either a blocked_unknown row OR an empty proposals list — both
+    # are valid; the requirement is that we did not crash.
+    assert "proposals" in snap
+
+
+def test_proposal_id_is_deterministic(isolated_pq: Path) -> None:
+    src = isolated_pq / "x.md"
+    src.write_text(
+        "# v3.15.15.42 — repeatable\n\nThis is a release candidate.\n",
+        encoding="utf-8",
+    )
+    snap1 = pq.collect_snapshot(mode="dry-run", source=str(src))
+    snap2 = pq.collect_snapshot(mode="dry-run", source=str(src))
+    ids1 = sorted(p["proposal_id"] for p in snap1["proposals"])
+    ids2 = sorted(p["proposal_id"] for p in snap2["proposals"])
+    assert ids1 == ids2 and ids1
+
+
+def test_counts_aggregate_correctly(isolated_pq: Path) -> None:
+    src = isolated_pq / "mix.md"
+    src.write_text(
+        (
+            "# Adopt canonical roadmap v4\n\nNew roadmap.\n\n"
+            "# Add ruff\n\nMIT license, dev-only, no telemetry.\n\n"
+            "# CI hygiene\n\nGitHub Actions SHA pin sweep.\n"
+        ),
+        encoding="utf-8",
+    )
+    snap = pq.collect_snapshot(mode="dry-run", source=str(src))
+    counts = snap["counts"]
+    assert counts["total"] == len(snap["proposals"])
+    # Adoption is HIGH; ruff (free) is LOW; CI hygiene is MEDIUM.
+    assert counts["by_risk"].get("HIGH", 0) >= 1
+    assert counts["by_risk"].get("LOW", 0) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Frozen contract integrity
+# ---------------------------------------------------------------------------
+
+
+def test_frozen_contracts_byte_identical_around_snapshot(
+    isolated_pq: Path,
+) -> None:
+    """The intake run must not mutate frozen contract files."""
+    paths = [
+        REPO_ROOT / "research" / "research_latest.json",
+        REPO_ROOT / "research" / "strategy_matrix.csv",
+    ]
+    before = {p.name: _file_sha256(p) for p in paths if p.exists()}
+    pq.collect_snapshot(mode="dry-run", source=str(isolated_pq))
+    after = {p.name: _file_sha256(p) for p in paths if p.exists()}
+    assert before == after
+
+
+# ---------------------------------------------------------------------------
+# CLI — stdout + persistence
+# ---------------------------------------------------------------------------
+
+
+def test_cli_dry_run_default_writes_no_files_with_no_write(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(pq, "DIGEST_DIR_JSON", tmp_path / "dq")
+    rc = pq.main(["--mode", "dry-run", "--no-write", "--source", str(tmp_path)])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["mode"] == "dry-run"
+    assert not (tmp_path / "dq").exists()
+
+
+def test_cli_dry_run_persists_to_logs_dir(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(pq, "DIGEST_DIR_JSON", tmp_path / "dq")
+    src = tmp_path / "x.md"
+    src.write_text("# h1\n\nbody\n", encoding="utf-8")
+    rc = pq.main(["--mode", "dry-run", "--source", str(src)])
+    assert rc == 0
+    capsys.readouterr()
+    latest = (tmp_path / "dq" / "latest.json").read_text(encoding="utf-8")
+    assert json.loads(latest)["report_kind"] == "proposal_queue_digest"
+
+
+# ---------------------------------------------------------------------------
+# Module-level invariants (paranoid static checks)
+# ---------------------------------------------------------------------------
+
+
+def test_no_subprocess_import_in_module() -> None:
+    src = Path(pq.__file__).read_text(encoding="utf-8")
+    assert "import subprocess" not in src
+    assert "from subprocess" not in src
+
+
+def test_no_gh_or_git_invocation_in_module() -> None:
+    src = Path(pq.__file__).read_text(encoding="utf-8")
+    forbidden = ('"gh"', "'gh'", '"git"', "'git'", "Popen")
+    for token in forbidden:
+        assert token not in src, f"forbidden token in proposal_queue.py: {token!r}"


### PR DESCRIPTION
## Summary

Adds the **intake** layer of the autonomous development loop. Reads roadmap-shaped sources (markdown / text from `docs/roadmap`, `docs/backlog`, `docs/spillovers`, or any operator-supplied path) and emits a deterministic queue of review-ready proposals.

## Core design principle

> Large roadmap / document upload **never** triggers direct execution.
> Instead it triggers: `intake → diff → proposal queue → approval → small scoped releases.`

The module emits proposals; it does not adopt roadmaps, merge PRs, modify governance docs, or write to `main`. Adoption / rejection / release-creation belong to v3.15.15.20+.

## What changed

### Backend — `reporting/proposal_queue.py`

Stdlib-only parser/classifier/planner. CLI:

```sh
python -m reporting.proposal_queue --mode dry-run
python -m reporting.proposal_queue --source docs/roadmap/qre_roadmap_v4.md --mode dry-run
```

Twelve proposal types (per the schema); six statuses; three risk classes. First-match decision precedence is pinned in the schema doc.

### Backend route — `dashboard/api_proposal_queue.py`

Single GET endpoint `/api/agent-control/proposals`. Reads `logs/proposal_queue/latest.json`, returns `not_available` envelope when missing / malformed / non-object. Same contract as the v3.15.15.18 PWA surface. Wiring requires one operator-led line in `dashboard.py` (no-touch).

### Frontend — Proposals card on the AgentControl PWA

Sixth card with empty / not_available / populated states; risk pill per row; **no approve / reject / merge button**.

Incidental build-hygiene fix: `tsconfig.json: noEmit: true` so `tsc -b` no longer leaves `.js` artifacts alongside source files; `vite.config.ts` + `vitest.config.ts` order `.ts`/`.tsx` ahead of `.js` so any pre-existing stale artifacts never shadow source. Without this, vitest was resolving an old `AgentControl.js` sibling instead of the updated `.tsx`.

## Hard guarantees (enforced by code AND tests)

| guarantee | enforcement |
|---|---|
| Stdlib-only — no subprocess / no `gh` / no `git` / no network | `test_no_subprocess_import_in_module`, `test_no_gh_or_git_invocation_in_module` |
| Reads source files only; never modifies them | `test_frozen_contracts_byte_identical_around_snapshot` |
| `dry-run` is the only allowed mode | `test_non_dry_run_mode_is_refused` |
| Strategic roadmap adoption → HIGH + `needs_human` | `test_strategic_roadmap_adoption_is_high_and_needs_human`, `test_strategic_roadmap_doc_yields_high_needs_human` |
| Tooling with secrets / signup / OAuth / telemetry → HIGH + `needs_human` | `test_tooling_with_secrets_or_telemetry_is_high` (5 parametrized cases) |
| Tooling explicitly free / dev-only / no-telemetry → LOW + `proposed` | `test_tooling_marked_free_dev_only_is_low` (3 parametrized cases) |
| Live / trading paths → `blocked_high_risk` | `test_live_trading_path_is_blocked_high_risk` |
| Frozen / no-touch paths → `blocked_protected_path` | `test_protected_path_is_blocked_protected_path`, `test_frozen_contract_path_is_blocked_protected_path` |
| Unknown / malformed source does not crash | `test_unknown_source_yields_blocked_unknown_or_missing`, `test_malformed_input_does_not_crash` |
| `proposal_id` is deterministic | `test_proposal_id_is_deterministic` |
| GET-only API; POST/PUT/PATCH/DELETE → 405 | `test_mutation_verbs_are_rejected` |
| Secret-redaction guard on every API payload | `test_credential_string_in_artifact_is_refused` |
| No execute / approve / merge button in the PWA | reuses `test_does_not_render_any_execute_approve_merge_BUTTON` from v3.15.15.18 |

## Negation-aware tooling check

Substring "telemetry" inside "no telemetry" is **not** counted as a HIGH signal. The classifier strips `no <token>` / `no-<token>` patterns before the HIGH check, so explicit free-tool markers always win. Verified by 5 + 3 parametrized cases.

## Documentation

- `docs/governance/proposal_queue/schema.v1.md` — full JSON schema (12 types, 6 statuses, 3 risk classes, decision precedence pinned).
- `docs/governance/roadmap_proposal_queue.md` — operator runbook.
- `docs/governance/tooling_intake_policy.md` — canonical tooling decision rubric (LOW / MEDIUM / HIGH), hard "no" list, required evidence fields.
- `docs/governance/autonomous_workloop_runbook.md` — release-table update + cross-link.

## Constraints respected

- No write to `dashboard/dashboard.py` (no-touch).
- No write to `.claude/**`.
- No frozen-contract changes.
- No live/paper/shadow/trading/risk behavior changes.
- No CI/test weakening.
- **No new dependencies.**
- No external telemetry, signup-required service, or paid plan.
- No POST/PUT/PATCH/DELETE handler anywhere on the new surface.
- No canonical roadmap adoption — `roadmap_adoption` proposals stay `needs_human`.

## Test plan

- [x] `python scripts/governance_lint.py` — OK (15 agents, 3 workflows).
- [x] `pytest tests/smoke -q` — 14/14 pass.
- [x] `pytest tests/unit -q` — **2805 passed** (was 2753; +52 new), 3 skipped, 0 failed.
- [x] `npm --prefix frontend test -- --run` — **40/40 pass** (was 37; +3 new).
- [x] `npm --prefix frontend run build` — green.
- [x] Frozen-contract hashes unchanged:
  - `research/research_latest.json` = `4a567bd6feb98eb7aa32db4a90a3201456843088314936c5e484a2ae6a93666c`
  - `research/strategy_matrix.csv`   = `ff15b8c4f35cc37b6941b712106ae71a1b82a1b5043da197731d42518d258d66`

## Forward roadmap (not shipped here)

| release | adds |
|---|---|
| **v3.15.15.19 (this)** | proposal parser, queue, schema, GET route, read-only PWA card |
| v3.15.15.20 | approval inbox: operator approves / rejects / supersedes |
| v3.15.15.21 | execute-safe controls (the first *write* button) |
| v3.15.15.23 | browser push for `needs_human` proposals |

🤖 Generated with [Claude Code](https://claude.com/claude-code)