### PR TITLE
feat(A12): operational digest / observability loop

### DIFF
--- a/docs/governance/development_operational_digest.md
+++ b/docs/governance/development_operational_digest.md
@@ -1,0 +1,170 @@
+# Autonomous Development Operational Digest (A12)
+
+> Canonical governance document for the Operational Digest
+> introduced in A12. Read-only aggregator across the four ADE
+> artifacts. No notifications. No dashboard work. No upstream
+> mutation. Step 5 implementation remains operator-gated.
+
+## Status
+
+Active. Modifications to this document require operator approval.
+
+## What this is — and is not
+
+A12 aggregates the four ADE artifacts (A8 work queue, A9 release
+gate, A10 bugfix loop, A11 delegation) into a single
+operator-facing snapshot plus a bounded append-only history. The
+digest computes a `step5_readiness` block whose `step5_ready` flag
+is the closed-form measurable signal that A9–A12 are coherent
+enough to consider Step 5 (Autonomous Implementation Loop)
+implementation.
+
+A12 is **not**:
+
+- a notification service,
+- a dashboard,
+- a mutation surface for any upstream artifact,
+- an authoriser for Step 5 implementation,
+- an LLM reasoner.
+
+`step5_ready=true` is **necessary but not sufficient**. The
+operator authorises Step 5 separately.
+
+## Architectural separation
+
+ADE core (this PR):
+
+```text
+reporting/development_operational_digest.py
+```
+
+Stdlib + ADE peer modules' read-only API only
+(`reporting.development_work_queue`,
+`reporting.development_release_gate`,
+`reporting.development_bugfix_loop`,
+`reporting.development_delegation`). No subprocess, no network, no
+`gh`, no `git`. AST-level pin forbids imports from
+`dashboard`/`automation`/`broker`/`agent.risk`/`agent.execution`/
+`research`/`reporting.intelligent_routing`.
+
+There is no out-of-core collector for A12 — its inputs are the
+four ADE artifacts, all already produced by ADE-core CLIs.
+
+## Output — current snapshot
+
+```
+logs/development_operational_digest/latest.json
+```
+
+Top-level keys:
+
+```
+schema_version, module_version, report_kind, generated_at_utc,
+note, presence_count, sources, operator_action_list,
+step5_readiness, vocabularies,
+queue_module_version, release_gate_module_version,
+bugfix_loop_module_version, delegation_module_version,
+max_history_entries, discipline_invariants
+```
+
+`sources` carries one summary per upstream artifact, with closed
+counts projected onto closed vocabularies. Missing upstream
+artifacts produce `present=false` summaries with zeroed counts —
+the digest is robust to any subset of upstream artifacts.
+
+`note` ∈ {`no_upstream_artifacts_present`,
+`partial_upstream_artifacts_present`,
+`all_upstream_artifacts_present`}.
+
+## Output — bounded append-only history
+
+```
+logs/development_operational_digest/history.jsonl
+```
+
+Strict JSONL. Each line is a compact projection (no full source
+payloads). Truncated to **`MAX_HISTORY_ENTRIES = 90`** (operator-
+approved) most-recent entries. Rewritten atomically on every
+append — never partial.
+
+History entry fields:
+
+```
+generated_at_utc, module_version, presence_count,
+step5_ready, criteria, operator_action_count,
+queue_total, release_gate_total,
+bugfix_loop_total, delegation_total
+```
+
+## Step 5 readiness criteria (closed)
+
+```
+release_gate_artifact_present
+release_gate_no_protected_surface_leakage
+bugfix_loop_artifact_present
+bugfix_loop_no_test_weakening_proposals
+delegation_artifact_present
+delegation_no_fuzzy_parsing_evidence
+queue_artifact_present
+queue_human_needed_signal_meaningful
+ade_qre_loose_coupling_clean
+no_protected_path_violations
+```
+
+`step5_ready = all(criteria.values())`. Any future criterion must
+be added to `STEP5_CRITERIA` and pinned by tests.
+
+`step5_design_planning_allowed` is reported as **always true**
+(operator-authored design planning is unrestricted).
+`step5_implementation_allowed` is reported as **always false** in
+this release — Step 5 implementation requires a separate operator
+authorisation step that the digest is not authoritative for.
+
+## Operator action list
+
+Bounded, deduplicated, deterministic. At most
+`MAX_OPERATOR_ACTIONS = 20` rows. Sorted by `(source, kind)`.
+
+Closed `kind` vocabulary:
+
+```
+queue_human_needed_items_present
+queue_blocked_items_present
+release_gate_no_go_human_needed
+release_gate_no_go_blocked
+bugfix_repeated_validation_failure
+bugfix_human_needed_candidates
+delegation_ready_for_operator_promotion
+delegation_human_needed_entries
+```
+
+## Hard guarantees (pinned by tests)
+
+- Stdlib + ADE peer modules' read-only API only.
+- No subprocess, no network, no `gh`, no `git`.
+- AST-level forbidden-import pin.
+- Atomic write only under
+  `logs/development_operational_digest/latest.json`. The history
+  guard refuses non-`logs/` paths.
+- Reading upstream artifacts never mutates them (pinned by
+  before/after byte comparison).
+- Wrapper carries an explicit `discipline_invariants` block:
+  ```
+  mutates_upstream_artifacts: false
+  sends_notifications: false
+  writes_dashboard: false
+  auto_authorises_step5: false
+  operator_step5_authorisation_required: true
+  ```
+
+## CLI surface
+
+```
+python -m reporting.development_operational_digest            # writes latest + history
+python -m reporting.development_operational_digest --no-write  # stdout only
+```
+
+## Modifying this document
+
+Standard governance discipline. Scope-bounded PR, CI green,
+post-merge gates, no `--admin` merge.

--- a/docs/roadmap/autonomous_development.txt
+++ b/docs/roadmap/autonomous_development.txt
@@ -1249,4 +1249,111 @@ operator_promotion_required: true
 
 The pure module accepts an injectable `generated_at_utc`. With the same canonical roadmap content, the same sidecar seed, and the same injected timestamp, output bytes are identical.
 
