### PR TITLE
feat(notif): N3a — Mobile Approval Inbox projector (read-only)

### DIFF
--- a/docs/governance/mobile_approval_inbox.md
+++ b/docs/governance/mobile_approval_inbox.md
@@ -1,0 +1,246 @@
+# Mobile Approval Inbox projector — N3a (read-only)
+
+> **Status:** Implemented (read-only, projector-only).
+>
+> **Module:** [`reporting/mobile_approval_inbox.py`](../../reporting/mobile_approval_inbox.py)
+> **Output artefact:** `logs/mobile_approval_inbox/latest.json`
+>
+> **Authority:** development-governance read-only.
+> N3a mints no token, approves nothing, merges nothing, deploys
+> nothing, sends no push, opens no PWA inbox screen, registers no
+> Flask blueprint. Level 6 stays permanently disabled per ADR-015
+> §Doctrine 1. **No approval can happen from a notification click
+> alone.**
+
+---
+
+## 1. Purpose
+
+N3a is the **projector** half of the future Mobile Approval Inbox
+surface. It reads the existing N2b-1 outbox at
+`logs/notification_dispatch_outbox/latest.json`, classifies each
+record's attention level, and emits a bounded inbox artefact at
+`logs/mobile_approval_inbox/latest.json`.
+
+The artefact is consumed by:
+
+- **A23 Merge Recommendation** (next slice) — combines this inbox
+  with the A22 PR lifecycle observer to produce a recommendation
+  record.
+- **N3b** (deferred, operator-action) — adds a Flask blueprint
+  serving the inbox under `/api/approval-inbox/v2/*`.
+- **N3c** (deferred, operator-action) — adds the PWA detail UI.
+
+N3a itself is purely an inspection surface — operators can already
+view today what the future N3b API would return and what the future
+N3c UI would render.
+
+---
+
+## 2. Hard constraints
+
+N3a, in this PR and at runtime, must not:
+
+- mint or verify approval tokens (N4 territory);
+- execute an approve / reject decision (N4 + N5 territory);
+- merge or deploy anything (N5 + future deploy adapter territory);
+- send any real push (N2b-3b territory);
+- register a Flask blueprint or wire into `dashboard/dashboard.py`
+  (N3b territory);
+- write to `seed.jsonl` / `delegation_seed.jsonl` /
+  `generated_seed.jsonl`;
+- mutate any upstream artefact;
+- edit canonical roadmap status fields;
+- mark any roadmap phase complete;
+- enable Step 5.1 or Step 5.2;
+- flip `step5_implementation_allowed`;
+- change `STEP5_ENABLED_SUBSTAGE`;
+- change QRE behaviour;
+- mutate research artifacts;
+- touch live / paper / shadow / risk / broker / execution paths;
+- edit `.claude/**`;
+- store secrets in repo.
+
+N3a ships its own AST-level forbidden-import scan + source-text
+scan to enforce the relevant bullets.
+
+---
+
+## 3. Closed vocabularies
+
+Pinned in [`reporting/mobile_approval_inbox.py`](../../reporting/mobile_approval_inbox.py):
+
+### `attention_level` (4 values)
+
+| Value                | When                                                                              |
+| -------------------- | --------------------------------------------------------------------------------- |
+| `informational`      | severity in `silent` / `digest` / `push_info` and intent is `sent` / `duplicate`  |
+| `needs_review`       | severity in `push_action_required` / `approval_required`                          |
+| `blocked_attention`  | outbound intent in `failed_secret_check` / `failed_stub_provider` / `rate_limited_outbound` |
+| `critical_attention` | severity == `critical`                                                            |
+
+### `decision_state` (6 values, but N3a only emits `pending`)
+
+```
+pending  acknowledged  approved  rejected  expired  superseded
+```
+
+N3a NEVER writes a value other than `pending`. The remaining values
+are reserved for the future N4 approval-token gate — once that lands
+and is operator-authorised, it becomes the only path that can flip
+`pending → approved` or `pending → rejected`. N3a has no callable
+that could effect such a flip.
+
+### `source_module` (1 value)
+
+```
+notification_dispatch_outbox
+```
+
+Tightly bounded. Adding a new source requires a code change pinned
+by an updated unit test.
+
+### `validation_warnings` (4 values)
+
+```
+outbox_artifact_absent
+outbox_artifact_unparseable
+outbox_record_invalid
+decision_verb_redacted_in_summary
+```
+
+### Per-row schema (14 keys, exact and ordered)
+
+```
+inbox_row_id  event_id  event_kind  event_severity
+source_module  source_id  endpoint_hash  outbound_delivery_intent
+attention_level  decision_state
+title  summary  open_at  created_at
+```
+
+All scalars bounded: `title ≤ 80 chars`, `summary ≤ 200 chars`,
+`open_at ≤ 300 chars`. The inbox surface itself is bounded
+(`MAX_INBOX_ROWS = 64`) so even a runaway outbox can't blow up the
+artefact size.
+
+---
+
+## 4. Decision-verb redaction
+
+N3a scans every emitted `title` and `summary` for the closed
+forbidden-verb set (`approve`, `reject`, `merge`, `deploy`) and
+**replaces the whole string with `[redacted-decision-verb]`** if any
+match. This is defense-in-depth: the closed N2b-1 payload schema
+already refuses decision verbs at the upstream layer, so this should
+never fire in production. If it does, a
+`decision_verb_redacted_in_summary` warning is added to the snapshot
+so the operator sees the upstream contract violation.
+
+---
+
+## 5. Discipline invariants (emitted on every artefact)
+
+```
+mints_approval_token                          = false
+verifies_approval_token                       = false
+executes_approve_or_reject                    = false
+merges_or_deploys                             = false
+sends_real_push                               = false
+opens_pwa_inbox_screen                        = false
+registers_flask_blueprint                     = false
+uses_subprocess_or_network                    = false
+operator_promotion_required                   = true
+step5_implementation_allowed                  = false
+step5_enabled_substage                        = "none"
+diagnostics_do_not_trade                      = true
+no_approval_from_notification_click_alone     = true
+```
+
+Every emitted snapshot is additionally routed through
+[`reporting.agent_audit_summary.assert_no_secrets`](../../reporting/agent_audit_summary.py)
+before write.
+
+---
+
+## 6. CLI
+
+```sh
+python -m reporting.mobile_approval_inbox --no-write
+python -m reporting.mobile_approval_inbox
+```
+
+Pure stdlib + `reporting.notification_dispatch_outbox` (read-only) +
+`reporting.notification_event` (read-only) +
+`reporting.agent_audit_summary.assert_no_secrets`. No subprocess, no
+network, no `gh`, no `git`.
+
+---
+
+## 7. Authority chain summary
+
+| Capability                                              | Today (post-A22) | After N3a                                | After N3b (future, operator-authored) | After N3c (future, operator-authored) | After N4b (future, operator-authored) | After N5 (future, operator-authored) |
+| ------------------------------------------------------- | ---------------- | ---------------------------------------- | -------------------------------------- | -------------------------------------- | --------------------------------------- | ------------------------------------- |
+| Compute inbox rows from outbox                          | does not exist   | yes — N3a (read-only)                    | unchanged                              | unchanged                              | unchanged                               | unchanged                             |
+| Serve inbox over HTTP                                    | does not exist   | does not exist                           | yes — `dashboard/api_approval_inbox_v2.py` | unchanged                          | unchanged                               | unchanged                             |
+| Render inbox in PWA                                      | does not exist   | does not exist                           | does not exist                         | yes — `frontend/src/routes/AgentControl/InboxDetail.tsx` | unchanged                  | unchanged                             |
+| Mint approval token                                      | does not exist   | does not exist                           | does not exist                         | does not exist                         | yes — operator-env-only                 | unchanged                             |
+| Execute approve / reject                                 | does not exist   | does not exist                           | does not exist                         | does not exist                         | does not exist                          | yes — bounded merge adapter           |
+| Autonomous merge / deploy                                | forbidden, Level 6 | unchanged — Level 6 permanently disabled | unchanged                              | unchanged                              | unchanged                               | unchanged                             |
+
+N3a is the **inspection-only** surface that lets the operator see
+what the future N3b/N3c/N4b/N5 stack would expose, **without**
+adding any of those surfaces yet.
+
+---
+
+## 8. Test coverage
+
+Pinned in [`tests/unit/test_mobile_approval_inbox.py`](../../tests/unit/test_mobile_approval_inbox.py):
+
+- closed `ATTENTION_LEVELS`, `INBOX_DECISION_STATES`,
+  `SOURCE_MODULES`, `VALIDATION_WARNINGS`, `INBOX_ROW_KEYS` pinned
+  exactly;
+- every row of §3's attention-level table maps correctly to one
+  of the four levels;
+- `decision_state` is NEVER set to anything other than `pending`
+  by N3a (pinned with synthetic upstream that already carries an
+  `approved` decision state — N3a still emits `pending`);
+- decision-verb redaction triggers on a forbidden token in the
+  upstream payload (defense-in-depth);
+- inbox rows are bounded to `MAX_INBOX_ROWS = 64` even when the
+  upstream outbox is larger;
+- `endpoint_hash` is propagated; full endpoint URL is NOT leaked
+  in any inbox scalar;
+- atomic write refuses any path outside
+  `logs/mobile_approval_inbox/`;
+- AST-level forbidden-import scan: no `dashboard`, `frontend`,
+  `automation`, `broker`, `agent.risk`, `agent.execution`,
+  `research`, `reporting.intelligent_routing`, `live`, `paper`,
+  `shadow`, `trading`;
+- source-text scan: no `subprocess`, `socket`, `urllib`,
+  `requests`, `httpx`, `aiohttp`, `pywebpush`, `web_push`, `gh`,
+  `git`;
+- importing the module does not flip Step 5 invariants;
+- this doc states "no approval from notification click alone".
+
+---
+
+## 9. What N3a does NOT do
+
+- N3a never mints or verifies approval tokens.
+- N3a never approves or rejects any row.
+- N3a never merges or deploys.
+- N3a never sends a real push.
+- N3a never registers a Flask blueprint.
+- N3a never writes to `dashboard/dashboard.py` or `frontend/**`.
+- N3a never writes to any seed file.
+- N3a never edits canonical roadmap status fields.
+- N3a never marks a roadmap phase complete.
+- N3a does not flip `step5_implementation_allowed`.
+- N3a does not change `STEP5_ENABLED_SUBSTAGE`.
+- Step 5.1 / Step 5.2 remain BLOCKED.
+- N3b / N3c / N4 (live) / N5 / deploy adapter remain
+  unimplemented.
+- Level 6 stays permanently disabled. Mobile approval is human
+  approval, not autonomous merge or deploy. **No approval can
+  happen from notification click alone.**

