### PR TITLE
docs(roadmap): A15 — first real ade_roadmap_intake marker (operating manual §9.3)

### DIFF
--- a/docs/roadmap/qre_roadmap_v6_ade_operating_manual.md
+++ b/docs/roadmap/qre_roadmap_v6_ade_operating_manual.md
@@ -428,6 +428,22 @@ reproducibility\_method
 quality\_gates
 ```
 
+<!-- ade_roadmap_intake
+candidate_id: qre_v3_15_16_addendum_source_manifest_001
+phase: v3.15.16
+title: Draft diagnostic-source manifest operating surface for Roadmap v6 Addendum §9.3 fields
+category: docs
+required_agent_role: planner
+risk_level: LOW
+target_path: docs/governance/agent_run_summaries/qre_addendum_source_manifest_001.md
+human_needed: false
+human_needed_reason: none
+acceptance_criteria:
+  - Candidate appears in logs/development_roadmap_intake/latest.json
+  - Execution Authority classifies target path AUTO_ALLOWED at LOW risk
+  - Step 5.0 dry-run can plan from this candidate after operator promotion
+-->
+
 ### 9.4 Required public-data quality gates
 
 * freshness check


### PR DESCRIPTION
## Summary

Adds exactly one explicit `<!-- ade_roadmap_intake ... -->` marker to the QRE Roadmap v6 ADE Operating Manual at §9.3 ("Required source manifest fields"). This gives the merged Roadmap Intake Bridge ([PR #158](https://github.com/roudjy/trading-agent/pull/158)) its **first production candidate** to discover.

## Marker

| field                 | value                                                                                                |
| --------------------- | ---------------------------------------------------------------------------------------------------- |
| `candidate_id`        | `qre_v3_15_16_addendum_source_manifest_001`                                                          |
| `phase`               | `v3.15.16`                                                                                            |
| `title`               | Draft diagnostic-source manifest operating surface for Roadmap v6 Addendum §9.3 fields               |
| `category`            | `docs`                                                                                                |
| `required_agent_role` | `planner`                                                                                             |
| `risk_level`          | `LOW`                                                                                                 |
| `target_path`         | `docs/governance/agent_run_summaries/qre_addendum_source_manifest_001.md` (new doc, not in this PR)  |
| `human_needed`        | `false`                                                                                               |
| `human_needed_reason` | `none`                                                                                                |

## Verification

`python -m reporting.development_roadmap_intake --no-write`:

- exactly **1 candidate** discovered
- `execution_authority_decision` = **AUTO_ALLOWED** (`low_risk_docs_non_policy`)
- `intake_status` = **eligible**
- `promotion_target` = **none** — **no automatic promotion** to `seed.jsonl` or `delegation_seed.jsonl`

## Hard guarantees

- ✅ No QRE behaviour change.
- ✅ No research-artifact mutation.
- ✅ No live / paper / shadow / risk / broker / execution change.
- ✅ No `.claude/**` change.
- ✅ Roadmap v6 stays canonical; the marker lives in the Operating Manual (extension surface), not Roadmap v6 itself.
- ✅ No roadmap status field changed; no phase marked complete.
- ✅ `step5_implementation_allowed` remains `False`; `STEP5_ENABLED_SUBSTAGE` remains `"none"`; Level 6 stays permanently disabled.
- ✅ Step 5.1 / 5.2 remain BLOCKED.

## Test plan

- [x] `python -m reporting.development_roadmap_intake --no-write` — 1 candidate, AUTO_ALLOWED, eligible, promotion_target=none.
- [x] `python -m reporting.development_roadmap_intake_status --no-write` — projects unchanged upstream artifact (no auto-write).
- [x] `python scripts/governance_lint.py` — OK.
- [x] `python -m pytest tests/unit/test_development_roadmap_intake*.py -q` — **61 passed**.
- [x] `python -m pytest tests/smoke -q` — **18 passed**.
- [x] CI checks
- [x] Diff scope = **1 file, 16 insertions**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)