### PR TITLE
feat(v3.15.16): governance-bootstrap — observe-intelligent-routing workflow

### DIFF
--- a/.github/workflows/observe-intelligent-routing.yml
+++ b/.github/workflows/observe-intelligent-routing.yml
@@ -1,0 +1,289 @@
+name: Observe v3.15.16 Intelligent Routing (advisory)
+
+# v3.15.16 — observation-only workflow_dispatch surface.
+#
+# Purpose:
+#   Run the already-merged advisory reporting CLIs on the VPS where
+#   the upstream research artifacts exist, then upload the two
+#   resulting JSON files as workflow artifacts so the operator can
+#   inspect the v3.15.16 advisory Intelligent Routing Layer against
+#   real input.
+#
+# Hard guarantees (mirrored from scripts/deploy_vps_dashboard.sh
+# governance posture and the v3.15.16 release framing):
+#
+#   * workflow_dispatch only. No push/pull_request/schedule trigger.
+#   * Zero workflow inputs. No operator-supplied tokens, branches,
+#     paths, or commands. The remote script is hard-coded inline.
+#   * No campaign launcher, research generation, run_research,
+#     docker compose, deploy script, broker, live/paper/shadow/
+#     trading/risk/execution, dashboard or nginx restart.
+#   * The remote CLIs are stdlib-only and write only into
+#     ``logs/intelligent_routing/latest.json`` and
+#     ``logs/intelligent_routing_status/latest.json``.
+#   * Frozen contracts (``research/research_latest.json`` and
+#     ``research/strategy_matrix.csv``) are sha256-pinned BEFORE
+#     and AFTER the CLI run; any drift fails the job.
+#   * Tracked-file changes during the run fail the job.
+#   * Any untracked file outside the two allowed log directories
+#     fails the job.
+#   * The runner uploads exactly the two log files plus the raw
+#     remote stdout transcript as the workflow artifact for audit.
+#   * Secrets (VPS_HOST / VPS_USER / VPS_SSH_KEY) are referenced via
+#     ${{ secrets.* }} only; never echoed; never printed.
+#   * SHA-pinned third-party actions per
+#     docs/governance/sha_pin_review.md.
+#
+# Why a separate workflow (not added to deploy-vps-dashboard.yml):
+#   The deploy workflow's posture is "deploy on push to main only,
+#   no manual escape hatch". Adding observation to it would widen
+#   that surface. A standalone workflow_dispatch entry point keeps
+#   the deploy posture intact and the observation posture explicit.
+#
+# Companion runbook: docs/governance/intelligent_routing_observation.md
+# Related modules:    reporting/intelligent_routing.py,
+#                     reporting/intelligent_routing_status.py
+# Release framing:    routing_effect = "advisory_only"
+#                     queue_ordering_effect = "none"
+
+on:
+  workflow_dispatch:
+    # Intentionally no inputs. The workflow is parameter-free by
+    # design. A future change that adds inputs MUST land in a new
+    # governance-bootstrap PR.
+
+concurrency:
+  group: observe-intelligent-routing
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  observe:
+    name: Observe Intelligent Routing artifact on VPS
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repo (runner-side context only)
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
+        with:
+          # Shallow checkout is fine — the observation work runs on
+          # the VPS, not on this runner. We only need this checkout
+          # so the runner has a workspace for the upload-artifact
+          # step.
+          fetch-depth: 1
+
+      - name: Configure SSH client
+        env:
+          # Pulled via env so the values never appear in the
+          # workflow's shell trace.
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+          VPS_USER: ${{ secrets.VPS_USER }}
+          VPS_SSH_KEY: ${{ secrets.VPS_SSH_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${VPS_HOST}" ] || [ -z "${VPS_USER}" ] || [ -z "${VPS_SSH_KEY}" ]; then
+            echo "missing one or more required secrets: VPS_HOST / VPS_USER / VPS_SSH_KEY"
+            exit 1
+          fi
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          # Write the private key without placing the value on a
+          # command line where another process could observe it.
+          umask 077
+          printf '%s\n' "${VPS_SSH_KEY}" > ~/.ssh/observe_key
+          chmod 600 ~/.ssh/observe_key
+          # Pin the host key. ssh-keyscan is silent on stderr to
+          # avoid leaking VPS_HOST to logs.
+          ssh-keyscan -H -T 10 "${VPS_HOST}" >> ~/.ssh/known_hosts 2>/dev/null
+          chmod 600 ~/.ssh/known_hosts
+          echo "ssh client configured (key + known_hosts)"
+
+      - name: Run observation on VPS
+        env:
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+          VPS_USER: ${{ secrets.VPS_USER }}
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+          # Single fixed SSH command. The remote script is hard-coded
+          # inline via a quoted heredoc so no expansion happens on the
+          # runner. The remote bash is invoked via ``bash -s`` so it
+          # reads the script from stdin; we pass NO arguments.
+          ssh \
+            -i ~/.ssh/observe_key \
+            -o StrictHostKeyChecking=yes \
+            -o BatchMode=yes \
+            -o ConnectTimeout=15 \
+            "${VPS_USER}@${VPS_HOST}" \
+            'bash -s' > artifacts/remote_stdout.txt << 'REMOTE_EOF'
+          set -euo pipefail
+          cd /root/trading-agent
+
+          # Bootstrap to main (mirror deploy-vps-dashboard pattern).
+          # If this first observation lands before the workflow file
+          # is on the VPS, the fetch+reset is what brings it in.
+          git fetch origin main >/dev/null
+          git reset --hard origin/main >/dev/null
+
+          # Pre-snapshot frozen contracts.
+          echo "FROZEN_BEFORE_BEGIN"
+          for f in research/research_latest.json research/strategy_matrix.csv; do
+            if [ -f "$f" ]; then
+              printf '%s  %s\n' "$(sha256sum "$f" | cut -d ' ' -f 1)" "$f"
+            else
+              printf 'absent  %s\n' "$f"
+            fi
+          done
+          echo "FROZEN_BEFORE_END"
+
+          # Pre-CLI git status (must be clean).
+          echo "GIT_STATUS_PRE_BEGIN"
+          git status --short || true
+          echo "GIT_STATUS_PRE_END"
+
+          # Run the advisory CLIs. Both are stdlib-only and write
+          # only inside logs/intelligent_routing[_status]/.
+          python3 -m reporting.intelligent_routing --write > /dev/null
+          python3 -m reporting.intelligent_routing_status --write > /dev/null
+
+          # Post-snapshot frozen contracts.
+          echo "FROZEN_AFTER_BEGIN"
+          for f in research/research_latest.json research/strategy_matrix.csv; do
+            if [ -f "$f" ]; then
+              printf '%s  %s\n' "$(sha256sum "$f" | cut -d ' ' -f 1)" "$f"
+            else
+              printf 'absent  %s\n' "$f"
+            fi
+          done
+          echo "FROZEN_AFTER_END"
+
+          # Post-CLI git status — only logs/intelligent_routing[_status]/*
+          # may be untracked.
+          echo "GIT_STATUS_POST_BEGIN"
+          git status --short || true
+          echo "GIT_STATUS_POST_END"
+
+          # Hard fail on any tracked-file modification.
+          if ! git diff --quiet HEAD --; then
+            echo "FAIL: tracked files modified during observation"
+            exit 2
+          fi
+
+          # Hard fail on any untracked file outside the two allowed
+          # log directories.
+          unexpected="$(git status --short \
+            | grep -vE '^\?\? logs/intelligent_routing(/|_status/)' \
+            | grep -v '^$' || true)"
+          if [ -n "${unexpected}" ]; then
+            echo "FAIL: unexpected untracked files during observation:"
+            printf '%s\n' "${unexpected}"
+            exit 3
+          fi
+
+          # Stream artifact contents back via stdout for the runner
+          # to extract and upload as a workflow artifact.
+          python3 - <<'PY'
+          from pathlib import Path
+
+          allowed = [
+              Path("logs/intelligent_routing/latest.json"),
+              Path("logs/intelligent_routing_status/latest.json"),
+          ]
+          for p in allowed:
+              if not p.exists():
+                  raise SystemExit(f"missing expected artifact: {p}")
+              print(f"ARTIFACT_BEGIN {p}")
+              print(p.read_text(encoding="utf-8"))
+              print(f"ARTIFACT_END {p}")
+          PY
+          REMOTE_EOF
+
+      - name: Extract artifacts from SSH stdout
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/logs/intelligent_routing
+          mkdir -p artifacts/logs/intelligent_routing_status
+          python3 - <<'PY'
+          import re
+          from pathlib import Path
+
+          src = Path("artifacts/remote_stdout.txt").read_text(encoding="utf-8")
+          # Pull every ARTIFACT_BEGIN/END pair. The path label echoed
+          # by the remote script appears on both fences; use it as
+          # the back-reference target so the regex cannot match
+          # across mismatched begin/end markers.
+          pattern = re.compile(
+              r"ARTIFACT_BEGIN\s+(?P<path>\S+)\s*\n"
+              r"(?P<body>.*?)\n?"
+              r"ARTIFACT_END\s+(?P=path)",
+              re.DOTALL,
+          )
+          blocks = list(pattern.finditer(src))
+          if len(blocks) != 2:
+              raise SystemExit(
+                  f"expected 2 artifact blocks, got {len(blocks)}"
+              )
+          for m in blocks:
+              path = m.group("path")
+              body = m.group("body")
+              out = Path("artifacts") / path
+              out.parent.mkdir(parents=True, exist_ok=True)
+              out.write_text(body, encoding="utf-8")
+              print(f"extracted: {out}")
+          PY
+
+      - name: Verify frozen-contract drift on remote
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          from pathlib import Path
+
+          src = Path("artifacts/remote_stdout.txt").read_text(encoding="utf-8")
+
+          def section(label: str) -> dict[str, str]:
+              start_marker = f"FROZEN_{label}_BEGIN"
+              end_marker = f"FROZEN_{label}_END"
+              if start_marker not in src or end_marker not in src:
+                  raise SystemExit(f"missing marker block: {label}")
+              start = src.index(start_marker) + len(start_marker)
+              end = src.index(end_marker)
+              out: dict[str, str] = {}
+              for line in src[start:end].splitlines():
+                  line = line.strip()
+                  if not line or "  " not in line:
+                      continue
+                  digest, path = line.split("  ", 1)
+                  out[path] = digest
+              return out
+
+          before = section("BEFORE")
+          after = section("AFTER")
+          if before != after:
+              raise SystemExit(
+                  f"FROZEN-CONTRACT DRIFT: before={before!r} "
+                  f"after={after!r}"
+              )
+          print("frozen-contract sha256 unchanged across observation:")
+          for path in sorted(before):
+              print(f"  {before[path]}  {path}")
+          PY
+
+      - name: Upload observation artifacts
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808  # v4.3.3
+        with:
+          name: v3-15-16-intelligent-routing-observation
+          path: |
+            artifacts/logs/intelligent_routing/latest.json
+            artifacts/logs/intelligent_routing_status/latest.json
+            artifacts/remote_stdout.txt
+          retention-days: 14
+          if-no-files-found: error
+
+      - name: Wipe SSH artifacts
+        if: always()
+        run: |
+          set -euo pipefail
+          rm -f ~/.ssh/observe_key ~/.ssh/known_hosts || true

--- a/docs/governance/intelligent_routing_observation.md
+++ b/docs/governance/intelligent_routing_observation.md
@@ -1,0 +1,164 @@
+# Intelligent Routing Observation Workflow — Operator Runbook
+
+> Workflow: `.github/workflows/observe-intelligent-routing.yml`
+> Modules:  `reporting/intelligent_routing.py`,
+>           `reporting/intelligent_routing_status.py`
+> Release:  v3.15.16 (advisory)
+> Companion: [`scripts/deploy_vps_dashboard.sh`](../../scripts/deploy_vps_dashboard.sh) (sibling deploy posture, mirrored secrets/SSH pattern)
+
+This is the operator-facing runbook for the v3.15.16 advisory
+Intelligent Routing **observation** workflow. It is the only governed
+path that runs `python -m reporting.intelligent_routing --write` (and
+its `_status` sibling) on the VPS where the upstream research
+artifacts live, then uploads the resulting JSON files as a workflow
+artifact for inspection.
+
+The workflow is **observation-only**. It never alters the trading
+agent, never restarts the dashboard, never deploys anything, and
+never touches research/** beyond the two log files written by the
+already-merged advisory CLIs.
+
+## Core design principle
+
+> The advisory Intelligent Routing artifact is observed against real
+> input only via a parameter-free, fixed-allowlist `workflow_dispatch`
+> entry point. Frozen contracts are sha256-pinned before AND after
+> every run. Any drift fails the job.
+>
+> The CLIs the workflow runs were merged in PRs [#117–#120](https://github.com/roudjy/trading-agent/pulls?q=v3.15.16+is%3Amerged) and
+> already carry their own no-write / `--write` invariants pinned by
+> 136 tests in the v3.15.16 suite.
+
+## TL;DR
+
+```sh
+# Trigger the observation from your local shell:
+gh workflow run observe-intelligent-routing.yml --ref main
+
+# Watch:
+gh run list --workflow=observe-intelligent-routing.yml --limit 1
+gh run watch <run-id>
+
+# Download the artifact (zip with both JSONs + remote_stdout.txt):
+gh run download <run-id> \
+    --name v3-15-16-intelligent-routing-observation \
+    -D ./observation-out
+```
+
+## What the workflow runs on the VPS
+
+A single fixed bash script delivered via SSH. The script accepts no
+arguments. The workflow has no inputs. The remote command list is:
+
+```sh
+cd /root/trading-agent
+git fetch origin main
+git reset --hard origin/main
+
+# pre-snapshot frozen contracts (research_latest.json, strategy_matrix.csv)
+# (sha256, printed to stdout under FROZEN_BEFORE_BEGIN/_END markers)
+
+python3 -m reporting.intelligent_routing --write
+python3 -m reporting.intelligent_routing_status --write
+
+# post-snapshot frozen contracts → must equal pre-snapshot
+# (printed under FROZEN_AFTER_BEGIN/_END)
+
+# git diff --quiet HEAD must succeed (no tracked-file mutation)
+# git status --short must list ONLY untracked entries under
+# logs/intelligent_routing/ or logs/intelligent_routing_status/
+
+# Stream both artifact files back via stdout (ARTIFACT_BEGIN/_END
+# markers) so the runner can re-write them and upload as a workflow
+# artifact.
+```
+
+Anything else is forbidden. The workflow is rejected by review if it
+ever invokes campaign launchers, research generation, `run_research`,
+docker compose, the deploy script, broker / live / paper / shadow /
+trading / risk / execution code, dashboard or nginx restart, or any
+arbitrary command from a workflow input.
+
+## Hard guarantees (enforced by code AND review)
+
+| guarantee | enforcement |
+|---|---|
+| `workflow_dispatch` only — no push / pull_request / schedule | source-text review of the `on:` block |
+| Zero workflow inputs — no operator-supplied tokens / branches / paths / commands | source-text review of the `workflow_dispatch:` block |
+| Remote script is a quoted heredoc — no shell expansion on the runner | `<<'REMOTE_EOF'` (single-quoted terminator) |
+| `python3 -m` only — no `bash -c`, no `eval`, no `os.system`, no `subprocess.run` from input | source-text review |
+| Frozen-contract drift detection (`research_latest.json`, `strategy_matrix.csv`) | sha256 captured before AND after the CLI; mismatch raises `SystemExit` on the runner |
+| Tracked-file mutation detection | `git diff --quiet HEAD` after CLI; non-zero fails job |
+| Untracked-path allowlist | `git status --short` filtered to `logs/intelligent_routing(/|_status/)` only; anything else fails job |
+| SHA-pinned third-party actions | `actions/checkout@b4ffde65…` and `actions/upload-artifact@65462800…` (verified by `scripts/governance_lint.py`) |
+| Secrets never echoed | `${{ secrets.* }}` only; `set -x` not used; `ssh-keyscan` stderr is silenced |
+| Ephemeral SSH key | written with chmod 600 via `umask 077`; wiped in an `if: always()` step |
+| Idempotent | re-running the workflow re-runs the CLIs; the only mutation is to the two `logs/` files, which are gitignored on the VPS too |
+
+## Trigger frequency
+
+Manual only. Use it when you want to take a fresh observation snapshot
+of the advisory artifact against real input. There is no schedule and
+no automatic trigger.
+
+Two consecutive runs against an unchanged upstream input set should
+produce the two artifact JSONs byte-identical modulo `generated_at_utc`
+(stability invariant pinned by the v3.15.16 unit tests).
+
+## Failure modes
+
+| Symptom | Likely cause |
+|---|---|
+| Job fails at "Configure SSH client" with `missing one or more required secrets` | One of `VPS_HOST`, `VPS_USER`, `VPS_SSH_KEY` is unset or empty in repo settings. |
+| Job fails at "Run observation on VPS" with `FAIL: tracked files modified during observation` | A CLI write escaped its expected target path; investigate before re-running. **Do not** rerun until the cause is identified. |
+| Job fails at "Run observation on VPS" with `FAIL: unexpected untracked files during observation` | Some file other than `logs/intelligent_routing[_status]/*` was created on the VPS during the run. **Do not** rerun until the cause is identified. |
+| Job fails at "Verify frozen-contract drift on remote" with `FROZEN-CONTRACT DRIFT` | A frozen contract sha256 changed between the pre- and post-snapshots. **Critical.** Investigate immediately. |
+| `python3` not found on the VPS | The CLIs are stdlib-only and require Python 3.11+. Ubuntu 24.04 ships 3.12 by default; if the VPS lacks `python3`, install before re-running. |
+
+In every failure mode, the runner uploads `artifacts/remote_stdout.txt`
+inside the workflow artifact — that's the canonical post-mortem
+record.
+
+## Where the artifact lands
+
+Workflow artifact name: `v3-15-16-intelligent-routing-observation`
+(retention 14 days). Contents:
+
+```
+artifacts/logs/intelligent_routing/latest.json
+artifacts/logs/intelligent_routing_status/latest.json
+artifacts/remote_stdout.txt
+```
+
+The runtime artifact on the VPS itself is at
+`/root/trading-agent/logs/intelligent_routing/latest.json` and
+`/root/trading-agent/logs/intelligent_routing_status/latest.json`.
+Both are gitignored (`logs/`). The workflow does not commit them.
+
+## Authorization trail
+
+The introduction of this workflow widened `.github/workflows/**`
+beyond the existing seed (deploy + tests + nightly + docker-build).
+The widening is scoped to **exactly** this single observation
+workflow. The operator authorisation that produced this PR is
+recorded in the originating session's chat transcript and in the PR
+description that landed it. Any future addition to
+`.github/workflows/**` requires a new operator authorisation in the
+same form — this doc is not a blanket precedent.
+
+## Relationship to v3.15.16 release framing
+
+The artifact this workflow uploads carries the unchanged v3.15.16
+release framing pinned by the merged code:
+
+- `routing_effect = "advisory_only"`
+- `queue_ordering_effect = "none"`
+
+Observing the artifact against real input is the mandatory
+prerequisite for any future queue-integration discussion. Until this
+workflow has been run on a checkout where the four upstream inputs
+(`research/campaign_queue_latest.v1.json`,
+`research/campaign_registry_latest.v1.json`,
+`research/campaigns/evidence/information_gain_latest.v1.json`,
+`research/campaigns/evidence/dead_zones_latest.v1.json`) are
+present, queue integration MUST NOT be proposed.


### PR DESCRIPTION
## Summary

**Operator-authorized governance-bootstrap PR** that adds a single new GitHub Actions \`workflow_dispatch\` surface so the v3.15.16 advisory Intelligent Routing artifact can be observed against real-input data on the VPS where the upstream research artifacts live.

This is **not** a product feature, **not** queue integration, **not** a deploy workflow, **not** a free-form remote command runner.

### Scope (operator allowlist for this PR only)

| File | Status |
|---|---|
| \`.github/workflows/observe-intelligent-routing.yml\` | **NEW** |
| \`docs/governance/intelligent_routing_observation.md\` | **NEW** |

No other file modified. No existing workflow modified. No deploy script modified. No \`reporting/intelligent_routing*.py\` modified. No \`research/**\`, \`dashboard/**\`, \`.claude/**\`, frozen contract, or \`live/paper/shadow/risk/trading/broker/execution\` path touched.

### Workflow design — hard guarantees

Mirrored from [scripts/deploy_vps_dashboard.sh](scripts/deploy_vps_dashboard.sh) governance posture:

- \`workflow_dispatch\` only — no \`push\` / \`pull_request\` / \`schedule\`.
- **Zero workflow inputs.** No operator-supplied tokens, branches, paths, or commands. Re-uses \`VPS_HOST\` / \`VPS_USER\` / \`VPS_SSH_KEY\` secrets already used by [deploy-vps-dashboard.yml](.github/workflows/deploy-vps-dashboard.yml).
- \`permissions: contents: read\`.
- Single SSH command via a quoted heredoc — no shell expansion on the runner; no dynamic command construction.
- Remote script runs **only**: change directory to the VPS repo root, force-sync the working tree to \`origin/main\` (the same bootstrap pattern the deploy workflow uses), then run the two reporting CLIs (\`intelligent_routing --write\` and \`intelligent_routing_status --write\`), with sha256 pre/post snapshots of \`research_latest.json\` and \`strategy_matrix.csv\` plus a git status check. Never invokes campaign launcher, \`run_research\`, docker compose, deploy script, broker, \`live\`/\`paper\`/\`shadow\`/\`trading\`/\`risk\`/\`execution\`, dashboard or nginx restart.
- **Frozen-contract drift detection.** sha256 captured BEFORE and AFTER the CLI run; mismatch raises \`SystemExit\` on the runner.
- **Tracked-file mutation detection.** \`git diff --quiet HEAD\` after the CLI must succeed; failure raises a hard exit.
- **Untracked-path allowlist.** Only \`logs/intelligent_routing(/|_status/)\` entries are tolerated; anything else fails.
- **SHA-pinned third-party actions** (verified by \`scripts/governance_lint.py\`):
    - \`actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11\`
    - \`actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808\`
- Ephemeral SSH key — written via \`printf\` + redirect with \`chmod 600\` under \`umask 077\`; wiped in an \`if: always()\` step.
- Workflow artifact name \`v3-15-16-intelligent-routing-observation\` (14-day retention) carries exactly:
    - \`artifacts/logs/intelligent_routing/latest.json\`
    - \`artifacts/logs/intelligent_routing_status/latest.json\`
    - \`artifacts/remote_stdout.txt\`

### Companion runbook

[docs/governance/intelligent_routing_observation.md](docs/governance/intelligent_routing_observation.md) documents trigger, failure modes, authorization trail, and the relationship to the v3.15.16 release framing (\`routing_effect = \"advisory_only\"\`, \`queue_ordering_effect = \"none\"\`).

### Local validation (all green)

- \`python scripts/governance_lint.py\` → \"Governance lint OK (16 agents, 5 workflows checked).\"
- \`tests/unit/test_hook_runtime.py\` + \`test_hooks_no_touch.py\` + \`test_agent_audit.py\` → 82 passed
- \`tests/unit/test_approval_policy.py\` + \`test_execution_authority.py\` + \`test_github_pr_lifecycle.py\` + \`test_hooks_outside_allowlist.py\` + \`test_roadmap_execution_protocol.py\` + \`test_vps_deploy_invariants.py\` → 337 passed
- \`tests/smoke\` → 18 passed
- Static grep audit:
    - no \`inputs:\` block under \`workflow_dispatch\`
    - no \`\${{ inputs.* }}\` or \`github.event.inputs.*\` references
    - no docker compose / deploy script / run_research / broker / live / paper / shadow / trading / nginx restart invocation outside disclaimer comments
    - both new files added; no existing file modified.

### After merge

The workflow will be triggered via:

\`\`\`
gh workflow run observe-intelligent-routing.yml --ref main
\`\`\`

The two log artifacts (and the raw remote stdout transcript) will then be downloaded as the workflow artifact for the operator-facing real-input observation report.

## Test plan

- [x] Local: \`python scripts/governance_lint.py\` clean.
- [x] Local: 82 + 337 + 18 = 437 tests pass across hook / approval / execution-authority / PR-lifecycle / outside-allowlist / roadmap / vps-deploy-invariants / smoke suites.
- [x] Static audit: zero workflow inputs; SHA-pinned actions; no forbidden command invocation.
- [x] CI fast pre-merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)