### PR TITLE
feat(notif): N1 — ADE Notification Event Taxonomy (pure data + routing)

### DIFF
--- a/docs/governance/notification_engine.md
+++ b/docs/governance/notification_engine.md
@@ -1,0 +1,319 @@
+# ADE Notification & Mobile Approval Engine
+
+> **Status:** N1 (event taxonomy) — implemented, read-only, pure data + routing.
+> N2–N5 — design only, **not implemented**.
+>
+> **Module:** [`reporting/notification_event.py`](../../reporting/notification_event.py)
+> **Tests:** [`tests/unit/test_notification_event.py`](../../tests/unit/test_notification_event.py)
+>
+> **Authority:** **none.** This engine grants no autonomous authority.
+> Mobile approval is **human approval, not autonomous merge/deploy.**
+> Level 6 stays permanently disabled per ADR-015 §Doctrine 1.
+
+---
+
+## 0. TL;DR
+
+The Notification & Mobile Approval Engine is a five-track design that
+gives the operator push notifications in the PWA and a phone-friendly
+approval surface for high-impact ADE actions (today: PR merge;
+later: deploy). It does **not** unlock any new agent capability — it
+replaces an absent operator UX with a deterministic, auditable one.
+
+Tracks land **independently** as separate PRs:
+
+| Track | Title                              | Status        |
+| ----- | ---------------------------------- | ------------- |
+| **N1**  | Notification Event Taxonomy        | implemented   |
+| **N2**  | Push Notification Engine           | design only   |
+| **N3**  | Mobile Approval Inbox              | design only   |
+| **N4**  | Approval Token Gate                | design only   |
+| **N5**  | Merge / Deploy Approval Adapter    | design only   |
+
+This document is the canonical anchor for all five.
+
+---
+
+## 1. Authority model
+
+| Capability                                  | Owner today                                                        | After N1–N5                                                            |
+| -------------------------------------------- | ------------------------------------------------------------------ | ---------------------------------------------------------------------- |
+| Classify an action                           | `reporting.execution_authority.classify(...)`                      | unchanged                                                              |
+| Emit a notification event                    | none today                                                         | future N2 dispatcher (read-only)                                       |
+| Persist an approval row                      | `reporting.approval_inbox` (read-only emitter)                     | future N3 mobile inbox (write-only, append-only)                       |
+| Mint an approval token                       | does not exist                                                     | future N4 (HMAC; never in repo; ≤15 min; one-time)                     |
+| **Execute** merge / deploy                   | operator + GitHub branch protection + manual VPS deploy            | unchanged at the authority layer; N5 only adds a phone UI on top       |
+| Autonomous merge / deploy                    | **forbidden, Level 6**                                             | **still forbidden, Level 6 stays permanently disabled**                |
+
+The engine adds **operator UX**, not agent authority. Mobile approval
+is human approval. There is no path by which N1–N5 grant autonomous
+merge or deploy. There is no path by which they extend Step 5.1 / 5.2.
+
+---
+
+## 2. Hard constraints
+
+This engine, in every track, must not:
+
+- modify `.claude/**`;
+- mutate research artefacts;
+- touch live / paper / shadow / risk / broker / execution paths;
+- edit canonical roadmap status fields;
+- mark any roadmap phase complete;
+- flip `step5_implementation_allowed` (stays `False`);
+- change `STEP5_ENABLED_SUBSTAGE` (stays `"none"`);
+- store secrets, private keys, or VAPID keys in the repo;
+- ingest any payload that has not first passed
+  `reporting.agent_audit_summary.assert_no_secrets`;
+- enable approval from a notification click alone (see §6);
+- introduce a network call, subprocess, `gh`, `git`, `requests`,
+  `urllib`, `socket`, `httpx`, or `aiohttp` import from any
+  notification-engine module.
+
+Each track ships its own AST-level forbidden-import scan to enforce
+the relevant bullets.
+
+---
+
+## 3. Event taxonomy (N1, implemented)
+
+### 3.1. Closed `event_kind` vocabulary
+
+Pinned in [`reporting/notification_event.py`](../../reporting/notification_event.py)
+as `EVENT_KINDS`. 31 members, ordered for byte-stable artefacts:
+
+```
+queue_item_proposed
+queue_item_blocked
+queue_item_human_needed
+delegation_emitted
+delegation_blocked
+bugfix_candidate_proposed
+bugfix_candidate_blocked
+intake_candidate_proposed
+intake_candidate_eligible
+intake_candidate_blocked
+step5_cycle_planned
+step5_cycle_halted
+step5_cycle_needs_human
+release_gate_pass
+release_gate_fail
+release_gate_needs_human
+operational_digest_emitted
+e2e_proof_pass
+e2e_proof_fail
+pr_lifecycle_event
+pr_merge_approval_required
+pr_merge_approved
+pr_merge_rejected
+pr_merge_executed
+deploy_approval_required
+deploy_approved
+deploy_rejected
+deploy_executed
+governance_violation_detected
+secret_or_pii_redaction_event
+audit_chain_anomaly
+unknown_state
+```
+
+Adding a value requires a code change pinned by an updated unit test.
+
+### 3.2. Closed `event_severity` vocabulary
+
+Pinned as `EVENT_SEVERITIES`, ordered low → high:
+
+```
+silent
+digest
+push_info
+push_action_required
+approval_required
+critical
+```
+
+### 3.3. Closed `decision_state` vocabulary
+
+Pinned as `DECISION_STATES` (reserved for future N3):
+
+```
+pending
+acknowledged
+approved
+rejected
+expired
+superseded
+```
+
+`approved` and `rejected` are writable **only** through the future N4
+approval-token gate.
+
+---
+
+## 4. Severity routing (N1, implemented)
+
+The default-severity table `EVENT_KIND_DEFAULT_SEVERITY` is pinned
+verbatim in code and verified by `test_routing_table_pinned`. Every
+member of `EVENT_KINDS` has exactly one default severity.
+
+**Unknown event kinds fail closed** to `push_action_required` (the
+constant `UNKNOWN_EVENT_KIND_FALLBACK_SEVERITY`) — never `silent`,
+never `digest`. Unknown is never silently OK.
+
+### 4.1. `route_for(event_kind, *, risk_class=None, execution_authority_decision=None)`
+
+Pure, deterministic, side-effect-free. Looks up the default and
+applies the following minimal escalation rules (pinned by tests):
+
+| Hint                                   | Effect                                                      |
+| -------------------------------------- | ----------------------------------------------------------- |
+| `risk_class="HIGH"`                    | floor at `push_info`                                        |
+| `risk_class="UNKNOWN"`                 | floor at `push_action_required`                             |
+| `execution_authority_decision="NEEDS_HUMAN"` | floor at `approval_required`                          |
+| `execution_authority_decision="PERMANENTLY_DENIED"` | floor at `critical`                              |
+
+Escalations only **lift** the severity; the routing-table default is
+never downgraded. Future tracks (N2–N5) may add escalation rules only
+via a code change pinned by an updated test.
+
+---
+
+## 5. Approval token design (future N4 only)
+
+> Not implemented in N1. Documented here so emitters can reason about
+> the eventual contract.
+
+| Property                | Decision                                                        |
+| ----------------------- | --------------------------------------------------------------- |
+| Algorithm               | HMAC-SHA256                                                     |
+| Secret location         | VPS environment, `secret_kid`-rotated; never in repo            |
+| Expiry                  | ≤ 15 minutes; tunable downward only                             |
+| Reuse                   | one-time; second verify returns 410 GONE                        |
+| Bindings                | `pr_number`, `pr_head_sha`, `evidence_hash`, optional `release_tag` |
+| Drift behaviour         | head_sha advance OR evidence_hash mutation invalidates the token |
+| Replay protection       | 24 h server-side seen-nonce set                                 |
+| Transport               | HTTPS only; never in URL query string                           |
+| Audit                   | mint, verify, approve, reject, execute each append one ledger event with `autonomy_level_claimed=0` |
+
+The token surface lives **server-side** (dashboard backend). The
+PWA receives only a public `token_id`; the secret never leaves the
+server.
+
+---
+
+## 6. Merge / deploy approval (future N5 only)
+
+> Not implemented in N1. Documented here so reviewers can confirm
+> the design preserves the no-autonomous-merge invariant.
+
+### 6.1. The "no approval from notification click alone" rule
+
+A push payload **never** contains a decision verb. Tapping the
+notification opens the PWA at the inbox row. To approve or reject,
+the operator must:
+
+1. open the PWA (authenticated session);
+2. read the bounded evidence summary;
+3. tap **Approve** or **Reject**;
+4. **re-authenticate** with the PWA session passphrase (one-shot
+   per session, ≤ 15 min);
+5. confirm in a modal that displays `pr_head_sha`, `evidence_hash`,
+   `expires_at`;
+6. submit. Only then does the dashboard backend mint and verify a
+   token and invoke the merge adapter.
+
+There is no swipe-to-approve. There is no approve-all. There is no
+approval channel that does not pass through the PWA UI.
+
+### 6.2. Merge flow (future N5)
+
+```
+ADE producer            →  pr_merge_approval_required
+notification_dispatcher →  routes → severity = approval_required
+mobile_approval_inbox   →  appends row, decision_state = pending
+push engine             →  opaque payload to PWA
+operator                →  opens PWA, reads evidence, taps Approve
+dashboard backend       →  re-auth → mints token (head_sha + evidence_hash)
+                       →  verifies token (one-time)
+                       →  appends ledger event approved
+                       →  invokes existing PR-merge path (gh pr merge --squash --delete-branch)
+                       →  emits pr_merge_executed
+```
+
+If the PR's HEAD advances after token mint, verify fails closed and
+the operator is shown a "head_sha drift" error. They re-open, re-read,
+re-approve with a fresh token.
+
+### 6.3. Deploy flow (future N5, design only)
+
+Same shape as merge with three additions: token binding includes
+`release_tag`; post-deploy emitter calls
+`python -m reporting.development_release_gate` and only emits
+`deploy_executed` when the gate is green; deploy approval can never
+bind a `head_sha` of a non-`main` branch.
+
+The deploy adapter is **described** but **not implemented** in
+N1–N5. A separate later track (e.g. A20+) is where deploy adapters
+land. Reason for the split: deploy touches the Hetzner VPS; the
+merge adapter does not.
+
+---
+
+## 7. What N1 does NOT do
+
+- N1 emits no notification.
+- N1 mints no token.
+- N1 opens no inbox row.
+- N1 changes no dashboard route.
+- N1 changes no frontend code.
+- N1 changes no roadmap-status field.
+- N1 marks no phase complete.
+- N1 does not flip `step5_implementation_allowed`.
+- N1 does not change `STEP5_ENABLED_SUBSTAGE`.
+- N1 grants no agent any new authority.
+- N1 enables no autonomous merge or deploy.
+- Level 6 remains permanently disabled. Mobile approval is human
+  approval, not autonomous merge or deploy. No approval can happen
+  from a notification click alone.
+
+---
+
+## 8. Test coverage (N1)
+
+Pinned in
+[`tests/unit/test_notification_event.py`](../../tests/unit/test_notification_event.py):
+
+- `EVENT_KINDS` order and content pinned exactly.
+- `EVENT_SEVERITIES` order and content pinned exactly.
+- `DECISION_STATES` order and content pinned exactly.
+- Routing table covers every `event_kind` (no kind without a default).
+- `route_for(known_kind)` returns the pinned default.
+- `route_for(unknown_kind)` returns `push_action_required` (fail-closed).
+- Risk-class and authority-decision escalations only lift severity,
+  never lower it.
+- AST-level forbidden-import scan: no `dashboard`, `frontend`,
+  `research`, `automation`, `broker`, `agent.risk`,
+  `agent.execution`, `reporting.intelligent_routing`.
+- Source-text scan: no `subprocess`, `socket`, `urllib`, `requests`,
+  `httpx`, `aiohttp`, `gh`, `git`.
+- Importing the module does not flip Step 5 invariants.
+- This document mentions Level 6 only with the qualifier
+  "permanently disabled".
+- This document mentions "no approval from notification click alone"
+  verbatim.
+
+---
+
+## 9. Track plan summary
+
+| Track | Files (allowlist when implemented)                                                                 | Authority delta                |
+| ----- | -------------------------------------------------------------------------------------------------- | ------------------------------ |
+| **N1**  | `reporting/notification_event.py`, this doc, `tests/unit/test_notification_event.py`             | none                           |
+| **N2**  | `reporting/notification_dispatcher.py` + status sibling, dashboard subscribe API, frontend stub  | none (read-only emitter)       |
+| **N3**  | `reporting/mobile_approval_inbox.py` + status sibling, dashboard inbox API, frontend list/detail | new write-only artefact        |
+| **N4**  | `reporting/approval_token_gate.py`, dashboard mint/verify API, audit hooks                       | tokens exist; not yet attached |
+| **N5**  | merge adapter; deploy is design-only here                                                          | unlocks merge-from-mobile only |
+
+Each track is one PR with its own no-touch scope and its own
+revertibility. None of the tracks lifts the Level 6 ceiling — Level 6
+stays permanently disabled per ADR-015 §Doctrine 1.

