### PR TITLE
feat(notif): N2b-3b — operator-authored wiring for real Web Push dispatch

### DIFF
--- a/dashboard/dashboard.py
+++ b/dashboard/dashboard.py
@@ -40,6 +40,7 @@ from dashboard.api_agent_control import register_agent_control_routes
 from dashboard.api_proposal_queue import register_proposal_queue_routes
 from dashboard.api_approval_inbox import register_approval_inbox_routes
 from dashboard.api_push_subscribe import register_push_subscribe_routes
+from dashboard.api_push_dispatch import register_push_dispatch_routes
 from dashboard.api_roadmap_priority import register_roadmap_priority_routes
 
 from reporting import audit_log
@@ -91,6 +92,7 @@ register_proposal_queue_routes(app)
 register_approval_inbox_routes(app)
 register_roadmap_priority_routes(app)
 register_push_subscribe_routes(app)
+register_push_dispatch_routes(app)
 
 
 @app.errorhandler(Exception)

--- a/docs/governance/notification_dispatch_real.md
+++ b/docs/governance/notification_dispatch_real.md
@@ -2,22 +2,27 @@
 
 > **Status:** N2b-3a (mocked-transport adapter) implemented.
 > N2b-3b (real Web Push HTTP transport + internal-only operator
-> dispatch endpoint) implemented, **unwired in `dashboard/dashboard.py`**
-> and gated by:
+> dispatch endpoint) implemented and **wired into
+> `dashboard/dashboard.py`** via the two-line operator-authored diff
+> (the agent's no-touch hook continues to block subsequent edits).
+> Runtime delivery still requires:
 >
 > 1. The operator setting the env-only VAPID private key on the VPS
->    (`WEB_PUSH_VAPID_PRIVATE_KEY` + `WEB_PUSH_VAPID_SUBJECT`).
-> 2. The optional `pywebpush` runtime dependency being installed on
->    the VPS.
-> 3. The operator-only two-line wiring diff in
->    `dashboard/dashboard.py` (the no-touch hook blocks the agent
->    from editing that file).
-> 4. nginx restricting `/api/push/dispatch` to `127.0.0.1` at the
->    edge (operator infra change).
+>    (`WEB_PUSH_VAPID_PRIVATE_KEY` + `WEB_PUSH_VAPID_SUBJECT`). The
+>    wired endpoint refuses with HTTP 503 `configuration_missing`
+>    when either is absent.
+> 2. `pywebpush>=1.14.0` in the Docker image — pinned in
+>    [`requirements.txt`](../../requirements.txt); installed by the
+>    image-build pipeline. Pin test: [`tests/unit/test_requirements_pywebpush.py`](../../tests/unit/test_requirements_pywebpush.py).
+> 3. nginx restricting `/api/push/dispatch` to `127.0.0.1` at the
+>    edge (operator infra change). The Python loopback gate in the
+>    blueprint also refuses non-loopback `request.remote_addr` with
+>    HTTP 403 `remote_not_loopback`.
 >
-> Until all four conditions hold, N2b-3b is a no-op at runtime.
-> Real Web Push delivery, when enabled, is **notification delivery
-> only** — never approval, never merge, never deploy.
+> Until all three runtime conditions hold, the wired endpoint is a
+> no-op (returns 503 or 403). Real Web Push delivery, when enabled,
+> is **notification delivery only** — never approval, never merge,
+> never deploy.
 >
 > **Modules:**
 > - [`reporting/web_push_dispatch_adapter.py`](../../reporting/web_push_dispatch_adapter.py) — N2b-3a envelope + outcome classifier (mocked transport)
@@ -310,9 +315,12 @@ must complete these one-shot setup steps on the VPS:
    }
    ```
 
-5. **Authorise the two-line wiring diff** in
-   `dashboard/dashboard.py` (operator commits; the agent prepares
-   the PR):
+5. **Two-line wiring diff in `dashboard/dashboard.py`** — **shipped**
+   in the operator-authored wiring PR (the agent's no-touch hook
+   blocks subsequent edits; the strict pin tests in
+   [`tests/unit/test_dashboard_dashboard_one_line_wiring.py`](../../tests/unit/test_dashboard_dashboard_one_line_wiring.py)
+   refuse any future edit that drops, duplicates, or reorders these
+   two lines):
 
    ```diff
    +from dashboard.api_push_dispatch import register_push_dispatch_routes

