### PR TITLE
feat(v3.15.15.27): observability / logging / security hardening sweep

### DIFF
--- a/docs/governance/autonomy_metrics.md
+++ b/docs/governance/autonomy_metrics.md
@@ -1,7 +1,8 @@
 # Autonomy metrics — operator runbook
 
 Module: `reporting.autonomy_metrics`
-Version: v3.15.15.25
+Version: v3.15.15.27 (introduced in v3.15.15.25; stale-artifact
+detection added in v3.15.15.27)
 Schema: `docs/governance/autonomy_metrics/schema.v1.md`
 
 ## TL;DR

--- a/docs/governance/autonomy_metrics/schema.v1.md
+++ b/docs/governance/autonomy_metrics/schema.v1.md
@@ -118,6 +118,27 @@ last_success_at_utc: str | null
 last_failure_at_utc: str | null
 ```
 
+### Stale-artifact detection (v3.15.15.27)
+
+Each `source_statuses` row whose `state == "ok"` carries:
+
+* `age_seconds: int | null` — the difference between the digest's
+  `generated_at_utc` and the source artifact's
+  `generated_at_utc`. `null` when the source artifact has no
+  `generated_at_utc` field.
+* `is_stale: bool` — true when `age_seconds` exceeds the
+  staleness threshold.
+
+Staleness threshold:
+
+* default `STALE_THRESHOLD_SECONDS_DEFAULT = 86400` (24 hours);
+* env var override:
+  `AUTONOMY_METRICS_STALE_THRESHOLD_SECONDS=<positive int>`;
+* CLI override:
+  `--stale-threshold-seconds <positive int>`.
+
+A stale row bumps `reliability.stale_artifact_count` by 1.
+
 ## safety
 
 ```

