### PR TITLE
fix(v3.15.16): metadata mapping — accept production dict shape + preset-catalog timeframe

### DIFF
--- a/reporting/intelligent_routing.py
+++ b/reporting/intelligent_routing.py
@@ -211,6 +211,27 @@ SUPPRESSED_PRIORITY_SCORE: Final[int] = -1
 # ---------------------------------------------------------------------------
 
 
+#: Provenance labels for ``BehaviorCoordinates.derivation_source``.
+#: ``registry`` — every coordinate field came directly from the
+#: campaign registry record. ``preset_catalog`` — at least one
+#: coordinate (typically ``timeframe``, which the registry record
+#: does not carry) was populated from the in-memory
+#: ``research.presets.PRESETS`` catalog by ``preset_name`` lookup.
+#: ``missing`` — at least one coordinate stayed ``unknown`` after
+#: every available source was tried. ``unknown`` is the dataclass
+#: default before derivation runs.
+DERIVATION_REGISTRY: Final[str] = "registry"
+DERIVATION_PRESET_CATALOG: Final[str] = "preset_catalog"
+DERIVATION_MISSING: Final[str] = "missing"
+
+DERIVATION_SOURCES: Final[tuple[str, ...]] = (
+    DERIVATION_REGISTRY,
+    DERIVATION_PRESET_CATALOG,
+    DERIVATION_MISSING,
+    UNKNOWN_COORDINATE,
+)
+
+
 @dataclasses.dataclass(frozen=True)
 class BehaviorCoordinates:
     """Provisional deterministic routing coordinates.
@@ -218,12 +239,16 @@ class BehaviorCoordinates:
     Not a behavior taxonomy. Not final tags. Derived from existing
     metadata only. The ``provisional`` boolean is part of the artifact
     so a reader is reminded of the framing.
+
+    ``derivation_source`` records which source(s) populated the
+    coordinate fields. See ``DERIVATION_SOURCES`` for the closed list.
     """
 
     family: str
     asset_class: str
     timeframe: str
     provisional: bool = True
+    derivation_source: str = UNKNOWN_COORDINATE
 
     def to_payload(self) -> dict[str, object]:
         return {
@@ -231,6 +256,7 @@ class BehaviorCoordinates:
             "asset_class": self.asset_class,
             "timeframe": self.timeframe,
             "provisional": self.provisional,
+            "derivation_source": self.derivation_source,
         }
 
     def as_tuple(self) -> tuple[str, str, str]:
@@ -359,6 +385,7 @@ def derive_behavior_coordinates(
     strategy_family: object = None,
     asset_class: object = None,
     timeframe: object = None,
+    derivation_source: str = UNKNOWN_COORDINATE,
 ) -> BehaviorCoordinates:
     """Pure derivation of the provisional 3-tuple from existing metadata.
 
@@ -366,12 +393,18 @@ def derive_behavior_coordinates(
     ``UNKNOWN_COORDINATE``. The ``provisional`` flag is always True so
     downstream readers cannot mistake the coordinates for final
     behavior tags.
+
+    ``derivation_source`` records the provenance label (one of
+    ``DERIVATION_SOURCES``). Callers that derive coordinates from
+    multiple sources use a label like ``DERIVATION_PRESET_CATALOG``
+    when at least one field came from ``research.presets``.
     """
     return BehaviorCoordinates(
         family=_safe_str(strategy_family),
         asset_class=_safe_str(asset_class),
         timeframe=_safe_str(timeframe),
         provisional=True,
+        derivation_source=derivation_source,
     )
 
 
@@ -630,24 +663,99 @@ def _index_registry(
 ) -> dict[str, dict[str, Any]]:
     """Project the registry payload to ``{campaign_id: record_dict}``.
 
+    Production writer (``research.campaign_registry.write_registry``)
+    stores ``"campaigns"`` as a **dict** keyed by ``campaign_id``.
+    Older test fixtures used the **list** shape; both are accepted.
+    The legacy ``"registry"`` top-level key is also accepted as a
+    fallback for forward-compat.
+
     Tolerates absent / malformed payloads. Read-only.
     """
     if not registry_payload:
         return {}
-    records = registry_payload.get("campaigns") or registry_payload.get(
-        "registry"
-    ) or []
-    if not isinstance(records, list):
-        return {}
     out: dict[str, dict[str, Any]] = {}
