### PR TITLE
feat(v3.15.16.9): governance-bootstrap PR-template synthesizer

### DIFF
--- a/docs/governance/bootstrap_templates/add_no_touch_carveout.md
+++ b/docs/governance/bootstrap_templates/add_no_touch_carveout.md
@@ -1,0 +1,60 @@
+# Bootstrap template — add a no-touch carveout
+
+> Template shape used by `reporting.governance_bootstrap`
+> (v3.15.16.9) when an in-flight task needs to edit a path that
+> is currently under a `.claude/hooks/deny_no_touch.py` glob and
+> the operator has explicitly authorised the carveout.
+
+## When this template fires
+
+- A future release needs to edit a file currently covered by a
+  no-touch glob (e.g., a one-off legitimate edit to a path that
+  was previously declared no-touch).
+- A future release needs to relax a hook's `_HARD_DENY` list
+  to permit a deliberate operator-approved capability.
+
+This template is **rare** — most blockers route through
+`extend_agent_allowlist.md` (allowlist extension) or
+`wiring_dashboard_py.md` (dashboard.py wiring) instead.
+
+## Synthesized fields
+
+```
+branch_name:    governance-bootstrap/<event_id>
+commit_message: governance-bootstrap: add no-touch carveout for <path>
+file_diff:      delta to .claude/hooks/deny_no_touch.py
+                adding an explicit carveout for the named path
+pr_title:       governance-bootstrap: add no-touch carveout for <path>
+pr_body:        operator-facing markdown explaining the carveout
+                AND including the date the carveout was authorised
+                AND including the related roadmap item_id
+```
+
+## Why this is the most-restricted template
+
+`.claude/hooks/*` is on the canonical no-touch list. Loosening a
+hook directly grants new mutation authority — every carveout
+must be:
+
+1. Justified in the PR body with a specific item_id.
+2. Authored AND merged by the operator (no agent shortcut).
+3. Reverted in a follow-up PR after the one-time edit lands
+   (the carveout should NOT be permanent unless explicitly stated).
+
+## Validation checklist (operator)
+
+- [ ] The carveout is the narrowest possible scope (single path,
+      not a wildcard).
+- [ ] The PR body cross-references the source `human_needed`
+      event and the related roadmap `item_id`.
+- [ ] `python scripts/governance_lint.py` passes.
+- [ ] `pytest tests/unit/test_hooks_no_touch.py -q` passes.
+- [ ] A follow-up issue / PR is filed to revert the carveout
+      after the one-time edit lands (or the PR body explicitly
+      states the carveout is permanent and why).
+
+## After merge
+
+The hook stops blocking writes to the carved-out path. The
+operator should immediately follow up with the actual edit PR
+and (optionally) a revert PR closing the carveout.

--- a/docs/governance/bootstrap_templates/extend_agent_allowlist.md
+++ b/docs/governance/bootstrap_templates/extend_agent_allowlist.md
@@ -1,0 +1,51 @@
+# Bootstrap template — extend an agent allowlist
+
+> Template shape used by `reporting.governance_bootstrap`
+> (v3.15.16.9) when a roadmap item's `affected_files` includes a
+> path that is not in any `.claude/agents/*.md` `allowed_roots`
+> union (so the `deny_outside_agent_allowlist` hook blocks all
+> writes to it).
+
+## When this template fires
+
+- A future v3.15.16.4 ships `ops/systemd/*` files; `ops/systemd/*`
+  is in no agent's `allowed_roots`, so the agent cannot write
+  them. The bootstrap is operator-authored.
+- A future release introduces a new top-level package
+  (e.g., a hypothetical `engine/` directory) that needs to be
+  added to one or more agent allowlists.
+
+## Synthesized fields
+
+```
+branch_name:    governance-bootstrap/<event_id>
+commit_message: governance-bootstrap: extend allowlist for <path>
+file_diff:      delta to .claude/agents/<agent>.md frontmatter
+                adding the path under allowed_roots
+pr_title:       governance-bootstrap: extend allowlist for <path>
+pr_body:        operator-facing markdown explaining the carveout
+```
+
+## Why the operator merges this manually
+
+`.claude/agents/*.md` is on the no-touch list. Allowlist
+extensions establish new authority surface and require explicit
+operator review. The bootstrap PR keeps the change small (one
+file, additive) so review is fast.
+
+## Validation checklist (operator)
+
+- [ ] The added path is genuinely needed by an in-flight roadmap
+      item (cross-reference the source `human_needed` event).
+- [ ] The added path is the narrowest possible scope (no
+      wildcards beyond the directory needed).
+- [ ] No additional `allowed_roots` entries beyond the one being
+      added in this PR.
+- [ ] `python scripts/governance_lint.py` passes.
+- [ ] CI green on every required check.
+
+## After merge
+
+The agent gains write authority to the new path on its next
+session. The operator should subsequently approve the
+implementation PR that uses the newly-allowed path.

--- a/docs/governance/bootstrap_templates/wiring_dashboard_py.md
+++ b/docs/governance/bootstrap_templates/wiring_dashboard_py.md
@@ -1,0 +1,57 @@
+# Bootstrap template — wiring `dashboard/dashboard.py`
+
+> Template shape used by `reporting.governance_bootstrap`
+> (v3.15.16.9) when the v3.15.16.8 `human_needed` detector finds
+> a `register_*_routes` definition in `dashboard/api_*.py` that is
+> NOT called in `dashboard/dashboard.py`.
+
+## Canonical case (v3.15.16.5)
+
+`dashboard/api_roadmap_priority.py` defines
+`register_roadmap_priority_routes` but `dashboard/dashboard.py`
+does not import or call it, so the
+`/api/agent-control/next-up` endpoint returns 404 on the VPS.
+
+The synthesized template:
+
+```
+branch_name:    governance-bootstrap/<event_id>
+commit_message: governance-bootstrap: register_roadmap_priority_routes
+file_diff:
+    # Add to dashboard/dashboard.py imports section:
+    from dashboard.api_roadmap_priority import register_roadmap_priority_routes
+
+    # Add to the route-registration block:
+    register_roadmap_priority_routes(app)
+pr_title:       governance-bootstrap: register_roadmap_priority_routes
+```
+
+## Why the operator merges this manually
+
+`dashboard/dashboard.py` is on the no-touch list per
+`.claude/hooks/deny_no_touch.py:80`. Even when the operator
+authorises the wiring in chat, the hook blocks the file-level
+write. The bootstrap PR is therefore intentionally
+operator-authored — the synthesizer prepares the diff, the
+operator commits and merges.
+
+## Validation checklist (operator)
+
+- [ ] PR diff contains EXACTLY the two added lines (one import, one
+      call). Nothing else.
+- [ ] CI green on every required check.
+- [ ] Frozen-contract sha256 unchanged.
+- [ ] No additional `register_*_routes` lines added.
+- [ ] No `register_execute_safe_routes` line added (forbidden by
+      v3.15.15.27 invariant; pinned by
+      `tests/unit/test_observability_security_invariants.py::test_dashboard_does_not_wire_execute_safe_routes`).
+
+## After merge
+
+Next deploy tick:
+
+1. recurring_maintenance refresh runs.
+2. human_needed re-scans dashboard.py, no longer detects the gap.
+3. human_needed event clears.
+4. governance_bootstrap drops the template.
+5. PWA Inbox card row clears on the operator's next refresh.

