### PR TITLE
fix(v3.15.15.25.1): approval inbox redaction false-positive cleanup

### DIFF
--- a/reporting/agent_audit_summary.py
+++ b/reporting/agent_audit_summary.py
@@ -342,7 +342,18 @@ def _walk_strings(obj: Any) -> Iterator[str]:
             yield from _walk_strings(v)
 
 
-_SENSITIVE_FRAGMENTS: tuple[str, ...] = (
+# v3.15.15.25.1 — these path strings are NO-TOUCH paths whose
+# CONTENTS must never be surfaced, but whose names are legitimate
+# evidence in inbox / proposal-queue / governance metadata. The
+# guard intentionally does NOT trip on substring matches against
+# these fragments — that produced a false positive on every
+# proposal that listed ``config/config.yaml`` as an
+# ``affected_files`` entry, halting the autonomous workloop.
+#
+# This list is preserved for documentation only — downstream
+# modules import it as ``KNOWN_NO_TOUCH_PATH_REFERENCES`` to
+# explicitly mark "this path mention is expected".
+KNOWN_NO_TOUCH_PATH_REFERENCES: tuple[str, ...] = (
     "config/config.yaml",
     "live_gate.secret",
     "fred.secret",
@@ -352,19 +363,37 @@ _SENSITIVE_FRAGMENTS: tuple[str, ...] = (
 
 
 def assert_no_secrets(snapshot: dict[str, Any]) -> None:
-    """Raise ``AssertionError`` if any string in the snapshot matches a
-    forbidden credential pattern or sensitive-path fragment."""
+    """Raise ``AssertionError`` if any string in the snapshot looks
+    like a credential VALUE.
+
+    Credential values match one of the narrow regex patterns in
+    ``_FORBIDDEN_PATTERNS`` (Anthropic ``sk-ant-`` keys, GitHub
+    ``ghp_`` / ``github_pat_`` tokens, AWS ``AKIA`` keys, PEM
+    private-key blocks). These never have a legitimate reason to
+    appear in any reporting projection — the writer redacts them and
+    this guard is the defense-in-depth safety net.
+
+    Path-shaped strings (e.g. ``config/config.yaml``,
+    ``automation/live_gate.py``, ``research/research_latest.json``)
+    are explicitly ALLOWED. The autonomous-development surface
+    legitimately surfaces these names as ``affected_files`` /
+    ``forbidden_actions`` / ``protected_paths_touched`` evidence;
+    the operator needs to see *what* the proposal touches in order
+    to decide.
+
+    The previous broader substring check on ``config/config.yaml``
+    et al. produced false positives on every legitimate proposal
+    that referenced a no-touch path, which halted the approval
+    inbox runtime in v3.15.15.25 (see release notes).
+
+    Mirror of the v3.15.15.22 narrowing in
+    ``reporting.workloop_runtime._assert_no_credential_values``.
+    """
     for s in _walk_strings(snapshot):
         for pat in _FORBIDDEN_PATTERNS:
             if pat.search(s):
                 raise AssertionError(
                     f"agent_audit_summary leaked credential-like string: pattern={pat.pattern!r}"
-                )
-        lowered = s.lower()
-        for frag in _SENSITIVE_FRAGMENTS:
-            if frag in lowered:
-                raise AssertionError(
-                    f"agent_audit_summary leaked sensitive path fragment: {frag!r}"
                 )
 
 

--- a/reporting/governance_status.py
+++ b/reporting/governance_status.py
@@ -402,7 +402,12 @@ _FORBIDDEN_VALUE_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"),
 )
 
-_FORBIDDEN_VALUE_FRAGMENTS: tuple[str, ...] = (
+# v3.15.15.25.1 — these are NO-TOUCH paths whose contents must
+# never be surfaced, but whose names are legitimate evidence.
+# Preserved here for documentation only — the guard intentionally
+# does NOT trip on substring matches against these fragments. See
+# docstring on ``assert_no_secrets`` for the rationale.
+KNOWN_NO_TOUCH_PATH_REFERENCES: tuple[str, ...] = (
     "config/config.yaml",
     "live_gate.secret",
     "fred.secret",
@@ -425,25 +430,30 @@ def _walk_strings(obj: Any) -> Iterable[str]:
 
 
 def assert_no_secrets(snapshot: dict[str, Any]) -> None:
-    """Raise ``AssertionError`` if the snapshot contains a forbidden
-    string. The check is conservative: any high-entropy credential
-    pattern OR any literal sensitive-path fragment counts.
+    """Raise ``AssertionError`` if the snapshot contains a credential
+    VALUE.
 
-    The snapshot is supposed to be entirely path/state metadata — there
-    is no legitimate reason for a credential or secret-path string to
-    appear in it.
+    Credential values match one of the narrow regex patterns in
+    ``_FORBIDDEN_VALUE_PATTERNS`` (Anthropic ``sk-ant-`` keys,
+    GitHub ``ghp_`` / ``github_pat_`` tokens, AWS ``AKIA`` keys,
+    PEM private-key blocks). These never have a legitimate reason
+    to appear in any reporting projection.
+
+    Path-shaped strings (e.g. ``config/config.yaml``,
+    ``automation/live_gate.py``, ``research/research_latest.json``)
+    are explicitly ALLOWED. They are legitimate path-reference
+    evidence in metadata; they are not credentials.
+
+    Mirror of the v3.15.15.22 narrowing in
+    ``reporting.workloop_runtime._assert_no_credential_values`` and
+    the v3.15.15.25.1 narrowing in
+    ``reporting.agent_audit_summary.assert_no_secrets``.
     """
     for s in _walk_strings(snapshot):
         for pat in _FORBIDDEN_VALUE_PATTERNS:
             if pat.search(s):
                 raise AssertionError(
                     f"governance_status leaked credential-like string: pattern={pat.pattern!r}"
-                )
-        lowered = s.lower()
-        for frag in _FORBIDDEN_VALUE_FRAGMENTS:
-            if frag in lowered:
-                raise AssertionError(
-                    f"governance_status leaked sensitive path fragment: {frag!r}"
                 )
 
 

--- a/tests/unit/test_agent_audit_summary.py
+++ b/tests/unit/test_agent_audit_summary.py
@@ -271,9 +271,49 @@ def test_assert_no_secrets_catches_credential_pattern() -> None:
         agent_audit_summary.assert_no_secrets(leaky)
 
 
-def test_assert_no_secrets_catches_sensitive_path_fragment() -> None:
-    leaky = {"x": "config/config.yaml"}
-    with pytest.raises(AssertionError, match="sensitive path"):
+def test_assert_no_secrets_allows_no_touch_path_references() -> None:
+    """v3.15.15.25.1: ``config/config.yaml`` (and the other entries in
+    ``KNOWN_NO_TOUCH_PATH_REFERENCES``) are NO-TOUCH paths whose
+    *contents* must never be surfaced, but whose *names* are
+    legitimate evidence in ``affected_files`` / ``forbidden_actions``
+    metadata. The guard must not trip on path-shaped strings — the
+    previous broader substring check halted the approval inbox
+    runtime on every proposal that referenced a no-touch path.
+    """
+    for path_ref in agent_audit_summary.KNOWN_NO_TOUCH_PATH_REFERENCES:
+        agent_audit_summary.assert_no_secrets({"x": path_ref})  # must not raise
+
+    # Also accept paths embedded in larger strings — proposals
+    # commonly inline these in summaries.
+    agent_audit_summary.assert_no_secrets(
+        {"summary": "edits config/config.yaml are forbidden"}
+    )
+    agent_audit_summary.assert_no_secrets(
+        {"affected_files": ["config/config.yaml", "SECURITY.md"]}
+    )
+
+
+def test_assert_no_secrets_still_catches_anthropic_key() -> None:
+    leaky = {"x": "leak: sk-ant-AAAAAAAA1234"}
+    with pytest.raises(AssertionError, match="credential-like"):
+        agent_audit_summary.assert_no_secrets(leaky)
+
+
+def test_assert_no_secrets_still_catches_aws_key() -> None:
+    leaky = {"x": "AKIAEXAMPLE12345"}
+    with pytest.raises(AssertionError, match="credential-like"):
+        agent_audit_summary.assert_no_secrets(leaky)
+
+
+def test_assert_no_secrets_still_catches_pem_block() -> None:
+    leaky = {"x": "-----BEGIN PRIVATE KEY-----"}
+    with pytest.raises(AssertionError, match="credential-like"):
+        agent_audit_summary.assert_no_secrets(leaky)
+
+
+def test_assert_no_secrets_still_catches_github_pat() -> None:
+    leaky = {"x": "github_pat_AAAAAAAAAAAA"}
+    with pytest.raises(AssertionError, match="credential-like"):
         agent_audit_summary.assert_no_secrets(leaky)
 
 

--- a/tests/unit/test_approval_inbox.py
+++ b/tests/unit/test_approval_inbox.py
@@ -1120,3 +1120,143 @@ def test_no_subprocess_or_gh_or_git_in_module() -> None:
     forbidden = ('"gh"', "'gh'", '"git"', "'git'", "Popen")
     for token in forbidden:
         assert token not in src, f"forbidden token in approval_inbox.py: {token!r}"
+
+
+# ---------------------------------------------------------------------------
+# v3.15.15.25.1 — redaction false-positive regression
+# ---------------------------------------------------------------------------
+
+
+def test_proposal_with_no_touch_path_in_affected_files_is_not_blocked_by_secret_guard(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Regression for v3.15.15.25 -> v3.15.15.25.1.
+
+    The approval_inbox builds a snap that legitimately surfaces the
+    no-touch path ``config/config.yaml`` as ``affected_files`` /
+    proposal evidence. The pre-fix ``assert_no_secrets`` rejected
+    this with ``AssertionError: agent_audit_summary leaked sensitive
+    path fragment: 'config/config.yaml'``, halting the autonomous
+    workloop. The fix narrows the guard to credential VALUES only;
+    path-shaped strings flow through.
+    """
+    # Build a minimal proposal_queue digest containing the no-touch
+    # path as legitimate evidence — this is the exact shape that
+    # tripped the original failure.
+    pq_path = tmp_path / "logs" / "proposal_queue" / "latest.json"
+    pq_path.parent.mkdir(parents=True, exist_ok=True)
+    pq_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "report_kind": "proposal_queue_digest",
+                "proposals": [
+                    _proposal(
+                        proposal_id="p_path_evidence",
+                        title="No-touch path mention",
+                        summary="Touches a protected path",
+                        proposal_type="governance_change",
+                        risk_class="HIGH",
+                        status="needs_human",
+                        affected_files=["config/config.yaml", "SECURITY.md"],
+                    )
+                ],
+                "counts": {
+                    "total": 1,
+                    "by_status": {"needs_human": 1},
+                    "by_risk": {"HIGH": 1},
+                    "by_type": {"governance_change": 1},
+                },
+                "final_recommendation": "needs_human_on_1_items",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(ai, "SOURCE_PROPOSAL_QUEUE", pq_path)
+    # Redirect the other sources to non-existent paths so the test
+    # is hermetic.
+    monkeypatch.setattr(
+        ai, "SOURCE_PR_LIFECYCLE", tmp_path / "_missing_pr_lifecycle.json"
+    )
+    monkeypatch.setattr(
+        ai, "SOURCE_WORKLOOP", tmp_path / "_missing_workloop.json"
+    )
+    monkeypatch.setattr(
+        ai,
+        "SOURCE_WORKLOOP_RUNTIME",
+        tmp_path / "_missing_workloop_runtime.json",
+    )
+    monkeypatch.setattr(
+        ai,
+        "SOURCE_RECURRING_MAINTENANCE",
+        tmp_path / "_missing_recurring_maintenance.json",
+    )
+
+    # Must not raise: the path-shaped string is legitimate evidence.
+    snap = ai.collect_snapshot(mode="dry-run")
+    assert snap["report_kind"] == "approval_inbox_digest"
+    flat = json.dumps(snap)
+    assert "config/config.yaml" in flat, (
+        "the path-evidence string must survive the secret guard"
+    )
+    # Sanity check: the digest identifies the proposal as a
+    # protected_path_change (its path matches PROTECTED_GLOBS).
+    items = snap.get("items") or []
+    assert any(
+        i.get("category") == "protected_path_change" for i in items
+    ), items
+
+
+def test_credential_value_in_proposal_still_blocked(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The narrowed guard must still block actual credential VALUES."""
+    pq_path = tmp_path / "logs" / "proposal_queue" / "latest.json"
+    pq_path.parent.mkdir(parents=True, exist_ok=True)
+    pq_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "report_kind": "proposal_queue_digest",
+                "proposals": [
+                    _proposal(
+                        proposal_id="p_leak",
+                        title="Leaky proposal",
+                        summary="contains a leaked sk-ant-AAAAAAAA12345 fragment",
+                        proposal_type="approval_required",
+                        risk_class="HIGH",
+                        status="needs_human",
+                        affected_files=[],
+                    )
+                ],
+                "counts": {
+                    "total": 1,
+                    "by_status": {"needs_human": 1},
+                    "by_risk": {"HIGH": 1},
+                    "by_type": {"approval_required": 1},
+                },
+                "final_recommendation": "needs_human_on_1_items",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(ai, "SOURCE_PROPOSAL_QUEUE", pq_path)
+    monkeypatch.setattr(
+        ai, "SOURCE_PR_LIFECYCLE", tmp_path / "_missing_pr_lifecycle.json"
+    )
+    monkeypatch.setattr(
+        ai, "SOURCE_WORKLOOP", tmp_path / "_missing_workloop.json"
+    )
+    monkeypatch.setattr(
+        ai,
+        "SOURCE_WORKLOOP_RUNTIME",
+        tmp_path / "_missing_workloop_runtime.json",
+    )
+    monkeypatch.setattr(
+        ai,
+        "SOURCE_RECURRING_MAINTENANCE",
+        tmp_path / "_missing_recurring_maintenance.json",
+    )
+    with pytest.raises(AssertionError, match="credential-like"):
+        ai.collect_snapshot(mode="dry-run")

--- a/tests/unit/test_dashboard_api_agent_control.py
+++ b/tests/unit/test_dashboard_api_agent_control.py
@@ -283,17 +283,22 @@ def test_payload_with_credential_string_is_refused(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """If a future regression slips a credential-shaped string into a
+    """If a future regression slips a credential-shaped VALUE into a
     surfaced artifact, ``assert_no_secrets`` should raise inside
     ``_safe_jsonify`` — the surface refuses to leak rather than
-    soften the rule."""
+    soften the rule.
+
+    v3.15.15.25.1: switched from the path-shaped string
+    ``config/config.yaml`` (which is now a legitimate path
+    reference) to an Anthropic-key-shaped credential value. Path
+    references are no longer rejected; only credential VALUES are.
+    """
     p = tmp_path / "logs" / "github_pr_lifecycle" / "latest.json"
     p.parent.mkdir(parents=True, exist_ok=True)
-    # Include a sensitive-path fragment in a string field.
     payload = {
         "schema_version": 1,
         "report_kind": "github_pr_lifecycle_digest",
-        "evil_field": "config/config.yaml",
+        "evil_field": "sk-ant-AAAAAAAA1234",
     }
     p.write_text(json.dumps(payload), encoding="utf-8")
     monkeypatch.setattr(ac, "PR_LIFECYCLE_LATEST", p)

--- a/tests/unit/test_dashboard_api_approval_inbox.py
+++ b/tests/unit/test_dashboard_api_approval_inbox.py
@@ -112,12 +112,16 @@ def test_valid_artifact_passes_through(
 def test_credential_string_in_artifact_is_refused(
     client, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """v3.15.15.25.1: the secret guard rejects credential VALUES;
+    path-shaped strings are legitimate evidence and flow through.
+    Use an Anthropic-key-shaped value to verify the value-rejection
+    behavior."""
     p = tmp_path / "logs" / "approval_inbox" / "latest.json"
     p.parent.mkdir(parents=True, exist_ok=True)
     payload = {
         "schema_version": 1,
         "report_kind": "approval_inbox_digest",
-        "evil_field": "config/config.yaml",
+        "evil_field": "sk-ant-AAAAAAAA1234",
     }
     p.write_text(json.dumps(payload), encoding="utf-8")
     monkeypatch.setattr(ac, "APPROVAL_INBOX_LATEST", p)

--- a/tests/unit/test_dashboard_api_proposal_queue.py
+++ b/tests/unit/test_dashboard_api_proposal_queue.py
@@ -119,12 +119,16 @@ def test_valid_artifact_passes_through(
 def test_credential_string_in_artifact_is_refused(
     client, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """v3.15.15.25.1: the secret guard rejects credential VALUES;
+    path-shaped strings are legitimate evidence and flow through.
+    Use an Anthropic-key-shaped value to verify the value-rejection
+    behavior."""
     p = tmp_path / "logs" / "proposal_queue" / "latest.json"
     p.parent.mkdir(parents=True, exist_ok=True)
     payload = {
         "schema_version": 1,
         "report_kind": "proposal_queue_digest",
-        "evil_field": "config/config.yaml",
+        "evil_field": "sk-ant-AAAAAAAA1234",
     }
     p.write_text(json.dumps(payload), encoding="utf-8")
     monkeypatch.setattr(ac, "PROPOSAL_QUEUE_LATEST", p)

--- a/tests/unit/test_governance_status.py
+++ b/tests/unit/test_governance_status.py
@@ -343,9 +343,26 @@ def test_assert_no_secrets_catches_credential_pattern() -> None:
         governance_status.assert_no_secrets(leaky)
 
 
-def test_assert_no_secrets_catches_sensitive_path_fragment() -> None:
-    leaky = {"path": "config/config.yaml"}
-    with pytest.raises(AssertionError, match="sensitive path"):
+def test_assert_no_secrets_allows_no_touch_path_references() -> None:
+    """v3.15.15.25.1: path-shaped strings are legitimate metadata.
+    The previous broader substring check produced false positives
+    that halted the autonomous workloop."""
+    for path_ref in governance_status.KNOWN_NO_TOUCH_PATH_REFERENCES:
+        governance_status.assert_no_secrets({"path": path_ref})  # must not raise
+    governance_status.assert_no_secrets(
+        {"summary": "edits to config/config.yaml are forbidden"}
+    )
+
+
+def test_assert_no_secrets_still_catches_aws_key() -> None:
+    leaky = {"x": "AKIAEXAMPLE12345"}
+    with pytest.raises(AssertionError, match="credential-like"):
+        governance_status.assert_no_secrets(leaky)
+
+
+def test_assert_no_secrets_still_catches_pem_block() -> None:
+    leaky = {"x": "-----BEGIN PRIVATE KEY-----"}
+    with pytest.raises(AssertionError, match="credential-like"):
         governance_status.assert_no_secrets(leaky)
 
 


### PR DESCRIPTION
## Summary

Narrows the redaction guards in `reporting.agent_audit_summary` and `reporting.governance_status` from the over-broad "substring match against any sensitive path fragment" to the narrow "match against credential VALUE patterns only", consistent with the v3.15.15.22 workloop_runtime narrowing and the v3.15.15.24 approval_policy guard.

## Bug

`python -m reporting.approval_inbox` (and downstream `workloop_runtime` and `autonomy_metrics` that depend on its artifact) raised `AssertionError` on the literal no-touch config-yaml path string. The trip was a **false positive**: the path is a no-touch path that `proposal_queue` legitimately surfaces as `affected_files` evidence. The path **string** is metadata; only the file **contents** are sensitive.

### Result before fix
- `logs/approval_inbox/latest.json` was missing.
- `workloop_runtime` accumulated 31 `consecutive_failures` and reported `runtime_halt_after_31_consecutive_failures`.
- `autonomy_metrics` reported `degraded_missing_sources` with `missing_artifact_count=3`.
- PWA Approval Inbox card had no real artifact backing.

## Fix

- `reporting/agent_audit_summary.py`: `assert_no_secrets` now only checks the credential-VALUE regex patterns (`sk-ant-`, `ghp_`, `github_pat_`, `AKIA`, `BEGIN PRIVATE KEY`). The previous path-fragment substring check is removed. The path list is preserved as `KNOWN_NO_TOUCH_PATH_REFERENCES` for documentation.
- `reporting/governance_status.py`: same narrowing applied to its duplicate `assert_no_secrets`. Same constant rename.

## Required behavior preserved

- Actual credential VALUES still raise `AssertionError`.
- Path-shaped strings flow through as legitimate evidence.
- Writer-level redaction in `agent_audit` (`[REDACTED]` substitution for high-entropy patterns) is unchanged.
- No allowlist of credential shapes; the regex check is exactly the same as before.

## Tests

- `test_agent_audit_summary.py`: the prior `catches_sensitive_path_fragment` test is replaced with `allows_no_touch_path_references` (asserts the OPPOSITE). +4 new positive credential-value tests (Anthropic / GitHub PAT / AWS / PEM).
- `test_governance_status.py`: same swap + 2 new positive credential-value tests.
- `test_approval_inbox.py`: +2 end-to-end regression tests proving (a) a proposal with the no-touch path in `affected_files` completes `collect_snapshot` without raising, and (b) a credential-shaped value in proposal summary still raises.
- `test_dashboard_api_agent_control.py` and the two sibling route tests: the previous test inputs that used the no-touch path as the "evil field" are switched to a fake Anthropic key shape so they continue to verify the credential-VALUE rejection.

## Validation gates green

- governance_lint OK (15 agents, 3 workflows).
- \`pytest tests/smoke\`: 14/14.
- \`pytest tests/unit\`: **3060 passed, 3 skipped, 4 warnings** (was 3052 pre-fix; +8 new positive cases).
- \`python -m reporting.approval_inbox\`: writes \`logs/approval_inbox/latest.json\` successfully.
- \`python -m reporting.workloop_runtime --once\`: \`consecutive_failures\` dropped from 31 to 0; \`final_recommendation = degraded_not_available_1\`.
- \`python -m reporting.autonomy_metrics --collect --no-write\`: \`missing_artifact_count\` dropped from 3 to 2.
- Frozen contract sha256 unchanged.

## Non-goals (explicitly out of scope)

- No \`.claude/**\` changes.
- No \`dashboard/dashboard.py\` changes.
- No frozen contract changes.
- No live/paper/shadow/trading/risk behavior changes.
- No CI/test weakening.
- No browser push.
- No new mutation API.
- No execute/approve/reject/merge buttons.
- No \`api_execute_safe_controls\` wiring.
- No paid/external telemetry/signup/secrets.
- No new feature.

## Test plan

- [ ] CI gates green (governance lint, smoke, unit, frontend, governance smoke)
- [ ] Frozen-contract hashes unchanged on main
- [ ] Approval inbox reporter completes end-to-end on the VPS
- [ ] Workloop runtime no longer halts on the path-mention false positive
- [ ] Autonomy metrics improves (one fewer missing source)

🤖 Generated with [Claude Code](https://claude.com/claude-code)