### PR TITLE
feat(v3.15.15.23): recurring safe maintenance automation

### DIFF
--- a/dashboard/api_agent_control.py
+++ b/dashboard/api_agent_control.py
@@ -182,7 +182,56 @@ def _status_payload() -> dict[str, Any]:
         "governance_status": gov,
         "frozen_hashes": _frozen_hashes_payload(),
         "workloop_runtime": _workloop_runtime_summary(),
+        "recurring_maintenance": _recurring_maintenance_summary(),
     }
+
+
+def _recurring_maintenance_summary() -> dict[str, Any]:
+    """Project the latest recurring-maintenance digest into a compact
+    summary suited for the Status card. Returns ``not_available`` on
+    a missing or malformed artifact.
+
+    The summary surfaces only the per-job last_status + counts +
+    final_recommendation (no executor evidence detail). The full
+    artifact is still readable at
+    ``logs/recurring_maintenance/latest.json``.
+    """
+    try:
+        from reporting.recurring_maintenance import read_latest_snapshot
+
+        snap = read_latest_snapshot()
+        if snap is None:
+            return {"status": "not_available", "reason": "missing"}
+        jobs = []
+        for j in snap.get("jobs") or []:
+            if not isinstance(j, dict):
+                continue
+            jobs.append(
+                {
+                    "job_type": j.get("job_type"),
+                    "last_status": j.get("last_status"),
+                    "enabled": j.get("enabled"),
+                    "consecutive_failures": j.get("consecutive_failures"),
+                    "next_run_after_utc": j.get("next_run_after_utc"),
+                }
+            )
+        return {
+            "status": "ok",
+            "data": {
+                "module_version": snap.get("module_version"),
+                "generated_at_utc": snap.get("generated_at_utc"),
+                "mode": snap.get("mode"),
+                "safe_to_execute": snap.get("safe_to_execute", False),
+                "counts": snap.get("counts") or {},
+                "final_recommendation": snap.get("final_recommendation"),
+                "jobs": jobs,
+            },
+        }
+    except Exception as e:  # noqa: BLE001
+        return {
+            "status": "not_available",
+            "reason": f"recurring_maintenance_error: {type(e).__name__}",
+        }
 
 
 def _workloop_runtime_summary() -> dict[str, Any]:

--- a/docs/governance/recurring_maintenance.md
+++ b/docs/governance/recurring_maintenance.md
@@ -1,0 +1,209 @@
+# Recurring Maintenance — Operator Runbook
+
+> Module: `reporting.recurring_maintenance`
+> Release: v3.15.15.23
+> Schema: [`recurring_maintenance/schema.v1.md`](recurring_maintenance/schema.v1.md)
+> Sits on top of: `reporting.workloop_runtime` (v3.15.15.22),
+> `reporting.proposal_queue` (v3.15.15.19),
+> `reporting.approval_inbox` (v3.15.15.20),
+> `reporting.github_pr_lifecycle` (v3.15.15.17).
+
+This is the operator-facing runbook for the v3.15.15.23 recurring
+safe-maintenance scheduler. It is a **typed, whitelisted,
+deterministic** loop that runs five low-risk maintenance jobs on a
+schedule. The Dependabot execute-safe job is **disabled by default**
+and requires explicit CLI opt-in.
+
+## TL;DR
+
+```sh
+# List the registry + persisted state, no execution.
+python -m reporting.recurring_maintenance --list-jobs
+
+# Show which jobs are due now (no execution).
+python -m reporting.recurring_maintenance --plan
+
+# Run a specific job by name.
+python -m reporting.recurring_maintenance \
+    --run-once refresh_workloop_runtime_once
+
+# Run every job whose next_run_after_utc has passed, exactly once.
+python -m reporting.recurring_maintenance --run-due-once
+
+# Bounded loop. Honors the standard clamps.
+python -m reporting.recurring_maintenance --loop \
+    --interval-seconds 600 --max-iterations 4
+
+# Read latest.json without re-running.
+python -m reporting.recurring_maintenance --status
+
+# Opt in to running the Dependabot LOW/MEDIUM execute-safe job.
+# Without this flag, the job is ALWAYS skipped, regardless of its
+# enabled flag in state.json.
+python -m reporting.recurring_maintenance --run-due-once \
+    --enable-dependabot-execute-safe
+```
+
+## Hard guarantees (enforced by code AND tests)
+
+| guarantee | enforcement |
+|---|---|
+| Closed job registry — exactly five entries | `test_job_registry_contains_only_approved_types` |
+| Unknown job types refused at boundary | `test_unknown_job_type_is_refused` |
+| No `--command`/`--argv`/`--shell`/`--cmd` CLI flags | `test_cli_does_not_accept_freeform_command_flags` |
+| No `subprocess` / `shell=True` / `os.system` / `Popen` | `test_module_does_not_invoke_subprocess_directly` |
+| `--max-iterations` clamped to 24 | `test_loop_clamps_max_iterations` |
+| `--interval-seconds` clamped to `[30, 21600]` | `test_loop_clamps_interval_seconds` |
+| One failing job does NOT crash others | `test_one_failing_job_does_not_crash_others` |
+| Per-job timeout produces `state="timeout"` | `test_job_timeout_classified_as_timeout` |
+| JSON write is atomic (`tmp` + `os.replace`) | `test_json_write_is_atomic` |
+| `history.jsonl` appends one line per run | `test_history_jsonl_appends_one_record_per_run` |
+| `safe_to_execute` is always `false` | `test_safe_to_execute_is_always_false` |
+| Job state survives process restarts via state.json | `test_job_state_persists_across_runs` |
+| Disabled job → `state=skipped` | `test_disabled_job_skipped` |
+| Dependabot job disabled by default | `test_dependabot_job_disabled_by_default` |
+| Dependabot job requires `--enable-dependabot-execute-safe` | `test_dependabot_job_requires_cli_opt_in` |
+| Dependabot job delegates HIGH-risk refusal to lifecycle module | (covered by lifecycle module tests) |
+| Approval inbox surfaces failed/blocked jobs | `test_runtime_halt_after_consecutive_failures`, `test_failed_jobs_emit_failed_automation` |
+| Frozen-contract sha256 unchanged around runs | `test_frozen_contracts_byte_identical_around_run` |
+
+## Job types
+
+| job_type | risk | needs gh? | default interval | default enabled | what it does |
+|---|---|---|---|---|---|
+| `refresh_workloop_runtime_once` | LOW | no | 15 min | ✓ | runs `workloop_runtime.run_once()` in-process |
+| `refresh_proposal_queue` | LOW | no | 60 min | ✓ | refreshes `proposal_queue` dry-run artifact |
+| `refresh_approval_inbox` | LOW | no | 15 min | ✓ | refreshes `approval_inbox` dry-run artifact |
+| `refresh_github_pr_lifecycle_dry_run` | LOW | yes | 30 min | ✓ | refreshes `github_pr_lifecycle` dry-run artifact |
+| `dependabot_low_medium_execute_safe` | MEDIUM | yes | 60 min | **✗** | delegates to `github_pr_lifecycle` execute-safe path |
+
+## Dependabot execute-safe — two-layer opt-in
+
+The Dependabot LOW/MEDIUM execute-safe job is the **only** job that
+can mutate GitHub state (post `@dependabot rebase` comments,
+squash-merge LOW/MEDIUM Dependabot PRs). It is gated by **two
+independent flags**:
+
+1. **State-file enabled flag** — defaults to `false`. Operators who
+   want it scheduled must edit `logs/recurring_maintenance/state.json`
+   and set `enabled: true` for that job.
+2. **CLI opt-in** — even when `enabled=true` in state, the CLI must
+   pass `--enable-dependabot-execute-safe` for the run to actually
+   invoke the lifecycle path. Without that flag, the job is
+   `blocked` with `blocked_reason: missing_dependabot_cli_opt_in`.
+
+This double-gate exists so a stray `cron` invocation cannot
+accidentally start merging PRs just because the scheduler exists.
+
+When both flags are set, the job calls
+`reporting.github_pr_lifecycle.execute_safe_actions(...)`. That
+module owns every Dependabot precondition:
+
+* PR author is `dependabot[bot]`.
+* PR base is `main`, not draft.
+* PR risk class is LOW or MEDIUM (HIGH is NEVER merged).
+* `mergeStateStatus == "CLEAN"`.
+* Every required GitHub check is `passed`.
+* No protected paths in the diff.
+* No frozen-contract files in the diff.
+* No live/paper/shadow/trading/risk paths.
+* No CI/test weakening.
+
+The maintenance scheduler does NOT re-implement those checks — it
+just refuses to invoke the path unless the operator opts in.
+
+## Status semantics
+
+| value | meaning |
+|---|---|
+| `not_run` | job has never run on this checkout |
+| `succeeded` | last run completed cleanly |
+| `skipped` | job was disabled in state, OR not yet due |
+| `blocked` | preconditions failed |
+| `failed` | executor raised an exception |
+| `timeout` | executor exceeded the per-job wall-clock budget |
+| `not_available` | executor returned a non-dict (upstream reshape) |
+
+## Reading the JSON artifact
+
+```sh
+# Latest digest:
+jq '.final_recommendation' logs/recurring_maintenance/latest.json
+
+# Per-job last_status + interval:
+jq '.jobs[] | {job_type, last_status, schedule, enabled}' \
+   logs/recurring_maintenance/latest.json
+
+# History (append-only):
+tail -n 10 logs/recurring_maintenance/history.jsonl | jq -c '.iteration, .counts'
+```
+
+## Approval-inbox integration
+
+`reporting.approval_inbox` reads
+`logs/recurring_maintenance/latest.json` and emits:
+
+* `consecutive_failures >= 3` on any job → one `runtime_halt` item
+  (severity: critical).
+* Each job with `last_status in {failed, timeout}` → one
+  `failed_automation` item (severity: high).
+* Each job with `last_status == blocked` → one `unknown_state`
+  item (severity: medium).
+
+Clean runs (every job `succeeded` / `not_run` / `skipped`) emit
+zero items.
+
+## Status-card integration
+
+The PWA Status card on `/agent-control` shows a
+`recurring_maintenance` row with a pill (`ok` / `warn` / `danger` /
+`unknown`) derived from the digest's `final_recommendation`. The
+PWA continues to consume only the existing `/api/agent-control/status`
+endpoint — no new dashboard.py wiring.
+
+## Operator workflow
+
+1. **Bring up the scheduler**: `python -m reporting.recurring_maintenance --list-jobs`
+   to see the registry and current state.
+2. **Plan**: `python -m reporting.recurring_maintenance --plan`
+   to see which jobs are due.
+3. **Run-due-once**: `python -m reporting.recurring_maintenance --run-due-once`
+   for a one-shot pass.
+4. **Loop**: `python -m reporting.recurring_maintenance --loop --max-iterations 4 --interval-seconds 600`
+   for a bounded recurring run.
+5. **Triage**: `python -m reporting.approval_inbox --mode dry-run`
+   to see whether any maintenance failure has surfaced as an inbox
+   item. Or open the Agent Control PWA Status card.
+
+## Forward roadmap (not shipped here)
+
+| release | adds |
+|---|---|
+| **v3.15.15.23 (this)** | typed scheduler, registry, loop driver, inbox + status integration, read-only PWA card |
+| v3.15.15.24 | per-job audit-ledger linkage (populated `audit_refs`) |
+| v3.15.15.25 | metrics dashboards on top of `history.jsonl` |
+| later | systemd service / cron wrapper around the loop driver |
+
+## Files added by v3.15.15.23
+
+```
+reporting/recurring_maintenance.py
+docs/governance/recurring_maintenance/schema.v1.md
+docs/governance/recurring_maintenance.md          (this file)
+tests/unit/test_recurring_maintenance.py
+```
+
+Plus extensions:
+
+```
+reporting/approval_inbox.py                       (+_build_from_recurring_maintenance)
+dashboard/api_agent_control.py                    (+_recurring_maintenance_summary)
+frontend/src/api/agent_control.ts                 (extended Status type)
+frontend/src/routes/AgentControl.tsx              (Status card maintenance row)
+frontend/src/test/AgentControl.test.tsx           (maintenance row mock + assertion)
+tests/unit/test_approval_inbox.py                 (maintenance projection tests)
+tests/unit/test_dashboard_api_agent_control.py    (maintenance block test)
+```
+
+No new dependencies. No write to `dashboard/dashboard.py`. No write
+to `.claude/**`. Frozen-contract hashes unchanged.

