### PR TITLE
feat(notif): N2b-1 — Notification Dispatch Outbox (stub provider, dry-run)

### DIFF
--- a/docs/governance/notification_dispatch_outbox.md
+++ b/docs/governance/notification_dispatch_outbox.md
@@ -1,0 +1,315 @@
+# Notification Dispatch Outbox — N2b-1 (stub provider, dry-run)
+
+> **Status:** Implemented (read-only-upstream, deterministic,
+> **stub-provider dry-run only**).
+>
+> **Module:** [`reporting/notification_dispatch_outbox.py`](../../reporting/notification_dispatch_outbox.py)
+> **Status reporter:** [`reporting/notification_dispatch_outbox_status.py`](../../reporting/notification_dispatch_outbox_status.py)
+>
+> **Output artefact:** `logs/notification_dispatch_outbox/latest.json`
+> **Bounded outbox history:** `logs/notification_dispatch_outbox/outbox.jsonl` (≤ 500 rows)
+> **Status artefact:** `logs/notification_dispatch_outbox_status/latest.json`
+>
+> **Authority:** development-governance read-only (upstream); local
+> persistence + audit-ledger append on normal runs.
+> N2b-1 sends no real push and grants no agent any new authority.
+> Level 6 stays permanently disabled per ADR-015 §Doctrine 1.
+
+---
+
+## 1. Purpose
+
+N2b-1 is the **delivery side** of the push engine, in dry-run shape.
+It reads N2a's `logs/notification_dispatcher/latest.json`, filters
+to records with `delivery_intent="ready"`, builds a bounded six-key
+push payload per event, runs every payload through the existing
+closed credential-pattern guard
+(`reporting.agent_audit_summary.assert_no_secrets`), and dispatches
+via a **stub provider** that records the *intended* URL / status /
+result but **never opens a network socket**. Each attempted record
+also produces a pair of audit-ledger events (`push_dispatch_attempt`
++ a result event) with `autonomy_level_claimed=0`, but **only on
+normal non-`--no-write` runs**.
+
+**N2b-2** (PWA subscription UI + service worker) and **N2b-3** (real
+Web Push delivery using an env-provided VAPID private key) remain
+unimplemented and require their own separate operator go-signals.
+
+**N3** (mobile approval inbox), **N4** (approval-token gate), and
+**N5** (merge/deploy adapter) remain out of scope.
+
+**No approval can happen from a notification click alone.** Even
+when a real push goes out (later, in N2b-3), the only action it
+triggers is opening the PWA at the inbox row. The operator must read
+evidence and re-authenticate to act. This rule is mirrored from
+[`docs/governance/notification_engine.md`](notification_engine.md)
+and pinned by the doc tests below.
+
+---
+
+## 2. Hard constraints
+
+N2b-1, in this PR and at runtime, must not:
+
+- send a real push (Web Push, APNs, FCM, Telegram, email, SMS, anything);
+- open a network socket;
+- import a Web Push library;
+- read or create a subscription file;
+- read or create any VAPID key;
+- write to `dashboard/**` or `frontend/**`;
+- mint approval tokens (N4 territory);
+- open mobile approval inbox rows (N3 territory);
+- merge or deploy (N5 / future);
+- emit audit events on `--no-write` runs;
+- amend the N1 closed `EVENT_KINDS` vocabulary (uses only existing kinds);
+- enable Step 5.1 or Step 5.2;
+- flip `step5_implementation_allowed`;
+- change `STEP5_ENABLED_SUBSTAGE`;
+- change QRE behaviour;
+- mutate research artifacts;
+- touch live / paper / shadow / risk / broker / execution paths;
+- edit `.claude/**`;
+- store secrets in repo;
+- edit canonical roadmap status fields;
+- mark any roadmap phase complete.
+
+The module ships its own AST-level forbidden-import scan and
+source-text scan to enforce the relevant bullets.
+
+---
+
+## 3. Closed vocabularies
+
+Pinned in [`reporting/notification_dispatch_outbox.py`](../../reporting/notification_dispatch_outbox.py):
+
+### `outbound_delivery_intent` (6 values)
+
+| Value                       | Meaning                                                                  |
+| --------------------------- | ------------------------------------------------------------------------ |
+| `sent`                      | stub provider accepted offline; the real N2b-3 surface would deliver this |
+| `duplicate`                 | `event_id` already in `outbox.jsonl` — not re-attempted                 |
+| `skipped_not_ready`         | upstream `delivery_intent != "ready"` — recorded but never dispatched   |
+| `rate_limited_outbound`     | exceeded `MAX_DISPATCH_PER_CYCLE = 16` `sent` events for this cycle     |
+| `failed_secret_check`       | payload failed the closed-pattern credential guard or the              |
+|                             | decision-verb / diff / PEM substring guard                              |
+| `failed_stub_provider`      | stub provider rejected the payload (e.g. wrong shape)                   |
+
+### `audit_event_names` (5 values)
+
+```
+push_dispatch_attempt
+push_dispatch_success
+push_dispatch_skipped_duplicate
+push_dispatch_skipped_rate_limit
+push_dispatch_failure
+```
+
+### Push payload schema (closed, exact, ordered)
+
+```
+event_id
+event_kind
+event_severity
+title       (≤ 80 chars; mobile rendering constraint)
+summary     (≤ 200 chars)
+open_at     ("/agent-control/inbox?event=<event_id>"; ≤ 300 chars)
+```
+
+Strictly forbidden in the payload (pinned by tests):
+
+- PR diff, file diff, patch hunks (`diff --git`, `+++ b/`, `--- a/`, `@@ -`)
+- PEM private-key blocks (`BEGIN PRIVATE KEY`, etc.)
+- credential-shaped strings (caught by `assert_no_secrets`)
+- decision verbs (`approve`, `reject`, `merge`, `deploy`)
+
+### Outbox record schema (closed, exact, ordered)
+
+```
+event_id
+event_kind
+event_severity
+source_module
+source_id
+outbound_delivery_intent
+payload
+stub_provider_url
+stub_provider_status
+stub_provider_result
+secret_guard_ok
+attempted_at
+audit_event_seq
+```
+
+### Wrapper-level fields
+
+```
+schema_version, module_version, report_kind, generated_at_utc,
+step5_enabled_substage, step5_implementation_allowed,
+dispatcher_artifact_path, dispatcher_artifact_available,
+outbox_history_path, stub_provider_url, note, validation_warnings,
+vocabularies, counts, records,
+notification_dispatcher_module_version,
+notification_event_module_version, discipline_invariants
+```
+
+---
+
+## 4. Stub provider
+
+N2b-1's `stub_provider(payload)` is a synthetic dispatch sink:
+
+- Validates the payload shape against `PUSH_PAYLOAD_KEYS`.
+- Records the *intended* URL as the closed sentinel
+  `stub://web-push-provider-disabled`.
+- Returns a result dict with `url`, `status`, `result`.
+- **Opens no socket. Imports no Web Push library. Reads no
+  subscription file. Reads no VAPID key.** The `subscription`
+  argument is accepted for forward-compat with N2b-3 but ignored.
+
+This is deliberate: the stub gives us end-to-end coverage of the
+gate / dedupe / payload-bound / audit machinery before any real push
+goes out the door. When N2b-3 lands later, the **real** provider
+will live in `dashboard/api_push_dispatch.py` (a single, audited
+file) and the stub stays in this module for tests.
+
+---
+
+## 5. `--no-write` discipline
+
+| Mode               | Writes `latest.json` | Appends to `outbox.jsonl` | Emits audit events |
+| ------------------ | -------------------- | -------------------------- | ------------------ |
+| `--no-write`       | **no**               | **no**                     | **no**             |
+| normal (default)   | yes                  | yes                        | yes (per-record pair) |
+
+Pinned by tests: `test_no_write_mode_writes_no_files_and_no_audit`
+and `test_normal_run_writes_artifacts_and_emits_audit`.
+
+---
+
+## 6. Discipline invariants
+
+```
+sends_real_push                = false
+invokes_network                = false
+invokes_subprocess             = false
+reads_subscription_files       = false
+reads_vapid_keys               = false
+writes_dashboard_or_frontend   = false
+opens_mobile_inbox             = false
+mints_approval_token           = false
+invokes_merge_or_deploy        = false
+uses_real_push_provider        = false
+secret_redactor_invoked        = true
+operator_promotion_required    = true
+step5_implementation_allowed   = false
+step5_enabled_substage         = "none"
+diagnostics_do_not_trade       = true
+```
+
+Every emitted snapshot is additionally routed through
+[`reporting.agent_audit_summary.assert_no_secrets`](../../reporting/agent_audit_summary.py)
+before write. Defense in depth — the module emits no
+secret-shaped strings by construction; the redactor is the safety
+net.
+
+---
+
+## 7. CLI
+
+```sh
+# Pure inspection — does not write artefacts and does not emit audit events:
+python -m reporting.notification_dispatch_outbox --no-write
+python -m reporting.notification_dispatch_outbox_status --no-write
+
+# Writes logs/notification_dispatch_outbox[_status]/latest.json AND
+# appends per-record audit events to today's agent_audit ledger:
+python -m reporting.notification_dispatch_outbox
+python -m reporting.notification_dispatch_outbox_status
+```
+
+Both modules are pure-stdlib + the read-only ADE/reporting deps. No
+subprocess, no network, no `gh`, no `git`.
+
+---
+
+## 8. Authority chain summary
+
+| Capability                                                | Today (post-N2a)                  | After N2b-1                                        | After N2b-2 (future)                                | After N2b-3 (future, gated)                                  |
+| --------------------------------------------------------- | --------------------------------- | -------------------------------------------------- | --------------------------------------------------- | ------------------------------------------------------------ |
+| Compute notification-ready event                          | `notification_dispatcher`         | unchanged                                          | unchanged                                           | unchanged                                                    |
+| Persist outbound *intent* per event                       | none                              | `logs/notification_dispatch_outbox/latest.json` + `outbox.jsonl` | unchanged                              | unchanged                                                    |
+| Open network socket / send a real push                    | does not exist                    | **does not exist** (stub provider only)            | **does not exist**                                  | yes (single, audited callable in `dashboard/api_push_dispatch.py`) |
+| Register / store a Web Push subscription                  | does not exist                    | does not exist                                     | yes (PWA → `POST /api/push/subscribe` → gitignored) | unchanged                                                    |
+| Mint approval tokens                                      | does not exist                    | does not exist                                     | does not exist                                      | does not exist (N4 territory)                                |
+| Open mobile inbox row                                     | does not exist                    | does not exist                                     | does not exist                                      | does not exist (N3 territory)                                |
+| Execute merge / deploy                                    | operator + branch protection      | unchanged                                          | unchanged                                           | unchanged                                                    |
+| Autonomous merge / deploy                                 | **forbidden, Level 6**            | unchanged — Level 6 stays permanently disabled     | unchanged — Level 6 stays permanently disabled      | unchanged — Level 6 stays permanently disabled                 |
+
+N2b-1 grants ADE **zero** new write authority over operator-authored
+surfaces. Real Web Push delivery (N2b-3) and the PWA subscription UI
+(N2b-2) each require their own explicit operator go-signal.
+
+---
+
+## 9. Test coverage
+
+Pinned in
+[`tests/unit/test_notification_dispatch_outbox.py`](../../tests/unit/test_notification_dispatch_outbox.py)
+and
+[`tests/unit/test_notification_dispatch_outbox_status.py`](../../tests/unit/test_notification_dispatch_outbox_status.py):
+
+- closed `OUTBOUND_DELIVERY_INTENTS`, `AUDIT_EVENT_NAMES`,
+  `PUSH_PAYLOAD_KEYS`, `OUTBOX_RECORD_SCHEMA_KEYS` pinned exactly;
+- only `delivery_intent="ready"` records reach the stub provider;
+- non-ready records record as `skipped_not_ready` and never dispatch;
+- the current real N2a `intake_candidate_eligible` event becomes
+  `outbound_delivery_intent="sent"` with a six-key payload;
+- duplicate `event_id` becomes `outbound_delivery_intent="duplicate"`;
+- excess `ready` events become `rate_limited_outbound` once the
+  `MAX_DISPATCH_PER_CYCLE=16` cap is reached;
+- payload contains no decision verbs (`approve`, `reject`, `merge`,
+  `deploy`);
+- payload contains no diff / PR-body / command-output substrings;
+- `assert_no_secrets` is invoked on every payload; a credential-
+  shaped string in upstream forces `failed_secret_check`;
+- `--no-write` writes nothing to either log directory and emits no
+  audit event;
+- a normal run writes both `latest.json` and `outbox.jsonl` and emits
+  audit events with `autonomy_level_claimed=0`;
+- atomic write refuses any path outside
+  `logs/notification_dispatch_outbox/`;
+- `outbox.jsonl` is bounded ≤ 500 rows;
+- AST-level forbidden-import scan: no `dashboard`, `frontend`,
+  `automation`, `broker`, `agent.risk`, `agent.execution`,
+  `research`, `reporting.intelligent_routing`, `live`, `paper`,
+  `shadow`, `trading`;
+- source-text scan: no `subprocess`, `socket`, `urllib`, `requests`,
+  `httpx`, `aiohttp`, `pywebpush`, `web_push`, `webpush`, `gh`, `git`;
+- importing the module does not flip Step 5 invariants on
+  `reporting.development_step5_loop`;
+- deterministic byte-stable output with an injected
+  `generated_at_utc`;
+- this doc explicitly states no real push in N2b-1, no approval from
+  notification click alone, and Level 6 stays permanently disabled.
+
+---
+
+## 10. What N2b-1 does NOT do
+
+- N2b-1 sends no real push.
+- N2b-1 opens no network socket.
+- N2b-1 reads no subscription file.
+- N2b-1 reads no VAPID key.
+- N2b-1 writes no `dashboard/**` or `frontend/**` file.
+- N2b-1 opens no inbox row.
+- N2b-1 mints no token.
+- N2b-1 does not change Step 5.0 logic.
+- N2b-1 does not flip `step5_implementation_allowed`.
+- N2b-1 does not change `STEP5_ENABLED_SUBSTAGE`.
+- Step 5.1 / Step 5.2 remain BLOCKED.
+- N2b-2 (PWA UI + SW), N2b-3 (real Web Push), N3 (mobile approval
+  inbox), N4 (token gate), and N5 (merge/deploy adapter) remain
+  unimplemented.
+- Level 6 stays permanently disabled. Mobile approval is human
+  approval, not autonomous merge or deploy. **No approval can happen
+  from notification click alone.**

