### PR TITLE
feat(v3.15.15.24): high-risk approval policy hardening

### DIFF
--- a/dashboard/api_agent_control.py
+++ b/dashboard/api_agent_control.py
@@ -183,7 +183,49 @@ def _status_payload() -> dict[str, Any]:
         "frozen_hashes": _frozen_hashes_payload(),
         "workloop_runtime": _workloop_runtime_summary(),
         "recurring_maintenance": _recurring_maintenance_summary(),
+        "approval_policy": _approval_policy_summary(),
     }
+
+
+def _approval_policy_summary() -> dict[str, Any]:
+    """Project the v3.15.15.24 high-risk approval policy into a
+    compact, read-only summary for the Status card. Returns
+    ``not_available`` on any import / runtime error — never raises.
+
+    The summary surfaces only static facts about the policy
+    (module version, decision count, executable invariants); it does
+    not call ``decide()`` so there is no per-row evaluation cost on
+    the status surface.
+    """
+    try:
+        from reporting.approval_policy import policy_summary
+
+        s = policy_summary()
+        return {
+            "status": "ok",
+            "data": {
+                "module_version": s.get("module_version"),
+                "schema_version": s.get("schema_version"),
+                "decision_count": len(s.get("decisions") or []),
+                "approval_category_count": len(
+                    s.get("approval_categories") or []
+                ),
+                "high_or_unknown_is_executable": s.get(
+                    "high_or_unknown_is_executable", False
+                ),
+                "execute_safe_requires_dependabot_low_or_medium": s.get(
+                    "execute_safe_requires_dependabot_low_or_medium", True
+                ),
+                "execute_safe_requires_two_layer_opt_in": s.get(
+                    "execute_safe_requires_two_layer_opt_in", True
+                ),
+            },
+        }
+    except Exception as e:  # noqa: BLE001
+        return {
+            "status": "not_available",
+            "reason": f"approval_policy_error: {type(e).__name__}",
+        }
 
 
 def _recurring_maintenance_summary() -> dict[str, Any]:

--- a/docs/governance/high_risk_approval_policy.md
+++ b/docs/governance/high_risk_approval_policy.md
@@ -1,0 +1,183 @@
+# High-Risk Approval Policy — operator runbook
+
+Module: `reporting.approval_policy`
+Version: v3.15.15.24
+Schema: `docs/governance/high_risk_approval_policy/schema.v1.md`
+
+## TL;DR
+
+Every governance / lifecycle module in the repository imports a
+single shared decision function: `approval_policy.decide()`.
+That function is pure, deterministic, and stdlib-only. It returns
+one of 14 decisions; only ONE of those decisions
+(`allowed_low_risk_execute_safe`) can ever carry `executable=true`.
+
+If you came here because you saw a `blocked_*` decision in an inbox
+row or a status payload — this document explains what that means
+and what action is appropriate.
+
+## Hard guarantees
+
+The policy enforces, by construction:
+
+* `UNKNOWN` is never executable.
+* `HIGH` is never executable.
+* Frozen contract change overrides LOW / MEDIUM.
+* Protected path change overrides LOW / MEDIUM.
+* Live / paper / shadow / risk path change overrides LOW / MEDIUM.
+* CI / test path change overrides LOW / MEDIUM.
+* Governance change is always HIGH.
+* Canonical roadmap adoption is always HIGH and routes to the
+  operator.
+* External account / secret / OAuth / API-key / signup is always
+  HIGH.
+* Telemetry / data egress is always HIGH.
+* Paid plan / hosted SaaS is always HIGH.
+* Malformed provider / pending checks / unknown mergeability route
+  to UNKNOWN, never LOW.
+* Non-Dependabot execute-safe routes to `needs_human`.
+* Even Dependabot LOW/MEDIUM execute-safe needs CLEAN merge state
+  AND all checks `passed`.
+
+## What agents may do automatically
+
+The agent layer may, without operator approval:
+
+* Read repository state.
+* Run read-only reporters (proposal_queue, approval_inbox,
+  github_pr_lifecycle dry-run, workloop_runtime,
+  recurring_maintenance).
+* Surface status payloads on the read-only PWA.
+* Refresh upstream artifacts via the supervised reporter chain.
+* For **Dependabot LOW/MEDIUM PRs only**, when ALL of the
+  following are true:
+  * The PR base is `main`.
+  * The PR is not a draft.
+  * The PR diff does not touch any protected/frozen/live/CI path.
+  * The merge state is `CLEAN`.
+  * Every required check is `passed`.
+  * The state-file flag for `dependabot_low_medium_execute_safe`
+    is `enabled=true`.
+  * The runtime CLI flag `--enable-dependabot-execute-safe` is
+    present.
+  the agent may post `@dependabot rebase` and / or perform a
+  squash-merge through the supervised
+  `reporting.github_pr_lifecycle` flow.
+
+## What agents may only propose
+
+The agent layer may *propose* (write a row to the queue / inbox,
+never act) for:
+
+* New tooling / dependencies.
+* New observability / testing / UX gaps.
+* Scoped release candidates.
+* Roadmap diffs (not adoptions — see below).
+
+These are surfaced as `allowed_read_only` rows in the inbox; the
+operator reviews and authors any follow-up PR by hand.
+
+## What agents must block
+
+Any of the following inputs route to a `blocked_*` decision and
+the agent layer refuses to act, even if every other gate is green:
+
+* `.claude/**` change.
+* `AGENTS.md` / `CLAUDE.md` change.
+* `.github/CODEOWNERS` change.
+* `VERSION` change.
+* Frozen contract regen
+  (`research/research_latest.json` /
+   `research/strategy_matrix.csv`).
+* Live / paper / shadow / risk path change
+  (`execution/**`, `automation/**`, `agent/risk/**`, etc.).
+* CI / test path change
+  (`.github/workflows/**`, `tests/regression/**`,
+   `scripts/governance_lint.py`, `scripts/release_gate.py`).
+* Branch-protection bypass.
+* Force push.
+* Direct push to `main`.
+* `gh pr merge --admin`.
+* Arbitrary command execution / `shell=True` / free-form argv.
+* Secrets / API keys / OAuth / SSO / account linking.
+* Paid tiers / hosted SaaS / subscriptions.
+* External telemetry / data egress.
+* Canonical roadmap adoption / supersession.
+* Governance weakening of any kind.
+* Unknown provider / check state.
+* Malformed provider output.
+* HIGH-risk PR.
+* Non-Dependabot PR being asked to execute-safe.
+* Protected-path PR.
+* Pending / failing / unknown checks.
+
+## What requires Joery approval
+
+Anything in the "must block" list above plus:
+
+* Any `needs_human` decision (e.g. a non-Dependabot author asking
+  for execute-safe).
+* Any `tooling_intake` HIGH proposal (Datadog, Sentry, etc.).
+* Any roadmap adoption proposal.
+* Any release candidate that the operator has not pre-approved.
+* Any change to the policy module itself
+  (`reporting/approval_policy.py`).
+* Any change to this runbook or to `schema.v1.md`.
+
+## Examples of HIGH
+
+* "Bump numpy from 1.24.0 to 2.0.0" — major bump on a numerical
+  dep -> HIGH.
+* "Add Datadog APM with API key auth" — telemetry + secret -> HIGH.
+* "Rewrite roadmap to v4 canonical plan" — canonical roadmap
+  adoption -> HIGH.
+* "Modify .github/workflows/ci.yml to skip slow tests" — CI
+  weakening -> HIGH.
+* "Update execution/live/broker_kraken.py timeout" — live trading
+  path -> HIGH.
+* "Edit .claude/settings.json to add new agent allowlist" —
+  governance / protected -> HIGH.
+
+## Examples of UNKNOWN
+
+* `gh pr list` returns malformed JSON -> UNKNOWN.
+* A required check is still pending -> UNKNOWN.
+* Mergeability state reports as `BEHIND` (or empty / unknown) ->
+  UNKNOWN.
+* A proposal source file is unparseable -> UNKNOWN.
+
+UNKNOWN never silently softens to LOW. The agent surfaces the
+`unknown_state` inbox category and waits.
+
+## Why HIGH is read-only / proposal-only
+
+The trading agent operates with a 50% drawdown ceiling and a
+financial-result-as-consequence principle (see `CLAUDE.md`). A
+HIGH-risk action — by definition — has scope to change live
+behavior, lose audit-chain integrity, weaken the test net, or
+exfiltrate data. Auto-executing any of those would mean the agent
+chose to spend operator trust without operator consent.
+
+The policy makes that decision impossible at the function-call
+level rather than the review level.
+
+## Cross-references
+
+* Schema: `docs/governance/high_risk_approval_policy/schema.v1.md`
+* Proposal queue: `docs/governance/proposal_queue.md`
+* Approval inbox: `docs/governance/approval_inbox.md`
+* GitHub PR lifecycle: `docs/governance/github_pr_lifecycle.md`
+* Execute-safe controls: `docs/governance/execute_safe_controls.md`
+* Recurring maintenance:
+  `docs/governance/recurring_maintenance.md`
+* No-touch paths: `docs/governance/no_touch_paths.md`
+* Authority doctrine:
+  `docs/adr/ADR-014-truth-authority-settlement.md`
+
+## Governance footnote
+
+This policy is itself a governance surface. Changing
+`reporting/approval_policy.py`, `schema.v1.md`, or this runbook is
+a `blocked_governance_change` per its own rules. The only way to
+modify the policy is via a human-authored PR with CODEOWNERS
+review.