+\---
+
+# A12 — Operational Digest / Observability Loop
+
+## Status
+
+```text
+Status: PR-ready (NOT complete)
+```
+
+A12 is marked complete only after the PR's CI is green, the squash merge has landed on `main`, and post-merge gates pass.
+
+## Purpose
+
+Aggregate the four ADE artifacts (A8 work queue, A9 release gate, A10 bugfix loop, A11 delegation) into a single operator-facing snapshot plus a bounded append-only history. Compute a `step5_readiness` block whose `step5_ready` flag is the closed-form measurable signal that A9–A12 are coherent enough to consider Step 5 implementation. `step5_ready=true` is necessary but not sufficient — the operator authorises Step 5 separately.
+
+## Architectural separation
+
+ADE core (this PR):
+
+```text
+reporting/development_operational_digest.py
+```
+
+Stdlib + ADE peer modules' read-only API only. No subprocess, no network, no `gh`, no `git`. Pinned by tests at AST level.
+
+There is no out-of-core collector for A12 — its inputs are the four ADE artifacts, all already produced by ADE-core CLIs.
+
+## Step 5 readiness criteria (closed)
+
+```text
+release_gate_artifact_present
+release_gate_no_protected_surface_leakage
+bugfix_loop_artifact_present
+bugfix_loop_no_test_weakening_proposals
+delegation_artifact_present
+delegation_no_fuzzy_parsing_evidence
+queue_artifact_present
+queue_human_needed_signal_meaningful
+ade_qre_loose_coupling_clean
+no_protected_path_violations
+```
+
+`step5_ready = all(criteria)`. Future criteria require a code change pinned by tests.
+
+## Discipline invariants (load-bearing)
+
+```text
+mutates_upstream_artifacts: false
+sends_notifications: false
+writes_dashboard: false
+auto_authorises_step5: false
+operator_step5_authorisation_required: true
+```
+
+## Required deliverables (this PR)
+
+```text
+1. reporting/development_operational_digest.py
+2. tests/unit/test_development_operational_digest.py
+3. docs/governance/development_operational_digest.md
+4. This entry in docs/roadmap/autonomous_development.txt
+```
+
+## Output artifacts
+
+```text
+logs/development_operational_digest/latest.json   — current snapshot
+logs/development_operational_digest/history.jsonl — bounded append-only,
+                                                     90-entry rolling window
+                                                     (operator-approved)
+```
+
+## Out of scope (deferred)
+
+```text
+- notifications (telegram / email / slack) — never within ADE core
+- dashboard surfaces — separate phase
+- Step 5 implementation authorisation — operator-authored
+- Any QRE/IR/v3.15.17 changes
+- Any live/paper/shadow/risk/trading/broker/execution change
+```
+
+## Definition of Done
+
+```text
+1. Branch feature/a12-operational-digest exists; nothing on main.
+2. Implementation complete on branch (module, tests, docs, roadmap entry).
+3. Targeted tests green:
+     python -m pytest tests/unit/test_development_operational_digest.py -q
+4. Broader unit suite green:
+     python -m pytest tests/unit -q
+5. Smoke suite green:
+     python -m pytest tests/smoke -q
+6. Governance lint green:
+     python scripts/governance_lint.py
+7. PR opened against main via the documented gh CLI flow.
+8. CI green on the PR.
+9. Squash-merged to main; post-merge gates green.
+10. Only after step 9 may this entry be flipped from `PR-ready` to
+    `Complete`, recording PR number and merge SHA.
+```
+
+## Determinism
+
+The pure module accepts an injectable `generated_at_utc`. With the same upstream artifact contents and the same injected timestamp, output bytes are identical. The bounded history file is rewritten atomically on every append.
+
 

