### PR TITLE
feat(v3.15.16.1): dead-zone coarse lookup annotation only

### DIFF
--- a/docs/governance/intelligent_routing_observation.md
+++ b/docs/governance/intelligent_routing_observation.md
@@ -3,8 +3,108 @@
 > Workflow: `.github/workflows/observe-intelligent-routing.yml`
 > Modules:  `reporting/intelligent_routing.py`,
 >           `reporting/intelligent_routing_status.py`
-> Release:  v3.15.16 (advisory)
+> Release:  v3.15.16 (advisory) + v3.15.16.1 (dead-zone coarse-lookup
+>           annotation)
 > Companion: [`scripts/deploy_vps_dashboard.sh`](../../scripts/deploy_vps_dashboard.sh) (sibling deploy posture, mirrored secrets/SSH pattern)
+
+## v3.15.16.1 — dead-zone coarse-lookup annotation only
+
+The first real-input observations of the v3.15.16 advisory artifact
+showed `dead_zone_status: "unknown"` for every campaign. Root cause:
+the upstream `dead_zones_latest.v1.json` artifact currently keys
+zones on `(asset, "unknown", family)` (per
+[`research/dead_zone_detection.py:21-24`](../../research/dead_zone_detection.py:21):
+*"Timeframe is currently 'unknown' for every zone because the
+upstream ledger event does not carry interval. v4 will enrich
+ledger events with timeframe."*). The routing layer's coordinates
+now carry real timeframes (`4h` / `1h` / `1d` etc.), so the exact
+key never matches.
+
+**v3.15.16.1 adds a coarse-lookup observability annotation only.**
+
+* If the artifact has an exact `(asset_class, timeframe, family)`
+  key, that wins → `dead_zone_lookup_precision = "exact_timeframe_match"`.
+  Existing advisory dead-zone behaviour applies (a `dead` exact
+  match may set `advisory_suppression_reason = "dead_zone"`).
+* If the artifact has only `(asset_class, "unknown", family)`,
+  the coarse fallback fires → `dead_zone_lookup_precision =
+  "coarse_unknown_timeframe_match"`. The decision row carries the
+  upstream `dead_zone_status` for operator visibility, **but**:
+  - It MUST NOT set `advisory_suppression_reason`.
+  - It MUST NOT alter `advisory_priority_score`.
+  - It MUST NOT alter `advisory_rank`.
+  - It MUST NOT be classified as exact timeframe-aware evidence.
+* If neither key is present →
+  `dead_zone_lookup_precision = "no_match"`,
+  `dead_zone_status = "unknown"`, no suppression / priority /
+  rank effect.
+
+These invariants are pinned by 14 dedicated tests in
+[`tests/unit/test_intelligent_routing_dead_zone_coarse_lookup.py`](../../tests/unit/test_intelligent_routing_dead_zone_coarse_lookup.py)
+plus updates to `test_intelligent_routing_advisory_suppression.py`
+and `test_intelligent_routing_pure.py`. No test was weakened,
+skipped, deleted, or marked `xfail`.
+
+## Current upstream-signal limits (operator-facing summary)
+
+These three limits sit upstream of the routing layer; the routing
+layer surfaces them honestly but does **not** infer them away.
+
+1. **Dead-zone artifact carries `timeframe="unknown"` for every zone
+   today.** v3.15.16.1 reads them via the coarse fallback (above)
+   so operators can see them at all. The canonical fix is the
+   upstream v4 ledger enrichment named in
+   [`research/dead_zone_detection.py:21-24`](../../research/dead_zone_detection.py:21).
+   That work is in `research/**`, which is no-touch for the
+   reporting layer; addressing it requires a separate
+   research-side product task.
+
+2. **Information-gain artifact is single-campaign.** The producer
+   in [`research/information_gain.py`](../../research/information_gain.py)
+   emits one `col_campaign_id` per file (the most recent
+   meaningful campaign). The routing layer's IG lookup is sparse
+   by construction: most campaigns will have `info_gain_score = 0
+   / bucket = "none"`. A multi-campaign IG roll-up via the
+   evidence ledger reader is **deferred to a separate, operator-
+   reviewed task** with a tight event-type allowlist; no scoping
+   nor implementation in this v3.15.16.1 phase.
+
+3. **`strategy_family` partial population.** Per
+   [`research/campaign_launcher.py:240-251`](../../research/campaign_launcher.py:240),
+   `strategy_family` is populated only when a preset has
+   `hypothesis_id` AND that hypothesis exists in the catalog.
+   Records whose preset lacks a `hypothesis_id` (or references a
+   missing one) carry `strategy_family: null`, surfaced as
+   `family: "unknown"` in the routing artifact. The fix is
+   producer-side (in `research/presets.py` or
+   `research/strategy_hypothesis_catalog.py`) and is therefore not
+   addressable from the routing layer.
+
+## Queue integration remains deferred
+
+`queue_ordering_effect: "none"` and `routing_effect: "advisory_only"`
+are unchanged in v3.15.16.1. Queue integration MUST NOT be
+considered until **all** of the following are met:
+
+- Per-campaign IG history is reliable across substantially more
+  than `1/N` campaigns (today's observed sparsity).
+- Dead-zone matching uses an exact, timeframe-aware key path
+  (i.e. the upstream v4 ledger enrichment has landed; coarse
+  matches alone are not sufficient).
+- `strategy_family` is populated for the strong majority of
+  active campaigns.
+- Behavior coordinates have meaningful diversity in the active
+  queue (today: 3 unique triples across 25 campaigns →
+  `orthogonality_bucket: "saturated"` for every row).
+- Top-ranked rows are explainable on signal beyond a single
+  campaign's IG.
+
+v3.15.17 Sampling Intelligence remains deferred until the same
+upstream-signal readiness gate clears (see Roadmap v6 lines
+297-340; *"low-information-region suppression"* and *"signal-
+density-aware sampling"* depend on per-campaign IG, *"stratified
+sampling"* depends on coordinate diversity, *"lower dead-zone
+compute burn"* depends on an exact dead-zone match path).
 
 This is the operator-facing runbook for the v3.15.16 advisory
 Intelligent Routing **observation** workflow. It is the only governed

--- a/reporting/intelligent_routing.py
+++ b/reporting/intelligent_routing.py
@@ -127,13 +127,46 @@ DEAD_ZONE_STATUSES: Final[tuple[str, ...]] = (
 
 #: Statuses that *never* trigger advisory suppression. Anything not in
 #: this set (i.e. only ``DEAD_ZONE_DEAD``) may set
-#: ``advisory_suppression_reason = "dead_zone"`` in PR-C.
+#: ``advisory_suppression_reason = "dead_zone"`` in PR-C — and only
+#: when the lookup that produced the status is ``exact_timeframe_match``
+#: (see ``DEAD_ZONE_LOOKUP_PRECISION_VALUES`` below).
 NEVER_SUPPRESS_DEAD_ZONE_STATUSES: Final[frozenset[str]] = frozenset({
     DEAD_ZONE_INSUFFICIENT_DATA,
     DEAD_ZONE_UNKNOWN,
     DEAD_ZONE_ALIVE,
     DEAD_ZONE_WEAK,
 })
+
+# ---------------------------------------------------------------------------
+# Dead-zone lookup precision (v3.15.16.1)
+# ---------------------------------------------------------------------------
+
+#: ``exact_timeframe_match`` — the dead-zone artifact contained a key
+#: ``(asset_class, timeframe, family)`` matching the campaign's
+#: behavior coordinates exactly. The status carries the same
+#: timeframe-aware precision as the campaign and may participate in
+#: existing advisory suppression behaviour.
+DEAD_ZONE_LOOKUP_EXACT: Final[str] = "exact_timeframe_match"
+
+#: ``coarse_unknown_timeframe_match`` — the dead-zone artifact did
+#: not contain an exact timeframed key but did contain
+#: ``(asset_class, "unknown", family)``. Per
+#: ``research/dead_zone_detection.py`` the upstream zones are
+#: currently always keyed with ``timeframe="unknown"`` (a documented
+#: producer-side limit awaiting a v4 ledger enrichment). The coarse
+#: match is **observability metadata only**: it MUST NOT trigger
+#: ``advisory_suppression_reason``, MUST NOT alter
+#: ``advisory_priority_score``, and MUST NOT alter ``advisory_rank``.
+DEAD_ZONE_LOOKUP_COARSE: Final[str] = "coarse_unknown_timeframe_match"
+
+#: ``no_match`` — neither key form was present in the artifact.
+DEAD_ZONE_LOOKUP_NO_MATCH: Final[str] = "no_match"
+
+DEAD_ZONE_LOOKUP_PRECISION_VALUES: Final[tuple[str, ...]] = (
+    DEAD_ZONE_LOOKUP_EXACT,
+    DEAD_ZONE_LOOKUP_COARSE,
+    DEAD_ZONE_LOOKUP_NO_MATCH,
+)
 
 # ---------------------------------------------------------------------------
 # Orthogonality buckets
@@ -300,6 +333,11 @@ class RoutingDecision:
     info_gain_score: float
     info_gain_bucket: str
     dead_zone_status: str
+    #: v3.15.16.1 — closed-vocabulary precision label for the
+    #: dead-zone lookup that produced ``dead_zone_status``. Coarse
+    #: matches are observability metadata only; they do NOT
+    #: participate in advisory suppression / priority / rank.
+    dead_zone_lookup_precision: str
     near_duplicate_group: str | None
     orthogonality_bucket: str
     advisory_suppression_reason: str | None
@@ -315,6 +353,7 @@ class RoutingDecision:
             "info_gain_score": float(self.info_gain_score),
             "info_gain_bucket": self.info_gain_bucket,
             "dead_zone_status": self.dead_zone_status,
+            "dead_zone_lookup_precision": self.dead_zone_lookup_precision,
             "near_duplicate_group": self.near_duplicate_group,
             "orthogonality_bucket": self.orthogonality_bucket,
             "advisory_suppression_reason": self.advisory_suppression_reason,
@@ -464,20 +503,59 @@ def _normalize_dead_zone_key(
 def classify_dead_zone_status(
     coords: BehaviorCoordinates,
     dead_zone_index: dict[tuple[str, str, str], str],
-) -> str:
+) -> tuple[str, str]:
     """Pure lookup of the dead-zone status for a coordinate.
 
-    The index is keyed on (asset, timeframe, family) — the same key the
-    upstream artifact uses. Missing entries collapse to
-    ``DEAD_ZONE_UNKNOWN``. Returns one of ``DEAD_ZONE_STATUSES``.
+    Returns a 2-tuple ``(status, lookup_precision)`` where:
+
+    * ``status`` is one of ``DEAD_ZONE_STATUSES`` (defaults to
+      ``DEAD_ZONE_UNKNOWN`` on miss).
+    * ``lookup_precision`` is one of
+      ``DEAD_ZONE_LOOKUP_PRECISION_VALUES``:
+
+      - ``DEAD_ZONE_LOOKUP_EXACT`` — the artifact contained
+        ``(asset_class, timeframe, family)`` matching the campaign's
+        coordinates exactly. Status carries timeframe-aware precision
+        and may participate in existing advisory suppression.
+      - ``DEAD_ZONE_LOOKUP_COARSE`` — the artifact did not contain
+        the exact key but did contain
+        ``(asset_class, "unknown", family)``. The upstream zones
+        currently always use ``timeframe="unknown"`` (a documented
+        producer-side limit). The coarse match is **observability
+        metadata only**: it MUST NOT participate in advisory
+        suppression / priority / rank.
+      - ``DEAD_ZONE_LOOKUP_NO_MATCH`` — neither key form was present.
+
+    Pure; never raises. The 2-tuple replaces the previous single-str
+    return as part of the v3.15.16.1 dead-zone coarse-lookup
+    annotation work.
     """
-    key = _normalize_dead_zone_key(
+    # Tier 1: exact (asset_class, timeframe, family).
+    exact_key = _normalize_dead_zone_key(
         coords.asset_class, coords.timeframe, coords.family,
     )
-    status = dead_zone_index.get(key, DEAD_ZONE_UNKNOWN)
-    if status not in DEAD_ZONE_STATUSES:
-        return DEAD_ZONE_UNKNOWN
-    return status
+    if exact_key in dead_zone_index:
+        status = dead_zone_index[exact_key]
+        if status not in DEAD_ZONE_STATUSES:
+            status = DEAD_ZONE_UNKNOWN
+        return status, DEAD_ZONE_LOOKUP_EXACT
+
+    # Tier 2: coarse fallback — match the documented upstream form
+    # ``(asset_class, "unknown", family)``. Skip when the coordinates
+    # themselves already use ``"unknown"`` for timeframe (the exact
+    # lookup above already covered that case).
+    if _safe_str(coords.timeframe) != UNKNOWN_COORDINATE:
+        coarse_key = _normalize_dead_zone_key(
+            coords.asset_class, UNKNOWN_COORDINATE, coords.family,
+        )
+        if coarse_key in dead_zone_index:
+            status = dead_zone_index[coarse_key]
+            if status not in DEAD_ZONE_STATUSES:
+                status = DEAD_ZONE_UNKNOWN
+            return status, DEAD_ZONE_LOOKUP_COARSE
+
+    # Tier 3: no match.
+    return DEAD_ZONE_UNKNOWN, DEAD_ZONE_LOOKUP_NO_MATCH
 
 
 def compute_orthogonality_bucket(
@@ -508,6 +586,7 @@ def compute_orthogonality_bucket(
 def derive_advisory_suppression_reason(
     *,
     dead_zone_status: str,
+    dead_zone_lookup_precision: str = DEAD_ZONE_LOOKUP_NO_MATCH,
     near_duplicate_group: str | None,
     is_first_in_group: bool,
 ) -> str | None:
@@ -515,9 +594,14 @@ def derive_advisory_suppression_reason(
 
     Resolution order:
 
-    1. ``dead_zone`` if and only if ``dead_zone_status == DEAD_ZONE_DEAD``.
+    1. ``dead_zone`` if and only if ``dead_zone_status == DEAD_ZONE_DEAD``
+       AND ``dead_zone_lookup_precision == DEAD_ZONE_LOOKUP_EXACT``.
        Statuses in ``NEVER_SUPPRESS_DEAD_ZONE_STATUSES`` *never*
-       trigger suppression.
+       trigger suppression. v3.15.16.1: a coarse
+       ``(asset, "unknown", family)`` match (precision
+       ``DEAD_ZONE_LOOKUP_COARSE``) is **observability metadata only**
+       and MUST NOT trigger this branch even if its status is
+       ``DEAD_ZONE_DEAD``.
     2. ``near_duplicate`` if and only if the campaign is part of a
        near-duplicate group AND is **not** the first member of that
        group (the first member always keeps ``None``).
@@ -527,7 +611,10 @@ def derive_advisory_suppression_reason(
     ``routing_effect = "advisory_only"``. Downstream queue ordering
     is not changed.
     """
-    if dead_zone_status == DEAD_ZONE_DEAD:
+    if (
+        dead_zone_status == DEAD_ZONE_DEAD
+        and dead_zone_lookup_precision == DEAD_ZONE_LOOKUP_EXACT
+    ):
         return SUPPRESSION_DEAD_ZONE
     if near_duplicate_group is not None and not is_first_in_group:
         return SUPPRESSION_NEAR_DUPLICATE
@@ -1133,7 +1220,9 @@ def build_report(
         spawned_at = str(entry.get("spawned_at_utc") or "")
         score = float(ig_index.get(cid, 0.0))
         bucket = bucket_info_gain(score)
-        zone_status = classify_dead_zone_status(coords, dead_zone_index)
+        zone_status, zone_precision = classify_dead_zone_status(
+            coords, dead_zone_index,
+        )
         if not has_full:
             metadata_gaps += 1
         prior_total = max(0, coord_counts[coords.as_tuple()] - 1)
@@ -1148,6 +1237,7 @@ def build_report(
             "score": round(score, 4),
             "bucket": bucket,
             "zone_status": zone_status,
+            "zone_precision": zone_precision,
             "group": group,
             "ortho": ortho,
             "tie_break_key": f"{spawned_at}|{cid}",
@@ -1179,6 +1269,7 @@ def build_report(
             is_first = first_member_in_group[gid] == row["tie_break_key"]
         reason = derive_advisory_suppression_reason(
             dead_zone_status=row["zone_status"],
+            dead_zone_lookup_precision=row["zone_precision"],
             near_duplicate_group=gid,
             is_first_in_group=is_first,
         )
@@ -1195,6 +1286,7 @@ def build_report(
                 info_gain_score=row["score"],
                 info_gain_bucket=row["bucket"],
                 dead_zone_status=row["zone_status"],
+                dead_zone_lookup_precision=row["zone_precision"],
                 near_duplicate_group=gid,
                 orthogonality_bucket=row["ortho"],
                 advisory_suppression_reason=reason,
@@ -1482,6 +1574,10 @@ __all__ = [
     "DEAD_ZONE_ALIVE",
     "DEAD_ZONE_DEAD",
     "DEAD_ZONE_INSUFFICIENT_DATA",
+    "DEAD_ZONE_LOOKUP_COARSE",
+    "DEAD_ZONE_LOOKUP_EXACT",
+    "DEAD_ZONE_LOOKUP_NO_MATCH",
+    "DEAD_ZONE_LOOKUP_PRECISION_VALUES",
     "DEAD_ZONE_STATUSES",
     "DEAD_ZONE_UNKNOWN",
     "DEAD_ZONE_WEAK",

--- a/tests/unit/test_intelligent_routing_advisory_suppression.py
+++ b/tests/unit/test_intelligent_routing_advisory_suppression.py
@@ -71,8 +71,13 @@ def _snapshot() -> dict[str, str | None]:
     ],
 )
 def test_dead_zone_suppression_only_for_dead(status: str, expected: str | None) -> None:
+    """v3.15.16.1: suppression on status==dead requires the lookup to
+    have been exact_timeframe_match. This test pins the EXACT path
+    (suppression fires); the coarse path is pinned separately below.
+    """
     out = ir.derive_advisory_suppression_reason(
         dead_zone_status=status,
+        dead_zone_lookup_precision="exact_timeframe_match",
         near_duplicate_group=None,
         is_first_in_group=True,
     )
@@ -82,6 +87,7 @@ def test_dead_zone_suppression_only_for_dead(status: str, expected: str | None) 
 def test_near_duplicate_first_member_keeps_none() -> None:
     out = ir.derive_advisory_suppression_reason(
         dead_zone_status="alive",
+        dead_zone_lookup_precision="exact_timeframe_match",
         near_duplicate_group="abc123",
         is_first_in_group=True,
     )
@@ -91,6 +97,7 @@ def test_near_duplicate_first_member_keeps_none() -> None:
 def test_near_duplicate_non_first_member_is_suppressed() -> None:
     out = ir.derive_advisory_suppression_reason(
         dead_zone_status="alive",
+        dead_zone_lookup_precision="exact_timeframe_match",
         near_duplicate_group="abc123",
         is_first_in_group=False,
     )
@@ -100,6 +107,7 @@ def test_near_duplicate_non_first_member_is_suppressed() -> None:
 def test_dead_zone_takes_precedence_over_near_duplicate() -> None:
     out = ir.derive_advisory_suppression_reason(
         dead_zone_status="dead",
+        dead_zone_lookup_precision="exact_timeframe_match",
         near_duplicate_group="abc123",
         is_first_in_group=False,
     )
@@ -110,10 +118,51 @@ def test_dead_zone_takes_precedence_over_near_duplicate() -> None:
 def test_no_group_no_suppression() -> None:
     out = ir.derive_advisory_suppression_reason(
         dead_zone_status="alive",
+        dead_zone_lookup_precision="exact_timeframe_match",
         near_duplicate_group=None,
         is_first_in_group=True,
     )
     assert out is None
+
+
+# ---------------------------------------------------------------------------
+# v3.15.16.1 — coarse fallback NEVER triggers suppression
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "precision",
+    [
+        # Per the v3.15.16.1 spec: only exact_timeframe_match may
+        # trigger dead-zone suppression. Every other value MUST keep
+        # the suppression at None even when status == dead.
+        "coarse_unknown_timeframe_match",
+        "no_match",
+    ],
+)
+def test_dead_status_with_non_exact_lookup_does_not_suppress(precision: str) -> None:
+    out = ir.derive_advisory_suppression_reason(
+        dead_zone_status="dead",
+        dead_zone_lookup_precision=precision,
+        near_duplicate_group=None,
+        is_first_in_group=True,
+    )
+    assert out is None
+
+
+def test_coarse_dead_match_does_not_block_near_duplicate_suppression() -> None:
+    """If the campaign is a non-first near-duplicate group member AND
+    its dead-zone lookup is coarse, the near_duplicate suppression
+    still fires (the coarse dead-zone match must not "shadow" the
+    near-duplicate path; it just doesn't add its own
+    dead_zone_suppression)."""
+    out = ir.derive_advisory_suppression_reason(
+        dead_zone_status="dead",
+        dead_zone_lookup_precision="coarse_unknown_timeframe_match",
+        near_duplicate_group="g1",
+        is_first_in_group=False,
+    )
+    assert out == "near_duplicate"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_intelligent_routing_dead_zone_coarse_lookup.py
+++ b/tests/unit/test_intelligent_routing_dead_zone_coarse_lookup.py
@@ -1,0 +1,403 @@
+"""v3.15.16.1 — dead-zone coarse-lookup annotation tests.
+
+Pins (operator hard requirements from the v3.15.16.1 plan):
+
+* The dead-zone artifact lookup is a 2-tier resolution:
+  1. exact ``(asset_class, timeframe, family)`` match
+     → ``DEAD_ZONE_LOOKUP_EXACT``
+  2. coarse ``(asset_class, "unknown", family)`` match
+     → ``DEAD_ZONE_LOOKUP_COARSE``
+  3. neither → ``DEAD_ZONE_LOOKUP_NO_MATCH``
+* ``RoutingDecision.dead_zone_lookup_precision`` carries one of
+  ``DEAD_ZONE_LOOKUP_PRECISION_VALUES``.
+* Coarse matches MUST NOT trigger ``advisory_suppression_reason``,
+  MUST NOT alter ``advisory_priority_score``, MUST NOT alter
+  ``advisory_rank``.
+* Exact matches preserve the existing advisory dead-zone behavior.
+* The artifact still carries
+  ``routing_effect = "advisory_only"`` and
+  ``queue_ordering_effect = "none"``.
+* Missing / malformed dead-zone artifacts degrade safely.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+from pathlib import Path
+
+import pytest
+
+from reporting import intelligent_routing as ir
+
+
+# ---------------------------------------------------------------------------
+# Closed vocabulary pin
+# ---------------------------------------------------------------------------
+
+
+def test_dead_zone_lookup_precision_values_pinned() -> None:
+    assert ir.DEAD_ZONE_LOOKUP_EXACT == "exact_timeframe_match"
+    assert ir.DEAD_ZONE_LOOKUP_COARSE == "coarse_unknown_timeframe_match"
+    assert ir.DEAD_ZONE_LOOKUP_NO_MATCH == "no_match"
+    assert ir.DEAD_ZONE_LOOKUP_PRECISION_VALUES == (
+        "exact_timeframe_match",
+        "coarse_unknown_timeframe_match",
+        "no_match",
+    )
+
+
+# ---------------------------------------------------------------------------
+# classify_dead_zone_status — three-tier resolution
+# ---------------------------------------------------------------------------
+
+
+def _coords(family: str, asset: str, timeframe: str) -> ir.BehaviorCoordinates:
+    return ir.derive_behavior_coordinates(
+        strategy_family=family, asset_class=asset, timeframe=timeframe,
+    )
+
+
+def test_classify_returns_exact_match_when_timeframed_key_present() -> None:
+    index: dict[tuple[str, str, str], str] = {
+        ("crypto", "4h", "ema_crossover"): "dead",
+    }
+    coords = _coords("ema_crossover", "crypto", "4h")
+    assert ir.classify_dead_zone_status(coords, index) == (
+        "dead", "exact_timeframe_match",
+    )
+
+
+def test_classify_returns_coarse_when_only_unknown_timeframe_key_present() -> None:
+    """Mirrors the documented upstream form: zones keyed on
+    (asset, "unknown", family) per
+    research/dead_zone_detection.py:21-24."""
+    index: dict[tuple[str, str, str], str] = {
+        ("crypto", "unknown", "ema_crossover"): "dead",
+    }
+    coords = _coords("ema_crossover", "crypto", "4h")
+    assert ir.classify_dead_zone_status(coords, index) == (
+        "dead", "coarse_unknown_timeframe_match",
+    )
+
+
+def test_classify_prefers_exact_when_both_keys_present() -> None:
+    """If the artifact has both an exact and a coarse key for the
+    same (asset, family), the exact one wins. This is important so
+    a future v4-enriched artifact doesn't silently fall back to the
+    coarse form."""
+    index: dict[tuple[str, str, str], str] = {
+        ("crypto", "4h", "ema_crossover"): "alive",
+        ("crypto", "unknown", "ema_crossover"): "dead",
+    }
+    coords = _coords("ema_crossover", "crypto", "4h")
+    assert ir.classify_dead_zone_status(coords, index) == (
+        "alive", "exact_timeframe_match",
+    )
+
+
+def test_classify_returns_no_match_when_neither_form_present() -> None:
+    coords = _coords("ema_crossover", "crypto", "4h")
+    assert ir.classify_dead_zone_status(coords, {}) == (
+        "unknown", "no_match",
+    )
+
+
+def test_classify_with_unknown_timeframe_coords_does_not_double_match() -> None:
+    """If the campaign coords *themselves* have timeframe="unknown",
+    the exact lookup already matches the upstream's coarse form;
+    the helper must not also report 'coarse_unknown_timeframe_match'
+    in that case (that would be ambiguous)."""
+    index: dict[tuple[str, str, str], str] = {
+        ("crypto", "unknown", "ema_crossover"): "dead",
+    }
+    coords = _coords("ema_crossover", "crypto", "unknown")
+    status, precision = ir.classify_dead_zone_status(coords, index)
+    assert status == "dead"
+    # The coords have timeframe=unknown so the lookup IS exact for
+    # those coords (no fallback needed).
+    assert precision == "exact_timeframe_match"
+
+
+def test_classify_coarse_with_bogus_status_normalises_to_unknown() -> None:
+    index: dict[tuple[str, str, str], str] = {
+        ("crypto", "unknown", "ema_crossover"): "DEFINITELY_NOT_REAL",
+    }
+    coords = _coords("ema_crossover", "crypto", "4h")
+    status, precision = ir.classify_dead_zone_status(coords, index)
+    assert status == "unknown"
+    assert precision == "coarse_unknown_timeframe_match"
+
+
+# ---------------------------------------------------------------------------
+# build_report integration — coarse match is observability metadata only
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fixed_now_utc() -> _dt.datetime:
+    return _dt.datetime(2026, 5, 6, 12, 0, 0, tzinfo=_dt.timezone.utc)
+
+
+def _campaign_record(cid: str, spawned: str, family: str, asset: str, tf: str) -> dict:
+    return {
+        "campaign_id": cid,
+        "preset_name": "preset_x",
+        "strategy_family": family,
+        "asset_class": asset,
+        "extra": {"timeframe": tf},
+        "input_artifact_fingerprint": "fp_" + cid,
+        "spawned_at_utc": spawned,
+    }
+
+
+def _write_inputs(
+    tmp_path: Path,
+    queue: dict, registry: dict, dead_zones: dict, ig: dict,
+) -> dict[str, Path]:
+    paths = {
+        "queue": tmp_path / "q.json",
+        "registry": tmp_path / "r.json",
+        "dead_zones": tmp_path / "d.json",
+        "ig": tmp_path / "i.json",
+    }
+    paths["queue"].write_text(json.dumps(queue), encoding="utf-8")
+    paths["registry"].write_text(json.dumps(registry), encoding="utf-8")
+    paths["dead_zones"].write_text(json.dumps(dead_zones), encoding="utf-8")
+    paths["ig"].write_text(json.dumps(ig), encoding="utf-8")
+    return paths
+
+
+def _build(
+    tmp_path: Path, queue, registry, dead_zones, ig, now,
+) -> ir.RoutingReport:
+    paths = _write_inputs(tmp_path, queue, registry, dead_zones, ig)
+    return ir.build_report(
+        now_utc=now,
+        queue_path=paths["queue"],
+        registry_path=paths["registry"],
+        dead_zones_path=paths["dead_zones"],
+        information_gain_path=paths["ig"],
+    )
+
+
+def test_coarse_dead_match_populates_status_but_not_suppression(
+    tmp_path: Path, fixed_now_utc: _dt.datetime,
+) -> None:
+    """A campaign whose (asset, family) matches a coarse
+    timeframe="unknown" zone marked "dead" gets the status surfaced
+    AND the precision label, but its
+    advisory_suppression_reason stays None."""
+    queue = {"queue": [{"campaign_id": "col-1", "spawned_at_utc": "t"}]}
+    registry = {
+        "campaigns": {
+            "col-1": _campaign_record(
+                "col-1", "t", "ema_crossover", "crypto", "4h",
+            ),
+        },
+    }
+    dead_zones = {
+        "zones": [
+            {
+                "asset": "crypto",
+                "timeframe": "unknown",  # documented upstream form
+                "strategy_family": "ema_crossover",
+                "zone_status": "dead",
+            },
+        ],
+    }
+    report = _build(tmp_path, queue, registry, dead_zones, {}, fixed_now_utc)
+    decision = report.decisions[0]
+    assert decision.dead_zone_status == "dead"
+    assert decision.dead_zone_lookup_precision == "coarse_unknown_timeframe_match"
+    assert decision.advisory_suppression_reason is None
+    # Summary suppression counter is unchanged by the coarse match.
+    assert report.summary.advisory_suppressed_dead_zone == 0
+
+
+def test_exact_dead_match_still_triggers_suppression(
+    tmp_path: Path, fixed_now_utc: _dt.datetime,
+) -> None:
+    """When an exact (asset, timeframe, family) zone is marked dead,
+    the existing advisory dead-zone suppression behaviour is
+    preserved."""
+    queue = {"queue": [{"campaign_id": "col-1", "spawned_at_utc": "t"}]}
+    registry = {
+        "campaigns": {
+            "col-1": _campaign_record(
+                "col-1", "t", "ema_crossover", "crypto", "4h",
+            ),
+        },
+    }
+    dead_zones = {
+        "zones": [
+            {
+                "asset": "crypto",
+                "timeframe": "4h",  # exact match
+                "strategy_family": "ema_crossover",
+                "zone_status": "dead",
+            },
+        ],
+    }
+    report = _build(tmp_path, queue, registry, dead_zones, {}, fixed_now_utc)
+    decision = report.decisions[0]
+    assert decision.dead_zone_status == "dead"
+    assert decision.dead_zone_lookup_precision == "exact_timeframe_match"
+    assert decision.advisory_suppression_reason == "dead_zone"
+    assert report.summary.advisory_suppressed_dead_zone == 1
+
+
+def test_coarse_match_does_not_change_priority_or_rank_vs_no_match(
+    tmp_path: Path, fixed_now_utc: _dt.datetime,
+) -> None:
+    """Same campaign coords + same suppression status (None) →
+    advisory_priority_score and advisory_rank are identical
+    regardless of whether the coarse fallback hit. The coarse
+    match's only effect is on the metadata fields
+    (dead_zone_status + dead_zone_lookup_precision)."""
+    queue = {"queue": [{"campaign_id": "col-1", "spawned_at_utc": "t"}]}
+    registry = {
+        "campaigns": {
+            "col-1": _campaign_record(
+                "col-1", "t", "ema_crossover", "crypto", "4h",
+            ),
+        },
+    }
+    coarse_zones = {
+        "zones": [
+            {
+                "asset": "crypto",
+                "timeframe": "unknown",
+                "strategy_family": "ema_crossover",
+                "zone_status": "dead",
+            },
+        ],
+    }
+    no_zones = {"zones": []}
+
+    coarse_report = _build(tmp_path, queue, registry, coarse_zones, {}, fixed_now_utc)
+    no_match_report = _build(tmp_path, queue, registry, no_zones, {}, fixed_now_utc)
+
+    coarse_d = coarse_report.decisions[0]
+    none_d = no_match_report.decisions[0]
+    assert coarse_d.advisory_priority_score == none_d.advisory_priority_score
+    assert coarse_d.advisory_rank == none_d.advisory_rank
+    assert coarse_d.advisory_suppression_reason == none_d.advisory_suppression_reason
+    # The metadata fields differ — that's the entire point.
+    assert coarse_d.dead_zone_status == "dead"
+    assert none_d.dead_zone_status == "unknown"
+    assert coarse_d.dead_zone_lookup_precision == "coarse_unknown_timeframe_match"
+    assert none_d.dead_zone_lookup_precision == "no_match"
+
+
+def test_coarse_alive_match_is_distinguishable_from_exact_alive(
+    tmp_path: Path, fixed_now_utc: _dt.datetime,
+) -> None:
+    """An alive zone reached via coarse fallback must report
+    coarse_unknown_timeframe_match (not exact_timeframe_match) so
+    operators can distinguish the two."""
+    queue = {"queue": [{"campaign_id": "col-1", "spawned_at_utc": "t"}]}
+    registry = {
+        "campaigns": {
+            "col-1": _campaign_record(
+                "col-1", "t", "rsi_extreme", "equity", "1d",
+            ),
+        },
+    }
+    dead_zones = {
+        "zones": [
+            {
+                "asset": "equity",
+                "timeframe": "unknown",
+                "strategy_family": "rsi_extreme",
+                "zone_status": "alive",
+            },
+        ],
+    }
+    report = _build(tmp_path, queue, registry, dead_zones, {}, fixed_now_utc)
+    decision = report.decisions[0]
+    assert decision.dead_zone_status == "alive"
+    assert decision.dead_zone_lookup_precision == "coarse_unknown_timeframe_match"
+
+
+def test_no_zone_artifact_yields_no_match_precision(
+    tmp_path: Path, fixed_now_utc: _dt.datetime,
+) -> None:
+    queue = {"queue": [{"campaign_id": "col-1", "spawned_at_utc": "t"}]}
+    registry = {
+        "campaigns": {
+            "col-1": _campaign_record(
+                "col-1", "t", "ema_crossover", "crypto", "4h",
+            ),
+        },
+    }
+    report = _build(tmp_path, queue, registry, {"zones": []}, {}, fixed_now_utc)
+    decision = report.decisions[0]
+    assert decision.dead_zone_status == "unknown"
+    assert decision.dead_zone_lookup_precision == "no_match"
+
+
+def test_malformed_dead_zone_artifact_degrades_to_no_match(
+    tmp_path: Path, fixed_now_utc: _dt.datetime,
+) -> None:
+    """A malformed dead-zone payload must not crash the report; every
+    row gets dead_zone_lookup_precision='no_match'."""
+    queue = {"queue": [{"campaign_id": "col-1", "spawned_at_utc": "t"}]}
+    registry = {
+        "campaigns": {
+            "col-1": _campaign_record(
+                "col-1", "t", "ema_crossover", "crypto", "4h",
+            ),
+        },
+    }
+    paths = {
+        "queue": tmp_path / "q.json",
+        "registry": tmp_path / "r.json",
+        "dead_zones": tmp_path / "d.json",
+        "ig": tmp_path / "i.json",
+    }
+    paths["queue"].write_text(json.dumps(queue), encoding="utf-8")
+    paths["registry"].write_text(json.dumps(registry), encoding="utf-8")
+    paths["dead_zones"].write_text("not json", encoding="utf-8")
+    paths["ig"].write_text(json.dumps({}), encoding="utf-8")
+    report = ir.build_report(
+        now_utc=fixed_now_utc,
+        queue_path=paths["queue"],
+        registry_path=paths["registry"],
+        dead_zones_path=paths["dead_zones"],
+        information_gain_path=paths["ig"],
+    )
+    assert report.decisions[0].dead_zone_lookup_precision == "no_match"
+
+
+def test_artifact_still_carries_advisory_framing_with_coarse_match(
+    tmp_path: Path, fixed_now_utc: _dt.datetime,
+) -> None:
+    """Belt-and-braces: even when coarse fallback fires for a 'dead'
+    coarse zone, the artifact still carries
+    routing_effect=advisory_only and queue_ordering_effect=none."""
+    queue = {"queue": [{"campaign_id": "col-1", "spawned_at_utc": "t"}]}
+    registry = {
+        "campaigns": {
+            "col-1": _campaign_record(
+                "col-1", "t", "ema_crossover", "crypto", "4h",
+            ),
+        },
+    }
+    dead_zones = {
+        "zones": [
+            {
+                "asset": "crypto",
+                "timeframe": "unknown",
+                "strategy_family": "ema_crossover",
+                "zone_status": "dead",
+            },
+        ],
+    }
+    report = _build(tmp_path, queue, registry, dead_zones, {}, fixed_now_utc)
+    payload = report.to_payload()
+    assert payload["routing_effect"] == "advisory_only"
+    assert payload["queue_ordering_effect"] == "none"
+    assert payload["decisions"][0]["dead_zone_lookup_precision"] == (
+        "coarse_unknown_timeframe_match"
+    )

--- a/tests/unit/test_intelligent_routing_pure.py
+++ b/tests/unit/test_intelligent_routing_pure.py
@@ -206,20 +206,27 @@ def _coords(family: str, asset: str, timeframe: str) -> ir.BehaviorCoordinates:
 
 def test_classify_dead_zone_status_lookup_hits() -> None:
     # Index keyed on (asset, timeframe, family) — same key the upstream
-    # dead-zone artifact uses.
+    # dead-zone artifact uses. v3.15.16.1: the helper returns a
+    # 2-tuple (status, lookup_precision).
     index: dict[tuple[str, str, str], str] = {
         ("crypto", "4h", "ema_crossover"): "dead",
         ("equities", "1d", "rsi_extreme"): "alive",
     }
     coords1 = _coords("ema_crossover", "crypto", "4h")
     coords2 = _coords("rsi_extreme", "equities", "1d")
-    assert ir.classify_dead_zone_status(coords1, index) == "dead"
-    assert ir.classify_dead_zone_status(coords2, index) == "alive"
+    assert ir.classify_dead_zone_status(coords1, index) == (
+        "dead", "exact_timeframe_match",
+    )
+    assert ir.classify_dead_zone_status(coords2, index) == (
+        "alive", "exact_timeframe_match",
+    )
 
 
 def test_classify_dead_zone_status_missing_collapses_to_unknown() -> None:
     coords = _coords("does_not_exist", "crypto", "4h")
-    assert ir.classify_dead_zone_status(coords, {}) == "unknown"
+    assert ir.classify_dead_zone_status(coords, {}) == (
+        "unknown", "no_match",
+    )
 
 
 def test_classify_dead_zone_status_only_returns_closed_taxonomy() -> None:
@@ -227,9 +234,12 @@ def test_classify_dead_zone_status_only_returns_closed_taxonomy() -> None:
         ("crypto", "4h", "ema_crossover"): "DEFINITELY_NOT_A_REAL_STATUS",
     }
     coords = _coords("ema_crossover", "crypto", "4h")
-    out = ir.classify_dead_zone_status(coords, bogus_index)
-    assert out in ir.DEAD_ZONE_STATUSES
-    assert out == "unknown"
+    status, precision = ir.classify_dead_zone_status(coords, bogus_index)
+    assert status in ir.DEAD_ZONE_STATUSES
+    assert status == "unknown"
+    # Bogus statuses still register the lookup as exact (the key was
+    # present in the artifact); only the status itself is normalised.
+    assert precision == "exact_timeframe_match"
 
 
 # ---------------------------------------------------------------------------
@@ -329,6 +339,7 @@ def test_routing_decision_payload_uses_advisory_field_names() -> None:
         info_gain_score=0.42,
         info_gain_bucket="medium",
         dead_zone_status="alive",
+        dead_zone_lookup_precision="exact_timeframe_match",
         near_duplicate_group=None,
         orthogonality_bucket="novel",
         advisory_suppression_reason=None,
@@ -340,6 +351,8 @@ def test_routing_decision_payload_uses_advisory_field_names() -> None:
     assert "advisory_suppression_reason" in payload
     assert "advisory_priority_score" in payload
     assert "advisory_rank" in payload
+    assert "dead_zone_lookup_precision" in payload  # v3.15.16.1
+    assert payload["dead_zone_lookup_precision"] == "exact_timeframe_match"
     assert "suppression_reason" not in payload
     assert "recommended_priority" not in payload
     assert "priority" not in payload
@@ -370,6 +383,7 @@ def test_routing_report_payload_carries_advisory_framing() -> None:
         info_gain_score=0.0,
         info_gain_bucket="none",
         dead_zone_status="unknown",
+        dead_zone_lookup_precision="no_match",
         near_duplicate_group=None,
         orthogonality_bucket="novel",
         advisory_suppression_reason=None,


### PR DESCRIPTION
## Summary

**Operator-approved restricted scope.** Adds an observability annotation for the documented upstream limit (dead-zone zones currently keyed on \`(asset, \"unknown\", family)\` per [research/dead_zone_detection.py:21-24](research/dead_zone_detection.py:21)) WITHOUT introducing any new queue-influencing behaviour.

### Hard contract preserved

- \`routing_effect = \"advisory_only\"\`
- \`queue_ordering_effect = \"none\"\`

### What changed

\`reporting/intelligent_routing.py\`:

- New constants: \`DEAD_ZONE_LOOKUP_EXACT\`, \`DEAD_ZONE_LOOKUP_COARSE\`, \`DEAD_ZONE_LOOKUP_NO_MATCH\`, \`DEAD_ZONE_LOOKUP_PRECISION_VALUES\`.
- \`RoutingDecision\` gains a single new field \`dead_zone_lookup_precision: str\`.
- \`classify_dead_zone_status\` now returns a 2-tuple \`(status, lookup_precision)\` with three-tier resolution:
    1. exact \`(asset_class, timeframe, family)\` → \`exact_timeframe_match\`
    2. coarse \`(asset_class, \"unknown\", family)\` when timeframe is real → \`coarse_unknown_timeframe_match\`
    3. neither → \`no_match\`
  Coarse is skipped when coords already use \`timeframe=\"unknown\"\` so the helper does not double-report ambiguity.
- \`derive_advisory_suppression_reason\` gains \`dead_zone_lookup_precision\` kwarg. Tier-1 (\`dead_zone\`) suppression now requires BOTH \`status == DEAD_ZONE_DEAD\` AND \`precision == DEAD_ZONE_LOOKUP_EXACT\`. **A coarse match with status=\"dead\" produces NO suppression, NO priority delta, NO rank delta — only the metadata fields differ.** Tier-2 (\`near_duplicate\`) is unchanged; a coarse-dead row that is also a non-first near-duplicate still gets near_duplicate suppression.
- \`build_report\` plumbs the precision through.

\`docs/governance/intelligent_routing_observation.md\`:

- New \"v3.15.16.1 — dead-zone coarse-lookup annotation only\" section pinning the exact / coarse / no_match semantics and explicitly stating that coarse fallback is observability metadata only.
- New \"Current upstream-signal limits\" section documenting the three known producer-side gaps (dead-zone timeframe=\"unknown\", IG single-campaign artifact, strategy_family partial population).
- New \"Queue integration remains deferred\" section listing the five upstream-signal-readiness preconditions; v3.15.17 Sampling Intelligence noted as deferred against the same gate.

### Tests (14 new + 5 updated; 191/191 green locally)

\`tests/unit/test_intelligent_routing_dead_zone_coarse_lookup.py\` (NEW): closed-vocabulary pinning, three-tier resolution semantics, build_report integration proving:

- coarse dead populates status but NOT \`advisory_suppression_reason\`,
- exact dead still triggers advisory dead-zone suppression (existing behaviour preserved),
- coarse match leaves \`advisory_priority_score\` AND \`advisory_rank\` identical to a no-match build of the same row,
- coarse alive is distinguishable from exact alive via the precision label,
- malformed dead-zone payload degrades to \`no_match\` (no crash),
- artifact still carries \`routing_effect=advisory_only\` + \`queue_ordering_effect=none\` even when coarse fires on a \"dead\" zone.

\`tests/unit/test_intelligent_routing_advisory_suppression.py\` (updated): existing tests now pass \`dead_zone_lookup_precision=\"exact_timeframe_match\"\` explicitly. New tests for non-exact precision (coarse OR no_match) yielding None; coarse-dead not blocking near-duplicate suppression.

\`tests/unit/test_intelligent_routing_pure.py\` (updated): \`classify_dead_zone_status\` tests unpack the new 2-tuple; \`RoutingDecision\` payload test extended to assert \`dead_zone_lookup_precision\` is in the payload.

**No tests weakened, skipped, deleted, or marked \`xfail\`. No \`pytest.importorskip\` introduced.**

### NOT changed

- No queue integration. \`queue_ordering_effect=\"none\"\`.
- No scoring weights changed.
- No multi-campaign IG ledger reader (deferred per operator).
- No \`research/**\` mutation.
- No \`dashboard/**\` changes.
- No \`live/paper/shadow/risk/trading/broker/execution\` touched.
- No frozen contract mutated.
- No Roadmap v6 rewrite.
- No workflow change (new fields are in \`latest.json\`, already uploaded by the existing observe-intelligent-routing workflow with zero inputs).
- No \`.claude/**\` changes.

### After merge

\`\`\`
gh workflow run observe-intelligent-routing.yml --ref main
\`\`\`

Then inspect \`logs/intelligent_routing/latest.json\`. If the upstream artifact has zones for any \`(asset, family)\` pair seen in the queue, those rows now carry status + \`precision=\"coarse_unknown_timeframe_match\"\` without affecting suppression / priority / rank.

## Test plan

- [x] \`python -m pytest tests/unit/test_intelligent_routing_*.py tests/integration/test_intelligent_routing_*.py tests/smoke/test_intelligent_routing_smoke.py -q\` → 191 passed.
- [x] \`python scripts/governance_lint.py\` → clean.
- [x] CI fast pre-merge gate.
- [ ] After merge: dispatch the existing observation workflow twice; confirm coarse fallback fires where applicable AND advisory_suppression_reason / priority / rank do not change vs no-match builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)