### PR TITLE
feat(notif): N5c spillover — discoverability link in PRs section

### DIFF
--- a/frontend/src/routes/AgentControl.tsx
+++ b/frontend/src/routes/AgentControl.tsx
@@ -30,6 +30,7 @@
 // docs/governance/mobile_agent_control_pwa.md.
 
 import { useCallback, useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import {
   agentControlApi,
   type AgentControlActivity,
@@ -1159,6 +1160,41 @@ function ExecuteSafeCard({
   );
 }
 
+// --- Card: merge-recommendations discoverability link (N5c spillover) ---
+// Static read-only entry into the existing N5c PWA route
+// /agent-control/merge-recommendation (backed by the N5a list/detail
+// API). The card issues NO fetch and renders NO button — only a
+// <Link>. The destination component is the canonical surface; this
+// card exists solely to make the route discoverable from the PRs tab.
+// No merge / approve / reject / deploy action. No N4b token call.
+function MergeRecommendationsLinkCard() {
+  return (
+    <Card
+      title="Merge Recommendations"
+      subtitle="read-only A23/N5a recommendations"
+    >
+      <p
+        className="agent-control-card__subtitle"
+        data-testid="merge-recommendations-description"
+        style={{ margin: "0 0 0.6rem 0" }}
+      >
+        Read-only oversight surface. Merge execution is not implemented
+        in this stage.
+      </p>
+      <p style={{ margin: 0 }}>
+        <Link
+          to="/agent-control/merge-recommendation"
+          data-testid="merge-recommendations-link"
+          aria-label="Open read-only merge recommendations"
+          style={{ color: "var(--ink, #1a73e8)" }}
+        >
+          Open merge recommendations →
+        </Link>
+      </p>
+    </Card>
+  );
+}
+
 // --- Card: notification center placeholder ---
 function NotificationsCard({
   payload,
@@ -1453,6 +1489,7 @@ export function AgentControl() {
           ariaLabel="PR lifecycle and execute-safe catalog"
         >
           <PRLifecycleCard payload={prLifecycle} />
+          <MergeRecommendationsLinkCard />
           <ExecuteSafeCard payload={executeSafe} />
         </Section>
 

--- a/frontend/src/test/AgentControl.test.tsx
+++ b/frontend/src/test/AgentControl.test.tsx
@@ -1532,3 +1532,145 @@ describe("AgentControl — roadmap_priority route wiring subsection (v3.15.16.9c
     ).not.toBeInTheDocument();
   });
 });
+
+// ---------------------------------------------------------------------------
+// N5c discoverability spillover — visible read-only entry to
+// /agent-control/merge-recommendation from the PRs section.
+// Read-only by structure: it is a <Link> (anchor), not a button, and
+// the card body never issues a fetch.
+// ---------------------------------------------------------------------------
+
+describe("AgentControl — N5c discoverability link in PRs section", () => {
+  it("renders a visible merge-recommendations link pointing at the N5c route", async () => {
+    installFetchMock(
+      {
+        "/api/agent-control/status": () => jsonResp(okStatusBody),
+        "/api/agent-control/activity": () => jsonResp(okActivityBody),
+        "/api/agent-control/workloop": () => jsonResp(okWorkloopBody),
+        "/api/agent-control/pr-lifecycle": () =>
+          jsonResp(okPRLifecycleEmptyBody),
+        "/api/agent-control/notifications": () =>
+          jsonResp(placeholderNotificationsBody),
+        "/api/agent-control/proposals": () => jsonResp(okProposalsEmptyBody),
+        "/api/agent-control/approval-inbox": () => jsonResp(okInboxEmptyBody),
+        "/api/agent-control/execute-safe": () => jsonResp(okExecuteSafeBody),
+      },
+      () => jsonResp({}, 404),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+
+    // The PRs section is rendered (hidden when inactive but the
+    // <Link> remains queryable from RTL).
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("merge-recommendations-link"),
+      ).toBeInTheDocument();
+    });
+
+    const link = screen.getByTestId("merge-recommendations-link");
+    expect(link).toHaveAttribute("href", "/agent-control/merge-recommendation");
+    // Anchor element, not a button — read-only by structure.
+    expect(link.tagName.toLowerCase()).toBe("a");
+    // Visible, accessible name describes the destination.
+    expect(link).toHaveAccessibleName(
+      /open read-only merge recommendations/i,
+    );
+    // Subtitle / description is present.
+    expect(
+      screen.getByTestId("merge-recommendations-description"),
+    ).toHaveTextContent(/read-only/i);
+  });
+
+  it("does not add any decision-verb button to the page", async () => {
+    installFetchMock(
+      {
+        "/api/agent-control/status": () => jsonResp(okStatusBody),
+        "/api/agent-control/activity": () => jsonResp(okActivityBody),
+        "/api/agent-control/workloop": () => jsonResp(okWorkloopBody),
+        "/api/agent-control/pr-lifecycle": () =>
+          jsonResp(okPRLifecycleEmptyBody),
+        "/api/agent-control/notifications": () =>
+          jsonResp(placeholderNotificationsBody),
+        "/api/agent-control/proposals": () => jsonResp(okProposalsEmptyBody),
+        "/api/agent-control/approval-inbox": () => jsonResp(okInboxEmptyBody),
+        "/api/agent-control/execute-safe": () => jsonResp(okExecuteSafeBody),
+      },
+      () => jsonResp({}, 404),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("merge-recommendations-link"),
+      ).toBeInTheDocument();
+    });
+
+    // Existing surface pins exactly one button (the Vernieuw refresh
+    // control). This must remain unchanged — no new button added.
+    const buttons = screen.queryAllByRole("button");
+    expect(buttons).toHaveLength(1);
+    expect(buttons[0]).toHaveAttribute(
+      "data-testid",
+      "agent-control-refresh",
+    );
+
+    // No approve / reject / deploy verbs anywhere on the page.
+    const card = screen.getByTestId("merge-recommendations-link");
+    const cardText = (card.textContent || "").toLowerCase();
+    expect(cardText).not.toMatch(/\bapprove\b/);
+    expect(cardText).not.toMatch(/\breject\b/);
+    expect(cardText).not.toMatch(/\bdeploy\b/);
+  });
+
+  it("does not introduce a new fetch and does not call any token endpoint", async () => {
+    installFetchMock(
+      {
+        "/api/agent-control/status": () => jsonResp(okStatusBody),
+        "/api/agent-control/activity": () => jsonResp(okActivityBody),
+        "/api/agent-control/workloop": () => jsonResp(okWorkloopBody),
+        "/api/agent-control/pr-lifecycle": () =>
+          jsonResp(okPRLifecycleEmptyBody),
+        "/api/agent-control/notifications": () =>
+          jsonResp(placeholderNotificationsBody),
+        "/api/agent-control/proposals": () => jsonResp(okProposalsEmptyBody),
+        "/api/agent-control/approval-inbox": () => jsonResp(okInboxEmptyBody),
+        "/api/agent-control/execute-safe": () => jsonResp(okExecuteSafeBody),
+      },
+      () => jsonResp({}, 404),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("merge-recommendations-link"),
+      ).toBeInTheDocument();
+    });
+
+    // The discoverability card never adds a fetch. The only fetches
+    // are the existing card-loader endpoints — never the
+    // merge-recommendation list/detail, never an approval-token URL.
+    for (const call of fetchSpy) {
+      const url = String(call.input);
+      expect(url).not.toContain(
+        "/api/agent-control/merge-recommendation/",
+      );
+      expect(url).not.toContain("/api/agent-control/approval-token/");
+      expect(call.method).toBe("GET");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

N5c spillover from PR #194: the read-only merge-recommendation route exists at `/agent-control/merge-recommendation` but is not discoverable from the existing PWA navigation. This PR adds a visible read-only entry in the bottom-nav PRs section.

- New `MergeRecommendationsLinkCard` rendered in the PRs `<Section>` between the existing `PRLifecycleCard` and `ExecuteSafeCard`.
- The entry is a `<Link>` (anchor) — not a `<button>`, no fetch, no token call.
- Destination component (`MergeRecommendation.tsx`) is unchanged.
- No backend touched, no API change, no new route.

## Read-only by structure

- Anchor element, not a button.
- No `fetch`, no `XMLHttpRequest`, no `navigator.sendBeacon`.
- No reference to `/api/agent-control/approval-token/*` or `/api/agent-control/mobile-inbox/*`.
- Existing single-button invariant on the AgentControl page (only `Vernieuw`) is preserved by test.

## Scope (2 files, additive)

- `frontend/src/routes/AgentControl.tsx` — add `Link` import, new `MergeRecommendationsLinkCard` component, mount it in the PRs section.
- `frontend/src/test/AgentControl.test.tsx` — 3 new tests asserting visibility, href, anchor tag, accessible name, no new button, no new fetch.

## Not touched

- `dashboard/dashboard.py` (operator-owned no-touch).
- Backend, reporting projectors, N4b activation, N3b inbox surface.
- `frontend/src/routes/AgentControl/MergeRecommendation.tsx` (destination unchanged).
- `frontend/src/api/agent_control.ts`, `frontend/src/App.tsx`.
- `seed.jsonl`, `generated_seed.jsonl`, `.claude/**`, `.gitleaks.toml`, `research/**`, `live/paper/shadow/risk/broker/execution/**`.

## Step 5 invariants

`step5_implementation_allowed=false`, `STEP5_ENABLED_SUBSTAGE="none"`, Level 6 permanently disabled — unchanged.

## Test plan

- [x] `python scripts/governance_lint.py` → OK
- [x] `python -m pytest tests/smoke -q` → 18 passed
- [x] `npm --prefix frontend run build` → green
- [x] `npm --prefix frontend run test` → 202 passed (14 files), incl. 3 new
- [x] `python -m reporting.development_step5_loop --no-write` → invariants intact
- [x] `python -m reporting.development_operational_digest --no-write` → exit 0
- [x] `python -m reporting.development_merge_recommendation --no-write` → exit 0
- [ ] GitHub CI: all checks green, mergeStateStatus=CLEAN, mergeable=MERGEABLE

🤖 Generated with [Claude Code](https://claude.com/claude-code)