### PR TITLE
feat(A11): bounded roadmap implementation delegation

### DIFF
--- a/docs/governance/development_delegation.md
+++ b/docs/governance/development_delegation.md
@@ -1,0 +1,157 @@
+# Autonomous Development Delegation (A11)
+
+> Canonical governance document for the Bounded Roadmap
+> Implementation Delegation introduced in A11. Read-only, pure
+> marker parser. No fuzzy parsing.
+
+## Status
+
+Active. Modifications to this document require operator approval.
+
+## What this is — and is not
+
+A11 introduces a deterministic mechanism for turning explicit
+roadmap items into routable delegation entries:
+
+- explicit `<!-- ade_delegation ... -->` markers inside the two
+  canonical roadmap docs;
+- explicit JSONL entries inside the optional sidecar
+  `docs/development_work_queue/delegation_seed.jsonl`.
+
+A11 is **not**:
+
+- a prose / heading / bullet-list parser,
+- an NLP/LLM reasoner,
+- an auto-promotion mechanism into the development work queue,
+- a writer to `seed.jsonl` / `bugfix_seed.jsonl` /
+  `delegation_seed.jsonl`.
+
+`reporting.development_delegation` produces only
+`logs/development_delegation/latest.json`. Promotion of any entry
+into the queue's `seed.jsonl` is a separate manual operator
+action — same discipline as A10.
+
+## Marker syntax (canonical roadmap docs)
+
+```
+<!-- ade_delegation
+delegation_id: <opaque-stable-id, [A-Za-z0-9_.-]+>
+title: <≤200 chars>
+category: <one of A8 CATEGORIES>
+required_agent_role: <one of A8 AGENT_ROLES>
+risk_level: <LOW | MEDIUM | HIGH | UNKNOWN>
+acceptance_criteria:
+  - <≤200 chars>
+  - <…>
+human_needed: <true | false>
+human_needed_reason: <closed reason; "none" iff human_needed=false>
+-->
+```
+
+Rules:
+
+- Markers are HTML comments — invisible to readers.
+- Each marker is **one** delegation entry.
+- Every required field must be present and pass the closed-vocab
+  check; otherwise the marker is dropped with a `validation_warning`.
+- `delegation_id` must match `^[A-Za-z0-9_.-]+$` and be unique
+  across all sources.
+- The grammar is intentionally minimal: scalar `key: value` lines
+  plus an `acceptance_criteria:` list of indented `- value` lines.
+- Anything that does not parse cleanly under this grammar is
+  rejected — no fuzzy fallback.
+
+Use markers **sparingly**. Canonical roadmap docs must remain
+human-readable. Markers are appropriate for high-level approved
+delegation anchors — the precise textual unit of work the operator
+wants the queue to track. Bulk decomposition belongs in the
+sidecar seed.
+
+## Sidecar seed (bulk decomposition, optional)
+
+```
+docs/development_work_queue/delegation_seed.jsonl
+```
+
+Strict JSONL: one JSON object per non-blank line. No `#` comments.
+Empty by default. Each entry follows the same schema as the marker
+fields. The `delegation_id` must be unique across the whole
+delegation surface.
+
+The sidecar is operator-authored. Promotion to the work queue
+remains manual.
+
+## Hard guarantees (pinned by tests)
+
+- ADE core stdlib + `reporting.execution_authority` +
+  `reporting.approval_policy` + `reporting.development_work_queue`.
+- No subprocess, no network, no `gh`, no `git`.
+- No imports from `dashboard`, `automation`, `broker`,
+  `agent.risk`, `agent.execution`, `research`,
+  `reporting.intelligent_routing` (AST-level pin).
+- Atomic write only under
+  `logs/development_delegation/latest.json`.
+- Plain markdown headings / prose / lists / bullets produce zero
+  delegation entries (load-bearing false-positive guard).
+- Roadmap paths under `docs/roadmap/archive/**` are excluded by
+  both inclusion list and a positive `archive/` substring check.
+- Non-canonical roadmap paths are excluded even when explicitly
+  passed.
+- Wrapper carries an explicit `discipline_invariants` block:
+  ```
+  writes_to_seed_jsonl: false
+  writes_to_bugfix_seed_jsonl: false
+  writes_to_delegation_seed_jsonl: false
+  fuzzy_parsing: false
+  operator_promotion_required: true
+  ```
+
+## Output: per-entry schema
+
+```
+delegation_id                     deterministic, operator-authored
+title                             bounded scalar
+source_document                   canonical roadmap path or "delegation_seed"
+source_section_or_anchor          "marker_<n>" or "line_<n>"
+roadmap_track                     autonomous_development | qre_feature_build | sidecar_seed
+category                          A8 CATEGORIES
+required_agent_role               A8 AGENT_ROLES
+supporting_agent_roles            list (empty in v0; reserved)
+execution_authority_decision      from classifier
+execution_authority_reason        from classifier
+status                            "triaged" (default; operator promotes onward)
+human_needed                      bool
+human_needed_reason               A8 HUMAN_NEEDED_REASONS
+risk_level                        from RISK_CLASSES
+protected_surface                 true if target is canonical/protected/CI/etc.
+acceptance_criteria               from marker
+validation_requirements           list (empty in v0; reserved)
+notes                             bounded scalar
+created_at_placeholder            "deterministic_seed_placeholder"
+updated_at_placeholder            "deterministic_seed_placeholder"
+```
+
+## Authority overrides
+
+- A delegation entry in the autonomous_development or qre_feature_build
+  track ⇒ classifier maps `source_document = canonical_roadmap` ⇒
+  `execution_authority_decision = NEEDS_HUMAN`. The marker itself
+  cannot be auto-allowed; operator-authored.
+- Sidecar seed entries with `source_document = delegation_seed`
+  classify under `target_path_category = other` ⇒ `NEEDS_HUMAN`
+  (fail-safe). To be auto-allowed, the operator must edit the
+  marker to point at a concrete repo path before promotion.
+- Any entry with `human_needed=true` is unambiguously
+  operator-gated.
+
+## CLI surface
+
+```
+python -m reporting.development_delegation            # writes artifact
+python -m reporting.development_delegation --no-write  # stdout only
+```
+
+## Modifying this document
+
+Standard governance discipline. Scope-bounded PR, CI green,
+post-merge gates, no `--admin` merge.

--- a/docs/roadmap/autonomous_development.txt
+++ b/docs/roadmap/autonomous_development.txt
@@ -1137,3 +1137,116 @@ repeat_count ≥ 3              → human_needed (repeated_validation_failure)
 
 The pure module accepts an injectable `generated_at_utc`. With the same failure-input contract and the same injected timestamp, output bytes are identical. Per-row `candidate_id` is sha256-derived from `(failure_class, target_path, message_digest)` and stable across runs.
 
