### PR TITLE
ci(deploy): VPS deploy triggers on Fast pre-merge gate success + dispatch

### DIFF
--- a/.github/workflows/deploy-vps-dashboard.yml
+++ b/.github/workflows/deploy-vps-dashboard.yml
@@ -1,14 +1,27 @@
 name: Deploy VPS Dashboard
 
-# v3.15.15.29 — automatic deploy of the dashboard + nginx surface
-# to the VPS on every push to main. The agent service is NOT
-# started or restarted by this workflow; it stays operator-gated.
+# v3.15.16.N5b1 — automatic deploy of the dashboard + nginx surface
+# to the VPS AFTER the "Fast pre-merge gate" workflow completes
+# successfully on main, plus a manual operator escape hatch via
+# ``workflow_dispatch``. The agent service is NOT started or
+# restarted by this workflow; it stays operator-gated by the
+# audited ``scripts/deploy_vps_dashboard.sh``.
 #
-# Trigger surface is intentionally narrow:
-#   * push to main only. No pull_request trigger (we never deploy
-#     unmerged code).
-#   * No workflow_dispatch (one less manual escape hatch).
-#   * No schedule (no implicit re-deploys).
+# Why workflow_run instead of push?
+#   The previous push-to-main trigger started the deploy the moment
+#   the merge commit landed, BEFORE the Fast pre-merge gate had a
+#   chance to fail on main (which can happen on direct pushes that
+#   bypass PR checks, or on a re-run that flips conclusion).
+#   ``workflow_run`` guarantees the deploy only fires for commits
+#   that the gate has actually accepted on main.
+#
+# Why workflow_dispatch?
+#   An operator-initiated manual deploy is occasionally useful
+#   (e.g. to retry after a transient SSH failure, or to redeploy
+#   from main without pushing a no-op commit). The dispatch surface
+#   declares NO inputs, so the operator cannot pass an arbitrary
+#   ref or argument — the deploy still resets the VPS checkout to
+#   ``origin/main`` and invokes the byte-identical deploy script.
 #
 # Concurrency policy:
 #   * group "deploy-vps-dashboard" so two deploys cannot race.
@@ -36,9 +49,11 @@ name: Deploy VPS Dashboard
 #   triggers it.
 
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: ["Fast pre-merge gate"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: deploy-vps-dashboard
@@ -52,6 +67,13 @@ jobs:
     name: Deploy dashboard + nginx
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # Fire on a successful gate run, OR on a manual operator
+    # dispatch. We deliberately do NOT fire on failed gate runs
+    # (which would otherwise deploy a commit the gate rejected).
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.conclusion == 'success')
 
     steps:
       - name: Checkout repo (for runner-side context only)
@@ -60,6 +82,13 @@ jobs:
           # Shallow checkout is fine — the deploy script runs on
           # the VPS, not in this checkout.
           fetch-depth: 1
+          # Pin the runner-side checkout to main in both event
+          # shapes. workflow_run defaults to the head of the
+          # triggering workflow's run, and workflow_dispatch
+          # defaults to the branch the workflow was dispatched
+          # from; either way we want main here so the workflow's
+          # own behavior is reproducible from any caller.
+          ref: main
 
       - name: Configure SSH client
         env:
@@ -67,11 +96,11 @@ jobs:
           # the workflow's shell trace.
           VPS_HOST: ${{ secrets.VPS_HOST }}
           VPS_USER: ${{ secrets.VPS_USER }}
-          VPS_SSH_KEY: ${{ secrets.VPS_SSH_KEY }}
+          VPS_SSH_PRIVATE_KEY: ${{ secrets.VPS_SSH_PRIVATE_KEY }}
         run: |
           set -euo pipefail
-          if [ -z "${VPS_HOST}" ] || [ -z "${VPS_USER}" ] || [ -z "${VPS_SSH_KEY}" ]; then
-            echo "missing one or more required secrets: VPS_HOST / VPS_USER / VPS_SSH_KEY"
+          if [ -z "${VPS_HOST}" ] || [ -z "${VPS_USER}" ] || [ -z "${VPS_SSH_PRIVATE_KEY}" ]; then
+            echo "missing one or more required secrets: VPS_HOST / VPS_USER / VPS_SSH_PRIVATE_KEY"
             exit 1
           fi
           mkdir -p ~/.ssh
@@ -80,7 +109,7 @@ jobs:
           # value on a command line where another process could
           # observe it via /proc/<pid>/cmdline.
           umask 077
