### PR TITLE
fix(v3.15.15.29.1): VPS deploy first-run bootstrap

### DIFF
--- a/.github/workflows/deploy-vps-dashboard.yml
+++ b/.github/workflows/deploy-vps-dashboard.yml
@@ -98,13 +98,23 @@ jobs:
           # audited scripts/deploy_vps_dashboard.sh. We do NOT
           # pass any arguments — the script refuses arguments by
           # design.
+          #
+          # v3.15.15.29.1 — first-run bootstrap. The script lives
+          # in main, but on the VERY first deploy the VPS checkout
+          # may still be on an older main commit that doesn't
+          # contain the script yet. We therefore prepend an
+          # explicit ``git fetch + reset`` so the script file is
+          # guaranteed to be on disk before we invoke it. This is
+          # idempotent: the script itself ALSO does fetch + reset
+          # as its first two steps, so subsequent runs do the same
+          # work twice (cheap) rather than skipping the bootstrap.
           ssh \
             -i ~/.ssh/deploy_key \
             -o StrictHostKeyChecking=yes \
             -o BatchMode=yes \
             -o ConnectTimeout=15 \
             "${VPS_USER}@${VPS_HOST}" \
-            'cd /root/trading-agent && bash scripts/deploy_vps_dashboard.sh'
+            'cd /root/trading-agent && git fetch origin main && git reset --hard origin/main && bash scripts/deploy_vps_dashboard.sh'
 
       - name: Wipe SSH artifacts
         if: always()

--- a/docs/governance/vps_deploy.md
+++ b/docs/governance/vps_deploy.md
@@ -55,6 +55,31 @@ recreated / started via compose's `depends_on` resolution. The
 deploy script and the workflow are explicit about NOT using this
 pattern, and a static test in `tests/unit/` enforces it.
 
+## First-run bootstrap (v3.15.15.29.1)
+
+The workflow's SSH command runs:
+
+```
+cd /root/trading-agent
+git fetch origin main
+git reset --hard origin/main
+bash scripts/deploy_vps_dashboard.sh
+```
+
+The explicit `git fetch` + `git reset --hard` BEFORE the script
+invocation is intentional. On the very first deploy the VPS
+checkout may be on an older `main` commit that does not yet
+contain `scripts/deploy_vps_dashboard.sh`. Without the bootstrap
+the SSH command fails with `bash: scripts/deploy_vps_dashboard.sh:
+No such file or directory` and exit code 127 (this is exactly
+what happened the first time the workflow ran after v3.15.15.29
+merged).
+
+The bootstrap is idempotent: the script itself ALSO does
+`git fetch` + `git reset --hard origin/main` as its first two
+steps. Subsequent deploys do the same work twice (cheap)
+rather than skipping the bootstrap.
+
 ## Required GitHub secrets
 
 The workflow consumes exactly three repository secrets:

--- a/tests/unit/test_vps_deploy_invariants.py
+++ b/tests/unit/test_vps_deploy_invariants.py
@@ -244,8 +244,13 @@ def test_workflow_does_not_embed_secrets_or_hosts(workflow_text: str) -> None:
     ]
     for tok in forbidden_substrings:
         assert tok not in workflow_text, f"workflow contains forbidden token: {tok!r}"
