### PR TITLE
fix(v3.15.15.29.3): force-recreate nginx after dashboard rebuild

### DIFF
--- a/docs/governance/vps_deploy.md
+++ b/docs/governance/vps_deploy.md
@@ -55,6 +55,40 @@ recreated / started via compose's `depends_on` resolution. The
 deploy script and the workflow are explicit about NOT using this
 pattern, and a static test in `tests/unit/` enforces it.
 
+## nginx upstream refresh (v3.15.15.29.3)
+
+After v3.15.15.29.2, the deploy got past the auth-aware
+healthcheck but still failed because every probe of
+`/agent-control` came back **502**. Sequence of events on the VPS:
+
+1. `dashboard` rebuilt + recreated → new container, new
+   internal IP on the docker bridge network (the exact value
+   varies; the operator can read it off `docker compose ps` if
+   curious).
+2. `nginx` was already in the running set, so `up -d --no-deps
+   dashboard nginx` left it alone (compose only touches
+   services that aren't already up, unless told otherwise).
+3. nginx kept its old upstream resolution from the previous
+   dashboard container, which no longer existed → 502 on every
+   request.
+
+**Fix in v3.15.15.29.3**: the deploy now passes
+`--force-recreate` so both `dashboard` AND `nginx` are
+recreated even when compose thinks they're already up:
+
+```
+docker compose up -d --no-deps --force-recreate dashboard nginx
+```
+
+`--no-deps` is unchanged (still prevents compose from touching
+the agent via `depends_on`). Adding `--force-recreate` makes
+nginx restart, re-resolve the upstream, and serve the fresh
+dashboard.
+
+`docker compose stop agent || true` and the agent-not-running
+verification both still run after this step. The forbidden
+`up -d --build` pattern remains banned.
+
 ## Auth-aware healthcheck (v3.15.15.29.2)
 
 The deploy script's final step verifies that the dashboard is

--- a/scripts/deploy_vps_dashboard.sh
+++ b/scripts/deploy_vps_dashboard.sh
@@ -70,12 +70,26 @@ git reset --hard origin/main
 log "step 3/6: build dashboard image (only)"
 ${COMPOSE} build dashboard
 
-log "step 4/6: bring dashboard + nginx up with --no-deps"
-# --no-deps is the critical flag. It tells compose to NOT touch
-# any service the named services depend on. Combined with the
-# explicit list (dashboard nginx), this means agent stays as it
-# was — typically stopped.
-${COMPOSE} up -d --no-deps dashboard nginx
+log "step 4/6: recreate dashboard + nginx with --no-deps + --force-recreate"
+# Two critical flags here:
+#
+# * ``--no-deps`` — tells compose to NOT touch any service the
+#   named services depend on. Combined with the explicit list
+#   (dashboard nginx), this means agent stays as it was —
+#   typically stopped.
+#
+# * ``--force-recreate`` — recreates BOTH containers even when
+#   compose thinks they're already up. This is the v3.15.15.29.3
+#   fix: without it, nginx is "Running" so compose leaves it
+#   alone, but dashboard was recreated with a new container IP.
+#   nginx then keeps its old upstream resolution and returns 502
+#   for every /agent-control request. Forcing recreate makes
+#   nginx restart, re-resolve the dashboard upstream, and serve
+#   the fresh container.
+#
+# We do NOT use ``up -d --build`` here — see the safety comment
+# at the top of this script for why that pattern is forbidden.
+${COMPOSE} up -d --no-deps --force-recreate dashboard nginx
 
 log "step 5/6: explicit defense-in-depth stop of agent"
 # This is intentional. We do NOT want the agent to be running on

--- a/tests/unit/test_vps_deploy_invariants.py
+++ b/tests/unit/test_vps_deploy_invariants.py
@@ -71,10 +71,63 @@ def test_script_uses_compose_build_dashboard_only(script_text: str) -> None:
 def test_script_uses_compose_up_no_deps_dashboard_nginx(script_text: str) -> None:
     """``--no-deps`` is the critical flag that prevents compose
     from touching the agent service via ``depends_on``
-    resolution."""
-    assert (
-        "docker compose up -d --no-deps dashboard nginx" in script_text
-        or "${COMPOSE} up -d --no-deps dashboard nginx" in script_text
+    resolution.
+
+    v3.15.15.29.3: the canonical form is now
+    ``up -d --no-deps --force-recreate dashboard nginx`` so
+    nginx is rebuilt and re-resolves the dashboard upstream.
+    The legacy form (no force-recreate) is still accepted by
+    this test so the invariant remains "uses --no-deps for the
+    up command, with both dashboard and nginx in the same
+    invocation".
+    """
+    accepted = [
+        "docker compose up -d --no-deps --force-recreate dashboard nginx",
+        "${COMPOSE} up -d --no-deps --force-recreate dashboard nginx",
+        "docker compose up -d --no-deps dashboard nginx",
+        "${COMPOSE} up -d --no-deps dashboard nginx",
+    ]
+    assert any(p in script_text for p in accepted), (
+        "script does not use any accepted '--no-deps dashboard nginx' "
+        "compose-up form"
+    )
+
+
+def test_script_force_recreates_nginx_after_dashboard_rebuild(
+    script_text: str,
+) -> None:
+    """v3.15.15.29.3 fix: when dashboard is rebuilt, the new
+    container gets a new internal IP. nginx (already Running)
+    is left alone by ``up -d --no-deps`` and keeps its stale
+    upstream → every /agent-control request 502s.
+
+    The deploy must explicitly refresh nginx. Three accepted
+    patterns:
+
+      A) ``up -d --no-deps --force-recreate dashboard nginx``
+         (single command, recreates both — preferred)
+      B) ``up -d --no-deps --force-recreate nginx`` after the
+         dashboard up
+      C) ``restart nginx`` after the dashboard up
+
+    Anything else is a regression that lets the 502 mode return.
+    """
+    pattern_a = (
+        "--no-deps --force-recreate dashboard nginx" in script_text
+        or "--force-recreate --no-deps dashboard nginx" in script_text
+    )
+    pattern_b = (
+        "--no-deps --force-recreate nginx" in script_text
+        or "--force-recreate --no-deps nginx" in script_text
+    )
+    pattern_c = (
+        "compose restart nginx" in script_text
+        or "${COMPOSE} restart nginx" in script_text
+    )
+    assert pattern_a or pattern_b or pattern_c, (
+        "deploy script does not explicitly refresh nginx after the "
+        "dashboard rebuild; the v3.15.15.29.3 502 regression mode "
+        "would re-emerge"
     )
 
 


### PR DESCRIPTION
## Summary

The Deploy VPS Dashboard workflow now bootstraps the VPS checkout (v3.15.15.29.1), runs an auth-aware healthcheck (v3.15.15.29.2), and successfully:

- fetched/reset `origin/main`
- built dashboard
- recreated dashboard
- explicitly stopped agent
- dashboard container started, agent stopped
- Flask started inside `jvr_dashboard`

**But the deploy still failed because every probe of `/agent-control` came back 502.** Sequence on the VPS:

1. `dashboard` rebuilt + recreated → new container, new internal IP on the docker bridge network.
2. `nginx` was already in the running set, so `up -d --no-deps dashboard nginx` left it alone (compose only touches services that aren't already up unless told otherwise).
3. nginx kept its old upstream resolution from the previous dashboard container, which no longer existed → 502 on every request.

## Fix

Pass `--force-recreate` so BOTH containers are recreated even when compose thinks they're already up:

```
docker compose up -d --no-deps --force-recreate dashboard nginx
```

`--no-deps` is unchanged (still prevents compose from touching agent via `depends_on`). `--force-recreate` makes nginx restart, re-resolve the upstream, and serve the fresh dashboard.

This is **Option A** from the brief (single command, both containers force-recreated) — the cleanest of the three accepted patterns.

## Files changed (3)

- `scripts/deploy_vps_dashboard.sh` — adds `--force-recreate` to the up command; comment block explains the v3.15.15.29.3 fix and why nginx had to be force-recreated.
- `tests/unit/test_vps_deploy_invariants.py` — +1 new `test_script_force_recreates_nginx_after_dashboard_rebuild` invariant; existing `test_script_uses_compose_up_no_deps_dashboard_nginx` updated to accept both the legacy and new forms.
- `docs/governance/vps_deploy.md` — new "nginx upstream refresh (v3.15.15.29.3)" section explaining the 502 root cause and the fix.

## All previously-asserted deploy invariants preserved

- `set -euo pipefail`.
- `docker compose build dashboard` (NOT `up -d --build`).
- `--no-deps` still present.
- The forbidden `up -d --build dashboard nginx` pattern still rejected by `test_script_does_not_use_forbidden_up_build_pattern`.
- `docker compose stop agent || true` + verification that agent is not running.
- Auth-aware healthcheck (200/302/401 accepted; 5xx/no-response rejected) — unchanged.
- First-run bootstrap: workflow fetches `origin main` and resets hard before invoking the script — unchanged.
- Workflow still triggers on `push:main` only; same three secrets; concurrency + timeout intact.
- No `.claude/**` changes; no `docker-compose.yml` edits; no frozen-contract changes; no `dashboard/dashboard.py` changes; no `api_execute_safe_controls` wiring; no agent enablement.
- Runbook IP-literal hygiene preserved (the new section describes the bridge-network IP without a literal value).

## Validation gates green

- governance_lint OK (16 agents, 4 workflows checked).
- `pytest tests/smoke`: 14/14.
- `pytest tests/unit`: **3180 passed, 3 skipped** (was 3179; +1 new force-recreate invariant).
- `pytest tests/unit/test_vps_deploy_invariants`: **35/35** (was 34).
- Frozen contract sha256 unchanged.

## Test plan

- [ ] CI gates green
- [ ] After merge: next push to main triggers the deploy workflow; both `dashboard` and `nginx` are recreated; healthcheck logs the accepted status (200/302/401) instead of 502
- [ ] The 502 failure mode does not recur

🤖 Generated with [Claude Code](https://claude.com/claude-code)