### PR TITLE
feat(v3.15.16.2): autonomous roadmap backlog ingestion + prioritization

### DIFF
--- a/docs/governance/recurring_maintenance.md
+++ b/docs/governance/recurring_maintenance.md
@@ -76,6 +76,7 @@ python -m reporting.recurring_maintenance --run-due-once \
 | `refresh_approval_inbox` | LOW | no | 15 min | ✓ | refreshes `approval_inbox` dry-run artifact |
 | `refresh_github_pr_lifecycle_dry_run` | LOW | yes | 30 min | ✓ | refreshes `github_pr_lifecycle` dry-run artifact |
 | `dependabot_low_medium_execute_safe` | MEDIUM | yes | 60 min | **✗** | delegates to `github_pr_lifecycle` execute-safe path |
+| `refresh_roadmap_priority` | LOW | no | 30 min | ✓ | refreshes `roadmap_priority` read-only digest (v3.15.16.2) |
 
 ## Dependabot execute-safe — two-layer opt-in
 
@@ -183,6 +184,27 @@ endpoint — no new dashboard.py wiring.
 | v3.15.15.24 | per-job audit-ledger linkage (populated `audit_refs`) |
 | v3.15.15.25 | metrics dashboards on top of `history.jsonl` |
 | later | systemd service / cron wrapper around the loop driver |
+
+## Roadmap priority projection (v3.15.16.2)
+
+A new closed job entry — `refresh_roadmap_priority` — runs the
+read-only prioritizer (`reporting.roadmap_priority.collect_snapshot`
++ `write_outputs`) every 30 minutes by default. The prioritizer
+is a pure projection over `logs/proposal_queue/latest.json`; it
+calls `reporting.roadmap_execution_protocol.plan_item` on each
+proposal to obtain the per-item decision and writes the
+deterministic `chosen_next_up` candidate into
+`logs/roadmap_priority/latest.json`.
+
+Hard guarantees re-asserted at this layer:
+
+* LOW risk; `needs_gh = False`; default-enabled.
+* `safe_to_execute` is hard-coded `false` in the digest schema
+  and pinned by a unit test.
+* The job never starts a branch, never opens a PR, never merges,
+  never invokes `gh`. It is observability only.
+* See `docs/governance/roadmap_priority.md` for the eligibility
+  filters, ranking policy, and operator workflow.
 
 ## VPS-side automation (v3.15.16.1)
 

--- a/docs/governance/roadmap_priority.md
+++ b/docs/governance/roadmap_priority.md
@@ -1,0 +1,229 @@
+# Roadmap Priority — operator runbook
+
+> Module: `reporting.roadmap_priority`
+> Release: v3.15.16.2
+> Sibling docs: `recurring_maintenance.md`,
+> `roadmap_item_execution_protocol.md`, `autonomy_metrics.md`,
+> `mobile_agent_control_pwa.md`.
+
+## TL;DR
+
+A pure, deterministic, read-only projection over the proposal
+queue. For every proposal it calls
+`reporting.roadmap_execution_protocol.plan_item` and applies a
+fixed eligibility filter + a fixed ranking policy. It picks **at
+most one** `chosen_next_up` item and writes the result to
+`logs/roadmap_priority/latest.json`. The operator (or a strictly
+later release) consumes the digest; this module never starts work.
+
+```
+proposal_queue/latest.json
+        │  (read-only)
+        ▼
+roadmap_priority.collect_snapshot()
+        │
+        ├──► roadmap_execution_protocol.plan_item(p)   per proposal
+        │           │
+        │           ▼
+        │    decision / implementation_allowed / requires_human
+        │
+        ▼
+filter → rank → pick → atomic write
+        │
+        ▼
+logs/roadmap_priority/latest.json
+```
+
+## Hard guarantees
+
+| guarantee | enforcement |
+| --- | --- |
+| Stdlib-only | no subprocess, no `gh`, no `git`, no network |
+| `safe_to_execute` is always `false` | hard-coded literal in source; pinned by a unit test |
+| Missing source ≠ silently OK | `final_recommendation = "not_available"` |
+| Malformed source ≠ silently OK | same as above, with `error` reason recorded |
+| Determinism | two runs on the same input produce a byte-identical `chosen_next_up` (modulo `generated_at_utc`) |
+| Risk classification | delegated 100% to `roadmap_execution_protocol.plan_item`; the prioritizer never re-classifies |
+| Atomic writes | `tmp` + `os.replace`, mirrors the rest of `reporting/` |
+| No mutation of upstream | the proposal_queue artifact is read with byte-identical content before/after |
+| Output scope | writes only under `logs/roadmap_priority/` |
+
+## Eligibility filters
+
+A proposal must pass **all** of these to be considered:
+
+| filter | reason emitted on rejection |
+| --- | --- |
+| `proposal_id` is a non-empty string | `invalid_proposal_shape` |
+| `status == "proposed"` | `status_not_proposed` |
+| `risk_class != "HIGH"` | `risk_high_excluded` |
+| protocol call must not raise | `protocol_classification_error` |
+| protocol `decision == "allowed_read_only"` | `protocol_decision_not_allowed_read_only` |
+| protocol `implementation_allowed == True` | `protocol_implementation_not_allowed` |
+| protocol `requires_human == False` | `protocol_requires_human` |
+| protocol `safe_to_execute == False` | `protocol_safe_to_execute_true` (sanity — protocol never returns True; if it ever does, that is itself a contract breach we surface) |
+
+The protocol module owns:
+
+* item-type classification (docs_only / observability_addition /
+  test_only / governance_change / live_paper_shadow_risk /
+  external_account_or_secret / telemetry_or_data_egress / ...);
+* the closed `ITEM_TYPES_OPEN_TO_IMPLEMENTATION` set that gates
+  `implementation_allowed`;
+* the `requires_human` decision.
+
+The prioritizer never second-guesses any of these. If you want to
+change them, change the protocol — the priority module will follow.
+
+## Ranking policy
+
+Within the eligible set, sort ascending by the tuple
+`(risk_rank, type_rank, proposal_id)`:
+
+1. **`risk_rank`**: LOW (0) → MEDIUM (1) → HIGH (2) → UNKNOWN (3).
+   HIGH is filtered out before this step; its position here is
+   defensive only.
+2. **`type_rank`** (most-leveraged unblockers first):
+   - `observability_addition` (0)
+   - `observability_gap` (1)
+   - `reporting_read_only` (2)
+   - `docs_only` (3)
+   - `testing_gap` (4)
+   - `test_only` (5)
+   - `ux_gap` (6)
+   - `frontend_read_only` (7)
+   - `ci_hygiene` (8)
+   - `dependency_cleanup` (9)
+   - `release_candidate` (10)
+   - anything else: 99
+3. **`proposal_id`** ascending — stable, deterministic across
+   runs.
+
+The first element of the sorted list becomes `chosen_next_up`.
+Every other eligible item is in `candidates[]` with its rank.
+Every rejected item is in `filtered_out[]` with its
+`filter_reason`.
+
+## Final recommendation enum
+
+| value | meaning |
+| --- | --- |
+| `ready_for_implementation` | a `chosen_next_up` was picked; the operator can review the protocol plan summary and decide whether to start work |
+| `nothing_ready` | the source artifact parsed, but no eligible candidate survived the filters |
+| `not_available` | the proposal_queue artifact was missing / malformed / not an object — the prioritizer cannot produce a verdict |
+
+## Integration with the recurring scheduler
+
+`reporting.recurring_maintenance` (v3.15.15.23) gains one new
+closed job entry in v3.15.16.2:
+
+| `job_type` | risk | needs `gh`? | default interval | default enabled | what it does |
+| --- | --- | --- | --- | --- | --- |
+| `refresh_roadmap_priority` | LOW | no | 30 min | ✓ | runs `roadmap_priority.collect_snapshot()` + `write_outputs()` |
+
+The job inherits all the supervisor-level safety rails of the
+existing scheduler:
+
+* per-job timeout (90 s default — well above the prioritizer's
+  observed runtime);
+* atomic state persistence;
+* failed/blocked job projection into `approval_inbox`;
+* `consecutive_failures >= 3` surfaces a `runtime_halt`.
+
+## CLI
+
+```
+# Default: dry-run, write the digest, print to stdout.
+python -m reporting.roadmap_priority
+
+# Inspection only (no file write).
+python -m reporting.roadmap_priority --no-write
+
+# Read the latest digest without re-running.
+python -m reporting.roadmap_priority --status
+
+# Pin the timestamp (deterministic tests).
+python -m reporting.roadmap_priority --frozen-utc 2026-05-04T12:00:00Z
+```
+
+There is **no execute-safe mode**. The CLI rejects any `--mode`
+other than `dry-run`. The execute path is intentionally absent —
+this release projects, the operator decides.
+
+## Operator workflow
+
+1. Refresh the upstream artifact (one of):
+   * `python -m reporting.proposal_queue --mode dry-run` — direct
+   * `python -m reporting.workloop_runtime --once` — bundles the
+     queue refresh in the workloop tick
+   * the `recurring_maintenance` scheduler — the canonical
+     scheduled path; runs every 60 minutes for the queue and
+     every 30 minutes for the priority projection.
+2. Inspect the priority digest:
+   ```
+   python -m reporting.roadmap_priority --status
+   ```
+3. If `final_recommendation == "ready_for_implementation"`, the
+   `chosen_next_up.protocol_plan_summary` block tells you the
+   `proposed_branch`, `required_tests`, and `expected_artifacts`
+   the protocol planner produced. The operator may then start
+   implementation under that plan.
+4. If `final_recommendation == "nothing_ready"`, every eligible
+   proposal was rejected by a filter. Inspect `filtered_out[]`
+   and `counts.filtered_out_by_reason` to find out why.
+5. If `final_recommendation == "not_available"`, refresh the
+   proposal queue first (step 1) and re-run.
+
+## What this module is NOT
+
+* It is **not** an autonomous starter. It does not create a
+  branch, open a PR, run tests, or invoke `gh`.
+* It is **not** a risk arbiter. Risk classification belongs to
+  `roadmap_execution_protocol`. The prioritizer mirrors the
+  protocol's verdict.
+* It is **not** an approval surface. Approvals go through
+  `reporting.approval_inbox` (which already projects
+  `failed_automation` / `unknown_state` rows from this module's
+  recurring-maintenance integration).
+* It is **not** a write target. Other modules must not write to
+  `logs/roadmap_priority/` — only the prioritizer does.
+
+## Forward roadmap (not shipped here)
+
+| release | adds |
+| --- | --- |
+| **v3.15.16.2 (this)** | prioritizer module, recurring-maintenance integration, canonical Roadmap v6.1 doc, runbook |
+| v3.15.16.3 | read-only `/api/agent-control/next-up` endpoint and a "Next up" PWA card |
+| v3.15.16.4 | operator-authored governance-bootstrap to add `ops/systemd/` to an agent allowlist union, then a recurring-maintenance systemd timer for VPS-side ongoing freshness |
+| later | optional explicit dependency declarations in the canonical roadmap doc; the MVP relies on release-id ordering |
+
+## Files added by v3.15.16.2
+
+```
+docs/roadmap/qre_roadmap_v6_1.md          (the canonical structured roadmap)
+reporting/roadmap_priority.py             (the prioritizer module)
+reporting/recurring_maintenance.py        (one new closed job entry)
+tests/unit/test_roadmap_priority.py       (filter + rank + write tests)
+tests/unit/test_recurring_maintenance.py  (registry assertion update)
+docs/governance/roadmap_priority.md       (this file)
+docs/governance/recurring_maintenance.md  (job table addition + cross-reference)
+```
+
+No new dependency. No `dashboard/dashboard.py` change. No
+`.claude/` change. No frozen contract change. No live / paper /
+shadow / risk path touch. No test weakening.
+
+## Cross-references
+
+* `reporting/roadmap_execution_protocol.py` — per-item plan + risk
+  arbiter (the canonical source of `decision` /
+  `implementation_allowed` / `requires_human`).
+* `reporting/proposal_queue.py` — markdown parser that turns
+  `docs/roadmap/*` into a typed proposal queue.
+* `reporting/recurring_maintenance.py` — typed scheduler.
+* `docs/governance/recurring_maintenance.md` — operator runbook
+  for the scheduler.
+* `docs/governance/roadmap_item_execution_protocol.md` — operator
+  runbook for the per-item protocol module.
+* `docs/roadmap/qre_roadmap_v6_1.md` — the canonical structured
+  Roadmap v6.1 the prioritizer ingests via the proposal queue.