-    # No hard-coded IP literal.
-    ip_re = re.compile(r"\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b")
+    # No hard-coded IP literal. Same boundary tightening as the
+    # script-level test: lookbehind+lookahead reject 4-octet
+    # subsequences inside longer dotted strings like a release
+    # tag (``v3.15.15.29.1`` contains ``15.15.29.1``).
+    ip_re = re.compile(
+        r"(?<![\w.])\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(?![.\d])"
+    )
     matches = ip_re.findall(workflow_text)
     assert matches == [], (
         f"workflow contains an IP literal (must come from secrets): {matches!r}"
@@ -256,6 +261,40 @@ def test_workflow_invokes_safe_deploy_script(workflow_text: str) -> None:
     """The deploy work must run via the audited script, not
     inline."""
     assert "scripts/deploy_vps_dashboard.sh" in workflow_text
+
+
+def test_workflow_bootstraps_repo_on_vps_before_running_script(
+    workflow_text: str,
+) -> None:
+    """v3.15.15.29.1 first-run fix: the workflow's SSH command
+    must perform ``git fetch origin main`` and
+    ``git reset --hard origin/main`` BEFORE invoking
+    ``bash scripts/deploy_vps_dashboard.sh``. Otherwise on a
+    stale VPS checkout the script file does not exist yet and
+    the deploy fails with exit code 127."""
+    assert "git fetch origin main" in workflow_text
+    assert "git reset --hard origin/main" in workflow_text
+
+
+def test_workflow_bootstrap_runs_before_script_invocation(
+    workflow_text: str,
+) -> None:
+    """The bootstrap commands must precede the script call in
+    the workflow text. We allow them to live on the same SSH
+    line (chained with ``&&``) or in separate prior steps; the
+    invariant is just ordering."""
+    fetch_idx = workflow_text.find("git fetch origin main")
+    reset_idx = workflow_text.find("git reset --hard origin/main")
+    script_idx = workflow_text.find("bash scripts/deploy_vps_dashboard.sh")
+    assert fetch_idx >= 0, "workflow does not run git fetch origin main"
+    assert reset_idx >= 0, "workflow does not run git reset --hard origin/main"
+    assert script_idx >= 0, "workflow does not invoke bash scripts/deploy_vps_dashboard.sh"
+    assert fetch_idx < script_idx, (
+        "git fetch origin main must precede the script invocation"
+    )
+    assert reset_idx < script_idx, (
+        "git reset --hard origin/main must precede the script invocation"
+    )
 
 
 def test_workflow_does_not_use_forbidden_compose_pattern(


### PR DESCRIPTION
## Summary

The Deploy VPS Dashboard workflow shipped in v3.15.15.29 failed on its first invocation:

```
bash: scripts/deploy_vps_dashboard.sh: No such file or directory
exit code 127
```

**Root cause:** the workflow's SSH command immediately invoked the script, but on the very first run the VPS checkout was still on an older `main` commit that did not yet contain the file.

## Fix

Prepend an explicit repo-refresh to the SSH command. The chain (in order):

1. `cd /root/trading-agent`
2. `git fetch origin main`
3. hard reset to `origin/main`
4. `bash scripts/deploy_vps_dashboard.sh`

Idempotent — the script itself also performs the same fetch + reset as its first two steps. Subsequent deploys do the same work twice (cheap) rather than skipping the bootstrap.

## Files changed (3)

- `.github/workflows/deploy-vps-dashboard.yml` — SSH command extended with the bootstrap chain.
- `tests/unit/test_vps_deploy_invariants.py` — +2 new bootstrap-order invariants; tightened the workflow IP-literal regex (release tag `v3.15.15.29.1` was matching the loose 4-octet pattern as `15.15.29.1`).
- `docs/governance/vps_deploy.md` — new "First-run bootstrap" section documenting the why.

## Tests added (2 new in `test_vps_deploy_invariants.py`)

- `test_workflow_bootstraps_repo_on_vps_before_running_script` — workflow text contains both the fetch and the hard-reset.
- `test_workflow_bootstrap_runs_before_script_invocation` — both bootstrap commands appear BEFORE the script invocation.

## Hard constraints preserved

- Native SSH, no third-party action.
- `push: branches: [main]` only; no `pull_request` / `pull_request_target` / `workflow_dispatch` / `schedule`.
- Concurrency group + `timeout-minutes` unchanged.
- `StrictHostKeyChecking=yes`; `BatchMode=yes`.
- Same three secrets only (`VPS_HOST` / `VPS_USER` / `VPS_SSH_KEY`).
- No echo of secret values; no embedded IPs.
- Deploy script `scripts/deploy_vps_dashboard.sh` unchanged.
- No agent / discovery worker enablement.
- No `api_execute_safe_controls` wiring.
- No live / paper / shadow / trading / risk behaviour change.
- No `.claude/**` changes.
- No frozen contract changes.
- No `dashboard/dashboard.py` changes.
- No CI/test/governance weakening.

## Validation gates green

- governance_lint OK (16 agents, 4 workflows checked).
- `pytest tests/smoke`: 14/14.
- `pytest tests/unit`: **3175 passed, 3 skipped** (was 3173; +2 new bootstrap-order invariants).
- Frozen contract sha256 unchanged.

## Test plan

- [ ] CI gates green
- [ ] After merge: next push to main triggers the deploy workflow successfully on the VPS, with the dashboard rebuilt + nginx recreated + agent stopped + `/agent-control` returning HTTP 2xx
- [ ] First-run failure (exit code 127 on missing script) does not recur

🤖 Generated with [Claude Code](https://claude.com/claude-code)