### PR TITLE
fix(v3.15.16.2.diag.1): correct IG ledger diagnostic path

### DIFF
--- a/.github/workflows/observe-intelligent-routing.yml
+++ b/.github/workflows/observe-intelligent-routing.yml
@@ -303,13 +303,24 @@ jobs:
           PY
 
           # v3.15.16.2.diag — IG-ledger-shape diagnostic. Streams the
-          # append-only campaign_evidence_ledger.jsonl line-by-line
-          # and emits a sanitized summary (counters + key sets +
-          # mapping-evidence counts only — NEVER full event bodies,
-          # NEVER secrets, NEVER raw nested payloads). Output is a
-          # single new file under the existing log directory:
+          # append-only campaign-evidence ledger line-by-line and
+          # emits a sanitized summary (counters + key sets + mapping-
+          # evidence counts only — NEVER full event bodies, NEVER
+          # secrets, NEVER raw nested payloads). Output is a single
+          # new file under the existing log directory:
           # logs/intelligent_routing/ig_ledger_shape_diagnostic.json.
           # Pure stdlib; bounded memory; bounded line scan.
+          #
+          # v3.15.16.2.diag.1 — corrected ledger path. The previous
+          # diagnostic targeted ``research/campaign_evidence_ledger.jsonl``
+          # which does NOT exist on the VPS (verified empirically by
+          # the prior diagnostic run; PR #127 / merge 4dcd5460). The
+          # canonical writer lives at
+          # ``research/campaign_evidence_ledger_latest.v1.jsonl`` per
+          # research/campaign_launcher.py:146 and
+          # research/diagnostics/paths.py:169 (CAMPAIGN_EVIDENCE_LEDGER_PATH).
+          # The literal corrected path is used here so the diagnostic
+          # is fully self-contained and never imports research modules.
           python3 - <<'PY'
           import json
           from collections import Counter
@@ -317,7 +328,7 @@ jobs:
 
           OUT = Path("logs/intelligent_routing/ig_ledger_shape_diagnostic.json")
           OUT.parent.mkdir(parents=True, exist_ok=True)
-          LEDGER = Path("research/campaign_evidence_ledger.jsonl")
+          LEDGER = Path("research/campaign_evidence_ledger_latest.v1.jsonl")
           MAX_LINES = 1_000_000
 
           # Probe field-name vocabularies (closed). The presence of

--- a/docs/governance/intelligent_routing_observation.md
+++ b/docs/governance/intelligent_routing_observation.md
@@ -241,13 +241,25 @@ no secrets). It is purely diagnostic — used to confirm what fields
 the routing layer can safely index without inferring metadata from
 `campaign_id`.
 
-The optional `ig_ledger_shape_diagnostic.json` (v3.15.16.2.diag) is
-a **sanitized** preview of the append-only
-`research/campaign_evidence_ledger.jsonl` ledger. It exists to help
-calibrate a future reporting-only multi-campaign Information Gain
-ledger reader (proposed v3.15.16.2). The diagnostic emits **counts,
-key sets, and bounded scalar values only** — never full event
-bodies, never raw nested payloads, never secrets. Specifically:
+The optional `ig_ledger_shape_diagnostic.json`
+(v3.15.16.2.diag, path-corrected in v3.15.16.2.diag.1) is a
+**sanitized** preview of the append-only campaign-evidence ledger
+at `research/campaign_evidence_ledger_latest.v1.jsonl`. The path
+matches the canonical writer in
+[`research/campaign_launcher.py:146`](../../research/campaign_launcher.py:146)
+and the constant
+`CAMPAIGN_EVIDENCE_LEDGER_PATH` at
+[`research/diagnostics/paths.py:169`](../../research/diagnostics/paths.py:169).
+(The unsuffixed path
+`research/campaign_evidence_ledger.jsonl` referenced in
+`research/research_evidence_ledger.py:42` is a stale alias and is
+**not** what the producer writes.)
+
+The diagnostic exists to help calibrate a future reporting-only
+multi-campaign Information Gain ledger reader (proposed
+v3.15.16.2). It emits **counts, key sets, and bounded scalar
+values only** — never full event bodies, never raw nested
+payloads, never secrets. Specifically:
 
 * Ledger presence + size + line counts (`line_count`,
   `parsed_line_count`, `malformed_line_count`, `truncated`,


### PR DESCRIPTION
## Summary

**Operator-approved diagnostic-only follow-up to [#127](https://github.com/roudjy/trading-agent/pull/127).** The prior diagnostic targeted \`research/campaign_evidence_ledger.jsonl\` which does NOT exist on the VPS (empirically verified by the diagnostic run, which reported \`present=false\` / \`file_size_bytes=0\` across every distribution).

The canonical writer is at \`research/campaign_evidence_ledger_latest.v1.jsonl\` per [research/campaign_launcher.py:146](research/campaign_launcher.py:146) (the producer's literal string target) and [research/diagnostics/paths.py:169](research/diagnostics/paths.py:169) (\`CAMPAIGN_EVIDENCE_LEDGER_PATH\`). The unsuffixed path in \`research/research_evidence_ledger.py:42\` is a stale alias and is NOT what the producer writes.

### Scope (operator allowlist for this PR only)

| File | Change |
|---|---|
| \`.github/workflows/observe-intelligent-routing.yml\` | Single literal-path fix in the diagnostic Python heredoc + a multi-line comment block citing the canonical sources |
| \`docs/governance/intelligent_routing_observation.md\` | Runbook updated to reference the corrected path and call out the stale alias |

No other file modified. The diagnostic step's behaviour is byte-identical to [#127](https://github.com/roudjy/trading-agent/pull/127)'s **except** for the ledger path. All sanitization, bounded scanning (\`MAX_LINES = 1_000_000\`), pre/post sha256 frozen-contract pin, tracked-file mutation check, and untracked-delta allowlist are unchanged. The diagnostic does NOT import research modules just to resolve the path; the literal corrected path is hard-coded.

### What this PR does NOT do

- Does NOT implement the v3.15.16.2 IG ledger reader.
- Does NOT modify \`reporting/intelligent_routing.py\` or \`_status.py\`.
- Does NOT change scoring weights or bucket boundaries.
- Does NOT mutate any frozen contract.
- Does NOT introduce v3.15.17.
- Does NOT introduce queue integration.

### Validation locally

- \`python scripts/governance_lint.py\` → \"Governance lint OK (16 agents, 5 workflows checked).\"
- YAML \`safe_load\` parses cleanly; \`jobs.observe\` has 7 steps as before.
- \`git diff main\` shows only the two authorized files.

### After merge

\`gh workflow run observe-intelligent-routing.yml --ref main\`

The corrected diagnostic should now report \`present=true\` and emit real distributions across \`event_type\`, \`meaningful_classification\`, \`outcome\`, \`reason_code\`, \`events_per_campaign_histogram\`, and the candidate mapping-evidence counters — providing the calibration evidence needed to review (in a separate operator-blessed task) the v3.15.16.2 reader's event-type allowlist + score mapping.

## Test plan

- [x] Governance lint clean.
- [x] YAML parse + diff scope check.
- [x] CI fast pre-merge gate.
- [ ] After merge: dispatch and confirm the corrected diagnostic JSON has real distributions; produce final calibration report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)