### PR TITLE
fix(recurring_maintenance): align proposal_queue refresh interval to 15min

### DIFF
--- a/reporting/recurring_maintenance.py
+++ b/reporting/recurring_maintenance.py
@@ -451,7 +451,18 @@ _JOB_REGISTRY: dict[str, dict[str, Any]] = {
         "timeout_seconds": DEFAULT_JOB_TIMEOUT_SECONDS,
     },
     JOB_REFRESH_PROPOSAL_QUEUE: {
-        "default_interval_seconds": 60 * 60,
+        # Aligned with JOB_REFRESH_APPROVAL_INBOX at 15 min. Previously
+        # 60 min; that left a 60-min race where two close-together
+        # deploys would let the second post-deploy ``--run-due-once``
+        # skip proposal_queue while every downstream (task_board /
+        # human_needed / governance_bootstrap / approval_inbox) was
+        # already due, refreshed, and re-projected the stale upstream
+        # source. The proposal_queue ingester is stdlib-only, parses
+        # ~6 markdown files, and runs in <100 ms — running it 4× more
+        # often is harmless. Invariant pinned by tests:
+        # proposal_queue.interval <= task_board.interval (upstream
+        # must never refresh slower than its downstream projection).
+        "default_interval_seconds": 15 * 60,
         "default_enabled": True,
         "executor": _exec_refresh_proposal_queue,
         "description": "Refresh proposal-queue dry-run artifact.",

--- a/tests/unit/test_recurring_maintenance.py
+++ b/tests/unit/test_recurring_maintenance.py
@@ -211,6 +211,73 @@ def test_governance_bootstrap_job_is_low_risk_no_gh_enabled_by_default() -> None
     assert spec["default_interval_seconds"] == 30 * 60
 
 
+# ---------------------------------------------------------------------------
+# v3.15.16.9f — proposal_queue interval alignment
+# ---------------------------------------------------------------------------
+#
+# The proposal_queue refresh is the upstream of the entire downstream
+# projection chain (task_board → human_needed → governance_bootstrap
+# and approval_inbox). If proposal_queue throttles slower than its
+# downstreams, two close-together deploys will let the second
+# post-deploy ``--run-due-once`` skip proposal_queue while every
+# downstream refreshes and re-projects the stale upstream — observed
+# as ``task_board:p_57880c67`` surviving PR #107's archive-skip code
+# fix because the VPS had not yet re-run the ingester.
+
+
+def test_proposal_queue_refresh_interval_is_15_minutes() -> None:
+    """Pinned to exactly 15 minutes after the v3.15.16.9f alignment.
+    Aligned with JOB_REFRESH_APPROVAL_INBOX. Previous value was 60
+    minutes; the change narrows the close-together-deploys race
+    window from 60 min to 15 min."""
+    spec = rm._JOB_REGISTRY[rm.JOB_REFRESH_PROPOSAL_QUEUE]
+    assert spec["default_interval_seconds"] == 15 * 60
+
+
+def test_proposal_queue_interval_does_not_exceed_downstream_intervals() -> None:
+    """Invariant: the proposal_queue refresh interval must be <= every
+    downstream that consumes its artifact. Otherwise the downstream
+    will refresh and re-project the stale upstream, defeating any
+    code change in the proposal_queue ingester until proposal_queue
+    catches up.
+
+    Downstream consumers of logs/proposal_queue/latest.json:
+      * roadmap_priority — reads proposal_queue
+      * task_board — reads proposal_queue
+      * approval_inbox — reads proposal_queue (and human_needed)
+      * human_needed — reads task_board (transitively reads
+        proposal_queue)
+      * governance_bootstrap — reads human_needed (transitively
+        reads proposal_queue)
+    """
+    upstream = rm._JOB_REGISTRY[rm.JOB_REFRESH_PROPOSAL_QUEUE][
+        "default_interval_seconds"
+    ]
+    downstream_jobs = (
+        rm.JOB_REFRESH_ROADMAP_PRIORITY,
+        rm.JOB_REFRESH_TASK_BOARD,
+        rm.JOB_REFRESH_APPROVAL_INBOX,
+        rm.JOB_REFRESH_HUMAN_NEEDED,
+        rm.JOB_REFRESH_GOVERNANCE_BOOTSTRAP,
+    )
+    for job in downstream_jobs:
+        downstream_interval = rm._JOB_REGISTRY[job]["default_interval_seconds"]
+        assert upstream <= downstream_interval, (
+            f"proposal_queue interval ({upstream}s) must not exceed "
+            f"{job} interval ({downstream_interval}s) — otherwise the "
+            f"downstream re-projects stale upstream data."
+        )
+
+
+def test_proposal_queue_job_is_low_risk_no_gh_enabled_by_default() -> None:
+    """Regression guard: aligning the interval must not change any
+    other registry attribute of JOB_REFRESH_PROPOSAL_QUEUE."""
+    spec = rm._JOB_REGISTRY[rm.JOB_REFRESH_PROPOSAL_QUEUE]
+    assert spec["risk_class"] == rm.RISK_LOW
+    assert spec["needs_gh"] is False
+    assert spec["default_enabled"] is True
+
+
 def test_dependabot_job_disabled_by_default() -> None:
     spec = rm._JOB_REGISTRY[rm.JOB_DEPENDABOT_EXECUTE_SAFE]
     assert spec["default_enabled"] is False


### PR DESCRIPTION
## Summary

Lower \`JOB_REFRESH_PROPOSAL_QUEUE.default_interval_seconds\` from 60 minutes to 15 minutes, aligning it with the cheapest downstream consumer (\`JOB_REFRESH_APPROVAL_INBOX\`). Narrows the close-together-deploys race window from 60 min to 15 min and enforces an invariant that the upstream of the projection chain must never refresh slower than its downstreams.

PR #107's archive-skip ingester code is correct. The reason \`task_board:p_57880c67\` survived the PR #107 deploy was that the live VPS \`logs/proposal_queue/latest.json\` was stale — the proposal_queue refresh got throttled out by a 60-min window after PR #106's deploy at ~19:24Z while PR #107's post-deploy hook fired \`--run-due-once\` at ~19:58Z (26 min inside the throttle).

## What

\`\`\`diff
     JOB_REFRESH_PROPOSAL_QUEUE: {
-        \"default_interval_seconds\": 60 * 60,
+        # Aligned with JOB_REFRESH_APPROVAL_INBOX at 15 min. ...
+        \"default_interval_seconds\": 15 * 60,
         ...
\`\`\`

## Throttle inventory after this PR

| job | interval | role |
|---|---|---|
| **JOB_REFRESH_PROPOSAL_QUEUE** | **15 min** ← aligned | upstream of all downstream projections |
| JOB_REFRESH_APPROVAL_INBOX | 15 min | downstream — equal |
| JOB_REFRESH_ROADMAP_PRIORITY | 30 min | downstream |
| JOB_REFRESH_TASK_BOARD | 30 min | downstream |
| JOB_REFRESH_HUMAN_NEEDED | 30 min | downstream |
| JOB_REFRESH_GOVERNANCE_BOOTSTRAP | 30 min | downstream |

Invariant pinned by test: \`proposal_queue interval ≤ every downstream interval\`.

## Roadmap protocol

| field | value |
|---|---|
| \`item_id\` | v3.15.16.9f |
| \`item_type\` | \`reporting_read_only\` |
| \`risk_class\` | LOW |
| \`decision\` | \`allowed_read_only\` |
| \`implementation_allowed\` | true |
| \`requires_human\` | false |
| \`safe_to_execute\` | false (protocol invariant) |
| \`status\` | \`proposed\` |
| \`blocked_reason\` | null |

## Effects

- ✅ Future close-together deploys are 4× less likely to re-project stale proposal_queue artifacts (race window: 60 min → 15 min)
- ✅ Once proposal_queue refresh actually runs after this PR's deploy, \`task_board:p_57880c67\` clears (PR #107 already skips archive directories correctly; the pending refresh just hasn't happened on the VPS yet)
- ❌ Does NOT eliminate the race entirely — two deploys within 15 min still race. A complete fix needs a deploy-script direct-call (deployment-implementation-agent territory, out of scope here)
- ⚠ Behaviour change: proposal_queue refresh frequency. Cost: ~50 ms per run, stdlib-only, 6 markdown files. Negligible.

## Constraints honored

| constraint | OK |
|---|---|
| read-only | ✓ |
| no deploy script change | ✓ |
| no proposal_queue ingester change (PR #107 archive-skip intact) | ✓ |
| no \`.claude\` change | ✓ |
| no \`dashboard/dashboard.py\` change | ✓ |
| no frozen contracts | ✓ |
| no live/paper/shadow/risk | ✓ |
| no execution engine | ✓ |
| Agent Control GET/read-only | ✓ |
| no test weakening | ✓ |
| branch → PR → CI → squash merge only | ✓ |

## Tests added (3 new)

1. \`test_proposal_queue_refresh_interval_is_15_minutes\` — pin the exact 15-min value
2. \`test_proposal_queue_interval_does_not_exceed_downstream_intervals\` — invariant: upstream ≤ every downstream (\`roadmap_priority\`, \`task_board\`, \`approval_inbox\`, \`human_needed\`, \`governance_bootstrap\`)
3. \`test_proposal_queue_job_is_low_risk_no_gh_enabled_by_default\` — regression guard for other registry attributes

## Validation gates (local)

| gate | result |
|---|---|
| \`tests/unit/test_recurring_maintenance.py\` | 40/40 (37 prior + 3 new) |
| \`scripts/governance_lint.py\` | OK |
| \`tests/smoke\` | 14/14 |

## Test plan

- [x] Local unit tests for recurring_maintenance (40/40)
- [x] Local governance_lint OK
- [x] Local smoke OK
- [ ] CI green
- [ ] Squash merge
- [ ] Auto-deploy run completes; post-deploy \`recurring_maintenance --run-due-once\` re-runs proposal_queue (it's been >15 min since the previous run; the throttle has long since expired by now). The archive-skip code from PR #107 finally executes against the VPS source tree.
- [ ] (operator visual confirmation) PWA Overview no longer shows \`task_board:p_57880c67\`. Top blocker rotates to a different entry from active live docs (out of scope for this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)