### PR TITLE
fix(notif): N2b-2b deploy hotfix — ArrayBuffer return + exclude tests from prod tsc

### DIFF
--- a/frontend/src/lib/webPush.ts
+++ b/frontend/src/lib/webPush.ts
@@ -64,17 +64,31 @@ const SW_PATH = "/sw-push.js";
 const SW_SCOPE = "/agent-control/";
 
 /**
- * Convert a base64url string into a Uint8Array for
- * applicationServerKey. The VAPID public key is published as
- * base64url; PushManager.subscribe() needs a binary buffer.
+ * Convert a base64url string into an ArrayBuffer suitable for
+ * `PushManager.subscribe({ applicationServerKey })`. The VAPID
+ * public key is published as base64url. PushManager requires a
+ * `BufferSource`; we allocate a real `ArrayBuffer` and fill it
+ * through a `Uint8Array` view, then return the underlying buffer
+ * so that the function's return type is unambiguously
+ * `ArrayBuffer` (the lib.dom.d.ts type for
+ * `applicationServerKey`).
+ *
+ * Returning a `Uint8Array` directly works at runtime in most
+ * browsers but trips strict TypeScript builds because
+ * `Uint8Array<ArrayBufferLike>` is not assignable to
+ * `BufferSource` under tighter lib.dom.d.ts types — observed in
+ * the v3.15.16 deploy after PR #167.
+ *
+ * Exported for unit-test pinning of the return type.
  */