-          printf '%s\n' "${VPS_SSH_KEY}" > ~/.ssh/deploy_key
+          printf '%s\n' "${VPS_SSH_PRIVATE_KEY}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
           # Pin the host key. ssh-keyscan is silent on stderr to
           # avoid leaking VPS_HOST to logs.

--- a/docs/governance/vps_deploy.md
+++ b/docs/governance/vps_deploy.md
@@ -8,10 +8,20 @@ Sibling docs: `mobile_agent_control_pwa.md`,
 
 ## TL;DR
 
-Every push to `main` automatically deploys the latest dashboard
-and nginx surface to the VPS. **The agent / discovery worker is
-NOT deployed and is NOT started by this workflow.** Live trading
-remains operator-gated.
+After every successful run of the **Fast pre-merge gate** on
+`main`, the deploy workflow automatically refreshes the dashboard
+and nginx surface on the VPS. An operator-initiated manual
+deploy is also available via `workflow_dispatch` (the **Run
+workflow** button on the *Deploy VPS Dashboard* page in GitHub
+Actions). **The agent / discovery worker is NOT deployed and is
+NOT started by this workflow.** Live trading remains
+operator-gated.
+
+> Upgraded in v3.15.16.N5b1: trigger switched from `push: main` to
+> `workflow_run` on the gate so a direct push that bypasses the
+> gate (or a gate run that flips to `failure`) cannot trigger an
+> auto-deploy. The secret previously named `VPS_SSH_KEY` was
+> renamed to `VPS_SSH_PRIVATE_KEY` for self-documentation.
 
 ## What this deploys
 
@@ -305,7 +315,19 @@ The workflow consumes exactly three repository secrets:
 | --- | --- | --- |
 | `VPS_HOST` | hostname or IP of the VPS (the operator already knows it; do NOT paste it into any committed file) | `Repo → Settings → Secrets and variables → Actions → New repository secret` |
 | `VPS_USER` | SSH user (typically `root`) | same place |
-| `VPS_SSH_KEY` | full private-key contents (PEM) of a dedicated deploy key | same place |
+| `VPS_SSH_PRIVATE_KEY` | full private-key contents (PEM) of a dedicated deploy key | same place |
+
+> The secret was renamed from `VPS_SSH_KEY` to
+> `VPS_SSH_PRIVATE_KEY` in v3.15.16.N5b1 so the name
+> self-documents that it carries the *private* key half (the
+> public half lives in the VPS `authorized_keys`). After the
+> v3.15.16.N5b1 PR lands, the operator must add a secret named
+> `VPS_SSH_PRIVATE_KEY` with the same private-key contents the
+> old `VPS_SSH_KEY` carried, and delete the old `VPS_SSH_KEY`
+> entry to keep the secret store clean. Between merge and that
+> operator action, the workflow fails fast with
+> `missing one or more required secrets: ... VPS_SSH_PRIVATE_KEY`
+> — non-destructive (no partial deploy).
 
 The workflow:
 
@@ -328,7 +350,7 @@ On a workstation (NOT the VPS):
 ssh-keygen -t ed25519 -f ./deploy_vps_dashboard_key -C "github-actions deploy" -N ""
 
 # Files produced:
-#   deploy_vps_dashboard_key       <- private key (goes into VPS_SSH_KEY)
+#   deploy_vps_dashboard_key       <- private key (goes into VPS_SSH_PRIVATE_KEY)
 #   deploy_vps_dashboard_key.pub   <- public key (goes onto the VPS)
 ```
 
@@ -349,10 +371,9 @@ Back on the workstation, add the **private** key as a GitHub
 secret:
 
 1. Open `Repo → Settings → Secrets and variables → Actions`.
-2. Add `VPS_SSH_KEY` with the full contents of
-   `deploy_vps_dashboard_key` (including the
-   `-----BEGIN OPENSSH PRIVATE KEY-----` header and the
-   `-----END OPENSSH PRIVATE KEY-----` footer).
+2. Add `VPS_SSH_PRIVATE_KEY` with the full contents of
+   `deploy_vps_dashboard_key` (including the PEM header and the
+   matching footer line).
 3. Add `VPS_HOST` (the deploy host the operator already knows; do not commit the value here).
 4. Add `VPS_USER` (e.g. `root`).
 
@@ -368,7 +389,23 @@ keep locally — it's already on the VPS.
 
 ## Manual deploy (operator-initiated)
 
-Run the same script manually from the VPS at any time:
+Two paths exist; both invoke the byte-identical
+`scripts/deploy_vps_dashboard.sh` on the VPS.
+
+### Path A — GitHub Actions `workflow_dispatch`
+
+1. Open the **Deploy VPS Dashboard** workflow in `Repo → Actions`.
+2. Click **Run workflow** in the top-right.
+3. Confirm the branch is `main` (the workflow ignores any other
+   ref by checking out `main` regardless of which branch the
+   dispatch was initiated from). The workflow declares no inputs,
+   so the operator cannot pass a free-form argument.
+4. The workflow then runs identically to an auto-deploy: same
+   concurrency group, same timeout, same SSH key/known_hosts
+   handling, same `git fetch + reset --hard origin/main + bash
+   scripts/deploy_vps_dashboard.sh` SSH command.
+
+### Path B — direct VPS shell
 
 ```bash
 ssh root@<VPS_HOST>
