### PR TITLE
feat(v3.15.15.28): roadmap item execution protocol

### DIFF
--- a/dashboard/api_agent_control.py
+++ b/dashboard/api_agent_control.py
@@ -185,7 +185,50 @@ def _status_payload() -> dict[str, Any]:
         "recurring_maintenance": _recurring_maintenance_summary(),
         "approval_policy": _approval_policy_summary(),
         "autonomy_metrics": _autonomy_metrics_summary(),
+        "roadmap_protocol": _roadmap_protocol_summary(),
     }
+
+
+def _roadmap_protocol_summary() -> dict[str, Any]:
+    """Project the v3.15.15.28 roadmap-execution protocol's latest
+    plan into a compact summary for the Status card. Returns
+    ``not_available`` if no plan has been written yet (the protocol
+    is opt-in; the operator runs ``--plan-item ... --dry-run`` and
+    that produces ``logs/roadmap_execution_protocol/latest.json``).
+    """
+    try:
+        from reporting.roadmap_execution_protocol import read_latest_snapshot
+
+        snap = read_latest_snapshot()
+        if snap is None:
+            return {"status": "not_available", "reason": "missing"}
+        return {
+            "status": "ok",
+            "data": {
+                "module_version": snap.get("module_version"),
+                "schema_version": snap.get("schema_version"),
+                "generated_at_utc": snap.get("generated_at_utc"),
+                "item_id": snap.get("item_id"),
+                "title": snap.get("title"),
+                "item_type": snap.get("item_type"),
+                "risk_class": snap.get("risk_class"),
+                "decision": snap.get("decision"),
+                "status_field": snap.get("status"),
+                "implementation_allowed": snap.get(
+                    "implementation_allowed", False
+                ),
+                "executable": snap.get("executable", False),
+                "safe_to_execute": snap.get("safe_to_execute", False),
+                "blocked_reason": snap.get("blocked_reason"),
+                "proposed_release_id": snap.get("proposed_release_id"),
+                "proposed_branch": snap.get("proposed_branch"),
+            },
+        }
+    except Exception as e:  # noqa: BLE001
+        return {
+            "status": "not_available",
+            "reason": f"roadmap_execution_protocol_error: {type(e).__name__}",
+        }
 
 
 def _autonomy_metrics_summary() -> dict[str, Any]:

--- a/docs/governance/agent_handoff_protocol.md
+++ b/docs/governance/agent_handoff_protocol.md
@@ -1,0 +1,160 @@
+# Agent handoff protocol — operator runbook
+
+Module: `reporting.roadmap_execution_protocol`
+Version: v3.15.15.28
+Sibling docs: `roadmap_item_execution_protocol.md`,
+`high_risk_approval_policy.md`, `permission_model.md`.
+
+This is the canonical description of the eight agent roles that
+participate in roadmap-item execution. Every role definition is
+emitted verbatim by
+`python -m reporting.roadmap_execution_protocol --describe`.
+
+## Roles and handoff order
+
+The handoff sequence is fixed; a plan that skips a role is
+treated as `unknown_state` by the operator.
+
+```
+1. Product Owner Agent
+       ↓ (acceptance_criteria, scope_summary, user_value)
+2. Strategic Advisor
+       ↓ (strategic_fit, deferral_recommendation)
+3. Planner Agent
+       ↓ (proposed_branch, proposed_release_id, required_tests,
+          expected_artifacts, rollback_plan)
+4. Implementation Agent (only after operator approval)
+       ↓ (PR URL, CI status, self_review_notes)
+5. Architecture Guardian            ┐
+6. CI Guardian                      ├ parallel reviews
+7. Security/Governance Guardian     ┘
+       ↓ (per-guardian pass_or_block)
+8. Operator (Joery)
+       ↓ merge_decision, post_merge_signal
+```
+
+## Role contracts (summary)
+
+For each role: responsibilities, allowed actions, forbidden
+actions, handoff input, handoff output, required evidence. The
+canonical machine-readable form is the `--describe` output;
+the prose below mirrors it for operator review.
+
+### 1. Product Owner Agent (`product_owner`)
+
+* Converts a roadmap item into operator-shaped acceptance
+  criteria.
+* Prevents vague scope; rejects items without measurable value.
+* Confirms user value with the operator before any branch is
+  opened.
+* Cannot open branches / PRs / modify code / modify tests /
+  modify governance.
+
+### 2. Strategic Advisor (`strategic_advisor`)
+
+* Checks sequencing and strategic fit against the autonomy
+  roadmap.
+* Recommends deferral or split when scope is too large.
+* Raises authority concerns to the operator.
+* Cannot implement directly / approve HIGH-risk items / open or
+  merge PRs.
+
+### 3. Planner Agent (`planner`)
+
+* Produces a bounded release plan.
+* Defines branch, commit boundaries, tests, rollback.
+* Lists expected artefacts and operator-visible changes.
+* Cannot implement code / open branches in git / open PRs /
+  modify governance / modify `.claude/**`.
+
+### 4. Implementation Agent (`implementation_agent`)
+
+* Implements only the approved scope on the proposed branch.
+* Makes no scope changes without re-running the protocol.
+* Runs all required tests before opening the PR.
+* Cannot expand scope without operator approval, weaken tests /
+  governance / CI, force push, admin merge, direct main push,
+  modify `.claude/**`, modify frozen contracts, modify
+  `automation/live_gate.py`, or wire `api_execute_safe_controls`
+  without an explicit operator brief.
+
+### 5. Architecture Guardian (`architecture_guardian`)
+
+* Checks layering, contracts, frozen outputs, no-touch files.
+* Verifies no protected-path or live-trading touch.
+* Confirms schema-version bumps when a contract changes.
+* Cannot rewrite the implementation, merge the PR, or wave
+  through HIGH-risk items.
+
+### 6. CI Guardian (`ci_guardian`)
+
+* Verifies required GitHub checks all green.
+* Verifies no test was skipped, deleted, or weakened.
+* Verifies required smoke + unit + governance_lint coverage.
+* Cannot skip or downgrade required checks, merge the PR, or
+  modify CI workflows outside a separate ci-hardening release.
+
+### 7. Security / Governance Guardian (`security_governance_guardian`)
+
+* Checks for secret-shaped values, protected paths, mutation
+  routes.
+* Checks for unsafe automation or governance weakening.
+* Checks `approval_policy` compliance for the item.
+* Cannot approve HIGH/UNKNOWN items autonomously, merge the PR,
+  or weaken redaction or guards.
+
+### 8. Operator (Joery) (`operator`)
+
+* Decides HIGH / UNKNOWN / `needs_human` items.
+* Approves external accounts / secrets / paid / telemetry.
+* Approves live / paper / shadow / risk changes.
+* Approves canonical roadmap adoption.
+* Is the trust boundary; the only role with no forbidden
+  actions.
+
+## When the chain breaks
+
+If any role's `handoff_output` is missing, the next role refuses
+its handoff and the protocol module emits a plan with
+`status="unknown_state"` and a deterministic `blocked_reason`.
+The operator inspects the plan in
+`logs/roadmap_execution_protocol/latest.json` and decides whether
+to re-run the protocol or reject the item.
+
+## Examples
+
+### Healthy LOW docs item
+
+```
+PO drafts criteria → Strategic confirms scope is bounded →
+Planner produces branch/tests/rollback → Operator approves →
+Implementation Agent commits docs only → Guardians review →
+Operator merges.
+```
+
+### Blocked HIGH live-trading item
+
+```
+PO drafts criteria → Strategic flags item as live-risk →
+approval_policy returns blocked_live_paper_shadow_risk →
+plan status = blocked → operator inspects → operator EITHER
+accepts the block (item is dropped or re-shaped) OR re-runs
+the protocol with a redesigned scope that no longer touches
+the live path.
+```
+
+### Unknown-evidence item
+
+```
+PO cannot articulate user value → no acceptance_criteria →
+Strategic / Planner refuse handoff → plan status = unknown_state
+→ operator decides whether to discard or refine.
+```
+
+## Cross-references
+
+* `docs/governance/roadmap_item_execution_protocol.md`
+* `docs/governance/roadmap_item_execution_protocol/schema.v1.md`
+* `docs/governance/high_risk_approval_policy.md`
+* `docs/governance/permission_model.md`
+* `docs/governance/no_touch_paths.md`

