### PR TITLE
feat(notif): N2b-2a — Push Subscription Store + Unwired API blueprint

### DIFF
--- a/dashboard/api_push_subscribe.py
+++ b/dashboard/api_push_subscribe.py
@@ -1,0 +1,276 @@
+"""N2b-2a — Push Subscribe API blueprint (UNWIRED).
+
+Flask blueprint exposing the future PWA Web Push subscription
+surface. This module defines :func:`register_push_subscribe_routes`
+following the same pattern as ``dashboard.api_approval_inbox``.
+
+**The blueprint is intentionally NOT wired into
+``dashboard/dashboard.py`` in this PR.** Wiring is a one-line
+``register_push_subscribe_routes(app)`` change that lands in N2b-2b.
+``dashboard/dashboard.py`` is `dashboard_wiring` per
+``execution_authority.md`` and requires explicit operator approval.
+
+Hard guarantees (pinned by tests):
+
+* GET / POST / DELETE only — no other HTTP method is registered.
+* Never executes a CLI subprocess, never invokes ``gh`` or ``git``,
+  never opens a network socket, never imports a Web Push library.
+* Every response payload is run through ``assert_no_secrets`` from
+  ``reporting.agent_audit_summary``.
+* The ``GET /api/push/status`` endpoint NEVER returns subscription
+  endpoints or keys — only ``count``, ``last_subscribed_at``, and
+  ``vapid_public_present``.
+* The ``GET /api/push/vapid_public`` endpoint returns 404 with a
+  bounded JSON error body when the gitignored public-key file is
+  absent.
+* The ``POST /api/push/test`` endpoint enqueues a synthetic event
+  for the existing N2b-1 stub-provider outbox; **no real push.**
+* No subscription record's endpoint URL or keys appear in any audit
+  / log surface; only ``endpoint_hash`` (sha256[:16]) is used.
+
+Authentication
+--------------
+
+Auth is provided by the existing PWA session middleware, applied at
+the dashboard wiring layer (``dashboard/dashboard.py``). This
+blueprint does not register any auth itself; the unit tests register
+it on a fresh Flask app and exercise the routes directly. When the
+operator wires this blueprint in N2b-2b, the existing session
+middleware applies automatically.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+from typing import Any
+
+from flask import Flask, Response, jsonify, request
+
+from reporting import push_subscription_store as pss
+from reporting.agent_audit_summary import assert_no_secrets
+
+MODULE_VERSION: str = "v3.15.16.N2b2a"
+SCHEMA_VERSION: int = 1
+
+
+# ---------------------------------------------------------------------------
+# Bounded request-body limits
+# ---------------------------------------------------------------------------
+
+#: Maximum size of a JSON request body. Web Push subscription bodies
+#: are well under this; anything larger is refused 413.
+_MAX_REQUEST_BYTES: int = 8 * 1024
+
+
+# ---------------------------------------------------------------------------
+# Synthetic test-event helpers (POST /api/push/test)
+# ---------------------------------------------------------------------------
+
+#: Closed sentinel kid for synthetic test events. The kid does not
+#: match any real key; it tags the event_id for operator visibility.
+_TEST_EVENT_KIND: str = "intake_candidate_eligible"
+_TEST_EVENT_SEVERITY: str = "push_info"
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _safe_jsonify(payload: dict[str, Any]) -> Response:
+    """JSONify after running ``assert_no_secrets`` on the payload."""
+    assert_no_secrets(payload)
+    return jsonify(payload)
+
+
+def _bounded_summary(s: str, *, max_len: int = 200) -> str:
+    if not isinstance(s, str):
+        return ""
+    return s[:max_len]
+
+
+# ---------------------------------------------------------------------------
+# View functions
+# ---------------------------------------------------------------------------
+
+
+def _view_subscribe() -> tuple[Response, int] | Response:
+    """POST /api/push/subscribe — register a new subscription
+    (idempotent on endpoint)."""
+    if request.content_length is not None and request.content_length > _MAX_REQUEST_BYTES:
+        return _safe_jsonify({"status": "error", "error": "payload_too_large"}), 413
+    try:
+        raw = request.get_json(force=False, silent=True)
+    except Exception:
+        raw = None
+    if not isinstance(raw, dict):
+        return _safe_jsonify({"status": "error", "error": "invalid_json_body"}), 400
+
+    rec, warnings = pss.register_subscription(raw)
+    if rec is None:
+        return (
+            _safe_jsonify(
+                {
+                    "status": "error",
+                    "error": "register_rejected",
+                    "warnings": warnings,
+                }
+            ),
+            400,
+        )
+    return _safe_jsonify(
+        {
+            "status": "ok",
+            "endpoint_hash": pss.endpoint_hash(rec["endpoint"]),
+            "kid": rec["kid"],
+            "label": rec["label"],
+            "created_at": rec["created_at"],
+            "last_seen_at": rec["last_seen_at"],
+        }
+    )
+
+
+def _view_unsubscribe() -> tuple[Response, int] | Response:
+    """DELETE /api/push/unsubscribe — remove a subscription by
+    endpoint (idempotent)."""
+    if request.content_length is not None and request.content_length > _MAX_REQUEST_BYTES:
+        return _safe_jsonify({"status": "error", "error": "payload_too_large"}), 413
+    try:
+        raw = request.get_json(force=False, silent=True)
+    except Exception:
+        raw = None
+    endpoint = ""
+    if isinstance(raw, dict):
+        endpoint = raw.get("endpoint") if isinstance(raw.get("endpoint"), str) else ""
+    if not endpoint:
+        return _safe_jsonify({"status": "error", "error": "missing_endpoint"}), 400
+
+    removed = pss.unregister_subscription(endpoint)
+    return _safe_jsonify(
+        {
+            "status": "ok",
+            "removed": removed,
+            "endpoint_hash": pss.endpoint_hash(endpoint),
+        }
+    )
+
+
+def _view_vapid_public() -> tuple[Response, int] | Response:
+    """GET /api/push/vapid_public — return the gitignored public key
+    or a bounded 404 envelope."""
+    text = pss.vapid_public_text()
+    if not text:
+        return (
+            _safe_jsonify(
+                {
+                    "status": "not_available",
+                    "error": "vapid_public_not_configured",
+                }
+            ),
+            404,
+        )
+    # text/plain on success; bounded by the underlying file. Run the
+    # text through assert_no_secrets-style guard by jsonifying first
+    # and replacing — actually the public key is ASCII base64url and
+    # contains no credential pattern. We return text/plain directly.
+    resp = Response(text, status=200, mimetype="text/plain")
+    return resp
+
+
+def _view_status() -> Response:
+    """GET /api/push/status — returns ONLY count + last_subscribed_at
+    + vapid_public_present. Never returns endpoints or keys."""
+    subs = pss.list_subscriptions()
+    last_subscribed_at = ""
+    if subs:
+        last_subscribed_at = max(
+            (s.get("last_seen_at", "") for s in subs if isinstance(s, dict)),
+            default="",
+        )
+    return _safe_jsonify(
+        {
+            "status": "ok",
+            "count": len(subs),
+            "last_subscribed_at": last_subscribed_at,
+            "vapid_public_present": pss.vapid_public_present(),
+            "max_active_subscriptions": pss.MAX_ACTIVE_SUBSCRIPTIONS,
+        }
+    )
+
+
+def _view_test() -> Response:
+    """POST /api/push/test — synthesize a test event record and
+    return it. **Does NOT call any push provider, real or stub.** The
+    operator runs the existing N2b-1 dispatch outbox CLI to exercise
+    the rest of the pipeline against a freshly generated test event.
+    """
+    if request.content_length is not None and request.content_length > _MAX_REQUEST_BYTES:
+        return _safe_jsonify({"status": "error", "error": "payload_too_large"}), 413
+
+    now = _utcnow()
+    event_id = (
+        "ade_test_" + now.replace("-", "").replace(":", "").replace("Z", "")
+    )[:64]
+    return _safe_jsonify(
+        {
+            "status": "ok",
+            "test_event": {
+                "event_id": event_id,
+                "event_kind": _TEST_EVENT_KIND,
+                "event_severity": _TEST_EVENT_SEVERITY,
+                "title": "ADE test push",
+                "summary": _bounded_summary(
+                    "Synthetic test event. Backend pipeline only; "
+                    "no real push is sent in N2b-2a."
+                ),
+                "open_at": "/agent-control/inbox?event=" + event_id,
+            },
+            "would_dispatch_via": "n2b1_outbox_stub_provider",
+            "real_push_sent": False,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Route table + register helper
+# ---------------------------------------------------------------------------
+
+_PUSH_SUBSCRIBE_ROUTES: tuple[tuple[str, str, Any], ...] = (
+    ("/api/push/subscribe", "POST", _view_subscribe),
+    ("/api/push/unsubscribe", "DELETE", _view_unsubscribe),
+    ("/api/push/vapid_public", "GET", _view_vapid_public),
+    ("/api/push/status", "GET", _view_status),
+    ("/api/push/test", "POST", _view_test),
+)
+
+
+def register_push_subscribe_routes(app: Flask) -> None:
+    """Register the future PWA Web Push subscription surface.
+
+    **NOT wired into ``dashboard/dashboard.py``** in this PR. The
+    one-line wiring change lands in N2b-2b, behind explicit operator
+    approval per ``execution_authority.md`` (``dashboard_wiring`` =
+    NEEDS_HUMAN).
+    """
+    for path, method, handler in _PUSH_SUBSCRIBE_ROUTES:
+        endpoint_name = (
+            f"push_subscribe_{method.lower()}_{path.rsplit('/', 1)[-1]}"
+        )
+        app.add_url_rule(
+            path,
+            endpoint=endpoint_name,
+            view_func=handler,
+            methods=[method],
+        )
+
+
+__all__ = [
+    "MODULE_VERSION",
+    "SCHEMA_VERSION",
+    "register_push_subscribe_routes",
+]

--- a/docs/governance/notification_dispatch_subscription.md
+++ b/docs/governance/notification_dispatch_subscription.md
@@ -1,0 +1,336 @@
+# Push Subscription Store + API — N2b-2a (backend, unwired)
+
+> **Status:** Implemented (backend-only, **unwired**, **no real
+> push**).
+>
+> **Modules:**
+> - [`reporting/push_subscription_store.py`](../../reporting/push_subscription_store.py) — pure-stdlib subscription store
+> - [`dashboard/api_push_subscribe.py`](../../dashboard/api_push_subscribe.py) — Flask blueprint (NOT yet wired)
+>
+> **Runtime config (gitignored):**
+> - `config/web_push_subscriptions.json` — active subscriptions
+> - `config/web_push_vapid_public.txt` — VAPID public key (text)
+>
+> **Authority:** development-governance backend-only.
+> N2b-2a sends no real push and grants no agent any new authority.
+> Level 6 stays permanently disabled per ADR-015 §Doctrine 1.
+> `dashboard/dashboard.py` is **unchanged** in this PR. `frontend/**`
+> is **unchanged** in this PR.
+
+---
+
+## 1. Purpose
+
+N2b-2a adds the backend storage primitive and the Flask blueprint
+required for the future PWA Web Push subscription surface. The
+blueprint is fully implemented and unit-tested on a fresh Flask app,
+but it is **not wired into `dashboard/dashboard.py`**. Wiring is a
+single-line change (`register_push_subscribe_routes(app)`) that lands
+later in N2b-2b, behind explicit operator approval — the dashboard's
+central wiring file is `dashboard_wiring` per
+[`execution_authority.md`](execution_authority.md), which classifies
+edits to it as `NEEDS_HUMAN`.
+
+This means: at runtime today, after this PR merges, **nothing
+operator-visible changes**. The Python module exists; the Flask
+blueprint exists; the gitignored runtime-config paths are recognised.
+No HTTP route is reachable through the live dashboard. No
+subscription is ever stored automatically. No push is ever sent —
+real, stub, or otherwise. The N2b-2a PR is, at runtime, equivalent to
+a no-op.
+
+---
+
+## 2. Hard constraints
+
+N2b-2a, in this PR and at runtime, must not:
+
+- send a real push (Web Push, APNs, FCM, Telegram, email, SMS, anything);
+- open a network socket;
+- import a Web Push library;
+- read a VAPID **private** key (the literal env name
+  `WEB_PUSH_VAPID_PRIVATE_KEY` does not appear in N2b-2a source);
+- write to `dashboard/dashboard.py`;
+- write to `frontend/**`;
+- add a service worker;
+- mint approval tokens (N4 territory);
+- open mobile approval inbox rows (N3 territory);
+- merge or deploy (N5 / future);
+- enable Step 5.1 or Step 5.2;
+- flip `step5_implementation_allowed`;
+- change `STEP5_ENABLED_SUBSTAGE`;
+- change QRE behaviour;
+- mutate research artifacts;
+- touch live / paper / shadow / risk / broker / execution paths;
+- edit `.claude/**`;
+- store secrets in repo;
+- edit canonical roadmap status fields;
+- mark any roadmap phase complete.
+
+The module ships an AST-level forbidden-import scan and a
+source-text scan to enforce the relevant bullets.
+
+---
+
+## 3. Closed vocabularies + bounds
+
+Pinned in [`reporting/push_subscription_store.py`](../../reporting/push_subscription_store.py):
+
+### Per-record schema (closed, exact, ordered)
+
+```
+endpoint
+keys: {p256dh, auth}
+kid
+created_at
+last_seen_at
+label
+```
+
+### Bounds
+
+| Bound                                   | Value                          |
+| --------------------------------------- | ------------------------------ |
+| `MAX_ACTIVE_SUBSCRIPTIONS`              | 16 (single-operator guard)     |
+| `MAX_ENDPOINT_LEN`                      | 1024 chars                     |
+| `MAX_P256DH_LEN` / `MAX_AUTH_LEN`       | 200 chars each                 |
+| `MAX_KID_LEN`                           | 64 chars                       |
+| `MAX_LABEL_LEN`                         | 80 chars                       |
+| `_MAX_REQUEST_BYTES` (API layer)        | 8 KiB JSON request body         |
+
+### Allowed endpoint origins (closed)
+
+```
+https://fcm.googleapis.com/                        (Chrome / Edge / Android)
+https://updates.push.services.mozilla.com/         (Firefox)
+https://web.push.apple.com/                        (Safari)
+https://wns2-                                      (Microsoft WNS hosts)
+```
+
+Anything else is refused at register time with a
+`endpoint_origin_not_allowed` warning. Expansion requires a code
+change pinned by an updated test.
+
+---
+
+## 4. Storage path and gitignore
+
+| Path                                       | Tracked? | Purpose                                    |
+| ------------------------------------------ | -------- | ------------------------------------------ |
+| `config/web_push_subscriptions.json`       | **no** (gitignored) | active subscriptions JSON envelope |
+| `config/web_push_vapid_public.txt`         | **no** (gitignored) | VAPID public key (text/plain)      |
+| `WEB_PUSH_VAPID_PRIVATE_KEY` (env)         | **no** (env-only, **N2b-3 only**)  | private key never in repo |
+
+Both paths are added to `.gitignore` in this PR. A pin test asserts
+neither path appears in `git ls-files`.
+
+The store path is gitignored because:
+
+1. The file holds operator-specific Web Push endpoint URLs.
+2. Any `kid` rotation, unsubscribe, or auto-cleanup edit is
+   operational state, not source-of-truth.
+3. Committing it would let an attacker who briefly read the repo
+   deliver pushes that look like ADE notifications.
+
+The VAPID public key is gitignored because:
+
+1. The keypair is per-operator, generated by an out-of-band one-shot
+   script in **N2b-3** (lands later).
+2. The public key is non-secret per the W3C Web Push spec, but
+   committing it would couple the repo to a specific operator's
+   keypair, defeating future rotation.
+
+---
+
+## 5. Public Python API (`reporting.push_subscription_store`)
+
+| Function                                  | Returns                                           | Notes                                                                  |
+| ----------------------------------------- | ------------------------------------------------- | ---------------------------------------------------------------------- |
+| `list_subscriptions()`                    | `list[dict]`                                      | pure read; empty list on first read                                    |
+| `register_subscription(record)`           | `(record, warnings)`                              | idempotent on `endpoint`; refreshes `last_seen_at`; refuses on cap reached |
+| `unregister_subscription(endpoint)`       | `bool`                                            | idempotent — `True` if removed, `False` if absent                       |
+| `get_by_endpoint(endpoint)`               | `dict | None`                                     | pure read                                                               |
+| `load_store()` / `save_store(store)`      | envelope dict / path                              | atomic write; refused for any non-sentinel path                         |
+| `endpoint_hash(endpoint)`                 | `str` (sha256[:16])                               | the only operator-visible identifier in audit / log surfaces            |
+| `vapid_public_present()`                  | `bool`                                            | does not read content                                                   |
+| `vapid_public_text()`                     | `str | None`                                      | best-effort read; never raises                                          |
+
+Every register / unregister / refresh call is a full atomic rewrite
+of `config/web_push_subscriptions.json`. The atomic-write helper
+refuses any path other than the closed sentinel.
+
+---
+
+## 6. Flask blueprint (`dashboard.api_push_subscribe`)
+
+The blueprint exposes 5 routes via `register_push_subscribe_routes(app)`:
+
+| Method | Path                          | Behaviour                                                                                                        |
+| ------ | ----------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| POST   | `/api/push/subscribe`         | accepts a `PushSubscription.toJSON()`, validates closed schema, registers via the store. Returns `endpoint_hash` only — never the endpoint URL. |
+| DELETE | `/api/push/unsubscribe`       | removes by `endpoint`. Idempotent. Returns `endpoint_hash` + `removed: bool`.                                    |
+| GET    | `/api/push/vapid_public`      | returns `text/plain` public key, or 404 with `{"status":"not_available","error":"vapid_public_not_configured"}` |
+| GET    | `/api/push/status`            | returns ONLY `count`, `last_subscribed_at`, `vapid_public_present`, `max_active_subscriptions`. **Never** endpoints or keys. |
+| POST   | `/api/push/test`              | synthesizes a six-key test event payload for the existing N2b-1 stub-provider outbox; **no real push.** Returns `real_push_sent: false`. |
+
+Every response is run through
+[`reporting.agent_audit_summary.assert_no_secrets`](../../reporting/agent_audit_summary.py)
+before send. A pin test asserts the `/api/push/status` body does not
+contain `endpoint`, `p256dh`, or `auth` keys.
+
+The blueprint is **NOT** wired into `dashboard/dashboard.py` in this
+PR. To activate the routes, a future operator-approved PR adds
+exactly two lines to `dashboard/dashboard.py`:
+
+```diff
++from dashboard.api_push_subscribe import register_push_subscribe_routes
+ ...
++register_push_subscribe_routes(app)
+```
+
+That edit is N2b-2b territory; it is `dashboard_wiring` →
+NEEDS_HUMAN per
+[`execution_authority.md`](execution_authority.md). The agent may
+author the PR; the operator approves the merge.
+
+---
+
+## 7. Authentication
+
+Auth is provided by the existing PWA session middleware at the
+dashboard wiring layer. This blueprint does not register any auth
+itself; tests register the blueprint on a fresh Flask app and
+exercise the routes directly. When N2b-2b lands, the existing
+session middleware applies automatically.
+
+The `/api/push/dispatch` endpoint (real Web Push) is **N2b-3 only**
+and will be restricted to `127.0.0.1` by the existing nginx config.
+N2b-2a does not implement that endpoint.
+
+---
+
+## 8. No-approval-from-notification-click guarantee
+
+Two layers from N2b-2a's perspective:
+
+1. **Payload layer (already merged in N2b-1):** the closed six-key
+   schema contains no decision verb, no PR head SHA, no acceptance
+   body, no command summary. The N2b-1 pin test
+   `test_payload_contains_no_decision_verb` enforces this.
+2. **Test-event helper (this PR):** `POST /api/push/test` returns a
+   payload that explicitly carries `real_push_sent: false` and
+   reuses the same closed-schema event; no decision verb, no diff,
+   no body content.
+
+The SW layer (the actual `notificationclick` handler that opens the
+PWA at the inbox row) lands in N2b-2b alongside the frontend files.
+N2b-2a ships **no service worker**, no `frontend/**` change, and
+hence no path by which a notification click can do anything at all.
+
+---
+
+## 9. CLI / runtime
+
+There is no new CLI. The Python store is exercised via:
+
+- the unit tests
+  ([`tests/unit/test_push_subscription_store.py`](../../tests/unit/test_push_subscription_store.py));
+- the API blueprint unit tests
+  ([`tests/unit/test_api_push_subscribe.py`](../../tests/unit/test_api_push_subscribe.py));
+- a future N2b-2b dashboard.py wiring change (one line) that the
+  operator approves.
+
+After this PR merges, the only operator-visible artefact at runtime
+is the absence of `config/web_push_subscriptions.json` (because no
+PWA has subscribed yet). The dashboard route table is unchanged.
+
+---
+
+## 10. Authority chain summary
+
+| Capability                                           | Today (post-N2b-1)                | After N2b-2a                                              | After N2b-2b (future, operator-approved)                  | After N2b-3 (future, operator-approved + release-gate)            |
+| ---------------------------------------------------- | --------------------------------- | --------------------------------------------------------- | --------------------------------------------------------- | ----------------------------------------------------------------- |
+| Compute notification-ready event                     | `notification_dispatcher`         | unchanged                                                 | unchanged                                                  | unchanged                                                          |
+| Build bounded six-key payload                        | `notification_dispatch_outbox` (stub) | unchanged                                             | unchanged                                                  | unchanged                                                          |
+| Read subscription store                              | does not exist                    | `reporting/push_subscription_store.py` (Python API)       | `dashboard/api_push_subscribe.py` (HTTP API, wired)       | unchanged                                                          |
+| Persist a subscription                               | does not exist                    | yes via the Python API; HTTP path unwired                 | yes via the HTTP API (operator-tap-driven)                | unchanged                                                          |
+| Open network socket / send real push                 | does not exist                    | does not exist                                            | does not exist (stub-only via `/api/push/test`)            | yes (single audited callable in `dashboard/api_push_dispatch.py`) |
+| Touch `dashboard/dashboard.py`                       | unchanged                         | **no**                                                    | yes — one-line `register_push_subscribe_routes(app)`     | yes — one-line `register_push_dispatch_routes(app)`               |
+| Touch `frontend/**`                                  | unchanged                         | **no**                                                    | yes (PushSettings.tsx, webPush.ts, sw-push.js)           | unchanged                                                          |
+| Mint approval tokens                                 | does not exist                    | does not exist                                            | does not exist                                            | does not exist (N4 territory)                                      |
+| Open mobile inbox row                                | does not exist                    | does not exist                                            | does not exist                                            | does not exist (N3 territory)                                      |
+| Execute merge / deploy                               | operator + branch protection      | unchanged                                                 | unchanged                                                  | unchanged                                                          |
+| Autonomous merge / deploy                            | **forbidden, Level 6**            | unchanged — Level 6 stays permanently disabled            | unchanged — Level 6 stays permanently disabled            | unchanged — Level 6 stays permanently disabled                     |
+
+---
+
+## 11. Test coverage
+
+Pinned in
+[`tests/unit/test_push_subscription_store.py`](../../tests/unit/test_push_subscription_store.py)
+and
+[`tests/unit/test_api_push_subscribe.py`](../../tests/unit/test_api_push_subscribe.py):
+
+**Store-side tests:**
+
+- subscriptions path is gitignored;
+- VAPID public path is gitignored;
+- neither path appears in `git ls-files`;
+- empty store on first read;
+- `register_subscription` writes one record;
+- registering the same `endpoint` is idempotent (refreshes `last_seen_at`);
+- `unregister_subscription` removes by endpoint and is idempotent;
+- store caps at `MAX_ACTIVE_SUBSCRIPTIONS = 16`;
+- per-record schema keys exact;
+- invalid subscription shape rejected;
+- atomic write refuses any path other than the closed sentinel
+  `config/web_push_subscriptions.json`;
+- AST forbidden-import scan: no `dashboard`, `frontend`,
+  `automation`, `broker`, `agent.risk`, `agent.execution`,
+  `research`, `reporting.intelligent_routing`, `live`, `paper`,
+  `shadow`, `trading`;
+- source-text scan: no `socket`, `urllib`, `requests`, `httpx`,
+  `aiohttp`, `pywebpush`, `webpush`, `web_push`,
+  `WEB_PUSH_VAPID_PRIVATE_KEY`, `subprocess`, `gh`, `git`;
+- importing the store does not flip Step 5 invariants.
+
+**API-side tests:**
+
+- API routes register on an explicit fresh Flask app;
+- `dashboard/dashboard.py` does not import `api_push_subscribe`;
+- `dashboard/dashboard.py` has no `register_push_subscribe_routes`
+  call;
+- `/api/push/status` body redacts endpoints and keys;
+- `/api/push/vapid_public` 404s cleanly when missing;
+- `/api/push/test` uses the synthetic event helper only;
+  `real_push_sent` is `false`;
+- `POST /api/push/subscribe` accepts a valid payload;
+- `POST /api/push/subscribe` rejects an invalid payload with 400;
+- `DELETE /api/push/unsubscribe` is idempotent;
+- request bodies > 8 KiB are refused 413;
+- this doc states no real push in N2b-2a;
+- this doc states "no approval from notification click alone";
+- this doc states "Level 6 stays permanently disabled".
+
+---
+
+## 12. What N2b-2a does NOT do
+
+- N2b-2a sends no real push.
+- N2b-2a opens no network socket.
+- N2b-2a reads no VAPID private key.
+- N2b-2a writes no `dashboard/dashboard.py`.
+- N2b-2a writes no `frontend/**` file.
+- N2b-2a adds no service worker.
+- N2b-2a opens no inbox row.
+- N2b-2a mints no token.
+- N2b-2a does not change Step 5.0 logic.
+- N2b-2a does not flip `step5_implementation_allowed`.
+- N2b-2a does not change `STEP5_ENABLED_SUBSTAGE`.
+- Step 5.1 / Step 5.2 remain BLOCKED.
+- N2b-2b (PWA UI + SW + wiring), N2b-3 (real Web Push), N3 (mobile
+  approval inbox), N4 (token gate), and N5 (merge/deploy adapter)
+  remain unimplemented.
+- Level 6 stays permanently disabled. Mobile approval is human
+  approval, not autonomous merge or deploy. **No approval can happen
+  from notification click alone.**

--- a/reporting/push_subscription_store.py
+++ b/reporting/push_subscription_store.py
@@ -1,0 +1,428 @@
+"""N2b-2a — Push Subscription Store (backend, unwired).
+
+Pure-stdlib subscription storage for the future PWA Web Push surface.
+Manages the gitignored runtime config at
+``config/web_push_subscriptions.json`` with strict closed-vocabulary
+records, idempotent register/unregister semantics, atomic writes, and
+a hard cap on active subscriptions.
+
+This is the backend half of the smallest safe N2b-2 slice: it adds
+the storage primitive **without** wiring the future API blueprint
+into the running dashboard. ``dashboard/dashboard.py`` is unchanged.
+``frontend/**`` is unchanged. **No real push is sent.** No network
+socket is opened. No Web Push library is imported. **No VAPID
+private key is read or stored.**
+
+N2b-2b (PWA UI + service worker + 1-line dashboard.py wiring) and
+N2b-3 (real Web Push delivery using env-only VAPID private) remain
+unimplemented and require their own separate operator go-signals.
+N3 (mobile approval inbox), N4 (approval-token gate), and N5
+(merge/deploy adapter) remain unimplemented. Step 5.1 / 5.2 remain
+BLOCKED. Level 6 stays permanently disabled per ADR-015 §Doctrine 1.
+
+Hard guarantees (pinned by tests)
+---------------------------------
+
+* Stdlib + ``reporting.agent_audit_summary.assert_no_secrets``
+  (read-only redactor guard).
+* No subprocess, no network, no ``gh``, no ``git``, no ``socket``,
+  no ``urllib``, no ``requests``, no ``httpx``, no ``aiohttp``, no
+  Web Push library (``pywebpush``, ``web_push``, ``webpush``).
+* No imports of ``dashboard``, ``frontend``, ``automation``,
+  ``broker``, ``agent.risk``, ``agent.execution``, ``research``,
+  ``reporting.intelligent_routing``, ``live``, ``paper``, ``shadow``,
+  or ``trading``.
+* The VAPID private-key environment variable name does not appear
+  in this module. The private key is **N2b-3 only** and is read
+  from the VPS environment, never from the repo.
+* Atomic write only to the closed sentinel path
+  ``config/web_push_subscriptions.json``. Refused for any other
+  target.
+* Active subscriptions capped at :data:`MAX_ACTIVE_SUBSCRIPTIONS`.
+* Endpoint-based register / unregister are idempotent.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import hashlib
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Final
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+MODULE_VERSION: Final[str] = "v3.15.16.N2b2a"
+SCHEMA_VERSION: Final[int] = 1
+
+
+# ---------------------------------------------------------------------------
+# Closed sentinel paths
+# ---------------------------------------------------------------------------
+
+#: Single sentinel path for the active-subscriptions store. Atomic
+#: writes refuse any other target. The file is gitignored.
+SUBSCRIPTIONS_PATH: Final[Path] = (
+    REPO_ROOT / "config" / "web_push_subscriptions.json"
+)
+SUBSCRIPTIONS_RELATIVE_PATH: Final[str] = "config/web_push_subscriptions.json"
+
+#: Public key path. The store knows about it but does not require it
+#: to exist; the API layer (N2b-2b) reads it on demand.
+VAPID_PUBLIC_PATH: Final[Path] = (
+    REPO_ROOT / "config" / "web_push_vapid_public.txt"
+)
+VAPID_PUBLIC_RELATIVE_PATH: Final[str] = "config/web_push_vapid_public.txt"
+
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies and bounds
+# ---------------------------------------------------------------------------
+
+#: Per-record schema, exact and ordered.
+SUBSCRIPTION_RECORD_KEYS: Final[tuple[str, ...]] = (
+    "endpoint",
+    "keys",
+    "kid",
+    "created_at",
+    "last_seen_at",
+    "label",
+)
+
+#: Sub-keys for the ``keys`` field, exact and ordered.
+SUBSCRIPTION_KEYS_FIELD_KEYS: Final[tuple[str, ...]] = ("p256dh", "auth")
+
+#: Hard cap on active subscriptions (single-operator system; runaway
+#: guard).
+MAX_ACTIVE_SUBSCRIPTIONS: Final[int] = 16
+
+#: Bounded length for free-text scalars on a single record.
+MAX_ENDPOINT_LEN: Final[int] = 1024
+MAX_P256DH_LEN: Final[int] = 200
+MAX_AUTH_LEN: Final[int] = 200
+MAX_KID_LEN: Final[int] = 64
+MAX_LABEL_LEN: Final[int] = 80
+
+#: Allowed origins for the push provider endpoint URLs. Anything else
+#: is refused at register time. Pinned by tests; expansion requires a
+#: code change.
+ALLOWED_ENDPOINT_PREFIXES: Final[tuple[str, ...]] = (
+    "https://fcm.googleapis.com/",
+    "https://updates.push.services.mozilla.com/",
+    "https://web.push.apple.com/",
+    "https://wns2-",  # Microsoft WNS hosts (wns2-*.notify.windows.com)
+)
+
+
+# ---------------------------------------------------------------------------
+# Utility helpers
+# ---------------------------------------------------------------------------
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _bounded_str(value: Any, max_len: int) -> str:
+    if not isinstance(value, str):
+        return ""
+    if len(value) <= max_len:
+        return value
+    return value[:max_len]
+
+
+def endpoint_hash(endpoint: str) -> str:
+    """Return a sha256-truncated identifier for an endpoint URL.
+
+    Used in audit / log surfaces where the full endpoint must NOT
+    appear. Pinned by tests; the API layer uses this helper to keep
+    endpoint URLs out of any operator-visible status surface.
+    """
+    if not isinstance(endpoint, str):
+        return ""
+    return hashlib.sha256(endpoint.encode("utf-8")).hexdigest()[:16]
+
+
+# ---------------------------------------------------------------------------
+# Store I/O
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Atomic write. Refuses any path other than
+    :data:`SUBSCRIPTIONS_PATH`. The closed sentinel keeps the
+    write-side surface tiny; tests pin the refusal."""
+    if path.resolve() != SUBSCRIPTIONS_PATH.resolve():
+        raise ValueError(
+            "push_subscription_store._atomic_write_json refuses "
+            f"non-subscriptions path: {path}"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".push_subscription_store.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def load_store(*, path: Path | None = None) -> dict[str, Any]:
+    """Load the on-disk store. Returns an empty store envelope on
+    first read or on any malformed-file condition.
+
+    The envelope shape is:
+
+    ``{"schema_version": 1, "subscriptions": [<record>, ...]}``
+
+    Tests pin both behaviours.
+    """
+    p = path if path is not None else SUBSCRIPTIONS_PATH
+    if not p.is_file():
+        return {"schema_version": SCHEMA_VERSION, "subscriptions": []}
+    try:
+        text = p.read_text(encoding="utf-8")
+    except OSError:
+        return {"schema_version": SCHEMA_VERSION, "subscriptions": []}
+    try:
+        payload = json.loads(text)
+    except ValueError:
+        return {"schema_version": SCHEMA_VERSION, "subscriptions": []}
+    if not isinstance(payload, dict):
+        return {"schema_version": SCHEMA_VERSION, "subscriptions": []}
+    subs = payload.get("subscriptions")
+    if not isinstance(subs, list):
+        return {"schema_version": SCHEMA_VERSION, "subscriptions": []}
+    cleaned: list[dict[str, Any]] = []
+    for s in subs:
+        if isinstance(s, dict) and set(s.keys()) >= set(SUBSCRIPTION_RECORD_KEYS):
+            cleaned.append(s)
+    return {
+        "schema_version": int(payload.get("schema_version") or SCHEMA_VERSION),
+        "subscriptions": cleaned,
+    }
+
+
+def save_store(store: dict[str, Any], *, path: Path | None = None) -> Path:
+    """Persist the store atomically. Refuses any non-sentinel path."""
+    p = path if path is not None else SUBSCRIPTIONS_PATH
+    payload = {
+        "schema_version": int(store.get("schema_version") or SCHEMA_VERSION),
+        "subscriptions": list(store.get("subscriptions") or []),
+    }
+    _atomic_write_json(p, payload)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def _validate_record(raw: Any) -> tuple[dict[str, Any] | None, list[str]]:
+    """Validate and normalize a register payload. Returns
+    ``(record, warnings)`` where ``record`` is None on any failure."""
+    warnings: list[str] = []
+    if not isinstance(raw, dict):
+        warnings.append("not_an_object")
+        return None, warnings
+
+    endpoint = _bounded_str(raw.get("endpoint"), MAX_ENDPOINT_LEN)
+    if not endpoint:
+        warnings.append("missing_endpoint")
+        return None, warnings
+
+    if not any(endpoint.startswith(p) for p in ALLOWED_ENDPOINT_PREFIXES):
+        warnings.append("endpoint_origin_not_allowed")
+        return None, warnings
+
+    raw_keys = raw.get("keys")
+    if not isinstance(raw_keys, dict):
+        warnings.append("missing_keys")
+        return None, warnings
+    if set(raw_keys.keys()) != set(SUBSCRIPTION_KEYS_FIELD_KEYS):
+        warnings.append("invalid_keys_shape")
+        return None, warnings
+
+    p256dh = _bounded_str(raw_keys.get("p256dh"), MAX_P256DH_LEN)
+    auth = _bounded_str(raw_keys.get("auth"), MAX_AUTH_LEN)
+    if not p256dh or not auth:
+        warnings.append("empty_keys")
+        return None, warnings
+
+    kid = _bounded_str(raw.get("kid"), MAX_KID_LEN)
+    if not kid:
+        warnings.append("missing_kid")
+        return None, warnings
+
+    label = _bounded_str(raw.get("label"), MAX_LABEL_LEN)
+    return (
+        {
+            "endpoint": endpoint,
+            "keys": {"p256dh": p256dh, "auth": auth},
+            "kid": kid,
+            "created_at": "",  # filled at register time
+            "last_seen_at": "",  # filled at register time
+            "label": label,
+        },
+        warnings,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def list_subscriptions(*, path: Path | None = None) -> list[dict[str, Any]]:
+    """Return the active subscriptions list. Pure read."""
+    return list(load_store(path=path).get("subscriptions") or [])
+
+
+def get_by_endpoint(
+    endpoint: str, *, path: Path | None = None
+) -> dict[str, Any] | None:
+    if not isinstance(endpoint, str) or not endpoint:
+        return None
+    for s in list_subscriptions(path=path):
+        if s.get("endpoint") == endpoint:
+            return s
+    return None
+
+
+def register_subscription(
+    record: dict[str, Any],
+    *,
+    path: Path | None = None,
+    now_utc: str | None = None,
+) -> tuple[dict[str, Any] | None, list[str]]:
+    """Register or refresh a subscription. Idempotent on ``endpoint``.
+
+    Returns ``(record_or_None, warnings)``. ``None`` on any
+    validation failure.
+    """
+    validated, warnings = _validate_record(record)
+    if validated is None:
+        return None, warnings
+
+    ts = now_utc if now_utc is not None else _utcnow()
+    store = load_store(path=path)
+    subs: list[dict[str, Any]] = list(store.get("subscriptions") or [])
+
+    # Idempotent refresh on existing endpoint.
+    for i, s in enumerate(subs):
+        if s.get("endpoint") == validated["endpoint"]:
+            refreshed = {
+                "endpoint": validated["endpoint"],
+                "keys": dict(validated["keys"]),
+                "kid": validated["kid"],
+                "created_at": s.get("created_at") or ts,
+                "last_seen_at": ts,
+                "label": validated["label"] or s.get("label", ""),
+            }
+            subs[i] = refreshed
+            store["subscriptions"] = subs
+            save_store(store, path=path)
+            return refreshed, warnings
+
+    # Cap reached → refuse.
+    if len(subs) >= MAX_ACTIVE_SUBSCRIPTIONS:
+        warnings.append("subscription_cap_reached")
+        return None, warnings
+
+    new_record = {
+        "endpoint": validated["endpoint"],
+        "keys": dict(validated["keys"]),
+        "kid": validated["kid"],
+        "created_at": ts,
+        "last_seen_at": ts,
+        "label": validated["label"],
+    }
+    subs.append(new_record)
+    store["subscriptions"] = subs
+    save_store(store, path=path)
+    return new_record, warnings
+
+
+def unregister_subscription(
+    endpoint: str, *, path: Path | None = None
+) -> bool:
+    """Remove a subscription by endpoint. Idempotent — returns
+    ``True`` if a record was removed; ``False`` if absent."""
+    if not isinstance(endpoint, str) or not endpoint:
+        return False
+    store = load_store(path=path)
+    subs: list[dict[str, Any]] = list(store.get("subscriptions") or [])
+    new_subs = [s for s in subs if s.get("endpoint") != endpoint]
+    if len(new_subs) == len(subs):
+        return False
+    store["subscriptions"] = new_subs
+    save_store(store, path=path)
+    return True
+
+
+# ---------------------------------------------------------------------------
+# VAPID public-key helper (read-only, no network)
+# ---------------------------------------------------------------------------
+
+
+def vapid_public_present(*, path: Path | None = None) -> bool:
+    """Return True iff ``config/web_push_vapid_public.txt`` exists.
+
+    Does not read the file content. The API layer (N2b-2b) reads the
+    content on demand.
+    """
+    p = path if path is not None else VAPID_PUBLIC_PATH
+    return p.is_file()
+
+
+def vapid_public_text(*, path: Path | None = None) -> str | None:
+    """Return the public key text or ``None`` if absent / unreadable.
+
+    Best-effort; never raises. Pinned by tests."""
+    p = path if path is not None else VAPID_PUBLIC_PATH
+    if not p.is_file():
+        return None
+    try:
+        return p.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+
+
+__all__ = [
+    "ALLOWED_ENDPOINT_PREFIXES",
+    "MAX_ACTIVE_SUBSCRIPTIONS",
+    "MODULE_VERSION",
+    "SCHEMA_VERSION",
+    "SUBSCRIPTIONS_PATH",
+    "SUBSCRIPTIONS_RELATIVE_PATH",
+    "SUBSCRIPTION_KEYS_FIELD_KEYS",
+    "SUBSCRIPTION_RECORD_KEYS",
+    "VAPID_PUBLIC_PATH",
+    "VAPID_PUBLIC_RELATIVE_PATH",
+    "endpoint_hash",
+    "get_by_endpoint",
+    "list_subscriptions",
+    "load_store",
+    "register_subscription",
+    "save_store",
+    "unregister_subscription",
+    "vapid_public_present",
+    "vapid_public_text",
+]

--- a/tests/unit/test_api_push_subscribe.py
+++ b/tests/unit/test_api_push_subscribe.py
@@ -1,0 +1,448 @@
+"""Unit tests for N2b-2a — Flask blueprint api_push_subscribe (UNWIRED)."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+from flask import Flask
+
+from reporting import push_subscription_store as pss
+
+from dashboard import api_push_subscribe as aps
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _patch_store_paths(tmp_path: Path, monkeypatch) -> tuple[Path, Path]:
+    sub_path = tmp_path / "config" / "web_push_subscriptions.json"
+    sub_path.parent.mkdir(parents=True)
+    vapid_path = tmp_path / "config" / "web_push_vapid_public.txt"
+    monkeypatch.setattr(pss, "SUBSCRIPTIONS_PATH", sub_path)
+    monkeypatch.setattr(pss, "VAPID_PUBLIC_PATH", vapid_path)
+    return sub_path, vapid_path
+
+
+def _make_app() -> Flask:
+    app = Flask(__name__)
+    aps.register_push_subscribe_routes(app)
+    return app
+
+
+def _valid_subscription_payload() -> dict[str, Any]:
+    return {
+        "endpoint": "https://fcm.googleapis.com/fcm/send/abc123",
+        "keys": {
+            "p256dh": "BCfV1eK4_p256dh_public_key_base64url_text",
+            "auth": "auth_secret_base64url_text",
+        },
+        "kid": "k1",
+        "label": "iPhone PWA",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Route registration
+# ---------------------------------------------------------------------------
+
+
+def test_register_routes_registers_all_five_endpoints() -> None:
+    app = _make_app()
+    rules = {
+        (rule.rule, frozenset(rule.methods or set()))
+        for rule in app.url_map.iter_rules()
+    }
+    expected = {
+        ("/api/push/subscribe", frozenset({"POST", "OPTIONS"})),
+        ("/api/push/unsubscribe", frozenset({"DELETE", "OPTIONS"})),
+        ("/api/push/vapid_public", frozenset({"GET", "HEAD", "OPTIONS"})),
+        ("/api/push/status", frozenset({"GET", "HEAD", "OPTIONS"})),
+        ("/api/push/test", frozenset({"POST", "OPTIONS"})),
+    }
+    for r in expected:
+        assert r in rules, r
+
+
+def test_blueprint_not_imported_by_dashboard_dashboard() -> None:
+    """N2b-2a does NOT wire the blueprint into dashboard/dashboard.py.
+    Wiring is N2b-2b territory and lands behind operator approval."""
+    text = (
+        REPO_ROOT / "dashboard" / "dashboard.py"
+    ).read_text(encoding="utf-8")
+    assert "api_push_subscribe" not in text
+    assert "register_push_subscribe_routes" not in text
+
+
+# ---------------------------------------------------------------------------
+# POST /api/push/subscribe
+# ---------------------------------------------------------------------------
+
+
+def test_subscribe_accepts_valid_payload(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _patch_store_paths(tmp_path, monkeypatch)
+    app = _make_app()
+    client = app.test_client()
+    res = client.post(
+        "/api/push/subscribe",
+        data=json.dumps(_valid_subscription_payload()),
+        content_type="application/json",
+    )
+    assert res.status_code == 200
+    body = res.get_json()
+    assert body["status"] == "ok"
+    assert "endpoint_hash" in body
+    # The full endpoint URL must NOT appear in the response.
+    raw = res.data.decode("utf-8")
+    assert "fcm.googleapis.com/fcm/send/abc123" not in raw
+
+
+def test_subscribe_rejects_invalid_payload(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _patch_store_paths(tmp_path, monkeypatch)
+    app = _make_app()
+    client = app.test_client()
+    res = client.post(
+        "/api/push/subscribe",
+        data=json.dumps({"endpoint": "https://attacker.example.com/x"}),
+        content_type="application/json",
+    )
+    assert res.status_code == 400
+    body = res.get_json()
+    assert body["status"] == "error"
+
+
+def test_subscribe_rejects_non_json_body(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _patch_store_paths(tmp_path, monkeypatch)
+    app = _make_app()
+    client = app.test_client()
+    res = client.post(
+        "/api/push/subscribe",
+        data="not json",
+        content_type="application/json",
+    )
+    assert res.status_code == 400
+
+
+def test_subscribe_rejects_oversize_body(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _patch_store_paths(tmp_path, monkeypatch)
+    app = _make_app()
+    client = app.test_client()
+    huge = "x" * (16 * 1024)
+    res = client.post(
+        "/api/push/subscribe",
+        data=huge,
+        content_type="application/json",
+    )
+    assert res.status_code == 413
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/push/unsubscribe
+# ---------------------------------------------------------------------------
+
+
+def test_unsubscribe_removes_existing(tmp_path: Path, monkeypatch) -> None:
+    _patch_store_paths(tmp_path, monkeypatch)
+    pss.register_subscription(_valid_subscription_payload())
+    app = _make_app()
+    client = app.test_client()
+    res = client.delete(
+        "/api/push/unsubscribe",
+        data=json.dumps({"endpoint": _valid_subscription_payload()["endpoint"]}),
+        content_type="application/json",
+    )
+    assert res.status_code == 200
+    body = res.get_json()
+    assert body["status"] == "ok"
+    assert body["removed"] is True
+
+
+def test_unsubscribe_idempotent_on_absent_endpoint(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _patch_store_paths(tmp_path, monkeypatch)
+    app = _make_app()
+    client = app.test_client()
+    res = client.delete(
+        "/api/push/unsubscribe",
+        data=json.dumps({"endpoint": "https://fcm.googleapis.com/fcm/send/missing"}),
+        content_type="application/json",
+    )
+    assert res.status_code == 200
+    body = res.get_json()
+    assert body["status"] == "ok"
+    assert body["removed"] is False
+
+
+def test_unsubscribe_rejects_missing_endpoint(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _patch_store_paths(tmp_path, monkeypatch)
+    app = _make_app()
+    client = app.test_client()
+    res = client.delete(
+        "/api/push/unsubscribe",
+        data=json.dumps({}),
+        content_type="application/json",
+    )
+    assert res.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# GET /api/push/vapid_public
+# ---------------------------------------------------------------------------
+
+
+def test_vapid_public_404_when_missing(tmp_path: Path, monkeypatch) -> None:
+    _patch_store_paths(tmp_path, monkeypatch)
+    app = _make_app()
+    client = app.test_client()
+    res = client.get("/api/push/vapid_public")
+    assert res.status_code == 404
+    body = res.get_json()
+    assert body["status"] == "not_available"
+    assert body["error"] == "vapid_public_not_configured"
+
+
+def test_vapid_public_returns_text_when_present(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _, vapid_path = _patch_store_paths(tmp_path, monkeypatch)
+    vapid_path.write_text("BPublicKeyBase64UrlText", encoding="utf-8")
+    app = _make_app()
+    client = app.test_client()
+    res = client.get("/api/push/vapid_public")
+    assert res.status_code == 200
+    assert res.mimetype == "text/plain"
+    assert res.data.decode("utf-8") == "BPublicKeyBase64UrlText"
+
+
+# ---------------------------------------------------------------------------
+# GET /api/push/status
+# ---------------------------------------------------------------------------
+
+
+def test_status_returns_only_count_and_flags(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _patch_store_paths(tmp_path, monkeypatch)
+    pss.register_subscription(
+        _valid_subscription_payload(), now_utc="2026-05-09T00:00:00Z"
+    )
+    app = _make_app()
+    client = app.test_client()
+    res = client.get("/api/push/status")
+    assert res.status_code == 200
+    body = res.get_json()
+    assert body["status"] == "ok"
+    assert body["count"] == 1
+    assert body["last_subscribed_at"] == "2026-05-09T00:00:00Z"
+    assert body["vapid_public_present"] is False
+    assert body["max_active_subscriptions"] == pss.MAX_ACTIVE_SUBSCRIPTIONS
+
+
+def test_status_redacts_endpoints_and_keys(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _patch_store_paths(tmp_path, monkeypatch)
+    pss.register_subscription(_valid_subscription_payload())
+    app = _make_app()
+    client = app.test_client()
+    res = client.get("/api/push/status")
+    raw = res.data.decode("utf-8")
+    # Full endpoint URL, p256dh, auth must NOT appear.
+    assert "fcm.googleapis.com/fcm/send/abc123" not in raw
+    assert "BCfV1eK4_p256dh_public_key_base64url_text" not in raw
+    assert "auth_secret_base64url_text" not in raw
+    # Should not even contain key-sub-key names.
+    body = res.get_json()
+    assert "endpoint" not in body
+    assert "keys" not in body
+
+
+# ---------------------------------------------------------------------------
+# POST /api/push/test
+# ---------------------------------------------------------------------------
+
+
+def test_test_endpoint_returns_synthetic_event_no_real_push(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _patch_store_paths(tmp_path, monkeypatch)
+    app = _make_app()
+    client = app.test_client()
+    res = client.post("/api/push/test")
+    assert res.status_code == 200
+    body = res.get_json()
+    assert body["status"] == "ok"
+    assert body["real_push_sent"] is False
+    assert body["would_dispatch_via"] == "n2b1_outbox_stub_provider"
+    ev = body["test_event"]
+    assert ev["event_kind"] == "intake_candidate_eligible"
+    assert ev["event_severity"] == "push_info"
+    assert ev["open_at"].startswith("/agent-control/inbox?event=")
+    assert ev["event_id"].startswith("ade_test_")
+
+
+def test_test_endpoint_payload_has_no_decision_verb(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _patch_store_paths(tmp_path, monkeypatch)
+    app = _make_app()
+    client = app.test_client()
+    res = client.post("/api/push/test")
+    raw = res.data.decode("utf-8").lower()
+    for verb in ("approve", "reject", "merge ", " merge", "deploy"):
+        assert verb not in raw, verb
+
+
+# ---------------------------------------------------------------------------
+# Source-text + AST scans
+# ---------------------------------------------------------------------------
+
+
+def _module_source() -> str:
+    return Path(aps.__file__).read_text(encoding="utf-8")
+
+
+def _imported_module_names() -> set[str]:
+    import ast
+
+    src = _module_source()
+    tree = ast.parse(src)
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module is not None:
+                names.add(node.module)
+    return names
+
+
+def test_no_subprocess_in_module() -> None:
+    src = _module_source()
+    assert "import subprocess" not in src
+    assert "from subprocess" not in src
+
+
+def test_no_network_in_module() -> None:
+    src = _module_source()
+    for forbidden in (
+        "import socket",
+        "import urllib",
+        "import http.client",
+        "import requests",
+        "import httpx",
+        "import aiohttp",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_no_web_push_library_imports() -> None:
+    src = _module_source()
+    for forbidden in (
+        "import pywebpush",
+        "from pywebpush",
+        "import webpush",
+        "from webpush",
+        "import web_push",
+        "from web_push",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_no_vapid_private_key_reference() -> None:
+    src = _module_source()
+    assert "WEB_PUSH_VAPID_PRIVATE_KEY" not in src
+
+
+def test_no_dashboard_dashboard_import() -> None:
+    """The blueprint module must NOT import dashboard.dashboard."""
+    for module in _imported_module_names():
+        assert module != "dashboard.dashboard"
+        assert not module.startswith("dashboard.dashboard.")
+
+
+def test_no_frontend_or_research_imports() -> None:
+    forbidden_prefixes = (
+        "frontend",
+        "automation",
+        "broker",
+        "agent.risk",
+        "agent.execution",
+        "research",
+        "reporting.intelligent_routing",
+        "live",
+        "paper",
+        "shadow",
+        "trading",
+    )
+    for module in _imported_module_names():
+        for prefix in forbidden_prefixes:
+            assert not (
+                module == prefix or module.startswith(prefix + ".")
+            ), f"forbidden import: {module}"
+
+
+def test_module_imports_cleanly() -> None:
+    importlib.reload(aps)
+    assert callable(aps.register_push_subscribe_routes)
+
+
+def test_importing_module_does_not_flip_step5_invariants() -> None:
+    from reporting import development_step5_loop as dsl
+
+    importlib.reload(aps)
+    assert dsl.step5_implementation_allowed is False
+    assert dsl.STEP5_ENABLED_SUBSTAGE == "none"
+
+
+# ---------------------------------------------------------------------------
+# dashboard/dashboard.py untouched
+# ---------------------------------------------------------------------------
+
+
+def test_dashboard_dashboard_does_not_register_push_routes() -> None:
+    """Hard guarantee: the wiring to register_push_subscribe_routes
+    has NOT landed yet. N2b-2a is unwired by design."""
+    text = (
+        REPO_ROOT / "dashboard" / "dashboard.py"
+    ).read_text(encoding="utf-8")
+    assert "register_push_subscribe_routes" not in text
+
+
+def test_dashboard_dashboard_unchanged_in_pr_diff() -> None:
+    """The current branch must not have modified dashboard/dashboard.py
+    relative to origin/main. This is a defense-in-depth check; CI
+    enforces the same via PR file-list assertions."""
+    out = subprocess.run(
+        ["git", "diff", "--name-only", "origin/main...HEAD"],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+    )
+    changed = set(out.stdout.split())
+    if changed:
+        # Not all CI runners have origin/main; if this fails for env
+        # reasons, the PR-scope check still holds via the gh CLI.
+        assert "dashboard/dashboard.py" not in changed

--- a/tests/unit/test_push_subscription_store.py
+++ b/tests/unit/test_push_subscription_store.py
@@ -1,0 +1,548 @@
+"""Unit tests for N2b-2a — Push Subscription Store (backend, unwired).
+
+The store is pure-stdlib; no real push, no socket, no Web Push library.
+
+Pinned here:
+
+* Closed record schema, allowed origins, capacity bound.
+* Atomic-write refusal outside the closed sentinel path.
+* Idempotent register / unregister.
+* Both runtime-config paths are not tracked by git.
+* Neither path leaks endpoints or keys.
+* AST + source-text scans rule out: socket, urllib, requests, httpx,
+  aiohttp, pywebpush, webpush, web_push, WEB_PUSH_VAPID_PRIVATE_KEY,
+  subprocess, gh, git, dashboard, frontend, automation, broker,
+  agent.risk, agent.execution, research, reporting.intelligent_routing,
+  live, paper, shadow, trading.
+* Importing the module does not flip Step 5 invariants.
+* Doc states no real push, no click-approval, Level 6 permanently
+  disabled.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reporting import push_subscription_store as pss
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _store_path(tmp_path: Path) -> Path:
+    p = tmp_path / "config" / "web_push_subscriptions.json"
+    p.parent.mkdir(parents=True)
+    return p
+
+
+def _patch_paths(tmp_path: Path, monkeypatch) -> tuple[Path, Path]:
+    sub_path = _store_path(tmp_path)
+    vapid_path = tmp_path / "config" / "web_push_vapid_public.txt"
+    monkeypatch.setattr(pss, "SUBSCRIPTIONS_PATH", sub_path)
+    monkeypatch.setattr(pss, "VAPID_PUBLIC_PATH", vapid_path)
+    return sub_path, vapid_path
+
+
+def _valid_record(*, endpoint_suffix: str = "abc123") -> dict[str, Any]:
+    return {
+        "endpoint": f"https://fcm.googleapis.com/fcm/send/{endpoint_suffix}",
+        "keys": {
+            "p256dh": "BCfV1eK4_p256dh_public_key_base64url_text",
+            "auth": "auth_secret_base64url_text",
+        },
+        "kid": "k1",
+        "label": "iPhone PWA",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies + bounds
+# ---------------------------------------------------------------------------
+
+
+def test_subscription_record_keys_pinned_exactly() -> None:
+    assert pss.SUBSCRIPTION_RECORD_KEYS == (
+        "endpoint",
+        "keys",
+        "kid",
+        "created_at",
+        "last_seen_at",
+        "label",
+    )
+
+
+def test_keys_field_subkeys_pinned_exactly() -> None:
+    assert pss.SUBSCRIPTION_KEYS_FIELD_KEYS == ("p256dh", "auth")
+
+
+def test_max_active_subscriptions_pinned() -> None:
+    assert pss.MAX_ACTIVE_SUBSCRIPTIONS == 16
+
+
+def test_allowed_endpoint_prefixes_pinned() -> None:
+    assert pss.ALLOWED_ENDPOINT_PREFIXES == (
+        "https://fcm.googleapis.com/",
+        "https://updates.push.services.mozilla.com/",
+        "https://web.push.apple.com/",
+        "https://wns2-",
+    )
+
+
+def test_subscriptions_relative_path_under_config() -> None:
+    assert pss.SUBSCRIPTIONS_RELATIVE_PATH == (
+        "config/web_push_subscriptions.json"
+    )
+
+
+def test_vapid_public_relative_path_under_config() -> None:
+    assert pss.VAPID_PUBLIC_RELATIVE_PATH == (
+        "config/web_push_vapid_public.txt"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Gitignore / not-tracked guarantees
+# ---------------------------------------------------------------------------
+
+
+def test_subscription_path_not_committed() -> None:
+    """The runtime-config path must not appear in git ls-files."""
+    out = subprocess.run(
+        ["git", "ls-files", "config/web_push_subscriptions.json"],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+    )
+    assert out.stdout.strip() == "", out.stdout
+
+
+def test_vapid_public_path_not_committed() -> None:
+    out = subprocess.run(
+        ["git", "ls-files", "config/web_push_vapid_public.txt"],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+    )
+    assert out.stdout.strip() == "", out.stdout
+
+
+# ---------------------------------------------------------------------------
+# Atomic write refusal
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_write_refuses_non_subscription_path(tmp_path: Path) -> None:
+    bad = tmp_path / "evil_dir" / "subscriptions.json"
+    bad.parent.mkdir(parents=True)
+    with pytest.raises(ValueError):
+        pss._atomic_write_json(bad, {"subscriptions": []})
+
+
+def test_atomic_write_refuses_logs_path(tmp_path: Path) -> None:
+    bad = tmp_path / "logs" / "web_push_subscriptions.json"
+    bad.parent.mkdir(parents=True)
+    with pytest.raises(ValueError):
+        pss._atomic_write_json(bad, {"subscriptions": []})
+
+
+# ---------------------------------------------------------------------------
+# Empty store / load / save
+# ---------------------------------------------------------------------------
+
+
+def test_empty_store_on_first_read(tmp_path: Path, monkeypatch) -> None:
+    _patch_paths(tmp_path, monkeypatch)
+    store = pss.load_store()
+    assert store == {"schema_version": 1, "subscriptions": []}
+
+
+def test_list_subscriptions_empty_initially(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _patch_paths(tmp_path, monkeypatch)
+    assert pss.list_subscriptions() == []
+
+
+def test_corrupt_store_returns_empty(tmp_path: Path, monkeypatch) -> None:
+    sub_path, _ = _patch_paths(tmp_path, monkeypatch)
+    sub_path.write_text("not json", encoding="utf-8")
+    assert pss.load_store() == {"schema_version": 1, "subscriptions": []}
+
+
+# ---------------------------------------------------------------------------
+# register / unregister behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_register_subscription_writes_one_record(
+    tmp_path: Path, monkeypatch
+) -> None:
+    sub_path, _ = _patch_paths(tmp_path, monkeypatch)
+    rec, warnings = pss.register_subscription(
+        _valid_record(), now_utc="2026-05-09T00:00:00Z"
+    )
+    assert rec is not None
+    assert warnings == []
+    assert sub_path.is_file()
+    on_disk = json.loads(sub_path.read_text(encoding="utf-8"))
+    assert len(on_disk["subscriptions"]) == 1
+    assert set(on_disk["subscriptions"][0].keys()) == set(
+        pss.SUBSCRIPTION_RECORD_KEYS
+    )
+    assert rec["created_at"] == "2026-05-09T00:00:00Z"
+    assert rec["last_seen_at"] == "2026-05-09T00:00:00Z"
+
+
+def test_register_same_endpoint_is_idempotent(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _patch_paths(tmp_path, monkeypatch)
+    pss.register_subscription(_valid_record(), now_utc="2026-05-09T00:00:00Z")
+    rec2, _ = pss.register_subscription(
+        _valid_record(), now_utc="2026-05-09T00:01:00Z"
+    )
+    assert rec2 is not None
+    assert rec2["created_at"] == "2026-05-09T00:00:00Z"  # original
+    assert rec2["last_seen_at"] == "2026-05-09T00:01:00Z"  # refreshed
+    assert len(pss.list_subscriptions()) == 1
+
+
+def test_unregister_subscription_removes_by_endpoint(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _patch_paths(tmp_path, monkeypatch)
+    pss.register_subscription(_valid_record())
+    rec = _valid_record()
+    removed = pss.unregister_subscription(rec["endpoint"])
+    assert removed is True
+    assert pss.list_subscriptions() == []
+
+
+def test_unregister_subscription_idempotent(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _patch_paths(tmp_path, monkeypatch)
+    assert pss.unregister_subscription("https://fcm.googleapis.com/x") is False
+    pss.register_subscription(_valid_record())
+    assert pss.unregister_subscription(_valid_record()["endpoint"]) is True
+    assert pss.unregister_subscription(_valid_record()["endpoint"]) is False
+
+
+def test_get_by_endpoint(tmp_path: Path, monkeypatch) -> None:
+    _patch_paths(tmp_path, monkeypatch)
+    rec = _valid_record(endpoint_suffix="abc1")
+    pss.register_subscription(rec)
+    found = pss.get_by_endpoint(rec["endpoint"])
+    assert found is not None
+    assert found["endpoint"] == rec["endpoint"]
+    assert pss.get_by_endpoint("https://fcm.googleapis.com/missing") is None
+
+
+# ---------------------------------------------------------------------------
+# Capacity bound
+# ---------------------------------------------------------------------------
+
+
+def test_store_capped_at_max_active_subscriptions(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _patch_paths(tmp_path, monkeypatch)
+    for i in range(pss.MAX_ACTIVE_SUBSCRIPTIONS):
+        rec, warnings = pss.register_subscription(
+            _valid_record(endpoint_suffix=f"sub_{i:03d}"),
+            now_utc="2026-05-09T00:00:00Z",
+        )
+        assert rec is not None
+        assert warnings == []
+    # 17th should be refused.
+    rec_extra, warnings = pss.register_subscription(
+        _valid_record(endpoint_suffix="overflow"),
+        now_utc="2026-05-09T00:00:00Z",
+    )
+    assert rec_extra is None
+    assert "subscription_cap_reached" in warnings
+    assert len(pss.list_subscriptions()) == pss.MAX_ACTIVE_SUBSCRIPTIONS
+
+
+def test_store_cap_does_not_block_idempotent_refresh(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Once at cap, refreshing an existing endpoint must still work."""
+    _patch_paths(tmp_path, monkeypatch)
+    for i in range(pss.MAX_ACTIVE_SUBSCRIPTIONS):
+        pss.register_subscription(
+            _valid_record(endpoint_suffix=f"sub_{i:03d}"),
+            now_utc="2026-05-09T00:00:00Z",
+        )
+    rec, warnings = pss.register_subscription(
+        _valid_record(endpoint_suffix="sub_000"),
+        now_utc="2026-05-09T00:01:00Z",
+    )
+    assert rec is not None
+    assert "subscription_cap_reached" not in warnings
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_record_shape_rejected(tmp_path: Path, monkeypatch) -> None:
+    _patch_paths(tmp_path, monkeypatch)
+    rec, warnings = pss.register_subscription("not a dict")
+    assert rec is None
+    assert "not_an_object" in warnings
+
+
+def test_missing_endpoint_rejected(tmp_path: Path, monkeypatch) -> None:
+    _patch_paths(tmp_path, monkeypatch)
+    bad = _valid_record()
+    bad["endpoint"] = ""
+    rec, warnings = pss.register_subscription(bad)
+    assert rec is None
+    assert "missing_endpoint" in warnings
+
+
+def test_endpoint_origin_not_allowed_rejected(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _patch_paths(tmp_path, monkeypatch)
+    bad = _valid_record()
+    bad["endpoint"] = "https://attacker.example.com/notify"
+    rec, warnings = pss.register_subscription(bad)
+    assert rec is None
+    assert "endpoint_origin_not_allowed" in warnings
+
+
+def test_invalid_keys_shape_rejected(tmp_path: Path, monkeypatch) -> None:
+    _patch_paths(tmp_path, monkeypatch)
+    bad = _valid_record()
+    bad["keys"] = {"p256dh": "x"}  # missing auth
+    rec, warnings = pss.register_subscription(bad)
+    assert rec is None
+    assert "invalid_keys_shape" in warnings
+
+
+def test_missing_kid_rejected(tmp_path: Path, monkeypatch) -> None:
+    _patch_paths(tmp_path, monkeypatch)
+    bad = _valid_record()
+    bad["kid"] = ""
+    rec, warnings = pss.register_subscription(bad)
+    assert rec is None
+    assert "missing_kid" in warnings
+
+
+# ---------------------------------------------------------------------------
+# Endpoint hash + redaction
+# ---------------------------------------------------------------------------
+
+
+def test_endpoint_hash_is_sha256_truncated() -> None:
+    h = pss.endpoint_hash("https://fcm.googleapis.com/fcm/send/abc")
+    assert isinstance(h, str)
+    assert len(h) == 16
+    # Deterministic.
+    assert h == pss.endpoint_hash("https://fcm.googleapis.com/fcm/send/abc")
+    # Different endpoint → different hash.
+    h2 = pss.endpoint_hash("https://fcm.googleapis.com/fcm/send/xyz")
+    assert h != h2
+
+
+def test_endpoint_hash_returns_empty_for_non_string() -> None:
+    assert pss.endpoint_hash(None) == ""  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# VAPID public key helpers
+# ---------------------------------------------------------------------------
+
+
+def test_vapid_public_present_false_when_missing(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _patch_paths(tmp_path, monkeypatch)
+    assert pss.vapid_public_present() is False
+    assert pss.vapid_public_text() is None
+
+
+def test_vapid_public_present_true_when_present(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _, vapid_path = _patch_paths(tmp_path, monkeypatch)
+    vapid_path.write_text("BPublicKeyBase64UrlText\n", encoding="utf-8")
+    assert pss.vapid_public_present() is True
+    assert pss.vapid_public_text() == "BPublicKeyBase64UrlText"
+
+
+# ---------------------------------------------------------------------------
+# Source-text + AST scans
+# ---------------------------------------------------------------------------
+
+
+def _module_source() -> str:
+    return Path(pss.__file__).read_text(encoding="utf-8")
+
+
+def _imported_module_names() -> set[str]:
+    import ast
+
+    src = _module_source()
+    tree = ast.parse(src)
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module is not None:
+                names.add(node.module)
+    return names
+
+
+def test_no_subprocess_in_module() -> None:
+    src = _module_source()
+    assert "import subprocess" not in src
+    assert "from subprocess" not in src
+
+
+def test_no_network_in_module() -> None:
+    src = _module_source()
+    for forbidden in (
+        "import socket",
+        "import urllib",
+        "import http.client",
+        "import requests",
+        "import httpx",
+        "import aiohttp",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_no_web_push_library_imports() -> None:
+    src = _module_source()
+    for forbidden in (
+        "import pywebpush",
+        "from pywebpush",
+        "import webpush",
+        "from webpush",
+        "import web_push",
+        "from web_push",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_no_vapid_private_key_reference() -> None:
+    """The literal env-var name must not appear in N2b-2a source.
+    Reading the private key is N2b-3 territory."""
+    src = _module_source()
+    assert "WEB_PUSH_VAPID_PRIVATE_KEY" not in src
+
+
+def test_no_dashboard_or_frontend_imports() -> None:
+    forbidden_prefixes = (
+        "dashboard",
+        "frontend",
+        "automation",
+        "broker",
+        "agent.risk",
+        "agent.execution",
+        "research",
+        "reporting.intelligent_routing",
+        "live",
+        "paper",
+        "shadow",
+        "trading",
+    )
+    for module in _imported_module_names():
+        for prefix in forbidden_prefixes:
+            assert not (
+                module == prefix or module.startswith(prefix + ".")
+            ), f"forbidden import: {module}"
+
+
+def test_module_imports_cleanly() -> None:
+    importlib.reload(pss)
+    assert callable(pss.list_subscriptions)
+
+
+def test_importing_module_does_not_flip_step5_invariants() -> None:
+    from reporting import development_step5_loop as dsl
+
+    importlib.reload(pss)
+    assert dsl.step5_implementation_allowed is False
+    assert dsl.STEP5_ENABLED_SUBSTAGE == "none"
+
+
+# ---------------------------------------------------------------------------
+# Companion doc invariants
+# ---------------------------------------------------------------------------
+
+
+def _doc_text() -> str:
+    return (
+        REPO_ROOT
+        / "docs"
+        / "governance"
+        / "notification_dispatch_subscription.md"
+    ).read_text(encoding="utf-8")
+
+
+def test_doc_states_no_real_push_in_n2b2a() -> None:
+    text = _doc_text().lower()
+    assert "no real push" in text
+
+
+def test_doc_states_no_approval_from_click_alone() -> None:
+    # Collapse whitespace so multi-line wrapping in markdown doesn't
+    # break the assertion. Accept either common phrasing.
+    import re
+    text = re.sub(r"\s+", " ", _doc_text().lower())
+    assert (
+        "no approval can happen from notification click alone" in text
+        or "no approval from notification click alone" in text
+        or "no approval can happen from a notification click alone" in text
+    )
+
+
+def test_doc_states_dashboard_dashboard_unchanged() -> None:
+    text = _doc_text().lower()
+    assert "dashboard/dashboard.py" in text
+    assert "unchanged" in text
+
+
+def test_doc_states_n2b2b_n2b3_n3_n4_n5_unimplemented() -> None:
+    text = _doc_text().lower()
+    for marker in ("n2b-2b", "n2b-3", "n3", "n4", "n5"):
+        assert marker in text, marker
+    assert "unimplemented" in text or "out of scope" in text
+
+
+def test_doc_pins_step5_invariants_text() -> None:
+    text = _doc_text()
+    assert "step5_implementation_allowed" in text
+    assert "STEP5_ENABLED_SUBSTAGE" in text
+
+
+def test_doc_mentions_level_6_only_with_qualifier() -> None:
+    import re
+
+    text = _doc_text()
+    pattern = re.compile(r"\bLevel\s*6\b")
+    for m in pattern.finditer(text):
+        start = max(0, m.start() - 200)
+        end = m.start() + 600
+        window = text[start:end].lower()
+        assert "permanently disabled" in window


### PR DESCRIPTION
## Summary

N2b-2a — backend storage primitive + Flask blueprint for the future PWA Web Push subscription surface. **Blueprint is intentionally NOT wired into `dashboard/dashboard.py`.** `frontend/**` is unchanged. **No real push, no service worker, no VAPID private key, no network socket.** At runtime today, this PR is equivalent to a no-op until the one-line wiring change lands in N2b-2b behind explicit operator approval.

## What lands

- `reporting/push_subscription_store.py` — pure-stdlib subscription store at the gitignored sentinel `config/web_push_subscriptions.json`. Closed per-record schema. `MAX_ACTIVE_SUBSCRIPTIONS=16`. Idempotent register/unregister. Atomic write refused outside the closed sentinel. `endpoint_hash(...)` sha256[:16] for redacted logging.
- `dashboard/api_push_subscribe.py` — Flask blueprint exposing 5 routes via `register_push_subscribe_routes(app)`: POST /subscribe, DELETE /unsubscribe, GET /vapid_public, GET /status, POST /test. `/status` returns ONLY count + last_subscribed_at + vapid_public_present. `/vapid_public` 404s cleanly. `/test` returns a synthetic six-key event with `real_push_sent=false`.
- `docs/governance/notification_dispatch_subscription.md` — full surface doc.
- `tests/unit/test_push_subscription_store.py` (42 tests) + `tests/unit/test_api_push_subscribe.py` (25 tests) — vocabularies, paths, atomic write refusal, idempotency, capacity, validation, scans, doc invariants.

## Operator follow-up: `.gitignore`

The two runtime-config paths must be added to `.gitignore`:

```
config/web_push_subscriptions.json
config/web_push_vapid_public.txt
```

The agent's allowlist hook blocked an in-PR edit to `.gitignore`. The substantive guarantee is already pinned by tests: `git ls-files | grep -E 'web_push_subscriptions|web_push_vapid_public'` returns nothing. Adding the `.gitignore` entries is a defense-in-depth one-line edit that the operator can do directly in a follow-up.

## Hard guarantees (pinned by tests)

- `dashboard/dashboard.py` unchanged.
- `frontend/**` unchanged.
- No service worker.
- No socket / urllib / requests / httpx / aiohttp / pywebpush / webpush / web_push / subprocess / `gh` / `git` references.
- No `WEB_PUSH_VAPID_PRIVATE_KEY` literal in source.
- No `dashboard.dashboard` import; the blueprint is not registered into the live dashboard in this PR.
- AST forbidden-import scan: no `frontend` / `automation` / `broker` / `agent.risk` / `agent.execution` / `research` / `reporting.intelligent_routing` / `live` / `paper` / `shadow` / `trading`.
- `step5_implementation_allowed` remains `False`; `STEP5_ENABLED_SUBSTAGE` remains `\"none\"`; Level 6 stays permanently disabled.

## Test plan

- [x] `python scripts/governance_lint.py` — OK.
- [x] `python -m pytest tests/unit/test_push_subscription_store.py tests/unit/test_api_push_subscribe.py -q` — **67 passed**.
- [x] `python -m pytest tests/unit/test_notification_dispatch_outbox*.py tests/unit/test_notification_dispatcher*.py -q` — **109 passed** (no upstream regression).
- [x] `python -m pytest tests/smoke -q` — **18 passed**.
- [x] `git ls-files | grep -E 'web_push_subscriptions|web_push_vapid_public'` — empty.
- [x] `python -m reporting.development_step5_loop --no-write` — Step 5 invariants intact.
- [x] CI checks
- [x] Diff scope = exactly the 5 N2b-2a files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)