### PR TITLE
fix(v3.15.15.26.1): Agent Control PWA service-worker cache versioning

### DIFF
--- a/docs/governance/mobile_agent_control_pwa.md
+++ b/docs/governance/mobile_agent_control_pwa.md
@@ -14,6 +14,73 @@ It explains what the app shows, what it does NOT do, how it is
 laid out for thumb-first mobile use, and the wiring step required
 to move it from "ships in the build" to "served on production".
 
+## v3.15.15.26.1 — Service worker cache-versioning fix
+
+After v3.15.15.26 was merged, the operator reported **no visible
+UX change** in the live PWA. Root cause analysis identified the
+service worker:
+
+* `frontend/public/sw.js` hard-coded the cache name to
+  `agent-control-shell-v1` and never bumped it between releases.
+* The `activate` handler only deleted caches NOT named `v1`, so a
+  new SW with the same cache name purged nothing.
+* `/agent-control` was served cache-first, so an already-installed
+  PWA kept replaying the cached pre-26 HTML — which still
+  referenced the OLD content-hashed asset bundle filenames.
+* Net effect: even after the dashboard served the fresh bundle,
+  the user's browser kept rendering the v3.15.15.21.1 UI until
+  they manually cleared site data.
+
+**Fix in v3.15.15.26.1**:
+
+* Added a single `SW_VERSION` constant pinned to the release
+  (e.g. `v3.15.15.26.1`). All cache names embed it
+  (`agent-control-shell-${SW_VERSION}`).
+* `activate` now uses an inclusive set of known cache names and
+  deletes any cache whose name does not match — including the
+  legacy `v1` caches from a pre-26 install.
+* SPA shell (`/`, `/agent-control`, `/manifest.webmanifest`,
+  `/agent-control-icon.svg`) is now served via
+  **stale-while-revalidate**. The user gets the cached UI
+  immediately *and* the SW fetches the latest in the background;
+  the next refresh shows the new UI.
+* Hashed assets under `/assets/` remain cache-first (safe — they
+  are content-addressed; a new build produces a new filename
+  which is fetched as a cache miss).
+* `/api/agent-control/*` remains **network-first** so the
+  operator never sees stale data.
+* `install` keeps `self.skipWaiting()` and `activate` keeps
+  `self.clients.claim()` so a freshly installed SW takes over on
+  the very next page load.
+
+**Operator instructions to verify v3.15.15.26 UX**:
+
+1. Confirm the deployed Flask container has been rebuilt /
+   restarted from the latest main SHA. The `frontend/dist/`
+   bundle inside the running container must contain the
+   v3.15.15.26 IA. Locally:
+   `npm --prefix frontend run build` produces fresh
+   `dist/assets/index-<hash>.{js,css}`.
+2. Open `/agent-control` on the phone. If the UI still looks
+   like the old grid layout:
+   * Pull-to-refresh once (the new SW will activate during this
+     load and the next refresh will paint the new UI).
+   * If still stale: Settings → site data → clear cache for the
+     dashboard host, then re-open. As a more thorough reset on
+     desktop Chrome: DevTools → Application → Service Workers →
+     Unregister, then hard reload.
+3. The new mobile-first UX must show:
+   * a 5-tab bottom navigation (`Overview / Inbox / Runtime /
+     PRs / About`) on phone-portrait;
+   * a `read-only` safety badge under the title;
+   * the new section grouping (one section visible per tab);
+   * a footer reading `v3.15.15.26 — read-only`.
+
+If all three are visible, v3.15.15.26.1 has propagated. If not,
+the deployment has not yet pushed the latest bundle to the
+serving container — `git pull && docker compose up -d --build` on
+the VPS, then refresh.
+
 ## v3.15.15.26 — Mobile-first IA rebuild
 
 The PWA now uses a **5-tab bottom navigation** on mobile (top

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,5 +1,5 @@
 /**
- * JvR Agent Control PWA — minimal service worker (v3.15.15.18).
+ * JvR Agent Control PWA — minimal service worker (v3.15.15.26.1).
  *
  * Hard guarantees:
  *   - Read-only. The SW never POSTs / PUTs / PATCHes / DELETEs.
@@ -7,9 +7,24 @@
  *     anything else passes through unmodified.
  *   - Network-first for /api/agent-control/* so the user always sees
  *     the latest data when online; cache-fallback when offline.
- *   - Cache-first for the SPA shell so the UI is installable and
- *     usable offline.
+ *   - Stale-while-revalidate for the SPA shell HTML (/, /agent-control,
+ *     manifest, icon) so a freshly deployed UI propagates within one
+ *     refresh cycle even when the SW is already installed.
+ *   - Cache-first for hashed asset bundles (/assets/index-<hash>.js
+ *     etc.) — those are immutable per build.
  *   - No analytics. No external service. No remote scripts.
+ *
+ * Why version-stamped cache names matter:
+ *   In v3.15.15.26 the operator merged a mobile-first IA rebuild but
+ *   reported no visible UX change. Root cause: the v3.15.15.18 SW
+ *   hard-coded ``agent-control-shell-v1`` and never bumped, so an
+ *   already-installed PWA continued to serve the cached pre-26 HTML
+ *   (which referenced the old asset hashes). Bumping the cache name
+ *   forces the activate handler to purge old caches and the shell
+ *   stale-while-revalidate path to reach for a fresh /agent-control.
+ *
+ *   Bump ``SW_VERSION`` on every release that materially changes the
+ *   PWA shell HTML / asset wiring. The default policy is: bump it.
  *
  * Scope: this file is served from "/", so it controls the whole
  * origin. Note that v3.15.15.18 does NOT register a top-level Flask
@@ -19,12 +34,20 @@
  * no-op in production; in `vite dev` it works as expected.
  */
 
-const SHELL_CACHE = "agent-control-shell-v1";
-const RUNTIME_CACHE = "agent-control-runtime-v1";
+// v3.15.15.26.1 — version-stamped cache names. Bump SW_VERSION on
+// every release that materially changes the PWA shell or assets.
+const SW_VERSION = "v3.15.15.26.1";
+const SHELL_CACHE = `agent-control-shell-${SW_VERSION}`;
+const RUNTIME_CACHE = `agent-control-runtime-${SW_VERSION}`;
+const KNOWN_CACHE_NAMES = new Set([SHELL_CACHE, RUNTIME_CACHE]);
 
 const SHELL_ASSETS = ["/agent-control", "/manifest.webmanifest", "/agent-control-icon.svg"];
 
 self.addEventListener("install", (event) => {
+  // skipWaiting() makes a freshly installed SW take over without
+  // waiting for every existing tab to close. Combined with
+  // clients.claim() in activate, this means a deploy propagates on
+  // the next page load rather than the next browser restart.
   event.waitUntil(
     caches
       .open(SHELL_CACHE)
@@ -34,11 +57,15 @@ self.addEventListener("install", (event) => {
 });
 
 self.addEventListener("activate", (event) => {
+  // Purge ANY cache whose name does not match the current
+  // version-stamped pair. This is what makes a release actually
+  // visible to an already-installed PWA: caches from the prior
+  // SW (e.g. ``agent-control-shell-v1``) get deleted on activate.
   event.waitUntil(
     caches.keys().then((keys) =>
       Promise.all(
         keys
-          .filter((k) => k !== SHELL_CACHE && k !== RUNTIME_CACHE)
+          .filter((k) => !KNOWN_CACHE_NAMES.has(k))
           .map((k) => caches.delete(k)),
       ),
     ).then(() => self.clients.claim()),
@@ -59,14 +86,22 @@ self.addEventListener("fetch", (event) => {
     return;
   }
 
-  // Static SPA shell — cache-first.
+  // SPA shell HTML / manifest / icon — stale-while-revalidate so a
+  // deployed UI change propagates within one refresh.
   if (
     url.pathname === "/" ||
     url.pathname === "/agent-control" ||
-    url.pathname.startsWith("/assets/") ||
     url.pathname === "/manifest.webmanifest" ||
     url.pathname === "/agent-control-icon.svg"
   ) {
+    event.respondWith(staleWhileRevalidate(req));
+    return;
+  }
+
+  // Hashed asset bundles (Vite emits ``/assets/index-<hash>.{js,css}``)
+  // are content-addressed; cache-first is safe — a new bundle
+  // produces a different filename which is fetched as a cache miss.
+  if (url.pathname.startsWith("/assets/")) {
     event.respondWith(cacheFirst(req));
     return;
   }
@@ -88,6 +123,35 @@ async function cacheFirst(req) {
   } catch (err) {
     return new Response("offline", { status: 503, statusText: "offline" });
   }
+}
+
+async function staleWhileRevalidate(req) {
+  // Serve cache immediately if present; in parallel fetch the
+  // network and refresh the cache. The next visit will see the
+  // refreshed copy. This is the right policy for shell HTML
+  // because the operator wants new UI as soon as possible while
+  // still having a working offline shell on next launch.
+  const cache = await caches.open(SHELL_CACHE);
+  const cachedPromise = cache.match(req);
+  const networkPromise = fetch(req)
+    .then((res) => {
+      if (res && res.ok) {
+        cache.put(req, res.clone()).catch(() => undefined);
+      }
+      return res;
+    })
+    .catch(() => undefined);
+  const cached = await cachedPromise;
+  if (cached) {
+    // Kick the revalidation but do not block on it.
+    networkPromise.catch(() => undefined);
+    return cached;
+  }
+  // No cache hit — wait for the network and synthesise an offline
+  // response if it fails outright.
+  const networked = await networkPromise;
+  if (networked) return networked;
+  return new Response("offline", { status: 503, statusText: "offline" });
 }
 
 async function networkFirst(req) {

--- a/frontend/src/test/PWAManifest.test.tsx
+++ b/frontend/src/test/PWAManifest.test.tsx
@@ -80,3 +80,76 @@ describe("PWA: registration", () => {
     expect(mainRaw).toMatch(/\.catch\(/);
   });
 });
+
+describe("PWA: service worker cache versioning (v3.15.15.26.1)", () => {
+  it("declares a versioned SW_VERSION constant tied to the release", () => {
+    // The fix is anchored on a single SW_VERSION constant so future
+    // releases bump exactly one place. The constant must be a real
+    // version string (not the legacy "v1") so it visibly differs
+    // from any installed pre-26 SW.
+    expect(swRaw).toMatch(/SW_VERSION\s*=\s*["']v3\.15\.15\./);
+  });
+
+  it("uses version-stamped cache names for shell + runtime", () => {
+    expect(swRaw).toMatch(/agent-control-shell-\$\{SW_VERSION\}/);
+    expect(swRaw).toMatch(/agent-control-runtime-\$\{SW_VERSION\}/);
+  });
+
+  it("activate handler purges any cache name not matching the current SW_VERSION", () => {
+    // The fix: instead of allowing only legacy v1 cache names, the
+    // activate handler now uses a SET of known names and deletes
+    // every cache whose name is NOT in that set. That is what
+    // forces stale pre-26 caches to actually go away.
+    expect(swRaw).toMatch(/KNOWN_CACHE_NAMES/);
+    expect(swRaw).toMatch(/!KNOWN_CACHE_NAMES\.has\(k\)/);
+    expect(swRaw).toMatch(/caches\.delete\(k\)/);
+  });
+
+  it("install calls skipWaiting and activate calls clients.claim for prompt update", () => {
+    expect(swRaw).toMatch(/self\.skipWaiting\(\)/);
+    expect(swRaw).toMatch(/self\.clients\.claim\(\)/);
+  });
+
+  it("shell HTML uses stale-while-revalidate, not permanent cache-first", () => {
+    // The pre-fix bug: ``/agent-control`` was served cache-first,
+    // so a new build never reached the user. The fix routes shell
+    // navigation through staleWhileRevalidate.
+    expect(swRaw).toMatch(/staleWhileRevalidate\s*\(/);
+    // The shell-route block routes / and /agent-control through
+    // stale-while-revalidate.
+    expect(swRaw).toMatch(/url\.pathname === ["']\/agent-control["']/);
+  });
+
+  it("API routes are network-first, not stale-while-revalidate", () => {
+    // /api/* must keep network-first semantics so the operator
+    // never sees stale agent-control data.
+    expect(swRaw).toMatch(/url\.pathname\.startsWith\(["']\/api\/agent-control\/["']\)/);
+    expect(swRaw).toMatch(/networkFirst\s*\(\s*req\s*\)/);
+  });
+
+  it("hashed assets remain cache-first", () => {
+    // Vite emits content-addressed bundles under /assets/. They
+    // are immutable per build, so cache-first is safe and the
+    // fastest path. A new build naturally produces a new filename
+    // which the SW fetches as a cache miss.
+    expect(swRaw).toMatch(/url\.pathname\.startsWith\(["']\/assets\/["']\)/);
+    expect(swRaw).toMatch(/cacheFirst\s*\(\s*req\s*\)/);
+  });
+
+  it("does not introduce any mutation verb in the new SW", () => {
+    // Hardening regression guard: the cache-fix release must not
+    // smuggle a POST/PUT/PATCH/DELETE into the SW.
+    expect(swRaw).toMatch(/req\.method !== ["']GET["']/);
+    for (const verb of ["POST", "PUT", "PATCH", "DELETE"]) {
+      expect(swRaw).not.toContain(`method: "${verb}"`);
+      expect(swRaw).not.toContain(`method:'${verb}'`);
+    }
+  });
+
+  it("does not reach external services in the new SW either", () => {
+    expect(swRaw).not.toMatch(
+      /google-analytics|googletagmanager|sentry|datadog|segment\.io/i,
+    );
+    expect(swRaw).not.toMatch(/https?:\/\//);
+  });
+});


### PR DESCRIPTION
## Summary

Operator reported **no visible UX change** in the live PWA after v3.15.15.26 was merged. This release fixes the cause and adds regression tests so it cannot recur silently on a future release.

## Root cause

| | before fix |
|---|---|
| Cache name | hard-coded \`agent-control-shell-v1\`; never bumped between releases |
| Activate handler | only deleted caches NOT named \`v1\` → a fresh SW with the same cache name purged nothing |
| Shell route | \`/agent-control\` was served **cache-first**, so an installed PWA replayed cached pre-26 HTML — which still referenced the OLD content-hashed asset bundle filenames |
| Net effect | even after the dashboard served the fresh bundle, the user's browser kept rendering the v3.15.15.21.1 UI until they manually cleared site data |

## Fix

| | after fix |
|---|---|
| Cache name | embeds a single \`SW_VERSION\` constant (\`v3.15.15.26.1\`); bumped on every release that materially changes the shell |
| Activate handler | uses an inclusive \`KNOWN_CACHE_NAMES\` set and **deletes every cache whose name is not in the set** — including the legacy \`v1\` |
| Shell route | now **stale-while-revalidate**: cache responds immediately, network refresh in parallel, next refresh paints the new UI |
| /assets/* | remains **cache-first** (safe — content-addressed; a new build produces a new filename which is fetched as a cache miss) |
| /api/agent-control/* | remains **network-first**; operator never sees stale data |
| Update propagation | \`self.skipWaiting()\` in install + \`self.clients.claim()\` in activate; new SW takes over on next page load |

## Tests added (9 new)

\`PWAManifest.test.tsx\`:

- \`SW_VERSION\` constant matches the release tag pattern.
- Cache names embed \`SW_VERSION\` for shell + runtime.
- Activate purges any cache name not in \`KNOWN_CACHE_NAMES\`.
- \`skipWaiting\` + \`clients.claim\` wired for prompt update.
- Shell HTML uses \`staleWhileRevalidate\`, not cache-first forever.
- \`/api/*\` uses \`networkFirst\`.
- \`/assets/*\` remains \`cacheFirst\`.
- No mutation verb in the new SW.
- No external services in the new SW.

## Validation gates green

- governance_lint OK (15 agents, 3 workflows).
- \`pytest tests/smoke\`: 14/14.
- \`pytest tests/unit\`: **3090 passed, 3 skipped** (unchanged; Python untouched).
- frontend vitest: **78/78** across 8 files (was 69; +9 new SW cache-versioning regression tests).
- frontend build: green (272 KB JS gzip 78 KB).
- Frozen contract sha256 unchanged (\`4a567bd6...\` / \`ff15b8c4...\`).

## Operator verification (after merge + deploy)

1. Confirm the deployed Flask container has been rebuilt / restarted from the latest main SHA. The \`frontend/dist/\` bundle inside the running container must contain the v3.15.15.26 IA. Locally: \`npm --prefix frontend run build\` produces fresh \`dist/assets/index-<hash>.{js,css}\`.
2. On the phone: pull-to-refresh; the new SW activates during that load and the next refresh paints the v3.15.15.26 UI (5-tab bottom nav, read-only badge, section grouping, footer reading \`v3.15.15.26 — read-only\`).
3. If still stale (rare — only happens if the browser cached \`/sw.js\` itself): clear site data for the dashboard host, or (desktop Chrome) DevTools → Application → Service Workers → Unregister → hard reload.

## Files changed

- \`frontend/public/sw.js\` — version-stamped cache names, activate purge, stale-while-revalidate for shell, full operator-runbook comment.
- \`frontend/src/test/PWAManifest.test.tsx\` — 9 new SW cache-versioning regression tests.
- \`docs/governance/mobile_agent_control_pwa.md\` — root-cause analysis section + operator verification steps.

## Non-goals (explicitly out of scope)

- No execute / approve / reject / merge buttons.
- No POST/PUT/PATCH/DELETE.
- No \`api_execute_safe_controls\` wiring.
- No browser push.
- No external telemetry / paid services / signup flows.
- No live / paper / shadow / risk behavior changes.
- No CI/test weakening.
- No \`.claude/**\` changes.
- No frozen contract changes.
- No \`dashboard/dashboard.py\` changes.

## Test plan

- [ ] CI gates green (governance lint, smoke, unit, frontend, governance smoke)
- [ ] Frozen-contract hashes unchanged on main
- [ ] After deploy + refresh: phone shows the v3.15.15.26 mobile-first UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)