### PR TITLE
fix(proposal_queue): skip archive subdirectories in _expand_source

### DIFF
--- a/reporting/proposal_queue.py
+++ b/reporting/proposal_queue.py
@@ -306,6 +306,14 @@ def _expand_source(source: Path) -> list[Path]:
     * file → [file] if .md/.markdown/.txt, else [].
     * dir  → recursive scan for .md/.markdown/.txt.
     * missing → [] (caller reports).
+
+    Files under any directory segment named ``archive`` (case-
+    insensitive) are skipped. Operators ``git mv`` historical
+    retrospectives into ``docs/<root>/archive/`` to opt them out of
+    fresh ingestion; this rule honors that intent. The filter
+    matches *path components* only — a top-level file like
+    ``archive_strategy.md`` is still ingested because its name is a
+    file, not a directory.
     """
     if not source.exists():
         return []
@@ -316,8 +324,21 @@ def _expand_source(source: Path) -> list[Path]:
     if source.is_dir():
         out: list[Path] = []
         for p in sorted(source.rglob("*")):
-            if p.is_file() and p.suffix.lower() in (".md", ".markdown", ".txt"):
-                out.append(p)
+            if not p.is_file():
+                continue
+            if p.suffix.lower() not in (".md", ".markdown", ".txt"):
+                continue
+            try:
+                rel_parts = p.relative_to(source).parts
+            except ValueError:
+                rel_parts = ()
+            # Only directory segments count — drop the filename
+            # before the membership check so a top-level file named
+            # ``archive_*.md`` is still ingested.
+            dir_parts = rel_parts[:-1]
+            if any(part.lower() == "archive" for part in dir_parts):
+                continue
+            out.append(p)
         return out
     return []
 

--- a/tests/unit/test_proposal_queue.py
+++ b/tests/unit/test_proposal_queue.py
@@ -513,6 +513,101 @@ def test_h1_skipped_even_when_body_contains_governance_token(
 
 
 # ---------------------------------------------------------------------------
+# Archive-subdirectory skip — _expand_source must honor the operator's
+# git-mv-into-archive convention.
+# ---------------------------------------------------------------------------
+#
+# Operators move historical retrospectives into a subdirectory named
+# ``archive`` (e.g. ``docs/roadmap/archive/<retrospective>.md``) to opt
+# them out of fresh ingestion. The recursive walker must skip files
+# under any directory segment named ``archive`` (case-insensitive). The
+# filter operates on path *components* only — a top-level filename
+# containing the word ``archive`` is NOT skipped.
+
+
+def test_archive_subdirectory_is_skipped(isolated_pq: Path) -> None:
+    """Direct ``archive/`` subdirectory: files inside are excluded; a
+    sibling file at the source root is still included."""
+    archive_dir = isolated_pq / "archive"
+    archive_dir.mkdir()
+    (archive_dir / "old_retrospective.md").write_text(
+        "# Historical title\n\n"
+        "## Goal\n\nLegacy goal that should not re-emit a proposal.\n",
+        encoding="utf-8",
+    )
+    (isolated_pq / "active.md").write_text(
+        "# Active doc\n\n## Add ruff\n\nMIT license, dev-only.\n",
+        encoding="utf-8",
+    )
+    files = pq._expand_source(isolated_pq)
+    rels = sorted(p.name for p in files)
+    assert rels == ["active.md"], rels
+
+
+def test_nested_archive_subdirectory_is_skipped(isolated_pq: Path) -> None:
+    """Nested ``sub/archive/...`` is also skipped — the rule matches
+    any directory segment in the relative path, not just the first."""
+    nested = isolated_pq / "sub" / "archive" / "deep"
+    nested.mkdir(parents=True)
+    (nested / "buried.md").write_text("# t\n", encoding="utf-8")
+    files = pq._expand_source(isolated_pq)
+    assert files == []
+
+
+@pytest.mark.parametrize("segment", ["Archive", "ARCHIVE", "ArCHive"])
+def test_archive_segment_match_is_case_insensitive(
+    isolated_pq: Path, segment: str
+) -> None:
+    """``Archive/``, ``ARCHIVE/``, ``ArCHive/`` segments are all
+    skipped. One fresh tmp_path per parameter — Windows filesystems
+    are case-insensitive, so each variant needs an isolated
+    workspace."""
+    d = isolated_pq / segment
+    d.mkdir()
+    (d / "x.md").write_text("# t\n", encoding="utf-8")
+    (isolated_pq / "active.md").write_text(
+        "# active\n\n## body\n", encoding="utf-8"
+    )
+    files = pq._expand_source(isolated_pq)
+    rels = sorted(p.name for p in files)
+    assert rels == ["active.md"], rels
+
+
+def test_archive_in_filename_outside_archive_dir_is_not_skipped(
+    isolated_pq: Path,
+) -> None:
+    """A *filename* containing the word ``archive`` at the root of the
+    source tree is NOT a directory segment and must still be ingested.
+    Skipping by filename would over-exclude legitimate operator docs
+    such as ``archive_strategy_sketch.md`` placed alongside live items."""
+    (isolated_pq / "archive_strategy_sketch.md").write_text(
+        "# Doc title\n\n## Some idea\n\nbody\n", encoding="utf-8"
+    )
+    (isolated_pq / "archived_quarterly_review.md").write_text(
+        "# Doc title\n\n## Notes\n\nbody\n", encoding="utf-8"
+    )
+    files = pq._expand_source(isolated_pq)
+    rels = sorted(p.name for p in files)
+    assert rels == [
+        "archive_strategy_sketch.md",
+        "archived_quarterly_review.md",
+    ], rels
+
+
+def test_normal_markdown_files_are_still_included(isolated_pq: Path) -> None:
+    """Regression guard: ordinary subdirectories without the ``archive``
+    name continue to be walked recursively. This pins that the
+    archive-skip rule is narrow."""
+    sub = isolated_pq / "subdir"
+    sub.mkdir()
+    (sub / "nested.md").write_text("# t\n\n## item\n\nbody\n", encoding="utf-8")
+    (isolated_pq / "top.md").write_text("# t\n\n## item\n\nbody\n", encoding="utf-8")
+    files = pq._expand_source(isolated_pq)
+    rels = sorted(str(p.relative_to(isolated_pq)).replace("\\", "/") for p in files)
+    assert rels == ["subdir/nested.md", "top.md"], rels
+
+
+# ---------------------------------------------------------------------------
 # Frozen contract integrity
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Read-only bugfix in [reporting/proposal_queue.py](reporting/proposal_queue.py) \`_expand_source\`. The recursive walker now skips files under any directory segment named \`archive\` (case-insensitive), so the operator's git-mv-into-archive convention is finally honored. After deploy this clears \`task_board:p_57880c67\` and the 5 sibling rows from the archived v3.15.15.12 retrospective.

## What

\`\`\`diff
 def _expand_source(source: Path) -> list[Path]:
     ...
     if source.is_dir():
         out: list[Path] = []
         for p in sorted(source.rglob(\"*\")):
-            if p.is_file() and p.suffix.lower() in (\".md\", \".markdown\", \".txt\"):
-                out.append(p)
+            if not p.is_file():
+                continue
+            if p.suffix.lower() not in (\".md\", \".markdown\", \".txt\"):
+                continue
+            try:
+                rel_parts = p.relative_to(source).parts
+            except ValueError:
+                rel_parts = ()
+            # Only directory segments count — drop the filename
+            # before the membership check so a top-level file named
+            # ``archive_*.md`` is still ingested.
+            dir_parts = rel_parts[:-1]
+            if any(part.lower() == \"archive\" for part in dir_parts):
+                continue
+            out.append(p)
         return out
\`\`\`

## Why

PR #105 moved \`v3.15.15.12-agent-governance.md\` into \`docs/roadmap/archive/\` to remove it from proposal_queue ingestion. The walker uses \`Path.rglob(\"*\")\` and recurses into the \`archive/\` subdirectory, so the file's headings were re-ingested under a *different* proposal_id (because \`_proposal_id\` hashes \`(source, title, line_idx)\` and the source path changed).

Concrete observed false positive on the live VPS:

| field | value |
|---|---|
| proposal_id | \`p_57880c67\` |
| source | \`docs/roadmap/archive/v3.15.15.12-agent-governance.md\` |
| heading | H2 line 7 — \`## Goal\` |
| classified | \`governance_change → HIGH → needs_human\` |
| visible as | \`task_board:p_57880c67\` (top blocker) |

## Roadmap protocol

| field | value |
|---|---|
| \`item_id\` | v3.15.16.9e |
| \`item_type\` | \`reporting_read_only\` |
| \`risk_class\` | LOW |
| \`decision\` | \`allowed_read_only\` |
| \`implementation_allowed\` | true |
| \`requires_human\` | false |
| \`safe_to_execute\` | false (protocol invariant) |
| \`status\` | \`proposed\` |
| \`blocked_reason\` | null |

## Effects

- ✅ Clears \`task_board:p_57880c67\` (Goal H2 from archived retrospective) and the 5 sibling rows (\`p_022cfc0f\`, \`p_a85dabbb\`, \`p_e4f2ed36\`, \`p_47fb0b2e\`, \`p_2a93d9b3\`) on the next post-deploy \`recurring_maintenance\` refresh
- ✅ Silently honors any future \`git mv … docs/<root>/archive/\` operator command
- ❌ Does NOT clear active-doc H2/H3 noise from \`qre_roadmap_v3_post_v3_15.md\`, \`qre_roadmap_v4.md\`, \`qre_prompt_guidelines_v2.md\`, \`qre_roadmap_v6_1.md\` — those need separate decisions
- ⚠ Net deletes only — no schema change, no API change

## Constraints honored

| constraint | OK |
|---|---|
| read-only | ✓ |
| no archive / move of any docs | ✓ |
| no \`qre_roadmap_v6_1.md\` change | ✓ |
| no \`agent_backlog.md\` change | ✓ |
| no \`qre_prompt_guidelines_v2.md\` change | ✓ |
| no \`.claude\` change | ✓ |
| no \`dashboard/dashboard.py\` change | ✓ |
| no frozen contracts | ✓ |
| no live/paper/shadow/risk | ✓ |
| no execution engine | ✓ |
| Agent Control GET/read-only | ✓ |
| H1-skip from PR #106 unchanged | ✓ |
| no test weakening | ✓ |
| branch → PR → CI → squash merge only | ✓ |

## Tests added

5 targeted unit tests:

1. \`test_archive_subdirectory_is_skipped\` — direct \`archive/\` excluded; sibling root-level file included
2. \`test_nested_archive_subdirectory_is_skipped\` — \`sub/archive/deep/\` excluded
3. \`test_archive_segment_match_is_case_insensitive\` (parametrized \`Archive/ARCHIVE/ArCHive\`) — case-insensitive segment match; one fresh tmp_path per parameter to handle Windows case-insensitive filesystems
4. \`test_archive_in_filename_outside_archive_dir_is_not_skipped\` — \`archive_strategy_sketch.md\` and \`archived_quarterly_review.md\` at root are INCLUDED (filename, not directory segment)
5. \`test_normal_markdown_files_are_still_included\` — regression guard for ordinary subdirectories

## Validation gates (local, before PR)

| gate | result |
|---|---|
| \`tests/unit/test_proposal_queue.py\` | 52/52 (47 prior + 5 new; parametrized case-test contributed +2 over a single test) |
| cross-module sweep | 213/213 (proposal_queue + dashboard_api_proposal_queue + roadmap_priority + task_board + human_needed + approval_inbox + governance_bootstrap) |
| \`scripts/governance_lint.py\` | OK |
| \`tests/smoke\` | 14/14 |

## Test plan

- [x] Local unit tests for proposal_queue (52/52)
- [x] Local cross-module sweep (213/213)
- [x] Local governance_lint OK
- [x] Local smoke OK
- [ ] CI green
- [ ] Squash merge
- [ ] Auto-deploy run completes; post-deploy \`recurring_maintenance\` refreshes proposal_queue → human_needed → governance_bootstrap → approval_inbox
- [ ] (operator visual confirmation) PWA Overview no longer shows \`task_board:p_57880c67\` as top blocker; aggregate may still be \`open\` due to active-doc H2/H3 noise

🤖 Generated with [Claude Code](https://claude.com/claude-code)