--- a/docs/governance/high_risk_approval_policy/schema.v1.md
+++ b/docs/governance/high_risk_approval_policy/schema.v1.md
@@ -1,0 +1,216 @@
+# High-Risk Approval Policy — schema v1
+
+Module: `reporting.approval_policy` (v3.15.15.24)
+Schema version: `1`
+Stability: stable; additions are SemVer minor, removals are breaking.
+
+This is the machine-readable description of the canonical
+HIGH-risk approval policy. Every governance / lifecycle module in
+the repository imports this policy and produces decisions that
+match it.
+
+## Risk classes
+
+```
+RISK_CLASSES = ["LOW", "MEDIUM", "HIGH", "UNKNOWN"]
+```
+
+* `LOW` — routine, reversible, scoped change with full evidence.
+* `MEDIUM` — routine but coarser scope (production-Python floor
+  bump, mixed/unknown diff scope, observability/testing/UX gap).
+* `HIGH` — protected path / frozen contract / live trading / major
+  semver bump / governance / canonical roadmap / external account
+  / paid tool / telemetry / CI weakening.
+* `UNKNOWN` — evidence missing or malformed. NEVER treated as LOW
+  or MEDIUM.
+
+## Decision enum (closed)
+
+```
+DECISIONS = [
+  "allowed_read_only",
+  "allowed_low_risk_execute_safe",
+  "needs_human",
+  "blocked_high_risk",
+  "blocked_unknown",
+  "blocked_protected_path",
+  "blocked_frozen_contract",
+  "blocked_live_paper_shadow_risk",
+  "blocked_governance_change",
+  "blocked_external_secret_required",
+  "blocked_telemetry_or_data_egress",
+  "blocked_paid_tool",
+  "blocked_ci_or_test_weakening",
+  "blocked_canonical_roadmap_change"
+]
+```
+
+Only `allowed_low_risk_execute_safe` carries `executable=true`.
+Every other decision returns `executable=false`.
+
+## Approval categories
+
+`APPROVAL_CATEGORIES` is the same set of strings used by
+`reporting.approval_inbox`. The policy is the single source of
+truth; the inbox imports it as a peer enum.
+
+```
+APPROVAL_CATEGORIES = [
+  "roadmap_adoption_required",
+  "high_risk_pr",
+  "protected_path_change",
+  "governance_change",
+  "tooling_requires_approval",
+  "external_account_or_secret_required",
+  "telemetry_or_data_egress_required",
+  "paid_tool_required",
+  "frozen_contract_risk",
+  "live_paper_shadow_risk_change",
+  "ci_or_test_weakening_risk",
+  "unknown_state",
+  "failed_automation",
+  "blocked_rebase",
+  "blocked_checks",
+  "runtime_halt",
+  "security_alert",
+  "manual_route_wiring_required"
+]
+```
+
+## Allowed maximum action classes
+
+```
+ACTIONS = [
+  "read_only",
+  "propose_only",
+  "low_risk_execute_safe",
+  "none"
+]
+```
+
+Decision -> `allowed_max_action`:
+
+| decision                                  | allowed_max_action       |
+| ----------------------------------------- | ------------------------ |
+| allowed_read_only                         | read_only                |
+| allowed_low_risk_execute_safe             | low_risk_execute_safe    |
+| needs_human                               | propose_only             |
+| any blocked_*                             | none                     |
+
+## PolicyInput
+
+```
+PolicyInput {
+  title: string
+  summary: string
+  source_type: string
+  affected_files: string[]
+  labels: string[]
+  risk_class: "LOW" | "MEDIUM" | "HIGH" | "UNKNOWN"
+  requested_action: string
+  requires_secret: bool
+  requires_external_account: bool
+  requires_paid_tool: bool
+  has_telemetry_or_data_egress: bool
+  touches_governance: bool
+  touches_frozen_contract: bool
+  touches_live_paper_shadow_risk: bool
+  touches_ci_or_tests: bool
+  changes_canonical_roadmap: bool
+  is_dependabot: bool
+  pr_author: string
+  provider_state: string
+  checks_state: string
+  mergeability_state: string
+}
+```
+
+## PolicyDecision
+
+```
+PolicyDecision {
+  decision: <one of DECISIONS>
+  risk_class: <one of RISK_CLASSES>
+  reason: string
+  approval_category: <one of APPROVAL_CATEGORIES>
+  allowed_max_action: <one of ACTIONS>
+  executable: bool   # true ONLY for allowed_low_risk_execute_safe
+  requires_human_approval: bool
+  forbidden_agent_actions: string[]
+  required_evidence: string[]
+}
+```
+
+## Order of evaluation (first-match wins)
+
+1. Frozen contract change -> `blocked_frozen_contract` (HIGH)
+2. Protected path change -> `blocked_protected_path` (HIGH)
+3. Live / paper / shadow / risk path change -> `blocked_live_paper_shadow_risk` (HIGH)
+4. CI / test path change -> `blocked_ci_or_test_weakening` (HIGH)
+5. Governance change (signal in title/summary OR `touches_governance`) -> `blocked_governance_change` (HIGH)
+6. Canonical roadmap adoption -> `blocked_canonical_roadmap_change` (HIGH)
+7. External account / secret / API key -> `blocked_external_secret_required` (HIGH)
+8. Telemetry / data egress -> `blocked_telemetry_or_data_egress` (HIGH)
+9. Paid plan / hosted SaaS -> `blocked_paid_tool` (HIGH)
+10. `risk_class == HIGH` upstream -> `blocked_high_risk`
+11. `risk_class == UNKNOWN` upstream -> `blocked_unknown`
+12. Execute-safe path:
+    - Non-Dependabot -> `needs_human`
+    - HIGH -> `blocked_high_risk`
+    - Provider/checks/merge bad -> `blocked_unknown`
+    - LOW or MEDIUM Dependabot, CLEAN, all checks passed -> `allowed_low_risk_execute_safe`
+13. Default -> `allowed_read_only`
+
+The order is the safety contract; reordering is a breaking change.
+
+## Universal forbidden agent actions
+
+The `forbidden_agent_actions` list always includes:
+
+```
+"git push origin main"
+"git push --force"
+"git push --force-with-lease"
+"gh pr merge --admin"
+"edit .claude/**"
+"edit AGENTS.md"
+"edit CLAUDE.md"
+"edit frozen contracts"
+"edit automation/live_gate.py"
+"modify VERSION"
+"execute live broker"
+"place real-money order"
+"arbitrary shell command"
+"free-form operator command string"
+"shell=True subprocess"
+"free-form argv"
+"branch protection bypass"
+"admin merge"
+```
+
+Each blocked decision adds its own per-decision extras (e.g.
+`"regenerate research/research_latest.json without operator sign-off"`
+under `blocked_frozen_contract`).
+
+## Credential-value redaction
+
+`assert_no_credential_values(payload)` raises `AssertionError`
+when any string contains:
+
+```
+sk-ant-
+ghp_
+github_pat_
+AKIA
+BEGIN PRIVATE KEY
+```
+
+Path-shaped strings (`config/config.yaml`, `research/...`, etc.)
+are explicitly allowed; the guard is intentionally narrow.
+
+## Two-layer Dependabot opt-in
+
+The policy alone does NOT enable Dependabot execute-safe. It is a
+necessary but not sufficient condition. The state-file flag and
+the runtime CLI flag are still required (see
+`docs/governance/recurring_maintenance.md`).

--- a/frontend/src/api/agent_control.ts
+++ b/frontend/src/api/agent_control.ts
@@ -60,6 +60,19 @@ export interface AgentControlStatus {
       }>;
     };
   };
