### PR TITLE
feat(step5): Step 5.0.1 — Roadmap Intake Bridge (read-only)

### DIFF
--- a/docs/governance/development_roadmap_intake.md
+++ b/docs/governance/development_roadmap_intake.md
@@ -1,0 +1,266 @@
+# Roadmap Intake Bridge — Step 5.0.1
+
+> **Status:** Implemented (read-only, deterministic, dry-run).
+>
+> **Module:** [`reporting/development_roadmap_intake.py`](../../reporting/development_roadmap_intake.py)
+> **Status reporter:** [`reporting/development_roadmap_intake_status.py`](../../reporting/development_roadmap_intake_status.py)
+> **Output artifact:** `logs/development_roadmap_intake/latest.json`
+> **Status artifact:** `logs/development_roadmap_intake_status/latest.json`
+>
+> **Authority:** development-governance read-only.
+> ADE roadmap intake is **not** trading or research execution authority.
+
+---
+
+## 1. Purpose
+
+ADE's autonomous-development surface (A8 work queue, A10 bugfix loop,
+A11 delegation, A14 Step 5.0 dry-run planner) can plan from existing
+queue / bugfix / delegation artefacts, but until now it had no
+deterministic path to pick up real roadmap work straight from:
+
+- [`docs/roadmap/Roadmap v6.md`](../roadmap/Roadmap%20v6.md) — canonical QRE roadmap;
+- [`docs/roadmap/Roadmap v6 Addendum.md`](../roadmap/Roadmap%20v6%20Addendum.md) — diagnostic-layer extension;
+- [`docs/roadmap/qre_roadmap_v6_phase_prompts.md`](../roadmap/qre_roadmap_v6_phase_prompts.md) — phase prompts;
+- [`docs/roadmap/qre_roadmap_v6_ade_operating_manual.md`](../roadmap/qre_roadmap_v6_ade_operating_manual.md) — ADE operating manual.
+
+A11 deliberately does **not** fuzzy-parse roadmap prose. The Roadmap
+Intake Bridge fills the gap **without** widening A11: it reads only
+explicit, machine-readable markers and emits read-only candidate
+records. Operator promotion into the actual queue or delegation
+pipeline remains a separate manual step.
+
+Existing Roadmap v6 stays canonical. The Addendum is treated as an
+**extension** (not a replacement). The phase-prompts and operating-
+manual docs are explicit additional sources, distinguished by
+`source_kind`.
+
+---
+
+## 2. Scope and non-scope
+
+In scope:
+
+- Read-only, deterministic parsing of explicit
+  `<!-- ade_roadmap_intake ... -->` markers in the four canonical
+  source documents.
+- Per-candidate `execution_authority` classification via
+  `reporting.execution_authority.classify(...)` against the marker's
+  `target_path` and `risk_level`.
+- Closed-vocabulary candidate records with bounded scalars only —
+  no PR text, no diffs, no command summary.
+- Atomic write of `logs/development_roadmap_intake/latest.json`.
+- Compact status summary at
+  `logs/development_roadmap_intake_status/latest.json` counting by
+  `source_kind`, `candidate_kind`, `intake_status`, and
+  `execution_authority_decision`.
+
+Non-scope (hard constraints):
+
+- **No Step 5.1, no Step 5.2.** `step5_implementation_allowed`
+  remains `False`. `STEP5_ENABLED_SUBSTAGE` remains `"none"`. The
+  autonomy ladder cap is unchanged. The autonomy-ladder ceiling
+  permanently disables fully autonomous merge / deploy.
+- No automatic promotion into
+  `docs/development_work_queue/seed.jsonl` or
+  `docs/development_work_queue/delegation_seed.jsonl`. Promotion is
+  an explicit operator action.
+- No mutation of any roadmap, addendum, phase-prompt, or operating-
+  manual document.
+- No edit of canonical roadmap status fields. No marking of any
+  roadmap phase as complete.
+- No fuzzy parsing of prose, headings, lists, or bullets. Plain
+  Markdown is invisible to the parser.
+- No QRE behaviour change. No research-artifact mutation. No
+  Intelligent Routing change.
+- No subprocess, no network, no `gh`, no `git`. No LLM calls. No
+  external APIs. Stdlib + the existing ADE/reporting dependencies
+  only.
+- No imports of `dashboard`, `automation`, `broker`, `agent.risk`,
+  `agent.execution`, `research`, `reporting.intelligent_routing`.
+- No edit of `.claude/**`. No edit of trading / paper / shadow /
+  risk / broker / execution surfaces.
+- Diagnostics do not trade. ADE roadmap intake is development
+  governance only.
+
+---
+
+## 3. Marker grammar (closed)
+
+A roadmap-intake candidate is created **only** by an explicit HTML
+comment marker inside one of the four canonical source documents.
+The marker grammar is:
+
+```
+<!-- ade_roadmap_intake
+candidate_id: <opaque-stable-id, [A-Za-z0-9_.-]+, ≤96 chars>
+phase: <≤64 chars; e.g. v3.15.16, v3.15.17, addendum>
+title: <≤200 chars>
+category: <one of: docs | reporting | governance | observability | test>
+required_agent_role: <one of A8 AGENT_ROLES>
+risk_level: <LOW | MEDIUM | HIGH | UNKNOWN>
+target_path: <repo-relative POSIX path, ≤300 chars>
+human_needed: <true | false>
+human_needed_reason: <closed reason; "none" iff human_needed=false>
+acceptance_criteria:
+  - <≤200 chars>
+  - <…>
+-->
+```
+
+Every required field must be present and pass the closed-vocab
+check. Any failure drops the marker with a `validation_warning`,
+never silent promotion.
+
+Use markers sparingly. The four source documents must remain
+human-readable. Markers are appropriate for explicit, approved
+hand-off anchors. Bulk decomposition belongs elsewhere (the A8 / A11
+sidecar seed pipelines).
+
+---
+
+## 4. Closed vocabularies
+
+| Vocabulary           | Members                                                                                             |
+| -------------------- | --------------------------------------------------------------------------------------------------- |
+| `intake_status`      | `proposed`, `eligible`, `blocked`, `human_needed`, `rejected`                                       |
+| `source_kind`        | `roadmap_v6`, `roadmap_v6_addendum`, `phase_prompt`, `operating_manual`                             |
+| `candidate_kind`     | `docs`, `reporting`, `governance`, `observability`, `test`                                          |
+| `promotion_target`   | `development_delegation`, `development_work_queue`, `none`                                          |
+| `risk_level`         | mirrored from `reporting.execution_authority.RISK_CLASSES`                                          |
+| `required_agent_role`| mirrored from `reporting.development_work_queue.AGENT_ROLES`                                        |
+| `human_needed_reason`| mirrored from `reporting.development_work_queue.HUMAN_NEEDED_REASONS`                               |
+
+Adding a value to any of these vocabularies requires a code change
+pinned by an updated unit test.
+
+---
+
+## 5. Per-candidate schema
+
+Per-candidate keys are exact and ordered:
+
+```
+candidate_id
+title
+source_document
+source_anchor
+roadmap_phase
+source_kind
+candidate_kind
+category
+required_agent_role
+risk_level
+target_path
+execution_authority_decision
+execution_authority_reason
+human_needed
+human_needed_reason
+intake_status
+acceptance_criteria
+validation_requirements
+promotion_target
+notes
+```
+
+`intake_status` is derived deterministically from
+`(execution_authority_decision, human_needed)`:
+
+| `human_needed` | `execution_authority_decision` | `intake_status` |
+| -------------- | ------------------------------- | --------------- |
+| `true`         | (any)                           | `human_needed`  |
+| `false`        | `PERMANENTLY_DENIED`            | `blocked`       |
+| `false`        | `NEEDS_HUMAN`                   | `human_needed`  |
+| `false`        | `AUTO_ALLOWED`                  | `eligible`      |
+| `false`        | (anything else / fail-safe)     | `proposed`      |
+
+`promotion_target` is always `none` in this PR. Promotion into the
+A8 work queue or A11 delegation pipeline is an explicit operator
+action or a later, explicitly approved bridge.
+
+---
+
+## 6. Step 5.0 consumption
+
+After operator promotion of a `latest.json` candidate into the A8
+work queue or A11 delegation pipeline, `development_step5_loop` can
+consume it like any other upstream item. The Step 5.0 loop already
+selects from delegation → bugfix → queue in deterministic order;
+the Roadmap Intake Bridge feeds those producers, never Step 5.0
+directly.
+
+The bridge does **not** change anything about how Step 5.0 selects
+or classifies items. It only widens the input surface from "operator
+sidecar seed" to "operator sidecar seed + explicit roadmap markers."
+
+---
+
+## 7. CLI
+
+```sh
+# Pure inspection — does not write artifacts:
+python -m reporting.development_roadmap_intake --no-write
+python -m reporting.development_roadmap_intake_status --no-write
+
+# Writes logs/development_roadmap_intake[_status]/latest.json:
+python -m reporting.development_roadmap_intake
+python -m reporting.development_roadmap_intake_status
+```
+
+Both modules are pure-stdlib + existing ADE/reporting dependencies.
+No subprocess, no network, no git/gh.
+
+---
+
+## 8. Determinism contract
+
+- Per-candidate ordering: `(source_kind, candidate_id)` ascending.
+- All free-text fields bounded.
+- Output is `json.dumps(..., sort_keys=True, indent=2) + "\n"`.
+- `generated_at_utc` is the only non-deterministic field; tests
+  inject it.
+- Atomic write via `os.replace(...)` from a same-directory
+  `tempfile.mkstemp(...)`.
+
+---
+
+## 9. Authority chain
+
+| Concern                         | Owner                                                                                  |
+| ------------------------------- | -------------------------------------------------------------------------------------- |
+| Marker grammar / vocabularies   | This document + the unit tests.                                                        |
+| Authority classification        | [`docs/governance/execution_authority.md`](execution_authority.md) (canonical).        |
+| Step 5 sub-stage cap            | [`docs/governance/step5_design.md`](step5_design.md) §12 + ADR-017.                    |
+| Roadmap canonical status        | [`docs/roadmap/Roadmap v6.md`](../roadmap/Roadmap%20v6.md) (canonical).                |
+| Roadmap diagnostic extension    | [`docs/roadmap/Roadmap v6 Addendum.md`](../roadmap/Roadmap%20v6%20Addendum.md).        |
+| Autonomy ladder                 | [`docs/governance/autonomy_ladder.md`](autonomy_ladder.md) + ADR-015.                  |
+
+---
+
+## 10. Test coverage
+
+Pinned in
+[`tests/unit/test_development_roadmap_intake.py`](../../tests/unit/test_development_roadmap_intake.py)
+and
+[`tests/unit/test_development_roadmap_intake_status.py`](../../tests/unit/test_development_roadmap_intake_status.py):
+
+- Plain Markdown headings produce zero candidates.
+- Explicit valid marker produces exactly one candidate.
+- Invalid marker fields produce a `validation_warning`, never a
+  candidate.
+- Archive paths under `docs/roadmap/archive/` are excluded.
+- Non-canonical source paths are excluded with a warning.
+- AUTO_ALLOWED `target_path` resolves to `intake_status=eligible`.
+- Protected `target_path` (canonical roadmap, governance hook,
+  policy doc, etc.) resolves to `human_needed` or `blocked`.
+- AST scan asserts no imports of research/live/paper/shadow/risk/
+  broker/execution surfaces.
+- AST/source scan asserts no `subprocess` / `socket` / `urllib` /
+  `http` / `requests` references and no `gh` / `git` references.
+- Output is deterministic byte-for-byte with an injected
+  `generated_at_utc`.
+- Atomic write refuses any path outside
+  `logs/development_roadmap_intake/`.
+- Status summary counts by `source_kind`, `candidate_kind`,
+  `intake_status`, `execution_authority_decision`.
+- Roadmap v6 Addendum extension framing preserved in the doc.

