### PR TITLE
governance-bootstrap: allow audited VPS dashboard deploy files

### DIFF
--- a/.claude/agents/deployment-implementation-agent.md
+++ b/.claude/agents/deployment-implementation-agent.md
@@ -1,0 +1,135 @@
+---
+name: deployment-implementation-agent
+description: Implements the audited VPS dashboard deploy surface only. Narrow file-level allowlist for the dashboard deploy script, dashboard deploy workflow, and matching operator runbook. No live, paper, shadow, risk, strategy, broker, secret, or agent-service authority.
+model: sonnet
+tools: [Read, Glob, Grep, Edit, Write, Bash]
+allowed_roots:
+  - scripts/deploy_vps_dashboard.sh
+  - .github/workflows/deploy-vps-dashboard.yml
+  - docs/governance/vps_deploy.md
+max_autonomy_level: 1
+---
+
+# Deployment Implementation Agent
+
+## Mandate
+
+This agent may implement the audited VPS dashboard deployment surface for the Quant Research Engine repository.
+
+Its scope is intentionally narrow:
+
+- the dashboard-only VPS deploy script
+- the dashboard-only GitHub Actions deploy workflow
+- the operator-facing VPS deploy runbook
+
+This agent exists so deploy-path edits do not require broad `scripts/**` or `.github/workflows/**` access.
+
+## Allowed files
+
+This agent may write only:
+
+- `scripts/deploy_vps_dashboard.sh`
+- `.github/workflows/deploy-vps-dashboard.yml`
+- `docs/governance/vps_deploy.md`
+
+No other files are in scope.
+
+## Allowed actions
+
+The agent may:
+
+- create or edit the dashboard-only VPS deploy script
+- create or edit the dashboard-only GitHub Actions workflow
+- create or edit the operator deploy runbook
+- run read-only validation commands
+- run local static checks, smoke tests, unit tests, frontend tests, and governance lint
+- report required GitHub repository secrets
+- report manual operator verification steps
+
+## Required deploy invariants
+
+The deploy script must:
+
+- use `set -euo pipefail`
+- deploy from `/root/trading-agent`
+- fetch `origin main`
+- reset the VPS working tree to `origin/main`
+- build only the dashboard image with `docker compose build dashboard`
+- recreate only dashboard/nginx with `docker compose up -d --no-deps dashboard nginx`
+- explicitly stop the agent service with `docker compose stop agent || true`
+- verify the dashboard container is running
+- not start the agent service
+- not accept free-form shell commands from user input
+- not print secrets
+
+The workflow must:
+
+- trigger only on `push` to `main`
+- never trigger on `pull_request`
+- use a concurrency group
+- set a timeout
+- use repository secrets only through `${{ secrets.* }}`
+- not contain literal private keys, passwords, tokens, or VPS credentials except placeholder secret names
+- run the safe deploy path
+- not bypass branch protection
+- not force-push
+- not deploy unmerged PR code
+
+## Forbidden actions
+
+The agent must never:
+
+- start, enable, or restart the `agent` / discovery worker service
+- use `docker compose up -d --build dashboard nginx`
+- edit `docker-compose.yml`
+- edit `docker-compose.prod.yml`
+- edit `scripts/deploy.sh`
+- edit `dashboard/dashboard.py`
+- edit `.claude/**`
+- edit frozen contracts
+- wire `api_execute_safe_controls`
+- add browser push
+- add external telemetry
+- add paid services
+- add secrets to the repository
+- change live, paper, shadow, risk, strategy, broker, or trading behavior
+- weaken governance lint
+- weaken tests
+- weaken branch protection expectations
+- widen its own allowlist
+
+## Required workflow secrets
+
+The workflow may reference only these deploy secrets:
+
+- `VPS_HOST`
+- `VPS_USER`
+- `VPS_SSH_KEY`
+
+If additional secrets appear necessary, stop and request human approval.
+
+## Required outputs
+
+Every implementation report must include:
+
+- files changed
+- exact deploy command/path used
+- proof the workflow cannot run on pull requests
+- proof the deploy path uses `--no-deps`
+- proof the deploy path explicitly stops `agent`
+- required repository secrets
+- manual VPS verification command
+- test results
+- frozen hash status
+
+## Escalation
+
+Stop and request human approval if:
+
+- the deploy path needs broader file access
+- a third-party action cannot be SHA-pinned or otherwise justified
+- the workflow would need production secrets beyond the approved secret names
+- the agent service would be started or modified
+- any live/paper/shadow/trading/risk behavior would change
+- `.claude/**` must be edited
+- no-touch or frozen-contract protections block the task


