### PR TITLE
feat(A9): agentic release-gate integration

### DIFF
--- a/docs/governance/development_release_gate.md
+++ b/docs/governance/development_release_gate.md
@@ -1,0 +1,230 @@
+# Autonomous Development Release Gate (A9)
+
+> Canonical governance document for the Release Gate introduced in
+> A9. Read-only schema + closed vocabularies + reporting CLI. ADE
+> core stays pure; evidence collection lives outside ADE core.
+
+## Status
+
+Active. Modifications to this document require operator approval.
+
+## What this is — and is not
+
+A9 turns Autonomous Development Operating Queue items in
+`category=release` with `status=validation_needed` into a
+deterministic go/no-go release-gate report. The output replaces ad-
+hoc "I think it's ready" reasoning with an evidence-backed verdict
+keyed by closed vocabulary.
+
+A9 is **not**:
+
+- an automatic merge or tag,
+- a deployment trigger,
+- a QRE-specific release surface,
+- a substitute for the operator's judgement on architecture
+  crossroads, frozen contracts, or live/capital-related work.
+
+`go` means "evidence shows nothing blocks merge". It does **not**
+mean "merge me automatically". The operator (or a future, separately
+governed automation) performs the actual merge through the GitHub
+PR lifecycle protocol (`docs/governance/github_pr_lifecycle.md`).
+
+## Architectural separation: ADE core vs evidence collectors
+
+ADE core
+:   `reporting/development_release_gate.py` and
+    `reporting/development_release_gate_status.py`. Stdlib +
+    `reporting.execution_authority` + `reporting.approval_policy` +
+    `reporting.development_work_queue` (read-only API). **No
+    subprocess, no network, no `gh`, no `git`.** Pinned by
+    source-text scans and AST import inspection.
+
+Evidence collectors / adapters (out of scope for A9 core)
+:   Optional, separately governed scripts that may live under
+    `scripts/` or be operator-driven runbooks. Collectors **may**
+    invoke `gh`, `git`, CI APIs, or read on-disk artifacts. They
+    write a structured **evidence input contract** (see below). ADE
+    core consumes only that contract; ADE core never imports a
+    collector.
+
+This split is permanent. The architecture explicitly preserves a
+future collector path so the operator does not have to permanently
+assemble release evidence by hand. Until a collector is committed,
+the operator may populate the evidence input by hand following this
+document — that is acceptable as a transitional state, not as the
+permanent architecture.
+
+## Evidence input contract
+
+Default path:
+```
+logs/release_gate_input/latest.json
+```
+
+Schema (closed; additive only):
+
+```json
+{
+  "schema_version": "1.0",
+  "generated_at_utc": "<iso utc>",
+  "evidence": {
+    "ci_status":                    {"present": <bool>, "value": "<closed>"},
+    "smoke_status":                 {"present": <bool>, "value": "<closed>"},
+    "governance_lint_status":       {"present": <bool>, "value": "<closed>"},
+    "frozen_hash_status":           {"present": <bool>, "value": "<closed>"},
+    "no_touch_path_delta_status":   {"present": <bool>, "value": "<closed>"},
+    "queue_cross_reference_status": {"present": <bool>, "value": "<closed>"}
+  }
+}
+```
+
+Closed value vocabularies (pinned in
+`reporting.development_release_gate.EVIDENCE_VALUE_VOCAB`):
+
+| Key | Allowed values |
+|---|---|
+| `ci_status` | `green`, `red`, `pending`, `unknown` |
+| `smoke_status` | `passed`, `failed`, `unknown` |
+| `governance_lint_status` | `ok`, `fail`, `unknown` |
+| `frozen_hash_status` | `stable`, `drift`, `unknown` |
+| `no_touch_path_delta_status` | `clean`, `violation`, `unknown` |
+| `queue_cross_reference_status` | `consistent`, `missing_item`, `unknown` |
+
+`present=false` always coerces `value` to `unknown` for verdict
+purposes. Unknown extra keys are dropped with a `validation_warning`.
+
+## Verdict vocabulary (closed, 5)
+
+```
+go                  — every required evidence key is present and clean
+go_with_followups   — same as go, plus the queue item lists advisory
+                      validation_requirements the operator should
+                      complete before/after merge
+no_go_blocked       — at least one hard-block evidence value is
+                      observed (CI red / smoke failed / lint fail /
+                      frozen drift / no-touch violation / queue
+                      cross-reference inconsistent)
+no_go_human_needed  — protected_surface=true, or the queue item's
+                      execution_authority is NEEDS_HUMAN /
+                      PERMANENTLY_DENIED. Operator decides.
+not_evaluated       — evidence input absent, required evidence
+                      missing/unknown, CI pending, queue artifact
+                      missing, or queue item is not category=release
+                      / status=validation_needed
+```
+
+## Verdict precedence (first-match)
+
+1. Queue-item-side overrides: `protected_surface=true` ⇒
+   `no_go_human_needed/protected_surface_present`.
+2. `execution_authority == PERMANENTLY_DENIED` ⇒
+   `no_go_human_needed/execution_authority_permanently_denied`.
+3. `execution_authority == NEEDS_HUMAN` ⇒
+   `no_go_human_needed/execution_authority_needs_human`.
+4. Evidence input absent ⇒
+   `not_evaluated/evidence_input_missing`.
+5. Hard-block evidence (in order):
+   - frozen-hash drift,
+   - no-touch path violation,
+   - CI red,
+   - smoke failed,
+   - governance-lint fail,
+   - queue cross-reference inconsistent.
+6. CI pending ⇒ `not_evaluated/ci_status_pending`.
+7. Required evidence absent or `unknown` ⇒
+   `not_evaluated/required_evidence_absent`.
+8. All evidence present and clean — if the queue item lists
+   `validation_requirements`, verdict is `go_with_followups`;
+   otherwise `go`.
+
+This precedence is pinned by tests and intentionally errs on the
+side of human escalation.
+
+## Per-row schema
+
+```
+gate_id                       — deterministic hash of (queue_item_id, evidence_snapshot_id)
+queue_item_id                 — A8 work-item id
+title                         — bounded scalar mirror
+verdict                       — closed
+verdict_reason                — closed
+evidence_inputs               — list of evidence keys actually evaluated
+missing_evidence              — list of evidence keys absent or unknown
+required_followups            — bounded list mirroring queue item's validation_requirements
+human_needed                  — bool (true iff verdict == no_go_human_needed)
+human_needed_reason           — closed (A8 vocabulary)
+execution_authority_decision  — mirrored from A8 item
+risk_level                    — mirrored from A8 item
+protected_surface             — mirrored from A8 item
+created_at_placeholder        — deterministic_seed_placeholder
+updated_at_placeholder        — deterministic_seed_placeholder
+notes                         — bounded scalar
+```
+
+## Hard guarantees (pinned by tests)
+
+- ADE core stdlib + `reporting.execution_authority` +
+  `reporting.approval_policy` + `reporting.development_work_queue`.
+- No subprocess, no network, no `gh`, no `git`.
+- No imports from `dashboard`, `automation`, `broker`,
+  `agent.risk`, `agent.execution`, `research`, or
+  `reporting.intelligent_routing` (AST-level pin).
+- Atomic write only under `logs/development_release_gate/latest.json`.
+- Pure scoring: same inputs (same queue artifact, same evidence
+  input, same injected `generated_at_utc`) produce byte-identical
+  output.
+- Per-row `gate_id` is deterministic; depends on the queue item id
+  and the canonical evidence snapshot id (sha256 of the normalized
+  evidence dict).
+
+## CLI surface
+
+```
+python -m reporting.development_release_gate            # writes artifact
+python -m reporting.development_release_gate --no-write  # stdout only
+python -m reporting.development_release_gate_status      # writes status artifact
+python -m reporting.development_release_gate_status --no-write
+```
+
+## Authority and safety
+
+- The release gate produces an **advisory** verdict. The decision to
+  merge remains an `pr_squash_merge` action gated by the Execution
+  Authority classifier.
+- A `go` verdict on an item never overrides the classifier or branch
+  protection. Both must independently allow the merge.
+- Items touching protected surfaces or with non-AUTO_ALLOWED
+  authority can never reach `go`; they reach at most
+  `no_go_human_needed`.
+- A frozen-hash drift signal always wins over any other evidence.
+- Any "go" recommendation is paired with the merged PR's normal
+  pre-merge verification (`docs/governance/github_pr_lifecycle.md`):
+  CI green, mergeable, no protected-path delta in the diff.
+
+## Future collector path (preserved, not implemented in A9 v0)
+
+A future collector script is expected to:
+
+1. Read the current branch / PR via `gh pr view <num>`.
+2. Read CI status via `gh pr checks <num>`.
+3. Read the diff via `git show --stat <sha>` and check for
+   protected-path / frozen-contract / live-path deltas.
+4. Read `logs/development_work_queue/latest.json` to confirm cross-
+   reference consistency.
+5. Run `python -m reporting.governance_lint` (or read its existing
+   artifact) to populate `governance_lint_status`.
+6. Run `python -m pytest tests/smoke -q` to populate `smoke_status`
+   (or read a CI artifact).
+7. Atomically write `logs/release_gate_input/latest.json` with the
+   collected evidence.
+8. Invoke `python -m reporting.development_release_gate` to score.
+
+The collector is governance/process work, not ADE core. It will be
+proposed in a separate, narrowly scoped PR after A9 lands and the
+operator has decided which collector shape best fits the workflow.
+
+## Modifying this document
+
+This is governance documentation. Modifications follow the same
+discipline as `docs/governance/development_work_queue.md`: scope-
+bounded PR, CI green, post-merge gates, no `--admin` merge.

