### PR TITLE
feat(notif): N3b/N3c — mobile approval inbox API + PWA detail UI (unwired)

### DIFF
--- a/dashboard/api_mobile_approval_inbox.py
+++ b/dashboard/api_mobile_approval_inbox.py
@@ -1,0 +1,318 @@
+"""N3b — Mobile Approval Inbox API (read-only, UNWIRED).
+
+GET-only Flask blueprint that exposes the existing N3a projector
+artefact at ``logs/mobile_approval_inbox/latest.json`` to the PWA
+inbox-detail surface.
+
+Hard guarantees (pinned by tests)
+---------------------------------
+
+* GET only — no POST / PUT / PATCH / DELETE handler is registered.
+* Never executes a CLI subprocess, never invokes ``gh`` / ``git``.
+* Never imports a Web Push library, never reads / writes any
+  approval-token, never reads the env VAPID private key (which by
+  policy is referenced by name only in
+  ``reporting.web_push_real_transport``).
+* Never mutates the upstream N3a artefact, the inbox state, or the
+  decision_state of any row.
+* Never approves / rejects / merges / deploys anything — no decision
+  verb appears in any code path.
+* Every response payload is run through
+  ``reporting.agent_audit_summary.assert_no_secrets`` before send.
+* ``not_available`` envelope returned when the artefact is missing,
+  unreadable, or malformed.
+* ``not_found`` envelope returned for a detail lookup when the
+  ``event_id`` is not present in the bounded rows.
+* The blueprint is intentionally **NOT** wired into
+  ``dashboard/dashboard.py`` in this PR — wiring is the operator's
+  two-line diff (per ``execution_authority.md``).
+
+Routes
+------
+
+::
+
+    GET /api/agent-control/mobile-inbox/list
+        → bounded rows + counts + safe envelope
+
+    GET /api/agent-control/mobile-inbox/detail/<event_id>
+        → exactly one row matching event_id, or not_found envelope
+
+The blueprint reads ``reporting.mobile_approval_inbox.ARTIFACT_LATEST``
+exactly once per request; no caching, no background work.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Final
+
+from flask import Flask, Response, jsonify
+
+from reporting import mobile_approval_inbox as mai
+from reporting.agent_audit_summary import assert_no_secrets
+
+MODULE_VERSION: Final[str] = "v3.15.16.N3b"
+SCHEMA_VERSION: Final[int] = 1
+
+# ---------------------------------------------------------------------------
+# Step 5 invariants
+# ---------------------------------------------------------------------------
+
+STEP5_ENABLED_SUBSTAGE: Final[str] = "none"
+step5_implementation_allowed: Final[bool] = False
+
+
+# ---------------------------------------------------------------------------
+# Closed bounds + sanitisation
+# ---------------------------------------------------------------------------
+
+#: Maximum event_id length accepted by the detail route. The N3a
+#: projector caps the inbox-row event_id well below this; the cap
+#: also exists as defense-in-depth against pathological URL paths.
+_MAX_EVENT_ID_LEN: Final[int] = 128
+
+#: Permissive but bounded event_id charset. The N3a projector uses
+#: ``[A-Za-z0-9_-]`` for all event_id values; allowing this exact
+#: charset on the URL parameter blocks any path-traversal /
+#: control-character smuggling.
+_EVENT_ID_PATTERN: Final[re.Pattern[str]] = re.compile(r"^[A-Za-z0-9_\-]+$")
+
+
+# ---------------------------------------------------------------------------
+# Artefact reader (read-only, never raises)
+# ---------------------------------------------------------------------------
+
+
+def _read_artifact() -> tuple[str, dict[str, Any]]:
+    """Return ``(status, payload)`` for the N3a artefact.
+
+    ``status`` is ``"ok"`` if the artefact parses to a dict, else
+    ``"not_available"``. ``payload`` is the parsed dict on success,
+    else a small envelope-friendly dict explaining the absence.
+    """
+    path: Path = mai.ARTIFACT_LATEST
+    if not path.is_file():
+        return "not_available", {"reason": "missing"}
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return "not_available", {
+            "reason": f"unreadable: {type(exc).__name__}"
+        }
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        return "not_available", {
+            "reason": f"malformed: {type(exc).__name__}"
+        }
+    if not isinstance(data, dict):
+        return "not_available", {"reason": "malformed: not_an_object"}
+    return "ok", data
+
+
+def _safe_rows(data: dict[str, Any]) -> list[dict[str, Any]]:
+    """Filter the projector artefact to rows whose shape matches the
+    closed N3a schema. Defense-in-depth — the projector already
+    enforces this, but we re-validate at the API boundary."""
+    raw = data.get("rows")
+    if not isinstance(raw, list):
+        return []
+    expected = set(mai.INBOX_ROW_KEYS)
+    out: list[dict[str, Any]] = []
+    for r in raw:
+        if not isinstance(r, dict):
+            continue
+        if set(r.keys()) != expected:
+            continue
+        out.append(r)
+    return out[: mai.MAX_INBOX_ROWS]
+
+
+# ---------------------------------------------------------------------------
+# View functions
+# ---------------------------------------------------------------------------
+
+
+def _safe_jsonify(payload: dict[str, Any]) -> Response:
+    assert_no_secrets(payload)
+    return jsonify(payload)
+
+
+def _list_envelope() -> dict[str, Any]:
+    status, data = _read_artifact()
+    if status != "ok":
+        return {
+            "kind": "agent_control_mobile_inbox_list",
+            "schema_version": SCHEMA_VERSION,
+            "module_version": MODULE_VERSION,
+            "status": "not_available",
+            "reason": data.get("reason", "missing"),
+            "rows": [],
+            "counts": {"rows": 0},
+            "artifact_path": mai.ARTIFACT_RELATIVE_PATH,
+            "step5_implementation_allowed": step5_implementation_allowed,
+            "step5_enabled_substage": STEP5_ENABLED_SUBSTAGE,
+        }
+    rows = _safe_rows(data)
+    return {
+        "kind": "agent_control_mobile_inbox_list",
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "status": "ok",
+        "rows": rows,
+        "counts": {"rows": len(rows)},
+        "generated_at_utc": str(data.get("generated_at_utc") or ""),
+        "artifact_path": mai.ARTIFACT_RELATIVE_PATH,
+        "step5_implementation_allowed": step5_implementation_allowed,
+        "step5_enabled_substage": STEP5_ENABLED_SUBSTAGE,
+    }
+
+
+def _detail_envelope(event_id: str) -> tuple[dict[str, Any], int]:
+    """Return ``(envelope, http_status)`` for the detail lookup."""
+    if not isinstance(event_id, str) or not event_id:
+        return (
+            {
+                "kind": "agent_control_mobile_inbox_detail",
+                "schema_version": SCHEMA_VERSION,
+                "module_version": MODULE_VERSION,
+                "status": "invalid_event_id",
+                "reason": "empty",
+                "step5_implementation_allowed": step5_implementation_allowed,
+                "step5_enabled_substage": STEP5_ENABLED_SUBSTAGE,
+            },
+            400,
+        )
+    if len(event_id) > _MAX_EVENT_ID_LEN:
+        return (
+            {
+                "kind": "agent_control_mobile_inbox_detail",
+                "schema_version": SCHEMA_VERSION,
+                "module_version": MODULE_VERSION,
+                "status": "invalid_event_id",
+                "reason": "too_long",
+                "step5_implementation_allowed": step5_implementation_allowed,
+                "step5_enabled_substage": STEP5_ENABLED_SUBSTAGE,
+            },
+            400,
+        )
+    if not _EVENT_ID_PATTERN.match(event_id):
+        return (
+            {
+                "kind": "agent_control_mobile_inbox_detail",
+                "schema_version": SCHEMA_VERSION,
+                "module_version": MODULE_VERSION,
+                "status": "invalid_event_id",
+                "reason": "bad_charset",
+                "step5_implementation_allowed": step5_implementation_allowed,
+                "step5_enabled_substage": STEP5_ENABLED_SUBSTAGE,
+            },
+            400,
+        )
+    status, data = _read_artifact()
+    if status != "ok":
+        return (
+            {
+                "kind": "agent_control_mobile_inbox_detail",
+                "schema_version": SCHEMA_VERSION,
+                "module_version": MODULE_VERSION,
+                "status": "not_available",
+                "reason": data.get("reason", "missing"),
+                "artifact_path": mai.ARTIFACT_RELATIVE_PATH,
+                "step5_implementation_allowed": step5_implementation_allowed,
+                "step5_enabled_substage": STEP5_ENABLED_SUBSTAGE,
+            },
+            404,
+        )
+    for row in _safe_rows(data):
+        if row.get("event_id") == event_id:
+            return (
+                {
+                    "kind": "agent_control_mobile_inbox_detail",
+                    "schema_version": SCHEMA_VERSION,
+                    "module_version": MODULE_VERSION,
+                    "status": "ok",
+                    "row": row,
+                    "generated_at_utc": str(
+                        data.get("generated_at_utc") or ""
+                    ),
+                    "artifact_path": mai.ARTIFACT_RELATIVE_PATH,
+                    "step5_implementation_allowed": step5_implementation_allowed,
+                    "step5_enabled_substage": STEP5_ENABLED_SUBSTAGE,
+                },
+                200,
+            )
+    return (
+        {
+            "kind": "agent_control_mobile_inbox_detail",
+            "schema_version": SCHEMA_VERSION,
+            "module_version": MODULE_VERSION,
+            "status": "not_found",
+            "reason": "no_matching_event_id",
+            "artifact_path": mai.ARTIFACT_RELATIVE_PATH,
+            "step5_implementation_allowed": step5_implementation_allowed,
+            "step5_enabled_substage": STEP5_ENABLED_SUBSTAGE,
+        },
+        404,
+    )
+
+
+def _view_list() -> Response:
+    return _safe_jsonify(_list_envelope())
+
+
+def _view_detail(event_id: str) -> tuple[Response, int] | Response:
+    envelope, code = _detail_envelope(event_id)
+    resp = _safe_jsonify(envelope)
+    if code == 200:
+        return resp
+    return resp, code
+
+
+# ---------------------------------------------------------------------------
+# Route table + register helper
+# ---------------------------------------------------------------------------
+
+_MOBILE_INBOX_ROUTES: tuple[tuple[str, str, Any, str], ...] = (
+    (
+        "/api/agent-control/mobile-inbox/list",
+        "GET",
+        _view_list,
+        "agent_control_mobile_inbox_list",
+    ),
+    (
+        "/api/agent-control/mobile-inbox/detail/<string:event_id>",
+        "GET",
+        _view_detail,
+        "agent_control_mobile_inbox_detail",
+    ),
+)
+
+
+def register_mobile_approval_inbox_routes(app: Flask) -> None:
+    """Register the read-only mobile-approval-inbox routes.
+
+    NOT wired into ``dashboard/dashboard.py`` in this PR. The
+    one-line wiring change ``register_mobile_approval_inbox_routes(app)``
+    is operator-only per ``execution_authority.md`` (``dashboard_wiring``
+    = NEEDS_HUMAN).
+    """
+    for path, method, handler, endpoint in _MOBILE_INBOX_ROUTES:
+        app.add_url_rule(
+            path,
+            endpoint=endpoint,
+            view_func=handler,
+            methods=[method],
+        )
+
+
+__all__ = [
+    "MODULE_VERSION",
+    "SCHEMA_VERSION",
+    "STEP5_ENABLED_SUBSTAGE",
+    "register_mobile_approval_inbox_routes",
+    "step5_implementation_allowed",
+]

--- a/frontend/src/routes/AgentControl/InboxPlaceholder.tsx
+++ b/frontend/src/routes/AgentControl/InboxPlaceholder.tsx
@@ -2,39 +2,89 @@
  * AgentControlInboxPlaceholder
  * ----------------------------
  *
- * Read-only landing page for ``/agent-control/inbox?event=<event_id>``
- * deep-links opened from the Web Push service worker's
- * ``notificationclick`` handler. The notification click is constrained
- * to this prefix by the SW sanitiser; this placeholder gives the
- * operator a safe destination until the real N3c inbox-detail UI
- * ships.
+ * N3c — read-only landing page for
+ * ``/agent-control/inbox?event=<event_id>`` deep-links opened by the
+ * Web Push service worker's ``notificationclick`` handler. The SW
+ * sanitiser already constrains the URL to the ``/agent-control/inbox``
+ * prefix; this component fetches the bounded N3b detail envelope and
+ * renders the safe fields.
  *
  * Hard guarantees enforced by the unit test:
  *   - Renders the bounded ``event_id`` query parameter when present.
+ *   - When the read-only N3b API at
+ *     ``/api/agent-control/mobile-inbox/detail/<event_id>`` returns a
+ *     row, the closed-schema scalars are rendered: event_id,
+ *     event_kind, event_severity, attention_level, decision_state,
+ *     source_module, title, summary, created_at, open_at.
+ *   - When the API returns ``not_available`` / ``not_found`` /
+ *     network failure, the component renders the safe empty state
+ *     and a ``data-testid="agent-control-inbox-empty"`` marker.
  *   - Contains NO ``approve`` / ``reject`` / ``merge`` / ``deploy``
- *     button, action, or text. Approval still requires the future N4
- *     token gate, never a notification tap.
- *   - Performs NO ``fetch`` / ``XMLHttpRequest`` / ``navigator.sendBeacon``
- *     calls. Strictly read-only.
- *   - Provides a ``<Link>`` back to ``/agent-control`` so the operator
- *     can reach the existing standalone surface.
+ *     button, link, or visible text. Approval still requires the
+ *     future N4 token gate, never a notification tap.
+ *   - Performs ONLY a single same-origin GET to the read-only
+ *     detail endpoint. No ``XMLHttpRequest``, no
+ *     ``navigator.sendBeacon``, no POST / DELETE / PUT.
+ *   - Provides a ``<Link>`` back to ``/agent-control``.
+ *   - The banner "Read-only inbox detail. Approval actions are not
+ *     implemented in this stage." is always rendered.
  *
- * No real evidence is shown — that lives in the not-yet-implemented
- * N3c inbox detail. The placeholder is intentionally bland.
+ * No real evidence is shown — only the bounded six-or-so scalars the
+ * projector already emitted. The placeholder is intentionally bland.
  */
 
+import { useEffect, useState } from "react";
 import { Link, useLocation, useSearchParams } from "react-router-dom";
 
 const MAX_EVENT_ID_LEN = 64;
+const DETAIL_BASE = "/api/agent-control/mobile-inbox/detail/";
 
 function boundedEventId(raw: string | null): string {
   if (typeof raw !== "string") return "";
   const trimmed = raw.trim();
   if (!trimmed) return "";
-  // Allow only the safe character set the N2b-1 outbox event_ids use.
   const safe = trimmed.replace(/[^A-Za-z0-9_\-]/g, "");
   return safe.slice(0, MAX_EVENT_ID_LEN);
 }
+
+type InboxRow = {
+  inbox_row_id: string;
+  event_id: string;
+  event_kind: string;
+  event_severity: string;
+  source_module: string;
+  source_id: string;
+  endpoint_hash: string;
+  outbound_delivery_intent: string;
+  attention_level: string;
+  decision_state: string;
+  title: string;
+  summary: string;
+  open_at: string;
+  created_at: string;
+};
+
+type DetailResponse =
+  | {
+      kind: string;
+      status: "ok";
+      row: InboxRow;
+      generated_at_utc?: string;
+    }
+  | {
+      kind: string;
+      status: "not_available" | "not_found" | "invalid_event_id";
+      reason?: string;
+    };
+
+type FetchState =
+  | { phase: "idle" }
+  | { phase: "loading" }
+  | { phase: "ok"; row: InboxRow; generatedAt: string }
+  | { phase: "empty"; reason: string };
+
+const READ_ONLY_BANNER =
+  "Read-only inbox detail. Approval actions are not implemented in this stage.";
 
 export function AgentControlInboxPlaceholder() {
   const location = useLocation();
@@ -42,6 +92,54 @@ export function AgentControlInboxPlaceholder() {
   const eventId = boundedEventId(search.get("event"));
   const isInbox = location.pathname.startsWith("/agent-control/inbox");
   const heading = isInbox ? "Inbox notification" : "Agent control";
+
+  const [state, setState] = useState<FetchState>({ phase: "idle" });
+
+  useEffect(() => {
+    if (!isInbox || !eventId) {
+      setState({ phase: "idle" });
+      return;
+    }
+    let cancelled = false;
+    setState({ phase: "loading" });
+    fetch(DETAIL_BASE + encodeURIComponent(eventId), {
+      method: "GET",
+      credentials: "same-origin",
+      headers: { Accept: "application/json" },
+    })
+      .then(async (res) => {
+        if (cancelled) return;
+        // Even on 4xx we still parse the body to honour the API's
+        // not_available / not_found envelope shape.
+        let body: DetailResponse | null = null;
+        try {
+          body = (await res.json()) as DetailResponse;
+        } catch {
+          body = null;
+        }
+        if (body && body.status === "ok" && "row" in body && body.row) {
+          setState({
+            phase: "ok",
+            row: body.row,
+            generatedAt:
+              ("generated_at_utc" in body && body.generated_at_utc) || "",
+          });
+          return;
+        }
+        const reason =
+          (body && "reason" in body && body.reason) ||
+          (body && "status" in body && body.status) ||
+          `http_${res.status}`;
+        setState({ phase: "empty", reason });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setState({ phase: "empty", reason: "network" });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [eventId, isInbox]);
 
   return (
     <main
@@ -53,9 +151,20 @@ export function AgentControlInboxPlaceholder() {
         fontFamily: "system-ui, -apple-system, sans-serif",
       }}
     >
-      <h1 style={{ fontSize: "1.4rem", margin: "0 0 0.75rem 0" }}>
-        {heading}
-      </h1>
+      <h1 style={{ fontSize: "1.4rem", margin: "0 0 0.75rem 0" }}>{heading}</h1>
+      <div
+        data-testid="agent-control-inbox-banner"
+        style={{
+          margin: "0 0 0.85rem 0",
+          padding: "0.55rem 0.7rem",
+          borderRadius: "0.4rem",
+          background: "rgba(0,0,0,0.05)",
+          fontSize: "0.85rem",
+          lineHeight: 1.4,
+        }}
+      >
+        {READ_ONLY_BANNER}
+      </div>
       {isInbox && eventId && (
         <p
           data-testid="agent-control-inbox-event-id"
@@ -71,12 +180,94 @@ export function AgentControlInboxPlaceholder() {
           event_id: {eventId}
         </p>
       )}
-      <p style={{ margin: "0.75rem 0", lineHeight: 1.45 }}>
-        The notification you tapped opened the PWA at this safe landing
-        page. The inbox-detail surface is not implemented yet; no
-        actions are available from this view.
-      </p>
-      <p style={{ margin: "0.75rem 0", lineHeight: 1.45, fontSize: "0.9rem" }}>
+
+      {state.phase === "loading" && (
+        <p data-testid="agent-control-inbox-loading">Loading inbox detail…</p>
+      )}
+
+      {state.phase === "ok" && (
+        <section
+          data-testid="agent-control-inbox-detail"
+          style={{ marginTop: "0.8rem" }}
+        >
+          <h2 style={{ fontSize: "1.05rem", margin: "0 0 0.4rem 0" }}>
+            {state.row.title || "Inbox row"}
+          </h2>
+          {state.row.summary && (
+            <p
+              data-testid="agent-control-inbox-summary"
+              style={{ margin: "0 0 0.6rem 0", lineHeight: 1.45 }}
+            >
+              {state.row.summary}
+            </p>
+          )}
+          <dl
+            data-testid="agent-control-inbox-detail-fields"
+            style={{
+              display: "grid",
+              gridTemplateColumns: "auto 1fr",
+              columnGap: "0.6rem",
+              rowGap: "0.25rem",
+              fontSize: "0.85rem",
+              margin: 0,
+            }}
+          >
+            <dt>event_kind</dt>
+            <dd data-testid="agent-control-inbox-detail-event-kind">
+              {state.row.event_kind}
+            </dd>
+            <dt>event_severity</dt>
+            <dd data-testid="agent-control-inbox-detail-event-severity">
+              {state.row.event_severity}
+            </dd>
+            <dt>attention_level</dt>
+            <dd data-testid="agent-control-inbox-detail-attention-level">
+              {state.row.attention_level}
+            </dd>
+            <dt>decision_state</dt>
+            <dd data-testid="agent-control-inbox-detail-decision-state">
+              {state.row.decision_state}
+            </dd>
+            <dt>source_module</dt>
+            <dd data-testid="agent-control-inbox-detail-source-module">
+              {state.row.source_module}
+            </dd>
+            <dt>created_at</dt>
+            <dd data-testid="agent-control-inbox-detail-created-at">
+              {state.row.created_at}
+            </dd>
+          </dl>
+        </section>
+      )}
+
+      {state.phase === "empty" && (
+        <p
+          data-testid="agent-control-inbox-empty"
+          style={{ margin: "0.75rem 0", lineHeight: 1.45 }}
+        >
+          No inbox detail is available for this event yet. The full inbox
+          surface is not implemented; the notification opened the PWA here
+          as a safe landing page.
+        </p>
+      )}
+
+      {state.phase === "idle" && (
+        <p
+          data-testid="agent-control-inbox-idle"
+          style={{ margin: "0.75rem 0", lineHeight: 1.45 }}
+        >
+          The notification you tapped opened the PWA at this safe landing
+          page. No actions are available from this view.
+        </p>
+      )}
+
+      <p
+        style={{
+          margin: "0.75rem 0",
+          lineHeight: 1.45,
+          fontSize: "0.9rem",
+        }}
+      >
         Approval still requires re-authentication in the PWA, never a
         notification tap.
       </p>

--- a/frontend/src/test/AgentControlInboxPlaceholder.test.tsx
+++ b/frontend/src/test/AgentControlInboxPlaceholder.test.tsx
@@ -5,21 +5,53 @@
  *   - The placeholder renders the bounded event_id query parameter.
  *   - The DOM contains NO decision verbs (approve / reject / merge /
  *     deploy) — neither as buttons, links, nor visible text.
- *   - The placeholder performs NO fetch / XMLHttpRequest /
- *     navigator.sendBeacon calls (strictly read-only).
+ *   - The placeholder performs at MOST one same-origin GET to the
+ *     read-only N3b detail endpoint, and never a POST / PUT / PATCH /
+ *     DELETE. No XMLHttpRequest, no navigator.sendBeacon.
+ *   - When the N3b API returns ``status: "ok"`` with a row, the
+ *     closed-schema scalars are rendered (event_kind, severity,
+ *     attention_level, decision_state, source_module, created_at).
+ *   - When the N3b API returns ``not_available`` / ``not_found`` /
+ *     network failure, the placeholder shows the safe-empty state.
+ *   - The read-only banner is always rendered.
  *   - A link back to /agent-control exists.
- *   - A long / hostile event_id is bounded and sanitised (no special
- *     chars, max 64 chars).
+ *   - A long / hostile event_id is bounded and sanitised.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 
 import { AgentControlInboxPlaceholder } from "../routes/AgentControl/InboxPlaceholder";
 
 const mockFetch = vi.fn();
 const mockSendBeacon = vi.fn();
+
+function jsonResponse(payload: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(payload), {
+    status: init.status ?? 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function row(event_id: string) {
+  return {
+    inbox_row_id: "row_" + event_id,
+    event_id,
+    event_kind: "intake_candidate_eligible",
+    event_severity: "push_info",
+    source_module: "notification_dispatch_outbox",
+    source_id: event_id,
+    endpoint_hash: "deadbeefdeadbeef",
+    outbound_delivery_intent: "sent",
+    attention_level: "informational",
+    decision_state: "pending",
+    title: "Inbox title for " + event_id,
+    summary: "A bounded inbox summary.",
+    open_at: `/agent-control/inbox?event=${event_id}`,
+    created_at: "2026-05-11T08:00:00Z",
+  };
+}
 
 beforeEach(() => {
   vi.stubGlobal("fetch", mockFetch);
@@ -46,54 +78,210 @@ function renderAt(path: string) {
   );
 }
 
-describe("AgentControlInboxPlaceholder — safe landing", () => {
-  it("renders the placeholder for /agent-control/inbox?event=...", () => {
-    renderAt("/agent-control/inbox?event=live_verify_20260511");
+// ---------------------------------------------------------------------------
+// Banner + structural elements
+// ---------------------------------------------------------------------------
+
+describe("AgentControlInboxPlaceholder — banner + structure", () => {
+  it("always renders the read-only banner", () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({ status: "not_available", reason: "missing" }, { status: 404 }),
+    );
+    renderAt("/agent-control/inbox?event=evt_safe");
     expect(
-      screen.getByTestId("agent-control-inbox-placeholder"),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByTestId("agent-control-inbox-event-id"),
-    ).toHaveTextContent("event_id: live_verify_20260511");
+      screen.getByTestId("agent-control-inbox-banner"),
+    ).toHaveTextContent(
+      /read-only inbox detail\. approval actions are not implemented/i,
+    );
   });
 
-  it("renders even when no event_id query parameter is present", () => {
-    renderAt("/agent-control/inbox");
-    expect(
-      screen.getByTestId("agent-control-inbox-placeholder"),
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByTestId("agent-control-inbox-event-id"),
-    ).not.toBeInTheDocument();
-  });
-
-  it("provides a link back to /agent-control", () => {
-    renderAt("/agent-control/inbox?event=abc");
+  it("always renders a link back to /agent-control", () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({ status: "not_available" }, { status: 404 }),
+    );
+    renderAt("/agent-control/inbox?event=evt_safe");
     const back = screen.getByTestId("agent-control-inbox-back-link");
     expect(back).toHaveAttribute("href", "/agent-control");
   });
+
+  it("renders the bounded event_id from the URL", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({ status: "not_available" }, { status: 404 }),
+    );
+    renderAt("/agent-control/inbox?event=evt_safe_marker");
+    expect(
+      screen.getByTestId("agent-control-inbox-event-id"),
+    ).toHaveTextContent("event_id: evt_safe_marker");
+  });
+
+  it("renders idle state when no event_id is present", () => {
+    renderAt("/agent-control/inbox");
+    // No event_id → no fetch is issued.
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(
+      screen.queryByTestId("agent-control-inbox-event-id"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId("agent-control-inbox-idle"),
+    ).toBeInTheDocument();
+  });
 });
 
-describe("AgentControlInboxPlaceholder — no decision verbs", () => {
-  it("DOM contains no approve / reject / merge / deploy verb", () => {
+// ---------------------------------------------------------------------------
+// N3b API integration — happy path
+// ---------------------------------------------------------------------------
+
+describe("AgentControlInboxPlaceholder — N3b detail render", () => {
+  it("fetches the read-only detail endpoint exactly once", async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ status: "ok", row: row("evt_one") }));
+    renderAt("/agent-control/inbox?event=evt_one");
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe("/api/agent-control/mobile-inbox/detail/evt_one");
+    expect((init as RequestInit | undefined)?.method ?? "GET").toBe("GET");
+    expect((init as RequestInit | undefined)?.credentials).toBe("same-origin");
+  });
+
+  it("renders the closed-schema scalars from the row", async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ status: "ok", row: row("evt_render") }));
+    renderAt("/agent-control/inbox?event=evt_render");
+    await waitFor(() =>
+      expect(screen.getByTestId("agent-control-inbox-detail")).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByTestId("agent-control-inbox-detail-event-kind"),
+    ).toHaveTextContent("intake_candidate_eligible");
+    expect(
+      screen.getByTestId("agent-control-inbox-detail-event-severity"),
+    ).toHaveTextContent("push_info");
+    expect(
+      screen.getByTestId("agent-control-inbox-detail-attention-level"),
+    ).toHaveTextContent("informational");
+    expect(
+      screen.getByTestId("agent-control-inbox-detail-decision-state"),
+    ).toHaveTextContent("pending");
+    expect(
+      screen.getByTestId("agent-control-inbox-detail-source-module"),
+    ).toHaveTextContent("notification_dispatch_outbox");
+    expect(
+      screen.getByTestId("agent-control-inbox-detail-created-at"),
+    ).toHaveTextContent("2026-05-11T08:00:00Z");
+    expect(
+      screen.getByTestId("agent-control-inbox-summary"),
+    ).toHaveTextContent("A bounded inbox summary.");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// N3b API integration — empty / not_available / not_found / network
+// ---------------------------------------------------------------------------
+
+describe("AgentControlInboxPlaceholder — safe empty states", () => {
+  it("renders empty state on not_available", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({ status: "not_available", reason: "missing" }, { status: 404 }),
+    );
+    renderAt("/agent-control/inbox?event=evt_x");
+    await waitFor(() =>
+      expect(screen.getByTestId("agent-control-inbox-empty")).toBeInTheDocument(),
+    );
+    expect(
+      screen.queryByTestId("agent-control-inbox-detail"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders empty state on not_found", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse(
+        { status: "not_found", reason: "no_matching_event_id" },
+        { status: 404 },
+      ),
+    );
+    renderAt("/agent-control/inbox?event=evt_missing");
+    await waitFor(() =>
+      expect(screen.getByTestId("agent-control-inbox-empty")).toBeInTheDocument(),
+    );
+  });
+
+  it("renders empty state on network failure", async () => {
+    mockFetch.mockRejectedValue(new Error("network"));
+    renderAt("/agent-control/inbox?event=evt_x");
+    await waitFor(() =>
+      expect(screen.getByTestId("agent-control-inbox-empty")).toBeInTheDocument(),
+    );
+  });
+
+  it("renders empty state on malformed body", async () => {
+    mockFetch.mockResolvedValue(
+      new Response("not json", {
+        status: 200,
+        headers: { "content-type": "text/plain" },
+      }),
+    );
+    renderAt("/agent-control/inbox?event=evt_x");
+    await waitFor(() =>
+      expect(screen.getByTestId("agent-control-inbox-empty")).toBeInTheDocument(),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No decision verbs / no action surface / no extra fetches
+// ---------------------------------------------------------------------------
+
+describe("AgentControlInboxPlaceholder — read-only invariants", () => {
+  it("DOM contains no approve / reject / merge / deploy verb", async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ status: "ok", row: row("evt_safe") }));
     renderAt("/agent-control/inbox?event=evt_safe");
+    await waitFor(() =>
+      expect(screen.getByTestId("agent-control-inbox-detail")).toBeInTheDocument(),
+    );
     const root = screen.getByTestId("agent-control-inbox-placeholder");
     const text = (root.textContent || "").toLowerCase();
-    // Whole-word matches — must not appear anywhere in visible text.
     expect(text).not.toMatch(/\bapprove\b/);
     expect(text).not.toMatch(/\breject\b/);
     expect(text).not.toMatch(/\bmerge\b/);
     expect(text).not.toMatch(/\bdeploy\b/);
   });
 
-  it("contains no action buttons", () => {
+  it("contains no action buttons", async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ status: "ok", row: row("evt_safe") }));
     renderAt("/agent-control/inbox?event=evt_safe");
+    await waitFor(() =>
+      expect(screen.getByTestId("agent-control-inbox-detail")).toBeInTheDocument(),
+    );
     const buttons = screen.queryAllByRole("button");
     expect(buttons).toHaveLength(0);
   });
 
-  it("reaffirms approval requires re-authentication", () => {
+  it("issues exactly one same-origin GET (no other fetch)", async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ status: "ok", row: row("evt_safe") }));
     renderAt("/agent-control/inbox?event=evt_safe");
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+    // Pin the URL prefix and method shape.
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(String(url)).toMatch(
+      /^\/api\/agent-control\/mobile-inbox\/detail\//,
+    );
+    const method = (init as RequestInit | undefined)?.method ?? "GET";
+    expect(["GET", "HEAD"]).toContain(method);
+  });
+
+  it("does not call navigator.sendBeacon", async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ status: "ok", row: row("evt_safe") }));
+    renderAt("/agent-control/inbox?event=evt_safe");
+    await waitFor(() =>
+      expect(screen.getByTestId("agent-control-inbox-detail")).toBeInTheDocument(),
+    );
+    expect(mockSendBeacon).not.toHaveBeenCalled();
+  });
+
+  it("reaffirms approval requires re-authentication", async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ status: "ok", row: row("evt_safe") }));
+    renderAt("/agent-control/inbox?event=evt_safe");
+    await waitFor(() =>
+      expect(screen.getByTestId("agent-control-inbox-detail")).toBeInTheDocument(),
+    );
     const root = screen.getByTestId("agent-control-inbox-placeholder");
     expect(
       (root.textContent || "").toLowerCase(),
@@ -101,20 +289,15 @@ describe("AgentControlInboxPlaceholder — no decision verbs", () => {
   });
 });
 
-describe("AgentControlInboxPlaceholder — strictly read-only", () => {
-  it("does not call fetch at any point during render", () => {
-    renderAt("/agent-control/inbox?event=evt_safe");
-    expect(mockFetch).not.toHaveBeenCalled();
-  });
-
-  it("does not call navigator.sendBeacon", () => {
-    renderAt("/agent-control/inbox?event=evt_safe");
-    expect(mockSendBeacon).not.toHaveBeenCalled();
-  });
-});
+// ---------------------------------------------------------------------------
+// event_id sanitisation
+// ---------------------------------------------------------------------------
 
 describe("AgentControlInboxPlaceholder — event_id sanitisation", () => {
   it("strips characters outside [A-Za-z0-9_-]", () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({ status: "not_available" }, { status: 404 }),
+    );
     renderAt("/agent-control/inbox?event=abc%20<script>def");
     const eventEl = screen.queryByTestId("agent-control-inbox-event-id");
     expect(eventEl?.textContent || "").not.toMatch(/<script>/);
@@ -122,6 +305,9 @@ describe("AgentControlInboxPlaceholder — event_id sanitisation", () => {
   });
 
   it("bounds the event_id to 64 characters", () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({ status: "not_available" }, { status: 404 }),
+    );
     const huge = "x".repeat(500);
     renderAt(`/agent-control/inbox?event=${huge}`);
     const eventEl = screen.queryByTestId("agent-control-inbox-event-id");
@@ -130,13 +316,13 @@ describe("AgentControlInboxPlaceholder — event_id sanitisation", () => {
   });
 });
 
-describe("AgentControlInboxPlaceholder — also handles non-inbox sub-paths", () => {
-  it("falls back to a bland heading for /agent-control/unknown", () => {
+describe("AgentControlInboxPlaceholder — non-inbox sub-paths", () => {
+  it("renders bland heading for /agent-control/unknown without fetching", () => {
     renderAt("/agent-control/unknown");
+    expect(mockFetch).not.toHaveBeenCalled();
     expect(
       screen.getByTestId("agent-control-inbox-placeholder"),
     ).toBeInTheDocument();
-    // No event_id when not on /inbox
     expect(
       screen.queryByTestId("agent-control-inbox-event-id"),
     ).not.toBeInTheDocument();

--- a/tests/unit/test_api_mobile_approval_inbox.py
+++ b/tests/unit/test_api_mobile_approval_inbox.py
@@ -1,0 +1,450 @@
+"""Unit tests for N3b — dashboard.api_mobile_approval_inbox (UNWIRED).
+
+Pins:
+* exactly 2 GET routes registered: list + detail; no other HTTP
+  method is registered;
+* list with missing artifact → ``not_available`` envelope;
+* list with valid artifact → bounded rows + counts;
+* detail with missing artifact → 404 ``not_available``;
+* detail with valid artifact but unknown event_id → 404 ``not_found``;
+* detail with valid event_id → 200 with exactly one row;
+* invalid event_id (empty / too long / bad charset) → 400
+  ``invalid_event_id``;
+* AST + source-text scans: no ``subprocess`` / ``gh`` / ``git`` /
+  ``pywebpush`` / ``WEB_PUSH_VAPID_PRIVATE_KEY`` / approval-token
+  helpers / decision-verb call patterns;
+* ``dashboard/dashboard.py`` does NOT yet import the new blueprint
+  (skip-or-enforce dual mode — operator step);
+* Step 5 invariants unchanged by import.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from flask import Flask
+
+from dashboard import api_mobile_approval_inbox as amai
+from reporting import mobile_approval_inbox as mai
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolate_artifact(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect ARTIFACT_LATEST into ``tmp_path`` so tests never read or
+    write the developer's logs/ directory."""
+    target = tmp_path / "logs" / "mobile_approval_inbox" / "latest.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(mai, "ARTIFACT_LATEST", target)
+    return target
+
+
+def _make_app() -> Flask:
+    app = Flask(__name__)
+    amai.register_mobile_approval_inbox_routes(app)
+    return app
+
+
+def _valid_row(event_id: str = "evt_abc12345abc12345") -> dict[str, Any]:
+    return {
+        "inbox_row_id": "row_" + event_id,
+        "event_id": event_id,
+        "event_kind": "intake_candidate_eligible",
+        "event_severity": "push_info",
+        "source_module": "notification_dispatch_outbox",
+        "source_id": event_id,
+        "endpoint_hash": "deadbeefdeadbeef",
+        "outbound_delivery_intent": "sent",
+        "attention_level": "informational",
+        "decision_state": "pending",
+        "title": "Some inbox title",
+        "summary": "A bounded inbox summary.",
+        "open_at": f"/agent-control/inbox?event={event_id}",
+        "created_at": "2026-05-11T08:00:00Z",
+    }
+
+
+def _write_artifact(artifact_path: Path, rows: list[dict[str, Any]]) -> None:
+    payload = {
+        "schema_version": mai.SCHEMA_VERSION,
+        "module_version": mai.MODULE_VERSION,
+        "report_kind": mai.REPORT_KIND,
+        "generated_at_utc": "2026-05-11T08:30:00Z",
+        "rows": rows,
+    }
+    artifact_path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Route registration
+# ---------------------------------------------------------------------------
+
+
+def test_register_routes_registers_only_two_get_routes() -> None:
+    app = _make_app()
+    rules = sorted(
+        (rule.rule, frozenset(rule.methods or set()))
+        for rule in app.url_map.iter_rules()
+        if rule.rule.startswith("/api/agent-control/mobile-inbox/")
+    )
+    assert rules == [
+        (
+            "/api/agent-control/mobile-inbox/detail/<string:event_id>",
+            frozenset({"GET", "HEAD", "OPTIONS"}),
+        ),
+        (
+            "/api/agent-control/mobile-inbox/list",
+            frozenset({"GET", "HEAD", "OPTIONS"}),
+        ),
+    ]
+
+
+def test_no_mutating_routes_registered() -> None:
+    app = _make_app()
+    for rule in app.url_map.iter_rules():
+        if rule.rule.startswith("/api/agent-control/mobile-inbox/"):
+            methods = rule.methods or set()
+            assert not (methods & {"POST", "PUT", "PATCH", "DELETE"}), (
+                f"unexpected mutating method on {rule.rule}: {methods}"
+            )
+
+
+def test_blueprint_not_yet_wired_into_dashboard_dashboard() -> None:
+    """Operator step pending: dashboard.py must not yet import the new
+    blueprint. Once wired, the strict pin tests in
+    test_dashboard_dashboard_one_line_wiring.py will assert the exact
+    two-line shape."""
+    text = (REPO_ROOT / "dashboard" / "dashboard.py").read_text(
+        encoding="utf-8"
+    )
+    wiring_present = (
+        "from dashboard.api_mobile_approval_inbox import register_mobile_approval_inbox_routes"
+        in text
+    )
+    register_present = "register_mobile_approval_inbox_routes(app)" in text
+    assert wiring_present == register_present, (
+        "dashboard.py must contain BOTH the import and the register "
+        "call for api_mobile_approval_inbox, or NEITHER."
+    )
+
+
+# ---------------------------------------------------------------------------
+# List endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_list_missing_artifact_returns_not_available() -> None:
+    app = _make_app()
+    client = app.test_client()
+    res = client.get("/api/agent-control/mobile-inbox/list")
+    assert res.status_code == 200
+    body = res.get_json()
+    assert body["status"] == "not_available"
+    assert body["counts"]["rows"] == 0
+    assert body["rows"] == []
+
+
+def test_list_valid_artifact_returns_bounded_rows(
+    _isolate_artifact: Path,
+) -> None:
+    rows = [_valid_row(f"evt_{i:08d}") for i in range(3)]
+    _write_artifact(_isolate_artifact, rows)
+    app = _make_app()
+    res = app.test_client().get("/api/agent-control/mobile-inbox/list")
+    body = res.get_json()
+    assert body["status"] == "ok"
+    assert body["counts"]["rows"] == 3
+    assert len(body["rows"]) == 3
+    assert body["rows"][0]["event_id"] == "evt_00000000"
+
+
+def test_list_envelope_carries_step5_invariants(
+    _isolate_artifact: Path,
+) -> None:
+    _write_artifact(_isolate_artifact, [_valid_row()])
+    app = _make_app()
+    body = app.test_client().get(
+        "/api/agent-control/mobile-inbox/list"
+    ).get_json()
+    assert body["step5_implementation_allowed"] is False
+    assert body["step5_enabled_substage"] == "none"
+
+
+def test_list_malformed_artifact_returns_not_available(
+    _isolate_artifact: Path,
+) -> None:
+    _isolate_artifact.write_text("not json", encoding="utf-8")
+    app = _make_app()
+    res = app.test_client().get("/api/agent-control/mobile-inbox/list")
+    body = res.get_json()
+    assert body["status"] == "not_available"
+    assert "malformed" in body["reason"]
+
+
+def test_list_artifact_with_invalid_row_shapes_is_filtered(
+    _isolate_artifact: Path,
+) -> None:
+    rows: list[dict[str, Any]] = [
+        _valid_row("evt_keep"),
+        {"event_id": "evt_partial"},  # missing required keys
+    ]
+    _write_artifact(_isolate_artifact, rows)
+    res = _make_app().test_client().get(
+        "/api/agent-control/mobile-inbox/list"
+    )
+    body = res.get_json()
+    assert [r["event_id"] for r in body["rows"]] == ["evt_keep"]
+
+
+# ---------------------------------------------------------------------------
+# Detail endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_detail_missing_artifact_returns_404_not_available() -> None:
+    app = _make_app()
+    res = app.test_client().get(
+        "/api/agent-control/mobile-inbox/detail/evt_abc"
+    )
+    assert res.status_code == 404
+    body = res.get_json()
+    assert body["status"] == "not_available"
+
+
+def test_detail_unknown_event_id_returns_404_not_found(
+    _isolate_artifact: Path,
+) -> None:
+    _write_artifact(_isolate_artifact, [_valid_row("evt_existing")])
+    app = _make_app()
+    res = app.test_client().get(
+        "/api/agent-control/mobile-inbox/detail/evt_nope"
+    )
+    assert res.status_code == 404
+    body = res.get_json()
+    assert body["status"] == "not_found"
+
+
+def test_detail_valid_event_id_returns_exact_row(
+    _isolate_artifact: Path,
+) -> None:
+    rows = [
+        _valid_row("evt_first"),
+        _valid_row("evt_second"),
+        _valid_row("evt_third"),
+    ]
+    _write_artifact(_isolate_artifact, rows)
+    app = _make_app()
+    res = app.test_client().get(
+        "/api/agent-control/mobile-inbox/detail/evt_second"
+    )
+    assert res.status_code == 200
+    body = res.get_json()
+    assert body["status"] == "ok"
+    assert body["row"]["event_id"] == "evt_second"
+    # The row is the closed N3a schema — no decision verb in payload.
+    for v in body["row"].values():
+        if isinstance(v, str):
+            lv = v.lower()
+            assert "approve" not in lv
+            assert "reject" not in lv
+            assert "deploy" not in lv
+
+
+def test_detail_invalid_event_id_too_long_returns_400(
+    _isolate_artifact: Path,
+) -> None:
+    _write_artifact(_isolate_artifact, [_valid_row()])
+    app = _make_app()
+    big = "x" * 200
+    res = app.test_client().get(
+        f"/api/agent-control/mobile-inbox/detail/{big}"
+    )
+    assert res.status_code == 400
+    body = res.get_json()
+    assert body["status"] == "invalid_event_id"
+    assert body["reason"] == "too_long"
+
+
+def test_detail_invalid_event_id_bad_charset_returns_400(
+    _isolate_artifact: Path,
+) -> None:
+    _write_artifact(_isolate_artifact, [_valid_row()])
+    app = _make_app()
+    # Flask path parameter does not accept '/' but allows ' '
+    # via URL encoding. We assert that something outside [A-Za-z0-9_-]
+    # is rejected.
+    res = app.test_client().get(
+        "/api/agent-control/mobile-inbox/detail/bad%20event"
+    )
+    assert res.status_code == 400
+    body = res.get_json()
+    assert body["status"] == "invalid_event_id"
+    assert body["reason"] == "bad_charset"
+
+
+def test_detail_envelope_carries_step5_invariants(
+    _isolate_artifact: Path,
+) -> None:
+    _write_artifact(_isolate_artifact, [_valid_row("evt_x")])
+    body = _make_app().test_client().get(
+        "/api/agent-control/mobile-inbox/detail/evt_x"
+    ).get_json()
+    assert body["step5_implementation_allowed"] is False
+    assert body["step5_enabled_substage"] == "none"
+
+
+# ---------------------------------------------------------------------------
+# Response payload safety: no endpoint URL leak, no key material
+# ---------------------------------------------------------------------------
+
+
+def test_response_payload_has_no_endpoint_url_or_key_material(
+    _isolate_artifact: Path,
+) -> None:
+    """The N3a artefact already redacts these; we re-assert at the API
+    boundary that the response carries only the closed scalars and
+    never a raw subscription endpoint URL or key bytes."""
+    _write_artifact(_isolate_artifact, [_valid_row()])
+    res = _make_app().test_client().get(
+        "/api/agent-control/mobile-inbox/list"
+    )
+    raw = res.data.decode("utf-8")
+    assert "fcm.googleapis.com" not in raw
+    assert "p256dh" not in raw
+    assert "BEGIN PRIVATE KEY" not in raw
+
+
+# ---------------------------------------------------------------------------
+# Source-text + AST scans
+# ---------------------------------------------------------------------------
+
+
+def _module_source() -> str:
+    return Path(amai.__file__).read_text(encoding="utf-8")
+
+
+def _imported_module_names() -> set[str]:
+    tree = ast.parse(_module_source())
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module is not None:
+                names.add(node.module)
+    return names
+
+
+def test_no_subprocess_in_module() -> None:
+    src = _module_source()
+    assert "import subprocess" not in src
+    assert "from subprocess" not in src
+
+
+def test_no_gh_or_git_in_module() -> None:
+    src = _module_source()
+    for needle in ("subprocess.run", "subprocess.call", " gh ", " git "):
+        assert needle not in src, needle
+
+
+def test_no_web_push_library_import_in_module() -> None:
+    names = _imported_module_names()
+    for n in names:
+        assert n not in {"pywebpush", "webpush", "web_push"}, n
+        assert not n.startswith("pywebpush."), n
+
+
+def test_no_vapid_private_key_literal_in_module() -> None:
+    src = _module_source()
+    assert "WEB_PUSH_VAPID_PRIVATE_KEY" not in src
+
+
+def test_no_token_mint_helpers_in_module() -> None:
+    src = _module_source().lower()
+    for needle in (
+        "mint_approval_token",
+        "approval_token_mint",
+        "verify_approval_token",
+        "approval_token_gate",
+    ):
+        assert needle not in src, needle
+
+
+def test_no_decision_verb_call_in_module() -> None:
+    src = _module_source().lower()
+    for verb in ("approve(", "reject(", "merge(", "deploy("):
+        assert verb not in src, verb
+
+
+def test_no_seed_jsonl_writes_in_module() -> None:
+    src = _module_source()
+    for forbidden in (
+        "seed.jsonl",
+        "delegation_seed.jsonl",
+        "generated_seed.jsonl",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_imports_only_mai_aas_flask_and_stdlib() -> None:
+    """The blueprint must import only the N3a projector module, the
+    secret-redactor guard, and Flask. No other reporting module."""
+    names = _imported_module_names()
+    allowed_reporting = {
+        "reporting",
+        "reporting.mobile_approval_inbox",
+        "reporting.agent_audit_summary",
+    }
+    for n in names:
+        if n == "reporting" or n.startswith("reporting."):
+            assert n in allowed_reporting, n
+
+
+def test_no_forbidden_module_imports() -> None:
+    forbidden_prefixes = (
+        "automation",
+        "broker",
+        "agent.risk",
+        "agent.execution",
+        "research",
+        "reporting.intelligent_routing",
+        "live",
+        "paper",
+        "shadow",
+        "trading",
+    )
+    for module in _imported_module_names():
+        for prefix in forbidden_prefixes:
+            assert module != prefix, module
+            assert not module.startswith(prefix + "."), module
+
+
+# ---------------------------------------------------------------------------
+# Step 5 invariants
+# ---------------------------------------------------------------------------
+
+
+def test_import_does_not_flip_step5_invariants() -> None:
+    importlib.reload(amai)
+    assert amai.step5_implementation_allowed is False
+    assert amai.STEP5_ENABLED_SUBSTAGE == "none"
+
+
+def test_module_source_pins_step5_invariants() -> None:
+    src = _module_source()
+    assert "step5_implementation_allowed: Final[bool] = False" in src
+    assert 'STEP5_ENABLED_SUBSTAGE: Final[str] = "none"' in src
+    assert "step5_implementation_allowed = True" not in src

--- a/tests/unit/test_dashboard_dashboard_one_line_wiring.py
+++ b/tests/unit/test_dashboard_dashboard_one_line_wiring.py
@@ -326,6 +326,70 @@ def test_dispatch_wiring_no_other_dashboard_dashboard_modifications() -> None:
 
 
 # ---------------------------------------------------------------------------
+# N3b mobile-approval-inbox wiring conditional pins (skip-or-enforce)
+# ---------------------------------------------------------------------------
+#
+# Same dual-mode pattern as the N2b-3b dispatch wiring above. Until
+# the operator adds the two-line
+# ``register_mobile_approval_inbox_routes(app)`` diff, these pins
+# return early. Once added, they enforce the exact wiring shape.
+# The blueprint at ``dashboard/api_mobile_approval_inbox.py`` is
+# READ-ONLY and exposes only GET routes; runtime delivery still
+# requires (a) the existing PWA session middleware and (b) the
+# operator wiring this blueprint into ``dashboard/dashboard.py``.
+
+EXPECTED_MOBILE_INBOX_IMPORT_LINE = (
+    "from dashboard.api_mobile_approval_inbox "
+    "import register_mobile_approval_inbox_routes"
+)
+EXPECTED_MOBILE_INBOX_REGISTER_CALL = (
+    "register_mobile_approval_inbox_routes(app)"
+)
+
+
+def _mobile_inbox_wiring_present() -> bool:
+    text = _dashboard_text()
+    return (
+        EXPECTED_MOBILE_INBOX_IMPORT_LINE in text
+        and EXPECTED_MOBILE_INBOX_REGISTER_CALL in text
+    )
+
+
+def test_mobile_inbox_wiring_exactly_one_import_and_one_register_call() -> None:
+    if not _mobile_inbox_wiring_present():
+        # Operator has not yet added the two-line diff. Conditional
+        # pin returns early; the test still passes. Once the operator
+        # commits the wiring, this branch is no longer taken and the
+        # assertions below fire.
+        return
+    text = _dashboard_text()
+    assert text.count(EXPECTED_MOBILE_INBOX_IMPORT_LINE) == 1, (
+        "dashboard.py must contain exactly one new mobile-inbox "
+        "import line"
+    )
+    assert text.count(EXPECTED_MOBILE_INBOX_REGISTER_CALL) == 1, (
+        "dashboard.py must contain exactly one new mobile-inbox "
+        "register call"
+    )
+
+
+def test_mobile_inbox_wiring_no_other_dashboard_dashboard_modifications() -> None:
+    if not _mobile_inbox_wiring_present():
+        return
+    text = _dashboard_text()
+    mobile_inbox_lines = [
+        line
+        for line in text.splitlines()
+        if "register_mobile_approval_inbox" in line
+        or "api_mobile_approval_inbox" in line
+    ]
+    assert len(mobile_inbox_lines) == 2, (
+        f"dashboard.py must contain exactly 2 mobile-inbox lines; "
+        f"found {len(mobile_inbox_lines)}: {mobile_inbox_lines}"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Companion doc invariants (always on)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Turns the existing N3a `mobile_approval_inbox` projector into an operator-facing **read-only** inbox surface. Two pieces:

- **N3b** — new GET-only Flask blueprint at [dashboard/api_mobile_approval_inbox.py](dashboard/api_mobile_approval_inbox.py) exposing `list` + `detail/<event_id>` over the existing N3a artefact at `logs/mobile_approval_inbox/latest.json`.
- **N3c** — extends the PWA inbox placeholder at [frontend/src/routes/AgentControl/InboxPlaceholder.tsx](frontend/src/routes/AgentControl/InboxPlaceholder.tsx) to fetch the read-only detail endpoint on mount and render the closed-schema scalars.

The blueprint is intentionally **NOT wired into `dashboard/dashboard.py`** in this PR — wiring is the operator's two-line diff in a follow-up PR (same pattern as N2b-2b / PR #184). Until then, the placeholder gracefully falls back to its safe-empty state on the unreachable route (Flask catch-all 404 → placeholder shows the bland \"no inbox detail available\" message).

## Diff scope (exactly 5 files)

| File | Change |
|------|--------|
| [dashboard/api_mobile_approval_inbox.py](dashboard/api_mobile_approval_inbox.py) | new GET-only blueprint (318 LOC) |
| [frontend/src/routes/AgentControl/InboxPlaceholder.tsx](frontend/src/routes/AgentControl/InboxPlaceholder.tsx) | adds the read-only detail fetch + closed-schema render + safe-empty state + always-on banner |
| [frontend/src/test/AgentControlInboxPlaceholder.test.tsx](frontend/src/test/AgentControlInboxPlaceholder.test.tsx) | rewrites PR #185 tests to allow exactly one same-origin GET; +7 new tests for the N3b integration |
| [tests/unit/test_api_mobile_approval_inbox.py](tests/unit/test_api_mobile_approval_inbox.py) | new strict suite (26 assertions) |
| [tests/unit/test_dashboard_dashboard_one_line_wiring.py](tests/unit/test_dashboard_dashboard_one_line_wiring.py) | appends skip-or-enforce wiring pins for the new blueprint (mirror of the N2b-3b dispatch-wiring pattern) |

## Surface contract

| Method | Path | Behaviour |
|--------|------|-----------|
| GET | `/api/agent-control/mobile-inbox/list` | bounded rows + counts, or `not_available` envelope when the artefact is missing/malformed |
| GET | `/api/agent-control/mobile-inbox/detail/<event_id>` | 200 + closed-schema row, or 404 `not_found` / `not_available`, or 400 `invalid_event_id` (empty / too long / bad charset) |

Every response is run through `assert_no_secrets`. Responses contain only the closed N3a 14-key per-row schema — no endpoint URLs, no key material, no decision verbs.

## Hard invariants preserved
- `step5_implementation_allowed = False`, `STEP5_ENABLED_SUBSTAGE = \"none\"` — unchanged
- Level 6 permanently disabled — governance-lint green
- `dashboard/dashboard.py` UNTOUCHED — operator wiring step deferred to follow-up PR
- [dashboard/api_push_dispatch.py](dashboard/api_push_dispatch.py), [reporting/web_push_real_transport.py](reporting/web_push_real_transport.py), [frontend/public/sw-push.js](frontend/public/sw-push.js), `.gitleaks.toml`, `.claude/**` — unchanged
- No QRE / research / live / paper / shadow / risk / broker / execution / orchestration / automation / trading changes
- No approval-token mint (N4 territory remains future)
- No inbox-row mutation — N3a remains the only writer of the upstream artefact
- No merge / deploy / token-triggered action — blueprint is GET-only, placeholder has zero buttons

## Test plan (all green locally)
- [x] `python scripts/governance_lint.py` → OK (16 agents, 5 workflows)
- [x] `python -m pytest tests/smoke -q` → 18 passed
- [x] `python -m pytest tests/unit/test_api_mobile_approval_inbox.py tests/unit/test_mobile_approval_inbox.py tests/unit/test_dashboard_dashboard_one_line_wiring.py tests/unit/test_api_push_dispatch.py tests/unit/test_web_push_real_transport.py tests/unit/test_dashboard_agent_control_spa_fallback.py -q` → 175 passed
- [x] `npm --prefix frontend run build` → clean
- [x] `npm --prefix frontend run test` → 170 passed (13 test files)
- [x] `python -m reporting.development_step5_loop --no-write` → invariants intact
- [x] `python -m reporting.development_operational_digest --no-write` → invariants intact

## Operator follow-up

A future operator PR (the same 2-line wiring pattern used in PR #184) will add to [dashboard/dashboard.py](dashboard/dashboard.py):

```diff
+from dashboard.api_mobile_approval_inbox import register_mobile_approval_inbox_routes
 ...
+register_mobile_approval_inbox_routes(app)
```

Once wired, the strict skip-or-enforce pins in [tests/unit/test_dashboard_dashboard_one_line_wiring.py](tests/unit/test_dashboard_dashboard_one_line_wiring.py) refuse any subsequent edit that drops, duplicates, or reorders those two lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)