--- a/docs/governance/roadmap_item_execution_protocol.md
+++ b/docs/governance/roadmap_item_execution_protocol.md
@@ -1,0 +1,303 @@
+# Roadmap item execution protocol — operator runbook
+
+Module: `reporting.roadmap_execution_protocol`
+Version: v3.15.15.28
+Schema: `docs/governance/roadmap_item_execution_protocol/schema.v1.md`
+Sibling docs: `agent_handoff_protocol.md`,
+`high_risk_approval_policy.md`,
+`approval_exception_inbox.md`, `roadmap_proposal_queue.md`,
+`mobile_agent_control_pwa.md`.
+
+## TL;DR
+
+Read-only protocol module that converts a roadmap item into a
+**fully-specified execution plan** without running any code.
+Implementation never happens here. The operator decides whether
+to start a real branch + PR by hand using the plan's
+deterministic outputs (proposed branch name, required tests,
+acceptance criteria, agent assignments, merge requirements,
+post-merge checks).
+
+This release does NOT implement a roadmap item. It creates the
+protocol and artefacts that make future roadmap item execution
+controlled and repeatable.
+
+## Roadmap item flow (16 steps)
+
+```
+1. Intake
+2. Classification               (this module)
+3. Proposal                     (proposal_queue + this module)
+4. Agent assignment             (this module)
+5. Plan                         (this module)
+6. Approval gate if needed      (approval_inbox + operator)
+7. Branch                       (operator-led git checkout -b ...)
+8. Implementation               (operator + Implementation Agent on branch)
+9. Tests                        (the required_tests list)
+10. Self-review                 (Implementation Agent)
+11. Guardian review             (architecture / ci / security guardians)
+12. PR                          (operator-led gh pr create)
+13. CI                          (the existing 16 GitHub checks)
+14. Merge                       (operator-led gh pr merge --squash)
+15. Post-merge verification     (the post_merge_checks list)
+16. Metrics/dashboard update    (workloop_runtime + autonomy_metrics)
+```
+
+The protocol module owns steps 2–5; everything else is operator
+or sibling-module territory.
+
+## Core principle
+
+A roadmap item must NEVER trigger direct execution. The plan is
+a proposal; only the operator may approve a branch open / PR
+merge. HIGH and UNKNOWN items are blocked by construction.
+
+## CLI
+
+```
+python -m reporting.roadmap_execution_protocol --describe
+python -m reporting.roadmap_execution_protocol \
+    --plan-item path/to/item.json --dry-run
+python -m reporting.roadmap_execution_protocol \
+    --plan-item '{"title": "Add docs", "summary": "..."}' --dry-run
+python -m reporting.roadmap_execution_protocol --status
+```
+
+`--plan-item` REQUIRES `--dry-run`. The CLI refuses any other
+mode in this release (`parser.error`). `--describe` prints the
+agent role catalogue + statuses + item types + merge
+requirements as a deterministic JSON document.
+
+`--status` reads the latest plan from
+`logs/roadmap_execution_protocol/latest.json`.
+
+## Item types and their fates
+
+Open to implementation (when the policy says
+`allowed_read_only`):
+
+* `docs_only`
+* `frontend_read_only`
+* `reporting_read_only`
+* `test_only`
+* `observability_addition`
+
+Always route to operator review:
+
+* `tooling_intake` (HIGH-shape variants block; LOW-shape
+  variants need_human via the existing tooling-intake policy)
+* `dependency_floor_bump` (CI guardian must confirm no SHA pin
+  downgrade)
+* `ci_hardening` (`touches_ci_or_tests` -> blocked from
+  auto-implementation by approval_policy)
+
+Always blocked:
+
+* `governance_change`
+* `canonical_roadmap_adoption`
+* `live_paper_shadow_risk`
+* `external_account_or_secret`
+* `telemetry_or_data_egress`
+* `paid_tool`
+
+`unknown` -> `unknown_state` -> operator inspects.
+
+## Approval rules
+
+The protocol delegates risk decisions to
+`reporting.approval_policy.decide()` and embeds the verbatim
+`PolicyDecision` in the plan's `approval_policy_decision` field.
+Rules:
+
+* LOW / MEDIUM may proceed only if policy says so.
+* HIGH / UNKNOWN must route to `needs_human`.
+* Canonical roadmap adoption requires human approval.
+* Live / paper / shadow / risk requires human approval.
+* Secrets / external / paid / telemetry require human approval.
+* Protected / frozen / governance weakening blocked.
+* Missing evidence => UNKNOWN, never a permissive default.
+
+## PR lifecycle protocol
+
+A roadmap-item PR must satisfy:
+
+* one roadmap item per branch (branch name is deterministic
+  from `proposed_branch`);
+* no direct main push;
+* no force push;
+* no `gh pr merge --admin`;
+* PR body must include:
+  * release id
+  * roadmap item id
+  * scope summary
+  * files changed
+  * risk class
+  * approval decision
+  * tests run
+  * frozen-hash check result
+  * screenshots for frontend / PWA changes
+  * confirmation of the `forbidden_scope` list
+  * rollback note
+* merge only when ALL of:
+  * CI green
+  * local gates green
+  * frozen hashes unchanged
+  * policy says not HIGH / UNKNOWN executable
+  * no protected-path / live-path / governance-weakening touch
+  * no test/CI weakening
+  * no unresolved approval-inbox row tied to the same `item_id`.
+
+These are emitted verbatim under `merge_requirements` on every
+plan so a guardian can read them off the digest.
+
+## How the operator is notified
+
+* When `status == "needs_human"` or `status == "blocked"`, the
+  approval inbox surfaces the plan via the existing inbox
+  category mapping.
+* When `safety.high_or_unknown_executable_count > 0` would ever
+  flip in `autonomy_metrics`, the metrics digest reports
+  `unsafe_state_detected` — by construction this should never
+  happen for a roadmap-item plan because `executable=false`.
+* The Agent Control PWA Status card surfaces a `roadmap protocol`
+  row pulled from the projection on
+  `/api/agent-control/status`.
+
+## Examples
+
+### LOW docs-only item -> implementation_allowed
+
+Input:
+
+```json
+{
+  "item_id": "r_docs_aaaa",
+  "title": "Add operator runbook for the new metrics module",
+  "summary": "Document the v3.15.15.27 staleness threshold semantics in docs/governance/autonomy_metrics.md and link from observability_security_hardening.md",
+  "affected_files": ["docs/governance/autonomy_metrics.md"],
+  "risk_class": "LOW"
+}
+```
+
+Plan (excerpt):
+
+```
+item_type: docs_only
+risk_class: LOW
+decision: allowed_read_only
+status: proposed
+implementation_allowed: true
+proposed_branch: fix/v3-15-16-x-r-docs-aaaa-add-operator-runbook-...
+required_tests: governance_lint, smoke, frozen-hash, doc presence
+guardian_reviews_required: architecture_guardian, ci_guardian, security_governance_guardian
+```
+
+### MEDIUM PWA read-only item -> implementation_allowed
+
+Input:
+
+```json
+{
+  "item_id": "r_pwa_bbbb",
+  "title": "PWA Status card: render a roadmap protocol row",
+  "summary": "Read-only display of logs/roadmap_execution_protocol/latest.json on the Status card",
+  "affected_files": [
+    "frontend/src/routes/AgentControl.tsx",
+    "frontend/src/api/agent_control.ts"
+  ],
+  "risk_class": "MEDIUM"
+}
+```
+
+Plan (excerpt):
+
+```
+item_type: frontend_read_only
+risk_class: MEDIUM
+decision: allowed_read_only
+status: proposed
+implementation_allowed: true
+required_tests: ..., npm --prefix frontend test -- --run, npm --prefix frontend run build
+acceptance_criteria:
+  - the new UI is visible on phone-portrait at /agent-control
+  - no execute / approve / reject / merge buttons added
+  - no mutation fetch verbs in frontend code
+```
+
+### HIGH live/risk item -> blocked
+
+Input:
+
+```json
+{
+  "item_id": "r_live_cccc",
+  "title": "Switch broker_kraken.py to use the live API",
+  "summary": "Update execution/live/broker_kraken.py to set use_live=True",
+  "affected_files": ["execution/live/broker_kraken.py"],
+  "risk_class": "HIGH"
+}
+```
+
+Plan (excerpt):
+
+```
+item_type: live_paper_shadow_risk
+risk_class: HIGH
+decision: blocked_live_paper_shadow_risk
+status: blocked
+implementation_allowed: false
+blocked_reason: approval_policy: blocked_live_paper_shadow_risk (...)
+forbidden_actions: includes "execute live broker", "place real-money order"
+```
+
+### UNKNOWN item -> blocked_unknown
+
+Input:
+
+```json
+{
+  "item_id": "r_unknown_dddd",
+  "title": "(unknown source)"
+}
+```
+
+Plan (excerpt):
+
+```
+item_type: unknown
+risk_class: UNKNOWN
+decision: blocked_unknown
+status: unknown_state
+implementation_allowed: false
+blocked_reason: unknown_item_type: routes to operator inspection
+```
+
+## What remains forbidden
+
+Everything in `approval_policy.UNIVERSAL_FORBIDDEN_AGENT_ACTIONS`
+plus per-decision extras, surfaced verbatim on every plan.
+
+The protocol module itself never:
+
+* opens a branch
+* opens a PR
+* merges a PR
+* runs tests
+* writes outside `logs/roadmap_execution_protocol/`
+* runs subprocess / `gh` / `git`
+* makes network calls
+* mutates frozen contracts
+* mutates `.claude/**`
+* enables Dependabot execute-safe
+* surfaces credential-shaped values
+
+## Cross-references
+
+* Schema: `docs/governance/roadmap_item_execution_protocol/schema.v1.md`
+* Agent handoff: `docs/governance/agent_handoff_protocol.md`
+* Approval policy: `docs/governance/high_risk_approval_policy.md`
+* Approval inbox: `docs/governance/approval_exception_inbox.md`
+* Proposal queue: `docs/governance/roadmap_proposal_queue.md`
+* PR lifecycle: `docs/governance/github_pr_lifecycle_integration.md`
+* PWA: `docs/governance/mobile_agent_control_pwa.md`
+* No-touch paths: `docs/governance/no_touch_paths.md`

--- a/docs/governance/roadmap_item_execution_protocol/schema.v1.md
+++ b/docs/governance/roadmap_item_execution_protocol/schema.v1.md
@@ -1,0 +1,198 @@
+# Roadmap item execution protocol — schema v1
+
+Module: `reporting.roadmap_execution_protocol` (v3.15.15.28)
+Schema version: `1`
+Stability: stable; additions are SemVer minor, removals are
+breaking.
+
+This is the machine-readable description of the roadmap-item
+execution plan emitted by `python -m reporting.roadmap_execution_protocol --plan-item ... --dry-run`.
+
+## Top-level shape
+
+```json
+{
+  "schema_version": 1,
+  "report_kind": "roadmap_execution_plan",
+  "module_version": "v3.15.15.28",
+  "generated_at_utc": "2026-05-03T08:00:00Z",
+  "item_id": "r_xxxxxxxx",
+  "source": "docs/roadmap/v3.15.16.md#item-3",
+  "source_type": "markdown_heading",
+  "title": "...",
+  "summary": "...",
+  "roadmap_reference": "docs/roadmap/v3.15.16.md",
+  "proposed_release_id": "v3.15.16.0",
+  "proposed_branch": "fix/v3-15-16-r-xxxxxxxx-...",
+  "item_type": "<one of ITEM_TYPES>",
+  "risk_class": "LOW | MEDIUM | HIGH | UNKNOWN",
+  "decision": "<one of approval_policy.DECISIONS>",
+  "approval_policy_decision": { ...PolicyDecision.to_dict()... },
+  "requires_human": bool,
+  "executable": false,
+  "implementation_allowed": bool,
+  "affected_areas": [string],
+  "forbidden_actions": [string],
+  "required_tests": [string],
+  "expected_artifacts": [string],
+  "rollback_plan": [string],
+  "acceptance_criteria": [string],
+  "agent_assignments": [AgentRole.to_dict()...],
+  "guardian_reviews_required": [string],
+  "merge_requirements": [string],
+  "post_merge_checks": [string],
+  "status": "<one of STATUSES>",
+  "blocked_reason": "..." | null,
+  "policy": {
+    "module_version": "v3.15.15.24",
+    "schema_version": 1,
+    "high_or_unknown_is_executable": false
+  },
+  "safe_to_execute": false
+}
+```
+
+## ITEM_TYPES (closed)
+
+```
+docs_only
+frontend_read_only
+reporting_read_only
+test_only
+dependency_floor_bump
+ci_hardening
+observability_addition
+tooling_intake
+governance_change
+canonical_roadmap_adoption
+live_paper_shadow_risk
+external_account_or_secret
+telemetry_or_data_egress
+paid_tool
+unknown
+```
+
+## STATUSES (closed)
+
+```
+proposed
+needs_human
+blocked
+unknown_state
+```
+
+## ITEM_TYPES open to implementation
+
+A plan with `implementation_allowed=true` is restricted to:
+
+```
+docs_only
+frontend_read_only
+reporting_read_only
+test_only
+observability_addition
+```
+
+Every other type routes to `needs_human` or `blocked` regardless
+of policy decision.
+
+## Agent role catalogue
+
+Eight roles, every plan surfaces all eight in `agent_assignments`
+in the canonical handoff order:
+
+1. `product_owner` — Product Owner Agent
+2. `strategic_advisor` — Strategic Advisor
+3. `planner` — Planner Agent
+4. `implementation_agent` — Implementation Agent
+5. `architecture_guardian` — Architecture Guardian
+6. `ci_guardian` — CI Guardian
+7. `security_governance_guardian` — Security / Governance Guardian
+8. `operator` — Operator (Joery)
+
+Each role is described by:
+
+```
+{
+  "name": string,
+  "title": string,
+  "responsibilities": [string],
+  "allowed_actions": [string],
+  "forbidden_actions": [string],
+  "handoff_input": [string],
+  "handoff_output": [string],
+  "required_evidence": [string]
+}
+```
+
+## guardian_reviews_required
+
+Always populated (even on blocked plans) so the operator can
+audit which guardian would block:
+
+```
+architecture_guardian
+ci_guardian
+security_governance_guardian
+```
+
+## merge_requirements
+
+Closed list, returned verbatim per release:
+
+```
+all required GitHub checks green
+local governance_lint OK
+local pytest tests/smoke OK
+frozen contract sha256 unchanged
+approval_policy decision is not HIGH/UNKNOWN executable
+no protected-path / live-path / governance-weakening touch
+no test/CI weakening
+no unresolved approval inbox row tied to the same item_id
+```
+
+## post_merge_checks
+
+```
+pull main
+verify final main SHA
+rerun python -m reporting.workloop_runtime --once
+rerun python -m reporting.autonomy_metrics --collect
+verify approval_inbox does not surface a new runtime_halt for the merged item
+verify frozen contract sha256 unchanged
+```
+
+## Determinism
+
+* `agent_assignments` is always returned in the canonical role
+  order.
+* `guardian_reviews_required` / `merge_requirements` /
+  `post_merge_checks` are deterministic per release.
+* `proposed_branch` is a deterministic slug:
+  `fix/<release_slug>-<item_slug>-<title_slug>`.
+* `generated_at_utc` is the only clock-derived field; pin via
+  `--frozen-utc` for tests.
+* `item_id` defaults to `r_<sha256(title|summary)[:8]>` when not
+  declared upstream.
+
+## Atomic writes
+
+Plans are written via `tmp` + `os.replace` to
+`logs/roadmap_execution_protocol/`:
+
+* `latest.json` — the most recent plan
+* `<utc>.json` — timestamped copy (byte-identical to latest)
+* `history.jsonl` — append-only log of all plans
+
+## Hard constraints
+
+* Stdlib-only. No subprocess, no `gh`, no `git`, no network.
+* `--plan-item` requires `--dry-run`; the protocol never
+  implements.
+* `safe_to_execute` is hard-coded `false` at the digest level.
+* `executable` is hard-coded `false` on every plan.
+* `implementation_allowed` is True only for the closed
+  `ITEM_TYPES_OPEN_TO_IMPLEMENTATION` set AND
+  `decision == allowed_read_only`.
+* No credential-shaped values are emitted (verified by
+  `approval_policy.assert_no_credential_values`).

--- a/frontend/src/api/agent_control.ts
+++ b/frontend/src/api/agent_control.ts
@@ -105,6 +105,27 @@ export interface AgentControlStatus {
       };
     };
   };
