### PR TITLE
feat(v3.15.16.5): Agent Control PWA Next-Up card surfacing roadmap_priority

### DIFF
--- a/dashboard/api_roadmap_priority.py
+++ b/dashboard/api_roadmap_priority.py
@@ -1,0 +1,260 @@
+"""Read-only Flask route for the v3.15.16.5 PWA Next-Up card.
+
+Single GET endpoint: ``/api/agent-control/next-up``. Reads the
+gitignored digest at ``logs/roadmap_priority/latest.json``
+(produced by ``reporting.roadmap_priority`` and refreshed on every
+merge by the v3.15.16.3 deploy hook) and returns a
+``not_available`` envelope when the artifact is missing or
+malformed.
+
+The endpoint never copies the full ``candidates[]`` /
+``filtered_out[]`` arrays — it copies counts only, plus the
+``chosen_next_up`` record. The full lists stay in the underlying
+artifact for operators who need them; the PWA card stays small
+and mobile-readable.
+
+Hard guarantees (enforced by code AND tests)
+--------------------------------------------
+
+* GET only. No POST / PUT / PATCH / DELETE handler is registered.
+* Never executes a CLI subprocess, never invokes ``gh`` or ``git``.
+* Never reads ``config/config.yaml``, ``state/*.secret``, ``.env``,
+  or any other path on the no-touch read-deny list.
+* Missing / malformed / unreadable / non-object artifacts →
+  ``{"status": "not_available", "reason": ...}``. ``ok`` requires
+  positive evidence.
+* The response payload is run through ``assert_no_secrets`` from
+  ``reporting.agent_audit_summary`` before it leaves the server,
+  so any credential-shaped string in the underlying digest causes
+  the request to fail loudly rather than leak.
+* The digest's ``safe_to_execute`` field is hard-coded ``false``
+  by ``reporting.roadmap_priority``; the boundary projection here
+  surfaces it verbatim.
+
+Wiring
+------
+
+Same pattern as ``dashboard.api_proposal_queue`` and
+``dashboard.api_approval_inbox``. To activate the route,
+``dashboard/dashboard.py`` needs two lines::
+
+    from dashboard.api_roadmap_priority import register_roadmap_priority_routes
+    register_roadmap_priority_routes(app)
+
+The operator authorized that wiring for v3.15.16.5, but
+``dashboard/dashboard.py`` is on the no-touch list and the
+``deny_no_touch`` hook blocks the write at the file level
+regardless of in-chat approval. The wiring therefore lands as a
+separate one-shot operator-authored governance-bootstrap PR after
+this module merges — the same shape that v3.15.15.21 used to wire
+``register_agent_control_routes`` / ``register_proposal_queue_routes``
+/ ``register_approval_inbox_routes``. Until that bootstrap lands,
+``/api/agent-control/next-up`` returns 404; the PWA frontend
+collapses that to a ``not_available`` envelope and the Next-Up
+card renders its empty state. Nothing crashes, nothing leaks.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from flask import Flask, jsonify
+
+from reporting.agent_audit_summary import assert_no_secrets
+
+REPO_ROOT: Path = Path(__file__).resolve().parent.parent
+LOGS_DIR: Path = REPO_ROOT / "logs"
+ROADMAP_PRIORITY_LATEST: Path = (
+    LOGS_DIR / "roadmap_priority" / "latest.json"
+)
+
+
+def _read_json_artifact(path: Path) -> dict[str, Any]:
+    """Read a JSON artifact and return one of:
+
+    * ``{"status": "ok", "data": <parsed dict>}`` on success;
+    * ``{"status": "not_available", "reason": "missing"}`` when the
+      file does not exist;
+    * ``{"status": "not_available", "reason": "malformed: <error>"}``
+      when the file exists but is not valid JSON;
+    * ``{"status": "not_available", "reason": "unreadable: <error>"}``
+      on filesystem error;
+    * ``{"status": "not_available", "reason": "malformed: not_an_object"}``
+      when the parsed payload is not a dict.
+
+    Always returns a dict (never raises).
+    """
+    if not path.exists():
+        return {"status": "not_available", "reason": "missing"}
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as e:
+        return {
+            "status": "not_available",
+            "reason": f"unreadable: {type(e).__name__}",
+        }
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as e:
+        return {
+            "status": "not_available",
+            "reason": f"malformed: {type(e).__name__}",
+        }
+    if not isinstance(data, dict):
+        return {"status": "not_available", "reason": "malformed: not_an_object"}
+    return {"status": "ok", "data": data}
+
+
+def _project_chosen_next_up(chosen: Any) -> dict[str, Any] | None:
+    """Project ``chosen_next_up`` to the bounded subset the PWA
+    card renders. Anything not in this allowlist is dropped at the
+    boundary so future digest fields cannot leak through to the
+    operator surface without a deliberate code change here."""
+    if not isinstance(chosen, dict):
+        return None
+    plan_in = chosen.get("protocol_plan_summary")
+    plan_out: dict[str, Any] = {}
+    if isinstance(plan_in, dict):
+        for k in (
+            "decision",
+            "implementation_allowed",
+            "requires_human",
+            "risk_class",
+            "item_type",
+            "proposed_branch",
+            "proposed_release_id",
+        ):
+            if k in plan_in:
+                plan_out[k] = plan_in[k]
+        # Lists: keep, but cap at a small number to keep payload tiny.
+        rt_in = plan_in.get("required_tests")
+        if isinstance(rt_in, list):
+            plan_out["required_tests"] = [str(x) for x in rt_in[:8]]
+        ea_in = plan_in.get("expected_artifacts")
+        if isinstance(ea_in, list):
+            plan_out["expected_artifacts"] = [str(x) for x in ea_in[:8]]
+    return {
+        "proposal_id": chosen.get("proposal_id"),
+        "title": chosen.get("title"),
+        "summary": chosen.get("summary"),
+        "proposal_type": chosen.get("proposal_type"),
+        "risk_class": chosen.get("risk_class"),
+        "rationale": chosen.get("rationale"),
+        "protocol_plan_summary": plan_out,
+    }
+
+
+def _project_counts(counts: Any) -> dict[str, Any]:
+    """Project counts to a stable, small-shape dict. Defensive
+    against the upstream digest evolving."""
+    if not isinstance(counts, dict):
+        return {
+            "proposals_total": 0,
+            "eligible_total": 0,
+            "filtered_out_total": 0,
+            "filtered_out_by_reason": {},
+        }
+    out: dict[str, Any] = {}
+    for k in ("proposals_total", "eligible_total", "filtered_out_total"):
+        v = counts.get(k)
+        out[k] = int(v) if isinstance(v, int) else 0
+    by_reason = counts.get("filtered_out_by_reason")
+    if isinstance(by_reason, dict):
+        out["filtered_out_by_reason"] = {
+            str(k): int(v) for k, v in by_reason.items() if isinstance(v, int)
+        }
+    else:
+        out["filtered_out_by_reason"] = {}
+    return out
+
+
+def _derive_needs_human(
+    final_recommendation: str | None, chosen: dict[str, Any] | None
+) -> bool:
+    """Deterministic ``needs_human`` projection.
+
+    True when:
+      * the digest is unavailable / unsafe, OR
+      * the chosen next-up's protocol plan reports requires_human=True
+        (defensive — the prioritizer filters such candidates out, but
+        a future protocol classifier might emit a value the
+        prioritizer did not anticipate).
+
+    Otherwise False.
+    """
+    if final_recommendation in ("not_available", "unsafe"):
+        return True
+    if isinstance(chosen, dict):
+        plan = chosen.get("protocol_plan_summary")
+        if isinstance(plan, dict) and bool(plan.get("requires_human")):
+            return True
+    return False
+
+
+def _next_up_payload() -> dict[str, Any]:
+    """Build the bounded ``/api/agent-control/next-up`` envelope."""
+    artifact = _read_json_artifact(ROADMAP_PRIORITY_LATEST)
+    if artifact.get("status") != "ok":
+        return {
+            "kind": "agent_control_next_up",
+            "schema_version": 1,
+            "status": "not_available",
+            "reason": artifact.get("reason", "unknown"),
+            "artifact_path": "logs/roadmap_priority/latest.json",
+        }
+    raw = artifact.get("data") or {}
+    chosen_projected = _project_chosen_next_up(raw.get("chosen_next_up"))
+    final_recommendation = raw.get("final_recommendation")
+    if not isinstance(final_recommendation, str):
+        final_recommendation = "unknown"
+    return {
+        "kind": "agent_control_next_up",
+        "schema_version": 1,
+        "status": "ok",
+        "data": {
+            "module_version": raw.get("module_version"),
+            "generated_at_utc": raw.get("generated_at_utc"),
+            "final_recommendation": final_recommendation,
+            "safe_to_execute": False,
+            "chosen_next_up": chosen_projected,
+            "counts": _project_counts(raw.get("counts")),
+            "needs_human": _derive_needs_human(
+                final_recommendation, chosen_projected
+            ),
+        },
+        "artifact_path": "logs/roadmap_priority/latest.json",
+    }
+
+
+def _safe_jsonify(payload: dict[str, Any]):
+    assert_no_secrets(payload)
+    return jsonify(payload)
+
+
+_ROADMAP_PRIORITY_ROUTES: tuple[tuple[str, Any], ...] = (
+    ("/api/agent-control/next-up", _next_up_payload),
+)
+
+
+def register_roadmap_priority_routes(app: Flask) -> None:
+    """Mount the read-only roadmap-priority route on ``app``.
+
+    Uses unique endpoint names so re-registering on the same app
+    doesn't collide with other agent-control modules."""
+    for path, handler in _ROADMAP_PRIORITY_ROUTES:
+        endpoint = "agent_control_next_up"
+
+        def _view(_h=handler):  # type: ignore[no-untyped-def]
+            return _safe_jsonify(_h())
+
+        app.add_url_rule(
+            path,
+            endpoint=endpoint,
+            view_func=_view,
+            methods=["GET"],
+        )
+
+
+__all__ = ["register_roadmap_priority_routes"]

