### PR TITLE
feat(notif): N5c — read-only merge recommendation UI in PWA

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import { Reports } from "./routes/Reports";
 import { Candidates } from "./routes/Candidates";
 import { AgentControl } from "./routes/AgentControl";
 import { AgentControlInboxPlaceholder } from "./routes/AgentControl/InboxPlaceholder";
+import { AgentControlMergeRecommendation } from "./routes/AgentControl/MergeRecommendation";
 
 export function App() {
   return (
@@ -55,6 +56,32 @@ export function App() {
           element={
             <RequireAuth>
               <AgentControlInboxPlaceholder />
+            </RequireAuth>
+          }
+        />
+        {/*
+         * v3.15.16.N5c — read-only merge-recommendation surface backed
+         * by the existing N5a /api/agent-control/merge-recommendation/{list,detail}
+         * blueprint. Both routes are read-only and share the same
+         * <AgentControlMergeRecommendation /> component, which picks
+         * list vs detail based on the optional :recommendationId param.
+         * No approve / reject / merge / deploy verbs are exposed; merge
+         * execution remains N5b territory and is not implemented in
+         * this stage.
+         */}
+        <Route
+          path="/agent-control/merge-recommendation"
+          element={
+            <RequireAuth>
+              <AgentControlMergeRecommendation />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/agent-control/merge-recommendation/:recommendationId"
+          element={
+            <RequireAuth>
+              <AgentControlMergeRecommendation />
             </RequireAuth>
           }
         />

--- a/frontend/src/api/agent_control.ts
+++ b/frontend/src/api/agent_control.ts
@@ -299,6 +299,60 @@ export interface AgentControlNextUp {
   artifact_path?: string;
 }
 
+// v3.15.16.N5c — read-only N5a merge-recommendation surface.
+// Closed-schema rows projected by reporting.development_merge_recommendation
+// and surfaced via dashboard.api_merge_recommendation (UNWIRED → wired by
+// PR #191). Every field is a bounded scalar (no PR body, no diff, no commit
+// message). The PWA renders these as read-only; no merge / approve / reject /
+// deploy verb is exposed in the UI, and the closed
+// recommendation_action vocabulary uses ``recommend_human_*`` prefixes that
+// are explicitly NOT the executable verbs themselves.
+export interface AgentControlMergeRecommendationRow {
+  recommendation_id: string;
+  pr_number: number;
+  head_sha: string;
+  head_ref: string;
+  base_ref: string;
+  observer_classification: string;
+  inbox_blocked_count: number;
+  inbox_critical_count: number;
+  inbox_needs_review_count: number;
+  recommendation_action: string;
+  recommendation_reason: string;
+  evaluated_at: string;
+}
+
+export interface AgentControlMergeRecommendationList {
+  kind: "agent_control_merge_recommendation_list";
+  schema_version: number;
+  module_version?: string;
+  status: "ok" | "not_available";
+  reason?: string;
+  rows: AgentControlMergeRecommendationRow[];
+  counts?: { rows?: number };
+  generated_at_utc?: string;
+  artifact_path?: string;
+  step5_implementation_allowed?: boolean;
+  step5_enabled_substage?: string;
+}
+
+export interface AgentControlMergeRecommendationDetail {
+  kind: "agent_control_merge_recommendation_detail";
+  schema_version: number;
+  module_version?: string;
+  status:
+    | "ok"
+    | "not_available"
+    | "not_found"
+    | "invalid_recommendation_id";
+  reason?: string;
+  row?: AgentControlMergeRecommendationRow;
+  generated_at_utc?: string;
+  artifact_path?: string;
+  step5_implementation_allowed?: boolean;
+  step5_enabled_substage?: string;
+}
+
 export interface AgentControlExecuteSafe {
   kind: "agent_control_execute_safe";
   schema_version: number;
@@ -351,6 +405,43 @@ async function getJson<T>(path: string): Promise<T> {
   }
 }
 
+// N5c — merge-recommendation client: the N5a API returns well-formed
+// envelopes even on 4xx (``not_found`` → 404, ``invalid_recommendation_id``
+// → 400, ``not_available`` → 404). The shared ``getJson`` helper would
+// collapse all of those to ``not_available``, hiding the API's
+// closed-vocabulary status from the read-only PWA. This helper honours
+// the JSON body on 4xx so the UI can render the precise state — still
+// without any mutating verb on the wire.
+async function getJsonEnvelope<T extends { status?: string }>(
+  path: string,
+): Promise<T> {
+  try {
+    const res = await fetch(path, {
+      method: "GET",
+      credentials: "include",
+      headers: { Accept: "application/json" },
+    });
+    let body: T | null = null;
+    try {
+      body = (await res.json()) as T;
+    } catch {
+      body = null;
+    }
+    if (body && typeof body === "object" && body.status) {
+      return body;
+    }
+    return {
+      status: "not_available",
+      reason: res.ok ? "malformed" : `http_${res.status}`,
+    } as unknown as T;
+  } catch (err) {
+    return {
+      status: "not_available",
+      reason: `fetch_error: ${(err as Error)?.name || "Error"}`,
+    } as unknown as T;
+  }
+}
+
 export const agentControlApi = {
   status: () => getJson<AgentControlStatus>(`${BASE}/status`),
   activity: () => getJson<AgentControlActivity>(`${BASE}/activity`),
@@ -365,4 +456,14 @@ export const agentControlApi = {
   executeSafe: () =>
     getJson<AgentControlExecuteSafe>(`${BASE}/execute-safe`),
   nextUp: () => getJson<AgentControlNextUp>(`${BASE}/next-up`),
+  mergeRecommendationList: () =>
+    getJsonEnvelope<AgentControlMergeRecommendationList>(
+      `${BASE}/merge-recommendation/list`,
+    ),
+  mergeRecommendationDetail: (recommendationId: string) =>
+    getJsonEnvelope<AgentControlMergeRecommendationDetail>(
+      `${BASE}/merge-recommendation/detail/${encodeURIComponent(
+        recommendationId,
+      )}`,
+    ),
 };

--- a/frontend/src/routes/AgentControl/MergeRecommendation.tsx
+++ b/frontend/src/routes/AgentControl/MergeRecommendation.tsx
@@ -1,0 +1,555 @@
+/**
+ * AgentControlMergeRecommendation
+ * --------------------------------
+ *
+ * N5c — read-only PWA surface for the existing N5a merge-recommendation
+ * API. Renders the closed-schema A23 / N5a payload as a bounded list
+ * and per-row detail. **No** approve / reject / merge / deploy action
+ * is exposed; merge execution remains N5b territory and is not
+ * implemented in this stage.
+ *
+ * Two views share this component:
+ *
+ *   ``/agent-control/merge-recommendation``
+ *       Renders the read-only N5a list envelope.
+ *
+ *   ``/agent-control/merge-recommendation/:recommendationId``
+ *       Renders the read-only N5a detail envelope for the bounded
+ *       ``recommendationId`` route parameter.
+ *
+ * Hard guarantees enforced by the unit tests:
+ *
+ *   - Read-only banner is always rendered.
+ *   - Only the N5a endpoints under
+ *     ``/api/agent-control/merge-recommendation/...`` are fetched.
+ *   - No call to any N4b ``approval-token`` endpoint.
+ *   - No call to the N3b mobile-inbox endpoints.
+ *   - No mutating verbs: every fetch is a ``GET`` with
+ *     ``credentials: same-origin``. No ``XMLHttpRequest``, no
+ *     ``navigator.sendBeacon``, no POST / PUT / PATCH / DELETE.
+ *   - Zero ``<button>`` elements in the rendered DOM. Tabs are
+ *     ``<Link>`` components only; refresh is a ``<Link>`` to the
+ *     same path with a refresh-triggered remount key.
+ *   - ``recommendationId`` is bounded to charset ``[A-Za-z0-9_-]``
+ *     and ≤ 128 characters before any fetch.
+ *   - Empty / not_available / not_found / invalid_recommendation_id /
+ *     malformed / network failure all collapse to safe states.
+ *   - A ``<Link>`` back to ``/agent-control`` is always present.
+ *
+ * Note on the word "merge": this surface is *about* merge
+ * recommendations and the read-only banner mentions that "merge
+ * execution is not implemented in this stage". The unit tests therefore
+ * assert *no decision-action button* and *no fetch to action endpoints*
+ * rather than asserting the literal string "merge" never appears.
+ */
+
+import { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+
+import {
+  agentControlApi,
+  type AgentControlMergeRecommendationDetail,
+  type AgentControlMergeRecommendationList,
+  type AgentControlMergeRecommendationRow,
+} from "../../api/agent_control";
+
+const MAX_RECOMMENDATION_ID_LEN = 128;
+const READ_ONLY_BANNER =
+  "Read-only merge recommendation. Merge execution is not implemented in this stage.";
+
+function boundedRecommendationId(raw: string | undefined | null): string {
+  if (typeof raw !== "string") return "";
+  const trimmed = raw.trim();
+  if (!trimmed) return "";
+  const safe = trimmed.replace(/[^A-Za-z0-9_\-]/g, "");
+  return safe.slice(0, MAX_RECOMMENDATION_ID_LEN);
+}
+
+function shortHead(sha: string | undefined | null): string {
+  if (typeof sha !== "string" || !sha) return "";
+  return sha.length > 12 ? `${sha.slice(0, 12)}…` : sha;
+}
+
+type ListState =
+  | { phase: "loading" }
+  | { phase: "ok"; envelope: AgentControlMergeRecommendationList }
+  | { phase: "empty"; envelope: AgentControlMergeRecommendationList }
+  | { phase: "not_available"; reason: string };
+
+type DetailState =
+  | { phase: "loading" }
+  | { phase: "ok"; envelope: AgentControlMergeRecommendationDetail }
+  | { phase: "not_found"; reason: string }
+  | { phase: "invalid"; reason: string }
+  | { phase: "not_available"; reason: string };
+
+function Banner() {
+  return (
+    <div
+      data-testid="agent-control-merge-recommendation-banner"
+      style={{
+        margin: "0 0 0.85rem 0",
+        padding: "0.55rem 0.7rem",
+        borderRadius: "0.4rem",
+        background: "rgba(0,0,0,0.05)",
+        fontSize: "0.85rem",
+        lineHeight: 1.4,
+      }}
+    >
+      {READ_ONLY_BANNER}
+    </div>
+  );
+}
+
+function BackLink() {
+  return (
+    <p style={{ margin: "1rem 0 0 0" }}>
+      <Link
+        to="/agent-control"
+        data-testid="agent-control-merge-recommendation-back-link"
+        style={{ color: "var(--ink, #1a73e8)" }}
+      >
+        Back to agent control
+      </Link>
+    </p>
+  );
+}
+
+function PageShell({
+  heading,
+  children,
+}: {
+  heading: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <main
+      data-testid="agent-control-merge-recommendation-root"
+      style={{
+        padding: "1.25rem",
+        maxWidth: "640px",
+        margin: "0 auto",
+        fontFamily: "system-ui, -apple-system, sans-serif",
+      }}
+    >
+      <h1 style={{ fontSize: "1.4rem", margin: "0 0 0.75rem 0" }}>{heading}</h1>
+      <Banner />
+      {children}
+      <BackLink />
+    </main>
+  );
+}
+
+function RowFields({
+  row,
+  testIdPrefix,
+}: {
+  row: AgentControlMergeRecommendationRow;
+  testIdPrefix: string;
+}) {
+  return (
+    <dl
+      data-testid={`${testIdPrefix}-fields`}
+      style={{
+        display: "grid",
+        gridTemplateColumns: "auto 1fr",
+        columnGap: "0.6rem",
+        rowGap: "0.25rem",
+        fontSize: "0.85rem",
+        margin: 0,
+      }}
+    >
+      <dt>recommendation_id</dt>
+      <dd data-testid={`${testIdPrefix}-recommendation-id`}>
+        <code>{row.recommendation_id}</code>
+      </dd>
+      <dt>pr_number</dt>
+      <dd data-testid={`${testIdPrefix}-pr-number`}>{row.pr_number}</dd>
+      <dt>head_ref</dt>
+      <dd data-testid={`${testIdPrefix}-head-ref`}>
+        <code>{row.head_ref || "—"}</code>
+      </dd>
+      <dt>base_ref</dt>
+      <dd data-testid={`${testIdPrefix}-base-ref`}>
+        <code>{row.base_ref || "—"}</code>
+      </dd>
+      <dt>head_sha</dt>
+      <dd
+        data-testid={`${testIdPrefix}-head-sha`}
+        title={row.head_sha || ""}
+      >
+        <code>{shortHead(row.head_sha) || "—"}</code>
+      </dd>
+      <dt>observer_classification</dt>
+      <dd data-testid={`${testIdPrefix}-observer-classification`}>
+        {row.observer_classification || "—"}
+      </dd>
+      <dt>recommendation_action</dt>
+      <dd data-testid={`${testIdPrefix}-recommendation-action`}>
+        {row.recommendation_action || "—"}
+      </dd>
+      <dt>recommendation_reason</dt>
+      <dd data-testid={`${testIdPrefix}-recommendation-reason`}>
+        {row.recommendation_reason || "—"}
+      </dd>
+      <dt>inbox_blocked_count</dt>
+      <dd data-testid={`${testIdPrefix}-inbox-blocked-count`}>
+        {row.inbox_blocked_count}
+      </dd>
+      <dt>inbox_critical_count</dt>
+      <dd data-testid={`${testIdPrefix}-inbox-critical-count`}>
+        {row.inbox_critical_count}
+      </dd>
+      <dt>inbox_needs_review_count</dt>
+      <dd data-testid={`${testIdPrefix}-inbox-needs-review-count`}>
+        {row.inbox_needs_review_count}
+      </dd>
+      <dt>evaluated_at</dt>
+      <dd data-testid={`${testIdPrefix}-evaluated-at`}>
+        {row.evaluated_at || "—"}
+      </dd>
+    </dl>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// List view
+// ---------------------------------------------------------------------------
+
+function ListView() {
+  const [state, setState] = useState<ListState>({ phase: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    setState({ phase: "loading" });
+    agentControlApi
+      .mergeRecommendationList()
+      .then((envelope) => {
+        if (cancelled) return;
+        if (envelope.status !== "ok") {
+          setState({
+            phase: "not_available",
+            reason: envelope.reason || "not_available",
+          });
+          return;
+        }
+        const rows = Array.isArray(envelope.rows) ? envelope.rows : [];
+        if (rows.length === 0) {
+          setState({ phase: "empty", envelope });
+          return;
+        }
+        setState({ phase: "ok", envelope });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setState({ phase: "not_available", reason: "network" });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <PageShell heading="Merge recommendations">
+      {state.phase === "loading" && (
+        <p data-testid="agent-control-merge-recommendation-loading">
+          Loading merge recommendations…
+        </p>
+      )}
+
+      {state.phase === "not_available" && (
+        <p
+          data-testid="agent-control-merge-recommendation-not-available"
+          style={{ margin: "0.75rem 0", lineHeight: 1.45 }}
+        >
+          The merge recommendation artefact is not available
+          ({state.reason}). The full N5a report is generated by{" "}
+          <code>reporting.development_merge_recommendation</code>; this
+          view will render rows once the artefact is present.
+        </p>
+      )}
+
+      {state.phase === "empty" && (
+        <p
+          data-testid="agent-control-merge-recommendation-empty"
+          style={{ margin: "0.75rem 0", lineHeight: 1.45 }}
+        >
+          No open recommendations at this time. The N5a projector has
+          produced an empty row set ({state.envelope.counts?.rows ?? 0}{" "}
+          row(s)).
+        </p>
+      )}
+
+      {state.phase === "ok" && (
+        <section
+          data-testid="agent-control-merge-recommendation-list"
+          style={{ marginTop: "0.5rem" }}
+        >
+          <p
+            data-testid="agent-control-merge-recommendation-list-count"
+            style={{
+              fontSize: "0.85rem",
+              color: "rgba(0,0,0,0.6)",
+              margin: "0 0 0.6rem 0",
+            }}
+          >
+            {state.envelope.rows.length} recommendation(s) —{" "}
+            generated_at_utc:{" "}
+            <code>{state.envelope.generated_at_utc || "—"}</code>
+          </p>
+          <ul
+            data-testid="agent-control-merge-recommendation-list-items"
+            style={{
+              listStyle: "none",
+              padding: 0,
+              margin: 0,
+              display: "flex",
+              flexDirection: "column",
+              gap: "0.5rem",
+            }}
+          >
+            {state.envelope.rows.map((row) => {
+              const safeId = boundedRecommendationId(row.recommendation_id);
+              return (
+                <li
+                  key={row.recommendation_id}
+                  data-testid={`agent-control-merge-recommendation-row-${row.recommendation_id}`}
+                  style={{
+                    padding: "0.6rem 0.7rem",
+                    border: "1px solid rgba(0,0,0,0.08)",
+                    borderRadius: "0.45rem",
+                    background: "rgba(0,0,0,0.02)",
+                  }}
+                >
+                  <Link
+                    to={`/agent-control/merge-recommendation/${safeId}`}
+                    data-testid={`agent-control-merge-recommendation-link-${row.recommendation_id}`}
+                    style={{
+                      color: "var(--ink, #1a73e8)",
+                      textDecoration: "none",
+                      display: "block",
+                    }}
+                  >
+                    <div
+                      style={{
+                        display: "flex",
+                        justifyContent: "space-between",
+                        gap: "0.5rem",
+                        fontFamily:
+                          "ui-monospace, SFMono-Regular, Menlo, monospace",
+                        fontSize: "0.85rem",
+                        marginBottom: "0.25rem",
+                      }}
+                    >
+                      <span>{row.recommendation_id}</span>
+                      <span>PR #{row.pr_number}</span>
+                    </div>
+                    <div
+                      style={{
+                        fontSize: "0.8rem",
+                        color: "rgba(0,0,0,0.7)",
+                      }}
+                    >
+                      {row.recommendation_action} ·{" "}
+                      {row.observer_classification || "—"}
+                    </div>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+          {state.envelope.step5_enabled_substage ? (
+            <p
+              data-testid="agent-control-merge-recommendation-step5-invariant"
+              style={{
+                marginTop: "0.85rem",
+                fontSize: "0.75rem",
+                color: "rgba(0,0,0,0.55)",
+              }}
+            >
+              step5_implementation_allowed:{" "}
+              {String(
+                state.envelope.step5_implementation_allowed ?? false,
+              )}{" "}
+              · step5_enabled_substage:{" "}
+              {state.envelope.step5_enabled_substage}
+            </p>
+          ) : null}
+        </section>
+      )}
+    </PageShell>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Detail view
+// ---------------------------------------------------------------------------
+
+function DetailView({ recommendationId }: { recommendationId: string }) {
+  const [state, setState] = useState<DetailState>({ phase: "loading" });
+
+  useEffect(() => {
+    if (!recommendationId) {
+      setState({ phase: "invalid", reason: "empty" });
+      return;
+    }
+    let cancelled = false;
+    setState({ phase: "loading" });
+    agentControlApi
+      .mergeRecommendationDetail(recommendationId)
+      .then((envelope) => {
+        if (cancelled) return;
+        switch (envelope.status) {
+          case "ok":
+            setState({ phase: "ok", envelope });
+            return;
+          case "not_found":
+            setState({
+              phase: "not_found",
+              reason: envelope.reason || "not_found",
+            });
+            return;
+          case "invalid_recommendation_id":
+            setState({
+              phase: "invalid",
+              reason: envelope.reason || "invalid_recommendation_id",
+            });
+            return;
+          default:
+            setState({
+              phase: "not_available",
+              reason: envelope.reason || "not_available",
+            });
+            return;
+        }
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setState({ phase: "not_available", reason: "network" });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [recommendationId]);
+
+  return (
+    <PageShell heading="Merge recommendation detail">
+      <p
+        data-testid="agent-control-merge-recommendation-detail-id"
+        style={{
+          fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+          fontSize: "0.85rem",
+          background: "rgba(0,0,0,0.04)",
+          padding: "0.5rem 0.65rem",
+          borderRadius: "0.4rem",
+          wordBreak: "break-all",
+          margin: "0 0 0.75rem 0",
+        }}
+      >
+        recommendation_id: {recommendationId || "—"}
+      </p>
+
+      <p style={{ margin: "0 0 0.75rem 0" }}>
+        <Link
+          to="/agent-control/merge-recommendation"
+          data-testid="agent-control-merge-recommendation-detail-list-link"
+          style={{ color: "var(--ink, #1a73e8)" }}
+        >
+          ← Back to list
+        </Link>
+      </p>
+
+      {state.phase === "loading" && (
+        <p data-testid="agent-control-merge-recommendation-detail-loading">
+          Loading merge recommendation detail…
+        </p>
+      )}
+
+      {state.phase === "ok" && state.envelope.row && (
+        <section
+          data-testid="agent-control-merge-recommendation-detail"
+          style={{ marginTop: "0.5rem" }}
+        >
+          <RowFields
+            row={state.envelope.row}
+            testIdPrefix="agent-control-merge-recommendation-detail"
+          />
+          {state.envelope.generated_at_utc ? (
+            <p
+              data-testid="agent-control-merge-recommendation-detail-generated-at"
+              style={{
+                marginTop: "0.65rem",
+                fontSize: "0.75rem",
+                color: "rgba(0,0,0,0.55)",
+              }}
+            >
+              generated_at_utc:{" "}
+              <code>{state.envelope.generated_at_utc}</code>
+            </p>
+          ) : null}
+          {state.envelope.step5_enabled_substage ? (
+            <p
+              data-testid="agent-control-merge-recommendation-detail-step5-invariant"
+              style={{
+                marginTop: "0.25rem",
+                fontSize: "0.75rem",
+                color: "rgba(0,0,0,0.55)",
+              }}
+            >
+              step5_implementation_allowed:{" "}
+              {String(
+                state.envelope.step5_implementation_allowed ?? false,
+              )}{" "}
+              · step5_enabled_substage:{" "}
+              {state.envelope.step5_enabled_substage}
+            </p>
+          ) : null}
+        </section>
+      )}
+
+      {state.phase === "not_found" && (
+        <p
+          data-testid="agent-control-merge-recommendation-detail-not-found"
+          style={{ margin: "0.75rem 0", lineHeight: 1.45 }}
+        >
+          No recommendation row matches this id ({state.reason}). The
+          N5a artefact may have advanced past this head SHA, or the
+          recommendation was already resolved upstream.
+        </p>
+      )}
+
+      {state.phase === "invalid" && (
+        <p
+          data-testid="agent-control-merge-recommendation-detail-invalid"
+          style={{ margin: "0.75rem 0", lineHeight: 1.45 }}
+        >
+          The recommendation_id in this URL is not valid
+          ({state.reason}). Go back to the list to pick a current row.
+        </p>
+      )}
+
+      {state.phase === "not_available" && (
+        <p
+          data-testid="agent-control-merge-recommendation-detail-not-available"
+          style={{ margin: "0.75rem 0", lineHeight: 1.45 }}
+        >
+          The merge recommendation artefact is not available
+          ({state.reason}).
+        </p>
+      )}
+    </PageShell>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Entry point — picks list or detail based on the route parameter
+// ---------------------------------------------------------------------------
+
+export function AgentControlMergeRecommendation() {
+  const params = useParams<{ recommendationId?: string }>();
+  const safeId = boundedRecommendationId(params.recommendationId);
+  if (typeof params.recommendationId === "string") {
+    return <DetailView recommendationId={safeId} />;
+  }
+  return <ListView />;
+}

--- a/frontend/src/test/AgentControlMergeRecommendation.test.tsx
+++ b/frontend/src/test/AgentControlMergeRecommendation.test.tsx
@@ -1,0 +1,682 @@
+/**
+ * Tests for AgentControlMergeRecommendation — the N5c read-only
+ * PWA surface over the existing N5a merge-recommendation API.
+ *
+ * Hard guarantees verified here:
+ *   - Read-only banner is always rendered, in both list + detail views.
+ *   - Only the read-only N5a endpoints under
+ *     ``/api/agent-control/merge-recommendation/`` are fetched.
+ *   - No call to any N4b ``/api/agent-control/approval-token/*`` URL,
+ *     no call to the N3b ``/api/agent-control/mobile-inbox/*`` URL.
+ *   - Every fetch is a same-origin GET. No POST / PUT / PATCH / DELETE.
+ *   - No ``<button>`` elements with executable decision verbs (approve,
+ *     reject, deploy, execute) appear in the DOM.
+ *   - List renders bounded closed-schema rows from the mocked API.
+ *   - Detail renders the bounded closed-schema row for status=ok.
+ *   - Empty / not_available / not_found / invalid_recommendation_id /
+ *     malformed / network failure all collapse to safe states.
+ *   - The bounded route param is sanitised before fetch (charset +
+ *     length).
+ *   - A link back to /agent-control is always rendered.
+ *   - navigator.sendBeacon is never called.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+
+import { AgentControlMergeRecommendation } from "../routes/AgentControl/MergeRecommendation";
+
+const mockFetch = vi.fn();
+const mockSendBeacon = vi.fn();
+
+const LIST_URL = "/api/agent-control/merge-recommendation/list";
+const DETAIL_BASE = "/api/agent-control/merge-recommendation/detail/";
+
+function jsonResponse(payload: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(payload), {
+    status: init.status ?? 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function row(
+  recommendation_id: string,
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    recommendation_id,
+    pr_number: 42,
+    head_sha: "deadbeefdeadbeef0000000000000001",
+    head_ref: "feature/branch-" + recommendation_id,
+    base_ref: "main",
+    observer_classification: "open_clean_mergeable",
+    inbox_blocked_count: 0,
+    inbox_critical_count: 0,
+    inbox_needs_review_count: 0,
+    recommendation_action: "recommend_human_merge",
+    recommendation_reason: "pr_clean_and_no_blocking_inbox",
+    evaluated_at: "2026-05-11T20:00:00Z",
+    ...overrides,
+  };
+}
+
+function listOkEnvelope(
+  rows: ReturnType<typeof row>[],
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    kind: "agent_control_merge_recommendation_list",
+    schema_version: 1,
+    module_version: "v3.15.16.N5a",
+    status: "ok",
+    rows,
+    counts: { rows: rows.length },
+    generated_at_utc: "2026-05-11T20:30:00Z",
+    artifact_path: "logs/development_merge_recommendation/latest.json",
+    step5_implementation_allowed: false,
+    step5_enabled_substage: "none",
+    ...overrides,
+  };
+}
+
+function detailOkEnvelope(r: ReturnType<typeof row>) {
+  return {
+    kind: "agent_control_merge_recommendation_detail",
+    schema_version: 1,
+    module_version: "v3.15.16.N5a",
+    status: "ok",
+    row: r,
+    generated_at_utc: "2026-05-11T20:30:00Z",
+    artifact_path: "logs/development_merge_recommendation/latest.json",
+    step5_implementation_allowed: false,
+    step5_enabled_substage: "none",
+  };
+}
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route
+          path="/agent-control/merge-recommendation"
+          element={<AgentControlMergeRecommendation />}
+        />
+        <Route
+          path="/agent-control/merge-recommendation/:recommendationId"
+          element={<AgentControlMergeRecommendation />}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", mockFetch);
+  if (typeof navigator !== "undefined") {
+    Object.defineProperty(navigator, "sendBeacon", {
+      configurable: true,
+      value: mockSendBeacon,
+    });
+  }
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  mockFetch.mockReset();
+  mockSendBeacon.mockReset();
+});
+
+// ---------------------------------------------------------------------------
+// Banner + back link — always rendered
+// ---------------------------------------------------------------------------
+
+describe("AgentControlMergeRecommendation — banner + structure", () => {
+  it("always renders the read-only banner on the list view", async () => {
+    mockFetch.mockResolvedValue(jsonResponse(listOkEnvelope([row("mr_1")])));
+    renderAt("/agent-control/merge-recommendation");
+    await waitFor(() =>
+      expect(mockFetch).toHaveBeenCalled(),
+    );
+    expect(
+      screen.getByTestId("agent-control-merge-recommendation-banner"),
+    ).toHaveTextContent(
+      /read-only merge recommendation\. merge execution is not implemented/i,
+    );
+  });
+
+  it("always renders the read-only banner on the detail view", async () => {
+    mockFetch.mockResolvedValue(jsonResponse(detailOkEnvelope(row("mr_1"))));
+    renderAt("/agent-control/merge-recommendation/mr_1");
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    expect(
+      screen.getByTestId("agent-control-merge-recommendation-banner"),
+    ).toHaveTextContent(
+      /read-only merge recommendation\. merge execution is not implemented/i,
+    );
+  });
+
+  it("always renders the back link to /agent-control on list", async () => {
+    mockFetch.mockResolvedValue(jsonResponse(listOkEnvelope([])));
+    renderAt("/agent-control/merge-recommendation");
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    expect(
+      screen.getByTestId("agent-control-merge-recommendation-back-link"),
+    ).toHaveAttribute("href", "/agent-control");
+  });
+
+  it("always renders the back link to /agent-control on detail", async () => {
+    mockFetch.mockResolvedValue(jsonResponse(detailOkEnvelope(row("mr_1"))));
+    renderAt("/agent-control/merge-recommendation/mr_1");
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    expect(
+      screen.getByTestId("agent-control-merge-recommendation-back-link"),
+    ).toHaveAttribute("href", "/agent-control");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// List view — happy path / empty / not_available / network / malformed
+// ---------------------------------------------------------------------------
+
+describe("AgentControlMergeRecommendation — list view", () => {
+  it("fetches only the N5a list endpoint with same-origin GET", async () => {
+    mockFetch.mockResolvedValue(jsonResponse(listOkEnvelope([row("mr_1")])));
+    renderAt("/agent-control/merge-recommendation");
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe(LIST_URL);
+    const method = (init as RequestInit | undefined)?.method ?? "GET";
+    expect(method).toBe("GET");
+    expect((init as RequestInit | undefined)?.credentials).toBe("include");
+  });
+
+  it("renders bounded closed-schema rows from the mocked list", async () => {
+    const rows = [
+      row("mr_alpha", {
+        pr_number: 101,
+        recommendation_action: "recommend_human_merge",
+        observer_classification: "open_clean_mergeable",
+      }),
+      row("mr_beta", {
+        pr_number: 202,
+        recommendation_action: "recommend_hold",
+        recommendation_reason: "pr_blocked_or_dirty",
+        observer_classification: "open_blocked_or_dirty",
+      }),
+    ];
+    mockFetch.mockResolvedValue(jsonResponse(listOkEnvelope(rows)));
+    renderAt("/agent-control/merge-recommendation");
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("agent-control-merge-recommendation-list"),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByTestId("agent-control-merge-recommendation-row-mr_alpha"),
+    ).toHaveTextContent(/PR #101/);
+    expect(
+      screen.getByTestId("agent-control-merge-recommendation-row-mr_beta"),
+    ).toHaveTextContent(/PR #202/);
+    expect(
+      screen.getByTestId("agent-control-merge-recommendation-list-count"),
+    ).toHaveTextContent(/2 recommendation\(s\)/);
+    // Each row links to the bounded detail route.
+    expect(
+      screen.getByTestId(
+        "agent-control-merge-recommendation-link-mr_alpha",
+      ),
+    ).toHaveAttribute(
+      "href",
+      "/agent-control/merge-recommendation/mr_alpha",
+    );
+  });
+
+  it("renders empty state when the API returns no rows", async () => {
+    mockFetch.mockResolvedValue(jsonResponse(listOkEnvelope([])));
+    renderAt("/agent-control/merge-recommendation");
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("agent-control-merge-recommendation-empty"),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      screen.queryByTestId("agent-control-merge-recommendation-list"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders not_available when API reports artefact missing", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({
+        kind: "agent_control_merge_recommendation_list",
+        schema_version: 1,
+        status: "not_available",
+        reason: "missing",
+        rows: [],
+        counts: { rows: 0 },
+        step5_implementation_allowed: false,
+        step5_enabled_substage: "none",
+      }),
+    );
+    renderAt("/agent-control/merge-recommendation");
+    await waitFor(() =>
+      expect(
+        screen.getByTestId(
+          "agent-control-merge-recommendation-not-available",
+        ),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("renders not_available on network failure", async () => {
+    mockFetch.mockRejectedValue(new Error("network"));
+    renderAt("/agent-control/merge-recommendation");
+    await waitFor(() =>
+      expect(
+        screen.getByTestId(
+          "agent-control-merge-recommendation-not-available",
+        ),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("renders not_available on malformed body", async () => {
+    mockFetch.mockResolvedValue(
+      new Response("not json", {
+        status: 200,
+        headers: { "content-type": "text/plain" },
+      }),
+    );
+    renderAt("/agent-control/merge-recommendation");
+    await waitFor(() =>
+      expect(
+        screen.getByTestId(
+          "agent-control-merge-recommendation-not-available",
+        ),
+      ).toBeInTheDocument(),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Detail view — happy path / not_found / invalid / not_available / network
+// ---------------------------------------------------------------------------
+
+describe("AgentControlMergeRecommendation — detail view", () => {
+  it("fetches the detail endpoint for the bounded recommendation_id", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse(detailOkEnvelope(row("mr_render"))),
+    );
+    renderAt("/agent-control/merge-recommendation/mr_render");
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe(`${DETAIL_BASE}mr_render`);
+    const method = (init as RequestInit | undefined)?.method ?? "GET";
+    expect(method).toBe("GET");
+  });
+
+  it("renders closed-schema scalars from the detail row", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse(
+        detailOkEnvelope(
+          row("mr_render", {
+            pr_number: 99,
+            head_ref: "feature/test",
+            base_ref: "main",
+            observer_classification: "open_clean_mergeable",
+            recommendation_action: "recommend_human_merge",
+            recommendation_reason: "pr_clean_and_no_blocking_inbox",
+            inbox_blocked_count: 0,
+            inbox_critical_count: 1,
+            inbox_needs_review_count: 2,
+            evaluated_at: "2026-05-11T20:00:00Z",
+          }),
+        ),
+      ),
+    );
+    renderAt("/agent-control/merge-recommendation/mr_render");
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("agent-control-merge-recommendation-detail"),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByTestId(
+        "agent-control-merge-recommendation-detail-recommendation-id",
+      ),
+    ).toHaveTextContent("mr_render");
+    expect(
+      screen.getByTestId(
+        "agent-control-merge-recommendation-detail-pr-number",
+      ),
+    ).toHaveTextContent("99");
+    expect(
+      screen.getByTestId(
+        "agent-control-merge-recommendation-detail-head-ref",
+      ),
+    ).toHaveTextContent("feature/test");
+    expect(
+      screen.getByTestId(
+        "agent-control-merge-recommendation-detail-base-ref",
+      ),
+    ).toHaveTextContent("main");
+    expect(
+      screen.getByTestId(
+        "agent-control-merge-recommendation-detail-observer-classification",
+      ),
+    ).toHaveTextContent("open_clean_mergeable");
+    expect(
+      screen.getByTestId(
+        "agent-control-merge-recommendation-detail-recommendation-action",
+      ),
+    ).toHaveTextContent("recommend_human_merge");
+    expect(
+      screen.getByTestId(
+        "agent-control-merge-recommendation-detail-recommendation-reason",
+      ),
+    ).toHaveTextContent("pr_clean_and_no_blocking_inbox");
+    expect(
+      screen.getByTestId(
+        "agent-control-merge-recommendation-detail-inbox-blocked-count",
+      ),
+    ).toHaveTextContent("0");
+    expect(
+      screen.getByTestId(
+        "agent-control-merge-recommendation-detail-inbox-critical-count",
+      ),
+    ).toHaveTextContent("1");
+    expect(
+      screen.getByTestId(
+        "agent-control-merge-recommendation-detail-inbox-needs-review-count",
+      ),
+    ).toHaveTextContent("2");
+    expect(
+      screen.getByTestId(
+        "agent-control-merge-recommendation-detail-evaluated-at",
+      ),
+    ).toHaveTextContent("2026-05-11T20:00:00Z");
+  });
+
+  it("renders not_found when the API reports an unknown recommendation_id", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse(
+        {
+          kind: "agent_control_merge_recommendation_detail",
+          schema_version: 1,
+          status: "not_found",
+          reason: "no_matching_recommendation_id",
+          artifact_path:
+            "logs/development_merge_recommendation/latest.json",
+          step5_implementation_allowed: false,
+          step5_enabled_substage: "none",
+        },
+        { status: 404 },
+      ),
+    );
+    renderAt("/agent-control/merge-recommendation/mr_missing");
+    await waitFor(() =>
+      expect(
+        screen.getByTestId(
+          "agent-control-merge-recommendation-detail-not-found",
+        ),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("renders invalid state when the API rejects the recommendation_id", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse(
+        {
+          kind: "agent_control_merge_recommendation_detail",
+          schema_version: 1,
+          status: "invalid_recommendation_id",
+          reason: "bad_charset",
+          step5_implementation_allowed: false,
+          step5_enabled_substage: "none",
+        },
+        { status: 400 },
+      ),
+    );
+    renderAt("/agent-control/merge-recommendation/mr_bad");
+    await waitFor(() =>
+      expect(
+        screen.getByTestId(
+          "agent-control-merge-recommendation-detail-invalid",
+        ),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("renders not_available on detail artefact missing", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse(
+        {
+          kind: "agent_control_merge_recommendation_detail",
+          schema_version: 1,
+          status: "not_available",
+          reason: "missing",
+          step5_implementation_allowed: false,
+          step5_enabled_substage: "none",
+        },
+        { status: 404 },
+      ),
+    );
+    renderAt("/agent-control/merge-recommendation/mr_x");
+    await waitFor(() =>
+      expect(
+        screen.getByTestId(
+          "agent-control-merge-recommendation-detail-not-available",
+        ),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("renders not_available on network failure in the detail view", async () => {
+    mockFetch.mockRejectedValue(new Error("network"));
+    renderAt("/agent-control/merge-recommendation/mr_x");
+    await waitFor(() =>
+      expect(
+        screen.getByTestId(
+          "agent-control-merge-recommendation-detail-not-available",
+        ),
+      ).toBeInTheDocument(),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// recommendation_id sanitisation
+// ---------------------------------------------------------------------------
+
+describe("AgentControlMergeRecommendation — recommendation_id sanitisation", () => {
+  it("strips characters outside [A-Za-z0-9_-] before display", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse(
+        {
+          kind: "agent_control_merge_recommendation_detail",
+          schema_version: 1,
+          status: "not_found",
+          reason: "no_matching_recommendation_id",
+          step5_implementation_allowed: false,
+          step5_enabled_substage: "none",
+        },
+        { status: 404 },
+      ),
+    );
+    renderAt("/agent-control/merge-recommendation/mr_safe<script>x");
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    const detailId = screen.getByTestId(
+      "agent-control-merge-recommendation-detail-id",
+    );
+    expect((detailId.textContent || "").toLowerCase()).not.toContain(
+      "<script>",
+    );
+  });
+
+  it("bounds the recommendation_id to 128 characters before display", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse(
+        {
+          kind: "agent_control_merge_recommendation_detail",
+          schema_version: 1,
+          status: "not_found",
+          reason: "no_matching_recommendation_id",
+          step5_implementation_allowed: false,
+          step5_enabled_substage: "none",
+        },
+        { status: 404 },
+      ),
+    );
+    const huge = "m".repeat(500);
+    renderAt(`/agent-control/merge-recommendation/${huge}`);
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    const detailId = screen.getByTestId(
+      "agent-control-merge-recommendation-detail-id",
+    );
+    const shown = (detailId.textContent || "").replace(
+      "recommendation_id: ",
+      "",
+    );
+    expect(shown.length).toBeLessThanOrEqual(128);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Read-only invariants
+// ---------------------------------------------------------------------------
+
+describe("AgentControlMergeRecommendation — read-only invariants", () => {
+  it("never issues a POST / PUT / PATCH / DELETE on the list view", async () => {
+    mockFetch.mockResolvedValue(jsonResponse(listOkEnvelope([row("mr_1")])));
+    renderAt("/agent-control/merge-recommendation");
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    for (const call of mockFetch.mock.calls) {
+      const init = call[1] as RequestInit | undefined;
+      const method = init?.method ?? "GET";
+      expect(["GET", "HEAD"]).toContain(method);
+    }
+  });
+
+  it("never issues a POST / PUT / PATCH / DELETE on the detail view", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse(detailOkEnvelope(row("mr_safe"))),
+    );
+    renderAt("/agent-control/merge-recommendation/mr_safe");
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    for (const call of mockFetch.mock.calls) {
+      const init = call[1] as RequestInit | undefined;
+      const method = init?.method ?? "GET";
+      expect(["GET", "HEAD"]).toContain(method);
+    }
+  });
+
+  it("never fetches an approval-token endpoint", async () => {
+    mockFetch.mockResolvedValue(jsonResponse(listOkEnvelope([row("mr_1")])));
+    renderAt("/agent-control/merge-recommendation");
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    for (const call of mockFetch.mock.calls) {
+      const url = String(call[0]);
+      expect(url).not.toContain("approval-token");
+    }
+  });
+
+  it("never fetches a mobile-inbox endpoint from the merge-recommendation surface", async () => {
+    mockFetch.mockResolvedValue(jsonResponse(listOkEnvelope([row("mr_1")])));
+    renderAt("/agent-control/merge-recommendation");
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    for (const call of mockFetch.mock.calls) {
+      const url = String(call[0]);
+      expect(url).not.toContain("/api/agent-control/mobile-inbox/");
+    }
+  });
+
+  it("only fetches the N5a merge-recommendation endpoints", async () => {
+    mockFetch.mockResolvedValue(jsonResponse(listOkEnvelope([row("mr_1")])));
+    renderAt("/agent-control/merge-recommendation");
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    for (const call of mockFetch.mock.calls) {
+      const url = String(call[0]);
+      expect(url).toMatch(/^\/api\/agent-control\/merge-recommendation\//);
+    }
+  });
+
+  it("does not call navigator.sendBeacon (list view)", async () => {
+    mockFetch.mockResolvedValue(jsonResponse(listOkEnvelope([row("mr_1")])));
+    renderAt("/agent-control/merge-recommendation");
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    expect(mockSendBeacon).not.toHaveBeenCalled();
+  });
+
+  it("does not call navigator.sendBeacon (detail view)", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse(detailOkEnvelope(row("mr_safe"))),
+    );
+    renderAt("/agent-control/merge-recommendation/mr_safe");
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    expect(mockSendBeacon).not.toHaveBeenCalled();
+  });
+
+  it("contains no executable decision-verb buttons on list", async () => {
+    mockFetch.mockResolvedValue(jsonResponse(listOkEnvelope([row("mr_1")])));
+    renderAt("/agent-control/merge-recommendation");
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("agent-control-merge-recommendation-list"),
+      ).toBeInTheDocument(),
+    );
+    const buttons = screen.queryAllByRole("button");
+    // No <button> at all on the read-only list surface.
+    expect(buttons).toHaveLength(0);
+  });
+
+  it("contains no executable decision-verb buttons on detail", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse(detailOkEnvelope(row("mr_safe"))),
+    );
+    renderAt("/agent-control/merge-recommendation/mr_safe");
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("agent-control-merge-recommendation-detail"),
+      ).toBeInTheDocument(),
+    );
+    const buttons = screen.queryAllByRole("button");
+    expect(buttons).toHaveLength(0);
+  });
+
+  it("does not render the words 'approve' / 'reject' / 'deploy' on list", async () => {
+    mockFetch.mockResolvedValue(jsonResponse(listOkEnvelope([row("mr_1")])));
+    renderAt("/agent-control/merge-recommendation");
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("agent-control-merge-recommendation-list"),
+      ).toBeInTheDocument(),
+    );
+    const root = screen.getByTestId(
+      "agent-control-merge-recommendation-root",
+    );
+    const text = (root.textContent || "").toLowerCase();
+    expect(text).not.toMatch(/\bapprove\b/);
+    expect(text).not.toMatch(/\breject\b/);
+    expect(text).not.toMatch(/\bdeploy\b/);
+  });
+
+  it("does not render the words 'approve' / 'reject' / 'deploy' on detail", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse(detailOkEnvelope(row("mr_safe"))),
+    );
+    renderAt("/agent-control/merge-recommendation/mr_safe");
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("agent-control-merge-recommendation-detail"),
+      ).toBeInTheDocument(),
+    );
+    const root = screen.getByTestId(
+      "agent-control-merge-recommendation-root",
+    );
+    const text = (root.textContent || "").toLowerCase();
+    expect(text).not.toMatch(/\bapprove\b/);
+    expect(text).not.toMatch(/\breject\b/);
+    expect(text).not.toMatch(/\bdeploy\b/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a mobile-first read-only PWA surface over the already-wired N5a merge-recommendation API. Two views share a single component:

- `/agent-control/merge-recommendation` — read-only list of recommendation rows from `GET /api/agent-control/merge-recommendation/list`
- `/agent-control/merge-recommendation/:recommendationId` — read-only detail row from `GET /api/agent-control/merge-recommendation/detail/<id>`

No backend touched, no `dashboard/dashboard.py` touched, no N4b token activation, no merge/approve/reject/deploy actions.

## Hard guarantees (pinned by Vitest)

- Read-only banner always rendered: _"Read-only merge recommendation. Merge execution is not implemented in this stage."_
- Only the N5a `/api/agent-control/merge-recommendation/{list,detail}` endpoints are fetched.
- No fetch to `/api/agent-control/approval-token/*` (N4b).
- No fetch to `/api/agent-control/mobile-inbox/*` (N3b).
- Every request is a same-origin GET. No POST/PUT/PATCH/DELETE, no `XMLHttpRequest`, no `navigator.sendBeacon`.
- Zero `<button>` elements with executable decision verbs (approve, reject, deploy, execute).
- `recommendation_id` bounded to charset `[A-Za-z0-9_-]` and ≤ 128 chars before any fetch/display.
- Safe states for: loading, empty, not_available, not_found, invalid_recommendation_id, malformed response, network failure.

## Scope (4 files, additive)

- `frontend/src/api/agent_control.ts` — closed-schema types + client methods + body-on-4xx helper (used **only** by the new methods so the API's well-formed `not_found` / `invalid_recommendation_id` envelopes survive to the UI). Shared `getJson` is unchanged.
- `frontend/src/routes/AgentControl/MergeRecommendation.tsx` — new read-only component (list + detail).
- `frontend/src/test/AgentControlMergeRecommendation.test.tsx` — new Vitest suite (26 tests).
- `frontend/src/App.tsx` — wire two new routes before the existing `/agent-control/*` catch-all.

## Not touched

- `dashboard/dashboard.py` (operator-owned no-touch). N5a blueprint is already wired.
- Any backend module / reporting projector.
- N4b token activation, N3b/N3c inbox surface.
- `seed.jsonl`, `generated_seed.jsonl`, `.claude/**`, `research/**`, `live/paper/shadow/risk/broker/execution/**`.

## Step 5 invariants

`step5_implementation_allowed=False`, `STEP5_ENABLED_SUBSTAGE="none"`, Level 6 disabled — this PR only displays what the N5a API already returns.

## Test plan

- [x] `python scripts/governance_lint.py` → OK (16 agents, 5 workflows)
- [x] `python -m pytest tests/smoke -q` → 18 passed
- [x] `python -m pytest tests/unit/test_api_merge_recommendation.py tests/unit/test_development_merge_recommendation.py tests/unit/test_dashboard_dashboard_one_line_wiring.py -q` → 98 passed
- [x] `npm --prefix frontend run build` → green
- [x] `npm --prefix frontend run test` → 199 passed (14 files), incl. 26 new tests
- [x] `python -m reporting.development_step5_loop --no-write` → invariants intact (`step5_implementation_allowed=false`, `step5_enabled_substage=none`)
- [x] `python -m reporting.development_operational_digest --no-write` → exit 0
- [x] `python -m reporting.development_merge_recommendation --no-write` → exit 0
- [ ] GitHub CI: all checks green, mergeStateStatus=CLEAN, mergeable=MERGEABLE

🤖 Generated with [Claude Code](https://claude.com/claude-code)