### PR TITLE
feat(n5b): read-only dashboard API for Phase 1 merge-preflight (UNWIRED)

### DIFF
--- a/dashboard/api_merge_preflight.py
+++ b/dashboard/api_merge_preflight.py
@@ -1,0 +1,419 @@
+"""N5b Phase 1 — Merge Preflight API blueprint (read-only, UNWIRED).
+
+GET-only Flask blueprint that exposes the existing
+``reporting.development_merge_preflight`` projector artefact at
+``logs/development_merge_preflight/latest.json`` to the
+operator-facing surface.
+
+This blueprint surfaces the closed-schema dry-run preflight rows
+that the N5b Phase 1 projector writes — joining the A22 PR-lifecycle
+observer and the A23 / N5a merge recommendation into a per-PR
+verdict the operator can read. It does **not** perform any merge /
+deploy / approve / reject action, it does **not** mint or verify
+approval tokens, it does **not** invoke ``gh`` / ``git`` /
+subprocess / network. Actual live merge execution is N5b Phase
+2/3/4 territory and remains permanently denied without a separate
+explicit operator-go per
+``docs/governance/n5b_merge_execution_plan.md`` §10.
+
+The blueprint is auth-agnostic and shipped unwired. Its live auth
+posture will be verified separately when the operator applies the
+dashboard.py wiring. This PR does not expose the routes.
+
+Hard guarantees (pinned by tests)
+---------------------------------
+
+* GET only — no POST / PUT / PATCH / DELETE handler is registered.
+* Two routes only:
+
+    GET /api/agent-control/merge-preflight/list
+    GET /api/agent-control/merge-preflight/detail/<preflight_id>
+
+* Reads only the N5b Phase 1 artefact via
+  ``reporting.development_merge_preflight.ARTIFACT_LATEST``.
+  Never mutates the upstream artefact, never mutates any PR, never
+  invokes ``gh`` / ``git``, never opens a network socket.
+* Never imports a Web Push library, never reads any approval-token
+  secret, never reads the env VAPID private key (those env vars
+  are referenced by name only in their respective owning modules).
+* Never executes a CLI subprocess.
+* Every response payload is run through
+  ``reporting.agent_audit_summary.assert_no_secrets`` before send.
+* ``not_available`` envelope returned when the artefact is missing,
+  unreadable, or malformed.
+* ``not_found`` envelope returned for a detail lookup when the
+  ``preflight_id`` is not present in the bounded rows.
+* ``invalid_preflight_id`` envelope returned for malformed or
+  oversized ``preflight_id`` path parameters.
+* The blueprint is intentionally **NOT** wired into
+  ``dashboard/dashboard.py`` in the PR that introduces it — wiring
+  is the operator's two-line diff (per ``execution_authority.md``).
+* No decision-verb call appears in any code path (the verb-with-
+  paren patterns are explicitly forbidden by the unit-test scan).
+* Every list and detail envelope carries the closed
+  ``step5_implementation_allowed=False``,
+  ``step5_enabled_substage="none"``, ``level6_enabled=False``,
+  ``dry_run_only=True``, ``live_merge_implemented=False``,
+  ``deploy_coupled=False`` invariants verbatim — the projector's
+  own ``discipline_invariants`` dict is mirrored at the API
+  boundary so the consumer always sees them.
+
+Routes contract
+---------------
+
+The list endpoint returns a redacted envelope shaped like:
+
+::
+
+    {
+        "kind": "agent_control_merge_preflight_list",
+        "schema_version": 1,
+        "module_version": "v3.15.16.N5b.phase1.api",
+        "status": "ok" | "not_available",
+        "rows": [...closed-schema N5b rows...],
+        "counts": {
+            "rows": <int>,
+            "by_dry_run_verdict": {<verdict>: <int>, ...},
+        },
+        "generated_at_utc": "<isoformat or empty>",
+        "artifact_path": "logs/development_merge_preflight/latest.json",
+        "step5_implementation_allowed": false,
+        "step5_enabled_substage": "none",
+        "level6_enabled": false,
+        "dry_run_only": true,
+        "live_merge_implemented": false,
+        "deploy_coupled": false
+    }
+
+The detail endpoint returns the same envelope shape with either a
+single ``row`` field or a ``status`` of ``not_found`` /
+``invalid_preflight_id`` / ``not_available``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Final
+
+from flask import Flask, Response, jsonify
+
+from reporting import development_merge_preflight as dmp
+from reporting.agent_audit_summary import assert_no_secrets
+
+MODULE_VERSION: Final[str] = "v3.15.16.N5b.phase1.api"
+SCHEMA_VERSION: Final[int] = 1
+
+
+# ---------------------------------------------------------------------------
+# Step 5 invariants
+# ---------------------------------------------------------------------------
+
+STEP5_ENABLED_SUBSTAGE: Final[str] = "none"
+step5_implementation_allowed: Final[bool] = False
+
+
+# ---------------------------------------------------------------------------
+# Bounded preflight_id surface
+# ---------------------------------------------------------------------------
+
+#: Maximum preflight_id length accepted by the detail route. The
+#: projector's id format is ``pf_<pr_number>_<sha_prefix_12>`` — far
+#: shorter than this cap. The cap also exists as defense-in-depth
+#: against pathological URL paths.
+_MAX_PREFLIGHT_ID_LEN: Final[int] = 128
+
+#: Permissive but bounded preflight_id charset. The projector's id
+#: only contains ASCII letters, digits, and underscores; this regex
+#: refuses any path segment that contains URL-encoded bytes,
+#: separators, or token-shaped characters (``.``, ``=``, ``/``).
+_PREFLIGHT_ID_PATTERN: Final[re.Pattern[str]] = re.compile(
+    r"^[A-Za-z0-9_\-]+$"
+)
+
+
+# ---------------------------------------------------------------------------
+# Discipline invariants every envelope carries
+# ---------------------------------------------------------------------------
+
+_DISCIPLINE_FIELDS: Final[dict[str, bool | str]] = {
+    "step5_implementation_allowed": False,
+    "step5_enabled_substage": STEP5_ENABLED_SUBSTAGE,
+    "level6_enabled": False,
+    "dry_run_only": True,
+    "live_merge_implemented": False,
+    "deploy_coupled": False,
+}
+
+
+def _with_discipline(envelope: dict[str, Any]) -> dict[str, Any]:
+    """Attach the closed discipline-invariant fields to ``envelope``.
+    Callers never overwrite these values."""
+    out = dict(envelope)
+    out.update(_DISCIPLINE_FIELDS)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Artefact reader (read-only, never raises)
+# ---------------------------------------------------------------------------
+
+
+def _read_artifact() -> tuple[str, dict[str, Any]]:
+    """Return ``(status, payload)`` for the N5b Phase 1 artefact."""
+    path: Path = dmp.ARTIFACT_LATEST
+    if not path.is_file():
+        return "not_available", {"reason": "missing"}
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return "not_available", {
+            "reason": f"unreadable: {type(exc).__name__}"
+        }
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        return "not_available", {
+            "reason": f"malformed: {type(exc).__name__}"
+        }
+    if not isinstance(data, dict):
+        return "not_available", {"reason": "malformed: not_an_object"}
+    return "ok", data
+
+
+def _safe_rows(data: dict[str, Any]) -> list[dict[str, Any]]:
+    """Filter the projector artefact to rows whose shape matches the
+    closed N5b Phase 1 candidate schema. Defense-in-depth — the
+    projector already enforces this, but we re-validate at the API
+    boundary."""
+    raw = data.get("candidates")
+    if not isinstance(raw, list):
+        return []
+    expected = set(dmp.CANDIDATE_ROW_KEYS)
+    out: list[dict[str, Any]] = []
+    for r in raw:
+        if not isinstance(r, dict):
+            continue
+        if set(r.keys()) != expected:
+            continue
+        out.append(r)
+    return out[: dmp.MAX_CANDIDATE_ROWS]
+
+
+def _by_dry_run_verdict(rows: list[dict[str, Any]]) -> dict[str, int]:
+    """Bounded counts dict over the closed
+    ``DRY_RUN_VERDICTS`` vocabulary."""
+    counts: dict[str, int] = {v: 0 for v in dmp.DRY_RUN_VERDICTS}
+    for row in rows:
+        verdict = row.get("dry_run_verdict")
+        if isinstance(verdict, str) and verdict in counts:
+            counts[verdict] += 1
+    return counts
+
+
+# ---------------------------------------------------------------------------
+# View functions
+# ---------------------------------------------------------------------------
+
+
+def _safe_jsonify(payload: dict[str, Any]) -> Response:
+    assert_no_secrets(payload)
+    return jsonify(payload)
+
+
+def _list_envelope() -> dict[str, Any]:
+    status, data = _read_artifact()
+    if status != "ok":
+        return _with_discipline(
+            {
+                "kind": "agent_control_merge_preflight_list",
+                "schema_version": SCHEMA_VERSION,
+                "module_version": MODULE_VERSION,
+                "status": "not_available",
+                "reason": data.get("reason", "missing"),
+                "rows": [],
+                "counts": {
+                    "rows": 0,
+                    "by_dry_run_verdict": {
+                        v: 0 for v in dmp.DRY_RUN_VERDICTS
+                    },
+                },
+                "artifact_path": dmp.ARTIFACT_RELATIVE_PATH,
+            }
+        )
+    rows = _safe_rows(data)
+    return _with_discipline(
+        {
+            "kind": "agent_control_merge_preflight_list",
+            "schema_version": SCHEMA_VERSION,
+            "module_version": MODULE_VERSION,
+            "status": "ok",
+            "rows": rows,
+            "counts": {
+                "rows": len(rows),
+                "by_dry_run_verdict": _by_dry_run_verdict(rows),
+            },
+            "generated_at_utc": str(data.get("generated_at_utc") or ""),
+            "artifact_path": dmp.ARTIFACT_RELATIVE_PATH,
+        }
+    )
+
+
+def _detail_envelope(
+    preflight_id: str,
+) -> tuple[dict[str, Any], int]:
+    """Return ``(envelope, http_status)`` for the detail lookup."""
+    if not isinstance(preflight_id, str) or not preflight_id:
+        return (
+            _with_discipline(
+                {
+                    "kind": "agent_control_merge_preflight_detail",
+                    "schema_version": SCHEMA_VERSION,
+                    "module_version": MODULE_VERSION,
+                    "status": "invalid_preflight_id",
+                    "reason": "empty",
+                }
+            ),
+            400,
+        )
+    if len(preflight_id) > _MAX_PREFLIGHT_ID_LEN:
+        return (
+            _with_discipline(
+                {
+                    "kind": "agent_control_merge_preflight_detail",
+                    "schema_version": SCHEMA_VERSION,
+                    "module_version": MODULE_VERSION,
+                    "status": "invalid_preflight_id",
+                    "reason": "too_long",
+                }
+            ),
+            400,
+        )
+    if not _PREFLIGHT_ID_PATTERN.match(preflight_id):
+        return (
+            _with_discipline(
+                {
+                    "kind": "agent_control_merge_preflight_detail",
+                    "schema_version": SCHEMA_VERSION,
+                    "module_version": MODULE_VERSION,
+                    "status": "invalid_preflight_id",
+                    "reason": "bad_charset",
+                }
+            ),
+            400,
+        )
+    status, data = _read_artifact()
+    if status != "ok":
+        return (
+            _with_discipline(
+                {
+                    "kind": "agent_control_merge_preflight_detail",
+                    "schema_version": SCHEMA_VERSION,
+                    "module_version": MODULE_VERSION,
+                    "status": "not_available",
+                    "reason": data.get("reason", "missing"),
+                    "artifact_path": dmp.ARTIFACT_RELATIVE_PATH,
+                }
+            ),
+            404,
+        )
+    for row in _safe_rows(data):
+        if row.get("preflight_id") == preflight_id:
+            return (
+                _with_discipline(
+                    {
+                        "kind": "agent_control_merge_preflight_detail",
+                        "schema_version": SCHEMA_VERSION,
+                        "module_version": MODULE_VERSION,
+                        "status": "ok",
+                        "row": row,
+                        "generated_at_utc": str(
+                            data.get("generated_at_utc") or ""
+                        ),
+                        "artifact_path": dmp.ARTIFACT_RELATIVE_PATH,
+                    }
+                ),
+                200,
+            )
+    return (
+        _with_discipline(
+            {
+                "kind": "agent_control_merge_preflight_detail",
+                "schema_version": SCHEMA_VERSION,
+                "module_version": MODULE_VERSION,
+                "status": "not_found",
+                "reason": "no_matching_preflight_id",
+                "artifact_path": dmp.ARTIFACT_RELATIVE_PATH,
+            }
+        ),
+        404,
+    )
+
+
+def _view_list() -> Response:
+    return _safe_jsonify(_list_envelope())
+
+
+def _view_detail(
+    preflight_id: str,
+) -> tuple[Response, int] | Response:
+    envelope, code = _detail_envelope(preflight_id)
+    resp = _safe_jsonify(envelope)
+    if code == 200:
+        return resp
+    return resp, code
+
+
+# ---------------------------------------------------------------------------
+# Route table + register helper
+# ---------------------------------------------------------------------------
+
+_MERGE_PREFLIGHT_ROUTES: tuple[tuple[str, str, Any, str], ...] = (
+    (
+        "/api/agent-control/merge-preflight/list",
+        "GET",
+        _view_list,
+        "agent_control_merge_preflight_list",
+    ),
+    (
+        "/api/agent-control/merge-preflight/detail/<string:preflight_id>",
+        "GET",
+        _view_detail,
+        "agent_control_merge_preflight_detail",
+    ),
+)
+
+
+def register_merge_preflight_routes(app: Flask) -> None:
+    """Register the read-only N5b Phase 1 merge-preflight routes.
+
+    NOT wired into ``dashboard/dashboard.py`` in the PR that
+    introduces this blueprint. The two-line wiring change
+
+    ::
+
+        from dashboard.api_merge_preflight import register_merge_preflight_routes
+        register_merge_preflight_routes(app)
+
+    is operator-only per ``docs/governance/execution_authority.md``
+    (``dashboard_wiring`` = NEEDS_HUMAN) and the no-touch hook at
+    ``.claude/hooks/deny_no_touch.py`` (which protects
+    ``dashboard/dashboard.py``).
+    """
+    for path, method, handler, endpoint in _MERGE_PREFLIGHT_ROUTES:
+        app.add_url_rule(
+            path,
+            endpoint=endpoint,
+            view_func=handler,
+            methods=[method],
+        )
+
+
+__all__ = [
+    "MODULE_VERSION",
+    "SCHEMA_VERSION",
+    "STEP5_ENABLED_SUBSTAGE",
+    "register_merge_preflight_routes",
+    "step5_implementation_allowed",
+]

--- a/tests/unit/test_api_merge_preflight.py
+++ b/tests/unit/test_api_merge_preflight.py
@@ -1,0 +1,659 @@
+"""Unit tests for N5b Phase 1 — ``dashboard.api_merge_preflight``
+(UNWIRED).
+
+Pins:
+
+* exactly two GET routes (list + detail); no other HTTP method
+  registered;
+* list with missing artifact → ``not_available`` envelope;
+* list with valid artifact → bounded rows + counts;
+* list with malformed artifact → safe ``not_available`` envelope;
+* list filters invalid row shapes (closed-schema key-set
+  defense-in-depth);
+* detail with missing artifact → 404 ``not_available``;
+* detail with valid artifact but unknown id → 404 ``not_found``;
+* detail with valid id → 200 with exactly one row;
+* detail with empty / too-long / bad-charset id →
+  400 ``invalid_preflight_id``;
+* every envelope carries the closed Step 5 + Level 6 + dry-run /
+  live-merge / deploy-coupled invariants verbatim;
+* AST + source-text scans: no subprocess / ``gh`` / ``git`` /
+  pywebpush / approval-token / ``approve(`` / ``reject(`` /
+  ``merge(`` / ``deploy(`` call patterns / ``seed.jsonl``
+  writes / forbidden module imports;
+* the blueprint is auth-agnostic; the dashboard.py wiring is
+  enforced as a both-or-neither skip-or-enforce pin (the
+  operator-applied two-line diff is the live wiring step).
+* Step 5 invariants intact by import.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from flask import Flask
+
+from dashboard import api_merge_preflight as amp
+from reporting import development_merge_preflight as dmp
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolate_artifact(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    target = (
+        tmp_path
+        / "logs"
+        / "development_merge_preflight"
+        / "latest.json"
+    )
+    target.parent.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(dmp, "ARTIFACT_LATEST", target)
+    return target
+
+
+def _make_app() -> Flask:
+    app = Flask(__name__)
+    amp.register_merge_preflight_routes(app)
+    return app
+
+
+def _valid_row(
+    pr_number: int = 42,
+    head_sha_prefix: str = "deadbeefdead",
+    verdict: str = "would_be_live_candidate_if_authorized",
+) -> dict[str, Any]:
+    """Build one closed-schema N5b candidate row. Key-set matches
+    ``dmp.CANDIDATE_ROW_KEYS`` exactly."""
+    preflight_id = f"pf_{pr_number}_{head_sha_prefix[:12]}"
+    expected_head_sha = (head_sha_prefix + "0" * 64)[:64]
+    return {
+        "preflight_id": preflight_id,
+        "recommendation_id": f"rec_pr_{pr_number}",
+        "pr_number": pr_number,
+        "expected_head_sha": expected_head_sha,
+        "observed_head_sha": expected_head_sha,
+        "base_ref": "main",
+        "head_ref": "feature/branch",
+        "merge_state": "CLEAN",
+        "checks_state": "SUCCESS",
+        "recommendation_action": "recommend_human_merge",
+        "recommendation_reason": "pr_clean_and_no_blocking_inbox",
+        "token_required_for_live": True,
+        "dry_run_verdict": verdict,
+        "live_merge_implemented": False,
+        "stop_conditions": [
+            "token_required_for_live",
+            "live_merge_not_implemented",
+        ],
+        "audit_note": "dry-run only",
+        "generated_at_utc": "2026-05-13T12:00:00Z",
+        "evidence_freshness_seconds": 30,
+    }
+
+
+def _write_artifact(
+    artifact_path: Path, candidates: list[dict[str, Any]]
+) -> None:
+    payload = {
+        "schema_version": dmp.SCHEMA_VERSION,
+        "module_version": dmp.MODULE_VERSION,
+        "report_kind": dmp.REPORT_KIND,
+        "generated_at_utc": "2026-05-13T12:00:00Z",
+        "step5_implementation_allowed": False,
+        "step5_enabled_substage": "none",
+        "dry_run_only": True,
+        "live_merge_implemented": False,
+        "deploy_coupled": False,
+        "level6_enabled": False,
+        "candidate_count": len(candidates),
+        "candidates": candidates,
+        "sources_read": {},
+        "validation_warnings": [],
+        "note": "candidates_present" if candidates else "no_recommendation_rows",
+    }
+    artifact_path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Route registration
+# ---------------------------------------------------------------------------
+
+
+def test_register_routes_registers_only_two_get_routes() -> None:
+    app = _make_app()
+    rules = sorted(
+        (rule.rule, frozenset(rule.methods or set()))
+        for rule in app.url_map.iter_rules()
+        if rule.rule.startswith("/api/agent-control/merge-preflight/")
+    )
+    assert rules == [
+        (
+            "/api/agent-control/merge-preflight/detail/<string:preflight_id>",
+            frozenset({"GET", "HEAD", "OPTIONS"}),
+        ),
+        (
+            "/api/agent-control/merge-preflight/list",
+            frozenset({"GET", "HEAD", "OPTIONS"}),
+        ),
+    ]
+
+
+def test_no_mutating_routes_registered() -> None:
+    app = _make_app()
+    for rule in app.url_map.iter_rules():
+        if rule.rule.startswith("/api/agent-control/merge-preflight/"):
+            methods = rule.methods or set()
+            assert not (
+                methods & {"POST", "PUT", "PATCH", "DELETE"}
+            ), (
+                f"unexpected mutating method on {rule.rule}: {methods}"
+            )
+
+
+def test_blueprint_not_yet_wired_into_dashboard_dashboard() -> None:
+    """Operator step pending: dashboard.py must contain BOTH the
+    import and the register call for api_merge_preflight, or
+    NEITHER. The two-line wiring diff is operator-applied per the
+    no-touch hook on ``dashboard/dashboard.py``."""
+    text = (REPO_ROOT / "dashboard" / "dashboard.py").read_text(
+        encoding="utf-8"
+    )
+    wiring_present = (
+        "from dashboard.api_merge_preflight "
+        "import register_merge_preflight_routes"
+        in text
+    )
+    register_present = (
+        "register_merge_preflight_routes(app)" in text
+    )
+    assert wiring_present == register_present, (
+        "dashboard.py must contain BOTH the import and the register "
+        "call for api_merge_preflight, or NEITHER."
+    )
+
+
+# ---------------------------------------------------------------------------
+# List endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_list_missing_artifact_returns_not_available() -> None:
+    res = _make_app().test_client().get(
+        "/api/agent-control/merge-preflight/list"
+    )
+    assert res.status_code == 200
+    body = res.get_json()
+    assert body["status"] == "not_available"
+    assert body["counts"]["rows"] == 0
+    assert body["rows"] == []
+    # by_dry_run_verdict counts dict is present and zeroed across
+    # the closed vocabulary.
+    bdv = body["counts"]["by_dry_run_verdict"]
+    assert set(bdv.keys()) == set(dmp.DRY_RUN_VERDICTS)
+    assert all(v == 0 for v in bdv.values())
+
+
+def test_list_valid_artifact_returns_bounded_rows(
+    _isolate_artifact: Path,
+) -> None:
+    rows = [
+        _valid_row(pr_number=i, head_sha_prefix=f"abcd{i:04x}eeee")
+        for i in range(3)
+    ]
+    _write_artifact(_isolate_artifact, rows)
+    res = _make_app().test_client().get(
+        "/api/agent-control/merge-preflight/list"
+    )
+    body = res.get_json()
+    assert body["status"] == "ok"
+    assert body["counts"]["rows"] == 3
+    assert len(body["rows"]) == 3
+    # by_dry_run_verdict counts the closed vocab.
+    assert sum(body["counts"]["by_dry_run_verdict"].values()) == 3
+
+
+def test_list_envelope_carries_step5_invariants(
+    _isolate_artifact: Path,
+) -> None:
+    _write_artifact(_isolate_artifact, [_valid_row()])
+    body = _make_app().test_client().get(
+        "/api/agent-control/merge-preflight/list"
+    ).get_json()
+    assert body["step5_implementation_allowed"] is False
+    assert body["step5_enabled_substage"] == "none"
+
+
+def test_list_envelope_carries_level6_and_dry_run_invariants(
+    _isolate_artifact: Path,
+) -> None:
+    _write_artifact(_isolate_artifact, [_valid_row()])
+    body = _make_app().test_client().get(
+        "/api/agent-control/merge-preflight/list"
+    ).get_json()
+    assert body["level6_enabled"] is False
+    assert body["dry_run_only"] is True
+    assert body["live_merge_implemented"] is False
+    assert body["deploy_coupled"] is False
+
+
+def test_list_envelope_when_not_available_still_carries_invariants() -> None:
+    """Even on the not_available path the envelope must restate the
+    six discipline invariants — consumers must never be able to
+    observe an N5b envelope without seeing them."""
+    body = _make_app().test_client().get(
+        "/api/agent-control/merge-preflight/list"
+    ).get_json()
+    assert body["step5_implementation_allowed"] is False
+    assert body["step5_enabled_substage"] == "none"
+    assert body["level6_enabled"] is False
+    assert body["dry_run_only"] is True
+    assert body["live_merge_implemented"] is False
+    assert body["deploy_coupled"] is False
+
+
+def test_list_malformed_artifact_returns_not_available(
+    _isolate_artifact: Path,
+) -> None:
+    _isolate_artifact.write_text("not json", encoding="utf-8")
+    body = _make_app().test_client().get(
+        "/api/agent-control/merge-preflight/list"
+    ).get_json()
+    assert body["status"] == "not_available"
+    assert "malformed" in body["reason"]
+
+
+def test_list_non_object_top_level_returns_not_available(
+    _isolate_artifact: Path,
+) -> None:
+    _isolate_artifact.write_text("[1, 2, 3]", encoding="utf-8")
+    body = _make_app().test_client().get(
+        "/api/agent-control/merge-preflight/list"
+    ).get_json()
+    assert body["status"] == "not_available"
+    assert "malformed" in body["reason"]
+
+
+def test_list_artifact_with_invalid_row_shapes_is_filtered(
+    _isolate_artifact: Path,
+) -> None:
+    rows: list[dict[str, Any]] = [
+        _valid_row(pr_number=1, head_sha_prefix="aaaaaaaaaaaa"),
+        # missing required keys — closed key-set check filters it out
+        {"preflight_id": "pf_2_bbbb"},
+    ]
+    _write_artifact(_isolate_artifact, rows)
+    body = _make_app().test_client().get(
+        "/api/agent-control/merge-preflight/list"
+    ).get_json()
+    assert [r["pr_number"] for r in body["rows"]] == [1]
+
+
+def test_list_carries_artifact_path_constant(
+    _isolate_artifact: Path,
+) -> None:
+    _write_artifact(_isolate_artifact, [_valid_row()])
+    body = _make_app().test_client().get(
+        "/api/agent-control/merge-preflight/list"
+    ).get_json()
+    assert body["artifact_path"] == dmp.ARTIFACT_RELATIVE_PATH
+
+
+# ---------------------------------------------------------------------------
+# Detail endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_detail_missing_artifact_returns_404_not_available() -> None:
+    res = _make_app().test_client().get(
+        "/api/agent-control/merge-preflight/detail/pf_42_deadbeefdead"
+    )
+    assert res.status_code == 404
+    body = res.get_json()
+    assert body["status"] == "not_available"
+
+
+def test_detail_unknown_id_returns_404_not_found(
+    _isolate_artifact: Path,
+) -> None:
+    _write_artifact(_isolate_artifact, [_valid_row(pr_number=7)])
+    res = _make_app().test_client().get(
+        "/api/agent-control/merge-preflight/detail/pf_99_ffffffffffff"
+    )
+    assert res.status_code == 404
+    body = res.get_json()
+    assert body["status"] == "not_found"
+    assert body["reason"] == "no_matching_preflight_id"
+
+
+def test_detail_valid_id_returns_exact_row(
+    _isolate_artifact: Path,
+) -> None:
+    rows = [
+        _valid_row(pr_number=1, head_sha_prefix="111122223333"),
+        _valid_row(pr_number=2, head_sha_prefix="444455556666"),
+        _valid_row(pr_number=3, head_sha_prefix="777788889999"),
+    ]
+    _write_artifact(_isolate_artifact, rows)
+    target = rows[1]["preflight_id"]
+    res = _make_app().test_client().get(
+        f"/api/agent-control/merge-preflight/detail/{target}"
+    )
+    assert res.status_code == 200
+    body = res.get_json()
+    assert body["status"] == "ok"
+    assert body["row"]["preflight_id"] == target
+    assert body["row"]["pr_number"] == 2
+    # Closed-schema row → no decision-verb literal in any scalar
+    # value (the projector's CANDIDATE_ROW_KEYS schema excludes
+    # such fields by construction, but defense-in-depth here).
+    for v in body["row"].values():
+        if isinstance(v, str):
+            lv = v.lower()
+            # Closed N5a recommendation_action uses recommend_human_*.
+            assert "approve_" not in lv or "recommend" in lv
+            assert "deploy" not in lv
+            assert "reject" not in lv
+
+
+def test_detail_empty_id_returns_400_invalid() -> None:
+    # Flask's routing rejects empty path segments at the URL-map
+    # level (it would be a 404 from werkzeug), so we exercise the
+    # underlying view function directly to pin the empty-id branch.
+    envelope, code = amp._detail_envelope("")
+    assert code == 400
+    assert envelope["status"] == "invalid_preflight_id"
+    assert envelope["reason"] == "empty"
+
+
+def test_detail_too_long_id_returns_400(
+    _isolate_artifact: Path,
+) -> None:
+    _write_artifact(_isolate_artifact, [_valid_row()])
+    big = "x" * 200
+    res = _make_app().test_client().get(
+        f"/api/agent-control/merge-preflight/detail/{big}"
+    )
+    assert res.status_code == 400
+    body = res.get_json()
+    assert body["status"] == "invalid_preflight_id"
+    assert body["reason"] == "too_long"
+
+
+def test_detail_bad_charset_id_returns_400(
+    _isolate_artifact: Path,
+) -> None:
+    _write_artifact(_isolate_artifact, [_valid_row()])
+    res = _make_app().test_client().get(
+        "/api/agent-control/merge-preflight/detail/bad%20id"
+    )
+    assert res.status_code == 400
+    body = res.get_json()
+    assert body["status"] == "invalid_preflight_id"
+    assert body["reason"] == "bad_charset"
+
+
+def test_detail_id_with_dot_returns_400(
+    _isolate_artifact: Path,
+) -> None:
+    """A ``.`` in the path segment is the canonical shape of a token
+    (``header.payload.signature``). The pattern must refuse it."""
+    _write_artifact(_isolate_artifact, [_valid_row()])
+    # Use bytes/url-encoded form so Flask doesn't normalise the dot.
+    res = _make_app().test_client().get(
+        "/api/agent-control/merge-preflight/detail/has%2Edots"
+    )
+    assert res.status_code == 400
+    body = res.get_json()
+    assert body["status"] == "invalid_preflight_id"
+
+
+def test_detail_envelope_carries_step5_invariants(
+    _isolate_artifact: Path,
+) -> None:
+    row = _valid_row()
+    _write_artifact(_isolate_artifact, [row])
+    body = _make_app().test_client().get(
+        f"/api/agent-control/merge-preflight/detail/{row['preflight_id']}"
+    ).get_json()
+    assert body["step5_implementation_allowed"] is False
+    assert body["step5_enabled_substage"] == "none"
+
+
+def test_detail_envelope_carries_level6_and_dry_run_invariants(
+    _isolate_artifact: Path,
+) -> None:
+    row = _valid_row()
+    _write_artifact(_isolate_artifact, [row])
+    body = _make_app().test_client().get(
+        f"/api/agent-control/merge-preflight/detail/{row['preflight_id']}"
+    ).get_json()
+    assert body["level6_enabled"] is False
+    assert body["dry_run_only"] is True
+    assert body["live_merge_implemented"] is False
+    assert body["deploy_coupled"] is False
+
+
+def test_detail_not_found_envelope_still_carries_invariants(
+    _isolate_artifact: Path,
+) -> None:
+    _write_artifact(_isolate_artifact, [_valid_row()])
+    body = _make_app().test_client().get(
+        "/api/agent-control/merge-preflight/detail/pf_99_zzzzzzzzzzzz"
+    ).get_json()
+    assert body["status"] == "invalid_preflight_id" or body["status"] == "not_found"
+    assert body["step5_implementation_allowed"] is False
+    assert body["step5_enabled_substage"] == "none"
+    assert body["level6_enabled"] is False
+    assert body["dry_run_only"] is True
+    assert body["live_merge_implemented"] is False
+    assert body["deploy_coupled"] is False
+
+
+# ---------------------------------------------------------------------------
+# Response payload safety
+# ---------------------------------------------------------------------------
+
+
+def test_response_payload_has_no_unexpected_secret_markers(
+    _isolate_artifact: Path,
+) -> None:
+    _write_artifact(_isolate_artifact, [_valid_row()])
+    res = _make_app().test_client().get(
+        "/api/agent-control/merge-preflight/list"
+    )
+    raw = res.data.decode("utf-8")
+    # No VAPID / push / token-secret material should ever land here.
+    assert "BEGIN PRIVATE KEY" not in raw
+    assert "p256dh" not in raw
+    assert "ADE_APPROVAL_TOKEN_HMAC_SECRET" not in raw
+    assert "ADE_GENERATED_LANE_WRITER_ENABLED" not in raw
+    assert "ADE_N5B_LIVE_EXECUTE_ENABLED" not in raw
+
+
+# ---------------------------------------------------------------------------
+# Source-text + AST scans
+# ---------------------------------------------------------------------------
+
+
+def _module_source() -> str:
+    return Path(amp.__file__).read_text(encoding="utf-8")
+
+
+def _imported_module_names() -> set[str]:
+    tree = ast.parse(_module_source())
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module is not None:
+                names.add(node.module)
+    return names
+
+
+def test_no_subprocess_in_module() -> None:
+    src = _module_source()
+    assert "import subprocess" not in src
+    assert "from subprocess" not in src
+
+
+def test_no_gh_or_git_in_module() -> None:
+    src = _module_source()
+    for needle in ("subprocess.run", " gh ", " git "):
+        assert needle not in src, needle
+
+
+def test_no_network_library_import_in_module() -> None:
+    names = _imported_module_names()
+    forbidden = {
+        "socket",
+        "urllib",
+        "urllib.request",
+        "urllib.parse",
+        "requests",
+        "httpx",
+        "aiohttp",
+        "http.client",
+    }
+    for n in names:
+        top = n.split(".", 1)[0]
+        assert top not in {
+            "socket",
+            "urllib",
+            "requests",
+            "httpx",
+            "aiohttp",
+        }, f"forbidden network import: {n}"
+        assert n not in forbidden, f"forbidden network import: {n}"
+
+
+def test_no_web_push_library_import_in_module() -> None:
+    names = _imported_module_names()
+    for n in names:
+        assert n not in {"pywebpush", "webpush", "web_push"}, n
+
+
+def test_no_vapid_private_key_literal_in_module() -> None:
+    src = _module_source()
+    assert "WEB_PUSH_VAPID_PRIVATE_KEY" not in src
+
+
+def test_no_approval_token_secret_literal_in_module() -> None:
+    """N5b Phase 1 is a read-only inspector — it must not reference
+    the approval-token env secret. Token issuance/verification is
+    N4b territory."""
+    src = _module_source()
+    assert "ADE_APPROVAL_TOKEN_HMAC_SECRET" not in src
+
+
+def test_no_token_mint_helpers_imported() -> None:
+    """N5b Phase 1 must not import the approval-token mint/verify
+    helpers. Acting on a preflight verdict is N5b Phase 2+
+    territory and requires explicit operator authorisation."""
+    names = _imported_module_names()
+    for forbidden in (
+        "reporting.approval_token_gate",
+        "reporting.approval_token_runtime",
+    ):
+        assert forbidden not in names, forbidden
+
+
+def test_no_decision_verb_call_in_module() -> None:
+    src = _module_source().lower()
+    for verb in ("approve(", "reject(", "merge(", "deploy("):
+        assert verb not in src, verb
+
+
+def test_no_seed_jsonl_writes_in_module() -> None:
+    src = _module_source()
+    for forbidden in (
+        "seed.jsonl",
+        "delegation_seed.jsonl",
+        "generated_seed.jsonl",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_no_forbidden_module_imports() -> None:
+    forbidden_prefixes = (
+        "automation",
+        "broker",
+        "agent.risk",
+        "agent.execution",
+        "research",
+        "reporting.intelligent_routing",
+        "live",
+        "paper",
+        "shadow",
+        "trading",
+    )
+    for module in _imported_module_names():
+        for prefix in forbidden_prefixes:
+            assert module != prefix, module
+            assert not module.startswith(prefix + "."), module
+
+
+def test_imports_only_dmp_aas_flask_and_stdlib() -> None:
+    """The blueprint must import only the N5b Phase 1 projector
+    module, the secret-redactor guard, and Flask."""
+    names = _imported_module_names()
+    allowed_reporting = {
+        "reporting",
+        "reporting.development_merge_preflight",
+        "reporting.agent_audit_summary",
+    }
+    for n in names:
+        if n == "reporting" or n.startswith("reporting."):
+            assert n in allowed_reporting, n
+
+
+def test_no_a18b_or_n5b_live_execute_env_flag_in_module() -> None:
+    """The blueprint must not reference the A18b runtime writer
+    enable flag or the N5b Phase 4 live-execute enable flag."""
+    src = _module_source()
+    for forbidden in (
+        "ADE_GENERATED_LANE_WRITER_ENABLED",
+        "ADE_N5B_LIVE_EXECUTE_ENABLED",
+    ):
+        assert forbidden not in src, forbidden
+
+
+# ---------------------------------------------------------------------------
+# Step 5 invariants
+# ---------------------------------------------------------------------------
+
+
+def test_import_does_not_flip_step5_invariants() -> None:
+    importlib.reload(amp)
+    assert amp.step5_implementation_allowed is False
+    assert amp.STEP5_ENABLED_SUBSTAGE == "none"
+
+
+def test_module_source_pins_step5_invariants() -> None:
+    src = _module_source()
+    assert "step5_implementation_allowed: Final[bool] = False" in src
+    assert 'STEP5_ENABLED_SUBSTAGE: Final[str] = "none"' in src
+    assert "step5_implementation_allowed = True" not in src
+
+
+def test_module_source_pins_level6_disabled() -> None:
+    src = _module_source().lower()
+    assert "level6_enabled" in src
+    # the literal True is never assigned to level6_enabled in this
+    # module — only False (via the _DISCIPLINE_FIELDS dict).
+    assert "level6_enabled = true" not in src
+    assert "level6_enabled=true" not in src
+    assert '"level6_enabled": true' not in src


### PR DESCRIPTION
## Summary

Adds `dashboard/api_merge_preflight.py` — a GET-only Flask
blueprint that exposes the existing
`reporting.development_merge_preflight` projector artefact at
`logs/development_merge_preflight/latest.json` to the
operator-facing Agent Control surface, plus 38 pin-tests in
`tests/unit/test_api_merge_preflight.py`.

> **The blueprint is auth-agnostic and shipped unwired. Its live
> auth posture will be verified separately when the operator
> applies the dashboard.py wiring. This PR does not expose the
> routes.**

Mirrors the existing N5a `api_merge_recommendation` pattern: closed
schema, two GET-only routes, in-process artefact reader,
defense-in-depth row filter, `assert_no_secrets` on every response,
no operator-facing `dashboard.py` edit (the no-touch hook at
`.claude/hooks/deny_no_touch.py` protects that file).

## Scope (narrow — two new files)

| File | Action |
|---|---|
| `dashboard/api_merge_preflight.py` | NEW |
| `tests/unit/test_api_merge_preflight.py` | NEW (38 tests) |

## Routes

| Method | Path |
|---|---|
| GET | `/api/agent-control/merge-preflight/list` |
| GET | `/api/agent-control/merge-preflight/detail/<preflight_id>` |

No POST / PUT / PATCH / DELETE handler registered (pinned).

## Envelope shape

Both endpoints return a closed-schema JSON envelope that
**always** carries the six discipline invariants:

\`\`\`
step5_implementation_allowed = false
step5_enabled_substage       = \"none\"
level6_enabled               = false
dry_run_only                 = true
live_merge_implemented       = false
deploy_coupled               = false
\`\`\`

Status semantics:

* List: HTTP 200 always; \`status\` ∈ {\`ok\`, \`not_available\`}.
* Detail: 200 on \`ok\`, 400 on \`invalid_preflight_id\`,
  404 on \`not_available\` / \`not_found\`.

## Operator wiring diff (for separate operator-applied edit)

The no-touch hook at \`.claude/hooks/deny_no_touch.py\` protects
\`dashboard/dashboard.py\` from agent edits. The two-line wiring
diff below is **operator-only**; once applied, the
both-or-neither skip-or-enforce pin in
\`test_api_merge_preflight.py\` becomes strict:

\`\`\`python
# dashboard/dashboard.py — alongside existing dashboard.api_* imports:
from dashboard.api_merge_preflight import register_merge_preflight_routes

# ... and alongside existing register_*_routes(app) lines:
register_merge_preflight_routes(app)
\`\`\`

Until the operator applies that diff, **the routes are not
exposed**.

## What is NOT touched

* \`dashboard/dashboard.py\` (no-touch hook; operator-only wiring)
* \`reporting/development_merge_preflight.py\` (projector is read
  by the API, never modified)
* \`frontend/**\`, \`scripts/**\`, \`.github/workflows/**\`
* \`.claude/**\`, \`.gitleaks.toml\`, \`research/**\`, \`live/**\`,
  \`paper/**\`, \`shadow/**\`, \`risk/**\`, \`broker/**\`,
  \`execution/**\`
* No A18b activation; no A18c; no N5b Phase 2/3/4 introduction
* No Step 5 / Level 6 change
* No GitHub mutation; no token mint/verify import; no deploy
  coupling
* No CLI subprocess; no network library import; no Web Push
  library import; no VAPID / approval-token env-var reference

## Pin-test highlights

* Route table is exactly the two GET rules — no other HTTP method.
* List missing / malformed / non-object artefact → safe
  \`not_available\` envelope; invariants present on every envelope
  shape including not_available.
* List valid → bounded rows + closed \`by_dry_run_verdict\` counts
  dict over all three verdicts.
* List invalid row shapes filtered (closed
  \`CANDIDATE_ROW_KEYS\` key-set check at the API boundary).
* Detail missing artefact → 404 \`not_available\`; unknown id →
  404 \`not_found\`; valid id → 200 with exactly one row; empty /
  too-long / bad-charset / dot-containing id → 400
  \`invalid_preflight_id\`.
* AST + source-text scans against \`subprocess\`, \`socket\`,
  \`urllib\`, \`requests\`, \`httpx\`, \`aiohttp\`, \`gh\`, \`git\`,
  \`pywebpush\`, the approval-token runtime modules, decision-verb
  call shapes, \`seed.jsonl\` / \`delegation_seed.jsonl\` /
  \`generated_seed.jsonl\`, and forbidden module prefixes.
* Import allowlist: \`reporting.development_merge_preflight\`,
  \`reporting.agent_audit_summary\`, Flask, stdlib only.
* No \`ADE_GENERATED_LANE_WRITER_ENABLED\` or
  \`ADE_N5B_LIVE_EXECUTE_ENABLED\` literal anywhere in the module.
* Step 5 invariants intact after \`importlib.reload\`.

## Test plan

- [x] \`python scripts/governance_lint.py\` — OK
- [x] \`python -m pytest tests/smoke -q\` — 18 passed
- [x] \`python -m pytest tests/unit/test_api_merge_preflight.py -q\` — 38 passed
- [x] \`python -m pytest tests/unit/test_api_merge_recommendation.py -q\` — still green
- [x] \`python -m pytest tests/unit/test_dashboard_dashboard_one_line_wiring.py -q\` — still green
- [x] \`python -m pytest tests/unit/test_development_merge_preflight.py -q\`
- [x] \`python -m pytest tests/unit/test_n5b_merge_preflight_runbook.py -q\`
- [x] \`python -m pytest tests/unit/test_recurring_maintenance_merge_preflight.py -q\`
- [x] \`python -m reporting.development_merge_preflight --no-write\` — invariants green
- [x] \`python -m reporting.development_step5_loop --no-write\` — Step 5 invariants green
- [x] \`python -m reporting.development_operational_digest --no-write\` — Step 5 invariant green

## Operator verification

PR ships unwired. \`dashboard/dashboard.py\` is unchanged.

* Until the operator applies the two-line wiring diff, the routes
  are **not** exposed and there is nothing to verify on the VPS.
* If/when the operator applies the diff, the operator may run
  GET requests against \`/api/agent-control/merge-preflight/list\`
  and \`/api/agent-control/merge-preflight/detail/<preflight_id>\`
  from their own shell, with the auth posture they apply at
  registration time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)