--- a/docs/governance/roadmap_priority.md
+++ b/docs/governance/roadmap_priority.md
@@ -174,6 +174,58 @@ this release projects, the operator decides.
 5. If `final_recommendation == "not_available"`, refresh the
    proposal queue first (step 1) and re-run.
 
+## PWA card (v3.15.16.5)
+
+The Agent Control PWA's **Inbox** tab gains a "Next up" card
+backed by `dashboard/api_roadmap_priority.py` and the new GET-only
+endpoint `/api/agent-control/next-up`. The endpoint is a strictly
+bounded projection over `logs/roadmap_priority/latest.json`:
+
+| field | source | shape |
+| --- | --- | --- |
+| `final_recommendation` | digest top-level | `"ready_for_implementation"` / `"nothing_ready"` / `"not_available"` |
+| `safe_to_execute` | hard-coded `false` at the boundary | `false` (defensive — even if a corrupted upstream digest sets this to `true`, the boundary projection drops it back to `false`) |
+| `chosen_next_up.{proposal_id,title,summary,proposal_type,risk_class,rationale}` | digest | bounded copy |
+| `chosen_next_up.protocol_plan_summary.{decision,implementation_allowed,requires_human,risk_class,item_type,proposed_branch,proposed_release_id,required_tests,expected_artifacts}` | digest | bounded copy; the lists are capped at 8 elements each |
+| `counts.{proposals_total,eligible_total,filtered_out_total,filtered_out_by_reason}` | digest | bounded copy |
+| `needs_human` | derived | `true` when `final_recommendation in {"not_available","unsafe"}` OR the chosen item's protocol plan reports `requires_human=true` |
+
+The full `candidates[]` and `filtered_out[]` arrays are NOT
+projected to the PWA card. They stay in the artifact for
+operators who need them.
+
+The card never adds an action button. The only interactive
+element on the Agent Control surface remains the global "Vernieuw"
+refresh button. Operator decisions remain manual: read the card,
+optionally re-run `python -m reporting.roadmap_execution_protocol
+--plan-item <item> --dry-run` for the full record, then start
+work by hand.
+
+### Wiring shape (operator note)
+
+`dashboard/dashboard.py` is on the no-touch list and the
+`deny_no_touch` hook blocks the wiring write at the file level
+even when the operator authorises it in chat. The two-line edit:
+
+```python
+from dashboard.api_roadmap_priority import register_roadmap_priority_routes
+register_roadmap_priority_routes(app)
+```
+
+therefore lands as a separate one-shot operator-authored
+governance-bootstrap PR after v3.15.16.5 merges — same shape that
+v3.15.15.21 used to wire `register_agent_control_routes` /
+`register_proposal_queue_routes` / `register_approval_inbox_routes`.
+
+Until that bootstrap lands:
+
+* `/api/agent-control/next-up` returns 404 from the dashboard;
+* the PWA's frontend client collapses 404 into the standard
+  `not_available` envelope;
+* the Next-Up card renders its `next-up-not-available` empty
+  state;
+* nothing crashes, nothing leaks.
+
 ## What this module is NOT
 
 * It is **not** an autonomous starter. It does not create a

--- a/docs/roadmap/qre_roadmap_v6_1.md
+++ b/docs/roadmap/qre_roadmap_v6_1.md
@@ -100,7 +100,7 @@ only execute-capable job stays `blocked` by construction.
   `docs/roadmap/qre_roadmap_v6_1.md`
 * `risk_class`: LOW
 * `proposal_type`: observability_addition
