### PR TITLE
feat(v3.15.16.7): agent flow orchestration with explicit handoffs

### DIFF
--- a/docs/governance/agent_flow.md
+++ b/docs/governance/agent_flow.md
@@ -1,0 +1,114 @@
+# Agent Flow — operator runbook
+
+> Module: `reporting.agent_flow`
+> Release: v3.15.16.7
+> Sibling docs: `task_board.md`, `roadmap_priority.md`,
+> `recurring_maintenance.md`,
+> `roadmap_item_execution_protocol.md`.
+
+## TL;DR
+
+Pure, deterministic, read-only orchestration projection over the
+v3.15.16.6 task-board state machine. For every task, surfaces:
+
+* `current_stage` — the task-board's `current_state`.
+* `responsible_agent` — which canonical agent role owns the
+  current stage.
+* `next_agent` — which agent receives the handoff at the next
+  state.
+* `next_action_proposed` — the closed-enum action the v3.15.16.11
+  actuator should perform once the v3.15.16.10 governance is in
+  place.
+* `blocking_reason` — short string when the task is blocked or
+  human_needed.
+* `handoff_eligible` — boolean: `True` iff the handoff to the
+  next agent is mechanically valid.
+
+Writes the result to `logs/agent_flow/latest.json`.
+
+## Closed `next_action_proposed` vocabulary
+
+The v3.15.16.11 actuator consumes this directly:
+
+| action | when | what the actuator does (Phase 1) |
+| --- | --- | --- |
+| `select_next_task` | stage `backlog` | no-op (waits for product_owner classification) |
+| `generate_plan` | stage `refined` | no-op (waits for planner) |
+| `implement` | stage `todo` | no-op (waits for me / future LLM agent) |
+| `validate` | stage `in_progress` | watch CI, retry flaky checks (max 2) |
+| `review` | stage `review` | run merge gates; auto-merge if ALL pass |
+| `merge` | stage `review` (synonym for the actuator's merge step) | gh pr merge --squash --delete-branch |
+| `escalate_human` | stage `blocked` or `human_needed` | emit human_needed event |
+| `no_op` | stage `done` or unknown | nothing |
+
+The closed enum is pinned by a unit test; new actions cannot be
+added without an explicit code change here AND a v3.15.16.10
+amendment.
+
+## State → next_agent / next_action mapping
+
+| current_stage | next_agent | next_action_proposed | handoff_eligible |
+| --- | --- | --- | --- |
+| `backlog` | `planner` | `select_next_task` | True |
+| `refined` | `implementation_agent` | `generate_plan` | True |
+| `todo` | `implementation_agent` | `implement` | True |
+| `in_progress` | `ci_guardian` | `validate` | True |
+| `review` | `operator` | `merge` | True |
+| `done` | `operator` | `no_op` | False |
+| `blocked` | `operator` | `escalate_human` | False |
+| `human_needed` | `operator` | `escalate_human` | False |
+
+## Hard guarantees
+
+| guarantee | enforcement |
+| --- | --- |
+| Stdlib-only | no subprocess, no `gh`, no `git`, no network — pinned by source-text test |
+| `safe_to_execute` is always `false` | hard-coded literal in source; pinned by unit test |
+| Missing source → `not_available` | never silently OK |
+| Determinism | two runs on the same input produce a byte-identical handoffs list |
+| Stable ordering | handoffs sorted by `item_id` ascending |
+| Atomic writes | `tmp` + `os.replace` |
+| No mutation of upstream | task_board artifact byte-identical before/after (pinned) |
+| Output scope | writes only under `logs/agent_flow/` |
+| Closed action vocabulary | every record's `next_action_proposed` is in the eight-element enum (pinned) |
+
+## CLI
+
+```
+python -m reporting.agent_flow
+python -m reporting.agent_flow --no-write
+python -m reporting.agent_flow --status
+python -m reporting.agent_flow --frozen-utc 2026-05-05T11:00:00Z
+```
+
+There is **no execute mode**.
+
+## Integration with the recurring scheduler
+
+`reporting.recurring_maintenance` (v3.15.15.23) gains one new
+closed job entry in v3.15.16.7:
+
+| `job_type` | risk | needs `gh`? | default interval | default enabled | what it does |
+| --- | --- | --- | --- | --- | --- |
+| `refresh_agent_flow` | LOW | no | 30 min | ✓ | runs `agent_flow.collect_snapshot()` + `write_outputs()` |
+
+## Files added by v3.15.16.7
+
+```
+reporting/agent_flow.py
+reporting/recurring_maintenance.py        (one new closed job entry)
+tests/unit/test_agent_flow.py
+tests/unit/test_recurring_maintenance.py  (registry + per-job assertion)
+docs/governance/agent_flow.md             (this file)
+docs/governance/recurring_maintenance.md  (job table + cross-reference)
+```
+
+No new dependency. No `dashboard/dashboard.py` change. No
+`.claude/` change. No frontend change. No frozen-contract change.
+No live / paper / shadow / risk path touch. No test weakening.
+
+## Cross-references
+
+* `reporting/task_board.py` — supplies the input rows.
+* `reporting/roadmap_execution_protocol.py` — owner-agent role
+  vocabulary (mirrored).

--- a/docs/governance/recurring_maintenance.md
+++ b/docs/governance/recurring_maintenance.md
@@ -78,6 +78,7 @@ python -m reporting.recurring_maintenance --run-due-once \
 | `dependabot_low_medium_execute_safe` | MEDIUM | yes | 60 min | **✗** | delegates to `github_pr_lifecycle` execute-safe path |
 | `refresh_roadmap_priority` | LOW | no | 30 min | ✓ | refreshes `roadmap_priority` read-only digest (v3.15.16.2) |
 | `refresh_task_board` | LOW | no | 30 min | ✓ | refreshes `task_board` state-machine digest (v3.15.16.6) |
+| `refresh_agent_flow` | LOW | no | 30 min | ✓ | refreshes `agent_flow` orchestration digest (v3.15.16.7) |
 
 ## Dependabot execute-safe — two-layer opt-in
 
@@ -208,6 +209,26 @@ Hard guarantees re-asserted at this layer:
 * See `docs/governance/task_board.md` for the closed state /
   owner-agent vocabularies, the rule precedence, and the operator
   workflow.
+
+## Agent flow projection (v3.15.16.7)
+
+A new closed job entry — `refresh_agent_flow` — runs the
+read-only orchestration projection
+(`reporting.agent_flow.collect_snapshot` + `write_outputs`) every
+30 minutes by default. Reads `logs/task_board/latest.json` and
+emits per-task handoff records carrying `responsible_agent`,
+`next_agent`, `next_action_proposed` (closed eight-element enum),
+`blocking_reason`, `handoff_eligible`. The future v3.15.16.11
+actuator consumes `next_action_proposed` directly.
+
+Hard guarantees re-asserted at this layer:
+
+* LOW risk; `needs_gh = False`; default-enabled.
+* `safe_to_execute` is hard-coded `false` in the digest schema.
+* The job never starts a branch, never opens a PR, never merges,
+  never invokes `gh`. It is observability only.
+* See `docs/governance/agent_flow.md` for the closed action /
+  next_agent mappings.
 
 ## Deploy-hook integration (v3.15.16.3)
 

--- a/docs/roadmap/qre_roadmap_v6_1.md
+++ b/docs/roadmap/qre_roadmap_v6_1.md
@@ -177,6 +177,31 @@ authority + execution engine pair.
   `docs/roadmap/qre_roadmap_v6_1.md`
 * `risk_class`: LOW
 * `proposal_type`: observability_addition
+* `status`: done
+
+### v3.15.16.7 — Agent flow orchestration with explicit handoffs
+
+Ship `reporting/agent_flow.py` — a deterministic orchestration
+projection over the v3.15.16.6 task-board. For every task surfaces
+`current_stage`, `responsible_agent`, `next_agent`,
+`next_action_proposed` (closed eight-element enum:
+select_next_task, generate_plan, implement, validate, review,
+merge, escalate_human, no_op), `blocking_reason`,
+`handoff_eligible`. The closed `next_action_proposed` enum is the
+deterministic interface the v3.15.16.11 actuator will consume.
+Writes `logs/agent_flow/latest.json`. JOB_REFRESH_AGENT_FLOW added
+to `recurring_maintenance`. Pure observability; no git/gh, no
+mutation surface.
+
+* `affected_files`: `reporting/agent_flow.py`,
+  `reporting/recurring_maintenance.py`,
+  `tests/unit/test_agent_flow.py`,
+  `tests/unit/test_recurring_maintenance.py`,
+  `docs/governance/agent_flow.md`,
+  `docs/governance/recurring_maintenance.md`,
+  `docs/roadmap/qre_roadmap_v6_1.md`
+* `risk_class`: LOW
+* `proposal_type`: observability_addition
 * `status`: proposed
 
 ---

--- a/reporting/agent_flow.py
+++ b/reporting/agent_flow.py
@@ -1,0 +1,540 @@
+"""Agent Flow Orchestration (v3.15.16.7).
+
+Pure read-only projection that, for every in-flight task in the
+task-board (v3.15.16.6), surfaces the agent orchestration view:
+
+* ``current_stage`` — same as the task-board's ``current_state``;
+  the eight closed states.
+* ``responsible_agent`` — which canonical agent role owns the
+  current stage (mirrors task_board).
+* ``next_agent`` — which agent receives the handoff at the next
+  state.
+* ``next_action_proposed`` — the closed-enum action the
+  v3.15.16.11 actuator should perform once the v3.15.16.10
+  governance is in place.
+* ``blocking_reason`` — when the task is blocked or human_needed,
+  a short string describing why.
+* ``handoff_eligible`` — boolean: True iff the handoff to the
+  next agent is mechanically valid (i.e., the next state is not
+  a terminal blocker / human-needed state).
+
+This module:
+
+* never starts work
+* never opens a branch
+* never opens a PR
+* never merges
+* never invokes ``gh``
+* never invokes ``git``
+* never calls any external service
+* never mutates any input artifact
+
+Hard guarantees (enforced by code AND tests)
+--------------------------------------------
+
+* Stdlib-only. No subprocess, no ``gh``, no ``git``, no network.
+* Reads ``logs/task_board/latest.json`` only. Never invokes the
+  task_board CLI; the recurring maintenance scheduler is the
+  canonical refresh path.
+* Output limited to ``logs/agent_flow/``.
+* Atomic writes (``tmp`` + ``os.replace``); no in-place edits.
+* ``safe_to_execute`` is hard-coded ``false`` at the digest level.
+* Missing or malformed task_board artifact produces
+  ``final_recommendation = "not_available"``; never silently OK.
+* Determinism: two runs on the same input produce a byte-identical
+  ``handoffs`` list (modulo ``generated_at_utc``).
+* Closed action vocabulary; unknown source data lands in ``no_op``
+  with a deterministic reason.
+
+Closed next_action_proposed vocabulary
+--------------------------------------
+
+::
+
+    select_next_task   — product_owner stage
+    generate_plan      — planner stage
+    implement          — implementation_agent stage (todo / in_progress)
+    validate           — implementation_agent (CI in flight)
+    review             — ci_guardian (review state, ready for merge gate)
+    merge              — operator (review state, all gates pass)
+    escalate_human     — operator (blocked / human_needed / unknown)
+    no_op              — terminal done state, or no actionable handoff
+
+CLI
+---
+
+::
+
+    python -m reporting.agent_flow
+    python -m reporting.agent_flow --no-write
+    python -m reporting.agent_flow --status
+
+Stdlib-only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT: Path = Path(__file__).resolve().parent.parent
+MODULE_VERSION: str = "v3.15.16.7"
+SCHEMA_VERSION: int = 1
+
+DIGEST_DIR_JSON: Path = REPO_ROOT / "logs" / "agent_flow"
+SOURCE_TASK_BOARD: Path = REPO_ROOT / "logs" / "task_board" / "latest.json"
+
+
+# ---------------------------------------------------------------------------
+# Closed taxonomies
+# ---------------------------------------------------------------------------
+
+
+# next_action_proposed — closed enum the v3.15.16.11 actuator
+# consumes. Mirror of the task-board state vocabulary, mapped to
+# the action that resolves the current stage.
+ACTION_SELECT_NEXT_TASK: str = "select_next_task"
+ACTION_GENERATE_PLAN: str = "generate_plan"
+ACTION_IMPLEMENT: str = "implement"
+ACTION_VALIDATE: str = "validate"
+ACTION_REVIEW: str = "review"
+ACTION_MERGE: str = "merge"
+ACTION_ESCALATE_HUMAN: str = "escalate_human"
+ACTION_NO_OP: str = "no_op"
+
+ACTIONS: tuple[str, ...] = (
+    ACTION_SELECT_NEXT_TASK,
+    ACTION_GENERATE_PLAN,
+    ACTION_IMPLEMENT,
+    ACTION_VALIDATE,
+    ACTION_REVIEW,
+    ACTION_MERGE,
+    ACTION_ESCALATE_HUMAN,
+    ACTION_NO_OP,
+)
+
+
+# Owner-agent vocabulary mirrors reporting.task_board.OWNER_AGENTS.
+# Kept local so this module can be tested in isolation; sync via
+# the task_board MODULE_VERSION reference if the closed set
+# changes.
+AGENT_PRODUCT_OWNER: str = "product_owner"
+AGENT_STRATEGIC_ADVISOR: str = "strategic_advisor"
+AGENT_PLANNER: str = "planner"
+AGENT_IMPLEMENTATION: str = "implementation_agent"
+AGENT_ARCHITECTURE_GUARDIAN: str = "architecture_guardian"
+AGENT_CI_GUARDIAN: str = "ci_guardian"
+AGENT_SECURITY_GOVERNANCE_GUARDIAN: str = "security_governance_guardian"
+AGENT_OPERATOR: str = "operator"
+
+OWNER_AGENTS: tuple[str, ...] = (
+    AGENT_PRODUCT_OWNER,
+    AGENT_STRATEGIC_ADVISOR,
+    AGENT_PLANNER,
+    AGENT_IMPLEMENTATION,
+    AGENT_ARCHITECTURE_GUARDIAN,
+    AGENT_CI_GUARDIAN,
+    AGENT_SECURITY_GOVERNANCE_GUARDIAN,
+    AGENT_OPERATOR,
+)
+
+
+# Mapping from current_stage to next_agent. Determined by which
+# agent receives the handoff when the task progresses to its
+# next_state. Mirrors task_board's _STATE_TO_NEXT and _STATE_TO_OWNER.
+_STAGE_TO_NEXT_AGENT: dict[str, str] = {
+    "backlog": AGENT_PLANNER,
+    "refined": AGENT_IMPLEMENTATION,
+    "todo": AGENT_IMPLEMENTATION,
+    "in_progress": AGENT_CI_GUARDIAN,
+    "review": AGENT_OPERATOR,
+    "done": AGENT_OPERATOR,  # terminal; no further handoff
+    "blocked": AGENT_OPERATOR,  # terminal until unblocked
+    "human_needed": AGENT_OPERATOR,  # terminal until cleared
+}
+
+
+# Mapping from current_stage to the next_action_proposed the
+# v3.15.16.11 actuator should consume.
+_STAGE_TO_ACTION: dict[str, str] = {
+    "backlog": ACTION_SELECT_NEXT_TASK,
+    "refined": ACTION_GENERATE_PLAN,
+    "todo": ACTION_IMPLEMENT,
+    "in_progress": ACTION_VALIDATE,
+    "review": ACTION_MERGE,
+    "done": ACTION_NO_OP,
+    "blocked": ACTION_ESCALATE_HUMAN,
+    "human_needed": ACTION_ESCALATE_HUMAN,
+}
+
+
+# Stages where the handoff to the next agent is mechanically
+# valid. Terminal blockers (blocked, human_needed) and terminal
+# successes (done) are NOT handoff_eligible — operator action is
+# required.
+_HANDOFF_ELIGIBLE_STAGES: frozenset[str] = frozenset(
+    {"backlog", "refined", "todo", "in_progress", "review"}
+)
+
+
+REC_OK: str = "ok"
+REC_NOT_AVAILABLE: str = "not_available"
+
+FINAL_RECOMMENDATIONS: tuple[str, ...] = (REC_OK, REC_NOT_AVAILABLE)
+
+
+# ---------------------------------------------------------------------------
+# Time / path helpers
+# ---------------------------------------------------------------------------
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _rel(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(REPO_ROOT.resolve())).replace(
+            "\\", "/"
+        )
+    except ValueError:
+        return str(path).replace("\\", "/")
+
+
+# ---------------------------------------------------------------------------
+# Source-artifact read (passive)
+# ---------------------------------------------------------------------------
+
+
+def _read_json_artifact(
+    path: Path,
+) -> tuple[dict[str, Any] | None, str | None]:
+    if not path.exists():
+        return (None, "missing")
+    if not path.is_file():
+        return (None, "not_a_file")
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as e:
+        return (None, f"unreadable: {type(e).__name__}")
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as e:
+        return (None, f"malformed: {type(e).__name__}")
+    if not isinstance(data, dict):
+        return (None, "not_an_object")
+    return (data, None)
+
+
+# ---------------------------------------------------------------------------
+# Per-task projection
+# ---------------------------------------------------------------------------
+
+
+def _build_handoff_record(task: Mapping[str, Any]) -> dict[str, Any] | None:
+    """Project one task_board row into one agent_flow record.
+    Returns ``None`` if the row's shape is invalid (missing
+    item_id or unknown current_state)."""
+    item_id = task.get("item_id")
+    current_stage = task.get("current_state")
+    responsible_agent = task.get("owner_agent")
+    if not isinstance(item_id, str) or not item_id:
+        return None
+    if not isinstance(current_stage, str):
+        return None
+    if current_stage not in _STAGE_TO_NEXT_AGENT:
+        # Unknown stage -> no_op + escalate
+        next_agent = AGENT_OPERATOR
+        next_action = ACTION_ESCALATE_HUMAN
+        blocking_reason = f"unknown_current_stage: {current_stage!r}"
+    else:
+        next_agent = _STAGE_TO_NEXT_AGENT[current_stage]
+        next_action = _STAGE_TO_ACTION[current_stage]
+        if current_stage == "blocked":
+            tr = task.get("transition_reason")
+            blocking_reason = (
+                str(tr) if isinstance(tr, str) else "blocked"
+            )
+        elif current_stage == "human_needed":
+            tr = task.get("transition_reason")
+            blocking_reason = (
+                str(tr) if isinstance(tr, str) else "human_needed"
+            )
+        else:
+            blocking_reason = None
+    handoff_eligible = current_stage in _HANDOFF_ELIGIBLE_STAGES
+    return {
+        "item_id": item_id,
+        "title": str(task.get("title") or ""),
+        "current_stage": current_stage,
+        "responsible_agent": (
+            responsible_agent
+            if isinstance(responsible_agent, str) and responsible_agent in OWNER_AGENTS
+            else AGENT_OPERATOR
+        ),
+        "next_agent": next_agent,
+        "next_action_proposed": next_action,
+        "blocking_reason": blocking_reason,
+        "handoff_eligible": handoff_eligible,
+        "evidence": {
+            "release_id": task.get("release_id"),
+            "transition_reason": task.get("transition_reason"),
+            "pr_url": (task.get("evidence") or {}).get("pr_url"),
+            "pr_number": (task.get("evidence") or {}).get("pr_number"),
+        },
+    }
+
+
+def _counts_by_action(
+    handoffs: Sequence[Mapping[str, Any]],
+) -> dict[str, int]:
+    out = {a: 0 for a in ACTIONS}
+    for h in handoffs:
+        a = str(h.get("next_action_proposed") or "")
+        if a in out:
+            out[a] += 1
+    return out
+
+
+def _counts_by_responsible_agent(
+    handoffs: Sequence[Mapping[str, Any]],
+) -> dict[str, int]:
+    out = {a: 0 for a in OWNER_AGENTS}
+    for h in handoffs:
+        a = str(h.get("responsible_agent") or "")
+        if a in out:
+            out[a] += 1
+    return out
+
+
+def collect_snapshot(
+    *,
+    frozen_utc: str | None = None,
+    task_board_override: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build the full agent-flow digest. Pure function."""
+    generated = frozen_utc or _utcnow()
+
+    if task_board_override is not None:
+        tb: Mapping[str, Any] | None = task_board_override
+        tb_error: str | None = None
+    else:
+        tb, tb_error = _read_json_artifact(SOURCE_TASK_BOARD)
+
+    if tb is None:
+        return _build_not_available_digest(
+            generated_at_utc=generated,
+            reason=tb_error or "unknown",
+            source_path=_rel(SOURCE_TASK_BOARD),
+        )
+
+    tasks_raw = tb.get("tasks")
+    if not isinstance(tasks_raw, list):
+        return _build_not_available_digest(
+            generated_at_utc=generated,
+            reason="tasks_field_not_a_list",
+            source_path=_rel(SOURCE_TASK_BOARD),
+        )
+
+    handoffs: list[dict[str, Any]] = []
+    skipped = 0
+    for t in tasks_raw:
+        if not isinstance(t, Mapping):
+            skipped += 1
+            continue
+        record = _build_handoff_record(t)
+        if record is None:
+            skipped += 1
+            continue
+        handoffs.append(record)
+
+    # Stable ordering: by item_id ascending.
+    handoffs.sort(key=lambda h: str(h.get("item_id") or ""))
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": "agent_flow_digest",
+        "module_version": MODULE_VERSION,
+        "generated_at_utc": generated,
+        "mode": "dry-run",
+        "source_task_board": {
+            "path": _rel(SOURCE_TASK_BOARD),
+            "status": "ok",
+            "module_version": tb.get("module_version"),
+            "task_count": len(tasks_raw),
+            "skipped_invalid_rows": skipped,
+        },
+        "policy": {
+            "actions": list(ACTIONS),
+            "owner_agents": list(OWNER_AGENTS),
+        },
+        "counts": {
+            "handoffs_total": len(handoffs),
+            "by_next_action_proposed": _counts_by_action(handoffs),
+            "by_responsible_agent": _counts_by_responsible_agent(handoffs),
+            "handoff_eligible_total": sum(
+                1 for h in handoffs if h.get("handoff_eligible")
+            ),
+        },
+        "handoffs": handoffs,
+        "final_recommendation": REC_OK,
+        "safe_to_execute": False,
+    }
+
+
+def _build_not_available_digest(
+    *, generated_at_utc: str, reason: str, source_path: str
+) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": "agent_flow_digest",
+        "module_version": MODULE_VERSION,
+        "generated_at_utc": generated_at_utc,
+        "mode": "dry-run",
+        "source_task_board": {
+            "path": source_path,
+            "status": "not_available",
+            "error": reason,
+            "module_version": None,
+            "task_count": 0,
+            "skipped_invalid_rows": 0,
+        },
+        "policy": {
+            "actions": list(ACTIONS),
+            "owner_agents": list(OWNER_AGENTS),
+        },
+        "counts": {
+            "handoffs_total": 0,
+            "by_next_action_proposed": {a: 0 for a in ACTIONS},
+            "by_responsible_agent": {a: 0 for a in OWNER_AGENTS},
+            "handoff_eligible_total": 0,
+        },
+        "handoffs": [],
+        "final_recommendation": REC_NOT_AVAILABLE,
+        "safe_to_execute": False,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Atomic write
+# ---------------------------------------------------------------------------
+
+
+def write_outputs(snapshot: Mapping[str, Any]) -> dict[str, str]:
+    DIGEST_DIR_JSON.mkdir(parents=True, exist_ok=True)
+    ts = str(snapshot["generated_at_utc"]).replace(":", "-")
+    json_now = DIGEST_DIR_JSON / f"{ts}.json"
+    json_latest = DIGEST_DIR_JSON / "latest.json"
+    history = DIGEST_DIR_JSON / "history.jsonl"
+    payload = json.dumps(snapshot, sort_keys=True, indent=2)
+
+    tmp_now = json_now.with_suffix(json_now.suffix + ".tmp")
+    tmp_now.write_text(payload, encoding="utf-8")
+    os.replace(tmp_now, json_now)
+
+    tmp_latest = json_latest.with_suffix(json_latest.suffix + ".tmp")
+    tmp_latest.write_text(payload, encoding="utf-8")
+    os.replace(tmp_latest, json_latest)
+
+    compact = json.dumps(snapshot, sort_keys=True, separators=(",", ":"))
+    with history.open("a", encoding="utf-8") as f:
+        f.write(compact + "\n")
+
+    return {
+        "latest": _rel(json_latest),
+        "timestamped": _rel(json_now),
+        "history": _rel(history),
+    }
+
+
+def read_latest_snapshot() -> dict[str, Any] | None:
+    p = DIGEST_DIR_JSON / "latest.json"
+    if not p.exists():
+        return None
+    try:
+        text = p.read_text(encoding="utf-8")
+        data = json.loads(text)
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="reporting.agent_flow",
+        description=(
+            f"Agent flow orchestration ({MODULE_VERSION}). "
+            "Stdlib-only. Read-only projection over the task_board "
+            "kanban projection."
+        ),
+    )
+    g = parser.add_mutually_exclusive_group(required=False)
+    g.add_argument(
+        "--mode",
+        type=str,
+        default="dry-run",
+        choices=["dry-run"],
+        help="Operating mode. Only dry-run is supported.",
+    )
+    g.add_argument(
+        "--status",
+        action="store_true",
+        help="Read and print the latest digest from logs/.",
+    )
+    parser.add_argument(
+        "--no-write",
+        action="store_true",
+        help="Do not persist the JSON digest (stdout only).",
+    )
+    parser.add_argument(
+        "--frozen-utc",
+        type=str,
+        default=None,
+        help="Pin generated_at_utc for deterministic tests.",
+    )
+    parser.add_argument(
+        "--indent",
+        type=int,
+        default=2,
+        help="JSON indent for stdout (0 for compact).",
+    )
+    args = parser.parse_args(argv)
+
+    if args.status:
+        snap = read_latest_snapshot()
+        if snap is None:
+            print(
+                json.dumps(
+                    {"status": "not_available", "reason": "missing"},
+                    indent=args.indent or None,
+                )
+            )
+            return 1
+        print(json.dumps(snap, sort_keys=True, indent=args.indent or None))
+        return 0
+
+    snap = collect_snapshot(frozen_utc=args.frozen_utc)
+    if not args.no_write:
+        write_outputs(snap)
+    print(json.dumps(snap, sort_keys=True, indent=args.indent or None))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/reporting/recurring_maintenance.py
+++ b/reporting/recurring_maintenance.py
@@ -95,6 +95,10 @@ JOB_REFRESH_ROADMAP_PRIORITY: str = "refresh_roadmap_priority"
 # current_state, next_state, transition_reason, owner_agent. LOW
 # risk; no gh; no external network; no mutation.
 JOB_REFRESH_TASK_BOARD: str = "refresh_task_board"
