### PR TITLE
feat(v3.15.16.9c): canonical bootstrap event surfacing on Loop closure

### DIFF
--- a/dashboard/api_agent_control.py
+++ b/dashboard/api_agent_control.py
@@ -76,6 +76,34 @@ APPROVAL_INBOX_LATEST: Path = LOGS_DIR / "approval_inbox" / "latest.json"
 # conservative upper bound on a single tick's wall-clock cost).
 LOOP_CLOSURE_CONSISTENCY_WINDOW_SECONDS: int = 10 * 60
 
+# v3.15.16.9c — canonical bootstrap event surfacing. The aggregate
+# loop_closure block can hide whether the *specific* v3.15.16.5
+# wiring gap is open / resolved when many unrelated human_needed
+# events are present. ``_roadmap_priority_wiring_summary()`` filters
+# the same three artifacts by an exact ``(reason, blocking_component)``
+# pair and reports its own closed-vocabulary state, independent of
+# the aggregate. The two literals below are the canonical filter.
+# They are pinned by a source-text test so they cannot drift.
+ROADMAP_PRIORITY_WIRING_COMPONENT: str = (
+    "dashboard/dashboard.py:register_roadmap_priority_routes"
+)
+ROADMAP_PRIORITY_WIRING_REASON: str = "governance_bootstrap_required"
+
+# Closed reason vocabulary surfaced when
+# ``roadmap_priority_wiring.state == "not_available"``. The set is
+# small on purpose: every entry maps to a deterministic upstream
+# condition the operator can act on.
+ROADMAP_PRIORITY_WIRING_NOT_AVAILABLE_REASONS: tuple[str, ...] = (
+    "human_needed_missing",
+    "human_needed_malformed",
+    "governance_bootstrap_missing",
+    "governance_bootstrap_malformed",
+    "approval_inbox_missing",
+    "approval_inbox_malformed",
+    "event_id_missing",
+    "governance_bootstrap_lags_human_needed",
+)
+
 # Frozen contracts the PWA surfaces verbatim (path + sha256 only).
 FROZEN_CONTRACTS: tuple[str, ...] = (
     "research/research_latest.json",
@@ -206,6 +234,178 @@ def _status_payload() -> dict[str, Any]:
     }
 
 
