### PR TITLE
feat(v3.15.16): PR-C — advisory suppression + priority + rank

### DIFF
--- a/reporting/intelligent_routing.py
+++ b/reporting/intelligent_routing.py
@@ -174,6 +174,37 @@ NEAR_DUPLICATE_FINGERPRINT_PREFIX_LEN: Final[int] = 8
 #: Output prefix length for the group hash. 12 hex chars = 48 bits.
 NEAR_DUPLICATE_GROUP_HASH_LEN: Final[int] = 12
 
+# ---------------------------------------------------------------------------
+# Advisory priority weights (PR-C)
+# ---------------------------------------------------------------------------
+
+#: Information-gain bucket → priority weight. Named constants per
+#: CLAUDE.md. Higher is better.
+INFO_GAIN_BUCKET_WEIGHTS: Final[dict[str, int]] = {
+    BUCKET_NONE: 0,
+    BUCKET_LOW: 1,
+    BUCKET_MEDIUM: 2,
+    BUCKET_HIGH: 3,
+}
+
+#: Orthogonality bucket → priority weight. Higher is better.
+ORTHOGONALITY_BUCKET_WEIGHTS: Final[dict[str, int]] = {
+    ORTHOGONALITY_SATURATED: 0,
+    ORTHOGONALITY_ADJACENT: 1,
+    ORTHOGONALITY_NOVEL: 2,
+}
+
+#: IG dominates orthogonality. Multiplier is intentionally larger than
+#: ``max(ORTHOGONALITY_BUCKET_WEIGHTS.values())`` so an IG step always
+#: outranks any orthogonality difference.
+INFO_GAIN_PRIORITY_MULTIPLIER: Final[int] = 10
+
+#: A campaign with ``advisory_suppression_reason != None`` receives this
+#: priority score so it sinks below every non-suppressed campaign in
+#: ``advisory_rank``. The artifact's ``queue_ordering_effect`` is still
+#: ``none`` — this is a *recommendation only*.
+SUPPRESSED_PRIORITY_SCORE: Final[int] = -1
+
 
 # ---------------------------------------------------------------------------
 # Pure dataclasses
