### PR TITLE
chore: wire roadmap priority route

### DIFF
--- a/dashboard/dashboard.py
+++ b/dashboard/dashboard.py
@@ -39,6 +39,7 @@ from dashboard.api_system_meta import register_system_meta_routes
 from dashboard.api_agent_control import register_agent_control_routes
 from dashboard.api_proposal_queue import register_proposal_queue_routes
 from dashboard.api_approval_inbox import register_approval_inbox_routes
+from dashboard.api_roadmap_priority import register_roadmap_priority_routes
 from reporting import audit_log
 
 app = Flask(__name__, template_folder="templates")
@@ -86,6 +87,7 @@ register_observability_routes(app)
 register_agent_control_routes(app)
 register_proposal_queue_routes(app)
 register_approval_inbox_routes(app)
+register_roadmap_priority_routes(app)
 
 
 @app.errorhandler(Exception)


### PR DESCRIPTION
Operator-authored governance bootstrap PR.

Purpose:
Wire the already-merged roadmap priority Agent Control API route into dashboard/dashboard.py.

Changes:
- Import register_roadmap_priority_routes
- Register register_roadmap_priority_routes(app)

Scope:
- dashboard/dashboard.py only
- exactly two added lines
- no .claude changes
- no frozen contract changes
- no trading/risk/live/paper/shadow changes
- no execution engine

Expected result:
After merge and deploy, Agent Control should expose /api/agent-control/next-up and the roadmap_priority route wiring proof should flip from open to resolved.