### PR TITLE
feat(A8): autonomous development operating queue foundation

### DIFF
--- a/docs/governance/development_work_queue.md
+++ b/docs/governance/development_work_queue.md
@@ -1,0 +1,291 @@
+# Autonomous Development Operating Queue (A8)
+
+> Canonical governance document for the Development Work Queue
+> introduced in A8. Read-only schema + vocabularies + reporting CLI.
+
+## Status correction
+
+Earlier handoffs described the Autonomous Development Track as
+"complete" after PRs #110–#116. That wording was misleading from the
+operator's perspective. The corrected framing is:
+
+- **Autonomous Development Governance Foundation: complete (A1–A7).**
+  Execution Authority policy + classifier, read-only authority/
+  readiness surfaces, proposal-queue cleanup, backlog discipline
+  reporting, and a final readiness gate are all in place.
+- **Autonomous Development Operating Queue: begins at A8.**
+  This is the first concrete, repo-native foundation for the
+  development operating loop. A8 is foundation only — schema +
+  vocabulary + read-only reporting + tests + docs.
+- **Fully autonomous code-development loop: future work.** A9
+  (release-gate integration), A10 (bugfix loop), A11 (bounded
+  delegation), A12 (operational digest) build on top of A8.
+
+## What this is — and is not
+
+This queue is the **autonomous development queue**: roadmap, build,
+maintenance, governance, reporting, test, docs, CI, deployment,
+release, observability, and refactor work for the repository itself.
+
+This queue is **not**:
+
+- the QRE research campaign queue (research execution ordering);
+- the Intelligent Routing Layer queue (advisory research routing);
+- `reporting.proposal_queue` (intake of roadmap proposals).
+
+The module name, file path, and artifact path all use
+`development_work_queue` so the distinction is impossible to miss.
+
+## Canonical sources
+
+The queue accepts items declared in the operator-authored sidecar:
+
+- `docs/development_work_queue/seed.jsonl`
+
+The file follows strict JSONL: each non-blank line is a single JSON
+object describing one work item. The committed file is **empty** by
+default — that is the correct state. Items are added by the operator
+only. Blank lines are tolerated; there are no comment lines.
+
+### Seed item schema
+
+Each JSON object on a line provides:
+
+| Field | Type | Notes |
+|---|---|---|
+| `title` | str (≤ 200) | Required |
+| `source_document` | str | Canonical roadmap path or `"sidecar_seed"` |
+| `source_section_or_anchor` | str | Free-text section reference |
+| `roadmap_track` | str | One of `autonomous_development`, `qre_feature_build`, `sidecar_seed` |
+| `category` | str | One of the 10 closed `CATEGORIES` |
+| `required_agent_role` | str | One of the 16 closed `AGENT_ROLES` |
+| `supporting_agent_roles` | list[str] | Subset of `AGENT_ROLES` |
+| `status` | str | One of the 12 closed `STATUSES` |
+| `human_needed` | bool | Explicit operator declaration |
+| `human_needed_reason` | str | One of the 11 closed reasons; `"none"` iff `human_needed=false` |
+| `blocked_by` | list[str] | Item-IDs |
+| `priority` | int | Clamped to 1..5 |
+| `risk_level` | str | One of `LOW`, `MEDIUM`, `HIGH`, `UNKNOWN` |
+| `protected_surface` | bool | Whether the item touches a protected surface |
+| `acceptance_criteria` | list[str] | ≤ 16 entries, ≤ 200 chars each |
+| `validation_requirements` | list[str] | Same bounds |
+| `notes` | str (≤ 1000) | Bounded scalar — no diffs / patches |
+
+`item_id` is computed deterministically from `title +
+source_section_or_anchor`. `execution_authority` is filled in by
+the generator from `reporting.execution_authority.classify`.
+
+A reference example is rendered in the project tests
+(`tests/unit/test_development_work_queue.py::_valid_item`).
+
+The two canonical roadmap docs remain the truth-of-record for the
+roadmap itself:
+
+- `docs/roadmap/autonomous_development.txt` (Autonomous Development Track)
+- `docs/roadmap/Roadmap v6.md` (QRE Feature Build Track)
+
+Items in the seed may name either canonical document as their
+`source_document` (declaring the relevant `roadmap_track`) or use
+`sidecar_seed` for items that do not yet have an upstream roadmap
+anchor.
+
+Anything under `docs/roadmap/archive/**` is historical and is
+**rejected** at parse time.
+
+## Closed vocabularies
+
+All vocabularies are closed `Final[tuple[str, ...]]` constants in
+`reporting/development_work_queue.py`. Adding a value requires a
+visible code change with a matching test update.
+
+### Agent roles (16)
+
+The role describes who is mandated to act on the item. The 15
+non-human roles correspond to the agents in `.claude/agents/*`;
+`human_operator` is the explicit fallback for items the human owns.
+
+```
+product_owner            — backlog curation, one-PR-per-session discipline
+strategic_advisor        — long-horizon, cross-cutting trade-offs (advise only)
+quant_research_architect — research authority and ledger correctness (advise only)
+planner                  — decomposes a roadmap item into ordered tasks
+architecture_guardian    — enforces ADR invariants (advise only)
+ci_guardian              — workflow edits in dedicated CI-hardening tasks
+implementation_agent     — backend non-core implementation
+frontend_agent           — React/Vite/Vitest implementation
+test_agent               — test authoring within allowed scopes
+determinism_guardian     — pin tests, digest recompute (advise only)
+evidence_verifier        — append-only ledger / audit-chain checks
+observability_guardian   — structured logging, audit events, healthchecks
+deployment_safety_agent  — compose/ops/deploy review (advise only)
+adversarial_reviewer     — red-team review (advise only)
+release_gate_agent       — final go/no-go report per release step
+human_operator           — explicit human authority
+```
+
+Whether an agent may implement / review / verify / advise is
+recorded in the per-agent `.claude/agents/*.md` definition. The
+queue uses `required_agent_role` to identify the primary owner and
+`supporting_agent_roles` to list reviewers / verifiers.
+
+### Statuses (12, Kanban)
+
+```
+proposed         — captured, not yet considered
+triaged          — categorized, owner identified
+planned          — has a concrete plan
+ready            — fully scoped, agent may pick up
+in_progress      — being executed
+blocked          — waiting on a dependency in `blocked_by`
+human_needed     — operator decision required (see `human_needed_reason`)
+review_needed    — work delivered, awaiting review
+validation_needed — work delivered, awaiting verification
+done             — finished and merged
+rejected         — explicitly declined
+archived         — closed without resolution; preserved for audit
+```
+
+### Categories (10)
+
+```
+governance, reporting, frontend, test, docs, ci, deployment,
+release, observability, refactor
+```
+
+### Risk levels (4)
+
+Reused verbatim from `reporting.execution_authority.RISK_CLASSES`:
+
+```
+LOW, MEDIUM, HIGH, UNKNOWN
+```
+
+### Human-needed reasons (11)
+
+```
+architecture_crossroads
+protected_governance_change
+frozen_contract_change
+risk_policy_change
+capital_or_live_execution_related
+destructive_or_irreversible_action
+priority_conflict
+ambiguous_scope
+missing_acceptance_criteria
+repeated_validation_failure
+none
+```
+
+`none` is reserved for `human_needed: false` rows. The two-way
+invariant is enforced at parse time and pinned by tests.
+
+## When human involvement is required
+
+`human_needed: true` is set explicitly per item. A reason from the
+closed vocabulary above is required. The intent is that
+`human_needed` reflects only **explicit** triggers:
+
+- architecture crossroads (multi-option ADR-level decisions);
+- protected governance / frozen-contract / risk-policy changes;
+- anything live / paper / shadow / capital-related;
+- destructive or irreversible actions;
+- a real priority conflict;
+- ambiguous scope or missing acceptance criteria;
+- repeated validation failure on a previously delivered item.
+
+Plain roadmap headings, unscoped notes, and ordinary documentation
+work do **not** become `human_needed`. The default state is *not*
+escalation.
+
+## How this relates to the Execution Authority foundation
+
+For each item, the generator runs:
+
+```
+reporting.execution_authority.classify(
+    action_type="file_edit",
+    target_path=item.source_document,
+    risk_class=item.risk_level,
+)
+```
+
+The decision (`AUTO_ALLOWED` / `NEEDS_HUMAN` / `PERMANENTLY_DENIED`)
+is recorded on the item as `execution_authority`. Mismatches between
+the operator-declared `human_needed` and the classifier's decision
+surface as `validation_warnings` on the artifact wrapper. The
+classifier never silently overrides the operator.
+
+This is the **same** classifier that backs A1–A2. The Operating
+Queue does not redefine authority — it consumes the existing
+authority signal.
+
+## What is ready for autonomous agent action
+
+The `counts.ready_for_autonomous_action` aggregate counts items where:
+
+- `execution_authority == "AUTO_ALLOWED"`, **and**
+- `human_needed == false`, **and**
+- `status in {"ready", "in_progress"}`.
+
+`counts.requiring_human_operator` counts items where any of:
+
+- `human_needed == true`, **or**
+- `execution_authority == "NEEDS_HUMAN"`, **or**
+- `status == "human_needed"`.
+
+These counts are surfaced verbatim by
+`reporting.development_work_queue_status` so the operator can see at
+a glance how many items are queue-ready and how many are gated.
+
+## A8 v0 limitations (intentional)
+
+A8 explicitly does not deliver:
+
+- Markdown marker parsing inside the canonical roadmap docs. The
+  schema reserves `roadmap_track in {autonomous_development,
+  qre_feature_build}` for that future input mode; today's only
+  input is the sidecar seed.
+- Wiring into `reporting.recurring_maintenance.JOB_TYPES`. The CLI
+  is the explicit operator-driven invocation.
+- Auto-approve, auto-merge, auto-execute behavior.
+- Any LLM-driven runtime planner.
+- Frontend dashboard surface (CLI-only for now).
+
+## Future phases (sketch)
+
+- **A9 — Agentic release-gate integration.** Wire the
+  `release_gate_agent` mandate into the queue: items in
+  `release` category with `status == validation_needed` produce a
+  go/no-go report.
+- **A10 — Agentic bugfix loop.** Bounded-scope bugfix items in the
+  `refactor` / `reporting` categories may move from `ready` to
+  `in_progress` without human gating when `execution_authority ==
+  AUTO_ALLOWED` and a deterministic test reproduces the bug.
+- **A11 — Bounded roadmap implementation delegation.** Plain roadmap
+  decomposition by the `planner` agent into the seed file, with the
+  decomposition itself read by a human before the items become
+  `ready`.
+- **A12 — Operational digest.** Aggregate the
+  `development_work_queue` history over time so the operator can see
+  throughput, bottlenecks, and human-needed escalation trends.
+
+## Hard guarantees
+
+- Stdlib + `reporting.execution_authority` + `reporting.approval_policy` only.
+- No subprocess, no network, no `gh`, no `git`.
+- No imports from `dashboard`, `automation`, `broker`, `agent.risk`,
+  `agent.execution`, `research`.
+- No mutation of research artifacts, frozen contracts, IR artifacts,
+  scoring, or queue ordering.
+- Atomic write under `logs/development_work_queue/latest.json` only.
+- Items declare deterministic timestamp placeholders so per-item
+  bytes are reproducible across runs.
+
+## CLI surface
+
+```
+python -m reporting.development_work_queue            # writes artifact
+python -m reporting.development_work_queue --no-write  # stdout only
+python -m reporting.development_work_queue_status      # writes status artifact
+python -m reporting.development_work_queue_status --no-write
+```

