### PR TITLE
feat(v3.15.15.25): autonomy throughput / observability metrics

### DIFF
--- a/dashboard/api_agent_control.py
+++ b/dashboard/api_agent_control.py
@@ -184,7 +184,82 @@ def _status_payload() -> dict[str, Any]:
         "workloop_runtime": _workloop_runtime_summary(),
         "recurring_maintenance": _recurring_maintenance_summary(),
         "approval_policy": _approval_policy_summary(),
+        "autonomy_metrics": _autonomy_metrics_summary(),
     }
+
+
+def _autonomy_metrics_summary() -> dict[str, Any]:
+    """Project the v3.15.15.25 autonomy metrics digest into a
+    compact, read-only summary for the Status card. Returns
+    ``not_available`` on a missing / malformed artifact — never
+    raises.
+
+    The summary surfaces top-level totals + final_recommendation +
+    safety summary. The full artifact is at
+    ``logs/autonomy_metrics/latest.json``.
+    """
+    try:
+        from reporting.autonomy_metrics import read_latest_snapshot
+
+        snap = read_latest_snapshot()
+        if snap is None:
+            return {"status": "not_available", "reason": "missing"}
+        throughput = snap.get("throughput") or {}
+        burden = snap.get("operator_burden") or {}
+        reliability = snap.get("reliability") or {}
+        safety = snap.get("safety") or {}
+        return {
+            "status": "ok",
+            "data": {
+                "module_version": snap.get("module_version"),
+                "metrics_version": snap.get("metrics_version"),
+                "generated_at_utc": snap.get("generated_at_utc"),
+                "final_recommendation": snap.get("final_recommendation"),
+                "safe_to_execute": snap.get("safe_to_execute", False),
+                "throughput_summary": {
+                    "proposals_total": throughput.get("proposals_total", 0),
+                    "inbox_items_total": throughput.get("inbox_items_total", 0),
+                    "pr_lifecycle_prs_seen": throughput.get(
+                        "pr_lifecycle_prs_seen", 0
+                    ),
+                    "recurring_jobs_total": throughput.get(
+                        "recurring_jobs_total", 0
+                    ),
+                    "runtime_sources_total": throughput.get(
+                        "runtime_sources_total", 0
+                    ),
+                },
+                "operator_burden_summary": {
+                    "needs_human_total": burden.get("needs_human_total", 0),
+                    "blocked_total": burden.get("blocked_total", 0),
+                    "estimated_operator_actions_total": burden.get(
+                        "estimated_operator_actions_total", 0
+                    ),
+                },
+                "reliability_summary": {
+                    "runtime_consecutive_failures": reliability.get(
+                        "runtime_consecutive_failures", 0
+                    ),
+                    "missing_artifact_count": reliability.get(
+                        "missing_artifact_count", 0
+                    ),
+                    "malformed_artifact_count": reliability.get(
+                        "malformed_artifact_count", 0
+                    ),
+                },
+                "safety_summary": {
+                    "high_or_unknown_executable_count": safety.get(
+                        "high_or_unknown_executable_count", 0
+                    ),
+                    "summary": safety.get("summary", "unknown"),
+                },
+            },
+        }
+    except Exception as e:  # noqa: BLE001
+        return {
+            "status": "not_available",
+            "reason": f"autonomy_metrics_error: {type(e).__name__}",
+        }
 
 
 def _approval_policy_summary() -> dict[str, Any]:

--- a/docs/governance/autonomy_metrics.md
+++ b/docs/governance/autonomy_metrics.md
@@ -1,0 +1,178 @@
+# Autonomy metrics — operator runbook
+
+Module: `reporting.autonomy_metrics`
+Version: v3.15.15.25
+Schema: `docs/governance/autonomy_metrics/schema.v1.md`
+
+## TL;DR
+
+Read-only digest that aggregates the JSON artifacts produced by
+the existing reporting modules into one snapshot. The digest
+answers the questions: how much work is the system doing, how
+much still needs Joery, where are blockers accumulating, are the
+autonomous jobs reliable, and is anything unsafe leaking through
+the safety net.
+
+The collector does not expand any execution authority. It does
+not add buttons, mutation endpoints, browser push, scheduling, or
+new automation. It reads and projects.
+
+## Hard guarantees
+
+* Stdlib-only. No subprocess, no `gh`, no `git`, no network.
+* Output limited to `logs/autonomy_metrics/`.
+* Atomic writes (tmp + os.replace), history is append-only.
+* Narrow credential-value redaction.
+* Missing / malformed artifacts are COUNTED, not coerced to ok.
+* Deterministic for a fixed set of input artifacts.
+* `safety.high_or_unknown_executable_count` is expected to be 0.
+  A non-zero value flips `final_recommendation` to
+  `unsafe_state_detected`.
+
+## Source artifacts
+
+| source                    | path                                          |
+| ------------------------- | --------------------------------------------- |
+| workloop_runtime          | `logs/workloop_runtime/latest.json`           |
+| recurring_maintenance     | `logs/recurring_maintenance/latest.json`      |
+| proposal_queue            | `logs/proposal_queue/latest.json`             |
+| approval_inbox            | `logs/approval_inbox/latest.json`             |
+| github_pr_lifecycle       | `logs/github_pr_lifecycle/latest.json`        |
+| execute_safe_controls     | `logs/execute_safe_controls/latest.json`      |
+
+History (best-effort) for trend windows:
+
+* `logs/workloop_runtime/history.jsonl`
+* `logs/recurring_maintenance/history.jsonl`
+
+A missing history is reported as
+`{ "status": "not_available", "reason": "no_history" }` — never
+guessed.
+
+## Metric meanings (which are actionable)
+
+### Throughput (informational)
+`proposals_total`, `inbox_items_total`, `pr_lifecycle_*`,
+`recurring_jobs_*`, `runtime_sources_*`,
+`execute_safe_actions_total`. Use these to track whether the
+autonomous loop is processing work, not as alarm signals.
+
+### Operator burden (actionable)
+`needs_human_total` and `estimated_operator_actions_total` are
+the primary "go look at the inbox" signal. If these grow over
+time without corresponding throughput, the system is queuing up
+work the operator has not cleared.
+
+`high_risk_blocked_total` and `unknown_state_total` should both
+trend toward zero — non-zero values mean an upstream module
+classified something HIGH or UNKNOWN and is waiting for review.
+
+`top_operator_action_categories` is the focus list — the five
+inbox categories with the most rows.
+
+### Reliability (actionable)
+`runtime_consecutive_failures` ≥ 3 → workloop runtime is in a
+soft halt. Inspect `last_failure_at_utc` and the workloop runtime
+artifact for the failing source.
+
+`recurring_consecutive_failures_max` reports the worst per-job
+consecutive failure count. Same threshold as runtime.
+
+`source_failure_rate` and `job_failure_rate` are 0..1 fractions
+over the most recent observed run.
+
+`missing_artifact_count` and `malformed_artifact_count` count
+upstream artifacts that did not parse cleanly. Both ≥ 1 is a
+sign the loop is running but producing bad output.
+
+### Safety (actionable; must remain zero)
+`high_or_unknown_executable_count` MUST be 0. A non-zero value
+means the cross-check between approval_policy and
+execute_safe_controls broke — investigate immediately.
+
+The `*_risk_count` metrics surface the per-category counts of
+inbox rows that the operator has not yet cleared. They are
+expected to be small but non-zero is normal.
+
+## Interpreting `final_recommendation`
+
+| value                       | meaning                                                          |
+| --------------------------- | ---------------------------------------------------------------- |
+| `healthy`                   | no missing/malformed sources, no operator burden, no unsafe state |
+| `action_required`           | operator has rows to clear but the system is otherwise fine      |
+| `degraded_missing_sources`  | ≥ 2 source artifacts are missing                                 |
+| `degraded_failures`         | malformed source(s) or runtime consecutive_failures ≥ 3          |
+| `unsafe_state_detected`     | `high_or_unknown_executable_count > 0` — STOP                    |
+| `not_available`             | no source artifacts present at all                               |
+
+## What should trigger human attention
+
+* `final_recommendation == unsafe_state_detected` — page Joery.
+* `runtime_consecutive_failures >= 3`.
+* `recurring_consecutive_failures_max >= 3`.
+* `high_or_unknown_executable_count != 0`.
+* `frozen_contract_risk_count != 0`.
+* `live_paper_shadow_risk_count != 0`.
+* `secret_or_external_account_required_count != 0`.
+* `paid_tool_required_count != 0`.
+
+## Metrics that MUST remain zero
+
+* `safety.high_or_unknown_executable_count`.
+* All `safety.*_risk_count` metrics over a long enough horizon
+  (transients during operator review are expected).
+* `policy.high_or_unknown_is_executable` is False by construction;
+  if the projection ever flips to True, the safety contract
+  broke.
+
+## CLI
+
+```
+python -m reporting.autonomy_metrics --collect
+python -m reporting.autonomy_metrics --collect --no-write
+python -m reporting.autonomy_metrics --collect --frozen-utc 2026-05-03T12:00:00Z
+python -m reporting.autonomy_metrics --status
+```
+
+`--collect` reads the source artifacts and writes a digest.
+`--status` prints the latest digest from
+`logs/autonomy_metrics/latest.json`.
+
+`--no-write` is for dry-run / CI.
+
+`--frozen-utc` pins `generated_at_utc` for deterministic tests.
+
+## Known limitations
+
+* No clock-aware liveness check on `latest.json` itself; if
+  upstream reporters stop running, the digest reports the same
+  numbers indefinitely. The freshness signal lives on
+  `last_success_at_utc` / `last_failure_at_utc` which come from
+  the workloop runtime and not from this module.
+* `high_or_unknown_executable_count` is computed from the
+  `execute_safe_controls` action list; if that artifact is
+  missing the count is 0 (accurate, not safe-by-default — the
+  overall state is still flagged via `not_available`).
+* History is best-effort: lines that fail to parse are skipped,
+  not counted as malformed (the freshness comes from the
+  per-line `generated_at_utc` rather than schema validity).
+
+## Cross-references
+
+* Schema: `docs/governance/autonomy_metrics/schema.v1.md`
+* Workloop runtime: `docs/governance/workloop_runtime.md`
+* Recurring maintenance: `docs/governance/recurring_maintenance.md`
+* High-risk approval policy:
+  `docs/governance/high_risk_approval_policy.md`
+* Approval inbox: `docs/governance/approval_inbox.md`
+* Proposal queue: `docs/governance/proposal_queue.md`
+* GitHub PR lifecycle: `docs/governance/github_pr_lifecycle.md`
+* Mobile Agent Control PWA:
+  `docs/governance/agent_control_pwa.md`
+
+## Governance footnote
+
+The autonomy metrics module is read-only. The PWA Status card
+surfaces a compact projection but never offers a button. To
+materially change the metrics shape, open a human-authored PR
+that updates schema.v1.md and adds a metrics_version bump.