+# v3.15.16.7 — read-only agent flow projection. Per task surfaces
+# responsible_agent, next_agent, next_action_proposed (closed enum)
+# so the v3.15.16.11 actuator can consume handoffs deterministically.
+JOB_REFRESH_AGENT_FLOW: str = "refresh_agent_flow"
 
 JOB_TYPES: tuple[str, ...] = (
     JOB_REFRESH_WORKLOOP_RUNTIME,
@@ -104,6 +108,7 @@ JOB_TYPES: tuple[str, ...] = (
     JOB_DEPENDABOT_EXECUTE_SAFE,
     JOB_REFRESH_ROADMAP_PRIORITY,
     JOB_REFRESH_TASK_BOARD,
+    JOB_REFRESH_AGENT_FLOW,
 )
 
 
@@ -328,6 +333,28 @@ def _exec_refresh_task_board() -> dict[str, Any]:
     }
 
 
+def _exec_refresh_agent_flow() -> dict[str, Any]:
+    """Run the v3.15.16.7 agent-flow projection (read-only).
+    Reads logs/task_board/latest.json (v3.15.16.6) and writes
+    logs/agent_flow/latest.json. Never starts a branch, never opens
+    a PR, never invokes ``gh``."""
+    from reporting.agent_flow import collect_snapshot, write_outputs
+
+    snap = collect_snapshot()
+    write_outputs(snap)
+    counts = snap.get("counts") or {}
+    return {
+        "summary": (
+            f"agent_flow "
+            f"{snap.get('final_recommendation') or 'no recommendation'}"
+        ),
+        "evidence": {
+            "handoffs_total": counts.get("handoffs_total"),
+            "by_next_action_proposed": counts.get("by_next_action_proposed"),
+        },
+    }
+
+
 def _exec_dependabot_execute_safe() -> dict[str, Any]:
     """Delegate to the existing ``reporting.github_pr_lifecycle``
     execute-safe path. The lifecycle module owns every Dependabot
@@ -430,6 +457,18 @@ _JOB_REGISTRY: dict[str, dict[str, Any]] = {
             "Refresh task-board state-machine digest "
             "(read-only kanban projection over the proposal queue "
             "+ roadmap_priority + github_pr_lifecycle + approval_inbox)."
+        ),
+        "risk_class": RISK_LOW,
+        "needs_gh": False,
+        "timeout_seconds": DEFAULT_JOB_TIMEOUT_SECONDS,
+    },
+    JOB_REFRESH_AGENT_FLOW: {
+        "default_interval_seconds": 30 * 60,
+        "default_enabled": True,
+        "executor": _exec_refresh_agent_flow,
+        "description": (
+            "Refresh agent-flow handoff digest "
+            "(read-only orchestration projection over the task_board)."
         ),
         "risk_class": RISK_LOW,
         "needs_gh": False,

--- a/tests/unit/test_agent_flow.py
+++ b/tests/unit/test_agent_flow.py
@@ -1,0 +1,428 @@
+"""Unit tests for ``reporting.agent_flow`` (v3.15.16.7)."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reporting import agent_flow as af
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+MODULE_PATH = REPO_ROOT / "reporting" / "agent_flow.py"
+
+
+@pytest.fixture
+def isolated_digest_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Path:
+    monkeypatch.setattr(af, "DIGEST_DIR_JSON", tmp_path / "af")
+    return tmp_path
+
+
+def _task(
+    item_id: str,
+    *,
+    current_state: str = "refined",
+    owner_agent: str = "planner",
+    title: str = "test item",
+    transition_reason: str = "classified_with_risk_LOW",
+    release_id: str | None = None,
+    pr_url: str = "",
+    pr_number: int | None = None,
+) -> dict[str, Any]:
+    return {
+        "item_id": item_id,
+        "title": title,
+        "release_id": release_id,
+        "current_state": current_state,
+        "next_state": "todo",
+        "transition_reason": transition_reason,
+        "owner_agent": owner_agent,
+        "retry_count": 0,
+        "last_update": None,
+        "evidence": {
+            "pr_url": pr_url,
+            "pr_number": pr_number,
+            "affected_files": [],
+        },
+    }
+
+
+def _tb(tasks: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "report_kind": "task_board_digest",
+        "module_version": "v3.15.16.6",
+        "tasks": tasks,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Hard-coded digest invariants
+# ---------------------------------------------------------------------------
+
+
+def test_safe_to_execute_is_always_false_with_handoffs() -> None:
+    snap = af.collect_snapshot(
+        task_board_override=_tb([_task("p_aaaaaaaa")]),
+        frozen_utc="2026-05-05T11:00:00Z",
+    )
+    assert snap["safe_to_execute"] is False
+
+
+def test_safe_to_execute_is_false_when_not_available() -> None:
+    snap = af.collect_snapshot(
+        task_board_override={"not": "valid"},
+        frozen_utc="2026-05-05T11:00:00Z",
+    )
+    assert snap["final_recommendation"] == af.REC_NOT_AVAILABLE
+    assert snap["safe_to_execute"] is False
+
+
+def test_module_version_pinned() -> None:
+    assert af.MODULE_VERSION == "v3.15.16.7"
+
+
+def test_schema_version_pinned() -> None:
+    assert af.SCHEMA_VERSION == 1
+
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies
+# ---------------------------------------------------------------------------
+
+
+def test_action_vocabulary_is_closed_eight_set() -> None:
+    expected = {
+        "select_next_task",
+        "generate_plan",
+        "implement",
+        "validate",
+        "review",
+        "merge",
+        "escalate_human",
+        "no_op",
+    }
+    assert set(af.ACTIONS) == expected
+    assert len(af.ACTIONS) == 8
+
+
+def test_owner_agent_vocabulary_matches_eight_canonical() -> None:
+    expected = {
+        "product_owner",
+        "strategic_advisor",
+        "planner",
+        "implementation_agent",
+        "architecture_guardian",
+        "ci_guardian",
+        "security_governance_guardian",
+        "operator",
+    }
+    assert set(af.OWNER_AGENTS) == expected
+    assert len(af.OWNER_AGENTS) == 8
+
+
+def test_every_known_stage_maps_to_action_and_next_agent() -> None:
+    stages = {
+        "backlog",
+        "refined",
+        "todo",
+        "in_progress",
+        "review",
+        "done",
+        "blocked",
+        "human_needed",
+    }
+    for s in stages:
+        assert s in af._STAGE_TO_NEXT_AGENT
+        assert s in af._STAGE_TO_ACTION
+        assert af._STAGE_TO_NEXT_AGENT[s] in af.OWNER_AGENTS
+        assert af._STAGE_TO_ACTION[s] in af.ACTIONS
+
+
+# ---------------------------------------------------------------------------
+# Source availability
+# ---------------------------------------------------------------------------
+
+
+def test_missing_source_yields_not_available() -> None:
+    snap = af.collect_snapshot(
+        task_board_override={"tasks": "not a list"},
+        frozen_utc="2026-05-05T11:00:00Z",
+    )
+    assert snap["final_recommendation"] == af.REC_NOT_AVAILABLE
+
+
+def test_empty_tasks_list_is_ok_with_zero_handoffs() -> None:
+    snap = af.collect_snapshot(
+        task_board_override=_tb([]), frozen_utc="2026-05-05T11:00:00Z"
+    )
+    assert snap["final_recommendation"] == af.REC_OK
+    assert snap["counts"]["handoffs_total"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Per-stage projections
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "stage,expected_action,expected_next_agent,expected_handoff_eligible",
+    [
+        ("backlog", "select_next_task", "planner", True),
+        ("refined", "generate_plan", "implementation_agent", True),
+        ("todo", "implement", "implementation_agent", True),
+        ("in_progress", "validate", "ci_guardian", True),
+        ("review", "merge", "operator", True),
+        ("done", "no_op", "operator", False),
+        ("blocked", "escalate_human", "operator", False),
+        ("human_needed", "escalate_human", "operator", False),
+    ],
+)
+def test_each_stage_projects_correctly(
+    stage: str,
+    expected_action: str,
+    expected_next_agent: str,
+    expected_handoff_eligible: bool,
+) -> None:
+    snap = af.collect_snapshot(
+        task_board_override=_tb([_task("p_aaaaaaaa", current_state=stage)]),
+        frozen_utc="2026-05-05T11:00:00Z",
+    )
+    h = snap["handoffs"][0]
+    assert h["current_stage"] == stage
+    assert h["next_action_proposed"] == expected_action
+    assert h["next_agent"] == expected_next_agent
+    assert h["handoff_eligible"] is expected_handoff_eligible
+
+
+def test_blocked_carries_blocking_reason() -> None:
+    snap = af.collect_snapshot(
+        task_board_override=_tb(
+            [
+                _task(
+                    "p_aaaaaaaa",
+                    current_state="blocked",
+                    transition_reason="proposal_status_blocked: blocked_protected_path: .claude/foo",
+                )
+            ]
+        ),
+        frozen_utc="2026-05-05T11:00:00Z",
+    )
+    h = snap["handoffs"][0]
+    assert "blocked_protected_path" in (h["blocking_reason"] or "")
+
+
+def test_human_needed_carries_blocking_reason() -> None:
+    snap = af.collect_snapshot(
+        task_board_override=_tb(
+            [
+                _task(
+                    "p_aaaaaaaa",
+                    current_state="human_needed",
+                    transition_reason="approval_inbox_severity_critical",
+                )
+            ]
+        ),
+        frozen_utc="2026-05-05T11:00:00Z",
+    )
+    h = snap["handoffs"][0]
+    assert h["blocking_reason"] == "approval_inbox_severity_critical"
+
+
+def test_unknown_stage_lands_in_escalate_human() -> None:
+    snap = af.collect_snapshot(
+        task_board_override=_tb(
+            [_task("p_aaaaaaaa", current_state="not_a_real_stage")]
+        ),
+        frozen_utc="2026-05-05T11:00:00Z",
+    )
+    h = snap["handoffs"][0]
+    assert h["next_action_proposed"] == af.ACTION_ESCALATE_HUMAN
+    assert "unknown_current_stage" in (h["blocking_reason"] or "")
+
+
+def test_invalid_row_shape_is_skipped() -> None:
+    snap = af.collect_snapshot(
+        task_board_override={
+            "tasks": [
+                {"missing": "item_id"},
+                _task("p_valid", current_state="refined"),
+            ]
+        },
+        frozen_utc="2026-05-05T11:00:00Z",
+    )
+    assert snap["counts"]["handoffs_total"] == 1
+    assert snap["source_task_board"]["skipped_invalid_rows"] == 1
+
+
+def test_owner_agent_outside_closed_set_falls_back_to_operator() -> None:
+    snap = af.collect_snapshot(
+        task_board_override=_tb(
+            [_task("p_aaaaaaaa", owner_agent="not_a_real_agent")]
+        ),
+        frozen_utc="2026-05-05T11:00:00Z",
+    )
+    h = snap["handoffs"][0]
+    assert h["responsible_agent"] == af.AGENT_OPERATOR
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+def test_two_runs_produce_identical_handoffs() -> None:
+    tb = _tb(
+        [
+            _task("p_zzzzzzzz", current_state="refined"),
+            _task("p_aaaaaaaa", current_state="refined"),
+            _task("p_mmmmmmmm", current_state="refined"),
+        ]
+    )
+    s1 = af.collect_snapshot(
+        task_board_override=tb, frozen_utc="2026-05-05T11:00:00Z"
+    )
+    s2 = af.collect_snapshot(
+        task_board_override=tb, frozen_utc="2026-05-05T11:00:00Z"
+    )
+    assert s1["handoffs"] == s2["handoffs"]
+    assert s1["counts"] == s2["counts"]
+
+
+def test_handoffs_sorted_by_item_id_ascending() -> None:
+    snap = af.collect_snapshot(
+        task_board_override=_tb(
+            [
+                _task("p_zzzzzzzz", current_state="refined"),
+                _task("p_aaaaaaaa", current_state="refined"),
+                _task("p_mmmmmmmm", current_state="refined"),
+            ]
+        ),
+        frozen_utc="2026-05-05T11:00:00Z",
+    )
+    ids = [h["item_id"] for h in snap["handoffs"]]
+    assert ids == ["p_aaaaaaaa", "p_mmmmmmmm", "p_zzzzzzzz"]
+
+
+# ---------------------------------------------------------------------------
+# Atomic write
+# ---------------------------------------------------------------------------
+
+
+def test_write_outputs_atomic_and_scoped(isolated_digest_dir: Path) -> None:
+    snap = af.collect_snapshot(
+        task_board_override=_tb([_task("p_aaaaaaaa", current_state="refined")]),
+        frozen_utc="2026-05-05T11:00:00Z",
+    )
+    paths = af.write_outputs(snap)
+    base = isolated_digest_dir / "af"
+    assert (base / "latest.json").exists()
+    assert (base / "history.jsonl").exists()
+    leftover = list(base.glob("*.tmp"))
+    assert leftover == []
+    assert paths["latest"].endswith("latest.json")
+
+
+def test_history_appends_one_line_per_write(
+    isolated_digest_dir: Path,
+) -> None:
+    snap = af.collect_snapshot(
+        task_board_override=_tb([_task("p_aaaaaaaa")]),
+        frozen_utc="2026-05-05T11:00:00Z",
+    )
+    af.write_outputs(snap)
+    af.write_outputs(snap)
+    history = isolated_digest_dir / "af" / "history.jsonl"
+    lines = [
+        ln for ln in history.read_text(encoding="utf-8").splitlines() if ln.strip()
+    ]
+    assert len(lines) == 2
+
+
+# ---------------------------------------------------------------------------
+# Module-source guarantees
+# ---------------------------------------------------------------------------
+
+
+def test_module_source_no_subprocess_no_network() -> None:
+    src = MODULE_PATH.read_text(encoding="utf-8")
+    forbidden = (
+        "import subprocess",
+        "from subprocess",
+        "shell=True",
+        "os.system(",
+        "Popen(",
+        "import requests",
+        "import urllib.request",
+        "from urllib.request",
+    )
+    for tok in forbidden:
+        assert tok not in src, f"forbidden token: {tok!r}"
+
+
+def test_module_source_no_gh_or_git_invocation() -> None:
+    src = MODULE_PATH.read_text(encoding="utf-8")
+    forbidden = ('"gh"', "'gh'", '"git"', "'git'", "Popen", "gh pr ", "git checkout ")
+    for tok in forbidden:
+        assert tok not in src, f"forbidden gh/git token: {tok!r}"
+
+
+def test_module_source_no_branch_or_pr_creation() -> None:
+    src = MODULE_PATH.read_text(encoding="utf-8")
+    forbidden = (
+        "git checkout -b",
+        "git push",
+        "gh pr create",
+        "gh pr merge",
+    )
+    for tok in forbidden:
+        assert tok not in src, f"forbidden action: {tok!r}"
+
+
+def test_safe_to_execute_field_is_hard_coded_false() -> None:
+    src = MODULE_PATH.read_text(encoding="utf-8")
+    occurrences = re.findall(r'"safe_to_execute":\s*([A-Za-z]+)', src)
+    assert occurrences, "safe_to_execute key not found in module source"
+    assert all(v == "False" for v in occurrences), (
+        f"safe_to_execute is not hard-coded False everywhere: {occurrences!r}"
+    )
+
+
+def test_no_input_mutation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    tb_file = tmp_path / "task_board.json"
+    payload = _tb([_task("p_aaaaaaaa")])
+    tb_file.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+    before = tb_file.read_bytes()
+    monkeypatch.setattr(af, "DIGEST_DIR_JSON", tmp_path / "af")
+    monkeypatch.setattr(af, "SOURCE_TASK_BOARD", tb_file)
+    snap = af.collect_snapshot(frozen_utc="2026-05-05T11:00:00Z")
+    af.write_outputs(snap)
+    after = tb_file.read_bytes()
+    assert before == after
+
+
+# ---------------------------------------------------------------------------
+# CLI surface
+# ---------------------------------------------------------------------------
+
+
+def test_cli_only_dry_run_mode_allowed() -> None:
+    with pytest.raises(SystemExit):
+        af.main(["--mode", "execute-safe"])
+
+
+def test_cli_status_returns_not_available_when_missing(
+    isolated_digest_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    rc = af.main(["--status"])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "not_available" in out

--- a/tests/unit/test_recurring_maintenance.py
+++ b/tests/unit/test_recurring_maintenance.py
@@ -77,6 +77,15 @@ def isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setitem(
         rm._JOB_REGISTRY, rm.JOB_REFRESH_TASK_BOARD, tb_spec
     )
+    # v3.15.16.7 — same isolation rationale: the agent-flow
+    # executor reads logs/task_board/latest.json and writes to
+    # logs/agent_flow/. Stub it for tests using the ``isolated``
+    # fixture so they stay hermetic.
+    af_spec = dict(rm._JOB_REGISTRY[rm.JOB_REFRESH_AGENT_FLOW])
+    af_spec["executor"] = lambda: {"summary": "ok (test stub)"}
+    monkeypatch.setitem(
+        rm._JOB_REGISTRY, rm.JOB_REFRESH_AGENT_FLOW, af_spec
+    )
     return tmp_path
 
 
@@ -116,10 +125,12 @@ def test_job_registry_contains_only_approved_types() -> None:
         "refresh_roadmap_priority",
         # v3.15.16.6 — read-only task-board state machine.
         "refresh_task_board",
+        # v3.15.16.7 — read-only agent-flow handoff projection.
+        "refresh_agent_flow",
     }
     assert set(rm.JOB_TYPES) == expected
     assert set(rm._JOB_REGISTRY.keys()) == expected
-    assert len(rm.JOB_TYPES) == 7
+    assert len(rm.JOB_TYPES) == 8
 
 
 def test_roadmap_priority_job_is_low_risk_no_gh_enabled_by_default() -> None:
@@ -139,6 +150,17 @@ def test_task_board_job_is_low_risk_no_gh_enabled_by_default() -> None:
     must not need ``gh``, and must be enabled by default (it is a
     pure read-only kanban projection)."""
     spec = rm._JOB_REGISTRY[rm.JOB_REFRESH_TASK_BOARD]
+    assert spec["risk_class"] == rm.RISK_LOW
+    assert spec["needs_gh"] is False
+    assert spec["default_enabled"] is True
+    assert spec["default_interval_seconds"] == 30 * 60
+
+
+def test_agent_flow_job_is_low_risk_no_gh_enabled_by_default() -> None:
+    """v3.15.16.7: the agent-flow refresh job must be LOW risk,
+    must not need ``gh``, and must be enabled by default (it is a
+    pure read-only orchestration projection)."""
+    spec = rm._JOB_REGISTRY[rm.JOB_REFRESH_AGENT_FLOW]
     assert spec["risk_class"] == rm.RISK_LOW
     assert spec["needs_gh"] is False
     assert spec["default_enabled"] is True


### PR DESCRIPTION
## Roadmap protocol context

| Field | Value |
| --- | --- |
| `item_id` | `r_v3_15_16_7` |
| `item_type` | `observability_addition` |
| `risk_class` | `LOW` |
| `decision` | `allowed_read_only` |
| `requires_human` | `false` |
| `implementation_allowed` | `true` |
| `safe_to_execute` | `false` |

## Phase 1 of the autonomous engine — orchestration projection

Second of four read-only Phase 1 releases. Reads the v3.15.16.6 task_board and emits per-task handoff records. The closed `next_action_proposed` enum is the deterministic interface the future v3.15.16.11 actuator consumes.

## What ships

`reporting/agent_flow.py` — surfaces `current_stage`, `responsible_agent`, `next_agent`, `next_action_proposed` (closed eight-element enum), `blocking_reason`, `handoff_eligible` for every in-flight task.

**Closed `next_action_proposed` vocabulary** (pinned by tests):

| stage | next_agent | next_action_proposed | handoff_eligible |
|---|---|---|---|
| backlog | planner | select_next_task | yes |
| refined | implementation_agent | generate_plan | yes |
| todo | implementation_agent | implement | yes |
| in_progress | ci_guardian | validate | yes |
| review | operator | merge | yes |
| done | operator | no_op | no |
| blocked | operator | escalate_human | no |
| human_needed | operator | escalate_human | no |

## Hard guarantees (pinned by tests)

- Stdlib-only — no subprocess / `gh` / `git` / network
- `safe_to_execute` hard-coded `false` at schema level (regex pin)
- Missing source → `not_available`
- Atomic write, output limited to `logs/agent_flow/`
- Determinism: byte-identical handoffs across runs
- Stable ordering: `item_id` ascending
- No mutation of any input artifact

## Wiring

`recurring_maintenance` gains `JOB_REFRESH_AGENT_FLOW` (LOW, no gh, default-enabled, 30-min cadence). Eighth and final read-only job in the typed scheduler for Phase 1.

## Validation gates

- [x] `python scripts/governance_lint.py` — OK
- [x] `sha256sum research/research_latest.json research/strategy_matrix.csv` — frozen hashes unchanged
- [x] `pytest tests/smoke -q` — 14 passed
- [x] `pytest tests/unit/test_agent_flow.py tests/unit/test_recurring_maintenance.py -q` — **68 passed**
- [x] `pytest tests/unit -q` — **3300 passed, 3 skipped, 0 failed**
- [x] `npm --prefix frontend test -- --run` — 90 passed
- [x] `npm --prefix frontend run build` — OK

## Diff

```
reporting/agent_flow.py                  | NEW (540 lines)
tests/unit/test_agent_flow.py            | NEW (428 lines)
reporting/recurring_maintenance.py       | +39
tests/unit/test_recurring_maintenance.py | +24
docs/governance/agent_flow.md            | NEW (114 lines)
docs/governance/recurring_maintenance.md | +21
docs/roadmap/qre_roadmap_v6_1.md         | +25
7 files changed, 1190 insertions(+), 1 deletion(-)
```

## Out of scope

Same as v3.15.16.6 — Phase 1 only; no git/gh actuation; v3.15.16.10/.11 strictly out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)