--- a/docs/governance/governance_bootstrap.md
+++ b/docs/governance/governance_bootstrap.md
@@ -1,0 +1,135 @@
+# Governance Bootstrap — operator runbook
+
+> Module: `reporting.governance_bootstrap`
+> Release: v3.15.16.9
+> Sibling docs: `human_needed.md`, `task_board.md`,
+> `agent_flow.md`, `recurring_maintenance.md`,
+> `approval_exception_inbox.md`.
+
+## TL;DR
+
+Pure read-only text synthesizer. Reads `logs/human_needed/latest.json`
+(v3.15.16.8) and produces copy-paste-able bootstrap-PR templates
+the operator can apply in seconds. Writes
+`logs/governance_bootstrap/latest.json`.
+
+The synthesizer **never** opens a branch, opens a PR, calls `gh`,
+calls `git`, or applies any patch. Pinned by source-text test.
+
+## What each template contains
+
+| field | contents |
+| --- | --- |
+| `template_id` | `gb_<short>` deterministic from the source event_id |
+| `source_event_id` | the v3.15.16.8 event this template was synthesized from |
+| `source_reason` | the v3.15.16.8 reason (e.g. `governance_bootstrap_required`) |
+| `branch_name` | `governance-bootstrap/<event_id>` |
+| `commit_message` | `governance-bootstrap: <short summary>` |
+| `file_diff` | byte-identical copy of the upstream `proposed_patch` |
+| `pr_title` | `governance-bootstrap: <short summary>` |
+| `pr_body` | operator-facing markdown body with cross-references |
+| `validation_checklist` | five-item canonical checklist |
+
+## Bootstrappable reasons
+
+The synthesizer emits a template for events whose reason is in:
+
+```
+governance_bootstrap_required
+no_touch_path_blocks_wiring
+allowlist_blocks_completion
+add_no_touch_carveout
+```
+
+`decision_cannot_be_inferred` and `system_cannot_proceed_safely`
+events are NOT auto-templated — they require human triage and
+have no deterministic patch.
+
+## Three template-shape cross-references
+
+* [Wiring `dashboard.py`](bootstrap_templates/wiring_dashboard_py.md) — the v3.15.16.5 case.
+* [Extend an agent allowlist](bootstrap_templates/extend_agent_allowlist.md) — the future v3.15.16.4 / v3.15.17.0 case.
+* [Add a no-touch carveout](bootstrap_templates/add_no_touch_carveout.md) — when a new path needs to be exempted from a no-touch rule.
+
+## Hard guarantees
+
+| guarantee | enforcement |
+| --- | --- |
+| Stdlib-only | no subprocess, no `gh`, no `git`, no network — pinned by source-text test |
+| Text only | the module contains no `git apply`, `patch -`, `subprocess.run`, `subprocess.Popen` (pinned) |
+| `safe_to_execute` is always `false` | hard-coded literal in source; pinned |
+| Determinism | byte-identical `templates` list across runs (modulo `generated_at_utc`); pinned |
+| Stable ordering | templates sorted by `template_id` ascending |
+| Atomic writes | `tmp` + `os.replace` |
+| Output scope | writes only under `logs/governance_bootstrap/` |
+
+## CLI
+
+```
+python -m reporting.governance_bootstrap
+python -m reporting.governance_bootstrap --no-write
+python -m reporting.governance_bootstrap --status
+python -m reporting.governance_bootstrap --frozen-utc 2026-05-05T12:00:00Z
+```
+
+There is **no execute mode**.
+
+## Integration with the recurring scheduler
+
+`reporting.recurring_maintenance` (v3.15.15.23) gains:
+
+| `job_type` | risk | needs `gh`? | default interval | default enabled |
+| --- | --- | --- | --- | --- |
+| `refresh_governance_bootstrap` | LOW | no | 30 min | ✓ |
+
+## Operator workflow
+
+1. The recurring scheduler tick (every 30 min on every merge via
+   the v3.15.16.3 deploy hook) runs:
+   * `refresh_human_needed` → emits events
+   * `refresh_governance_bootstrap` → synthesizes templates
+2. Operator opens the PWA Inbox tab and sees a `failed_automation`
+   row referencing a `governance_bootstrap_required` event.
+3. Operator opens `logs/governance_bootstrap/latest.json` (or runs
+   `python -m reporting.governance_bootstrap --status`) and copies
+   the template's `branch_name`, `commit_message`, `file_diff`,
+   `pr_title`, `pr_body` into a tiny one-shot bootstrap PR.
+4. Operator merges the bootstrap PR after CI passes.
+5. Next tick: `human_needed` no longer detects the gap → event
+   clears → governance_bootstrap drops the template.
+6. Loop continues.
+
+## What this module is NOT
+
+* **Not** an actuator. It produces text only. The v3.15.16.11
+  execution engine (out of scope for Phase 1) is the only
+  component that may turn templates into actual PRs, and even
+  then it never auto-merges governance-bootstrap PRs (operator
+  merges those manually per v3.15.16.10 §9).
+* **Not** a risk arbiter. Risk classification belongs to
+  `roadmap_execution_protocol` and `human_needed`.
+
+## Files added by v3.15.16.9
+
+```
+reporting/governance_bootstrap.py
+reporting/recurring_maintenance.py        (one new closed job entry)
+tests/unit/test_governance_bootstrap.py
+tests/unit/test_recurring_maintenance.py  (registry + per-job assertion)
+docs/governance/governance_bootstrap.md   (this file)
+docs/governance/bootstrap_templates/wiring_dashboard_py.md
+docs/governance/bootstrap_templates/extend_agent_allowlist.md
+docs/governance/bootstrap_templates/add_no_touch_carveout.md
+docs/governance/recurring_maintenance.md  (job table + section)
+docs/roadmap/qre_roadmap_v6_1.md
+```
+
+No new dependency. No `dashboard/dashboard.py` change. No
+`.claude/` change. No frontend change. No frozen-contract change.
+No live / paper / shadow / risk path touch. No test weakening.
+
+## Cross-references
+
+* `reporting/human_needed.py` — supplies the events.
+* `reporting/approval_inbox.py` — surfaces the corresponding
+  inbox row.

