### PR TITLE
feat(A10): agentic bugfix loop (intake/proposal only)

### DIFF
--- a/docs/governance/development_bugfix_loop.md
+++ b/docs/governance/development_bugfix_loop.md
@@ -1,0 +1,230 @@
+# Autonomous Development Bugfix Loop (A10)
+
+> Canonical governance document for the Bugfix Loop introduced in
+> A10. Read-only intake; closed vocabularies; emits proposals to
+> `logs/development_bugfix_loop/latest.json` only. Operator
+> promotion remains manual.
+
+## Status
+
+Active. Modifications to this document require operator approval.
+
+## What this is — and is not
+
+A10 is the **intake** layer of the autonomous bugfix loop. It
+consumes a structured failure-summary contract and emits bounded
+bugfix-candidate proposals so the operator can decide what to
+promote into the development work queue.
+
+A10 is **not**:
+
+- an automatic code-change generator,
+- a branch / PR / commit creator,
+- a test runner,
+- a writer to `seed.jsonl` or `bugfix_seed.jsonl`,
+- a fuzzy log parser,
+- an LLM reasoner.
+
+`reporting.development_bugfix_loop` produces only
+`logs/development_bugfix_loop/latest.json`. Promotion of any
+candidate into a queue seed file (or any actual code change) is a
+separate operator action gated by the Execution Authority
+classifier and the GitHub PR lifecycle protocol.
+
+## Architectural separation: ADE core vs failure collectors
+
+ADE core
+:   `reporting/development_bugfix_loop.py`. Stdlib +
+    `reporting.execution_authority` + `reporting.approval_policy` +
+    `reporting.development_work_queue`. **No subprocess, no network,
+    no `gh`, no `git`, no test runners.** Pinned by source-text
+    scans and AST import inspection.
+
+Failure collectors / adapters (out of scope for A10 core)
+:   Optional, separately governed scripts that may live under
+    `scripts/` or be operator-driven runbooks. Collectors **may**
+    invoke `pytest`, `ruff`, `mypy`, `gh pr checks`, etc. to
+    populate the failure-input contract. ADE core consumes the
+    contract; ADE core never imports a collector.
+
+The split is permanent. The operator may populate the failure
+input by hand following this document — that is acceptable as a
+transitional state, not the permanent architecture.
+
+## Failure-input contract
+
+Default path:
+```
+logs/bugfix_loop_input/latest.json
+```
+
+Schema (closed; additive only):
+
+```json
+{
+  "schema_version": "1.0",
+  "generated_at_utc": "<iso utc>",
+  "failures": [
+    {
+      "failure_class": "<closed: see below>",
+      "target_path": "<repo-relative path>",
+      "message_digest": "<bounded scalar; deterministic hash of the failure message>",
+      "severity": "low | medium | high | unknown",
+      "occurrence_count": <int>,
+      "first_seen_utc": "<iso utc>",
+      "last_seen_utc": "<iso utc>",
+      "detail": "<bounded scalar, ≤ 500 chars>"
+    }
+  ]
+}
+```
+
+### Closed `failure_class` vocabulary (10)
+
+```
+unit_test, smoke_test, regression_test,
+lint, typecheck, governance_lint,
+frozen_hash, hook, ci_workflow, unknown
+```
+
+`unknown` is a fail-safe bucket — collectors should classify
+explicitly when possible. The module routes `unknown` to
+`human_operator`.
+
+### Closed `severity` vocabulary (4)
+
+```
+low, medium, high, unknown
+```
+
+Severity maps deterministically to risk class for the Execution
+Authority classifier (`low → LOW`, `medium → MEDIUM`, `high → HIGH`,
+`unknown → UNKNOWN`).
+
+## Output: per-candidate schema
+
+```
+candidate_id                       deterministic hash of (failure_class, target_path, message_digest)
+failure_class                      closed
+target_path                        bounded repo-relative
+target_path_category               from execution_authority classifier
+bugfix_scope                       closed (see below)
+suggested_status                   "proposed" | "human_needed"
+suggested_required_agent_role      from A8 AGENT_ROLES (closed mapping per failure_class)
+suggested_category                 from A8 CATEGORIES (closed mapping per failure_class)
+human_needed                       bool
+human_needed_reason                from A8 HUMAN_NEEDED_REASONS
+execution_authority_decision       AUTO_ALLOWED / NEEDS_HUMAN / PERMANENTLY_DENIED
+execution_authority_reason         classifier reason
+repeat_count                       bounded int (≥1)
+first_seen_utc / last_seen_utc     bounded scalars
+severity                           closed
+acceptance_criteria_template       safe template list (no test-weakening tokens)
+notes                              bounded scalar
+created_at_placeholder             "deterministic_seed_placeholder"
+updated_at_placeholder             "deterministic_seed_placeholder"
+```
+
+### Closed `bugfix_scope` vocabulary (7)
+
+```
+bounded_in_repo                — safe, scoped fix in non-protected repo paths
+protected_path                 — touches a protected governance/policy/wiring/branch-protection/deploy path
+live_path                      — touches automation/live_gate, broker/, agent/risk/, agent/execution/
+frozen_contract                — research/research_latest.json or research/strategy_matrix.csv
+ci_only                        — CI workflow change required (ci_guardian)
+requires_architecture_review   — `other` target category or NEEDS_HUMAN authority
+out_of_scope                   — would require test weakening or other governance violation
+```
+
+## Test-weakening discipline (load-bearing)
+
+Acceptance-criteria templates are drawn from a closed safe set per
+failure class. The template strings are pinned by tests to **never**
+contain any of:
+
+```
+skip
+xfail
+pytest.mark.skip
+pytest.mark.xfail
+remove pin
+weaken
+relax
+disable
+```
+
+This is the load-bearing test-weakening invariant. Adding a new
+failure class requires adding a safe template that is also
+test-weakening-clean, enforced by
+`tests/unit/test_development_bugfix_loop.py::test_acceptance_templates_never_contain_test_weakening_tokens`.
+
+## Authority and safety
+
+- Items targeting `frozen_contract` paths ⇒ always
+  `human_needed=true / frozen_contract_change`.
+- Items targeting `live_path` ⇒ always
+  `human_needed=true / capital_or_live_execution_related`.
+- Items targeting `claude_governance_hook`, `dashboard_wiring`,
+  `canonical_policy_doc`, `canonical_roadmap`,
+  `branch_protection_config`, `deploy_script` ⇒ always
+  `human_needed=true / protected_governance_change`.
+- Items targeting `ci_workflow` ⇒
+  `human_needed=true / protected_governance_change` (ci_guardian
+  proposes the workflow PR; not the bugfix loop).
+- Items whose Execution Authority decision is `NEEDS_HUMAN` /
+  `PERMANENTLY_DENIED` ⇒ always `human_needed=true`.
+- Items with `repeat_count ≥ REPEATED_FAILURE_THRESHOLD` (3) ⇒
+  escalated to `human_needed / repeated_validation_failure`.
+
+A `bugfix_scope=bounded_in_repo` candidate with `human_needed=false`
+is **eligible** for operator promotion into the work queue. It is
+not auto-promoted. The operator decides.
+
+## Hard guarantees (pinned by tests)
+
+- Stdlib + `reporting.execution_authority` +
+  `reporting.approval_policy` + `reporting.development_work_queue`.
+- No subprocess, no network, no `gh`, no `git`.
+- No imports from `dashboard`, `automation`, `broker`,
+  `agent.risk`, `agent.execution`, `research`,
+  `reporting.intelligent_routing`, `pytest`, `_pytest`, `unittest`
+  (AST-level pin).
+- Atomic write only under
+  `logs/development_bugfix_loop/latest.json`. The atomic-write
+  guard explicitly refuses any `seed.jsonl` / `bugfix_seed.jsonl`
+  path because both lie outside `logs/`.
+- Wrapper carries an explicit `discipline_invariants` block:
+  ```
+  writes_to_seed_jsonl: false
+  writes_to_bugfix_seed_jsonl: false
+  auto_creates_branches: false
+  auto_opens_prs: false
+  auto_modifies_code: false
+  operator_promotion_required: true
+  ```
+
+## CLI surface
+
+```
+python -m reporting.development_bugfix_loop            # writes artifact
+python -m reporting.development_bugfix_loop --no-write  # stdout only
+```
+
+## Future collector path (preserved, not implemented in A10 v0)
+
+Future collector scripts (under `scripts/`, not in ADE core) will:
+
+1. Run the failing test suite or read CI artifacts (`gh run view --log`).
+2. Parse JUnit XML / ruff JSON / mypy JSON / governance-lint output.
+3. Hash failure messages into a stable `message_digest`.
+4. Atomically write `logs/bugfix_loop_input/latest.json`.
+5. Invoke `python -m reporting.development_bugfix_loop` to score.
+
+The collector is governance/process work, separate from ADE core.
+
+## Modifying this document
+
+This is governance documentation. Modifications follow the same
+discipline as the rest of `docs/governance/`: scope-bounded PR, CI
+green, post-merge gates, no `--admin` merge.