+def _roadmap_priority_wiring_summary(
+    hn_env: dict[str, Any],
+    gb_env: dict[str, Any],
+    ai_env: dict[str, Any],
+) -> dict[str, Any]:
+    """v3.15.16.9c — derive the canonical bootstrap event surfacing.
+
+    Consumes the *same* three artifact envelopes that the aggregate
+    ``_loop_closure_summary()`` already reads and reports its own
+    state, independent of the aggregate ``loop_state``. This lets the
+    operator see whether the *specific* v3.15.16.5 wiring gap is open
+    / resolved without being drowned out by 200+ unrelated
+    ``human_needed`` events.
+
+    Returned shape (closed vocabulary, never raises)::
+
+        {
+            "state": "open" | "resolved" | "not_available",
+            "reason": str | None,
+            "event_id": str | None,
+            "blocking_component": str | None,
+            "source_reason": str | None,
+            "template_branch": str | None,
+            "inbox_row_present": bool,
+        }
+
+    State semantics:
+
+    * ``open`` — at least one ``human_needed.events[*]`` matches both
+      canonical literals AND yields a non-empty ``event_id``. The
+      lex-smallest matching event_id is reported. ``template_branch``
+      is resolved by ``source_event_id == event_id`` AND
+      ``source_reason == REASON`` (PRIMARY match). ``inbox_row_present``
+      is ``True`` only when an ``approval_inbox.items[*]`` has
+      ``source == f"human_needed:{event_id}"`` (exact equality).
+
+    * ``resolved`` — all three artifacts valid (events / templates /
+      items are lists) AND no ``human_needed`` event matches the
+      canonical pair AND no ``governance_bootstrap`` template matches
+      ``source_reason == REASON`` AND
+      ``evidence.blocking_component == COMPONENT``. Unrelated events
+      may persist; aggregate ``loop_state`` may still be ``open``.
+
+    * ``not_available`` — any artifact is missing or malformed, or
+      the artifacts are mid-refresh inconsistent. ``reason`` carries
+      the closed-vocabulary value from
+      ``ROADMAP_PRIORITY_WIRING_NOT_AVAILABLE_REASONS``.
+
+    Hard guarantees:
+
+    * Stdlib-only. No subprocess, no network, no git, no gh.
+    * Reads artifact envelopes only — never re-reads the disk.
+    * Never returns ``proposed_patch``, ``pr_body``, ``file_diff``,
+      ``commit_message``, or any other large/sensitive template
+      payload. Bounded scalars only.
+    """
+
+    def _na(reason: str) -> dict[str, Any]:
+        return {
+            "state": "not_available",
+            "reason": reason,
+            "event_id": None,
+            "blocking_component": None,
+            "source_reason": None,
+            "template_branch": None,
+            "inbox_row_present": False,
+        }
+
+    # 1. Validate each artifact's envelope and inner shape.
+    if hn_env.get("status") != "ok":
+        return _na("human_needed_missing")
+    hn_data = hn_env.get("data") or {}
+    if not isinstance(hn_data, dict):
+        return _na("human_needed_malformed")
+    hn_events = hn_data.get("events")
+    if not isinstance(hn_events, list):
+        return _na("human_needed_malformed")
+
+    if gb_env.get("status") != "ok":
+        return _na("governance_bootstrap_missing")
+    gb_data = gb_env.get("data") or {}
+    if not isinstance(gb_data, dict):
+        return _na("governance_bootstrap_malformed")
+    gb_templates = gb_data.get("templates")
+    if not isinstance(gb_templates, list):
+        return _na("governance_bootstrap_malformed")
+
+    if ai_env.get("status") != "ok":
+        return _na("approval_inbox_missing")
+    ai_data = ai_env.get("data") or {}
+    if not isinstance(ai_data, dict):
+        return _na("approval_inbox_malformed")
+    ai_items = ai_data.get("items")
+    if not isinstance(ai_items, list):
+        return _na("approval_inbox_malformed")
+
+    # 2. Identify canonical references in each source.
+    matching_hn_events = [
+        e
+        for e in hn_events
+        if isinstance(e, dict)
+        and e.get("reason") == ROADMAP_PRIORITY_WIRING_REASON
+        and e.get("blocking_component") == ROADMAP_PRIORITY_WIRING_COMPONENT
+    ]
+    canonical_hn_event_ids = sorted(
+        eid
+        for eid in (str(e.get("event_id") or "") for e in matching_hn_events)
+        if eid
+    )
+    matching_gb_templates = [
+        t
+        for t in gb_templates
+        if isinstance(t, dict)
+        and t.get("source_reason") == ROADMAP_PRIORITY_WIRING_REASON
+        and isinstance(t.get("evidence"), dict)
+        and t["evidence"].get("blocking_component")
+        == ROADMAP_PRIORITY_WIRING_COMPONENT
+    ]
+    canonical_gb_event_ids = sorted(
+        eid
+        for eid in (
+            str(t.get("source_event_id") or "") for t in matching_gb_templates
+        )
+        if eid
+    )
+
+    # 3. Decide.
+    if matching_hn_events and not canonical_hn_event_ids:
+        return _na("event_id_missing")
+
+    if canonical_hn_event_ids:
+        event_id = canonical_hn_event_ids[0]
+        template_branch: str | None = None
+        for t in gb_templates:
+            if (
+                isinstance(t, dict)
+                and str(t.get("source_event_id") or "") == event_id
+                and t.get("source_reason") == ROADMAP_PRIORITY_WIRING_REASON
+            ):
+                bn = t.get("branch_name")
+                if isinstance(bn, str) and bn:
+                    template_branch = bn
+                    break
+        inbox_source = f"human_needed:{event_id}"
+        inbox_row_present = any(
+            isinstance(it, dict) and it.get("source") == inbox_source
+            for it in ai_items
+        )
+        return {
+            "state": "open",
+            "reason": None,
+            "event_id": event_id,
+            "blocking_component": ROADMAP_PRIORITY_WIRING_COMPONENT,
+            "source_reason": ROADMAP_PRIORITY_WIRING_REASON,
+            "template_branch": template_branch,
+            "inbox_row_present": inbox_row_present,
+        }
+
+    if canonical_gb_event_ids:
+        return _na("governance_bootstrap_lags_human_needed")
+
+    return {
+        "state": "resolved",
+        "reason": None,
+        "event_id": None,
+        "blocking_component": None,
+        "source_reason": None,
+        "template_branch": None,
+        "inbox_row_present": False,
+    }
+
+
 def _loop_closure_summary() -> dict[str, Any]:
     """v3.15.16.9b — surface the autonomous-loop closure state on
     the existing Status card.
@@ -246,20 +446,29 @@ def _loop_closure_summary() -> dict[str, Any]:
     gb_env = _read_json_artifact(GOVERNANCE_BOOTSTRAP_LATEST)
     ai_env = _read_json_artifact(APPROVAL_INBOX_LATEST)
 
+    # v3.15.16.9c — compute the canonical bootstrap event surfacing
+    # against the same three artifact envelopes. Always emitted at
+    # the envelope level so the operator sees the canonical proof
+    # whether or not the aggregate loop_closure is ``ok``.
+    rpw = _roadmap_priority_wiring_summary(hn_env, gb_env, ai_env)
+
     if hn_env.get("status") != "ok":
         return {
             "status": "not_available",
             "reason": f"human_needed: {hn_env.get('reason') or 'unknown'}",
+            "roadmap_priority_wiring": rpw,
         }
     if gb_env.get("status") != "ok":
         return {
             "status": "not_available",
             "reason": f"governance_bootstrap: {gb_env.get('reason') or 'unknown'}",
+            "roadmap_priority_wiring": rpw,
         }
     if ai_env.get("status") != "ok":
         return {
             "status": "not_available",
             "reason": f"approval_inbox: {ai_env.get('reason') or 'unknown'}",
+            "roadmap_priority_wiring": rpw,
         }
 
     hn_data = hn_env.get("data") or {}
@@ -273,6 +482,7 @@ def _loop_closure_summary() -> dict[str, Any]:
         return {
             "status": "not_available",
             "reason": "missing generated_at_utc on one or more artifacts",
+            "roadmap_priority_wiring": rpw,
         }
 
     # human_needed projection — bounded.
@@ -381,6 +591,7 @@ def _loop_closure_summary() -> dict[str, Any]:
             },
             "last_refreshed_utc": last_refreshed_utc,
         },
+        "roadmap_priority_wiring": rpw,
     }
 
 

--- a/docs/governance/mobile_agent_control_pwa.md
+++ b/docs/governance/mobile_agent_control_pwa.md
@@ -1,7 +1,7 @@
 # Mobile-first Agent Control PWA — Operator Runbook
 
 > Module: `dashboard.api_agent_control` (backend) + `frontend/src/routes/AgentControl.tsx` (frontend)
-> Release: v3.15.15.26 (mobile-first IA rebuild on top of v3.15.15.18); v3.15.16.9b adds Loop closure subsection
+> Release: v3.15.15.26 (mobile-first IA rebuild on top of v3.15.15.18); v3.15.16.9b adds Loop closure subsection; v3.15.16.9c adds canonical bootstrap event surfacing
 > Sibling lifecycle modules: `reporting.autonomous_workloop`,
 > `reporting.github_pr_lifecycle`,
 > `reporting.workloop_runtime`,
@@ -66,6 +66,80 @@ After the bootstrap PR merges and the auto-deploy completes, the
 operator refreshes and sees `loop_state: resolved` with all three
 counts at zero. That two-state visual flip is the canonical
 Phase 1 end-to-end proof — no log inspection required.
+
+> **Aggregate vs canonical proof:** the `loop_state` field above is
+> an aggregate over *all* `human_needed` events. With many unrelated
+> blockers in flight, a single bootstrap PR may not flip
+> `loop_state` to `resolved`. v3.15.16.9c adds an independent
+> `roadmap_priority_wiring` subsection (see below) that is filtered
+> to one canonical `(reason, blocking_component)` pair, so the
+> specific v3.15.16.5 wiring gap can flip open→resolved without the
+> aggregate clearing.
+
+## v3.15.16.9c — `roadmap_priority_wiring` subsection (specific bootstrap proof)
+
+The Loop closure subsection now also carries a sibling field at
+the envelope level — `loop_closure.roadmap_priority_wiring` —
+that reports a single, *specific* canonical bootstrap event by
+exact `(reason, blocking_component)` match. It is independent of
+the aggregate `loop_state` so the operator can validate one
+bootstrap PR's effect without being drowned out by 200+ unrelated
+`human_needed` events.
+
+### Closed vocabulary
+
+`state ∈ {open, resolved, not_available}`. Three values, no fourth.
+
+`reason` is `null` when `state ∈ {open, resolved}`. When
+`state == "not_available"`, `reason` is one of the eight closed
+values:
+
+| reason | meaning |
+| --- | --- |
+| `human_needed_missing` | `logs/human_needed/latest.json` not present |
+| `human_needed_malformed` | artifact present but `events` is not a list |
+| `governance_bootstrap_missing` | `logs/governance_bootstrap/latest.json` not present |
+| `governance_bootstrap_malformed` | artifact present but `templates` is not a list |
+| `approval_inbox_missing` | `logs/approval_inbox/latest.json` not present |
+| `approval_inbox_malformed` | artifact present but `items` is not a list |
+| `event_id_missing` | a matching event was found but its `event_id` is empty |
+| `governance_bootstrap_lags_human_needed` | mid-refresh inconsistency: a matching template exists but no matching event |
+
+### Detection rules
+
+| step | rule |
+| --- | --- |
+| canonical literals | `REASON = "governance_bootstrap_required"`; `COMPONENT = "dashboard/dashboard.py:register_roadmap_priority_routes"` |
+| open | `human_needed.events[*]` contains an entry with `reason == REASON` AND `blocking_component == COMPONENT` AND a non-empty `event_id` |
+| open primary event | the lex-smallest matching `event_id` |
+| open template branch | first `governance_bootstrap.templates[*].branch_name` whose `source_event_id == event_id` AND `source_reason == REASON` (PRIMARY match by `source_event_id`) |
+| open inbox row present | any `approval_inbox.items[*]` whose `source == f"human_needed:{event_id}"` (exact equality, no substring) |
+| resolved | all three artifacts valid AND no `human_needed` event matches AND no `governance_bootstrap` template matches `(source_reason, evidence.blocking_component)` |
+| not_available | any artifact missing/malformed; or matching event with no `event_id`; or template-without-event mid-refresh |
+
+### Acceptance contract
+
+**Pre-bootstrap (current operator state):**
+
+```
+roadmap_priority route wiring: open
+  event_id: h_<10hex>
+  blocking_component: dashboard/dashboard.py:register_roadmap_priority_routes
+  source_reason: governance_bootstrap_required
+  template branch: governance-bootstrap/h_<10hex>
+  approval_inbox row: present
+```
+
+**Post-bootstrap (after operator's dashboard.py wiring PR merges and the
+recurring-maintenance refresh completes):**
+
+```
+roadmap_priority route wiring: resolved
+```
+
+The flip happens **independently** of the aggregate `loop_state`.
+Other `human_needed` events may persist; the aggregate may stay
+`open`. The canonical proof is the specific subsection.
 
 This is the operator-facing runbook for the Agent Control PWA.
 It explains what the app shows, what it does NOT do, how it is

--- a/docs/roadmap/qre_roadmap_v6_1.md
+++ b/docs/roadmap/qre_roadmap_v6_1.md
@@ -264,6 +264,48 @@ operator.
   `docs/roadmap/qre_roadmap_v6_1.md`
 * `risk_class`: LOW
 * `proposal_type`: observability_addition
+* `status`: done
+
+### v3.15.16.9c — Canonical bootstrap event surfacing on Loop closure
+
+Extend the v3.15.16.9b `loop_closure` envelope with one bounded
+sibling field — `loop_closure.roadmap_priority_wiring` — that
+filters to a single, *specific* canonical bootstrap event by
+exact `(reason, blocking_component)` match. Closed state
+vocabulary `{open, resolved, not_available}` plus closed reason
+vocabulary on `not_available`. The new field is **independent of
+the aggregate `loop_state`** so the operator can validate one
+specific bootstrap PR's effect without being drowned out by 200+
+unrelated `human_needed` events.
+
+* Match priorities pinned by tests:
+  * `human_needed` event by exact `reason == "governance_bootstrap_required"`
+    AND `blocking_component == "dashboard/dashboard.py:register_roadmap_priority_routes"`
+  * `governance_bootstrap` template by PRIMARY
+    `source_event_id == matching_event.event_id` AND
+    `source_reason == REASON`; FALLBACK
+    `evidence.blocking_component == COMPONENT` for the resolved
+    consistency check
+  * `approval_inbox` row by EXACT
+    `source == f"human_needed:{event_id}"` (no substring)
+* Resolved requires the *full canonical triple* cleared
+  (no matching event, no matching template, no matching inbox row).
+* Read-only; no new endpoint; no `dashboard/dashboard.py` change;
+  no mutation; no `.claude` change. Bounded payload — never
+  carries `proposed_patch`, `pr_body`, `file_diff`,
+  `commit_message`. The two canonical literals are pinned by a
+  source-text invariant test; the governance_bootstrap template
+  schema is also pinned (`source_event_id`, `source_reason`,
+  `branch_name`, `evidence.blocking_component`).
+* `affected_files`: `dashboard/api_agent_control.py`,
+  `frontend/src/api/agent_control.ts`,
+  `frontend/src/routes/AgentControl.tsx`,
+  `tests/unit/test_dashboard_api_agent_control.py`,
+  `frontend/src/test/AgentControl.test.tsx`,
+  `docs/governance/mobile_agent_control_pwa.md`,
+  `docs/roadmap/qre_roadmap_v6_1.md`
+* `risk_class`: LOW
+* `proposal_type`: observability_addition
 * `status`: proposed
 
 ### v3.15.16.9 — Governance-bootstrap PR-template synthesizer

--- a/frontend/src/api/agent_control.ts
+++ b/frontend/src/api/agent_control.ts
@@ -132,6 +132,12 @@ export interface AgentControlStatus {
   // payload only: counts, top blocking_component, top branch_name,
   // last_refreshed_utc, loop_state. NEVER carries proposed_patch
   // body, pr_body, full events / templates lists.
+  //
+  // v3.15.16.9c — ``roadmap_priority_wiring`` rides at the envelope
+  // level (sibling of ``status`` / ``reason`` / ``data``) so the
+  // operator sees the canonical bootstrap event proof independently
+  // of the aggregate ``loop_state``. Closed vocabulary on
+  // ``state`` and (when ``state == "not_available"``) ``reason``.
   loop_closure?: {
     status: "ok" | "not_available";
     reason?: string;
@@ -153,6 +159,15 @@ export interface AgentControlStatus {
         generated_at_utc: string;
       };
       last_refreshed_utc: string;
+    };
+    roadmap_priority_wiring?: {
+      state: "open" | "resolved" | "not_available";
+      reason: string | null;
+      event_id: string | null;
+      blocking_component: string | null;
+      source_reason: string | null;
+      template_branch: string | null;
+      inbox_row_present: boolean;
     };
   };
 }

--- a/frontend/src/routes/AgentControl.tsx
+++ b/frontend/src/routes/AgentControl.tsx
@@ -373,6 +373,9 @@ function LoopClosureBlock({
           <dt>reason</dt>
           <dd>{payload.reason ?? "not_available"}</dd>
         </div>
+        <RoadmapPriorityWiringBlock
+          payload={payload.roadmap_priority_wiring}
+        />
       </>
     );
   }
@@ -456,6 +459,113 @@ function LoopClosureBlock({
           {data.last_refreshed_utc}
         </dd>
       </div>
+      <RoadmapPriorityWiringBlock
+        payload={payload.roadmap_priority_wiring}
+      />
+    </>
+  );
+}
+
+// --- Subsection: roadmap_priority route wiring (v3.15.16.9c) ---
+// Surfaces the *specific* canonical bootstrap event for the
+// v3.15.16.5 wiring gap, independent of the aggregate loop_state.
+// Read-only. No proposed_patch / pr_body / file_diff is rendered;
+// only bounded scalar fields.
+function RoadmapPriorityWiringBlock({
+  payload,
+}: {
+  payload: NonNullable<
+    AgentControlStatus["loop_closure"]
+  >["roadmap_priority_wiring"];
+}) {
+  if (!payload) {
+    return null;
+  }
+  const state = payload.state;
+  const pillState: "ok" | "warn" | "danger" | "unknown" =
+    state === "resolved"
+      ? "ok"
+      : state === "open"
+        ? "danger"
+        : "unknown";
+  return (
+    <>
+      <div
+        className="agent-control-card__row"
+        data-testid="roadmap-priority-wiring-row"
+      >
+        <dt>roadmap_priority route wiring</dt>
+        <dd>
+          <span data-testid="roadmap-priority-wiring-state">{state}</span>{" "}
+          <StatusPill state={pillState} />
+        </dd>
+      </div>
+      {state === "not_available" && payload.reason ? (
+        <div
+          className="agent-control-card__row"
+          data-testid="roadmap-priority-wiring-reason-row"
+        >
+          <dt>reason</dt>
+          <dd data-testid="roadmap-priority-wiring-reason">
+            {payload.reason}
+          </dd>
+        </div>
+      ) : null}
+      {state === "open" && payload.event_id ? (
+        <div
+          className="agent-control-card__row"
+          data-testid="roadmap-priority-wiring-event-id-row"
+        >
+          <dt>event_id</dt>
+          <dd data-testid="roadmap-priority-wiring-event-id">
+            <code>{payload.event_id}</code>
+          </dd>
+        </div>
+      ) : null}
+      {state === "open" && payload.blocking_component ? (
+        <div
+          className="agent-control-card__row"
+          data-testid="roadmap-priority-wiring-blocking-component-row"
+        >
+          <dt>blocking_component</dt>
+          <dd data-testid="roadmap-priority-wiring-blocking-component">
+            <code>{payload.blocking_component}</code>
+          </dd>
+        </div>
+      ) : null}
+      {state === "open" && payload.source_reason ? (
+        <div
+          className="agent-control-card__row"
+          data-testid="roadmap-priority-wiring-source-reason-row"
+        >
+          <dt>source_reason</dt>
+          <dd data-testid="roadmap-priority-wiring-source-reason">
+            <code>{payload.source_reason}</code>
+          </dd>
+        </div>
+      ) : null}
+      {state === "open" && payload.template_branch ? (
+        <div
+          className="agent-control-card__row"
+          data-testid="roadmap-priority-wiring-template-branch-row"
+        >
+          <dt>template branch</dt>
+          <dd data-testid="roadmap-priority-wiring-template-branch">
+            <code>{payload.template_branch}</code>
+          </dd>
+        </div>
+      ) : null}
+      {state === "open" ? (
+        <div
+          className="agent-control-card__row"
+          data-testid="roadmap-priority-wiring-inbox-row"
+        >
+          <dt>approval_inbox row</dt>
+          <dd data-testid="roadmap-priority-wiring-inbox-present">
+            {payload.inbox_row_present ? "present" : "absent"}
+          </dd>
+        </div>
+      ) : null}
     </>
   );
 }

--- a/frontend/src/test/AgentControl.test.tsx
+++ b/frontend/src/test/AgentControl.test.tsx
@@ -1297,3 +1297,238 @@ describe("AgentControl — loop closure subsection (v3.15.16.9b)", () => {
     ).not.toBeInTheDocument();
   });
 });
+
+// ---------------------------------------------------------------------------
+// v3.15.16.9c — roadmap_priority route wiring subsection
+// ---------------------------------------------------------------------------
+
+const rpwOpen = {
+  state: "open" as const,
+  reason: null,
+  event_id: "h_044e7e64e",
+  blocking_component:
+    "dashboard/dashboard.py:register_roadmap_priority_routes",
+  source_reason: "governance_bootstrap_required",
+  template_branch: "governance-bootstrap/h_044e7e64e",
+  inbox_row_present: true,
+};
+
+const rpwResolved = {
+  state: "resolved" as const,
+  reason: null,
+  event_id: null,
+  blocking_component: null,
+  source_reason: null,
+  template_branch: null,
+  inbox_row_present: false,
+};
+
+const rpwNotAvailable = {
+  state: "not_available" as const,
+  reason: "governance_bootstrap_lags_human_needed",
+  event_id: null,
+  blocking_component: null,
+  source_reason: null,
+  template_branch: null,
+  inbox_row_present: false,
+};
+
+const loopClosureOpenWithRpwOpen = {
+  ...loopClosureOpen,
+  roadmap_priority_wiring: rpwOpen,
+};
+
+const loopClosureOpenWithRpwResolved = {
+  ...loopClosureOpen,
+  roadmap_priority_wiring: rpwResolved,
+};
+
+const loopClosureNotAvailableWithRpwNotAvailable = {
+  ...loopClosureNotAvailable,
+  roadmap_priority_wiring: rpwNotAvailable,
+};
+
+describe("AgentControl — roadmap_priority route wiring subsection (v3.15.16.9c)", () => {
+  it("renders open state with all five canonical fields", async () => {
+    installFetchMock(
+      {
+        "/api/agent-control/status": () =>
+          jsonResp(makeStatusBodyWithLoopClosure(loopClosureOpenWithRpwOpen)),
+        "/api/agent-control/activity": () => jsonResp(okActivityBody),
+        "/api/agent-control/workloop": () => jsonResp(okWorkloopBody),
+        "/api/agent-control/pr-lifecycle": () =>
+          jsonResp(okPRLifecycleEmptyBody),
+        "/api/agent-control/notifications": () =>
+          jsonResp(placeholderNotificationsBody),
+        "/api/agent-control/proposals": () => jsonResp(okProposalsEmptyBody),
+        "/api/agent-control/approval-inbox": () => jsonResp(okInboxEmptyBody),
+        "/api/agent-control/execute-safe": () => jsonResp(okExecuteSafeBody),
+      },
+      () => jsonResp({}, 404),
+    );
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("roadmap-priority-wiring-state"),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByTestId("roadmap-priority-wiring-state"),
+    ).toHaveTextContent("open");
+    expect(
+      screen.getByTestId("roadmap-priority-wiring-event-id"),
+    ).toHaveTextContent("h_044e7e64e");
+    expect(
+      screen.getByTestId("roadmap-priority-wiring-blocking-component"),
+    ).toHaveTextContent(
+      "dashboard/dashboard.py:register_roadmap_priority_routes",
+    );
+    expect(
+      screen.getByTestId("roadmap-priority-wiring-source-reason"),
+    ).toHaveTextContent("governance_bootstrap_required");
+    expect(
+      screen.getByTestId("roadmap-priority-wiring-template-branch"),
+    ).toHaveTextContent("governance-bootstrap/h_044e7e64e");
+    expect(
+      screen.getByTestId("roadmap-priority-wiring-inbox-present"),
+    ).toHaveTextContent("present");
+    expect(
+      screen.queryByTestId("roadmap-priority-wiring-reason"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders resolved state without descriptive fields", async () => {
+    installFetchMock(
+      {
+        "/api/agent-control/status": () =>
+          jsonResp(
+            makeStatusBodyWithLoopClosure(loopClosureOpenWithRpwResolved),
+          ),
+        "/api/agent-control/activity": () => jsonResp(okActivityBody),
+        "/api/agent-control/workloop": () => jsonResp(okWorkloopBody),
+        "/api/agent-control/pr-lifecycle": () =>
+          jsonResp(okPRLifecycleEmptyBody),
+        "/api/agent-control/notifications": () =>
+          jsonResp(placeholderNotificationsBody),
+        "/api/agent-control/proposals": () => jsonResp(okProposalsEmptyBody),
+        "/api/agent-control/approval-inbox": () => jsonResp(okInboxEmptyBody),
+        "/api/agent-control/execute-safe": () => jsonResp(okExecuteSafeBody),
+      },
+      () => jsonResp({}, 404),
+    );
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("roadmap-priority-wiring-state"),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByTestId("roadmap-priority-wiring-state"),
+    ).toHaveTextContent("resolved");
+    // Descriptive rows are absent in the resolved state.
+    expect(
+      screen.queryByTestId("roadmap-priority-wiring-event-id"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("roadmap-priority-wiring-blocking-component"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("roadmap-priority-wiring-source-reason"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("roadmap-priority-wiring-template-branch"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("roadmap-priority-wiring-inbox-present"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("roadmap-priority-wiring-reason"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders not_available state with the closed reason", async () => {
+    installFetchMock(
+      {
+        "/api/agent-control/status": () =>
+          jsonResp(
+            makeStatusBodyWithLoopClosure(
+              loopClosureNotAvailableWithRpwNotAvailable,
+            ),
+          ),
+        "/api/agent-control/activity": () => jsonResp(okActivityBody),
+        "/api/agent-control/workloop": () => jsonResp(okWorkloopBody),
+        "/api/agent-control/pr-lifecycle": () =>
+          jsonResp(okPRLifecycleEmptyBody),
+        "/api/agent-control/notifications": () =>
+          jsonResp(placeholderNotificationsBody),
+        "/api/agent-control/proposals": () => jsonResp(okProposalsEmptyBody),
+        "/api/agent-control/approval-inbox": () => jsonResp(okInboxEmptyBody),
+        "/api/agent-control/execute-safe": () => jsonResp(okExecuteSafeBody),
+      },
+      () => jsonResp({}, 404),
+    );
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("roadmap-priority-wiring-state"),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByTestId("roadmap-priority-wiring-state"),
+    ).toHaveTextContent("not_available");
+    expect(
+      screen.getByTestId("roadmap-priority-wiring-reason"),
+    ).toHaveTextContent("governance_bootstrap_lags_human_needed");
+    // No descriptive open-only fields in not_available either.
+    expect(
+      screen.queryByTestId("roadmap-priority-wiring-event-id"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("roadmap-priority-wiring-template-branch"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not render the wiring subsection when payload omits roadmap_priority_wiring", async () => {
+    // Backwards-compat: an older /status payload without the new
+    // sub-object must not crash the card.
+    installFetchMock(
+      {
+        "/api/agent-control/status": () =>
+          jsonResp(makeStatusBodyWithLoopClosure(loopClosureOpen)),
+        "/api/agent-control/activity": () => jsonResp(okActivityBody),
+        "/api/agent-control/workloop": () => jsonResp(okWorkloopBody),
+        "/api/agent-control/pr-lifecycle": () =>
+          jsonResp(okPRLifecycleEmptyBody),
+        "/api/agent-control/notifications": () =>
+          jsonResp(placeholderNotificationsBody),
+        "/api/agent-control/proposals": () => jsonResp(okProposalsEmptyBody),
+        "/api/agent-control/approval-inbox": () => jsonResp(okInboxEmptyBody),
+        "/api/agent-control/execute-safe": () => jsonResp(okExecuteSafeBody),
+      },
+      () => jsonResp({}, 404),
+    );
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("loop-closure-state")).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByTestId("roadmap-priority-wiring-state"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/tests/unit/test_dashboard_api_agent_control.py
+++ b/tests/unit/test_dashboard_api_agent_control.py
@@ -717,3 +717,562 @@ def test_loop_closure_not_available_on_missing_generated_at_utc(
     lc = body["loop_closure"]
     assert lc["status"] == "not_available"
     assert "generated_at_utc" in lc["reason"]
+
+
+# ---------------------------------------------------------------------------
+# v3.15.16.9c — canonical bootstrap event surfacing
+# ---------------------------------------------------------------------------
+
+
+_CANON_COMPONENT = "dashboard/dashboard.py:register_roadmap_priority_routes"
+_CANON_REASON = "governance_bootstrap_required"
+
+
+def _hn_canon(
+    *,
+    event_id: "str | None" = "h_044e7e64e",
+    extra_events: "list | None" = None,
+    matching_blocking_component: str = _CANON_COMPONENT,
+    matching_reason: str = _CANON_REASON,
+    include_match: bool = True,
+    generated_at_utc: str = "2026-05-05T13:00:00Z",
+) -> dict:
+    """human_needed digest with one matching canonical event plus
+    optional extra (unrelated) events. Used by v3.15.16.9c tests."""
+    events: list = []
+    if include_match:
+        ev: dict[str, Any] = {
+            "reason": matching_reason,
+            "blocking_component": matching_blocking_component,
+            "priority": "HIGH",
+        }
+        if event_id is not None:
+            ev["event_id"] = event_id
+        events.append(ev)
+    if extra_events:
+        events.extend(extra_events)
+    return {
+        "schema_version": 1,
+        "report_kind": "human_needed_digest",
+        "module_version": "v3.15.16.8",
+        "generated_at_utc": generated_at_utc,
+        "counts": {
+            "events_total": len(events),
+            "by_reason": {_CANON_REASON: 1 if include_match else 0},
+        },
+        "events": events,
+    }
+
+
+def _gb_canon(
+    *,
+    event_id: str = "h_044e7e64e",
+    branch_name: str = "governance-bootstrap/h_044e7e64e",
+    extra_templates: "list | None" = None,
+    include_match: bool = True,
+    matching_blocking_component: str = _CANON_COMPONENT,
+    matching_reason: str = _CANON_REASON,
+    generated_at_utc: str = "2026-05-05T13:00:00Z",
+) -> dict:
+    """governance_bootstrap digest with one matching canonical
+    template (using the *full* canonical schema: source_event_id,
+    source_reason, evidence.blocking_component) plus optional extras."""
+    templates: list = []
+    if include_match:
+        templates.append(
+            {
+                "template_id": "gb_044e7e64e",
+                "source_event_id": event_id,
+                "source_reason": matching_reason,
+                "branch_name": branch_name,
+                "evidence": {
+                    "blocking_component": matching_blocking_component,
+                    "impact": "HIGH",
+                    "priority": "HIGH",
+                    "related_item": None,
+                },
+            }
+        )
+    if extra_templates:
+        templates.extend(extra_templates)
+    return {
+        "schema_version": 1,
+        "report_kind": "governance_bootstrap_digest",
+        "module_version": "v3.15.16.9",
+        "generated_at_utc": generated_at_utc,
+        "counts": {"templates_total": len(templates)},
+        "templates": templates,
+    }
+
+
+def _ai_canon(
+    *,
+    event_id: str = "h_044e7e64e",
+    include_match: bool = True,
+    extra_items: "list | None" = None,
+    generated_at_utc: str = "2026-05-05T13:00:00Z",
+) -> dict:
+    items: list = []
+    if include_match:
+        items.append(
+            {"item_id": "i_canon", "source": f"human_needed:{event_id}"}
+        )
+    if extra_items:
+        items.extend(extra_items)
+    return {
+        "schema_version": 1,
+        "report_kind": "approval_inbox_digest",
+        "module_version": "v3.15.15.20",
+        "generated_at_utc": generated_at_utc,
+        "items": items,
+    }
+
+
+# --- open state ---
+
+
+def test_rpw_open_when_event_matches_both_literals(client, tmp_path: Path) -> None:
+    """Canonical pre-bootstrap state: matching event + matching
+    template + matching inbox row → state=open with all literals."""
+    _set_loop_closure_artifacts(
+        tmp_path, hn=_hn_canon(), gb=_gb_canon(), ai=_ai_canon()
+    )
+    body = client.get("/api/agent-control/status").get_json()
+    rpw = body["loop_closure"]["roadmap_priority_wiring"]
+    assert rpw["state"] == "open"
+    assert rpw["reason"] is None
+    assert rpw["event_id"] == "h_044e7e64e"
+    assert rpw["blocking_component"] == _CANON_COMPONENT
+    assert rpw["source_reason"] == _CANON_REASON
+    assert rpw["template_branch"] == "governance-bootstrap/h_044e7e64e"
+    assert rpw["inbox_row_present"] is True
+
+
+def test_rpw_open_template_branch_resolved_by_source_event_id_PRIMARY(
+    client, tmp_path: Path
+) -> None:
+    """Template match is PRIMARY on (source_event_id, source_reason).
+    A template whose source_event_id matches the chosen event_id
+    populates template_branch, regardless of evidence shape."""
+    # Two templates: one with the canonical pair (matches), one
+    # with the canonical reason but a different event_id (does NOT
+    # match). Helper must pick the PRIMARY (event_id) match.
+    extra = [
+        {
+            "template_id": "gb_other",
+            "source_event_id": "h_other",
+            "source_reason": _CANON_REASON,
+            "branch_name": "governance-bootstrap/h_other",
+            "evidence": {"blocking_component": _CANON_COMPONENT},
+        }
+    ]
+    _set_loop_closure_artifacts(
+        tmp_path,
+        hn=_hn_canon(),
+        gb=_gb_canon(extra_templates=extra),
+        ai=_ai_canon(),
+    )
+    body = client.get("/api/agent-control/status").get_json()
+    rpw = body["loop_closure"]["roadmap_priority_wiring"]
+    assert rpw["state"] == "open"
+    assert rpw["template_branch"] == "governance-bootstrap/h_044e7e64e"
+
+
+def test_rpw_open_inbox_row_present_via_exact_source_equality(
+    client, tmp_path: Path
+) -> None:
+    """inbox_row_present is True ONLY when an item has
+    source == "human_needed:<event_id>" exactly. Substring matches
+    or near-misses must NOT count."""
+    near_miss_items = [
+        {
+            "item_id": "i_substr",
+            "source": "human_needed:h_044e7e64e_extra",
+        },  # near-miss: superstring
+        {
+            "item_id": "i_other_prefix",
+            "source": "recurring_maintenance:h_044e7e64e",
+        },  # near-miss: different prefix
+        {
+            "item_id": "i_blocking_substr",
+            "source": "manual:dashboard/dashboard.py:register_roadmap_priority_routes",
+        },  # near-miss: blocking_component embedded but not the canonical source format
+    ]
+    _set_loop_closure_artifacts(
+        tmp_path,
+        hn=_hn_canon(),
+        gb=_gb_canon(),
+        ai=_ai_canon(include_match=False, extra_items=near_miss_items),
+    )
+    body = client.get("/api/agent-control/status").get_json()
+    rpw = body["loop_closure"]["roadmap_priority_wiring"]
+    assert rpw["state"] == "open"
+    assert rpw["inbox_row_present"] is False
+
+
+def test_rpw_open_picks_lex_smallest_event_id_deterministically(
+    client, tmp_path: Path
+) -> None:
+    """When several human_needed events match the canonical pair,
+    the lex-smallest event_id is chosen for the open report."""
+    extra_events = [
+        {
+            "event_id": "h_zzzzzzzzzz",
+            "reason": _CANON_REASON,
+            "blocking_component": _CANON_COMPONENT,
+            "priority": "HIGH",
+        },
+        {
+            "event_id": "h_000000000a",  # smallest
+            "reason": _CANON_REASON,
+            "blocking_component": _CANON_COMPONENT,
+            "priority": "HIGH",
+        },
+    ]
+    _set_loop_closure_artifacts(
+        tmp_path,
+        hn=_hn_canon(extra_events=extra_events),
+        gb=_gb_canon(),
+        ai=_ai_canon(),
+    )
+    body = client.get("/api/agent-control/status").get_json()
+    rpw = body["loop_closure"]["roadmap_priority_wiring"]
+    assert rpw["state"] == "open"
+    assert rpw["event_id"] == "h_000000000a"
+
+
+# --- resolved state ---
+
+
+def test_rpw_resolved_when_all_three_artifacts_clear_of_canonical(
+    client, tmp_path: Path
+) -> None:
+    """Resolved requires the *full triple* cleared. With no matching
+    event, no matching template, and no matching inbox row, state is
+    resolved — even though counts are non-zero (unrelated work)."""
+    _set_loop_closure_artifacts(
+        tmp_path,
+        hn=_hn_canon(include_match=False),
+        gb=_gb_canon(include_match=False),
+        ai=_ai_canon(include_match=False),
+    )
+    body = client.get("/api/agent-control/status").get_json()
+    rpw = body["loop_closure"]["roadmap_priority_wiring"]
+    assert rpw["state"] == "resolved"
+    assert rpw["reason"] is None
+    assert rpw["event_id"] is None
+    assert rpw["blocking_component"] is None
+    assert rpw["source_reason"] is None
+    assert rpw["template_branch"] is None
+    assert rpw["inbox_row_present"] is False
+
+
+def test_rpw_resolved_ignores_unrelated_events_and_unrelated_inbox_rows(
+    client, tmp_path: Path
+) -> None:
+    """The resolved decision is *non-aggregate*. Unrelated
+    human_needed events, unrelated governance_bootstrap templates,
+    and unrelated approval_inbox rows persist — yet the canonical
+    triple is cleared, so state=resolved."""
+    unrelated_events = [
+        {
+            "event_id": "h_unrelated1",
+            "reason": _CANON_REASON,
+            "blocking_component": "dashboard/dashboard.py:register_other_routes",
+            "priority": "HIGH",
+        },
+        {
+            "event_id": "h_unrelated2",
+            "reason": "decision_unclear",
+            "blocking_component": _CANON_COMPONENT,  # canonical comp + non-canonical reason
+            "priority": "MEDIUM",
+        },
+    ]
+    unrelated_templates = [
+        {
+            "template_id": "gb_other",
+            "source_event_id": "h_unrelated1",
+            "source_reason": _CANON_REASON,
+            "branch_name": "governance-bootstrap/h_unrelated1",
+            "evidence": {
+                "blocking_component": "dashboard/dashboard.py:register_other_routes",
+            },
+        }
+    ]
+    unrelated_items = [
+        {"item_id": "i_un1", "source": "human_needed:h_unrelated1"},
+        {"item_id": "i_un2", "source": "recurring_maintenance:foo"},
+    ]
+    _set_loop_closure_artifacts(
+        tmp_path,
+        hn=_hn_canon(include_match=False, extra_events=unrelated_events),
+        gb=_gb_canon(include_match=False, extra_templates=unrelated_templates),
+        ai=_ai_canon(include_match=False, extra_items=unrelated_items),
+    )
+    body = client.get("/api/agent-control/status").get_json()
+    rpw = body["loop_closure"]["roadmap_priority_wiring"]
+    assert rpw["state"] == "resolved"
+    # Aggregate loop_state may still be open because counts are non-zero —
+    # the rpw subsection is independent of that signal.
+    aggregate_loop_state = body["loop_closure"]["data"]["loop_state"]
+    assert aggregate_loop_state == "open"
+
+
+# --- not_available state ---
+
+
+def test_rpw_not_available_human_needed_missing(
+    client, tmp_path: Path
+) -> None:
+    """Artifact missing → not_available + closed reason."""
+    _set_loop_closure_artifacts(
+        tmp_path, hn=None, gb=_gb_canon(), ai=_ai_canon()
+    )
+    body = client.get("/api/agent-control/status").get_json()
+    rpw = body["loop_closure"]["roadmap_priority_wiring"]
+    assert rpw["state"] == "not_available"
+    assert rpw["reason"] == "human_needed_missing"
+
+
+def test_rpw_not_available_human_needed_malformed(
+    client, tmp_path: Path
+) -> None:
+    """events not a list → human_needed_malformed."""
+    bad = _hn_canon()
+    bad["events"] = {"this": "is not a list"}
+    _set_loop_closure_artifacts(tmp_path, hn=bad, gb=_gb_canon(), ai=_ai_canon())
+    body = client.get("/api/agent-control/status").get_json()
+    rpw = body["loop_closure"]["roadmap_priority_wiring"]
+    assert rpw["state"] == "not_available"
+    assert rpw["reason"] == "human_needed_malformed"
+
+
+def test_rpw_not_available_governance_bootstrap_missing(
+    client, tmp_path: Path
+) -> None:
+    _set_loop_closure_artifacts(
+        tmp_path, hn=_hn_canon(), gb=None, ai=_ai_canon()
+    )
+    body = client.get("/api/agent-control/status").get_json()
+    rpw = body["loop_closure"]["roadmap_priority_wiring"]
+    assert rpw["state"] == "not_available"
+    assert rpw["reason"] == "governance_bootstrap_missing"
+
+
+def test_rpw_not_available_governance_bootstrap_malformed(
+    client, tmp_path: Path
+) -> None:
+    bad = _gb_canon()
+    bad["templates"] = "not a list"
+    _set_loop_closure_artifacts(tmp_path, hn=_hn_canon(), gb=bad, ai=_ai_canon())
+    body = client.get("/api/agent-control/status").get_json()
+    rpw = body["loop_closure"]["roadmap_priority_wiring"]
+    assert rpw["state"] == "not_available"
+    assert rpw["reason"] == "governance_bootstrap_malformed"
+
+
+def test_rpw_not_available_approval_inbox_missing(
+    client, tmp_path: Path
+) -> None:
+    _set_loop_closure_artifacts(
+        tmp_path, hn=_hn_canon(), gb=_gb_canon(), ai=None
+    )
+    body = client.get("/api/agent-control/status").get_json()
+    rpw = body["loop_closure"]["roadmap_priority_wiring"]
+    assert rpw["state"] == "not_available"
+    assert rpw["reason"] == "approval_inbox_missing"
+
+
+def test_rpw_not_available_approval_inbox_malformed(
+    client, tmp_path: Path
+) -> None:
+    bad = _ai_canon()
+    bad["items"] = 12345  # int, not a list
+    _set_loop_closure_artifacts(tmp_path, hn=_hn_canon(), gb=_gb_canon(), ai=bad)
+    body = client.get("/api/agent-control/status").get_json()
+    rpw = body["loop_closure"]["roadmap_priority_wiring"]
+    assert rpw["state"] == "not_available"
+    assert rpw["reason"] == "approval_inbox_malformed"
+
+
+def test_rpw_not_available_event_id_missing(client, tmp_path: Path) -> None:
+    """Matching event with empty event_id → event_id_missing.
+    Matching is observed (so not 'resolved') but cannot be derived
+    deterministically (so not 'open')."""
+    _set_loop_closure_artifacts(
+        tmp_path,
+        hn=_hn_canon(event_id=None),  # event present but missing event_id field
+        gb=_gb_canon(),
+        ai=_ai_canon(),
+    )
+    body = client.get("/api/agent-control/status").get_json()
+    rpw = body["loop_closure"]["roadmap_priority_wiring"]
+    assert rpw["state"] == "not_available"
+    assert rpw["reason"] == "event_id_missing"
+
+
+def test_rpw_not_available_governance_bootstrap_lags_human_needed(
+    client, tmp_path: Path
+) -> None:
+    """Mid-refresh inconsistency: gb has matching template but hn
+    does not. Closed reason captures this exact case."""
+    _set_loop_closure_artifacts(
+        tmp_path,
+        hn=_hn_canon(include_match=False),
+        gb=_gb_canon(),  # still has the canonical template
+        ai=_ai_canon(),
+    )
+    body = client.get("/api/agent-control/status").get_json()
+    rpw = body["loop_closure"]["roadmap_priority_wiring"]
+    assert rpw["state"] == "not_available"
+    assert rpw["reason"] == "governance_bootstrap_lags_human_needed"
+
+
+# --- closed-vocabulary, schema and no-leak guards ---
+
+
+def test_rpw_closed_reason_vocabulary_pinned() -> None:
+    """The closed reason vocabulary is pinned; any addition is a
+    deliberate API change requiring a new release."""
+    expected = {
+        "human_needed_missing",
+        "human_needed_malformed",
+        "governance_bootstrap_missing",
+        "governance_bootstrap_malformed",
+        "approval_inbox_missing",
+        "approval_inbox_malformed",
+        "event_id_missing",
+        "governance_bootstrap_lags_human_needed",
+    }
+    assert set(ac.ROADMAP_PRIORITY_WIRING_NOT_AVAILABLE_REASONS) == expected
+
+
+def test_rpw_canonical_literals_are_frozen() -> None:
+    """Source-text invariant: the two canonical literals are pinned.
+    A drift breaks the open→resolved proof for the operator."""
+    src = (REPO_ROOT / "dashboard" / "api_agent_control.py").read_text(
+        encoding="utf-8"
+    )
+    assert (
+        'ROADMAP_PRIORITY_WIRING_COMPONENT: str = (\n'
+        '    "dashboard/dashboard.py:register_roadmap_priority_routes"\n'
+        ")"
+    ) in src
+    assert (
+        'ROADMAP_PRIORITY_WIRING_REASON: str = "governance_bootstrap_required"'
+        in src
+    )
+
+
+def test_rpw_governance_bootstrap_template_schema_pinned() -> None:
+    """The fields the helper consumes (source_event_id, source_reason,
+    branch_name, evidence.blocking_component) MUST exist in the
+    governance_bootstrap module's template builder. If that schema
+    drifts, this test fails before the live wire silently misclassifies."""
+    src = (REPO_ROOT / "reporting" / "governance_bootstrap.py").read_text(
+        encoding="utf-8"
+    )
+    # Top-level keys.
+    assert '"source_event_id"' in src
+    assert '"source_reason"' in src
+    assert '"branch_name"' in src
+    # Nested key.
+    assert '"blocking_component"' in src
+
+
+def test_rpw_payload_keys_are_bounded(client, tmp_path: Path) -> None:
+    """The roadmap_priority_wiring payload exposes ONLY the seven
+    bounded keys. No extra fields, no proposed_patch, no pr_body."""
+    _set_loop_closure_artifacts(
+        tmp_path, hn=_hn_canon(), gb=_gb_canon(), ai=_ai_canon()
+    )
+    body = client.get("/api/agent-control/status").get_json()
+    rpw = body["loop_closure"]["roadmap_priority_wiring"]
+    assert set(rpw.keys()) == {
+        "state",
+        "reason",
+        "event_id",
+        "blocking_component",
+        "source_reason",
+        "template_branch",
+        "inbox_row_present",
+    }
+
+
+def test_rpw_no_proposed_patch_or_pr_body_or_diff_leak(
+    client, tmp_path: Path
+) -> None:
+    """Defensive: feed templates / events with leak-shaped fields and
+    confirm none of them appear in the rendered payload."""
+    leaky_events = [
+        {
+            "event_id": "h_044e7e64e",
+            "reason": _CANON_REASON,
+            "blocking_component": _CANON_COMPONENT,
+            "proposed_patch": "MARKER_LEAK_PATCH",
+            "priority": "HIGH",
+        }
+    ]
+    leaky_templates = [
+        {
+            "template_id": "gb_044e7e64e",
+            "source_event_id": "h_044e7e64e",
+            "source_reason": _CANON_REASON,
+            "branch_name": "governance-bootstrap/h_044e7e64e",
+            "pr_body": "MARKER_LEAK_PR_BODY",
+            "file_diff": "MARKER_LEAK_FILE_DIFF",
+            "commit_message": "MARKER_LEAK_COMMIT",
+            "evidence": {"blocking_component": _CANON_COMPONENT},
+        }
+    ]
+    _set_loop_closure_artifacts(
+        tmp_path,
+        hn={
+            "schema_version": 1,
+            "module_version": "v3.15.16.8",
+            "generated_at_utc": "2026-05-05T13:00:00Z",
+            "counts": {"events_total": 1, "by_reason": {_CANON_REASON: 1}},
+            "events": leaky_events,
+        },
+        gb={
+            "schema_version": 1,
+            "module_version": "v3.15.16.9",
+            "generated_at_utc": "2026-05-05T13:00:00Z",
+            "counts": {"templates_total": 1},
+            "templates": leaky_templates,
+        },
+        ai=_ai_canon(),
+    )
+    body = client.get("/api/agent-control/status").get_json()
+    rpw = body["loop_closure"]["roadmap_priority_wiring"]
+    assert rpw["state"] == "open"
+    text = json.dumps(rpw)
+    for marker in (
+        "MARKER_LEAK_PATCH",
+        "MARKER_LEAK_PR_BODY",
+        "MARKER_LEAK_FILE_DIFF",
+        "MARKER_LEAK_COMMIT",
+        "proposed_patch",
+        "pr_body",
+        "file_diff",
+        "commit_message",
+    ):
+        assert marker not in text, (
+            f"roadmap_priority_wiring leaks forbidden token: {marker!r}"
+        )
+
+
+def test_rpw_present_at_envelope_level_on_not_available_loop_closure(
+    client, tmp_path: Path
+) -> None:
+    """When the aggregate loop_closure is itself not_available
+    (e.g. an artifact is missing), the rpw subsection still rides
+    at the envelope level so the operator can see the canonical
+    reason."""
+    _set_loop_closure_artifacts(tmp_path, hn=None, gb=None, ai=None)
+    body = client.get("/api/agent-control/status").get_json()
+    lc = body["loop_closure"]
+    assert lc["status"] == "not_available"
+    rpw = lc["roadmap_priority_wiring"]
+    assert rpw["state"] == "not_available"
+    assert rpw["reason"] == "human_needed_missing"


### PR DESCRIPTION
## Summary

Extends the v3.15.16.9b `loop_closure` envelope on `/api/agent-control/status` with one bounded sibling field — `loop_closure.roadmap_priority_wiring` — that filters to a *single specific* canonical bootstrap event by exact `(reason, blocking_component)` match. Independent of the aggregate `loop_state` so the operator can validate one bootstrap PR's effect without being drowned out by 200+ unrelated `human_needed` events.

## Why

Operator feedback after v3.15.16.9b deploy: the aggregate loop closure block correctly showed `open` / 226 events / 1 template / 224 inbox rows, but the *top* `blocking_component` was `task_board:p_55344326` rather than the v3.15.16.5 wiring gap. After the dashboard.py bootstrap PR merges, `loop_state` will likely stay `open` (other events persist) → no operator-visible per-event proof.

This PR adds an independent per-event proof for the canonical wiring gap.

## What

* New helper `_roadmap_priority_wiring_summary()` in `dashboard/api_agent_control.py` derived from the same three artifact envelopes already read by `_loop_closure_summary()`. No new disk reads.
* Two module constants pinned by source-text test:
  * `ROADMAP_PRIORITY_WIRING_COMPONENT = "dashboard/dashboard.py:register_roadmap_priority_routes"`
  * `ROADMAP_PRIORITY_WIRING_REASON = "governance_bootstrap_required"`
* Closed state vocabulary `{open, resolved, not_available}` plus 8-value closed reason vocabulary on `not_available`.
* Resolved requires the **full canonical triple cleared** (no matching event, no matching template, no matching inbox row); unrelated events / inbox rows may persist.
* Match priorities pinned:
  * `human_needed` event by exact `reason` + `blocking_component`
  * `governance_bootstrap` template by PRIMARY `source_event_id == event_id` + `source_reason == REASON`; FALLBACK `evidence.blocking_component == COMPONENT` for the resolved consistency check
  * `approval_inbox` row by **EXACT** `source == f\"human_needed:{event_id}\"` (no substring)
* PWA Overview tab Status card gains one bounded subsection rendering the new field.

## Roadmap protocol

| field | value |
| --- | --- |
| `item_id` | v3.15.16.9c |
| `item_type` | reporting_read_only |
| `risk_class` | LOW |
| `decision` | allowed_read_only |
| `implementation_allowed` | true |
| `requires_human` | false |
| `safe_to_execute` | false (protocol invariant) |
| `status` | proposed |
| `blocked_reason` | null |

## Constraints honored

| constraint | OK |
| --- | --- |
| read-only | ✓ |
| existing `/api/agent-control/status` only | ✓ |
| no new endpoint | ✓ |
| no `dashboard/dashboard.py` | ✓ |
| no `.claude` | ✓ |
| no execution engine / push notifications / v3.15.16.10 | ✓ |
| no live/paper/shadow/risk | ✓ |
| no frozen contracts | ✓ |
| no test weakening | ✓ |

## Acceptance contract

**Pre-bootstrap (current operator state):**
\`\`\`
roadmap_priority route wiring: open
  event_id: h_<10hex>
  blocking_component: dashboard/dashboard.py:register_roadmap_priority_routes
  source_reason: governance_bootstrap_required
  template branch: governance-bootstrap/h_<10hex>
  approval_inbox row: present
\`\`\`

**Post-bootstrap (after operator's dashboard.py wiring PR merges and the recurring-maintenance refresh completes):**
\`\`\`
roadmap_priority route wiring: resolved
\`\`\`

The flip happens **independently** of the aggregate `loop_state`.

## Test plan

- [x] backend unit tests (20 new) — open/resolved/not_available, lex-smallest event_id, exact source equality, PRIMARY template match by source_event_id, closed reason vocabulary, canonical literal source-text invariant, governance_bootstrap template schema invariant, no-leak guard
- [x] frontend render tests (4 new) — open/resolved/not_available + backwards-compat (subsection absent when payload omits the new field)
- [x] governance_lint OK
- [x] tests/smoke 14/14
- [x] tests/unit 3374 passed, 3 skipped, 0 failed (~13m)
- [x] frontend test 99/99
- [x] frontend build clean
- [x] frozen contracts no drift
- [ ] CI green
- [ ] post-deploy: PWA Overview shows `roadmap_priority route wiring: open` with literal `dashboard/dashboard.py:register_roadmap_priority_routes`
- [ ] (operator authors and merges the dashboard.py wiring bootstrap PR — out of scope here)
- [ ] (after that deploys: PWA flips to `roadmap_priority route wiring: resolved`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)