### PR TITLE
feat(v3.15.16.1): VPS-side PR lifecycle artifact auto-refresh on deploy

### DIFF
--- a/docs/governance/recurring_maintenance.md
+++ b/docs/governance/recurring_maintenance.md
@@ -184,6 +184,26 @@ endpoint — no new dashboard.py wiring.
 | v3.15.15.25 | metrics dashboards on top of `history.jsonl` |
 | later | systemd service / cron wrapper around the loop driver |
 
+## VPS-side automation (v3.15.16.1)
+
+`reporting.github_pr_lifecycle --mode dry-run --no-smoke` is now
+**also** invoked as a best-effort post-deploy step at the end of
+`scripts/deploy_vps_dashboard.sh`. This refreshes
+`logs/github_pr_lifecycle/latest.json` on the VPS after every
+merge to `main`, so `/api/agent-control/pr-lifecycle` and the
+Agent Control PWA's PRs tab always have data without any manual
+SSH step.
+
+The post-deploy refresh is **non-fatal** — a failure logs a
+single line and the deploy still exits 0. The recurring
+maintenance scheduler in this module continues to be the
+canonical, scheduled refresh path; the deploy hook is an
+additive freshness guarantee that pins "fresh on every merge"
+specifically.
+
+See `docs/governance/vps_deploy.md` §"Post-deploy PR lifecycle
+artifact refresh (v3.15.16.1)" for the detailed contract.
+
 ## Files added by v3.15.15.23
 
 ```

--- a/docs/governance/vps_deploy.md
+++ b/docs/governance/vps_deploy.md
@@ -89,6 +89,83 @@ dashboard.
 verification both still run after this step. The forbidden
 `up -d --build` pattern remains banned.
 
+## Post-deploy PR lifecycle artifact refresh (v3.15.16.1)
+
+After `deploy ok`, the script runs a **best-effort, non-fatal**
+post-deploy step that refreshes
+`logs/github_pr_lifecycle/latest.json` on the VPS:
+
+```
+python3 -m reporting.github_pr_lifecycle --mode dry-run --no-smoke
+```
+
+This is the artifact `/api/agent-control/pr-lifecycle` reads, and
+the Agent Control PWA's PRs tab depends on. Before v3.15.16.1 the
+artifact was only generated wherever the operator ran the reporter
+by hand; `logs/` is gitignored, so a fresh checkout on the VPS
+never had it.
+
+### Hard guarantees re-asserted
+
+| guarantee | how it is enforced |
+| --- | --- |
+| Cannot fail the deploy | the step is wrapped in `if ...; then ... else ... fi`. `set -e` does not trip on commands inside `if` conditions; a non-zero exit logs a single non-fatal line and the script proceeds to `exit 0`. |
+| Read-only, no GitHub mutation | `--mode dry-run` is the read-only path of `reporting.github_pr_lifecycle`. The execute-safe path is never invoked from the deploy script. |
+| No new free-form surface | the argv is literal: `python3 -m reporting.github_pr_lifecycle --mode dry-run --no-smoke`. The script accepts no positional argument forwarding. |
+| No new secret | the reporter shells out to `gh`, which is already authenticated on the VPS host (used by other operator work). No additional credential is read or written by the deploy step. |
+| No agent restart | the step does not touch any compose service. `docker compose stop agent` already ran in step 5/6. |
+| Atomic write | the reporter writes via tmp + `os.replace`; readers (the dashboard) never see a half-written file. |
+
+### Why host-side, not container-side
+
+`gh` is authenticated on the VPS host but is not necessarily in
+the dashboard container image. Running the reporter on the host
+keeps the dashboard image surface unchanged and uses the
+authenticated `gh` that already exists. The artifact lands at
+`/root/trading-agent/logs/github_pr_lifecycle/latest.json` on the
+host; the dashboard container's `./logs:/app/logs` bind-mount
+makes it immediately readable as `/app/logs/github_pr_lifecycle/latest.json`
+inside the container — the path the Flask route reads.
+
+### Why after `deploy ok`, not before
+
+The deploy is "successful" the moment the dashboard is verified
+alive and the agent is verified stopped. The PR lifecycle artifact
+is observability data, not deploy infrastructure. Placing the
+refresh after the success log line makes the contract explicit:
+the deploy succeeded; whatever happens to the artifact refresh
+afterwards cannot retroactively turn the deploy into a failure.
+
+### Operator log lines
+
+Successful refresh:
+
+```
+[deploy_vps_dashboard] post-deploy: refresh github_pr_lifecycle artifact (best-effort)
+[deploy_vps_dashboard] post-deploy: pr_lifecycle refresh ok
+```
+
+Failed refresh (non-fatal — the deploy still exits 0):
+
+```
+[deploy_vps_dashboard] post-deploy: refresh github_pr_lifecycle artifact (best-effort)
+[deploy_vps_dashboard] post-deploy: pr_lifecycle refresh failed or unavailable (non-fatal)
+```
+
+If the failure line appears repeatedly, the operator can run the
+reporter manually from the VPS shell:
+
+```
+ssh root@<VPS_HOST>
+cd /root/trading-agent
+python3 -m reporting.github_pr_lifecycle --mode dry-run --no-smoke
+```
+
+`--mode dry-run` is read-only; it never posts comments, never
+merges, never force-pushes. See
+`docs/governance/recurring_maintenance.md` for the full surface
+of read-only refresh jobs.
+
 ## Auth-aware healthcheck (v3.15.15.29.2)
 
 The deploy script's final step verifies that the dashboard is

--- a/scripts/deploy_vps_dashboard.sh
+++ b/scripts/deploy_vps_dashboard.sh
@@ -169,4 +169,60 @@ if [[ "${http_ok}" -ne 1 ]]; then
 fi
 
 log "deploy ok: dashboard + nginx running, agent stopped"
+
+# v3.15.16.1 — post-deploy github_pr_lifecycle artifact refresh.
+#
+# Why this lives AFTER "deploy ok":
+#   * The deploy itself is "successful" the moment the dashboard is
+#     verified alive and the agent is verified stopped. The PR
+#     lifecycle artifact is observability data, not deploy
+#     infrastructure. It MUST NOT be allowed to fail the deploy.
+#   * Placing the refresh here makes the failure path explicit:
+#     "deploy ok" prints unconditionally, then the refresh runs as a
+#     bounded, non-fatal best-effort step. Either log line surfaces
+#     in the deploy workflow output for the operator.
+#
+# What it does:
+#   * Runs ``python3 -m reporting.github_pr_lifecycle --mode dry-run
+#     --no-smoke`` on the VPS host. ``--mode dry-run`` is read-only
+#     (never comments, never merges); ``--no-smoke`` skips the local
+#     smoke gate so a transient test slowness can't stall the deploy.
+#   * The reporter writes ``logs/github_pr_lifecycle/latest.json``
+#     (atomic tmp + os.replace) and a timestamped copy under
+#     ``logs/github_pr_lifecycle/``. The dashboard container's
+#     ``./logs:/app/logs`` bind-mount makes the new artifact
+#     immediately visible to ``/api/agent-control/pr-lifecycle``.
+#
+# Why host-side and not container-side:
+#   * The reporter shells out to ``gh`` for repo / PR data. ``gh`` is
+#     authenticated on the VPS host (already used for other operator
+#     work) but is not necessarily installed in the dashboard image.
+#     Running on the host is the simpler, more reliable path and
+#     keeps the dashboard image surface unchanged.
+#
+# Failure handling:
+#   * The whole step is wrapped in ``if ...; then ... else ... fi``.
+#     ``set -e`` does not trip on commands inside ``if`` conditions,
+#     so a non-zero exit here cannot fail the deploy. The else
+#     branch logs a single human-readable line so the operator can
+#     spot a recurring failure in the workflow log.
+#   * ``command -v python3`` short-circuits on hosts that don't have
+#     a system ``python3`` available; the step degrades to a logged
+#     skip instead of an error.
+#
+# Hard guarantees re-asserted:
+#   * No mutation of GitHub state (--mode dry-run).
+#   * No new free-form command surface (literal argv only).
+#   * No new secret read or printed.
+#   * No agent service started or restarted.
+#   * No api_execute_safe_controls wiring.
+log "post-deploy: refresh github_pr_lifecycle artifact (best-effort)"
+if command -v python3 >/dev/null 2>&1 \
+        && python3 -m reporting.github_pr_lifecycle \
+            --mode dry-run --no-smoke >/dev/null 2>&1; then
+    log "post-deploy: pr_lifecycle refresh ok"
+else
+    log "post-deploy: pr_lifecycle refresh failed or unavailable (non-fatal)"
+fi
+
 exit 0


### PR DESCRIPTION
## Roadmap protocol context

Second roadmap item executed through `reporting.roadmap_execution_protocol`. Plan written to `logs/roadmap_execution_protocol/latest.json`.

| Field | Value |
| --- | --- |
| `item_id` | `r_v3_15_16_1` |
| `item_type` | `observability_addition` |
| `risk_class` | `LOW` |
| `decision` | `allowed_read_only` |
| `requires_human` | `false` |
| `implementation_allowed` | `true` |
| `safe_to_execute` | `false` |
| `status` | `proposed` |
| `proposed_release_id` | `v3.15.16.1` |

## Problem

`/api/agent-control/pr-lifecycle` and the Agent Control PWA's PRs tab depend on `logs/github_pr_lifecycle/latest.json` on the VPS. Before this PR, that artifact was only generated wherever the operator ran the reporter by hand; `logs/` is gitignored, so a fresh checkout on the VPS never had it. The PWA showed `not_available`.

## Fix

Append a **best-effort, non-fatal** post-deploy step to `scripts/deploy_vps_dashboard.sh`:

```bash
log "post-deploy: refresh github_pr_lifecycle artifact (best-effort)"
if command -v python3 >/dev/null 2>&1 \
        && python3 -m reporting.github_pr_lifecycle \
            --mode dry-run --no-smoke >/dev/null 2>&1; then
    log "post-deploy: pr_lifecycle refresh ok"