--- a/docs/roadmap/autonomous_development.txt
+++ b/docs/roadmap/autonomous_development.txt
@@ -707,6 +707,133 @@ unless the operator explicitly starts the corresponding QRE Feature Build Track 
 
 \---
 
+# A8 — Autonomous Development Operating Queue Foundation
+
+## Status
+
+```text
+Status: PR-ready (NOT complete)
+```
+
+A8 is marked complete only after the PR's CI is green, the squash merge has landed on `main`, and post-merge gates pass. Until then, this section reads `PR-ready` and the operator may move it to `Implementing` if a hard blocker emerges.
+
+## Correction
+
+The wording "Autonomous Development Track complete" was misleading from the operator's perspective. Replace with:
+
+```text
+Autonomous Development Governance Foundation: complete (A1–A7).
+Autonomous Development Operating Queue: begins at A8.
+Fully autonomous code-development loop: future work (A9–A12).
+```
+
+A1–A7 delivered the policy, classifier, read-only authority/readiness surfaces, proposal-queue cleanup, backlog discipline, and the readiness gate. None of those provide a Kanban-style operating queue, agent mandate routing, or human-needed escalation semantics — so they cannot count as autonomous development on their own.
+
+## Purpose
+
+A8 introduces the first concrete, repo-native foundation for the autonomous development operating loop:
+
+```text
+- a deterministic, read-only Kanban-style development work queue;
+- explicit agent mandate vocabulary;
+- closed Kanban status vocabulary;
+- closed human-needed reason vocabulary;
+- a stable JSON artifact under logs/development_work_queue/latest.json;
+- a status summary CLI for operator visibility.
+```
+
+It is **not** the QRE research campaign queue, **not** the Intelligent Routing advisory queue, and **not** `reporting.proposal_queue`. The module path, file name, and log path all use `development_work_queue` to make the distinction structural.
+
+## Scope
+
+Allowed:
+
+```text
+read-only reporting modules (reporting/development_work_queue.py and reporting/development_work_queue_status.py)
+operator-authored sidecar seed (docs/development_work_queue/seed.jsonl, strict JSONL, empty by default)
+governance documentation (docs/governance/development_work_queue.md)
+unit tests under tests/unit/
+```
+
+Not allowed in this phase:
+
+```text
+no QRE research campaign queue ordering changes
+no Intelligent Routing scoring or queue ordering changes
+no v3.15.17 work
+no auto-execute, auto-approve, auto-merge behavior
+no LLM-driven runtime planner
+no live/paper/shadow/risk/trading/broker/execution behavior changes
+no .claude/ writes
+no frozen-contract mutation
+no recurring_maintenance JOB_TYPES wiring (deferred to A9)
+no markdown roadmap-marker parser (schema reserved; not implemented in v0)
+```
+
+## Required deliverables
+
+```text
+1. reporting/development_work_queue.py — generator, vocabularies, schema, CLI.
+2. reporting/development_work_queue_status.py — read-only summary CLI.
+3. docs/development_work_queue/seed.jsonl — empty strict-JSONL placeholder.
+4. docs/governance/development_work_queue.md — governance doc explaining the autonomy correction, the mandate model, human-needed semantics, A8 v0 limits, and the A9–A12 outlook.
+5. tests/unit/test_development_work_queue.py — vocabulary, schema, parser, archive exclusion, false-positive suppression, deterministic output, source-text scans for forbidden imports.
+6. tests/unit/test_development_work_queue_status.py — counts pass-through, vocabulary buckets, read-only invariant, source-text scans.
+7. This entry in docs/roadmap/autonomous_development.txt.
+```
+
+## Closed vocabularies (canonical reference)
+
+```text
+AGENT_ROLES (16) — see reporting.development_work_queue.AGENT_ROLES
+STATUSES (12)    — Kanban: proposed, triaged, planned, ready, in_progress,
+                   blocked, human_needed, review_needed, validation_needed,
+                   done, rejected, archived
+CATEGORIES (10)  — governance, reporting, frontend, test, docs, ci,
+                   deployment, release, observability, refactor
+HUMAN_NEEDED_REASONS (11) — including "none" for human_needed=False
+ROADMAP_TRACKS (3)        — autonomous_development, qre_feature_build, sidecar_seed
+RISK_LEVELS               — reused from reporting.execution_authority.RISK_CLASSES
+```
+
+## Definition of Done
+
+```text
+1. Branch feature/a8-autonomous-development-operating-queue exists; nothing on main.
+2. Implementation complete on branch (modules, docs, tests, seed file).
+3. Targeted tests green:
+     python -m pytest tests/unit/test_development_work_queue.py \
+                      tests/unit/test_development_work_queue_status.py -q
+4. Broader unit suite green:
+     python -m pytest tests/unit -q
+5. Smoke suite green:
+     python -m pytest tests/smoke -q
+6. PR opened against main with summary, file map, and validation evidence.
+7. CI green on the PR.
+8. Squash-merged to main; post-merge gates green.
+9. Only after step 8 may this entry be flipped from `PR-ready` to `Complete`.
+10. If the PR cannot be merged in this session, the entry remains `PR-ready`
+    (or moves to `Implementing` if a hard blocker emerges) — never falsely
+    marked Complete.
+```
+
+## Determinism
+
+The pure generator accepts an injectable `generated_at_utc`. With the same seed input and the same injected timestamp, output bytes are identical. The runtime CLI defaults the timestamp to the current UTC clock, which means CLI invocations across different wall-clock seconds are **not** byte-identical for the wrapper; per-item bytes (item_id, ordering, content) remain stable.
+
+## Future phases
+
+```text
+A9  — Agentic release-gate integration into the queue
+A10 — Agentic bugfix loop for AUTO_ALLOWED bounded items
+A11 — Bounded roadmap implementation delegation (planner → seed entries)
+A12 — Operational digest of queue throughput and human-needed trends
+```
+
+These build on top of A8 and are explicitly out of scope for this PR.
+
+\---
+
 # 8\. Immediate next instruction to Claude
 
 Use this as the next implementation prompt after confirming PR #111 post-merge gates are green.

