### PR TITLE
feat(v3.15.15.26): mobile-first Agent Control PWA UX rebuild

### DIFF
--- a/docs/governance/mobile_agent_control_pwa.md
+++ b/docs/governance/mobile_agent_control_pwa.md
@@ -1,14 +1,51 @@
 # Mobile-first Agent Control PWA — Operator Runbook
 
 > Module: `dashboard.api_agent_control` (backend) + `frontend/src/routes/AgentControl.tsx` (frontend)
-> Release: v3.15.15.18
+> Release: v3.15.15.26 (mobile-first IA rebuild on top of v3.15.15.18)
 > Sibling lifecycle modules: `reporting.autonomous_workloop`,
-> `reporting.github_pr_lifecycle`
+> `reporting.github_pr_lifecycle`,
+> `reporting.workloop_runtime`,
+> `reporting.recurring_maintenance`,
+> `reporting.approval_policy`,
+> `reporting.autonomy_metrics`
 
-This is the operator-facing runbook for the v3.15.15.18 mobile-first
-Agent Control PWA. It explains what the app shows, what it does NOT
-do, how to install it on a phone, and the wiring step required to
-move it from "ships in the build" to "served on production".
+This is the operator-facing runbook for the Agent Control PWA.
+It explains what the app shows, what it does NOT do, how it is
+laid out for thumb-first mobile use, and the wiring step required
+to move it from "ships in the build" to "served on production".
+
+## v3.15.15.26 — Mobile-first IA rebuild
+
+The PWA now uses a **5-tab bottom navigation** on mobile (top
+sticky tabs ≥ 720px) and groups its existing read-only cards
+into operator-meaningful sections instead of a single long grid.
+
+| Tab | Purpose | Cards |
+|---|---|---|
+| **Overview** | Is the system healthy? | Status (governance + frozen + workloop runtime + recurring maintenance + approval policy + autonomy metrics, all as compact rows) |
+| **Inbox** | What needs Joery? | Approval Inbox + Proposal Queue |
+| **Runtime** | Background telemetry | Autonomous Workloop digest + Activity (audit timeline) |
+| **PRs** | Code lifecycle (read-only) | GitHub PR Lifecycle + Execute-safe Catalog |
+| **About** | Meta | Notifications placeholder |
+
+The header carries a small **read-only badge** below the title
+to re-affirm the safety posture; the page summary banner remains
+the primary at-a-glance signal.
+
+Hard guarantees preserved:
+
+* Touch targets ≥ 44 px (Apple HIG / WCAG 2.5.5).
+* No horizontal scroll on phone-portrait.
+* Inactive sections are `hidden` (excluded from the AT tree but
+  still queryable from React Testing Library so the existing
+  card test suite continues to work).
+* No new external dependencies. No new network egress. No new
+  service-worker scope. No browser push.
+* No execute / approve / reject / merge buttons anywhere in the
+  rendered DOM (verified by a regression test that scans every
+  `<button>` for those verbs).
+* PWA manifest, service worker, install behavior, and the
+  `/agent-control` deep link are unchanged.
 
 ## What this is
 

--- a/frontend/src/routes/AgentControl.tsx
+++ b/frontend/src/routes/AgentControl.tsx
@@ -1,13 +1,29 @@
-// Mobile-first read-only Agent Control PWA — v3.15.15.18.
+// Mobile-first read-only Agent Control PWA — v3.15.15.26.
 //
 // Hard guarantees enforced by structure:
 //   - No execute / approve / reject / merge buttons. The only
-//     interactive control is a single "Vernieuw" (refresh) button
-//     that re-fetches the same five GET endpoints.
+//     interactive controls are the bottom-nav tabs (which only
+//     change the active section) and a single "Vernieuw" refresh
+//     button that re-fetches the same GET endpoints. Tabs and
+//     refresh are local state changes; nothing mutates server
+//     state.
 //   - Cards render an empty / not_available state when their backing
 //     artifact is missing or malformed; nothing is silently OK.
