### PR TITLE
chore: ignore web push runtime config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,6 @@ pytest-cache-files-*/
 *.tmp
 *.bak
 *.swp
+# Web Push runtime config
+config/web_push_subscriptions.json
+config/web_push_vapid_public.txt


### PR DESCRIPTION
## Summary

Adds gitignore entries for Web Push runtime config files introduced by the N2b-2a push subscription backend.

## Files changed

- .gitignore

## Entries added

- config/web_push_subscriptions.json
- config/web_push_vapid_public.txt

## Scope

- No code changes
- No dashboard/frontend changes
- No real push implementation
- No subscription or VAPID files committed
- No QRE/research/live/paper/shadow/risk/broker/execution changes
- No Step 5.1/5.2 changes
- Level 6 remains permanently disabled

## Validation

- git diff --stat main...HEAD shows only .gitignore
