### PR TITLE
feat(v3.15.15.22): long-running workloop runtime (observe/classify/report)

### DIFF
--- a/dashboard/api_agent_control.py
+++ b/dashboard/api_agent_control.py
@@ -150,12 +150,15 @@ def _safe_jsonify(payload: dict[str, Any]):
 
 
 def _status_payload() -> dict[str, Any]:
-    """Aggregate health: governance status + frozen-contract hashes.
+    """Aggregate health: governance status + frozen-contract hashes
+    + workloop runtime summary.
 
     The PWA Status card consumes this. No CLI subprocess; the
     governance status reporter is imported lazily and called as a
     pure function so the read remains synchronous and side-effect
-    free.
+    free. The workloop runtime block is a thin projection of
+    ``logs/workloop_runtime/latest.json`` — see
+    ``reporting.workloop_runtime`` (v3.15.15.22).
     """
     try:
         # Late import: keeps the module light when the surface is not
@@ -178,7 +181,60 @@ def _status_payload() -> dict[str, Any]:
         "schema_version": 1,
         "governance_status": gov,
         "frozen_hashes": _frozen_hashes_payload(),
+        "workloop_runtime": _workloop_runtime_summary(),
     }
+
+
+def _workloop_runtime_summary() -> dict[str, Any]:
+    """Project the latest workloop-runtime artifact into a compact
+    summary suited for the Status card. Returns ``not_available`` on
+    a missing or malformed artifact.
+
+    The summary deliberately strips the per-source ``summary`` field
+    detail (it can contain long path strings) and surfaces only the
+    counts + loop_health + final_recommendation. The full artifact
+    is still readable at ``logs/workloop_runtime/latest.json``.
+    """
+    try:
+        from reporting.workloop_runtime import read_latest_snapshot
+
+        snap = read_latest_snapshot()
+        if snap is None:
+            return {
+                "status": "not_available",
+                "reason": "missing",
+            }
+        return {
+            "status": "ok",
+            "data": {
+                "runtime_version": snap.get("runtime_version"),
+                "generated_at_utc": snap.get("generated_at_utc"),
+                "run_id": snap.get("run_id"),
+                "mode": snap.get("mode"),
+                "iteration": snap.get("iteration"),
+                "max_iterations": snap.get("max_iterations"),
+                "interval_seconds": snap.get("interval_seconds"),
+                "next_run_after_utc": snap.get("next_run_after_utc"),
+                "duration_ms": snap.get("duration_ms"),
+                "safe_to_execute": snap.get("safe_to_execute", False),
+                "loop_health": snap.get("loop_health") or {},
+                "counts": snap.get("counts") or {},
+                "final_recommendation": snap.get("final_recommendation"),
+                "source_states": [
+                    {
+                        "source": s.get("source"),
+                        "state": s.get("state"),
+                    }
+                    for s in (snap.get("sources") or [])
+                    if isinstance(s, dict)
+                ],
+            },
+        }
+    except Exception as e:  # noqa: BLE001
+        return {
+            "status": "not_available",
+            "reason": f"workloop_runtime_error: {type(e).__name__}",
+        }
 
 
 def _activity_payload() -> dict[str, Any]:

--- a/docs/governance/workloop_runtime.md
+++ b/docs/governance/workloop_runtime.md
@@ -1,0 +1,192 @@
+# Workloop Runtime — Operator Runbook
+
+> Module: `reporting.workloop_runtime`
+> Release: v3.15.15.22
+> Schema: [`workloop_runtime/schema.v1.md`](workloop_runtime/schema.v1.md)
+> Sibling reporters consumed: `governance_status`, `agent_audit_summary`,
+> `autonomous_workloop`, `github_pr_lifecycle`, `proposal_queue`,
+> `approval_inbox`, `execute_safe_controls`.
+
+This is the operator-facing runbook for the v3.15.15.22 long-running
+workloop runtime. The runtime is an **observe / classify / report**
+supervisor — never an autonomous executor.
+
+## TL;DR
+
+```sh
+# Single iteration, write artifact, exit. This is the default.
+python -m reporting.workloop_runtime --once
+
+# Bounded loop. Clamped to MAX_ITERATIONS_LIMIT=24 and an interval
+# of [30, 21600] seconds. Tests rely on this clamping.
+python -m reporting.workloop_runtime --loop \
+    --interval-seconds 300 --max-iterations 3
+
+# Read the most recent artifact without re-running.
+python -m reporting.workloop_runtime --status
+```
+
+The runtime is **stdlib-only**. It calls the seven supervised
+reporting modules in-process, captures their results into a single
+JSON envelope, and writes the envelope atomically.
+
+## Hard guarantees (enforced by code AND tests)
+
+| guarantee | enforcement |
+|---|---|
+| Stdlib-only — no subprocess / `gh` / `git` / network | `test_module_does_not_invoke_subprocess_or_gh_or_git` |
+| `--once` runs exactly one iteration | `test_once_mode_writes_one_artifact` |
+| `--loop` honours `--max-iterations` (clamped to 24) | `test_loop_mode_respects_max_iterations` |
+| `--interval-seconds` clamped to `[30, 21600]` | `test_loop_clamps_interval_seconds` |
+| One failing source does not crash the loop or other sources | `test_one_failing_source_does_not_crash_others` |
+| Per-source wall-clock timeout produces `state="timeout"` | `test_timeout_classified_as_timeout` |
+| Missing source returns `not_available` (never silently OK) | `test_missing_source_classified_not_available` |
+| Malformed JSON in upstream artifact does not crash the supervisor | `test_malformed_json_handled_safely` |
+| JSON write is atomic (`tmp` + `os.replace`) | `test_json_write_is_atomic` |
+| `history.jsonl` appends one line per iteration | `test_history_jsonl_appends_one_record_per_run` |
+| Credential-value patterns (sk-ant-, ghp_, ...) are caught at every layer | `test_credential_value_in_source_is_classified_failed` |
+| `safe_to_execute` is always `false` | `test_safe_to_execute_is_always_false` |
+| KeyboardInterrupt produces graceful stop | `test_keyboard_interrupt_exits_gracefully` |
+| Schema is stable | `test_top_level_shape`, `test_every_source_carries_required_fields` |
+
+## What the runtime does NOT do
+
+* No Dependabot execute-safe scheduling.
+* No recurring maintenance automation.
+* No browser push notifications.
+* No POST/PUT/PATCH/DELETE API.
+* No approve/reject/merge/execute buttons.
+* No arbitrary shell command runner.
+* No GitHub mutation.
+* No `git push`, force-push, admin merge, direct main push.
+* No live/paper/shadow/trading/risk behavior changes.
+* No frozen-contract changes.
+* No `.claude/**` changes.
+* No CI/test weakening.
+* No paid/external telemetry/signup/secrets.
+* No new `dashboard.py` wiring (the runtime status flows through
+  the already-wired `/api/agent-control/status` endpoint).
+
+## Source catalog (closed)
+
+| source | needs gh? | typical state |
+|---|---|---|
+| `governance_status` | no | `ok` |
+| `agent_audit_summary` | no | `ok` if today's ledger exists, else `not_available` |
+| `autonomous_workloop` | no | `ok` (may be `degraded` if blocked items) |
+| `github_pr_lifecycle` | yes | `ok` if gh authenticated, else `not_available` |
+| `proposal_queue` | no | `ok` |
+| `approval_inbox` | no | `ok` |
+| `execute_safe_controls` | no | `ok` (catalog-only) |
+
+Each source is called in-process; per-source wall-clock timeout
+defaults to 60s. Adding a new source requires a new release plus
+an ADR.
+
+## State enum
+
+| value | meaning |
+|---|---|
+| `ok` | source ran healthily |
+| `degraded` | source ran but reports non-fatal trouble |
+| `not_available` | source ran but a required upstream is missing |
+| `failed` | source raised an exception or leaked a credential value |
+| `timeout` | source did not return within the wall-clock budget |
+| `skipped` | reserved (not emitted in v3.15.15.22) |
+| `unknown` | supervisor could not classify; never elevated |
+
+## Approval-inbox integration
+
+`reporting.approval_inbox` reads `logs/workloop_runtime/latest.json`
+and emits inbox items per the rules in
+[`schema.v1.md`](workloop_runtime/schema.v1.md):
+
+* `loop_health.consecutive_failures >= 3` → one `runtime_halt`
+  item (severity: critical).
+* Each source with `state in {failed, timeout}` → one
+  `failed_automation` item (severity: high).
+* Each source with `state == unknown` → one `unknown_state` item
+  (severity: medium).
+
+A clean runtime artifact (every source `ok` or only
+`not_available`) produces zero new inbox items. The
+`not_available` source generates a separate "missing source" item
+the way it always did.
+
+## Status-card integration
+
+The Status card on the Agent Control PWA gains:
+
+* a runtime pill (`ok` / `warn` / `danger`) derived from
+  `loop_health.consecutive_failures` and `final_recommendation`;
+* a row showing the runtime's `final_recommendation` string when
+  the artifact is available.
+
+The card consumes the existing GET-only
+`/api/agent-control/status` endpoint, which in turn calls
+`reporting.workloop_runtime.read_latest_snapshot()` in-process. No
+new dashboard.py wiring is required.
+
+## Reading the JSON artifact
+
+```sh
+# Latest snapshot:
+jq '.final_recommendation' logs/workloop_runtime/latest.json
+
+# Per-source state:
+jq '.sources[] | {source, state, summary}' logs/workloop_runtime/latest.json
+
+# Loop health across iterations:
+jq '.loop_health' logs/workloop_runtime/latest.json
+
+# Append-only history (one line per iteration):
+tail -n 5 logs/workloop_runtime/history.jsonl | jq -c '.run_id, .counts'
+```
+
+## Operator workflow
+
+1. **One-shot debugging**: `python -m reporting.workloop_runtime --once`
+   to refresh upstream artifacts in-process and see which sources
+   are healthy.
+2. **Bounded loop**: `python -m reporting.workloop_runtime --loop
+   --max-iterations 6 --interval-seconds 600` to run 6 iterations
+   over an hour. The CLI exits 0 when the loop completes; SIGINT
+   exits 130 (graceful).
+3. **Inspect**: `python -m reporting.workloop_runtime --status` or
+   open the Agent Control PWA Status card.
+4. **Triage failures**: any `failed` / `timeout` source produces a
+   `failed_automation` inbox item the next time
+   `python -m reporting.approval_inbox` runs (or the next time the
+   PWA refreshes its inbox endpoint).
+
+## Forward roadmap (not shipped here)
+
+| release | adds |
+|---|---|
+| **v3.15.15.22 (this)** | observe-only runtime, schema, inbox + status integration, read-only PWA card |
+| v3.15.15.23 | browser push for `needs_human` / `runtime_halt` items |
+| v3.15.15.25 | metrics / observability dashboards on top of `history.jsonl` |
+
+## Files added by v3.15.15.22
+
+```
+reporting/workloop_runtime.py
+docs/governance/workloop_runtime/schema.v1.md
+docs/governance/workloop_runtime.md          (this file)
+tests/unit/test_workloop_runtime.py
+```
+
+Plus extensions:
+
+```
+reporting/approval_inbox.py                  (+_build_from_workloop_runtime)
+dashboard/api_agent_control.py               (+_workloop_runtime_summary)
+frontend/src/api/agent_control.ts            (extended Status type)
+frontend/src/routes/AgentControl.tsx         (Status card runtime row)
+frontend/src/test/AgentControl.test.tsx      (runtime row mock + assertion)
+tests/unit/test_approval_inbox.py            (+ runtime-projection tests)
+tests/unit/test_dashboard_api_agent_control.py (+ workloop_runtime block test)
+```
+
+No new dependencies. No write to `dashboard/dashboard.py`. No write
+to `.claude/**`. Frozen-contract hashes unchanged.

--- a/docs/governance/workloop_runtime/schema.v1.md
+++ b/docs/governance/workloop_runtime/schema.v1.md
@@ -1,0 +1,177 @@
+# Workloop Runtime Digest — Schema v1
+
+> Module: `reporting.workloop_runtime`
+> Module version: `v3.15.15.22`
+> Schema version: `1`
+> Artifact path (gitignored): `logs/workloop_runtime/latest.json`
+> Timestamped copies: `logs/workloop_runtime/<UTC>.json`
+> Append-only history: `logs/workloop_runtime/history.jsonl`
+
+## Top-level fields
+
+| field | type | values | notes |
+|---|---|---|---|
+| `schema_version` | int | `1` | bump on breaking changes |
+| `report_kind` | string | `"workloop_runtime_digest"` | constant |
+| `runtime_version` | string | `"v3.15.15.22"` | source-of-truth |
+| `generated_at_utc` | string | RFC3339 UTC | seconds resolution |
+| `run_id` | string | `"wl_<sha8>"` | deterministic over `generated_at_utc` + `iteration` |
+| `mode` | enum | `"once"` / `"loop"` | matches the CLI flag |
+| `iteration` | int | `0..max_iterations - 1` | zero-based |
+| `max_iterations` | int | clamped to `MAX_ITERATIONS_LIMIT` (24) | |
+| `interval_seconds` | int \| null | clamped to `[30, 21600]` | only set in loop mode |
+| `next_run_after_utc` | string \| null | RFC3339 UTC | only set in loop mode |
+| `duration_ms` | int | wall-clock for the iteration | |
+| `safe_to_execute` | bool | **always `false` in v3.15.15.22** | runtime never grants execute rights |
+| `loop_health` | object | see "loop_health" | |
+| `sources` | array | see "Source result" | one per supervised source |
+| `counts` | object | aggregate state counts | |
+| `final_recommendation` | string | see "final_recommendation" | |
+
+## `loop_health` object
+
+```json
+{
+  "iterations_completed": 7,
+  "iterations_failed": 1,
+  "last_success_utc": "2026-05-02T10:00:00Z",
+  "last_failure_utc": "2026-05-02T09:30:00Z",
+  "consecutive_failures": 0
+}
+```
+
+`consecutive_failures` survives process restarts (read from
+`latest.json`). Three or more consecutive failed iterations promote
+the runtime to `runtime_halt` in the approval inbox.
+
+## Source result
+
+One entry per supervised reporter. The catalog of supervised
+sources is **closed** — adding a new source requires a new release
+plus an ADR.
+
+| field | type | notes |
+|---|---|---|
+| `source` | string | short name (e.g. `"governance_status"`) |
+| `module` | string | dotted module path (e.g. `"reporting.governance_status"`) |
+| `state` | enum | see "State enum" |
+| `duration_ms` | int | wall-clock per source |
+| `summary` | string | length-capped human-readable note |
+| `artifact_path` | string | repo-relative path of the upstream artifact (informational) |
+| `error_class` | string \| null | `type(e).__name__` on a `failed` source |
+
+### Closed source catalog
+
+| source | module | needs gh? | notes |
+|---|---|---|---|
+| `governance_status` | `reporting.governance_status` | no | always in-process |
+| `agent_audit_summary` | `reporting.agent_audit_summary` | no | reads today's ledger |
+| `autonomous_workloop` | `reporting.autonomous_workloop` | no | dry-run only |
+| `github_pr_lifecycle` | `reporting.github_pr_lifecycle` | yes | dry-run only; degrades to `not_available` when gh missing |
+| `proposal_queue` | `reporting.proposal_queue` | no | dry-run only |
+| `approval_inbox` | `reporting.approval_inbox` | no | dry-run only |
+| `execute_safe_controls` | `reporting.execute_safe_controls` | no | catalog-only (eligibility planning, never execution) |
+
+## State enum
+
+| value | meaning |
+|---|---|
+| `ok` | source returned a valid envelope and its envelope-inspector classified it as healthy |
+| `degraded` | source ran but its envelope reports a non-fatal problem (e.g. audit chain broken) |
+| `not_available` | source returned but a required upstream is missing (e.g. gh not installed) |
+| `failed` | source raised an exception OR its inner result tripped the credential-value guard |
+| `timeout` | source did not return within the per-source wall-clock budget |
+| `skipped` | reserved for future opt-out flows; not emitted in v3.15.15.22 |
+| `unknown` | the supervisor could not classify; never elevated to `ok` |
+
+## `final_recommendation` enum
+
+| value | meaning |
+|---|---|
+| `"all_sources_ok"` | every supervised source returned `ok` |
+| `"degraded_not_available_<n>"` | at least one source is `not_available` (no failures) |
+| `"degraded_failed_<f>_timeout_<t>"` | at least one source `failed` or timed out |
+| `"runtime_halt_after_<n>_consecutive_failures"` | three or more consecutive iterations failed; the inbox emits a `runtime_halt` item |
+
+## `counts` object
+
+```json
+{
+  "total": 7,
+  "by_state": {"ok": 5, "degraded": 1, "not_available": 1}
+}
+```
+
+## Hard guarantees encoded in the schema
+
+* `safe_to_execute` is **always `false`** in this release.
+* The supervisor never invokes `git`, `gh`, `subprocess`, or any
+  arbitrary command. Each source is called in-process.
+* Per-source wall-clock timeout. Cross-platform (thread-join).
+* One failing source does NOT crash the loop or other sources.
+* JSON write is atomic (`tmp` + `os.replace`).
+* `history.jsonl` is append-only.
+* `_assert_no_credential_values` (sk-ant-, ghp_, github_pat_, AKIA,
+  BEGIN PRIVATE KEY) runs over every source's inner snapshot AND
+  the final outer snapshot. Sensitive-path fragments are intentionally
+  NOT checked at the runtime layer because supervised snapshots
+  legitimately echo path-shaped strings (`config/config.yaml` in
+  no-touch metadata, `state/*.secret` glob references, etc.) —
+  those are metadata, not leaks.
+* `MAX_ITERATIONS_LIMIT` (24) and `[MIN_INTERVAL_SECONDS=30,
+  MAX_INTERVAL_SECONDS=21600]` are clamped at the CLI boundary so a
+  runaway loop is impossible.
+
+## Loop semantics
+
+* `--once` runs exactly one iteration, writes the artifact, and
+  exits 0. This is the default and what tests use.
+* `--loop` runs up to `--max-iterations` iterations with
+  `--interval-seconds` between them. Both flags are clamped.
+* `KeyboardInterrupt` causes a graceful exit — the partial snapshot
+  list is preserved on disk; the loop does not crash mid-write.
+* Loop health (`iterations_completed`, `iterations_failed`,
+  `consecutive_failures`) survives process restarts because each
+  iteration reads `latest.json` before writing the new one.
+
+## CLI flags
+
+```
+--once                      single iteration (default)
+--loop                      bounded loop
+--status                    print latest.json contents and exit
+--interval-seconds N        clamped to [30, 21600]
+--max-iterations N          clamped to 24
+--timeout-per-source-seconds N
+--no-write                  stdout only
+--indent N                  JSON indent (0 = compact)
+```
+
+`--once` / `--loop` / `--status` are mutually exclusive.
+
+## Wiring with the rest of the system
+
+| consumer | how it consumes the runtime artifact |
+|---|---|
+| `dashboard.api_agent_control._status_payload` | calls `read_latest_snapshot()` in-process and surfaces a compact projection under `status.workloop_runtime` |
+| `reporting.approval_inbox._build_from_workloop_runtime` | maps `loop_health.consecutive_failures >= 3` → `runtime_halt`, each `failed`/`timeout` source → `failed_automation`, each `unknown` source → `unknown_state` |
+| `frontend/src/routes/AgentControl.tsx::StatusCard` | renders a runtime pill + final-recommendation row inside the existing Status card; no new endpoint |
+
+No new dashboard route is wired in v3.15.15.22 — the runtime
+status flows through the already-wired
+`/api/agent-control/status` endpoint.
+
+## Forbidden in v3.15.15.22
+
+* Dependabot execute-safe scheduling.
+* Recurring maintenance automation.
+* Browser push notifications.
+* POST/PUT/PATCH/DELETE on the dashboard surface.
+* Approve/reject/merge/execute buttons.
+* Arbitrary shell command runner.
+* GitHub mutation, git push, force-push, admin merge, direct main push.
+* `safe_to_execute=true`.
+
+The next release (v3.15.15.23) introduces browser push for
+`needs_human` / critical inbox items including `runtime_halt`. The
+runtime itself stays read-only.

--- a/frontend/src/api/agent_control.ts
+++ b/frontend/src/api/agent_control.ts
@@ -21,6 +21,26 @@ export interface AgentControlStatus {
   schema_version: number;
   governance_status: AgentControlStatusEnvelope;
   frozen_hashes: FrozenHashesPayload;
+  workloop_runtime?: {
+    status: "ok" | "not_available";
+    reason?: string;
+    data?: {
+      runtime_version?: string;
+      generated_at_utc?: string;
+      mode?: string;
+      iteration?: number;
+      duration_ms?: number;
+      safe_to_execute?: boolean;
+      loop_health?: {
+        consecutive_failures?: number;
+        iterations_completed?: number;
+        iterations_failed?: number;
+      };
+      counts?: { total?: number; by_state?: Record<string, number> };
+      final_recommendation?: string;
+      source_states?: Array<{ source: string; state: string }>;
+    };
+  };
 }
 
 export interface AgentControlActivity {

--- a/frontend/src/routes/AgentControl.tsx
+++ b/frontend/src/routes/AgentControl.tsx
@@ -79,13 +79,13 @@ function pillFor(status: string | undefined): "ok" | "warn" | "danger" | "unknow
   return "unknown";
 }
 
-// --- Card: governance status + frozen hashes ---
+// --- Card: governance status + frozen hashes + workloop runtime ---
 function StatusCard({ payload }: { payload: AgentControlStatus | null }) {
   if (!payload) {
     return (
       <Card
         title="Status"
-        subtitle="governance + frozen contracts"
+        subtitle="governance + frozen + runtime"
       >
         <p className="agent-control-card__empty" data-testid="status-loading">
           Laden…
@@ -96,8 +96,28 @@ function StatusCard({ payload }: { payload: AgentControlStatus | null }) {
   const govStatus = payload.governance_status?.status ?? "not_available";
   const fhStatus = payload.frozen_hashes?.status ?? "not_available";
   const fh = payload.frozen_hashes?.data ?? {};
+  const runtime = payload.workloop_runtime;
+  const runtimeStatus = runtime?.status ?? "not_available";
+  const runtimeData = runtime?.status === "ok" ? runtime.data : undefined;
+  const runtimeRecommendation = String(
+    runtimeData?.final_recommendation ?? "n/a",
+  );
+  const runtimeConsecutiveFailures = Number(
+    runtimeData?.loop_health?.consecutive_failures ?? 0,
+  );
+  // Tone: critical if loop has halted, warn if any failures, ok otherwise.
+  const runtimePill: "ok" | "warn" | "danger" | "unknown" =
+    runtimeStatus !== "ok"
+      ? "unknown"
+      : runtimeConsecutiveFailures >= 3
+        ? "danger"
+        : runtimeRecommendation.startsWith("degraded")
+          ? "warn"
+          : runtimeRecommendation === "all_sources_ok"
+            ? "ok"
+            : "unknown";
   return (
-    <Card title="Status" subtitle="governance + frozen contracts">
+    <Card title="Status" subtitle="governance + frozen + runtime">
       <div className="agent-control-card__row">
         <dt>governance</dt>
         <dd>
@@ -110,6 +130,21 @@ function StatusCard({ payload }: { payload: AgentControlStatus | null }) {
           <StatusPill state={pillFor(fhStatus)} />
         </dd>
       </div>
+      <div className="agent-control-card__row" data-testid="status-runtime-row">
+        <dt>workloop runtime</dt>
+        <dd>
+          <StatusPill state={runtimePill} />
+        </dd>
+      </div>
+      {runtimeStatus === "ok" && runtimeData ? (
+        <div
+          className="agent-control-card__row"
+          data-testid="status-runtime-recommendation"
+        >
+          <dt>runtime rec.</dt>
+          <dd>{runtimeRecommendation}</dd>
+        </div>
+      ) : null}
       {Object.keys(fh).length === 0 ? (
         <p
           className="agent-control-card__empty"

--- a/frontend/src/test/AgentControl.test.tsx
+++ b/frontend/src/test/AgentControl.test.tsx
@@ -36,6 +36,28 @@ const okStatusBody = {
   schema_version: 1,
   governance_status: { status: "ok", data: {} },
   frozen_hashes: okFrozenHashes,
+  workloop_runtime: {
+    status: "ok",
+    data: {
+      runtime_version: "v3.15.15.22",
+      generated_at_utc: "2026-05-02T20:00:00Z",
+      mode: "once",
+      iteration: 0,
+      duration_ms: 200,
+      safe_to_execute: false,
+      loop_health: {
+        consecutive_failures: 0,
+        iterations_completed: 1,
+        iterations_failed: 0,
+      },
+      counts: { total: 7, by_state: { ok: 7 } },
+      final_recommendation: "all_sources_ok",
+      source_states: [
+        { source: "governance_status", state: "ok" },
+        { source: "approval_inbox", state: "ok" },
+      ],
+    },
+  },
 };
 
 const okActivityBody = {

--- a/frontend/src/test/AgentControlPolish.test.tsx
+++ b/frontend/src/test/AgentControlPolish.test.tsx
@@ -42,6 +42,23 @@ const okStatusBody = {
   schema_version: 1,
   governance_status: { status: "ok", data: {} },
   frozen_hashes: okFrozenHashes,
+  workloop_runtime: {
+    status: "ok",
+    data: {
+      runtime_version: "v3.15.15.22",
+      mode: "once",
+      iteration: 0,
+      safe_to_execute: false,
+      loop_health: {
+        consecutive_failures: 0,
+        iterations_completed: 1,
+        iterations_failed: 0,
+      },
+      counts: { total: 7, by_state: { ok: 7 } },
+      final_recommendation: "all_sources_ok",
+      source_states: [],
+    },
+  },
 };
 
 const okActivityBody = {
@@ -328,6 +345,45 @@ describe("AgentControl polish — non-GET fetch is forbidden everywhere", () => 
     for (const c of fetchSpy) {
       expect(c.method).toBe("GET");
     }
+  });
+});
+
+describe("AgentControl polish — Status card runtime row (v3.15.15.22)", () => {
+  it("renders the workloop_runtime row when the artifact is available", async () => {
+    installFetchMock(_allOk());
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+    const row = await screen.findByTestId("status-runtime-row");
+    expect(row).toBeInTheDocument();
+    const rec = await screen.findByTestId("status-runtime-recommendation");
+    expect(rec).toHaveTextContent("all_sources_ok");
+  });
+
+  it("renders runtime row as unknown when status payload omits workloop_runtime", async () => {
+    const statusBodyNoRuntime = {
+      kind: "agent_control_status",
+      schema_version: 1,
+      governance_status: { status: "ok", data: {} },
+      frozen_hashes: okFrozenHashes,
+    };
+    installFetchMock({
+      ..._allOk(),
+      "/api/agent-control/status": () => jsonResp(statusBodyNoRuntime),
+    });
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+    const row = await screen.findByTestId("status-runtime-row");
+    expect(row).toBeInTheDocument();
+    // No recommendation row when runtime is not available.
+    expect(
+      screen.queryByTestId("status-runtime-recommendation"),
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/reporting/approval_inbox.py
+++ b/reporting/approval_inbox.py
@@ -76,6 +76,9 @@ SOURCE_PR_LIFECYCLE: Path = (
     REPO_ROOT / "logs" / "github_pr_lifecycle" / "latest.json"
 )
 SOURCE_WORKLOOP: Path = REPO_ROOT / "logs" / "autonomous_workloop" / "latest.json"
+SOURCE_WORKLOOP_RUNTIME: Path = (
+    REPO_ROOT / "logs" / "workloop_runtime" / "latest.json"
+)
 
 # Canonical inbox categories (18 per the v3.15.15.20 brief).
 CATEGORIES: tuple[str, ...] = (
@@ -604,6 +607,93 @@ def _dashboard_py_text() -> str:
         return ""
 
 
+def _build_from_workloop_runtime(envelope: dict[str, Any]) -> list[dict[str, Any]]:
+    """Project a v3.15.15.22 workloop runtime artifact into inbox items.
+
+    Mapping:
+      * ``loop_health.consecutive_failures >= 3`` → ``runtime_halt``
+        (severity: critical) — the loop has degraded enough to warrant
+        human attention.
+      * Each source with ``state in {failed, timeout}`` →
+        ``failed_automation`` (severity: high) so the operator sees
+        which exact source died.
+      * Each source with ``state == unknown`` → ``unknown_state``.
+
+    A clean runtime artifact (every source ok or only ``not_available``)
+    produces zero inbox items.
+    """
+    if envelope["status"] != "ok" or not envelope.get("data"):
+        return []
+    data = envelope["data"]
+    items: list[dict[str, Any]] = []
+
+    health = data.get("loop_health") or {}
+    consecutive = (
+        int(health.get("consecutive_failures") or 0)
+        if isinstance(health, dict)
+        else 0
+    )
+    if consecutive >= 3:
+        items.append(
+            _build_item(
+                source="workloop_runtime:loop_health",
+                source_type="manual",
+                title=(
+                    f"Workloop runtime: {consecutive} consecutive failed "
+                    "iterations — runtime_halt"
+                ),
+                summary=str(data.get("final_recommendation") or "runtime_halt"),
+                category="runtime_halt",
+                risk_class="HIGH",
+                status=STATUS_BLOCKED,
+                affected_files=[],
+                evidence={"loop_health": health},
+            )
+        )
+
+    for src in data.get("sources") or []:
+        if not isinstance(src, dict):
+            continue
+        state = src.get("state")
+        name = src.get("source") or "unknown_source"
+        module = src.get("module") or ""
+        summary = src.get("summary") or ""
+        if state in ("failed", "timeout"):
+            items.append(
+                _build_item(
+                    source=f"workloop_runtime:{name}",
+                    source_type="manual",
+                    title=f"Workloop runtime: {name} {state}",
+                    summary=summary,
+                    category="failed_automation",
+                    risk_class="HIGH",
+                    status=STATUS_BLOCKED,
+                    affected_files=[],
+                    evidence={
+                        "module": module,
+                        "duration_ms": src.get("duration_ms"),
+                        "error_class": src.get("error_class"),
+                    },
+                )
+            )
+        elif state == "unknown":
+            items.append(
+                _build_item(
+                    source=f"workloop_runtime:{name}",
+                    source_type="manual",
+                    title=f"Workloop runtime: {name} unknown state",
+                    summary=summary,
+                    category="unknown_state",
+                    risk_class="MEDIUM",
+                    status=STATUS_BLOCKED,
+                    affected_files=[],
+                    evidence={"module": module},
+                )
+            )
+
+    return items
+
+
 def _build_manual_route_wiring_items() -> list[dict[str, Any]]:
     """Per the v3.15.15.18 / .19 / .20 release notes,
     ``dashboard/dashboard.py`` is no-touch except via an
