### PR TITLE
docs(n5b): operator runbook for Phase 1 preflight upstream-refresh chain

### DIFF
--- a/docs/governance/n5b_merge_preflight_runbook.md
+++ b/docs/governance/n5b_merge_preflight_runbook.md
@@ -1,0 +1,389 @@
+# N5b Phase 1 — Merge Preflight Upstream-Refresh Operator Runbook
+
+> **Status:** Operator-facing runbook for the **read-only** N5b
+> Phase 1 dry-run preflight projector
+> ([`reporting/development_merge_preflight.py`](../../reporting/development_merge_preflight.py)).
+>
+> **Authority:** development-governance read-only documentation.
+> This runbook grants ADE **zero** new authority. It documents the
+> exact, dry-run-only CLI sequence the operator runs to refresh the
+> chain of upstream artefacts the N5b Phase 1 projector reads, so
+> that the preflight artefact stops reporting `candidate_count = 0`
+> when there is, in fact, mergeable PR state to project.
+>
+> **Permanent denials (re-asserted):**
+>
+> * `step5_implementation_allowed = false` (unchanged)
+> * `STEP5_ENABLED_SUBSTAGE = "none"` (unchanged)
+> * Level 6 is permanently disabled per ADR-015 §Doctrine 1.
+> * No autonomous merge / deploy / trade / approval.
+> * No approval can happen from a notification click alone.
+> * No `gh pr merge`, no `gh pr review --approve`, no `--admin`, no
+>   branch-protection bypass, no force push, no
+>   `seed.jsonl` / `generated_seed.jsonl` write, no `.claude/**`
+>   edit, no `.gitleaks.toml` edit, no test weakening, no hook
+>   bypass.
+> * No `ADE_GENERATED_LANE_WRITER_ENABLED=true` is requested by
+>   this runbook (that is A18b runtime activation territory and is
+>   a separate operator-only step gated behind a separate
+>   operator-go).
+> * No `ADE_N5B_LIVE_EXECUTE_ENABLED=true` is requested by this
+>   runbook (that is N5b Phase 4 territory and is permanently
+>   denied until a separate explicit operator-go per
+>   [`docs/governance/n5b_merge_execution_plan.md`](n5b_merge_execution_plan.md)
+>   §10).
+
+---
+
+## 1. Purpose
+
+The N5b Phase 1 projector at
+[`reporting/development_merge_preflight.py`](../../reporting/development_merge_preflight.py)
+emits a closed-schema dry-run preflight artefact at
+`logs/development_merge_preflight/latest.json` by joining two
+existing read-only artefacts:
+
+* **A22** — `logs/development_pr_lifecycle_observer/latest.json`
+* **A23 / N5a** — `logs/development_merge_recommendation/latest.json`
+
+A23 itself is a pure projector over **A22 + N3a**, where N3a is
+the mobile-approval-inbox artefact at
+`logs/mobile_approval_inbox/latest.json`. A22 in turn projects the
+upstream GitHub-PR-lifecycle digest at
+`logs/github_pr_lifecycle/latest.json`, which is the **only**
+artefact in the chain whose producer calls `gh` (a subprocess +
+network step).
+
+If any link in this chain is absent, malformed, or stale, the N5b
+Phase 1 projector default-denies and reports `candidate_count = 0`
+with a closed-vocab warning. That is **safe** but **not useful**.
+This runbook documents the exact dry-run-only CLI commands the
+operator can run, in order, to refresh the chain on the VPS (or
+locally) so the Phase 1 projector has fresh material to project.
+
+This runbook is **not** an authorisation to ship Phase 2+. Each
+Phase 2 / 3 / 4 of the N5b rollout plan
+([`n5b_merge_execution_plan.md`](n5b_merge_execution_plan.md) §10)
+requires its own separate explicit operator-go, in a separate PR,
+with the full §9 test set.
+
+---
+
+## 2. Hard constraints
+
+This runbook, the surfaces it documents, and the commands it
+prescribes must not:
+
+* merge any PR;
+* push to `main` or force-push any branch;
+* call `gh pr merge`, `gh pr review --approve`, or any other
+  GitHub mutation outside the existing audited Dependabot
+  execute-safe path (which is **not** invoked by this runbook);
+* call `git merge` against `main`, `git push`, or any equivalent
+  mutating Git operation;
+* mint or verify approval tokens (N4 territory; preflight is
+  pre-token);
+* execute an approve / reject decision (N4 + N5 execution
+  territory);
+* deploy anything;
+* send any real push notification (N2b–N3b territory);
+* register a Flask blueprint or wire into `dashboard/dashboard.py`;
+* touch `frontend/**`;
+* mutate any upstream artefact (the projectors write only their
+  own artefact path; the upstream is **read** by every step);
+* edit canonical roadmap status fields;
+* mark any roadmap phase complete;
+* enable Step 5.1 or Step 5.2;
+* flip `step5_implementation_allowed`;
+* change `STEP5_ENABLED_SUBSTAGE`;
+* enable Level 6 (Level 6 is permanently disabled per ADR-015 §Doctrine 1);
+* change QRE behaviour;
+* mutate research artifacts;
+* touch live / paper / shadow / risk / broker / execution paths;
+* edit `.claude/**`;
+* edit `.gitleaks.toml`;
+* weaken or bypass tests, hooks, gates, or pin-tests;
+* write a `seed.jsonl` or `generated_seed.jsonl` record (A18b
+  writer is a separate runtime that is **not** invoked by this
+  runbook);
+* store secrets in repo.
+
+---
+
+## 3. The refresh chain (read-only)
+
+| Step | Module | Reads | Writes | Calls `gh` / net / subprocess? |
+|---|---|---|---|---|
+| 1 | [`reporting.github_pr_lifecycle`](../../reporting/github_pr_lifecycle.py) | `gh` GraphQL | `logs/github_pr_lifecycle/latest.json` | **Yes (`gh` CLI + subprocess).** Already invoked by `scripts/deploy_vps_dashboard.sh` post-deploy and by `reporting.recurring_maintenance` job `refresh_github_pr_lifecycle_dry_run`. |
+| 2 | [`reporting.development_pr_lifecycle_observer`](../../reporting/development_pr_lifecycle_observer.py) (A22) | step 1's artefact | `logs/development_pr_lifecycle_observer/latest.json` | No. Pure stdlib projector. |
+| 3 | [`reporting.mobile_approval_inbox`](../../reporting/mobile_approval_inbox.py) (N3a) | notification dispatch outbox | `logs/mobile_approval_inbox/latest.json` | No. Pure stdlib projector. |
+| 4 | [`reporting.development_merge_recommendation`](../../reporting/development_merge_recommendation.py) (A23) | A22 + N3a | `logs/development_merge_recommendation/latest.json` | No. Pure stdlib projector. |
+| 5 | [`reporting.development_merge_preflight`](../../reporting/development_merge_preflight.py) (N5b Phase 1) | A22 + A23 | `logs/development_merge_preflight/latest.json` | No. Pure stdlib projector. |
+
+**Only step 1 talks to the network.** Steps 2–5 are pinned by
+their own AST-level forbidden-import and source-text scans to
+contain no `subprocess`, no `socket`, no `urllib`, no `requests`,
+no `httpx`, no `aiohttp`, no `gh`, no `git`. The projectors are
+deterministic functions of their on-disk inputs.
+
+---
+
+## 4. Operator workflow — VPS
+
+Run the chain in order. Every step is dry-run only and writes
+only its own artefact path. Any failure on a downstream step is
+non-fatal for upstream steps (the file simply does not refresh on
+that pass).
+
+```sh
+cd /root/trading-agent
+
+# Step 1 — refresh the upstream gh digest (subprocess + gh).
+#          Skipped here if a recent post-deploy / recurring tick
+#          has already refreshed it; safe to re-run.
+python3 -m reporting.github_pr_lifecycle --mode dry-run --no-smoke
+
+# Step 2 — A22 read-only projector. No gh, no network.
+python3 -m reporting.development_pr_lifecycle_observer
+
+# Step 3 — N3a inbox read-only projector. No gh, no network.
+python3 -m reporting.mobile_approval_inbox
+
+# Step 4 — A23 read-only recommendation projector. No gh, no network.
+python3 -m reporting.development_merge_recommendation
+
+# Step 5 — N5b Phase 1 read-only preflight projector. No gh, no network.
+python3 -m reporting.development_merge_preflight --no-write
+```
+
+The final `--no-write` invocation prints the snapshot to stdout
+without persisting it. Drop `--no-write` to also persist
+`logs/development_merge_preflight/latest.json`. Both shapes are
+safe; neither calls `gh` or the network.
+
+### 4.1 Expected closed-envelope shape from step 5
+
+```jsonc
+{
+  "dry_run_only": true,
+  "live_merge_implemented": false,
+  "deploy_coupled": false,
+  "level6_enabled": false,
+  "step5_implementation_allowed": false,
+  "step5_enabled_substage": "none",
+  "candidate_count": <int>,
+  "candidates": [ ... ],
+  "validation_warnings": [ ... ],
+  "note": "candidates_present" | "missing_merge_recommendation_artifact" | "missing_pr_lifecycle_artifact" | "no_recommendation_rows"
+}
+```
+
+`candidate_count` may legitimately be `0` even after a clean
+chain refresh — the universe of open PRs may simply not contain
+any A23 row whose `recommendation_action == "recommend_human_merge"`
+at that moment. That is also safe.
+
+### 4.2 Operator verification commands (read-only)
+
+```sh
+jq '.dry_run_only,
+    .live_merge_implemented,
+    .deploy_coupled,
+    .level6_enabled,
+    .step5_implementation_allowed,
+    .step5_enabled_substage,
+    .candidate_count,
+    .note,
+    .validation_warnings' \
+   logs/development_merge_preflight/latest.json
+
+# Per-candidate verdict + stop conditions:
+jq '.candidates[] | {pr_number, dry_run_verdict, stop_conditions}' \
+   logs/development_merge_preflight/latest.json
+```
+
+Expected verifications:
+
+* `.dry_run_only == true`
+* `.live_merge_implemented == false`
+* `.deploy_coupled == false`
+* `.level6_enabled == false`
+* `.step5_implementation_allowed == false`
+* `.step5_enabled_substage == "none"`
+* every candidate's `.dry_run_verdict` is one of
+  `would_block`, `would_require_operator`,
+  `would_be_live_candidate_if_authorized` (closed vocab pinned
+  by the projector's tests)
+* every candidate's `stop_conditions` includes
+  `token_required_for_live` **and** `live_merge_not_implemented`
+  (those two are informational reminders the projector emits on
+  **every** row — see
+  [`development_merge_preflight.py`](../../reporting/development_merge_preflight.py)
+  §`_INFORMATIONAL_STOP_CONDITIONS`).
+
+---
+
+## 5. Operator workflow — local dry-run
+
+For a smoke pass without VPS access, run the same chain from the
+repo working tree. Step 1 still requires `gh` + GitHub auth in
+the local shell; if that is not available, skip step 1 (steps
+2–5 will project whatever digest is already on disk under
+`logs/github_pr_lifecycle/`, or default-deny if nothing is there
+yet).
+
+```sh
+# from the repo root, in an activated venv:
+python -m reporting.development_pr_lifecycle_observer --no-write
+python -m reporting.mobile_approval_inbox --no-write
+python -m reporting.development_merge_recommendation --no-write
+python -m reporting.development_merge_preflight --no-write
+```
+
+`--no-write` is the canonical safety flag; nothing is persisted.
+Output is the closed-schema snapshot to stdout.
+
+---
+
+## 6. Stop conditions and safe envelopes
+
+If step 5's snapshot reports:
+
+| `note` | Operator action |
+|---|---|
+| `missing_merge_recommendation_artifact` | step 4 has not run on this host since step 5; re-run step 4 then step 5. |
+| `missing_pr_lifecycle_artifact` | step 2 has not run on this host since step 5; re-run step 2 then step 5. |
+| `no_recommendation_rows` | the upstream A22 + A23 projection ran cleanly but no PR satisfies A23's `recommend_human_merge` rule today. Safe; no action. |
+| `candidates_present` | step 5 found at least one row to project. Inspect `.candidates[*].dry_run_verdict` and `.candidates[*].stop_conditions`. |
+
+If a `would_block` or `would_require_operator` verdict appears,
+the operator can read the closed-vocab `stop_conditions` (e.g.
+`merge_state_not_clean`, `checks_not_green`,
+`critical_inbox_rows_present`, `stale_recommendation`,
+`head_sha_mismatch`, etc.) directly. **No N5b live merge route
+exists**; the verdict is informational only.
+
+---
+
+## 7. Rollback
+
+The runbook describes only read-only projector invocations.
+"Rollback" means: drop the downstream artefacts. Subsequent runs
+of step 5 will then report `missing_*` warnings and
+`candidate_count = 0`, which is the canonical safe rest state.
+
+```sh
+# Optional safe-rest reset (operator-only). The projectors
+# regenerate the files on the next invocation; no other
+# subsystem reads these four directories outside the documented
+# projector / dashboard read paths.
+rm -f logs/development_merge_preflight/latest.json
+rm -f logs/development_merge_recommendation/latest.json
+rm -f logs/development_pr_lifecycle_observer/latest.json
+rm -f logs/mobile_approval_inbox/latest.json
+```
+
+This rollback does **not** touch `logs/github_pr_lifecycle/`
+(that artefact is consumed by other dashboards and the recurring
+maintenance scheduler).
+
+---
+
+## 8. Step 5 and Level 6 invariants
+
+Level 6 is **permanently disabled** per ADR-015 §Doctrine 1 and is
+**never** raised by this runbook. The six invariants below are
+re-asserted on every line of this runbook:
+
+```
+step5_implementation_allowed = false
+STEP5_ENABLED_SUBSTAGE        = "none"
+level6_enabled                = false
+dry_run_only                  = true
+live_merge_implemented        = false
+deploy_coupled                = false
+```
+
+The N5b Phase 1 projector emits these literal values into its
+artefact's `discipline_invariants` dict on every snapshot
+([`reporting/development_merge_preflight.py`](../../reporting/development_merge_preflight.py)
+§`_DISCIPLINE_INVARIANTS`). This runbook does not authorise the
+operator to flip any of them. Any future change to those
+invariants requires a separate operator-authored ADR and a
+separate PR.
+
+---
+
+## 9. What this runbook does NOT do
+
+* Does **not** schedule the refresh. The recurring-maintenance
+  scheduler (`reporting.recurring_maintenance`) does **not**
+  currently include A22 / N3a / A23 / N5b refresh jobs. A
+  separate PR (the planned Task 2 in the operator's task plan)
+  may add those jobs in a future change. **No** scheduler change
+  is included in this PR.
+* Does **not** add a dashboard API surface for the preflight
+  artefact. (That is the planned Task 3.)
+* Does **not** add a PWA surface for the preflight artefact.
+  (That is the planned Task 4.)
+* Does **not** activate the A18b
+  `generated_seed.jsonl` writer on the VPS. (That is the planned
+  Task 5, **operator-only**, and is gated behind a separate
+  operator-go.)
+* Does **not** introduce N5b Phase 2 (token-bound dry-run
+  endpoint), Phase 3 (sacrificial-repo live execute), or Phase 4
+  (production live execute). Each of those is denied unless and
+  until the operator separately authorises it per
+  [`n5b_merge_execution_plan.md`](n5b_merge_execution_plan.md)
+  §10.
+* Does **not** grant ADE permission to merge any PR, push to
+  `main`, force-push, deploy, mint an approval token, verify an
+  approval token, send a real push notification, or open / close
+  / comment on any PR.
+
+---
+
+## 10. Authority chain summary
+
+| Capability | Today | After this runbook | After Task 2 (future, separate PR) | After N5b Phase 2 (future, operator-go required) | After N5b Phase 4 (future, operator-go required) |
+|---|---|---|---|---|---|
+| Read step-1 gh digest | yes | unchanged | unchanged | unchanged | unchanged |
+| Run step-2 A22 projector on demand | yes (CLI) | yes (documented) | yes (scheduled) | unchanged | unchanged |
+| Run step-3 N3a projector on demand | yes (CLI) | yes (documented) | yes (scheduled) | unchanged | unchanged |
+| Run step-4 A23 projector on demand | yes (CLI) | yes (documented) | yes (scheduled) | unchanged | unchanged |
+| Run step-5 N5b Phase 1 preflight on demand | yes (CLI) | yes (documented) | yes (scheduled) | unchanged | unchanged |
+| Mint approval token | does not exist | unchanged | unchanged | yes — operator-env-only via N4b | unchanged |
+| Token-bound dry-run merge endpoint | does not exist | unchanged | unchanged | yes — operator-go required | unchanged |
+| Live merge of any PR | does not exist | unchanged | unchanged | does not exist | yes — separate operator-go per §10 |
+| Autonomous merge / deploy / trade | forbidden (Level 6 disabled) | unchanged | unchanged | unchanged | unchanged |
+
+This runbook grants ADE **zero** new authority. The refresh
+chain is information, not authority.
+
+---
+
+## 11. Cross-references
+
+* [`docs/governance/n5b_merge_execution_plan.md`](n5b_merge_execution_plan.md) —
+  the N5b governance / plan-only doc; §10 enumerates the four
+  rollout phases and re-asserts that each requires a separate
+  operator-go.
+* [`docs/governance/development_pr_lifecycle_observer.md`](development_pr_lifecycle_observer.md) —
+  A22 read-only projector contract.
+* [`docs/governance/development_merge_recommendation.md`](development_merge_recommendation.md) —
+  A23 read-only recommendation projector contract.
+* [`docs/governance/recurring_maintenance.md`](recurring_maintenance.md) —
+  the typed scheduler that today refreshes step 1 (and not the
+  downstream chain).
+* [`docs/governance/vps_deploy.md`](vps_deploy.md) — the deploy
+  surface; the post-deploy hook refreshes step 1 only.
+* [`docs/governance/n4b_runtime_activation.md`](n4b_runtime_activation.md) —
+  the operator-only runbook for N4b Phase B activation.
+* [`docs/adr/ADR-014-truth-authority-settlement.md`](../adr/ADR-014-truth-authority-settlement.md) —
+  authority doctrine.
+* [`docs/adr/ADR-015-claude-agent-governance.md`](../adr/ADR-015-claude-agent-governance.md) —
+  Level 6 permanently-disabled doctrine.
+* [`docs/governance/execution_authority.md`](execution_authority.md) —
+  per-action authority decisions.
+* [`docs/governance/no_touch_paths.md`](no_touch_paths.md) — the
+  protected paths.

--- a/tests/unit/test_n5b_merge_preflight_runbook.py
+++ b/tests/unit/test_n5b_merge_preflight_runbook.py
@@ -1,0 +1,565 @@
+"""Pin-tests for the N5b Phase 1 merge-preflight upstream-refresh
+operator runbook.
+
+These tests do **not** activate any runtime gate. They pin that the
+operator runbook at
+``docs/governance/n5b_merge_preflight_runbook.md``:
+
+* exists, is non-trivial, and is plain text;
+* documents the canonical dry-run-only CLI sequence for steps
+  1 → 5 of the read-only refresh chain;
+* references each module by its repo-relative path;
+* references each artefact by the exact ``ARTIFACT_RELATIVE_PATH``
+  constant declared in the corresponding ``reporting/*`` module
+  (so the runbook cannot silently drift away from the schema);
+* re-asserts the Step 5 + Level 6 invariants explicitly;
+* re-asserts the dry-run / no-live-merge / no-deploy-coupling
+  invariants explicitly;
+* does NOT instruct the operator to merge a PR, mint or verify an
+  approval token, deploy anything, write a seed file, enable
+  A18b's runtime writer flag, enable N5b's live-execute flag,
+  flip a Step 5 flag, enable Level 6, edit ``.claude/**`` /
+  ``.gitleaks.toml`` / no-touch paths, weaken tests, or bypass
+  hooks;
+* does NOT embed a PEM block, a hex-64 inline-code literal that
+  looks like an exported secret, or a bearer-token-shaped
+  string.
+
+This is a documentation pin-test, not a runtime gate. The
+projector code at
+``reporting/development_merge_preflight.py`` already enforces
+read-only behaviour at import / collect / write time and is
+independently pinned by
+``tests/unit/test_development_merge_preflight.py``.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUNBOOK_PATH = (
+    REPO_ROOT / "docs" / "governance" / "n5b_merge_preflight_runbook.md"
+)
+
+
+def _runbook_text() -> str:
+    return RUNBOOK_PATH.read_text(encoding="utf-8")
+
+
+# A markdown fenced code block opens with a line starting with ```
+# and closes with a matching line. The negative pin-tests below
+# scan only the *contents* of these blocks, because the runbook
+# necessarily quotes every forbidden imperative in its narrative
+# negative list and those mentions are legitimate. Operators only
+# copy commands out of fenced blocks, so the relevant safety
+# concern is "do not let a fenced block contain a mutating shape".
+_FENCE_RE = re.compile(r"```[^\n]*\n(.*?)```", re.DOTALL)
+
+
+def _runbook_code_blocks() -> str:
+    """Concatenated text of every fenced code block in the runbook.
+
+    Lower-cased so the imperative-shape pins can be written in
+    lowercase without per-phrase ``.lower()`` calls."""
+    text = _runbook_text()
+    return "\n".join(m.group(1) for m in _FENCE_RE.finditer(text)).lower()
+
+
+# ---------------------------------------------------------------------------
+# Existence + shape
+# ---------------------------------------------------------------------------
+
+
+def test_runbook_file_exists() -> None:
+    assert RUNBOOK_PATH.is_file(), (
+        f"N5b merge-preflight runbook missing: {RUNBOOK_PATH}"
+    )
+
+
+def test_runbook_is_non_empty() -> None:
+    text = _runbook_text()
+    # A meaningful runbook is at least a few KiB. Anything tiny
+    # means the operator does not have enough material to refresh
+    # the chain safely.
+    assert len(text) > 4000, (
+        f"N5b preflight runbook is too short ({len(text)} bytes); "
+        f"the runbook must document the full dry-run refresh chain."
+    )
+
+
+def test_runbook_is_markdown() -> None:
+    text = _runbook_text()
+    assert text.lstrip().startswith("# "), (
+        "runbook must be a markdown file beginning with a top-level "
+        "heading."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Canonical CLI invocations (steps 1 → 5)
+# ---------------------------------------------------------------------------
+
+_REQUIRED_CLI_INVOCATIONS: tuple[str, ...] = (
+    "python3 -m reporting.github_pr_lifecycle --mode dry-run",
+    "python3 -m reporting.development_pr_lifecycle_observer",
+    "python3 -m reporting.mobile_approval_inbox",
+    "python3 -m reporting.development_merge_recommendation",
+    "python3 -m reporting.development_merge_preflight",
+)
+
+
+def test_runbook_documents_every_required_cli_invocation() -> None:
+    text = _runbook_text()
+    for cmd in _REQUIRED_CLI_INVOCATIONS:
+        assert cmd in text, (
+            f"runbook must contain the canonical CLI invocation "
+            f"verbatim: {cmd!r}"
+        )
+
+
+def test_runbook_documents_no_write_flag_on_preflight() -> None:
+    """The preflight invocation must be shown with ``--no-write``
+    at least once so the operator has a write-free smoke path."""
+    text = _runbook_text()
+    assert (
+        "python3 -m reporting.development_merge_preflight --no-write"
+        in text
+        or "python -m reporting.development_merge_preflight --no-write"
+        in text
+    ), (
+        "runbook must document the --no-write smoke path for the "
+        "preflight projector."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Artefact paths must agree with the module constants
+# ---------------------------------------------------------------------------
+
+
+def _import_artifact_relative_paths() -> dict[str, str]:
+    from reporting import (  # noqa: WPS433 — local import is intentional
+        development_merge_preflight as n5b,
+        development_merge_recommendation as a23,
+        development_pr_lifecycle_observer as a22,
+        mobile_approval_inbox as n3a,
+    )
+
+    return {
+        "a22": a22.ARTIFACT_RELATIVE_PATH,
+        "n3a": n3a.ARTIFACT_RELATIVE_PATH,
+        "a23": a23.ARTIFACT_RELATIVE_PATH,
+        "n5b": n5b.ARTIFACT_RELATIVE_PATH,
+    }
+
+
+def test_runbook_lists_every_artefact_relative_path() -> None:
+    """The runbook must reference each upstream artefact by its
+    canonical ``ARTIFACT_RELATIVE_PATH`` so path drift in the
+    projector source fails this test before the runbook can
+    silently disagree with the code."""
+    paths = _import_artifact_relative_paths()
+    text = _runbook_text()
+    for label, rel in paths.items():
+        assert rel in text, (
+            f"runbook must reference the {label!r} artefact path "
+            f"{rel!r} exactly."
+        )
+
+
+def test_runbook_references_upstream_github_pr_lifecycle_artefact() -> None:
+    """Step 1 of the chain is the upstream-of-upstream gh digest.
+    The runbook must call it out by its on-disk path so the
+    operator knows where the network step writes."""
+    text = _runbook_text()
+    assert "logs/github_pr_lifecycle/latest.json" in text, (
+        "runbook must reference the upstream gh-digest path "
+        "logs/github_pr_lifecycle/latest.json."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Closed-vocab discipline invariants from the projector
+# ---------------------------------------------------------------------------
+
+
+def test_runbook_states_dry_run_only_invariant() -> None:
+    text = _runbook_text()
+    assert "dry_run_only" in text, (
+        "runbook must restate the projector's dry_run_only invariant."
+    )
+    # ``dry_run_only`` and the literal ``true`` must appear in close
+    # proximity at least once so the invariant is unambiguous.
+    idx = text.find("dry_run_only")
+    nearby = text[idx : idx + 200].lower()
+    assert "true" in nearby, (
+        "dry_run_only must be stated as `true` explicitly in the "
+        "runbook."
+    )
+
+
+def test_runbook_states_live_merge_implemented_false() -> None:
+    text = _runbook_text()
+    assert "live_merge_implemented" in text, (
+        "runbook must restate the live_merge_implemented invariant."
+    )
+    idx = text.find("live_merge_implemented")
+    nearby = text[idx : idx + 200].lower()
+    assert "false" in nearby, (
+        "live_merge_implemented must be stated as `false` explicitly."
+    )
+
+
+def test_runbook_states_deploy_coupled_false() -> None:
+    text = _runbook_text()
+    assert "deploy_coupled" in text, (
+        "runbook must restate the deploy_coupled invariant."
+    )
+    idx = text.find("deploy_coupled")
+    nearby = text[idx : idx + 200].lower()
+    assert "false" in nearby, (
+        "deploy_coupled must be stated as `false` explicitly."
+    )
+
+
+def test_runbook_states_step5_implementation_allowed_false() -> None:
+    text = _runbook_text()
+    assert "step5_implementation_allowed" in text, (
+        "runbook must reaffirm step5_implementation_allowed = false."
+    )
+    idx = text.find("step5_implementation_allowed")
+    nearby = text[idx : idx + 200].lower()
+    assert "false" in nearby, (
+        "step5_implementation_allowed must be stated as `false` "
+        "explicitly in the runbook."
+    )
+
+
+def test_runbook_states_step5_enabled_substage_none() -> None:
+    text = _runbook_text()
+    assert (
+        "STEP5_ENABLED_SUBSTAGE" in text
+        or "step5_enabled_substage" in text
+    ), "runbook must reaffirm the STEP5_ENABLED_SUBSTAGE invariant."
+    lowered = text.lower()
+    assert '"none"' in text or " none" in lowered, (
+        "STEP5_ENABLED_SUBSTAGE must be stated as 'none'."
+    )
+
+
+def test_runbook_states_level_6_permanently_disabled() -> None:
+    text = _runbook_text().lower()
+    assert "level 6" in text, "runbook must reaffirm Level 6 doctrine."
+    assert "permanently disabled" in text, (
+        "runbook must state Level 6 remains permanently disabled."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Closed verdict / stop-condition reminders
+# ---------------------------------------------------------------------------
+
+
+def test_runbook_documents_closed_dry_run_verdict_vocab() -> None:
+    text = _runbook_text()
+    for verdict in (
+        "would_block",
+        "would_require_operator",
+        "would_be_live_candidate_if_authorized",
+    ):
+        assert verdict in text, (
+            f"runbook must list the closed verdict {verdict!r} so "
+            f"the operator can interpret the snapshot."
+        )
+
+
+def test_runbook_documents_informational_stop_conditions() -> None:
+    """The projector emits these two informational stop conditions on
+    every candidate row. The runbook must explain that so the
+    operator does not interpret them as live blockers."""
+    text = _runbook_text()
+    for sc in ("token_required_for_live", "live_merge_not_implemented"):
+        assert sc in text, (
+            f"runbook must reference the informational stop "
+            f"condition {sc!r}."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Negative pins — the runbook must NOT carry an authority escalation
+# ---------------------------------------------------------------------------
+
+
+def test_runbook_code_blocks_contain_no_real_merge_command() -> None:
+    """The runbook's executable surface (its fenced code blocks)
+    must contain no GitHub-mutation command. Narrative negative
+    mentions in prose (``no ``--admin`` ...``) are legitimate and
+    in fact required; they live outside the fenced blocks."""
+    code = _runbook_code_blocks()
+    forbidden_command_shapes = (
+        "gh pr merge --squash",
+        "gh pr merge --rebase",
+        "gh pr merge --merge",
+        "gh pr review --approve",
+        "gh pr review --request-changes",
+        "git merge --no-ff",
+        "git push --force",
+        "git push -f ",
+        "git push origin main",
+        "--admin",
+    )
+    for shape in forbidden_command_shapes:
+        assert shape not in code, (
+            f"runbook code block contains a forbidden "
+            f"mutating-command shape: {shape!r}"
+        )
+
+
+def test_runbook_code_blocks_do_not_enable_a18b_runtime_writer() -> None:
+    """A18b runtime writer activation is a separate operator-only
+    step gated behind a separate operator-go. The runbook's
+    executable surface must not contain an env-flag enable line
+    for it."""
+    code = _runbook_code_blocks()
+    forbidden = (
+        "ade_generated_lane_writer_enabled=true",
+        'ade_generated_lane_writer_enabled="true"',
+        "export ade_generated_lane_writer_enabled",
+    )
+    for phrase in forbidden:
+        assert phrase not in code, (
+            f"runbook code block must NOT enable the A18b runtime "
+            f"writer: {phrase!r}"
+        )
+
+
+def test_runbook_code_blocks_do_not_enable_n5b_live_execute() -> None:
+    """N5b Phase 4 live execute is permanently denied without a
+    separate explicit operator-go. The runbook's executable
+    surface must not contain an env-flag enable line."""
+    code = _runbook_code_blocks()
+    forbidden = (
+        "ade_n5b_live_execute_enabled=true",
+        'ade_n5b_live_execute_enabled="true"',
+        "export ade_n5b_live_execute_enabled",
+    )
+    for phrase in forbidden:
+        assert phrase not in code, (
+            f"runbook code block must NOT enable N5b live execute: "
+            f"{phrase!r}"
+        )
+
+
+def test_runbook_code_blocks_do_not_flip_step5_or_level6() -> None:
+    """Imperative Step 5 / Level 6 flips would only ever appear as
+    executable lines (env exports, assignments, set commands). The
+    invariants block prints the literal lowercase strings (e.g.
+    ``step5_implementation_allowed = false``) inside a fenced
+    block, so we have to scan only for the *true*-shaped flips."""
+    code = _runbook_code_blocks()
+    forbidden_phrases = (
+        "step5_implementation_allowed = true",
+        'step5_implementation_allowed="true"',
+        "step5_implementation_allowed=true",
+        'step5_enabled_substage = "5.1"',
+        'step5_enabled_substage = "5.2"',
+        'step5_enabled_substage="5.1"',
+        'step5_enabled_substage="5.2"',
+        "level6_enabled = true",
+        "level6_enabled=true",
+    )
+    for phrase in forbidden_phrases:
+        assert phrase not in code, (
+            f"runbook code block contains a forbidden "
+            f"authority-escalation flip: {phrase!r}"
+        )
+
+
+def test_runbook_code_blocks_do_not_instruct_token_mint_or_verify() -> None:
+    """Preflight is pre-token. The runbook's executable surface
+    must not contain a token mint / verify invocation. Narrative
+    mentions in the negative list (``does not mint an approval
+    token``) are required and live outside fenced blocks."""
+    code = _runbook_code_blocks()
+    forbidden_phrases = (
+        "approval_token_runtime.mint",
+        "approval_token_runtime.verify",
+        "mint_approval_token",
+        "verify_approval_token",
+        "--mint-token",
+        "--verify-token",
+    )
+    for phrase in forbidden_phrases:
+        assert phrase not in code, (
+            f"runbook code block contains a forbidden token "
+            f"mint/verify invocation: {phrase!r}"
+        )
+
+
+def test_runbook_does_not_instruct_touching_no_touch_paths() -> None:
+    text = _runbook_text().lower()
+    forbidden_imperatives = (
+        "edit .claude",
+        "modify .claude",
+        "write to .claude",
+        "edit .gitleaks.toml",
+        "modify .gitleaks.toml",
+        "disable .gitleaks.toml",
+        "weaken .gitleaks.toml",
+        "edit seed.jsonl",
+        "modify seed.jsonl",
+        "write to seed.jsonl",
+        "append to seed.jsonl",
+        "edit generated_seed.jsonl",
+        "modify generated_seed.jsonl",
+        "write to generated_seed.jsonl",
+        "append to generated_seed.jsonl",
+        "weaken the test",
+        "weaken the tests",
+        "skip the gate",
+        "bypass the hook",
+        "bypass hooks",
+    )
+    for phrase in forbidden_imperatives:
+        assert phrase not in text, (
+            f"runbook contains a forbidden no-touch-path / "
+            f"safety-bypass imperative: {phrase!r}"
+        )
+
+
+def test_runbook_does_not_instruct_deploy() -> None:
+    text = _runbook_text().lower()
+    forbidden_phrases = (
+        "trigger the deploy workflow",
+        "trigger deploy workflow",
+        "force the deploy",
+        "run the deploy",
+        "dispatch the deploy",
+        "couple this to deploy",
+    )
+    for phrase in forbidden_phrases:
+        assert phrase not in text, (
+            f"runbook contains a forbidden deploy-coupling "
+            f"instruction: {phrase!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Negative pins — the runbook must NOT embed secret material
+# ---------------------------------------------------------------------------
+
+
+def test_runbook_contains_no_pem_secret_block() -> None:
+    """Defense-in-depth: the runbook must not contain a real PEM
+    secret block. The PEM markers below are assembled at runtime
+    so the test source itself does not embed a literal PEM header
+    (which would otherwise trip gitleaks' ``private-key`` rule on
+    the test file)."""
+    text = _runbook_text()
+    dashes = "-" * 5
+    pem_kinds = (
+        "PRIVATE KEY",
+        "EC PRIVATE KEY",
+        "RSA PRIVATE KEY",
+        "OPENSSH PRIVATE KEY",
+    )
+    forbidden = [f"{dashes}BEGIN {kind}{dashes}" for kind in pem_kinds]
+    for marker in forbidden:
+        assert marker not in text, (
+            f"runbook contains a PEM-style secret block: {marker!r}"
+        )
+
+
+def test_runbook_contains_no_inline_hex_64_secret() -> None:
+    """A 64-character hex run inside backticks would look like a
+    copy-pasted ``openssl rand -hex 32`` output. The runbook
+    documents read-only projector commands and has no business
+    quoting an HMAC secret."""
+    text = _runbook_text()
+    pattern = re.compile(r"`[0-9a-fA-F]{64}`")
+    matches = pattern.findall(text)
+    assert not matches, (
+        f"runbook embeds a hex-64 literal that looks like a "
+        f"secret: {matches!r}"
+    )
+
+
+def test_runbook_contains_no_bearer_token_header() -> None:
+    """No literal ``Authorization: Bearer <token>`` line — the
+    refresh chain is unauthenticated stdlib projection."""
+    text = _runbook_text().lower()
+    forbidden_patterns = (
+        "authorization: bearer ",
+        "x-api-key: ",
+        "ghp_",
+        "github_pat_",
+        "sk-ant-",
+    )
+    for pat in forbidden_patterns:
+        assert pat not in text, (
+            f"runbook contains a credential-shaped string: {pat!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Step 5 + Level 6 invariants must be stated in a single explicit block
+# ---------------------------------------------------------------------------
+
+
+def test_runbook_contains_combined_invariants_block() -> None:
+    """The runbook must somewhere state the six core invariants in
+    a single close block so the operator can read them together
+    without ambiguity. We require all six lowercased substrings
+    to appear within the same 1200-character window."""
+    text = _runbook_text().lower()
+    needles = (
+        "step5_implementation_allowed",
+        "step5_enabled_substage",
+        "level6_enabled",
+        "dry_run_only",
+        "live_merge_implemented",
+        "deploy_coupled",
+    )
+    # Find the earliest window in which all six needles co-occur.
+    first_idx = text.find(needles[0])
+    while first_idx != -1:
+        window = text[first_idx : first_idx + 1200]
+        if all(n in window for n in needles):
+            return
+        first_idx = text.find(needles[0], first_idx + 1)
+    raise AssertionError(
+        "runbook must state all six invariants "
+        f"({needles!r}) within a single ~1.2 KiB window so the "
+        "operator can read them together."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cross-reference pins — the runbook must link back to the doctrine
+# ---------------------------------------------------------------------------
+
+
+def test_runbook_cross_references_n5b_plan_doc() -> None:
+    text = _runbook_text()
+    assert "n5b_merge_execution_plan.md" in text, (
+        "runbook must cross-reference the N5b plan / governance doc."
+    )
+
+
+def test_runbook_cross_references_adr_015() -> None:
+    text = _runbook_text()
+    assert "ADR-015" in text, (
+        "runbook must cross-reference ADR-015 (Level 6 "
+        "permanently-disabled doctrine)."
+    )
+
+
+def test_runbook_cross_references_recurring_maintenance() -> None:
+    text = _runbook_text()
+    assert "recurring_maintenance" in text, (
+        "runbook must mention recurring_maintenance so the operator "
+        "knows which subsystem (does NOT yet) schedule the "
+        "downstream chain."
+    )


### PR DESCRIPTION
## Summary

Adds the operator runbook for the **read-only** N5b Phase 1
dry-run preflight projector at
`reporting/development_merge_preflight.py`, plus a companion
pin-test suite at
`tests/unit/test_n5b_merge_preflight_runbook.py`.

The runbook documents the dry-run-only CLI sequence the operator
runs to refresh the chain of upstream artefacts the Phase 1
projector reads:

```
github_pr_lifecycle  →  A22  →  N3a  →  A23  →  N5b preflight
```

Without that chain materialised on the host, the projector
default-denies and reports `candidate_count = 0` even when
eligible PR state exists upstream (this is the safe rest state
observed on VPS today). This PR documents the existing safe
refresh path; **no runtime code is modified**.

## Scope (strictly docs + pin-tests)

* `docs/governance/n5b_merge_preflight_runbook.md` — NEW
* `tests/unit/test_n5b_merge_preflight_runbook.py` — NEW (29 tests)

## What is NOT touched

* `reporting/**` (no module change; the projectors are
  read-only and already pinned by their own tests)
* `reporting/recurring_maintenance.py` (scheduler integration
  for the downstream chain is a deliberate follow-up; explicitly
  out of scope here)
* `dashboard/**`, `frontend/**`, `scripts/**`,
  `.github/workflows/**`
* `.claude/**`, `.gitleaks.toml`, `research/**`, `live/**`,
  `paper/**`, `shadow/**`, `risk/**`, `broker/**`, `execution/**`
* No A18b runtime activation. No N5b Phase 2/3/4 introduction.
  No Step 5 or Level 6 change.

## Invariants reaffirmed (pinned by the new tests)

* `step5_implementation_allowed = false`
* `STEP5_ENABLED_SUBSTAGE = \"none\"`
* `level6_enabled = false` (Level 6 permanently disabled per
  ADR-015 §Doctrine 1)
* `dry_run_only = true`
* `live_merge_implemented = false`
* `deploy_coupled = false`

## Pin-test highlights

* Existence + non-emptiness of the runbook
* Every required CLI invocation present verbatim
  (`reporting.github_pr_lifecycle`, `.development_pr_lifecycle_observer`,
  `.mobile_approval_inbox`, `.development_merge_recommendation`,
  `.development_merge_preflight`)
* Artefact paths match the module-level
  `ARTIFACT_RELATIVE_PATH` constants (path drift fails the test
  before the runbook can silently disagree with the code)
* Closed verdict and stop-condition vocab documented
* Fenced code blocks contain no GitHub-mutation command, no
  `--admin`, no env-flag enable for A18b runtime writer, no
  env-flag enable for N5b live execute, no Step 5 flip, no
  Level 6 enable, no approval-token mint/verify call
* No PEM block, no hex-64 inline-code secret, no bearer-token
  header
* Cross-references to `n5b_merge_execution_plan.md`,
  ADR-015, and `recurring_maintenance.md`

## Test plan

- [x] `python scripts/governance_lint.py` — Governance lint OK
- [x] `python -m pytest tests/smoke -q` — 18 passed
- [x] `python -m pytest tests/unit/test_n5b_merge_preflight_runbook.py -q` — 29 passed
- [x] `python -m reporting.development_merge_preflight --no-write` — dry_run_only=true, live_merge_implemented=false, deploy_coupled=false, candidate_count=0
- [x] `python -m reporting.development_step5_loop --no-write` — step5 invariants false/none
- [x] `python -m reporting.development_operational_digest --no-write` — step5 invariants false

## Operator verification (post-merge, optional)

Docs+tests only — **no auto-deploy is triggered**. The runbook
itself ships the manual VPS sequence the operator can run to
refresh the chain on demand; that sequence is dry-run only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)