--- a/reporting/notification_dispatch_outbox.py
+++ b/reporting/notification_dispatch_outbox.py
@@ -1,0 +1,824 @@
+"""N2b-1 — Notification Dispatch Outbox (stub provider, dry-run).
+
+Pure, deterministic, stdlib-only **dry-run** push outbox. Reads
+``logs/notification_dispatcher/latest.json`` (N2a), filters records
+with ``delivery_intent="ready"``, builds a bounded six-key push
+payload per event, runs every payload through the existing closed
+credential-pattern guard, and dispatches via a **stub provider** that
+records the intended URL / headers / payload but **never opens a
+network socket**.
+
+This is the smallest safe N2b-1 slice. **No real push is sent.**
+N2b-2 (PWA subscription UI + service worker) and N2b-3 (real Web
+Push delivery using env-provided VAPID private key) remain
+unimplemented. N3 (mobile approval inbox), N4 (approval-token gate),
+and N5 (merge/deploy adapter) remain unimplemented. Step 5.1 / 5.2
+remain BLOCKED. Level 6 stays permanently disabled per ADR-015
+§Doctrine 1.
+
+Hard guarantees (pinned by tests)
+---------------------------------
+
+* Stdlib + ``reporting.notification_dispatcher`` (read-only) +
+  ``reporting.notification_event`` (read-only) +
+  ``reporting.execution_authority`` (read-only) +
+  ``reporting.agent_audit`` (write to today's ledger; only on
+  non-``--no-write`` runs) +
+  ``reporting.agent_audit_summary.assert_no_secrets`` (read-only
+  redactor guard).
+* No subprocess, no network, no ``gh``, no ``git``, no ``socket``,
+  no ``urllib``, no ``requests``, no ``httpx``, no ``aiohttp``, no
+  Web Push library (``pywebpush``, ``web_push``, ``webpush``).
+* No imports of ``dashboard``, ``frontend``, ``automation``,
+  ``broker``, ``agent.risk``, ``agent.execution``, ``research``,
+  ``reporting.intelligent_routing``, ``live``, ``paper``, ``shadow``,
+  or ``trading``.
+* No mutation of any upstream artefact (N2a's ``latest.json`` and
+  ``events.jsonl`` are read-only).
+* Atomic write only under
+  ``logs/notification_dispatch_outbox/...``.
+* Closed ``outbound_delivery_intent`` vocabulary; closed payload
+  schema (exactly six bounded scalar keys).
+* Audit events are emitted **only on normal non-``--no-write`` runs**;
+  ``--no-write`` writes nothing and emits no audit event.
+* ``step5_implementation_allowed`` remains ``False`` and
+  ``STEP5_ENABLED_SUBSTAGE`` remains ``"none"``.
+
+CLI
+---
+
+::
+
+    python -m reporting.notification_dispatch_outbox
+    python -m reporting.notification_dispatch_outbox --no-write
+    python -m reporting.notification_dispatch_outbox --indent 0
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Callable, Final
+
+from reporting import agent_audit as _audit
+from reporting import notification_dispatcher as nd
+from reporting import notification_event as ne
+from reporting.agent_audit_summary import assert_no_secrets
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[str] = "1.0"
+MODULE_VERSION: Final[str] = "v3.15.16.N2b1"
+REPORT_KIND: Final[str] = "notification_dispatch_outbox"
+
+# ---------------------------------------------------------------------------
+# Step 5 invariants
+# ---------------------------------------------------------------------------
+
+STEP5_ENABLED_SUBSTAGE: Final[str] = "none"
+step5_implementation_allowed: Final[bool] = False
+
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies
+# ---------------------------------------------------------------------------
+
+#: Closed outbound-delivery-intent vocabulary. Adding a value
+#: requires a code change pinned by an updated unit test.
+OUTBOUND_DELIVERY_INTENTS: Final[tuple[str, ...]] = (
+    "sent",
+    "duplicate",
+    "skipped_not_ready",
+    "rate_limited_outbound",
+    "failed_secret_check",
+    "failed_stub_provider",
+)
+
+#: Closed audit-event-name vocabulary for this module.
+AUDIT_EVENT_NAMES: Final[tuple[str, ...]] = (
+    "push_dispatch_attempt",
+    "push_dispatch_success",
+    "push_dispatch_skipped_duplicate",
+    "push_dispatch_skipped_rate_limit",
+    "push_dispatch_failure",
+)
+
+#: Closed push-payload schema, exact and ordered.
+PUSH_PAYLOAD_KEYS: Final[tuple[str, ...]] = (
+    "event_id",
+    "event_kind",
+    "event_severity",
+    "title",
+    "summary",
+    "open_at",
+)
+
+#: Per-outbox-row schema, exact and ordered.
+OUTBOX_RECORD_SCHEMA_KEYS: Final[tuple[str, ...]] = (
+    "event_id",
+    "event_kind",
+    "event_severity",
+    "source_module",
+    "source_id",
+    "outbound_delivery_intent",
+    "payload",
+    "stub_provider_url",
+    "stub_provider_status",
+    "stub_provider_result",
+    "secret_guard_ok",
+    "attempted_at",
+    "audit_event_seq",
+)
+
+#: Maximum events with ``outbound_delivery_intent="sent"`` per cycle.
+MAX_DISPATCH_PER_CYCLE: Final[int] = 16
+
+#: Maximum events retained in the bounded ``outbox.jsonl``.
+MAX_OUTBOX_HISTORY: Final[int] = 500
+
+#: Bounded length for free-text scalars in the push payload.
+#: Tighter than N2a's because mobile rendering is the constraint.
+MAX_PUSH_TITLE_LEN: Final[int] = 80
+MAX_PUSH_SUMMARY_LEN: Final[int] = 200
+MAX_OPEN_AT_LEN: Final[int] = 300
+
+#: Forbidden substrings inside any payload field (defense-in-depth on
+#: top of the closed schema). Pinned by tests.
+_FORBIDDEN_PAYLOAD_SUBSTRINGS: Final[tuple[str, ...]] = (
+    "diff --git ",
+    "+++ b/",
+    "--- a/",
+    "@@ -",
+    "BEGIN PRIVATE KEY",
+    "BEGIN RSA PRIVATE KEY",
+    "BEGIN EC PRIVATE KEY",
+)
+
+#: Forbidden decision-verb substrings inside the payload. The push
+#: never carries a verb; the operator must open the PWA to act.
+_FORBIDDEN_DECISION_VERBS: Final[tuple[str, ...]] = (
+    "approve",
+    "reject",
+    "merge ",
+    " merge",
+    "deploy",
+)
+
+#: Closed wrapper-level note vocabulary.
+NOTE_NO_DISPATCHER_ARTIFACT: Final[str] = "dispatcher_artifact_absent"
+NOTE_NO_READY_EVENTS: Final[str] = "no_ready_events_to_dispatch"
+NOTE_DISPATCH_PRESENT: Final[str] = "dispatch_records_present"
+
+#: The deep-link path the SW would use on click to open the PWA.
+#: This is the only "action" the push triggers; it never approves.
+_PWA_INBOX_PATH_PREFIX: Final[str] = "/agent-control/inbox?event="
+
+#: Synthetic stub-provider URL — opaque sentinel, never resolved,
+#: never connected to. The real provider in N2b-3 will live in
+#: ``dashboard/api_push_dispatch.py``; this sentinel exists so the
+#: outbox row records "what would have been the dispatch URL" without
+#: ever doing the dispatch.
+_STUB_PROVIDER_URL: Final[str] = "stub://web-push-provider-disabled"
+
+# ---------------------------------------------------------------------------
+# Repo-relative paths
+# ---------------------------------------------------------------------------
+
+ARTIFACT_DIR: Final[Path] = (
+    REPO_ROOT / "logs" / "notification_dispatch_outbox"
+)
+ARTIFACT_LATEST: Final[Path] = ARTIFACT_DIR / "latest.json"
+ARTIFACT_RELATIVE_PATH: Final[str] = (
+    "logs/notification_dispatch_outbox/latest.json"
+)
+OUTBOX_JSONL_PATH: Final[Path] = ARTIFACT_DIR / "outbox.jsonl"
+OUTBOX_JSONL_RELATIVE_PATH: Final[str] = (
+    "logs/notification_dispatch_outbox/outbox.jsonl"
+)
+
+#: Atomic-write allowlist (substring form).
+_WRITE_PREFIX: Final[str] = "logs/notification_dispatch_outbox/"
+
+# ---------------------------------------------------------------------------
+# Discipline invariants
+# ---------------------------------------------------------------------------
+
+_DISCIPLINE_INVARIANTS: Final[dict[str, bool | str]] = {
+    "sends_real_push": False,
+    "invokes_network": False,
+    "invokes_subprocess": False,
+    "reads_subscription_files": False,
+    "reads_vapid_keys": False,
+    "writes_dashboard_or_frontend": False,
+    "opens_mobile_inbox": False,
+    "mints_approval_token": False,
+    "invokes_merge_or_deploy": False,
+    "uses_real_push_provider": False,
+    "secret_redactor_invoked": True,
+    "operator_promotion_required": True,
+    "step5_implementation_allowed": False,
+    "step5_enabled_substage": "none",
+    "diagnostics_do_not_trade": True,
+}
+
+
+# ---------------------------------------------------------------------------
+# Utility helpers
+# ---------------------------------------------------------------------------
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _bounded_str(value: Any, max_len: int) -> str:
+    if not isinstance(value, str):
+        return ""
+    if len(value) <= max_len:
+        return value
+    return value[:max_len]
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+
+def _read_outbox_event_ids(path: Path) -> set[str]:
+    """Read prior event_ids from the bounded outbox JSONL. Best-effort."""
+    seen: set[str] = set()
+    if not path.is_file():
+        return seen
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return seen
+    for raw in text.splitlines():
+        s = raw.strip()
+        if not s:
+            continue
+        try:
+            entry = json.loads(s)
+        except ValueError:
+            continue
+        if not isinstance(entry, dict):
+            continue
+        eid = entry.get("event_id")
+        if isinstance(eid, str) and eid:
+            seen.add(eid)
+    return seen
+
+
+# ---------------------------------------------------------------------------
+# Push-payload builder + closed-schema enforcement
+# ---------------------------------------------------------------------------
+
+
+def _build_push_payload(event: dict[str, Any]) -> dict[str, str]:
+    """Build the closed six-key push payload. All scalars bounded."""
+    event_id = str(event.get("event_id") or "")
+    event_kind = str(event.get("event_kind") or "")
+    event_severity = str(event.get("event_severity") or "")
+    title = _bounded_str(event.get("title"), MAX_PUSH_TITLE_LEN)
+    summary = _bounded_str(event.get("summary"), MAX_PUSH_SUMMARY_LEN)
+    open_at = _bounded_str(
+        f"{_PWA_INBOX_PATH_PREFIX}{event_id}", MAX_OPEN_AT_LEN
+    )
+    return {
+        "event_id": event_id,
+        "event_kind": event_kind,
+        "event_severity": event_severity,
+        "title": title,
+        "summary": summary,
+        "open_at": open_at,
+    }
+
+
+def _payload_passes_no_decision_verb(payload: dict[str, str]) -> bool:
+    """Defense-in-depth: payload must contain no decision verb."""
+    for v in payload.values():
+        if not isinstance(v, str):
+            continue
+        lo = v.lower()
+        for verb in _FORBIDDEN_DECISION_VERBS:
+            if verb in lo:
+                return False
+    return True
+
+
+def _payload_passes_no_diff_or_pem(payload: dict[str, str]) -> bool:
+    for v in payload.values():
+        if not isinstance(v, str):
+            continue
+        for forbidden in _FORBIDDEN_PAYLOAD_SUBSTRINGS:
+            if forbidden in v:
+                return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Stub provider — never opens a socket; never makes a network call
+# ---------------------------------------------------------------------------
+
+
+def stub_provider(
+    payload: dict[str, str], *, subscription: dict[str, Any] | None = None
+) -> dict[str, str]:
+    """Synthetic dispatch provider for N2b-1.
+
+    Behaviour:
+
+    * Validates the payload shape against :data:`PUSH_PAYLOAD_KEYS`.
+    * Records the *intended* URL (the closed sentinel
+      :data:`_STUB_PROVIDER_URL`) and the bounded header set the real
+      N2b-3 provider would use.
+    * Returns a dict with ``url``, ``status``, and ``result``.
+    * **Opens no socket. Imports no Web Push library. Reads no
+      subscription file. Reads no VAPID key.**
+
+    The ``subscription`` argument is accepted for forward-compat with
+    N2b-3 but ignored — the stub never authenticates against a real
+    push provider.
+    """
+    # Closed shape check.
+    if set(payload.keys()) != set(PUSH_PAYLOAD_KEYS):
+        return {
+            "url": _STUB_PROVIDER_URL,
+            "status": "rejected_shape",
+            "result": "invalid_payload_keys",
+        }
+    return {
+        "url": _STUB_PROVIDER_URL,
+        "status": "accepted_offline",
+        "result": "would_send",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Per-event dispatch
+# ---------------------------------------------------------------------------
+
+
+def _dispatch_one(
+    event: dict[str, Any],
+    *,
+    seen_event_ids: set[str],
+    sent_count: int,
+    attempted_at: str,
+) -> dict[str, Any]:
+    """Process one N2a event and produce one outbox record. Pure;
+    never calls the audit ledger (the caller does, on non-``--no-write``
+    runs)."""
+    event_id = str(event.get("event_id") or "")
+    delivery_intent = event.get("delivery_intent")
+
+    base: dict[str, Any] = {
+        "event_id": event_id,
+        "event_kind": str(event.get("event_kind") or ""),
+        "event_severity": str(event.get("event_severity") or ""),
+        "source_module": str(event.get("source_module") or ""),
+        "source_id": str(event.get("source_id") or ""),
+        "outbound_delivery_intent": "skipped_not_ready",
+        "payload": {},
+        "stub_provider_url": "",
+        "stub_provider_status": "",
+        "stub_provider_result": "",
+        "secret_guard_ok": False,
+        "attempted_at": attempted_at,
+        "audit_event_seq": None,
+    }
+
+    if delivery_intent != "ready":
+        return base
+
+    if event_id and event_id in seen_event_ids:
+        base["outbound_delivery_intent"] = "duplicate"
+        return base
+
+    if sent_count >= MAX_DISPATCH_PER_CYCLE:
+        base["outbound_delivery_intent"] = "rate_limited_outbound"
+        return base
+
+    payload = _build_push_payload(event)
+
+    # Defense-in-depth: closed-schema, no diff/PEM, no decision verb.
+    # On any failure, we record `failed_secret_check` and **drop** the
+    # payload from the outbox record. Persisting the dirty payload
+    # would defeat the purpose of the guard and would re-trigger
+    # ``assert_no_secrets`` at snapshot-build time.
+    if not _payload_passes_no_diff_or_pem(payload):
+        base["outbound_delivery_intent"] = "failed_secret_check"
+        base["secret_guard_ok"] = False
+        return base
+    if not _payload_passes_no_decision_verb(payload):
+        base["outbound_delivery_intent"] = "failed_secret_check"
+        base["secret_guard_ok"] = False
+        return base
+
+    # Closed-pattern credential guard. Fails closed; never persists
+    # the dirty payload.
+    try:
+        assert_no_secrets({"payload": payload})
+    except AssertionError:
+        base["outbound_delivery_intent"] = "failed_secret_check"
+        base["secret_guard_ok"] = False
+        return base
+
+    base["secret_guard_ok"] = True
+    base["payload"] = payload
+
+    # Stub-dispatch.
+    try:
+        result = stub_provider(payload)
+    except Exception:
+        base["outbound_delivery_intent"] = "failed_stub_provider"
+        return base
+
+    base["stub_provider_url"] = result.get("url", "")
+    base["stub_provider_status"] = result.get("status", "")
+    base["stub_provider_result"] = result.get("result", "")
+
+    if result.get("status") == "accepted_offline":
+        base["outbound_delivery_intent"] = "sent"
+    else:
+        base["outbound_delivery_intent"] = "failed_stub_provider"
+
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Snapshot assembly
+# ---------------------------------------------------------------------------
+
+
+def _empty_counts() -> dict[str, Any]:
+    return {
+        "total": 0,
+        "sent": 0,
+        "duplicate": 0,
+        "skipped_not_ready": 0,
+        "rate_limited_outbound": 0,
+        "failed_secret_check": 0,
+        "failed_stub_provider": 0,
+        "by_outbound_delivery_intent": {
+            v: 0 for v in OUTBOUND_DELIVERY_INTENTS
+        },
+        "by_event_kind": {k: 0 for k in ne.EVENT_KINDS},
+        "by_event_severity": {s: 0 for s in ne.EVENT_SEVERITIES},
+        "by_source_module": {m: 0 for m in nd.SOURCE_MODULES},
+    }
+
+
+def _aggregate_counts(records: list[dict[str, Any]]) -> dict[str, Any]:
+    counts = _empty_counts()
+    counts["total"] = len(records)
+    for r in records:
+        di = r.get("outbound_delivery_intent")
+        if di in counts:
+            counts[di] += 1
+        if di in counts["by_outbound_delivery_intent"]:
+            counts["by_outbound_delivery_intent"][di] += 1
+        ek = r.get("event_kind")
+        if isinstance(ek, str) and ek in counts["by_event_kind"]:
+            counts["by_event_kind"][ek] += 1
+        es = r.get("event_severity")
+        if isinstance(es, str) and es in counts["by_event_severity"]:
+            counts["by_event_severity"][es] += 1
+        sm = r.get("source_module")
+        if isinstance(sm, str) and sm in counts["by_source_module"]:
+            counts["by_source_module"][sm] += 1
+    return counts
+
+
+def collect_snapshot(
+    *,
+    dispatcher_artifact_path: Path | None = None,
+    outbox_history_path: Path | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    """Build the deterministic outbox snapshot.
+
+    Pure: reads upstream + outbox history; **never** writes,
+    **never** appends to the audit ledger. Audit emission is the
+    caller's responsibility (see :func:`write_outputs`)."""
+    dap = (
+        dispatcher_artifact_path
+        if dispatcher_artifact_path is not None
+        else nd.ARTIFACT_LATEST
+    )
+    ohp = (
+        outbox_history_path
+        if outbox_history_path is not None
+        else OUTBOX_JSONL_PATH
+    )
+    ts = generated_at_utc if generated_at_utc is not None else _utcnow()
+
+    payload = _read_json(dap)
+    seen_ids = _read_outbox_event_ids(ohp)
+
+    records: list[dict[str, Any]] = []
+    if payload is None:
+        events = []
+        note = NOTE_NO_DISPATCHER_ARTIFACT
+    else:
+        events = payload.get("events") if isinstance(payload, dict) else None
+        if not isinstance(events, list):
+            events = []
+        note = NOTE_NO_READY_EVENTS
+
+    sent_count = 0
+    for ev in events:
+        if not isinstance(ev, dict):
+            continue
+        # Only ever consider records whose upstream delivery_intent is
+        # "ready". Non-ready records are recorded as skipped_not_ready
+        # for operator visibility, but only up to MAX_DISPATCH_PER_CYCLE
+        # of them — the rest are dropped silently to keep the artefact
+        # bounded.
+        rec = _dispatch_one(
+            ev,
+            seen_event_ids=seen_ids,
+            sent_count=sent_count,
+            attempted_at=ts,
+        )
+        if rec["outbound_delivery_intent"] == "sent":
+            sent_count += 1
+        records.append(rec)
+
+    if records and any(r["outbound_delivery_intent"] == "sent" for r in records):
+        note = NOTE_DISPATCH_PRESENT
+
+    records.sort(
+        key=lambda r: (r.get("source_module", ""), r.get("event_id", ""))
+    )
+    counts = _aggregate_counts(records)
+
+    snapshot = {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": ts,
+        "step5_enabled_substage": STEP5_ENABLED_SUBSTAGE,
+        "step5_implementation_allowed": step5_implementation_allowed,
+        "dispatcher_artifact_path": str(dap),
+        "dispatcher_artifact_available": payload is not None,
+        "outbox_history_path": str(ohp),
+        "stub_provider_url": _STUB_PROVIDER_URL,
+        "note": note,
+        "validation_warnings": [],
+        "vocabularies": {
+            "outbound_delivery_intents": list(OUTBOUND_DELIVERY_INTENTS),
+            "audit_event_names": list(AUDIT_EVENT_NAMES),
+            "push_payload_keys": list(PUSH_PAYLOAD_KEYS),
+            "outbox_record_schema_keys": list(OUTBOX_RECORD_SCHEMA_KEYS),
+            "max_dispatch_per_cycle": MAX_DISPATCH_PER_CYCLE,
+            "max_outbox_history": MAX_OUTBOX_HISTORY,
+        },
+        "counts": counts,
+        "records": records,
+        "notification_dispatcher_module_version": nd.MODULE_VERSION,
+        "notification_event_module_version": ne.MODULE_VERSION,
+        "discipline_invariants": dict(_DISCIPLINE_INVARIANTS),
+    }
+    assert_no_secrets(snapshot)
+    return snapshot
+
+
+# ---------------------------------------------------------------------------
+# Atomic write + bounded outbox.jsonl append
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    posix = path.as_posix()
+    if _WRITE_PREFIX not in posix and not posix.startswith(_WRITE_PREFIX):
+        raise ValueError(
+            "notification_dispatch_outbox._atomic_write_json refuses "
+            f"non-outbox-logs output path: {path}"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".notification_dispatch_outbox.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def _append_outbox_history(
+    path: Path, records: list[dict[str, Any]]
+) -> None:
+    posix = path.as_posix()
+    if _WRITE_PREFIX not in posix and not posix.startswith(_WRITE_PREFIX):
+        raise ValueError(
+            "notification_dispatch_outbox._append_outbox_history "
+            f"refuses non-outbox-logs path: {path}"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    existing: list[str] = []
+    if path.is_file():
+        try:
+            existing = [
+                line for line in path.read_text(encoding="utf-8").splitlines()
+                if line.strip()
+            ]
+        except OSError:
+            existing = []
+    for rec in records:
+        # Only append rows that we *attempted* (sent / duplicate /
+        # rate_limited / failed_*); skipped_not_ready rows roll the
+        # outbox forward without value and are excluded.
+        di = rec.get("outbound_delivery_intent")
+        if di == "skipped_not_ready":
+            continue
+        compact = {
+            "event_id": rec["event_id"],
+            "event_kind": rec["event_kind"],
+            "outbound_delivery_intent": di,
+            "stub_provider_status": rec.get("stub_provider_status", ""),
+            "attempted_at": rec["attempted_at"],
+        }
+        existing.append(
+            json.dumps(compact, sort_keys=True, ensure_ascii=False)
+        )
+    if len(existing) > MAX_OUTBOX_HISTORY:
+        existing = existing[-MAX_OUTBOX_HISTORY:]
+    text = "\n".join(existing) + ("\n" if existing else "")
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".notification_dispatch_outbox.outbox.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Audit emission (best-effort; never raises)
+# ---------------------------------------------------------------------------
+
+
+def _audit_event_for_record(rec: dict[str, Any]) -> str:
+    di = rec.get("outbound_delivery_intent")
+    if di == "sent":
+        return "push_dispatch_success"
+    if di == "duplicate":
+        return "push_dispatch_skipped_duplicate"
+    if di == "rate_limited_outbound":
+        return "push_dispatch_skipped_rate_limit"
+    if di in ("failed_secret_check", "failed_stub_provider"):
+        return "push_dispatch_failure"
+    # skipped_not_ready and any other value do not generate an audit row.
+    return ""
+
+
+def _emit_audit_for_records(
+    records: list[dict[str, Any]],
+) -> int:
+    """Append one audit event per attempted record. Best-effort:
+    never raises (mirrors A14 audit posture). Returns the count of
+    successfully appended events."""
+    count = 0
+    for rec in records:
+        name = _audit_event_for_record(rec)
+        if not name:
+            continue
+        # Pre-attempt event for visibility — pinned by the closed
+        # AUDIT_EVENT_NAMES set; emit before the result event.
+        try:
+            _audit.append_event(
+                {
+                    "actor": "notification_dispatch_outbox:dry_run",
+                    "event": "push_dispatch_attempt",
+                    "tool": "notification_dispatch_outbox",
+                    "outcome": "ok",
+                    "autonomy_level_claimed": 0,
+                    "push_event_id": rec.get("event_id"),
+                    "push_event_kind": rec.get("event_kind"),
+                    "push_module_version": MODULE_VERSION,
+                }
+            )
+            sealed = _audit.append_event(
+                {
+                    "actor": "notification_dispatch_outbox:dry_run",
+                    "event": name,
+                    "tool": "notification_dispatch_outbox",
+                    "outcome": "ok"
+                    if name == "push_dispatch_success"
+                    else "blocked",
+                    "block_reason": (
+                        rec.get("outbound_delivery_intent")
+                        if name == "push_dispatch_failure"
+                        else None
+                    ),
+                    "autonomy_level_claimed": 0,
+                    "push_event_id": rec.get("event_id"),
+                    "push_event_kind": rec.get("event_kind"),
+                    "push_outbound_delivery_intent": rec.get(
+                        "outbound_delivery_intent"
+                    ),
+                    "push_module_version": MODULE_VERSION,
+                }
+            )
+            if isinstance(sealed, dict) and "sequence_id" in sealed:
+                rec["audit_event_seq"] = sealed["sequence_id"]
+            count += 2
+        except Exception:
+            continue
+    return count
+
+
+def write_outputs(snapshot: dict[str, Any]) -> tuple[Path, Path]:
+    """Persist artefacts and emit per-record audit events.
+
+    **Only call this on non-``--no-write`` runs.** The CLI guards the
+    audit-emission boundary; tests may also call this helper directly.
+    """
+    records = list(snapshot.get("records") or [])
+    _emit_audit_for_records(records)
+    # The audit emission may have stamped audit_event_seq onto each
+    # record; refresh the snapshot's records list before writing.
+    snapshot["records"] = records
+    _atomic_write_json(ARTIFACT_LATEST, snapshot)
+    _append_outbox_history(OUTBOX_JSONL_PATH, records)
+    return (ARTIFACT_LATEST, OUTBOX_JSONL_PATH)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m reporting.notification_dispatch_outbox",
+        description=(
+            "N2b-1 Notification Dispatch Outbox (stub provider, "
+            "dry-run). Read-only deterministic projector that "
+            "converts N2a delivery_intent=ready events into bounded "
+            "six-key push payloads, runs them through "
+            "assert_no_secrets, dispatches via a stub provider that "
+            "OPENS NO SOCKET, and writes outbox records under "
+            "logs/notification_dispatch_outbox/. Sends no real push. "
+            "Audit events emitted only on normal non --no-write runs."
+        ),
+    )
+    p.add_argument(
+        "--indent", type=int, default=2, help="JSON indent (0 for compact)."
+    )
+    p.add_argument(
+        "--no-write",
+        action="store_true",
+        help=(
+            "Do not persist artefacts; do not emit audit events. "
+            "Print the snapshot JSON to stdout only."
+        ),
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    indent = args.indent if args.indent and args.indent > 0 else None
+    snap = collect_snapshot()
+    if not args.no_write:
+        write_outputs(snap)
+    json.dump(snap, sys.stdout, indent=indent, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/reporting/notification_dispatch_outbox_status.py
+++ b/reporting/notification_dispatch_outbox_status.py
@@ -1,0 +1,285 @@
+"""N2b-1 — Notification Dispatch Outbox status summary.
+
+Read-only projection that consumes
+``logs/notification_dispatch_outbox/latest.json`` and emits a compact
+operator-facing status summary, counting records by
+``outbound_delivery_intent``, ``event_kind``, ``event_severity``, and
+``source_module``. Surfaces an ``operator_attention_count`` of failure
+records (``failed_secret_check`` + ``failed_stub_provider``).
+
+Hard guarantees (pinned by tests):
+
+* Stdlib + ``reporting.notification_dispatch_outbox`` (read-only) +
+  ``reporting.notification_event`` (read-only) +
+  ``reporting.notification_dispatcher`` (read-only) +
+  ``reporting.agent_audit_summary.assert_no_secrets`` (read-only
+  redactor guard).
+* No subprocess, no network, no ``gh``, no ``git``, no ``socket``,
+  no ``urllib``, no ``requests``, no ``httpx``, no ``aiohttp``, no
+  Web Push library.
+* No imports of ``dashboard``, ``frontend``, ``automation``,
+  ``broker``, ``agent.risk``, ``agent.execution``, ``research``,
+  ``reporting.intelligent_routing``, ``live``, ``paper``, ``shadow``,
+  or ``trading``.
+* Pure read on the upstream artefact; never mutates ``latest.json``.
+* Atomic write only under
+  ``logs/notification_dispatch_outbox_status/``.
+
+CLI::
+
+    python -m reporting.notification_dispatch_outbox_status
+    python -m reporting.notification_dispatch_outbox_status --indent 2
+    python -m reporting.notification_dispatch_outbox_status --no-write
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Final
+
+from reporting import notification_dispatch_outbox as ndo
+from reporting import notification_dispatcher as nd
+from reporting import notification_event as ne
+from reporting.agent_audit_summary import assert_no_secrets
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[str] = "1.0"
+MODULE_VERSION: Final[str] = "v3.15.16.N2b1"
+REPORT_KIND: Final[str] = "notification_dispatch_outbox_status"
+
+ARTIFACT_DIR: Final[Path] = (
+    REPO_ROOT / "logs" / "notification_dispatch_outbox_status"
+)
+ARTIFACT_LATEST: Final[Path] = ARTIFACT_DIR / "latest.json"
+ARTIFACT_RELATIVE_PATH: Final[str] = (
+    "logs/notification_dispatch_outbox_status/latest.json"
+)
+
+_WRITE_PREFIX: Final[str] = "logs/notification_dispatch_outbox_status/"
+
+#: Failure intents that warrant operator attention.
+_FAILURE_INTENTS: Final[frozenset[str]] = frozenset(
+    {"failed_secret_check", "failed_stub_provider"}
+)
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+
+def _schema_pinned() -> dict[str, Any]:
+    return {
+        "outbound_delivery_intents": list(ndo.OUTBOUND_DELIVERY_INTENTS),
+        "audit_event_names": list(ndo.AUDIT_EVENT_NAMES),
+        "push_payload_keys": list(ndo.PUSH_PAYLOAD_KEYS),
+        "outbox_record_schema_keys": list(ndo.OUTBOX_RECORD_SCHEMA_KEYS),
+        "notification_event_kinds": list(ne.EVENT_KINDS),
+        "notification_event_severities": list(ne.EVENT_SEVERITIES),
+        "source_modules": list(nd.SOURCE_MODULES),
+    }
+
+
+def _empty_counts() -> dict[str, Any]:
+    return {
+        "total": 0,
+        "sent": 0,
+        "duplicate": 0,
+        "skipped_not_ready": 0,
+        "rate_limited_outbound": 0,
+        "failed_secret_check": 0,
+        "failed_stub_provider": 0,
+        "by_outbound_delivery_intent": {
+            v: 0 for v in ndo.OUTBOUND_DELIVERY_INTENTS
+        },
+        "by_event_kind": {k: 0 for k in ne.EVENT_KINDS},
+        "by_event_severity": {s: 0 for s in ne.EVENT_SEVERITIES},
+        "by_source_module": {m: 0 for m in nd.SOURCE_MODULES},
+    }
+
+
+def collect_status(
+    *,
+    outbox_artifact_path: Path | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    op = (
+        outbox_artifact_path
+        if outbox_artifact_path is not None
+        else ndo.ARTIFACT_LATEST
+    )
+    ts = generated_at_utc if generated_at_utc is not None else _utcnow()
+    payload = _read_json(op)
+    if payload is None:
+        snap = {
+            "schema_version": SCHEMA_VERSION,
+            "module_version": MODULE_VERSION,
+            "report_kind": REPORT_KIND,
+            "generated_at_utc": ts,
+            "outbox_artifact_path": str(op),
+            "outbox_artifact_available": False,
+            "outbox_module_version": ndo.MODULE_VERSION,
+            "step5_enabled_substage": ndo.STEP5_ENABLED_SUBSTAGE,
+            "step5_implementation_allowed": ndo.step5_implementation_allowed,
+            "schema_pinned": _schema_pinned(),
+            "counts": _empty_counts(),
+            "operator_attention_count": 0,
+            "validation_warnings": [],
+            "note": "outbox_artifact_absent",
+        }
+        assert_no_secrets(snap)
+        return snap
+
+    upstream_counts = payload.get("counts") or {}
+    if not isinstance(upstream_counts, dict):
+        upstream_counts = {}
+
+    records = (
+        payload.get("records") if isinstance(payload.get("records"), list) else []
+    )
+    records = [r for r in records if isinstance(r, dict)]
+
+    counts = _empty_counts()
+    counts["total"] = int(upstream_counts.get("total") or len(records))
+    for v in ndo.OUTBOUND_DELIVERY_INTENTS:
+        counts[v] = int(upstream_counts.get(v) or 0)
+
+    by_di = upstream_counts.get("by_outbound_delivery_intent") or {}
+    if isinstance(by_di, dict):
+        for v in ndo.OUTBOUND_DELIVERY_INTENTS:
+            counts["by_outbound_delivery_intent"][v] = int(by_di.get(v) or 0)
+
+    by_kind = upstream_counts.get("by_event_kind") or {}
+    if isinstance(by_kind, dict):
+        for k in ne.EVENT_KINDS:
+            counts["by_event_kind"][k] = int(by_kind.get(k) or 0)
+
+    by_sev = upstream_counts.get("by_event_severity") or {}
+    if isinstance(by_sev, dict):
+        for s in ne.EVENT_SEVERITIES:
+            counts["by_event_severity"][s] = int(by_sev.get(s) or 0)
+
+    by_sm = upstream_counts.get("by_source_module") or {}
+    if isinstance(by_sm, dict):
+        for m in nd.SOURCE_MODULES:
+            counts["by_source_module"][m] = int(by_sm.get(m) or 0)
+
+    operator_attention_count = sum(
+        1 for r in records
+        if r.get("outbound_delivery_intent") in _FAILURE_INTENTS
+    )
+
+    snap = {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": ts,
+        "outbox_artifact_path": str(op),
+        "outbox_artifact_available": True,
+        "outbox_module_version": payload.get("module_version"),
+        "outbox_schema_version": payload.get("schema_version"),
+        "outbox_generated_at_utc": payload.get("generated_at_utc"),
+        "outbox_note": payload.get("note"),
+        "step5_enabled_substage": payload.get("step5_enabled_substage")
+        or ndo.STEP5_ENABLED_SUBSTAGE,
+        "step5_implementation_allowed": bool(
+            payload.get("step5_implementation_allowed")
+        ),
+        "schema_pinned": _schema_pinned(),
+        "counts": counts,
+        "operator_attention_count": operator_attention_count,
+        "validation_warnings": list(payload.get("validation_warnings") or []),
+        "note": "outbox_artifact_present",
+    }
+    assert_no_secrets(snap)
+    return snap
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    posix = path.as_posix()
+    if _WRITE_PREFIX not in posix and not posix.startswith(_WRITE_PREFIX):
+        raise ValueError(
+            "notification_dispatch_outbox_status._atomic_write_json "
+            f"refuses non-status-logs output path: {path}"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".notification_dispatch_outbox_status.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_outputs(snapshot: dict[str, Any]) -> Path:
+    _atomic_write_json(ARTIFACT_LATEST, snapshot)
+    return ARTIFACT_LATEST
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m reporting.notification_dispatch_outbox_status",
+        description=(
+            "Read-only summary of "
+            "logs/notification_dispatch_outbox/latest.json. Decides "
+            "nothing; mutates nothing."
+        ),
+    )
+    p.add_argument(
+        "--indent", type=int, default=2, help="JSON indent (0 for compact)."
+    )
+    p.add_argument(
+        "--no-write",
+        action="store_true",
+        help=(
+            "Do not persist "
+            "logs/notification_dispatch_outbox_status/latest.json "
+            "(stdout only)."
+        ),
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    indent = args.indent if args.indent and args.indent > 0 else None
+    snap = collect_status()
+    if not args.no_write:
+        write_outputs(snap)
+    json.dump(snap, sys.stdout, indent=indent, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/unit/test_notification_dispatch_outbox.py
+++ b/tests/unit/test_notification_dispatch_outbox.py
@@ -1,0 +1,801 @@
+"""Unit tests for N2b-1 — Notification Dispatch Outbox (stub provider).
+
+The module is a dry-run dispatch outbox. Real push is BLOCKED at the
+code level by closed-vocabulary tests and source-text scans. Audit
+emission is gated to non-`--no-write` runs.
+
+Synthetic deterministic fixtures only.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reporting import agent_audit as _audit
+from reporting import notification_dispatch_outbox as ndo
+from reporting import notification_dispatcher as nd
+from reporting import notification_event as ne
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_logs(tmp_path: Path) -> tuple[Path, Path]:
+    dispatcher = (
+        tmp_path / "logs" / "notification_dispatcher" / "latest.json"
+    )
+    outbox = (
+        tmp_path / "logs" / "notification_dispatch_outbox" / "outbox.jsonl"
+    )
+    for p in (dispatcher, outbox):
+        p.parent.mkdir(parents=True, exist_ok=True)
+    return dispatcher, outbox
+
+
+def _ev(
+    *,
+    event_id: str = "eid_001",
+    event_kind: str = "intake_candidate_eligible",
+    event_severity: str = "push_info",
+    delivery_intent: str = "ready",
+    source_module: str = "development_intake_promotion",
+    source_id: str = "src_001",
+    title: str = "Synthetic eligible candidate title",
+    summary: str = "decision_state=eligible; risk=LOW; target=docs/x.md",
+    target_path: str = "docs/x.md",
+    risk_class: str = "LOW",
+    execution_authority_decision: str = "AUTO_ALLOWED",
+) -> dict[str, Any]:
+    return {
+        "event_id": event_id,
+        "event_kind": event_kind,
+        "event_severity": event_severity,
+        "delivery_intent": delivery_intent,
+        "source_module": source_module,
+        "source_artifact_path": "logs/x/latest.json",
+        "source_id": source_id,
+        "title": title,
+        "summary": summary,
+        "risk_class": risk_class,
+        "execution_authority_decision": execution_authority_decision,
+        "acceptance_criteria": [],
+        "target_path": target_path,
+        "evidence_hash": "h",
+        "created_at": "2026-05-09T00:00:00Z",
+        "notes": "",
+    }
+
+
+def _dispatcher_payload(
+    *, events: list[dict[str, Any]] | None = None
+) -> dict[str, Any]:
+    events = events or []
+    return {
+        "schema_version": "1.0",
+        "module_version": nd.MODULE_VERSION,
+        "report_kind": "notification_dispatcher",
+        "generated_at_utc": "2026-05-09T00:00:00Z",
+        "step5_enabled_substage": "none",
+        "step5_implementation_allowed": False,
+        "events": events,
+    }
+
+
+def _write_dispatcher(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(
+        json.dumps(payload, sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies
+# ---------------------------------------------------------------------------
+
+
+def test_outbound_delivery_intents_pinned_exactly() -> None:
+    assert ndo.OUTBOUND_DELIVERY_INTENTS == (
+        "sent",
+        "duplicate",
+        "skipped_not_ready",
+        "rate_limited_outbound",
+        "failed_secret_check",
+        "failed_stub_provider",
+    )
+
+
+def test_audit_event_names_pinned_exactly() -> None:
+    assert ndo.AUDIT_EVENT_NAMES == (
+        "push_dispatch_attempt",
+        "push_dispatch_success",
+        "push_dispatch_skipped_duplicate",
+        "push_dispatch_skipped_rate_limit",
+        "push_dispatch_failure",
+    )
+
+
+def test_push_payload_keys_pinned_exactly_and_ordered() -> None:
+    assert ndo.PUSH_PAYLOAD_KEYS == (
+        "event_id",
+        "event_kind",
+        "event_severity",
+        "title",
+        "summary",
+        "open_at",
+    )
+
+
+def test_outbox_record_schema_keys_pinned_exactly_and_ordered() -> None:
+    assert ndo.OUTBOX_RECORD_SCHEMA_KEYS == (
+        "event_id",
+        "event_kind",
+        "event_severity",
+        "source_module",
+        "source_id",
+        "outbound_delivery_intent",
+        "payload",
+        "stub_provider_url",
+        "stub_provider_status",
+        "stub_provider_result",
+        "secret_guard_ok",
+        "attempted_at",
+        "audit_event_seq",
+    )
+
+
+def test_max_dispatch_per_cycle_pinned() -> None:
+    assert ndo.MAX_DISPATCH_PER_CYCLE == 16
+
+
+def test_max_outbox_history_pinned() -> None:
+    assert ndo.MAX_OUTBOX_HISTORY == 500
+
+
+def test_artifact_paths_under_logs_only() -> None:
+    assert ndo.ARTIFACT_RELATIVE_PATH.startswith(
+        "logs/notification_dispatch_outbox/"
+    )
+    assert ndo.OUTBOX_JSONL_RELATIVE_PATH.startswith(
+        "logs/notification_dispatch_outbox/"
+    )
+    assert "research/" not in ndo.ARTIFACT_RELATIVE_PATH
+
+
+# ---------------------------------------------------------------------------
+# Atomic-write refusal
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_write_refuses_non_outbox_logs_path(tmp_path: Path) -> None:
+    bad = tmp_path / "evil_dir" / "latest.json"
+    with pytest.raises(ValueError):
+        ndo._atomic_write_json(bad, {"x": 1})
+
+
+def test_atomic_write_refuses_other_logs_subdir(tmp_path: Path) -> None:
+    bad = tmp_path / "logs" / "notification_dispatcher" / "latest.json"
+    with pytest.raises(ValueError):
+        ndo._atomic_write_json(bad, {"x": 1})
+
+
+def test_outbox_append_refuses_non_outbox_path(tmp_path: Path) -> None:
+    bad = tmp_path / "logs" / "elsewhere" / "outbox.jsonl"
+    with pytest.raises(ValueError):
+        ndo._append_outbox_history(bad, [])
+
+
+# ---------------------------------------------------------------------------
+# Step 5 invariants
+# ---------------------------------------------------------------------------
+
+
+def test_step5_invariants_pinned() -> None:
+    assert ndo.step5_implementation_allowed is False
+    assert ndo.STEP5_ENABLED_SUBSTAGE == "none"
+
+
+def test_snapshot_carries_step5_invariants(tmp_path: Path) -> None:
+    dispatcher, outbox = _make_logs(tmp_path)
+    snap = ndo.collect_snapshot(
+        dispatcher_artifact_path=dispatcher,
+        outbox_history_path=outbox,
+        generated_at_utc="2026-05-09T00:00:00Z",
+    )
+    assert snap["step5_enabled_substage"] == "none"
+    assert snap["step5_implementation_allowed"] is False
+
+
+def test_discipline_invariants_present(tmp_path: Path) -> None:
+    dispatcher, outbox = _make_logs(tmp_path)
+    snap = ndo.collect_snapshot(
+        dispatcher_artifact_path=dispatcher,
+        outbox_history_path=outbox,
+    )
+    inv = snap["discipline_invariants"]
+    assert inv["sends_real_push"] is False
+    assert inv["invokes_network"] is False
+    assert inv["invokes_subprocess"] is False
+    assert inv["reads_subscription_files"] is False
+    assert inv["reads_vapid_keys"] is False
+    assert inv["writes_dashboard_or_frontend"] is False
+    assert inv["opens_mobile_inbox"] is False
+    assert inv["mints_approval_token"] is False
+    assert inv["invokes_merge_or_deploy"] is False
+    assert inv["uses_real_push_provider"] is False
+    assert inv["secret_redactor_invoked"] is True
+    assert inv["step5_implementation_allowed"] is False
+    assert inv["step5_enabled_substage"] == "none"
+
+
+# ---------------------------------------------------------------------------
+# Snapshot top-level shape
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_top_level_keys(tmp_path: Path) -> None:
+    dispatcher, outbox = _make_logs(tmp_path)
+    snap = ndo.collect_snapshot(
+        dispatcher_artifact_path=dispatcher,
+        outbox_history_path=outbox,
+        generated_at_utc="2026-05-09T00:00:00Z",
+    )
+    expected = {
+        "schema_version",
+        "module_version",
+        "report_kind",
+        "generated_at_utc",
+        "step5_enabled_substage",
+        "step5_implementation_allowed",
+        "dispatcher_artifact_path",
+        "dispatcher_artifact_available",
+        "outbox_history_path",
+        "stub_provider_url",
+        "note",
+        "validation_warnings",
+        "vocabularies",
+        "counts",
+        "records",
+        "notification_dispatcher_module_version",
+        "notification_event_module_version",
+        "discipline_invariants",
+    }
+    assert set(snap.keys()) == expected
+    assert snap["report_kind"] == "notification_dispatch_outbox"
+
+
+# ---------------------------------------------------------------------------
+# Ready vs not-ready filtering
+# ---------------------------------------------------------------------------
+
+
+def test_only_ready_records_reach_stub_provider(tmp_path: Path) -> None:
+    dispatcher, outbox = _make_logs(tmp_path)
+    _write_dispatcher(
+        dispatcher,
+        _dispatcher_payload(events=[
+            _ev(event_id="r_01", delivery_intent="ready"),
+            _ev(event_id="s_01", delivery_intent="suppressed"),
+            _ev(event_id="d_01", delivery_intent="duplicate_within_window"),
+            _ev(event_id="c_01", delivery_intent="suppressed_cooldown"),
+            _ev(event_id="x_01", delivery_intent="rate_limited"),
+        ]),
+    )
+    snap = ndo.collect_snapshot(
+        dispatcher_artifact_path=dispatcher,
+        outbox_history_path=outbox,
+        generated_at_utc="2026-05-09T00:00:00Z",
+    )
+    by_id = {r["event_id"]: r for r in snap["records"]}
+    assert by_id["r_01"]["outbound_delivery_intent"] == "sent"
+    assert by_id["s_01"]["outbound_delivery_intent"] == "skipped_not_ready"
+    assert by_id["d_01"]["outbound_delivery_intent"] == "skipped_not_ready"
+    assert by_id["c_01"]["outbound_delivery_intent"] == "skipped_not_ready"
+    assert by_id["x_01"]["outbound_delivery_intent"] == "skipped_not_ready"
+
+
+def test_real_a16a_eligible_event_becomes_sent_via_stub(tmp_path: Path) -> None:
+    dispatcher, outbox = _make_logs(tmp_path)
+    real = _ev(
+        event_id="abc12345abc12345abc12345abc12345",
+        event_kind="intake_candidate_eligible",
+        event_severity="push_info",
+        delivery_intent="ready",
+        source_module="development_intake_promotion",
+        source_id="qre_v3_15_16_addendum_source_manifest_001",
+        title="Draft diagnostic-source manifest",
+    )
+    _write_dispatcher(dispatcher, _dispatcher_payload(events=[real]))
+    snap = ndo.collect_snapshot(
+        dispatcher_artifact_path=dispatcher,
+        outbox_history_path=outbox,
+        generated_at_utc="2026-05-09T00:00:00Z",
+    )
+    assert len(snap["records"]) == 1
+    rec = snap["records"][0]
+    assert set(rec.keys()) == set(ndo.OUTBOX_RECORD_SCHEMA_KEYS)
+    assert rec["outbound_delivery_intent"] == "sent"
+    assert rec["stub_provider_status"] == "accepted_offline"
+    assert rec["stub_provider_url"] == "stub://web-push-provider-disabled"
+    assert rec["stub_provider_result"] == "would_send"
+    assert rec["secret_guard_ok"] is True
+    assert set(rec["payload"].keys()) == set(ndo.PUSH_PAYLOAD_KEYS)
+    assert rec["payload"]["event_id"] == real["event_id"]
+    assert rec["payload"]["event_kind"] == "intake_candidate_eligible"
+    assert rec["payload"]["event_severity"] == "push_info"
+    assert rec["payload"]["open_at"].startswith("/agent-control/inbox?event=")
+    assert rec["payload"]["open_at"].endswith(real["event_id"])
+
+
+# ---------------------------------------------------------------------------
+# Dedupe / rate-limit / failure modes
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_event_id_becomes_duplicate(tmp_path: Path) -> None:
+    dispatcher, outbox = _make_logs(tmp_path)
+    _write_dispatcher(
+        dispatcher,
+        _dispatcher_payload(events=[_ev(event_id="dup_001")]),
+    )
+    # Pre-seed outbox with the same event_id.
+    outbox.write_text(
+        json.dumps(
+            {
+                "event_id": "dup_001",
+                "event_kind": "intake_candidate_eligible",
+                "outbound_delivery_intent": "sent",
+                "stub_provider_status": "accepted_offline",
+                "attempted_at": "2026-05-09T00:00:00Z",
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    snap = ndo.collect_snapshot(
+        dispatcher_artifact_path=dispatcher,
+        outbox_history_path=outbox,
+        generated_at_utc="2026-05-09T00:01:00Z",
+    )
+    assert snap["records"][0]["outbound_delivery_intent"] == "duplicate"
+
+
+def test_rate_limit_excess_becomes_rate_limited_outbound(tmp_path: Path) -> None:
+    dispatcher, outbox = _make_logs(tmp_path)
+    events = [_ev(event_id=f"rl_{i:03d}") for i in range(20)]
+    _write_dispatcher(dispatcher, _dispatcher_payload(events=events))
+    snap = ndo.collect_snapshot(
+        dispatcher_artifact_path=dispatcher,
+        outbox_history_path=outbox,
+        generated_at_utc="2026-05-09T00:00:00Z",
+    )
+    intents = [r["outbound_delivery_intent"] for r in snap["records"]]
+    assert intents.count("sent") == ndo.MAX_DISPATCH_PER_CYCLE
+    assert intents.count("rate_limited_outbound") == 20 - ndo.MAX_DISPATCH_PER_CYCLE
+
+
+def test_outbox_jsonl_bounded_to_max(tmp_path: Path) -> None:
+    """outbox.jsonl is trimmed to <= MAX_OUTBOX_HISTORY rows on append."""
+    dispatcher, outbox = _make_logs(tmp_path)
+    _write_dispatcher(
+        dispatcher,
+        _dispatcher_payload(events=[_ev(event_id="bound_001")]),
+    )
+    # Pre-fill with 600 rows.
+    lines = [
+        json.dumps(
+            {
+                "event_id": f"existing_{i:04d}",
+                "event_kind": "intake_candidate_eligible",
+                "outbound_delivery_intent": "sent",
+                "stub_provider_status": "accepted_offline",
+                "attempted_at": "2026-04-30T00:00:00Z",
+            },
+            sort_keys=True,
+        )
+        for i in range(600)
+    ]
+    outbox.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    snap = ndo.collect_snapshot(
+        dispatcher_artifact_path=dispatcher,
+        outbox_history_path=outbox,
+        generated_at_utc="2026-05-09T00:00:00Z",
+    )
+    ndo._append_outbox_history(outbox, snap.get("records") or [])
+    bounded = [
+        line for line in outbox.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert len(bounded) <= ndo.MAX_OUTBOX_HISTORY
+
+
+# ---------------------------------------------------------------------------
+# Payload guarantees
+# ---------------------------------------------------------------------------
+
+
+def test_payload_contains_no_decision_verb(tmp_path: Path) -> None:
+    """Even if upstream title contains a decision verb, the outbox
+    must mark the record failed_secret_check."""
+    dispatcher, outbox = _make_logs(tmp_path)
+    _write_dispatcher(
+        dispatcher,
+        _dispatcher_payload(events=[
+            _ev(event_id="dv_001", title="Please approve this PR now"),
+        ]),
+    )
+    snap = ndo.collect_snapshot(
+        dispatcher_artifact_path=dispatcher,
+        outbox_history_path=outbox,
+        generated_at_utc="2026-05-09T00:00:00Z",
+    )
+    rec = snap["records"][0]
+    assert rec["outbound_delivery_intent"] == "failed_secret_check"
+
+
+def test_payload_contains_no_diff_or_pem(tmp_path: Path) -> None:
+    dispatcher, outbox = _make_logs(tmp_path)
+    _write_dispatcher(
+        dispatcher,
+        _dispatcher_payload(events=[
+            _ev(event_id="diff_001", summary="diff --git a/x b/x change"),
+        ]),
+    )
+    snap = ndo.collect_snapshot(
+        dispatcher_artifact_path=dispatcher,
+        outbox_history_path=outbox,
+    )
+    rec = snap["records"][0]
+    assert rec["outbound_delivery_intent"] == "failed_secret_check"
+
+
+def test_payload_contains_no_secret(tmp_path: Path) -> None:
+    """A credential-shaped string in upstream forces failed_secret_check
+    via assert_no_secrets at the record-build stage. The wrapper-level
+    assert_no_secrets at snapshot time would also raise, but we never
+    reach it because the per-record guard catches first."""
+    dispatcher, outbox = _make_logs(tmp_path)
+    _write_dispatcher(
+        dispatcher,
+        _dispatcher_payload(events=[
+            _ev(
+                event_id="sec_001",
+                summary="leaked sk-ant-api03-very-bad-secret-here-please-break",
+            ),
+        ]),
+    )
+    # The per-record guard catches first, so the snapshot does not raise.
+    snap = ndo.collect_snapshot(
+        dispatcher_artifact_path=dispatcher,
+        outbox_history_path=outbox,
+    )
+    rec = snap["records"][0]
+    assert rec["outbound_delivery_intent"] == "failed_secret_check"
+    assert rec["secret_guard_ok"] is False
+
+
+def test_secret_guard_invoked_on_every_payload_path() -> None:
+    """The per-record path explicitly calls assert_no_secrets — the
+    function name must appear in source."""
+    src = Path(ndo.__file__).read_text(encoding="utf-8")
+    assert "assert_no_secrets" in src
+
+
+def test_stub_provider_returns_offline_accept_for_valid_payload() -> None:
+    payload = {
+        "event_id": "x",
+        "event_kind": "intake_candidate_eligible",
+        "event_severity": "push_info",
+        "title": "t",
+        "summary": "s",
+        "open_at": "/agent-control/inbox?event=x",
+    }
+    result = ndo.stub_provider(payload)
+    assert result["url"] == "stub://web-push-provider-disabled"
+    assert result["status"] == "accepted_offline"
+    assert result["result"] == "would_send"
+
+
+def test_stub_provider_rejects_invalid_payload_shape() -> None:
+    bad = {"event_id": "x"}  # missing keys
+    result = ndo.stub_provider(bad)
+    assert result["status"] == "rejected_shape"
+    assert result["result"] == "invalid_payload_keys"
+
+
+# ---------------------------------------------------------------------------
+# --no-write discipline + audit emission boundary
+# ---------------------------------------------------------------------------
+
+
+def test_no_write_writes_no_files_and_no_audit(tmp_path: Path, monkeypatch) -> None:
+    """The CLI in --no-write mode must:
+    * not write logs/notification_dispatch_outbox/latest.json,
+    * not append to logs/notification_dispatch_outbox/outbox.jsonl,
+    * not call agent_audit.append_event.
+    """
+    dispatcher, outbox = _make_logs(tmp_path)
+    _write_dispatcher(
+        dispatcher,
+        _dispatcher_payload(events=[_ev(event_id="nw_001")]),
+    )
+    # Monkeypatch the module's defaults so --no-write doesn't touch
+    # the real repo paths.
+    monkeypatch.setattr(ndo, "ARTIFACT_LATEST", tmp_path / "logs" / "notification_dispatch_outbox" / "latest.json")
+    monkeypatch.setattr(ndo, "OUTBOX_JSONL_PATH", outbox)
+    monkeypatch.setattr(nd, "ARTIFACT_LATEST", dispatcher)
+
+    audit_calls: list[Any] = []
+
+    def fake_append(event, *, base_dir=None):  # type: ignore[no-redef]
+        audit_calls.append(event)
+        return {"sequence_id": 999}
+
+    monkeypatch.setattr(_audit, "append_event", fake_append)
+
+    rc = ndo.main(["--no-write", "--indent", "0"])
+    assert rc == 0
+    # No files written.
+    assert not (tmp_path / "logs" / "notification_dispatch_outbox" / "latest.json").exists()
+    # outbox.jsonl exists from _make_logs but should be empty (we never wrote).
+    text = outbox.read_text(encoding="utf-8") if outbox.exists() else ""
+    assert text == ""
+    # No audit calls.
+    assert audit_calls == []
+
+
+def test_normal_run_writes_and_emits_audit(tmp_path: Path, monkeypatch) -> None:
+    dispatcher, outbox = _make_logs(tmp_path)
+    _write_dispatcher(
+        dispatcher,
+        _dispatcher_payload(events=[_ev(event_id="nr_001")]),
+    )
+    artifact_latest = (
+        tmp_path / "logs" / "notification_dispatch_outbox" / "latest.json"
+    )
+    monkeypatch.setattr(ndo, "ARTIFACT_LATEST", artifact_latest)
+    monkeypatch.setattr(ndo, "OUTBOX_JSONL_PATH", outbox)
+    monkeypatch.setattr(nd, "ARTIFACT_LATEST", dispatcher)
+
+    audit_calls: list[Any] = []
+
+    def fake_append(event, *, base_dir=None):  # type: ignore[no-redef]
+        audit_calls.append(event)
+        return {"sequence_id": len(audit_calls)}
+
+    monkeypatch.setattr(_audit, "append_event", fake_append)
+
+    rc = ndo.main(["--indent", "0"])
+    assert rc == 0
+    assert artifact_latest.is_file()
+    # outbox.jsonl appended.
+    text = outbox.read_text(encoding="utf-8")
+    assert "nr_001" in text
+    # Two audit events per record (attempt + success).
+    assert len(audit_calls) == 2
+    assert audit_calls[0]["event"] == "push_dispatch_attempt"
+    assert audit_calls[1]["event"] == "push_dispatch_success"
+    assert audit_calls[0]["autonomy_level_claimed"] == 0
+    assert audit_calls[1]["autonomy_level_claimed"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Determinism + sorting
+# ---------------------------------------------------------------------------
+
+
+def test_determinism_with_injected_timestamp(tmp_path: Path) -> None:
+    dispatcher, outbox = _make_logs(tmp_path)
+    _write_dispatcher(
+        dispatcher,
+        _dispatcher_payload(events=[_ev(event_id="det_001")]),
+    )
+    snap_a = ndo.collect_snapshot(
+        dispatcher_artifact_path=dispatcher,
+        outbox_history_path=outbox,
+        generated_at_utc="2026-05-09T00:00:00Z",
+    )
+    snap_b = ndo.collect_snapshot(
+        dispatcher_artifact_path=dispatcher,
+        outbox_history_path=outbox,
+        generated_at_utc="2026-05-09T00:00:00Z",
+    )
+    a = json.dumps(snap_a, sort_keys=True, indent=2).encode("utf-8")
+    b = json.dumps(snap_b, sort_keys=True, indent=2).encode("utf-8")
+    assert a == b
+
+
+def test_records_sort_stably(tmp_path: Path) -> None:
+    dispatcher, outbox = _make_logs(tmp_path)
+    _write_dispatcher(
+        dispatcher,
+        _dispatcher_payload(events=[
+            _ev(event_id="z_03"),
+            _ev(event_id="a_01"),
+            _ev(event_id="m_02"),
+        ]),
+    )
+    snap = ndo.collect_snapshot(
+        dispatcher_artifact_path=dispatcher,
+        outbox_history_path=outbox,
+    )
+    keys = [(r["source_module"], r["event_id"]) for r in snap["records"]]
+    assert keys == sorted(keys)
+
+
+# ---------------------------------------------------------------------------
+# Source-text scans
+# ---------------------------------------------------------------------------
+
+
+def _module_source() -> str:
+    return Path(ndo.__file__).read_text(encoding="utf-8")
+
+
+def _imported_module_names() -> set[str]:
+    import ast
+
+    src = _module_source()
+    tree = ast.parse(src)
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module is not None:
+                names.add(node.module)
+    return names
+
+
+def test_no_subprocess_in_module() -> None:
+    src = _module_source()
+    assert "import subprocess" not in src
+    assert "from subprocess" not in src
+
+
+def test_no_network_in_module() -> None:
+    src = _module_source()
+    for forbidden in (
+        "import socket",
+        "import urllib",
+        "import http.client",
+        "import requests",
+        "import httpx",
+        "import aiohttp",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_no_web_push_library_imports() -> None:
+    src = _module_source()
+    for forbidden in (
+        "import pywebpush",
+        "from pywebpush",
+        "import webpush",
+        "from webpush",
+        "import web_push",
+        "from web_push",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_no_gh_or_git_subprocess_references() -> None:
+    src = _module_source()
+    for forbidden in (
+        "subprocess.run",
+        "subprocess.Popen",
+        "os.system",
+        "os.popen",
+        "shell=True",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_no_dashboard_or_live_path_or_qre_imports() -> None:
+    forbidden_prefixes = (
+        "dashboard",
+        "frontend",
+        "automation",
+        "broker",
+        "agent.risk",
+        "agent.execution",
+        "research",
+        "reporting.intelligent_routing",
+        "live",
+        "paper",
+        "shadow",
+        "trading",
+    )
+    for module in _imported_module_names():
+        for prefix in forbidden_prefixes:
+            assert not (
+                module == prefix or module.startswith(prefix + ".")
+            ), f"forbidden import: {module}"
+
+
+def test_no_subscription_or_vapid_code_paths() -> None:
+    """Defense in depth: module must not contain code that opens a
+    subscription file or VAPID key. Documentation references in
+    docstrings are explicitly allowed (we document what we DO NOT
+    do); this test scans for code-shaped patterns only."""
+    src = _module_source()
+    forbidden_code_patterns = (
+        "subscriptions.json",
+        "web_push_subscriptions",
+        "vapid_public.txt",
+        "vapid_private",
+        "VAPID_PRIVATE",
+        "WEB_PUSH_VAPID",
+    )
+    for forbidden in forbidden_code_patterns:
+        assert forbidden not in src, forbidden
+
+
+def test_module_imports_cleanly() -> None:
+    importlib.reload(ndo)
+    assert callable(ndo.collect_snapshot)
+
+
+def test_importing_module_does_not_flip_step5_invariants() -> None:
+    from reporting import development_step5_loop as dsl
+
+    importlib.reload(ndo)
+    assert dsl.step5_implementation_allowed is False
+    assert dsl.STEP5_ENABLED_SUBSTAGE == "none"
+
+
+# ---------------------------------------------------------------------------
+# Companion doc invariants
+# ---------------------------------------------------------------------------
+
+
+def _doc_text() -> str:
+    return (
+        REPO_ROOT / "docs" / "governance" / "notification_dispatch_outbox.md"
+    ).read_text(encoding="utf-8")
+
+
+def test_doc_states_no_real_push_in_n2b1() -> None:
+    text = _doc_text().lower()
+    assert "no real push" in text
+
+
+def test_doc_states_no_approval_from_click_alone() -> None:
+    text = _doc_text().lower()
+    assert "no approval can happen from a notification click alone" in text
+
+
+def test_doc_states_n2b2_n2b3_n3_n4_n5_remain_unimplemented() -> None:
+    text = _doc_text().lower()
+    for marker in ("n2b-2", "n2b-3", "n3", "n4", "n5"):
+        assert marker in text, marker
+    assert "out of scope" in text or "remain unimplemented" in text or "unimplemented" in text
+
+
+def test_doc_pins_step5_invariants_text() -> None:
+    text = _doc_text()
+    assert "step5_implementation_allowed" in text
+    assert "STEP5_ENABLED_SUBSTAGE" in text
+
+
+def test_doc_mentions_level_6_only_with_qualifier() -> None:
+    import re
+
+    text = _doc_text()
+    pattern = re.compile(r"\bLevel\s*6\b")
+    for m in pattern.finditer(text):
+        start = max(0, m.start() - 200)
+        end = m.start() + 600
+        window = text[start:end].lower()
+        assert "permanently disabled" in window

--- a/tests/unit/test_notification_dispatch_outbox_status.py
+++ b/tests/unit/test_notification_dispatch_outbox_status.py
@@ -1,0 +1,325 @@
+"""Unit tests for N2b-1 — Dispatch Outbox status summary."""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reporting import notification_dispatch_outbox as ndo
+from reporting import notification_dispatch_outbox_status as ndos
+from reporting import notification_dispatcher as nd
+from reporting import notification_event as ne
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_outbox_artifact(tmp_path: Path, payload: dict[str, Any]) -> Path:
+    p = tmp_path / "logs" / "notification_dispatch_outbox" / "latest.json"
+    p.parent.mkdir(parents=True)
+    p.write_text(
+        json.dumps(payload, sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return p
+
+
+def _synthetic_outbox_payload(
+    *,
+    records: list[dict[str, Any]] | None = None,
+    note: str = "dispatch_records_present",
+) -> dict[str, Any]:
+    records = records or []
+    counts = {
+        "total": len(records),
+        "sent": 0,
+        "duplicate": 0,
+        "skipped_not_ready": 0,
+        "rate_limited_outbound": 0,
+        "failed_secret_check": 0,
+        "failed_stub_provider": 0,
+        "by_outbound_delivery_intent": {
+            v: 0 for v in ndo.OUTBOUND_DELIVERY_INTENTS
+        },
+        "by_event_kind": {k: 0 for k in ne.EVENT_KINDS},
+        "by_event_severity": {s: 0 for s in ne.EVENT_SEVERITIES},
+        "by_source_module": {m: 0 for m in nd.SOURCE_MODULES},
+    }
+    for r in records:
+        di = r.get("outbound_delivery_intent")
+        if di in counts:
+            counts[di] = counts[di] + 1
+        if di in counts["by_outbound_delivery_intent"]:
+            counts["by_outbound_delivery_intent"][di] += 1
+        ek = r.get("event_kind")
+        if isinstance(ek, str) and ek in counts["by_event_kind"]:
+            counts["by_event_kind"][ek] += 1
+        es = r.get("event_severity")
+        if isinstance(es, str) and es in counts["by_event_severity"]:
+            counts["by_event_severity"][es] += 1
+        sm = r.get("source_module")
+        if isinstance(sm, str) and sm in counts["by_source_module"]:
+            counts["by_source_module"][sm] += 1
+    return {
+        "schema_version": "1.0",
+        "module_version": ndo.MODULE_VERSION,
+        "report_kind": "notification_dispatch_outbox",
+        "generated_at_utc": "2026-05-09T00:00:00Z",
+        "step5_enabled_substage": "none",
+        "step5_implementation_allowed": False,
+        "dispatcher_artifact_path": "/tmp/dispatcher.json",
+        "dispatcher_artifact_available": True,
+        "outbox_history_path": "/tmp/outbox.jsonl",
+        "stub_provider_url": "stub://web-push-provider-disabled",
+        "note": note,
+        "validation_warnings": [],
+        "vocabularies": {},
+        "counts": counts,
+        "records": records,
+        "notification_dispatcher_module_version": nd.MODULE_VERSION,
+        "notification_event_module_version": ne.MODULE_VERSION,
+        "discipline_invariants": {},
+    }
+
+
+def _rec(
+    *,
+    event_id: str = "rec_001",
+    event_kind: str = "intake_candidate_eligible",
+    event_severity: str = "push_info",
+    source_module: str = "development_intake_promotion",
+    outbound_delivery_intent: str = "sent",
+) -> dict[str, Any]:
+    return {
+        "event_id": event_id,
+        "event_kind": event_kind,
+        "event_severity": event_severity,
+        "source_module": source_module,
+        "source_id": "src_001",
+        "outbound_delivery_intent": outbound_delivery_intent,
+        "payload": {},
+        "stub_provider_url": "stub://web-push-provider-disabled",
+        "stub_provider_status": "accepted_offline",
+        "stub_provider_result": "would_send",
+        "secret_guard_ok": True,
+        "attempted_at": "2026-05-09T00:00:00Z",
+        "audit_event_seq": None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Atomic-write refusal
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_write_refuses_non_status_logs_path(tmp_path: Path) -> None:
+    bad = tmp_path / "evil_dir" / "latest.json"
+    with pytest.raises(ValueError):
+        ndos._atomic_write_json(bad, {"x": 1})
+
+
+def test_atomic_write_refuses_outbox_logs_path(tmp_path: Path) -> None:
+    bad = tmp_path / "logs" / "notification_dispatch_outbox" / "latest.json"
+    with pytest.raises(ValueError):
+        ndos._atomic_write_json(bad, {"x": 1})
+
+
+# ---------------------------------------------------------------------------
+# Status when upstream artefact is absent
+# ---------------------------------------------------------------------------
+
+
+def test_status_when_artifact_absent(tmp_path: Path) -> None:
+    missing = tmp_path / "logs" / "notification_dispatch_outbox" / "latest.json"
+    snap = ndos.collect_status(
+        outbox_artifact_path=missing,
+        generated_at_utc="2026-05-09T00:00:00Z",
+    )
+    assert snap["outbox_artifact_available"] is False
+    assert snap["counts"]["total"] == 0
+    assert snap["operator_attention_count"] == 0
+    assert snap["note"] == "outbox_artifact_absent"
+    assert snap["step5_implementation_allowed"] is False
+    assert snap["step5_enabled_substage"] == "none"
+    sp = snap["schema_pinned"]
+    assert sp["outbound_delivery_intents"] == list(
+        ndo.OUTBOUND_DELIVERY_INTENTS
+    )
+    assert sp["push_payload_keys"] == list(ndo.PUSH_PAYLOAD_KEYS)
+
+
+# ---------------------------------------------------------------------------
+# Status with synthetic upstream
+# ---------------------------------------------------------------------------
+
+
+def test_status_counts_mirror_upstream(tmp_path: Path) -> None:
+    records = [
+        _rec(event_id="r_a", outbound_delivery_intent="sent"),
+        _rec(event_id="r_b", outbound_delivery_intent="duplicate"),
+        _rec(
+            event_id="r_c",
+            outbound_delivery_intent="failed_secret_check",
+        ),
+        _rec(
+            event_id="r_d",
+            outbound_delivery_intent="failed_stub_provider",
+        ),
+        _rec(
+            event_id="r_e",
+            outbound_delivery_intent="rate_limited_outbound",
+        ),
+    ]
+    payload = _synthetic_outbox_payload(records=records)
+    artifact = _write_outbox_artifact(tmp_path, payload)
+    snap = ndos.collect_status(
+        outbox_artifact_path=artifact,
+        generated_at_utc="2026-05-09T00:00:00Z",
+    )
+    assert snap["outbox_artifact_available"] is True
+    assert snap["counts"]["total"] == 5
+    assert snap["counts"]["sent"] == 1
+    assert snap["counts"]["duplicate"] == 1
+    assert snap["counts"]["failed_secret_check"] == 1
+    assert snap["counts"]["failed_stub_provider"] == 1
+    assert snap["counts"]["rate_limited_outbound"] == 1
+    assert snap["counts"]["by_outbound_delivery_intent"]["sent"] == 1
+    assert snap["counts"]["by_outbound_delivery_intent"]["duplicate"] == 1
+    assert snap["operator_attention_count"] == 2
+    assert snap["outbox_module_version"] == ndo.MODULE_VERSION
+    assert snap["outbox_note"] == "dispatch_records_present"
+    assert snap["step5_implementation_allowed"] is False
+    assert snap["step5_enabled_substage"] == "none"
+
+
+def test_operator_attention_only_counts_failures(tmp_path: Path) -> None:
+    records = [
+        _rec(event_id="r_a", outbound_delivery_intent="sent"),
+        _rec(event_id="r_b", outbound_delivery_intent="duplicate"),
+        _rec(event_id="r_c", outbound_delivery_intent="skipped_not_ready"),
+        _rec(event_id="r_d", outbound_delivery_intent="rate_limited_outbound"),
+    ]
+    payload = _synthetic_outbox_payload(records=records)
+    artifact = _write_outbox_artifact(tmp_path, payload)
+    snap = ndos.collect_status(
+        outbox_artifact_path=artifact,
+        generated_at_utc="2026-05-09T00:00:00Z",
+    )
+    assert snap["operator_attention_count"] == 0
+
+
+def test_status_handles_corrupt_artifact(tmp_path: Path) -> None:
+    bad = tmp_path / "logs" / "notification_dispatch_outbox" / "latest.json"
+    bad.parent.mkdir(parents=True)
+    bad.write_text("not json", encoding="utf-8")
+    snap = ndos.collect_status(
+        outbox_artifact_path=bad,
+        generated_at_utc="2026-05-09T00:00:00Z",
+    )
+    assert snap["outbox_artifact_available"] is False
+    assert snap["note"] == "outbox_artifact_absent"
+
+
+def test_status_determinism_with_injected_timestamp(tmp_path: Path) -> None:
+    payload = _synthetic_outbox_payload()
+    artifact = _write_outbox_artifact(tmp_path, payload)
+    snap_a = ndos.collect_status(
+        outbox_artifact_path=artifact,
+        generated_at_utc="2026-05-09T00:00:00Z",
+    )
+    snap_b = ndos.collect_status(
+        outbox_artifact_path=artifact,
+        generated_at_utc="2026-05-09T00:00:00Z",
+    )
+    assert (
+        json.dumps(snap_a, sort_keys=True, indent=2).encode("utf-8")
+        == json.dumps(snap_b, sort_keys=True, indent=2).encode("utf-8")
+    )
+
+
+# ---------------------------------------------------------------------------
+# Source-text scans
+# ---------------------------------------------------------------------------
+
+
+def _module_source() -> str:
+    return Path(ndos.__file__).read_text(encoding="utf-8")
+
+
+def _imported_module_names() -> set[str]:
+    import ast
+
+    src = _module_source()
+    tree = ast.parse(src)
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module is not None:
+                names.add(node.module)
+    return names
+
+
+def test_no_subprocess_in_status_module() -> None:
+    src = _module_source()
+    assert "import subprocess" not in src
+    assert "from subprocess" not in src
+
+
+def test_no_network_in_status_module() -> None:
+    src = _module_source()
+    for forbidden in (
+        "import socket",
+        "import urllib",
+        "import http.client",
+        "import requests",
+        "import httpx",
+        "import aiohttp",
+    ):
+        assert forbidden not in src
+
+
+def test_no_web_push_library_imports_status() -> None:
+    src = _module_source()
+    for forbidden in (
+        "import pywebpush",
+        "from pywebpush",
+        "import webpush",
+        "from webpush",
+    ):
+        assert forbidden not in src
+
+
+def test_no_forbidden_imports_in_status_module() -> None:
+    forbidden_prefixes = (
+        "dashboard",
+        "frontend",
+        "automation",
+        "broker",
+        "agent.risk",
+        "agent.execution",
+        "research",
+        "reporting.intelligent_routing",
+        "live",
+        "paper",
+        "shadow",
+        "trading",
+    )
+    for module in _imported_module_names():
+        for prefix in forbidden_prefixes:
+            assert not (
+                module == prefix or module.startswith(prefix + ".")
+            ), f"forbidden import: {module}"
+
+
+def test_status_module_imports_cleanly() -> None:
+    importlib.reload(ndos)
+    assert callable(ndos.collect_status)


### PR DESCRIPTION
## Summary

N2b-1 — pure stdlib-only **dry-run** push outbox. Reads N2a `delivery_intent=ready` events, builds a closed six-key push payload per event, runs every payload through the existing closed credential-pattern guard, and dispatches via a **stub provider** that opens **no network socket**. Audit events emitted only on normal non-`--no-write` runs.

N2b-2 (PWA subscription UI + service worker), N2b-3 (real Web Push delivery), N3 (mobile approval inbox), N4 (token gate), N5 (merge/deploy adapter) all remain **unimplemented** and require separate go-signals.

## What lands

- `reporting/notification_dispatch_outbox.py` — pure projector + in-process audit emission boundary. Closed vocabularies (`OUTBOUND_DELIVERY_INTENTS=6`, `AUDIT_EVENT_NAMES=5`, `PUSH_PAYLOAD_KEYS=6`, `OUTBOX_RECORD_SCHEMA_KEYS=13`). `MAX_DISPATCH_PER_CYCLE=16`, `MAX_OUTBOX_HISTORY=500`. Stub provider sentinel URL `stub://web-push-provider-disabled`. Dirty payloads dropped from the record on guard failure.
- `reporting/notification_dispatch_outbox_status.py` — status summary by `outbound_delivery_intent` / `event_kind` / `event_severity` / `source_module`; `operator_attention_count` surfaces failures only.
- `docs/governance/notification_dispatch_outbox.md` — full surface doc.
- `tests/unit/test_notification_dispatch_outbox.py` (41 tests) + `tests/unit/test_notification_dispatch_outbox_status.py` (13 tests).

## Hard guarantees (pinned by tests)

- No `dashboard` / `frontend` / `automation` / `broker` / `agent.risk` / `agent.execution` / `research` / `reporting.intelligent_routing` / `live` / `paper` / `shadow` / `trading` imports.
- No subprocess / socket / urllib / requests / httpx / aiohttp / pywebpush / web_push / webpush / `gh` / `git`.
- No subscription-file or VAPID-key code paths.
- `--no-write` writes nothing and emits no audit events.
- `step5_implementation_allowed` remains `False`; `STEP5_ENABLED_SUBSTAGE` remains `\"none\"`; Level 6 stays permanently disabled.

## Live verification on `main`

`python -m reporting.notification_dispatch_outbox` (with N2a events.jsonl freshly cleared so the A16a candidate becomes `ready`):

- A16a `intake_candidate_eligible` event_id `7d4717896a34962fc99d894f86b2dcdb` → `outbound_delivery_intent=sent`.
- 6-key payload: `{event_id, event_kind, event_severity, title, summary, open_at}`.
- `open_at = \"/agent-control/inbox?event=7d4717896a34962fc99d894f86b2dcdb\"`.
- `stub_provider_status=accepted_offline`, `stub_provider_url=stub://web-push-provider-disabled`.
- Second run: same event becomes `outbound_delivery_intent=duplicate`.
- Suppressed events become `skipped_not_ready`.
- Status: `total=3, sent=1, skipped_not_ready=2, operator_attention_count=0`.
- Audit ledger gained two rows per sent record (`push_dispatch_attempt` + `push_dispatch_success`), each with `autonomy_level_claimed=0`.

## Test plan

- [x] `python scripts/governance_lint.py` — OK.
- [x] `python -m pytest tests/unit/test_notification_dispatch_outbox*.py -q` — **54 passed**.
- [x] `python -m pytest tests/unit/test_notification_dispatcher*.py -q` — **68 passed** (N2a unaffected).
- [x] `python -m pytest tests/unit/test_notification_event.py -q` — **38 passed** (N1 unaffected).
- [x] `python -m pytest tests/smoke -q` — **18 passed**.
- [x] CI checks
- [x] Diff scope = exactly the 5 N2b-1 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)