### PR TITLE
feat(v3.15.16.9b): loop closure visibility on Agent Control Overview

### DIFF
--- a/dashboard/api_agent_control.py
+++ b/dashboard/api_agent_control.py
@@ -43,6 +43,7 @@ Until that PR lands, the PWA frontend treats every endpoint as
 
 from __future__ import annotations
 
+import datetime as _dt
 import json
 from pathlib import Path
 from typing import Any
@@ -59,6 +60,21 @@ LOGS_DIR: Path = REPO_ROOT / "logs"
 # happens here, so this surface stays light and side-effect free.
 WORKLOOP_LATEST: Path = LOGS_DIR / "autonomous_workloop" / "latest.json"
 PR_LIFECYCLE_LATEST: Path = LOGS_DIR / "github_pr_lifecycle" / "latest.json"
+# v3.15.16.9b — loop closure visibility. Three additional artifacts
+# read by ``_loop_closure_summary()`` to surface whether the
+# v3.15.16.8 detection -> v3.15.16.9 templating -> operator-PR ->
+# loop-closure cycle has completed. Read-only.
+HUMAN_NEEDED_LATEST: Path = LOGS_DIR / "human_needed" / "latest.json"
+GOVERNANCE_BOOTSTRAP_LATEST: Path = (
+    LOGS_DIR / "governance_bootstrap" / "latest.json"
+)
+APPROVAL_INBOX_LATEST: Path = LOGS_DIR / "approval_inbox" / "latest.json"
+# Consistency window: when all three counts are zero, the three
+# generated_at_utc values must lie within this window of each
+# other to qualify as ``resolved``. Wider spread -> ``stale``
+# (the typed scheduler runs sequentially; a 10-min spread is the
+# conservative upper bound on a single tick's wall-clock cost).
+LOOP_CLOSURE_CONSISTENCY_WINDOW_SECONDS: int = 10 * 60
 
 # Frozen contracts the PWA surfaces verbatim (path + sha256 only).
 FROZEN_CONTRACTS: tuple[str, ...] = (
@@ -186,6 +202,185 @@ def _status_payload() -> dict[str, Any]:
         "approval_policy": _approval_policy_summary(),
         "autonomy_metrics": _autonomy_metrics_summary(),
         "roadmap_protocol": _roadmap_protocol_summary(),
+        "loop_closure": _loop_closure_summary(),
+    }
+
+
+def _loop_closure_summary() -> dict[str, Any]:
+    """v3.15.16.9b — surface the autonomous-loop closure state on
+    the existing Status card.
+
+    Reads three already-published artifacts:
+
+    * ``logs/human_needed/latest.json`` (v3.15.16.8) — counts.events_total,
+      top events[0].blocking_component, generated_at_utc.
+    * ``logs/governance_bootstrap/latest.json`` (v3.15.16.9) —
+      counts.templates_total, top templates[0].branch_name,
+      generated_at_utc.
+    * ``logs/approval_inbox/latest.json`` (v3.15.15.20+) — count of
+      data.items where source startswith ``human_needed:``,
+      generated_at_utc.
+
+    Returns the bounded envelope::
+
+        {status: "ok"|"not_available", reason?, data?: {
+            loop_state: "open"|"resolved"|"stale",
+            human_needed: {events_total, by_reason,
+                           top_blocking_component, generated_at_utc},
+            governance_bootstrap: {templates_total, top_branch_name,
+                                   generated_at_utc},
+            approval_inbox: {human_needed_derived_rows,
+                             generated_at_utc},
+            last_refreshed_utc: str
+        }}
+
+    Hard guarantees:
+
+    * ``loop_state`` is the semantic state, separate from
+      transport-level ``status``.
+    * No ``proposed_patch``, no ``pr_body``, no full ``events`` /
+      ``templates`` lists are returned. Only safe summary fields.
+    * Defensive: any missing / malformed artifact -> ``not_available``.
+    """
+    hn_env = _read_json_artifact(HUMAN_NEEDED_LATEST)
+    gb_env = _read_json_artifact(GOVERNANCE_BOOTSTRAP_LATEST)
+    ai_env = _read_json_artifact(APPROVAL_INBOX_LATEST)
+
+    if hn_env.get("status") != "ok":
+        return {
+            "status": "not_available",
+            "reason": f"human_needed: {hn_env.get('reason') or 'unknown'}",
+        }
+    if gb_env.get("status") != "ok":
+        return {
+            "status": "not_available",
+            "reason": f"governance_bootstrap: {gb_env.get('reason') or 'unknown'}",
+        }
+    if ai_env.get("status") != "ok":
+        return {
+            "status": "not_available",
+            "reason": f"approval_inbox: {ai_env.get('reason') or 'unknown'}",
+        }
+
+    hn_data = hn_env.get("data") or {}
+    gb_data = gb_env.get("data") or {}
+    ai_data = ai_env.get("data") or {}
+
+    hn_ts = hn_data.get("generated_at_utc")
+    gb_ts = gb_data.get("generated_at_utc")
+    ai_ts = ai_data.get("generated_at_utc")
+    if not all(isinstance(t, str) and t for t in (hn_ts, gb_ts, ai_ts)):
+        return {
+            "status": "not_available",
+            "reason": "missing generated_at_utc on one or more artifacts",
+        }
+
+    # human_needed projection — bounded.
+    hn_counts = hn_data.get("counts") or {}
+    hn_events_total = int(hn_counts.get("events_total") or 0)
+    hn_by_reason = (
+        dict(hn_counts.get("by_reason") or {})
+        if isinstance(hn_counts.get("by_reason"), dict)
+        else {}
+    )
+    hn_events_list = (
+        hn_data.get("events") if isinstance(hn_data.get("events"), list) else []
+    )
+    top_blocking_component: str | None = None
+    if hn_events_list:
+        first = hn_events_list[0]
+        if isinstance(first, dict):
+            bc = first.get("blocking_component")
+            if isinstance(bc, str) and bc:
+                top_blocking_component = bc
+
+    # governance_bootstrap projection — bounded.
+    gb_counts = gb_data.get("counts") or {}
+    gb_templates_total = int(gb_counts.get("templates_total") or 0)
+    gb_templates_list = (
+        gb_data.get("templates")
+        if isinstance(gb_data.get("templates"), list)
+        else []
+    )
+    top_branch_name: str | None = None
+    if gb_templates_list:
+        first_t = gb_templates_list[0]
+        if isinstance(first_t, dict):
+            bn = first_t.get("branch_name")
+            if isinstance(bn, str) and bn:
+                top_branch_name = bn
+
+    # approval_inbox derived-row count — counts items whose
+    # ``source`` starts with the canonical v3.15.16.8 prefix.
+    items = ai_data.get("items")
+    if not isinstance(items, list):
+        items = []
+    ai_human_needed_derived_rows = sum(
+        1
+        for it in items
+        if isinstance(it, dict)
+        and isinstance(it.get("source"), str)
+        and it["source"].startswith("human_needed:")
+    )
+
+    # Derive loop_state.
+    counts_all_zero = (
+        hn_events_total == 0
+        and gb_templates_total == 0
+        and ai_human_needed_derived_rows == 0
+    )
+
+    if not counts_all_zero:
+        loop_state = "open"
+    else:
+        # Counts all zero — judge consistency by spread of
+        # generated_at_utc values. ``stale`` if the spread is
+        # wider than the consistency window; ``resolved`` if
+        # within the window. Parsing is defensive: if any
+        # timestamp is unparsable, fall back to ``stale``.
+        parsed: list[float] = []
+        for t in (hn_ts, gb_ts, ai_ts):
+            try:
+                norm = t[:-1] + "+00:00" if t.endswith("Z") else t
+                parsed.append(_dt.datetime.fromisoformat(norm).timestamp())
+            except (TypeError, ValueError):
+                parsed = []
+                break
+        if not parsed or len(parsed) != 3:
+            loop_state = "stale"
+        else:
+            spread = max(parsed) - min(parsed)
+            if spread > LOOP_CLOSURE_CONSISTENCY_WINDOW_SECONDS:
+                loop_state = "stale"
+            else:
+                loop_state = "resolved"
+
+    # last_refreshed_utc is the lexicographic max of the three
+    # ISO-Z timestamps. Lexicographic ordering is correct for
+    # ISO-8601 UTC strings ending in ``Z``.
+    last_refreshed_utc = max(hn_ts, gb_ts, ai_ts)
+
+    return {
+        "status": "ok",
+        "data": {
+            "loop_state": loop_state,
+            "human_needed": {
+                "events_total": hn_events_total,
+                "by_reason": hn_by_reason,
+                "top_blocking_component": top_blocking_component,
+                "generated_at_utc": hn_ts,
+            },
+            "governance_bootstrap": {
+                "templates_total": gb_templates_total,
+                "top_branch_name": top_branch_name,
+                "generated_at_utc": gb_ts,
+            },
+            "approval_inbox": {
+                "human_needed_derived_rows": ai_human_needed_derived_rows,
+                "generated_at_utc": ai_ts,
+            },
+            "last_refreshed_utc": last_refreshed_utc,
+        },
     }
 
 