--- a/docs/roadmap/qre_roadmap_v6_1.md
+++ b/docs/roadmap/qre_roadmap_v6_1.md
@@ -1,0 +1,257 @@
+# Roadmap v6.1 — Quant Research Engine
+
+> Canonical, structured roadmap for the post-v3.15.16.0 phase of the
+> Quant Research Engine. This document is parsed by
+> `reporting.proposal_queue` (one H3 per shippable item) and consumed
+> by `reporting.roadmap_priority` (which projects the safe-next-up
+> item under the deterministic eligibility + ranking policy).
+>
+> Authoring rules (so the parser never produces noise):
+>
+> * One H1 — the document title.
+> * One H2 per release group, with the release prefix in the title:
+>   `## v3.15.16.x — <topic>`.
+> * One H3 per shippable item, with the exact release id in the
+>   title: `### v3.15.16.2 — <imperative title>`.
+> * Body lines per item: a one-line summary, an `affected_files:`
+>   line listing each path in `backticks` (so the parser picks them
+>   up), a `risk_class:` line, a `status:` line (`proposed`, `done`,
+>   `deferred`, `superseded`).
+> * Done items stay in this document with `status: done` so the
+>   prioritizer can skip them. Never delete items — supersede with a
+>   linked successor.
+>
+> See `docs/governance/roadmap_priority.md` for the operator runbook
+> and `reporting/roadmap_priority.py` for the deterministic
+> prioritizer that consumes this document via the proposal queue.
+
+---
+
+## v3.15.16.x — Autonomous backlog & deploy plumbing
+
+### v3.15.16.0 — First protocol-driven roadmap item — operator runbook for stale-artifact detection
+
+Document the v3.15.15.27 stale-artifact detection surface in an
+operator-facing runbook section.
+
+* `affected_files`: `docs/governance/autonomy_metrics.md`,
+  `docs/governance/observability_security_hardening.md`
+* `risk_class`: LOW
+* `proposal_type`: docs_only
+* `status`: done
+
+### v3.15.16.1 — VPS-side PR lifecycle artifact auto-refresh on deploy
+
+Add a best-effort, non-fatal post-deploy step to
+`scripts/deploy_vps_dashboard.sh` that runs the
+github_pr_lifecycle dry-run reporter on the VPS host after every
+merge to `main`. Result: `logs/github_pr_lifecycle/latest.json` is
+fresh on the VPS and the Agent Control PWA's PRs tab has data.
+
+* `affected_files`: `scripts/deploy_vps_dashboard.sh`,
+  `docs/governance/vps_deploy.md`,
+  `docs/governance/recurring_maintenance.md`
+* `risk_class`: LOW
+* `proposal_type`: observability_addition
+* `status`: done
+
+### v3.15.16.2 — Autonomous roadmap backlog ingestion and prioritization
+
+Ship this canonical structured Roadmap v6.1 document and a new
+read-only prioritizer module that joins the proposal queue with
+the roadmap execution protocol to project a deterministic
+chosen-next-up item plus its protocol plan summary into
+`logs/roadmap_priority/latest.json`. The prioritizer is read-only
+observability; it never starts work, never opens a branch, never
+opens a PR, never merges, never calls `gh`. The
+`recurring_maintenance` scheduler gains one new closed job entry
+so the digest stays fresh on the VPS.
+
+* `affected_files`: `docs/roadmap/qre_roadmap_v6_1.md`,
+  `reporting/roadmap_priority.py`,
+  `reporting/recurring_maintenance.py`,
+  `tests/unit/test_roadmap_priority.py`,
+  `tests/unit/test_recurring_maintenance.py`,
+  `docs/governance/roadmap_priority.md`,
+  `docs/governance/recurring_maintenance.md`
+* `risk_class`: LOW
+* `proposal_type`: observability_addition
+* `status`: proposed
+
+### v3.15.16.3 — PWA next-up card for the priority digest
+
+Surface `logs/roadmap_priority/latest.json` to the operator via a
+new GET-only `/api/agent-control/next-up` endpoint and a read-only
+"Next up" card on the Agent Control PWA. No mutation, no
+auto-execution, no execute-safe wiring. The card displays the
+chosen-next-up item, its rationale, and its protocol plan summary.
+
+* `affected_files`: `dashboard/api_agent_control.py`,
+  `frontend/src/api/agent_control.ts`,
+  `frontend/src/routes/AgentControl.tsx`,
+  `frontend/src/test/AgentControl.test.tsx`,
+  `tests/unit/test_dashboard_api_agent_control.py`,
+  `docs/governance/roadmap_priority.md`
+* `risk_class`: LOW
+* `proposal_type`: observability_addition
+* `status`: proposed
+
+### v3.15.16.4 — Recurring-maintenance systemd timer (governance-bootstrap-gated)
+
+Operator-authored governance-bootstrap PR that adds `ops/systemd/`
+to an agent's allowlist union, then ships
+`ops/systemd/trading-agent-recurring-maintenance.{service,timer}`
+so the existing read-only scheduler runs on a fixed cadence on the
+VPS without any manual `cron` / `systemd` step.
+
+* `affected_files`: `.claude/agents/...`,
+  `docs/governance/no_touch_paths.md`,
+  `ops/systemd/trading-agent-recurring-maintenance.service`,
+  `ops/systemd/trading-agent-recurring-maintenance.timer`,
+  `ops/systemd/README.md`,
+  `docs/governance/vps_deploy.md`
+* `risk_class`: HIGH (governance-bootstrap; operator-authored)
+* `proposal_type`: governance_change
+* `status`: proposed
+
+---
+
+## v3.15.17.x — Push notifications (operator-authored governance bootstrap required)
+
+### v3.15.17.0 — Web Push alerts governance-bootstrap
+
+OPERATOR-AUTHORED governance-bootstrap PR that lifts the
+no-browser-push constraint for a strictly bounded alert-only Web
+Push surface and prepares the policy ground for the v3.15.17.1+
+implementation phases.
+
+* `affected_files`: `AGENTS.md`, `CLAUDE.md`,
+  `.claude/agents/...`,
+  `docs/governance/agent_control_push_alerts.md`,
+  `docs/governance/no_touch_paths.md`,
+  `docs/governance/observability_security_hardening.md`,
+  `docs/governance/mobile_agent_control_pwa.md`,
+  `tests/unit/test_observability_security_invariants.py`,
+  `requirements.txt`, `config/web_push_public_key.txt`
+* `risk_class`: HIGH (governance-bootstrap; operator-authored)
+* `proposal_type`: governance_change
+* `status`: proposed
+
+### v3.15.17.1 — Push backend foundation
+
+`dashboard/api_push.py` (new), `reporting/web_push_dispatch.py`
+(new), VAPID key plumbing. No SW changes, no event triggers, no
+real push sent yet.
+
+* `affected_files`: `dashboard/api_push.py`,
+  `reporting/web_push_dispatch.py`,
+  `state/web_push_subscriptions.json`,
+  `tests/unit/test_web_push_dispatch.py`,
+  `tests/unit/test_web_push_subscription_store.py`
+* `risk_class`: MEDIUM (depends on v3.15.17.0)
+* `proposal_type`: tooling_intake
+* `status`: proposed
+
+### v3.15.17.2 — Frontend SW push handler + permission UX
+
+`frontend/public/sw.js` push event handler,
+`frontend/src/components/PushPermissionPrompt.tsx`,
+`frontend/src/api/agent_control_push.ts`. End-to-end works for
+manually injected events.
+
+* `affected_files`: `frontend/public/sw.js`,
+  `frontend/src/api/agent_control_push.ts`,
+  `frontend/src/components/PushPermissionPrompt.tsx`,
+  `tests/integration/test_web_push_end_to_end.py`
+* `risk_class`: MEDIUM (depends on v3.15.17.1)
+* `proposal_type`: ux_gap
+* `status`: proposed
+
+### v3.15.17.3 — Event triggers + dispatch
+
+`reporting/web_push_event_diff.py` and a closed-vocabulary list of
+event kinds (PR opened/updated/merged, CI pass/fail, deploy
+success/failure, approval_inbox new, proposal_queue new). First
+real outbound push, throttled and feature-flagged.
+
+* `affected_files`: `reporting/web_push_event_diff.py`,
+  `reporting/recurring_maintenance.py`,
+  `state/web_push_dispatch_enabled.flag`
+* `risk_class`: MEDIUM (depends on v3.15.17.2)
+* `proposal_type`: observability_addition
+* `status`: proposed
+
+---
+
+## v3.15.18.x — Roadmap v6.1 §v3.15.16 — Intelligent Routing Layer
+
+### v3.15.18.0 — Behavior-aware campaign routing scaffold
+
+Make campaign routing behavior-aware instead of preset-count-aware.
+Scaffold-only release: introduces the read-only routing-priority
+projection without changing any active campaign selection.
+
+* `affected_files`: `research/routing_priority.py`,
+  `research/observability/routing_priority.v1.json`,
+  `tests/unit/test_routing_priority.py`,
+  `docs/governance/intelligent_routing.md`
+* `risk_class`: LOW
+* `proposal_type`: observability_addition
+* `status`: proposed
+
+---
+
+## v3.15.19.x — Roadmap v6.1 §v3.15.17 — Sampling Intelligence
+
+### v3.15.19.0 — Stratified sampling + low-information-region suppression scaffold
+
+Scaffold-only release: introduces the deterministic stratified
+sampling helper and the low-information-region detector as read-only
+projections. No change to the active sampler.
+
+* `affected_files`: `research/sampling_intelligence.py`,
+  `research/observability/sampling_intelligence.v1.json`,
+  `tests/unit/test_sampling_intelligence.py`,
+  `docs/governance/sampling_intelligence.md`
+* `risk_class`: LOW
+* `proposal_type`: observability_addition
+* `status`: proposed
+
+---
+
+## Authoring conventions
+
+* `risk_class` MUST be one of `LOW`, `MEDIUM`, `HIGH`. The
+  prioritizer filters HIGH out of the next-up surface; HIGH items
+  are visible in the queue but are never auto-selected.
+* `proposal_type` SHOULD match the canonical
+  `reporting.proposal_queue` taxonomy: `observability_addition`,
+  `observability_gap`, `testing_gap`, `ux_gap`, `ci_hygiene`,
+  `dependency_cleanup`, `release_candidate`, `tooling_intake`,
+  `governance_change`, `roadmap_adoption`, `roadmap_diff`,
+  `approval_required`. The prioritizer never relies on
+  `proposal_type` for risk decisions — those come from the
+  `roadmap_execution_protocol`.
+* `status: done` items remain in this document for traceability.
+  The prioritizer ignores them. The proposal_queue parser converts
+  them into proposals with `status="done"` derived from this
+  marker; the prioritizer rejects any non-`proposed` candidate.
+* Inter-item dependencies are captured by **release-id ordering**:
+  an item under `## v3.15.17.x` is implicitly dependent on the
+  preceding `## v3.15.16.x` group reaching `done` for the items
+  this group depends on. The MVP prioritizer does not parse
+  free-form `Depends on:` lines; that is a v3.15.16.4+ enhancement.
+
+## Cross-references
+
+* `docs/governance/roadmap_priority.md` — operator runbook for the
+  prioritizer.
+* `docs/governance/recurring_maintenance.md` — operator runbook for
+  the scheduler that keeps `logs/roadmap_priority/latest.json`
+  fresh on the VPS.
+* `docs/governance/vps_deploy.md` — VPS deploy runbook (covers the
+  `github_pr_lifecycle` post-deploy refresh from v3.15.16.1).
+* `reporting/roadmap_priority.py` — prioritizer module.
+* `reporting/proposal_queue.py` — markdown parser.
+* `reporting/roadmap_execution_protocol.py` — per-item plan + risk
+  arbiter.