--- a/docs/governance/observability_security_hardening.md
+++ b/docs/governance/observability_security_hardening.md
@@ -1,0 +1,202 @@
+# Observability / logging / security hardening sweep — v3.15.15.27
+
+> Release: v3.15.15.27 (sweep release on top of v3.15.15.26)
+> Sibling docs: `high_risk_approval_policy.md`,
+> `autonomy_metrics.md`, `recurring_maintenance.md`,
+> `workloop_runtime.md`, `mobile_agent_control_pwa.md`,
+> `approval_inbox.md`.
+
+## TL;DR
+
+This release does **not** expand execution authority. It tightens
+the observability and security invariants of the existing
+read-only governance/autonomy stack. The hardening is enforced
+by code AND by tests; future regressions trip a unit-test-level
+guard rather than waiting for a runtime incident.
+
+## Hardening areas
+
+### 1. Stale-artifact detection (autonomy_metrics)
+
+Before this release, `reliability.stale_artifact_count` was wired
+but never bumped because "stale" was treated as a synonym for
+`STATE_UNREADABLE`. After v3.15.15.27 the metrics digest annotates
+every ok-parsing source row with:
+
+* `age_seconds: int | null` — difference between the digest's
+  `generated_at_utc` and the source artifact's
+  `generated_at_utc`.
+* `is_stale: bool` — true when `age_seconds` exceeds the
+  staleness threshold.
+
+Threshold: `STALE_THRESHOLD_SECONDS_DEFAULT = 86400` (24 hours).
+Override via the `AUTONOMY_METRICS_STALE_THRESHOLD_SECONDS` env
+var or the new `--stale-threshold-seconds` CLI flag. A stale row
+bumps `reliability.stale_artifact_count` and surfaces in the
+existing `degraded_failures` recommendation evaluator.
+
+This makes "the workloop ran an hour ago" visibly different from
+"the workloop hasn't run today" without changing the digest's
+top-level shape.
+
+### 2. Boundary exception-handler invariant
+
+Every dashboard route module that surfaces JSON to the operator
+PWA already redacts caught exceptions to `type(e).__name__` —
+the v3.15.15.27 sweep adds a **source-text guard** so a future
+regression cannot reintroduce `str(e)`, `repr(e)`,
+`f"{e}"`, `e.args`, or `traceback.format_exc()` into any of:
+
+* `dashboard/api_agent_control.py`
+* `dashboard/api_approval_inbox.py`
+* `dashboard/api_proposal_queue.py`
+* `dashboard/api_execute_safe_controls.py`
+
+The guard lives in
+`tests/unit/test_observability_security_invariants.py` and is
+parametrised over the four files. It scans the raw module source
+because runtime patching cannot defeat a regex over the file
+bytes.
+
+### 3. GET-only verb sweep
+
+Same set of files: every `methods=[...]` list is parsed; if any
+contains `POST`, `PUT`, `PATCH`, or `DELETE` the test fails. This
+prevents an accidental verb expansion from sneaking into a route
+file even if `dashboard.dashboard` continues to wire it under
+`register_*_routes`.
+
+### 4. `api_execute_safe_controls` remains UNWIRED
+
+`dashboard/dashboard.py` is asserted to NOT contain
+`register_execute_safe_routes`. The execute-safe API stays
+intentionally unwired until the operator approves a separate
+release — the test prevents a future bootstrap commit from
+quietly wiring it.
+
+### 5. v3.15.15.25.1 path-reference allowlist preserved
+
+The narrow credential-VALUE redaction in:
+
+* `reporting.agent_audit_summary.assert_no_secrets`
+* `reporting.governance_status.assert_no_secrets`
+* `reporting.approval_policy.assert_no_credential_values`
+
+is verified at unit-test level. Adding a new
+`_SENSITIVE_FRAGMENTS` substring rule that re-rejects path
+references would re-introduce the v3.15.15.25 false positive
+that halted the approval inbox runtime — the tests fail loudly
+in that case.
+
+### 6. End-to-end credential-leak scan
+
+`/api/agent-control/status` is exercised with monkeypatched empty
+artifacts; the response body is scanned for the canonical
+credential fragments (`sk-ant-`, `ghp_`, `github_pat_`, `AKIA`,
+`BEGIN PRIVATE KEY`). If any of those appear, the test fails.
+
+### 7. Frontend mutation-fetch sweep
+
+`frontend/src/api/agent_control.ts` is checked to never contain
+`"POST"`/`"PUT"`/`"PATCH"`/`"DELETE"` literals. The PWA already
+uses `fetch(GET)` only; this guard prevents a future PR from
+introducing a mutation verb against the agent-control surface.
+
+### 8. Subprocess / network sweep
+
+The four agent-control route files are checked to never contain
+`import subprocess`, `Popen(`, or any `urllib.request` /
+`requests` import. The dashboard surface stays in-process by
+construction.
+
+## Hardening report — gaps found vs fixed
+
+| Area | Pre-sweep state | Post-sweep state |
+| --- | --- | --- |
+| Stale-artifact detection | Wired field, never bumped | Per-row age + threshold + counter |
+| `str(e)` in agent-control boundaries | Already redacted | Source-text guard added |
+| GET-only verb invariant | Manual code review only | Source-text test sweep |
+| `api_execute_safe_controls` wiring | Manual review | Source-text guard added |
+| Path-reference allowlist | Code-level fix in v3.15.15.25.1 | Test-level guards across 3 modules |
+| Status-payload credential scan | Existing per-source `assert_no_secrets` | End-to-end Flask test added |
+| Frontend mutation fetch | Manual review | Source-text guard added |
+| Subprocess/network in dashboard | Already absent | Source-text guard added |
+
+## Remaining intentional limitations
+
+The following are **intentional non-goals** for v3.15.15.27 and
+must not be relaxed without an explicit operator brief:
+
+* Browser push notifications — out of scope.
+* Approval / reject mutation UI — out of scope.
+* `api_execute_safe_controls` production wiring — out of scope.
+* HIGH-risk execution — out of scope.
+* External telemetry / paid services / signup flows — out of scope.
+* Live / paper / shadow / risk behavior changes — out of scope.
+
+## Security invariants now covered by tests
+
+Every invariant below is verified by at least one parametrised
+unit test:
+
+* GET-only on agent-control routes.
+* No mutation verbs in agent-control route files.
+* No `str(e)` / `repr(e)` / `f"{e}"` / `e.args` /
+  `traceback.format_exc()` in agent-control boundary handlers.
+* No credential-shaped values in `/api/agent-control/status`.
+* No `api_execute_safe_controls` wiring in `dashboard.dashboard`.
+* Path references like `config/config.yaml` flow through the
+  three secret guards (no false positives).
+* Credential-shaped values still trip the three secret guards.
+* Frontend agent-control API uses no mutation verb literal.
+* No `subprocess` / `urllib.request` / `requests` imports in
+  agent-control route files.
+* `recurring_maintenance` and `execute_safe_controls` artifacts
+  are classified as `not_available` rather than `failed` when
+  missing.
+
+## Observability signals now available
+
+* `autonomy_metrics.reliability.stale_artifact_count` (real,
+  bumped by per-row staleness).
+* `autonomy_metrics.source_statuses[].age_seconds` /
+  `.is_stale` (per-source freshness annotation).
+* `autonomy_metrics.reliability.last_success_at_utc` /
+  `last_failure_at_utc` (already present; verified preserved).
+* `workloop_runtime.loop_health.consecutive_failures` (already
+  present; verified preserved).
+* `recurring_maintenance.jobs[].consecutive_failures` (already
+  present; verified preserved).
+* Approval inbox `runtime_halt` / `failed_automation` /
+  `unknown_state` projections from upstream digests (already
+  present; verified preserved).
+
+## How to validate locally
+
+```
+python scripts/governance_lint.py
+pytest tests/smoke -q
+pytest tests/unit -q
+sha256sum research/research_latest.json research/strategy_matrix.csv
+python -m reporting.autonomy_metrics --collect --no-write \
+  --frozen-utc 2026-05-03T08:00:00Z \
+  --stale-threshold-seconds 300
+```
+
+A clean run reports all green gates, frozen hashes unchanged
+(`4a567bd6...` / `ff15b8c4...`), and the metrics digest carries
+non-null `age_seconds` / `is_stale` annotations on every
+ok-state source row.
+
+## Cross-references
+
+* Schema:
+  `docs/governance/autonomy_metrics/schema.v1.md`
+* Approval policy:
+  `docs/governance/high_risk_approval_policy.md`
+* Approval inbox:
+  `docs/governance/approval_exception_inbox.md`
+* PWA UX rebuild:
+  `docs/governance/mobile_agent_control_pwa.md`
+* No-touch paths:
+  `docs/governance/no_touch_paths.md`