--- a/docs/governance/mobile_agent_control_pwa.md
+++ b/docs/governance/mobile_agent_control_pwa.md
@@ -1,13 +1,71 @@
 # Mobile-first Agent Control PWA — Operator Runbook
 
 > Module: `dashboard.api_agent_control` (backend) + `frontend/src/routes/AgentControl.tsx` (frontend)
-> Release: v3.15.15.26 (mobile-first IA rebuild on top of v3.15.15.18)
+> Release: v3.15.15.26 (mobile-first IA rebuild on top of v3.15.15.18); v3.15.16.9b adds Loop closure subsection
 > Sibling lifecycle modules: `reporting.autonomous_workloop`,
 > `reporting.github_pr_lifecycle`,
 > `reporting.workloop_runtime`,
 > `reporting.recurring_maintenance`,
 > `reporting.approval_policy`,
-> `reporting.autonomy_metrics`
+> `reporting.autonomy_metrics`,
+> `reporting.human_needed` (v3.15.16.8),
+> `reporting.governance_bootstrap` (v3.15.16.9)
+
+## v3.15.16.9b — Loop closure subsection on the Status card
+
+The Overview tab's existing Status card gains a "Loop closure"
+subsection that surfaces the autonomous-loop closure state at a
+glance. Read-only; no new endpoint; no `dashboard/dashboard.py`
+change (the `/api/agent-control/status` route is already wired
+since v3.15.15.21 — v3.15.16.9b only **extends the existing
+payload**).
+
+### What the subsection shows
+
+| field | source artifact | meaning |
+| --- | --- | --- |
+| `loop_state` | derived | `open` / `resolved` / `stale` |
+| `human_needed` count | `logs/human_needed/latest.json` | `counts.events_total` |
+| `top_blocking_component` | `logs/human_needed/latest.json` | first event's `blocking_component` (only when `events_total > 0`) |
+| `governance_bootstrap` count | `logs/governance_bootstrap/latest.json` | `counts.templates_total` |
+| `top_branch_name` | `logs/governance_bootstrap/latest.json` | first template's `branch_name` (only when `templates_total > 0`) |
+| `approval_inbox` derived rows | `logs/approval_inbox/latest.json` | count of `items` whose `source` startswith `human_needed:` |
+| `last_refreshed_utc` | derived | lexicographic max of the three `generated_at_utc` fields |
+
+### State derivation rules (pinned by tests)
+
+| rule | resulting state |
+| --- | --- |
+| any source missing / malformed / no `generated_at_utc` | transport: `not_available` |
+| any of the three counts > 0 | `data.loop_state: open` |
+| all three counts == 0 AND timestamps within consistency window (10 min) | `data.loop_state: resolved` |
+| all three counts == 0 BUT timestamps spread > 10 min | `data.loop_state: stale` |
+
+The 10-minute consistency window is a relative spread check, not
+an absolute clock check. There is **no recurring 30-minute timer
+in v3.15.16.x** — the current cadence is the v3.15.16.3
+post-deploy hook only. The operator compares `last_refreshed_utc`
+against their last known deploy time to assess freshness; the
+`stale` indicator only flags inconsistency between the three
+artifacts within the same tick window.
+
+### Bounded payload
+
+The `loop_closure` envelope **never** carries `proposed_patch`,
+`pr_body`, `file_diff`, full `events[]`, or full `templates[]`
+lists. Only safe summary fields. Pinned by a defensive guard test
+that asserts the exact set of allowed keys.
+
+### Canonical use case
+
+Bootstrap-PR validation for the v3.15.16.5 wiring gap: the
+operator opens the Overview tab BEFORE the bootstrap PR merges
+and sees `loop_state: open` with
+`top_blocking_component: dashboard/dashboard.py:register_roadmap_priority_routes`.
+After the bootstrap PR merges and the auto-deploy completes, the
+operator refreshes and sees `loop_state: resolved` with all three
+counts at zero. That two-state visual flip is the canonical
+Phase 1 end-to-end proof — no log inspection required.
 
 This is the operator-facing runbook for the Agent Control PWA.
 It explains what the app shows, what it does NOT do, how it is

