### PR TITLE
fix(proposal_queue): skip H1 headings unconditionally

### DIFF
--- a/reporting/proposal_queue.py
+++ b/reporting/proposal_queue.py
@@ -902,11 +902,16 @@ def _build_all_proposals(files: list[Path]) -> list[dict[str, Any]]:
             continue
         segments = _heading_segments(text)
         for level, line_idx, title, body in segments:
-            # Skip the file-level title heading on a doc that consists
-            # only of a single H1 + index (very common in docs/).
-            if level == 1 and not body.strip():
+            # Skip the file-level title heading regardless of body. By
+            # the documented authoring convention used by every intake
+            # doc under DEFAULT_SOURCE_ROOTS, one H1 = the document
+            # title; shippable items are at H2 / H3. An H1 with a
+            # non-empty preamble body otherwise self-classifies as a
+            # fresh roadmap_adoption / governance_change proposal via
+            # trigger tokens in the rationale text — false positive.
+            if level == 1:
                 continue
-            # Only H1/H2/H3 segments produce proposals; H4+ are sub-
+            # Only H2/H3 segments produce proposals; H4+ are sub-
             # sections and would dilute the queue.
             if level == 0 or level > 3:
                 # Preamble + deep sub-sections are surfaced as a single

--- a/tests/unit/test_proposal_queue.py
+++ b/tests/unit/test_proposal_queue.py
@@ -286,7 +286,8 @@ def test_strategic_roadmap_doc_yields_high_needs_human(
 ) -> None:
     src = isolated_pq / "roadmap_v4.md"
     src.write_text(
-        "# Adopt canonical roadmap v4\n\n"
+        "# Roadmap test fixture\n\n"
+        "## Adopt canonical roadmap v4\n\n"
         "Replace the existing roadmap with this new canonical roadmap.\n",
         encoding="utf-8",
     )
@@ -302,7 +303,8 @@ def test_release_candidate_with_protected_path_is_blocked(
 ) -> None:
     src = isolated_pq / "rc.md"
     src.write_text(
-        "# v3.15.15.20 — touch live gate\n\n"
+        "# Release candidate test fixture\n\n"
+        "## v3.15.15.20 — touch live gate\n\n"
         "Modify `automation/live_gate.py` to wire the broker.\n",
         encoding="utf-8",
     )
