### PR TITLE
feat(intake): A19 — Roadmap Progress Tracker (read-only projector)

### DIFF
--- a/docs/governance/development_roadmap_progress.md
+++ b/docs/governance/development_roadmap_progress.md
@@ -1,0 +1,160 @@
+# Roadmap Progress Tracker — A19 (read-only, deterministic projector)
+
+> **Status:** Implemented (read-only, **mutates nothing**, **never
+> marks any phase complete**).
+>
+> **Module:** [`reporting/development_roadmap_progress.py`](../../reporting/development_roadmap_progress.py)
+> **Status reporter:** [`reporting/development_roadmap_progress_status.py`](../../reporting/development_roadmap_progress_status.py)
+>
+> **Output artefact:** `logs/development_roadmap_progress/latest.json`
+> **Status artefact:** `logs/development_roadmap_progress_status/latest.json`
+>
+> **Authority:** development-governance read-only.
+> A19 grants no agent any new authority.
+> Level 6 stays permanently disabled per ADR-015 §Doctrine 1.
+
+---
+
+## 1. Purpose
+
+A19 joins the existing read-only ADE artefacts and emits a per-phase
+progress snapshot:
+
+- Roadmap Intake Bridge candidates per `roadmap_phase`;
+- A16a Promotion Staging rows per phase;
+- A17 Queue Admission Policy rows per phase;
+- Step 5.0 plan history rows resolved to a phase via candidate id.
+
+The output answers, per phase: **what's been observed, and what
+state the phase is currently in**. A19 never assigns
+`complete` autonomously — that remains an operator-marked state in
+the canonical roadmap.
+
+---
+
+## 2. Hard constraints
+
+A19 must not:
+
+- edit canonical roadmap status fields;
+- mark any roadmap phase complete (the closed
+  `phase_progress_state` value `complete` is reserved for operator
+  use; A19's derivation never assigns it);
+- mutate any upstream artefact;
+- write to `seed.jsonl`, `delegation_seed.jsonl`, or any
+  `generated_seed.jsonl`;
+- enable Step 5.1 or Step 5.2;
+- flip `step5_implementation_allowed`;
+- change `STEP5_ENABLED_SUBSTAGE`;
+- change QRE behaviour;
+- mutate research artifacts;
+- touch live / paper / shadow / risk / broker / execution paths;
+- edit `.claude/**`;
+- send a real push;
+- mint approval tokens;
+- merge or deploy.
+
+---
+
+## 3. Closed `phase_progress_state` (6 values)
+
+| Value                | Meaning                                                            |
+| -------------------- | ------------------------------------------------------------------ |
+| `not_started`        | no signal observed in any upstream artefact for this phase         |
+| `intake_only`        | intake bridge sees a candidate; no promotion / admission / Step 5  |
+| `promotion_active`   | A16a promotion staging has at least one row in this phase          |
+| `admission_active`   | A17 admission policy has at least one row in this phase            |
+| `planning_active`    | Step 5.0 has produced a `plan_emitted` for this phase              |
+| `complete`           | **operator-only**; A19 never assigns this autonomously             |
+
+Derivation priority (first match wins): planning → admission →
+promotion → intake → not_started.
+
+---
+
+## 4. Per-row schema (15 keys)
+
+```
+roadmap_phase
+intake_candidate_count
+intake_eligible_count
+intake_blocked_count
+intake_human_needed_count
+promotion_total
+promotion_eligible_count
+promotion_blocked_count
+admission_total
+admission_admissible_count
+admission_blocked_count
+admission_needs_human_count
+step5_planned_count
+step5_halted_count
+phase_progress_state
+```
+
+Every row covers exactly one `roadmap_phase` value (e.g. `v3.15.16`).
+
+---
+
+## 5. Discipline invariants (emitted on every artefact)
+
+```
+writes_to_seed_jsonl                       = false
+writes_to_delegation_seed_jsonl            = false
+writes_to_generated_seed_jsonl             = false
+mutates_canonical_roadmap_status_fields    = false
+marks_any_phase_complete                   = false
+operator_promotion_required                = true
+step5_implementation_allowed               = false
+step5_enabled_substage                     = "none"
+diagnostics_do_not_trade                   = true
+```
+
+---
+
+## 6. CLI
+
+```sh
+python -m reporting.development_roadmap_progress --no-write
+python -m reporting.development_roadmap_progress
+python -m reporting.development_roadmap_progress_status --no-write
+```
+
+Pure stdlib + read-only ADE deps. No subprocess, no network,
+no `gh`, no `git`.
+
+---
+
+## 7. Test coverage
+
+Pinned in [`tests/unit/test_development_roadmap_progress.py`](../../tests/unit/test_development_roadmap_progress.py)
+and [`tests/unit/test_development_roadmap_progress_status.py`](../../tests/unit/test_development_roadmap_progress_status.py):
+
+- closed `PHASE_PROGRESS_STATES`, `PHASE_ROW_KEYS` pinned exactly;
+- A19 NEVER assigns `complete` (test pins this with synthetic data
+  that should otherwise look complete);
+- the live A15 phase `v3.15.16` lands in `planning_active` once
+  Step 5.0 has produced a plan_emitted for the candidate;
+- per-row counts mirror upstream;
+- atomic write refuses any path outside `logs/development_roadmap_progress/`;
+- AST-level forbidden-import scan: no `dashboard`, `frontend`,
+  `automation`, `broker`, `agent.risk`, `agent.execution`,
+  `research`, `reporting.intelligent_routing`, `live`, `paper`,
+  `shadow`, `trading`;
+- source-text scan: no `subprocess`, `socket`, `urllib`, `requests`,
+  `httpx`, `aiohttp`, `gh`, `git`;
+- importing the module does not flip Step 5 invariants.
+
+---
+
+## 8. What A19 does NOT do
+
+- A19 never marks a phase complete.
+- A19 never edits canonical roadmap status fields.
+- A19 never writes to any seed file.
+- A19 does not change Step 5.0 logic.
+- A19 does not flip `step5_implementation_allowed`.
+- A19 does not change `STEP5_ENABLED_SUBSTAGE`.
+- Step 5.1 / Step 5.2 remain BLOCKED.
+- A18 / N2b-3b / N3 / N4 / N5 remain unimplemented.
+- Level 6 stays permanently disabled per ADR-015 §Doctrine 1.

--- a/reporting/development_roadmap_progress.py
+++ b/reporting/development_roadmap_progress.py
@@ -1,0 +1,539 @@
+"""A19 — Roadmap Progress Tracker (read-only, deterministic projector).
+
+Pure stdlib-only projector that joins the existing read-only ADE
+artefacts:
+
+* Roadmap Intake Bridge (`logs/development_roadmap_intake/latest.json`)
+* A16a Promotion Staging (`logs/development_intake_promotion/latest.json`)
+* A17 Queue Admission Policy (`logs/development_queue_admission_policy/latest.json`)
+* Step 5.0 plan history (`logs/step5_plan/history.jsonl`)
+
+…and emits a per-roadmap-phase progress snapshot. **Reports only;
+mutates nothing; promotes nothing; flips no roadmap status field.**
+
+Hard guarantees (pinned by tests)
+---------------------------------
+
+* Stdlib + read-only `reporting.development_roadmap_intake`,
+  `reporting.development_intake_promotion`,
+  `reporting.development_queue_admission_policy`,
+  `reporting.development_step5_loop`,
+  `reporting.agent_audit_summary.assert_no_secrets`.
+* No subprocess, no network, no `gh`, no `git`.
+* No imports of `dashboard`, `frontend`, `automation`, `broker`,
+  `agent.risk`, `agent.execution`, `research`,
+  `reporting.intelligent_routing`, `live`, `paper`, `shadow`,
+  `trading`.
+* Atomic write only under
+  `logs/development_roadmap_progress/...`.
+* Never edits canonical roadmap status fields. Never marks any
+  phase complete. Never mutates upstream artefacts.
+* `step5_implementation_allowed` remains `False` and
+  `STEP5_ENABLED_SUBSTAGE` remains `"none"`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Final
+
+from reporting import development_intake_promotion as dip
+from reporting import development_queue_admission_policy as qap
+from reporting import development_roadmap_intake as dri
+from reporting import development_step5_loop as dsl
+from reporting.agent_audit_summary import assert_no_secrets
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[str] = "1.0"
+MODULE_VERSION: Final[str] = "v3.15.16.A19"
+REPORT_KIND: Final[str] = "development_roadmap_progress"
+
+# ---------------------------------------------------------------------------
+# Step 5 invariants
+# ---------------------------------------------------------------------------
+
+STEP5_ENABLED_SUBSTAGE: Final[str] = "none"
+step5_implementation_allowed: Final[bool] = False
+
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies
+# ---------------------------------------------------------------------------
+
+#: Closed phase-progress-state vocabulary. Adding a value requires
+#: a code change pinned by an updated unit test. Note: A19 NEVER
+#: assigns ``complete`` autonomously — it is reserved for the future
+#: where an operator marks a phase complete in the canonical roadmap.
+#: Today every phase A19 sees lands in ``not_started`` /
+#: ``intake_only`` / ``promotion_active`` / ``admission_active`` /
+#: ``planning_active`` based on observed signal in upstream artefacts.
+PHASE_PROGRESS_STATES: Final[tuple[str, ...]] = (
+    "not_started",
+    "intake_only",
+    "promotion_active",
+    "admission_active",
+    "planning_active",
+    "complete",
+)
+
+#: Per-phase row schema, exact and ordered.
+PHASE_ROW_KEYS: Final[tuple[str, ...]] = (
+    "roadmap_phase",
+    "intake_candidate_count",
+    "intake_eligible_count",
+    "intake_blocked_count",
+    "intake_human_needed_count",
+    "promotion_total",
+    "promotion_eligible_count",
+    "promotion_blocked_count",
+    "admission_total",
+    "admission_admissible_count",
+    "admission_blocked_count",
+    "admission_needs_human_count",
+    "step5_planned_count",
+    "step5_halted_count",
+    "phase_progress_state",
+)
+
+#: Wrapper-level note vocabulary.
+NOTE_NO_PHASES: Final[str] = "no_roadmap_phases_observed"
+NOTE_PHASES_PRESENT: Final[str] = "roadmap_phases_present"
+NOTE_NO_UPSTREAM_ARTIFACTS: Final[str] = "no_upstream_artifacts"
+
+#: Repo-relative paths.
+ARTIFACT_DIR: Final[Path] = (
+    REPO_ROOT / "logs" / "development_roadmap_progress"
+)
+ARTIFACT_LATEST: Final[Path] = ARTIFACT_DIR / "latest.json"
+ARTIFACT_RELATIVE_PATH: Final[str] = (
+    "logs/development_roadmap_progress/latest.json"
+)
+
+#: Atomic-write allowlist (substring form).
+_WRITE_PREFIX: Final[str] = "logs/development_roadmap_progress/"
+
+
+# ---------------------------------------------------------------------------
+# Discipline invariants
+# ---------------------------------------------------------------------------
+
+_DISCIPLINE_INVARIANTS: Final[dict[str, bool | str]] = {
+    "writes_to_seed_jsonl": False,
+    "writes_to_delegation_seed_jsonl": False,
+    "writes_to_generated_seed_jsonl": False,
+    "mutates_canonical_roadmap_status_fields": False,
+    "marks_any_phase_complete": False,
+    "actually_modifies_target": False,
+    "uses_subprocess_or_network": False,
+    "calls_llm_or_external_api": False,
+    "mutates_research_artifacts": False,
+    "operator_promotion_required": True,
+    "step5_implementation_allowed": False,
+    "step5_enabled_substage": "none",
+    "diagnostics_do_not_trade": True,
+}
+
+
+# ---------------------------------------------------------------------------
+# Utility helpers
+# ---------------------------------------------------------------------------
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.is_file():
+        return []
+    out: list[dict[str, Any]] = []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return out
+    for raw in text.splitlines():
+        s = raw.strip()
+        if not s:
+            continue
+        try:
+            entry = json.loads(s)
+        except ValueError:
+            continue
+        if isinstance(entry, dict):
+            out.append(entry)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Phase-progress derivation
+# ---------------------------------------------------------------------------
+
+
+def _derive_phase_state(row: dict[str, Any]) -> str:
+    """Closed-table derivation of `phase_progress_state` from observed
+    signal in upstream artefacts.
+
+    Priority order (first match wins):
+
+    1. Step 5.0 has produced a `plan_emitted` for any candidate in
+       this phase → `planning_active`.
+    2. Admission policy has at least one row in this phase →
+       `admission_active`.
+    3. Promotion staging has at least one row in this phase →
+       `promotion_active`.
+    4. Intake bridge has at least one candidate in this phase →
+       `intake_only`.
+    5. Otherwise (no signal anywhere) → `not_started`.
+
+    A19 never assigns `complete` — that remains an operator-marked
+    state in the canonical roadmap, never inferred by the agent.
+    """
+    if int(row.get("step5_planned_count", 0)) > 0:
+        return "planning_active"
+    if int(row.get("admission_total", 0)) > 0:
+        return "admission_active"
+    if int(row.get("promotion_total", 0)) > 0:
+        return "promotion_active"
+    if int(row.get("intake_candidate_count", 0)) > 0:
+        return "intake_only"
+    return "not_started"
+
+
+# ---------------------------------------------------------------------------
+# Per-phase aggregation
+# ---------------------------------------------------------------------------
+
+
+def _empty_row(phase: str) -> dict[str, Any]:
+    return {
+        "roadmap_phase": phase,
+        "intake_candidate_count": 0,
+        "intake_eligible_count": 0,
+        "intake_blocked_count": 0,
+        "intake_human_needed_count": 0,
+        "promotion_total": 0,
+        "promotion_eligible_count": 0,
+        "promotion_blocked_count": 0,
+        "admission_total": 0,
+        "admission_admissible_count": 0,
+        "admission_blocked_count": 0,
+        "admission_needs_human_count": 0,
+        "step5_planned_count": 0,
+        "step5_halted_count": 0,
+        "phase_progress_state": "not_started",
+    }
+
+
+def _accumulate_intake(
+    rows: dict[str, dict[str, Any]],
+    intake_payload: dict[str, Any] | None,
+) -> None:
+    if not isinstance(intake_payload, dict):
+        return
+    candidates = intake_payload.get("candidates")
+    if not isinstance(candidates, list):
+        return
+    for c in candidates:
+        if not isinstance(c, dict):
+            continue
+        phase = str(c.get("roadmap_phase") or "")
+        if not phase:
+            continue
+        row = rows.setdefault(phase, _empty_row(phase))
+        row["intake_candidate_count"] += 1
+        status = c.get("intake_status")
+        if status == "eligible":
+            row["intake_eligible_count"] += 1
+        elif status == "blocked":
+            row["intake_blocked_count"] += 1
+        elif status == "human_needed":
+            row["intake_human_needed_count"] += 1
+
+
+def _accumulate_promotion(
+    rows: dict[str, dict[str, Any]],
+    promotion_payload: dict[str, Any] | None,
+) -> None:
+    if not isinstance(promotion_payload, dict):
+        return
+    promo_rows = promotion_payload.get("rows")
+    if not isinstance(promo_rows, list):
+        return
+    for r in promo_rows:
+        if not isinstance(r, dict):
+            continue
+        phase = str(r.get("roadmap_phase") or "")
+        if not phase:
+            continue
+        row = rows.setdefault(phase, _empty_row(phase))
+        row["promotion_total"] += 1
+        ds = r.get("decision_state")
+        if ds == "eligible":
+            row["promotion_eligible_count"] += 1
+        elif ds == "blocked":
+            row["promotion_blocked_count"] += 1
+
+
+def _accumulate_admission(
+    rows: dict[str, dict[str, Any]],
+    admission_payload: dict[str, Any] | None,
+) -> None:
+    if not isinstance(admission_payload, dict):
+        return
+    adm_rows = admission_payload.get("rows")
+    if not isinstance(adm_rows, list):
+        return
+    for r in adm_rows:
+        if not isinstance(r, dict):
+            continue
+        phase = str(r.get("roadmap_phase") or "")
+        if not phase:
+            continue
+        row = rows.setdefault(phase, _empty_row(phase))
+        row["admission_total"] += 1
+        d = r.get("admission_decision")
+        if d == "admissible":
+            row["admission_admissible_count"] += 1
+        elif d == "blocked":
+            row["admission_blocked_count"] += 1
+        elif d == "needs_human":
+            row["admission_needs_human_count"] += 1
+
+
+def _accumulate_step5(
+    rows: dict[str, dict[str, Any]],
+    step5_history: list[dict[str, Any]],
+    promotion_payload: dict[str, Any] | None,
+    intake_payload: dict[str, Any] | None,
+) -> None:
+    """Step 5.0 history rows reference candidates by `source_id` /
+    `cycle_id`, not directly by phase. Resolve the phase by looking
+    up the source_id in the upstream promotion + intake artefacts."""
+    candidate_phase: dict[str, str] = {}
+    if isinstance(intake_payload, dict):
+        for c in (intake_payload.get("candidates") or []):
+            if isinstance(c, dict):
+                cid = str(c.get("candidate_id") or "")
+                ph = str(c.get("roadmap_phase") or "")
+                if cid and ph:
+                    candidate_phase[cid] = ph
+    if isinstance(promotion_payload, dict):
+        for r in (promotion_payload.get("rows") or []):
+            if isinstance(r, dict):
+                cid = str(r.get("candidate_id") or "")
+                ph = str(r.get("roadmap_phase") or "")
+                if cid and ph:
+                    candidate_phase[cid] = ph
+
+    for entry in step5_history:
+        outcome = str(entry.get("outcome") or "")
+        source_id = str(entry.get("source_id") or "")
+        if not source_id:
+            continue
+        phase = candidate_phase.get(source_id, "")
+        if not phase:
+            continue
+        row = rows.setdefault(phase, _empty_row(phase))
+        if outcome == "plan_emitted":
+            row["step5_planned_count"] += 1
+        elif outcome.startswith("halt_"):
+            row["step5_halted_count"] += 1
+
+
+# ---------------------------------------------------------------------------
+# Snapshot assembly
+# ---------------------------------------------------------------------------
+
+
+def collect_snapshot(
+    *,
+    intake_artifact_path: Path | None = None,
+    promotion_artifact_path: Path | None = None,
+    admission_artifact_path: Path | None = None,
+    step5_history_path: Path | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    """Build the deterministic phase-progress snapshot.
+
+    Reads four upstream artefacts read-only. Every path argument is
+    overridable for tests; defaults point at the production paths.
+    """
+    ip = intake_artifact_path if intake_artifact_path is not None else dri.ARTIFACT_LATEST
+    pp = promotion_artifact_path if promotion_artifact_path is not None else dip.ARTIFACT_LATEST
+    ap = admission_artifact_path if admission_artifact_path is not None else qap.ARTIFACT_LATEST
+    hp = step5_history_path if step5_history_path is not None else dsl.HISTORY_PATH
+    ts = generated_at_utc if generated_at_utc is not None else _utcnow()
+
+    intake_payload = _read_json(ip)
+    promotion_payload = _read_json(pp)
+    admission_payload = _read_json(ap)
+    step5_history = _read_jsonl(hp)
+
+    rows: dict[str, dict[str, Any]] = {}
+    _accumulate_intake(rows, intake_payload)
+    _accumulate_promotion(rows, promotion_payload)
+    _accumulate_admission(rows, admission_payload)
+    _accumulate_step5(rows, step5_history, promotion_payload, intake_payload)
+
+    # Derive phase_progress_state for every row.
+    for r in rows.values():
+        r["phase_progress_state"] = _derive_phase_state(r)
+        # Closed shape check.
+        assert set(r.keys()) == set(PHASE_ROW_KEYS)
+
+    rows_sorted = sorted(rows.values(), key=lambda r: r["roadmap_phase"])
+
+    sources_present = {
+        "intake": intake_payload is not None,
+        "promotion": promotion_payload is not None,
+        "admission": admission_payload is not None,
+        "step5_history": bool(step5_history),
+    }
+    if not any(sources_present.values()):
+        note = NOTE_NO_UPSTREAM_ARTIFACTS
+    elif not rows_sorted:
+        note = NOTE_NO_PHASES
+    else:
+        note = NOTE_PHASES_PRESENT
+
+    counts = {
+        "phase_count": len(rows_sorted),
+        "by_phase_progress_state": {s: 0 for s in PHASE_PROGRESS_STATES},
+    }
+    for r in rows_sorted:
+        s = r["phase_progress_state"]
+        if s in counts["by_phase_progress_state"]:
+            counts["by_phase_progress_state"][s] += 1
+
+    snapshot = {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": ts,
+        "step5_enabled_substage": STEP5_ENABLED_SUBSTAGE,
+        "step5_implementation_allowed": step5_implementation_allowed,
+        "sources_read": [
+            {"source": "intake", "path": str(ip), "available": intake_payload is not None},
+            {"source": "promotion", "path": str(pp), "available": promotion_payload is not None},
+            {"source": "admission", "path": str(ap), "available": admission_payload is not None},
+            {"source": "step5_history", "path": str(hp), "available": bool(step5_history)},
+        ],
+        "note": note,
+        "validation_warnings": [],
+        "vocabularies": {
+            "phase_progress_states": list(PHASE_PROGRESS_STATES),
+            "phase_row_keys": list(PHASE_ROW_KEYS),
+        },
+        "counts": counts,
+        "rows": rows_sorted,
+        "intake_module_version": dri.MODULE_VERSION,
+        "promotion_module_version": dip.MODULE_VERSION,
+        "admission_module_version": qap.MODULE_VERSION,
+        "step5_module_version": dsl.MODULE_VERSION,
+        "discipline_invariants": dict(_DISCIPLINE_INVARIANTS),
+    }
+    assert_no_secrets(snapshot)
+    return snapshot
+
+
+# ---------------------------------------------------------------------------
+# Atomic write
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    posix = path.as_posix()
+    if _WRITE_PREFIX not in posix and not posix.startswith(_WRITE_PREFIX):
+        raise ValueError(
+            "development_roadmap_progress._atomic_write_json refuses "
+            f"non-progress-logs output path: {path}"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".development_roadmap_progress.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_outputs(snapshot: dict[str, Any]) -> Path:
+    _atomic_write_json(ARTIFACT_LATEST, snapshot)
+    return ARTIFACT_LATEST
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m reporting.development_roadmap_progress",
+        description=(
+            "A19 Roadmap Progress Tracker. Read-only deterministic "
+            "projector that joins intake / promotion / admission / "
+            "step5 artefacts and emits a per-phase progress snapshot. "
+            "Mutates no roadmap status field; never marks a phase "
+            "complete."
+        ),
+    )
+    p.add_argument(
+        "--indent", type=int, default=2, help="JSON indent (0 for compact)."
+    )
+    p.add_argument(
+        "--no-write",
+        action="store_true",
+        help=(
+            "Do not persist "
+            "logs/development_roadmap_progress/latest.json "
+            "(stdout only)."
+        ),
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    indent = args.indent if args.indent and args.indent > 0 else None
+    snap = collect_snapshot()
+    if not args.no_write:
+        write_outputs(snap)
+    json.dump(snap, sys.stdout, indent=indent, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/reporting/development_roadmap_progress_status.py
+++ b/reporting/development_roadmap_progress_status.py
@@ -1,0 +1,200 @@
+"""A19 — Roadmap Progress Tracker status summary."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Final
+
+from reporting import development_roadmap_progress as drp
+from reporting.agent_audit_summary import assert_no_secrets
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[str] = "1.0"
+MODULE_VERSION: Final[str] = "v3.15.16.A19"
+REPORT_KIND: Final[str] = "development_roadmap_progress_status"
+
+ARTIFACT_DIR: Final[Path] = (
+    REPO_ROOT / "logs" / "development_roadmap_progress_status"
+)
+ARTIFACT_LATEST: Final[Path] = ARTIFACT_DIR / "latest.json"
+ARTIFACT_RELATIVE_PATH: Final[str] = (
+    "logs/development_roadmap_progress_status/latest.json"
+)
+
+_WRITE_PREFIX: Final[str] = "logs/development_roadmap_progress_status/"
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+
+def _empty_counts() -> dict[str, Any]:
+    return {
+        "phase_count": 0,
+        "by_phase_progress_state": {s: 0 for s in drp.PHASE_PROGRESS_STATES},
+    }
+
+
+def collect_status(
+    *,
+    progress_artifact_path: Path | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    pp = (
+        progress_artifact_path
+        if progress_artifact_path is not None
+        else drp.ARTIFACT_LATEST
+    )
+    ts = generated_at_utc if generated_at_utc is not None else _utcnow()
+    payload = _read_json(pp)
+    if payload is None:
+        snap = {
+            "schema_version": SCHEMA_VERSION,
+            "module_version": MODULE_VERSION,
+            "report_kind": REPORT_KIND,
+            "generated_at_utc": ts,
+            "progress_artifact_path": str(pp),
+            "progress_artifact_available": False,
+            "progress_module_version": drp.MODULE_VERSION,
+            "step5_enabled_substage": drp.STEP5_ENABLED_SUBSTAGE,
+            "step5_implementation_allowed": drp.step5_implementation_allowed,
+            "schema_pinned": {
+                "phase_progress_states": list(drp.PHASE_PROGRESS_STATES),
+                "phase_row_keys": list(drp.PHASE_ROW_KEYS),
+            },
+            "counts": _empty_counts(),
+            "validation_warnings": [],
+            "note": "progress_artifact_absent",
+        }
+        assert_no_secrets(snap)
+        return snap
+
+    upstream_counts = payload.get("counts") or {}
+    if not isinstance(upstream_counts, dict):
+        upstream_counts = {}
+
+    counts = _empty_counts()
+    counts["phase_count"] = int(upstream_counts.get("phase_count") or 0)
+
+    by_state = upstream_counts.get("by_phase_progress_state") or {}
+    if isinstance(by_state, dict):
+        for s in drp.PHASE_PROGRESS_STATES:
+            counts["by_phase_progress_state"][s] = int(by_state.get(s) or 0)
+
+    snap = {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": ts,
+        "progress_artifact_path": str(pp),
+        "progress_artifact_available": True,
+        "progress_module_version": payload.get("module_version"),
+        "progress_schema_version": payload.get("schema_version"),
+        "progress_generated_at_utc": payload.get("generated_at_utc"),
+        "progress_note": payload.get("note"),
+        "step5_enabled_substage": payload.get("step5_enabled_substage")
+        or drp.STEP5_ENABLED_SUBSTAGE,
+        "step5_implementation_allowed": bool(
+            payload.get("step5_implementation_allowed")
+        ),
+        "schema_pinned": {
+            "phase_progress_states": list(drp.PHASE_PROGRESS_STATES),
+            "phase_row_keys": list(drp.PHASE_ROW_KEYS),
+        },
+        "counts": counts,
+        "validation_warnings": list(payload.get("validation_warnings") or []),
+        "note": "progress_artifact_present",
+    }
+    assert_no_secrets(snap)
+    return snap
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    posix = path.as_posix()
+    if _WRITE_PREFIX not in posix and not posix.startswith(_WRITE_PREFIX):
+        raise ValueError(
+            "development_roadmap_progress_status._atomic_write_json refuses "
+            f"non-status-logs output path: {path}"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".development_roadmap_progress_status.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_outputs(snapshot: dict[str, Any]) -> Path:
+    _atomic_write_json(ARTIFACT_LATEST, snapshot)
+    return ARTIFACT_LATEST
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m reporting.development_roadmap_progress_status",
+        description=(
+            "Read-only summary of "
+            "logs/development_roadmap_progress/latest.json. Decides "
+            "nothing; mutates nothing."
+        ),
+    )
+    p.add_argument(
+        "--indent", type=int, default=2, help="JSON indent (0 for compact)."
+    )
+    p.add_argument(
+        "--no-write",
+        action="store_true",
+        help=(
+            "Do not persist "
+            "logs/development_roadmap_progress_status/latest.json "
+            "(stdout only)."
+        ),
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    indent = args.indent if args.indent and args.indent > 0 else None
+    snap = collect_status()
+    if not args.no_write:
+        write_outputs(snap)
+    json.dump(snap, sys.stdout, indent=indent, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/unit/test_development_roadmap_progress.py
+++ b/tests/unit/test_development_roadmap_progress.py
@@ -1,0 +1,529 @@
+"""Unit tests for A19 — Roadmap Progress Tracker."""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reporting import development_roadmap_progress as drp
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_paths(tmp_path: Path) -> tuple[Path, Path, Path, Path]:
+    intake = tmp_path / "logs" / "development_roadmap_intake" / "latest.json"
+    promo = tmp_path / "logs" / "development_intake_promotion" / "latest.json"
+    adm = tmp_path / "logs" / "development_queue_admission_policy" / "latest.json"
+    hist = tmp_path / "logs" / "step5_plan" / "history.jsonl"
+    for p in (intake, promo, adm, hist):
+        p.parent.mkdir(parents=True, exist_ok=True)
+    return intake, promo, adm, hist
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(
+        json.dumps(payload, sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_jsonl(path: Path, entries: list[dict[str, Any]]) -> None:
+    path.write_text(
+        "\n".join(json.dumps(e, sort_keys=True) for e in entries) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _intake_payload(
+    candidates: list[dict[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "schema_version": "1.0",
+        "module_version": "v0",
+        "report_kind": "development_roadmap_intake",
+        "generated_at_utc": "2026-05-10T00:00:00Z",
+        "candidates": candidates,
+    }
+
+
+def _promo_payload(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "schema_version": "1.0",
+        "module_version": "v0",
+        "report_kind": "development_intake_promotion",
+        "generated_at_utc": "2026-05-10T00:00:00Z",
+        "rows": rows,
+    }
+
+
+def _adm_payload(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "schema_version": "1.0",
+        "module_version": "v0",
+        "report_kind": "development_queue_admission_policy",
+        "generated_at_utc": "2026-05-10T00:00:00Z",
+        "rows": rows,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies
+# ---------------------------------------------------------------------------
+
+
+def test_phase_progress_states_pinned_exactly() -> None:
+    assert drp.PHASE_PROGRESS_STATES == (
+        "not_started",
+        "intake_only",
+        "promotion_active",
+        "admission_active",
+        "planning_active",
+        "complete",
+    )
+
+
+def test_phase_row_keys_pinned_exactly_and_ordered() -> None:
+    assert drp.PHASE_ROW_KEYS == (
+        "roadmap_phase",
+        "intake_candidate_count",
+        "intake_eligible_count",
+        "intake_blocked_count",
+        "intake_human_needed_count",
+        "promotion_total",
+        "promotion_eligible_count",
+        "promotion_blocked_count",
+        "admission_total",
+        "admission_admissible_count",
+        "admission_blocked_count",
+        "admission_needs_human_count",
+        "step5_planned_count",
+        "step5_halted_count",
+        "phase_progress_state",
+    )
+
+
+def test_step5_invariants_pinned() -> None:
+    assert drp.step5_implementation_allowed is False
+    assert drp.STEP5_ENABLED_SUBSTAGE == "none"
+
+
+# ---------------------------------------------------------------------------
+# Atomic write refusal
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_write_refuses_non_progress_path(tmp_path: Path) -> None:
+    bad = tmp_path / "evil_dir" / "latest.json"
+    with pytest.raises(ValueError):
+        drp._atomic_write_json(bad, {"x": 1})
+
+
+# ---------------------------------------------------------------------------
+# A19 NEVER assigns `complete` autonomously
+# ---------------------------------------------------------------------------
+
+
+def test_a19_never_assigns_complete(tmp_path: Path) -> None:
+    """Even with maximally rich upstream signal (intake + promotion +
+    admission + Step 5.0 plan_emitted), A19 lands in
+    `planning_active`, never `complete`. Operator-only marker."""
+    intake, promo, adm, hist = _make_paths(tmp_path)
+    _write_json(
+        intake,
+        _intake_payload([
+            {
+                "candidate_id": "c1",
+                "roadmap_phase": "v3.15.16",
+                "intake_status": "eligible",
+            },
+        ]),
+    )
+    _write_json(
+        promo,
+        _promo_payload([
+            {
+                "candidate_id": "c1",
+                "roadmap_phase": "v3.15.16",
+                "decision_state": "eligible",
+            },
+        ]),
+    )
+    _write_json(
+        adm,
+        _adm_payload([
+            {
+                "candidate_id": "c1",
+                "roadmap_phase": "v3.15.16",
+                "admission_decision": "admissible",
+            },
+        ]),
+    )
+    _write_jsonl(hist, [{"source_id": "c1", "outcome": "plan_emitted"}])
+    snap = drp.collect_snapshot(
+        intake_artifact_path=intake,
+        promotion_artifact_path=promo,
+        admission_artifact_path=adm,
+        step5_history_path=hist,
+        generated_at_utc="2026-05-10T00:00:00Z",
+    )
+    rows = snap["rows"]
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["phase_progress_state"] == "planning_active"
+    assert row["phase_progress_state"] != "complete"
+
+
+# ---------------------------------------------------------------------------
+# Phase derivation
+# ---------------------------------------------------------------------------
+
+
+def test_intake_only_state(tmp_path: Path) -> None:
+    intake, promo, adm, hist = _make_paths(tmp_path)
+    _write_json(
+        intake,
+        _intake_payload([
+            {"candidate_id": "c1", "roadmap_phase": "v3.15.17", "intake_status": "proposed"},
+        ]),
+    )
+    _write_json(promo, _promo_payload([]))
+    _write_json(adm, _adm_payload([]))
+    _write_jsonl(hist, [])
+    snap = drp.collect_snapshot(
+        intake_artifact_path=intake,
+        promotion_artifact_path=promo,
+        admission_artifact_path=adm,
+        step5_history_path=hist,
+    )
+    assert snap["rows"][0]["phase_progress_state"] == "intake_only"
+
+
+def test_promotion_active_state(tmp_path: Path) -> None:
+    intake, promo, adm, hist = _make_paths(tmp_path)
+    _write_json(intake, _intake_payload([]))
+    _write_json(
+        promo,
+        _promo_payload([
+            {"candidate_id": "c1", "roadmap_phase": "v3.15.17", "decision_state": "eligible"},
+        ]),
+    )
+    _write_json(adm, _adm_payload([]))
+    _write_jsonl(hist, [])
+    snap = drp.collect_snapshot(
+        intake_artifact_path=intake,
+        promotion_artifact_path=promo,
+        admission_artifact_path=adm,
+        step5_history_path=hist,
+    )
+    assert snap["rows"][0]["phase_progress_state"] == "promotion_active"
+
+
+def test_admission_active_state(tmp_path: Path) -> None:
+    intake, promo, adm, hist = _make_paths(tmp_path)
+    _write_json(intake, _intake_payload([]))
+    _write_json(promo, _promo_payload([]))
+    _write_json(
+        adm,
+        _adm_payload([
+            {"candidate_id": "c1", "roadmap_phase": "v3.15.17", "admission_decision": "admissible"},
+        ]),
+    )
+    _write_jsonl(hist, [])
+    snap = drp.collect_snapshot(
+        intake_artifact_path=intake,
+        promotion_artifact_path=promo,
+        admission_artifact_path=adm,
+        step5_history_path=hist,
+    )
+    assert snap["rows"][0]["phase_progress_state"] == "admission_active"
+
+
+def test_planning_active_state_resolved_via_promotion_phase(
+    tmp_path: Path,
+) -> None:
+    intake, promo, adm, hist = _make_paths(tmp_path)
+    _write_json(intake, _intake_payload([]))
+    _write_json(
+        promo,
+        _promo_payload([
+            {"candidate_id": "c1", "roadmap_phase": "v3.15.17", "decision_state": "eligible"},
+        ]),
+    )
+    _write_json(adm, _adm_payload([]))
+    _write_jsonl(hist, [{"source_id": "c1", "outcome": "plan_emitted"}])
+    snap = drp.collect_snapshot(
+        intake_artifact_path=intake,
+        promotion_artifact_path=promo,
+        admission_artifact_path=adm,
+        step5_history_path=hist,
+    )
+    assert snap["rows"][0]["phase_progress_state"] == "planning_active"
+
+
+# ---------------------------------------------------------------------------
+# Counts
+# ---------------------------------------------------------------------------
+
+
+def test_intake_counts_per_phase(tmp_path: Path) -> None:
+    intake, promo, adm, hist = _make_paths(tmp_path)
+    _write_json(
+        intake,
+        _intake_payload([
+            {"candidate_id": "a", "roadmap_phase": "p1", "intake_status": "eligible"},
+            {"candidate_id": "b", "roadmap_phase": "p1", "intake_status": "blocked"},
+            {"candidate_id": "c", "roadmap_phase": "p1", "intake_status": "human_needed"},
+            {"candidate_id": "d", "roadmap_phase": "p2", "intake_status": "eligible"},
+        ]),
+    )
+    _write_json(promo, _promo_payload([]))
+    _write_json(adm, _adm_payload([]))
+    _write_jsonl(hist, [])
+    snap = drp.collect_snapshot(
+        intake_artifact_path=intake,
+        promotion_artifact_path=promo,
+        admission_artifact_path=adm,
+        step5_history_path=hist,
+    )
+    by_phase = {r["roadmap_phase"]: r for r in snap["rows"]}
+    assert by_phase["p1"]["intake_candidate_count"] == 3
+    assert by_phase["p1"]["intake_eligible_count"] == 1
+    assert by_phase["p1"]["intake_blocked_count"] == 1
+    assert by_phase["p1"]["intake_human_needed_count"] == 1
+    assert by_phase["p2"]["intake_candidate_count"] == 1
+
+
+def test_step5_counts_planned_vs_halted(tmp_path: Path) -> None:
+    intake, promo, adm, hist = _make_paths(tmp_path)
+    _write_json(intake, _intake_payload([]))
+    _write_json(
+        promo,
+        _promo_payload([
+            {"candidate_id": "c1", "roadmap_phase": "p1", "decision_state": "eligible"},
+        ]),
+    )
+    _write_json(adm, _adm_payload([]))
+    _write_jsonl(
+        hist,
+        [
+            {"source_id": "c1", "outcome": "plan_emitted"},
+            {"source_id": "c1", "outcome": "halt_needs_human"},
+            {"source_id": "c1", "outcome": "halt_permanently_denied"},
+        ],
+    )
+    snap = drp.collect_snapshot(
+        intake_artifact_path=intake,
+        promotion_artifact_path=promo,
+        admission_artifact_path=adm,
+        step5_history_path=hist,
+    )
+    by_phase = {r["roadmap_phase"]: r for r in snap["rows"]}
+    assert by_phase["p1"]["step5_planned_count"] == 1
+    assert by_phase["p1"]["step5_halted_count"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Snapshot shape
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_top_level_keys(tmp_path: Path) -> None:
+    intake, promo, adm, hist = _make_paths(tmp_path)
+    snap = drp.collect_snapshot(
+        intake_artifact_path=intake,
+        promotion_artifact_path=promo,
+        admission_artifact_path=adm,
+        step5_history_path=hist,
+        generated_at_utc="2026-05-10T00:00:00Z",
+    )
+    expected = {
+        "schema_version",
+        "module_version",
+        "report_kind",
+        "generated_at_utc",
+        "step5_enabled_substage",
+        "step5_implementation_allowed",
+        "sources_read",
+        "note",
+        "validation_warnings",
+        "vocabularies",
+        "counts",
+        "rows",
+        "intake_module_version",
+        "promotion_module_version",
+        "admission_module_version",
+        "step5_module_version",
+        "discipline_invariants",
+    }
+    assert set(snap.keys()) == expected
+
+
+def test_discipline_invariants_present(tmp_path: Path) -> None:
+    intake, promo, adm, hist = _make_paths(tmp_path)
+    snap = drp.collect_snapshot(
+        intake_artifact_path=intake,
+        promotion_artifact_path=promo,
+        admission_artifact_path=adm,
+        step5_history_path=hist,
+    )
+    inv = snap["discipline_invariants"]
+    assert inv["writes_to_seed_jsonl"] is False
+    assert inv["mutates_canonical_roadmap_status_fields"] is False
+    assert inv["marks_any_phase_complete"] is False
+    assert inv["step5_implementation_allowed"] is False
+    assert inv["step5_enabled_substage"] == "none"
+
+
+def test_determinism_with_injected_timestamp(tmp_path: Path) -> None:
+    intake, promo, adm, hist = _make_paths(tmp_path)
+    _write_json(
+        intake,
+        _intake_payload([
+            {"candidate_id": "c1", "roadmap_phase": "p1", "intake_status": "eligible"},
+        ]),
+    )
+    _write_json(promo, _promo_payload([]))
+    _write_json(adm, _adm_payload([]))
+    _write_jsonl(hist, [])
+    snap_a = drp.collect_snapshot(
+        intake_artifact_path=intake,
+        promotion_artifact_path=promo,
+        admission_artifact_path=adm,
+        step5_history_path=hist,
+        generated_at_utc="2026-05-10T00:00:00Z",
+    )
+    snap_b = drp.collect_snapshot(
+        intake_artifact_path=intake,
+        promotion_artifact_path=promo,
+        admission_artifact_path=adm,
+        step5_history_path=hist,
+        generated_at_utc="2026-05-10T00:00:00Z",
+    )
+    assert (
+        json.dumps(snap_a, sort_keys=True, indent=2)
+        == json.dumps(snap_b, sort_keys=True, indent=2)
+    )
+
+
+def test_no_upstream_artifacts_yields_clean_snapshot(tmp_path: Path) -> None:
+    intake, promo, adm, hist = _make_paths(tmp_path)
+    snap = drp.collect_snapshot(
+        intake_artifact_path=intake,
+        promotion_artifact_path=promo,
+        admission_artifact_path=adm,
+        step5_history_path=hist,
+    )
+    assert snap["rows"] == []
+    assert snap["note"] == "no_upstream_artifacts"
+
+
+# ---------------------------------------------------------------------------
+# Source / AST scans
+# ---------------------------------------------------------------------------
+
+
+def _module_source() -> str:
+    return Path(drp.__file__).read_text(encoding="utf-8")
+
+
+def _imported_module_names() -> set[str]:
+    import ast
+
+    src = _module_source()
+    tree = ast.parse(src)
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module is not None:
+                names.add(node.module)
+    return names
+
+
+def test_no_subprocess_or_network_in_module() -> None:
+    src = _module_source()
+    forbidden = (
+        "import subprocess",
+        "from subprocess",
+        "import socket",
+        "import urllib",
+        "import http.client",
+        "import requests",
+        "import httpx",
+        "import aiohttp",
+    )
+    for s in forbidden:
+        assert s not in src, s
+
+
+def test_no_dashboard_or_frontend_imports() -> None:
+    forbidden_prefixes = (
+        "dashboard",
+        "frontend",
+        "automation",
+        "broker",
+        "agent.risk",
+        "agent.execution",
+        "research",
+        "reporting.intelligent_routing",
+        "live",
+        "paper",
+        "shadow",
+        "trading",
+    )
+    for module in _imported_module_names():
+        for prefix in forbidden_prefixes:
+            assert not (
+                module == prefix or module.startswith(prefix + ".")
+            ), f"forbidden import: {module}"
+
+
+def test_module_imports_cleanly() -> None:
+    importlib.reload(drp)
+    assert callable(drp.collect_snapshot)
+
+
+def test_importing_module_does_not_flip_step5_invariants() -> None:
+    from reporting import development_step5_loop as dsl
+
+    importlib.reload(drp)
+    assert dsl.step5_implementation_allowed is False
+    assert dsl.STEP5_ENABLED_SUBSTAGE == "none"
+
+
+def test_module_does_not_open_seed_jsonl_for_writing() -> None:
+    src = _module_source()
+    forbidden = (
+        "seed.jsonl\", \"w",
+        "seed.jsonl', 'w",
+        "seed.jsonl\", \"a",
+        "seed.jsonl', 'a",
+        "delegation_seed.jsonl\", \"w",
+        "GENERATED_SEED_PATH",
+    )
+    for s in forbidden:
+        assert s not in src, s
+
+
+def test_module_does_not_mutate_canonical_roadmap() -> None:
+    """Defense in depth: A19 source must not contain code that writes
+    to the canonical roadmap docs."""
+    src = _module_source()
+    forbidden = (
+        "Roadmap v6.md\", \"w",
+        "autonomous_development.txt\", \"w",
+    )
+    for s in forbidden:
+        assert s not in src

--- a/tests/unit/test_development_roadmap_progress_status.py
+++ b/tests/unit/test_development_roadmap_progress_status.py
@@ -1,0 +1,129 @@
+"""Unit tests for A19 — Roadmap Progress Tracker status summary."""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reporting import development_roadmap_progress as drp
+from reporting import development_roadmap_progress_status as drps
+
+
+def _write_progress(tmp_path: Path, payload: dict[str, Any]) -> Path:
+    p = tmp_path / "logs" / "development_roadmap_progress" / "latest.json"
+    p.parent.mkdir(parents=True)
+    p.write_text(
+        json.dumps(payload, sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return p
+
+
+def _synthetic(by_state: dict[str, int]) -> dict[str, Any]:
+    counts = {
+        "phase_count": sum(by_state.values()),
+        "by_phase_progress_state": {s: 0 for s in drp.PHASE_PROGRESS_STATES},
+    }
+    for s, n in by_state.items():
+        if s in counts["by_phase_progress_state"]:
+            counts["by_phase_progress_state"][s] = n
+    return {
+        "schema_version": "1.0",
+        "module_version": drp.MODULE_VERSION,
+        "report_kind": "development_roadmap_progress",
+        "generated_at_utc": "2026-05-10T00:00:00Z",
+        "step5_enabled_substage": "none",
+        "step5_implementation_allowed": False,
+        "note": "roadmap_phases_present",
+        "validation_warnings": [],
+        "counts": counts,
+        "rows": [],
+    }
+
+
+def test_atomic_write_refuses_non_status_logs_path(tmp_path: Path) -> None:
+    bad = tmp_path / "evil_dir" / "latest.json"
+    with pytest.raises(ValueError):
+        drps._atomic_write_json(bad, {"x": 1})
+
+
+def test_status_when_artifact_absent(tmp_path: Path) -> None:
+    missing = tmp_path / "logs" / "development_roadmap_progress" / "latest.json"
+    snap = drps.collect_status(
+        progress_artifact_path=missing,
+        generated_at_utc="2026-05-10T00:00:00Z",
+    )
+    assert snap["progress_artifact_available"] is False
+    assert snap["counts"]["phase_count"] == 0
+    assert snap["note"] == "progress_artifact_absent"
+    assert snap["step5_implementation_allowed"] is False
+
+
+def test_status_counts_mirror_upstream(tmp_path: Path) -> None:
+    payload = _synthetic({"intake_only": 1, "promotion_active": 1, "planning_active": 1})
+    artifact = _write_progress(tmp_path, payload)
+    snap = drps.collect_status(
+        progress_artifact_path=artifact,
+        generated_at_utc="2026-05-10T00:00:00Z",
+    )
+    assert snap["progress_artifact_available"] is True
+    assert snap["counts"]["phase_count"] == 3
+    assert snap["counts"]["by_phase_progress_state"]["intake_only"] == 1
+    assert snap["counts"]["by_phase_progress_state"]["promotion_active"] == 1
+    assert snap["counts"]["by_phase_progress_state"]["planning_active"] == 1
+    # complete count must always be 0 — A19 never assigns it.
+    assert snap["counts"]["by_phase_progress_state"]["complete"] == 0
+
+
+def test_status_handles_corrupt_artifact(tmp_path: Path) -> None:
+    bad = tmp_path / "logs" / "development_roadmap_progress" / "latest.json"
+    bad.parent.mkdir(parents=True)
+    bad.write_text("not json", encoding="utf-8")
+    snap = drps.collect_status(
+        progress_artifact_path=bad,
+        generated_at_utc="2026-05-10T00:00:00Z",
+    )
+    assert snap["progress_artifact_available"] is False
+
+
+def test_status_module_imports_cleanly() -> None:
+    importlib.reload(drps)
+    assert callable(drps.collect_status)
+
+
+def test_no_forbidden_imports_in_status_module() -> None:
+    import ast
+
+    src = Path(drps.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module is not None:
+                names.add(node.module)
+    forbidden_prefixes = (
+        "dashboard",
+        "frontend",
+        "automation",
+        "broker",
+        "agent.risk",
+        "agent.execution",
+        "research",
+        "reporting.intelligent_routing",
+        "live",
+        "paper",
+        "shadow",
+        "trading",
+    )
+    for module in names:
+        for prefix in forbidden_prefixes:
+            assert not (
+                module == prefix or module.startswith(prefix + ".")
+            ), f"forbidden import: {module}"


### PR DESCRIPTION
## Summary

A19 — pure-stdlib projector that joins the read-only ADE artefacts (intake bridge, A16a promotion, A17 admission policy, Step 5.0 plan history) and emits a per-phase progress snapshot. **Reports only; mutates nothing; never marks a phase complete; never edits canonical roadmap status fields.**

## What lands

- `reporting/development_roadmap_progress.py` — closed `PHASE_PROGRESS_STATES` (6 values), 15-key per-row schema. **A19 NEVER assigns `complete` autonomously** — operator-only marker (pinned by `test_a19_never_assigns_complete`).
- `reporting/development_roadmap_progress_status.py` — status summary by `phase_progress_state`.
- `docs/governance/development_roadmap_progress.md` — full surface doc.
- `tests/unit/test_development_roadmap_progress.py` (21 tests) + `tests/unit/test_development_roadmap_progress_status.py` (6 tests).

## Hard guarantees (pinned by tests)

- No write to `seed.jsonl` / `delegation_seed.jsonl` / `generated_seed.jsonl`.
- No write to canonical roadmap docs.
- A19 never assigns `phase_progress_state=\"complete\"` (synthetic test with maximally rich upstream signal still lands in `planning_active`).
- No `dashboard` / `frontend` / `automation` / `broker` / `agent.risk` / `agent.execution` / `research` / `reporting.intelligent_routing` / live / paper / shadow / trading imports.
- No subprocess / network / `gh` / `git`.
- `step5_implementation_allowed=false`, `STEP5_ENABLED_SUBSTAGE=\"none\"`, Level 6 permanently disabled.

## Live verification on `main`

`python -m reporting.development_roadmap_progress --no-write` against the existing intake/promotion/admission artefacts:

- phase `v3.15.16` → `phase_progress_state=promotion_active` (real A15 candidate present in promotion stage, no plan_emitted in this run).
- `phase_count=1`.

## Test plan

- [x] `python scripts/governance_lint.py` — OK.
- [x] `python -m pytest tests/unit/test_development_roadmap_progress*.py -q` — **27 passed**.
- [x] Stack regression (intake + promotion + admission) — **160 passed**.
- [x] `python -m pytest tests/smoke -q` — **18 passed**.
- [x] Diff scope = 5 A19 files.
- [x] CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)