--- a/docs/roadmap/qre_roadmap_v6_1.md
+++ b/docs/roadmap/qre_roadmap_v6_1.md
@@ -239,6 +239,33 @@ only on these events.
 * `proposal_type`: observability_addition
 * `status`: done
 
+### v3.15.16.9b — Loop closure visibility on Agent Control Overview tab
+
+Extend the already-wired `/api/agent-control/status` payload with
+a small read-only `loop_closure` envelope. The existing Status
+card on the PWA Overview tab gains a "Loop closure" subsection
+surfacing `loop_state` (open / resolved / stale), counts and top
+items from `human_needed` / `governance_bootstrap` /
+`approval_inbox`, plus `last_refreshed_utc`. Pure observability;
+**no new endpoint**, **no `dashboard/dashboard.py` change** (status
+route already wired since v3.15.15.21), no mutation surface, no
+`.claude` change. Bounded payload — never carries `proposed_patch`
+body, `pr_body`, `file_diff`, or full events/templates lists.
+Validates the v3.15.16.6→.7→.8→.9 detection→templating→loop-closure
+cycle visually in the PWA, with no log inspection needed by the
+operator.
+
+* `affected_files`: `dashboard/api_agent_control.py`,
+  `frontend/src/api/agent_control.ts`,
+  `frontend/src/routes/AgentControl.tsx`,
+  `tests/unit/test_dashboard_api_agent_control.py`,
+  `frontend/src/test/AgentControl.test.tsx`,
+  `docs/governance/mobile_agent_control_pwa.md`,
+  `docs/roadmap/qre_roadmap_v6_1.md`
+* `risk_class`: LOW
+* `proposal_type`: observability_addition
+* `status`: proposed
+
 ### v3.15.16.9 — Governance-bootstrap PR-template synthesizer
 
 Ship `reporting/governance_bootstrap.py` — pure read-only text

--- a/frontend/src/api/agent_control.ts
+++ b/frontend/src/api/agent_control.ts
@@ -126,6 +126,35 @@ export interface AgentControlStatus {
       proposed_branch?: string;
     };
   };
+  // v3.15.16.9b — Loop closure subsection on the Status card.
+  // Surfaces whether the v3.15.16.8 detection -> v3.15.16.9 templating
+  // -> operator-PR -> loop-closure cycle has completed. Bounded
+  // payload only: counts, top blocking_component, top branch_name,
+  // last_refreshed_utc, loop_state. NEVER carries proposed_patch
+  // body, pr_body, full events / templates lists.
+  loop_closure?: {
+    status: "ok" | "not_available";
+    reason?: string;
+    data?: {
+      loop_state: "open" | "resolved" | "stale";
+      human_needed: {
+        events_total: number;
+        by_reason: Record<string, number>;
+        top_blocking_component: string | null;
+        generated_at_utc: string;
+      };
+      governance_bootstrap: {
+        templates_total: number;
+        top_branch_name: string | null;
+        generated_at_utc: string;
+      };
+      approval_inbox: {
+        human_needed_derived_rows: number;
+        generated_at_utc: string;
+      };
+      last_refreshed_utc: string;
+    };
+  };
 }
 
 export interface AgentControlActivity {

--- a/frontend/src/routes/AgentControl.tsx
+++ b/frontend/src/routes/AgentControl.tsx
@@ -335,7 +335,128 @@ function StatusCard({ payload }: { payload: AgentControlStatus | null }) {
           </div>
         ))
       )}
+      <LoopClosureBlock payload={payload.loop_closure} />
     </Card>
+  );
+}
+
+// --- Subsection: Loop closure (v3.15.16.9b) ---
+// Renders the autonomous-loop closure state on the existing
+// Status card. Read-only. Surfaces only safe summary fields:
+// counts, top blocking_component, top branch_name,
+// last_refreshed_utc, loop_state. NEVER renders proposed_patch
+// body, pr_body, or full events / templates lists.
+function LoopClosureBlock({
+  payload,
+}: {
+  payload: AgentControlStatus["loop_closure"];
+}) {
+  if (!payload) {
+    return null;
+  }
+  if (payload.status !== "ok" || !payload.data) {
+    return (
+      <>
+        <div
+          className="agent-control-card__row"
+          data-testid="loop-closure-row"
+        >
+          <dt>loop closure</dt>
+          <dd>
+            <StatusPill state="unknown" />
+          </dd>
+        </div>
+        <div
+          className="agent-control-card__row"
+          data-testid="loop-closure-not-available"
+        >
+          <dt>reason</dt>
+          <dd>{payload.reason ?? "not_available"}</dd>
+        </div>
+      </>
+    );
+  }
+  const data = payload.data;
+  const loopState = data.loop_state;
+  const pillState: "ok" | "warn" | "danger" | "unknown" =
+    loopState === "resolved"
+      ? "ok"
+      : loopState === "open"
+        ? "danger"
+        : loopState === "stale"
+          ? "warn"
+          : "unknown";
+  return (
+    <>
+      <div
+        className="agent-control-card__row"
+        data-testid="loop-closure-row"
+      >
+        <dt>loop closure</dt>
+        <dd>
+          <span data-testid="loop-closure-state">{loopState}</span>{" "}
+          <StatusPill state={pillState} />
+        </dd>
+      </div>
+      <div
+        className="agent-control-card__row"
+        data-testid="loop-closure-human-needed-row"
+      >
+        <dt>human_needed</dt>
+        <dd data-testid="loop-closure-human-needed-count">
+          {data.human_needed.events_total} event(s)
+        </dd>
+      </div>
+      {data.human_needed.top_blocking_component ? (
+        <div
+          className="agent-control-card__row"
+          data-testid="loop-closure-blocking-component-row"
+        >
+          <dt>blocking_component</dt>
+          <dd data-testid="loop-closure-blocking-component">
+            <code>{data.human_needed.top_blocking_component}</code>
+          </dd>
+        </div>
+      ) : null}
+      <div
+        className="agent-control-card__row"
+        data-testid="loop-closure-governance-bootstrap-row"
+      >
+        <dt>governance_bootstrap</dt>
+        <dd data-testid="loop-closure-templates-count">
+          {data.governance_bootstrap.templates_total} template(s)
+        </dd>
+      </div>
+      {data.governance_bootstrap.top_branch_name ? (
+        <div
+          className="agent-control-card__row"
+          data-testid="loop-closure-branch-name-row"
+        >
+          <dt>branch</dt>
+          <dd data-testid="loop-closure-branch-name">
+            <code>{data.governance_bootstrap.top_branch_name}</code>
+          </dd>
+        </div>
+      ) : null}
+      <div
+        className="agent-control-card__row"
+        data-testid="loop-closure-approval-inbox-row"
+      >
+        <dt>approval_inbox derived rows</dt>
+        <dd data-testid="loop-closure-inbox-rows-count">
+          {data.approval_inbox.human_needed_derived_rows}
+        </dd>
+      </div>
+      <div
+        className="agent-control-card__row"
+        data-testid="loop-closure-last-refreshed-row"
+      >
+        <dt>last refreshed</dt>
+        <dd data-testid="loop-closure-last-refreshed">
+          {data.last_refreshed_utc}
+        </dd>
+      </div>
+    </>
   );
 }
 