--- a/reporting/development_roadmap_intake.py
+++ b/reporting/development_roadmap_intake.py
@@ -1,0 +1,763 @@
+"""Step 5.0.1 — Roadmap Intake Bridge (read-only, deterministic).
+
+Pure, stdlib-only roadmap-to-candidate bridge. Converts explicit,
+machine-readable ``<!-- ade_roadmap_intake ... -->`` markers inside
+Roadmap v6, the Roadmap v6 Addendum, the QRE phase-prompts doc, and
+the QRE ADE operating-manual doc into bounded ADE candidate work
+items.
+
+This module is the **only** path by which ADE picks up real roadmap
+work without operator-authored sidecar seeds. **No fuzzy parsing.**
+Plain Markdown headings, prose, lists, and bullet points produce
+zero candidates. Archive paths are excluded. Anything not inside an
+explicit marker is invisible to this module.
+
+Hard guarantees (pinned by tests):
+
+* Stdlib + ``reporting.execution_authority`` +
+  ``reporting.approval_policy`` + ``reporting.development_work_queue``
+  (read-only) + ``reporting.development_delegation`` (read-only).
+* No subprocess, no network, no ``gh``, no ``git``.
+* No imports from ``dashboard``, ``automation``, ``broker``,
+  ``agent.risk``, ``agent.execution``, ``research``,
+  ``reporting.intelligent_routing``.
+* No mutation of any upstream roadmap, phase-prompt, or operating-
+  manual document. Read-only.
+* No promotion into ``docs/development_work_queue/seed.jsonl`` or
+  ``docs/development_work_queue/delegation_seed.jsonl``. Promotion
+  remains an explicit operator action.
+* Atomic write only under ``logs/development_roadmap_intake/``.
+* Roadmap v6 remains canonical; the Addendum is treated as an
+  extension, not a replacement.
+* Step 5.0.1 carries ``step5_implementation_allowed = False`` and
+  ``STEP5_ENABLED_SUBSTAGE = "none"`` invariants. Step 5.1 / 5.2
+  remain BLOCKED.
+
+CLI::
+
+    python -m reporting.development_roadmap_intake
+    python -m reporting.development_roadmap_intake --no-write
+    python -m reporting.development_roadmap_intake --indent 0
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import re
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Final
+
+from reporting import development_work_queue as dwq
+from reporting import execution_authority as ea
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[str] = "1.0"
+MODULE_VERSION: Final[str] = "v3.15.16.A14.5_0_1"
+REPORT_KIND: Final[str] = "development_roadmap_intake"
+
+# ---------------------------------------------------------------------------
+# Step 5 invariants (re-asserted on every artefact)
+# ---------------------------------------------------------------------------
+
+#: Step 5 sub-stage cap. Default-deny. Mirrors
+#: ``reporting.development_step5_loop`` so the artefact is self-attesting.
+STEP5_ENABLED_SUBSTAGE: Final[str] = "none"
+
+#: Hard-pinned literal: Step 5 implementation is NOT allowed beyond
+#: the dry-run / planner-only Step 5.0 surface plus the read-only
+#: intake bridge. Flipping this constant requires a code change pinned
+#: by a test update AND an ADR-015 amendment AND a fresh release-gate
+#: report.
+step5_implementation_allowed: Final[bool] = False
+
+
+# ---------------------------------------------------------------------------
+# Sources (closed)
+# ---------------------------------------------------------------------------
+
+#: Closed source-kind vocabulary. Adding a value requires a code
+#: change pinned by an updated test.
+SOURCE_KINDS: Final[tuple[str, ...]] = (
+    "roadmap_v6",
+    "roadmap_v6_addendum",
+    "phase_prompt",
+    "operating_manual",
+)
+
+#: Mapping from canonical source path → source_kind. The parser refuses
+#: any path not listed here. Existing Roadmap v6 stays canonical;
+#: Addendum is an extension, not a replacement.
+SOURCE_PATH_TO_KIND: Final[dict[str, str]] = {
+    "docs/roadmap/Roadmap v6.md": "roadmap_v6",
+    "docs/roadmap/Roadmap v6 Addendum.md": "roadmap_v6_addendum",
+    "docs/roadmap/qre_roadmap_v6_phase_prompts.md": "phase_prompt",
+    "docs/roadmap/qre_roadmap_v6_ade_operating_manual.md": "operating_manual",
+}
+
+#: Default canonical source paths, in deterministic order.
+DEFAULT_SOURCE_PATHS: Final[tuple[str, ...]] = tuple(
+    sorted(SOURCE_PATH_TO_KIND.keys())
+)
+
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies
+# ---------------------------------------------------------------------------
+
+#: Intake-status closed vocabulary.
+INTAKE_STATUSES: Final[tuple[str, ...]] = (
+    "proposed",
+    "eligible",
+    "blocked",
+    "human_needed",
+    "rejected",
+)
+
+#: Candidate-kind closed vocabulary. Read-only governance work only.
+#: Notably absent: live, paper, shadow, risk, broker, execution,
+#: trading. Diagnostics do not trade.
+CANDIDATE_KINDS: Final[tuple[str, ...]] = (
+    "docs",
+    "reporting",
+    "governance",
+    "observability",
+    "test",
+)
+
+#: Promotion-target closed vocabulary. ``none`` is the default for
+#: this PR — promotion remains an explicit operator action.
+PROMOTION_TARGETS: Final[tuple[str, ...]] = (
+    "development_delegation",
+    "development_work_queue",
+    "none",
+)
+
+#: Marker required field set; closed.
+MARKER_REQUIRED_FIELDS: Final[frozenset[str]] = frozenset(
+    {
+        "candidate_id",
+        "phase",
+        "title",
+        "category",
+        "required_agent_role",
+        "risk_level",
+        "target_path",
+        "human_needed",
+        "human_needed_reason",
+        "acceptance_criteria",
+    }
+)
+
+#: Per-candidate schema keys; exact and ordered.
+CANDIDATE_SCHEMA_KEYS: Final[tuple[str, ...]] = (
+    "candidate_id",
+    "title",
+    "source_document",
+    "source_anchor",
+    "roadmap_phase",
+    "source_kind",
+    "candidate_kind",
+    "category",
+    "required_agent_role",
+    "risk_level",
+    "target_path",
+    "execution_authority_decision",
+    "execution_authority_reason",
+    "human_needed",
+    "human_needed_reason",
+    "intake_status",
+    "acceptance_criteria",
+    "validation_requirements",
+    "promotion_target",
+    "notes",
+)
+
+#: Bounded length for free-text fields on a single candidate.
+MAX_TITLE_LEN: Final[int] = 200
+MAX_NOTES_LEN: Final[int] = 1000
+MAX_AC_ITEMS: Final[int] = 16
+MAX_AC_LINE_LEN: Final[int] = 200
+MAX_ID_LEN: Final[int] = 96
+MAX_PHASE_LEN: Final[int] = 64
+MAX_TARGET_PATH_LEN: Final[int] = 300
+MAX_MARKERS_PER_DOC: Final[int] = 256
+
+#: Wrapper-level note vocabulary.
+NOTE_NO_CANDIDATES: Final[str] = "no_explicit_intake_candidates"
+NOTE_CANDIDATES_PRESENT: Final[str] = "intake_candidates_present"
+NOTE_SOURCE_DOCS_MISSING: Final[str] = "source_docs_missing"
+
+#: Marker pattern. Opener and closer are pinned exactly so prose
+#: cannot accidentally match.
+_MARKER_RE: Final[re.Pattern[str]] = re.compile(
+    r"<!--\s*ade_roadmap_intake\b(.*?)-->", re.DOTALL
+)
+
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "development_roadmap_intake"
+ARTIFACT_LATEST: Final[Path] = ARTIFACT_DIR / "latest.json"
+ARTIFACT_RELATIVE_PATH: Final[str] = (
+    "logs/development_roadmap_intake/latest.json"
+)
+
+#: Atomic-write allowlist (POSIX path substring form). Any write
+#: target whose path does not contain this substring is refused with
+#: ``ValueError``.
+_WRITE_PREFIX: Final[str] = "logs/development_roadmap_intake/"
+
+
+# ---------------------------------------------------------------------------
+# Discipline invariants emitted into every artefact
+# ---------------------------------------------------------------------------
+
+_DISCIPLINE_INVARIANTS: Final[dict[str, bool]] = {
+    "actually_modifies_target": False,
+    "creates_real_branches": False,
+    "opens_real_prs": False,
+    "mergeable_by_agent": False,
+    "deployable_by_agent": False,
+    "writes_to_seed_jsonl": False,
+    "writes_to_delegation_seed_jsonl": False,
+    "fuzzy_parsing": False,
+    "uses_subprocess_or_network": False,
+    "calls_llm_or_external_api": False,
+    "mutates_research_artifacts": False,
+    "mutates_roadmap_status_fields": False,
+    "marks_phase_complete": False,
+    "operator_promotion_required": True,
+    "step5_implementation_allowed": False,
+    "diagnostics_do_not_trade": True,
+}
+
+
+# ---------------------------------------------------------------------------
+# Utility helpers
+# ---------------------------------------------------------------------------
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _bounded_str(value: Any, max_len: int) -> str:
+    if not isinstance(value, str):
+        return ""
+    if len(value) <= max_len:
+        return value
+    return value[:max_len]
+
+
+def _normalize_path(p: str) -> str:
+    if not p:
+        return ""
+    return p.replace("\\", "/").lstrip("./")
+
+
+def _is_archive_path(p: str) -> bool:
+    n = _normalize_path(p).lower()
+    return n.startswith("docs/roadmap/archive/") or "/archive/" in n
+
+
+def _read_text(path: Path) -> str | None:
+    if not path.is_file():
+        return None
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+
+def _coerce_bool(s: Any) -> bool | None:
+    if isinstance(s, bool):
+        return s
+    if not isinstance(s, str):
+        return None
+    v = s.strip().lower()
+    if v in {"true", "yes", "1"}:
+        return True
+    if v in {"false", "no", "0"}:
+        return False
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Marker body parser
+# ---------------------------------------------------------------------------
+
+
+def _parse_marker_body(body: str) -> tuple[dict[str, Any] | None, list[str]]:
+    """Parse a marker body into a typed dict.
+
+    Returns ``(payload, warnings)``. Returns ``None`` payload with
+    warnings on any structural failure. Same minimal grammar as A11:
+
+    * one ``key: value`` per line for scalar fields,
+    * ``acceptance_criteria:`` followed by indented ``- value`` lines,
+    * blank lines and comment lines (``#``) tolerated.
+
+    Anything else is rejected with a warning.
+    """
+    warnings: list[str] = []
+    out: dict[str, Any] = {}
+    ac: list[str] | None = None
+    for raw_line in body.splitlines():
+        line = raw_line.rstrip()
+        if not line.strip():
+            continue
+        if line.lstrip().startswith("#"):
+            continue
+        if ac is not None:
+            stripped = line.lstrip()
+            if stripped.startswith("- "):
+                if len(ac) >= MAX_AC_ITEMS:
+                    warnings.append("acceptance_criteria_truncated")
+                else:
+                    ac.append(_bounded_str(stripped[2:].strip(), MAX_AC_LINE_LEN))
+                continue
+            ac = None
+        if ":" not in line:
+            warnings.append("marker_line_without_colon")
+            continue
+        key, _, value = line.partition(":")
+        key = key.strip()
+        value_stripped = value.strip()
+        if key == "acceptance_criteria":
+            ac = []
+            out["acceptance_criteria"] = ac
+            continue
+        out[key] = value_stripped
+    return out if out else None, warnings
+
+
+def _validate_marker_payload(
+    payload: dict[str, Any]
+) -> tuple[dict[str, Any] | None, list[str]]:
+    warnings: list[str] = []
+    missing = MARKER_REQUIRED_FIELDS - set(payload.keys())
+    if missing:
+        warnings.append(f"marker_missing_fields:{','.join(sorted(missing))}")
+        return None, warnings
+
+    candidate_id = _bounded_str(payload.get("candidate_id"), MAX_ID_LEN)
+    if not candidate_id or not re.match(r"^[A-Za-z0-9_.\-]+$", candidate_id):
+        warnings.append("marker_invalid_candidate_id")
+        return None, warnings
+
+    phase = _bounded_str(payload.get("phase"), MAX_PHASE_LEN)
+    if not phase:
+        warnings.append("marker_missing_phase")
+        return None, warnings
+
+    title = _bounded_str(payload.get("title"), MAX_TITLE_LEN)
+    if not title:
+        warnings.append("marker_missing_title")
+        return None, warnings
+
+    category = payload.get("category")
+    if category not in CANDIDATE_KINDS:
+        warnings.append("marker_invalid_category")
+        return None, warnings
+
+    role = payload.get("required_agent_role")
+    if role not in dwq.AGENT_ROLES:
+        warnings.append("marker_invalid_required_agent_role")
+        return None, warnings
+
+    risk = payload.get("risk_level")
+    if risk not in ea.RISK_CLASSES:
+        warnings.append("marker_invalid_risk_level")
+        return None, warnings
+
+    target_path = _bounded_str(payload.get("target_path"), MAX_TARGET_PATH_LEN)
+    if not target_path:
+        warnings.append("marker_missing_target_path")
+        return None, warnings
+
+    hn_raw = payload.get("human_needed")
+    human_needed = _coerce_bool(hn_raw)
+    if human_needed is None:
+        warnings.append("marker_invalid_human_needed")
+        return None, warnings
+
+    hn_reason = payload.get("human_needed_reason")
+    if hn_reason not in dwq.HUMAN_NEEDED_REASONS:
+        warnings.append("marker_invalid_human_needed_reason")
+        return None, warnings
+    if human_needed and hn_reason == "none":
+        warnings.append("marker_human_needed_true_but_reason_none")
+        return None, warnings
+    if (not human_needed) and hn_reason != "none":
+        warnings.append("marker_human_needed_false_but_reason_not_none")
+        return None, warnings
+
+    ac = payload.get("acceptance_criteria") or []
+    if not isinstance(ac, list) or not ac:
+        warnings.append("marker_missing_acceptance_criteria")
+        return None, warnings
+    ac_clean: list[str] = []
+    for entry in ac[:MAX_AC_ITEMS]:
+        if isinstance(entry, str) and entry.strip():
+            ac_clean.append(_bounded_str(entry, MAX_AC_LINE_LEN))
+    if not ac_clean:
+        warnings.append("marker_acceptance_criteria_empty_after_clean")
+        return None, warnings
+
+    return (
+        {
+            "candidate_id": candidate_id,
+            "phase": phase,
+            "title": title,
+            "category": category,
+            "required_agent_role": role,
+            "risk_level": risk,
+            "target_path": _normalize_path(target_path),
+            "human_needed": human_needed,
+            "human_needed_reason": hn_reason,
+            "acceptance_criteria": ac_clean,
+        },
+        warnings,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Candidate construction
+# ---------------------------------------------------------------------------
+
+
+def _intake_status_for(
+    *, decision: ea.ExecutionDecision, human_needed: bool
+) -> str:
+    """Map (decision, human_needed) → closed intake_status value.
+
+    * Operator marked ``human_needed=true`` → ``human_needed``.
+    * Authority ``PERMANENTLY_DENIED`` → ``blocked``.
+    * Authority ``NEEDS_HUMAN`` → ``human_needed``.
+    * Authority ``AUTO_ALLOWED`` and not human_needed → ``eligible``.
+    * Anything else → ``proposed`` (fail-safe; never silently
+      ``eligible``).
+    """
+    if human_needed:
+        return "human_needed"
+    if decision.decision == ea.DECISION_PERMANENTLY_DENIED:
+        return "blocked"
+    if decision.decision == ea.DECISION_NEEDS_HUMAN:
+        return "human_needed"
+    if decision.decision == ea.DECISION_AUTO_ALLOWED:
+        return "eligible"
+    return "proposed"
+
+
+def _build_candidate(
+    validated: dict[str, Any],
+    *,
+    source_document: str,
+    source_anchor: str,
+    source_kind: str,
+) -> dict[str, Any]:
+    decision = ea.classify(
+        action_type="file_edit",
+        target_path=validated["target_path"],
+        risk_class=validated["risk_level"],
+    )
+    intake_status = _intake_status_for(
+        decision=decision,
+        human_needed=validated["human_needed"],
+    )
+    return {
+        "candidate_id": validated["candidate_id"],
+        "title": validated["title"],
+        "source_document": source_document,
+        "source_anchor": source_anchor,
+        "roadmap_phase": validated["phase"],
+        "source_kind": source_kind,
+        "candidate_kind": validated["category"],
+        "category": validated["category"],
+        "required_agent_role": validated["required_agent_role"],
+        "risk_level": validated["risk_level"],
+        "target_path": validated["target_path"],
+        "execution_authority_decision": decision.decision,
+        "execution_authority_reason": decision.reason,
+        "human_needed": validated["human_needed"],
+        "human_needed_reason": validated["human_needed_reason"],
+        "intake_status": intake_status,
+        "acceptance_criteria": validated["acceptance_criteria"],
+        "validation_requirements": [],
+        "promotion_target": "none",
+        "notes": "",
+    }
+
+
+def _candidates_from_doc(
+    doc_path: str, *, text: str, source_kind: str
+) -> tuple[list[dict[str, Any]], list[str]]:
+    warnings: list[str] = []
+    candidates: list[dict[str, Any]] = []
+    matches = list(_MARKER_RE.finditer(text))
+    if len(matches) > MAX_MARKERS_PER_DOC:
+        warnings.append(f"too_many_markers_truncated_at_{MAX_MARKERS_PER_DOC}")
+        matches = matches[:MAX_MARKERS_PER_DOC]
+    for idx, m in enumerate(matches, start=1):
+        body = m.group(1)
+        parsed, parse_warns = _parse_marker_body(body)
+        for w in parse_warns:
+            warnings.append(f"{doc_path}#marker{idx}:{w}")
+        if parsed is None:
+            continue
+        validated, val_warns = _validate_marker_payload(parsed)
+        for w in val_warns:
+            warnings.append(f"{doc_path}#marker{idx}:{w}")
+        if validated is None:
+            continue
+        candidate = _build_candidate(
+            validated,
+            source_document=doc_path,
+            source_anchor=f"marker_{idx}",
+            source_kind=source_kind,
+        )
+        candidates.append(candidate)
+    return candidates, warnings
+
+
+# ---------------------------------------------------------------------------
+# Aggregation
+# ---------------------------------------------------------------------------
+
+
+def _empty_counts() -> dict[str, Any]:
+    return {
+        "total": 0,
+        "by_source_kind": {k: 0 for k in SOURCE_KINDS},
+        "by_candidate_kind": {k: 0 for k in CANDIDATE_KINDS},
+        "by_intake_status": {s: 0 for s in INTAKE_STATUSES},
+        "by_execution_authority_decision": {
+            ea.DECISION_AUTO_ALLOWED: 0,
+            ea.DECISION_NEEDS_HUMAN: 0,
+            ea.DECISION_PERMANENTLY_DENIED: 0,
+        },
+        "by_required_agent_role": {r: 0 for r in dwq.AGENT_ROLES},
+        "by_promotion_target": {t: 0 for t in PROMOTION_TARGETS},
+        "human_needed": 0,
+        "eligible": 0,
+        "blocked": 0,
+    }
+
+
+def _aggregate_counts(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    counts = _empty_counts()
+    counts["total"] = len(rows)
+    for row in rows:
+        counts["by_source_kind"][row["source_kind"]] += 1
+        counts["by_candidate_kind"][row["candidate_kind"]] += 1
+        counts["by_intake_status"][row["intake_status"]] += 1
+        counts["by_execution_authority_decision"][
+            row["execution_authority_decision"]
+        ] += 1
+        counts["by_required_agent_role"][row["required_agent_role"]] += 1
+        counts["by_promotion_target"][row["promotion_target"]] += 1
+        if row["human_needed"]:
+            counts["human_needed"] += 1
+        if row["intake_status"] == "eligible":
+            counts["eligible"] += 1
+        if row["intake_status"] == "blocked":
+            counts["blocked"] += 1
+    return counts
+
+
+# ---------------------------------------------------------------------------
+# Snapshot assembly
+# ---------------------------------------------------------------------------
+
+
+def collect_snapshot(
+    *,
+    source_paths: tuple[str, ...] | None = None,
+    repo_root: Path | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    """Build the deterministic roadmap-intake snapshot.
+
+    Args:
+        source_paths: override the default canonical source paths.
+            Tests pass synthetic fixture paths here. The check
+            against archive prefixes always runs; non-canonical paths
+            are excluded with a validation_warning.
+        repo_root: override repo root for tests. Defaults to the
+            module's repo root.
+        generated_at_utc: override the wrapper's report timestamp.
+            Tests inject this for byte-stable output.
+    """
+    sp = source_paths if source_paths is not None else DEFAULT_SOURCE_PATHS
+    root = repo_root if repo_root is not None else REPO_ROOT
+    ts = generated_at_utc if generated_at_utc is not None else _utcnow()
+
+    warnings: list[str] = []
+    candidates: list[dict[str, Any]] = []
+    docs_used: list[str] = []
+    docs_missing: list[str] = []
+    seen_ids: set[str] = set()
+
+    for doc in sp:
+        norm = _normalize_path(doc)
+        if _is_archive_path(norm):
+            warnings.append(f"archive_path_excluded:{norm}")
+            continue
+        source_kind = SOURCE_PATH_TO_KIND.get(norm)
+        if source_kind is None:
+            warnings.append(f"non_canonical_source_path_excluded:{norm}")
+            continue
+        full_path = root / norm
+        text = _read_text(full_path)
+        if text is None:
+            docs_missing.append(norm)
+            continue
+        docs_used.append(norm)
+        doc_candidates, doc_warns = _candidates_from_doc(
+            norm, text=text, source_kind=source_kind
+        )
+        warnings.extend(doc_warns)
+        for cand in doc_candidates:
+            if cand["candidate_id"] in seen_ids:
+                warnings.append(
+                    f"{norm}:duplicate_candidate_id:{cand['candidate_id']}"
+                )
+                continue
+            seen_ids.add(cand["candidate_id"])
+            candidates.append(cand)
+
+    candidates.sort(key=lambda c: (c["source_kind"], c["candidate_id"]))
+
+    counts = _aggregate_counts(candidates)
+
+    if not docs_used:
+        note = NOTE_SOURCE_DOCS_MISSING if docs_missing else NOTE_NO_CANDIDATES
+    elif not candidates:
+        note = NOTE_NO_CANDIDATES
+    else:
+        note = NOTE_CANDIDATES_PRESENT
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": ts,
+        "step5_enabled_substage": STEP5_ENABLED_SUBSTAGE,
+        "step5_implementation_allowed": step5_implementation_allowed,
+        "canonical_source_paths": list(DEFAULT_SOURCE_PATHS),
+        "source_paths_used": docs_used,
+        "source_paths_missing": docs_missing,
+        "note": note,
+        "validation_warnings": warnings,
+        "vocabularies": {
+            "source_kinds": list(SOURCE_KINDS),
+            "candidate_kinds": list(CANDIDATE_KINDS),
+            "intake_statuses": list(INTAKE_STATUSES),
+            "promotion_targets": list(PROMOTION_TARGETS),
+            "agent_roles": list(dwq.AGENT_ROLES),
+            "risk_levels": list(ea.RISK_CLASSES),
+            "human_needed_reasons": list(dwq.HUMAN_NEEDED_REASONS),
+            "marker_required_fields": sorted(MARKER_REQUIRED_FIELDS),
+        },
+        "counts": counts,
+        "candidates": candidates,
+        "execution_authority_module_version": ea.MODULE_VERSION,
+        "queue_module_version": dwq.MODULE_VERSION,
+        "discipline_invariants": dict(_DISCIPLINE_INVARIANTS),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Atomic write
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Write ``payload`` as sorted-key indented JSON to ``path``,
+    atomically, refusing any path outside
+    ``logs/development_roadmap_intake/...``."""
+    posix = path.as_posix()
+    if _WRITE_PREFIX not in posix and not posix.startswith(_WRITE_PREFIX):
+        raise ValueError(
+            "development_roadmap_intake._atomic_write_json refuses "
+            f"non-intake-logs output path: {path}"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".development_roadmap_intake.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_outputs(snapshot: dict[str, Any]) -> Path:
+    _atomic_write_json(ARTIFACT_LATEST, snapshot)
+    return ARTIFACT_LATEST
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m reporting.development_roadmap_intake",
+        description=(
+            "Step 5.0.1 Roadmap Intake Bridge. Read-only deterministic "
+            "parser of explicit `<!-- ade_roadmap_intake ... -->` "
+            "markers in Roadmap v6, the Roadmap v6 Addendum, the QRE "
+            "phase-prompts doc, and the QRE ADE operating-manual doc. "
+            "No fuzzy parsing. Decides nothing; mutates nothing. Step "
+            "5 implementation remains BLOCKED."
+        ),
+    )
+    p.add_argument(
+        "--indent",
+        type=int,
+        default=2,
+        help="JSON indent for stdout output (0 for compact).",
+    )
+    p.add_argument(
+        "--no-write",
+        action="store_true",
+        help=(
+            "Do not persist logs/development_roadmap_intake/latest.json "
+            "(stdout only)."
+        ),
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    indent = args.indent if args.indent and args.indent > 0 else None
+    snap = collect_snapshot()
+    if not args.no_write:
+        write_outputs(snap)
+    json.dump(snap, sys.stdout, indent=indent, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/reporting/development_roadmap_intake_status.py
+++ b/reporting/development_roadmap_intake_status.py
@@ -1,0 +1,286 @@
+"""Step 5.0.1 — Roadmap Intake Bridge status summary.
+
+Read-only projection that consumes
+``logs/development_roadmap_intake/latest.json`` and emits a compact
+operator-facing status summary, counting candidates by ``source_kind``,
+``candidate_kind``, ``intake_status``, and
+``execution_authority_decision``.
+
+Hard guarantees (pinned by tests):
+
+* Stdlib + ``reporting.development_roadmap_intake``.
+* No subprocess, no network, no ``gh``, no ``git``.
+* No imports from ``dashboard``, ``automation``, ``broker``,
+  ``agent.risk``, ``agent.execution``, ``research``,
+  ``reporting.intelligent_routing``.
+* Pure read on the upstream artifact; never mutates ``latest.json``.
+* Atomic write only under ``logs/development_roadmap_intake_status/``.
+
+CLI::
+
+    python -m reporting.development_roadmap_intake_status
+    python -m reporting.development_roadmap_intake_status --indent 2
+    python -m reporting.development_roadmap_intake_status --no-write
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Final
+
+from reporting import development_roadmap_intake as dri
+from reporting import development_work_queue as dwq
+from reporting import execution_authority as ea
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[str] = "1.0"
+MODULE_VERSION: Final[str] = "v3.15.16.A14.5_0_1"
+REPORT_KIND: Final[str] = "development_roadmap_intake_status"
+
+ARTIFACT_DIR: Final[Path] = (
+    REPO_ROOT / "logs" / "development_roadmap_intake_status"
+)
+ARTIFACT_LATEST: Final[Path] = ARTIFACT_DIR / "latest.json"
+ARTIFACT_RELATIVE_PATH: Final[str] = (
+    "logs/development_roadmap_intake_status/latest.json"
+)
+
+_WRITE_PREFIX: Final[str] = "logs/development_roadmap_intake_status/"
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+
+def _schema_pinned() -> dict[str, Any]:
+    return {
+        "source_kinds": list(dri.SOURCE_KINDS),
+        "candidate_kinds": list(dri.CANDIDATE_KINDS),
+        "intake_statuses": list(dri.INTAKE_STATUSES),
+        "promotion_targets": list(dri.PROMOTION_TARGETS),
+        "agent_roles": list(dwq.AGENT_ROLES),
+        "risk_levels": list(ea.RISK_CLASSES),
+    }
+
+
+def _empty_counts() -> dict[str, Any]:
+    return {
+        "total": 0,
+        "human_needed": 0,
+        "eligible": 0,
+        "blocked": 0,
+        "by_source_kind": {k: 0 for k in dri.SOURCE_KINDS},
+        "by_candidate_kind": {k: 0 for k in dri.CANDIDATE_KINDS},
+        "by_intake_status": {s: 0 for s in dri.INTAKE_STATUSES},
+        "by_execution_authority_decision": {
+            ea.DECISION_AUTO_ALLOWED: 0,
+            ea.DECISION_NEEDS_HUMAN: 0,
+            ea.DECISION_PERMANENTLY_DENIED: 0,
+        },
+    }
+
+
+def collect_status(
+    *,
+    intake_artifact_path: Path | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    """Build a deterministic status snapshot from the intake artifact.
+
+    Args:
+        intake_artifact_path: override the default
+            ``logs/development_roadmap_intake/latest.json`` source.
+            Tests pass a synthetic fixture here.
+        generated_at_utc: override the wrapper's report timestamp.
+            Tests inject this for byte-stable output.
+    """
+    ip = (
+        intake_artifact_path
+        if intake_artifact_path is not None
+        else dri.ARTIFACT_LATEST
+    )
+    ts = generated_at_utc if generated_at_utc is not None else _utcnow()
+    payload = _read_json(ip)
+    if payload is None:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "module_version": MODULE_VERSION,
+            "report_kind": REPORT_KIND,
+            "generated_at_utc": ts,
+            "intake_artifact_path": str(ip),
+            "intake_artifact_available": False,
+            "intake_module_version": dri.MODULE_VERSION,
+            "step5_enabled_substage": dri.STEP5_ENABLED_SUBSTAGE,
+            "step5_implementation_allowed": dri.step5_implementation_allowed,
+            "schema_pinned": _schema_pinned(),
+            "counts": _empty_counts(),
+            "validation_warnings": [],
+            "note": "intake_artifact_absent",
+        }
+
+    upstream_counts = payload.get("counts") or {}
+    if not isinstance(upstream_counts, dict):
+        upstream_counts = {}
+
+    by_source_kind = (
+        upstream_counts.get("by_source_kind")
+        if isinstance(upstream_counts.get("by_source_kind"), dict)
+        else {}
+    )
+    by_candidate_kind = (
+        upstream_counts.get("by_candidate_kind")
+        if isinstance(upstream_counts.get("by_candidate_kind"), dict)
+        else {}
+    )
+    by_intake_status = (
+        upstream_counts.get("by_intake_status")
+        if isinstance(upstream_counts.get("by_intake_status"), dict)
+        else {}
+    )
+    by_decision = (
+        upstream_counts.get("by_execution_authority_decision")
+        if isinstance(
+            upstream_counts.get("by_execution_authority_decision"), dict
+        )
+        else {}
+    )
+
+    counts: dict[str, Any] = {
+        "total": int(upstream_counts.get("total") or 0),
+        "human_needed": int(upstream_counts.get("human_needed") or 0),
+        "eligible": int(upstream_counts.get("eligible") or 0),
+        "blocked": int(upstream_counts.get("blocked") or 0),
+        "by_source_kind": {
+            k: int(by_source_kind.get(k) or 0) for k in dri.SOURCE_KINDS
+        },
+        "by_candidate_kind": {
+            k: int(by_candidate_kind.get(k) or 0) for k in dri.CANDIDATE_KINDS
+        },
+        "by_intake_status": {
+            s: int(by_intake_status.get(s) or 0) for s in dri.INTAKE_STATUSES
+        },
+        "by_execution_authority_decision": {
+            ea.DECISION_AUTO_ALLOWED: int(
+                by_decision.get(ea.DECISION_AUTO_ALLOWED) or 0
+            ),
+            ea.DECISION_NEEDS_HUMAN: int(
+                by_decision.get(ea.DECISION_NEEDS_HUMAN) or 0
+            ),
+            ea.DECISION_PERMANENTLY_DENIED: int(
+                by_decision.get(ea.DECISION_PERMANENTLY_DENIED) or 0
+            ),
+        },
+    }
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": ts,
+        "intake_artifact_path": str(ip),
+        "intake_artifact_available": True,
+        "intake_module_version": payload.get("module_version"),
+        "intake_schema_version": payload.get("schema_version"),
+        "intake_generated_at_utc": payload.get("generated_at_utc"),
+        "intake_note": payload.get("note"),
+        "step5_enabled_substage": payload.get("step5_enabled_substage")
+        or dri.STEP5_ENABLED_SUBSTAGE,
+        "step5_implementation_allowed": bool(
+            payload.get("step5_implementation_allowed")
+        ),
+        "schema_pinned": _schema_pinned(),
+        "counts": counts,
+        "validation_warnings": list(payload.get("validation_warnings") or []),
+        "note": "intake_artifact_present",
+    }
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    posix = path.as_posix()
+    if _WRITE_PREFIX not in posix and not posix.startswith(_WRITE_PREFIX):
+        raise ValueError(
+            "development_roadmap_intake_status._atomic_write_json refuses "
+            f"non-intake-status-logs output path: {path}"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".development_roadmap_intake_status.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_outputs(snapshot: dict[str, Any]) -> Path:
+    _atomic_write_json(ARTIFACT_LATEST, snapshot)
+    return ARTIFACT_LATEST
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m reporting.development_roadmap_intake_status",
+        description=(
+            "Read-only summary of "
+            "logs/development_roadmap_intake/latest.json. Decides "
+            "nothing; mutates nothing."
+        ),
+    )
+    p.add_argument(
+        "--indent", type=int, default=2, help="JSON indent (0 for compact)."
+    )
+    p.add_argument(
+        "--no-write",
+        action="store_true",
+        help=(
+            "Do not persist "
+            "logs/development_roadmap_intake_status/latest.json "
+            "(stdout only)."
+        ),
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    indent = args.indent if args.indent and args.indent > 0 else None
+    snap = collect_status()
+    if not args.no_write:
+        write_outputs(snap)
+    json.dump(snap, sys.stdout, indent=indent, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/unit/test_development_roadmap_intake.py
+++ b/tests/unit/test_development_roadmap_intake.py
@@ -1,0 +1,917 @@
+"""Unit tests for Step 5.0.1 — Roadmap Intake Bridge.
+
+Synthetic deterministic fixtures only. The pure marker parser
+consumes only explicit ``<!-- ade_roadmap_intake ... -->`` markers
+inside the four canonical source documents:
+
+* ``docs/roadmap/Roadmap v6.md``
+* ``docs/roadmap/Roadmap v6 Addendum.md``
+* ``docs/roadmap/qre_roadmap_v6_phase_prompts.md``
+* ``docs/roadmap/qre_roadmap_v6_ade_operating_manual.md``
+
+Plain Markdown headings, prose, lists, and bullet points must produce
+zero candidates. Archive paths are excluded. No fuzzy parsing, no
+LLM, no network, no subprocess.
+
+Step 5 implementation remains BLOCKED:
+``step5_implementation_allowed`` is ``False`` and
+``STEP5_ENABLED_SUBSTAGE`` is ``"none"``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reporting import development_roadmap_intake as dri
+from reporting import development_work_queue as dwq
+from reporting import execution_authority as ea
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_repo_root(tmp_path: Path) -> Path:
+    (tmp_path / "docs" / "roadmap").mkdir(parents=True)
+    return tmp_path
+
+
+def _write_source_doc(root: Path, name: str, body: str) -> Path:
+    p = root / "docs" / "roadmap" / name
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+def _marker(**fields: Any) -> str:
+    base = {
+        "candidate_id": "syn_intake_001",
+        "phase": "v3.15.16",
+        "title": "Add a synthetic ADE intake doc improvement",
+        "category": "docs",
+        "required_agent_role": "implementation_agent",
+        "risk_level": "LOW",
+        "target_path": "docs/governance/agent_run_summaries/syn_intake.md",
+        "human_needed": "false",
+        "human_needed_reason": "none",
+    }
+    base.update({k: v for k, v in fields.items() if k != "acceptance_criteria"})
+    ac = fields.get("acceptance_criteria", ["candidate appears in latest.json"])
+    lines = ["<!-- ade_roadmap_intake"]
+    for key, val in base.items():
+        lines.append(f"{key}: {val}")
+    lines.append("acceptance_criteria:")
+    for item in ac:
+        lines.append(f"  - {item}")
+    lines.append("-->")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Vocabulary / shape
+# ---------------------------------------------------------------------------
+
+
+def test_source_kinds_are_closed() -> None:
+    assert dri.SOURCE_KINDS == (
+        "roadmap_v6",
+        "roadmap_v6_addendum",
+        "phase_prompt",
+        "operating_manual",
+    )
+
+
+def test_candidate_kinds_are_closed() -> None:
+    assert dri.CANDIDATE_KINDS == (
+        "docs",
+        "reporting",
+        "governance",
+        "observability",
+        "test",
+    )
+
+
+def test_intake_statuses_are_closed() -> None:
+    assert dri.INTAKE_STATUSES == (
+        "proposed",
+        "eligible",
+        "blocked",
+        "human_needed",
+        "rejected",
+    )
+
+
+def test_promotion_targets_are_closed() -> None:
+    assert dri.PROMOTION_TARGETS == (
+        "development_delegation",
+        "development_work_queue",
+        "none",
+    )
+
+
+def test_canonical_source_paths_match_doctrine() -> None:
+    assert set(dri.SOURCE_PATH_TO_KIND.keys()) == {
+        "docs/roadmap/Roadmap v6.md",
+        "docs/roadmap/Roadmap v6 Addendum.md",
+        "docs/roadmap/qre_roadmap_v6_phase_prompts.md",
+        "docs/roadmap/qre_roadmap_v6_ade_operating_manual.md",
+    }
+
+
+def test_default_source_paths_are_sorted_and_complete() -> None:
+    assert dri.DEFAULT_SOURCE_PATHS == tuple(sorted(dri.SOURCE_PATH_TO_KIND.keys()))
+
+
+def test_marker_required_fields_are_closed() -> None:
+    assert dri.MARKER_REQUIRED_FIELDS == frozenset(
+        {
+            "candidate_id",
+            "phase",
+            "title",
+            "category",
+            "required_agent_role",
+            "risk_level",
+            "target_path",
+            "human_needed",
+            "human_needed_reason",
+            "acceptance_criteria",
+        }
+    )
+
+
+def test_candidate_schema_keys_are_exact_and_ordered() -> None:
+    assert dri.CANDIDATE_SCHEMA_KEYS == (
+        "candidate_id",
+        "title",
+        "source_document",
+        "source_anchor",
+        "roadmap_phase",
+        "source_kind",
+        "candidate_kind",
+        "category",
+        "required_agent_role",
+        "risk_level",
+        "target_path",
+        "execution_authority_decision",
+        "execution_authority_reason",
+        "human_needed",
+        "human_needed_reason",
+        "intake_status",
+        "acceptance_criteria",
+        "validation_requirements",
+        "promotion_target",
+        "notes",
+    )
+
+
+def test_artifact_path_is_under_logs_not_research() -> None:
+    assert dri.ARTIFACT_RELATIVE_PATH.startswith(
+        "logs/development_roadmap_intake/"
+    )
+    assert "research/" not in dri.ARTIFACT_RELATIVE_PATH
+
+
+def test_atomic_write_refuses_non_intake_logs_path(tmp_path: Path) -> None:
+    bad = tmp_path / "evil_dir" / "latest.json"
+    with pytest.raises(ValueError):
+        dri._atomic_write_json(bad, {"x": 1})
+
+
+def test_atomic_write_refuses_non_intake_logs_path_within_logs(
+    tmp_path: Path,
+) -> None:
+    bad = tmp_path / "logs" / "some_other_module" / "latest.json"
+    with pytest.raises(ValueError):
+        dri._atomic_write_json(bad, {"x": 1})
+
+
+# ---------------------------------------------------------------------------
+# Step 5 invariants on every snapshot
+# ---------------------------------------------------------------------------
+
+
+def test_step5_invariants_pinned() -> None:
+    assert dri.step5_implementation_allowed is False
+    assert dri.STEP5_ENABLED_SUBSTAGE == "none"
+
+
+def test_snapshot_carries_step5_invariants(tmp_path: Path) -> None:
+    root = _make_repo_root(tmp_path)
+    snap = dri.collect_snapshot(
+        repo_root=root, generated_at_utc="2026-05-08T00:00:00Z"
+    )
+    assert snap["step5_enabled_substage"] == "none"
+    assert snap["step5_implementation_allowed"] is False
+
+
+def test_discipline_invariants_block_is_present(tmp_path: Path) -> None:
+    root = _make_repo_root(tmp_path)
+    snap = dri.collect_snapshot(repo_root=root)
+    inv = snap["discipline_invariants"]
+    assert inv["actually_modifies_target"] is False
+    assert inv["creates_real_branches"] is False
+    assert inv["opens_real_prs"] is False
+    assert inv["mergeable_by_agent"] is False
+    assert inv["deployable_by_agent"] is False
+    assert inv["writes_to_seed_jsonl"] is False
+    assert inv["writes_to_delegation_seed_jsonl"] is False
+    assert inv["fuzzy_parsing"] is False
+    assert inv["uses_subprocess_or_network"] is False
+    assert inv["calls_llm_or_external_api"] is False
+    assert inv["mutates_research_artifacts"] is False
+    assert inv["mutates_roadmap_status_fields"] is False
+    assert inv["marks_phase_complete"] is False
+    assert inv["operator_promotion_required"] is True
+    assert inv["step5_implementation_allowed"] is False
+    assert inv["diagnostics_do_not_trade"] is True
+
+
+# ---------------------------------------------------------------------------
+# Snapshot top-level shape
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_top_level_keys(tmp_path: Path) -> None:
+    root = _make_repo_root(tmp_path)
+    snap = dri.collect_snapshot(
+        repo_root=root, generated_at_utc="2026-05-08T00:00:00Z"
+    )
+    expected = {
+        "schema_version",
+        "module_version",
+        "report_kind",
+        "generated_at_utc",
+        "step5_enabled_substage",
+        "step5_implementation_allowed",
+        "canonical_source_paths",
+        "source_paths_used",
+        "source_paths_missing",
+        "note",
+        "validation_warnings",
+        "vocabularies",
+        "counts",
+        "candidates",
+        "execution_authority_module_version",
+        "queue_module_version",
+        "discipline_invariants",
+    }
+    assert set(snap.keys()) == expected
+    assert snap["report_kind"] == "development_roadmap_intake"
+
+
+# ---------------------------------------------------------------------------
+# False-positive guards (load-bearing)
+# ---------------------------------------------------------------------------
+
+
+def test_plain_markdown_headings_produce_zero_candidates(tmp_path: Path) -> None:
+    root = _make_repo_root(tmp_path)
+    body = """# Roadmap
+
+## v3.15.16
+
+- some bullet
+- another bullet
+
+### Sub-section
+
+prose explaining the section that contains the words `roadmap_intake`,
+`candidate`, and `marker` but is not inside a marker.
+"""
+    _write_source_doc(root, "Roadmap v6.md", body)
+    _write_source_doc(root, "Roadmap v6 Addendum.md", body)
+    _write_source_doc(root, "qre_roadmap_v6_phase_prompts.md", body)
+    _write_source_doc(root, "qre_roadmap_v6_ade_operating_manual.md", body)
+    snap = dri.collect_snapshot(
+        repo_root=root, generated_at_utc="2026-05-08T00:00:00Z"
+    )
+    assert snap["candidates"] == []
+    assert snap["note"] == dri.NOTE_NO_CANDIDATES
+
+
+def test_html_comment_without_intake_keyword_is_ignored(tmp_path: Path) -> None:
+    root = _make_repo_root(tmp_path)
+    body = """<!-- this is a regular html comment -->
+<!-- ade_roadmap_intake_lookalike: not the real opener -->
+<!-- ade_delegation
+delegation_id: not_intake
+title: not the right marker
+-->
+<!-- ade_intake -->
+"""
+    _write_source_doc(root, "Roadmap v6.md", body)
+    snap = dri.collect_snapshot(
+        repo_root=root, generated_at_utc="2026-05-08T00:00:00Z"
+    )
+    assert snap["candidates"] == []
+
+
+def test_archive_source_paths_are_excluded(tmp_path: Path) -> None:
+    """A roadmap path under docs/roadmap/archive/ must never be parsed
+    even if the operator passes it explicitly."""
+    root = _make_repo_root(tmp_path)
+    archive_path = "docs/roadmap/archive/qre_roadmap_v6_1.md"
+    (root / "docs" / "roadmap" / "archive").mkdir(parents=True)
+    (root / archive_path).write_text(_marker(), encoding="utf-8")
+    snap = dri.collect_snapshot(
+        source_paths=(archive_path,),
+        repo_root=root,
+        generated_at_utc="2026-05-08T00:00:00Z",
+    )
+    assert snap["candidates"] == []
+    assert any(
+        "archive_path_excluded" in w for w in snap["validation_warnings"]
+    )
+
+
+def test_non_canonical_source_path_is_excluded(tmp_path: Path) -> None:
+    """Any source path outside the closed canonical set must be
+    refused (defence in depth against accidental misuse)."""
+    root = _make_repo_root(tmp_path)
+    other_path = "docs/operator/some_other_doc.md"
+    (root / "docs" / "operator").mkdir(parents=True)
+    (root / other_path).write_text(_marker(), encoding="utf-8")
+    snap = dri.collect_snapshot(
+        source_paths=(other_path,),
+        repo_root=root,
+        generated_at_utc="2026-05-08T00:00:00Z",
+    )
+    assert snap["candidates"] == []
+    assert any(
+        "non_canonical_source_path_excluded" in w
+        for w in snap["validation_warnings"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Marker happy path
+# ---------------------------------------------------------------------------
+
+
+def test_valid_marker_in_addendum_produces_eligible_candidate(
+    tmp_path: Path,
+) -> None:
+    """An AUTO_ALLOWED target_path on a non-protected docs path
+    classifies as eligible."""
+    root = _make_repo_root(tmp_path)
+    _write_source_doc(
+        root,
+        "Roadmap v6 Addendum.md",
+        "## Some heading\n\n" + _marker() + "\n\nmore prose\n",
+    )
+    snap = dri.collect_snapshot(
+        repo_root=root, generated_at_utc="2026-05-08T00:00:00Z"
+    )
+    assert snap["counts"]["total"] == 1
+    cand = snap["candidates"][0]
+    assert set(cand.keys()) == set(dri.CANDIDATE_SCHEMA_KEYS)
+    assert cand["candidate_id"] == "syn_intake_001"
+    assert cand["source_kind"] == "roadmap_v6_addendum"
+    assert cand["roadmap_phase"] == "v3.15.16"
+    assert cand["candidate_kind"] == "docs"
+    assert cand["category"] == "docs"
+    assert cand["required_agent_role"] == "implementation_agent"
+    assert cand["risk_level"] == "LOW"
+    assert cand["target_path"] == "docs/governance/agent_run_summaries/syn_intake.md"
+    assert cand["execution_authority_decision"] == ea.DECISION_AUTO_ALLOWED
+    assert cand["intake_status"] == "eligible"
+    assert cand["human_needed"] is False
+    assert cand["human_needed_reason"] == "none"
+    assert cand["acceptance_criteria"] == ["candidate appears in latest.json"]
+    assert cand["promotion_target"] == "none"
+
+
+def test_marker_in_phase_prompts_uses_correct_source_kind(
+    tmp_path: Path,
+) -> None:
+    root = _make_repo_root(tmp_path)
+    _write_source_doc(
+        root,
+        "qre_roadmap_v6_phase_prompts.md",
+        _marker(candidate_id="syn_phase_001"),
+    )
+    snap = dri.collect_snapshot(
+        repo_root=root, generated_at_utc="2026-05-08T00:00:00Z"
+    )
+    assert snap["candidates"][0]["source_kind"] == "phase_prompt"
+
+
+def test_marker_in_operating_manual_uses_correct_source_kind(
+    tmp_path: Path,
+) -> None:
+    root = _make_repo_root(tmp_path)
+    _write_source_doc(
+        root,
+        "qre_roadmap_v6_ade_operating_manual.md",
+        _marker(candidate_id="syn_om_001"),
+    )
+    snap = dri.collect_snapshot(
+        repo_root=root, generated_at_utc="2026-05-08T00:00:00Z"
+    )
+    assert snap["candidates"][0]["source_kind"] == "operating_manual"
+
+
+def test_marker_in_roadmap_v6_uses_correct_source_kind(tmp_path: Path) -> None:
+    root = _make_repo_root(tmp_path)
+    _write_source_doc(
+        root,
+        "Roadmap v6.md",
+        _marker(candidate_id="syn_v6_001"),
+    )
+    snap = dri.collect_snapshot(
+        repo_root=root, generated_at_utc="2026-05-08T00:00:00Z"
+    )
+    assert snap["candidates"][0]["source_kind"] == "roadmap_v6"
+
+
+# ---------------------------------------------------------------------------
+# Authority classification edges
+# ---------------------------------------------------------------------------
+
+
+def test_protected_target_path_becomes_human_needed(tmp_path: Path) -> None:
+    """A canonical roadmap target_path classifies as NEEDS_HUMAN, so
+    intake_status must be human_needed (not eligible)."""
+    root = _make_repo_root(tmp_path)
+    _write_source_doc(
+        root,
+        "Roadmap v6 Addendum.md",
+        _marker(
+            candidate_id="syn_protected_001",
+            target_path="docs/roadmap/Roadmap v6.md",
+            risk_level="MEDIUM",
+        ),
+    )
+    snap = dri.collect_snapshot(
+        repo_root=root, generated_at_utc="2026-05-08T00:00:00Z"
+    )
+    cand = snap["candidates"][0]
+    assert cand["execution_authority_decision"] == ea.DECISION_NEEDS_HUMAN
+    assert cand["intake_status"] == "human_needed"
+
+
+def test_frozen_contract_target_path_becomes_blocked(tmp_path: Path) -> None:
+    """A frozen-contract target_path classifies as PERMANENTLY_DENIED,
+    so intake_status must be blocked."""
+    root = _make_repo_root(tmp_path)
+    _write_source_doc(
+        root,
+        "Roadmap v6 Addendum.md",
+        _marker(
+            candidate_id="syn_blocked_001",
+            target_path="research/research_latest.json",
+            risk_level="HIGH",
+        ),
+    )
+    snap = dri.collect_snapshot(
+        repo_root=root, generated_at_utc="2026-05-08T00:00:00Z"
+    )
+    cand = snap["candidates"][0]
+    assert cand["execution_authority_decision"] == ea.DECISION_PERMANENTLY_DENIED
+    assert cand["intake_status"] == "blocked"
+
+
+def test_human_needed_true_overrides_auto_allowed(tmp_path: Path) -> None:
+    """If the operator marked human_needed=true, intake_status must
+    be human_needed regardless of the authority decision."""
+    root = _make_repo_root(tmp_path)
+    _write_source_doc(
+        root,
+        "Roadmap v6 Addendum.md",
+        _marker(
+            candidate_id="syn_hn_001",
+            human_needed="true",
+            human_needed_reason="architecture_crossroads",
+        ),
+    )
+    snap = dri.collect_snapshot(
+        repo_root=root, generated_at_utc="2026-05-08T00:00:00Z"
+    )
+    cand = snap["candidates"][0]
+    assert cand["intake_status"] == "human_needed"
+    assert cand["human_needed"] is True
+    # The underlying authority decision can still be AUTO_ALLOWED on
+    # a non-protected docs target — but the status flips on
+    # operator-explicit human_needed=true.
+    assert cand["execution_authority_decision"] == ea.DECISION_AUTO_ALLOWED
+
+
+# ---------------------------------------------------------------------------
+# Marker validation — required fields and closed vocabularies
+# ---------------------------------------------------------------------------
+
+
+def test_missing_required_field_drops_marker(tmp_path: Path) -> None:
+    root = _make_repo_root(tmp_path)
+    body = (
+        "<!-- ade_roadmap_intake\n"
+        "candidate_id: syn_missing_ac\n"
+        "phase: v3.15.16\n"
+        "title: missing AC\n"
+        "category: docs\n"
+        "required_agent_role: implementation_agent\n"
+        "risk_level: LOW\n"
+        "target_path: docs/governance/x.md\n"
+        "human_needed: false\n"
+        "human_needed_reason: none\n"
+        "-->\n"
+    )
+    _write_source_doc(root, "Roadmap v6 Addendum.md", body)
+    snap = dri.collect_snapshot(
+        repo_root=root, generated_at_utc="2026-05-08T00:00:00Z"
+    )
+    assert snap["candidates"] == []
+    assert any(
+        "marker_missing_fields" in w for w in snap["validation_warnings"]
+    )
+
+
+def test_invalid_category_drops_marker(tmp_path: Path) -> None:
+    root = _make_repo_root(tmp_path)
+    _write_source_doc(
+        root,
+        "Roadmap v6 Addendum.md",
+        _marker(category="not_a_kind"),
+    )
+    snap = dri.collect_snapshot(
+        repo_root=root, generated_at_utc="2026-05-08T00:00:00Z"
+    )
+    assert snap["candidates"] == []
+    assert any("invalid_category" in w for w in snap["validation_warnings"])
+
+
+def test_invalid_role_drops_marker(tmp_path: Path) -> None:
+    root = _make_repo_root(tmp_path)
+    _write_source_doc(
+        root,
+        "Roadmap v6 Addendum.md",
+        _marker(required_agent_role="not_a_role"),
+    )
+    snap = dri.collect_snapshot(
+        repo_root=root, generated_at_utc="2026-05-08T00:00:00Z"
+    )
+    assert snap["candidates"] == []
+    assert any(
+        "invalid_required_agent_role" in w for w in snap["validation_warnings"]
+    )
+
+
+def test_invalid_risk_level_drops_marker(tmp_path: Path) -> None:
+    root = _make_repo_root(tmp_path)
+    _write_source_doc(
+        root, "Roadmap v6 Addendum.md", _marker(risk_level="EXTREME")
+    )
+    snap = dri.collect_snapshot(
+        repo_root=root, generated_at_utc="2026-05-08T00:00:00Z"
+    )
+    assert snap["candidates"] == []
+    assert any(
+        "invalid_risk_level" in w for w in snap["validation_warnings"]
+    )
+
+
+def test_human_needed_consistency_with_reason_is_enforced(
+    tmp_path: Path,
+) -> None:
+    root = _make_repo_root(tmp_path)
+    _write_source_doc(
+        root,
+        "Roadmap v6 Addendum.md",
+        _marker(human_needed="true", human_needed_reason="none"),
+    )
+    snap = dri.collect_snapshot(
+        repo_root=root, generated_at_utc="2026-05-08T00:00:00Z"
+    )
+    assert snap["candidates"] == []
+    assert any(
+        "human_needed_true_but_reason_none" in w
+        for w in snap["validation_warnings"]
+    )
+
+
+def test_invalid_candidate_id_drops_marker(tmp_path: Path) -> None:
+    root = _make_repo_root(tmp_path)
+    _write_source_doc(
+        root,
+        "Roadmap v6 Addendum.md",
+        _marker(candidate_id="bad id with spaces!"),
+    )
+    snap = dri.collect_snapshot(
+        repo_root=root, generated_at_utc="2026-05-08T00:00:00Z"
+    )
+    assert snap["candidates"] == []
+    assert any(
+        "invalid_candidate_id" in w for w in snap["validation_warnings"]
+    )
+
+
+def test_missing_target_path_drops_marker(tmp_path: Path) -> None:
+    root = _make_repo_root(tmp_path)
+    _write_source_doc(
+        root,
+        "Roadmap v6 Addendum.md",
+        _marker(target_path=""),
+    )
+    snap = dri.collect_snapshot(
+        repo_root=root, generated_at_utc="2026-05-08T00:00:00Z"
+    )
+    assert snap["candidates"] == []
+    assert any(
+        "missing_target_path" in w for w in snap["validation_warnings"]
+    )
+
+
+def test_invalid_marker_does_not_crash(tmp_path: Path) -> None:
+    """A wholly malformed marker must produce a validation_warning
+    rather than raising an exception."""
+    root = _make_repo_root(tmp_path)
+    body = (
+        "<!-- ade_roadmap_intake\n"
+        "this line has no colon\n"
+        "neither does this one\n"
+        "-->\n"
+    )
+    _write_source_doc(root, "Roadmap v6 Addendum.md", body)
+    snap = dri.collect_snapshot(
+        repo_root=root, generated_at_utc="2026-05-08T00:00:00Z"
+    )
+    assert snap["candidates"] == []
+    assert snap["validation_warnings"]
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+def test_determinism_with_injected_timestamp(tmp_path: Path) -> None:
+    root = _make_repo_root(tmp_path)
+    _write_source_doc(root, "Roadmap v6 Addendum.md", _marker())
+    snap_a = dri.collect_snapshot(
+        repo_root=root, generated_at_utc="2026-05-08T00:00:00Z"
+    )
+    snap_b = dri.collect_snapshot(
+        repo_root=root, generated_at_utc="2026-05-08T00:00:00Z"
+    )
+    a_bytes = json.dumps(snap_a, sort_keys=True, indent=2).encode("utf-8")
+    b_bytes = json.dumps(snap_b, sort_keys=True, indent=2).encode("utf-8")
+    assert a_bytes == b_bytes
+
+
+def test_candidates_sort_deterministically(tmp_path: Path) -> None:
+    """Order is (source_kind, candidate_id) ascending."""
+    root = _make_repo_root(tmp_path)
+    _write_source_doc(
+        root,
+        "Roadmap v6 Addendum.md",
+        "\n\n".join(
+            [
+                _marker(candidate_id=f"id_{i}")
+                for i in ("003", "001", "002")
+            ]
+        ),
+    )
+    snap = dri.collect_snapshot(
+        repo_root=root, generated_at_utc="2026-05-08T00:00:00Z"
+    )
+    ids = [c["candidate_id"] for c in snap["candidates"]]
+    assert ids == sorted(ids)
+
+
+def test_duplicate_candidate_id_within_same_doc_is_dropped(
+    tmp_path: Path,
+) -> None:
+    root = _make_repo_root(tmp_path)
+    _write_source_doc(
+        root,
+        "Roadmap v6 Addendum.md",
+        "\n\n".join([_marker(candidate_id="dup_001")] * 2),
+    )
+    snap = dri.collect_snapshot(
+        repo_root=root, generated_at_utc="2026-05-08T00:00:00Z"
+    )
+    assert snap["counts"]["total"] == 1
+    assert any(
+        "duplicate_candidate_id" in w for w in snap["validation_warnings"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Counts
+# ---------------------------------------------------------------------------
+
+
+def test_counts_aggregate_and_close_vocabularies(tmp_path: Path) -> None:
+    root = _make_repo_root(tmp_path)
+    _write_source_doc(
+        root,
+        "Roadmap v6.md",
+        _marker(candidate_id="a"),
+    )
+    _write_source_doc(
+        root,
+        "Roadmap v6 Addendum.md",
+        _marker(
+            candidate_id="b",
+            human_needed="true",
+            human_needed_reason="architecture_crossroads",
+        ),
+    )
+    snap = dri.collect_snapshot(
+        repo_root=root, generated_at_utc="2026-05-08T00:00:00Z"
+    )
+    counts = snap["counts"]
+    assert counts["total"] == 2
+    assert counts["human_needed"] == 1
+    assert sum(counts["by_source_kind"].values()) == 2
+    assert sum(counts["by_candidate_kind"].values()) == 2
+    assert sum(counts["by_intake_status"].values()) == 2
+    assert sum(counts["by_execution_authority_decision"].values()) == 2
+    # Eligible (auto-allowed, not human_needed) vs human_needed.
+    assert counts["eligible"] == 1
+    assert counts["by_intake_status"]["human_needed"] == 1
+
+
+def test_human_needed_reasons_are_subset_of_a8(tmp_path: Path) -> None:
+    """Every reason emitted must be in the A8 closed vocabulary."""
+    root = _make_repo_root(tmp_path)
+    _write_source_doc(
+        root,
+        "Roadmap v6 Addendum.md",
+        _marker(
+            human_needed="true",
+            human_needed_reason="protected_governance_change",
+        ),
+    )
+    snap = dri.collect_snapshot(
+        repo_root=root, generated_at_utc="2026-05-08T00:00:00Z"
+    )
+    for c in snap["candidates"]:
+        assert c["human_needed_reason"] in dwq.HUMAN_NEEDED_REASONS
+
+
+# ---------------------------------------------------------------------------
+# Source-text scans (no subprocess / no network / no forbidden imports)
+# ---------------------------------------------------------------------------
+
+
+def _module_source() -> str:
+    return Path(dri.__file__).read_text(encoding="utf-8")
+
+
+def _imported_module_names() -> set[str]:
+    import ast
+
+    src = _module_source()
+    tree = ast.parse(src)
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module is not None:
+                names.add(node.module)
+    return names
+
+
+def test_no_subprocess_in_module() -> None:
+    src = _module_source()
+    assert "import subprocess" not in src
+    assert "from subprocess" not in src
+
+
+def test_no_network_in_module() -> None:
+    src = _module_source()
+    for forbidden in (
+        "import socket",
+        "import urllib",
+        "import http.client",
+        "import requests",
+    ):
+        assert forbidden not in src
+    assert "from socket" not in src
+    assert "from urllib" not in src
+    assert "from http" not in src
+
+
+def test_no_dashboard_or_live_path_or_qre_imports() -> None:
+    forbidden_prefixes = (
+        "dashboard",
+        "automation",
+        "broker",
+        "agent.risk",
+        "agent.execution",
+        "research",
+        "reporting.intelligent_routing",
+    )
+    for module in _imported_module_names():
+        for prefix in forbidden_prefixes:
+            assert not (
+                module == prefix or module.startswith(prefix + ".")
+            ), f"forbidden import: {module}"
+
+
+def test_no_gh_or_git_subprocess_references() -> None:
+    src = _module_source()
+    for forbidden in (
+        "subprocess.run",
+        "subprocess.Popen",
+        "os.system",
+        "os.popen",
+        "shell=True",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_no_llm_or_external_api_calls() -> None:
+    """No anthropic / openai / requests / httpx imports."""
+    src = _module_source()
+    for forbidden in (
+        "anthropic",
+        "openai",
+        "import requests",
+        "import httpx",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_module_imports_cleanly() -> None:
+    importlib.reload(dri)
+    assert callable(dri.collect_snapshot)
+
+
+# ---------------------------------------------------------------------------
+# Schema-version + module-version surfaces
+# ---------------------------------------------------------------------------
+
+
+def test_schema_and_module_version_strings() -> None:
+    assert isinstance(dri.SCHEMA_VERSION, str) and dri.SCHEMA_VERSION
+    assert isinstance(dri.MODULE_VERSION, str) and dri.MODULE_VERSION
+
+
+# ---------------------------------------------------------------------------
+# Roadmap v6 Addendum extension framing preserved in docs
+# ---------------------------------------------------------------------------
+
+
+def test_governance_doc_preserves_addendum_extension_framing() -> None:
+    doc = (
+        Path(__file__).resolve().parents[2]
+        / "docs"
+        / "governance"
+        / "development_roadmap_intake.md"
+    )
+    text = doc.read_text(encoding="utf-8").lower()
+    assert "extension" in text
+    assert "roadmap v6" in text
+    assert "addendum" in text
+    assert "canonical" in text
+
+
+def test_governance_doc_pins_no_step5_escalation() -> None:
+    doc = (
+        Path(__file__).resolve().parents[2]
+        / "docs"
+        / "governance"
+        / "development_roadmap_intake.md"
+    )
+    text = doc.read_text(encoding="utf-8").lower()
+    assert "step5_implementation_allowed" in text
+    assert "step5_enabled_substage" in text
+    assert "no step 5.1" in text or "no step 5.1, no step 5.2" in text
+
+
+# ---------------------------------------------------------------------------
+# Production-doc safety (the committed canonical sources must not yet
+# contain explicit intake markers — we want this PR's diff to be
+# deterministic and to land without polluting roadmap docs).
+# ---------------------------------------------------------------------------
+
+
+def test_committed_canonical_sources_have_no_unparseable_markers() -> None:
+    """If any of the four canonical sources happen to contain real
+    `<!-- ade_roadmap_intake ... -->` markers, every one must parse
+    cleanly. This test is tolerant of zero markers (the default) and
+    strict on validation warnings only when markers exist."""
+    root = Path(__file__).resolve().parents[2]
+    snap = dri.collect_snapshot(
+        repo_root=root, generated_at_utc="2026-05-08T00:00:00Z"
+    )
+    parse_warns = [
+        w
+        for w in snap["validation_warnings"]
+        if "marker" in w
+        and "non_canonical_source_path_excluded" not in w
+        and "archive_path_excluded" not in w
+    ]
+    if snap["candidates"]:
+        # If we've already begun seeding markers, none of them may be
+        # malformed.
+        assert not parse_warns, parse_warns

--- a/tests/unit/test_development_roadmap_intake_status.py
+++ b/tests/unit/test_development_roadmap_intake_status.py
@@ -1,0 +1,326 @@
+"""Unit tests for Step 5.0.1 — Roadmap Intake Bridge status summary."""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reporting import development_roadmap_intake as dri
+from reporting import development_roadmap_intake_status as dris
+from reporting import development_work_queue as dwq
+from reporting import execution_authority as ea
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_intake_artifact(tmp_path: Path, payload: dict[str, Any]) -> Path:
+    p = tmp_path / "logs" / "development_roadmap_intake" / "latest.json"
+    p.parent.mkdir(parents=True)
+    p.write_text(
+        json.dumps(payload, sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return p
+
+
+def _synthetic_intake_payload(
+    *,
+    counts_total: int = 2,
+    human_needed: int = 1,
+    eligible: int = 1,
+    blocked: int = 0,
+    by_intake_status: dict[str, int] | None = None,
+    by_source_kind: dict[str, int] | None = None,
+    by_candidate_kind: dict[str, int] | None = None,
+    by_decision: dict[str, int] | None = None,
+    note: str = "intake_candidates_present",
+    validation_warnings: list[str] | None = None,
+) -> dict[str, Any]:
+    statuses = {s: 0 for s in dri.INTAKE_STATUSES}
+    if by_intake_status:
+        statuses.update(by_intake_status)
+    sources = {k: 0 for k in dri.SOURCE_KINDS}
+    if by_source_kind:
+        sources.update(by_source_kind)
+    kinds = {k: 0 for k in dri.CANDIDATE_KINDS}
+    if by_candidate_kind:
+        kinds.update(by_candidate_kind)
+    decisions = {
+        ea.DECISION_AUTO_ALLOWED: 0,
+        ea.DECISION_NEEDS_HUMAN: 0,
+        ea.DECISION_PERMANENTLY_DENIED: 0,
+    }
+    if by_decision:
+        decisions.update(by_decision)
+    return {
+        "schema_version": "1.0",
+        "module_version": dri.MODULE_VERSION,
+        "report_kind": "development_roadmap_intake",
+        "generated_at_utc": "2026-05-08T00:00:00Z",
+        "step5_enabled_substage": "none",
+        "step5_implementation_allowed": False,
+        "canonical_source_paths": list(dri.DEFAULT_SOURCE_PATHS),
+        "source_paths_used": [],
+        "source_paths_missing": [],
+        "note": note,
+        "validation_warnings": list(validation_warnings or []),
+        "vocabularies": {
+            "source_kinds": list(dri.SOURCE_KINDS),
+            "candidate_kinds": list(dri.CANDIDATE_KINDS),
+            "intake_statuses": list(dri.INTAKE_STATUSES),
+            "promotion_targets": list(dri.PROMOTION_TARGETS),
+            "agent_roles": list(dwq.AGENT_ROLES),
+            "risk_levels": list(ea.RISK_CLASSES),
+            "human_needed_reasons": list(dwq.HUMAN_NEEDED_REASONS),
+            "marker_required_fields": sorted(dri.MARKER_REQUIRED_FIELDS),
+        },
+        "counts": {
+            "total": counts_total,
+            "by_source_kind": sources,
+            "by_candidate_kind": kinds,
+            "by_intake_status": statuses,
+            "by_execution_authority_decision": decisions,
+            "by_required_agent_role": {r: 0 for r in dwq.AGENT_ROLES},
+            "by_promotion_target": {t: 0 for t in dri.PROMOTION_TARGETS},
+            "human_needed": human_needed,
+            "eligible": eligible,
+            "blocked": blocked,
+        },
+        "candidates": [],
+        "execution_authority_module_version": ea.MODULE_VERSION,
+        "queue_module_version": dwq.MODULE_VERSION,
+        "discipline_invariants": {},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Vocabulary / shape
+# ---------------------------------------------------------------------------
+
+
+def test_artifact_path_under_logs_only() -> None:
+    assert dris.ARTIFACT_RELATIVE_PATH.startswith(
+        "logs/development_roadmap_intake_status/"
+    )
+    assert "research/" not in dris.ARTIFACT_RELATIVE_PATH
+
+
+def test_atomic_write_refuses_non_status_logs_path(tmp_path: Path) -> None:
+    bad = tmp_path / "evil_dir" / "latest.json"
+    with pytest.raises(ValueError):
+        dris._atomic_write_json(bad, {"x": 1})
+
+
+def test_atomic_write_refuses_other_logs_subdir(tmp_path: Path) -> None:
+    bad = tmp_path / "logs" / "development_roadmap_intake" / "latest.json"
+    with pytest.raises(ValueError):
+        dris._atomic_write_json(bad, {"x": 1})
+
+
+# ---------------------------------------------------------------------------
+# Status when upstream artifact is absent
+# ---------------------------------------------------------------------------
+
+
+def test_status_when_artifact_absent(tmp_path: Path) -> None:
+    missing = tmp_path / "logs" / "development_roadmap_intake" / "latest.json"
+    snap = dris.collect_status(
+        intake_artifact_path=missing,
+        generated_at_utc="2026-05-08T00:00:00Z",
+    )
+    assert snap["intake_artifact_available"] is False
+    assert snap["counts"]["total"] == 0
+    assert snap["counts"]["human_needed"] == 0
+    assert snap["counts"]["eligible"] == 0
+    assert snap["counts"]["blocked"] == 0
+    assert snap["note"] == "intake_artifact_absent"
+    assert snap["step5_implementation_allowed"] is False
+    assert snap["step5_enabled_substage"] == "none"
+    # The schema_pinned block must echo the closed vocabularies.
+    sp = snap["schema_pinned"]
+    assert sp["source_kinds"] == list(dri.SOURCE_KINDS)
+    assert sp["candidate_kinds"] == list(dri.CANDIDATE_KINDS)
+    assert sp["intake_statuses"] == list(dri.INTAKE_STATUSES)
+    assert sp["promotion_targets"] == list(dri.PROMOTION_TARGETS)
+
+
+# ---------------------------------------------------------------------------
+# Status with synthetic upstream payload
+# ---------------------------------------------------------------------------
+
+
+def test_status_counts_mirror_upstream(tmp_path: Path) -> None:
+    payload = _synthetic_intake_payload(
+        counts_total=3,
+        human_needed=1,
+        eligible=1,
+        blocked=1,
+        by_intake_status={
+            "eligible": 1,
+            "blocked": 1,
+            "human_needed": 1,
+        },
+        by_source_kind={
+            "roadmap_v6": 1,
+            "roadmap_v6_addendum": 1,
+            "phase_prompt": 1,
+        },
+        by_candidate_kind={
+            "docs": 2,
+            "reporting": 1,
+        },
+        by_decision={
+            ea.DECISION_AUTO_ALLOWED: 1,
+            ea.DECISION_NEEDS_HUMAN: 1,
+            ea.DECISION_PERMANENTLY_DENIED: 1,
+        },
+    )
+    artifact = _write_intake_artifact(tmp_path, payload)
+    snap = dris.collect_status(
+        intake_artifact_path=artifact,
+        generated_at_utc="2026-05-08T00:00:00Z",
+    )
+    assert snap["intake_artifact_available"] is True
+    assert snap["counts"]["total"] == 3
+    assert snap["counts"]["human_needed"] == 1
+    assert snap["counts"]["eligible"] == 1
+    assert snap["counts"]["blocked"] == 1
+    assert snap["counts"]["by_intake_status"]["eligible"] == 1
+    assert snap["counts"]["by_intake_status"]["blocked"] == 1
+    assert snap["counts"]["by_intake_status"]["human_needed"] == 1
+    assert snap["counts"]["by_source_kind"]["roadmap_v6"] == 1
+    assert snap["counts"]["by_source_kind"]["roadmap_v6_addendum"] == 1
+    assert snap["counts"]["by_source_kind"]["phase_prompt"] == 1
+    assert snap["counts"]["by_candidate_kind"]["docs"] == 2
+    assert snap["counts"]["by_candidate_kind"]["reporting"] == 1
+    assert snap["counts"]["by_execution_authority_decision"][
+        ea.DECISION_AUTO_ALLOWED
+    ] == 1
+    assert snap["counts"]["by_execution_authority_decision"][
+        ea.DECISION_NEEDS_HUMAN
+    ] == 1
+    assert snap["counts"]["by_execution_authority_decision"][
+        ea.DECISION_PERMANENTLY_DENIED
+    ] == 1
+    assert snap["intake_module_version"] == dri.MODULE_VERSION
+    assert snap["intake_note"] == "intake_candidates_present"
+    assert snap["step5_implementation_allowed"] is False
+    assert snap["step5_enabled_substage"] == "none"
+
+
+def test_status_validation_warnings_pass_through(tmp_path: Path) -> None:
+    payload = _synthetic_intake_payload(
+        validation_warnings=["docs/roadmap/Foo.md#marker1:invalid_category"],
+    )
+    artifact = _write_intake_artifact(tmp_path, payload)
+    snap = dris.collect_status(
+        intake_artifact_path=artifact,
+        generated_at_utc="2026-05-08T00:00:00Z",
+    )
+    assert snap["validation_warnings"] == [
+        "docs/roadmap/Foo.md#marker1:invalid_category"
+    ]
+
+
+def test_status_handles_corrupt_artifact(tmp_path: Path) -> None:
+    bad = tmp_path / "logs" / "development_roadmap_intake" / "latest.json"
+    bad.parent.mkdir(parents=True)
+    bad.write_text("not json at all", encoding="utf-8")
+    snap = dris.collect_status(
+        intake_artifact_path=bad,
+        generated_at_utc="2026-05-08T00:00:00Z",
+    )
+    assert snap["intake_artifact_available"] is False
+    assert snap["note"] == "intake_artifact_absent"
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+def test_status_determinism_with_injected_timestamp(tmp_path: Path) -> None:
+    payload = _synthetic_intake_payload()
+    artifact = _write_intake_artifact(tmp_path, payload)
+    snap_a = dris.collect_status(
+        intake_artifact_path=artifact,
+        generated_at_utc="2026-05-08T00:00:00Z",
+    )
+    snap_b = dris.collect_status(
+        intake_artifact_path=artifact,
+        generated_at_utc="2026-05-08T00:00:00Z",
+    )
+    a_bytes = json.dumps(snap_a, sort_keys=True, indent=2).encode("utf-8")
+    b_bytes = json.dumps(snap_b, sort_keys=True, indent=2).encode("utf-8")
+    assert a_bytes == b_bytes
+
+
+# ---------------------------------------------------------------------------
+# Source-text scans (no subprocess / no network / no forbidden imports)
+# ---------------------------------------------------------------------------
+
+
+def _module_source() -> str:
+    return Path(dris.__file__).read_text(encoding="utf-8")
+
+
+def _imported_module_names() -> set[str]:
+    import ast
+
+    src = _module_source()
+    tree = ast.parse(src)
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module is not None:
+                names.add(node.module)
+    return names
+
+
+def test_no_subprocess_in_status_module() -> None:
+    src = _module_source()
+    assert "import subprocess" not in src
+    assert "from subprocess" not in src
+
+
+def test_no_network_in_status_module() -> None:
+    src = _module_source()
+    for forbidden in (
+        "import socket",
+        "import urllib",
+        "import http.client",
+        "import requests",
+    ):
+        assert forbidden not in src
+
+
+def test_no_forbidden_imports_in_status_module() -> None:
+    forbidden_prefixes = (
+        "dashboard",
+        "automation",
+        "broker",
+        "agent.risk",
+        "agent.execution",
+        "research",
+        "reporting.intelligent_routing",
+    )
+    for module in _imported_module_names():
+        for prefix in forbidden_prefixes:
+            assert not (
+                module == prefix or module.startswith(prefix + ".")
+            ), f"forbidden import: {module}"
+
+
+def test_status_module_imports_cleanly() -> None:
+    importlib.reload(dris)
+    assert callable(dris.collect_status)


### PR DESCRIPTION
## Summary

Adds a deterministic, stdlib-only **Roadmap Intake Bridge** that converts explicit `<!-- ade_roadmap_intake ... -->` markers in Roadmap v6, the Roadmap v6 Addendum, the QRE phase-prompts doc, and the QRE ADE operating-manual doc into bounded ADE candidate work items.

This unblocks ADE picking up real roadmap work without granting Step 5.1 authority and without fuzzy parsing.

### What lands

- `reporting/development_roadmap_intake.py` — pure marker parser, closed vocabularies (`source_kind`, `candidate_kind`, `intake_status`, `promotion_target`), per-candidate `execution_authority.classify(...)`, atomic write under `logs/development_roadmap_intake/`.
- `reporting/development_roadmap_intake_status.py` — status summary counting by `source_kind`, `candidate_kind`, `intake_status`, and `execution_authority_decision`.
- `docs/governance/development_roadmap_intake.md` — full surface doc; preserves "Roadmap v6 canonical, Addendum is extension" framing.
- `tests/unit/test_development_roadmap_intake*.py` — **61 unit tests** covering vocabularies, marker validation, false-positive guards, authority edges, determinism, archive exclusion, atomic-write refusal, and AST-level forbidden-import scans.

### Hard guarantees (pinned by tests)

- No fuzzy parsing — plain headings produce zero candidates.
- No automatic promotion into `seed.jsonl` / `delegation_seed.jsonl`.
- No subprocess, no network, no LLM, no `gh`, no `git`.
- No imports of `dashboard` / `automation` / `broker` / `agent.risk` / `agent.execution` / `research` / `reporting.intelligent_routing`.
- Atomic write only under `logs/development_roadmap_intake[_status]/`.
- `step5_implementation_allowed = False` and `STEP5_ENABLED_SUBSTAGE = "none"` carried through every artefact.
- Archive paths excluded; non-canonical source paths excluded with a warning.

### Out of scope (explicitly)

- No Step 5.1, no Step 5.2 — they remain BLOCKED.
- No flip of `step5_implementation_allowed`.
- No flip of `STEP5_ENABLED_SUBSTAGE`.
- No autonomy-ladder change.
- No edit of canonical roadmap status fields. No phase marked complete.
- No QRE / Intelligent Routing change. No research-artifact mutation.
- No `.claude/**` edit. No live / paper / shadow / risk / broker / execution touch.
- No marker pollution of production roadmap docs (synthetic fixtures only in tests).

## Test plan

- [x] `python scripts/governance_lint.py` — OK (16 agents, 5 workflows).
- [x] `python -m pytest tests/unit/test_development_roadmap_intake*.py -q` — **61 passed**.
- [x] `python -m pytest tests/smoke -q` — **18 passed**.
- [x] `python -m pytest tests/unit/test_development_delegation.py tests/unit/test_development_work_queue.py tests/unit/test_development_step5_loop.py -q` — **137 passed** (no regressions in upstream ADE modules).
- [x] `python -m reporting.development_roadmap_intake --no-write` — clean run; **zero candidates** in current canonical docs (no markers committed); `note = no_explicit_intake_candidates`.
- [x] CI checks
- [x] Diff scope limited to roadmap-intake module / status / tests / governance doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)