+  roadmap_protocol?: {
+    status: "ok" | "not_available";
+    reason?: string;
+    data?: {
+      module_version?: string;
+      schema_version?: number;
+      generated_at_utc?: string;
+      item_id?: string;
+      title?: string;
+      item_type?: string;
+      risk_class?: string;
+      decision?: string;
+      status_field?: string;
+      implementation_allowed?: boolean;
+      executable?: boolean;
+      safe_to_execute?: boolean;
+      blocked_reason?: string | null;
+      proposed_release_id?: string;
+      proposed_branch?: string;
+    };
+  };
 }
 
 export interface AgentControlActivity {

--- a/frontend/src/routes/AgentControl.tsx
+++ b/frontend/src/routes/AgentControl.tsx
@@ -188,6 +188,22 @@ function StatusCard({ payload }: { payload: AgentControlStatus | null }) {
   const operatorActions = String(
     metricsData?.operator_burden_summary?.estimated_operator_actions_total ?? 0,
   );
+
+  const roadmap = payload.roadmap_protocol;
+  const roadmapStatus = roadmap?.status ?? "not_available";
+  const roadmapData =
+    roadmap?.status === "ok" ? roadmap.data : undefined;
+  const roadmapField = String(roadmapData?.status_field ?? "n/a");
+  const roadmapPill: "ok" | "warn" | "danger" | "unknown" =
+    roadmapStatus !== "ok"
+      ? "unknown"
+      : roadmapField === "blocked" || roadmapField === "unknown_state"
+        ? "danger"
+        : roadmapField === "needs_human"
+          ? "warn"
+          : roadmapField === "proposed"
+            ? "ok"
+            : "unknown";
   return (
     <Card title="Status" subtitle="governance + frozen + runtime">
       <div className="agent-control-card__row">
@@ -279,6 +295,24 @@ function StatusCard({ payload }: { payload: AgentControlStatus | null }) {
             <dd>{operatorActions}</dd>
           </div>
         </>
+      ) : null}
+      <div
+        className="agent-control-card__row"
+        data-testid="status-roadmap-row"
+      >
+        <dt>roadmap protocol</dt>
+        <dd>
+          <StatusPill state={roadmapPill} />
+        </dd>
+      </div>
+      {roadmapStatus === "ok" && roadmapData ? (
+        <div
+          className="agent-control-card__row"
+          data-testid="status-roadmap-state"
+        >
+          <dt>roadmap state</dt>
+          <dd>{roadmapField}</dd>
+        </div>
       ) : null}
       {Object.keys(fh).length === 0 ? (
         <p

--- a/frontend/src/test/AgentControl.test.tsx
+++ b/frontend/src/test/AgentControl.test.tsx
@@ -112,6 +112,26 @@ const okStatusBody = {
       },
     },
   },
+  roadmap_protocol: {
+    status: "ok",
+    data: {
+      module_version: "v3.15.15.28",
+      schema_version: 1,
+      generated_at_utc: "2026-05-03T08:00:00Z",
+      item_id: "r_test1234",
+      title: "Sample roadmap item",
+      item_type: "docs_only",
+      risk_class: "LOW",
+      decision: "allowed_read_only",
+      status_field: "proposed",
+      implementation_allowed: true,
+      executable: false,
+      safe_to_execute: false,
+      blocked_reason: null,
+      proposed_release_id: "v3.15.16.0",
+      proposed_branch: "fix/v3-15-16-0-r-test1234-sample-roadmap-item",
+    },
+  },
 };
 
 const okActivityBody = {

--- a/frontend/src/test/AgentControlPolish.test.tsx
+++ b/frontend/src/test/AgentControlPolish.test.tsx
@@ -113,6 +113,26 @@ const okStatusBody = {
       },
     },
   },
+  roadmap_protocol: {
+    status: "ok",
+    data: {
+      module_version: "v3.15.15.28",
+      schema_version: 1,
+      generated_at_utc: "2026-05-03T08:00:00Z",
+      item_id: "r_test1234",
+      title: "Sample roadmap item",
+      item_type: "docs_only",
+      risk_class: "LOW",
+      decision: "allowed_read_only",
+      status_field: "proposed",
+      implementation_allowed: true,
+      executable: false,
+      safe_to_execute: false,
+      blocked_reason: null,
+      proposed_release_id: "v3.15.16.0",
+      proposed_branch: "fix/v3-15-16-0-r-test1234-sample-roadmap-item",
+    },
+  },
 };
 
 const okActivityBody = {
@@ -560,6 +580,42 @@ describe("AgentControl polish — Status card autonomy-metrics row (v3.15.15.25)
     expect(
       screen.queryByTestId("status-metrics-recommendation"),
     ).not.toBeInTheDocument();
+  });
+});
+
+describe("AgentControl polish — roadmap protocol row (v3.15.15.28)", () => {
+  it("renders roadmap protocol row with state when status payload provides it", async () => {
+    installFetchMock(_allOk());
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+    const row = await screen.findByTestId("status-roadmap-row");
+    expect(row).toBeInTheDocument();
+    const state = await screen.findByTestId("status-roadmap-state");
+    expect(state).toHaveTextContent("proposed");
+  });
+
+  it("renders roadmap row as unknown when payload omits roadmap_protocol", async () => {
+    const statusBodyNoRoadmap = {
+      kind: "agent_control_status",
+      schema_version: 1,
+      governance_status: { status: "ok", data: {} },
+      frozen_hashes: okFrozenHashes,
+    };
+    installFetchMock({
+      ..._allOk(),
+      "/api/agent-control/status": () => jsonResp(statusBodyNoRoadmap),
+    });
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+    const row = await screen.findByTestId("status-roadmap-row");
+    expect(row).toBeInTheDocument();
+    expect(screen.queryByTestId("status-roadmap-state")).not.toBeInTheDocument();
   });
 });
 

