### PR TITLE
feat(v3.15.16.3): VPS recurring maintenance automation on deploy

### DIFF
--- a/docs/governance/recurring_maintenance.md
+++ b/docs/governance/recurring_maintenance.md
@@ -185,6 +185,46 @@ endpoint — no new dashboard.py wiring.
 | v3.15.15.25 | metrics dashboards on top of `history.jsonl` |
 | later | systemd service / cron wrapper around the loop driver |
 
+## Deploy-hook integration (v3.15.16.3)
+
+`scripts/deploy_vps_dashboard.sh` runs a **best-effort, non-fatal**
+post-deploy step that calls
+`python3 -m reporting.recurring_maintenance --run-due-once` on
+the VPS host after every successful merge to `main`. This drives
+the typed scheduler once per merge so every Agent-Control-facing
+read-only artifact (`logs/proposal_queue/latest.json`,
+`logs/approval_inbox/latest.json`,
+`logs/github_pr_lifecycle/latest.json`,
+`logs/roadmap_priority/latest.json`,
+`logs/workloop_runtime/latest.json`) is refreshed without manual
+SSH or operator commands.
+
+Hard guarantees re-asserted at this call site:
+
+* The deploy script does **not** pass
+  `--enable-dependabot-execute-safe`, so the only execute-capable
+  job (`dependabot_low_medium_execute_safe`) is classified
+  `blocked` with reason `missing_dependabot_cli_opt_in`. By
+  construction at this call site, the deploy hook can never
+  trigger a Dependabot mutation.
+* The step is wrapped in `if ...; then ... else ... fi` so a
+  non-zero exit is non-fatal — `set -e` does not trip on
+  commands inside `if` conditions, and the deploy still exits 0
+  even if the recurring tick fails.
+* Failures project into the existing approval-inbox surface
+  (`failed_automation` row on first failure,
+  `runtime_halt` row after 3 consecutive failures), which the
+  operator sees on the PWA without any new code.
+
+This is the **merge-driven cadence**. Between-merge ongoing
+freshness — running the same scheduler every 10–30 min via a
+systemd timer on the VPS — requires the operator-authored
+governance-bootstrap that adds `ops/systemd/*` to an agent's
+`allowed_roots` union, and is the explicit scope of a separate
+later release. See `docs/governance/vps_deploy.md`
+§"Post-deploy recurring maintenance refresh (v3.15.16.3)" for
+the deploy-hook contract in full.
+
 ## Roadmap priority projection (v3.15.16.2)
 
 A new closed job entry — `refresh_roadmap_priority` — runs the

--- a/docs/governance/vps_deploy.md
+++ b/docs/governance/vps_deploy.md
@@ -166,6 +166,85 @@ merges, never force-pushes. See
 `docs/governance/recurring_maintenance.md` for the full surface
 of read-only refresh jobs.
 