--- a/docs/governance/recurring_maintenance.md
+++ b/docs/governance/recurring_maintenance.md
@@ -80,6 +80,7 @@ python -m reporting.recurring_maintenance --run-due-once \
 | `refresh_task_board` | LOW | no | 30 min | ✓ | refreshes `task_board` state-machine digest (v3.15.16.6) |
 | `refresh_agent_flow` | LOW | no | 30 min | ✓ | refreshes `agent_flow` orchestration digest (v3.15.16.7) |
 | `refresh_human_needed` | LOW | no | 30 min | ✓ | refreshes `human_needed` blocker-detection digest (v3.15.16.8) |
+| `refresh_governance_bootstrap` | LOW | no | 30 min | ✓ | refreshes `governance_bootstrap` PR-template digest (v3.15.16.9) |
 
 ## Dependabot execute-safe — two-layer opt-in
 
@@ -250,6 +251,27 @@ Hard guarantees re-asserted at this layer:
   patch-application call (pinned).
 * The job never starts a branch, never opens a PR, never merges,
   never invokes `gh`.
+
+## Governance-bootstrap synthesizer (v3.15.16.9)
+
+A new closed job entry — `refresh_governance_bootstrap` — runs
+the read-only PR-template synthesizer
+(`reporting.governance_bootstrap.collect_snapshot` +
+`write_outputs`) every 30 minutes by default. Reads
+`logs/human_needed/latest.json` and writes
+`logs/governance_bootstrap/latest.json` with one copy-paste-able
+PR template per bootstrappable event. Pinned by tests: the module
+contains no patch-application code; produces text only.
+
+Hard guarantees re-asserted at this layer:
+
+* LOW risk; `needs_gh = False`; default-enabled.
+* `safe_to_execute` is hard-coded `false` in the digest schema.
+* The job never starts a branch, never opens a PR, never merges,
+  never invokes `gh`, never applies a patch.
+
+See `docs/governance/governance_bootstrap.md` for the synthesizer
+contract and the three template-shape cross-references.
 
 ## Deploy-hook integration (v3.15.16.3)
 

--- a/docs/roadmap/qre_roadmap_v6_1.md
+++ b/docs/roadmap/qre_roadmap_v6_1.md
@@ -237,6 +237,36 @@ only on these events.
   `docs/roadmap/qre_roadmap_v6_1.md`
 * `risk_class`: LOW
 * `proposal_type`: observability_addition
+* `status`: done
+
+### v3.15.16.9 — Governance-bootstrap PR-template synthesizer
+
+Ship `reporting/governance_bootstrap.py` — pure read-only text
+synthesizer. Reads `logs/human_needed/latest.json` (v3.15.16.8) and
+produces copy-paste-able bootstrap-PR templates the operator can
+apply in seconds. Each template carries `branch_name`,
+`commit_message`, `file_diff` (byte-identical copy of the upstream
+`proposed_patch`), `pr_title`, `pr_body`, `validation_checklist`.
+Three template shapes ship under `docs/governance/bootstrap_templates/`.
+The synthesizer NEVER opens a branch, NEVER opens a PR, NEVER
+calls `gh`, NEVER applies a patch (pinned by source-text test
+forbidding `git apply`, `patch -`, `subprocess.run`,
+`subprocess.Popen`). JOB_REFRESH_GOVERNANCE_BOOTSTRAP added to
+`recurring_maintenance`. **Final Phase 1 release before the
+operator-authored v3.15.16.10 governance ratification.**
+
+* `affected_files`: `reporting/governance_bootstrap.py`,
+  `reporting/recurring_maintenance.py`,
+  `tests/unit/test_governance_bootstrap.py`,
+  `tests/unit/test_recurring_maintenance.py`,
+  `docs/governance/governance_bootstrap.md`,
+  `docs/governance/bootstrap_templates/wiring_dashboard_py.md`,
+  `docs/governance/bootstrap_templates/extend_agent_allowlist.md`,
+  `docs/governance/bootstrap_templates/add_no_touch_carveout.md`,
+  `docs/governance/recurring_maintenance.md`,
+  `docs/roadmap/qre_roadmap_v6_1.md`
+* `risk_class`: LOW
+* `proposal_type`: observability_addition
 * `status`: proposed
 
 ---

