### PR TITLE
chore(deps): pin pywebpush>=1.14.0 for N2b-3b runtime image

### DIFF
--- a/docs/governance/notification_dispatch_real.md
+++ b/docs/governance/notification_dispatch_real.md
@@ -282,10 +282,20 @@ must complete these one-shot setup steps on the VPS:
    WEB_PUSH_VAPID_SUBJECT=mailto:joeryvanrooij@gmail.com
    ```
 
-3. **Install the optional runtime dependency** on the VPS:
+3. **Confirm the runtime dependency is present.** `pywebpush>=1.14.0`
+   is now pinned in [`requirements.txt`](../../requirements.txt) and
+   ships in the Dockerfile-built image. After the next image rebuild
+   on the VPS, no operator action is required for this step:
 
    ```bash
-   pip install pywebpush
+   # No-op verification (post next rebuild):
+   docker compose exec dashboard python -m pip show pywebpush | head -1
+   ```
+
+   For ad-hoc non-Docker setups only:
+
+   ```bash
+   pip install 'pywebpush>=1.14.0'
    ```
 
 4. **Restrict the dispatch route to 127.0.0.1** in the nginx config

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ pytest>=7.4.0
 pytest-asyncio>=0.23.0
 flask-httpauth
 passlib[bcrypt]
+pywebpush>=1.14.0

--- a/tests/unit/test_requirements_pywebpush.py
+++ b/tests/unit/test_requirements_pywebpush.py
@@ -1,0 +1,78 @@
+"""Pin test for the N2b-3b runtime dependency on ``pywebpush``.
+
+Pins:
+
+* ``requirements.txt`` contains exactly one ``pywebpush`` declaration;
+* the declaration is exactly ``pywebpush>=1.14.0`` (the version
+  bound matched by :mod:`reporting.web_push_real_transport`'s lazy
+  import contract);
+* no VAPID-private-key env name or PEM marker appears on the
+  ``pywebpush`` line (defense-in-depth — ``requirements.txt`` is
+  not the place to ever stash secrets);
+* the line is well-formed (no leading whitespace, no trailing
+  comment, single token).
+
+This is a declarative pin: it does NOT import ``pywebpush`` and
+therefore passes in dev environments where the optional runtime
+dependency has not been pip-installed locally. The Dockerfile is
+the install boundary (``pip install -r requirements.txt``).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REQUIREMENTS_PATH = REPO_ROOT / "requirements.txt"
+
+_EXPECTED_LINE = "pywebpush>=1.14.0"
+
+# Defense-in-depth — patterns that must never appear on the
+# pywebpush declaration line in requirements.txt.
+_FORBIDDEN_ON_DEP_LINE = (
+    "WEB_PUSH_VAPID_PRIVATE_KEY",
+    "BEGIN PRIVATE KEY",
+    "BEGIN RSA PRIVATE KEY",
+)
+
+
+def _requirements_lines() -> list[str]:
+    return REQUIREMENTS_PATH.read_text(encoding="utf-8").splitlines()
+
+
+def _pywebpush_lines() -> list[str]:
+    return [
+        ln for ln in _requirements_lines()
+        if re.match(r"^\s*pywebpush\b", ln, re.IGNORECASE)
+    ]
+
+
+def test_requirements_file_exists() -> None:
+    assert REQUIREMENTS_PATH.is_file()
+
+
+def test_exactly_one_pywebpush_line() -> None:
+    matches = _pywebpush_lines()
+    assert len(matches) == 1, (
+        f"requirements.txt must contain exactly one pywebpush line; "
+        f"found {len(matches)}: {matches}"
+    )
+
+
+def test_pywebpush_line_is_pinned_exactly() -> None:
+    matches = _pywebpush_lines()
+    assert matches == [_EXPECTED_LINE], (
+        f"requirements.txt pywebpush pin must be {_EXPECTED_LINE!r}; "
+        f"got {matches!r}"
+    )
+
+
+def test_pywebpush_line_carries_no_secret_marker() -> None:
+    matches = _pywebpush_lines()
+    assert matches, "pywebpush line missing"
+    line = matches[0]
+    for needle in _FORBIDDEN_ON_DEP_LINE:
+        assert needle not in line, (
+            f"requirements.txt pywebpush line must not contain {needle!r}"
+        )


### PR DESCRIPTION
## Summary

Adds the optional runtime dependency `pywebpush>=1.14.0` to the Docker image, so the merged N2b-3b real Web Push transport at [reporting/web_push_real_transport.py](reporting/web_push_real_transport.py) can lazy-import it on the VPS dashboard container.

Without this pin, the merged dispatch endpoint at [dashboard/api_push_dispatch.py](dashboard/api_push_dispatch.py) would always classify outcomes as `library_missing` → `retry` (graceful degradation, no crash) and real push delivery would never fire — defeating the purpose of N2b-3b.

This PR is **dependency-only**. The two-line operator wiring change to [dashboard/dashboard.py](dashboard/dashboard.py) is a separate PR. `dashboard/dashboard.py` is **not** touched here.

## Diff scope (intentionally minimal)
- `requirements.txt` — append exactly one new line `pywebpush>=1.14.0` after the existing `passlib[bcrypt]` entry. No other line is reordered or modified. (Operator appended; the agent only ships the pin test + doc note + commit.)
- `tests/unit/test_requirements_pywebpush.py` — new declarative pin test (stdlib-only, does not actually `import pywebpush` so it passes in dev environments without the optional dep). Asserts exactly one `pywebpush` line, the literal `pywebpush>=1.14.0` bound, and that the line carries no VAPID-private-key env name or PEM marker (defense-in-depth — `requirements.txt` is not the place for secrets).
- `docs/governance/notification_dispatch_real.md` — replace the operator `pip install pywebpush` step with a no-op verification note pointing at the Dockerfile install boundary; keep the ad-hoc non-Docker fallback for completeness.

## Hard invariants preserved
- `step5_implementation_allowed = False` (unchanged)
- `STEP5_ENABLED_SUBSTAGE = "none"` (unchanged)
- Level 6 permanently disabled (qualifier preserved in doc — 3 occurrences)
- `dashboard/dashboard.py` untouched (still unwired for N2b-3b)
- `dashboard/api_push_dispatch.py` untouched
- `reporting/web_push_real_transport.py` untouched
- `.gitleaks.toml` untouched
- `.claude/**` untouched
- No QRE / research / live / paper / shadow / risk / broker / execution changes
- No approval / merge / deploy code added

## Test plan (all green locally)
- [x] `python -m pytest tests/unit/test_requirements_pywebpush.py -q` → 4 passed
- [x] `python scripts/governance_lint.py` → OK (16 agents, 5 workflows)
- [x] `python -m pytest tests/smoke -q` → 18 passed
- [x] `python -m pytest tests/unit/test_web_push_real_transport.py tests/unit/test_api_push_dispatch.py -q` → 61 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)