### PR TITLE
feat(workloop): A18a — Generated Queue Lane dry-run projector (report-only)

### DIFF
--- a/docs/governance/development_generated_lane.md
+++ b/docs/governance/development_generated_lane.md
@@ -1,0 +1,193 @@
+# A18 — Generated Queue Lane
+
+> **Status:** A18a (dry-run / report-only projector) implemented in
+> [`reporting/development_generated_lane.py`](../../reporting/development_generated_lane.py).
+> **A18b** (generated_seed.jsonl writer) and **A18c** (A17
+> admission integration) **remain unimplemented** and each requires
+> its own explicit operator go-signal.
+>
+> **Authority:** development-governance read-only.
+> A18a grants ADE **zero** new write authority over the queue,
+> never mints approval tokens, never opens an inbox row, never
+> merges, and never deploys. Step 5.1 / Step 5.2 remain BLOCKED.
+> Level 6 stays permanently disabled per ADR-015 §Doctrine 1.
+
+---
+
+## 1. Purpose
+
+The current ADE work-queue admits items via two operator-curated
+sources:
+
+* `seed.jsonl` — read by A16a intake promotion staging + A17 queue
+  admission policy;
+* `delegation_seed.jsonl` — read by A11 delegation + A16a + A17.
+
+A complete autonomous-development loop would benefit from a third,
+**agent-generated** lane fed by the existing read-only A10
+bugfix-loop, A11 delegation, and A13 e2e-proof artefacts. **A18a is
+the report-only first slice that surfaces what such a lane would
+propose, without introducing any new authority.**
+
+A18a is purely diagnostic.
+**The generated_seed.jsonl writer is not authorised** in this slice.
+The future A18b writer slice — which would actually create and append
+to `generated_seed.jsonl` — and the A18c admission-integration slice
+— which would teach A17 to read the new file — are not authorised
+and will not be implemented in this slice.
+
+---
+
+## 2. Hard constraints (A18a)
+
+A18a, in this PR and at runtime, must not:
+
+* create `generated_seed.jsonl`;
+* mutate `generated_seed.jsonl`, `seed.jsonl`, or
+  `delegation_seed.jsonl`;
+* register itself with A17 admission as an active seed source;
+* enqueue or dequeue any work item;
+* mint or verify any approval token;
+* send any push;
+* invoke `gh`, `git`, `subprocess`, or any network call;
+* mutate any upstream artefact;
+* edit any roadmap status field;
+* mark any roadmap phase complete;
+* enable Step 5.1 or Step 5.2;
+* flip `step5_implementation_allowed`;
+* change `STEP5_ENABLED_SUBSTAGE`;
+* introduce or change Level 6 status.
+
+The projector ships its own AST-level forbidden-import scan and
+source-text scan to enforce the relevant bullets.
+
+---
+
+## 3. Output
+
+A18a writes the bounded dry-run report at
+[`logs/development_generated_lane/latest.json`](../../logs/development_generated_lane/).
+The path is sentinel-restricted at the atomic-write boundary; any
+other target is refused (pinned by tests, including explicit refusal
+of `seed.jsonl`, `delegation_seed.jsonl`, and `generated_seed.jsonl`
+paths).
+
+### Wrapper schema (closed)
+
+```
+schema_version
+module_version
+report_kind                     # "development_generated_lane"
+generated_at_utc
+step5_implementation_allowed    # always false
+step5_enabled_substage          # always "none"
+candidate_count
+candidates                      # list of closed-schema rows, ≤ 16
+sources_read                    # {bugfix_loop, delegation, e2e_proof}
+validation_warnings
+vocabularies
+discipline_invariants
+note
+```
+
+### Per-candidate schema (closed, exact, ordered)
+
+```
+generated_candidate_id          # sha256(source_module + source_id)[:16]
+source_module                   # development_bugfix_loop | development_delegation | development_e2e_proof
+source_id                       # bounded scalar from the upstream record
+proposed_kind                   # bugfix | delegation | e2e_proof | unknown
+proposed_title                  # bounded ≤ 120 chars
+proposed_summary                # bounded ≤ 300 chars
+evidence_hash                   # sha256(source_module + source_id + "evidence")[:16]
+admission_preview               # always "report_only_not_admitted"
+block_reason                    # always "generated_lane_writer_not_authorized"
+would_require_operator_go       # always true
+```
+
+### Closed vocabularies
+
+* `proposed_kinds`: `bugfix`, `delegation`, `e2e_proof`, `unknown`.
+* `admission_previews`: only `report_only_not_admitted`.
+* `block_reasons`: only `generated_lane_writer_not_authorized`.
+
+No decision verb (`approve`, `reject`, `merge`, `deploy`, `trade`)
+appears in any vocabulary value.
+
+### Discipline invariants (every snapshot)
+
+```
+writes_to_seed_jsonl:                false
+writes_to_delegation_seed_jsonl:     false
+writes_to_generated_seed_jsonl:      false
+generated_seed_writer_authorized:    false
+mutates_generated_seed:              false
+admits_queue_items:                  false
+executes_work:                       false
+mints_or_verifies_approval_tokens:   false
+sends_real_push:                     false
+operator_promotion_required:         true
+operator_go_required_for_writer:     true
+step5_implementation_allowed:        false
+step5_enabled_substage:              "none"
+```
+
+---
+
+## 4. CLI
+
+```
+python -m reporting.development_generated_lane
+python -m reporting.development_generated_lane --no-write
+python -m reporting.development_generated_lane --indent 0
+```
+
+`--no-write` prints the snapshot to stdout only — it writes no
+file. Default mode atomic-writes
+`logs/development_generated_lane/latest.json` AND prints. **In
+neither mode is `generated_seed.jsonl` created.**
+
+---
+
+## 5. Authority chain summary
+
+| Capability                                        | Today (post-A18a)         | After A18b (future, operator-go) | After A18c (future, operator-go) |
+| ------------------------------------------------- | ------------------------- | -------------------------------- | -------------------------------- |
+| Read upstream bugfix/delegation/e2e artefacts     | yes (read-only)           | yes                              | yes                              |
+| Project bounded candidate rows into a report      | yes                       | yes                              | yes                              |
+| Create / append `generated_seed.jsonl`            | **forbidden**             | yes (operator-authorised)        | yes                              |
+| Pass through A16a intake promotion                | n/a                       | n/a                              | yes (same gates as `seed.jsonl`) |
+| Pass through A17 queue admission policy           | n/a                       | n/a                              | yes (same gates as `seed.jsonl`) |
+| Enter A8 work queue                               | n/a                       | n/a                              | yes (same gates as `seed.jsonl`) |
+| Execute / merge / deploy                          | **forbidden**             | **forbidden**                    | **forbidden**                    |
+| Autonomous approval / merge / deploy              | **forbidden, Level 6**    | unchanged (Level 6 permanently disabled) | unchanged (Level 6 permanently disabled) |
+
+A18a grants ADE zero new write authority. A18b and A18c are
+operator-gated. Level 6 stays permanently disabled across all
+three.
+
+---
+
+## 6. What A18a does NOT do
+
+* A18a never creates `generated_seed.jsonl`. The file remains
+  absent (pinned by unit test
+  `test_generated_seed_jsonl_remains_absent_in_repo`).
+* A18a never writes anywhere outside its sentinel directory
+  (`logs/development_generated_lane/`).
+* A18a never integrates with A17 admission. A17's authoritative
+  filter is unchanged.
+* A18a never mints or verifies an approval token (N4 territory).
+* A18a never merges or deploys (N5 / future).
+* A18a never opens a mobile-inbox row (N3 territory).
+* A18a never sends a Web Push (N2b-3 territory).
+* A18a never executes a CLI subprocess and never calls `gh` /
+  `git` / a network endpoint.
+* A18a does not change Step 5.0 logic.
+* A18a does not flip `step5_implementation_allowed`.
+* A18a does not change `STEP5_ENABLED_SUBSTAGE`.
+* Step 5.1 / Step 5.2 remain BLOCKED.
+* Level 6 stays permanently disabled.
+* A18b (writer) and A18c (A17 admission integration) remain
+  unimplemented and **each requires its own explicit operator
+  go-signal**.