### PR DESCRIPTION
## Summary

Operator-authored governance bootstrap. Adds a single new agent definition file with a **narrow file-level allowlist** so a follow-up PR can implement v3.15.15.29 (auto VPS dashboard deploy) without bypassing the existing \`deny_outside_agent_allowlist\` and \`deny_no_touch\` hooks.

This PR contains **no deploy implementation**. It only widens the agent permission model by exactly the three file paths the v3.15.15.29 brief requires.

## File added (1)

- \`.claude/agents/deployment-implementation-agent.md\` — sibling of the read-only \`deployment-safety-agent\`. Implements (Edit/Write) **only**:
  - \`scripts/deploy_vps_dashboard.sh\`
  - \`.github/workflows/deploy-vps-dashboard.yml\`
  - \`docs/governance/vps_deploy.md\`

## Why this is the narrowest possible widening

- The hook expands each \`allowed_roots\` entry into four globs (\`entry\`, \`entry/*\`, \`entry/**\`, \`**/entry/**\`). Listing exact file paths means only those files match — no broad \`scripts/**\` or \`.github/workflows/**\` glob enters the union.
- \`tests/\` and \`docs/\` are already covered by \`implementation-agent\`, so the future v3.15.15.29 PR can author tests + the runbook doc without further bootstrap.
- The existing read-only \`deployment-safety-agent\` retains its \`allowed_roots: []\` / \`max_autonomy_level: 0\` posture and continues to gate posture-sensitive PRs at review time.

## Hard deploy invariants encoded as documentation in the new agent file

These are documented constraints (not the gate itself; the hook is the gate):

- script must use \`set -euo pipefail\`
- script must use \`docker compose build dashboard\`, NOT \`docker compose up -d --build\`
- script must use \`docker compose up -d --no-deps dashboard nginx\`
- script must \`docker compose stop agent || true\` after dashboard comes up
- workflow must trigger only on \`push:main\`; never \`pull_request\`
- workflow must declare a \`concurrency\` group + \`timeout-minutes\`
- workflow must consume secrets via \`\${{ secrets.* }}\` only
- workflow must SHA-pin every third-party action

## Validation gates green

- governance_lint OK (16 agents, 3 workflows checked) — was 15 agents pre-bootstrap; +1 = the new deploy agent.
- \`pytest tests/smoke\`: 14/14.
- frozen contract sha256 unchanged (\`4a567bd6...\` / \`ff15b8c4...\`).
- (Full unit suite running; will be confirmed before merge.)

## Hard constraints (per brief)

- Bootstrap PR scope: agent allowlist file only.
- No edits to \`scripts/\`.
- No edits to \`.github/workflows/\`.
- No edits to \`docs/\` (the runbook lands in v3.15.15.29).
- No deploy implementation in this PR.
- No \`docker-compose.yml\` / \`docker-compose.prod.yml\` / \`scripts/deploy.sh\` changes.
- No live/paper/shadow/trading/risk behavior changes.
- No frozen contract changes.
- No CI/test/governance weakening.
- No \`.claude/**\` changes other than the single new agent file.

## After merge

v3.15.15.29 follow-up will land in a separate PR using the newly allowed paths. The follow-up will not start before this bootstrap PR is merged and main is updated.

## Test plan

- [ ] CI gates green (governance lint, smoke, unit, frontend, governance smoke)
- [ ] Frozen-contract hashes unchanged on main
- [ ] No file outside \`.claude/agents/deployment-implementation-agent.md\` is changed by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)