--- a/reporting/autonomy_metrics.py
+++ b/reporting/autonomy_metrics.py
@@ -59,11 +59,20 @@ from typing import Any
 from reporting import approval_policy as _approval_policy
 
 REPO_ROOT: Path = Path(__file__).resolve().parent.parent
-MODULE_VERSION: str = "v3.15.15.25"
+MODULE_VERSION: str = "v3.15.15.27"
 METRICS_VERSION: str = "v1"
 SCHEMA_VERSION: int = 1
 
 DIGEST_DIR_JSON: Path = REPO_ROOT / "logs" / "autonomy_metrics"
+
+# v3.15.15.27 — stale-artifact threshold. A source whose
+# ``generated_at_utc`` is older than this is counted as stale even
+# though it parsed cleanly. Default 24 hours; the operator can
+# override via the AUTONOMY_METRICS_STALE_THRESHOLD_SECONDS env var
+# at collection time. The threshold is conservative on purpose —
+# we want operators to notice when the workloop has stopped
+# producing fresh artifacts, not to swamp them with churn.
+STALE_THRESHOLD_SECONDS_DEFAULT: int = 24 * 3600
 
 
 # ---------------------------------------------------------------------------
@@ -156,6 +165,21 @@ def _utcnow() -> str:
 
 def _utcnow_dt() -> _dt.datetime:
     return _dt.datetime.now(_dt.UTC).replace(microsecond=0)
+
+
+def _stale_threshold_from_env() -> int:
+    """Return the staleness threshold in seconds, honouring the
+    ``AUTONOMY_METRICS_STALE_THRESHOLD_SECONDS`` env var when set
+    to a positive integer. Falls back to
+    ``STALE_THRESHOLD_SECONDS_DEFAULT`` otherwise."""
+    raw = os.environ.get("AUTONOMY_METRICS_STALE_THRESHOLD_SECONDS", "")
+    try:
+        v = int(raw)
+        if v > 0:
+            return v
+    except (TypeError, ValueError):
+        pass
+    return STALE_THRESHOLD_SECONDS_DEFAULT
 
 
 def _rel(path: Path) -> str:
