### PR TITLE
feat(v3.15.15.29): automatic VPS dashboard deploy on main merge

### DIFF
--- a/.github/workflows/deploy-vps-dashboard.yml
+++ b/.github/workflows/deploy-vps-dashboard.yml
@@ -1,0 +1,114 @@
+name: Deploy VPS Dashboard
+
+# v3.15.15.29 — automatic deploy of the dashboard + nginx surface
+# to the VPS on every push to main. The agent service is NOT
+# started or restarted by this workflow; it stays operator-gated.
+#
+# Trigger surface is intentionally narrow:
+#   * push to main only. No pull_request trigger (we never deploy
+#     unmerged code).
+#   * No workflow_dispatch (one less manual escape hatch).
+#   * No schedule (no implicit re-deploys).
+#
+# Concurrency policy:
+#   * group "deploy-vps-dashboard" so two deploys cannot race.
+#   * cancel-in-progress: false — let the in-flight deploy
+#     complete; the next one queues. We never want to interrupt
+#     a deploy mid-flight.
+#
+# Time + secret hygiene:
+#   * timeout-minutes: 20 — well above an expected deploy
+#     (~2-3 minutes) but bounded enough that a hung SSH cannot
+#     burn an entire runner hour.
+#   * secrets are referenced via ``${{ secrets.* }}`` only; never
+#     echoed; never printed.
+#   * the SSH private key file is created with chmod 600,
+#     consumed once, and the runner is GitHub-ephemeral so it
+#     is destroyed at end-of-job.
+#
+# Implementation note:
+#   We use the openssh-client already present on
+#   ``ubuntu-latest`` runners (no third-party SSH action). This
+#   keeps the third-party-action footprint at exactly one
+#   (actions/checkout, SHA-pinned per the existing repo-wide
+#   policy). The deploy work itself runs ON THE VPS via
+#   ``scripts/deploy_vps_dashboard.sh``; this workflow only
+#   triggers it.
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: deploy-vps-dashboard
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy dashboard + nginx
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repo (for runner-side context only)
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
+        with:
+          # Shallow checkout is fine — the deploy script runs on
+          # the VPS, not in this checkout.
+          fetch-depth: 1
+
+      - name: Configure SSH client
+        env:
+          # We pull these in via env so the value never appears in
+          # the workflow's shell trace.
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+          VPS_USER: ${{ secrets.VPS_USER }}
+          VPS_SSH_KEY: ${{ secrets.VPS_SSH_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${VPS_HOST}" ] || [ -z "${VPS_USER}" ] || [ -z "${VPS_SSH_KEY}" ]; then
+            echo "missing one or more required secrets: VPS_HOST / VPS_USER / VPS_SSH_KEY"
+            exit 1
+          fi
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          # Write the private key. The redirect avoids placing the
+          # value on a command line where another process could
+          # observe it via /proc/<pid>/cmdline.
+          umask 077
+          printf '%s\n' "${VPS_SSH_KEY}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          # Pin the host key. ssh-keyscan is silent on stderr to
+          # avoid leaking VPS_HOST to logs.
+          ssh-keyscan -H -T 10 "${VPS_HOST}" >> ~/.ssh/known_hosts 2>/dev/null
+          chmod 600 ~/.ssh/known_hosts
+          echo "ssh client configured (key + known_hosts)"
+
+      - name: Run deploy script on VPS
+        env:
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+          VPS_USER: ${{ secrets.VPS_USER }}
+        run: |
+          set -euo pipefail
+          # The deploy work happens entirely on the VPS via the
+          # audited scripts/deploy_vps_dashboard.sh. We do NOT
+          # pass any arguments — the script refuses arguments by
+          # design.
+          ssh \
+            -i ~/.ssh/deploy_key \
+            -o StrictHostKeyChecking=yes \
+            -o BatchMode=yes \
+            -o ConnectTimeout=15 \
+            "${VPS_USER}@${VPS_HOST}" \
+            'cd /root/trading-agent && bash scripts/deploy_vps_dashboard.sh'
+
+      - name: Wipe SSH artifacts
+        if: always()
+        run: |
+          set -euo pipefail
+          # Defense in depth even though the runner is ephemeral.
+          rm -f ~/.ssh/deploy_key ~/.ssh/known_hosts || true

--- a/docs/governance/vps_deploy.md
+++ b/docs/governance/vps_deploy.md
@@ -1,0 +1,245 @@
+# VPS dashboard deploy — operator runbook
+
+Module: `scripts/deploy_vps_dashboard.sh` + `.github/workflows/deploy-vps-dashboard.yml`
+Release: v3.15.15.29
+Sibling docs: `mobile_agent_control_pwa.md`,
+`high_risk_approval_policy.md`, `recurring_maintenance.md`,
+`no_touch_paths.md`.
+
+## TL;DR
+
+Every push to `main` automatically deploys the latest dashboard
+and nginx surface to the VPS. **The agent / discovery worker is
+NOT deployed and is NOT started by this workflow.** Live trading
+remains operator-gated.
+
+## What this deploys
+
+| service | role | deployed by this workflow? |
+| --- | --- | :---: |
+| `dashboard` | Flask app + Agent Control PWA | yes (rebuilt + restarted) |
+| `nginx` | reverse proxy | yes (recreated) |
+| `agent` | autonomous trading worker | **NO — explicitly stopped after deploy** |
+| any other compose service the dashboard `depends_on` | — | **NO — `--no-deps` prevents touch** |
+
+## Hard guarantees encoded in the script
+
+* `set -euo pipefail` — any failed step halts the deploy.
+* `docker compose build dashboard` (NOT `up -d --build`) — only
+  the dashboard image is rebuilt; the agent image is untouched.
+* `docker compose up -d --no-deps dashboard nginx` — the
+  `--no-deps` flag tells compose to NOT touch any service the
+  named services depend on. Combined with the explicit
+  service list, this means the agent is never recreated.
+* `docker compose stop agent || true` — defense in depth: even
+  if a future compose reorganisation forgets `--no-deps`, the
+  agent is explicitly stopped after deploy.
+* The script then asserts:
+  * `dashboard` is in the running set.
+  * `agent` is NOT in the running set.
+  * `http://127.0.0.1:8050/agent-control` responds with HTTP 2xx
+    within 5 retry attempts (3 s sleep between attempts).
+* The script accepts no arguments. There is no free-form
+  command surface.
+
+## The forbidden compose pattern
+
+**Never use:**
+
+```
+docker compose up -d --build dashboard nginx
+```
+
+This previously caused the `agent` service to be rebuilt /
+recreated / started via compose's `depends_on` resolution. The
+deploy script and the workflow are explicit about NOT using this
+pattern, and a static test in `tests/unit/` enforces it.
+
+## Required GitHub secrets
+
+The workflow consumes exactly three repository secrets:
+
+| secret | purpose | where to set |
+| --- | --- | --- |
+| `VPS_HOST` | hostname or IP of the VPS (the operator already knows it; do NOT paste it into any committed file) | `Repo → Settings → Secrets and variables → Actions → New repository secret` |
+| `VPS_USER` | SSH user (typically `root`) | same place |
+| `VPS_SSH_KEY` | full private-key contents (PEM) of a dedicated deploy key | same place |
+
+The workflow:
+
+* references each secret via `${{ secrets.* }}` only;
+* never echoes secret values;
+* writes the private key to `~/.ssh/deploy_key` with `chmod 600`
+  on the ephemeral GitHub-hosted runner;
+* wipes `~/.ssh/deploy_key` and `~/.ssh/known_hosts` in an
+  `if: always()` final step.
+
+## One-time setup: dedicated deploy SSH key
+
+Generate a **new** SSH key dedicated to the deploy workflow.
+Do NOT reuse personal keys.
+
+On a workstation (NOT the VPS):
+
+```bash
+# Generate the deploy key. ed25519 is small + modern; rsa-4096 is fine too.
+ssh-keygen -t ed25519 -f ./deploy_vps_dashboard_key -C "github-actions deploy" -N ""
+
+# Files produced:
+#   deploy_vps_dashboard_key       <- private key (goes into VPS_SSH_KEY)
+#   deploy_vps_dashboard_key.pub   <- public key (goes onto the VPS)
+```
+
+On the VPS, append the public key to the deploy user's
+`authorized_keys`:
+
+```bash
+# Run as root (or the deploy user) on the VPS:
+mkdir -p /root/.ssh
+chmod 700 /root/.ssh
+cat >> /root/.ssh/authorized_keys <<'EOF'
+<contents of deploy_vps_dashboard_key.pub>
+EOF
+chmod 600 /root/.ssh/authorized_keys
+```
+
+Back on the workstation, add the **private** key as a GitHub
+secret:
+
+1. Open `Repo → Settings → Secrets and variables → Actions`.
+2. Add `VPS_SSH_KEY` with the full contents of
+   `deploy_vps_dashboard_key` (including the
+   `-----BEGIN OPENSSH PRIVATE KEY-----` header and the
+   `-----END OPENSSH PRIVATE KEY-----` footer).
+3. Add `VPS_HOST` (the deploy host the operator already knows; do not commit the value here).
+4. Add `VPS_USER` (e.g. `root`).
+
+Then **delete the local copy of the private key** from the
+workstation:
+
+```bash
+rm -f ./deploy_vps_dashboard_key
+```
+
+The public key file (`deploy_vps_dashboard_key.pub`) is safe to
+keep locally — it's already on the VPS.
+
+## Manual deploy (operator-initiated)
+
+Run the same script manually from the VPS at any time:
+
+```bash
+ssh root@<VPS_HOST>
+cd /root/trading-agent
+bash scripts/deploy_vps_dashboard.sh
+```
+
+Same script, same invariants. The workflow and the manual path
+are byte-identical.
+
+## Manual verification
+
+After a deploy (manual or automatic):
+
+```bash
+# Cluster state.
+docker compose ps
+
+# Dashboard health.
+curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:8050/agent-control
+# Expected: 200 (or 302 if redirected to /login).
+
+# Confirm agent is NOT running.
+docker compose ps --status running --services | grep -q '^agent$' \
+  && echo "FAIL: agent is running" \
+  || echo "OK: agent is stopped"
+```
+
+The Agent Control PWA may need a service-worker / site-data
+clear after a shell or asset cache release; see
+`mobile_agent_control_pwa.md` for the v3.15.15.26.x SW versioning
+runbook.
+
+## Rollback
+
+To roll back to a previous SHA:
+
+```bash
+ssh root@<VPS_HOST>
+cd /root/trading-agent
+
+# Inspect recent merge commits.
+git log --oneline --first-parent -10 main
+
+# Reset to a known-good SHA (replace with the actual SHA).
+git fetch origin main
+git reset --hard <SHA>
+
+# Re-build + relaunch via the audited script.
+# (The script always resets to origin/main; for a deliberate
+#  rollback you must override that. The simplest pattern is to
+#  push a revert commit through GitHub so the workflow picks it
+#  up the same way as any other merge.)
+```
+
+The recommended rollback path is a `git revert` PR through
+GitHub: it preserves the audit trail and re-uses the same
+deploy workflow without manual SSH.
+
+## Operator note: PWA cache
+
+After this release ships, the Agent Control PWA standalone
+shell from v3.15.15.26.2 already lives behind
+`SW_VERSION=v3.15.15.26.2`. No additional cache action is
+required for v3.15.15.29. Future releases that change the PWA
+shell or assets must bump `SW_VERSION` in
+`frontend/public/sw.js`; see `mobile_agent_control_pwa.md` for
+the canonical procedure.
+
+## Security notes
+
+* **Do not reuse personal SSH keys.** Use the dedicated deploy
+  key generated via the steps above.
+* **Do not commit secrets.** A static test in `tests/unit/`
+  enforces that the workflow file contains no literal IPs,
+  private-key headers, or token-shaped values.
+* **The deploy user need not be root.** If you create a
+  dedicated `deploy` user on the VPS, grant it the minimum
+  privileges needed to run `docker compose` and edit
+  `/root/trading-agent` (or move the repo to that user's home).
+  Then set `VPS_USER=deploy` accordingly.
+* **The workflow runner is GitHub-ephemeral.** The private key
+  file lives only for the duration of one job and is wiped in
+  the final step.
+
+## Static-test guarantees
+
+`tests/unit/test_vps_deploy_invariants.py` enforces:
+
+* the script exists, contains `set -euo pipefail`,
+  `docker compose build dashboard`,
+  `docker compose up -d --no-deps dashboard nginx`,
+  `docker compose stop agent`, and does NOT contain
+  `docker compose up -d --build dashboard nginx`;
+* the workflow exists, triggers on `push:` to `main` only, has
+  no `pull_request` trigger, references the three required
+  secrets, declares a `concurrency` group + `timeout-minutes`
+  cap, contains no literal private-key / token / password /
+  hostname material, and invokes the safe deploy script.
+
+These tests run as part of `pytest tests/unit` on every PR;
+breaking any invariant fails the build.
+
+## Cross-references
+
+* `scripts/deploy_vps_dashboard.sh` — the audited deploy script.
+* `.github/workflows/deploy-vps-dashboard.yml` — the GitHub
+  Actions workflow.
+* `tests/unit/test_vps_deploy_invariants.py` — invariant
+  guards.
+* `.claude/agents/deployment-implementation-agent.md` — the
+  agent that authored these files (narrow file-level allowlist).
+* `.claude/agents/deployment-safety-agent.md` — the read-only
+  reviewer that gates production-posture diffs.
+* `docs/governance/no_touch_paths.md` — the broader no-touch
+  policy.

--- a/reporting/autonomy_metrics.py
+++ b/reporting/autonomy_metrics.py
@@ -891,7 +891,15 @@ def collect_snapshot(
 
     runtime_history = _read_jsonl_history(SOURCE_WORKLOOP_RUNTIME_HISTORY)
     recurring_history = _read_jsonl_history(SOURCE_RECURRING_MAINTENANCE_HISTORY)
-    trends = _trends(runtime_history, recurring_history, now=_utcnow_dt())
+    # v3.15.15.29: when ``frozen_utc`` is pinned (deterministic
+    # tests), use it as the trend-window "now" too. Without this
+    # the trend window kept drifting against real-UTC and made
+    # the test_trends_* cases time-of-day flaky. In production
+    # (no frozen_utc) the behaviour is unchanged.
+    now_for_trends = _parse_iso(frozen_utc) if frozen_utc else None
+    if now_for_trends is None:
+        now_for_trends = _utcnow_dt()
+    trends = _trends(runtime_history, recurring_history, now=now_for_trends)
 
     final_rec = _final_recommendation(
         src_statuses=src_statuses,

--- a/scripts/deploy_vps_dashboard.sh
+++ b/scripts/deploy_vps_dashboard.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# scripts/deploy_vps_dashboard.sh
+#
+# Audited VPS deploy for the JvR Trading Agent dashboard surface.
+# v3.15.15.29 — automatic deploy on main merge.
+#
+# WHAT THIS DEPLOYS:
+#   * dashboard service (Flask app + Agent Control PWA)
+#   * nginx service (reverse proxy)
+#
+# WHAT THIS DOES NOT DEPLOY / START:
+#   * agent service (the autonomous trading worker)
+#   * discovery / research worker
+#
+# Why the safe compose pattern:
+#   ``docker compose up -d --build dashboard nginx`` previously
+#   caused the ``agent`` service to be rebuilt/recreated/started
+#   via compose's depends_on / dependency resolution. The pattern
+#   below is the safe one:
+#
+#     docker compose build dashboard
+#     docker compose up -d --no-deps dashboard nginx
+#     docker compose stop agent || true
+#
+#   ``--no-deps`` prevents compose from touching the agent service
+#   even if dashboard declares depends_on. The trailing ``stop
+#   agent`` is a defense-in-depth guarantee that even if a future
+#   compose reorganisation forgets ``--no-deps``, the agent does
+#   not silently start.
+#
+# Hard guarantees:
+#   * No live / paper / shadow / trading / risk action.
+#   * No free-form command input. The script accepts no arguments.
+#   * No secrets read or echoed.
+#   * No api_execute_safe_controls wiring.
+#   * No browser push.
+#   * Idempotent: re-running is safe.
+
+set -euo pipefail
+
+REPO_ROOT="/root/trading-agent"
+DASHBOARD_HEALTH_URL="http://127.0.0.1:8050/agent-control"
+COMPOSE="docker compose"
+
+log() {
+    # Plain stdout; never echo secrets.
+    printf '[deploy_vps_dashboard] %s\n' "$*"
+}
+
+# Refuse to run with arguments — keeps the surface intentionally
+# narrow. The workflow invokes this script bare.
+if [[ "$#" -gt 0 ]]; then
+    log "refused: this script accepts no arguments (got $#)"
+    exit 2
+fi
+
+if [[ ! -d "${REPO_ROOT}" ]]; then
+    log "fatal: ${REPO_ROOT} does not exist on this host"
+    exit 3
+fi
+
+cd "${REPO_ROOT}"
+
+log "step 1/6: fetch latest origin/main"
+git fetch origin main
+
+log "step 2/6: hard-reset working tree to origin/main"
+git reset --hard origin/main
+
+log "step 3/6: build dashboard image (only)"
+${COMPOSE} build dashboard
+
+log "step 4/6: bring dashboard + nginx up with --no-deps"
+# --no-deps is the critical flag. It tells compose to NOT touch
+# any service the named services depend on. Combined with the
+# explicit list (dashboard nginx), this means agent stays as it
+# was — typically stopped.
+${COMPOSE} up -d --no-deps dashboard nginx
+
+log "step 5/6: explicit defense-in-depth stop of agent"
+# This is intentional. We do NOT want the agent to be running on
+# the VPS by default; live trading is operator-gated. The ``|| true``
+# is defensive — if the service is already stopped or not in the
+# compose file, this is not a fatal error.
+${COMPOSE} stop agent || true
+
+log "step 6/6: verify cluster state"
+${COMPOSE} ps
+
+# Verification: dashboard must be Up.
+if ! ${COMPOSE} ps --status running --services | grep -qx dashboard; then
+    log "fatal: dashboard service did not reach running state"
+    ${COMPOSE} logs --tail=120 dashboard || true
+    exit 4
+fi
+
+# Verification: agent must NOT be Up. We log + fail loudly so
+# the workflow surfaces the regression in the deploy run.
+if ${COMPOSE} ps --status running --services | grep -qx agent; then
+    log "fatal: agent service is unexpectedly running after deploy"
+    ${COMPOSE} logs --tail=120 agent || true
+    exit 5
+fi
+
+log "verifying dashboard responds on ${DASHBOARD_HEALTH_URL}"
+# A short retry loop covers the seconds while nginx / Flask warm
+# up. We hit /agent-control because the standalone PWA route is
+# the operator-facing surface and is guaranteed to be wired.
+http_ok=0
+for attempt in 1 2 3 4 5; do
+    if curl -sSf -o /dev/null --max-time 5 "${DASHBOARD_HEALTH_URL}"; then
+        http_ok=1
+        break
+    fi
+    log "attempt ${attempt}/5: dashboard not responding yet, sleeping 3s"
+    sleep 3
+done
+
+if [[ "${http_ok}" -ne 1 ]]; then
+    log "fatal: dashboard did not respond on ${DASHBOARD_HEALTH_URL}"
+    ${COMPOSE} logs --tail=120 dashboard || true
+    exit 6
+fi
+
+log "deploy ok: dashboard + nginx running, agent stopped"
+exit 0

--- a/tests/unit/test_vps_deploy_invariants.py
+++ b/tests/unit/test_vps_deploy_invariants.py
@@ -1,0 +1,355 @@
+"""Static-guard invariants for the v3.15.15.29 VPS dashboard deploy.
+
+These tests are pure source-text checks. They never run the
+deploy script and never make a network call. The point is to
+make every safety-critical decision in
+``scripts/deploy_vps_dashboard.sh`` and
+``.github/workflows/deploy-vps-dashboard.yml`` re-checkable on
+every PR — a future regression that softens the dashboard-only
+deploy contract trips a unit-test failure rather than waiting
+for a runtime incident on the VPS.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "deploy_vps_dashboard.sh"
+WORKFLOW_PATH = (
+    REPO_ROOT / ".github" / "workflows" / "deploy-vps-dashboard.yml"
+)
+DOC_PATH = REPO_ROOT / "docs" / "governance" / "vps_deploy.md"
+
+
+# ---------------------------------------------------------------------------
+# Files exist
+# ---------------------------------------------------------------------------
+
+
+def test_deploy_script_exists() -> None:
+    assert SCRIPT_PATH.exists(), f"missing: {SCRIPT_PATH}"
+
+
+def test_workflow_exists() -> None:
+    assert WORKFLOW_PATH.exists(), f"missing: {WORKFLOW_PATH}"
+
+
+def test_runbook_exists() -> None:
+    assert DOC_PATH.exists(), f"missing: {DOC_PATH}"
+    text = DOC_PATH.read_text(encoding="utf-8")
+    assert "v3.15.15.29" in text
+
+
+# ---------------------------------------------------------------------------
+# Deploy script invariants
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def script_text() -> str:
+    return SCRIPT_PATH.read_text(encoding="utf-8")
+
+
+def test_script_has_strict_bash_options(script_text: str) -> None:
+    assert "set -euo pipefail" in script_text
+
+
+def test_script_uses_compose_build_dashboard_only(script_text: str) -> None:
+    """The safe build pattern: build the dashboard image WITHOUT
+    forcing a recreate of any other service."""
+    assert "docker compose build dashboard" in script_text or (
+        "${COMPOSE} build dashboard" in script_text
+        and 'COMPOSE="docker compose"' in script_text
+    )
+
+
+def test_script_uses_compose_up_no_deps_dashboard_nginx(script_text: str) -> None:
+    """``--no-deps`` is the critical flag that prevents compose
+    from touching the agent service via ``depends_on``
+    resolution."""
+    assert (
+        "docker compose up -d --no-deps dashboard nginx" in script_text
+        or "${COMPOSE} up -d --no-deps dashboard nginx" in script_text
+    )
+
+
+def test_script_explicitly_stops_agent(script_text: str) -> None:
+    """Defense-in-depth: even if a future compose reorganisation
+    forgets ``--no-deps``, the agent must be stopped after deploy."""
+    assert (
+        "docker compose stop agent" in script_text
+        or "${COMPOSE} stop agent" in script_text
+    )
+
+
+def test_script_does_not_use_forbidden_up_build_pattern(
+    script_text: str,
+) -> None:
+    """The forbidden pattern that previously caused the agent
+    service to be rebuilt/recreated/started: ``docker compose
+    up -d --build dashboard nginx``. Any variant of
+    ``up -d --build`` is rejected.
+
+    The script's safety-policy COMMENT explains why this pattern
+    is forbidden, so the literal phrase appears legitimately in
+    a comment. We only scan executable (non-comment) lines.
+    """
+    forbidden_patterns = [
+        "docker compose up -d --build dashboard nginx",
+        "docker compose up -d --build dashboard",
+        "docker compose up --build dashboard nginx",
+        "${COMPOSE} up -d --build dashboard nginx",
+    ]
+    executable_lines = [
+        ln for ln in script_text.splitlines() if not ln.lstrip().startswith("#")
+    ]
+    executable = "\n".join(executable_lines)
+    for pat in forbidden_patterns:
+        assert pat not in executable, (
+            f"deploy script (executable lines only) contains "
+            f"forbidden pattern: {pat!r}"
+        )
+
+
+def test_script_refuses_arguments(script_text: str) -> None:
+    """Narrow-by-design: the script must refuse any positional
+    argument so the workflow cannot accidentally pass arbitrary
+    operator input."""
+    assert '"$#"' in script_text or "$#" in script_text
+    assert "exit 2" in script_text
+
+
+def test_script_verifies_dashboard_running(script_text: str) -> None:
+    """The script must fail loudly if dashboard did not reach
+    running state."""
+    assert "ps --status running --services" in script_text
+    assert "grep -qx dashboard" in script_text
+
+
+def test_script_verifies_agent_not_running(script_text: str) -> None:
+    """The script must fail loudly if agent is still running."""
+    assert "grep -qx agent" in script_text
+    # The check for agent running must be a fatal exit.
+    assert re.search(r"unexpectedly running.*\n.*exit\s+5", script_text, re.DOTALL) or (
+        "exit 5" in script_text
+    )
+
+
+def test_script_does_not_embed_secrets_or_hosts(script_text: str) -> None:
+    """The script must not contain literal IPs, tokens, or
+    private-key headers. The VPS hostname only appears as a
+    constant repo path; the deploy URL is localhost."""
+    forbidden_substrings = [
+        "BEGIN OPENSSH PRIVATE KEY",
+        "BEGIN RSA PRIVATE KEY",
+        "BEGIN EC PRIVATE KEY",
+        "BEGIN PRIVATE KEY",
+        "ssh-rsa AAAA",
+        "ssh-ed25519 AAAA",
+        "ghp_",
+        "github_pat_",
+        "sk-ant-",
+        "AKIA",
+    ]
+    for tok in forbidden_substrings:
+        assert tok not in script_text, f"script contains forbidden token: {tok!r}"
+    # No hard-coded VPS IP. The only IP literal allowed is loopback.
+    # Lookbehind ``(?<![\w.])`` prevents matching a 4-octet
+    # subsequence inside a longer dotted string like the version
+    # tag ``v3.15.15.26.2`` (contains ``15.15.26.2``) or
+    # ``v3.15.15.29`` (contains ``3.15.15.29``). Lookahead
+    # ``(?![.\d])`` prevents matching a 4-octet prefix of a 5+
+    # component string.
+    ip_re = re.compile(
+        r"(?<![\w.])(?!127\.0\.0\.1\b)\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(?![.\d])"
+    )
+    matches = ip_re.findall(script_text)
+    assert matches == [], (
+        f"deploy script contains a non-loopback IP literal: {matches!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Workflow invariants
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def workflow_text() -> str:
+    return WORKFLOW_PATH.read_text(encoding="utf-8")
+
+
+def test_workflow_triggers_only_on_push_to_main(workflow_text: str) -> None:
+    """The trigger surface must be exactly ``push: branches:
+    [main]``. Specifically NO ``pull_request`` trigger."""
+    # Must contain a push:main block.
+    assert re.search(r"on:\s*\n\s*push:\s*\n\s*branches:\s*\n\s*-\s*main", workflow_text)
+
+
+def test_workflow_does_not_trigger_on_pull_request(workflow_text: str) -> None:
+    """A pull_request trigger would deploy unmerged code. Refuse
+    any variant."""
+    forbidden = ["pull_request:", "pull_request_target:"]
+    for tok in forbidden:
+        assert tok not in workflow_text, (
+            f"workflow contains forbidden trigger: {tok!r}"
+        )
+
+
+def test_workflow_uses_required_secrets(workflow_text: str) -> None:
+    """The three repository secrets the workflow consumes."""
+    assert "${{ secrets.VPS_HOST }}" in workflow_text
+    assert "${{ secrets.VPS_USER }}" in workflow_text
+    assert "${{ secrets.VPS_SSH_KEY }}" in workflow_text
+
+
+def test_workflow_has_concurrency_group(workflow_text: str) -> None:
+    """Two deploys must not race; the in-flight deploy must not be
+    cancelled mid-flight."""
+    assert "concurrency:" in workflow_text
+    assert "group: deploy-vps-dashboard" in workflow_text
+    assert "cancel-in-progress: false" in workflow_text
+
+
+def test_workflow_has_timeout_minutes(workflow_text: str) -> None:
+    """A bounded timeout prevents a hung SSH from burning a
+    runner-hour."""
+    m = re.search(r"timeout-minutes:\s*(\d+)", workflow_text)
+    assert m, "workflow does not declare timeout-minutes"
+    minutes = int(m.group(1))
+    assert 1 <= minutes <= 60, f"workflow timeout-minutes ({minutes}) out of sane range"
+
+
+def test_workflow_does_not_embed_secrets_or_hosts(workflow_text: str) -> None:
+    """No literal private-key material, tokens, IPs, or
+    passwords."""
+    forbidden_substrings = [
+        "BEGIN OPENSSH PRIVATE KEY",
+        "BEGIN RSA PRIVATE KEY",
+        "BEGIN EC PRIVATE KEY",
+        "BEGIN PRIVATE KEY",
+        "ssh-rsa AAAA",
+        "ssh-ed25519 AAAA",
+        "ghp_",
+        "github_pat_",
+        "sk-ant-",
+        "AKIA",
+        "password:",
+        "PASSWORD=",
+    ]
+    for tok in forbidden_substrings:
+        assert tok not in workflow_text, f"workflow contains forbidden token: {tok!r}"
+    # No hard-coded IP literal.
+    ip_re = re.compile(r"\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b")
+    matches = ip_re.findall(workflow_text)
+    assert matches == [], (
+        f"workflow contains an IP literal (must come from secrets): {matches!r}"
+    )
+
+
+def test_workflow_invokes_safe_deploy_script(workflow_text: str) -> None:
+    """The deploy work must run via the audited script, not
+    inline."""
+    assert "scripts/deploy_vps_dashboard.sh" in workflow_text
+
+
+def test_workflow_does_not_use_forbidden_compose_pattern(
+    workflow_text: str,
+) -> None:
+    """The workflow itself must not paste the unsafe up-build
+    pattern. The deploy script enforces this on the VPS, but
+    the workflow is also a source of truth."""
+    forbidden_patterns = [
+        "docker compose up -d --build dashboard nginx",
+        "docker compose up -d --build dashboard",
+    ]
+    for pat in forbidden_patterns:
+        assert pat not in workflow_text, (
+            f"workflow contains forbidden compose pattern: {pat!r}"
+        )
+
+
+def test_workflow_actions_are_sha_pinned(workflow_text: str) -> None:
+    """Every ``uses:`` reference must be SHA-pinned (40 hex
+    chars). This matches the repo-wide governance lint policy."""
+    uses_re = re.compile(r"uses:\s*([^\s#]+)")
+    for line_match in uses_re.finditer(workflow_text):
+        ref = line_match.group(1)
+        # The action ref must include a 40-char hex SHA, e.g.
+        # ``actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11``.
+        assert re.search(r"@[0-9a-f]{40}\b", ref), (
+            f"workflow uses non-SHA-pinned action: {ref!r}"
+        )
+
+
+def test_workflow_wipes_ssh_artifacts(workflow_text: str) -> None:
+    """Defense in depth even though the runner is ephemeral:
+    the SSH key file must be removed at end-of-job."""
+    assert "rm -f ~/.ssh/deploy_key" in workflow_text
+
+
+def test_workflow_uses_strict_host_key_checking(workflow_text: str) -> None:
+    """The SSH command must NOT disable host key checking."""
+    assert "StrictHostKeyChecking=yes" in workflow_text
+    assert "StrictHostKeyChecking=no" not in workflow_text
+
+
+def test_workflow_uses_batch_mode_to_refuse_password_prompts(
+    workflow_text: str,
+) -> None:
+    """``BatchMode=yes`` ensures the SSH client never falls back
+    to interactive auth (which would hang a runner)."""
+    assert "BatchMode=yes" in workflow_text
+
+
+# ---------------------------------------------------------------------------
+# Cross-file consistency
+# ---------------------------------------------------------------------------
+
+
+def test_runbook_references_required_secrets(workflow_text: str) -> None:
+    """The operator runbook must enumerate the secrets the
+    workflow consumes so the operator can't miss one during
+    setup."""
+    text = DOC_PATH.read_text(encoding="utf-8")
+    for sec in ("VPS_HOST", "VPS_USER", "VPS_SSH_KEY"):
+        assert sec in text, f"runbook does not document required secret: {sec!r}"
+
+
+def test_runbook_documents_safe_compose_pattern() -> None:
+    text = DOC_PATH.read_text(encoding="utf-8")
+    assert "docker compose build dashboard" in text
+    assert "docker compose up -d --no-deps dashboard nginx" in text
+    assert "docker compose stop agent" in text
+
+
+def test_runbook_warns_against_forbidden_pattern() -> None:
+    text = DOC_PATH.read_text(encoding="utf-8")
+    # The runbook's "Never use" section must call out the
+    # forbidden pattern verbatim so reviewers spot a regression.
+    assert "docker compose up -d --build dashboard nginx" in text
+
+
+def test_no_other_file_references_a_full_vps_ip() -> None:
+    """No file we ship in this release contains a non-loopback
+    IPv4 literal."""
+    # Lookbehind ``(?<![\w.])`` prevents matching a 4-octet
+    # subsequence inside a longer dotted string like the version
+    # tag ``v3.15.15.26.2`` (contains ``15.15.26.2``) or
+    # ``v3.15.15.29`` (contains ``3.15.15.29``). Lookahead
+    # ``(?![.\d])`` prevents matching a 4-octet prefix of a 5+
+    # component string.
+    ip_re = re.compile(
+        r"(?<![\w.])(?!127\.0\.0\.1\b)\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(?![.\d])"
+    )
+    for path in (SCRIPT_PATH, WORKFLOW_PATH, DOC_PATH):
+        text = path.read_text(encoding="utf-8")
+        matches = ip_re.findall(text)
+        assert matches == [], (
+            f"{path.name} contains a non-loopback IP literal: {matches!r}"
+        )


### PR DESCRIPTION
## Summary

Adds an audited, narrow auto-deploy surface so every merge to `main` updates the VPS dashboard + nginx services automatically. **The agent / discovery worker is NOT deployed and NOT started by this workflow.**

## Files

- `scripts/deploy_vps_dashboard.sh` — strict-bash audited deploy script. `set -euo pipefail`. Refuses arguments. Verifies the dashboard reaches running state, the agent is NOT running, and `/agent-control` responds with HTTP 2xx within 5 retries.
- `.github/workflows/deploy-vps-dashboard.yml` — triggers ONLY on `push:main`; **no `pull_request` trigger**; concurrency group `deploy-vps-dashboard` with `cancel-in-progress: false`; `timeout-minutes: 20`; consumes `VPS_HOST` / `VPS_USER` / `VPS_SSH_KEY` via `secrets.*` only; uses native openssh-client (no third-party SSH action); SHA-pinned every `uses:` reference; `StrictHostKeyChecking=yes`; `BatchMode=yes`; SSH key wiped in `if: always()` final step.
- `docs/governance/vps_deploy.md` — operator runbook with required-secrets table, dedicated deploy-key generation, manual deploy command, manual verification, rollback, and security notes (no IP literals committed).
- `tests/unit/test_vps_deploy_invariants.py` — **28 static-guard cases** enforcing every invariant above.
- `reporting/autonomy_metrics.py` — sub-fix: when `--frozen-utc` is pinned, the trend window also uses that as "now". Without this the trend tests drifted against real-UTC. Production behaviour unchanged. One-line.

## Proof the workflow cannot deploy on PR

`.github/workflows/deploy-vps-dashboard.yml` trigger block:

```yaml
on:
  push:
    branches:
      - main
```

No `pull_request:` / `pull_request_target:` / `workflow_dispatch:` / `schedule:`. Enforced by `test_workflow_does_not_trigger_on_pull_request`.

## Proof the deploy path uses --no-deps

`scripts/deploy_vps_dashboard.sh`:

```bash
${COMPOSE} build dashboard
${COMPOSE} up -d --no-deps dashboard nginx
${COMPOSE} stop agent || true
```

The forbidden up-build pattern is rejected by `test_script_does_not_use_forbidden_up_build_pattern` (executable lines only).

## Proof agent is explicitly stopped

The script runs `${COMPOSE} stop agent || true` after dashboard comes up, then asserts the agent is **not** in the running set; if it is, the script exits non-zero and the workflow fails. Enforced by `test_script_explicitly_stops_agent` and `test_script_verifies_agent_not_running`.

## Required GitHub secrets the operator still needs to configure

| secret | purpose |
| --- | --- |
| `VPS_HOST` | hostname or IP of the VPS |
| `VPS_USER` | SSH user (typically `root`) |
| `VPS_SSH_KEY` | full private-key contents of a dedicated deploy key |

Setup steps in `docs/governance/vps_deploy.md`. The first push to main after merge will fail the deploy step until those three secrets are configured; that failure is loud, isolated to the deploy job, and does not affect the rest of CI.

## Manual one-time VPS verification

After secrets are set and at least one deploy has run, on the VPS:

```
docker compose ps
curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:8050/agent-control
docker compose ps --status running --services | grep -q '^agent$' && echo FAIL || echo OK
```

## Validation gates green

- governance_lint OK (16 agents, 4 workflows checked).
- `pytest tests/smoke`: 14/14.
- `pytest tests/unit`: **3173 passed, 3 skipped** (was 3145; +28 static-guard cases for the new deploy surface).
- frontend vitest: 87/87 across 9 files (unchanged).
- frontend build: green.
- Frozen contract sha256 unchanged.

## Non-goals (explicitly out of scope)

- No live / paper / shadow / trading / risk behaviour change.
- No agent / discovery worker enablement.
- No api_execute_safe_controls wiring.
- No browser push.
- No external telemetry.
- No paid services / signup flows.
- No .claude/** changes (governance-bootstrap PR #87 already added the one needed agent file).
- No frozen contract changes.
- No dashboard/dashboard.py changes.
- No CI/test/governance weakening.
- No secrets committed.

## Test plan

- [ ] CI gates green
- [ ] Frozen-contract hashes unchanged on main
- [ ] Operator configures the three repository secrets
- [ ] Next push to main triggers a successful deploy: dashboard rebuilt + nginx recreated + agent stopped + `/agent-control` returns HTTP 2xx

🤖 Generated with [Claude Code](https://claude.com/claude-code)