else
    log "post-deploy: pr_lifecycle refresh failed or unavailable (non-fatal)"
fi
```

Result: `logs/github_pr_lifecycle/latest.json` is refreshed on the VPS on **every merge to main**, immediately readable through the existing `./logs:/app/logs` bind-mount.

## Hard guarantees re-asserted

| Guarantee | Enforcement |
| --- | --- |
| Cannot fail the deploy | wrapped in `if`/`then`/`else` — `set -e` does not trip on commands inside `if` conditions |
| Read-only, no GitHub mutation | `--mode dry-run`; the execute-safe path is never invoked |
| No new free-form surface | literal argv only |
| No new secret | `gh` already authenticated on VPS for other operator work |
| No agent restart | does not touch any compose service; `stop agent` already ran in step 5/6 |
| Atomic write | reporter uses tmp + `os.replace` |

## Why after `deploy ok`, not before

The deploy is "successful" the moment the dashboard is verified alive and the agent verified stopped. The PR lifecycle artifact is observability data, not deploy infrastructure — placing the refresh after the success log line makes the contract explicit.

## Why host-side, not container-side

`gh` is authenticated on the VPS host but is not necessarily in the dashboard container image. Running on the host keeps the dashboard image surface unchanged.

## Diff scope

```
docs/governance/recurring_maintenance.md | 20 +++++
docs/governance/vps_deploy.md            | 77 +++++++++++++++++
scripts/deploy_vps_dashboard.sh          | 56 +++++++++++++
3 files changed, 153 insertions(+)
```

All three files are within existing agent allowlists (`scripts/deploy_vps_dashboard.sh` ↦ `deployment-implementation-agent`; `docs/governance/*` ↦ `implementation-agent`).

## Out of scope (deferred)

- `ops/systemd/trading-agent-pr-lifecycle.{service,timer}` is **not** in this PR. `ops/systemd/*` is in no agent's `allowed_roots` union; adding it requires an operator-authored governance-bootstrap PR. The deploy-hook approach alone solves the immediate problem (fresh on every merge); periodic refresh between merges is a later additive release.

## Validation gates

- [x] `python scripts/governance_lint.py` — OK (16 agents, 4 workflows checked)
- [x] `sha256sum research/research_latest.json research/strategy_matrix.csv` — frozen hashes unchanged (`4a567bd6...`, `ff15b8c4...`)
- [x] `pytest tests/smoke -q` — 14 passed
- [x] `pytest tests/unit/test_vps_deploy_invariants.py -q` — **35 passed** (every existing invariant still green, including no-curl-fail / no-up-build / no-IP-literal / agent-not-running checks)
- [x] `pytest tests/unit -q` — 3180 passed, 3 skipped
- [x] `npm --prefix frontend test -- --run` — 87/87 passed
- [x] `npm --prefix frontend run build` — OK
- [x] `bash -n scripts/deploy_vps_dashboard.sh` — syntax OK

## Test plan

- [ ] CI green on all required checks
- [ ] After squash merge, the auto-deploy run shows the new step writing `logs/github_pr_lifecycle/latest.json` on the VPS and prints `post-deploy: pr_lifecycle refresh ok`
- [ ] `/api/agent-control/pr-lifecycle` no longer returns `not_available`
- [ ] PWA PRs tab populates after refresh

## Rollback plan

`git revert <merge_sha>` on a fresh branch; one-line revert PR; merge after CI green. The systemd timer and `ops/systemd/*` files are out of scope so no rollback work there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)