+\---
+
+# A11 — Bounded Roadmap Implementation Delegation
+
+## Status
+
+```text
+Status: PR-ready (NOT complete)
+```
+
+A11 is marked complete only after the PR's CI is green, the squash merge has landed on `main`, and post-merge gates pass.
+
+## Purpose
+
+Convert explicit, machine-readable roadmap items into routable delegation entries — without any fuzzy parsing. Markers inside canonical roadmap docs are HTML-comment fenced and invisible to readers; an optional sidecar JSONL seed supports bulk operator-authored decomposition. Promotion into the development work queue remains a separate manual operator action.
+
+## Architectural separation
+
+ADE core (this PR):
+
+```text
+reporting/development_delegation.py
+```
+
+Stdlib + `reporting.execution_authority` + `reporting.approval_policy` + `reporting.development_work_queue`. No subprocess, no network, no `gh`, no `git`. Pinned by tests at AST level.
+
+There is no out-of-core collector for A11 — markers and the sidecar are operator-authored.
+
+## Marker grammar (canonical roadmap docs)
+
+```
+<!-- ade_delegation
+delegation_id: <opaque-stable-id, [A-Za-z0-9_.-]+>
+title: <≤200 chars>
+category: <one of A8 CATEGORIES>
+required_agent_role: <one of A8 AGENT_ROLES>
+risk_level: <LOW | MEDIUM | HIGH | UNKNOWN>
+acceptance_criteria:
+  - <≤200 chars>
+  - <…>
+human_needed: <true | false>
+human_needed_reason: <closed reason; "none" iff human_needed=false>
+-->
+```
+
+Strict closed grammar — every required field must be present and pass the closed-vocab check. Any failure drops the marker with a `validation_warning`.
+
+Use markers sparingly. Canonical roadmap docs must remain human-readable. Markers are appropriate for high-level approved delegation anchors. Bulk decomposition belongs in the sidecar seed.
+
+## Sidecar seed
+
+```text
+docs/development_work_queue/delegation_seed.jsonl
+```
+
+Strict JSONL. Empty by default. One JSON object per non-blank line; same fields as the marker grammar.
+
+## Discipline invariants (load-bearing)
+
+```text
+writes_to_seed_jsonl: false
+writes_to_bugfix_seed_jsonl: false
+writes_to_delegation_seed_jsonl: false
+fuzzy_parsing: false
+operator_promotion_required: true
+```
+
+## Required deliverables (this PR)
+
+```text
+1. reporting/development_delegation.py
+2. tests/unit/test_development_delegation.py
+3. docs/governance/development_delegation.md
+4. docs/development_work_queue/delegation_seed.jsonl (empty placeholder)
+5. This entry in docs/roadmap/autonomous_development.txt
+```
+
+## Out of scope (deferred)
+
+```text
+- automatic promotion into seed.jsonl — never; operator-gated
+- prose / heading / list / NLP parsing — never
+- A12 operational digest — separate phase
+- Any QRE/IR/v3.15.17 changes
+- Any live/paper/shadow/risk/trading/broker/execution change
+```
+
+## Definition of Done
+
+```text
+1. Branch feature/a11-roadmap-delegation exists; nothing on main.
+2. Implementation complete on branch (module, tests, docs, seed,
+   roadmap entry).
+3. Targeted tests green:
+     python -m pytest tests/unit/test_development_delegation.py -q
+4. Broader unit suite green:
+     python -m pytest tests/unit -q
+5. Smoke suite green:
+     python -m pytest tests/smoke -q
+6. Governance lint green:
+     python scripts/governance_lint.py
+7. PR opened against main via the documented gh CLI flow.
+8. CI green on the PR.
+9. Squash-merged to main; post-merge gates green.
+10. Only after step 9 may this entry be flipped from `PR-ready` to
+    `Complete`, recording PR number and merge SHA.
+```
+
+## Determinism
+
+The pure module accepts an injectable `generated_at_utc`. With the same canonical roadmap content, the same sidecar seed, and the same injected timestamp, output bytes are identical.
+
+