@@ -417,6 +448,56 @@ def compute_orthogonality_bucket(
     if count <= ORTHOGONALITY_ADJACENT_MAX_PRIOR:
         return ORTHOGONALITY_ADJACENT
     return ORTHOGONALITY_SATURATED
+
+
+def derive_advisory_suppression_reason(
+    *,
+    dead_zone_status: str,
+    near_duplicate_group: str | None,
+    is_first_in_group: bool,
+) -> str | None:
+    """Pure derivation of the advisory suppression reason.
+
+    Resolution order:
+
+    1. ``dead_zone`` if and only if ``dead_zone_status == DEAD_ZONE_DEAD``.
+       Statuses in ``NEVER_SUPPRESS_DEAD_ZONE_STATUSES`` *never*
+       trigger suppression.
+    2. ``near_duplicate`` if and only if the campaign is part of a
+       near-duplicate group AND is **not** the first member of that
+       group (the first member always keeps ``None``).
+    3. ``None`` otherwise.
+
+    The framing remains advisory: the artifact still carries
+    ``routing_effect = "advisory_only"``. Downstream queue ordering
+    is not changed.
+    """
+    if dead_zone_status == DEAD_ZONE_DEAD:
+        return SUPPRESSION_DEAD_ZONE
+    if near_duplicate_group is not None and not is_first_in_group:
+        return SUPPRESSION_NEAR_DUPLICATE
+    return None
+
+
+def compute_advisory_priority_score(
+    *,
+    advisory_suppression_reason: str | None,
+    info_gain_bucket: str,
+    orthogonality_bucket: str,
+) -> int:
+    """Pure derivation of the advisory priority score.
+
+    Suppressed campaigns receive ``SUPPRESSED_PRIORITY_SCORE`` so they
+    always rank below non-suppressed campaigns. Non-suppressed
+    campaigns receive ``ig_weight * INFO_GAIN_PRIORITY_MULTIPLIER +
+    ortho_weight``. Higher is better. Unknown bucket names map to
+    weight 0 (defensive fallback).
+    """
+    if advisory_suppression_reason is not None:
+        return SUPPRESSED_PRIORITY_SCORE
+    ig_weight = INFO_GAIN_BUCKET_WEIGHTS.get(info_gain_bucket, 0)
+    ortho_weight = ORTHOGONALITY_BUCKET_WEIGHTS.get(orthogonality_bucket, 0)
+    return ig_weight * INFO_GAIN_PRIORITY_MULTIPLIER + ortho_weight
 
 
 def compute_near_duplicate_group(
@@ -702,9 +783,14 @@ def build_report(
     ``datetime.now(tz=UTC)``).
 
     PR-B: populates behavior_coordinates, info_gain_score/bucket,
-    dead_zone_status, near_duplicate_group, orthogonality_bucket. Sets
-    ``advisory_suppression_reason = None``, ``advisory_priority_score
-    = 0``, ``advisory_rank = 0``. PR-C derives the advisory ranking.
+    dead_zone_status, near_duplicate_group, orthogonality_bucket.
+
+    PR-C: derives ``advisory_suppression_reason`` (dead-zone or
+    near-duplicate annotation only — queue is **not** mutated),
+    ``advisory_priority_score`` (deterministic int) and
+    ``advisory_rank`` (1-indexed total ordering). The artifact still
+    carries ``routing_effect = "advisory_only"`` and
+    ``queue_ordering_effect = "none"``.
     """
     if callable(now_utc):
         as_of = now_utc()
@@ -744,7 +830,9 @@ def build_report(
     for _, coords, _, _, _ in coord_records:
         coord_counts[coords.as_tuple()] += 1
 
-    decisions: list[RoutingDecision] = []
+    # First pass: build provisional per-campaign rows without
+    # advisory_* fields.
+    provisional_rows: list[dict[str, Any]] = []
     metadata_gaps = 0
     for entry, coords, preset_name, fp, has_full in coord_records:
         cid = str(entry.get("campaign_id"))
@@ -754,37 +842,97 @@ def build_report(
         zone_status = classify_dead_zone_status(coords, dead_zone_index)
         if not has_full:
             metadata_gaps += 1
-        # Prior count = total occurrences minus the current campaign.
         prior_total = max(0, coord_counts[coords.as_tuple()] - 1)
         ortho = compute_orthogonality_bucket(
             coords, {coords.as_tuple(): prior_total},
         )
         group = compute_near_duplicate_group(coords, fp)
-        decisions.append(
+        provisional_rows.append({
+            "campaign_id": cid,
+            "preset_name": preset_name,
+            "coords": coords,
+            "score": round(score, 4),
+            "bucket": bucket,
+            "zone_status": zone_status,
+            "group": group,
+            "ortho": ortho,
+            "tie_break_key": f"{spawned_at}|{cid}",
+        })
+
+    # Second pass: identify the first member of each near-duplicate
+    # group by tie_break_key. Within a group, the first-by-
+    # (spawned_at_utc, campaign_id) row keeps suppression=None; the
+    # rest get advisory_suppression_reason="near_duplicate" — UNLESS
+    # the dead-zone status already set the reason to "dead_zone".
+    group_members: dict[str, list[str]] = {}
+    for row in provisional_rows:
+        gid = row["group"]
+        if gid is None:
+            continue
+        group_members.setdefault(gid, []).append(row["tie_break_key"])
+    first_member_in_group: dict[str, str] = {
+        gid: min(keys) for gid, keys in group_members.items()
+    }
+
+    # Third pass: derive advisory_suppression_reason +
+    # advisory_priority_score per row.
+    enriched: list[RoutingDecision] = []
+    for row in provisional_rows:
+        gid = row["group"]
+        if gid is None:
+            is_first = True
+        else:
+            is_first = first_member_in_group[gid] == row["tie_break_key"]
+        reason = derive_advisory_suppression_reason(
+            dead_zone_status=row["zone_status"],
+            near_duplicate_group=gid,
+            is_first_in_group=is_first,
+        )
+        priority = compute_advisory_priority_score(
+            advisory_suppression_reason=reason,
+            info_gain_bucket=row["bucket"],
+            orthogonality_bucket=row["ortho"],
+        )
+        enriched.append(
             RoutingDecision(
-                campaign_id=cid,
-                preset_name=preset_name,
-                behavior_coordinates=coords,
-                info_gain_score=round(score, 4),
-                info_gain_bucket=bucket,
-                dead_zone_status=zone_status,
-                near_duplicate_group=group,
-                orthogonality_bucket=ortho,
-                advisory_suppression_reason=None,
-                advisory_priority_score=0,
-                advisory_rank=0,
-                tie_break_key=f"{spawned_at}|{cid}",
+                campaign_id=row["campaign_id"],
+                preset_name=row["preset_name"],
+                behavior_coordinates=row["coords"],
+                info_gain_score=row["score"],
+                info_gain_bucket=row["bucket"],
+                dead_zone_status=row["zone_status"],
+                near_duplicate_group=gid,
+                orthogonality_bucket=row["ortho"],
+                advisory_suppression_reason=reason,
+                advisory_priority_score=priority,
+                advisory_rank=0,  # filled in below
+                tie_break_key=row["tie_break_key"],
             )
         )
 
-    # Stable ordering by (spawned_at_utc, campaign_id) so that two
-    # invocations with identical inputs produce byte-identical output.
-    decisions.sort(key=lambda d: (d.tie_break_key,))
+    # Fourth pass: total ordering by (-advisory_priority_score,
+    # tie_break_key). Higher priority first; ties broken by
+    # (spawned_at_utc, campaign_id) ascending. Assign 1-indexed
+    # advisory_rank.
+    enriched.sort(
+        key=lambda d: (-d.advisory_priority_score, d.tie_break_key)
+    )
+    decisions: list[RoutingDecision] = []
+    for idx, d in enumerate(enriched, start=1):
+        decisions.append(
+            dataclasses.replace(d, advisory_rank=idx)
+        )
 
     summary = RoutingReportSummary(
         total=len(decisions),
-        advisory_suppressed_dead_zone=0,
-        advisory_suppressed_near_duplicate=0,
+        advisory_suppressed_dead_zone=sum(
+            1 for d in decisions
+            if d.advisory_suppression_reason == SUPPRESSION_DEAD_ZONE
+        ),
+        advisory_suppressed_near_duplicate=sum(
+            1 for d in decisions
+            if d.advisory_suppression_reason == SUPPRESSION_NEAR_DUPLICATE
+        ),
         high_info_gain=sum(
             1 for d in decisions if d.info_gain_bucket == BUCKET_HIGH
         ),
@@ -940,6 +1088,8 @@ __all__ = [
     "IG_BUCKET_HIGH_FLOOR",
     "IG_BUCKET_MEDIUM_FLOOR",
     "INFO_GAIN_BUCKETS",
+    "INFO_GAIN_BUCKET_WEIGHTS",
+    "INFO_GAIN_PRIORITY_MULTIPLIER",
     "MODULE_VERSION",
     "NEAR_DUPLICATE_FINGERPRINT_PREFIX_LEN",
     "NEAR_DUPLICATE_GROUP_HASH_LEN",
@@ -948,6 +1098,7 @@ __all__ = [
     "ORTHOGONALITY_ADJACENT_MAX_PRIOR",
     "ORTHOGONALITY_BUCKETS",
     "ORTHOGONALITY_NOVEL",
+    "ORTHOGONALITY_BUCKET_WEIGHTS",
     "ORTHOGONALITY_NOVEL_MAX_PRIOR",
     "ORTHOGONALITY_SATURATED",
     "QUEUE_ORDERING_EFFECT_NONE",
@@ -957,14 +1108,17 @@ __all__ = [
     "RoutingReport",
     "RoutingReportSummary",
     "SCHEMA_VERSION",
+    "SUPPRESSED_PRIORITY_SCORE",
     "SUPPRESSION_DEAD_ZONE",
     "SUPPRESSION_NEAR_DUPLICATE",
     "UNKNOWN_COORDINATE",
     "bucket_info_gain",
     "build_report",
     "classify_dead_zone_status",
+    "compute_advisory_priority_score",
     "compute_near_duplicate_group",
     "compute_orthogonality_bucket",
+    "derive_advisory_suppression_reason",
     "derive_behavior_coordinates",
     "main",
 ]

--- a/tests/unit/test_intelligent_routing_advisory_priority.py
+++ b/tests/unit/test_intelligent_routing_advisory_priority.py
@@ -1,0 +1,282 @@
+"""PR-C — advisory priority + rank tests for reporting.intelligent_routing.
+
+Pins:
+
+* ``compute_advisory_priority_score`` is total-ordering: high IG novel
+  > medium IG novel > medium IG saturated > low > suppressed.
+* Suppressed campaigns receive ``SUPPRESSED_PRIORITY_SCORE`` (-1)
+  unconditionally.
+* ``advisory_rank`` is 1-indexed and assigned in
+  ``(-priority, tie_break_key)`` order — stable tie-breaks by
+  ``(spawned_at_utc, campaign_id)``.
+* High-IG novel beats low-IG saturated.
+* The artifact still carries ``queue_ordering_effect = "none"`` —
+  ranking is annotation only.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+from pathlib import Path
+
+import pytest
+
+from reporting import intelligent_routing as ir
+
+
+# ---------------------------------------------------------------------------
+# compute_advisory_priority_score — pure helper
+# ---------------------------------------------------------------------------
+
+
+def test_priority_score_for_suppressed_is_minus_one() -> None:
+    assert ir.compute_advisory_priority_score(
+        advisory_suppression_reason="dead_zone",
+        info_gain_bucket="high",
+        orthogonality_bucket="novel",
+    ) == ir.SUPPRESSED_PRIORITY_SCORE
+    assert ir.compute_advisory_priority_score(
+        advisory_suppression_reason="near_duplicate",
+        info_gain_bucket="high",
+        orthogonality_bucket="novel",
+    ) == ir.SUPPRESSED_PRIORITY_SCORE
+    assert ir.SUPPRESSED_PRIORITY_SCORE == -1
+
+
+def test_priority_score_high_ig_novel_is_max() -> None:
+    high_novel = ir.compute_advisory_priority_score(
+        advisory_suppression_reason=None,
+        info_gain_bucket="high",
+        orthogonality_bucket="novel",
+    )
+    none_saturated = ir.compute_advisory_priority_score(
+        advisory_suppression_reason=None,
+        info_gain_bucket="none",
+        orthogonality_bucket="saturated",
+    )
+    assert high_novel > none_saturated
+
+
+def test_priority_score_ig_dominates_orthogonality() -> None:
+    """An IG-bucket step always outranks any orthogonality difference."""
+    medium_novel = ir.compute_advisory_priority_score(
+        advisory_suppression_reason=None,
+        info_gain_bucket="medium",
+        orthogonality_bucket="novel",
+    )
+    high_saturated = ir.compute_advisory_priority_score(
+        advisory_suppression_reason=None,
+        info_gain_bucket="high",
+        orthogonality_bucket="saturated",
+    )
+    # high beats medium even with worst orthogonality vs best.
+    assert high_saturated > medium_novel
+
+
+def test_priority_score_unknown_buckets_default_to_zero_weight() -> None:
+    out = ir.compute_advisory_priority_score(
+        advisory_suppression_reason=None,
+        info_gain_bucket="bogus_bucket",
+        orthogonality_bucket="another_bogus",
+    )
+    assert out == 0
+
+
+@pytest.mark.parametrize("ig_bucket,ortho_bucket,expected", [
+    ("none", "saturated", 0),
+    ("none", "adjacent", 1),
+    ("none", "novel", 2),
+    ("low", "saturated", 10),
+    ("low", "novel", 12),
+    ("medium", "saturated", 20),
+    ("medium", "novel", 22),
+    ("high", "saturated", 30),
+    ("high", "adjacent", 31),
+    ("high", "novel", 32),
+])
+def test_priority_score_explicit_bucket_grid(
+    ig_bucket: str, ortho_bucket: str, expected: int,
+) -> None:
+    out = ir.compute_advisory_priority_score(
+        advisory_suppression_reason=None,
+        info_gain_bucket=ig_bucket,
+        orthogonality_bucket=ortho_bucket,
+    )
+    assert out == expected
+
+
+# ---------------------------------------------------------------------------
+# advisory_rank — total ordering + stable tie-breaks via build_report
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fixed_now_utc() -> _dt.datetime:
+    return _dt.datetime(2026, 5, 6, 12, 0, 0, tzinfo=_dt.timezone.utc)
+
+
+def _campaign(cid: str, spawned: str, family: str, asset: str, tf: str, fp: str) -> dict:
+    return {
+        "campaign_id": cid,
+        "preset_name": "preset_x",
+        "strategy_family": family,
+        "asset_class": asset,
+        "extra": {"timeframe": tf},
+        "input_artifact_fingerprint": fp,
+        "spawned_at_utc": spawned,
+    }
+
+
+def _build(tmp_path: Path, queue, registry, dead_zones, ig, now) -> ir.RoutingReport:
+    paths = {
+        "queue": tmp_path / "queue.json",
+        "registry": tmp_path / "registry.json",
+        "dead_zones": tmp_path / "dz.json",
+        "information_gain": tmp_path / "ig.json",
+    }
+    paths["queue"].write_text(json.dumps(queue), encoding="utf-8")
+    paths["registry"].write_text(json.dumps(registry), encoding="utf-8")
+    paths["dead_zones"].write_text(json.dumps(dead_zones), encoding="utf-8")
+    paths["information_gain"].write_text(json.dumps(ig), encoding="utf-8")
+    return ir.build_report(
+        now_utc=now,
+        queue_path=paths["queue"],
+        registry_path=paths["registry"],
+        dead_zones_path=paths["dead_zones"],
+        information_gain_path=paths["information_gain"],
+    )
+
+
+def test_high_ig_novel_outranks_low_ig_saturated(
+    tmp_path: Path, fixed_now_utc: _dt.datetime,
+) -> None:
+    queue = {"queue": [
+        {"campaign_id": "low_sat", "spawned_at_utc": "2026-05-06T10:00:00+00:00"},
+        {"campaign_id": "high_novel", "spawned_at_utc": "2026-05-06T10:01:00+00:00"},
+        # Three more saturated campaigns share coords with low_sat
+        # (4 total) → each sees ≥3 priors → saturated.
+        {"campaign_id": "extra1", "spawned_at_utc": "2026-05-06T10:02:00+00:00"},
+        {"campaign_id": "extra2", "spawned_at_utc": "2026-05-06T10:03:00+00:00"},
+        {"campaign_id": "extra3", "spawned_at_utc": "2026-05-06T10:04:00+00:00"},
+    ]}
+    registry = {"campaigns": [
+        _campaign("low_sat", "2026-05-06T10:00:00+00:00", "f1", "a1", "t1", "fp_a"),
+        _campaign("extra1", "2026-05-06T10:02:00+00:00", "f1", "a1", "t1", "fp_b"),
+        _campaign("extra2", "2026-05-06T10:03:00+00:00", "f1", "a1", "t1", "fp_c"),
+        _campaign("extra3", "2026-05-06T10:04:00+00:00", "f1", "a1", "t1", "fp_d"),
+        _campaign("high_novel", "2026-05-06T10:01:00+00:00", "f2", "a2", "t2", "fp_z"),
+    ]}
+    # IG payload only carries one campaign; give "high_novel" a high score.
+    ig = {"col_campaign_id": "high_novel", "information_gain": {"score": 0.9, "bucket": "high"}}
+    report = _build(tmp_path, queue, registry, {"zones": []}, ig, fixed_now_utc)
+    by_id = {d.campaign_id: d for d in report.decisions}
+    assert by_id["high_novel"].orthogonality_bucket == "novel"
+    assert by_id["high_novel"].info_gain_bucket == "high"
+    # low_sat shares coords with extras → saturated.
+    assert by_id["low_sat"].orthogonality_bucket == "saturated"
+    assert by_id["high_novel"].advisory_priority_score > by_id["low_sat"].advisory_priority_score
+    assert by_id["high_novel"].advisory_rank < by_id["low_sat"].advisory_rank
+
+
+def test_advisory_rank_is_total_ordering_one_indexed(
+    tmp_path: Path, fixed_now_utc: _dt.datetime,
+) -> None:
+    queue = {"queue": [
+        {"campaign_id": "c1", "spawned_at_utc": "2026-05-06T10:00:00+00:00"},
+        {"campaign_id": "c2", "spawned_at_utc": "2026-05-06T10:01:00+00:00"},
+        {"campaign_id": "c3", "spawned_at_utc": "2026-05-06T10:02:00+00:00"},
+    ]}
+    registry = {"campaigns": [
+        _campaign("c1", "2026-05-06T10:00:00+00:00", "f1", "a1", "t1", "fp1"),
+        _campaign("c2", "2026-05-06T10:01:00+00:00", "f2", "a2", "t2", "fp2"),
+        _campaign("c3", "2026-05-06T10:02:00+00:00", "f3", "a3", "t3", "fp3"),
+    ]}
+    report = _build(tmp_path, queue, registry, {"zones": []}, {}, fixed_now_utc)
+    ranks = sorted(d.advisory_rank for d in report.decisions)
+    assert ranks == [1, 2, 3]
+    # All ranks distinct.
+    assert len({d.advisory_rank for d in report.decisions}) == 3
+
+
+def test_suppressed_campaigns_rank_below_non_suppressed(
+    tmp_path: Path, fixed_now_utc: _dt.datetime,
+) -> None:
+    queue = {"queue": [
+        {"campaign_id": "deadzone", "spawned_at_utc": "2026-05-06T10:00:00+00:00"},
+        {"campaign_id": "alive", "spawned_at_utc": "2026-05-06T10:01:00+00:00"},
+    ]}
+    registry = {"campaigns": [
+        _campaign("deadzone", "2026-05-06T10:00:00+00:00", "ema_crossover", "crypto", "4h", "fp1"),
+        _campaign("alive", "2026-05-06T10:01:00+00:00", "rsi_extreme", "equities", "1d", "fp2"),
+    ]}
+    dead_zones = {"zones": [
+        {"asset": "crypto", "timeframe": "4h", "strategy_family": "ema_crossover", "zone_status": "dead"},
+        {"asset": "equities", "timeframe": "1d", "strategy_family": "rsi_extreme", "zone_status": "alive"},
+    ]}
+    report = _build(tmp_path, queue, registry, dead_zones, {}, fixed_now_utc)
+    by_id = {d.campaign_id: d for d in report.decisions}
+    # alive ranks higher (lower number) than deadzone.
+    assert by_id["alive"].advisory_rank < by_id["deadzone"].advisory_rank
+    assert by_id["deadzone"].advisory_priority_score == ir.SUPPRESSED_PRIORITY_SCORE
+
+
+def test_tie_break_is_stable_by_spawned_at_then_campaign_id(
+    tmp_path: Path, fixed_now_utc: _dt.datetime,
+) -> None:
+    """Two campaigns with identical priority scores break ties on
+    ``(spawned_at_utc, campaign_id)``."""
+    # Two distinct coords → both novel + IG bucket none → identical scores.
+    queue = {"queue": [
+        # b before a alphabetically but later in time → time wins.
+        {"campaign_id": "b1", "spawned_at_utc": "2026-05-06T10:01:00+00:00"},
+        {"campaign_id": "a1", "spawned_at_utc": "2026-05-06T10:00:00+00:00"},
+    ]}
+    registry = {"campaigns": [
+        _campaign("a1", "2026-05-06T10:00:00+00:00", "f1", "a1", "t1", "fpA"),
+        _campaign("b1", "2026-05-06T10:01:00+00:00", "f2", "a2", "t2", "fpB"),
+    ]}
+    report = _build(tmp_path, queue, registry, {"zones": []}, {}, fixed_now_utc)
+    by_id = {d.campaign_id: d for d in report.decisions}
+    # Same score (both novel, none IG).
+    assert by_id["a1"].advisory_priority_score == by_id["b1"].advisory_priority_score
+    # Earlier spawned_at_utc gets rank 1.
+    assert by_id["a1"].advisory_rank == 1
+    assert by_id["b1"].advisory_rank == 2
+
+
+def test_decisions_list_sorted_by_advisory_rank_in_artifact(
+    tmp_path: Path, fixed_now_utc: _dt.datetime,
+) -> None:
+    queue = {"queue": [
+        {"campaign_id": "c1", "spawned_at_utc": "2026-05-06T10:00:00+00:00"},
+        {"campaign_id": "c2", "spawned_at_utc": "2026-05-06T10:01:00+00:00"},
+        {"campaign_id": "c3", "spawned_at_utc": "2026-05-06T10:02:00+00:00"},
+    ]}
+    registry = {"campaigns": [
+        _campaign(f"c{i}", f"2026-05-06T10:0{i-1}:00+00:00", f"f{i}", f"a{i}", f"t{i}", f"fp{i}")
+        for i in range(1, 4)
+    ]}
+    report = _build(tmp_path, queue, registry, {"zones": []}, {}, fixed_now_utc)
+    ranks = [d.advisory_rank for d in report.decisions]
+    assert ranks == sorted(ranks)
+
+
+# ---------------------------------------------------------------------------
+# Framing pin still carried after priority/rank derivation
+# ---------------------------------------------------------------------------
+
+
+def test_queue_ordering_effect_remains_none_after_ranking(
+    tmp_path: Path, fixed_now_utc: _dt.datetime,
+) -> None:
+    queue = {"queue": [
+        {"campaign_id": "c1", "spawned_at_utc": "2026-05-06T10:00:00+00:00"},
+    ]}
+    registry = {"campaigns": [
+        _campaign("c1", "2026-05-06T10:00:00+00:00", "f1", "a1", "t1", "fp1"),
+    ]}
+    report = _build(tmp_path, queue, registry, {"zones": []}, {}, fixed_now_utc)
+    payload = report.to_payload()
+    assert payload["queue_ordering_effect"] == "none"
+    assert payload["routing_effect"] == "advisory_only"

--- a/tests/unit/test_intelligent_routing_advisory_suppression.py
+++ b/tests/unit/test_intelligent_routing_advisory_suppression.py
@@ -1,0 +1,335 @@
+"""PR-C — advisory suppression tests for reporting.intelligent_routing.
+
+Pins the advisory framing — Correction 4:
+
+* ``advisory_suppression_reason`` is set to ``"dead_zone"`` *iff* the
+  upstream dead-zone status is ``"dead"`` AND the campaign coordinates
+  match. Statuses ``alive``, ``weak``, ``unknown``,
+  ``insufficient_data`` never trigger suppression.
+* ``advisory_suppression_reason`` is set to ``"near_duplicate"`` for
+  every member of a near-duplicate group EXCEPT the first by
+  ``(spawned_at_utc, campaign_id)``. The first member always keeps
+  ``None``. At-least-one survivor per group.
+* Dead-zone takes precedence over near-duplicate when both would
+  apply (the dead-zone signal is the louder advisory).
+* The artifact still carries ``routing_effect = "advisory_only"`` and
+  ``queue_ordering_effect = "none"`` after suppression is applied —
+  pre/post snapshot of ``research/**`` shows zero changes.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from reporting import intelligent_routing as ir
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+#: Same closed list used by the PR-A import-safety test. Pre/post
+#: snapshot proves a --write run does not mutate any frozen / no-touch
+#: research artifact.
+FROZEN_RESEARCH_PATHS: tuple[str, ...] = (
+    "research/research_latest.json",
+    "research/strategy_matrix.csv",
+    "research/campaigns/evidence/dead_zones_latest.v1.json",
+    "research/campaigns/evidence/information_gain_latest.v1.json",
+    "research/campaigns/evidence/viability_latest.v1.json",
+    "research/campaigns/evidence/stop_conditions_latest.v1.json",
+    "research/campaigns/evidence/evidence_ledger_latest.v1.json",
+)
+
+
+def _snapshot() -> dict[str, str | None]:
+    out: dict[str, str | None] = {}
+    for rel in FROZEN_RESEARCH_PATHS:
+        p = REPO_ROOT / rel
+        out[rel] = (
+            hashlib.sha256(p.read_bytes()).hexdigest() if p.exists() else None
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# derive_advisory_suppression_reason — pure helper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "status,expected",
+    [
+        ("dead", "dead_zone"),
+        ("alive", None),
+        ("weak", None),
+        ("unknown", None),
+        ("insufficient_data", None),
+    ],
+)
+def test_dead_zone_suppression_only_for_dead(status: str, expected: str | None) -> None:
+    out = ir.derive_advisory_suppression_reason(
+        dead_zone_status=status,
+        near_duplicate_group=None,
+        is_first_in_group=True,
+    )
+    assert out == expected
+
+
+def test_near_duplicate_first_member_keeps_none() -> None:
+    out = ir.derive_advisory_suppression_reason(
+        dead_zone_status="alive",
+        near_duplicate_group="abc123",
+        is_first_in_group=True,
+    )
+    assert out is None
+
+
+def test_near_duplicate_non_first_member_is_suppressed() -> None:
+    out = ir.derive_advisory_suppression_reason(
+        dead_zone_status="alive",
+        near_duplicate_group="abc123",
+        is_first_in_group=False,
+    )
+    assert out == "near_duplicate"
+
+
+def test_dead_zone_takes_precedence_over_near_duplicate() -> None:
+    out = ir.derive_advisory_suppression_reason(
+        dead_zone_status="dead",
+        near_duplicate_group="abc123",
+        is_first_in_group=False,
+    )
+    # Dead-zone wins.
+    assert out == "dead_zone"
+
+
+def test_no_group_no_suppression() -> None:
+    out = ir.derive_advisory_suppression_reason(
+        dead_zone_status="alive",
+        near_duplicate_group=None,
+        is_first_in_group=True,
+    )
+    assert out is None
+
+
+# ---------------------------------------------------------------------------
+# build_report — full-pipeline suppression behavior
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fixed_now_utc() -> _dt.datetime:
+    return _dt.datetime(2026, 5, 6, 12, 0, 0, tzinfo=_dt.timezone.utc)
+
+
+def _write_inputs(tmp_path: Path, queue: dict, registry: dict, dead_zones: dict, ig: dict) -> dict[str, Path]:
+    paths = {
+        "queue": tmp_path / "queue.json",
+        "registry": tmp_path / "registry.json",
+        "dead_zones": tmp_path / "dz.json",
+        "information_gain": tmp_path / "ig.json",
+    }
+    paths["queue"].write_text(json.dumps(queue), encoding="utf-8")
+    paths["registry"].write_text(json.dumps(registry), encoding="utf-8")
+    paths["dead_zones"].write_text(json.dumps(dead_zones), encoding="utf-8")
+    paths["information_gain"].write_text(json.dumps(ig), encoding="utf-8")
+    return paths
+
+
+def _build(tmp_path: Path, queue, registry, dead_zones, ig, now) -> ir.RoutingReport:
+    paths = _write_inputs(tmp_path, queue, registry, dead_zones, ig)
+    return ir.build_report(
+        now_utc=now,
+        queue_path=paths["queue"],
+        registry_path=paths["registry"],
+        dead_zones_path=paths["dead_zones"],
+        information_gain_path=paths["information_gain"],
+    )
+
+
+def _campaign(cid: str, spawned: str, family: str, asset: str, tf: str, fp: str, preset: str = "preset_x") -> dict:
+    return {
+        "campaign_id": cid,
+        "preset_name": preset,
+        "strategy_family": family,
+        "asset_class": asset,
+        "extra": {"timeframe": tf},
+        "input_artifact_fingerprint": fp,
+        "spawned_at_utc": spawned,
+    }
+
+
+def test_dead_zone_suppression_in_full_report(
+    tmp_path: Path, fixed_now_utc: _dt.datetime,
+) -> None:
+    queue = {"queue": [
+        {"campaign_id": "c1", "spawned_at_utc": "2026-05-06T10:00:00+00:00", "priority_tier": 2},
+        {"campaign_id": "c2", "spawned_at_utc": "2026-05-06T10:01:00+00:00", "priority_tier": 2},
+    ]}
+    registry = {"campaigns": [
+        _campaign("c1", "2026-05-06T10:00:00+00:00", "ema_crossover", "crypto", "4h", "fp1"),
+        _campaign("c2", "2026-05-06T10:01:00+00:00", "rsi_extreme", "equities", "1d", "fp2"),
+    ]}
+    dead_zones = {"zones": [
+        {"asset": "crypto", "timeframe": "4h", "strategy_family": "ema_crossover", "zone_status": "dead"},
+        {"asset": "equities", "timeframe": "1d", "strategy_family": "rsi_extreme", "zone_status": "alive"},
+    ]}
+    report = _build(tmp_path, queue, registry, dead_zones, {}, fixed_now_utc)
+    by_id = {d.campaign_id: d for d in report.decisions}
+    assert by_id["c1"].advisory_suppression_reason == "dead_zone"
+    assert by_id["c2"].advisory_suppression_reason is None
+
+
+@pytest.mark.parametrize("status", ["alive", "weak", "unknown", "insufficient_data"])
+def test_no_dead_zone_suppression_for_non_dead_statuses(
+    tmp_path: Path, fixed_now_utc: _dt.datetime, status: str,
+) -> None:
+    queue = {"queue": [{"campaign_id": "c1", "spawned_at_utc": "2026-05-06T10:00:00+00:00"}]}
+    registry = {"campaigns": [
+        _campaign("c1", "2026-05-06T10:00:00+00:00", "ema_crossover", "crypto", "4h", "fp1"),
+    ]}
+    dead_zones = {"zones": [
+        {"asset": "crypto", "timeframe": "4h", "strategy_family": "ema_crossover", "zone_status": status},
+    ]}
+    report = _build(tmp_path, queue, registry, dead_zones, {}, fixed_now_utc)
+    assert report.decisions[0].advisory_suppression_reason is None
+
+
+def test_near_duplicate_group_first_member_survives(
+    tmp_path: Path, fixed_now_utc: _dt.datetime,
+) -> None:
+    """All non-first members of a near-duplicate group are suppressed,
+    but at least the first member survives (Correction 6 risk #6)."""
+    queue = {"queue": [
+        {"campaign_id": "c1", "spawned_at_utc": "2026-05-06T10:00:00+00:00"},
+        {"campaign_id": "c2", "spawned_at_utc": "2026-05-06T10:01:00+00:00"},
+        {"campaign_id": "c3", "spawned_at_utc": "2026-05-06T10:02:00+00:00"},
+    ]}
+    registry = {"campaigns": [
+        # All three share coords + fingerprint prefix → same group.
+        _campaign("c1", "2026-05-06T10:00:00+00:00", "ema_crossover", "crypto", "4h", "abcd1234ff"),
+        _campaign("c2", "2026-05-06T10:01:00+00:00", "ema_crossover", "crypto", "4h", "abcd1234aa"),
+        _campaign("c3", "2026-05-06T10:02:00+00:00", "ema_crossover", "crypto", "4h", "abcd1234bb"),
+    ]}
+    # No dead zones in this fixture.
+    report = _build(tmp_path, queue, registry, {"zones": []}, {}, fixed_now_utc)
+    by_id = {d.campaign_id: d for d in report.decisions}
+    # Earliest spawned wins.
+    assert by_id["c1"].advisory_suppression_reason is None
+    assert by_id["c2"].advisory_suppression_reason == "near_duplicate"
+    assert by_id["c3"].advisory_suppression_reason == "near_duplicate"
+
+
+def test_at_least_one_survivor_per_near_duplicate_group(
+    tmp_path: Path, fixed_now_utc: _dt.datetime,
+) -> None:
+    """For every group, at least one campaign keeps suppression=None."""
+    queue = {"queue": [
+        {"campaign_id": f"c{i}", "spawned_at_utc": f"2026-05-06T10:0{i}:00+00:00"}
+        for i in range(1, 4)
+    ]}
+    registry = {"campaigns": [
+        _campaign(f"c{i}", f"2026-05-06T10:0{i}:00+00:00", "ema_crossover", "crypto", "4h", f"abcd1234{i}")
+        for i in range(1, 4)
+    ]}
+    report = _build(tmp_path, queue, registry, {"zones": []}, {}, fixed_now_utc)
+    by_group: dict[str, list[ir.RoutingDecision]] = {}
+    for d in report.decisions:
+        if d.near_duplicate_group is None:
+            continue
+        by_group.setdefault(d.near_duplicate_group, []).append(d)
+    for gid, members in by_group.items():
+        survivors = [
+            m for m in members if m.advisory_suppression_reason != "near_duplicate"
+        ]
+        assert len(survivors) >= 1, f"group {gid} has no survivor: {members!r}"
+
+
+def test_dead_zone_precedes_near_duplicate_in_report(
+    tmp_path: Path, fixed_now_utc: _dt.datetime,
+) -> None:
+    """When a campaign is both in a dead zone AND not the first member
+    of its near-duplicate group, the suppression reason is dead_zone."""
+    queue = {"queue": [
+        {"campaign_id": "c1", "spawned_at_utc": "2026-05-06T10:00:00+00:00"},
+        {"campaign_id": "c2", "spawned_at_utc": "2026-05-06T10:01:00+00:00"},
+    ]}
+    registry = {"campaigns": [
+        _campaign("c1", "2026-05-06T10:00:00+00:00", "ema_crossover", "crypto", "4h", "abcd1234"),
+        _campaign("c2", "2026-05-06T10:01:00+00:00", "ema_crossover", "crypto", "4h", "abcd1234"),
+    ]}
+    dead_zones = {"zones": [
+        {"asset": "crypto", "timeframe": "4h", "strategy_family": "ema_crossover", "zone_status": "dead"},
+    ]}
+    report = _build(tmp_path, queue, registry, dead_zones, {}, fixed_now_utc)
+    by_id = {d.campaign_id: d for d in report.decisions}
+    # c1 is dead-zone; c2 is dead-zone (precedence over near-duplicate).
+    assert by_id["c1"].advisory_suppression_reason == "dead_zone"
+    assert by_id["c2"].advisory_suppression_reason == "dead_zone"
+
+
+def test_summary_counters_match_suppression_reasons(
+    tmp_path: Path, fixed_now_utc: _dt.datetime,
+) -> None:
+    queue = {"queue": [
+        {"campaign_id": "c1", "spawned_at_utc": "2026-05-06T10:00:00+00:00"},
+        {"campaign_id": "c2", "spawned_at_utc": "2026-05-06T10:01:00+00:00"},
+        {"campaign_id": "c3", "spawned_at_utc": "2026-05-06T10:02:00+00:00"},
+    ]}
+    registry = {"campaigns": [
+        _campaign("c1", "2026-05-06T10:00:00+00:00", "ema_crossover", "crypto", "4h", "abcd1234"),
+        _campaign("c2", "2026-05-06T10:01:00+00:00", "ema_crossover", "crypto", "4h", "abcd1234"),
+        _campaign("c3", "2026-05-06T10:02:00+00:00", "rsi_extreme", "equities", "1d", "ffff"),
+    ]}
+    dead_zones = {"zones": [
+        {"asset": "equities", "timeframe": "1d", "strategy_family": "rsi_extreme", "zone_status": "dead"},
+    ]}
+    report = _build(tmp_path, queue, registry, dead_zones, {}, fixed_now_utc)
+    s = report.summary
+    assert s.total == 3
+    # c2 is near_duplicate (c1 is the survivor); c3 is dead_zone.
+    assert s.advisory_suppressed_near_duplicate == 1
+    assert s.advisory_suppressed_dead_zone == 1
+
+
+# ---------------------------------------------------------------------------
+# Framing pin: routing_effect / queue_ordering_effect remain after PR-C
+# ---------------------------------------------------------------------------
+
+
+def test_routing_effect_and_queue_ordering_effect_present(
+    tmp_path: Path, fixed_now_utc: _dt.datetime,
+) -> None:
+    queue = {"queue": [
+        {"campaign_id": "c1", "spawned_at_utc": "2026-05-06T10:00:00+00:00"},
+    ]}
+    registry = {"campaigns": [
+        _campaign("c1", "2026-05-06T10:00:00+00:00", "ema_crossover", "crypto", "4h", "fp1"),
+    ]}
+    report = _build(tmp_path, queue, registry, {"zones": []}, {}, fixed_now_utc)
+    payload = report.to_payload()
+    assert payload["routing_effect"] == "advisory_only"
+    assert payload["queue_ordering_effect"] == "none"
+
+
+def test_pre_post_snapshot_of_research_paths_unchanged_across_build(
+    tmp_path: Path, fixed_now_utc: _dt.datetime,
+) -> None:
+    """Calling build_report writes nothing under research/**.
+
+    Targeted snapshot of a closed list per Critical-review item 1.
+    """
+    queue = {"queue": [
+        {"campaign_id": "c1", "spawned_at_utc": "2026-05-06T10:00:00+00:00"},
+    ]}
+    registry = {"campaigns": [
+        _campaign("c1", "2026-05-06T10:00:00+00:00", "ema_crossover", "crypto", "4h", "fp1"),
+    ]}
+    before = _snapshot()
+    _build(tmp_path, queue, registry, {"zones": []}, {}, fixed_now_utc)
+    after = _snapshot()
+    assert before == after

--- a/tests/unit/test_intelligent_routing_report.py
+++ b/tests/unit/test_intelligent_routing_report.py
@@ -237,21 +237,39 @@ def test_report_near_duplicate_group_consistent_within_coords(
 def test_report_decisions_are_sorted_deterministically(
     synth_inputs: dict[str, Path], fixed_now_utc: _dt.datetime,
 ) -> None:
+    """PR-C: decisions are listed in ``advisory_rank`` ascending order
+    — equivalent to ``(-priority, tie_break_key)`` ascending. Two
+    invocations with identical inputs produce the same total ordering.
+    """
     report = _build(synth_inputs, fixed_now_utc)
-    keys = [d.tie_break_key for d in report.decisions]
-    assert keys == sorted(keys)
+    ranks = [d.advisory_rank for d in report.decisions]
+    assert ranks == sorted(ranks)
+    # Re-build and assert the listing is byte-identical with a pinned
+    # generated_at_utc.
+    report2 = _build(synth_inputs, fixed_now_utc)
+    assert report.to_payload() == report2.to_payload()
 
 
 def test_report_summary_counts(
     synth_inputs: dict[str, Path], fixed_now_utc: _dt.datetime,
 ) -> None:
+    """PR-C: summary counters reflect the suppression pipeline.
+
+    Fixture: col-c1 and col-c2 share coords (crypto/4h/ema_crossover)
+    and the dead-zones artifact marks that coord ``dead`` — both get
+    ``advisory_suppressed_dead_zone``. col-c3 is on a unique alive
+    coordinate.
+    """
     report = _build(synth_inputs, fixed_now_utc)
     s = report.summary
     assert s.total == 3
-    assert s.advisory_suppressed_dead_zone == 0  # PR-B: still 0
-    assert s.advisory_suppressed_near_duplicate == 0  # PR-B: still 0
-    assert s.high_info_gain == 1  # only col-c3
-    assert s.novel_behavior_coordinates == 1  # only col-c3
+    # Both crypto/4h/ema_crossover campaigns are dead-zone suppressed.
+    assert s.advisory_suppressed_dead_zone == 2
+    # Dead-zone takes precedence over near-duplicate, so the
+    # near-duplicate counter stays 0.
+    assert s.advisory_suppressed_near_duplicate == 0
+    assert s.high_info_gain == 1  # only col-c3 (IG=0.85)
+    assert s.novel_behavior_coordinates == 1  # only col-c3 (unique coords)
     assert s.metadata_gaps == 0  # all coordinates fully populated
 
 


### PR DESCRIPTION
## Summary

PR-C of v3.15.16 — **Intelligent Routing Layer (advisory)**. Builds on [#117](https://github.com/roudjy/trading-agent/pull/117) and [#118](https://github.com/roudjy/trading-agent/pull/118).

Wires the advisory suppression and priority/rank derivation into \`build_report\`. The artifact still carries \`routing_effect = \"advisory_only\"\` and \`queue_ordering_effect = \"none\"\` — annotation only; no queue mutation; no research/** write.

### What's added

**Pure helpers**

| Symbol | Purpose |
|---|---|
| \`derive_advisory_suppression_reason\` | \`dead_zone\` iff status==\`dead\`; \`near_duplicate\` iff in group AND not first member; dead-zone takes precedence. |
| \`compute_advisory_priority_score\` | Suppressed → -1; else \`ig_weight * 10 + ortho_weight\` with named-constant weight maps. |
| \`INFO_GAIN_BUCKET_WEIGHTS\` | \`none=0 low=1 medium=2 high=3\`. |
| \`ORTHOGONALITY_BUCKET_WEIGHTS\` | \`saturated=0 adjacent=1 novel=2\`. |
| \`INFO_GAIN_PRIORITY_MULTIPLIER = 10\` | IG step dominates orthogonality. |
| \`SUPPRESSED_PRIORITY_SCORE = -1\` | All suppressed campaigns sink below non-suppressed. |

**Wired into \`build_report\`**

Three new passes after the existing PR-B coordinate/IG/dead-zone/group computation:
1. First-member detection per near-duplicate group.
2. Per-row \`advisory_suppression_reason\` + \`advisory_priority_score\` derivation.
3. Total ordering by \`(-priority, tie_break_key)\` → 1-indexed \`advisory_rank\`.

Summary counters now reflect the suppression pipeline: \`advisory_suppressed_dead_zone\`, \`advisory_suppressed_near_duplicate\`.

### Tests (40 new + 2 PR-B tests updated; 116/116 green locally)

| File | What it pins |
|---|---|
| \`tests/unit/test_intelligent_routing_advisory_suppression.py\` (new, 14 tests) | Suppression reason logic; only \`dead\` triggers \`dead_zone\`; first-member-by-(spawned_at, cid) survives; at-least-one survivor per group; dead-zone precedes near-duplicate; summary counters match per-decision reasons; pre/post snapshot of frozen research artifacts unchanged across a \`build_report\` invocation (targeted closed list per Critical-review item 1). |
| \`tests/unit/test_intelligent_routing_advisory_priority.py\` (new, 11 tests) | Suppressed → -1 always; high-IG-novel > none-IG-saturated; IG step dominates orthogonality; unknown bucket → 0; explicit bucket-grid; \`advisory_rank\` is 1-indexed total ordering; suppressed sink below non-suppressed; ties on \`(spawned_at, cid)\` ascending; decisions list sorted by \`advisory_rank\`; \`queue_ordering_effect\` remains \`none\`. |
| \`tests/unit/test_intelligent_routing_report.py\` (updates) | \`test_report_decisions_are_sorted_deterministically\` now asserts \`advisory_rank\` ascending + byte-identical re-build; \`test_report_summary_counts\` updated for dead-zone precedence in the existing fixture (no test weakening — assertions changed to match the new spec, not removed/skipped/xfailed). |

### Hard no-touch envelope respected

No file under \`research/**\`, \`automation/**\`, \`agent/risk/**\`, \`agent/execution/**\`, \`broker/**\`, \`live/**\`, \`paper/**\`, \`shadow/**\`, \`trading/**\`, \`.claude/**\`, \`dashboard/**\`, \`.github/workflows/**\`, or any frozen \`*_latest.v1.json\`. No \`tests/regression/**\` modified.

CLI smoke locally:

\`\`\`
\$ python -m reporting.intelligent_routing --no-write
{... routing_effect: \"advisory_only\", queue_ordering_effect: \"none\" ...}
\`\`\`

No \`logs/intelligent_routing/\` directory created (verified).

## Test plan

- [x] \`python -m pytest tests/unit/test_intelligent_routing_*.py tests/integration/test_intelligent_routing_*.py -q\` — 116/116 pass locally.
- [x] CLI \`--no-write\` smoke.
- [x] CI fast pre-merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)