### PR TITLE
feat(notif): N2a — Artifact-only Notification Dispatcher

### DIFF
--- a/docs/governance/notification_dispatcher.md
+++ b/docs/governance/notification_dispatcher.md
@@ -1,0 +1,283 @@
+# Notification Dispatcher — N2a (artifact-only)
+
+> **Status:** Implemented (read-only, deterministic, **artifact-only**).
+>
+> **Module:** [`reporting/notification_dispatcher.py`](../../reporting/notification_dispatcher.py)
+> **Status reporter:** [`reporting/notification_dispatcher_status.py`](../../reporting/notification_dispatcher_status.py)
+>
+> **Output artefact:** `logs/notification_dispatcher/latest.json`
+> **Bounded events history:** `logs/notification_dispatcher/events.jsonl` (≤ 500 rows)
+> **Status artefact:** `logs/notification_dispatcher_status/latest.json`
+>
+> **Authority:** development-governance read-only.
+> N2a sends no real push and grants no agent any new authority.
+> Level 6 stays permanently disabled per ADR-015 §Doctrine 1.
+
+---
+
+## 1. Purpose
+
+N2a converts existing ADE upstream artefacts (A8 work queue, A14 Step
+5.0 plan, A16a intake promotion, Step 5.0.1 roadmap intake) into
+notification-ready event records using the closed N1 taxonomy, and
+writes them to a single dedicated log directory. **No push is sent.**
+The dispatcher decides nothing; it computes which event would be
+delivered and persists the result. Future N2b adds the actual Web
+Push delivery on top of these records, behind a separate explicit
+operator go-signal.
+
+---
+
+## 2. Hard constraints
+
+N2a, in this PR and at runtime, must not:
+
+- send a real push (Web Push, APNs, FCM, Telegram, email, SMS, anything);
+- open a network socket;
+- import a Web Push library;
+- read or create a subscription file;
+- read or create any VAPID key;
+- write to `dashboard/**` or `frontend/**`;
+- mint approval tokens (N4 territory);
+- open mobile approval inbox rows (N3 territory);
+- merge or deploy (N5 / future);
+- amend the N1 closed `EVENT_KINDS` vocabulary (uses only existing kinds);
+- enable Step 5.1 or Step 5.2;
+- flip `step5_implementation_allowed`;
+- change `STEP5_ENABLED_SUBSTAGE`;
+- change QRE behaviour;
+- mutate research artifacts;
+- touch live / paper / shadow / risk / broker / execution paths;
+- edit `.claude/**`;
+- store secrets in repo;
+- edit canonical roadmap status fields;
+- mark any roadmap phase complete.
+
+The dispatcher ships its own AST-level forbidden-import scan and
+source-text scan to enforce the relevant bullets.
+
+**No approval can happen from a notification click alone.** N2a
+emits *records*; even the future N2b never carries a decision verb in
+its payload. The PWA UI (a future track) is the only path that can
+submit an approval, and that path passes through re-authentication and
+the future N4 token gate. This rule is mirrored from
+[`docs/governance/notification_engine.md`](notification_engine.md).
+
+---
+
+## 3. Closed vocabularies
+
+Pinned in [`reporting/notification_dispatcher.py`](../../reporting/notification_dispatcher.py):
+
+### `delivery_intent` (5 values)
+
+| Value                       | Meaning                                                                  |
+| --------------------------- | ------------------------------------------------------------------------ |
+| `ready`                     | passes all gates; would be delivered by a future N2b push surface        |
+| `suppressed`                | severity is `silent` or `digest` — never delivered                       |
+| `suppressed_cooldown`       | within the cooldown window for its `event_kind`                          |
+| `duplicate_within_window`   | `event_id` seen within the 24-h sliding window                           |
+| `rate_limited`              | exceeded `MAX_DISPATCH_PER_CYCLE = 16` `ready` events for this cycle     |
+
+### `source_module` (3 values)
+
+```
+development_intake_promotion
+development_step5_loop
+development_roadmap_intake
+```
+
+### Cooldown table (`COOLDOWN_SECONDS_PER_EVENT_KIND`)
+
+Pinned per-event-kind cooldown in seconds. Default for any unlisted
+kind is `600`. Cross-cutting kinds (`governance_violation_detected`,
+`secret_or_pii_redaction_event`, `audit_chain_anomaly`) are `0` —
+never silenced. Operator-attention kinds (`*_needs_human`,
+`*_approval_required`, `release_gate_fail`, `e2e_proof_fail`) are also
+`0`.
+
+### `EVENT_SCHEMA_KEYS` (closed and ordered)
+
+```
+event_id
+event_kind
+event_severity
+delivery_intent
+source_module
+source_artifact_path
+source_id
+title
+summary
+risk_class
+execution_authority_decision
+acceptance_criteria
+target_path
+evidence_hash
+created_at
+notes
+```
+
+Wrapper-level fields: `schema_version`, `module_version`,
+`report_kind`, `generated_at_utc`, `step5_enabled_substage`,
+`step5_implementation_allowed`, `sources_read`, `events_history_path`,
+`note`, `validation_warnings`, `vocabularies`,
+`cooldown_seconds_per_event_kind`, `counts`, `events`,
+`execution_authority_module_version`,
+`notification_event_module_version`,
+`intake_promotion_module_version`, `step5_module_version`,
+`roadmap_intake_module_version`, `discipline_invariants`.
+
+---
+
+## 4. Delivery-intent gating (closed table)
+
+Pinned in `_apply_delivery_gates(...)` and tested verbatim. Priority
+order, first match wins:
+
+| Condition                                                            | Outcome                  |
+| -------------------------------------------------------------------- | ------------------------ |
+| `event_severity in {silent, digest}`                                 | `suppressed`             |
+| `event_id` seen within the 24-h sliding window                       | `duplicate_within_window`|
+| `event_kind` cooldown not yet elapsed                                | `suppressed_cooldown`    |
+| ready_count ≥ `MAX_DISPATCH_PER_CYCLE`                               | `rate_limited`           |
+| otherwise                                                            | `ready`                  |
+
+The dispatcher never **drops** an event from the artefact — it only
+re-labels its `delivery_intent`. The full set is always written, so
+the operator can inspect every gate decision after the fact.
+
+---
+
+## 5. Discipline invariants (emitted on every artefact)
+
+```
+sends_real_push                = false
+opens_mobile_inbox             = false
+mints_approval_token           = false
+invokes_network                = false
+invokes_subprocess             = false
+mutates_upstream_artifacts     = false
+reads_subscription_files       = false
+reads_vapid_keys               = false
+writes_dashboard_or_frontend   = false
+secret_redactor_invoked        = true
+operator_promotion_required    = true
+step5_implementation_allowed   = false
+step5_enabled_substage         = "none"
+diagnostics_do_not_trade       = true
+```
+
+Every emitted snapshot is additionally routed through
+[`reporting.agent_audit_summary.assert_no_secrets`](../../reporting/agent_audit_summary.py)
+before write. Defense in depth — the dispatcher emits no
+secret-shaped strings by construction; the redactor is the safety
+net.
+
+---
+
+## 6. CLI
+
+```sh
+# Pure inspection — does not write artifacts:
+python -m reporting.notification_dispatcher --no-write
+python -m reporting.notification_dispatcher_status --no-write
+
+# Writes logs/notification_dispatcher[_status]/latest.json:
+python -m reporting.notification_dispatcher
+python -m reporting.notification_dispatcher_status
+```
+
+Both modules are pure-stdlib + the read-only ADE/reporting deps
+(`notification_event`, `execution_authority`,
+`development_intake_promotion`, `development_step5_loop`,
+`development_roadmap_intake` for the writer module;
+`notification_dispatcher`, `notification_event`,
+`execution_authority` for the status module). No subprocess, no
+network, no `gh`, no `git`.
+
+---
+
+## 7. Authority chain summary
+
+| Capability                                                | Today                                | After N2a                                          | After N2b (future, gated)                          |
+| --------------------------------------------------------- | ------------------------------------ | -------------------------------------------------- | -------------------------------------------------- |
+| Read upstream artefacts (A8/A10/A11/A14/A16a)             | step5_loop, intake_promotion         | unchanged + notification_dispatcher                | unchanged                                          |
+| Compute severity per event                                | N1 `route_for(...)`                  | unchanged                                          | unchanged                                          |
+| Persist a notification-intent record                      | none                                 | `logs/notification_dispatcher/latest.json` + `events.jsonl` | unchanged                              |
+| Send a Web Push to a phone                                | does not exist                       | does not exist                                     | `dashboard/api_push_dispatch.py` (server-side)     |
+| Mint approval tokens                                      | does not exist                       | does not exist                                     | does not exist (N4 territory)                      |
+| Open mobile inbox row                                     | does not exist                       | does not exist                                     | does not exist (N3 territory)                      |
+| Execute merge / deploy                                    | operator + branch protection         | unchanged                                          | unchanged                                          |
+| Autonomous merge / deploy                                 | **forbidden, Level 6**               | unchanged — Level 6 stays permanently disabled     | unchanged — Level 6 stays permanently disabled     |
+
+N2a is operator-supervised. **N2b stays paused** until the operator
+sees the dispatcher artefact in production, validates the dedupe and
+cooldown behaviour, and explicitly authorises a real push surface.
+
+N3 (mobile approval inbox), N4 (approval-token gate), and N5
+(merge/deploy adapter) remain **out of scope** for both N2a and N2b.
+
+---
+
+## 8. Test coverage
+
+Pinned in
+[`tests/unit/test_notification_dispatcher.py`](../../tests/unit/test_notification_dispatcher.py)
+and
+[`tests/unit/test_notification_dispatcher_status.py`](../../tests/unit/test_notification_dispatcher_status.py):
+
+- closed `DELIVERY_INTENTS`, `SOURCE_MODULES`, `EVENT_SCHEMA_KEYS`
+  pinned exactly;
+- the current real A16a candidate becomes
+  `event_kind="intake_candidate_eligible"`,
+  `event_severity="push_info"`,
+  `delivery_intent="ready"` when fed in;
+- a Step 5.0 `plan_emitted` cycle becomes
+  `event_kind="step5_cycle_planned"`,
+  `event_severity="silent"`,
+  `delivery_intent="suppressed"`;
+- duplicate `event_id` within the 24-h sliding window becomes
+  `delivery_intent="duplicate_within_window"`;
+- cooldown suppression works per pinned cooldown table;
+- excess events become `delivery_intent="rate_limited"` once the
+  per-cycle cap is reached;
+- atomic write refuses any path outside
+  `logs/notification_dispatcher/`;
+- `events.jsonl` is bounded ≤ 500 rows;
+- AST-level forbidden-import scan: no `dashboard`, `frontend`,
+  `automation`, `broker`, `agent.risk`, `agent.execution`,
+  `research`, `reporting.intelligent_routing`, `live`, `paper`,
+  `shadow`, `trading`;
+- source-text scan: no `subprocess`, `socket`, `urllib`, `requests`,
+  `httpx`, `aiohttp`, `pywebpush`, `web_push`, `gh`, `git`;
+- importing the module does not flip Step 5 invariants on
+  `reporting.development_step5_loop`;
+- deterministic byte-stable output with an injected
+  `generated_at_utc`;
+- `assert_no_secrets` is invoked before every write;
+- this doc explicitly states no real push in N2a and that N2b is
+  operator-gated;
+- this doc states "no approval from notification click alone"
+  verbatim;
+- this doc states "Level 6 stays permanently disabled" verbatim.
+
+---
+
+## 9. What N2a does NOT do
+
+- N2a sends no real push.
+- N2a opens no network socket.
+- N2a reads no subscription file.
+- N2a reads no VAPID key.
+- N2a writes no `dashboard/**` or `frontend/**` file.
+- N2a opens no inbox row.
+- N2a mints no token.
+- N2a does not change Step 5.0 logic.
+- N2a does not flip `step5_implementation_allowed`.
+- N2a does not change `STEP5_ENABLED_SUBSTAGE`.
+- Step 5.1 / Step 5.2 remain BLOCKED.
+- N3 (mobile approval inbox), N4 (token gate), N5 (merge/deploy
+  adapter) and N2b (real Web Push) remain unimplemented.
+- Level 6 stays permanently disabled. Mobile approval is human
+  approval, not autonomous merge or deploy. **No approval can happen
+  from notification click alone.**

