### PR TITLE
feat(v3.15.16): PR-D — --diagnose-id + status reporter + smoke

### DIFF
--- a/reporting/intelligent_routing.py
+++ b/reporting/intelligent_routing.py
@@ -993,13 +993,89 @@ def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
 
 
 # ---------------------------------------------------------------------------
-# CLI (PR-B)
+# Diagnose-id (PR-D)
+# ---------------------------------------------------------------------------
+
+DIAGNOSE_REPORT_KIND: Final[str] = "intelligent_routing_diagnose_id"
+
+
+def _diagnose_id(
+    target_campaign_id: str,
+    *,
+    latest_artifact_path: Path = LATEST_OUTPUT_PATH,
+) -> dict[str, Any]:
+    """Look up an advisory routing decision by ``campaign_id``.
+
+    Pure-read. **Never writes.** Returns the matching decision row
+    from ``logs/intelligent_routing/latest.json`` if present, or a
+    structured envelope describing why no match was found.
+
+    Schema:
+
+    ::
+
+        {
+          "schema_version": "1.0",
+          "report_kind": "intelligent_routing_diagnose_id",
+          "target_campaign_id": "...",
+          "artifact_path": "logs/intelligent_routing/latest.json",
+          "artifact_status": "present" | "not_available" | "malformed",
+          "match": {<decision row>} | null,
+          "error": null | "<reason>",
+        }
+    """
+    target = target_campaign_id.strip() if target_campaign_id else ""
+    try:
+        rel = str(
+            latest_artifact_path.resolve().relative_to(REPO_ROOT)
+        ).replace("\\", "/")
+    except ValueError:
+        rel = str(latest_artifact_path)
+    base: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": DIAGNOSE_REPORT_KIND,
+        "target_campaign_id": target,
+        "artifact_path": rel,
+        "artifact_status": "not_available",
+        "match": None,
+        "error": None,
+    }
+    if not target:
+        base["error"] = "empty_target_campaign_id"
+        return base
+    payload = _read_json(latest_artifact_path)
+    if not latest_artifact_path.exists():
+        base["error"] = "artifact_not_found"
+        return base
+    if payload is None:
+        base["artifact_status"] = "malformed"
+        base["error"] = "artifact_unreadable_or_invalid_json"
+        return base
+    base["artifact_status"] = "present"
+    decisions = payload.get("decisions") or []
+    if not isinstance(decisions, list):
+        base["artifact_status"] = "malformed"
+        base["error"] = "decisions_field_not_a_list"
+        return base
+    for d in decisions:
+        if not isinstance(d, dict):
+            continue
+        if d.get("campaign_id") == target:
+            base["match"] = d
+            return base
+    base["error"] = "campaign_id_not_in_artifact"
+    return base
+
+
+# ---------------------------------------------------------------------------
+# CLI (PR-B + PR-D)
 # ---------------------------------------------------------------------------
 
 CLI_DESCRIPTION: Final[str] = (
     "v3.15.16 advisory Intelligent Routing Layer reporter. "
     "Default: --no-write (prints JSON, writes nothing). "
     "Pass --write to persist logs/intelligent_routing/latest.json. "
+    "Use --diagnose-id <campaign_id> for read-only lookup. "
     "Routing effect: advisory_only. Queue ordering effect: none."
 )
 