+  approval_policy?: {
+    status: "ok" | "not_available";
+    reason?: string;
+    data?: {
+      module_version?: string;
+      schema_version?: number;
+      decision_count?: number;
+      approval_category_count?: number;
+      high_or_unknown_is_executable?: boolean;
+      execute_safe_requires_dependabot_low_or_medium?: boolean;
+      execute_safe_requires_two_layer_opt_in?: boolean;
+    };
+  };
 }
 
 export interface AgentControlActivity {

--- a/frontend/src/routes/AgentControl.tsx
+++ b/frontend/src/routes/AgentControl.tsx
@@ -134,6 +134,19 @@ function StatusCard({ payload }: { payload: AgentControlStatus | null }) {
           : maintenanceRecommendation === "all_jobs_ok"
             ? "ok"
             : "unknown";
+
+  const policy = payload.approval_policy;
+  const policyStatus = policy?.status ?? "not_available";
+  const policyData =
+    policy?.status === "ok" ? policy.data : undefined;
+  const policyVersion = String(policyData?.module_version ?? "n/a");
+  const policyPill: "ok" | "warn" | "danger" | "unknown" =
+    policyStatus !== "ok"
+      ? "unknown"
+      : policyData?.high_or_unknown_is_executable === false &&
+          policyData?.execute_safe_requires_two_layer_opt_in === true
+        ? "ok"
+        : "warn";
   return (
     <Card title="Status" subtitle="governance + frozen + runtime">
       <div className="agent-control-card__row">
@@ -179,6 +192,24 @@ function StatusCard({ payload }: { payload: AgentControlStatus | null }) {
         >
           <dt>maintenance rec.</dt>
           <dd>{maintenanceRecommendation}</dd>
+        </div>
+      ) : null}
+      <div
+        className="agent-control-card__row"
+        data-testid="status-policy-row"
+      >
+        <dt>approval policy</dt>
+        <dd>
+          <StatusPill state={policyPill} />
+        </dd>
+      </div>
+      {policyStatus === "ok" && policyData ? (
+        <div
+          className="agent-control-card__row"
+          data-testid="status-policy-version"
+        >
+          <dt>policy version</dt>
+          <dd>{policyVersion}</dd>
         </div>
       ) : null}
       {Object.keys(fh).length === 0 ? (

--- a/frontend/src/test/AgentControl.test.tsx
+++ b/frontend/src/test/AgentControl.test.tsx
@@ -69,6 +69,18 @@ const okStatusBody = {
       jobs: [],
     },
   },
+  approval_policy: {
+    status: "ok",
+    data: {
+      module_version: "v3.15.15.24",
+      schema_version: 1,
+      decision_count: 14,
+      approval_category_count: 18,
+      high_or_unknown_is_executable: false,
+      execute_safe_requires_dependabot_low_or_medium: true,
+      execute_safe_requires_two_layer_opt_in: true,
+    },
+  },
 };
 
 const okActivityBody = {

--- a/frontend/src/test/AgentControlPolish.test.tsx
+++ b/frontend/src/test/AgentControlPolish.test.tsx
@@ -70,6 +70,18 @@ const okStatusBody = {
       jobs: [],
     },
   },
+  approval_policy: {
+    status: "ok",
+    data: {
+      module_version: "v3.15.15.24",
+      schema_version: 1,
+      decision_count: 14,
+      approval_category_count: 18,
+      high_or_unknown_is_executable: false,
+      execute_safe_requires_dependabot_low_or_medium: true,
+      execute_safe_requires_two_layer_opt_in: true,
+    },
+  },
 };
 
 const okActivityBody = {
@@ -432,6 +444,44 @@ describe("AgentControl polish — Status card maintenance row (v3.15.15.23)", ()
     expect(row).toBeInTheDocument();
     expect(
       screen.queryByTestId("status-maintenance-recommendation"),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("AgentControl polish — Status card approval-policy row (v3.15.15.24)", () => {
+  it("renders the approval_policy row when the status payload provides it", async () => {
+    installFetchMock(_allOk());
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+    const row = await screen.findByTestId("status-policy-row");
+    expect(row).toBeInTheDocument();
+    const ver = await screen.findByTestId("status-policy-version");
+    expect(ver).toHaveTextContent("v3.15.15.24");
+  });
+
+  it("renders policy row as unknown when status payload omits approval_policy", async () => {
+    const statusBodyNoPolicy = {
+      kind: "agent_control_status",
+      schema_version: 1,
+      governance_status: { status: "ok", data: {} },
+      frozen_hashes: okFrozenHashes,
+    };
+    installFetchMock({
+      ..._allOk(),
+      "/api/agent-control/status": () => jsonResp(statusBodyNoPolicy),
+    });
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+    const row = await screen.findByTestId("status-policy-row");
+    expect(row).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("status-policy-version"),
     ).not.toBeInTheDocument();
   });
 });

--- a/reporting/approval_inbox.py
+++ b/reporting/approval_inbox.py
@@ -61,6 +61,7 @@ from pathlib import Path
 from typing import Any
 
 from reporting.agent_audit_summary import assert_no_secrets
+from reporting import approval_policy as _ap
 
 REPO_ROOT: Path = Path(__file__).resolve().parent.parent
 MODULE_VERSION: str = "v3.15.15.20"
@@ -83,27 +84,11 @@ SOURCE_RECURRING_MAINTENANCE: Path = (
     REPO_ROOT / "logs" / "recurring_maintenance" / "latest.json"
 )
 
-# Canonical inbox categories (18 per the v3.15.15.20 brief).
-CATEGORIES: tuple[str, ...] = (
-    "roadmap_adoption_required",
-    "high_risk_pr",
-    "protected_path_change",
-    "governance_change",
-    "tooling_requires_approval",
-    "external_account_or_secret_required",
-    "telemetry_or_data_egress_required",
-    "paid_tool_required",
-    "frozen_contract_risk",
-    "live_paper_shadow_risk_change",
-    "ci_or_test_weakening_risk",
-    "unknown_state",
-    "failed_automation",
-    "blocked_rebase",
-    "blocked_checks",
-    "runtime_halt",
-    "security_alert",
-    "manual_route_wiring_required",
-)
+# Canonical inbox categories — v3.15.15.24: imported from the
+# shared approval policy so the inbox cannot drift from the
+# canonical set. Must remain a ``tuple[str, ...]`` for
+# backwards-compatibility with ``test_approval_inbox.py``.
+CATEGORIES: tuple[str, ...] = tuple(_ap.APPROVAL_CATEGORIES)
 
 # Severity scale.
 SEVERITIES: tuple[str, ...] = ("info", "low", "medium", "high", "critical")

--- a/reporting/approval_policy.py
+++ b/reporting/approval_policy.py
@@ -1,0 +1,1012 @@
+"""Shared HIGH-risk approval policy (v3.15.15.24).
+
+A pure, deterministic, stdlib-only module that encodes ONE canonical
+decision function for every other governance / lifecycle module to
+import. It does not import Flask, the frontend, GitHub, or the
+network. It does not perform I/O.
+
+The goal is to remove drift between the duplicated risk-classification
+blocks in:
+
+* reporting.proposal_queue
+* reporting.approval_inbox
+* reporting.github_pr_lifecycle
+* reporting.execute_safe_controls
+* reporting.workloop_runtime
+* reporting.recurring_maintenance
+
+Each of those modules continues to own its own decision flow, but the
+HIGH / UNKNOWN / protected / canonical / governance / live / risk /
+secret / external / paid / telemetry / ci / frozen-contract verdict
+is now produced by ONE function here. If a module diverges from this
+verdict, a unit test in tests/unit/test_approval_policy.py will fail.
+
+Hard guarantees
+---------------
+
+The decision function MUST satisfy the following invariants. They
+are enforced by tests in
+``tests/unit/test_approval_policy.py``:
+
+* ``UNKNOWN`` never executes.
+* ``HIGH`` never executes.
+* Protected path overrides LOW / MEDIUM.
+* Frozen contract change overrides LOW / MEDIUM.
+* Live / paper / shadow / risk change overrides LOW / MEDIUM.
+* CI / test weakening overrides LOW / MEDIUM.
+* External account / secret / telemetry / paid -> needs_human or
+  blocked.
+* Canonical roadmap adoption -> needs_human.
+* Malformed provider output -> UNKNOWN / blocked.
+* Pending / failing / unknown checks block.
+* Non-Dependabot execute-safe is blocked.
+* Dependabot LOW / MEDIUM execute-safe is policy-allowed only when
+  ALL evidence is present (mergeable, CLEAN, all checks passed,
+  baseline ok, two-layer opt-in confirmed elsewhere).
+* No decision returns ``executable=true`` for HIGH / UNKNOWN /
+  needs_human / blocked_*.
+* The output never contains credential-shaped values.
+
+Stdlib-only.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import datetime as _dt
+import fnmatch
+import re
+from collections.abc import Iterable, Mapping
+from typing import Any, Final
+
+
+MODULE_VERSION: Final[str] = "v3.15.15.24"
+SCHEMA_VERSION: Final[int] = 1
+
+
+# ---------------------------------------------------------------------------
+# Risk classes
+# ---------------------------------------------------------------------------
+
+RISK_LOW: Final[str] = "LOW"
+RISK_MEDIUM: Final[str] = "MEDIUM"
+RISK_HIGH: Final[str] = "HIGH"
+RISK_UNKNOWN: Final[str] = "UNKNOWN"
+
+RISK_CLASSES: Final[tuple[str, ...]] = (
+    RISK_LOW,
+    RISK_MEDIUM,
+    RISK_HIGH,
+    RISK_UNKNOWN,
+)
+
+
+# ---------------------------------------------------------------------------
+# Decision classes (the closed set the policy emits)
+# ---------------------------------------------------------------------------
+
+DECISION_ALLOWED_READ_ONLY: Final[str] = "allowed_read_only"
+DECISION_ALLOWED_LOW_RISK_EXECUTE_SAFE: Final[str] = "allowed_low_risk_execute_safe"
+DECISION_NEEDS_HUMAN: Final[str] = "needs_human"
+DECISION_BLOCKED_HIGH_RISK: Final[str] = "blocked_high_risk"
+DECISION_BLOCKED_UNKNOWN: Final[str] = "blocked_unknown"
+DECISION_BLOCKED_PROTECTED_PATH: Final[str] = "blocked_protected_path"
+DECISION_BLOCKED_FROZEN_CONTRACT: Final[str] = "blocked_frozen_contract"
+DECISION_BLOCKED_LIVE_PAPER_SHADOW_RISK: Final[str] = "blocked_live_paper_shadow_risk"
+DECISION_BLOCKED_GOVERNANCE_CHANGE: Final[str] = "blocked_governance_change"
+DECISION_BLOCKED_EXTERNAL_SECRET_REQUIRED: Final[str] = "blocked_external_secret_required"
+DECISION_BLOCKED_TELEMETRY_OR_DATA_EGRESS: Final[str] = "blocked_telemetry_or_data_egress"
+DECISION_BLOCKED_PAID_TOOL: Final[str] = "blocked_paid_tool"
+DECISION_BLOCKED_CI_OR_TEST_WEAKENING: Final[str] = "blocked_ci_or_test_weakening"
+DECISION_BLOCKED_CANONICAL_ROADMAP_CHANGE: Final[str] = "blocked_canonical_roadmap_change"
+
+
+DECISIONS: Final[tuple[str, ...]] = (
+    DECISION_ALLOWED_READ_ONLY,
+    DECISION_ALLOWED_LOW_RISK_EXECUTE_SAFE,
+    DECISION_NEEDS_HUMAN,
+    DECISION_BLOCKED_HIGH_RISK,
+    DECISION_BLOCKED_UNKNOWN,
+    DECISION_BLOCKED_PROTECTED_PATH,
+    DECISION_BLOCKED_FROZEN_CONTRACT,
+    DECISION_BLOCKED_LIVE_PAPER_SHADOW_RISK,
+    DECISION_BLOCKED_GOVERNANCE_CHANGE,
+    DECISION_BLOCKED_EXTERNAL_SECRET_REQUIRED,
+    DECISION_BLOCKED_TELEMETRY_OR_DATA_EGRESS,
+    DECISION_BLOCKED_PAID_TOOL,
+    DECISION_BLOCKED_CI_OR_TEST_WEAKENING,
+    DECISION_BLOCKED_CANONICAL_ROADMAP_CHANGE,
+)
+
+
+# Approval categories — superset of approval_inbox CATEGORIES, kept
+# as a pure mirror so downstream modules can map decision -> category
+# without duplicating the enum.
+APPROVAL_CATEGORIES: Final[tuple[str, ...]] = (
+    "roadmap_adoption_required",
+    "high_risk_pr",
+    "protected_path_change",
+    "governance_change",
+    "tooling_requires_approval",
+    "external_account_or_secret_required",
+    "telemetry_or_data_egress_required",
+    "paid_tool_required",
+    "frozen_contract_risk",
+    "live_paper_shadow_risk_change",
+    "ci_or_test_weakening_risk",
+    "unknown_state",
+    "failed_automation",
+    "blocked_rebase",
+    "blocked_checks",
+    "runtime_halt",
+    "security_alert",
+    "manual_route_wiring_required",
+)
+
+
+# ---------------------------------------------------------------------------
+# Action classes
+# ---------------------------------------------------------------------------
+
+ACTION_READ_ONLY: Final[str] = "read_only"
+ACTION_PROPOSE_ONLY: Final[str] = "propose_only"
+ACTION_LOW_RISK_EXECUTE_SAFE: Final[str] = "low_risk_execute_safe"
+ACTION_NONE: Final[str] = "none"
+
+ACTIONS: Final[tuple[str, ...]] = (
+    ACTION_READ_ONLY,
+    ACTION_PROPOSE_ONLY,
+    ACTION_LOW_RISK_EXECUTE_SAFE,
+    ACTION_NONE,
+)
+
+
+# ---------------------------------------------------------------------------
+# Forbidden / protected glob lists
+# ---------------------------------------------------------------------------
+
+# Frozen research contracts — byte-identity must be preserved.
+FROZEN_CONTRACTS: Final[tuple[str, ...]] = (
+    "research/research_latest.json",
+    "research/strategy_matrix.csv",
+)
+
+
+# Protected (no-touch) globs — mirror of
+# ``docs/governance/no_touch_paths.md``.
+PROTECTED_GLOBS: Final[tuple[str, ...]] = (
+    ".claude/settings.json",
+    ".claude/hooks/*",
+    ".claude/hooks/**",
+    ".claude/agents/*",
+    ".claude/agents/**",
+    ".claude/commands/*",
+    ".claude/commands/**",
+    "AGENTS.md",
+    "CLAUDE.md",
+    ".github/CODEOWNERS",
+    "VERSION",
+    "automation/live_gate.py",
+    "automation/*.secret",
+    "state/*.secret",
+    "config/config.yaml",
+    ".env",
+    ".env.*",
+    "*_latest.v1.json",
+    "*_latest.v1.jsonl",
+    "**/*_latest.v1.json",
+    "**/*_latest.v1.jsonl",
+    "docker-compose.prod.yml",
+    "scripts/deploy.sh",
+    "Dockerfile",
+    "Dockerfile.*",
+)
+
+
+# Live / paper / shadow / trading / risk-bearing globs.
+LIVE_PATH_GLOBS: Final[tuple[str, ...]] = (
+    "execution/live/**",
+    "automation/live/**",
+    "agent/execution/live/**",
+    "**/live_*broker*.py",
+    "**/*live*broker*.py",
+    "**/*live_executor*.py",
+    "**/*live*executor*.py",
+    "**/*_live.py",
+    "automation/live_gate.py",
+    "automation/**",
+    "execution/**",
+    "strategies/**",
+    "agent/risk/**",
+    "agent/execution/**",
+    "**/paper/**",
+    "**/shadow/**",
+)
+
+
+# CI / test / governance weakening globs. Anything under these paths
+# always escalates to ``blocked_ci_or_test_weakening`` unless
+# ``touches_ci_or_tests`` is explicitly False (which only the
+# ci-guardian may set).
+CI_OR_TESTS_GLOBS: Final[tuple[str, ...]] = (
+    ".github/workflows/**",
+    ".github/actions/**",
+    "tests/regression/**",
+    "scripts/governance_lint.py",
+    "scripts/release_gate.py",
+)
+
+
+# Tokens that strongly suggest an external-account / secret / API-key
+# requirement.
+EXTERNAL_SECRET_TOKENS: Final[tuple[str, ...]] = (
+    "api key",
+    "api-key",
+    "api_key",
+    "auth token",
+    "access token",
+    "bearer token",
+    "oauth",
+    "signup",
+    "sign-up",
+    "create an account",
+    "create account",
+    "service account",
+    "client secret",
+    "client_secret",
+    "private key",
+    "ssh key",
+)
+
+
+# Tokens that strongly suggest telemetry / data egress.
+TELEMETRY_TOKENS: Final[tuple[str, ...]] = (
+    "telemetry",
+    "datadog",
+    "sentry",
+    "segment.io",
+    "google-analytics",
+    "googletagmanager",
+    "data egress",
+    "pii export",
+)
+
+
+# Tokens that strongly suggest a paid plan / hosted SaaS.
+PAID_TOOL_TOKENS: Final[tuple[str, ...]] = (
+    "paid plan",
+    "paid tier",
+    "subscription",
+    "saas",
+    "hosted service",
+    "hosted plan",
+)
+
+
+# Tokens that strongly suggest canonical roadmap adoption.
+CANONICAL_ROADMAP_TOKENS: Final[tuple[str, ...]] = (
+    "canonical roadmap",
+    "new roadmap",
+    "roadmap adoption",
+    "rewrite roadmap",
+    "supersede roadmap",
+    "v4 roadmap",
+    "post-v3.15",
+)
+
+
+# Negation prefixes — strip ``no <token>`` / ``no-<token>`` before
+# matching tokens so "no telemetry" does not trigger telemetry.
+_NEGATION_RE = re.compile(r"\bno[- ]\w[-\w ]*")
+
+
+# Universal forbidden agent actions — surfaced on every blocked /
+# needs_human decision regardless of category.
+UNIVERSAL_FORBIDDEN_AGENT_ACTIONS: Final[tuple[str, ...]] = (
+    "git push origin main",
+    "git push --force",
+    "git push --force-with-lease",
+    "gh pr merge --admin",
+    "edit .claude/**",
+    "edit AGENTS.md",
+    "edit CLAUDE.md",
+    "edit frozen contracts",
+    "edit automation/live_gate.py",
+    "modify VERSION",
+    "execute live broker",
+    "place real-money order",
+    "arbitrary shell command",
+    "free-form operator command string",
+    "shell=True subprocess",
+    "free-form argv",
+    "branch protection bypass",
+    "admin merge",
+)
+
+
+# Decision -> additional forbidden actions. The universal list is
+# always emitted; the per-decision list extends it.
+_DECISION_FORBIDDEN_EXTRA: Final[Mapping[str, tuple[str, ...]]] = {
+    DECISION_BLOCKED_PROTECTED_PATH: (
+        "modify any path under .claude/**",
+        "modify CODEOWNERS",
+        "modify VERSION",
+        "modify Dockerfile / Dockerfile.*",
+        "modify docker-compose.prod.yml",
+        "modify scripts/deploy.sh",
+    ),
+    DECISION_BLOCKED_FROZEN_CONTRACT: (
+        "regenerate research/research_latest.json without operator sign-off",
+        "regenerate research/strategy_matrix.csv without operator sign-off",
+    ),
+    DECISION_BLOCKED_LIVE_PAPER_SHADOW_RISK: (
+        "modify execution/** or automation/** without operator approval",
+        "modify agent/risk/** without operator approval",
+        "modify paper/shadow trading flow without operator approval",
+    ),
+    DECISION_BLOCKED_GOVERNANCE_CHANGE: (
+        "weaken hook layer",
+        "weaken governance_lint",
+        "modify .claude/agents/** without operator approval",
+        "modify .claude/hooks/** without operator approval",
+    ),
+    DECISION_BLOCKED_CI_OR_TEST_WEAKENING: (
+        "remove or skip required CI checks",
+        "downgrade SHA pins",
+        "disable required tests",
+        "soften governance_lint",
+    ),
+    DECISION_BLOCKED_EXTERNAL_SECRET_REQUIRED: (
+        "request or store API keys",
+        "perform OAuth / SSO flow",
+        "create accounts on third-party services",
+        "linking the agent to any external account",
+    ),
+    DECISION_BLOCKED_TELEMETRY_OR_DATA_EGRESS: (
+        "send telemetry to a third-party service",
+        "export PII",
+        "open an outbound network egress for analytics",
+    ),
+    DECISION_BLOCKED_PAID_TOOL: (
+        "subscribe to a paid plan",
+        "exceed free tier without operator approval",
+    ),
+    DECISION_BLOCKED_CANONICAL_ROADMAP_CHANGE: (
+        "rewrite or adopt a canonical roadmap autonomously",
+        "supersede an existing roadmap autonomously",
+    ),
+    DECISION_BLOCKED_HIGH_RISK: (
+        "auto-merge a HIGH PR",
+        "auto-execute a HIGH action",
+    ),
+    DECISION_BLOCKED_UNKNOWN: (
+        "act on UNKNOWN evidence",
+        "treat malformed provider output as safe",
+    ),
+}
+
+
+# Decision -> required evidence fields. The decision is reported but
+# downstream consumers can use this list to surface what the operator
+# should look at. None of the values are credentials.
+_DECISION_REQUIRED_EVIDENCE: Final[Mapping[str, tuple[str, ...]]] = {
+    DECISION_BLOCKED_PROTECTED_PATH: ("affected_files", "matched_protected_glob"),
+    DECISION_BLOCKED_FROZEN_CONTRACT: ("affected_files", "matched_frozen_contract"),
+    DECISION_BLOCKED_LIVE_PAPER_SHADOW_RISK: (
+        "affected_files",
+        "matched_live_glob",
+    ),
+    DECISION_BLOCKED_GOVERNANCE_CHANGE: ("touches_governance", "title", "summary"),
+    DECISION_BLOCKED_CI_OR_TEST_WEAKENING: (
+        "touches_ci_or_tests",
+        "affected_files",
+    ),
+    DECISION_BLOCKED_EXTERNAL_SECRET_REQUIRED: (
+        "requires_secret",
+        "requires_external_account",
+        "matched_secret_token",
+    ),
+    DECISION_BLOCKED_TELEMETRY_OR_DATA_EGRESS: (
+        "has_telemetry_or_data_egress",
+        "matched_telemetry_token",
+    ),
+    DECISION_BLOCKED_PAID_TOOL: ("requires_paid_tool", "matched_paid_token"),
+    DECISION_BLOCKED_CANONICAL_ROADMAP_CHANGE: (
+        "changes_canonical_roadmap",
+        "title",
+        "summary",
+    ),
+    DECISION_BLOCKED_HIGH_RISK: ("risk_class", "title", "summary"),
+    DECISION_BLOCKED_UNKNOWN: ("provider_state", "checks_state", "mergeability_state"),
+    DECISION_NEEDS_HUMAN: ("title", "summary"),
+    DECISION_ALLOWED_READ_ONLY: (),
+    DECISION_ALLOWED_LOW_RISK_EXECUTE_SAFE: (
+        "is_dependabot",
+        "checks_state",
+        "mergeability_state",
+        "risk_class",
+    ),
+}
+
+
+# Decision -> approval inbox category. The mapping is intentionally
+# many-to-one: e.g. both the dedicated frozen-contract decision and
+# the protected-path decision can ultimately ask the operator for
+# guidance, but the approval surface keeps them distinct.
+_DECISION_TO_CATEGORY: Final[Mapping[str, str]] = {
+    DECISION_BLOCKED_PROTECTED_PATH: "protected_path_change",
+    DECISION_BLOCKED_FROZEN_CONTRACT: "frozen_contract_risk",
+    DECISION_BLOCKED_LIVE_PAPER_SHADOW_RISK: "live_paper_shadow_risk_change",
+    DECISION_BLOCKED_GOVERNANCE_CHANGE: "governance_change",
+    DECISION_BLOCKED_CI_OR_TEST_WEAKENING: "ci_or_test_weakening_risk",
+    DECISION_BLOCKED_EXTERNAL_SECRET_REQUIRED: "external_account_or_secret_required",
+    DECISION_BLOCKED_TELEMETRY_OR_DATA_EGRESS: "telemetry_or_data_egress_required",
+    DECISION_BLOCKED_PAID_TOOL: "paid_tool_required",
+    DECISION_BLOCKED_CANONICAL_ROADMAP_CHANGE: "roadmap_adoption_required",
+    DECISION_BLOCKED_HIGH_RISK: "high_risk_pr",
+    DECISION_BLOCKED_UNKNOWN: "unknown_state",
+    DECISION_NEEDS_HUMAN: "tooling_requires_approval",
+}
+
+
+# ---------------------------------------------------------------------------
+# Glob / token helpers
+# ---------------------------------------------------------------------------
+
+
+def _norm(p: str) -> str:
+    return p.replace("\\", "/")
+
+
+def _matches_any(path: str, globs: Iterable[str]) -> str | None:
+    n = _norm(path)
+    for g in globs:
+        if fnmatch.fnmatchcase(n, g):
+            return g
+    return None
+
+
+def diff_touches_frozen(files: Iterable[str]) -> tuple[bool, str | None]:
+    """First match wins; returns ``(True, frozen_path)`` or
+    ``(False, None)``."""
+    for f in files:
+        n = _norm(f)
+        if n in FROZEN_CONTRACTS:
+            return (True, n)
+    return (False, None)
+
+
+def diff_touches_protected(files: Iterable[str]) -> tuple[bool, str | None]:
+    """``frozen ⊂ protected`` semantically — but a dedicated check is
+    still needed so a caller can distinguish ``frozen_contract_risk``
+    from a generic ``protected_path_change``."""
+    for f in files:
+        n = _norm(f)
+        if n in FROZEN_CONTRACTS:
+            return (True, n)
+    for f in files:
+        match = _matches_any(f, PROTECTED_GLOBS)
+        if match:
+            return (True, _norm(f))
+    return (False, None)
+
+
+def diff_touches_live(files: Iterable[str]) -> tuple[bool, str | None]:
+    for f in files:
+        match = _matches_any(f, LIVE_PATH_GLOBS)
+        if match:
+            return (True, _norm(f))
+    return (False, None)
+
+
+def diff_touches_ci_or_tests(files: Iterable[str]) -> tuple[bool, str | None]:
+    for f in files:
+        match = _matches_any(f, CI_OR_TESTS_GLOBS)
+        if match:
+            return (True, _norm(f))
+    return (False, None)
+
+
+def _scrub_negations(text: str) -> str:
+    """Strip ``no <token>`` / ``no-<token>`` so explicit negations
+    cannot trigger HIGH-token rules. Lower-cased input."""
+    return _NEGATION_RE.sub(" ", text)
+
+
+def _matched_token(text: str, tokens: Iterable[str]) -> str | None:
+    """Return the first matching token in ``text`` after negation
+    scrub, or ``None``. ``text`` is expected lower-cased already."""
+    scrubbed = _scrub_negations(text)
+    for t in tokens:
+        if t in scrubbed:
+            return t
+    return None
+
+
+# ---------------------------------------------------------------------------
+# PolicyInput / PolicyDecision dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class PolicyInput:
+    """All inputs the policy considers. Optional fields default to
+    ``None`` / ``False`` / ``""`` so callers can supply only what they
+    know — missing evidence routes to UNKNOWN, never to LOW."""
+
+    title: str = ""
+    summary: str = ""
+    source_type: str = ""
+    affected_files: tuple[str, ...] = ()
+    labels: tuple[str, ...] = ()
+    risk_class: str = RISK_UNKNOWN
+    requested_action: str = ""
+    requires_secret: bool = False
+    requires_external_account: bool = False
+    requires_paid_tool: bool = False
+    has_telemetry_or_data_egress: bool = False
+    touches_governance: bool = False
+    touches_frozen_contract: bool = False
+    touches_live_paper_shadow_risk: bool = False
+    touches_ci_or_tests: bool = False
+    changes_canonical_roadmap: bool = False
+    is_dependabot: bool = False
+    pr_author: str = ""
+    provider_state: str = ""
+    checks_state: str = ""
+    mergeability_state: str = ""
+
+    @staticmethod
+    def from_mapping(d: Mapping[str, Any]) -> "PolicyInput":
+        """Lift a plain dict into a ``PolicyInput``. Unknown keys are
+        ignored; missing keys take their dataclass defaults. Tuples
+        are normalised from any iterable."""
+        def _tup(v: Any) -> tuple[str, ...]:
+            if v is None:
+                return ()
+            if isinstance(v, (list, tuple)):
+                return tuple(str(x) for x in v)
+            return (str(v),)
+
+        def _str(v: Any) -> str:
+            if v is None:
+                return ""
+            return str(v)
+
+        def _bool(v: Any) -> bool:
+            return bool(v) if v is not None else False
+
+        rc = _str(d.get("risk_class")) or RISK_UNKNOWN
+        if rc not in RISK_CLASSES:
+            rc = RISK_UNKNOWN
+        return PolicyInput(
+            title=_str(d.get("title")),
+            summary=_str(d.get("summary")),
+            source_type=_str(d.get("source_type")),
+            affected_files=_tup(d.get("affected_files")),
+            labels=_tup(d.get("labels")),
+            risk_class=rc,
+            requested_action=_str(d.get("requested_action")),
+            requires_secret=_bool(d.get("requires_secret")),
+            requires_external_account=_bool(d.get("requires_external_account")),
+            requires_paid_tool=_bool(d.get("requires_paid_tool")),
+            has_telemetry_or_data_egress=_bool(
+                d.get("has_telemetry_or_data_egress")
+            ),
+            touches_governance=_bool(d.get("touches_governance")),
+            touches_frozen_contract=_bool(d.get("touches_frozen_contract")),
+            touches_live_paper_shadow_risk=_bool(
+                d.get("touches_live_paper_shadow_risk")
+            ),
+            touches_ci_or_tests=_bool(d.get("touches_ci_or_tests")),
+            changes_canonical_roadmap=_bool(d.get("changes_canonical_roadmap")),
+            is_dependabot=_bool(d.get("is_dependabot")),
+            pr_author=_str(d.get("pr_author")),
+            provider_state=_str(d.get("provider_state")),
+            checks_state=_str(d.get("checks_state")),
+            mergeability_state=_str(d.get("mergeability_state")),
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class PolicyDecision:
+    """The pure output of ``decide()``.
+
+    Invariants:
+
+    * ``executable`` is True only for
+      ``allowed_low_risk_execute_safe``. ``allowed_read_only`` is
+      reading-only; the caller must not interpret it as
+      ``executable``.
+    * ``decision`` is always in ``DECISIONS``.
+    * ``risk_class`` is always in ``RISK_CLASSES``.
+    """
+
+    decision: str
+    risk_class: str
+    reason: str
+    approval_category: str
+    allowed_max_action: str
+    executable: bool
+    requires_human_approval: bool
+    forbidden_agent_actions: tuple[str, ...]
+    required_evidence: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "decision": self.decision,
+            "risk_class": self.risk_class,
+            "reason": self.reason,
+            "approval_category": self.approval_category,
+            "allowed_max_action": self.allowed_max_action,
+            "executable": self.executable,
+            "requires_human_approval": self.requires_human_approval,
+            "forbidden_agent_actions": list(self.forbidden_agent_actions),
+            "required_evidence": list(self.required_evidence),
+        }
+
+
+def _build_decision(
+    *,
+    decision: str,
+    risk_class: str,
+    reason: str,
+) -> PolicyDecision:
+    if decision not in DECISIONS:
+        raise ValueError(f"unknown decision: {decision!r}")
+    if risk_class not in RISK_CLASSES:
+        raise ValueError(f"unknown risk_class: {risk_class!r}")
+    executable = decision == DECISION_ALLOWED_LOW_RISK_EXECUTE_SAFE
+    requires_human_approval = decision in (
+        DECISION_NEEDS_HUMAN,
+        DECISION_BLOCKED_HIGH_RISK,
+        DECISION_BLOCKED_UNKNOWN,
+        DECISION_BLOCKED_PROTECTED_PATH,
+        DECISION_BLOCKED_FROZEN_CONTRACT,
+        DECISION_BLOCKED_LIVE_PAPER_SHADOW_RISK,
+        DECISION_BLOCKED_GOVERNANCE_CHANGE,
+        DECISION_BLOCKED_EXTERNAL_SECRET_REQUIRED,
+        DECISION_BLOCKED_TELEMETRY_OR_DATA_EGRESS,
+        DECISION_BLOCKED_PAID_TOOL,
+        DECISION_BLOCKED_CI_OR_TEST_WEAKENING,
+        DECISION_BLOCKED_CANONICAL_ROADMAP_CHANGE,
+    )
+    if decision == DECISION_ALLOWED_READ_ONLY:
+        allowed_max_action = ACTION_READ_ONLY
+    elif decision == DECISION_ALLOWED_LOW_RISK_EXECUTE_SAFE:
+        allowed_max_action = ACTION_LOW_RISK_EXECUTE_SAFE
+    elif decision == DECISION_NEEDS_HUMAN:
+        allowed_max_action = ACTION_PROPOSE_ONLY
+    else:
+        allowed_max_action = ACTION_NONE
+    forbidden = list(UNIVERSAL_FORBIDDEN_AGENT_ACTIONS)
+    forbidden.extend(_DECISION_FORBIDDEN_EXTRA.get(decision, ()))
+    # De-duplicate while preserving order.
+    seen: set[str] = set()
+    forbidden_unique: list[str] = []
+    for f in forbidden:
+        if f not in seen:
+            seen.add(f)
+            forbidden_unique.append(f)
+    required = tuple(_DECISION_REQUIRED_EVIDENCE.get(decision, ()))
+    return PolicyDecision(
+        decision=decision,
+        risk_class=risk_class,
+        reason=reason,
+        approval_category=_DECISION_TO_CATEGORY.get(decision, "tooling_requires_approval"),
+        allowed_max_action=allowed_max_action,
+        executable=executable,
+        requires_human_approval=requires_human_approval,
+        forbidden_agent_actions=tuple(forbidden_unique),
+        required_evidence=required,
+    )
+
+
+# ---------------------------------------------------------------------------
+# decide() — the canonical decision function
+# ---------------------------------------------------------------------------
+
+
+def decide(p: PolicyInput | Mapping[str, Any]) -> PolicyDecision:
+    """The single source of truth for HIGH-risk approval decisions.
+
+    Order of evaluation — first match wins. The order is the
+    governing safety contract; do NOT reorder without updating
+    ``tests/unit/test_approval_policy.py``.
+    """
+    pi = p if isinstance(p, PolicyInput) else PolicyInput.from_mapping(p)
+    title_l = pi.title.lower()
+    summary_l = pi.summary.lower()
+    text_l = f"{title_l}\n{summary_l}"
+    files = list(pi.affected_files)
+
+    # 1. Frozen contract (most specific protected path).
+    frozen_hit, frozen_path = diff_touches_frozen(files)
+    if frozen_hit or pi.touches_frozen_contract:
+        return _build_decision(
+            decision=DECISION_BLOCKED_FROZEN_CONTRACT,
+            risk_class=RISK_HIGH,
+            reason=(
+                f"frozen contract change: {frozen_path}"
+                if frozen_path
+                else "input flag touches_frozen_contract is true"
+            ),
+        )
+
+    # 2. Protected path (no-touch / .claude/** / AGENTS.md / ...).
+    prot_hit, prot_path = diff_touches_protected(files)
+    if prot_hit:
+        return _build_decision(
+            decision=DECISION_BLOCKED_PROTECTED_PATH,
+            risk_class=RISK_HIGH,
+            reason=f"protected path change: {prot_path}",
+        )
+
+    # 3. Live / paper / shadow / risk path.
+    live_hit, live_path = diff_touches_live(files)
+    if live_hit or pi.touches_live_paper_shadow_risk:
+        return _build_decision(
+            decision=DECISION_BLOCKED_LIVE_PAPER_SHADOW_RISK,
+            risk_class=RISK_HIGH,
+            reason=(
+                f"live/paper/shadow/risk path change: {live_path}"
+                if live_path
+                else "input flag touches_live_paper_shadow_risk is true"
+            ),
+        )
+
+    # 4. CI / test weakening.
+    ci_hit, ci_path = diff_touches_ci_or_tests(files)
+    if ci_hit or pi.touches_ci_or_tests:
+        return _build_decision(
+            decision=DECISION_BLOCKED_CI_OR_TEST_WEAKENING,
+            risk_class=RISK_HIGH,
+            reason=(
+                f"CI/test path change: {ci_path}"
+                if ci_path
+                else "input flag touches_ci_or_tests is true"
+            ),
+        )
+
+    # 5. Governance change (signal in summary OR explicit flag).
+    if pi.touches_governance or any(
+        t in text_l
+        for t in (
+            ".claude/",
+            "agents.md",
+            "claude.md",
+            "branch protection",
+            "codeowners",
+            "no_touch_paths",
+            "agent governance",
+            "release gate",
+            "autonomy ladder",
+        )
+    ):
+        return _build_decision(
+            decision=DECISION_BLOCKED_GOVERNANCE_CHANGE,
+            risk_class=RISK_HIGH,
+            reason="touches governance surface",
+        )
+
+    # 6. Canonical roadmap adoption.
+    if pi.changes_canonical_roadmap or _matched_token(
+        text_l, CANONICAL_ROADMAP_TOKENS
+    ):
+        return _build_decision(
+            decision=DECISION_BLOCKED_CANONICAL_ROADMAP_CHANGE,
+            risk_class=RISK_HIGH,
+            reason="canonical roadmap adoption requires human approval",
+        )
+
+    # 7. External account / secret.
+    secret_token = _matched_token(text_l, EXTERNAL_SECRET_TOKENS)
+    if pi.requires_secret or pi.requires_external_account or secret_token:
+        return _build_decision(
+            decision=DECISION_BLOCKED_EXTERNAL_SECRET_REQUIRED,
+            risk_class=RISK_HIGH,
+            reason=(
+                f"external secret/account: token {secret_token!r}"
+                if secret_token
+                else "input flag requires_secret/requires_external_account is true"
+            ),
+        )
+
+    # 8. Telemetry / data egress.
+    telemetry_token = _matched_token(text_l, TELEMETRY_TOKENS)
+    if pi.has_telemetry_or_data_egress or telemetry_token:
+        return _build_decision(
+            decision=DECISION_BLOCKED_TELEMETRY_OR_DATA_EGRESS,
+            risk_class=RISK_HIGH,
+            reason=(
+                f"telemetry/data egress: token {telemetry_token!r}"
+                if telemetry_token
+                else "input flag has_telemetry_or_data_egress is true"
+            ),
+        )
+
+    # 9. Paid tool.
+    paid_token = _matched_token(text_l, PAID_TOOL_TOKENS)
+    if pi.requires_paid_tool or paid_token:
+        return _build_decision(
+            decision=DECISION_BLOCKED_PAID_TOOL,
+            risk_class=RISK_HIGH,
+            reason=(
+                f"paid plan: token {paid_token!r}"
+                if paid_token
+                else "input flag requires_paid_tool is true"
+            ),
+        )
+
+    # 10. HIGH risk class declared upstream.
+    if pi.risk_class == RISK_HIGH:
+        return _build_decision(
+            decision=DECISION_BLOCKED_HIGH_RISK,
+            risk_class=RISK_HIGH,
+            reason="upstream classified the input as HIGH",
+        )
+
+    # 11. UNKNOWN risk class OR malformed provider/check/merge state.
+    if pi.risk_class == RISK_UNKNOWN:
+        return _build_decision(
+            decision=DECISION_BLOCKED_UNKNOWN,
+            risk_class=RISK_UNKNOWN,
+            reason="risk_class is UNKNOWN",
+        )
+    bad_provider = pi.provider_state in ("malformed", "unknown")
+    bad_checks = pi.checks_state in ("failed", "pending", "unknown")
+    bad_merge = pi.mergeability_state in ("dirty", "behind", "unknown", "")
+    if pi.requested_action == "execute_safe" and (bad_provider or bad_checks):
+        return _build_decision(
+            decision=DECISION_BLOCKED_UNKNOWN,
+            risk_class=RISK_UNKNOWN,
+            reason=(
+                f"execute_safe blocked on provider_state={pi.provider_state!r}, "
+                f"checks_state={pi.checks_state!r}, "
+                f"mergeability_state={pi.mergeability_state!r}"
+            ),
+        )
+
+    # 12. Execute-safe path — the ONLY decision that returns
+    # executable=True. Both layers of opt-in (state-file + CLI flag)
+    # are checked in the recurring_maintenance / execute_safe modules
+    # themselves; this function only gates on the per-PR evidence.
+    if pi.requested_action == "execute_safe":
+        if not pi.is_dependabot:
+            return _build_decision(
+                decision=DECISION_NEEDS_HUMAN,
+                risk_class=pi.risk_class,
+                reason=(
+                    "execute_safe is restricted to Dependabot PRs; "
+                    f"author={pi.pr_author!r}"
+                ),
+            )
+        if pi.risk_class not in (RISK_LOW, RISK_MEDIUM):
+            return _build_decision(
+                decision=DECISION_BLOCKED_HIGH_RISK,
+                risk_class=pi.risk_class,
+                reason=(
+                    "execute_safe requires LOW or MEDIUM risk; "
+                    f"got {pi.risk_class!r}"
+                ),
+            )
+        if bad_merge or pi.checks_state != "passed":
+            return _build_decision(
+                decision=DECISION_BLOCKED_UNKNOWN,
+                risk_class=RISK_UNKNOWN,
+                reason=(
+                    "execute_safe requires CLEAN mergeability and passed checks; "
+                    f"checks_state={pi.checks_state!r}, "
+                    f"mergeability_state={pi.mergeability_state!r}"
+                ),
+            )
+        return _build_decision(
+            decision=DECISION_ALLOWED_LOW_RISK_EXECUTE_SAFE,
+            risk_class=pi.risk_class,
+            reason="LOW/MEDIUM Dependabot PR with CLEAN merge + passed checks",
+        )
+
+    # 13. Default — read-only is always allowed when nothing above
+    # matched. The caller decides whether to surface the row.
+    return _build_decision(
+        decision=DECISION_ALLOWED_READ_ONLY,
+        risk_class=pi.risk_class if pi.risk_class != RISK_UNKNOWN else RISK_LOW,
+        reason="no high-risk gate matched; read-only surfacing allowed",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Convenience helpers for downstream modules
+# ---------------------------------------------------------------------------
+
+
+def decision_to_category(decision: str) -> str:
+    """Map a decision name to an approval-inbox category. Defaults to
+    ``tooling_requires_approval`` for unmapped decisions."""
+    return _DECISION_TO_CATEGORY.get(decision, "tooling_requires_approval")
+
+
+def is_executable_decision(decision: str) -> bool:
+    """The single canonical answer to "may this auto-execute?"."""
+    return decision == DECISION_ALLOWED_LOW_RISK_EXECUTE_SAFE
+
+
+def universal_forbidden_actions() -> tuple[str, ...]:
+    return UNIVERSAL_FORBIDDEN_AGENT_ACTIONS
+
+
+def policy_summary() -> dict[str, Any]:
+    """A read-only, deterministic summary of the policy. Suitable for
+    surfacing on status endpoints. Does not include credential-shaped
+    values."""
+    return {
+        "module_version": MODULE_VERSION,
+        "schema_version": SCHEMA_VERSION,
+        "generated_at_utc": _utcnow(),
+        "risk_classes": list(RISK_CLASSES),
+        "decisions": list(DECISIONS),
+        "approval_categories": list(APPROVAL_CATEGORIES),
+        "allowed_max_actions": list(ACTIONS),
+        "forbidden_agent_actions_universal": list(UNIVERSAL_FORBIDDEN_AGENT_ACTIONS),
+        "frozen_contracts": list(FROZEN_CONTRACTS),
+        "protected_globs_count": len(PROTECTED_GLOBS),
+        "live_globs_count": len(LIVE_PATH_GLOBS),
+        "ci_or_tests_globs_count": len(CI_OR_TESTS_GLOBS),
+        "external_secret_tokens_count": len(EXTERNAL_SECRET_TOKENS),
+        "telemetry_tokens_count": len(TELEMETRY_TOKENS),
+        "paid_tool_tokens_count": len(PAID_TOOL_TOKENS),
+        "canonical_roadmap_tokens_count": len(CANONICAL_ROADMAP_TOKENS),
+        "high_or_unknown_is_executable": False,
+        "execute_safe_requires_dependabot_low_or_medium": True,
+        "execute_safe_requires_two_layer_opt_in": True,
+    }
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+# ---------------------------------------------------------------------------
+# Credential-value redaction (mirrors the pattern in workloop_runtime
+# and recurring_maintenance — defense in depth)
+# ---------------------------------------------------------------------------
+
+
+_CREDENTIAL_FRAGMENTS: Final[tuple[str, ...]] = (
+    "sk-ant-",
+    "ghp_",
+    "github_pat_",
+    "AKIA",
+    "BEGIN PRIVATE KEY",
+)
+
+
+def assert_no_credential_values(payload: Any, *, _path: str = "$") -> None:
+    """Raise ``AssertionError`` if any string in ``payload`` looks
+    like a credential value. Path-shaped strings are explicitly
+    allowed — only the narrow credential fragments above are
+    rejected.
+
+    Mirrors ``reporting.workloop_runtime._assert_no_credential_values``.
+    """
+    if isinstance(payload, str):
+        for frag in _CREDENTIAL_FRAGMENTS:
+            if frag in payload:
+                raise AssertionError(
+                    f"credential-shaped value at {_path}: contains {frag!r}"
+                )
+        return
+    if isinstance(payload, Mapping):
+        for k, v in payload.items():
+            assert_no_credential_values(v, _path=f"{_path}.{k}")
+        return
+    if isinstance(payload, (list, tuple)):
+        for i, v in enumerate(payload):
+            assert_no_credential_values(v, _path=f"{_path}[{i}]")
+        return
+    return

--- a/reporting/execute_safe_controls.py
+++ b/reporting/execute_safe_controls.py
@@ -68,6 +68,8 @@ from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
+from reporting import approval_policy as _approval_policy
+
 REPO_ROOT: Path = Path(__file__).resolve().parent.parent
 MODULE_VERSION: str = "v3.15.15.21"
 SCHEMA_VERSION: int = 1
@@ -569,6 +571,11 @@ def collect_catalog(
         "frozen_hashes": _frozen_hashes(),
         "actions": actions,
         "counts": _counts(actions),
+        "policy": {
+            "module_version": _approval_policy.MODULE_VERSION,
+            "schema_version": _approval_policy.SCHEMA_VERSION,
+            "high_or_unknown_is_executable": False,
+        },
     }
 
 

--- a/reporting/github_pr_lifecycle.py
+++ b/reporting/github_pr_lifecycle.py
@@ -62,6 +62,8 @@ from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
+from reporting import approval_policy as _approval_policy
+
 REPO_ROOT: Path = Path(__file__).resolve().parent.parent
 MODULE_VERSION: str = "v3.15.15.17"
 SCHEMA_VERSION: int = 1
@@ -962,6 +964,12 @@ def collect_snapshot(
         "prs": [],
         "actions_taken": [],
         "final_recommendation": "needs_human",
+        "policy": {
+            "module_version": _approval_policy.MODULE_VERSION,
+            "schema_version": _approval_policy.SCHEMA_VERSION,
+            "high_or_unknown_is_executable": False,
+            "execute_safe_requires_dependabot_low_or_medium": True,
+        },
     }
 
     if provider.get("status") != "available":

--- a/reporting/proposal_queue.py
+++ b/reporting/proposal_queue.py
@@ -68,6 +68,8 @@ from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
+from reporting import approval_policy as _approval_policy
+
 REPO_ROOT: Path = Path(__file__).resolve().parent.parent
 MODULE_VERSION: str = "v3.15.15.19"
 SCHEMA_VERSION: int = 1
@@ -842,6 +844,11 @@ def collect_snapshot(
             "missing_sources": [],
             "proposals": [],
             "final_recommendation": "needs_human",
+            "policy": {
+                "module_version": _approval_policy.MODULE_VERSION,
+                "schema_version": _approval_policy.SCHEMA_VERSION,
+                "high_or_unknown_is_executable": False,
+            },
         }
 
     if proposals_override is not None:
@@ -865,6 +872,11 @@ def collect_snapshot(
         "proposals": proposals,
         "counts": counts,
         "final_recommendation": _final_recommendation(counts, proposals),
+        "policy": {
+            "module_version": _approval_policy.MODULE_VERSION,
+            "schema_version": _approval_policy.SCHEMA_VERSION,
+            "high_or_unknown_is_executable": False,
+        },
     }
 
 

--- a/reporting/recurring_maintenance.py
+++ b/reporting/recurring_maintenance.py
@@ -55,6 +55,8 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
+from reporting import approval_policy as _approval_policy
+
 REPO_ROOT: Path = Path(__file__).resolve().parent.parent
 MODULE_VERSION: str = "v3.15.15.23"
 SCHEMA_VERSION: int = 1
@@ -623,6 +625,12 @@ def collect_snapshot(
         "actions_taken": list(actions_taken or []),
         "counts": {"by_status": counts, "total": len(job_rows)},
         "final_recommendation": _final_recommendation(job_rows),
+        "policy": {
+            "module_version": _approval_policy.MODULE_VERSION,
+            "schema_version": _approval_policy.SCHEMA_VERSION,
+            "high_or_unknown_is_executable": False,
+            "execute_safe_requires_two_layer_opt_in": True,
+        },
     }
     _assert_no_credential_values(snap)
     return snap

--- a/reporting/workloop_runtime.py
+++ b/reporting/workloop_runtime.py
@@ -55,6 +55,8 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
+from reporting import approval_policy as _approval_policy
+
 # Credential-value patterns checked at the OUTER snapshot boundary.
 # We deliberately do not check sensitive-path fragments at the outer
 # layer — the snapshot legitimately includes path-shaped strings
@@ -601,6 +603,11 @@ def collect_snapshot(
         "sources": list(results),
         "counts": {"by_state": counts, "total": len(results)},
         "final_recommendation": _final_recommendation(counts, health),
+        "policy": {
+            "module_version": _approval_policy.MODULE_VERSION,
+            "schema_version": _approval_policy.SCHEMA_VERSION,
+            "high_or_unknown_is_executable": False,
+        },
     }
     # Outer defense-in-depth credential-value guard. The strict
     # path-fragment check already ran per source via _supervise; this

--- a/tests/unit/test_approval_policy.py
+++ b/tests/unit/test_approval_policy.py
@@ -1,0 +1,695 @@
+"""Unit tests for the shared HIGH-risk approval policy
+(``reporting.approval_policy``).
+
+Properties enforced:
+
+* ``UNKNOWN`` and ``HIGH`` are NEVER ``executable``.
+* Protected / frozen / live / CI / governance / secret / telemetry /
+  paid / canonical-roadmap inputs all route to a non-executable
+  decision and a sensible approval category.
+* The order of evaluation is stable and matches the docstring.
+* The output dataclass never carries credential-shaped strings.
+* Every decision in ``DECISIONS`` round-trips through
+  ``decision_to_category`` without raising.
+* Cross-module alignment: ``proposal_queue``, ``approval_inbox``,
+  ``github_pr_lifecycle``, ``execute_safe_controls``,
+  ``recurring_maintenance``, and ``workloop_runtime`` agree with the
+  policy on a representative sample of inputs.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reporting import approval_policy as ap
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+# ---------------------------------------------------------------------------
+# Pure invariants on the policy module itself
+# ---------------------------------------------------------------------------
+
+
+def test_module_version_is_v3_15_15_24() -> None:
+    assert ap.MODULE_VERSION == "v3.15.15.24"
+
+
+def test_schema_version_is_one() -> None:
+    assert ap.SCHEMA_VERSION == 1
+
+
+def test_risk_classes_are_four() -> None:
+    assert ap.RISK_CLASSES == ("LOW", "MEDIUM", "HIGH", "UNKNOWN")
+
+
+def test_decisions_enum_is_closed_and_documented() -> None:
+    expected = {
+        "allowed_read_only",
+        "allowed_low_risk_execute_safe",
+        "needs_human",
+        "blocked_high_risk",
+        "blocked_unknown",
+        "blocked_protected_path",
+        "blocked_frozen_contract",
+        "blocked_live_paper_shadow_risk",
+        "blocked_governance_change",
+        "blocked_external_secret_required",
+        "blocked_telemetry_or_data_egress",
+        "blocked_paid_tool",
+        "blocked_ci_or_test_weakening",
+        "blocked_canonical_roadmap_change",
+    }
+    assert set(ap.DECISIONS) == expected
+
+
+def test_only_one_decision_is_executable() -> None:
+    executable = [
+        d for d in ap.DECISIONS if ap.is_executable_decision(d)
+    ]
+    assert executable == ["allowed_low_risk_execute_safe"]
+
+
+def test_decision_to_category_round_trips_for_every_decision() -> None:
+    for d in ap.DECISIONS:
+        cat = ap.decision_to_category(d)
+        # All emitted categories belong to the closed approval list.
+        assert cat in ap.APPROVAL_CATEGORIES, f"decision {d!r} -> {cat!r}"
+
+
+def test_universal_forbidden_actions_includes_critical_no_touch_items() -> None:
+    fa = ap.universal_forbidden_actions()
+    for must in (
+        "edit .claude/**",
+        "edit AGENTS.md",
+        "edit CLAUDE.md",
+        "edit frozen contracts",
+        "git push --force",
+        "gh pr merge --admin",
+        "execute live broker",
+        "place real-money order",
+    ):
+        assert must in fa, f"missing forbidden action: {must!r}"
+
+
+# ---------------------------------------------------------------------------
+# decide() — order of evaluation invariants
+# ---------------------------------------------------------------------------
+
+
+def _decide(**kw: Any) -> ap.PolicyDecision:
+    return ap.decide(kw)
+
+
+def test_unknown_risk_class_is_never_executable() -> None:
+    d = _decide(risk_class="UNKNOWN")
+    assert d.decision == "blocked_unknown"
+    assert d.executable is False
+
+
+def test_high_risk_class_is_never_executable() -> None:
+    d = _decide(risk_class="HIGH", title="bump numpy major")
+    assert d.decision == "blocked_high_risk"
+    assert d.executable is False
+
+
+def test_high_with_execute_safe_request_is_still_blocked() -> None:
+    d = _decide(
+        risk_class="HIGH",
+        requested_action="execute_safe",
+        is_dependabot=True,
+        checks_state="passed",
+        mergeability_state="clean",
+    )
+    assert d.decision == "blocked_high_risk"
+    assert d.executable is False
+
+
+def test_protected_path_overrides_low_risk() -> None:
+    d = _decide(
+        risk_class="LOW",
+        affected_files=[".claude/agents/orchestrator.md"],
+    )
+    assert d.decision == "blocked_protected_path"
+    assert d.executable is False
+
+
+def test_protected_path_overrides_medium_risk() -> None:
+    d = _decide(
+        risk_class="MEDIUM",
+        affected_files=["VERSION"],
+    )
+    assert d.decision == "blocked_protected_path"
+
+
+def test_frozen_contract_overrides_low_risk_and_outranks_protected() -> None:
+    """Frozen check fires BEFORE the generic protected check, so the
+    decision is the dedicated frozen one (not protected_path)."""
+    d = _decide(
+        risk_class="LOW",
+        affected_files=[
+            "research/research_latest.json",
+            ".claude/hooks/foo.py",
+        ],
+    )
+    assert d.decision == "blocked_frozen_contract"
+
+
+def test_frozen_contract_strategy_matrix_is_blocked() -> None:
+    d = _decide(
+        risk_class="MEDIUM",
+        affected_files=["research/strategy_matrix.csv"],
+    )
+    assert d.decision == "blocked_frozen_contract"
+
+
+def test_live_path_overrides_low_risk() -> None:
+    d = _decide(
+        risk_class="LOW",
+        affected_files=["execution/live/broker_kraken.py"],
+    )
+    assert d.decision == "blocked_live_paper_shadow_risk"
+
+
+def test_paper_shadow_path_blocks() -> None:
+    d = _decide(
+        risk_class="LOW",
+        affected_files=["agent/paper/shadow_runner.py"],
+    )
+    # paper/** glob hits live globs.
+    assert d.decision == "blocked_live_paper_shadow_risk"
+
+
+def test_ci_path_overrides_low_risk() -> None:
+    d = _decide(
+        risk_class="LOW",
+        affected_files=[".github/workflows/ci.yml"],
+    )
+    assert d.decision == "blocked_ci_or_test_weakening"
+
+
+def test_governance_change_blocks() -> None:
+    d = _decide(
+        risk_class="MEDIUM",
+        title="Update CODEOWNERS",
+    )
+    assert d.decision == "blocked_governance_change"
+
+
+def test_governance_flag_alone_blocks() -> None:
+    d = _decide(risk_class="LOW", touches_governance=True)
+    assert d.decision == "blocked_governance_change"
+
+
+def test_canonical_roadmap_token_blocks() -> None:
+    d = _decide(summary="v4 roadmap supersedes v3.15", risk_class="MEDIUM")
+    assert d.decision == "blocked_canonical_roadmap_change"
+
+
+def test_canonical_roadmap_flag_alone_blocks() -> None:
+    d = _decide(risk_class="LOW", changes_canonical_roadmap=True)
+    assert d.decision == "blocked_canonical_roadmap_change"
+
+
+def test_external_account_or_secret_blocks() -> None:
+    d = _decide(
+        risk_class="MEDIUM",
+        summary="add Datadog APM with api_key auth",
+    )
+    # api_key is more specific (secret) than telemetry; the order in
+    # the policy makes secret fire first.
+    assert d.decision == "blocked_external_secret_required"
+
+
+def test_telemetry_token_blocks_when_no_secret_present() -> None:
+    d = _decide(
+        risk_class="MEDIUM",
+        summary="enable telemetry export to a third-party",
+    )
+    assert d.decision == "blocked_telemetry_or_data_egress"
+
+
+def test_paid_tool_token_blocks() -> None:
+    d = _decide(
+        risk_class="MEDIUM",
+        summary="upgrade to the paid plan for nightly storage",
+    )
+    assert d.decision == "blocked_paid_tool"
+
+
+def test_negation_disables_telemetry_token() -> None:
+    """`no telemetry` must NOT trigger the telemetry rule."""
+    d = _decide(
+        risk_class="LOW",
+        summary="dev-only tool with no telemetry",
+    )
+    assert d.decision != "blocked_telemetry_or_data_egress"
+
+
+def test_negation_disables_secret_token() -> None:
+    d = _decide(
+        risk_class="LOW",
+        summary="library that uses no api key, fully local",
+    )
+    assert d.decision != "blocked_external_secret_required"
+
+
+# ---------------------------------------------------------------------------
+# Provider / merge / checks state — UNKNOWN routing
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_provider_routes_unknown() -> None:
+    d = _decide(
+        risk_class="LOW",
+        requested_action="execute_safe",
+        provider_state="malformed",
+        is_dependabot=True,
+        checks_state="passed",
+        mergeability_state="clean",
+    )
+    assert d.decision == "blocked_unknown"
+    assert d.executable is False
+
+
+def test_pending_checks_block_execute_safe() -> None:
+    d = _decide(
+        risk_class="LOW",
+        requested_action="execute_safe",
+        is_dependabot=True,
+        checks_state="pending",
+        mergeability_state="clean",
+    )
+    assert d.decision == "blocked_unknown"
+
+
+def test_failing_checks_block_execute_safe() -> None:
+    d = _decide(
+        risk_class="LOW",
+        requested_action="execute_safe",
+        is_dependabot=True,
+        checks_state="failed",
+        mergeability_state="clean",
+    )
+    assert d.decision == "blocked_unknown"
+
+
+def test_unknown_checks_block_execute_safe() -> None:
+    d = _decide(
+        risk_class="LOW",
+        requested_action="execute_safe",
+        is_dependabot=True,
+        checks_state="unknown",
+        mergeability_state="clean",
+    )
+    assert d.decision == "blocked_unknown"
+
+
+def test_dirty_merge_blocks_execute_safe() -> None:
+    d = _decide(
+        risk_class="LOW",
+        requested_action="execute_safe",
+        is_dependabot=True,
+        checks_state="passed",
+        mergeability_state="dirty",
+    )
+    assert d.decision == "blocked_unknown"
+
+
+# ---------------------------------------------------------------------------
+# Dependabot execute-safe — the only allowed_low_risk_execute_safe path
+# ---------------------------------------------------------------------------
+
+
+def test_non_dependabot_execute_safe_routes_to_needs_human() -> None:
+    d = _decide(
+        risk_class="LOW",
+        requested_action="execute_safe",
+        is_dependabot=False,
+        pr_author="joery",
+        checks_state="passed",
+        mergeability_state="clean",
+    )
+    assert d.decision == "needs_human"
+    assert d.executable is False
+
+
+def test_dependabot_low_with_all_evidence_is_executable() -> None:
+    d = _decide(
+        risk_class="LOW",
+        requested_action="execute_safe",
+        is_dependabot=True,
+        checks_state="passed",
+        mergeability_state="clean",
+    )
+    assert d.decision == "allowed_low_risk_execute_safe"
+    assert d.executable is True
+
+
+def test_dependabot_medium_with_all_evidence_is_executable() -> None:
+    d = _decide(
+        risk_class="MEDIUM",
+        requested_action="execute_safe",
+        is_dependabot=True,
+        checks_state="passed",
+        mergeability_state="clean",
+    )
+    assert d.decision == "allowed_low_risk_execute_safe"
+    assert d.executable is True
+
+
+def test_dependabot_high_is_blocked_even_when_other_evidence_is_perfect() -> None:
+    d = _decide(
+        risk_class="HIGH",
+        requested_action="execute_safe",
+        is_dependabot=True,
+        checks_state="passed",
+        mergeability_state="clean",
+    )
+    assert d.decision == "blocked_high_risk"
+    assert d.executable is False
+
+
+# ---------------------------------------------------------------------------
+# Default / read-only path
+# ---------------------------------------------------------------------------
+
+
+def test_low_risk_no_signals_is_read_only() -> None:
+    d = _decide(risk_class="LOW", title="harmless docs change")
+    assert d.decision == "allowed_read_only"
+    assert d.executable is False
+    assert d.allowed_max_action == "read_only"
+
+
+def test_medium_risk_no_signals_is_read_only() -> None:
+    d = _decide(risk_class="MEDIUM", title="another harmless change")
+    assert d.decision == "allowed_read_only"
+    assert d.executable is False
+
+
+# ---------------------------------------------------------------------------
+# Defensive: no decision returns executable=true except the canonical one
+# ---------------------------------------------------------------------------
+
+
+def test_no_blocked_or_needs_human_ever_executable() -> None:
+    """Iterate the full enumeration and verify the invariant."""
+    for d_name in ap.DECISIONS:
+        # Skip the one positive case.
+        if d_name == "allowed_low_risk_execute_safe":
+            continue
+        # Build a synthetic decision via _build_decision-equivalent
+        # path: invoke decide() with inputs tailored to land on each
+        # decision. We only sanity-check the closed enum here.
+        assert ap.is_executable_decision(d_name) is False
+
+
+# ---------------------------------------------------------------------------
+# PolicyInput.from_mapping robustness
+# ---------------------------------------------------------------------------
+
+
+def test_from_mapping_handles_missing_fields() -> None:
+    pi = ap.PolicyInput.from_mapping({})
+    assert pi.title == ""
+    assert pi.risk_class == "UNKNOWN"
+    assert pi.affected_files == ()
+    assert pi.is_dependabot is False
+
+
+def test_from_mapping_normalises_unknown_risk_class() -> None:
+    pi = ap.PolicyInput.from_mapping({"risk_class": "WAT"})
+    assert pi.risk_class == "UNKNOWN"
+
+
+def test_from_mapping_handles_none_values() -> None:
+    pi = ap.PolicyInput.from_mapping(
+        {"title": None, "affected_files": None, "is_dependabot": None}
+    )
+    assert pi.title == ""
+    assert pi.affected_files == ()
+    assert pi.is_dependabot is False
+
+
+# ---------------------------------------------------------------------------
+# policy_summary() shape
+# ---------------------------------------------------------------------------
+
+
+def test_policy_summary_is_stable_shape() -> None:
+    s = ap.policy_summary()
+    for k in (
+        "module_version",
+        "schema_version",
+        "generated_at_utc",
+        "risk_classes",
+        "decisions",
+        "approval_categories",
+        "allowed_max_actions",
+        "forbidden_agent_actions_universal",
+        "frozen_contracts",
+        "high_or_unknown_is_executable",
+        "execute_safe_requires_dependabot_low_or_medium",
+        "execute_safe_requires_two_layer_opt_in",
+    ):
+        assert k in s, f"missing key {k!r}"
+    assert s["high_or_unknown_is_executable"] is False
+    assert s["execute_safe_requires_dependabot_low_or_medium"] is True
+    assert s["execute_safe_requires_two_layer_opt_in"] is True
+
+
+def test_policy_summary_has_no_credentials() -> None:
+    ap.assert_no_credential_values(ap.policy_summary())
+
+
+# ---------------------------------------------------------------------------
+# Credential redaction
+# ---------------------------------------------------------------------------
+
+
+def test_assert_no_credential_values_accepts_path_strings() -> None:
+    # Path-shaped strings (including config/config.yaml) are NOT
+    # credentials. The narrow guard must pass them through.
+    ap.assert_no_credential_values(
+        {"path": "config/config.yaml", "frozen": "research/research_latest.json"}
+    )
+
+
+def test_assert_no_credential_values_rejects_anthropic_key() -> None:
+    with pytest.raises(AssertionError):
+        ap.assert_no_credential_values({"leak": "sk-ant-XXXXXXXX"})
+
+
+def test_assert_no_credential_values_rejects_github_pat() -> None:
+    with pytest.raises(AssertionError):
+        ap.assert_no_credential_values(["ghp_AAAAAAA"])
+
+
+def test_assert_no_credential_values_rejects_aws_key() -> None:
+    with pytest.raises(AssertionError):
+        ap.assert_no_credential_values({"x": {"y": "AKIAEXAMPLE"}})
+
+
+def test_assert_no_credential_values_rejects_pem() -> None:
+    with pytest.raises(AssertionError):
+        ap.assert_no_credential_values("-----BEGIN PRIVATE KEY-----")
+
+
+# ---------------------------------------------------------------------------
+# Cross-module alignment — the whole point of v3.15.15.24
+# ---------------------------------------------------------------------------
+
+
+def test_proposal_queue_constants_align_with_policy() -> None:
+    """``reporting.proposal_queue`` keeps its own copy of the
+    governance lists for self-containment, but every entry must be a
+    subset of the canonical lists in approval_policy."""
+    from reporting import proposal_queue as pq
+
+    assert set(pq.FROZEN_CONTRACTS) <= set(ap.FROZEN_CONTRACTS)
+    # PROTECTED_GLOBS in proposal_queue is a subset of ap's (ap adds
+    # AGENTS.md and CLAUDE.md beyond the proposal_queue list).
+    assert set(pq.PROTECTED_GLOBS) <= set(ap.PROTECTED_GLOBS)
+
+
+def test_approval_inbox_categories_align_with_policy() -> None:
+    from reporting import approval_inbox as ai
+
+    assert set(ai.CATEGORIES) == set(ap.APPROVAL_CATEGORIES)
+
+
+def test_github_pr_lifecycle_high_pr_routes_to_high_risk() -> None:
+    """A PR classified HIGH by github_pr_lifecycle must, when fed
+    through the shared policy, land on blocked_high_risk."""
+    d = ap.decide(
+        {
+            "title": "Bump numpy from 1.24 to 2.0",
+            "risk_class": "HIGH",
+            "is_dependabot": True,
+            "pr_author": "dependabot[bot]",
+            "checks_state": "passed",
+            "mergeability_state": "clean",
+            "requested_action": "execute_safe",
+        }
+    )
+    assert d.decision == "blocked_high_risk"
+    assert d.executable is False
+
+
+def test_github_pr_lifecycle_protected_path_routes_to_protected() -> None:
+    d = ap.decide(
+        {
+            "title": "Bump foo",
+            "risk_class": "LOW",
+            "is_dependabot": True,
+            "affected_files": [".github/CODEOWNERS"],
+            "requested_action": "execute_safe",
+            "checks_state": "passed",
+            "mergeability_state": "clean",
+        }
+    )
+    assert d.decision == "blocked_protected_path"
+
+
+def test_recurring_maintenance_dependabot_job_disabled_by_default() -> None:
+    """Cross-module alignment: the dependabot execute-safe job in
+    recurring_maintenance must remain disabled by default. Without
+    that, the two-layer opt-in is meaningless."""
+    from reporting import recurring_maintenance as rm
+
+    spec = rm._JOB_REGISTRY.get(rm.JOB_DEPENDABOT_EXECUTE_SAFE)
+    assert spec is not None
+    assert spec["default_enabled"] is False
+
+
+def test_workloop_runtime_safe_to_execute_remains_false() -> None:
+    """The shared policy promises HIGH/UNKNOWN never execute. The
+    workloop runtime carries this contract via a hard-coded
+    ``safe_to_execute=false``. We verify the constant directly."""
+    from reporting import workloop_runtime as wr
+
+    src = Path(wr.__file__).read_text(encoding="utf-8")
+    assert '"safe_to_execute": False' in src
+
+
+def test_recurring_maintenance_safe_to_execute_remains_false() -> None:
+    from reporting import recurring_maintenance as rm
+
+    src = Path(rm.__file__).read_text(encoding="utf-8")
+    assert '"safe_to_execute": False' in src
+
+
+def test_execute_safe_controls_high_actions_not_in_catalog() -> None:
+    """The execute-safe controls catalog must never list a HIGH
+    action as eligible. We assert: every action the catalog declares
+    as executable has risk LOW or MEDIUM."""
+    from reporting import execute_safe_controls as esc
+
+    for action_name, risk in esc._ACTION_RISK.items():
+        assert risk in (esc.RISK_LOW, esc.RISK_MEDIUM), (
+            f"action {action_name!r} declared as {risk!r} (must be LOW or MEDIUM)"
+        )
+
+
+def test_no_module_emits_safe_to_execute_true_for_high() -> None:
+    """Repository-wide invariant: search every reporting module for a
+    line that would wire ``safe_to_execute=True`` near a HIGH
+    classification. We rely on the negative property: NO occurrence
+    of the literal substring ``"safe_to_execute": True``."""
+    bad = []
+    for mod_name in (
+        "reporting/workloop_runtime.py",
+        "reporting/recurring_maintenance.py",
+        "reporting/execute_safe_controls.py",
+        "reporting/github_pr_lifecycle.py",
+        "reporting/proposal_queue.py",
+        "reporting/approval_inbox.py",
+        "reporting/approval_policy.py",
+    ):
+        text = (REPO_ROOT / mod_name).read_text(encoding="utf-8")
+        if '"safe_to_execute": True' in text or "safe_to_execute=True" in text:
+            bad.append(mod_name)
+    assert bad == [], f"modules emit safe_to_execute=True: {bad}"
+
+
+# ---------------------------------------------------------------------------
+# Schema doc presence (machine-readable surface)
+# ---------------------------------------------------------------------------
+
+
+def test_schema_doc_exists() -> None:
+    p = REPO_ROOT / "docs" / "governance" / "high_risk_approval_policy" / "schema.v1.md"
+    assert p.exists(), f"missing schema doc: {p}"
+    text = p.read_text(encoding="utf-8")
+    assert "v3.15.15.24" in text
+
+
+def test_runbook_doc_exists() -> None:
+    p = REPO_ROOT / "docs" / "governance" / "high_risk_approval_policy.md"
+    assert p.exists(), f"missing runbook doc: {p}"
+    text = p.read_text(encoding="utf-8")
+    assert "v3.15.15.24" in text
+
+
+# ---------------------------------------------------------------------------
+# Decision payload sanity
+# ---------------------------------------------------------------------------
+
+
+def test_decision_to_dict_is_json_safe() -> None:
+    d = _decide(risk_class="LOW")
+    payload = d.to_dict()
+    json.dumps(payload)  # must serialise
+
+
+def test_every_decision_has_required_evidence_or_explicit_empty() -> None:
+    """Every decision either declares which evidence fields it
+    references, or explicitly returns empty (read-only)."""
+    samples = {
+        "blocked_protected_path": {"affected_files": [".claude/hooks/x.py"]},
+        "blocked_frozen_contract": {
+            "affected_files": ["research/research_latest.json"]
+        },
+        "blocked_live_paper_shadow_risk": {
+            "affected_files": ["execution/live/foo.py"]
+        },
+        "blocked_ci_or_test_weakening": {
+            "affected_files": [".github/workflows/ci.yml"]
+        },
+        "blocked_governance_change": {"touches_governance": True},
+        "blocked_canonical_roadmap_change": {
+            "changes_canonical_roadmap": True,
+        },
+        "blocked_external_secret_required": {"requires_secret": True},
+        "blocked_telemetry_or_data_egress": {
+            "has_telemetry_or_data_egress": True
+        },
+        "blocked_paid_tool": {"requires_paid_tool": True},
+        "blocked_high_risk": {"risk_class": "HIGH"},
+        "blocked_unknown": {"risk_class": "UNKNOWN"},
+        "needs_human": {
+            "risk_class": "LOW",
+            "requested_action": "execute_safe",
+            "is_dependabot": False,
+            "pr_author": "joery",
+            "checks_state": "passed",
+            "mergeability_state": "clean",
+        },
+        "allowed_low_risk_execute_safe": {
+            "risk_class": "LOW",
+            "requested_action": "execute_safe",
+            "is_dependabot": True,
+            "checks_state": "passed",
+            "mergeability_state": "clean",
+        },
+        "allowed_read_only": {"risk_class": "LOW"},
+    }
+    for expected, kwargs in samples.items():
+        d = ap.decide(kwargs)
+        assert d.decision == expected, f"input {kwargs!r} expected {expected!r} got {d.decision!r}"

--- a/tests/unit/test_dashboard_api_agent_control.py
+++ b/tests/unit/test_dashboard_api_agent_control.py
@@ -206,6 +206,27 @@ def test_status_payload_includes_recurring_maintenance_block(client) -> None:
         assert "reason" in rm_block
 
 
+def test_status_payload_includes_approval_policy_block(client) -> None:
+    """v3.15.15.24: status payload now also carries a read-only
+    approval_policy summary. The block must not be silently OK on
+    error — it either reports ``ok`` with a populated ``data`` dict
+    or ``not_available`` with a reason."""
+    body = client.get("/api/agent-control/status").get_json()
+    assert "approval_policy" in body
+    ap_block = body["approval_policy"]
+    assert ap_block["status"] in ("ok", "not_available")
+    if ap_block["status"] == "ok":
+        data = ap_block["data"]
+        assert data["high_or_unknown_is_executable"] is False
+        assert data["execute_safe_requires_dependabot_low_or_medium"] is True
+        assert data["execute_safe_requires_two_layer_opt_in"] is True
+        assert isinstance(data["module_version"], str)
+        assert isinstance(data["decision_count"], int)
+        assert data["decision_count"] >= 14
+    else:
+        assert "reason" in ap_block
+
+
 def test_status_payload_includes_workloop_runtime_block(client) -> None:
     """v3.15.15.22: status payload now carries a workloop_runtime
     summary. When the artifact is missing the block reports


### PR DESCRIPTION
## Summary

Adds `reporting.approval_policy` — a single shared, pure, deterministic, stdlib-only decision module that encodes ONE canonical HIGH-risk approval verdict. Every governance / lifecycle module now imports it so the duplicated risk classification logic cannot drift.

This release is **policy hardening and consistency only**. It does not add approval execution. It does not add approve/reject buttons. It does not add mutation endpoints. It does not enable any high-risk automation.

## Hard guarantees (enforced by tests)

- `UNKNOWN` never executes.
- `HIGH` never executes.
- Protected path overrides LOW/MEDIUM.
- Frozen contract change overrides LOW/MEDIUM.
- Live / paper / shadow / risk path change overrides LOW/MEDIUM.
- CI / test path change overrides LOW/MEDIUM.
- Governance change is HIGH.
- Canonical roadmap adoption is HIGH and routes to operator.
- External account / secret / OAuth / API-key / signup is HIGH.
- Telemetry / data egress is HIGH.
- Paid plan / hosted SaaS is HIGH.
- Malformed provider / pending checks / unknown mergeability route to UNKNOWN.
- Non-Dependabot execute-safe routes to `needs_human`.
- Even Dependabot LOW/MEDIUM execute-safe needs CLEAN merge AND all checks passed.
- Output never contains credential-shaped values (`sk-ant-`, `ghp_`, `github_pat_`, `AKIA`, `BEGIN PRIVATE KEY`).
- Only one decision (`allowed_low_risk_execute_safe`) ever returns `executable=true`; every other returns `executable=false`.

## Decision enum (closed, 14 entries)

allowed_read_only / allowed_low_risk_execute_safe / needs_human / blocked_high_risk / blocked_unknown / blocked_protected_path / blocked_frozen_contract / blocked_live_paper_shadow_risk / blocked_governance_change / blocked_external_secret_required / blocked_telemetry_or_data_egress / blocked_paid_tool / blocked_ci_or_test_weakening / blocked_canonical_roadmap_change.

## Cross-module alignment

- `approval_inbox`: imports `APPROVAL_CATEGORIES` from `approval_policy` so the inbox cannot drift from the canonical set.
- `proposal_queue` / `github_pr_lifecycle` / `execute_safe_controls` / `workloop_runtime` / `recurring_maintenance`: each digest now carries a top-level \`policy\` block referencing `approval_policy` module version + invariants.

## Surface (read-only projection)

- `dashboard.api_agent_control`: status payload now carries an `approval_policy` summary block (`not_available` semantics on error).
- Frontend AgentControl Status card: renders approval-policy row + policy version (read-only).
- `AgentControlStatus` TS interface extended.

## Tests added (61 new policy cases + 1 dashboard + 2 frontend polish)

- `tests/unit/test_approval_policy.py`: order-of-evaluation, HIGH/UNKNOWN never executable, protected/frozen/live/CI overrides, governance/canonical/secret/telemetry/paid blocking, negation scrubbing, dependabot two-layer alignment, malformed/pending/failed/unknown checks, default read-only, cross-module alignment with proposal_queue / approval_inbox / github_pr_lifecycle / execute_safe_controls / workloop_runtime / recurring_maintenance, schema doc + runbook presence, credential redaction.
- `tests/unit/test_dashboard_api_agent_control.py`: +1 approval_policy status block case.
- Frontend `AgentControlPolish.test.tsx`: +2 policy row cases.

## Validation gates green

- governance_lint OK (15 agents, 3 workflows checked).
- \`pytest tests/smoke\`: 14/14.
- \`pytest\` targeted unit suite (8 modules): 315/315.
- frontend vitest: 60/60 across 8 files.
- frontend build: green.
- frozen contract sha256 unchanged.

## Non-goals (explicitly out of scope)

- No approve/reject/ack/resolved state mutation.
- No POST/PUT/PATCH/DELETE API.
- No browser push.
- No new execute buttons.
- No wiring of api_execute_safe_controls.
- No \`dashboard/dashboard.py\` changes.
- No \`.claude/**\` changes.
- No frozen contract changes.
- No live/paper/shadow/trading/risk behavior changes.
- No CI/test weakening.
- No new paid/external telemetry/signup/secrets.
- No arbitrary command runner.
- No high-risk automerge.
- Dependabot execute-safe remains disabled by default.

## Test plan

- [ ] CI gates green (governance lint, smoke, unit, frontend, governance smoke)
- [ ] Frozen-contract hashes unchanged on main
- [ ] Read-only PWA renders new approval_policy row + version
- [ ] No mutation endpoints introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)