--- a/reporting/governance_bootstrap.py
+++ b/reporting/governance_bootstrap.py
@@ -1,0 +1,487 @@
+"""Governance-Bootstrap PR-Template Synthesizer (v3.15.16.9).
+
+Pure read-only text synthesizer. Reads logs/human_needed/latest.json
+(v3.15.16.8) and produces copy-paste-able bootstrap-PR templates
+the operator can apply in seconds. Each template is byte-identical
+across runs for the same input.
+
+The synthesizer **never**:
+
+* opens a branch
+* opens a PR
+* invokes ``gh``
+* invokes ``git``
+* writes to anything outside ``logs/governance_bootstrap/``
+* mutates any input artifact
+
+For every human_needed event with reason in
+``governance_bootstrap_required`` the synthesizer emits a
+template with:
+
+* ``branch_name``: deterministic branch shape
+  ``governance-bootstrap/<event_id>``.
+* ``commit_message``: ``governance-bootstrap: <short summary>``.
+* ``file_diff``: literal text (NOT applied — copied as-is from
+  the upstream event's ``proposed_patch``).
+* ``pr_title``: ``governance-bootstrap: <short summary>``.
+* ``pr_body``: explanatory operator-facing text + cross-reference
+  to the underlying event_id and the related PR.
+* ``validation_checklist``: deterministic list the operator can
+  tick.
+
+Hard guarantees (enforced by code AND tests)
+--------------------------------------------
+
+* Stdlib-only. No subprocess, no ``gh``, no ``git``, no network.
+* Output limited to ``logs/governance_bootstrap/``.
+* Atomic writes (``tmp`` + ``os.replace``).
+* ``safe_to_execute`` is hard-coded ``false`` at the digest level.
+* Module source contains no ``git apply``, ``patch -``,
+  ``subprocess.run``, ``subprocess.Popen`` (pinned). The synthesizer
+  produces text only.
+* Determinism: two runs on the same input produce a byte-identical
+  ``templates`` list (modulo ``generated_at_utc``).
+* Closed reason vocabulary mirrors v3.15.16.8.
+
+CLI
+---
+
+::
+
+    python -m reporting.governance_bootstrap
+    python -m reporting.governance_bootstrap --no-write
+    python -m reporting.governance_bootstrap --status
+
+Stdlib-only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT: Path = Path(__file__).resolve().parent.parent
+MODULE_VERSION: str = "v3.15.16.9"
+SCHEMA_VERSION: int = 1
+
+DIGEST_DIR_JSON: Path = REPO_ROOT / "logs" / "governance_bootstrap"
+SOURCE_HUMAN_NEEDED: Path = (
+    REPO_ROOT / "logs" / "human_needed" / "latest.json"
+)
+
+
+# ---------------------------------------------------------------------------
+# Closed taxonomies
+# ---------------------------------------------------------------------------
+
+
+# Reasons that produce a bootstrap-PR template. Other reasons (e.g.
+# decision_cannot_be_inferred) require human triage and have no
+# deterministic patch — we deliberately do not synthesize templates
+# for them.
+BOOTSTRAPPABLE_REASONS: tuple[str, ...] = (
+    "governance_bootstrap_required",
+    "no_touch_path_blocks_wiring",
+    "allowlist_blocks_completion",
+    "add_no_touch_carveout",
+)
+
+
+REC_OK: str = "ok"
+REC_NOT_AVAILABLE: str = "not_available"
+
+FINAL_RECOMMENDATIONS: tuple[str, ...] = (REC_OK, REC_NOT_AVAILABLE)
+
+
+# ---------------------------------------------------------------------------
+# Time / path helpers
+# ---------------------------------------------------------------------------
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _rel(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(REPO_ROOT.resolve())).replace(
+            "\\", "/"
+        )
+    except ValueError:
+        return str(path).replace("\\", "/")
+
+
+# ---------------------------------------------------------------------------
+# Source read (passive)
+# ---------------------------------------------------------------------------
+
+
+def _read_json_artifact(
+    path: Path,
+) -> tuple[dict[str, Any] | None, str | None]:
+    if not path.exists():
+        return (None, "missing")
+    if not path.is_file():
+        return (None, "not_a_file")
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as e:
+        return (None, f"unreadable: {type(e).__name__}")
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as e:
+        return (None, f"malformed: {type(e).__name__}")
+    if not isinstance(data, dict):
+        return (None, "not_an_object")
+    return (data, None)
+
+
+# ---------------------------------------------------------------------------
+# Per-event template synthesis
+# ---------------------------------------------------------------------------
+
+
+def _short_summary(event: Mapping[str, Any]) -> str:
+    """Short one-line summary used in branch / commit / PR title."""
+    reason = str(event.get("reason") or "")
+    component = str(event.get("blocking_component") or "")
+    # Strip leading file/module indicators to keep the message tight.
+    short = component.split(":", 1)[-1] if ":" in component else component
+    return f"{reason}: {short}"[:120]
+
+
+def _commit_message(event: Mapping[str, Any]) -> str:
+    return f"governance-bootstrap: {_short_summary(event)}"
+
+
+def _branch_name(event: Mapping[str, Any]) -> str:
+    event_id = str(event.get("event_id") or "")
+    if not event_id:
+        return "governance-bootstrap/unknown"
+    return f"governance-bootstrap/{event_id}"
+
+
+def _pr_title(event: Mapping[str, Any]) -> str:
+    return f"governance-bootstrap: {_short_summary(event)}"
+
+
+def _pr_body(event: Mapping[str, Any]) -> str:
+    reason = str(event.get("reason") or "")
+    component = str(event.get("blocking_component") or "")
+    required = str(event.get("required_action") or "")
+    impact = str(event.get("impact") or "MEDIUM")
+    priority = str(event.get("priority") or "MEDIUM")
+    related = event.get("related_item")
+    body_lines = [
+        "## Governance Bootstrap PR",
+        "",
+        "Synthesized automatically by `reporting.governance_bootstrap`",
+        f"({MODULE_VERSION}) from a v3.15.16.8 `human_needed` event.",
+        "",
+        "## Source event",
+        "",
+        f"- event_id: `{event.get('event_id', '')}`",
+        f"- reason: `{reason}`",
+        f"- blocking_component: `{component}`",
+        f"- impact: `{impact}`",
+        f"- priority: `{priority}`",
+    ]
+    if isinstance(related, str) and related:
+        body_lines.append(f"- related_item: `{related}`")
+    body_lines.extend(
+        [
+            "",
+            "## Required operator action",
+            "",
+            required,
+            "",
+            "## Validation checklist",
+            "",
+            "- [ ] PR diff matches the synthesized `file_diff` byte-for-byte",
+            "- [ ] CI green on every required check",
+            "- [ ] Frozen-contract sha256 unchanged",
+            "- [ ] No `.claude/` change beyond the explicit governance-bootstrap delta",
+            "- [ ] No live / paper / shadow / risk path touch",
+            "",
+            "## Out of scope",
+            "",
+            "- This PR resolves only the specific blocker above.",
+            "- The autonomous engine (v3.15.16.11, future) does NOT auto-merge",
+            "  governance-bootstrap PRs — operator merges manually.",
+            "",
+            "🤖 Synthesized by `reporting.governance_bootstrap`",
+        ]
+    )
+    return "\n".join(body_lines)
+
+
+def _validation_checklist() -> list[str]:
+    """Deterministic checklist surfaced as a structured field."""
+    return [
+        "PR diff matches the synthesized file_diff byte-for-byte",
+        "CI green on every required check",
+        "Frozen-contract sha256 unchanged",
+        "No .claude/ change beyond the explicit governance-bootstrap delta",
+        "No live / paper / shadow / risk path touch",
+    ]
+
+
+def _build_template(event: Mapping[str, Any]) -> dict[str, Any] | None:
+    """Synthesize one bootstrap-PR template from one human_needed
+    event. Returns ``None`` if the event has no derivable patch
+    (proposed_patch is None) or its reason is not in the bootstrappable
+    set."""
+    reason = str(event.get("reason") or "")
+    if reason not in BOOTSTRAPPABLE_REASONS:
+        return None
+    proposed = event.get("proposed_patch")
+    if not isinstance(proposed, str) or not proposed.strip():
+        return None
+    event_id = str(event.get("event_id") or "")
+    if not event_id:
+        return None
+    return {
+        "template_id": f"gb_{event_id[2:]}" if event_id.startswith("h_") else f"gb_{event_id}",
+        "source_event_id": event_id,
+        "source_reason": reason,
+        "branch_name": _branch_name(event),
+        "commit_message": _commit_message(event),
+        "file_diff": str(proposed),  # text only — NEVER applied
+        "pr_title": _pr_title(event),
+        "pr_body": _pr_body(event),
+        "validation_checklist": _validation_checklist(),
+        "evidence": {
+            "blocking_component": str(event.get("blocking_component") or ""),
+            "impact": str(event.get("impact") or "MEDIUM"),
+            "priority": str(event.get("priority") or "MEDIUM"),
+            "related_item": event.get("related_item"),
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Snapshot construction
+# ---------------------------------------------------------------------------
+
+
+def collect_snapshot(
+    *,
+    frozen_utc: str | None = None,
+    human_needed_override: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build the full governance-bootstrap digest. Pure function."""
+    generated = frozen_utc or _utcnow()
+
+    if human_needed_override is not None:
+        hn: Mapping[str, Any] | None = human_needed_override
+        hn_error: str | None = None
+    else:
+        hn, hn_error = _read_json_artifact(SOURCE_HUMAN_NEEDED)
+
+    if hn is None:
+        return _build_not_available_digest(
+            generated_at_utc=generated,
+            reason=hn_error or "unknown",
+            source_path=_rel(SOURCE_HUMAN_NEEDED),
+        )
+
+    events = hn.get("events")
+    if not isinstance(events, list):
+        return _build_not_available_digest(
+            generated_at_utc=generated,
+            reason="events_field_not_a_list",
+            source_path=_rel(SOURCE_HUMAN_NEEDED),
+        )
+
+    templates: list[dict[str, Any]] = []
+    skipped = 0
+    for ev in events:
+        if not isinstance(ev, Mapping):
+            skipped += 1
+            continue
+        t = _build_template(ev)
+        if t is None:
+            skipped += 1
+            continue
+        templates.append(t)
+
+    # Stable ordering: by template_id ascending.
+    templates.sort(key=lambda t: str(t.get("template_id") or ""))
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": "governance_bootstrap_digest",
+        "module_version": MODULE_VERSION,
+        "generated_at_utc": generated,
+        "mode": "dry-run",
+        "source_human_needed": {
+            "path": _rel(SOURCE_HUMAN_NEEDED),
+            "status": "ok",
+            "module_version": hn.get("module_version"),
+            "events_total": len(events),
+            "skipped_events": skipped,
+        },
+        "policy": {
+            "bootstrappable_reasons": list(BOOTSTRAPPABLE_REASONS),
+        },
+        "counts": {
+            "templates_total": len(templates),
+        },
+        "templates": templates,
+        "final_recommendation": REC_OK,
+        "safe_to_execute": False,
+    }
+
+
+def _build_not_available_digest(
+    *, generated_at_utc: str, reason: str, source_path: str
+) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": "governance_bootstrap_digest",
+        "module_version": MODULE_VERSION,
+        "generated_at_utc": generated_at_utc,
+        "mode": "dry-run",
+        "source_human_needed": {
+            "path": source_path,
+            "status": "not_available",
+            "error": reason,
+            "module_version": None,
+            "events_total": 0,
+            "skipped_events": 0,
+        },
+        "policy": {
+            "bootstrappable_reasons": list(BOOTSTRAPPABLE_REASONS),
+        },
+        "counts": {
+            "templates_total": 0,
+        },
+        "templates": [],
+        "final_recommendation": REC_NOT_AVAILABLE,
+        "safe_to_execute": False,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Atomic write
+# ---------------------------------------------------------------------------
+
+
+def write_outputs(snapshot: Mapping[str, Any]) -> dict[str, str]:
+    DIGEST_DIR_JSON.mkdir(parents=True, exist_ok=True)
+    ts = str(snapshot["generated_at_utc"]).replace(":", "-")
+    json_now = DIGEST_DIR_JSON / f"{ts}.json"
+    json_latest = DIGEST_DIR_JSON / "latest.json"
+    history = DIGEST_DIR_JSON / "history.jsonl"
+    payload = json.dumps(snapshot, sort_keys=True, indent=2)
+
+    tmp_now = json_now.with_suffix(json_now.suffix + ".tmp")
+    tmp_now.write_text(payload, encoding="utf-8")
+    os.replace(tmp_now, json_now)
+
+    tmp_latest = json_latest.with_suffix(json_latest.suffix + ".tmp")
+    tmp_latest.write_text(payload, encoding="utf-8")
+    os.replace(tmp_latest, json_latest)
+
+    compact = json.dumps(snapshot, sort_keys=True, separators=(",", ":"))
+    with history.open("a", encoding="utf-8") as f:
+        f.write(compact + "\n")
+
+    return {
+        "latest": _rel(json_latest),
+        "timestamped": _rel(json_now),
+        "history": _rel(history),
+    }
+
+
+def read_latest_snapshot() -> dict[str, Any] | None:
+    p = DIGEST_DIR_JSON / "latest.json"
+    if not p.exists():
+        return None
+    try:
+        text = p.read_text(encoding="utf-8")
+        data = json.loads(text)
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="reporting.governance_bootstrap",
+        description=(
+            f"Governance-bootstrap PR-template synthesizer "
+            f"({MODULE_VERSION}). Stdlib-only. Read-only text "
+            "generation over the human_needed digest."
+        ),
+    )
+    g = parser.add_mutually_exclusive_group(required=False)
+    g.add_argument(
+        "--mode",
+        type=str,
+        default="dry-run",
+        choices=["dry-run"],
+        help="Operating mode. Only dry-run is supported.",
+    )
+    g.add_argument(
+        "--status",
+        action="store_true",
+        help="Read and print the latest digest from logs/.",
+    )
+    parser.add_argument(
+        "--no-write",
+        action="store_true",
+        help="Do not persist the JSON digest (stdout only).",
+    )
+    parser.add_argument(
+        "--frozen-utc",
+        type=str,
+        default=None,
+        help="Pin generated_at_utc for deterministic tests.",
+    )
+    parser.add_argument(
+        "--indent",
+        type=int,
+        default=2,
+        help="JSON indent for stdout (0 for compact).",
+    )
+    args = parser.parse_args(argv)
+
+    if args.status:
+        snap = read_latest_snapshot()
+        if snap is None:
+            print(
+                json.dumps(
+                    {"status": "not_available", "reason": "missing"},
+                    indent=args.indent or None,
+                )
+            )
+            return 1
+        print(json.dumps(snap, sort_keys=True, indent=args.indent or None))
+        return 0
+
+    snap = collect_snapshot(frozen_utc=args.frozen_utc)
+    if not args.no_write:
+        write_outputs(snap)
+    print(json.dumps(snap, sort_keys=True, indent=args.indent or None))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/reporting/recurring_maintenance.py
+++ b/reporting/recurring_maintenance.py
@@ -104,6 +104,10 @@ JOB_REFRESH_AGENT_FLOW: str = "refresh_agent_flow"
 # with proposed_patch text. Future push notifications trigger only
 # from these events.
 JOB_REFRESH_HUMAN_NEEDED: str = "refresh_human_needed"