--- a/docs/governance/autonomy_metrics/schema.v1.md
+++ b/docs/governance/autonomy_metrics/schema.v1.md
@@ -1,0 +1,204 @@
+# Autonomy metrics — schema v1
+
+Module: `reporting.autonomy_metrics` (v3.15.15.25)
+Schema version: `1`
+Metrics version: `v1`
+Stability: stable; additions are SemVer minor, removals are
+breaking.
+
+This is the machine-readable description of the autonomy
+throughput / observability metrics digest. The collector reads
+the existing JSON artifacts from sibling reporting modules and
+projects them into a single deterministic snapshot.
+
+## Top-level shape
+
+```json
+{
+  "schema_version": 1,
+  "report_kind": "autonomy_metrics_digest",
+  "module_version": "v3.15.15.25",
+  "metrics_version": "v1",
+  "generated_at_utc": "2026-05-03T08:00:00Z",
+  "source_statuses": [...],
+  "throughput": {...},
+  "operator_burden": {...},
+  "reliability": {...},
+  "safety": {...},
+  "trends": {...},
+  "policy": {
+    "module_version": "v3.15.15.24",
+    "schema_version": 1,
+    "high_or_unknown_is_executable": false
+  },
+  "final_recommendation": "healthy",
+  "safe_to_execute": false
+}
+```
+
+## source_statuses
+
+A deterministic ordered list of source-state records:
+
+```json
+{
+  "source": "workloop_runtime",
+  "artifact_path": "logs/workloop_runtime/latest.json",
+  "state": "ok | missing | malformed | unreadable | not_an_object",
+  "reason": "missing | malformed: <ErrorClass> | ..."
+}
+```
+
+Source order:
+
+1. `workloop_runtime`
+2. `recurring_maintenance`
+3. `proposal_queue`
+4. `approval_inbox`
+5. `github_pr_lifecycle`
+6. `execute_safe_controls`
+
+## throughput
+
+```
+proposals_total: int
+proposals_by_status: { proposed|needs_human|blocked|approved|...: int }
+proposals_by_risk: { LOW|MEDIUM|HIGH|UNKNOWN: int }
+proposals_by_type: { tooling_intake|...: int }
+inbox_items_total: int
+inbox_items_by_category: { high_risk_pr|...: int }
+inbox_items_by_severity: { info|low|medium|high|critical: int }
+pr_lifecycle_prs_seen: int
+pr_lifecycle_merge_allowed: int
+pr_lifecycle_blocked: int
+pr_lifecycle_needs_human: int
+pr_lifecycle_wait_for_rebase: int
+pr_lifecycle_wait_for_checks: int
+recurring_jobs_total: int
+recurring_jobs_succeeded: int
+recurring_jobs_blocked: int
+recurring_jobs_failed: int
+recurring_jobs_skipped: int
+recurring_jobs_timeout: int
+recurring_jobs_not_run: int
+runtime_sources_total: int
+runtime_sources_ok: int
+runtime_sources_degraded: int
+runtime_sources_failed: int
+execute_safe_actions_total: int
+execute_safe_by_eligibility: { eligible|ineligible|blocked|unknown: int }
+execute_safe_by_risk_class: { LOW|MEDIUM|HIGH|UNKNOWN: int }
+```
+
+## operator_burden
+
+```
+needs_human_total: int
+blocked_total: int
+approval_required_total: int
+manual_route_wiring_required_total: int
+high_risk_blocked_total: int
+unknown_state_total: int
+estimated_operator_actions_total: int
+top_operator_action_categories: [{ category: str, count: int }]
+by_severity: { info|low|medium|high|critical: int }
+```
+
+## reliability
+
+```
+runtime_consecutive_failures: int
+recurring_consecutive_failures_max: int
+source_failure_rate: float (0.0..1.0)
+job_failure_rate: float (0.0..1.0)
+stale_artifact_count: int
+malformed_artifact_count: int
+missing_artifact_count: int
+last_success_at_utc: str | null
+last_failure_at_utc: str | null
+```
+
+## safety
+
+```
+high_or_unknown_executable_count: int     # invariant: 0
+frozen_contract_risk_count: int
+protected_path_risk_count: int
+live_paper_shadow_risk_count: int
+ci_or_test_weakening_risk_count: int
+secret_or_external_account_required_count: int
+telemetry_or_data_egress_count: int
+paid_tool_required_count: int
+high_risk_proposal_count: int
+unknown_risk_proposal_count: int
+execute_safe_eligible_count: int
+execute_safe_blocked_count: int
+execute_safe_high_count: int
+policy_version: str   # e.g. "v3.15.15.24"
+summary: "ok" | "unsafe_state_detected"
+```
+
+`high_or_unknown_executable_count` MUST always be 0. A non-zero
+value flips `final_recommendation` to `unsafe_state_detected`.
+
+## trends
+
+```
+current: { runtime: <agg>, recurring: <agg> }
+last_24h: { runtime: <agg>, recurring: <agg> }
+last_7d: { runtime: <agg>, recurring: <agg> }
+all_time_from_available_history: { runtime: <agg>, recurring: <agg> }
+```
+
+Each `<agg>` is one of:
+
+```
+{ "status": "not_available", "reason": "no_history" }
+```
+
+or
+
+```
+{
+  "status": "ok",
+  "total_runs": int,
+  "succeeded_runs": int,
+  "failed_runs": int,
+  "degraded_runs": int,
+  "consecutive_failures_max": int
+}
+```
+
+## final_recommendation enum
+
+```
+healthy
+degraded_missing_sources
+degraded_failures
+action_required
+unsafe_state_detected
+not_available
+```
+
+Order of evaluation (first match wins):
+
+1. `safety.high_or_unknown_executable_count > 0` → `unsafe_state_detected`
+2. all sources missing/not_an_object → `not_available`
+3. `reliability.missing_artifact_count >= 2` → `degraded_missing_sources`
+4. `reliability.malformed_artifact_count > 0` → `degraded_failures`
+5. `reliability.runtime_consecutive_failures >= 3` → `degraded_failures`
+6. `operator_burden.estimated_operator_actions_total > 0` → `action_required`
+7. else → `healthy`
+
+## Determinism
+
+* All counter dicts emit keys in alphabetical order.
+* `top_operator_action_categories` is sorted by count desc, then
+  alphabetical, capped at 5.
+* `generated_at_utc` is the only clock-derived field. It can be
+  pinned via `--frozen-utc` for deterministic tests.
+
+## Atomic writes
+
+Snapshot is written via tmp + os.replace. History is append-only.
+Latest is byte-identical to the timestamped copy of the same run.

--- a/frontend/src/api/agent_control.ts
+++ b/frontend/src/api/agent_control.ts
@@ -73,6 +73,38 @@ export interface AgentControlStatus {
       execute_safe_requires_two_layer_opt_in?: boolean;
     };
   };