-* `status`: proposed
+* `status`: done
 
 ### v3.15.16.4 — Recurring-maintenance systemd timer (governance-bootstrap-gated)
 
@@ -122,22 +122,33 @@ cadence; v3.15.16.4 adds the continuous tick.
 * `proposal_type`: governance_change
 * `status`: proposed
 
-### v3.15.16.5 — PWA next-up card for the priority digest
+### v3.15.16.5 — PWA Next-Up card surfacing roadmap_priority digest
 
-Surface `logs/roadmap_priority/latest.json` to the operator via a
-new GET-only `/api/agent-control/next-up` endpoint and a read-only
-"Next up" card on the Agent Control PWA. No mutation, no
-auto-execution, no execute-safe wiring. The card displays the
-chosen-next-up item, its rationale, and its protocol plan summary.
-(Previously slotted as v3.15.16.3; renumbered after the
-recurring-maintenance deploy hook took priority.)
+Add a new GET-only endpoint `/api/agent-control/next-up` backed
+by `dashboard/api_roadmap_priority.py` and a read-only "Next up"
+card on the Agent Control PWA's Inbox tab. The card surfaces
+`logs/roadmap_priority/latest.json`: chosen_next_up,
+final_recommendation pill, rationale, protocol_plan_summary,
+filtered_out counts, needs_human indicator. Pure observability;
+no action buttons; never wires `api_execute_safe_controls`.
 
-* `affected_files`: `dashboard/api_agent_control.py`,
+The two-line `dashboard/dashboard.py` wiring required to activate
+the route is **deferred to a separate operator-authored
+governance-bootstrap PR** because the `deny_no_touch` hook blocks
+the file-level write to `dashboard/dashboard.py` regardless of
+in-chat operator approval — same shape that v3.15.15.21 used to
+land the previous batch of agent-control wiring lines. Until that
+bootstrap merges, the endpoint returns 404 and the PWA card
+renders its `next-up-not-available` empty state.
+
+* `affected_files`: `dashboard/api_roadmap_priority.py`,
   `frontend/src/api/agent_control.ts`,
   `frontend/src/routes/AgentControl.tsx`,
   `frontend/src/test/AgentControl.test.tsx`,
-  `tests/unit/test_dashboard_api_agent_control.py`,
-  `docs/governance/roadmap_priority.md`
+  `tests/unit/test_dashboard_api_roadmap_priority.py`,
+  `tests/unit/test_observability_security_invariants.py`,
+  `docs/governance/roadmap_priority.md`,
+  `docs/roadmap/qre_roadmap_v6_1.md`
 * `risk_class`: LOW
 * `proposal_type`: observability_addition
 * `status`: proposed

--- a/frontend/src/api/agent_control.ts
+++ b/frontend/src/api/agent_control.ts
@@ -208,6 +208,53 @@ export interface AgentControlApprovalInbox {
   artifact_path: string;
 }
 