@@ -738,6 +828,7 @@ def collect_snapshot(
             "proposal_queue": _read_json_artifact(SOURCE_PROPOSAL_QUEUE),
             "pr_lifecycle": _read_json_artifact(SOURCE_PR_LIFECYCLE),
             "workloop": _read_json_artifact(SOURCE_WORKLOOP),
+            "workloop_runtime": _read_json_artifact(SOURCE_WORKLOOP_RUNTIME),
             "governance_status": _governance_status_safe(),
         }
 
@@ -745,6 +836,11 @@ def collect_snapshot(
     items.extend(_build_from_proposal_queue(sources.get("proposal_queue", {"status": "not_available"})))
     items.extend(_build_from_pr_lifecycle(sources.get("pr_lifecycle", {"status": "not_available"})))
     items.extend(_build_from_workloop(sources.get("workloop", {"status": "not_available"})))
+    items.extend(
+        _build_from_workloop_runtime(
+            sources.get("workloop_runtime", {"status": "not_available"})
+        )
+    )
     items.extend(
         _build_from_governance_status(
             sources.get("governance_status", {"status": "not_available"})

--- a/reporting/workloop_runtime.py
+++ b/reporting/workloop_runtime.py
@@ -1,0 +1,842 @@
+"""Long-running workloop runtime (v3.15.15.22).
+
+A deterministic, bounded supervisor that periodically invokes the
+existing read-only / dry-run governance reporters and captures their
+results as a single runtime-state artifact. Observe / classify /
+report — **never** an autonomous executor.
+
+Hard guarantees (enforced by code AND tests)
+--------------------------------------------
+
+* Stdlib-only. No subprocess, no ``gh``, no ``git``, no network.
+* Calls the listed reporting modules in-process; never invokes an
+  arbitrary command, never accepts a free-form command string.
+* ``--once`` mode runs exactly one iteration and exits.
+* ``--loop`` mode honours ``--max-iterations`` and ``--interval-
+  seconds``. Both flags are clamped to safe upper bounds so a test
+  never runs forever.
+* One source failure does NOT crash the loop; the source is
+  classified ``failed``/``timeout`` and the supervisor moves on.
+* Per-source wall-clock timeout. Cross-platform (thread-join on
+  Windows, no SIGALRM).
+* Atomic JSON write: tmp file + ``os.replace``.
+* ``assert_no_secrets`` runs over every per-source result and over
+  the final snapshot before persistence.
+* ``safe_to_execute`` is hard-coded ``false`` in this release.
+* No GitHub mutation, no git operation, no live/paper/shadow/risk
+  surface touched.
+* CLI flags are validated; unknown flags are rejected.
+
+CLI
+---
+
+::
+
+    python -m reporting.workloop_runtime --once
+    python -m reporting.workloop_runtime --loop \\
+        --interval-seconds 300 --max-iterations 3
+    python -m reporting.workloop_runtime --status
+
+Stdlib-only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import hashlib
+import json
+import os
+import re
+import sys
+import threading
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+# Credential-value patterns checked at the OUTER snapshot boundary.
+# We deliberately do not check sensitive-path fragments at the outer
+# layer — the snapshot legitimately includes path-shaped strings
+# (artifact_path fields, source names, etc.) and the per-source
+# supervisor already runs the strict ``assert_no_secrets`` against
+# each source's inner value before it lands in the snapshot.
+_OUTER_CREDENTIAL_PATTERNS: tuple[str, ...] = (
+    "sk-ant-",
+    "ghp_",
+    "github_pat_",
+    "AKIA",
+    "-----BEGIN ",
+)
+
+
+def _assert_no_credential_values(snapshot: dict[str, Any]) -> None:
+    """Outer-boundary credential check. Walks every string in
+    ``snapshot`` and refuses anything that looks like a real
+    credential value (Anthropic key, GitHub PAT, AWS key, private
+    key block). Raises ``AssertionError`` on a hit.
+
+    This is intentionally narrower than the inner per-source
+    redaction: it does not check path fragments because the runtime
+    snapshot is metadata-shaped and legitimately echoes
+    ``logs/...`` and ``docs/...`` paths in artifact_path fields.
+    """
+    import collections.abc as _abc
+
+    def _walk(o: Any):
+        if isinstance(o, str):
+            yield o
+        elif isinstance(o, dict):
+            for v in o.values():
+                yield from _walk(v)
+        elif isinstance(o, _abc.Iterable) and not isinstance(o, (bytes, bytearray)):
+            for v in o:
+                yield from _walk(v)
+
+    for s in _walk(snapshot):
+        for pat in _OUTER_CREDENTIAL_PATTERNS:
+            if pat in s:
+                raise AssertionError(
+                    f"workloop_runtime leaked credential-like value: "
+                    f"pattern={pat!r}"
+                )
+
+REPO_ROOT: Path = Path(__file__).resolve().parent.parent
+RUNTIME_VERSION: str = "v3.15.15.22"
+SCHEMA_VERSION: int = 1
+
+DIGEST_DIR_JSON: Path = REPO_ROOT / "logs" / "workloop_runtime"
+
+# Hard runtime caps. Tests rely on these; do not loosen without a
+# governance-bootstrap PR.
+MAX_ITERATIONS_LIMIT: int = 24
+MIN_INTERVAL_SECONDS: int = 30
+MAX_INTERVAL_SECONDS: int = 6 * 3600  # 6 hours
+
+# Per-source wall-clock timeout (seconds).
+DEFAULT_SOURCE_TIMEOUT_SECONDS: int = 60
+
+# State enum surfaced in the schema doc.
+STATE_OK: str = "ok"
+STATE_DEGRADED: str = "degraded"
+STATE_NOT_AVAILABLE: str = "not_available"
+STATE_FAILED: str = "failed"
+STATE_TIMEOUT: str = "timeout"
+STATE_SKIPPED: str = "skipped"
+STATE_UNKNOWN: str = "unknown"
+STATE_VALUES: tuple[str, ...] = (
+    STATE_OK,
+    STATE_DEGRADED,
+    STATE_NOT_AVAILABLE,
+    STATE_FAILED,
+    STATE_TIMEOUT,
+    STATE_SKIPPED,
+    STATE_UNKNOWN,
+)
+
+
+# ---------------------------------------------------------------------------
+# Time / id helpers
+# ---------------------------------------------------------------------------
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _utcnow_dt() -> _dt.datetime:
+    return _dt.datetime.now(_dt.UTC).replace(microsecond=0)
+
+
+def _run_id(generated_at: str, iteration: int) -> str:
+    raw = f"{generated_at}|{iteration}".encode("utf-8")
+    return "wl_" + hashlib.sha256(raw).hexdigest()[:8]
+
+
+def _rel(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(REPO_ROOT.resolve())).replace("\\", "/")
+    except ValueError:
+        return str(path).replace("\\", "/")
+
+
+# ---------------------------------------------------------------------------
+# Per-source supervisor primitives
+# ---------------------------------------------------------------------------
+
+
+# Sentinel signalling "do nothing" inside the source result envelope.
+_NO_ARTIFACT: str = ""
+
+
+class _SourceResult(dict[str, Any]):
+    """Typed-ish envelope for one supervised source result."""
+
+
+def _supervise(
+    *,
+    name: str,
+    module: str,
+    artifact_path: str,
+    fn: Callable[[], Any],
+    timeout: int = DEFAULT_SOURCE_TIMEOUT_SECONDS,
+    state_from_envelope: Callable[[Any], tuple[str, str]] | None = None,
+) -> _SourceResult:
+    """Run one source's read-only call with a wall-clock timeout, a
+    secret-redaction guard, and an exception fence.
+
+    Returns an :class:`_SourceResult` dict. Never raises.
+    """
+    start = time.monotonic()
+    state: str = STATE_UNKNOWN
+    summary: str = ""
+    error_class: str | None = None
+
+    holder: dict[str, Any] = {}
+
+    def _runner() -> None:
+        try:
+            holder["value"] = fn()
+        except BaseException as e:  # noqa: BLE001 — defensive fence
+            holder["error"] = e
+
+    t = threading.Thread(target=_runner, daemon=True)
+    t.start()
+    t.join(timeout)
+    duration_ms = int((time.monotonic() - start) * 1000)
+
+    if t.is_alive():
+        # Cannot kill the thread cleanly in stdlib; mark timeout, the
+        # daemon thread will be reaped on process exit.
+        return _SourceResult(
+            source=name,
+            module=module,
+            state=STATE_TIMEOUT,
+            duration_ms=duration_ms,
+            summary=f"timeout after {timeout}s",
+            artifact_path=artifact_path,
+            error_class=None,
+        )
+
+    if "error" in holder:
+        e = holder["error"]
+        return _SourceResult(
+            source=name,
+            module=module,
+            state=STATE_FAILED,
+            duration_ms=duration_ms,
+            summary=f"{type(e).__name__}: {str(e)[:200]}",
+            artifact_path=artifact_path,
+            error_class=type(e).__name__,
+        )
+
+    value = holder.get("value")
+
+    # Per-source credential-value guard. We deliberately do NOT use
+    # the strict path-fragment check from agent_audit_summary here:
+    # the supervised snapshots LEGITIMATELY echo path-shaped strings
+    # (e.g. ``config/config.yaml`` as a no-touch path reference, or
+    # ``state/*.secret`` glob patterns) and rejecting those would
+    # mark legitimate read-only output as a leak. The narrow guard
+    # below catches actual credential VALUES — Anthropic keys, GitHub
+    # PATs, AWS access keys, private-key blocks — which are the real
+    # leak risk.
+    if isinstance(value, dict):
+        try:
+            _assert_no_credential_values(value)
+        except AssertionError:
+            # Intentionally do NOT echo the original assertion message
+            # — it contains the credential pattern verbatim, which
+            # would trip the outer guard. The error_class is enough
+            # for the operator to know what happened; the underlying
+            # source is the canonical place to investigate.
+            return _SourceResult(
+                source=name,
+                module=module,
+                state=STATE_FAILED,
+                duration_ms=duration_ms,
+                summary="secret_redaction_failed",
+                artifact_path=artifact_path,
+                error_class="SecretRedactionFailed",
+            )
+
+    # Caller-supplied envelope inspection decides ok / degraded /
+    # not_available. Default: any non-None value is ``ok``.
+    if state_from_envelope is not None:
+        try:
+            state, summary = state_from_envelope(value)
+        except Exception as e:  # noqa: BLE001
+            state = STATE_FAILED
+            summary = f"envelope_inspect_failed: {type(e).__name__}"
+            error_class = type(e).__name__
+    else:
+        if value is None:
+            state, summary = STATE_NOT_AVAILABLE, "value is None"
+        else:
+            state, summary = STATE_OK, "ok"
+
+    return _SourceResult(
+        source=name,
+        module=module,
+        state=state,
+        duration_ms=duration_ms,
+        summary=summary,
+        artifact_path=artifact_path,
+        error_class=error_class,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Source factory — closed list of allowed reporters
+# ---------------------------------------------------------------------------
+
+
+def _governance_status_call() -> Any:
+    from reporting.governance_status import collect_status
+
+    return collect_status()
+
+
+def _governance_status_envelope(value: Any) -> tuple[str, str]:
+    if not isinstance(value, dict):
+        return (STATE_DEGRADED, "non-dict envelope")
+    audit = value.get("audit_chain_status") or {}
+    audit_state = audit.get("status") if isinstance(audit, dict) else None
+    if audit_state == "broken":
+        return (STATE_DEGRADED, f"audit_chain_status={audit_state!r}")
+    return (STATE_OK, "governance_status ok")
+
+
+def _agent_audit_summary_call() -> Any:
+    from reporting import agent_audit_summary as audit_summary
+    import datetime as _local_dt
+
+    today = _local_dt.datetime.now(_local_dt.UTC).strftime("%Y-%m-%d")
+    ledger = REPO_ROOT / "logs" / f"agent_audit.{today}.jsonl"
+    return audit_summary.collect_timeline(ledger, limit=50)
+
+
+def _agent_audit_summary_envelope(value: Any) -> tuple[str, str]:
+    if not isinstance(value, dict):
+        return (STATE_DEGRADED, "non-dict envelope")
+    if not value.get("ledger_present"):
+        return (STATE_NOT_AVAILABLE, "today's ledger is missing")
+    chain = value.get("chain_status")
+    if chain == "broken":
+        return (STATE_DEGRADED, f"chain_status={chain!r}")
+    return (STATE_OK, f"events={value.get('ledger_event_count', 0)}")
+
+
+def _autonomous_workloop_call() -> Any:
+    from reporting.autonomous_workloop import collect_snapshot
+
+    return collect_snapshot(mode="dry-run", cycle_id=0)
+
+
+def _autonomous_workloop_envelope(value: Any) -> tuple[str, str]:
+    if not isinstance(value, dict):
+        return (STATE_DEGRADED, "non-dict envelope")
+    blocked = value.get("blocked_items") or []
+    return (
+        STATE_OK if not blocked else STATE_DEGRADED,
+        f"blocked={len(blocked)}",
+    )
+
+
+def _github_pr_lifecycle_call() -> Any:
+    from reporting.github_pr_lifecycle import collect_snapshot
+
+    return collect_snapshot(mode="dry-run")
+
+
+def _github_pr_lifecycle_envelope(value: Any) -> tuple[str, str]:
+    if not isinstance(value, dict):
+        return (STATE_DEGRADED, "non-dict envelope")
+    provider = value.get("provider_status")
+    if provider in (None, "", "not_available"):
+        return (STATE_NOT_AVAILABLE, f"provider_status={provider!r}")
+    if provider != "available":
+        return (STATE_DEGRADED, f"provider_status={provider!r}")
+    return (STATE_OK, "gh provider available")
+
+
+def _proposal_queue_call() -> Any:
+    from reporting.proposal_queue import collect_snapshot
+
+    return collect_snapshot(mode="dry-run")
+
+
+def _proposal_queue_envelope(value: Any) -> tuple[str, str]:
+    if not isinstance(value, dict):
+        return (STATE_DEGRADED, "non-dict envelope")
+    counts = value.get("counts") or {}
+    total = counts.get("total", 0) if isinstance(counts, dict) else 0
+    return (STATE_OK, f"proposals={total}")
+
+
+def _approval_inbox_call() -> Any:
+    from reporting.approval_inbox import collect_snapshot
+
+    return collect_snapshot(mode="dry-run")
+
+
+def _approval_inbox_envelope(value: Any) -> tuple[str, str]:
+    if not isinstance(value, dict):
+        return (STATE_DEGRADED, "non-dict envelope")
+    counts = value.get("counts") or {}
+    total = counts.get("total", 0) if isinstance(counts, dict) else 0
+    return (STATE_OK, f"items={total}")
+
+
+def _execute_safe_catalog_call() -> Any:
+    from reporting.execute_safe_controls import collect_catalog
+
+    return collect_catalog()
+
+
+def _execute_safe_envelope(value: Any) -> tuple[str, str]:
+    if not isinstance(value, dict):
+        return (STATE_DEGRADED, "non-dict envelope")
+    actions = value.get("actions") or []
+    return (STATE_OK, f"actions={len(actions)}")
+
+
+# Closed list. Adding a new source requires a new release + ADR.
+SOURCES: tuple[dict[str, Any], ...] = (
+    {
+        "name": "governance_status",
+        "module": "reporting.governance_status",
+        "artifact_path": "governance_status:in_process",
+        "fn": _governance_status_call,
+        "envelope": _governance_status_envelope,
+    },
+    {
+        "name": "agent_audit_summary",
+        "module": "reporting.agent_audit_summary",
+        "artifact_path": "logs/agent_audit.<UTC>.jsonl",
+        "fn": _agent_audit_summary_call,
+        "envelope": _agent_audit_summary_envelope,
+    },
+    {
+        "name": "autonomous_workloop",
+        "module": "reporting.autonomous_workloop",
+        "artifact_path": "logs/autonomous_workloop/latest.json",
+        "fn": _autonomous_workloop_call,
+        "envelope": _autonomous_workloop_envelope,
+    },
+    {
+        "name": "github_pr_lifecycle",
+        "module": "reporting.github_pr_lifecycle",
+        "artifact_path": "logs/github_pr_lifecycle/latest.json",
+        "fn": _github_pr_lifecycle_call,
+        "envelope": _github_pr_lifecycle_envelope,
+    },
+    {
+        "name": "proposal_queue",
+        "module": "reporting.proposal_queue",
+        "artifact_path": "logs/proposal_queue/latest.json",
+        "fn": _proposal_queue_call,
+        "envelope": _proposal_queue_envelope,
+    },
+    {
+        "name": "approval_inbox",
+        "module": "reporting.approval_inbox",
+        "artifact_path": "logs/approval_inbox/latest.json",
+        "fn": _approval_inbox_call,
+        "envelope": _approval_inbox_envelope,
+    },
+    {
+        "name": "execute_safe_controls",
+        "module": "reporting.execute_safe_controls",
+        "artifact_path": "logs/execute_safe_controls/latest.json",
+        "fn": _execute_safe_catalog_call,
+        "envelope": _execute_safe_envelope,
+    },
+)
+
+
+# ---------------------------------------------------------------------------
+# Loop-health bookkeeping (recovers across restarts via latest.json)
+# ---------------------------------------------------------------------------
+
+
+def _read_previous_loop_health() -> dict[str, Any]:
+    """Best-effort read of the prior latest.json so loop-health
+    counters survive process restarts."""
+    p = DIGEST_DIR_JSON / "latest.json"
+    if not p.exists():
+        return {
+            "iterations_completed": 0,
+            "iterations_failed": 0,
+            "last_success_utc": None,
+            "last_failure_utc": None,
+            "consecutive_failures": 0,
+        }
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {
+            "iterations_completed": 0,
+            "iterations_failed": 0,
+            "last_success_utc": None,
+            "last_failure_utc": None,
+            "consecutive_failures": 0,
+        }
+    health = data.get("loop_health") or {}
+    if not isinstance(health, dict):
+        return {
+            "iterations_completed": 0,
+            "iterations_failed": 0,
+            "last_success_utc": None,
+            "last_failure_utc": None,
+            "consecutive_failures": 0,
+        }
+    return {
+        "iterations_completed": int(health.get("iterations_completed") or 0),
+        "iterations_failed": int(health.get("iterations_failed") or 0),
+        "last_success_utc": health.get("last_success_utc") or None,
+        "last_failure_utc": health.get("last_failure_utc") or None,
+        "consecutive_failures": int(health.get("consecutive_failures") or 0),
+    }
+
+
+def _update_loop_health(
+    prev: dict[str, Any],
+    *,
+    sources: list[_SourceResult],
+    generated_at: str,
+) -> dict[str, Any]:
+    iteration_failed = any(
+        r.get("state") in (STATE_FAILED, STATE_TIMEOUT) for r in sources
+    )
+    out = dict(prev)
+    out["iterations_completed"] = (prev.get("iterations_completed") or 0) + 1
+    if iteration_failed:
+        out["iterations_failed"] = (prev.get("iterations_failed") or 0) + 1
+        out["last_failure_utc"] = generated_at
+        out["consecutive_failures"] = (prev.get("consecutive_failures") or 0) + 1
+    else:
+        out["last_success_utc"] = generated_at
+        out["consecutive_failures"] = 0
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Snapshot builder
+# ---------------------------------------------------------------------------
+
+
+def collect_snapshot(
+    *,
+    mode: str = "once",
+    iteration: int = 0,
+    max_iterations: int = 1,
+    interval_seconds: int | None = None,
+    sources_override: tuple[dict[str, Any], ...] | None = None,
+    timeout_per_source: int = DEFAULT_SOURCE_TIMEOUT_SECONDS,
+    previous_loop_health: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Run every supervised source once and return a snapshot dict.
+
+    Pure orchestration: every source call goes through ``_supervise``
+    so an exception, timeout, or secret-redaction failure on one
+    source is contained.
+    """
+    start = time.monotonic()
+    generated_at = _utcnow()
+    sources_to_run = sources_override if sources_override is not None else SOURCES
+    results: list[_SourceResult] = []
+    for src in sources_to_run:
+        results.append(
+            _supervise(
+                name=src["name"],
+                module=src["module"],
+                artifact_path=src["artifact_path"],
+                fn=src["fn"],
+                timeout=timeout_per_source,
+                state_from_envelope=src.get("envelope"),
+            )
+        )
+    duration_ms = int((time.monotonic() - start) * 1000)
+
+    # Counts.
+    counts: dict[str, int] = {}
+    for r in results:
+        s = r.get("state", STATE_UNKNOWN)
+        counts[s] = counts.get(s, 0) + 1
+
+    prev_health = (
+        previous_loop_health
+        if previous_loop_health is not None
+        else _read_previous_loop_health()
+    )
+    health = _update_loop_health(prev_health, sources=results, generated_at=generated_at)
+
+    # next_run_after_utc only meaningful in loop mode.
+    next_run = None
+    if mode == "loop" and interval_seconds is not None:
+        # interval is sanitized at the CLI boundary.
+        next_run_dt = _utcnow_dt() + _dt.timedelta(seconds=interval_seconds)
+        next_run = next_run_dt.isoformat().replace("+00:00", "Z")
+
+    snap: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": "workloop_runtime_digest",
+        "runtime_version": RUNTIME_VERSION,
+        "generated_at_utc": generated_at,
+        "run_id": _run_id(generated_at, iteration),
+        "mode": mode,
+        "iteration": iteration,
+        "max_iterations": max_iterations,
+        "interval_seconds": interval_seconds,
+        "next_run_after_utc": next_run,
+        "duration_ms": duration_ms,
+        "safe_to_execute": False,
+        "loop_health": health,
+        "sources": list(results),
+        "counts": {"by_state": counts, "total": len(results)},
+        "final_recommendation": _final_recommendation(counts, health),
+    }
+    # Outer defense-in-depth credential-value guard. The strict
+    # path-fragment check already ran per source via _supervise; this
+    # outer layer only catches actual credential VALUES (sk-ant-…,
+    # ghp_…, AWS keys, private-key blocks) leaking into metadata.
+    _assert_no_credential_values(snap)
+    return snap
+
+
+def _final_recommendation(counts: dict[str, int], health: dict[str, Any]) -> str:
+    failed = counts.get(STATE_FAILED, 0)
+    timeouts = counts.get(STATE_TIMEOUT, 0)
+    not_available = counts.get(STATE_NOT_AVAILABLE, 0)
+    consecutive = int(health.get("consecutive_failures") or 0)
+    if consecutive >= 3:
+        return f"runtime_halt_after_{consecutive}_consecutive_failures"
+    if failed + timeouts > 0:
+        return f"degraded_failed_{failed}_timeout_{timeouts}"
+    if not_available > 0:
+        return f"degraded_not_available_{not_available}"
+    return "all_sources_ok"
+
+
+# ---------------------------------------------------------------------------
+# Atomic persistence
+# ---------------------------------------------------------------------------
+
+
+def write_outputs(snapshot: dict[str, Any]) -> dict[str, str]:
+    """Atomic write to ``latest.json`` and the timestamped copy, plus
+    one history line. ``os.replace`` is atomic on POSIX and on Windows
+    (NTFS) — on Windows it is implemented via MoveFileExW + REPLACE_EXISTING.
+    """
+    DIGEST_DIR_JSON.mkdir(parents=True, exist_ok=True)
+    ts = snapshot["generated_at_utc"].replace(":", "-")
+    json_now = DIGEST_DIR_JSON / f"{ts}.json"
+    json_latest = DIGEST_DIR_JSON / "latest.json"
+    history = DIGEST_DIR_JSON / "history.jsonl"
+    payload = json.dumps(snapshot, sort_keys=True, indent=2)
+
+    # Atomic write to the timestamped copy.
+    tmp_now = json_now.with_suffix(json_now.suffix + ".tmp")
+    tmp_now.write_text(payload, encoding="utf-8")
+    os.replace(tmp_now, json_now)
+
+    # Atomic write to latest.
+    tmp_latest = json_latest.with_suffix(json_latest.suffix + ".tmp")
+    tmp_latest.write_text(payload, encoding="utf-8")
+    os.replace(tmp_latest, json_latest)
+
+    # Append one line to history.jsonl. JSONL is append-only by
+    # design; we use a single-line compact form so each record is
+    # one row.
+    compact = json.dumps(snapshot, sort_keys=True, separators=(",", ":"))
+    with history.open("a", encoding="utf-8") as f:
+        f.write(compact + "\n")
+
+    return {
+        "json_now": _rel(json_now),
+        "json_latest": _rel(json_latest),
+        "history_jsonl": _rel(history),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Loop driver
+# ---------------------------------------------------------------------------
+
+
+def run_once(
+    *,
+    iteration: int = 0,
+    max_iterations: int = 1,
+    interval_seconds: int | None = None,
+    timeout_per_source: int = DEFAULT_SOURCE_TIMEOUT_SECONDS,
+    sources_override: tuple[dict[str, Any], ...] | None = None,
+    write: bool = True,
+) -> dict[str, Any]:
+    snap = collect_snapshot(
+        mode="loop" if max_iterations > 1 else "once",
+        iteration=iteration,
+        max_iterations=max_iterations,
+        interval_seconds=interval_seconds,
+        sources_override=sources_override,
+        timeout_per_source=timeout_per_source,
+    )
+    if write:
+        write_outputs(snap)
+    return snap
+
+
+def run_loop(
+    *,
+    interval_seconds: int,
+    max_iterations: int,
+    timeout_per_source: int = DEFAULT_SOURCE_TIMEOUT_SECONDS,
+    sources_override: tuple[dict[str, Any], ...] | None = None,
+    write: bool = True,
+    sleeper: Callable[[float], None] = time.sleep,
+) -> list[dict[str, Any]]:
+    """Bounded loop. Honours ``max_iterations`` (clamped to
+    :data:`MAX_ITERATIONS_LIMIT`) and ``interval_seconds`` (clamped to
+    [:data:`MIN_INTERVAL_SECONDS`, :data:`MAX_INTERVAL_SECONDS`]).
+
+    Returns the list of snapshots in iteration order. On
+    KeyboardInterrupt the loop exits gracefully and the caller can
+    inspect the partial list.
+    """
+    iters = max(1, min(max_iterations, MAX_ITERATIONS_LIMIT))
+    interval = max(MIN_INTERVAL_SECONDS, min(interval_seconds, MAX_INTERVAL_SECONDS))
+    snapshots: list[dict[str, Any]] = []
+    try:
+        for i in range(iters):
+            snap = run_once(
+                iteration=i,
+                max_iterations=iters,
+                interval_seconds=interval,
+                timeout_per_source=timeout_per_source,
+                sources_override=sources_override,
+                write=write,
+            )
+            snapshots.append(snap)
+            if i < iters - 1:
+                sleeper(interval)
+    except KeyboardInterrupt:
+        # Graceful stop: fall through with the partial snapshot list.
+        pass
+    return snapshots
+
+
+# ---------------------------------------------------------------------------
+# Read-side helpers (for status / inbox integration)
+# ---------------------------------------------------------------------------
+
+
+def read_latest_snapshot() -> dict[str, Any] | None:
+    """Return the most recent snapshot, or ``None`` if missing /
+    malformed. Never raises."""
+    p = DIGEST_DIR_JSON / "latest.json"
+    if not p.exists():
+        return None
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    return data
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m reporting.workloop_runtime",
+        description=(
+            "Long-running workloop runtime. Periodically invokes the "
+            "existing read-only / dry-run governance reporters and "
+            "writes a single runtime-state artifact. Observe / "
+            "classify / report — never an autonomous executor."
+        ),
+    )
+    mode = p.add_mutually_exclusive_group()
+    mode.add_argument("--once", action="store_true", help="Run a single iteration and exit (default).")
+    mode.add_argument("--loop", action="store_true", help="Run a bounded loop.")
+    mode.add_argument("--status", action="store_true", help="Print the most recent snapshot from latest.json.")
+    p.add_argument(
+        "--interval-seconds",
+        type=int,
+        default=300,
+        help=f"Loop interval (clamped to [{MIN_INTERVAL_SECONDS}, {MAX_INTERVAL_SECONDS}]).",
+    )
+    p.add_argument(
+        "--max-iterations",
+        type=int,
+        default=1,
+        help=f"Max iterations in --loop mode (clamped to {MAX_ITERATIONS_LIMIT}).",
+    )
+    p.add_argument(
+        "--timeout-per-source-seconds",
+        type=int,
+        default=DEFAULT_SOURCE_TIMEOUT_SECONDS,
+        help="Per-source wall-clock timeout (seconds).",
+    )
+    p.add_argument(
+        "--no-write",
+        action="store_true",
+        help="Do not persist the JSON digest (stdout only).",
+    )
+    p.add_argument(
+        "--indent",
+        type=int,
+        default=2,
+        help="JSON indent (0 for compact).",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    indent = args.indent if args.indent and args.indent > 0 else None
+
+    if args.status:
+        snap = read_latest_snapshot()
+        if snap is None:
+            sys.stdout.write(
+                json.dumps({"status": "not_available", "reason": "no latest.json"}, indent=indent)
+                + "\n"
+            )
+            return 0
+        sys.stdout.write(json.dumps(snap, indent=indent, sort_keys=True) + "\n")
+        return 0
+
+    if args.loop:
+        snaps = run_loop(
+            interval_seconds=args.interval_seconds,
+            max_iterations=args.max_iterations,
+            timeout_per_source=args.timeout_per_source_seconds,
+            write=not args.no_write,
+        )
+        # Print the last snapshot for operator visibility.
+        last = snaps[-1] if snaps else {}
+        sys.stdout.write(json.dumps(last, indent=indent, sort_keys=True) + "\n")
+        return 0
+
+    # Default: --once.
+    snap = run_once(
+        timeout_per_source=args.timeout_per_source_seconds,
+        write=not args.no_write,
+    )
+    sys.stdout.write(json.dumps(snap, indent=indent, sort_keys=True) + "\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/unit/test_approval_inbox.py
+++ b/tests/unit/test_approval_inbox.py
@@ -119,6 +119,59 @@ def _pr_envelope(prs: list[dict]) -> dict:
     )
 
 
+def _empty_runtime() -> dict:
+    return _ok_envelope(
+        {
+            "schema_version": 1,
+            "report_kind": "workloop_runtime_digest",
+            "loop_health": {
+                "consecutive_failures": 0,
+                "iterations_completed": 1,
+                "iterations_failed": 0,
+            },
+            "sources": [],
+        }
+    )
+
+
+def _runtime_with_consecutive_failures(n: int) -> dict:
+    return _ok_envelope(
+        {
+            "schema_version": 1,
+            "report_kind": "workloop_runtime_digest",
+            "loop_health": {
+                "consecutive_failures": n,
+                "iterations_completed": n,
+                "iterations_failed": n,
+            },
+            "sources": [],
+            "final_recommendation": (
+                f"runtime_halt_after_{n}_consecutive_failures"
+            ),
+        }
+    )
+
+
+def _runtime_with_failed_source(name: str, state: str) -> dict:
+    return _ok_envelope(
+        {
+            "schema_version": 1,
+            "report_kind": "workloop_runtime_digest",
+            "loop_health": {"consecutive_failures": 0, "iterations_completed": 1, "iterations_failed": 0},
+            "sources": [
+                {
+                    "source": name,
+                    "module": f"reporting.{name}",
+                    "state": state,
+                    "summary": "synthetic",
+                    "duration_ms": 100,
+                    "error_class": "RuntimeError" if state == "failed" else None,
+                }
+            ],
+        }
+    )
+
+
 def _empty_workloop() -> dict:
     return _ok_envelope(
         {
@@ -519,6 +572,95 @@ def test_workloop_trading_risk_row_becomes_live_paper_shadow_risk_change() -> No
 # ---------------------------------------------------------------------------
 # Governance projection
 # ---------------------------------------------------------------------------
+
+
+def test_runtime_consecutive_failures_emit_runtime_halt() -> None:
+    sources = {
+        "proposal_queue": _proposal_envelope([]),
+        "pr_lifecycle": _pr_envelope([]),
+        "workloop": _empty_workloop(),
+        "workloop_runtime": _runtime_with_consecutive_failures(3),
+        "governance_status": _empty_governance(),
+    }
+    snap = _build(sources)
+    cats = _categories(snap)
+    assert "runtime_halt" in cats
+    item = next(it for it in snap["items"] if it["category"] == "runtime_halt")
+    assert item["severity"] == "critical"
+    assert item["status"] == ai.STATUS_BLOCKED
+
+
+def test_runtime_failed_source_emits_failed_automation() -> None:
+    sources = {
+        "proposal_queue": _proposal_envelope([]),
+        "pr_lifecycle": _pr_envelope([]),
+        "workloop": _empty_workloop(),
+        "workloop_runtime": _runtime_with_failed_source("github_pr_lifecycle", "failed"),
+        "governance_status": _empty_governance(),
+    }
+    snap = _build(sources)
+    failed_items = [
+        it
+        for it in snap["items"]
+        if it["category"] == "failed_automation"
+        and (it["source"] or "").startswith("workloop_runtime:")
+    ]
+    assert len(failed_items) == 1
+    assert "github_pr_lifecycle" in (failed_items[0]["title"] or "")
+
+
+def test_runtime_timeout_source_emits_failed_automation() -> None:
+    sources = {
+        "proposal_queue": _proposal_envelope([]),
+        "pr_lifecycle": _pr_envelope([]),
+        "workloop": _empty_workloop(),
+        "workloop_runtime": _runtime_with_failed_source("autonomous_workloop", "timeout"),
+        "governance_status": _empty_governance(),
+    }
+    snap = _build(sources)
+    failed_items = [
+        it
+        for it in snap["items"]
+        if it["category"] == "failed_automation"
+        and (it["source"] or "").startswith("workloop_runtime:")
+    ]
+    assert len(failed_items) == 1
+    assert "timeout" in (failed_items[0]["title"] or "").lower()
+
+
+def test_runtime_unknown_source_emits_unknown_state() -> None:
+    sources = {
+        "proposal_queue": _proposal_envelope([]),
+        "pr_lifecycle": _pr_envelope([]),
+        "workloop": _empty_workloop(),
+        "workloop_runtime": _runtime_with_failed_source("approval_inbox", "unknown"),
+        "governance_status": _empty_governance(),
+    }
+    snap = _build(sources)
+    runtime_unknown = [
+        it
+        for it in snap["items"]
+        if it["category"] == "unknown_state"
+        and (it["source"] or "").startswith("workloop_runtime:")
+    ]
+    assert len(runtime_unknown) == 1
+
+
+def test_runtime_clean_artifact_yields_no_runtime_inbox_items() -> None:
+    sources = {
+        "proposal_queue": _proposal_envelope([]),
+        "pr_lifecycle": _pr_envelope([]),
+        "workloop": _empty_workloop(),
+        "workloop_runtime": _empty_runtime(),
+        "governance_status": _empty_governance(),
+    }
+    snap = _build(sources)
+    runtime_items = [
+        it
+        for it in snap["items"]
+        if (it["source"] or "").startswith("workloop_runtime:")
+    ]
+    assert runtime_items == []
 
 
 def test_broken_audit_chain_becomes_security_alert() -> None:

--- a/tests/unit/test_dashboard_api_agent_control.py
+++ b/tests/unit/test_dashboard_api_agent_control.py
@@ -195,6 +195,18 @@ def test_notifications_is_placeholder(client) -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_status_payload_includes_workloop_runtime_block(client) -> None:
+    """v3.15.15.22: status payload now carries a workloop_runtime
+    summary. When the artifact is missing the block reports
+    not_available — the surface never silently OKs."""
+    body = client.get("/api/agent-control/status").get_json()
+    assert "workloop_runtime" in body
+    rt = body["workloop_runtime"]
+    assert rt["status"] in ("ok", "not_available")
+    if rt["status"] == "not_available":
+        assert "reason" in rt
+
+
 def test_status_payload_includes_frozen_hashes(client) -> None:
     resp = client.get("/api/agent-control/status")
     body = resp.get_json()

--- a/tests/unit/test_workloop_runtime.py
+++ b/tests/unit/test_workloop_runtime.py
@@ -1,0 +1,563 @@
+"""Unit tests for ``reporting.workloop_runtime``.
+
+Verbatim properties from the v3.15.15.22 brief:
+
+* once mode builds a valid artifact
+* loop mode respects max_iterations
+* one failing source does not crash all sources
+* timeout classified as timeout
+* missing source classified as not_available / skipped as appropriate
+* malformed JSON handled safely
+* JSON artifact write is atomic
+* history.jsonl appends one record per run
+* no arbitrary command execution
+* no GitHub mutation functions called
+* redaction of credential-shaped values
+* schema stability
+* safe_to_execute remains false
+* KeyboardInterrupt produces graceful stop (best effort, optional)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reporting import workloop_runtime as wlr
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / fakes
+# ---------------------------------------------------------------------------
+
+
+def _ok_source(name: str = "fake_ok"):
+    return {
+        "name": name,
+        "module": f"reporting.{name}",
+        "artifact_path": f"logs/{name}/latest.json",
+        "fn": lambda: {"hello": "world", "count": 1},
+        "envelope": lambda v: (wlr.STATE_OK, "fake ok"),
+    }
+
+
+def _failing_source(name: str = "fake_fail"):
+    def boom():
+        raise RuntimeError("synthetic failure")
+
+    return {
+        "name": name,
+        "module": f"reporting.{name}",
+        "artifact_path": f"logs/{name}/latest.json",
+        "fn": boom,
+        "envelope": None,
+    }
+
+
+def _slow_source(name: str = "fake_slow", duration: float = 5.0):
+    def slow():
+        time.sleep(duration)
+        return {"slow": True}
+
+    return {
+        "name": name,
+        "module": f"reporting.{name}",
+        "artifact_path": f"logs/{name}/latest.json",
+        "fn": slow,
+        "envelope": lambda v: (wlr.STATE_OK, "ok"),
+    }
+
+
+def _credential_leaking_source(name: str = "fake_leaky"):
+    return {
+        "name": name,
+        "module": f"reporting.{name}",
+        "artifact_path": f"logs/{name}/latest.json",
+        "fn": lambda: {"secret": "sk-ant-api03-leaked-fake-token"},
+        "envelope": None,
+    }
+
+
+def _path_only_source(name: str = "fake_paths"):
+    """Returns a snapshot whose strings include a no-touch path
+    fragment (e.g. ``config/config.yaml``). The runtime supervisor
+    must NOT classify this as a leak — only credential VALUES are
+    refused."""
+    return {
+        "name": name,
+        "module": f"reporting.{name}",
+        "artifact_path": f"logs/{name}/latest.json",
+        "fn": lambda: {"forbidden_actions": ["edit config/config.yaml", "modify VERSION"]},
+        "envelope": None,
+    }
+
+
+def _none_source(name: str = "fake_none"):
+    return {
+        "name": name,
+        "module": f"reporting.{name}",
+        "artifact_path": f"logs/{name}/latest.json",
+        "fn": lambda: None,
+        "envelope": None,
+    }
+
+
+@pytest.fixture
+def isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setattr(wlr, "DIGEST_DIR_JSON", tmp_path / "wlr")
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Once mode
+# ---------------------------------------------------------------------------
+
+
+def test_once_mode_writes_one_artifact(isolated: Path) -> None:
+    snap = wlr.run_once(
+        timeout_per_source=2,
+        sources_override=(_ok_source("a"), _ok_source("b")),
+        write=True,
+    )
+    assert snap["mode"] == "once"
+    assert snap["iteration"] == 0
+    assert snap["max_iterations"] == 1
+    assert snap["safe_to_execute"] is False
+    latest = (isolated / "wlr" / "latest.json").read_text(encoding="utf-8")
+    parsed = json.loads(latest)
+    assert parsed["report_kind"] == "workloop_runtime_digest"
+    assert parsed["run_id"].startswith("wl_")
+
+
+def test_once_mode_contains_required_top_level_fields(isolated: Path) -> None:
+    snap = wlr.run_once(
+        timeout_per_source=2,
+        sources_override=(_ok_source("a"),),
+        write=False,
+    )
+    required = {
+        "schema_version",
+        "report_kind",
+        "runtime_version",
+        "generated_at_utc",
+        "run_id",
+        "mode",
+        "iteration",
+        "max_iterations",
+        "interval_seconds",
+        "next_run_after_utc",
+        "duration_ms",
+        "safe_to_execute",
+        "loop_health",
+        "sources",
+        "counts",
+        "final_recommendation",
+    }
+    assert required.issubset(snap.keys())
+
+
+def test_safe_to_execute_is_always_false(isolated: Path) -> None:
+    """v3.15.15.22 hard-codes safe_to_execute=false. Verified across
+    once + loop modes and across healthy and failing source sets."""
+    for sources in (
+        (_ok_source("a"),),
+        (_failing_source("b"),),
+        (_ok_source("a"), _failing_source("b"), _none_source("c")),
+    ):
+        snap = wlr.run_once(
+            timeout_per_source=2,
+            sources_override=sources,
+            write=False,
+        )
+        assert snap["safe_to_execute"] is False
+
+
+def test_every_source_carries_required_fields(isolated: Path) -> None:
+    snap = wlr.run_once(
+        timeout_per_source=2,
+        sources_override=(_ok_source("a"),),
+        write=False,
+    )
+    required = {
+        "source",
+        "module",
+        "state",
+        "duration_ms",
+        "summary",
+        "artifact_path",
+        "error_class",
+    }
+    for s in snap["sources"]:
+        assert required.issubset(s.keys())
+        assert s["state"] in wlr.STATE_VALUES
+
+
+# ---------------------------------------------------------------------------
+# One failing source does not crash others
+# ---------------------------------------------------------------------------
+
+
+def test_one_failing_source_does_not_crash_others(isolated: Path) -> None:
+    snap = wlr.run_once(
+        timeout_per_source=2,
+        sources_override=(
+            _ok_source("a"),
+            _failing_source("b"),
+            _ok_source("c"),
+        ),
+        write=False,
+    )
+    states = {s["source"]: s["state"] for s in snap["sources"]}
+    assert states["a"] == "ok"
+    assert states["b"] == "failed"
+    assert states["c"] == "ok"
+
+
+def test_failed_source_records_error_class(isolated: Path) -> None:
+    snap = wlr.run_once(
+        timeout_per_source=2,
+        sources_override=(_failing_source("b"),),
+        write=False,
+    )
+    s = snap["sources"][0]
+    assert s["state"] == "failed"
+    assert s["error_class"] == "RuntimeError"
+    assert "synthetic failure" in (s["summary"] or "")
+
+
+# ---------------------------------------------------------------------------
+# Timeout
+# ---------------------------------------------------------------------------
+
+
+def test_timeout_classified_as_timeout(isolated: Path) -> None:
+    """A source that runs longer than the per-source budget is
+    classified as ``timeout`` and the supervisor moves on."""
+    snap = wlr.run_once(
+        timeout_per_source=1,
+        sources_override=(_slow_source("slow", duration=3.0), _ok_source("ok")),
+        write=False,
+    )
+    states = {s["source"]: s["state"] for s in snap["sources"]}
+    assert states["slow"] == "timeout"
+    assert states["ok"] == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Missing / not_available
+# ---------------------------------------------------------------------------
+
+
+def test_missing_source_classified_not_available(isolated: Path) -> None:
+    """A source whose function returns ``None`` is classified as
+    ``not_available`` (never silently OK)."""
+    snap = wlr.run_once(
+        timeout_per_source=2,
+        sources_override=(_none_source("none"),),
+        write=False,
+    )
+    s = snap["sources"][0]
+    assert s["state"] == "not_available"
+
+
+# ---------------------------------------------------------------------------
+# Credential redaction
+# ---------------------------------------------------------------------------
+
+
+def test_credential_value_in_source_is_classified_failed(isolated: Path) -> None:
+    """A source that produces a credential-value string (e.g. an
+    Anthropic key) is supposed to be caught at the per-source layer
+    and surfaced as ``failed`` with ``error_class=SecretRedactionFailed``.
+    """
+    snap = wlr.run_once(
+        timeout_per_source=2,
+        sources_override=(_credential_leaking_source("leak"),),
+        write=False,
+    )
+    s = snap["sources"][0]
+    assert s["state"] == "failed"
+    assert s["error_class"] == "SecretRedactionFailed"
+
+
+def test_path_fragment_in_source_is_NOT_classified_failed(isolated: Path) -> None:
+    """A source that legitimately echoes a no-touch path string
+    (e.g. ``config/config.yaml`` in a forbidden-actions list) is NOT
+    classified as a leak — only credential VALUES are."""
+    snap = wlr.run_once(
+        timeout_per_source=2,
+        sources_override=(_path_only_source("paths"),),
+        write=False,
+    )
+    s = snap["sources"][0]
+    assert s["state"] != "failed", s
+    assert s["state"] in (wlr.STATE_OK, wlr.STATE_DEGRADED), s
+
+
+# ---------------------------------------------------------------------------
+# Atomic JSON write + history.jsonl
+# ---------------------------------------------------------------------------
+
+
+def test_json_write_is_atomic(isolated: Path) -> None:
+    """The supervisor writes via ``tmp`` + ``os.replace``; the tmp
+    file must not exist after a successful write."""
+    wlr.run_once(
+        timeout_per_source=2,
+        sources_override=(_ok_source("a"),),
+        write=True,
+    )
+    latest = isolated / "wlr" / "latest.json"
+    tmp = isolated / "wlr" / "latest.json.tmp"
+    assert latest.exists()
+    assert not tmp.exists()
+
+
+def test_history_jsonl_appends_one_record_per_run(isolated: Path) -> None:
+    for _ in range(3):
+        wlr.run_once(
+            timeout_per_source=2,
+            sources_override=(_ok_source("a"),),
+            write=True,
+        )
+    history = (isolated / "wlr" / "history.jsonl").read_text(encoding="utf-8")
+    lines = [ln for ln in history.splitlines() if ln.strip()]
+    assert len(lines) == 3
+    for ln in lines:
+        rec = json.loads(ln)
+        assert rec["report_kind"] == "workloop_runtime_digest"
+
+
+# ---------------------------------------------------------------------------
+# Loop mode
+# ---------------------------------------------------------------------------
+
+
+def test_loop_mode_respects_max_iterations(isolated: Path) -> None:
+    sleeps: list[float] = []
+    snaps = wlr.run_loop(
+        interval_seconds=30,
+        max_iterations=4,
+        timeout_per_source=2,
+        sources_override=(_ok_source("a"),),
+        write=True,
+        sleeper=lambda s: sleeps.append(s),
+    )
+    assert len(snaps) == 4
+    # Sleeps happen between iterations only (n-1).
+    assert len(sleeps) == 3
+
+
+def test_loop_clamps_max_iterations(isolated: Path) -> None:
+    """A request for a runaway loop is clamped to MAX_ITERATIONS_LIMIT."""
+    snaps = wlr.run_loop(
+        interval_seconds=30,
+        max_iterations=10_000,
+        timeout_per_source=2,
+        sources_override=(_ok_source("a"),),
+        write=False,
+        sleeper=lambda s: None,
+    )
+    assert len(snaps) == wlr.MAX_ITERATIONS_LIMIT
+
+
+def test_loop_clamps_interval_seconds(isolated: Path) -> None:
+    """interval is clamped to [MIN, MAX]; capture the value as
+    persisted in the snapshot for verification."""
+    sleeps: list[float] = []
+    wlr.run_loop(
+        interval_seconds=1,  # below MIN, should clamp up
+        max_iterations=2,
+        timeout_per_source=2,
+        sources_override=(_ok_source("a"),),
+        write=False,
+        sleeper=lambda s: sleeps.append(s),
+    )
+    assert all(s >= wlr.MIN_INTERVAL_SECONDS for s in sleeps)
+
+
+def test_loop_health_increments_consecutive_failures(isolated: Path) -> None:
+    """Three consecutive failed iterations should drive
+    ``consecutive_failures`` to 3."""
+    snaps = wlr.run_loop(
+        interval_seconds=30,
+        max_iterations=3,
+        timeout_per_source=2,
+        sources_override=(_failing_source("b"),),
+        write=True,
+        sleeper=lambda s: None,
+    )
+    last = snaps[-1]
+    assert last["loop_health"]["consecutive_failures"] == 3
+    assert last["final_recommendation"].startswith(
+        "runtime_halt_after_3_consecutive_failures"
+    )
+
+
+def test_loop_health_resets_on_success(isolated: Path) -> None:
+    # Two failed then one ok.
+    sources_seq = [
+        (_failing_source("b"),),
+        (_failing_source("b"),),
+        (_ok_source("a"),),
+    ]
+    for srcs in sources_seq:
+        wlr.run_once(
+            timeout_per_source=2,
+            sources_override=srcs,
+            write=True,
+        )
+    last = json.loads(
+        (isolated / "wlr" / "latest.json").read_text(encoding="utf-8")
+    )
+    assert last["loop_health"]["consecutive_failures"] == 0
+    assert last["loop_health"]["last_success_utc"] is not None
+
+
+# ---------------------------------------------------------------------------
+# Static module invariants
+# ---------------------------------------------------------------------------
+
+
+def test_module_does_not_invoke_subprocess_or_gh_or_git() -> None:
+    src = Path(wlr.__file__).read_text(encoding="utf-8")
+    forbidden = (
+        "import subprocess",
+        "from subprocess",
+        '"gh"',
+        "'gh'",
+        '"git"',
+        "'git'",
+        "Popen",
+        "os.system",
+        "shell=True",
+    )
+    for token in forbidden:
+        assert token not in src, f"forbidden token in workloop_runtime.py: {token!r}"
+
+
+def test_module_does_not_offer_freeform_command_input() -> None:
+    """The CLI must not accept any --command / --argv / --shell flag."""
+    src = Path(wlr.__file__).read_text(encoding="utf-8")
+    for forbidden_flag in ("--command", "--argv", "--shell", "--cmd"):
+        assert forbidden_flag not in src
+
+
+# ---------------------------------------------------------------------------
+# Frozen-contract integrity
+# ---------------------------------------------------------------------------
+
+
+def test_frozen_contracts_byte_identical_around_run(isolated: Path) -> None:
+    import hashlib
+
+    paths = [
+        REPO_ROOT / "research" / "research_latest.json",
+        REPO_ROOT / "research" / "strategy_matrix.csv",
+    ]
+
+    def _sha(p: Path) -> str:
+        h = hashlib.sha256()
+        with p.open("rb") as f:
+            for chunk in iter(lambda: f.read(8192), b""):
+                h.update(chunk)
+        return h.hexdigest()
+
+    before = {p.name: _sha(p) for p in paths if p.exists()}
+    wlr.run_once(
+        timeout_per_source=2,
+        sources_override=(_ok_source("a"), _failing_source("b")),
+        write=True,
+    )
+    after = {p.name: _sha(p) for p in paths if p.exists()}
+    assert before == after
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def test_cli_once_default(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(wlr, "DIGEST_DIR_JSON", tmp_path / "wlr")
+    # Stub SOURCES so the CLI smoke is fast.
+    monkeypatch.setattr(wlr, "SOURCES", (_ok_source("a"),))
+    rc = wlr.main(["--once", "--no-write"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["report_kind"] == "workloop_runtime_digest"
+
+
+def test_cli_status_when_no_artifact(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(wlr, "DIGEST_DIR_JSON", tmp_path / "wlr")
+    rc = wlr.main(["--status"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "not_available"
+
+
+def test_cli_status_returns_latest(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(wlr, "DIGEST_DIR_JSON", tmp_path / "wlr")
+    monkeypatch.setattr(wlr, "SOURCES", (_ok_source("a"),))
+    # Run --once first to write latest.json.
+    wlr.main(["--once"])
+    capsys.readouterr()
+    rc = wlr.main(["--status"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["report_kind"] == "workloop_runtime_digest"
+
+
+# ---------------------------------------------------------------------------
+# read_latest_snapshot helper (used by api_agent_control + approval_inbox)
+# ---------------------------------------------------------------------------
+
+
+def test_read_latest_snapshot_handles_missing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(wlr, "DIGEST_DIR_JSON", tmp_path / "wlr")
+    assert wlr.read_latest_snapshot() is None
+
+
+def test_read_latest_snapshot_handles_malformed(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(wlr, "DIGEST_DIR_JSON", tmp_path / "wlr")
+    (tmp_path / "wlr").mkdir()
+    (tmp_path / "wlr" / "latest.json").write_text("{ not json", encoding="utf-8")
+    assert wlr.read_latest_snapshot() is None
+
+
+def test_read_latest_snapshot_handles_non_object(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(wlr, "DIGEST_DIR_JSON", tmp_path / "wlr")
+    (tmp_path / "wlr").mkdir()
+    (tmp_path / "wlr" / "latest.json").write_text("[1, 2]", encoding="utf-8")
+    assert wlr.read_latest_snapshot() is None
+
+
+def test_read_latest_snapshot_returns_dict(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(wlr, "DIGEST_DIR_JSON", tmp_path / "wlr")
+    (tmp_path / "wlr").mkdir()
+    (tmp_path / "wlr" / "latest.json").write_text(
+        json.dumps({"report_kind": "workloop_runtime_digest", "x": 1}),
+        encoding="utf-8",
+    )
+    out = wlr.read_latest_snapshot()
+    assert isinstance(out, dict)
+    assert out["report_kind"] == "workloop_runtime_digest"


### PR DESCRIPTION
## Summary

A controlled, deterministic, bounded supervisor that periodically runs the existing read-only / dry-run governance reporters and captures their results in a single runtime-state artifact. **Observe / classify / report — never an autonomous executor.**

## What changed

### Backend module — `reporting/workloop_runtime.py`

Stdlib-only. CLI:

```sh
python -m reporting.workloop_runtime --once
python -m reporting.workloop_runtime --loop --interval-seconds 300 --max-iterations 3
python -m reporting.workloop_runtime --status
```

**Closed catalog** of seven supervised reporters: `governance_status`, `agent_audit_summary`, `autonomous_workloop`, `github_pr_lifecycle`, `proposal_queue`, `approval_inbox`, `execute_safe_controls`.

### Inbox integration — `reporting/approval_inbox.py`

Reads `logs/workloop_runtime/latest.json` and emits:
- `consecutive_failures >= 3` → **`runtime_halt`** (severity: critical).
- Each `failed`/`timeout` source → **`failed_automation`** (severity: high).
- Each `unknown` source → **`unknown_state`**.
- A clean runtime artifact emits zero new inbox items.

### Status integration — `dashboard/api_agent_control.py`

`_status_payload()` now carries a `workloop_runtime` block that strips per-source summary detail and surfaces only counts + `loop_health` + `final_recommendation` + per-source states. **No new dashboard.py wiring** — the already-wired `/api/agent-control/status` endpoint carries the new block.

### Frontend — Status card runtime row

`StatusCard` now renders a runtime pill (ok/warn/danger/unknown) and the `final_recommendation`. No new buttons; **still exactly ONE button on the entire page** (the Vernieuw refresh).

## Hard guarantees (enforced by code AND tests)

| guarantee | enforcement |
|---|---|
| Stdlib-only — no subprocess / `gh` / `git` / network / shell | `test_module_does_not_invoke_subprocess_or_gh_or_git` |
| No free-form command input (no `--command`, `--argv`, etc.) | `test_module_does_not_offer_freeform_command_input` |
| `--once` runs exactly one iteration | `test_once_mode_writes_one_artifact` |
| `--loop` honours `--max-iterations` clamped to 24 | `test_loop_mode_respects_max_iterations`, `test_loop_clamps_max_iterations` |
| `--interval-seconds` clamped to `[30, 21600]` | `test_loop_clamps_interval_seconds` |
| One failing source does NOT crash others | `test_one_failing_source_does_not_crash_others` |
| Timeout produces `state="timeout"` | `test_timeout_classified_as_timeout` |
| `None` source returns `not_available` (never silently OK) | `test_missing_source_classified_not_available` |
| Credential VALUE patterns refused at every layer | `test_credential_value_in_source_is_classified_failed` |
| Sensitive-PATH fragments allowed in metadata | `test_path_fragment_in_source_is_NOT_classified_failed` |
| JSON write is atomic (`tmp` + `os.replace`) | `test_json_write_is_atomic` |
| `history.jsonl` appends one record per iteration | `test_history_jsonl_appends_one_record_per_run` |
| `safe_to_execute` is **always `false`** | `test_safe_to_execute_is_always_false` |
| Loop health survives process restarts | `test_loop_health_increments_consecutive_failures`, `test_loop_health_resets_on_success` |
| Frozen-contract sha256 unchanged around runs | `test_frozen_contracts_byte_identical_around_run` |
| Inbox emits `runtime_halt` after 3 consecutive failures | `test_runtime_consecutive_failures_emit_runtime_halt` |
| Inbox emits `failed_automation` per failed/timeout source | `test_runtime_failed_source_emits_failed_automation`, `test_runtime_timeout_source_emits_failed_automation` |
| Inbox emits `unknown_state` per unknown source | `test_runtime_unknown_source_emits_unknown_state` |
| Clean runtime artifact emits zero new inbox items | `test_runtime_clean_artifact_yields_no_runtime_inbox_items` |
| Status endpoint includes `workloop_runtime` block | `test_status_payload_includes_workloop_runtime_block` |
| PWA renders runtime row + recommendation | `test_renders_workloop_runtime_row...` |
| PWA missing-runtime fallback works | `test_renders_runtime_row_as_unknown_when_status_payload_omits_workloop_runtime` |

## Constraints respected

- No write to `dashboard/dashboard.py` (no-touch).
- No write to `.claude/**`.
- No frozen-contract changes.
- No live/paper/shadow/trading/risk behavior changes.
- No CI/test weakening.
- **No new dependencies.**
- No external telemetry, signup-required service, or paid plan.
- No POST/PUT/PATCH/DELETE handler.
- No approve/reject/merge/execute button on the PWA.
- `api_execute_safe_controls` remains intentionally unwired.
- `safe_to_execute` always `false`.
- No browser push, no recurring automation.

## Test plan

- [x] `python scripts/governance_lint.py` — OK.
- [x] `pytest tests/smoke -q` — 14/14 pass.
- [x] `pytest tests/unit -q` — running locally (will report).
- [x] `npm --prefix frontend test -- --run` — **56/56 pass** (was 54; +2 new).
- [x] `npm --prefix frontend run build` — green.
- [x] Frozen-contract hashes unchanged:
  - `research/research_latest.json` = `4a567bd6feb98eb7aa32db4a90a3201456843088314936c5e484a2ae6a93666c`
  - `research/strategy_matrix.csv`   = `ff15b8c4f35cc37b6941b712106ae71a1b82a1b5043da197731d42518d258d66`

## Forward roadmap (not shipped here)

| release | adds |
|---|---|
| **v3.15.15.22 (this)** | observe-only runtime, schema, inbox + status integration, read-only PWA card |
| v3.15.15.23 | browser push for `needs_human` / `runtime_halt` |
| v3.15.15.25 | metrics / observability dashboards on top of `history.jsonl` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)