--- a/reporting/recurring_maintenance.py
+++ b/reporting/recurring_maintenance.py
@@ -85,6 +85,11 @@ JOB_REFRESH_PROPOSAL_QUEUE: str = "refresh_proposal_queue"
 JOB_REFRESH_APPROVAL_INBOX: str = "refresh_approval_inbox"
 JOB_REFRESH_PR_LIFECYCLE_DRY_RUN: str = "refresh_github_pr_lifecycle_dry_run"
 JOB_DEPENDABOT_EXECUTE_SAFE: str = "dependabot_low_medium_execute_safe"
+# v3.15.16.2 — read-only roadmap priority projection. Joins the
+# proposal queue with the roadmap execution protocol to emit a
+# deterministic chosen_next_up item plus its plan summary. LOW
+# risk; no gh; no external network; no mutation.
+JOB_REFRESH_ROADMAP_PRIORITY: str = "refresh_roadmap_priority"
 
 JOB_TYPES: tuple[str, ...] = (
     JOB_REFRESH_WORKLOOP_RUNTIME,
@@ -92,6 +97,7 @@ JOB_TYPES: tuple[str, ...] = (
     JOB_REFRESH_APPROVAL_INBOX,
     JOB_REFRESH_PR_LIFECYCLE_DRY_RUN,
     JOB_DEPENDABOT_EXECUTE_SAFE,
+    JOB_REFRESH_ROADMAP_PRIORITY,
 )
 
 
@@ -266,6 +272,33 @@ def _exec_refresh_pr_lifecycle_dry_run() -> dict[str, Any]:
     }
 
 