+// v3.15.16.5 — read-only Next-Up surface backed by
+// reporting.roadmap_priority's chosen_next_up projection.
+// Strictly bounded subset of logs/roadmap_priority/latest.json;
+// the full candidates / filtered_out arrays stay in the file. The
+// PWA card surfaces the chosen item, recommendation pill,
+// rationale, protocol plan summary, backlog counts, and a derived
+// needs_human boolean. No mutation surface; no action verbs.
+export interface AgentControlNextUp {
+  kind: "agent_control_next_up";
+  schema_version: number;
+  status: "ok" | "not_available";
+  reason?: string;
+  data?: {
+    module_version?: string;
+    generated_at_utc?: string;
+    final_recommendation: string;
+    safe_to_execute: boolean;
+    chosen_next_up: {
+      proposal_id?: string;
+      title?: string;
+      summary?: string;
+      proposal_type?: string;
+      risk_class?: string;
+      rationale?: string;
+      protocol_plan_summary?: {
+        decision?: string;
+        implementation_allowed?: boolean;
+        requires_human?: boolean;
+        risk_class?: string;
+        item_type?: string;
+        proposed_branch?: string;
+        proposed_release_id?: string;
+        required_tests?: string[];
+        expected_artifacts?: string[];
+      };
+    } | null;
+    counts: {
+      proposals_total?: number;
+      eligible_total?: number;
+      filtered_out_total?: number;
+      filtered_out_by_reason?: Record<string, number>;
+    };
+    needs_human: boolean;
+  };
+  artifact_path?: string;
+}
+
 export interface AgentControlExecuteSafe {
   kind: "agent_control_execute_safe";
   schema_version: number;
@@ -273,4 +320,5 @@ export const agentControlApi = {
     getJson<AgentControlApprovalInbox>(`${BASE}/approval-inbox`),
   executeSafe: () =>
     getJson<AgentControlExecuteSafe>(`${BASE}/execute-safe`),
+  nextUp: () => getJson<AgentControlNextUp>(`${BASE}/next-up`),
 };

--- a/frontend/src/routes/AgentControl.tsx
+++ b/frontend/src/routes/AgentControl.tsx
@@ -35,6 +35,7 @@ import {
   type AgentControlActivity,
   type AgentControlApprovalInbox,
   type AgentControlExecuteSafe,
+  type AgentControlNextUp,
   type AgentControlNotifications,
   type AgentControlPRLifecycle,
   type AgentControlProposals,
@@ -607,6 +608,151 @@ function ProposalsCard({
   );
 }
 
+// --- Card: deterministic priority projection (v3.15.16.5) ---
+// Read-only surface over logs/roadmap_priority/latest.json. Renders
+// chosen_next_up + final_recommendation pill + rationale + protocol
+// plan summary + backlog counts + needs_human indicator. NEVER adds
+// an action button; the operator decides whether to act on the
+// recommendation by hand.
+function NextUpCard({
+  payload,
+}: {
+  payload: AgentControlNextUp | null;
+}) {
+  if (!payload) {
+    return (
+      <Card title="Next up" subtitle="deterministic priority projection">
+        <p className="agent-control-card__empty" data-testid="next-up-loading">
+          Laden…
+        </p>
+      </Card>
+    );
+  }
+  if (payload.status !== "ok" || !payload.data) {
+    return (
+      <Card title="Next up" subtitle="deterministic priority projection">
+        <p
+          className="agent-control-card__empty"
+          data-testid="next-up-not-available"
+        >
+          {payload.reason ?? "not_available"} —{" "}
+          <code>{payload.artifact_path ?? "logs/roadmap_priority/latest.json"}</code>
+        </p>
+      </Card>
+    );
+  }
+  const data = payload.data;
+  const chosen = data.chosen_next_up;
+  const counts = data.counts ?? {};
+  const recommendation = String(data.final_recommendation ?? "unknown");
+  const needsHuman = Boolean(data.needs_human);
+  const recPill: "ok" | "warn" | "danger" | "unknown" =
+    recommendation === "ready_for_implementation"
+      ? "ok"
+      : recommendation === "nothing_ready"
+        ? "warn"
+        : recommendation === "not_available"
+          ? "unknown"
+          : "danger";
+  const proposalsTotal = Number(counts.proposals_total ?? 0);
+  const eligibleTotal = Number(counts.eligible_total ?? 0);
+  const filteredTotal = Number(counts.filtered_out_total ?? 0);
+  return (
+    <Card title="Next up" subtitle="deterministic priority projection">
+      <div className="agent-control-card__row">
+        <dt>recommendation</dt>
+        <dd data-testid="next-up-recommendation">
+          {recommendation} <StatusPill state={recPill} />
+        </dd>
+      </div>
+      <div className="agent-control-card__row">
+        <dt>needs_human</dt>
+        <dd data-testid="next-up-needs-human">{needsHuman ? "yes" : "no"}</dd>
+      </div>
+      {chosen ? (
+        <>
+          <div className="agent-control-card__row">
+            <dt>{String(chosen.proposal_id ?? "?")}</dt>
+            <dd data-testid="next-up-title">
+              {String(chosen.title ?? "(no title)")}
+            </dd>
+          </div>
+          <div className="agent-control-card__row">
+            <dt>type</dt>
+            <dd data-testid="next-up-type">
+              {String(chosen.proposal_type ?? "unknown")} ·{" "}
+              {String(chosen.risk_class ?? "?")}
+            </dd>
+          </div>
+          {chosen.rationale ? (
+            <div className="agent-control-card__row">
+              <dt>rationale</dt>
+              <dd data-testid="next-up-rationale">{String(chosen.rationale)}</dd>
+            </div>
+          ) : null}
+          {chosen.protocol_plan_summary ? (
+            <>
+              <div className="agent-control-card__row">
+                <dt>decision</dt>
+                <dd data-testid="next-up-decision">
+                  {String(
+                    chosen.protocol_plan_summary.decision ?? "unknown",
+                  )}
+                </dd>
+              </div>
+              <div className="agent-control-card__row">
+                <dt>impl_allowed</dt>
+                <dd>
+                  {chosen.protocol_plan_summary.implementation_allowed
+                    ? "yes"
+                    : "no"}
+                </dd>
+              </div>
+              <div className="agent-control-card__row">
+                <dt>requires_human</dt>
+                <dd>
+                  {chosen.protocol_plan_summary.requires_human ? "yes" : "no"}
+                </dd>
+              </div>
+              {chosen.protocol_plan_summary.proposed_branch ? (
+                <div className="agent-control-card__row">
+                  <dt>branch</dt>
+                  <dd data-testid="next-up-branch">
+                    <code>{String(chosen.protocol_plan_summary.proposed_branch)}</code>
+                  </dd>
+                </div>
+              ) : null}
+              {chosen.protocol_plan_summary.proposed_release_id ? (
+                <div className="agent-control-card__row">
+                  <dt>release</dt>
+                  <dd>
+                    {String(chosen.protocol_plan_summary.proposed_release_id)}
+                  </dd>
+                </div>
+              ) : null}
+            </>
+          ) : null}
+        </>
+      ) : (
+        <p
+          className="agent-control-card__empty"
+          data-testid="next-up-no-candidate"
+        >
+          Geen geschikte kandidaat — {filteredTotal} gefilterd van{" "}
+          {proposalsTotal}.
+        </p>
+      )}
+      <div className="agent-control-card__row">
+        <dt>backlog</dt>
+        <dd data-testid="next-up-counts">
+          {proposalsTotal} proposals · {eligibleTotal} eligible ·{" "}
+          {filteredTotal} filtered
+        </dd>
+      </div>
+    </Card>
+  );
+}
+
 // --- Card: approval / exception inbox (v3.15.15.20) ---
 function InboxCard({
   payload,
@@ -944,13 +1090,14 @@ export function AgentControl() {
   const [inbox, setInbox] = useState<AgentControlApprovalInbox | null>(null);
   const [executeSafe, setExecuteSafe] =
     useState<AgentControlExecuteSafe | null>(null);
+  const [nextUp, setNextUp] = useState<AgentControlNextUp | null>(null);
   const [loading, setLoading] = useState<boolean>(false);
   const [refreshedAt, setRefreshedAt] = useState<string>("");
   const [activeSection, setActiveSection] = useState<SectionId>("overview");
 
   const loadAll = useCallback(async () => {
     setLoading(true);
-    const [s, a, w, p, n, q, i, e] = await Promise.all([
+    const [s, a, w, p, n, q, i, e, nu] = await Promise.all([
       agentControlApi.status(),
       agentControlApi.activity(),
       agentControlApi.workloop(),
@@ -959,6 +1106,7 @@ export function AgentControl() {
       agentControlApi.proposals(),
       agentControlApi.approvalInbox(),
       agentControlApi.executeSafe(),
+      agentControlApi.nextUp(),
     ]);
     setStatus(s);
     setActivity(a);
@@ -968,6 +1116,7 @@ export function AgentControl() {
     setProposals(q);
     setInbox(i);
     setExecuteSafe(e);
+    setNextUp(nu);
     setRefreshedAt(new Date().toISOString().replace("T", " ").slice(0, 19));
     setLoading(false);
   }, []);
@@ -1052,6 +1201,7 @@ export function AgentControl() {
           active={activeSection === "inbox"}
           ariaLabel="Operator inbox and proposal queue"
         >
+          <NextUpCard payload={nextUp} />
           <InboxCard payload={inbox} />
           <ProposalsCard payload={proposals} />
         </Section>

--- a/frontend/src/test/AgentControl.test.tsx
+++ b/frontend/src/test/AgentControl.test.tsx
@@ -271,6 +271,71 @@ const okExecuteSafeBody = {
   },
 };
 
+// v3.15.16.5 — Next-Up card test fixtures.
+const okNextUpReadyBody = {
+  kind: "agent_control_next_up",
+  schema_version: 1,
+  status: "ok",
+  data: {
+    module_version: "v3.15.16.2",
+    generated_at_utc: "2026-05-05T08:00:00Z",
+    final_recommendation: "ready_for_implementation",
+    safe_to_execute: false,
+    chosen_next_up: {
+      proposal_id: "p_aaaaaaaa",
+      title: "add observability metric",
+      summary: "add observability monitoring for the audit log",
+      proposal_type: "observability_addition",
+      risk_class: "LOW",
+      rationale:
+        "risk LOW, type observability_addition, protocol decision allowed_read_only",
+      protocol_plan_summary: {
+        decision: "allowed_read_only",
+        implementation_allowed: true,
+        requires_human: false,
+        risk_class: "LOW",
+        item_type: "observability_addition",
+        proposed_branch: "fix/v3-15-16-x-p-aaaaaaaa-add-observability-metric",
+        proposed_release_id: "v3.15.16.x",
+        required_tests: ["scripts/governance_lint.py", "tests/smoke"],
+        expected_artifacts: ["docs/governance/<doc>.md"],
+      },
+    },
+    counts: {
+      proposals_total: 206,
+      eligible_total: 4,
+      filtered_out_total: 202,
+      filtered_out_by_reason: {
+        risk_high_excluded: 12,
+        protocol_decision_not_allowed_read_only: 180,
+      },
+    },
+    needs_human: false,
+  },
+  artifact_path: "logs/roadmap_priority/latest.json",
+};
+
+const okNextUpNothingReadyBody = {
+  kind: "agent_control_next_up",
+  schema_version: 1,
+  status: "ok",
+  data: {
+    module_version: "v3.15.16.2",
+    generated_at_utc: "2026-05-05T08:00:00Z",
+    final_recommendation: "nothing_ready",
+    safe_to_execute: false,
+    chosen_next_up: null,
+    counts: {
+      proposals_total: 12,
+      eligible_total: 0,
+      filtered_out_total: 12,
+      filtered_out_by_reason: { status_not_proposed: 12 },
+    },
+    needs_human: false,
+  },
+  artifact_path: "logs/roadmap_priority/latest.json",
+};
+
 const okInboxBody = {
   kind: "agent_control_approval_inbox",
   schema_version: 1,
@@ -501,6 +566,117 @@ describe("AgentControl — approval inbox card", () => {
     ).not.toHaveLength(0);
     // Still exactly one button on the page (the refresh).
     expect(screen.queryAllByRole("button")).toHaveLength(1);
+  });
+});
+
+describe("AgentControl — next-up card (v3.15.16.5)", () => {
+  it("renders chosen_next_up with the ready_for_implementation recommendation", async () => {
+    installFetchMock(
+      {
+        "/api/agent-control/status": () => jsonResp(okStatusBody),
+        "/api/agent-control/activity": () => jsonResp(okActivityBody),
+        "/api/agent-control/workloop": () => jsonResp(okWorkloopBody),
+        "/api/agent-control/pr-lifecycle": () =>
+          jsonResp(okPRLifecycleEmptyBody),
+        "/api/agent-control/notifications": () =>
+          jsonResp(placeholderNotificationsBody),
+        "/api/agent-control/proposals": () => jsonResp(okProposalsEmptyBody),
+        "/api/agent-control/approval-inbox": () => jsonResp(okInboxEmptyBody),
+        "/api/agent-control/execute-safe": () => jsonResp(okExecuteSafeBody),
+        "/api/agent-control/next-up": () => jsonResp(okNextUpReadyBody),
+      },
+      () => jsonResp({}, 404),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("next-up-recommendation")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("next-up-recommendation")).toHaveTextContent(
+      "ready_for_implementation",
+    );
+    expect(screen.getByTestId("next-up-needs-human")).toHaveTextContent("no");
+    expect(screen.getByTestId("next-up-title")).toHaveTextContent(
+      /add observability metric/,
+    );
+    expect(screen.getByTestId("next-up-decision")).toHaveTextContent(
+      "allowed_read_only",
+    );
+    expect(screen.getByTestId("next-up-counts")).toHaveTextContent(
+      /206 proposals/,
+    );
+    // The card must never add an action button — only the global
+    // refresh button stays.
+    expect(screen.queryAllByRole("button")).toHaveLength(1);
+  });
+
+  it("renders the no-candidate empty state when nothing is ready", async () => {
+    installFetchMock(
+      {
+        "/api/agent-control/status": () => jsonResp(okStatusBody),
+        "/api/agent-control/activity": () => jsonResp(okActivityBody),
+        "/api/agent-control/workloop": () => jsonResp(okWorkloopBody),
+        "/api/agent-control/pr-lifecycle": () =>
+          jsonResp(okPRLifecycleEmptyBody),
+        "/api/agent-control/notifications": () =>
+          jsonResp(placeholderNotificationsBody),
+        "/api/agent-control/proposals": () => jsonResp(okProposalsEmptyBody),
+        "/api/agent-control/approval-inbox": () => jsonResp(okInboxEmptyBody),
+        "/api/agent-control/execute-safe": () => jsonResp(okExecuteSafeBody),
+        "/api/agent-control/next-up": () => jsonResp(okNextUpNothingReadyBody),
+      },
+      () => jsonResp({}, 404),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("next-up-no-candidate")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("next-up-recommendation")).toHaveTextContent(
+      "nothing_ready",
+    );
+  });
+
+  it("renders not_available when the next-up endpoint 404s", async () => {
+    installFetchMock(
+      {
+        "/api/agent-control/status": () => jsonResp(okStatusBody),
+        "/api/agent-control/activity": () => jsonResp(okActivityBody),
+        "/api/agent-control/workloop": () => jsonResp(okWorkloopBody),
+        "/api/agent-control/pr-lifecycle": () =>
+          jsonResp(okPRLifecycleEmptyBody),
+        "/api/agent-control/notifications": () =>
+          jsonResp(placeholderNotificationsBody),
+        "/api/agent-control/proposals": () => jsonResp(okProposalsEmptyBody),
+        "/api/agent-control/approval-inbox": () => jsonResp(okInboxEmptyBody),
+        "/api/agent-control/execute-safe": () => jsonResp(okExecuteSafeBody),
+        // Intentionally omit /api/agent-control/next-up so the
+        // fetch falls through to the 404 fallback. This emulates
+        // production while the v3.15.16.5 dashboard.py wiring has
+        // not yet landed via its bootstrap PR.
+      },
+      () => jsonResp({}, 404),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("next-up-not-available")).toBeInTheDocument();
+    });
   });
 });
 

--- a/tests/unit/test_dashboard_api_roadmap_priority.py
+++ b/tests/unit/test_dashboard_api_roadmap_priority.py
@@ -1,0 +1,413 @@
+"""Unit tests for ``dashboard.api_roadmap_priority`` (v3.15.16.5).
+
+Verifies the same hard guarantees as the sibling agent-control
+route modules:
+
+* GET only (POST/PUT/PATCH/DELETE return 405).
+* Missing artifact → ``not_available``.
+* Malformed artifact → ``not_available``.
+* Non-object artifact → ``not_available``.
+* Valid artifact passes through with the bounded projection.
+* ``safe_to_execute`` is always ``False`` in the response payload,
+  regardless of what the underlying digest contains (defensive
+  redaction at the boundary).
+* ``needs_human`` is derived deterministically.
+* The chosen_next_up payload is bounded to the documented allowlist
+  of fields; unknown fields in the underlying digest are dropped.
+* Secret-redaction guard refuses leaks.
+* No subprocess / no ``gh`` / no ``git`` token in the module source.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from flask import Flask
+
+from dashboard import api_roadmap_priority as ac
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+@pytest.fixture
+def app(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Flask:
+    monkeypatch.setattr(ac, "LOGS_DIR", tmp_path / "logs")
+    monkeypatch.setattr(
+        ac,
+        "ROADMAP_PRIORITY_LATEST",
+        tmp_path / "logs" / "roadmap_priority" / "latest.json",
+    )
+    flask_app = Flask(__name__)
+    ac.register_roadmap_priority_routes(flask_app)
+    return flask_app
+
+
+@pytest.fixture
+def client(app: Flask):
+    return app.test_client()
+
+
+_PATH = "/api/agent-control/next-up"
+
+
+# ---------------------------------------------------------------------------
+# Verb / route invariants
+# ---------------------------------------------------------------------------
+
+
+def test_get_returns_200(client) -> None:
+    resp = client.get(_PATH)
+    assert resp.status_code == 200
+    assert resp.is_json
+
+
+@pytest.mark.parametrize("verb", ["POST", "PUT", "PATCH", "DELETE"])
+def test_mutation_verbs_are_rejected(client, verb: str) -> None:
+    resp = client.open(_PATH, method=verb)
+    assert resp.status_code == 405
+
+
+def test_only_next_up_route_registered(app: Flask) -> None:
+    rules = [
+        r for r in app.url_map.iter_rules() if r.rule.startswith("/api/agent-control/")
+    ]
+    paths = sorted(r.rule for r in rules)
+    assert paths == [_PATH]
+    for r in rules:
+        verbs = set(r.methods or ()) - {"HEAD", "OPTIONS"}
+        assert verbs == {"GET"}
+
+
+# ---------------------------------------------------------------------------
+# not_available envelopes
+# ---------------------------------------------------------------------------
+
+
+def test_missing_artifact_yields_not_available(client) -> None:
+    body = client.get(_PATH).get_json()
+    assert body["kind"] == "agent_control_next_up"
+    assert body["schema_version"] == 1
+    assert body["status"] == "not_available"
+    assert body["reason"] == "missing"
+    assert body["artifact_path"] == "logs/roadmap_priority/latest.json"
+
+
+def test_malformed_artifact_yields_not_available(
+    client, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    p = tmp_path / "logs" / "roadmap_priority" / "latest.json"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("{ not json", encoding="utf-8")
+    monkeypatch.setattr(ac, "ROADMAP_PRIORITY_LATEST", p)
+    body = client.get(_PATH).get_json()
+    assert body["status"] == "not_available"
+    assert body["reason"].startswith("malformed:")
+
+
+def test_non_object_artifact_yields_not_available(
+    client, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    p = tmp_path / "logs" / "roadmap_priority" / "latest.json"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("[1, 2, 3]", encoding="utf-8")
+    monkeypatch.setattr(ac, "ROADMAP_PRIORITY_LATEST", p)
+    body = client.get(_PATH).get_json()
+    assert body["status"] == "not_available"
+    assert "not_an_object" in body["reason"]
+
+
+# ---------------------------------------------------------------------------
+# Valid artifact projection
+# ---------------------------------------------------------------------------
+
+
+def _write_artifact(p: Path, payload: dict) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_valid_ready_artifact_projects_chosen_next_up(
+    client, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    p = tmp_path / "logs" / "roadmap_priority" / "latest.json"
+    _write_artifact(
+        p,
+        {
+            "schema_version": 1,
+            "report_kind": "roadmap_priority_digest",
+            "module_version": "v3.15.16.2",
+            "generated_at_utc": "2026-05-05T08:00:00Z",
+            "final_recommendation": "ready_for_implementation",
+            "safe_to_execute": False,
+            "chosen_next_up": {
+                "proposal_id": "p_aaaaaaaa",
+                "title": "test",
+                "summary": "summary",
+                "proposal_type": "observability_addition",
+                "risk_class": "LOW",
+                "rationale": "lowest-rank eligible candidate",
+                "protocol_plan_summary": {
+                    "decision": "allowed_read_only",
+                    "implementation_allowed": True,
+                    "requires_human": False,
+                    "risk_class": "LOW",
+                    "item_type": "observability_addition",
+                    "proposed_branch": "fix/test",
+                    "proposed_release_id": "v3.15.16.x",
+                    "required_tests": ["scripts/governance_lint.py"],
+                    "expected_artifacts": ["docs/governance/x.md"],
+                    "rollback_plan": ["git revert"],
+                },
+            },
+            "candidates": [{"proposal_id": "p_aaaaaaaa", "rank": 1}],
+            "filtered_out": [{"proposal_id": "p_zz", "filter_reason": "risk_high_excluded"}],
+            "counts": {
+                "proposals_total": 10,
+                "eligible_total": 1,
+                "filtered_out_total": 9,
+                "filtered_out_by_reason": {"risk_high_excluded": 9},
+            },
+        },
+    )
+    monkeypatch.setattr(ac, "ROADMAP_PRIORITY_LATEST", p)
+    body = client.get(_PATH).get_json()
+    assert body["status"] == "ok"
+    data = body["data"]
+    assert data["final_recommendation"] == "ready_for_implementation"
+    assert data["safe_to_execute"] is False
+    assert data["needs_human"] is False
+    chosen = data["chosen_next_up"]
+    assert chosen["proposal_id"] == "p_aaaaaaaa"
+    assert chosen["title"] == "test"
+    plan = chosen["protocol_plan_summary"]
+    assert plan["decision"] == "allowed_read_only"
+    assert plan["implementation_allowed"] is True
+    assert plan["proposed_branch"] == "fix/test"
+    # The full candidates / filtered_out arrays are NOT projected.
+    assert "candidates" not in data
+    assert "filtered_out" not in data
+    assert data["counts"]["proposals_total"] == 10
+    assert data["counts"]["eligible_total"] == 1
+
+
+def test_nothing_ready_artifact_projects_null_chosen(
+    client, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    p = tmp_path / "logs" / "roadmap_priority" / "latest.json"
+    _write_artifact(
+        p,
+        {
+            "schema_version": 1,
+            "report_kind": "roadmap_priority_digest",
+            "module_version": "v3.15.16.2",
+            "final_recommendation": "nothing_ready",
+            "safe_to_execute": False,
+            "chosen_next_up": None,
+            "counts": {
+                "proposals_total": 12,
+                "eligible_total": 0,
+                "filtered_out_total": 12,
+                "filtered_out_by_reason": {"status_not_proposed": 12},
+            },
+        },
+    )
+    monkeypatch.setattr(ac, "ROADMAP_PRIORITY_LATEST", p)
+    body = client.get(_PATH).get_json()
+    assert body["status"] == "ok"
+    assert body["data"]["chosen_next_up"] is None
+    assert body["data"]["needs_human"] is False
+    assert body["data"]["final_recommendation"] == "nothing_ready"
+
+
+# ---------------------------------------------------------------------------
+# safe_to_execute hard-coded false
+# ---------------------------------------------------------------------------
+
+
+def test_safe_to_execute_in_payload_is_always_false(
+    client, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Even if a corrupted upstream digest claims ``safe_to_execute:
+    true`` (which the prioritizer pin forbids — but defense in depth
+    matters), the boundary projection must not propagate that
+    value. We hard-code False on the way out."""
+    p = tmp_path / "logs" / "roadmap_priority" / "latest.json"
+    _write_artifact(
+        p,
+        {
+            "schema_version": 1,
+            "module_version": "v3.15.16.2",
+            "final_recommendation": "ready_for_implementation",
+            "safe_to_execute": True,  # corrupted upstream
+            "chosen_next_up": {
+                "proposal_id": "p_aaaaaaaa",
+                "title": "x",
+                "protocol_plan_summary": {
+                    "decision": "allowed_read_only",
+                    "implementation_allowed": True,
+                    "requires_human": False,
+                },
+            },
+            "counts": {},
+        },
+    )
+    monkeypatch.setattr(ac, "ROADMAP_PRIORITY_LATEST", p)
+    body = client.get(_PATH).get_json()
+    assert body["data"]["safe_to_execute"] is False
+
+
+# ---------------------------------------------------------------------------
+# needs_human derivation
+# ---------------------------------------------------------------------------
+
+
+def test_needs_human_true_when_protocol_requires_human(
+    client, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    p = tmp_path / "logs" / "roadmap_priority" / "latest.json"
+    _write_artifact(
+        p,
+        {
+            "schema_version": 1,
+            "module_version": "v3.15.16.2",
+            "final_recommendation": "ready_for_implementation",
+            "chosen_next_up": {
+                "proposal_id": "p_aaaaaaaa",
+                "title": "x",
+                "protocol_plan_summary": {
+                    "decision": "allowed_read_only",
+                    "implementation_allowed": True,
+                    "requires_human": True,
+                },
+            },
+            "counts": {},
+        },
+    )
+    monkeypatch.setattr(ac, "ROADMAP_PRIORITY_LATEST", p)
+    body = client.get(_PATH).get_json()
+    assert body["data"]["needs_human"] is True
+
+
+def test_needs_human_true_when_final_recommendation_unsafe(
+    client, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    p = tmp_path / "logs" / "roadmap_priority" / "latest.json"
+    _write_artifact(
+        p,
+        {
+            "schema_version": 1,
+            "module_version": "v3.15.16.2",
+            "final_recommendation": "unsafe",
+            "chosen_next_up": None,
+            "counts": {},
+        },
+    )
+    monkeypatch.setattr(ac, "ROADMAP_PRIORITY_LATEST", p)
+    body = client.get(_PATH).get_json()
+    assert body["data"]["needs_human"] is True
+
+
+# ---------------------------------------------------------------------------
+# Secrets-redaction guard
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_top_level_fields_are_not_projected(
+    client, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The boundary copies a bounded allowlist of fields from the
+    underlying digest. Unknown top-level fields — including
+    accidentally-credential-shaped ones — are dropped at the
+    boundary and never reach assert_no_secrets, which is the
+    strongest possible posture (defence-in-depth: even if a future
+    upstream digest grows a new field, it cannot leak through this
+    surface without an explicit code change here)."""
+    p = tmp_path / "logs" / "roadmap_priority" / "latest.json"
+    _write_artifact(
+        p,
+        {
+            "schema_version": 1,
+            "module_version": "v3.15.16.2",
+            "final_recommendation": "ready_for_implementation",
+            "evil_field": "sk-ant-AAAAAAAA1234",
+            "chosen_next_up": None,
+            "counts": {},
+        },
+    )
+    monkeypatch.setattr(ac, "ROADMAP_PRIORITY_LATEST", p)
+    resp = client.get(_PATH)
+    assert resp.status_code == 200
+    body = resp.get_json()
+    # The credential-shaped value never appears in the response.
+    assert "evil_field" not in body
+    assert "evil_field" not in (body.get("data") or {})
+    text = resp.get_data(as_text=True)
+    assert "sk-ant-" not in text
+
+
+def test_credential_in_projected_field_is_refused(
+    client, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If a credential-shaped value DOES land in a field the
+    boundary projects (e.g. via a malicious proposal title),
+    assert_no_secrets must trip and the request must fail loudly
+    rather than leak."""
+    p = tmp_path / "logs" / "roadmap_priority" / "latest.json"
+    _write_artifact(
+        p,
+        {
+            "schema_version": 1,
+            "module_version": "v3.15.16.2",
+            "final_recommendation": "ready_for_implementation",
+            "chosen_next_up": {
+                "proposal_id": "p_aaaaaaaa",
+                # Title is in the bounded projection allowlist —
+                # planting a credential here forces the value
+                # through the assert_no_secrets boundary.
+                "title": "sk-ant-AAAAAAAA1234",
+                "protocol_plan_summary": {
+                    "decision": "allowed_read_only",
+                    "implementation_allowed": True,
+                    "requires_human": False,
+                },
+            },
+            "counts": {},
+        },
+    )
+    monkeypatch.setattr(ac, "ROADMAP_PRIORITY_LATEST", p)
+    resp = client.get(_PATH)
+    assert resp.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# Module-source guarantees
+# ---------------------------------------------------------------------------
+
+
+def test_no_subprocess_imports_in_module() -> None:
+    src = Path(ac.__file__).read_text(encoding="utf-8")
+    assert "import subprocess" not in src
+    assert "from subprocess" not in src
+
+
+def test_no_gh_or_git_invocation_in_module() -> None:
+    src = Path(ac.__file__).read_text(encoding="utf-8")
+    forbidden = ('"gh"', "'gh'", '"git"', "'git'", "Popen")
+    for token in forbidden:
+        assert token not in src, f"forbidden token: {token!r}"
+
+
+def test_no_mutation_verb_in_module() -> None:
+    """The module declares only methods=['GET']. No mutation verb
+    string may appear anywhere in the source."""
+    src = Path(ac.__file__).read_text(encoding="utf-8")
+    forbidden = (
+        '"POST"', "'POST'",
+        '"PUT"', "'PUT'",
+        '"PATCH"', "'PATCH'",
+        '"DELETE"', "'DELETE'",
+    )
+    for token in forbidden:
+        assert token not in src, f"forbidden mutation verb literal: {token!r}"

--- a/tests/unit/test_observability_security_invariants.py
+++ b/tests/unit/test_observability_security_invariants.py
@@ -51,6 +51,12 @@ _AGENT_CONTROL_BOUNDARY_FILES: tuple[str, ...] = (
     "dashboard/api_approval_inbox.py",
     "dashboard/api_proposal_queue.py",
     "dashboard/api_execute_safe_controls.py",
+    # v3.15.16.5 — Next-Up read-only projection over
+    # logs/roadmap_priority/latest.json. Same hard guarantees as
+    # every other agent-control boundary file: GET-only, no
+    # subprocess / network, no exception-string leak, no mutation
+    # verb literal.
+    "dashboard/api_roadmap_priority.py",
 )
 
 


### PR DESCRIPTION
## Roadmap protocol context

Fifth roadmap item executed through `reporting.roadmap_execution_protocol`. Plan written to `logs/roadmap_execution_protocol/latest.json`.

| Field | Value |
| --- | --- |
| `item_id` | `r_v3_15_16_5` |
| `item_type` | `observability_addition` |
| `risk_class` | `LOW` |
| `decision` | `allowed_read_only` |
| `requires_human` | `false` |
| `implementation_allowed` | `true` |
| `safe_to_execute` | `false` |
| `status` | `proposed` |
| `proposed_release_id` | `v3.15.16.5` |

## Summary

Add a new GET-only endpoint `/api/agent-control/next-up` and a read-only "Next up" card on the Agent Control PWA's Inbox tab. The card surfaces `logs/roadmap_priority/latest.json` (refreshed every merge by the v3.15.16.3 deploy hook): `chosen_next_up`, `final_recommendation` pill, rationale, `protocol_plan_summary`, backlog counts, and a derived `needs_human` indicator. **No action button.** No mutation surface anywhere in the diff.

## ⚠️ Operator wiring deferred

The operator authorised C2 (bundle the two-line `dashboard/dashboard.py` wiring into this PR), but the `deny_no_touch` hook (`.claude/hooks/deny_no_touch.py:80`) hard-codes `dashboard/dashboard.py` and blocks file-level writes to it. With `.claude` changes forbidden in this PR's scope I cannot edit the hook to honour the verbal authorisation. The wiring therefore lands as a separate **one-shot operator-authored governance-bootstrap PR** afterward — same pattern that v3.15.15.21 used for the previous batch of agent-control wiring lines (`register_agent_control_routes`, `register_proposal_queue_routes`, `register_approval_inbox_routes`). Two lines:

```python
from dashboard.api_roadmap_priority import register_roadmap_priority_routes
register_roadmap_priority_routes(app)
```

Until that bootstrap merges:
- `/api/agent-control/next-up` returns 404
- the PWA frontend collapses 404 → `not_available` envelope
- the Next-Up card renders its `next-up-not-available` empty state
- nothing crashes, nothing leaks

The bootstrap PR is intentionally tiny — single 2-line change inside `dashboard/dashboard.py`, no other files touched.

## Hard guarantees

| Guarantee | Enforcement |
| --- | --- |
| GET-only on the new file | `tests/unit/test_observability_security_invariants.py` parametrize sweep extended to include the new file; mutation-verb regex would fail if any future change adds POST/PUT/PATCH/DELETE |
| `safe_to_execute` always `false` in the response | hard-coded at the boundary; pinned by `test_safe_to_execute_in_payload_is_always_false` even when the upstream digest is corrupted |
| `needs_human` derivation is deterministic | pinned by 2 dedicated tests |
| Bounded projection (full `candidates[]`/`filtered_out[]` arrays not surfaced) | pinned by `test_valid_ready_artifact_projects_chosen_next_up` |
| Defence-in-depth: unknown upstream fields cannot leak through | pinned by `test_unknown_top_level_fields_are_not_projected` |
| Credential-shaped values in projected fields trip `assert_no_secrets` | pinned by `test_credential_in_projected_field_is_refused` |
| No subprocess / no `gh` / no `git` invocation | pinned by `test_no_subprocess_imports_in_module`, `test_no_gh_or_git_invocation_in_module`, and the extended invariants sweep |
| No mutation verb literal in module source | pinned by `test_no_mutation_verb_in_module` |
| `api_execute_safe_controls` remains UNWIRED | the existing `test_dashboard_does_not_wire_execute_safe_routes` test continues to pass — this PR does not touch that wiring |

## Diff scope

```
dashboard/api_roadmap_priority.py                  | NEW (240 lines)
docs/governance/roadmap_priority.md                | +52
docs/roadmap/qre_roadmap_v6_1.md                   | +28/-13
frontend/src/api/agent_control.ts                  | +48
frontend/src/routes/AgentControl.tsx               | +152
frontend/src/test/AgentControl.test.tsx            | +176
tests/unit/test_dashboard_api_roadmap_priority.py  | NEW (380 lines)
tests/unit/test_observability_security_invariants.py | +6
8 files changed, 1131 insertions(+), 15 deletions(-)
```

`dashboard/dashboard.py` is **NOT** in this PR (see "Operator wiring deferred" above).

## Validation gates

- [x] `python scripts/governance_lint.py` — OK
- [x] `sha256sum research/research_latest.json research/strategy_matrix.csv` — frozen hashes unchanged (`4a567bd6...`, `ff15b8c4...`)
- [x] `pytest tests/smoke -q` — 14 passed
- [x] `pytest tests/unit/test_dashboard_api_roadmap_priority.py tests/unit/test_observability_security_invariants.py -q` — **43 passed**
- [x] `pytest tests/unit -q` — **3232 passed, 3 skipped, 0 failed**
- [x] `npm --prefix frontend test -- --run` — **90 passed** (3 new Next-Up card tests)
- [x] `npm --prefix frontend run build` — OK
- [x] `python -m py_compile dashboard/api_roadmap_priority.py` — OK

## Test plan

- [ ] CI green on all required checks
- [ ] After squash merge, the auto-deploy log continues to show v3.15.16.1 + v3.15.16.3 post-deploy steps completing successfully (`post-deploy: pr_lifecycle refresh ok`, `post-deploy: recurring maintenance refresh ok`)
- [ ] After the operator merges the tiny `dashboard.py` bootstrap PR: `/api/agent-control/next-up` returns 200 with the bounded envelope; the PWA's Inbox tab populates the Next-Up card

## Out of scope (deferred)

- **`dashboard/dashboard.py` 2-line bootstrap PR** — operator-authored, see "Operator wiring deferred" above
- **v3.15.16.4** — operator-authored governance-bootstrap to add `ops/systemd/` to an agent allowlist + ship recurring-maintenance systemd timers for between-merge freshness
- **v3.15.17.x** — push notifications. Operator-authored governance-bootstrap required first.

## Rollback plan

`git revert <merge_sha>` on a fresh branch; one-line revert PR; merge after CI green. The only effect: the new endpoint and the new card are removed; the existing Approval Inbox / Proposals cards continue to work unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)