### PR TITLE
feat(n5b): PWA read-only UI for Phase 1 merge-preflight verdicts

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import { Candidates } from "./routes/Candidates";
 import { AgentControl } from "./routes/AgentControl";
 import { AgentControlInboxPlaceholder } from "./routes/AgentControl/InboxPlaceholder";
 import { AgentControlMergeRecommendation } from "./routes/AgentControl/MergeRecommendation";
+import { AgentControlMergePreflight } from "./routes/AgentControl/MergePreflight";
 import { ApprovalTokenDiagnostics } from "./routes/AgentControl/ApprovalTokenDiagnostics";
 
 export function App() {
@@ -83,6 +84,35 @@ export function App() {
           element={
             <RequireAuth>
               <AgentControlMergeRecommendation />
+            </RequireAuth>
+          }
+        />
+        {/*
+         * v3.15.16.N5b.phase1 — read-only N5b Phase 1 dry-run
+         * merge-preflight surface backed by the wired
+         * /api/agent-control/merge-preflight/{list,detail} blueprint.
+         * Both routes are read-only and share the same
+         * <AgentControlMergePreflight /> component, which picks list
+         * vs detail based on the optional :preflightId param. No
+         * approve / reject / merge / deploy / execute verbs are
+         * exposed; live merge execution is N5b Phase 2/3/4 territory
+         * and is not implemented in this stage. The banner literal is
+         * fixed verbatim: "Dry-run only. Live merge execution is not
+         * implemented."
+         */}
+        <Route
+          path="/agent-control/merge-preflight"
+          element={
+            <RequireAuth>
+              <AgentControlMergePreflight />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/agent-control/merge-preflight/:preflightId"
+          element={
+            <RequireAuth>
+              <AgentControlMergePreflight />
             </RequireAuth>
           }
         />

--- a/frontend/src/api/agent_control.ts
+++ b/frontend/src/api/agent_control.ts
@@ -353,6 +353,81 @@ export interface AgentControlMergeRecommendationDetail {
   step5_enabled_substage?: string;
 }
 
+// v3.15.16.N5b.phase1 — read-only N5b Phase 1 dry-run merge-preflight
+// surface. Closed-schema candidate rows projected by
+// reporting.development_merge_preflight and surfaced via
+// dashboard.api_merge_preflight (UNWIRED → wired by operator-applied
+// two-line dashboard.py diff). Every field is a bounded scalar (no PR
+// body, no diff, no commit message). The PWA renders these as
+// read-only; the closed dry_run_verdict vocabulary uses ``would_*``
+// prefixes that are explicitly NOT executable verbs. Live merge
+// execution is N5b Phase 2/3/4 territory and is not implemented;
+// every envelope mirrors the projector's discipline invariants
+// (dry_run_only=true, live_merge_implemented=false,
+// deploy_coupled=false, level6_enabled=false).
+export interface AgentControlMergePreflightRow {
+  preflight_id: string;
+  recommendation_id: string;
+  pr_number: number;
+  expected_head_sha: string;
+  observed_head_sha: string;
+  base_ref: string;
+  head_ref: string;
+  merge_state: string;
+  checks_state: string;
+  recommendation_action: string;
+  recommendation_reason: string;
+  token_required_for_live: boolean;
+  dry_run_verdict: string;
+  live_merge_implemented: boolean;
+  stop_conditions: string[];
+  audit_note: string;
+  generated_at_utc: string;
+  evidence_freshness_seconds: number;
+}
+
+export interface AgentControlMergePreflightList {
+  kind: "agent_control_merge_preflight_list";
+  schema_version: number;
+  module_version?: string;
+  status: "ok" | "not_available";
+  reason?: string;
+  rows: AgentControlMergePreflightRow[];
+  counts?: {
+    rows?: number;
+    by_dry_run_verdict?: Record<string, number>;
+  };
+  generated_at_utc?: string;
+  artifact_path?: string;
+  step5_implementation_allowed?: boolean;
+  step5_enabled_substage?: string;
+  level6_enabled?: boolean;
+  dry_run_only?: boolean;
+  live_merge_implemented?: boolean;
+  deploy_coupled?: boolean;
+}
+
+export interface AgentControlMergePreflightDetail {
+  kind: "agent_control_merge_preflight_detail";
+  schema_version: number;
+  module_version?: string;
+  status:
+    | "ok"
+    | "not_available"
+    | "not_found"
+    | "invalid_preflight_id";
+  reason?: string;
+  row?: AgentControlMergePreflightRow;
+  generated_at_utc?: string;
+  artifact_path?: string;
+  step5_implementation_allowed?: boolean;
+  step5_enabled_substage?: string;
+  level6_enabled?: boolean;
+  dry_run_only?: boolean;
+  live_merge_implemented?: boolean;
+  deploy_coupled?: boolean;
+}
+
 // v3.15.16.N4c — read-only diagnostic surface over the already-wired
 // N4b approval-token runtime gate. All three endpoints already live
 // in dashboard.api_approval_token_gate; this client provides only
@@ -562,6 +637,20 @@ export const agentControlApi = {
       `${BASE}/merge-recommendation/detail/${encodeURIComponent(
         recommendationId,
       )}`,
+    ),
+  // v3.15.16.N5b.phase1 — read-only N5b Phase 1 merge-preflight
+  // client. Mirrors the N5c merge-recommendation pattern (both are
+  // closed-vocabulary GET-only surfaces). The same getJsonEnvelope
+  // helper honours 4xx bodies so the UI can render the precise
+  // closed status (``not_found`` / ``invalid_preflight_id`` /
+  // ``not_available``) instead of a generic fetch failure.
+  mergePreflightList: () =>
+    getJsonEnvelope<AgentControlMergePreflightList>(
+      `${BASE}/merge-preflight/list`,
+    ),
+  mergePreflightDetail: (preflightId: string) =>
+    getJsonEnvelope<AgentControlMergePreflightDetail>(
+      `${BASE}/merge-preflight/detail/${encodeURIComponent(preflightId)}`,
     ),
   approvalTokenStatus: () =>
     getJsonEnvelope<AgentControlApprovalTokenStatus>(

--- a/frontend/src/routes/AgentControl.tsx
+++ b/frontend/src/routes/AgentControl.tsx
@@ -1232,6 +1232,43 @@ function MergeRecommendationsLinkCard() {
   );
 }
 
+// --- Card: merge-preflight discoverability link (N5b Phase 1) ---
+// Static read-only entry into the v3.15.16.N5b.phase1 PWA route
+// /agent-control/merge-preflight (backed by the read-only
+// /api/agent-control/merge-preflight/list endpoint). The card issues
+// NO fetch and renders NO button — only a <Link>. The destination
+// component is the canonical surface; this card exists solely to make
+// the route discoverable from the PRs tab. No merge / approve /
+// reject / deploy / execute action. No N4b token call. The banner
+// literal on the destination is fixed verbatim:
+// "Dry-run only. Live merge execution is not implemented."
+function MergePreflightLinkCard() {
+  return (
+    <Card
+      title="Merge Preflight (N5b dry-run)"
+      subtitle="read-only N5b Phase 1 verdicts"
+    >
+      <p
+        className="agent-control-card__subtitle"
+        data-testid="merge-preflight-description"
+        style={{ margin: "0 0 0.6rem 0" }}
+      >
+        Dry-run only. Live merge execution is not implemented.
+      </p>
+      <p style={{ margin: 0 }}>
+        <Link
+          to="/agent-control/merge-preflight"
+          data-testid="merge-preflight-link"
+          aria-label="Open read-only merge preflight"
+          style={{ color: "var(--ink, #1a73e8)" }}
+        >
+          Open merge preflight →
+        </Link>
+      </p>
+    </Card>
+  );
+}
+
 // --- Card: notification center placeholder ---
 function NotificationsCard({
   payload,
@@ -1527,6 +1564,7 @@ export function AgentControl() {
         >
           <PRLifecycleCard payload={prLifecycle} />
           <MergeRecommendationsLinkCard />
+          <MergePreflightLinkCard />
           <ExecuteSafeCard payload={executeSafe} />
         </Section>
 

--- a/frontend/src/routes/AgentControl/MergePreflight.tsx
+++ b/frontend/src/routes/AgentControl/MergePreflight.tsx
@@ -1,0 +1,632 @@
+/**
+ * AgentControlMergePreflight
+ * --------------------------
+ *
+ * v3.15.16.N5b.phase1 — read-only PWA surface for the existing N5b
+ * Phase 1 dry-run merge-preflight API
+ * (``/api/agent-control/merge-preflight/{list,detail}``). Renders the
+ * closed-schema candidate rows projected by
+ * ``reporting.development_merge_preflight`` and surfaced via
+ * ``dashboard.api_merge_preflight``.
+ *
+ * Two views share this component:
+ *
+ *   ``/agent-control/merge-preflight``
+ *       Renders the read-only N5b list envelope.
+ *
+ *   ``/agent-control/merge-preflight/:preflightId``
+ *       Renders the read-only N5b detail envelope for the bounded
+ *       ``preflightId`` route parameter.
+ *
+ * The banner literal is fixed verbatim:
+ *
+ *   "Dry-run only. Live merge execution is not implemented."
+ *
+ * Hard guarantees enforced by the unit tests:
+ *
+ *   - Read-only banner is always rendered (list + detail).
+ *   - Only the N5b endpoints under
+ *     ``/api/agent-control/merge-preflight/...`` are fetched.
+ *   - No call to any N4b ``approval-token`` endpoint.
+ *   - No call to the N3b mobile-inbox endpoints.
+ *   - No call to any hypothetical merge-execution / live merge
+ *     endpoint.
+ *   - No mutating verbs: every fetch is a ``GET`` with
+ *     ``credentials: include``. No ``XMLHttpRequest``, no
+ *     ``navigator.sendBeacon``, no POST / PUT / PATCH / DELETE.
+ *   - Zero ``<button>`` elements in the rendered DOM. Navigation is
+ *     via ``<Link>`` components only.
+ *   - ``preflightId`` is bounded to charset ``[A-Za-z0-9_-]`` and
+ *     ≤ 128 characters before any fetch.
+ *   - Empty / not_available / not_found / invalid_preflight_id /
+ *     malformed / network failure all collapse to safe states.
+ *   - Discipline invariants from the envelope are surfaced verbatim
+ *     (``dry_run_only``, ``live_merge_implemented``,
+ *     ``deploy_coupled``, ``level6_enabled``,
+ *     ``step5_implementation_allowed``, ``step5_enabled_substage``).
+ *   - A ``<Link>`` back to ``/agent-control`` is always present.
+ *
+ * The closed ``dry_run_verdict`` vocabulary
+ * (``would_block`` / ``would_require_operator`` /
+ * ``would_be_live_candidate_if_authorized``) uses ``would_*`` prefixes
+ * that are explicitly NOT executable decision verbs. The component
+ * renders these strings verbatim from the envelope.
+ */
+
+import { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+
+import {
+  agentControlApi,
+  type AgentControlMergePreflightDetail,
+  type AgentControlMergePreflightList,
+  type AgentControlMergePreflightRow,
+} from "../../api/agent_control";
+
+const MAX_PREFLIGHT_ID_LEN = 128;
+const READ_ONLY_BANNER =
+  "Dry-run only. Live merge execution is not implemented.";
+
+function boundedPreflightId(raw: string | undefined | null): string {
+  if (typeof raw !== "string") return "";
+  const trimmed = raw.trim();
+  if (!trimmed) return "";
+  const safe = trimmed.replace(/[^A-Za-z0-9_\-]/g, "");
+  return safe.slice(0, MAX_PREFLIGHT_ID_LEN);
+}
+
+function shortHead(sha: string | undefined | null): string {
+  if (typeof sha !== "string" || !sha) return "";
+  return sha.length > 12 ? `${sha.slice(0, 12)}…` : sha;
+}
+
+type ListState =
+  | { phase: "loading" }
+  | { phase: "ok"; envelope: AgentControlMergePreflightList }
+  | { phase: "empty"; envelope: AgentControlMergePreflightList }
+  | { phase: "not_available"; reason: string };
+
+type DetailState =
+  | { phase: "loading" }
+  | { phase: "ok"; envelope: AgentControlMergePreflightDetail }
+  | { phase: "not_found"; reason: string }
+  | { phase: "invalid"; reason: string }
+  | { phase: "not_available"; reason: string };
+
+function Banner() {
+  return (
+    <div
+      data-testid="agent-control-merge-preflight-banner"
+      style={{
+        margin: "0 0 0.85rem 0",
+        padding: "0.55rem 0.7rem",
+        borderRadius: "0.4rem",
+        background: "rgba(0,0,0,0.05)",
+        fontSize: "0.85rem",
+        lineHeight: 1.4,
+      }}
+    >
+      {READ_ONLY_BANNER}
+    </div>
+  );
+}
+
+function BackLink() {
+  return (
+    <p style={{ margin: "1rem 0 0 0" }}>
+      <Link
+        to="/agent-control"
+        data-testid="agent-control-merge-preflight-back-link"
+        style={{ color: "var(--ink, #1a73e8)" }}
+      >
+        Back to agent control
+      </Link>
+    </p>
+  );
+}
+
+function DisciplineInvariants({
+  envelope,
+}: {
+  envelope:
+    | AgentControlMergePreflightList
+    | AgentControlMergePreflightDetail;
+}) {
+  return (
+    <p
+      data-testid="agent-control-merge-preflight-invariants"
+      style={{
+        marginTop: "0.85rem",
+        fontSize: "0.75rem",
+        color: "rgba(0,0,0,0.55)",
+        lineHeight: 1.5,
+      }}
+    >
+      dry_run_only: {String(envelope.dry_run_only ?? true)} ·{" "}
+      live_merge_implemented:{" "}
+      {String(envelope.live_merge_implemented ?? false)} ·{" "}
+      deploy_coupled: {String(envelope.deploy_coupled ?? false)} ·{" "}
+      level6_enabled: {String(envelope.level6_enabled ?? false)} ·{" "}
+      step5_implementation_allowed:{" "}
+      {String(envelope.step5_implementation_allowed ?? false)} ·{" "}
+      step5_enabled_substage:{" "}
+      {envelope.step5_enabled_substage || "none"}
+    </p>
+  );
+}
+
+function PageShell({
+  heading,
+  children,
+}: {
+  heading: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <main
+      data-testid="agent-control-merge-preflight-root"
+      style={{
+        padding: "1.25rem",
+        maxWidth: "640px",
+        margin: "0 auto",
+        fontFamily: "system-ui, -apple-system, sans-serif",
+      }}
+    >
+      <h1 style={{ fontSize: "1.4rem", margin: "0 0 0.75rem 0" }}>{heading}</h1>
+      <Banner />
+      {children}
+      <BackLink />
+    </main>
+  );
+}
+
+function StopConditions({
+  conditions,
+  testIdPrefix,
+}: {
+  conditions: string[];
+  testIdPrefix: string;
+}) {
+  if (!Array.isArray(conditions) || conditions.length === 0) {
+    return (
+      <span data-testid={`${testIdPrefix}-stop-conditions-empty`}>—</span>
+    );
+  }
+  return (
+    <ul
+      data-testid={`${testIdPrefix}-stop-conditions`}
+      style={{
+        listStyle: "disc",
+        margin: 0,
+        paddingLeft: "1.1rem",
+        fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+        fontSize: "0.8rem",
+      }}
+    >
+      {conditions.map((sc) => (
+        <li
+          key={sc}
+          data-testid={`${testIdPrefix}-stop-condition-${sc}`}
+        >
+          {sc}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function RowFields({
+  row,
+  testIdPrefix,
+}: {
+  row: AgentControlMergePreflightRow;
+  testIdPrefix: string;
+}) {
+  return (
+    <dl
+      data-testid={`${testIdPrefix}-fields`}
+      style={{
+        display: "grid",
+        gridTemplateColumns: "auto 1fr",
+        columnGap: "0.6rem",
+        rowGap: "0.25rem",
+        fontSize: "0.85rem",
+        margin: 0,
+      }}
+    >
+      <dt>preflight_id</dt>
+      <dd data-testid={`${testIdPrefix}-preflight-id`}>
+        <code>{row.preflight_id}</code>
+      </dd>
+      <dt>pr_number</dt>
+      <dd data-testid={`${testIdPrefix}-pr-number`}>{row.pr_number}</dd>
+      <dt>head_ref</dt>
+      <dd data-testid={`${testIdPrefix}-head-ref`}>
+        <code>{row.head_ref || "—"}</code>
+      </dd>
+      <dt>base_ref</dt>
+      <dd data-testid={`${testIdPrefix}-base-ref`}>
+        <code>{row.base_ref || "—"}</code>
+      </dd>
+      <dt>expected_head_sha</dt>
+      <dd
+        data-testid={`${testIdPrefix}-expected-head-sha`}
+        title={row.expected_head_sha || ""}
+      >
+        <code>{shortHead(row.expected_head_sha) || "—"}</code>
+      </dd>
+      <dt>observed_head_sha</dt>
+      <dd
+        data-testid={`${testIdPrefix}-observed-head-sha`}
+        title={row.observed_head_sha || ""}
+      >
+        <code>{shortHead(row.observed_head_sha) || "—"}</code>
+      </dd>
+      <dt>merge_state</dt>
+      <dd data-testid={`${testIdPrefix}-merge-state`}>
+        {row.merge_state || "—"}
+      </dd>
+      <dt>checks_state</dt>
+      <dd data-testid={`${testIdPrefix}-checks-state`}>
+        {row.checks_state || "—"}
+      </dd>
+      <dt>dry_run_verdict</dt>
+      <dd data-testid={`${testIdPrefix}-dry-run-verdict`}>
+        {row.dry_run_verdict || "—"}
+      </dd>
+      <dt>token_required_for_live</dt>
+      <dd data-testid={`${testIdPrefix}-token-required-for-live`}>
+        {String(row.token_required_for_live ?? true)}
+      </dd>
+      <dt>stop_conditions</dt>
+      <dd>
+        <StopConditions
+          conditions={row.stop_conditions || []}
+          testIdPrefix={testIdPrefix}
+        />
+      </dd>
+      <dt>recommendation_action</dt>
+      <dd data-testid={`${testIdPrefix}-recommendation-action`}>
+        {row.recommendation_action || "—"}
+      </dd>
+      <dt>recommendation_reason</dt>
+      <dd data-testid={`${testIdPrefix}-recommendation-reason`}>
+        {row.recommendation_reason || "—"}
+      </dd>
+      <dt>evidence_freshness_seconds</dt>
+      <dd data-testid={`${testIdPrefix}-evidence-freshness-seconds`}>
+        {row.evidence_freshness_seconds}
+      </dd>
+      <dt>generated_at_utc</dt>
+      <dd data-testid={`${testIdPrefix}-generated-at-utc`}>
+        {row.generated_at_utc || "—"}
+      </dd>
+    </dl>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// List view
+// ---------------------------------------------------------------------------
+
+function ListView() {
+  const [state, setState] = useState<ListState>({ phase: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    setState({ phase: "loading" });
+    agentControlApi
+      .mergePreflightList()
+      .then((envelope) => {
+        if (cancelled) return;
+        if (envelope.status !== "ok") {
+          setState({
+            phase: "not_available",
+            reason: envelope.reason || "not_available",
+          });
+          return;
+        }
+        const rows = Array.isArray(envelope.rows) ? envelope.rows : [];
+        if (rows.length === 0) {
+          setState({ phase: "empty", envelope });
+          return;
+        }
+        setState({ phase: "ok", envelope });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setState({ phase: "not_available", reason: "network" });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <PageShell heading="Merge preflight (N5b dry-run)">
+      {state.phase === "loading" && (
+        <p data-testid="agent-control-merge-preflight-loading">
+          Loading merge preflight…
+        </p>
+      )}
+
+      {state.phase === "not_available" && (
+        <p
+          data-testid="agent-control-merge-preflight-not-available"
+          style={{ margin: "0.75rem 0", lineHeight: 1.45 }}
+        >
+          The merge preflight artefact is not available
+          ({state.reason}). The full N5b Phase 1 report is generated
+          by <code>reporting.development_merge_preflight</code>; this
+          view will render rows once the artefact is present.
+        </p>
+      )}
+
+      {state.phase === "empty" && (
+        <>
+          <p
+            data-testid="agent-control-merge-preflight-empty"
+            style={{ margin: "0.75rem 0", lineHeight: 1.45 }}
+          >
+            No open preflight candidates at this time. The N5b
+            projector has produced an empty row set (
+            {state.envelope.counts?.rows ?? 0} row(s)).
+          </p>
+          <DisciplineInvariants envelope={state.envelope} />
+        </>
+      )}
+
+      {state.phase === "ok" && (
+        <section
+          data-testid="agent-control-merge-preflight-list"
+          style={{ marginTop: "0.5rem" }}
+        >
+          <p
+            data-testid="agent-control-merge-preflight-list-count"
+            style={{
+              fontSize: "0.85rem",
+              color: "rgba(0,0,0,0.6)",
+              margin: "0 0 0.6rem 0",
+            }}
+          >
+            {state.envelope.rows.length} candidate(s) — generated_at_utc:{" "}
+            <code>{state.envelope.generated_at_utc || "—"}</code>
+          </p>
+          <ul
+            data-testid="agent-control-merge-preflight-list-items"
+            style={{
+              listStyle: "none",
+              padding: 0,
+              margin: 0,
+              display: "flex",
+              flexDirection: "column",
+              gap: "0.5rem",
+            }}
+          >
+            {state.envelope.rows.map((row) => {
+              const safeId = boundedPreflightId(row.preflight_id);
+              return (
+                <li
+                  key={row.preflight_id}
+                  data-testid={`agent-control-merge-preflight-row-${row.preflight_id}`}
+                  style={{
+                    padding: "0.6rem 0.7rem",
+                    border: "1px solid rgba(0,0,0,0.08)",
+                    borderRadius: "0.45rem",
+                    background: "rgba(0,0,0,0.02)",
+                  }}
+                >
+                  <Link
+                    to={`/agent-control/merge-preflight/${safeId}`}
+                    data-testid={`agent-control-merge-preflight-link-${row.preflight_id}`}
+                    style={{
+                      color: "var(--ink, #1a73e8)",
+                      textDecoration: "none",
+                      display: "block",
+                    }}
+                  >
+                    <div
+                      style={{
+                        display: "flex",
+                        justifyContent: "space-between",
+                        gap: "0.5rem",
+                        fontFamily:
+                          "ui-monospace, SFMono-Regular, Menlo, monospace",
+                        fontSize: "0.85rem",
+                        marginBottom: "0.25rem",
+                      }}
+                    >
+                      <span>{row.preflight_id}</span>
+                      <span>PR #{row.pr_number}</span>
+                    </div>
+                    <div
+                      style={{
+                        fontSize: "0.8rem",
+                        color: "rgba(0,0,0,0.7)",
+                      }}
+                    >
+                      <span
+                        data-testid={`agent-control-merge-preflight-row-${row.preflight_id}-verdict`}
+                      >
+                        {row.dry_run_verdict || "—"}
+                      </span>{" "}
+                      ·{" "}
+                      <span
+                        data-testid={`agent-control-merge-preflight-row-${row.preflight_id}-merge-state`}
+                      >
+                        {row.merge_state || "—"}
+                      </span>{" "}
+                      /{" "}
+                      <span
+                        data-testid={`agent-control-merge-preflight-row-${row.preflight_id}-checks-state`}
+                      >
+                        {row.checks_state || "—"}
+                      </span>
+                    </div>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+          <DisciplineInvariants envelope={state.envelope} />
+        </section>
+      )}
+    </PageShell>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Detail view
+// ---------------------------------------------------------------------------
+
+function DetailView({ preflightId }: { preflightId: string }) {
+  const [state, setState] = useState<DetailState>({ phase: "loading" });
+
+  useEffect(() => {
+    if (!preflightId) {
+      setState({ phase: "invalid", reason: "empty" });
+      return;
+    }
+    let cancelled = false;
+    setState({ phase: "loading" });
+    agentControlApi
+      .mergePreflightDetail(preflightId)
+      .then((envelope) => {
+        if (cancelled) return;
+        switch (envelope.status) {
+          case "ok":
+            setState({ phase: "ok", envelope });
+            return;
+          case "not_found":
+            setState({
+              phase: "not_found",
+              reason: envelope.reason || "not_found",
+            });
+            return;
+          case "invalid_preflight_id":
+            setState({
+              phase: "invalid",
+              reason: envelope.reason || "invalid_preflight_id",
+            });
+            return;
+          default:
+            setState({
+              phase: "not_available",
+              reason: envelope.reason || "not_available",
+            });
+            return;
+        }
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setState({ phase: "not_available", reason: "network" });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [preflightId]);
+
+  return (
+    <PageShell heading="Merge preflight detail (N5b dry-run)">
+      <p
+        data-testid="agent-control-merge-preflight-detail-id"
+        style={{
+          fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+          fontSize: "0.85rem",
+          background: "rgba(0,0,0,0.04)",
+          padding: "0.5rem 0.65rem",
+          borderRadius: "0.4rem",
+          wordBreak: "break-all",
+          margin: "0 0 0.75rem 0",
+        }}
+      >
+        preflight_id: {preflightId || "—"}
+      </p>
+
+      <p style={{ margin: "0 0 0.75rem 0" }}>
+        <Link
+          to="/agent-control/merge-preflight"
+          data-testid="agent-control-merge-preflight-detail-list-link"
+          style={{ color: "var(--ink, #1a73e8)" }}
+        >
+          ← Back to list
+        </Link>
+      </p>
+
+      {state.phase === "loading" && (
+        <p data-testid="agent-control-merge-preflight-detail-loading">
+          Loading merge preflight detail…
+        </p>
+      )}
+
+      {state.phase === "ok" && state.envelope.row && (
+        <section
+          data-testid="agent-control-merge-preflight-detail"
+          style={{ marginTop: "0.5rem" }}
+        >
+          <RowFields
+            row={state.envelope.row}
+            testIdPrefix="agent-control-merge-preflight-detail"
+          />
+          {state.envelope.generated_at_utc ? (
+            <p
+              data-testid="agent-control-merge-preflight-detail-generated-at"
+              style={{
+                marginTop: "0.65rem",
+                fontSize: "0.75rem",
+                color: "rgba(0,0,0,0.55)",
+              }}
+            >
+              generated_at_utc:{" "}
+              <code>{state.envelope.generated_at_utc}</code>
+            </p>
+          ) : null}
+          <DisciplineInvariants envelope={state.envelope} />
+        </section>
+      )}
+
+      {state.phase === "not_found" && (
+        <p
+          data-testid="agent-control-merge-preflight-detail-not-found"
+          style={{ margin: "0.75rem 0", lineHeight: 1.45 }}
+        >
+          No preflight row matches this id ({state.reason}). The N5b
+          artefact may have advanced past this head SHA, or the
+          recommendation was already resolved upstream.
+        </p>
+      )}
+
+      {state.phase === "invalid" && (
+        <p
+          data-testid="agent-control-merge-preflight-detail-invalid"
+          style={{ margin: "0.75rem 0", lineHeight: 1.45 }}
+        >
+          The preflight_id in this URL is not valid ({state.reason}).
+          Go back to the list to pick a current row.
+        </p>
+      )}
+
+      {state.phase === "not_available" && (
+        <p
+          data-testid="agent-control-merge-preflight-detail-not-available"
+          style={{ margin: "0.75rem 0", lineHeight: 1.45 }}
+        >
+          The merge preflight artefact is not available ({state.reason}).
+        </p>
+      )}
+    </PageShell>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Entry point — picks list or detail based on the route parameter
+// ---------------------------------------------------------------------------
+
+export function AgentControlMergePreflight() {
+  const params = useParams<{ preflightId?: string }>();
+  const safeId = boundedPreflightId(params.preflightId);
+  if (typeof params.preflightId === "string") {
+    return <DetailView preflightId={safeId} />;
+  }
+  return <ListView />;
+}

--- a/frontend/src/test/AgentControl.test.tsx
+++ b/frontend/src/test/AgentControl.test.tsx
@@ -1676,6 +1676,150 @@ describe("AgentControl — N5c discoverability link in PRs section", () => {
 });
 
 // ---------------------------------------------------------------------------
+// v3.15.16.N5b.phase1 discoverability spillover — visible read-only entry
+// to /agent-control/merge-preflight from the PRs section. Same
+// anchor-only, no-fetch, no-button shape as the N5c
+// merge-recommendations link.
+// ---------------------------------------------------------------------------
+
+describe("AgentControl — N5b Phase 1 discoverability link in PRs section", () => {
+  it("renders a visible merge-preflight link pointing at the N5b route", async () => {
+    installFetchMock(
+      {
+        "/api/agent-control/status": () => jsonResp(okStatusBody),
+        "/api/agent-control/activity": () => jsonResp(okActivityBody),
+        "/api/agent-control/workloop": () => jsonResp(okWorkloopBody),
+        "/api/agent-control/pr-lifecycle": () =>
+          jsonResp(okPRLifecycleEmptyBody),
+        "/api/agent-control/notifications": () =>
+          jsonResp(placeholderNotificationsBody),
+        "/api/agent-control/proposals": () => jsonResp(okProposalsEmptyBody),
+        "/api/agent-control/approval-inbox": () => jsonResp(okInboxEmptyBody),
+        "/api/agent-control/execute-safe": () => jsonResp(okExecuteSafeBody),
+      },
+      () => jsonResp({}, 404),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("merge-preflight-link"),
+      ).toBeInTheDocument();
+    });
+
+    const link = screen.getByTestId("merge-preflight-link");
+    expect(link).toHaveAttribute(
+      "href",
+      "/agent-control/merge-preflight",
+    );
+    // Anchor element, not a button — read-only by structure.
+    expect(link.tagName.toLowerCase()).toBe("a");
+    // Visible, accessible name describes the destination.
+    expect(link).toHaveAccessibleName(
+      /open read-only merge preflight/i,
+    );
+    // Description carries the operator-prescribed banner literal.
+    expect(
+      screen.getByTestId("merge-preflight-description"),
+    ).toHaveTextContent(
+      /dry-run only\. live merge execution is not implemented\./i,
+    );
+  });
+
+  it("does not add a button and does not render decision verbs in its card", async () => {
+    installFetchMock(
+      {
+        "/api/agent-control/status": () => jsonResp(okStatusBody),
+        "/api/agent-control/activity": () => jsonResp(okActivityBody),
+        "/api/agent-control/workloop": () => jsonResp(okWorkloopBody),
+        "/api/agent-control/pr-lifecycle": () =>
+          jsonResp(okPRLifecycleEmptyBody),
+        "/api/agent-control/notifications": () =>
+          jsonResp(placeholderNotificationsBody),
+        "/api/agent-control/proposals": () => jsonResp(okProposalsEmptyBody),
+        "/api/agent-control/approval-inbox": () => jsonResp(okInboxEmptyBody),
+        "/api/agent-control/execute-safe": () => jsonResp(okExecuteSafeBody),
+      },
+      () => jsonResp({}, 404),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("merge-preflight-link"),
+      ).toBeInTheDocument();
+    });
+
+    // The merge-preflight card adds zero new buttons; the surface still
+    // contains exactly the existing single refresh button.
+    const buttons = screen.queryAllByRole("button");
+    expect(buttons).toHaveLength(1);
+    expect(buttons[0]).toHaveAttribute(
+      "data-testid",
+      "agent-control-refresh",
+    );
+
+    // No executable decision verb appears in the new card text.
+    const card = screen.getByTestId("merge-preflight-link");
+    const cardText = (card.textContent || "").toLowerCase();
+    expect(cardText).not.toMatch(/\bapprove\b/);
+    expect(cardText).not.toMatch(/\breject\b/);
+    expect(cardText).not.toMatch(/\bdeploy\b/);
+    expect(cardText).not.toMatch(/\bexecute\b/);
+  });
+
+  it("does not introduce a new fetch and does not call any token endpoint", async () => {
+    installFetchMock(
+      {
+        "/api/agent-control/status": () => jsonResp(okStatusBody),
+        "/api/agent-control/activity": () => jsonResp(okActivityBody),
+        "/api/agent-control/workloop": () => jsonResp(okWorkloopBody),
+        "/api/agent-control/pr-lifecycle": () =>
+          jsonResp(okPRLifecycleEmptyBody),
+        "/api/agent-control/notifications": () =>
+          jsonResp(placeholderNotificationsBody),
+        "/api/agent-control/proposals": () => jsonResp(okProposalsEmptyBody),
+        "/api/agent-control/approval-inbox": () => jsonResp(okInboxEmptyBody),
+        "/api/agent-control/execute-safe": () => jsonResp(okExecuteSafeBody),
+      },
+      () => jsonResp({}, 404),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/agent-control"]}>
+        <AgentControl />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("merge-preflight-link"),
+      ).toBeInTheDocument();
+    });
+
+    // The discoverability card itself never adds a fetch — the
+    // destination route page is where /api/agent-control/merge-preflight/
+    // fetches happen, never from the AgentControl hub.
+    for (const call of fetchSpy) {
+      const url = String(call.input);
+      expect(url).not.toContain("/api/agent-control/merge-preflight/");
+      expect(url).not.toContain("/api/agent-control/approval-token/");
+      expect(call.method).toBe("GET");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // N4c discoverability link in the About section — visible read-only
 // entry to /agent-control/approval-token-diagnostics. Same anchor-only,
 // no-fetch shape as the N5c merge-recommendations link.

--- a/frontend/src/test/AgentControlMergePreflight.test.tsx
+++ b/frontend/src/test/AgentControlMergePreflight.test.tsx
@@ -1,0 +1,807 @@
+/**
+ * Tests for AgentControlMergePreflight — the v3.15.16.N5b.phase1
+ * read-only PWA surface over the existing N5b Phase 1 merge-preflight
+ * API.
+ *
+ * Hard guarantees verified here:
+ *   - Read-only banner is always rendered, in both list + detail views.
+ *   - Banner literal is exactly
+ *     "Dry-run only. Live merge execution is not implemented."
+ *   - Only the read-only N5b endpoints under
+ *     ``/api/agent-control/merge-preflight/`` are fetched.
+ *   - No call to any N4b ``/api/agent-control/approval-token/*`` URL,
+ *     no call to the N3b ``/api/agent-control/mobile-inbox/*`` URL,
+ *     no call to any hypothetical merge-execution endpoint.
+ *   - Every fetch is a same-origin GET. No POST / PUT / PATCH / DELETE.
+ *   - No ``<button>`` elements appear in the DOM on either view.
+ *   - No executable decision verbs (approve / reject / deploy /
+ *     execute) appear in the rendered text.
+ *   - List renders bounded closed-schema rows from the mocked API.
+ *   - Detail renders the bounded closed-schema row for status=ok.
+ *   - Empty / not_available / not_found / invalid_preflight_id /
+ *     malformed / network failure all collapse to safe states.
+ *   - The bounded route param is sanitised before fetch (charset +
+ *     length).
+ *   - Discipline invariants (dry_run_only / live_merge_implemented /
+ *     deploy_coupled / level6_enabled / step5_implementation_allowed
+ *     / step5_enabled_substage) surface verbatim from the envelope.
+ *   - A link back to /agent-control is always rendered.
+ *   - navigator.sendBeacon is never called.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+
+import { AgentControlMergePreflight } from "../routes/AgentControl/MergePreflight";
+
+const mockFetch = vi.fn();
+const mockSendBeacon = vi.fn();
+
+const LIST_URL = "/api/agent-control/merge-preflight/list";
+const DETAIL_BASE = "/api/agent-control/merge-preflight/detail/";
+
+const BANNER_LITERAL =
+  "Dry-run only. Live merge execution is not implemented.";
+
+function jsonResponse(payload: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(payload), {
+    status: init.status ?? 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function candidate(
+  preflight_id: string,
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    preflight_id,
+    recommendation_id: "rec_pr_42",
+    pr_number: 42,
+    expected_head_sha: "deadbeefdeadbeef0000000000000001",
+    observed_head_sha: "deadbeefdeadbeef0000000000000001",
+    base_ref: "main",
+    head_ref: "feature/branch",
+    merge_state: "CLEAN",
+    checks_state: "SUCCESS",
+    recommendation_action: "recommend_human_merge",
+    recommendation_reason: "pr_clean_and_no_blocking_inbox",
+    token_required_for_live: true,
+    dry_run_verdict: "would_be_live_candidate_if_authorized",
+    live_merge_implemented: false,
+    stop_conditions: [
+      "token_required_for_live",
+      "live_merge_not_implemented",
+    ],
+    audit_note: "dry-run only",
+    generated_at_utc: "2026-05-13T12:00:00Z",
+    evidence_freshness_seconds: 30,
+    ...overrides,
+  };
+}
+
+function listOkEnvelope(
+  rows: ReturnType<typeof candidate>[],
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    kind: "agent_control_merge_preflight_list",
+    schema_version: 1,
+    module_version: "v3.15.16.N5b.phase1.api",
+    status: "ok",
+    rows,
+    counts: {
+      rows: rows.length,
+      by_dry_run_verdict: {
+        would_block: 0,
+        would_require_operator: 0,
+        would_be_live_candidate_if_authorized: rows.length,
+      },
+    },
+    generated_at_utc: "2026-05-13T12:30:00Z",
+    artifact_path: "logs/development_merge_preflight/latest.json",
+    step5_implementation_allowed: false,
+    step5_enabled_substage: "none",
+    level6_enabled: false,
+    dry_run_only: true,
+    live_merge_implemented: false,
+    deploy_coupled: false,
+    ...overrides,
+  };
+}
+
+function detailOkEnvelope(r: ReturnType<typeof candidate>) {
+  return {
+    kind: "agent_control_merge_preflight_detail",
+    schema_version: 1,
+    module_version: "v3.15.16.N5b.phase1.api",
+    status: "ok",
+    row: r,
+    generated_at_utc: "2026-05-13T12:30:00Z",
+    artifact_path: "logs/development_merge_preflight/latest.json",
+    step5_implementation_allowed: false,
+    step5_enabled_substage: "none",
+    level6_enabled: false,
+    dry_run_only: true,
+    live_merge_implemented: false,
+    deploy_coupled: false,
+  };
+}
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route
+          path="/agent-control/merge-preflight"
+          element={<AgentControlMergePreflight />}
+        />
+        <Route
+          path="/agent-control/merge-preflight/:preflightId"
+          element={<AgentControlMergePreflight />}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", mockFetch);
+  if (typeof navigator !== "undefined") {
+    Object.defineProperty(navigator, "sendBeacon", {
+      configurable: true,
+      value: mockSendBeacon,
+    });
+  }
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  mockFetch.mockReset();
+  mockSendBeacon.mockReset();
+});
+
+// ---------------------------------------------------------------------------
+// Banner + structure — always rendered
+// ---------------------------------------------------------------------------
+
+describe("AgentControlMergePreflight — banner + structure", () => {
+  it("always renders the operator-prescribed banner literal on list", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse(listOkEnvelope([candidate("pf_42_deadbeefdead")])),
+    );
+    renderAt("/agent-control/merge-preflight");
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    expect(
+      screen.getByTestId("agent-control-merge-preflight-banner"),
+    ).toHaveTextContent(BANNER_LITERAL);
+  });
+
+  it("always renders the operator-prescribed banner literal on detail", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse(detailOkEnvelope(candidate("pf_42_deadbeefdead"))),
+    );
+    renderAt("/agent-control/merge-preflight/pf_42_deadbeefdead");
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    expect(
+      screen.getByTestId("agent-control-merge-preflight-banner"),
+    ).toHaveTextContent(BANNER_LITERAL);
+  });
+
+  it("always renders the back link to /agent-control on list", async () => {
+    mockFetch.mockResolvedValue(jsonResponse(listOkEnvelope([])));
+    renderAt("/agent-control/merge-preflight");
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    expect(
+      screen.getByTestId("agent-control-merge-preflight-back-link"),
+    ).toHaveAttribute("href", "/agent-control");
+  });
+
+  it("always renders the back link to /agent-control on detail", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse(detailOkEnvelope(candidate("pf_42_deadbeefdead"))),
+    );
+    renderAt("/agent-control/merge-preflight/pf_42_deadbeefdead");
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    expect(
+      screen.getByTestId("agent-control-merge-preflight-back-link"),
+    ).toHaveAttribute("href", "/agent-control");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// List view — happy path / empty / not_available / malformed / network
+// ---------------------------------------------------------------------------
+
+describe("AgentControlMergePreflight — list view", () => {
+  it("fetches only the N5b list endpoint with same-origin GET", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse(listOkEnvelope([candidate("pf_1_aaaa")])),
+    );
+    renderAt("/agent-control/merge-preflight");
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe(LIST_URL);
+    const method = (init as RequestInit | undefined)?.method ?? "GET";
+    expect(method).toBe("GET");
+    expect((init as RequestInit | undefined)?.credentials).toBe("include");
+  });
+
+  it("renders empty state when the API returns rows=[]", async () => {
+    mockFetch.mockResolvedValue(jsonResponse(listOkEnvelope([])));
+    renderAt("/agent-control/merge-preflight");
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("agent-control-merge-preflight-empty"),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      screen.queryByTestId("agent-control-merge-preflight-list"),
+    ).not.toBeInTheDocument();
+    // Discipline invariants still surface on the empty path.
+    expect(
+      screen.getByTestId("agent-control-merge-preflight-invariants"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a would_block candidate with its stop_conditions", async () => {
+    const rows = [
+      candidate("pf_1_aaaaaaaaaaaa", {
+        pr_number: 101,
+        dry_run_verdict: "would_block",
+        merge_state: "BLOCKED",
+        checks_state: "FAILURE",
+        stop_conditions: [
+          "merge_state_not_clean",
+          "checks_not_green",
+          "token_required_for_live",
+          "live_merge_not_implemented",
+        ],
+      }),
+    ];
+    mockFetch.mockResolvedValue(jsonResponse(listOkEnvelope(rows)));
+    renderAt("/agent-control/merge-preflight");
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("agent-control-merge-preflight-list"),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByTestId(
+        "agent-control-merge-preflight-row-pf_1_aaaaaaaaaaaa-verdict",
+      ),
+    ).toHaveTextContent(/would_block/);
+    expect(
+      screen.getByTestId(
+        "agent-control-merge-preflight-row-pf_1_aaaaaaaaaaaa-merge-state",
+      ),
+    ).toHaveTextContent(/BLOCKED/);
+    expect(
+      screen.getByTestId(
+        "agent-control-merge-preflight-row-pf_1_aaaaaaaaaaaa-checks-state",
+      ),
+    ).toHaveTextContent(/FAILURE/);
+  });
+
+  it("renders a would_be_live_candidate row with NO action button", async () => {
+    const rows = [
+      candidate("pf_2_bbbbbbbbbbbb", {
+        pr_number: 202,
+        dry_run_verdict: "would_be_live_candidate_if_authorized",
+        merge_state: "CLEAN",
+        checks_state: "SUCCESS",
+      }),
+    ];
+    mockFetch.mockResolvedValue(jsonResponse(listOkEnvelope(rows)));
+    renderAt("/agent-control/merge-preflight");
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("agent-control-merge-preflight-list"),
+      ).toBeInTheDocument(),
+    );
+    // Verdict is rendered verbatim.
+    expect(
+      screen.getByTestId(
+        "agent-control-merge-preflight-row-pf_2_bbbbbbbbbbbb-verdict",
+      ),
+    ).toHaveTextContent(/would_be_live_candidate_if_authorized/);
+    // Zero buttons on the route page — even when a candidate is
+    // technically a live candidate the UI exposes NO action.
+    const buttons = screen.queryAllByRole("button");
+    expect(buttons).toHaveLength(0);
+  });
+
+  it("renders the row count and each row links to the bounded detail route", async () => {
+    const rows = [
+      candidate("pf_a_111111111111", { pr_number: 1 }),
+      candidate("pf_b_222222222222", { pr_number: 2 }),
+    ];
+    mockFetch.mockResolvedValue(jsonResponse(listOkEnvelope(rows)));
+    renderAt("/agent-control/merge-preflight");
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("agent-control-merge-preflight-list-count"),
+      ).toHaveTextContent(/2 candidate\(s\)/),
+    );
+    expect(
+      screen.getByTestId(
+        "agent-control-merge-preflight-link-pf_a_111111111111",
+      ),
+    ).toHaveAttribute(
+      "href",
+      "/agent-control/merge-preflight/pf_a_111111111111",
+    );
+    expect(
+      screen.getByTestId(
+        "agent-control-merge-preflight-link-pf_b_222222222222",
+      ),
+    ).toHaveAttribute(
+      "href",
+      "/agent-control/merge-preflight/pf_b_222222222222",
+    );
+  });
+
+  it("renders not_available when the API reports artefact missing", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({
+        kind: "agent_control_merge_preflight_list",
+        schema_version: 1,
+        status: "not_available",
+        reason: "missing",
+        rows: [],
+        counts: { rows: 0 },
+        step5_implementation_allowed: false,
+        step5_enabled_substage: "none",
+        level6_enabled: false,
+        dry_run_only: true,
+        live_merge_implemented: false,
+        deploy_coupled: false,
+      }),
+    );
+    renderAt("/agent-control/merge-preflight");
+    await waitFor(() =>
+      expect(
+        screen.getByTestId(
+          "agent-control-merge-preflight-not-available",
+        ),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("renders not_available on network failure", async () => {
+    mockFetch.mockRejectedValue(new Error("network"));
+    renderAt("/agent-control/merge-preflight");
+    await waitFor(() =>
+      expect(
+        screen.getByTestId(
+          "agent-control-merge-preflight-not-available",
+        ),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("renders not_available on malformed body", async () => {
+    mockFetch.mockResolvedValue(
+      new Response("not json", {
+        status: 200,
+        headers: { "content-type": "text/plain" },
+      }),
+    );
+    renderAt("/agent-control/merge-preflight");
+    await waitFor(() =>
+      expect(
+        screen.getByTestId(
+          "agent-control-merge-preflight-not-available",
+        ),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("surfaces the six discipline invariants from the envelope", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse(listOkEnvelope([candidate("pf_x_xxxxxxxxxxxx")])),
+    );
+    renderAt("/agent-control/merge-preflight");
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("agent-control-merge-preflight-invariants"),
+      ).toBeInTheDocument(),
+    );
+    const text = screen.getByTestId(
+      "agent-control-merge-preflight-invariants",
+    ).textContent || "";
+    expect(text).toMatch(/dry_run_only:\s*true/);
+    expect(text).toMatch(/live_merge_implemented:\s*false/);
+    expect(text).toMatch(/deploy_coupled:\s*false/);
+    expect(text).toMatch(/level6_enabled:\s*false/);
+    expect(text).toMatch(/step5_implementation_allowed:\s*false/);
+    expect(text).toMatch(/step5_enabled_substage:\s*none/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Detail view — happy / not_found / invalid / not_available / network
+// ---------------------------------------------------------------------------
+
+describe("AgentControlMergePreflight — detail view", () => {
+  it("fetches only the bounded N5b detail endpoint with same-origin GET", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse(detailOkEnvelope(candidate("pf_42_deadbeefdead"))),
+    );
+    renderAt("/agent-control/merge-preflight/pf_42_deadbeefdead");
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe(`${DETAIL_BASE}pf_42_deadbeefdead`);
+    const method = (init as RequestInit | undefined)?.method ?? "GET";
+    expect(method).toBe("GET");
+    expect((init as RequestInit | undefined)?.credentials).toBe("include");
+  });
+
+  it("renders the exact closed-schema row for status=ok", async () => {
+    const row = candidate("pf_42_deadbeefdead", {
+      pr_number: 77,
+      merge_state: "CLEAN",
+      checks_state: "SUCCESS",
+      dry_run_verdict: "would_be_live_candidate_if_authorized",
+    });
+    mockFetch.mockResolvedValue(jsonResponse(detailOkEnvelope(row)));
+    renderAt("/agent-control/merge-preflight/pf_42_deadbeefdead");
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("agent-control-merge-preflight-detail"),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByTestId(
+        "agent-control-merge-preflight-detail-preflight-id",
+      ),
+    ).toHaveTextContent(/pf_42_deadbeefdead/);
+    expect(
+      screen.getByTestId(
+        "agent-control-merge-preflight-detail-pr-number",
+      ),
+    ).toHaveTextContent(/77/);
+    expect(
+      screen.getByTestId(
+        "agent-control-merge-preflight-detail-dry-run-verdict",
+      ),
+    ).toHaveTextContent(/would_be_live_candidate_if_authorized/);
+    expect(
+      screen.getByTestId(
+        "agent-control-merge-preflight-detail-merge-state",
+      ),
+    ).toHaveTextContent(/CLEAN/);
+    expect(
+      screen.getByTestId(
+        "agent-control-merge-preflight-detail-checks-state",
+      ),
+    ).toHaveTextContent(/SUCCESS/);
+    expect(
+      screen.getByTestId(
+        "agent-control-merge-preflight-detail-token-required-for-live",
+      ),
+    ).toHaveTextContent(/true/);
+  });
+
+  it("renders stop_conditions as a bulleted list", async () => {
+    const row = candidate("pf_55_aaaaaaaaaaaa", {
+      pr_number: 55,
+      stop_conditions: [
+        "merge_state_not_clean",
+        "checks_not_green",
+        "token_required_for_live",
+        "live_merge_not_implemented",
+      ],
+    });
+    mockFetch.mockResolvedValue(jsonResponse(detailOkEnvelope(row)));
+    renderAt("/agent-control/merge-preflight/pf_55_aaaaaaaaaaaa");
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("agent-control-merge-preflight-detail"),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByTestId(
+        "agent-control-merge-preflight-detail-stop-conditions",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId(
+        "agent-control-merge-preflight-detail-stop-condition-merge_state_not_clean",
+      ),
+    ).toHaveTextContent(/merge_state_not_clean/);
+    expect(
+      screen.getByTestId(
+        "agent-control-merge-preflight-detail-stop-condition-checks_not_green",
+      ),
+    ).toHaveTextContent(/checks_not_green/);
+  });
+
+  it("renders not_found when the API rejects the preflight_id", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse(
+        {
+          kind: "agent_control_merge_preflight_detail",
+          schema_version: 1,
+          status: "not_found",
+          reason: "no_matching_preflight_id",
+          step5_implementation_allowed: false,
+          step5_enabled_substage: "none",
+        },
+        { status: 404 },
+      ),
+    );
+    renderAt("/agent-control/merge-preflight/pf_99_ffffffffffff");
+    await waitFor(() =>
+      expect(
+        screen.getByTestId(
+          "agent-control-merge-preflight-detail-not-found",
+        ),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("renders invalid when the API rejects the preflight_id shape", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse(
+        {
+          kind: "agent_control_merge_preflight_detail",
+          schema_version: 1,
+          status: "invalid_preflight_id",
+          reason: "bad_charset",
+        },
+        { status: 400 },
+      ),
+    );
+    renderAt("/agent-control/merge-preflight/pf_x_yyyy");
+    await waitFor(() =>
+      expect(
+        screen.getByTestId(
+          "agent-control-merge-preflight-detail-invalid",
+        ),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("renders not_available on network failure", async () => {
+    mockFetch.mockRejectedValue(new Error("network"));
+    renderAt("/agent-control/merge-preflight/pf_42_deadbeefdead");
+    await waitFor(() =>
+      expect(
+        screen.getByTestId(
+          "agent-control-merge-preflight-detail-not-available",
+        ),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("renders not_available on malformed body", async () => {
+    mockFetch.mockResolvedValue(
+      new Response("not json", {
+        status: 200,
+        headers: { "content-type": "text/plain" },
+      }),
+    );
+    renderAt("/agent-control/merge-preflight/pf_42_deadbeefdead");
+    await waitFor(() =>
+      expect(
+        screen.getByTestId(
+          "agent-control-merge-preflight-detail-not-available",
+        ),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("sanitises the route parameter against bad charset before fetch", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse(detailOkEnvelope(candidate("pf_42_deadbeefdead"))),
+    );
+    // The route would normally never receive these bytes (Flask
+    // refuses), but the bounded sanitisation in the component is a
+    // defense-in-depth layer. Inject a path that contains forbidden
+    // characters; after sanitisation, only the allowed characters
+    // survive.
+    renderAt("/agent-control/merge-preflight/pf!@%23_deadbeefdead");
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    const [url] = mockFetch.mock.calls[0];
+    // The literal `!`, `@`, `%`, `#` (raw form) must NOT be present
+    // in the eventual fetched URL.
+    expect(url).not.toMatch(/[!@#]/);
+  });
+
+  it("surfaces the six discipline invariants from the detail envelope", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse(detailOkEnvelope(candidate("pf_42_deadbeefdead"))),
+    );
+    renderAt("/agent-control/merge-preflight/pf_42_deadbeefdead");
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("agent-control-merge-preflight-invariants"),
+      ).toBeInTheDocument(),
+    );
+    const text = screen.getByTestId(
+      "agent-control-merge-preflight-invariants",
+    ).textContent || "";
+    expect(text).toMatch(/dry_run_only:\s*true/);
+    expect(text).toMatch(/live_merge_implemented:\s*false/);
+    expect(text).toMatch(/deploy_coupled:\s*false/);
+    expect(text).toMatch(/level6_enabled:\s*false/);
+    expect(text).toMatch(/step5_implementation_allowed:\s*false/);
+    expect(text).toMatch(/step5_enabled_substage:\s*none/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Read-only structural pins — no buttons, no decision verbs,
+// no token endpoint, no mutating method, no sendBeacon.
+// ---------------------------------------------------------------------------
+
+describe("AgentControlMergePreflight — read-only structural pins", () => {
+  it("never issues a POST / PUT / PATCH / DELETE on the list view", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse(listOkEnvelope([candidate("pf_42_deadbeefdead")])),
+    );
+    renderAt("/agent-control/merge-preflight");
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    for (const call of mockFetch.mock.calls) {
+      const init = (call[1] as RequestInit | undefined) ?? {};
+      const method = (init.method ?? "GET").toUpperCase();
+      expect(["POST", "PUT", "PATCH", "DELETE"]).not.toContain(method);
+    }
+  });
+
+  it("never issues a POST / PUT / PATCH / DELETE on the detail view", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse(detailOkEnvelope(candidate("pf_42_deadbeefdead"))),
+    );
+    renderAt("/agent-control/merge-preflight/pf_42_deadbeefdead");
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    for (const call of mockFetch.mock.calls) {
+      const init = (call[1] as RequestInit | undefined) ?? {};
+      const method = (init.method ?? "GET").toUpperCase();
+      expect(["POST", "PUT", "PATCH", "DELETE"]).not.toContain(method);
+    }
+  });
+
+  it("never fetches an approval-token endpoint", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse(listOkEnvelope([candidate("pf_42_deadbeefdead")])),
+    );
+    renderAt("/agent-control/merge-preflight");
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    for (const call of mockFetch.mock.calls) {
+      const url = String(call[0]);
+      expect(url).not.toContain("approval-token");
+    }
+  });
+
+  it("never fetches a mobile-inbox endpoint", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse(listOkEnvelope([candidate("pf_42_deadbeefdead")])),
+    );
+    renderAt("/agent-control/merge-preflight");
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    for (const call of mockFetch.mock.calls) {
+      const url = String(call[0]);
+      expect(url).not.toContain("/api/agent-control/mobile-inbox/");
+    }
+  });
+
+  it("never fetches any merge-execution / live-merge endpoint", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse(listOkEnvelope([candidate("pf_42_deadbeefdead")])),
+    );
+    renderAt("/agent-control/merge-preflight");
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    for (const call of mockFetch.mock.calls) {
+      const url = String(call[0]);
+      expect(url).not.toContain("merge-execution");
+      expect(url).not.toContain("/n5b/execute");
+      expect(url).not.toContain("live-merge");
+    }
+  });
+
+  it("does not call navigator.sendBeacon (list view)", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse(listOkEnvelope([candidate("pf_42_deadbeefdead")])),
+    );
+    renderAt("/agent-control/merge-preflight");
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    expect(mockSendBeacon).not.toHaveBeenCalled();
+  });
+
+  it("does not call navigator.sendBeacon (detail view)", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse(detailOkEnvelope(candidate("pf_42_deadbeefdead"))),
+    );
+    renderAt("/agent-control/merge-preflight/pf_42_deadbeefdead");
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    expect(mockSendBeacon).not.toHaveBeenCalled();
+  });
+
+  it("contains no buttons on list (read-only by structure)", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse(listOkEnvelope([candidate("pf_42_deadbeefdead")])),
+    );
+    renderAt("/agent-control/merge-preflight");
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("agent-control-merge-preflight-list"),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.queryAllByRole("button")).toHaveLength(0);
+  });
+
+  it("contains no buttons on detail (read-only by structure)", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse(detailOkEnvelope(candidate("pf_42_deadbeefdead"))),
+    );
+    renderAt("/agent-control/merge-preflight/pf_42_deadbeefdead");
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("agent-control-merge-preflight-detail"),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.queryAllByRole("button")).toHaveLength(0);
+  });
+
+  it("does not render the words 'approve' / 'reject' / 'deploy' / 'execute' on list", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse(listOkEnvelope([candidate("pf_42_deadbeefdead")])),
+    );
+    renderAt("/agent-control/merge-preflight");
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("agent-control-merge-preflight-list"),
+      ).toBeInTheDocument(),
+    );
+    const text = (
+      screen.getByTestId("agent-control-merge-preflight-root")
+        .textContent || ""
+    ).toLowerCase();
+    expect(text).not.toMatch(/\bapprove\b/);
+    expect(text).not.toMatch(/\breject\b/);
+    expect(text).not.toMatch(/\bdeploy\b/);
+    expect(text).not.toMatch(/\bexecute\b/);
+  });
+
+  it("does not render the words 'approve' / 'reject' / 'deploy' / 'execute' on detail", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse(detailOkEnvelope(candidate("pf_42_deadbeefdead"))),
+    );
+    renderAt("/agent-control/merge-preflight/pf_42_deadbeefdead");
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("agent-control-merge-preflight-detail"),
+      ).toBeInTheDocument(),
+    );
+    const text = (
+      screen.getByTestId("agent-control-merge-preflight-root")
+        .textContent || ""
+    ).toLowerCase();
+    expect(text).not.toMatch(/\bapprove\b/);
+    expect(text).not.toMatch(/\breject\b/);
+    expect(text).not.toMatch(/\bdeploy\b/);
+    expect(text).not.toMatch(/\bexecute\b/);
+  });
+
+  it("does not embed any raw token-shaped literal in the DOM", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse(detailOkEnvelope(candidate("pf_42_deadbeefdead"))),
+    );
+    renderAt("/agent-control/merge-preflight/pf_42_deadbeefdead");
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("agent-control-merge-preflight-detail"),
+      ).toBeInTheDocument(),
+    );
+    const text =
+      screen.getByTestId("agent-control-merge-preflight-root").textContent ||
+      "";
+    expect(text).not.toMatch(/Bearer\s+/);
+    // Two-dot JWT-style header.payload.signature.
+    expect(text).not.toMatch(/[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the v3.15.16.N5b.phase1 read-only PWA surface over the
already-wired N5b Phase 1 merge-preflight API
(\`/api/agent-control/merge-preflight/{list,detail}\`). New route
\`/agent-control/merge-preflight\` renders closed-schema dry-run
candidate rows; a new discoverability card in the PRs tab of
Agent Control links to it. The route page is the only place that
fetches the merge-preflight endpoint; the hub stays fetch-free.

> Banner literal verbatim (operator-prescribed):
> **\"Dry-run only. Live merge execution is not implemented.\"**

## Scope (six files, all under \`frontend/\`)

| File | Action |
|---|---|
| \`frontend/src/api/agent_control.ts\` | EDIT (additive) — new types + 2 GET client methods |
| \`frontend/src/routes/AgentControl/MergePreflight.tsx\` | NEW |
| \`frontend/src/test/AgentControlMergePreflight.test.tsx\` | NEW (34 tests) |
| \`frontend/src/App.tsx\` | EDIT (additive) — 2 auth-guarded routes |
| \`frontend/src/routes/AgentControl.tsx\` | EDIT (additive) — \`MergePreflightLinkCard\` in PRs tab |
| \`frontend/src/test/AgentControl.test.tsx\` | EDIT (additive) — 3 card tests |

## What is rendered

* **Discoverability card** in the PRs tab, directly below the
  existing \"Merge Recommendations\" card and above
  \"Execute-Safe Catalog\". The card is a \`<Link>\` only — no
  button, no fetch, no token form.
* **Route page** at \`/agent-control/merge-preflight\` with a
  \`/agent-control/merge-preflight/:preflightId\` detail view.
* Every envelope rendering surfaces the six discipline invariants
  verbatim: \`dry_run_only\`, \`live_merge_implemented\`,
  \`deploy_coupled\`, \`level6_enabled\`,
  \`step5_implementation_allowed\`, \`step5_enabled_substage\`.
* Per-candidate fields: \`pr_number\`, \`head_ref\` / \`base_ref\`,
  shortened \`expected_head_sha\` / \`observed_head_sha\`,
  \`dry_run_verdict\`, \`stop_conditions\` (bulleted list),
  \`token_required_for_live\`, \`merge_state\`, \`checks_state\`,
  \`evidence_freshness_seconds\`.

## Hard invariants reaffirmed by tests

* \`dry_run_only = true\`, \`live_merge_implemented = false\`,
  \`deploy_coupled = false\`, \`level6_enabled = false\`,
  \`step5_implementation_allowed = false\`,
  \`step5_enabled_substage = \"none\"\`.
* Zero \`<button>\` elements on either view; the AgentControl hub
  still has exactly the one existing refresh button.
* No POST / PUT / PATCH / DELETE method on any fetch.
* No fetch to any URL containing \`approval-token\`,
  \`mobile-inbox\`, \`merge-execution\`, \`live-merge\`, or
  \`/n5b/execute\`.
* No \`navigator.sendBeacon\` call.
* No rendered text matches \`\bapprove\b\` / \`\breject\b\` /
  \`\bdeploy\b\` / \`\bexecute\b\` on either view.
* No \`Bearer\` token literal or JWT-shaped \`a.b.c\` triple in the
  DOM.

## What is NOT touched

* \`dashboard/\`, \`reporting/\`, \`scripts/\`,
  \`.github/workflows/\`
* \`.claude/\`, \`.gitleaks.toml\`, \`research/\`, \`live/\`,
  \`paper/\`, \`shadow/\`, \`risk/\`, \`broker/\`, \`execution/\`
* No new dependency in \`frontend/package.json\`
* No A18b / A18c
* No N5b Phase 2 / 3 / 4 introduction
* No Step 5 / Level 6 change
* No token form or token input element

## Test plan

- [x] \`python scripts/governance_lint.py\` — OK
- [x] \`python -m pytest tests/smoke -q\` — 18 passed
- [x] \`npm --prefix frontend test -- --run\` — 279 passed (was
  245; +34 MergePreflight tests + 3 AgentControl card tests)
- [x] \`npm --prefix frontend run build\` — vite production build OK
- [x] \`python -m reporting.development_merge_preflight --no-write\`
  — invariants green
- [x] \`python -m reporting.development_step5_loop --no-write\` —
  Step 5 invariants green
- [x] \`python -m reporting.development_operational_digest --no-write\`
  — Step 5 invariant green

## Post-merge operator verification (auto-deploy expected)

PR touches \`frontend/\`, so the auto-deploy workflow will rebuild
and ship the new PWA assets. After deploy lands:

1. From a logged-in PWA session at /agent-control, open the PRs
   tab. A new \"Merge Preflight (N5b dry-run)\" card appears
   directly below the existing \"Merge Recommendations\" card,
   with the description text \"Dry-run only. Live merge
   execution is not implemented.\"
2. Tap/click the \"Open merge preflight →\" link. The destination
   route shows the same banner literal at the top.
3. The list view shows either the empty-state copy (today's
   posture, because upstream A22/A23 artefacts are absent → the
   N5b artefact's \`candidates\` array is empty) or, once the
   operator manually refreshes the chain per the Task-1 runbook,
   the per-candidate rows.
4. The six discipline invariants are visible in a footer pill on
   both list and detail views.

🤖 Generated with [Claude Code](https://claude.com/claude-code)