+  autonomy_metrics?: {
+    status: "ok" | "not_available";
+    reason?: string;
+    data?: {
+      module_version?: string;
+      metrics_version?: string;
+      generated_at_utc?: string;
+      final_recommendation?: string;
+      safe_to_execute?: boolean;
+      throughput_summary?: {
+        proposals_total?: number;
+        inbox_items_total?: number;
+        pr_lifecycle_prs_seen?: number;
+        recurring_jobs_total?: number;
+        runtime_sources_total?: number;
+      };
+      operator_burden_summary?: {
+        needs_human_total?: number;
+        blocked_total?: number;
+        estimated_operator_actions_total?: number;
+      };
+      reliability_summary?: {
+        runtime_consecutive_failures?: number;
+        missing_artifact_count?: number;
+        malformed_artifact_count?: number;
+      };
+      safety_summary?: {
+        high_or_unknown_executable_count?: number;
+        summary?: string;
+      };
+    };
+  };
 }
 
 export interface AgentControlActivity {

--- a/frontend/src/routes/AgentControl.tsx
+++ b/frontend/src/routes/AgentControl.tsx
@@ -147,6 +147,31 @@ function StatusCard({ payload }: { payload: AgentControlStatus | null }) {
           policyData?.execute_safe_requires_two_layer_opt_in === true
         ? "ok"
         : "warn";
+
+  const metrics = payload.autonomy_metrics;
+  const metricsStatus = metrics?.status ?? "not_available";
+  const metricsData =
+    metrics?.status === "ok" ? metrics.data : undefined;
+  const metricsRecommendation = String(
+    metricsData?.final_recommendation ?? "n/a",
+  );
+  const metricsPill: "ok" | "warn" | "danger" | "unknown" =
+    metricsStatus !== "ok"
+      ? "unknown"
+      : metricsRecommendation === "unsafe_state_detected"
+        ? "danger"
+        : metricsRecommendation === "healthy"
+          ? "ok"
+          : metricsRecommendation === "action_required"
+            ? "warn"
+            : metricsRecommendation.startsWith("degraded")
+              ? "warn"
+              : metricsRecommendation === "not_available"
+                ? "unknown"
+                : "unknown";
+  const operatorActions = String(
+    metricsData?.operator_burden_summary?.estimated_operator_actions_total ?? 0,
+  );
   return (
     <Card title="Status" subtitle="governance + frozen + runtime">
       <div className="agent-control-card__row">
@@ -211,6 +236,33 @@ function StatusCard({ payload }: { payload: AgentControlStatus | null }) {
           <dt>policy version</dt>
           <dd>{policyVersion}</dd>
         </div>
+      ) : null}
+      <div
+        className="agent-control-card__row"
+        data-testid="status-metrics-row"
+      >
+        <dt>autonomy metrics</dt>
+        <dd>
+          <StatusPill state={metricsPill} />
+        </dd>
+      </div>
+      {metricsStatus === "ok" && metricsData ? (
+        <>
+          <div
+            className="agent-control-card__row"
+            data-testid="status-metrics-recommendation"
+          >
+            <dt>metrics rec.</dt>
+            <dd>{metricsRecommendation}</dd>
+          </div>
+          <div
+            className="agent-control-card__row"
+            data-testid="status-metrics-operator-actions"
+          >
+            <dt>operator actions</dt>
+            <dd>{operatorActions}</dd>
+          </div>
+        </>
       ) : null}
       {Object.keys(fh).length === 0 ? (
         <p

--- a/frontend/src/test/AgentControl.test.tsx
+++ b/frontend/src/test/AgentControl.test.tsx
@@ -81,6 +81,37 @@ const okStatusBody = {
       execute_safe_requires_two_layer_opt_in: true,
     },
   },
+  autonomy_metrics: {
+    status: "ok",
+    data: {
+      module_version: "v3.15.15.25",
+      metrics_version: "v1",
+      generated_at_utc: "2026-05-03T08:00:00Z",
+      final_recommendation: "healthy",
+      safe_to_execute: false,
+      throughput_summary: {
+        proposals_total: 0,
+        inbox_items_total: 0,
+        pr_lifecycle_prs_seen: 0,
+        recurring_jobs_total: 0,
+        runtime_sources_total: 0,
+      },
+      operator_burden_summary: {
+        needs_human_total: 0,
+        blocked_total: 0,
+        estimated_operator_actions_total: 0,
+      },
+      reliability_summary: {
+        runtime_consecutive_failures: 0,
+        missing_artifact_count: 0,
+        malformed_artifact_count: 0,
+      },
+      safety_summary: {
+        high_or_unknown_executable_count: 0,
+        summary: "ok",
+      },
+    },
+  },
 };
 
 const okActivityBody = {

--- a/frontend/src/test/AgentControlPolish.test.tsx
+++ b/frontend/src/test/AgentControlPolish.test.tsx
@@ -82,6 +82,37 @@ const okStatusBody = {
       execute_safe_requires_two_layer_opt_in: true,
     },
   },
+  autonomy_metrics: {
+    status: "ok",
+    data: {
+      module_version: "v3.15.15.25",
+      metrics_version: "v1",
+      generated_at_utc: "2026-05-03T08:00:00Z",
+      final_recommendation: "healthy",
+      safe_to_execute: false,
+      throughput_summary: {
+        proposals_total: 0,
+        inbox_items_total: 0,
+        pr_lifecycle_prs_seen: 0,
+        recurring_jobs_total: 0,
+        runtime_sources_total: 0,
+      },
+      operator_burden_summary: {
+        needs_human_total: 0,
+        blocked_total: 0,
+        estimated_operator_actions_total: 0,
+      },
+      reliability_summary: {
+        runtime_consecutive_failures: 0,
+        missing_artifact_count: 0,
+        malformed_artifact_count: 0,
+      },
+      safety_summary: {
+        high_or_unknown_executable_count: 0,
+        summary: "ok",
+      },
+    },
+  },
 };
 
 const okActivityBody = {
@@ -482,6 +513,46 @@ describe("AgentControl polish — Status card approval-policy row (v3.15.15.24)"
     expect(row).toBeInTheDocument();
     expect(
       screen.queryByTestId("status-policy-version"),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("AgentControl polish — Status card autonomy-metrics row (v3.15.15.25)", () => {
+  it("renders the autonomy_metrics row when the status payload provides it", async () => {
+    installFetchMock(_allOk());
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+    const row = await screen.findByTestId("status-metrics-row");
+    expect(row).toBeInTheDocument();
+    const rec = await screen.findByTestId("status-metrics-recommendation");
+    expect(rec).toHaveTextContent("healthy");
+    const ops = await screen.findByTestId("status-metrics-operator-actions");
+    expect(ops).toHaveTextContent("0");
+  });
+
+  it("renders metrics row as unknown when status payload omits autonomy_metrics", async () => {
+    const statusBodyNoMetrics = {
+      kind: "agent_control_status",
+      schema_version: 1,
+      governance_status: { status: "ok", data: {} },
+      frozen_hashes: okFrozenHashes,
+    };
+    installFetchMock({
+      ..._allOk(),
+      "/api/agent-control/status": () => jsonResp(statusBodyNoMetrics),
+    });
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+    const row = await screen.findByTestId("status-metrics-row");
+    expect(row).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("status-metrics-recommendation"),
     ).not.toBeInTheDocument();
   });
 });

--- a/reporting/autonomy_metrics.py
+++ b/reporting/autonomy_metrics.py
@@ -1,0 +1,987 @@
+"""Autonomy throughput / observability metrics (v3.15.15.25).
+
+A deterministic, stdlib-only metrics collector that aggregates
+the JSON artifacts produced by the existing reporting modules
+(workloop_runtime, recurring_maintenance, proposal_queue,
+approval_inbox, github_pr_lifecycle, execute_safe_controls,
+agent_audit_summary) into a single read-only digest. The digest
+answers the operator-burden / reliability / safety / throughput
+questions enumerated in the v3.15.15.25 brief without expanding
+any execution authority.
+
+Hard guarantees
+---------------
+
+* Stdlib-only. No subprocess, no ``gh``, no ``git``, no network.
+* The collector NEVER writes to ``research/``, ``.claude/``,
+  ``automation/``, ``execution/``, or any other governance-protected
+  path. Output is limited to ``logs/autonomy_metrics/``.
+* Writes are atomic (``tmp`` + ``os.replace``) and history is
+  append-only.
+* Output is run through narrow credential-value redaction
+  (``sk-ant-`` / ``ghp_`` / ``github_pat_`` / ``AKIA`` /
+  ``BEGIN PRIVATE KEY``); path-shaped strings are explicitly
+  preserved so the operator can still see *what* the source was.
+* Missing / malformed artifacts are COUNTED and reported under
+  ``source_statuses`` — never silently coerced to "ok".
+* The output is deterministic given a fixed set of input
+  artifacts. There is no clock-derived field beyond the
+  top-level ``generated_at_utc`` which the caller may pin via
+  ``--frozen-utc`` for testing.
+* ``high_or_unknown_executable_count`` is expected to be
+  zero. A non-zero value flips ``final_recommendation`` to
+  ``unsafe_state_detected``.
+
+CLI
+---
+
+::
+
+    python -m reporting.autonomy_metrics --collect
+    python -m reporting.autonomy_metrics --status
+    python -m reporting.autonomy_metrics --no-write
+
+Stdlib-only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import hashlib
+import json
+import os
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from reporting import approval_policy as _approval_policy
+
+REPO_ROOT: Path = Path(__file__).resolve().parent.parent
+MODULE_VERSION: str = "v3.15.15.25"
+METRICS_VERSION: str = "v1"
+SCHEMA_VERSION: int = 1
+
+DIGEST_DIR_JSON: Path = REPO_ROOT / "logs" / "autonomy_metrics"
+
+
+# ---------------------------------------------------------------------------
+# Source artifact paths — kept narrow on purpose.
+# ---------------------------------------------------------------------------
+
+
+SOURCE_WORKLOOP_RUNTIME: Path = REPO_ROOT / "logs" / "workloop_runtime" / "latest.json"
+SOURCE_WORKLOOP_RUNTIME_HISTORY: Path = (
+    REPO_ROOT / "logs" / "workloop_runtime" / "history.jsonl"
+)
+SOURCE_RECURRING_MAINTENANCE: Path = (
+    REPO_ROOT / "logs" / "recurring_maintenance" / "latest.json"
+)
+SOURCE_RECURRING_MAINTENANCE_HISTORY: Path = (
+    REPO_ROOT / "logs" / "recurring_maintenance" / "history.jsonl"
+)
+SOURCE_PROPOSAL_QUEUE: Path = REPO_ROOT / "logs" / "proposal_queue" / "latest.json"
+SOURCE_APPROVAL_INBOX: Path = REPO_ROOT / "logs" / "approval_inbox" / "latest.json"
+SOURCE_PR_LIFECYCLE: Path = REPO_ROOT / "logs" / "github_pr_lifecycle" / "latest.json"
+SOURCE_EXECUTE_SAFE_CONTROLS: Path = (
+    REPO_ROOT / "logs" / "execute_safe_controls" / "latest.json"
+)
+
+
+# Source ordering controls determinism in the digest.
+SOURCE_ORDER: tuple[tuple[str, str], ...] = (
+    ("workloop_runtime", "logs/workloop_runtime/latest.json"),
+    ("recurring_maintenance", "logs/recurring_maintenance/latest.json"),
+    ("proposal_queue", "logs/proposal_queue/latest.json"),
+    ("approval_inbox", "logs/approval_inbox/latest.json"),
+    ("github_pr_lifecycle", "logs/github_pr_lifecycle/latest.json"),
+    ("execute_safe_controls", "logs/execute_safe_controls/latest.json"),
+)
+
+
+# Source status enum.
+STATE_OK: str = "ok"
+STATE_MISSING: str = "missing"
+STATE_MALFORMED: str = "malformed"
+STATE_UNREADABLE: str = "unreadable"
+STATE_NOT_AN_OBJECT: str = "not_an_object"
+
+SOURCE_STATES: tuple[str, ...] = (
+    STATE_OK,
+    STATE_MISSING,
+    STATE_MALFORMED,
+    STATE_UNREADABLE,
+    STATE_NOT_AN_OBJECT,
+)
+
+
+# Final recommendation enum.
+REC_HEALTHY: str = "healthy"
+REC_DEGRADED_MISSING: str = "degraded_missing_sources"
+REC_DEGRADED_FAILURES: str = "degraded_failures"
+REC_ACTION_REQUIRED: str = "action_required"
+REC_UNSAFE: str = "unsafe_state_detected"
+REC_NOT_AVAILABLE: str = "not_available"
+
+FINAL_RECOMMENDATIONS: tuple[str, ...] = (
+    REC_HEALTHY,
+    REC_DEGRADED_MISSING,
+    REC_DEGRADED_FAILURES,
+    REC_ACTION_REQUIRED,
+    REC_UNSAFE,
+    REC_NOT_AVAILABLE,
+)
+
+
+# Trend window labels.
+TREND_LAST_24H: str = "last_24h"
+TREND_LAST_7D: str = "last_7d"
+TREND_ALL_TIME: str = "all_time_from_available_history"
+
+
+# ---------------------------------------------------------------------------
+# Time + path helpers
+# ---------------------------------------------------------------------------
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _utcnow_dt() -> _dt.datetime:
+    return _dt.datetime.now(_dt.UTC).replace(microsecond=0)
+
+
+def _rel(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(REPO_ROOT.resolve())).replace("\\", "/")
+    except ValueError:
+        return str(path).replace("\\", "/")
+
+
+def _file_sha256(path: Path) -> str:
+    if not path.exists():
+        return "missing"
+    h = hashlib.sha256()
+    try:
+        with path.open("rb") as f:
+            for chunk in iter(lambda: f.read(8192), b""):
+                h.update(chunk)
+    except OSError:
+        return "missing"
+    return h.hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Source readers — never raise; missing / malformed → status entry
+# ---------------------------------------------------------------------------
+
+
+def _read_json_artifact(path: Path) -> dict[str, Any]:
+    """Return a status envelope ``{state, reason, data}``. Always
+    returns a dict; never raises."""
+    if not path.exists():
+        return {
+            "state": STATE_MISSING,
+            "reason": "missing",
+            "data": None,
+        }
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as e:
+        return {
+            "state": STATE_UNREADABLE,
+            "reason": f"unreadable: {type(e).__name__}",
+            "data": None,
+        }
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as e:
+        return {
+            "state": STATE_MALFORMED,
+            "reason": f"malformed: {type(e).__name__}",
+            "data": None,
+        }
+    if not isinstance(data, dict):
+        return {
+            "state": STATE_NOT_AN_OBJECT,
+            "reason": "malformed: not_an_object",
+            "data": None,
+        }
+    return {"state": STATE_OK, "reason": None, "data": data}
+
+
+def _read_jsonl_history(path: Path, *, max_records: int = 5000) -> list[dict[str, Any]]:
+    """Read a ``history.jsonl`` file best-effort. Lines that fail to
+    parse are skipped silently — the history is informational only.
+    Returns at most ``max_records`` parsed dict rows from the END
+    (the most recent rows). Never raises."""
+    if not path.exists() or not path.is_file():
+        return []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    lines = text.splitlines()
+    out: list[dict[str, Any]] = []
+    for line in lines[-max_records:]:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(row, dict):
+            out.append(row)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Throughput / burden / reliability / safety counters
+# ---------------------------------------------------------------------------
+
+
+def _count_proposals(env: dict[str, Any]) -> dict[str, Any]:
+    """Project the proposal_queue digest into throughput counters.
+
+    Falls back to zeroes when the source is not available, but
+    surfaces ``available=False`` so the operator can distinguish
+    "no proposals" from "no source".
+    """
+    if env["state"] != STATE_OK or not env.get("data"):
+        return {
+            "available": False,
+            "proposals_total": 0,
+            "by_status": {},
+            "by_risk": {},
+            "by_type": {},
+        }
+    data = env["data"]
+    counts = data.get("counts") if isinstance(data, dict) else None
+    counts = counts if isinstance(counts, dict) else {}
+    by_status = counts.get("by_status") or {}
+    by_risk = counts.get("by_risk") or {}
+    by_type = counts.get("by_type") or {}
+    total = counts.get("total")
+    if not isinstance(total, int):
+        proposals = data.get("proposals") or []
+        total = len(proposals) if isinstance(proposals, list) else 0
+    return {
+        "available": True,
+        "proposals_total": int(total),
+        "by_status": _coerce_counter(by_status),
+        "by_risk": _coerce_counter(by_risk),
+        "by_type": _coerce_counter(by_type),
+    }
+
+
+def _count_inbox(env: dict[str, Any]) -> dict[str, Any]:
+    if env["state"] != STATE_OK or not env.get("data"):
+        return {
+            "available": False,
+            "inbox_items_total": 0,
+            "by_category": {},
+            "by_severity": {},
+        }
+    data = env["data"]
+    items = data.get("items") if isinstance(data, dict) else None
+    items = items if isinstance(items, list) else []
+    by_cat: dict[str, int] = {}
+    by_sev: dict[str, int] = {}
+    for it in items:
+        if not isinstance(it, dict):
+            continue
+        cat = str(it.get("category") or "unknown")
+        sev = str(it.get("severity") or "unknown")
+        by_cat[cat] = by_cat.get(cat, 0) + 1
+        by_sev[sev] = by_sev.get(sev, 0) + 1
+    return {
+        "available": True,
+        "inbox_items_total": len(items),
+        "by_category": _coerce_counter(by_cat),
+        "by_severity": _coerce_counter(by_sev),
+    }
+
+
+def _count_pr_lifecycle(env: dict[str, Any]) -> dict[str, Any]:
+    if env["state"] != STATE_OK or not env.get("data"):
+        return {
+            "available": False,
+            "prs_seen": 0,
+            "merge_allowed": 0,
+            "blocked": 0,
+            "needs_human": 0,
+            "wait_for_rebase": 0,
+            "wait_for_checks": 0,
+        }
+    data = env["data"]
+    prs = data.get("prs") if isinstance(data, dict) else None
+    prs = prs if isinstance(prs, list) else []
+    merge_allowed = 0
+    blocked = 0
+    needs_human = 0
+    rebase = 0
+    checks = 0
+    for pr in prs:
+        if not isinstance(pr, dict):
+            continue
+        decision = str(pr.get("decision") or "")
+        if decision == "merge_allowed":
+            merge_allowed += 1
+        elif decision.startswith("blocked_"):
+            blocked += 1
+        elif decision == "needs_human":
+            needs_human += 1
+        elif decision == "wait_for_rebase":
+            rebase += 1
+        elif decision == "wait_for_checks":
+            checks += 1
+    return {
+        "available": True,
+        "prs_seen": len(prs),
+        "merge_allowed": merge_allowed,
+        "blocked": blocked,
+        "needs_human": needs_human,
+        "wait_for_rebase": rebase,
+        "wait_for_checks": checks,
+    }
+
+
+def _count_recurring(env: dict[str, Any]) -> dict[str, Any]:
+    if env["state"] != STATE_OK or not env.get("data"):
+        return {
+            "available": False,
+            "jobs_total": 0,
+            "succeeded": 0,
+            "blocked": 0,
+            "failed": 0,
+            "skipped": 0,
+            "timeout": 0,
+            "not_run": 0,
+            "consecutive_failures_max": 0,
+        }
+    data = env["data"]
+    counts = data.get("counts") if isinstance(data, dict) else {}
+    counts = counts if isinstance(counts, dict) else {}
+    by_status = counts.get("by_status") if isinstance(counts.get("by_status"), dict) else {}
+    total = counts.get("total")
+    jobs = data.get("jobs") if isinstance(data, dict) else []
+    jobs = jobs if isinstance(jobs, list) else []
+    if not isinstance(total, int):
+        total = len(jobs)
+    cf_max = 0
+    for j in jobs:
+        if not isinstance(j, dict):
+            continue
+        cf = j.get("consecutive_failures")
+        if isinstance(cf, int) and cf > cf_max:
+            cf_max = cf
+    return {
+        "available": True,
+        "jobs_total": int(total),
+        "succeeded": int(by_status.get("succeeded", 0) or 0),
+        "blocked": int(by_status.get("blocked", 0) or 0),
+        "failed": int(by_status.get("failed", 0) or 0),
+        "skipped": int(by_status.get("skipped", 0) or 0),
+        "timeout": int(by_status.get("timeout", 0) or 0),
+        "not_run": int(by_status.get("not_run", 0) or 0),
+        "consecutive_failures_max": cf_max,
+    }
+
+
+def _count_runtime(env: dict[str, Any]) -> dict[str, Any]:
+    if env["state"] != STATE_OK or not env.get("data"):
+        return {
+            "available": False,
+            "sources_total": 0,
+            "ok": 0,
+            "degraded": 0,
+            "failed": 0,
+            "consecutive_failures": 0,
+            "last_success_utc": None,
+            "last_failure_utc": None,
+        }
+    data = env["data"]
+    counts = data.get("counts") if isinstance(data, dict) else {}
+    counts = counts if isinstance(counts, dict) else {}
+    by_state = counts.get("by_state") if isinstance(counts.get("by_state"), dict) else {}
+    total = counts.get("total")
+    sources = data.get("sources") if isinstance(data, dict) else []
+    sources = sources if isinstance(sources, list) else []
+    if not isinstance(total, int):
+        total = len(sources)
+    health = data.get("loop_health") if isinstance(data, dict) else {}
+    health = health if isinstance(health, dict) else {}
+    return {
+        "available": True,
+        "sources_total": int(total),
+        "ok": int(by_state.get("ok", 0) or 0),
+        "degraded": int(by_state.get("degraded", 0) or 0)
+        + int(by_state.get("not_available", 0) or 0),
+        "failed": int(by_state.get("failed", 0) or 0),
+        "consecutive_failures": int(health.get("consecutive_failures", 0) or 0),
+        "last_success_utc": health.get("last_success_utc"),
+        "last_failure_utc": health.get("last_failure_utc"),
+    }
+
+
+def _count_execute_safe(env: dict[str, Any]) -> dict[str, Any]:
+    if env["state"] != STATE_OK or not env.get("data"):
+        return {
+            "available": False,
+            "actions_total": 0,
+            "by_eligibility": {},
+            "by_risk_class": {},
+        }
+    data = env["data"]
+    counts = data.get("counts") if isinstance(data, dict) else {}
+    counts = counts if isinstance(counts, dict) else {}
+    by_e = counts.get("by_eligibility") if isinstance(counts.get("by_eligibility"), dict) else {}
+    by_r = counts.get("by_risk_class") if isinstance(counts.get("by_risk_class"), dict) else {}
+    actions = data.get("actions") if isinstance(data, dict) else []
+    actions = actions if isinstance(actions, list) else []
+    total = counts.get("total")
+    if not isinstance(total, int):
+        total = len(actions)
+    return {
+        "available": True,
+        "actions_total": int(total),
+        "by_eligibility": _coerce_counter(by_e),
+        "by_risk_class": _coerce_counter(by_r),
+    }
+
+
+def _coerce_counter(d: Any) -> dict[str, int]:
+    """Normalise any dict-shaped object into ``Mapping[str, int]``.
+    Non-int values are coerced via ``int()``; failures are dropped.
+    Keys are sorted for determinism."""
+    if not isinstance(d, Mapping):
+        return {}
+    out: dict[str, int] = {}
+    for k in sorted(str(x) for x in d.keys()):
+        v = d.get(k)
+        try:
+            out[k] = int(v)
+        except (TypeError, ValueError):
+            continue
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Operator burden + safety + reliability aggregation
+# ---------------------------------------------------------------------------
+
+# Categories that signal a HIGH-risk approval class (all from the
+# canonical approval_policy enum).
+HIGH_RISK_CATEGORIES: tuple[str, ...] = (
+    "high_risk_pr",
+    "protected_path_change",
+    "frozen_contract_risk",
+    "live_paper_shadow_risk_change",
+    "ci_or_test_weakening_risk",
+    "external_account_or_secret_required",
+    "telemetry_or_data_egress_required",
+    "paid_tool_required",
+    "roadmap_adoption_required",
+    "governance_change",
+)
+
+
+def _operator_burden(
+    proposals: dict[str, Any],
+    inbox: dict[str, Any],
+    pr_lc: dict[str, Any],
+) -> dict[str, Any]:
+    by_status = proposals.get("by_status") or {}
+    by_cat = inbox.get("by_category") or {}
+    by_sev = inbox.get("by_severity") or {}
+    needs_human = int(by_status.get("needs_human", 0) or 0) + int(
+        pr_lc.get("needs_human", 0) or 0
+    )
+    blocked_total = int(by_status.get("blocked", 0) or 0) + int(
+        pr_lc.get("blocked", 0) or 0
+    )
+    approval_required = int(by_cat.get("tooling_requires_approval", 0) or 0)
+    manual_route = int(by_cat.get("manual_route_wiring_required", 0) or 0)
+    high_risk_blocked = int(by_cat.get("high_risk_pr", 0) or 0)
+    unknown_state = int(by_cat.get("unknown_state", 0) or 0)
+    estimated_total = (
+        needs_human
+        + blocked_total
+        + approval_required
+        + manual_route
+        + high_risk_blocked
+        + unknown_state
+    )
+    # Top categories — sorted descending by count, then alphabetical.
+    top: list[tuple[str, int]] = []
+    for k in sorted(by_cat.keys()):
+        v = int(by_cat.get(k, 0) or 0)
+        if v > 0:
+            top.append((k, v))
+    top.sort(key=lambda t: (-t[1], t[0]))
+    top_categories = [{"category": c, "count": n} for c, n in top[:5]]
+    return {
+        "needs_human_total": needs_human,
+        "blocked_total": blocked_total,
+        "approval_required_total": approval_required,
+        "manual_route_wiring_required_total": manual_route,
+        "high_risk_blocked_total": high_risk_blocked,
+        "unknown_state_total": unknown_state,
+        "estimated_operator_actions_total": estimated_total,
+        "top_operator_action_categories": top_categories,
+        "by_severity": _coerce_counter(by_sev),
+    }
+
+
+def _reliability(
+    runtime: dict[str, Any],
+    recurring: dict[str, Any],
+    src_statuses: list[dict[str, Any]],
+) -> dict[str, Any]:
+    sources_total = int(runtime.get("sources_total", 0) or 0)
+    sources_failed = int(runtime.get("failed", 0) or 0) + int(
+        runtime.get("degraded", 0) or 0
+    )
+    src_failure_rate = (
+        round(sources_failed / sources_total, 4) if sources_total > 0 else 0.0
+    )
+    jobs_total = int(recurring.get("jobs_total", 0) or 0)
+    jobs_failed = int(recurring.get("failed", 0) or 0) + int(
+        recurring.get("timeout", 0) or 0
+    )
+    job_failure_rate = (
+        round(jobs_failed / jobs_total, 4) if jobs_total > 0 else 0.0
+    )
+    stale = 0
+    malformed = 0
+    missing = 0
+    for s in src_statuses:
+        st = s.get("state")
+        if st == STATE_MALFORMED or st == STATE_NOT_AN_OBJECT:
+            malformed += 1
+        elif st == STATE_MISSING:
+            missing += 1
+        elif st == STATE_UNREADABLE:
+            stale += 1
+    return {
+        "runtime_consecutive_failures": int(runtime.get("consecutive_failures", 0) or 0),
+        "recurring_consecutive_failures_max": int(
+            recurring.get("consecutive_failures_max", 0) or 0
+        ),
+        "source_failure_rate": src_failure_rate,
+        "job_failure_rate": job_failure_rate,
+        "stale_artifact_count": stale,
+        "malformed_artifact_count": malformed,
+        "missing_artifact_count": missing,
+        "last_success_at_utc": runtime.get("last_success_utc"),
+        "last_failure_at_utc": runtime.get("last_failure_utc"),
+    }
+
+
+def _safety(
+    inbox: dict[str, Any],
+    execute_safe: dict[str, Any],
+    proposals: dict[str, Any],
+) -> dict[str, Any]:
+    by_cat = inbox.get("by_category") or {}
+    by_eligibility = execute_safe.get("by_eligibility") or {}
+    by_risk = execute_safe.get("by_risk_class") or {}
+    proposal_by_risk = proposals.get("by_risk") or {}
+
+    # The safety contract: nothing classified HIGH or UNKNOWN may be
+    # ELIGIBLE (executable) at the same time. We approximate this as
+    # "count of HIGH+UNKNOWN actions that are also eligible".
+    # ``execute_safe_controls`` does not currently emit cross-tabulated
+    # data, so we read the action list directly when available.
+    high_or_unknown_executable = 0
+    actions = execute_safe.get("_actions_passthrough") or []
+    if isinstance(actions, list):
+        for a in actions:
+            if not isinstance(a, dict):
+                continue
+            r = str(a.get("risk_class", "")).upper()
+            e = str(a.get("eligibility", "")).lower()
+            if r in ("HIGH", "UNKNOWN") and e == "eligible":
+                high_or_unknown_executable += 1
+
+    return {
+        "high_or_unknown_executable_count": high_or_unknown_executable,
+        "frozen_contract_risk_count": int(by_cat.get("frozen_contract_risk", 0) or 0),
+        "protected_path_risk_count": int(by_cat.get("protected_path_change", 0) or 0),
+        "live_paper_shadow_risk_count": int(
+            by_cat.get("live_paper_shadow_risk_change", 0) or 0
+        ),
+        "ci_or_test_weakening_risk_count": int(
+            by_cat.get("ci_or_test_weakening_risk", 0) or 0
+        ),
+        "secret_or_external_account_required_count": int(
+            by_cat.get("external_account_or_secret_required", 0) or 0
+        ),
+        "telemetry_or_data_egress_count": int(
+            by_cat.get("telemetry_or_data_egress_required", 0) or 0
+        ),
+        "paid_tool_required_count": int(by_cat.get("paid_tool_required", 0) or 0),
+        "high_risk_proposal_count": int(proposal_by_risk.get("HIGH", 0) or 0),
+        "unknown_risk_proposal_count": int(proposal_by_risk.get("UNKNOWN", 0) or 0),
+        "execute_safe_eligible_count": int(by_eligibility.get("eligible", 0) or 0),
+        "execute_safe_blocked_count": int(by_eligibility.get("blocked", 0) or 0),
+        "execute_safe_high_count": int(by_risk.get("HIGH", 0) or 0),
+        "policy_version": _approval_policy.MODULE_VERSION,
+        "summary": (
+            "ok"
+            if high_or_unknown_executable == 0
+            else "unsafe_state_detected"
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Trend windows from history.jsonl files
+# ---------------------------------------------------------------------------
+
+
+def _parse_iso(s: Any) -> _dt.datetime | None:
+    if not isinstance(s, str):
+        return None
+    try:
+        if s.endswith("Z"):
+            s2 = s[:-1] + "+00:00"
+        else:
+            s2 = s
+        return _dt.datetime.fromisoformat(s2)
+    except (TypeError, ValueError):
+        return None
+
+
+def _window_filter(
+    rows: list[dict[str, Any]],
+    *,
+    now: _dt.datetime,
+    seconds: int | None,
+) -> list[dict[str, Any]]:
+    if seconds is None:
+        return rows
+    cutoff = now - _dt.timedelta(seconds=seconds)
+    out: list[dict[str, Any]] = []
+    for r in rows:
+        ts = _parse_iso(r.get("generated_at_utc"))
+        if ts is None:
+            continue
+        if ts >= cutoff:
+            out.append(r)
+    return out
+
+
+def _trend_aggregate(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate a list of historical digest rows into a few simple
+    bounded counters. Designed for both runtime and recurring
+    histories — they share enough shape (counts.total etc.) that a
+    single aggregator works."""
+    if not rows:
+        return {"status": "not_available", "reason": "no_history"}
+    n = len(rows)
+    total_runs = n
+    failed_runs = 0
+    succeeded_runs = 0
+    degraded_runs = 0
+    consecutive_failures_max = 0
+    for r in rows:
+        rec = str(r.get("final_recommendation") or "")
+        cf = 0
+        health = r.get("loop_health")
+        if isinstance(health, dict):
+            cf = int(health.get("consecutive_failures", 0) or 0)
+        consecutive_failures_max = max(consecutive_failures_max, cf)
+        if rec.startswith("runtime_halt") or "consecutive_failures" in rec:
+            failed_runs += 1
+        elif rec in ("all_sources_ok", "all_jobs_ok", "healthy", "ok"):
+            succeeded_runs += 1
+        elif rec.startswith("degraded"):
+            degraded_runs += 1
+    return {
+        "status": "ok",
+        "total_runs": total_runs,
+        "succeeded_runs": succeeded_runs,
+        "failed_runs": failed_runs,
+        "degraded_runs": degraded_runs,
+        "consecutive_failures_max": consecutive_failures_max,
+    }
+
+
+def _trends(
+    runtime_history: list[dict[str, Any]],
+    recurring_history: list[dict[str, Any]],
+    *,
+    now: _dt.datetime,
+) -> dict[str, Any]:
+    return {
+        "current": {
+            "runtime": _trend_aggregate(runtime_history[-1:]),
+            "recurring": _trend_aggregate(recurring_history[-1:]),
+        },
+        TREND_LAST_24H: {
+            "runtime": _trend_aggregate(
+                _window_filter(runtime_history, now=now, seconds=24 * 3600)
+            ),
+            "recurring": _trend_aggregate(
+                _window_filter(recurring_history, now=now, seconds=24 * 3600)
+            ),
+        },
+        TREND_LAST_7D: {
+            "runtime": _trend_aggregate(
+                _window_filter(runtime_history, now=now, seconds=7 * 24 * 3600)
+            ),
+            "recurring": _trend_aggregate(
+                _window_filter(recurring_history, now=now, seconds=7 * 24 * 3600)
+            ),
+        },
+        TREND_ALL_TIME: {
+            "runtime": _trend_aggregate(runtime_history),
+            "recurring": _trend_aggregate(recurring_history),
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Final recommendation logic
+# ---------------------------------------------------------------------------
+
+
+def _final_recommendation(
+    *,
+    src_statuses: list[dict[str, Any]],
+    operator_burden: dict[str, Any],
+    reliability: dict[str, Any],
+    safety: dict[str, Any],
+) -> str:
+    if safety.get("high_or_unknown_executable_count", 0) > 0:
+        return REC_UNSAFE
+    missing = sum(
+        1 for s in src_statuses if s.get("state") in (STATE_MISSING, STATE_NOT_AN_OBJECT)
+    )
+    if missing == len(src_statuses):
+        return REC_NOT_AVAILABLE
+    if reliability.get("missing_artifact_count", 0) >= 2:
+        return REC_DEGRADED_MISSING
+    if reliability.get("malformed_artifact_count", 0) > 0:
+        return REC_DEGRADED_FAILURES
+    if reliability.get("runtime_consecutive_failures", 0) >= 3:
+        return REC_DEGRADED_FAILURES
+    if operator_burden.get("estimated_operator_actions_total", 0) > 0:
+        return REC_ACTION_REQUIRED
+    return REC_HEALTHY
+
+
+# ---------------------------------------------------------------------------
+# collect_snapshot / write_outputs
+# ---------------------------------------------------------------------------
+
+
+def collect_snapshot(*, frozen_utc: str | None = None) -> dict[str, Any]:
+    """Build the full metrics digest. Pure with respect to the
+    filesystem state at call time. ``frozen_utc`` pins the
+    generated_at_utc field for deterministic tests."""
+    src_envelopes: dict[str, dict[str, Any]] = {
+        "workloop_runtime": _read_json_artifact(SOURCE_WORKLOOP_RUNTIME),
+        "recurring_maintenance": _read_json_artifact(SOURCE_RECURRING_MAINTENANCE),
+        "proposal_queue": _read_json_artifact(SOURCE_PROPOSAL_QUEUE),
+        "approval_inbox": _read_json_artifact(SOURCE_APPROVAL_INBOX),
+        "github_pr_lifecycle": _read_json_artifact(SOURCE_PR_LIFECYCLE),
+        "execute_safe_controls": _read_json_artifact(SOURCE_EXECUTE_SAFE_CONTROLS),
+    }
+
+    src_statuses: list[dict[str, Any]] = []
+    for name, rel in SOURCE_ORDER:
+        env = src_envelopes[name]
+        src_statuses.append(
+            {
+                "source": name,
+                "artifact_path": rel,
+                "state": env["state"],
+                "reason": env["reason"],
+            }
+        )
+
+    proposals = _count_proposals(src_envelopes["proposal_queue"])
+    inbox = _count_inbox(src_envelopes["approval_inbox"])
+    pr_lc = _count_pr_lifecycle(src_envelopes["github_pr_lifecycle"])
+    runtime = _count_runtime(src_envelopes["workloop_runtime"])
+    recurring = _count_recurring(src_envelopes["recurring_maintenance"])
+    execute_safe = _count_execute_safe(src_envelopes["execute_safe_controls"])
+
+    # Cross-tab pass-through for safety eval — read raw actions.
+    es_data = src_envelopes["execute_safe_controls"].get("data") or {}
+    if isinstance(es_data, dict):
+        execute_safe["_actions_passthrough"] = es_data.get("actions") or []
+    else:
+        execute_safe["_actions_passthrough"] = []
+
+    operator_burden = _operator_burden(proposals, inbox, pr_lc)
+    reliability = _reliability(runtime, recurring, src_statuses)
+    safety = _safety(inbox, execute_safe, proposals)
+
+    runtime_history = _read_jsonl_history(SOURCE_WORKLOOP_RUNTIME_HISTORY)
+    recurring_history = _read_jsonl_history(SOURCE_RECURRING_MAINTENANCE_HISTORY)
+    trends = _trends(runtime_history, recurring_history, now=_utcnow_dt())
+
+    final_rec = _final_recommendation(
+        src_statuses=src_statuses,
+        operator_burden=operator_burden,
+        reliability=reliability,
+        safety=safety,
+    )
+
+    # Strip the internal pass-through field — it is not part of the
+    # public schema.
+    execute_safe.pop("_actions_passthrough", None)
+
+    snap: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": "autonomy_metrics_digest",
+        "module_version": MODULE_VERSION,
+        "metrics_version": METRICS_VERSION,
+        "generated_at_utc": frozen_utc or _utcnow(),
+        "source_statuses": src_statuses,
+        "throughput": {
+            "proposals_total": proposals.get("proposals_total", 0),
+            "proposals_by_status": proposals.get("by_status", {}),
+            "proposals_by_risk": proposals.get("by_risk", {}),
+            "proposals_by_type": proposals.get("by_type", {}),
+            "inbox_items_total": inbox.get("inbox_items_total", 0),
+            "inbox_items_by_category": inbox.get("by_category", {}),
+            "inbox_items_by_severity": inbox.get("by_severity", {}),
+            "pr_lifecycle_prs_seen": pr_lc.get("prs_seen", 0),
+            "pr_lifecycle_merge_allowed": pr_lc.get("merge_allowed", 0),
+            "pr_lifecycle_blocked": pr_lc.get("blocked", 0),
+            "pr_lifecycle_needs_human": pr_lc.get("needs_human", 0),
+            "pr_lifecycle_wait_for_rebase": pr_lc.get("wait_for_rebase", 0),
+            "pr_lifecycle_wait_for_checks": pr_lc.get("wait_for_checks", 0),
+            "recurring_jobs_total": recurring.get("jobs_total", 0),
+            "recurring_jobs_succeeded": recurring.get("succeeded", 0),
+            "recurring_jobs_blocked": recurring.get("blocked", 0),
+            "recurring_jobs_failed": recurring.get("failed", 0),
+            "recurring_jobs_skipped": recurring.get("skipped", 0),
+            "recurring_jobs_timeout": recurring.get("timeout", 0),
+            "recurring_jobs_not_run": recurring.get("not_run", 0),
+            "runtime_sources_total": runtime.get("sources_total", 0),
+            "runtime_sources_ok": runtime.get("ok", 0),
+            "runtime_sources_degraded": runtime.get("degraded", 0),
+            "runtime_sources_failed": runtime.get("failed", 0),
+            "execute_safe_actions_total": execute_safe.get("actions_total", 0),
+            "execute_safe_by_eligibility": execute_safe.get("by_eligibility", {}),
+            "execute_safe_by_risk_class": execute_safe.get("by_risk_class", {}),
+        },
+        "operator_burden": operator_burden,
+        "reliability": reliability,
+        "safety": safety,
+        "trends": trends,
+        "policy": {
+            "module_version": _approval_policy.MODULE_VERSION,
+            "schema_version": _approval_policy.SCHEMA_VERSION,
+            "high_or_unknown_is_executable": False,
+        },
+        "final_recommendation": final_rec,
+        "safe_to_execute": False,
+    }
+
+    _approval_policy.assert_no_credential_values(snap)
+    return snap
+
+
+def write_outputs(snapshot: dict[str, Any]) -> dict[str, str]:
+    """Atomic write of latest.json + timestamped copy + history append."""
+    DIGEST_DIR_JSON.mkdir(parents=True, exist_ok=True)
+    ts = snapshot["generated_at_utc"].replace(":", "-")
+    json_now = DIGEST_DIR_JSON / f"{ts}.json"
+    json_latest = DIGEST_DIR_JSON / "latest.json"
+    history = DIGEST_DIR_JSON / "history.jsonl"
+    payload = json.dumps(snapshot, sort_keys=True, indent=2)
+
+    tmp_now = json_now.with_suffix(json_now.suffix + ".tmp")
+    tmp_now.write_text(payload, encoding="utf-8")
+    os.replace(tmp_now, json_now)
+
+    tmp_latest = json_latest.with_suffix(json_latest.suffix + ".tmp")
+    tmp_latest.write_text(payload, encoding="utf-8")
+    os.replace(tmp_latest, json_latest)
+
+    compact = json.dumps(snapshot, sort_keys=True, separators=(",", ":"))
+    with history.open("a", encoding="utf-8") as f:
+        f.write(compact + "\n")
+
+    return {
+        "latest": _rel(json_latest),
+        "timestamped": _rel(json_now),
+        "history": _rel(history),
+    }
+
+
+def read_latest_snapshot() -> dict[str, Any] | None:
+    """Helper for downstream consumers (status surface). Returns the
+    parsed digest or ``None`` if the artifact is missing/malformed."""
+    env = _read_json_artifact(DIGEST_DIR_JSON / "latest.json")
+    if env["state"] == STATE_OK:
+        return env["data"]
+    return None
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="reporting.autonomy_metrics",
+        description=(
+            "Read-only autonomy throughput / observability metrics "
+            "(v3.15.15.25). Stdlib-only."
+        ),
+    )
+    g = parser.add_mutually_exclusive_group(required=True)
+    g.add_argument("--collect", action="store_true", help="Collect and write a snapshot.")
+    g.add_argument("--status", action="store_true", help="Read and print the latest snapshot.")
+    parser.add_argument(
+        "--no-write",
+        action="store_true",
+        help="With --collect, skip the artifact write (useful for CI).",
+    )
+    parser.add_argument(
+        "--frozen-utc",
+        type=str,
+        default=None,
+        help="Pin generated_at_utc for deterministic tests.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.status:
+        snap = read_latest_snapshot()
+        if snap is None:
+            print(json.dumps({"status": "not_available", "reason": "missing"}, indent=2))
+            return 1
+        print(json.dumps(snap, sort_keys=True, indent=2))
+        return 0
+
+    if args.collect:
+        snap = collect_snapshot(frozen_utc=args.frozen_utc)
+        if not args.no_write:
+            paths = write_outputs(snap)
+            print(json.dumps({"status": "ok", "paths": paths}, indent=2))
+        else:
+            print(json.dumps(snap, sort_keys=True, indent=2))
+        return 0
+
+    parser.error("no mode chosen")
+    return 2  # unreachable
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_autonomy_metrics.py
+++ b/tests/unit/test_autonomy_metrics.py
@@ -1,0 +1,717 @@
+"""Unit tests for ``reporting.autonomy_metrics``.
+
+Properties enforced:
+
+* Empty / missing artifacts produce ``not_available`` /
+  ``degraded_*`` recommendations, never crash.
+* Malformed artifacts are counted under ``reliability``.
+* Output is deterministic for a fixed input set
+  (byte-identical when ``--frozen-utc`` is used).
+* Throughput / operator-burden / reliability / safety counters
+  reflect their inputs.
+* ``high_or_unknown_executable_count`` is 0 for safe inputs and
+  non-zero when execute-safe lists a HIGH/UNKNOWN action as
+  ``eligible``; the latter flips ``final_recommendation`` to
+  ``unsafe_state_detected``.
+* History trend windows return ``not_available`` when no
+  history file exists, and ``ok`` aggregates when it does.
+* Atomic write: ``latest.json`` is byte-identical to the
+  timestamped copy of the same run.
+* History append-only: a new run extends ``history.jsonl``
+  rather than overwriting.
+* Credential-shaped values in upstream artifacts trip the guard.
+* ``source_statuses`` always includes one row per source, in
+  canonical order.
+* The CLI never accepts free-form command flags.
+* No mutation routes / no forbidden tokens in the module.
+* The status surface includes the metrics block when wired.
+* Frozen contract paths are unchanged by collection.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reporting import autonomy_metrics as am
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_dirs(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """Redirect every source artifact path + the digest dir into
+    ``tmp_path`` so the test never touches real artifacts."""
+    monkeypatch.setattr(am, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(am, "DIGEST_DIR_JSON", tmp_path / "logs" / "autonomy_metrics")
+    monkeypatch.setattr(
+        am,
+        "SOURCE_WORKLOOP_RUNTIME",
+        tmp_path / "logs" / "workloop_runtime" / "latest.json",
+    )
+    monkeypatch.setattr(
+        am,
+        "SOURCE_WORKLOOP_RUNTIME_HISTORY",
+        tmp_path / "logs" / "workloop_runtime" / "history.jsonl",
+    )
+    monkeypatch.setattr(
+        am,
+        "SOURCE_RECURRING_MAINTENANCE",
+        tmp_path / "logs" / "recurring_maintenance" / "latest.json",
+    )
+    monkeypatch.setattr(
+        am,
+        "SOURCE_RECURRING_MAINTENANCE_HISTORY",
+        tmp_path / "logs" / "recurring_maintenance" / "history.jsonl",
+    )
+    monkeypatch.setattr(
+        am,
+        "SOURCE_PROPOSAL_QUEUE",
+        tmp_path / "logs" / "proposal_queue" / "latest.json",
+    )
+    monkeypatch.setattr(
+        am,
+        "SOURCE_APPROVAL_INBOX",
+        tmp_path / "logs" / "approval_inbox" / "latest.json",
+    )
+    monkeypatch.setattr(
+        am,
+        "SOURCE_PR_LIFECYCLE",
+        tmp_path / "logs" / "github_pr_lifecycle" / "latest.json",
+    )
+    monkeypatch.setattr(
+        am,
+        "SOURCE_EXECUTE_SAFE_CONTROLS",
+        tmp_path / "logs" / "execute_safe_controls" / "latest.json",
+    )
+    return tmp_path
+
+
+def _write(p: Path, payload: dict[str, Any]) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _ok_workloop_runtime() -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "report_kind": "workloop_runtime_digest",
+        "module_version": "v3.15.15.22",
+        "generated_at_utc": "2026-05-03T07:00:00Z",
+        "mode": "once",
+        "iteration": 0,
+        "max_iterations": 1,
+        "duration_ms": 100,
+        "safe_to_execute": False,
+        "loop_health": {
+            "consecutive_failures": 0,
+            "iterations_completed": 1,
+            "iterations_failed": 0,
+            "last_success_utc": "2026-05-03T07:00:00Z",
+            "last_failure_utc": None,
+        },
+        "sources": [
+            {"source": "governance_status", "state": "ok"},
+            {"source": "approval_inbox", "state": "ok"},
+            {"source": "proposal_queue", "state": "ok"},
+            {"source": "github_pr_lifecycle", "state": "not_available"},
+            {"source": "agent_audit_summary", "state": "ok"},
+            {"source": "autonomous_workloop", "state": "ok"},
+            {"source": "execute_safe_controls", "state": "ok"},
+        ],
+        "counts": {
+            "by_state": {"ok": 6, "not_available": 1},
+            "total": 7,
+        },
+        "final_recommendation": "all_sources_ok",
+    }
+
+
+def _ok_recurring_maintenance() -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "module_version": "v3.15.15.23",
+        "generated_at_utc": "2026-05-03T07:00:30Z",
+        "mode": "list",
+        "safe_to_execute": False,
+        "jobs": [
+            {"job_type": "refresh_proposal_queue", "last_status": "succeeded", "consecutive_failures": 0, "enabled": True},
+            {"job_type": "refresh_approval_inbox", "last_status": "succeeded", "consecutive_failures": 0, "enabled": True},
+            {"job_type": "refresh_github_pr_lifecycle_dry_run", "last_status": "blocked", "consecutive_failures": 1, "enabled": True},
+            {"job_type": "refresh_workloop_runtime_once", "last_status": "succeeded", "consecutive_failures": 0, "enabled": True},
+            {"job_type": "dependabot_low_medium_execute_safe", "last_status": "skipped", "consecutive_failures": 0, "enabled": False},
+        ],
+        "counts": {
+            "total": 5,
+            "by_status": {"succeeded": 3, "blocked": 1, "skipped": 1},
+        },
+        "final_recommendation": "all_jobs_ok",
+    }
+
+
+def _ok_proposal_queue() -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "module_version": "v3.15.15.19",
+        "generated_at_utc": "2026-05-03T07:01:00Z",
+        "proposals": [],
+        "counts": {
+            "total": 4,
+            "by_status": {"proposed": 3, "needs_human": 1},
+            "by_risk": {"LOW": 2, "MEDIUM": 1, "HIGH": 1},
+            "by_type": {"observability_gap": 2, "ci_hygiene": 2},
+        },
+        "final_recommendation": "needs_human_on_1_items",
+    }
+
+
+def _ok_approval_inbox() -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "module_version": "v3.15.15.20",
+        "generated_at_utc": "2026-05-03T07:01:30Z",
+        "items": [
+            {"category": "high_risk_pr", "severity": "high"},
+            {"category": "tooling_requires_approval", "severity": "medium"},
+            {"category": "manual_route_wiring_required", "severity": "low"},
+        ],
+        "counts": {
+            "total": 3,
+            "by_category": {
+                "high_risk_pr": 1,
+                "tooling_requires_approval": 1,
+                "manual_route_wiring_required": 1,
+            },
+            "by_severity": {"high": 1, "medium": 1, "low": 1},
+        },
+    }
+
+
+def _ok_pr_lifecycle() -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "module_version": "v3.15.15.17",
+        "generated_at_utc": "2026-05-03T07:02:00Z",
+        "prs": [
+            {"decision": "merge_allowed"},
+            {"decision": "blocked_high_risk"},
+            {"decision": "wait_for_rebase"},
+        ],
+        "final_recommendation": "ok",
+    }
+
+
+def _ok_execute_safe_controls(*, leak_high_eligible: bool = False) -> dict[str, Any]:
+    actions = [
+        {"action_type": "refresh_pr_lifecycle", "risk_class": "LOW", "eligibility": "eligible"},
+        {"action_type": "refresh_proposal_queue", "risk_class": "LOW", "eligibility": "eligible"},
+        {"action_type": "refresh_approval_inbox", "risk_class": "LOW", "eligibility": "eligible"},
+        {"action_type": "run_dependabot_execute_safe", "risk_class": "MEDIUM", "eligibility": "blocked"},
+    ]
+    if leak_high_eligible:
+        actions.append(
+            {"action_type": "fake_high", "risk_class": "HIGH", "eligibility": "eligible"}
+        )
+    return {
+        "schema_version": 1,
+        "module_version": "v3.15.15.21",
+        "generated_at_utc": "2026-05-03T07:02:30Z",
+        "actions": actions,
+        "counts": {
+            "total": len(actions),
+            "by_eligibility": {
+                "eligible": sum(1 for a in actions if a["eligibility"] == "eligible"),
+                "blocked": sum(1 for a in actions if a["eligibility"] == "blocked"),
+            },
+            "by_risk_class": {
+                "LOW": sum(1 for a in actions if a["risk_class"] == "LOW"),
+                "MEDIUM": sum(1 for a in actions if a["risk_class"] == "MEDIUM"),
+                "HIGH": sum(1 for a in actions if a["risk_class"] == "HIGH"),
+            },
+        },
+    }
+
+
+def _write_all_ok(tmp_path: Path) -> None:
+    _write(tmp_path / "logs" / "workloop_runtime" / "latest.json", _ok_workloop_runtime())
+    _write(tmp_path / "logs" / "recurring_maintenance" / "latest.json", _ok_recurring_maintenance())
+    _write(tmp_path / "logs" / "proposal_queue" / "latest.json", _ok_proposal_queue())
+    _write(tmp_path / "logs" / "approval_inbox" / "latest.json", _ok_approval_inbox())
+    _write(tmp_path / "logs" / "github_pr_lifecycle" / "latest.json", _ok_pr_lifecycle())
+    _write(tmp_path / "logs" / "execute_safe_controls" / "latest.json", _ok_execute_safe_controls())
+
+
+# ---------------------------------------------------------------------------
+# Module-level invariants
+# ---------------------------------------------------------------------------
+
+
+def test_module_version_is_v3_15_15_25() -> None:
+    assert am.MODULE_VERSION == "v3.15.15.25"
+
+
+def test_metrics_version_is_v1() -> None:
+    assert am.METRICS_VERSION == "v1"
+
+
+def test_schema_version_is_1() -> None:
+    assert am.SCHEMA_VERSION == 1
+
+
+def test_source_order_is_six_items_in_canonical_order() -> None:
+    names = [n for n, _ in am.SOURCE_ORDER]
+    assert names == [
+        "workloop_runtime",
+        "recurring_maintenance",
+        "proposal_queue",
+        "approval_inbox",
+        "github_pr_lifecycle",
+        "execute_safe_controls",
+    ]
+
+
+def test_no_subprocess_or_network_imports_in_module() -> None:
+    src = Path(am.__file__).read_text(encoding="utf-8")
+    forbidden = (
+        "import subprocess",
+        "from subprocess",
+        "Popen(",
+        "import requests",
+        "import urllib.request",
+        "from urllib.request",
+        "import socket",
+    )
+    for token in forbidden:
+        assert token not in src, f"forbidden import in autonomy_metrics: {token!r}"
+
+
+def test_no_gh_or_git_invocation_in_module() -> None:
+    src = Path(am.__file__).read_text(encoding="utf-8")
+    forbidden = ('"gh"', "'gh'", "/usr/bin/gh", '"git"', "'git'", "/usr/bin/git")
+    for token in forbidden:
+        assert token not in src, f"forbidden tool spawn: {token!r}"
+
+
+# ---------------------------------------------------------------------------
+# Empty / missing source semantics
+# ---------------------------------------------------------------------------
+
+
+def test_collect_with_no_artifacts_returns_not_available(isolated_dirs) -> None:
+    snap = am.collect_snapshot(frozen_utc="2026-05-03T08:00:00Z")
+    # Every source row reports missing.
+    states = [s["state"] for s in snap["source_statuses"]]
+    assert all(st == am.STATE_MISSING for st in states), states
+    assert snap["final_recommendation"] == am.REC_NOT_AVAILABLE
+    # safe_to_execute is hard-coded false.
+    assert snap["safe_to_execute"] is False
+
+
+def test_collect_with_some_artifacts_missing_reports_degraded(isolated_dirs) -> None:
+    # Provide only proposal_queue + approval_inbox; others missing.
+    _write(isolated_dirs / "logs" / "proposal_queue" / "latest.json", _ok_proposal_queue())
+    _write(isolated_dirs / "logs" / "approval_inbox" / "latest.json", _ok_approval_inbox())
+    snap = am.collect_snapshot(frozen_utc="2026-05-03T08:00:00Z")
+    # 4 sources missing => degraded_missing_sources.
+    assert snap["final_recommendation"] in (
+        am.REC_DEGRADED_MISSING,
+        am.REC_ACTION_REQUIRED,
+    )
+    # Reliability counts the missing.
+    assert snap["reliability"]["missing_artifact_count"] >= 2
+
+
+def test_malformed_artifact_is_counted(isolated_dirs) -> None:
+    p = isolated_dirs / "logs" / "workloop_runtime" / "latest.json"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("{not json", encoding="utf-8")
+    _write_all_ok_excluding_runtime = lambda: None  # noqa: E731 — placeholder
+    _write(isolated_dirs / "logs" / "recurring_maintenance" / "latest.json", _ok_recurring_maintenance())
+    _write(isolated_dirs / "logs" / "proposal_queue" / "latest.json", _ok_proposal_queue())
+    _write(isolated_dirs / "logs" / "approval_inbox" / "latest.json", _ok_approval_inbox())
+    _write(isolated_dirs / "logs" / "github_pr_lifecycle" / "latest.json", _ok_pr_lifecycle())
+    _write(isolated_dirs / "logs" / "execute_safe_controls" / "latest.json", _ok_execute_safe_controls())
+    snap = am.collect_snapshot(frozen_utc="2026-05-03T08:00:00Z")
+    assert snap["reliability"]["malformed_artifact_count"] >= 1
+    states = [s["state"] for s in snap["source_statuses"] if s["source"] == "workloop_runtime"]
+    assert states == [am.STATE_MALFORMED]
+
+
+def test_array_top_level_artifact_is_not_an_object(isolated_dirs) -> None:
+    p = isolated_dirs / "logs" / "approval_inbox" / "latest.json"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("[1, 2, 3]", encoding="utf-8")
+    _write(isolated_dirs / "logs" / "workloop_runtime" / "latest.json", _ok_workloop_runtime())
+    snap = am.collect_snapshot(frozen_utc="2026-05-03T08:00:00Z")
+    states = [s["state"] for s in snap["source_statuses"] if s["source"] == "approval_inbox"]
+    assert states == [am.STATE_NOT_AN_OBJECT]
+
+
+# ---------------------------------------------------------------------------
+# Throughput counters
+# ---------------------------------------------------------------------------
+
+
+def test_throughput_counts_match_inputs(isolated_dirs) -> None:
+    _write_all_ok(isolated_dirs)
+    snap = am.collect_snapshot(frozen_utc="2026-05-03T08:00:00Z")
+    t = snap["throughput"]
+    assert t["proposals_total"] == 4
+    assert t["proposals_by_status"] == {"needs_human": 1, "proposed": 3}
+    assert t["proposals_by_risk"] == {"HIGH": 1, "LOW": 2, "MEDIUM": 1}
+    assert t["inbox_items_total"] == 3
+    assert t["pr_lifecycle_prs_seen"] == 3
+    assert t["pr_lifecycle_merge_allowed"] == 1
+    assert t["pr_lifecycle_blocked"] == 1
+    assert t["pr_lifecycle_wait_for_rebase"] == 1
+    assert t["recurring_jobs_total"] == 5
+    assert t["recurring_jobs_succeeded"] == 3
+    assert t["recurring_jobs_blocked"] == 1
+    assert t["recurring_jobs_skipped"] == 1
+    assert t["runtime_sources_total"] == 7
+    assert t["runtime_sources_ok"] == 6
+    assert t["runtime_sources_degraded"] == 1
+    assert t["execute_safe_actions_total"] == 4
+
+
+def test_operator_burden_counts_aggregate_across_sources(isolated_dirs) -> None:
+    _write_all_ok(isolated_dirs)
+    snap = am.collect_snapshot(frozen_utc="2026-05-03T08:00:00Z")
+    b = snap["operator_burden"]
+    # 1 needs_human in proposal_queue, 0 in pr_lifecycle decisions.
+    assert b["needs_human_total"] == 1
+    # blocked_total: proposals=0 + pr_lifecycle=1.
+    assert b["blocked_total"] == 1
+    assert b["high_risk_blocked_total"] == 1
+    assert b["approval_required_total"] == 1
+    assert b["manual_route_wiring_required_total"] == 1
+    assert b["estimated_operator_actions_total"] == (
+        b["needs_human_total"]
+        + b["blocked_total"]
+        + b["approval_required_total"]
+        + b["manual_route_wiring_required_total"]
+        + b["high_risk_blocked_total"]
+        + b["unknown_state_total"]
+    )
+    assert isinstance(b["top_operator_action_categories"], list)
+
+
+def test_reliability_counts(isolated_dirs) -> None:
+    _write_all_ok(isolated_dirs)
+    snap = am.collect_snapshot(frozen_utc="2026-05-03T08:00:00Z")
+    r = snap["reliability"]
+    assert r["runtime_consecutive_failures"] == 0
+    assert r["recurring_consecutive_failures_max"] == 1
+    # No missing artifacts in the all-ok scenario.
+    assert r["missing_artifact_count"] == 0
+    assert r["malformed_artifact_count"] == 0
+    # 1 not_available in the runtime sources -> failure_rate > 0.
+    assert r["source_failure_rate"] > 0
+    assert r["last_success_at_utc"] == "2026-05-03T07:00:00Z"
+
+
+def test_safety_counts_high_or_unknown_executable_is_zero_for_safe_inputs(
+    isolated_dirs,
+) -> None:
+    _write_all_ok(isolated_dirs)
+    snap = am.collect_snapshot(frozen_utc="2026-05-03T08:00:00Z")
+    assert snap["safety"]["high_or_unknown_executable_count"] == 0
+    assert snap["safety"]["summary"] == "ok"
+
+
+def test_safety_detects_high_eligible_action(isolated_dirs) -> None:
+    """If the execute_safe_controls catalog ever lists a HIGH action
+    as ``eligible``, the metrics digest must surface it as
+    unsafe_state_detected."""
+    _write(isolated_dirs / "logs" / "workloop_runtime" / "latest.json", _ok_workloop_runtime())
+    _write(isolated_dirs / "logs" / "recurring_maintenance" / "latest.json", _ok_recurring_maintenance())
+    _write(isolated_dirs / "logs" / "proposal_queue" / "latest.json", _ok_proposal_queue())
+    _write(isolated_dirs / "logs" / "approval_inbox" / "latest.json", _ok_approval_inbox())
+    _write(isolated_dirs / "logs" / "github_pr_lifecycle" / "latest.json", _ok_pr_lifecycle())
+    _write(
+        isolated_dirs / "logs" / "execute_safe_controls" / "latest.json",
+        _ok_execute_safe_controls(leak_high_eligible=True),
+    )
+    snap = am.collect_snapshot(frozen_utc="2026-05-03T08:00:00Z")
+    assert snap["safety"]["high_or_unknown_executable_count"] >= 1
+    assert snap["safety"]["summary"] == "unsafe_state_detected"
+    assert snap["final_recommendation"] == am.REC_UNSAFE
+
+
+# ---------------------------------------------------------------------------
+# Final recommendation logic
+# ---------------------------------------------------------------------------
+
+
+def test_final_recommendation_healthy_for_clean_inputs(isolated_dirs) -> None:
+    # Use a "clean" inbox/proposal set: zero needs_human, zero
+    # blocked, zero high_risk, zero unknown.
+    inbox = {
+        "schema_version": 1,
+        "items": [],
+        "counts": {"total": 0, "by_category": {}, "by_severity": {}},
+    }
+    proposals = {
+        "schema_version": 1,
+        "proposals": [],
+        "counts": {
+            "total": 0,
+            "by_status": {},
+            "by_risk": {},
+            "by_type": {},
+        },
+    }
+    pr = {"prs": []}
+    rt = _ok_workloop_runtime()
+    rc = _ok_recurring_maintenance()
+    # Clean recurring: no blocked job, all succeeded.
+    rc["jobs"] = [
+        {"job_type": j["job_type"], "last_status": "succeeded", "consecutive_failures": 0, "enabled": True}
+        for j in rc["jobs"]
+    ]
+    rc["counts"] = {"total": 5, "by_status": {"succeeded": 5}}
+    es = _ok_execute_safe_controls()
+    _write(isolated_dirs / "logs" / "workloop_runtime" / "latest.json", rt)
+    _write(isolated_dirs / "logs" / "recurring_maintenance" / "latest.json", rc)
+    _write(isolated_dirs / "logs" / "proposal_queue" / "latest.json", proposals)
+    _write(isolated_dirs / "logs" / "approval_inbox" / "latest.json", inbox)
+    _write(isolated_dirs / "logs" / "github_pr_lifecycle" / "latest.json", pr)
+    _write(isolated_dirs / "logs" / "execute_safe_controls" / "latest.json", es)
+
+    snap = am.collect_snapshot(frozen_utc="2026-05-03T08:00:00Z")
+    assert snap["final_recommendation"] == am.REC_HEALTHY
+
+
+def test_final_recommendation_action_required_when_burden_nonzero(isolated_dirs) -> None:
+    _write_all_ok(isolated_dirs)
+    snap = am.collect_snapshot(frozen_utc="2026-05-03T08:00:00Z")
+    assert snap["final_recommendation"] == am.REC_ACTION_REQUIRED
+
+
+def test_final_recommendation_degraded_failures_on_three_consecutive_failures(
+    isolated_dirs,
+) -> None:
+    _write_all_ok(isolated_dirs)
+    rt = _ok_workloop_runtime()
+    rt["loop_health"]["consecutive_failures"] = 3
+    _write(isolated_dirs / "logs" / "workloop_runtime" / "latest.json", rt)
+    snap = am.collect_snapshot(frozen_utc="2026-05-03T08:00:00Z")
+    assert snap["final_recommendation"] == am.REC_DEGRADED_FAILURES
+
+
+# ---------------------------------------------------------------------------
+# Determinism + atomic writes + history
+# ---------------------------------------------------------------------------
+
+
+def test_collect_is_deterministic_with_pinned_utc(isolated_dirs) -> None:
+    _write_all_ok(isolated_dirs)
+    a = am.collect_snapshot(frozen_utc="2026-05-03T08:00:00Z")
+    b = am.collect_snapshot(frozen_utc="2026-05-03T08:00:00Z")
+    assert json.dumps(a, sort_keys=True) == json.dumps(b, sort_keys=True)
+
+
+def test_atomic_write_latest_matches_timestamped(isolated_dirs) -> None:
+    _write_all_ok(isolated_dirs)
+    snap = am.collect_snapshot(frozen_utc="2026-05-03T08:00:00Z")
+    paths = am.write_outputs(snap)
+    latest = (isolated_dirs / paths["latest"]).read_bytes()
+    timestamped = (isolated_dirs / paths["timestamped"]).read_bytes()
+    assert latest == timestamped
+
+
+def test_history_is_append_only(isolated_dirs) -> None:
+    _write_all_ok(isolated_dirs)
+    s1 = am.collect_snapshot(frozen_utc="2026-05-03T08:00:00Z")
+    am.write_outputs(s1)
+    s2 = am.collect_snapshot(frozen_utc="2026-05-03T08:01:00Z")
+    am.write_outputs(s2)
+    hist = (isolated_dirs / "logs" / "autonomy_metrics" / "history.jsonl").read_text(
+        encoding="utf-8"
+    )
+    lines = [ln for ln in hist.splitlines() if ln.strip()]
+    assert len(lines) == 2
+    parsed = [json.loads(ln) for ln in lines]
+    assert parsed[0]["generated_at_utc"] == "2026-05-03T08:00:00Z"
+    assert parsed[1]["generated_at_utc"] == "2026-05-03T08:01:00Z"
+
+
+def test_read_latest_snapshot_returns_none_on_missing(isolated_dirs) -> None:
+    snap = am.read_latest_snapshot()
+    assert snap is None
+
+
+def test_read_latest_snapshot_returns_dict_when_present(isolated_dirs) -> None:
+    _write_all_ok(isolated_dirs)
+    s = am.collect_snapshot(frozen_utc="2026-05-03T08:00:00Z")
+    am.write_outputs(s)
+    rt = am.read_latest_snapshot()
+    assert isinstance(rt, dict)
+    assert rt["report_kind"] == "autonomy_metrics_digest"
+
+
+# ---------------------------------------------------------------------------
+# Trend windows
+# ---------------------------------------------------------------------------
+
+
+def test_trends_not_available_without_history(isolated_dirs) -> None:
+    _write_all_ok(isolated_dirs)
+    snap = am.collect_snapshot(frozen_utc="2026-05-03T08:00:00Z")
+    assert snap["trends"]["last_24h"]["runtime"]["status"] == "not_available"
+    assert snap["trends"]["all_time_from_available_history"]["runtime"]["status"] == "not_available"
+
+
+def test_trends_ok_when_history_present(isolated_dirs) -> None:
+    _write_all_ok(isolated_dirs)
+    hist = isolated_dirs / "logs" / "workloop_runtime" / "history.jsonl"
+    hist.parent.mkdir(parents=True, exist_ok=True)
+    rows = [
+        {"generated_at_utc": "2026-05-03T07:00:00Z", "final_recommendation": "all_sources_ok", "loop_health": {"consecutive_failures": 0}},
+        {"generated_at_utc": "2026-05-03T07:30:00Z", "final_recommendation": "runtime_halt_after_3_consecutive_failures", "loop_health": {"consecutive_failures": 3}},
+    ]
+    with hist.open("w", encoding="utf-8") as f:
+        for r in rows:
+            f.write(json.dumps(r) + "\n")
+    snap = am.collect_snapshot(frozen_utc="2026-05-03T08:00:00Z")
+    agg = snap["trends"]["last_24h"]["runtime"]
+    assert agg["status"] == "ok"
+    assert agg["total_runs"] == 2
+    assert agg["failed_runs"] == 1
+    assert agg["consecutive_failures_max"] == 3
+
+
+def test_trends_filter_old_rows_outside_window(isolated_dirs) -> None:
+    _write_all_ok(isolated_dirs)
+    hist = isolated_dirs / "logs" / "workloop_runtime" / "history.jsonl"
+    hist.parent.mkdir(parents=True, exist_ok=True)
+    # One ancient row + one recent row.
+    rows = [
+        {"generated_at_utc": "2024-01-01T00:00:00Z", "final_recommendation": "all_sources_ok", "loop_health": {"consecutive_failures": 0}},
+        {"generated_at_utc": "2026-05-03T07:00:00Z", "final_recommendation": "all_sources_ok", "loop_health": {"consecutive_failures": 0}},
+    ]
+    with hist.open("w", encoding="utf-8") as f:
+        for r in rows:
+            f.write(json.dumps(r) + "\n")
+    snap = am.collect_snapshot(frozen_utc="2026-05-03T08:00:00Z")
+    last_24h = snap["trends"]["last_24h"]["runtime"]
+    all_time = snap["trends"]["all_time_from_available_history"]["runtime"]
+    assert last_24h["status"] == "ok"
+    assert last_24h["total_runs"] == 1
+    assert all_time["status"] == "ok"
+    assert all_time["total_runs"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Source statuses
+# ---------------------------------------------------------------------------
+
+
+def test_source_statuses_always_six_rows_in_canonical_order(isolated_dirs) -> None:
+    snap = am.collect_snapshot(frozen_utc="2026-05-03T08:00:00Z")
+    rows = snap["source_statuses"]
+    assert len(rows) == 6
+    names = [r["source"] for r in rows]
+    expected = [n for n, _ in am.SOURCE_ORDER]
+    assert names == expected
+
+
+def test_source_statuses_path_strings_are_relative(isolated_dirs) -> None:
+    snap = am.collect_snapshot(frozen_utc="2026-05-03T08:00:00Z")
+    for r in snap["source_statuses"]:
+        ap = r["artifact_path"]
+        assert ap.startswith("logs/"), f"non-relative path: {ap!r}"
+
+
+# ---------------------------------------------------------------------------
+# Safety: credential redaction on raw upstream content
+# ---------------------------------------------------------------------------
+
+
+def test_credential_value_in_upstream_artifact_trips_guard(isolated_dirs) -> None:
+    _write_all_ok(isolated_dirs)
+    # Inject a credential-shaped value into the workloop_runtime's
+    # loop_health.last_success_utc — that string is carried verbatim
+    # into ``reliability.last_success_at_utc`` and must trip the
+    # narrow credential-value redaction guard.
+    rt = _ok_workloop_runtime()
+    rt["loop_health"]["last_success_utc"] = "sk-ant-XXXXXXXX"
+    _write(isolated_dirs / "logs" / "workloop_runtime" / "latest.json", rt)
+    with pytest.raises(AssertionError):
+        am.collect_snapshot(frozen_utc="2026-05-03T08:00:00Z")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def test_cli_no_freeform_flags(isolated_dirs) -> None:
+    src = Path(am.__file__).read_text(encoding="utf-8")
+    forbidden = ("--command", "--argv", "--shell", "--exec")
+    for tok in forbidden:
+        assert tok not in src, f"free-form flag in CLI: {tok!r}"
+
+
+def test_cli_collect_no_write_does_not_create_artifact(
+    isolated_dirs, capsys
+) -> None:
+    _write_all_ok(isolated_dirs)
+    rc = am.main(["--collect", "--no-write", "--frozen-utc", "2026-05-03T08:00:00Z"])
+    assert rc == 0
+    assert not (isolated_dirs / "logs" / "autonomy_metrics" / "latest.json").exists()
+
+
+def test_cli_status_with_missing_artifact_exits_nonzero(isolated_dirs) -> None:
+    rc = am.main(["--status"])
+    assert rc != 0
+
+
+def test_cli_collect_writes_artifact(isolated_dirs) -> None:
+    _write_all_ok(isolated_dirs)
+    rc = am.main(["--collect", "--frozen-utc", "2026-05-03T08:00:00Z"])
+    assert rc == 0
+    assert (isolated_dirs / "logs" / "autonomy_metrics" / "latest.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# Schema-doc presence
+# ---------------------------------------------------------------------------
+
+
+def test_schema_doc_exists() -> None:
+    p = REPO_ROOT / "docs" / "governance" / "autonomy_metrics" / "schema.v1.md"
+    assert p.exists()
+    text = p.read_text(encoding="utf-8")
+    assert "v3.15.15.25" in text
+
+
+def test_runbook_doc_exists() -> None:
+    p = REPO_ROOT / "docs" / "governance" / "autonomy_metrics.md"
+    assert p.exists()
+    text = p.read_text(encoding="utf-8")
+    assert "v3.15.15.25" in text
+
+
+# ---------------------------------------------------------------------------
+# Frozen contract paths unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_collect_does_not_mutate_frozen_contract_paths(isolated_dirs) -> None:
+    """Defensive: the digest dir is under logs/, never under
+    research/. Verify the only writes target logs/autonomy_metrics."""
+    _write_all_ok(isolated_dirs)
+    snap = am.collect_snapshot(frozen_utc="2026-05-03T08:00:00Z")
+    paths = am.write_outputs(snap)
+    for label, rel in paths.items():
+        assert rel.startswith("logs/autonomy_metrics/"), f"{label} -> {rel}"

--- a/tests/unit/test_dashboard_api_agent_control.py
+++ b/tests/unit/test_dashboard_api_agent_control.py
@@ -227,6 +227,27 @@ def test_status_payload_includes_approval_policy_block(client) -> None:
         assert "reason" in ap_block
 
 
+def test_status_payload_includes_autonomy_metrics_block(client) -> None:
+    """v3.15.15.25: status payload now also carries a read-only
+    autonomy_metrics summary. The block must not be silently OK on
+    error — it either reports ``ok`` with a populated ``data`` dict
+    or ``not_available`` with a reason."""
+    body = client.get("/api/agent-control/status").get_json()
+    assert "autonomy_metrics" in body
+    am_block = body["autonomy_metrics"]
+    assert am_block["status"] in ("ok", "not_available")
+    if am_block["status"] == "ok":
+        data = am_block["data"]
+        assert data["safe_to_execute"] is False
+        assert "final_recommendation" in data
+        assert "throughput_summary" in data
+        assert "operator_burden_summary" in data
+        assert "reliability_summary" in data
+        assert "safety_summary" in data
+    else:
+        assert "reason" in am_block
+
+
 def test_status_payload_includes_workloop_runtime_block(client) -> None:
     """v3.15.15.22: status payload now carries a workloop_runtime
     summary. When the artifact is missing the block reports


### PR DESCRIPTION
## Summary

Adds `reporting.autonomy_metrics` — a deterministic, stdlib-only metrics collector that aggregates the existing reporting artifacts (workloop_runtime, recurring_maintenance, proposal_queue, approval_inbox, github_pr_lifecycle, execute_safe_controls) into one read-only digest answering the throughput / operator-burden / reliability / safety / trend questions for the autonomous development loop.

This release **measures** the system. It does not expand execution authority, add approval mutation, add browser push, add new risky automation, or change scheduling.

## Hard guarantees

- Stdlib-only. No subprocess, no `gh`, no `git`, no network.
- Atomic writes via `tmp` + `os.replace`; history is append-only.
- Narrow credential-value redaction (`sk-ant-`, `ghp_`, `github_pat_`, `AKIA`, `BEGIN PRIVATE KEY`).
- Missing / malformed artifacts are COUNTED under `reliability` and surfaced under `source_statuses` — never silently coerced to ok.
- Deterministic for a fixed input set when `generated_at_utc` is pinned via `--frozen-utc`.
- `safety.high_or_unknown_executable_count` is expected to be 0; non-zero flips `final_recommendation` to `unsafe_state_detected`.
- `safe_to_execute` is hard-coded `false` at the digest level.
- All counter dicts emit keys in alphabetical order.

## Schema highlights

- `schema_version=1`, `metrics_version=v1`, `module_version=v3.15.15.25`.
- 5 metric blocks: `source_statuses`, `throughput`, `operator_burden`, `reliability`, `safety`, `trends`.
- Trends evaluated over `current` / `last_24h` / `last_7d` / `all_time_from_available_history` — `not_available` when no history.
- `final_recommendation` enum: `healthy`, `degraded_missing_sources`, `degraded_failures`, `action_required`, `unsafe_state_detected`, `not_available`.

## CLI

- `python -m reporting.autonomy_metrics --collect`
- `python -m reporting.autonomy_metrics --collect --no-write`
- `python -m reporting.autonomy_metrics --collect --frozen-utc <ts>`
- `python -m reporting.autonomy_metrics --status`

No free-form command flags.

## Surface (read-only projection)

- `dashboard.api_agent_control`: status payload now carries an `autonomy_metrics` summary block (`not_available` semantics on error).
- Frontend AgentControl Status card: renders metrics row + recommendation pill + operator-actions count when artifact is available.
- `AgentControlStatus` TS interface extended.

## Tests added

- `tests/unit/test_autonomy_metrics.py` (38 cases): empty/missing artifacts, malformed counts, throughput/burden/reliability/safety counters, deterministic output with pinned utc, atomic write byte-identity, history append, trend windows with/without history and outside-window filter, source-order invariants, credential-value redaction trip, no-subprocess/no-gh/no-git invariants, no-freeform-flag CLI invariants, schema-doc + runbook presence, frozen contract paths unchanged.
- `tests/unit/test_dashboard_api_agent_control.py`: +1 autonomy_metrics status block case.
- Frontend `AgentControlPolish.test.tsx`: +2 metrics row cases.

## Validation gates green

- governance_lint OK (15 agents, 3 workflows).
- \`pytest tests/smoke\`: 14/14.
- targeted unit suite: 76/76.
- frontend vitest: 62/62 across 8 files.
- frontend build: green.
- frozen contract sha256 unchanged (\`4a567bd6...\` / \`ff15b8c4...\`).

## Non-goals (explicitly out of scope)

- No POST/PUT/PATCH/DELETE API.
- No execute/approve/reject/ack/resolve/merge buttons.
- No browser push.
- No new automation authority.
- No scheduling changes.
- No Dependabot execute-safe enablement.
- No high-risk execution.
- No arbitrary command execution.
- No subprocess/gh/git/network required.
- No \`.claude/**\` changes.
- No \`dashboard/dashboard.py\` changes.
- No frozen contract changes.
- No live/paper/shadow/trading/risk behavior changes.
- No CI/test weakening.
- No paid/external telemetry/signup/secrets.
- No api_execute_safe_controls wiring.

## Test plan

- [ ] CI gates green (governance lint, smoke, unit, frontend, governance smoke)
- [ ] Frozen-contract hashes unchanged on main
- [ ] Read-only PWA renders new autonomy_metrics row + recommendation
- [ ] No mutation endpoints introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)