--- a/docs/governance/recurring_maintenance/schema.v1.md
+++ b/docs/governance/recurring_maintenance/schema.v1.md
@@ -1,0 +1,156 @@
+# Recurring Maintenance Digest — Schema v1
+
+> Module: `reporting.recurring_maintenance`
+> Module version: `v3.15.15.23`
+> Schema version: `1`
+> Artifact paths (gitignored):
+> * `logs/recurring_maintenance/latest.json`
+> * timestamped copies: `logs/recurring_maintenance/<UTC>.json`
+> * append-only history: `logs/recurring_maintenance/history.jsonl`
+> * persisted per-job state: `logs/recurring_maintenance/state.json`
+
+## Top-level fields
+
+| field | type | values | notes |
+|---|---|---|---|
+| `schema_version` | int | `1` | bump on breaking changes |
+| `report_kind` | string | `"recurring_maintenance_digest"` | constant |
+| `module_version` | string | `"v3.15.15.23"` | source-of-truth |
+| `generated_at_utc` | string | RFC3339 UTC | seconds resolution |
+| `mode` | enum | `"list"` / `"plan"` / `"run_once"` / `"run_due_once"` / `"loop"` / `"status"` | mirrors the CLI |
+| `iteration` | int | `0..max_iterations - 1` | zero-based |
+| `max_iterations` | int | clamped to `MAX_ITERATIONS_LIMIT` (24) | |
+| `interval_seconds` | int \| null | clamped to `[30, 21600]` | only set in loop mode |
+| `next_run_after_utc` | string \| null | RFC3339 UTC | only set in loop mode |
+| `safe_to_execute` | bool | **always `false`** | digest-level guard |
+| `jobs` | array | see "Job state" | one entry per registered job_type |
+| `actions_taken` | array | see "Action" | empty when no execution happened |
+| `counts` | object | aggregate status counts | |
+| `final_recommendation` | string | see "final_recommendation" | |
+| `due_now` (plan only) | array | list of job_types whose `next_run_after_utc <= now` | only set in `mode=plan` |
+
+## Job state
+
+One entry per registered job. The registry is **closed** —
+exactly five entries.
+
+| field | type | notes |
+|---|---|---|
+| `job_id` | string | `"j_<sha8>"` deterministic over `job_type` |
+| `job_type` | enum | see "Job types" |
+| `schedule` | object | `{kind: "fixed_interval", interval_seconds: int}` |
+| `enabled` | bool | persisted in state.json; defaults from registry |
+| `default_enabled` | bool | the registry default for this job_type |
+| `risk_class` | enum | `"LOW"` / `"MEDIUM"` |
+| `needs_gh` | bool | informational |
+| `last_run_at_utc` | string \| null | RFC3339 UTC |
+| `next_run_after_utc` | string \| null | RFC3339 UTC; bumped after every run |
+| `last_status` | enum | see "Status enum" |
+| `last_result_summary` | string \| null | short human-readable note |
+| `consecutive_failures` | int | reset to 0 on success |
+| `blocked_reason` | string \| null | non-null when last_status is `blocked` |
+| `audit_refs` | array | reserved for future audit-ledger linkage |
+
+## Job types (closed list)
+
+| job_type | risk | needs gh? | default interval | default enabled |
+|---|---|---|---|---|
+| `refresh_workloop_runtime_once` | LOW | no | 15 min | yes |
+| `refresh_proposal_queue` | LOW | no | 60 min | yes |
+| `refresh_approval_inbox` | LOW | no | 15 min | yes |
+| `refresh_github_pr_lifecycle_dry_run` | LOW | yes | 30 min | yes |
+| `dependabot_low_medium_execute_safe` | MEDIUM | yes | 60 min | **no** (CLI opt-in required) |
+
+Adding a new job requires a new release plus an ADR.
+
+### Job semantics
+
+* **`refresh_workloop_runtime_once`** — calls `reporting.workloop_runtime.run_once()` in-process. Read-only artifact refresh.
+* **`refresh_proposal_queue`** — calls `reporting.proposal_queue.collect_snapshot(mode="dry-run")` + `write_outputs()`. Read-only.
+* **`refresh_approval_inbox`** — calls `reporting.approval_inbox.collect_snapshot(mode="dry-run")` + `write_outputs()`. Read-only.
+* **`refresh_github_pr_lifecycle_dry_run`** — calls `reporting.github_pr_lifecycle.collect_snapshot(mode="dry-run")` + `write_outputs()`. Read-only.
+* **`dependabot_low_medium_execute_safe`** — delegates to the existing `reporting.github_pr_lifecycle` execute-safe path (`collect_snapshot(mode="execute-safe")` + `execute_safe_actions()`). The lifecycle module owns every Dependabot precondition (LOW/MEDIUM only, CLEAN mergeability, all checks green, no protected paths, no live/trading paths, etc.); the maintenance scheduler does not re-implement these — it only refuses to invoke the path unless the operator passes `--enable-dependabot-execute-safe`.
+
+## Status enum
+
+| value | meaning |
+|---|---|
+| `not_run` | job has never run on this checkout |
+| `succeeded` | last run completed cleanly |
+| `skipped` | job was disabled in state, or not yet due |
+| `blocked` | preconditions failed (unknown job_type, missing CLI opt-in, etc.) |
+| `failed` | executor raised an exception |
+| `timeout` | executor exceeded the per-job wall-clock budget |
+| `not_available` | executor returned a non-dict (upstream module reshape) |
+
+## Action
+
+```json
+{
+  "kind": "run_job",
+  "target": "refresh_proposal_queue",
+  "outcome": "succeeded",
+  "reason": "proposal_queue review_3_proposed_items (duration_ms=210)"
+}
+```
+
+`kind` is `"run_job"` for executions and `"refused"` for unknown
+job types.
+
+## `final_recommendation` enum
+
+Stable values:
+
+* `"all_jobs_ok"` — every job last_status is succeeded / not_run / skipped.
+* `"degraded_failed_<n>"` — at least one job is in `failed`/`timeout`.
+* `"degraded_blocked_<n>"` — at least one job is `blocked`.
+* `"runtime_halt_after_<n>_consecutive_failures"` — any job has `consecutive_failures >= 3`.
+
+## Hard guarantees encoded in the schema
+
+* `safe_to_execute` is **always `false`** at the digest level.
+* The Dependabot execute-safe job is **disabled by default** AND
+  requires `--enable-dependabot-execute-safe` at the CLI even when
+  enabled in state.json. Two layers of opt-in.
+* No arbitrary command runner. The CLI does not accept `--command`,
+  `--argv`, `--shell`, `--cmd`, or any equivalent flag.
+* `--max-iterations` and `--interval-seconds` are clamped at the
+  CLI boundary so a runaway loop is impossible.
+* JSON write is atomic (`tmp` + `os.replace`).
+* `history.jsonl` is append-only.
+* Per-job wall-clock timeout (cross-platform thread-join).
+* One failing job does NOT crash other jobs in the same iteration.
+* Credential-VALUE patterns (sk-ant-, ghp_, github_pat_, AKIA,
+  BEGIN PRIVATE KEY) refused at the snapshot boundary. Sensitive-
+  PATH fragments are intentionally allowed in metadata so
+  legitimate no-touch references flow through.
+
+## Wiring with the rest of the system
+
+| consumer | how it consumes the artifact |
+|---|---|
+| `reporting.approval_inbox` | reads `logs/recurring_maintenance/latest.json`. `consecutive_failures >= 3` → `runtime_halt`; each `failed` / `timeout` job → `failed_automation`; each `blocked` job → `unknown_state`. |
+| `dashboard.api_agent_control._status_payload` | reads via `read_latest_snapshot()` and surfaces a compact `recurring_maintenance` block under `status`. |
+| `frontend/src/routes/AgentControl.tsx::StatusCard` | renders a recurring-maintenance pill + final-recommendation row inside the existing Status card. No new endpoint. |
+
+No new dashboard route is wired in v3.15.15.23 — the maintenance
+status flows through the already-wired `/api/agent-control/status`
+endpoint.
+
+## Forbidden in v3.15.15.23
+
+* HIGH-risk PR merge.
+* Unknown-risk execution.
+* Arbitrary shell commands.
+* Free-form argv/command input.
+* Browser push notifications.
+* Approve/reject/merge buttons in the PWA.
+* Approval status mutation.
+* POST/PUT/PATCH/DELETE API.
+* Live/paper/shadow/trading/risk behavior changes.
+* Frozen-contract changes.
+* `.claude/**` changes.
+* CI/test weakening.
+* Paid/external telemetry/signup/secrets.
+* Wiring `api_execute_safe_controls` (intentionally unwired).
+* Modifying `dashboard/dashboard.py`.

--- a/frontend/src/api/agent_control.ts
+++ b/frontend/src/api/agent_control.ts
@@ -41,6 +41,25 @@ export interface AgentControlStatus {
       source_states?: Array<{ source: string; state: string }>;
     };
   };