--- a/reporting/notification_dispatcher.py
+++ b/reporting/notification_dispatcher.py
@@ -1,0 +1,1027 @@
+"""N2a — Artifact-only Notification Dispatcher.
+
+Pure, deterministic, stdlib-only notification *dispatcher*. Reads
+existing ADE artefacts (A8 work queue, A14 Step 5.0 plan, A16a intake
+promotion, Step 5.0.1 roadmap intake) and produces notification-ready
+event records under ``logs/notification_dispatcher/``.
+
+This is the smallest safe N2a slice. **No real push is sent.** No
+network call, no socket, no Web Push library, no subscription file,
+no VAPID key, no dashboard or frontend code path. The dispatcher
+*decides nothing*; it computes which event would be delivered and
+writes the result.
+
+N3 (mobile approval inbox), N4 (approval-token gate), and N5
+(merge/deploy adapter) remain unimplemented. N2b (real Web Push
+delivery) remains unimplemented and is gated on a separate explicit
+operator go-signal.
+
+Hard guarantees (pinned by tests)
+---------------------------------
+
+* Stdlib + ``reporting.notification_event`` (read-only) +
+  ``reporting.execution_authority`` (read-only) +
+  ``reporting.development_intake_promotion`` (read-only) +
+  ``reporting.development_roadmap_intake`` (read-only) +
+  ``reporting.development_step5_loop`` (read-only) +
+  ``reporting.agent_audit_summary.assert_no_secrets`` (read-only
+  redactor guard).
+* No subprocess, no network, no ``gh``, no ``git``, no ``socket``,
+  no ``urllib``, no ``requests``, no ``httpx``, no ``aiohttp``, no
+  Web Push library.
+* No imports of ``dashboard``, ``frontend``, ``automation``,
+  ``broker``, ``agent.risk``, ``agent.execution``, ``research``,
+  ``reporting.intelligent_routing``, ``live``, ``paper``, ``shadow``,
+  or ``trading``.
+* No mutation of any upstream artefact.
+* Atomic write only under
+  ``logs/notification_dispatcher/...``.
+* Closed ``delivery_intent`` vocabulary; the routing-table is N1's.
+* ``step5_implementation_allowed`` remains ``False`` and
+  ``STEP5_ENABLED_SUBSTAGE`` remains ``"none"``. Step 5.1 / 5.2 stay
+  BLOCKED. Level 6 stays permanently disabled per ADR-015 §Doctrine 1.
+
+CLI
+---
+
+::
+
+    python -m reporting.notification_dispatcher
+    python -m reporting.notification_dispatcher --no-write
+    python -m reporting.notification_dispatcher --indent 0
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import hashlib
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Final
+
+from reporting import development_intake_promotion as dip
+from reporting import development_roadmap_intake as dri
+from reporting import development_step5_loop as dsl
+from reporting import execution_authority as ea
+from reporting import notification_event as ne
+from reporting.agent_audit_summary import assert_no_secrets
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[str] = "1.0"
+MODULE_VERSION: Final[str] = "v3.15.16.N2a"
+REPORT_KIND: Final[str] = "notification_dispatcher"
+
+# ---------------------------------------------------------------------------
+# Step 5 invariants (re-asserted on every artefact)
+# ---------------------------------------------------------------------------
+
+#: Mirrors the ``development_step5_loop`` constant so the artefact is
+#: self-attesting.
+STEP5_ENABLED_SUBSTAGE: Final[str] = "none"
+
+#: Hard-pinned literal: Step 5 implementation remains BLOCKED.
+step5_implementation_allowed: Final[bool] = False
+
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies
+# ---------------------------------------------------------------------------
+
+#: Closed delivery-intent vocabulary. Adding a value requires a code
+#: change pinned by an updated unit test.
+DELIVERY_INTENTS: Final[tuple[str, ...]] = (
+    "ready",
+    "suppressed",
+    "suppressed_cooldown",
+    "duplicate_within_window",
+    "rate_limited",
+)
+
+#: Closed source-module vocabulary the dispatcher recognises.
+SOURCE_MODULES: Final[tuple[str, ...]] = (
+    "development_intake_promotion",
+    "development_step5_loop",
+    "development_roadmap_intake",
+)
+
+#: Maximum events with ``delivery_intent="ready"`` per cycle. Excess
+#: events are flagged ``rate_limited`` and roll into the next cycle's
+#: ``events.jsonl`` for re-evaluation.
+MAX_DISPATCH_PER_CYCLE: Final[int] = 16
+
+#: Maximum events retained in the bounded ``events.jsonl`` history.
+MAX_EVENTS_HISTORY: Final[int] = 500
+
+#: Per-event-kind cooldown in seconds. Default-deny: any kind not
+#: listed gets a generous 600s cooldown to avoid noise.
+COOLDOWN_SECONDS_PER_EVENT_KIND: Final[dict[str, int]] = {
+    "queue_item_proposed": 1800,
+    "queue_item_blocked": 600,
+    "queue_item_human_needed": 0,
+    "delegation_emitted": 1800,
+    "delegation_blocked": 600,
+    "bugfix_candidate_proposed": 1800,
+    "bugfix_candidate_blocked": 600,
+    "intake_candidate_proposed": 1800,
+    "intake_candidate_eligible": 600,
+    "intake_candidate_blocked": 600,
+    "step5_cycle_planned": 1800,
+    "step5_cycle_halted": 0,
+    "step5_cycle_needs_human": 0,
+    "release_gate_pass": 1800,
+    "release_gate_fail": 0,
+    "release_gate_needs_human": 0,
+    "operational_digest_emitted": 1800,
+    "e2e_proof_pass": 1800,
+    "e2e_proof_fail": 0,
+    "pr_lifecycle_event": 600,
+    "pr_merge_approval_required": 0,
+    "pr_merge_approved": 600,
+    "pr_merge_rejected": 600,
+    "pr_merge_executed": 600,
+    "deploy_approval_required": 0,
+    "deploy_approved": 600,
+    "deploy_rejected": 600,
+    "deploy_executed": 600,
+    "governance_violation_detected": 0,
+    "secret_or_pii_redaction_event": 0,
+    "audit_chain_anomaly": 0,
+    "unknown_state": 600,
+}
+
+#: Severities that are treated as "delivery-suppressed" — the
+#: dispatcher records the event but flags it so a future N2b push
+#: surface never delivers it.
+_SUPPRESSED_SEVERITIES: Final[frozenset[str]] = frozenset({"silent", "digest"})
+
+#: 24-hour sliding-window for duplicate event_id dedupe.
+DEDUPE_WINDOW_SECONDS: Final[int] = 24 * 60 * 60
+
+#: Closed wrapper-level note vocabulary.
+NOTE_NO_SOURCES: Final[str] = "no_upstream_sources_available"
+NOTE_NO_EVENTS: Final[str] = "no_events_to_dispatch"
+NOTE_EVENTS_PRESENT: Final[str] = "events_present"
+
+#: Per-event schema, exact and ordered.
+EVENT_SCHEMA_KEYS: Final[tuple[str, ...]] = (
+    "event_id",
+    "event_kind",
+    "event_severity",
+    "delivery_intent",
+    "source_module",
+    "source_artifact_path",
+    "source_id",
+    "title",
+    "summary",
+    "risk_class",
+    "execution_authority_decision",
+    "acceptance_criteria",
+    "target_path",
+    "evidence_hash",
+    "created_at",
+    "notes",
+)
+
+#: Bounded length for free-text scalars.
+MAX_TITLE_LEN: Final[int] = 200
+MAX_SUMMARY_LEN: Final[int] = 480
+MAX_NOTES_LEN: Final[int] = 1000
+MAX_AC_ITEMS: Final[int] = 16
+MAX_AC_LINE_LEN: Final[int] = 200
+MAX_TARGET_PATH_LEN: Final[int] = 300
+
+# ---------------------------------------------------------------------------
+# Repo-relative paths
+# ---------------------------------------------------------------------------
+
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "notification_dispatcher"
+ARTIFACT_LATEST: Final[Path] = ARTIFACT_DIR / "latest.json"
+ARTIFACT_RELATIVE_PATH: Final[str] = (
+    "logs/notification_dispatcher/latest.json"
+)
+EVENTS_JSONL_PATH: Final[Path] = ARTIFACT_DIR / "events.jsonl"
+EVENTS_JSONL_RELATIVE_PATH: Final[str] = (
+    "logs/notification_dispatcher/events.jsonl"
+)
+
+#: Atomic-write allowlist (substring form).
+_WRITE_PREFIX: Final[str] = "logs/notification_dispatcher/"
+
+# ---------------------------------------------------------------------------
+# Discipline invariants emitted into every artefact
+# ---------------------------------------------------------------------------
+
+_DISCIPLINE_INVARIANTS: Final[dict[str, bool | str]] = {
+    "sends_real_push": False,
+    "opens_mobile_inbox": False,
+    "mints_approval_token": False,
+    "invokes_network": False,
+    "invokes_subprocess": False,
+    "mutates_upstream_artifacts": False,
+    "reads_subscription_files": False,
+    "reads_vapid_keys": False,
+    "writes_dashboard_or_frontend": False,
+    "secret_redactor_invoked": True,
+    "operator_promotion_required": True,
+    "step5_implementation_allowed": False,
+    "step5_enabled_substage": "none",
+    "diagnostics_do_not_trade": True,
+}
+
+
+# ---------------------------------------------------------------------------
+# Utility helpers
+# ---------------------------------------------------------------------------
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _bounded_str(value: Any, max_len: int) -> str:
+    if not isinstance(value, str):
+        return ""
+    if len(value) <= max_len:
+        return value
+    return value[:max_len]
+
+
+def _bounded_str_list(
+    value: Any, max_items: int, max_line_len: int
+) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    out: list[str] = []
+    for v in value[:max_items]:
+        if isinstance(v, str):
+            out.append(_bounded_str(v, max_line_len))
+    return out
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+
+def _parse_iso_utc(s: str | None) -> _dt.datetime | None:
+    """Best-effort parse of an RFC3339 UTC string. Returns None on
+    failure; never raises on malformed input."""
+    if not isinstance(s, str) or not s:
+        return None
+    try:
+        norm = s.replace("Z", "+00:00")
+        dt = _dt.datetime.fromisoformat(norm)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=_dt.UTC)
+        return dt
+    except ValueError:
+        return None
+
+
+def _seconds_between(later: str | None, earlier: str | None) -> float | None:
+    a = _parse_iso_utc(later)
+    b = _parse_iso_utc(earlier)
+    if a is None or b is None:
+        return None
+    return (a - b).total_seconds()
+
+
+def _evidence_hash(parts: dict[str, Any]) -> str:
+    payload = json.dumps(parts, sort_keys=True, ensure_ascii=False)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _event_id(event_kind: str, source_module: str, source_id: str, content_hash: str) -> str:
+    raw = f"{event_kind}|{source_module}|{source_id}|{content_hash}".encode(
+        "utf-8"
+    )
+    return hashlib.sha256(raw).hexdigest()[:32]
+
+
+# ---------------------------------------------------------------------------
+# Source projectors — pure: dict in, list[dict] out
+# ---------------------------------------------------------------------------
+
+
+def _project_intake_promotion_rows(
+    payload: dict[str, Any] | None,
+    *,
+    artifact_path: str,
+    created_at: str,
+) -> list[dict[str, Any]]:
+    """Map A16a promotion-intent rows to event records."""
+    if not isinstance(payload, dict):
+        return []
+    rows = payload.get("rows")
+    if not isinstance(rows, list):
+        return []
+
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        decision_state = row.get("decision_state")
+        if decision_state == "eligible":
+            event_kind = "intake_candidate_eligible"
+        elif decision_state in ("blocked", "human_needed"):
+            event_kind = "intake_candidate_blocked"
+        elif decision_state == "already_promoted":
+            event_kind = "intake_candidate_eligible"
+        else:
+            continue
+
+        source_id = str(row.get("candidate_id") or "")
+        if not source_id:
+            continue
+
+        risk_class = row.get("risk_level")
+        reclassified = row.get("reclassified_execution_authority_decision")
+        severity = ne.route_for(
+            event_kind,
+            risk_class=risk_class if isinstance(risk_class, str) else None,
+            execution_authority_decision=(
+                reclassified if isinstance(reclassified, str) else None
+            ),
+        )
+
+        title = _bounded_str(row.get("title"), MAX_TITLE_LEN)
+        summary_raw = (
+            f"decision_state={decision_state}; "
+            f"risk={risk_class}; "
+            f"target={row.get('target_path') or ''}"
+        )
+        summary = _bounded_str(summary_raw, MAX_SUMMARY_LEN)
+        ac = _bounded_str_list(
+            row.get("acceptance_criteria"), MAX_AC_ITEMS, MAX_AC_LINE_LEN
+        )
+        target_path = _bounded_str(row.get("target_path"), MAX_TARGET_PATH_LEN)
+
+        content_parts = {
+            "decision_state": decision_state,
+            "risk_class": risk_class,
+            "reclassified_execution_authority_decision": reclassified,
+            "target_path": target_path,
+            "title": title,
+            "evidence_hash_upstream": row.get("evidence_hash"),
+        }
+        evidence_hash = _evidence_hash(content_parts)
+        eid = _event_id(
+            event_kind,
+            "development_intake_promotion",
+            source_id,
+            evidence_hash,
+        )
+
+        out.append(
+            {
+                "event_id": eid,
+                "event_kind": event_kind,
+                "event_severity": severity,
+                "delivery_intent": "ready",  # gates will overwrite later
+                "source_module": "development_intake_promotion",
+                "source_artifact_path": artifact_path,
+                "source_id": source_id,
+                "title": title,
+                "summary": summary,
+                "risk_class": risk_class if isinstance(risk_class, str) else "",
+                "execution_authority_decision": (
+                    reclassified if isinstance(reclassified, str) else ""
+                ),
+                "acceptance_criteria": ac,
+                "target_path": target_path,
+                "evidence_hash": evidence_hash,
+                "created_at": created_at,
+                "notes": "",
+            }
+        )
+    return out
+
+
+def _project_step5_loop_row(
+    payload: dict[str, Any] | None,
+    *,
+    artifact_path: str,
+    created_at: str,
+) -> list[dict[str, Any]]:
+    """Map the latest Step 5.0 loop snapshot to a single event."""
+    if not isinstance(payload, dict):
+        return []
+    plan = payload.get("current_plan")
+    if not isinstance(plan, dict):
+        return []
+    outcome = plan.get("outcome")
+    halt_reason = plan.get("halt_reason")
+    decision = plan.get("execution_authority_decision")
+
+    if outcome == "plan_emitted":
+        event_kind = "step5_cycle_planned"
+    elif outcome in ("halt_needs_human",):
+        event_kind = "step5_cycle_needs_human"
+    elif outcome in (
+        "halt_permanently_denied",
+        "halt_out_of_allowlist",
+    ):
+        event_kind = "step5_cycle_halted"
+    elif outcome == "no_op_no_eligible_item":
+        # Don't emit a notification for empty cycles — pure noise.
+        return []
+    else:
+        return []
+
+    cycle_id = str(plan.get("cycle_id") or "")
+    if not cycle_id:
+        return []
+
+    severity = ne.route_for(
+        event_kind,
+        risk_class=None,
+        execution_authority_decision=(
+            decision if isinstance(decision, str) else None
+        ),
+    )
+
+    title = _bounded_str(
+        f"Step 5.0 {outcome}: {plan.get('source_kind') or ''}/{plan.get('source_id') or ''}",
+        MAX_TITLE_LEN,
+    )
+    summary = _bounded_str(
+        f"halt_reason={halt_reason}; decision={decision}",
+        MAX_SUMMARY_LEN,
+    )
+
+    content_parts = {
+        "outcome": outcome,
+        "halt_reason": halt_reason,
+        "execution_authority_decision": decision,
+        "source_kind": plan.get("source_kind"),
+        "source_id": plan.get("source_id"),
+    }
+    evidence_hash = _evidence_hash(content_parts)
+    eid = _event_id(
+        event_kind, "development_step5_loop", cycle_id, evidence_hash
+    )
+
+    return [
+        {
+            "event_id": eid,
+            "event_kind": event_kind,
+            "event_severity": severity,
+            "delivery_intent": "ready",
+            "source_module": "development_step5_loop",
+            "source_artifact_path": artifact_path,
+            "source_id": cycle_id,
+            "title": title,
+            "summary": summary,
+            "risk_class": "",
+            "execution_authority_decision": (
+                decision if isinstance(decision, str) else ""
+            ),
+            "acceptance_criteria": [],
+            "target_path": "",
+            "evidence_hash": evidence_hash,
+            "created_at": created_at,
+            "notes": "",
+        }
+    ]
+
+
+def _project_roadmap_intake_candidates(
+    payload: dict[str, Any] | None,
+    *,
+    artifact_path: str,
+    created_at: str,
+) -> list[dict[str, Any]]:
+    """Map Step 5.0.1 roadmap intake candidates (proposed-only) to
+    intake_candidate_proposed events. Eligible/blocked candidates are
+    handled by the A16a projector above; this projector emits the
+    discovery-stage event so the operator can see new candidates as
+    they show up."""
+    if not isinstance(payload, dict):
+        return []
+    candidates = payload.get("candidates")
+    if not isinstance(candidates, list):
+        return []
+
+    out: list[dict[str, Any]] = []
+    for cand in candidates:
+        if not isinstance(cand, dict):
+            continue
+        # Only emit "proposed" — eligible/blocked are owned by A16a.
+        # If the upstream intake_status is "eligible", the A16a
+        # projector emits the actionable event; this projector emits
+        # the silent discovery event.
+        intake_status = cand.get("intake_status")
+        if intake_status not in ("proposed", "eligible"):
+            continue
+
+        event_kind = "intake_candidate_proposed"
+        candidate_id = str(cand.get("candidate_id") or "")
+        if not candidate_id:
+            continue
+
+        risk_class = cand.get("risk_level")
+        decision = cand.get("execution_authority_decision")
+
+        severity = ne.route_for(
+            event_kind,
+            risk_class=risk_class if isinstance(risk_class, str) else None,
+            execution_authority_decision=(
+                decision if isinstance(decision, str) else None
+            ),
+        )
+
+        title = _bounded_str(cand.get("title"), MAX_TITLE_LEN)
+        summary_raw = (
+            f"intake_status={intake_status}; "
+            f"risk={risk_class}; "
+            f"target={cand.get('target_path') or ''}"
+        )
+        summary = _bounded_str(summary_raw, MAX_SUMMARY_LEN)
+        ac = _bounded_str_list(
+            cand.get("acceptance_criteria"), MAX_AC_ITEMS, MAX_AC_LINE_LEN
+        )
+        target_path = _bounded_str(
+            cand.get("target_path"), MAX_TARGET_PATH_LEN
+        )
+
+        content_parts = {
+            "intake_status": intake_status,
+            "risk_class": risk_class,
+            "execution_authority_decision": decision,
+            "target_path": target_path,
+            "title": title,
+        }
+        evidence_hash = _evidence_hash(content_parts)
+        eid = _event_id(
+            event_kind,
+            "development_roadmap_intake",
+            candidate_id,
+            evidence_hash,
+        )
+
+        out.append(
+            {
+                "event_id": eid,
+                "event_kind": event_kind,
+                "event_severity": severity,
+                "delivery_intent": "ready",
+                "source_module": "development_roadmap_intake",
+                "source_artifact_path": artifact_path,
+                "source_id": candidate_id,
+                "title": title,
+                "summary": summary,
+                "risk_class": risk_class if isinstance(risk_class, str) else "",
+                "execution_authority_decision": (
+                    decision if isinstance(decision, str) else ""
+                ),
+                "acceptance_criteria": ac,
+                "target_path": target_path,
+                "evidence_hash": evidence_hash,
+                "created_at": created_at,
+                "notes": "",
+            }
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Delivery-intent gates
+# ---------------------------------------------------------------------------
+
+
+def _read_history(path: Path) -> list[dict[str, Any]]:
+    """Read prior events from the bounded history JSONL. Best-effort;
+    malformed lines skipped."""
+    if not path.is_file():
+        return []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    out: list[dict[str, Any]] = []
+    for raw in text.splitlines():
+        s = raw.strip()
+        if not s:
+            continue
+        try:
+            entry = json.loads(s)
+        except ValueError:
+            continue
+        if isinstance(entry, dict):
+            out.append(entry)
+    return out
+
+
+def _apply_delivery_gates(
+    events: list[dict[str, Any]],
+    *,
+    history: list[dict[str, Any]],
+    now_utc: str,
+) -> list[dict[str, Any]]:
+    """Apply the closed delivery-intent rules in priority order:
+
+    1. severity in {silent, digest} → ``suppressed``
+    2. event_id seen in 24h sliding window → ``duplicate_within_window``
+    3. event_kind within cooldown → ``suppressed_cooldown``
+    4. excess over MAX_DISPATCH_PER_CYCLE → ``rate_limited``
+    5. otherwise → ``ready``
+
+    Returns events with mutated ``delivery_intent`` values; never
+    drops an event from the output list (gating only re-labels).
+    """
+    seen_ids: dict[str, str] = {}  # event_id -> created_at
+    last_seen_per_kind: dict[str, str] = {}
+    for h in history:
+        eid = h.get("event_id")
+        ek = h.get("event_kind")
+        ts = h.get("created_at")
+        if isinstance(eid, str) and isinstance(ts, str):
+            seen_ids[eid] = ts
+        if isinstance(ek, str) and isinstance(ts, str):
+            prev = last_seen_per_kind.get(ek)
+            if prev is None or ts > prev:
+                last_seen_per_kind[ek] = ts
+
+    ready_count = 0
+    out: list[dict[str, Any]] = []
+    for ev in events:
+        new_ev = dict(ev)
+        sev = new_ev.get("event_severity")
+        kind = new_ev.get("event_kind")
+        eid = new_ev.get("event_id")
+
+        # 1. Severity-default suppression.
+        if sev in _SUPPRESSED_SEVERITIES:
+            new_ev["delivery_intent"] = "suppressed"
+            out.append(new_ev)
+            continue
+
+        # 2. event_id dedupe within sliding window.
+        if isinstance(eid, str) and eid in seen_ids:
+            seen_ts = seen_ids[eid]
+            seconds = _seconds_between(now_utc, seen_ts)
+            if seconds is None or seconds <= DEDUPE_WINDOW_SECONDS:
+                new_ev["delivery_intent"] = "duplicate_within_window"
+                out.append(new_ev)
+                continue
+
+        # 3. Cooldown per event_kind.
+        if isinstance(kind, str):
+            cooldown = COOLDOWN_SECONDS_PER_EVENT_KIND.get(kind, 600)
+            if cooldown > 0:
+                last_ts = last_seen_per_kind.get(kind)
+                if last_ts is not None:
+                    seconds = _seconds_between(now_utc, last_ts)
+                    if seconds is not None and seconds < cooldown:
+                        new_ev["delivery_intent"] = "suppressed_cooldown"
+                        out.append(new_ev)
+                        continue
+
+        # 4. Rate limit.
+        if ready_count >= MAX_DISPATCH_PER_CYCLE:
+            new_ev["delivery_intent"] = "rate_limited"
+            out.append(new_ev)
+            continue
+
+        # 5. Default — ready.
+        new_ev["delivery_intent"] = "ready"
+        ready_count += 1
+        out.append(new_ev)
+
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Snapshot assembly
+# ---------------------------------------------------------------------------
+
+
+def _empty_counts() -> dict[str, Any]:
+    return {
+        "total": 0,
+        "ready": 0,
+        "suppressed": 0,
+        "suppressed_cooldown": 0,
+        "duplicate_within_window": 0,
+        "rate_limited": 0,
+        "by_event_kind": {k: 0 for k in ne.EVENT_KINDS},
+        "by_event_severity": {s: 0 for s in ne.EVENT_SEVERITIES},
+        "by_delivery_intent": {d: 0 for d in DELIVERY_INTENTS},
+        "by_source_module": {m: 0 for m in SOURCE_MODULES},
+        "by_execution_authority_decision": {
+            ea.DECISION_AUTO_ALLOWED: 0,
+            ea.DECISION_NEEDS_HUMAN: 0,
+            ea.DECISION_PERMANENTLY_DENIED: 0,
+        },
+    }
+
+
+def _aggregate_counts(events: list[dict[str, Any]]) -> dict[str, Any]:
+    counts = _empty_counts()
+    counts["total"] = len(events)
+    for ev in events:
+        di = ev.get("delivery_intent")
+        if di in counts:
+            counts[di] += 1
+        if di in counts["by_delivery_intent"]:
+            counts["by_delivery_intent"][di] += 1
+        kind = ev.get("event_kind")
+        if isinstance(kind, str) and kind in counts["by_event_kind"]:
+            counts["by_event_kind"][kind] += 1
+        sev = ev.get("event_severity")
+        if isinstance(sev, str) and sev in counts["by_event_severity"]:
+            counts["by_event_severity"][sev] += 1
+        sm = ev.get("source_module")
+        if isinstance(sm, str) and sm in counts["by_source_module"]:
+            counts["by_source_module"][sm] += 1
+        d = ev.get("execution_authority_decision")
+        if d in counts["by_execution_authority_decision"]:
+            counts["by_execution_authority_decision"][d] += 1
+    return counts
+
+
+def collect_snapshot(
+    *,
+    intake_promotion_path: Path | None = None,
+    step5_loop_path: Path | None = None,
+    roadmap_intake_path: Path | None = None,
+    events_history_path: Path | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    """Build the deterministic notification-dispatcher snapshot.
+
+    All path arguments are read-only. ``events_history_path`` is read
+    for sliding-window dedupe and cooldown computation; not mutated
+    here.
+    """
+    ip = (
+        intake_promotion_path
+        if intake_promotion_path is not None
+        else dip.ARTIFACT_LATEST
+    )
+    sp = (
+        step5_loop_path
+        if step5_loop_path is not None
+        else dsl.ARTIFACT_LATEST
+    )
+    rp = (
+        roadmap_intake_path
+        if roadmap_intake_path is not None
+        else dri.ARTIFACT_LATEST
+    )
+    eh = (
+        events_history_path
+        if events_history_path is not None
+        else EVENTS_JSONL_PATH
+    )
+    ts = generated_at_utc if generated_at_utc is not None else _utcnow()
+
+    intake_payload = _read_json(ip)
+    step5_payload = _read_json(sp)
+    roadmap_payload = _read_json(rp)
+
+    sources_read: list[dict[str, Any]] = [
+        {
+            "source_module": "development_intake_promotion",
+            "path": str(ip),
+            "available": intake_payload is not None,
+        },
+        {
+            "source_module": "development_step5_loop",
+            "path": str(sp),
+            "available": step5_payload is not None,
+        },
+        {
+            "source_module": "development_roadmap_intake",
+            "path": str(rp),
+            "available": roadmap_payload is not None,
+        },
+    ]
+
+    events: list[dict[str, Any]] = []
+    events.extend(
+        _project_intake_promotion_rows(
+            intake_payload,
+            artifact_path=str(ip),
+            created_at=ts,
+        )
+    )
+    events.extend(
+        _project_step5_loop_row(
+            step5_payload, artifact_path=str(sp), created_at=ts
+        )
+    )
+    events.extend(
+        _project_roadmap_intake_candidates(
+            roadmap_payload, artifact_path=str(rp), created_at=ts
+        )
+    )
+
+    # Stable ordering: source_module, event_kind, event_id.
+    events.sort(
+        key=lambda e: (
+            e.get("source_module", ""),
+            e.get("event_kind", ""),
+            e.get("event_id", ""),
+        )
+    )
+
+    history = _read_history(eh)
+    events = _apply_delivery_gates(events, history=history, now_utc=ts)
+
+    counts = _aggregate_counts(events)
+
+    if all(s["available"] is False for s in sources_read):
+        note = NOTE_NO_SOURCES
+    elif not events:
+        note = NOTE_NO_EVENTS
+    else:
+        note = NOTE_EVENTS_PRESENT
+
+    snapshot = {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": ts,
+        "step5_enabled_substage": STEP5_ENABLED_SUBSTAGE,
+        "step5_implementation_allowed": step5_implementation_allowed,
+        "sources_read": sources_read,
+        "events_history_path": str(eh),
+        "note": note,
+        "validation_warnings": [],
+        "vocabularies": {
+            "delivery_intents": list(DELIVERY_INTENTS),
+            "source_modules": list(SOURCE_MODULES),
+            "notification_event_kinds": list(ne.EVENT_KINDS),
+            "notification_event_severities": list(ne.EVENT_SEVERITIES),
+            "max_dispatch_per_cycle": MAX_DISPATCH_PER_CYCLE,
+            "max_events_history": MAX_EVENTS_HISTORY,
+            "dedupe_window_seconds": DEDUPE_WINDOW_SECONDS,
+        },
+        "cooldown_seconds_per_event_kind": dict(
+            COOLDOWN_SECONDS_PER_EVENT_KIND
+        ),
+        "counts": counts,
+        "events": events,
+        "execution_authority_module_version": ea.MODULE_VERSION,
+        "notification_event_module_version": ne.MODULE_VERSION,
+        "intake_promotion_module_version": dip.MODULE_VERSION,
+        "step5_module_version": dsl.MODULE_VERSION,
+        "roadmap_intake_module_version": dri.MODULE_VERSION,
+        "discipline_invariants": dict(_DISCIPLINE_INVARIANTS),
+    }
+
+    # Defense-in-depth: every emitted snapshot is run through the
+    # closed credential-pattern guard. The dispatcher emits no
+    # secret-shaped strings by construction, but the guard is the
+    # safety net per the canonical rule.
+    assert_no_secrets(snapshot)
+    return snapshot
+
+
+# ---------------------------------------------------------------------------
+# Atomic write + bounded events.jsonl append
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    posix = path.as_posix()
+    if _WRITE_PREFIX not in posix and not posix.startswith(_WRITE_PREFIX):
+        raise ValueError(
+            "notification_dispatcher._atomic_write_json refuses "
+            f"non-dispatcher-logs output path: {path}"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".notification_dispatcher.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def _append_events_history(
+    path: Path, events: list[dict[str, Any]]
+) -> None:
+    posix = path.as_posix()
+    if _WRITE_PREFIX not in posix and not posix.startswith(_WRITE_PREFIX):
+        raise ValueError(
+            "notification_dispatcher._append_events_history refuses "
+            f"non-dispatcher-logs path: {path}"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    existing: list[str] = []
+    if path.is_file():
+        try:
+            existing = [
+                line for line in path.read_text(encoding="utf-8").splitlines()
+                if line.strip()
+            ]
+        except OSError:
+            existing = []
+    for ev in events:
+        compact = {
+            "event_id": ev["event_id"],
+            "event_kind": ev["event_kind"],
+            "event_severity": ev["event_severity"],
+            "delivery_intent": ev["delivery_intent"],
+            "source_module": ev["source_module"],
+            "source_id": ev["source_id"],
+            "created_at": ev["created_at"],
+        }
+        existing.append(json.dumps(compact, sort_keys=True, ensure_ascii=False))
+    if len(existing) > MAX_EVENTS_HISTORY:
+        existing = existing[-MAX_EVENTS_HISTORY:]
+    text = "\n".join(existing) + ("\n" if existing else "")
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".notification_dispatcher.events.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_outputs(snapshot: dict[str, Any]) -> tuple[Path, Path]:
+    _atomic_write_json(ARTIFACT_LATEST, snapshot)
+    _append_events_history(EVENTS_JSONL_PATH, snapshot.get("events") or [])
+    return (ARTIFACT_LATEST, EVENTS_JSONL_PATH)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m reporting.notification_dispatcher",
+        description=(
+            "N2a Artifact-only Notification Dispatcher. Read-only "
+            "deterministic projector that converts ADE upstream "
+            "artefacts into notification-ready event records under "
+            "logs/notification_dispatcher/. Sends no real push. "
+            "Decides nothing; emits no notifications externally. "
+            "Step 5 implementation remains BLOCKED."
+        ),
+    )
+    p.add_argument(
+        "--indent", type=int, default=2, help="JSON indent (0 for compact)."
+    )
+    p.add_argument(
+        "--no-write",
+        action="store_true",
+        help=(
+            "Do not persist "
+            "logs/notification_dispatcher/latest.json or events.jsonl "
+            "(stdout only)."
+        ),
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    indent = args.indent if args.indent and args.indent > 0 else None
+    snap = collect_snapshot()
+    if not args.no_write:
+        write_outputs(snap)
+    json.dump(snap, sys.stdout, indent=indent, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/reporting/notification_dispatcher_status.py
+++ b/reporting/notification_dispatcher_status.py
@@ -1,0 +1,356 @@
+"""N2a — Artifact-only Notification Dispatcher status summary.
+
+Read-only projection that consumes
+``logs/notification_dispatcher/latest.json`` and emits a compact
+operator-facing status summary, counting events by ``event_kind``,
+``event_severity``, ``delivery_intent``, ``source_module``, and
+``execution_authority_decision``. Builds an ``operator_action_list``
+of ready events at severity ``push_action_required``,
+``approval_required``, or ``critical``.
+
+Hard guarantees (pinned by tests):
+
+* Stdlib + ``reporting.notification_dispatcher`` (read-only) +
+  ``reporting.notification_event`` (read-only) +
+  ``reporting.execution_authority`` (read-only) +
+  ``reporting.agent_audit_summary.assert_no_secrets`` (read-only
+  redactor guard).
+* No subprocess, no network, no ``gh``, no ``git``, no ``socket``,
+  no ``urllib``, no ``requests``, no ``httpx``, no ``aiohttp``, no
+  Web Push library.
+* No imports of ``dashboard``, ``frontend``, ``automation``,
+  ``broker``, ``agent.risk``, ``agent.execution``, ``research``,
+  ``reporting.intelligent_routing``, ``live``, ``paper``, ``shadow``,
+  or ``trading``.
+* Pure read on the upstream artefact; never mutates ``latest.json``.
+* Atomic write only under ``logs/notification_dispatcher_status/``.
+
+CLI::
+
+    python -m reporting.notification_dispatcher_status
+    python -m reporting.notification_dispatcher_status --indent 2
+    python -m reporting.notification_dispatcher_status --no-write
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Final
+
+from reporting import execution_authority as ea
+from reporting import notification_dispatcher as nd
+from reporting import notification_event as ne
+from reporting.agent_audit_summary import assert_no_secrets
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[str] = "1.0"
+MODULE_VERSION: Final[str] = "v3.15.16.N2a"
+REPORT_KIND: Final[str] = "notification_dispatcher_status"
+
+ARTIFACT_DIR: Final[Path] = (
+    REPO_ROOT / "logs" / "notification_dispatcher_status"
+)
+ARTIFACT_LATEST: Final[Path] = ARTIFACT_DIR / "latest.json"
+ARTIFACT_RELATIVE_PATH: Final[str] = (
+    "logs/notification_dispatcher_status/latest.json"
+)
+
+_WRITE_PREFIX: Final[str] = "logs/notification_dispatcher_status/"
+
+#: Severities that warrant operator attention.
+_OPERATOR_ATTENTION_SEVERITIES: Final[frozenset[str]] = frozenset(
+    {"push_action_required", "approval_required", "critical"}
+)
+
+#: Maximum operator-action rows surfaced in the status summary.
+_MAX_OPERATOR_ACTION_ROWS: Final[int] = 16
+
+#: Bounded length for the per-row operator-action title/summary.
+_MAX_OPERATOR_ACTION_TITLE_LEN: Final[int] = 200
+_MAX_OPERATOR_ACTION_SUMMARY_LEN: Final[int] = 480
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+
+def _bounded(s: Any, n: int) -> str:
+    if not isinstance(s, str):
+        return ""
+    return s[:n]
+
+
+def _schema_pinned() -> dict[str, Any]:
+    return {
+        "delivery_intents": list(nd.DELIVERY_INTENTS),
+        "source_modules": list(nd.SOURCE_MODULES),
+        "notification_event_kinds": list(ne.EVENT_KINDS),
+        "notification_event_severities": list(ne.EVENT_SEVERITIES),
+        "execution_authority_decisions": [
+            ea.DECISION_AUTO_ALLOWED,
+            ea.DECISION_NEEDS_HUMAN,
+            ea.DECISION_PERMANENTLY_DENIED,
+        ],
+    }
+
+
+def _empty_counts() -> dict[str, Any]:
+    return {
+        "total": 0,
+        "ready": 0,
+        "suppressed": 0,
+        "suppressed_cooldown": 0,
+        "duplicate_within_window": 0,
+        "rate_limited": 0,
+        "operator_attention_ready": 0,
+        "by_event_kind": {k: 0 for k in ne.EVENT_KINDS},
+        "by_event_severity": {s: 0 for s in ne.EVENT_SEVERITIES},
+        "by_delivery_intent": {d: 0 for d in nd.DELIVERY_INTENTS},
+        "by_source_module": {m: 0 for m in nd.SOURCE_MODULES},
+        "by_execution_authority_decision": {
+            ea.DECISION_AUTO_ALLOWED: 0,
+            ea.DECISION_NEEDS_HUMAN: 0,
+            ea.DECISION_PERMANENTLY_DENIED: 0,
+        },
+    }
+
+
+def _build_operator_action_list(
+    events: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Pick out ``ready`` events at attention-warranting severities."""
+    out: list[dict[str, Any]] = []
+    for ev in events:
+        if not isinstance(ev, dict):
+            continue
+        if ev.get("delivery_intent") != "ready":
+            continue
+        if ev.get("event_severity") not in _OPERATOR_ATTENTION_SEVERITIES:
+            continue
+        out.append(
+            {
+                "event_id": ev.get("event_id", ""),
+                "event_kind": ev.get("event_kind", ""),
+                "event_severity": ev.get("event_severity", ""),
+                "source_module": ev.get("source_module", ""),
+                "source_id": ev.get("source_id", ""),
+                "title": _bounded(
+                    ev.get("title"), _MAX_OPERATOR_ACTION_TITLE_LEN
+                ),
+                "summary": _bounded(
+                    ev.get("summary"), _MAX_OPERATOR_ACTION_SUMMARY_LEN
+                ),
+                "execution_authority_decision": ev.get(
+                    "execution_authority_decision", ""
+                ),
+                "target_path": _bounded(ev.get("target_path"), 300),
+                "created_at": ev.get("created_at", ""),
+            }
+        )
+        if len(out) >= _MAX_OPERATOR_ACTION_ROWS:
+            break
+    return out
+
+
+def collect_status(
+    *,
+    dispatcher_artifact_path: Path | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    """Build a deterministic status snapshot from the dispatcher
+    artifact."""
+    dp = (
+        dispatcher_artifact_path
+        if dispatcher_artifact_path is not None
+        else nd.ARTIFACT_LATEST
+    )
+    ts = generated_at_utc if generated_at_utc is not None else _utcnow()
+    payload = _read_json(dp)
+    if payload is None:
+        snap = {
+            "schema_version": SCHEMA_VERSION,
+            "module_version": MODULE_VERSION,
+            "report_kind": REPORT_KIND,
+            "generated_at_utc": ts,
+            "dispatcher_artifact_path": str(dp),
+            "dispatcher_artifact_available": False,
+            "dispatcher_module_version": nd.MODULE_VERSION,
+            "step5_enabled_substage": nd.STEP5_ENABLED_SUBSTAGE,
+            "step5_implementation_allowed": nd.step5_implementation_allowed,
+            "schema_pinned": _schema_pinned(),
+            "counts": _empty_counts(),
+            "operator_action_list": [],
+            "validation_warnings": [],
+            "note": "dispatcher_artifact_absent",
+        }
+        assert_no_secrets(snap)
+        return snap
+
+    upstream_counts = payload.get("counts") or {}
+    if not isinstance(upstream_counts, dict):
+        upstream_counts = {}
+
+    events = payload.get("events") if isinstance(payload.get("events"), list) else []
+    events = [e for e in events if isinstance(e, dict)]
+
+    counts = _empty_counts()
+    counts["total"] = int(upstream_counts.get("total") or len(events))
+    counts["ready"] = int(upstream_counts.get("ready") or 0)
+    counts["suppressed"] = int(upstream_counts.get("suppressed") or 0)
+    counts["suppressed_cooldown"] = int(
+        upstream_counts.get("suppressed_cooldown") or 0
+    )
+    counts["duplicate_within_window"] = int(
+        upstream_counts.get("duplicate_within_window") or 0
+    )
+    counts["rate_limited"] = int(upstream_counts.get("rate_limited") or 0)
+
+    by_kind = upstream_counts.get("by_event_kind") or {}
+    if isinstance(by_kind, dict):
+        for k in ne.EVENT_KINDS:
+            counts["by_event_kind"][k] = int(by_kind.get(k) or 0)
+
+    by_sev = upstream_counts.get("by_event_severity") or {}
+    if isinstance(by_sev, dict):
+        for s in ne.EVENT_SEVERITIES:
+            counts["by_event_severity"][s] = int(by_sev.get(s) or 0)
+
+    by_di = upstream_counts.get("by_delivery_intent") or {}
+    if isinstance(by_di, dict):
+        for d in nd.DELIVERY_INTENTS:
+            counts["by_delivery_intent"][d] = int(by_di.get(d) or 0)
+
+    by_sm = upstream_counts.get("by_source_module") or {}
+    if isinstance(by_sm, dict):
+        for m in nd.SOURCE_MODULES:
+            counts["by_source_module"][m] = int(by_sm.get(m) or 0)
+
+    by_dec = upstream_counts.get("by_execution_authority_decision") or {}
+    if isinstance(by_dec, dict):
+        for d in (
+            ea.DECISION_AUTO_ALLOWED,
+            ea.DECISION_NEEDS_HUMAN,
+            ea.DECISION_PERMANENTLY_DENIED,
+        ):
+            counts["by_execution_authority_decision"][d] = int(
+                by_dec.get(d) or 0
+            )
+
+    operator_action_list = _build_operator_action_list(events)
+    counts["operator_attention_ready"] = len(operator_action_list)
+
+    snap = {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": ts,
+        "dispatcher_artifact_path": str(dp),
+        "dispatcher_artifact_available": True,
+        "dispatcher_module_version": payload.get("module_version"),
+        "dispatcher_schema_version": payload.get("schema_version"),
+        "dispatcher_generated_at_utc": payload.get("generated_at_utc"),
+        "dispatcher_note": payload.get("note"),
+        "step5_enabled_substage": payload.get("step5_enabled_substage")
+        or nd.STEP5_ENABLED_SUBSTAGE,
+        "step5_implementation_allowed": bool(
+            payload.get("step5_implementation_allowed")
+        ),
+        "schema_pinned": _schema_pinned(),
+        "counts": counts,
+        "operator_action_list": operator_action_list,
+        "validation_warnings": list(payload.get("validation_warnings") or []),
+        "note": "dispatcher_artifact_present",
+    }
+    assert_no_secrets(snap)
+    return snap
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    posix = path.as_posix()
+    if _WRITE_PREFIX not in posix and not posix.startswith(_WRITE_PREFIX):
+        raise ValueError(
+            "notification_dispatcher_status._atomic_write_json refuses "
+            f"non-status-logs output path: {path}"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".notification_dispatcher_status.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_outputs(snapshot: dict[str, Any]) -> Path:
+    _atomic_write_json(ARTIFACT_LATEST, snapshot)
+    return ARTIFACT_LATEST
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m reporting.notification_dispatcher_status",
+        description=(
+            "Read-only summary of "
+            "logs/notification_dispatcher/latest.json. Decides nothing; "
+            "mutates nothing."
+        ),
+    )
+    p.add_argument(
+        "--indent", type=int, default=2, help="JSON indent (0 for compact)."
+    )
+    p.add_argument(
+        "--no-write",
+        action="store_true",
+        help=(
+            "Do not persist "
+            "logs/notification_dispatcher_status/latest.json "
+            "(stdout only)."
+        ),
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    indent = args.indent if args.indent and args.indent > 0 else None
+    snap = collect_status()
+    if not args.no_write:
+        write_outputs(snap)
+    json.dump(snap, sys.stdout, indent=indent, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/unit/test_notification_dispatcher.py
+++ b/tests/unit/test_notification_dispatcher.py
@@ -1,0 +1,885 @@
+"""Unit tests for N2a — Artifact-only Notification Dispatcher.
+
+Synthetic deterministic fixtures only. The dispatcher is read-only:
+it reads existing ADE artefacts and produces notification-ready
+records. **It sends no real push, opens no socket, and mints no
+token.**
+
+Pinned here:
+
+* Closed vocabularies (DELIVERY_INTENTS, SOURCE_MODULES,
+  EVENT_SCHEMA_KEYS) are byte-exact.
+* The current real A16a candidate becomes a `ready`
+  `intake_candidate_eligible` / `push_info` event.
+* A Step 5.0 `plan_emitted` cycle becomes a `suppressed`
+  `step5_cycle_planned` / `silent` event.
+* Duplicate event_id within the 24h sliding window dedupes.
+* Cooldown suppression fires per the pinned table.
+* Rate-limit fires after MAX_DISPATCH_PER_CYCLE.
+* events.jsonl is bounded ≤ 500.
+* No subprocess / socket / urllib / requests / httpx / aiohttp / gh /
+  git in the module.
+* No imports of dashboard / frontend / automation / broker /
+  agent.risk / agent.execution / research /
+  reporting.intelligent_routing / live / paper / shadow / trading.
+* Importing the module does not flip Step 5 invariants.
+* Atomic write refuses any path outside logs/notification_dispatcher/.
+* Doc states no real push in N2a, no click-approval, and Level 6
+  permanently disabled.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reporting import development_intake_promotion as dip
+from reporting import development_step5_loop as dsl
+from reporting import execution_authority as ea
+from reporting import notification_dispatcher as nd
+from reporting import notification_event as ne
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_logs(tmp_path: Path) -> tuple[Path, Path, Path, Path]:
+    intake = tmp_path / "logs" / "development_intake_promotion" / "latest.json"
+    step5 = tmp_path / "logs" / "step5_loop" / "latest.json"
+    roadmap = tmp_path / "logs" / "development_roadmap_intake" / "latest.json"
+    history = tmp_path / "logs" / "notification_dispatcher" / "events.jsonl"
+    for p in (intake, step5, roadmap, history):
+        p.parent.mkdir(parents=True, exist_ok=True)
+    return (intake, step5, roadmap, history)
+
+
+def _eligible_promotion_payload(
+    *, candidate_id: str = "qre_v3_15_16_addendum_source_manifest_001"
+) -> dict[str, Any]:
+    return {
+        "schema_version": "1.0",
+        "module_version": dip.MODULE_VERSION,
+        "report_kind": "development_intake_promotion",
+        "generated_at_utc": "2026-05-09T00:00:00Z",
+        "step5_enabled_substage": "none",
+        "step5_implementation_allowed": False,
+        "rows": [
+            {
+                "candidate_id": candidate_id,
+                "title": "Draft diagnostic-source manifest",
+                "source_document": "docs/roadmap/qre_roadmap_v6_ade_operating_manual.md",
+                "source_kind": "operating_manual",
+                "roadmap_phase": "v3.15.16",
+                "candidate_kind": "docs",
+                "required_agent_role": "planner",
+                "risk_level": "LOW",
+                "target_path": "docs/governance/agent_run_summaries/qre_addendum_source_manifest_001.md",
+                "upstream_intake_status": "eligible",
+                "upstream_execution_authority_decision": ea.DECISION_AUTO_ALLOWED,
+                "reclassified_execution_authority_decision": ea.DECISION_AUTO_ALLOWED,
+                "reclassified_execution_authority_reason": "low_risk_docs_non_policy",
+                "classification_drift": False,
+                "human_needed": False,
+                "human_needed_reason": "none",
+                "acceptance_criteria": ["criterion 1", "criterion 2"],
+                "evidence_hash": "abc123",
+                "notification_event_kind": "intake_candidate_eligible",
+                "notification_event_severity": "push_info",
+                "already_in_seed_jsonl": False,
+                "already_in_delegation_seed": False,
+                "duplicate_of_history_entry": False,
+                "decision_state": "eligible",
+                "promotion_target": "none",
+                "notes": "",
+            }
+        ],
+        "counts": {"total": 1, "eligible": 1},
+        "validation_warnings": [],
+        "discipline_invariants": {},
+    }
+
+
+def _step5_loop_payload(
+    *, outcome: str = "plan_emitted", cycle_id: str = "test_cycle_001"
+) -> dict[str, Any]:
+    return {
+        "schema_version": "1.0",
+        "module_version": dsl.MODULE_VERSION,
+        "report_kind": "step5_loop",
+        "generated_at_utc": "2026-05-09T00:00:00Z",
+        "step5_enabled_substage": "none",
+        "step5_implementation_allowed": False,
+        "current_plan": {
+            "cycle_id": cycle_id,
+            "source_kind": "queue",
+            "source_id": "dwq_test123",
+            "outcome": outcome,
+            "halt_reason": "ok" if outcome == "plan_emitted" else "needs_human",
+            "execution_authority_decision": ea.DECISION_AUTO_ALLOWED,
+        },
+    }
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(
+        json.dumps(payload, sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies
+# ---------------------------------------------------------------------------
+
+
+def test_delivery_intents_pinned_exactly() -> None:
+    assert nd.DELIVERY_INTENTS == (
+        "ready",
+        "suppressed",
+        "suppressed_cooldown",
+        "duplicate_within_window",
+        "rate_limited",
+    )
+
+
+def test_source_modules_pinned_exactly() -> None:
+    assert nd.SOURCE_MODULES == (
+        "development_intake_promotion",
+        "development_step5_loop",
+        "development_roadmap_intake",
+    )
+
+
+def test_event_schema_keys_pinned_exactly_and_ordered() -> None:
+    assert nd.EVENT_SCHEMA_KEYS == (
+        "event_id",
+        "event_kind",
+        "event_severity",
+        "delivery_intent",
+        "source_module",
+        "source_artifact_path",
+        "source_id",
+        "title",
+        "summary",
+        "risk_class",
+        "execution_authority_decision",
+        "acceptance_criteria",
+        "target_path",
+        "evidence_hash",
+        "created_at",
+        "notes",
+    )
+
+
+def test_max_dispatch_per_cycle_pinned() -> None:
+    assert nd.MAX_DISPATCH_PER_CYCLE == 16
+
+
+def test_max_events_history_pinned() -> None:
+    assert nd.MAX_EVENTS_HISTORY == 500
+
+
+def test_dedupe_window_seconds_pinned() -> None:
+    assert nd.DEDUPE_WINDOW_SECONDS == 24 * 60 * 60
+
+
+def test_cooldown_table_covers_all_event_kinds() -> None:
+    """Every member of N1 EVENT_KINDS must have a cooldown."""
+    missing = set(ne.EVENT_KINDS) - set(
+        nd.COOLDOWN_SECONDS_PER_EVENT_KIND.keys()
+    )
+    assert missing == set(), f"event_kinds missing cooldown: {missing}"
+
+
+def test_cooldown_critical_kinds_have_zero_cooldown() -> None:
+    for k in (
+        "governance_violation_detected",
+        "secret_or_pii_redaction_event",
+        "audit_chain_anomaly",
+        "step5_cycle_halted",
+        "step5_cycle_needs_human",
+        "release_gate_fail",
+        "release_gate_needs_human",
+        "pr_merge_approval_required",
+        "deploy_approval_required",
+    ):
+        assert nd.COOLDOWN_SECONDS_PER_EVENT_KIND[k] == 0
+
+
+def test_artifact_paths_under_logs_only() -> None:
+    assert nd.ARTIFACT_RELATIVE_PATH.startswith(
+        "logs/notification_dispatcher/"
+    )
+    assert nd.EVENTS_JSONL_RELATIVE_PATH.startswith(
+        "logs/notification_dispatcher/"
+    )
+    assert "research/" not in nd.ARTIFACT_RELATIVE_PATH
+
+
+# ---------------------------------------------------------------------------
+# Atomic write refusal
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_write_refuses_non_dispatcher_logs_path(tmp_path: Path) -> None:
+    bad = tmp_path / "evil_dir" / "latest.json"
+    with pytest.raises(ValueError):
+        nd._atomic_write_json(bad, {"x": 1})
+
+
+def test_atomic_write_refuses_other_logs_subdir(tmp_path: Path) -> None:
+    bad = tmp_path / "logs" / "development_roadmap_intake" / "latest.json"
+    with pytest.raises(ValueError):
+        nd._atomic_write_json(bad, {"x": 1})
+
+
+def test_history_append_refuses_non_dispatcher_path(tmp_path: Path) -> None:
+    bad = tmp_path / "logs" / "elsewhere" / "events.jsonl"
+    with pytest.raises(ValueError):
+        nd._append_events_history(bad, [])
+
+
+# ---------------------------------------------------------------------------
+# Step 5 invariants
+# ---------------------------------------------------------------------------
+
+
+def test_step5_invariants_pinned() -> None:
+    assert nd.step5_implementation_allowed is False
+    assert nd.STEP5_ENABLED_SUBSTAGE == "none"
+
+
+def test_snapshot_carries_step5_invariants(tmp_path: Path) -> None:
+    intake, step5, roadmap, history = _make_logs(tmp_path)
+    snap = nd.collect_snapshot(
+        intake_promotion_path=intake,  # missing file → no rows
+        step5_loop_path=step5,
+        roadmap_intake_path=roadmap,
+        events_history_path=history,
+        generated_at_utc="2026-05-09T00:00:00Z",
+    )
+    assert snap["step5_enabled_substage"] == "none"
+    assert snap["step5_implementation_allowed"] is False
+
+
+def test_discipline_invariants_present(tmp_path: Path) -> None:
+    intake, step5, roadmap, history = _make_logs(tmp_path)
+    snap = nd.collect_snapshot(
+        intake_promotion_path=intake,
+        step5_loop_path=step5,
+        roadmap_intake_path=roadmap,
+        events_history_path=history,
+    )
+    inv = snap["discipline_invariants"]
+    assert inv["sends_real_push"] is False
+    assert inv["opens_mobile_inbox"] is False
+    assert inv["mints_approval_token"] is False
+    assert inv["invokes_network"] is False
+    assert inv["invokes_subprocess"] is False
+    assert inv["mutates_upstream_artifacts"] is False
+    assert inv["reads_subscription_files"] is False
+    assert inv["reads_vapid_keys"] is False
+    assert inv["writes_dashboard_or_frontend"] is False
+    assert inv["secret_redactor_invoked"] is True
+    assert inv["step5_implementation_allowed"] is False
+    assert inv["step5_enabled_substage"] == "none"
+
+
+# ---------------------------------------------------------------------------
+# Snapshot top-level shape
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_top_level_keys(tmp_path: Path) -> None:
+    intake, step5, roadmap, history = _make_logs(tmp_path)
+    snap = nd.collect_snapshot(
+        intake_promotion_path=intake,
+        step5_loop_path=step5,
+        roadmap_intake_path=roadmap,
+        events_history_path=history,
+        generated_at_utc="2026-05-09T00:00:00Z",
+    )
+    expected = {
+        "schema_version",
+        "module_version",
+        "report_kind",
+        "generated_at_utc",
+        "step5_enabled_substage",
+        "step5_implementation_allowed",
+        "sources_read",
+        "events_history_path",
+        "note",
+        "validation_warnings",
+        "vocabularies",
+        "cooldown_seconds_per_event_kind",
+        "counts",
+        "events",
+        "execution_authority_module_version",
+        "notification_event_module_version",
+        "intake_promotion_module_version",
+        "step5_module_version",
+        "roadmap_intake_module_version",
+        "discipline_invariants",
+    }
+    assert set(snap.keys()) == expected
+    assert snap["report_kind"] == "notification_dispatcher"
+
+
+# ---------------------------------------------------------------------------
+# Real-shape happy path: A16a eligible → ready intake_candidate_eligible
+# ---------------------------------------------------------------------------
+
+
+def test_real_a16a_eligible_becomes_ready_event(tmp_path: Path) -> None:
+    intake, step5, roadmap, history = _make_logs(tmp_path)
+    _write_json(intake, _eligible_promotion_payload())
+    snap = nd.collect_snapshot(
+        intake_promotion_path=intake,
+        step5_loop_path=step5,
+        roadmap_intake_path=roadmap,
+        events_history_path=history,
+        generated_at_utc="2026-05-09T00:00:00Z",
+    )
+    eligibles = [e for e in snap["events"] if e["source_module"] == "development_intake_promotion"]
+    assert len(eligibles) == 1
+    ev = eligibles[0]
+    assert set(ev.keys()) == set(nd.EVENT_SCHEMA_KEYS)
+    assert ev["event_kind"] == "intake_candidate_eligible"
+    assert ev["event_severity"] == "push_info"
+    assert ev["delivery_intent"] == "ready"
+    assert ev["source_id"] == "qre_v3_15_16_addendum_source_manifest_001"
+    assert ev["execution_authority_decision"] == ea.DECISION_AUTO_ALLOWED
+    # No diff, no PR body, no command summary in fields.
+    forbidden_in_summary = ("diff --git", "@@", "PATCH", "git commit")
+    for field in ("title", "summary", "notes"):
+        for s in forbidden_in_summary:
+            assert s not in ev[field]
+
+
+def test_step5_plan_emitted_becomes_suppressed_silent_event(
+    tmp_path: Path,
+) -> None:
+    intake, step5, roadmap, history = _make_logs(tmp_path)
+    _write_json(step5, _step5_loop_payload(outcome="plan_emitted"))
+    snap = nd.collect_snapshot(
+        intake_promotion_path=intake,
+        step5_loop_path=step5,
+        roadmap_intake_path=roadmap,
+        events_history_path=history,
+        generated_at_utc="2026-05-09T00:00:00Z",
+    )
+    step5_events = [e for e in snap["events"] if e["source_module"] == "development_step5_loop"]
+    assert len(step5_events) == 1
+    ev = step5_events[0]
+    assert ev["event_kind"] == "step5_cycle_planned"
+    assert ev["event_severity"] == "silent"
+    assert ev["delivery_intent"] == "suppressed"
+
+
+def test_step5_halt_needs_human_becomes_ready_event(tmp_path: Path) -> None:
+    intake, step5, roadmap, history = _make_logs(tmp_path)
+    _write_json(step5, _step5_loop_payload(outcome="halt_needs_human"))
+    snap = nd.collect_snapshot(
+        intake_promotion_path=intake,
+        step5_loop_path=step5,
+        roadmap_intake_path=roadmap,
+        events_history_path=history,
+        generated_at_utc="2026-05-09T00:00:00Z",
+    )
+    step5_events = [e for e in snap["events"] if e["source_module"] == "development_step5_loop"]
+    assert len(step5_events) == 1
+    ev = step5_events[0]
+    assert ev["event_kind"] == "step5_cycle_needs_human"
+    # severity is push_action_required; HIGH risk hint or NEEDS_HUMAN
+    # decision could escalate further, but the routing-table default
+    # for this kind is push_action_required.
+    assert ev["event_severity"] in ("push_action_required", "approval_required", "critical")
+    assert ev["delivery_intent"] == "ready"
+
+
+def test_step5_halt_permanently_denied_becomes_halted_event(
+    tmp_path: Path,
+) -> None:
+    intake, step5, roadmap, history = _make_logs(tmp_path)
+    _write_json(step5, _step5_loop_payload(outcome="halt_permanently_denied"))
+    snap = nd.collect_snapshot(
+        intake_promotion_path=intake,
+        step5_loop_path=step5,
+        roadmap_intake_path=roadmap,
+        events_history_path=history,
+        generated_at_utc="2026-05-09T00:00:00Z",
+    )
+    step5_events = [e for e in snap["events"] if e["source_module"] == "development_step5_loop"]
+    assert len(step5_events) == 1
+    assert step5_events[0]["event_kind"] == "step5_cycle_halted"
+
+
+def test_step5_no_op_emits_no_event(tmp_path: Path) -> None:
+    intake, step5, roadmap, history = _make_logs(tmp_path)
+    _write_json(step5, _step5_loop_payload(outcome="no_op_no_eligible_item"))
+    snap = nd.collect_snapshot(
+        intake_promotion_path=intake,
+        step5_loop_path=step5,
+        roadmap_intake_path=roadmap,
+        events_history_path=history,
+    )
+    step5_events = [e for e in snap["events"] if e["source_module"] == "development_step5_loop"]
+    assert len(step5_events) == 0
+
+
+# ---------------------------------------------------------------------------
+# Delivery-intent gates
+# ---------------------------------------------------------------------------
+
+
+def test_silent_severity_becomes_suppressed(tmp_path: Path) -> None:
+    intake, step5, roadmap, history = _make_logs(tmp_path)
+    _write_json(step5, _step5_loop_payload(outcome="plan_emitted"))
+    snap = nd.collect_snapshot(
+        intake_promotion_path=intake,
+        step5_loop_path=step5,
+        roadmap_intake_path=roadmap,
+        events_history_path=history,
+    )
+    for ev in snap["events"]:
+        if ev["event_severity"] == "silent":
+            assert ev["delivery_intent"] == "suppressed"
+
+
+def test_duplicate_event_id_within_window_deduped(tmp_path: Path) -> None:
+    intake, step5, roadmap, history = _make_logs(tmp_path)
+    _write_json(intake, _eligible_promotion_payload())
+    snap1 = nd.collect_snapshot(
+        intake_promotion_path=intake,
+        step5_loop_path=step5,
+        roadmap_intake_path=roadmap,
+        events_history_path=history,
+        generated_at_utc="2026-05-09T00:00:00Z",
+    )
+    eid = snap1["events"][0]["event_id"]
+    # Pre-seed the history with the same event_id at an earlier time.
+    history.write_text(
+        json.dumps(
+            {
+                "event_id": eid,
+                "event_kind": "intake_candidate_eligible",
+                "event_severity": "push_info",
+                "delivery_intent": "ready",
+                "source_module": "development_intake_promotion",
+                "source_id": "qre_v3_15_16_addendum_source_manifest_001",
+                "created_at": "2026-05-09T00:00:00Z",
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    snap2 = nd.collect_snapshot(
+        intake_promotion_path=intake,
+        step5_loop_path=step5,
+        roadmap_intake_path=roadmap,
+        events_history_path=history,
+        generated_at_utc="2026-05-09T00:01:00Z",
+    )
+    target = [e for e in snap2["events"] if e["event_id"] == eid]
+    assert len(target) == 1
+    assert target[0]["delivery_intent"] == "duplicate_within_window"
+
+
+def test_cooldown_per_event_kind_suppresses_recent_kind(
+    tmp_path: Path,
+) -> None:
+    """A different event_id but same event_kind seen ≤ cooldown ago
+    should be `suppressed_cooldown`."""
+    intake, step5, roadmap, history = _make_logs(tmp_path)
+    _write_json(intake, _eligible_promotion_payload())
+    # Pre-seed history with a different event_id of the same kind, 1 minute ago.
+    history.write_text(
+        json.dumps(
+            {
+                "event_id": "different_id",
+                "event_kind": "intake_candidate_eligible",
+                "event_severity": "push_info",
+                "delivery_intent": "ready",
+                "source_module": "development_intake_promotion",
+                "source_id": "different_source",
+                "created_at": "2026-05-09T00:00:00Z",
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    snap = nd.collect_snapshot(
+        intake_promotion_path=intake,
+        step5_loop_path=step5,
+        roadmap_intake_path=roadmap,
+        events_history_path=history,
+        generated_at_utc="2026-05-09T00:01:00Z",  # 1 minute later, < 600 cooldown
+    )
+    eligibles = [e for e in snap["events"] if e["source_module"] == "development_intake_promotion"]
+    assert len(eligibles) == 1
+    assert eligibles[0]["delivery_intent"] == "suppressed_cooldown"
+
+
+def test_max_dispatch_per_cycle_rate_limits_excess(tmp_path: Path) -> None:
+    intake, step5, roadmap, history = _make_logs(tmp_path)
+    rows = []
+    for i in range(20):
+        rows.append(
+            {
+                "candidate_id": f"cand_{i:03d}",
+                "title": f"Candidate {i}",
+                "source_document": "docs/roadmap/qre_roadmap_v6_ade_operating_manual.md",
+                "source_kind": "operating_manual",
+                "roadmap_phase": "v3.15.16",
+                "candidate_kind": "docs",
+                "required_agent_role": "planner",
+                "risk_level": "LOW",
+                "target_path": f"docs/governance/agent_run_summaries/syn_{i:03d}.md",
+                "upstream_intake_status": "eligible",
+                "upstream_execution_authority_decision": ea.DECISION_AUTO_ALLOWED,
+                "reclassified_execution_authority_decision": ea.DECISION_AUTO_ALLOWED,
+                "reclassified_execution_authority_reason": "low_risk_docs_non_policy",
+                "classification_drift": False,
+                "human_needed": False,
+                "human_needed_reason": "none",
+                "acceptance_criteria": ["a"],
+                "evidence_hash": f"hash_{i}",
+                "notification_event_kind": "intake_candidate_eligible",
+                "notification_event_severity": "push_info",
+                "already_in_seed_jsonl": False,
+                "already_in_delegation_seed": False,
+                "duplicate_of_history_entry": False,
+                "decision_state": "eligible",
+                "promotion_target": "none",
+                "notes": "",
+            }
+        )
+    payload = _eligible_promotion_payload()
+    payload["rows"] = rows
+    _write_json(intake, payload)
+    snap = nd.collect_snapshot(
+        intake_promotion_path=intake,
+        step5_loop_path=step5,
+        roadmap_intake_path=roadmap,
+        events_history_path=history,
+        generated_at_utc="2026-05-09T00:00:00Z",
+    )
+    intents = [e["delivery_intent"] for e in snap["events"]]
+    ready_count = sum(1 for i in intents if i == "ready")
+    rate_limited_count = sum(1 for i in intents if i == "rate_limited")
+    assert ready_count == nd.MAX_DISPATCH_PER_CYCLE
+    assert rate_limited_count == 20 - nd.MAX_DISPATCH_PER_CYCLE
+
+
+# ---------------------------------------------------------------------------
+# events.jsonl bounded
+# ---------------------------------------------------------------------------
+
+
+def test_events_jsonl_bounded_to_max(tmp_path: Path) -> None:
+    intake, step5, roadmap, history = _make_logs(tmp_path)
+    # Pre-populate with 600 rows of placeholder history.
+    lines = []
+    for i in range(600):
+        lines.append(
+            json.dumps(
+                {
+                    "event_id": f"eid_{i:04d}",
+                    "event_kind": "intake_candidate_proposed",
+                    "event_severity": "digest",
+                    "delivery_intent": "suppressed",
+                    "source_module": "development_roadmap_intake",
+                    "source_id": f"src_{i:04d}",
+                    "created_at": "2026-04-30T00:00:00Z",
+                },
+                sort_keys=True,
+            )
+        )
+    history.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    # Now run write_outputs which trims the history.
+    snap = nd.collect_snapshot(
+        intake_promotion_path=intake,
+        step5_loop_path=step5,
+        roadmap_intake_path=roadmap,
+        events_history_path=history,
+        generated_at_utc="2026-05-09T00:00:00Z",
+    )
+    # Build a minimal write target.
+    out_dir = tmp_path / "logs" / "notification_dispatcher"
+    latest = out_dir / "latest.json"
+    nd._atomic_write_json(latest, snap)
+    nd._append_events_history(history, snap.get("events") or [])
+    bounded = [
+        line for line in history.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert len(bounded) <= nd.MAX_EVENTS_HISTORY
+
+
+# ---------------------------------------------------------------------------
+# Determinism + sorting
+# ---------------------------------------------------------------------------
+
+
+def test_determinism_with_injected_timestamp(tmp_path: Path) -> None:
+    intake, step5, roadmap, history = _make_logs(tmp_path)
+    _write_json(intake, _eligible_promotion_payload())
+    _write_json(step5, _step5_loop_payload())
+    snap_a = nd.collect_snapshot(
+        intake_promotion_path=intake,
+        step5_loop_path=step5,
+        roadmap_intake_path=roadmap,
+        events_history_path=history,
+        generated_at_utc="2026-05-09T00:00:00Z",
+    )
+    snap_b = nd.collect_snapshot(
+        intake_promotion_path=intake,
+        step5_loop_path=step5,
+        roadmap_intake_path=roadmap,
+        events_history_path=history,
+        generated_at_utc="2026-05-09T00:00:00Z",
+    )
+    assert (
+        json.dumps(snap_a, sort_keys=True, indent=2).encode("utf-8")
+        == json.dumps(snap_b, sort_keys=True, indent=2).encode("utf-8")
+    )
+
+
+def test_events_sort_stably(tmp_path: Path) -> None:
+    intake, step5, roadmap, history = _make_logs(tmp_path)
+    _write_json(intake, _eligible_promotion_payload())
+    _write_json(step5, _step5_loop_payload())
+    snap = nd.collect_snapshot(
+        intake_promotion_path=intake,
+        step5_loop_path=step5,
+        roadmap_intake_path=roadmap,
+        events_history_path=history,
+        generated_at_utc="2026-05-09T00:00:00Z",
+    )
+    keys = [
+        (e["source_module"], e["event_kind"], e["event_id"])
+        for e in snap["events"]
+    ]
+    assert keys == sorted(keys)
+
+
+# ---------------------------------------------------------------------------
+# No-secret guard / no-noise payload
+# ---------------------------------------------------------------------------
+
+
+def test_event_records_carry_no_diff_or_pr_body(tmp_path: Path) -> None:
+    intake, step5, roadmap, history = _make_logs(tmp_path)
+    payload = _eligible_promotion_payload()
+    # Even if upstream payload contains diff-like junk in title, the
+    # dispatcher must not propagate it as a body field.
+    payload["rows"][0]["title"] = "diff --git fake patch text"
+    _write_json(intake, payload)
+    snap = nd.collect_snapshot(
+        intake_promotion_path=intake,
+        step5_loop_path=step5,
+        roadmap_intake_path=roadmap,
+        events_history_path=history,
+    )
+    ev = snap["events"][0]
+    # title is bounded and may pass through verbatim, but no PR body /
+    # diff block is present in the *summary* / *notes* / scalar fields.
+    for forbidden in ("@@ -", "+++ b/", "--- a/"):
+        for field in ("summary", "notes"):
+            assert forbidden not in ev[field]
+
+
+def test_assert_no_secrets_called_on_snapshot(tmp_path: Path) -> None:
+    """Defense-in-depth: a credential-shaped string anywhere in the
+    snapshot must raise AssertionError via assert_no_secrets."""
+    intake, step5, roadmap, history = _make_logs(tmp_path)
+    payload = _eligible_promotion_payload()
+    # Inject a credential pattern into title.
+    payload["rows"][0]["title"] = "leaked sk-ant-api03-very-bad-secret-here-please-break"
+    _write_json(intake, payload)
+    with pytest.raises(AssertionError):
+        nd.collect_snapshot(
+            intake_promotion_path=intake,
+            step5_loop_path=step5,
+            roadmap_intake_path=roadmap,
+            events_history_path=history,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Source-text scans
+# ---------------------------------------------------------------------------
+
+
+def _module_source() -> str:
+    return Path(nd.__file__).read_text(encoding="utf-8")
+
+
+def _imported_module_names() -> set[str]:
+    import ast
+
+    src = _module_source()
+    tree = ast.parse(src)
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module is not None:
+                names.add(node.module)
+    return names
+
+
+def test_no_subprocess_in_module() -> None:
+    src = _module_source()
+    assert "import subprocess" not in src
+    assert "from subprocess" not in src
+
+
+def test_no_network_in_module() -> None:
+    src = _module_source()
+    for forbidden in (
+        "import socket",
+        "import urllib",
+        "import http.client",
+        "import requests",
+        "import httpx",
+        "import aiohttp",
+    ):
+        assert forbidden not in src
+
+
+def test_no_web_push_library_imports() -> None:
+    src = _module_source()
+    for forbidden in (
+        "pywebpush",
+        "web_push",
+        "webpush",
+        "from pywebpush",
+        "from web_push",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_no_gh_or_git_subprocess_references() -> None:
+    src = _module_source()
+    for forbidden in (
+        "subprocess.run",
+        "subprocess.Popen",
+        "os.system",
+        "os.popen",
+        "shell=True",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_no_dashboard_or_live_path_or_qre_imports() -> None:
+    forbidden_prefixes = (
+        "dashboard",
+        "frontend",
+        "automation",
+        "broker",
+        "agent.risk",
+        "agent.execution",
+        "research",
+        "reporting.intelligent_routing",
+        "live",
+        "paper",
+        "shadow",
+        "trading",
+    )
+    for module in _imported_module_names():
+        for prefix in forbidden_prefixes:
+            assert not (
+                module == prefix or module.startswith(prefix + ".")
+            ), f"forbidden import: {module}"
+
+
+def test_no_subscription_file_reads_or_writes() -> None:
+    """Defense in depth: module must not contain code paths that
+    open a subscription file or VAPID key. Documentation references
+    in docstrings are explicitly allowed (we document what we DO NOT
+    do). This test scans for code-shaped patterns only."""
+    src = _module_source()
+    forbidden_code_patterns = (
+        "subscriptions.json",
+        "web_push_subscriptions",
+        "vapid_public.txt",
+        "vapid_private",
+        "VAPID_PRIVATE",
+        "WEB_PUSH_VAPID",
+        "open_push_subscription",
+        ".send_web_push",
+        "WebPushClient",
+    )
+    for forbidden in forbidden_code_patterns:
+        assert forbidden not in src, forbidden
+
+
+def test_module_imports_cleanly() -> None:
+    importlib.reload(nd)
+    assert callable(nd.collect_snapshot)
+
+
+def test_importing_module_does_not_flip_step5_invariants() -> None:
+    importlib.reload(nd)
+    assert dsl.step5_implementation_allowed is False
+    assert dsl.STEP5_ENABLED_SUBSTAGE == "none"
+
+
+# ---------------------------------------------------------------------------
+# Companion doc invariants
+# ---------------------------------------------------------------------------
+
+
+def _doc_text() -> str:
+    return (
+        REPO_ROOT / "docs" / "governance" / "notification_dispatcher.md"
+    ).read_text(encoding="utf-8")
+
+
+def test_doc_states_no_real_push_in_n2a() -> None:
+    text = _doc_text().lower()
+    assert "no real push" in text or "no real push in n2a" in text
+
+
+def test_doc_states_no_approval_from_click_alone() -> None:
+    text = _doc_text().lower()
+    assert "no approval can happen from a notification click alone" in text or "no approval from notification click alone" in text
+
+
+def test_doc_states_n2b_n3_n4_n5_remain_unimplemented() -> None:
+    text = _doc_text().lower()
+    for marker in ("n2b", "n3", "n4", "n5"):
+        assert marker in text, marker
+    assert "out of scope" in text or "remain unimplemented" in text or "unimplemented" in text
+
+
+def test_doc_pins_step5_invariants_text() -> None:
+    text = _doc_text()
+    assert "step5_implementation_allowed" in text
+    assert "STEP5_ENABLED_SUBSTAGE" in text
+
+
+def test_doc_mentions_level_6_only_with_qualifier() -> None:
+    import re
+
+    text = _doc_text()
+    pattern = re.compile(r"\bLevel\s*6\b")
+    for m in pattern.finditer(text):
+        start = max(0, m.start() - 200)
+        end = m.start() + 600
+        window = text[start:end].lower()
+        assert "permanently disabled" in window

--- a/tests/unit/test_notification_dispatcher_status.py
+++ b/tests/unit/test_notification_dispatcher_status.py
@@ -1,0 +1,369 @@
+"""Unit tests for N2a — Notification Dispatcher status summary."""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reporting import execution_authority as ea
+from reporting import notification_dispatcher as nd
+from reporting import notification_dispatcher_status as nds
+from reporting import notification_event as ne
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_dispatcher_artifact(
+    tmp_path: Path, payload: dict[str, Any]
+) -> Path:
+    p = tmp_path / "logs" / "notification_dispatcher" / "latest.json"
+    p.parent.mkdir(parents=True)
+    p.write_text(
+        json.dumps(payload, sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return p
+
+
+def _synthetic_dispatcher_payload(
+    *,
+    events: list[dict[str, Any]] | None = None,
+    note: str = "events_present",
+) -> dict[str, Any]:
+    events = events or []
+    counts = {
+        "total": len(events),
+        "ready": sum(1 for e in events if e.get("delivery_intent") == "ready"),
+        "suppressed": sum(
+            1 for e in events if e.get("delivery_intent") == "suppressed"
+        ),
+        "suppressed_cooldown": 0,
+        "duplicate_within_window": 0,
+        "rate_limited": 0,
+        "by_event_kind": {k: 0 for k in ne.EVENT_KINDS},
+        "by_event_severity": {s: 0 for s in ne.EVENT_SEVERITIES},
+        "by_delivery_intent": {d: 0 for d in nd.DELIVERY_INTENTS},
+        "by_source_module": {m: 0 for m in nd.SOURCE_MODULES},
+        "by_execution_authority_decision": {
+            ea.DECISION_AUTO_ALLOWED: 0,
+            ea.DECISION_NEEDS_HUMAN: 0,
+            ea.DECISION_PERMANENTLY_DENIED: 0,
+        },
+    }
+    for ev in events:
+        kind = ev.get("event_kind")
+        if isinstance(kind, str) and kind in counts["by_event_kind"]:
+            counts["by_event_kind"][kind] += 1
+        sev = ev.get("event_severity")
+        if isinstance(sev, str) and sev in counts["by_event_severity"]:
+            counts["by_event_severity"][sev] += 1
+        di = ev.get("delivery_intent")
+        if di in counts["by_delivery_intent"]:
+            counts["by_delivery_intent"][di] += 1
+        sm = ev.get("source_module")
+        if isinstance(sm, str) and sm in counts["by_source_module"]:
+            counts["by_source_module"][sm] += 1
+        d = ev.get("execution_authority_decision")
+        if d in counts["by_execution_authority_decision"]:
+            counts["by_execution_authority_decision"][d] += 1
+    return {
+        "schema_version": "1.0",
+        "module_version": nd.MODULE_VERSION,
+        "report_kind": "notification_dispatcher",
+        "generated_at_utc": "2026-05-09T00:00:00Z",
+        "step5_enabled_substage": "none",
+        "step5_implementation_allowed": False,
+        "sources_read": [],
+        "events_history_path": "/tmp/events.jsonl",
+        "note": note,
+        "validation_warnings": [],
+        "vocabularies": {},
+        "cooldown_seconds_per_event_kind": dict(
+            nd.COOLDOWN_SECONDS_PER_EVENT_KIND
+        ),
+        "counts": counts,
+        "events": events,
+        "execution_authority_module_version": ea.MODULE_VERSION,
+        "notification_event_module_version": ne.MODULE_VERSION,
+        "intake_promotion_module_version": "v0",
+        "step5_module_version": "v0",
+        "roadmap_intake_module_version": "v0",
+        "discipline_invariants": {},
+    }
+
+
+def _ev(
+    *,
+    event_id: str = "eid_001",
+    event_kind: str = "intake_candidate_eligible",
+    event_severity: str = "push_info",
+    delivery_intent: str = "ready",
+    source_module: str = "development_intake_promotion",
+    source_id: str = "src_001",
+    execution_authority_decision: str = ea.DECISION_AUTO_ALLOWED,
+    title: str = "Title",
+    summary: str = "Summary",
+    target_path: str = "docs/x.md",
+) -> dict[str, Any]:
+    return {
+        "event_id": event_id,
+        "event_kind": event_kind,
+        "event_severity": event_severity,
+        "delivery_intent": delivery_intent,
+        "source_module": source_module,
+        "source_artifact_path": "logs/x/latest.json",
+        "source_id": source_id,
+        "title": title,
+        "summary": summary,
+        "risk_class": "LOW",
+        "execution_authority_decision": execution_authority_decision,
+        "acceptance_criteria": [],
+        "target_path": target_path,
+        "evidence_hash": "h",
+        "created_at": "2026-05-09T00:00:00Z",
+        "notes": "",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Atomic write refusal
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_write_refuses_non_status_logs_path(tmp_path: Path) -> None:
+    bad = tmp_path / "evil_dir" / "latest.json"
+    with pytest.raises(ValueError):
+        nds._atomic_write_json(bad, {"x": 1})
+
+
+def test_atomic_write_refuses_dispatcher_logs_path(tmp_path: Path) -> None:
+    bad = tmp_path / "logs" / "notification_dispatcher" / "latest.json"
+    with pytest.raises(ValueError):
+        nds._atomic_write_json(bad, {"x": 1})
+
+
+# ---------------------------------------------------------------------------
+# Status when upstream artefact is absent
+# ---------------------------------------------------------------------------
+
+
+def test_status_when_artifact_absent(tmp_path: Path) -> None:
+    missing = tmp_path / "logs" / "notification_dispatcher" / "latest.json"
+    snap = nds.collect_status(
+        dispatcher_artifact_path=missing,
+        generated_at_utc="2026-05-09T00:00:00Z",
+    )
+    assert snap["dispatcher_artifact_available"] is False
+    assert snap["counts"]["total"] == 0
+    assert snap["operator_action_list"] == []
+    assert snap["note"] == "dispatcher_artifact_absent"
+    assert snap["step5_implementation_allowed"] is False
+    assert snap["step5_enabled_substage"] == "none"
+    sp = snap["schema_pinned"]
+    assert sp["delivery_intents"] == list(nd.DELIVERY_INTENTS)
+    assert sp["source_modules"] == list(nd.SOURCE_MODULES)
+
+
+# ---------------------------------------------------------------------------
+# Status with synthetic upstream
+# ---------------------------------------------------------------------------
+
+
+def test_status_counts_mirror_upstream(tmp_path: Path) -> None:
+    events = [
+        _ev(
+            event_id="e_a",
+            event_kind="intake_candidate_eligible",
+            event_severity="push_info",
+            delivery_intent="ready",
+        ),
+        _ev(
+            event_id="e_b",
+            event_kind="step5_cycle_planned",
+            event_severity="silent",
+            delivery_intent="suppressed",
+            source_module="development_step5_loop",
+        ),
+        _ev(
+            event_id="e_c",
+            event_kind="step5_cycle_needs_human",
+            event_severity="push_action_required",
+            delivery_intent="ready",
+            source_module="development_step5_loop",
+        ),
+    ]
+    payload = _synthetic_dispatcher_payload(events=events)
+    artifact = _write_dispatcher_artifact(tmp_path, payload)
+    snap = nds.collect_status(
+        dispatcher_artifact_path=artifact,
+        generated_at_utc="2026-05-09T00:00:00Z",
+    )
+    assert snap["dispatcher_artifact_available"] is True
+    assert snap["counts"]["total"] == 3
+    assert snap["counts"]["ready"] == 2
+    assert snap["counts"]["suppressed"] == 1
+    assert snap["counts"]["by_event_kind"]["intake_candidate_eligible"] == 1
+    assert snap["counts"]["by_event_kind"]["step5_cycle_planned"] == 1
+    assert snap["counts"]["by_event_kind"]["step5_cycle_needs_human"] == 1
+    assert snap["counts"]["by_event_severity"]["push_info"] == 1
+    assert snap["counts"]["by_event_severity"]["silent"] == 1
+    assert snap["counts"]["by_event_severity"]["push_action_required"] == 1
+    assert (
+        snap["counts"]["by_source_module"]["development_intake_promotion"]
+        == 1
+    )
+    assert snap["counts"]["by_source_module"]["development_step5_loop"] == 2
+    # Operator-attention events: only the push_action_required ready one.
+    assert snap["counts"]["operator_attention_ready"] == 1
+    assert len(snap["operator_action_list"]) == 1
+    assert snap["operator_action_list"][0]["event_id"] == "e_c"
+    assert snap["operator_action_list"][0]["event_kind"] == "step5_cycle_needs_human"
+
+
+def test_operator_action_list_only_includes_ready_attention_events(
+    tmp_path: Path,
+) -> None:
+    events = [
+        # Suppressed approval_required must NOT appear.
+        _ev(
+            event_id="e_a",
+            event_kind="pr_merge_approval_required",
+            event_severity="approval_required",
+            delivery_intent="suppressed_cooldown",
+        ),
+        # ready + push_info is below the attention threshold.
+        _ev(
+            event_id="e_b",
+            event_kind="intake_candidate_eligible",
+            event_severity="push_info",
+            delivery_intent="ready",
+        ),
+        # ready + critical → attention.
+        _ev(
+            event_id="e_c",
+            event_kind="governance_violation_detected",
+            event_severity="critical",
+            delivery_intent="ready",
+        ),
+    ]
+    payload = _synthetic_dispatcher_payload(events=events)
+    artifact = _write_dispatcher_artifact(tmp_path, payload)
+    snap = nds.collect_status(
+        dispatcher_artifact_path=artifact,
+        generated_at_utc="2026-05-09T00:00:00Z",
+    )
+    ids = {row["event_id"] for row in snap["operator_action_list"]}
+    assert ids == {"e_c"}
+
+
+def test_status_handles_corrupt_artifact(tmp_path: Path) -> None:
+    bad = tmp_path / "logs" / "notification_dispatcher" / "latest.json"
+    bad.parent.mkdir(parents=True)
+    bad.write_text("not json", encoding="utf-8")
+    snap = nds.collect_status(
+        dispatcher_artifact_path=bad,
+        generated_at_utc="2026-05-09T00:00:00Z",
+    )
+    assert snap["dispatcher_artifact_available"] is False
+    assert snap["note"] == "dispatcher_artifact_absent"
+
+
+def test_status_determinism_with_injected_timestamp(tmp_path: Path) -> None:
+    payload = _synthetic_dispatcher_payload()
+    artifact = _write_dispatcher_artifact(tmp_path, payload)
+    snap_a = nds.collect_status(
+        dispatcher_artifact_path=artifact,
+        generated_at_utc="2026-05-09T00:00:00Z",
+    )
+    snap_b = nds.collect_status(
+        dispatcher_artifact_path=artifact,
+        generated_at_utc="2026-05-09T00:00:00Z",
+    )
+    assert (
+        json.dumps(snap_a, sort_keys=True, indent=2).encode("utf-8")
+        == json.dumps(snap_b, sort_keys=True, indent=2).encode("utf-8")
+    )
+
+
+# ---------------------------------------------------------------------------
+# Source-text scans
+# ---------------------------------------------------------------------------
+
+
+def _module_source() -> str:
+    return Path(nds.__file__).read_text(encoding="utf-8")
+
+
+def _imported_module_names() -> set[str]:
+    import ast
+
+    src = _module_source()
+    tree = ast.parse(src)
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module is not None:
+                names.add(node.module)
+    return names
+
+
+def test_no_subprocess_in_status_module() -> None:
+    src = _module_source()
+    assert "import subprocess" not in src
+    assert "from subprocess" not in src
+
+
+def test_no_network_in_status_module() -> None:
+    src = _module_source()
+    for forbidden in (
+        "import socket",
+        "import urllib",
+        "import http.client",
+        "import requests",
+        "import httpx",
+        "import aiohttp",
+    ):
+        assert forbidden not in src
+
+
+def test_no_web_push_library_imports_status() -> None:
+    src = _module_source()
+    for forbidden in ("pywebpush", "from pywebpush", "from web_push"):
+        assert forbidden not in src
+
+
+def test_no_forbidden_imports_in_status_module() -> None:
+    forbidden_prefixes = (
+        "dashboard",
+        "frontend",
+        "automation",
+        "broker",
+        "agent.risk",
+        "agent.execution",
+        "research",
+        "reporting.intelligent_routing",
+        "live",
+        "paper",
+        "shadow",
+        "trading",
+    )
+    for module in _imported_module_names():
+        for prefix in forbidden_prefixes:
+            assert not (
+                module == prefix or module.startswith(prefix + ".")
+            ), f"forbidden import: {module}"
+
+
+def test_status_module_imports_cleanly() -> None:
+    importlib.reload(nds)
+    assert callable(nds.collect_status)


### PR DESCRIPTION
## Summary

N2a — pure stdlib-only **artifact-only** Notification Dispatcher. Reads existing ADE upstream artefacts (A8 work queue, A14 Step 5.0 plan, A16a intake promotion, Step 5.0.1 roadmap intake) and produces deterministic notification-ready event records under `logs/notification_dispatcher/`. **Sends no real push.** Opens no socket. Imports no Web Push library. Reads no subscription file. Reads no VAPID key.

N2b (real Web Push delivery), N3 (mobile approval inbox), N4 (token gate), N5 (merge/deploy adapter) all remain **unimplemented** and require their own separate go-signals.

## What lands

- `reporting/notification_dispatcher.py` — pure projector. Closed vocabularies (`DELIVERY_INTENTS`, `SOURCE_MODULES`, `EVENT_SCHEMA_KEYS`). Severity via N1 `notification_event.route_for(...)`. Five delivery-intent gates: severity-default suppression, 24h `event_id` dedupe, per-event-kind cooldown, `MAX_DISPATCH_PER_CYCLE=16`, ready fallback. Bounded `events.jsonl` ≤ 500 rows. `assert_no_secrets` on every emit. Atomic write only under `logs/notification_dispatcher/`.
- `reporting/notification_dispatcher_status.py` — status summary by kind/severity/intent/source_module/decision; `operator_action_list` filters ready events at `push_action_required`/`approval_required`/`critical`.
- `docs/governance/notification_dispatcher.md` — full surface doc.
- `tests/unit/test_notification_dispatcher.py` (55 tests) + `tests/unit/test_notification_dispatcher_status.py` (13 tests) — vocabularies, schema, gates, dedupe, cooldown, rate-limit, bounded events.jsonl, AST-level forbidden imports, source-text scans, secret guard, doc invariants.

## Hard guarantees (pinned by tests)

- No `dashboard` / `frontend` / `automation` / `broker` / `agent.risk` / `agent.execution` / `research` / `reporting.intelligent_routing` / `live` / `paper` / `shadow` / `trading` imports.
- No subprocess / socket / urllib / requests / httpx / aiohttp / pywebpush / web_push / `gh` / `git`.
- No subscription-file or VAPID-key code paths.
- `step5_implementation_allowed` remains `False`; `STEP5_ENABLED_SUBSTAGE` remains `\"none\"`; Level 6 stays permanently disabled.

## Live verification on `main`

`python -m reporting.notification_dispatcher --no-write`:

- A16a candidate `qre_v3_15_16_addendum_source_manifest_001` → `event_kind=intake_candidate_eligible`, `event_severity=push_info`, `delivery_intent=ready`.
- Most recent Step 5.0 `plan_emitted` cycle → `event_kind=step5_cycle_planned`, `event_severity=silent`, `delivery_intent=suppressed`.
- Roadmap intake `proposed` candidate → `event_kind=intake_candidate_proposed`, `event_severity=digest`, `delivery_intent=suppressed`.
- Status: `total=3`, `ready=1`, `suppressed=2`, `operator_attention_ready=0`.

## Test plan

- [x] `python scripts/governance_lint.py` — OK.
- [x] `python -m pytest tests/unit/test_notification_dispatcher*.py -q` — **68 passed** (55 + 13).
- [x] `python -m pytest tests/unit/test_notification_event.py -q` — **38 passed** (N1 unaffected).
- [x] `python -m pytest tests/unit/test_development_intake_promotion*.py -q` — **55 passed** (A16a unaffected).
- [x] `python -m pytest tests/unit/test_development_step5_loop.py -q` — **65 passed** (Step 5.0 unaffected).
- [x] `python -m pytest tests/smoke -q` — **18 passed**.
- [x] `python -m reporting.notification_dispatcher --no-write` — clean run, real candidate ready.
- [x] `python -m reporting.notification_dispatcher_status --no-write` — clean status, counts correct.
- [x] CI checks
- [x] Diff scope = exactly the 5 N2a files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)