-//   - Notification center is a placeholder; v3.15.15.18 does not ship
-//     browser push.
+//   - Notification center is a placeholder; browser push is not
+//     wired and is intentionally out of scope.
+//
+// v3.15.15.26 — IA rebuild for genuinely mobile-first UX:
+//   - 5-tab bottom navigation (Overview / Inbox / Runtime / PRs /
+//     About). Thumb-reachable; sticky bottom on mobile, top tabs
+//     on desktop ≥ 720px. No external dependencies.
+//   - Operator mental model: Overview answers "is the system
+//     healthy?", Inbox answers "what needs Joery?", Runtime shows
+//     background telemetry, PRs covers code lifecycle, About
+//     surfaces policy + meta.
+//   - Cards retain their data-testid hooks so the existing
+//     read-only tests still pass; inactive sections use the
+//     ``hidden`` attribute (still queryable from RTL but excluded
+//     from the AT tree).
 //
 // The full feature roadmap (proposal queue → approval inbox →
 // execute-safe controls → browser push → metrics) is documented in
@@ -762,6 +778,123 @@ function NotificationsCard({
   );
 }
 
+// ---------------------------------------------------------------------------
+// Section model — operator mental model, mobile-first
+// ---------------------------------------------------------------------------
+
+type SectionId = "overview" | "inbox" | "runtime" | "prs" | "about";
+
+interface SectionMeta {
+  id: SectionId;
+  label: string;
+  glyph: string;
+  description: string;
+}
+
+const SECTIONS: readonly SectionMeta[] = [
+  {
+    id: "overview",
+    label: "Overview",
+    glyph: "◉",
+    description: "system health summary",
+  },
+  {
+    id: "inbox",
+    label: "Inbox",
+    glyph: "✉",
+    description: "what needs Joery",
+  },
+  {
+    id: "runtime",
+    label: "Runtime",
+    glyph: "▶",
+    description: "background workloop / activity",
+  },
+  {
+    id: "prs",
+    label: "PRs",
+    glyph: "⤴",
+    description: "code lifecycle (read-only)",
+  },
+  {
+    id: "about",
+    label: "About",
+    glyph: "ⓘ",
+    description: "policy + notifications",
+  },
+] as const;
+
+// --- BottomNav: thumb-reachable section switcher ---
+function BottomNav({
+  active,
+  onChange,
+}: {
+  active: SectionId;
+  onChange: (id: SectionId) => void;
+}) {
+  return (
+    <nav
+      className="agent-control__nav"
+      data-testid="agent-control-nav"
+      role="tablist"
+      aria-label="Agent control sections"
+    >
+      {SECTIONS.map((s) => {
+        const isActive = s.id === active;
+        return (
+          <button
+            key={s.id}
+            type="button"
+            role="tab"
+            aria-selected={isActive}
+            aria-controls={`section-${s.id}`}
+            id={`tab-${s.id}`}
+            className={`agent-control__nav-tab ${
+              isActive ? "agent-control__nav-tab--active" : ""
+            }`}
+            data-testid={`nav-tab-${s.id}`}
+            onClick={() => onChange(s.id)}
+            tabIndex={isActive ? 0 : -1}
+          >
+            <span aria-hidden="true" className="agent-control__nav-glyph">
+              {s.glyph}
+            </span>
+            <span className="agent-control__nav-label">{s.label}</span>
+          </button>
+        );
+      })}
+    </nav>
+  );
+}
+
+// --- Section: visibility wrapper that keeps hidden sections in the DOM ---
+function Section({
+  id,
+  active,
+  ariaLabel,
+  children,
+}: {
+  id: SectionId;
+  active: boolean;
+  ariaLabel: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section
+      id={`section-${id}`}
+      role="tabpanel"
+      aria-labelledby={`tab-${id}`}
+      aria-label={ariaLabel}
+      data-testid={`section-${id}`}
+      data-section-active={active ? "true" : "false"}
+      hidden={!active}
+      className="agent-control__section"
+    >
+      {children}
+    </section>
+  );
+}
+
 // --- Route ---
 export function AgentControl() {
   const [status, setStatus] = useState<AgentControlStatus | null>(null);
@@ -779,6 +912,7 @@ export function AgentControl() {
     useState<AgentControlExecuteSafe | null>(null);
   const [loading, setLoading] = useState<boolean>(false);
   const [refreshedAt, setRefreshedAt] = useState<string>("");
+  const [activeSection, setActiveSection] = useState<SectionId>("overview");
 
   const loadAll = useCallback(async () => {
     setLoading(true);
@@ -819,7 +953,16 @@ export function AgentControl() {
     >
       <header className="agent-control__header" role="banner">
         <div className="agent-control__title-row">
-          <h1 id="agent-control-title">Agent Control</h1>
+          <div>
+            <h1 id="agent-control-title">Agent Control</h1>
+            <p
+              className="agent-control__safety-badge"
+              data-testid="agent-control-safety-badge"
+              aria-label="Read-only surface"
+            >
+              <span aria-hidden="true">🔒</span> read-only
+            </p>
+          </div>
           <button
             type="button"
             className="agent-control__refresh"
@@ -833,7 +976,7 @@ export function AgentControl() {
           </button>
         </div>
         <p className="agent-control__subtitle">
-          Read-only observability surface — v3.15.15.21.1.
+          Read-only observability surface — v3.15.15.26.
         </p>
         <div
           className={`agent-control__summary agent-control__summary--${summary.tone}`}
@@ -856,24 +999,59 @@ export function AgentControl() {
         ) : null}
       </header>
 
-      <section
-        className="agent-control__grid"
-        data-testid="agent-control-grid"
-        aria-label="Agent control kaarten"
+      <BottomNav active={activeSection} onChange={setActiveSection} />
+
+      <div
+        className="agent-control__sections"
+        data-testid="agent-control-sections"
       >
-        <StatusCard payload={status} />
-        <InboxCard payload={inbox} />
-        <ProposalsCard payload={proposals} />
-        <PRLifecycleCard payload={prLifecycle} />
-        <WorkloopCard payload={workloop} />
-        <ActivityCard payload={activity} />
-        <ExecuteSafeCard payload={executeSafe} />
-        <NotificationsCard payload={notifications} />
-      </section>
+        <Section
+          id="overview"
+          active={activeSection === "overview"}
+          ariaLabel="System health overview"
+        >
+          <StatusCard payload={status} />
+        </Section>
+
+        <Section
+          id="inbox"
+          active={activeSection === "inbox"}
+          ariaLabel="Operator inbox and proposal queue"
+        >
+          <InboxCard payload={inbox} />
+          <ProposalsCard payload={proposals} />
+        </Section>
+
+        <Section
+          id="runtime"
+          active={activeSection === "runtime"}
+          ariaLabel="Background runtime and activity"
+        >
+          <WorkloopCard payload={workloop} />
+          <ActivityCard payload={activity} />
+        </Section>
+
+        <Section
+          id="prs"
+          active={activeSection === "prs"}
+          ariaLabel="PR lifecycle and execute-safe catalog"
+        >
+          <PRLifecycleCard payload={prLifecycle} />
+          <ExecuteSafeCard payload={executeSafe} />
+        </Section>
+
+        <Section
+          id="about"
+          active={activeSection === "about"}
+          ariaLabel="About this surface"
+        >
+          <NotificationsCard payload={notifications} />
+        </Section>
+      </div>
 
       <footer className="agent-control__footer">
         <p>
-          v3.15.15.21.1 — read-only. Geen execute / approve / merge knoppen.
+          v3.15.15.26 — read-only. Geen execute / approve / merge knoppen.
           Schema:{" "}
           <code>docs/governance/github_pr_lifecycle/schema.v1.md</code>
         </p>

--- a/frontend/src/styles/agent_control.css
+++ b/frontend/src/styles/agent_control.css
@@ -1,25 +1,50 @@
 /*
- * Mobile-first Agent Control PWA — v3.15.15.21.1.
+ * Mobile-first Agent Control PWA — v3.15.15.26.
  *
- * Phone-portrait is the primary viewport. Cards stack vertically.
+ * Phone-portrait is the primary viewport. The 5-tab bottom-nav
+ * sticks to the bottom on phones (thumb-reachable, safe-area-inset
+ * aware). On tablet and desktop ≥ 720px the nav becomes a top
+ * sticky tab row and section content lays out in a multi-column
+ * grid.
+ *
  * Touch targets are >= 44x44 px (Apple HIG / WCAG 2.5.5 minimum).
- * Layout scales up at >= 720px to a two-column grid and >= 1080px
- * to a three-column grid.
- *
  * Status colors are semantic: ok = teal, warn = amber, danger = red,
  * not_available = gray. All combinations meet WCAG AA contrast at
  * the body text size against the elevated card background.
+ *
+ * Layout overview:
+ *   header (sticky-top on phone)
+ *     - title + read-only badge + refresh button
+ *     - subtitle + summary banner + last-refresh timestamp
+ *   nav (sticky-bottom on phone, sticky-top on >= 720px)
+ *     - 5 tabs: Overview / Inbox / Runtime / PRs / About
+ *   sections (only the active section is visually shown;
+ *             inactive sections use the ``hidden`` attribute and
+ *             are excluded from the AT tree but remain queryable
+ *             from React Testing Library by default)
+ *   footer (read-only confirmation)
  */
 
 .agent-control {
-  /* Phone-first padding; use safe-area insets for the notch. */
+  /* Phone-first padding; use safe-area insets for the notch. The
+   * bottom padding leaves room for the sticky bottom-nav (≈ 64px)
+   * plus safe-area inset; on >= 720px the nav is at the top so we
+   * back this off. */
   padding: max(env(safe-area-inset-top, 0px), 16px) 16px
-    max(env(safe-area-inset-bottom, 0px), 16px) 16px;
+    calc(max(env(safe-area-inset-bottom, 0px), 16px) + 76px) 16px;
   display: flex;
   flex-direction: column;
   gap: 16px;
   max-width: 1280px;
   margin: 0 auto;
+  /* Prevent any child from forcing horizontal scroll on a phone. */
+  overflow-x: hidden;
+}
+
+@media (min-width: 720px) {
+  .agent-control {
+    padding-bottom: 24px;
+  }
 }
 
 /* ------------------------------------------------------------------ */
@@ -42,10 +67,35 @@
 }
 
 .agent-control__header h1 {
-  font-size: 24px;
+  font-size: 22px;
   font-weight: 600;
   margin: 0;
   letter-spacing: -0.015em;
+}
+
+@media (min-width: 720px) {
+  .agent-control__header h1 {
+    font-size: 26px;
+  }
+}
+
+/* Tiny safety badge under the title — re-affirms the read-only
+ * posture without occupying a full row. */
+.agent-control__safety-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin: 4px 0 0 0;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  background: rgba(61, 220, 151, 0.12);
+  color: var(--ok);
+  border: 1px solid rgba(61, 220, 151, 0.4);
+  border-radius: 999px;
+  line-height: 1.5;
 }
 
 .agent-control__subtitle {
@@ -162,24 +212,141 @@
 }
 
 /* ------------------------------------------------------------------ */
-/* Card grid                                                           */
+/* Bottom-nav (mobile) / top-tab-row (desktop)                         */
 /* ------------------------------------------------------------------ */
 
-.agent-control__grid {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 14px;
+.agent-control__nav {
+  /* Phone: sticky bottom, full-width. Safe-area inset on the
+   * bottom for the home-indicator on iOS. */
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 20;
+  display: flex;
+  justify-content: space-around;
+  align-items: stretch;
+  gap: 0;
+  padding: 6px 6px max(env(safe-area-inset-bottom, 0px), 8px) 6px;
+  background: var(--bg-elev);
+  border-top: 1px solid var(--border);
+  /* Soft shadow up so the nav reads as floating above the content. */
+  box-shadow: 0 -2px 12px rgba(0, 0, 0, 0.18);
+  backdrop-filter: blur(8px);
+}
+
+.agent-control__nav-tab {
+  /* Touch target ≥ 44 high; let the row decide horizontal split. */
+  flex: 1 1 0;
+  min-height: 56px;
+  min-width: 56px;
+  padding: 6px 4px;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  background: transparent;
+  border: none;
+  border-radius: 10px;
+  color: var(--fg-muted);
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.12s ease, color 0.12s ease;
+  /* No accidental horizontal scroll from long labels. */
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-control__nav-tab:hover:not(:disabled),
+.agent-control__nav-tab:focus-visible {
+  color: var(--fg);
+  background: rgba(79, 180, 255, 0.08);
+}
+
+.agent-control__nav-tab:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+.agent-control__nav-tab--active {
+  color: var(--accent);
+  background: rgba(79, 180, 255, 0.14);
+}
+
+.agent-control__nav-glyph {
+  font-size: 18px;
+  line-height: 1;
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
+}
+
+.agent-control__nav-label {
+  letter-spacing: 0.02em;
 }
 
 @media (min-width: 720px) {
-  .agent-control__grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+  /* Top tab row instead of bottom nav on tablet/desktop. */
+  .agent-control__nav {
+    position: sticky;
+    top: 0;
+    bottom: auto;
+    z-index: 5;
+    justify-content: flex-start;
+    gap: 4px;
+    padding: 8px;
+    background: var(--bg-elev);
+    border-top: none;
+    border-bottom: 1px solid var(--border);
+    box-shadow: none;
+    backdrop-filter: none;
+  }
+
+  .agent-control__nav-tab {
+    flex: 0 0 auto;
+    min-width: 110px;
+    flex-direction: row;
+    gap: 8px;
+    font-size: 13px;
   }
 }
 
+/* ------------------------------------------------------------------ */
+/* Sections (one active at a time)                                     */
+/* ------------------------------------------------------------------ */
+
+.agent-control__sections {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.agent-control__section {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+/* Inactive sections use the native ``hidden`` attribute; the
+ * browser hides them but RTL queries still find them. The
+ * style below is defensive — never collapse layout if React
+ * forgets to apply ``hidden``. */
+.agent-control__section[hidden] {
+  display: none;
+}
+
+/* On desktop, multi-card sections lay out in a 2-column grid. */
 @media (min-width: 1080px) {
-  .agent-control__grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+  .agent-control__section {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 16px;
+  }
+
+  /* Single-card sections (Overview) center their card. */
+  .agent-control__section:has(> :only-child) {
+    grid-template-columns: minmax(0, 1fr);
   }
 }
 

--- a/frontend/src/test/AgentControl.test.tsx
+++ b/frontend/src/test/AgentControl.test.tsx
@@ -820,7 +820,13 @@ describe("AgentControl — UI affordances", () => {
 
     const root = screen.getByTestId("agent-control-root");
     expect(root).toHaveClass("agent-control");
-    const grid = root.querySelector(".agent-control__grid");
-    expect(grid).not.toBeNull();
+    // v3.15.15.26: ``__grid`` was replaced with bottom-nav +
+    // per-section ``__sections``. The phone-first layout is
+    // verified by the presence of both the nav and the
+    // overview tabpanel.
+    const sections = root.querySelector(".agent-control__sections");
+    expect(sections).not.toBeNull();
+    const nav = root.querySelector(".agent-control__nav");
+    expect(nav).not.toBeNull();
   });
 });

--- a/frontend/src/test/AgentControlPolish.test.tsx
+++ b/frontend/src/test/AgentControlPolish.test.tsx
@@ -19,7 +19,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { AgentControl } from "../routes/AgentControl";
 
@@ -374,15 +374,21 @@ describe("AgentControl polish — accessibility & semantic landmarks", () => {
     expect(btn).toHaveAttribute("aria-label");
   });
 
-  it("grid is announced as a region with a label", async () => {
+  it("nav and at least one section are announced as a region", async () => {
+    // v3.15.15.26: the legacy ``agent-control-grid`` was replaced
+    // with a 5-tab bottom nav + per-section ``tabpanel`` regions.
+    // The nav itself carries an aria-label; each section carries
+    // its own aria-label via ``role="tabpanel"``.
     installFetchMock(_allOk());
     render(
       <MemoryRouter initialEntries={["/agent-control"]}>
         <AgentControl />
       </MemoryRouter>,
     );
-    const grid = await screen.findByTestId("agent-control-grid");
-    expect(grid).toHaveAttribute("aria-label");
+    const nav = await screen.findByTestId("agent-control-nav");
+    expect(nav).toHaveAttribute("aria-label");
+    const overview = await screen.findByTestId("section-overview");
+    expect(overview).toHaveAttribute("aria-label");
   });
 });
 
@@ -566,5 +572,146 @@ describe("AgentControl polish — App.tsx wires the /agent-control route", () =>
     expect(src).toMatch(/<Route\s+path="\/agent-control"/);
     expect(src).toMatch(/element=\{<AgentControl\s*\/>}/);
     expect(src).toMatch(/from\s+"\.\/routes\/AgentControl"/);
+  });
+});
+
+describe("AgentControl polish — mobile-first IA (v3.15.15.26)", () => {
+  it("renders five bottom-nav tabs with aria-selected reflecting the active section", async () => {
+    installFetchMock(_allOk());
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+    const nav = await screen.findByTestId("agent-control-nav");
+    expect(nav).toHaveAttribute("role", "tablist");
+    for (const id of ["overview", "inbox", "runtime", "prs", "about"]) {
+      const tab = await screen.findByTestId(`nav-tab-${id}`);
+      expect(tab).toHaveAttribute("role", "tab");
+      expect(tab).toHaveAttribute("aria-controls", `section-${id}`);
+    }
+    // Default active section is overview.
+    const overviewTab = await screen.findByTestId("nav-tab-overview");
+    expect(overviewTab).toHaveAttribute("aria-selected", "true");
+    const inboxTab = await screen.findByTestId("nav-tab-inbox");
+    expect(inboxTab).toHaveAttribute("aria-selected", "false");
+  });
+
+  it("clicking a nav tab activates the corresponding section and hides the others", async () => {
+    installFetchMock(_allOk());
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+    const inboxTab = await screen.findByTestId("nav-tab-inbox");
+    fireEvent.click(inboxTab);
+    await waitFor(() => {
+      expect(inboxTab).toHaveAttribute("aria-selected", "true");
+    });
+    // Overview becomes inactive: data-section-active flips and the
+    // ``hidden`` attribute is applied.
+    const overview = await screen.findByTestId("section-overview");
+    expect(overview).toHaveAttribute("data-section-active", "false");
+    expect(overview).toHaveAttribute("hidden");
+    const inbox = await screen.findByTestId("section-inbox");
+    expect(inbox).toHaveAttribute("data-section-active", "true");
+    expect(inbox).not.toHaveAttribute("hidden");
+  });
+
+  it("each section is a tabpanel with a non-empty aria-label", async () => {
+    installFetchMock(_allOk());
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+    for (const id of ["overview", "inbox", "runtime", "prs", "about"]) {
+      const section = await screen.findByTestId(`section-${id}`);
+      expect(section).toHaveAttribute("role", "tabpanel");
+      expect(section).toHaveAttribute("aria-labelledby", `tab-${id}`);
+      const label = section.getAttribute("aria-label") ?? "";
+      expect(label.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("renders a read-only safety badge in the header", async () => {
+    installFetchMock(_allOk());
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+    const badge = await screen.findByTestId("agent-control-safety-badge");
+    expect(badge).toHaveAttribute("aria-label");
+    expect(badge.textContent ?? "").toMatch(/read-only/i);
+  });
+
+  it("preserves the canonical card hooks across all sections", async () => {
+    // The mobile-first IA reorganized cards into 5 sections, but
+    // the data-testid hooks the existing test suite + downstream
+    // consumers rely on must still resolve regardless of which
+    // tab is currently active.
+    installFetchMock(_allOk());
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+    // Overview section.
+    expect(await screen.findByTestId("status-runtime-row")).toBeInTheDocument();
+    expect(await screen.findByTestId("status-policy-row")).toBeInTheDocument();
+    expect(await screen.findByTestId("status-metrics-row")).toBeInTheDocument();
+    // Inbox section.
+    expect(await screen.findByTestId("inbox-recommendation")).toBeInTheDocument();
+    expect(
+      await screen.findByTestId("proposals-recommendation"),
+    ).toBeInTheDocument();
+    // PRs section.
+    expect(await screen.findByTestId("pr-recommendation")).toBeInTheDocument();
+    expect(
+      await screen.findByTestId("execute-safe-cli-only"),
+    ).toBeInTheDocument();
+    // About section.
+    expect(await screen.findByTestId("notifications-empty")).toBeInTheDocument();
+  });
+
+  it("nav tabs are keyboard-navigable and have a min height >= 44px touch target", async () => {
+    installFetchMock(_allOk());
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+    const overviewTab = await screen.findByTestId("nav-tab-overview");
+    // The active tab is keyboard-reachable; inactive tabs use
+    // tabIndex=-1 so the tab order doesn't include all five at
+    // once, which matches APG tablist semantics.
+    expect(overviewTab).toHaveAttribute("tabindex", "0");
+    const inboxTab = await screen.findByTestId("nav-tab-inbox");
+    expect(inboxTab).toHaveAttribute("tabindex", "-1");
+    // Touch-target invariant: the button class carries the >= 44px
+    // min-height rule. We verify the class is present rather than
+    // computed style (jsdom does not implement it reliably).
+    expect(overviewTab.className).toMatch(/agent-control__nav-tab/);
+  });
+
+  it("does not render any execute / approve / merge buttons anywhere in the tree", async () => {
+    installFetchMock(_allOk());
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+    // Wait for the tree to settle.
+    await screen.findByTestId("agent-control-root");
+    const buttons = Array.from(document.querySelectorAll("button"));
+    for (const b of buttons) {
+      const label = (b.textContent ?? "").toLowerCase();
+      const aria = (b.getAttribute("aria-label") ?? "").toLowerCase();
+      const haystack = `${label} ${aria}`;
+      // Forbidden mutation verbs:
+      expect(haystack).not.toMatch(/execute|approve|reject|merge|squash|ack|resolve/);
+    }
   });
 });


### PR DESCRIPTION
## Summary

Rebuilds the read-only Agent Control PWA into a genuinely mobile-first operator console. **Five tabs in a thumb-reachable bottom navigation** (sticky-bottom on phone, sticky-top tabs ≥ 720px) group the existing read-only cards into operator-meaningful sections. The cards themselves are unchanged in content; the change is information architecture and visual quality.

This is a UX/frontend release. **No backend changes. No new fetch verbs. No mutation UI. No browser push. No new dependencies.**

## UX summary (what changed visually)

- **Header** now carries a small read-only safety badge under the title to re-affirm the posture next to the existing summary banner.
- **Bottom nav** with 5 tabs (Overview / Inbox / Runtime / PRs / About) on phone-portrait. Becomes sticky-top tabs on tablet+desktop ≥ 720px. Touch targets ≥ 56 px, safe-area-inset aware, no horizontal scroll.
- **Sections** are role=tabpanel with aria-labelledby pointing at the matching role=tab button. Inactive sections use the native `hidden` attribute — they are excluded from the AT tree but remain queryable from RTL so the existing card test suite continues to work.
- **Footer** version updated to v3.15.15.26.

## Operator mental model (new section grouping)

| Tab | Question it answers | Cards |
|---|---|---|
| Overview | Is the system healthy? | Status (governance / frozen / runtime / maintenance / policy / metrics) |
| Inbox | What needs Joery? | Approval Inbox + Proposal Queue |
| Runtime | Background telemetry | Autonomous Workloop digest + Activity timeline |
| PRs | Code lifecycle (read-only) | GitHub PR Lifecycle + Execute-safe Catalog |
| About | Meta | Notifications placeholder |

## Read-only safety preserved

- **No** execute / approve / reject / merge / ack / resolve buttons.
- A new regression test scans every \`<button>\` in the rendered DOM and refuses any of those mutation verbs.
- **No** POST/PUT/PATCH/DELETE. **No** mutation fetch calls. **No** \`api_execute_safe_controls\` wiring. **No** browser push.
- Existing PWA manifest, service worker, install behavior, and \`/agent-control\` deep link unchanged.
- **No new dependencies** (no charting/UI library/etc.).

## Files changed

- \`frontend/src/routes/AgentControl.tsx\` — adds BottomNav + Section components, wraps existing cards in 5 sections, adds active-section state.
- \`frontend/src/styles/agent_control.css\` — adds bottom-nav rules (sticky-bottom phone, sticky-top desktop, ≥ 56 px tabs), section visibility rules, safety badge styling, multi-column desktop section grids, \`overflow-x: hidden\` on the root.
- \`frontend/src/test/AgentControl.test.tsx\` — updates the legacy \`__grid\` layout assertion to the new \`__sections\` + \`__nav\` selectors.
- \`frontend/src/test/AgentControlPolish.test.tsx\` — 7 new mobile-first regression tests + the legacy grid-aria test rewritten for the new nav/section model.
- \`docs/governance/mobile_agent_control_pwa.md\` — adds the v3.15.15.26 IA section explaining the new tabs and the read-only invariants they preserve.

## Tests added (7 new mobile-first cases)

- Five bottom-nav tabs with role/aria-controls/aria-selected.
- Click-to-activate switches active section + applies \`hidden\` to others.
- Each section is a tabpanel with non-empty aria-label.
- Read-only safety badge renders with aria-label and a \`read-only\` text token.
- Canonical card data-testid hooks survive across all 5 sections (Overview/Inbox/PRs/About card hooks are queryable regardless of which tab is active).
- Nav tabs have APG-compliant tabindex semantics (active=0, inactive=-1).
- DOM scan: no execute / approve / reject / merge / squash / ack / resolve verbs in any \`<button>\` text or aria-label.

## Validation gates green

- governance_lint OK (15 agents, 3 workflows).
- \`pytest tests/smoke\`: 14/14.
- frontend vitest: **69/69** across 8 files (was 62; +7 new mobile-first tests).
- frontend build: green (~272 KB JS gzip 78 KB; +1 KB CSS for the new nav/section/badge rules).
- frozen contract sha256 unchanged (\`4a567bd6...\` / \`ff15b8c4...\`).

## Non-goals (explicitly out of scope)

- No execute / approve / reject / merge / ack / resolve buttons.
- No POST/PUT/PATCH/DELETE.
- No mutation fetch calls.
- No \`api_execute_safe_controls\` wiring.
- No browser push.
- No external telemetry.
- No new dependencies.
- No paid tools.
- No secrets.
- No \`.claude/**\` changes.
- No \`dashboard/dashboard.py\` changes.
- No frozen contract changes.
- No live/paper/shadow/trading/risk behavior changes.
- No CI/test weakening.

## Test plan

- [ ] CI gates green (governance lint, smoke, unit, frontend, governance smoke)
- [ ] Frozen-contract hashes unchanged on main
- [ ] Bottom-nav reachable on a real phone-portrait viewport
- [ ] No mutation buttons introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)