+def _exec_refresh_roadmap_priority() -> dict[str, Any]:
+    """Run the v3.15.16.2 roadmap priority projection (read-only).
+
+    Reads ``logs/proposal_queue/latest.json`` and, for each
+    proposal, calls ``roadmap_execution_protocol.plan_item`` to
+    obtain the per-item decision. Writes the deterministic
+    ``logs/roadmap_priority/latest.json`` digest. Never starts a
+    branch, never opens a PR, never invokes ``gh``. The digest's
+    ``safe_to_execute`` field is hard-coded ``false``."""
+    from reporting.roadmap_priority import collect_snapshot, write_outputs
+
+    snap = collect_snapshot()
+    write_outputs(snap)
+    chosen = snap.get("chosen_next_up") or {}
+    return {
+        "summary": (
+            f"roadmap_priority "
+            f"{snap.get('final_recommendation') or 'no recommendation'}"
+        ),
+        "evidence": {
+            "chosen_proposal_id": chosen.get("proposal_id"),
+            "chosen_title": chosen.get("title"),
+            "counts": snap.get("counts"),
+        },
+    }
+
+
 def _exec_dependabot_execute_safe() -> dict[str, Any]:
     """Delegate to the existing ``reporting.github_pr_lifecycle``
     execute-safe path. The lifecycle module owns every Dependabot
@@ -346,6 +379,19 @@ _JOB_REGISTRY: dict[str, dict[str, Any]] = {
         "risk_class": RISK_MEDIUM,
         "needs_gh": True,
         "timeout_seconds": DEPENDABOT_JOB_TIMEOUT_SECONDS,
+    },
+    JOB_REFRESH_ROADMAP_PRIORITY: {
+        "default_interval_seconds": 30 * 60,
+        "default_enabled": True,
+        "executor": _exec_refresh_roadmap_priority,
+        "description": (
+            "Refresh roadmap priority dry-run digest "
+            "(read-only projection over the proposal queue + "
+            "roadmap execution protocol)."
+        ),
+        "risk_class": RISK_LOW,
+        "needs_gh": False,
+        "timeout_seconds": DEFAULT_JOB_TIMEOUT_SECONDS,
     },
 }
 

--- a/reporting/roadmap_priority.py
+++ b/reporting/roadmap_priority.py
@@ -1,0 +1,719 @@
+"""Roadmap Priority Projection (v3.15.16.2).
+
+Pure read-only projection over the proposal queue + roadmap
+execution protocol. Selects exactly one ``chosen_next_up`` item
+under a deterministic eligibility + ranking policy, and writes the
+result to ``logs/roadmap_priority/latest.json``.
+
+This module:
+
+* never starts work
+* never opens a branch
+* never opens a PR
+* never merges
+* never calls ``gh``
+* never calls any external service
+* never mutates the proposal queue, the protocol module, or any
+  other artifact
+
+Hard guarantees (enforced by code AND tests)
+--------------------------------------------
+
+* Stdlib-only. No subprocess, no ``gh``, no ``git``, no network.
+* Reads ``logs/proposal_queue/latest.json`` only. Never invokes
+  the proposal queue's CLI; the recurring maintenance scheduler is
+  the canonical refresh path for that artifact.
+* Output limited to ``logs/roadmap_priority/``.
+* Atomic writes (``tmp`` + ``os.replace``); no in-place edits.
+* ``safe_to_execute`` is hard-coded ``false`` at the digest level —
+  the prioritizer surfaces; the operator decides.
+* Missing or malformed proposal_queue artifact produces
+  ``final_recommendation = "not_available"``; never silently OK.
+* Risk classification delegates to
+  ``reporting.roadmap_execution_protocol.plan_item`` — there is no
+  second source of truth.
+* Determinism: two runs on the same input produce a byte-identical
+  ``chosen_next_up`` and ``candidates`` list (modulo the
+  ``generated_at_utc`` timestamp).
+
+CLI
+---
+
+::
+
+    python -m reporting.roadmap_priority --mode dry-run
+    python -m reporting.roadmap_priority --mode dry-run --no-write
+    python -m reporting.roadmap_priority --status
+
+Stdlib-only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from reporting import roadmap_execution_protocol as _rep
+
+REPO_ROOT: Path = Path(__file__).resolve().parent.parent
+MODULE_VERSION: str = "v3.15.16.2"
+SCHEMA_VERSION: int = 1
+
+DIGEST_DIR_JSON: Path = REPO_ROOT / "logs" / "roadmap_priority"
+SOURCE_PROPOSAL_QUEUE: Path = (
+    REPO_ROOT / "logs" / "proposal_queue" / "latest.json"
+)
+
+
+# ---------------------------------------------------------------------------
+# Closed taxonomies
+# ---------------------------------------------------------------------------
+
+
+REC_READY: str = "ready_for_implementation"
+REC_NOTHING_READY: str = "nothing_ready"
+REC_NOT_AVAILABLE: str = "not_available"
+
+FINAL_RECOMMENDATIONS: tuple[str, ...] = (
+    REC_READY,
+    REC_NOTHING_READY,
+    REC_NOT_AVAILABLE,
+)
+
+
+# Eligibility filter labels — surfaced verbatim in ``filtered_out``
+# so the operator can audit why each candidate was rejected.
+FILTER_STATUS_NOT_PROPOSED: str = "status_not_proposed"
+FILTER_RISK_HIGH: str = "risk_high_excluded"
+FILTER_PROTOCOL_DECISION: str = "protocol_decision_not_allowed_read_only"
+FILTER_PROTOCOL_IMPL_NOT_ALLOWED: str = "protocol_implementation_not_allowed"
+FILTER_PROTOCOL_REQUIRES_HUMAN: str = "protocol_requires_human"
+FILTER_PROTOCOL_SAFE_TO_EXECUTE_TRUE: str = "protocol_safe_to_execute_true"
+FILTER_PROTOCOL_ERROR: str = "protocol_classification_error"
+FILTER_INVALID_PROPOSAL_SHAPE: str = "invalid_proposal_shape"
+
+FILTER_REASONS: tuple[str, ...] = (
+    FILTER_STATUS_NOT_PROPOSED,
+    FILTER_RISK_HIGH,
+    FILTER_PROTOCOL_DECISION,
+    FILTER_PROTOCOL_IMPL_NOT_ALLOWED,
+    FILTER_PROTOCOL_REQUIRES_HUMAN,
+    FILTER_PROTOCOL_SAFE_TO_EXECUTE_TRUE,
+    FILTER_PROTOCOL_ERROR,
+    FILTER_INVALID_PROPOSAL_SHAPE,
+)
+
+
+# Ranking key 1: risk_class. LOW before MEDIUM. (HIGH already
+# filtered out — its position here is unreachable in practice.)
+_RISK_RANK: dict[str, int] = {
+    "LOW": 0,
+    "MEDIUM": 1,
+    "HIGH": 2,
+    "UNKNOWN": 3,
+}
+
+
+# Ranking key 2: proposal_type. Most-leveraged unblockers first
+# (observability before reporting before docs before tests before
+# UX before everything else). The full taxonomy from
+# ``reporting.proposal_queue`` is included so a future type does
+# not silently land at the bottom — unknown types get the
+# highest numerical rank (last).
+_PROPOSAL_TYPE_RANK: dict[str, int] = {
+    # Most-leveraged unblockers — these make later work observable
+    # and reviewable.
+    "observability_addition": 0,
+    "observability_gap": 1,
+    # Read-only reporting / docs.
+    "reporting_read_only": 2,
+    "docs_only": 3,
+    # Test gaps — close before running new code.
+    "testing_gap": 4,
+    "test_only": 5,
+    # UX surface only (reads existing data).
+    "ux_gap": 6,
+    "frontend_read_only": 7,
+    # CI / dependency hygiene.
+    "ci_hygiene": 8,
+    "dependency_cleanup": 9,
+    # Release candidates — bigger scope, last.
+    "release_candidate": 10,
+    # Anything else → last; this also covers types we explicitly
+    # never want to auto-select (governance_change,
+    # roadmap_adoption, roadmap_diff, tooling_intake,
+    # approval_required, blocked_unknown). The protocol filter
+    # above will already reject most of these via the
+    # implementation_allowed gate.
+}
+_FALLBACK_TYPE_RANK: int = 99
+
+
+# ---------------------------------------------------------------------------
+# Time + path helpers
+# ---------------------------------------------------------------------------
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _rel(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(REPO_ROOT.resolve())).replace(
+            "\\", "/"
+        )
+    except ValueError:
+        return str(path).replace("\\", "/")
+
+
+# ---------------------------------------------------------------------------
+# Proposal-queue read (passive; never invokes the producer)
+# ---------------------------------------------------------------------------
+
+
+def _read_proposal_queue(
+    path: Path = SOURCE_PROPOSAL_QUEUE,
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Read ``logs/proposal_queue/latest.json``. Returns
+    ``(snapshot, None)`` on success or ``(None, reason)`` on any
+    error. Never raises."""
+    if not path.exists():
+        return (None, "missing")
+    if not path.is_file():
+        return (None, "not_a_file")
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as e:
+        return (None, f"unreadable: {type(e).__name__}")
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as e:
+        return (None, f"malformed: {type(e).__name__}")
+    if not isinstance(data, dict):
+        return (None, "not_an_object")
+    return (data, None)
+
+
+# ---------------------------------------------------------------------------
+# Eligibility + protocol classification
+# ---------------------------------------------------------------------------
+
+
+def _proposal_to_protocol_input(p: Mapping[str, Any]) -> dict[str, Any]:
+    """Lift a proposal_queue record into the input shape that
+    ``roadmap_execution_protocol.plan_item`` accepts. We pass only
+    the title + summary + affected_files + a few boolean overrides;
+    the protocol classifier owns the actual decision."""
+    return {
+        "item_id": p.get("proposal_id"),
+        "source": "reporting.roadmap_priority",
+        "source_type": "proposal_queue_record",
+        "title": p.get("title"),
+        "summary": p.get("summary"),
+        "affected_files": p.get("affected_files") or [],
+        "labels": p.get("labels") or [],
+        "risk_class": p.get("risk_class"),
+        # The proposal_queue already classified governance / live /
+        # paid / telemetry concerns into its own status; we forward
+        # the conservative defaults so the protocol re-checks from
+        # the file paths and prose. We never mark a flag True from
+        # this side.
+        "requires_secret": False,
+        "requires_external_account": False,
+        "requires_paid_tool": False,
+        "has_telemetry_or_data_egress": False,
+        "touches_governance": False,
+        "touches_frozen_contract": False,
+        "touches_live_paper_shadow_risk": False,
+        "touches_ci_or_tests": False,
+        "changes_canonical_roadmap": False,
+        "pr_author": "claude-code",
+    }
+
+
+def _classify_via_protocol(
+    p: Mapping[str, Any], *, frozen_utc: str | None = None
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Call ``roadmap_execution_protocol.plan_item`` for a single
+    proposal. Returns ``(plan, None)`` on success or
+    ``(None, error_reason)`` if the protocol call raises. Never
+    raises."""
+    try:
+        plan = _rep.plan_item(
+            _proposal_to_protocol_input(p), frozen_utc=frozen_utc
+        )
+    except Exception as e:  # noqa: BLE001 — defensive fence
+        return (None, f"{type(e).__name__}: {e!s}"[:200])
+    if not isinstance(plan, dict):
+        return (None, "protocol_returned_non_dict")
+    return (plan, None)
+
+
+def _eligibility_filter(
+    p: Mapping[str, Any], plan: Mapping[str, Any] | None, plan_error: str | None
+) -> str | None:
+    """Return the first eligibility filter that rejects this
+    proposal, or ``None`` if every filter passes."""
+    # Filter 1: shape sanity. The queue should never produce a row
+    # without a proposal_id, but defensively reject anyway.
+    if not isinstance(p.get("proposal_id"), str) or not p.get("proposal_id"):
+        return FILTER_INVALID_PROPOSAL_SHAPE
+
+    # Filter 2: status must be exactly "proposed". Anything else
+    # (needs_human / blocked / approved / rejected / superseded /
+    # done / unknown) is excluded.
+    if p.get("status") != "proposed":
+        return FILTER_STATUS_NOT_PROPOSED
+
+    # Filter 3: risk_class must not be HIGH. The proposal_queue's
+    # own classification is the first signal; the protocol's
+    # classification is the second signal (Filter 5+) and may
+    # downgrade or upgrade.
+    if p.get("risk_class") == "HIGH":
+        return FILTER_RISK_HIGH
+
+    # Filter 4: the protocol call itself must have succeeded.
+    if plan_error is not None or plan is None:
+        return FILTER_PROTOCOL_ERROR
+
+    # Filter 5: protocol decision must be allowed_read_only.
+    if plan.get("decision") != "allowed_read_only":
+        return FILTER_PROTOCOL_DECISION
+
+    # Filter 6: protocol must explicitly mark
+    # implementation_allowed=True. This rejects governance /
+    # canonical-roadmap / live-path / secret / telemetry / paid
+    # items even when the prose did not classify them via the
+    # proposal queue.
+    if not plan.get("implementation_allowed"):
+        return FILTER_PROTOCOL_IMPL_NOT_ALLOWED
+
+    # Filter 7: protocol must explicitly mark requires_human=False.
+    if plan.get("requires_human"):
+        return FILTER_PROTOCOL_REQUIRES_HUMAN
+
+    # Filter 8: protocol must report safe_to_execute=False. The
+    # protocol always sets this to False at the digest level; if
+    # it ever returns True, that is itself a contract breach we
+    # surface as a rejected candidate rather than silently picking.
+    if plan.get("safe_to_execute"):
+        return FILTER_PROTOCOL_SAFE_TO_EXECUTE_TRUE
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Ranking
+# ---------------------------------------------------------------------------
+
+
+def _rank_key(
+    p: Mapping[str, Any], plan: Mapping[str, Any]
+) -> tuple[int, int, str]:
+    """Stable sort key. Tuple ordering: (risk_rank, type_rank,
+    proposal_id). Lower is better."""
+    # Trust the protocol's risk classification when it disagrees
+    # with the proposal queue (it is the canonical arbiter).
+    risk = plan.get("risk_class") or p.get("risk_class") or "UNKNOWN"
+    risk_rank = _RISK_RANK.get(str(risk), _RISK_RANK["UNKNOWN"])
+    ptype = p.get("proposal_type") or "unknown"
+    type_rank = _PROPOSAL_TYPE_RANK.get(str(ptype), _FALLBACK_TYPE_RANK)
+    pid = str(p.get("proposal_id") or "")
+    return (risk_rank, type_rank, pid)
+
+
+# ---------------------------------------------------------------------------
+# Snapshot construction
+# ---------------------------------------------------------------------------
+
+
+def _plan_summary(plan: Mapping[str, Any]) -> dict[str, Any]:
+    """Project a small, operator-readable subset of the protocol
+    plan onto the priority digest. We never copy the full plan —
+    the operator can run the protocol CLI for the full record.
+
+    Note: this summary intentionally does NOT include
+    ``safe_to_execute``. The digest's top-level ``safe_to_execute``
+    field is the single canonical source of that signal and is
+    pinned to literal ``False`` by a unit test; duplicating it
+    here would double-write the same fact while also triggering
+    the literal-False source-text guard against any
+    ``bool(...)`` projection."""
+    return {
+        "decision": plan.get("decision"),
+        "implementation_allowed": bool(plan.get("implementation_allowed")),
+        "requires_human": bool(plan.get("requires_human")),
+        "risk_class": plan.get("risk_class"),
+        "item_type": plan.get("item_type"),
+        "proposed_branch": plan.get("proposed_branch"),
+        "proposed_release_id": plan.get("proposed_release_id"),
+        "required_tests": list(plan.get("required_tests") or []),
+        "expected_artifacts": list(plan.get("expected_artifacts") or []),
+        "rollback_plan": list(plan.get("rollback_plan") or []),
+    }
+
+
+def _build_chosen_next_up(
+    p: Mapping[str, Any], plan: Mapping[str, Any], rank: int
+) -> dict[str, Any]:
+    return {
+        "proposal_id": p.get("proposal_id"),
+        "title": p.get("title"),
+        "summary": p.get("summary"),
+        "source": p.get("source"),
+        "proposal_type": p.get("proposal_type"),
+        "risk_class": plan.get("risk_class") or p.get("risk_class"),
+        "affected_files": list(p.get("affected_files") or []),
+        "rank": rank,
+        "rationale": _rationale(p, plan),
+        "protocol_plan_summary": _plan_summary(plan),
+    }
+
+
+def _rationale(
+    p: Mapping[str, Any], plan: Mapping[str, Any]
+) -> str:
+    """One-line operator-readable explanation of why this item won
+    the ranking. Static phrasing — does not summarise the whole
+    plan, just the dominant signal."""
+    risk = plan.get("risk_class") or p.get("risk_class") or "UNKNOWN"
+    ptype = p.get("proposal_type") or "unknown"
+    return (
+        f"risk {risk}, type {ptype}, "
+        f"protocol decision {plan.get('decision')}; "
+        "lowest-rank eligible candidate by deterministic policy"
+    )
+
+
+def _build_candidate_record(
+    *, p: Mapping[str, Any], plan: Mapping[str, Any], rank: int
+) -> dict[str, Any]:
+    """One row in the ``candidates`` list (eligible items, ranked)."""
+    return {
+        "proposal_id": p.get("proposal_id"),
+        "title": p.get("title"),
+        "proposal_type": p.get("proposal_type"),
+        "risk_class": plan.get("risk_class") or p.get("risk_class"),
+        "rank": rank,
+        "score_signals": {
+            "risk_rank": _RISK_RANK.get(
+                str(plan.get("risk_class") or p.get("risk_class") or "UNKNOWN"),
+                _RISK_RANK["UNKNOWN"],
+            ),
+            "type_rank": _PROPOSAL_TYPE_RANK.get(
+                str(p.get("proposal_type") or "unknown"),
+                _FALLBACK_TYPE_RANK,
+            ),
+        },
+    }
+
+
+def _build_filtered_record(
+    *, p: Mapping[str, Any], filter_reason: str, plan_error: str | None
+) -> dict[str, Any]:
+    """One row in the ``filtered_out`` list (rejected items)."""
+    return {
+        "proposal_id": p.get("proposal_id"),
+        "title": p.get("title"),
+        "proposal_type": p.get("proposal_type"),
+        "risk_class": p.get("risk_class"),
+        "filter_reason": filter_reason,
+        "protocol_error": plan_error,
+    }
+
+
+def collect_snapshot(
+    *,
+    frozen_utc: str | None = None,
+    proposals_override: Sequence[Mapping[str, Any]] | None = None,
+    proposal_source_override: Path | None = None,
+) -> dict[str, Any]:
+    """Build the full priority digest. Pure function. Test fixtures
+    can use ``proposals_override`` to skip the file read.
+    ``proposal_source_override`` allows tests to point at a custom
+    proposal_queue artifact path."""
+    generated = frozen_utc or _utcnow()
+
+    # Source ingestion. Tests can short-circuit via override.
+    if proposals_override is not None:
+        proposals: list[Mapping[str, Any]] = list(proposals_override)
+        source_status = "ok"
+        source_error: str | None = None
+        source_path = "test_override"
+        source_module_version: str | None = None
+    else:
+        path = proposal_source_override or SOURCE_PROPOSAL_QUEUE
+        snap, err = _read_proposal_queue(path)
+        if snap is None:
+            return _build_not_available_digest(
+                generated_at_utc=generated,
+                reason=err or "unknown",
+                source_path=_rel(path),
+            )
+        raw_proposals = snap.get("proposals")
+        if not isinstance(raw_proposals, list):
+            return _build_not_available_digest(
+                generated_at_utc=generated,
+                reason="proposals_field_not_a_list",
+                source_path=_rel(path),
+            )
+        proposals = [p for p in raw_proposals if isinstance(p, dict)]
+        source_status = "ok"
+        source_error = None
+        source_path = _rel(path)
+        source_module_version = snap.get("module_version")
+
+    eligible: list[tuple[Mapping[str, Any], Mapping[str, Any]]] = []
+    filtered: list[dict[str, Any]] = []
+
+    for p in proposals:
+        plan, plan_error = _classify_via_protocol(p, frozen_utc=frozen_utc)
+        reason = _eligibility_filter(p, plan, plan_error)
+        if reason is None and plan is not None:
+            eligible.append((p, plan))
+        else:
+            filtered.append(
+                _build_filtered_record(
+                    p=p,
+                    filter_reason=reason or FILTER_PROTOCOL_ERROR,
+                    plan_error=plan_error,
+                )
+            )
+
+    # Stable rank: tuple sort, deterministic across runs.
+    eligible.sort(key=lambda pp: _rank_key(pp[0], pp[1]))
+
+    candidates: list[dict[str, Any]] = []
+    for idx, (p, plan) in enumerate(eligible, start=1):
+        candidates.append(
+            _build_candidate_record(p=p, plan=plan, rank=idx)
+        )
+
+    chosen_next_up: dict[str, Any] | None = None
+    if eligible:
+        top_p, top_plan = eligible[0]
+        chosen_next_up = _build_chosen_next_up(top_p, top_plan, rank=1)
+
+    final_recommendation = (
+        REC_READY if chosen_next_up is not None else REC_NOTHING_READY
+    )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": "roadmap_priority_digest",
+        "module_version": MODULE_VERSION,
+        "generated_at_utc": generated,
+        "mode": "dry-run",
+        "source_proposal_queue": {
+            "path": source_path,
+            "status": source_status,
+            "error": source_error,
+            "module_version": source_module_version,
+            "proposal_count": len(proposals),
+        },
+        "policy": {
+            "filters": list(FILTER_REASONS),
+            "ranking": [
+                "risk_low_first",
+                "observability_first",
+                "reporting_first",
+                "docs_first",
+                "test_first",
+                "ux_first",
+                "frontend_first",
+                "ci_hygiene_first",
+                "dependency_cleanup_first",
+                "release_candidate_last",
+                "stable_proposal_id_tiebreak",
+            ],
+            "protocol_module_version": _rep.MODULE_VERSION,
+        },
+        "counts": {
+            "proposals_total": len(proposals),
+            "eligible_total": len(eligible),
+            "filtered_out_total": len(filtered),
+            "filtered_out_by_reason": _counts_by_reason(filtered),
+        },
+        "chosen_next_up": chosen_next_up,
+        "candidates": candidates,
+        "filtered_out": filtered,
+        "final_recommendation": final_recommendation,
+        "safe_to_execute": False,
+    }
+
+
+def _build_not_available_digest(
+    *, generated_at_utc: str, reason: str, source_path: str
+) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": "roadmap_priority_digest",
+        "module_version": MODULE_VERSION,
+        "generated_at_utc": generated_at_utc,
+        "mode": "dry-run",
+        "source_proposal_queue": {
+            "path": source_path,
+            "status": "not_available",
+            "error": reason,
+            "module_version": None,
+            "proposal_count": 0,
+        },
+        "policy": {
+            "filters": list(FILTER_REASONS),
+            "ranking": [],
+            "protocol_module_version": _rep.MODULE_VERSION,
+        },
+        "counts": {
+            "proposals_total": 0,
+            "eligible_total": 0,
+            "filtered_out_total": 0,
+            "filtered_out_by_reason": {},
+        },
+        "chosen_next_up": None,
+        "candidates": [],
+        "filtered_out": [],
+        "final_recommendation": REC_NOT_AVAILABLE,
+        "safe_to_execute": False,
+    }
+
+
+def _counts_by_reason(filtered: list[dict[str, Any]]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for row in filtered:
+        r = row.get("filter_reason")
+        if isinstance(r, str):
+            counts[r] = counts.get(r, 0) + 1
+    return counts
+
+
+# ---------------------------------------------------------------------------
+# Atomic write
+# ---------------------------------------------------------------------------
+
+
+def write_outputs(snapshot: Mapping[str, Any]) -> dict[str, str]:
+    """Atomic write of latest.json + timestamped copy + history
+    append. Mirrors the atomic-write pattern used by the rest of
+    the reporting modules."""
+    DIGEST_DIR_JSON.mkdir(parents=True, exist_ok=True)
+    ts = str(snapshot["generated_at_utc"]).replace(":", "-")
+    json_now = DIGEST_DIR_JSON / f"{ts}.json"
+    json_latest = DIGEST_DIR_JSON / "latest.json"
+    history = DIGEST_DIR_JSON / "history.jsonl"
+    payload = json.dumps(snapshot, sort_keys=True, indent=2)
+
+    tmp_now = json_now.with_suffix(json_now.suffix + ".tmp")
+    tmp_now.write_text(payload, encoding="utf-8")
+    os.replace(tmp_now, json_now)
+
+    tmp_latest = json_latest.with_suffix(json_latest.suffix + ".tmp")
+    tmp_latest.write_text(payload, encoding="utf-8")
+    os.replace(tmp_latest, json_latest)
+
+    compact = json.dumps(snapshot, sort_keys=True, separators=(",", ":"))
+    with history.open("a", encoding="utf-8") as f:
+        f.write(compact + "\n")
+
+    return {
+        "latest": _rel(json_latest),
+        "timestamped": _rel(json_now),
+        "history": _rel(history),
+    }
+
+
+def read_latest_snapshot() -> dict[str, Any] | None:
+    p = DIGEST_DIR_JSON / "latest.json"
+    if not p.exists():
+        return None
+    try:
+        text = p.read_text(encoding="utf-8")
+        data = json.loads(text)
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="reporting.roadmap_priority",
+        description=(
+            "Read-only roadmap priority projection "
+            f"({MODULE_VERSION}). Stdlib-only. Never executes "
+            "implementation; always projects."
+        ),
+    )
+    g = parser.add_mutually_exclusive_group(required=False)
+    g.add_argument(
+        "--mode",
+        type=str,
+        default="dry-run",
+        choices=["dry-run"],
+        help=(
+            "Operating mode (default: dry-run). The execute path is "
+            "intentionally absent in this release: the prioritizer "
+            "never starts work."
+        ),
+    )
+    g.add_argument(
+        "--status",
+        action="store_true",
+        help="Read and print the latest digest from logs/.",
+    )
+    parser.add_argument(
+        "--no-write",
+        action="store_true",
+        help="Do not persist the JSON digest (stdout only).",
+    )
+    parser.add_argument(
+        "--frozen-utc",
+        type=str,
+        default=None,
+        help="Pin generated_at_utc for deterministic tests.",
+    )
+    parser.add_argument(
+        "--indent",
+        type=int,
+        default=2,
+        help="JSON indent for stdout (0 for compact).",
+    )
+    args = parser.parse_args(argv)
+
+    if args.status:
+        snap = read_latest_snapshot()
+        if snap is None:
+            print(
+                json.dumps(
+                    {"status": "not_available", "reason": "missing"},
+                    indent=args.indent or None,
+                )
+            )
+            return 1
+        print(json.dumps(snap, sort_keys=True, indent=args.indent or None))
+        return 0
+
+    snap = collect_snapshot(frozen_utc=args.frozen_utc)
+    if not args.no_write:
+        write_outputs(snap)
+    print(json.dumps(snap, sort_keys=True, indent=args.indent or None))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_recurring_maintenance.py
+++ b/tests/unit/test_recurring_maintenance.py
@@ -52,6 +52,22 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 @pytest.fixture
 def isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setattr(rm, "DIGEST_DIR_JSON", tmp_path / "rm")