--- a/docs/roadmap/autonomous_development.txt
+++ b/docs/roadmap/autonomous_development.txt
@@ -1008,3 +1008,125 @@ Step 5 — Autonomous Implementation Loop (planning may begin after A12;
          implementation only after readiness gate + explicit operator approval)
 ```
 
+\---
+
+# A10 — Agentic Bugfix Loop
+
+## Status
+
+```text
+Status: PR-ready (NOT complete)
+```
+
+A10 is marked complete only after the PR's CI is green, the squash merge has landed on `main`, and post-merge gates pass.
+
+## Purpose
+
+Convert structured routine failures into bounded bugfix-candidate proposals so the operator can decide what to promote into the development work queue. A10 is **intake only**: it never writes to seed files, never creates branches, never opens PRs, never modifies code.
+
+## Architectural separation: ADE core vs failure collectors
+
+ADE core (this PR):
+
+```text
+reporting/development_bugfix_loop.py
+```
+
+Stdlib + `reporting.execution_authority` + `reporting.approval_policy` + `reporting.development_work_queue`. No subprocess, no network, no `gh`, no `git`, no test runners. Pinned by tests at AST level.
+
+Failure collectors / adapters (out of scope for A10 core; preserved future path):
+
+```text
+- collectors live outside ADE core, preferred under scripts/
+- collectors may invoke pytest/ruff/mypy/gh and parse outputs
+- collectors produce logs/bugfix_loop_input/latest.json
+- ADE core consumes only the failure-input contract
+- ADE core never imports collectors
+```
+
+## Vocabulary (closed)
+
+```text
+failure_classes (10): unit_test, smoke_test, regression_test,
+                      lint, typecheck, governance_lint,
+                      frozen_hash, hook, ci_workflow, unknown
+bugfix_scopes (7):    bounded_in_repo, protected_path, live_path,
+                      frozen_contract, ci_only,
+                      requires_architecture_review, out_of_scope
+severities (4):       low, medium, high, unknown
+suggested_statuses:   proposed, human_needed
+```
+
+## Discipline invariants (load-bearing)
+
+```text
+writes_to_seed_jsonl: false
+writes_to_bugfix_seed_jsonl: false
+auto_creates_branches: false
+auto_opens_prs: false
+auto_modifies_code: false
+operator_promotion_required: true
+```
+
+The atomic-write guard refuses any path outside `logs/`, including `seed.jsonl` and `bugfix_seed.jsonl`. Acceptance-criteria templates are pinned to a closed safe set; test-weakening tokens (`skip`, `xfail`, `remove pin`, `weaken`, `relax`, `disable`) are absent and asserted by tests.
+
+## Authority overrides
+
+```text
+frozen_contract path           → human_needed (frozen_contract_change)
+live_path                      → human_needed (capital_or_live_execution_related)
+canonical_policy_doc /
+  canonical_roadmap /
+  claude_governance_hook /
+  dashboard_wiring /
+  branch_protection_config /
+  deploy_script               → human_needed (protected_governance_change)
+ci_workflow                   → ci_only + human_needed (protected_governance_change)
+authority NEEDS_HUMAN /
+  PERMANENTLY_DENIED          → human_needed
+repeat_count ≥ 3              → human_needed (repeated_validation_failure)
+```
+
+## Required deliverables (this PR)
+
+```text
+1. reporting/development_bugfix_loop.py
+2. tests/unit/test_development_bugfix_loop.py
+3. docs/governance/development_bugfix_loop.md
+4. This entry in docs/roadmap/autonomous_development.txt
+```
+
+## Out of scope (deferred)
+
+```text
+- failure collector script(s) — separate PR after A10
+- automatic branch / PR / commit creation — never; operator-gated
+- A11 / A12 — separate phases
+- Any QRE/IR/v3.15.17 changes
+- Any live/paper/shadow/risk/trading/broker/execution change
+```
+
+## Definition of Done
+
+```text
+1. Branch feature/a10-bugfix-loop exists; nothing on main.
+2. Implementation complete on branch (module, tests, docs, roadmap entry).
+3. Targeted tests green:
+     python -m pytest tests/unit/test_development_bugfix_loop.py -q
+4. Broader unit suite green:
+     python -m pytest tests/unit -q
+5. Smoke suite green:
+     python -m pytest tests/smoke -q
+6. Governance lint green:
+     python scripts/governance_lint.py
+7. PR opened against main via the documented gh CLI flow.
+8. CI green on the PR.
+9. Squash-merged to main; post-merge gates green.
+10. Only after step 9 may this entry be flipped from `PR-ready` to
+    `Complete`, recording PR number and merge SHA.
+```
+
+## Determinism
+
+The pure module accepts an injectable `generated_at_utc`. With the same failure-input contract and the same injected timestamp, output bytes are identical. Per-row `candidate_id` is sha256-derived from `(failure_class, target_path, message_digest)` and stable across runs.
+

--- a/reporting/development_bugfix_loop.py
+++ b/reporting/development_bugfix_loop.py
@@ -1,0 +1,672 @@
+"""A10 — Agentic Bugfix Loop.
+
+Pure, deterministic, stdlib-only **intake** module. Converts a
+structured failure-summary contract into bounded bugfix-candidate
+proposals. The module is intake/proposal **only**:
+
+* it never writes to ``docs/development_work_queue/seed.jsonl``;
+* it never writes to ``docs/development_work_queue/bugfix_seed.jsonl``;
+* it emits proposals only to ``logs/development_bugfix_loop/latest.json``;
+* operator promotion of any candidate into a queue seed file is a
+  separate manual action.
+
+The pure module never runs tests, never invokes ``pytest``, never
+calls ``gh``/``git``/``subprocess``, and never imports test runners.
+Failure summaries are produced **outside ADE core** by collectors
+under ``scripts/`` (or by hand). ADE core only consumes the
+contract; ADE core never imports collectors.
+
+Hard guarantees (pinned by tests):
+
+* Stdlib + ``reporting.execution_authority`` + ``reporting.approval_policy`` +
+  ``reporting.development_work_queue`` (read-only API).
+* No subprocess, no network, no ``gh``, no ``git``.
+* No imports from ``dashboard``, ``automation``, ``broker``,
+  ``agent.risk``, ``agent.execution``, ``research``,
+  ``reporting.intelligent_routing``.
+* No mutation of any upstream artifact.
+* Atomic write only under ``logs/development_bugfix_loop/latest.json``.
+* Acceptance-criteria templates are drawn from a closed safe set;
+  test-weakening suggestions (``skip``, ``xfail``, pin removal,
+  assertion relaxation) are intentionally absent and pinned by
+  tests.
+
+CLI::
+
+    python -m reporting.development_bugfix_loop
+    python -m reporting.development_bugfix_loop --indent 2
+    python -m reporting.development_bugfix_loop --no-write
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import hashlib
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Final
+
+from reporting import development_work_queue as dwq
+from reporting import execution_authority as ea
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[str] = "1.0"
+MODULE_VERSION: Final[str] = "v3.15.16.A10"
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies
+# ---------------------------------------------------------------------------
+
+#: 10 failure classes. Closed; additive only.
+FAILURE_CLASSES: Final[tuple[str, ...]] = (
+    "unit_test",
+    "smoke_test",
+    "regression_test",
+    "lint",
+    "typecheck",
+    "governance_lint",
+    "frozen_hash",
+    "hook",
+    "ci_workflow",
+    "unknown",
+)
+
+#: 7 bugfix scopes. ``out_of_scope`` is the explicit "do not touch"
+#: bucket — used for any failure whose only mechanical fix would
+#: require test weakening or any other governance-violating action.
+BUGFIX_SCOPES: Final[tuple[str, ...]] = (
+    "bounded_in_repo",
+    "protected_path",
+    "live_path",
+    "frozen_contract",
+    "ci_only",
+    "requires_architecture_review",
+    "out_of_scope",
+)
+
+#: Closed severity vocabulary on the failure-input side.
+INPUT_SEVERITIES: Final[tuple[str, ...]] = ("low", "medium", "high", "unknown")
+
+#: Suggested status for the proposed candidate. Mirrors a subset of
+#: the A8 Kanban statuses appropriate for an unpromoted proposal.
+SUGGESTED_STATUSES: Final[tuple[str, ...]] = ("proposed", "human_needed")
+
+#: Per-candidate schema keys, exact and ordered.
+CANDIDATE_SCHEMA_KEYS: Final[tuple[str, ...]] = (
+    "candidate_id",
+    "failure_class",
+    "target_path",
+    "target_path_category",
+    "bugfix_scope",
+    "suggested_status",
+    "suggested_required_agent_role",
+    "suggested_category",
+    "human_needed",
+    "human_needed_reason",
+    "execution_authority_decision",
+    "execution_authority_reason",
+    "repeat_count",
+    "first_seen_utc",
+    "last_seen_utc",
+    "severity",
+    "acceptance_criteria_template",
+    "notes",
+    "created_at_placeholder",
+    "updated_at_placeholder",
+)
+
+ITEM_TIME_PLACEHOLDER: Final[str] = "deterministic_seed_placeholder"
+
+#: Threshold for promoting a repeated failure to ``human_needed``.
+REPEATED_FAILURE_THRESHOLD: Final[int] = 3
+
+DEFAULT_INPUT_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "bugfix_loop_input" / "latest.json"
+)
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "development_bugfix_loop"
+ARTIFACT_LATEST: Final[Path] = ARTIFACT_DIR / "latest.json"
+ARTIFACT_RELATIVE_PATH: Final[str] = "logs/development_bugfix_loop/latest.json"
+
+#: Bounded length for free-text fields.
+MAX_DETAIL_LEN: Final[int] = 500
+MAX_NOTES_LEN: Final[int] = 1000
+MAX_PATH_LEN: Final[int] = 256
+MAX_FAILURES: Final[int] = 1000
+
+#: Wrapper-level note vocabulary.
+NOTE_INPUT_ABSENT: Final[str] = "input_absent"
+NOTE_INPUT_EMPTY: Final[str] = "input_empty"
+NOTE_CANDIDATES_PRESENT: Final[str] = "candidates_present"
+
+#: Forbidden tokens in any acceptance-criteria template — pinned by
+#: tests. The module's only safe templates are constructed from this
+#: closed-vocabulary set; the test asserts the closed set never
+#: contains a weakening token.
+FORBIDDEN_ACCEPTANCE_TOKENS: Final[tuple[str, ...]] = (
+    "skip",
+    "xfail",
+    "pytest.mark.skip",
+    "pytest.mark.xfail",
+    "remove pin",
+    "weaken",
+    "relax",
+    "disable",
+)
+
+# ---------------------------------------------------------------------------
+# Per-failure-class safe acceptance-criteria templates.
+# Operator-extensible only via code review. None of these strings
+# may match a FORBIDDEN_ACCEPTANCE_TOKENS entry; pinned by tests.
+# ---------------------------------------------------------------------------
+
+ACCEPTANCE_TEMPLATES: Final[dict[str, tuple[str, ...]]] = {
+    "unit_test": (
+        "reproduce the failure deterministically",
+        "fix the root cause without changing assertions",
+        "rerun the failing test until green",
+        "rerun the broader unit suite",
+    ),
+    "smoke_test": (
+        "reproduce the smoke failure deterministically",
+        "fix the root cause without changing assertions",
+        "rerun smoke and confirm green",
+    ),
+    "regression_test": (
+        "reproduce the regression deterministically",
+        "fix the root cause without removing pins",
+        "rerun the regression test until green",
+        "confirm pin still asserts the historical guarantee",
+    ),
+    "lint": (
+        "address the lint finding at its source",
+        "rerun the lint check until green",
+    ),
+    "typecheck": (
+        "fix the type error at its source",
+        "rerun mypy narrow until green",
+    ),
+    "governance_lint": (
+        "fix the governance-lint finding at its source",
+        "rerun governance_lint until OK",
+    ),
+    "frozen_hash": (
+        "operator confirms whether this drift is intentional",
+        "if drift is unintentional, revert to the byte-stable state",
+        "if drift is intentional, follow the operator-authored frozen-hash rotation flow",
+    ),
+    "hook": (
+        "operator reviews whether the hook is correctly tuned",
+        "fix the underlying cause without bypassing the hook",
+    ),
+    "ci_workflow": (
+        "ci_guardian reviews the workflow change required",
+        "fix root cause through a ci-guardian-authored workflow PR",
+    ),
+    "unknown": (
+        "operator triages the failure",
+        "classify the failure into a known failure_class",
+    ),
+}
+
+#: Suggested primary agent role per failure class (closed mapping).
+ROLE_BY_FAILURE_CLASS: Final[dict[str, str]] = {
+    "unit_test": "test_agent",
+    "smoke_test": "test_agent",
+    "regression_test": "test_agent",
+    "lint": "implementation_agent",
+    "typecheck": "implementation_agent",
+    "governance_lint": "architecture_guardian",
+    "frozen_hash": "human_operator",
+    "hook": "architecture_guardian",
+    "ci_workflow": "ci_guardian",
+    "unknown": "human_operator",
+}
+
+#: Suggested A8 category per failure class (closed mapping).
+CATEGORY_BY_FAILURE_CLASS: Final[dict[str, str]] = {
+    "unit_test": "test",
+    "smoke_test": "test",
+    "regression_test": "test",
+    "lint": "refactor",
+    "typecheck": "refactor",
+    "governance_lint": "governance",
+    "frozen_hash": "governance",
+    "hook": "governance",
+    "ci_workflow": "ci",
+    "unknown": "refactor",
+}
+
+
+# ---------------------------------------------------------------------------
+# Utility helpers
+# ---------------------------------------------------------------------------
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _bounded_str(value: Any, max_len: int) -> str:
+    if not isinstance(value, str):
+        return ""
+    if len(value) <= max_len:
+        return value
+    return value[:max_len]
+
+
+def _normalize_path(p: str) -> str:
+    """Repo-relative POSIX path. Mirrors
+    ``reporting.execution_authority._normalize`` so that ``.claude/``
+    and ``.github/`` paths retain their leading dot."""
+    if not p:
+        return ""
+    forward = p.replace("\\", "/")
+    if forward.startswith("./"):
+        return forward[2:]
+    if forward.startswith("."):
+        return forward
+    return forward.lstrip("/")
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+
+def _coerce_count(value: Any) -> int:
+    if isinstance(value, bool):
+        return 1
+    if isinstance(value, int) and value >= 1:
+        if value > 10**9:  # bounded
+            return 10**9
+        return value
+    return 1
+
+
+def _deterministic_candidate_id(
+    failure_class: str, target_path: str, message_digest: str
+) -> str:
+    h = hashlib.sha256()
+    h.update(failure_class.encode("utf-8"))
+    h.update(b"\x1f")
+    h.update(target_path.encode("utf-8"))
+    h.update(b"\x1f")
+    h.update(message_digest.encode("utf-8"))
+    return "bug_" + h.hexdigest()[:12]
+
+
+# ---------------------------------------------------------------------------
+# Classification rules
+# ---------------------------------------------------------------------------
+
+
+def _classify_target_to_scope(
+    target_path_category: str,
+    *,
+    failure_class: str,
+    authority_decision: str,
+) -> tuple[str, bool, str]:
+    """Map (target_path_category, authority_decision) to
+    (bugfix_scope, human_needed, human_needed_reason)."""
+    if target_path_category == "frozen_contract":
+        return ("frozen_contract", True, "frozen_contract_change")
+    if target_path_category == "live_path":
+        return ("live_path", True, "capital_or_live_execution_related")
+    if target_path_category in {
+        "claude_governance_hook",
+        "dashboard_wiring",
+        "canonical_policy_doc",
+        "canonical_roadmap",
+        "branch_protection_config",
+        "deploy_script",
+    }:
+        return ("protected_path", True, "protected_governance_change")
+    if target_path_category == "ci_workflow":
+        return ("ci_only", True, "protected_governance_change")
+    if authority_decision == ea.DECISION_PERMANENTLY_DENIED:
+        return ("protected_path", True, "protected_governance_change")
+    if authority_decision == ea.DECISION_NEEDS_HUMAN:
+        return ("requires_architecture_review", True, "ambiguous_scope")
+    if target_path_category == "other":
+        return ("requires_architecture_review", True, "ambiguous_scope")
+    if failure_class == "frozen_hash":
+        return ("frozen_contract", True, "frozen_contract_change")
+    if failure_class == "ci_workflow":
+        return ("ci_only", True, "protected_governance_change")
+    return ("bounded_in_repo", False, "none")
+
+
+def _safe_acceptance_template(failure_class: str) -> list[str]:
+    return list(ACCEPTANCE_TEMPLATES.get(failure_class, ACCEPTANCE_TEMPLATES["unknown"]))
+
+
+def _suggested_status_for(human_needed: bool, repeat_count: int) -> str:
+    if human_needed or repeat_count >= REPEATED_FAILURE_THRESHOLD:
+        return "human_needed"
+    return "proposed"
+
+
+# ---------------------------------------------------------------------------
+# Failure parsing
+# ---------------------------------------------------------------------------
+
+
+def _parse_failure(
+    raw: Any, *, line_index: int
+) -> tuple[dict[str, Any] | None, list[str]]:
+    """Project a raw failure record onto the closed schema.
+
+    Returns ``(candidate, warnings)``. Invalid records are dropped
+    with a warning, never raised."""
+    warnings: list[str] = []
+    if not isinstance(raw, dict):
+        warnings.append(f"failure_{line_index}_not_an_object")
+        return None, warnings
+
+    fc = raw.get("failure_class")
+    if fc not in FAILURE_CLASSES:
+        warnings.append(f"failure_{line_index}_invalid_failure_class")
+        return None, warnings
+
+    target_raw = raw.get("target_path")
+    if not isinstance(target_raw, str) or not target_raw.strip():
+        target_path = ""
+    else:
+        target_path = _normalize_path(_bounded_str(target_raw, MAX_PATH_LEN))
+
+    message_digest = _bounded_str(raw.get("message_digest"), 64)
+    if not message_digest:
+        # Synthesize a deterministic placeholder digest so identical
+        # input produces identical candidate_id even when the operator
+        # does not pre-hash.
+        h = hashlib.sha256()
+        h.update(_bounded_str(raw.get("detail"), MAX_DETAIL_LEN).encode("utf-8"))
+        message_digest = h.hexdigest()[:24]
+
+    severity_raw = raw.get("severity")
+    if isinstance(severity_raw, str) and severity_raw in INPUT_SEVERITIES:
+        severity = severity_raw
+    else:
+        severity = "unknown"
+
+    repeat_count = _coerce_count(raw.get("occurrence_count"))
+
+    first_seen = _bounded_str(raw.get("first_seen_utc"), 32)
+    last_seen = _bounded_str(raw.get("last_seen_utc"), 32)
+
+    detail = _bounded_str(raw.get("detail"), MAX_DETAIL_LEN)
+
+    # Authority classification — never reads the file at target_path.
+    decision = ea.classify(
+        action_type="file_edit",
+        target_path=target_path or None,
+        risk_class=ea.RISK_UNKNOWN if severity == "unknown" else _severity_to_risk(severity),
+    )
+    target_path_category = decision.target_path_category
+
+    bugfix_scope, human_needed, human_reason = _classify_target_to_scope(
+        target_path_category,
+        failure_class=fc,
+        authority_decision=decision.decision,
+    )
+
+    # Repeated-failure escalation may flip a non-human-needed
+    # candidate to human_needed.
+    if not human_needed and repeat_count >= REPEATED_FAILURE_THRESHOLD:
+        human_needed = True
+        human_reason = "repeated_validation_failure"
+
+    suggested_status = _suggested_status_for(human_needed, repeat_count)
+
+    candidate_id = _deterministic_candidate_id(fc, target_path, message_digest)
+
+    candidate: dict[str, Any] = {
+        "candidate_id": candidate_id,
+        "failure_class": fc,
+        "target_path": target_path,
+        "target_path_category": target_path_category,
+        "bugfix_scope": bugfix_scope,
+        "suggested_status": suggested_status,
+        "suggested_required_agent_role": ROLE_BY_FAILURE_CLASS[fc],
+        "suggested_category": CATEGORY_BY_FAILURE_CLASS[fc],
+        "human_needed": human_needed,
+        "human_needed_reason": human_reason,
+        "execution_authority_decision": decision.decision,
+        "execution_authority_reason": decision.reason,
+        "repeat_count": repeat_count,
+        "first_seen_utc": first_seen,
+        "last_seen_utc": last_seen,
+        "severity": severity,
+        "acceptance_criteria_template": _safe_acceptance_template(fc),
+        "notes": detail,
+        "created_at_placeholder": ITEM_TIME_PLACEHOLDER,
+        "updated_at_placeholder": ITEM_TIME_PLACEHOLDER,
+    }
+    return candidate, warnings
+
+
+def _severity_to_risk(severity: str) -> str:
+    if severity == "low":
+        return ea.RISK_LOW
+    if severity == "medium":
+        return ea.RISK_MEDIUM
+    if severity == "high":
+        return ea.RISK_HIGH
+    return ea.RISK_UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# Snapshot assembly
+# ---------------------------------------------------------------------------
+
+
+def _empty_counts() -> dict[str, Any]:
+    return {
+        "total": 0,
+        "by_failure_class": {fc: 0 for fc in FAILURE_CLASSES},
+        "by_bugfix_scope": {s: 0 for s in BUGFIX_SCOPES},
+        "by_suggested_status": {s: 0 for s in SUGGESTED_STATUSES},
+        "human_needed": 0,
+        "repeated_failure": 0,
+        "out_of_scope": 0,
+        "ready_for_operator_promotion": 0,
+        "requiring_human_operator": 0,
+    }
+
+
+def _aggregate_counts(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    counts = _empty_counts()
+    counts["total"] = len(rows)
+    for row in rows:
+        counts["by_failure_class"][row["failure_class"]] += 1
+        counts["by_bugfix_scope"][row["bugfix_scope"]] += 1
+        counts["by_suggested_status"][row["suggested_status"]] += 1
+        if row["human_needed"]:
+            counts["human_needed"] += 1
+            counts["requiring_human_operator"] += 1
+        else:
+            counts["ready_for_operator_promotion"] += 1
+        if row["repeat_count"] >= REPEATED_FAILURE_THRESHOLD:
+            counts["repeated_failure"] += 1
+        if row["bugfix_scope"] == "out_of_scope":
+            counts["out_of_scope"] += 1
+    return counts
+
+
+def collect_snapshot(
+    *,
+    failure_input_path: Path | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    """Build the deterministic bugfix-loop snapshot from the failure
+    summary contract."""
+    fp = failure_input_path if failure_input_path is not None else DEFAULT_INPUT_PATH
+    ts = generated_at_utc if generated_at_utc is not None else _utcnow()
+
+    payload = _read_json(fp)
+    input_present = payload is not None
+
+    rows: list[dict[str, Any]] = []
+    warnings: list[str] = []
+
+    if input_present:
+        raw_failures = (payload or {}).get("failures")
+        if not isinstance(raw_failures, list):
+            warnings.append("input_failures_not_a_list")
+            raw_failures = []
+        if len(raw_failures) > MAX_FAILURES:
+            warnings.append(f"input_failures_truncated_at_{MAX_FAILURES}")
+            raw_failures = raw_failures[:MAX_FAILURES]
+        for idx, raw in enumerate(raw_failures, start=1):
+            cand, warns = _parse_failure(raw, line_index=idx)
+            warnings.extend(warns)
+            if cand is not None:
+                rows.append(cand)
+
+    # Collapse duplicates by candidate_id; keep the row with the
+    # highest repeat_count.
+    by_id: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        cid = row["candidate_id"]
+        if cid in by_id:
+            existing = by_id[cid]
+            if row["repeat_count"] > existing["repeat_count"]:
+                by_id[cid] = row
+        else:
+            by_id[cid] = row
+    rows = list(by_id.values())
+
+    rows.sort(key=lambda r: r["candidate_id"])
+
+    if not input_present:
+        note = NOTE_INPUT_ABSENT
+    elif not rows:
+        note = NOTE_INPUT_EMPTY
+    else:
+        note = NOTE_CANDIDATES_PRESENT
+
+    counts = _aggregate_counts(rows)
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "report_kind": "development_bugfix_loop",
+        "generated_at_utc": ts,
+        "failure_input_path": str(fp),
+        "failure_input_present": input_present,
+        "note": note,
+        "validation_warnings": warnings,
+        "vocabularies": {
+            "failure_classes": list(FAILURE_CLASSES),
+            "bugfix_scopes": list(BUGFIX_SCOPES),
+            "suggested_statuses": list(SUGGESTED_STATUSES),
+            "input_severities": list(INPUT_SEVERITIES),
+            "agent_roles": list(dwq.AGENT_ROLES),
+            "categories": list(dwq.CATEGORIES),
+            "human_needed_reasons": list(dwq.HUMAN_NEEDED_REASONS),
+            "risk_levels": list(ea.RISK_CLASSES),
+        },
+        "counts": counts,
+        "candidates": rows,
+        "execution_authority_module_version": ea.MODULE_VERSION,
+        "queue_module_version": dwq.MODULE_VERSION,
+        "discipline_invariants": {
+            "writes_to_seed_jsonl": False,
+            "writes_to_bugfix_seed_jsonl": False,
+            "auto_creates_branches": False,
+            "auto_opens_prs": False,
+            "auto_modifies_code": False,
+            "operator_promotion_required": True,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Atomic write
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    posix = path.as_posix()
+    if "/logs/" not in posix and not posix.startswith("logs/"):
+        raise ValueError(
+            "development_bugfix_loop._atomic_write_json refuses "
+            f"non-logs/ output path: {path}"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".development_bugfix_loop.", suffix=".tmp", dir=str(path.parent)
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_outputs(snapshot: dict[str, Any]) -> Path:
+    _atomic_write_json(ARTIFACT_LATEST, snapshot)
+    return ARTIFACT_LATEST
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m reporting.development_bugfix_loop",
+        description=(
+            "Read-only intake module for routine failure summaries. "
+            "Emits bugfix-candidate proposals to "
+            "logs/development_bugfix_loop/latest.json. Mutates "
+            "nothing; never writes to seed.jsonl or bugfix_seed.jsonl. "
+            "Operator promotion is a separate manual action."
+        ),
+    )
+    p.add_argument("--indent", type=int, default=2, help="JSON indent (0 for compact).")
+    p.add_argument(
+        "--no-write",
+        action="store_true",
+        help=(
+            "Do not persist logs/development_bugfix_loop/latest.json "
+            "(stdout only)."
+        ),
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    indent = args.indent if args.indent and args.indent > 0 else None
+    snap = collect_snapshot()
+    if not args.no_write:
+        write_outputs(snap)
+    json.dump(snap, sys.stdout, indent=indent, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/unit/test_development_bugfix_loop.py
+++ b/tests/unit/test_development_bugfix_loop.py
@@ -1,0 +1,681 @@
+"""Unit tests for A10 — Agentic Bugfix Loop.
+
+Synthetic deterministic fixtures only. The pure intake module reads
+a structured failure-summary contract and emits bugfix-candidate
+proposals to ``logs/development_bugfix_loop/latest.json``. The
+module never writes to ``seed.jsonl`` or ``bugfix_seed.jsonl``;
+operator promotion is a separate manual action.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reporting import development_bugfix_loop as dbl
+from reporting import development_work_queue as dwq
+from reporting import execution_authority as ea
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _input_path(tmp_path: Path) -> Path:
+    return tmp_path / "failures.json"
+
+
+def _failure(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "failure_class": "unit_test",
+        "target_path": "reporting/foo.py",
+        "message_digest": "abc123",
+        "severity": "low",
+        "occurrence_count": 1,
+        "first_seen_utc": "2026-05-07T00:00:00Z",
+        "last_seen_utc": "2026-05-07T00:00:00Z",
+        "detail": "AssertionError: 1 != 2",
+    }
+    base.update(overrides)
+    return base
+
+
+def _write_input(tmp_path: Path, failures: list[dict[str, Any]]) -> Path:
+    p = _input_path(tmp_path)
+    p.write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0",
+                "generated_at_utc": "2026-05-07T00:00:00Z",
+                "failures": failures,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Vocabulary integrity
+# ---------------------------------------------------------------------------
+
+
+def test_failure_classes_vocabulary_is_closed_and_ordered() -> None:
+    assert dbl.FAILURE_CLASSES == (
+        "unit_test",
+        "smoke_test",
+        "regression_test",
+        "lint",
+        "typecheck",
+        "governance_lint",
+        "frozen_hash",
+        "hook",
+        "ci_workflow",
+        "unknown",
+    )
+    assert len(dbl.FAILURE_CLASSES) == 10
+
+
+def test_bugfix_scopes_vocabulary_is_closed_and_ordered() -> None:
+    assert dbl.BUGFIX_SCOPES == (
+        "bounded_in_repo",
+        "protected_path",
+        "live_path",
+        "frozen_contract",
+        "ci_only",
+        "requires_architecture_review",
+        "out_of_scope",
+    )
+    assert len(dbl.BUGFIX_SCOPES) == 7
+
+
+def test_input_severities_vocabulary_is_closed() -> None:
+    assert dbl.INPUT_SEVERITIES == ("low", "medium", "high", "unknown")
+
+
+def test_suggested_statuses_subset_of_a8_kanban() -> None:
+    assert set(dbl.SUGGESTED_STATUSES).issubset(set(dwq.STATUSES))
+
+
+def test_role_and_category_maps_cover_all_failure_classes() -> None:
+    assert set(dbl.ROLE_BY_FAILURE_CLASS) == set(dbl.FAILURE_CLASSES)
+    assert set(dbl.CATEGORY_BY_FAILURE_CLASS) == set(dbl.FAILURE_CLASSES)
+    for v in dbl.ROLE_BY_FAILURE_CLASS.values():
+        assert v in dwq.AGENT_ROLES
+    for v in dbl.CATEGORY_BY_FAILURE_CLASS.values():
+        assert v in dwq.CATEGORIES
+
+
+def test_acceptance_templates_cover_all_failure_classes() -> None:
+    assert set(dbl.ACCEPTANCE_TEMPLATES) == set(dbl.FAILURE_CLASSES)
+
+
+def test_candidate_schema_keys_are_exact_and_ordered() -> None:
+    assert dbl.CANDIDATE_SCHEMA_KEYS == (
+        "candidate_id",
+        "failure_class",
+        "target_path",
+        "target_path_category",
+        "bugfix_scope",
+        "suggested_status",
+        "suggested_required_agent_role",
+        "suggested_category",
+        "human_needed",
+        "human_needed_reason",
+        "execution_authority_decision",
+        "execution_authority_reason",
+        "repeat_count",
+        "first_seen_utc",
+        "last_seen_utc",
+        "severity",
+        "acceptance_criteria_template",
+        "notes",
+        "created_at_placeholder",
+        "updated_at_placeholder",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test-weakening discipline (pinned)
+# ---------------------------------------------------------------------------
+
+
+def test_acceptance_templates_never_contain_test_weakening_tokens() -> None:
+    """No safe template may contain skip/xfail/pin removal/weaken/
+    relax/disable. This is the core test-weakening invariant."""
+    for fc, templates in dbl.ACCEPTANCE_TEMPLATES.items():
+        for line in templates:
+            lowered = line.lower()
+            for forbidden in dbl.FORBIDDEN_ACCEPTANCE_TOKENS:
+                assert forbidden not in lowered, (
+                    f"failure_class={fc!r}: template contains "
+                    f"forbidden token {forbidden!r}: {line!r}"
+                )
+
+
+def test_forbidden_acceptance_tokens_set_is_meaningful() -> None:
+    assert "skip" in dbl.FORBIDDEN_ACCEPTANCE_TOKENS
+    assert "xfail" in dbl.FORBIDDEN_ACCEPTANCE_TOKENS
+    assert "remove pin" in dbl.FORBIDDEN_ACCEPTANCE_TOKENS
+    assert "weaken" in dbl.FORBIDDEN_ACCEPTANCE_TOKENS
+
+
+# ---------------------------------------------------------------------------
+# Artifact path discipline
+# ---------------------------------------------------------------------------
+
+
+def test_artifact_path_is_under_logs_not_research() -> None:
+    assert dbl.ARTIFACT_RELATIVE_PATH.startswith("logs/")
+    assert "research/" not in dbl.ARTIFACT_RELATIVE_PATH
+
+
+def test_atomic_write_refuses_non_logs_path(tmp_path: Path) -> None:
+    bad = tmp_path / "evil_dir" / "latest.json"
+    with pytest.raises(ValueError):
+        dbl._atomic_write_json(bad, {"x": 1})
+
+
+def test_atomic_write_refuses_seed_jsonl_paths(tmp_path: Path) -> None:
+    """The bugfix loop must never write to either seed.jsonl or
+    bugfix_seed.jsonl, even by mistake. The atomic write enforces a
+    logs/-only whitelist; these paths fall outside logs/."""
+    seed = tmp_path / "docs" / "development_work_queue" / "seed.jsonl"
+    bugfix_seed = tmp_path / "docs" / "development_work_queue" / "bugfix_seed.jsonl"
+    with pytest.raises(ValueError):
+        dbl._atomic_write_json(seed, {"x": 1})
+    with pytest.raises(ValueError):
+        dbl._atomic_write_json(bugfix_seed, {"x": 1})
+
+
+# ---------------------------------------------------------------------------
+# Snapshot top-level shape
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_top_level_keys(tmp_path: Path) -> None:
+    fp = _write_input(tmp_path, [_failure()])
+    snap = dbl.collect_snapshot(
+        failure_input_path=fp, generated_at_utc="2026-05-07T00:00:00Z"
+    )
+    expected = {
+        "schema_version",
+        "module_version",
+        "report_kind",
+        "generated_at_utc",
+        "failure_input_path",
+        "failure_input_present",
+        "note",
+        "validation_warnings",
+        "vocabularies",
+        "counts",
+        "candidates",
+        "execution_authority_module_version",
+        "queue_module_version",
+        "discipline_invariants",
+    }
+    assert set(snap.keys()) == expected
+    assert snap["report_kind"] == "development_bugfix_loop"
+    assert snap["failure_input_present"] is True
+
+
+def test_input_absent_yields_empty_snapshot(tmp_path: Path) -> None:
+    fp = tmp_path / "missing.json"
+    snap = dbl.collect_snapshot(failure_input_path=fp)
+    assert snap["failure_input_present"] is False
+    assert snap["note"] == dbl.NOTE_INPUT_ABSENT
+    assert snap["candidates"] == []
+
+
+def test_empty_failures_list_yields_input_empty_note(tmp_path: Path) -> None:
+    fp = _write_input(tmp_path, [])
+    snap = dbl.collect_snapshot(failure_input_path=fp)
+    assert snap["failure_input_present"] is True
+    assert snap["note"] == dbl.NOTE_INPUT_EMPTY
+    assert snap["candidates"] == []
+
+
+def test_discipline_invariants_block_is_present(tmp_path: Path) -> None:
+    """The wrapper carries an explicit discipline-invariants block so
+    operators can audit at a glance that the module did not violate
+    its own rules."""
+    fp = _write_input(tmp_path, [_failure()])
+    snap = dbl.collect_snapshot(failure_input_path=fp)
+    inv = snap["discipline_invariants"]
+    assert inv["writes_to_seed_jsonl"] is False
+    assert inv["writes_to_bugfix_seed_jsonl"] is False
+    assert inv["auto_creates_branches"] is False
+    assert inv["auto_opens_prs"] is False
+    assert inv["auto_modifies_code"] is False
+    assert inv["operator_promotion_required"] is True
+
+
+# ---------------------------------------------------------------------------
+# Classification — happy paths and overrides
+# ---------------------------------------------------------------------------
+
+
+def test_unit_test_failure_in_reporting_module_is_bounded_in_repo(
+    tmp_path: Path,
+) -> None:
+    fp = _write_input(tmp_path, [_failure(target_path="reporting/foo.py")])
+    snap = dbl.collect_snapshot(failure_input_path=fp)
+    cand = snap["candidates"][0]
+    assert cand["failure_class"] == "unit_test"
+    assert cand["target_path_category"] == "reporting_module"
+    assert cand["bugfix_scope"] == "bounded_in_repo"
+    assert cand["human_needed"] is False
+    assert cand["suggested_status"] == "proposed"
+    assert cand["suggested_required_agent_role"] == "test_agent"
+    assert cand["suggested_category"] == "test"
+
+
+def test_frozen_contract_failure_always_human_needed(tmp_path: Path) -> None:
+    fp = _write_input(
+        tmp_path,
+        [
+            _failure(
+                failure_class="frozen_hash",
+                target_path="research/research_latest.json",
+            )
+        ],
+    )
+    snap = dbl.collect_snapshot(failure_input_path=fp)
+    cand = snap["candidates"][0]
+    assert cand["bugfix_scope"] == "frozen_contract"
+    assert cand["human_needed"] is True
+    assert cand["human_needed_reason"] == "frozen_contract_change"
+
+
+def test_live_path_failure_always_human_needed(tmp_path: Path) -> None:
+    fp = _write_input(
+        tmp_path,
+        [_failure(failure_class="lint", target_path="broker/whatever.py")],
+    )
+    snap = dbl.collect_snapshot(failure_input_path=fp)
+    cand = snap["candidates"][0]
+    assert cand["bugfix_scope"] == "live_path"
+    assert cand["human_needed"] is True
+    assert cand["human_needed_reason"] == "capital_or_live_execution_related"
+
+
+def test_canonical_policy_doc_failure_is_protected_path(tmp_path: Path) -> None:
+    fp = _write_input(
+        tmp_path,
+        [
+            _failure(
+                failure_class="governance_lint",
+                target_path="docs/governance/execution_authority.md",
+            )
+        ],
+    )
+    snap = dbl.collect_snapshot(failure_input_path=fp)
+    cand = snap["candidates"][0]
+    assert cand["bugfix_scope"] == "protected_path"
+    assert cand["human_needed"] is True
+    assert cand["human_needed_reason"] == "protected_governance_change"
+
+
+def test_claude_governance_hook_failure_is_protected_path(tmp_path: Path) -> None:
+    fp = _write_input(
+        tmp_path,
+        [_failure(failure_class="hook", target_path=".claude/hooks/foo.py")],
+    )
+    snap = dbl.collect_snapshot(failure_input_path=fp)
+    cand = snap["candidates"][0]
+    assert cand["bugfix_scope"] == "protected_path"
+    assert cand["human_needed"] is True
+
+
+def test_ci_workflow_failure_is_ci_only_human_needed(tmp_path: Path) -> None:
+    fp = _write_input(
+        tmp_path,
+        [
+            _failure(
+                failure_class="ci_workflow",
+                target_path=".github/workflows/tests.yml",
+            )
+        ],
+    )
+    snap = dbl.collect_snapshot(failure_input_path=fp)
+    cand = snap["candidates"][0]
+    assert cand["bugfix_scope"] == "ci_only"
+    assert cand["human_needed"] is True
+    assert cand["suggested_required_agent_role"] == "ci_guardian"
+
+
+def test_other_target_falls_back_to_requires_architecture_review(
+    tmp_path: Path,
+) -> None:
+    fp = _write_input(
+        tmp_path,
+        [_failure(target_path="some/random/script.py")],
+    )
+    snap = dbl.collect_snapshot(failure_input_path=fp)
+    cand = snap["candidates"][0]
+    assert cand["target_path_category"] == "other"
+    assert cand["bugfix_scope"] == "requires_architecture_review"
+    assert cand["human_needed"] is True
+    assert cand["human_needed_reason"] == "ambiguous_scope"
+
+
+# ---------------------------------------------------------------------------
+# Repeated failure escalation
+# ---------------------------------------------------------------------------
+
+
+def test_repeated_failure_escalates_to_human_needed(tmp_path: Path) -> None:
+    fp = _write_input(
+        tmp_path,
+        [
+            _failure(
+                target_path="reporting/foo.py",
+                occurrence_count=dbl.REPEATED_FAILURE_THRESHOLD,
+            )
+        ],
+    )
+    snap = dbl.collect_snapshot(failure_input_path=fp)
+    cand = snap["candidates"][0]
+    assert cand["human_needed"] is True
+    assert cand["human_needed_reason"] == "repeated_validation_failure"
+    assert cand["repeat_count"] == dbl.REPEATED_FAILURE_THRESHOLD
+    assert cand["suggested_status"] == "human_needed"
+
+
+def test_below_threshold_repeat_count_does_not_escalate(tmp_path: Path) -> None:
+    fp = _write_input(
+        tmp_path,
+        [
+            _failure(
+                target_path="reporting/foo.py",
+                occurrence_count=dbl.REPEATED_FAILURE_THRESHOLD - 1,
+            )
+        ],
+    )
+    snap = dbl.collect_snapshot(failure_input_path=fp)
+    cand = snap["candidates"][0]
+    assert cand["human_needed"] is False
+    assert cand["suggested_status"] == "proposed"
+
+
+# ---------------------------------------------------------------------------
+# Invalid input handling
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_failure_class_is_dropped_with_warning(tmp_path: Path) -> None:
+    fp = _write_input(tmp_path, [_failure(failure_class="not_a_class")])
+    snap = dbl.collect_snapshot(failure_input_path=fp)
+    assert snap["candidates"] == []
+    assert any("invalid_failure_class" in w for w in snap["validation_warnings"])
+
+
+def test_failure_record_not_an_object_is_dropped(tmp_path: Path) -> None:
+    fp = _input_path(tmp_path)
+    fp.write_text(
+        json.dumps({"schema_version": "1.0", "failures": ["not-an-object"]}),
+        encoding="utf-8",
+    )
+    snap = dbl.collect_snapshot(failure_input_path=fp)
+    assert snap["candidates"] == []
+    assert any("not_an_object" in w for w in snap["validation_warnings"])
+
+
+def test_failures_not_a_list_emits_warning(tmp_path: Path) -> None:
+    fp = _input_path(tmp_path)
+    fp.write_text(
+        json.dumps({"schema_version": "1.0", "failures": "oops"}),
+        encoding="utf-8",
+    )
+    snap = dbl.collect_snapshot(failure_input_path=fp)
+    assert snap["candidates"] == []
+    assert any(
+        "input_failures_not_a_list" in w for w in snap["validation_warnings"]
+    )
+
+
+def test_unknown_severity_coerces_to_unknown(tmp_path: Path) -> None:
+    fp = _write_input(tmp_path, [_failure(severity="critical")])
+    snap = dbl.collect_snapshot(failure_input_path=fp)
+    assert snap["candidates"][0]["severity"] == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+def test_candidate_id_is_deterministic_for_same_failure(tmp_path: Path) -> None:
+    fp = _write_input(tmp_path, [_failure()])
+    snap_a = dbl.collect_snapshot(
+        failure_input_path=fp, generated_at_utc="2026-05-07T00:00:00Z"
+    )
+    snap_b = dbl.collect_snapshot(
+        failure_input_path=fp, generated_at_utc="2026-05-07T00:00:00Z"
+    )
+    assert snap_a["candidates"][0]["candidate_id"] == snap_b["candidates"][0]["candidate_id"]
+    assert snap_a["candidates"][0]["candidate_id"].startswith("bug_")
+
+
+def test_artifact_bytes_are_deterministic_with_injected_timestamp(
+    tmp_path: Path,
+) -> None:
+    fp = _write_input(tmp_path, [_failure(), _failure(message_digest="def456")])
+    snap_a = dbl.collect_snapshot(
+        failure_input_path=fp, generated_at_utc="2026-05-07T00:00:00Z"
+    )
+    snap_b = dbl.collect_snapshot(
+        failure_input_path=fp, generated_at_utc="2026-05-07T00:00:00Z"
+    )
+    assert json.dumps(snap_a, sort_keys=True, indent=2).encode("utf-8") == json.dumps(
+        snap_b, sort_keys=True, indent=2
+    ).encode("utf-8")
+
+
+def test_duplicate_candidates_collapse_keeping_max_repeat_count(
+    tmp_path: Path,
+) -> None:
+    """Same failure_class + target_path + message_digest yields the
+    same candidate_id; the loop collapses duplicates and keeps the
+    higher repeat_count."""
+    fp = _write_input(
+        tmp_path,
+        [
+            _failure(occurrence_count=2),
+            _failure(occurrence_count=5),
+        ],
+    )
+    snap = dbl.collect_snapshot(failure_input_path=fp)
+    assert len(snap["candidates"]) == 1
+    assert snap["candidates"][0]["repeat_count"] == 5
+
+
+# ---------------------------------------------------------------------------
+# Counts
+# ---------------------------------------------------------------------------
+
+
+def test_counts_aggregate_and_close_vocabularies(tmp_path: Path) -> None:
+    fp = _write_input(
+        tmp_path,
+        [
+            _failure(target_path="reporting/foo.py", message_digest="a"),
+            _failure(
+                failure_class="frozen_hash",
+                target_path="research/strategy_matrix.csv",
+                message_digest="b",
+            ),
+            _failure(
+                failure_class="ci_workflow",
+                target_path=".github/workflows/tests.yml",
+                message_digest="c",
+            ),
+            _failure(
+                target_path="reporting/bar.py",
+                message_digest="d",
+                occurrence_count=10,
+            ),
+        ],
+    )
+    snap = dbl.collect_snapshot(failure_input_path=fp)
+    counts = snap["counts"]
+    assert counts["total"] == 4
+    assert sum(counts["by_failure_class"].values()) == 4
+    assert sum(counts["by_bugfix_scope"].values()) == 4
+    assert sum(counts["by_suggested_status"].values()) == 4
+    assert counts["human_needed"] >= 3
+    assert counts["repeated_failure"] >= 1
+    assert counts["ready_for_operator_promotion"] + counts["requiring_human_operator"] == 4
+    assert set(counts["by_failure_class"]) == set(dbl.FAILURE_CLASSES)
+    assert set(counts["by_bugfix_scope"]) == set(dbl.BUGFIX_SCOPES)
+
+
+# ---------------------------------------------------------------------------
+# Candidate sorting
+# ---------------------------------------------------------------------------
+
+
+def test_candidates_sort_deterministically(tmp_path: Path) -> None:
+    fp = _write_input(
+        tmp_path,
+        [
+            _failure(message_digest="zzz"),
+            _failure(message_digest="aaa"),
+        ],
+    )
+    snap = dbl.collect_snapshot(failure_input_path=fp)
+    ids = [c["candidate_id"] for c in snap["candidates"]]
+    assert ids == sorted(ids)
+
+
+# ---------------------------------------------------------------------------
+# Source-text scans (no subprocess / no network / no forbidden imports)
+# ---------------------------------------------------------------------------
+
+
+def _module_source() -> str:
+    return Path(dbl.__file__).read_text(encoding="utf-8")
+
+
+def _imported_module_names() -> set[str]:
+    import ast
+
+    src = _module_source()
+    tree = ast.parse(src)
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module is not None:
+                names.add(node.module)
+    return names
+
+
+def test_no_subprocess_in_module() -> None:
+    src = _module_source()
+    assert "import subprocess" not in src
+    assert "from subprocess" not in src
+
+
+def test_no_network_in_module() -> None:
+    src = _module_source()
+    for forbidden in (
+        "import socket",
+        "import urllib",
+        "import http.client",
+        "import requests",
+    ):
+        assert forbidden not in src
+    assert "from socket" not in src
+    assert "from urllib" not in src
+    assert "from http" not in src
+    assert "from requests" not in src
+
+
+def test_no_test_runner_imports_in_module() -> None:
+    """A10 must not import pytest or other test runners — it consumes
+    structured failure summaries, never runs tests itself."""
+    forbidden_modules = ("pytest", "_pytest", "unittest")
+    for module in _imported_module_names():
+        assert module.split(".")[0] not in forbidden_modules, module
+
+
+def test_no_dashboard_or_live_path_or_qre_imports() -> None:
+    forbidden_prefixes = (
+        "dashboard",
+        "automation",
+        "broker",
+        "agent.risk",
+        "agent.execution",
+        "research",
+        "reporting.intelligent_routing",
+    )
+    for module in _imported_module_names():
+        for prefix in forbidden_prefixes:
+            assert not (module == prefix or module.startswith(prefix + ".")), (
+                f"forbidden import: {module}"
+            )
+
+
+def test_no_gh_or_git_subprocess_references() -> None:
+    src = _module_source()
+    for forbidden in (
+        "subprocess.run",
+        "subprocess.Popen",
+        "os.system",
+        "os.popen",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_module_imports_cleanly() -> None:
+    importlib.reload(dbl)
+    assert callable(dbl.collect_snapshot)
+
+
+# ---------------------------------------------------------------------------
+# Schema-version + module-version surfaces
+# ---------------------------------------------------------------------------
+
+
+def test_schema_and_module_version_strings() -> None:
+    assert isinstance(dbl.SCHEMA_VERSION, str) and dbl.SCHEMA_VERSION
+    assert isinstance(dbl.MODULE_VERSION, str) and dbl.MODULE_VERSION
+    assert "A10" in dbl.MODULE_VERSION
+
+
+# ---------------------------------------------------------------------------
+# Cross-module sanity: A10 vocabularies do not overlap A8 vocabularies
+# in incompatible ways
+# ---------------------------------------------------------------------------
+
+
+def test_human_needed_reasons_used_are_subset_of_a8(tmp_path: Path) -> None:
+    """Every reason A10 emits must be in the A8 closed vocabulary."""
+    fp = _write_input(
+        tmp_path,
+        [
+            _failure(failure_class="frozen_hash", target_path="research/research_latest.json"),
+            _failure(failure_class="lint", target_path="broker/x.py", message_digest="b"),
+            _failure(failure_class="governance_lint", target_path="docs/governance/execution_authority.md", message_digest="c"),
+            _failure(failure_class="lint", target_path="other/x.py", message_digest="d"),
+            _failure(target_path="reporting/foo.py", occurrence_count=5, message_digest="e"),
+        ],
+    )
+    snap = dbl.collect_snapshot(failure_input_path=fp)
+    for c in snap["candidates"]:
+        assert c["human_needed_reason"] in dwq.HUMAN_NEEDED_REASONS
+
+
+def test_execution_authority_decision_is_classifier_value(tmp_path: Path) -> None:
+    fp = _write_input(tmp_path, [_failure()])
+    snap = dbl.collect_snapshot(failure_input_path=fp)
+    decisions = {c["execution_authority_decision"] for c in snap["candidates"]}
+    assert decisions.issubset(set(ea.DECISIONS))


### PR DESCRIPTION
## Summary

Convert structured routine failures into bounded bugfix-candidate proposals so the operator can decide what to promote into the development work queue. A10 is **intake / proposal only**.

**Status: PR-ready, NOT Complete.**

## Scope

**Added (read-only / additive):**
- `reporting/development_bugfix_loop.py` — pure intake module.
  - 10 closed `FAILURE_CLASSES`, 7 closed `BUGFIX_SCOPES`, 4 closed `INPUT_SEVERITIES`, 2 closed `SUGGESTED_STATUSES`.
  - Per-candidate schema with deterministic `candidate_id = sha256(failure_class || target_path || message_digest)`.
  - Closed authority/scope routing: `frozen_contract` / `live_path` / `canonical_policy_doc` / `canonical_roadmap` / `claude_governance_hook` / `dashboard_wiring` / `branch_protection_config` / `deploy_script` / `ci_workflow` always escalate to `human_needed`.
  - Repeated-failure escalation: `repeat_count ≥ 3` ⇒ `human_needed / repeated_validation_failure`.
  - Test-weakening discipline: closed safe-template set per failure class; `tests/unit/test_development_bugfix_loop.py::test_acceptance_templates_never_contain_test_weakening_tokens` pins the absence of `skip` / `xfail` / `remove pin` / `weaken` / `relax` / `disable`.
  - Atomic write only under `logs/development_bugfix_loop/latest.json`; the guard explicitly refuses any `seed.jsonl` / `bugfix_seed.jsonl` path because both lie outside `logs/`.
  - Wrapper carries an explicit `discipline_invariants` block so operators can audit at a glance.
- `tests/unit/test_development_bugfix_loop.py` — 43 tests.
- `docs/governance/development_bugfix_loop.md` — governance doc.

**Modified:**
- `docs/roadmap/autonomous_development.txt` — append §A10 block with `Status: PR-ready (NOT complete)`.

**Untouched:** `research/**`, frozen contracts, Intelligent Routing modules, scoring, `.claude/**`, `dashboard/dashboard.py`, all live/paper/shadow/risk/trading/broker/execution paths, all CI workflows.

## Discipline invariants (load-bearing)

```
writes_to_seed_jsonl: false
writes_to_bugfix_seed_jsonl: false
auto_creates_branches: false
auto_opens_prs: false
auto_modifies_code: false
operator_promotion_required: true
```

## Architectural separation

ADE core (this PR) stays pure: stdlib + `reporting.execution_authority` + `reporting.approval_policy` + `reporting.development_work_queue`. No subprocess, no network, no `gh`, no `git`, no test runners. AST-level pin forbids imports from `pytest`, `_pytest`, `unittest`, plus the standard ADE forbidden list.

Failure collectors/adapters live outside ADE core (preferred under `scripts/`) and may invoke `pytest`/`ruff`/`mypy`/`gh` to populate `logs/bugfix_loop_input/latest.json`. ADE core consumes only that contract; ADE core never imports collectors. Operator may populate the input by hand as a transitional state.

## Validation

- `python -m pytest tests/unit/test_development_bugfix_loop.py -q` → **43 passed**.
- `python -m pytest tests/unit -q` → **3942 passed, 3 skipped**.
- `python -m pytest tests/smoke -q` → **18 passed**.
- `python scripts/governance_lint.py` → **OK**.

## Pre-merge verification

- [ ] CI green on this PR.
- [ ] No `research/**` changes.
- [ ] No Intelligent Routing behavior change.
- [ ] No frozen-contract changes.
- [ ] No `.claude/**` writes.
- [ ] §A10 reads `Status: PR-ready (NOT complete)`.

## Out of scope (deferred)

- Failure collector script(s) — separate PR after A10.
- Automatic branch / PR / commit creation — never; operator-gated.
- A11 / A12 — separate phases.
- Any QRE / IR / v3.15.17 / scoring change.
- Any live/paper/shadow/risk/trading/broker/execution change.

## Test plan

- [ ] CI green on this PR.
- [ ] After merge: post-merge gates green; flip §A10 status from `PR-ready` to `Complete` in a follow-up commit.