### PR TITLE
fix(v3.15.15.29.2): auth-aware dashboard healthcheck

### DIFF
--- a/docs/governance/vps_deploy.md
+++ b/docs/governance/vps_deploy.md
@@ -55,6 +55,33 @@ recreated / started via compose's `depends_on` resolution. The
 deploy script and the workflow are explicit about NOT using this
 pattern, and a static test in `tests/unit/` enforces it.
 
+## Auth-aware healthcheck (v3.15.15.29.2)
+
+The deploy script's final step verifies that the dashboard is
+responding on `http://127.0.0.1:8050/agent-control`. That route
+is **auth-protected** (wrapped in `<RequireAuth>` on the SPA
+side; Flask requires a session cookie), so an anonymous request
+from the deploy job receives one of:
+
+| status | meaning | accepted? |
+| :---: | --- | :---: |
+| 200 | fully served (only when host cookies are present, e.g. manual run from a logged-in shell) | ✅ |
+| 302 | auth redirect or trailing-slash redirect | ✅ |
+| 401 | authenticated endpoint rejects the anonymous request | ✅ |
+| 000 / no response | dashboard not listening / connection refused | ❌ retry |
+| 4xx (other) | misrouted | ❌ retry |
+| 5xx | dashboard crashed | ❌ retry |
+| anything else | unexpected | ❌ retry |
+
+All three accepted statuses prove the Flask app is alive AND the
+auth layer is active. The script captures the status code with
+`curl ... -w '%{http_code}'` (NOT `curl --fail`) so a 401 does
+not collapse to exit 22 and trip the script. The accepted status
+is logged so the operator sees in the workflow log that, e.g.,
+`HTTP 401` was treated as alive and not as a silent skip.
+
+The script never embeds credentials and never bypasses auth.
+
 ## First-run bootstrap (v3.15.15.29.1)
 
 The workflow's SSH command runs:

--- a/scripts/deploy_vps_dashboard.sh
+++ b/scripts/deploy_vps_dashboard.sh
@@ -106,18 +106,50 @@ log "verifying dashboard responds on ${DASHBOARD_HEALTH_URL}"
 # A short retry loop covers the seconds while nginx / Flask warm
 # up. We hit /agent-control because the standalone PWA route is
 # the operator-facing surface and is guaranteed to be wired.
+#
+# v3.15.15.29.2: the healthcheck is auth-aware. /agent-control
+# is wrapped in <RequireAuth> on the SPA side and the Flask
+# layer requires a session cookie. An anonymous request from
+# the deploy job therefore receives one of:
+#
+#   200  — fully served (only happens if the host's session
+#          cookies are present, e.g. during a manual run from
+#          a logged-in shell)
+#   302  — redirected (auth redirect, or trailing-slash redirect)
+#   401  — authenticated endpoint rejects the anonymous request
+#
+# All three prove the Flask app is alive AND the auth layer is
+# active. Anything else (no response, 5xx, 404, unexpected
+# status) is a real failure. We capture the status code with
+# %{http_code} instead of using curl --fail so a 401 does not
+# trip the script. We never embed credentials and never bypass
+# auth.
 http_ok=0
+last_status=""
 for attempt in 1 2 3 4 5; do
-    if curl -sSf -o /dev/null --max-time 5 "${DASHBOARD_HEALTH_URL}"; then
-        http_ok=1
-        break
-    fi
-    log "attempt ${attempt}/5: dashboard not responding yet, sleeping 3s"
-    sleep 3
+    # ``|| true`` so a transport-level failure (no response at
+    # all) just yields an empty status; the if-block below
+    # treats that as "not yet alive" and retries.
+    last_status="$(curl -sS -o /dev/null -w '%{http_code}' \
+        --max-time 5 "${DASHBOARD_HEALTH_URL}" || true)"
+    case "${last_status}" in
+        200|302|401)
+            http_ok=1
+            log "dashboard responded with HTTP ${last_status}; treating as alive (\
+/agent-control is auth-protected)"
+            break
+            ;;
+        *)
+            log "attempt ${attempt}/5: dashboard not alive yet (status=\
+${last_status:-no_response}), sleeping 3s"
+            sleep 3
+            ;;
+    esac
 done
 
 if [[ "${http_ok}" -ne 1 ]]; then
-    log "fatal: dashboard did not respond on ${DASHBOARD_HEALTH_URL}"
+    log "fatal: dashboard did not respond on ${DASHBOARD_HEALTH_URL} \
+(last status=${last_status:-no_response})"
     ${COMPOSE} logs --tail=120 dashboard || true
     exit 6
 fi

--- a/tests/unit/test_vps_deploy_invariants.py
+++ b/tests/unit/test_vps_deploy_invariants.py
@@ -131,6 +131,65 @@ def test_script_verifies_dashboard_running(script_text: str) -> None:
     assert "grep -qx dashboard" in script_text
 
 