-    for rec in records:
-        if not isinstance(rec, dict):
-            continue
-        cid = rec.get("campaign_id")
-        if not isinstance(cid, str) or not cid:
-            continue
-        out[cid] = rec
+
+    def _ingest(value: Any) -> None:
+        if isinstance(value, dict):
+            # Production shape: {campaign_id: {<record>}}.
+            for cid, rec in value.items():
+                if not isinstance(rec, dict) or not isinstance(cid, str):
+                    continue
+                if not cid:
+                    continue
+                # Trust the index key when a record's own
+                # ``campaign_id`` differs (the index key is the canonical
+                # identity per ``write_registry`` sort).
+                out[cid] = rec
+        elif isinstance(value, list):
+            # Test-fixture shape: [{campaign_id, ...}, ...].
+            for rec in value:
+                if not isinstance(rec, dict):
+                    continue
+                cid = rec.get("campaign_id")
+                if isinstance(cid, str) and cid:
+                    out[cid] = rec
+
+    _ingest(registry_payload.get("campaigns"))
+    if not out:
+        _ingest(registry_payload.get("registry"))
     return out
+
+
+# ---------------------------------------------------------------------------
+# Lazy preset-catalog lookup (PR-E — Stage 4 fix for v3.15.16)
+# ---------------------------------------------------------------------------
+
+#: Module-level cache of the {preset_name: {"timeframe": "<value>"}}
+#: projection. Populated at first call to ``_preset_lookup`` so module
+#: import remains I/O-free (the ``test_intelligent_routing_import_safety``
+#: pin still holds: importing the module never opens any file in write
+#: mode and never pulls forbidden modules). ``research.presets`` is a
+#: pure-data module of frozen dataclasses; importing it lazily here is
+#: a read-only consumption matching the v3.15.16 advisory framing.
+_PRESET_LOOKUP_CACHE: dict[str, dict[str, str]] | None = None
+
+
+def _preset_lookup() -> dict[str, dict[str, str]]:
+    """Return ``{preset_name: {"timeframe": str}}`` from
+    ``research.presets.PRESETS``.
+
+    Lazy-imported and cached. If the import fails for any reason,
+    returns an empty mapping; the caller falls back to ``unknown``.
+    Pure-read; never raises.
+    """
+    global _PRESET_LOOKUP_CACHE
+    if _PRESET_LOOKUP_CACHE is not None:
+        return _PRESET_LOOKUP_CACHE
+    out: dict[str, dict[str, str]] = {}
+    try:
+        from research.presets import PRESETS  # local import — see docstring
+    except Exception:  # noqa: BLE001 — defensive: lookup must never raise
+        _PRESET_LOOKUP_CACHE = out
+        return out
+    for preset in PRESETS:
+        try:
+            name = str(getattr(preset, "name", ""))
+            timeframe = str(getattr(preset, "timeframe", ""))
+        except (AttributeError, TypeError):
+            continue
+        if not name:
+            continue
+        entry: dict[str, str] = {}
+        if timeframe:
+            entry["timeframe"] = timeframe
+        if entry:
+            out[name] = entry
+    _PRESET_LOOKUP_CACHE = out
+    return out
+
+
+def _reset_preset_lookup_cache_for_tests() -> None:
+    """Test seam: clear the preset-catalog cache. Called only by
+    tests that need to verify the lookup-failure path explicitly.
+    """
+    global _PRESET_LOOKUP_CACHE
+    _PRESET_LOOKUP_CACHE = None
 
 
 def _index_dead_zones(
@@ -725,37 +833,94 @@ def _coords_for_campaign(
 ) -> tuple[BehaviorCoordinates, str, str | None, bool]:
     """Return (coords, preset_name, fingerprint, has_full_metadata).
 
-    ``has_full_metadata`` is False when at least one of the three
-    coordinate fields was missing or empty in the registry record —
-    used to populate ``summary.metadata_gaps``.
+    Source-of-truth order (Stage 4 metadata-mapping fix):
+
+    1. **Registry record** — ``strategy_family``, ``asset_class``, and
+       (rarely) ``timeframe`` / ``interval`` come from the registry
+       record's own fields. The production registry record on the VPS
+       does **not** carry ``timeframe`` / ``interval`` directly; the
+       record's ``extra`` is typically empty.
+    2. **Preset catalog** — when ``timeframe`` is missing from the
+       registry record, look it up by ``preset_name`` in
+       ``research.presets.PRESETS``. The catalog's ``timeframe`` field
+       is the canonical run-time setting (e.g. ``"4h"`` /  ``"1h"`` /
+       ``"1d"``). This is **not** parsing the campaign_id; it is
+       reading a real registry-side artifact field (``preset_name``)
+       and joining it against an in-memory frozen catalog.
+
+    ``has_full_metadata`` is True iff all three coordinate fields are
+    populated after the lookups above. ``coords.derivation_source``
+    records which sources contributed.
     """
     rec = registry_index.get(cid, {})
-    family = rec.get("strategy_family")
-    asset_class = rec.get("asset_class")
+    raw_family = rec.get("strategy_family")
+    raw_asset_class = rec.get("asset_class")
     extra = rec.get("extra") if isinstance(rec.get("extra"), dict) else {}
-    timeframe = (
+    raw_timeframe = (
         rec.get("timeframe")
         or rec.get("interval")
         or extra.get("timeframe")
         or extra.get("interval")
     )
-    coords = derive_behavior_coordinates(
-        strategy_family=family,
+
+    raw_preset_name = rec.get("preset_name")
+    preset_name_str = (
+        raw_preset_name
+        if isinstance(raw_preset_name, str) and raw_preset_name
+        else None
+    )
+
+    # Step 2: preset-catalog fallback for timeframe only.
+    used_preset_catalog = False
+    if not raw_timeframe and preset_name_str is not None:
+        catalog = _preset_lookup()
+        catalog_entry = catalog.get(preset_name_str, {})
+        catalog_timeframe = catalog_entry.get("timeframe")
+        if catalog_timeframe:
+            raw_timeframe = catalog_timeframe
+            used_preset_catalog = True
+
+    # Compute provisional coords.
+    family = _safe_str(raw_family)
+    asset_class = _safe_str(raw_asset_class)
+    timeframe = _safe_str(raw_timeframe)
+
+    has_full = (
+        family != UNKNOWN_COORDINATE
+        and asset_class != UNKNOWN_COORDINATE
+        and timeframe != UNKNOWN_COORDINATE
+    )
+
+    # Compute the derivation_source label. Order:
+    #   * "missing" if any coord stayed unknown after fallback.
+    #   * "preset_catalog" if the preset-catalog filled at least one
+    #     field (currently only timeframe).
+    #   * "registry" otherwise (every coord came from the registry
+    #     record fields directly).
+    if not has_full:
+        source = DERIVATION_MISSING
+    elif used_preset_catalog:
+        source = DERIVATION_PRESET_CATALOG
+    else:
+        source = DERIVATION_REGISTRY
+
+    coords = BehaviorCoordinates(
+        family=family,
         asset_class=asset_class,
         timeframe=timeframe,
+        provisional=True,
+        derivation_source=source,
     )
-    has_full = (
-        coords.family != UNKNOWN_COORDINATE
-        and coords.asset_class != UNKNOWN_COORDINATE
-        and coords.timeframe != UNKNOWN_COORDINATE
+
+    preset_name_out = preset_name_str if preset_name_str else UNKNOWN_COORDINATE
+
+    fingerprint_raw = rec.get("input_artifact_fingerprint")
+    fingerprint = (
+        fingerprint_raw
+        if isinstance(fingerprint_raw, str) and fingerprint_raw
+        else None
     )
-    preset_name = rec.get("preset_name")
-    if not isinstance(preset_name, str) or not preset_name:
-        preset_name = UNKNOWN_COORDINATE
-    fingerprint = rec.get("input_artifact_fingerprint")
-    if not isinstance(fingerprint, str) or not fingerprint:
-        fingerprint = None
-    return coords, preset_name, fingerprint, has_full
+    return coords, preset_name_out, fingerprint, has_full
 
 
 # ---------------------------------------------------------------------------
@@ -1191,6 +1356,10 @@ __all__ = [
     "DEAD_ZONE_STATUSES",
     "DEAD_ZONE_UNKNOWN",
     "DEAD_ZONE_WEAK",
+    "DERIVATION_MISSING",
+    "DERIVATION_PRESET_CATALOG",
+    "DERIVATION_REGISTRY",
+    "DERIVATION_SOURCES",
     "DIAGNOSE_REPORT_KIND",
     "IG_BUCKET_HIGH_FLOOR",
     "IG_BUCKET_MEDIUM_FLOOR",

--- a/tests/unit/test_intelligent_routing_registry_shape.py
+++ b/tests/unit/test_intelligent_routing_registry_shape.py
@@ -1,0 +1,439 @@
+"""PR-E (v3.15.16 metadata-mapping fix) — registry shape + preset
+catalog fallback tests.
+
+Pins the Stage-4 fix to the metadata-gap diagnostic:
+
+* ``_index_registry`` accepts BOTH the production dict shape
+  (``{campaigns: {campaign_id: {<record>}}}`` per
+  ``research.campaign_registry.write_registry``) AND the legacy
+  list shape used by older fixtures.
+* ``_coords_for_campaign`` populates ``timeframe`` from
+  ``research.presets.PRESETS`` when the registry record does not
+  carry a ``timeframe`` field directly.
+* ``BehaviorCoordinates.derivation_source`` records which source
+  (``registry`` / ``preset_catalog`` / ``missing``) supplied the
+  coordinates.
+* Reading the production-shape fixture closes the metadata-gap on
+  every campaign whose ``preset_name`` is in the in-memory catalog.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+from pathlib import Path
+
+import pytest
+
+from reporting import intelligent_routing as ir
+from research.presets import PRESETS as _PRODUCTION_PRESETS
+
+
+# ---------------------------------------------------------------------------
+# Closed-vocabulary pin for derivation labels
+# ---------------------------------------------------------------------------
+
+
+def test_derivation_constants_pinned() -> None:
+    assert ir.DERIVATION_REGISTRY == "registry"
+    assert ir.DERIVATION_PRESET_CATALOG == "preset_catalog"
+    assert ir.DERIVATION_MISSING == "missing"
+    assert ir.UNKNOWN_COORDINATE in ir.DERIVATION_SOURCES
+    assert set(ir.DERIVATION_SOURCES) == {
+        "registry", "preset_catalog", "missing", "unknown",
+    }
+
+
+# ---------------------------------------------------------------------------
+# _index_registry — both shapes accepted
+# ---------------------------------------------------------------------------
+
+
+_RECORD_KEY = "col-20260503T100002576157Z-trend_equities_4h_baseline-43b53a7d29"
+_RECORD_PAYLOAD = {
+    "campaign_id": _RECORD_KEY,
+    "preset_name": "trend_equities_4h_baseline",
+    "asset_class": "equity",
+    "strategy_family": None,
+    "input_artifact_fingerprint": (
+        "ce4e87ebd0072f6d6491704b6eff2dea430ff050de498c288336a7396e67b5d9"
+    ),
+    "extra": {},
+    "spawned_at_utc": "2026-05-03T10:00:02.576157Z",
+}
+
+
+def test_index_registry_accepts_production_dict_shape() -> None:
+    """Production writer (research.campaign_registry.write_registry)
+    stores ``campaigns`` as a dict keyed by campaign_id."""
+    payload = {
+        "schema_version": "1.0",
+        "campaigns": {_RECORD_KEY: _RECORD_PAYLOAD},
+    }
+    out = ir._index_registry(payload)
+    assert _RECORD_KEY in out
+    assert out[_RECORD_KEY] == _RECORD_PAYLOAD
+
+
+def test_index_registry_accepts_legacy_list_shape() -> None:
+    """Legacy fixture form: campaigns as a list of records."""
+    payload = {
+        "schema_version": "1.0",
+        "campaigns": [_RECORD_PAYLOAD],
+    }
+    out = ir._index_registry(payload)
+    assert _RECORD_KEY in out
+    assert out[_RECORD_KEY] == _RECORD_PAYLOAD
+
+
+def test_index_registry_dict_with_mismatched_inner_id_uses_index_key() -> None:
+    """When the index key disagrees with the record's own
+    campaign_id field, the index key is canonical."""
+    rec = dict(_RECORD_PAYLOAD)
+    rec["campaign_id"] = "col-WHATEVER"  # mismatched
+    payload = {"campaigns": {_RECORD_KEY: rec}}
+    out = ir._index_registry(payload)
+    assert _RECORD_KEY in out
+    assert "col-WHATEVER" not in out
+
+
+def test_index_registry_legacy_top_level_registry_key_dict() -> None:
+    payload = {"registry": {_RECORD_KEY: _RECORD_PAYLOAD}}
+    out = ir._index_registry(payload)
+    assert _RECORD_KEY in out
+
+
+def test_index_registry_legacy_top_level_registry_key_list() -> None:
+    payload = {"registry": [_RECORD_PAYLOAD]}
+    out = ir._index_registry(payload)
+    assert _RECORD_KEY in out
+
+
+def test_index_registry_skips_non_dict_records() -> None:
+    payload = {"campaigns": {_RECORD_KEY: "oops not a dict"}}
+    out = ir._index_registry(payload)
+    assert out == {}
+
+
+def test_index_registry_skips_empty_or_non_string_keys() -> None:
+    payload = {"campaigns": {"": _RECORD_PAYLOAD, 42: _RECORD_PAYLOAD}}
+    out = ir._index_registry(payload)
+    assert out == {}
+
+
+def test_index_registry_handles_neither_key() -> None:
+    payload = {"schema_version": "1.0"}
+    out = ir._index_registry(payload)
+    assert out == {}
+
+
+# ---------------------------------------------------------------------------
+# _preset_lookup — populated from research.presets.PRESETS
+# ---------------------------------------------------------------------------
+
+
+def test_preset_lookup_populated_from_real_catalog() -> None:
+    """The lookup returns ``{name: {"timeframe": str}}`` for every
+    preset in the canonical PRESETS catalog."""
+    ir._reset_preset_lookup_cache_for_tests()
+    out = ir._preset_lookup()
+    expected_names = {str(p.name) for p in _PRODUCTION_PRESETS}
+    actual_names = set(out)
+    # All real preset names are present; any extra catalog-internal
+    # presets are tolerated.
+    assert expected_names.issubset(actual_names), (
+        f"missing presets: {expected_names - actual_names!r}"
+    )
+    # Every entry carries a non-empty timeframe.
+    for name, entry in out.items():
+        assert "timeframe" in entry, name
+        assert entry["timeframe"], name
+
+
+def test_preset_lookup_is_cached() -> None:
+    """Two consecutive calls return the same dict object."""
+    ir._reset_preset_lookup_cache_for_tests()
+    a = ir._preset_lookup()
+    b = ir._preset_lookup()
+    assert a is b
+
+
+# ---------------------------------------------------------------------------
+# _coords_for_campaign — derivation_source labels
+# ---------------------------------------------------------------------------
+
+
+def test_coords_full_registry_yields_registry_source() -> None:
+    """When the registry record carries family + asset_class +
+    timeframe directly, derivation_source == 'registry'."""
+    rec = {
+        "campaign_id": "col-x",
+        "preset_name": "preset_x",
+        "strategy_family": "ema_crossover",
+        "asset_class": "crypto",
+        "timeframe": "4h",
+        "input_artifact_fingerprint": "abcd1234",
+    }
+    index = {"col-x": rec}
+    coords, preset_name, fp, has_full = ir._coords_for_campaign(
+        "col-x", index,
+    )
+    assert coords.family == "ema_crossover"
+    assert coords.asset_class == "crypto"
+    assert coords.timeframe == "4h"
+    assert coords.derivation_source == "registry"
+    assert preset_name == "preset_x"
+    assert fp == "abcd1234"
+    assert has_full is True
+
+
+def test_coords_production_record_uses_preset_catalog_for_timeframe() -> None:
+    """Production registry records carry preset_name + asset_class
+    but NOT timeframe. The preset-catalog lookup fills timeframe;
+    derivation_source becomes 'preset_catalog'."""
+    # Use a real preset name from the live catalog.
+    real_preset = next(p for p in _PRODUCTION_PRESETS)
+    rec = {
+        "campaign_id": "col-y",
+        "preset_name": real_preset.name,
+        "asset_class": "equity",
+        "strategy_family": "ema_crossover",
+        # NB: no timeframe / interval; extra empty.
+        "extra": {},
+        "input_artifact_fingerprint": "ffff0000",
+    }
+    index = {"col-y": rec}
+    ir._reset_preset_lookup_cache_for_tests()
+    coords, preset_name, fp, has_full = ir._coords_for_campaign(
+        "col-y", index,
+    )
+    assert coords.family == "ema_crossover"
+    assert coords.asset_class == "equity"
+    assert coords.timeframe == real_preset.timeframe
+    assert coords.derivation_source == "preset_catalog"
+    assert preset_name == real_preset.name
+    assert has_full is True
+
+
+def test_coords_unknown_preset_yields_missing() -> None:
+    """When the registry record's preset_name is not in the catalog
+    AND no timeframe field exists, derivation_source == 'missing'
+    and timeframe stays unknown."""
+    rec = {
+        "campaign_id": "col-z",
+        "preset_name": "preset_does_not_exist_anywhere",
+        "asset_class": "crypto",
+        "strategy_family": "ema_crossover",
+        "extra": {},
+        "input_artifact_fingerprint": "deadbeef",
+    }
+    index = {"col-z": rec}
+    coords, preset_name, fp, has_full = ir._coords_for_campaign(
+        "col-z", index,
+    )
+    assert coords.timeframe == "unknown"
+    assert coords.derivation_source == "missing"
+    assert has_full is False
+
+
+def test_coords_extra_timeframe_takes_priority_over_preset_catalog() -> None:
+    """When the registry record's ``extra`` carries a timeframe
+    explicitly, it wins over the preset-catalog fallback."""
+    real_preset = next(p for p in _PRODUCTION_PRESETS)
+    rec = {
+        "campaign_id": "col-w",
+        "preset_name": real_preset.name,
+        "asset_class": "crypto",
+        "strategy_family": "ema_crossover",
+        "extra": {"timeframe": "1d"},  # NOT real_preset.timeframe
+        "input_artifact_fingerprint": "abcd",
+    }
+    index = {"col-w": rec}
+    coords, _preset_name, _fp, has_full = ir._coords_for_campaign(
+        "col-w", index,
+    )
+    assert coords.timeframe == "1d"  # extra wins
+    assert coords.derivation_source == "registry"  # registry source
+    assert has_full is True
+
+
+def test_coords_missing_record_yields_missing() -> None:
+    """No record at all → coords are all unknown,
+    derivation_source == 'missing'."""
+    coords, preset_name, fp, has_full = ir._coords_for_campaign(
+        "col-not-in-index", {},
+    )
+    assert coords.family == "unknown"
+    assert coords.asset_class == "unknown"
+    assert coords.timeframe == "unknown"
+    assert coords.derivation_source == "missing"
+    assert preset_name == "unknown"
+    assert fp is None
+    assert has_full is False
+
+
+# ---------------------------------------------------------------------------
+# build_report — full pipeline using a production-shape fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fixed_now_utc() -> _dt.datetime:
+    return _dt.datetime(2026, 5, 6, 12, 0, 0, tzinfo=_dt.timezone.utc)
+
+
+def _write(tmp_path: Path, queue, registry, dz, ig) -> dict[str, Path]:
+    paths = {
+        "queue": tmp_path / "q.json",
+        "registry": tmp_path / "r.json",
+        "dead_zones": tmp_path / "d.json",
+        "ig": tmp_path / "i.json",
+    }
+    paths["queue"].write_text(json.dumps(queue), encoding="utf-8")
+    paths["registry"].write_text(json.dumps(registry), encoding="utf-8")
+    paths["dead_zones"].write_text(json.dumps(dz), encoding="utf-8")
+    paths["ig"].write_text(json.dumps(ig), encoding="utf-8")
+    return paths
+
+
+def test_build_report_against_production_shape_closes_metadata_gap(
+    tmp_path: Path, fixed_now_utc: _dt.datetime,
+) -> None:
+    """Build a report from a fixture mirroring the production VPS
+    shape (dict-keyed campaigns, registry records carrying
+    preset_name/asset_class/strategy_family but NOT timeframe).
+    Assert the metadata gap is closed for the rows whose preset is
+    in the canonical catalog."""
+    real_preset = next(
+        p for p in _PRODUCTION_PRESETS if p.timeframe and p.name
+    )
+    queue = {
+        "schema_version": "1.0",
+        "queue": [
+            {
+                "campaign_id": "col-real",
+                "priority_tier": 2,
+                "spawned_at_utc": "2026-05-06T10:00:00+00:00",
+                "state": "pending",
+            },
+        ],
+    }
+    registry = {
+        "schema_version": "1.0",
+        # Production dict shape.
+        "campaigns": {
+            "col-real": {
+                "campaign_id": "col-real",
+                "preset_name": real_preset.name,
+                "asset_class": "crypto",
+                "strategy_family": "ema_crossover",
+                "extra": {},
+                "input_artifact_fingerprint": "feedface",
+                "spawned_at_utc": "2026-05-06T10:00:00+00:00",
+            },
+        },
+    }
+    paths = _write(tmp_path, queue, registry, {"zones": []}, {})
+    report = ir.build_report(
+        now_utc=fixed_now_utc,
+        queue_path=paths["queue"],
+        registry_path=paths["registry"],
+        dead_zones_path=paths["dead_zones"],
+        information_gain_path=paths["ig"],
+    )
+    assert report.summary.total == 1
+    # Metadata gap is closed: the preset-catalog filled in timeframe.
+    assert report.summary.metadata_gaps == 0
+    decision = report.decisions[0]
+    coords = decision.behavior_coordinates
+    assert coords.family == "ema_crossover"
+    assert coords.asset_class == "crypto"
+    assert coords.timeframe == real_preset.timeframe
+    assert coords.derivation_source == "preset_catalog"
+    payload = decision.to_payload()
+    coord_payload = payload["behavior_coordinates"]
+    assert coord_payload["derivation_source"] == "preset_catalog"
+    assert coord_payload["provisional"] is True
+    # Framing intact.
+    full_payload = report.to_payload()
+    assert full_payload["routing_effect"] == "advisory_only"
+    assert full_payload["queue_ordering_effect"] == "none"
+
+
+def test_build_report_legacy_list_shape_still_works(
+    tmp_path: Path, fixed_now_utc: _dt.datetime,
+) -> None:
+    """Backwards-compatibility: pre-PR-E fixtures using the legacy
+    list-shape registry must still index correctly."""
+    queue = {
+        "queue": [
+            {"campaign_id": "col-legacy", "spawned_at_utc": "2026-05-06T10:00:00+00:00"},
+        ],
+    }
+    registry = {
+        "campaigns": [
+            {
+                "campaign_id": "col-legacy",
+                "preset_name": "preset_legacy",
+                "strategy_family": "ema_crossover",
+                "asset_class": "crypto",
+                "timeframe": "4h",
+                "input_artifact_fingerprint": "abcd",
+                "spawned_at_utc": "2026-05-06T10:00:00+00:00",
+            },
+        ],
+    }
+    paths = _write(tmp_path, queue, registry, {"zones": []}, {})
+    report = ir.build_report(
+        now_utc=fixed_now_utc,
+        queue_path=paths["queue"],
+        registry_path=paths["registry"],
+        dead_zones_path=paths["dead_zones"],
+        information_gain_path=paths["ig"],
+    )
+    assert report.summary.total == 1
+    coords = report.decisions[0].behavior_coordinates
+    assert coords.timeframe == "4h"
+    # Legacy fixture had timeframe directly in the record → registry.
+    assert coords.derivation_source == "registry"
+
+
+def test_build_report_dict_with_partial_strategy_family(
+    tmp_path: Path, fixed_now_utc: _dt.datetime,
+) -> None:
+    """The production registry records sometimes have
+    ``strategy_family: null`` (when no hypothesis is bound). The
+    routing layer must mark ``derivation_source = 'missing'`` for
+    those rows even if preset_name + asset_class + timeframe are
+    available, because ``family`` is a coordinate field too."""
+    real_preset = next(
+        p for p in _PRODUCTION_PRESETS if p.timeframe and p.name
+    )
+    queue = {
+        "queue": [
+            {"campaign_id": "col-partial", "spawned_at_utc": "t"},
+        ],
+    }
+    registry = {
+        "campaigns": {
+            "col-partial": {
+                "campaign_id": "col-partial",
+                "preset_name": real_preset.name,
+                "asset_class": "equity",
+                "strategy_family": None,  # ← partial
+                "extra": {},
+            },
+        },
+    }
+    paths = _write(tmp_path, queue, registry, {"zones": []}, {})
+    report = ir.build_report(
+        now_utc=fixed_now_utc,
+        queue_path=paths["queue"],
+        registry_path=paths["registry"],
+        dead_zones_path=paths["dead_zones"],
+        information_gain_path=paths["ig"],
+    )
+    coords = report.decisions[0].behavior_coordinates
+    assert coords.family == "unknown"
+    assert coords.derivation_source == "missing"
+    assert report.summary.metadata_gaps == 1


### PR DESCRIPTION
## Summary

Stage 4 fix to the v3.15.16 metadata gap. The first real-input observation ([run 25454835978](https://github.com/roudjy/trading-agent/actions/runs/25454835978)) yielded 23 decisions all with \`behavior_coordinates: (unknown, unknown, unknown)\`. The Stage-2 metadata-shape diagnostic ([run 25456346063](https://github.com/roudjy/trading-agent/actions/runs/25456346063)) confirmed the production registry artifact stores \`campaigns\` as a **dict** keyed by campaign_id, not a list. Stage-3 classification: **TYPE C — Mixed** (mapping bug + partial-population gap).

### Root cause evidence (from `metadata_shape_diagnostic.json` on the VPS)

\`\`\`
campaign_registry:
  campaigns_value_type: \"dict\"
  campaigns_record_count: 24
  first_three_records[].keys include:
    preset_name, asset_class, strategy_family,
    input_artifact_fingerprint, hypothesis_id, extra (empty), universe, ...
  probe_fields_missing on every record:
    timeframe, interval, params, metadata, preset, strategy,
    strategy_name, family, symbol

campaign_queue:
  queue_value_type: \"list\"  (already handled correctly)
\`\`\`

Sample record: \`preset_name=\"trend_pullback_crypto_1h\"\`, \`asset_class=\"crypto\"\`, \`strategy_family=\"trend_pullback\"\` (sometimes null), \`extra={}\` (empty), no timeframe, no interval.

### Fix (scoped strictly to `reporting/intelligent_routing.py`)

| Change | What |
|---|---|
| \`_index_registry\` | Accepts BOTH the production dict shape (\`{campaigns: {campaign_id: {<record>}}}\` per [research.campaign_registry.write_registry](research/campaign_registry.py)) and the legacy list shape used by older fixtures. The dict-key is canonical when it disagrees with the record's own \`campaign_id\` field. Legacy \`registry\` top-level key still accepted as fallback. |
| \`_coords_for_campaign\` | When the registry record does not carry \`timeframe\`/\`interval\` (production case), falls back to a lazy lookup of \`preset_name\` in [\`research.presets.PRESETS\`](research/presets.py) for the canonical timeframe. **Not** campaign_id parsing — \`preset_name\` is a real registry-side field; PRESETS is the in-memory frozen catalog of valid presets. The campaign_id parsing fallback is intentionally **not** implemented because every record carries \`preset_name\` directly. |
| \`BehaviorCoordinates.derivation_source\` (NEW) | Closed-vocabulary string field recording provenance: \`registry\` / \`preset_catalog\` / \`missing\` / \`unknown\`. |
| \`_preset_lookup()\` (NEW) | Lazy + cached. Imports \`research.presets\` at first call (read-only; research.presets is a pure-data module of frozen dataclasses). Returns empty on import failure → caller falls back to \`missing\`. Module import stays I/O-free; the import-safety pin still holds. \`research.presets\` is NOT in the forbidden-imports list (test_intelligent_routing_import_safety.py:FORBIDDEN_IMPORT_PREFIXES). |
| \`_reset_preset_lookup_cache_for_tests()\` | Test seam. |

### Framing preserved (still pinned by tests)

- \`routing_effect = \"advisory_only\"\`
- \`queue_ordering_effect = \"none\"\`
- \`schema_version = \"1.0\"\`, \`report_kind = \"intelligent_routing\"\`, \`version = \"v3.15.16\"\`

### What's NOT changed

- No queue integration.
- No scoring change. Priority/rank derivation untouched; bucket weights untouched.
- No campaign launcher / research generation invocation.
- No \`research/**\` writes.
- No \`dashboard/**\` changes.
- No frozen contract mutated.
- No \`live/paper/shadow/risk/trading/broker/execution\` path touched.

### Tests (19 new + 136 existing; 155/155 green locally)

[tests/unit/test_intelligent_routing_registry_shape.py](tests/unit/test_intelligent_routing_registry_shape.py) (NEW):

- DERIVATION_* constant pinning.
- \`_index_registry\` accepts production dict shape AND legacy list shape; dict-key wins on mismatch; legacy \`registry\` key (dict + list); skips non-dict records / empty keys / payload missing both keys.
- \`_preset_lookup\` populated from real PRESETS catalog; cached (returns same object).
- \`_coords_for_campaign\` with full registry → \`derivation_source=\"registry\"\`.
- \`_coords_for_campaign\` with production-shape (no timeframe) → \`derivation_source=\"preset_catalog\"\` and timeframe filled from PRESETS.
- Unknown preset → \`derivation_source=\"missing\"\`, timeframe \"unknown\".
- \`extra.timeframe\` in registry record takes priority over preset-catalog fallback.
- Missing record → \`derivation_source=\"missing\"\`.
- \`build_report\` against production-shape fixture **closes the metadata gap** (metadata_gaps == 0) when preset is in catalog.
- Legacy list-shape fixture still works (back-compat).
- Partial \`strategy_family=null\` → \`derivation_source=\"missing\"\`.

All 136 prior v3.15.16 tests still pass unchanged.

### After merge

Re-dispatch via \`gh workflow run observe-intelligent-routing.yml --ref main\`. The decisions array should now show populated coords + populated preset_name for every campaign with a known preset, and \`metadata_gaps\` should drop substantially.

## Test plan

- [x] Local: 155/155 v3.15.16 tests pass.
- [x] Local: \`python scripts/governance_lint.py\` clean.
- [x] Local: \`python -m reporting.intelligent_routing --no-write\` smoke OK on absent inputs.
- [x] CI fast pre-merge gate.
- [ ] After merge: re-dispatch and confirm metadata_gaps drops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)