### PR TITLE
feat(workloop): A24 — Autonomous Development Workloop event-taxonomy projector (read-only)

### DIFF
--- a/docs/governance/development_workloop_events.md
+++ b/docs/governance/development_workloop_events.md
@@ -1,0 +1,226 @@
+# Autonomous Development Workloop event-taxonomy projector — A24
+
+> **Status:** Implemented (read-only, projector-only).
+>
+> **Module:** [`reporting/development_workloop_events.py`](../../reporting/development_workloop_events.py)
+> **Output artefact:** `logs/development_workloop_events/latest.json`
+>
+> **Authority:** development-governance read-only.
+> A24 NEVER calls `git` / `gh`, NEVER invokes any workloop function,
+> NEVER emits a notification, NEVER mints an approval token, NEVER
+> merges or deploys. Level 6 stays permanently disabled per ADR-015
+> §Doctrine 1. **No approval can happen from a notification click
+> alone.**
+
+---
+
+## 1. Purpose
+
+A24 is the read-only **wiring layer** between the existing
+[`reporting.autonomous_workloop`](../../reporting/autonomous_workloop.py)
+controller and the N1 notification-event taxonomy.
+
+The workloop is allowed to call `git` / `gh` and produces a
+structured digest at `logs/autonomous_workloop/latest.json` with
+sections like `pr_queue`, `dependabot_queue`, `roadmap_queue`,
+`blocked_items`, `audit_chain_status`, `governance_status`, and
+`actions_taken`. A24 reads that digest and classifies each signal
+into the closed N1 `event_kind` / `event_severity` vocabulary, then
+emits a bounded per-event projection at
+`logs/development_workloop_events/latest.json`.
+
+A24 itself is **strictly read-only**. Tests assert (via AST) that
+no callable in this module invokes any function from the workloop
+module — the upstream module is imported only for its
+`MODULE_VERSION` constant.
+
+---
+
+## 2. Hard constraints
+
+A24, in this PR and at runtime, must not:
+
+- call `git`, `gh`, or any other CLI / subprocess;
+- open a network socket;
+- emit a real notification or push;
+- mint or verify approval tokens (N4 territory);
+- execute an approve / reject / merge / deploy action;
+- register a Flask blueprint or wire into `dashboard/dashboard.py`;
+- touch `frontend/**`;
+- mutate any upstream artefact;
+- edit canonical roadmap status fields;
+- mark any roadmap phase complete;
+- enable Step 5.1 or Step 5.2;
+- flip `step5_implementation_allowed`;
+- change `STEP5_ENABLED_SUBSTAGE`;
+- change QRE behaviour;
+- mutate research artifacts;
+- touch live / paper / shadow / risk / broker / execution paths;
+- edit `.claude/**`;
+- store secrets in repo.
+
+A24 ships its own AST-level forbidden-import scan, source-text
+scans, **and an AST scan that no callable from the workloop module
+is invoked**.
+
+---
+
+## 3. Closed vocabularies
+
+### `workloop_signal_source` (7 values)
+
+```
+pr_queue
+dependabot_queue
+roadmap_queue
+blocked_items
+audit_chain_status
+governance_status
+actions_taken
+```
+
+These are the sections of the workloop digest A24 projects from.
+
+### N1 event mapping (closed table)
+
+| Workloop signal               | N1 `event_kind`                  |
+| ----------------------------- | -------------------------------- |
+| `pr_queue` item               | `pr_lifecycle_event`             |
+| `dependabot_queue` item       | `pr_lifecycle_event`             |
+| `roadmap_queue` (normal risk) | `queue_item_proposed`            |
+| `roadmap_queue` (blocked risk)| `queue_item_blocked`             |
+| `blocked_items` row           | `queue_item_blocked`             |
+| `audit_chain_status` (any)    | `audit_chain_anomaly` (severity: `critical` regardless of value, by N1 routing) |
+| `governance_status` ok        | `operational_digest_emitted`     |
+| `governance_status` anomaly   | `governance_violation_detected`  |
+| `actions_taken` row           | `operational_digest_emitted`     |
+
+The severity for each row is computed by
+`reporting.notification_event.route_for(event_kind)` — A24 reuses
+the N1 routing table verbatim; no custom severity logic.
+
+### Per-row schema (9 keys, exact and ordered)
+
+```
+workloop_event_id  source_signal  source_index
+event_kind  event_severity
+decision_or_outcome
+title  summary  extracted_at
+```
+
+`workloop_event_id = "awe_<source_signal>_<index04d>_<identity_key_prefix32>"` — stable per signal+index+identity.
+
+### `validation_warnings` (3 values, closed)
+
+```
+workloop_digest_absent
+workloop_digest_unparseable
+workloop_signal_invalid
+```
+
+---
+
+## 4. Bounded surface
+
+- `MAX_EVENT_ROWS = 128` — projection capped per snapshot.
+- `title ≤ 200 chars`, `summary ≤ 480 chars` — bounded scalars.
+- No PR body, no diff, no command output, no commit message
+  propagated into the artefact.
+
+---
+
+## 5. Discipline invariants (emitted on every artefact)
+
+```
+calls_workloop_functions                       = false
+calls_gh_cli                                   = false
+calls_git_cli                                  = false
+uses_subprocess_or_network                     = false
+emits_real_notification                        = false
+mints_approval_token                           = false
+merges_or_deploys                              = false
+operator_promotion_required                    = true
+step5_implementation_allowed                   = false
+step5_enabled_substage                         = "none"
+diagnostics_do_not_trade                       = true
+no_approval_from_notification_click_alone      = true
+```
+
+Every emitted snapshot is additionally routed through
+[`reporting.agent_audit_summary.assert_no_secrets`](../../reporting/agent_audit_summary.py)
+before write.
+
+---
+
+## 6. CLI
+
+```sh
+python -m reporting.development_workloop_events --no-write
+python -m reporting.development_workloop_events
+```
+
+Pure stdlib + `reporting.notification_event` (read-only) +
+`reporting.autonomous_workloop` (imported for `MODULE_VERSION` constant
+only; AST-pinned not to be called) +
+`reporting.agent_audit_summary.assert_no_secrets`.
+
+---
+
+## 7. Authority chain summary
+
+| Capability                                              | Today (post-N4a) | After A24                                |
+| ------------------------------------------------------- | ---------------- | ---------------------------------------- |
+| Read autonomous_workloop digest                          | does not exist   | yes — A24 (read-only)                    |
+| Map workloop signals to N1 event taxonomy                | does not exist   | yes — closed table, deterministic        |
+| Call `git` / `gh` from A24 itself                        | does not exist   | **does not exist** (AST-pinned)         |
+| Invoke any workloop function from A24                    | does not exist   | **does not exist** (AST-pinned)         |
+| Emit a real notification                                 | does not exist   | does not exist                           |
+| Autonomous merge / deploy                                | forbidden, Level 6 | unchanged — Level 6 permanently disabled |
+
+---
+
+## 8. Test coverage
+
+Pinned in [`tests/unit/test_development_workloop_events.py`](../../tests/unit/test_development_workloop_events.py):
+
+- closed `WORKLOOP_SIGNAL_SOURCES` (7), `VALIDATION_WARNINGS` (3),
+  `EVENT_ROW_KEYS` (9) pinned exactly;
+- every entry in the workloop-signal → N1-event-kind mapping table
+  produces the expected `event_kind`;
+- `event_severity` is always routed through N1's `route_for`
+  (no custom severity logic in A24);
+- atomic write refuses any path outside
+  `logs/development_workloop_events/`;
+- AST-level forbidden-import scan: no `dashboard`, `frontend`,
+  `automation`, `broker`, `agent.risk`, `agent.execution`,
+  `research`, `reporting.intelligent_routing`, `live`, `paper`,
+  `shadow`, `trading`;
+- source-text scan: no `subprocess`, `socket`, `urllib`,
+  `requests`, `httpx`, `aiohttp`, `gh`, `git`;
+- **AST scan: no callable in A24 invokes any function from
+  `reporting.autonomous_workloop`**. The upstream module is
+  imported only for the `MODULE_VERSION` constant;
+- importing the module does not flip Step 5 invariants;
+- this doc states "no approval from notification click alone" and
+  "Level 6 stays permanently disabled".
+
+---
+
+## 9. What A24 does NOT do
+
+- A24 never calls `git` or `gh`.
+- A24 never invokes any workloop function.
+- A24 never emits a real notification.
+- A24 never mints or verifies approval tokens.
+- A24 never merges or deploys.
+- A24 never sends a real push.
+- A24 never registers a Flask blueprint.
+- A24 never writes to `dashboard/dashboard.py` or `frontend/**`.
+- A24 never writes to any seed file.
+- A24 never edits canonical roadmap status fields.
+- A24 does not flip `step5_implementation_allowed`.
+- A24 does not change `STEP5_ENABLED_SUBSTAGE`.
+- Step 5.1 / Step 5.2 remain BLOCKED.
+- N2b-3b / N3b / N3c / N4b / N5 / A18 / A21 / deploy adapter all
+  remain unimplemented.
+- Level 6 stays permanently disabled.