--- a/tests/unit/test_dashboard_dashboard_one_line_wiring.py
+++ b/tests/unit/test_dashboard_dashboard_one_line_wiring.py
@@ -44,7 +44,9 @@ EXPECTED_IMPORT_LINE = (
 EXPECTED_REGISTER_CALL = "register_push_subscribe_routes(app)"
 
 # These lines MUST remain in dashboard.py post-edit. Removing or
-# reordering any of them is forbidden.
+# reordering any of them is forbidden. The N2b-2b push-subscribe
+# wiring is now part of this required-list so a future edit cannot
+# accidentally drop or reorder it.
 EXISTING_REGISTRATIONS_REQUIRED: tuple[str, ...] = (
     "from dashboard.api_campaigns import register_campaign_routes",
     "from dashboard.api_research_intelligence import (",
@@ -53,6 +55,7 @@ EXISTING_REGISTRATIONS_REQUIRED: tuple[str, ...] = (
     "from dashboard.api_agent_control import register_agent_control_routes",
     "from dashboard.api_proposal_queue import register_proposal_queue_routes",
     "from dashboard.api_approval_inbox import register_approval_inbox_routes",
+    "from dashboard.api_push_subscribe import register_push_subscribe_routes",
     "from dashboard.api_roadmap_priority import "
     "register_roadmap_priority_routes",
     "register_campaign_routes(app)",
@@ -63,6 +66,7 @@ EXISTING_REGISTRATIONS_REQUIRED: tuple[str, ...] = (
     "register_proposal_queue_routes(app)",
     "register_approval_inbox_routes(app)",
     "register_roadmap_priority_routes(app)",
+    "register_push_subscribe_routes(app)",
 )
 
 
@@ -103,23 +107,17 @@ def test_existing_dashboard_registrations_unchanged() -> None:
         last_pos = pos
 
 
-def test_dashboard_api_push_dispatch_module_present_but_unwired() -> None:
+def test_dashboard_api_push_dispatch_module_present() -> None:
     """N2b-3b: the real-delivery endpoint module exists at
-    ``dashboard/api_push_dispatch.py`` but must remain unwired in
-    ``dashboard/dashboard.py`` until the operator adds the two-line
-    wiring diff (gated by env + nginx + pywebpush).
-
-    This guard runs in BOTH modes (wiring present or absent):
-    * the module file must exist (N2b-3b shipped);
-    * the dispatch wiring may or may not yet be in dashboard.py — the
-      skip-or-enforce conditional pins below enforce the exact shape
-      once the operator adds the two lines.
+    ``dashboard/api_push_dispatch.py``. After this PR the module is
+    wired into ``dashboard/dashboard.py`` via the strict-enforce
+    pins below — runtime delivery still requires the env vars and
+    the nginx ``127.0.0.1`` lock to fire.
     """
     module_path = REPO_ROOT / "dashboard" / "api_push_dispatch.py"
     assert module_path.is_file(), (
         "dashboard/api_push_dispatch.py is N2b-3b territory and must "
-        "exist (the blueprint module is shipped; wiring is operator-"
-        "only)."
+        "exist."
     )
 
 
@@ -233,13 +231,23 @@ def test_wiring_no_other_dashboard_dashboard_modifications() -> None:
 
 
 # ---------------------------------------------------------------------------
-# N2b-3b dispatch-wiring conditional pins (skip-or-enforce)
+# N2b-3b dispatch-wiring strict pins (operator wired this PR)
 # ---------------------------------------------------------------------------
 #
-# Same dual-mode pattern as the N2b-2b subscribe wiring above. Until
-# the operator adds the two-line ``register_push_dispatch_routes(app)``
-# diff, these pins return early. Once added, they enforce the exact
-# wiring shape.
+# These pins were dual-mode (skip-or-enforce) until the operator added
+# the two-line wiring diff in this PR. They are now STRICT: removing
+# either line will fail CI. The wiring shape is exactly:
+#
+#     from dashboard.api_push_dispatch import register_push_dispatch_routes
+#     ...
+#     register_push_dispatch_routes(app)
+#
+# Runtime delivery still requires (a) ``WEB_PUSH_VAPID_PRIVATE_KEY`` and
+# ``WEB_PUSH_VAPID_SUBJECT`` in the VPS env, and (b) the nginx
+# ``127.0.0.1`` lock on ``/api/push/dispatch``. Without either, the
+# wired endpoint still refuses with 503 ``configuration_missing`` or
+# 403 ``remote_not_loopback`` — pinned by the api_push_dispatch unit
+# tests.
 
 EXPECTED_DISPATCH_IMPORT_LINE = (
     "from dashboard.api_push_dispatch import register_push_dispatch_routes"
@@ -255,13 +263,22 @@ def _dispatch_wiring_present() -> bool:
     )
 
 
+def test_dispatch_wiring_present() -> None:
+    """Strict-enforce: dashboard.py must contain BOTH the import and
+    the register call. Operator-added two-line diff."""
+    text = _dashboard_text()
+    assert EXPECTED_DISPATCH_IMPORT_LINE in text, (
+        "dashboard.py is missing the dispatch import line: "
+        f"{EXPECTED_DISPATCH_IMPORT_LINE!r}"
+    )
+    assert EXPECTED_DISPATCH_REGISTER_CALL in text, (
+        "dashboard.py is missing the dispatch register call: "
+        f"{EXPECTED_DISPATCH_REGISTER_CALL!r}"
+    )
+
+
 def test_dispatch_wiring_exactly_one_import_and_one_register_call() -> None:
-    if not _dispatch_wiring_present():
-        # Operator has not yet added the two-line diff. Conditional
-        # pin returns early; the test still passes. Once the operator
-        # commits the wiring, this branch is no longer taken and the
-        # assertions below fire.
-        return
+    """No duplicate dispatch route registration."""
     text = _dashboard_text()
     assert text.count(EXPECTED_DISPATCH_IMPORT_LINE) == 1, (
         "dashboard.py must contain exactly one new dispatch import line"
@@ -271,11 +288,30 @@ def test_dispatch_wiring_exactly_one_import_and_one_register_call() -> None:
     )
 
 
+def test_dispatch_register_call_after_push_subscribe_call() -> None:
+    """The new dispatch register call must appear AFTER the existing
+    ``register_push_subscribe_routes(app)`` anchor (the N2b-2b
+    wiring). Catches an accidental reorder that would put dispatch
+    above the subscription surface or replace it entirely."""
+    text = _dashboard_text()
+    subscribe_anchor = "register_push_subscribe_routes(app)"
+    subscribe_pos = text.find(subscribe_anchor)
+    dispatch_pos = text.find(EXPECTED_DISPATCH_REGISTER_CALL)
+    assert subscribe_pos != -1, (
+        "dashboard.py must still contain the N2b-2b push-subscribe "
+        "register call as the anchor"
+    )
+    assert dispatch_pos != -1
+    assert dispatch_pos > subscribe_pos, (
+        "the new dispatch register call must appear AFTER the "
+        "existing register_push_subscribe_routes(app) anchor"
+    )
+
+
 def test_dispatch_wiring_no_other_dashboard_dashboard_modifications() -> None:
-    """When the dispatch wiring lands, the diff must include ONLY two
-    new lines (one import + one register call)."""
-    if not _dispatch_wiring_present():
-        return
+    """The dispatch wiring must add exactly 2 lines mentioning the
+    new blueprint (one import + one register call); anything else
+    signals a stray edit."""
     text = _dashboard_text()
     push_dispatch_lines = [
         line


### PR DESCRIPTION
## Summary

Wires the merged N2b-3b real Web Push dispatch blueprint at [dashboard/api_push_dispatch.py](dashboard/api_push_dispatch.py) into the running Flask dashboard. The two-line edit to [dashboard/dashboard.py](dashboard/dashboard.py) is **operator-authored** (the agent's no-touch hook blocks edits to that file per [docs/governance/no_touch_paths.md](docs/governance/no_touch_paths.md)). The wiring tests are flipped from skip-or-enforce to strict-enforce so any future regression that drops, duplicates, or reorders these two lines fails CI.

The wired endpoint is **internal-only**: loopback gate (403 non-loopback) + nginx 127.0.0.1 restriction + env gate (503 `configuration_missing`) + 1 KiB body gate (413). It performs **notification delivery only** — never approval, never merge, never deploy.

## Diff scope (3 files)

### `dashboard/dashboard.py` — operator added exactly two lines
```diff
+from dashboard.api_push_dispatch import register_push_dispatch_routes
 ...
+register_push_dispatch_routes(app)
```
No other line is reordered or modified.

### `tests/unit/test_dashboard_dashboard_one_line_wiring.py`
- `EXISTING_REGISTRATIONS_REQUIRED` gains the N2b-2b push-subscribe import + register call (was missing; now strictly required to stay).
- N2b-3b dispatch wiring pins flipped from skip-or-enforce to **strict-enforce**: import + register call each appear exactly once; register call appears AFTER `register_push_subscribe_routes(app)`; total dispatch-related lines == 2.
- Module-presence test renamed (module is now wired, no longer "unwired").

### `docs/governance/notification_dispatch_real.md`
- Status block reworded: wiring **shipped**; runtime gates remain operator-controlled (env vars + nginx + pywebpush in image).
- Operator setup checklist step 5 marked **shipped** with a note that the strict pin tests now refuse any future edit that drops/duplicates/reorders these lines.

## Three runtime conditions remain operator-gated (no behaviour change to those)
1. `WEB_PUSH_VAPID_PRIVATE_KEY` + `WEB_PUSH_VAPID_SUBJECT` in VPS env — without these, wired endpoint refuses 503 `configuration_missing`.
2. `pywebpush>=1.14.0` in the Docker image (merged via PR [#183](https://github.com/roudjy/trading-agent/pull/183); pinned by [tests/unit/test_requirements_pywebpush.py](tests/unit/test_requirements_pywebpush.py)).
3. nginx `127.0.0.1` lock on `/api/push/dispatch` — without it the Python loopback gate refuses 403 `remote_not_loopback`.

## Hard invariants preserved
- `step5_implementation_allowed = False` (unchanged)
- `STEP5_ENABLED_SUBSTAGE = "none"` (unchanged)
- Level 6 permanently disabled (3 qualifier occurrences in doc)
- [dashboard/api_push_dispatch.py](dashboard/api_push_dispatch.py) untouched (loopback + env + 1 KiB body gates intact)
- [reporting/web_push_real_transport.py](reporting/web_push_real_transport.py) untouched (env-gated lazy `pywebpush` import intact)
- `.gitleaks.toml` untouched
- `.claude/**` untouched
- No approval / merge / deploy code added
- No QRE / research / live / paper / shadow / risk / broker / execution changes

## Test plan (all green locally)
- [x] `python scripts/governance_lint.py` → OK (16 agents, 5 workflows)
- [x] `python -m pytest tests/smoke -q` → 18 passed
- [x] `python -m pytest tests/unit/test_dashboard_dashboard_one_line_wiring.py tests/unit/test_api_push_dispatch.py tests/unit/test_web_push_real_transport.py tests/unit/test_requirements_pywebpush.py -q` → 88 passed
- [x] `npm --prefix frontend run build` → clean
- [x] `npm --prefix frontend run test` → 137 passed
- [x] `python -m reporting.development_step5_loop --no-write` → halts `no_op_no_eligible_item`; `step5_implementation_allowed=false`, `step5_enabled_substage="none"`
- [x] `python -m reporting.development_operational_digest --no-write` → `auto_authorises_step5=false`, `operator_step5_authorisation_required=true`, `step5_implementation_allowed=false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)