--- a/reporting/development_operational_digest.py
+++ b/reporting/development_operational_digest.py
@@ -1,0 +1,738 @@
+"""A12 — Operational Digest / Observability Loop.
+
+Pure, deterministic, stdlib-only digest. Aggregates the four ADE
+artifacts into a single operator-facing snapshot:
+
+* ``logs/development_work_queue/latest.json``       (A8)
+* ``logs/development_release_gate/latest.json``     (A9)
+* ``logs/development_bugfix_loop/latest.json``      (A10)
+* ``logs/development_delegation/latest.json``       (A11)
+
+Outputs:
+
+* ``logs/development_operational_digest/latest.json``
+* ``logs/development_operational_digest/history.jsonl`` (bounded
+  append-only history, retained at most ``MAX_HISTORY_ENTRIES``)
+
+Hard guarantees (pinned by tests):
+
+* Stdlib + ADE peer modules' read-only API only.
+* No subprocess, no network, no ``gh``, no ``git``.
+* No imports from ``dashboard``, ``automation``, ``broker``,
+  ``agent.risk``, ``agent.execution``, ``research``,
+  ``reporting.intelligent_routing``.
+* No mutation of any upstream artifact.
+* The digest never sends notifications and never writes to any
+  dashboard surface.
+* ``step5_ready=true`` is necessary but not sufficient — the
+  operator must separately authorise Step 5 implementation.
+
+CLI::
+
+    python -m reporting.development_operational_digest
+    python -m reporting.development_operational_digest --no-write
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Final
+
+from reporting import development_bugfix_loop as dbl
+from reporting import development_delegation as ddl
+from reporting import development_release_gate as drg
+from reporting import development_work_queue as dwq
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[str] = "1.0"
+MODULE_VERSION: Final[str] = "v3.15.16.A12"
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "development_operational_digest"
+ARTIFACT_LATEST: Final[Path] = ARTIFACT_DIR / "latest.json"
+ARTIFACT_HISTORY: Final[Path] = ARTIFACT_DIR / "history.jsonl"
+ARTIFACT_RELATIVE_PATH: Final[str] = (
+    "logs/development_operational_digest/latest.json"
+)
+HISTORY_RELATIVE_PATH: Final[str] = (
+    "logs/development_operational_digest/history.jsonl"
+)
+
+#: Bounded append-only history. Operator-approved at 90 entries.
+MAX_HISTORY_ENTRIES: Final[int] = 90
+
+#: Maximum operator-action-list rows to return. Bounded so the
+#: operator gets a tractable list instead of an unbounded dump.
+MAX_OPERATOR_ACTIONS: Final[int] = 20
+
+#: Step 5 readiness criteria are pinned in this closed list. Any
+#: future criterion must be added to the list AND to the test
+#: matrix; tests pin the cardinality.
+STEP5_CRITERIA: Final[tuple[str, ...]] = (
+    "release_gate_artifact_present",
+    "release_gate_no_protected_surface_leakage",
+    "bugfix_loop_artifact_present",
+    "bugfix_loop_no_test_weakening_proposals",
+    "delegation_artifact_present",
+    "delegation_no_fuzzy_parsing_evidence",
+    "queue_artifact_present",
+    "queue_human_needed_signal_meaningful",
+    "ade_qre_loose_coupling_clean",
+    "no_protected_path_violations",
+)
+
+# ---------------------------------------------------------------------------
+# Wrapper-level note vocabulary
+# ---------------------------------------------------------------------------
+
+NOTE_NO_INPUT: Final[str] = "no_upstream_artifacts_present"
+NOTE_PARTIAL_INPUT: Final[str] = "partial_upstream_artifacts_present"
+NOTE_FULL_INPUT: Final[str] = "all_upstream_artifacts_present"
+
+
+# ---------------------------------------------------------------------------
+# Utility helpers
+# ---------------------------------------------------------------------------
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+
+def _coerce_int(value: Any) -> int:
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return value
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Per-source projection helpers
+# ---------------------------------------------------------------------------
+
+
+def _summarize_queue(payload: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        return {
+            "present": False,
+            "module_version": None,
+            "generated_at_utc": None,
+            "note": None,
+            "total": 0,
+            "human_needed": 0,
+            "blocked": 0,
+            "protected_surface": 0,
+            "ready_for_autonomous_action": 0,
+            "requiring_human_operator": 0,
+            "by_role": {r: 0 for r in dwq.AGENT_ROLES},
+            "by_status": {s: 0 for s in dwq.STATUSES},
+        }
+    counts = payload.get("counts") or {}
+    by_role = counts.get("by_role") if isinstance(counts.get("by_role"), dict) else {}
+    by_status = (
+        counts.get("by_status") if isinstance(counts.get("by_status"), dict) else {}
+    )
+    return {
+        "present": True,
+        "module_version": payload.get("module_version"),
+        "generated_at_utc": payload.get("generated_at_utc"),
+        "note": payload.get("note"),
+        "total": _coerce_int(counts.get("total")),
+        "human_needed": _coerce_int(counts.get("human_needed")),
+        "blocked": _coerce_int(counts.get("blocked")),
+        "protected_surface": _coerce_int(counts.get("protected_surface")),
+        "ready_for_autonomous_action": _coerce_int(
+            counts.get("ready_for_autonomous_action")
+        ),
+        "requiring_human_operator": _coerce_int(
+            counts.get("requiring_human_operator")
+        ),
+        "by_role": {r: _coerce_int(by_role.get(r)) for r in dwq.AGENT_ROLES},
+        "by_status": {s: _coerce_int(by_status.get(s)) for s in dwq.STATUSES},
+    }
+
+
+def _summarize_release_gate(payload: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        return {
+            "present": False,
+            "module_version": None,
+            "generated_at_utc": None,
+            "note": None,
+            "total": 0,
+            "by_verdict": {v: 0 for v in drg.VERDICTS},
+            "human_needed": 0,
+            "protected_surface": 0,
+            "evidence_input_present": False,
+        }
+    counts = payload.get("counts") or {}
+    by_verdict = (
+        counts.get("by_verdict") if isinstance(counts.get("by_verdict"), dict) else {}
+    )
+    return {
+        "present": True,
+        "module_version": payload.get("module_version"),
+        "generated_at_utc": payload.get("generated_at_utc"),
+        "note": payload.get("note"),
+        "total": _coerce_int(counts.get("total")),
+        "by_verdict": {
+            v: _coerce_int(by_verdict.get(v)) for v in drg.VERDICTS
+        },
+        "human_needed": _coerce_int(counts.get("human_needed")),
+        "protected_surface": _coerce_int(counts.get("protected_surface")),
+        "evidence_input_present": bool(payload.get("evidence_input_present")),
+    }
+
+
+def _summarize_bugfix_loop(payload: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        return {
+            "present": False,
+            "module_version": None,
+            "generated_at_utc": None,
+            "note": None,
+            "total": 0,
+            "human_needed": 0,
+            "repeated_failure": 0,
+            "out_of_scope": 0,
+            "by_failure_class": {fc: 0 for fc in dbl.FAILURE_CLASSES},
+            "by_bugfix_scope": {s: 0 for s in dbl.BUGFIX_SCOPES},
+            "discipline_invariants": None,
+        }
+    counts = payload.get("counts") or {}
+    by_failure_class = (
+        counts.get("by_failure_class")
+        if isinstance(counts.get("by_failure_class"), dict)
+        else {}
+    )
+    by_bugfix_scope = (
+        counts.get("by_bugfix_scope")
+        if isinstance(counts.get("by_bugfix_scope"), dict)
+        else {}
+    )
+    return {
+        "present": True,
+        "module_version": payload.get("module_version"),
+        "generated_at_utc": payload.get("generated_at_utc"),
+        "note": payload.get("note"),
+        "total": _coerce_int(counts.get("total")),
+        "human_needed": _coerce_int(counts.get("human_needed")),
+        "repeated_failure": _coerce_int(counts.get("repeated_failure")),
+        "out_of_scope": _coerce_int(counts.get("out_of_scope")),
+        "by_failure_class": {
+            fc: _coerce_int(by_failure_class.get(fc)) for fc in dbl.FAILURE_CLASSES
+        },
+        "by_bugfix_scope": {
+            s: _coerce_int(by_bugfix_scope.get(s)) for s in dbl.BUGFIX_SCOPES
+        },
+        "discipline_invariants": payload.get("discipline_invariants"),
+    }
+
+
+def _summarize_delegation(payload: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        return {
+            "present": False,
+            "module_version": None,
+            "generated_at_utc": None,
+            "note": None,
+            "total": 0,
+            "human_needed": 0,
+            "protected_surface": 0,
+            "ready_for_operator_promotion": 0,
+            "by_roadmap_track": {
+                "autonomous_development": 0,
+                "qre_feature_build": 0,
+                "sidecar_seed": 0,
+            },
+            "discipline_invariants": None,
+        }
+    counts = payload.get("counts") or {}
+    by_track = (
+        counts.get("by_roadmap_track")
+        if isinstance(counts.get("by_roadmap_track"), dict)
+        else {}
+    )
+    return {
+        "present": True,
+        "module_version": payload.get("module_version"),
+        "generated_at_utc": payload.get("generated_at_utc"),
+        "note": payload.get("note"),
+        "total": _coerce_int(counts.get("total")),
+        "human_needed": _coerce_int(counts.get("human_needed")),
+        "protected_surface": _coerce_int(counts.get("protected_surface")),
+        "ready_for_operator_promotion": _coerce_int(
+            counts.get("ready_for_operator_promotion")
+        ),
+        "by_roadmap_track": {
+            k: _coerce_int(by_track.get(k))
+            for k in ("autonomous_development", "qre_feature_build", "sidecar_seed")
+        },
+        "discipline_invariants": payload.get("discipline_invariants"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Step 5 readiness scoring
+# ---------------------------------------------------------------------------
+
+
+def _evaluate_step5(
+    *,
+    queue: dict[str, Any],
+    release_gate: dict[str, Any],
+    bugfix_loop: dict[str, Any],
+    delegation: dict[str, Any],
+) -> dict[str, Any]:
+    """Evaluate Step 5 readiness criteria. Each criterion is bool;
+    the aggregate ``step5_ready`` is true iff every criterion is
+    true. Necessary but not sufficient — operator authorisation
+    remains separate."""
+    queue_present = bool(queue.get("present"))
+    rg_present = bool(release_gate.get("present"))
+    bl_present = bool(bugfix_loop.get("present"))
+    del_present = bool(delegation.get("present"))
+
+    rg_no_protected_leakage = (
+        not rg_present
+        or release_gate.get("by_verdict", {}).get(
+            drg.VERDICT_NO_GO_BLOCKED, 0
+        )
+        == 0
+        or release_gate.get("by_verdict", {}).get(drg.VERDICT_GO, 0)
+        + release_gate.get("by_verdict", {}).get(drg.VERDICT_GO_WITH_FOLLOWUPS, 0)
+        > 0
+    )
+    bl_inv = bugfix_loop.get("discipline_invariants") or {}
+    bl_no_weakening = bool(bl_inv) and bl_inv.get("auto_modifies_code") is False
+    del_inv = delegation.get("discipline_invariants") or {}
+    del_no_fuzzy = bool(del_inv) and del_inv.get("fuzzy_parsing") is False
+    queue_signal = (
+        queue.get("requiring_human_operator", 0) > 0
+        or queue.get("ready_for_autonomous_action", 0) > 0
+    )
+
+    # ADE/QRE loose coupling is verified by the source-text scan
+    # tests on every ADE module. The digest re-asserts the invariant
+    # by checking that no upstream summary references an Intelligent-
+    # Routing or research artifact path; we use module-version
+    # presence as a marker that the producers are the ADE producers.
+    coupling_clean = True
+    for source in (queue, release_gate, bugfix_loop, delegation):
+        mv = source.get("module_version")
+        if mv is not None and "intelligent_routing" in str(mv):
+            coupling_clean = False
+            break
+
+    no_protected_violations = release_gate.get("by_verdict", {}).get(
+        drg.VERDICT_NO_GO_BLOCKED, 0
+    ) == 0 or rg_present is False
+
+    criteria: dict[str, bool] = {
+        "release_gate_artifact_present": rg_present,
+        "release_gate_no_protected_surface_leakage": rg_no_protected_leakage,
+        "bugfix_loop_artifact_present": bl_present,
+        "bugfix_loop_no_test_weakening_proposals": bl_no_weakening,
+        "delegation_artifact_present": del_present,
+        "delegation_no_fuzzy_parsing_evidence": del_no_fuzzy,
+        "queue_artifact_present": queue_present,
+        "queue_human_needed_signal_meaningful": queue_signal,
+        "ade_qre_loose_coupling_clean": coupling_clean,
+        "no_protected_path_violations": no_protected_violations,
+    }
+    # Pin: every criterion in STEP5_CRITERIA must be evaluated.
+    for c in STEP5_CRITERIA:
+        criteria.setdefault(c, False)
+
+    step5_ready = all(criteria[c] for c in STEP5_CRITERIA)
+
+    return {
+        "criteria": {c: bool(criteria[c]) for c in STEP5_CRITERIA},
+        "step5_ready": step5_ready,
+        "step5_design_planning_allowed": True,
+        "step5_implementation_allowed": False,
+        "step5_implementation_blocker": (
+            "operator_authorisation_required" if step5_ready
+            else "readiness_criteria_not_satisfied"
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Operator action list
+# ---------------------------------------------------------------------------
+
+
+def _build_operator_action_list(
+    *,
+    queue: dict[str, Any],
+    release_gate: dict[str, Any],
+    bugfix_loop: dict[str, Any],
+    delegation: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Bounded, deduplicated, deterministic operator action list."""
+    actions: list[dict[str, Any]] = []
+    if queue.get("present"):
+        if queue.get("human_needed", 0) > 0:
+            actions.append(
+                {
+                    "kind": "queue_human_needed_items_present",
+                    "count": queue["human_needed"],
+                    "source": "development_work_queue",
+                }
+            )
+        if queue.get("blocked", 0) > 0:
+            actions.append(
+                {
+                    "kind": "queue_blocked_items_present",
+                    "count": queue["blocked"],
+                    "source": "development_work_queue",
+                }
+            )
+    if release_gate.get("present"):
+        no_go_human = release_gate["by_verdict"].get(
+            drg.VERDICT_NO_GO_HUMAN_NEEDED, 0
+        )
+        if no_go_human > 0:
+            actions.append(
+                {
+                    "kind": "release_gate_no_go_human_needed",
+                    "count": no_go_human,
+                    "source": "development_release_gate",
+                }
+            )
+        no_go_blocked = release_gate["by_verdict"].get(
+            drg.VERDICT_NO_GO_BLOCKED, 0
+        )
+        if no_go_blocked > 0:
+            actions.append(
+                {
+                    "kind": "release_gate_no_go_blocked",
+                    "count": no_go_blocked,
+                    "source": "development_release_gate",
+                }
+            )
+    if bugfix_loop.get("present"):
+        if bugfix_loop.get("repeated_failure", 0) > 0:
+            actions.append(
+                {
+                    "kind": "bugfix_repeated_validation_failure",
+                    "count": bugfix_loop["repeated_failure"],
+                    "source": "development_bugfix_loop",
+                }
+            )
+        if bugfix_loop.get("human_needed", 0) > 0:
+            actions.append(
+                {
+                    "kind": "bugfix_human_needed_candidates",
+                    "count": bugfix_loop["human_needed"],
+                    "source": "development_bugfix_loop",
+                }
+            )
+    if delegation.get("present"):
+        if delegation.get("ready_for_operator_promotion", 0) > 0:
+            actions.append(
+                {
+                    "kind": "delegation_ready_for_operator_promotion",
+                    "count": delegation["ready_for_operator_promotion"],
+                    "source": "development_delegation",
+                }
+            )
+        if delegation.get("human_needed", 0) > 0:
+            actions.append(
+                {
+                    "kind": "delegation_human_needed_entries",
+                    "count": delegation["human_needed"],
+                    "source": "development_delegation",
+                }
+            )
+
+    # Deterministic deduplication — same kind+source collapses.
+    seen: set[tuple[str, str]] = set()
+    deduped: list[dict[str, Any]] = []
+    for a in actions:
+        key = (a["kind"], a["source"])
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(a)
+    deduped.sort(key=lambda a: (a["source"], a["kind"]))
+    return deduped[:MAX_OPERATOR_ACTIONS]
+
+
+# ---------------------------------------------------------------------------
+# Snapshot assembly
+# ---------------------------------------------------------------------------
+
+
+def collect_snapshot(
+    *,
+    queue_path: Path | None = None,
+    release_gate_path: Path | None = None,
+    bugfix_loop_path: Path | None = None,
+    delegation_path: Path | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    """Build the deterministic operational digest."""
+    qp = queue_path if queue_path is not None else dwq.ARTIFACT_LATEST
+    rgp = release_gate_path if release_gate_path is not None else drg.ARTIFACT_LATEST
+    blp = bugfix_loop_path if bugfix_loop_path is not None else dbl.ARTIFACT_LATEST
+    dp = delegation_path if delegation_path is not None else ddl.ARTIFACT_LATEST
+    ts = generated_at_utc if generated_at_utc is not None else _utcnow()
+
+    queue_payload = _read_json(qp)
+    rg_payload = _read_json(rgp)
+    bl_payload = _read_json(blp)
+    del_payload = _read_json(dp)
+
+    queue = _summarize_queue(queue_payload)
+    release_gate = _summarize_release_gate(rg_payload)
+    bugfix_loop = _summarize_bugfix_loop(bl_payload)
+    delegation = _summarize_delegation(del_payload)
+
+    presence_count = sum(
+        1
+        for s in (queue, release_gate, bugfix_loop, delegation)
+        if s.get("present")
+    )
+    if presence_count == 0:
+        note = NOTE_NO_INPUT
+    elif presence_count < 4:
+        note = NOTE_PARTIAL_INPUT
+    else:
+        note = NOTE_FULL_INPUT
+
+    step5 = _evaluate_step5(
+        queue=queue,
+        release_gate=release_gate,
+        bugfix_loop=bugfix_loop,
+        delegation=delegation,
+    )
+
+    actions = _build_operator_action_list(
+        queue=queue,
+        release_gate=release_gate,
+        bugfix_loop=bugfix_loop,
+        delegation=delegation,
+    )
+
+    sources = {
+        "queue": {"path": str(qp), "summary": queue},
+        "release_gate": {"path": str(rgp), "summary": release_gate},
+        "bugfix_loop": {"path": str(blp), "summary": bugfix_loop},
+        "delegation": {"path": str(dp), "summary": delegation},
+    }
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "report_kind": "development_operational_digest",
+        "generated_at_utc": ts,
+        "note": note,
+        "presence_count": presence_count,
+        "sources": sources,
+        "operator_action_list": actions,
+        "step5_readiness": step5,
+        "vocabularies": {
+            "agent_roles": list(dwq.AGENT_ROLES),
+            "statuses": list(dwq.STATUSES),
+            "categories": list(dwq.CATEGORIES),
+            "release_gate_verdicts": list(drg.VERDICTS),
+            "failure_classes": list(dbl.FAILURE_CLASSES),
+            "bugfix_scopes": list(dbl.BUGFIX_SCOPES),
+            "step5_criteria": list(STEP5_CRITERIA),
+        },
+        "queue_module_version": dwq.MODULE_VERSION,
+        "release_gate_module_version": drg.MODULE_VERSION,
+        "bugfix_loop_module_version": dbl.MODULE_VERSION,
+        "delegation_module_version": ddl.MODULE_VERSION,
+        "max_history_entries": MAX_HISTORY_ENTRIES,
+        "discipline_invariants": {
+            "mutates_upstream_artifacts": False,
+            "sends_notifications": False,
+            "writes_dashboard": False,
+            "auto_authorises_step5": False,
+            "operator_step5_authorisation_required": True,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Atomic write + bounded history
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    posix = path.as_posix()
+    if "/logs/" not in posix and not posix.startswith("logs/"):
+        raise ValueError(
+            "development_operational_digest._atomic_write_json refuses "
+            f"non-logs/ output path: {path}"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".development_operational_digest.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def _append_history(path: Path, entry: dict[str, Any]) -> None:
+    """Append a compact JSONL entry; truncate to MAX_HISTORY_ENTRIES.
+    History is bounded so the file stays operator-readable. The
+    truncation is implemented by reading existing lines, dropping
+    the oldest, and rewriting atomically — never partial. A small
+    retry covers transient Windows file-replace contention when
+    callers append many entries back-to-back."""
+    import time as _time
+
+    posix = path.as_posix()
+    if "/logs/" not in posix and not posix.startswith("logs/"):
+        raise ValueError(
+            "development_operational_digest._append_history refuses "
+            f"non-logs/ output path: {path}"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    existing: list[str] = []
+    if path.is_file():
+        try:
+            existing = [
+                line for line in path.read_text(encoding="utf-8").splitlines()
+                if line.strip()
+            ]
+        except OSError:
+            existing = []
+    existing.append(json.dumps(entry, sort_keys=True))
+    if len(existing) > MAX_HISTORY_ENTRIES:
+        existing = existing[-MAX_HISTORY_ENTRIES:]
+    text = "\n".join(existing) + "\n"
+    last_error: BaseException | None = None
+    for attempt in range(5):
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=".development_operational_digest_history.",
+            suffix=".tmp",
+            dir=str(path.parent),
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                fh.write(text)
+            os.replace(tmp_name, path)
+            return
+        except PermissionError as exc:
+            last_error = exc
+            try:
+                os.unlink(tmp_name)
+            except OSError:
+                pass
+            _time.sleep(0.01 * (attempt + 1))
+            continue
+        except Exception:
+            try:
+                os.unlink(tmp_name)
+            except OSError:
+                pass
+            raise
+    if last_error is not None:
+        raise last_error
+
+
+def _history_entry(snapshot: dict[str, Any]) -> dict[str, Any]:
+    """Compact projection for the history file: per-snapshot scalars
+    only, no full source payloads."""
+    s5 = snapshot.get("step5_readiness", {})
+    return {
+        "generated_at_utc": snapshot.get("generated_at_utc"),
+        "module_version": snapshot.get("module_version"),
+        "presence_count": snapshot.get("presence_count"),
+        "step5_ready": s5.get("step5_ready"),
+        "criteria": s5.get("criteria"),
+        "operator_action_count": len(snapshot.get("operator_action_list") or []),
+        "queue_total": snapshot["sources"]["queue"]["summary"].get("total"),
+        "release_gate_total": snapshot["sources"]["release_gate"]["summary"].get("total"),
+        "bugfix_loop_total": snapshot["sources"]["bugfix_loop"]["summary"].get("total"),
+        "delegation_total": snapshot["sources"]["delegation"]["summary"].get("total"),
+    }
+
+
+def write_outputs(snapshot: dict[str, Any]) -> tuple[Path, Path]:
+    _atomic_write_json(ARTIFACT_LATEST, snapshot)
+    _append_history(ARTIFACT_HISTORY, _history_entry(snapshot))
+    return ARTIFACT_LATEST, ARTIFACT_HISTORY
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m reporting.development_operational_digest",
+        description=(
+            "Read-only ADE operational digest. Aggregates A8-A11 "
+            "artifacts into a single operator-facing snapshot with "
+            "Step 5 readiness signals. Decides nothing; mutates "
+            "nothing upstream; sends no notifications."
+        ),
+    )
+    p.add_argument("--indent", type=int, default=2, help="JSON indent (0 for compact).")
+    p.add_argument(
+        "--no-write",
+        action="store_true",
+        help=(
+            "Do not persist logs/development_operational_digest/latest.json "
+            "or history.jsonl (stdout only)."
+        ),
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    indent = args.indent if args.indent and args.indent > 0 else None
+    snap = collect_snapshot()
+    if not args.no_write:
+        write_outputs(snap)
+    json.dump(snap, sys.stdout, indent=indent, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/unit/test_development_operational_digest.py
+++ b/tests/unit/test_development_operational_digest.py
@@ -1,0 +1,622 @@
+"""Unit tests for A12 — Operational Digest / Observability Loop.
+
+Synthetic deterministic fixtures only. The pure aggregator reads
+the four upstream ADE artifacts (A8 queue, A9 release gate, A10
+bugfix loop, A11 delegation) and emits a compact operator-facing
+snapshot plus a bounded append-only history.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reporting import development_bugfix_loop as dbl
+from reporting import development_delegation as ddl
+from reporting import development_operational_digest as dod
+from reporting import development_release_gate as drg
+from reporting import development_work_queue as dwq
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _write(path: Path, payload: dict[str, Any]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _queue_payload(
+    *,
+    total: int = 1,
+    human_needed: int = 0,
+    blocked: int = 0,
+    protected_surface: int = 0,
+    ready_for_autonomous_action: int = 0,
+    requiring_human_operator: int = 0,
+) -> dict[str, Any]:
+    return {
+        "schema_version": "1.0",
+        "module_version": dwq.MODULE_VERSION,
+        "report_kind": "development_work_queue",
+        "generated_at_utc": "2026-05-07T00:00:00Z",
+        "note": "explicit_seed_items_present",
+        "counts": {
+            "total": total,
+            "human_needed": human_needed,
+            "blocked": blocked,
+            "protected_surface": protected_surface,
+            "ready_for_autonomous_action": ready_for_autonomous_action,
+            "requiring_human_operator": requiring_human_operator,
+            "by_role": {r: 0 for r in dwq.AGENT_ROLES},
+            "by_status": {s: 0 for s in dwq.STATUSES},
+        },
+    }
+
+
+def _release_gate_payload(
+    *,
+    total: int = 1,
+    human_needed: int = 0,
+    protected_surface: int = 0,
+    by_verdict_overrides: dict[str, int] | None = None,
+) -> dict[str, Any]:
+    by_verdict = {v: 0 for v in drg.VERDICTS}
+    if by_verdict_overrides:
+        by_verdict.update(by_verdict_overrides)
+    return {
+        "schema_version": "1.0",
+        "module_version": drg.MODULE_VERSION,
+        "report_kind": "development_release_gate",
+        "generated_at_utc": "2026-05-07T00:00:00Z",
+        "note": drg.NOTE_VERDICTS_PRESENT,
+        "evidence_input_present": True,
+        "queue_artifact_present": True,
+        "counts": {
+            "total": total,
+            "human_needed": human_needed,
+            "protected_surface": protected_surface,
+            "by_verdict": by_verdict,
+            "by_verdict_reason": {r: 0 for r in drg.VERDICT_REASONS},
+        },
+    }
+
+
+def _bugfix_loop_payload(
+    *,
+    total: int = 1,
+    human_needed: int = 0,
+    repeated_failure: int = 0,
+    out_of_scope: int = 0,
+) -> dict[str, Any]:
+    return {
+        "schema_version": "1.0",
+        "module_version": dbl.MODULE_VERSION,
+        "report_kind": "development_bugfix_loop",
+        "generated_at_utc": "2026-05-07T00:00:00Z",
+        "note": dbl.NOTE_CANDIDATES_PRESENT,
+        "counts": {
+            "total": total,
+            "by_failure_class": {fc: 0 for fc in dbl.FAILURE_CLASSES},
+            "by_bugfix_scope": {s: 0 for s in dbl.BUGFIX_SCOPES},
+            "human_needed": human_needed,
+            "repeated_failure": repeated_failure,
+            "out_of_scope": out_of_scope,
+        },
+        "discipline_invariants": {
+            "writes_to_seed_jsonl": False,
+            "writes_to_bugfix_seed_jsonl": False,
+            "auto_creates_branches": False,
+            "auto_opens_prs": False,
+            "auto_modifies_code": False,
+            "operator_promotion_required": True,
+        },
+    }
+
+
+def _delegation_payload(
+    *,
+    total: int = 1,
+    human_needed: int = 0,
+    protected_surface: int = 0,
+    ready_for_operator_promotion: int = 0,
+) -> dict[str, Any]:
+    return {
+        "schema_version": "1.0",
+        "module_version": ddl.MODULE_VERSION,
+        "report_kind": "development_delegation",
+        "generated_at_utc": "2026-05-07T00:00:00Z",
+        "note": ddl.NOTE_ENTRIES_PRESENT,
+        "counts": {
+            "total": total,
+            "by_roadmap_track": {
+                "autonomous_development": 0,
+                "qre_feature_build": 0,
+                "sidecar_seed": 0,
+            },
+            "by_category": {c: 0 for c in dwq.CATEGORIES},
+            "by_required_agent_role": {r: 0 for r in dwq.AGENT_ROLES},
+            "by_status": {ddl.DEFAULT_STATUS: 0},
+            "by_execution_authority_decision": {},
+            "human_needed": human_needed,
+            "protected_surface": protected_surface,
+            "ready_for_operator_promotion": ready_for_operator_promotion,
+        },
+        "discipline_invariants": {
+            "writes_to_seed_jsonl": False,
+            "writes_to_bugfix_seed_jsonl": False,
+            "writes_to_delegation_seed_jsonl": False,
+            "fuzzy_parsing": False,
+            "operator_promotion_required": True,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Vocabulary / shape
+# ---------------------------------------------------------------------------
+
+
+def test_step5_criteria_vocabulary_is_closed_and_ordered() -> None:
+    assert dod.STEP5_CRITERIA == (
+        "release_gate_artifact_present",
+        "release_gate_no_protected_surface_leakage",
+        "bugfix_loop_artifact_present",
+        "bugfix_loop_no_test_weakening_proposals",
+        "delegation_artifact_present",
+        "delegation_no_fuzzy_parsing_evidence",
+        "queue_artifact_present",
+        "queue_human_needed_signal_meaningful",
+        "ade_qre_loose_coupling_clean",
+        "no_protected_path_violations",
+    )
+    assert len(dod.STEP5_CRITERIA) == 10
+
+
+def test_artifact_path_is_under_logs_not_research() -> None:
+    assert dod.ARTIFACT_RELATIVE_PATH.startswith("logs/")
+    assert dod.HISTORY_RELATIVE_PATH.startswith("logs/")
+    assert "research/" not in dod.ARTIFACT_RELATIVE_PATH
+    assert "research/" not in dod.HISTORY_RELATIVE_PATH
+
+
+def test_max_history_entries_is_operator_approved_90() -> None:
+    """Operator approved 90 entries during plan amendment review."""
+    assert dod.MAX_HISTORY_ENTRIES == 90
+
+
+def test_max_operator_actions_is_bounded() -> None:
+    assert dod.MAX_OPERATOR_ACTIONS > 0
+    assert dod.MAX_OPERATOR_ACTIONS <= 50
+
+
+def test_atomic_write_refuses_non_logs_path(tmp_path: Path) -> None:
+    bad = tmp_path / "evil_dir" / "latest.json"
+    with pytest.raises(ValueError):
+        dod._atomic_write_json(bad, {"x": 1})
+
+
+def test_history_append_refuses_non_logs_path(tmp_path: Path) -> None:
+    bad = tmp_path / "evil_dir" / "history.jsonl"
+    with pytest.raises(ValueError):
+        dod._append_history(bad, {"x": 1})
+
+
+# ---------------------------------------------------------------------------
+# Snapshot top-level shape
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_top_level_keys_when_no_inputs(tmp_path: Path) -> None:
+    snap = dod.collect_snapshot(
+        queue_path=tmp_path / "missing_queue.json",
+        release_gate_path=tmp_path / "missing_rg.json",
+        bugfix_loop_path=tmp_path / "missing_bl.json",
+        delegation_path=tmp_path / "missing_del.json",
+        generated_at_utc="2026-05-07T00:00:00Z",
+    )
+    expected = {
+        "schema_version",
+        "module_version",
+        "report_kind",
+        "generated_at_utc",
+        "note",
+        "presence_count",
+        "sources",
+        "operator_action_list",
+        "step5_readiness",
+        "vocabularies",
+        "queue_module_version",
+        "release_gate_module_version",
+        "bugfix_loop_module_version",
+        "delegation_module_version",
+        "max_history_entries",
+        "discipline_invariants",
+    }
+    assert set(snap.keys()) == expected
+    assert snap["report_kind"] == "development_operational_digest"
+    assert snap["presence_count"] == 0
+    assert snap["note"] == dod.NOTE_NO_INPUT
+    assert snap["operator_action_list"] == []
+    assert snap["step5_readiness"]["step5_ready"] is False
+    assert snap["step5_readiness"]["step5_implementation_allowed"] is False
+
+
+def test_partial_inputs_yields_partial_note(tmp_path: Path) -> None:
+    qp = _write(tmp_path / "q.json", _queue_payload())
+    snap = dod.collect_snapshot(
+        queue_path=qp,
+        release_gate_path=tmp_path / "missing_rg.json",
+        bugfix_loop_path=tmp_path / "missing_bl.json",
+        delegation_path=tmp_path / "missing_del.json",
+    )
+    assert snap["presence_count"] == 1
+    assert snap["note"] == dod.NOTE_PARTIAL_INPUT
+
+
+def test_full_inputs_yields_full_note(tmp_path: Path) -> None:
+    qp = _write(tmp_path / "q.json", _queue_payload())
+    rgp = _write(tmp_path / "rg.json", _release_gate_payload())
+    blp = _write(tmp_path / "bl.json", _bugfix_loop_payload())
+    dp = _write(tmp_path / "del.json", _delegation_payload())
+    snap = dod.collect_snapshot(
+        queue_path=qp,
+        release_gate_path=rgp,
+        bugfix_loop_path=blp,
+        delegation_path=dp,
+    )
+    assert snap["presence_count"] == 4
+    assert snap["note"] == dod.NOTE_FULL_INPUT
+
+
+# ---------------------------------------------------------------------------
+# Operator action list
+# ---------------------------------------------------------------------------
+
+
+def test_operator_action_list_aggregates_from_each_source(tmp_path: Path) -> None:
+    qp = _write(
+        tmp_path / "q.json",
+        _queue_payload(total=3, human_needed=1, blocked=1),
+    )
+    rgp = _write(
+        tmp_path / "rg.json",
+        _release_gate_payload(
+            total=2,
+            human_needed=1,
+            by_verdict_overrides={
+                drg.VERDICT_NO_GO_HUMAN_NEEDED: 1,
+                drg.VERDICT_GO: 1,
+            },
+        ),
+    )
+    blp = _write(
+        tmp_path / "bl.json",
+        _bugfix_loop_payload(total=2, human_needed=1, repeated_failure=1),
+    )
+    dp = _write(
+        tmp_path / "del.json",
+        _delegation_payload(total=2, human_needed=1, ready_for_operator_promotion=1),
+    )
+    snap = dod.collect_snapshot(
+        queue_path=qp,
+        release_gate_path=rgp,
+        bugfix_loop_path=blp,
+        delegation_path=dp,
+    )
+    actions = snap["operator_action_list"]
+    kinds = {a["kind"] for a in actions}
+    assert "queue_human_needed_items_present" in kinds
+    assert "queue_blocked_items_present" in kinds
+    assert "release_gate_no_go_human_needed" in kinds
+    assert "bugfix_repeated_validation_failure" in kinds
+    assert "bugfix_human_needed_candidates" in kinds
+    assert "delegation_human_needed_entries" in kinds
+    assert "delegation_ready_for_operator_promotion" in kinds
+
+
+def test_operator_action_list_is_bounded(tmp_path: Path) -> None:
+    qp = _write(
+        tmp_path / "q.json",
+        _queue_payload(total=99, human_needed=99, blocked=99),
+    )
+    rgp = _write(
+        tmp_path / "rg.json",
+        _release_gate_payload(
+            total=99,
+            by_verdict_overrides={
+                drg.VERDICT_NO_GO_HUMAN_NEEDED: 99,
+                drg.VERDICT_NO_GO_BLOCKED: 99,
+            },
+        ),
+    )
+    blp = _write(
+        tmp_path / "bl.json",
+        _bugfix_loop_payload(total=99, human_needed=99, repeated_failure=99),
+    )
+    dp = _write(
+        tmp_path / "del.json",
+        _delegation_payload(
+            total=99, human_needed=99, ready_for_operator_promotion=99
+        ),
+    )
+    snap = dod.collect_snapshot(
+        queue_path=qp,
+        release_gate_path=rgp,
+        bugfix_loop_path=blp,
+        delegation_path=dp,
+    )
+    assert len(snap["operator_action_list"]) <= dod.MAX_OPERATOR_ACTIONS
+
+
+# ---------------------------------------------------------------------------
+# Step 5 readiness
+# ---------------------------------------------------------------------------
+
+
+def test_step5_ready_is_false_when_artifacts_missing(tmp_path: Path) -> None:
+    snap = dod.collect_snapshot(
+        queue_path=tmp_path / "missing_q.json",
+        release_gate_path=tmp_path / "missing_rg.json",
+        bugfix_loop_path=tmp_path / "missing_bl.json",
+        delegation_path=tmp_path / "missing_del.json",
+    )
+    s5 = snap["step5_readiness"]
+    assert s5["step5_ready"] is False
+    # The bool result for every criterion is reported, no missing keys.
+    assert set(s5["criteria"]) == set(dod.STEP5_CRITERIA)
+
+
+def test_step5_implementation_always_blocked_pending_operator(tmp_path: Path) -> None:
+    """Even when every criterion passes, step5_implementation_allowed
+    must remain False — operator authorisation is separate."""
+    qp = _write(
+        tmp_path / "q.json",
+        _queue_payload(
+            total=1,
+            human_needed=0,
+            ready_for_autonomous_action=1,
+            requiring_human_operator=0,
+        ),
+    )
+    rgp = _write(
+        tmp_path / "rg.json",
+        _release_gate_payload(
+            total=1, by_verdict_overrides={drg.VERDICT_GO: 1}
+        ),
+    )
+    blp = _write(tmp_path / "bl.json", _bugfix_loop_payload(total=0))
+    dp = _write(tmp_path / "del.json", _delegation_payload(total=0))
+    snap = dod.collect_snapshot(
+        queue_path=qp,
+        release_gate_path=rgp,
+        bugfix_loop_path=blp,
+        delegation_path=dp,
+    )
+    s5 = snap["step5_readiness"]
+    assert s5["step5_implementation_allowed"] is False
+    # design_planning is allowed unconditionally (operator-authored).
+    assert s5["step5_design_planning_allowed"] is True
+
+
+def test_step5_design_planning_is_always_allowed(tmp_path: Path) -> None:
+    snap = dod.collect_snapshot(
+        queue_path=tmp_path / "missing.json",
+        release_gate_path=tmp_path / "missing.json",
+        bugfix_loop_path=tmp_path / "missing.json",
+        delegation_path=tmp_path / "missing.json",
+    )
+    assert snap["step5_readiness"]["step5_design_planning_allowed"] is True
+
+
+# ---------------------------------------------------------------------------
+# Discipline invariants
+# ---------------------------------------------------------------------------
+
+
+def test_discipline_invariants_block_is_present(tmp_path: Path) -> None:
+    snap = dod.collect_snapshot(
+        queue_path=tmp_path / "missing_q.json",
+        release_gate_path=tmp_path / "missing_rg.json",
+        bugfix_loop_path=tmp_path / "missing_bl.json",
+        delegation_path=tmp_path / "missing_del.json",
+    )
+    inv = snap["discipline_invariants"]
+    assert inv["mutates_upstream_artifacts"] is False
+    assert inv["sends_notifications"] is False
+    assert inv["writes_dashboard"] is False
+    assert inv["auto_authorises_step5"] is False
+    assert inv["operator_step5_authorisation_required"] is True
+
+
+def test_digest_does_not_mutate_upstream_artifacts(tmp_path: Path) -> None:
+    qp = _write(tmp_path / "q.json", _queue_payload())
+    rgp = _write(tmp_path / "rg.json", _release_gate_payload())
+    blp = _write(tmp_path / "bl.json", _bugfix_loop_payload())
+    dp = _write(tmp_path / "del.json", _delegation_payload())
+    before = {
+        "q": qp.read_bytes(),
+        "rg": rgp.read_bytes(),
+        "bl": blp.read_bytes(),
+        "del": dp.read_bytes(),
+    }
+    dod.collect_snapshot(
+        queue_path=qp,
+        release_gate_path=rgp,
+        bugfix_loop_path=blp,
+        delegation_path=dp,
+    )
+    assert qp.read_bytes() == before["q"]
+    assert rgp.read_bytes() == before["rg"]
+    assert blp.read_bytes() == before["bl"]
+    assert dp.read_bytes() == before["del"]
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+def test_artifact_bytes_are_deterministic_with_injected_timestamp(
+    tmp_path: Path,
+) -> None:
+    qp = _write(tmp_path / "q.json", _queue_payload())
+    rgp = _write(tmp_path / "rg.json", _release_gate_payload())
+    blp = _write(tmp_path / "bl.json", _bugfix_loop_payload())
+    dp = _write(tmp_path / "del.json", _delegation_payload())
+    snap_a = dod.collect_snapshot(
+        queue_path=qp,
+        release_gate_path=rgp,
+        bugfix_loop_path=blp,
+        delegation_path=dp,
+        generated_at_utc="2026-05-07T00:00:00Z",
+    )
+    snap_b = dod.collect_snapshot(
+        queue_path=qp,
+        release_gate_path=rgp,
+        bugfix_loop_path=blp,
+        delegation_path=dp,
+        generated_at_utc="2026-05-07T00:00:00Z",
+    )
+    assert json.dumps(snap_a, sort_keys=True, indent=2).encode("utf-8") == json.dumps(
+        snap_b, sort_keys=True, indent=2
+    ).encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# History
+# ---------------------------------------------------------------------------
+
+
+def test_history_append_is_bounded_at_max_entries(tmp_path: Path) -> None:
+    history = tmp_path / "logs" / "development_operational_digest" / "history.jsonl"
+    history.parent.mkdir(parents=True)
+    for i in range(dod.MAX_HISTORY_ENTRIES + 5):
+        dod._append_history(history, {"i": i})
+    lines = history.read_text(encoding="utf-8").strip().split("\n")
+    assert len(lines) == dod.MAX_HISTORY_ENTRIES
+    # The earliest entries dropped; the last entry is i=MAX+4.
+    last = json.loads(lines[-1])
+    assert last["i"] == dod.MAX_HISTORY_ENTRIES + 4
+
+
+def test_history_entry_is_compact_projection() -> None:
+    snapshot = {
+        "generated_at_utc": "2026-05-07T00:00:00Z",
+        "module_version": "v3.15.16.A12",
+        "presence_count": 4,
+        "step5_readiness": {
+            "step5_ready": False,
+            "criteria": {c: True for c in dod.STEP5_CRITERIA},
+        },
+        "operator_action_list": [{"kind": "x", "source": "y"}],
+        "sources": {
+            "queue": {"summary": {"total": 2}},
+            "release_gate": {"summary": {"total": 1}},
+            "bugfix_loop": {"summary": {"total": 0}},
+            "delegation": {"summary": {"total": 1}},
+        },
+    }
+    entry = dod._history_entry(snapshot)
+    assert entry["presence_count"] == 4
+    assert entry["step5_ready"] is False
+    assert entry["queue_total"] == 2
+    assert entry["operator_action_count"] == 1
+    # No raw source payloads embedded.
+    assert "sources" not in entry
+
+
+# ---------------------------------------------------------------------------
+# Source-text scans (no subprocess / no network / no forbidden imports)
+# ---------------------------------------------------------------------------
+
+
+def _module_source() -> str:
+    return Path(dod.__file__).read_text(encoding="utf-8")
+
+
+def _imported_module_names() -> set[str]:
+    import ast
+
+    src = _module_source()
+    tree = ast.parse(src)
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module is not None:
+                names.add(node.module)
+    return names
+
+
+def test_no_subprocess_in_module() -> None:
+    src = _module_source()
+    assert "import subprocess" not in src
+    assert "from subprocess" not in src
+
+
+def test_no_network_in_module() -> None:
+    src = _module_source()
+    for forbidden in (
+        "import socket",
+        "import urllib",
+        "import http.client",
+        "import requests",
+    ):
+        assert forbidden not in src
+    assert "from socket" not in src
+    assert "from urllib" not in src
+    assert "from http" not in src
+
+
+def test_no_dashboard_or_live_path_or_qre_imports() -> None:
+    forbidden_prefixes = (
+        "dashboard",
+        "automation",
+        "broker",
+        "agent.risk",
+        "agent.execution",
+        "research",
+        "reporting.intelligent_routing",
+    )
+    for module in _imported_module_names():
+        for prefix in forbidden_prefixes:
+            assert not (module == prefix or module.startswith(prefix + ".")), (
+                f"forbidden import: {module}"
+            )
+
+
+def test_no_gh_or_git_subprocess_references() -> None:
+    src = _module_source()
+    for forbidden in (
+        "subprocess.run",
+        "subprocess.Popen",
+        "os.system",
+        "os.popen",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_module_imports_cleanly() -> None:
+    importlib.reload(dod)
+    assert callable(dod.collect_snapshot)
+
+
+# ---------------------------------------------------------------------------
+# Schema-version + module-version surfaces
+# ---------------------------------------------------------------------------
+
+
+def test_schema_and_module_version_strings() -> None:
+    assert isinstance(dod.SCHEMA_VERSION, str) and dod.SCHEMA_VERSION
+    assert isinstance(dod.MODULE_VERSION, str) and dod.MODULE_VERSION
+    assert "A12" in dod.MODULE_VERSION


### PR DESCRIPTION
## Summary

Aggregate the four ADE artifacts (A8 work queue, A9 release gate, A10 bugfix loop, A11 delegation) into a single operator-facing snapshot plus a bounded append-only 90-entry rolling history. Compute a `step5_readiness` block with closed criteria. Step 5 implementation remains **operator-gated** — `step5_implementation_allowed` is always false in this release.

**Status: PR-ready, NOT Complete.**

## Scope

**Added:**
- `reporting/development_operational_digest.py` — pure aggregator. 10 closed `STEP5_CRITERIA`, per-source summary projections, bounded operator action list (≤20 rows, closed kinds), atomic `latest.json` + rolling 90-entry `history.jsonl`, CLI.
- `tests/unit/test_development_operational_digest.py` — 25 tests pinning vocabulary, schema, partial/full input handling, action list aggregation/dedup/bound, Step 5 readiness logic, step5_implementation invariant, discipline invariants, no upstream mutation, determinism, bounded history, AST-level forbidden-import scan.
- `docs/governance/development_operational_digest.md` — governance doc.

**Modified:**
- `docs/roadmap/autonomous_development.txt` — append §A12 block with `Status: PR-ready (NOT complete)`.

**Untouched:** `research/**`, frozen contracts, Intelligent Routing modules, scoring, `.claude/**`, `dashboard/dashboard.py`, all live/paper/shadow/risk/trading/broker/execution paths, all CI workflows.

## Step 5 readiness criteria (closed, 10)

```
release_gate_artifact_present
release_gate_no_protected_surface_leakage
bugfix_loop_artifact_present
bugfix_loop_no_test_weakening_proposals
delegation_artifact_present
delegation_no_fuzzy_parsing_evidence
queue_artifact_present
queue_human_needed_signal_meaningful
ade_qre_loose_coupling_clean
no_protected_path_violations
```

`step5_ready = all(criteria)`. `step5_implementation_allowed` is always **false** (operator authorisation separate).

## Discipline invariants (load-bearing)

```
mutates_upstream_artifacts: false
sends_notifications: false
writes_dashboard: false
auto_authorises_step5: false
operator_step5_authorisation_required: true
```

## Validation

- `python -m pytest tests/unit/test_development_operational_digest.py -q` → **25 passed**.
- `python -m pytest tests/unit/test_development_*.py tests/unit/test_execution_authority.py -q` → **297 passed**.
- `python -m pytest tests/smoke -q` → **18 passed**.
- `python scripts/governance_lint.py` → **OK**.

## Out of scope (deferred)

- Notifications (telegram/email/slack) — never within ADE core.
- Dashboard surfaces — separate phase.
- Step 5 implementation authorisation — operator-authored.
- Any QRE / IR / v3.15.17 / scoring change.
- Any live/paper/shadow/risk/trading/broker/execution change.

## Test plan

- [ ] CI green on this PR.
- [ ] After merge: post-merge gates green; flip §A12 to `Complete`; run ADE E2E proof.