### PR TITLE
test(A13): failure-mode coverage backfill for ADE E2E proof harness

### DIFF
--- a/tests/unit/test_development_e2e_proof.py
+++ b/tests/unit/test_development_e2e_proof.py
@@ -25,6 +25,7 @@ from typing import Any
 import pytest
 
 from reporting import development_e2e_proof as e2e
+from reporting import execution_authority as ea
 
 
 # ---------------------------------------------------------------------------
@@ -310,3 +311,467 @@ def test_final_operator_summary_describes_passed_run(tmp_path: Path) -> None:
     summary: str = snap["final_operator_summary"]
     assert "Step 5 design planning is allowed" in summary
     assert "Step 5 implementation requires separate operator" in summary
+
+
+# ---------------------------------------------------------------------------
+# Failure-mode coverage (post-A13 hardening)
+#
+# These tests exercise the closed failure / blocked branches inside
+# ``reporting.development_e2e_proof._run_lifecycle`` that the
+# happy-path tests above do not reach. Each test injects exactly one
+# fault by monkeypatching a public seam (``_build_synthetic_*`` fixture
+# helper, the imported peer module's ``MODULE_VERSION`` global, or the
+# ``SIMULATION_TARGET_PATH`` constant) and asserts that the proof
+# snapshot reports the expected blocked / failed state with the
+# documented closed-vocabulary reason.
+#
+# No production code is modified by any of these tests.
+# ---------------------------------------------------------------------------
+
+
+def _step_by_name(snap: dict[str, Any], name: str) -> dict[str, Any]:
+    """Return the flow-step entry for ``name``. Raises KeyError if
+    the harness did not emit that step."""
+    for s in snap["flow_steps"]:
+        if s["step"] == name:
+            return s
+    raise KeyError(name)
+
+
+# ---------------------------------------------------------------------------
+# 1. Protected path violation blocks the proof (queue surface route)
+# ---------------------------------------------------------------------------
+
+
+def test_protected_surface_queue_item_blocks_proof(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A queue item that declares ``protected_surface=True`` must
+    cause execution_readiness to emit ``status='blocked'`` with
+    blocker_reason ``simulation_target_protected``, append to
+    ``protected_path_violations``, drive ``proof_status`` to
+    ``'blocked'``, and clear ``autonomous_development_possible``."""
+    original = e2e._build_synthetic_queue_seed_item
+
+    def with_protected_surface() -> dict[str, Any]:
+        item = original()
+        item["protected_surface"] = True
+        return item
+
+    monkeypatch.setattr(
+        e2e, "_build_synthetic_queue_seed_item", with_protected_surface
+    )
+    snap = e2e.collect_snapshot(
+        scratch_dir=tmp_path / "scratch",
+        generated_at_utc="2026-05-08T00:00:00Z",
+    )
+
+    assert snap["proof_status"] == "blocked"
+    assert snap["protected_path_violations"], snap["protected_path_violations"]
+    assert snap["autonomous_development_possible"] is False
+    assert snap["step5_implementation_allowed"] is False
+    assert snap["step5_design_planning_allowed"] is True
+
+    readiness = _step_by_name(snap, "execution_readiness")
+    assert readiness["status"] == "blocked"
+    assert readiness["blocker_reason"] == "simulation_target_protected"
+    # Closed vocabulary integrity is preserved.
+    assert readiness["blocker_reason"] in e2e.BLOCKER_REASONS
+    assert readiness["status"] in e2e.STEP_STATUSES
+
+
+# ---------------------------------------------------------------------------
+# 2. Protected simulation target (PERMANENTLY_DENIED) blocks the proof
+# ---------------------------------------------------------------------------
+
+
+def test_permanently_denied_simulation_target_blocks_proof(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """If the bounded-execution target classifies as
+    PERMANENTLY_DENIED via ``execution_authority.classify`` (e.g. a
+    ``live_path``), the bounded-execution step must record
+    ``status='blocked'`` with the closed
+    ``simulation_target_protected`` blocker_reason, append to
+    ``protected_path_violations``, and drive ``proof_status`` to
+    ``'blocked'``."""
+    monkeypatch.setattr(
+        e2e, "SIMULATION_TARGET_PATH", "automation/live_gate.py"
+    )
+    snap = e2e.collect_snapshot(
+        scratch_dir=tmp_path / "scratch",
+        generated_at_utc="2026-05-08T00:00:00Z",
+    )
+
+    assert snap["proof_status"] == "blocked"
+    assert "automation/live_gate.py" in snap["protected_path_violations"]
+    assert snap["autonomous_development_possible"] is False
+    # Discipline invariants must remain pinned even under failure.
+    assert snap["discipline_invariants"]["actually_modifies_target"] is False
+    assert snap["step5_implementation_allowed"] is False
+
+    sim = _step_by_name(snap, "bounded_execution_or_simulation")
+    assert sim["status"] == "blocked"
+    assert sim["blocker_reason"] == "simulation_target_protected"
+    assert sim["evidence"]["authority_decision"] == ea.DECISION_PERMANENTLY_DENIED
+    assert sim["evidence"]["would_modify_target_path"] == "automation/live_gate.py"
+    # The synthetic target file must NOT exist on disk after the proof.
+    assert not (
+        tmp_path / "scratch" / "automation/live_gate.py"
+    ).exists()
+
+
+def test_needs_human_simulation_target_blocks_proof(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """If the bounded-execution target classifies as NEEDS_HUMAN
+    (e.g. a ``claude_governance_hook`` path), the bounded-execution
+    step must block, ``actual_modification`` must remain false, and
+    Step 5 implementation must remain disallowed."""
+    monkeypatch.setattr(
+        e2e, "SIMULATION_TARGET_PATH", ".claude/agents/synthetic_role.md"
+    )
+    snap = e2e.collect_snapshot(
+        scratch_dir=tmp_path / "scratch",
+        generated_at_utc="2026-05-08T00:00:00Z",
+    )
+
+    assert snap["proof_status"] == "blocked"
+    assert any(
+        ".claude/agents/synthetic_role.md" in p
+        for p in snap["protected_path_violations"]
+    )
+    assert snap["autonomous_development_possible"] is False
+    assert snap["step5_implementation_allowed"] is False
+    assert snap["discipline_invariants"]["actually_modifies_target"] is False
+    assert (
+        snap["discipline_invariants"][
+            "operator_step5_authorisation_required"
+        ]
+        is True
+    )
+
+    sim = _step_by_name(snap, "bounded_execution_or_simulation")
+    assert sim["status"] == "blocked"
+    assert sim["blocker_reason"] == "simulation_target_protected"
+    assert sim["evidence"]["authority_decision"] == ea.DECISION_NEEDS_HUMAN
+
+
+# ---------------------------------------------------------------------------
+# 3. QRE coupling violation blocks the proof
+# ---------------------------------------------------------------------------
+
+
+def test_qre_coupling_violation_via_module_version_blocks_proof(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """If any ADE peer snapshot reports a ``module_version`` that
+    contains the substring ``intelligent_routing``, the loose-
+    coupling self-check inside the harness must populate
+    ``qre_coupling_violations``, drive ``proof_status`` to
+    ``'blocked'``, and refuse to authorise autonomous development."""
+    # Patch the imported peer module's MODULE_VERSION global. The
+    # peer's ``collect_snapshot`` reads this at call time, so the
+    # patched string flows into the snapshot the harness inspects.
+    monkeypatch.setattr(
+        e2e.ddl,
+        "MODULE_VERSION",
+        "v3.15.16.A11+intelligent_routing_marker",
+    )
+    snap = e2e.collect_snapshot(
+        scratch_dir=tmp_path / "scratch",
+        generated_at_utc="2026-05-08T00:00:00Z",
+    )
+
+    assert snap["proof_status"] == "blocked"
+    assert snap["qre_coupling_violations"], snap["qre_coupling_violations"]
+    assert any(
+        "intelligent_routing" in v for v in snap["qre_coupling_violations"]
+    )
+    assert snap["autonomous_development_possible"] is False
+    assert snap["step5_implementation_allowed"] is False
+    assert snap["step5_design_planning_allowed"] is True
+
+
+# ---------------------------------------------------------------------------
+# 4. Human-needed item surfaces the human signal and never authorises Step 5
+# ---------------------------------------------------------------------------
+
+
+def test_human_needed_queue_item_surfaces_human_needed_signal(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A queue item that declares ``human_needed=True`` with a
+    closed-vocabulary reason must propagate to
+    ``snap['human_needed_items'] > 0``, surface
+    ``requiring_human_operator > 0`` in the execution_readiness
+    evidence, raise the digest's operator_action_count, and leave
+    Step 5 implementation gated."""
+    original = e2e._build_synthetic_queue_seed_item
+
+    def with_human_needed() -> dict[str, Any]:
+        item = original()
+        item["human_needed"] = True
+        item["human_needed_reason"] = "architecture_crossroads"
+        return item
+
+    monkeypatch.setattr(
+        e2e, "_build_synthetic_queue_seed_item", with_human_needed
+    )
+    snap = e2e.collect_snapshot(
+        scratch_dir=tmp_path / "scratch",
+        generated_at_utc="2026-05-08T00:00:00Z",
+    )
+
+    assert snap["human_needed_items"] > 0
+    assert snap["step5_implementation_allowed"] is False
+    assert snap["step5_design_planning_allowed"] is True
+    # Discipline invariants must remain pinned.
+    inv = snap["discipline_invariants"]
+    assert inv["operator_step5_authorisation_required"] is True
+    assert inv["actually_modifies_target"] is False
+
+    readiness = _step_by_name(snap, "execution_readiness")
+    assert readiness["evidence"]["requiring_human_operator"] >= 1
+    assert readiness["evidence"]["ready_for_autonomous_action"] == 0
+
+    digest = _step_by_name(snap, "digest_report_out")
+    assert digest["evidence"]["operator_action_count"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# 5. Missing lifecycle step (no parsable delegation) fails safely
+# ---------------------------------------------------------------------------
+
+
+def test_missing_delegation_marker_fails_proof(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """If the canonical-roadmap fixture contains no parsable A11
+    delegation marker, ``roadmap_pickup`` must fail with the closed
+    blocker_reason ``no_delegation_entry_parsed``,
+    ``agent_refinement`` must roll forward to ``not_evaluated`` with
+    the same blocker, ``missing_capabilities`` must include
+    ``roadmap_pickup``, ``proof_status`` becomes ``'failed'``, and
+    ``autonomous_development_possible`` is False."""
+
+    def no_marker() -> str:
+        # Plain prose only — no <!-- ade_delegation ... --> block.
+        return (
+            "# Synthetic roadmap with no marker\n"
+            "Plain prose. Bullets and headings must not produce "
+            "delegation entries.\n"
+        )
+
+    monkeypatch.setattr(
+        e2e, "_build_synthetic_canonical_roadmap_text", no_marker
+    )
+    snap = e2e.collect_snapshot(
+        scratch_dir=tmp_path / "scratch",
+        generated_at_utc="2026-05-08T00:00:00Z",
+    )
+
+    assert snap["proof_status"] == "failed"
+    assert snap["autonomous_development_possible"] is False
+    assert "roadmap_pickup" in snap["missing_capabilities"]
+    assert snap["step5_implementation_allowed"] is False
+
+    pickup = _step_by_name(snap, "roadmap_pickup")
+    assert pickup["status"] == "failed"
+    assert pickup["blocker_reason"] == "no_delegation_entry_parsed"
+    assert pickup["blocker_reason"] in e2e.BLOCKER_REASONS
+
+    refinement = _step_by_name(snap, "agent_refinement")
+    assert refinement["status"] == "not_evaluated"
+    assert refinement["blocker_reason"] == "no_delegation_entry_parsed"
+    assert refinement["status"] in e2e.STEP_STATUSES
+
+
+# ---------------------------------------------------------------------------
+# 6. Malformed input (release evidence) degrades safely without raising
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_release_evidence_degrades_safely(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """If the synthetic release-evidence fixture is degraded so the
+    A9 release gate cannot emit a ``go``/``go_with_followups``
+    verdict, the harness must NOT raise, ``release_gate`` must record
+    ``status='failed'`` with closed blocker_reason
+    ``release_gate_no_go``, ``missing_capabilities`` must reflect the
+    gap, and ``proof_status`` must become ``'failed'`` (not raise,
+    not silently pass)."""
+
+    def empty_evidence() -> dict[str, Any]:
+        return {"schema_version": "1.0", "evidence": {}}
+
+    monkeypatch.setattr(
+        e2e, "_build_synthetic_release_evidence", empty_evidence
+    )
+
+    # Must not raise.
+    snap = e2e.collect_snapshot(
+        scratch_dir=tmp_path / "scratch",
+        generated_at_utc="2026-05-08T00:00:00Z",
+    )
+
+    assert snap["proof_status"] == "failed"
+    assert snap["autonomous_development_possible"] is False
+    assert snap["step5_implementation_allowed"] is False
+
+    rg = _step_by_name(snap, "release_gate")
+    assert rg["status"] == "failed"
+    assert rg["blocker_reason"] in e2e.BLOCKER_REASONS
+    assert rg["blocker_reason"] == "release_gate_no_go"
+    # ``missing_capabilities`` must surface a release-gate-related entry.
+    assert any("release_gate" in c for c in snap["missing_capabilities"])
+
+
+# ---------------------------------------------------------------------------
+# 7. No-op dry-run invariants pinned (full-block assertion, all six flags)
+# ---------------------------------------------------------------------------
+
+
+def test_no_op_dry_run_invariants_fully_pinned_happy_path(
+    tmp_path: Path,
+) -> None:
+    """Pin every discipline invariant on a clean run so a future
+    edit to the harness cannot silently flip any of them. Mirrors
+    the existing block test but is explicit per-flag and explicitly
+    asserts that the bounded-execution step recorded a no-op
+    dry-run."""
+    snap = e2e.collect_snapshot(scratch_dir=tmp_path / "scratch")
+    inv = snap["discipline_invariants"]
+
+    assert inv["actually_modifies_target"] is False
+    assert inv["creates_real_branches"] is False
+    assert inv["opens_real_prs"] is False
+    assert inv["mutates_production_artifacts"] is False
+    assert inv["uses_subprocess_or_network"] is False
+    assert inv["operator_step5_authorisation_required"] is True
+
+    sim = _step_by_name(snap, "bounded_execution_or_simulation")
+    assert sim["evidence"]["actual_modification"] is False
+    assert sim["evidence"]["simulation_kind"] == "no_op_dry_run"
+    # The synthetic target file must NOT exist on disk after the proof.
+    assert not (
+        tmp_path / "scratch" / e2e.SIMULATION_TARGET_PATH
+    ).exists()
+
+
+def test_no_op_dry_run_invariants_pinned_under_blocked_proof(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Even when the proof reaches ``proof_status='blocked'`` via a
+    protected-path violation, every discipline invariant must remain
+    pinned. A blocked proof MUST NOT silently flip any invariant."""
+    monkeypatch.setattr(
+        e2e, "SIMULATION_TARGET_PATH", "automation/live_gate.py"
+    )
+    snap = e2e.collect_snapshot(scratch_dir=tmp_path / "scratch")
+
+    assert snap["proof_status"] == "blocked"
+    inv = snap["discipline_invariants"]
+    assert inv["actually_modifies_target"] is False
+    assert inv["creates_real_branches"] is False
+    assert inv["opens_real_prs"] is False
+    assert inv["mutates_production_artifacts"] is False
+    assert inv["uses_subprocess_or_network"] is False
+    assert inv["operator_step5_authorisation_required"] is True
+
+    # The protected target must NOT exist on disk after the proof.
+    assert not (
+        tmp_path / "scratch" / "automation" / "live_gate.py"
+    ).exists()
+
+
+# ---------------------------------------------------------------------------
+# 8. Final operator summary never claims real implementation
+# ---------------------------------------------------------------------------
+
+
+def test_final_operator_summary_never_claims_real_implementation_passed(
+    tmp_path: Path,
+) -> None:
+    """On a passing run the final operator summary must explicitly
+    name proof-harness mode and the operator-authorisation gate, and
+    must NOT contain any claim that real autonomous implementation
+    is currently allowed."""
+    snap = e2e.collect_snapshot(scratch_dir=tmp_path / "scratch")
+    summary: str = snap["final_operator_summary"]
+
+    assert "proof-harness mode" in summary
+    assert "Step 5 design planning is allowed" in summary
+    assert "Step 5 implementation requires separate operator" in summary
+
+    # Negative assertions — words that would imply real implementation
+    # is now authorised must NOT appear.
+    forbidden_phrases = (
+        "real autonomous implementation is now allowed",
+        "Step 5 implementation is now allowed",
+        "Step 5 implementation is authorised",
+        "Step 5 implementation is authorized",
+        "real branches are created",
+        "production artifacts are mutated",
+    )
+    for phrase in forbidden_phrases:
+        assert phrase not in summary, phrase
+
+
+def test_final_operator_summary_on_blocked_proof_signals_block(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """When the proof reaches ``proof_status='blocked'``, the final
+    operator summary must signal the block AND must not contain any
+    claim of authorised implementation."""
+    monkeypatch.setattr(
+        e2e, "SIMULATION_TARGET_PATH", "automation/live_gate.py"
+    )
+    snap = e2e.collect_snapshot(scratch_dir=tmp_path / "scratch")
+
+    assert snap["proof_status"] == "blocked"
+    summary: str = snap["final_operator_summary"]
+    assert "BLOCKED" in summary
+    assert (
+        "protected_path_violations" in summary
+        or "qre_coupling_violations" in summary
+    )
+
+    forbidden_phrases = (
+        "Step 5 implementation is allowed",
+        "Step 5 implementation is authorised",
+        "Step 5 implementation is authorized",
+        "real autonomous implementation",
+    )
+    for phrase in forbidden_phrases:
+        assert phrase not in summary, phrase
+
+
+def test_final_operator_summary_on_failed_proof_signals_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """When the proof reaches ``proof_status='failed'``, the final
+    operator summary must signal failure AND must not authorise
+    autonomous implementation."""
+
+    def no_marker() -> str:
+        return "# No marker here\nPlain prose only.\n"
+
+    monkeypatch.setattr(
+        e2e, "_build_synthetic_canonical_roadmap_text", no_marker
+    )
+    snap = e2e.collect_snapshot(scratch_dir=tmp_path / "scratch")
+
+    assert snap["proof_status"] == "failed"
+    summary: str = snap["final_operator_summary"]
+    assert "FAILED" in summary
+
+    forbidden_phrases = (
+        "Step 5 implementation is allowed",
+        "Step 5 implementation is authorised",
+        "Step 5 implementation is authorized",
+        "real autonomous implementation",
+    )
+    for phrase in forbidden_phrases:
+        assert phrase not in summary, phrase


### PR DESCRIPTION
## Summary

Test-only backfill addressing the single coverage gap surfaced by the post-merge audit on A9–A13. The E2E proof harness in `reporting/development_e2e_proof.py` had strong happy-path tests but its closed `failed` / `blocked` branches were not directly exercised.

- **Scope:** `tests/unit/test_development_e2e_proof.py` only. No production code changed.
- **Adds:** 12 tests (+465 LOC). 0 skips, 0 xfails, 0 importorskip, 0 removed assertions.
- **Step 5 implementation remains blocked.** Every new test pins `step5_implementation_allowed=False` and the discipline invariants.

Each new test injects exactly one fault by monkeypatching a public seam (`_build_synthetic_*` fixture helpers, an imported peer module's `MODULE_VERSION` global, or the `SIMULATION_TARGET_PATH` constant) and asserts the proof reports the expected blocked / failed state with the documented closed-vocabulary reason.

## Failure branches now covered

| # | Test | Branch covered |
|---|---|---|
| 1 | test_protected_surface_queue_item_blocks_proof | execution_readiness -> blocked, simulation_target_protected |
| 2 | test_permanently_denied_simulation_target_blocks_proof | bounded_execution -> blocked when ea.classify returns PERMANENTLY_DENIED (live_path) |
| 3 | test_needs_human_simulation_target_blocks_proof | bounded_execution -> blocked when ea.classify returns NEEDS_HUMAN (claude_governance_hook) |
| 4 | test_qre_coupling_violation_via_module_version_blocks_proof | Loose-coupling self-check -> qre_coupling_violations populated, proof blocked |
| 5 | test_human_needed_queue_item_surfaces_human_needed_signal | human_needed_items > 0; digest operator_action_count >= 1; Step 5 still gated |
| 6 | test_missing_delegation_marker_fails_proof | roadmap_pickup -> failed (no_delegation_entry_parsed); agent_refinement -> not_evaluated |
| 7 | test_malformed_release_evidence_degrades_safely | Malformed input handled without raising; release_gate -> failed (release_gate_no_go) |
| 8a | test_no_op_dry_run_invariants_fully_pinned_happy_path | All 6 discipline invariants pinned per-flag on a clean run |
| 8b | test_no_op_dry_run_invariants_pinned_under_blocked_proof | Same 6 invariants remain pinned under proof_status=blocked |
| 9a | test_final_operator_summary_never_claims_real_implementation_passed | Positive + negative phrase assertions on passed run |
| 9b | test_final_operator_summary_on_blocked_proof_signals_block | Final summary signals BLOCKED; rejects implementation-authorised wording |
| 9c | test_final_operator_summary_on_failed_proof_signals_failure | Final summary signals FAILED; rejects implementation-authorised wording |

## Test plan

- [x] python -m pytest tests/unit/test_development_e2e_proof.py -q -> 33 passed (21 existing + 12 new)
- [x] python -m pytest tests/smoke -q -> 18 passed
- [x] python scripts/governance_lint.py -> OK (16 agents, 5 workflows)
- [x] git diff --name-only -> only tests/unit/test_development_e2e_proof.py
- [x] No production file changed
- [x] No skip / xfail / importorskip added
- [x] No removed test functions, no removed assertions, no loosened assertions
- [ ] CI green
- [ ] Squash-merge after CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)