--- a/frontend/src/test/AgentControl.test.tsx
+++ b/frontend/src/test/AgentControl.test.tsx
@@ -1026,3 +1026,274 @@ describe("AgentControl — UI affordances", () => {
     expect(nav).not.toBeNull();
   });
 });
+
+
+const loopClosureOpen = {
+  status: "ok" as const,
+  data: {
+    loop_state: "open" as const,
+    human_needed: {
+      events_total: 1,
+      by_reason: { governance_bootstrap_required: 1 },
+      top_blocking_component:
+        "dashboard/dashboard.py:register_roadmap_priority_routes",
+      generated_at_utc: "2026-05-05T13:00:00Z",
+    },
+    governance_bootstrap: {
+      templates_total: 1,
+      top_branch_name: "governance-bootstrap/h_aaaaaaaaaa",
+      generated_at_utc: "2026-05-05T13:00:00Z",
+    },
+    approval_inbox: {
+      human_needed_derived_rows: 1,
+      generated_at_utc: "2026-05-05T13:00:00Z",
+    },
+    last_refreshed_utc: "2026-05-05T13:00:00Z",
+  },
+};
+
+const loopClosureResolved = {
+  status: "ok" as const,
+  data: {
+    loop_state: "resolved" as const,
+    human_needed: {
+      events_total: 0,
+      by_reason: { governance_bootstrap_required: 0 },
+      top_blocking_component: null,
+      generated_at_utc: "2026-05-05T13:00:00Z",
+    },
+    governance_bootstrap: {
+      templates_total: 0,
+      top_branch_name: null,
+      generated_at_utc: "2026-05-05T13:00:30Z",
+    },
+    approval_inbox: {
+      human_needed_derived_rows: 0,
+      generated_at_utc: "2026-05-05T13:00:45Z",
+    },
+    last_refreshed_utc: "2026-05-05T13:00:45Z",
+  },
+};
+
+const loopClosureStale = {
+  status: "ok" as const,
+  data: {
+    loop_state: "stale" as const,
+    human_needed: {
+      events_total: 0,
+      by_reason: { governance_bootstrap_required: 0 },
+      top_blocking_component: null,
+      generated_at_utc: "2026-05-05T13:00:00Z",
+    },
+    governance_bootstrap: {
+      templates_total: 0,
+      top_branch_name: null,
+      generated_at_utc: "2026-05-05T12:30:00Z",
+    },
+    approval_inbox: {
+      human_needed_derived_rows: 0,
+      generated_at_utc: "2026-05-05T13:00:30Z",
+    },
+    last_refreshed_utc: "2026-05-05T13:00:30Z",
+  },
+};
+
+const loopClosureNotAvailable = {
+  status: "not_available" as const,
+  reason: "human_needed: missing",
+};
+
+function makeStatusBodyWithLoopClosure(loopClosure: unknown) {
+  return { ...okStatusBody, loop_closure: loopClosure };
+}
+
+describe("AgentControl — loop closure subsection (v3.15.16.9b)", () => {
+  it("renders open state with blocking_component and branch_name", async () => {
+    installFetchMock(
+      {
+        "/api/agent-control/status": () =>
+          jsonResp(makeStatusBodyWithLoopClosure(loopClosureOpen)),
+        "/api/agent-control/activity": () => jsonResp(okActivityBody),
+        "/api/agent-control/workloop": () => jsonResp(okWorkloopBody),
+        "/api/agent-control/pr-lifecycle": () => jsonResp(okPRLifecycleEmptyBody),
+        "/api/agent-control/notifications": () =>
+          jsonResp(placeholderNotificationsBody),
+        "/api/agent-control/proposals": () => jsonResp(okProposalsEmptyBody),
+        "/api/agent-control/approval-inbox": () => jsonResp(okInboxEmptyBody),
+        "/api/agent-control/execute-safe": () => jsonResp(okExecuteSafeBody),
+      },
+      () => jsonResp({}, 404),
+    );
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("loop-closure-state")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("loop-closure-state")).toHaveTextContent("open");
+    expect(screen.getByTestId("loop-closure-human-needed-count")).toHaveTextContent(
+      "1 event(s)",
+    );
+    expect(
+      screen.getByTestId("loop-closure-blocking-component"),
+    ).toHaveTextContent(
+      "dashboard/dashboard.py:register_roadmap_priority_routes",
+    );
+    expect(
+      screen.getByTestId("loop-closure-templates-count"),
+    ).toHaveTextContent("1 template(s)");
+    expect(screen.getByTestId("loop-closure-branch-name")).toHaveTextContent(
+      "governance-bootstrap/h_aaaaaaaaaa",
+    );
+    expect(
+      screen.getByTestId("loop-closure-inbox-rows-count"),
+    ).toHaveTextContent("1");
+    expect(
+      screen.getByTestId("loop-closure-last-refreshed"),
+    ).toHaveTextContent("2026-05-05T13:00:00Z");
+  });
+
+  it("renders resolved state with all zero counts", async () => {
+    installFetchMock(
+      {
+        "/api/agent-control/status": () =>
+          jsonResp(makeStatusBodyWithLoopClosure(loopClosureResolved)),
+        "/api/agent-control/activity": () => jsonResp(okActivityBody),
+        "/api/agent-control/workloop": () => jsonResp(okWorkloopBody),
+        "/api/agent-control/pr-lifecycle": () => jsonResp(okPRLifecycleEmptyBody),
+        "/api/agent-control/notifications": () =>
+          jsonResp(placeholderNotificationsBody),
+        "/api/agent-control/proposals": () => jsonResp(okProposalsEmptyBody),
+        "/api/agent-control/approval-inbox": () => jsonResp(okInboxEmptyBody),
+        "/api/agent-control/execute-safe": () => jsonResp(okExecuteSafeBody),
+      },
+      () => jsonResp({}, 404),
+    );
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("loop-closure-state")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("loop-closure-state")).toHaveTextContent(
+      "resolved",
+    );
+    expect(
+      screen.getByTestId("loop-closure-human-needed-count"),
+    ).toHaveTextContent("0 event(s)");
+    expect(
+      screen.getByTestId("loop-closure-templates-count"),
+    ).toHaveTextContent("0 template(s)");
+    expect(
+      screen.getByTestId("loop-closure-inbox-rows-count"),
+    ).toHaveTextContent("0");
+    // Resolved state: blocking_component and branch_name rows are
+    // ABSENT (not just empty).
+    expect(
+      screen.queryByTestId("loop-closure-blocking-component"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("loop-closure-branch-name"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId("loop-closure-last-refreshed"),
+    ).toHaveTextContent("2026-05-05T13:00:45Z");
+  });
+
+  it("renders stale state when artifacts are inconsistent", async () => {
+    installFetchMock(
+      {
+        "/api/agent-control/status": () =>
+          jsonResp(makeStatusBodyWithLoopClosure(loopClosureStale)),
+        "/api/agent-control/activity": () => jsonResp(okActivityBody),
+        "/api/agent-control/workloop": () => jsonResp(okWorkloopBody),
+        "/api/agent-control/pr-lifecycle": () => jsonResp(okPRLifecycleEmptyBody),
+        "/api/agent-control/notifications": () =>
+          jsonResp(placeholderNotificationsBody),
+        "/api/agent-control/proposals": () => jsonResp(okProposalsEmptyBody),
+        "/api/agent-control/approval-inbox": () => jsonResp(okInboxEmptyBody),
+        "/api/agent-control/execute-safe": () => jsonResp(okExecuteSafeBody),
+      },
+      () => jsonResp({}, 404),
+    );
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("loop-closure-state")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("loop-closure-state")).toHaveTextContent(
+      "stale",
+    );
+  });
+
+  it("renders not_available when loop_closure status is not_available", async () => {
+    installFetchMock(
+      {
+        "/api/agent-control/status": () =>
+          jsonResp(makeStatusBodyWithLoopClosure(loopClosureNotAvailable)),
+        "/api/agent-control/activity": () => jsonResp(okActivityBody),
+        "/api/agent-control/workloop": () => jsonResp(okWorkloopBody),
+        "/api/agent-control/pr-lifecycle": () => jsonResp(okPRLifecycleEmptyBody),
+        "/api/agent-control/notifications": () =>
+          jsonResp(placeholderNotificationsBody),
+        "/api/agent-control/proposals": () => jsonResp(okProposalsEmptyBody),
+        "/api/agent-control/approval-inbox": () => jsonResp(okInboxEmptyBody),
+        "/api/agent-control/execute-safe": () => jsonResp(okExecuteSafeBody),
+      },
+      () => jsonResp({}, 404),
+    );
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("loop-closure-not-available"),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByTestId("loop-closure-not-available"),
+    ).toHaveTextContent("human_needed: missing");
+  });
+
+  it("does not render the loop closure block when payload omits loop_closure", async () => {
+    // Backwards-compat: an older /status payload without loop_closure
+    // must not crash the card.
+    installFetchMock(
+      {
+        "/api/agent-control/status": () => jsonResp(okStatusBody),
+        "/api/agent-control/activity": () => jsonResp(okActivityBody),
+        "/api/agent-control/workloop": () => jsonResp(okWorkloopBody),
+        "/api/agent-control/pr-lifecycle": () => jsonResp(okPRLifecycleEmptyBody),
+        "/api/agent-control/notifications": () =>
+          jsonResp(placeholderNotificationsBody),
+        "/api/agent-control/proposals": () => jsonResp(okProposalsEmptyBody),
+        "/api/agent-control/approval-inbox": () => jsonResp(okInboxEmptyBody),
+        "/api/agent-control/execute-safe": () => jsonResp(okExecuteSafeBody),
+      },
+      () => jsonResp({}, 404),
+    );
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("agent-control-root")).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByTestId("loop-closure-state"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("loop-closure-not-available"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/tests/unit/test_dashboard_api_agent_control.py
+++ b/tests/unit/test_dashboard_api_agent_control.py
@@ -47,6 +47,24 @@ def app(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Flask:
         "PR_LIFECYCLE_LATEST",
         tmp_path / "logs" / "github_pr_lifecycle" / "latest.json",
     )
+    # v3.15.16.9b — redirect the three Loop closure source paths
+    # too so the ``isolated`` test environment cannot read repo
+    # artifacts.
+    monkeypatch.setattr(
+        ac,
+        "HUMAN_NEEDED_LATEST",
+        tmp_path / "logs" / "human_needed" / "latest.json",
+    )
+    monkeypatch.setattr(
+        ac,
+        "GOVERNANCE_BOOTSTRAP_LATEST",
+        tmp_path / "logs" / "governance_bootstrap" / "latest.json",
+    )
+    monkeypatch.setattr(
+        ac,
+        "APPROVAL_INBOX_LATEST",
+        tmp_path / "logs" / "approval_inbox" / "latest.json",
+    )
     flask_app = Flask(__name__)
     ac.register_agent_control_routes(flask_app)
     return flask_app
@@ -357,3 +375,345 @@ def test_no_gh_or_git_invocation_in_module() -> None:
     )
     for token in forbidden:
         assert token not in src, f"forbidden token in api_agent_control.py: {token!r}"
+
+
+# ---------------------------------------------------------------------------
+# v3.15.16.9b — loop closure subsection tests
+# ---------------------------------------------------------------------------
+
+
+def _write_artifact(p: Path, payload: dict) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _hn_payload(
+    *,
+    events_total: int = 0,
+    blocking_component: "str | None" = None,
+    generated_at_utc: str = "2026-05-05T13:00:00Z",
+) -> dict:
+    events = []
+    if events_total > 0 and blocking_component:
+        events.append(
+            {
+                "event_id": "h_aaaaaaaaaa",
+                "reason": "governance_bootstrap_required",
+                "blocking_component": blocking_component,
+                "priority": "HIGH",
+            }
+        )
+    return {
+        "schema_version": 1,
+        "report_kind": "human_needed_digest",
+        "module_version": "v3.15.16.8",
+        "generated_at_utc": generated_at_utc,
+        "counts": {
+            "events_total": events_total,
+            "by_reason": {"governance_bootstrap_required": events_total},
+        },
+        "events": events,
+    }
+
+
+def _gb_payload(
+    *,
+    templates_total: int = 0,
+    branch_name: "str | None" = None,
+    generated_at_utc: str = "2026-05-05T13:00:00Z",
+) -> dict:
+    templates = []
+    if templates_total > 0 and branch_name:
+        templates.append(
+            {
+                "template_id": "gb_aaaaaaaaaa",
+                "branch_name": branch_name,
+                "source_event_id": "h_aaaaaaaaaa",
+            }
+        )
+    return {
+        "schema_version": 1,
+        "report_kind": "governance_bootstrap_digest",
+        "module_version": "v3.15.16.9",
+        "generated_at_utc": generated_at_utc,
+        "counts": {"templates_total": templates_total},
+        "templates": templates,
+    }
+
+
+def _ai_payload(
+    *,
+    items=None,
+    generated_at_utc: str = "2026-05-05T13:00:00Z",
+) -> dict:
+    """Approval-inbox digest fixture. Items live at TOP LEVEL of the
+    digest (per ``reporting.approval_inbox.collect_snapshot`` line
+    1047 — ``items: items``); they are NOT nested under a ``data``
+    key. Matching the canonical schema is critical: the loop-closure
+    summary reads ``digest['items']`` directly."""
+    return {
+        "schema_version": 1,
+        "report_kind": "approval_inbox_digest",
+        "module_version": "v3.15.15.20",
+        "generated_at_utc": generated_at_utc,
+        "items": items if items is not None else [],
+    }
+
+
+def _set_loop_closure_artifacts(
+    tmp_path: Path,
+    *,
+    hn,
+    gb,
+    ai,
+) -> None:
+    if hn is not None:
+        _write_artifact(tmp_path / "logs" / "human_needed" / "latest.json", hn)
+    if gb is not None:
+        _write_artifact(
+            tmp_path / "logs" / "governance_bootstrap" / "latest.json", gb
+        )
+    if ai is not None:
+        _write_artifact(tmp_path / "logs" / "approval_inbox" / "latest.json", ai)
+
+
+def test_loop_closure_not_available_when_human_needed_missing(
+    client, tmp_path: Path
+) -> None:
+    body = client.get("/api/agent-control/status").get_json()
+    lc = body["loop_closure"]
+    assert lc["status"] == "not_available"
+    assert "human_needed" in lc["reason"]
+
+
+def test_loop_closure_not_available_when_governance_bootstrap_missing(
+    client, tmp_path: Path
+) -> None:
+    _set_loop_closure_artifacts(
+        tmp_path, hn=_hn_payload(), gb=None, ai=_ai_payload()
+    )
+    body = client.get("/api/agent-control/status").get_json()
+    lc = body["loop_closure"]
+    assert lc["status"] == "not_available"
+    assert "governance_bootstrap" in lc["reason"]
+
+
+def test_loop_closure_not_available_when_approval_inbox_missing(
+    client, tmp_path: Path
+) -> None:
+    _set_loop_closure_artifacts(
+        tmp_path, hn=_hn_payload(), gb=_gb_payload(), ai=None
+    )
+    body = client.get("/api/agent-control/status").get_json()
+    lc = body["loop_closure"]
+    assert lc["status"] == "not_available"
+    assert "approval_inbox" in lc["reason"]
+
+
+def test_loop_closure_open_with_top_blocking_component(
+    client, tmp_path: Path
+) -> None:
+    """The canonical v3.15.16.5 wiring-gap case: human_needed has 1
+    event, governance_bootstrap has 1 template, approval_inbox has
+    1 derived row."""
+    _set_loop_closure_artifacts(
+        tmp_path,
+        hn=_hn_payload(
+            events_total=1,
+            blocking_component="dashboard/dashboard.py:register_roadmap_priority_routes",
+        ),
+        gb=_gb_payload(
+            templates_total=1,
+            branch_name="governance-bootstrap/h_aaaaaaaaaa",
+        ),
+        ai=_ai_payload(
+            items=[
+                {"item_id": "i_xxx", "source": "human_needed:h_aaaaaaaaaa"},
+                {"item_id": "i_yyy", "source": "recurring_maintenance:something"},
+            ]
+        ),
+    )
+    body = client.get("/api/agent-control/status").get_json()
+    lc = body["loop_closure"]
+    assert lc["status"] == "ok"
+    data = lc["data"]
+    assert data["loop_state"] == "open"
+    assert data["human_needed"]["events_total"] == 1
+    assert (
+        data["human_needed"]["top_blocking_component"]
+        == "dashboard/dashboard.py:register_roadmap_priority_routes"
+    )
+    assert data["governance_bootstrap"]["templates_total"] == 1
+    assert (
+        data["governance_bootstrap"]["top_branch_name"]
+        == "governance-bootstrap/h_aaaaaaaaaa"
+    )
+    # Counts only rows whose source startswith human_needed: (the
+    # canonical v3.15.16.8 emission); other sources do not count.
+    assert data["approval_inbox"]["human_needed_derived_rows"] == 1
+    assert data["last_refreshed_utc"] == "2026-05-05T13:00:00Z"
+
+
+def test_loop_closure_resolved_when_all_zero_and_timestamps_within_window(
+    client, tmp_path: Path
+) -> None:
+    """All three counts zero AND timestamps within consistency
+    window -> resolved."""
+    _set_loop_closure_artifacts(
+        tmp_path,
+        hn=_hn_payload(generated_at_utc="2026-05-05T13:00:01Z"),
+        gb=_gb_payload(generated_at_utc="2026-05-05T13:00:30Z"),
+        ai=_ai_payload(generated_at_utc="2026-05-05T13:00:45Z"),
+    )
+    body = client.get("/api/agent-control/status").get_json()
+    lc = body["loop_closure"]
+    assert lc["status"] == "ok"
+    data = lc["data"]
+    assert data["loop_state"] == "resolved"
+    assert data["human_needed"]["events_total"] == 0
+    assert data["human_needed"]["top_blocking_component"] is None
+    assert data["governance_bootstrap"]["templates_total"] == 0
+    assert data["governance_bootstrap"]["top_branch_name"] is None
+    assert data["approval_inbox"]["human_needed_derived_rows"] == 0
+    # last_refreshed_utc is the lexicographic max of the three.
+    assert data["last_refreshed_utc"] == "2026-05-05T13:00:45Z"
+
+
+def test_loop_closure_stale_when_timestamps_spread_beyond_window(
+    client, tmp_path: Path
+) -> None:
+    """All three counts zero BUT one timestamp >10 min older than
+    the others -> stale (digests inconsistent)."""
+    _set_loop_closure_artifacts(
+        tmp_path,
+        hn=_hn_payload(generated_at_utc="2026-05-05T13:00:00Z"),
+        gb=_gb_payload(generated_at_utc="2026-05-05T12:30:00Z"),  # 30 min older
+        ai=_ai_payload(generated_at_utc="2026-05-05T13:00:30Z"),
+    )
+    body = client.get("/api/agent-control/status").get_json()
+    lc = body["loop_closure"]
+    assert lc["status"] == "ok"
+    assert lc["data"]["loop_state"] == "stale"
+
+
+def test_loop_closure_inbox_count_uses_canonical_source_prefix(
+    client, tmp_path: Path
+) -> None:
+    """The human_needed_derived_rows count must use the canonical
+    v3.15.16.8 source-field prefix human_needed: — not any other
+    field, not a substring search elsewhere."""
+    _set_loop_closure_artifacts(
+        tmp_path,
+        hn=_hn_payload(),
+        gb=_gb_payload(),
+        ai=_ai_payload(
+            items=[
+                {"item_id": "a", "source": "human_needed:h_111"},
+                {"item_id": "b", "source": "human_needed:h_222"},
+                {"item_id": "c", "source": "recurring_maintenance:foo"},
+                {"item_id": "d", "source": "proposal_queue:bar"},
+                # Non-string source is ignored, not crashed:
+                {"item_id": "e", "source": None},
+            ]
+        ),
+    )
+    body = client.get("/api/agent-control/status").get_json()
+    lc = body["loop_closure"]
+    assert lc["status"] == "ok"
+    # Two of five items match the canonical prefix.
+    assert lc["data"]["approval_inbox"]["human_needed_derived_rows"] == 2
+
+
+def test_loop_closure_payload_contains_no_unsafe_fields(
+    client, tmp_path: Path
+) -> None:
+    """The bounded payload must NOT carry proposed_patch, pr_body,
+    or full events / templates lists. Pinned defensively."""
+    _set_loop_closure_artifacts(
+        tmp_path,
+        hn={
+            **_hn_payload(
+                events_total=1,
+                blocking_component="dashboard/dashboard.py:register_x_routes",
+            ),
+            "events": [
+                {
+                    "event_id": "h_a",
+                    "reason": "governance_bootstrap_required",
+                    "blocking_component": "dashboard/dashboard.py:register_x_routes",
+                    "proposed_patch": "secret-shaped patch text NOT for the wire",
+                    "priority": "HIGH",
+                }
+            ],
+        },
+        gb={
+            **_gb_payload(
+                templates_total=1, branch_name="governance-bootstrap/h_a"
+            ),
+            "templates": [
+                {
+                    "template_id": "gb_a",
+                    "branch_name": "governance-bootstrap/h_a",
+                    "source_event_id": "h_a",
+                    "pr_body": "MARKER_SHOULD_NOT_APPEAR_ON_WIRE",
+                    "file_diff": "MARKER_SHOULD_NOT_APPEAR_ON_WIRE",
+                }
+            ],
+        },
+        ai=_ai_payload(),
+    )
+    body = client.get("/api/agent-control/status").get_json()
+    lc = body["loop_closure"]
+    assert lc["status"] == "ok"
+    text = json.dumps(lc)
+    forbidden = (
+        "proposed_patch",
+        "pr_body",
+        "file_diff",
+        "MARKER_SHOULD_NOT_APPEAR_ON_WIRE",
+        "secret-shaped patch text",
+    )
+    for tok in forbidden:
+        assert tok not in text, (
+            f"loop_closure payload leaks forbidden field/value: {tok!r}"
+        )
+    # Defensive: confirm the bounded keys and ONLY the bounded keys.
+    data = lc["data"]
+    assert set(data.keys()) == {
+        "loop_state",
+        "human_needed",
+        "governance_bootstrap",
+        "approval_inbox",
+        "last_refreshed_utc",
+    }
+    assert set(data["human_needed"].keys()) == {
+        "events_total",
+        "by_reason",
+        "top_blocking_component",
+        "generated_at_utc",
+    }
+    assert set(data["governance_bootstrap"].keys()) == {
+        "templates_total",
+        "top_branch_name",
+        "generated_at_utc",
+    }
+    assert set(data["approval_inbox"].keys()) == {
+        "human_needed_derived_rows",
+        "generated_at_utc",
+    }
+
+
+def test_loop_closure_not_available_on_missing_generated_at_utc(
+    client, tmp_path: Path
+) -> None:
+    """If any artifact lacks generated_at_utc, the surface returns
+    not_available rather than rendering a meaningless timestamp."""
+    bad_hn = _hn_payload()
+    del bad_hn["generated_at_utc"]
+    _set_loop_closure_artifacts(
+        tmp_path, hn=bad_hn, gb=_gb_payload(), ai=_ai_payload()
+    )
+    body = client.get("/api/agent-control/status").get_json()
+    lc = body["loop_closure"]
+    assert lc["status"] == "not_available"
+    assert "generated_at_utc" in lc["reason"]


### PR DESCRIPTION
## Roadmap protocol context

| Field | Value |
| --- | --- |
| `item_id` | `r_v3_15_16_9b` |
| `item_type` | `observability_addition` |
| `risk_class` | `LOW` |
| `decision` | `allowed_read_only` |
| `requires_human` | `false` |
| `implementation_allowed` | `true` |
| `safe_to_execute` | `false` |

## Phase 1 visibility — final piece before the v3.15.16.5 wiring bootstrap PR

Extends the **already-wired** `/api/agent-control/status` payload with a small read-only `loop_closure` envelope. The Status card on the PWA Overview tab gains a "Loop closure" subsection. **No new endpoint. No `dashboard/dashboard.py` change.**

## Bounded payload (pinned)

The new envelope carries ONLY safe summary fields:

```json
"loop_closure": {
  "status": "ok | not_available",
  "data": {
    "loop_state": "open | resolved | stale",
    "human_needed": {
      "events_total": <int>,
      "by_reason": {<reason>: <int>},
      "top_blocking_component": <string|null>,
      "generated_at_utc": <iso>
    },
    "governance_bootstrap": {
      "templates_total": <int>,
      "top_branch_name": <string|null>,
      "generated_at_utc": <iso>
    },
    "approval_inbox": {
      "human_needed_derived_rows": <int>,
      "generated_at_utc": <iso>
    },
    "last_refreshed_utc": <iso>
  }
}
```

**Pinned defensively:** the payload NEVER carries `proposed_patch`, `pr_body`, `file_diff`, full `events[]`, or full `templates[]` lists. A `test_loop_closure_payload_contains_no_unsafe_fields` test asserts the exact set of allowed keys and rejects any leak.

## State derivation rules (pinned)

| rule | resulting state |
| --- | --- |
| any source missing / malformed / no `generated_at_utc` | transport: `not_available` |
| any of the three counts > 0 | `data.loop_state: open` |
| all three counts == 0 AND timestamps within 10-min consistency window | `data.loop_state: resolved` |
| all three counts == 0 BUT timestamps spread > 10 min | `data.loop_state: stale` |

The 10-minute consistency window is a relative spread check, not an absolute clock check. **There is NO recurring 30-min timer in v3.15.16.x** — current cadence is the v3.15.16.3 post-deploy hook only. `last_refreshed_utc` is rendered verbatim so the operator compares against their last known deploy time.

## Canonical v3.15.16.5 case (pinned by test)

`test_loop_closure_open_with_top_blocking_component`:

Input fixture: human_needed `events_total=1` + `blocking_component="dashboard/dashboard.py:register_roadmap_priority_routes"`, governance_bootstrap `templates_total=1` + `branch_name="governance-bootstrap/h_aaaaaaaaaa"`, approval_inbox 1 row with `source="human_needed:h_aaaaaaaaaa"`.

Expected output: `loop_state: open`, `top_blocking_component` and `top_branch_name` surfaced verbatim, derived_rows count = 1.

After the v3.15.16.5 wiring bootstrap PR merges + auto-deploy: same test (all counts zero) produces `loop_state: resolved`. **Two-state visual flip is the canonical Phase 1 end-to-end proof — no log inspection needed.**

## Approval-inbox derived-row count (canonical)

The v3.15.16.8 emission at `reporting/approval_inbox.py:827` is `source=f"human_needed:{event_id}"`. The loop_closure summary counts `data.items` where `it["source"].startswith("human_needed:")`. Pinned by `test_loop_closure_inbox_count_uses_canonical_source_prefix` with mixed source-prefix fixture.

## Hard guarantees (pinned by tests)

- No new endpoint. No `dashboard/dashboard.py` change. No `.claude` change.
- No mutation surface. No subprocess / `gh` / `git` in module source (existing source-text invariant remains green).
- Bounded payload set of allowed keys is exactly the documented list — defensive guard test asserts no `proposed_patch` / `pr_body` / `file_diff` / `MARKER_SHOULD_NOT_APPEAR_ON_WIRE` leaks.
- Frontend type extends `AgentControlStatus.loop_closure?` only — no new fetch verb literal added.
- Frontend StatusCard renders four distinct render states (open / resolved / stale / not_available) — pinned by render tests.
- Backwards-compat: an older `/status` payload without `loop_closure` does not crash the card (pinned).

## Validation gates

- [x] `python scripts/governance_lint.py` — OK
- [x] `sha256sum research/research_latest.json research/strategy_matrix.csv` — frozen hashes unchanged
- [x] `pytest tests/smoke -q` — 14 passed
- [x] `pytest tests/unit/test_dashboard_api_agent_control.py tests/unit/test_observability_security_invariants.py -q` — **74 passed**
- [x] `pytest tests/unit -q` — **3354 passed, 3 skipped, 0 failed**
- [x] `npm --prefix frontend test -- --run` — **95 passed** (5 new render tests for open / resolved / stale / not_available / backwards-compat)
- [x] `npm --prefix frontend run build` — OK

## Diff

```
dashboard/api_agent_control.py                 | +195 (_loop_closure_summary + 3 path consts + datetime import)
frontend/src/api/agent_control.ts              | +29 (AgentControlStatus.loop_closure type)
frontend/src/routes/AgentControl.tsx           | +121 (LoopClosureBlock subsection)
tests/unit/test_dashboard_api_agent_control.py | +360 (8 new tests + fixture redirects)
frontend/src/test/AgentControl.test.tsx        | +271 (5 new render tests)
docs/governance/mobile_agent_control_pwa.md    | +62 (new v3.15.16.9b section)
docs/roadmap/qre_roadmap_v6_1.md               | +27 (mark .9 done; add .9b)
7 files changed, 1063 insertions(+), 2 deletions(-)
```

## Out of scope (unchanged)

- Read-only only. No new endpoint. No `dashboard/dashboard.py`. No `.claude`. No execution engine. No push notifications. No v3.15.16.10. No live/paper/shadow/risk. No frozen contracts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)