+  recurring_maintenance?: {
+    status: "ok" | "not_available";
+    reason?: string;
+    data?: {
+      module_version?: string;
+      generated_at_utc?: string;
+      mode?: string;
+      safe_to_execute?: boolean;
+      counts?: { total?: number; by_status?: Record<string, number> };
+      final_recommendation?: string;
+      jobs?: Array<{
+        job_type: string;
+        last_status: string;
+        enabled?: boolean;
+        consecutive_failures?: number;
+        next_run_after_utc?: string | null;
+      }>;
+    };
+  };
 }
 
 export interface AgentControlActivity {

--- a/frontend/src/routes/AgentControl.tsx
+++ b/frontend/src/routes/AgentControl.tsx
@@ -116,6 +116,24 @@ function StatusCard({ payload }: { payload: AgentControlStatus | null }) {
           : runtimeRecommendation === "all_sources_ok"
             ? "ok"
             : "unknown";
+
+  const maintenance = payload.recurring_maintenance;
+  const maintenanceStatus = maintenance?.status ?? "not_available";
+  const maintenanceData =
+    maintenance?.status === "ok" ? maintenance.data : undefined;
+  const maintenanceRecommendation = String(
+    maintenanceData?.final_recommendation ?? "n/a",
+  );
+  const maintenancePill: "ok" | "warn" | "danger" | "unknown" =
+    maintenanceStatus !== "ok"
+      ? "unknown"
+      : maintenanceRecommendation.startsWith("runtime_halt")
+        ? "danger"
+        : maintenanceRecommendation.startsWith("degraded")
+          ? "warn"
+          : maintenanceRecommendation === "all_jobs_ok"
+            ? "ok"
+            : "unknown";
   return (
     <Card title="Status" subtitle="governance + frozen + runtime">
       <div className="agent-control-card__row">
@@ -143,6 +161,24 @@ function StatusCard({ payload }: { payload: AgentControlStatus | null }) {
         >
           <dt>runtime rec.</dt>
           <dd>{runtimeRecommendation}</dd>
+        </div>
+      ) : null}
+      <div
+        className="agent-control-card__row"
+        data-testid="status-maintenance-row"
+      >
+        <dt>recurring maintenance</dt>
+        <dd>
+          <StatusPill state={maintenancePill} />
+        </dd>
+      </div>
+      {maintenanceStatus === "ok" && maintenanceData ? (
+        <div
+          className="agent-control-card__row"
+          data-testid="status-maintenance-recommendation"
+        >
+          <dt>maintenance rec.</dt>
+          <dd>{maintenanceRecommendation}</dd>
         </div>
       ) : null}
       {Object.keys(fh).length === 0 ? (

--- a/frontend/src/test/AgentControl.test.tsx
+++ b/frontend/src/test/AgentControl.test.tsx
@@ -58,6 +58,17 @@ const okStatusBody = {
       ],
     },
   },
+  recurring_maintenance: {
+    status: "ok",
+    data: {
+      module_version: "v3.15.15.23",
+      mode: "list",
+      safe_to_execute: false,
+      counts: { total: 5, by_status: { not_run: 5 } },
+      final_recommendation: "all_jobs_ok",
+      jobs: [],
+    },
+  },
 };
 
 const okActivityBody = {

--- a/frontend/src/test/AgentControlPolish.test.tsx
+++ b/frontend/src/test/AgentControlPolish.test.tsx
@@ -59,6 +59,17 @@ const okStatusBody = {
       source_states: [],
     },
   },
+  recurring_maintenance: {
+    status: "ok",
+    data: {
+      module_version: "v3.15.15.23",
+      mode: "list",
+      safe_to_execute: false,
+      counts: { total: 5, by_status: { not_run: 5 } },
+      final_recommendation: "all_jobs_ok",
+      jobs: [],
+    },
+  },
 };
 
 const okActivityBody = {
@@ -383,6 +394,44 @@ describe("AgentControl polish — Status card runtime row (v3.15.15.22)", () => 
     // No recommendation row when runtime is not available.
     expect(
       screen.queryByTestId("status-runtime-recommendation"),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("AgentControl polish — Status card maintenance row (v3.15.15.23)", () => {
+  it("renders the recurring_maintenance row when the artifact is available", async () => {
+    installFetchMock(_allOk());
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+    const row = await screen.findByTestId("status-maintenance-row");
+    expect(row).toBeInTheDocument();
+    const rec = await screen.findByTestId("status-maintenance-recommendation");
+    expect(rec).toHaveTextContent("all_jobs_ok");
+  });
+
+  it("renders maintenance row as unknown when status payload omits recurring_maintenance", async () => {
+    const statusBodyNoMaintenance = {
+      kind: "agent_control_status",
+      schema_version: 1,
+      governance_status: { status: "ok", data: {} },
+      frozen_hashes: okFrozenHashes,
+    };
+    installFetchMock({
+      ..._allOk(),
+      "/api/agent-control/status": () => jsonResp(statusBodyNoMaintenance),
+    });
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+    const row = await screen.findByTestId("status-maintenance-row");
+    expect(row).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("status-maintenance-recommendation"),
     ).not.toBeInTheDocument();
   });
 });

--- a/reporting/approval_inbox.py
+++ b/reporting/approval_inbox.py
@@ -79,6 +79,9 @@ SOURCE_WORKLOOP: Path = REPO_ROOT / "logs" / "autonomous_workloop" / "latest.jso
 SOURCE_WORKLOOP_RUNTIME: Path = (
     REPO_ROOT / "logs" / "workloop_runtime" / "latest.json"
 )
+SOURCE_RECURRING_MAINTENANCE: Path = (
+    REPO_ROOT / "logs" / "recurring_maintenance" / "latest.json"
+)
 
 # Canonical inbox categories (18 per the v3.15.15.20 brief).
 CATEGORIES: tuple[str, ...] = (
@@ -694,6 +697,91 @@ def _build_from_workloop_runtime(envelope: dict[str, Any]) -> list[dict[str, Any
     return items
 
 
+def _build_from_recurring_maintenance(envelope: dict[str, Any]) -> list[dict[str, Any]]:
+    """Project a v3.15.15.23 recurring-maintenance digest into inbox
+    items.
+
+    Mapping:
+      * any job with ``consecutive_failures >= 3`` →
+        ``runtime_halt`` (severity: critical)
+      * each job with ``last_status in {failed, timeout}`` →
+        ``failed_automation`` (severity: high)
+      * each job with ``last_status == blocked`` →
+        ``unknown_state`` (severity: medium)
+
+    A clean digest (every job ``succeeded`` / ``not_run`` / ``skipped``)
+    produces zero inbox items.
+    """
+    if envelope["status"] != "ok" or not envelope.get("data"):
+        return []
+    data = envelope["data"]
+    items: list[dict[str, Any]] = []
+
+    jobs = data.get("jobs") or []
+    for job in jobs:
+        if not isinstance(job, dict):
+            continue
+        consecutive = int(job.get("consecutive_failures") or 0)
+        last_status = job.get("last_status") or ""
+        job_type = job.get("job_type") or "unknown_job"
+        summary = job.get("last_result_summary") or ""
+        if consecutive >= 3:
+            items.append(
+                _build_item(
+                    source=f"recurring_maintenance:{job_type}",
+                    source_type="manual",
+                    title=(
+                        f"Recurring maintenance: {job_type} has {consecutive} "
+                        "consecutive failures — runtime_halt"
+                    ),
+                    summary=summary,
+                    category="runtime_halt",
+                    risk_class="HIGH",
+                    status=STATUS_BLOCKED,
+                    affected_files=[],
+                    evidence={
+                        "consecutive_failures": consecutive,
+                        "last_status": last_status,
+                    },
+                )
+            )
+            # The runtime_halt item subsumes the failed_automation
+            # item for this same job; do not double-emit.
+            continue
+        if last_status in ("failed", "timeout"):
+            items.append(
+                _build_item(
+                    source=f"recurring_maintenance:{job_type}",
+                    source_type="manual",
+                    title=f"Recurring maintenance: {job_type} {last_status}",
+                    summary=summary,
+                    category="failed_automation",
+                    risk_class="HIGH",
+                    status=STATUS_BLOCKED,
+                    affected_files=[],
+                    evidence={"last_status": last_status},
+                )
+            )
+        elif last_status == "blocked":
+            items.append(
+                _build_item(
+                    source=f"recurring_maintenance:{job_type}",
+                    source_type="manual",
+                    title=f"Recurring maintenance: {job_type} blocked",
+                    summary=summary,
+                    category="unknown_state",
+                    risk_class="MEDIUM",
+                    status=STATUS_BLOCKED,
+                    affected_files=[],
+                    evidence={
+                        "blocked_reason": job.get("blocked_reason"),
+                    },
+                )
+            )
+
+    return items
+
+
 def _build_manual_route_wiring_items() -> list[dict[str, Any]]:
     """Per the v3.15.15.18 / .19 / .20 release notes,
     ``dashboard/dashboard.py`` is no-touch except via an
@@ -829,6 +917,9 @@ def collect_snapshot(
             "pr_lifecycle": _read_json_artifact(SOURCE_PR_LIFECYCLE),
             "workloop": _read_json_artifact(SOURCE_WORKLOOP),
             "workloop_runtime": _read_json_artifact(SOURCE_WORKLOOP_RUNTIME),
+            "recurring_maintenance": _read_json_artifact(
+                SOURCE_RECURRING_MAINTENANCE
+            ),
             "governance_status": _governance_status_safe(),
         }
 
@@ -839,6 +930,11 @@ def collect_snapshot(
     items.extend(
         _build_from_workloop_runtime(
             sources.get("workloop_runtime", {"status": "not_available"})
+        )
+    )
+    items.extend(
+        _build_from_recurring_maintenance(
+            sources.get("recurring_maintenance", {"status": "not_available"})
         )
     )
     items.extend(

--- a/reporting/recurring_maintenance.py
+++ b/reporting/recurring_maintenance.py
@@ -1,0 +1,917 @@
+"""Recurring safe maintenance scheduler (v3.15.15.23).
+
+A typed, whitelisted, deterministic scheduler that runs a closed
+set of low-risk maintenance jobs at fixed intervals. Sits ON TOP of
+the v3.15.15.22 workloop runtime — it does not replace it. The
+runtime supervises one round of read-only reporters; the
+maintenance scheduler decides which of those reporters should
+actually be re-run on a schedule.
+
+Hard guarantees
+---------------
+
+See ``docs/governance/recurring_maintenance.md`` for the full list
+and the test suite that enforces each one. The shape is the same as
+``reporting.workloop_runtime``: closed registry, in-process
+executors only, atomic writes, bounded loop, credential-value
+redaction, and a hard-coded false ``safe_to_execute`` flag at the
+digest level.
+
+The Dependabot LOW/MEDIUM execute-safe job is the only job that can
+mutate GitHub state. It is gated by two independent flags: the
+state-file ``enabled`` flag (defaults to false) AND a runtime CLI
+opt-in flag. Without both, the job is refused. Even when both are
+set, the actual merge logic lives in
+``reporting.github_pr_lifecycle`` — the maintenance scheduler is
+a thin pass-through.
+
+CLI
+---
+
+::
+
+    python -m reporting.recurring_maintenance --list-jobs
+    python -m reporting.recurring_maintenance --plan
+    python -m reporting.recurring_maintenance --run-once <job_type>
+    python -m reporting.recurring_maintenance --run-due-once
+    python -m reporting.recurring_maintenance --loop \\
+        --interval-seconds 300 --max-iterations 3
+    python -m reporting.recurring_maintenance --status
+
+Stdlib-only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import hashlib
+import json
+import os
+import sys
+import threading
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT: Path = Path(__file__).resolve().parent.parent
+MODULE_VERSION: str = "v3.15.15.23"
+SCHEMA_VERSION: int = 1
+
+DIGEST_DIR_JSON: Path = REPO_ROOT / "logs" / "recurring_maintenance"
+
+# Hard runtime caps.
+MAX_ITERATIONS_LIMIT: int = 24
+MIN_INTERVAL_SECONDS: int = 30
+MAX_INTERVAL_SECONDS: int = 6 * 3600  # 6 hours
+
+# Per-job wall-clock timeout (seconds). The Dependabot path is the
+# only one with a long budget because it can post comments and
+# squash-merge PRs.
+DEFAULT_JOB_TIMEOUT_SECONDS: int = 90
+DEPENDABOT_JOB_TIMEOUT_SECONDS: int = 600
+
+
+# ---------------------------------------------------------------------------
+# Closed job-type list
+# ---------------------------------------------------------------------------
+
+
+JOB_REFRESH_WORKLOOP_RUNTIME: str = "refresh_workloop_runtime_once"
+JOB_REFRESH_PROPOSAL_QUEUE: str = "refresh_proposal_queue"
+JOB_REFRESH_APPROVAL_INBOX: str = "refresh_approval_inbox"
+JOB_REFRESH_PR_LIFECYCLE_DRY_RUN: str = "refresh_github_pr_lifecycle_dry_run"
+JOB_DEPENDABOT_EXECUTE_SAFE: str = "dependabot_low_medium_execute_safe"
+
+JOB_TYPES: tuple[str, ...] = (
+    JOB_REFRESH_WORKLOOP_RUNTIME,
+    JOB_REFRESH_PROPOSAL_QUEUE,
+    JOB_REFRESH_APPROVAL_INBOX,
+    JOB_REFRESH_PR_LIFECYCLE_DRY_RUN,
+    JOB_DEPENDABOT_EXECUTE_SAFE,
+)
+
+
+# Result-status enum.
+STATUS_NOT_RUN: str = "not_run"
+STATUS_SUCCEEDED: str = "succeeded"
+STATUS_SKIPPED: str = "skipped"
+STATUS_BLOCKED: str = "blocked"
+STATUS_FAILED: str = "failed"
+STATUS_TIMEOUT: str = "timeout"
+STATUS_NOT_AVAILABLE: str = "not_available"
+
+STATUS_VALUES: tuple[str, ...] = (
+    STATUS_NOT_RUN,
+    STATUS_SUCCEEDED,
+    STATUS_SKIPPED,
+    STATUS_BLOCKED,
+    STATUS_FAILED,
+    STATUS_TIMEOUT,
+    STATUS_NOT_AVAILABLE,
+)
+
+RISK_LOW: str = "LOW"
+RISK_MEDIUM: str = "MEDIUM"
+
+
+# Credential-value patterns — same posture as workloop_runtime: we
+# refuse credential VALUES at the snapshot boundary, but allow
+# path-shaped strings (no-touch metadata legitimately appears in
+# job descriptions).
+_OUTER_CREDENTIAL_PATTERNS: tuple[str, ...] = (
+    "sk-ant-",
+    "ghp_",
+    "github_pat_",
+    "AKIA",
+    "-----BEGIN ",
+)
+
+
+def _assert_no_credential_values(snapshot: dict[str, Any]) -> None:
+    import collections.abc as _abc
+
+    def _walk(o: Any):
+        if isinstance(o, str):
+            yield o
+        elif isinstance(o, dict):
+            for v in o.values():
+                yield from _walk(v)
+        elif isinstance(o, _abc.Iterable) and not isinstance(o, (bytes, bytearray)):
+            for v in o:
+                yield from _walk(v)
+
+    for s in _walk(snapshot):
+        for pat in _OUTER_CREDENTIAL_PATTERNS:
+            if pat in s:
+                raise AssertionError(
+                    f"recurring_maintenance leaked credential-like value: "
+                    f"pattern={pat!r}"
+                )
+
+
+# ---------------------------------------------------------------------------
+# Time / id helpers
+# ---------------------------------------------------------------------------
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _utcnow_dt() -> _dt.datetime:
+    return _dt.datetime.now(_dt.UTC).replace(microsecond=0)
+
+
+def _job_id(job_type: str) -> str:
+    raw = job_type.encode("utf-8")
+    return "j_" + hashlib.sha256(raw).hexdigest()[:8]
+
+
+def _rel(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(REPO_ROOT.resolve())).replace("\\", "/")
+    except ValueError:
+        return str(path).replace("\\", "/")
+
+
+def _parse_iso_utc(s: str | None) -> _dt.datetime | None:
+    if not s:
+        return None
+    try:
+        # Strip the trailing 'Z' and parse.
+        if s.endswith("Z"):
+            s = s[:-1] + "+00:00"
+        return _dt.datetime.fromisoformat(s)
+    except (TypeError, ValueError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Job executors (in-process; no subprocess from this module)
+# ---------------------------------------------------------------------------
+
+
+def _exec_refresh_workloop_runtime() -> dict[str, Any]:
+    """Run a single iteration of the v3.15.15.22 workloop runtime."""
+    from reporting.workloop_runtime import run_once as _run_once
+
+    snap = _run_once(write=True)
+    return {
+        "summary": (
+            f"workloop_runtime "
+            f"{snap.get('final_recommendation') or 'no recommendation'}"
+        ),
+        "evidence": {
+            "run_id": snap.get("run_id"),
+            "duration_ms": snap.get("duration_ms"),
+            "counts": snap.get("counts"),
+        },
+    }
+
+
+def _exec_refresh_proposal_queue() -> dict[str, Any]:
+    from reporting.proposal_queue import collect_snapshot, write_outputs
+
+    snap = collect_snapshot(mode="dry-run")
+    write_outputs(snap)
+    return {
+        "summary": (
+            f"proposal_queue "
+            f"{snap.get('final_recommendation') or 'no recommendation'}"
+        ),
+        "evidence": {
+            "counts": snap.get("counts"),
+        },
+    }
+
+
+def _exec_refresh_approval_inbox() -> dict[str, Any]:
+    from reporting.approval_inbox import collect_snapshot, write_outputs
+
+    snap = collect_snapshot(mode="dry-run")
+    write_outputs(snap)
+    return {
+        "summary": (
+            f"approval_inbox "
+            f"{snap.get('final_recommendation') or 'no recommendation'}"
+        ),
+        "evidence": {
+            "counts": snap.get("counts"),
+        },
+    }
+
+
+def _exec_refresh_pr_lifecycle_dry_run() -> dict[str, Any]:
+    from reporting.github_pr_lifecycle import collect_snapshot, write_outputs
+
+    snap = collect_snapshot(mode="dry-run")
+    write_outputs(snap)
+    return {
+        "summary": (
+            f"github_pr_lifecycle "
+            f"{snap.get('final_recommendation') or 'no recommendation'}"
+        ),
+        "evidence": {
+            "provider_status": snap.get("provider_status"),
+        },
+    }
+
+
+def _exec_dependabot_execute_safe() -> dict[str, Any]:
+    """Delegate to the existing ``reporting.github_pr_lifecycle``
+    execute-safe path. The lifecycle module owns every Dependabot
+    precondition (LOW/MEDIUM only, CLEAN mergeability, checks green,
+    no protected paths, no live/trading paths, etc.) — we do not
+    re-implement them here.
+    """
+    from reporting.github_pr_lifecycle import (
+        collect_snapshot,
+        execute_safe_actions,
+        write_outputs,
+    )
+
+    snap = collect_snapshot(mode="execute-safe")
+    snap = execute_safe_actions(snap)
+    write_outputs(snap)
+    return {
+        "summary": (
+            f"dependabot_execute_safe "
+            f"{snap.get('final_recommendation') or 'no recommendation'}"
+        ),
+        "evidence": {
+            "actions_taken_count": len(snap.get("actions_taken") or []),
+        },
+    }
+
+
+# Registry: closed list, addressed by job_type.
+_JOB_REGISTRY: dict[str, dict[str, Any]] = {
+    JOB_REFRESH_WORKLOOP_RUNTIME: {
+        "default_interval_seconds": 15 * 60,
+        "default_enabled": True,
+        "executor": _exec_refresh_workloop_runtime,
+        "description": "Run reporting.workloop_runtime.run_once() (read-only refresh).",
+        "risk_class": RISK_LOW,
+        "needs_gh": False,
+        "timeout_seconds": DEFAULT_JOB_TIMEOUT_SECONDS,
+    },
+    JOB_REFRESH_PROPOSAL_QUEUE: {
+        "default_interval_seconds": 60 * 60,
+        "default_enabled": True,
+        "executor": _exec_refresh_proposal_queue,
+        "description": "Refresh proposal-queue dry-run artifact.",
+        "risk_class": RISK_LOW,
+        "needs_gh": False,
+        "timeout_seconds": DEFAULT_JOB_TIMEOUT_SECONDS,
+    },
+    JOB_REFRESH_APPROVAL_INBOX: {
+        "default_interval_seconds": 15 * 60,
+        "default_enabled": True,
+        "executor": _exec_refresh_approval_inbox,
+        "description": "Refresh approval-inbox dry-run artifact.",
+        "risk_class": RISK_LOW,
+        "needs_gh": False,
+        "timeout_seconds": DEFAULT_JOB_TIMEOUT_SECONDS,
+    },
+    JOB_REFRESH_PR_LIFECYCLE_DRY_RUN: {
+        "default_interval_seconds": 30 * 60,
+        "default_enabled": True,
+        "executor": _exec_refresh_pr_lifecycle_dry_run,
+        "description": "Refresh GitHub PR lifecycle dry-run artifact.",
+        "risk_class": RISK_LOW,
+        "needs_gh": True,
+        "timeout_seconds": DEFAULT_JOB_TIMEOUT_SECONDS,
+    },
+    JOB_DEPENDABOT_EXECUTE_SAFE: {
+        "default_interval_seconds": 60 * 60,
+        # *** Disabled by default. The CLI also requires
+        # --enable-dependabot-execute-safe at runtime, so a stray
+        # invocation cannot accidentally merge a PR. ***
+        "default_enabled": False,
+        "executor": _exec_dependabot_execute_safe,
+        "description": (
+            "Run reporting.github_pr_lifecycle execute-safe path "
+            "(LOW/MEDIUM Dependabot PRs only). Disabled by default; "
+            "requires --enable-dependabot-execute-safe at the CLI."
+        ),
+        "risk_class": RISK_MEDIUM,
+        "needs_gh": True,
+        "timeout_seconds": DEPENDABOT_JOB_TIMEOUT_SECONDS,
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# State persistence
+# ---------------------------------------------------------------------------
+
+
+def _state_file() -> Path:
+    return DIGEST_DIR_JSON / "state.json"
+
+
+def _read_state() -> dict[str, Any]:
+    """Read the per-job state file. Returns ``{}`` on any error."""
+    p = _state_file()
+    if not p.exists():
+        return {}
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return data
+
+
+def _write_state(state: dict[str, Any]) -> None:
+    """Atomic write of ``state.json``."""
+    DIGEST_DIR_JSON.mkdir(parents=True, exist_ok=True)
+    p = _state_file()
+    tmp = p.with_suffix(p.suffix + ".tmp")
+    tmp.write_text(json.dumps(state, sort_keys=True, indent=2), encoding="utf-8")
+    os.replace(tmp, p)
+
+
+def _initial_job_state(job_type: str) -> dict[str, Any]:
+    spec = _JOB_REGISTRY[job_type]
+    return {
+        "job_id": _job_id(job_type),
+        "job_type": job_type,
+        "schedule": {
+            "kind": "fixed_interval",
+            "interval_seconds": int(spec["default_interval_seconds"]),
+        },
+        "enabled": bool(spec["default_enabled"]),
+        "risk_class": spec["risk_class"],
+        "default_enabled": bool(spec["default_enabled"]),
+        "needs_gh": bool(spec.get("needs_gh", False)),
+        "last_run_at_utc": None,
+        "next_run_after_utc": None,
+        "last_status": STATUS_NOT_RUN,
+        "last_result_summary": None,
+        "consecutive_failures": 0,
+        "blocked_reason": None,
+        "audit_refs": [],
+    }
+
+
+def _hydrate_state() -> dict[str, dict[str, Any]]:
+    """Merge persisted state with the canonical defaults so renames
+    in the registry never desync the on-disk state."""
+    persisted = _read_state()
+    out: dict[str, dict[str, Any]] = {}
+    for job_type in JOB_TYPES:
+        base = _initial_job_state(job_type)
+        if isinstance(persisted.get(job_type), dict):
+            for key in (
+                "enabled",
+                "last_run_at_utc",
+                "next_run_after_utc",
+                "last_status",
+                "last_result_summary",
+                "consecutive_failures",
+                "blocked_reason",
+                "audit_refs",
+            ):
+                if key in persisted[job_type]:
+                    base[key] = persisted[job_type][key]
+            # Allow operator override of schedule via state file.
+            if isinstance(persisted[job_type].get("schedule"), dict):
+                base["schedule"] = persisted[job_type]["schedule"]
+        out[job_type] = base
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Per-job supervisor
+# ---------------------------------------------------------------------------
+
+
+def _is_due(job_state: dict[str, Any], *, now: _dt.datetime | None = None) -> bool:
+    if not job_state.get("enabled"):
+        return False
+    next_run = _parse_iso_utc(job_state.get("next_run_after_utc"))
+    if next_run is None:
+        return True  # never run before
+    now_dt = now or _utcnow_dt()
+    return now_dt >= next_run
+
+
+def _supervise_job(
+    job_type: str,
+    *,
+    state: dict[str, Any],
+    enable_dependabot: bool = False,
+) -> dict[str, Any]:
+    """Run one job under the supervisor. Returns the updated job
+    state dict. Never raises."""
+    if job_type not in _JOB_REGISTRY:
+        new_state = dict(state)
+        new_state["last_run_at_utc"] = _utcnow()
+        new_state["last_status"] = STATUS_BLOCKED
+        new_state["last_result_summary"] = f"unknown_job_type: {job_type!r}"
+        new_state["blocked_reason"] = "unknown_job_type"
+        return new_state
+
+    spec = _JOB_REGISTRY[job_type]
+
+    # Disabled? -> skipped.
+    if not state.get("enabled", False):
+        new_state = dict(state)
+        new_state["last_run_at_utc"] = _utcnow()
+        new_state["last_status"] = STATUS_SKIPPED
+        new_state["last_result_summary"] = "job is disabled in state.json"
+        new_state["blocked_reason"] = None
+        return _bump_next_run_after(new_state)
+
+    # Dependabot opt-in gate.
+    if job_type == JOB_DEPENDABOT_EXECUTE_SAFE and not enable_dependabot:
+        new_state = dict(state)
+        new_state["last_run_at_utc"] = _utcnow()
+        new_state["last_status"] = STATUS_BLOCKED
+        new_state["last_result_summary"] = (
+            "dependabot execute-safe requires --enable-dependabot-execute-safe at the CLI"
+        )
+        new_state["blocked_reason"] = "missing_dependabot_cli_opt_in"
+        return _bump_next_run_after(new_state)
+
+    timeout = int(spec.get("timeout_seconds", DEFAULT_JOB_TIMEOUT_SECONDS))
+    holder: dict[str, Any] = {}
+
+    def _runner() -> None:
+        try:
+            holder["value"] = spec["executor"]()
+        except BaseException as e:  # noqa: BLE001 - defensive fence
+            holder["error"] = e
+
+    t = threading.Thread(target=_runner, daemon=True)
+    start = time.monotonic()
+    t.start()
+    t.join(timeout)
+    duration_ms = int((time.monotonic() - start) * 1000)
+
+    new_state = dict(state)
+    new_state["last_run_at_utc"] = _utcnow()
+    new_state["audit_refs"] = list(state.get("audit_refs") or [])
+
+    if t.is_alive():
+        new_state["last_status"] = STATUS_TIMEOUT
+        new_state["last_result_summary"] = (
+            f"timeout after {timeout}s (duration_ms={duration_ms})"
+        )
+        new_state["blocked_reason"] = None
+        new_state["consecutive_failures"] = (
+            int(state.get("consecutive_failures") or 0) + 1
+        )
+        return _bump_next_run_after(new_state)
+
+    if "error" in holder:
+        e = holder["error"]
+        new_state["last_status"] = STATUS_FAILED
+        new_state["last_result_summary"] = (
+            f"{type(e).__name__}: {str(e)[:200]} (duration_ms={duration_ms})"
+        )
+        new_state["blocked_reason"] = None
+        new_state["consecutive_failures"] = (
+            int(state.get("consecutive_failures") or 0) + 1
+        )
+        return _bump_next_run_after(new_state)
+
+    value = holder.get("value")
+    if not isinstance(value, dict):
+        new_state["last_status"] = STATUS_NOT_AVAILABLE
+        new_state["last_result_summary"] = "executor did not return a dict"
+        new_state["blocked_reason"] = None
+        new_state["consecutive_failures"] = (
+            int(state.get("consecutive_failures") or 0) + 1
+        )
+        return _bump_next_run_after(new_state)
+
+    summary = str(value.get("summary") or "ok")
+    # Sanitise summary against credential-value patterns even though
+    # the supervised executor's own per-source guard already catches
+    # them — defense in depth.
+    for pat in _OUTER_CREDENTIAL_PATTERNS:
+        if pat in summary:
+            summary = "secret_redaction_failed"
+            break
+
+    new_state["last_status"] = STATUS_SUCCEEDED
+    new_state["last_result_summary"] = (
+        f"{summary} (duration_ms={duration_ms})"
+    )[:480]
+    new_state["blocked_reason"] = None
+    new_state["consecutive_failures"] = 0
+    return _bump_next_run_after(new_state)
+
+
+def _bump_next_run_after(state: dict[str, Any]) -> dict[str, Any]:
+    schedule = state.get("schedule") or {}
+    interval = int(schedule.get("interval_seconds") or 900)
+    interval = max(MIN_INTERVAL_SECONDS, min(interval, MAX_INTERVAL_SECONDS))
+    next_run = _utcnow_dt() + _dt.timedelta(seconds=interval)
+    out = dict(state)
+    out["next_run_after_utc"] = next_run.isoformat().replace("+00:00", "Z")
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Snapshot builder
+# ---------------------------------------------------------------------------
+
+
+def _final_recommendation(jobs: list[dict[str, Any]]) -> str:
+    failed = sum(1 for j in jobs if j["last_status"] in (STATUS_FAILED, STATUS_TIMEOUT))
+    blocked = sum(1 for j in jobs if j["last_status"] == STATUS_BLOCKED)
+    consecutive_max = max(
+        (int(j.get("consecutive_failures") or 0) for j in jobs),
+        default=0,
+    )
+    if consecutive_max >= 3:
+        return f"runtime_halt_after_{consecutive_max}_consecutive_failures"
+    if failed > 0:
+        return f"degraded_failed_{failed}"
+    if blocked > 0:
+        return f"degraded_blocked_{blocked}"
+    return "all_jobs_ok"
+
+
+def collect_snapshot(
+    *,
+    mode: str = "list",
+    iteration: int = 0,
+    max_iterations: int = 1,
+    interval_seconds: int | None = None,
+    jobs_state: dict[str, dict[str, Any]] | None = None,
+    actions_taken: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    state = jobs_state if jobs_state is not None else _hydrate_state()
+    job_rows = [state[jt] for jt in JOB_TYPES]
+    counts: dict[str, int] = {}
+    for j in job_rows:
+        s = j["last_status"]
+        counts[s] = counts.get(s, 0) + 1
+
+    snap = {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": "recurring_maintenance_digest",
+        "module_version": MODULE_VERSION,
+        "generated_at_utc": _utcnow(),
+        "mode": mode,
+        "iteration": iteration,
+        "max_iterations": max_iterations,
+        "interval_seconds": interval_seconds,
+        "next_run_after_utc": (
+            (
+                (_utcnow_dt() + _dt.timedelta(seconds=interval_seconds))
+                .isoformat()
+                .replace("+00:00", "Z")
+            )
+            if (mode == "loop" and interval_seconds is not None)
+            else None
+        ),
+        "safe_to_execute": False,
+        "jobs": job_rows,
+        "actions_taken": list(actions_taken or []),
+        "counts": {"by_status": counts, "total": len(job_rows)},
+        "final_recommendation": _final_recommendation(job_rows),
+    }
+    _assert_no_credential_values(snap)
+    return snap
+
+
+def write_outputs(snapshot: dict[str, Any]) -> dict[str, str]:
+    """Atomic write of latest.json + timestamped copy + history append."""
+    DIGEST_DIR_JSON.mkdir(parents=True, exist_ok=True)
+    ts = snapshot["generated_at_utc"].replace(":", "-")
+    json_now = DIGEST_DIR_JSON / f"{ts}.json"
+    json_latest = DIGEST_DIR_JSON / "latest.json"
+    history = DIGEST_DIR_JSON / "history.jsonl"
+    payload = json.dumps(snapshot, sort_keys=True, indent=2)
+
+    tmp_now = json_now.with_suffix(json_now.suffix + ".tmp")
+    tmp_now.write_text(payload, encoding="utf-8")
+    os.replace(tmp_now, json_now)
+
+    tmp_latest = json_latest.with_suffix(json_latest.suffix + ".tmp")
+    tmp_latest.write_text(payload, encoding="utf-8")
+    os.replace(tmp_latest, json_latest)
+
+    compact = json.dumps(snapshot, sort_keys=True, separators=(",", ":"))
+    with history.open("a", encoding="utf-8") as f:
+        f.write(compact + "\n")
+
+    return {
+        "json_now": _rel(json_now),
+        "json_latest": _rel(json_latest),
+        "history_jsonl": _rel(history),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public driver functions
+# ---------------------------------------------------------------------------
+
+
+def list_jobs() -> dict[str, Any]:
+    """Return the current state of all jobs (no execution)."""
+    return collect_snapshot(mode="list")
+
+
+def plan(*, now: _dt.datetime | None = None) -> dict[str, Any]:
+    """Return a snapshot annotated with which jobs are due RIGHT
+    NOW. Does not mutate state."""
+    state = _hydrate_state()
+    due = []
+    for job_type in JOB_TYPES:
+        if _is_due(state[job_type], now=now):
+            due.append(job_type)
+    snap = collect_snapshot(mode="plan", jobs_state=state)
+    snap["due_now"] = due
+    return snap
+
+
+def run_one_job(
+    job_type: str,
+    *,
+    enable_dependabot: bool = False,
+    persist: bool = True,
+) -> dict[str, Any]:
+    """Run a single job by type. Returns the resulting snapshot."""
+    state = _hydrate_state()
+    if job_type not in _JOB_REGISTRY:
+        snap = collect_snapshot(mode="run_once", jobs_state=state)
+        snap["actions_taken"].append(
+            {
+                "kind": "refused",
+                "target": job_type,
+                "outcome": "blocked",
+                "reason": f"unknown_job_type: {job_type!r}",
+            }
+        )
+        if persist:
+            write_outputs(snap)
+        return snap
+
+    new_job_state = _supervise_job(
+        job_type, state=state[job_type], enable_dependabot=enable_dependabot
+    )
+    state[job_type] = new_job_state
+    _write_state(state)
+    snap = collect_snapshot(mode="run_once", jobs_state=state)
+    snap["actions_taken"].append(
+        {
+            "kind": "run_job",
+            "target": job_type,
+            "outcome": new_job_state["last_status"],
+            "reason": new_job_state["last_result_summary"],
+        }
+    )
+    if persist:
+        write_outputs(snap)
+    return snap
+
+
+def run_due_once(
+    *,
+    enable_dependabot: bool = False,
+    persist: bool = True,
+    now: _dt.datetime | None = None,
+) -> dict[str, Any]:
+    """Run every job whose ``next_run_after_utc <= now`` exactly
+    once. Returns the resulting snapshot."""
+    state = _hydrate_state()
+    actions: list[dict[str, Any]] = []
+    for job_type in JOB_TYPES:
+        if not _is_due(state[job_type], now=now):
+            continue
+        new_job_state = _supervise_job(
+            job_type, state=state[job_type], enable_dependabot=enable_dependabot
+        )
+        state[job_type] = new_job_state
+        actions.append(
+            {
+                "kind": "run_job",
+                "target": job_type,
+                "outcome": new_job_state["last_status"],
+                "reason": new_job_state["last_result_summary"],
+            }
+        )
+    _write_state(state)
+    snap = collect_snapshot(mode="run_due_once", jobs_state=state, actions_taken=actions)
+    if persist:
+        write_outputs(snap)
+    return snap
+
+
+def run_loop(
+    *,
+    interval_seconds: int,
+    max_iterations: int,
+    enable_dependabot: bool = False,
+    persist: bool = True,
+    sleeper: Callable[[float], None] = time.sleep,
+) -> list[dict[str, Any]]:
+    """Bounded loop. Runs ``run_due_once`` up to ``max_iterations``
+    times with ``interval_seconds`` between iterations. Both bounds
+    are clamped."""
+    iters = max(1, min(max_iterations, MAX_ITERATIONS_LIMIT))
+    interval = max(MIN_INTERVAL_SECONDS, min(interval_seconds, MAX_INTERVAL_SECONDS))
+    snaps: list[dict[str, Any]] = []
+    try:
+        for i in range(iters):
+            snap = run_due_once(enable_dependabot=enable_dependabot, persist=persist)
+            snap["iteration"] = i
+            snap["max_iterations"] = iters
+            snap["interval_seconds"] = interval
+            snap["mode"] = "loop"
+            snaps.append(snap)
+            if i < iters - 1:
+                sleeper(interval)
+    except KeyboardInterrupt:
+        pass
+    return snaps
+
+
+def read_latest_snapshot() -> dict[str, Any] | None:
+    p = DIGEST_DIR_JSON / "latest.json"
+    if not p.exists():
+        return None
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    return data
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m reporting.recurring_maintenance",
+        description=(
+            "Recurring safe-maintenance scheduler. Runs a closed set "
+            "of low-risk maintenance jobs at fixed intervals. The "
+            "Dependabot execute-safe job is disabled by default and "
+            "requires --enable-dependabot-execute-safe at the CLI."
+        ),
+    )
+    mode = p.add_mutually_exclusive_group()
+    mode.add_argument("--list-jobs", action="store_true", help="List jobs and exit.")
+    mode.add_argument("--plan", action="store_true", help="Print which jobs are due now (no execution).")
+    mode.add_argument("--run-once", type=str, default=None, help="Run a single job by type.")
+    mode.add_argument("--run-due-once", action="store_true", help="Run every job whose next_run_after_utc <= now, once.")
+    mode.add_argument("--loop", action="store_true", help="Bounded loop over run-due-once.")
+    mode.add_argument("--status", action="store_true", help="Print latest.json contents and exit.")
+    p.add_argument(
+        "--interval-seconds",
+        type=int,
+        default=300,
+        help=f"Loop interval (clamped to [{MIN_INTERVAL_SECONDS}, {MAX_INTERVAL_SECONDS}]).",
+    )
+    p.add_argument(
+        "--max-iterations",
+        type=int,
+        default=1,
+        help=f"Max iterations in --loop mode (clamped to {MAX_ITERATIONS_LIMIT}).",
+    )
+    p.add_argument(
+        "--enable-dependabot-execute-safe",
+        action="store_true",
+        help=(
+            "Explicit opt-in to running the Dependabot LOW/MEDIUM "
+            "execute-safe job. Without this flag the job is always "
+            "skipped, regardless of its enabled flag in state.json."
+        ),
+    )
+    p.add_argument(
+        "--no-write",
+        action="store_true",
+        help="Do not persist the JSON digest (stdout only).",
+    )
+    p.add_argument(
+        "--indent",
+        type=int,
+        default=2,
+        help="JSON indent (0 for compact).",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    indent = args.indent if args.indent and args.indent > 0 else None
+
+    if args.status:
+        snap = read_latest_snapshot()
+        if snap is None:
+            sys.stdout.write(
+                json.dumps(
+                    {"status": "not_available", "reason": "no latest.json"},
+                    indent=indent,
+                )
+                + "\n"
+            )
+            return 0
+        sys.stdout.write(json.dumps(snap, indent=indent, sort_keys=True) + "\n")
+        return 0
+
+    if args.list_jobs:
+        snap = list_jobs()
+        sys.stdout.write(json.dumps(snap, indent=indent, sort_keys=True) + "\n")
+        return 0
+
+    if args.plan:
+        snap = plan()
+        sys.stdout.write(json.dumps(snap, indent=indent, sort_keys=True) + "\n")
+        return 0
+
+    if args.run_once is not None:
+        snap = run_one_job(
+            args.run_once,
+            enable_dependabot=args.enable_dependabot_execute_safe,
+            persist=not args.no_write,
+        )
+        sys.stdout.write(json.dumps(snap, indent=indent, sort_keys=True) + "\n")
+        return 0
+
+    if args.run_due_once:
+        snap = run_due_once(
+            enable_dependabot=args.enable_dependabot_execute_safe,
+            persist=not args.no_write,
+        )
+        sys.stdout.write(json.dumps(snap, indent=indent, sort_keys=True) + "\n")
+        return 0
+
+    if args.loop:
+        snaps = run_loop(
+            interval_seconds=args.interval_seconds,
+            max_iterations=args.max_iterations,
+            enable_dependabot=args.enable_dependabot_execute_safe,
+            persist=not args.no_write,
+        )
+        last = snaps[-1] if snaps else {}
+        sys.stdout.write(json.dumps(last, indent=indent, sort_keys=True) + "\n")
+        return 0
+
+    # Default: --list-jobs.
+    snap = list_jobs()
+    sys.stdout.write(json.dumps(snap, indent=indent, sort_keys=True) + "\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/unit/test_approval_inbox.py
+++ b/tests/unit/test_approval_inbox.py
@@ -172,6 +172,66 @@ def _runtime_with_failed_source(name: str, state: str) -> dict:
     )
 
 
+def _empty_recurring_maintenance() -> dict:
+    return _ok_envelope(
+        {
+            "schema_version": 1,
+            "report_kind": "recurring_maintenance_digest",
+            "module_version": "v3.15.15.23",
+            "jobs": [
+                {
+                    "job_type": "refresh_workloop_runtime_once",
+                    "last_status": "succeeded",
+                    "consecutive_failures": 0,
+                    "last_result_summary": "ok",
+                    "blocked_reason": None,
+                }
+            ],
+            "final_recommendation": "all_jobs_ok",
+        }
+    )
+
+
+def _maintenance_with_consecutive_failures(n: int) -> dict:
+    return _ok_envelope(
+        {
+            "schema_version": 1,
+            "report_kind": "recurring_maintenance_digest",
+            "jobs": [
+                {
+                    "job_type": "refresh_approval_inbox",
+                    "last_status": "failed",
+                    "consecutive_failures": n,
+                    "last_result_summary": "synthetic",
+                    "blocked_reason": None,
+                }
+            ],
+        }
+    )
+
+
+def _maintenance_with_failed_job(status: str) -> dict:
+    return _ok_envelope(
+        {
+            "schema_version": 1,
+            "report_kind": "recurring_maintenance_digest",
+            "jobs": [
+                {
+                    "job_type": "refresh_approval_inbox",
+                    "last_status": status,
+                    "consecutive_failures": 1,
+                    "last_result_summary": "synthetic",
+                    "blocked_reason": (
+                        "missing_dependabot_cli_opt_in"
+                        if status == "blocked"
+                        else None
+                    ),
+                }
+            ],
+        }
+    )
+
+
 def _empty_workloop() -> dict:
     return _ok_envelope(
         {
@@ -663,6 +723,101 @@ def test_runtime_clean_artifact_yields_no_runtime_inbox_items() -> None:
     assert runtime_items == []
 
 
+def test_recurring_maintenance_consecutive_failures_emit_runtime_halt() -> None:
+    sources = {
+        "proposal_queue": _proposal_envelope([]),
+        "pr_lifecycle": _pr_envelope([]),
+        "workloop": _empty_workloop(),
+        "workloop_runtime": _empty_runtime(),
+        "recurring_maintenance": _maintenance_with_consecutive_failures(3),
+        "governance_status": _empty_governance(),
+    }
+    snap = _build(sources)
+    runtime_halt = [
+        it
+        for it in snap["items"]
+        if it["category"] == "runtime_halt"
+        and (it["source"] or "").startswith("recurring_maintenance:")
+    ]
+    assert len(runtime_halt) == 1
+    assert runtime_halt[0]["severity"] == "critical"
+
+
+def test_recurring_maintenance_failed_job_emits_failed_automation() -> None:
+    sources = {
+        "proposal_queue": _proposal_envelope([]),
+        "pr_lifecycle": _pr_envelope([]),
+        "workloop": _empty_workloop(),
+        "workloop_runtime": _empty_runtime(),
+        "recurring_maintenance": _maintenance_with_failed_job("failed"),
+        "governance_status": _empty_governance(),
+    }
+    snap = _build(sources)
+    failed_items = [
+        it
+        for it in snap["items"]
+        if it["category"] == "failed_automation"
+        and (it["source"] or "").startswith("recurring_maintenance:")
+    ]
+    assert len(failed_items) == 1
+
+
+def test_recurring_maintenance_timeout_job_emits_failed_automation() -> None:
+    sources = {
+        "proposal_queue": _proposal_envelope([]),
+        "pr_lifecycle": _pr_envelope([]),
+        "workloop": _empty_workloop(),
+        "workloop_runtime": _empty_runtime(),
+        "recurring_maintenance": _maintenance_with_failed_job("timeout"),
+        "governance_status": _empty_governance(),
+    }
+    snap = _build(sources)
+    failed_items = [
+        it
+        for it in snap["items"]
+        if it["category"] == "failed_automation"
+        and (it["source"] or "").startswith("recurring_maintenance:")
+    ]
+    assert len(failed_items) == 1
+
+
+def test_recurring_maintenance_blocked_job_emits_unknown_state() -> None:
+    sources = {
+        "proposal_queue": _proposal_envelope([]),
+        "pr_lifecycle": _pr_envelope([]),
+        "workloop": _empty_workloop(),
+        "workloop_runtime": _empty_runtime(),
+        "recurring_maintenance": _maintenance_with_failed_job("blocked"),
+        "governance_status": _empty_governance(),
+    }
+    snap = _build(sources)
+    unknown_items = [
+        it
+        for it in snap["items"]
+        if it["category"] == "unknown_state"
+        and (it["source"] or "").startswith("recurring_maintenance:")
+    ]
+    assert len(unknown_items) == 1
+
+
+def test_recurring_maintenance_clean_artifact_yields_no_inbox_items() -> None:
+    sources = {
+        "proposal_queue": _proposal_envelope([]),
+        "pr_lifecycle": _pr_envelope([]),
+        "workloop": _empty_workloop(),
+        "workloop_runtime": _empty_runtime(),
+        "recurring_maintenance": _empty_recurring_maintenance(),
+        "governance_status": _empty_governance(),
+    }
+    snap = _build(sources)
+    rm_items = [
+        it
+        for it in snap["items"]
+        if (it["source"] or "").startswith("recurring_maintenance:")
+    ]
+    assert rm_items == []
+
+
 def test_broken_audit_chain_becomes_security_alert() -> None:
     sources = {
         "proposal_queue": _proposal_envelope([]),
@@ -912,6 +1067,15 @@ def test_cli_dry_run_default(
     monkeypatch.setattr(ai, "SOURCE_PROPOSAL_QUEUE", tmp_path / "missing-1.json")
     monkeypatch.setattr(ai, "SOURCE_PR_LIFECYCLE", tmp_path / "missing-2.json")
     monkeypatch.setattr(ai, "SOURCE_WORKLOOP", tmp_path / "missing-3.json")
+    # v3.15.15.22 / .23 added two more upstream artifacts. Redirect
+    # them to non-existent paths so the CLI smoke is deterministic
+    # regardless of any stale local artifacts under logs/.
+    monkeypatch.setattr(
+        ai, "SOURCE_WORKLOOP_RUNTIME", tmp_path / "missing-4.json"
+    )
+    monkeypatch.setattr(
+        ai, "SOURCE_RECURRING_MAINTENANCE", tmp_path / "missing-5.json"
+    )
     rc = ai.main(["--mode", "dry-run", "--no-write"])
     assert rc == 0
     payload = json.loads(capsys.readouterr().out)

--- a/tests/unit/test_dashboard_api_agent_control.py
+++ b/tests/unit/test_dashboard_api_agent_control.py
@@ -195,6 +195,17 @@ def test_notifications_is_placeholder(client) -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_status_payload_includes_recurring_maintenance_block(client) -> None:
+    """v3.15.15.23: status payload now also carries a
+    recurring_maintenance summary."""
+    body = client.get("/api/agent-control/status").get_json()
+    assert "recurring_maintenance" in body
+    rm_block = body["recurring_maintenance"]
+    assert rm_block["status"] in ("ok", "not_available")
+    if rm_block["status"] == "not_available":
+        assert "reason" in rm_block
+
+
 def test_status_payload_includes_workloop_runtime_block(client) -> None:
     """v3.15.15.22: status payload now carries a workloop_runtime
     summary. When the artifact is missing the block reports

--- a/tests/unit/test_recurring_maintenance.py
+++ b/tests/unit/test_recurring_maintenance.py
@@ -1,0 +1,629 @@
+"""Unit tests for ``reporting.recurring_maintenance``.
+
+Properties enforced (verbatim from the v3.15.15.23 brief):
+
+* job registry contains only the five approved job types
+* unknown job type rejected at planner AND executor
+* no arbitrary command execution; no shell/subprocess in the module
+* plan mode does not mutate state
+* run-once executes only the selected job
+* run-due-once respects next_run_after_utc
+* loop mode respects max_iterations + interval clamping
+* job state persists across runs (state.json)
+* atomic write (tmp + os.replace)
+* history.jsonl appends one record per execution
+* secret redaction at the snapshot boundary
+* one failing job does not crash other jobs
+* timeout classified as timeout
+* disabled job skipped
+* dependabot job disabled by default
+* dependabot job rejects without --enable-dependabot-execute-safe
+* dependabot job dispatch goes through github_pr_lifecycle (we
+  cover the lifecycle module's HIGH-rejection separately)
+* no git push/force/admin/direct-main operation possible from this
+  module
+* approval_inbox integration for failed/blocked jobs
+* status endpoint projection
+* frozen hashes unchanged
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import hashlib
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reporting import recurring_maintenance as rm
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setattr(rm, "DIGEST_DIR_JSON", tmp_path / "rm")
+    return tmp_path
+
+
+def _file_sha256(p: Path) -> str:
+    h = hashlib.sha256()
+    with p.open("rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _patch_executor(
+    monkeypatch: pytest.MonkeyPatch,
+    job_type: str,
+    fn,
+) -> None:
+    """Replace one job's executor so tests don't actually invoke the
+    real workloop / proposal-queue / lifecycle modules."""
+    spec = dict(rm._JOB_REGISTRY[job_type])
+    spec["executor"] = fn
+    monkeypatch.setitem(rm._JOB_REGISTRY, job_type, spec)
+
+
+# ---------------------------------------------------------------------------
+# Closed registry
+# ---------------------------------------------------------------------------
+
+
+def test_job_registry_contains_only_approved_types() -> None:
+    expected = {
+        "refresh_workloop_runtime_once",
+        "refresh_proposal_queue",
+        "refresh_approval_inbox",
+        "refresh_github_pr_lifecycle_dry_run",
+        "dependabot_low_medium_execute_safe",
+    }
+    assert set(rm.JOB_TYPES) == expected
+    assert set(rm._JOB_REGISTRY.keys()) == expected
+    assert len(rm.JOB_TYPES) == 5
+
+
+def test_dependabot_job_disabled_by_default() -> None:
+    spec = rm._JOB_REGISTRY[rm.JOB_DEPENDABOT_EXECUTE_SAFE]
+    assert spec["default_enabled"] is False
+    assert spec["risk_class"] == rm.RISK_MEDIUM
+
+
+def test_other_jobs_enabled_by_default() -> None:
+    for job_type in rm.JOB_TYPES:
+        if job_type == rm.JOB_DEPENDABOT_EXECUTE_SAFE:
+            continue
+        assert rm._JOB_REGISTRY[job_type]["default_enabled"] is True
+
+
+def test_unknown_job_type_is_refused_via_run_one_job(isolated: Path) -> None:
+    snap = rm.run_one_job("rm_minus_rf_root", persist=False)
+    refused = [
+        a
+        for a in snap["actions_taken"]
+        if a.get("kind") == "refused" and a.get("target") == "rm_minus_rf_root"
+    ]
+    assert refused, snap
+
+
+# ---------------------------------------------------------------------------
+# Plan + list (no mutation)
+# ---------------------------------------------------------------------------
+
+
+def test_list_jobs_does_not_mutate(isolated: Path) -> None:
+    snap = rm.list_jobs()
+    assert snap["mode"] == "list"
+    # Nothing written.
+    assert not (isolated / "rm" / "latest.json").exists()
+    assert not (isolated / "rm" / "state.json").exists()
+
+
+def test_plan_does_not_mutate(isolated: Path) -> None:
+    snap = rm.plan()
+    assert snap["mode"] == "plan"
+    assert "due_now" in snap
+    # Initially every enabled job is due (no last_run_at_utc).
+    assert rm.JOB_REFRESH_WORKLOOP_RUNTIME in snap["due_now"]
+    # Plan does NOT execute, so state.json is not written.
+    assert not (isolated / "rm" / "state.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# run_one_job
+# ---------------------------------------------------------------------------
+
+
+def test_run_one_job_executes_only_selected_job(
+    isolated: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[str] = []
+    _patch_executor(
+        monkeypatch,
+        rm.JOB_REFRESH_PROPOSAL_QUEUE,
+        lambda: (calls.append("proposal_queue"), {"summary": "ok"})[1],
+    )
+    _patch_executor(
+        monkeypatch,
+        rm.JOB_REFRESH_APPROVAL_INBOX,
+        lambda: (calls.append("approval_inbox"), {"summary": "ok"})[1],
+    )
+    snap = rm.run_one_job(rm.JOB_REFRESH_PROPOSAL_QUEUE, persist=True)
+    assert calls == ["proposal_queue"]
+    state = snap["jobs"]
+    pq = next(j for j in state if j["job_type"] == rm.JOB_REFRESH_PROPOSAL_QUEUE)
+    assert pq["last_status"] == rm.STATUS_SUCCEEDED
+
+
+def test_run_once_persists_state(isolated: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_executor(
+        monkeypatch, rm.JOB_REFRESH_APPROVAL_INBOX, lambda: {"summary": "ok"}
+    )
+    rm.run_one_job(rm.JOB_REFRESH_APPROVAL_INBOX, persist=True)
+    state_file = isolated / "rm" / "state.json"
+    assert state_file.exists()
+    data = json.loads(state_file.read_text(encoding="utf-8"))
+    assert rm.JOB_REFRESH_APPROVAL_INBOX in data
+    assert data[rm.JOB_REFRESH_APPROVAL_INBOX]["last_status"] == rm.STATUS_SUCCEEDED
+
+
+def test_disabled_job_is_skipped(isolated: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """If a job is disabled in state, run_one_job marks it skipped
+    without invoking the executor."""
+    state = rm._hydrate_state()
+    state[rm.JOB_REFRESH_APPROVAL_INBOX]["enabled"] = False
+    rm._write_state(state)
+    called: list[bool] = []
+    _patch_executor(
+        monkeypatch, rm.JOB_REFRESH_APPROVAL_INBOX, lambda: (called.append(True), {"summary": "ok"})[1]
+    )
+    snap = rm.run_one_job(rm.JOB_REFRESH_APPROVAL_INBOX, persist=True)
+    assert called == []
+    job_state = next(
+        j for j in snap["jobs"] if j["job_type"] == rm.JOB_REFRESH_APPROVAL_INBOX
+    )
+    assert job_state["last_status"] == rm.STATUS_SKIPPED
+
+
+# ---------------------------------------------------------------------------
+# Failing / timeout supervision
+# ---------------------------------------------------------------------------
+
+
+def test_one_failing_job_does_not_crash_others(
+    isolated: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def _boom():
+        raise RuntimeError("synthetic failure")
+
+    _patch_executor(monkeypatch, rm.JOB_REFRESH_APPROVAL_INBOX, _boom)
+    _patch_executor(
+        monkeypatch, rm.JOB_REFRESH_PROPOSAL_QUEUE, lambda: {"summary": "ok"}
+    )
+    snap = rm.run_due_once(persist=True)
+    statuses = {
+        j["job_type"]: j["last_status"]
+        for j in snap["jobs"]
+    }
+    assert statuses[rm.JOB_REFRESH_APPROVAL_INBOX] == rm.STATUS_FAILED
+    assert statuses[rm.JOB_REFRESH_PROPOSAL_QUEUE] == rm.STATUS_SUCCEEDED
+
+
+def test_job_timeout_classified_as_timeout(
+    isolated: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def _slow():
+        time.sleep(3.0)
+        return {"summary": "should not reach"}
+
+    # Patch the registry timeout for this job to 1s, plus the
+    # executor itself.
+    spec = dict(rm._JOB_REGISTRY[rm.JOB_REFRESH_APPROVAL_INBOX])
+    spec["executor"] = _slow
+    spec["timeout_seconds"] = 1
+    monkeypatch.setitem(rm._JOB_REGISTRY, rm.JOB_REFRESH_APPROVAL_INBOX, spec)
+    snap = rm.run_one_job(rm.JOB_REFRESH_APPROVAL_INBOX, persist=False)
+    job_state = next(
+        j for j in snap["jobs"] if j["job_type"] == rm.JOB_REFRESH_APPROVAL_INBOX
+    )
+    assert job_state["last_status"] == rm.STATUS_TIMEOUT
+    assert "timeout" in (job_state["last_result_summary"] or "").lower()
+
+
+def test_failed_job_increments_consecutive_failures(
+    isolated: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_executor(
+        monkeypatch,
+        rm.JOB_REFRESH_APPROVAL_INBOX,
+        lambda: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    for _ in range(3):
+        rm.run_one_job(rm.JOB_REFRESH_APPROVAL_INBOX, persist=True)
+    state = rm._read_state()
+    assert state[rm.JOB_REFRESH_APPROVAL_INBOX]["consecutive_failures"] == 3
+    assert state[rm.JOB_REFRESH_APPROVAL_INBOX]["last_status"] == rm.STATUS_FAILED
+
+
+def test_succeeded_job_resets_consecutive_failures(
+    isolated: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Two failures.
+    _patch_executor(
+        monkeypatch,
+        rm.JOB_REFRESH_APPROVAL_INBOX,
+        lambda: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    rm.run_one_job(rm.JOB_REFRESH_APPROVAL_INBOX, persist=True)
+    rm.run_one_job(rm.JOB_REFRESH_APPROVAL_INBOX, persist=True)
+    # One success.
+    _patch_executor(
+        monkeypatch, rm.JOB_REFRESH_APPROVAL_INBOX, lambda: {"summary": "ok"}
+    )
+    rm.run_one_job(rm.JOB_REFRESH_APPROVAL_INBOX, persist=True)
+    state = rm._read_state()
+    assert state[rm.JOB_REFRESH_APPROVAL_INBOX]["consecutive_failures"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Dependabot opt-in gate
+# ---------------------------------------------------------------------------
+
+
+def test_dependabot_job_requires_cli_opt_in(
+    isolated: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Even if the operator manually flips enabled=true in
+    state.json, the Dependabot job is still ``blocked`` without the
+    runtime --enable-dependabot-execute-safe flag."""
+    state = rm._hydrate_state()
+    state[rm.JOB_DEPENDABOT_EXECUTE_SAFE]["enabled"] = True
+    rm._write_state(state)
+
+    called: list[bool] = []
+    _patch_executor(
+        monkeypatch,
+        rm.JOB_DEPENDABOT_EXECUTE_SAFE,
+        lambda: (called.append(True), {"summary": "ok"})[1],
+    )
+    snap = rm.run_one_job(
+        rm.JOB_DEPENDABOT_EXECUTE_SAFE, enable_dependabot=False, persist=True
+    )
+    job_state = next(
+        j for j in snap["jobs"] if j["job_type"] == rm.JOB_DEPENDABOT_EXECUTE_SAFE
+    )
+    assert called == [], "executor must NOT be invoked without CLI opt-in"
+    assert job_state["last_status"] == rm.STATUS_BLOCKED
+    assert (
+        job_state["blocked_reason"] == "missing_dependabot_cli_opt_in"
+    ), job_state
+
+
+def test_dependabot_job_runs_with_explicit_opt_in(
+    isolated: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state = rm._hydrate_state()
+    state[rm.JOB_DEPENDABOT_EXECUTE_SAFE]["enabled"] = True
+    rm._write_state(state)
+
+    called: list[bool] = []
+    _patch_executor(
+        monkeypatch,
+        rm.JOB_DEPENDABOT_EXECUTE_SAFE,
+        lambda: (called.append(True), {"summary": "merged 0 PRs"})[1],
+    )
+    snap = rm.run_one_job(
+        rm.JOB_DEPENDABOT_EXECUTE_SAFE, enable_dependabot=True, persist=True
+    )
+    job_state = next(
+        j for j in snap["jobs"] if j["job_type"] == rm.JOB_DEPENDABOT_EXECUTE_SAFE
+    )
+    assert called == [True]
+    assert job_state["last_status"] == rm.STATUS_SUCCEEDED
+
+
+# ---------------------------------------------------------------------------
+# run_due_once — schedule respect
+# ---------------------------------------------------------------------------
+
+
+def test_run_due_once_respects_next_run_after_utc(
+    isolated: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Once a job has run, its next_run_after_utc is set in the
+    future; a subsequent run_due_once should NOT re-execute it."""
+    calls: list[str] = []
+    _patch_executor(
+        monkeypatch,
+        rm.JOB_REFRESH_APPROVAL_INBOX,
+        lambda: (calls.append("a"), {"summary": "ok"})[1],
+    )
+    _patch_executor(
+        monkeypatch,
+        rm.JOB_REFRESH_PROPOSAL_QUEUE,
+        lambda: (calls.append("p"), {"summary": "ok"})[1],
+    )
+    _patch_executor(
+        monkeypatch,
+        rm.JOB_REFRESH_WORKLOOP_RUNTIME,
+        lambda: (calls.append("r"), {"summary": "ok"})[1],
+    )
+    _patch_executor(
+        monkeypatch,
+        rm.JOB_REFRESH_PR_LIFECYCLE_DRY_RUN,
+        lambda: (calls.append("g"), {"summary": "ok"})[1],
+    )
+    rm.run_due_once(persist=True)
+    n_first = len(calls)
+    rm.run_due_once(persist=True)
+    n_second = len(calls)
+    # Second pass: nothing was due, so no additional executor calls.
+    assert n_second == n_first, calls
+
+
+def test_run_due_once_runs_due_jobs_when_time_advances(
+    isolated: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If we manually push next_run_after_utc into the past, the job
+    runs again."""
+    calls: list[int] = []
+    _patch_executor(
+        monkeypatch,
+        rm.JOB_REFRESH_APPROVAL_INBOX,
+        lambda: (calls.append(1), {"summary": "ok"})[1],
+    )
+    rm.run_one_job(rm.JOB_REFRESH_APPROVAL_INBOX, persist=True)
+    state = rm._read_state()
+    state[rm.JOB_REFRESH_APPROVAL_INBOX]["next_run_after_utc"] = (
+        "2000-01-01T00:00:00Z"
+    )
+    # Disable other jobs so we only check the targeted one.
+    for jt in rm.JOB_TYPES:
+        if jt != rm.JOB_REFRESH_APPROVAL_INBOX:
+            state[jt]["enabled"] = False
+    rm._write_state(state)
+    rm.run_due_once(persist=True)
+    assert sum(calls) == 2  # original + due-now run
+
+
+# ---------------------------------------------------------------------------
+# Loop mode
+# ---------------------------------------------------------------------------
+
+
+def test_loop_clamps_max_iterations(
+    isolated: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sleeps: list[float] = []
+    snaps = rm.run_loop(
+        interval_seconds=30,
+        max_iterations=10_000,
+        persist=False,
+        sleeper=lambda s: sleeps.append(s),
+    )
+    assert len(snaps) == rm.MAX_ITERATIONS_LIMIT
+    assert len(sleeps) == rm.MAX_ITERATIONS_LIMIT - 1
+
+
+def test_loop_clamps_interval_seconds(
+    isolated: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sleeps: list[float] = []
+    rm.run_loop(
+        interval_seconds=1,  # below MIN; should clamp up
+        max_iterations=2,
+        persist=False,
+        sleeper=lambda s: sleeps.append(s),
+    )
+    assert all(s >= rm.MIN_INTERVAL_SECONDS for s in sleeps)
+
+
+# ---------------------------------------------------------------------------
+# Atomic write + history
+# ---------------------------------------------------------------------------
+
+
+def test_json_write_is_atomic(isolated: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_executor(
+        monkeypatch, rm.JOB_REFRESH_APPROVAL_INBOX, lambda: {"summary": "ok"}
+    )
+    rm.run_one_job(rm.JOB_REFRESH_APPROVAL_INBOX, persist=True)
+    latest = isolated / "rm" / "latest.json"
+    assert latest.exists()
+    assert not (isolated / "rm" / "latest.json.tmp").exists()
+    assert not (isolated / "rm" / "state.json.tmp").exists()
+
+
+def test_history_jsonl_appends_one_record_per_run(
+    isolated: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_executor(
+        monkeypatch, rm.JOB_REFRESH_APPROVAL_INBOX, lambda: {"summary": "ok"}
+    )
+    for _ in range(3):
+        rm.run_one_job(rm.JOB_REFRESH_APPROVAL_INBOX, persist=True)
+    history = (isolated / "rm" / "history.jsonl").read_text(encoding="utf-8")
+    lines = [ln for ln in history.splitlines() if ln.strip()]
+    assert len(lines) == 3
+    for ln in lines:
+        rec = json.loads(ln)
+        assert rec["report_kind"] == "recurring_maintenance_digest"
+
+
+# ---------------------------------------------------------------------------
+# safe_to_execute always false
+# ---------------------------------------------------------------------------
+
+
+def test_safe_to_execute_is_always_false(
+    isolated: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Across list / plan / run-once / run-due-once, the digest's
+    safe_to_execute is hard-coded false."""
+    _patch_executor(
+        monkeypatch, rm.JOB_REFRESH_APPROVAL_INBOX, lambda: {"summary": "ok"}
+    )
+    for snap in (
+        rm.list_jobs(),
+        rm.plan(),
+        rm.run_one_job(rm.JOB_REFRESH_APPROVAL_INBOX, persist=False),
+        rm.run_due_once(persist=False),
+    ):
+        assert snap["safe_to_execute"] is False
+
+
+# ---------------------------------------------------------------------------
+# Module invariants — no shell, no subprocess, no free-form command
+# ---------------------------------------------------------------------------
+
+
+def test_module_does_not_invoke_subprocess_directly() -> None:
+    src = Path(rm.__file__).read_text(encoding="utf-8")
+    forbidden = (
+        "import subprocess",
+        "from subprocess",
+        '"gh"',
+        "'gh'",
+        '"git"',
+        "'git'",
+        "Popen",
+        "os.system",
+        "shell=True",
+    )
+    for token in forbidden:
+        assert token not in src, (
+            f"forbidden token in recurring_maintenance.py: {token!r}"
+        )
+
+
+def test_cli_does_not_accept_freeform_command_flags() -> None:
+    src = Path(rm.__file__).read_text(encoding="utf-8")
+    for forbidden_flag in ("--command", "--argv", "--shell", "--cmd"):
+        assert forbidden_flag not in src
+
+
+# ---------------------------------------------------------------------------
+# Frozen contract integrity
+# ---------------------------------------------------------------------------
+
+
+def test_frozen_contracts_byte_identical_around_run(
+    isolated: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_executor(
+        monkeypatch, rm.JOB_REFRESH_APPROVAL_INBOX, lambda: {"summary": "ok"}
+    )
+    paths = [
+        REPO_ROOT / "research" / "research_latest.json",
+        REPO_ROOT / "research" / "strategy_matrix.csv",
+    ]
+    before = {p.name: _file_sha256(p) for p in paths if p.exists()}
+    rm.run_one_job(rm.JOB_REFRESH_APPROVAL_INBOX, persist=True)
+    after = {p.name: _file_sha256(p) for p in paths if p.exists()}
+    assert before == after
+
+
+# ---------------------------------------------------------------------------
+# Credential-redaction guard
+# ---------------------------------------------------------------------------
+
+
+def test_credential_value_in_summary_is_sanitized(
+    isolated: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If an executor returns a summary string containing a
+    credential pattern (sk-ant-...), the supervisor sanitises it to
+    ``secret_redaction_failed`` before persisting — defence in
+    depth on top of the lifecycle module's own redaction."""
+    _patch_executor(
+        monkeypatch,
+        rm.JOB_REFRESH_APPROVAL_INBOX,
+        lambda: {"summary": "leaked sk-ant-api03-fakeleak token"},
+    )
+    snap = rm.run_one_job(rm.JOB_REFRESH_APPROVAL_INBOX, persist=False)
+    job_state = next(
+        j for j in snap["jobs"] if j["job_type"] == rm.JOB_REFRESH_APPROVAL_INBOX
+    )
+    assert "sk-ant-" not in (job_state["last_result_summary"] or "")
+    assert "secret_redaction_failed" in (job_state["last_result_summary"] or "")
+
+
+# ---------------------------------------------------------------------------
+# read_latest_snapshot helper (used by api_agent_control + approval_inbox)
+# ---------------------------------------------------------------------------
+
+
+def test_read_latest_snapshot_handles_missing(isolated: Path) -> None:
+    assert rm.read_latest_snapshot() is None
+
+
+def test_read_latest_snapshot_handles_malformed(isolated: Path) -> None:
+    (isolated / "rm").mkdir()
+    (isolated / "rm" / "latest.json").write_text("{ not json", encoding="utf-8")
+    assert rm.read_latest_snapshot() is None
+
+
+def test_read_latest_snapshot_returns_dict(
+    isolated: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_executor(
+        monkeypatch, rm.JOB_REFRESH_APPROVAL_INBOX, lambda: {"summary": "ok"}
+    )
+    rm.run_one_job(rm.JOB_REFRESH_APPROVAL_INBOX, persist=True)
+    snap = rm.read_latest_snapshot()
+    assert isinstance(snap, dict)
+    assert snap["report_kind"] == "recurring_maintenance_digest"
+
+
+# ---------------------------------------------------------------------------
+# CLI thin-shim
+# ---------------------------------------------------------------------------
+
+
+def test_cli_list_jobs_default(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(rm, "DIGEST_DIR_JSON", tmp_path / "rm")
+    rc = rm.main(["--list-jobs", "--no-write"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["report_kind"] == "recurring_maintenance_digest"
+    assert payload["mode"] == "list"
+
+
+def test_cli_plan_does_not_persist(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(rm, "DIGEST_DIR_JSON", tmp_path / "rm")
+    rc = rm.main(["--plan", "--no-write"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["mode"] == "plan"
+    assert "due_now" in payload
+    assert not (tmp_path / "rm" / "state.json").exists()
+
+
+def test_cli_status_when_no_artifact(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(rm, "DIGEST_DIR_JSON", tmp_path / "rm")
+    rc = rm.main(["--status"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "not_available"


### PR DESCRIPTION
## Summary

- Adds `reporting.recurring_maintenance` — a typed, whitelisted scheduler that runs a closed set of low-risk read-only reporters at fixed intervals on top of v3.15.15.22's workloop runtime.
- Surfaces a new `recurring_maintenance` block on the agent-control status payload and a new maintenance row on the AgentControl PWA Status card.
- Extends `approval_inbox` to project recurring maintenance into operator-actionable entries.

## Hard guarantees

- **Closed registry** — `JOB_TYPES` is a 5-entry tuple; unknown job names are refused.
- **`safe_to_execute=false`** at the digest level, always.
- **Atomic JSON writes** via `tmp` + `os.replace`.
- **Bounded loop** — `MAX_ITERATIONS_LIMIT=24`, interval clamped to `[30, 21600]` seconds.
- **Per-job thread-join supervisor** with classified status enum (`not_run` / `succeeded` / `skipped` / `blocked` / `failed` / `timeout` / `not_available`); a single failing job never crashes the round.
- **Narrow credential-value redaction** (`sk-ant-`, `ghp_`, `github_pat_`, `AKIA`, `BEGIN PRIVATE KEY`) — path-shaped strings still surface.
- **No subprocess in this module** — executors call supervised reporters in-process.
- **No free-form CLI flags** — no `--command`, no `--argv`, no `--shell`.

## Dependabot LOW/MEDIUM execute-safe — TWO-LAYER opt-in

- `default_enabled=False` in registry (state-file gate).
- Requires runtime `--enable-dependabot-execute-safe` CLI flag.
- Both must be set; either alone keeps the job disabled.
- Even when both are set, merge logic lives in `reporting.github_pr_lifecycle` — this module is a thin pass-through.

## Surfaces extended (read-only)

- `reporting.approval_inbox`: builds entries from the recurring_maintenance digest.
  - `consecutive_failures>=3` -> `runtime_halt` (severity: critical)
  - `last_status` in `{failed, timeout}` -> `failed_automation` (severity: high)
  - `last_status==blocked` -> `unknown_state` (severity: medium)
- `dashboard.api_agent_control`: status payload now carries a compact `recurring_maintenance` block; missing/malformed artifact -> `not_available` (never silent OK).
- Frontend `AgentControl`: Status card renders maintenance row + recommendation pill; `AgentControlStatus` type extended.

## Tests

- `tests/unit/test_recurring_maintenance.py` (32 cases): closed registry, plan/list non-mutation, `run_one_job` classification, disabled→skipped, failing-job-isolated, timeout, dependabot two-layer opt-in (3 cases), schedule respect, loop clamping, atomic writes, history append, `safe_to_execute=false`, no-subprocess invariant, no-freeform-flags invariant, frozen-contract integrity, credential redaction.
- `tests/unit/test_approval_inbox.py`: +5 projection cases.
- `tests/unit/test_dashboard_api_agent_control.py`: +1 status block case.
- Frontend `AgentControlPolish.test.tsx`: +2 maintenance row cases.

Targeted unit suite: 111/111 passing.

## Non-goals (explicitly out of scope for v3.15.15.23)

- No CI changes, no SHA-pin changes.
- No new dependencies.
- No live / paper / shadow / risk surface changes.
- No `.claude/**` writes.
- No `dashboard/dashboard.py` writes.
- No POST/PUT/PATCH/DELETE handlers added.
- No frozen-contract changes (`research/research_latest.json`, `research/strategy_matrix.csv` hashes unchanged).

## Test plan

- [ ] CI gates green (governance lint, smoke, unit, frontend, governance smoke)
- [ ] Frozen-contract hashes unchanged on main
- [ ] PR Lifecycle / Dependabot housekeeping flow remains intact (no new mutating verbs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)