@@ -571,6 +595,11 @@ def _reliability(
             missing += 1
         elif st == STATE_UNREADABLE:
             stale += 1
+        elif st == STATE_OK and bool(s.get("is_stale", False)):
+            # v3.15.15.27 — an ok-parsing artifact whose
+            # generated_at_utc is older than the staleness threshold
+            # is still counted as a reliability concern.
+            stale += 1
     return {
         "runtime_consecutive_failures": int(runtime.get("consecutive_failures", 0) or 0),
         "recurring_consecutive_failures_max": int(
@@ -785,10 +814,18 @@ def _final_recommendation(
 # ---------------------------------------------------------------------------
 
 
-def collect_snapshot(*, frozen_utc: str | None = None) -> dict[str, Any]:
+def collect_snapshot(
+    *,
+    frozen_utc: str | None = None,
+    stale_threshold_seconds: int | None = None,
+) -> dict[str, Any]:
     """Build the full metrics digest. Pure with respect to the
     filesystem state at call time. ``frozen_utc`` pins the
-    generated_at_utc field for deterministic tests."""
+    generated_at_utc field for deterministic tests.
+    ``stale_threshold_seconds`` overrides the default
+    ``STALE_THRESHOLD_SECONDS_DEFAULT``; pass an explicit value in
+    tests to make staleness deterministic without depending on the
+    real clock relative to the artifact mtime."""
     src_envelopes: dict[str, dict[str, Any]] = {
         "workloop_runtime": _read_json_artifact(SOURCE_WORKLOOP_RUNTIME),
         "recurring_maintenance": _read_json_artifact(SOURCE_RECURRING_MAINTENANCE),
@@ -798,17 +835,41 @@ def collect_snapshot(*, frozen_utc: str | None = None) -> dict[str, Any]:
         "execute_safe_controls": _read_json_artifact(SOURCE_EXECUTE_SAFE_CONTROLS),
     }
 
+    threshold = (
+        stale_threshold_seconds
+        if stale_threshold_seconds is not None
+        else _stale_threshold_from_env()
+    )
+    # Anchor "now" to the pinned frozen_utc when provided so stale
+    # detection is deterministic for a given input set.
+    now_dt = _parse_iso(frozen_utc) if frozen_utc else _utcnow_dt()
+    if now_dt is None:
+        now_dt = _utcnow_dt()
+
     src_statuses: list[dict[str, Any]] = []
     for name, rel in SOURCE_ORDER:
         env = src_envelopes[name]
-        src_statuses.append(
-            {
-                "source": name,
-                "artifact_path": rel,
-                "state": env["state"],
-                "reason": env["reason"],
-            }
-        )
+        row: dict[str, Any] = {
+            "source": name,
+            "artifact_path": rel,
+            "state": env["state"],
+            "reason": env["reason"],
+        }
+        # v3.15.15.27 — annotate ok rows with age + staleness so
+        # the operator can distinguish "fresh" from "ancient" at
+        # a glance. Inputs without a generated_at_utc field are
+        # left without an age (no false certainty).
+        if env["state"] == STATE_OK and isinstance(env.get("data"), dict):
+            gen = env["data"].get("generated_at_utc")
+            gen_dt = _parse_iso(gen) if isinstance(gen, str) else None
+            if gen_dt is not None:
+                age_seconds = max(0, int((now_dt - gen_dt).total_seconds()))
+                row["age_seconds"] = age_seconds
+                row["is_stale"] = age_seconds > threshold
+            else:
+                row["age_seconds"] = None
+                row["is_stale"] = False
+        src_statuses.append(row)
 
     proposals = _count_proposals(src_envelopes["proposal_queue"])
     inbox = _count_inbox(src_envelopes["approval_inbox"])
@@ -960,6 +1021,17 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="Pin generated_at_utc for deterministic tests.",
     )
+    parser.add_argument(
+        "--stale-threshold-seconds",
+        type=int,
+        default=None,
+        help=(
+            "Override the staleness threshold (default: "
+            f"{STALE_THRESHOLD_SECONDS_DEFAULT}s = 24h). "
+            "Sources whose generated_at_utc is older than this "
+            "are counted under reliability.stale_artifact_count."
+        ),
+    )
     args = parser.parse_args(argv)
 
     if args.status:
@@ -971,7 +1043,10 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     if args.collect:
-        snap = collect_snapshot(frozen_utc=args.frozen_utc)
+        snap = collect_snapshot(
+            frozen_utc=args.frozen_utc,
+            stale_threshold_seconds=args.stale_threshold_seconds,
+        )
         if not args.no_write:
             paths = write_outputs(snap)
             print(json.dumps({"status": "ok", "paths": paths}, indent=2))

--- a/tests/unit/test_autonomy_metrics.py
+++ b/tests/unit/test_autonomy_metrics.py
@@ -255,8 +255,10 @@ def _write_all_ok(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_module_version_is_v3_15_15_25() -> None:
-    assert am.MODULE_VERSION == "v3.15.15.25"
+def test_module_version_is_at_least_v3_15_15_25() -> None:
+    """Stays >= v3.15.15.25 (initial release). v3.15.15.27 added
+    stale-artifact detection on top of the same metrics_version."""
+    assert am.MODULE_VERSION >= "v3.15.15.25"
 
 
 def test_metrics_version_is_v1() -> None:
@@ -715,3 +717,116 @@ def test_collect_does_not_mutate_frozen_contract_paths(isolated_dirs) -> None:
     paths = am.write_outputs(snap)
     for label, rel in paths.items():
         assert rel.startswith("logs/autonomy_metrics/"), f"{label} -> {rel}"
+
+
+# ---------------------------------------------------------------------------
+# v3.15.15.27 — stale-artifact detection
+# ---------------------------------------------------------------------------
+
+
+def test_stale_threshold_default_is_24_hours() -> None:
+    assert am.STALE_THRESHOLD_SECONDS_DEFAULT == 24 * 3600
+
+
+def test_fresh_artifact_is_not_stale(isolated_dirs) -> None:
+    """An ok-parsing artifact whose generated_at_utc is the same
+    as the digest's frozen_utc has age 0 and is not stale."""
+    _write_all_ok(isolated_dirs)
+    snap = am.collect_snapshot(frozen_utc="2026-05-03T07:00:00Z")
+    rt_row = next(r for r in snap["source_statuses"] if r["source"] == "workloop_runtime")
+    assert rt_row["state"] == "ok"
+    assert rt_row["age_seconds"] == 0
+    assert rt_row["is_stale"] is False
+    assert snap["reliability"]["stale_artifact_count"] == 0
+
+
+def test_old_artifact_is_classified_stale_and_counted(isolated_dirs) -> None:
+    """An ok-parsing artifact whose generated_at_utc is older than
+    the threshold is annotated is_stale=True and bumps
+    reliability.stale_artifact_count."""
+    _write_all_ok(isolated_dirs)
+    # The fixture writes generated_at_utc=2026-05-03T07:00:00Z;
+    # pin frozen_utc to 25 hours later -> age 90000s > default 86400s.
+    snap = am.collect_snapshot(frozen_utc="2026-05-04T08:00:00Z")
+    rt_row = next(r for r in snap["source_statuses"] if r["source"] == "workloop_runtime")
+    assert rt_row["state"] == "ok"
+    assert rt_row["age_seconds"] >= 24 * 3600
+    assert rt_row["is_stale"] is True
+    assert snap["reliability"]["stale_artifact_count"] >= 1
+
+
+def test_stale_threshold_seconds_override_via_argument(isolated_dirs) -> None:
+    """Operator override: a tighter threshold makes any artifact
+    older than ~5 minutes stale."""
+    _write_all_ok(isolated_dirs)
+    # Fixture generated_at_utc=2026-05-03T07:00:00Z; frozen at +10
+    # minutes; 5-minute threshold => stale.
+    snap = am.collect_snapshot(
+        frozen_utc="2026-05-03T07:10:00Z",
+        stale_threshold_seconds=300,
+    )
+    rt_row = next(r for r in snap["source_statuses"] if r["source"] == "workloop_runtime")
+    assert rt_row["age_seconds"] == 10 * 60
+    assert rt_row["is_stale"] is True
+    assert snap["reliability"]["stale_artifact_count"] >= 1
+
+
+def test_missing_generated_at_does_not_assert_staleness(isolated_dirs) -> None:
+    """An artifact that parses but lacks ``generated_at_utc`` reports
+    age_seconds=None and is_stale=False — we never invent a clock."""
+    rt = _ok_workloop_runtime()
+    rt.pop("generated_at_utc", None)
+    _write(isolated_dirs / "logs" / "workloop_runtime" / "latest.json", rt)
+    snap = am.collect_snapshot(frozen_utc="2026-05-03T08:00:00Z")
+    rt_row = next(r for r in snap["source_statuses"] if r["source"] == "workloop_runtime")
+    assert rt_row["state"] == "ok"
+    assert rt_row["age_seconds"] is None
+    assert rt_row["is_stale"] is False
+
+
+def test_missing_artifact_is_not_classified_stale(isolated_dirs) -> None:
+    """Missing artifacts are counted as missing (not stale) — the
+    distinction matters because missing means "collector didn't
+    run", stale means "collector ran but its output is too old"."""
+    snap = am.collect_snapshot(frozen_utc="2026-05-03T08:00:00Z")
+    # Every source is missing -> no stale entries.
+    for row in snap["source_statuses"]:
+        assert row["state"] == "missing"
+        # Missing rows do not carry age_seconds / is_stale.
+        assert "age_seconds" not in row or row.get("age_seconds") is None
+    assert snap["reliability"]["stale_artifact_count"] == 0
+
+
+def test_env_var_threshold_is_honoured(isolated_dirs, monkeypatch) -> None:
+    """``AUTONOMY_METRICS_STALE_THRESHOLD_SECONDS`` env var overrides
+    the default when set to a positive integer."""
+    monkeypatch.setenv("AUTONOMY_METRICS_STALE_THRESHOLD_SECONDS", "60")
+    _write_all_ok(isolated_dirs)
+    snap = am.collect_snapshot(frozen_utc="2026-05-03T07:05:00Z")
+    rt_row = next(r for r in snap["source_statuses"] if r["source"] == "workloop_runtime")
+    assert rt_row["age_seconds"] == 5 * 60
+    assert rt_row["is_stale"] is True
+
+
+def test_env_var_invalid_falls_back_to_default(monkeypatch) -> None:
+    monkeypatch.setenv("AUTONOMY_METRICS_STALE_THRESHOLD_SECONDS", "not-a-number")
+    assert am._stale_threshold_from_env() == am.STALE_THRESHOLD_SECONDS_DEFAULT
+    monkeypatch.setenv("AUTONOMY_METRICS_STALE_THRESHOLD_SECONDS", "-1")
+    assert am._stale_threshold_from_env() == am.STALE_THRESHOLD_SECONDS_DEFAULT
+    monkeypatch.setenv("AUTONOMY_METRICS_STALE_THRESHOLD_SECONDS", "0")
+    assert am._stale_threshold_from_env() == am.STALE_THRESHOLD_SECONDS_DEFAULT
+
+
+def test_cli_collect_with_stale_threshold_flag(isolated_dirs) -> None:
+    _write_all_ok(isolated_dirs)
+    rc = am.main(
+        [
+            "--collect",
+            "--no-write",
+            "--frozen-utc",
+            "2026-05-03T07:10:00Z",
+            "--stale-threshold-seconds",
+            "300",
+        ]
+    )
+    assert rc == 0

--- a/tests/unit/test_observability_security_invariants.py
+++ b/tests/unit/test_observability_security_invariants.py
@@ -1,0 +1,326 @@
+"""Cross-module observability + security invariants (v3.15.15.27).
+
+This is the v3.15.15.27 hardening sweep test surface. It walks
+``dashboard/api_*.py`` and ``reporting/*.py`` files in source form
+and asserts:
+
+* Agent-Control endpoints are GET-only at the registration layer.
+* Boundary exception handlers in those files emit only the
+  exception's class name (``type(e).__name__``), never ``str(e)``
+  / ``repr(e)`` / ``e.args`` — those can carry credential strings,
+  free-form path mentions, or internal traceback fragments.
+* Status payload responses never contain credential-shaped values
+  (``sk-ant-`` / ``ghp_`` / ``github_pat_`` / ``AKIA`` /
+  ``BEGIN PRIVATE KEY``).
+* ``api_execute_safe_controls`` remains UNWIRED in
+  ``dashboard.dashboard``.
+* The shared no-touch-path-reference allowlist is preserved across
+  ``approval_policy``, ``agent_audit_summary``, and
+  ``governance_status`` — the v3.15.15.25.1 narrowing must not be
+  re-broadened by a future regression.
+* Frontend bundle (raw source) never imports a mutation fetch verb
+  (POST/PUT/PATCH/DELETE) for any /api/agent-control/* endpoint.
+
+These tests are intentionally source-text checks — they cannot be
+defeated by stubbing or runtime patching, which is the point.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+# ---------------------------------------------------------------------------
+# Boundary handler invariants
+# ---------------------------------------------------------------------------
+
+
+# Files we apply the strict boundary-handler rules to. Each is a
+# read-only surface that publishes status to operator-facing
+# JSON / API / PWA. Anything else (e.g. CLI scripts, internal
+# helpers) is allowed to keep ``str(e)`` because it never leaves
+# the local process.
+_AGENT_CONTROL_BOUNDARY_FILES: tuple[str, ...] = (
+    "dashboard/api_agent_control.py",
+    "dashboard/api_approval_inbox.py",
+    "dashboard/api_proposal_queue.py",
+    "dashboard/api_execute_safe_controls.py",
+)
+
+
+# Forbidden patterns inside the body of a boundary exception
+# handler. We accept ``type(e).__name__`` (the canonical redacted
+# form) and reject every other way of stringifying the exception.
+_FORBIDDEN_EXC_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\bstr\(\s*e\s*\)"),
+    re.compile(r"\brepr\(\s*e\s*\)"),
+    re.compile(r"\bf['\"][^'\"]*\{e\}[^'\"]*['\"]"),
+    re.compile(r"\be\.args\b"),
+    re.compile(r"\btraceback\.format_exc\("),
+)
+
+
+@pytest.mark.parametrize("rel", _AGENT_CONTROL_BOUNDARY_FILES)
+def test_agent_control_boundary_handlers_redact_exception_messages(rel: str) -> None:
+    """Boundary handlers in agent-control routes must not emit raw
+    exception messages. Only ``type(e).__name__`` is allowed."""
+    p = REPO_ROOT / rel
+    src = p.read_text(encoding="utf-8")
+    for pat in _FORBIDDEN_EXC_PATTERNS:
+        match = pat.search(src)
+        assert match is None, (
+            f"{rel} contains a forbidden exception-leak pattern: "
+            f"{pat.pattern!r} matched {match.group(0)!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# GET-only verb invariant
+# ---------------------------------------------------------------------------
+
+
+_METHODS_RE = re.compile(r"methods\s*=\s*\[([^\]]+)\]")
+_FORBIDDEN_VERBS: frozenset[str] = frozenset(
+    {"POST", "PUT", "PATCH", "DELETE"}
+)
+
+
+@pytest.mark.parametrize("rel", _AGENT_CONTROL_BOUNDARY_FILES)
+def test_agent_control_routes_are_get_only(rel: str) -> None:
+    """No ``methods=[...]`` list in any agent-control route file
+    contains a mutation verb."""
+    p = REPO_ROOT / rel
+    src = p.read_text(encoding="utf-8")
+    for m in _METHODS_RE.finditer(src):
+        verbs_raw = m.group(1)
+        verbs = {v.strip().strip("'\"").upper() for v in verbs_raw.split(",")}
+        leaked = verbs & _FORBIDDEN_VERBS
+        assert not leaked, (
+            f"{rel} registers a mutation verb {leaked!r} in "
+            f"methods={verbs_raw!r}"
+        )
+
+
+def test_dashboard_does_not_wire_execute_safe_routes() -> None:
+    """``dashboard.dashboard`` must NOT call
+    ``register_execute_safe_routes``. The execute-safe API stays
+    intentionally unwired until the operator approves a separate
+    release."""
+    p = REPO_ROOT / "dashboard" / "dashboard.py"
+    src = p.read_text(encoding="utf-8")
+    assert "register_execute_safe_routes" not in src, (
+        "dashboard/dashboard.py must not wire api_execute_safe_controls"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Status payload no-credential-leak meta-test
+# ---------------------------------------------------------------------------
+
+
+_CREDENTIAL_FRAGMENTS: tuple[str, ...] = (
+    "sk-ant-",
+    "ghp_",
+    "github_pat_",
+    "AKIA",
+    "BEGIN PRIVATE KEY",
+)
+
+
+def test_agent_control_status_endpoint_emits_no_credential_shaped_values(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """End-to-end guard: hitting ``/api/agent-control/status`` must
+    never return a credential-shaped string in any field. We
+    redirect every artifact path into ``tmp_path`` so the test is
+    hermetic."""
+    from flask import Flask
+    from dashboard import api_agent_control as ac
+
+    monkeypatch.setattr(ac, "LOGS_DIR", tmp_path / "logs")
+    monkeypatch.setattr(
+        ac,
+        "WORKLOOP_LATEST",
+        tmp_path / "logs" / "autonomous_workloop" / "latest.json",
+    )
+    monkeypatch.setattr(
+        ac,
+        "PR_LIFECYCLE_LATEST",
+        tmp_path / "logs" / "github_pr_lifecycle" / "latest.json",
+    )
+    flask_app = Flask(__name__)
+    ac.register_agent_control_routes(flask_app)
+    client = flask_app.test_client()
+    resp = client.get("/api/agent-control/status")
+    assert resp.status_code == 200
+    text = resp.get_data(as_text=True)
+    for frag in _CREDENTIAL_FRAGMENTS:
+        assert frag not in text, (
+            f"/api/agent-control/status response leaks credential fragment {frag!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# v3.15.15.25.1 path-reference allowlist preserved
+# ---------------------------------------------------------------------------
+
+
+def test_agent_audit_summary_assert_no_secrets_allows_no_touch_paths() -> None:
+    """The v3.15.15.25.1 narrowing must not be re-broadened. A
+    future regression that re-introduces a ``_SENSITIVE_FRAGMENTS``
+    substring check would break inbox/runtime collection."""
+    from reporting import agent_audit_summary as aas
+
+    for path_ref in aas.KNOWN_NO_TOUCH_PATH_REFERENCES:
+        aas.assert_no_secrets({"path": path_ref})  # must not raise
+
+
+def test_governance_status_assert_no_secrets_allows_no_touch_paths() -> None:
+    from reporting import governance_status as gs
+
+    for path_ref in gs.KNOWN_NO_TOUCH_PATH_REFERENCES:
+        gs.assert_no_secrets({"path": path_ref})  # must not raise
+
+
+def test_approval_policy_assert_no_credential_values_allows_no_touch_paths() -> None:
+    """The shared approval_policy guard is intentionally narrow:
+    only credential VALUES trip; path-shaped strings flow through.
+    Verified verbatim against v3.15.15.24 contract."""
+    from reporting import approval_policy as ap
+
+    for path_ref in (
+        "config/config.yaml",
+        "automation/live_gate.py",
+        "research/research_latest.json",
+    ):
+        ap.assert_no_credential_values({"path": path_ref})  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Frontend bundle source: no mutation fetch
+# ---------------------------------------------------------------------------
+
+
+def test_frontend_agent_control_api_uses_only_get() -> None:
+    """``frontend/src/api/agent_control.ts`` must not call any
+    mutation verb against the agent-control surface. We grep the
+    raw source for ``method:`` declarations."""
+    p = REPO_ROOT / "frontend" / "src" / "api" / "agent_control.ts"
+    src = p.read_text(encoding="utf-8")
+    forbidden = (
+        '"POST"', "'POST'",
+        '"PUT"', "'PUT'",
+        '"PATCH"', "'PATCH'",
+        '"DELETE"', "'DELETE'",
+    )
+    for tok in forbidden:
+        assert tok not in src, (
+            f"frontend/src/api/agent_control.ts contains a forbidden mutation verb: {tok!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Stale-artifact classification (v3.15.15.27)
+# ---------------------------------------------------------------------------
+
+
+def test_autonomy_metrics_classifies_known_missing_as_not_available() -> None:
+    """The two known-missing collectors (recurring_maintenance and
+    execute_safe_controls) must be classified ``missing`` /
+    ``not_available`` — NOT failed, NOT stale. This protects the
+    operator from being told "these are bugs" when they are simply
+    "not yet collected"."""
+    from reporting import autonomy_metrics as am
+
+    for src_path in (
+        "logs/recurring_maintenance/latest.json",
+        "logs/execute_safe_controls/latest.json",
+    ):
+        # The path is one of the canonical SOURCE_ORDER entries.
+        assert any(
+            src_path == rel for _, rel in am.SOURCE_ORDER
+        ), f"missing source path not registered: {src_path}"
+
+
+def test_autonomy_metrics_stale_threshold_is_documented() -> None:
+    """The schema doc must document the stale-threshold default and
+    the env var override."""
+    schema = (
+        REPO_ROOT
+        / "docs"
+        / "governance"
+        / "autonomy_metrics"
+        / "schema.v1.md"
+    )
+    text = schema.read_text(encoding="utf-8")
+    # Either the v3.15.15.27 docs are present (preferred) or the
+    # original v1 schema doc is — staleness is documented as a
+    # reliability metric in both cases.
+    assert "stale_artifact_count" in text
+
+
+# ---------------------------------------------------------------------------
+# No subprocess / network in the agent-control surface
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("rel", _AGENT_CONTROL_BOUNDARY_FILES)
+def test_agent_control_boundary_files_use_no_subprocess_or_network(
+    rel: str,
+) -> None:
+    p = REPO_ROOT / rel
+    src = p.read_text(encoding="utf-8")
+    forbidden = (
+        "import subprocess",
+        "from subprocess",
+        "import requests",
+        "import urllib.request",
+        "from urllib.request",
+        "Popen(",
+    )
+    for tok in forbidden:
+        assert tok not in src, (
+            f"{rel} contains a forbidden import/usage: {tok!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Ad-hoc structural test: status payload shape stays read-only
+# ---------------------------------------------------------------------------
+
+
+def test_agent_control_status_payload_shape_is_read_only(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """End-to-end: every top-level value of the status payload is
+    an envelope (status: ok|not_available) with no embedded
+    "execute" / "approve" / "merge" verbs in any string field."""
+    from flask import Flask
+    from dashboard import api_agent_control as ac
+
+    monkeypatch.setattr(ac, "LOGS_DIR", tmp_path / "logs")
+    monkeypatch.setattr(
+        ac,
+        "WORKLOOP_LATEST",
+        tmp_path / "logs" / "autonomous_workloop" / "latest.json",
+    )
+    monkeypatch.setattr(
+        ac,
+        "PR_LIFECYCLE_LATEST",
+        tmp_path / "logs" / "github_pr_lifecycle" / "latest.json",
+    )
+    flask_app = Flask(__name__)
+    ac.register_agent_control_routes(flask_app)
+    client = flask_app.test_client()
+    body = client.get("/api/agent-control/status").get_json()
+
+    forbidden_verbs = ("execute_now", "approve_now", "merge_now", "ack_now", "reject_now")
+    flat = json.dumps(body).lower()
+    for v in forbidden_verbs:
+        assert v not in flat, f"status payload contains forbidden mutation verb {v!r}"


### PR DESCRIPTION
## Summary

Tightens the observability and security invariants of the existing read-only governance/autonomy stack **without expanding execution authority**. Hardening is enforced by code AND by tests so future regressions trip a unit-test-level guard rather than waiting for a runtime incident.

## Hardening areas

| # | area | before | after |
|---|---|---|---|
| 1 | Stale-artifact detection (\`autonomy_metrics\`) | wired field, never bumped | per-row \`age_seconds\` + \`is_stale\` + counter |
| 2 | Boundary exception-handler invariant | manual review | source-text guard: refuses \`str(e)\`/\`repr(e)\`/\`f\"{e}\"\`/\`e.args\`/\`traceback.format_exc()\` |
| 3 | GET-only verb sweep | manual review | source-text test refuses POST/PUT/PATCH/DELETE in any \`methods=[]\` list |
| 4 | \`api_execute_safe_controls\` wiring | manual review | source-text guard: \`register_execute_safe_routes\` must NOT appear in \`dashboard/dashboard.py\` |
| 5 | v3.15.15.25.1 path-reference allowlist | code-level fix only | test-level guard across 3 modules |
| 6 | Status-payload credential-leak scan | per-source guards | end-to-end Flask test on \`/api/agent-control/status\` |
| 7 | Frontend mutation-fetch sweep | manual review | source-text guard: no POST/PUT/PATCH/DELETE literals in \`agent_control.ts\` |
| 8 | Subprocess / network in dashboard | already absent | source-text guard added |

## Stale-artifact detection (highlight)

Each \`source_statuses\` row whose \`state == \"ok\"\` now carries:

- \`age_seconds: int | null\` — diff between digest's \`generated_at_utc\` and the source artifact's \`generated_at_utc\`.
- \`is_stale: bool\` — true when \`age_seconds > threshold\`.

Threshold:

- default \`STALE_THRESHOLD_SECONDS_DEFAULT = 86400\` (24 hours);
- env var override: \`AUTONOMY_METRICS_STALE_THRESHOLD_SECONDS=<positive int>\`;
- new CLI flag: \`--stale-threshold-seconds <positive int>\`.

A stale row bumps \`reliability.stale_artifact_count\` and feeds the existing \`degraded_failures\` recommendation evaluator.

## Tests added (30 new)

- \`tests/unit/test_observability_security_invariants.py\` — cross-module sweep parametrised over the four agent-control route files: boundary-handler regex sweep, GET-only verb sweep, no-credential scan on the live status endpoint, no-execute-safe wiring, path-reference allowlist preservation across 3 modules, frontend mutation-fetch sweep, subprocess/network sweep.
- \`tests/unit/test_autonomy_metrics.py\` — 8 new staleness cases (default threshold = 24h, fresh = age 0, old = stale + counted, CLI override, env-var override + invalid fallback, null \`generated_at_utc\` behaviour, missing artifact NOT classified stale, CLI flag end-to-end).

## Validation gates green

- governance_lint OK (15 agents, 3 workflows).
- \`pytest tests/smoke\`: 14/14.
- \`pytest tests/unit\`: **3090 passed, 3 skipped** (was 3060 pre-sweep; +30 new hardening tests).
- Frozen contract sha256 unchanged (\`4a567bd6...\` / \`ff15b8c4...\`).

## Files changed

- \`reporting/autonomy_metrics.py\` — staleness detection, env var helper, new CLI flag, threading through \`collect_snapshot\`.
- \`tests/unit/test_autonomy_metrics.py\` — +8 staleness cases; module-version assertion relaxed to \`>= v3.15.15.25\`.
- \`tests/unit/test_observability_security_invariants.py\` — new file (the sweep).
- \`docs/governance/autonomy_metrics.md\` — version note for v3.15.15.27.
- \`docs/governance/autonomy_metrics/schema.v1.md\` — staleness fields documented.
- \`docs/governance/observability_security_hardening.md\` — hardening report.

## Non-goals (explicitly out of scope)

- No new execution authority.
- No browser push notifications.
- No approval / reject mutation UI.
- No \`api_execute_safe_controls\` wiring.
- No HIGH-risk execution.
- No Dependabot execute-safe enablement.
- No external telemetry / paid services / signup flows.
- No live / paper / shadow / risk behavior changes.
- No CI/test weakening.
- No \`.claude/**\` changes.
- No frozen contract changes.
- No \`dashboard/dashboard.py\` changes.

## Test plan

- [ ] CI gates green (governance lint, smoke, unit, frontend, governance smoke)
- [ ] Frozen-contract hashes unchanged on main
- [ ] Stale detection observable via \`python -m reporting.autonomy_metrics --collect --no-write\`
- [ ] No mutation endpoints introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)