### PR TITLE
fix(deploy): protocol-aware healthcheck for VPS dashboard deploy

### DIFF
--- a/scripts/deploy_vps_dashboard.sh
+++ b/scripts/deploy_vps_dashboard.sh
@@ -39,8 +39,23 @@
 set -euo pipefail
 
 REPO_ROOT="/root/trading-agent"
-DASHBOARD_HEALTH_URL="http://127.0.0.1:8050/agent-control"
 COMPOSE="docker compose"
+
+# Healthcheck URL strategy:
+# * If DASHBOARD_HEALTH_URL is exported, probe exactly that URL.
+# * Otherwise try HTTPS first, then HTTP. Local nginx may speak
+#   either; the deploy must succeed on both. ``curl -k`` accepts
+#   the self-signed local CA the operator may use on the VPS HTTPS
+#   configuration.
+DASHBOARD_HEALTH_URL_OVERRIDE="${DASHBOARD_HEALTH_URL:-}"
+if [[ -n "${DASHBOARD_HEALTH_URL_OVERRIDE}" ]]; then
+    DASHBOARD_HEALTH_CANDIDATES=("${DASHBOARD_HEALTH_URL_OVERRIDE}")
+else
+    DASHBOARD_HEALTH_CANDIDATES=(
+        "https://127.0.0.1:8050/agent-control"
+        "http://127.0.0.1:8050/agent-control"
+    )
+fi
 
 log() {
     # Plain stdout; never echo secrets.
@@ -116,7 +131,7 @@ if ${COMPOSE} ps --status running --services | grep -qx agent; then
     exit 5
 fi
 
-log "verifying dashboard responds on ${DASHBOARD_HEALTH_URL}"
+log "verifying dashboard responds on candidate URLs (HTTPS then HTTP)"
 # A short retry loop covers the seconds while nginx / Flask warm
 # up. We hit /agent-control because the standalone PWA route is
 # the operator-facing surface and is guaranteed to be wired.
@@ -138,31 +153,38 @@ log "verifying dashboard responds on ${DASHBOARD_HEALTH_URL}"
 # %{http_code} instead of using curl --fail so a 401 does not
 # trip the script. We never embed credentials and never bypass
 # auth.
+#
+# v3.15.15.29.4: protocol-aware healthcheck. When nginx speaks
+# TLS on port 8050 (operator HTTPS setup with self-signed local
+# CA), probing http:// returns HTTP 400. The loop now tries each
+# candidate URL per attempt; ``curl -k`` accepts the self-signed
+# CA on loopback — safe because we only probe 127.0.0.1. The
+# first candidate to return an alive status wins.
 http_ok=0
 last_status=""
+alive_url=""
 for attempt in 1 2 3 4 5; do
-    # ``|| true`` so a transport-level failure (no response at
-    # all) just yields an empty status; the if-block below
-    # treats that as "not yet alive" and retries.
-    last_status="$(curl -sS -o /dev/null -w '%{http_code}' \
-        --max-time 5 "${DASHBOARD_HEALTH_URL}" || true)"
-    case "${last_status}" in
-        200|302|401)
-            http_ok=1
-            log "dashboard responded with HTTP ${last_status}; treating as alive (\
-/agent-control is auth-protected)"
-            break
-            ;;
-        *)
-            log "attempt ${attempt}/5: dashboard not alive yet (status=\
-${last_status:-no_response}), sleeping 3s"
-            sleep 3
-            ;;
-    esac
+    for url in "${DASHBOARD_HEALTH_CANDIDATES[@]}"; do
+        # ``|| true`` so a transport-level failure (no response at
+        # all) just yields an empty status; the case block below
+        # treats that as "not yet alive" and continues.
+        last_status="$(curl -k -sS -o /dev/null -w '%{http_code}' \
+            --max-time 5 "${url}" || true)"
+        case "${last_status}" in
+            200|302|401)
+                http_ok=1
+                alive_url="${url}"
+                log "dashboard responded with HTTP ${last_status} at ${url}; treating as alive (/agent-control is auth-protected)"
+                break 2
+                ;;
+        esac
+    done
+    log "attempt ${attempt}/5: dashboard not alive yet (last status=${last_status:-no_response}), sleeping 3s"
+    sleep 3
 done
 
 if [[ "${http_ok}" -ne 1 ]]; then