--- a/reporting/roadmap_execution_protocol.py
+++ b/reporting/roadmap_execution_protocol.py
@@ -1,0 +1,1087 @@
+"""Roadmap item execution protocol (v3.15.15.28).
+
+A deterministic, stdlib-only protocol module that converts a
+single roadmap item into a fully-specified execution plan without
+running any code. Implementation is forbidden in this module —
+the plan is a *proposal*, not an action. Actual implementation
+requires:
+
+* operator approval for HIGH/UNKNOWN/secret/external/paid/
+  telemetry/protected/canonical-roadmap items;
+* the existing CI gates;
+* the existing PR-lifecycle protocol;
+* a separate human-authored implementation step inside the
+  branch the plan proposes.
+
+Hard guarantees
+---------------
+
+* Stdlib-only. No subprocess, no ``gh``, no ``git``, no network.
+* Output limited to ``logs/roadmap_execution_protocol/``.
+* Atomic writes (``tmp`` + ``os.replace``); no in-place edits.
+* Risk decisions delegate to ``reporting.approval_policy.decide()``
+  — there is no second source of truth.
+* ``safe_to_execute`` is hard-coded ``false`` at the digest level.
+* ``executable`` is False for every emitted plan; the operator
+  decides whether to start implementation by hand.
+* ``implementation_allowed`` is True only for LOW / MEDIUM items
+  whose policy decision is ``allowed_read_only`` AND whose item
+  type is in the closed ``ITEM_TYPES_OPEN_TO_IMPLEMENTATION``
+  set; HIGH / UNKNOWN / governance / canonical / live / paid /
+  external / secret items are False by construction.
+* Agent assignments come from a closed taxonomy; an item that
+  doesn't fit any known type lands as ``unknown_state`` and
+  routes to the operator.
+
+CLI
+---
+
+::
+
+    python -m reporting.roadmap_execution_protocol --describe
+    python -m reporting.roadmap_execution_protocol \
+        --plan-item path/to/item.json --dry-run
+    python -m reporting.roadmap_execution_protocol --status
+
+Stdlib-only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime as _dt
+import hashlib
+import json
+import os
+import re
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Final
+
+from reporting import approval_policy as _approval_policy
+
+REPO_ROOT: Path = Path(__file__).resolve().parent.parent
+MODULE_VERSION: Final[str] = "v3.15.15.28"
+SCHEMA_VERSION: Final[int] = 1
+
+DIGEST_DIR_JSON: Path = REPO_ROOT / "logs" / "roadmap_execution_protocol"
+
+
+# ---------------------------------------------------------------------------
+# Closed taxonomies
+# ---------------------------------------------------------------------------
+
+
+# Item types the protocol recognises. Anything outside this set is
+# classified ``unknown_state`` regardless of any other signal.
+ITEM_TYPES: Final[tuple[str, ...]] = (
+    "docs_only",
+    "frontend_read_only",
+    "reporting_read_only",
+    "test_only",
+    "dependency_floor_bump",
+    "ci_hardening",
+    "observability_addition",
+    "tooling_intake",
+    "governance_change",
+    "canonical_roadmap_adoption",
+    "live_paper_shadow_risk",
+    "frozen_contract_change",
+    "external_account_or_secret",
+    "telemetry_or_data_egress",
+    "paid_tool",
+    "unknown",
+)
+
+
+# Item types that, when paired with a LOW/MEDIUM policy decision,
+# are eligible to enter the implementation phase under the PR
+# protocol. Everything else (HIGH-by-shape items, unknown,
+# governance-change, etc.) routes to needs_human regardless.
+ITEM_TYPES_OPEN_TO_IMPLEMENTATION: Final[frozenset[str]] = frozenset(
+    {
+        "docs_only",
+        "frontend_read_only",
+        "reporting_read_only",
+        "test_only",
+        "observability_addition",
+    }
+)
+
+
+# Status enum — surfaces the high-level state of the plan to the
+# operator inbox / metrics surface.
+STATUS_PROPOSED: Final[str] = "proposed"
+STATUS_NEEDS_HUMAN: Final[str] = "needs_human"
+STATUS_BLOCKED: Final[str] = "blocked"
+STATUS_UNKNOWN: Final[str] = "unknown_state"
+
+STATUSES: Final[tuple[str, ...]] = (
+    STATUS_PROPOSED,
+    STATUS_NEEDS_HUMAN,
+    STATUS_BLOCKED,
+    STATUS_UNKNOWN,
+)
+
+
+# ---------------------------------------------------------------------------
+# Agent role catalog
+# ---------------------------------------------------------------------------
+
+
+AGENT_PRODUCT_OWNER: Final[str] = "product_owner"
+AGENT_STRATEGIC_ADVISOR: Final[str] = "strategic_advisor"
+AGENT_PLANNER: Final[str] = "planner"
+AGENT_IMPLEMENTATION: Final[str] = "implementation_agent"
+AGENT_ARCHITECTURE_GUARDIAN: Final[str] = "architecture_guardian"
+AGENT_CI_GUARDIAN: Final[str] = "ci_guardian"
+AGENT_SECURITY_GOVERNANCE_GUARDIAN: Final[str] = "security_governance_guardian"
+AGENT_OPERATOR: Final[str] = "operator"
+
+
+# Role definitions — surfaced through ``--describe`` so the
+# operator can audit who is allowed to do what without reading
+# the source. Every field is a tuple of strings; deterministic
+# ordering is guaranteed.
+@dataclasses.dataclass(frozen=True)
+class AgentRole:
+    name: str
+    title: str
+    responsibilities: tuple[str, ...]
+    allowed_actions: tuple[str, ...]
+    forbidden_actions: tuple[str, ...]
+    handoff_input: tuple[str, ...]
+    handoff_output: tuple[str, ...]
+    required_evidence: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "title": self.title,
+            "responsibilities": list(self.responsibilities),
+            "allowed_actions": list(self.allowed_actions),
+            "forbidden_actions": list(self.forbidden_actions),
+            "handoff_input": list(self.handoff_input),
+            "handoff_output": list(self.handoff_output),
+            "required_evidence": list(self.required_evidence),
+        }
+
+
+_AGENT_ROLES: Final[tuple[AgentRole, ...]] = (
+    AgentRole(
+        name=AGENT_PRODUCT_OWNER,
+        title="Product Owner Agent",
+        responsibilities=(
+            "convert a roadmap item into operator-shaped acceptance criteria",
+            "prevent vague scope; reject items without measurable value",
+            "confirm user value with operator before any branch is opened",
+        ),
+        allowed_actions=(
+            "read roadmap / proposal / inbox artifacts",
+            "draft acceptance_criteria entries on the plan",
+            "request operator clarification via the inbox",
+        ),
+        forbidden_actions=(
+            "open branches",
+            "open PRs",
+            "modify code",
+            "modify tests",
+            "modify governance",
+        ),
+        handoff_input=("roadmap item record", "operator brief"),
+        handoff_output=("acceptance_criteria", "scope_summary", "user_value"),
+        required_evidence=("title", "summary", "operator_user_value_confirmed"),
+    ),
+    AgentRole(
+        name=AGENT_STRATEGIC_ADVISOR,
+        title="Strategic Advisor",
+        responsibilities=(
+            "check sequencing and strategic fit against the autonomy roadmap",
+            "recommend deferral or split when scope is too large",
+            "raise authority concerns to the operator",
+        ),
+        allowed_actions=(
+            "read roadmap / ADR / governance / proposal artifacts",
+            "annotate the plan with strategic notes",
+            "recommend a different proposed_release_id",
+        ),
+        forbidden_actions=(
+            "implement directly",
+            "approve HIGH-risk items",
+            "open or merge PRs",
+        ),
+        handoff_input=("plan draft from product_owner",),
+        handoff_output=("strategic_fit", "deferral_recommendation"),
+        required_evidence=("roadmap_reference", "scope_summary"),
+    ),
+    AgentRole(
+        name=AGENT_PLANNER,
+        title="Planner Agent",
+        responsibilities=(
+            "produce a bounded release plan for the proposed item",
+            "define branch, commit boundaries, tests, and rollback",
+            "list expected artifacts and operator-visible changes",
+        ),
+        allowed_actions=(
+            "read repository state",
+            "draft proposed_branch / required_tests / rollback_plan",
+            "write the plan to logs/roadmap_execution_protocol/",
+        ),
+        forbidden_actions=(
+            "implement code",
+            "open branches in git",
+            "open PRs",
+            "modify governance",
+            "modify .claude/**",
+        ),
+        handoff_input=("plan draft from strategic_advisor",),
+        handoff_output=(
+            "proposed_branch",
+            "proposed_release_id",
+            "required_tests",
+            "expected_artifacts",
+            "rollback_plan",
+        ),
+        required_evidence=("acceptance_criteria",),
+    ),
+    AgentRole(
+        name=AGENT_IMPLEMENTATION,
+        title="Implementation Agent",
+        responsibilities=(
+            "implement only the approved scope on the proposed branch",
+            "make no scope changes without re-running the protocol",
+            "run all required tests before opening the PR",
+        ),
+        allowed_actions=(
+            "edit files declared under affected_areas",
+            "add tests under tests/{smoke,unit,...}",
+            "open the PR with the deterministic body shape",
+        ),
+        forbidden_actions=(
+            "expand scope without operator approval",
+            "weaken tests / governance / CI",
+            "force push",
+            "admin merge",
+            "direct main push",
+            "modify .claude/**",
+            "modify frozen contracts",
+            "modify automation/live_gate.py",
+            "wire api_execute_safe_controls without explicit operator brief",
+        ),
+        handoff_input=("approved plan",),
+        handoff_output=("PR URL", "CI status", "self_review_notes"),
+        required_evidence=("proposed_branch", "approval_policy_decision"),
+    ),
+    AgentRole(
+        name=AGENT_ARCHITECTURE_GUARDIAN,
+        title="Architecture Guardian",
+        responsibilities=(
+            "check layering, contracts, frozen outputs, no-touch files",
+            "verify no protected-path or live-trading touch",
+            "confirm schema version bumps when a contract changes",
+        ),
+        allowed_actions=(
+            "read PR diff",
+            "block merge with a comment",
+            "request re-plan via the operator",
+        ),
+        forbidden_actions=(
+            "rewrite the implementation",
+            "merge the PR",
+            "wave through HIGH-risk items",
+        ),
+        handoff_input=("open PR",),
+        handoff_output=("architecture_review_pass_or_block",),
+        required_evidence=("PR URL", "files_changed"),
+    ),
+    AgentRole(
+        name=AGENT_CI_GUARDIAN,
+        title="CI Guardian",
+        responsibilities=(
+            "verify required GitHub checks all green",
+            "verify no test was skipped, deleted, or weakened",
+            "verify required smoke + unit + governance_lint coverage",
+        ),
+        allowed_actions=(
+            "read CI artefacts",
+            "block merge with a comment",
+        ),
+        forbidden_actions=(
+            "skip or downgrade required checks",
+            "merge the PR",
+            "modify CI workflows outside a separate ci-hardening release",
+        ),
+        handoff_input=("open PR",),
+        handoff_output=("ci_review_pass_or_block",),
+        required_evidence=("CI run summary",),
+    ),
+    AgentRole(
+        name=AGENT_SECURITY_GOVERNANCE_GUARDIAN,
+        title="Security / Governance Guardian",
+        responsibilities=(
+            "check for secret-shaped values, protected paths, mutation routes",
+            "check for unsafe automation or governance weakening",
+            "check approval_policy compliance for the item",
+        ),
+        allowed_actions=(
+            "read PR diff",
+            "block merge with a comment",
+            "demand the plan be re-run through approval_policy",
+        ),
+        forbidden_actions=(
+            "approve HIGH/UNKNOWN items autonomously",
+            "merge the PR",
+            "weaken redaction or guards",
+        ),
+        handoff_input=("open PR",),
+        handoff_output=("security_review_pass_or_block",),
+        required_evidence=("PR URL", "approval_policy_decision"),
+    ),
+    AgentRole(
+        name=AGENT_OPERATOR,
+        title="Operator (Joery)",
+        responsibilities=(
+            "decide HIGH / UNKNOWN / needs_human items",
+            "approve external accounts / secrets / paid / telemetry",
+            "approve live / paper / shadow / risk changes",
+            "approve canonical roadmap adoption",
+        ),
+        allowed_actions=(
+            "approve or reject any plan",
+            "merge a PR after Guardian reviews pass",
+            "ramp / disable / re-arm the autonomous loop",
+        ),
+        forbidden_actions=(
+            "(none — the operator is the trust boundary)",
+        ),
+        handoff_input=("plan with all guardian reviews",),
+        handoff_output=("merge_decision", "post_merge_signal"),
+        required_evidence=("acceptance_criteria", "approval_policy_decision"),
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Required evidence per plan field
+# ---------------------------------------------------------------------------
+
+
+# The set of fields the planner is REQUIRED to populate. Missing
+# fields do not fail the plan — they route it to ``unknown_state``
+# with a deterministic ``blocked_reason``.
+_REQUIRED_FIELDS: Final[tuple[str, ...]] = (
+    "item_id",
+    "source",
+    "source_type",
+    "title",
+    "summary",
+    "roadmap_reference",
+    "proposed_release_id",
+    "proposed_branch",
+    "risk_class",
+    "decision",
+    "requires_human",
+    "approval_policy_decision",
+    "affected_areas",
+    "forbidden_actions",
+    "required_tests",
+    "expected_artifacts",
+    "rollback_plan",
+    "acceptance_criteria",
+    "agent_assignments",
+    "guardian_reviews_required",
+    "merge_requirements",
+    "post_merge_checks",
+    "status",
+    "blocked_reason",
+    "generated_at_utc",
+    "schema_version",
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _rel(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(REPO_ROOT.resolve())).replace("\\", "/")
+    except ValueError:
+        return str(path).replace("\\", "/")
+
+
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _slug(s: str, *, max_len: int = 48) -> str:
+    cleaned = _SLUG_RE.sub("-", s.lower()).strip("-")
+    return cleaned[:max_len] or "item"
+
+
+def _branch_for(item_id: str, title: str, release_id: str) -> str:
+    """Deterministic branch name: one item per branch by default."""
+    rel_slug = _slug(release_id, max_len=20) or "release"
+    title_slug = _slug(title, max_len=40)
+    item_slug = _slug(item_id, max_len=12)
+    return f"fix/{rel_slug}-{item_slug}-{title_slug}".rstrip("-")
+
+
+# ---------------------------------------------------------------------------
+# Item-shape inputs
+# ---------------------------------------------------------------------------
+
+
+def _coerce_str(v: Any, default: str = "") -> str:
+    if v is None:
+        return default
+    return str(v)
+
+
+def _coerce_tuple_str(v: Any) -> tuple[str, ...]:
+    if v is None:
+        return ()
+    if isinstance(v, (list, tuple)):
+        return tuple(str(x) for x in v)
+    return (str(v),)
+
+
+def _coerce_bool(v: Any) -> bool:
+    if v is None:
+        return False
+    return bool(v)
+
+
+# ---------------------------------------------------------------------------
+# Item type classification
+# ---------------------------------------------------------------------------
+
+
+def _classify_item_type(item: Mapping[str, Any]) -> str:
+    """Map an item to one of the closed ITEM_TYPES. First-match wins.
+
+    The classifier is intentionally narrow: anything that does not
+    match a known shape lands as ``unknown`` and routes through
+    the operator. We never invent a permissive default.
+    """
+    requested = _coerce_str(item.get("item_type")).strip().lower()
+    if requested in ITEM_TYPES:
+        return requested
+
+    files = _coerce_tuple_str(item.get("affected_files"))
+    files_normalised = tuple(f.replace("\\", "/") for f in files)
+    title = _coerce_str(item.get("title")).lower()
+    summary = _coerce_str(item.get("summary")).lower()
+    text = f"{title}\n{summary}"
+
+    # 0. frozen contract (highest precedence — file-level match;
+    # mirrors approval_policy.diff_touches_frozen).
+    for f in files_normalised:
+        if f in _approval_policy.FROZEN_CONTRACTS:
+            return "frozen_contract_change"
+    if _coerce_bool(item.get("touches_frozen_contract")):
+        return "frozen_contract_change"
+
+    # 1. canonical-roadmap adoption (always blocks).
+    if _approval_policy._matched_token(
+        text, _approval_policy.CANONICAL_ROADMAP_TOKENS
+    ) or _coerce_bool(item.get("changes_canonical_roadmap")):
+        return "canonical_roadmap_adoption"
+
+    # 2. governance change (always blocks).
+    if _coerce_bool(item.get("touches_governance")) or any(
+        t in text
+        for t in (
+            ".claude/",
+            "agents.md",
+            "claude.md",
+            "branch protection",
+            "codeowners",
+            "no_touch_paths",
+            "agent governance",
+            "release gate",
+            "autonomy ladder",
+        )
+    ):
+        return "governance_change"
+
+    # 3. live / paper / shadow / risk path.
+    if _coerce_bool(item.get("touches_live_paper_shadow_risk")):
+        return "live_paper_shadow_risk"
+    for f in files_normalised:
+        if _approval_policy._matches_any(f, _approval_policy.LIVE_PATH_GLOBS):
+            return "live_paper_shadow_risk"
+
+    # 4. external secret / account.
+    if (
+        _coerce_bool(item.get("requires_secret"))
+        or _coerce_bool(item.get("requires_external_account"))
+        or _approval_policy._matched_token(
+            text, _approval_policy.EXTERNAL_SECRET_TOKENS
+        )
+    ):
+        return "external_account_or_secret"
+
+    # 5. telemetry / data egress.
+    if _coerce_bool(item.get("has_telemetry_or_data_egress")) or (
+        _approval_policy._matched_token(text, _approval_policy.TELEMETRY_TOKENS)
+    ):
+        return "telemetry_or_data_egress"
+
+    # 6. paid tool.
+    if _coerce_bool(item.get("requires_paid_tool")) or (
+        _approval_policy._matched_token(text, _approval_policy.PAID_TOOL_TOKENS)
+    ):
+        return "paid_tool"
+
+    # 7. CI / test path.
+    if _coerce_bool(item.get("touches_ci_or_tests")) or any(
+        _approval_policy._matches_any(f, _approval_policy.CI_OR_TESTS_GLOBS)
+        for f in files_normalised
+    ):
+        return "ci_hardening"
+
+    # 8. docs_only — every affected file is under docs/.
+    if files_normalised and all(
+        f.startswith("docs/") for f in files_normalised
+    ):
+        return "docs_only"
+
+    # 9. frontend_read_only — every affected file is under frontend/
+    # and the title/summary do not mention a mutation verb.
+    if files_normalised and all(f.startswith("frontend/") for f in files_normalised):
+        if not _approval_policy._matched_token(
+            text,
+            ("execute", "approve", "reject", "merge button", "post", "mutate"),
+        ):
+            return "frontend_read_only"
+
+    # 10. reporting_read_only — every affected file is under reporting/
+    # and the title/summary describe an additive read-only module.
+    if files_normalised and all(f.startswith("reporting/") for f in files_normalised):
+        if any(t in text for t in ("read-only", "report", "metric", "audit", "digest")):
+            return "reporting_read_only"
+
+    # 11. test_only.
+    if files_normalised and all(f.startswith("tests/") for f in files_normalised):
+        return "test_only"
+
+    # 12. dependency_floor_bump — affected files are requirements
+    # or package.json, summary mentions "bump" / "update".
+    if files_normalised and all(
+        f.endswith("requirements.txt")
+        or f.endswith("package.json")
+        or f.endswith("package-lock.json")
+        for f in files_normalised
+    ):
+        return "dependency_floor_bump"
+
+    # 13. observability_addition.
+    if any(
+        t in text
+        for t in ("observability", "logging", "metrics", "audit log", "monitoring")
+    ):
+        return "observability_addition"
+
+    # 14. tooling intake.
+    if any(
+        t in text
+        for t in ("tooling", "library upgrade", "dev dependency", "new package")
+    ):
+        return "tooling_intake"
+
+    # Default: operator decides.
+    return "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Risk decision via approval_policy
+# ---------------------------------------------------------------------------
+
+
+def _approval_decision(item: Mapping[str, Any]) -> _approval_policy.PolicyDecision:
+    """Lift a roadmap item into a PolicyInput and run the canonical
+    decide() function. The mapping is verbatim; we never reshape
+    the policy decision."""
+    pi = _approval_policy.PolicyInput.from_mapping(
+        {
+            "title": item.get("title"),
+            "summary": item.get("summary"),
+            "source_type": item.get("source_type"),
+            "affected_files": item.get("affected_files"),
+            "labels": item.get("labels"),
+            "risk_class": item.get("risk_class"),
+            "requested_action": "propose",
+            "requires_secret": item.get("requires_secret"),
+            "requires_external_account": item.get("requires_external_account"),
+            "requires_paid_tool": item.get("requires_paid_tool"),
+            "has_telemetry_or_data_egress": item.get(
+                "has_telemetry_or_data_egress"
+            ),
+            "touches_governance": item.get("touches_governance"),
+            "touches_frozen_contract": item.get("touches_frozen_contract"),
+            "touches_live_paper_shadow_risk": item.get(
+                "touches_live_paper_shadow_risk"
+            ),
+            "touches_ci_or_tests": item.get("touches_ci_or_tests"),
+            "changes_canonical_roadmap": item.get("changes_canonical_roadmap"),
+            "is_dependabot": False,
+            "pr_author": item.get("pr_author"),
+        }
+    )
+    return _approval_policy.decide(pi)
+
+
+# ---------------------------------------------------------------------------
+# Plan synthesis
+# ---------------------------------------------------------------------------
+
+
+def _agent_assignments_for(item_type: str) -> list[dict[str, Any]]:
+    """Every plan involves the full agent chain. The order encodes
+    the handoff sequence: PO → Strategic → Planner → Implementation
+    → Architecture/CI/Security guardians → Operator. Items that
+    the policy blocks still surface the chain so the operator can
+    audit which guardian would block."""
+    return [role.to_dict() for role in _AGENT_ROLES]
+
+
+def _guardian_reviews_required(decision: _approval_policy.PolicyDecision) -> list[str]:
+    """Every implementation-eligible item gets all three guardian
+    reviews. Blocked items still document the reviews so the
+    operator sees what would have been required."""
+    return [
+        AGENT_ARCHITECTURE_GUARDIAN,
+        AGENT_CI_GUARDIAN,
+        AGENT_SECURITY_GOVERNANCE_GUARDIAN,
+    ]
+
+
+def _merge_requirements() -> list[str]:
+    return [
+        "all required GitHub checks green",
+        "local governance_lint OK",
+        "local pytest tests/smoke OK",
+        "frozen contract sha256 unchanged",
+        "approval_policy decision is not HIGH/UNKNOWN executable",
+        "no protected-path / live-path / governance-weakening touch",
+        "no test/CI weakening",
+        "no unresolved approval inbox row tied to the same item_id",
+    ]
+
+
+def _post_merge_checks() -> list[str]:
+    return [
+        "pull main",
+        "verify final main SHA",
+        "rerun python -m reporting.workloop_runtime --once",
+        "rerun python -m reporting.autonomy_metrics --collect",
+        "verify approval_inbox does not surface a new runtime_halt for the merged item",
+        "verify frozen contract sha256 unchanged",
+    ]
+
+
+def _required_tests_for(item_type: str) -> list[str]:
+    base = [
+        "scripts/governance_lint.py",
+        "tests/smoke",
+        "frozen-hash check",
+    ]
+    if item_type == "frontend_read_only":
+        return base + [
+            "npm --prefix frontend test -- --run",
+            "npm --prefix frontend run build",
+        ]
+    if item_type == "reporting_read_only" or item_type == "observability_addition":
+        return base + ["tests/unit (targeted module + cross-module sweep)"]
+    if item_type == "test_only":
+        return base + ["tests/unit (the new tests)"]
+    if item_type == "docs_only":
+        return base + ["doc presence test if a schema doc changed"]
+    if item_type == "dependency_floor_bump":
+        return base + [
+            "tests/unit",
+            "no SHA pin downgrades in .github/workflows",
+        ]
+    return base + ["tests/unit"]
+
+
+def _expected_artifacts_for(item_type: str) -> list[str]:
+    if item_type == "reporting_read_only" or item_type == "observability_addition":
+        return [
+            "reporting/<new_module>.py",
+            "logs/<new_module>/latest.json (atomic write)",
+            "tests/unit/test_<new_module>.py",
+            "docs/governance/<new_module>.md",
+        ]
+    if item_type == "frontend_read_only":
+        return [
+            "frontend/src/...",
+            "frontend/dist/assets/index-<hash>.{js,css} after npm run build",
+            "frontend tests pass",
+        ]
+    if item_type == "docs_only":
+        return ["docs/governance/<doc>.md"]
+    if item_type == "test_only":
+        return ["tests/unit/test_<scope>.py"]
+    return ["see plan"]
+
+
+def _rollback_plan_for(item_type: str) -> list[str]:
+    return [
+        "git revert <release_commit_sha> on a fresh branch",
+        "open a one-line revert PR with the same release id",
+        "merge after CI green and frozen hashes unchanged",
+        "post-merge re-run workloop_runtime + autonomy_metrics",
+    ]
+
+
+def _acceptance_criteria_for(
+    item: Mapping[str, Any], item_type: str
+) -> list[str]:
+    declared = item.get("acceptance_criteria")
+    if isinstance(declared, list) and declared:
+        return [str(x) for x in declared]
+    # Default per item type so the operator at least sees a
+    # measurable bar even when the upstream item didn't declare
+    # one.
+    if item_type == "frontend_read_only":
+        return [
+            "the new UI is visible on phone-portrait at /agent-control",
+            "no execute / approve / reject / merge buttons added",
+            "no mutation fetch verbs in frontend code",
+        ]
+    if item_type == "reporting_read_only":
+        return [
+            "the new module emits a deterministic JSON digest",
+            "missing/malformed sources are counted, never silently OK",
+            "narrow credential-value redaction enforced",
+            "stdlib-only (no subprocess / network / gh / git)",
+        ]
+    if item_type == "observability_addition":
+        return [
+            "the new signal is reachable from /api/agent-control/status",
+            "the signal is read-only and auditable",
+            "no new mutation routes",
+        ]
+    if item_type == "docs_only":
+        return [
+            "the new doc references the canonical schema",
+            "no behavior change implied",
+        ]
+    if item_type == "test_only":
+        return [
+            "the new tests pin a real invariant",
+            "no production code changes",
+        ]
+    return ["operator-defined acceptance criteria required"]
+
+
+def _affected_areas(item: Mapping[str, Any]) -> list[str]:
+    files = _coerce_tuple_str(item.get("affected_files"))
+    return list(files)
+
+
+def _status_from(decision: _approval_policy.PolicyDecision, item_type: str) -> str:
+    if item_type == "unknown":
+        return STATUS_UNKNOWN
+    if decision.requires_human_approval and not decision.executable:
+        if decision.decision == _approval_policy.DECISION_BLOCKED_UNKNOWN:
+            return STATUS_UNKNOWN
+        if decision.decision == _approval_policy.DECISION_NEEDS_HUMAN:
+            return STATUS_NEEDS_HUMAN
+        return STATUS_BLOCKED
+    return STATUS_PROPOSED
+
+
+def _implementation_allowed(
+    decision: _approval_policy.PolicyDecision, item_type: str
+) -> bool:
+    """``implementation_allowed`` is True only when the policy
+    decision is allowed_read_only AND the item type is in the
+    open-to-implementation set. Every other shape is False."""
+    if decision.decision != _approval_policy.DECISION_ALLOWED_READ_ONLY:
+        return False
+    return item_type in ITEM_TYPES_OPEN_TO_IMPLEMENTATION
+
+
+def _blocked_reason(
+    decision: _approval_policy.PolicyDecision, item_type: str
+) -> str | None:
+    if item_type == "unknown":
+        return "unknown_item_type: routes to operator inspection"
+    if decision.decision != _approval_policy.DECISION_ALLOWED_READ_ONLY:
+        return f"approval_policy: {decision.decision} ({decision.reason})"
+    if item_type not in ITEM_TYPES_OPEN_TO_IMPLEMENTATION:
+        return (
+            f"item_type {item_type!r} requires operator approval before "
+            "an implementation branch may be opened"
+        )
+    return None
+
+
+def plan_item(item: Mapping[str, Any], *, frozen_utc: str | None = None) -> dict[str, Any]:
+    """Produce a fully-specified execution plan for one roadmap
+    item. Pure function — no I/O. Determinism is guaranteed when
+    ``frozen_utc`` is provided.
+    """
+    item_type = _classify_item_type(item)
+    decision = _approval_decision(item)
+    proposed_release_id = _coerce_str(
+        item.get("proposed_release_id"), default="v3.15.16.x"
+    )
+    item_id = _coerce_str(
+        item.get("item_id"),
+        default="r_" + hashlib.sha256(
+            (
+                _coerce_str(item.get("title"))
+                + "|"
+                + _coerce_str(item.get("summary"))
+            ).encode("utf-8")
+        ).hexdigest()[:8],
+    )
+    title = _coerce_str(item.get("title"), default="(no title)")
+    proposed_branch = _branch_for(item_id, title, proposed_release_id)
+    status = _status_from(decision, item_type)
+    blocked_reason = _blocked_reason(decision, item_type)
+
+    plan: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": "roadmap_execution_plan",
+        "module_version": MODULE_VERSION,
+        "generated_at_utc": frozen_utc or _utcnow(),
+        "item_id": item_id,
+        "source": _coerce_str(item.get("source")),
+        "source_type": _coerce_str(item.get("source_type")),
+        "title": title,
+        "summary": _coerce_str(item.get("summary")),
+        "roadmap_reference": _coerce_str(
+            item.get("roadmap_reference"), default="docs/roadmap"
+        ),
+        "proposed_release_id": proposed_release_id,
+        "proposed_branch": proposed_branch,
+        "item_type": item_type,
+        "risk_class": decision.risk_class,
+        "decision": decision.decision,
+        "approval_policy_decision": decision.to_dict(),
+        "requires_human": decision.requires_human_approval,
+        "executable": False,  # the protocol never auto-executes
+        "implementation_allowed": _implementation_allowed(decision, item_type),
+        "affected_areas": _affected_areas(item),
+        "forbidden_actions": list(decision.forbidden_agent_actions),
+        "required_tests": _required_tests_for(item_type),
+        "expected_artifacts": _expected_artifacts_for(item_type),
+        "rollback_plan": _rollback_plan_for(item_type),
+        "acceptance_criteria": _acceptance_criteria_for(item, item_type),
+        "agent_assignments": _agent_assignments_for(item_type),
+        "guardian_reviews_required": _guardian_reviews_required(decision),
+        "merge_requirements": _merge_requirements(),
+        "post_merge_checks": _post_merge_checks(),
+        "status": status,
+        "blocked_reason": blocked_reason,
+        "policy": {
+            "module_version": _approval_policy.MODULE_VERSION,
+            "schema_version": _approval_policy.SCHEMA_VERSION,
+            "high_or_unknown_is_executable": False,
+        },
+        "safe_to_execute": False,
+    }
+
+    _approval_policy.assert_no_credential_values(plan)
+    return plan
+
+
+def describe_protocol() -> dict[str, Any]:
+    """Return the full role / handoff / status / item-type
+    catalogue. The shape is stable; callers (docs, tests, status
+    surface) consume it deterministically."""
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": "roadmap_execution_protocol_description",
+        "module_version": MODULE_VERSION,
+        "generated_at_utc": _utcnow(),
+        "item_types": list(ITEM_TYPES),
+        "item_types_open_to_implementation": sorted(
+            ITEM_TYPES_OPEN_TO_IMPLEMENTATION
+        ),
+        "statuses": list(STATUSES),
+        "agent_roles": [r.to_dict() for r in _AGENT_ROLES],
+        "merge_requirements": _merge_requirements(),
+        "post_merge_checks": _post_merge_checks(),
+        "policy": {
+            "module_version": _approval_policy.MODULE_VERSION,
+            "schema_version": _approval_policy.SCHEMA_VERSION,
+            "high_or_unknown_is_executable": False,
+        },
+        "safe_to_execute": False,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Atomic write
+# ---------------------------------------------------------------------------
+
+
+def write_outputs(snapshot: dict[str, Any]) -> dict[str, str]:
+    """Atomic write of latest.json + timestamped copy + history append."""
+    DIGEST_DIR_JSON.mkdir(parents=True, exist_ok=True)
+    ts = snapshot["generated_at_utc"].replace(":", "-")
+    json_now = DIGEST_DIR_JSON / f"{ts}.json"
+    json_latest = DIGEST_DIR_JSON / "latest.json"
+    history = DIGEST_DIR_JSON / "history.jsonl"
+    payload = json.dumps(snapshot, sort_keys=True, indent=2)
+
+    tmp_now = json_now.with_suffix(json_now.suffix + ".tmp")
+    tmp_now.write_text(payload, encoding="utf-8")
+    os.replace(tmp_now, json_now)
+
+    tmp_latest = json_latest.with_suffix(json_latest.suffix + ".tmp")
+    tmp_latest.write_text(payload, encoding="utf-8")
+    os.replace(tmp_latest, json_latest)
+
+    compact = json.dumps(snapshot, sort_keys=True, separators=(",", ":"))
+    with history.open("a", encoding="utf-8") as f:
+        f.write(compact + "\n")
+
+    return {
+        "latest": _rel(json_latest),
+        "timestamped": _rel(json_now),
+        "history": _rel(history),
+    }
+
+
+def read_latest_snapshot() -> dict[str, Any] | None:
+    p = DIGEST_DIR_JSON / "latest.json"
+    if not p.exists():
+        return None
+    try:
+        text = p.read_text(encoding="utf-8")
+        data = json.loads(text)
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+# ---------------------------------------------------------------------------
+# Item file loader
+# ---------------------------------------------------------------------------
+
+
+def _load_item(arg: str) -> dict[str, Any]:
+    """Load an item from a path or an inline JSON string. Never
+    raises — returns a minimal item with status=unknown if the
+    input is unreadable."""
+    p = Path(arg)
+    if p.exists() and p.is_file():
+        try:
+            return json.loads(p.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            return {"item_id": "r_unparseable", "title": _rel(p)}
+    # Inline JSON string?
+    try:
+        parsed = json.loads(arg)
+        if isinstance(parsed, dict):
+            return parsed
+    except (TypeError, json.JSONDecodeError):
+        pass
+    # Treat as a title only — minimum-viable plan.
+    return {"title": arg}
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="reporting.roadmap_execution_protocol",
+        description=(
+            "Read-only roadmap-item execution protocol planner "
+            f"({MODULE_VERSION}). Stdlib-only. Never executes "
+            "implementation; always proposes."
+        ),
+    )
+    g = parser.add_mutually_exclusive_group(required=True)
+    g.add_argument(
+        "--describe",
+        action="store_true",
+        help="Print the full role/handoff/item-type catalogue.",
+    )
+    g.add_argument(
+        "--plan-item",
+        type=str,
+        default=None,
+        help="Path to a JSON item file or an inline JSON object.",
+    )
+    g.add_argument(
+        "--status",
+        action="store_true",
+        help="Read and print the latest plan from logs/.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "When set with --plan-item, do NOT write to logs/. "
+            "The plan is printed to stdout instead. This release's "
+            "policy: --plan-item without --dry-run is REJECTED."
+        ),
+    )
+    parser.add_argument(
+        "--frozen-utc",
+        type=str,
+        default=None,
+        help="Pin generated_at_utc for deterministic tests.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.describe:
+        print(json.dumps(describe_protocol(), sort_keys=True, indent=2))
+        return 0
+
+    if args.status:
+        snap = read_latest_snapshot()
+        if snap is None:
+            print(json.dumps({"status": "not_available", "reason": "missing"}, indent=2))
+            return 1
+        print(json.dumps(snap, sort_keys=True, indent=2))
+        return 0
+
+    if args.plan_item is not None:
+        if not args.dry_run:
+            # Hard policy: this release does not implement, only
+            # proposes. Refuse any non-dry-run invocation so we
+            # never silently mutate state outside the gitignored
+            # logs/ dir.
+            parser.error(
+                "--plan-item must be combined with --dry-run in "
+                f"{MODULE_VERSION} (the protocol does not implement)."
+            )
+            return 2  # unreachable
+        item = _load_item(args.plan_item)
+        plan = plan_item(item, frozen_utc=args.frozen_utc)
+        # Even in --dry-run we still emit the plan to logs/ so the
+        # status surface can read it. The dry-run flag prevents
+        # any other side effect.
+        write_outputs(plan)
+        print(json.dumps(plan, sort_keys=True, indent=2))
+        return 0
+
+    parser.error("no mode chosen")
+    return 2  # unreachable
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_dashboard_api_agent_control.py
+++ b/tests/unit/test_dashboard_api_agent_control.py
@@ -248,6 +248,27 @@ def test_status_payload_includes_autonomy_metrics_block(client) -> None:
         assert "reason" in am_block
 
 
+def test_status_payload_includes_roadmap_protocol_block(client) -> None:
+    """v3.15.15.28: status payload now also carries a read-only
+    roadmap_protocol summary. The block is ``not_available`` until
+    the operator runs ``--plan-item ... --dry-run`` for the first
+    time; ``ok`` once a plan exists. The protocol surface itself
+    never executes."""
+    body = client.get("/api/agent-control/status").get_json()
+    assert "roadmap_protocol" in body
+    rp_block = body["roadmap_protocol"]
+    assert rp_block["status"] in ("ok", "not_available")
+    if rp_block["status"] == "ok":
+        data = rp_block["data"]
+        assert data["safe_to_execute"] is False
+        assert data["executable"] is False
+        assert "decision" in data
+        assert "item_type" in data
+        assert "implementation_allowed" in data
+    else:
+        assert "reason" in rp_block
+
+
 def test_status_payload_includes_workloop_runtime_block(client) -> None:
     """v3.15.15.22: status payload now carries a workloop_runtime
     summary. When the artifact is missing the block reports

