### PR TITLE
docs(governance-bootstrap): operator-authored root doc modernization (CLAUDE.md / AGENTS.md / INSTALLATIEGIDS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,126 +56,51 @@ These outputs must:
 
 ---
 
-## 4. AI Tooling Roles
+## 4. Agent roles and authority
 
-Strict separation between reasoning, planning, and execution.
+Agent role separation has moved from the original "Claude / Codex CLI
+/ Claude Code" three-actor model to the v3.15.15.12 governance layer's
+sixteen-role model, plus the eight canonical handoff roles defined in
+`reporting.roadmap_execution_protocol`. The full mapping lives in:
 
-No agent may operate outside its assigned role.
+- `docs/governance/agent_handoff_protocol.md` — eight canonical
+  handoff roles (product_owner, strategic_advisor, planner,
+  implementation_agent, architecture_guardian, ci_guardian,
+  security/governance_guardian, human_operator).
+- `docs/governance/autonomy_ladder.md` — six autonomy levels (L0–L6).
+  Level 6 is permanently disabled.
+- `docs/adr/ADR-015-claude-agent-governance.md` — authority chain.
+- `.claude/agents/` — per-agent frontmatter with `allowed_roots`,
+  `tools`, and `max_autonomy_level`.
 
----
+Agent capability is bounded at every layer (policy, hooks,
+CODEOWNERS, branch protection). No agent role overrides
+`reporting.execution_authority.classify(...)`. Step 5 design (the
+future autonomous implementation loop) is documented in
+`docs/governance/step5_design.md` and remains implementation-blocked.
 
-### Claude (Architect / Analyst)
-
-Responsible for:
-
-- system architecture decisions
-- research reasoning
-- hypothesis design
-- evaluation of results
-- defining refactor scope
-
-Must:
-
-- produce structured plans before any implementation
-- enforce AGENTS.md and orchestrator specifications
-- identify risks and constraint violations
-
-Not responsible for:
-
-- executing code changes
-- performing multi-file edits
-- running CLI commands
+The original "Claude / Codex CLI / Claude Code" three-actor model is
+**superseded** and should not be cited as current. Cross-reference
+`docs/governance/agent_governance.md` for the public-facing overview.
 
 ---
 
-### Codex CLI (Implementation Engine)
+## 5. Execution workflow
 
-Responsible for:
+The canonical execution workflow is defined in:
 
-- implementing approved changes
-- performing multi-file refactors
-- running commands and validations
+- `docs/governance/roadmap_item_execution_protocol.md` — protocol
+  per roadmap item.
+- `docs/governance/agent_flow.md` — closed `next_action_proposed`
+  vocabulary.
+- `docs/governance/task_board.md` — read-only state-machine
+  projection.
+- `docs/governance/github_pr_lifecycle.md` — branch → PR → CI →
+  squash-merge → post-merge protocol.
 
-Must:
-
-- read `AGENTS.md` and `docs/orchestrator_brief.md` before acting
-- present a clear diff plan before making changes
-- keep changes minimal, scoped, and reversible
-- preserve existing behavior unless explicitly instructed otherwise
-
-Not allowed to:
-
-- introduce new strategy logic without explicit approval
-- change architecture without a prior plan
-- bypass system constraints or layer boundaries
-
----
-
-### Claude Code (Precision Tool)
-
-Responsible for:
-
-- small targeted edits
-- debugging specific issues
-- inspecting and explaining code
-
-Must:
-
-- operate within the current architecture
-- avoid structural or multi-file changes
-
----
-
-### Execution Flow (Strict)
-
-All work must follow this sequence:
-
-1. Claude:
-   - analyzes problem
-   - defines plan
-   - identifies risks
-
-2. Human:
-   - reviews and approves plan
-
-3. Codex:
-   - proposes diff
-   - applies changes
-
-4. Human:
-   - validates outcome
-
-No step may be skipped.
-
----
-
-### Core Principle
-
-Separate thinking from execution:
-
-- Claude decides what to build
-- Codex implements it
-- Human validates correctness
-
-Never mix roles within a single step.
-
----
-
-## 5. Execution Workflow
-
-Every change follows this sequence:
-
-1. Define the task (architecture or research goal)
-2. Use Claude to design the minimal solution
-3. Use Codex to implement the change
-4. Run smoke checks
-5. Review outputs before committing
-
-Rules:
-
-* no direct coding without a plan
-* no strategy changes during architecture work
-* prefer the smallest possible change set
+No agent may bypass `reporting.execution_authority.classify(...)`
+or skip the GitHub PR lifecycle. The previous prose ("Claude
+designs → Codex implements → Human validates") is superseded.
 
 ---
 
@@ -250,38 +175,25 @@ Then continue from the current system state.
   * `refactor:` structural change
   * `fix:` bug fix
 
-## 11. Git Workflow
+## 11. Git workflow
 
-All work must happen on a non-main branch.
+Canonical: `docs/governance/github_pr_lifecycle.md`.
 
-Branch rules:
-- never work directly on `main`
-- create a new branch before any implementation work
-- keep one branch limited to one coherent scope
+- Never commit directly to `main`.
+- Branch naming: `feature/`, `feat/`, `fix/`, `chore/`, `docs/`,
+  `refactor/` per the existing repo convention.
+- Merge strategy: squash-merge only (`gh pr merge --squash
+  --delete-branch`).
+- No `--admin` merge.
+- No force push.
+- No hook bypass (`--no-verify`, `--no-gpg-sign`, etc.).
+- Pre-commit and pre-push hooks run on every commit and push.
+- CI must be green before merge; post-merge gates must pass before
+  a roadmap entry is flipped to `Complete`.
 
-Branch naming:
-- `feature/...` for new capabilities
-- `refactor/...` for structural changes
-- `fix/...` for bug fixes
-
-Commit rules:
-- keep commits small and atomic
-- commit only at meaningful checkpoints
-- push regularly so remote state stays current
-
-Pull request rules:
-- merge to `main` only through a reviewed, intentional PR
-- summarize scope, risks, and smoke checks in the PR
-
-Session start rule:
-- confirm current branch before doing any work
-- if on `main`, create a new branch immediately
-
-Never commit:
-
-* temporary logs
-* irrelevant artifacts
-* partial experiments
+The GitHub CLI portable lives at
+`C:\Users\joery.van.rooij\tools\gh\bin\gh.exe`. Absence of `gh` on
+PATH is **never** justification to fall back to manual PRs.
 
 ## 12. Enforcement
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,38 @@ De agent mag NOOIT risico verhogen om een doel te halen
 
 Authority doctrine: `docs/adr/ADR-014-truth-authority-settlement.md` — canonical mapping of which subsystem owns truth for each domain (registry / presets / catalog / candidate lifecycle / paper readiness / live governance).
 
+Agent governance doctrine: `docs/adr/ADR-015-claude-agent-governance.md`
+— authority chain for Claude / agent code-modification capability
+(no-touch paths, autonomy ladder L0–L6, audit ledger). Level 6
+(autonomous merge / deploy) is permanently disabled.
+
+Session-start protocol for any branch → PR → CI → squash-merge →
+post-merge work: `docs/governance/github_pr_lifecycle.md`.
+GitHub CLI portable: `C:\Users\joery.van.rooij\tools\gh\bin\gh.exe`.
+No `--admin` merges, no force push, no direct push to `main`, no
+hook bypass, no test weakening, no `.claude/**` writes.
+
+Project split:
+
+- **QRE** (Quant Research Engine) — research execution platform
+  under `research/`. Roadmap: `docs/roadmap/Roadmap v6.md`.
+- **ADE** (Autonomous Development Engine) — governance + work queue
+  + release gate + bugfix loop + delegation + operational digest +
+  E2E proof under `reporting/development_*.py`. Roadmap:
+  `docs/roadmap/autonomous_development.txt`.
+
+ADE A1–A13 are complete. Step 5 design is complete
+(`docs/governance/step5_design.md`,
+`docs/adr/_drafts/ADR-017-step5-autonomous-implementation-loop.md`).
+**Step 5 implementation remains blocked** behind explicit operator
+authorisation, the autonomy-ladder ceiling, and the readiness gate
+(`docs/governance/step5_design.md` §12).
+
+Allowed surfaces and forbidden surfaces are listed in
+`docs/governance/no_touch_paths.md`. Per-action authority decisions
+follow `docs/governance/execution_authority.md`. Autonomy levels
+follow `docs/governance/autonomy_ladder.md`.
+
 ## Server
 VPS: Hetzner CX22 | IP: 23.88.110.92
 OS: Ubuntu 24.04 | Project: /root/trading-agent/
@@ -340,6 +372,8 @@ KERNREGEL ZELFLEREN:
 - Telegram: nog in te voeren na monitoring build
 
 ---
+
+## Historical (pre-v3.15) — superseded by Roadmap v6 + autonomous_development.txt
 
 ## ROADMAP — Maximaal 1 maand
 

--- a/INSTALLATIEGIDS.md
+++ b/INSTALLATIEGIDS.md
@@ -221,6 +221,19 @@ Wat je doet in deze fase:
 - Geen crashes of rare gedragingen
 - Je begrijpt waarom elke trade is gemaakt
 
+> **Current paper-readiness criteria** are now defined by the
+> v3.15+ paper-validation engine, not by the simple `win-rate >55%
+> over 50 trades` threshold above. The full closed-vocabulary
+> readiness gate is documented in:
+>
+> - `research/paper_readiness.py` — closed blocking-reason taxonomy.
+> - `docs/handoffs/v3.15-to-v3.16.md` §2 — narrative summary.
+>
+> The threshold above is kept as a simple human-readable signpost;
+> the authoritative criteria are the ones in the paper-readiness
+> gate. Treat the section above as the "comfort milestone", not the
+> live-trading authorisation gate.
+
 ---
 
 ## STAP 8 — Live zetten


### PR DESCRIPTION
## Summary

Operator-authored governance-bootstrap PR applying the three patches from `docs/governance/markdown_modernization_handoff.md` (landed in PR #149) to the root-level docs that the agent-allowlist hook correctly blocks from agent edits.

This PR was authored manually by the operator; the agent layer is responsible only for validation, lifecycle, and post-merge gates per the operator brief.

## Files changed (3 docs files, no protected paths)

- `CLAUDE.md` — inserts a new pointer block after the ADR-014 reference (Agent governance doctrine ADR-015 + L6 permanently disabled note + GitHub PR lifecycle session-start protocol + QRE/ADE project split + Step 5 design-complete-but-implementation-blocked status + cross-refs to no_touch_paths / execution_authority / autonomy_ladder). Demotes the legacy "ROADMAP — Maximaal 1 maand" block by inserting a single `## Historical (pre-v3.15) — superseded by Roadmap v6 + autonomous_development.txt` header line before it.
- `AGENTS.md` — replaces §4 ("AI Tooling Roles" — Claude / Codex CLI / Claude Code three-actor model) with a pointer block referencing `agent_handoff_protocol.md`, ADR-015, autonomy ladder, and `.claude/agents/`. Replaces §5 ("Execution Workflow") with pointers to `roadmap_item_execution_protocol.md`, `agent_flow.md`, `task_board.md`, `github_pr_lifecycle.md`. Replaces §11 ("Git Workflow") with a pointer to the canonical GitHub PR lifecycle protocol.
- `INSTALLATIEGIDS.md` — appends a single blockquote in §STAP 7 noting that the v3.15+ paper-validation engine and `research/paper_readiness.py` are the authoritative paper-readiness criteria, and that the legacy "win-rate >55% over 50 trades" line is a comfort milestone, not the live-trading authorisation gate.

## What this PR does **not** do

- **No** edits to `.claude/**`, no allowlist widening.
- **No** edits to canonical_roadmap (`docs/roadmap/autonomous_development.txt`, `docs/roadmap/Roadmap v6.md`).
- **No** ADR-017 promotion (stays in `_drafts/`).
- **No** §A14 entry added to the autonomous-development roadmap.
- **No** Step 5 implementation, no flag flipping (`step5_implementation_allowed` stays `false`), no QRE behavior change.
- **No** start of v3.15.17 / v3.15.16 / Intelligent Routing.
- **No** research artifact mutation.
- **No** edits to live/paper/shadow/risk/trading/broker/execution code.
- **No** test weakening, no CI workflow change, no branch-protection change.

## Test plan

- [x] `python scripts/governance_lint.py` — `OK (16 agents, 5 workflows checked)`
- [x] `python -m pytest tests/smoke -q` — `18 passed`
- [x] Diff scope: 3 docs files only; no protected paths touched
- [ ] CI green
- [ ] Post-merge gates green
- [ ] Diff scope inspection of merge SHA confirms only the three docs files changed

## Step 5 gate G7 status (after this merge)

Per `docs/governance/step5_design.md` §12, gate G7 (documentation modernization merged on `main`) becomes **satisfied** when this PR merges. The remaining Step 5.0 readiness gates (G8 ADR-017 promotion, G9 §A14 roadmap entry, G10 explicit operator authorisation in Step 5.0 PR body, G11 Step 5 §10 tests committed and green, G12 fresh release-gate report + rollback drill ≤14 days) remain pending and explicitly out of scope of this PR.

`step5_implementation_allowed=false`, autonomy-ladder Level 6 permanently disabled per ADR-015 §Doctrine 1, ADR-017 still draft-only — all unchanged.