--- a/reporting/development_work_queue.py
+++ b/reporting/development_work_queue.py
@@ -1,0 +1,697 @@
+"""A8 — Autonomous Development Operating Queue Foundation.
+
+Read-only, deterministic Kanban-style **development** work queue. This
+module exposes a closed vocabulary, a frozen per-item schema, an
+explicit operator-authored seed input, and an artifact under
+``logs/development_work_queue/latest.json``.
+
+Distinct from:
+
+* ``reporting.proposal_queue`` — roadmap-document intake of proposals.
+* the QRE research campaign queue — research execution ordering.
+* the Intelligent Routing Layer queue — advisory research routing.
+
+This is the autonomous **development** queue: roadmap/build/maintenance
+work items, routed to agent roles by mandate, and progressed through
+deterministic gates. A8 ships the schema + vocabularies + a read-only
+CLI; auto-execute and auto-merge are out of scope.
+
+Hard guarantees (pinned by tests):
+
+* Stdlib + ``reporting.execution_authority`` + ``reporting.approval_policy``.
+* No subprocess, no network, no ``gh``, no ``git``.
+* No imports from ``dashboard``, ``automation``, ``broker``,
+  ``agent.risk``, ``agent.execution``, ``research``.
+* No mutation behaviour, no approval-inbox decisions.
+* Only canonical roadmap paths are accepted as ``source_document``;
+  archive paths under ``docs/roadmap/archive/`` are rejected.
+* Plain headings in the canonical roadmap docs do **not** become
+  queue items. Items only come from explicit operator-authored
+  entries in the sidecar seed file.
+* Bounded scalars only — no PR text, no diffs, no body content.
+
+CLI::
+
+    python -m reporting.development_work_queue
+    python -m reporting.development_work_queue --indent 2
+    python -m reporting.development_work_queue --no-write
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import hashlib
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Final
+
+from reporting import execution_authority as ea
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[str] = "1.0"
+MODULE_VERSION: Final[str] = "v3.15.16.A8"
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies
+# ---------------------------------------------------------------------------
+
+#: 16 agent mandates. Mirrors ``.claude/agents/*`` plus ``human_operator``.
+AGENT_ROLES: Final[tuple[str, ...]] = (
+    "product_owner",
+    "strategic_advisor",
+    "quant_research_architect",
+    "planner",
+    "architecture_guardian",
+    "ci_guardian",
+    "implementation_agent",
+    "frontend_agent",
+    "test_agent",
+    "determinism_guardian",
+    "evidence_verifier",
+    "observability_guardian",
+    "deployment_safety_agent",
+    "adversarial_reviewer",
+    "release_gate_agent",
+    "human_operator",
+)
+
+#: 12 Kanban-style item statuses.
+STATUSES: Final[tuple[str, ...]] = (
+    "proposed",
+    "triaged",
+    "planned",
+    "ready",
+    "in_progress",
+    "blocked",
+    "human_needed",
+    "review_needed",
+    "validation_needed",
+    "done",
+    "rejected",
+    "archived",
+)
+
+#: 10 development work categories.
+CATEGORIES: Final[tuple[str, ...]] = (
+    "governance",
+    "reporting",
+    "frontend",
+    "test",
+    "docs",
+    "ci",
+    "deployment",
+    "release",
+    "observability",
+    "refactor",
+)
+
+#: 11 human-needed reasons. ``"none"`` is reserved for ``human_needed=False``.
+HUMAN_NEEDED_REASONS: Final[tuple[str, ...]] = (
+    "architecture_crossroads",
+    "protected_governance_change",
+    "frozen_contract_change",
+    "risk_policy_change",
+    "capital_or_live_execution_related",
+    "destructive_or_irreversible_action",
+    "priority_conflict",
+    "ambiguous_scope",
+    "missing_acceptance_criteria",
+    "repeated_validation_failure",
+    "none",
+)
+
+#: Roadmap tracks the items can claim as their source.
+ROADMAP_TRACKS: Final[tuple[str, ...]] = (
+    "autonomous_development",
+    "qre_feature_build",
+    "sidecar_seed",
+)
+
+#: Risk levels are reused verbatim from the Execution Authority classifier.
+RISK_LEVELS: Final[tuple[str, ...]] = ea.RISK_CLASSES
+
+#: Per-item schema keys, exact and ordered.
+ITEM_SCHEMA_KEYS: Final[tuple[str, ...]] = (
+    "item_id",
+    "title",
+    "source_document",
+    "source_section_or_anchor",
+    "roadmap_track",
+    "category",
+    "required_agent_role",
+    "supporting_agent_roles",
+    "execution_authority",
+    "status",
+    "human_needed",
+    "human_needed_reason",
+    "blocked_by",
+    "priority",
+    "risk_level",
+    "protected_surface",
+    "acceptance_criteria",
+    "validation_requirements",
+    "created_at_placeholder",
+    "updated_at_placeholder",
+    "notes",
+)
+
+#: Deterministic placeholders for per-item timestamps. The wrapper
+#: artifact carries ``generated_at_utc`` for the report itself; items
+#: stay byte-reproducible across runs.
+ITEM_TIME_PLACEHOLDER: Final[str] = "deterministic_seed_placeholder"
+
+#: Bounded length for free-text fields on a single item. Keeps the
+#: artifact small and the evidence audit-friendly.
+MAX_TITLE_LEN: Final[int] = 200
+MAX_NOTES_LEN: Final[int] = 1000
+MAX_ACCEPTANCE_ITEMS: Final[int] = 16
+MAX_ACCEPTANCE_LINE_LEN: Final[int] = 200
+MAX_BLOCKED_BY: Final[int] = 16
+
+#: Canonical roadmap paths the queue accepts as ``source_document``
+#: when ``roadmap_track in {autonomous_development, qre_feature_build}``.
+CANONICAL_ROADMAP_PATHS: Final[tuple[str, ...]] = (
+    "docs/roadmap/autonomous_development.txt",
+    "docs/roadmap/Roadmap v6.md",
+)
+
+#: Default seed file path. Optional. Absent = zero items.
+DEFAULT_SEED_PATH: Final[Path] = (
+    REPO_ROOT / "docs" / "development_work_queue" / "seed.jsonl"
+)
+
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "development_work_queue"
+ARTIFACT_LATEST: Final[Path] = ARTIFACT_DIR / "latest.json"
+ARTIFACT_RELATIVE_PATH: Final[str] = "logs/development_work_queue/latest.json"
+
+#: Marker emitted on the report wrapper when no items are present.
+NOTE_NO_ITEMS: Final[str] = "no_explicit_queue_items_found"
+NOTE_ITEMS_PRESENT: Final[str] = "explicit_seed_items_present"
+NOTE_SEED_FILE_ABSENT: Final[str] = "seed_file_absent"
+NOTE_SEED_FILE_EMPTY: Final[str] = "seed_file_empty"
+
+# ---------------------------------------------------------------------------
+# Utility helpers
+# ---------------------------------------------------------------------------
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _normalize_path(p: str) -> str:
+    return p.replace("\\", "/").lstrip("./") if p else ""
+
+
+def _is_archive_path(p: str) -> bool:
+    n = _normalize_path(p).lower()
+    return n.startswith("docs/roadmap/archive/")
+
+
+def _is_canonical_roadmap_path(p: str) -> bool:
+    return _normalize_path(p) in CANONICAL_ROADMAP_PATHS
+
+
+def _bounded_str(value: Any, max_len: int) -> str:
+    """Coerce to ``str`` and enforce a hard length bound. Non-strings
+    yield an empty string. The classifier keeps body content out of
+    the artifact; this helper is the second line of defence."""
+    if not isinstance(value, str):
+        return ""
+    if len(value) <= max_len:
+        return value
+    return value[:max_len]
+
+
+def _bounded_str_list(
+    value: Any, max_items: int, max_line_len: int
+) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    out: list[str] = []
+    for v in value[:max_items]:
+        if isinstance(v, str):
+            out.append(_bounded_str(v, max_line_len))
+    return out
+
+
+def _bounded_id_list(value: Any, max_items: int) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    out: list[str] = []
+    for v in value[:max_items]:
+        if isinstance(v, str) and v.strip():
+            out.append(_bounded_str(v, 64))
+    return out
+
+
+def _bounded_role_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    out: list[str] = []
+    seen: set[str] = set()
+    for v in value:
+        if not isinstance(v, str):
+            continue
+        if v not in AGENT_ROLES:
+            continue
+        if v in seen:
+            continue
+        seen.add(v)
+        out.append(v)
+    return out
+
+
+def _coerce_priority(value: Any) -> int:
+    """Bound priority to the inclusive range [1, 5]. Non-ints map to 3."""
+    if isinstance(value, bool):
+        return 3
+    if isinstance(value, int):
+        if value < 1:
+            return 1
+        if value > 5:
+            return 5
+        return value
+    return 3
+
+
+def _deterministic_item_id(title: str, source_section: str) -> str:
+    h = hashlib.sha256()
+    h.update(title.encode("utf-8"))
+    h.update(b"\x1f")
+    h.update(source_section.encode("utf-8"))
+    return "dwq_" + h.hexdigest()[:12]
+
+
+# ---------------------------------------------------------------------------
+# Item parsing and validation
+# ---------------------------------------------------------------------------
+
+
+def _validate_and_normalize_item(
+    raw: dict[str, Any],
+    *,
+    line_index: int,
+) -> tuple[dict[str, Any] | None, list[str]]:
+    """Return a normalized item dict plus a list of warnings.
+
+    Items that fail closed-vocabulary checks are dropped (return
+    ``None``) with a warning; items that pass become a fully-typed
+    schema-conformant dict. Never raises on user input."""
+    warnings: list[str] = []
+
+    if not isinstance(raw, dict):
+        warnings.append(f"seed_line_{line_index}_not_an_object")
+        return None, warnings
+
+    title = _bounded_str(raw.get("title"), MAX_TITLE_LEN)
+    if not title:
+        warnings.append(f"seed_line_{line_index}_missing_title")
+        return None, warnings
+
+    track = raw.get("roadmap_track")
+    if track not in ROADMAP_TRACKS:
+        warnings.append(f"seed_line_{line_index}_invalid_roadmap_track")
+        return None, warnings
+
+    source_document = _normalize_path(
+        raw.get("source_document") if isinstance(raw.get("source_document"), str) else ""
+    )
+    if track == "sidecar_seed":
+        if source_document and source_document not in ("sidecar_seed", ""):
+            # Tolerated: operator may point sidecar entries at any path.
+            pass
+        if not source_document:
+            source_document = "sidecar_seed"
+    else:
+        if _is_archive_path(source_document):
+            warnings.append(f"seed_line_{line_index}_archive_path_rejected")
+            return None, warnings
+        if not _is_canonical_roadmap_path(source_document):
+            warnings.append(
+                f"seed_line_{line_index}_non_canonical_source_document"
+            )
+            return None, warnings
+
+    section = _bounded_str(raw.get("source_section_or_anchor"), MAX_TITLE_LEN)
+
+    category = raw.get("category")
+    if category not in CATEGORIES:
+        warnings.append(f"seed_line_{line_index}_invalid_category")
+        return None, warnings
+
+    required_role = raw.get("required_agent_role")
+    if required_role not in AGENT_ROLES:
+        warnings.append(f"seed_line_{line_index}_invalid_required_agent_role")
+        return None, warnings
+
+    supporting = _bounded_role_list(raw.get("supporting_agent_roles"))
+
+    status = raw.get("status")
+    if status not in STATUSES:
+        warnings.append(f"seed_line_{line_index}_invalid_status")
+        return None, warnings
+
+    risk_level = raw.get("risk_level")
+    if risk_level not in RISK_LEVELS:
+        warnings.append(f"seed_line_{line_index}_invalid_risk_level")
+        return None, warnings
+
+    human_needed = raw.get("human_needed")
+    if not isinstance(human_needed, bool):
+        warnings.append(f"seed_line_{line_index}_invalid_human_needed")
+        return None, warnings
+
+    human_needed_reason = raw.get("human_needed_reason")
+    if human_needed_reason not in HUMAN_NEEDED_REASONS:
+        warnings.append(f"seed_line_{line_index}_invalid_human_needed_reason")
+        return None, warnings
+
+    if human_needed and human_needed_reason == "none":
+        warnings.append(f"seed_line_{line_index}_human_needed_true_but_reason_none")
+        return None, warnings
+    if (not human_needed) and human_needed_reason != "none":
+        warnings.append(
+            f"seed_line_{line_index}_human_needed_false_but_reason_not_none"
+        )
+        return None, warnings
+
+    protected_surface = raw.get("protected_surface")
+    if not isinstance(protected_surface, bool):
+        warnings.append(f"seed_line_{line_index}_invalid_protected_surface")
+        return None, warnings
+
+    blocked_by = _bounded_id_list(raw.get("blocked_by"), MAX_BLOCKED_BY)
+    acceptance = _bounded_str_list(
+        raw.get("acceptance_criteria"),
+        MAX_ACCEPTANCE_ITEMS,
+        MAX_ACCEPTANCE_LINE_LEN,
+    )
+    validation = _bounded_str_list(
+        raw.get("validation_requirements"),
+        MAX_ACCEPTANCE_ITEMS,
+        MAX_ACCEPTANCE_LINE_LEN,
+    )
+
+    notes = _bounded_str(raw.get("notes"), MAX_NOTES_LEN)
+
+    priority = _coerce_priority(raw.get("priority"))
+
+    # Cross-validate against execution_authority. The decision becomes
+    # an additive field on the item; never silently rewrites the
+    # operator's declared status.
+    decision = ea.classify(
+        action_type="file_edit",
+        target_path=source_document if source_document else None,
+        risk_class=risk_level,
+    )
+
+    item_id = _deterministic_item_id(title, section)
+
+    item: dict[str, Any] = {
+        "item_id": item_id,
+        "title": title,
+        "source_document": source_document,
+        "source_section_or_anchor": section,
+        "roadmap_track": track,
+        "category": category,
+        "required_agent_role": required_role,
+        "supporting_agent_roles": supporting,
+        "execution_authority": decision.decision,
+        "status": status,
+        "human_needed": human_needed,
+        "human_needed_reason": human_needed_reason,
+        "blocked_by": blocked_by,
+        "priority": priority,
+        "risk_level": risk_level,
+        "protected_surface": protected_surface,
+        "acceptance_criteria": acceptance,
+        "validation_requirements": validation,
+        "created_at_placeholder": ITEM_TIME_PLACEHOLDER,
+        "updated_at_placeholder": ITEM_TIME_PLACEHOLDER,
+        "notes": notes,
+    }
+
+    if not acceptance:
+        warnings.append(f"item_{item_id}_missing_acceptance_criteria")
+    if (
+        decision.decision == ea.DECISION_AUTO_ALLOWED
+        and human_needed is True
+    ):
+        warnings.append(
+            f"item_{item_id}_human_needed_true_but_authority_auto_allowed"
+        )
+    if (
+        decision.decision == ea.DECISION_PERMANENTLY_DENIED
+        and human_needed is False
+    ):
+        warnings.append(
+            f"item_{item_id}_human_needed_false_but_authority_denied"
+        )
+
+    return item, warnings
+
+
+def _read_seed_lines(path: Path) -> tuple[list[str], bool]:
+    """Read non-blank lines from a strict JSONL seed file.
+
+    Each line must be either blank (tolerated) or a single JSON
+    object (parsed downstream). A second tuple member reports
+    whether the file existed at all."""
+    if not path.is_file():
+        return [], False
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return [], True
+    out: list[str] = []
+    for raw_line in text.splitlines():
+        s = raw_line.strip()
+        if not s:
+            continue
+        out.append(s)
+    return out, True
+
+
+# ---------------------------------------------------------------------------
+# Snapshot assembly
+# ---------------------------------------------------------------------------
+
+
+def _empty_counts() -> dict[str, Any]:
+    return {
+        "total": 0,
+        "by_status": {s: 0 for s in STATUSES},
+        "by_role": {r: 0 for r in AGENT_ROLES},
+        "by_category": {c: 0 for c in CATEGORIES},
+        "human_needed": 0,
+        "blocked": 0,
+        "protected_surface": 0,
+        "ready_for_autonomous_action": 0,
+        "requiring_human_operator": 0,
+        "execution_authority": {
+            ea.DECISION_AUTO_ALLOWED: 0,
+            ea.DECISION_NEEDS_HUMAN: 0,
+            ea.DECISION_PERMANENTLY_DENIED: 0,
+        },
+    }
+
+
+_AUTONOMOUS_READY_STATUSES: Final[frozenset[str]] = frozenset(
+    {"ready", "in_progress"}
+)
+
+
+def _aggregate_counts(items: list[dict[str, Any]]) -> dict[str, Any]:
+    counts = _empty_counts()
+    counts["total"] = len(items)
+    for it in items:
+        counts["by_status"][it["status"]] += 1
+        counts["by_role"][it["required_agent_role"]] += 1
+        counts["by_category"][it["category"]] += 1
+        counts["execution_authority"][it["execution_authority"]] += 1
+        if it["human_needed"]:
+            counts["human_needed"] += 1
+        if it["status"] == "blocked":
+            counts["blocked"] += 1
+        if it["protected_surface"]:
+            counts["protected_surface"] += 1
+        if (
+            it["execution_authority"] == ea.DECISION_AUTO_ALLOWED
+            and not it["human_needed"]
+            and it["status"] in _AUTONOMOUS_READY_STATUSES
+        ):
+            counts["ready_for_autonomous_action"] += 1
+        if (
+            it["human_needed"]
+            or it["execution_authority"] == ea.DECISION_NEEDS_HUMAN
+            or it["status"] == "human_needed"
+        ):
+            counts["requiring_human_operator"] += 1
+    return counts
+
+
+def collect_snapshot(
+    *,
+    seed_path: Path | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    """Build a deterministic snapshot dict.
+
+    The pure generator is byte-stable when called twice with the
+    same inputs **including** an injected ``generated_at_utc``. The
+    runtime CLI defaults the timestamp to the current UTC clock,
+    which means CLI invocations are *not* byte-identical across
+    different wall-clock seconds — that is intentional. Tests
+    asserting byte-stable output must inject ``generated_at_utc``.
+
+    Args:
+        seed_path: override the default
+            ``docs/development_work_queue/seed.jsonl`` source. Tests
+            point this at a synthetic fixture path.
+        generated_at_utc: override the wrapper's report timestamp.
+            ``None`` (the default) reads the current UTC clock.
+            Tests pass a fixed string to assert byte-stable output.
+    """
+    sp = seed_path if seed_path is not None else DEFAULT_SEED_PATH
+    ts = generated_at_utc if generated_at_utc is not None else _utcnow()
+
+    seed_lines, seed_present = _read_seed_lines(sp)
+    warnings: list[str] = []
+    items: list[dict[str, Any]] = []
+
+    for idx, line in enumerate(seed_lines, start=1):
+        try:
+            payload = json.loads(line)
+        except ValueError:
+            warnings.append(f"seed_line_{idx}_invalid_json")
+            continue
+        item, item_warns = _validate_and_normalize_item(
+            payload, line_index=idx
+        )
+        warnings.extend(item_warns)
+        if item is not None:
+            items.append(item)
+
+    items.sort(key=lambda it: (it["priority"], it["item_id"]))
+
+    if not seed_present:
+        note = NOTE_SEED_FILE_ABSENT
+    elif not seed_lines:
+        note = NOTE_SEED_FILE_EMPTY
+    elif not items:
+        note = NOTE_NO_ITEMS
+    else:
+        note = NOTE_ITEMS_PRESENT
+
+    counts = _aggregate_counts(items)
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "report_kind": "development_work_queue",
+        "generated_at_utc": ts,
+        "source_document_paths": list(CANONICAL_ROADMAP_PATHS),
+        "seed_path": str(sp.relative_to(REPO_ROOT)) if sp.is_relative_to(REPO_ROOT) else str(sp),
+        "seed_present": seed_present,
+        "source_available": True,
+        "note": note,
+        "validation_warnings": warnings,
+        "vocabularies": {
+            "agent_roles": list(AGENT_ROLES),
+            "statuses": list(STATUSES),
+            "categories": list(CATEGORIES),
+            "human_needed_reasons": list(HUMAN_NEEDED_REASONS),
+            "risk_levels": list(RISK_LEVELS),
+            "roadmap_tracks": list(ROADMAP_TRACKS),
+        },
+        "counts": counts,
+        "items": items,
+        "execution_authority_module_version": ea.MODULE_VERSION,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Atomic write
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    posix = path.as_posix()
+    if "/logs/" not in posix and not posix.startswith("logs/"):
+        raise ValueError(
+            "development_work_queue._atomic_write_json refuses "
+            f"non-logs/ output path: {path}"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".development_work_queue.", suffix=".tmp", dir=str(path.parent)
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_outputs(snapshot: dict[str, Any]) -> Path:
+    _atomic_write_json(ARTIFACT_LATEST, snapshot)
+    return ARTIFACT_LATEST
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m reporting.development_work_queue",
+        description=(
+            "Read-only Autonomous Development Operating Queue. Reads "
+            "the operator-authored sidecar seed and produces a "
+            "deterministic Kanban-style work-item queue. Decides "
+            "nothing; mutates nothing."
+        ),
+    )
+    p.add_argument("--indent", type=int, default=2, help="JSON indent (0 for compact).")
+    p.add_argument(
+        "--no-write",
+        action="store_true",
+        help=(
+            "Do not persist logs/development_work_queue/latest.json "
+            "(stdout only)."
+        ),
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    indent = args.indent if args.indent and args.indent > 0 else None
+    snap = collect_snapshot()
+    if not args.no_write:
+        write_outputs(snap)
+    json.dump(snap, sys.stdout, indent=indent, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/reporting/development_work_queue_status.py
+++ b/reporting/development_work_queue_status.py
@@ -1,0 +1,224 @@
+"""A8 — Development Work Queue status summary.
+
+Read-only projection that consumes
+``logs/development_work_queue/latest.json`` and emits a compact
+operator-facing status summary.
+
+Hard guarantees (pinned by tests):
+
+* Stdlib + ``reporting.development_work_queue``.
+* No subprocess, no network, no ``gh``, no ``git``.
+* No imports from ``dashboard``, ``automation``, ``broker``,
+  ``agent.risk``, ``agent.execution``, ``research``.
+* Pure read on the artifact; never mutates ``latest.json``.
+
+CLI::
+
+    python -m reporting.development_work_queue_status
+    python -m reporting.development_work_queue_status --indent 2
+    python -m reporting.development_work_queue_status --no-write
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Final
+
+from reporting import development_work_queue as dwq
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[str] = "1.0"
+MODULE_VERSION: Final[str] = "v3.15.16.A8"
+
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "development_work_queue_status"
+ARTIFACT_LATEST: Final[Path] = ARTIFACT_DIR / "latest.json"
+ARTIFACT_RELATIVE_PATH: Final[str] = "logs/development_work_queue_status/latest.json"
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+
+def collect_status(
+    *,
+    queue_artifact_path: Path | None = None,
+) -> dict[str, Any]:
+    """Build a deterministic status snapshot from the queue artifact.
+
+    Args:
+        queue_artifact_path: override the default
+            ``logs/development_work_queue/latest.json`` source. Tests
+            pass a synthetic fixture here.
+    """
+    qp = (
+        queue_artifact_path
+        if queue_artifact_path is not None
+        else dwq.ARTIFACT_LATEST
+    )
+    payload = _read_json(qp)
+    if payload is None:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "module_version": MODULE_VERSION,
+            "report_kind": "development_work_queue_status",
+            "generated_at_utc": _utcnow(),
+            "queue_artifact_path": str(qp),
+            "queue_artifact_available": False,
+            "queue_module_version": dwq.MODULE_VERSION,
+            "schema_pinned": {
+                "agent_roles": list(dwq.AGENT_ROLES),
+                "statuses": list(dwq.STATUSES),
+                "categories": list(dwq.CATEGORIES),
+                "human_needed_reasons": list(dwq.HUMAN_NEEDED_REASONS),
+            },
+            "counts": {
+                "total": 0,
+                "human_needed": 0,
+                "blocked": 0,
+                "protected_surface": 0,
+                "ready_for_autonomous_action": 0,
+                "requiring_human_operator": 0,
+                "by_status": {s: 0 for s in dwq.STATUSES},
+                "by_role": {r: 0 for r in dwq.AGENT_ROLES},
+                "by_category": {c: 0 for c in dwq.CATEGORIES},
+            },
+            "validation_warnings": [],
+            "note": "queue_artifact_absent",
+        }
+
+    counts = payload.get("counts") or {}
+    if not isinstance(counts, dict):
+        counts = {}
+
+    by_status = counts.get("by_status") if isinstance(counts.get("by_status"), dict) else {}
+    by_role = counts.get("by_role") if isinstance(counts.get("by_role"), dict) else {}
+    by_category = (
+        counts.get("by_category")
+        if isinstance(counts.get("by_category"), dict)
+        else {}
+    )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "report_kind": "development_work_queue_status",
+        "generated_at_utc": _utcnow(),
+        "queue_artifact_path": str(qp),
+        "queue_artifact_available": True,
+        "queue_module_version": payload.get("module_version"),
+        "queue_schema_version": payload.get("schema_version"),
+        "queue_generated_at_utc": payload.get("generated_at_utc"),
+        "queue_note": payload.get("note"),
+        "schema_pinned": {
+            "agent_roles": list(dwq.AGENT_ROLES),
+            "statuses": list(dwq.STATUSES),
+            "categories": list(dwq.CATEGORIES),
+            "human_needed_reasons": list(dwq.HUMAN_NEEDED_REASONS),
+        },
+        "counts": {
+            "total": int(counts.get("total") or 0),
+            "human_needed": int(counts.get("human_needed") or 0),
+            "blocked": int(counts.get("blocked") or 0),
+            "protected_surface": int(counts.get("protected_surface") or 0),
+            "ready_for_autonomous_action": int(
+                counts.get("ready_for_autonomous_action") or 0
+            ),
+            "requiring_human_operator": int(
+                counts.get("requiring_human_operator") or 0
+            ),
+            "by_status": {s: int(by_status.get(s) or 0) for s in dwq.STATUSES},
+            "by_role": {r: int(by_role.get(r) or 0) for r in dwq.AGENT_ROLES},
+            "by_category": {
+                c: int(by_category.get(c) or 0) for c in dwq.CATEGORIES
+            },
+        },
+        "validation_warnings": list(payload.get("validation_warnings") or []),
+        "note": "queue_artifact_present",
+    }
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    posix = path.as_posix()
+    if "/logs/" not in posix and not posix.startswith("logs/"):
+        raise ValueError(
+            "development_work_queue_status._atomic_write_json refuses "
+            f"non-logs/ output path: {path}"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".development_work_queue_status.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_outputs(snapshot: dict[str, Any]) -> Path:
+    _atomic_write_json(ARTIFACT_LATEST, snapshot)
+    return ARTIFACT_LATEST
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m reporting.development_work_queue_status",
+        description=(
+            "Read-only summary of logs/development_work_queue/latest.json. "
+            "Decides nothing; mutates nothing."
+        ),
+    )
+    p.add_argument("--indent", type=int, default=2, help="JSON indent (0 for compact).")
+    p.add_argument(
+        "--no-write",
+        action="store_true",
+        help=(
+            "Do not persist logs/development_work_queue_status/latest.json "
+            "(stdout only)."
+        ),
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    indent = args.indent if args.indent and args.indent > 0 else None
+    snap = collect_status()
+    if not args.no_write:
+        write_outputs(snap)
+    json.dump(snap, sys.stdout, indent=indent, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/unit/test_development_work_queue.py
+++ b/tests/unit/test_development_work_queue.py
@@ -1,0 +1,757 @@
+"""Unit tests for A8 — Autonomous Development Operating Queue Foundation.
+
+Synthetic deterministic fixtures only. No runtime ``/tmp`` baselines
+committed. The module is read-only; tests assert the schema, the
+closed vocabularies, archive-path rejection, false-positive
+suppression for plain headings, deterministic output, and the
+absence of any subprocess / network / gh / git / forbidden-package
+import.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reporting import development_work_queue as dwq
+from reporting import execution_authority as ea
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed_path(tmp_path: Path) -> Path:
+    return tmp_path / "seed.jsonl"
+
+
+def _write_seed(tmp_path: Path, lines: list[str]) -> Path:
+    p = _seed_path(tmp_path)
+    p.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+    return p
+
+
+def _valid_item(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "title": "Document A8 governance",
+        "source_document": "docs/roadmap/autonomous_development.txt",
+        "source_section_or_anchor": "A8.1",
+        "roadmap_track": "autonomous_development",
+        "category": "docs",
+        "required_agent_role": "implementation_agent",
+        "supporting_agent_roles": ["test_agent"],
+        "status": "ready",
+        "human_needed": False,
+        "human_needed_reason": "none",
+        "blocked_by": [],
+        "priority": 3,
+        "risk_level": "LOW",
+        "protected_surface": False,
+        "acceptance_criteria": ["Doc page lands"],
+        "validation_requirements": ["Lints clean"],
+        "notes": "scoped item",
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Vocabulary integrity
+# ---------------------------------------------------------------------------
+
+
+def test_agent_roles_vocabulary_is_closed_and_ordered() -> None:
+    assert dwq.AGENT_ROLES == (
+        "product_owner",
+        "strategic_advisor",
+        "quant_research_architect",
+        "planner",
+        "architecture_guardian",
+        "ci_guardian",
+        "implementation_agent",
+        "frontend_agent",
+        "test_agent",
+        "determinism_guardian",
+        "evidence_verifier",
+        "observability_guardian",
+        "deployment_safety_agent",
+        "adversarial_reviewer",
+        "release_gate_agent",
+        "human_operator",
+    )
+    assert len(dwq.AGENT_ROLES) == 16
+    assert "human_operator" in dwq.AGENT_ROLES
+
+
+def test_statuses_vocabulary_is_closed_and_ordered() -> None:
+    assert dwq.STATUSES == (
+        "proposed",
+        "triaged",
+        "planned",
+        "ready",
+        "in_progress",
+        "blocked",
+        "human_needed",
+        "review_needed",
+        "validation_needed",
+        "done",
+        "rejected",
+        "archived",
+    )
+    assert len(dwq.STATUSES) == 12
+
+
+def test_categories_vocabulary_is_closed_and_ordered() -> None:
+    assert dwq.CATEGORIES == (
+        "governance",
+        "reporting",
+        "frontend",
+        "test",
+        "docs",
+        "ci",
+        "deployment",
+        "release",
+        "observability",
+        "refactor",
+    )
+    assert len(dwq.CATEGORIES) == 10
+
+
+def test_human_needed_reasons_vocabulary_is_closed_with_none_terminator() -> None:
+    assert dwq.HUMAN_NEEDED_REASONS == (
+        "architecture_crossroads",
+        "protected_governance_change",
+        "frozen_contract_change",
+        "risk_policy_change",
+        "capital_or_live_execution_related",
+        "destructive_or_irreversible_action",
+        "priority_conflict",
+        "ambiguous_scope",
+        "missing_acceptance_criteria",
+        "repeated_validation_failure",
+        "none",
+    )
+    # Eleven entries: ten real reasons plus the explicit "none" sentinel.
+    assert len(dwq.HUMAN_NEEDED_REASONS) == 11
+    assert "none" in dwq.HUMAN_NEEDED_REASONS
+
+
+def test_roadmap_tracks_vocabulary_is_closed() -> None:
+    assert dwq.ROADMAP_TRACKS == (
+        "autonomous_development",
+        "qre_feature_build",
+        "sidecar_seed",
+    )
+
+
+def test_risk_levels_match_execution_authority() -> None:
+    """Risk levels are reused verbatim from the classifier — never
+    redefined here."""
+    assert dwq.RISK_LEVELS == ea.RISK_CLASSES
+
+
+def test_canonical_roadmap_paths_match_execution_authority_doctrine() -> None:
+    assert set(dwq.CANONICAL_ROADMAP_PATHS) == {
+        "docs/roadmap/autonomous_development.txt",
+        "docs/roadmap/Roadmap v6.md",
+    }
+
+
+def test_item_schema_keys_are_exact_and_ordered() -> None:
+    assert dwq.ITEM_SCHEMA_KEYS == (
+        "item_id",
+        "title",
+        "source_document",
+        "source_section_or_anchor",
+        "roadmap_track",
+        "category",
+        "required_agent_role",
+        "supporting_agent_roles",
+        "execution_authority",
+        "status",
+        "human_needed",
+        "human_needed_reason",
+        "blocked_by",
+        "priority",
+        "risk_level",
+        "protected_surface",
+        "acceptance_criteria",
+        "validation_requirements",
+        "created_at_placeholder",
+        "updated_at_placeholder",
+        "notes",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Artifact path
+# ---------------------------------------------------------------------------
+
+
+def test_artifact_path_is_under_logs_not_research() -> None:
+    assert dwq.ARTIFACT_RELATIVE_PATH.startswith("logs/")
+    assert "research/" not in dwq.ARTIFACT_RELATIVE_PATH
+
+
+def test_atomic_write_refuses_non_logs_path(tmp_path: Path) -> None:
+    bad = tmp_path / "evil_dir" / "latest.json"
+    with pytest.raises(ValueError):
+        dwq._atomic_write_json(bad, {"x": 1})
+
+
+# ---------------------------------------------------------------------------
+# Snapshot top-level shape
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_top_level_keys_when_seed_absent(tmp_path: Path) -> None:
+    seed = tmp_path / "missing.jsonl"
+    snap = dwq.collect_snapshot(seed_path=seed)
+    expected = {
+        "schema_version",
+        "module_version",
+        "report_kind",
+        "generated_at_utc",
+        "source_document_paths",
+        "seed_path",
+        "seed_present",
+        "source_available",
+        "note",
+        "validation_warnings",
+        "vocabularies",
+        "counts",
+        "items",
+        "execution_authority_module_version",
+    }
+    assert set(snap.keys()) == expected
+    assert snap["report_kind"] == "development_work_queue"
+    assert snap["source_available"] is True
+    assert snap["seed_present"] is False
+    assert snap["note"] == dwq.NOTE_SEED_FILE_ABSENT
+    assert snap["items"] == []
+    assert snap["counts"]["total"] == 0
+
+
+def test_empty_seed_yields_zero_items_with_clear_note(tmp_path: Path) -> None:
+    """A seed file with only blank lines (strict JSONL) reports
+    `seed_file_empty`. There are no comment lines in JSONL."""
+    seed = _write_seed(tmp_path, ["", "", ""])
+    snap = dwq.collect_snapshot(seed_path=seed)
+    assert snap["seed_present"] is True
+    assert snap["items"] == []
+    assert snap["note"] == dwq.NOTE_SEED_FILE_EMPTY
+
+
+def test_zero_byte_seed_file_yields_zero_items(tmp_path: Path) -> None:
+    """The committed `seed.jsonl` is a zero-byte file. The parser
+    must handle that without raising."""
+    seed = _seed_path(tmp_path)
+    seed.write_bytes(b"")
+    snap = dwq.collect_snapshot(seed_path=seed)
+    assert snap["seed_present"] is True
+    assert snap["items"] == []
+    assert snap["note"] == dwq.NOTE_SEED_FILE_EMPTY
+
+
+def test_default_seed_file_in_repo_yields_zero_items_by_default() -> None:
+    """The committed seed file under `docs/development_work_queue/`
+    is intentionally empty. Default behaviour must therefore be
+    zero items."""
+    snap = dwq.collect_snapshot()
+    assert snap["counts"]["total"] == 0
+    assert snap["items"] == []
+    assert snap["note"] in {dwq.NOTE_SEED_FILE_EMPTY, dwq.NOTE_SEED_FILE_ABSENT}
+
+
+def test_committed_repo_seed_file_is_strict_jsonl_no_comments() -> None:
+    """`docs/development_work_queue/seed.jsonl` must be valid JSONL —
+    every non-blank line must parse as JSON. No `#`-prefixed comment
+    lines are allowed in the canonical file."""
+    seed_file = dwq.DEFAULT_SEED_PATH
+    assert seed_file.is_file(), f"committed seed.jsonl missing at {seed_file}"
+    raw = seed_file.read_text(encoding="utf-8")
+    for line in raw.splitlines():
+        s = line.strip()
+        if not s:
+            continue
+        assert not s.startswith("#"), (
+            "JSONL must not contain `#` comment lines"
+        )
+        json.loads(s)
+
+
+# ---------------------------------------------------------------------------
+# Plain headings must NOT become items
+# ---------------------------------------------------------------------------
+
+
+def test_plain_h2_h3_headings_in_seed_do_not_become_items(tmp_path: Path) -> None:
+    """The seed parser only consumes JSON object lines. Plain headings
+    are non-JSON and must be reported as `invalid_json` warnings, not
+    promoted to queue items."""
+    seed = _write_seed(
+        tmp_path,
+        [
+            "## A8 Operating Queue",
+            "### Sub-section",
+            "Some prose explaining the section.",
+        ],
+    )
+    snap = dwq.collect_snapshot(seed_path=seed)
+    assert snap["items"] == []
+    assert any(
+        w.startswith("seed_line_") and w.endswith("_invalid_json")
+        for w in snap["validation_warnings"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Item parsing
+# ---------------------------------------------------------------------------
+
+
+def test_valid_seed_item_round_trips(tmp_path: Path) -> None:
+    item = _valid_item()
+    seed = _write_seed(tmp_path, [json.dumps(item)])
+    snap = dwq.collect_snapshot(seed_path=seed)
+    assert snap["counts"]["total"] == 1
+    parsed = snap["items"][0]
+    assert set(parsed.keys()) == set(dwq.ITEM_SCHEMA_KEYS)
+    assert parsed["title"] == item["title"]
+    assert parsed["source_document"] == item["source_document"]
+    assert parsed["roadmap_track"] == "autonomous_development"
+    assert parsed["status"] == "ready"
+    assert parsed["execution_authority"] == ea.DECISION_NEEDS_HUMAN
+    # autonomous_development.txt is canonical_roadmap → NEEDS_HUMAN.
+
+
+def test_item_id_is_deterministic(tmp_path: Path) -> None:
+    item = _valid_item(title="t", source_section_or_anchor="s")
+    seed = _write_seed(tmp_path, [json.dumps(item)])
+    snap_a = dwq.collect_snapshot(seed_path=seed)
+    snap_b = dwq.collect_snapshot(seed_path=seed)
+    assert snap_a["items"][0]["item_id"] == snap_b["items"][0]["item_id"]
+    assert snap_a["items"][0]["item_id"].startswith("dwq_")
+
+
+def test_item_carries_deterministic_timestamp_placeholders(tmp_path: Path) -> None:
+    seed = _write_seed(tmp_path, [json.dumps(_valid_item())])
+    snap = dwq.collect_snapshot(seed_path=seed)
+    item = snap["items"][0]
+    assert item["created_at_placeholder"] == dwq.ITEM_TIME_PLACEHOLDER
+    assert item["updated_at_placeholder"] == dwq.ITEM_TIME_PLACEHOLDER
+
+
+def test_archive_path_source_document_is_rejected(tmp_path: Path) -> None:
+    item = _valid_item(
+        source_document="docs/roadmap/archive/qre_roadmap_v6_1.md",
+        roadmap_track="qre_feature_build",
+    )
+    seed = _write_seed(tmp_path, [json.dumps(item)])
+    snap = dwq.collect_snapshot(seed_path=seed)
+    assert snap["items"] == []
+    assert any(
+        "archive_path_rejected" in w for w in snap["validation_warnings"]
+    )
+
+
+def test_non_canonical_source_document_is_rejected_for_roadmap_tracks(
+    tmp_path: Path,
+) -> None:
+    item = _valid_item(
+        source_document="docs/some/other/file.md",
+        roadmap_track="autonomous_development",
+    )
+    seed = _write_seed(tmp_path, [json.dumps(item)])
+    snap = dwq.collect_snapshot(seed_path=seed)
+    assert snap["items"] == []
+    assert any(
+        "non_canonical_source_document" in w for w in snap["validation_warnings"]
+    )
+
+
+def test_sidecar_seed_track_accepts_sidecar_source(tmp_path: Path) -> None:
+    item = _valid_item(
+        source_document="sidecar_seed",
+        roadmap_track="sidecar_seed",
+    )
+    seed = _write_seed(tmp_path, [json.dumps(item)])
+    snap = dwq.collect_snapshot(seed_path=seed)
+    assert snap["counts"]["total"] == 1
+
+
+def test_qre_feature_build_track_requires_canonical_roadmap_path(
+    tmp_path: Path,
+) -> None:
+    item = _valid_item(
+        source_document="docs/roadmap/Roadmap v6.md",
+        roadmap_track="qre_feature_build",
+        risk_level="LOW",
+    )
+    seed = _write_seed(tmp_path, [json.dumps(item)])
+    snap = dwq.collect_snapshot(seed_path=seed)
+    assert snap["counts"]["total"] == 1
+    assert snap["items"][0]["roadmap_track"] == "qre_feature_build"
+
+
+def test_invalid_roadmap_track_rejected(tmp_path: Path) -> None:
+    item = _valid_item(roadmap_track="completely_made_up_track")
+    seed = _write_seed(tmp_path, [json.dumps(item)])
+    snap = dwq.collect_snapshot(seed_path=seed)
+    assert snap["items"] == []
+    assert any("invalid_roadmap_track" in w for w in snap["validation_warnings"])
+
+
+def test_invalid_status_rejected(tmp_path: Path) -> None:
+    item = _valid_item(status="not_a_status")
+    seed = _write_seed(tmp_path, [json.dumps(item)])
+    snap = dwq.collect_snapshot(seed_path=seed)
+    assert snap["items"] == []
+    assert any("invalid_status" in w for w in snap["validation_warnings"])
+
+
+def test_invalid_role_rejected(tmp_path: Path) -> None:
+    item = _valid_item(required_agent_role="not_an_agent")
+    seed = _write_seed(tmp_path, [json.dumps(item)])
+    snap = dwq.collect_snapshot(seed_path=seed)
+    assert snap["items"] == []
+    assert any(
+        "invalid_required_agent_role" in w
+        for w in snap["validation_warnings"]
+    )
+
+
+def test_invalid_category_rejected(tmp_path: Path) -> None:
+    item = _valid_item(category="not_a_category")
+    seed = _write_seed(tmp_path, [json.dumps(item)])
+    snap = dwq.collect_snapshot(seed_path=seed)
+    assert snap["items"] == []
+    assert any("invalid_category" in w for w in snap["validation_warnings"])
+
+
+def test_invalid_risk_level_rejected(tmp_path: Path) -> None:
+    item = _valid_item(risk_level="EXTREME")
+    seed = _write_seed(tmp_path, [json.dumps(item)])
+    snap = dwq.collect_snapshot(seed_path=seed)
+    assert snap["items"] == []
+    assert any("invalid_risk_level" in w for w in snap["validation_warnings"])
+
+
+def test_human_needed_true_requires_non_none_reason(tmp_path: Path) -> None:
+    item = _valid_item(human_needed=True, human_needed_reason="none")
+    seed = _write_seed(tmp_path, [json.dumps(item)])
+    snap = dwq.collect_snapshot(seed_path=seed)
+    assert snap["items"] == []
+    assert any(
+        "human_needed_true_but_reason_none" in w
+        for w in snap["validation_warnings"]
+    )
+
+
+def test_human_needed_false_requires_reason_none(tmp_path: Path) -> None:
+    item = _valid_item(human_needed=False, human_needed_reason="ambiguous_scope")
+    seed = _write_seed(tmp_path, [json.dumps(item)])
+    snap = dwq.collect_snapshot(seed_path=seed)
+    assert snap["items"] == []
+    assert any(
+        "human_needed_false_but_reason_not_none" in w
+        for w in snap["validation_warnings"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cross-validation against execution_authority
+# ---------------------------------------------------------------------------
+
+
+def test_doc_non_policy_low_risk_yields_auto_allowed(tmp_path: Path) -> None:
+    """A LOW-risk edit to a non-policy doc path classifies as
+    AUTO_ALLOWED. The queue surfaces this as the
+    ``execution_authority`` field on the item."""
+    item = _valid_item(
+        source_document="docs/operator/notes.md",
+        roadmap_track="sidecar_seed",
+        risk_level="LOW",
+    )
+    seed = _write_seed(tmp_path, [json.dumps(item)])
+    snap = dwq.collect_snapshot(seed_path=seed)
+    assert snap["items"][0]["execution_authority"] == ea.DECISION_AUTO_ALLOWED
+
+
+def test_bare_sidecar_seed_source_falls_through_to_needs_human(
+    tmp_path: Path,
+) -> None:
+    """An item declaring `sidecar_seed` as both track and source —
+    i.e. naming no concrete target path — must classify as
+    NEEDS_HUMAN under the fail-safe rule. The classifier maps any
+    unrecognised path to `other`, and `other` + modify is gated.
+    Operators must point items at a concrete target to obtain
+    AUTO_ALLOWED."""
+    item = _valid_item(
+        source_document="sidecar_seed",
+        roadmap_track="sidecar_seed",
+        risk_level="LOW",
+    )
+    seed = _write_seed(tmp_path, [json.dumps(item)])
+    snap = dwq.collect_snapshot(seed_path=seed)
+    assert snap["items"][0]["execution_authority"] == ea.DECISION_NEEDS_HUMAN
+
+
+def test_canonical_policy_doc_yields_needs_human(tmp_path: Path) -> None:
+    """An item naming a canonical_policy_doc as its source must
+    produce a NEEDS_HUMAN authority decision regardless of risk
+    level."""
+    item = _valid_item(
+        source_document="docs/governance/execution_authority.md",
+        roadmap_track="sidecar_seed",
+        risk_level="LOW",
+    )
+    seed = _write_seed(tmp_path, [json.dumps(item)])
+    snap = dwq.collect_snapshot(seed_path=seed)
+    assert snap["items"][0]["execution_authority"] == ea.DECISION_NEEDS_HUMAN
+
+
+def test_authority_auto_allowed_with_human_needed_true_emits_warning(
+    tmp_path: Path,
+) -> None:
+    item = _valid_item(
+        source_document="docs/operator/notes.md",
+        roadmap_track="sidecar_seed",
+        risk_level="LOW",
+        human_needed=True,
+        human_needed_reason="ambiguous_scope",
+    )
+    seed = _write_seed(tmp_path, [json.dumps(item)])
+    snap = dwq.collect_snapshot(seed_path=seed)
+    assert any(
+        "human_needed_true_but_authority_auto_allowed" in w
+        for w in snap["validation_warnings"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Counts
+# ---------------------------------------------------------------------------
+
+
+def test_counts_aggregate_and_close_vocabularies(tmp_path: Path) -> None:
+    a = _valid_item(
+        title="A",
+        source_document="docs/operator/notes.md",
+        roadmap_track="sidecar_seed",
+        risk_level="LOW",
+        status="ready",
+        human_needed=False,
+        human_needed_reason="none",
+        category="reporting",
+        required_agent_role="implementation_agent",
+    )
+    b = _valid_item(
+        title="B",
+        source_document="docs/governance/execution_authority.md",
+        roadmap_track="sidecar_seed",
+        risk_level="HIGH",
+        status="human_needed",
+        human_needed=True,
+        human_needed_reason="protected_governance_change",
+        category="governance",
+        required_agent_role="human_operator",
+        protected_surface=True,
+    )
+    c = _valid_item(
+        title="C",
+        source_document="sidecar_seed",
+        roadmap_track="sidecar_seed",
+        risk_level="LOW",
+        status="blocked",
+        human_needed=False,
+        human_needed_reason="none",
+        category="test",
+        required_agent_role="test_agent",
+        blocked_by=["dwq_deadbeef0000"],
+    )
+    seed = _write_seed(
+        tmp_path, [json.dumps(a), json.dumps(b), json.dumps(c)]
+    )
+    snap = dwq.collect_snapshot(seed_path=seed)
+    counts = snap["counts"]
+    assert counts["total"] == 3
+    assert sum(counts["by_status"].values()) == 3
+    assert sum(counts["by_role"].values()) == 3
+    assert sum(counts["by_category"].values()) == 3
+    assert counts["human_needed"] == 1
+    assert counts["blocked"] == 1
+    assert counts["protected_surface"] == 1
+    # Item A is AUTO_ALLOWED + ready + not human_needed → ready_for_autonomous_action.
+    assert counts["ready_for_autonomous_action"] >= 1
+    # Item B is human_needed + NEEDS_HUMAN → requiring_human_operator.
+    assert counts["requiring_human_operator"] >= 1
+    # Vocabularies in by_status / by_role / by_category cover all keys.
+    assert set(counts["by_status"]) == set(dwq.STATUSES)
+    assert set(counts["by_role"]) == set(dwq.AGENT_ROLES)
+    assert set(counts["by_category"]) == set(dwq.CATEGORIES)
+
+
+# ---------------------------------------------------------------------------
+# Determinism + sorted JSON output
+# ---------------------------------------------------------------------------
+
+
+def test_artifact_bytes_are_deterministic_with_injected_timestamp(
+    tmp_path: Path,
+) -> None:
+    """The pure generator is byte-stable across repeated calls when
+    the same `generated_at_utc` is injected. This confirms the only
+    non-deterministic field is the wrapper timestamp; everything
+    else (item ids, ordering, counts, vocabularies) is pinned."""
+    item_a = _valid_item(title="alpha", source_section_or_anchor="A.1")
+    item_b = _valid_item(title="bravo", source_section_or_anchor="A.2")
+    seed = _write_seed(tmp_path, [json.dumps(item_a), json.dumps(item_b)])
+
+    fixed_ts = "2026-05-07T00:00:00Z"
+    snap_a = dwq.collect_snapshot(seed_path=seed, generated_at_utc=fixed_ts)
+    snap_b = dwq.collect_snapshot(seed_path=seed, generated_at_utc=fixed_ts)
+
+    bytes_a = json.dumps(snap_a, sort_keys=True, indent=2).encode("utf-8")
+    bytes_b = json.dumps(snap_b, sort_keys=True, indent=2).encode("utf-8")
+    assert bytes_a == bytes_b
+    assert snap_a["generated_at_utc"] == fixed_ts
+
+
+def test_runtime_timestamp_changes_between_calls(tmp_path: Path) -> None:
+    """When `generated_at_utc` is *not* injected, the wrapper carries
+    the runtime UTC clock — and is therefore not byte-identical
+    across different wall-clock seconds. The pure generator is
+    byte-stable only with injected `generated_at_utc`."""
+    seed = _write_seed(tmp_path, [json.dumps(_valid_item())])
+    snap = dwq.collect_snapshot(seed_path=seed)
+    # The runtime timestamp is a non-empty UTC string.
+    assert isinstance(snap["generated_at_utc"], str)
+    assert snap["generated_at_utc"].endswith("Z")
+    # Items are byte-stable regardless of the wrapper timestamp.
+    snap2 = dwq.collect_snapshot(seed_path=seed)
+    assert snap["items"] == snap2["items"]
+
+
+def test_items_sort_by_priority_then_id(tmp_path: Path) -> None:
+    high_pri = _valid_item(
+        title="high",
+        source_section_or_anchor="X",
+        priority=1,
+        source_document="sidecar_seed",
+        roadmap_track="sidecar_seed",
+    )
+    low_pri = _valid_item(
+        title="low",
+        source_section_or_anchor="Y",
+        priority=5,
+        source_document="sidecar_seed",
+        roadmap_track="sidecar_seed",
+    )
+    seed = _write_seed(tmp_path, [json.dumps(low_pri), json.dumps(high_pri)])
+    snap = dwq.collect_snapshot(seed_path=seed)
+    assert [it["title"] for it in snap["items"]] == ["high", "low"]
+
+
+# ---------------------------------------------------------------------------
+# Bounded scalars / no body content
+# ---------------------------------------------------------------------------
+
+
+def test_long_title_is_bounded(tmp_path: Path) -> None:
+    long = "x" * (dwq.MAX_TITLE_LEN * 4)
+    item = _valid_item(title=long)
+    seed = _write_seed(tmp_path, [json.dumps(item)])
+    snap = dwq.collect_snapshot(seed_path=seed)
+    assert snap["counts"]["total"] == 1
+    assert len(snap["items"][0]["title"]) <= dwq.MAX_TITLE_LEN
+
+
+def test_long_notes_field_is_bounded(tmp_path: Path) -> None:
+    long_notes = "z" * (dwq.MAX_NOTES_LEN * 3)
+    item = _valid_item(notes=long_notes)
+    seed = _write_seed(tmp_path, [json.dumps(item)])
+    snap = dwq.collect_snapshot(seed_path=seed)
+    assert len(snap["items"][0]["notes"]) <= dwq.MAX_NOTES_LEN
+
+
+def test_priority_is_clamped_to_1_5(tmp_path: Path) -> None:
+    too_high = _valid_item(title="too_high", priority=99)
+    too_low = _valid_item(title="too_low", priority=-3)
+    bogus = _valid_item(title="bogus", priority="not_a_number")
+    seed = _write_seed(
+        tmp_path,
+        [json.dumps(too_high), json.dumps(too_low), json.dumps(bogus)],
+    )
+    snap = dwq.collect_snapshot(seed_path=seed)
+    by_title = {it["title"]: it["priority"] for it in snap["items"]}
+    assert by_title["too_high"] == 5
+    assert by_title["too_low"] == 1
+    assert by_title["bogus"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Source-text scans (no subprocess / no network / no forbidden imports)
+# ---------------------------------------------------------------------------
+
+
+def _module_source(mod_path_attr: str = "__file__") -> str:
+    p = Path(getattr(dwq, mod_path_attr))
+    return p.read_text(encoding="utf-8")
+
+
+def test_no_subprocess_in_module() -> None:
+    src = _module_source()
+    assert "import subprocess" not in src
+    assert "from subprocess" not in src
+
+
+def test_no_network_in_module() -> None:
+    src = _module_source()
+    for forbidden in ("import socket", "import urllib", "import http.client", "import requests"):
+        assert forbidden not in src
+    assert "from socket" not in src
+    assert "from urllib" not in src
+    assert "from http" not in src
+    assert "from requests" not in src
+
+
+def test_no_dashboard_or_live_path_imports() -> None:
+    src = _module_source()
+    for forbidden in (
+        "import dashboard",
+        "from dashboard",
+        "import automation",
+        "from automation",
+        "import broker",
+        "from broker",
+        "import agent.risk",
+        "import agent.execution",
+        "from agent.risk",
+        "from agent.execution",
+        "from research",
+        "import research",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_module_imports_cleanly() -> None:
+    """Re-import the module to confirm no startup side-effects."""
+    importlib.reload(dwq)
+    assert callable(dwq.collect_snapshot)
+
+
+# ---------------------------------------------------------------------------
+# Schema-version + module-version surfaces
+# ---------------------------------------------------------------------------
+
+
+def test_schema_and_module_version_strings() -> None:
+    assert isinstance(dwq.SCHEMA_VERSION, str) and dwq.SCHEMA_VERSION
+    assert isinstance(dwq.MODULE_VERSION, str) and dwq.MODULE_VERSION
+    assert "A8" in dwq.MODULE_VERSION

--- a/tests/unit/test_development_work_queue_status.py
+++ b/tests/unit/test_development_work_queue_status.py
@@ -1,0 +1,217 @@
+"""Unit tests for A8 — Development Work Queue status summary.
+
+Synthetic deterministic fixtures only. The status module reads the
+queue artifact at ``logs/development_work_queue/latest.json`` and
+emits a compact operator-facing summary; it does not mutate the
+queue artifact.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reporting import development_work_queue as dwq
+from reporting import development_work_queue_status as dwqs
+
+
+def _write_queue_artifact(
+    tmp_path: Path, payload: dict[str, Any]
+) -> Path:
+    p = tmp_path / "queue.json"
+    p.write_text(json.dumps(payload), encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Vocabulary / shape
+# ---------------------------------------------------------------------------
+
+
+def test_artifact_path_is_under_logs_not_research() -> None:
+    assert dwqs.ARTIFACT_RELATIVE_PATH.startswith("logs/")
+    assert "research/" not in dwqs.ARTIFACT_RELATIVE_PATH
+
+
+def test_atomic_write_refuses_non_logs_path(tmp_path: Path) -> None:
+    bad = tmp_path / "evil_dir" / "latest.json"
+    with pytest.raises(ValueError):
+        dwqs._atomic_write_json(bad, {"x": 1})
+
+
+def test_status_top_level_keys_when_queue_artifact_absent(tmp_path: Path) -> None:
+    qp = tmp_path / "missing.json"
+    snap = dwqs.collect_status(queue_artifact_path=qp)
+    expected = {
+        "schema_version",
+        "module_version",
+        "report_kind",
+        "generated_at_utc",
+        "queue_artifact_path",
+        "queue_artifact_available",
+        "queue_module_version",
+        "schema_pinned",
+        "counts",
+        "validation_warnings",
+        "note",
+    }
+    assert set(snap.keys()) == expected
+    assert snap["report_kind"] == "development_work_queue_status"
+    assert snap["queue_artifact_available"] is False
+    assert snap["counts"]["total"] == 0
+    assert snap["note"] == "queue_artifact_absent"
+    # The status module exposes the closed schema even when the
+    # queue artifact is missing — useful for operator visibility.
+    assert set(snap["schema_pinned"]) == {
+        "agent_roles",
+        "statuses",
+        "categories",
+        "human_needed_reasons",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Counts pass-through and bucket completeness
+# ---------------------------------------------------------------------------
+
+
+def test_counts_pass_through_when_queue_artifact_present(tmp_path: Path) -> None:
+    fake_queue = {
+        "schema_version": "1.0",
+        "module_version": dwq.MODULE_VERSION,
+        "generated_at_utc": "2026-05-07T00:00:00Z",
+        "note": dwq.NOTE_ITEMS_PRESENT,
+        "counts": {
+            "total": 3,
+            "human_needed": 1,
+            "blocked": 1,
+            "protected_surface": 1,
+            "ready_for_autonomous_action": 1,
+            "requiring_human_operator": 1,
+            "by_status": {s: 0 for s in dwq.STATUSES},
+            "by_role": {r: 0 for r in dwq.AGENT_ROLES},
+            "by_category": {c: 0 for c in dwq.CATEGORIES},
+        },
+        "validation_warnings": ["item_x_missing_acceptance_criteria"],
+    }
+    fake_queue["counts"]["by_status"]["ready"] = 1
+    fake_queue["counts"]["by_status"]["blocked"] = 1
+    fake_queue["counts"]["by_status"]["human_needed"] = 1
+    fake_queue["counts"]["by_role"]["implementation_agent"] = 1
+    fake_queue["counts"]["by_role"]["test_agent"] = 1
+    fake_queue["counts"]["by_role"]["human_operator"] = 1
+    fake_queue["counts"]["by_category"]["docs"] = 2
+    fake_queue["counts"]["by_category"]["governance"] = 1
+
+    qp = _write_queue_artifact(tmp_path, fake_queue)
+    snap = dwqs.collect_status(queue_artifact_path=qp)
+
+    assert snap["queue_artifact_available"] is True
+    assert snap["counts"]["total"] == 3
+    assert snap["counts"]["human_needed"] == 1
+    assert snap["counts"]["blocked"] == 1
+    assert snap["counts"]["protected_surface"] == 1
+    assert snap["counts"]["ready_for_autonomous_action"] == 1
+    assert snap["counts"]["requiring_human_operator"] == 1
+    assert snap["counts"]["by_status"]["ready"] == 1
+    assert sum(snap["counts"]["by_status"].values()) == 3
+    assert sum(snap["counts"]["by_role"].values()) == 3
+    assert sum(snap["counts"]["by_category"].values()) == 3
+    # Validation warnings carry through verbatim.
+    assert "item_x_missing_acceptance_criteria" in snap["validation_warnings"]
+
+
+def test_status_buckets_cover_all_closed_vocabularies(tmp_path: Path) -> None:
+    """Even sparse input artifacts are projected onto the full closed
+    vocabularies — operators see zero counts for unused categories,
+    not missing buckets."""
+    sparse_queue = {
+        "schema_version": "1.0",
+        "module_version": dwq.MODULE_VERSION,
+        "note": dwq.NOTE_NO_ITEMS,
+        "counts": {"total": 0},
+        "validation_warnings": [],
+    }
+    qp = _write_queue_artifact(tmp_path, sparse_queue)
+    snap = dwqs.collect_status(queue_artifact_path=qp)
+    assert set(snap["counts"]["by_status"]) == set(dwq.STATUSES)
+    assert set(snap["counts"]["by_role"]) == set(dwq.AGENT_ROLES)
+    assert set(snap["counts"]["by_category"]) == set(dwq.CATEGORIES)
+    assert all(v == 0 for v in snap["counts"]["by_status"].values())
+
+
+# ---------------------------------------------------------------------------
+# Read-only invariant
+# ---------------------------------------------------------------------------
+
+
+def test_status_does_not_mutate_queue_artifact(tmp_path: Path) -> None:
+    """Reading the queue artifact must never mutate it. We snapshot
+    the bytes before and after a status read and assert byte equality."""
+    fake_queue = {
+        "schema_version": "1.0",
+        "module_version": dwq.MODULE_VERSION,
+        "note": dwq.NOTE_NO_ITEMS,
+        "counts": {"total": 0},
+        "validation_warnings": [],
+    }
+    qp = _write_queue_artifact(tmp_path, fake_queue)
+    before = qp.read_bytes()
+    dwqs.collect_status(queue_artifact_path=qp)
+    after = qp.read_bytes()
+    assert before == after
+
+
+# ---------------------------------------------------------------------------
+# Source-text scans (no subprocess / no network / no forbidden imports)
+# ---------------------------------------------------------------------------
+
+
+def _module_source() -> str:
+    p = Path(dwqs.__file__)
+    return p.read_text(encoding="utf-8")
+
+
+def test_no_subprocess_in_status_module() -> None:
+    src = _module_source()
+    assert "import subprocess" not in src
+    assert "from subprocess" not in src
+
+
+def test_no_network_in_status_module() -> None:
+    src = _module_source()
+    for forbidden in ("import socket", "import urllib", "import http.client", "import requests"):
+        assert forbidden not in src
+    assert "from socket" not in src
+    assert "from urllib" not in src
+    assert "from http" not in src
+    assert "from requests" not in src
+
+
+def test_no_dashboard_or_live_path_imports_in_status_module() -> None:
+    src = _module_source()
+    for forbidden in (
+        "import dashboard",
+        "from dashboard",
+        "import automation",
+        "from automation",
+        "import broker",
+        "from broker",
+        "import agent.risk",
+        "import agent.execution",
+        "from agent.risk",
+        "from agent.execution",
+        "from research",
+        "import research",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_status_module_imports_cleanly() -> None:
+    import importlib
+
+    importlib.reload(dwqs)
+    assert callable(dwqs.collect_status)


### PR DESCRIPTION
## Summary

Introduce the first concrete, repo-native foundation for the **Autonomous Development Operating Queue** — a deterministic, read-only Kanban-style work queue with explicit agent mandates, status vocabulary, human-needed semantics, and a stable JSON artifact under `logs/development_work_queue/latest.json`.

This corrects the earlier "Autonomous Development Track complete" wording: A1–A7 delivered the **governance foundation** (Execution Authority policy + classifier, readiness gates), but the **operating queue** that lets agents pick up work by mandate and progress through gates begins here at **A8**.

This is **not** the QRE research campaign queue, **not** the Intelligent Routing advisory queue, and **not** `reporting.proposal_queue`.

**Status: PR-ready, NOT Complete.** The §A8 entry in `docs/roadmap/autonomous_development.txt` flips to `Complete` only after CI green + squash-merge + post-merge gates.

## Scope

**Added (read-only / additive):**
- `reporting/development_work_queue.py` — closed vocabularies (16 agent roles, 12 Kanban statuses, 10 categories, 11 human-needed reasons, 3 roadmap tracks), frozen per-item schema, strict-JSONL parser, deterministic snapshot generator with injectable `generated_at_utc`, atomic write, CLI.
- `reporting/development_work_queue_status.py` — read-only summary CLI projecting the queue artifact onto closed vocabularies.
- `docs/development_work_queue/seed.jsonl` — empty strict-JSONL operator-authored sidecar; default state is zero items.
- `docs/governance/development_work_queue.md` — governance doc with autonomy correction, mandate model, human-needed triggers, A8 v0 limits, and A9–A12 outlook.
- `tests/unit/test_development_work_queue.py` — 56 tests pinning vocabularies, schema, archive-path rejection, false-positive suppression, deterministic byte-stable output (with injected timestamp), source-text scans for forbidden imports.
- `tests/unit/test_development_work_queue_status.py` — 9 tests covering counts pass-through, vocabulary buckets, read-only invariant, source-text scans.

**Modified (canonical_roadmap; operator-authorised by issue prompt):**
- `docs/roadmap/autonomous_development.txt` — append §A8 block with `Status: PR-ready (NOT complete)`.

**Untouched:** `research/**`, frozen contracts, Intelligent Routing modules, scoring, `.claude/**`, `dashboard/dashboard.py`, all live/paper/shadow/risk/trading/broker/execution paths, all CI workflows.

## Determinism

The pure generator accepts an injectable `generated_at_utc`. With the same seed input and the same injected timestamp, output bytes are identical. The runtime CLI defaults to the current UTC clock, so CLI invocations across different wall-clock seconds are not byte-identical for the wrapper field; per-item bytes (item_id, ordering, content) remain stable. This is asserted by two complementary tests.

## Hard guarantees

- Stdlib + `reporting.execution_authority` + `reporting.approval_policy` only.
- No subprocess, no network, no `gh`, no `git`.
- No imports from `dashboard`, `automation`, `broker`, `agent.risk`, `agent.execution`, `research`.
- Atomic write only under `logs/development_work_queue/latest.json`.
- Items carry deterministic timestamp placeholders so per-item bytes are reproducible.

## Validation

- `python -m pytest tests/unit -q` → **3850 passed, 3 skipped, 0 failed**.
- `python -m pytest tests/smoke -q` → **18 passed**.
- `python -m pytest tests/unit/test_development_work_queue.py tests/unit/test_development_work_queue_status.py -q` → **65 passed**.
- `python scripts/governance_lint.py` → **OK**.
- `python -m reporting.development_work_queue --no-write` → empty-queue snapshot with `note: "seed_file_empty"`.
- No regression in `test_execution_authority`, `test_autonomous_backlog_summary`, `test_autonomous_dev_readiness`.

## Pre-merge verification (operator)

- [ ] CI green on this PR.
- [ ] No changes under `research/**`.
- [ ] No Intelligent Routing behavior change (no edits to `reporting/intelligent_routing*.py`, no `logs/intelligent_routing/**` mutation).
- [ ] No frozen-contract changes (`research/research_latest.json`, `research/strategy_matrix.csv`).
- [ ] No `.claude/**` writes.
- [ ] `docs/roadmap/autonomous_development.txt` §A8 block reads `Status: PR-ready (NOT complete)`.

## Definition of Done

A8 is **PR-ready**, not complete. The roadmap entry remains `Status: PR-ready` until:

1. CI green on this PR.
2. Squash-merged to `main`.
3. Post-merge gates green.

If the PR cannot be merged in this session, A8 stays `PR-ready` (or moves to `Implementing` if a hard blocker emerges) — never falsely marked Complete.

After squash-merge + post-merge gates green:
- update `docs/roadmap/autonomous_development.txt` from A8 PR-ready to Complete (record merge SHA);
- treat A8 as completed foundation for A9.

## Out of scope (deferred)

- **A9** — agentic release-gate integration into the queue.
- **A10** — agentic bugfix loop for AUTO_ALLOWED bounded items.
- **A11** — bounded roadmap implementation delegation (planner → seed entries).
- **A12** — operational digest of queue throughput and human-needed trends.
- Wiring into `reporting.recurring_maintenance.JOB_TYPES`.
- Markdown roadmap-marker parser (schema reserved).
- Any QRE / IR / v3.15.17 / scoring change.
- Any live/paper/shadow/risk/trading/broker/execution change.
- Auto-merge or auto-execute behavior.