-    log "fatal: dashboard did not respond on ${DASHBOARD_HEALTH_URL} \
+    log "fatal: dashboard did not respond on any candidate URLs \
 (last status=${last_status:-no_response})"
     ${COMPOSE} logs --tail=120 dashboard || true
     exit 6

--- a/tests/unit/test_vps_deploy_invariants.py
+++ b/tests/unit/test_vps_deploy_invariants.py
@@ -504,3 +504,92 @@ def test_no_other_file_references_a_full_vps_ip() -> None:
         assert matches == [], (
             f"{path.name} contains a non-loopback IP literal: {matches!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# v3.15.15.29.4 — protocol-aware healthcheck invariants
+# ---------------------------------------------------------------------------
+
+
+def test_script_healthcheck_supports_https_with_self_signed_ca(
+    script_text: str,
+) -> None:
+    """The healthcheck curl call must use ``-k`` (or ``--insecure``)
+    so the VPS self-signed local CA on the HTTPS variant of port
+    8050 does not cause a certificate-verification failure.
+
+    We only scan executable (non-comment) lines so a comment
+    explaining why ``-k`` is safe does not satisfy this test on
+    its own — the flag must appear in an actual curl invocation.
+    """
+    executable_lines = [
+        ln for ln in script_text.splitlines() if not ln.lstrip().startswith("#")
+    ]
+    executable = "\n".join(executable_lines)
+    assert "curl -k" in executable or "curl --insecure" in executable, (
+        "healthcheck curl call does not pass -k / --insecure; "
+        "HTTPS with a self-signed local CA will fail"
+    )
+
+
+def test_script_healthcheck_lists_https_and_http_candidates(
+    script_text: str,
+) -> None:
+    """Both the HTTPS and HTTP loopback candidates must appear
+    literally in the script so the operator can audit the two
+    probe addresses without having to reason about runtime
+    string construction."""
+    assert "https://127.0.0.1:8050/agent-control" in script_text, (
+        "script does not contain HTTPS candidate "
+        "https://127.0.0.1:8050/agent-control"
+    )
+    assert "http://127.0.0.1:8050/agent-control" in script_text, (
+        "script does not contain HTTP candidate "
+        "http://127.0.0.1:8050/agent-control"
+    )
+
+
+def test_script_healthcheck_honours_env_override(
+    script_text: str,
+) -> None:
+    """The script must expose an operator-level env override so a
+    non-standard setup (different port, different path) can be
+    accommodated without editing the script.
+
+    Accepted forms:
+      * ``${DASHBOARD_HEALTH_URL:-}`` — explicit default-empty
+        expansion used to detect whether the var is set.
+      * ``${DASHBOARD_HEALTH_URL_OVERRIDE}`` — a local copy that
+        the script derives from the env var.
+    Either form proves the script reads DASHBOARD_HEALTH_URL from
+    the environment.
+    """
+    assert (
+        "${DASHBOARD_HEALTH_URL:-}" in script_text
+        or "${DASHBOARD_HEALTH_URL_OVERRIDE}" in script_text
+    ), (
+        "script does not reference DASHBOARD_HEALTH_URL as an "
+        "env-driven override (expected ${DASHBOARD_HEALTH_URL:-} "
+        "or ${DASHBOARD_HEALTH_URL_OVERRIDE})"
+    )
+
+
+def test_script_healthcheck_iterates_candidates(
+    script_text: str,
+) -> None:
+    """The healthcheck must iterate over a candidates array so
+    both HTTPS and HTTP are tried per retry attempt — a healthy
+    HTTP-only deploy must not be delayed by HTTPS timeouts on
+    all five attempts before HTTP is even tried.
+
+    Accepted pattern: ``for url in "${DASHBOARD_HEALTH_CANDIDATES[@]}"``
+    (or a functionally equivalent iteration over the array).
+    """
+    assert (
+        'for url in "${DASHBOARD_HEALTH_CANDIDATES[@]}"' in script_text
+        or "DASHBOARD_HEALTH_CANDIDATES[@]" in script_text
+    ), (
+        "script does not iterate over DASHBOARD_HEALTH_CANDIDATES[@]; "
+        "both HTTPS and HTTP candidates must be tried inside each "
+        "retry attempt"
+    )


### PR DESCRIPTION
## Summary

The live VPS now serves the dashboard behind an HTTPS nginx on port 8050 (self-signed local CA). The deploy script's HTTP-only healthcheck against `http://127.0.0.1:8050/agent-control` was returning HTTP 400 (nginx "plain HTTP request was sent to HTTPS port") — the deploy job failed on the verification step even though the dashboard was healthy.

This PR adds the smallest safe protocol-aware healthcheck. The build / recreate / stop-agent steps and every existing safety guard are unchanged.

## Healthcheck behaviour

| Condition | Behaviour |
|-----------|-----------|
| `DASHBOARD_HEALTH_URL` env var set | probe **exactly** that URL (operator escape hatch) |
| Not set (default) | probe `https://127.0.0.1:8050/agent-control` **first**, then `http://127.0.0.1:8050/agent-control`, interleaved per attempt |
| `curl -k` | accepts self-signed local CA on loopback (safe — we only probe `127.0.0.1`) |
| Accepted statuses | `200 / 302 / 401` (unchanged) |
| Retry loop | 5 attempts × candidates, 3-second sleep (unchanged) |
| No `curl --fail` / `-f` | preserved (pinned by existing test) |
| `%{http_code}` capture | preserved (pinned by existing test) |
| `dashboard responded with HTTP` log | preserved (pinned by existing test) |

## Diff scope (exactly 2 files)

| File | Change |
|------|--------|
| [scripts/deploy_vps_dashboard.sh](scripts/deploy_vps_dashboard.sh) | replace the single `DASHBOARD_HEALTH_URL` constant with an env-aware candidates array; rewrite the verification block to iterate candidates per attempt |
| [tests/unit/test_vps_deploy_invariants.py](tests/unit/test_vps_deploy_invariants.py) | append 4 new source-text pin tests (HTTPS-with-`-k`, both URL literals present, env override, candidates iteration) |

Authored by the `deployment-implementation-agent` (narrow file-level allowlist for the audited VPS dashboard deploy surface).

## Hard invariants preserved
- No dashboard / frontend / reporting / `.claude` / research / live / paper / shadow / risk / broker / execution / trading / orchestration / automation changes.
- No `docker-compose*.yml` / `Dockerfile` / `scripts/deploy.sh` changes.
- No new secrets, no new IP literals beyond `127.0.0.1`, no new ports beyond `8050`.
- `--no-deps --force-recreate dashboard nginx` and `stop agent` preserved verbatim.
- `step5_implementation_allowed = False`, `STEP5_ENABLED_SUBSTAGE = "none"`, Level 6 permanently disabled — unchanged.
- No approval-token mint, no inbox-row creation, no merge / deploy authority gained.

## Test plan
- [x] `python scripts/governance_lint.py` → OK (16 agents, 5 workflows)
- [x] `python -m pytest tests/smoke -q` → 18 passed
- [x] `python -m pytest tests/unit/test_vps_deploy_invariants.py -q` → 39 passed (35 baseline + 4 new)
- [x] `python -m reporting.development_step5_loop --no-write` → invariants intact
- [x] `python -m reporting.development_operational_digest --no-write` → invariants intact

## Operator verification on the live VPS after merge

From the VPS shell (`cd /root/trading-agent`):

```bash
bash scripts/deploy_vps_dashboard.sh
```

Expected line: `dashboard responded with HTTP 302 at https://127.0.0.1:8050/agent-control; treating as alive (/agent-control is auth-protected)`.

Explicit-override (e.g. for ad-hoc plain-HTTP rollback on a hypothetical HTTP-only setup):

```bash
DASHBOARD_HEALTH_URL=http://127.0.0.1:8050/agent-control \
    bash scripts/deploy_vps_dashboard.sh
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)