+    # v3.15.16.2 — the recurring scheduler now contains a
+    # roadmap_priority refresh job whose real executor reads the
+    # repo's logs/proposal_queue/latest.json (~290 KB, 206
+    # proposals) and runs the roadmap_execution_protocol per
+    # proposal. That is fine in production but unnecessary work
+    # for tests, and the real write_outputs would also pollute
+    # ``logs/roadmap_priority/`` in the repo. Stub it with a
+    # no-op summary so every test using ``isolated`` stays
+    # hermetic. Tests that specifically want to exercise the
+    # roadmap_priority job can still call _patch_executor with
+    # their own stub.
+    spec = dict(rm._JOB_REGISTRY[rm.JOB_REFRESH_ROADMAP_PRIORITY])
+    spec["executor"] = lambda: {"summary": "ok (test stub)"}
+    monkeypatch.setitem(
+        rm._JOB_REGISTRY, rm.JOB_REFRESH_ROADMAP_PRIORITY, spec
+    )
     return tmp_path
 
 
@@ -87,10 +103,24 @@ def test_job_registry_contains_only_approved_types() -> None:
         "refresh_approval_inbox",
         "refresh_github_pr_lifecycle_dry_run",
         "dependabot_low_medium_execute_safe",
+        # v3.15.16.2 — read-only roadmap priority projection.
+        "refresh_roadmap_priority",
     }
     assert set(rm.JOB_TYPES) == expected
     assert set(rm._JOB_REGISTRY.keys()) == expected
