### PR TITLE
feat(notif): N4b — runtime approval-token gate (env-gated, unwired)

### DIFF
--- a/dashboard/api_approval_token_gate.py
+++ b/dashboard/api_approval_token_gate.py
@@ -1,0 +1,424 @@
+"""N4b — Approval Token Gate API blueprint (session-protected, UNWIRED).
+
+Session-protected Flask blueprint that exposes mint / verify / status
+for the runtime approval-token gate. The blueprint is intentionally
+**NOT wired into ``dashboard/dashboard.py``** in this PR; wiring is
+the operator's two-line diff (per ``execution_authority.md``).
+
+Hard guarantees (pinned by tests)
+---------------------------------
+
+* The blueprint registers exactly three routes:
+
+    POST /api/agent-control/approval-token/mint
+    POST /api/agent-control/approval-token/verify
+    GET  /api/agent-control/approval-token/status
+
+  No other HTTP method is registered. No mutating route exists
+  beyond mint + verify; the verify endpoint records the nonce but
+  performs NO underlying approve / reject / merge / deploy action.
+
+* Each route requires an operator session (``session["operator_authenticated"]
+  is True``). Missing session → HTTP 401 ``operator_session_required``.
+
+* The mint and verify routes refuse to operate unless
+  ``approval_token_runtime.is_configured()`` returns True. Missing
+  env → HTTP 503 ``configuration_missing``. The status route is
+  always reachable (it reports the configured / unconfigured state).
+
+* Request body > :data:`_MAX_REQUEST_BYTES` (4 KiB) → HTTP 413.
+
+* Never executes a CLI subprocess, never invokes ``gh`` / ``git``,
+  never opens its own network socket, never imports a Web Push
+  library, never reads the VAPID private-key env var.
+
+* Every response payload is run through
+  ``reporting.agent_audit_summary.assert_no_secrets`` before send.
+  The HMAC secret never appears in any response, audit log, or
+  printed line.
+
+* The mint response carries the minted token string for the
+  operator session that requested it. The token is sensitive but
+  not a long-term secret (it is short-TTL, single-use, bound to
+  the event_id). It travels back over the existing session-
+  protected HTTPS channel.
+
+* No approval / reject / merge / deploy decision verb call appears
+  in any code path. The verify endpoint returns the outcome only;
+  acting on the verified token is N5 territory.
+
+Authentication
+--------------
+
+Auth is provided by ``flask.session["operator_authenticated"]``,
+set by the existing ``/api/session/login`` endpoint in
+``dashboard/dashboard.py``. The blueprint does not register any
+auth itself.
+
+The route is reachable from the PWA (which authenticates via
+``/api/session/login``) and from the operator's curl invocations on
+the VPS host (the PWA session cookie is the only credential).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+from flask import Flask, Response, jsonify, request, session
+
+from reporting import approval_token_runtime as atr
+from reporting.agent_audit_summary import assert_no_secrets
+
+MODULE_VERSION: Final[str] = "v3.15.16.N4b"
+SCHEMA_VERSION: Final[int] = 1
+
+
+# ---------------------------------------------------------------------------
+# Step 5 invariants
+# ---------------------------------------------------------------------------
+
+STEP5_ENABLED_SUBSTAGE: Final[str] = "none"
+step5_implementation_allowed: Final[bool] = False
+
+
+# ---------------------------------------------------------------------------
+# Bounded body cap
+# ---------------------------------------------------------------------------
+
+#: Maximum JSON body size accepted by mint/verify. The bodies are
+#: small structured envelopes (event_id + intent + bindings); 4 KiB
+#: is a generous cap that still bounds the surface.
+_MAX_REQUEST_BYTES: Final[int] = 4 * 1024
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _safe_jsonify(payload: dict[str, Any]) -> Response:
+    assert_no_secrets(payload)
+    return jsonify(payload)
+
+
+def _has_operator_session() -> bool:
+    """Return True iff the Flask session carries the
+    ``operator_authenticated`` flag set by ``/api/session/login``."""
+    try:
+        return bool(session.get("operator_authenticated"))
+    except Exception:
+        return False
+
+
+def _read_body() -> dict[str, Any] | None:
+    """Read the JSON body. Returns ``None`` on any failure."""
+    try:
+        raw = request.get_json(force=False, silent=True)
+    except Exception:
+        return None
+    return raw if isinstance(raw, dict) else None
+
+
+def _too_large() -> bool:
+    return (
+        request.content_length is not None
+        and request.content_length > _MAX_REQUEST_BYTES
+    )
+
+
+# ---------------------------------------------------------------------------
+# View functions
+# ---------------------------------------------------------------------------
+
+
+def _view_status() -> Response | tuple[Response, int]:
+    """GET /api/agent-control/approval-token/status."""
+    if not _has_operator_session():
+        return (
+            _safe_jsonify(
+                {
+                    "kind": "approval_token_status",
+                    "schema_version": SCHEMA_VERSION,
+                    "module_version": MODULE_VERSION,
+                    "status": "error",
+                    "error": "operator_session_required",
+                }
+            ),
+            401,
+        )
+    return _safe_jsonify(
+        {
+            "kind": "approval_token_status",
+            "schema_version": SCHEMA_VERSION,
+            "module_version": MODULE_VERSION,
+            "status": "ok",
+            "is_configured": atr.is_configured(),
+            "current_kid": atr.current_kid(),
+            "step5_implementation_allowed": step5_implementation_allowed,
+            "step5_enabled_substage": STEP5_ENABLED_SUBSTAGE,
+        }
+    )
+
+
+def _view_mint() -> Response | tuple[Response, int]:
+    """POST /api/agent-control/approval-token/mint."""
+    if not _has_operator_session():
+        return (
+            _safe_jsonify(
+                {"status": "error", "error": "operator_session_required"}
+            ),
+            401,
+        )
+    if _too_large():
+        return (
+            _safe_jsonify({"status": "error", "error": "payload_too_large"}),
+            413,
+        )
+    if not atr.is_configured():
+        return (
+            _safe_jsonify(
+                {"status": "error", "error": "configuration_missing"}
+            ),
+            503,
+        )
+    body = _read_body()
+    if body is None:
+        return (
+            _safe_jsonify(
+                {"status": "error", "error": "invalid_json_body"}
+            ),
+            400,
+        )
+    intent = body.get("intent")
+    event_id = body.get("event_id")
+    evidence_hash = body.get("evidence_hash")
+    pr_number = body.get("pr_number")
+    pr_head_sha = body.get("pr_head_sha")
+    release_tag = body.get("release_tag")
+    if not isinstance(intent, str):
+        return (
+            _safe_jsonify(
+                {"status": "error", "error": "intent_must_be_string"}
+            ),
+            400,
+        )
+    if not isinstance(event_id, str):
+        return (
+            _safe_jsonify(
+                {"status": "error", "error": "event_id_must_be_string"}
+            ),
+            400,
+        )
+    if not isinstance(evidence_hash, str):
+        return (
+            _safe_jsonify(
+                {"status": "error", "error": "evidence_hash_must_be_string"}
+            ),
+            400,
+        )
+    if pr_number is not None and not isinstance(pr_number, int):
+        return (
+            _safe_jsonify(
+                {"status": "error", "error": "pr_number_must_be_int_or_null"}
+            ),
+            400,
+        )
+    if pr_head_sha is not None and not isinstance(pr_head_sha, str):
+        return (
+            _safe_jsonify(
+                {
+                    "status": "error",
+                    "error": "pr_head_sha_must_be_string_or_null",
+                }
+            ),
+            400,
+        )
+    if release_tag is not None and not isinstance(release_tag, str):
+        return (
+            _safe_jsonify(
+                {
+                    "status": "error",
+                    "error": "release_tag_must_be_string_or_null",
+                }
+            ),
+            400,
+        )
+    envelope = atr.mint_runtime(
+        intent=intent,
+        event_id=event_id,
+        pr_number=pr_number,
+        pr_head_sha=pr_head_sha,
+        evidence_hash=evidence_hash,
+        release_tag=release_tag,
+    )
+    # Surface the closed mint-result envelope. Non-ok statuses are
+    # mapped to a non-200 HTTP code so the PWA can distinguish them.
+    status_code = 200 if envelope.get("status") == "ok" else 400
+    return _safe_jsonify(envelope), status_code
+
+
+def _view_verify() -> Response | tuple[Response, int]:
+    """POST /api/agent-control/approval-token/verify."""
+    if not _has_operator_session():
+        return (
+            _safe_jsonify(
+                {"status": "error", "error": "operator_session_required"}
+            ),
+            401,
+        )
+    if _too_large():
+        return (
+            _safe_jsonify({"status": "error", "error": "payload_too_large"}),
+            413,
+        )
+    if not atr.is_configured():
+        return (
+            _safe_jsonify(
+                {"status": "error", "error": "configuration_missing"}
+            ),
+            503,
+        )
+    body = _read_body()
+    if body is None:
+        return (
+            _safe_jsonify(
+                {"status": "error", "error": "invalid_json_body"}
+            ),
+            400,
+        )
+    token = body.get("token")
+    expected_event_id = body.get("expected_event_id")
+    expected_evidence_hash = body.get("expected_evidence_hash")
+    expected_pr_number = body.get("expected_pr_number")
+    expected_pr_head_sha = body.get("expected_pr_head_sha")
+    expected_release_tag = body.get("expected_release_tag")
+    if not isinstance(token, str):
+        return (
+            _safe_jsonify(
+                {"status": "error", "error": "token_must_be_string"}
+            ),
+            400,
+        )
+    if not isinstance(expected_event_id, str):
+        return (
+            _safe_jsonify(
+                {
+                    "status": "error",
+                    "error": "expected_event_id_must_be_string",
+                }
+            ),
+            400,
+        )
+    if not isinstance(expected_evidence_hash, str):
+        return (
+            _safe_jsonify(
+                {
+                    "status": "error",
+                    "error": "expected_evidence_hash_must_be_string",
+                }
+            ),
+            400,
+        )
+    if expected_pr_number is not None and not isinstance(
+        expected_pr_number, int
+    ):
+        return (
+            _safe_jsonify(
+                {
+                    "status": "error",
+                    "error": "expected_pr_number_must_be_int_or_null",
+                }
+            ),
+            400,
+        )
+    if expected_pr_head_sha is not None and not isinstance(
+        expected_pr_head_sha, str
+    ):
+        return (
+            _safe_jsonify(
+                {
+                    "status": "error",
+                    "error": "expected_pr_head_sha_must_be_string_or_null",
+                }
+            ),
+            400,
+        )
+    if expected_release_tag is not None and not isinstance(
+        expected_release_tag, str
+    ):
+        return (
+            _safe_jsonify(
+                {
+                    "status": "error",
+                    "error": "expected_release_tag_must_be_string_or_null",
+                }
+            ),
+            400,
+        )
+    envelope = atr.verify_runtime(
+        token=token,
+        expected_event_id=expected_event_id,
+        expected_pr_number=expected_pr_number,
+        expected_pr_head_sha=expected_pr_head_sha,
+        expected_evidence_hash=expected_evidence_hash,
+        expected_release_tag=expected_release_tag,
+    )
+    status_code = 200 if envelope.get("status") == "ok" else 400
+    return _safe_jsonify(envelope), status_code
+
+
+# ---------------------------------------------------------------------------
+# Route table + register helper
+# ---------------------------------------------------------------------------
+
+_APPROVAL_TOKEN_ROUTES: tuple[tuple[str, str, Any, str], ...] = (
+    (
+        "/api/agent-control/approval-token/status",
+        "GET",
+        _view_status,
+        "agent_control_approval_token_status",
+    ),
+    (
+        "/api/agent-control/approval-token/mint",
+        "POST",
+        _view_mint,
+        "agent_control_approval_token_mint",
+    ),
+    (
+        "/api/agent-control/approval-token/verify",
+        "POST",
+        _view_verify,
+        "agent_control_approval_token_verify",
+    ),
+)
+
+
+def register_approval_token_gate_routes(app: Flask) -> None:
+    """Register the session-protected approval-token gate routes.
+
+    NOT wired into ``dashboard/dashboard.py`` in this PR. The
+    operator-only two-line wiring change is
+    ``register_approval_token_gate_routes(app)`` per
+    ``execution_authority.md`` (``dashboard_wiring`` = NEEDS_HUMAN).
+
+    Runtime delivery requires:
+      1. ``ADE_APPROVAL_TOKEN_HMAC_SECRET`` set in the VPS env.
+      2. The two-line wiring diff applied to dashboard.py.
+      3. The PWA session cookie (existing /api/session/login flow).
+    """
+    for path, method, handler, endpoint in _APPROVAL_TOKEN_ROUTES:
+        app.add_url_rule(
+            path,
+            endpoint=endpoint,
+            view_func=handler,
+            methods=[method],
+        )
+
+
+__all__ = [
+    "MODULE_VERSION",
+    "SCHEMA_VERSION",
+    "STEP5_ENABLED_SUBSTAGE",
+    "register_approval_token_gate_routes",
+    "step5_implementation_allowed",
+]

--- a/reporting/approval_token_runtime.py
+++ b/reporting/approval_token_runtime.py
@@ -1,0 +1,522 @@
+"""N4b — Runtime approval-token gate (env-gated wrapper around N4a).
+
+Provides the env-driven layer on top of the existing pure N4a
+``approval_token_gate`` mint/verify primitives. This is the **only**
+module allowed to read the HMAC secret env var and to persist
+seen-nonce replay state.
+
+Hard guarantees (pinned by tests)
+---------------------------------
+
+* Stdlib + ``reporting.approval_token_gate`` (read-only) +
+  ``reporting.agent_audit_summary.assert_no_secrets`` (read-only
+  redactor guard).
+* No subprocess, no network, no ``gh``, no ``git``.
+* No imports of ``dashboard``, ``frontend``, ``automation``,
+  ``broker``, ``agent.risk``, ``agent.execution``, ``research``,
+  ``reporting.intelligent_routing``, ``live``, ``paper``, ``shadow``,
+  ``trading``.
+* The literal env-var name ``ADE_APPROVAL_TOKEN_HMAC_SECRET`` IS
+  allowed in this module — this is the **only** module permitted to
+  reference it. Every other module pins its absence.
+* :func:`is_configured` returns a boolean only; it NEVER returns,
+  logs, prints, or echoes the secret value.
+* Mint refuses to operate without a valid env secret (length-checked
+  via N4a's ``MIN_SECRET_LENGTH_BYTES`` ≥ 32 bytes).
+* Mint binds every token to the operator-supplied closed-vocab
+  ``intent`` + ``event_id`` + the optional PR/release identifiers
+  per N4a's closed claim schema.
+* Verify on ``outcome == "ok"`` records the nonce to the bounded
+  on-disk store at ``state/approval_token_seen_nonces.jsonl``;
+  subsequent verifies with the same nonce are rejected with the
+  closed-vocab outcome ``replay_detected``.
+* The seen-nonce store is gitignored (``state/`` is in
+  ``.gitignore``), bounded to :data:`MAX_SEEN_NONCES` rows, atomic
+  rewrite, sentinel-restricted writes.
+* This module performs NO approve / reject / merge / deploy
+  action. It only proves that a token can be minted and verified;
+  the underlying action is N5 territory.
+* Importing this module does NOT flip Step 5 invariants.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Final
+
+from reporting import approval_token_gate as atg
+
+MODULE_VERSION: Final[str] = "v3.15.16.N4b"
+SCHEMA_VERSION: Final[str] = "1.0"
+
+# ---------------------------------------------------------------------------
+# Step 5 invariants
+# ---------------------------------------------------------------------------
+
+STEP5_ENABLED_SUBSTAGE: Final[str] = "none"
+step5_implementation_allowed: Final[bool] = False
+
+
+# ---------------------------------------------------------------------------
+# Closed env-var names
+# ---------------------------------------------------------------------------
+
+#: Name of the env var the operator must export on the VPS. Value
+#: must be ≥32 bytes when interpreted as hex / base64 / raw. The
+#: module reads this once per call and never logs / prints the
+#: value. Recommended generation:
+#:
+#:     openssl rand -hex 32
+#:
+#: then export as ``ADE_APPROVAL_TOKEN_HMAC_SECRET=<the hex string>``.
+ENV_APPROVAL_TOKEN_HMAC_SECRET: Final[str] = "ADE_APPROVAL_TOKEN_HMAC_SECRET"
+
+#: Current key id. A single static kid is sufficient for the smallest
+#: safe slice; rotating to a new kid requires a code change pinned by
+#: an updated test. The kid appears in token claims so future N4
+#: rotations can verify against multiple secrets simultaneously.
+CURRENT_KID: Final[str] = "k1"
+
+
+# ---------------------------------------------------------------------------
+# Persistent seen-nonce store
+# ---------------------------------------------------------------------------
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+#: Bounded seen-nonce store under ``state/``. ``state/`` is fully
+#: gitignored (line 25 of ``.gitignore``). The file is treated as a
+#: bounded JSONL: every record helper compacts to the newest
+#: :data:`MAX_SEEN_NONCES` rows on each write.
+SEEN_NONCES_PATH: Final[Path] = (
+    REPO_ROOT / "state" / "approval_token_seen_nonces.jsonl"
+)
+SEEN_NONCES_RELATIVE_PATH: Final[str] = "state/approval_token_seen_nonces.jsonl"
+
+#: Atomic-write allowlist (substring form).
+_WRITE_PREFIX: Final[str] = "state/approval_token_seen_nonces"
+
+#: Maximum nonces retained in the bounded store. The runtime
+#: replay-protection window for an operator-paced approval flow.
+MAX_SEEN_NONCES: Final[int] = 1024
+
+
+# ---------------------------------------------------------------------------
+# Closed mint-result + verify-result envelopes
+# ---------------------------------------------------------------------------
+
+#: Closed mint-result envelope keys. The caller (dashboard API
+#: layer) receives exactly this shape; no secret material appears.
+MINT_RESULT_KEYS: Final[tuple[str, ...]] = (
+    "status",
+    "token",
+    "kid",
+    "intent",
+    "event_id",
+    "issued_at_utc",
+    "expires_at_utc",
+)
+
+#: Closed verify-result envelope keys.
+VERIFY_RESULT_KEYS: Final[tuple[str, ...]] = (
+    "status",
+    "outcome",
+    "reason",
+)
+
+
+# ---------------------------------------------------------------------------
+# Env-secret reader (never echoes the value)
+# ---------------------------------------------------------------------------
+
+
+def _decode_env_secret(raw: str) -> bytes | None:
+    """Decode the env-supplied secret. Accepts hex, base64url, or
+    raw bytes (utf-8). Returns ``None`` if no decoding yields ≥ the
+    minimum length."""
+    if not isinstance(raw, str) or not raw:
+        return None
+    candidate = raw.strip()
+    if not candidate:
+        return None
+    # Try hex first (the recommended form: openssl rand -hex 32 → 64 hex chars).
+    try:
+        decoded = bytes.fromhex(candidate)
+        if len(decoded) >= atg.MIN_SECRET_LENGTH_BYTES:
+            return decoded
+    except ValueError:
+        pass
+    # Try base64url next.
+    try:
+        import base64
+
+        pad = "=" * ((4 - len(candidate) % 4) % 4)
+        decoded = base64.urlsafe_b64decode(candidate + pad)
+        if len(decoded) >= atg.MIN_SECRET_LENGTH_BYTES:
+            return decoded
+    except Exception:
+        pass
+    # Fall back to raw bytes.
+    raw_bytes = candidate.encode("utf-8")
+    if len(raw_bytes) >= atg.MIN_SECRET_LENGTH_BYTES:
+        return raw_bytes
+    return None
+
+
+def _read_env_secret() -> bytes | None:
+    """Return the decoded env secret as bytes, or ``None`` if absent
+    or too short. NEVER logs / prints / echoes the value."""
+    raw = os.environ.get(ENV_APPROVAL_TOKEN_HMAC_SECRET)
+    if not isinstance(raw, str):
+        return None
+    return _decode_env_secret(raw)
+
+
+def is_configured() -> bool:
+    """Return True iff the env secret is set and decodes to ≥32 bytes.
+
+    Returns a boolean only; does not echo the secret. Pinned by tests.
+    """
+    return _read_env_secret() is not None
+
+
+def current_kid() -> str:
+    """Return the active kid. Hard-coded for the smallest safe slice."""
+    return CURRENT_KID
+
+
+def secrets_by_kid() -> dict[str, bytes]:
+    """Return the ``{kid: secret}`` map for :func:`atg.verify_token`.
+
+    Empty dict if not configured."""
+    secret = _read_env_secret()
+    if secret is None:
+        return {}
+    return {CURRENT_KID: secret}
+
+
+# ---------------------------------------------------------------------------
+# Seen-nonce store (atomic rewrite, bounded)
+# ---------------------------------------------------------------------------
+
+
+def _read_seen_nonces() -> set[str]:
+    """Read the persistent seen-nonce store. Best-effort; never raises."""
+    path = SEEN_NONCES_PATH
+    if not path.is_file():
+        return set()
+    out: set[str] = set()
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return out
+    for line in text.splitlines():
+        s = line.strip()
+        if not s:
+            continue
+        try:
+            entry = json.loads(s)
+        except ValueError:
+            continue
+        if isinstance(entry, dict):
+            nonce = entry.get("nonce")
+            if isinstance(nonce, str) and nonce:
+                out.add(nonce)
+    return out
+
+
+def is_nonce_seen(nonce: str) -> bool:
+    if not isinstance(nonce, str) or not nonce:
+        return False
+    return nonce in _read_seen_nonces()
+
+
+def _atomic_replace_jsonl(path: Path, lines: list[str]) -> None:
+    """Atomic-write the bounded JSONL. Sentinel-restricted."""
+    posix = path.as_posix()
+    if _WRITE_PREFIX not in posix and not posix.startswith(_WRITE_PREFIX):
+        raise ValueError(
+            "approval_token_runtime._atomic_replace_jsonl refuses "
+            f"non-state path: {path}"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = "\n".join(lines) + ("\n" if lines else "")
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".approval_token_seen_nonces.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def record_nonce(nonce: str) -> bool:
+    """Append a nonce to the bounded seen-store, then compact to the
+    last :data:`MAX_SEEN_NONCES` rows. Returns True if the nonce was
+    newly recorded; False if it was already present (caller can
+    treat as a no-op).
+
+    Never raises. NEVER stores or logs the secret. Only the nonce
+    (16-byte hex from N4a) is written.
+    """
+    if not isinstance(nonce, str) or not nonce:
+        return False
+    path = SEEN_NONCES_PATH
+    existing_lines: list[str] = []
+    if path.is_file():
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            text = ""
+        for line in text.splitlines():
+            s = line.strip()
+            if not s:
+                continue
+            try:
+                entry = json.loads(s)
+            except ValueError:
+                continue
+            if not isinstance(entry, dict):
+                continue
+            n = entry.get("nonce")
+            if isinstance(n, str) and n:
+                if n == nonce:
+                    return False
+                existing_lines.append(s)
+    new_line = json.dumps({"nonce": nonce}, sort_keys=True)
+    existing_lines.append(new_line)
+    # Compact to the newest MAX_SEEN_NONCES rows.
+    if len(existing_lines) > MAX_SEEN_NONCES:
+        existing_lines = existing_lines[-MAX_SEEN_NONCES:]
+    _atomic_replace_jsonl(path, existing_lines)
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Mint
+# ---------------------------------------------------------------------------
+
+
+def mint_runtime(
+    *,
+    intent: str,
+    event_id: str,
+    pr_number: int | None = None,
+    pr_head_sha: str | None = None,
+    evidence_hash: str,
+    release_tag: str | None = None,
+) -> dict[str, Any]:
+    """Mint an HMAC-SHA256 approval token using the env secret.
+
+    Returns a closed-shape envelope (see :data:`MINT_RESULT_KEYS`).
+    Failure modes are returned as ``status`` values; this function
+    never raises for predictable failure modes (missing env, invalid
+    intent, etc.). The token string is included on ``status == "ok"``;
+    on any other status it is omitted (``None``).
+    """
+    secret = _read_env_secret()
+    if secret is None:
+        return _mint_envelope(
+            status="configuration_missing",
+            token=None,
+            kid=CURRENT_KID,
+            intent=intent,
+            event_id=event_id,
+            issued_at_utc="",
+            expires_at_utc="",
+        )
+    if intent not in atg.TOKEN_INTENTS:
+        return _mint_envelope(
+            status="invalid_intent",
+            token=None,
+            kid=CURRENT_KID,
+            intent=intent,
+            event_id=event_id,
+            issued_at_utc="",
+            expires_at_utc="",
+        )
+    if not isinstance(event_id, str) or not event_id:
+        return _mint_envelope(
+            status="invalid_event_id",
+            token=None,
+            kid=CURRENT_KID,
+            intent=intent,
+            event_id=str(event_id or ""),
+            issued_at_utc="",
+            expires_at_utc="",
+        )
+    if not isinstance(evidence_hash, str) or not evidence_hash:
+        return _mint_envelope(
+            status="invalid_evidence_hash",
+            token=None,
+            kid=CURRENT_KID,
+            intent=intent,
+            event_id=event_id,
+            issued_at_utc="",
+            expires_at_utc="",
+        )
+    try:
+        token = atg.mint_token(
+            intent=intent,
+            event_id=event_id,
+            pr_number=pr_number,
+            pr_head_sha=pr_head_sha,
+            evidence_hash=evidence_hash,
+            release_tag=release_tag,
+            kid=CURRENT_KID,
+            secret=secret,
+            ttl_seconds=atg.DEFAULT_TTL_SECONDS,
+        )
+    except (TypeError, ValueError) as exc:
+        return _mint_envelope(
+            status="mint_rejected",
+            token=None,
+            kid=CURRENT_KID,
+            intent=intent,
+            event_id=event_id,
+            issued_at_utc="",
+            expires_at_utc="",
+            reason=exc.__class__.__name__,
+        )
+    claims = _claims_from_token(token)
+    return _mint_envelope(
+        status="ok",
+        token=token,
+        kid=CURRENT_KID,
+        intent=intent,
+        event_id=event_id,
+        issued_at_utc=str(claims.get("issued_at_utc") or ""),
+        expires_at_utc=str(claims.get("expires_at_utc") or ""),
+    )
+
+
+def _claims_from_token(token: str) -> dict[str, Any]:
+    """Best-effort decode of the claims portion. Never raises."""
+    if not isinstance(token, str) or "." not in token:
+        return {}
+    try:
+        claims_b64, _sig_b64 = token.split(".", 1)
+        import base64
+
+        pad = "=" * ((4 - len(claims_b64) % 4) % 4)
+        decoded = base64.urlsafe_b64decode(claims_b64 + pad)
+        obj = json.loads(decoded)
+        return obj if isinstance(obj, dict) else {}
+    except Exception:
+        return {}
+
+
+def _mint_envelope(
+    *,
+    status: str,
+    token: str | None,
+    kid: str,
+    intent: str,
+    event_id: str,
+    issued_at_utc: str,
+    expires_at_utc: str,
+    reason: str | None = None,
+) -> dict[str, Any]:
+    env: dict[str, Any] = {
+        "status": status,
+        "token": token,
+        "kid": kid,
+        "intent": intent,
+        "event_id": event_id,
+        "issued_at_utc": issued_at_utc,
+        "expires_at_utc": expires_at_utc,
+    }
+    if reason is not None:
+        env["reason"] = reason
+    return env
+
+
+# ---------------------------------------------------------------------------
+# Verify
+# ---------------------------------------------------------------------------
+
+
+def verify_runtime(
+    *,
+    token: str,
+    expected_event_id: str,
+    expected_pr_number: int | None = None,
+    expected_pr_head_sha: str | None = None,
+    expected_evidence_hash: str,
+    expected_release_tag: str | None = None,
+) -> dict[str, Any]:
+    """Verify a token against the env secret + record the nonce on
+    success. Returns the closed-shape verify envelope (see
+    :data:`VERIFY_RESULT_KEYS`).
+
+    This function NEVER performs the underlying action. The caller
+    must independently check business invariants before acting on
+    the verified claims.
+    """
+    by_kid = secrets_by_kid()
+    if not by_kid:
+        return {
+            "status": "configuration_missing",
+            "outcome": "",
+            "reason": "env_secret_absent",
+        }
+    seen = _read_seen_nonces()
+    result = atg.verify_token(
+        token,
+        expected_event_id=expected_event_id,
+        expected_pr_number=expected_pr_number,
+        expected_pr_head_sha=expected_pr_head_sha,
+        expected_evidence_hash=expected_evidence_hash,
+        expected_release_tag=expected_release_tag,
+        secrets_by_kid=by_kid,
+        seen_nonces=seen,
+    )
+    if result.outcome == "ok" and isinstance(result.claims, dict):
+        nonce = result.claims.get("nonce")
+        if isinstance(nonce, str) and nonce:
+            try:
+                record_nonce(nonce)
+            except Exception:
+                # Best-effort: a failed write does not turn a verified
+                # token into a rejected one. The next verify of the
+                # same nonce will still be detected via the in-memory
+                # ``seen`` set on a re-read.
+                pass
+    return {
+        "status": "ok" if result.outcome == "ok" else "rejected",
+        "outcome": result.outcome,
+        "reason": result.reason,
+    }
+
+
+__all__ = [
+    "CURRENT_KID",
+    "ENV_APPROVAL_TOKEN_HMAC_SECRET",
+    "MAX_SEEN_NONCES",
+    "MINT_RESULT_KEYS",
+    "MODULE_VERSION",
+    "SCHEMA_VERSION",
+    "SEEN_NONCES_PATH",
+    "SEEN_NONCES_RELATIVE_PATH",
+    "STEP5_ENABLED_SUBSTAGE",
+    "VERIFY_RESULT_KEYS",
+    "current_kid",
+    "is_configured",
+    "is_nonce_seen",
+    "mint_runtime",
+    "record_nonce",
+    "secrets_by_kid",
+    "step5_implementation_allowed",
+    "verify_runtime",
+]

--- a/tests/unit/test_api_approval_token_gate.py
+++ b/tests/unit/test_api_approval_token_gate.py
@@ -1,0 +1,601 @@
+"""Unit tests for N4b — dashboard.api_approval_token_gate (UNWIRED).
+
+Pins:
+* exactly 3 routes registered: GET status, POST mint, POST verify;
+  no other HTTP method appears on any of those paths;
+* every route refuses without an operator session (401);
+* mint/verify refuse without env (503 ``configuration_missing``);
+* oversize body → 413 ``payload_too_large``;
+* happy mint + happy verify round-trip with synthetic env secret;
+* replay rejected on second verify of the same nonce;
+* malformed/binding-mismatched token rejected with closed outcome;
+* no secret material leaks into any response body;
+* AST + source-text scans: no subprocess / gh / git / pywebpush /
+  approve(/reject(/merge(/deploy( call patterns / seed.jsonl writes;
+* ``dashboard/dashboard.py`` does NOT yet import the new blueprint
+  (skip-or-enforce consistency);
+* Step 5 invariants intact by import.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import secrets as _secrets
+from pathlib import Path
+from typing import Any
+
+import pytest
+from flask import Flask
+
+from dashboard import api_approval_token_gate as atg_api
+from reporting import approval_token_runtime as atr
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolate_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    target = tmp_path / "state" / "approval_token_seen_nonces.jsonl"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(atr, "SEEN_NONCES_PATH", target)
+    return target
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(atr.ENV_APPROVAL_TOKEN_HMAC_SECRET, raising=False)
+
+
+def _synthetic_secret_hex() -> str:
+    return _secrets.token_hex(32)
+
+
+def _make_app() -> Flask:
+    app = Flask(__name__)
+    # Set a session secret_key so test_client can sign cookies and
+    # session_transaction works.
+    app.secret_key = "test-secret-key-for-flask-session"
+    atg_api.register_approval_token_gate_routes(app)
+    return app
+
+
+def _authed_client(app: Flask):
+    client = app.test_client()
+    with client.session_transaction() as sess:
+        sess["operator_authenticated"] = True
+        sess["operator_actor"] = "test"
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Route registration
+# ---------------------------------------------------------------------------
+
+
+def test_register_routes_registers_exactly_three_routes() -> None:
+    app = _make_app()
+    rules = sorted(
+        (rule.rule, frozenset(rule.methods or set()))
+        for rule in app.url_map.iter_rules()
+        if rule.rule.startswith("/api/agent-control/approval-token/")
+    )
+    assert rules == [
+        (
+            "/api/agent-control/approval-token/mint",
+            frozenset({"POST", "OPTIONS"}),
+        ),
+        (
+            "/api/agent-control/approval-token/status",
+            frozenset({"GET", "HEAD", "OPTIONS"}),
+        ),
+        (
+            "/api/agent-control/approval-token/verify",
+            frozenset({"POST", "OPTIONS"}),
+        ),
+    ]
+
+
+def test_no_unexpected_methods_on_token_paths() -> None:
+    app = _make_app()
+    for rule in app.url_map.iter_rules():
+        if not rule.rule.startswith("/api/agent-control/approval-token/"):
+            continue
+        methods = rule.methods or set()
+        if rule.rule.endswith("/status"):
+            assert "POST" not in methods
+            assert "PUT" not in methods
+            assert "DELETE" not in methods
+        else:
+            assert "GET" not in methods
+            assert "PUT" not in methods
+            assert "DELETE" not in methods
+
+
+def test_blueprint_not_yet_wired_into_dashboard_dashboard() -> None:
+    text = (REPO_ROOT / "dashboard" / "dashboard.py").read_text(
+        encoding="utf-8"
+    )
+    wiring_present = (
+        "from dashboard.api_approval_token_gate "
+        "import register_approval_token_gate_routes"
+        in text
+    )
+    register_present = (
+        "register_approval_token_gate_routes(app)" in text
+    )
+    assert wiring_present == register_present, (
+        "dashboard.py must contain BOTH the import and the register "
+        "call for api_approval_token_gate, or NEITHER."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Auth — every route requires an operator session
+# ---------------------------------------------------------------------------
+
+
+def test_status_requires_operator_session() -> None:
+    app = _make_app()
+    res = app.test_client().get("/api/agent-control/approval-token/status")
+    assert res.status_code == 401
+    body = res.get_json()
+    assert body["error"] == "operator_session_required"
+
+
+def test_mint_requires_operator_session() -> None:
+    app = _make_app()
+    res = app.test_client().post(
+        "/api/agent-control/approval-token/mint",
+        data="{}",
+        content_type="application/json",
+    )
+    assert res.status_code == 401
+
+
+def test_verify_requires_operator_session() -> None:
+    app = _make_app()
+    res = app.test_client().post(
+        "/api/agent-control/approval-token/verify",
+        data="{}",
+        content_type="application/json",
+    )
+    assert res.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Env gate
+# ---------------------------------------------------------------------------
+
+
+def test_mint_returns_503_when_env_unset() -> None:
+    app = _make_app()
+    client = _authed_client(app)
+    res = client.post(
+        "/api/agent-control/approval-token/mint",
+        json={
+            "intent": "mobile_approval_dispatch",
+            "event_id": "evt_x",
+            "evidence_hash": "h_x",
+        },
+    )
+    assert res.status_code == 503
+    assert res.get_json()["error"] == "configuration_missing"
+
+
+def test_verify_returns_503_when_env_unset() -> None:
+    app = _make_app()
+    client = _authed_client(app)
+    res = client.post(
+        "/api/agent-control/approval-token/verify",
+        json={
+            "token": "a.b",
+            "expected_event_id": "evt_x",
+            "expected_evidence_hash": "h_x",
+        },
+    )
+    assert res.status_code == 503
+    assert res.get_json()["error"] == "configuration_missing"
+
+
+def test_status_reports_unconfigured() -> None:
+    app = _make_app()
+    client = _authed_client(app)
+    res = client.get("/api/agent-control/approval-token/status")
+    assert res.status_code == 200
+    body = res.get_json()
+    assert body["status"] == "ok"
+    assert body["is_configured"] is False
+    assert body["current_kid"] == atr.CURRENT_KID
+    assert body["step5_implementation_allowed"] is False
+    assert body["step5_enabled_substage"] == "none"
+
+
+def test_status_reports_configured_when_env_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        atr.ENV_APPROVAL_TOKEN_HMAC_SECRET, _synthetic_secret_hex()
+    )
+    client = _authed_client(_make_app())
+    body = client.get(
+        "/api/agent-control/approval-token/status"
+    ).get_json()
+    assert body["is_configured"] is True
+
+
+# ---------------------------------------------------------------------------
+# Body-size gate
+# ---------------------------------------------------------------------------
+
+
+def test_mint_oversize_body_returns_413(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        atr.ENV_APPROVAL_TOKEN_HMAC_SECRET, _synthetic_secret_hex()
+    )
+    app = _make_app()
+    client = _authed_client(app)
+    res = client.post(
+        "/api/agent-control/approval-token/mint",
+        data="x" * (atg_api._MAX_REQUEST_BYTES + 1),
+        content_type="application/json",
+    )
+    assert res.status_code == 413
+
+
+def test_verify_oversize_body_returns_413(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        atr.ENV_APPROVAL_TOKEN_HMAC_SECRET, _synthetic_secret_hex()
+    )
+    client = _authed_client(_make_app())
+    res = client.post(
+        "/api/agent-control/approval-token/verify",
+        data="x" * (atg_api._MAX_REQUEST_BYTES + 1),
+        content_type="application/json",
+    )
+    assert res.status_code == 413
+
+
+# ---------------------------------------------------------------------------
+# Happy mint + verify round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_mint_happy_path_returns_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        atr.ENV_APPROVAL_TOKEN_HMAC_SECRET, _synthetic_secret_hex()
+    )
+    client = _authed_client(_make_app())
+    res = client.post(
+        "/api/agent-control/approval-token/mint",
+        json={
+            "intent": "mobile_approval_dispatch",
+            "event_id": "evt_happy",
+            "pr_number": 42,
+            "pr_head_sha": "deadbeef00000001",
+            "evidence_hash": "h_happy",
+            "release_tag": None,
+        },
+    )
+    assert res.status_code == 200
+    body = res.get_json()
+    assert body["status"] == "ok"
+    assert isinstance(body["token"], str) and "." in body["token"]
+    assert body["kid"] == atr.CURRENT_KID
+    assert body["intent"] == "mobile_approval_dispatch"
+    assert body["event_id"] == "evt_happy"
+
+
+def test_mint_then_verify_round_trip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        atr.ENV_APPROVAL_TOKEN_HMAC_SECRET, _synthetic_secret_hex()
+    )
+    client = _authed_client(_make_app())
+    mint = client.post(
+        "/api/agent-control/approval-token/mint",
+        json={
+            "intent": "mobile_approval_dispatch",
+            "event_id": "evt_rt",
+            "pr_number": 7,
+            "pr_head_sha": "abc1230000000001",
+            "evidence_hash": "h_rt",
+            "release_tag": None,
+        },
+    )
+    token = mint.get_json()["token"]
+    verify = client.post(
+        "/api/agent-control/approval-token/verify",
+        json={
+            "token": token,
+            "expected_event_id": "evt_rt",
+            "expected_pr_number": 7,
+            "expected_pr_head_sha": "abc1230000000001",
+            "expected_evidence_hash": "h_rt",
+            "expected_release_tag": None,
+        },
+    )
+    assert verify.status_code == 200
+    body = verify.get_json()
+    assert body == {"status": "ok", "outcome": "ok", "reason": "verified"}
+
+
+def test_verify_rejects_replay_with_replay_detected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        atr.ENV_APPROVAL_TOKEN_HMAC_SECRET, _synthetic_secret_hex()
+    )
+    client = _authed_client(_make_app())
+    mint = client.post(
+        "/api/agent-control/approval-token/mint",
+        json={
+            "intent": "mobile_approval_dispatch",
+            "event_id": "evt_replay",
+            "evidence_hash": "h_replay",
+        },
+    )
+    token = mint.get_json()["token"]
+    first = client.post(
+        "/api/agent-control/approval-token/verify",
+        json={
+            "token": token,
+            "expected_event_id": "evt_replay",
+            "expected_evidence_hash": "h_replay",
+        },
+    )
+    assert first.get_json()["outcome"] == "ok"
+    second = client.post(
+        "/api/agent-control/approval-token/verify",
+        json={
+            "token": token,
+            "expected_event_id": "evt_replay",
+            "expected_evidence_hash": "h_replay",
+        },
+    )
+    assert second.status_code == 400
+    body = second.get_json()
+    assert body["status"] == "rejected"
+    assert body["outcome"] == "replay_detected"
+
+
+def test_verify_rejects_binding_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        atr.ENV_APPROVAL_TOKEN_HMAC_SECRET, _synthetic_secret_hex()
+    )
+    client = _authed_client(_make_app())
+    mint = client.post(
+        "/api/agent-control/approval-token/mint",
+        json={
+            "intent": "mobile_approval_dispatch",
+            "event_id": "evt_bind",
+            "evidence_hash": "h_bind",
+        },
+    )
+    token = mint.get_json()["token"]
+    bad = client.post(
+        "/api/agent-control/approval-token/verify",
+        json={
+            "token": token,
+            "expected_event_id": "evt_OTHER",
+            "expected_evidence_hash": "h_bind",
+        },
+    )
+    body = bad.get_json()
+    assert body["outcome"] == "binding_mismatch"
+
+
+def test_verify_rejects_malformed_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        atr.ENV_APPROVAL_TOKEN_HMAC_SECRET, _synthetic_secret_hex()
+    )
+    client = _authed_client(_make_app())
+    res = client.post(
+        "/api/agent-control/approval-token/verify",
+        json={
+            "token": "not-a-valid-token",
+            "expected_event_id": "evt",
+            "expected_evidence_hash": "h",
+        },
+    )
+    body = res.get_json()
+    assert body["outcome"] == "malformed_envelope"
+
+
+# ---------------------------------------------------------------------------
+# Body validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "body,err",
+    [
+        ({}, "intent_must_be_string"),
+        ({"intent": 42}, "intent_must_be_string"),
+        (
+            {"intent": "mobile_approval_dispatch"},
+            "event_id_must_be_string",
+        ),
+        (
+            {
+                "intent": "mobile_approval_dispatch",
+                "event_id": "evt_x",
+            },
+            "evidence_hash_must_be_string",
+        ),
+        (
+            {
+                "intent": "mobile_approval_dispatch",
+                "event_id": "evt_x",
+                "evidence_hash": "h",
+                "pr_number": "not_int",
+            },
+            "pr_number_must_be_int_or_null",
+        ),
+    ],
+)
+def test_mint_rejects_malformed_body(
+    body: dict[str, Any],
+    err: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        atr.ENV_APPROVAL_TOKEN_HMAC_SECRET, _synthetic_secret_hex()
+    )
+    client = _authed_client(_make_app())
+    res = client.post(
+        "/api/agent-control/approval-token/mint",
+        json=body,
+    )
+    assert res.status_code == 400
+    assert res.get_json()["error"] == err
+
+
+# ---------------------------------------------------------------------------
+# Secret leakage / response body safety
+# ---------------------------------------------------------------------------
+
+
+def test_response_never_leaks_env_secret(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    raw = _synthetic_secret_hex()
+    monkeypatch.setenv(atr.ENV_APPROVAL_TOKEN_HMAC_SECRET, raw)
+    client = _authed_client(_make_app())
+    res = client.post(
+        "/api/agent-control/approval-token/mint",
+        json={
+            "intent": "mobile_approval_dispatch",
+            "event_id": "evt_leak",
+            "evidence_hash": "h_leak",
+        },
+    )
+    body_raw = res.data.decode("utf-8")
+    assert raw not in body_raw
+
+
+# ---------------------------------------------------------------------------
+# Source-text + AST scans
+# ---------------------------------------------------------------------------
+
+
+def _module_source() -> str:
+    return Path(atg_api.__file__).read_text(encoding="utf-8")
+
+
+def _imported_module_names() -> set[str]:
+    tree = ast.parse(_module_source())
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module is not None:
+                names.add(node.module)
+    return names
+
+
+def test_no_subprocess_in_module() -> None:
+    src = _module_source()
+    assert "import subprocess" not in src
+    assert "from subprocess" not in src
+
+
+def test_no_gh_or_git_in_module() -> None:
+    src = _module_source()
+    for needle in ("subprocess.run", " gh ", " git "):
+        assert needle not in src, needle
+
+
+def test_no_web_push_library_import_in_module() -> None:
+    names = _imported_module_names()
+    for n in names:
+        assert n not in {"pywebpush", "webpush", "web_push"}, n
+
+
+def test_no_vapid_private_key_literal_in_module() -> None:
+    src = _module_source()
+    assert "WEB_PUSH_VAPID_PRIVATE_KEY" not in src
+
+
+def test_no_decision_verb_call_in_module() -> None:
+    src = _module_source().lower()
+    for verb in ("approve(", "reject(", "merge(", "deploy("):
+        assert verb not in src, verb
+
+
+def test_no_seed_jsonl_writes_in_module() -> None:
+    src = _module_source()
+    for forbidden in (
+        "seed.jsonl",
+        "delegation_seed.jsonl",
+        "generated_seed.jsonl",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_no_forbidden_module_imports() -> None:
+    forbidden_prefixes = (
+        "automation",
+        "broker",
+        "agent.risk",
+        "agent.execution",
+        "research",
+        "reporting.intelligent_routing",
+        "live",
+        "paper",
+        "shadow",
+        "trading",
+    )
+    for module in _imported_module_names():
+        for prefix in forbidden_prefixes:
+            assert module != prefix, module
+            assert not module.startswith(prefix + "."), module
+
+
+def test_imports_only_atr_aas_flask_and_stdlib() -> None:
+    names = _imported_module_names()
+    allowed_reporting = {
+        "reporting",
+        "reporting.approval_token_runtime",
+        "reporting.agent_audit_summary",
+    }
+    for n in names:
+        if n == "reporting" or n.startswith("reporting."):
+            assert n in allowed_reporting, n
+
+
+# ---------------------------------------------------------------------------
+# Step 5 invariants
+# ---------------------------------------------------------------------------
+
+
+def test_import_does_not_flip_step5_invariants() -> None:
+    importlib.reload(atg_api)
+    assert atg_api.step5_implementation_allowed is False
+    assert atg_api.STEP5_ENABLED_SUBSTAGE == "none"
+
+
+def test_module_source_pins_step5_invariants() -> None:
+    src = _module_source()
+    assert "step5_implementation_allowed: Final[bool] = False" in src
+    assert 'STEP5_ENABLED_SUBSTAGE: Final[str] = "none"' in src
+    assert "step5_implementation_allowed = True" not in src

--- a/tests/unit/test_approval_token_runtime.py
+++ b/tests/unit/test_approval_token_runtime.py
@@ -1,0 +1,543 @@
+"""Unit tests for N4b — reporting.approval_token_runtime.
+
+Pins:
+* ``is_configured`` is env-only and never echoes the secret;
+* hex / base64url / raw-bytes secret decoding all work, short
+  secrets are rejected;
+* ``mint_runtime`` rejects missing env, invalid intent, missing
+  event_id, missing evidence_hash, and bubbles the closed status
+  vocabulary;
+* ``mint_runtime`` on the happy path returns a token + ``status="ok"``
+  + bounded claim envelope; the response is closed-shape;
+* ``verify_runtime`` happy round-trip;
+* replay rejection on second verify of the same nonce;
+* expired-token rejection;
+* binding-mismatch rejection (event_id, evidence_hash, pr_number,
+  pr_head_sha, release_tag);
+* malformed-token rejection;
+* configuration_missing on missing env;
+* the seen-nonce store is bounded and the write path refuses
+  non-sentinel paths;
+* source-text + AST scans: no subprocess / gh / git / pywebpush /
+  approve(/reject(/merge(/deploy( call patterns / seed.jsonl writes;
+* Step 5 invariants intact by import.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import json
+import secrets as _secrets
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reporting import approval_token_gate as atg
+from reporting import approval_token_runtime as atr
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = Path(atr.__file__).resolve()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _synthetic_secret_hex() -> str:
+    """Return a 64-hex-char (32-byte) synthetic secret. Tests-only."""
+    return _secrets.token_hex(32)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect SEEN_NONCES_PATH into ``tmp_path/state/``. The repo's
+    ``state/`` directory is gitignored runtime state we never touch
+    from unit tests."""
+    target = tmp_path / "state" / "approval_token_seen_nonces.jsonl"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(atr, "SEEN_NONCES_PATH", target)
+    # The sentinel-restricted write helper uses a substring match,
+    # so a tmp_path of any depth works.
+    return target
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(atr.ENV_APPROVAL_TOKEN_HMAC_SECRET, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# is_configured + env decoding
+# ---------------------------------------------------------------------------
+
+
+def test_step5_invariants_intact() -> None:
+    assert atr.STEP5_ENABLED_SUBSTAGE == "none"
+    assert atr.step5_implementation_allowed is False
+
+
+def test_is_configured_false_when_env_unset() -> None:
+    assert atr.is_configured() is False
+
+
+def test_is_configured_false_when_env_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(atr.ENV_APPROVAL_TOKEN_HMAC_SECRET, "")
+    assert atr.is_configured() is False
+
+
+def test_is_configured_false_when_secret_too_short(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(atr.ENV_APPROVAL_TOKEN_HMAC_SECRET, "shortsecret")
+    assert atr.is_configured() is False
+
+
+def test_is_configured_true_with_valid_hex_secret(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        atr.ENV_APPROVAL_TOKEN_HMAC_SECRET, _synthetic_secret_hex()
+    )
+    assert atr.is_configured() is True
+
+
+def test_is_configured_true_with_valid_raw_secret(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        atr.ENV_APPROVAL_TOKEN_HMAC_SECRET, "x" * 32
+    )
+    assert atr.is_configured() is True
+
+
+def test_is_configured_returns_boolean_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Defence-in-depth: the predicate never embeds the secret in
+    its return value or its repr."""
+    monkeypatch.setenv(
+        atr.ENV_APPROVAL_TOKEN_HMAC_SECRET, _synthetic_secret_hex()
+    )
+    result = atr.is_configured()
+    assert isinstance(result, bool)
+    assert repr(result) in ("True", "False")
+
+
+# ---------------------------------------------------------------------------
+# mint_runtime — failure modes
+# ---------------------------------------------------------------------------
+
+
+def test_mint_runtime_configuration_missing_when_env_unset() -> None:
+    out = atr.mint_runtime(
+        intent="mobile_approval_dispatch",
+        event_id="evt_x",
+        evidence_hash="h_x",
+    )
+    assert out["status"] == "configuration_missing"
+    assert out["token"] is None
+
+
+def test_mint_runtime_invalid_intent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        atr.ENV_APPROVAL_TOKEN_HMAC_SECRET, _synthetic_secret_hex()
+    )
+    out = atr.mint_runtime(
+        intent="bogus_intent",
+        event_id="evt_x",
+        evidence_hash="h_x",
+    )
+    assert out["status"] == "invalid_intent"
+    assert out["token"] is None
+
+
+def test_mint_runtime_invalid_event_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        atr.ENV_APPROVAL_TOKEN_HMAC_SECRET, _synthetic_secret_hex()
+    )
+    out = atr.mint_runtime(
+        intent="mobile_approval_dispatch",
+        event_id="",
+        evidence_hash="h_x",
+    )
+    assert out["status"] == "invalid_event_id"
+    assert out["token"] is None
+
+
+def test_mint_runtime_invalid_evidence_hash(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        atr.ENV_APPROVAL_TOKEN_HMAC_SECRET, _synthetic_secret_hex()
+    )
+    out = atr.mint_runtime(
+        intent="mobile_approval_dispatch",
+        event_id="evt_x",
+        evidence_hash="",
+    )
+    assert out["status"] == "invalid_evidence_hash"
+
+
+# ---------------------------------------------------------------------------
+# mint_runtime — happy path + closed-shape result envelope
+# ---------------------------------------------------------------------------
+
+
+def test_mint_runtime_happy_path_returns_closed_envelope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        atr.ENV_APPROVAL_TOKEN_HMAC_SECRET, _synthetic_secret_hex()
+    )
+    out = atr.mint_runtime(
+        intent="mobile_approval_dispatch",
+        event_id="evt_happy",
+        pr_number=42,
+        pr_head_sha="abcdef0123456789",
+        evidence_hash="h_evidence_42",
+        release_tag=None,
+    )
+    assert out["status"] == "ok"
+    assert isinstance(out["token"], str) and "." in out["token"]
+    assert set(out.keys()) >= set(atr.MINT_RESULT_KEYS)
+    assert out["kid"] == atr.CURRENT_KID
+    assert out["intent"] == "mobile_approval_dispatch"
+    assert out["event_id"] == "evt_happy"
+    assert out["issued_at_utc"]
+    assert out["expires_at_utc"]
+
+
+def test_mint_runtime_secret_never_leaks_into_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    raw = _synthetic_secret_hex()
+    monkeypatch.setenv(atr.ENV_APPROVAL_TOKEN_HMAC_SECRET, raw)
+    out = atr.mint_runtime(
+        intent="mobile_approval_dispatch",
+        event_id="evt_no_leak",
+        evidence_hash="h_evidence",
+    )
+    raw_repr = json.dumps(out, default=str)
+    # The raw env value must NEVER appear in the response.
+    assert raw not in raw_repr
+
+
+# ---------------------------------------------------------------------------
+# verify_runtime — happy round-trip
+# ---------------------------------------------------------------------------
+
+
+def _mint_for_verify(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    event_id: str = "evt_rt",
+    pr_number: int | None = 99,
+    pr_head_sha: str | None = "deadbeef00000001",
+    evidence_hash: str = "h_rt_evidence",
+    release_tag: str | None = None,
+) -> str:
+    monkeypatch.setenv(
+        atr.ENV_APPROVAL_TOKEN_HMAC_SECRET, _synthetic_secret_hex()
+    )
+    out = atr.mint_runtime(
+        intent="mobile_approval_dispatch",
+        event_id=event_id,
+        pr_number=pr_number,
+        pr_head_sha=pr_head_sha,
+        evidence_hash=evidence_hash,
+        release_tag=release_tag,
+    )
+    assert out["status"] == "ok"
+    return out["token"]
+
+
+def test_verify_runtime_happy_round_trip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    token = _mint_for_verify(monkeypatch)
+    out = atr.verify_runtime(
+        token=token,
+        expected_event_id="evt_rt",
+        expected_pr_number=99,
+        expected_pr_head_sha="deadbeef00000001",
+        expected_evidence_hash="h_rt_evidence",
+        expected_release_tag=None,
+    )
+    assert out == {"status": "ok", "outcome": "ok", "reason": "verified"}
+
+
+def test_verify_runtime_replay_detected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    token = _mint_for_verify(monkeypatch)
+    # First verify: ok + nonce recorded.
+    first = atr.verify_runtime(
+        token=token,
+        expected_event_id="evt_rt",
+        expected_pr_number=99,
+        expected_pr_head_sha="deadbeef00000001",
+        expected_evidence_hash="h_rt_evidence",
+    )
+    assert first["status"] == "ok"
+    # Second verify of the same token: replay detected.
+    second = atr.verify_runtime(
+        token=token,
+        expected_event_id="evt_rt",
+        expected_pr_number=99,
+        expected_pr_head_sha="deadbeef00000001",
+        expected_evidence_hash="h_rt_evidence",
+    )
+    assert second["status"] == "rejected"
+    assert second["outcome"] == "replay_detected"
+
+
+def test_verify_runtime_binding_mismatch_event_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    token = _mint_for_verify(monkeypatch)
+    out = atr.verify_runtime(
+        token=token,
+        expected_event_id="evt_other",
+        expected_pr_number=99,
+        expected_pr_head_sha="deadbeef00000001",
+        expected_evidence_hash="h_rt_evidence",
+    )
+    assert out["status"] == "rejected"
+    assert out["outcome"] == "binding_mismatch"
+
+
+def test_verify_runtime_binding_mismatch_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    token = _mint_for_verify(monkeypatch)
+    out = atr.verify_runtime(
+        token=token,
+        expected_event_id="evt_rt",
+        expected_pr_number=99,
+        expected_pr_head_sha="deadbeef00000001",
+        expected_evidence_hash="h_other_evidence",
+    )
+    assert out["outcome"] == "binding_mismatch"
+
+
+def test_verify_runtime_malformed_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        atr.ENV_APPROVAL_TOKEN_HMAC_SECRET, _synthetic_secret_hex()
+    )
+    out = atr.verify_runtime(
+        token="not-a-valid-token",
+        expected_event_id="evt",
+        expected_evidence_hash="h",
+    )
+    assert out["status"] == "rejected"
+    assert out["outcome"] == "malformed_envelope"
+
+
+def test_verify_runtime_configuration_missing() -> None:
+    out = atr.verify_runtime(
+        token="anything.anything",
+        expected_event_id="evt",
+        expected_evidence_hash="h",
+    )
+    assert out["status"] == "configuration_missing"
+
+
+def test_verify_runtime_expired_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sanity: when N4a expires a token, verify_runtime surfaces
+    ``outcome == "expired"``."""
+    raw = _synthetic_secret_hex()
+    secret_bytes = bytes.fromhex(raw)
+    monkeypatch.setenv(atr.ENV_APPROVAL_TOKEN_HMAC_SECRET, raw)
+    # Build a token that is already expired by calling N4a directly
+    # with a ``now`` in the past minus more than the TTL.
+    from datetime import UTC, datetime, timedelta
+
+    past = datetime.now(UTC).replace(microsecond=0) - timedelta(seconds=2 * atg.DEFAULT_TTL_SECONDS)
+    token = atg.mint_token(
+        intent="mobile_approval_dispatch",
+        event_id="evt_expire",
+        pr_number=None,
+        pr_head_sha=None,
+        evidence_hash="h_exp",
+        release_tag=None,
+        kid=atr.CURRENT_KID,
+        secret=secret_bytes,
+        ttl_seconds=atg.DEFAULT_TTL_SECONDS,
+        now=past,
+    )
+    out = atr.verify_runtime(
+        token=token,
+        expected_event_id="evt_expire",
+        expected_evidence_hash="h_exp",
+    )
+    assert out["outcome"] == "expired"
+    assert out["status"] == "rejected"
+
+
+# ---------------------------------------------------------------------------
+# Seen-nonce store
+# ---------------------------------------------------------------------------
+
+
+def test_record_nonce_round_trip() -> None:
+    assert atr.is_nonce_seen("nonce_a") is False
+    assert atr.record_nonce("nonce_a") is True
+    assert atr.is_nonce_seen("nonce_a") is True
+    assert atr.record_nonce("nonce_a") is False
+
+
+def test_record_nonce_atomic_write_refuses_non_sentinel(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    bogus = tmp_path / "logs" / "elsewhere" / "approval_token_seen_nonces.jsonl"
+    bogus.parent.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(atr, "SEEN_NONCES_PATH", bogus)
+    # The sentinel-substring guard refuses any path that does not
+    # contain the closed prefix.
+    with pytest.raises(ValueError):
+        atr.record_nonce("any_nonce")
+
+
+def test_seen_nonce_store_bounded_to_max(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Shrink the bound to make the test cheap.
+    monkeypatch.setattr(atr, "MAX_SEEN_NONCES", 5)
+    for i in range(20):
+        atr.record_nonce(f"nonce_{i}")
+    seen = atr._read_seen_nonces()  # type: ignore[attr-defined]
+    assert len(seen) <= 5
+    # The newest entries are retained.
+    assert "nonce_19" in seen
+
+
+# ---------------------------------------------------------------------------
+# Source-text + AST scans
+# ---------------------------------------------------------------------------
+
+
+def _module_source() -> str:
+    return MODULE_PATH.read_text(encoding="utf-8")
+
+
+def _imported_module_names() -> set[str]:
+    tree = ast.parse(_module_source())
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module is not None:
+                names.add(node.module)
+    return names
+
+
+def test_no_subprocess_in_module() -> None:
+    src = _module_source()
+    assert "import subprocess" not in src
+    assert "from subprocess" not in src
+
+
+def test_no_gh_or_git_in_module() -> None:
+    src = _module_source()
+    for needle in ("subprocess.run", " gh ", " git "):
+        assert needle not in src, needle
+
+
+def test_no_web_push_library_import_in_module() -> None:
+    names = _imported_module_names()
+    for n in names:
+        assert n not in {"pywebpush", "webpush", "web_push"}, n
+        assert not n.startswith("pywebpush."), n
+
+
+def test_no_vapid_private_key_literal_in_module() -> None:
+    src = _module_source()
+    assert "WEB_PUSH_VAPID_PRIVATE_KEY" not in src
+
+
+def test_env_var_name_appears_only_here() -> None:
+    src = _module_source()
+    assert "ADE_APPROVAL_TOKEN_HMAC_SECRET" in src
+
+
+def test_no_decision_verb_call_in_module() -> None:
+    src = _module_source().lower()
+    for verb in ("approve(", "reject(", "merge(", "deploy("):
+        assert verb not in src, verb
+
+
+def test_no_seed_jsonl_writes_in_module() -> None:
+    src = _module_source()
+    for forbidden in (
+        "seed.jsonl",
+        "delegation_seed.jsonl",
+        "generated_seed.jsonl",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_no_forbidden_module_imports() -> None:
+    forbidden_prefixes = (
+        "dashboard",
+        "frontend",
+        "automation",
+        "broker",
+        "agent.risk",
+        "agent.execution",
+        "research",
+        "reporting.intelligent_routing",
+        "live",
+        "paper",
+        "shadow",
+        "trading",
+    )
+    for module in _imported_module_names():
+        for prefix in forbidden_prefixes:
+            assert module != prefix, module
+            assert not module.startswith(prefix + "."), module
+
+
+def test_imports_only_atg_aas_stdlib() -> None:
+    names = _imported_module_names()
+    allowed_reporting = {
+        "reporting",
+        "reporting.approval_token_gate",
+        "reporting.agent_audit_summary",
+    }
+    for n in names:
+        if n == "reporting" or n.startswith("reporting."):
+            assert n in allowed_reporting, n
+
+
+# ---------------------------------------------------------------------------
+# Step 5 invariants — import-time
+# ---------------------------------------------------------------------------
+
+
+def test_import_does_not_flip_step5_invariants() -> None:
+    importlib.reload(atr)
+    assert atr.step5_implementation_allowed is False
+    assert atr.STEP5_ENABLED_SUBSTAGE == "none"
+
+
+def test_module_source_pins_step5_invariants() -> None:
+    src = _module_source()
+    assert "step5_implementation_allowed: Final[bool] = False" in src
+    assert 'STEP5_ENABLED_SUBSTAGE: Final[str] = "none"' in src
+    assert "step5_implementation_allowed = True" not in src

--- a/tests/unit/test_dashboard_dashboard_one_line_wiring.py
+++ b/tests/unit/test_dashboard_dashboard_one_line_wiring.py
@@ -390,6 +390,68 @@ def test_mobile_inbox_wiring_no_other_dashboard_dashboard_modifications() -> Non
 
 
 # ---------------------------------------------------------------------------
+# N4b approval-token-gate wiring conditional pins (skip-or-enforce)
+# ---------------------------------------------------------------------------
+#
+# Same dual-mode pattern as the N3b/N2b-3b wirings above. Until the
+# operator adds the two-line ``register_approval_token_gate_routes(app)``
+# diff, these pins return early. Once added, they enforce the exact
+# wiring shape.
+#
+# Runtime delivery additionally requires the env secret
+# ``ADE_APPROVAL_TOKEN_HMAC_SECRET`` to be exported on the VPS; the
+# wired endpoint refuses with HTTP 503 ``configuration_missing`` when
+# the env is absent — pinned by the api_approval_token_gate unit
+# tests.
+
+EXPECTED_TOKEN_GATE_IMPORT_LINE = (
+    "from dashboard.api_approval_token_gate "
+    "import register_approval_token_gate_routes"
+)
+EXPECTED_TOKEN_GATE_REGISTER_CALL = (
+    "register_approval_token_gate_routes(app)"
+)
+
+
+def _token_gate_wiring_present() -> bool:
+    text = _dashboard_text()
+    return (
+        EXPECTED_TOKEN_GATE_IMPORT_LINE in text
+        and EXPECTED_TOKEN_GATE_REGISTER_CALL in text
+    )
+
+
+def test_token_gate_wiring_exactly_one_import_and_one_register_call() -> None:
+    if not _token_gate_wiring_present():
+        return
+    text = _dashboard_text()
+    assert text.count(EXPECTED_TOKEN_GATE_IMPORT_LINE) == 1, (
+        "dashboard.py must contain exactly one new token-gate "
+        "import line"
+    )
+    assert text.count(EXPECTED_TOKEN_GATE_REGISTER_CALL) == 1, (
+        "dashboard.py must contain exactly one new token-gate "
+        "register call"
+    )
+
+
+def test_token_gate_wiring_no_other_dashboard_dashboard_modifications() -> None:
+    if not _token_gate_wiring_present():
+        return
+    text = _dashboard_text()
+    token_gate_lines = [
+        line
+        for line in text.splitlines()
+        if "register_approval_token_gate" in line
+        or "api_approval_token_gate" in line
+    ]
+    assert len(token_gate_lines) == 2, (
+        f"dashboard.py must contain exactly 2 token-gate lines; "
+        f"found {len(token_gate_lines)}: {token_gate_lines}"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Companion doc invariants (always on)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Wires the pure [N4a approval-token primitives](reporting/approval_token_gate.py) into an env-gated runtime surface. The operator can mint and verify tokens bound to `event_id` + intent + the optional PR/release bindings, with HMAC-SHA256 signatures, a 900-second TTL, and persistent replay protection.

**This slice introduces NO approve / reject / merge / deploy action.** It only proves that a token can be minted and verified for a future N5 operator action.

The blueprint is intentionally **NOT wired into [dashboard/dashboard.py](dashboard/dashboard.py)** in this PR — wiring is the operator's two-line diff in a follow-up PR (same pattern as N3b PR #188, N2b-3b PR #184).

## Surface contract

| Method | Path | Behaviour |
|--------|------|-----------|
| GET | `/api/agent-control/approval-token/status` | session-required; returns `{is_configured, current_kid, step5_*}` (boolean only — never echoes the secret) |
| POST | `/api/agent-control/approval-token/mint` | session-required, env-required (else 503); body 4 KiB cap (else 413); mints token bound to operator-supplied `event_id` + `intent` + optional `pr_number` / `pr_head_sha` / `evidence_hash` / `release_tag` |
| POST | `/api/agent-control/approval-token/verify` | session-required, env-required; verifies + records nonce on success; surfaces the closed N4a outcome vocab (`ok` / `expired` / `signature_invalid` / `binding_mismatch` / `intent_unknown` / `malformed_envelope` / `replay_detected` / `unknown_kid`) |

Every response runs through `assert_no_secrets`. The HMAC secret **never** appears in any response body, log line, or repr.

## Diff scope (exactly 5 files)

| File | Change |
|------|--------|
| [reporting/approval_token_runtime.py](reporting/approval_token_runtime.py) | new env-gated wrapper — `is_configured`, `mint_runtime`, `verify_runtime`, seen-nonce store (522 LOC) |
| [dashboard/api_approval_token_gate.py](dashboard/api_approval_token_gate.py) | new session-protected Flask blueprint (424 LOC) |
| [tests/unit/test_approval_token_runtime.py](tests/unit/test_approval_token_runtime.py) | 34 pure tests with synthetic secret via `monkeypatch.setenv` |
| [tests/unit/test_api_approval_token_gate.py](tests/unit/test_api_approval_token_gate.py) | 33 Flask `test_client` tests with `session_transaction` auth |
| [tests/unit/test_dashboard_dashboard_one_line_wiring.py](tests/unit/test_dashboard_dashboard_one_line_wiring.py) | appends skip-or-enforce wiring pins for the new `register_approval_token_gate_routes(app)` wiring |

## Operator gates required for runtime delivery (deferred to follow-up PR)

1. **VPS env secret.** Export on the VPS host (recommended generation):

   ```bash
   openssl rand -hex 32
   # → 64-hex-char string
   # then in the systemd unit / /etc/trading-agent.env (outside the repo):
   #   ADE_APPROVAL_TOKEN_HMAC_SECRET=<that hex string>
   ```

   The module accepts hex, base64url, or raw bytes. Anything < 32 bytes is rejected with `is_configured()=False` and the API returns 503.

2. **Two-line wiring diff** in `dashboard/dashboard.py` (follow-up operator PR, same pattern as PR #184):

   ```diff
   +from dashboard.api_approval_token_gate import register_approval_token_gate_routes
    ...
   +register_approval_token_gate_routes(app)
   ```

   The strict skip-or-enforce pins in [tests/unit/test_dashboard_dashboard_one_line_wiring.py](tests/unit/test_dashboard_dashboard_one_line_wiring.py) refuse any subsequent edit that drops, duplicates, or reorders those two lines.

## Hard invariants preserved
- `step5_implementation_allowed = False`, `STEP5_ENABLED_SUBSTAGE = \"none\"` — unchanged
- Level 6 permanently disabled — governance-lint green
- [reporting/approval_token_gate.py](reporting/approval_token_gate.py) (N4a pure) UNTOUCHED
- [dashboard/dashboard.py](dashboard/dashboard.py) UNTOUCHED
- [dashboard/api_push_dispatch.py](dashboard/api_push_dispatch.py) / [reporting/web_push_real_transport.py](reporting/web_push_real_transport.py) / [frontend/public/sw-push.js](frontend/public/sw-push.js) — unchanged
- `.gitleaks.toml`, `.claude/**` — unchanged
- No QRE / research / live / paper / shadow / risk / broker / execution / orchestration / automation / trading changes
- **No approve / reject / merge / deploy call pattern in any code path** (verified by AST + source-text scans in both new test suites)
- No queue / decision / acceptance state mutation
- No autonomous merge / deploy capability gained

## Test plan (all green locally)
- [x] `python scripts/governance_lint.py` → OK (16 agents, 5 workflows)
- [x] `python -m pytest tests/smoke -q` → 18 passed
- [x] `python -m pytest tests/unit/test_approval_token_runtime.py tests/unit/test_api_approval_token_gate.py tests/unit/test_approval_token_gate.py tests/unit/test_dashboard_dashboard_one_line_wiring.py tests/unit/test_api_mobile_approval_inbox.py -q` → 163 passed
- [x] `python -m reporting.development_step5_loop --no-write` → invariants intact
- [x] `python -m reporting.development_operational_digest --no-write` → invariants intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)