+## Post-deploy recurring maintenance refresh (v3.15.16.3)
+
+After the v3.15.16.1 `pr_lifecycle` step, the deploy script runs
+a **second best-effort, non-fatal** post-deploy step that drives
+the existing typed scheduler:
+
+```
+python3 -m reporting.recurring_maintenance --run-due-once
+```
+
+This refreshes every Agent-Control-facing read-only artifact in
+one tick:
+
+| job | refreshes |
+| --- | --- |
+| `refresh_workloop_runtime_once` | `logs/workloop_runtime/latest.json` |
+| `refresh_proposal_queue` | `logs/proposal_queue/latest.json` |
+| `refresh_approval_inbox` | `logs/approval_inbox/latest.json` |
+| `refresh_github_pr_lifecycle_dry_run` | `logs/github_pr_lifecycle/latest.json` (often `skipped` since the explicit v3.15.16.1 step just refreshed it) |
+| `refresh_roadmap_priority` | `logs/roadmap_priority/latest.json` |
+| `dependabot_low_medium_execute_safe` | **blocked** — the deploy script does NOT pass `--enable-dependabot-execute-safe`, so the scheduler classifies this job as `blocked` with reason `missing_dependabot_cli_opt_in`. By construction at this call site, the deploy hook can never trigger a Dependabot mutation. |
+
+The result: every PWA card on `/agent-control` that surfaces one
+of these artifacts (Status, Approval Inbox, Proposals, PRs, Next
+up) shows fresh data on the operator's next refresh after a
+merge. No manual SSH, no operator CLI command.
+
+### Hard guarantees re-asserted
+
+| guarantee | how it is enforced |
+| --- | --- |
+| Cannot fail the deploy | wrapped in `if ...; then ... else ... fi`. `set -e` does not trip on commands inside `if` conditions; a non-zero exit logs a single non-fatal line and the script still proceeds to `exit 0`. |
+| No GitHub mutation | the Dependabot execute-safe job stays `blocked` because the deploy script does not pass the CLI opt-in flag. The scheduler refuses execute-capable work at the call-site level — verifiable in the workflow log. |
+| No new free-form surface | the argv is literal: `python3 -m reporting.recurring_maintenance --run-due-once`. No positional argument forwarding. |
+| No new secret | the typed scheduler delegates to existing reporters (`gh` already authenticated on the VPS for the v3.15.16.1 hook). |
+| No agent restart | the step does not touch any compose service. |
+| Atomic writes | every refresher in the typed registry uses tmp + `os.replace`. |
+| Per-job timeout | 90 s wall-clock per job in the scheduler's supervisor; a hung downstream cannot stall the deploy beyond the bounded budget. |
+
+### Failure projection
+
+If any job fails or times out, the existing
+`reporting.approval_inbox` projection surfaces a
+`failed_automation` row (severity `high`) into the PWA's approval
+inbox card on the next refresh. Three consecutive failures of any
+single job surface a `runtime_halt` row (severity `critical`). The
+operator notices via the PWA without any new code.
+
+### Operator log lines
+
+Successful refresh:
+
+```
+[deploy_vps_dashboard] post-deploy: refresh recurring maintenance artifacts (best-effort)
+[deploy_vps_dashboard] post-deploy: recurring maintenance refresh ok
+```
+
+Failed refresh (non-fatal — deploy still exits 0):
+
+```
+[deploy_vps_dashboard] post-deploy: refresh recurring maintenance artifacts (best-effort)
+[deploy_vps_dashboard] post-deploy: recurring maintenance refresh failed or unavailable (non-fatal)
+```
+
+Persistent failures should be triaged via the PWA's approval
+inbox card, which surfaces the underlying job's status and
+reason.
+
+### What this is NOT
+
+* It is **not** a between-merge cadence. Between deploys, the
+  scheduler does not run on the VPS. Adding a between-merge
+  systemd timer is the explicit scope of a separate later
+  release that requires an operator-authored
+  governance-bootstrap (because `ops/systemd/*` is not in any
+  agent's `allowed_roots` union today).
+* It is **not** an automation surface. The deploy hook is a
+  one-shot tick driven by the merge event itself.
+
 ## Auth-aware healthcheck (v3.15.15.29.2)
 
 The deploy script's final step verifies that the dashboard is

--- a/docs/roadmap/qre_roadmap_v6_1.md
+++ b/docs/roadmap/qre_roadmap_v6_1.md
@@ -76,22 +76,28 @@ so the digest stays fresh on the VPS.
   `docs/governance/recurring_maintenance.md`
 * `risk_class`: LOW
 * `proposal_type`: observability_addition
-* `status`: proposed
+* `status`: done
 
-### v3.15.16.3 — PWA next-up card for the priority digest
+### v3.15.16.3 — VPS recurring maintenance automation on deploy
 
-Surface `logs/roadmap_priority/latest.json` to the operator via a
-new GET-only `/api/agent-control/next-up` endpoint and a read-only
-"Next up" card on the Agent Control PWA. No mutation, no
-auto-execution, no execute-safe wiring. The card displays the
-chosen-next-up item, its rationale, and its protocol plan summary.
+Append a best-effort, non-fatal post-deploy step to
+`scripts/deploy_vps_dashboard.sh` that runs the existing typed
+scheduler via `python3 -m reporting.recurring_maintenance
+--run-due-once` on the VPS host after every successful merge to
+`main`. Result: every Agent-Control-facing read-only artifact
+(`logs/proposal_queue/latest.json`,
+`logs/approval_inbox/latest.json`,
+`logs/github_pr_lifecycle/latest.json`,
+`logs/roadmap_priority/latest.json`,
+`logs/workloop_runtime/latest.json`) is refreshed automatically
+on every merge — no manual SSH, no operator command. The deploy
+script does not pass `--enable-dependabot-execute-safe`, so the
+only execute-capable job stays `blocked` by construction.
 
-* `affected_files`: `dashboard/api_agent_control.py`,
-  `frontend/src/api/agent_control.ts`,
-  `frontend/src/routes/AgentControl.tsx`,
-  `frontend/src/test/AgentControl.test.tsx`,
-  `tests/unit/test_dashboard_api_agent_control.py`,
-  `docs/governance/roadmap_priority.md`
+* `affected_files`: `scripts/deploy_vps_dashboard.sh`,
+  `docs/governance/vps_deploy.md`,
+  `docs/governance/recurring_maintenance.md`,
+  `docs/roadmap/qre_roadmap_v6_1.md`
 * `risk_class`: LOW
 * `proposal_type`: observability_addition
 * `status`: proposed
@@ -102,7 +108,9 @@ Operator-authored governance-bootstrap PR that adds `ops/systemd/`
 to an agent's allowlist union, then ships
 `ops/systemd/trading-agent-recurring-maintenance.{service,timer}`
 so the existing read-only scheduler runs on a fixed cadence on the
-VPS without any manual `cron` / `systemd` step.
+VPS for **between-merge** freshness without any manual `cron` /
+`systemd` step. v3.15.16.3 already covers the merge-driven
+cadence; v3.15.16.4 adds the continuous tick.
 
 * `affected_files`: `.claude/agents/...`,
   `docs/governance/no_touch_paths.md`,
@@ -112,6 +120,26 @@ VPS without any manual `cron` / `systemd` step.
   `docs/governance/vps_deploy.md`
 * `risk_class`: HIGH (governance-bootstrap; operator-authored)
 * `proposal_type`: governance_change
+* `status`: proposed
+
+### v3.15.16.5 — PWA next-up card for the priority digest
+
+Surface `logs/roadmap_priority/latest.json` to the operator via a
+new GET-only `/api/agent-control/next-up` endpoint and a read-only
+"Next up" card on the Agent Control PWA. No mutation, no
+auto-execution, no execute-safe wiring. The card displays the
+chosen-next-up item, its rationale, and its protocol plan summary.
+(Previously slotted as v3.15.16.3; renumbered after the
+recurring-maintenance deploy hook took priority.)
+
+* `affected_files`: `dashboard/api_agent_control.py`,
+  `frontend/src/api/agent_control.ts`,
+  `frontend/src/routes/AgentControl.tsx`,
+  `frontend/src/test/AgentControl.test.tsx`,
+  `tests/unit/test_dashboard_api_agent_control.py`,
+  `docs/governance/roadmap_priority.md`
+* `risk_class`: LOW
+* `proposal_type`: observability_addition
 * `status`: proposed
 
 ---

--- a/scripts/deploy_vps_dashboard.sh
+++ b/scripts/deploy_vps_dashboard.sh
@@ -225,4 +225,76 @@ else
     log "post-deploy: pr_lifecycle refresh failed or unavailable (non-fatal)"
 fi
 
+# v3.15.16.3 — drive the typed recurring_maintenance scheduler so
+# every Agent-Control-facing read-only artifact is fresh on the
+# VPS after every merge to main.
+#
+# Why this lives AFTER the v3.15.16.1 pr_lifecycle step:
+#   * The pr_lifecycle step has been a stable operator-visible
+#     signal since v3.15.16.1 ("post-deploy: pr_lifecycle refresh
+#     ok"). Removing it would be a breaking observability change.
+#     The typed scheduler also covers the pr_lifecycle job, but
+#     decides per-job whether each is "due" via
+#     next_run_after_utc — so when the explicit step has just
+#     refreshed the artifact, the scheduler usually classifies
+#     pr_lifecycle as `skipped` rather than re-running it.
+#
+# What it does:
+#   * Runs ``python3 -m reporting.recurring_maintenance
+#     --run-due-once`` on the VPS host. The typed scheduler
+#     iterates its closed job registry and refreshes every job
+#     whose next_run_after_utc has passed. Jobs covered:
+#       - refresh_workloop_runtime_once          → logs/workloop_runtime/latest.json
+#       - refresh_proposal_queue                 → logs/proposal_queue/latest.json
+#       - refresh_approval_inbox                 → logs/approval_inbox/latest.json
+#       - refresh_github_pr_lifecycle_dry_run    → logs/github_pr_lifecycle/latest.json
+#       - refresh_roadmap_priority               → logs/roadmap_priority/latest.json
+#       - dependabot_low_medium_execute_safe     → BLOCKED (see below)
+#   * The scheduler owns its own per-job 90 s wall-clock timeout,
+#     atomic state file under logs/recurring_maintenance/state.json,
+#     and approval-inbox failure projection — failures here surface
+#     in the existing PWA inbox card without any new code.
+#
+# Why this CANNOT mutate GitHub state:
+#   * The only execute-capable job in the registry is
+#     ``dependabot_low_medium_execute_safe``. The scheduler
+#     refuses to run it without ``--enable-dependabot-execute-safe``
+#     on the CLI. The deploy script intentionally does NOT pass
+#     that flag, so the job is classified ``blocked`` with reason
+#     ``missing_dependabot_cli_opt_in`` on every deploy.
+#   * Hard-coded by construction at this call site.
+#
+# Why host-side and not container-side:
+#   * Mirrors the v3.15.16.1 pr_lifecycle step: ``gh`` is
+#     authenticated on the VPS host (used by other operator work)
+#     but is not necessarily in the dashboard container image. The
+#     artifacts land at ``/root/trading-agent/logs/...`` on the
+#     host; the dashboard container's ``./logs:/app/logs``
+#     bind-mount makes them immediately readable inside the
+#     container as ``/app/logs/...`` — the path the Flask routes
+#     read from.
+#
+# Failure handling:
+#   * Wrapped in ``if ...; then ... else ... fi`` so ``set -e``
+#     does not trip on a non-zero exit. Failures log a single
+#     human-readable line; the deploy still exits 0.
+#   * ``command -v python3`` short-circuits on hosts that don't
+#     have a system ``python3``; the step degrades to a logged
+#     skip instead of an error.
+#
+# Hard guarantees re-asserted:
+#   * No mutation of GitHub state (Dependabot job stays blocked).
+#   * No new free-form command surface (literal argv only).
+#   * No new secret read or printed.
+#   * No agent service started or restarted.
+#   * No api_execute_safe_controls wiring.
+log "post-deploy: refresh recurring maintenance artifacts (best-effort)"
+if command -v python3 >/dev/null 2>&1 \
+        && python3 -m reporting.recurring_maintenance \
+            --run-due-once >/dev/null 2>&1; then
+    log "post-deploy: recurring maintenance refresh ok"
+else
+    log "post-deploy: recurring maintenance refresh failed or unavailable (non-fatal)"
+fi
+
 exit 0


### PR DESCRIPTION
## Roadmap protocol context

Fourth roadmap item executed through `reporting.roadmap_execution_protocol`. Plan written to `logs/roadmap_execution_protocol/latest.json`.

| Field | Value |
| --- | --- |
| `item_id` | `r_v3_15_16_3` |
| `item_type` | `observability_addition` |
| `risk_class` | `LOW` |
| `decision` | `allowed_read_only` |
| `requires_human` | `false` |
| `implementation_allowed` | `true` |
| `safe_to_execute` | `false` |
| `status` | `proposed` |
| `proposed_release_id` | `v3.15.16.3` |

## Problem

After v3.15.16.1, only `logs/github_pr_lifecycle/latest.json` was refreshed on the VPS automatically. The other Agent-Control-facing read-only artifacts (`logs/proposal_queue/latest.json`, `logs/approval_inbox/latest.json`, `logs/roadmap_priority/latest.json`, `logs/workloop_runtime/latest.json`) only existed wherever an operator had run their reporters by hand. `logs/` is gitignored, so a fresh checkout on the VPS had none of them — the PWA cards depending on those artifacts showed `not_available`.

## Fix

Append a **second best-effort, non-fatal** post-deploy step to `scripts/deploy_vps_dashboard.sh` that drives the existing typed scheduler:

```bash
log "post-deploy: refresh recurring maintenance artifacts (best-effort)"
if command -v python3 >/dev/null 2>&1 \
        && python3 -m reporting.recurring_maintenance \
            --run-due-once >/dev/null 2>&1; then
    log "post-deploy: recurring maintenance refresh ok"
else
    log "post-deploy: recurring maintenance refresh failed or unavailable (non-fatal)"
fi
```

Result: every Agent-Control-facing artifact is refreshed automatically on every merge to `main`. No manual SSH, no operator command. The PWA cards (Status, Approval Inbox, Proposals, PRs) populate on the operator's next refresh.

## Hard guarantees re-asserted at the call site

| Guarantee | Enforcement |
| --- | --- |
| Cannot fail the deploy | wrapped in `if`/`then`/`else`; `set -e` does not trip on commands inside `if` conditions |
| **No GitHub mutation** | the deploy script does NOT pass `--enable-dependabot-execute-safe`. The only execute-capable job (`dependabot_low_medium_execute_safe`) is classified `blocked` with reason `missing_dependabot_cli_opt_in`. By construction at this call site, the deploy hook can never trigger a Dependabot mutation. |
| No new free-form surface | literal argv only |
| No new secret | `gh` already authenticated for the v3.15.16.1 hook |
| No agent restart | does not touch any compose service |
| Per-job timeout | typed scheduler enforces 90 s wall-clock per job |
| Atomic write | every refresher uses tmp + `os.replace` |
| Failure projection | failed/blocked jobs surface `failed_automation` (or `runtime_halt` after 3 consecutive failures) into the existing PWA approval-inbox card |

## Why after the v3.15.16.1 step, not replacing it

The `post-deploy: pr_lifecycle refresh ok` log line is a stable operator signal since v3.15.16.1. Removing it would be a breaking observability change. The typed scheduler covers `pr_lifecycle` too, but with `next_run_after_utc=30 min`; on deploys within that window the scheduler classifies the job as `skipped` rather than re-running, so no actual duplicate work in the typical case.

## Diff scope

```
docs/governance/recurring_maintenance.md |  40 +++
docs/governance/vps_deploy.md            |  79 +++++
docs/roadmap/qre_roadmap_v6_1.md         |  58 +++-
scripts/deploy_vps_dashboard.sh          |  72 ++++
4 files changed, 234 insertions(+), 15 deletions(-)
```

All within existing agent allowlists (`scripts/deploy_vps_dashboard.sh` ↦ deployment-implementation-agent; `docs/**` ↦ implementation-agent + deployment-implementation-agent).

## Validation gates

- [x] `python scripts/governance_lint.py` — OK (16 agents, 4 workflows)
- [x] `sha256sum research/research_latest.json research/strategy_matrix.csv` — frozen hashes unchanged (`4a567bd6...`, `ff15b8c4...`)
- [x] `pytest tests/unit/test_vps_deploy_invariants.py -q` — **35/35 passed** (every existing invariant still green: no-curl-fail / no-up-build / no-IP-literal / agent-not-running / etc.)
- [x] `pytest tests/smoke -q` — 14 passed
- [x] `pytest tests/unit -q` — **3210 passed, 3 skipped, 0 failed**
- [x] `npm --prefix frontend test -- --run` — 87/87 passed
- [x] `npm --prefix frontend run build` — OK
- [x] `bash -n scripts/deploy_vps_dashboard.sh` — syntax OK

## Test plan

- [ ] CI green on all required checks
- [ ] After squash merge, the auto-deploy run shows BOTH operator log lines:
  - `[deploy_vps_dashboard] post-deploy: refresh recurring maintenance artifacts (best-effort)` (NEW)
  - `[deploy_vps_dashboard] post-deploy: recurring maintenance refresh ok` (NEW)
- [ ] All five artifacts (`logs/proposal_queue/latest.json`, `logs/approval_inbox/latest.json`, `logs/github_pr_lifecycle/latest.json`, `logs/roadmap_priority/latest.json`, `logs/workloop_runtime/latest.json`) updated on the VPS to `mtime ≈ deploy time`
- [ ] PWA cards (Status / Approval Inbox / Proposals / PRs) populate on the operator's next refresh — verified through the GET-only endpoints already wired since v3.15.15.x; no SSH required

## Out of scope (deferred)

- **v3.15.16.4** — operator-authored governance-bootstrap that adds `ops/systemd/` to an agent's allowlist union, then ships `ops/systemd/trading-agent-recurring-maintenance.{service,timer}` for **between-merge** ongoing freshness. v3.15.16.3 covers the merge-driven cadence; v3.15.16.4 adds the continuous tick.
- **v3.15.16.5** — PWA "Next up" card surfacing `roadmap_priority/latest.json` (was previously slotted as v3.15.16.3 before the operator priority shift).
- **v3.15.17.x** — push notifications. Operator-authored governance-bootstrap required first.

## Rollback plan

`git revert <merge_sha>` on a fresh branch; one-line revert PR; merge after CI green. The only effect: the deploy stops calling the new step. The typed scheduler itself remains untouched and can still be invoked manually by the operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)