-    assert len(rm.JOB_TYPES) == 5
+    assert len(rm.JOB_TYPES) == 6
+
+
+def test_roadmap_priority_job_is_low_risk_no_gh_enabled_by_default() -> None:
+    """v3.15.16.2: the roadmap priority refresh job must be LOW
+    risk, must not need ``gh``, and must be enabled by default
+    (it is a pure read-only projection)."""
+    spec = rm._JOB_REGISTRY[rm.JOB_REFRESH_ROADMAP_PRIORITY]
+    assert spec["risk_class"] == rm.RISK_LOW
+    assert spec["needs_gh"] is False
+    assert spec["default_enabled"] is True
+    # 30-minute default cadence matches the design.
+    assert spec["default_interval_seconds"] == 30 * 60
 
 
 def test_dependabot_job_disabled_by_default() -> None:

--- a/tests/unit/test_roadmap_priority.py
+++ b/tests/unit/test_roadmap_priority.py
@@ -1,0 +1,618 @@
+"""Unit tests for ``reporting.roadmap_priority`` (v3.15.16.2).
+
+Properties enforced:
+
+* digest's ``safe_to_execute`` is always ``False``
+* missing source artifact → ``final_recommendation == "not_available"``
+* malformed source artifact → ``final_recommendation == "not_available"``
+* empty proposal list → ``final_recommendation == "nothing_ready"``
+* status != "proposed" filters out
+* risk_class == "HIGH" filters out
+* protocol decision != "allowed_read_only" filters out
+* protocol implementation_allowed == False filters out
+* protocol requires_human == True filters out
+* protocol error filters out (with reason recorded)
+* invalid proposal shape filters out
+* deterministic ordering: LOW before MEDIUM, observability before
+  reporting/docs/test/ux/frontend/ci/dep, stable proposal_id
+  tiebreak
+* two runs on the same input produce a byte-identical
+  ``chosen_next_up`` (modulo timestamp)
+* ``write_outputs`` is atomic (tmp + os.replace) and never
+  writes outside ``logs/roadmap_priority/``
+* CLI rejects modes other than ``dry-run`` (only ``dry-run`` is
+  exposed)
+* No subprocess / shell / network in the module source
+* No mutation of any input artifact
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reporting import roadmap_priority as rp
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+MODULE_PATH = REPO_ROOT / "reporting" / "roadmap_priority.py"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_digest_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Path:
+    """Redirect the digest output directory so write_outputs lands in
+    a temp dir per-test."""
+    monkeypatch.setattr(rp, "DIGEST_DIR_JSON", tmp_path / "rp")
+    return tmp_path
+
+
+def _proposed(
+    pid: str,
+    *,
+    title: str = "test item",
+    summary: str = "an observability addition for monitoring",
+    proposal_type: str = "observability_addition",
+    risk_class: str = "LOW",
+    affected_files: list[str] | None = None,
+    status: str = "proposed",
+) -> dict[str, Any]:
+    """Build a minimal proposal-queue-shaped record."""
+    if affected_files is None:
+        affected_files = ["reporting/example.py", "tests/unit/test_example.py"]
+    return {
+        "proposal_id": pid,
+        "title": title,
+        "summary": summary,
+        "proposal_type": proposal_type,
+        "risk_class": risk_class,
+        "affected_files": affected_files,
+        "status": status,
+        "source": "docs/roadmap/test.md",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Hard-coded digest invariants
+# ---------------------------------------------------------------------------
+
+
+def test_safe_to_execute_is_always_false_with_proposals() -> None:
+    snap = rp.collect_snapshot(
+        proposals_override=[_proposed("p_aaaaaaaa")],
+        frozen_utc="2026-05-04T12:00:00Z",
+    )
+    assert snap["safe_to_execute"] is False
+
+
+def test_safe_to_execute_is_false_when_not_available(
+    tmp_path: Path,
+) -> None:
+    """Even on a missing source the safe_to_execute flag is False."""
+    snap = rp.collect_snapshot(
+        proposal_source_override=tmp_path / "does_not_exist.json",
+        frozen_utc="2026-05-04T12:00:00Z",
+    )
+    assert snap["final_recommendation"] == rp.REC_NOT_AVAILABLE
+    assert snap["safe_to_execute"] is False
+
+
+def test_module_version_pinned() -> None:
+    assert rp.MODULE_VERSION == "v3.15.16.2"
+
+
+def test_schema_version_pinned() -> None:
+    assert rp.SCHEMA_VERSION == 1
+
+
+# ---------------------------------------------------------------------------
+# Source-availability handling
+# ---------------------------------------------------------------------------
+
+
+def test_missing_source_yields_not_available(tmp_path: Path) -> None:
+    snap = rp.collect_snapshot(
+        proposal_source_override=tmp_path / "missing.json",
+        frozen_utc="2026-05-04T12:00:00Z",
+    )
+    assert snap["final_recommendation"] == rp.REC_NOT_AVAILABLE
+    assert snap["chosen_next_up"] is None
+    assert snap["candidates"] == []
+    assert snap["filtered_out"] == []
+    assert snap["source_proposal_queue"]["status"] == "not_available"
+    assert snap["source_proposal_queue"]["error"] == "missing"
+
+
+def test_malformed_source_yields_not_available(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_text("not-json {[", encoding="utf-8")
+    snap = rp.collect_snapshot(
+        proposal_source_override=bad,
+        frozen_utc="2026-05-04T12:00:00Z",
+    )
+    assert snap["final_recommendation"] == rp.REC_NOT_AVAILABLE
+    assert snap["source_proposal_queue"]["status"] == "not_available"
+    assert "malformed" in (snap["source_proposal_queue"]["error"] or "")
+
+
+def test_source_not_an_object_yields_not_available(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_text("[]", encoding="utf-8")
+    snap = rp.collect_snapshot(
+        proposal_source_override=bad,
+        frozen_utc="2026-05-04T12:00:00Z",
+    )
+    assert snap["final_recommendation"] == rp.REC_NOT_AVAILABLE
+
+
+def test_source_proposals_field_not_a_list_yields_not_available(
+    tmp_path: Path,
+) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_text(
+        json.dumps({"proposals": "not a list"}),
+        encoding="utf-8",
+    )
+    snap = rp.collect_snapshot(
+        proposal_source_override=bad,
+        frozen_utc="2026-05-04T12:00:00Z",
+    )
+    assert snap["final_recommendation"] == rp.REC_NOT_AVAILABLE
+
+
+def test_empty_queue_yields_nothing_ready() -> None:
+    snap = rp.collect_snapshot(
+        proposals_override=[],
+        frozen_utc="2026-05-04T12:00:00Z",
+    )
+    assert snap["final_recommendation"] == rp.REC_NOTHING_READY
+    assert snap["chosen_next_up"] is None
+    assert snap["candidates"] == []
+
+
+# ---------------------------------------------------------------------------
+# Eligibility filters
+# ---------------------------------------------------------------------------
+
+
+def test_status_not_proposed_filters_out() -> None:
+    snap = rp.collect_snapshot(
+        proposals_override=[
+            _proposed("p_aaaaaaaa", status="needs_human"),
+            _proposed("p_bbbbbbbb", status="blocked"),
+            _proposed("p_cccccccc", status="approved"),
+            _proposed("p_dddddddd", status="rejected"),
+            _proposed("p_eeeeeeee", status="superseded"),
+            _proposed("p_ffffffff", status="done"),
+        ],
+        frozen_utc="2026-05-04T12:00:00Z",
+    )
+    assert snap["chosen_next_up"] is None
+    assert snap["final_recommendation"] == rp.REC_NOTHING_READY
+    reasons = {
+        row["filter_reason"] for row in snap["filtered_out"]
+    }
+    assert reasons == {rp.FILTER_STATUS_NOT_PROPOSED}
+
+
+def test_risk_high_filters_out() -> None:
+    snap = rp.collect_snapshot(
+        proposals_override=[_proposed("p_aaaaaaaa", risk_class="HIGH")],
+        frozen_utc="2026-05-04T12:00:00Z",
+    )
+    assert snap["chosen_next_up"] is None
+    assert snap["filtered_out"][0]["filter_reason"] == rp.FILTER_RISK_HIGH
+
+
+def test_invalid_proposal_shape_filters_out() -> None:
+    snap = rp.collect_snapshot(
+        proposals_override=[
+            {"title": "no proposal_id"},  # missing proposal_id
+            {"proposal_id": ""},  # empty proposal_id
+            {"proposal_id": 42},  # non-string proposal_id
+        ],
+        frozen_utc="2026-05-04T12:00:00Z",
+    )
+    assert snap["chosen_next_up"] is None
+    reasons = {row["filter_reason"] for row in snap["filtered_out"]}
+    assert reasons == {rp.FILTER_INVALID_PROPOSAL_SHAPE}
+
+
+def test_governance_change_filters_out_via_protocol() -> None:
+    """A proposal whose summary mentions ``.claude/`` is classified
+    by the protocol as ``governance_change`` (not in the open-set),
+    so the prioritizer rejects it via the implementation_not_allowed
+    filter."""
+    snap = rp.collect_snapshot(
+        proposals_override=[
+            _proposed(
+                "p_aaaaaaaa",
+                title="Update agent governance for some reason",
+                summary="Edit .claude/agents/foo.md and CLAUDE.md",
+                affected_files=[".claude/agents/foo.md", "CLAUDE.md"],
+                proposal_type="governance_change",
+            ),
+        ],
+        frozen_utc="2026-05-04T12:00:00Z",
+    )
+    assert snap["chosen_next_up"] is None
+    # Governance items either trip the protocol's needs_human flag
+    # or land outside ITEM_TYPES_OPEN_TO_IMPLEMENTATION; either way
+    # they are rejected.
+    assert snap["filtered_out"][0]["filter_reason"] in {
+        rp.FILTER_PROTOCOL_REQUIRES_HUMAN,
+        rp.FILTER_PROTOCOL_IMPL_NOT_ALLOWED,
+        rp.FILTER_PROTOCOL_DECISION,
+    }
+
+
+def test_live_path_filters_out_via_protocol() -> None:
+    snap = rp.collect_snapshot(
+        proposals_override=[
+            _proposed(
+                "p_aaaaaaaa",
+                title="Add live broker integration",
+                summary="Touches automation/live/ and execution/live/.",
+                affected_files=["automation/live/broker.py"],
+            ),
+        ],
+        frozen_utc="2026-05-04T12:00:00Z",
+    )
+    assert snap["chosen_next_up"] is None
+    assert snap["filtered_out"][0]["filter_reason"] in {
+        rp.FILTER_PROTOCOL_REQUIRES_HUMAN,
+        rp.FILTER_PROTOCOL_IMPL_NOT_ALLOWED,
+        rp.FILTER_PROTOCOL_DECISION,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Ranking determinism
+# ---------------------------------------------------------------------------
+
+
+def test_low_picks_before_medium() -> None:
+    snap = rp.collect_snapshot(
+        proposals_override=[
+            _proposed(
+                "p_zz_medium",
+                title="medium item",
+                summary="add observability metrics for monitoring",
+                proposal_type="observability_addition",
+                risk_class="MEDIUM",
+            ),
+            _proposed(
+                "p_aa_low",
+                title="low item",
+                summary="add observability metrics for monitoring",
+                proposal_type="observability_addition",
+                risk_class="LOW",
+            ),
+        ],
+        frozen_utc="2026-05-04T12:00:00Z",
+    )
+    # The MEDIUM item may filter out depending on protocol; if it
+    # passes, the LOW must rank ahead.
+    chosen = snap["chosen_next_up"]
+    assert chosen is not None
+    # The picked item must be from a LOW candidate (the
+    # MEDIUM-risk proposal cannot be picked ahead of a LOW one).
+    assert chosen["risk_class"] == "LOW"
+    assert chosen["proposal_id"] == "p_aa_low"
+
+
+def test_observability_picks_before_test_only() -> None:
+    snap = rp.collect_snapshot(
+        proposals_override=[
+            _proposed(
+                "p_zz_test",
+                title="add tests for foo",
+                summary="add tests covering monitoring observability gaps",
+                proposal_type="test_only",
+                risk_class="LOW",
+                affected_files=["tests/unit/test_foo.py"],
+            ),
+            _proposed(
+                "p_zz_obs",
+                title="add observability hook",
+                summary="add observability monitoring metric to the audit log",
+                proposal_type="observability_addition",
+                risk_class="LOW",
+                affected_files=["reporting/audit.py"],
+            ),
+        ],
+        frozen_utc="2026-05-04T12:00:00Z",
+    )
+    chosen = snap["chosen_next_up"]
+    assert chosen is not None
+    assert chosen["proposal_type"] == "observability_addition"
+
+
+def test_stable_proposal_id_tiebreak() -> None:
+    """When risk + type are equal, proposal_id ascending decides."""
+    base = dict(
+        title="add observability metric for monitoring",
+        summary="add observability metric for monitoring the audit log",
+        proposal_type="observability_addition",
+        risk_class="LOW",
+        affected_files=["reporting/m.py"],
+    )
+    snap = rp.collect_snapshot(
+        proposals_override=[
+            _proposed("p_zzzzzzzz", **base),
+            _proposed("p_aaaaaaaa", **base),
+            _proposed("p_mmmmmmmm", **base),
+        ],
+        frozen_utc="2026-05-04T12:00:00Z",
+    )
+    chosen = snap["chosen_next_up"]
+    assert chosen is not None
+    assert chosen["proposal_id"] == "p_aaaaaaaa"
+    # And the candidates list reflects the same order.
+    ids_in_order = [c["proposal_id"] for c in snap["candidates"]]
+    assert ids_in_order == ["p_aaaaaaaa", "p_mmmmmmmm", "p_zzzzzzzz"]
+
+
+def test_two_runs_produce_identical_chosen_next_up() -> None:
+    """Determinism: same input → byte-identical chosen_next_up
+    (modulo the generated_at_utc timestamp)."""
+    proposals = [
+        _proposed(
+            "p_aaaaaaaa",
+            title="first low observability item",
+            summary="add observability monitoring for the audit log",
+            proposal_type="observability_addition",
+            risk_class="LOW",
+            affected_files=["reporting/m.py"],
+        ),
+        _proposed(
+            "p_bbbbbbbb",
+            title="second low test item",
+            summary="add tests for observability monitoring",
+            proposal_type="test_only",
+            risk_class="LOW",
+            affected_files=["tests/unit/test_m.py"],
+        ),
+    ]
+    s1 = rp.collect_snapshot(
+        proposals_override=proposals, frozen_utc="2026-05-04T12:00:00Z"
+    )
+    s2 = rp.collect_snapshot(
+        proposals_override=proposals, frozen_utc="2026-05-04T12:00:00Z"
+    )
+    assert s1["chosen_next_up"] == s2["chosen_next_up"]
+    assert s1["candidates"] == s2["candidates"]
+    assert s1["filtered_out"] == s2["filtered_out"]
+
+
+# ---------------------------------------------------------------------------
+# Protocol delegation
+# ---------------------------------------------------------------------------
+
+
+def test_chosen_includes_protocol_plan_summary() -> None:
+    snap = rp.collect_snapshot(
+        proposals_override=[
+            _proposed(
+                "p_aaaaaaaa",
+                title="add observability metric",
+                summary="add observability monitoring for the audit log",
+                proposal_type="observability_addition",
+                affected_files=["reporting/audit.py"],
+            ),
+        ],
+        frozen_utc="2026-05-04T12:00:00Z",
+    )
+    chosen = snap["chosen_next_up"]
+    assert chosen is not None
+    plan = chosen["protocol_plan_summary"]
+    assert plan["decision"] == "allowed_read_only"
+    assert plan["implementation_allowed"] is True
+    assert plan["requires_human"] is False
+    # safe_to_execute is intentionally NOT duplicated into the
+    # plan_summary — see _plan_summary docstring. The digest's
+    # top-level safe_to_execute is the canonical source.
+    assert "safe_to_execute" not in plan
+    assert snap["safe_to_execute"] is False
+
+
+def test_protocol_module_version_recorded() -> None:
+    from reporting import roadmap_execution_protocol as _rep
+
+    snap = rp.collect_snapshot(
+        proposals_override=[],
+        frozen_utc="2026-05-04T12:00:00Z",
+    )
+    assert snap["policy"]["protocol_module_version"] == _rep.MODULE_VERSION
+
+
+# ---------------------------------------------------------------------------
+# Atomic write
+# ---------------------------------------------------------------------------
+
+
+def test_write_outputs_atomic_and_scoped(
+    isolated_digest_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    snap = rp.collect_snapshot(
+        proposals_override=[
+            _proposed(
+                "p_aaaaaaaa",
+                title="add observability metric",
+                summary="add observability monitoring for the audit log",
+                proposal_type="observability_addition",
+                affected_files=["reporting/audit.py"],
+            ),
+        ],
+        frozen_utc="2026-05-04T12:00:00Z",
+    )
+    paths = rp.write_outputs(snap)
+    base = isolated_digest_dir / "rp"
+    latest = base / "latest.json"
+    history = base / "history.jsonl"
+    assert latest.exists()
+    assert history.exists()
+    # Latest contains the same payload (sort_keys=True).
+    payload = json.loads(latest.read_text(encoding="utf-8"))
+    assert payload["chosen_next_up"]["proposal_id"] == "p_aaaaaaaa"
+    # The returned path map points at logs/-relative paths.
+    assert paths["latest"].endswith("latest.json")
+    # No stray .tmp left behind.
+    leftover_tmps = list(base.glob("*.tmp"))
+    assert leftover_tmps == [], f"leftover tmp files: {leftover_tmps}"
+
+
+def test_write_outputs_appends_one_history_line(
+    isolated_digest_dir: Path,
+) -> None:
+    snap = rp.collect_snapshot(
+        proposals_override=[
+            _proposed(
+                "p_aaaaaaaa",
+                title="o1",
+                summary="add observability metric for monitoring",
+                proposal_type="observability_addition",
+            ),
+        ],
+        frozen_utc="2026-05-04T12:00:00Z",
+    )
+    rp.write_outputs(snap)
+    rp.write_outputs(snap)
+    history = isolated_digest_dir / "rp" / "history.jsonl"
+    lines = [
+        ln for ln in history.read_text(encoding="utf-8").splitlines() if ln.strip()
+    ]
+    assert len(lines) == 2
+
+
+def test_no_input_artifact_mutated(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The prioritizer must not mutate logs/proposal_queue/latest.json
+    or any other input."""
+    src = tmp_path / "proposal_queue.json"
+    payload = {
+        "schema_version": 1,
+        "report_kind": "proposal_queue_digest",
+        "module_version": "v3.15.15.19",
+        "proposals": [_proposed("p_aaaaaaaa")],
+    }
+    src.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+    before = src.read_bytes()
+    monkeypatch.setattr(rp, "DIGEST_DIR_JSON", tmp_path / "rp")
+    snap = rp.collect_snapshot(
+        proposal_source_override=src,
+        frozen_utc="2026-05-04T12:00:00Z",
+    )
+    rp.write_outputs(snap)
+    after = src.read_bytes()
+    assert before == after
+
+
+# ---------------------------------------------------------------------------
+# Module-source guarantees
+# ---------------------------------------------------------------------------
+
+
+def test_module_source_no_subprocess() -> None:
+    src = MODULE_PATH.read_text(encoding="utf-8")
+    forbidden = (
+        "import subprocess",
+        "from subprocess",
+        "shell=True",
+        "os.system(",
+        "Popen(",
+        "import requests",
+        "from requests",
+        "import urllib.request",
+        "from urllib.request",
+        "import urllib3",
+    )
+    for tok in forbidden:
+        assert tok not in src, (
+            f"reporting/roadmap_priority.py contains forbidden token: "
+            f"{tok!r}"
+        )
+
+
+def test_module_source_no_gh_invocation() -> None:
+    """The prioritizer must never invoke ``gh``."""
+    src = MODULE_PATH.read_text(encoding="utf-8")
+    # Allow the word "gh" in comments / docstrings; deny actual
+    # invocation patterns. The cheapest check: forbid any
+    # subprocess-shaped call (already covered) plus the literal
+    # "gh CLI" / "gh.exe" command shapes that would only appear
+    # from a deliberate invocation.
+    forbidden = (
+        '["gh"',
+        "['gh'",
+        '"gh "',
+        "'gh '",
+    )
+    for tok in forbidden:
+        assert tok not in src, (
+            f"reporting/roadmap_priority.py contains gh-invocation token: "
+            f"{tok!r}"
+        )
+
+
+def test_module_source_no_branch_or_pr_creation() -> None:
+    """The prioritizer must never start a branch, open a PR, or
+    merge."""
+    src = MODULE_PATH.read_text(encoding="utf-8")
+    forbidden = (
+        "git checkout -b",
+        "git push",
+        "gh pr create",
+        "gh pr merge",
+    )
+    for tok in forbidden:
+        assert tok not in src, (
+            f"reporting/roadmap_priority.py contains forbidden action: "
+            f"{tok!r}"
+        )
+
+
+def test_safe_to_execute_field_is_hard_coded_false() -> None:
+    """At the source level the digest's safe_to_execute key must be
+    bound to literal False — never to a variable that could be
+    reassigned."""
+    src = MODULE_PATH.read_text(encoding="utf-8")
+    # The two builders both set safe_to_execute. Both must be
+    # literal False.
+    occurrences = re.findall(r'"safe_to_execute":\s*([A-Za-z]+)', src)
+    assert occurrences, "safe_to_execute key not found in module source"
+    assert all(v == "False" for v in occurrences), (
+        f"safe_to_execute is not hard-coded False everywhere: "
+        f"{occurrences!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI surface
+# ---------------------------------------------------------------------------
+
+
+def test_cli_only_dry_run_mode_allowed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """argparse should reject any --mode other than dry-run."""
+    with pytest.raises(SystemExit):
+        rp.main(["--mode", "execute-safe"])
+
+
+def test_cli_status_returns_not_available_when_missing(
+    isolated_digest_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    rc = rp.main(["--status"])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "not_available" in out


### PR DESCRIPTION
## Roadmap protocol context

Third roadmap item executed through `reporting.roadmap_execution_protocol`. Plan written to `logs/roadmap_execution_protocol/latest.json`.

| Field | Value |
| --- | --- |
| `item_id` | `r_v3_15_16_2` |
| `item_type` | `observability_addition` |
| `risk_class` | `LOW` |
| `decision` | `allowed_read_only` |
| `requires_human` | `false` |
| `implementation_allowed` | `true` |
| `safe_to_execute` | `false` |
| `status` | `proposed` |
| `proposed_release_id` | `v3.15.16.2` |

## Summary

Ship the canonical structured Roadmap v6.1 doc and a new read-only prioritizer that joins `proposal_queue` × `roadmap_execution_protocol` to project a deterministic `chosen_next_up` roadmap item into `logs/roadmap_priority/latest.json`. **Observability only — never starts work, never opens a branch, never opens a PR, never merges, never calls `gh`.**

## Architecture

```
docs/roadmap/qre_roadmap_v6_1.md  (NEW canonical structured doc)
        │
        ▼ existing parser
reporting/proposal_queue.py  →  logs/proposal_queue/latest.json
        │
        ▼ NEW
reporting/roadmap_priority.py
  - filters: status==proposed, risk!=HIGH, protocol decision==
    allowed_read_only, implementation_allowed, !requires_human
  - ranking: LOW first, observability/reporting/docs/test/ux/
    frontend/ci/dependency_cleanup/release_candidate descending,
    stable proposal_id tiebreak
  - safe_to_execute is hard-coded false at the digest level
  - atomic write to logs/roadmap_priority/
        │
        ▼
reporting/recurring_maintenance.py (one new job, 30-min cadence)
```

## Hard guarantees

- **No mutation surface.** Read-only digest, no new endpoints in this release.
- **No autonomous start.** The prioritizer never creates a branch, opens a PR, merges, or invokes `gh`. Pinned by source-text tests that forbid `subprocess`, `Popen`, `gh ` argv, `git checkout -b`, `git push`, `gh pr create`, `gh pr merge`.
- **`safe_to_execute` literal-False pin.** A regex test scans the module source and asserts every `"safe_to_execute":` key binds to `False` (no `bool(...)` projections).
- **Determinism.** Two runs on the same input produce a byte-identical `chosen_next_up`.
- **Risk classification delegated to the protocol.** No second source of truth.
- **Frozen hashes unchanged.** `research/research_latest.json` `4a567bd6...`, `research/strategy_matrix.csv` `ff15b8c4...`.
- **No `.claude/` change, no `dashboard/dashboard.py` change, no frozen contract change, no live/paper/shadow/risk path touch, no test weakening.**

## Diff scope

```
docs/governance/recurring_maintenance.md |  22 +
docs/governance/roadmap_priority.md      | 229 +++++++
docs/roadmap/qre_roadmap_v6_1.md         | 257 +++++++++
reporting/recurring_maintenance.py       |  46 +
reporting/roadmap_priority.py            | 719 +++++++++++++++
tests/unit/test_recurring_maintenance.py |  32 ++
tests/unit/test_roadmap_priority.py      | 618 ++++++++++++
7 files changed, 1922 insertions(+), 1 deletion(-)
```

All files within existing agent allowlists (`reporting/`, `docs/`, `tests/unit/` ↦ implementation-agent + test-agent).

## Validation gates

- [x] `python scripts/governance_lint.py` — OK (16 agents, 4 workflows)
- [x] `sha256sum research/research_latest.json research/strategy_matrix.csv` — frozen hashes unchanged
- [x] `pytest tests/smoke -q` — 14 passed
- [x] `pytest tests/unit/test_roadmap_priority.py tests/unit/test_recurring_maintenance.py tests/unit/test_vps_deploy_invariants.py tests/unit/test_proposal_queue.py tests/unit/test_approval_inbox.py -q` — **179/179 passed**
- [x] `npm --prefix frontend test -- --run` — 87/87 passed
- [x] `npm --prefix frontend run build` — OK
- [x] `python -m py_compile reporting/roadmap_priority.py reporting/recurring_maintenance.py` — OK
- [x] Live smoke: `python -m reporting.roadmap_priority --no-write` produces a valid digest with a chosen_next_up item from the live proposal queue

### Note on full-suite unit run

In the full `pytest tests/unit -q` sweep on this Windows workstation one test flaked: `tests/unit/test_run_research_observability.py::test_screening_timeout_is_persisted_and_run_continues`. Re-run in isolation: **passes**. The test lives in the research observability module, which this PR does not touch. The full-suite failure is a pre-existing test-interaction issue and CI on Linux runners has historically been green for it. CI will be the canonical gate.

## Test plan

- [ ] CI green on all required checks (Linux runners — no Windows flake interaction)
- [ ] After squash merge, the auto-deploy run continues to print `post-deploy: pr_lifecycle refresh ok` (v3.15.16.1 contract preserved)
- [ ] After the next `recurring_maintenance` tick on the VPS, `logs/roadmap_priority/latest.json` materialises with `final_recommendation in {ready_for_implementation, nothing_ready, not_available}` and `safe_to_execute: false`

## Out of scope (deferred)

- v3.15.16.3 — PWA next-up card (`/api/agent-control/next-up` GET endpoint + frontend card). Separate LOW PR.
- v3.15.16.4 — operator-authored governance-bootstrap to add `ops/systemd/` to an agent allowlist union, enabling a recurring-maintenance systemd timer for VPS-side ongoing freshness without manual cron steps.
- v3.15.17.x — push notifications. Operator-authored governance-bootstrap required first.

## Rollback plan

`git revert <merge_sha>` on a fresh branch; one-line revert PR; merge after CI green. The new recurring-maintenance job becomes a no-op if its source module is missing — and operators can also flip `enabled=false` on the new job in `logs/recurring_maintenance/state.json` to stop the periodic refresh without redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)