--- a/reporting/notification_event.py
+++ b/reporting/notification_event.py
@@ -1,0 +1,287 @@
+"""N1 — ADE Notification Event Taxonomy (pure data + routing).
+
+Pinned, closed-vocabulary lookup module for the ADE Notification &
+Mobile Approval Engine. This is the **smallest safe slice (N1)**:
+N2 (push engine), N3 (mobile inbox), N4 (approval-token gate), and
+N5 (merge/deploy adapter) are NOT implemented and remain BLOCKED at
+the design layer.
+
+Hard guarantees (pinned by tests):
+
+* **Pure stdlib only.** No I/O. No subprocess, no network, no
+  ``gh``, no ``git``, no ``requests``, no ``urllib``, no ``socket``,
+  no ``httpx``, no ``aiohttp``.
+* No imports of ``dashboard``, ``frontend``, ``research``,
+  ``automation``, ``broker``, ``agent.risk``, ``agent.execution``,
+  ``reporting.intelligent_routing``, or any live / paper / shadow /
+  trading path.
+* **This module emits no notifications.** It mints no tokens. It
+  approves nothing. It opens no inbox row. It is a closed-vocabulary
+  lookup table plus one pure routing function. Importing this
+  module performs zero side-effects and grants zero authority.
+* Step 5 invariants are unaffected: importing this module does NOT
+  flip ``reporting.development_step5_loop.step5_implementation_allowed``
+  and does NOT change ``STEP5_ENABLED_SUBSTAGE``.
+* Level 6 stays permanently disabled per ADR-015 §Doctrine 1.
+
+Design anchor: ``docs/governance/notification_engine.md``.
+
+Public surface
+--------------
+
+* :data:`EVENT_KINDS`            — closed tuple of event-kind strings.
+* :data:`EVENT_SEVERITIES`       — closed tuple of severity strings,
+                                   ordered low → high.
+* :data:`DECISION_STATES`        — closed tuple of inbox decision-state
+                                   strings (used by future N3).
+* :data:`EVENT_KIND_DEFAULT_SEVERITY`
+                                 — pinned ``event_kind → severity``
+                                   default mapping, the routing table.
+* :func:`route_for`              — pure deterministic routing function.
+
+Anything outside this surface is private and may change without a
+SemVer-style bump.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+MODULE_VERSION: Final[str] = "v3.15.16.N1"
+SCHEMA_VERSION: Final[str] = "1.0"
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies
+# ---------------------------------------------------------------------------
+
+#: Closed event-kind vocabulary. Adding a value requires a code
+#: change pinned by an updated unit test. Order is significant for
+#: byte-stable artefacts.
+EVENT_KINDS: Final[tuple[str, ...]] = (
+    # Queue (A8)
+    "queue_item_proposed",
+    "queue_item_blocked",
+    "queue_item_human_needed",
+    # Delegation (A11)
+    "delegation_emitted",
+    "delegation_blocked",
+    # Bugfix loop (A10)
+    "bugfix_candidate_proposed",
+    "bugfix_candidate_blocked",
+    # Roadmap intake (Step 5.0.1)
+    "intake_candidate_proposed",
+    "intake_candidate_eligible",
+    "intake_candidate_blocked",
+    # Step 5 dry-run planner (A14)
+    "step5_cycle_planned",
+    "step5_cycle_halted",
+    "step5_cycle_needs_human",
+    # Release gate (A9)
+    "release_gate_pass",
+    "release_gate_fail",
+    "release_gate_needs_human",
+    # Operational digest / E2E (A12 / A13)
+    "operational_digest_emitted",
+    "e2e_proof_pass",
+    "e2e_proof_fail",
+    # PR / merge (future N5; the kind exists in N1 vocab so emitters
+    # can reserve it without code change later)
+    "pr_lifecycle_event",
+    "pr_merge_approval_required",
+    "pr_merge_approved",
+    "pr_merge_rejected",
+    "pr_merge_executed",
+    # Deploy (design-only in N5; vocab-only here)
+    "deploy_approval_required",
+    "deploy_approved",
+    "deploy_rejected",
+    "deploy_executed",
+    # Cross-cutting
+    "governance_violation_detected",
+    "secret_or_pii_redaction_event",
+    "audit_chain_anomaly",
+    "unknown_state",
+)
+
+#: Closed severity vocabulary, ordered low → high. ``silent`` is the
+#: floor (ledger only); ``critical`` is the ceiling (bypasses Do Not
+#: Disturb on operator-opted devices).
+EVENT_SEVERITIES: Final[tuple[str, ...]] = (
+    "silent",
+    "digest",
+    "push_info",
+    "push_action_required",
+    "approval_required",
+    "critical",
+)
+
+#: Closed inbox decision-state vocabulary. Reserved for the N3 mobile
+#: approval inbox; pinned here so producers can reference the closed
+#: set without taking a dependency on a not-yet-implemented module.
+#: ``approved`` and ``rejected`` are writable ONLY through the future
+#: N4 approval-token gate. ``superseded`` allows an emitter to
+#: invalidate a prior pending row when a fresher row supersedes it.
+DECISION_STATES: Final[tuple[str, ...]] = (
+    "pending",
+    "acknowledged",
+    "approved",
+    "rejected",
+    "expired",
+    "superseded",
+)
+
+
+# ---------------------------------------------------------------------------
+# Routing table — pinned, deterministic, byte-stable
+# ---------------------------------------------------------------------------
+
+#: Pinned default severity per event_kind. Every member of
+#: :data:`EVENT_KINDS` MUST appear as a key here. Test
+#: ``test_routing_table_covers_all_event_kinds`` enforces it.
+EVENT_KIND_DEFAULT_SEVERITY: Final[dict[str, str]] = {
+    # Proposals are non-blocking — digest only.
+    "queue_item_proposed": "digest",
+    "delegation_emitted": "digest",
+    "bugfix_candidate_proposed": "digest",
+    "intake_candidate_proposed": "digest",
+    "operational_digest_emitted": "digest",
+    # "Now actionable" — push_info.
+    "intake_candidate_eligible": "push_info",
+    "release_gate_pass": "push_info",
+    "e2e_proof_pass": "push_info",
+    "pr_merge_executed": "push_info",
+    "deploy_executed": "push_info",
+    "pr_merge_approved": "push_info",
+    "pr_merge_rejected": "push_info",
+    "deploy_approved": "push_info",
+    "deploy_rejected": "push_info",
+    # Generic PR lifecycle (opened / labelled / ready) — push_info.
+    "pr_lifecycle_event": "push_info",
+    # Blocks / fails — visible but not gated.
+    "queue_item_blocked": "push_info",
+    "delegation_blocked": "push_info",
+    "bugfix_candidate_blocked": "push_info",
+    "intake_candidate_blocked": "push_info",
+    # Loop is waiting on the operator — push_action_required.
+    "queue_item_human_needed": "push_action_required",
+    "step5_cycle_halted": "push_action_required",
+    "step5_cycle_needs_human": "push_action_required",
+    "release_gate_fail": "push_action_required",
+    "e2e_proof_fail": "push_action_required",
+    # The fail-safe surface for unknown / malformed upstream state.
+    "unknown_state": "push_action_required",
+    # Approval-required — gated by future N4 token.
+    "release_gate_needs_human": "approval_required",
+    "pr_merge_approval_required": "approval_required",
+    "deploy_approval_required": "approval_required",
+    # Silent (ledger only). step5_cycle_planned is high-volume and
+    # boring — operator can pull the digest if interested.
+    "step5_cycle_planned": "silent",
+    # Critical — bypass DND for operator-opted devices.
+    "governance_violation_detected": "critical",
+    "secret_or_pii_redaction_event": "critical",
+    "audit_chain_anomaly": "critical",
+}
+
+
+#: Severity used when an emitter passes an event_kind that is not in
+#: :data:`EVENT_KINDS`. Default-deny: an unknown kind is treated as a
+#: gap that the operator must inspect. NEVER ``silent``.
+UNKNOWN_EVENT_KIND_FALLBACK_SEVERITY: Final[str] = "push_action_required"
+
+
+# ---------------------------------------------------------------------------
+# Pure routing function
+# ---------------------------------------------------------------------------
+
+
+def route_for(
+    event_kind: str,
+    *,
+    risk_class: str | None = None,
+    execution_authority_decision: str | None = None,
+) -> str:
+    """Return the pinned severity for ``event_kind``.
+
+    Pure, deterministic, side-effect-free. Does not read from disk,
+    does not write to disk, does not call the network, does not
+    consult any external state.
+
+    Parameters
+    ----------
+    event_kind:
+        One of :data:`EVENT_KINDS`. Anything else is treated as
+        unknown and routes to
+        :data:`UNKNOWN_EVENT_KIND_FALLBACK_SEVERITY`.
+    risk_class:
+        Optional risk-class hint (mirrors
+        ``reporting.approval_policy.RISK_CLASSES``). When provided as
+        ``"HIGH"`` or ``"UNKNOWN"`` it can ESCALATE a non-critical,
+        non-approval severity by one step (e.g. ``digest`` →
+        ``push_info`` → ``push_action_required``). It can never
+        DOWNGRADE a severity below the routing-table default.
+    execution_authority_decision:
+        Optional upstream-recorded authority decision (mirrors
+        ``reporting.execution_authority`` decisions). When the
+        decision is ``"NEEDS_HUMAN"`` and the routing-table default is
+        below ``approval_required``, the result is escalated to
+        ``approval_required``. ``"PERMANENTLY_DENIED"`` escalates to
+        ``critical`` if the default is below ``critical``. The
+        default is never downgraded.
+
+    Returns
+    -------
+    str
+        A member of :data:`EVENT_SEVERITIES`.
+
+    Notes
+    -----
+    The escalation rules are intentionally minimal in N1 and pinned
+    by ``test_route_for_escalations``. Future tracks (N2–N5) MAY add
+    further escalations only via a code change pinned by an updated
+    test.
+    """
+    base = EVENT_KIND_DEFAULT_SEVERITY.get(
+        event_kind, UNKNOWN_EVENT_KIND_FALLBACK_SEVERITY
+    )
+
+    # Look up severity ordering for the (very small) escalation
+    # logic. ``EVENT_SEVERITIES`` is ordered low → high, so a higher
+    # tuple index is a stricter severity.
+    rank = EVENT_SEVERITIES.index(base)
+
+    def _at_least(idx: int) -> str:
+        return EVENT_SEVERITIES[max(rank, idx)]
+
+    push_info_idx = EVENT_SEVERITIES.index("push_info")
+    push_action_idx = EVENT_SEVERITIES.index("push_action_required")
+    approval_idx = EVENT_SEVERITIES.index("approval_required")
+    critical_idx = EVENT_SEVERITIES.index("critical")
+
+    # Risk-class escalations.
+    if risk_class == "HIGH":
+        # HIGH risk lifts a digest to push_info, otherwise no-op.
+        rank = EVENT_SEVERITIES.index(_at_least(push_info_idx))
+    elif risk_class == "UNKNOWN":
+        # Unknown is never silently OK — push_action_required floor.
+        rank = EVENT_SEVERITIES.index(_at_least(push_action_idx))
+
+    # Authority-decision escalations.
+    if execution_authority_decision == "NEEDS_HUMAN":
+        rank = EVENT_SEVERITIES.index(_at_least(approval_idx))
+    elif execution_authority_decision == "PERMANENTLY_DENIED":
+        rank = EVENT_SEVERITIES.index(_at_least(critical_idx))
+
+    return EVENT_SEVERITIES[rank]
+
+
+__all__ = [
+    "DECISION_STATES",
+    "EVENT_KIND_DEFAULT_SEVERITY",
+    "EVENT_KINDS",
+    "EVENT_SEVERITIES",
+    "MODULE_VERSION",
+    "SCHEMA_VERSION",
+    "UNKNOWN_EVENT_KIND_FALLBACK_SEVERITY",
+    "route_for",
+]

--- a/tests/unit/test_notification_event.py
+++ b/tests/unit/test_notification_event.py
@@ -1,0 +1,512 @@
+"""Unit tests for N1 — ADE Notification Event Taxonomy.
+
+The module under test is pure data + one pure routing function. It
+emits no notifications, mints no tokens, and grants no authority.
+
+Hard guarantees (pinned here):
+
+* Closed vocabularies (`EVENT_KINDS`, `EVENT_SEVERITIES`,
+  `DECISION_STATES`) are byte-exact.
+* The default-severity routing table covers every event_kind.
+* Unknown event kinds fail closed to ``push_action_required`` —
+  never to ``silent`` or ``digest``.
+* Importing the module performs zero side-effects and does not flip
+  any Step 5 invariant.
+* The module imports nothing from dashboard / frontend / research /
+  automation / broker / agent.risk / agent.execution /
+  reporting.intelligent_routing.
+* No subprocess / network / gh / git references in the module.
+* The companion governance doc mentions Level 6 only with the
+  ``permanently disabled`` qualifier and contains the load-bearing
+  rule "no approval from notification click alone".
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+from reporting import notification_event as ne
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies
+# ---------------------------------------------------------------------------
+
+
+def test_event_kinds_pinned_exactly() -> None:
+    assert ne.EVENT_KINDS == (
+        "queue_item_proposed",
+        "queue_item_blocked",
+        "queue_item_human_needed",
+        "delegation_emitted",
+        "delegation_blocked",
+        "bugfix_candidate_proposed",
+        "bugfix_candidate_blocked",
+        "intake_candidate_proposed",
+        "intake_candidate_eligible",
+        "intake_candidate_blocked",
+        "step5_cycle_planned",
+        "step5_cycle_halted",
+        "step5_cycle_needs_human",
+        "release_gate_pass",
+        "release_gate_fail",
+        "release_gate_needs_human",
+        "operational_digest_emitted",
+        "e2e_proof_pass",
+        "e2e_proof_fail",
+        "pr_lifecycle_event",
+        "pr_merge_approval_required",
+        "pr_merge_approved",
+        "pr_merge_rejected",
+        "pr_merge_executed",
+        "deploy_approval_required",
+        "deploy_approved",
+        "deploy_rejected",
+        "deploy_executed",
+        "governance_violation_detected",
+        "secret_or_pii_redaction_event",
+        "audit_chain_anomaly",
+        "unknown_state",
+    )
+
+
+def test_event_severities_pinned_exactly_and_ordered() -> None:
+    assert ne.EVENT_SEVERITIES == (
+        "silent",
+        "digest",
+        "push_info",
+        "push_action_required",
+        "approval_required",
+        "critical",
+    )
+
+
+def test_decision_states_pinned_exactly() -> None:
+    assert ne.DECISION_STATES == (
+        "pending",
+        "acknowledged",
+        "approved",
+        "rejected",
+        "expired",
+        "superseded",
+    )
+
+
+def test_event_kinds_are_unique() -> None:
+    assert len(set(ne.EVENT_KINDS)) == len(ne.EVENT_KINDS)
+
+
+def test_event_severities_are_unique() -> None:
+    assert len(set(ne.EVENT_SEVERITIES)) == len(ne.EVENT_SEVERITIES)
+
+
+def test_decision_states_are_unique() -> None:
+    assert len(set(ne.DECISION_STATES)) == len(ne.DECISION_STATES)
+
+
+# ---------------------------------------------------------------------------
+# Routing table — pinned shape and coverage
+# ---------------------------------------------------------------------------
+
+
+def test_routing_table_covers_all_event_kinds() -> None:
+    """Every event_kind in EVENT_KINDS must have a default severity.
+    No silent omissions allowed."""
+    missing = set(ne.EVENT_KINDS) - set(ne.EVENT_KIND_DEFAULT_SEVERITY)
+    extra = set(ne.EVENT_KIND_DEFAULT_SEVERITY) - set(ne.EVENT_KINDS)
+    assert missing == set(), f"event_kinds without a default: {missing}"
+    assert extra == set(), f"routing-table keys not in EVENT_KINDS: {extra}"
+
+
+def test_routing_table_severities_are_valid() -> None:
+    for kind, sev in ne.EVENT_KIND_DEFAULT_SEVERITY.items():
+        assert sev in ne.EVENT_SEVERITIES, (kind, sev)
+
+
+def test_routing_table_pinned() -> None:
+    """The full default-severity table is pinned verbatim. Any
+    change requires updating this test together with the module."""
+    assert ne.EVENT_KIND_DEFAULT_SEVERITY == {
+        "queue_item_proposed": "digest",
+        "delegation_emitted": "digest",
+        "bugfix_candidate_proposed": "digest",
+        "intake_candidate_proposed": "digest",
+        "operational_digest_emitted": "digest",
+        "intake_candidate_eligible": "push_info",
+        "release_gate_pass": "push_info",
+        "e2e_proof_pass": "push_info",
+        "pr_merge_executed": "push_info",
+        "deploy_executed": "push_info",
+        "pr_merge_approved": "push_info",
+        "pr_merge_rejected": "push_info",
+        "deploy_approved": "push_info",
+        "deploy_rejected": "push_info",
+        "pr_lifecycle_event": "push_info",
+        "queue_item_blocked": "push_info",
+        "delegation_blocked": "push_info",
+        "bugfix_candidate_blocked": "push_info",
+        "intake_candidate_blocked": "push_info",
+        "queue_item_human_needed": "push_action_required",
+        "step5_cycle_halted": "push_action_required",
+        "step5_cycle_needs_human": "push_action_required",
+        "release_gate_fail": "push_action_required",
+        "e2e_proof_fail": "push_action_required",
+        "unknown_state": "push_action_required",
+        "release_gate_needs_human": "approval_required",
+        "pr_merge_approval_required": "approval_required",
+        "deploy_approval_required": "approval_required",
+        "step5_cycle_planned": "silent",
+        "governance_violation_detected": "critical",
+        "secret_or_pii_redaction_event": "critical",
+        "audit_chain_anomaly": "critical",
+    }
+
+
+def test_unknown_event_kind_fallback_is_push_action_required() -> None:
+    assert ne.UNKNOWN_EVENT_KIND_FALLBACK_SEVERITY == "push_action_required"
+
+
+def test_unknown_event_kind_fallback_is_not_silent_or_digest() -> None:
+    """Unknown is never silently OK."""
+    assert ne.UNKNOWN_EVENT_KIND_FALLBACK_SEVERITY not in ("silent", "digest")
+
+
+# ---------------------------------------------------------------------------
+# route_for() — known kinds
+# ---------------------------------------------------------------------------
+
+
+def test_route_for_returns_pinned_default_for_each_kind() -> None:
+    for kind, expected in ne.EVENT_KIND_DEFAULT_SEVERITY.items():
+        assert ne.route_for(kind) == expected
+
+
+def test_route_for_critical_kind_stays_critical() -> None:
+    assert ne.route_for("governance_violation_detected") == "critical"
+    assert ne.route_for("secret_or_pii_redaction_event") == "critical"
+    assert ne.route_for("audit_chain_anomaly") == "critical"
+
+
+def test_route_for_silent_kind_default_silent() -> None:
+    assert ne.route_for("step5_cycle_planned") == "silent"
+
+
+# ---------------------------------------------------------------------------
+# route_for() — unknown kinds (fail-closed)
+# ---------------------------------------------------------------------------
+
+
+def test_route_for_unknown_kind_routes_to_fallback() -> None:
+    assert ne.route_for("not_a_real_kind") == "push_action_required"
+    assert ne.route_for("") == "push_action_required"
+
+
+def test_route_for_unknown_kind_does_not_route_to_silent_or_digest() -> None:
+    for bogus in ("does_not_exist", "x", "QUEUE_ITEM_PROPOSED"):
+        # Note: "QUEUE_ITEM_PROPOSED" is upper-case and therefore NOT
+        # a member of EVENT_KINDS; it must fail closed.
+        assert ne.route_for(bogus) not in ("silent", "digest")
+
+
+# ---------------------------------------------------------------------------
+# route_for() — escalations only lift, never lower
+# ---------------------------------------------------------------------------
+
+
+def test_route_for_escalations_only_lift_never_lower() -> None:
+    """For every (kind, hint) combination, the routed severity must
+    be at least as strict as the routing-table default."""
+    sev_rank = {s: i for i, s in enumerate(ne.EVENT_SEVERITIES)}
+    risk_hints = (None, "LOW", "MEDIUM", "HIGH", "UNKNOWN", "weird_value")
+    decision_hints = (
+        None,
+        "AUTO_ALLOWED",
+        "NEEDS_HUMAN",
+        "PERMANENTLY_DENIED",
+        "weird_value",
+    )
+    for kind, default in ne.EVENT_KIND_DEFAULT_SEVERITY.items():
+        for r in risk_hints:
+            for d in decision_hints:
+                routed = ne.route_for(
+                    kind, risk_class=r, execution_authority_decision=d
+                )
+                assert sev_rank[routed] >= sev_rank[default], (
+                    kind,
+                    default,
+                    r,
+                    d,
+                    routed,
+                )
+
+
+def test_route_for_high_risk_floors_at_push_info() -> None:
+    # A digest kind escalates to push_info under HIGH risk.
+    assert ne.route_for("queue_item_proposed", risk_class="HIGH") == "push_info"
+    # A push_info kind stays push_info.
+    assert ne.route_for("queue_item_blocked", risk_class="HIGH") == "push_info"
+    # A critical kind stays critical.
+    assert (
+        ne.route_for("governance_violation_detected", risk_class="HIGH")
+        == "critical"
+    )
+
+
+def test_route_for_unknown_risk_floors_at_push_action_required() -> None:
+    assert (
+        ne.route_for("queue_item_proposed", risk_class="UNKNOWN")
+        == "push_action_required"
+    )
+    # silent → push_action_required when risk_class is unknown
+    assert (
+        ne.route_for("step5_cycle_planned", risk_class="UNKNOWN")
+        == "push_action_required"
+    )
+
+
+def test_route_for_needs_human_floors_at_approval_required() -> None:
+    assert (
+        ne.route_for(
+            "queue_item_proposed",
+            execution_authority_decision="NEEDS_HUMAN",
+        )
+        == "approval_required"
+    )
+    # An already-approval_required kind stays approval_required.
+    assert (
+        ne.route_for(
+            "pr_merge_approval_required",
+            execution_authority_decision="NEEDS_HUMAN",
+        )
+        == "approval_required"
+    )
+
+
+def test_route_for_permanently_denied_floors_at_critical() -> None:
+    assert (
+        ne.route_for(
+            "queue_item_proposed",
+            execution_authority_decision="PERMANENTLY_DENIED",
+        )
+        == "critical"
+    )
+    assert (
+        ne.route_for(
+            "step5_cycle_planned",
+            execution_authority_decision="PERMANENTLY_DENIED",
+        )
+        == "critical"
+    )
+
+
+def test_route_for_no_hints_returns_default() -> None:
+    for kind, expected in ne.EVENT_KIND_DEFAULT_SEVERITY.items():
+        assert (
+            ne.route_for(kind, risk_class=None, execution_authority_decision=None)
+            == expected
+        )
+
+
+# ---------------------------------------------------------------------------
+# Module versioning
+# ---------------------------------------------------------------------------
+
+
+def test_module_and_schema_version_strings() -> None:
+    assert isinstance(ne.MODULE_VERSION, str) and ne.MODULE_VERSION
+    assert isinstance(ne.SCHEMA_VERSION, str) and ne.SCHEMA_VERSION
+    assert "N1" in ne.MODULE_VERSION
+
+
+# ---------------------------------------------------------------------------
+# Side-effect / authority isolation
+# ---------------------------------------------------------------------------
+
+
+def test_module_imports_cleanly_and_is_pure() -> None:
+    importlib.reload(ne)
+    assert callable(ne.route_for)
+
+
+def test_importing_module_does_not_flip_step5_invariants() -> None:
+    """Re-importing notification_event must not mutate Step 5.0
+    invariants on the live development_step5_loop module."""
+    from reporting import development_step5_loop as dsl
+
+    importlib.reload(ne)
+    assert dsl.step5_implementation_allowed is False
+    assert dsl.STEP5_ENABLED_SUBSTAGE == "none"
+
+
+# ---------------------------------------------------------------------------
+# Source-text scans
+# ---------------------------------------------------------------------------
+
+
+def _module_source() -> str:
+    return Path(ne.__file__).read_text(encoding="utf-8")
+
+
+def _imported_module_names() -> set[str]:
+    import ast
+
+    src = _module_source()
+    tree = ast.parse(src)
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module is not None:
+                names.add(node.module)
+    return names
+
+
+def test_no_subprocess_in_module() -> None:
+    src = _module_source()
+    assert "import subprocess" not in src
+    assert "from subprocess" not in src
+
+
+def test_no_network_in_module() -> None:
+    src = _module_source()
+    for forbidden in (
+        "import socket",
+        "import urllib",
+        "import http.client",
+        "import requests",
+        "import httpx",
+        "import aiohttp",
+    ):
+        assert forbidden not in src, forbidden
+    assert "from socket" not in src
+    assert "from urllib" not in src
+    assert "from http" not in src
+    assert "from requests" not in src
+    assert "from httpx" not in src
+    assert "from aiohttp" not in src
+
+
+def test_no_gh_or_git_subprocess_references() -> None:
+    src = _module_source()
+    for forbidden in (
+        "subprocess.run",
+        "subprocess.Popen",
+        "os.system",
+        "os.popen",
+        "shell=True",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_no_io_in_module() -> None:
+    """N1 is pure — no path open / read / write helpers."""
+    src = _module_source()
+    for forbidden in (
+        "Path(",
+        "open(",
+        ".read_text(",
+        ".write_text(",
+        "tempfile",
+        "os.replace",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_no_dashboard_or_live_path_or_qre_imports() -> None:
+    forbidden_prefixes = (
+        "dashboard",
+        "frontend",
+        "automation",
+        "broker",
+        "agent.risk",
+        "agent.execution",
+        "research",
+        "reporting.intelligent_routing",
+        "live",
+        "paper",
+        "shadow",
+        "trading",
+    )
+    for module in _imported_module_names():
+        for prefix in forbidden_prefixes:
+            assert not (
+                module == prefix or module.startswith(prefix + ".")
+            ), f"forbidden import: {module}"
+
+
+def test_module_imports_only_typing() -> None:
+    """N1 is pure stdlib + nothing more. The only allowed import is
+    ``typing`` (for ``Final``)."""
+    names = _imported_module_names()
+    # ``__future__`` is allowed (annotations).
+    allowed = {"__future__", "typing"}
+    extra = names - allowed
+    assert extra == set(), f"unexpected imports: {extra}"
+
+
+# ---------------------------------------------------------------------------
+# Companion doc invariants
+# ---------------------------------------------------------------------------
+
+
+def _doc_text() -> str:
+    return (REPO_ROOT / "docs" / "governance" / "notification_engine.md").read_text(
+        encoding="utf-8"
+    )
+
+
+def test_doc_mentions_level_6_only_as_permanently_disabled() -> None:
+    """Every mention of "Level 6" in the companion doc must appear
+    near a `permanently disabled` qualifier (mirrors
+    governance_lint.py rules)."""
+    import re
+
+    text = _doc_text()
+    pattern = re.compile(r"\bLevel\s*6\b")
+    for m in pattern.finditer(text):
+        start = max(0, m.start() - 200)
+        end = m.start() + 600
+        window = text[start:end].lower()
+        assert "permanently disabled" in window, (
+            f"'Level 6' at offset {m.start()} lacks "
+            f"'permanently disabled' qualifier in surrounding window"
+        )
+
+
+def test_doc_states_no_approval_from_notification_click_alone() -> None:
+    text = _doc_text().lower()
+    assert "no approval from notification click alone" in text
+
+
+def test_doc_states_mobile_approval_is_human_approval() -> None:
+    text = _doc_text().lower()
+    assert "human approval" in text
+    assert "autonomous merge" in text or "autonomous merge or deploy" in text
+
+
+def test_doc_pins_step5_invariants_text() -> None:
+    text = _doc_text()
+    assert "step5_implementation_allowed" in text
+    assert "STEP5_ENABLED_SUBSTAGE" in text
+
+
+def test_doc_lists_n1_through_n5_tracks() -> None:
+    text = _doc_text()
+    for marker in ("N1", "N2", "N3", "N4", "N5"):
+        assert marker in text, marker
+
+
+def test_doc_marks_n2_through_n5_as_design_only() -> None:
+    text = _doc_text().lower()
+    assert "design only" in text or "design-only" in text
+
+
+def test_doc_states_no_secrets_in_repo() -> None:
+    text = _doc_text().lower()
+    assert "never in repo" in text or "never in the repo" in text


### PR DESCRIPTION
## Summary

N1 of the **ADE Notification & Mobile Approval Engine** — the smallest safe slice. Pure stdlib-only closed-vocabulary lookup module + routing table. Zero I/O, zero side-effects, zero authority delta.

N2 (push), N3 (mobile approval inbox), N4 (approval-token gate), and N5 (merge/deploy adapter) remain **unimplemented** and require their own go-signals.

## What lands

- `reporting/notification_event.py` — `EVENT_KINDS` (32 values), `EVENT_SEVERITIES` (6 values, ordered low→high), `DECISION_STATES` (reserved for N3), `EVENT_KIND_DEFAULT_SEVERITY` (full coverage), `UNKNOWN_EVENT_KIND_FALLBACK_SEVERITY = "push_action_required"` (fail-closed), and a pure `route_for(...)` function with risk-class / authority-decision escalation that only LIFTS, never lowers.
- `docs/governance/notification_engine.md` — canonical doc anchoring N1–N5; N2–N5 marked design-only.
- `tests/unit/test_notification_event.py` — 38 tests pinning vocabularies, routing-table contents, fail-closed unknown handling, escalation lift-only invariant, AST-level forbidden-import scan, source-text scans, and doc invariants.

## Hard guarantees (pinned by tests)

- Module imports **only** `__future__` and `typing`.
- No `dashboard` / `frontend` / `research` / `automation` / `broker` / `agent.risk` / `agent.execution` / `reporting.intelligent_routing` / live / paper / shadow / trading imports.
- No subprocess / socket / urllib / requests / httpx / aiohttp / `gh` / `git`.
- No I/O at import or call time.
- `step5_implementation_allowed` remains `False`; `STEP5_ENABLED_SUBSTAGE` remains `"none"`.
- Doc mentions \"Level 6\" only with the \"permanently disabled\" qualifier.
- Doc states \"no approval from notification click alone\" verbatim.
- Doc states mobile approval is human approval, not autonomous merge/deploy.
- N1 emits no notification, mints no token, opens no inbox row, and grants no authority.

## Test plan

- [x] `python scripts/governance_lint.py` — OK.
- [x] `python -m pytest tests/unit/test_notification_event.py -q` — **38 passed**.
- [x] `python -m pytest tests/smoke -q` — **18 passed**.
- [x] `python -m reporting.development_step5_loop --no-write --indent 2` — clean run (Step 5 invariants intact).
- [x] `python -m reporting.development_operational_digest --no-write` — clean run.
- [x] CI checks
- [x] Diff scope limited to the three N1 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)