--- a/reporting/mobile_approval_inbox.py
+++ b/reporting/mobile_approval_inbox.py
@@ -1,0 +1,555 @@
+"""N3a — Mobile Approval Inbox projector (read-only).
+
+Pure stdlib-only projector that reads the existing N2b-1 dispatch
+outbox artefact at ``logs/notification_dispatch_outbox/latest.json``
+and projects the subset of rows that warrant operator attention into
+a bounded mobile inbox artefact at
+``logs/mobile_approval_inbox/latest.json``.
+
+N3a is **strictly read-only**. It does **not**:
+
+* mint or verify approval tokens (that is N4 territory);
+* approve, reject, merge, or deploy anything (N5 territory);
+* open a real PWA inbox screen (N3c territory);
+* register a Flask blueprint or otherwise wire into the dashboard
+  (N3b territory);
+* send any push, write any subscription state, or call any
+  Web Push provider (N2b-3 territory);
+* mutate any upstream artefact;
+* edit any roadmap status field;
+* mark any roadmap phase complete.
+
+Today N3a is consulted by no one in production. It is a pure
+projector that emits ``logs/mobile_approval_inbox/latest.json`` so
+the operator can inspect what a future N3b API + N3c UI would
+display, before those slices are authorised.
+
+Hard guarantees (pinned by tests)
+---------------------------------
+
+* Stdlib + ``reporting.notification_dispatch_outbox`` (read-only) +
+  ``reporting.notification_event`` (read-only) +
+  ``reporting.agent_audit_summary.assert_no_secrets`` (read-only
+  redactor guard).
+* No subprocess, no network, no ``gh``, no ``git``.
+* No imports of ``dashboard``, ``frontend``, ``automation``,
+  ``broker``, ``agent.risk``, ``agent.execution``, ``research``,
+  ``reporting.intelligent_routing``, ``live``, ``paper``, ``shadow``,
+  ``trading``.
+* Atomic write only under ``logs/mobile_approval_inbox/...``.
+* Per-row schema is closed and exact. Bounded scalars only — no
+  diff content, no PR body, no command summary.
+* No decision verb (``approve``, ``reject``, ``merge``, ``deploy``)
+  appears in the emitted record. The future N3c UI is the only
+  surface allowed to expose action affordances, and even then the
+  click only opens the PWA detail screen — N4 + re-authentication
+  remain the only path to a real decision.
+* ``step5_implementation_allowed`` remains ``False`` and
+  ``STEP5_ENABLED_SUBSTAGE`` remains ``"none"``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Final
+
+from reporting import notification_dispatch_outbox as ndo
+from reporting import notification_event as ne
+from reporting.agent_audit_summary import assert_no_secrets
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[str] = "1.0"
+MODULE_VERSION: Final[str] = "v3.15.16.N3a"
+REPORT_KIND: Final[str] = "mobile_approval_inbox"
+
+# ---------------------------------------------------------------------------
+# Step 5 invariants
+# ---------------------------------------------------------------------------
+
+STEP5_ENABLED_SUBSTAGE: Final[str] = "none"
+step5_implementation_allowed: Final[bool] = False
+
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies
+# ---------------------------------------------------------------------------
+
+#: Closed inbox-row attention-level vocabulary.
+ATTENTION_LEVELS: Final[tuple[str, ...]] = (
+    "informational",
+    "needs_review",
+    "blocked_attention",
+    "critical_attention",
+)
+
+#: Closed inbox decision-state vocabulary. Reserved for the future
+#: N4 approval-token gate. N3a NEVER sets a value other than
+#: ``pending`` — `approved`, `rejected`, `expired`, and
+#: `superseded` are reserved for the future N4 surface to set, never
+#: by N3a itself.
+INBOX_DECISION_STATES: Final[tuple[str, ...]] = (
+    "pending",
+    "acknowledged",
+    "approved",
+    "rejected",
+    "expired",
+    "superseded",
+)
+
+#: Closed source-module vocabulary the inbox accepts upstream from.
+SOURCE_MODULES: Final[tuple[str, ...]] = (
+    "notification_dispatch_outbox",
+)
+
+#: Closed validation-warning vocabulary.
+VALIDATION_WARNINGS: Final[tuple[str, ...]] = (
+    "outbox_artifact_absent",
+    "outbox_artifact_unparseable",
+    "outbox_record_invalid",
+    "decision_verb_redacted_in_summary",
+)
+
+#: Closed per-row schema, exact and ordered.
+INBOX_ROW_KEYS: Final[tuple[str, ...]] = (
+    "inbox_row_id",
+    "event_id",
+    "event_kind",
+    "event_severity",
+    "source_module",
+    "source_id",
+    "endpoint_hash",
+    "outbound_delivery_intent",
+    "attention_level",
+    "decision_state",
+    "title",
+    "summary",
+    "open_at",
+    "created_at",
+)
+
+#: Bounded length for free-text scalars; tighter than N2a/N2b-1
+#: because mobile rendering is the constraint.
+MAX_TITLE_LEN: Final[int] = 80
+MAX_SUMMARY_LEN: Final[int] = 200
+MAX_OPEN_AT_LEN: Final[int] = 300
+
+#: Maximum number of inbox rows kept in any single snapshot. Bounds
+#: the artefact size and the future N3c rendering surface.
+MAX_INBOX_ROWS: Final[int] = 64
+
+#: Severities that warrant operator attention. Anything else routes
+#: to ``informational`` and downstream gating may suppress display.
+_ATTENTION_SEVERITIES: Final[dict[str, str]] = {
+    "push_action_required": "needs_review",
+    "approval_required": "needs_review",
+    "critical": "critical_attention",
+}
+
+#: Outbound delivery intents that signal a blocked / failure state.
+_BLOCKED_INTENTS: Final[frozenset[str]] = frozenset(
+    {"failed_secret_check", "failed_stub_provider", "rate_limited_outbound"}
+)
+
+#: Forbidden decision-verb tokens inside any rendered scalar.
+_FORBIDDEN_DECISION_VERBS: Final[tuple[str, ...]] = (
+    "approve",
+    "reject",
+    "merge ",
+    " merge",
+    "deploy",
+)
+
+#: Wrapper-level note vocabulary.
+NOTE_NO_OUTBOX: Final[str] = "outbox_artifact_absent"
+NOTE_NO_ATTENTION: Final[str] = "no_rows_warrant_attention"
+NOTE_INBOX_PRESENT: Final[str] = "inbox_rows_present"
+
+#: Repo-relative paths.
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "mobile_approval_inbox"
+ARTIFACT_LATEST: Final[Path] = ARTIFACT_DIR / "latest.json"
+ARTIFACT_RELATIVE_PATH: Final[str] = (
+    "logs/mobile_approval_inbox/latest.json"
+)
+
+#: Atomic-write allowlist (substring form).
+_WRITE_PREFIX: Final[str] = "logs/mobile_approval_inbox/"
+
+
+# ---------------------------------------------------------------------------
+# Discipline invariants emitted into every artefact
+# ---------------------------------------------------------------------------
+
+_DISCIPLINE_INVARIANTS: Final[dict[str, bool | str]] = {
+    "mints_approval_token": False,
+    "verifies_approval_token": False,
+    "executes_approve_or_reject": False,
+    "merges_or_deploys": False,
+    "sends_real_push": False,
+    "opens_pwa_inbox_screen": False,
+    "registers_flask_blueprint": False,
+    "uses_subprocess_or_network": False,
+    "calls_llm_or_external_api": False,
+    "mutates_research_artifacts": False,
+    "mutates_roadmap_status_fields": False,
+    "writes_to_seed_jsonl": False,
+    "operator_promotion_required": True,
+    "step5_implementation_allowed": False,
+    "step5_enabled_substage": "none",
+    "diagnostics_do_not_trade": True,
+    "no_approval_from_notification_click_alone": True,
+}
+
+
+# ---------------------------------------------------------------------------
+# Utility helpers
+# ---------------------------------------------------------------------------
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+
+def _bounded(value: Any, max_len: int) -> str:
+    if not isinstance(value, str):
+        return ""
+    return value[:max_len]
+
+
+def _contains_decision_verb(text: str) -> bool:
+    if not isinstance(text, str):
+        return False
+    lo = text.lower()
+    for verb in _FORBIDDEN_DECISION_VERBS:
+        if verb in lo:
+            return True
+    return False
+
+
+def _redact_decision_verbs(text: str) -> tuple[str, bool]:
+    """If ``text`` contains a forbidden decision verb, redact it
+    with the closed-vocab placeholder. Returns ``(text, was_redacted)``.
+    """
+    if not _contains_decision_verb(text):
+        return text, False
+    lo = text.lower()
+    out = text
+    for verb in _FORBIDDEN_DECISION_VERBS:
+        if verb in lo:
+            # Use a generic placeholder; mobile detail screen will
+            # surface the full evidence behind authentication.
+            out = "[redacted-decision-verb]"
+            break
+    return out, True
+
+
+# ---------------------------------------------------------------------------
+# Attention-level classification
+# ---------------------------------------------------------------------------
+
+
+def classify_attention(record: dict[str, Any]) -> str:
+    """Closed-table mapping from one N2b-1 outbox record to an
+    attention level. Pure, deterministic, side-effect-free."""
+    if not isinstance(record, dict):
+        return "informational"
+    intent = record.get("outbound_delivery_intent")
+    severity = record.get("event_severity")
+    if intent in _BLOCKED_INTENTS:
+        return "blocked_attention"
+    if isinstance(severity, str) and severity in _ATTENTION_SEVERITIES:
+        return _ATTENTION_SEVERITIES[severity]
+    return "informational"
+
+
+# ---------------------------------------------------------------------------
+# Per-row construction
+# ---------------------------------------------------------------------------
+
+
+def _inbox_row_id(event_id: str) -> str:
+    """Stable inbox row id derived from the event_id. Mirroring the
+    N2a/N2b-1 event_id keeps the identity chain auditable."""
+    return f"mai_{event_id[:32]}" if event_id else ""
+
+
+def _build_row(
+    record: dict[str, Any],
+    *,
+    created_at: str,
+    warnings: list[str],
+) -> dict[str, Any] | None:
+    """Coerce one N2b-1 outbox record into the closed inbox schema.
+
+    Returns ``None`` if the record's identity is unusable.
+    Otherwise returns a closed-schema row.
+    """
+    if not isinstance(record, dict):
+        warnings.append("outbox_record_invalid")
+        return None
+    event_id = str(record.get("event_id") or "")
+    if not event_id:
+        warnings.append("outbox_record_invalid")
+        return None
+
+    attention_level = classify_attention(record)
+    payload = record.get("payload")
+    if not isinstance(payload, dict):
+        payload = {}
+
+    title_raw = _bounded(payload.get("title"), MAX_TITLE_LEN)
+    summary_raw = _bounded(payload.get("summary"), MAX_SUMMARY_LEN)
+    open_at_raw = _bounded(payload.get("open_at"), MAX_OPEN_AT_LEN)
+
+    title_clean, title_redacted = _redact_decision_verbs(title_raw)
+    summary_clean, summary_redacted = _redact_decision_verbs(summary_raw)
+    if title_redacted or summary_redacted:
+        warnings.append("decision_verb_redacted_in_summary")
+
+    row: dict[str, Any] = {
+        "inbox_row_id": _inbox_row_id(event_id),
+        "event_id": event_id,
+        "event_kind": str(record.get("event_kind") or ""),
+        "event_severity": str(record.get("event_severity") or ""),
+        "source_module": "notification_dispatch_outbox",
+        "source_id": str(record.get("source_id") or ""),
+        "endpoint_hash": str(record.get("endpoint_hash") or ""),
+        "outbound_delivery_intent": str(
+            record.get("outbound_delivery_intent") or ""
+        ),
+        "attention_level": attention_level,
+        # Closed: N3a NEVER sets this to anything other than
+        # `pending`. The future N4 surface is the only path that
+        # can flip it.
+        "decision_state": "pending",
+        "title": title_clean,
+        "summary": summary_clean,
+        "open_at": open_at_raw,
+        "created_at": created_at,
+    }
+    assert set(row.keys()) == set(INBOX_ROW_KEYS)
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Aggregation
+# ---------------------------------------------------------------------------
+
+
+def _empty_counts() -> dict[str, Any]:
+    return {
+        "total": 0,
+        "informational": 0,
+        "needs_review": 0,
+        "blocked_attention": 0,
+        "critical_attention": 0,
+        "by_attention_level": {a: 0 for a in ATTENTION_LEVELS},
+        "by_event_kind": {k: 0 for k in ne.EVENT_KINDS},
+        "by_event_severity": {s: 0 for s in ne.EVENT_SEVERITIES},
+    }
+
+
+def _aggregate_counts(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    counts = _empty_counts()
+    counts["total"] = len(rows)
+    for row in rows:
+        att = row.get("attention_level")
+        if att in counts:
+            counts[att] += 1
+        if att in counts["by_attention_level"]:
+            counts["by_attention_level"][att] += 1
+        kind = row.get("event_kind")
+        if isinstance(kind, str) and kind in counts["by_event_kind"]:
+            counts["by_event_kind"][kind] += 1
+        sev = row.get("event_severity")
+        if isinstance(sev, str) and sev in counts["by_event_severity"]:
+            counts["by_event_severity"][sev] += 1
+    return counts
+
+
+# ---------------------------------------------------------------------------
+# Snapshot assembly
+# ---------------------------------------------------------------------------
+
+
+def collect_snapshot(
+    *,
+    outbox_artifact_path: Path | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    """Build the deterministic inbox snapshot.
+
+    Reads ``logs/notification_dispatch_outbox/latest.json`` (read-only).
+    Never mutates upstream. Returns a closed-schema snapshot.
+    """
+    op = (
+        outbox_artifact_path
+        if outbox_artifact_path is not None
+        else ndo.ARTIFACT_LATEST
+    )
+    ts = generated_at_utc if generated_at_utc is not None else _utcnow()
+
+    payload = _read_json(op)
+    warnings: list[str] = []
+    rows: list[dict[str, Any]] = []
+
+    if payload is None:
+        warnings.append("outbox_artifact_absent")
+        note = NOTE_NO_OUTBOX
+        records: list[dict[str, Any]] = []
+    elif not isinstance(payload, dict):
+        warnings.append("outbox_artifact_unparseable")
+        note = NOTE_NO_OUTBOX
+        records = []
+    else:
+        raw = payload.get("records")
+        records = (
+            [r for r in raw if isinstance(r, dict)] if isinstance(raw, list) else []
+        )
+        note = NOTE_NO_ATTENTION
+
+    for rec in records:
+        row = _build_row(rec, created_at=ts, warnings=warnings)
+        if row is None:
+            continue
+        # Bound the inbox surface even with a huge outbox upstream.
+        if len(rows) >= MAX_INBOX_ROWS:
+            break
+        rows.append(row)
+
+    rows.sort(key=lambda r: (r["attention_level"], r["event_id"]))
+
+    if rows:
+        note = NOTE_INBOX_PRESENT
+
+    counts = _aggregate_counts(rows)
+
+    snapshot = {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": ts,
+        "step5_enabled_substage": STEP5_ENABLED_SUBSTAGE,
+        "step5_implementation_allowed": step5_implementation_allowed,
+        "outbox_artifact_path": str(op),
+        "outbox_artifact_available": payload is not None,
+        "max_inbox_rows": MAX_INBOX_ROWS,
+        "note": note,
+        "validation_warnings": warnings,
+        "vocabularies": {
+            "attention_levels": list(ATTENTION_LEVELS),
+            "inbox_decision_states": list(INBOX_DECISION_STATES),
+            "source_modules": list(SOURCE_MODULES),
+            "validation_warnings": list(VALIDATION_WARNINGS),
+            "inbox_row_keys": list(INBOX_ROW_KEYS),
+        },
+        "counts": counts,
+        "rows": rows,
+        "notification_dispatch_outbox_module_version": ndo.MODULE_VERSION,
+        "notification_event_module_version": ne.MODULE_VERSION,
+        "discipline_invariants": dict(_DISCIPLINE_INVARIANTS),
+    }
+    assert_no_secrets(snapshot)
+    return snapshot
+
+
+# ---------------------------------------------------------------------------
+# Atomic write
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    posix = path.as_posix()
+    if _WRITE_PREFIX not in posix and not posix.startswith(_WRITE_PREFIX):
+        raise ValueError(
+            "mobile_approval_inbox._atomic_write_json refuses "
+            f"non-inbox-logs output path: {path}"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".mobile_approval_inbox.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_outputs(snapshot: dict[str, Any]) -> Path:
+    _atomic_write_json(ARTIFACT_LATEST, snapshot)
+    return ARTIFACT_LATEST
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m reporting.mobile_approval_inbox",
+        description=(
+            "N3a Mobile Approval Inbox projector. Read-only "
+            "deterministic projector of "
+            "logs/notification_dispatch_outbox/latest.json. Mints "
+            "no token; approves no row; merges nothing; deploys "
+            "nothing. The future N3c PWA UI is the only surface "
+            "allowed to display the rows."
+        ),
+    )
+    p.add_argument(
+        "--indent", type=int, default=2, help="JSON indent (0 for compact)."
+    )
+    p.add_argument(
+        "--no-write",
+        action="store_true",
+        help=(
+            "Do not persist "
+            "logs/mobile_approval_inbox/latest.json (stdout only)."
+        ),
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    indent = args.indent if args.indent and args.indent > 0 else None
+    snap = collect_snapshot()
+    if not args.no_write:
+        write_outputs(snap)
+    json.dump(snap, sys.stdout, indent=indent, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/unit/test_mobile_approval_inbox.py
+++ b/tests/unit/test_mobile_approval_inbox.py
@@ -1,0 +1,572 @@
+"""Unit tests for N3a — Mobile Approval Inbox projector."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reporting import mobile_approval_inbox as mai
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _outbox_record(
+    *,
+    event_id: str = "eid_001abc",
+    event_kind: str = "intake_candidate_eligible",
+    event_severity: str = "push_info",
+    outbound_delivery_intent: str = "sent",
+    source_id: str = "src_001",
+    title: str = "Synthetic eligible candidate",
+    summary: str = "decision_state=eligible; risk=LOW",
+    open_at: str = "/agent-control/inbox?event=eid_001abc",
+    endpoint_hash: str = "deadbeefdeadbeef",
+) -> dict[str, Any]:
+    return {
+        "event_id": event_id,
+        "event_kind": event_kind,
+        "event_severity": event_severity,
+        "outbound_delivery_intent": outbound_delivery_intent,
+        "source_id": source_id,
+        "endpoint_hash": endpoint_hash,
+        "payload": {
+            "event_id": event_id,
+            "event_kind": event_kind,
+            "event_severity": event_severity,
+            "title": title,
+            "summary": summary,
+            "open_at": open_at,
+        },
+    }
+
+
+def _write_outbox(tmp_path: Path, records: list[dict[str, Any]]) -> Path:
+    p = tmp_path / "logs" / "notification_dispatch_outbox" / "latest.json"
+    p.parent.mkdir(parents=True)
+    payload = {
+        "schema_version": "1.0",
+        "module_version": "v0",
+        "report_kind": "notification_dispatch_outbox",
+        "generated_at_utc": "2026-05-10T00:00:00Z",
+        "step5_enabled_substage": "none",
+        "step5_implementation_allowed": False,
+        "records": records,
+    }
+    p.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies
+# ---------------------------------------------------------------------------
+
+
+def test_attention_levels_pinned_exactly() -> None:
+    assert mai.ATTENTION_LEVELS == (
+        "informational",
+        "needs_review",
+        "blocked_attention",
+        "critical_attention",
+    )
+
+
+def test_inbox_decision_states_pinned_exactly() -> None:
+    assert mai.INBOX_DECISION_STATES == (
+        "pending",
+        "acknowledged",
+        "approved",
+        "rejected",
+        "expired",
+        "superseded",
+    )
+
+
+def test_source_modules_pinned() -> None:
+    assert mai.SOURCE_MODULES == ("notification_dispatch_outbox",)
+
+
+def test_validation_warnings_pinned() -> None:
+    assert mai.VALIDATION_WARNINGS == (
+        "outbox_artifact_absent",
+        "outbox_artifact_unparseable",
+        "outbox_record_invalid",
+        "decision_verb_redacted_in_summary",
+    )
+
+
+def test_inbox_row_keys_pinned_exactly_and_ordered() -> None:
+    assert mai.INBOX_ROW_KEYS == (
+        "inbox_row_id",
+        "event_id",
+        "event_kind",
+        "event_severity",
+        "source_module",
+        "source_id",
+        "endpoint_hash",
+        "outbound_delivery_intent",
+        "attention_level",
+        "decision_state",
+        "title",
+        "summary",
+        "open_at",
+        "created_at",
+    )
+
+
+def test_max_inbox_rows_bounded() -> None:
+    assert mai.MAX_INBOX_ROWS == 64
+
+
+def test_step5_invariants_pinned() -> None:
+    assert mai.step5_implementation_allowed is False
+    assert mai.STEP5_ENABLED_SUBSTAGE == "none"
+
+
+# ---------------------------------------------------------------------------
+# Atomic write refusal
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_write_refuses_non_inbox_logs_path(tmp_path: Path) -> None:
+    bad = tmp_path / "evil_dir" / "latest.json"
+    with pytest.raises(ValueError):
+        mai._atomic_write_json(bad, {"x": 1})
+
+
+def test_atomic_write_refuses_upstream_outbox_path(tmp_path: Path) -> None:
+    bad = tmp_path / "logs" / "notification_dispatch_outbox" / "latest.json"
+    with pytest.raises(ValueError):
+        mai._atomic_write_json(bad, {"x": 1})
+
+
+# ---------------------------------------------------------------------------
+# Attention-level classification
+# ---------------------------------------------------------------------------
+
+
+def test_classify_informational_for_push_info_sent() -> None:
+    rec = _outbox_record(event_severity="push_info", outbound_delivery_intent="sent")
+    assert mai.classify_attention(rec) == "informational"
+
+
+def test_classify_needs_review_for_push_action_required() -> None:
+    rec = _outbox_record(event_severity="push_action_required")
+    assert mai.classify_attention(rec) == "needs_review"
+
+
+def test_classify_needs_review_for_approval_required() -> None:
+    rec = _outbox_record(event_severity="approval_required")
+    assert mai.classify_attention(rec) == "needs_review"
+
+
+def test_classify_critical_attention_for_critical_severity() -> None:
+    rec = _outbox_record(event_severity="critical")
+    assert mai.classify_attention(rec) == "critical_attention"
+
+
+def test_classify_blocked_attention_for_failed_secret_check() -> None:
+    rec = _outbox_record(outbound_delivery_intent="failed_secret_check")
+    assert mai.classify_attention(rec) == "blocked_attention"
+
+
+def test_classify_blocked_attention_for_failed_stub_provider() -> None:
+    rec = _outbox_record(outbound_delivery_intent="failed_stub_provider")
+    assert mai.classify_attention(rec) == "blocked_attention"
+
+
+def test_classify_blocked_attention_for_rate_limited_outbound() -> None:
+    rec = _outbox_record(outbound_delivery_intent="rate_limited_outbound")
+    assert mai.classify_attention(rec) == "blocked_attention"
+
+
+def test_classify_non_dict_is_informational() -> None:
+    # Non-dict input never crashes and defaults to informational.
+    assert mai.classify_attention("not a dict") == "informational"  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Decision-state invariant: N3a NEVER emits anything other than pending
+# ---------------------------------------------------------------------------
+
+
+def test_decision_state_always_pending_even_with_upstream_approved(
+    tmp_path: Path,
+) -> None:
+    """Even if the upstream record carries a (hypothetical)
+    `decision_state="approved"`, N3a's output row MUST set
+    decision_state="pending". N3a is forbidden from advancing the
+    decision state — that is N4 territory."""
+    rec = _outbox_record(event_severity="approval_required")
+    # Inject a hypothetical upstream decision_state — N3a should ignore it.
+    rec["decision_state"] = "approved"
+    artifact = _write_outbox(tmp_path, [rec])
+    snap = mai.collect_snapshot(
+        outbox_artifact_path=artifact,
+        generated_at_utc="2026-05-10T00:00:00Z",
+    )
+    assert len(snap["rows"]) == 1
+    assert snap["rows"][0]["decision_state"] == "pending"
+
+
+def test_decision_state_always_pending_for_every_record(
+    tmp_path: Path,
+) -> None:
+    """Across a mixed batch of upstream rows, EVERY emitted row has
+    decision_state == "pending"."""
+    records = [
+        _outbox_record(event_id=f"e{i:03d}", event_severity="approval_required")
+        for i in range(5)
+    ]
+    artifact = _write_outbox(tmp_path, records)
+    snap = mai.collect_snapshot(outbox_artifact_path=artifact)
+    for row in snap["rows"]:
+        assert row["decision_state"] == "pending"
+
+
+# ---------------------------------------------------------------------------
+# Decision-verb redaction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "forbidden",
+    ["approve", "reject", "merge ", " merge", "deploy"],
+)
+def test_decision_verb_in_title_is_redacted(
+    tmp_path: Path, forbidden: str
+) -> None:
+    rec = _outbox_record(
+        title=f"please {forbidden} this",
+        summary="bounded summary",
+    )
+    artifact = _write_outbox(tmp_path, [rec])
+    snap = mai.collect_snapshot(outbox_artifact_path=artifact)
+    row = snap["rows"][0]
+    assert row["title"] == "[redacted-decision-verb]"
+    assert "decision_verb_redacted_in_summary" in snap["validation_warnings"]
+
+
+def test_decision_verb_in_summary_is_redacted(tmp_path: Path) -> None:
+    rec = _outbox_record(
+        title="ok title",
+        summary="please approve this",
+    )
+    artifact = _write_outbox(tmp_path, [rec])
+    snap = mai.collect_snapshot(outbox_artifact_path=artifact)
+    row = snap["rows"][0]
+    assert row["summary"] == "[redacted-decision-verb]"
+
+
+def test_clean_title_summary_passes_through(tmp_path: Path) -> None:
+    rec = _outbox_record(
+        title="Synthetic eligible candidate",
+        summary="decision_state=eligible; risk=LOW",
+    )
+    artifact = _write_outbox(tmp_path, [rec])
+    snap = mai.collect_snapshot(outbox_artifact_path=artifact)
+    row = snap["rows"][0]
+    assert row["title"] == "Synthetic eligible candidate"
+    assert row["summary"].startswith("decision_state=eligible")
+
+
+# ---------------------------------------------------------------------------
+# Endpoint URL redaction
+# ---------------------------------------------------------------------------
+
+
+def test_no_full_endpoint_url_in_inbox_row(tmp_path: Path) -> None:
+    rec = _outbox_record(
+        endpoint_hash="deadbeefdeadbeef",
+        title="Synthetic",
+        summary="Synthetic summary",
+    )
+    artifact = _write_outbox(tmp_path, [rec])
+    snap = mai.collect_snapshot(outbox_artifact_path=artifact)
+    raw = json.dumps(snap, sort_keys=True)
+    # The endpoint URL itself must not appear; only the hash.
+    assert "fcm.googleapis.com" not in raw
+    assert "deadbeefdeadbeef" in raw
+
+
+# ---------------------------------------------------------------------------
+# Inbox row id stability
+# ---------------------------------------------------------------------------
+
+
+def test_inbox_row_id_stable_for_same_event_id(tmp_path: Path) -> None:
+    rec = _outbox_record(event_id="ev_abcdef")
+    artifact = _write_outbox(tmp_path, [rec])
+    snap = mai.collect_snapshot(outbox_artifact_path=artifact)
+    assert snap["rows"][0]["inbox_row_id"] == "mai_ev_abcdef"
+
+
+# ---------------------------------------------------------------------------
+# Bounded inbox
+# ---------------------------------------------------------------------------
+
+
+def test_inbox_rows_bounded_to_max(tmp_path: Path) -> None:
+    records = [
+        _outbox_record(event_id=f"ev_{i:04d}")
+        for i in range(100)
+    ]
+    artifact = _write_outbox(tmp_path, records)
+    snap = mai.collect_snapshot(outbox_artifact_path=artifact)
+    assert len(snap["rows"]) <= mai.MAX_INBOX_ROWS
+
+
+# ---------------------------------------------------------------------------
+# Wrapper shape + counts
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_top_level_keys(tmp_path: Path) -> None:
+    artifact = _write_outbox(tmp_path, [_outbox_record()])
+    snap = mai.collect_snapshot(
+        outbox_artifact_path=artifact,
+        generated_at_utc="2026-05-10T00:00:00Z",
+    )
+    expected = {
+        "schema_version",
+        "module_version",
+        "report_kind",
+        "generated_at_utc",
+        "step5_enabled_substage",
+        "step5_implementation_allowed",
+        "outbox_artifact_path",
+        "outbox_artifact_available",
+        "max_inbox_rows",
+        "note",
+        "validation_warnings",
+        "vocabularies",
+        "counts",
+        "rows",
+        "notification_dispatch_outbox_module_version",
+        "notification_event_module_version",
+        "discipline_invariants",
+    }
+    assert set(snap.keys()) == expected
+
+
+def test_discipline_invariants_present(tmp_path: Path) -> None:
+    artifact = _write_outbox(tmp_path, [_outbox_record()])
+    snap = mai.collect_snapshot(outbox_artifact_path=artifact)
+    inv = snap["discipline_invariants"]
+    assert inv["mints_approval_token"] is False
+    assert inv["verifies_approval_token"] is False
+    assert inv["executes_approve_or_reject"] is False
+    assert inv["merges_or_deploys"] is False
+    assert inv["sends_real_push"] is False
+    assert inv["registers_flask_blueprint"] is False
+    assert inv["operator_promotion_required"] is True
+    assert inv["step5_implementation_allowed"] is False
+    assert inv["step5_enabled_substage"] == "none"
+    assert inv["no_approval_from_notification_click_alone"] is True
+
+
+def test_counts_aggregate_by_attention_level(tmp_path: Path) -> None:
+    records = [
+        _outbox_record(event_id="a", event_severity="push_info"),
+        _outbox_record(event_id="b", event_severity="approval_required"),
+        _outbox_record(event_id="c", event_severity="critical"),
+        _outbox_record(
+            event_id="d", outbound_delivery_intent="failed_secret_check"
+        ),
+    ]
+    artifact = _write_outbox(tmp_path, records)
+    snap = mai.collect_snapshot(outbox_artifact_path=artifact)
+    counts = snap["counts"]
+    assert counts["total"] == 4
+    assert counts["informational"] == 1
+    assert counts["needs_review"] == 1
+    assert counts["critical_attention"] == 1
+    assert counts["blocked_attention"] == 1
+
+
+def test_determinism_with_injected_timestamp(tmp_path: Path) -> None:
+    artifact = _write_outbox(tmp_path, [_outbox_record()])
+    a = mai.collect_snapshot(
+        outbox_artifact_path=artifact,
+        generated_at_utc="2026-05-10T00:00:00Z",
+    )
+    b = mai.collect_snapshot(
+        outbox_artifact_path=artifact,
+        generated_at_utc="2026-05-10T00:00:00Z",
+    )
+    assert json.dumps(a, sort_keys=True) == json.dumps(b, sort_keys=True)
+
+
+def test_no_outbox_artifact_yields_warning(tmp_path: Path) -> None:
+    missing = tmp_path / "logs" / "notification_dispatch_outbox" / "latest.json"
+    snap = mai.collect_snapshot(
+        outbox_artifact_path=missing,
+        generated_at_utc="2026-05-10T00:00:00Z",
+    )
+    assert "outbox_artifact_absent" in snap["validation_warnings"]
+    assert snap["rows"] == []
+
+
+def test_unparseable_outbox_yields_warning(tmp_path: Path) -> None:
+    bad = tmp_path / "logs" / "notification_dispatch_outbox" / "latest.json"
+    bad.parent.mkdir(parents=True)
+    bad.write_text("not json", encoding="utf-8")
+    snap = mai.collect_snapshot(outbox_artifact_path=bad)
+    assert "outbox_artifact_absent" in snap["validation_warnings"] or (
+        "outbox_artifact_unparseable" in snap["validation_warnings"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Source / AST scans
+# ---------------------------------------------------------------------------
+
+
+def _module_source() -> str:
+    return Path(mai.__file__).read_text(encoding="utf-8")
+
+
+def _imported_module_names() -> set[str]:
+    import ast
+
+    src = _module_source()
+    tree = ast.parse(src)
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module is not None:
+                names.add(node.module)
+    return names
+
+
+def test_no_subprocess_or_network() -> None:
+    src = _module_source()
+    forbidden = (
+        "import subprocess",
+        "from subprocess",
+        "import socket",
+        "import urllib",
+        "import http.client",
+        "import requests",
+        "import httpx",
+        "import aiohttp",
+    )
+    for s in forbidden:
+        assert s not in src, s
+
+
+def test_no_web_push_library_imports() -> None:
+    src = _module_source()
+    for forbidden in (
+        "pywebpush",
+        "from webpush",
+        "import webpush",
+        "from web_push",
+        "import web_push",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_no_dashboard_or_frontend_imports() -> None:
+    forbidden_prefixes = (
+        "dashboard",
+        "frontend",
+        "automation",
+        "broker",
+        "agent.risk",
+        "agent.execution",
+        "research",
+        "reporting.intelligent_routing",
+        "live",
+        "paper",
+        "shadow",
+        "trading",
+    )
+    for module in _imported_module_names():
+        for prefix in forbidden_prefixes:
+            assert not (
+                module == prefix or module.startswith(prefix + ".")
+            ), f"forbidden import: {module}"
+
+
+def test_module_imports_cleanly() -> None:
+    importlib.reload(mai)
+    assert callable(mai.collect_snapshot)
+
+
+def test_importing_module_does_not_flip_step5_invariants() -> None:
+    from reporting import development_step5_loop as dsl
+
+    importlib.reload(mai)
+    assert dsl.step5_implementation_allowed is False
+    assert dsl.STEP5_ENABLED_SUBSTAGE == "none"
+
+
+def test_module_does_not_open_seed_jsonl_for_writing() -> None:
+    src = _module_source()
+    forbidden_code_patterns = (
+        "seed.jsonl\", \"w",
+        "seed.jsonl', 'w",
+        "delegation_seed.jsonl\", \"w",
+        "GENERATED_SEED_PATH",
+        ".register_blueprint(",
+        "add_url_rule(",
+    )
+    for s in forbidden_code_patterns:
+        assert s not in src, s
+
+
+# ---------------------------------------------------------------------------
+# Companion doc invariants
+# ---------------------------------------------------------------------------
+
+
+def _doc_text() -> str:
+    return (
+        REPO_ROOT / "docs" / "governance" / "mobile_approval_inbox.md"
+    ).read_text(encoding="utf-8")
+
+
+def test_doc_states_no_approval_from_click_alone() -> None:
+    text = re.sub(r"\s+", " ", _doc_text().lower())
+    assert (
+        "no approval can happen from notification click alone" in text
+        or "no approval from notification click alone" in text
+    )
+
+
+def test_doc_states_n4_path_only_for_decision_state_flip() -> None:
+    text = _doc_text().lower()
+    assert "n4" in text
+    assert "pending" in text
+
+
+def test_doc_pins_step5_invariants_text() -> None:
+    text = _doc_text()
+    assert "step5_implementation_allowed" in text
+    assert "STEP5_ENABLED_SUBSTAGE" in text
+
+
+def test_doc_mentions_level_6_only_with_qualifier() -> None:
+    text = _doc_text()
+    pattern = re.compile(r"\bLevel\s*6\b")
+    for m in pattern.finditer(text):
+        start = max(0, m.start() - 200)
+        end = m.start() + 600
+        raw = text[start:end].lower()
+        cleaned = re.sub(r"\n\s*>\s*", " ", raw)
+        cleaned = re.sub(r"\s+", " ", cleaned)
+        assert "permanently disabled" in cleaned


### PR DESCRIPTION
## Summary

N3a — pure-stdlib read-only projector of `logs/notification_dispatch_outbox/latest.json` into a bounded mobile inbox artefact at `logs/mobile_approval_inbox/latest.json`. **Mints no token, approves nothing, merges nothing, deploys nothing, sends no push, opens no PWA screen, registers no Flask blueprint.**

## What lands

- `reporting/mobile_approval_inbox.py` — closed `ATTENTION_LEVELS` (4), `INBOX_DECISION_STATES` (6; N3a NEVER emits anything other than `pending`), `SOURCE_MODULES` (1), 14-key `INBOX_ROW_KEYS`. `MAX_INBOX_ROWS=64`. Decision-verb redaction.
- `docs/governance/mobile_approval_inbox.md` — full surface doc.
- `tests/unit/test_mobile_approval_inbox.py` — 45 tests pinning vocabularies, every attention-level row, decision-state-always-pending invariant (even when upstream carries `approved`), decision-verb redaction, endpoint redaction, AST forbidden imports, no-Flask-blueprint pin, atomic write refusal.

## Hard guarantees (pinned by tests)

- No `dashboard` / `frontend` / `automation` / `broker` / `agent.risk` / `agent.execution` / `research` / `reporting.intelligent_routing` / live / paper / shadow / trading imports.
- No subprocess / network / `gh` / `git` / Web Push library.
- No Flask blueprint registration (`add_url_rule` / `register_blueprint` absent in source).
- No seed.jsonl write code paths.
- `step5_implementation_allowed=false`, `STEP5_ENABLED_SUBSTAGE=\"none\"`, Level 6 permanently disabled.

## Live verification on `main`

`python -m reporting.mobile_approval_inbox --no-write` against existing N2b-1 outbox:

- `total=3` inbox rows
- every `attention_level=informational`, `decision_state=pending`
- `validation_warnings=[]`

## Test plan

- [x] `python scripts/governance_lint.py` — OK.
- [x] `python -m pytest tests/unit/test_mobile_approval_inbox.py -q` — **45 passed**.
- [x] `python -m pytest tests/smoke -q` — **18 passed**.
- [x] Diff scope = 3 N3a files.
- [x] CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)