### PR TITLE
chore(A10): mark A10 Complete

### DIFF
--- a/docs/roadmap/autonomous_development.txt
+++ b/docs/roadmap/autonomous_development.txt
@@ -1015,10 +1015,17 @@ Step 5 — Autonomous Implementation Loop (planning may begin after A12;
 ## Status
 
 ```text
-Status: PR-ready (NOT complete)
+Status: Complete
+PR: #136
+Merge SHA: 21d9064
+CI: green
+Post-merge gates: green (governance_lint OK, smoke 18/18 passed,
+                  A10 + adjacent unit tests 238/238 passed,
+                  no research/IR/frozen/.claude/.github/workflows
+                  changes in the merge SHA)
 ```
 
-A10 is marked complete only after the PR's CI is green, the squash merge has landed on `main`, and post-merge gates pass.
+A10 is the completed agentic bugfix-loop intake foundation. A11 may now begin.
 
 ## Purpose
 


### PR DESCRIPTION
## Summary

Scope-bounded follow-up to the merged A10 PR ([#136](https://github.com/roudjy/trading-agent/pull/136), SHA `21d9064`).

Flip the §A10 Status block in `docs/roadmap/autonomous_development.txt` from `PR-ready (NOT complete)` to `Complete`, recording PR number, merge SHA, CI status, and post-merge gate results. A11 may now begin per the operator-approved phase order.

## Changes

- `docs/roadmap/autonomous_development.txt` — §A10 Status block flipped to `Complete`. No other content changed.

## Constraints upheld

- Docs-only.
- No research/IR/frozen-contract changes.
- No `.claude/**` writes, no `.github/workflows/**` writes.
- No code changes.