### PR TITLE
feat(notif): N2b-3b — real Web Push internal-only dispatch (unwired)

### DIFF
--- a/dashboard/api_push_dispatch.py
+++ b/dashboard/api_push_dispatch.py
@@ -1,0 +1,497 @@
+"""N2b-3b — Real Web Push dispatch API blueprint (UNWIRED, loopback-only).
+
+Flask blueprint exposing the **single** real-delivery endpoint
+:code:`POST /api/push/dispatch`. The endpoint composes the existing
+N2a / N2b-1 / N2b-2a / N2b-3a stack into one operator-triggered call:
+
+* reads the latest dispatch outbox snapshot
+  (``logs/notification_dispatch_outbox/latest.json``) — pure read;
+* filters records with ``outbound_delivery_intent == "sent"`` (i.e.
+  the stub provider accepted them offline);
+* loads the active Web Push subscriptions from the gitignored
+  store via :mod:`reporting.push_subscription_store`;
+* for each (record × subscription) pair, builds the N2b-3a envelope
+  and calls :func:`reporting.web_push_dispatch_adapter.dispatch_one`
+  with a real-transport closure from
+  :mod:`reporting.web_push_real_transport`;
+* on any ``drop_subscription`` outcome, removes the subscription
+  via ``pss.unregister_subscription``;
+* writes a bounded summary to
+  ``logs/notification_dispatch_real/latest.json`` (atomic,
+  sentinel-restricted) and returns it (already redacted: counts +
+  endpoint_hash + outcome class — never endpoint URL, never key
+  material).
+
+**The blueprint is intentionally NOT wired into**
+``dashboard/dashboard.py``. Wiring is a one-line
+``register_push_dispatch_routes(app)`` change that the operator adds
+at PR review (the no-touch hook blocks the agent from editing the
+file). Until that wiring lands, the endpoint is unreachable through
+the live dashboard.
+
+Hard guarantees (pinned by tests)
+---------------------------------
+
+* POST only — no other HTTP method is registered.
+* Refuses any request whose ``request.remote_addr`` is not in
+  ``{"127.0.0.1", "::1"}`` with HTTP 403. nginx is expected to
+  restrict the route to ``127.0.0.1`` at the edge; this Python
+  check is defense-in-depth.
+* Refuses requests when
+  :func:`reporting.web_push_real_transport.is_configured` returns
+  False, with HTTP 503 ``configuration_missing``.
+* Refuses request bodies greater than 1 KiB with HTTP 413.
+* Never executes a CLI subprocess, never invokes ``gh`` or ``git``,
+  never opens its own network socket (delegates to the lazy-imported
+  ``pywebpush`` inside the transport module), never imports a Web
+  Push library at this layer.
+* Every response payload is run through ``assert_no_secrets`` from
+  ``reporting.agent_audit_summary``.
+* Response payload NEVER contains subscription endpoint URLs or
+  keys — only ``endpoint_hash`` and outcome classes.
+* No approval verb (approve / reject / merge / deploy) is accepted,
+  emitted, or actionable. The endpoint delivers notifications only;
+  N3 (approval inbox), N4 (token gate), and N5 (merge / deploy
+  adapter) remain unimplemented.
+
+Authentication
+--------------
+
+Auth is provided by the existing PWA session middleware applied at
+the dashboard wiring layer. The blueprint does not register any auth
+itself. Defense in depth: nginx is expected to restrict
+``/api/push/dispatch`` to ``127.0.0.1`` and the loopback check above
+re-enforces that at the Python layer. The dispatch endpoint is an
+operator tool (curl from the VPS), never reachable from the public
+internet.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Final
+
+from flask import Flask, Response, jsonify, request
+
+from reporting import push_subscription_store as pss
+from reporting import web_push_dispatch_adapter as wpda
+from reporting import web_push_real_transport as wprt
+from reporting.agent_audit_summary import assert_no_secrets
+
+MODULE_VERSION: Final[str] = "v3.15.16.N2b3b"
+SCHEMA_VERSION: Final[int] = 1
+
+
+# ---------------------------------------------------------------------------
+# Step 5 invariants
+# ---------------------------------------------------------------------------
+
+STEP5_ENABLED_SUBSTAGE: Final[str] = "none"
+step5_implementation_allowed: Final[bool] = False
+
+
+# ---------------------------------------------------------------------------
+# Bounded request body limit
+# ---------------------------------------------------------------------------
+
+#: Maximum JSON body size. The dispatch endpoint accepts an empty
+#: body or a small object with a future optional ``event_id`` filter;
+#: anything larger is refused 413.
+_MAX_REQUEST_BYTES: Final[int] = 1024
+
+
+# ---------------------------------------------------------------------------
+# Loopback allowlist (defense in depth on top of nginx)
+# ---------------------------------------------------------------------------
+
+_LOOPBACK_REMOTE_ADDRS: Final[frozenset[str]] = frozenset({"127.0.0.1", "::1"})
+
+
+# ---------------------------------------------------------------------------
+# Artefact write target (sentinel-restricted, atomic)
+# ---------------------------------------------------------------------------
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "notification_dispatch_real"
+ARTIFACT_LATEST: Final[Path] = ARTIFACT_DIR / "latest.json"
+ARTIFACT_RELATIVE_PATH: Final[str] = (
+    "logs/notification_dispatch_real/latest.json"
+)
+_WRITE_PREFIX: Final[str] = "logs/notification_dispatch_real/"
+
+
+# ---------------------------------------------------------------------------
+# Source-snapshot path (N2b-1 outbox latest)
+# ---------------------------------------------------------------------------
+
+_OUTBOX_LATEST: Final[Path] = (
+    REPO_ROOT / "logs" / "notification_dispatch_outbox" / "latest.json"
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _safe_jsonify(payload: dict[str, Any]) -> Response:
+    """JSONify after running ``assert_no_secrets`` on the payload."""
+    assert_no_secrets(payload)
+    return jsonify(payload)
+
+
+def _is_loopback(addr: str | None) -> bool:
+    if not isinstance(addr, str) or not addr:
+        return False
+    return addr in _LOOPBACK_REMOTE_ADDRS
+
+
+def _read_outbox_snapshot() -> dict[str, Any] | None:
+    """Read the latest N2b-1 outbox snapshot. Best-effort; never raises."""
+    if not _OUTBOX_LATEST.is_file():
+        return None
+    try:
+        text = _OUTBOX_LATEST.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    try:
+        payload = json.loads(text)
+    except ValueError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return payload
+
+
+def _ready_records(snapshot: dict[str, Any] | None) -> list[dict[str, Any]]:
+    """Filter outbox records to those the stub provider accepted.
+
+    Those are the only candidates for real delivery — anything else
+    failed an upstream gate (schema, secret guard, rate limit, etc.)
+    and must not be promoted to a real push.
+    """
+    if not isinstance(snapshot, dict):
+        return []
+    records = snapshot.get("records")
+    if not isinstance(records, list):
+        return []
+    out: list[dict[str, Any]] = []
+    for r in records:
+        if not isinstance(r, dict):
+            continue
+        if r.get("outbound_delivery_intent") != "sent":
+            continue
+        payload = r.get("payload")
+        if not isinstance(payload, dict):
+            continue
+        eid = payload.get("event_id")
+        if not isinstance(eid, str) or not eid:
+            continue
+        out.append(r)
+    return out
+
+
+def _atomic_write_summary(payload: dict[str, Any]) -> Path:
+    """Atomic-write the dispatch summary. Sentinel-restricted."""
+    path = ARTIFACT_LATEST
+    posix = path.as_posix()
+    if _WRITE_PREFIX not in posix and not posix.startswith(_WRITE_PREFIX):
+        raise ValueError(
+            "api_push_dispatch._atomic_write_summary refuses non-real-logs "
+            f"output path: {path}"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".api_push_dispatch.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Core dispatch routine (test-injectable transport factory)
+# ---------------------------------------------------------------------------
+
+
+def _redact_record(
+    *,
+    event_id: str,
+    endpoint_hash: str,
+    outcome: str,
+    provider_status_class: str,
+    provider_status_code: int | None,
+    attempted_at: str,
+) -> dict[str, Any]:
+    """Return the redacted per-attempt summary row. Never contains the
+    endpoint URL, never contains key material."""
+    return {
+        "event_id": event_id,
+        "endpoint_hash": endpoint_hash,
+        "outcome": outcome,
+        "provider_status_class": provider_status_class,
+        "provider_status_code": provider_status_code,
+        "attempted_at": attempted_at,
+    }
+
+
+def dispatch_ready_events(
+    *,
+    transport_factory: Any | None = None,
+    outbox_snapshot: dict[str, Any] | None = None,
+    subscriptions: list[dict[str, Any]] | None = None,
+    unregister_callable: Any | None = None,
+) -> dict[str, Any]:
+    """Walk the latest outbox snapshot and dispatch each ready record
+    to each active subscription using the real transport.
+
+    Test-injection points (all default to the production wiring):
+
+    * ``transport_factory`` — defaults to
+      :func:`reporting.web_push_real_transport.make_transport_for_subscription`.
+    * ``outbox_snapshot`` — defaults to reading
+      ``logs/notification_dispatch_outbox/latest.json``.
+    * ``subscriptions`` — defaults to ``pss.list_subscriptions()``.
+    * ``unregister_callable`` — defaults to
+      ``pss.unregister_subscription`` (only invoked on a
+      ``drop_subscription`` outcome).
+
+    Returns the bounded summary dict; the caller writes it to
+    ``logs/notification_dispatch_real/latest.json``.
+    """
+    tf = (
+        transport_factory
+        if transport_factory is not None
+        else wprt.make_transport_for_subscription
+    )
+    snap = (
+        outbox_snapshot
+        if outbox_snapshot is not None
+        else _read_outbox_snapshot()
+    )
+    subs = (
+        list(subscriptions)
+        if subscriptions is not None
+        else list(pss.list_subscriptions())
+    )
+    unreg = (
+        unregister_callable
+        if unregister_callable is not None
+        else pss.unregister_subscription
+    )
+
+    ts = _utcnow()
+    records = _ready_records(snap)
+
+    attempts: list[dict[str, Any]] = []
+    counts: dict[str, int] = {
+        "ready_records": len(records),
+        "subscriptions": len(subs),
+        "attempted": 0,
+        "sent": 0,
+        "drop_subscription": 0,
+        "failed_provider": 0,
+        "retry": 0,
+        "skipped_no_subscription": 0,
+        "skipped_invalid_record": 0,
+        "unregistered_on_410": 0,
+    }
+
+    if not records or not subs:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "module_version": MODULE_VERSION,
+            "generated_at_utc": ts,
+            "step5_enabled_substage": STEP5_ENABLED_SUBSTAGE,
+            "step5_implementation_allowed": step5_implementation_allowed,
+            "counts": counts,
+            "attempts": attempts,
+            "note": (
+                "no_ready_records" if not records else "no_subscriptions"
+            ),
+        }
+
+    for rec in records:
+        payload = rec.get("payload") or {}
+        for sub in subs:
+            if not isinstance(sub, dict):
+                continue
+            endpoint = sub.get("endpoint")
+            if not isinstance(endpoint, str) or not endpoint:
+                continue
+
+            transport_callable = tf(subscription=sub)
+            dispatch_record = wpda.dispatch_one(
+                record=payload,
+                subscription=sub,
+                transport=transport_callable,
+                attempted_at=ts,
+            )
+            counts["attempted"] += 1
+            outcome = str(dispatch_record.get("outcome") or "")
+            if outcome in counts:
+                counts[outcome] += 1
+
+            if outcome == "drop_subscription":
+                try:
+                    if unreg(endpoint):
+                        counts["unregistered_on_410"] += 1
+                except Exception:
+                    pass
+
+            attempts.append(
+                _redact_record(
+                    event_id=str(dispatch_record.get("event_id") or ""),
+                    endpoint_hash=str(
+                        dispatch_record.get("endpoint_hash") or ""
+                    ),
+                    outcome=outcome,
+                    provider_status_class=str(
+                        dispatch_record.get("provider_status_class") or ""
+                    ),
+                    provider_status_code=(
+                        dispatch_record.get("provider_status_code")
+                        if isinstance(
+                            dispatch_record.get("provider_status_code"),
+                            int,
+                        )
+                        else None
+                    ),
+                    attempted_at=str(
+                        dispatch_record.get("attempted_at") or ts
+                    ),
+                )
+            )
+
+    summary = {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "generated_at_utc": ts,
+        "step5_enabled_substage": STEP5_ENABLED_SUBSTAGE,
+        "step5_implementation_allowed": step5_implementation_allowed,
+        "counts": counts,
+        "attempts": attempts,
+        "note": "dispatch_summary",
+    }
+    assert_no_secrets(summary)
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# View function
+# ---------------------------------------------------------------------------
+
+
+def _view_dispatch() -> tuple[Response, int] | Response:
+    """POST /api/push/dispatch — operator-triggered real delivery."""
+    if not _is_loopback(request.remote_addr):
+        return (
+            _safe_jsonify(
+                {"status": "error", "error": "remote_not_loopback"}
+            ),
+            403,
+        )
+    if request.content_length is not None and (
+        request.content_length > _MAX_REQUEST_BYTES
+    ):
+        return (
+            _safe_jsonify(
+                {"status": "error", "error": "payload_too_large"}
+            ),
+            413,
+        )
+    if not wprt.is_configured():
+        return (
+            _safe_jsonify(
+                {"status": "error", "error": "configuration_missing"}
+            ),
+            503,
+        )
+
+    try:
+        summary = dispatch_ready_events()
+    except Exception as exc:  # defense in depth
+        return (
+            _safe_jsonify(
+                {
+                    "status": "error",
+                    "error": "dispatch_exception",
+                    "exc_class": exc.__class__.__name__,
+                }
+            ),
+            500,
+        )
+
+    try:
+        _atomic_write_summary(summary)
+    except Exception:
+        # Best-effort: summary write failure does not undo the dispatch.
+        pass
+
+    return _safe_jsonify({"status": "ok", "summary": summary})
+
+
+# ---------------------------------------------------------------------------
+# Route table + register helper
+# ---------------------------------------------------------------------------
+
+_PUSH_DISPATCH_ROUTES: tuple[tuple[str, str, Any], ...] = (
+    ("/api/push/dispatch", "POST", _view_dispatch),
+)
+
+
+def register_push_dispatch_routes(app: Flask) -> None:
+    """Register the real Web Push dispatch surface.
+
+    **NOT wired into ``dashboard/dashboard.py``** in this PR. The
+    one-line wiring change ``register_push_dispatch_routes(app)`` is
+    operator-only per ``execution_authority.md`` (``dashboard_wiring``
+    = NEEDS_HUMAN). The blueprint becomes session-protected (and
+    nginx-loopback-restricted) once that wiring lands.
+    """
+    for path, method, handler in _PUSH_DISPATCH_ROUTES:
+        endpoint_name = (
+            f"push_dispatch_{method.lower()}_{path.rsplit('/', 1)[-1]}"
+        )
+        app.add_url_rule(
+            path,
+            endpoint=endpoint_name,
+            view_func=handler,
+            methods=[method],
+        )
+
+
+__all__ = [
+    "ARTIFACT_LATEST",
+    "ARTIFACT_RELATIVE_PATH",
+    "MODULE_VERSION",
+    "SCHEMA_VERSION",
+    "STEP5_ENABLED_SUBSTAGE",
+    "dispatch_ready_events",
+    "register_push_dispatch_routes",
+    "step5_implementation_allowed",
+]

--- a/docs/governance/notification_dispatch_real.md
+++ b/docs/governance/notification_dispatch_real.md
@@ -1,15 +1,34 @@
-# Real Web Push delivery — N2b-3 (design + N2b-3a adapter)
+# Real Web Push delivery — N2b-3 (N2b-3a adapter + N2b-3b internal-only delivery)
 
 > **Status:** N2b-3a (mocked-transport adapter) implemented.
-> N2b-3b (real Web Push provider call) **deferred** — needs operator
-> setup of the VAPID private-key environment variable and an
-> nginx 127.0.0.1 lock for `/api/push/dispatch`.
+> N2b-3b (real Web Push HTTP transport + internal-only operator
+> dispatch endpoint) implemented, **unwired in `dashboard/dashboard.py`**
+> and gated by:
 >
-> **Module:** [`reporting/web_push_dispatch_adapter.py`](../../reporting/web_push_dispatch_adapter.py)
+> 1. The operator setting the env-only VAPID private key on the VPS
+>    (`WEB_PUSH_VAPID_PRIVATE_KEY` + `WEB_PUSH_VAPID_SUBJECT`).
+> 2. The optional `pywebpush` runtime dependency being installed on
+>    the VPS.
+> 3. The operator-only two-line wiring diff in
+>    `dashboard/dashboard.py` (the no-touch hook blocks the agent
+>    from editing that file).
+> 4. nginx restricting `/api/push/dispatch` to `127.0.0.1` at the
+>    edge (operator infra change).
+>
+> Until all four conditions hold, N2b-3b is a no-op at runtime.
+> Real Web Push delivery, when enabled, is **notification delivery
+> only** — never approval, never merge, never deploy.
+>
+> **Modules:**
+> - [`reporting/web_push_dispatch_adapter.py`](../../reporting/web_push_dispatch_adapter.py) — N2b-3a envelope + outcome classifier (mocked transport)
+> - [`reporting/web_push_real_transport.py`](../../reporting/web_push_real_transport.py) — N2b-3b env-gated, lazy-imported real transport
+> - [`dashboard/api_push_dispatch.py`](../../dashboard/api_push_dispatch.py) — N2b-3b internal-only operator dispatch endpoint (UNWIRED)
 >
 > **Authority:** development-governance read-only.
-> N2b-3a sends no real push and grants no agent any new authority.
-> Level 6 stays permanently disabled per ADR-015 §Doctrine 1.
+> N2b-3 grants ADE **zero** new write authority over trading code,
+> never mints approval tokens, never opens an inbox row, never
+> merges, and never deploys. Level 6 stays permanently disabled per
+> ADR-015 §Doctrine 1.
 
 ---
 
@@ -18,29 +37,35 @@
 N2b-3 is the **real-delivery** half of the Push Notification Engine.
 The split:
 
-| Slice  | Title                                                    | Network call? | Operator action required? |
-| ------ | -------------------------------------------------------- | ------------- | ------------------------- |
-| **N2b-3a** | Mocked-transport dispatch adapter (this PR)         | **no**        | none                      |
-| **N2b-3b** | Real HTTP transport + VAPID JWT signing (deferred) | yes           | yes — VAPID env + nginx lock + key-rotation playbook |
+| Slice  | Title                                                             | Network call? | Operator action required?                                              |
+| ------ | ----------------------------------------------------------------- | ------------- | ---------------------------------------------------------------------- |
+| **N2b-3a** | Mocked-transport dispatch adapter                             | **no**        | none                                                                   |
+| **N2b-3b** | Real HTTP transport + internal-only operator dispatch route | yes (operator-triggered only) | yes — VAPID env + `pywebpush` install + nginx 127.0.0.1 lock + two-line wiring diff |
 
-N2b-3a builds the **HTTP envelope** that a real Web Push provider
-expects (URL, headers, body metadata, kid, endpoint hash, event id)
-and dispatches it through a **caller-supplied transport callable**.
-There is no module-level default transport; production wiring in
-N2b-3b will provide a real HTTP client via the future
-`dashboard/api_push_dispatch.py`.
+N2b-3a sends no real push by itself (it is the mocked-transport
+adapter; tests inject a synthetic transport). N2b-3b builds on top:
+
+1. A single env-gated, lazy-imported real-transport callable
+   (`reporting/web_push_real_transport.py`).
+2. A single internal-only Flask blueprint
+   (`dashboard/api_push_dispatch.py`) exposing exactly one route:
+   `POST /api/push/dispatch`. The blueprint is **NOT wired into**
+   `dashboard/dashboard.py` in this PR — wiring is the operator's
+   two-line diff.
 
 ---
 
 ## 2. Hard constraints
 
-N2b-3a, in this PR and at runtime, must not:
+N2b-3a + N2b-3b, in this PR and at runtime, must not:
 
-- send a real push (Web Push, APNs, FCM, Telegram, email, SMS, anything);
-- open a network socket;
-- import a Web Push library (`pywebpush`, `web_push`, `webpush`, etc.);
-- read or create a VAPID **private** key (the env-var name does
-  not appear in N2b-3a source);
+- send a real push without operator-controlled configuration in place;
+- open a network socket unless **all** of (env-set, `pywebpush`
+  installed, wired, loopback-only request) are true;
+- import a Web Push library at module-load time (`pywebpush` is
+  lazy-imported inside the transport call);
+- log raw VAPID private key, public key, endpoint URL, or key
+  material;
 - write to `dashboard/dashboard.py`;
 - write to `frontend/**`;
 - mint approval tokens (N4 territory);
@@ -53,75 +78,90 @@ N2b-3a, in this PR and at runtime, must not:
 - mutate research artifacts;
 - touch live / paper / shadow / risk / broker / execution paths;
 - edit `.claude/**`;
-- store secrets in repo;
+- store secrets in the repo;
 - edit canonical roadmap status fields;
 - mark any roadmap phase complete;
 - accept an approval from a notification click.
 
 The adapter ships its own AST-level forbidden-import scan and
-source-text scan to enforce the relevant bullets.
+source-text scan. The transport module ships a source-text scan that
+forbids any other module from referencing
+`WEB_PUSH_VAPID_PRIVATE_KEY`. The dispatch blueprint ships
+source-text and AST scans that forbid `subprocess`, `gh`, `git`,
+direct Web Push library imports, and decision verbs.
 
 ---
 
 ## 3. Closed vocabularies
 
-Pinned in [`reporting/web_push_dispatch_adapter.py`](../../reporting/web_push_dispatch_adapter.py):
+Pinned in
+[`reporting/web_push_dispatch_adapter.py`](../../reporting/web_push_dispatch_adapter.py)
+and
+[`reporting/web_push_real_transport.py`](../../reporting/web_push_real_transport.py):
 
-### `dispatch_outcome` (6 values)
+### `dispatch_outcome` (6 values, owned by N2b-3a)
 
 | Value                       | Meaning                                                                  |
 | --------------------------- | ------------------------------------------------------------------------ |
 | `sent`                      | provider returned 2xx                                                    |
-| `drop_subscription`         | provider returned 410 — subscription is dead, caller should remove it    |
+| `drop_subscription`         | provider returned 410 — subscription is dead, caller removes it          |
 | `failed_provider`           | 4xx other than 410 — payload or VAPID mismatch                           |
 | `retry`                     | 5xx or transport_error — try again with backoff                          |
 | `skipped_no_subscription`   | record had no subscription record to deliver to                          |
 | `skipped_invalid_record`    | record was missing `event_id` or otherwise malformed                     |
 
-### `provider_status_class` (6 values)
+### `provider_status_class` (6 values, owned by N2b-3a)
 
 ```
 2xx  410  4xx_other  5xx  transport_error  unknown
 ```
 
-### Envelope schema (closed, exact, ordered)
+### `error_class` (5 values, owned by N2b-3b real transport)
+
+| Value                  | Meaning                                                                            |
+| ---------------------- | ---------------------------------------------------------------------------------- |
+| `ok`                   | the provider returned an HTTP response (status_code is set)                        |
+| `config_missing`       | one or both VAPID env vars are absent at call time                                 |
+| `library_missing`      | the optional `pywebpush` dependency is not importable on the VPS                   |
+| `invalid_envelope`     | the envelope failed defense-in-depth shape validation                              |
+| `transport_exception` | `pywebpush` raised an unexpected exception, or returned no status code             |
+
+Every error_class except `ok` produces ``status_code=None`` in the
+transport result, which the adapter classifies as `transport_error`
+→ outcome `retry`.
+
+### Transport-result envelope (closed, exact)
 
 ```
-url            (the subscription endpoint URL)
-method         ("POST")
-headers        {TTL, Content-Encoding, Content-Type,
-                Authorization-Mode, Crypto-Key-Mode}
-body_meta      {event_id, event_kind, event_severity,
-                title, summary, open_at}
-kid
-endpoint_hash  (sha256(endpoint)[:16])
+status_code   (int | None)
+error_class   (one of ERROR_CLASSES)
+```
+
+### Dispatch-summary record (closed, exact, ordered)
+
+The dispatch endpoint writes per-attempt rows to
+`logs/notification_dispatch_real/latest.json` with **only** these
+fields — never the endpoint URL, never key material:
+
+```
 event_id
-```
-
-### Dispatch-record schema (closed, exact, ordered)
-
-```
-event_id
-event_kind
-event_severity
 endpoint_hash
-kid
 outcome
 provider_status_class
 provider_status_code
-envelope_url
 attempted_at
 ```
 
 ---
 
-## 4. Decoupled transport
+## 4. Decoupled transport (N2b-3a)
 
 `dispatch_one(record=..., subscription=..., transport=...)` requires
 the caller to supply the transport callable. **There is no default.**
-A missing or non-callable `transport` raises `TypeError` immediately.
+Tests inject a synthetic transport; production wiring in N2b-3b uses
+`reporting.web_push_real_transport.make_transport_for_subscription(...)`.
 
-Outcome classification:
+Outcome classification (unchanged from N2b-3a):
 
 | Provider response                   | `provider_status_class` | `outcome`            |
 | ----------------------------------- | ----------------------- | -------------------- |
@@ -132,109 +172,208 @@ Outcome classification:
 | Transport raised exception          | `transport_error`       | `retry`              |
 | Other (e.g. status_code=None)       | `unknown`               | `failed_provider`    |
 
-Tests pin every row of this table.
+---
+
+## 5. Real transport (N2b-3b)
+
+`reporting.web_push_real_transport` exposes three public symbols:
+
+| Symbol                                    | Purpose                                                                                          |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `is_configured()`                         | Boolean predicate — True iff both VAPID env vars are present and non-empty. Never echoes values. |
+| `make_transport()`                        | Returns a `Transport` callable that exercises env/library guards only (returns `invalid_envelope` on any real envelope — keys are not in the adapter envelope). Reserved for tests. |
+| `make_transport_for_subscription(*, subscription)` | Returns a per-subscription closure that performs the real Web Push request via `pywebpush`. The closure captures `subscription.keys.{p256dh,auth}` and re-reads the env at call time. |
+
+The real send call:
+
+1. Re-reads `WEB_PUSH_VAPID_PRIVATE_KEY` and `WEB_PUSH_VAPID_SUBJECT`
+   from env at call time (honours a rotation without restart).
+2. Validates the envelope shape against the closed key set.
+3. Confirms the envelope's `url` matches the subscription's
+   `endpoint` (defense in depth against caller mix-up).
+4. Lazy-imports `pywebpush`. Missing dependency → `library_missing`.
+5. Calls `pywebpush.webpush(subscription_info=..., data=...,
+   vapid_private_key=..., vapid_claims={"sub": subject}, ttl=...)`.
+6. Returns the closed `{status_code, error_class}` envelope.
+
+The transport NEVER raises; it classifies every failure mode.
 
 ---
 
-## 5. What is NOT yet computed in N2b-3a
+## 6. Dispatch endpoint (N2b-3b)
 
-| Concern                                  | Status                                                                        |
-| ---------------------------------------- | ----------------------------------------------------------------------------- |
-| Real HTTP client                         | **deferred to N2b-3b**                                                        |
-| Real `Authorization: vapid t=<jwt>`      | **deferred to N2b-3b** — header carries a closed placeholder mode string only |
-| Real `Crypto-Key: ...`                   | **deferred to N2b-3b** — header carries a closed placeholder mode string only |
-| AES-128-GCM encrypted body               | **deferred to N2b-3b** — body_meta carries the bounded six-key payload only   |
-| VAPID private key in env                 | **deferred to N2b-3b** — operator action required to generate keypair        |
-| `dashboard/api_push_dispatch.py`         | **deferred to N2b-3b** — wiring requires `dashboard_wiring=NEEDS_HUMAN`      |
-| nginx 127.0.0.1 lock for dispatch route  | **deferred to N2b-3b** — operator infra change                                |
-| Push subscription auto-drop on 410       | **deferred to N2b-3b** — N2b-3a returns the `drop_subscription` outcome but does not call `pss.unregister_subscription` itself |
+`dashboard.api_push_dispatch` exposes one route:
 
----
+| Method | Path                       | Behaviour                                                                                                                                                                                  |
+| ------ | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| POST   | `/api/push/dispatch`       | reads `logs/notification_dispatch_outbox/latest.json`, filters records with `outbound_delivery_intent=="sent"`, and dispatches each (record × subscription) via the real transport. Writes a redacted summary to `logs/notification_dispatch_real/latest.json`. |
 
-## 6. N2b-3b operator-action checklist (preview, for when the slice lands)
+Hard gates, in order, before any dispatch is attempted:
 
-Before N2b-3b can ship:
+1. **Loopback gate** — request must come from `127.0.0.1` or `::1`,
+   else HTTP 403 `remote_not_loopback`. nginx is expected to enforce
+   the same restriction at the edge; the Python check is defense in
+   depth.
+2. **Body-size gate** — body > 1 KiB → 413 `payload_too_large`.
+3. **Configuration gate** — `web_push_real_transport.is_configured()`
+   must return True, else HTTP 503 `configuration_missing`.
 
-1. Operator generates a VAPID keypair (one-shot script — agent can prepare, operator runs):
-   - public key written to gitignored `config/web_push_vapid_public.txt`;
-   - private key printed once to stdout, never to disk in repo.
-2. Operator sets `WEB_PUSH_VAPID_PRIVATE_KEY` in the VPS environment
-   (e.g. systemd unit override, `.env` outside repo).
-3. Operator confirms nginx restricts `/api/push/dispatch` to `127.0.0.1`
-   (existing pattern; agent prepares the operator-approved diff).
-4. Operator authorises the wiring PR for
-   `dashboard/api_push_dispatch.py` + the one-line
-   `register_push_dispatch_routes(app)` in `dashboard/dashboard.py`.
+On any `drop_subscription` outcome the endpoint calls
+`push_subscription_store.unregister_subscription(endpoint)`.
 
-Until all four are done, N2b-3b stays paused.
+The response body is run through
+`reporting.agent_audit_summary.assert_no_secrets` and contains only
+counts + per-attempt rows with `endpoint_hash` (never the endpoint
+URL, never key material).
+
+**The blueprint is NOT wired into `dashboard/dashboard.py` in this
+PR.** Wiring is the two-line operator diff:
+
+```diff
++from dashboard.api_push_dispatch import register_push_dispatch_routes
+ ...
++register_push_dispatch_routes(app)
+```
+
+The same skip-or-enforce dual-mode pin pattern used for N2b-2b
+applies: until the operator adds the two lines, the wiring pin tests
+return early; once added, they actively enforce the exact shape.
 
 ---
 
 ## 7. Authority chain summary
 
-| Capability                               | Today (post-N2b-2b) | After N2b-3a                                                  | After N2b-3b (future, gated)                                  |
-| ---------------------------------------- | ------------------- | ------------------------------------------------------------- | -------------------------------------------------------------- |
-| Compute notification-ready event         | N2a                 | unchanged                                                     | unchanged                                                     |
-| Build bounded six-key payload            | N2b-1 stub          | unchanged                                                     | unchanged                                                     |
-| Build Web Push HTTP envelope             | does not exist      | yes — N2b-3a `build_envelope(...)`                            | unchanged                                                     |
-| Open network socket / send a real push   | does not exist      | **does not exist** (transport is caller-supplied; tests use a synthetic) | yes — single audited callable in `dashboard/api_push_dispatch.py` |
-| Sign VAPID JWT                           | does not exist      | does not exist (placeholder `Authorization-Mode` header only) | yes — using env-only `WEB_PUSH_VAPID_PRIVATE_KEY`             |
-| Mint approval tokens                     | does not exist      | does not exist                                                | does not exist (N4 territory)                                 |
-| Open mobile inbox row                    | does not exist      | does not exist                                                | does not exist (N3 territory)                                 |
-| Execute merge / deploy                   | operator + branch protection | unchanged                                              | unchanged                                                     |
-| Autonomous merge / deploy                | **forbidden, Level 6** | unchanged — Level 6 stays permanently disabled              | unchanged — Level 6 stays permanently disabled                |
+| Capability                               | Today (post-N2b-3a) | After N2b-3b (this PR, unwired) | After operator wiring + env + nginx                          |
+| ---------------------------------------- | ------------------- | ------------------------------- | ------------------------------------------------------------- |
+| Compute notification-ready event         | N2a                 | unchanged                       | unchanged                                                     |
+| Build bounded six-key payload            | N2b-1 stub          | unchanged                       | unchanged                                                     |
+| Build Web Push HTTP envelope             | N2b-3a              | unchanged                       | unchanged                                                     |
+| Open network socket / send a real push   | does not exist      | **exists but disabled** (env unset, blueprint unwired, dependency optional) | yes — single audited callable in `reporting/web_push_real_transport.py`, invoked only by `dashboard/api_push_dispatch.py` |
+| Sign VAPID JWT                           | does not exist      | does not exist (env unset)      | yes — via env-only `WEB_PUSH_VAPID_PRIVATE_KEY`              |
+| Mint approval tokens                     | does not exist      | does not exist                  | does not exist (N4 territory)                                 |
+| Open mobile inbox row                    | does not exist      | does not exist                  | does not exist (N3 territory)                                 |
+| Execute merge / deploy                   | operator + branch protection | unchanged              | unchanged                                                     |
+| Autonomous merge / deploy                | **forbidden, Level 6** | unchanged — Level 6 stays permanently disabled | unchanged — Level 6 stays permanently disabled               |
 
-N2b-3a grants ADE **zero** new write authority, opens **zero**
-network sockets, and ships **zero** secret-handling code.
-
----
-
-## 8. Test coverage
-
-Pinned in [`tests/unit/test_web_push_dispatch_adapter.py`](../../tests/unit/test_web_push_dispatch_adapter.py):
-
-- closed `DISPATCH_OUTCOMES`, `PROVIDER_STATUS_CLASSES`,
-  `ENVELOPE_KEYS`, `ENVELOPE_HEADERS_KEYS`, `DISPATCH_RECORD_KEYS`
-  pinned exactly;
-- envelope shape: exactly the closed key set; no extras;
-- header set: exactly the five closed header keys;
-- `body_meta` is the six-key payload mirror;
-- `dispatch_one` requires the transport kwarg (`TypeError` on
-  missing or non-callable);
-- 2xx → `sent`; 410 → `drop_subscription`; 4xx-other →
-  `failed_provider`; 5xx → `retry`; transport exception → `retry`;
-- skipped paths: missing event_id → `skipped_invalid_record`;
-  missing subscription → `skipped_no_subscription`;
-- `endpoint_hash` is sha256[:16]; full endpoint URL never appears
-  in the dispatch record;
-- AST-level forbidden-import scan: no `dashboard`, `frontend`,
-  `automation`, `broker`, `agent.risk`, `agent.execution`,
-  `research`, `reporting.intelligent_routing`, `live`, `paper`,
-  `shadow`, `trading`;
-- source-text scan: no `subprocess`, `socket`, `urllib`, `requests`,
-  `httpx`, `aiohttp`, `pywebpush`, `web_push`, `webpush`, `gh`,
-  `git`;
-- no `WEB_PUSH_VAPID_PRIVATE_KEY` literal in source;
-- importing the module does not flip Step 5 invariants;
-- `assert_no_secrets` is invoked on every envelope and every
-  dispatch record.
+N2b-3b grants ADE **zero** new write authority over trading code,
+opens **zero** new approval/merge/deploy paths, and ships **zero**
+secret-in-repo code. The single real-push capability is gated by
+four independent operator-controlled signals (env, library, nginx,
+wiring).
 
 ---
 
-## 9. What N2b-3a does NOT do
+## 8. Operator setup checklist
 
-- N2b-3a sends no real push.
-- N2b-3a opens no network socket.
-- N2b-3a reads no VAPID private key.
-- N2b-3a does not create `dashboard/api_push_dispatch.py`.
-- N2b-3a writes no `dashboard/**` or `frontend/**` file.
-- N2b-3a opens no inbox row (N3 territory).
-- N2b-3a mints no token (N4 territory).
-- N2b-3a does not change Step 5.0 logic.
-- N2b-3a does not flip `step5_implementation_allowed`.
-- N2b-3a does not change `STEP5_ENABLED_SUBSTAGE`.
+Before the dispatch endpoint can deliver a real push, the operator
+must complete these one-shot setup steps on the VPS:
+
+1. **Generate a VAPID keypair** (one-shot, agent prepares the script
+   on operator request; the operator runs it):
+
+   ```bash
+   python -c "from py_vapid import Vapid01; v = Vapid01(); v.generate_keys(); v.save_key('config/web_push_vapid_private.pem'); v.save_public_key('config/web_push_vapid_public.txt'); print('done')"
+   ```
+
+   Write the public key text to `config/web_push_vapid_public.txt`
+   (gitignored). Keep the private key out of the repo entirely;
+   re-encode it as the env-var value (see step 2).
+
+2. **Set the env vars** in the systemd unit override or
+   `/etc/trading-agent.env` (outside the repo):
+
+   ```
+   WEB_PUSH_VAPID_PRIVATE_KEY=<base64url-or-pem-of-private-key>
+   WEB_PUSH_VAPID_SUBJECT=mailto:joeryvanrooij@gmail.com
+   ```
+
+3. **Install the optional runtime dependency** on the VPS:
+
+   ```bash
+   pip install pywebpush
+   ```
+
+4. **Restrict the dispatch route to 127.0.0.1** in the nginx config
+   (defense in depth on top of the Python loopback check):
+
+   ```nginx
+   location = /api/push/dispatch {
+       allow 127.0.0.1;
+       allow ::1;
+       deny all;
+       proxy_pass http://127.0.0.1:8050;
+   }
+   ```
+
+5. **Authorise the two-line wiring diff** in
+   `dashboard/dashboard.py` (operator commits; the agent prepares
+   the PR):
+
+   ```diff
+   +from dashboard.api_push_dispatch import register_push_dispatch_routes
+    ...
+   +register_push_dispatch_routes(app)
+   ```
+
+6. **Verify**:
+
+   ```bash
+   curl -sI http://127.0.0.1:8050/api/push/vapid_public
+   # → 200 (vapid_public_present=true via /api/push/status)
+   curl -sX POST http://127.0.0.1:8050/api/push/dispatch
+   # → 200 with a JSON summary; or 503 configuration_missing; or 403 remote_not_loopback
+   ```
+
+Until all six steps are done, the dispatch endpoint stays a no-op.
+
+---
+
+## 9. Test coverage
+
+Pinned in:
+
+- [`tests/unit/test_web_push_dispatch_adapter.py`](../../tests/unit/test_web_push_dispatch_adapter.py)
+  — N2b-3a envelope + outcome classifier + closed vocabularies.
+- [`tests/unit/test_web_push_real_transport.py`](../../tests/unit/test_web_push_real_transport.py)
+  — env gate, lazy-import gate, envelope validation, mocked
+  `pywebpush` call, transport-result envelope shape, no secret leak,
+  source-text scans.
+- [`tests/unit/test_api_push_dispatch.py`](../../tests/unit/test_api_push_dispatch.py)
+  — method set (POST only), loopback gate (403 from non-loopback),
+  env gate (503 from no env), body-size gate (413), happy path with
+  injected mock transport factory, 410 → unregister call, summary
+  redaction (no endpoint URLs, no keys, no decision verbs), atomic
+  sentinel-restricted write, AST + source-text guard scans.
+- [`tests/unit/test_dashboard_dashboard_one_line_wiring.py`](../../tests/unit/test_dashboard_dashboard_one_line_wiring.py)
+  — N2b-2b skip-or-enforce wiring pin (unchanged) + a new
+  skip-or-enforce pin for the N2b-3b dispatch wiring (until the
+  operator adds the two lines, the pin returns early; once added,
+  the file must contain EXACTLY one import + one register call,
+  with all existing registrations preserved).
+
+---
+
+## 10. What N2b-3b does NOT do
+
+- N2b-3b never sends a real push without all four operator-controlled
+  signals (env, library, nginx, wiring) in place.
+- N2b-3b does not edit `dashboard/dashboard.py` directly — the
+  no-touch hook blocks the agent.
+- N2b-3b does not store the VAPID private key in the repo.
+- N2b-3b does not log raw endpoint URLs or key material.
+- N2b-3b does not open a mobile inbox row (N3 territory remains
+  future).
+- N2b-3b does not mint approval tokens (N4 territory remains
+  future).
+- N2b-3b does not merge or deploy (N5 / future remain
+  unimplemented).
+- N2b-3b does not change Step 5.0 logic.
+- N2b-3b does not flip `step5_implementation_allowed`.
+- N2b-3b does not change `STEP5_ENABLED_SUBSTAGE`.
 - Step 5.1 / Step 5.2 remain BLOCKED.
-- N2b-3b (real Web Push), N3 (mobile approval inbox), N4 (token
-  gate), and N5 (merge/deploy adapter) remain unimplemented.
-- Level 6 stays permanently disabled. **No approval can happen
-  from notification click alone.**
+- N3 (mobile approval inbox), N4 (token gate), and N5 (merge/deploy
+  adapter) remain unimplemented.
+- Level 6 stays permanently disabled. **No approval can happen from
+  notification click alone.** Real push delivery, when enabled, is
+  notification delivery only — never approval, never merge, never
+  deploy.

--- a/reporting/web_push_real_transport.py
+++ b/reporting/web_push_real_transport.py
@@ -1,0 +1,391 @@
+"""N2b-3b — Real Web Push transport (env-gated, lazy-imported).
+
+Provides the single isolated callable that actually performs a Web
+Push HTTP request to a real provider (FCM / Mozilla / Apple / WNS).
+It is the only place in the repository that may open a Web Push
+network socket. It does so only when:
+
+1. The VPS environment exposes ``WEB_PUSH_VAPID_PRIVATE_KEY`` and
+   ``WEB_PUSH_VAPID_SUBJECT``; and
+2. The optional ``pywebpush`` runtime dependency is importable; and
+3. The caller (``dashboard.api_push_dispatch``) explicitly constructs
+   the transport via :func:`make_transport` and hands it to the
+   existing N2b-3a adapter ``dispatch_one(transport=...)``.
+
+If any of those conditions fail, the transport refuses to operate and
+returns ``{"status_code": None, "error_class": "..."}`` so the
+adapter classifies the outcome as ``retry`` and emits no real push.
+
+Hard guarantees (pinned by tests)
+---------------------------------
+
+* Stdlib-only at import time. ``pywebpush`` is imported **lazily**
+  inside :func:`_real_send`; it is never imported at module load.
+* No subprocess, no ``gh``, no ``git``.
+* The literal env-var name ``WEB_PUSH_VAPID_PRIVATE_KEY`` IS allowed
+  in this module — this is the one and only module permitted to
+  reference it. Every other module pins its absence.
+* :func:`is_configured` returns a boolean only; it never returns,
+  logs, or echoes the private-key content.
+* The transport return envelope is the closed shape
+  ``{"status_code": int|None, "error_class": str|None}``.
+* Endpoint URLs are never logged. The caller already supplies an
+  ``endpoint_hash`` field; this module relies on that for any
+  observability surface (none is added here — the adapter and the
+  dashboard API layer own observability).
+* No imports of ``dashboard``, ``frontend``, ``automation``,
+  ``broker``, ``agent.risk``, ``agent.execution``, ``research``,
+  ``reporting.intelligent_routing``, ``live``, ``paper``, ``shadow``,
+  ``trading``.
+* No mutation of any file; the transport is a pure HTTP egress
+  helper.
+* Importing this module does NOT flip Step 5 invariants.
+
+Architecture
+------------
+
+::
+
+    notification_dispatcher (N2a)
+       └─ records with delivery_intent="ready"
+           ↓
+    notification_dispatch_outbox (N2b-1)
+       └─ stub provider, accepted_offline
+           ↓
+    web_push_dispatch_adapter (N2b-3a)
+       └─ build_envelope(...) → transport(envelope) → outcome
+                                ↑
+                                │
+    web_push_real_transport (N2b-3b)  ← THIS MODULE
+       └─ make_transport() → callable[envelope] → {status_code, error_class}
+           (lazy pywebpush import; env-only VAPID private)
+
+The transport is the smallest safe surface that lets a real push
+flow end-to-end. It does **not**:
+
+* mint approval tokens (N4 territory);
+* open mobile approval inbox rows (N3 territory);
+* execute merge / deploy (N5 / future);
+* enable Step 5.1 or Step 5.2;
+* flip ``step5_implementation_allowed``;
+* change ``STEP5_ENABLED_SUBSTAGE``;
+* touch QRE / research / live / paper / shadow / risk / broker /
+  execution paths;
+* edit ``.claude/**``;
+* persist secrets to the repo.
+
+Level 6 stays permanently disabled per ADR-015 §Doctrine 1.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Callable, Final
+
+MODULE_VERSION: Final[str] = "v3.15.16.N2b3b"
+SCHEMA_VERSION: Final[str] = "1.0"
+
+# ---------------------------------------------------------------------------
+# Step 5 invariants
+# ---------------------------------------------------------------------------
+
+STEP5_ENABLED_SUBSTAGE: Final[str] = "none"
+step5_implementation_allowed: Final[bool] = False
+
+
+# ---------------------------------------------------------------------------
+# Closed env-var names
+# ---------------------------------------------------------------------------
+
+#: Name of the env var that holds the VAPID private key (PEM or base64url
+#: depending on the provider library's accepted format). The value is
+#: NEVER hard-coded in repo; the operator sets this in the VPS
+#: environment (systemd unit override or `.env` outside the repo).
+ENV_VAPID_PRIVATE_KEY: Final[str] = "WEB_PUSH_VAPID_PRIVATE_KEY"
+
+#: Name of the env var that holds the VAPID subject (``mailto:`` URI or
+#: ``https://`` URL identifying the application server, per RFC 8292).
+ENV_VAPID_SUBJECT: Final[str] = "WEB_PUSH_VAPID_SUBJECT"
+
+
+# ---------------------------------------------------------------------------
+# Closed result envelope
+# ---------------------------------------------------------------------------
+
+#: Closed transport-result envelope. The same keys whatever the
+#: outcome — caller checks ``status_code`` (None on transport error).
+TRANSPORT_RESULT_KEYS: Final[tuple[str, ...]] = (
+    "status_code",
+    "error_class",
+)
+
+#: Closed ``error_class`` vocabulary. The adapter maps these to its
+#: ``provider_status_class``; the transport never invents new values.
+ERROR_CLASSES: Final[tuple[str, ...]] = (
+    "ok",
+    "config_missing",
+    "library_missing",
+    "invalid_envelope",
+    "transport_exception",
+)
+
+
+# ---------------------------------------------------------------------------
+# Configuration predicate (env-only, never echoes values)
+# ---------------------------------------------------------------------------
+
+
+def is_configured() -> bool:
+    """Return True iff both VAPID env vars are present and non-empty.
+
+    Does NOT return or log the values themselves. The dashboard API
+    layer uses this predicate to fail-closed before invoking the
+    transport. Pinned by tests.
+    """
+    priv = os.environ.get(ENV_VAPID_PRIVATE_KEY) or ""
+    subj = os.environ.get(ENV_VAPID_SUBJECT) or ""
+    return bool(priv) and bool(subj)
+
+
+def _read_env_subject() -> str:
+    """Return the VAPID subject env value or empty string.
+
+    Internal helper; never echoes the private key.
+    """
+    return (os.environ.get(ENV_VAPID_SUBJECT) or "").strip()
+
+
+def _read_env_private_key() -> str:
+    """Return the VAPID private-key env value or empty string.
+
+    Internal helper. The returned value is passed directly to the
+    Web Push library and never logged, printed, or persisted.
+    """
+    return (os.environ.get(ENV_VAPID_PRIVATE_KEY) or "").strip()
+
+
+# ---------------------------------------------------------------------------
+# Envelope validation
+# ---------------------------------------------------------------------------
+
+_ENVELOPE_REQUIRED_KEYS: Final[tuple[str, ...]] = (
+    "url",
+    "method",
+    "headers",
+    "body_meta",
+    "kid",
+    "endpoint_hash",
+    "event_id",
+)
+
+
+def _envelope_is_valid(envelope: Any) -> bool:
+    """Return True iff the envelope matches the N2b-3a adapter shape.
+
+    Defense-in-depth: the adapter already builds the envelope, but
+    the transport refuses anything else. This keeps the only network
+    egress callable in the repo from being abused by a future caller
+    that forgets the envelope contract.
+    """
+    if not isinstance(envelope, dict):
+        return False
+    if set(envelope.keys()) != set(_ENVELOPE_REQUIRED_KEYS):
+        return False
+    url = envelope.get("url")
+    if not isinstance(url, str) or not url:
+        return False
+    if not (
+        url.startswith("https://fcm.googleapis.com/")
+        or url.startswith("https://updates.push.services.mozilla.com/")
+        or url.startswith("https://web.push.apple.com/")
+        or url.startswith("https://wns2-")
+    ):
+        return False
+    headers = envelope.get("headers")
+    if not isinstance(headers, dict):
+        return False
+    body_meta = envelope.get("body_meta")
+    if not isinstance(body_meta, dict):
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Result envelope helpers
+# ---------------------------------------------------------------------------
+
+
+def _result(
+    *, status_code: int | None, error_class: str
+) -> dict[str, Any]:
+    """Build the closed-shape transport result envelope."""
+    res = {"status_code": status_code, "error_class": error_class}
+    assert set(res.keys()) == set(TRANSPORT_RESULT_KEYS)
+    return res
+
+
+# ---------------------------------------------------------------------------
+# Real provider call (lazy pywebpush import)
+# ---------------------------------------------------------------------------
+
+
+def _payload_bytes(body_meta: dict[str, Any]) -> bytes:
+    """Encode the bounded six-key payload as deterministic JSON bytes.
+
+    The N2b-3a adapter already enforces the payload schema; we just
+    serialize it. ``sort_keys=True`` so a given record always produces
+    the same payload bytes for transport-layer replay.
+    """
+    return json.dumps(body_meta, sort_keys=True, ensure_ascii=False).encode(
+        "utf-8"
+    )
+
+
+def _real_send(envelope: dict[str, Any]) -> dict[str, Any]:
+    """Bare-transport stub used by :func:`make_transport`.
+
+    The adapter envelope does NOT carry the per-subscription keys that
+    ``pywebpush`` requires, so a bare transport cannot perform a real
+    push even when env + library are present. This function therefore
+    only exercises the env-presence and envelope-shape guards; the
+    dashboard API layer uses :func:`make_transport_for_subscription`
+    to obtain a callable that captures the subscription's keys.
+    """
+    subject = _read_env_subject()
+    private_key = _read_env_private_key()
+    if not subject or not private_key:
+        return _result(status_code=None, error_class="config_missing")
+    if not _envelope_is_valid(envelope):
+        return _result(status_code=None, error_class="invalid_envelope")
+    return _result(status_code=None, error_class="invalid_envelope")
+
+
+def make_transport() -> Callable[[dict[str, Any]], dict[str, Any]]:
+    """Return a ``Transport`` callable compatible with the N2b-3a
+    adapter.
+
+    The returned callable refuses to operate unless
+    :func:`is_configured` is True at call time. It also requires the
+    optional ``pywebpush`` dependency at call time; without it the
+    callable returns ``library_missing``. The callable never raises;
+    all failure modes are classified into the closed
+    :data:`ERROR_CLASSES` vocabulary.
+
+    NOTE: a bare ``make_transport()`` cannot perform a real push
+    because the Web Push subscription's ``keys.p256dh`` / ``keys.auth``
+    are NOT part of the adapter's envelope schema. The bare callable
+    therefore returns ``invalid_envelope`` even on a valid envelope —
+    it is wired only for tests that exercise the env / library /
+    envelope-validation gates. The dashboard API layer uses
+    :func:`make_transport_for_subscription` to produce a callable that
+    captures the subscription keys per dispatch.
+    """
+    return _real_send
+
+
+def make_transport_for_subscription(
+    *,
+    subscription: dict[str, Any],
+) -> Callable[[dict[str, Any]], dict[str, Any]]:
+    """Return a per-subscription transport closure.
+
+    The closure captures the subscription's ``keys`` dict (required by
+    ``pywebpush`` for AES-128-GCM payload encryption) and performs the
+    real Web Push HTTP request on each call. All failure modes are
+    classified into :data:`ERROR_CLASSES`; the closure never raises.
+
+    The dashboard API layer composes one closure per (event ×
+    subscription) pair before handing it to
+    ``web_push_dispatch_adapter.dispatch_one``.
+    """
+
+    def _send(envelope: dict[str, Any]) -> dict[str, Any]:
+        subject = _read_env_subject()
+        private_key = _read_env_private_key()
+        if not subject or not private_key:
+            return _result(status_code=None, error_class="config_missing")
+
+        if not _envelope_is_valid(envelope):
+            return _result(status_code=None, error_class="invalid_envelope")
+
+        if not isinstance(subscription, dict):
+            return _result(status_code=None, error_class="invalid_envelope")
+        endpoint = envelope.get("url")
+        sub_endpoint = subscription.get("endpoint")
+        if endpoint != sub_endpoint:
+            return _result(status_code=None, error_class="invalid_envelope")
+        keys = subscription.get("keys")
+        if not isinstance(keys, dict):
+            return _result(status_code=None, error_class="invalid_envelope")
+        p256dh = keys.get("p256dh")
+        auth = keys.get("auth")
+        if not isinstance(p256dh, str) or not p256dh:
+            return _result(status_code=None, error_class="invalid_envelope")
+        if not isinstance(auth, str) or not auth:
+            return _result(status_code=None, error_class="invalid_envelope")
+
+        try:
+            from pywebpush import WebPushException, webpush  # type: ignore
+        except Exception:
+            return _result(status_code=None, error_class="library_missing")
+
+        body_meta = envelope.get("body_meta", {})
+        if not isinstance(body_meta, dict):
+            return _result(status_code=None, error_class="invalid_envelope")
+        payload = _payload_bytes(body_meta)
+
+        headers = envelope.get("headers", {}) or {}
+        ttl_str = headers.get("TTL") if isinstance(headers, dict) else None
+        try:
+            ttl = int(ttl_str) if ttl_str is not None else 60
+        except (TypeError, ValueError):
+            ttl = 60
+
+        subscription_info = {
+            "endpoint": endpoint,
+            "keys": {"p256dh": p256dh, "auth": auth},
+        }
+
+        try:
+            resp = webpush(
+                subscription_info=subscription_info,
+                data=payload,
+                vapid_private_key=private_key,
+                vapid_claims={"sub": subject},
+                ttl=ttl,
+            )
+        except WebPushException as exc:  # type: ignore[misc]
+            status = None
+            inner = getattr(exc, "response", None)
+            if inner is not None:
+                code = getattr(inner, "status_code", None)
+                if isinstance(code, int):
+                    status = code
+            if status is None:
+                return _result(status_code=None, error_class="transport_exception")
+            return _result(status_code=status, error_class="ok")
+        except Exception:
+            return _result(status_code=None, error_class="transport_exception")
+
+        status_code = getattr(resp, "status_code", None)
+        if not isinstance(status_code, int):
+            return _result(status_code=None, error_class="transport_exception")
+        return _result(status_code=status_code, error_class="ok")
+
+    return _send
+
+
+__all__ = [
+    "ENV_VAPID_PRIVATE_KEY",
+    "ENV_VAPID_SUBJECT",
+    "ERROR_CLASSES",
+    "MODULE_VERSION",
+    "SCHEMA_VERSION",
+    "STEP5_ENABLED_SUBSTAGE",
+    "TRANSPORT_RESULT_KEYS",
+    "is_configured",
+    "make_transport",
+    "make_transport_for_subscription",
+    "step5_implementation_allowed",
+]

--- a/tests/unit/test_api_push_dispatch.py
+++ b/tests/unit/test_api_push_dispatch.py
@@ -1,0 +1,616 @@
+"""Unit tests for N2b-3b — dashboard.api_push_dispatch (UNWIRED).
+
+Pins:
+
+* the blueprint registers exactly one route, POST /api/push/dispatch;
+* the loopback gate refuses non-loopback `request.remote_addr` with 403;
+* the env gate refuses (503 `configuration_missing`) when
+  :func:`reporting.web_push_real_transport.is_configured` is False;
+* the body-size gate refuses payloads > 1 KiB with 413;
+* the happy path with a mocked transport factory dispatches each
+  (record × subscription) pair and aggregates counts;
+* a 410 outcome triggers ``pss.unregister_subscription`` and
+  increments ``unregistered_on_410``;
+* the response body contains no endpoint URLs, no key material, no
+  decision-verb literals;
+* the summary file write is atomic and sentinel-restricted;
+* `dashboard/dashboard.py` does NOT yet import or register the
+  dispatch blueprint (until the operator wires it; skip-or-enforce);
+* source-text + AST scans for forbidden imports / literals / verbs;
+* Step 5 invariants unchanged by import.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from flask import Flask
+
+from dashboard import api_push_dispatch as apd
+from reporting import push_subscription_store as pss
+from reporting import web_push_real_transport as wprt
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolate_artifacts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect the artefact write target into ``tmp_path``."""
+    target_dir = tmp_path / "logs" / "notification_dispatch_real"
+    target_latest = target_dir / "latest.json"
+    monkeypatch.setattr(apd, "ARTIFACT_DIR", target_dir)
+    monkeypatch.setattr(apd, "ARTIFACT_LATEST", target_latest)
+    return target_dir
+
+
+@pytest.fixture(autouse=True)
+def _isolate_subscription_store(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Path:
+    sub_path = tmp_path / "config" / "web_push_subscriptions.json"
+    sub_path.parent.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(pss, "SUBSCRIPTIONS_PATH", sub_path)
+    monkeypatch.setattr(
+        pss,
+        "VAPID_PUBLIC_PATH",
+        tmp_path / "config" / "web_push_vapid_public.txt",
+    )
+    return sub_path
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(wprt.ENV_VAPID_PRIVATE_KEY, raising=False)
+    monkeypatch.delenv(wprt.ENV_VAPID_SUBJECT, raising=False)
+
+
+def _make_app() -> Flask:
+    app = Flask(__name__)
+    apd.register_push_dispatch_routes(app)
+    return app
+
+
+def _valid_outbox_snapshot() -> dict[str, Any]:
+    return {
+        "records": [
+            {
+                "event_id": "abc12345abc12345",
+                "outbound_delivery_intent": "sent",
+                "payload": {
+                    "event_id": "abc12345abc12345",
+                    "event_kind": "intake_candidate_eligible",
+                    "event_severity": "push_info",
+                    "title": "title",
+                    "summary": "summary",
+                    "open_at": "/agent-control/inbox?event=abc12345abc12345",
+                },
+            }
+        ]
+    }
+
+
+def _valid_subscription() -> dict[str, Any]:
+    return {
+        "endpoint": "https://fcm.googleapis.com/fcm/send/abc",
+        "keys": {"p256dh": "BCfV1eK4_pub", "auth": "auth_secret"},
+        "kid": "k1",
+    }
+
+
+def _register_a_subscription() -> None:
+    """Persist one valid subscription via the store API."""
+    rec, _warnings = pss.register_subscription(
+        {
+            "endpoint": "https://fcm.googleapis.com/fcm/send/abc",
+            "keys": {
+                "p256dh": "BCfV1eK4_p256dh_public_key_base64url_text",
+                "auth": "auth_secret_base64url_text",
+            },
+            "kid": "k1",
+            "label": "test",
+        }
+    )
+    assert rec is not None
+
+
+# ---------------------------------------------------------------------------
+# Route registration
+# ---------------------------------------------------------------------------
+
+
+def test_register_routes_registers_only_dispatch_post() -> None:
+    app = _make_app()
+    rules = [
+        (rule.rule, frozenset(rule.methods or set()))
+        for rule in app.url_map.iter_rules()
+        if rule.rule.startswith("/api/push/")
+    ]
+    assert rules == [(
+        "/api/push/dispatch",
+        frozenset({"POST", "OPTIONS"}),
+    )], rules
+
+
+def test_dispatch_route_not_yet_wired_into_dashboard_dashboard() -> None:
+    """Until the operator commits the two-line wiring diff for
+    api_push_dispatch, `dashboard/dashboard.py` must not import or
+    register this blueprint. Skip-or-enforce dual mode: if the wiring
+    is present, the same test_dashboard_dashboard_one_line_wiring test
+    enforces the exact shape; here we ONLY assert that the wiring is
+    not present (i.e., this test currently passes because the
+    operator has not yet wired it)."""
+    text = (REPO_ROOT / "dashboard" / "dashboard.py").read_text(
+        encoding="utf-8"
+    )
+    wiring_present = (
+        "from dashboard.api_push_dispatch import register_push_dispatch_routes"
+        in text
+    )
+    register_present = "register_push_dispatch_routes(app)" in text
+    # The two flags must be in sync (both absent or both present).
+    assert wiring_present == register_present, (
+        "dashboard.py must contain BOTH import and register call for "
+        "api_push_dispatch wiring, or NEITHER. Found import="
+        f"{wiring_present}, register={register_present}."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Loopback gate
+# ---------------------------------------------------------------------------
+
+
+def test_loopback_gate_refuses_non_loopback() -> None:
+    app = _make_app()
+    client = app.test_client()
+    res = client.post(
+        "/api/push/dispatch",
+        data="{}",
+        content_type="application/json",
+        environ_overrides={"REMOTE_ADDR": "203.0.113.42"},
+    )
+    assert res.status_code == 403
+    body = res.get_json()
+    assert body == {"status": "error", "error": "remote_not_loopback"}
+
+
+def test_loopback_gate_accepts_ipv4_loopback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A loopback request still needs env to proceed; without env we
+    expect 503, not 403."""
+    app = _make_app()
+    client = app.test_client()
+    res = client.post(
+        "/api/push/dispatch",
+        data="{}",
+        content_type="application/json",
+        environ_overrides={"REMOTE_ADDR": "127.0.0.1"},
+    )
+    assert res.status_code == 503
+
+
+def test_loopback_gate_accepts_ipv6_loopback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = _make_app()
+    client = app.test_client()
+    res = client.post(
+        "/api/push/dispatch",
+        data="{}",
+        content_type="application/json",
+        environ_overrides={"REMOTE_ADDR": "::1"},
+    )
+    assert res.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# Env gate
+# ---------------------------------------------------------------------------
+
+
+def test_env_gate_refuses_when_unconfigured() -> None:
+    app = _make_app()
+    client = app.test_client()
+    res = client.post(
+        "/api/push/dispatch",
+        data="{}",
+        content_type="application/json",
+        environ_overrides={"REMOTE_ADDR": "127.0.0.1"},
+    )
+    assert res.status_code == 503
+    body = res.get_json()
+    assert body == {"status": "error", "error": "configuration_missing"}
+
+
+# ---------------------------------------------------------------------------
+# Body-size gate
+# ---------------------------------------------------------------------------
+
+
+def test_body_size_gate_refuses_oversize_body() -> None:
+    app = _make_app()
+    client = app.test_client()
+    res = client.post(
+        "/api/push/dispatch",
+        data="x" * (apd._MAX_REQUEST_BYTES + 1),
+        content_type="application/json",
+        environ_overrides={"REMOTE_ADDR": "127.0.0.1"},
+    )
+    assert res.status_code == 413
+    body = res.get_json()
+    assert body == {"status": "error", "error": "payload_too_large"}
+
+
+# ---------------------------------------------------------------------------
+# Happy path with injected mock transport
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_ready_events_happy_path_with_mock_transport() -> None:
+    """End-to-end (record × subscription) dispatch via an injected
+    transport factory that returns 2xx."""
+
+    def fake_factory(*, subscription: dict[str, Any]) -> Any:
+        def _t(envelope: dict[str, Any]) -> dict[str, Any]:
+            return {"status_code": 201, "error_class": "ok"}
+
+        return _t
+
+    snap = _valid_outbox_snapshot()
+    summary = apd.dispatch_ready_events(
+        transport_factory=fake_factory,
+        outbox_snapshot=snap,
+        subscriptions=[_valid_subscription()],
+        unregister_callable=lambda _e: False,
+    )
+    counts = summary["counts"]
+    assert counts["ready_records"] == 1
+    assert counts["subscriptions"] == 1
+    assert counts["attempted"] == 1
+    assert counts["sent"] == 1
+    assert summary["note"] == "dispatch_summary"
+    # Per-attempt rows are redacted.
+    assert len(summary["attempts"]) == 1
+    row = summary["attempts"][0]
+    for k in ("event_id", "endpoint_hash", "outcome", "provider_status_class"):
+        assert k in row
+    # Endpoint URL and keys never appear.
+    raw = json.dumps(summary)
+    assert "fcm.googleapis.com" not in raw
+    assert "BCfV1eK4_pub" not in raw
+    assert "auth_secret" not in raw
+
+
+def test_dispatch_ready_events_410_triggers_unregister() -> None:
+    """A 410 from the transport must classify as `drop_subscription`
+    AND call the unregister callable AND increment the counter."""
+    unreg_calls: list[str] = []
+
+    def fake_factory(*, subscription: dict[str, Any]) -> Any:
+        def _t(envelope: dict[str, Any]) -> dict[str, Any]:
+            return {"status_code": 410, "error_class": "ok"}
+
+        return _t
+
+    def fake_unreg(endpoint: str) -> bool:
+        unreg_calls.append(endpoint)
+        return True
+
+    snap = _valid_outbox_snapshot()
+    summary = apd.dispatch_ready_events(
+        transport_factory=fake_factory,
+        outbox_snapshot=snap,
+        subscriptions=[_valid_subscription()],
+        unregister_callable=fake_unreg,
+    )
+    counts = summary["counts"]
+    assert counts["drop_subscription"] == 1
+    assert counts["unregistered_on_410"] == 1
+    assert unreg_calls == ["https://fcm.googleapis.com/fcm/send/abc"]
+
+
+def test_dispatch_ready_events_no_records_returns_no_ready_records() -> None:
+    summary = apd.dispatch_ready_events(
+        transport_factory=lambda *, subscription: (lambda e: {}),
+        outbox_snapshot={"records": []},
+        subscriptions=[_valid_subscription()],
+        unregister_callable=lambda _e: False,
+    )
+    assert summary["note"] == "no_ready_records"
+    assert summary["counts"]["attempted"] == 0
+
+
+def test_dispatch_ready_events_no_subscriptions_returns_no_subscriptions() -> None:
+    summary = apd.dispatch_ready_events(
+        transport_factory=lambda *, subscription: (lambda e: {}),
+        outbox_snapshot=_valid_outbox_snapshot(),
+        subscriptions=[],
+        unregister_callable=lambda _e: False,
+    )
+    assert summary["note"] == "no_subscriptions"
+    assert summary["counts"]["attempted"] == 0
+
+
+def test_dispatch_ready_events_skips_non_sent_outbox_records() -> None:
+    """A `duplicate` or `failed_*` outbox record must not be promoted
+    to real delivery."""
+    snap = {
+        "records": [
+            {
+                "event_id": "x",
+                "outbound_delivery_intent": "duplicate",
+                "payload": {"event_id": "x"},
+            }
+        ]
+    }
+    summary = apd.dispatch_ready_events(
+        transport_factory=lambda *, subscription: (lambda e: {}),
+        outbox_snapshot=snap,
+        subscriptions=[_valid_subscription()],
+        unregister_callable=lambda _e: False,
+    )
+    assert summary["counts"]["ready_records"] == 0
+    assert summary["counts"]["attempted"] == 0
+
+
+# ---------------------------------------------------------------------------
+# End-to-end via Flask client (env set, mocked transport)
+# ---------------------------------------------------------------------------
+
+
+def test_post_dispatch_happy_path_writes_summary(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv(wprt.ENV_VAPID_PRIVATE_KEY, "x")
+    monkeypatch.setenv(wprt.ENV_VAPID_SUBJECT, "mailto:x@y.z")
+
+    # Replace _read_outbox_snapshot with our in-test snapshot.
+    monkeypatch.setattr(
+        apd, "_read_outbox_snapshot", lambda: _valid_outbox_snapshot()
+    )
+    _register_a_subscription()
+
+    # Inject a successful mock factory via patching make_transport_for_subscription.
+    def fake_factory(*, subscription: dict[str, Any]) -> Any:
+        def _t(envelope: dict[str, Any]) -> dict[str, Any]:
+            return {"status_code": 201, "error_class": "ok"}
+
+        return _t
+
+    monkeypatch.setattr(
+        wprt, "make_transport_for_subscription", fake_factory
+    )
+
+    app = _make_app()
+    client = app.test_client()
+    res = client.post(
+        "/api/push/dispatch",
+        data="{}",
+        content_type="application/json",
+        environ_overrides={"REMOTE_ADDR": "127.0.0.1"},
+    )
+    assert res.status_code == 200, res.data
+    body = res.get_json()
+    assert body["status"] == "ok"
+    assert body["summary"]["counts"]["sent"] == 1
+    # Summary written to ARTIFACT_LATEST.
+    assert apd.ARTIFACT_LATEST.is_file()
+
+
+def test_post_dispatch_response_never_contains_endpoint_or_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(wprt.ENV_VAPID_PRIVATE_KEY, "x")
+    monkeypatch.setenv(wprt.ENV_VAPID_SUBJECT, "mailto:x@y.z")
+    monkeypatch.setattr(
+        apd, "_read_outbox_snapshot", lambda: _valid_outbox_snapshot()
+    )
+    _register_a_subscription()
+
+    def fake_factory(*, subscription: dict[str, Any]) -> Any:
+        return lambda envelope: {"status_code": 201, "error_class": "ok"}
+
+    monkeypatch.setattr(
+        wprt, "make_transport_for_subscription", fake_factory
+    )
+
+    app = _make_app()
+    client = app.test_client()
+    res = client.post(
+        "/api/push/dispatch",
+        data="{}",
+        content_type="application/json",
+        environ_overrides={"REMOTE_ADDR": "127.0.0.1"},
+    )
+    body_raw = res.data.decode("utf-8")
+    assert "fcm.googleapis.com/fcm/send/abc" not in body_raw
+    assert "p256dh" not in body_raw
+    assert "auth_secret_base64url_text" not in body_raw
+
+
+# ---------------------------------------------------------------------------
+# Atomic write sentinel
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_write_summary_refuses_non_sentinel_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        apd,
+        "ARTIFACT_LATEST",
+        tmp_path / "logs" / "elsewhere" / "latest.json",
+    )
+    with pytest.raises(ValueError):
+        apd._atomic_write_summary({"x": 1})
+
+
+# ---------------------------------------------------------------------------
+# Source-text + AST scans
+# ---------------------------------------------------------------------------
+
+
+def _module_source() -> str:
+    return Path(apd.__file__).read_text(encoding="utf-8")
+
+
+def _imported_module_names() -> set[str]:
+    tree = ast.parse(_module_source())
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module is not None:
+                names.add(node.module)
+    return names
+
+
+def test_no_subprocess_in_module() -> None:
+    src = _module_source()
+    assert "import subprocess" not in src
+    assert "from subprocess" not in src
+
+
+def test_no_gh_or_git_in_module() -> None:
+    src = _module_source()
+    forbidden = ("subprocess.run", "subprocess.call", " gh ", " git ")
+    for needle in forbidden:
+        assert needle not in src, needle
+
+
+def test_no_web_push_library_import_in_module() -> None:
+    """The dispatch blueprint must never import a real Web Push
+    library directly; the lazy import lives only in
+    `reporting/web_push_real_transport`. We check via AST so the
+    benign `from reporting import web_push_*` imports of our own
+    modules are not flagged."""
+    names = _imported_module_names()
+    for n in names:
+        assert n not in {"pywebpush", "webpush", "web_push"}, n
+        assert not n.startswith("pywebpush."), n
+        assert not n.startswith("webpush."), n
+        assert not n.startswith("web_push."), n
+
+
+def test_no_vapid_private_key_literal_in_module() -> None:
+    """The literal env-var name must NOT appear in the blueprint; the
+    transport module is the only allowed reference site."""
+    src = _module_source()
+    assert "WEB_PUSH_VAPID_PRIVATE_KEY" not in src
+
+
+def test_no_decision_verb_in_module() -> None:
+    """The blueprint must contain no decision-verb literals. The
+    dispatch endpoint delivers notifications only; approvals are N4
+    territory and merge/deploy is N5 territory."""
+    src = _module_source().lower()
+    for verb in ("approve(", "reject(", "merge(", "deploy("):
+        assert verb not in src, verb
+
+
+def test_no_seed_jsonl_writes_in_module() -> None:
+    src = _module_source()
+    for forbidden in (
+        "seed.jsonl",
+        "delegation_seed.jsonl",
+        "generated_seed.jsonl",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_no_step5_invariant_writes_in_module() -> None:
+    """The module may declare its own Step 5 invariants (read-only
+    pins) but must not assign to ``step5_implementation_allowed`` more
+    than once nor flip it True; and must not assign
+    ``STEP5_ENABLED_SUBSTAGE`` to anything other than ``\"none\"``."""
+    src = _module_source()
+    assert src.count("step5_implementation_allowed: Final[bool] = False") == 1
+    assert "step5_implementation_allowed = True" not in src
+    assert 'STEP5_ENABLED_SUBSTAGE: Final[str] = "none"' in src
+
+
+def test_no_forbidden_module_imports() -> None:
+    forbidden_prefixes = (
+        "automation",
+        "broker",
+        "agent.risk",
+        "agent.execution",
+        "research",
+        "reporting.intelligent_routing",
+        "live",
+        "paper",
+        "shadow",
+        "trading",
+    )
+    for module in _imported_module_names():
+        for prefix in forbidden_prefixes:
+            assert module != prefix, module
+            assert not module.startswith(prefix + "."), module
+
+
+def test_imports_only_pss_wpda_wprt_aas_and_stdlib() -> None:
+    """The blueprint must import only the existing subscription store,
+    the existing N2b-3a adapter, the new transport module, and the
+    secret-redactor guard. No other reporting module is allowed."""
+    names = _imported_module_names()
+    allowed_reporting = {
+        "reporting",  # bare package name from `from reporting import ...`
+        "reporting.push_subscription_store",
+        "reporting.web_push_dispatch_adapter",
+        "reporting.web_push_real_transport",
+        "reporting.agent_audit_summary",
+    }
+    for n in names:
+        if n == "reporting" or n.startswith("reporting."):
+            assert n in allowed_reporting, n
+
+
+# ---------------------------------------------------------------------------
+# Step 5 invariants
+# ---------------------------------------------------------------------------
+
+
+def test_import_does_not_flip_step5_invariants() -> None:
+    importlib.reload(apd)
+    assert apd.step5_implementation_allowed is False
+    assert apd.STEP5_ENABLED_SUBSTAGE == "none"
+
+
+# ---------------------------------------------------------------------------
+# Gitignored config invariants (defense in depth)
+# ---------------------------------------------------------------------------
+
+
+def test_vapid_subscriptions_path_gitignored() -> None:
+    gitignore = (REPO_ROOT / ".gitignore").read_text(encoding="utf-8")
+    assert "config/web_push_subscriptions.json" in gitignore
+    assert "config/web_push_vapid_public.txt" in gitignore
+
+
+def test_vapid_public_text_path_not_tracked_in_git() -> None:
+    """If the file currently exists on disk it must not be in git."""
+    pub = REPO_ROOT / "config" / "web_push_vapid_public.txt"
+    if not pub.is_file():
+        return
+    # Best-effort: read .gitignore as authoritative; we already pin
+    # the path's presence in the ignore file above. This guard is
+    # defensive: don't allow the file to be created with content
+    # matching a private-key marker.
+    text = pub.read_text(encoding="utf-8")
+    forbidden = ("BEGIN PRIVATE KEY", "BEGIN RSA PRIVATE KEY")
+    for needle in forbidden:
+        assert needle not in text, needle

--- a/tests/unit/test_dashboard_dashboard_one_line_wiring.py
+++ b/tests/unit/test_dashboard_dashboard_one_line_wiring.py
@@ -103,13 +103,23 @@ def test_existing_dashboard_registrations_unchanged() -> None:
         last_pos = pos
 
 
-def test_no_dashboard_api_push_dispatch_module() -> None:
-    """N2b-3 territory: the real-delivery endpoint module must not
-    exist yet. N2b-2b adds the subscription surface only."""
-    bad = REPO_ROOT / "dashboard" / "api_push_dispatch.py"
-    assert not bad.is_file(), (
-        "dashboard/api_push_dispatch.py is N2b-3 territory and must "
-        "not exist in N2b-2b"
+def test_dashboard_api_push_dispatch_module_present_but_unwired() -> None:
+    """N2b-3b: the real-delivery endpoint module exists at
+    ``dashboard/api_push_dispatch.py`` but must remain unwired in
+    ``dashboard/dashboard.py`` until the operator adds the two-line
+    wiring diff (gated by env + nginx + pywebpush).
+
+    This guard runs in BOTH modes (wiring present or absent):
+    * the module file must exist (N2b-3b shipped);
+    * the dispatch wiring may or may not yet be in dashboard.py — the
+      skip-or-enforce conditional pins below enforce the exact shape
+      once the operator adds the two lines.
+    """
+    module_path = REPO_ROOT / "dashboard" / "api_push_dispatch.py"
+    assert module_path.is_file(), (
+        "dashboard/api_push_dispatch.py is N2b-3b territory and must "
+        "exist (the blueprint module is shipped; wiring is operator-"
+        "only)."
     )
 
 
@@ -219,6 +229,63 @@ def test_wiring_no_other_dashboard_dashboard_modifications() -> None:
     assert len(push_lines) == 2, (
         f"dashboard.py must contain exactly 2 push-subscribe lines; "
         f"found {len(push_lines)}: {push_lines}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# N2b-3b dispatch-wiring conditional pins (skip-or-enforce)
+# ---------------------------------------------------------------------------
+#
+# Same dual-mode pattern as the N2b-2b subscribe wiring above. Until
+# the operator adds the two-line ``register_push_dispatch_routes(app)``
+# diff, these pins return early. Once added, they enforce the exact
+# wiring shape.
+
+EXPECTED_DISPATCH_IMPORT_LINE = (
+    "from dashboard.api_push_dispatch import register_push_dispatch_routes"
+)
+EXPECTED_DISPATCH_REGISTER_CALL = "register_push_dispatch_routes(app)"
+
+
+def _dispatch_wiring_present() -> bool:
+    text = _dashboard_text()
+    return (
+        EXPECTED_DISPATCH_IMPORT_LINE in text
+        and EXPECTED_DISPATCH_REGISTER_CALL in text
+    )
+
+
+def test_dispatch_wiring_exactly_one_import_and_one_register_call() -> None:
+    if not _dispatch_wiring_present():
+        # Operator has not yet added the two-line diff. Conditional
+        # pin returns early; the test still passes. Once the operator
+        # commits the wiring, this branch is no longer taken and the
+        # assertions below fire.
+        return
+    text = _dashboard_text()
+    assert text.count(EXPECTED_DISPATCH_IMPORT_LINE) == 1, (
+        "dashboard.py must contain exactly one new dispatch import line"
+    )
+    assert text.count(EXPECTED_DISPATCH_REGISTER_CALL) == 1, (
+        "dashboard.py must contain exactly one new dispatch register call"
+    )
+
+
+def test_dispatch_wiring_no_other_dashboard_dashboard_modifications() -> None:
+    """When the dispatch wiring lands, the diff must include ONLY two
+    new lines (one import + one register call)."""
+    if not _dispatch_wiring_present():
+        return
+    text = _dashboard_text()
+    push_dispatch_lines = [
+        line
+        for line in text.splitlines()
+        if "register_push_dispatch" in line
+        or "api_push_dispatch" in line
+    ]
+    assert len(push_dispatch_lines) == 2, (
+        f"dashboard.py must contain exactly 2 push-dispatch lines; "
+        f"found {len(push_dispatch_lines)}: {push_dispatch_lines}"
     )
 
 

--- a/tests/unit/test_web_push_real_transport.py
+++ b/tests/unit/test_web_push_real_transport.py
@@ -34,6 +34,7 @@ from typing import Any
 
 import pytest
 
+from reporting import web_push_dispatch_adapter as wpda
 from reporting import web_push_real_transport as wprt
 
 
@@ -51,11 +52,11 @@ def _valid_envelope() -> dict[str, Any]:
         "url": "https://fcm.googleapis.com/fcm/send/abc",
         "method": "POST",
         "headers": {
-            "TTL": "60",
-            "Content-Encoding": "aes128gcm",
-            "Content-Type": "application/octet-stream",
-            "Authorization-Mode": "vapid_jwt_pending_n2b3b",
-            "Crypto-Key-Mode": "ecdh_p256_pending_n2b3b",
+            "TTL": str(wpda.DEFAULT_TTL_SECONDS),
+            "Content-Encoding": wpda.CONTENT_ENCODING,
+            "Content-Type": wpda.CONTENT_TYPE,
+            "Authorization-Mode": wpda.AUTHORIZATION_MODE_PLACEHOLDER,
+            "Crypto-Key-Mode": wpda.CRYPTO_KEY_MODE_PLACEHOLDER,
         },
         "body_meta": {
             "event_id": "abc12345abc12345",

--- a/tests/unit/test_web_push_real_transport.py
+++ b/tests/unit/test_web_push_real_transport.py
@@ -1,0 +1,550 @@
+"""Unit tests for N2b-3b — Real Web Push transport (env-gated, lazy import).
+
+These tests pin:
+
+* the closed env-var names and the closed result envelope shape;
+* :func:`is_configured` is env-only and never echoes values;
+* :func:`make_transport` refuses (returns ``invalid_envelope``) even
+  on a structurally valid envelope because the adapter envelope does
+  not carry subscription keys — the bare transport is for env/library
+  gate tests only;
+* :func:`make_transport_for_subscription` returns a closure that
+  classifies every failure mode into the closed
+  ``error_class`` vocabulary;
+* the closure refuses without env, without subscription keys, with a
+  mismatched envelope url vs subscription endpoint, and when
+  ``pywebpush`` is unimportable;
+* the closure invokes ``pywebpush.webpush`` exactly once on the happy
+  path, with no endpoint URL or VAPID private key in the surfaced
+  result;
+* the module never imports ``pywebpush`` at module load;
+* source-text + AST scans for forbidden imports and forbidden
+  literals;
+* Step 5 invariants are not flipped by import.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reporting import web_push_real_transport as wprt
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = Path(wprt.__file__).resolve()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _valid_envelope() -> dict[str, Any]:
+    return {
+        "url": "https://fcm.googleapis.com/fcm/send/abc",
+        "method": "POST",
+        "headers": {
+            "TTL": "60",
+            "Content-Encoding": "aes128gcm",
+            "Content-Type": "application/octet-stream",
+            "Authorization-Mode": "vapid_jwt_pending_n2b3b",
+            "Crypto-Key-Mode": "ecdh_p256_pending_n2b3b",
+        },
+        "body_meta": {
+            "event_id": "abc12345abc12345",
+            "event_kind": "intake_candidate_eligible",
+            "event_severity": "push_info",
+            "title": "title",
+            "summary": "summary",
+            "open_at": "/agent-control/inbox?event=abc12345abc12345",
+        },
+        "kid": "k1",
+        "endpoint_hash": "deadbeefdeadbeef",
+        "event_id": "abc12345abc12345",
+    }
+
+
+def _valid_subscription() -> dict[str, Any]:
+    return {
+        "endpoint": "https://fcm.googleapis.com/fcm/send/abc",
+        "keys": {"p256dh": "BCfV1eK4_publickeybase64url", "auth": "auth_secret"},
+        "kid": "k1",
+    }
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(wprt.ENV_VAPID_PRIVATE_KEY, raising=False)
+    monkeypatch.delenv(wprt.ENV_VAPID_SUBJECT, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies + Step 5
+# ---------------------------------------------------------------------------
+
+
+def test_env_names_pinned_exactly() -> None:
+    assert wprt.ENV_VAPID_PRIVATE_KEY == "WEB_PUSH_VAPID_PRIVATE_KEY"
+    assert wprt.ENV_VAPID_SUBJECT == "WEB_PUSH_VAPID_SUBJECT"
+
+
+def test_transport_result_keys_pinned() -> None:
+    assert wprt.TRANSPORT_RESULT_KEYS == ("status_code", "error_class")
+
+
+def test_error_classes_pinned_exactly() -> None:
+    assert wprt.ERROR_CLASSES == (
+        "ok",
+        "config_missing",
+        "library_missing",
+        "invalid_envelope",
+        "transport_exception",
+    )
+
+
+def test_step5_invariants_unchanged() -> None:
+    assert wprt.STEP5_ENABLED_SUBSTAGE == "none"
+    assert wprt.step5_implementation_allowed is False
+
+
+# ---------------------------------------------------------------------------
+# is_configured()
+# ---------------------------------------------------------------------------
+
+
+def test_is_configured_false_when_both_unset() -> None:
+    assert wprt.is_configured() is False
+
+
+def test_is_configured_false_when_only_private_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(wprt.ENV_VAPID_PRIVATE_KEY, "x")
+    assert wprt.is_configured() is False
+
+
+def test_is_configured_false_when_only_subject_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(wprt.ENV_VAPID_SUBJECT, "mailto:x@y.z")
+    assert wprt.is_configured() is False
+
+
+def test_is_configured_true_when_both_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(wprt.ENV_VAPID_PRIVATE_KEY, "x")
+    monkeypatch.setenv(wprt.ENV_VAPID_SUBJECT, "mailto:x@y.z")
+    assert wprt.is_configured() is True
+
+
+def test_is_configured_false_for_empty_string(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(wprt.ENV_VAPID_PRIVATE_KEY, "")
+    monkeypatch.setenv(wprt.ENV_VAPID_SUBJECT, "")
+    assert wprt.is_configured() is False
+
+
+def test_is_configured_returns_boolean_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(wprt.ENV_VAPID_PRIVATE_KEY, "super-secret-value")
+    monkeypatch.setenv(wprt.ENV_VAPID_SUBJECT, "mailto:x@y.z")
+    result = wprt.is_configured()
+    assert isinstance(result, bool)
+    # Should never include the secret in any representation.
+    assert "super-secret-value" not in repr(result)
+
+
+# ---------------------------------------------------------------------------
+# make_transport() bare callable — env / library / envelope gates
+# ---------------------------------------------------------------------------
+
+
+def test_make_transport_returns_callable() -> None:
+    t = wprt.make_transport()
+    assert callable(t)
+
+
+def test_make_transport_config_missing_when_no_env() -> None:
+    t = wprt.make_transport()
+    out = t(_valid_envelope())
+    assert out == {"status_code": None, "error_class": "config_missing"}
+
+
+def test_make_transport_invalid_envelope_when_env_set_but_no_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(wprt.ENV_VAPID_PRIVATE_KEY, "x")
+    monkeypatch.setenv(wprt.ENV_VAPID_SUBJECT, "mailto:x@y.z")
+    # The bare transport always returns invalid_envelope on a valid
+    # envelope because the adapter envelope does not carry keys.
+    t = wprt.make_transport()
+    out = t(_valid_envelope())
+    assert out["status_code"] is None
+    assert out["error_class"] == "invalid_envelope"
+
+
+def test_make_transport_rejects_unknown_origin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(wprt.ENV_VAPID_PRIVATE_KEY, "x")
+    monkeypatch.setenv(wprt.ENV_VAPID_SUBJECT, "mailto:x@y.z")
+    env = _valid_envelope()
+    env["url"] = "https://evil.example.com/send/abc"
+    t = wprt.make_transport()
+    out = t(env)
+    assert out == {"status_code": None, "error_class": "invalid_envelope"}
+
+
+def test_make_transport_rejects_extra_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(wprt.ENV_VAPID_PRIVATE_KEY, "x")
+    monkeypatch.setenv(wprt.ENV_VAPID_SUBJECT, "mailto:x@y.z")
+    env = _valid_envelope()
+    env["unexpected"] = "value"
+    t = wprt.make_transport()
+    out = t(env)
+    assert out["error_class"] == "invalid_envelope"
+
+
+def test_make_transport_returns_closed_shape_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    t = wprt.make_transport()
+    out = t(_valid_envelope())
+    assert set(out.keys()) == set(wprt.TRANSPORT_RESULT_KEYS)
+
+
+# ---------------------------------------------------------------------------
+# make_transport_for_subscription() — full closure behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_subscription_transport_config_missing_when_no_env() -> None:
+    closure = wprt.make_transport_for_subscription(
+        subscription=_valid_subscription()
+    )
+    out = closure(_valid_envelope())
+    assert out == {"status_code": None, "error_class": "config_missing"}
+
+
+def test_subscription_transport_mismatched_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(wprt.ENV_VAPID_PRIVATE_KEY, "x")
+    monkeypatch.setenv(wprt.ENV_VAPID_SUBJECT, "mailto:x@y.z")
+    sub = _valid_subscription()
+    sub["endpoint"] = "https://fcm.googleapis.com/fcm/send/different"
+    closure = wprt.make_transport_for_subscription(subscription=sub)
+    out = closure(_valid_envelope())
+    assert out == {"status_code": None, "error_class": "invalid_envelope"}
+
+
+def test_subscription_transport_missing_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(wprt.ENV_VAPID_PRIVATE_KEY, "x")
+    monkeypatch.setenv(wprt.ENV_VAPID_SUBJECT, "mailto:x@y.z")
+    sub = _valid_subscription()
+    sub["keys"] = {}
+    closure = wprt.make_transport_for_subscription(subscription=sub)
+    out = closure(_valid_envelope())
+    assert out == {"status_code": None, "error_class": "invalid_envelope"}
+
+
+def test_subscription_transport_library_missing_when_pywebpush_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If `pywebpush` is not importable, the closure must classify
+    as `library_missing` and return None status_code."""
+    monkeypatch.setenv(wprt.ENV_VAPID_PRIVATE_KEY, "x")
+    monkeypatch.setenv(wprt.ENV_VAPID_SUBJECT, "mailto:x@y.z")
+
+    # Simulate the import failing by intercepting sys.modules.
+    sentinel = object()
+    monkeypatch.setitem(sys.modules, "pywebpush", None)  # type: ignore[arg-type]
+    try:
+        closure = wprt.make_transport_for_subscription(
+            subscription=_valid_subscription()
+        )
+        out = closure(_valid_envelope())
+        assert out["status_code"] is None
+        assert out["error_class"] == "library_missing"
+    finally:
+        # Best-effort restore; pytest monkeypatch reverts at teardown.
+        pass
+
+
+def test_subscription_transport_happy_path_calls_pywebpush(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """On a fully valid input + env + (mocked) pywebpush, the closure
+    returns ``ok`` with the mocked status_code."""
+    monkeypatch.setenv(wprt.ENV_VAPID_PRIVATE_KEY, "private-key-value")
+    monkeypatch.setenv(wprt.ENV_VAPID_SUBJECT, "mailto:x@y.z")
+
+    calls: list[dict[str, Any]] = []
+
+    class FakeResponse:
+        status_code = 201
+
+    class FakeWebPushException(Exception):
+        pass
+
+    def fake_webpush(**kwargs: Any) -> FakeResponse:
+        calls.append(kwargs)
+        return FakeResponse()
+
+    fake_module = type(sys)("pywebpush")
+    fake_module.webpush = fake_webpush  # type: ignore[attr-defined]
+    fake_module.WebPushException = FakeWebPushException  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "pywebpush", fake_module)
+
+    closure = wprt.make_transport_for_subscription(
+        subscription=_valid_subscription()
+    )
+    out = closure(_valid_envelope())
+
+    assert out == {"status_code": 201, "error_class": "ok"}
+    assert len(calls) == 1
+    kw = calls[0]
+    assert kw["subscription_info"]["endpoint"] == (
+        "https://fcm.googleapis.com/fcm/send/abc"
+    )
+    assert kw["vapid_claims"] == {"sub": "mailto:x@y.z"}
+    assert kw["ttl"] == 60
+    # Defense-in-depth: result must not embed the private key or
+    # the endpoint URL.
+    repr_out = repr(out)
+    assert "private-key-value" not in repr_out
+    assert "/fcm/send/abc" not in repr_out
+
+
+def test_subscription_transport_410_classifies_via_pywebpush_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(wprt.ENV_VAPID_PRIVATE_KEY, "x")
+    monkeypatch.setenv(wprt.ENV_VAPID_SUBJECT, "mailto:x@y.z")
+
+    class FakeInner:
+        status_code = 410
+
+    class FakeWebPushException(Exception):
+        def __init__(self) -> None:
+            super().__init__("gone")
+            self.response = FakeInner()
+
+    def fake_webpush(**kwargs: Any) -> Any:
+        raise FakeWebPushException()
+
+    fake_module = type(sys)("pywebpush")
+    fake_module.webpush = fake_webpush  # type: ignore[attr-defined]
+    fake_module.WebPushException = FakeWebPushException  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "pywebpush", fake_module)
+
+    closure = wprt.make_transport_for_subscription(
+        subscription=_valid_subscription()
+    )
+    out = closure(_valid_envelope())
+    assert out == {"status_code": 410, "error_class": "ok"}
+
+
+def test_subscription_transport_unknown_exception_classified_as_transport_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(wprt.ENV_VAPID_PRIVATE_KEY, "x")
+    monkeypatch.setenv(wprt.ENV_VAPID_SUBJECT, "mailto:x@y.z")
+
+    def fake_webpush(**kwargs: Any) -> Any:
+        raise RuntimeError("boom")
+
+    class FakeWebPushException(Exception):
+        pass
+
+    fake_module = type(sys)("pywebpush")
+    fake_module.webpush = fake_webpush  # type: ignore[attr-defined]
+    fake_module.WebPushException = FakeWebPushException  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "pywebpush", fake_module)
+
+    closure = wprt.make_transport_for_subscription(
+        subscription=_valid_subscription()
+    )
+    out = closure(_valid_envelope())
+    assert out == {"status_code": None, "error_class": "transport_exception"}
+
+
+def test_subscription_transport_never_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(wprt.ENV_VAPID_PRIVATE_KEY, "x")
+    monkeypatch.setenv(wprt.ENV_VAPID_SUBJECT, "mailto:x@y.z")
+    closure = wprt.make_transport_for_subscription(
+        subscription="not-a-dict",  # type: ignore[arg-type]
+    )
+    out = closure(_valid_envelope())
+    assert out["status_code"] is None
+    assert out["error_class"] == "invalid_envelope"
+
+
+# ---------------------------------------------------------------------------
+# Source-text + AST scans
+# ---------------------------------------------------------------------------
+
+
+def _module_source() -> str:
+    return MODULE_PATH.read_text(encoding="utf-8")
+
+
+def _imported_module_names() -> set[str]:
+    tree = ast.parse(_module_source())
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module is not None:
+                names.add(node.module)
+    return names
+
+
+def test_no_subprocess_in_module() -> None:
+    src = _module_source()
+    assert "import subprocess" not in src
+    assert "from subprocess" not in src
+
+
+def test_no_gh_or_git_in_module() -> None:
+    src = _module_source()
+    forbidden = (" gh ", " git ", "subprocess.call", "subprocess.run")
+    for needle in forbidden:
+        assert needle not in src, needle
+
+
+def test_pywebpush_imported_only_lazily() -> None:
+    """The module must not contain a top-level `import pywebpush` or
+    `from pywebpush import ...`. The lazy import lives inside
+    function bodies."""
+    tree = ast.parse(_module_source())
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name != "pywebpush", (
+                    "pywebpush must be lazy-imported, not top-level"
+                )
+        if isinstance(node, ast.ImportFrom):
+            assert node.module != "pywebpush", (
+                "pywebpush must be lazy-imported, not top-level"
+            )
+
+
+def test_no_dashboard_or_frontend_imports() -> None:
+    forbidden_prefixes = (
+        "dashboard",
+        "frontend",
+        "automation",
+        "broker",
+        "agent.risk",
+        "agent.execution",
+        "research",
+        "reporting.intelligent_routing",
+        "live",
+        "paper",
+        "shadow",
+        "trading",
+    )
+    for module in _imported_module_names():
+        for prefix in forbidden_prefixes:
+            assert module != prefix, module
+            assert not module.startswith(prefix + "."), module
+
+
+def test_no_decision_verb_call_in_module() -> None:
+    """The transport must not invoke any approve/reject/merge/deploy
+    callable. The transport is delivery-only. We look for the
+    function-call pattern (``verb(``) so the docstring's prose
+    describing what the transport *does not* do is allowed to mention
+    the verbs."""
+    src = _module_source().lower()
+    for verb in ("approve(", "reject(", "merge(", "deploy("):
+        assert verb not in src, verb
+
+
+def test_env_var_name_is_the_only_one_referenced() -> None:
+    """This module is the ONLY place the literal env-var name appears.
+    Other modules pin its absence. We also check that no other secret
+    env name leaks in."""
+    src = _module_source()
+    assert "WEB_PUSH_VAPID_PRIVATE_KEY" in src
+    forbidden = (
+        "ADE_APPROVAL_TOKEN_HMAC_SECRET",
+        "ANTHROPIC_API_KEY",
+        "BITVAVO_SECRET",
+        "POLYMARKET_PRIVATE_KEY",
+    )
+    for needle in forbidden:
+        assert needle not in src, needle
+
+
+# ---------------------------------------------------------------------------
+# Step 5 invariants — import-time
+# ---------------------------------------------------------------------------
+
+
+def test_import_does_not_flip_step5_invariants() -> None:
+    """A fresh import must not flip any Step 5 invariant."""
+    importlib.reload(wprt)
+    assert wprt.step5_implementation_allowed is False
+    assert wprt.STEP5_ENABLED_SUBSTAGE == "none"
+
+
+# ---------------------------------------------------------------------------
+# Doc invariants
+# ---------------------------------------------------------------------------
+
+
+def _doc_text() -> str:
+    return (
+        REPO_ROOT
+        / "docs"
+        / "governance"
+        / "notification_dispatch_real.md"
+    ).read_text(encoding="utf-8")
+
+
+def test_doc_states_level_6_permanently_disabled() -> None:
+    text = _doc_text().lower()
+    assert "level 6" in text
+    assert "permanently disabled" in text
+
+
+def test_doc_states_no_approval_from_click_alone() -> None:
+    import re
+
+    text = re.sub(r"\s+", " ", _doc_text().lower())
+    assert (
+        "no approval can happen from notification click alone" in text
+        or "no approval from notification click alone" in text
+        or "no approval can happen from a notification click alone" in text
+    )
+
+
+def test_doc_lists_n3_n4_n5_as_future() -> None:
+    text = _doc_text().lower()
+    for marker in ("n3", "n4", "n5"):
+        assert marker in text, marker
+    assert (
+        "unimplemented" in text
+        or "out of scope" in text
+        or "future" in text
+    )


### PR DESCRIPTION
## Summary

Adds the smallest safe operator-gated slice that turns the existing
N2a → N2b-1 → N2b-3a stack into actual Web Push delivery, but only
when **all four** operator-controlled signals are in place:

1. VAPID env vars (`WEB_PUSH_VAPID_PRIVATE_KEY`, `WEB_PUSH_VAPID_SUBJECT`)
2. `pywebpush` installed on the VPS (optional runtime dep, lazy-imported)
3. nginx `127.0.0.1` lock on `/api/push/dispatch` (operator infra)
4. The two-line `register_push_dispatch_routes(app)` wiring in
   `dashboard/dashboard.py` (operator-only — the no-touch hook
   blocks the agent from editing that file)

Until all four hold, N2b-3b is a no-op at runtime. Real push, when
enabled, is **notification delivery only** — never approval, never
merge, never deploy.

### New files
- `reporting/web_push_real_transport.py` — env-gated transport with
  lazy `pywebpush` import. Closed `{status_code, error_class}` result
  envelope. `is_configured()` predicate (boolean only, no value
  echo). `make_transport()` for env/library gate tests;
  `make_transport_for_subscription(*, subscription)` for the dashboard
  API layer (captures per-subscription `keys.p256dh` / `keys.auth`).
- `dashboard/api_push_dispatch.py` — single route `POST /api/push/dispatch`.
  Hard gates (in order): loopback 403, body 413, is_configured 503.
  Reads N2b-1 outbox, dispatches each (record × subscription) via
  the real transport closure, auto-unregisters on 410, writes a
  redacted summary to `logs/notification_dispatch_real/latest.json`.
  **NOT wired into `dashboard/dashboard.py`** (operator-only edit).
- `tests/unit/test_web_push_real_transport.py` — closed vocab,
  env gate, lazy-import gate, envelope validation, mocked pywebpush
  (happy + 410 + unknown exception), source-text + AST scans, Step 5
  invariants, doc invariants.
- `tests/unit/test_api_push_dispatch.py` — POST-only route table,
  loopback gate, env gate, body-size gate, mocked-transport happy
  path, 410 → unregister, no endpoint/key leak in response, atomic
  write sentinel, full AST + source-text guard scans, dashboard.py
  wiring dual-mode (skip-or-enforce).

### Modified files
- `docs/governance/notification_dispatch_real.md` — promoted from
  N2b-3a-only / N2b-3b-deferred to N2b-3a + N2b-3b shipped-but-unwired.
  Operator setup checklist, authority-chain table, Step 5 invariants,
  Level 6 disabled qualifier preserved.
- `tests/unit/test_dashboard_dashboard_one_line_wiring.py` — replaces
  the must-not-exist guard with a present-but-unwired guard, plus a
  new skip-or-enforce dispatch-wiring pin pair (mirrors N2b-2b
  pattern).

### Hard invariants preserved
- `step5_implementation_allowed = False`, `STEP5_ENABLED_SUBSTAGE = "none"`
- Level 6 permanently disabled qualifier remains in every doc
- No approval-from-notification-click path
- Real push payload remains the bounded six-key payload (no decision
  verb, no evidence body, no PR head SHA)
- `dashboard/dashboard.py` untouched (no-touch hook honoured)
- `.claude/**` untouched
- QRE / research / live / paper / shadow / risk / broker / execution
  untouched
- `seed.jsonl` / `delegation_seed.jsonl` untouched

## Test plan
- [x] `python scripts/governance_lint.py` → OK (16 agents, 5 workflows)
- [x] `python -m pytest tests/smoke -q` → 18 passed
- [x] Targeted push-stack tests → 190 passed
- [x] `python -m pytest tests/unit -q` → 4849 passed, 3 skipped, 0 failed
- [x] `npm --prefix frontend run test` → 137 passed
- [x] `npm --prefix frontend run build` → clean

## Operator setup (after merge, before real push fires)
1. Generate VAPID keypair; write public key text to
   `config/web_push_vapid_public.txt` (gitignored).
2. Set `WEB_PUSH_VAPID_PRIVATE_KEY` and `WEB_PUSH_VAPID_SUBJECT` in
   the systemd unit override / outside-repo `.env`.
3. `pip install pywebpush` on the VPS.
4. nginx: restrict `/api/push/dispatch` to `127.0.0.1` + `::1`.
5. Apply the two-line wiring diff to `dashboard/dashboard.py`.
6. Verify: `curl -sX POST http://127.0.0.1:8050/api/push/dispatch`
   returns 200 with a JSON summary; non-loopback returns 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)