--- a/docs/roadmap/autonomous_development.txt
+++ b/docs/roadmap/autonomous_development.txt
@@ -878,3 +878,127 @@ Open a PR against main.
 Do not merge automatically.
 ```
 
+\---
+
+# A9 — Agentic Release-Gate Integration
+
+## Status
+
+```text
+Status: PR-ready (NOT complete)
+```
+
+A9 is marked complete only after the PR's CI is green, the squash merge has landed on `main`, and post-merge gates pass.
+
+## Purpose
+
+Connect the `release_gate_agent` mandate to the development work queue: items in `category=release` with `status=validation_needed` receive deterministic go/no-go reports. Replace ad-hoc readiness reasoning with an evidence-backed verdict keyed by closed vocabulary.
+
+A9 is **not** an automatic merge or deployment trigger. `go` means "evidence shows nothing blocks merge"; the merge itself remains a separate `pr_squash_merge` action gated by the Execution Authority classifier and the GitHub PR lifecycle protocol.
+
+## Architectural separation: ADE core vs evidence collectors
+
+ADE core (this PR):
+
+```text
+reporting/development_release_gate.py
+reporting/development_release_gate_status.py
+```
+
+Stdlib + `reporting.execution_authority` + `reporting.approval_policy` + `reporting.development_work_queue`. No subprocess, no network, no `gh`, no `git`. Pinned by tests at AST level.
+
+Evidence collectors / adapters (out of scope for A9 core; preserved future path):
+
+```text
+- collectors live outside ADE core, preferred under scripts/
+- collectors may invoke gh/git/CI APIs
+- collectors produce logs/release_gate_input/latest.json
+- ADE core consumes only the evidence input contract
+- ADE core never imports collectors
+```
+
+A9 v0 accepts operator-driven evidence collection as a transitional state — not as the permanent architecture. The architecture explicitly preserves the future collector path so the operator does not have to permanently assemble release evidence by hand.
+
+## Verdict vocabulary (closed, 5)
+
+```text
+go                  - all required evidence clean
+go_with_followups   - clean, queue item lists advisory followups
+no_go_blocked       - hard-block evidence observed
+no_go_human_needed  - protected_surface=true OR authority NEEDS_HUMAN
+                       / PERMANENTLY_DENIED
+not_evaluated       - evidence absent / pending / item not qualifying
+```
+
+## Evidence keys (closed, 6)
+
+```text
+ci_status                   { green | red | pending | unknown }
+smoke_status                { passed | failed | unknown }
+governance_lint_status      { ok | fail | unknown }
+frozen_hash_status          { stable | drift | unknown }
+no_touch_path_delta_status  { clean | violation | unknown }
+queue_cross_reference_status { consistent | missing_item | unknown }
+```
+
+Frozen-hash drift signals always win. Protected-surface override always wins.
+
+## Required deliverables (this PR)
+
+```text
+1. reporting/development_release_gate.py
+2. reporting/development_release_gate_status.py
+3. tests/unit/test_development_release_gate.py
+4. tests/unit/test_development_release_gate_status.py
+5. docs/governance/development_release_gate.md
+6. This entry in docs/roadmap/autonomous_development.txt
+```
+
+## Out of scope (deferred)
+
+```text
+- evidence collector script(s) — separate PR after A9
+- automatic merge — never; remains operator-gated
+- deployment trigger — out of scope
+- A10/A11/A12 — separate phases
+- QRE-specific release semantics — disjoint
+```
+
+## Definition of Done
+
+```text
+1. Branch feature/a9-release-gate-integration exists; nothing on main.
+2. Implementation complete on branch (modules, docs, tests, roadmap entry).
+3. Targeted tests green:
+     python -m pytest tests/unit/test_development_release_gate.py \
+                      tests/unit/test_development_release_gate_status.py -q
+4. Broader unit suite green:
+     python -m pytest tests/unit -q
+5. Smoke suite green:
+     python -m pytest tests/smoke -q
+6. Governance lint green:
+     python scripts/governance_lint.py
+7. PR opened against main via the documented gh CLI flow.
+8. CI green on the PR.
+9. Squash-merged to main; post-merge gates green.
+10. Only after step 9 may this entry be flipped from `PR-ready` to
+    `Complete`, recording PR number and merge SHA.
+11. If the PR cannot be merged in this session, the entry remains
+    `PR-ready` (or moves to `Implementing` if a hard blocker emerges)
+    — never falsely marked Complete.
+```
+
+## Determinism
+
+Same as A8. The pure scorer accepts an injectable `generated_at_utc`. With the same queue artifact, the same evidence input, and the same injected timestamp, output bytes are identical. Per-row `gate_id` is sha256-derived and stable across runs with identical evidence.
+
+## Future phases
+
+```text
+A10 — Agentic Bugfix Loop (intake/proposal only; no auto-write to seed)
+A11 — Bounded Roadmap Implementation Delegation (explicit markers only)
+A12 — Operational Digest / Observability Loop
+Step 5 — Autonomous Implementation Loop (planning may begin after A12;
+         implementation only after readiness gate + explicit operator approval)
+```
+

--- a/reporting/development_release_gate.py
+++ b/reporting/development_release_gate.py
@@ -1,0 +1,733 @@
+"""A9 — Agentic Release-Gate Integration.
+
+Pure, deterministic, stdlib-only release-gate scorer for ADE work
+items in ``category=release`` with ``status=validation_needed``.
+
+The scorer consumes two read-only inputs and emits a closed-vocabulary
+verdict per qualifying queue item:
+
+1. The A8 development work queue artifact at
+   ``logs/development_work_queue/latest.json``.
+2. A structured **evidence input contract** at
+   ``logs/release_gate_input/latest.json`` (or any path the caller
+   supplies).
+
+The evidence input contract is an additive, closed-vocabulary JSON
+file. **ADE core never collects evidence itself.** Future
+collectors/adapters that invoke ``gh``/``git``/CI APIs live outside
+ADE core (preferred location: ``scripts/``). They produce the
+evidence input file; this module reads it. Until such a collector
+exists, the operator may populate the file by hand. The architecture
+explicitly preserves the future collector path (see
+``docs/governance/development_release_gate.md``).
+
+Hard guarantees (pinned by tests):
+
+* Stdlib + ``reporting.execution_authority`` + ``reporting.approval_policy`` +
+  ``reporting.development_work_queue`` (read-only API only).
+* No subprocess, no network, no ``gh``, no ``git``.
+* No imports from ``dashboard``, ``automation``, ``broker``,
+  ``agent.risk``, ``agent.execution``, ``research``,
+  ``reporting.intelligent_routing``.
+* Pure functions. No mutation of any upstream artifact.
+* Bounded scalars only — no PR text, no diffs, no body content.
+* Atomic write only under ``logs/development_release_gate/latest.json``.
+
+CLI::
+
+    python -m reporting.development_release_gate
+    python -m reporting.development_release_gate --indent 2
+    python -m reporting.development_release_gate --no-write
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import hashlib
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Final
+
+from reporting import development_work_queue as dwq
+from reporting import execution_authority as ea
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[str] = "1.0"
+MODULE_VERSION: Final[str] = "v3.15.16.A9"
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies
+# ---------------------------------------------------------------------------
+
+#: 5 release-gate verdicts.
+VERDICTS: Final[tuple[str, ...]] = (
+    "go",
+    "go_with_followups",
+    "no_go_blocked",
+    "no_go_human_needed",
+    "not_evaluated",
+)
+
+VERDICT_GO: Final[str] = "go"
+VERDICT_GO_WITH_FOLLOWUPS: Final[str] = "go_with_followups"
+VERDICT_NO_GO_BLOCKED: Final[str] = "no_go_blocked"
+VERDICT_NO_GO_HUMAN_NEEDED: Final[str] = "no_go_human_needed"
+VERDICT_NOT_EVALUATED: Final[str] = "not_evaluated"
+
+#: Closed verdict_reason vocabulary. Each verdict has documented
+#: reasons; all reasons map back to exactly one verdict.
+VERDICT_REASONS: Final[tuple[str, ...]] = (
+    # go
+    "all_required_evidence_clean",
+    # go_with_followups
+    "clean_with_advisory_followups",
+    # no_go_blocked
+    "ci_failed",
+    "smoke_failed",
+    "governance_lint_failed",
+    "frozen_contract_change_detected",
+    "protected_path_modification_detected",
+    "queue_cross_reference_inconsistent",
+    # no_go_human_needed
+    "protected_surface_present",
+    "execution_authority_needs_human",
+    "execution_authority_permanently_denied",
+    # not_evaluated
+    "evidence_input_missing",
+    "required_evidence_absent",
+    "ci_status_pending",
+    "queue_artifact_missing",
+    "queue_item_not_release_validation_needed",
+)
+
+#: 6 evidence keys the gate evaluates. Closed; additive only.
+EVIDENCE_KEYS: Final[tuple[str, ...]] = (
+    "ci_status",
+    "smoke_status",
+    "governance_lint_status",
+    "frozen_hash_status",
+    "no_touch_path_delta_status",
+    "queue_cross_reference_status",
+)
+
+#: Closed value vocabulary per evidence key. Each key MUST report one
+#: of these values when ``present=true``.
+EVIDENCE_VALUE_VOCAB: Final[dict[str, tuple[str, ...]]] = {
+    "ci_status": ("green", "red", "pending", "unknown"),
+    "smoke_status": ("passed", "failed", "unknown"),
+    "governance_lint_status": ("ok", "fail", "unknown"),
+    "frozen_hash_status": ("stable", "drift", "unknown"),
+    "no_touch_path_delta_status": ("clean", "violation", "unknown"),
+    "queue_cross_reference_status": ("consistent", "missing_item", "unknown"),
+}
+
+#: Per-row schema keys; exact and ordered.
+ROW_SCHEMA_KEYS: Final[tuple[str, ...]] = (
+    "gate_id",
+    "queue_item_id",
+    "title",
+    "verdict",
+    "verdict_reason",
+    "evidence_inputs",
+    "missing_evidence",
+    "required_followups",
+    "human_needed",
+    "human_needed_reason",
+    "execution_authority_decision",
+    "risk_level",
+    "protected_surface",
+    "created_at_placeholder",
+    "updated_at_placeholder",
+    "notes",
+)
+
+ITEM_TIME_PLACEHOLDER: Final[str] = "deterministic_seed_placeholder"
+
+DEFAULT_QUEUE_ARTIFACT_PATH: Final[Path] = dwq.ARTIFACT_LATEST
+DEFAULT_EVIDENCE_INPUT_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "release_gate_input" / "latest.json"
+)
+
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "development_release_gate"
+ARTIFACT_LATEST: Final[Path] = ARTIFACT_DIR / "latest.json"
+ARTIFACT_RELATIVE_PATH: Final[str] = "logs/development_release_gate/latest.json"
+
+#: Bounded length for free-text fields.
+MAX_TITLE_LEN: Final[int] = 200
+MAX_NOTES_LEN: Final[int] = 1000
+MAX_FOLLOWUPS: Final[int] = 16
+MAX_FOLLOWUP_LINE_LEN: Final[int] = 200
+
+#: Wrapper-level note vocabulary.
+NOTE_NO_QUEUE_ARTIFACT: Final[str] = "queue_artifact_missing"
+NOTE_NO_QUALIFYING_ITEMS: Final[str] = "no_release_validation_needed_items"
+NOTE_NO_EVIDENCE_INPUT: Final[str] = "evidence_input_absent"
+NOTE_VERDICTS_PRESENT: Final[str] = "verdicts_present"
+
+# ---------------------------------------------------------------------------
+# Utility helpers
+# ---------------------------------------------------------------------------
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _bounded_str(value: Any, max_len: int) -> str:
+    if not isinstance(value, str):
+        return ""
+    if len(value) <= max_len:
+        return value
+    return value[:max_len]
+
+
+def _bounded_str_list(value: Any, max_items: int, max_line_len: int) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    out: list[str] = []
+    for v in value[:max_items]:
+        if isinstance(v, str):
+            out.append(_bounded_str(v, max_line_len))
+    return out
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+
+def _deterministic_gate_id(queue_item_id: str, evidence_snapshot_id: str) -> str:
+    h = hashlib.sha256()
+    h.update(queue_item_id.encode("utf-8"))
+    h.update(b"\x1f")
+    h.update(evidence_snapshot_id.encode("utf-8"))
+    return "rg_" + h.hexdigest()[:12]
+
+
+def _evidence_snapshot_id(evidence: dict[str, Any]) -> str:
+    """Deterministic id for the evidence payload. Used to make
+    ``gate_id`` stable across runs with identical evidence."""
+    canonical = json.dumps(evidence, sort_keys=True).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()[:16]
+
+
+# ---------------------------------------------------------------------------
+# Evidence input parsing
+# ---------------------------------------------------------------------------
+
+
+def _normalize_evidence(raw: dict[str, Any] | None) -> tuple[dict[str, Any], list[str]]:
+    """Project the raw evidence input onto the closed vocabulary.
+
+    Returns ``(normalized_evidence, warnings)``. Unknown keys are
+    dropped; unknown values become ``unknown``."""
+    warnings: list[str] = []
+    normalized: dict[str, Any] = {}
+    if not isinstance(raw, dict):
+        for key in EVIDENCE_KEYS:
+            normalized[key] = {"present": False, "value": "unknown"}
+        if raw is not None:
+            warnings.append("evidence_input_not_an_object")
+        return normalized, warnings
+
+    payload = raw.get("evidence")
+    if not isinstance(payload, dict):
+        for key in EVIDENCE_KEYS:
+            normalized[key] = {"present": False, "value": "unknown"}
+        warnings.append("evidence_block_missing")
+        return normalized, warnings
+
+    for key in EVIDENCE_KEYS:
+        block = payload.get(key)
+        if not isinstance(block, dict):
+            normalized[key] = {"present": False, "value": "unknown"}
+            continue
+        present_raw = block.get("present")
+        present = bool(present_raw) if isinstance(present_raw, bool) else False
+        value_raw = block.get("value")
+        allowed = EVIDENCE_VALUE_VOCAB[key]
+        if isinstance(value_raw, str) and value_raw in allowed:
+            value = value_raw
+        else:
+            value = "unknown"
+            if present_raw is True:
+                warnings.append(f"evidence_{key}_value_invalid")
+        normalized[key] = {"present": present, "value": value}
+
+    extra_keys = sorted(k for k in payload if k not in EVIDENCE_KEYS)
+    for k in extra_keys[:8]:
+        warnings.append(f"evidence_unknown_key_{k}")
+
+    return normalized, warnings
+
+
+# ---------------------------------------------------------------------------
+# Verdict scoring
+# ---------------------------------------------------------------------------
+
+
+def _score_item(
+    item: dict[str, Any],
+    evidence: dict[str, Any],
+    *,
+    evidence_input_present: bool,
+) -> tuple[str, str, list[str], list[str], list[str]]:
+    """Return ``(verdict, verdict_reason, evidence_inputs,
+    missing_evidence, required_followups)``.
+
+    Precedence is intentionally first-match:
+    1. queue item's protected_surface or NEEDS_HUMAN/PERMANENTLY_DENIED
+       authority -> no_go_human_needed.
+    2. queue artifact / evidence file totally absent -> not_evaluated.
+    3. hard-block evidence violations -> no_go_blocked.
+    4. pending evidence -> not_evaluated.
+    5. missing required evidence -> not_evaluated.
+    6. otherwise -> go (or go_with_followups when followups present)."""
+    eaa = item.get("execution_authority")
+    protected = bool(item.get("protected_surface"))
+
+    if protected:
+        return (
+            VERDICT_NO_GO_HUMAN_NEEDED,
+            "protected_surface_present",
+            [],
+            [],
+            [],
+        )
+
+    if eaa == ea.DECISION_PERMANENTLY_DENIED:
+        return (
+            VERDICT_NO_GO_HUMAN_NEEDED,
+            "execution_authority_permanently_denied",
+            [],
+            [],
+            [],
+        )
+    if eaa == ea.DECISION_NEEDS_HUMAN:
+        return (
+            VERDICT_NO_GO_HUMAN_NEEDED,
+            "execution_authority_needs_human",
+            [],
+            [],
+            [],
+        )
+
+    if not evidence_input_present:
+        return (
+            VERDICT_NOT_EVALUATED,
+            "evidence_input_missing",
+            [],
+            list(EVIDENCE_KEYS),
+            [],
+        )
+
+    evidence_inputs: list[str] = []
+    missing: list[str] = []
+    for key in EVIDENCE_KEYS:
+        block = evidence.get(key) or {}
+        if block.get("present"):
+            evidence_inputs.append(key)
+        else:
+            missing.append(key)
+
+    # Hard-block precedence over not_evaluated: if any evaluated
+    # evidence shows a hard violation, the item is no_go_blocked even
+    # if some other evidence is missing.
+    frozen = (evidence.get("frozen_hash_status") or {}).get("value")
+    no_touch = (evidence.get("no_touch_path_delta_status") or {}).get("value")
+    ci = (evidence.get("ci_status") or {}).get("value")
+    smoke = (evidence.get("smoke_status") or {}).get("value")
+    gov = (evidence.get("governance_lint_status") or {}).get("value")
+    cross = (evidence.get("queue_cross_reference_status") or {}).get("value")
+
+    frozen_present = (evidence.get("frozen_hash_status") or {}).get("present", False)
+    no_touch_present = (
+        evidence.get("no_touch_path_delta_status") or {}
+    ).get("present", False)
+    ci_present = (evidence.get("ci_status") or {}).get("present", False)
+    smoke_present = (evidence.get("smoke_status") or {}).get("present", False)
+    gov_present = (evidence.get("governance_lint_status") or {}).get("present", False)
+    cross_present = (
+        evidence.get("queue_cross_reference_status") or {}
+    ).get("present", False)
+
+    if frozen_present and frozen == "drift":
+        return (
+            VERDICT_NO_GO_BLOCKED,
+            "frozen_contract_change_detected",
+            evidence_inputs,
+            missing,
+            [],
+        )
+    if no_touch_present and no_touch == "violation":
+        return (
+            VERDICT_NO_GO_BLOCKED,
+            "protected_path_modification_detected",
+            evidence_inputs,
+            missing,
+            [],
+        )
+    if ci_present and ci == "red":
+        return (
+            VERDICT_NO_GO_BLOCKED,
+            "ci_failed",
+            evidence_inputs,
+            missing,
+            [],
+        )
+    if smoke_present and smoke == "failed":
+        return (
+            VERDICT_NO_GO_BLOCKED,
+            "smoke_failed",
+            evidence_inputs,
+            missing,
+            [],
+        )
+    if gov_present and gov == "fail":
+        return (
+            VERDICT_NO_GO_BLOCKED,
+            "governance_lint_failed",
+            evidence_inputs,
+            missing,
+            [],
+        )
+    if cross_present and cross == "missing_item":
+        return (
+            VERDICT_NO_GO_BLOCKED,
+            "queue_cross_reference_inconsistent",
+            evidence_inputs,
+            missing,
+            [],
+        )
+
+    if ci_present and ci == "pending":
+        return (
+            VERDICT_NOT_EVALUATED,
+            "ci_status_pending",
+            evidence_inputs,
+            missing,
+            [],
+        )
+
+    # Required evidence keys for a go verdict: everything must be
+    # present and clean. If any required key is absent or unknown,
+    # the verdict is not_evaluated.
+    if missing:
+        return (
+            VERDICT_NOT_EVALUATED,
+            "required_evidence_absent",
+            evidence_inputs,
+            missing,
+            [],
+        )
+    unknown_values: list[str] = []
+    for key in EVIDENCE_KEYS:
+        block = evidence.get(key) or {}
+        if block.get("value") == "unknown":
+            unknown_values.append(key)
+    if unknown_values:
+        return (
+            VERDICT_NOT_EVALUATED,
+            "required_evidence_absent",
+            evidence_inputs,
+            unknown_values,
+            [],
+        )
+
+    # All present + clean. Surface advisory follow-ups from the queue
+    # item's validation_requirements if any (bounded).
+    followups = _bounded_str_list(
+        item.get("validation_requirements"), MAX_FOLLOWUPS, MAX_FOLLOWUP_LINE_LEN
+    )
+    if followups:
+        return (
+            VERDICT_GO_WITH_FOLLOWUPS,
+            "clean_with_advisory_followups",
+            evidence_inputs,
+            [],
+            followups,
+        )
+
+    return (
+        VERDICT_GO,
+        "all_required_evidence_clean",
+        evidence_inputs,
+        [],
+        [],
+    )
+
+
+def _human_needed_for_verdict(verdict: str) -> bool:
+    return verdict == VERDICT_NO_GO_HUMAN_NEEDED
+
+
+def _human_needed_reason_for(item: dict[str, Any], verdict: str) -> str:
+    if verdict != VERDICT_NO_GO_HUMAN_NEEDED:
+        # Mirror the queue item's own value when available.
+        raw = item.get("human_needed_reason")
+        if isinstance(raw, str) and raw in dwq.HUMAN_NEEDED_REASONS:
+            return raw
+        return "none"
+    if item.get("protected_surface"):
+        return "protected_governance_change"
+    eaa = item.get("execution_authority")
+    if eaa == ea.DECISION_PERMANENTLY_DENIED:
+        return "capital_or_live_execution_related"
+    return "ambiguous_scope"
+
+
+def _build_row(
+    item: dict[str, Any],
+    *,
+    evidence: dict[str, Any],
+    evidence_input_present: bool,
+    evidence_snapshot_id: str,
+) -> dict[str, Any]:
+    verdict, reason, ev_inputs, missing, followups = _score_item(
+        item, evidence, evidence_input_present=evidence_input_present
+    )
+    queue_item_id = str(item.get("item_id") or "")
+    gate_id = _deterministic_gate_id(queue_item_id, evidence_snapshot_id)
+    return {
+        "gate_id": gate_id,
+        "queue_item_id": queue_item_id,
+        "title": _bounded_str(item.get("title"), MAX_TITLE_LEN),
+        "verdict": verdict,
+        "verdict_reason": reason,
+        "evidence_inputs": ev_inputs,
+        "missing_evidence": missing,
+        "required_followups": followups,
+        "human_needed": _human_needed_for_verdict(verdict),
+        "human_needed_reason": _human_needed_reason_for(item, verdict),
+        "execution_authority_decision": item.get("execution_authority"),
+        "risk_level": item.get("risk_level"),
+        "protected_surface": bool(item.get("protected_surface")),
+        "created_at_placeholder": ITEM_TIME_PLACEHOLDER,
+        "updated_at_placeholder": ITEM_TIME_PLACEHOLDER,
+        "notes": _bounded_str(item.get("notes"), MAX_NOTES_LEN),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Snapshot assembly
+# ---------------------------------------------------------------------------
+
+
+def _qualifying_items(queue_payload: dict[str, Any] | None) -> list[dict[str, Any]]:
+    if not isinstance(queue_payload, dict):
+        return []
+    items = queue_payload.get("items")
+    if not isinstance(items, list):
+        return []
+    out: list[dict[str, Any]] = []
+    for it in items:
+        if not isinstance(it, dict):
+            continue
+        if it.get("category") != "release":
+            continue
+        if it.get("status") != "validation_needed":
+            continue
+        out.append(it)
+    return out
+
+
+def _empty_counts() -> dict[str, Any]:
+    return {
+        "total": 0,
+        "by_verdict": {v: 0 for v in VERDICTS},
+        "by_verdict_reason": {r: 0 for r in VERDICT_REASONS},
+        "human_needed": 0,
+        "protected_surface": 0,
+    }
+
+
+def _aggregate_counts(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    counts = _empty_counts()
+    counts["total"] = len(rows)
+    for row in rows:
+        counts["by_verdict"][row["verdict"]] += 1
+        counts["by_verdict_reason"][row["verdict_reason"]] += 1
+        if row["human_needed"]:
+            counts["human_needed"] += 1
+        if row["protected_surface"]:
+            counts["protected_surface"] += 1
+    return counts
+
+
+def collect_snapshot(
+    *,
+    queue_artifact_path: Path | None = None,
+    evidence_input_path: Path | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    """Build the deterministic release-gate snapshot.
+
+    Args:
+        queue_artifact_path: override the default
+            ``logs/development_work_queue/latest.json`` source.
+        evidence_input_path: override the default
+            ``logs/release_gate_input/latest.json`` source.
+        generated_at_utc: override the wrapper's report timestamp.
+            ``None`` reads the runtime UTC clock; tests pass a fixed
+            string to assert byte-stable output.
+    """
+    qp = queue_artifact_path if queue_artifact_path is not None else DEFAULT_QUEUE_ARTIFACT_PATH
+    ep = evidence_input_path if evidence_input_path is not None else DEFAULT_EVIDENCE_INPUT_PATH
+    ts = generated_at_utc if generated_at_utc is not None else _utcnow()
+
+    queue_payload = _read_json(qp)
+    queue_present = queue_payload is not None
+
+    evidence_payload = _read_json(ep)
+    evidence_input_present = evidence_payload is not None
+    normalized_evidence, evidence_warnings = _normalize_evidence(evidence_payload)
+    snapshot_id = _evidence_snapshot_id(normalized_evidence)
+
+    items = _qualifying_items(queue_payload)
+    rows: list[dict[str, Any]] = []
+    for it in items:
+        rows.append(
+            _build_row(
+                it,
+                evidence=normalized_evidence,
+                evidence_input_present=evidence_input_present,
+                evidence_snapshot_id=snapshot_id,
+            )
+        )
+
+    rows.sort(key=lambda r: r["gate_id"])
+
+    counts = _aggregate_counts(rows)
+
+    if not queue_present:
+        note = NOTE_NO_QUEUE_ARTIFACT
+    elif not items:
+        note = NOTE_NO_QUALIFYING_ITEMS
+    elif not evidence_input_present:
+        note = NOTE_NO_EVIDENCE_INPUT
+    else:
+        note = NOTE_VERDICTS_PRESENT
+
+    validation_warnings: list[str] = list(evidence_warnings)
+    # If the queue item is missing acceptance criteria, surface that.
+    for it in items:
+        ac = it.get("acceptance_criteria") or []
+        if not isinstance(ac, list) or not ac:
+            validation_warnings.append(
+                f"queue_item_{it.get('item_id')}_missing_acceptance_criteria"
+            )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "report_kind": "development_release_gate",
+        "generated_at_utc": ts,
+        "queue_artifact_path": str(qp),
+        "queue_artifact_present": queue_present,
+        "evidence_input_path": str(ep),
+        "evidence_input_present": evidence_input_present,
+        "evidence_snapshot_id": snapshot_id,
+        "note": note,
+        "validation_warnings": validation_warnings,
+        "vocabularies": {
+            "verdicts": list(VERDICTS),
+            "verdict_reasons": list(VERDICT_REASONS),
+            "evidence_keys": list(EVIDENCE_KEYS),
+            "evidence_value_vocab": {k: list(v) for k, v in EVIDENCE_VALUE_VOCAB.items()},
+        },
+        "counts": counts,
+        "rows": rows,
+        "execution_authority_module_version": ea.MODULE_VERSION,
+        "queue_module_version": dwq.MODULE_VERSION,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Atomic write
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    posix = path.as_posix()
+    if "/logs/" not in posix and not posix.startswith("logs/"):
+        raise ValueError(
+            "development_release_gate._atomic_write_json refuses "
+            f"non-logs/ output path: {path}"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".development_release_gate.", suffix=".tmp", dir=str(path.parent)
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_outputs(snapshot: dict[str, Any]) -> Path:
+    _atomic_write_json(ARTIFACT_LATEST, snapshot)
+    return ARTIFACT_LATEST
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m reporting.development_release_gate",
+        description=(
+            "Read-only release-gate scorer for ADE work items in "
+            "category=release with status=validation_needed. Decides "
+            "nothing destructive; mutates nothing. Evidence is "
+            "consumed from logs/release_gate_input/latest.json; ADE "
+            "core never collects evidence itself."
+        ),
+    )
+    p.add_argument("--indent", type=int, default=2, help="JSON indent (0 for compact).")
+    p.add_argument(
+        "--no-write",
+        action="store_true",
+        help=(
+            "Do not persist logs/development_release_gate/latest.json "
+            "(stdout only)."
+        ),
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    indent = args.indent if args.indent and args.indent > 0 else None
+    snap = collect_snapshot()
+    if not args.no_write:
+        write_outputs(snap)
+    json.dump(snap, sys.stdout, indent=indent, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/reporting/development_release_gate_status.py
+++ b/reporting/development_release_gate_status.py
@@ -1,0 +1,232 @@
+"""A9 — Release-gate status summary.
+
+Read-only projection that consumes
+``logs/development_release_gate/latest.json`` and emits a compact
+operator-facing summary with closed-vocabulary buckets.
+
+Hard guarantees (pinned by tests):
+
+* Stdlib + ``reporting.development_release_gate`` (read-only API).
+* No subprocess, no network, no ``gh``, no ``git``.
+* No imports from ``dashboard``, ``automation``, ``broker``,
+  ``agent.risk``, ``agent.execution``, ``research``,
+  ``reporting.intelligent_routing``.
+* Pure read on the artifact; never mutates ``latest.json``.
+
+CLI::
+
+    python -m reporting.development_release_gate_status
+    python -m reporting.development_release_gate_status --indent 2
+    python -m reporting.development_release_gate_status --no-write
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Final
+
+from reporting import development_release_gate as drg
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[str] = "1.0"
+MODULE_VERSION: Final[str] = "v3.15.16.A9"
+
+ARTIFACT_DIR: Final[Path] = (
+    REPO_ROOT / "logs" / "development_release_gate_status"
+)
+ARTIFACT_LATEST: Final[Path] = ARTIFACT_DIR / "latest.json"
+ARTIFACT_RELATIVE_PATH: Final[str] = (
+    "logs/development_release_gate_status/latest.json"
+)
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+
+def _empty_counts() -> dict[str, Any]:
+    return {
+        "total": 0,
+        "human_needed": 0,
+        "protected_surface": 0,
+        "by_verdict": {v: 0 for v in drg.VERDICTS},
+        "by_verdict_reason": {r: 0 for r in drg.VERDICT_REASONS},
+        "ready_for_merge": 0,
+        "requiring_human_operator": 0,
+    }
+
+
+def collect_status(
+    *,
+    gate_artifact_path: Path | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    """Build a deterministic status snapshot from the gate artifact."""
+    gp = (
+        gate_artifact_path
+        if gate_artifact_path is not None
+        else drg.ARTIFACT_LATEST
+    )
+    ts = generated_at_utc if generated_at_utc is not None else _utcnow()
+    payload = _read_json(gp)
+    if payload is None:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "module_version": MODULE_VERSION,
+            "report_kind": "development_release_gate_status",
+            "generated_at_utc": ts,
+            "gate_artifact_path": str(gp),
+            "gate_artifact_available": False,
+            "gate_module_version": drg.MODULE_VERSION,
+            "schema_pinned": {
+                "verdicts": list(drg.VERDICTS),
+                "verdict_reasons": list(drg.VERDICT_REASONS),
+                "evidence_keys": list(drg.EVIDENCE_KEYS),
+            },
+            "counts": _empty_counts(),
+            "validation_warnings": [],
+            "note": "gate_artifact_absent",
+        }
+
+    src_counts = payload.get("counts") or {}
+    if not isinstance(src_counts, dict):
+        src_counts = {}
+    by_verdict_src = (
+        src_counts.get("by_verdict")
+        if isinstance(src_counts.get("by_verdict"), dict)
+        else {}
+    )
+    by_reason_src = (
+        src_counts.get("by_verdict_reason")
+        if isinstance(src_counts.get("by_verdict_reason"), dict)
+        else {}
+    )
+
+    by_verdict = {v: int(by_verdict_src.get(v) or 0) for v in drg.VERDICTS}
+    by_reason = {r: int(by_reason_src.get(r) or 0) for r in drg.VERDICT_REASONS}
+
+    ready_for_merge = (
+        by_verdict.get(drg.VERDICT_GO, 0)
+        + by_verdict.get(drg.VERDICT_GO_WITH_FOLLOWUPS, 0)
+    )
+    requiring_human = by_verdict.get(drg.VERDICT_NO_GO_HUMAN_NEEDED, 0)
+
+    counts = {
+        "total": int(src_counts.get("total") or 0),
+        "human_needed": int(src_counts.get("human_needed") or 0),
+        "protected_surface": int(src_counts.get("protected_surface") or 0),
+        "by_verdict": by_verdict,
+        "by_verdict_reason": by_reason,
+        "ready_for_merge": ready_for_merge,
+        "requiring_human_operator": requiring_human,
+    }
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "report_kind": "development_release_gate_status",
+        "generated_at_utc": ts,
+        "gate_artifact_path": str(gp),
+        "gate_artifact_available": True,
+        "gate_module_version": payload.get("module_version"),
+        "gate_schema_version": payload.get("schema_version"),
+        "gate_generated_at_utc": payload.get("generated_at_utc"),
+        "gate_note": payload.get("note"),
+        "evidence_input_present": bool(payload.get("evidence_input_present")),
+        "queue_artifact_present": bool(payload.get("queue_artifact_present")),
+        "schema_pinned": {
+            "verdicts": list(drg.VERDICTS),
+            "verdict_reasons": list(drg.VERDICT_REASONS),
+            "evidence_keys": list(drg.EVIDENCE_KEYS),
+        },
+        "counts": counts,
+        "validation_warnings": list(payload.get("validation_warnings") or []),
+        "note": "gate_artifact_present",
+    }
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    posix = path.as_posix()
+    if "/logs/" not in posix and not posix.startswith("logs/"):
+        raise ValueError(
+            "development_release_gate_status._atomic_write_json refuses "
+            f"non-logs/ output path: {path}"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".development_release_gate_status.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_outputs(snapshot: dict[str, Any]) -> Path:
+    _atomic_write_json(ARTIFACT_LATEST, snapshot)
+    return ARTIFACT_LATEST
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m reporting.development_release_gate_status",
+        description=(
+            "Read-only summary of logs/development_release_gate/"
+            "latest.json. Decides nothing; mutates nothing."
+        ),
+    )
+    p.add_argument("--indent", type=int, default=2, help="JSON indent (0 for compact).")
+    p.add_argument(
+        "--no-write",
+        action="store_true",
+        help=(
+            "Do not persist logs/development_release_gate_status/latest.json "
+            "(stdout only)."
+        ),
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    indent = args.indent if args.indent and args.indent > 0 else None
+    snap = collect_status()
+    if not args.no_write:
+        write_outputs(snap)
+    json.dump(snap, sys.stdout, indent=indent, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/unit/test_development_release_gate.py
+++ b/tests/unit/test_development_release_gate.py
@@ -1,0 +1,643 @@
+"""Unit tests for A9 — Agentic Release-Gate Integration.
+
+Synthetic deterministic fixtures only. The pure scorer consumes
+two read-only inputs (the A8 work-queue artifact and the structured
+evidence input contract) and emits closed-vocabulary verdicts.
+ADE core never collects evidence itself; the architecture explicitly
+preserves a future collector/adapter path outside ADE core.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reporting import development_release_gate as drg
+from reporting import development_work_queue as dwq
+from reporting import execution_authority as ea
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _queue_path(tmp_path: Path) -> Path:
+    return tmp_path / "queue.json"
+
+
+def _evidence_path(tmp_path: Path) -> Path:
+    return tmp_path / "evidence.json"
+
+
+def _release_item(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "item_id": "dwq_a9releaseaaa",
+        "title": "Cut release v3.15.16.A9",
+        "source_document": "docs/operator/release_notes.md",
+        "source_section_or_anchor": "A9-release",
+        "roadmap_track": "sidecar_seed",
+        "category": "release",
+        "required_agent_role": "release_gate_agent",
+        "supporting_agent_roles": ["evidence_verifier"],
+        "execution_authority": ea.DECISION_AUTO_ALLOWED,
+        "status": "validation_needed",
+        "human_needed": False,
+        "human_needed_reason": "none",
+        "blocked_by": [],
+        "priority": 2,
+        "risk_level": "LOW",
+        "protected_surface": False,
+        "acceptance_criteria": ["release notes drafted"],
+        "validation_requirements": [],
+        "created_at_placeholder": "deterministic_seed_placeholder",
+        "updated_at_placeholder": "deterministic_seed_placeholder",
+        "notes": "",
+    }
+    base.update(overrides)
+    return base
+
+
+def _write_queue(tmp_path: Path, items: list[dict[str, Any]]) -> Path:
+    p = _queue_path(tmp_path)
+    p.write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0",
+                "module_version": dwq.MODULE_VERSION,
+                "report_kind": "development_work_queue",
+                "items": items,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return p
+
+
+def _all_clean_evidence() -> dict[str, Any]:
+    return {
+        "schema_version": "1.0",
+        "evidence": {
+            "ci_status": {"present": True, "value": "green"},
+            "smoke_status": {"present": True, "value": "passed"},
+            "governance_lint_status": {"present": True, "value": "ok"},
+            "frozen_hash_status": {"present": True, "value": "stable"},
+            "no_touch_path_delta_status": {"present": True, "value": "clean"},
+            "queue_cross_reference_status": {"present": True, "value": "consistent"},
+        },
+    }
+
+
+def _write_evidence(tmp_path: Path, payload: dict[str, Any]) -> Path:
+    p = _evidence_path(tmp_path)
+    p.write_text(json.dumps(payload), encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Vocabulary integrity
+# ---------------------------------------------------------------------------
+
+
+def test_verdicts_vocabulary_is_closed_and_ordered() -> None:
+    assert drg.VERDICTS == (
+        "go",
+        "go_with_followups",
+        "no_go_blocked",
+        "no_go_human_needed",
+        "not_evaluated",
+    )
+    assert len(drg.VERDICTS) == 5
+
+
+def test_verdict_reasons_vocabulary_is_closed_and_ordered() -> None:
+    assert drg.VERDICT_REASONS == (
+        "all_required_evidence_clean",
+        "clean_with_advisory_followups",
+        "ci_failed",
+        "smoke_failed",
+        "governance_lint_failed",
+        "frozen_contract_change_detected",
+        "protected_path_modification_detected",
+        "queue_cross_reference_inconsistent",
+        "protected_surface_present",
+        "execution_authority_needs_human",
+        "execution_authority_permanently_denied",
+        "evidence_input_missing",
+        "required_evidence_absent",
+        "ci_status_pending",
+        "queue_artifact_missing",
+        "queue_item_not_release_validation_needed",
+    )
+    assert len(drg.VERDICT_REASONS) == 16
+
+
+def test_evidence_keys_vocabulary_is_closed_and_ordered() -> None:
+    assert drg.EVIDENCE_KEYS == (
+        "ci_status",
+        "smoke_status",
+        "governance_lint_status",
+        "frozen_hash_status",
+        "no_touch_path_delta_status",
+        "queue_cross_reference_status",
+    )
+    assert len(drg.EVIDENCE_KEYS) == 6
+
+
+def test_evidence_value_vocab_is_closed_per_key() -> None:
+    assert drg.EVIDENCE_VALUE_VOCAB["ci_status"] == ("green", "red", "pending", "unknown")
+    assert drg.EVIDENCE_VALUE_VOCAB["smoke_status"] == ("passed", "failed", "unknown")
+    assert drg.EVIDENCE_VALUE_VOCAB["governance_lint_status"] == ("ok", "fail", "unknown")
+    assert drg.EVIDENCE_VALUE_VOCAB["frozen_hash_status"] == ("stable", "drift", "unknown")
+    assert drg.EVIDENCE_VALUE_VOCAB["no_touch_path_delta_status"] == ("clean", "violation", "unknown")
+    assert drg.EVIDENCE_VALUE_VOCAB["queue_cross_reference_status"] == ("consistent", "missing_item", "unknown")
+    # Every evidence key has a value vocabulary.
+    assert set(drg.EVIDENCE_VALUE_VOCAB) == set(drg.EVIDENCE_KEYS)
+
+
+def test_row_schema_keys_are_exact_and_ordered() -> None:
+    assert drg.ROW_SCHEMA_KEYS == (
+        "gate_id",
+        "queue_item_id",
+        "title",
+        "verdict",
+        "verdict_reason",
+        "evidence_inputs",
+        "missing_evidence",
+        "required_followups",
+        "human_needed",
+        "human_needed_reason",
+        "execution_authority_decision",
+        "risk_level",
+        "protected_surface",
+        "created_at_placeholder",
+        "updated_at_placeholder",
+        "notes",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Artifact path discipline
+# ---------------------------------------------------------------------------
+
+
+def test_artifact_path_is_under_logs_not_research() -> None:
+    assert drg.ARTIFACT_RELATIVE_PATH.startswith("logs/")
+    assert "research/" not in drg.ARTIFACT_RELATIVE_PATH
+
+
+def test_atomic_write_refuses_non_logs_path(tmp_path: Path) -> None:
+    bad = tmp_path / "not_logs" / "latest.json"
+    with pytest.raises(ValueError):
+        drg._atomic_write_json(bad, {"x": 1})
+
+
+# ---------------------------------------------------------------------------
+# Snapshot top-level shape
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_top_level_keys(tmp_path: Path) -> None:
+    qp = _write_queue(tmp_path, [_release_item()])
+    ep = _write_evidence(tmp_path, _all_clean_evidence())
+    snap = drg.collect_snapshot(
+        queue_artifact_path=qp,
+        evidence_input_path=ep,
+        generated_at_utc="2026-05-07T00:00:00Z",
+    )
+    expected = {
+        "schema_version",
+        "module_version",
+        "report_kind",
+        "generated_at_utc",
+        "queue_artifact_path",
+        "queue_artifact_present",
+        "evidence_input_path",
+        "evidence_input_present",
+        "evidence_snapshot_id",
+        "note",
+        "validation_warnings",
+        "vocabularies",
+        "counts",
+        "rows",
+        "execution_authority_module_version",
+        "queue_module_version",
+    }
+    assert set(snap.keys()) == expected
+    assert snap["report_kind"] == "development_release_gate"
+    assert snap["queue_artifact_present"] is True
+    assert snap["evidence_input_present"] is True
+
+
+def test_snapshot_when_queue_artifact_missing(tmp_path: Path) -> None:
+    qp = tmp_path / "missing_queue.json"
+    snap = drg.collect_snapshot(queue_artifact_path=qp, evidence_input_path=tmp_path / "missing_ev.json")
+    assert snap["queue_artifact_present"] is False
+    assert snap["rows"] == []
+    assert snap["note"] == drg.NOTE_NO_QUEUE_ARTIFACT
+    assert snap["counts"]["total"] == 0
+
+
+def test_snapshot_when_no_qualifying_items(tmp_path: Path) -> None:
+    """Items not in category=release or not in status=validation_needed
+    must not appear in the gate."""
+    items = [
+        _release_item(item_id="dwq_other001", category="docs"),
+        _release_item(item_id="dwq_other002", status="ready"),
+    ]
+    qp = _write_queue(tmp_path, items)
+    ep = _write_evidence(tmp_path, _all_clean_evidence())
+    snap = drg.collect_snapshot(
+        queue_artifact_path=qp, evidence_input_path=ep
+    )
+    assert snap["rows"] == []
+    assert snap["note"] == drg.NOTE_NO_QUALIFYING_ITEMS
+
+
+def test_snapshot_when_evidence_input_missing(tmp_path: Path) -> None:
+    qp = _write_queue(tmp_path, [_release_item()])
+    snap = drg.collect_snapshot(
+        queue_artifact_path=qp,
+        evidence_input_path=tmp_path / "missing_ev.json",
+    )
+    assert snap["note"] == drg.NOTE_NO_EVIDENCE_INPUT
+    assert snap["rows"][0]["verdict"] == drg.VERDICT_NOT_EVALUATED
+    assert snap["rows"][0]["verdict_reason"] == "evidence_input_missing"
+
+
+# ---------------------------------------------------------------------------
+# Verdict semantics — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_all_clean_evidence_yields_go(tmp_path: Path) -> None:
+    qp = _write_queue(tmp_path, [_release_item()])
+    ep = _write_evidence(tmp_path, _all_clean_evidence())
+    snap = drg.collect_snapshot(queue_artifact_path=qp, evidence_input_path=ep)
+    assert snap["counts"]["total"] == 1
+    row = snap["rows"][0]
+    assert row["verdict"] == drg.VERDICT_GO
+    assert row["verdict_reason"] == "all_required_evidence_clean"
+    assert set(row["evidence_inputs"]) == set(drg.EVIDENCE_KEYS)
+    assert row["missing_evidence"] == []
+    assert row["required_followups"] == []
+    assert row["human_needed"] is False
+
+
+def test_clean_with_validation_requirements_yields_go_with_followups(
+    tmp_path: Path,
+) -> None:
+    item = _release_item(
+        validation_requirements=["operator confirms changelog drafted"]
+    )
+    qp = _write_queue(tmp_path, [item])
+    ep = _write_evidence(tmp_path, _all_clean_evidence())
+    snap = drg.collect_snapshot(queue_artifact_path=qp, evidence_input_path=ep)
+    row = snap["rows"][0]
+    assert row["verdict"] == drg.VERDICT_GO_WITH_FOLLOWUPS
+    assert row["verdict_reason"] == "clean_with_advisory_followups"
+    assert "operator confirms changelog drafted" in row["required_followups"]
+
+
+# ---------------------------------------------------------------------------
+# Verdict semantics — protected-surface and authority overrides
+# ---------------------------------------------------------------------------
+
+
+def test_protected_surface_always_no_go_human_needed_even_with_clean_evidence(
+    tmp_path: Path,
+) -> None:
+    item = _release_item(protected_surface=True)
+    qp = _write_queue(tmp_path, [item])
+    ep = _write_evidence(tmp_path, _all_clean_evidence())
+    snap = drg.collect_snapshot(queue_artifact_path=qp, evidence_input_path=ep)
+    row = snap["rows"][0]
+    assert row["verdict"] == drg.VERDICT_NO_GO_HUMAN_NEEDED
+    assert row["verdict_reason"] == "protected_surface_present"
+    assert row["human_needed"] is True
+    assert row["human_needed_reason"] == "protected_governance_change"
+
+
+def test_execution_authority_needs_human_blocks_go(tmp_path: Path) -> None:
+    item = _release_item(execution_authority=ea.DECISION_NEEDS_HUMAN)
+    qp = _write_queue(tmp_path, [item])
+    ep = _write_evidence(tmp_path, _all_clean_evidence())
+    snap = drg.collect_snapshot(queue_artifact_path=qp, evidence_input_path=ep)
+    row = snap["rows"][0]
+    assert row["verdict"] == drg.VERDICT_NO_GO_HUMAN_NEEDED
+    assert row["verdict_reason"] == "execution_authority_needs_human"
+
+
+def test_execution_authority_permanently_denied_blocks_go(tmp_path: Path) -> None:
+    item = _release_item(execution_authority=ea.DECISION_PERMANENTLY_DENIED)
+    qp = _write_queue(tmp_path, [item])
+    ep = _write_evidence(tmp_path, _all_clean_evidence())
+    snap = drg.collect_snapshot(queue_artifact_path=qp, evidence_input_path=ep)
+    row = snap["rows"][0]
+    assert row["verdict"] == drg.VERDICT_NO_GO_HUMAN_NEEDED
+    assert row["verdict_reason"] == "execution_authority_permanently_denied"
+
+
+# ---------------------------------------------------------------------------
+# Verdict semantics — hard blocks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("evidence_key", "bad_value", "expected_reason"),
+    [
+        ("frozen_hash_status", "drift", "frozen_contract_change_detected"),
+        ("no_touch_path_delta_status", "violation", "protected_path_modification_detected"),
+        ("ci_status", "red", "ci_failed"),
+        ("smoke_status", "failed", "smoke_failed"),
+        ("governance_lint_status", "fail", "governance_lint_failed"),
+        ("queue_cross_reference_status", "missing_item", "queue_cross_reference_inconsistent"),
+    ],
+)
+def test_hard_block_evidence_yields_no_go_blocked(
+    tmp_path: Path,
+    evidence_key: str,
+    bad_value: str,
+    expected_reason: str,
+) -> None:
+    payload = _all_clean_evidence()
+    payload["evidence"][evidence_key]["value"] = bad_value
+    qp = _write_queue(tmp_path, [_release_item()])
+    ep = _write_evidence(tmp_path, payload)
+    snap = drg.collect_snapshot(queue_artifact_path=qp, evidence_input_path=ep)
+    row = snap["rows"][0]
+    assert row["verdict"] == drg.VERDICT_NO_GO_BLOCKED
+    assert row["verdict_reason"] == expected_reason
+
+
+def test_frozen_drift_overrides_other_signals(tmp_path: Path) -> None:
+    """Frozen-contract drift takes precedence over any other hard
+    block, by precedence ordering."""
+    payload = _all_clean_evidence()
+    payload["evidence"]["frozen_hash_status"]["value"] = "drift"
+    payload["evidence"]["ci_status"]["value"] = "red"
+    payload["evidence"]["smoke_status"]["value"] = "failed"
+    qp = _write_queue(tmp_path, [_release_item()])
+    ep = _write_evidence(tmp_path, payload)
+    snap = drg.collect_snapshot(queue_artifact_path=qp, evidence_input_path=ep)
+    assert snap["rows"][0]["verdict_reason"] == "frozen_contract_change_detected"
+
+
+# ---------------------------------------------------------------------------
+# Verdict semantics — not_evaluated
+# ---------------------------------------------------------------------------
+
+
+def test_ci_pending_yields_not_evaluated(tmp_path: Path) -> None:
+    payload = _all_clean_evidence()
+    payload["evidence"]["ci_status"]["value"] = "pending"
+    qp = _write_queue(tmp_path, [_release_item()])
+    ep = _write_evidence(tmp_path, payload)
+    snap = drg.collect_snapshot(queue_artifact_path=qp, evidence_input_path=ep)
+    row = snap["rows"][0]
+    assert row["verdict"] == drg.VERDICT_NOT_EVALUATED
+    assert row["verdict_reason"] == "ci_status_pending"
+
+
+def test_required_evidence_absent_yields_not_evaluated(tmp_path: Path) -> None:
+    payload = _all_clean_evidence()
+    payload["evidence"]["governance_lint_status"]["present"] = False
+    qp = _write_queue(tmp_path, [_release_item()])
+    ep = _write_evidence(tmp_path, payload)
+    snap = drg.collect_snapshot(queue_artifact_path=qp, evidence_input_path=ep)
+    row = snap["rows"][0]
+    assert row["verdict"] == drg.VERDICT_NOT_EVALUATED
+    assert row["verdict_reason"] == "required_evidence_absent"
+    assert "governance_lint_status" in row["missing_evidence"]
+
+
+def test_unknown_evidence_value_yields_not_evaluated(tmp_path: Path) -> None:
+    payload = _all_clean_evidence()
+    payload["evidence"]["smoke_status"]["value"] = "unknown"
+    qp = _write_queue(tmp_path, [_release_item()])
+    ep = _write_evidence(tmp_path, payload)
+    snap = drg.collect_snapshot(queue_artifact_path=qp, evidence_input_path=ep)
+    row = snap["rows"][0]
+    assert row["verdict"] == drg.VERDICT_NOT_EVALUATED
+    assert row["verdict_reason"] == "required_evidence_absent"
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+def test_gate_id_is_deterministic_for_same_inputs(tmp_path: Path) -> None:
+    qp = _write_queue(tmp_path, [_release_item()])
+    ep = _write_evidence(tmp_path, _all_clean_evidence())
+    snap_a = drg.collect_snapshot(
+        queue_artifact_path=qp,
+        evidence_input_path=ep,
+        generated_at_utc="2026-05-07T00:00:00Z",
+    )
+    snap_b = drg.collect_snapshot(
+        queue_artifact_path=qp,
+        evidence_input_path=ep,
+        generated_at_utc="2026-05-07T00:00:00Z",
+    )
+    assert snap_a["rows"][0]["gate_id"] == snap_b["rows"][0]["gate_id"]
+    assert snap_a["rows"][0]["gate_id"].startswith("rg_")
+
+
+def test_artifact_bytes_are_deterministic_with_injected_timestamp(
+    tmp_path: Path,
+) -> None:
+    qp = _write_queue(tmp_path, [_release_item()])
+    ep = _write_evidence(tmp_path, _all_clean_evidence())
+    snap_a = drg.collect_snapshot(
+        queue_artifact_path=qp,
+        evidence_input_path=ep,
+        generated_at_utc="2026-05-07T00:00:00Z",
+    )
+    snap_b = drg.collect_snapshot(
+        queue_artifact_path=qp,
+        evidence_input_path=ep,
+        generated_at_utc="2026-05-07T00:00:00Z",
+    )
+    bytes_a = json.dumps(snap_a, sort_keys=True, indent=2).encode("utf-8")
+    bytes_b = json.dumps(snap_b, sort_keys=True, indent=2).encode("utf-8")
+    assert bytes_a == bytes_b
+
+
+def test_runtime_timestamp_changes_but_rows_remain_stable(tmp_path: Path) -> None:
+    qp = _write_queue(tmp_path, [_release_item()])
+    ep = _write_evidence(tmp_path, _all_clean_evidence())
+    a = drg.collect_snapshot(queue_artifact_path=qp, evidence_input_path=ep)
+    b = drg.collect_snapshot(queue_artifact_path=qp, evidence_input_path=ep)
+    assert a["rows"] == b["rows"]
+    assert a["evidence_snapshot_id"] == b["evidence_snapshot_id"]
+
+
+# ---------------------------------------------------------------------------
+# Counts
+# ---------------------------------------------------------------------------
+
+
+def test_counts_aggregate_and_close_vocabularies(tmp_path: Path) -> None:
+    items = [
+        _release_item(item_id="dwq_clean__001"),
+        _release_item(item_id="dwq_protec_002", protected_surface=True),
+        _release_item(
+            item_id="dwq_needhu_003",
+            execution_authority=ea.DECISION_NEEDS_HUMAN,
+        ),
+    ]
+    qp = _write_queue(tmp_path, items)
+    payload = _all_clean_evidence()
+    ep = _write_evidence(tmp_path, payload)
+    snap = drg.collect_snapshot(queue_artifact_path=qp, evidence_input_path=ep)
+    counts = snap["counts"]
+    assert counts["total"] == 3
+    assert sum(counts["by_verdict"].values()) == 3
+    assert counts["by_verdict"][drg.VERDICT_GO] == 1
+    assert counts["by_verdict"][drg.VERDICT_NO_GO_HUMAN_NEEDED] == 2
+    assert counts["human_needed"] == 2
+    assert counts["protected_surface"] == 1
+    assert set(counts["by_verdict"]) == set(drg.VERDICTS)
+    assert set(counts["by_verdict_reason"]) == set(drg.VERDICT_REASONS)
+
+
+# ---------------------------------------------------------------------------
+# Validation warnings
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_evidence_value_records_warning(tmp_path: Path) -> None:
+    payload = _all_clean_evidence()
+    payload["evidence"]["ci_status"]["value"] = "not_a_real_value"
+    qp = _write_queue(tmp_path, [_release_item()])
+    ep = _write_evidence(tmp_path, payload)
+    snap = drg.collect_snapshot(queue_artifact_path=qp, evidence_input_path=ep)
+    assert any("evidence_ci_status_value_invalid" in w for w in snap["validation_warnings"])
+    # Bad value should be coerced to "unknown".
+    assert snap["rows"][0]["verdict"] == drg.VERDICT_NOT_EVALUATED
+
+
+def test_unknown_evidence_extra_key_records_warning(tmp_path: Path) -> None:
+    payload = {
+        "evidence": {
+            **_all_clean_evidence()["evidence"],
+            "made_up_key": {"present": True, "value": "anything"},
+        }
+    }
+    qp = _write_queue(tmp_path, [_release_item()])
+    ep = _write_evidence(tmp_path, payload)
+    snap = drg.collect_snapshot(queue_artifact_path=qp, evidence_input_path=ep)
+    assert any("evidence_unknown_key_made_up_key" in w for w in snap["validation_warnings"])
+
+
+def test_missing_acceptance_criteria_records_warning(tmp_path: Path) -> None:
+    item = _release_item(acceptance_criteria=[])
+    qp = _write_queue(tmp_path, [item])
+    ep = _write_evidence(tmp_path, _all_clean_evidence())
+    snap = drg.collect_snapshot(queue_artifact_path=qp, evidence_input_path=ep)
+    assert any(
+        "missing_acceptance_criteria" in w for w in snap["validation_warnings"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Source-text scans (no subprocess / no network / no forbidden imports)
+# ---------------------------------------------------------------------------
+
+
+def _module_source() -> str:
+    return Path(drg.__file__).read_text(encoding="utf-8")
+
+
+def test_no_subprocess_in_module() -> None:
+    src = _module_source()
+    assert "import subprocess" not in src
+    assert "from subprocess" not in src
+
+
+def test_no_network_in_module() -> None:
+    src = _module_source()
+    for forbidden in (
+        "import socket",
+        "import urllib",
+        "import http.client",
+        "import requests",
+    ):
+        assert forbidden not in src
+    assert "from socket" not in src
+    assert "from urllib" not in src
+    assert "from http" not in src
+    assert "from requests" not in src
+
+
+def _imported_module_names() -> set[str]:
+    """Return the set of fully-qualified module names imported by the
+    scorer module, parsed via ``ast`` so that docstring/comment
+    mentions of forbidden modules do not produce false positives."""
+    import ast
+
+    src = _module_source()
+    tree = ast.parse(src)
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module is not None:
+                names.add(node.module)
+    return names
+
+
+def test_no_dashboard_or_live_path_or_qre_imports() -> None:
+    """ADE core never imports dashboard/automation/broker/agent
+    risk/execution/research/Intelligent Routing modules. Pinned by
+    AST-level inspection so docstring mentions are safe."""
+    forbidden_prefixes = (
+        "dashboard",
+        "automation",
+        "broker",
+        "agent.risk",
+        "agent.execution",
+        "research",
+        "reporting.intelligent_routing",
+    )
+    for module in _imported_module_names():
+        for prefix in forbidden_prefixes:
+            assert not (module == prefix or module.startswith(prefix + ".")), (
+                f"forbidden import: {module}"
+            )
+
+
+def test_no_gh_or_git_subprocess_references() -> None:
+    src = _module_source()
+    # The module must not shell out — these tokens would suggest it.
+    for forbidden in (
+        "subprocess.run",
+        "subprocess.Popen",
+        "os.system",
+        "os.popen",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_module_imports_cleanly() -> None:
+    importlib.reload(drg)
+    assert callable(drg.collect_snapshot)
+    assert callable(drg.write_outputs)
+
+
+# ---------------------------------------------------------------------------
+# Schema-version + module-version surfaces
+# ---------------------------------------------------------------------------
+
+
+def test_schema_and_module_version_strings() -> None:
+    assert isinstance(drg.SCHEMA_VERSION, str) and drg.SCHEMA_VERSION
+    assert isinstance(drg.MODULE_VERSION, str) and drg.MODULE_VERSION
+    assert "A9" in drg.MODULE_VERSION

--- a/tests/unit/test_development_release_gate_status.py
+++ b/tests/unit/test_development_release_gate_status.py
@@ -1,0 +1,220 @@
+"""Unit tests for A9 — release-gate status summary.
+
+Synthetic deterministic fixtures only. The module reads
+``logs/development_release_gate/latest.json`` and emits a compact
+operator-facing summary; it does not mutate the gate artifact.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reporting import development_release_gate as drg
+from reporting import development_release_gate_status as drgs
+
+
+def _write_gate_artifact(tmp_path: Path, payload: dict[str, Any]) -> Path:
+    p = tmp_path / "gate.json"
+    p.write_text(json.dumps(payload), encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Vocabulary / shape
+# ---------------------------------------------------------------------------
+
+
+def test_artifact_path_is_under_logs_not_research() -> None:
+    assert drgs.ARTIFACT_RELATIVE_PATH.startswith("logs/")
+    assert "research/" not in drgs.ARTIFACT_RELATIVE_PATH
+
+
+def test_atomic_write_refuses_non_logs_path(tmp_path: Path) -> None:
+    bad = tmp_path / "evil_dir" / "latest.json"
+    with pytest.raises(ValueError):
+        drgs._atomic_write_json(bad, {"x": 1})
+
+
+def test_status_top_level_keys_when_gate_artifact_absent(tmp_path: Path) -> None:
+    qp = tmp_path / "missing.json"
+    snap = drgs.collect_status(gate_artifact_path=qp, generated_at_utc="2026-05-07T00:00:00Z")
+    expected = {
+        "schema_version",
+        "module_version",
+        "report_kind",
+        "generated_at_utc",
+        "gate_artifact_path",
+        "gate_artifact_available",
+        "gate_module_version",
+        "schema_pinned",
+        "counts",
+        "validation_warnings",
+        "note",
+    }
+    assert set(snap.keys()) == expected
+    assert snap["report_kind"] == "development_release_gate_status"
+    assert snap["gate_artifact_available"] is False
+    assert snap["counts"]["total"] == 0
+    assert snap["note"] == "gate_artifact_absent"
+    assert set(snap["schema_pinned"]) == {
+        "verdicts",
+        "verdict_reasons",
+        "evidence_keys",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Counts pass-through and bucket completeness
+# ---------------------------------------------------------------------------
+
+
+def test_counts_pass_through_when_gate_artifact_present(tmp_path: Path) -> None:
+    fake_gate = {
+        "schema_version": "1.0",
+        "module_version": drg.MODULE_VERSION,
+        "generated_at_utc": "2026-05-07T00:00:00Z",
+        "note": drg.NOTE_VERDICTS_PRESENT,
+        "evidence_input_present": True,
+        "queue_artifact_present": True,
+        "counts": {
+            "total": 4,
+            "human_needed": 1,
+            "protected_surface": 1,
+            "by_verdict": {v: 0 for v in drg.VERDICTS},
+            "by_verdict_reason": {r: 0 for r in drg.VERDICT_REASONS},
+        },
+        "validation_warnings": ["item_x_missing_acceptance_criteria"],
+    }
+    fake_gate["counts"]["by_verdict"][drg.VERDICT_GO] = 2
+    fake_gate["counts"]["by_verdict"][drg.VERDICT_GO_WITH_FOLLOWUPS] = 1
+    fake_gate["counts"]["by_verdict"][drg.VERDICT_NO_GO_HUMAN_NEEDED] = 1
+    fake_gate["counts"]["by_verdict_reason"]["all_required_evidence_clean"] = 2
+    fake_gate["counts"]["by_verdict_reason"]["clean_with_advisory_followups"] = 1
+    fake_gate["counts"]["by_verdict_reason"]["protected_surface_present"] = 1
+
+    qp = _write_gate_artifact(tmp_path, fake_gate)
+    snap = drgs.collect_status(gate_artifact_path=qp)
+
+    assert snap["gate_artifact_available"] is True
+    assert snap["counts"]["total"] == 4
+    assert snap["counts"]["human_needed"] == 1
+    assert snap["counts"]["protected_surface"] == 1
+    assert snap["counts"]["by_verdict"][drg.VERDICT_GO] == 2
+    assert snap["counts"]["by_verdict"][drg.VERDICT_GO_WITH_FOLLOWUPS] == 1
+    assert snap["counts"]["by_verdict"][drg.VERDICT_NO_GO_HUMAN_NEEDED] == 1
+    assert snap["counts"]["ready_for_merge"] == 3
+    assert snap["counts"]["requiring_human_operator"] == 1
+    assert "item_x_missing_acceptance_criteria" in snap["validation_warnings"]
+
+
+def test_status_buckets_cover_all_closed_vocabularies(tmp_path: Path) -> None:
+    sparse_gate = {
+        "schema_version": "1.0",
+        "module_version": drg.MODULE_VERSION,
+        "note": drg.NOTE_NO_QUALIFYING_ITEMS,
+        "counts": {"total": 0},
+        "validation_warnings": [],
+    }
+    qp = _write_gate_artifact(tmp_path, sparse_gate)
+    snap = drgs.collect_status(gate_artifact_path=qp)
+    assert set(snap["counts"]["by_verdict"]) == set(drg.VERDICTS)
+    assert set(snap["counts"]["by_verdict_reason"]) == set(drg.VERDICT_REASONS)
+    assert all(v == 0 for v in snap["counts"]["by_verdict"].values())
+    assert snap["counts"]["ready_for_merge"] == 0
+    assert snap["counts"]["requiring_human_operator"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Read-only invariant
+# ---------------------------------------------------------------------------
+
+
+def test_status_does_not_mutate_gate_artifact(tmp_path: Path) -> None:
+    fake_gate = {
+        "schema_version": "1.0",
+        "module_version": drg.MODULE_VERSION,
+        "note": drg.NOTE_NO_QUALIFYING_ITEMS,
+        "counts": {"total": 0},
+        "validation_warnings": [],
+    }
+    qp = _write_gate_artifact(tmp_path, fake_gate)
+    before = qp.read_bytes()
+    drgs.collect_status(gate_artifact_path=qp)
+    after = qp.read_bytes()
+    assert before == after
+
+
+# ---------------------------------------------------------------------------
+# Source-text scans
+# ---------------------------------------------------------------------------
+
+
+def _module_source() -> str:
+    return Path(drgs.__file__).read_text(encoding="utf-8")
+
+
+def test_no_subprocess_in_status_module() -> None:
+    src = _module_source()
+    assert "import subprocess" not in src
+    assert "from subprocess" not in src
+
+
+def test_no_network_in_status_module() -> None:
+    src = _module_source()
+    for forbidden in (
+        "import socket",
+        "import urllib",
+        "import http.client",
+        "import requests",
+    ):
+        assert forbidden not in src
+    assert "from socket" not in src
+    assert "from urllib" not in src
+    assert "from http" not in src
+    assert "from requests" not in src
+
+
+def _imported_module_names() -> set[str]:
+    """Return the set of fully-qualified module names imported by
+    the status module, parsed via ``ast`` so that docstring/comment
+    mentions of forbidden modules do not produce false positives."""
+    import ast
+
+    src = _module_source()
+    tree = ast.parse(src)
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module is not None:
+                names.add(node.module)
+    return names
+
+
+def test_no_dashboard_or_live_path_or_qre_imports_in_status_module() -> None:
+    forbidden_prefixes = (
+        "dashboard",
+        "automation",
+        "broker",
+        "agent.risk",
+        "agent.execution",
+        "research",
+        "reporting.intelligent_routing",
+    )
+    for module in _imported_module_names():
+        for prefix in forbidden_prefixes:
+            assert not (module == prefix or module.startswith(prefix + ".")), (
+                f"forbidden import: {module}"
+            )
+
+
+def test_status_module_imports_cleanly() -> None:
+    importlib.reload(drgs)
+    assert callable(drgs.collect_status)


### PR DESCRIPTION
## Summary

Connect the `release_gate_agent` mandate to the A8 development work queue. Items in `category=release` with `status=validation_needed` now receive a deterministic, evidence-backed go/no-go report with closed-vocabulary verdicts. ADE core stays pure; evidence collection lives outside ADE core and is explicitly deferred so the operator does not have to permanently assemble release evidence by hand.

**Status: PR-ready, NOT Complete.** The §A9 entry in `docs/roadmap/autonomous_development.txt` flips to `Complete` only after CI green + squash-merge + post-merge gates.

## Scope

**Added (read-only / additive):**
- `reporting/development_release_gate.py` — pure scorer.
  - 5 verdicts: `go`, `go_with_followups`, `no_go_blocked`, `no_go_human_needed`, `not_evaluated`.
  - 16 closed verdict reasons, 6 evidence keys with closed value vocabularies, frozen per-row schema.
  - Deterministic `gate_id` (sha256-derived); injectable `generated_at_utc` for byte-stable tests.
  - Atomic write under `logs/development_release_gate/latest.json` only.
- `reporting/development_release_gate_status.py` — read-only summary CLI projecting the gate artifact onto closed vocabularies; surfaces `ready_for_merge` / `requiring_human_operator` counts.
- `tests/unit/test_development_release_gate.py` — 35 tests.
- `tests/unit/test_development_release_gate_status.py` — 14 tests.
- `docs/governance/development_release_gate.md` — governance doc covering verdict precedence, evidence contract, ADE-core/collector split, future collector path.

**Modified (canonical_roadmap; operator-authorised by issue prompt):**
- `docs/roadmap/autonomous_development.txt` — append §A9 block with `Status: PR-ready (NOT complete)`.

**Untouched:** `research/**`, frozen contracts, Intelligent Routing modules, scoring, `.claude/**`, `dashboard/dashboard.py`, all live/paper/shadow/risk/trading/broker/execution paths, all CI workflows.

## Architectural separation

ADE core (`reporting/development_release_gate*`) is stdlib + `reporting.execution_authority` + `reporting.approval_policy` + `reporting.development_work_queue` only. No subprocess, no network, no `gh`, no `git`. Pinned by AST-level forbidden-import tests so docstring mentions of forbidden modules don't generate false positives.

Evidence collectors/adapters (out of scope for A9 v0):
- live outside ADE core, preferred under `scripts/`,
- may invoke `gh`/`git`/CI APIs,
- produce `logs/release_gate_input/latest.json`,
- are never imported by ADE core.

The architecture explicitly preserves the future collector path. A9 v0 accepts operator-driven evidence collection as a transitional state, not as the permanent architecture.

## Verdict precedence (first-match)

1. queue item `protected_surface=true` → `no_go_human_needed/protected_surface_present`
2. queue item authority `PERMANENTLY_DENIED` → `no_go_human_needed/execution_authority_permanently_denied`
3. queue item authority `NEEDS_HUMAN` → `no_go_human_needed/execution_authority_needs_human`
4. evidence input absent → `not_evaluated/evidence_input_missing`
5. hard-block evidence (in order):
   - frozen-hash drift, no-touch violation, CI red, smoke failed, lint fail, queue cross-ref inconsistent → `no_go_blocked/<reason>`
6. CI pending → `not_evaluated/ci_status_pending`
7. required evidence absent or `unknown` → `not_evaluated/required_evidence_absent`
8. all clean + no `validation_requirements` → `go/all_required_evidence_clean`
9. all clean + `validation_requirements` → `go_with_followups/clean_with_advisory_followups`

A `go` verdict is **advisory**. Merge remains a separate `pr_squash_merge` action gated by the Execution Authority classifier and the GitHub PR lifecycle protocol.

## Determinism

The pure scorer accepts an injectable `generated_at_utc`. With the same queue artifact, the same evidence input, and the same injected timestamp, output bytes are identical. Per-row `gate_id = sha256(queue_item_id || evidence_snapshot_id)` is stable across runs with identical inputs.

## Hard guarantees

- Stdlib + `reporting.execution_authority` + `reporting.approval_policy` + `reporting.development_work_queue` only.
- No subprocess, no network, no `gh`, no `git`.
- No imports from `dashboard`, `automation`, `broker`, `agent.risk`, `agent.execution`, `research`, or `reporting.intelligent_routing` (AST-level pin).
- Atomic write only under `logs/development_release_gate/latest.json`.
- Plain markdown headings inside any input file produce zero gate rows (mirrors A8 false-positive guard).

## Validation

- `python -m pytest tests/unit/test_development_release_gate.py tests/unit/test_development_release_gate_status.py -q` → **49 passed**.
- `python -m pytest tests/unit -q` → **3899 passed, 3 skipped, 0 failed**.
- `python -m pytest tests/smoke -q` → **18 passed**.
- `python scripts/governance_lint.py` → **OK**.
- No regression in A8 modules (`test_development_work_queue*`), Execution Authority tests, or autonomous backlog/readiness tests.

## Pre-merge verification (operator)

- [ ] CI green on this PR.
- [ ] No changes under `research/**`.
- [ ] No Intelligent Routing behavior change (no edits to `reporting/intelligent_routing*.py`, no `logs/intelligent_routing/**` mutation).
- [ ] No frozen-contract changes.
- [ ] No `.claude/**` writes.
- [ ] §A9 in `docs/roadmap/autonomous_development.txt` reads `Status: PR-ready (NOT complete)`.

## Definition of Done

A9 is **PR-ready**, not complete. The roadmap entry remains `Status: PR-ready` until:

1. CI green on this PR.
2. Squash-merged to `main` via `gh pr merge --squash --delete-branch`.
3. Post-merge gates green.

After squash-merge + post-merge gates green, a follow-up `chore/a9-mark-complete` PR flips §A9 to `Complete` with PR# + merge SHA.

## Out of scope (deferred)

- **Evidence collector script(s)** — separate PR after A9 lands; will live outside ADE core (under `scripts/`).
- **Automatic merge** — never; remains operator-gated.
- **A10** — agentic bugfix loop (intake/proposal only; no auto-write to `seed.jsonl`).
- **A11** — bounded roadmap delegation (explicit markers only; no fuzzy parsing).
- **A12** — operational digest.
- Any QRE / IR / v3.15.17 / scoring change.
- Any live/paper/shadow/risk/trading/broker/execution change.

## Test plan

- [ ] CI green on this PR (unit + smoke + governance_lint + frozen-hash check).
- [ ] Reviewer confirms zero changes under `research/`, `automation/`, `broker/`, `agent/risk/`, `agent/execution/`, `dashboard/dashboard.py`, `.claude/`, `.github/workflows/`, frozen contracts.
- [ ] Reviewer confirms the canonical-roadmap edit is the §A9 append only.
- [ ] After merge: post-merge gates green; flip §A9 status from `PR-ready` to `Complete` in a follow-up commit.