+# v3.15.16.9 — read-only governance-bootstrap PR-template
+# synthesizer. Reads logs/human_needed/latest.json and produces
+# copy-paste-able bootstrap-PR templates (text only).
+JOB_REFRESH_GOVERNANCE_BOOTSTRAP: str = "refresh_governance_bootstrap"
 
 JOB_TYPES: tuple[str, ...] = (
     JOB_REFRESH_WORKLOOP_RUNTIME,
@@ -115,6 +119,7 @@ JOB_TYPES: tuple[str, ...] = (
     JOB_REFRESH_TASK_BOARD,
     JOB_REFRESH_AGENT_FLOW,
     JOB_REFRESH_HUMAN_NEEDED,
+    JOB_REFRESH_GOVERNANCE_BOOTSTRAP,
 )
 
 
@@ -385,6 +390,28 @@ def _exec_refresh_human_needed() -> dict[str, Any]:
     }
 
 
+def _exec_refresh_governance_bootstrap() -> dict[str, Any]:
+    """Run the v3.15.16.9 governance-bootstrap PR-template
+    synthesizer (read-only). Reads logs/human_needed/latest.json
+    (v3.15.16.8) and writes logs/governance_bootstrap/latest.json
+    with one copy-paste-able PR template per bootstrappable event.
+    Never starts a branch, never opens a PR, never invokes ``gh``."""
+    from reporting.governance_bootstrap import collect_snapshot, write_outputs
+
+    snap = collect_snapshot()
+    write_outputs(snap)
+    counts = snap.get("counts") or {}
+    return {
+        "summary": (
+            f"governance_bootstrap "
+            f"{snap.get('final_recommendation') or 'no recommendation'}"
+        ),
+        "evidence": {
+            "templates_total": counts.get("templates_total"),
+        },
+    }
+
+
 def _exec_dependabot_execute_safe() -> dict[str, Any]:
     """Delegate to the existing ``reporting.github_pr_lifecycle``
     execute-safe path. The lifecycle module owns every Dependabot
@@ -511,6 +538,18 @@ _JOB_REGISTRY: dict[str, dict[str, Any]] = {
         "description": (
             "Refresh human_needed event-detection digest "
             "(read-only blocker detection with proposed_patch synthesis)."
+        ),
+        "risk_class": RISK_LOW,
+        "needs_gh": False,
+        "timeout_seconds": DEFAULT_JOB_TIMEOUT_SECONDS,
+    },
+    JOB_REFRESH_GOVERNANCE_BOOTSTRAP: {
+        "default_interval_seconds": 30 * 60,
+        "default_enabled": True,
+        "executor": _exec_refresh_governance_bootstrap,
+        "description": (
+            "Refresh governance-bootstrap PR-template digest "
+            "(read-only text synthesis over the human_needed events)."
         ),
         "risk_class": RISK_LOW,
         "needs_gh": False,

--- a/tests/unit/test_governance_bootstrap.py
+++ b/tests/unit/test_governance_bootstrap.py
@@ -1,0 +1,327 @@
+"""Unit tests for ``reporting.governance_bootstrap`` (v3.15.16.9)."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reporting import governance_bootstrap as gb
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+MODULE_PATH = REPO_ROOT / "reporting" / "governance_bootstrap.py"
+
+
+def _strip_strings_and_comments(src: str) -> str:
+    """Return ``src`` with triple-quoted string literals and ``#``
+    line comments removed. Sufficient for source-text invariant
+    checks that need to look only at executable code, not at
+    docstrings or in-line documentation that legitimately mentions
+    forbidden tokens (e.g. ``git apply``)."""
+    src = re.sub(r'"""[\s\S]*?"""', '""', src)
+    src = re.sub(r"'''[\s\S]*?'''", "''", src)
+    src = re.sub(r"#[^\n]*", "", src)
+    return src
+
+
+@pytest.fixture
+def isolated_digest_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Path:
+    monkeypatch.setattr(gb, "DIGEST_DIR_JSON", tmp_path / "gb")
+    return tmp_path
+
+
+def _event(
+    event_id: str,
+    *,
+    reason: str = "governance_bootstrap_required",
+    blocking_component: str = "dashboard/dashboard.py:register_xyz_routes",
+    required_action: str = "Open a one-shot bootstrap PR.",
+    proposed_patch: str | None = (
+        "from dashboard.api_xyz import register_xyz_routes\n"
+        "register_xyz_routes(app)\n"
+    ),
+    impact: str = "MEDIUM",
+    priority: str = "HIGH",
+    related_item: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "event_id": event_id,
+        "reason": reason,
+        "blocking_component": blocking_component,
+        "required_action": required_action,
+        "proposed_patch": proposed_patch,
+        "impact": impact,
+        "priority": priority,
+        "related_item": related_item,
+        "evidence": {},
+    }
+
+
+def _hn(events: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "report_kind": "human_needed_digest",
+        "module_version": "v3.15.16.8",
+        "events": events,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Hard-coded digest invariants
+# ---------------------------------------------------------------------------
+
+
+def test_safe_to_execute_is_always_false_with_templates() -> None:
+    snap = gb.collect_snapshot(
+        human_needed_override=_hn([_event("h_aaaaaaaaaa")]),
+        frozen_utc="2026-05-05T12:00:00Z",
+    )
+    assert snap["safe_to_execute"] is False
+
+
+def test_safe_to_execute_is_false_when_not_available() -> None:
+    snap = gb.collect_snapshot(
+        human_needed_override={"events": "not a list"},
+        frozen_utc="2026-05-05T12:00:00Z",
+    )
+    assert snap["final_recommendation"] == gb.REC_NOT_AVAILABLE
+    assert snap["safe_to_execute"] is False
+
+
+def test_module_version_pinned() -> None:
+    assert gb.MODULE_VERSION == "v3.15.16.9"
+
+
+def test_schema_version_pinned() -> None:
+    assert gb.SCHEMA_VERSION == 1
+
+
+# ---------------------------------------------------------------------------
+# Template synthesis
+# ---------------------------------------------------------------------------
+
+
+def test_governance_bootstrap_event_produces_template() -> None:
+    snap = gb.collect_snapshot(
+        human_needed_override=_hn([_event("h_aaaaaaaaaa")]),
+        frozen_utc="2026-05-05T12:00:00Z",
+    )
+    assert snap["counts"]["templates_total"] == 1
+    t = snap["templates"][0]
+    assert t["source_event_id"] == "h_aaaaaaaaaa"
+    assert t["source_reason"] == "governance_bootstrap_required"
+    assert t["branch_name"] == "governance-bootstrap/h_aaaaaaaaaa"
+    assert t["commit_message"].startswith("governance-bootstrap:")
+    assert t["pr_title"].startswith("governance-bootstrap:")
+    # file_diff is byte-identical to proposed_patch
+    assert t["file_diff"] == (
+        "from dashboard.api_xyz import register_xyz_routes\n"
+        "register_xyz_routes(app)\n"
+    )
+    # PR body references the source event id
+    assert "h_aaaaaaaaaa" in t["pr_body"]
+    # validation_checklist is the canonical list
+    assert isinstance(t["validation_checklist"], list)
+    assert len(t["validation_checklist"]) == 5
+
+
+def test_event_without_proposed_patch_is_skipped() -> None:
+    snap = gb.collect_snapshot(
+        human_needed_override=_hn(
+            [_event("h_aaaaaaaaaa", proposed_patch=None)]
+        ),
+        frozen_utc="2026-05-05T12:00:00Z",
+    )
+    assert snap["counts"]["templates_total"] == 0
+    assert snap["source_human_needed"]["skipped_events"] == 1
+
+
+def test_decision_unclear_event_is_skipped() -> None:
+    """decision_cannot_be_inferred is not in BOOTSTRAPPABLE_REASONS."""
+    snap = gb.collect_snapshot(
+        human_needed_override=_hn(
+            [
+                _event(
+                    "h_aaaaaaaaaa",
+                    reason="decision_cannot_be_inferred",
+                    proposed_patch="some text",
+                )
+            ]
+        ),
+        frozen_utc="2026-05-05T12:00:00Z",
+    )
+    assert snap["counts"]["templates_total"] == 0
+
+
+def test_v3_15_16_5_wiring_gap_template_is_byte_identical_across_runs() -> None:
+    """Determinism canary: feed the canonical v3.15.16.5 wiring gap
+    event and assert the synthesized template is byte-identical
+    across two runs."""
+    ev = _event(
+        "h_canonical1",
+        blocking_component="dashboard/dashboard.py:register_roadmap_priority_routes",
+        proposed_patch=(
+            "from dashboard.api_roadmap_priority import register_roadmap_priority_routes\n"
+            "register_roadmap_priority_routes(app)\n"
+        ),
+    )
+    s1 = gb.collect_snapshot(
+        human_needed_override=_hn([ev]),
+        frozen_utc="2026-05-05T12:00:00Z",
+    )
+    s2 = gb.collect_snapshot(
+        human_needed_override=_hn([ev]),
+        frozen_utc="2026-05-05T12:00:00Z",
+    )
+    assert s1["templates"] == s2["templates"]
+    t = s1["templates"][0]
+    # The proposed_patch is the literal two-line wiring edit.
+    assert "from dashboard.api_roadmap_priority import register_roadmap_priority_routes" in t["file_diff"]
+    assert "register_roadmap_priority_routes(app)" in t["file_diff"]
+    # The branch name is deterministic.
+    assert t["branch_name"] == "governance-bootstrap/h_canonical1"
+
+
+def test_template_id_deterministic() -> None:
+    snap = gb.collect_snapshot(
+        human_needed_override=_hn([_event("h_aaaaaaaaaa")]),
+        frozen_utc="2026-05-05T12:00:00Z",
+    )
+    t = snap["templates"][0]
+    # Strips the h_ prefix and re-prefixes with gb_.
+    assert t["template_id"] == "gb_aaaaaaaaaa"
+
+
+# ---------------------------------------------------------------------------
+# Source availability
+# ---------------------------------------------------------------------------
+
+
+def test_missing_human_needed_yields_not_available() -> None:
+    snap = gb.collect_snapshot(
+        human_needed_override={"not": "valid"},
+        frozen_utc="2026-05-05T12:00:00Z",
+    )
+    assert snap["final_recommendation"] == gb.REC_NOT_AVAILABLE
+
+
+def test_empty_events_list_is_ok_with_zero_templates() -> None:
+    snap = gb.collect_snapshot(
+        human_needed_override=_hn([]),
+        frozen_utc="2026-05-05T12:00:00Z",
+    )
+    assert snap["final_recommendation"] == gb.REC_OK
+    assert snap["counts"]["templates_total"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Module-source guarantees
+# ---------------------------------------------------------------------------
+
+
+def test_module_source_no_subprocess_no_network() -> None:
+    src = MODULE_PATH.read_text(encoding="utf-8")
+    forbidden = (
+        "import subprocess",
+        "from subprocess",
+        "shell=True",
+        "os.system(",
+        "Popen(",
+        "import requests",
+        "import urllib.request",
+    )
+    for tok in forbidden:
+        assert tok not in src, f"forbidden token: {tok!r}"
+
+
+def test_module_source_no_gh_or_git_invocation() -> None:
+    """Strip docstrings + comments before checking — the module's
+    docstring legitimately documents what it does NOT do (mentions
+    `gh`, `git`, etc. as prose). We only care about executable code."""
+    src = _strip_strings_and_comments(MODULE_PATH.read_text(encoding="utf-8"))
+    forbidden = ('"gh"', "'gh'", '"git"', "'git'", "Popen", "gh pr ", "git checkout ")
+    for tok in forbidden:
+        assert tok not in src, f"forbidden gh/git token in executable code: {tok!r}"
+
+
+def test_module_source_does_not_apply_patches() -> None:
+    """The synthesizer produces text only — never applies patches.
+    Strip docstrings + comments so the test inspects executable
+    code only (the module's docstring explicitly mentions
+    `git apply` / `subprocess.run` as the forbidden behaviours)."""
+    src = _strip_strings_and_comments(MODULE_PATH.read_text(encoding="utf-8"))
+    forbidden = (
+        "git apply",
+        "patch -",
+        "subprocess.run",
+        "subprocess.Popen",
+    )
+    for tok in forbidden:
+        assert tok not in src, (
+            f"forbidden patch-application token in executable code: {tok!r}"
+        )
+
+
+def test_module_source_no_branch_or_pr_creation() -> None:
+    src = MODULE_PATH.read_text(encoding="utf-8")
+    forbidden = (
+        "git checkout -b",
+        "git push",
+        "gh pr create",
+        "gh pr merge",
+    )
+    for tok in forbidden:
+        assert tok not in src, f"forbidden action: {tok!r}"
+
+
+def test_safe_to_execute_field_is_hard_coded_false() -> None:
+    src = MODULE_PATH.read_text(encoding="utf-8")
+    occurrences = re.findall(r'"safe_to_execute":\s*([A-Za-z]+)', src)
+    assert occurrences, "safe_to_execute key not found in module source"
+    assert all(v == "False" for v in occurrences), (
+        f"safe_to_execute is not hard-coded False everywhere: {occurrences!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Atomic write
+# ---------------------------------------------------------------------------
+
+
+def test_write_outputs_atomic_and_scoped(isolated_digest_dir: Path) -> None:
+    snap = gb.collect_snapshot(
+        human_needed_override=_hn([_event("h_aaaaaaaaaa")]),
+        frozen_utc="2026-05-05T12:00:00Z",
+    )
+    paths = gb.write_outputs(snap)
+    base = isolated_digest_dir / "gb"
+    assert (base / "latest.json").exists()
+    assert (base / "history.jsonl").exists()
+    assert paths["latest"].endswith("latest.json")
+    leftover = list(base.glob("*.tmp"))
+    assert leftover == []
+
+
+# ---------------------------------------------------------------------------
+# CLI surface
+# ---------------------------------------------------------------------------
+
+
+def test_cli_only_dry_run_mode_allowed() -> None:
+    with pytest.raises(SystemExit):
+        gb.main(["--mode", "execute-safe"])
+
+
+def test_cli_status_returns_not_available_when_missing(
+    isolated_digest_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    rc = gb.main(["--status"])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "not_available" in out

--- a/tests/unit/test_recurring_maintenance.py
+++ b/tests/unit/test_recurring_maintenance.py
@@ -95,6 +95,15 @@ def isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setitem(
         rm._JOB_REGISTRY, rm.JOB_REFRESH_HUMAN_NEEDED, hn_spec
     )
+    # v3.15.16.9 — same isolation rationale: the
+    # governance_bootstrap executor reads logs/human_needed and
+    # writes logs/governance_bootstrap/. Stub it for tests using
+    # the ``isolated`` fixture.
+    gb_spec = dict(rm._JOB_REGISTRY[rm.JOB_REFRESH_GOVERNANCE_BOOTSTRAP])
+    gb_spec["executor"] = lambda: {"summary": "ok (test stub)"}
+    monkeypatch.setitem(
+        rm._JOB_REGISTRY, rm.JOB_REFRESH_GOVERNANCE_BOOTSTRAP, gb_spec
+    )
     return tmp_path
 
 
@@ -138,10 +147,12 @@ def test_job_registry_contains_only_approved_types() -> None:
         "refresh_agent_flow",
         # v3.15.16.8 — read-only human_needed event detection.
         "refresh_human_needed",
+        # v3.15.16.9 — read-only governance-bootstrap synthesizer.
+        "refresh_governance_bootstrap",
     }
     assert set(rm.JOB_TYPES) == expected
     assert set(rm._JOB_REGISTRY.keys()) == expected
-    assert len(rm.JOB_TYPES) == 9
+    assert len(rm.JOB_TYPES) == 10
 
 
 def test_roadmap_priority_job_is_low_risk_no_gh_enabled_by_default() -> None:
@@ -183,6 +194,17 @@ def test_human_needed_job_is_low_risk_no_gh_enabled_by_default() -> None:
     must not need ``gh``, and must be enabled by default (it is a
     pure read-only blocker-detection projection)."""
     spec = rm._JOB_REGISTRY[rm.JOB_REFRESH_HUMAN_NEEDED]
+    assert spec["risk_class"] == rm.RISK_LOW
+    assert spec["needs_gh"] is False
+    assert spec["default_enabled"] is True
+    assert spec["default_interval_seconds"] == 30 * 60
+
+
+def test_governance_bootstrap_job_is_low_risk_no_gh_enabled_by_default() -> None:
+    """v3.15.16.9: the governance-bootstrap refresh job must be LOW
+    risk, must not need ``gh``, and must be enabled by default
+    (it is a pure read-only text synthesizer)."""
+    spec = rm._JOB_REGISTRY[rm.JOB_REFRESH_GOVERNANCE_BOOTSTRAP]
     assert spec["risk_class"] == rm.RISK_LOW
     assert spec["needs_gh"] is False
     assert spec["default_enabled"] is True


### PR DESCRIPTION
## Roadmap protocol context

| Field | Value |
| --- | --- |
| `item_id` | `r_v3_15_16_9` |
| `item_type` | `observability_addition` |
| `risk_class` | `LOW` |
| `decision` | `allowed_read_only` |
| `requires_human` | `false` |
| `implementation_allowed` | `true` |
| `safe_to_execute` | `false` |

## Phase 1 of the autonomous engine — final release

Fourth and final read-only Phase 1 release. Closes the coordination foundation. Phase 2 (v3.15.16.10 governance + v3.15.16.11 execution engine) is strictly out of scope and requires operator-authored governance ratification.

## What ships

`reporting/governance_bootstrap.py` — pure read-only text synthesizer that reads `logs/human_needed/latest.json` (v3.15.16.8) and produces copy-paste-able bootstrap-PR templates per event.

Each template carries: `template_id`, `source_event_id`, `source_reason`, `branch_name`, `commit_message`, `file_diff` (byte-identical copy of upstream `proposed_patch`), `pr_title`, `pr_body`, `validation_checklist`.

## Bootstrappable reasons

```
governance_bootstrap_required   (canonical: v3.15.16.5 wiring gap)
no_touch_path_blocks_wiring
allowlist_blocks_completion
add_no_touch_carveout
```

`decision_cannot_be_inferred` and `system_cannot_proceed_safely` are deliberately NOT auto-templated — they require human triage.

## Three template-shape docs

- `docs/governance/bootstrap_templates/wiring_dashboard_py.md` — canonical v3.15.16.5 case
- `docs/governance/bootstrap_templates/extend_agent_allowlist.md` — future v3.15.16.4 / v3.15.17.0
- `docs/governance/bootstrap_templates/add_no_touch_carveout.md` — rare: hook carveout

## Hard guarantees (pinned by tests)

- Stdlib-only — no subprocess / `gh` / `git` / network in **executable** source (docstring legitimately mentions these as prose; tests strip docstrings + comments before checking)
- The synthesizer NEVER opens a branch, NEVER opens a PR, NEVER calls `gh`, NEVER applies a patch (`git apply`, `patch -`, `subprocess.run`, `subprocess.Popen` all forbidden in executable code)
- `safe_to_execute` hard-coded `false` (regex pin)
- Determinism: byte-identical templates across runs
- Stable ordering: templates sorted by `template_id` ascending
- Atomic write, output limited to `logs/governance_bootstrap/`

## Wiring

`recurring_maintenance` gains `JOB_REFRESH_GOVERNANCE_BOOTSTRAP` (LOW, no gh, default-enabled, 30-min cadence). **Tenth and final read-only job in the typed scheduler for Phase 1.**

## Validation gates

- [x] `python scripts/governance_lint.py` — OK
- [x] `sha256sum research/research_latest.json research/strategy_matrix.csv` — frozen hashes unchanged
- [x] `pytest tests/smoke -q` — 14 passed
- [x] `pytest tests/unit/test_governance_bootstrap.py tests/unit/test_recurring_maintenance.py -q` — **56 passed**
- [x] `pytest tests/unit -q` — **3345 passed, 3 skipped, 0 failed**
- [x] `npm --prefix frontend test -- --run` — 90 passed
- [x] `npm --prefix frontend run build` — OK

## Diff

```
reporting/governance_bootstrap.py                       | NEW (487 lines)
tests/unit/test_governance_bootstrap.py                 | NEW (327 lines)
reporting/recurring_maintenance.py                      | +39 (new closed job entry)
tests/unit/test_recurring_maintenance.py                | +24 (registry + per-job)
docs/governance/governance_bootstrap.md                 | NEW (135 lines)
docs/governance/bootstrap_templates/wiring_dashboard_py.md      | NEW (57 lines)
docs/governance/bootstrap_templates/extend_agent_allowlist.md   | NEW (51 lines)
docs/governance/bootstrap_templates/add_no_touch_carveout.md    | NEW (60 lines)
docs/governance/recurring_maintenance.md                | +22 (job table + section)
docs/roadmap/qre_roadmap_v6_1.md                        | +30 (mark .8 done; add .9)
10 files changed, 1231 insertions(+), 1 deletion(-)
```

## Out of scope (HARD STOP after this)

- v3.15.16.10 — execution authority governance (HIGH, operator-authored)
- v3.15.16.11 — execution engine Phase 1 (MEDIUM)
- Push notifications (v3.15.17.x)
- Any git/gh actuation

🤖 Generated with [Claude Code](https://claude.com/claude-code)