@@ -318,7 +320,8 @@ def test_release_candidate_with_protected_path_is_blocked(
 def test_tooling_intake_marked_secrets_is_high(isolated_pq: Path) -> None:
     src = isolated_pq / "tooling.md"
     src.write_text(
-        "# Add Datadog\n\nWire Datadog APM. Requires an API key.\n",
+        "# Tooling test fixture\n\n"
+        "## Add Datadog\n\nWire Datadog APM. Requires an API key.\n",
         encoding="utf-8",
     )
     snap = pq.collect_snapshot(mode="dry-run", source=str(src))
@@ -331,7 +334,8 @@ def test_tooling_intake_marked_secrets_is_high(isolated_pq: Path) -> None:
 def test_tooling_intake_marked_free_is_low(isolated_pq: Path) -> None:
     src = isolated_pq / "free_tool.md"
     src.write_text(
-        "# Add ruff\n\nMIT license, dev-only, no telemetry.\n",
+        "# Tooling test fixture\n\n"
+        "## Add ruff\n\nMIT license, dev-only, no telemetry.\n",
         encoding="utf-8",
     )
     snap = pq.collect_snapshot(mode="dry-run", source=str(src))
@@ -372,7 +376,8 @@ def test_malformed_input_does_not_crash(isolated_pq: Path) -> None:
 def test_proposal_id_is_deterministic(isolated_pq: Path) -> None:
     src = isolated_pq / "x.md"
     src.write_text(
-        "# v3.15.15.42 — repeatable\n\nThis is a release candidate.\n",
+        "# Repeatable test fixture\n\n"
+        "## v3.15.15.42 — repeatable\n\nThis is a release candidate.\n",
         encoding="utf-8",
     )
     snap1 = pq.collect_snapshot(mode="dry-run", source=str(src))
@@ -386,9 +391,10 @@ def test_counts_aggregate_correctly(isolated_pq: Path) -> None:
     src = isolated_pq / "mix.md"
     src.write_text(
         (
-            "# Adopt canonical roadmap v4\n\nNew roadmap.\n\n"
-            "# Add ruff\n\nMIT license, dev-only, no telemetry.\n\n"
-            "# CI hygiene\n\nGitHub Actions SHA pin sweep.\n"
+            "# Mixed test fixture\n\n"
+            "## Adopt canonical roadmap v4\n\nNew roadmap.\n\n"
+            "## Add ruff\n\nMIT license, dev-only, no telemetry.\n\n"
+            "## CI hygiene\n\nGitHub Actions SHA pin sweep.\n"
         ),
         encoding="utf-8",
     )
@@ -398,6 +404,112 @@ def test_counts_aggregate_correctly(isolated_pq: Path) -> None:
     # Adoption is HIGH; ruff (free) is LOW; CI hygiene is MEDIUM.
     assert counts["by_risk"].get("HIGH", 0) >= 1
     assert counts["by_risk"].get("LOW", 0) >= 1
+
+
+# ---------------------------------------------------------------------------
+# H1 ingestion bugfix — H1 is the document title, never a shippable item.
+# ---------------------------------------------------------------------------
+#
+# By the documented authoring convention used by every intake doc under
+# DEFAULT_SOURCE_ROOTS (docs/roadmap, docs/backlog, docs/spillovers),
+# H1 = document title; shippable items are at H2 / H3. An H1 with a
+# non-empty preamble body otherwise self-classifies as a fresh
+# roadmap_adoption / governance_change proposal via trigger tokens
+# in the rationale text — false positive.
+
+
+def test_h1_with_empty_body_is_skipped(isolated_pq: Path) -> None:
+    """Regression guard: H1 with empty body remains skipped (existing
+    behavior before the bugfix)."""
+    src = isolated_pq / "empty_body.md"
+    src.write_text("# Document title\n", encoding="utf-8")
+    snap = pq.collect_snapshot(mode="dry-run", source=str(src))
+    assert snap["proposals"] == []
+
+
+def test_h1_with_non_empty_body_is_skipped(isolated_pq: Path) -> None:
+    """The bugfix: H1 with a preamble body is ALSO skipped. Previously
+    this body would be classified through the type/risk/status pipeline
+    and emit a proposal record. Now: skipped."""
+    src = isolated_pq / "h1_with_preamble.md"
+    src.write_text(
+        "# Document title\n\n"
+        "This is a self-describing preamble. It explains the doc and may "
+        "mention canonical post-v3.15 phases. It is not a shippable item.\n",
+        encoding="utf-8",
+    )
+    snap = pq.collect_snapshot(mode="dry-run", source=str(src))
+    assert snap["proposals"] == [], snap["proposals"]
+
+
+def test_h2_after_h1_with_preamble_still_produces_proposal(
+    isolated_pq: Path,
+) -> None:
+    """H2 after a non-empty-body H1 is still ingested. The H1 body
+    being skipped must NOT mute H2/H3 ingestion."""
+    src = isolated_pq / "h1_then_h2.md"
+    src.write_text(
+        "# Document title\n\n"
+        "Doc-level preamble describing the file purpose.\n\n"
+        "## Add ruff\n\nMIT license, dev-only, no telemetry.\n",
+        encoding="utf-8",
+    )
+    snap = pq.collect_snapshot(mode="dry-run", source=str(src))
+    titles = [p["title"] for p in snap["proposals"]]
+    assert "Document title" not in titles
+    assert "Add ruff" in titles
+
+
+def test_h3_still_produces_proposal(isolated_pq: Path) -> None:
+    """H3 ingestion is unchanged — these are the canonical shippable
+    items in the v6.1 roadmap convention."""
+    src = isolated_pq / "h3_item.md"
+    src.write_text(
+        "# Document title\n\n"
+        "## Release group\n\n"
+        "### v3.15.15.50 — observability addition\n\n"
+        "Add a read-only digest. risk_class: LOW.\n",
+        encoding="utf-8",
+    )
+    snap = pq.collect_snapshot(mode="dry-run", source=str(src))
+    titles = [p["title"] for p in snap["proposals"]]
+    assert "Document title" not in titles
+    assert "v3.15.15.50 — observability addition" in titles
+
+
+def test_h1_skipped_even_when_body_contains_strategic_roadmap_token(
+    isolated_pq: Path,
+) -> None:
+    """Specifically pin the canonical case that motivated this fix:
+    an H1 whose body contains the substring "post-v3.15" (which is in
+    STRATEGIC_ROADMAP_TOKENS and otherwise triggers
+    roadmap_adoption / HIGH / needs_human classification) must be
+    skipped rather than emitted as a proposal."""
+    src = isolated_pq / "qre_roadmap_v6_1_like.md"
+    src.write_text(
+        "# Roadmap v6.1 — Quant Research Engine\n\n"
+        "> Canonical, structured roadmap for the post-v3.15.16.0 phase of the\n"
+        "> Quant Research Engine. This document is parsed by the ingester.\n",
+        encoding="utf-8",
+    )
+    snap = pq.collect_snapshot(mode="dry-run", source=str(src))
+    assert snap["proposals"] == [], snap["proposals"]
+
+
+def test_h1_skipped_even_when_body_contains_governance_token(
+    isolated_pq: Path,
+) -> None:
+    """Cousin pin: an H1 whose body contains a governance token (e.g.
+    "release gate") must also be skipped — the fix is unconditional."""
+    src = isolated_pq / "governance_doc.md"
+    src.write_text(
+        "# Agent governance retrospective\n\n"
+        "Build the safety perimeter required before agents are given any "
+        "autonomy. Ordering: secrets first, then CI, then release gate.\n",
+        encoding="utf-8",
+    )
+    snap = pq.collect_snapshot(mode="dry-run", source=str(src))
+    assert snap["proposals"] == [], snap["proposals"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This is a read-only proposal_queue ingestion false-positive fix. It prevents document titles with preamble text from becoming HIGH-risk proposals. It preserves H2/H3 proposal ingestion. It should clear H1-derived false positives such as `task_board:p_cfee9be1` after deploy/refresh.

## What

One-line behaviour change in [reporting/proposal_queue.py](reporting/proposal_queue.py) inside `_build_all_proposals`:

\`\`\`diff
-            # Skip the file-level title heading on a doc that consists
-            # only of a single H1 + index (very common in docs/).
-            if level == 1 and not body.strip():
-                continue
+            # Skip the file-level title heading regardless of body. By
+            # the documented authoring convention used by every intake
+            # doc under DEFAULT_SOURCE_ROOTS, one H1 = the document
+            # title; shippable items are at H2 / H3. An H1 with a
+            # non-empty preamble body otherwise self-classifies as a
+            # fresh roadmap_adoption / governance_change proposal via
+            # trigger tokens in the rationale text — false positive.
+            if level == 1:
+                continue
\`\`\`

## Why

The intake docs under \`docs/roadmap\`, \`docs/backlog\`, \`docs/spillovers\` use H1 strictly as the document title — never as a shippable item. This is the explicit authoring convention stated by the canonical roadmap doc itself (\`docs/roadmap/qre_roadmap_v6_1.md\` lines 11-15: *\"One H1 — the document title. One H2 per release group. One H3 per shippable item.\"*).

The H1 of \`qre_roadmap_v6_1.md\` has a 1218-char preamble body containing the literal substring \`post-v3.15\`, which is in \`STRATEGIC_ROADMAP_TOKENS\`. Result: the document's own self-describing rationale auto-classifies the file's title as a fresh \`roadmap_adoption / HIGH / needs_human\` proposal. Self-referential classifier false positive.

## Roadmap protocol

| field | value |
|---|---|
| \`item_id\` | v3.15.16.9d |
| \`item_type\` | \`reporting_read_only\` |
| \`risk_class\` | LOW |
| \`decision\` | \`allowed_read_only\` |
| \`implementation_allowed\` | true |
| \`requires_human\` | false |
| \`safe_to_execute\` | false (protocol invariant) |
| \`status\` | \`proposed\` |
| \`blocked_reason\` | null |

## Effects

- ✅ Clears H1-derived false positives (\`task_board:p_cfee9be1\` Roadmap v6.1 H1, \`task_board:p_b517e20e\` Agent Backlog H1) on the next post-deploy \`recurring_maintenance\` refresh of the human_needed → governance_bootstrap → approval_inbox chain
- ❌ Does NOT clear H2-preamble false positives (\`p_1f81cb23\`, \`p_61d8e363\`) — those need a separate fix or operator decision on superseded roadmap variants
- ⚠ Net deletes only — proposal_queue, task_board, human_needed, governance_bootstrap, approval_inbox digests will all see fewer rows on the next refresh. No new rows; no schema change; no API change.

## Constraints honored

| constraint | OK |
|---|---|
| read-only | ✓ |
| no archive / move of any docs | ✓ |
| no \`qre_roadmap_v6_1.md\` change | ✓ |
| no \`agent_backlog.md\` change | ✓ |
| no \`qre_prompt_guidelines_v2.md\` change | ✓ |
| no \`.claude\` change | ✓ |
| no \`dashboard/dashboard.py\` change | ✓ |
| no frozen contracts | ✓ |
| no live/paper/shadow/risk | ✓ |
| no execution engine | ✓ |
| Agent Control GET/read-only | ✓ |
| no test weakening | ✓ |
| branch → PR → CI → squash merge only | ✓ |

## Tests

Updated 5 existing tests that used H1 as the proposal heading (now use \`# Document title\` H1 + H2 with the classified body — fixture shape only).

Added 6 new H1-skip pinning tests:
1. \`test_h1_with_empty_body_is_skipped\` — regression guard
2. \`test_h1_with_non_empty_body_is_skipped\` — the bugfix
3. \`test_h2_after_h1_with_preamble_still_produces_proposal\` — H2 unchanged
4. \`test_h3_still_produces_proposal\` — H3 unchanged
5. \`test_h1_skipped_even_when_body_contains_strategic_roadmap_token\` — canonical case
6. \`test_h1_skipped_even_when_body_contains_governance_token\` — cousin case

## Validation gates (local, before PR)

| gate | result |
|---|---|
| \`tests/unit/test_proposal_queue.py\` | 45/45 (39 prior + 6 new) |
| cross-module sweep | 206/206 (proposal_queue + dashboard_api_proposal_queue + roadmap_priority + task_board + human_needed + approval_inbox + governance_bootstrap) |
| \`scripts/governance_lint.py\` | OK (16 agents, 4 workflows) |
| \`tests/smoke\` | 14/14 |

## Test plan

- [x] Local unit tests for proposal_queue (45/45)
- [x] Local cross-module sweep (206/206)
- [x] Local governance_lint OK
- [x] Local smoke OK
- [ ] CI green
- [ ] Squash merge
- [ ] Auto-deploy run completes; post-deploy recurring_maintenance refreshes human_needed/governance_bootstrap/approval_inbox
- [ ] (operator visual confirmation) Agent Control inbox shows fewer HIGH items; \`task_board:p_cfee9be1\` no longer the top blocker

🤖 Generated with [Claude Code](https://claude.com/claude-code)