--- a/tests/unit/test_roadmap_execution_protocol.py
+++ b/tests/unit/test_roadmap_execution_protocol.py
@@ -1,0 +1,717 @@
+"""Unit tests for ``reporting.roadmap_execution_protocol``.
+
+Properties enforced (verbatim from the v3.15.15.28 brief):
+
+* ``--describe`` outputs the protocol catalogue.
+* ``--plan-item`` requires ``--dry-run``; the protocol never
+  implements.
+* LOW item with a known type produces ``executable=false`` and
+  ``implementation_allowed=true`` after policy approval.
+* HIGH item routes to ``status=blocked`` / ``needs_human``.
+* UNKNOWN item routes to ``blocked_unknown`` / ``unknown_state``.
+* Canonical roadmap adoption requires human approval.
+* Live / paper / shadow / risk item is blocked.
+* Secret / external / paid / telemetry items need human approval.
+* Protected / frozen-path items are blocked.
+* Missing evidence => UNKNOWN.
+* Agent assignment contains all eight required roles in canonical
+  order.
+* Guardian review requirements present on every plan.
+* Required tests list includes the baseline gates.
+* Branch naming is deterministic.
+* One item per branch by default.
+* No actual git/gh/subprocess/network execution path.
+* Artifact / schema is stable.
+* approval_policy integration is verbatim.
+* Frozen contract sha256 unchanged after running the protocol.
+* No credential-shaped values in any plan output.
+* Status endpoint projection works when the artifact exists.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reporting import approval_policy as ap
+from reporting import roadmap_execution_protocol as rep
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+# ---------------------------------------------------------------------------
+# Module-level invariants
+# ---------------------------------------------------------------------------
+
+
+def test_module_version_is_v3_15_15_28() -> None:
+    assert rep.MODULE_VERSION == "v3.15.15.28"
+
+
+def test_schema_version_is_one() -> None:
+    assert rep.SCHEMA_VERSION == 1
+
+
+def test_item_types_is_a_closed_tuple_with_unknown() -> None:
+    assert isinstance(rep.ITEM_TYPES, tuple)
+    assert "unknown" in rep.ITEM_TYPES
+
+
+def test_item_types_open_to_implementation_is_a_subset() -> None:
+    assert rep.ITEM_TYPES_OPEN_TO_IMPLEMENTATION.issubset(set(rep.ITEM_TYPES))
+
+
+def test_statuses_enum_is_closed() -> None:
+    assert set(rep.STATUSES) == {
+        "proposed",
+        "needs_human",
+        "blocked",
+        "unknown_state",
+    }
+
+
+def test_no_subprocess_or_network_in_module() -> None:
+    src = Path(rep.__file__).read_text(encoding="utf-8")
+    forbidden = (
+        "import subprocess",
+        "from subprocess",
+        "Popen(",
+        "import requests",
+        "import urllib.request",
+        "from urllib.request",
+        "import socket",
+    )
+    for tok in forbidden:
+        assert tok not in src, f"forbidden import in roadmap_execution_protocol: {tok!r}"
+
+
+def test_no_gh_or_git_invocation_in_module() -> None:
+    src = Path(rep.__file__).read_text(encoding="utf-8")
+    forbidden = ('"gh"', "'gh'", "/usr/bin/gh", '"git"', "'git'", "/usr/bin/git")
+    for tok in forbidden:
+        assert tok not in src, f"forbidden tool spawn: {tok!r}"
+
+
+# ---------------------------------------------------------------------------
+# describe()
+# ---------------------------------------------------------------------------
+
+
+def test_describe_returns_protocol_catalogue() -> None:
+    d = rep.describe_protocol()
+    assert d["report_kind"] == "roadmap_execution_protocol_description"
+    assert d["module_version"] == rep.MODULE_VERSION
+    assert d["safe_to_execute"] is False
+    assert set(d["item_types"]) == set(rep.ITEM_TYPES)
+    assert set(d["statuses"]) == set(rep.STATUSES)
+    role_names = [r["name"] for r in d["agent_roles"]]
+    expected_roles = [
+        "product_owner",
+        "strategic_advisor",
+        "planner",
+        "implementation_agent",
+        "architecture_guardian",
+        "ci_guardian",
+        "security_governance_guardian",
+        "operator",
+    ]
+    assert role_names == expected_roles
+
+
+def test_describe_is_serializable() -> None:
+    d = rep.describe_protocol()
+    json.dumps(d)
+
+
+# ---------------------------------------------------------------------------
+# plan_item — happy paths and forbidden paths
+# ---------------------------------------------------------------------------
+
+
+def _plan(**kw: Any) -> dict[str, Any]:
+    return rep.plan_item(kw, frozen_utc="2026-05-03T08:00:00Z")
+
+
+def test_low_docs_item_is_implementation_allowed() -> None:
+    p = _plan(
+        item_id="r_docs_aaaa",
+        title="Add operator runbook",
+        summary="Document staleness threshold semantics",
+        affected_files=["docs/governance/autonomy_metrics.md"],
+        risk_class="LOW",
+    )
+    assert p["item_type"] == "docs_only"
+    assert p["risk_class"] == "LOW"
+    assert p["decision"] == ap.DECISION_ALLOWED_READ_ONLY
+    assert p["status"] == rep.STATUS_PROPOSED
+    assert p["executable"] is False
+    assert p["implementation_allowed"] is True
+    assert p["safe_to_execute"] is False
+    assert p["blocked_reason"] is None
+
+
+def test_low_frontend_read_only_item_is_implementation_allowed() -> None:
+    p = _plan(
+        title="Render new read-only row on Status card",
+        summary="Read-only display from existing /api/agent-control/status payload",
+        affected_files=[
+            "frontend/src/routes/AgentControl.tsx",
+            "frontend/src/api/agent_control.ts",
+        ],
+        risk_class="MEDIUM",
+    )
+    assert p["item_type"] == "frontend_read_only"
+    assert p["status"] == rep.STATUS_PROPOSED
+    assert p["implementation_allowed"] is True
+
+
+def test_low_reporting_read_only_item_is_implementation_allowed() -> None:
+    p = _plan(
+        title="Add a small read-only digest module",
+        summary="Emit a deterministic JSON digest for a new metric source",
+        affected_files=["reporting/new_digest.py"],
+        risk_class="LOW",
+    )
+    assert p["item_type"] == "reporting_read_only"
+    assert p["implementation_allowed"] is True
+
+
+def test_high_live_path_item_is_blocked() -> None:
+    p = _plan(
+        title="Switch broker_kraken to live API",
+        summary="execution/live/broker_kraken use_live=True",
+        affected_files=["execution/live/broker_kraken.py"],
+        risk_class="HIGH",
+    )
+    assert p["item_type"] == "live_paper_shadow_risk"
+    assert p["status"] == rep.STATUS_BLOCKED
+    assert p["implementation_allowed"] is False
+    assert "blocked_live_paper_shadow_risk" in p["decision"]
+
+
+def test_unknown_item_routes_to_unknown_state() -> None:
+    p = _plan(title="(no idea)")
+    # No affected files + no token signals => item_type=unknown.
+    assert p["item_type"] == "unknown"
+    assert p["status"] == rep.STATUS_UNKNOWN
+    assert p["implementation_allowed"] is False
+    assert "unknown_item_type" in (p["blocked_reason"] or "")
+
+
+def test_high_risk_class_routes_to_blocked() -> None:
+    p = _plan(
+        title="Bump numpy from 1.24 to 2.0",
+        summary="major bump",
+        affected_files=["requirements.txt"],
+        risk_class="HIGH",
+    )
+    assert p["risk_class"] == "HIGH"
+    assert p["decision"] == ap.DECISION_BLOCKED_HIGH_RISK
+    assert p["implementation_allowed"] is False
+    assert p["status"] == rep.STATUS_BLOCKED
+
+
+def test_canonical_roadmap_adoption_requires_human() -> None:
+    p = _plan(
+        title="Adopt v4 roadmap",
+        summary="canonical roadmap adoption supersedes v3.15",
+    )
+    assert p["item_type"] == "canonical_roadmap_adoption"
+    # The policy classifies this as blocked_canonical_roadmap_change.
+    assert p["decision"] == ap.DECISION_BLOCKED_CANONICAL_ROADMAP_CHANGE
+    assert p["status"] == rep.STATUS_BLOCKED
+    assert p["implementation_allowed"] is False
+
+
+def test_governance_change_routes_to_blocked() -> None:
+    p = _plan(
+        title="Update CODEOWNERS",
+        summary="add a new owner to .github/CODEOWNERS",
+        touches_governance=True,
+    )
+    assert p["item_type"] == "governance_change"
+    assert p["decision"] == ap.DECISION_BLOCKED_GOVERNANCE_CHANGE
+    assert p["status"] == rep.STATUS_BLOCKED
+    assert p["implementation_allowed"] is False
+
+
+def test_external_secret_item_needs_human() -> None:
+    p = _plan(
+        title="Add Datadog APM",
+        summary="we'll need an api key",
+        risk_class="MEDIUM",
+    )
+    assert p["item_type"] == "external_account_or_secret"
+    assert p["decision"] == ap.DECISION_BLOCKED_EXTERNAL_SECRET_REQUIRED
+    assert p["implementation_allowed"] is False
+
+
+def test_telemetry_item_needs_human() -> None:
+    p = _plan(
+        title="Pipe metrics to telemetry",
+        summary="telemetry export to a third-party",
+        risk_class="MEDIUM",
+    )
+    assert p["item_type"] == "telemetry_or_data_egress"
+    assert p["decision"] == ap.DECISION_BLOCKED_TELEMETRY_OR_DATA_EGRESS
+    assert p["implementation_allowed"] is False
+
+
+def test_paid_tool_item_needs_human() -> None:
+    p = _plan(
+        title="Subscribe to paid plan for nightly storage",
+        summary="paid plan upgrade",
+        risk_class="MEDIUM",
+    )
+    assert p["item_type"] == "paid_tool"
+    assert p["decision"] == ap.DECISION_BLOCKED_PAID_TOOL
+    assert p["implementation_allowed"] is False
+
+
+def test_protected_path_item_is_blocked() -> None:
+    p = _plan(
+        title="Edit no-touch settings",
+        summary="touch .claude/settings.json",
+        affected_files=[".claude/settings.json"],
+    )
+    # Protected path takes precedence in approval_policy ordering.
+    assert p["decision"] == ap.DECISION_BLOCKED_PROTECTED_PATH
+    assert p["status"] == rep.STATUS_BLOCKED
+    assert p["implementation_allowed"] is False
+
+
+def test_frozen_contract_item_is_blocked() -> None:
+    p = _plan(
+        title="Regenerate research_latest",
+        summary="contract regen",
+        affected_files=["research/research_latest.json"],
+    )
+    assert p["decision"] == ap.DECISION_BLOCKED_FROZEN_CONTRACT
+    assert p["status"] == rep.STATUS_BLOCKED
+
+
+def test_ci_or_tests_item_is_blocked_from_implementation() -> None:
+    p = _plan(
+        title="Tweak CI workflow",
+        summary="speed up tests",
+        affected_files=[".github/workflows/ci.yml"],
+        risk_class="LOW",
+    )
+    # The policy elevates this to blocked_ci_or_test_weakening.
+    assert p["decision"] == ap.DECISION_BLOCKED_CI_OR_TEST_WEAKENING
+    assert p["status"] == rep.STATUS_BLOCKED
+    assert p["implementation_allowed"] is False
+
+
+def test_missing_evidence_routes_to_unknown() -> None:
+    p = _plan()  # no fields at all
+    assert p["item_type"] == "unknown"
+    # Empty risk_class => UNKNOWN policy decision.
+    assert p["decision"] == ap.DECISION_BLOCKED_UNKNOWN
+    assert p["status"] == rep.STATUS_UNKNOWN
+    assert p["implementation_allowed"] is False
+
+
+# ---------------------------------------------------------------------------
+# Plan shape
+# ---------------------------------------------------------------------------
+
+
+def test_every_plan_has_eight_agent_roles_in_order() -> None:
+    p = _plan(
+        title="Add docs",
+        summary="docs only",
+        affected_files=["docs/governance/example.md"],
+        risk_class="LOW",
+    )
+    role_names = [a["name"] for a in p["agent_assignments"]]
+    assert role_names == [
+        "product_owner",
+        "strategic_advisor",
+        "planner",
+        "implementation_agent",
+        "architecture_guardian",
+        "ci_guardian",
+        "security_governance_guardian",
+        "operator",
+    ]
+
+
+def test_every_plan_has_three_guardian_reviews() -> None:
+    p = _plan(title="x")
+    assert p["guardian_reviews_required"] == [
+        "architecture_guardian",
+        "ci_guardian",
+        "security_governance_guardian",
+    ]
+
+
+def test_every_plan_has_baseline_required_tests() -> None:
+    p = _plan(title="x", affected_files=["docs/governance/example.md"])
+    base = ["scripts/governance_lint.py", "tests/smoke", "frozen-hash check"]
+    for entry in base:
+        assert entry in p["required_tests"], entry
+
+
+def test_every_plan_has_merge_requirements() -> None:
+    p = _plan(title="x")
+    assert "all required GitHub checks green" in p["merge_requirements"]
+    assert "frozen contract sha256 unchanged" in p["merge_requirements"]
+
+
+def test_every_plan_has_post_merge_checks() -> None:
+    p = _plan(title="x")
+    assert "pull main" in p["post_merge_checks"]
+
+
+def test_every_plan_carries_safe_to_execute_false() -> None:
+    p = _plan(title="x")
+    assert p["safe_to_execute"] is False
+    assert p["executable"] is False
+
+
+def test_every_plan_carries_policy_reference() -> None:
+    p = _plan(title="x")
+    assert p["policy"]["module_version"] == ap.MODULE_VERSION
+    assert p["policy"]["high_or_unknown_is_executable"] is False
+
+
+def test_every_plan_emits_forbidden_actions_from_policy() -> None:
+    p = _plan(
+        title="Edit no-touch",
+        affected_files=[".claude/settings.json"],
+    )
+    # Universal forbidden actions are always present.
+    assert "git push --force" in p["forbidden_actions"]
+    assert "edit .claude/**" in p["forbidden_actions"]
+
+
+# ---------------------------------------------------------------------------
+# Branch naming
+# ---------------------------------------------------------------------------
+
+
+def test_branch_name_is_deterministic_for_same_inputs() -> None:
+    p1 = _plan(
+        item_id="r_aaaa1234",
+        title="Add operator runbook",
+        proposed_release_id="v3.15.16.0",
+        affected_files=["docs/governance/example.md"],
+        risk_class="LOW",
+    )
+    p2 = _plan(
+        item_id="r_aaaa1234",
+        title="Add operator runbook",
+        proposed_release_id="v3.15.16.0",
+        affected_files=["docs/governance/example.md"],
+        risk_class="LOW",
+    )
+    assert p1["proposed_branch"] == p2["proposed_branch"]
+
+
+def test_branch_name_uses_item_id_and_title() -> None:
+    p = _plan(
+        item_id="r_aaaa1234",
+        title="Add operator runbook",
+        proposed_release_id="v3.15.16.0",
+        affected_files=["docs/governance/example.md"],
+        risk_class="LOW",
+    )
+    branch = p["proposed_branch"]
+    assert branch.startswith("fix/")
+    assert "r-aaaa1234" in branch
+    assert "add-operator-runbook" in branch
+
+
+def test_one_item_per_branch_default() -> None:
+    """The branch name embeds the item_id; two different item_ids
+    produce two different branches."""
+    p1 = _plan(item_id="r_aaaa", title="X", risk_class="LOW")
+    p2 = _plan(item_id="r_bbbb", title="X", risk_class="LOW")
+    assert p1["proposed_branch"] != p2["proposed_branch"]
+
+
+# ---------------------------------------------------------------------------
+# approval_policy integration
+# ---------------------------------------------------------------------------
+
+
+def test_approval_policy_decision_is_embedded_verbatim() -> None:
+    p = _plan(title="x", risk_class="HIGH")
+    apd = p["approval_policy_decision"]
+    # Shape parity with PolicyDecision.to_dict().
+    assert "decision" in apd
+    assert "risk_class" in apd
+    assert "approval_category" in apd
+    assert "allowed_max_action" in apd
+    assert "executable" in apd
+    assert "requires_human_approval" in apd
+    assert "forbidden_agent_actions" in apd
+    assert "required_evidence" in apd
+
+
+def test_implementation_allowed_only_if_policy_says_allowed_read_only() -> None:
+    """Even an open-to-implementation item type stays blocked if
+    the policy decision is NOT ``allowed_read_only``."""
+    # A docs-only item with risk_class HIGH still has decision
+    # blocked_high_risk via approval_policy.
+    p = _plan(
+        title="docs item but flagged HIGH",
+        affected_files=["docs/governance/example.md"],
+        risk_class="HIGH",
+    )
+    assert p["item_type"] == "docs_only"
+    assert p["decision"] == ap.DECISION_BLOCKED_HIGH_RISK
+    assert p["implementation_allowed"] is False
+
+
+def test_unknown_state_explicitly_returns_implementation_disallowed() -> None:
+    p = _plan(title="(unknown)")
+    assert p["item_type"] == "unknown"
+    assert p["implementation_allowed"] is False
+
+
+# ---------------------------------------------------------------------------
+# Atomic writes + read_latest_snapshot
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_dirs(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setattr(rep, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(
+        rep,
+        "DIGEST_DIR_JSON",
+        tmp_path / "logs" / "roadmap_execution_protocol",
+    )
+    return tmp_path
+
+
+def test_write_outputs_creates_latest_and_timestamped(isolated_dirs) -> None:
+    p = _plan(title="x", risk_class="LOW", affected_files=["docs/governance/example.md"])
+    paths = rep.write_outputs(p)
+    latest = (isolated_dirs / paths["latest"]).read_bytes()
+    timestamped = (isolated_dirs / paths["timestamped"]).read_bytes()
+    assert latest == timestamped
+    history = (isolated_dirs / paths["history"]).read_text(encoding="utf-8")
+    assert history.strip().endswith("}")
+
+
+def test_history_is_append_only(isolated_dirs) -> None:
+    p1 = _plan(
+        title="x",
+        risk_class="LOW",
+        affected_files=["docs/governance/example.md"],
+    )
+    p2 = rep.plan_item(
+        {
+            "title": "y",
+            "risk_class": "LOW",
+            "affected_files": ["docs/governance/example.md"],
+        },
+        frozen_utc="2026-05-03T08:01:00Z",
+    )
+    rep.write_outputs(p1)
+    rep.write_outputs(p2)
+    hist = (
+        isolated_dirs / "logs" / "roadmap_execution_protocol" / "history.jsonl"
+    ).read_text(encoding="utf-8")
+    lines = [ln for ln in hist.splitlines() if ln.strip()]
+    assert len(lines) == 2
+
+
+def test_read_latest_snapshot_returns_none_when_missing(isolated_dirs) -> None:
+    assert rep.read_latest_snapshot() is None
+
+
+def test_read_latest_snapshot_round_trips(isolated_dirs) -> None:
+    p = _plan(title="x", risk_class="LOW", affected_files=["docs/governance/example.md"])
+    rep.write_outputs(p)
+    rt = rep.read_latest_snapshot()
+    assert isinstance(rt, dict)
+    assert rt["item_id"] == p["item_id"]
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def test_cli_describe_returns_zero(capsys, monkeypatch: pytest.MonkeyPatch) -> None:
+    rc = rep.main(["--describe"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    parsed = json.loads(out)
+    assert parsed["report_kind"] == "roadmap_execution_protocol_description"
+
+
+def test_cli_plan_item_without_dry_run_is_refused(
+    capsys, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Hard policy: --plan-item without --dry-run is rejected."""
+    with pytest.raises(SystemExit):
+        rep.main(["--plan-item", '{"title":"x"}'])
+
+
+def test_cli_plan_item_with_dry_run_writes_artifact(
+    isolated_dirs, capsys, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    rc = rep.main(
+        [
+            "--plan-item",
+            '{"title":"x","risk_class":"LOW","affected_files":["docs/governance/example.md"]}',
+            "--dry-run",
+            "--frozen-utc",
+            "2026-05-03T08:00:00Z",
+        ]
+    )
+    assert rc == 0
+    assert (
+        isolated_dirs / "logs" / "roadmap_execution_protocol" / "latest.json"
+    ).exists()
+
+
+def test_cli_status_returns_one_when_artifact_missing(
+    isolated_dirs, capsys
+) -> None:
+    rc = rep.main(["--status"])
+    assert rc != 0
+
+
+def test_cli_no_freeform_command_flags() -> None:
+    """The CLI must not expose --command / --argv / --shell / --exec."""
+    src = Path(rep.__file__).read_text(encoding="utf-8")
+    for tok in ("--command", "--argv", "--shell", "--exec"):
+        assert tok not in src, f"free-form CLI flag found: {tok!r}"
+
+
+# ---------------------------------------------------------------------------
+# Frozen-contract integrity
+# ---------------------------------------------------------------------------
+
+
+def test_protocol_does_not_mutate_frozen_contract_paths(isolated_dirs) -> None:
+    """The protocol writes only under logs/roadmap_execution_protocol/."""
+    p = _plan(title="x", risk_class="LOW", affected_files=["docs/governance/example.md"])
+    paths = rep.write_outputs(p)
+    for label, rel in paths.items():
+        assert rel.startswith(
+            "logs/roadmap_execution_protocol/"
+        ), f"{label} -> {rel}"
+
+
+# ---------------------------------------------------------------------------
+# Schema/runbook docs presence
+# ---------------------------------------------------------------------------
+
+
+def test_schema_doc_exists() -> None:
+    p = (
+        REPO_ROOT
+        / "docs"
+        / "governance"
+        / "roadmap_item_execution_protocol"
+        / "schema.v1.md"
+    )
+    assert p.exists(), f"missing schema doc: {p}"
+    text = p.read_text(encoding="utf-8")
+    assert "v3.15.15.28" in text
+
+
+def test_runbook_doc_exists() -> None:
+    p = REPO_ROOT / "docs" / "governance" / "roadmap_item_execution_protocol.md"
+    assert p.exists(), f"missing runbook doc: {p}"
+    text = p.read_text(encoding="utf-8")
+    assert "v3.15.15.28" in text
+
+
+def test_agent_handoff_doc_exists() -> None:
+    p = REPO_ROOT / "docs" / "governance" / "agent_handoff_protocol.md"
+    assert p.exists(), f"missing agent handoff doc: {p}"
+
+
+# ---------------------------------------------------------------------------
+# Credential redaction
+# ---------------------------------------------------------------------------
+
+
+def test_credential_value_in_input_trips_guard() -> None:
+    """A credential-shaped string in the title routes through the
+    same approval_policy.assert_no_credential_values guard that
+    every other reporter uses."""
+    with pytest.raises(AssertionError):
+        rep.plan_item(
+            {"title": "leak: sk-ant-AAAAAAAA12345"},
+            frozen_utc="2026-05-03T08:00:00Z",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Dashboard projection (read-only)
+# ---------------------------------------------------------------------------
+
+
+def test_dashboard_status_includes_roadmap_protocol_block(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """End-to-end: /api/agent-control/status emits a
+    ``roadmap_protocol`` envelope that is either ``ok`` with
+    populated data or ``not_available`` with a reason."""
+    from flask import Flask
+    from dashboard import api_agent_control as ac
+
+    monkeypatch.setattr(ac, "LOGS_DIR", tmp_path / "logs")
+    monkeypatch.setattr(
+        ac,
+        "WORKLOOP_LATEST",
+        tmp_path / "logs" / "autonomous_workloop" / "latest.json",
+    )
+    monkeypatch.setattr(
+        ac,
+        "PR_LIFECYCLE_LATEST",
+        tmp_path / "logs" / "github_pr_lifecycle" / "latest.json",
+    )
+    flask_app = Flask(__name__)
+    ac.register_agent_control_routes(flask_app)
+    client = flask_app.test_client()
+    body = client.get("/api/agent-control/status").get_json()
+    assert "roadmap_protocol" in body
+    rp = body["roadmap_protocol"]
+    assert rp["status"] in ("ok", "not_available")
+    if rp["status"] == "not_available":
+        assert "reason" in rp
+
+
+# ---------------------------------------------------------------------------
+# Defense-in-depth: no plan ever returns executable=True
+# ---------------------------------------------------------------------------
+
+
+def test_no_combination_of_inputs_yields_executable_true() -> None:
+    """Sweep a large representative sample of inputs and confirm
+    the protocol never emits ``executable=true``."""
+    samples: list[dict[str, Any]] = [
+        {"title": "x"},
+        {"title": "x", "risk_class": "LOW"},
+        {"title": "x", "risk_class": "MEDIUM"},
+        {"title": "x", "risk_class": "HIGH"},
+        {"title": "x", "risk_class": "UNKNOWN"},
+        {"title": "x", "is_dependabot": True},
+        {"title": "x", "affected_files": ["docs/governance/example.md"]},
+        {"title": "x", "affected_files": [".claude/settings.json"]},
+        {"title": "x", "affected_files": ["execution/live/foo.py"]},
+        {"title": "x", "affected_files": ["research/research_latest.json"]},
+        {"title": "x", "affected_files": [".github/workflows/ci.yml"]},
+        {"title": "v4 roadmap supersedes v3.15"},
+        {"title": "Datadog API key needed"},
+        {"title": "telemetry export"},
+        {"title": "paid plan upgrade"},
+    ]
+    for s in samples:
+        p = rep.plan_item(s, frozen_utc="2026-05-03T08:00:00Z")
+        assert p["executable"] is False, f"input {s!r} yielded executable=True"
+        assert p["safe_to_execute"] is False


### PR DESCRIPTION
## Summary

Adds \`reporting.roadmap_execution_protocol\` — a deterministic, stdlib-only planner that converts a single roadmap item into a fully-specified execution plan **without running any code**. The protocol module owns intake / classification / proposal / agent assignment / plan; everything else (branch open, implementation, PR, CI, merge, post-merge verification) remains operator-led.

This release does **not** implement a roadmap item. It creates the protocol and artefacts that make future roadmap-item execution controlled and repeatable.

## Hard guarantees

- Stdlib-only. No subprocess, no \`gh\`, no \`git\`, no network.
- \`--plan-item\` REQUIRES \`--dry-run\`; the protocol never implements.
- \`safe_to_execute\` is hard-coded \`false\` at the digest level.
- \`executable\` is hard-coded \`false\` on every plan.
- \`implementation_allowed\` is True only for the closed \`ITEM_TYPES_OPEN_TO_IMPLEMENTATION\` set AND \`decision == allowed_read_only\`.
- Risk decisions delegate to \`approval_policy.decide()\` — there is no second source of truth.
- Output limited to \`logs/roadmap_execution_protocol/\`.
- Atomic writes (\`tmp\` + \`os.replace\`); history is append-only.
- Output is run through \`approval_policy.assert_no_credential_values\`.

## Closed taxonomies

**ITEM_TYPES (16):** docs_only / frontend_read_only / reporting_read_only / test_only / dependency_floor_bump / ci_hardening / observability_addition / tooling_intake / governance_change / canonical_roadmap_adoption / live_paper_shadow_risk / frozen_contract_change / external_account_or_secret / telemetry_or_data_egress / paid_tool / unknown.

**STATUSES (4):** proposed / needs_human / blocked / unknown_state.

## Eight agent roles (canonical handoff order)

\`product_owner\` → \`strategic_advisor\` → \`planner\` → \`implementation_agent\` → {\`architecture\`, \`ci\`, \`security_governance\`}_\`guardian\` → \`operator\`. Every plan emits all eight roles with responsibilities / allowed / forbidden / handoff fields so the operator can audit who is allowed to do what.

## CLI

\`\`\`
python -m reporting.roadmap_execution_protocol --describe
python -m reporting.roadmap_execution_protocol \
    --plan-item path-or-json --dry-run
python -m reporting.roadmap_execution_protocol --status
\`\`\`

## Surface (read-only projection)

- \`dashboard.api_agent_control\`: status payload now carries a \`roadmap_protocol\` summary block. \`not_available\` until the operator first runs \`--plan-item\` (the artifact lives at \`logs/roadmap_execution_protocol/latest.json\`).
- Frontend AgentControl Status card: renders a roadmap-protocol pill + state row when the artifact is available.
- \`AgentControlStatus\` TS interface extended.

## Tests added (54 protocol + 1 dashboard + 2 frontend polish)

Protocol tests (\`tests/unit/test_roadmap_execution_protocol.py\`):

- module invariants, \`describe()\`, 14 plan-shape cases (LOW/MEDIUM \`implementation_allowed\`, HIGH/UNKNOWN blocked, canonical roadmap blocked, governance blocked, secret/telemetry/paid blocked, protected/frozen path blocked, CI/test blocked);
- agent role count + canonical order;
- three-guardian review invariant;
- baseline tests / merge requirements / post-merge checks present;
- branch-naming determinism + one-item-per-branch default;
- \`approval_policy\` decision embedded verbatim;
- atomic writes + history append;
- CLI: \`--describe\` works; \`--status\` returns 1 when artifact missing; \`--plan-item\` without \`--dry-run\` is **refused**; no free-form CLI flags;
- no-subprocess / no-network / no-gh / no-git invariant;
- schema / runbook / handoff doc presence;
- credential-value redaction trip;
- dashboard end-to-end status projection;
- defense-in-depth sweep over 15 representative inputs confirming \`executable=false\` always.

Dashboard test:

- \`tests/unit/test_dashboard_api_agent_control.py\`: +1 status payload includes \`roadmap_protocol\` block.

Frontend tests:

- \`AgentControlPolish.test.tsx\`: +2 roadmap row cases (visible when payload provides it; falls back to unknown when omitted).

## Validation gates green

- governance_lint OK (15 agents, 3 workflows).
- \`pytest tests/smoke\`: 14/14.
- \`pytest tests/unit\`: **3145 passed, 3 skipped** (was 3090 pre-.28; +55 new tests).
- frontend vitest: **80/80** across 8 files (was 78; +2 roadmap row tests).
- frontend build: green (~272 KB JS gzip 78 KB).
- Frozen contract sha256 unchanged (\`4a567bd6...\` / \`ff15b8c4...\`).

## Files changed

- \`reporting/roadmap_execution_protocol.py\` — new module (~700 lines).
- \`tests/unit/test_roadmap_execution_protocol.py\` — new test file (54 cases).
- \`dashboard/api_agent_control.py\` — \`_roadmap_protocol_summary\` projection on status payload.
- \`tests/unit/test_dashboard_api_agent_control.py\` — +1 status case.
- \`frontend/src/api/agent_control.ts\` — \`AgentControlStatus.roadmap_protocol\` envelope.
- \`frontend/src/routes/AgentControl.tsx\` — read-only roadmap row + state.
- \`frontend/src/test/AgentControl.test.tsx\` + \`AgentControlPolish.test.tsx\` — fixtures + 2 polish tests.
- \`docs/governance/roadmap_item_execution_protocol.md\` — operator runbook.
- \`docs/governance/roadmap_item_execution_protocol/schema.v1.md\` — schema.
- \`docs/governance/agent_handoff_protocol.md\` — agent handoff doc.

## Non-goals (explicitly out of scope)

- No actual roadmap-item implementation (that requires a separate operator-led release).
- No execute / approve / reject / merge buttons.
- No POST/PUT/PATCH/DELETE.
- No \`api_execute_safe_controls\` wiring.
- No browser push.
- No external telemetry / paid services / signup flows.
- No live / paper / shadow / risk behavior changes.
- No CI/test weakening.
- No \`.claude/**\` changes.
- No frozen contract changes.
- No \`dashboard/dashboard.py\` changes.

## Test plan

- [ ] CI gates green (governance lint, smoke, unit, frontend, governance smoke)
- [ ] Frozen-contract hashes unchanged on main
- [ ] \`python -m reporting.roadmap_execution_protocol --describe\` prints the role catalogue
- [ ] \`python -m reporting.roadmap_execution_protocol --plan-item ... --dry-run\` produces a deterministic plan
- [ ] No mutation endpoints / unsafe buttons introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)