### PR TITLE
feat(v3.15.16): observation workflow — add metadata-shape diagnostic

### DIFF
--- a/.github/workflows/observe-intelligent-routing.yml
+++ b/.github/workflows/observe-intelligent-routing.yml
@@ -156,6 +156,152 @@ jobs:
           python3 -m reporting.intelligent_routing --write > /dev/null
           python3 -m reporting.intelligent_routing_status --write > /dev/null
 
+          # Metadata-shape diagnostic. Reads the upstream registry and
+          # queue artifacts read-only and writes a sanitized summary
+          # (top-level keys + first three records' key-sets + scalar
+          # presence flags) to logs/intelligent_routing/metadata_shape_
+          # diagnostic.json. Truncates every value to a short scalar
+          # preview; never echoes the full payload; never prints
+          # secrets. Pure stdlib.
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          OUT = Path("logs/intelligent_routing/metadata_shape_diagnostic.json")
+          OUT.parent.mkdir(parents=True, exist_ok=True)
+          REGISTRY = Path("research/campaign_registry_latest.v1.json")
+          QUEUE = Path("research/campaign_queue_latest.v1.json")
+          MAX_PREVIEW = 80
+
+          def preview(v):
+              if v is None:
+                  return None
+              if isinstance(v, (bool, int, float)):
+                  return v
+              if isinstance(v, str):
+                  return v if len(v) <= MAX_PREVIEW else v[:MAX_PREVIEW] + "…"
+              if isinstance(v, (list, tuple)):
+                  return f"<{type(v).__name__} len={len(v)}>"
+              if isinstance(v, dict):
+                  return f"<dict keys={sorted(v)[:8]}>"
+              return f"<{type(v).__name__}>"
+
+          def load(path):
+              if not path.exists():
+                  return None
+              try:
+                  data = json.loads(path.read_text(encoding="utf-8"))
+              except json.JSONDecodeError:
+                  return None
+              return data if isinstance(data, dict) else None
+
+          probe_keys = [
+              "campaign_id", "preset_name", "preset", "strategy",
+              "strategy_name", "strategy_family", "family",
+              "asset_class", "timeframe", "interval", "symbol",
+              "universe", "extra", "metadata", "params",
+              "input_artifact_fingerprint", "hypothesis_id",
+          ]
+
+          def record_probe(rec):
+              out = {"keys": sorted(rec.keys())}
+              found = {}
+              for k in probe_keys:
+                  if k in rec:
+                      found[k] = preview(rec[k])
+              out["probe_fields_present"] = found
+              out["probe_fields_missing"] = sorted(
+                  k for k in probe_keys if k not in rec
+              )
+              extra = rec.get("extra")
+              if isinstance(extra, dict):
+                  out["extra_keys"] = sorted(extra.keys())
+                  out["extra_probe"] = {
+                      k: preview(extra[k]) for k in probe_keys if k in extra
+                  }
+              return out
+
+          summary = {
+              "schema_version": "1.0",
+              "report_kind": "intelligent_routing_metadata_shape_diagnostic",
+              "campaign_registry": {"status": "absent"},
+              "campaign_queue": {"status": "absent"},
+              "campaign_id_encoding_hint": (
+                  "campaign_id format from build_campaign_id() is "
+                  "col-{ts}-{preset_name}-{nonce10}; preset_name embeds "
+                  "asset_class and timeframe by convention "
+                  "(e.g. trend_equities_4h_baseline -> equities/4h)."
+              ),
+          }
+
+          reg = load(REGISTRY)
+          if reg is not None:
+              top_keys = sorted(reg.keys())
+              campaigns = reg.get("campaigns")
+              shape = (
+                  "dict" if isinstance(campaigns, dict)
+                  else ("list" if isinstance(campaigns, list)
+                        else type(campaigns).__name__)
+              )
+              record_count = (
+                  len(campaigns) if isinstance(campaigns, (dict, list))
+                  else 0
+              )
+              first_three = []
+              if isinstance(campaigns, dict):
+                  cids = sorted(campaigns.keys())[:3]
+                  for cid in cids:
+                      rec = campaigns[cid]
+                      if isinstance(rec, dict):
+                          probe = record_probe(rec)
+                          probe["campaign_id_from_index"] = cid
+                          first_three.append(probe)
+              elif isinstance(campaigns, list):
+                  for rec in campaigns[:3]:
+                      if isinstance(rec, dict):
+                          first_three.append(record_probe(rec))
+              summary["campaign_registry"] = {
+                  "status": "present",
+                  "top_level_keys": top_keys,
+                  "campaigns_value_type": shape,
+                  "campaigns_record_count": record_count,
+                  "first_three_records": first_three,
+              }
+
+          q = load(QUEUE)
+          if q is not None:
+              top_keys = sorted(q.keys())
+              entries = q.get("queue")
+              shape = type(entries).__name__
+              entry_count = len(entries) if isinstance(entries, list) else 0
+              first_three = []
+              if isinstance(entries, list):
+                  for entry in entries[:3]:
+                      if isinstance(entry, dict):
+                          out = {"keys": sorted(entry.keys())}
+                          out["scalar_preview"] = {
+                              k: preview(entry[k]) for k in entry
+                              if k in (
+                                  "campaign_id", "priority_tier",
+                                  "spawned_at_utc", "state",
+                              )
+                          }
+                          first_three.append(out)
+              summary["campaign_queue"] = {
+                  "status": "present",
+                  "top_level_keys": top_keys,
+                  "queue_value_type": shape,
+                  "queue_entry_count": entry_count,
+                  "first_three_entries": first_three,
+              }
+
+          OUT.write_text(
+              json.dumps(summary, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          print(f"wrote: {OUT}")
+          PY
+
           # Post-snapshot frozen contracts.
           echo "FROZEN_AFTER_BEGIN"
           for f in research/research_latest.json research/strategy_matrix.csv; do
@@ -199,17 +345,28 @@ jobs:
           fi
 
           # Stream artifact contents back via stdout for the runner
-          # to extract and upload as a workflow artifact.
+          # to extract and upload as a workflow artifact. The
+          # metadata-shape diagnostic is optional — included when
+          # present, omitted gracefully when absent.
           python3 - <<'PY'
           from pathlib import Path
 
-          allowed = [
+          required = [
               Path("logs/intelligent_routing/latest.json"),
               Path("logs/intelligent_routing_status/latest.json"),
           ]
-          for p in allowed:
+          optional = [
+              Path("logs/intelligent_routing/metadata_shape_diagnostic.json"),
+          ]
+          for p in required:
               if not p.exists():
                   raise SystemExit(f"missing expected artifact: {p}")
+              print(f"ARTIFACT_BEGIN {p}")
+              print(p.read_text(encoding="utf-8"))
+              print(f"ARTIFACT_END {p}")
+          for p in optional:
+              if not p.exists():
+                  continue
               print(f"ARTIFACT_BEGIN {p}")
               print(p.read_text(encoding="utf-8"))
               print(f"ARTIFACT_END {p}")
@@ -237,9 +394,12 @@ jobs:
               re.DOTALL,
           )
           blocks = list(pattern.finditer(src))
-          if len(blocks) != 2:
+          # Two required artifacts (routing + status) are mandatory;
+          # the metadata-shape diagnostic is optional. Accept 2 or 3
+          # blocks; reject anything outside that range.
+          if len(blocks) not in (2, 3):
               raise SystemExit(
-                  f"expected 2 artifact blocks, got {len(blocks)}"
+                  f"expected 2 or 3 artifact blocks, got {len(blocks)}"
               )
           for m in blocks:
               path = m.group("path")
@@ -298,6 +458,7 @@ jobs:
           name: v3-15-16-intelligent-routing-observation
           path: |
             artifacts/logs/intelligent_routing/latest.json
+            artifacts/logs/intelligent_routing/metadata_shape_diagnostic.json
             artifacts/logs/intelligent_routing_status/latest.json
             artifacts/remote_stdout.txt
           retention-days: 14

--- a/docs/governance/intelligent_routing_observation.md
+++ b/docs/governance/intelligent_routing_observation.md
@@ -126,9 +126,19 @@ Workflow artifact name: `v3-15-16-intelligent-routing-observation`
 
 ```
 artifacts/logs/intelligent_routing/latest.json
+artifacts/logs/intelligent_routing/metadata_shape_diagnostic.json   # optional
 artifacts/logs/intelligent_routing_status/latest.json
 artifacts/remote_stdout.txt
 ```
+
+The optional `metadata_shape_diagnostic.json` is a **sanitized**
+preview of the shape of the upstream registry + queue artifacts. It
+lists top-level keys, the value-type of `campaigns` (`dict` vs
+`list`), the record count, and the **key sets** of the first three
+records along with **scalar previews** (≤ 80 chars; no full payload;
+no secrets). It is purely diagnostic — used to confirm what fields
+the routing layer can safely index without inferring metadata from
+`campaign_id`.
 
 The runtime artifact on the VPS itself is at
 `/root/trading-agent/logs/intelligent_routing/latest.json` and


### PR DESCRIPTION
## Summary

Stage 2 of the metadata-gap diagnostic. The first real-input observation ([run 25454835978](https://github.com/roudjy/trading-agent/actions/runs/25454835978)) produced 23 decisions, all with \`behavior_coordinates: (unknown, unknown, unknown)\` and \`preset_name: unknown\`. Local Stage-1 code inspection found the smoking gun:

- [research/campaign_registry.py:246, 273-274, 287, 295](research/campaign_registry.py:246) writes \`{\"campaigns\": {<campaign_id>: {<record>}}}\` (a **dict** keyed by campaign_id).
- [reporting/intelligent_routing.py:640](reporting/intelligent_routing.py:640) \`_index_registry\` only handles a **list** shape: \`if not isinstance(records, list): return {}\`.
- Existing tests use list-shaped fixtures (e.g. [tests/unit/test_intelligent_routing_advisory_priority.py:163](tests/unit/test_intelligent_routing_advisory_priority.py:163)) so the bug never surfaced.

This PR extends the existing governed observation workflow with a **narrow, fixed, no-input metadata-shape diagnostic step** that emits a sanitized JSON summary. It does **not** modify \`reporting/\` — the routing fix lands in a separate scoped PR after the VPS shape is confirmed empirically.

### What's added

| File | Status |
|---|---|
| \`.github/workflows/observe-intelligent-routing.yml\` | extended (one new diagnostic block + 1-line allowlist update for the new artifact filename + extract step accepts 2 or 3 blocks) |
| \`docs/governance/intelligent_routing_observation.md\` | extended (documents the new optional artifact) |

### Diagnostic payload (sanitized, scalar previews ≤ 80 chars, never secrets, never full payloads)

\`\`\`
campaign_registry:
  - top-level keys
  - campaigns_value_type (dict | list | other)
  - campaigns_record_count
  - first 3 records' key sets + probe-field presence/preview for:
    campaign_id, preset_name, preset, strategy, strategy_name,
    strategy_family, family, asset_class, timeframe, interval,
    symbol, universe, extra, metadata, params,
    input_artifact_fingerprint, hypothesis_id

campaign_queue:
  - top-level keys
  - queue_value_type
  - queue_entry_count
  - first 3 entries' key sets + scalar previews of campaign_id,
    priority_tier, spawned_at_utc, state

campaign_id_encoding_hint: documents the col-{ts}-{preset_name}-{nonce10}
convention so any future fallback parser is explicit and auditable.
\`\`\`

### Hard guarantees preserved

- \`workflow_dispatch\` only — no push/pull_request/schedule.
- **Zero workflow inputs** still.
- Single SSH command via the same quoted heredoc.
- \`permissions: contents: read\`.
- Only \`logs/intelligent_routing/**\` and \`logs/intelligent_routing_status/**\` are writable on the VPS. The new diagnostic file lives in the first dir → existing untracked-delta allowlist passes without changes.
- Frozen-contract sha256 pre/post still runs; mismatch fails.
- Tracked-file mutation check still runs.
- SHA-pinned third-party actions unchanged.
- Extract step now accepts 2 or 3 artifact blocks (the third = diagnostic when present); rejects any other count.

### Validation (all green locally)

- \`python scripts/governance_lint.py\` → \"Governance lint OK (16 agents, 5 workflows checked).\"
- \`git diff main\` shows only the two authorized files.

### After merge

Dispatch via \`gh workflow run observe-intelligent-routing.yml --ref main\`. The diagnostic JSON will be inside the workflow artifact at \`artifacts/logs/intelligent_routing/metadata_shape_diagnostic.json\` and will inform the (separately scoped) \`reporting/intelligent_routing.py\` mapping fix.

## Test plan

- [x] Local governance lint clean.
- [x] Static review of the diagnostic Python: stdlib-only, no \`subprocess\`, no \`os.system\`, no operator-supplied input, scalar-preview truncation, no full payload print.
- [x] CI fast pre-merge gate.
- [ ] After merge: dispatch and confirm \`metadata_shape_diagnostic.json\` lands in the workflow artifact and the routing CLIs still succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)