### PR TITLE
fix(v3.15.16): observe workflow — pre/post untracked diff + always-upload

### DIFF
--- a/.github/workflows/observe-intelligent-routing.yml
+++ b/.github/workflows/observe-intelligent-routing.yml
@@ -139,9 +139,16 @@ jobs:
           done
           echo "FROZEN_BEFORE_END"
 
-          # Pre-CLI git status (must be clean).
+          # Pre-CLI git status snapshot. The VPS is a live system
+          # and will legitimately have untracked-non-ignored files
+          # under research/campaigns/, research/discovery_sprints/,
+          # etc. that the trading agent has produced. We do NOT
+          # demand a clean tree; we demand only that the observation
+          # introduces no NEW untracked entries outside the two
+          # allowed log directories.
           echo "GIT_STATUS_PRE_BEGIN"
-          git status --short || true
+          pre_status="$(git status --short || true)"
+          printf '%s\n' "${pre_status}"
           echo "GIT_STATUS_PRE_END"
 
           # Run the advisory CLIs. Both are stdlib-only and write
@@ -160,10 +167,10 @@ jobs:
           done
           echo "FROZEN_AFTER_END"
 
-          # Post-CLI git status — only logs/intelligent_routing[_status]/*
-          # may be untracked.
+          # Post-CLI git status snapshot.
           echo "GIT_STATUS_POST_BEGIN"
-          git status --short || true
+          post_status="$(git status --short || true)"
+          printf '%s\n' "${post_status}"
           echo "GIT_STATUS_POST_END"
 
           # Hard fail on any tracked-file modification.
@@ -172,15 +179,23 @@ jobs:
             exit 2
           fi
 
-          # Hard fail on any untracked file outside the two allowed
-          # log directories.
-          unexpected="$(git status --short \
-            | grep -vE '^\?\? logs/intelligent_routing(/|_status/)' \
+          # Compute NEW untracked entries (post minus pre) and fail
+          # if any new entry lives outside the two allowed log
+          # directories. comm -13 prints lines unique to file 2
+          # (post). Both inputs are sorted for stable comparison.
+          new_entries="$(comm -13 \
+            <(printf '%s\n' "${pre_status}" | sort -u) \
+            <(printf '%s\n' "${post_status}" | sort -u) \
             | grep -v '^$' || true)"
-          if [ -n "${unexpected}" ]; then
-            echo "FAIL: unexpected untracked files during observation:"
-            printf '%s\n' "${unexpected}"
-            exit 3
+          if [ -n "${new_entries}" ]; then
+            unexpected="$(printf '%s\n' "${new_entries}" \
+              | grep -vE '^\?\? logs/intelligent_routing(/|_status/)' \
+              || true)"
+            if [ -n "${unexpected}" ]; then
+              echo "FAIL: unexpected new untracked files during observation:"
+              printf '%s\n' "${unexpected}"
+              exit 3
+            fi
           fi
 
           # Stream artifact contents back via stdout for the runner
@@ -272,6 +287,12 @@ jobs:
           PY
 
       - name: Upload observation artifacts
+        # Always upload — on failure we still want the
+        # remote_stdout.txt transcript for post-mortem. The two
+        # log JSONs may be missing on failure (extraction step
+        # would have skipped); upload-artifact handles per-path
+        # absence gracefully when at least one path is present.
+        if: always()
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808  # v4.3.3
         with:
           name: v3-15-16-intelligent-routing-observation
@@ -280,7 +301,7 @@ jobs:
             artifacts/logs/intelligent_routing_status/latest.json
             artifacts/remote_stdout.txt
           retention-days: 14
-          if-no-files-found: error
+          if-no-files-found: warn
 
       - name: Wipe SSH artifacts
         if: always()


### PR DESCRIPTION
## Summary

Runtime fix to the observation workflow merged in [#121](https://github.com/roudjy/trading-agent/pull/121).

### Symptom

[Workflow run 25454175777](https://github.com/roudjy/trading-agent/actions/runs/25454175777) failed with exit 3 at the post-CLI git status check.

### Root cause

The original check rejected **any** untracked-non-ignored file outside \`logs/intelligent_routing[_status]/\`. The VPS legitimately carries pre-existing untracked-non-ignored files under \`research/campaigns/\`, \`research/discovery_sprints/\`, etc. that the live trading agent emits. Those entries were already there before the observation ran; the check should not reject them.

### Fix

- Snapshot \`git status --short\` BEFORE the CLI run as \`pre_status\` and AFTER as \`post_status\`. Compute new untracked entries via \`comm -13\` on the sorted snapshots. Only **new** entries are checked against the allowlist; pre-existing untracked entries pass.
- Make the upload-artifact step \`if: always()\` so the \`remote_stdout.txt\` transcript is preserved on failure for post-mortem. Switch \`if-no-files-found\` from \`error\` to \`warn\` so a partial-success upload still produces an artifact when only the remote transcript exists.

### What stays the same

- Frozen-contract drift detection (sha256 pre/post on \`research_latest.json\` + \`strategy_matrix.csv\`).
- Tracked-file diff check (\`git diff --quiet HEAD\`).
- Artifact-block round-trip (\`ARTIFACT_BEGIN\`/\`ARTIFACT_END\` markers).
- Allowlist for new untracked entries (\`logs/intelligent_routing(/|_status/)\`).
- Zero workflow inputs.
- \`permissions: contents: read\`.
- SHA-pinned third-party actions.

### Scope

This is a runtime bug-fix to the same single file PR [#121](https://github.com/roudjy/trading-agent/pull/121) introduced, not an expansion of the observation surface. \`git diff main\` shows only \`.github/workflows/observe-intelligent-routing.yml\` changed.

### Validation (all green locally)

- \`python scripts/governance_lint.py\` → \"Governance lint OK (16 agents, 5 workflows checked).\"
- \`python -m pytest tests/unit/test_hook_runtime.py tests/unit/test_hooks_no_touch.py tests/unit/test_vps_deploy_invariants.py tests/smoke -q\` → 122 passed.

## Test plan

- [x] Local governance lint clean.
- [x] Local hook + smoke + vps-deploy-invariants tests green.
- [x] CI fast pre-merge gate.
- [ ] After merge: re-dispatch the workflow on \`main\` and confirm the post-CLI untracked-delta logic correctly tolerates pre-existing untracked entries on the VPS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)