+def test_script_healthcheck_captures_http_status_code(
+    script_text: str,
+) -> None:
+    """v3.15.15.29.2: the dashboard healthcheck captures the HTTP
+    status with ``%{http_code}`` instead of using ``curl --fail``.
+    The previous form treated 401 as failure, but 401 is the
+    expected response from /agent-control (auth-protected) and
+    proves the Flask app + auth layer are alive."""
+    assert "%{http_code}" in script_text
+
+
+def test_script_healthcheck_does_not_use_curl_fail(
+    script_text: str,
+) -> None:
+    """``curl --fail`` (or ``-f``) collapses 4xx/5xx into exit
+    code 22, which prevents the script from distinguishing 401
+    (auth-alive) from 5xx (server down). The auth-aware version
+    must NOT use ``--fail``/``-f`` against /agent-control."""
+    # The forbidden flags. We allow ``-sS`` (silent + show errors
+    # on transport failure), ``-o``, ``-w``, and ``--max-time``.
+    executable_lines = [
+        ln for ln in script_text.splitlines() if not ln.lstrip().startswith("#")
+    ]
+    executable = "\n".join(executable_lines)
+    forbidden = [
+        "curl -sSf",
+        "curl -fsS",
+        "curl -f",
+        "curl --fail",
+    ]
+    for f in forbidden:
+        assert f not in executable, (
+            f"deploy script (executable lines) uses forbidden curl flag: {f!r}"
+        )
+
+
+def test_script_healthcheck_accepts_200_302_401(script_text: str) -> None:
+    """The auth-aware healthcheck must accept 200, 302, and 401
+    as alive. Each must appear as an accepted status in the
+    case statement that gates the retry loop."""
+    # A robust check: each accepted status must appear, and they
+    # must appear together as a case-pattern alternation
+    # (``200|302|401)`` — no scattered references that may not be
+    # in the case-arm.
+    assert re.search(r"200\s*\|\s*302\s*\|\s*401\b", script_text), (
+        "script does not declare 200|302|401 as the accepted "
+        "alive case for /agent-control"
+    )
+
+
+def test_script_healthcheck_logs_accepted_status(script_text: str) -> None:
+    """When the healthcheck accepts a status, the script must log
+    which status it accepted so the operator can see (in the
+    workflow log) that 401 was the expected response, not a
+    silent skip."""
+    # The script logs ``dashboard responded with HTTP <status>``.
+    assert "dashboard responded with HTTP" in script_text
+
+
 def test_script_verifies_agent_not_running(script_text: str) -> None:
     """The script must fail loudly if agent is still running."""
     assert "grep -qx agent" in script_text


### PR DESCRIPTION
## Summary

The Deploy VPS Dashboard workflow now bootstraps the VPS checkout (v3.15.15.29.1) and successfully:

- fetched/reset `origin/main`
- built dashboard
- recreated dashboard/nginx with `--no-deps`
- explicitly stopped agent
- dashboard container started, nginx running, agent stopped

**But the deploy job still failed at the final healthcheck** because the previous probe used the fail-on-error variant that treats HTTP 401 as failure. `/agent-control` is auth-protected, so an anonymous probe always returns 401 — which actually proves the Flask app + auth layer are alive, but the previous flag collapsed the response to exit 22 and the script bailed.

Observed log line:

```
GET /agent-control HTTP/1.1 401
fatal: dashboard did not respond on http://127.0.0.1:8050/agent-control
```

## Fix

| | before | after |
| --- | --- | --- |
| Healthcheck form | fail-on-HTTP-error (treats 4xx/5xx as exit 22) | status-code capture via the `%{http_code}` writer |
| Accepted statuses | only 2xx | **200 / 302 / 401** (all three prove app + auth alive) |
| Rejected statuses | everything ≠ 2xx | empty / no_response, other 4xx, 5xx, unexpected |
| Logging | silent on success | logs the accepted status verbatim |
| Credentials | none | still none — no auth bypass, no embedded creds |
| Retry loop | 5×3s | unchanged |

## Auth-aware status table

| status | meaning | accepted? |
| :---: | --- | :---: |
| 200 | served directly (only with host cookies) | ✅ |
| 302 | auth redirect / trailing-slash redirect | ✅ |
| 401 | anonymous request rejected by auth | ✅ |
| 000 | no response / connection refused | ❌ retry |
| 4xx (other) | misrouted | ❌ retry |
| 5xx | dashboard crashed | ❌ retry |

## Files changed (3)

- `scripts/deploy_vps_dashboard.sh` — replaces the fail-on-error probe with status-code capture; case-arm gates the retry loop on `200|302|401`; logs the accepted status.
- `tests/unit/test_vps_deploy_invariants.py` — +4 new auth-aware healthcheck invariants.
- `docs/governance/vps_deploy.md` — new "Auth-aware healthcheck" section with the status table and rationale.

## Tests added (4 new in `test_vps_deploy_invariants.py`)

- `test_script_healthcheck_captures_http_status_code` — the `%{http_code}` writer is present.
- `test_script_healthcheck_does_not_use_curl_fail` — refuses the fail-on-error flag in executable lines (the safety comment may still describe the legacy form).
- `test_script_healthcheck_accepts_200_302_401` — `200|302|401` appears as a case-pattern alternation.
- `test_script_healthcheck_logs_accepted_status` — script logs the accepted status text.

## All previously-asserted deploy invariants preserved

- `set -euo pipefail`.
- `docker compose build dashboard` (NOT `up -d --build`).
- `--no-deps` for the up command.
- Forbidden up-build pattern still rejected.
- `docker compose stop agent || true` + verification that agent is not running.
- Dashboard verified in the running set before the HTTP probe.
- Workflow still triggers on `push:main` only; same three secrets; concurrency + timeout intact.
- No `.claude/**` changes; no frozen-contract changes; no `dashboard/dashboard.py` changes; no `api_execute_safe_controls` wiring; no agent enablement.

## Validation gates green

- governance_lint OK (16 agents, 4 workflows checked).
- `pytest tests/smoke`: 14/14.
- `pytest tests/unit`: **3179 passed, 3 skipped** (was 3175; +4 new auth-aware healthcheck invariants).
- Frozen contract sha256 unchanged.

## Test plan

- [ ] CI gates green
- [ ] After merge: next push to main triggers the deploy workflow and the healthcheck logs the accepted status (e.g. HTTP 401 treated as alive), then the deploy step exits 0
- [ ] The 5xx/no-response failure mode still trips a real failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)