--- a/reporting/development_delegation.py
+++ b/reporting/development_delegation.py
@@ -1,0 +1,742 @@
+"""A11 — Bounded Roadmap Implementation Delegation.
+
+Pure, deterministic, stdlib-only roadmap-marker parser. Converts
+explicit, machine-readable delegation markers inside the canonical
+roadmap docs (and an optional sidecar seed) into routable
+delegation entries. **No fuzzy parsing.** Plain headings, prose,
+lists, and bullet points produce zero entries. Archive paths are
+excluded.
+
+Marker syntax inside a canonical roadmap doc:
+
+::
+
+    <!-- ade_delegation
+    delegation_id: <opaque-stable-id>
+    title: <≤200 chars>
+    category: <one of A8 CATEGORIES>
+    required_agent_role: <one of A8 AGENT_ROLES>
+    risk_level: <LOW | MEDIUM | HIGH | UNKNOWN>
+    acceptance_criteria:
+      - <≤200 chars>
+      - <…>
+    human_needed: <true | false>
+    human_needed_reason: <closed reason>
+    -->
+
+The parser is strict: every required field must be present and
+each value must belong to the closed vocabulary. Anything else
+becomes a validation_warning and is dropped, never silently
+promoted.
+
+Hard guarantees (pinned by tests):
+
+* Stdlib + ``reporting.execution_authority`` + ``reporting.approval_policy`` +
+  ``reporting.development_work_queue`` (read-only API).
+* No subprocess, no network, no ``gh``, no ``git``.
+* No imports from ``dashboard``, ``automation``, ``broker``,
+  ``agent.risk``, ``agent.execution``, ``research``,
+  ``reporting.intelligent_routing``.
+* No mutation of any upstream artifact.
+* Atomic write only under ``logs/development_delegation/latest.json``.
+* Only canonical roadmap paths are accepted as roadmap sources;
+  archive paths are excluded by both inclusion list and a positive
+  ``archive/`` substring check.
+
+CLI::
+
+    python -m reporting.development_delegation
+    python -m reporting.development_delegation --no-write
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import hashlib
+import json
+import os
+import re
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Final
+
+from reporting import development_work_queue as dwq
+from reporting import execution_authority as ea
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[str] = "1.0"
+MODULE_VERSION: Final[str] = "v3.15.16.A11"
+
+# ---------------------------------------------------------------------------
+# Sources
+# ---------------------------------------------------------------------------
+
+#: The two canonical roadmap docs accepted as marker sources. The
+#: parser refuses any other document. ADE remains generic, but this
+#: module's roadmap-pickup happens against these two (and the
+#: optional sidecar seed). Archive paths are explicitly rejected.
+CANONICAL_ROADMAP_PATHS: Final[tuple[str, ...]] = (
+    "docs/roadmap/autonomous_development.txt",
+    "docs/roadmap/Roadmap v6.md",
+)
+
+#: Optional sidecar seed file. Strict JSONL. Empty by default.
+DEFAULT_SIDECAR_SEED_PATH: Final[Path] = (
+    REPO_ROOT / "docs" / "development_work_queue" / "delegation_seed.jsonl"
+)
+
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "development_delegation"
+ARTIFACT_LATEST: Final[Path] = ARTIFACT_DIR / "latest.json"
+ARTIFACT_RELATIVE_PATH: Final[str] = "logs/development_delegation/latest.json"
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies (re-using A8 vocabularies, plus a closed marker
+# field set)
+# ---------------------------------------------------------------------------
+
+#: Marker required field set; closed.
+MARKER_REQUIRED_FIELDS: Final[frozenset[str]] = frozenset(
+    {
+        "delegation_id",
+        "title",
+        "category",
+        "required_agent_role",
+        "risk_level",
+        "acceptance_criteria",
+        "human_needed",
+        "human_needed_reason",
+    }
+)
+
+#: Per-entry schema keys; exact and ordered.
+ENTRY_SCHEMA_KEYS: Final[tuple[str, ...]] = (
+    "delegation_id",
+    "title",
+    "source_document",
+    "source_section_or_anchor",
+    "roadmap_track",
+    "category",
+    "required_agent_role",
+    "supporting_agent_roles",
+    "execution_authority_decision",
+    "execution_authority_reason",
+    "status",
+    "human_needed",
+    "human_needed_reason",
+    "risk_level",
+    "protected_surface",
+    "acceptance_criteria",
+    "validation_requirements",
+    "notes",
+    "created_at_placeholder",
+    "updated_at_placeholder",
+)
+
+ITEM_TIME_PLACEHOLDER: Final[str] = "deterministic_seed_placeholder"
+
+#: Status assigned to parsed delegation entries. Operator promotion
+#: into the work queue is required to advance to ``ready``.
+DEFAULT_STATUS: Final[str] = "triaged"
+
+#: Bounded length for free-text fields.
+MAX_TITLE_LEN: Final[int] = 200
+MAX_NOTES_LEN: Final[int] = 1000
+MAX_AC_ITEMS: Final[int] = 16
+MAX_AC_LINE_LEN: Final[int] = 200
+MAX_DELEGATION_ID_LEN: Final[int] = 64
+MAX_MARKERS_PER_DOC: Final[int] = 256
+
+#: Roadmap track per source document.
+ROADMAP_TRACK_BY_SOURCE: Final[dict[str, str]] = {
+    "docs/roadmap/autonomous_development.txt": "autonomous_development",
+    "docs/roadmap/Roadmap v6.md": "qre_feature_build",
+}
+
+#: Wrapper-level note vocabulary.
+NOTE_NO_ENTRIES: Final[str] = "no_explicit_delegation_entries"
+NOTE_ENTRIES_PRESENT: Final[str] = "delegation_entries_present"
+NOTE_ROADMAP_DOCS_MISSING: Final[str] = "roadmap_docs_missing"
+
+#: Marker pattern. The opener and closer are pinned exactly so prose
+#: cannot accidentally match.
+_MARKER_OPEN: Final[str] = "<!-- ade_delegation"
+_MARKER_CLOSE: Final[str] = "-->"
+_MARKER_RE: Final[re.Pattern[str]] = re.compile(
+    r"<!--\s*ade_delegation\b(.*?)-->", re.DOTALL
+)
+
+
+# ---------------------------------------------------------------------------
+# Utility helpers
+# ---------------------------------------------------------------------------
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _bounded_str(value: Any, max_len: int) -> str:
+    if not isinstance(value, str):
+        return ""
+    if len(value) <= max_len:
+        return value
+    return value[:max_len]
+
+
+def _normalize_path(p: str) -> str:
+    if not p:
+        return ""
+    return p.replace("\\", "/").lstrip("./")
+
+
+def _is_archive_path(p: str) -> bool:
+    n = _normalize_path(p).lower()
+    return n.startswith("docs/roadmap/archive/") or "/archive/" in n
+
+
+def _read_text(path: Path) -> str | None:
+    if not path.is_file():
+        return None
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+
+def _coerce_bool(s: str) -> bool | None:
+    s = s.strip().lower()
+    if s in {"true", "yes", "1"}:
+        return True
+    if s in {"false", "no", "0"}:
+        return False
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Marker body parser
+# ---------------------------------------------------------------------------
+
+
+def _parse_marker_body(body: str) -> tuple[dict[str, Any] | None, list[str]]:
+    """Parse a marker body into a typed dict.
+
+    Returns ``(payload, warnings)``. Returns ``None`` payload with
+    warnings on any structural failure. The grammar is intentionally
+    minimal:
+
+    * one ``key: value`` per line for scalar fields,
+    * ``acceptance_criteria:`` followed by indented ``- value`` lines,
+    * blank lines and comment lines (``#``) tolerated.
+
+    Anything else is rejected with a warning."""
+    warnings: list[str] = []
+    out: dict[str, Any] = {}
+    ac: list[str] | None = None
+    for raw_line in body.splitlines():
+        line = raw_line.rstrip()
+        if not line.strip():
+            ac = None if ac is not None else None
+            continue
+        if line.lstrip().startswith("#"):
+            continue
+        # acceptance_criteria block markers
+        if ac is not None:
+            stripped = line.lstrip()
+            if stripped.startswith("- "):
+                if len(ac) >= MAX_AC_ITEMS:
+                    warnings.append("acceptance_criteria_truncated")
+                else:
+                    ac.append(_bounded_str(stripped[2:].strip(), MAX_AC_LINE_LEN))
+                continue
+            ac = None  # any other line ends the block
+        if ":" not in line:
+            warnings.append("marker_line_without_colon")
+            continue
+        key, _, value = line.partition(":")
+        key = key.strip()
+        value_stripped = value.strip()
+        if key == "acceptance_criteria":
+            ac = []
+            out["acceptance_criteria"] = ac
+            continue
+        out[key] = value_stripped
+    return out if out else None, warnings
+
+
+def _validate_marker_payload(
+    payload: dict[str, Any]
+) -> tuple[dict[str, Any] | None, list[str]]:
+    warnings: list[str] = []
+    missing = MARKER_REQUIRED_FIELDS - set(payload.keys())
+    if missing:
+        warnings.append(f"marker_missing_fields:{','.join(sorted(missing))}")
+        return None, warnings
+
+    delegation_id = _bounded_str(payload.get("delegation_id"), MAX_DELEGATION_ID_LEN)
+    if not delegation_id or not re.match(r"^[A-Za-z0-9_.\-]+$", delegation_id):
+        warnings.append("marker_invalid_delegation_id")
+        return None, warnings
+
+    title = _bounded_str(payload.get("title"), MAX_TITLE_LEN)
+    if not title:
+        warnings.append("marker_missing_title")
+        return None, warnings
+
+    category = payload.get("category")
+    if category not in dwq.CATEGORIES:
+        warnings.append("marker_invalid_category")
+        return None, warnings
+
+    role = payload.get("required_agent_role")
+    if role not in dwq.AGENT_ROLES:
+        warnings.append("marker_invalid_required_agent_role")
+        return None, warnings
+
+    risk = payload.get("risk_level")
+    if risk not in ea.RISK_CLASSES:
+        warnings.append("marker_invalid_risk_level")
+        return None, warnings
+
+    hn_raw = payload.get("human_needed")
+    if isinstance(hn_raw, bool):
+        human_needed = hn_raw
+    else:
+        coerced = _coerce_bool(str(hn_raw)) if hn_raw is not None else None
+        if coerced is None:
+            warnings.append("marker_invalid_human_needed")
+            return None, warnings
+        human_needed = coerced
+
+    hn_reason = payload.get("human_needed_reason")
+    if hn_reason not in dwq.HUMAN_NEEDED_REASONS:
+        warnings.append("marker_invalid_human_needed_reason")
+        return None, warnings
+    if human_needed and hn_reason == "none":
+        warnings.append("marker_human_needed_true_but_reason_none")
+        return None, warnings
+    if (not human_needed) and hn_reason != "none":
+        warnings.append("marker_human_needed_false_but_reason_not_none")
+        return None, warnings
+
+    ac = payload.get("acceptance_criteria") or []
+    if not isinstance(ac, list) or not ac:
+        warnings.append("marker_missing_acceptance_criteria")
+        return None, warnings
+    ac_clean: list[str] = []
+    for entry in ac[:MAX_AC_ITEMS]:
+        if isinstance(entry, str) and entry.strip():
+            ac_clean.append(_bounded_str(entry, MAX_AC_LINE_LEN))
+    if not ac_clean:
+        warnings.append("marker_acceptance_criteria_empty_after_clean")
+        return None, warnings
+
+    return (
+        {
+            "delegation_id": delegation_id,
+            "title": title,
+            "category": category,
+            "required_agent_role": role,
+            "risk_level": risk,
+            "human_needed": human_needed,
+            "human_needed_reason": hn_reason,
+            "acceptance_criteria": ac_clean,
+        },
+        warnings,
+    )
+
+
+def _entries_from_doc(
+    doc_path: str, *, text: str
+) -> tuple[list[dict[str, Any]], list[str]]:
+    warnings: list[str] = []
+    entries: list[dict[str, Any]] = []
+    matches = list(_MARKER_RE.finditer(text))
+    if len(matches) > MAX_MARKERS_PER_DOC:
+        warnings.append(f"too_many_markers_truncated_at_{MAX_MARKERS_PER_DOC}")
+        matches = matches[:MAX_MARKERS_PER_DOC]
+    for idx, m in enumerate(matches, start=1):
+        body = m.group(1)
+        parsed, parse_warns = _parse_marker_body(body)
+        for w in parse_warns:
+            warnings.append(f"{doc_path}#marker{idx}:{w}")
+        if parsed is None:
+            continue
+        validated, val_warns = _validate_marker_payload(parsed)
+        for w in val_warns:
+            warnings.append(f"{doc_path}#marker{idx}:{w}")
+        if validated is None:
+            continue
+        entry = _build_entry(
+            validated,
+            source_document=doc_path,
+            source_section=f"marker_{idx}",
+            roadmap_track=ROADMAP_TRACK_BY_SOURCE.get(doc_path, "sidecar_seed"),
+        )
+        entries.append(entry)
+    return entries, warnings
+
+
+def _entries_from_sidecar(
+    seed_path: Path,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    warnings: list[str] = []
+    entries: list[dict[str, Any]] = []
+    text = _read_text(seed_path)
+    if text is None:
+        return entries, warnings
+    seen_ids: set[str] = set()
+    for idx, raw_line in enumerate(text.splitlines(), start=1):
+        s = raw_line.strip()
+        if not s:
+            continue
+        try:
+            payload = json.loads(s)
+        except ValueError:
+            warnings.append(f"sidecar_line_{idx}_invalid_json")
+            continue
+        if not isinstance(payload, dict):
+            warnings.append(f"sidecar_line_{idx}_not_an_object")
+            continue
+        validated, val_warns = _validate_marker_payload(payload)
+        for w in val_warns:
+            warnings.append(f"sidecar_line_{idx}:{w}")
+        if validated is None:
+            continue
+        if validated["delegation_id"] in seen_ids:
+            warnings.append(
+                f"sidecar_line_{idx}:duplicate_delegation_id"
+            )
+            continue
+        seen_ids.add(validated["delegation_id"])
+        entries.append(
+            _build_entry(
+                validated,
+                source_document="delegation_seed",
+                source_section=f"line_{idx}",
+                roadmap_track="sidecar_seed",
+            )
+        )
+    return entries, warnings
+
+
+# ---------------------------------------------------------------------------
+# Entry construction
+# ---------------------------------------------------------------------------
+
+
+def _execution_authority_for(
+    *, source_document: str, risk_level: str
+) -> ea.ExecutionDecision:
+    """Run the entry through ``ea.classify`` so the artifact carries
+    a deterministic authority decision. The source document is the
+    target_path the operator would edit to act on the delegation."""
+    target = source_document if source_document != "delegation_seed" else "sidecar_seed"
+    return ea.classify(
+        action_type="file_edit",
+        target_path=target if target else None,
+        risk_class=risk_level,
+    )
+
+
+def _protected_surface(
+    *, source_document: str, decision: ea.ExecutionDecision
+) -> bool:
+    """Mark canonical roadmap edits and any NEEDS_HUMAN/PERMANENTLY_DENIED
+    target as protected. Operators may still promote them; the
+    delegation parser only flags the surface."""
+    if decision.target_path_category in {
+        "claude_governance_hook",
+        "dashboard_wiring",
+        "frozen_contract",
+        "live_path",
+        "branch_protection_config",
+        "deploy_script",
+        "canonical_policy_doc",
+        "canonical_roadmap",
+        "ci_workflow",
+    }:
+        return True
+    return decision.decision != ea.DECISION_AUTO_ALLOWED
+
+
+def _build_entry(
+    validated: dict[str, Any],
+    *,
+    source_document: str,
+    source_section: str,
+    roadmap_track: str,
+) -> dict[str, Any]:
+    decision = _execution_authority_for(
+        source_document=source_document,
+        risk_level=validated["risk_level"],
+    )
+    return {
+        "delegation_id": validated["delegation_id"],
+        "title": validated["title"],
+        "source_document": source_document,
+        "source_section_or_anchor": source_section,
+        "roadmap_track": roadmap_track,
+        "category": validated["category"],
+        "required_agent_role": validated["required_agent_role"],
+        "supporting_agent_roles": [],
+        "execution_authority_decision": decision.decision,
+        "execution_authority_reason": decision.reason,
+        "status": DEFAULT_STATUS,
+        "human_needed": validated["human_needed"],
+        "human_needed_reason": validated["human_needed_reason"],
+        "risk_level": validated["risk_level"],
+        "protected_surface": _protected_surface(
+            source_document=source_document, decision=decision
+        ),
+        "acceptance_criteria": validated["acceptance_criteria"],
+        "validation_requirements": [],
+        "notes": "",
+        "created_at_placeholder": ITEM_TIME_PLACEHOLDER,
+        "updated_at_placeholder": ITEM_TIME_PLACEHOLDER,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Snapshot assembly
+# ---------------------------------------------------------------------------
+
+
+def _empty_counts() -> dict[str, Any]:
+    return {
+        "total": 0,
+        "by_roadmap_track": {
+            "autonomous_development": 0,
+            "qre_feature_build": 0,
+            "sidecar_seed": 0,
+        },
+        "by_category": {c: 0 for c in dwq.CATEGORIES},
+        "by_required_agent_role": {r: 0 for r in dwq.AGENT_ROLES},
+        "by_status": {DEFAULT_STATUS: 0},
+        "by_execution_authority_decision": {
+            ea.DECISION_AUTO_ALLOWED: 0,
+            ea.DECISION_NEEDS_HUMAN: 0,
+            ea.DECISION_PERMANENTLY_DENIED: 0,
+        },
+        "human_needed": 0,
+        "protected_surface": 0,
+        "ready_for_operator_promotion": 0,
+        "requiring_human_operator": 0,
+    }
+
+
+def _aggregate_counts(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    counts = _empty_counts()
+    counts["total"] = len(rows)
+    for row in rows:
+        counts["by_roadmap_track"][row["roadmap_track"]] += 1
+        counts["by_category"][row["category"]] += 1
+        counts["by_required_agent_role"][row["required_agent_role"]] += 1
+        counts["by_status"][row["status"]] = counts["by_status"].get(row["status"], 0) + 1
+        counts["by_execution_authority_decision"][
+            row["execution_authority_decision"]
+        ] += 1
+        if row["human_needed"]:
+            counts["human_needed"] += 1
+            counts["requiring_human_operator"] += 1
+        elif row["execution_authority_decision"] == ea.DECISION_AUTO_ALLOWED and not row["protected_surface"]:
+            counts["ready_for_operator_promotion"] += 1
+        else:
+            counts["requiring_human_operator"] += 1
+        if row["protected_surface"]:
+            counts["protected_surface"] += 1
+    return counts
+
+
+def collect_snapshot(
+    *,
+    roadmap_paths: tuple[str, ...] | None = None,
+    sidecar_seed_path: Path | None = None,
+    repo_root: Path | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    """Build the deterministic delegation snapshot.
+
+    Args:
+        roadmap_paths: override the default canonical roadmap paths.
+            Tests pass synthetic fixture paths here. The check
+            against archive prefixes always runs.
+        sidecar_seed_path: override the default
+            ``docs/development_work_queue/delegation_seed.jsonl``.
+        repo_root: override repo root for tests. Defaults to the
+            module's repo root.
+        generated_at_utc: override the wrapper's report timestamp.
+    """
+    rp = roadmap_paths if roadmap_paths is not None else CANONICAL_ROADMAP_PATHS
+    root = repo_root if repo_root is not None else REPO_ROOT
+    sp = sidecar_seed_path if sidecar_seed_path is not None else DEFAULT_SIDECAR_SEED_PATH
+    ts = generated_at_utc if generated_at_utc is not None else _utcnow()
+
+    warnings: list[str] = []
+    entries: list[dict[str, Any]] = []
+    docs_used: list[str] = []
+    docs_missing: list[str] = []
+    seen_delegation_ids: set[str] = set()
+
+    for doc in rp:
+        norm = _normalize_path(doc)
+        if _is_archive_path(norm):
+            warnings.append(f"archive_path_excluded:{norm}")
+            continue
+        if norm not in CANONICAL_ROADMAP_PATHS:
+            warnings.append(f"non_canonical_roadmap_path_excluded:{norm}")
+            continue
+        full_path = root / norm
+        text = _read_text(full_path)
+        if text is None:
+            docs_missing.append(norm)
+            continue
+        docs_used.append(norm)
+        doc_entries, doc_warns = _entries_from_doc(norm, text=text)
+        warnings.extend(doc_warns)
+        for entry in doc_entries:
+            if entry["delegation_id"] in seen_delegation_ids:
+                warnings.append(
+                    f"{norm}:duplicate_delegation_id:{entry['delegation_id']}"
+                )
+                continue
+            seen_delegation_ids.add(entry["delegation_id"])
+            entries.append(entry)
+
+    sidecar_entries, sidecar_warns = _entries_from_sidecar(sp)
+    warnings.extend(sidecar_warns)
+    for entry in sidecar_entries:
+        if entry["delegation_id"] in seen_delegation_ids:
+            warnings.append(
+                f"sidecar:duplicate_delegation_id:{entry['delegation_id']}"
+            )
+            continue
+        seen_delegation_ids.add(entry["delegation_id"])
+        entries.append(entry)
+
+    entries.sort(key=lambda e: (e["roadmap_track"], e["delegation_id"]))
+
+    counts = _aggregate_counts(entries)
+
+    if not docs_used and not sp.is_file():
+        note = NOTE_ROADMAP_DOCS_MISSING if docs_missing else NOTE_NO_ENTRIES
+    elif not entries:
+        note = NOTE_NO_ENTRIES
+    else:
+        note = NOTE_ENTRIES_PRESENT
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "report_kind": "development_delegation",
+        "generated_at_utc": ts,
+        "canonical_roadmap_paths": list(CANONICAL_ROADMAP_PATHS),
+        "roadmap_paths_used": docs_used,
+        "roadmap_paths_missing": docs_missing,
+        "sidecar_seed_path": str(sp.relative_to(root)) if sp.is_relative_to(root) else str(sp),
+        "sidecar_seed_present": sp.is_file(),
+        "note": note,
+        "validation_warnings": warnings,
+        "vocabularies": {
+            "agent_roles": list(dwq.AGENT_ROLES),
+            "categories": list(dwq.CATEGORIES),
+            "human_needed_reasons": list(dwq.HUMAN_NEEDED_REASONS),
+            "risk_levels": list(ea.RISK_CLASSES),
+            "roadmap_tracks": ["autonomous_development", "qre_feature_build", "sidecar_seed"],
+            "marker_required_fields": sorted(MARKER_REQUIRED_FIELDS),
+        },
+        "counts": counts,
+        "entries": entries,
+        "execution_authority_module_version": ea.MODULE_VERSION,
+        "queue_module_version": dwq.MODULE_VERSION,
+        "discipline_invariants": {
+            "writes_to_seed_jsonl": False,
+            "writes_to_bugfix_seed_jsonl": False,
+            "writes_to_delegation_seed_jsonl": False,
+            "fuzzy_parsing": False,
+            "operator_promotion_required": True,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Atomic write
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    posix = path.as_posix()
+    if "/logs/" not in posix and not posix.startswith("logs/"):
+        raise ValueError(
+            "development_delegation._atomic_write_json refuses "
+            f"non-logs/ output path: {path}"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".development_delegation.", suffix=".tmp", dir=str(path.parent)
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_outputs(snapshot: dict[str, Any]) -> Path:
+    _atomic_write_json(ARTIFACT_LATEST, snapshot)
+    return ARTIFACT_LATEST
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m reporting.development_delegation",
+        description=(
+            "Read-only delegation parser. Reads explicit "
+            "`<!-- ade_delegation ... -->` markers from canonical "
+            "roadmap docs and entries from the optional sidecar seed. "
+            "No fuzzy parsing. Decides nothing; mutates nothing."
+        ),
+    )
+    p.add_argument("--indent", type=int, default=2, help="JSON indent (0 for compact).")
+    p.add_argument(
+        "--no-write",
+        action="store_true",
+        help=(
+            "Do not persist logs/development_delegation/latest.json "
+            "(stdout only)."
+        ),
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    indent = args.indent if args.indent and args.indent > 0 else None
+    snap = collect_snapshot()
+    if not args.no_write:
+        write_outputs(snap)
+    json.dump(snap, sys.stdout, indent=indent, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/unit/test_development_delegation.py
+++ b/tests/unit/test_development_delegation.py
@@ -1,0 +1,681 @@
+"""Unit tests for A11 — Bounded Roadmap Implementation Delegation.
+
+Synthetic deterministic fixtures only. The pure marker parser
+consumes only:
+
+* explicit ``<!-- ade_delegation ... -->`` markers in the canonical
+  roadmap docs;
+* operator-authored entries in the sidecar
+  ``docs/development_work_queue/delegation_seed.jsonl``.
+
+Plain headings, prose, lists, and bullet points must produce zero
+delegation entries. Archive paths are excluded. No fuzzy parsing.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reporting import development_delegation as ddl
+from reporting import development_work_queue as dwq
+from reporting import execution_authority as ea
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_repo_root(tmp_path: Path) -> Path:
+    """Create a synthetic repo-root with the two canonical roadmap
+    paths so the parser can read them. Tests then write only the
+    files they need; missing files become roadmap_paths_missing."""
+    (tmp_path / "docs" / "roadmap").mkdir(parents=True)
+    (tmp_path / "docs" / "development_work_queue").mkdir(parents=True)
+    return tmp_path
+
+
+def _write_canonical_doc(
+    root: Path, name: str, body: str
+) -> Path:
+    p = root / "docs" / "roadmap" / name
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+def _marker(**fields: Any) -> str:
+    base = {
+        "delegation_id": "syn_001",
+        "title": "Add a synthetic ADE doc improvement",
+        "category": "docs",
+        "required_agent_role": "implementation_agent",
+        "risk_level": "LOW",
+        "human_needed": "false",
+        "human_needed_reason": "none",
+    }
+    base.update({k: v for k, v in fields.items() if k != "acceptance_criteria"})
+    ac = fields.get("acceptance_criteria", ["doc lands and lints clean"])
+    lines = ["<!-- ade_delegation"]
+    for key, val in base.items():
+        lines.append(f"{key}: {val}")
+    lines.append("acceptance_criteria:")
+    for item in ac:
+        lines.append(f"  - {item}")
+    lines.append("-->")
+    return "\n".join(lines)
+
+
+def _seed_path(root: Path) -> Path:
+    return root / "docs" / "development_work_queue" / "delegation_seed.jsonl"
+
+
+def _write_sidecar(root: Path, lines: list[str]) -> Path:
+    p = _seed_path(root)
+    p.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Vocabulary / shape
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_roadmap_paths_match_doctrine() -> None:
+    assert set(ddl.CANONICAL_ROADMAP_PATHS) == {
+        "docs/roadmap/autonomous_development.txt",
+        "docs/roadmap/Roadmap v6.md",
+    }
+
+
+def test_marker_required_fields_are_closed() -> None:
+    assert ddl.MARKER_REQUIRED_FIELDS == frozenset(
+        {
+            "delegation_id",
+            "title",
+            "category",
+            "required_agent_role",
+            "risk_level",
+            "acceptance_criteria",
+            "human_needed",
+            "human_needed_reason",
+        }
+    )
+
+
+def test_entry_schema_keys_are_exact_and_ordered() -> None:
+    assert ddl.ENTRY_SCHEMA_KEYS == (
+        "delegation_id",
+        "title",
+        "source_document",
+        "source_section_or_anchor",
+        "roadmap_track",
+        "category",
+        "required_agent_role",
+        "supporting_agent_roles",
+        "execution_authority_decision",
+        "execution_authority_reason",
+        "status",
+        "human_needed",
+        "human_needed_reason",
+        "risk_level",
+        "protected_surface",
+        "acceptance_criteria",
+        "validation_requirements",
+        "notes",
+        "created_at_placeholder",
+        "updated_at_placeholder",
+    )
+
+
+def test_artifact_path_is_under_logs_not_research() -> None:
+    assert ddl.ARTIFACT_RELATIVE_PATH.startswith("logs/")
+    assert "research/" not in ddl.ARTIFACT_RELATIVE_PATH
+
+
+def test_atomic_write_refuses_non_logs_path(tmp_path: Path) -> None:
+    bad = tmp_path / "evil_dir" / "latest.json"
+    with pytest.raises(ValueError):
+        ddl._atomic_write_json(bad, {"x": 1})
+
+
+# ---------------------------------------------------------------------------
+# Snapshot top-level shape
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_top_level_keys(tmp_path: Path) -> None:
+    root = _make_repo_root(tmp_path)
+    snap = ddl.collect_snapshot(
+        repo_root=root,
+        sidecar_seed_path=_seed_path(root),
+        generated_at_utc="2026-05-07T00:00:00Z",
+    )
+    expected = {
+        "schema_version",
+        "module_version",
+        "report_kind",
+        "generated_at_utc",
+        "canonical_roadmap_paths",
+        "roadmap_paths_used",
+        "roadmap_paths_missing",
+        "sidecar_seed_path",
+        "sidecar_seed_present",
+        "note",
+        "validation_warnings",
+        "vocabularies",
+        "counts",
+        "entries",
+        "execution_authority_module_version",
+        "queue_module_version",
+        "discipline_invariants",
+    }
+    assert set(snap.keys()) == expected
+    assert snap["report_kind"] == "development_delegation"
+
+
+def test_discipline_invariants_block_is_present(tmp_path: Path) -> None:
+    root = _make_repo_root(tmp_path)
+    snap = ddl.collect_snapshot(
+        repo_root=root, sidecar_seed_path=_seed_path(root)
+    )
+    inv = snap["discipline_invariants"]
+    assert inv["writes_to_seed_jsonl"] is False
+    assert inv["writes_to_bugfix_seed_jsonl"] is False
+    assert inv["writes_to_delegation_seed_jsonl"] is False
+    assert inv["fuzzy_parsing"] is False
+    assert inv["operator_promotion_required"] is True
+
+
+# ---------------------------------------------------------------------------
+# False-positive guards (load-bearing)
+# ---------------------------------------------------------------------------
+
+
+def test_plain_markdown_headings_produce_zero_entries(tmp_path: Path) -> None:
+    root = _make_repo_root(tmp_path)
+    body = """# Roadmap
+
+## §A11
+
+- some bullet
+- another bullet
+
+### Sub-section
+
+prose explaining the section that contains the words `delegation` and `marker`
+but is not inside a marker.
+"""
+    _write_canonical_doc(root, "autonomous_development.txt", body)
+    _write_canonical_doc(root, "Roadmap v6.md", body)
+    snap = ddl.collect_snapshot(
+        repo_root=root, sidecar_seed_path=_seed_path(root)
+    )
+    assert snap["entries"] == []
+    assert snap["note"] == ddl.NOTE_NO_ENTRIES
+
+
+def test_html_comment_without_ade_delegation_keyword_is_ignored(
+    tmp_path: Path,
+) -> None:
+    root = _make_repo_root(tmp_path)
+    body = """<!-- this is a regular html comment -->
+<!-- ade_delegation_lookalike: not the real opener -->
+<!-- ade -->
+"""
+    _write_canonical_doc(root, "autonomous_development.txt", body)
+    snap = ddl.collect_snapshot(
+        repo_root=root, sidecar_seed_path=_seed_path(root)
+    )
+    assert snap["entries"] == []
+
+
+def test_archive_roadmap_paths_are_excluded(tmp_path: Path) -> None:
+    """A roadmap path starting with docs/roadmap/archive/ must never
+    be parsed even if the operator passes it explicitly."""
+    root = _make_repo_root(tmp_path)
+    archive_path = "docs/roadmap/archive/qre_roadmap_v6_1.md"
+    (root / "docs" / "roadmap" / "archive").mkdir(parents=True)
+    (root / archive_path).write_text(_marker(), encoding="utf-8")
+    # Pass the archive path as a roadmap path; the module must
+    # refuse it.
+    snap = ddl.collect_snapshot(
+        roadmap_paths=(archive_path,),
+        sidecar_seed_path=_seed_path(root),
+        repo_root=root,
+    )
+    assert snap["entries"] == []
+    assert any("archive_path_excluded" in w for w in snap["validation_warnings"])
+
+
+def test_non_canonical_roadmap_path_is_excluded(tmp_path: Path) -> None:
+    """Any roadmap path outside the closed canonical set must be
+    refused (defence in depth against accidental misuse)."""
+    root = _make_repo_root(tmp_path)
+    other_path = "docs/operator/some_other_doc.md"
+    (root / "docs" / "operator").mkdir(parents=True)
+    (root / other_path).write_text(_marker(), encoding="utf-8")
+    snap = ddl.collect_snapshot(
+        roadmap_paths=(other_path,),
+        sidecar_seed_path=_seed_path(root),
+        repo_root=root,
+    )
+    assert snap["entries"] == []
+    assert any(
+        "non_canonical_roadmap_path_excluded" in w
+        for w in snap["validation_warnings"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Marker happy path
+# ---------------------------------------------------------------------------
+
+
+def test_valid_marker_in_canonical_doc_produces_entry(tmp_path: Path) -> None:
+    root = _make_repo_root(tmp_path)
+    _write_canonical_doc(
+        root,
+        "autonomous_development.txt",
+        "## Some heading\n\n" + _marker() + "\n\nmore prose\n",
+    )
+    snap = ddl.collect_snapshot(
+        repo_root=root,
+        sidecar_seed_path=_seed_path(root),
+        generated_at_utc="2026-05-07T00:00:00Z",
+    )
+    assert snap["counts"]["total"] == 1
+    entry = snap["entries"][0]
+    assert set(entry.keys()) == set(ddl.ENTRY_SCHEMA_KEYS)
+    assert entry["delegation_id"] == "syn_001"
+    assert entry["roadmap_track"] == "autonomous_development"
+    assert entry["status"] == ddl.DEFAULT_STATUS
+    assert entry["category"] == "docs"
+    assert entry["required_agent_role"] == "implementation_agent"
+    assert entry["acceptance_criteria"] == ["doc lands and lints clean"]
+    # Editing autonomous_development.txt is canonical_roadmap → NEEDS_HUMAN.
+    assert entry["execution_authority_decision"] == ea.DECISION_NEEDS_HUMAN
+    assert entry["protected_surface"] is True
+
+
+def test_marker_in_qre_feature_build_track_uses_correct_track(
+    tmp_path: Path,
+) -> None:
+    root = _make_repo_root(tmp_path)
+    _write_canonical_doc(root, "Roadmap v6.md", _marker(delegation_id="syn_002"))
+    snap = ddl.collect_snapshot(
+        repo_root=root, sidecar_seed_path=_seed_path(root)
+    )
+    assert snap["entries"][0]["roadmap_track"] == "qre_feature_build"
+
+
+# ---------------------------------------------------------------------------
+# Marker validation — required fields and closed vocabularies
+# ---------------------------------------------------------------------------
+
+
+def test_missing_required_field_drops_marker(tmp_path: Path) -> None:
+    root = _make_repo_root(tmp_path)
+    # Build a marker missing acceptance_criteria.
+    body = (
+        "<!-- ade_delegation\n"
+        "delegation_id: syn_003\n"
+        "title: missing AC\n"
+        "category: docs\n"
+        "required_agent_role: implementation_agent\n"
+        "risk_level: LOW\n"
+        "human_needed: false\n"
+        "human_needed_reason: none\n"
+        "-->\n"
+    )
+    _write_canonical_doc(root, "autonomous_development.txt", body)
+    snap = ddl.collect_snapshot(
+        repo_root=root, sidecar_seed_path=_seed_path(root)
+    )
+    assert snap["entries"] == []
+    assert any("marker_missing_fields" in w for w in snap["validation_warnings"])
+
+
+def test_invalid_category_drops_marker(tmp_path: Path) -> None:
+    root = _make_repo_root(tmp_path)
+    _write_canonical_doc(
+        root,
+        "autonomous_development.txt",
+        _marker(category="not_a_category"),
+    )
+    snap = ddl.collect_snapshot(
+        repo_root=root, sidecar_seed_path=_seed_path(root)
+    )
+    assert snap["entries"] == []
+    assert any("invalid_category" in w for w in snap["validation_warnings"])
+
+
+def test_invalid_role_drops_marker(tmp_path: Path) -> None:
+    root = _make_repo_root(tmp_path)
+    _write_canonical_doc(
+        root,
+        "autonomous_development.txt",
+        _marker(required_agent_role="not_a_role"),
+    )
+    snap = ddl.collect_snapshot(
+        repo_root=root, sidecar_seed_path=_seed_path(root)
+    )
+    assert snap["entries"] == []
+    assert any(
+        "invalid_required_agent_role" in w for w in snap["validation_warnings"]
+    )
+
+
+def test_invalid_risk_level_drops_marker(tmp_path: Path) -> None:
+    root = _make_repo_root(tmp_path)
+    _write_canonical_doc(
+        root, "autonomous_development.txt", _marker(risk_level="EXTREME")
+    )
+    snap = ddl.collect_snapshot(
+        repo_root=root, sidecar_seed_path=_seed_path(root)
+    )
+    assert snap["entries"] == []
+    assert any("invalid_risk_level" in w for w in snap["validation_warnings"])
+
+
+def test_human_needed_consistency_with_reason_is_enforced(tmp_path: Path) -> None:
+    root = _make_repo_root(tmp_path)
+    _write_canonical_doc(
+        root,
+        "autonomous_development.txt",
+        _marker(human_needed="true", human_needed_reason="none"),
+    )
+    snap = ddl.collect_snapshot(
+        repo_root=root, sidecar_seed_path=_seed_path(root)
+    )
+    assert snap["entries"] == []
+    assert any(
+        "human_needed_true_but_reason_none" in w
+        for w in snap["validation_warnings"]
+    )
+
+
+def test_invalid_delegation_id_drops_marker(tmp_path: Path) -> None:
+    root = _make_repo_root(tmp_path)
+    _write_canonical_doc(
+        root,
+        "autonomous_development.txt",
+        _marker(delegation_id="bad id with spaces!"),
+    )
+    snap = ddl.collect_snapshot(
+        repo_root=root, sidecar_seed_path=_seed_path(root)
+    )
+    assert snap["entries"] == []
+    assert any("invalid_delegation_id" in w for w in snap["validation_warnings"])
+
+
+# ---------------------------------------------------------------------------
+# Sidecar seed
+# ---------------------------------------------------------------------------
+
+
+def test_empty_sidecar_seed_yields_zero_entries(tmp_path: Path) -> None:
+    root = _make_repo_root(tmp_path)
+    _write_sidecar(root, [])
+    snap = ddl.collect_snapshot(
+        repo_root=root, sidecar_seed_path=_seed_path(root)
+    )
+    assert snap["entries"] == []
+
+
+def test_valid_sidecar_seed_entry_round_trips(tmp_path: Path) -> None:
+    root = _make_repo_root(tmp_path)
+    payload = {
+        "delegation_id": "syn_sidecar_001",
+        "title": "Synthetic sidecar work item",
+        "category": "test",
+        "required_agent_role": "test_agent",
+        "risk_level": "LOW",
+        "acceptance_criteria": ["test added", "ci green"],
+        "human_needed": False,
+        "human_needed_reason": "none",
+    }
+    _write_sidecar(root, [json.dumps(payload)])
+    snap = ddl.collect_snapshot(
+        repo_root=root, sidecar_seed_path=_seed_path(root)
+    )
+    assert snap["counts"]["total"] == 1
+    entry = snap["entries"][0]
+    assert entry["roadmap_track"] == "sidecar_seed"
+    assert entry["source_document"] == "delegation_seed"
+    assert entry["status"] == ddl.DEFAULT_STATUS
+
+
+def test_sidecar_seed_strict_jsonl_no_comments(tmp_path: Path) -> None:
+    """Markdown headings or `#` comment lines in the sidecar are
+    invalid JSONL; they must be reported and dropped."""
+    root = _make_repo_root(tmp_path)
+    _write_sidecar(
+        root,
+        [
+            "# this is not valid JSONL",
+            "## also not",
+            "[just a bracket",
+        ],
+    )
+    snap = ddl.collect_snapshot(
+        repo_root=root, sidecar_seed_path=_seed_path(root)
+    )
+    assert snap["entries"] == []
+    assert any("invalid_json" in w for w in snap["validation_warnings"])
+
+
+def test_duplicate_delegation_id_is_dropped(tmp_path: Path) -> None:
+    root = _make_repo_root(tmp_path)
+    payload = {
+        "delegation_id": "dup_001",
+        "title": "x",
+        "category": "docs",
+        "required_agent_role": "implementation_agent",
+        "risk_level": "LOW",
+        "acceptance_criteria": ["a"],
+        "human_needed": False,
+        "human_needed_reason": "none",
+    }
+    _write_sidecar(root, [json.dumps(payload), json.dumps(payload)])
+    snap = ddl.collect_snapshot(
+        repo_root=root, sidecar_seed_path=_seed_path(root)
+    )
+    assert snap["counts"]["total"] == 1
+    assert any("duplicate_delegation_id" in w for w in snap["validation_warnings"])
+
+
+def test_committed_repo_sidecar_is_strict_jsonl_or_absent() -> None:
+    """The committed `docs/development_work_queue/delegation_seed.jsonl`
+    must be either absent or strict JSONL — every non-blank line
+    parses as JSON."""
+    p = ddl.DEFAULT_SIDECAR_SEED_PATH
+    if not p.is_file():
+        return
+    raw = p.read_text(encoding="utf-8")
+    for line in raw.splitlines():
+        s = line.strip()
+        if not s:
+            continue
+        assert not s.startswith("#"), "JSONL must not contain `#` comments"
+        json.loads(s)
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+def test_determinism_with_injected_timestamp(tmp_path: Path) -> None:
+    root = _make_repo_root(tmp_path)
+    _write_canonical_doc(root, "autonomous_development.txt", _marker())
+    snap_a = ddl.collect_snapshot(
+        repo_root=root,
+        sidecar_seed_path=_seed_path(root),
+        generated_at_utc="2026-05-07T00:00:00Z",
+    )
+    snap_b = ddl.collect_snapshot(
+        repo_root=root,
+        sidecar_seed_path=_seed_path(root),
+        generated_at_utc="2026-05-07T00:00:00Z",
+    )
+    assert json.dumps(snap_a, sort_keys=True, indent=2).encode("utf-8") == json.dumps(
+        snap_b, sort_keys=True, indent=2
+    ).encode("utf-8")
+
+
+def test_entries_sort_deterministically(tmp_path: Path) -> None:
+    root = _make_repo_root(tmp_path)
+    _write_canonical_doc(
+        root,
+        "autonomous_development.txt",
+        "\n\n".join([_marker(delegation_id=f"id_{i}") for i in ("003", "001", "002")]),
+    )
+    snap = ddl.collect_snapshot(
+        repo_root=root, sidecar_seed_path=_seed_path(root)
+    )
+    ids = [e["delegation_id"] for e in snap["entries"]]
+    assert ids == sorted(ids)
+
+
+# ---------------------------------------------------------------------------
+# Counts
+# ---------------------------------------------------------------------------
+
+
+def test_counts_aggregate_and_close_vocabularies(tmp_path: Path) -> None:
+    root = _make_repo_root(tmp_path)
+    _write_canonical_doc(
+        root,
+        "autonomous_development.txt",
+        _marker(delegation_id="a"),
+    )
+    _write_canonical_doc(
+        root,
+        "Roadmap v6.md",
+        _marker(
+            delegation_id="b",
+            human_needed="true",
+            human_needed_reason="architecture_crossroads",
+        ),
+    )
+    snap = ddl.collect_snapshot(
+        repo_root=root, sidecar_seed_path=_seed_path(root)
+    )
+    counts = snap["counts"]
+    assert counts["total"] == 2
+    assert counts["human_needed"] == 1
+    assert counts["protected_surface"] == 2
+    assert sum(counts["by_roadmap_track"].values()) == 2
+    assert sum(counts["by_required_agent_role"].values()) == 2
+
+
+# ---------------------------------------------------------------------------
+# Source-text scans (no subprocess / no network / no forbidden imports)
+# ---------------------------------------------------------------------------
+
+
+def _module_source() -> str:
+    return Path(ddl.__file__).read_text(encoding="utf-8")
+
+
+def _imported_module_names() -> set[str]:
+    import ast
+
+    src = _module_source()
+    tree = ast.parse(src)
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module is not None:
+                names.add(node.module)
+    return names
+
+
+def test_no_subprocess_in_module() -> None:
+    src = _module_source()
+    assert "import subprocess" not in src
+    assert "from subprocess" not in src
+
+
+def test_no_network_in_module() -> None:
+    src = _module_source()
+    for forbidden in (
+        "import socket",
+        "import urllib",
+        "import http.client",
+        "import requests",
+    ):
+        assert forbidden not in src
+    assert "from socket" not in src
+    assert "from urllib" not in src
+    assert "from http" not in src
+
+
+def test_no_dashboard_or_live_path_or_qre_imports() -> None:
+    forbidden_prefixes = (
+        "dashboard",
+        "automation",
+        "broker",
+        "agent.risk",
+        "agent.execution",
+        "research",
+        "reporting.intelligent_routing",
+    )
+    for module in _imported_module_names():
+        for prefix in forbidden_prefixes:
+            assert not (module == prefix or module.startswith(prefix + ".")), (
+                f"forbidden import: {module}"
+            )
+
+
+def test_no_gh_or_git_subprocess_references() -> None:
+    src = _module_source()
+    for forbidden in (
+        "subprocess.run",
+        "subprocess.Popen",
+        "os.system",
+        "os.popen",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_module_imports_cleanly() -> None:
+    importlib.reload(ddl)
+    assert callable(ddl.collect_snapshot)
+
+
+# ---------------------------------------------------------------------------
+# Schema-version + module-version surfaces
+# ---------------------------------------------------------------------------
+
+
+def test_schema_and_module_version_strings() -> None:
+    assert isinstance(ddl.SCHEMA_VERSION, str) and ddl.SCHEMA_VERSION
+    assert isinstance(ddl.MODULE_VERSION, str) and ddl.MODULE_VERSION
+    assert "A11" in ddl.MODULE_VERSION
+
+
+def test_human_needed_reasons_used_are_subset_of_a8(tmp_path: Path) -> None:
+    """Every reason A11 emits must be in the A8 closed vocabulary."""
+    root = _make_repo_root(tmp_path)
+    _write_canonical_doc(
+        root,
+        "autonomous_development.txt",
+        _marker(
+            human_needed="true",
+            human_needed_reason="protected_governance_change",
+        ),
+    )
+    snap = ddl.collect_snapshot(
+        repo_root=root, sidecar_seed_path=_seed_path(root)
+    )
+    for e in snap["entries"]:
+        assert e["human_needed_reason"] in dwq.HUMAN_NEEDED_REASONS


### PR DESCRIPTION
## Summary

Convert explicit, machine-readable roadmap items into routable delegation entries — without any fuzzy parsing. Markers in the canonical roadmap docs are HTML-comment-fenced; an optional sidecar JSONL seed supports bulk operator-authored decomposition. Promotion into the development work queue remains a separate manual operator action.

**Status: PR-ready, NOT Complete.**

## Scope

**Added:**
- `reporting/development_delegation.py` — pure marker parser. Closed grammar (8 required fields), per-entry schema, deterministic `delegation_id`, atomic write under `logs/development_delegation/latest.json`, CLI.
- `docs/development_work_queue/delegation_seed.jsonl` — empty strict-JSONL placeholder for bulk decomposition.
- `tests/unit/test_development_delegation.py` — 34 tests pinning vocabulary, schema, marker grammar, false-positive guards (plain headings/prose/lists ⇒ zero entries), archive exclusion, non-canonical exclusion, sidecar strict JSONL, determinism, AST-level forbidden-import scan.
- `docs/governance/development_delegation.md` — governance doc.

**Modified:**
- `docs/roadmap/autonomous_development.txt` — append §A11 block with `Status: PR-ready (NOT complete)`.

**Untouched:** `research/**`, frozen contracts, Intelligent Routing modules, scoring, `.claude/**`, `dashboard/dashboard.py`, all live/paper/shadow/risk/trading/broker/execution paths, all CI workflows.

## Marker syntax

```
<!-- ade_delegation
delegation_id: <opaque-stable-id, [A-Za-z0-9_.-]+>
title: <≤200 chars>
category: <one of A8 CATEGORIES>
required_agent_role: <one of A8 AGENT_ROLES>
risk_level: <LOW | MEDIUM | HIGH | UNKNOWN>
acceptance_criteria:
  - <≤200 chars>
human_needed: <true | false>
human_needed_reason: <closed reason; "none" iff human_needed=false>
-->
```

Strict closed grammar — every required field must be present and pass the closed-vocab check. Markers are HTML comments, invisible to readers. Use sparingly: canonical roadmap docs must remain human-readable. Bulk decomposition belongs in the sidecar.

## Discipline invariants (load-bearing)

```
writes_to_seed_jsonl: false
writes_to_bugfix_seed_jsonl: false
writes_to_delegation_seed_jsonl: false
fuzzy_parsing: false
operator_promotion_required: true
```

## Validation

- `python -m pytest tests/unit/test_development_delegation.py -q` → **34 passed**.
- `python -m pytest tests/unit/test_development_*.py tests/unit/test_execution_authority.py -q` → **272 passed**.
- `python -m pytest tests/smoke -q` → **18 passed**.
- `python scripts/governance_lint.py` → **OK**.

## Out of scope (deferred)

- Automatic promotion into `seed.jsonl` — never; operator-gated.
- A12 operational digest — separate phase.
- Any QRE / IR / v3.15.17 / scoring change.
- Any live/paper/shadow/risk/trading/broker/execution change.

## Test plan

- [ ] CI green on this PR.
- [ ] After merge: post-merge gates green; flip §A11 to `Complete`.