--- a/reporting/development_generated_lane.py
+++ b/reporting/development_generated_lane.py
@@ -1,0 +1,675 @@
+"""A18a — Generated Queue Lane projector (DRY-RUN / REPORT-ONLY).
+
+Pure stdlib-only projector that inspects existing read-only
+development artefacts (A10 bugfix loop, A11 delegation, A13 e2e
+proof) and emits a bounded **dry-run** report of generated
+candidate work items at
+``logs/development_generated_lane/latest.json``.
+
+This is the **smallest safe A18 slice**. It exists to make the
+question "what would a generated queue lane propose?" answerable
+**without** introducing any new authority. It does **NOT**:
+
+* create or mutate ``generated_seed.jsonl`` (the file remains
+  absent until a future operator-authorised A18b writer slice);
+* append to ``seed.jsonl`` or ``delegation_seed.jsonl``;
+* integrate with A17 queue admission as an active seed source;
+* enqueue, execute, or dequeue any work item;
+* mint or verify any approval token;
+* call ``gh`` / ``git`` / ``subprocess`` / network;
+* mutate any upstream artefact;
+* edit any roadmap status field;
+* mark any roadmap phase complete;
+* enable Step 5.1 or Step 5.2;
+* flip ``step5_implementation_allowed``;
+* change ``STEP5_ENABLED_SUBSTAGE``;
+* introduce or change Level 6 status.
+
+Hard guarantees (pinned by tests)
+---------------------------------
+
+* Stdlib + ``reporting.agent_audit_summary.assert_no_secrets``
+  (read-only redactor guard).
+* No subprocess, no network, no ``gh``, no ``git``.
+* No imports of ``dashboard``, ``frontend``, ``automation``,
+  ``broker``, ``agent.risk``, ``agent.execution``, ``research``,
+  ``reporting.intelligent_routing``, ``live``, ``paper``, ``shadow``,
+  ``trading``, ``reporting.approval_token_gate``,
+  ``reporting.approval_token_runtime``,
+  ``reporting.web_push_real_transport``.
+* Atomic write only under ``logs/development_generated_lane/...``.
+* Per-candidate schema is closed and exact. Bounded scalars only.
+* No decision verb (``approve``, ``reject``, ``merge``, ``deploy``,
+  ``trade``) appears in any emitted action / status / vocabulary
+  value. The closed admission-preview / block-reason vocabularies
+  use ``report_only_not_admitted`` and
+  ``generated_lane_writer_not_authorized`` — they are explicitly
+  NOT executable verbs.
+* The literal string ``generated_seed.jsonl`` may appear in
+  docstrings and discipline-invariant flag names (asserting absence)
+  but NEVER on a write code path. The atomic-write helper refuses
+  any path outside ``logs/development_generated_lane/...``.
+
+CLI
+---
+
+::
+
+    python -m reporting.development_generated_lane
+    python -m reporting.development_generated_lane --no-write
+    python -m reporting.development_generated_lane --indent 0
+
+``--no-write`` prints the snapshot to stdout only; it writes no
+file. Default mode atomic-writes
+``logs/development_generated_lane/latest.json`` AND prints. **In
+neither mode is ``generated_seed.jsonl`` created.**
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import hashlib
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Final
+
+from reporting.agent_audit_summary import assert_no_secrets
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[str] = "1.0"
+MODULE_VERSION: Final[str] = "v3.15.16.A18a"
+REPORT_KIND: Final[str] = "development_generated_lane"
+
+# ---------------------------------------------------------------------------
+# Step 5 invariants
+# ---------------------------------------------------------------------------
+
+STEP5_ENABLED_SUBSTAGE: Final[str] = "none"
+step5_implementation_allowed: Final[bool] = False
+
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies + bounds
+# ---------------------------------------------------------------------------
+
+#: Closed proposed-kind vocabulary. Maps a source artefact to the
+#: kind of generated candidate that would be proposed if a future
+#: A18b writer were authorised. Adding a value requires a code
+#: change pinned by an updated test.
+PROPOSED_KINDS: Final[tuple[str, ...]] = (
+    "bugfix",
+    "delegation",
+    "e2e_proof",
+    "unknown",
+)
+
+#: Closed admission-preview vocabulary. A18a NEVER emits a value
+#: other than ``report_only_not_admitted`` — admission is the
+#: future A18c slice's authority, not this projector's.
+ADMISSION_PREVIEWS: Final[tuple[str, ...]] = (
+    "report_only_not_admitted",
+)
+
+#: Closed block-reason vocabulary. A18a NEVER emits a value
+#: other than ``generated_lane_writer_not_authorized``.
+BLOCK_REASONS: Final[tuple[str, ...]] = (
+    "generated_lane_writer_not_authorized",
+)
+
+#: Closed validation-warning vocabulary.
+VALIDATION_WARNINGS: Final[tuple[str, ...]] = (
+    "bugfix_loop_artifact_absent",
+    "bugfix_loop_artifact_unparseable",
+    "delegation_artifact_absent",
+    "delegation_artifact_unparseable",
+    "e2e_proof_artifact_absent",
+    "e2e_proof_artifact_unparseable",
+    "no_candidates_from_any_source",
+)
+
+#: Closed candidate-record schema, exact and ordered.
+GENERATED_CANDIDATE_KEYS: Final[tuple[str, ...]] = (
+    "generated_candidate_id",
+    "source_module",
+    "source_id",
+    "proposed_kind",
+    "proposed_title",
+    "proposed_summary",
+    "evidence_hash",
+    "admission_preview",
+    "block_reason",
+    "would_require_operator_go",
+)
+
+#: Closed wrapper-level note vocabulary.
+NOTE_NO_SOURCES: Final[str] = "no_upstream_sources_available"
+NOTE_NO_CANDIDATES: Final[str] = "no_candidates_from_any_source"
+NOTE_CANDIDATES_PRESENT: Final[str] = "candidates_present_report_only"
+
+#: Bounded length for free-text scalars. Tighter than upstream
+#: schemas because A18a's job is to surface the existence of
+#: candidates, not to render their contents.
+MAX_TITLE_LEN: Final[int] = 120
+MAX_SUMMARY_LEN: Final[int] = 300
+MAX_SOURCE_ID_LEN: Final[int] = 200
+
+#: Maximum candidates retained in any single snapshot, across all
+#: sources combined. The list is round-robin across the three
+#: upstream sources to give each visibility.
+MAX_GENERATED_CANDIDATES: Final[int] = 16
+
+#: Forbidden substrings inside any candidate scalar (defense in
+#: depth on top of the closed schema + assert_no_secrets).
+_FORBIDDEN_CANDIDATE_SUBSTRINGS: Final[tuple[str, ...]] = (
+    "BEGIN PRIVATE KEY",
+    "BEGIN RSA PRIVATE KEY",
+    "BEGIN EC PRIVATE KEY",
+    "diff --git ",
+    "+++ b/",
+    "--- a/",
+    "@@ -",
+)
+
+
+# ---------------------------------------------------------------------------
+# Upstream artefact paths (read-only)
+# ---------------------------------------------------------------------------
+
+_BUGFIX_LOOP_LATEST: Final[Path] = (
+    REPO_ROOT / "logs" / "development_bugfix_loop" / "latest.json"
+)
+_DELEGATION_LATEST: Final[Path] = (
+    REPO_ROOT / "logs" / "development_delegation" / "latest.json"
+)
+_E2E_PROOF_LATEST: Final[Path] = (
+    REPO_ROOT / "logs" / "development_e2e_proof" / "latest.json"
+)
+
+
+# ---------------------------------------------------------------------------
+# A18a output path (sentinel-restricted)
+# ---------------------------------------------------------------------------
+
+ARTIFACT_DIR: Final[Path] = (
+    REPO_ROOT / "logs" / "development_generated_lane"
+)
+ARTIFACT_LATEST: Final[Path] = ARTIFACT_DIR / "latest.json"
+ARTIFACT_RELATIVE_PATH: Final[str] = (
+    "logs/development_generated_lane/latest.json"
+)
+
+#: Atomic-write allowlist (substring form). The sentinel-restricted
+#: writer refuses any path that does not contain this prefix.
+_WRITE_PREFIX: Final[str] = "logs/development_generated_lane/"
+
+
+# ---------------------------------------------------------------------------
+# Discipline invariants emitted into every artefact
+# ---------------------------------------------------------------------------
+
+_DISCIPLINE_INVARIANTS: Final[dict[str, bool | str]] = {
+    "writes_to_seed_jsonl": False,
+    "writes_to_delegation_seed_jsonl": False,
+    "writes_to_generated_seed_jsonl": False,
+    "generated_seed_writer_authorized": False,
+    "mutates_generated_seed": False,
+    "admits_queue_items": False,
+    "executes_work": False,
+    "creates_real_branches": False,
+    "opens_real_prs": False,
+    "mergeable_by_agent": False,
+    "deployable_by_agent": False,
+    "mints_or_verifies_approval_tokens": False,
+    "sends_real_push": False,
+    "uses_subprocess_or_network": False,
+    "calls_llm_or_external_api": False,
+    "mutates_research_artifacts": False,
+    "mutates_roadmap_status_fields": False,
+    "marks_phase_complete": False,
+    "operator_promotion_required": True,
+    "operator_go_required_for_writer": True,
+    "step5_implementation_allowed": False,
+    "step5_enabled_substage": "none",
+    "diagnostics_do_not_trade": True,
+}
+
+
+# ---------------------------------------------------------------------------
+# Utility helpers
+# ---------------------------------------------------------------------------
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _bounded_str(value: Any, max_len: int) -> str:
+    if not isinstance(value, str):
+        return ""
+    if len(value) <= max_len:
+        return value
+    return value[:max_len]
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    try:
+        obj = json.loads(text)
+    except ValueError:
+        return None
+    if not isinstance(obj, dict):
+        return None
+    return obj
+
+
+def _digest(*parts: str) -> str:
+    h = hashlib.sha256()
+    for p in parts:
+        h.update((p or "").encode("utf-8"))
+        h.update(b"|")
+    return h.hexdigest()[:16]
+
+
+def _scalar_passes_no_forbidden(value: str) -> bool:
+    for needle in _FORBIDDEN_CANDIDATE_SUBSTRINGS:
+        if needle in value:
+            return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Per-source projectors → bounded candidate stubs
+# ---------------------------------------------------------------------------
+
+
+def _project_bugfix_candidate(
+    rec: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Project a A10 bugfix-loop candidate record into the closed
+    A18a candidate schema. Returns ``None`` if the record is too
+    malformed to project safely."""
+    src_id = _bounded_str(
+        rec.get("candidate_id"), MAX_SOURCE_ID_LEN
+    )
+    if not src_id:
+        return None
+    title = _bounded_str(
+        rec.get("target_path") or rec.get("failure_class") or "",
+        MAX_TITLE_LEN,
+    )
+    summary = _bounded_str(
+        rec.get("rationale") or rec.get("failure_class") or "",
+        MAX_SUMMARY_LEN,
+    )
+    if not _scalar_passes_no_forbidden(title):
+        title = ""
+    if not _scalar_passes_no_forbidden(summary):
+        summary = ""
+    return _build_candidate(
+        source_module="development_bugfix_loop",
+        source_id=src_id,
+        proposed_kind="bugfix",
+        proposed_title=title,
+        proposed_summary=summary,
+    )
+
+
+def _project_delegation_candidate(
+    rec: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Project an A11 delegation record into the closed A18a
+    candidate schema."""
+    src_id = _bounded_str(
+        rec.get("candidate_id") or rec.get("source_id"),
+        MAX_SOURCE_ID_LEN,
+    )
+    if not src_id:
+        return None
+    title = _bounded_str(rec.get("title") or "", MAX_TITLE_LEN)
+    summary = _bounded_str(
+        rec.get("summary") or rec.get("rationale") or "",
+        MAX_SUMMARY_LEN,
+    )
+    if not _scalar_passes_no_forbidden(title):
+        title = ""
+    if not _scalar_passes_no_forbidden(summary):
+        summary = ""
+    return _build_candidate(
+        source_module="development_delegation",
+        source_id=src_id,
+        proposed_kind="delegation",
+        proposed_title=title,
+        proposed_summary=summary,
+    )
+
+
+def _project_e2e_proof_candidate(
+    rec: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Project an A13 e2e-proof record into the closed A18a
+    candidate schema. Many e2e_proof artefacts are roll-up reports
+    rather than per-candidate rows; this projector skips records
+    without an identifiable source id."""
+    src_id = _bounded_str(
+        rec.get("proof_id") or rec.get("candidate_id") or rec.get("id"),
+        MAX_SOURCE_ID_LEN,
+    )
+    if not src_id:
+        return None
+    title = _bounded_str(rec.get("title") or "", MAX_TITLE_LEN)
+    summary = _bounded_str(
+        rec.get("summary") or "",
+        MAX_SUMMARY_LEN,
+    )
+    if not _scalar_passes_no_forbidden(title):
+        title = ""
+    if not _scalar_passes_no_forbidden(summary):
+        summary = ""
+    return _build_candidate(
+        source_module="development_e2e_proof",
+        source_id=src_id,
+        proposed_kind="e2e_proof",
+        proposed_title=title,
+        proposed_summary=summary,
+    )
+
+
+def _build_candidate(
+    *,
+    source_module: str,
+    source_id: str,
+    proposed_kind: str,
+    proposed_title: str,
+    proposed_summary: str,
+) -> dict[str, Any]:
+    """Build the closed-schema A18a candidate row."""
+    assert proposed_kind in PROPOSED_KINDS, proposed_kind
+    candidate = {
+        "generated_candidate_id": _digest(source_module, source_id),
+        "source_module": source_module,
+        "source_id": source_id,
+        "proposed_kind": proposed_kind,
+        "proposed_title": proposed_title,
+        "proposed_summary": proposed_summary,
+        "evidence_hash": _digest(source_module, source_id, "evidence"),
+        "admission_preview": "report_only_not_admitted",
+        "block_reason": "generated_lane_writer_not_authorized",
+        "would_require_operator_go": True,
+    }
+    assert set(candidate.keys()) == set(GENERATED_CANDIDATE_KEYS), (
+        sorted(candidate.keys())
+    )
+    return candidate
+
+
+def _candidates_from_artifact(
+    payload: dict[str, Any],
+    projector: Any,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Walk the upstream artefact's records / rows / candidates list
+    and project up to ``limit`` rows. Tolerant of missing keys."""
+    out: list[dict[str, Any]] = []
+    for key in ("candidates", "rows", "records"):
+        raw = payload.get(key)
+        if isinstance(raw, list):
+            for r in raw:
+                if not isinstance(r, dict):
+                    continue
+                projected = projector(r)
+                if projected is None:
+                    continue
+                out.append(projected)
+                if len(out) >= limit:
+                    return out
+            if out:
+                return out
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Snapshot assembly
+# ---------------------------------------------------------------------------
+
+
+def collect_snapshot(
+    *,
+    bugfix_loop_artifact_path: Path | None = None,
+    delegation_artifact_path: Path | None = None,
+    e2e_proof_artifact_path: Path | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    """Build the deterministic A18a snapshot. Pure: reads upstream
+    artefacts read-only; never writes; never appends to any seed
+    file. The caller is responsible for atomic-writing the
+    snapshot via :func:`write_outputs`."""
+    bp = (
+        bugfix_loop_artifact_path
+        if bugfix_loop_artifact_path is not None
+        else _BUGFIX_LOOP_LATEST
+    )
+    dp = (
+        delegation_artifact_path
+        if delegation_artifact_path is not None
+        else _DELEGATION_LATEST
+    )
+    ep = (
+        e2e_proof_artifact_path
+        if e2e_proof_artifact_path is not None
+        else _E2E_PROOF_LATEST
+    )
+    ts = generated_at_utc if generated_at_utc is not None else _utcnow()
+
+    warnings: list[str] = []
+    sources_read: dict[str, dict[str, Any]] = {}
+
+    # Bugfix loop
+    bugfix_payload = _read_json(bp)
+    sources_read["bugfix_loop"] = {
+        "path": str(bp),
+        "available": bugfix_payload is not None,
+    }
+    if not bp.is_file():
+        warnings.append("bugfix_loop_artifact_absent")
+    elif bugfix_payload is None:
+        warnings.append("bugfix_loop_artifact_unparseable")
+
+    # Delegation
+    delegation_payload = _read_json(dp)
+    sources_read["delegation"] = {
+        "path": str(dp),
+        "available": delegation_payload is not None,
+    }
+    if not dp.is_file():
+        warnings.append("delegation_artifact_absent")
+    elif delegation_payload is None:
+        warnings.append("delegation_artifact_unparseable")
+
+    # E2E proof
+    e2e_payload = _read_json(ep)
+    sources_read["e2e_proof"] = {
+        "path": str(ep),
+        "available": e2e_payload is not None,
+    }
+    if not ep.is_file():
+        warnings.append("e2e_proof_artifact_absent")
+    elif e2e_payload is None:
+        warnings.append("e2e_proof_artifact_unparseable")
+
+    # Round-robin per-source projection up to the global cap.
+    per_source_cap = max(1, MAX_GENERATED_CANDIDATES // 3)
+    candidates: list[dict[str, Any]] = []
+    if bugfix_payload is not None:
+        candidates.extend(
+            _candidates_from_artifact(
+                bugfix_payload, _project_bugfix_candidate, per_source_cap
+            )
+        )
+    if delegation_payload is not None:
+        candidates.extend(
+            _candidates_from_artifact(
+                delegation_payload,
+                _project_delegation_candidate,
+                per_source_cap,
+            )
+        )
+    if e2e_payload is not None:
+        candidates.extend(
+            _candidates_from_artifact(
+                e2e_payload,
+                _project_e2e_proof_candidate,
+                per_source_cap,
+            )
+        )
+
+    # Global cap defense-in-depth.
+    if len(candidates) > MAX_GENERATED_CANDIDATES:
+        candidates = candidates[:MAX_GENERATED_CANDIDATES]
+
+    if not candidates:
+        if all(
+            not s["available"] for s in sources_read.values()
+        ):
+            note = NOTE_NO_SOURCES
+        else:
+            note = NOTE_NO_CANDIDATES
+            warnings.append("no_candidates_from_any_source")
+    else:
+        note = NOTE_CANDIDATES_PRESENT
+
+    snapshot = {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": ts,
+        "step5_implementation_allowed": step5_implementation_allowed,
+        "step5_enabled_substage": STEP5_ENABLED_SUBSTAGE,
+        "candidate_count": len(candidates),
+        "candidates": candidates,
+        "sources_read": sources_read,
+        "validation_warnings": warnings,
+        "vocabularies": {
+            "proposed_kinds": list(PROPOSED_KINDS),
+            "admission_previews": list(ADMISSION_PREVIEWS),
+            "block_reasons": list(BLOCK_REASONS),
+            "validation_warnings": list(VALIDATION_WARNINGS),
+            "generated_candidate_keys": list(GENERATED_CANDIDATE_KEYS),
+            "max_generated_candidates": MAX_GENERATED_CANDIDATES,
+        },
+        "discipline_invariants": dict(_DISCIPLINE_INVARIANTS),
+        "note": note,
+    }
+    assert_no_secrets(snapshot)
+    return snapshot
+
+
+# ---------------------------------------------------------------------------
+# Atomic write (sentinel-restricted)
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Write ``payload`` atomically; refuse any path outside
+    ``logs/development_generated_lane/...``. The substring guard
+    also blocks any attempt to write ``seed.jsonl`` /
+    ``delegation_seed.jsonl`` / ``generated_seed.jsonl`` because
+    those filenames are never under the generated-lane prefix."""
+    posix = path.as_posix()
+    if _WRITE_PREFIX not in posix and not posix.startswith(_WRITE_PREFIX):
+        raise ValueError(
+            "development_generated_lane._atomic_write_json refuses "
+            f"non-generated-lane output path: {path}"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".development_generated_lane.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_outputs(snapshot: dict[str, Any]) -> Path:
+    """Persist the A18a snapshot. ONLY writes
+    ``logs/development_generated_lane/latest.json``. Never touches
+    any seed file."""
+    _atomic_write_json(ARTIFACT_LATEST, snapshot)
+    return ARTIFACT_LATEST
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m reporting.development_generated_lane",
+        description=(
+            "A18a Generated Queue Lane projector (DRY-RUN / "
+            "REPORT-ONLY). Read-only deterministic projector that "
+            "inspects existing development_bugfix_loop / "
+            "development_delegation / development_e2e_proof "
+            "artefacts and emits a bounded dry-run report of "
+            "candidate work items at "
+            "logs/development_generated_lane/latest.json. "
+            "Does NOT create or mutate generated_seed.jsonl, and "
+            "does NOT integrate with A17 admission as an active "
+            "seed source. Step 5 implementation remains BLOCKED. "
+            "Level 6 stays permanently disabled."
+        ),
+    )
+    p.add_argument(
+        "--indent", type=int, default=2, help="JSON indent (0 for compact)."
+    )
+    p.add_argument(
+        "--no-write",
+        action="store_true",
+        help=(
+            "Do not persist "
+            "logs/development_generated_lane/latest.json "
+            "(stdout only). In neither mode is generated_seed.jsonl "
+            "created."
+        ),
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    indent = args.indent if args.indent and args.indent > 0 else None
+    snap = collect_snapshot()
+    if not args.no_write:
+        write_outputs(snap)
+    json.dump(snap, sys.stdout, indent=indent, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/unit/test_development_generated_lane.py
+++ b/tests/unit/test_development_generated_lane.py
@@ -1,0 +1,625 @@
+"""Unit tests for A18a — Generated Queue Lane projector (DRY-RUN).
+
+Pins:
+* ``--no-write`` mode creates no file.
+* Default mode atomic-writes EXACTLY
+  ``logs/development_generated_lane/latest.json`` and nothing else.
+* Atomic-write helper refuses any path outside the closed sentinel
+  prefix.
+* Missing upstream artefacts → safe empty report.
+* Valid upstream artefacts → bounded candidates ≤
+  :data:`MAX_GENERATED_CANDIDATES`, each with the closed
+  10-key schema.
+* ``admission_preview`` is always ``"report_only_not_admitted"``;
+  ``block_reason`` is always ``"generated_lane_writer_not_authorized"``;
+  ``would_require_operator_go`` is always ``True``.
+* No ``generated_seed.jsonl`` is created or written in any mode.
+* Discipline-invariant block carries every required flag with the
+  exact expected value.
+* Source-text + AST scans: no subprocess / gh / git / pywebpush /
+  approval-token mint imports / merge or deploy call patterns;
+  ``generated_seed.jsonl`` literal never appears in a write
+  context.
+* Step 5 invariants preserved by import.
+
+The tests **never** allow the projector to read the real
+``logs/`` directory; ``ARTIFACT_LATEST`` and the three upstream-
+artefact paths are redirected into ``tmp_path``.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reporting import development_generated_lane as dgl
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def isolated_artifacts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> dict[str, Path]:
+    """Redirect every read + write path into ``tmp_path``."""
+    out_dir = tmp_path / "logs" / "development_generated_lane"
+    out_latest = out_dir / "latest.json"
+    monkeypatch.setattr(dgl, "ARTIFACT_DIR", out_dir)
+    monkeypatch.setattr(dgl, "ARTIFACT_LATEST", out_latest)
+    # Redirect upstream-artefact reads.
+    bp = tmp_path / "logs" / "development_bugfix_loop" / "latest.json"
+    dp = tmp_path / "logs" / "development_delegation" / "latest.json"
+    ep = tmp_path / "logs" / "development_e2e_proof" / "latest.json"
+    monkeypatch.setattr(dgl, "_BUGFIX_LOOP_LATEST", bp)
+    monkeypatch.setattr(dgl, "_DELEGATION_LATEST", dp)
+    monkeypatch.setattr(dgl, "_E2E_PROOF_LATEST", ep)
+    return {
+        "out_dir": out_dir,
+        "out_latest": out_latest,
+        "bugfix_loop": bp,
+        "delegation": dp,
+        "e2e_proof": ep,
+        "tmp_root": tmp_path,
+    }
+
+
+def _write_artifact(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Step 5 + module-level invariants
+# ---------------------------------------------------------------------------
+
+
+def test_step5_invariants_intact() -> None:
+    assert dgl.STEP5_ENABLED_SUBSTAGE == "none"
+    assert dgl.step5_implementation_allowed is False
+
+
+def test_module_version_pinned() -> None:
+    assert dgl.MODULE_VERSION == "v3.15.16.A18a"
+
+
+def test_report_kind_pinned() -> None:
+    assert dgl.REPORT_KIND == "development_generated_lane"
+
+
+def test_closed_vocabularies_pinned() -> None:
+    assert dgl.PROPOSED_KINDS == (
+        "bugfix",
+        "delegation",
+        "e2e_proof",
+        "unknown",
+    )
+    assert dgl.ADMISSION_PREVIEWS == ("report_only_not_admitted",)
+    assert dgl.BLOCK_REASONS == (
+        "generated_lane_writer_not_authorized",
+    )
+    assert dgl.GENERATED_CANDIDATE_KEYS == (
+        "generated_candidate_id",
+        "source_module",
+        "source_id",
+        "proposed_kind",
+        "proposed_title",
+        "proposed_summary",
+        "evidence_hash",
+        "admission_preview",
+        "block_reason",
+        "would_require_operator_go",
+    )
+
+
+def test_artifact_path_under_generated_lane_logs() -> None:
+    assert dgl.ARTIFACT_RELATIVE_PATH == (
+        "logs/development_generated_lane/latest.json"
+    )
+
+
+def test_max_candidates_is_bounded() -> None:
+    assert dgl.MAX_GENERATED_CANDIDATES == 16
+
+
+# ---------------------------------------------------------------------------
+# Empty-state behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_collect_snapshot_no_sources_returns_safe_empty(
+    isolated_artifacts: dict[str, Path],
+) -> None:
+    snap = dgl.collect_snapshot()
+    assert snap["candidate_count"] == 0
+    assert snap["candidates"] == []
+    assert snap["note"] == dgl.NOTE_NO_SOURCES
+    # All three sources absent.
+    for w in (
+        "bugfix_loop_artifact_absent",
+        "delegation_artifact_absent",
+        "e2e_proof_artifact_absent",
+    ):
+        assert w in snap["validation_warnings"]
+    # Step 5 invariants surfaced in the snapshot.
+    assert snap["step5_implementation_allowed"] is False
+    assert snap["step5_enabled_substage"] == "none"
+
+
+def test_collect_snapshot_unparseable_source_returns_warning(
+    isolated_artifacts: dict[str, Path],
+) -> None:
+    isolated_artifacts["bugfix_loop"].parent.mkdir(
+        parents=True, exist_ok=True
+    )
+    isolated_artifacts["bugfix_loop"].write_text(
+        "not json", encoding="utf-8"
+    )
+    snap = dgl.collect_snapshot()
+    assert "bugfix_loop_artifact_unparseable" in snap["validation_warnings"]
+
+
+# ---------------------------------------------------------------------------
+# Candidate projection from each source
+# ---------------------------------------------------------------------------
+
+
+def _bugfix_payload(n: int) -> dict[str, Any]:
+    return {
+        "candidates": [
+            {
+                "candidate_id": f"bugfix_cand_{i:04d}",
+                "target_path": f"reporting/some_module_{i}.py",
+                "failure_class": "unit_test",
+                "rationale": "Failing assertion in some_module.py.",
+            }
+            for i in range(n)
+        ]
+    }
+
+
+def _delegation_payload(n: int) -> dict[str, Any]:
+    return {
+        "rows": [
+            {
+                "candidate_id": f"deleg_cand_{i:04d}",
+                "title": f"Delegation candidate {i}",
+                "summary": "A bounded delegation summary.",
+            }
+            for i in range(n)
+        ]
+    }
+
+
+def _e2e_proof_payload(n: int) -> dict[str, Any]:
+    return {
+        "records": [
+            {
+                "proof_id": f"e2e_proof_{i:04d}",
+                "title": f"E2E proof candidate {i}",
+                "summary": "A bounded e2e proof summary.",
+            }
+            for i in range(n)
+        ]
+    }
+
+
+def test_collect_snapshot_with_all_sources_projects_candidates(
+    isolated_artifacts: dict[str, Path],
+) -> None:
+    _write_artifact(isolated_artifacts["bugfix_loop"], _bugfix_payload(3))
+    _write_artifact(isolated_artifacts["delegation"], _delegation_payload(3))
+    _write_artifact(isolated_artifacts["e2e_proof"], _e2e_proof_payload(3))
+    snap = dgl.collect_snapshot()
+    assert snap["candidate_count"] >= 1
+    assert snap["note"] == dgl.NOTE_CANDIDATES_PRESENT
+    for c in snap["candidates"]:
+        assert set(c.keys()) == set(dgl.GENERATED_CANDIDATE_KEYS)
+        assert c["admission_preview"] == "report_only_not_admitted"
+        assert c["block_reason"] == "generated_lane_writer_not_authorized"
+        assert c["would_require_operator_go"] is True
+        assert c["proposed_kind"] in dgl.PROPOSED_KINDS
+
+
+def test_candidates_bounded_to_max_generated_candidates(
+    isolated_artifacts: dict[str, Path],
+) -> None:
+    # Far more than MAX_GENERATED_CANDIDATES across all sources.
+    _write_artifact(isolated_artifacts["bugfix_loop"], _bugfix_payload(50))
+    _write_artifact(isolated_artifacts["delegation"], _delegation_payload(50))
+    _write_artifact(isolated_artifacts["e2e_proof"], _e2e_proof_payload(50))
+    snap = dgl.collect_snapshot()
+    assert snap["candidate_count"] <= dgl.MAX_GENERATED_CANDIDATES
+
+
+def test_candidate_scalars_are_bounded(
+    isolated_artifacts: dict[str, Path],
+) -> None:
+    huge_title = "x" * 5000
+    huge_summary = "y" * 5000
+    _write_artifact(
+        isolated_artifacts["delegation"],
+        {
+            "rows": [
+                {
+                    "candidate_id": "deleg_huge",
+                    "title": huge_title,
+                    "summary": huge_summary,
+                }
+            ]
+        },
+    )
+    snap = dgl.collect_snapshot()
+    for c in snap["candidates"]:
+        assert len(c["proposed_title"]) <= dgl.MAX_TITLE_LEN
+        assert len(c["proposed_summary"]) <= dgl.MAX_SUMMARY_LEN
+
+
+def test_candidate_scalars_reject_diff_and_pem_markers(
+    isolated_artifacts: dict[str, Path],
+) -> None:
+    """Defense-in-depth: diff hunks / PEM markers in upstream
+    titles/summaries are stripped to empty rather than passed
+    through."""
+    _write_artifact(
+        isolated_artifacts["delegation"],
+        {
+            "rows": [
+                {
+                    "candidate_id": "deleg_pem",
+                    "title": "diff --git a/x b/x",
+                    "summary": "BEGIN PRIVATE KEY abc...",
+                }
+            ]
+        },
+    )
+    snap = dgl.collect_snapshot()
+    assert len(snap["candidates"]) >= 1
+    c = snap["candidates"][0]
+    assert "diff --git " not in c["proposed_title"]
+    assert "BEGIN PRIVATE KEY" not in c["proposed_summary"]
+
+
+# ---------------------------------------------------------------------------
+# Discipline invariants
+# ---------------------------------------------------------------------------
+
+
+def test_discipline_invariants_carry_required_flags(
+    isolated_artifacts: dict[str, Path],
+) -> None:
+    snap = dgl.collect_snapshot()
+    inv = snap["discipline_invariants"]
+    assert inv["step5_implementation_allowed"] is False
+    assert inv["step5_enabled_substage"] == "none"
+    assert inv["generated_seed_writer_authorized"] is False
+    assert inv["mutates_generated_seed"] is False
+    assert inv["admits_queue_items"] is False
+    assert inv["executes_work"] is False
+    assert inv["operator_promotion_required"] is True
+    assert inv["operator_go_required_for_writer"] is True
+    assert inv["writes_to_seed_jsonl"] is False
+    assert inv["writes_to_delegation_seed_jsonl"] is False
+    assert inv["writes_to_generated_seed_jsonl"] is False
+    assert inv["mints_or_verifies_approval_tokens"] is False
+    assert inv["sends_real_push"] is False
+    assert inv["uses_subprocess_or_network"] is False
+
+
+# ---------------------------------------------------------------------------
+# Write modes
+# ---------------------------------------------------------------------------
+
+
+def test_no_write_mode_creates_no_files(
+    isolated_artifacts: dict[str, Path],
+) -> None:
+    _write_artifact(isolated_artifacts["bugfix_loop"], _bugfix_payload(2))
+    rc = dgl.main(["--no-write"])
+    assert rc == 0
+    assert not isolated_artifacts["out_latest"].exists()
+    # And no other file is created under the sentinel dir.
+    if isolated_artifacts["out_dir"].exists():
+        assert list(isolated_artifacts["out_dir"].iterdir()) == []
+
+
+def test_default_mode_writes_only_latest_json(
+    isolated_artifacts: dict[str, Path],
+) -> None:
+    _write_artifact(isolated_artifacts["bugfix_loop"], _bugfix_payload(2))
+    rc = dgl.main([])
+    assert rc == 0
+    assert isolated_artifacts["out_latest"].is_file()
+    # ONLY latest.json is created in the sentinel directory.
+    entries = sorted(p.name for p in isolated_artifacts["out_dir"].iterdir())
+    assert entries == ["latest.json"]
+
+
+def test_atomic_write_refuses_non_sentinel_path(
+    isolated_artifacts: dict[str, Path],
+    tmp_path: Path,
+) -> None:
+    bogus = tmp_path / "logs" / "elsewhere" / "latest.json"
+    bogus.parent.mkdir(parents=True, exist_ok=True)
+    with pytest.raises(ValueError):
+        dgl._atomic_write_json(bogus, {"x": 1})
+
+
+def test_atomic_write_refuses_seed_jsonl_paths(
+    isolated_artifacts: dict[str, Path],
+    tmp_path: Path,
+) -> None:
+    """The sentinel guard refuses any seed.jsonl / delegation_seed.jsonl
+    / generated_seed.jsonl write attempt."""
+    for name in ("seed.jsonl", "delegation_seed.jsonl", "generated_seed.jsonl"):
+        target = tmp_path / name
+        with pytest.raises(ValueError):
+            dgl._atomic_write_json(target, {"x": 1})
+        # And the file must NOT have been created as a side effect.
+        assert not target.exists()
+
+
+# ---------------------------------------------------------------------------
+# generated_seed.jsonl ABSENCE invariant
+# ---------------------------------------------------------------------------
+
+
+def test_generated_seed_jsonl_remains_absent_in_repo() -> None:
+    """The repo root must not contain ``generated_seed.jsonl`` —
+    the A18b writer slice is not authorised."""
+    path = REPO_ROOT / "generated_seed.jsonl"
+    assert not path.exists(), (
+        "generated_seed.jsonl must not exist; the A18b writer slice "
+        "is operator-go territory and has not been authorised."
+    )
+
+
+def test_default_mode_does_not_create_generated_seed_jsonl(
+    isolated_artifacts: dict[str, Path],
+) -> None:
+    """Even after running default mode (which writes to its sentinel
+    path), generated_seed.jsonl must not appear anywhere under
+    tmp_path."""
+    _write_artifact(isolated_artifacts["bugfix_loop"], _bugfix_payload(2))
+    rc = dgl.main([])
+    assert rc == 0
+    for found in isolated_artifacts["tmp_root"].rglob("generated_seed.jsonl"):
+        raise AssertionError(
+            f"generated_seed.jsonl appeared at {found} after A18a run — "
+            "A18b writer is not authorised"
+        )
+
+
+def test_no_write_mode_does_not_create_generated_seed_jsonl(
+    isolated_artifacts: dict[str, Path],
+) -> None:
+    _write_artifact(isolated_artifacts["bugfix_loop"], _bugfix_payload(2))
+    rc = dgl.main(["--no-write"])
+    assert rc == 0
+    for found in isolated_artifacts["tmp_root"].rglob("generated_seed.jsonl"):
+        raise AssertionError(
+            f"generated_seed.jsonl appeared at {found} during --no-write run"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Source-text + AST scans
+# ---------------------------------------------------------------------------
+
+
+def _module_source() -> str:
+    return Path(dgl.__file__).read_text(encoding="utf-8")
+
+
+def _imported_module_names() -> set[str]:
+    tree = ast.parse(_module_source())
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module is not None:
+                names.add(node.module)
+    return names
+
+
+def test_no_subprocess_in_module() -> None:
+    src = _module_source()
+    assert "import subprocess" not in src
+    assert "from subprocess" not in src
+
+
+def test_no_gh_or_git_in_module() -> None:
+    src = _module_source()
+    for needle in ("subprocess.run", " gh ", " git "):
+        assert needle not in src, needle
+
+
+def test_no_network_imports_in_module() -> None:
+    src = _module_source()
+    for forbidden in (
+        "import socket",
+        "import urllib",
+        "import http.client",
+        "import requests",
+        "import httpx",
+        "import aiohttp",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_no_web_push_library_import_in_module() -> None:
+    names = _imported_module_names()
+    for n in names:
+        assert n not in {"pywebpush", "webpush", "web_push"}, n
+        assert not n.startswith("pywebpush."), n
+
+
+def test_no_token_mint_helpers_imported() -> None:
+    """A18a must not import the approval-token mint/verify helpers.
+    Acting on a generated candidate is N5b / A18b/A18c territory."""
+    names = _imported_module_names()
+    for forbidden in (
+        "reporting.approval_token_gate",
+        "reporting.approval_token_runtime",
+        "reporting.web_push_real_transport",
+    ):
+        assert forbidden not in names, forbidden
+
+
+def test_no_vapid_or_token_env_literal_in_module() -> None:
+    src = _module_source()
+    assert "WEB_PUSH_VAPID_PRIVATE_KEY" not in src
+    assert "ADE_APPROVAL_TOKEN_HMAC_SECRET" not in src
+
+
+def test_no_decision_verb_call_in_module() -> None:
+    src = _module_source().lower()
+    for verb in ("approve(", "reject(", "merge(", "deploy(", "trade("):
+        assert verb not in src, verb
+
+
+def test_no_seed_jsonl_writes_in_module() -> None:
+    """The literal seed-file names may appear in DOCSTRING / discipline-
+    invariant flag names (asserting absence), but must NEVER appear on a
+    write code path. The atomic-write helper restricts to the sentinel
+    prefix, and the test above pins that helper refuses the seed paths.
+    Here we additionally pin that no ``open(...,"w"`` / ``write_text``
+    / ``.write(`` call site mentions a seed filename."""
+    src = _module_source()
+    # Reject open() write modes mentioning seed file names.
+    forbidden_write_call_patterns = (
+        '"seed.jsonl"',
+        '"delegation_seed.jsonl"',
+        '"generated_seed.jsonl"',
+    )
+    # The docstring mentions ``generated_seed.jsonl`` (as the file we
+    # do NOT create) and the discipline invariants use
+    # ``writes_to_generated_seed_jsonl`` as a flag name. These uses
+    # appear OUTSIDE of write-call contexts; we scan executable lines
+    # only.
+    executable_lines = [
+        ln for ln in src.splitlines() if not ln.lstrip().startswith("#")
+    ]
+    executable = "\n".join(executable_lines)
+    # Defense-in-depth: no Python write-call (open(...,"w") /
+    # write_text(...) / .write(...)) on the same line as a seed name.
+    for line in executable.splitlines():
+        if "open(" in line or "write_text(" in line or ".write(" in line:
+            for needle in forbidden_write_call_patterns:
+                assert needle not in line, (
+                    f"seed-name literal {needle!r} appears on a write line: "
+                    f"{line!r}"
+                )
+
+
+def test_no_forbidden_module_imports() -> None:
+    forbidden_prefixes = (
+        "dashboard",
+        "frontend",
+        "automation",
+        "broker",
+        "agent.risk",
+        "agent.execution",
+        "research",
+        "reporting.intelligent_routing",
+        "live",
+        "paper",
+        "shadow",
+        "trading",
+    )
+    for module in _imported_module_names():
+        for prefix in forbidden_prefixes:
+            assert module != prefix, module
+            assert not module.startswith(prefix + "."), module
+
+
+def test_imports_only_stdlib_and_assert_no_secrets() -> None:
+    """The projector must import only stdlib plus the secret-redactor
+    guard."""
+    names = _imported_module_names()
+    allowed_reporting = {
+        "reporting",
+        "reporting.agent_audit_summary",
+    }
+    for n in names:
+        if n == "reporting" or n.startswith("reporting."):
+            assert n in allowed_reporting, n
+
+
+# ---------------------------------------------------------------------------
+# Step 5 + Level 6 invariants
+# ---------------------------------------------------------------------------
+
+
+def test_import_does_not_flip_step5_invariants() -> None:
+    importlib.reload(dgl)
+    assert dgl.step5_implementation_allowed is False
+    assert dgl.STEP5_ENABLED_SUBSTAGE == "none"
+
+
+def test_module_source_pins_step5_invariants() -> None:
+    src = _module_source()
+    assert "step5_implementation_allowed: Final[bool] = False" in src
+    assert 'STEP5_ENABLED_SUBSTAGE: Final[str] = "none"' in src
+    assert "step5_implementation_allowed = True" not in src
+
+
+# ---------------------------------------------------------------------------
+# Doc invariants
+# ---------------------------------------------------------------------------
+
+
+def _doc_text() -> str:
+    return (
+        REPO_ROOT
+        / "docs"
+        / "governance"
+        / "development_generated_lane.md"
+    ).read_text(encoding="utf-8")
+
+
+def test_doc_states_dry_run_only() -> None:
+    text = _doc_text().lower()
+    assert "dry-run" in text or "report-only" in text
+
+
+def test_doc_states_writer_not_authorized() -> None:
+    text = _doc_text().lower()
+    assert "writer is not authorised" in text or (
+        "writer is not authorized" in text
+    ) or "writer not authorised" in text or (
+        "writer not authorized" in text
+    )
+
+
+def test_doc_states_step5_blocked() -> None:
+    text = _doc_text().lower()
+    assert "step 5" in text
+    assert "blocked" in text or "remains blocked" in text or (
+        "permanently disabled" in text
+    )
+
+
+def test_doc_states_level_6_permanently_disabled() -> None:
+    text = _doc_text().lower()
+    assert "level 6" in text
+    assert "permanently disabled" in text
+
+
+def test_doc_mentions_a18b_and_a18c_as_separate_operator_go() -> None:
+    text = _doc_text().lower()
+    assert "a18b" in text
+    assert "a18c" in text
+    assert "operator" in text


### PR DESCRIPTION
## Summary

Adds the **smallest safe A18 slice**: a pure stdlib-only projector at [reporting/development_generated_lane.py](reporting/development_generated_lane.py) that inspects the existing A10 bugfix-loop / A11 delegation / A13 e2e-proof artefacts and emits a bounded dry-run report at `logs/development_generated_lane/latest.json` describing what generated candidate work items **would** be proposed **if** a future generated-lane writer were authorised.

**No new authority is introduced.** The `generated_seed.jsonl` writer is **NOT** authorised — A18b (writer) and A18c (A17 admission integration) each require their own explicit operator go-signal.

## Surface contract

- **Output path:** `logs/development_generated_lane/latest.json` (sentinel-restricted atomic write).
- **Wrapper schema:** `schema_version`, `module_version`, `report_kind`, `generated_at_utc`, `step5_*`, `candidate_count`, `candidates` (≤ 16), `sources_read`, `validation_warnings`, `vocabularies`, `discipline_invariants`, `note`.
- **Per-candidate schema (closed, 10 keys):** `generated_candidate_id`, `source_module`, `source_id`, `proposed_kind` (`bugfix` / `delegation` / `e2e_proof` / `unknown`), `proposed_title` (≤ 120 chars), `proposed_summary` (≤ 300 chars), `evidence_hash`, `admission_preview` (always `report_only_not_admitted`), `block_reason` (always `generated_lane_writer_not_authorized`), `would_require_operator_go` (always `True`).
- **CLI:** `python -m reporting.development_generated_lane [--no-write] [--indent N]`. `--no-write` prints to stdout only; default mode atomic-writes the report AND prints. **In NEITHER mode is `generated_seed.jsonl` created.**

## Diff scope (exactly 3 files)

| File | Change |
|------|--------|
| [reporting/development_generated_lane.py](reporting/development_generated_lane.py) | new stdlib-only projector (675 LOC) |
| [tests/unit/test_development_generated_lane.py](tests/unit/test_development_generated_lane.py) | 37 strict pin tests (625 LOC) |
| [docs/governance/development_generated_lane.md](docs/governance/development_generated_lane.md) | operator-facing companion doc (193 LOC) |

## Hard invariants preserved
- `step5_implementation_allowed = False`, `STEP5_ENABLED_SUBSTAGE = \"none\"` — unchanged
- Level 6 permanently disabled — governance-lint green
- [dashboard/dashboard.py](dashboard/dashboard.py) UNTOUCHED
- [dashboard/api_push_dispatch.py](dashboard/api_push_dispatch.py) / [reporting/web_push_real_transport.py](reporting/web_push_real_transport.py) / [frontend/public/sw-push.js](frontend/public/sw-push.js) / [reporting/approval_token_*](reporting/) — UNCHANGED
- `.gitleaks.toml` / `.claude/**` UNTOUCHED
- No QRE / research / live / paper / shadow / risk / broker / execution / orchestration / automation / trading changes
- No `approve(` / `reject(` / `merge(` / `deploy(` / `trade(` call patterns
- **`generated_seed.jsonl` ABSENT in repo** (test-pinned: `test_generated_seed_jsonl_remains_absent_in_repo`)
- `generated_seed.jsonl` not created during any test run (`tmp_path.rglob` scan-pinned)
- The atomic-write helper explicitly refuses `seed.jsonl` / `delegation_seed.jsonl` / `generated_seed.jsonl` write attempts (test-pinned)
- No new env-var read, no new secret, no new authority

## Test plan (all green locally)
- [x] `python scripts/governance_lint.py` → OK (16 agents, 5 workflows)
- [x] `python -m pytest tests/smoke -q` → 18 passed
- [x] `python -m pytest tests/unit/test_development_generated_lane.py -q` → 37 passed
- [x] `python -m reporting.development_generated_lane --no-write` → emits closed-schema dry-run report (Step 5 invariants intact)
- [x] `python -m reporting.development_step5_loop --no-write` → invariants intact
- [x] `python -m reporting.development_operational_digest --no-write` → invariants intact

Frontend was NOT touched (no `frontend/**` changes).

## Remains open (NOT in this slice)

- **A18b** — generated_seed.jsonl writer. Requires explicit operator go-signal. Will introduce a sentinel-restricted append-only writer; the projector will then have a real candidate-emission path. A18b does NOT change A17 admission.
- **A18c** — A17 admission integration of the new lane. Requires explicit operator go-signal. A17 will read `generated_seed.jsonl` with the SAME admission filter as `seed.jsonl` / `delegation_seed.jsonl` — no relaxation.
- **N5b** — actual merge execution (separate roadmap track, operator-go required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)