--- a/reporting/development_workloop_events.py
+++ b/reporting/development_workloop_events.py
@@ -1,0 +1,646 @@
+"""A24 — Autonomous Development Workloop event-taxonomy projector.
+
+Pure stdlib-only projector that reads the existing
+``logs/autonomous_workloop/latest.json`` digest (produced by
+``reporting.autonomous_workloop``, which is allowed to call ``git``
+/ ``gh`` itself) and projects each significant workloop signal into
+the closed N1 ``notification_event`` taxonomy.
+
+A24 is the read-only **wiring layer** between the workloop and the
+notification engine. It does NOT replace the workloop. It does NOT
+emit notifications. It does NOT call ``git``, ``gh``, or any
+network/subprocess surface itself — it only reads the workloop's
+already-collected digest.
+
+Hard guarantees (pinned by tests)
+---------------------------------
+
+* Stdlib + ``reporting.notification_event`` (read-only) +
+  ``reporting.autonomous_workloop`` (imported only for
+  ``MODULE_VERSION`` constant pinning; no function call) +
+  ``reporting.agent_audit_summary.assert_no_secrets`` (read-only
+  redactor guard).
+* No subprocess, no network, no ``gh``, no ``git``.
+* No imports of ``dashboard``, ``frontend``, ``automation``,
+  ``broker``, ``agent.risk``, ``agent.execution``, ``research``,
+  ``reporting.intelligent_routing``, ``live``, ``paper``, ``shadow``,
+  ``trading``.
+* AST-pinned: no callable in this module invokes any function from
+  ``reporting.autonomous_workloop``. The upstream module is imported
+  only for its ``MODULE_VERSION`` constant.
+* Atomic write only under ``logs/development_workloop_events/...``.
+* Per-row schema is closed and exact. Bounded scalars only — no
+  diff content, no PR body, no command summary.
+* The projector NEVER emits a notification, NEVER mints an approval
+  token, NEVER merges or deploys.
+* ``step5_implementation_allowed`` remains ``False`` and
+  ``STEP5_ENABLED_SUBSTAGE`` remains ``"none"``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Final
+
+from reporting import autonomous_workloop as _aw  # for MODULE_VERSION only
+from reporting import notification_event as ne
+from reporting.agent_audit_summary import assert_no_secrets
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[str] = "1.0"
+MODULE_VERSION: Final[str] = "v3.15.16.A24"
+REPORT_KIND: Final[str] = "development_workloop_events"
+
+# ---------------------------------------------------------------------------
+# Step 5 invariants
+# ---------------------------------------------------------------------------
+
+STEP5_ENABLED_SUBSTAGE: Final[str] = "none"
+step5_implementation_allowed: Final[bool] = False
+
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies
+# ---------------------------------------------------------------------------
+
+#: Closed workloop signal-source vocabulary. Each value is one of
+#: the known workloop digest sections A24 projects from.
+WORKLOOP_SIGNAL_SOURCES: Final[tuple[str, ...]] = (
+    "pr_queue",
+    "dependabot_queue",
+    "roadmap_queue",
+    "blocked_items",
+    "audit_chain_status",
+    "governance_status",
+    "actions_taken",
+)
+
+#: Closed validation-warning vocabulary.
+VALIDATION_WARNINGS: Final[tuple[str, ...]] = (
+    "workloop_digest_absent",
+    "workloop_digest_unparseable",
+    "workloop_signal_invalid",
+)
+
+#: Per-row schema, exact and ordered.
+EVENT_ROW_KEYS: Final[tuple[str, ...]] = (
+    "workloop_event_id",
+    "source_signal",
+    "source_index",
+    "event_kind",
+    "event_severity",
+    "decision_or_outcome",
+    "title",
+    "summary",
+    "extracted_at",
+)
+
+#: Maximum rows kept in any single snapshot. Bounds the artefact
+#: regardless of how large the upstream workloop digest grows.
+MAX_EVENT_ROWS: Final[int] = 128
+
+#: Bounded length for free-text scalars. The workloop carries
+#: bounded strings already; this is defense-in-depth.
+MAX_TITLE_LEN: Final[int] = 200
+MAX_SUMMARY_LEN: Final[int] = 480
+
+#: Wrapper-level note vocabulary.
+NOTE_NO_DIGEST: Final[str] = "workloop_digest_absent"
+NOTE_NO_SIGNALS: Final[str] = "no_workloop_signals"
+NOTE_SIGNALS_PRESENT: Final[str] = "workloop_signals_present"
+
+#: Repo-relative paths.
+ARTIFACT_DIR: Final[Path] = (
+    REPO_ROOT / "logs" / "development_workloop_events"
+)
+ARTIFACT_LATEST: Final[Path] = ARTIFACT_DIR / "latest.json"
+ARTIFACT_RELATIVE_PATH: Final[str] = (
+    "logs/development_workloop_events/latest.json"
+)
+
+#: Upstream workloop digest path. Produced by
+#: ``reporting.autonomous_workloop``; A24 reads it only.
+UPSTREAM_WORKLOOP_DIGEST_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "autonomous_workloop" / "latest.json"
+)
+
+#: Atomic-write allowlist (substring form).
+_WRITE_PREFIX: Final[str] = "logs/development_workloop_events/"
+
+
+# ---------------------------------------------------------------------------
+# Discipline invariants emitted into every artefact
+# ---------------------------------------------------------------------------
+
+_DISCIPLINE_INVARIANTS: Final[dict[str, bool | str]] = {
+    "calls_workloop_functions": False,
+    "calls_gh_cli": False,
+    "calls_git_cli": False,
+    "uses_subprocess_or_network": False,
+    "emits_real_notification": False,
+    "mints_approval_token": False,
+    "merges_or_deploys": False,
+    "mutates_research_artifacts": False,
+    "writes_to_seed_jsonl": False,
+    "operator_promotion_required": True,
+    "step5_implementation_allowed": False,
+    "step5_enabled_substage": "none",
+    "diagnostics_do_not_trade": True,
+    "no_approval_from_notification_click_alone": True,
+}
+
+
+# ---------------------------------------------------------------------------
+# Utility helpers
+# ---------------------------------------------------------------------------
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+
+def _bounded(value: Any, max_len: int) -> str:
+    if not isinstance(value, str):
+        return ""
+    return value[:max_len]
+
+
+def _workloop_event_id(source_signal: str, source_index: int, key: str) -> str:
+    """Stable id derived from source signal + index + identity key."""
+    return f"awe_{source_signal}_{source_index:04d}_{key[:32]}"
+
+
+# ---------------------------------------------------------------------------
+# Signal-to-N1 mapping (closed table)
+# ---------------------------------------------------------------------------
+
+
+def _classify_pr_queue_item(item: dict[str, Any]) -> tuple[str, str]:
+    """Return ``(event_kind, decision_or_outcome)`` for one PR-queue
+    item. Closed N1 kind only."""
+    decision = str(item.get("decision") or "operator_click")
+    if decision == "auto_merge_eligible":
+        return ("pr_lifecycle_event", "auto_merge_eligible")
+    if decision == "operator_click":
+        return ("pr_lifecycle_event", "operator_click")
+    if decision == "blocked":
+        return ("pr_lifecycle_event", "blocked")
+    return ("pr_lifecycle_event", decision)
+
+
+def _classify_dependabot_item(item: dict[str, Any]) -> tuple[str, str]:
+    decision = str(item.get("decision") or "operator_click")
+    return ("pr_lifecycle_event", decision)
+
+
+def _classify_roadmap_item(item: dict[str, Any]) -> tuple[str, str]:
+    risk = str(item.get("risk_class") or "")
+    if "blocked" in risk.lower():
+        return ("queue_item_blocked", risk or "blocked")
+    return ("queue_item_proposed", risk or "proposed")
+
+
+def _classify_blocked_item(item: dict[str, Any]) -> tuple[str, str]:
+    return ("queue_item_blocked", str(item.get("reason") or "blocked"))
+
+
+def _classify_audit_chain(status: dict[str, Any]) -> tuple[str, str]:
+    s = str(status.get("status") or "unknown").lower()
+    if s == "intact":
+        return ("audit_chain_anomaly", "intact")  # severity routes to critical regardless of value
+    return ("audit_chain_anomaly", s or "anomaly")
+
+
+def _classify_governance(status: dict[str, Any]) -> tuple[str, str]:
+    s = str(status.get("status") or "unknown").lower()
+    if s == "ok":
+        return ("operational_digest_emitted", "ok")
+    return ("governance_violation_detected", s or "anomaly")
+
+
+def _classify_action(action: dict[str, Any]) -> tuple[str, str]:
+    outcome = str(action.get("outcome") or "ok")
+    return ("operational_digest_emitted", outcome)
+
+
+# ---------------------------------------------------------------------------
+# Per-row construction
+# ---------------------------------------------------------------------------
+
+
+def _build_row(
+    *,
+    source_signal: str,
+    source_index: int,
+    item: dict[str, Any],
+    classifier,
+    title: str,
+    summary: str,
+    extracted_at: str,
+) -> dict[str, Any]:
+    event_kind, decision = classifier(item)
+    severity = ne.route_for(event_kind)
+    identity_key = (
+        item.get("item_id")
+        or item.get("branch_or_pr")
+        or item.get("target")
+        or item.get("kind")
+        or item.get("status")
+        or "anon"
+    )
+    row: dict[str, Any] = {
+        "workloop_event_id": _workloop_event_id(
+            source_signal, source_index, str(identity_key)
+        ),
+        "source_signal": source_signal,
+        "source_index": source_index,
+        "event_kind": event_kind,
+        "event_severity": severity,
+        "decision_or_outcome": decision,
+        "title": _bounded(title, MAX_TITLE_LEN),
+        "summary": _bounded(summary, MAX_SUMMARY_LEN),
+        "extracted_at": extracted_at,
+    }
+    assert set(row.keys()) == set(EVENT_ROW_KEYS)
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Per-signal projection
+# ---------------------------------------------------------------------------
+
+
+def _project_pr_queue(
+    payload: dict[str, Any], *, extracted_at: str, rows: list[dict[str, Any]]
+) -> None:
+    items = payload.get("pr_queue") or []
+    if not isinstance(items, list):
+        return
+    for i, item in enumerate(items):
+        if not isinstance(item, dict):
+            continue
+        if len(rows) >= MAX_EVENT_ROWS:
+            return
+        rows.append(
+            _build_row(
+                source_signal="pr_queue",
+                source_index=i,
+                item=item,
+                classifier=_classify_pr_queue_item,
+                title=str(item.get("title") or ""),
+                summary=f"decision={item.get('decision')}; risk={item.get('risk_class')}",
+                extracted_at=extracted_at,
+            )
+        )
+
+
+def _project_dependabot_queue(
+    payload: dict[str, Any], *, extracted_at: str, rows: list[dict[str, Any]]
+) -> None:
+    items = payload.get("dependabot_queue") or []
+    if not isinstance(items, list):
+        return
+    for i, item in enumerate(items):
+        if not isinstance(item, dict):
+            continue
+        if len(rows) >= MAX_EVENT_ROWS:
+            return
+        rows.append(
+            _build_row(
+                source_signal="dependabot_queue",
+                source_index=i,
+                item=item,
+                classifier=_classify_dependabot_item,
+                title=str(item.get("title") or ""),
+                summary=f"decision={item.get('decision')}; risk={item.get('risk_class')}",
+                extracted_at=extracted_at,
+            )
+        )
+
+
+def _project_roadmap_queue(
+    payload: dict[str, Any], *, extracted_at: str, rows: list[dict[str, Any]]
+) -> None:
+    items = payload.get("roadmap_queue") or []
+    if not isinstance(items, list):
+        return
+    for i, item in enumerate(items):
+        if not isinstance(item, dict):
+            continue
+        if len(rows) >= MAX_EVENT_ROWS:
+            return
+        rows.append(
+            _build_row(
+                source_signal="roadmap_queue",
+                source_index=i,
+                item=item,
+                classifier=_classify_roadmap_item,
+                title=str(item.get("title") or ""),
+                summary=f"risk={item.get('risk_class')}",
+                extracted_at=extracted_at,
+            )
+        )
+
+
+def _project_blocked_items(
+    payload: dict[str, Any], *, extracted_at: str, rows: list[dict[str, Any]]
+) -> None:
+    items = payload.get("blocked_items") or []
+    if not isinstance(items, list):
+        return
+    for i, item in enumerate(items):
+        if not isinstance(item, dict):
+            continue
+        if len(rows) >= MAX_EVENT_ROWS:
+            return
+        rows.append(
+            _build_row(
+                source_signal="blocked_items",
+                source_index=i,
+                item=item,
+                classifier=_classify_blocked_item,
+                title=str(item.get("title") or item.get("item_id") or ""),
+                summary=f"reason={item.get('reason')}",
+                extracted_at=extracted_at,
+            )
+        )
+
+
+def _project_audit_chain(
+    payload: dict[str, Any], *, extracted_at: str, rows: list[dict[str, Any]]
+) -> None:
+    status = payload.get("audit_chain_status")
+    if not isinstance(status, dict):
+        return
+    if len(rows) >= MAX_EVENT_ROWS:
+        return
+    rows.append(
+        _build_row(
+            source_signal="audit_chain_status",
+            source_index=0,
+            item=status,
+            classifier=_classify_audit_chain,
+            title="audit_chain_status",
+            summary=f"status={status.get('status')}; ledger={status.get('ledger_path')}",
+            extracted_at=extracted_at,
+        )
+    )
+
+
+def _project_governance(
+    payload: dict[str, Any], *, extracted_at: str, rows: list[dict[str, Any]]
+) -> None:
+    status = payload.get("governance_status")
+    if not isinstance(status, dict):
+        return
+    if len(rows) >= MAX_EVENT_ROWS:
+        return
+    rows.append(
+        _build_row(
+            source_signal="governance_status",
+            source_index=0,
+            item=status,
+            classifier=_classify_governance,
+            title="governance_status",
+            summary=f"status={status.get('status')}",
+            extracted_at=extracted_at,
+        )
+    )
+
+
+def _project_actions(
+    payload: dict[str, Any], *, extracted_at: str, rows: list[dict[str, Any]]
+) -> None:
+    actions = payload.get("actions_taken") or []
+    if not isinstance(actions, list):
+        return
+    for i, action in enumerate(actions):
+        if not isinstance(action, dict):
+            continue
+        if len(rows) >= MAX_EVENT_ROWS:
+            return
+        rows.append(
+            _build_row(
+                source_signal="actions_taken",
+                source_index=i,
+                item=action,
+                classifier=_classify_action,
+                title=str(action.get("kind") or "action"),
+                summary=f"outcome={action.get('outcome')}; target={action.get('target')}",
+                extracted_at=extracted_at,
+            )
+        )
+
+
+# ---------------------------------------------------------------------------
+# Aggregation
+# ---------------------------------------------------------------------------
+
+
+def _empty_counts() -> dict[str, Any]:
+    return {
+        "total": 0,
+        "by_source_signal": {s: 0 for s in WORKLOOP_SIGNAL_SOURCES},
+        "by_event_kind": {k: 0 for k in ne.EVENT_KINDS},
+        "by_event_severity": {s: 0 for s in ne.EVENT_SEVERITIES},
+    }
+
+
+def _aggregate_counts(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    counts = _empty_counts()
+    counts["total"] = len(rows)
+    for row in rows:
+        sig = row.get("source_signal")
+        if isinstance(sig, str) and sig in counts["by_source_signal"]:
+            counts["by_source_signal"][sig] += 1
+        kind = row.get("event_kind")
+        if isinstance(kind, str) and kind in counts["by_event_kind"]:
+            counts["by_event_kind"][kind] += 1
+        sev = row.get("event_severity")
+        if isinstance(sev, str) and sev in counts["by_event_severity"]:
+            counts["by_event_severity"][sev] += 1
+    return counts
+
+
+# ---------------------------------------------------------------------------
+# Snapshot assembly
+# ---------------------------------------------------------------------------
+
+
+def collect_snapshot(
+    *,
+    workloop_digest_path: Path | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    """Build the deterministic workloop-events snapshot."""
+    wp = (
+        workloop_digest_path
+        if workloop_digest_path is not None
+        else UPSTREAM_WORKLOOP_DIGEST_PATH
+    )
+    ts = generated_at_utc if generated_at_utc is not None else _utcnow()
+
+    payload = _read_json(wp)
+    warnings: list[str] = []
+    rows: list[dict[str, Any]] = []
+    upstream_controller_version = ""
+    upstream_mode = ""
+    upstream_cycle_id: int | None = None
+
+    if payload is None:
+        warnings.append("workloop_digest_absent")
+        note = NOTE_NO_DIGEST
+    elif not isinstance(payload, dict):
+        warnings.append("workloop_digest_unparseable")
+        note = NOTE_NO_DIGEST
+    else:
+        upstream_controller_version = str(payload.get("controller_version") or "")
+        upstream_mode = str(payload.get("mode") or "")
+        cid = payload.get("cycle_id")
+        upstream_cycle_id = cid if isinstance(cid, int) else None
+        _project_pr_queue(payload, extracted_at=ts, rows=rows)
+        _project_dependabot_queue(payload, extracted_at=ts, rows=rows)
+        _project_roadmap_queue(payload, extracted_at=ts, rows=rows)
+        _project_blocked_items(payload, extracted_at=ts, rows=rows)
+        _project_audit_chain(payload, extracted_at=ts, rows=rows)
+        _project_governance(payload, extracted_at=ts, rows=rows)
+        _project_actions(payload, extracted_at=ts, rows=rows)
+        note = NOTE_SIGNALS_PRESENT if rows else NOTE_NO_SIGNALS
+
+    rows.sort(key=lambda r: (r["source_signal"], r["source_index"], r["workloop_event_id"]))
+
+    counts = _aggregate_counts(rows)
+
+    snapshot = {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": ts,
+        "step5_enabled_substage": STEP5_ENABLED_SUBSTAGE,
+        "step5_implementation_allowed": step5_implementation_allowed,
+        "workloop_digest_path": str(wp),
+        "workloop_digest_available": payload is not None,
+        "upstream_controller_version": upstream_controller_version,
+        "upstream_mode": upstream_mode,
+        "upstream_cycle_id": upstream_cycle_id,
+        "max_event_rows": MAX_EVENT_ROWS,
+        "note": note,
+        "validation_warnings": warnings,
+        "vocabularies": {
+            "workloop_signal_sources": list(WORKLOOP_SIGNAL_SOURCES),
+            "notification_event_kinds": list(ne.EVENT_KINDS),
+            "notification_event_severities": list(ne.EVENT_SEVERITIES),
+            "validation_warnings": list(VALIDATION_WARNINGS),
+            "event_row_keys": list(EVENT_ROW_KEYS),
+        },
+        "counts": counts,
+        "rows": rows,
+        "autonomous_workloop_module_version": _aw.CONTROLLER_VERSION,
+        "notification_event_module_version": ne.MODULE_VERSION,
+        "discipline_invariants": dict(_DISCIPLINE_INVARIANTS),
+    }
+    assert_no_secrets(snapshot)
+    return snapshot
+
+
+# ---------------------------------------------------------------------------
+# Atomic write
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    posix = path.as_posix()
+    if _WRITE_PREFIX not in posix and not posix.startswith(_WRITE_PREFIX):
+        raise ValueError(
+            "development_workloop_events._atomic_write_json refuses "
+            f"non-workloop-events-logs output path: {path}"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".development_workloop_events.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_outputs(snapshot: dict[str, Any]) -> Path:
+    _atomic_write_json(ARTIFACT_LATEST, snapshot)
+    return ARTIFACT_LATEST
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m reporting.development_workloop_events",
+        description=(
+            "A24 Autonomous Development Workloop event-taxonomy "
+            "projector. Read-only deterministic projector of "
+            "logs/autonomous_workloop/latest.json. Never calls "
+            "git, gh, or any workloop function. Never emits a "
+            "real notification."
+        ),
+    )
+    p.add_argument(
+        "--indent", type=int, default=2, help="JSON indent (0 for compact)."
+    )
+    p.add_argument(
+        "--no-write",
+        action="store_true",
+        help=(
+            "Do not persist "
+            "logs/development_workloop_events/latest.json "
+            "(stdout only)."
+        ),
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    indent = args.indent if args.indent and args.indent > 0 else None
+    snap = collect_snapshot()
+    if not args.no_write:
+        write_outputs(snap)
+    json.dump(snap, sys.stdout, indent=indent, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/unit/test_development_workloop_events.py
+++ b/tests/unit/test_development_workloop_events.py
@@ -1,0 +1,565 @@
+"""Unit tests for A24 — Autonomous Development Workloop event-taxonomy projector."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reporting import development_workloop_events as a24
+from reporting import notification_event as ne
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_workloop_digest(tmp_path: Path, payload: dict[str, Any]) -> Path:
+    p = tmp_path / "logs" / "autonomous_workloop" / "latest.json"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(
+        json.dumps(payload, sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return p
+
+
+def _digest(
+    *,
+    pr_queue: list[dict[str, Any]] | None = None,
+    dependabot_queue: list[dict[str, Any]] | None = None,
+    roadmap_queue: list[dict[str, Any]] | None = None,
+    blocked_items: list[dict[str, Any]] | None = None,
+    audit_chain_status: dict[str, Any] | None = None,
+    governance_status: dict[str, Any] | None = None,
+    actions_taken: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return {
+        "controller_version": "v3.15.15.16",
+        "cycle_id": 0,
+        "mode": "dry-run",
+        "pr_queue": pr_queue or [],
+        "dependabot_queue": dependabot_queue or [],
+        "roadmap_queue": roadmap_queue or [],
+        "blocked_items": blocked_items or [],
+        "audit_chain_status": audit_chain_status,
+        "governance_status": governance_status,
+        "actions_taken": actions_taken or [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies
+# ---------------------------------------------------------------------------
+
+
+def test_workloop_signal_sources_pinned_exactly() -> None:
+    assert a24.WORKLOOP_SIGNAL_SOURCES == (
+        "pr_queue",
+        "dependabot_queue",
+        "roadmap_queue",
+        "blocked_items",
+        "audit_chain_status",
+        "governance_status",
+        "actions_taken",
+    )
+
+
+def test_validation_warnings_pinned() -> None:
+    assert a24.VALIDATION_WARNINGS == (
+        "workloop_digest_absent",
+        "workloop_digest_unparseable",
+        "workloop_signal_invalid",
+    )
+
+
+def test_event_row_keys_pinned_exactly_and_ordered() -> None:
+    assert a24.EVENT_ROW_KEYS == (
+        "workloop_event_id",
+        "source_signal",
+        "source_index",
+        "event_kind",
+        "event_severity",
+        "decision_or_outcome",
+        "title",
+        "summary",
+        "extracted_at",
+    )
+
+
+def test_max_event_rows_pinned() -> None:
+    assert a24.MAX_EVENT_ROWS == 128
+
+
+def test_step5_invariants_pinned() -> None:
+    assert a24.step5_implementation_allowed is False
+    assert a24.STEP5_ENABLED_SUBSTAGE == "none"
+
+
+# ---------------------------------------------------------------------------
+# Atomic write refusal
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_write_refuses_non_workloop_events_path(tmp_path: Path) -> None:
+    bad = tmp_path / "evil_dir" / "latest.json"
+    with pytest.raises(ValueError):
+        a24._atomic_write_json(bad, {"x": 1})
+
+
+def test_atomic_write_refuses_upstream_workloop_path(tmp_path: Path) -> None:
+    bad = tmp_path / "logs" / "autonomous_workloop" / "latest.json"
+    with pytest.raises(ValueError):
+        a24._atomic_write_json(bad, {"x": 1})
+
+
+# ---------------------------------------------------------------------------
+# Signal → N1 mapping
+# ---------------------------------------------------------------------------
+
+
+def test_pr_queue_maps_to_pr_lifecycle_event(tmp_path: Path) -> None:
+    digest = _digest(
+        pr_queue=[
+            {
+                "item_id": "pr1",
+                "title": "PR #1",
+                "decision": "operator_click",
+                "risk_class": "low",
+            }
+        ]
+    )
+    artifact = _write_workloop_digest(tmp_path, digest)
+    snap = a24.collect_snapshot(workloop_digest_path=artifact)
+    rows = [r for r in snap["rows"] if r["source_signal"] == "pr_queue"]
+    assert len(rows) == 1
+    assert rows[0]["event_kind"] == "pr_lifecycle_event"
+    # Severity is routed verbatim through N1; pr_lifecycle_event → push_info.
+    assert rows[0]["event_severity"] == ne.route_for("pr_lifecycle_event")
+
+
+def test_dependabot_queue_maps_to_pr_lifecycle_event(tmp_path: Path) -> None:
+    digest = _digest(
+        dependabot_queue=[
+            {
+                "item_id": "dep1",
+                "branch_or_pr": "dependabot/x",
+                "decision": "operator_click",
+                "risk_class": "dependabot_minor_safe_candidate",
+            }
+        ]
+    )
+    artifact = _write_workloop_digest(tmp_path, digest)
+    snap = a24.collect_snapshot(workloop_digest_path=artifact)
+    rows = [r for r in snap["rows"] if r["source_signal"] == "dependabot_queue"]
+    assert len(rows) == 1
+    assert rows[0]["event_kind"] == "pr_lifecycle_event"
+
+
+def test_roadmap_queue_normal_maps_to_queue_item_proposed(tmp_path: Path) -> None:
+    digest = _digest(
+        roadmap_queue=[
+            {"item_id": "rm1", "title": "Roadmap item", "risk_class": "low"}
+        ]
+    )
+    artifact = _write_workloop_digest(tmp_path, digest)
+    snap = a24.collect_snapshot(workloop_digest_path=artifact)
+    rows = [r for r in snap["rows"] if r["source_signal"] == "roadmap_queue"]
+    assert len(rows) == 1
+    assert rows[0]["event_kind"] == "queue_item_proposed"
+
+
+def test_roadmap_queue_blocked_maps_to_queue_item_blocked(tmp_path: Path) -> None:
+    digest = _digest(
+        roadmap_queue=[
+            {"item_id": "rm2", "title": "Blocked", "risk_class": "blocked_path"}
+        ]
+    )
+    artifact = _write_workloop_digest(tmp_path, digest)
+    snap = a24.collect_snapshot(workloop_digest_path=artifact)
+    rows = [r for r in snap["rows"] if r["source_signal"] == "roadmap_queue"]
+    assert rows[0]["event_kind"] == "queue_item_blocked"
+
+
+def test_blocked_items_maps_to_queue_item_blocked(tmp_path: Path) -> None:
+    digest = _digest(
+        blocked_items=[
+            {"item_id": "b1", "title": "Blocked", "reason": "missing_label"}
+        ]
+    )
+    artifact = _write_workloop_digest(tmp_path, digest)
+    snap = a24.collect_snapshot(workloop_digest_path=artifact)
+    rows = [r for r in snap["rows"] if r["source_signal"] == "blocked_items"]
+    assert rows[0]["event_kind"] == "queue_item_blocked"
+
+
+def test_audit_chain_status_maps_to_audit_chain_anomaly(tmp_path: Path) -> None:
+    """audit_chain_anomaly routes to severity=critical regardless of
+    status value — this is intentional (every audit-chain signal
+    surfaces to the operator)."""
+    digest = _digest(
+        audit_chain_status={"status": "intact", "ledger_path": "logs/x.jsonl"}
+    )
+    artifact = _write_workloop_digest(tmp_path, digest)
+    snap = a24.collect_snapshot(workloop_digest_path=artifact)
+    rows = [r for r in snap["rows"] if r["source_signal"] == "audit_chain_status"]
+    assert rows[0]["event_kind"] == "audit_chain_anomaly"
+    assert rows[0]["event_severity"] == "critical"
+
+
+def test_governance_ok_maps_to_operational_digest_emitted(tmp_path: Path) -> None:
+    digest = _digest(governance_status={"status": "ok"})
+    artifact = _write_workloop_digest(tmp_path, digest)
+    snap = a24.collect_snapshot(workloop_digest_path=artifact)
+    rows = [r for r in snap["rows"] if r["source_signal"] == "governance_status"]
+    assert rows[0]["event_kind"] == "operational_digest_emitted"
+
+
+def test_governance_anomaly_maps_to_violation_detected(tmp_path: Path) -> None:
+    digest = _digest(governance_status={"status": "drift"})
+    artifact = _write_workloop_digest(tmp_path, digest)
+    snap = a24.collect_snapshot(workloop_digest_path=artifact)
+    rows = [r for r in snap["rows"] if r["source_signal"] == "governance_status"]
+    assert rows[0]["event_kind"] == "governance_violation_detected"
+    # governance_violation_detected → critical per N1 routing.
+    assert rows[0]["event_severity"] == "critical"
+
+
+def test_actions_taken_maps_to_operational_digest_emitted(tmp_path: Path) -> None:
+    digest = _digest(
+        actions_taken=[{"kind": "write_digest", "outcome": "ok", "target": "x"}]
+    )
+    artifact = _write_workloop_digest(tmp_path, digest)
+    snap = a24.collect_snapshot(workloop_digest_path=artifact)
+    rows = [r for r in snap["rows"] if r["source_signal"] == "actions_taken"]
+    assert rows[0]["event_kind"] == "operational_digest_emitted"
+
+
+# ---------------------------------------------------------------------------
+# Severity routed through N1
+# ---------------------------------------------------------------------------
+
+
+def test_every_emitted_event_severity_comes_from_n1_route_for(
+    tmp_path: Path,
+) -> None:
+    """A24 must not introduce custom severity logic. For every row,
+    `event_severity == route_for(event_kind)` (with defaults — no
+    risk_class / authority-decision hints in A24)."""
+    digest = _digest(
+        pr_queue=[{"item_id": "p1", "title": "x", "decision": "blocked"}],
+        roadmap_queue=[{"item_id": "r1", "title": "x", "risk_class": "low"}],
+        blocked_items=[{"item_id": "b1", "title": "x", "reason": "y"}],
+        audit_chain_status={"status": "intact"},
+        governance_status={"status": "ok"},
+        actions_taken=[{"kind": "k", "outcome": "ok"}],
+    )
+    artifact = _write_workloop_digest(tmp_path, digest)
+    snap = a24.collect_snapshot(workloop_digest_path=artifact)
+    for row in snap["rows"]:
+        assert row["event_severity"] == ne.route_for(row["event_kind"]), row
+
+
+# ---------------------------------------------------------------------------
+# Bounded artefact + identity
+# ---------------------------------------------------------------------------
+
+
+def test_rows_bounded_to_max(tmp_path: Path) -> None:
+    digest = _digest(
+        pr_queue=[
+            {"item_id": f"pr{i:04d}", "title": f"PR {i}", "decision": "operator_click"}
+            for i in range(200)
+        ]
+    )
+    artifact = _write_workloop_digest(tmp_path, digest)
+    snap = a24.collect_snapshot(workloop_digest_path=artifact)
+    assert len(snap["rows"]) <= a24.MAX_EVENT_ROWS
+
+
+def test_workloop_event_id_is_stable_for_same_signal_and_index(tmp_path: Path) -> None:
+    digest = _digest(
+        pr_queue=[{"item_id": "p1", "title": "x", "decision": "operator_click"}]
+    )
+    artifact = _write_workloop_digest(tmp_path, digest)
+    snap1 = a24.collect_snapshot(workloop_digest_path=artifact)
+    snap2 = a24.collect_snapshot(workloop_digest_path=artifact)
+    assert snap1["rows"][0]["workloop_event_id"] == snap2["rows"][0]["workloop_event_id"]
+
+
+# ---------------------------------------------------------------------------
+# Wrapper shape + counts
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_top_level_keys(tmp_path: Path) -> None:
+    artifact = _write_workloop_digest(tmp_path, _digest())
+    snap = a24.collect_snapshot(
+        workloop_digest_path=artifact,
+        generated_at_utc="2026-05-11T00:00:00Z",
+    )
+    expected = {
+        "schema_version",
+        "module_version",
+        "report_kind",
+        "generated_at_utc",
+        "step5_enabled_substage",
+        "step5_implementation_allowed",
+        "workloop_digest_path",
+        "workloop_digest_available",
+        "upstream_controller_version",
+        "upstream_mode",
+        "upstream_cycle_id",
+        "max_event_rows",
+        "note",
+        "validation_warnings",
+        "vocabularies",
+        "counts",
+        "rows",
+        "autonomous_workloop_module_version",
+        "notification_event_module_version",
+        "discipline_invariants",
+    }
+    assert set(snap.keys()) == expected
+
+
+def test_discipline_invariants_present(tmp_path: Path) -> None:
+    artifact = _write_workloop_digest(tmp_path, _digest())
+    snap = a24.collect_snapshot(workloop_digest_path=artifact)
+    inv = snap["discipline_invariants"]
+    assert inv["calls_workloop_functions"] is False
+    assert inv["calls_gh_cli"] is False
+    assert inv["calls_git_cli"] is False
+    assert inv["uses_subprocess_or_network"] is False
+    assert inv["emits_real_notification"] is False
+    assert inv["mints_approval_token"] is False
+    assert inv["merges_or_deploys"] is False
+    assert inv["operator_promotion_required"] is True
+    assert inv["step5_implementation_allowed"] is False
+    assert inv["step5_enabled_substage"] == "none"
+
+
+def test_counts_aggregate_by_signal_kind_severity(tmp_path: Path) -> None:
+    digest = _digest(
+        pr_queue=[
+            {"item_id": "p1", "title": "x", "decision": "operator_click"},
+            {"item_id": "p2", "title": "y", "decision": "blocked"},
+        ],
+        roadmap_queue=[
+            {"item_id": "r1", "title": "x", "risk_class": "low"},
+        ],
+        audit_chain_status={"status": "intact"},
+    )
+    artifact = _write_workloop_digest(tmp_path, digest)
+    snap = a24.collect_snapshot(workloop_digest_path=artifact)
+    counts = snap["counts"]
+    assert counts["total"] == 4
+    assert counts["by_source_signal"]["pr_queue"] == 2
+    assert counts["by_source_signal"]["roadmap_queue"] == 1
+    assert counts["by_source_signal"]["audit_chain_status"] == 1
+    assert counts["by_event_kind"]["pr_lifecycle_event"] == 2
+    assert counts["by_event_kind"]["queue_item_proposed"] == 1
+    assert counts["by_event_kind"]["audit_chain_anomaly"] == 1
+
+
+def test_determinism_with_injected_timestamp(tmp_path: Path) -> None:
+    digest = _digest(pr_queue=[{"item_id": "p1", "title": "x"}])
+    artifact = _write_workloop_digest(tmp_path, digest)
+    a = a24.collect_snapshot(
+        workloop_digest_path=artifact, generated_at_utc="2026-05-11T00:00:00Z"
+    )
+    b = a24.collect_snapshot(
+        workloop_digest_path=artifact, generated_at_utc="2026-05-11T00:00:00Z"
+    )
+    assert json.dumps(a, sort_keys=True) == json.dumps(b, sort_keys=True)
+
+
+# ---------------------------------------------------------------------------
+# Absent / unparseable digest
+# ---------------------------------------------------------------------------
+
+
+def test_absent_digest_yields_warning(tmp_path: Path) -> None:
+    missing = tmp_path / "logs" / "autonomous_workloop" / "latest.json"
+    snap = a24.collect_snapshot(
+        workloop_digest_path=missing,
+        generated_at_utc="2026-05-11T00:00:00Z",
+    )
+    assert "workloop_digest_absent" in snap["validation_warnings"]
+    assert snap["workloop_digest_available"] is False
+    assert snap["rows"] == []
+
+
+def test_unparseable_digest_yields_warning(tmp_path: Path) -> None:
+    bad = tmp_path / "logs" / "autonomous_workloop" / "latest.json"
+    bad.parent.mkdir(parents=True)
+    bad.write_text("not json", encoding="utf-8")
+    snap = a24.collect_snapshot(workloop_digest_path=bad)
+    assert (
+        "workloop_digest_absent" in snap["validation_warnings"]
+        or "workloop_digest_unparseable" in snap["validation_warnings"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Source / AST scans
+# ---------------------------------------------------------------------------
+
+
+def _module_source() -> str:
+    return Path(a24.__file__).read_text(encoding="utf-8")
+
+
+def _imported_module_names() -> set[str]:
+    import ast
+
+    src = _module_source()
+    tree = ast.parse(src)
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module is not None:
+                names.add(node.module)
+    return names
+
+
+def test_no_subprocess_or_network() -> None:
+    src = _module_source()
+    forbidden = (
+        "import subprocess",
+        "from subprocess",
+        "import socket",
+        "import urllib",
+        "import http.client",
+        "import requests",
+        "import httpx",
+        "import aiohttp",
+    )
+    for s in forbidden:
+        assert s not in src, s
+
+
+def test_no_dashboard_or_frontend_imports() -> None:
+    forbidden_prefixes = (
+        "dashboard",
+        "frontend",
+        "automation",
+        "broker",
+        "agent.risk",
+        "agent.execution",
+        "research",
+        "reporting.intelligent_routing",
+        "live",
+        "paper",
+        "shadow",
+        "trading",
+    )
+    for module in _imported_module_names():
+        for prefix in forbidden_prefixes:
+            assert not (
+                module == prefix or module.startswith(prefix + ".")
+            ), f"forbidden import: {module}"
+
+
+def test_module_does_not_invoke_workloop_functions() -> None:
+    """The most load-bearing pin: A24 imports
+    `reporting.autonomous_workloop` only for its MODULE_VERSION
+    constant. It must NEVER call any function from that module."""
+    import ast
+
+    src = _module_source()
+    tree = ast.parse(src)
+    # Find every Call whose function resolves to an attribute or name
+    # under the workloop alias `_aw`.
+    forbidden_callables = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            func = node.func
+            # `_aw.foo(...)` pattern.
+            if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
+                if func.value.id == "_aw":
+                    forbidden_callables.add(func.attr)
+    assert forbidden_callables == set(), (
+        f"A24 must not call any function from autonomous_workloop; "
+        f"found calls to: {forbidden_callables}"
+    )
+
+
+def test_module_does_not_open_seed_jsonl_for_writing() -> None:
+    src = _module_source()
+    forbidden = (
+        "seed.jsonl\", \"w",
+        "seed.jsonl', 'w",
+        "delegation_seed.jsonl\", \"w",
+        "GENERATED_SEED_PATH",
+        ".register_blueprint(",
+        "add_url_rule(",
+    )
+    for s in forbidden:
+        assert s not in src, s
+
+
+def test_module_imports_cleanly() -> None:
+    importlib.reload(a24)
+    assert callable(a24.collect_snapshot)
+
+
+def test_importing_module_does_not_flip_step5_invariants() -> None:
+    from reporting import development_step5_loop as dsl
+
+    importlib.reload(a24)
+    assert dsl.step5_implementation_allowed is False
+    assert dsl.STEP5_ENABLED_SUBSTAGE == "none"
+
+
+# ---------------------------------------------------------------------------
+# Companion doc invariants
+# ---------------------------------------------------------------------------
+
+
+def _doc_text() -> str:
+    return (
+        REPO_ROOT / "docs" / "governance" / "development_workloop_events.md"
+    ).read_text(encoding="utf-8")
+
+
+def test_doc_states_a24_never_calls_workloop() -> None:
+    text = _doc_text().lower()
+    assert "never invokes any workloop function" in text or "never invoke any workloop function" in text
+
+
+def test_doc_states_no_approval_from_click_alone() -> None:
+    text = re.sub(r"\s+", " ", _doc_text().lower())
+    assert (
+        "no approval can happen from notification click alone" in text
+        or "no approval from notification click alone" in text
+    )
+
+
+def test_doc_pins_step5_invariants_text() -> None:
+    text = _doc_text()
+    assert "step5_implementation_allowed" in text
+    assert "STEP5_ENABLED_SUBSTAGE" in text
+
+
+def test_doc_mentions_level_6_only_with_qualifier() -> None:
+    text = _doc_text()
+    pattern = re.compile(r"\bLevel\s*6\b")
+    for m in pattern.finditer(text):
+        start = max(0, m.start() - 200)
+        end = m.start() + 600
+        raw = text[start:end].lower()
+        cleaned = re.sub(r"\n\s*>\s*", " ", raw)
+        cleaned = re.sub(r"\s+", " ", cleaned)
+        assert "permanently disabled" in cleaned


### PR DESCRIPTION
## Summary

A24 — pure-stdlib read-only projector that joins the existing `reporting.autonomous_workloop` digest (`logs/autonomous_workloop/latest.json`) with the closed N1 `notification_event` taxonomy. Emits a bounded per-event projection at `logs/development_workloop_events/latest.json`.

A24 is the read-only **wiring layer** between the workloop (which is allowed to call `git`/`gh` itself) and the notification engine. **A24 itself NEVER calls `git`, `gh`, or any subprocess/network surface. A24 NEVER invokes any workloop function** — the upstream module is imported only for its `CONTROLLER_VERSION` constant. **A24 NEVER emits a real notification, mints a token, merges, or deploys.**

## What lands

- `reporting/development_workloop_events.py` — closed `WORKLOOP_SIGNAL_SOURCES` (7), `VALIDATION_WARNINGS` (3), 9-key `EVENT_ROW_KEYS`. `MAX_EVENT_ROWS=128`.
- `docs/governance/development_workloop_events.md` — full surface doc with the signal→N1 mapping table.
- `tests/unit/test_development_workloop_events.py` — 35 tests, including the load-bearing `test_module_does_not_invoke_workloop_functions` AST scan that verifies no `_aw.X(...)` call site exists, plus `test_every_emitted_event_severity_comes_from_n1_route_for` pinning that A24 has zero custom severity logic.

## Hard guarantees (pinned by tests)

- No subprocess / network / `gh` / `git` references.
- No invocation of any `autonomous_workloop` function (AST-pinned).
- No Flask blueprint registration.
- No `dashboard` / `frontend` / `automation` / `broker` / `agent.risk` / `agent.execution` / `research` / `reporting.intelligent_routing` / live / paper / shadow / trading imports.
- Severity is **always** `notification_event.route_for(event_kind)` — no custom logic.
- `step5_implementation_allowed=false`, `STEP5_ENABLED_SUBSTAGE=\"none\"`, Level 6 permanently disabled.

## Live verification on `main`

`python -m reporting.development_workloop_events --no-write` against the existing workloop digest:

- **55 events** projected across `pr_queue`, `dependabot_queue`, `roadmap_queue`, `blocked_items`, `audit_chain_status`, `governance_status`, `actions_taken`.
- `audit_chain_status` event correctly classified as `audit_chain_anomaly` with `event_severity=critical` (routes via N1 to critical regardless of `intact`/`anomaly` value — every audit-chain signal surfaces to the operator).
- `actions_taken` events correctly classified as `operational_digest_emitted` / `digest`.

## Test plan

- [x] `python scripts/governance_lint.py` — OK.
- [x] `python -m pytest tests/unit/test_development_workloop_events.py -q` — **35 passed**.
- [x] `python -m pytest tests/smoke -q` — **18 passed**.
- [x] Diff scope = 3 A24 files.
- [x] CI checks

## Out of scope (deferred)

- N2b-3b real Web Push delivery.
- N3b inbox HTTP API + N3c PWA inbox UI.
- N4b token-gate live wiring.
- N5 merge approval adapter.
- A18 generated queue lane.
- A21 Step 5.1 executor (permanently blocked by `step5_implementation_allowed=false`).
- Deploy adapter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)