### PR TITLE
fix(notif): SPA fallback for /agent-control/<path:path> so push-click lands safely

### DIFF
--- a/dashboard/dashboard.py
+++ b/dashboard/dashboard.py
@@ -356,8 +356,9 @@ def robots_txt():
 @app.route("/version")
 @app.route("/observability")
 @app.route("/agent-control")
+@app.route("/agent-control/<path:path>")
 @requires_auth
-def spa_fallback_authed():
+def spa_fallback_authed(path: str = ""):
     return index()
 
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import { History } from "./routes/History";
 import { Reports } from "./routes/Reports";
 import { Candidates } from "./routes/Candidates";
 import { AgentControl } from "./routes/AgentControl";
+import { AgentControlInboxPlaceholder } from "./routes/AgentControl/InboxPlaceholder";
 
 export function App() {
   return (
@@ -37,6 +38,31 @@ export function App() {
           element={
             <RequireAuth>
               <AgentControl />
+            </RequireAuth>
+          }
+        />
+        {/*
+         * Safe placeholder for /agent-control/inbox?event=<event_id>
+         * deep-links opened from the Web Push notification click. The
+         * SW already constrains open_at to the /agent-control/inbox
+         * prefix; the placeholder is read-only and contains no
+         * decision verbs. The real N3c inbox-detail UI is not yet
+         * implemented; until then this view lets the operator land
+         * safely instead of hitting Flask's catch-all JSON 404.
+         */}
+        <Route
+          path="/agent-control/inbox"
+          element={
+            <RequireAuth>
+              <AgentControlInboxPlaceholder />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/agent-control/*"
+          element={
+            <RequireAuth>
+              <AgentControlInboxPlaceholder />
             </RequireAuth>
           }
         />

--- a/frontend/src/routes/AgentControl/InboxPlaceholder.tsx
+++ b/frontend/src/routes/AgentControl/InboxPlaceholder.tsx
@@ -1,0 +1,94 @@
+/**
+ * AgentControlInboxPlaceholder
+ * ----------------------------
+ *
+ * Read-only landing page for ``/agent-control/inbox?event=<event_id>``
+ * deep-links opened from the Web Push service worker's
+ * ``notificationclick`` handler. The notification click is constrained
+ * to this prefix by the SW sanitiser; this placeholder gives the
+ * operator a safe destination until the real N3c inbox-detail UI
+ * ships.
+ *
+ * Hard guarantees enforced by the unit test:
+ *   - Renders the bounded ``event_id`` query parameter when present.
+ *   - Contains NO ``approve`` / ``reject`` / ``merge`` / ``deploy``
+ *     button, action, or text. Approval still requires the future N4
+ *     token gate, never a notification tap.
+ *   - Performs NO ``fetch`` / ``XMLHttpRequest`` / ``navigator.sendBeacon``
+ *     calls. Strictly read-only.
+ *   - Provides a ``<Link>`` back to ``/agent-control`` so the operator
+ *     can reach the existing standalone surface.
+ *
+ * No real evidence is shown — that lives in the not-yet-implemented
+ * N3c inbox detail. The placeholder is intentionally bland.
+ */
+
+import { Link, useLocation, useSearchParams } from "react-router-dom";
+
+const MAX_EVENT_ID_LEN = 64;
+
+function boundedEventId(raw: string | null): string {
+  if (typeof raw !== "string") return "";
+  const trimmed = raw.trim();
+  if (!trimmed) return "";
+  // Allow only the safe character set the N2b-1 outbox event_ids use.
+  const safe = trimmed.replace(/[^A-Za-z0-9_\-]/g, "");
+  return safe.slice(0, MAX_EVENT_ID_LEN);
+}
+
+export function AgentControlInboxPlaceholder() {
+  const location = useLocation();
+  const [search] = useSearchParams();
+  const eventId = boundedEventId(search.get("event"));
+  const isInbox = location.pathname.startsWith("/agent-control/inbox");
+  const heading = isInbox ? "Inbox notification" : "Agent control";
+
+  return (
+    <main
+      data-testid="agent-control-inbox-placeholder"
+      style={{
+        padding: "1.25rem",
+        maxWidth: "640px",
+        margin: "0 auto",
+        fontFamily: "system-ui, -apple-system, sans-serif",
+      }}
+    >
+      <h1 style={{ fontSize: "1.4rem", margin: "0 0 0.75rem 0" }}>
+        {heading}
+      </h1>
+      {isInbox && eventId && (
+        <p
+          data-testid="agent-control-inbox-event-id"
+          style={{
+            fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+            fontSize: "0.85rem",
+            background: "rgba(0,0,0,0.04)",
+            padding: "0.5rem 0.65rem",
+            borderRadius: "0.4rem",
+            wordBreak: "break-all",
+          }}
+        >
+          event_id: {eventId}
+        </p>
+      )}
+      <p style={{ margin: "0.75rem 0", lineHeight: 1.45 }}>
+        The notification you tapped opened the PWA at this safe landing
+        page. The inbox-detail surface is not implemented yet; no
+        actions are available from this view.
+      </p>
+      <p style={{ margin: "0.75rem 0", lineHeight: 1.45, fontSize: "0.9rem" }}>
+        Approval still requires re-authentication in the PWA, never a
+        notification tap.
+      </p>
+      <p style={{ margin: "1rem 0 0 0" }}>
+        <Link
+          to="/agent-control"
+          data-testid="agent-control-inbox-back-link"
+          style={{ color: "var(--ink, #1a73e8)" }}
+        >
+          Back to agent control
+        </Link>
+      </p>
+    </main>
+  );
+}

--- a/frontend/src/test/AgentControlInboxPlaceholder.test.tsx
+++ b/frontend/src/test/AgentControlInboxPlaceholder.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * Tests for the AgentControlInboxPlaceholder landing page.
+ *
+ * Hard guarantees verified here:
+ *   - The placeholder renders the bounded event_id query parameter.
+ *   - The DOM contains NO decision verbs (approve / reject / merge /
+ *     deploy) — neither as buttons, links, nor visible text.
+ *   - The placeholder performs NO fetch / XMLHttpRequest /
+ *     navigator.sendBeacon calls (strictly read-only).
+ *   - A link back to /agent-control exists.
+ *   - A long / hostile event_id is bounded and sanitised (no special
+ *     chars, max 64 chars).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+import { AgentControlInboxPlaceholder } from "../routes/AgentControl/InboxPlaceholder";
+
+const mockFetch = vi.fn();
+const mockSendBeacon = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", mockFetch);
+  if (typeof navigator !== "undefined") {
+    Object.defineProperty(navigator, "sendBeacon", {
+      configurable: true,
+      value: mockSendBeacon,
+    });
+  }
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  mockFetch.mockReset();
+  mockSendBeacon.mockReset();
+});
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <AgentControlInboxPlaceholder />
+    </MemoryRouter>,
+  );
+}
+
+describe("AgentControlInboxPlaceholder — safe landing", () => {
+  it("renders the placeholder for /agent-control/inbox?event=...", () => {
+    renderAt("/agent-control/inbox?event=live_verify_20260511");
+    expect(
+      screen.getByTestId("agent-control-inbox-placeholder"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("agent-control-inbox-event-id"),
+    ).toHaveTextContent("event_id: live_verify_20260511");
+  });
+
+  it("renders even when no event_id query parameter is present", () => {
+    renderAt("/agent-control/inbox");
+    expect(
+      screen.getByTestId("agent-control-inbox-placeholder"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("agent-control-inbox-event-id"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("provides a link back to /agent-control", () => {
+    renderAt("/agent-control/inbox?event=abc");
+    const back = screen.getByTestId("agent-control-inbox-back-link");
+    expect(back).toHaveAttribute("href", "/agent-control");
+  });
+});
+
+describe("AgentControlInboxPlaceholder — no decision verbs", () => {
+  it("DOM contains no approve / reject / merge / deploy verb", () => {
+    renderAt("/agent-control/inbox?event=evt_safe");
+    const root = screen.getByTestId("agent-control-inbox-placeholder");
+    const text = (root.textContent || "").toLowerCase();
+    // Whole-word matches — must not appear anywhere in visible text.
+    expect(text).not.toMatch(/\bapprove\b/);
+    expect(text).not.toMatch(/\breject\b/);
+    expect(text).not.toMatch(/\bmerge\b/);
+    expect(text).not.toMatch(/\bdeploy\b/);
+  });
+
+  it("contains no action buttons", () => {
+    renderAt("/agent-control/inbox?event=evt_safe");
+    const buttons = screen.queryAllByRole("button");
+    expect(buttons).toHaveLength(0);
+  });
+
+  it("reaffirms approval requires re-authentication", () => {
+    renderAt("/agent-control/inbox?event=evt_safe");
+    const root = screen.getByTestId("agent-control-inbox-placeholder");
+    expect(
+      (root.textContent || "").toLowerCase(),
+    ).toContain("re-authentication");
+  });
+});
+
+describe("AgentControlInboxPlaceholder — strictly read-only", () => {
+  it("does not call fetch at any point during render", () => {
+    renderAt("/agent-control/inbox?event=evt_safe");
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("does not call navigator.sendBeacon", () => {
+    renderAt("/agent-control/inbox?event=evt_safe");
+    expect(mockSendBeacon).not.toHaveBeenCalled();
+  });
+});
+
+describe("AgentControlInboxPlaceholder — event_id sanitisation", () => {
+  it("strips characters outside [A-Za-z0-9_-]", () => {
+    renderAt("/agent-control/inbox?event=abc%20<script>def");
+    const eventEl = screen.queryByTestId("agent-control-inbox-event-id");
+    expect(eventEl?.textContent || "").not.toMatch(/<script>/);
+    expect(eventEl?.textContent || "").not.toMatch(/%20/);
+  });
+
+  it("bounds the event_id to 64 characters", () => {
+    const huge = "x".repeat(500);
+    renderAt(`/agent-control/inbox?event=${huge}`);
+    const eventEl = screen.queryByTestId("agent-control-inbox-event-id");
+    const shown = (eventEl?.textContent || "").replace("event_id: ", "");
+    expect(shown.length).toBeLessThanOrEqual(64);
+  });
+});
+
+describe("AgentControlInboxPlaceholder — also handles non-inbox sub-paths", () => {
+  it("falls back to a bland heading for /agent-control/unknown", () => {
+    renderAt("/agent-control/unknown");
+    expect(
+      screen.getByTestId("agent-control-inbox-placeholder"),
+    ).toBeInTheDocument();
+    // No event_id when not on /inbox
+    expect(
+      screen.queryByTestId("agent-control-inbox-event-id"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/tests/unit/test_dashboard_agent_control_spa_fallback.py
+++ b/tests/unit/test_dashboard_agent_control_spa_fallback.py
@@ -1,0 +1,207 @@
+"""SPA-fallback integration test for /agent-control/<path:path>.
+
+Reproduces the regression observed live on the VPS after N2b-3b
+real-push went green: a notification tap opened
+``/agent-control/inbox?event=<event_id>`` and Flask returned its
+catch-all JSON 404 envelope
+(``{"error":"404 Not Found...","data":[]}``) because no route matched
+the deep-link.
+
+This test exercises the **real** ``dashboard.dashboard.app`` via the
+Flask test client and asserts the deep-link path now serves the SPA
+(or auth challenge), never the JSON-404 envelope.
+
+The companion frontend route at
+``frontend/src/routes/AgentControl/InboxPlaceholder.tsx`` renders a
+read-only landing page; the existing Web Push SW already constrains
+``open_at`` to the ``/agent-control/inbox`` prefix.
+
+Hard guarantees verified:
+* GET ``/agent-control/inbox?event=test`` returns status 200 (SPA
+  HTML on an authed session) or 401 (Basic-Auth challenge for an
+  unauthed client) — **never** the JSON 404 envelope.
+* Response ``Content-Type`` is not ``application/json``.
+* Response body does not contain the catch-all error envelope
+  substring ``"data":[]`` or ``"error":"404 Not Found``.
+* Source text of ``dashboard/dashboard.py`` contains the new
+  ``@app.route("/agent-control/<path:path>")`` decorator and an
+  ``spa_fallback_authed`` signature that accepts a defaulted
+  ``path`` parameter (operator-authored, no-touch path).
+* No new approval / merge / deploy / token capability is implied by
+  this change.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DASHBOARD_PY = REPO_ROOT / "dashboard" / "dashboard.py"
+
+
+# ---------------------------------------------------------------------------
+# Source-text pin (operator wiring presence)
+# ---------------------------------------------------------------------------
+
+
+def _dashboard_text() -> str:
+    return DASHBOARD_PY.read_text(encoding="utf-8")
+
+
+def test_dashboard_dashboard_has_agent_control_subpath_decorator() -> None:
+    """Strict pin: the operator-authored decorator must be present.
+
+    The new wiring is a single ``@app.route("/agent-control/<path:path>")``
+    line added to the existing ``spa_fallback_authed`` decorator stack.
+    """
+    text = _dashboard_text()
+    assert '@app.route("/agent-control/<path:path>")' in text, (
+        "dashboard.py is missing the /agent-control/<path:path> "
+        "SPA-fallback decorator (operator-authored two-line edit)."
+    )
+
+
+def test_dashboard_dashboard_spa_fallback_signature_accepts_path() -> None:
+    """The ``spa_fallback_authed`` function must accept an optional
+    ``path`` parameter so the same handler covers both the legacy
+    exact routes and the new sub-path route."""
+    text = _dashboard_text()
+    pattern = re.compile(
+        r"def\s+spa_fallback_authed\s*\(\s*path\s*:\s*str\s*=\s*\"\"\s*\)\s*:"
+    )
+    assert pattern.search(text) is not None, (
+        "dashboard.py spa_fallback_authed must accept a defaulted "
+        "``path: str = \"\"`` parameter so both exact and sub-path "
+        "routes resolve to the same SPA handler."
+    )
+
+
+def test_dashboard_dashboard_existing_agent_control_route_preserved() -> None:
+    """The legacy ``/agent-control`` exact route must still be there;
+    this PR only ADDS a sibling sub-path route."""
+    text = _dashboard_text()
+    assert '@app.route("/agent-control")' in text, (
+        "dashboard.py must still register the legacy /agent-control "
+        "exact route alongside the new sub-path route."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Flask integration: deep-link must not return the JSON 404 envelope
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def app_client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """Return ``(test_client, app)`` for the real dashboard app.
+
+    Redirects the on-disk session-secret target into ``tmp_path`` so the
+    test never mutates the developer's state/ directory.
+    """
+    # Redirect secret-on-disk targets BEFORE importing the dashboard.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    from dashboard import dashboard as dashboard_mod
+
+    dashboard_mod.app.testing = True
+    return dashboard_mod.app.test_client(), dashboard_mod.app
+
+
+def _is_json_404_envelope(body: bytes, content_type: str) -> bool:
+    """Return True iff the response looks like the catch-all JSON
+    error envelope produced by the global ``@app.errorhandler``."""
+    if "application/json" not in (content_type or "").lower():
+        return False
+    text = body.decode("utf-8", errors="replace")
+    return '"data":[]' in text and '"error"' in text
+
+
+def test_agent_control_inbox_deeplink_does_not_return_json_404(
+    app_client,
+) -> None:
+    client, _app = app_client
+    resp = client.get("/agent-control/inbox?event=test")
+    # Acceptable responses: 200 (authed SPA), 401 (Basic-Auth
+    # challenge), 302 (redirect to /login). The JSON-404 envelope is
+    # explicitly forbidden.
+    assert resp.status_code in (200, 401, 302), (
+        f"unexpected status {resp.status_code} for /agent-control/inbox"
+    )
+    content_type = resp.headers.get("Content-Type") or ""
+    assert "application/json" not in content_type.lower(), (
+        f"deep-link must not return JSON; got {content_type!r}"
+    )
+    assert not _is_json_404_envelope(resp.data, content_type), (
+        "deep-link must not return the catch-all JSON 404 envelope"
+    )
+
+
+def test_agent_control_unknown_subpath_does_not_return_json_404(
+    app_client,
+) -> None:
+    """Any sub-path under /agent-control/ should land on the SPA
+    fallback (or auth challenge), not the JSON 404 envelope. The
+    React router decides what to render."""
+    client, _app = app_client
+    resp = client.get("/agent-control/some-future-subpath")
+    assert resp.status_code in (200, 401, 302)
+    content_type = resp.headers.get("Content-Type") or ""
+    assert "application/json" not in content_type.lower()
+    assert not _is_json_404_envelope(resp.data, content_type)
+
+
+def test_unknown_top_level_path_still_404s_through_error_handler(
+    app_client,
+) -> None:
+    """Regression guard: the fix is scoped to /agent-control/<...>
+    only. Random top-level paths are still handled by Flask's
+    catch-all. This test pins that scope so a future careless edit
+    can't accidentally turn the whole app into a SPA fallback."""
+    client, _app = app_client
+    resp = client.get("/this-path-must-not-exist-12345")
+    # The error handler returns JSON 500 (per the existing catch-all
+    # at the top of dashboard.py). What matters is that the deep-link
+    # fix above did NOT silently swallow other 404s into the SPA.
+    assert resp.status_code in (404, 500), (
+        f"non-/agent-control 404 must still error, got {resp.status_code}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scope guards: this fix is read-only / no new authority
+# ---------------------------------------------------------------------------
+
+
+def test_no_decision_verb_added_in_spa_fallback_block(
+    app_client,
+) -> None:
+    """The operator-added decorator/signature change must not bring
+    any approve/reject/merge/deploy verb call into dashboard.py."""
+    text = _dashboard_text().lower()
+    for verb in ("approve(", "reject(", "merge(", "deploy("):
+        assert verb not in text, verb
+
+
+def test_no_real_push_provider_in_dashboard_dashboard() -> None:
+    """Defense-in-depth: this PR must not add a pywebpush import,
+    VAPID private-key reference, or any real Web Push library import
+    into the dashboard module — those are reserved for the existing
+    N2b-3b dispatch route and the env-only transport."""
+    text = _dashboard_text().lower()
+    forbidden = (
+        "pywebpush",
+        "from webpush",
+        "import webpush",
+        "web_push_vapid_private_key",
+    )
+    for needle in forbidden:
+        assert needle not in text, needle
+
+
+def test_step5_invariants_unaffected_by_this_pr() -> None:
+    text = _dashboard_text()
+    assert "step5_implementation_allowed" not in text
+    assert "STEP5_ENABLED_SUBSTAGE" not in text


### PR DESCRIPTION
## Summary

After N2b-3b real Web Push went green on the VPS, tapping the iPhone notification opened `/agent-control/inbox?event=<event_id>` and Flask returned its catch-all JSON 404 envelope — because no route matched the deep-link.

This PR adds the smallest safe fix:
1. **Flask** — a sibling `@app.route("/agent-control/<path:path>")` on the existing `spa_fallback_authed` handler so the deep-link reaches React.
2. **React** — two sibling routes inside the standalone `/agent-control` branch that render a new safe placeholder.
3. **Placeholder** — read-only landing page that shows the bounded `event_id`, explains the N3c inbox-detail UI is not yet implemented, reaffirms approval requires re-authentication, and links back to `/agent-control`. No fetch, no buttons, no decision verbs.

The Web Push SW at [frontend/public/sw-push.js](frontend/public/sw-push.js) is **unchanged** — the existing `open_at` sanitiser already constrains the click target to the `/agent-control/inbox` prefix.

## Diff scope (5 files)

| File | Change |
|------|--------|
| [dashboard/dashboard.py](dashboard/dashboard.py) | operator-authored 2-line edit: new `@app.route("/agent-control/<path:path>")` decorator + `path: str = ""` default param |
| [frontend/src/App.tsx](frontend/src/App.tsx) | + import + 2 new `<Route>` elements inside the standalone branch |
| [frontend/src/routes/AgentControl/InboxPlaceholder.tsx](frontend/src/routes/AgentControl/InboxPlaceholder.tsx) | new read-only component (94 LOC) |
| [frontend/src/test/AgentControlInboxPlaceholder.test.tsx](frontend/src/test/AgentControlInboxPlaceholder.test.tsx) | 11 new Vitest assertions |
| [tests/unit/test_dashboard_agent_control_spa_fallback.py](tests/unit/test_dashboard_agent_control_spa_fallback.py) | 9 new pytest assertions (incl. Flask test_client integration test) |

## Hard invariants preserved
- `step5_implementation_allowed = False`, `STEP5_ENABLED_SUBSTAGE = "none"` (unchanged)
- Level 6 permanently disabled (no doc edits; governance-lint green)
- [dashboard/api_push_dispatch.py](dashboard/api_push_dispatch.py) untouched — loopback + env + 1 KiB body gates intact
- [reporting/web_push_real_transport.py](reporting/web_push_real_transport.py) untouched — env-gated lazy pywebpush import intact
- [frontend/public/sw-push.js](frontend/public/sw-push.js) untouched
- `.gitleaks.toml` untouched; `.claude/**` untouched
- No QRE / research / live / paper / shadow / risk / broker / execution changes
- No approval-token mint, no inbox-row creation (N3 territory remains future), no merge/deploy (N5 territory remains future)

## Test plan (all green locally)
- [x] `python scripts/governance_lint.py` → OK (16 agents, 5 workflows)
- [x] `python -m pytest tests/smoke -q` → 18 passed
- [x] `python -m pytest tests/unit/test_dashboard_agent_control_spa_fallback.py tests/unit/test_dashboard_dashboard_one_line_wiring.py tests/unit/test_api_push_dispatch.py tests/unit/test_web_push_real_transport.py tests/unit/test_requirements_pywebpush.py -q` → 97 passed
- [x] `npm --prefix frontend run build` → clean (80 modules)
- [x] `npm --prefix frontend run test` → 148 passed (137 baseline + 11 new InboxPlaceholder tests)
- [x] `python -m reporting.development_step5_loop --no-write` → halts `no_op_no_eligible_item`; `step5_implementation_allowed=false`, `step5_enabled_substage="none"`
- [x] `python -m reporting.development_operational_digest --no-write` → `auto_authorises_step5=false`, `operator_step5_authorisation_required=true`, `step5_implementation_allowed=false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)