### PR TITLE
fix(v3.15.16): metadata mapping — add AST source-parse + preset_name regex fallbacks

### DIFF
--- a/reporting/intelligent_routing.py
+++ b/reporting/intelligent_routing.py
@@ -49,11 +49,13 @@ This module never writes anywhere outside ``logs/intelligent_routing/``.
 from __future__ import annotations
 
 import argparse
+import ast
 import dataclasses
 import datetime as _dt
 import hashlib
 import json
 import os
+import re
 import sys
 import tempfile
 from collections import Counter
@@ -222,13 +224,33 @@ SUPPRESSED_PRIORITY_SCORE: Final[int] = -1
 #: default before derivation runs.
 DERIVATION_REGISTRY: Final[str] = "registry"
 DERIVATION_PRESET_CATALOG: Final[str] = "preset_catalog"
+#: Last-resort label: the timeframe was parsed deterministically from
+#: the ``preset_name`` field (a real registry-side artifact field) via
+#: a closed regex when both the canonical ``research.presets.PRESETS``
+#: import AND the AST-based source parse of ``research/presets.py``
+#: were unreachable on the runtime environment (e.g. VPS system
+#: Python where the trading-agent's transitive dependencies are only
+#: installed inside the Docker container). This is **not** parsing
+#: ``campaign_id`` — it is parsing the registry record's own
+#: ``preset_name`` field. Tests pin the exact regex.
+DERIVATION_PRESET_NAME_FALLBACK: Final[str] = "preset_name_fallback"
 DERIVATION_MISSING: Final[str] = "missing"
 
 DERIVATION_SOURCES: Final[tuple[str, ...]] = (
     DERIVATION_REGISTRY,
     DERIVATION_PRESET_CATALOG,
+    DERIVATION_PRESET_NAME_FALLBACK,
     DERIVATION_MISSING,
     UNKNOWN_COORDINATE,
+)
+
+#: Regex that recognises a timeframe token as authored in canonical
+#: preset names. Matches one of ``1m``, ``5m``, ``15m``, ``1h``,
+#: ``4h``, ``1d``, ``1w``, ``1M`` etc. — the standard CCXT/yfinance
+#: convention. Anchored so it is bounded by ``_`` or string edges so
+#: a substring like ``crypto4hello`` does not match.
+_PRESET_NAME_TIMEFRAME_REGEX: Final[re.Pattern[str]] = re.compile(
+    r"(?:^|_)(\d+[smhdwM])(?:_|$)"
 )
 
 
@@ -717,37 +739,128 @@ _PRESET_LOOKUP_CACHE: dict[str, dict[str, str]] | None = None
 
 
 def _preset_lookup() -> dict[str, dict[str, str]]:
-    """Return ``{preset_name: {"timeframe": str}}`` from
-    ``research.presets.PRESETS``.
+    """Return ``{preset_name: {"timeframe": str}}`` derived from
+    ``research/presets.py``.
 