-function base64UrlToUint8Array(base64url: string): Uint8Array {
+export function base64UrlToArrayBuffer(base64url: string): ArrayBuffer {
   const padding = "=".repeat((4 - (base64url.length % 4)) % 4);
   const base64 = (base64url + padding).replace(/-/g, "+").replace(/_/g, "/");
   const raw = atob(base64);
-  const out = new Uint8Array(raw.length);
-  for (let i = 0; i < raw.length; i++) out[i] = raw.charCodeAt(i);
-  return out;
+  const buffer = new ArrayBuffer(raw.length);
+  const view = new Uint8Array(buffer);
+  for (let i = 0; i < raw.length; i++) view[i] = raw.charCodeAt(i);
+  return buffer;
 }
 
 export async function getPushStatus(): Promise<PushStatusResponse> {
@@ -145,7 +159,7 @@ export async function subscribeToPush(): Promise<SubscribeResult> {
   try {
     subscription = await registration.pushManager.subscribe({
       userVisibleOnly: true,
-      applicationServerKey: base64UrlToUint8Array(vapid),
+      applicationServerKey: base64UrlToArrayBuffer(vapid),
     });
   } catch (_err) {
     return { ok: false, reason: "push_subscribe_failed" };

--- a/frontend/src/test/webPush_lib.test.ts
+++ b/frontend/src/test/webPush_lib.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Unit tests for frontend/src/lib/webPush.ts pure helpers.
+ *
+ * Hard guarantees verified here:
+ *   - base64UrlToArrayBuffer returns a real ArrayBuffer (the type
+ *     PushManager.subscribe({ applicationServerKey }) expects), not
+ *     a Uint8Array — fixes the v3.15.16.N2b2b production tsc build
+ *     failure where Uint8Array<ArrayBufferLike> was rejected as
+ *     not assignable to BufferSource.
+ *   - The byte content of the returned buffer matches the decoded
+ *     base64url input.
+ *   - Empty input is tolerated.
+ *   - Padding-less and standard padded inputs both decode correctly.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { base64UrlToArrayBuffer } from "../lib/webPush";
+
+describe("base64UrlToArrayBuffer", () => {
+  it("returns an ArrayBuffer (not a Uint8Array)", () => {
+    const buf = base64UrlToArrayBuffer("BCfV1eK4");
+    // ArrayBuffer is the type PushManager wants. A Uint8Array's
+    // .buffer would also be an ArrayBuffer but the *return value*
+    // must itself be an ArrayBuffer.
+    expect(buf).toBeInstanceOf(ArrayBuffer);
+    expect(buf instanceof Uint8Array).toBe(false);
+  });
+
+  it("byteLength matches the decoded base64 length", () => {
+    // "Hello" in base64 is "SGVsbG8=" (5 bytes decoded).
+    // base64url variant: "SGVsbG8" (no padding required for this length).
+    const buf = base64UrlToArrayBuffer("SGVsbG8");
+    expect(buf.byteLength).toBe(5);
+  });
+
+  it("decodes content correctly into the buffer", () => {
+    const buf = base64UrlToArrayBuffer("SGVsbG8");
+    const view = new Uint8Array(buf);
+    // 'H' 'e' 'l' 'l' 'o'
+    expect(Array.from(view)).toEqual([72, 101, 108, 108, 111]);
+  });
+
+  it("tolerates inputs that need padding restoration", () => {
+    // "M" base64 is "TQ==" (1 byte). base64url: "TQ".
+    const buf = base64UrlToArrayBuffer("TQ");
+    expect(buf.byteLength).toBe(1);
+    expect(new Uint8Array(buf)[0]).toBe(0x4d);
+  });
+
+  it("handles base64url-specific characters (- and _)", () => {
+    // 0xff,0xff base64 is "//8=", base64url is "__8".
+    const buf = base64UrlToArrayBuffer("__8");
+    expect(buf.byteLength).toBe(2);
+    expect(new Uint8Array(buf)).toEqual(new Uint8Array([0xff, 0xff]));
+    // 0xfb,0xff base64 is "+/8=", base64url is "-_8".
+    const buf2 = base64UrlToArrayBuffer("-_8");
+    expect(new Uint8Array(buf2)).toEqual(new Uint8Array([0xfb, 0xff]));
+  });
+
+  it("empty string yields a zero-length ArrayBuffer", () => {
+    const buf = base64UrlToArrayBuffer("");
+    expect(buf).toBeInstanceOf(ArrayBuffer);
+    expect(buf.byteLength).toBe(0);
+  });
+});

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -17,5 +17,11 @@
     "forceConsistentCasingInFileNames": true,
     "noEmit": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": [
+    "src/test/**",
+    "src/**/__tests__/**",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx"
+  ]
 }

--- a/tests/unit/test_frontend_tsconfig_excludes_tests.py
+++ b/tests/unit/test_frontend_tsconfig_excludes_tests.py
@@ -1,0 +1,130 @@
+"""Hotfix pin: production tsc build excludes frontend test files.
+
+After PR #167 (N2b-2b) the production Docker frontend build failed
+because ``tsc -b`` was compiling ``frontend/src/test/*.test.ts`` as
+part of the production build. Test files use node-only imports
+(``node:fs``, ``node:path``, ``__dirname``) that are not in the
+``DOM`` lib — and they have no place in the production bundle in
+the first place.
+
+This pin asserts that ``frontend/tsconfig.json`` excludes all the
+test-file globs so a future regression that re-includes them fails
+at unit-test time, not at deploy time on the VPS.
+
+The vitest pipeline is unaffected — vitest uses its own
+``frontend/vitest.config.ts`` to discover and type-check tests via
+esbuild, independent of tsc.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TSCONFIG_PATH = REPO_ROOT / "frontend" / "tsconfig.json"
+
+
+def _tsconfig() -> dict[str, object]:
+    return json.loads(TSCONFIG_PATH.read_text(encoding="utf-8"))
+
+
+def test_frontend_tsconfig_exists() -> None:
+    assert TSCONFIG_PATH.is_file()
+
+
+def test_frontend_tsconfig_excludes_test_directories() -> None:
+    """The closed exclude list must contain at minimum the four
+    test-file globs. Adding more is fine; removing any of these is
+    forbidden."""
+    cfg = _tsconfig()
+    exclude = cfg.get("exclude")
+    assert isinstance(exclude, list), (
+        "frontend/tsconfig.json must define an `exclude` array"
+    )
+    required = {
+        "src/test/**",
+        "src/**/__tests__/**",
+        "src/**/*.test.ts",
+        "src/**/*.test.tsx",
+    }
+    missing = required - set(exclude)
+    assert not missing, (
+        f"frontend/tsconfig.json `exclude` is missing required globs: "
+        f"{sorted(missing)}"
+    )
+
+
+def test_frontend_tsconfig_keeps_src_in_include() -> None:
+    """`include` still covers `src` so production source files are
+    type-checked. The exclude is the only narrowing."""
+    cfg = _tsconfig()
+    include = cfg.get("include")
+    assert isinstance(include, list), "`include` must be present"
+    assert "src" in include, "`include` must still cover `src`"
+
+
+def test_frontend_tsconfig_no_emit_remains_true() -> None:
+    """Production tsc is type-check-only. Emit is handled by vite."""
+    cfg = _tsconfig()
+    co = cfg.get("compilerOptions")
+    assert isinstance(co, dict)
+    assert co.get("noEmit") is True
+
+
+def test_frontend_test_file_uses_node_imports() -> None:
+    """Defense-in-depth: the test file that triggered the deploy
+    failure (``sw_push_click.test.ts``) does in fact import node-only
+    modules. If a future refactor removes those imports, the
+    `exclude` becomes unnecessary; re-evaluate then. Today the
+    exclude is load-bearing."""
+    sw_test = (
+        REPO_ROOT
+        / "frontend"
+        / "src"
+        / "test"
+        / "sw_push_click.test.ts"
+    )
+    assert sw_test.is_file()
+    text = sw_test.read_text(encoding="utf-8")
+    # At least one node-only import must be present, otherwise the
+    # exclude no longer protects this file from a production tsc
+    # regression.
+    has_node_imports = (
+        "node:fs" in text
+        or "node:path" in text
+        or "__dirname" in text
+    )
+    assert has_node_imports, (
+        "sw_push_click.test.ts no longer uses node-only imports; "
+        "either re-evaluate the tsconfig exclude or document why it "
+        "stays."
+    )
+
+
+def test_webpush_lib_uses_array_buffer_for_application_server_key() -> None:
+    """The VAPID public key conversion must return an ArrayBuffer,
+    not a Uint8Array, to satisfy strict tsc lib.dom.d.ts typing for
+    `PushManager.subscribe({ applicationServerKey })`. This is the
+    other half of the v3.15.16.N2b2b deploy fix."""
+    src = (
+        REPO_ROOT / "frontend" / "src" / "lib" / "webPush.ts"
+    ).read_text(encoding="utf-8")
+    # The exported helper exists and returns ArrayBuffer.
+    assert "export function base64UrlToArrayBuffer(" in src, (
+        "webPush.ts must export base64UrlToArrayBuffer"
+    )
+    assert "): ArrayBuffer {" in src, (
+        "base64UrlToArrayBuffer must declare ArrayBuffer return type"
+    )
+    # The subscribe call uses the helper.
+    assert "applicationServerKey: base64UrlToArrayBuffer(vapid)" in src, (
+        "subscribeToPush must pass base64UrlToArrayBuffer(vapid) to "
+        "PushManager.subscribe"
+    )
+    # The old Uint8Array-returning helper must be gone.
+    assert "base64UrlToUint8Array" not in src, (
+        "the old base64UrlToUint8Array helper must be removed; it "
+        "returns the wrong BufferSource type"
+    )


### PR DESCRIPTION
## Summary

Hotfix for the Docker frontend build failure after PR #167. Two issues, both deploy-time-only (vitest stayed green throughout because vitest uses esbuild, not tsc):

1. `frontend/src/lib/webPush.ts:148` — `base64UrlToUint8Array(...)` returned `Uint8Array<ArrayBufferLike>` which strict `lib.dom.d.ts` rejects as not assignable to `BufferSource` for `PushManager.subscribe({ applicationServerKey })`.
2. `frontend/src/test/sw_push_click.test.ts` imports `node:fs` / `node:path` / `__dirname` and was being compiled by the production `tsc -b` step (tsconfig had no `exclude` block).

## What lands

- `frontend/src/lib/webPush.ts` — new `base64UrlToArrayBuffer(...) -> ArrayBuffer` helper. Allocates a real `ArrayBuffer`, fills via a `Uint8Array` view, returns the buffer. The single call site in `subscribeToPush()` is updated. Helper is `export`ed so the unit test can pin the return type.
- `frontend/tsconfig.json` — adds an `exclude` block: `["src/test/**", "src/**/__tests__/**", "src/**/*.test.ts", "src/**/*.test.tsx"]`. Production tsc now type-checks production source only; vitest's separate config still discovers and runs every test under those paths.
- `frontend/src/test/webPush_lib.test.ts` — 6 vitest unit tests pinning `base64UrlToArrayBuffer` returns an `ArrayBuffer` (not `Uint8Array`), matches decoded byteLength, decodes content correctly, tolerates padding, handles base64url `-` / `_`, zero-length for empty.
- `tests/unit/test_frontend_tsconfig_excludes_tests.py` — 6 Python unit tests pinning the tsconfig `exclude` block, the `base64UrlToArrayBuffer` export, the `ArrayBuffer` return type, the subscribe call site, and the absence of the old `base64UrlToUint8Array` helper.

## Hard guarantees

- No production code outside `frontend/src/lib/webPush.ts` modified.
- No QRE / research / live / paper / shadow / risk / broker / execution / `.claude/**` change.
- Step 5.1 / 5.2 remain BLOCKED. `step5_implementation_allowed=false`. `STEP5_ENABLED_SUBSTAGE=none`. Level 6 stays permanently disabled.
- `dashboard/dashboard.py` unchanged.
- No real push, no VAPID private handling, no `dashboard/api_push_dispatch.py`.

## Test plan

- [x] `npm --prefix frontend run build` — green (5.15s, dist emitted, no tsc errors).
- [x] `npm --prefix frontend run test` — **137 passed across 12 files** (was 131 before; +6 new webPush_lib tests).
- [x] `python scripts/governance_lint.py` — OK.
- [x] `python -m pytest tests/unit/test_frontend_tsconfig_excludes_tests.py -q` — **6 passed**.
- [x] `python -m pytest tests/unit/test_dashboard_dashboard_one_line_wiring.py tests/unit/test_api_push_subscribe.py -q` — **44 passed** (push wiring intact).
- [x] `python -m pytest tests/smoke -q` — **18 passed**.
- [x] CI checks
- [x] Diff scope = 4 files (webPush.ts + tsconfig.json + 2 new tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)