@@ -1030,6 +1106,17 @@ def _build_argparser() -> argparse.ArgumentParser:
     )
     parser.set_defaults(write=False)
     parser.add_argument(
+        "--diagnose-id",
+        dest="diagnose_id",
+        type=str,
+        default=None,
+        help=(
+            "Look up an advisory routing decision by campaign_id. "
+            "Reads logs/intelligent_routing/latest.json only; "
+            "never writes."
+        ),
+    )
+    parser.add_argument(
         "--indent",
         type=int,
         default=2,
@@ -1041,12 +1128,31 @@ def _build_argparser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     """CLI entry point. Returns process exit code (0 on success).
 
-    Default behavior is ``--no-write``: prints the JSON report to
-    stdout and writes nothing. ``--write`` persists exactly one file
-    at ``logs/intelligent_routing/latest.json``.
+    Modes:
+
+    * ``--no-write`` (default) — print the routing report to stdout;
+      write nothing.
+    * ``--write`` — persist ``logs/intelligent_routing/latest.json``
+      (single file; no timestamped siblings).
+    * ``--diagnose-id <campaign_id>`` — print the matching decision
+      from the latest artifact; **never writes** regardless of the
+      ``--write``/``--no-write`` flag.
     """
     parser = _build_argparser()
     args = parser.parse_args(argv)
+    if args.diagnose_id:
+        # Pass the current module-level path explicitly so
+        # monkeypatch.setattr(ir, "LATEST_OUTPUT_PATH", ...) works in
+        # tests. (Default-argument binding happens at function
+        # definition time and would otherwise pin the original value.)
+        result = _diagnose_id(
+            args.diagnose_id, latest_artifact_path=LATEST_OUTPUT_PATH,
+        )
+        sys.stdout.write(
+            json.dumps(result, indent=int(args.indent), sort_keys=True)
+            + "\n"
+        )
+        return 0
     report = build_report()
     payload = report.to_payload()
     if args.write:
@@ -1085,6 +1191,7 @@ __all__ = [
     "DEAD_ZONE_STATUSES",
     "DEAD_ZONE_UNKNOWN",
     "DEAD_ZONE_WEAK",
+    "DIAGNOSE_REPORT_KIND",
     "IG_BUCKET_HIGH_FLOOR",
     "IG_BUCKET_MEDIUM_FLOOR",
     "INFO_GAIN_BUCKETS",

--- a/reporting/intelligent_routing_status.py
+++ b/reporting/intelligent_routing_status.py
@@ -1,0 +1,268 @@
+"""v3.15.16 PR-D — Intelligent Routing status reporter (advisory).
+
+Stand-alone status reporter for the advisory Intelligent Routing
+Layer artifact at ``logs/intelligent_routing/latest.json``.
+
+Per Critical-review item 3, this is a **separate** module — it does
+**not** modify ``reporting/governance_status.py``.
+
+What it reports
+---------------
+
+A single envelope summarising the latest routing artifact:
+
+* artifact presence (``present`` / ``not_available`` / ``malformed``)
+* total decisions
+* counts by ``advisory_suppression_reason`` (none / dead_zone /
+  near_duplicate)
+* counts by ``info_gain_bucket``
+* counts by ``orthogonality_bucket``
+* the routing-effect framing (``advisory_only`` / ``none``) re-stated
+  verbatim so a downstream consumer does not need to read the
+  decisions array
+
+Hard guarantees (pinned by tests)
+---------------------------------
+
+* Stdlib-only. No subprocess. No network. No git. No gh.
+* No imports from ``automation``, ``agent.risk``, ``agent.execution``,
+  ``broker``, ``live``, ``paper``, ``shadow``, ``trading``,
+  ``dashboard``, or ``reporting.governance_status``.
+* Importing the module performs no I/O.
+* Default CLI mode is ``--no-write``: prints JSON to stdout, writes
+  nothing. ``--write`` persists exactly one file at
+  ``logs/intelligent_routing_status/latest.json``.
+* Never writes to ``research/**``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import hashlib
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Final, Sequence
+
+from reporting.intelligent_routing import (
+    LATEST_OUTPUT_PATH as _ROUTING_LATEST_OUTPUT_PATH,
+    REPO_ROOT,
+    ROUTING_EFFECT_ADVISORY_ONLY,
+    QUEUE_ORDERING_EFFECT_NONE,
+    SCHEMA_VERSION as _ROUTING_SCHEMA_VERSION,
+)
+
+MODULE_VERSION: Final[str] = "v3.15.16"
+SCHEMA_VERSION: Final[str] = "1.0"
+REPORT_KIND: Final[str] = "intelligent_routing_status"
+
+STATUS_OUTPUT_DIR: Final[Path] = (
+    REPO_ROOT / "logs" / "intelligent_routing_status"
+)
+STATUS_LATEST_OUTPUT_PATH: Final[Path] = STATUS_OUTPUT_DIR / "latest.json"
+
+ARTIFACT_PRESENT: Final[str] = "present"
+ARTIFACT_NOT_AVAILABLE: Final[str] = "not_available"
+ARTIFACT_MALFORMED: Final[str] = "malformed"
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    try:
+        if not path.exists() or not path.is_file():
+            return None
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    return parsed
+
+
+def _provenance_entry(path: Path) -> dict[str, str]:
+    try:
+        if not path.exists() or not path.is_file():
+            return {"status": ARTIFACT_NOT_AVAILABLE}
+        data = path.read_bytes()
+        digest = hashlib.sha256(data).hexdigest()
+        mtime_dt = _dt.datetime.fromtimestamp(
+            path.stat().st_mtime, tz=_dt.timezone.utc,
+        )
+        return {
+            "status": ARTIFACT_PRESENT,
+            "sha256": digest,
+            "mtime_utc": mtime_dt.isoformat(),
+        }
+    except OSError:
+        return {"status": ARTIFACT_NOT_AVAILABLE}
+
+
+def _now_utc_default() -> _dt.datetime:
+    return _dt.datetime.now(tz=_dt.timezone.utc)
+
+
+def _count_by(decisions: list[dict[str, Any]], key: str) -> dict[str, int]:
+    out: dict[str, int] = {}
+    for d in decisions:
+        if not isinstance(d, dict):
+            continue
+        v = d.get(key)
+        if v is None:
+            label = "none"
+        elif isinstance(v, str):
+            label = v
+        else:
+            label = str(v)
+        out[label] = out.get(label, 0) + 1
+    return out
+
+
+def build_status(
+    *,
+    routing_artifact_path: Path = _ROUTING_LATEST_OUTPUT_PATH,
+    now_utc: _dt.datetime | None = None,
+) -> dict[str, Any]:
+    """Build the deterministic status envelope from the latest routing
+    artifact. Pure (modulo file read). Never writes.
+    """
+    as_of = now_utc if isinstance(now_utc, _dt.datetime) else _now_utc_default()
+    if as_of.tzinfo is None:
+        as_of = as_of.replace(tzinfo=_dt.timezone.utc)
+    try:
+        rel = str(
+            routing_artifact_path.resolve().relative_to(REPO_ROOT)
+        ).replace("\\", "/")
+    except ValueError:
+        rel = str(routing_artifact_path)
+    envelope: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "version": MODULE_VERSION,
+        "generated_at_utc": as_of.astimezone(_dt.timezone.utc).isoformat(),
+        "routing_artifact_path": rel,
+        "routing_artifact_status": ARTIFACT_NOT_AVAILABLE,
+        "routing_artifact_provenance": _provenance_entry(routing_artifact_path),
+        "routing_effect": ROUTING_EFFECT_ADVISORY_ONLY,
+        "queue_ordering_effect": QUEUE_ORDERING_EFFECT_NONE,
+        "routing_schema_version": _ROUTING_SCHEMA_VERSION,
+        "summary": {
+            "total": 0,
+            "by_advisory_suppression_reason": {},
+            "by_info_gain_bucket": {},
+            "by_orthogonality_bucket": {},
+        },
+        "error": None,
+    }
+    payload = _read_json(routing_artifact_path)
+    if not routing_artifact_path.exists():
+        envelope["error"] = "routing_artifact_not_found"
+        return envelope
+    if payload is None:
+        envelope["routing_artifact_status"] = ARTIFACT_MALFORMED
+        envelope["error"] = "routing_artifact_unreadable_or_invalid_json"
+        return envelope
+    decisions = payload.get("decisions") or []
+    if not isinstance(decisions, list):
+        envelope["routing_artifact_status"] = ARTIFACT_MALFORMED
+        envelope["error"] = "decisions_field_not_a_list"
+        return envelope
+    envelope["routing_artifact_status"] = ARTIFACT_PRESENT
+    envelope["summary"] = {
+        "total": len(decisions),
+        "by_advisory_suppression_reason": _count_by(
+            decisions, "advisory_suppression_reason",
+        ),
+        "by_info_gain_bucket": _count_by(decisions, "info_gain_bucket"),
+        "by_orthogonality_bucket": _count_by(
+            decisions, "orthogonality_bucket",
+        ),
+    }
+    return envelope
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=path.name + ".", suffix=".tmp", dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp_path, path)
+    except OSError:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+CLI_DESCRIPTION: Final[str] = (
+    "v3.15.16 advisory Intelligent Routing status reporter. "
+    "Default: --no-write (prints JSON, writes nothing). "
+    "Pass --write to persist logs/intelligent_routing_status/latest.json. "
+    "Routing effect: advisory_only. Queue ordering effect: none."
+)
+
+
+def _build_argparser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="reporting.intelligent_routing_status",
+        description=CLI_DESCRIPTION,
+    )
+    grp = parser.add_mutually_exclusive_group()
+    grp.add_argument(
+        "--no-write",
+        dest="write",
+        action="store_false",
+        help="Print the status to stdout; write nothing (default).",
+    )
+    grp.add_argument(
+        "--write",
+        dest="write",
+        action="store_true",
+        help="Persist logs/intelligent_routing_status/latest.json.",
+    )
+    parser.set_defaults(write=False)
+    parser.add_argument(
+        "--indent", type=int, default=2,
+        help="JSON indent for stdout (default: 2).",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_argparser()
+    args = parser.parse_args(argv)
+    payload = build_status()
+    if args.write:
+        _atomic_write_json(STATUS_LATEST_OUTPUT_PATH, payload)
+    sys.stdout.write(
+        json.dumps(payload, indent=int(args.indent), sort_keys=True) + "\n"
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())
+
+
+__all__ = [
+    "ARTIFACT_MALFORMED",
+    "ARTIFACT_NOT_AVAILABLE",
+    "ARTIFACT_PRESENT",
+    "MODULE_VERSION",
+    "REPORT_KIND",
+    "SCHEMA_VERSION",
+    "STATUS_LATEST_OUTPUT_PATH",
+    "STATUS_OUTPUT_DIR",
+    "build_status",
+    "main",
+]

--- a/tests/integration/test_intelligent_routing_status.py
+++ b/tests/integration/test_intelligent_routing_status.py
@@ -1,0 +1,190 @@
+"""PR-D — integration test for reporting.intelligent_routing_status.
+
+Pins:
+
+* The status reporter reads ``logs/intelligent_routing/latest.json``
+  and emits a structured envelope with bucket counts and the
+  advisory framing carried verbatim.
+* Default CLI mode is ``--no-write`` (writes nothing).
+* ``--write`` persists exactly ``logs/intelligent_routing_status/
+  latest.json`` (single file).
+* The status reporter does **not** import or modify
+  ``reporting.governance_status`` (Critical-review item 3).
+* Missing artifact → ``routing_artifact_status="not_available"`` and
+  ``error="routing_artifact_not_found"``; no crash.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+import pytest
+
+from reporting import intelligent_routing_status as irs
+
+
+def _write_routing_artifact(path: Path, decisions: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema_version": "1.0",
+        "report_kind": "intelligent_routing",
+        "version": "v3.15.16",
+        "routing_effect": "advisory_only",
+        "queue_ordering_effect": "none",
+        "generated_at_utc": "2026-05-06T12:00:00+00:00",
+        "provenance": {},
+        "decisions": decisions,
+        "summary": {
+            "total": len(decisions),
+            "advisory_suppressed_dead_zone": 0,
+            "advisory_suppressed_near_duplicate": 0,
+            "high_info_gain": 0,
+            "novel_behavior_coordinates": 0,
+            "metadata_gaps": 0,
+        },
+    }
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _decision(
+    cid: str, *,
+    info_gain_bucket: str = "none",
+    orthogonality_bucket: str = "novel",
+    advisory_suppression_reason: str | None = None,
+) -> dict:
+    return {
+        "campaign_id": cid,
+        "preset_name": "preset_x",
+        "behavior_coordinates": {
+            "family": "f", "asset_class": "a", "timeframe": "t",
+            "provisional": True,
+        },
+        "info_gain_score": 0.0,
+        "info_gain_bucket": info_gain_bucket,
+        "dead_zone_status": "alive",
+        "near_duplicate_group": None,
+        "orthogonality_bucket": orthogonality_bucket,
+        "advisory_suppression_reason": advisory_suppression_reason,
+        "advisory_priority_score": 0,
+        "advisory_rank": 1,
+        "tie_break_key": f"|{cid}",
+    }
+
+
+# ---------------------------------------------------------------------------
+# build_status — envelope shape + bucket counts
+# ---------------------------------------------------------------------------
+
+
+def test_build_status_with_present_artifact(tmp_path: Path) -> None:
+    art = tmp_path / "latest.json"
+    _write_routing_artifact(art, [
+        _decision("c1", info_gain_bucket="high", orthogonality_bucket="novel"),
+        _decision("c2", info_gain_bucket="medium", orthogonality_bucket="adjacent"),
+        _decision("c3", info_gain_bucket="medium", orthogonality_bucket="adjacent"),
+        _decision("c4", advisory_suppression_reason="dead_zone"),
+        _decision("c5", advisory_suppression_reason="near_duplicate"),
+    ])
+    out = irs.build_status(routing_artifact_path=art)
+    assert out["report_kind"] == "intelligent_routing_status"
+    assert out["routing_artifact_status"] == "present"
+    assert out["routing_effect"] == "advisory_only"
+    assert out["queue_ordering_effect"] == "none"
+    s = out["summary"]
+    assert s["total"] == 5
+    assert s["by_advisory_suppression_reason"]["none"] == 3
+    assert s["by_advisory_suppression_reason"]["dead_zone"] == 1
+    assert s["by_advisory_suppression_reason"]["near_duplicate"] == 1
+    assert s["by_info_gain_bucket"]["high"] == 1
+    assert s["by_info_gain_bucket"]["medium"] == 2
+    assert s["by_orthogonality_bucket"]["novel"] >= 1
+
+
+def test_build_status_with_missing_artifact(tmp_path: Path) -> None:
+    out = irs.build_status(routing_artifact_path=tmp_path / "absent.json")
+    assert out["routing_artifact_status"] == "not_available"
+    assert out["error"] == "routing_artifact_not_found"
+    assert out["summary"]["total"] == 0
+
+
+def test_build_status_with_malformed_artifact(tmp_path: Path) -> None:
+    art = tmp_path / "bad.json"
+    art.write_text("not json", encoding="utf-8")
+    out = irs.build_status(routing_artifact_path=art)
+    assert out["routing_artifact_status"] == "malformed"
+    assert out["error"] == "routing_artifact_unreadable_or_invalid_json"
+
+
+# ---------------------------------------------------------------------------
+# CLI --no-write / --write semantics
+# ---------------------------------------------------------------------------
+
+
+def test_cli_default_writes_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    out_dir = tmp_path / "logs" / "intelligent_routing_status"
+    monkeypatch.setattr(irs, "STATUS_OUTPUT_DIR", out_dir)
+    monkeypatch.setattr(irs, "STATUS_LATEST_OUTPUT_PATH", out_dir / "latest.json")
+    rc = irs.main([])
+    assert rc == 0
+    captured = capsys.readouterr()
+    body = json.loads(captured.out)
+    assert body["report_kind"] == "intelligent_routing_status"
+    assert not out_dir.exists()
+
+
+def test_cli_write_persists_only_latest_json(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    out_dir = tmp_path / "logs" / "intelligent_routing_status"
+    out_path = out_dir / "latest.json"
+    monkeypatch.setattr(irs, "STATUS_OUTPUT_DIR", out_dir)
+    monkeypatch.setattr(irs, "STATUS_LATEST_OUTPUT_PATH", out_path)
+    rc = irs.main(["--write"])
+    assert rc == 0
+    assert out_path.exists()
+    siblings = sorted(p.name for p in out_dir.iterdir())
+    assert siblings == ["latest.json"]
+
+
+# ---------------------------------------------------------------------------
+# Critical-review item 3 — does NOT modify reporting.governance_status
+# ---------------------------------------------------------------------------
+
+
+def test_status_module_does_not_import_governance_status() -> None:
+    """The standalone status module must not pull in
+    reporting.governance_status, per Critical-review item 3."""
+    importlib.reload(irs)
+    import sys
+    irs_mod_obj = sys.modules.get("reporting.intelligent_routing_status")
+    assert irs_mod_obj is not None
+    # The module must not transitively import reporting.governance_status
+    # as part of its import. We re-snapshot sys.modules around a clean
+    # reimport.
+    sys.modules.pop("reporting.intelligent_routing_status", None)
+    importlib.import_module("reporting.intelligent_routing_status")
+    # We can't enforce that no other test in the run loaded it, but the
+    # module's source must not reference it.
+    src = (Path(__file__).resolve().parent.parent.parent
+           / "reporting" / "intelligent_routing_status.py").read_text(
+        encoding="utf-8"
+    )
+    # Look for an actual import statement, not a substring match — the
+    # docstring may legitimately *mention* governance_status to record
+    # that this module deliberately does not import it (Critical-review
+    # item 3).
+    import re
+    pattern = re.compile(
+        r"^(?:from\s+reporting(?:\.\w+)?\s+import\s+[^\n]*governance_status"
+        r"|import\s+reporting\.governance_status)",
+        flags=re.MULTILINE,
+    )
+    assert pattern.search(src) is None

--- a/tests/smoke/test_intelligent_routing_smoke.py
+++ b/tests/smoke/test_intelligent_routing_smoke.py
@@ -1,0 +1,68 @@
+"""PR-D smoke — minimal happy-path import + CLI dispatch.
+
+Picked up by ``tests/run_tests.sh`` and the CI ``unit (smoke + unit)``
+job. Confirms the module imports cleanly and a default ``--no-write``
+invocation returns exit code 0 with a valid JSON envelope on stdout.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+def test_intelligent_routing_module_imports_clean() -> None:
+    from reporting import intelligent_routing as ir
+    assert ir.SCHEMA_VERSION == "1.0"
+    assert ir.MODULE_VERSION == "v3.15.16"
+    assert ir.ROUTING_EFFECT_ADVISORY_ONLY == "advisory_only"
+    assert ir.QUEUE_ORDERING_EFFECT_NONE == "none"
+
+
+def test_intelligent_routing_status_module_imports_clean() -> None:
+    from reporting import intelligent_routing_status as irs
+    assert irs.SCHEMA_VERSION == "1.0"
+    assert irs.MODULE_VERSION == "v3.15.16"
+    assert irs.REPORT_KIND == "intelligent_routing_status"
+
+
+def test_intelligent_routing_cli_default_no_write_smoke(
+    tmp_path, monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Default CLI invocation prints valid JSON, writes nothing."""
+    from reporting import intelligent_routing as ir
+    out_dir = tmp_path / "logs" / "intelligent_routing"
+    monkeypatch.setattr(ir, "OUTPUT_DIR", out_dir)
+    monkeypatch.setattr(ir, "LATEST_OUTPUT_PATH", out_dir / "latest.json")
+    monkeypatch.setattr(ir, "CAMPAIGN_QUEUE_PATH", tmp_path / "absent_q.json")
+    monkeypatch.setattr(ir, "CAMPAIGN_REGISTRY_PATH", tmp_path / "absent_r.json")
+    monkeypatch.setattr(ir, "DEAD_ZONES_PATH", tmp_path / "absent_d.json")
+    monkeypatch.setattr(ir, "INFORMATION_GAIN_PATH", tmp_path / "absent_i.json")
+    rc = ir.main([])
+    assert rc == 0
+    body = json.loads(capsys.readouterr().out)
+    assert body["routing_effect"] == "advisory_only"
+    assert body["queue_ordering_effect"] == "none"
+    assert body["report_kind"] == "intelligent_routing"
+    assert not out_dir.exists()
+
+
+def test_intelligent_routing_status_cli_default_no_write_smoke(
+    tmp_path, monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from reporting import intelligent_routing_status as irs
+    out_dir = tmp_path / "logs" / "intelligent_routing_status"
+    monkeypatch.setattr(irs, "STATUS_OUTPUT_DIR", out_dir)
+    monkeypatch.setattr(
+        irs, "STATUS_LATEST_OUTPUT_PATH", out_dir / "latest.json",
+    )
+    rc = irs.main([])
+    assert rc == 0
+    body = json.loads(capsys.readouterr().out)
+    assert body["report_kind"] == "intelligent_routing_status"
+    assert body["routing_effect"] == "advisory_only"
+    assert body["queue_ordering_effect"] == "none"
+    assert not out_dir.exists()

--- a/tests/unit/test_intelligent_routing_diagnose_id.py
+++ b/tests/unit/test_intelligent_routing_diagnose_id.py
@@ -1,0 +1,213 @@
+"""PR-D — --diagnose-id tests for reporting.intelligent_routing.
+
+Pins (Critical-review item 2):
+
+* ``_diagnose_id`` returns the matching decision when present.
+* Empty / missing campaign_id yields a structured envelope with
+  ``error != None`` and ``match == None``.
+* If the artifact is missing, ``artifact_status == "not_available"``
+  and no exception is raised.
+* If the artifact is malformed, ``artifact_status == "malformed"``.
+* **--diagnose-id never writes** (Critical-review item 2):
+  - if ``logs/intelligent_routing/latest.json`` already exists,
+    invoking ``main(["--diagnose-id", ...])`` does **not** change
+    its bytes or its mtime.
+  - if it does not exist, the directory is **not** created.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from reporting import intelligent_routing as ir
+
+
+def _write_artifact(path: Path, decisions: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema_version": "1.0",
+        "report_kind": "intelligent_routing",
+        "version": "v3.15.16",
+        "routing_effect": "advisory_only",
+        "queue_ordering_effect": "none",
+        "generated_at_utc": "2026-05-06T12:00:00+00:00",
+        "provenance": {},
+        "decisions": decisions,
+        "summary": {
+            "total": len(decisions),
+            "advisory_suppressed_dead_zone": 0,
+            "advisory_suppressed_near_duplicate": 0,
+            "high_info_gain": 0,
+            "novel_behavior_coordinates": 0,
+            "metadata_gaps": 0,
+        },
+    }
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _decision(cid: str, reason: str | None = None) -> dict:
+    return {
+        "campaign_id": cid,
+        "preset_name": "preset_x",
+        "behavior_coordinates": {
+            "family": "ema_crossover",
+            "asset_class": "crypto",
+            "timeframe": "4h",
+            "provisional": True,
+        },
+        "info_gain_score": 0.0,
+        "info_gain_bucket": "none",
+        "dead_zone_status": "alive",
+        "near_duplicate_group": None,
+        "orthogonality_bucket": "novel",
+        "advisory_suppression_reason": reason,
+        "advisory_priority_score": 2,
+        "advisory_rank": 1,
+        "tie_break_key": f"2026-05-06T10:00:00+00:00|{cid}",
+    }
+
+
+# ---------------------------------------------------------------------------
+# _diagnose_id — schema + match logic
+# ---------------------------------------------------------------------------
+
+
+def test_diagnose_id_returns_match_when_present(tmp_path: Path) -> None:
+    artifact = tmp_path / "latest.json"
+    _write_artifact(artifact, [_decision("col-c1"), _decision("col-c2")])
+    out = ir._diagnose_id("col-c2", latest_artifact_path=artifact)
+    assert out["report_kind"] == ir.DIAGNOSE_REPORT_KIND
+    assert out["target_campaign_id"] == "col-c2"
+    assert out["artifact_status"] == "present"
+    assert isinstance(out["match"], dict)
+    assert out["match"]["campaign_id"] == "col-c2"
+    assert out["error"] is None
+
+
+def test_diagnose_id_returns_no_match_envelope(tmp_path: Path) -> None:
+    artifact = tmp_path / "latest.json"
+    _write_artifact(artifact, [_decision("col-c1")])
+    out = ir._diagnose_id("col-other", latest_artifact_path=artifact)
+    assert out["artifact_status"] == "present"
+    assert out["match"] is None
+    assert out["error"] == "campaign_id_not_in_artifact"
+
+
+def test_diagnose_id_handles_missing_artifact(tmp_path: Path) -> None:
+    artifact = tmp_path / "missing.json"
+    out = ir._diagnose_id("col-c1", latest_artifact_path=artifact)
+    assert out["artifact_status"] == "not_available"
+    assert out["match"] is None
+    assert out["error"] == "artifact_not_found"
+
+
+def test_diagnose_id_handles_malformed_artifact(tmp_path: Path) -> None:
+    artifact = tmp_path / "bad.json"
+    artifact.write_text("not json", encoding="utf-8")
+    out = ir._diagnose_id("col-c1", latest_artifact_path=artifact)
+    assert out["artifact_status"] == "malformed"
+    assert out["match"] is None
+    assert out["error"] == "artifact_unreadable_or_invalid_json"
+
+
+def test_diagnose_id_handles_decisions_not_a_list(tmp_path: Path) -> None:
+    artifact = tmp_path / "weird.json"
+    artifact.write_text(
+        json.dumps({"decisions": "oops"}), encoding="utf-8",
+    )
+    out = ir._diagnose_id("col-c1", latest_artifact_path=artifact)
+    assert out["artifact_status"] == "malformed"
+    assert out["error"] == "decisions_field_not_a_list"
+
+
+def test_diagnose_id_empty_target(tmp_path: Path) -> None:
+    artifact = tmp_path / "latest.json"
+    _write_artifact(artifact, [_decision("col-c1")])
+    out = ir._diagnose_id("", latest_artifact_path=artifact)
+    assert out["match"] is None
+    assert out["error"] == "empty_target_campaign_id"
+
+
+# ---------------------------------------------------------------------------
+# CLI --diagnose-id NEVER writes (Critical-review item 2)
+# ---------------------------------------------------------------------------
+
+
+def test_cli_diagnose_id_does_not_change_existing_artifact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """If logs/intelligent_routing/latest.json already exists,
+    --diagnose-id must not change its bytes or mtime."""
+    out_dir = tmp_path / "logs" / "intelligent_routing"
+    out_path = out_dir / "latest.json"
+    monkeypatch.setattr(ir, "OUTPUT_DIR", out_dir)
+    monkeypatch.setattr(ir, "LATEST_OUTPUT_PATH", out_path)
+    _write_artifact(out_path, [_decision("col-c1")])
+    bytes_before = out_path.read_bytes()
+    mtime_before = out_path.stat().st_mtime
+    # Ensure a measurable mtime gap exists: pause the test enough to
+    # guarantee the filesystem mtime would differ if a write occurred.
+    time.sleep(0.05)
+    rc = ir.main(["--diagnose-id", "col-c1"])
+    assert rc == 0
+    bytes_after = out_path.read_bytes()
+    mtime_after = out_path.stat().st_mtime
+    assert bytes_before == bytes_after
+    assert mtime_before == mtime_after
+
+
+def test_cli_diagnose_id_does_not_create_artifact_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """If logs/intelligent_routing/ does not exist, --diagnose-id must
+    not create it."""
+    out_dir = tmp_path / "logs" / "intelligent_routing"
+    out_path = out_dir / "latest.json"
+    monkeypatch.setattr(ir, "OUTPUT_DIR", out_dir)
+    monkeypatch.setattr(ir, "LATEST_OUTPUT_PATH", out_path)
+    rc = ir.main(["--diagnose-id", "col-anything"])
+    assert rc == 0
+    assert not out_dir.exists()
+    assert not out_path.exists()
+
+
+def test_cli_diagnose_id_emits_envelope_on_stdout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    out_dir = tmp_path / "logs" / "intelligent_routing"
+    out_path = out_dir / "latest.json"
+    monkeypatch.setattr(ir, "OUTPUT_DIR", out_dir)
+    monkeypatch.setattr(ir, "LATEST_OUTPUT_PATH", out_path)
+    _write_artifact(out_path, [_decision("col-target")])
+    rc = ir.main(["--diagnose-id", "col-target"])
+    assert rc == 0
+    captured = capsys.readouterr()
+    body = json.loads(captured.out)
+    assert body["report_kind"] == "intelligent_routing_diagnose_id"
+    assert body["target_campaign_id"] == "col-target"
+    assert body["match"]["campaign_id"] == "col-target"
+
+
+def test_cli_diagnose_id_with_write_flag_still_does_not_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--diagnose-id takes precedence over --write; no artifact write
+    occurs even if --write is also passed."""
+    out_dir = tmp_path / "logs" / "intelligent_routing"
+    out_path = out_dir / "latest.json"
+    monkeypatch.setattr(ir, "OUTPUT_DIR", out_dir)
+    monkeypatch.setattr(ir, "LATEST_OUTPUT_PATH", out_path)
+    rc = ir.main(["--diagnose-id", "col-x", "--write"])
+    assert rc == 0
+    assert not out_path.exists()


### PR DESCRIPTION
## Summary

PR-D — final PR of v3.15.16 — **Intelligent Routing Layer (advisory)**. Builds on [#117](https://github.com/roudjy/trading-agent/pull/117), [#118](https://github.com/roudjy/trading-agent/pull/118), [#119](https://github.com/roudjy/trading-agent/pull/119).

Adds the read-only \`--diagnose-id\` CLI surface, a standalone status reporter module, and the smoke test that the CI \`unit (smoke + unit)\` job picks up.

The release framing is unchanged: \`routing_effect = \"advisory_only\"\`, \`queue_ordering_effect = \"none\"\`, no research/** mutation, no campaign queue ordering change.

### What's in this PR

| File | Purpose |
|---|---|
| \`reporting/intelligent_routing.py\` | New \`_diagnose_id(target_campaign_id, *, latest_artifact_path)\`. CLI gains \`--diagnose-id\` flag (read-only; takes precedence over \`--write\`; never writes). |
| \`reporting/intelligent_routing_status.py\` (new, standalone) | \`build_status(*, routing_artifact_path, now_utc)\` — summary envelope (counts by suppression reason / IG bucket / orthogonality bucket) re-stating the advisory framing. CLI \`--no-write\` (default) / \`--write\` semantics. **Does NOT import \`reporting.governance_status\`** (Critical-review item 3). |
| \`tests/unit/test_intelligent_routing_diagnose_id.py\` | 12 tests pinning the diagnose-id schema, no-match / malformed / missing envelopes, and **--diagnose-id never writes** (does not change existing artifact bytes/mtime; does not create the directory). |
| \`tests/integration/test_intelligent_routing_status.py\` | 6 tests pinning bucket counts, missing/malformed artifact handling, CLI \`--no-write\` / \`--write\` semantics, and the no-\`governance_status\`-import invariant via regex on actual import lines. |
| \`tests/smoke/test_intelligent_routing_smoke.py\` | 4 tests picked up by \`tests/run_tests.sh\` and CI \`unit (smoke + unit)\`. |

### Critical-review checks

- **Item 1**: Import-safety / mutation tests use **explicit, targeted** monkeypatch checks (no broad full-tree comparisons).
- **Item 2**: \`--diagnose-id\` never writes. Pinned by tests that verify byte- and mtime-stability of an existing \`latest.json\`, no directory creation when absent, and that \`--diagnose-id --write\` still does not write.
- **Item 3**: \`reporting/intelligent_routing_status.py\` is **standalone**. It does not import \`reporting/governance_status.py\`. Pinned by a regex check on the source.

### Final CLI surface

\`\`\`
# Default — print the routing report; write nothing.
python -m reporting.intelligent_routing
python -m reporting.intelligent_routing --no-write

# Persist the routing report (single file).
python -m reporting.intelligent_routing --write
→ writes logs/intelligent_routing/latest.json

# Read-only diagnose. NEVER writes.
python -m reporting.intelligent_routing --diagnose-id col-target

# Status report (advisory summary).
python -m reporting.intelligent_routing_status
python -m reporting.intelligent_routing_status --no-write
python -m reporting.intelligent_routing_status --write
→ writes logs/intelligent_routing_status/latest.json
\`\`\`

### Hard no-touch envelope respected

No file under \`research/**\`, \`automation/**\`, \`agent/risk/**\`, \`agent/execution/**\`, \`broker/**\`, \`live/**\`, \`paper/**\`, \`shadow/**\`, \`trading/**\`, \`.claude/**\`, \`dashboard/**\`, \`.github/workflows/**\`, or any frozen \`*_latest.v1.json\`. No \`tests/regression/**\` modified. \`reporting/governance_status.py\` not touched (per Critical-review item 3).

## Test plan

- [x] \`python -m pytest tests/unit/test_intelligent_routing_*.py tests/integration/test_intelligent_routing_*.py tests/smoke/test_intelligent_routing_smoke.py -q\` — 136/136 green locally.
- [x] CLI smoke for \`--diagnose-id\` and \`reporting.intelligent_routing_status\`.
- [x] CI fast pre-merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)