@@ -463,11 +500,16 @@ the canonical procedure.
   `docker compose up -d --no-deps dashboard nginx`,
   `docker compose stop agent`, and does NOT contain
   `docker compose up -d --build dashboard nginx`;
-* the workflow exists, triggers on `push:` to `main` only, has
-  no `pull_request` trigger, references the three required
-  secrets, declares a `concurrency` group + `timeout-minutes`
-  cap, contains no literal private-key / token / password /
-  hostname material, and invokes the safe deploy script.
+* the workflow exists, triggers on `workflow_run` after the
+  *Fast pre-merge gate* completes on `main` plus
+  `workflow_dispatch`, has no `pull_request` trigger, guards the
+  deploy job on `workflow_run.conclusion == 'success'` (or
+  `workflow_dispatch`), references the three required secrets
+  (`VPS_HOST`, `VPS_USER`, `VPS_SSH_PRIVATE_KEY` — legacy
+  `VPS_SSH_KEY` is no longer accepted), declares a `concurrency`
+  group + `timeout-minutes` cap, contains no literal private-key
+  / token / password / hostname material, and invokes the safe
+  deploy script.
 
 These tests run as part of `pytest tests/unit` on every PR;
 breaking any invariant fails the build.

--- a/tests/unit/test_vps_deploy_invariants.py
+++ b/tests/unit/test_vps_deploy_invariants.py
@@ -296,11 +296,65 @@ def workflow_text() -> str:
     return WORKFLOW_PATH.read_text(encoding="utf-8")
 
 
-def test_workflow_triggers_only_on_push_to_main(workflow_text: str) -> None:
-    """The trigger surface must be exactly ``push: branches:
-    [main]``. Specifically NO ``pull_request`` trigger."""
-    # Must contain a push:main block.
-    assert re.search(r"on:\s*\n\s*push:\s*\n\s*branches:\s*\n\s*-\s*main", workflow_text)
+def test_workflow_triggers_on_gate_success_or_dispatch(
+    workflow_text: str,
+) -> None:
+    """v3.15.16.N5b1 — the trigger surface is exactly
+    ``workflow_run`` after the "Fast pre-merge gate" completes on
+    ``main``, plus an operator-only ``workflow_dispatch`` for
+    manual deploys. The legacy ``push:`` trigger has been removed
+    so a direct push to ``main`` (bypassing the gate) cannot
+    auto-deploy. ``pull_request`` is still explicitly absent."""
+    # workflow_run trigger:
+    assert "workflow_run:" in workflow_text, (
+        "workflow must use workflow_run as the auto-deploy trigger"
+    )
+    assert 'workflows: ["Fast pre-merge gate"]' in workflow_text, (
+        "workflow_run must reference the exact 'Fast pre-merge gate' "
+        "workflow name"
+    )
+    assert "types: [completed]" in workflow_text, (
+        "workflow_run must subscribe to the 'completed' type "
+        "(branch filter + if: guard further restrict to success-on-main)"
+    )
+    assert "branches: [main]" in workflow_text, (
+        "workflow_run must restrict to the main branch only"
+    )
+
+    # workflow_dispatch trigger:
+    assert "workflow_dispatch:" in workflow_text, (
+        "workflow must expose a workflow_dispatch surface for "
+        "operator-initiated manual deploys"
+    )
+
+    # Legacy push trigger explicitly removed:
+    assert not re.search(
+        r"^\s*push:\s*\n\s*branches:", workflow_text, re.MULTILINE
+    ), (
+        "legacy push-to-main trigger must be removed — the "
+        "workflow_run trigger is the canonical auto-deploy path"
+    )
+
+
+def test_workflow_only_deploys_on_successful_gate_or_dispatch(
+    workflow_text: str,
+) -> None:
+    """The deploy job must guard against running on a failed gate
+    run. Without this guard, ``workflow_run`` would fire on every
+    gate completion including failures."""
+    # The if-guard must include the conclusion check.
+    assert (
+        "github.event.workflow_run.conclusion == 'success'"
+        in workflow_text
+    ), (
+        "deploy job must guard on workflow_run.conclusion == 'success' "
+        "so a failed gate run cannot trigger a deploy"
+    )
+    # The if-guard must also allow workflow_dispatch through.
+    assert "workflow_dispatch" in workflow_text, (
+        "deploy job must allow workflow_dispatch as the operator "
+        "manual-deploy path through its if-guard"
+    )
 
 
 def test_workflow_does_not_trigger_on_pull_request(workflow_text: str) -> None:
@@ -314,10 +368,22 @@ def test_workflow_does_not_trigger_on_pull_request(workflow_text: str) -> None:
 
 
 def test_workflow_uses_required_secrets(workflow_text: str) -> None:
-    """The three repository secrets the workflow consumes."""
+    """The three repository secrets the workflow consumes.
+
+    v3.15.16.N5b1 renamed ``VPS_SSH_KEY`` → ``VPS_SSH_PRIVATE_KEY``
+    so the secret name self-documents that it carries the *private*
+    key material (and the operator does not confuse it with the
+    deploy *public* key that lives on the VPS authorized_keys)."""
     assert "${{ secrets.VPS_HOST }}" in workflow_text
     assert "${{ secrets.VPS_USER }}" in workflow_text
-    assert "${{ secrets.VPS_SSH_KEY }}" in workflow_text
+    assert "${{ secrets.VPS_SSH_PRIVATE_KEY }}" in workflow_text
+    # The legacy name must not linger anywhere in the workflow,
+    # otherwise the operator could mis-set the GitHub secret and
+    # get a confusing "missing secrets" failure later.
+    assert "VPS_SSH_KEY" not in workflow_text, (
+        "legacy secret name VPS_SSH_KEY must not appear in the "
+        "workflow — it was renamed to VPS_SSH_PRIVATE_KEY"
+    )
 
 
 def test_workflow_has_concurrency_group(workflow_text: str) -> None:
@@ -466,9 +532,11 @@ def test_workflow_uses_batch_mode_to_refuse_password_prompts(
 def test_runbook_references_required_secrets(workflow_text: str) -> None:
     """The operator runbook must enumerate the secrets the
     workflow consumes so the operator can't miss one during
-    setup."""
+    setup. The secret name is the v3.15.16.N5b1
+    ``VPS_SSH_PRIVATE_KEY`` (legacy name ``VPS_SSH_KEY`` is no
+    longer accepted)."""
     text = DOC_PATH.read_text(encoding="utf-8")
-    for sec in ("VPS_HOST", "VPS_USER", "VPS_SSH_KEY"):
+    for sec in ("VPS_HOST", "VPS_USER", "VPS_SSH_PRIVATE_KEY"):
         assert sec in text, f"runbook does not document required secret: {sec!r}"
 
 


### PR DESCRIPTION
## Summary

Upgrades the existing `.github/workflows/deploy-vps-dashboard.yml` auto-deploy workflow from `push: branches: [main]` to a more conservative trigger pair:

- **`workflow_run`** on the *Fast pre-merge gate* workflow, with `types: [completed]` and `branches: [main]` — the deploy only fires for commits the gate has actually accepted on main. A failed gate run is guarded out by an `if:` on `github.event.workflow_run.conclusion == 'success'`.
- **`workflow_dispatch`** as an operator-only manual escape hatch — no `inputs:`, no free-form ref handling. Checkout always pins to `main`.

Secret rename for self-documentation: `VPS_SSH_KEY` → `VPS_SSH_PRIVATE_KEY`.

The deploy script `scripts/deploy_vps_dashboard.sh` is **byte-identical** to its current state — this PR only changes the trigger surface, the secret name, three pin-tests, and the runbook. The SSH command that the workflow sends to the VPS is unchanged (audited fetch + reset to origin/main + bash invocation).

## Why this change

The previous `push: main` trigger started the deploy the moment the merge commit landed, even if the *Fast pre-merge gate* workflow for that commit was still in flight or had failed (which can happen on a direct push that bypasses PR checks, or a gate re-run that flips to `failure`). `workflow_run` guarantees the deploy only fires for commits the gate has actually accepted.

## Preserved (unchanged)

- `scripts/deploy_vps_dashboard.sh` byte-identical; SSH command on the workflow side is unchanged.
- Concurrency group `deploy-vps-dashboard` with `cancel-in-progress: false`.
- `timeout-minutes: 20`.
- `permissions: contents: read` (minimal).
- SHA-pinned `actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11`.
- `ssh-keyscan -H -T 10` for `known_hosts` pinning.
- `StrictHostKeyChecking=yes`, `BatchMode=yes`, `ConnectTimeout=15`.
- `if: always()` wipe of `~/.ssh/deploy_key` and `~/.ssh/known_hosts`.
- Dashboard + nginx deploy; agent service stopped defensively (`--no-deps` + `--force-recreate` posture in the deploy script).
- Auth-aware healthcheck accepting `200|302|401`.
- Post-deploy refresh of `pr_lifecycle` + `recurring_maintenance` artefacts.

## Tests

`tests/unit/test_vps_deploy_invariants.py` updated:
- Replaced `test_workflow_triggers_only_on_push_to_main` → `test_workflow_triggers_on_gate_success_or_dispatch`.
- New `test_workflow_only_deploys_on_successful_gate_or_dispatch` — pins the `conclusion == 'success'` if-guard.
- `test_workflow_uses_required_secrets` now asserts `VPS_SSH_PRIVATE_KEY` and forbids the legacy `VPS_SSH_KEY` anywhere in the workflow.
- `test_runbook_references_required_secrets` updated for the rename.
- All other pins (concurrency, timeout, SHA pin, no-IP, no-secret-literal, bootstrap commands, wipe step, strict host checking, batch mode, healthcheck protocol/status/codes) unchanged.

## Runbook (`docs/governance/vps_deploy.md`)

- TL;DR rewritten: gate-success-triggered + workflow_dispatch escape hatch.
- Required GitHub Secrets table: `VPS_SSH_PRIVATE_KEY` everywhere.
- New \"Path A — GitHub Actions `workflow_dispatch`\" subsection in *Manual deploy*.
- Static-test guarantees section updated to describe the new trigger + secret invariants.

## Not touched

- `scripts/deploy_vps_dashboard.sh` (operator-owned, audited; not changed).
- Any Dockerfile, compose file, app/runtime code.
- `dashboard/**`, `frontend/**`, `reporting/**`, `tests/**` (other than the one workflow-invariant test).
- `.claude/**`, `.gitleaks.toml`, `live/**`, `paper/**`, `shadow/**`, `risk/**`, `broker/**`, `execution/**`.
- Seed files, Step 5 flags, Level 6.

## Authority posture (unchanged)

- No agent deploy authority — CI runs the workflow, and only after a successful gate or an explicit operator dispatch.
- No autonomous approve / merge / deploy / trade.
- Level 6 permanently disabled.
- Step 5 invariants intact (`step5_implementation_allowed=false`, `STEP5_ENABLED_SUBSTAGE=\"none\"`).

## Test plan

- [x] `python scripts/governance_lint.py` → OK (16 agents, 5 workflows)
- [x] `python -m pytest tests/smoke -q` → 18 passed
- [x] `python -m pytest tests/unit/test_vps_deploy_invariants.py -q` → 40 passed
- [x] `npm --prefix frontend run test` → 214 passed (no regression)
- [x] `python -m reporting.development_step5_loop --no-write` → invariants intact
- [x] `python -m reporting.development_operational_digest --no-write` → exit 0
- [ ] GitHub CI: all checks green, mergeStateStatus=CLEAN, mergeable=MERGEABLE

## Operator follow-up after merge

A short instruction block follows in the merge report. In short:
1. Add a new GitHub Actions secret named `VPS_SSH_PRIVATE_KEY` (with the same private-key contents the old `VPS_SSH_KEY` carried).
2. Delete the legacy `VPS_SSH_KEY` secret.
3. Confirm the VPS `authorized_keys` still contains the public half of the deploy key.
4. Trigger *Deploy VPS Dashboard* once via GitHub Actions → Run workflow as a smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)