-    Lazy-imported and cached. If the import fails for any reason,
-    returns an empty mapping; the caller falls back to ``unknown``.
-    Pure-read; never raises.
+    Two-tier resolution (lazy + cached):
+
+    1. **Canonical import** — ``from research.presets import PRESETS``.
+       Works in any environment where the project's dependency tree
+       is installed (CI, dev shells, the trading-agent Docker
+       container).
+    2. **AST source parse** — when the import fails (e.g. on the VPS
+       system Python where the project's transitive deps are only
+       inside the Docker container), parse ``research/presets.py``
+       with the ``ast`` module and extract every ``ResearchPreset(
+       name=..., timeframe=..., ...)`` instantiation's ``name`` and
+       ``timeframe`` keyword args. Stdlib-only; no transitive imports.
+
+    Returns an empty mapping if both tiers fail; the caller falls
+    back to ``DERIVATION_PRESET_NAME_FALLBACK`` (regex on
+    ``preset_name``) or to ``DERIVATION_MISSING``. Pure-read; never
+    raises.
     """
     global _PRESET_LOOKUP_CACHE
     if _PRESET_LOOKUP_CACHE is not None:
         return _PRESET_LOOKUP_CACHE
     out: dict[str, dict[str, str]] = {}
+
+    # Tier 1: canonical import.
     try:
         from research.presets import PRESETS  # local import — see docstring
     except Exception:  # noqa: BLE001 — defensive: lookup must never raise
-        _PRESET_LOOKUP_CACHE = out
-        return out
-    for preset in PRESETS:
-        try:
-            name = str(getattr(preset, "name", ""))
-            timeframe = str(getattr(preset, "timeframe", ""))
-        except (AttributeError, TypeError):
-            continue
-        if not name:
-            continue
-        entry: dict[str, str] = {}
-        if timeframe:
-            entry["timeframe"] = timeframe
-        if entry:
-            out[name] = entry
+        PRESETS = None  # type: ignore[assignment]
+    if PRESETS is not None:
+        for preset in PRESETS:
+            try:
+                name = str(getattr(preset, "name", ""))
+                timeframe = str(getattr(preset, "timeframe", ""))
+            except (AttributeError, TypeError):
+                continue
+            if not name:
+                continue
+            entry: dict[str, str] = {}
+            if timeframe:
+                entry["timeframe"] = timeframe
+            if entry:
+                out[name] = entry
+
+    # Tier 2: AST source parse (only if Tier 1 yielded nothing).
+    if not out:
+        out.update(_parse_presets_source_via_ast())
+
     _PRESET_LOOKUP_CACHE = out
     return out
+
+
+def _parse_presets_source_via_ast() -> dict[str, dict[str, str]]:
+    """Stdlib-only AST parse of ``research/presets.py`` to extract
+    ``{preset_name: {"timeframe": str}}`` from every
+    ``ResearchPreset(name="...", timeframe="...", ...)`` call. Pure;
+    never raises; returns an empty dict on any error.
+
+    This intentionally does NOT import the module — the whole point
+    is to work in environments where the import would fail.
+    """
+    out: dict[str, dict[str, str]] = {}
+    src_path = REPO_ROOT / "research" / "presets.py"
+    try:
+        if not src_path.is_file():
+            return out
+        text = src_path.read_text(encoding="utf-8")
+    except OSError:
+        return out
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return out
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        # Match `ResearchPreset(...)`. Be strict — only match the
+        # bare name; do not match `module.ResearchPreset(...)` etc.
+        if not (isinstance(func, ast.Name) and func.id == "ResearchPreset"):
+            continue
+        kwargs = {kw.arg: kw.value for kw in node.keywords if kw.arg}
+        name_node = kwargs.get("name")
+        timeframe_node = kwargs.get("timeframe")
+        if not (
+            isinstance(name_node, ast.Constant)
+            and isinstance(timeframe_node, ast.Constant)
+        ):
+            continue
+        name_value = name_node.value
+        timeframe_value = timeframe_node.value
+        if not (isinstance(name_value, str) and isinstance(timeframe_value, str)):
+            continue
+        if name_value and timeframe_value:
+            out[name_value] = {"timeframe": timeframe_value}
+    return out
+
+
+def _parse_timeframe_from_preset_name(preset_name: object) -> str | None:
+    """Last-resort regex parse of ``preset_name`` to extract a
+    timeframe. Used only when both the canonical import AND the AST
+    source parse fail (e.g. on a stripped runtime where neither
+    Python deps nor the source file are reachable).
+
+    Matches ``\\d+[smhdwM]`` as a token bounded by ``_`` or string
+    edges (canonical preset-name convention). Returns ``None`` if no
+    match. Pure; never raises.
+
+    NB: this parses the registry-side ``preset_name`` field, NOT the
+    ``campaign_id``. ``preset_name`` is a real registry artifact
+    field with author-controlled values; ``campaign_id`` is a
+    derived collision-proof identifier.
+    """
+    if not isinstance(preset_name, str) or not preset_name:
+        return None
+    match = _PRESET_NAME_TIMEFRAME_REGEX.search(preset_name)
+    if match is None:
+        return None
+    return match.group(1)
 
 
 def _reset_preset_lookup_cache_for_tests() -> None:
@@ -872,6 +985,7 @@ def _coords_for_campaign(
 
     # Step 2: preset-catalog fallback for timeframe only.
     used_preset_catalog = False
+    used_preset_name_fallback = False
     if not raw_timeframe and preset_name_str is not None:
         catalog = _preset_lookup()
         catalog_entry = catalog.get(preset_name_str, {})
@@ -879,6 +993,17 @@ def _coords_for_campaign(
         if catalog_timeframe:
             raw_timeframe = catalog_timeframe
             used_preset_catalog = True
+
+    # Step 3: last-resort regex parse of preset_name. Only fires when
+    # both the registry record AND the preset catalog (import + AST
+    # source parse) failed to produce a timeframe. Marks the
+    # provenance distinctly so an auditor can identify rows that
+    # depend on the regex contract.
+    if not raw_timeframe and preset_name_str is not None:
+        parsed = _parse_timeframe_from_preset_name(preset_name_str)
+        if parsed:
+            raw_timeframe = parsed
+            used_preset_name_fallback = True
 
     # Compute provisional coords.
     family = _safe_str(raw_family)
@@ -892,13 +1017,17 @@ def _coords_for_campaign(
     )
 
     # Compute the derivation_source label. Order:
-    #   * "missing" if any coord stayed unknown after fallback.
-    #   * "preset_catalog" if the preset-catalog filled at least one
-    #     field (currently only timeframe).
+    #   * "missing" if any coord stayed unknown after every fallback.
+    #   * "preset_name_fallback" if at least one coord came from the
+    #     regex parse of preset_name (last-resort).
+    #   * "preset_catalog" if at least one coord came from the
+    #     preset-catalog lookup (currently only timeframe).
     #   * "registry" otherwise (every coord came from the registry
     #     record fields directly).
     if not has_full:
         source = DERIVATION_MISSING
+    elif used_preset_name_fallback:
+        source = DERIVATION_PRESET_NAME_FALLBACK
     elif used_preset_catalog:
         source = DERIVATION_PRESET_CATALOG
     else:
@@ -1358,6 +1487,7 @@ __all__ = [
     "DEAD_ZONE_WEAK",
     "DERIVATION_MISSING",
     "DERIVATION_PRESET_CATALOG",
+    "DERIVATION_PRESET_NAME_FALLBACK",
     "DERIVATION_REGISTRY",
     "DERIVATION_SOURCES",
     "DIAGNOSE_REPORT_KIND",

--- a/tests/unit/test_intelligent_routing_registry_shape.py
+++ b/tests/unit/test_intelligent_routing_registry_shape.py
@@ -37,10 +37,12 @@ from research.presets import PRESETS as _PRODUCTION_PRESETS
 def test_derivation_constants_pinned() -> None:
     assert ir.DERIVATION_REGISTRY == "registry"
     assert ir.DERIVATION_PRESET_CATALOG == "preset_catalog"
+    assert ir.DERIVATION_PRESET_NAME_FALLBACK == "preset_name_fallback"
     assert ir.DERIVATION_MISSING == "missing"
     assert ir.UNKNOWN_COORDINATE in ir.DERIVATION_SOURCES
     assert set(ir.DERIVATION_SOURCES) == {
-        "registry", "preset_catalog", "missing", "unknown",
+        "registry", "preset_catalog", "preset_name_fallback",
+        "missing", "unknown",
     }
 
 
@@ -156,6 +158,148 @@ def test_preset_lookup_is_cached() -> None:
     a = ir._preset_lookup()
     b = ir._preset_lookup()
     assert a is b
+
+
+# ---------------------------------------------------------------------------
+# AST source-parse fallback
+# ---------------------------------------------------------------------------
+
+
+def test_ast_source_parse_yields_same_presets_as_canonical_import() -> None:
+    """The Tier-2 AST source parse of research/presets.py must
+    produce a superset (== set) of (name, timeframe) pairs as the
+    canonical Tier-1 import. Tier 2 is what the VPS uses when its
+    system Python cannot import the project's deps."""
+    canonical: dict[str, str] = {}
+    for p in _PRODUCTION_PRESETS:
+        if p.name and p.timeframe:
+            canonical[p.name] = p.timeframe
+    ast_out = ir._parse_presets_source_via_ast()
+    ast_pairs = {n: e["timeframe"] for n, e in ast_out.items()}
+    assert ast_pairs == canonical, (
+        f"AST source parse drift:\n  canonical={canonical!r}\n  ast={ast_pairs!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tier 3 — preset_name regex fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "preset_name,expected",
+    [
+        # Real production preset names observed on the VPS.
+        ("vol_compression_breakout_crypto_4h", "4h"),
+        ("trend_equities_4h_baseline", "4h"),
+        ("trend_pullback_crypto_1h", "1h"),
+        ("trend_regime_filtered_equities_4h", "4h"),
+        ("vol_compression_breakout_crypto_1h", "1h"),
+        # Other timeframe shapes.
+        ("strategy_15m_xyz", "15m"),
+        ("xyz_5m_baseline", "5m"),
+        ("daily_only_1d", "1d"),
+        ("anchor_1w", "1w"),
+        ("monthly_1M", "1M"),
+        # Negative cases — must NOT match.
+        ("no_timeframe_token_here", None),
+        ("crypto4hello", None),  # not bounded by underscore
+        ("only_4hours", None),  # 4hours has 4h as substring but not a token
+        ("", None),
+    ],
+)
+def test_parse_timeframe_from_preset_name(
+    preset_name: str, expected: str | None,
+) -> None:
+    out = ir._parse_timeframe_from_preset_name(preset_name)
+    assert out == expected
+
+
+def test_parse_timeframe_from_preset_name_none_input() -> None:
+    assert ir._parse_timeframe_from_preset_name(None) is None
+    assert ir._parse_timeframe_from_preset_name(42) is None
+
+
+def test_coords_uses_preset_name_fallback_when_catalog_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Simulate the VPS environment: catalog import fails AND the
+    AST source parse fails. The regex on preset_name then fires."""
+    # Force both tiers to return empty by clearing the cache and
+    # monkeypatching _parse_presets_source_via_ast to {}, then also
+    # making the real PRESETS import return nothing usable. The
+    # cleanest way: override the cache directly with empty content.
+    ir._reset_preset_lookup_cache_for_tests()
+    monkeypatch.setattr(ir, "_PRESET_LOOKUP_CACHE", {})
+    rec = {
+        "campaign_id": "col-fallback",
+        "preset_name": "trend_pullback_crypto_1h",  # Tier-3 will parse "1h"
+        "asset_class": "crypto",
+        "strategy_family": "trend_pullback",
+        "extra": {},
+        "input_artifact_fingerprint": "abcd",
+    }
+    coords, preset_name, _fp, has_full = ir._coords_for_campaign(
+        "col-fallback", {"col-fallback": rec},
+    )
+    assert coords.timeframe == "1h"
+    assert coords.derivation_source == "preset_name_fallback"
+    assert preset_name == "trend_pullback_crypto_1h"
+    assert has_full is True
+    # Restore catalog so other tests are unaffected.
+    ir._reset_preset_lookup_cache_for_tests()
+
+
+def test_coords_preset_name_fallback_failure_yields_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When all three tiers fail (preset_name has no recognizable
+    timeframe token), derivation_source == 'missing'."""
+    ir._reset_preset_lookup_cache_for_tests()
+    monkeypatch.setattr(ir, "_PRESET_LOOKUP_CACHE", {})
+    rec = {
+        "campaign_id": "col-no-timeframe",
+        "preset_name": "no_timeframe_token_here",
+        "asset_class": "crypto",
+        "strategy_family": "ema_crossover",
+        "extra": {},
+    }
+    coords, _preset_name, _fp, has_full = ir._coords_for_campaign(
+        "col-no-timeframe", {"col-no-timeframe": rec},
+    )
+    assert coords.timeframe == "unknown"
+    assert coords.derivation_source == "missing"
+    assert has_full is False
+    ir._reset_preset_lookup_cache_for_tests()
+
+
+def test_coords_preference_order_registry_then_catalog_then_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the registry record carries an explicit timeframe, it
+    wins over both the catalog and the regex (already pinned by
+    test_coords_extra_timeframe_takes_priority_over_preset_catalog).
+    When registry omits timeframe but catalog has it, catalog wins
+    over the regex (the regex never even runs). Verify the regex is
+    reached only when both registry AND catalog are silent."""
+    real_preset = next(
+        p for p in _PRODUCTION_PRESETS if p.timeframe and p.name
+    )
+    ir._reset_preset_lookup_cache_for_tests()
+    # Catalog populated normally — regex must NOT fire.
+    rec = {
+        "campaign_id": "col-cat-wins",
+        "preset_name": real_preset.name,
+        "asset_class": "equity",
+        "strategy_family": "ema_crossover",
+        "extra": {},
+    }
+    coords, _, _, _ = ir._coords_for_campaign(
+        "col-cat-wins", {"col-cat-wins": rec},
+    )
+    assert coords.timeframe == real_preset.timeframe
+    assert coords.derivation_source == "preset_catalog"  # NOT "preset_name_fallback"
+    ir._reset_preset_lookup_cache_for_tests()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Continuation of [#124](https://github.com/roudjy/trading-agent/pull/124). After #124 landed, re-dispatching the observation ([run 25457233544](https://github.com/roudjy/trading-agent/actions/runs/25457233544)) showed \`metadata_gaps\` still 24/24 — \`preset_name\` and \`asset_class\` were now correctly populated, but \`timeframe\` stayed \`unknown\` across every row.

### Root cause of the residual gap

\`from research.presets import PRESETS\` succeeds locally (pulls 7 presets) but **fails on the VPS system Python**. \`research.presets\` transitively imports \`research.registry\` → \`agent.backtesting.strategies\`, which depends on \`numpy\`/\`pandas\`/\`ta\`/\`ccxt\` — installed only inside the trading-agent Docker container. The observation runner uses the host's system Python, which lacks those deps. The catalog returns empty; every campaign falls through to the \"missing\" branch, and \`timeframe\` stays unknown.

### Fix

Add two more stdlib-only tiers to \`_preset_lookup\`:

| Tier | Mechanism | Where it works |
|---|---|---|
| 1 | \`from research.presets import PRESETS\` (existing) | CI / dev / Docker container |
| 2 | **NEW**: AST source parse of \`research/presets.py\` via stdlib \`ast.walk\` | Anywhere the source file is on disk |
| 3 | **NEW**: regex on \`preset_name\` (matches \`\d+[smhdwM]\` bounded by \`_\` or string edges — canonical CCXT/yfinance timeframe convention baked into preset names by their authors). NOT parsing \`campaign_id\` — \`preset_name\` is a real registry field. | Anywhere |

\`derivation_source\` extended with a new closed-vocabulary value:

\`\`\`
DERIVATION_PRESET_NAME_FALLBACK = \"preset_name_fallback\"
\`\`\`

Resolution order in \`_coords_for_campaign\`:

\`\`\`
registry.timeframe/interval/extra → derivation = registry
catalog.timeframe via preset_name → derivation = preset_catalog
regex on preset_name              → derivation = preset_name_fallback
none of the above                 → derivation = missing
\`\`\`

### Framing preserved

\`routing_effect = \"advisory_only\"\`, \`queue_ordering_effect = \"none\"\`, \`schema_version = \"1.0\"\`.

### What's NOT changed

Queue integration, scoring, frozen contracts, \`research/**\`, \`dashboard/**\`, \`.claude/**\`, \`.github/workflows/**\`. This PR only touches \`reporting/\` + \`tests/\`.

### Tests (38 in registry-shape suite, 174/174 total v3.15.16 tests green locally)

- \`ast_source_parse_yields_same_presets_as_canonical_import\` — asserts the AST parser produces an EXACT match to the canonical PRESETS catalog (catches drift if \`research/presets.py\` structure changes).
- 13 parametrized regex tests across real VPS preset-names + synthetic edge cases. Negative cases (substring matches, empty string, no underscore boundary) must NOT match.
- \`coords_uses_preset_name_fallback_when_catalog_unavailable\` — simulates VPS environment by clearing the cache; asserts \`derivation_source == \"preset_name_fallback\"\`.
- \`coords_preset_name_fallback_failure_yields_missing\` — when even the regex fails, \`derivation_source == \"missing\"\`.
- \`coords_preference_order_registry_then_catalog_then_fallback\` — pins resolution order; the regex MUST NOT fire when catalog or registry already has the answer.

### After merge

Re-dispatch via \`gh workflow run observe-intelligent-routing.yml --ref main\`. Every decision row should now have a populated timeframe. Rows whose \`strategy_family\` is null in the registry will still mark \"missing\" — those are upstream-data partial-population, not layer-side gaps.

## Test plan

- [x] Local: 174/174 v3.15.16 tests pass.
- [x] Local governance lint clean.
- [x] CI fast pre-merge gate.
- [ ] After merge: dispatch and confirm \`metadata_gaps\` drops + \`derivation_source\` reflects the actual fallback path used on the VPS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)