### PR TITLE
docs(phase0): autonomous-development-lane baseline observation runbook

### DIFF
--- a/docs/governance/autonomous_development_baseline_observation.md
+++ b/docs/governance/autonomous_development_baseline_observation.md
@@ -1,0 +1,393 @@
+# Autonomous Development Lane — Baseline Observation Runbook
+
+> **Status:** Operator-facing observation runbook for the
+> autonomous-development-lane safe rest state. Phase 0 of the
+> autonomous-development-lane phased plan.
+>
+> **Authority:** development-governance read-only documentation.
+> This runbook grants ADE **zero** new authority. It documents the
+> exact dry-run-only CLI sequence the operator runs on the VPS (or
+> locally) to confirm that every component of the
+> autonomous-development lane is at its documented safe rest state
+> before a later phase is allowed to start.
+>
+> **Permanent denials (re-asserted):**
+>
+> * `step5_implementation_allowed = false` (unchanged)
+> * `STEP5_ENABLED_SUBSTAGE = "none"` (unchanged)
+> * Level 6 is permanently disabled per ADR-015 §Doctrine 1.
+> * No autonomous merge / deploy / trade / approval.
+> * No approval can happen from a notification click alone.
+> * No `gh pr merge`, no `gh pr review --approve`, no `--admin`,
+>   no branch-protection bypass, no force push, no
+>   `seed.jsonl` / `generated_seed.jsonl` write, no `.claude/**`
+>   edit, no `.gitleaks.toml` edit, no test weakening, no hook
+>   bypass.
+> * No `ADE_GENERATED_LANE_WRITER_ENABLED=true` export is
+>   requested by this runbook. The A18b runtime activation is a
+>   separate operator-only step gated behind the explicit
+>   operator-go phrase
+>   `GO enable A18b writer on VPS` (Phase 1 of the plan).
+> * No `ADE_N5B_LIVE_EXECUTE_ENABLED=true` export is requested by
+>   this runbook. N5b Phase 4 production merge requires its own
+>   distinct high-risk operator-go.
+> * No A18c admission integration is documented here; A18c remains
+>   plan-only, gated by `GO A18c plan-only`.
+
+---
+
+## 1. Purpose
+
+Phase 0 of the autonomous-development-lane plan is the **baseline
+observation / safety inventory** step. Its purpose is to capture,
+in a single durable artefact, the exact closed-vocab values the
+operator must observe before any later phase is allowed to start.
+
+The autonomous-development lane spans:
+
+* **A18a** — `reporting.development_generated_lane` dry-run
+  candidate projector (read-only).
+* **A18b** — `reporting.development_generated_lane_writer` —
+  default-disabled append-only writer for `generated_seed.jsonl`.
+* **A18c** — admission integration into the A17 queue admission
+  policy. **Not implemented.** Plan-only until a separate
+  operator-go.
+* **N5b Phase 1** — `reporting.development_merge_preflight` —
+  dry-run merge-preflight projector (read-only).
+* **N5b Phase 2/3/4** — token-bound dry-run / sacrificial-repo
+  live merge / production live merge. **Not implemented.** Each
+  later phase requires its own distinct operator-go per
+  [`docs/governance/n5b_merge_execution_plan.md`](n5b_merge_execution_plan.md)
+  §10.
+* **Step 5** — implementation planner / adapter / PR creation
+  surfaces. **Not implemented.** Plan-only until a separate
+  operator-go.
+* **N4b** — approval-token runtime (already Phase B-active on
+  VPS, claim-only, no autonomous action).
+
+This runbook tells the operator how to verify that, at the
+moment Phase 0 closes, **every** component listed above is at
+its documented safe rest state and **no** later phase has
+silently started.
+
+This runbook is **not** an authorisation to start any later
+phase. Each later phase requires its own explicit operator-go
+phrase per the accepted plan.
+
+---
+
+## 2. Hard constraints
+
+This runbook, the commands it prescribes, and any caller acting on
+them must not:
+
+* merge any PR;
+* push to `main` or force-push any branch;
+* call `gh pr merge`, `gh pr review --approve`, or any other
+  GitHub mutation;
+* call `git merge` against `main`, `git push`, or any equivalent
+  mutating Git operation;
+* mint or verify approval tokens (Phase 0 is pre-token, pre-N5b);
+* execute an approve / reject decision (N4 + N5 execution
+  territory);
+* deploy anything;
+* send any real push notification;
+* register a Flask blueprint or wire into
+  `dashboard/dashboard.py`;
+* touch `frontend/**`;
+* mutate any upstream artefact (Phase 0 is read-only by
+  construction);
+* edit canonical roadmap status fields;
+* mark any roadmap phase complete;
+* enable Step 5.1 or Step 5.2;
+* flip `step5_implementation_allowed`;
+* change `STEP5_ENABLED_SUBSTAGE`;
+* raise Level 6 (Level 6 is permanently disabled per ADR-015 §Doctrine 1);
+* change QRE behaviour;
+* mutate research artifacts;
+* touch live / paper / shadow / risk / broker / execution paths;
+* edit `.claude/**`;
+* edit `.gitleaks.toml`;
+* weaken or bypass tests, hooks, gates, or pin-tests;
+* export `ADE_GENERATED_LANE_WRITER_ENABLED=true`;
+* export `ADE_N5B_LIVE_EXECUTE_ENABLED=true`;
+* write a `seed.jsonl` or `generated_seed.jsonl` record;
+* store secrets in repo.
+
+---
+
+## 3. The baseline observation chain (read-only)
+
+Every command in this section is a dry-run inspection of an
+existing component. None of them mutate disk, network, env, or
+process state. Each command's expected output is **closed
+vocabulary** — anything outside the closed set is treated as a
+divergence the operator inspects manually and resolves before
+any later phase is allowed to start.
+
+| Step | Subsystem | What is observed | Where the source-of-truth lives |
+|---|---|---|---|
+| 1 | A18b writer artefact | `generated_seed.jsonl` is absent on disk | `reporting.development_generated_lane_writer.GENERATED_SEED_PATH` → `/root/trading-agent/generated_seed.jsonl` |
+| 2 | A18b writer status | writer is default-disabled; `record_count=0`; Step 5 + Level 6 invariants intact | `reporting.development_generated_lane_writer._status_snapshot` |
+| 3 | A18b writer env-gate on VPS | `ADE_GENERATED_LANE_WRITER_ENABLED` is unset in the dashboard container | `reporting.development_generated_lane_writer.ENV_WRITER_ENABLED` |
+| 4 | N5b Phase 1 preflight | `dry_run_only=true`, `live_merge_implemented=false`, `deploy_coupled=false`, `level6_enabled=false`, `candidate_count=0`, Step 5 invariants intact | `reporting.development_merge_preflight` |
+| 5 | Step 5 loop reporter | `step5_implementation_allowed=false`, `step5_enabled_substage="none"` | `reporting.development_step5_loop` |
+| 6 | Operational digest | `step5_implementation_allowed=false` | `reporting.development_operational_digest` |
+| 7 | Recurring maintenance registry | `refresh_merge_preflight` job present, enabled, LOW risk, no-gh, 30-minute interval | `reporting.recurring_maintenance` |
+| 8 | Agent service on VPS | agent container is stopped | docker compose project state |
+
+---
+
+## 4. Operator workflow — VPS
+
+Run the chain in order. Every step is dry-run only. Any
+divergence from the expected closed-vocab values in §3 pauses
+Phase 1 and beyond.
+
+```sh
+cd /root/trading-agent
+
+# Step 1 — confirm A18b writer artefact is absent on the canonical path.
+test -f /root/trading-agent/generated_seed.jsonl \
+   && echo "generated_seed exists" \
+   || echo "generated_seed absent"
+
+# Step 2 — inspect A18b writer status snapshot (read-only; CLI never writes).
+python3 -m reporting.development_generated_lane_writer --no-write
+
+# Step 3 — confirm A18b writer env-gate is unset in the dashboard container.
+docker compose -p trading-agent exec dashboard env \
+   | grep -E '^ADE_GENERATED_LANE_WRITER_ENABLED=' \
+   || echo "ADE_GENERATED_LANE_WRITER_ENABLED is unset (writer off)"
+
+# Step 4 — inspect N5b Phase 1 preflight rest state.
+python3 -m reporting.development_merge_preflight --no-write
+
+# Step 5 — Step 5 loop reporter.
+python3 -m reporting.development_step5_loop --no-write
+
+# Step 6 — operational digest.
+python3 -m reporting.development_operational_digest --no-write
+
+# Step 7 — recurring maintenance registry posture.
+python3 -m reporting.recurring_maintenance --list-jobs
+
+# Step 8 — confirm agent service is stopped on VPS.
+docker compose -p trading-agent ps agent
+```
+
+### 4.1 Expected closed-vocab values per step
+
+**Step 1.** Stdout: exactly `generated_seed absent`.
+
+**Step 2.** Snapshot JSON must include:
+
+* `writer_enabled = false`
+* `env_var_name = "ADE_GENERATED_LANE_WRITER_ENABLED"`
+* `generated_seed_path = "/root/trading-agent/generated_seed.jsonl"`
+* `record_count = 0`
+* `max_records_cap = 256`
+* `step5_implementation_allowed = false`
+* `step5_enabled_substage = "none"`
+* `level6_enabled = false`
+* `discipline_invariants` dict present and all values match the
+  module's `_DISCIPLINE_INVARIANTS` constant.
+
+**Step 3.** Stdout: exactly
+`ADE_GENERATED_LANE_WRITER_ENABLED is unset (writer off)`. The
+`grep` exit code is non-zero when the var is unset; the `||`
+branch fires the explicit confirmation message.
+
+**Step 4.** Snapshot JSON must include:
+
+* `dry_run_only = true`
+* `live_merge_implemented = false`
+* `deploy_coupled = false`
+* `level6_enabled = false`
+* `step5_implementation_allowed = false`
+* `step5_enabled_substage = "none"`
+* `candidate_count = 0`
+
+`note` may legitimately be any closed-vocab value from the
+projector's vocabulary (typically
+`missing_merge_recommendation_artifact` or
+`missing_pr_lifecycle_artifact` when the upstream A22 / A23
+chain has not been refreshed — see
+[`docs/governance/n5b_merge_preflight_runbook.md`](n5b_merge_preflight_runbook.md)).
+
+**Step 5.** Snapshot JSON must include:
+
+* `step5_implementation_allowed = false`
+* `step5_enabled_substage = "none"`
+
+**Step 6.** Snapshot JSON must include:
+
+* `step5_implementation_allowed = false`
+
+**Step 7.** The `jobs` list must contain a row with:
+
+* `job_type = "refresh_merge_preflight"`
+* `enabled = true`
+* `risk_class = "LOW"`
+* `needs_gh = false`
+* `schedule.interval_seconds = 1800` (30 minutes)
+
+**Step 8.** Docker shows the `agent` service as stopped (the
+container row reports a non-running state). The dashboard
+service may legitimately be running; this runbook is about the
+agent service.
+
+---
+
+## 5. Operator workflow — local dry-run
+
+For a local smoke pass without VPS access, run the equivalent
+commands from the repo working tree. Steps 3 and 8 are VPS-only
+(they inspect the live docker compose project) and are skipped
+locally. All other steps run identically:
+
+```sh
+test -f generated_seed.jsonl \
+   && echo "generated_seed exists" \
+   || echo "generated_seed absent"
+python -m reporting.development_generated_lane_writer --no-write
+python -m reporting.development_merge_preflight --no-write
+python -m reporting.development_step5_loop --no-write
+python -m reporting.development_operational_digest --no-write
+python -m reporting.recurring_maintenance --list-jobs
+```
+
+The CLI `--no-write` flag on the A18b writer is documented in
+the module's `_build_parser()` docstring as a no-op accepted for
+parity with sibling reporting modules; the writer's CLI never
+writes regardless. The status snapshot is what the bare CLI
+emits by default.
+
+---
+
+## 6. Stop conditions and divergence handling
+
+If any closed-vocab value from §4.1 fails to match, the operator:
+
+1. **Stops.** No later phase may start.
+2. **Captures evidence.** Saves the divergent command output to a
+   private operator note (never to a public artefact or PR body;
+   the output may contain bounded diagnostic information about
+   the host).
+3. **Investigates.** Inspects the relevant source-of-truth
+   module (see §3 table) to determine whether the divergence is
+   a real drift, a transient artefact-absence (Step 4 can
+   legitimately differ when the upstream A22/A23 chain has not
+   been refreshed), or a tooling artefact (Step 3 grep semantics
+   on different shells).
+4. **Resolves manually** before re-running this runbook. Phase 1
+   remains blocked until §4.1 closes green.
+
+The §4.1 closed-vocab values are the only authorised "go-ahead"
+signal for Phase 1.
+
+---
+
+## 7. Rollback
+
+This runbook describes only read-only inspection commands.
+"Rollback" therefore reduces to **revert the docs PR** that
+shipped this runbook (single `git revert`). No on-disk
+artefact, no env variable, and no docker state is mutated by
+running the runbook commands, so there is nothing else to
+rewind.
+
+---
+
+## 8. Step 5 and Level 6 invariants
+
+Level 6 is **permanently disabled** per ADR-015 §Doctrine 1 and
+is **never** raised by this runbook. The six invariants below are
+re-asserted on every line of this runbook:
+
+```
+step5_implementation_allowed = false
+STEP5_ENABLED_SUBSTAGE        = "none"
+level6_enabled                = false
+dry_run_only                  = true
+live_merge_implemented        = false
+deploy_coupled                = false
+```
+
+The autonomous-development-lane projectors emit these literal
+values into their snapshot envelopes on every run. This runbook
+does not authorise the operator to flip any of them. Any future
+change to these invariants requires a separate operator-authored
+ADR and a separate PR.
+
+---
+
+## 9. What this runbook does NOT do
+
+* Does **not** activate the A18b writer. Activation is Phase 1
+  of the plan and requires the exact operator-go phrase
+  `GO enable A18b writer on VPS`. Phase 0 only **observes** that
+  the writer is default-disabled.
+* Does **not** write any production `generated_seed.jsonl`
+  record. The Phase 2 controlled production write smoke is a
+  separate operator-go: `GO A18b controlled production write smoke`.
+* Does **not** plan or implement A18c. A18c remains plan-only,
+  gated by `GO A18c plan-only`.
+* Does **not** plan, implement, or activate any Step 5 substage.
+  Step 5 surfaces remain plan-only, gated by `GO Step 5 plan-only`
+  with each substage having its own subsequent go phrase. No
+  flag flip happens in Phase 0.
+* Does **not** introduce N5b Phase 2 token-bound dry-run, Phase
+  3 sacrificial-repo live merge, or Phase 4 production merge.
+  Each requires its own operator-go per
+  [`n5b_merge_execution_plan.md`](n5b_merge_execution_plan.md) §10.
+* Does **not** grant ADE permission to merge any PR, push to
+  `main`, force-push, deploy, mint an approval token, verify an
+  approval token, send a real push notification, or open / close
+  / comment on any PR.
+* Does **not** modify, mark complete, or advance any roadmap
+  status field.
+
+---
+
+## 10. Authority chain summary
+
+| Capability | Today | After this runbook | After Phase 1 go (operator-only) | After Phase 4 (A18c, future, operator-go required) | After N5b Phase 4 (future, distinct operator-go required) |
+|---|---|---|---|---|---|
+| Read A18b writer status snapshot | yes (CLI) | yes (documented) | unchanged | unchanged | unchanged |
+| Read N5b Phase 1 preflight artefact | yes (CLI, scheduled) | yes (documented) | unchanged | unchanged | unchanged |
+| Append a `generated_seed.jsonl` record | does not exist (env-gated, off) | unchanged | yes (writer armed; no record written until Phase 2 go) | unchanged | unchanged |
+| Project `generated_seed.jsonl` rows into queue candidates | does not exist | unchanged | unchanged | yes — A18c, default-disabled by env flag | unchanged |
+| Mint approval token | yes (N4b Phase B active, claim-only) | unchanged | unchanged | unchanged | unchanged |
+| Live merge of any PR | does not exist | unchanged | unchanged | unchanged | yes — single PR per invocation, distinct operator-go |
+| Autonomous merge / deploy / trade | forbidden (Level 6 permanently disabled) | unchanged | unchanged | unchanged | unchanged |
+
+This runbook grants ADE **zero** new authority. The baseline
+observation is information, not authority.
+
+---
+
+## 11. Cross-references
+
+* [`docs/governance/development_generated_lane.md`](development_generated_lane.md)
+  — A18a / A18b governance and writer contract.
+* [`docs/governance/n5b_merge_execution_plan.md`](n5b_merge_execution_plan.md)
+  — N5b governance / plan-only doc; §10 enumerates the four
+  rollout phases and reasserts that each requires a separate
+  operator-go.
+* [`docs/governance/n5b_merge_preflight_runbook.md`](n5b_merge_preflight_runbook.md)
+  — N5b Phase 1 dry-run preflight upstream-refresh runbook.
+* [`docs/governance/recurring_maintenance.md`](recurring_maintenance.md)
+  — typed scheduler that owns the
+  `refresh_merge_preflight` job (Step 7 of the chain).
+* [`docs/governance/n4b_runtime_activation.md`](n4b_runtime_activation.md)
+  — the operator-only runbook for N4b Phase B activation
+  (already complete; N4b is at Phase B).
+* [`docs/adr/ADR-014-truth-authority-settlement.md`](../adr/ADR-014-truth-authority-settlement.md)
+  — authority doctrine.
+* [`docs/adr/ADR-015-claude-agent-governance.md`](../adr/ADR-015-claude-agent-governance.md)
+  — Level 6 permanently-disabled doctrine.
+* [`docs/governance/execution_authority.md`](execution_authority.md)
+  — per-action authority decisions.
+* [`docs/governance/no_touch_paths.md`](no_touch_paths.md) — the
+  protected paths.

--- a/tests/unit/test_autonomous_development_baseline_observation_runbook.py
+++ b/tests/unit/test_autonomous_development_baseline_observation_runbook.py
@@ -1,0 +1,587 @@
+"""Pin-tests for the Phase 0 autonomous-development-lane baseline
+observation runbook.
+
+These tests do **not** activate any runtime gate. They pin that the
+operator runbook at
+``docs/governance/autonomous_development_baseline_observation.md``:
+
+* exists, is non-trivial, and is plain text;
+* documents the canonical dry-run-only CLI sequence for the eight
+  observation steps;
+* uses only the confirmed-existing A18b writer CLI shape
+  (``python3 -m reporting.development_generated_lane_writer
+  --no-write`` plus the bare invocation without flags);
+* does NOT reference any non-existent ``--status`` flag on the
+  writer CLI;
+* references the canonical seed path exactly
+  (``/root/trading-agent/generated_seed.jsonl``);
+* does NOT reference a non-canonical
+  ``logs/development_generated_lane/`` seed path;
+* re-asserts the Step 5 + Level 6 + dry-run / live-merge /
+  deploy-coupled invariants explicitly;
+* does NOT instruct the operator to enable the A18b writer env
+  flag, the N5b live execute env flag, flip a Step 5 flag, raise
+  Level 6, merge / push / force-push, mint or verify approval
+  tokens, weaken tests, or bypass hooks;
+* does NOT embed a PEM block, a hex-64 inline-code literal, or a
+  bearer-token-shaped string;
+* cross-references the canonical doctrine documents.
+
+This is a documentation pin-test, not a runtime gate. The
+projector / writer / scheduler modules referenced by the runbook
+each have their own independent pin-tests.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUNBOOK_PATH = (
+    REPO_ROOT
+    / "docs"
+    / "governance"
+    / "autonomous_development_baseline_observation.md"
+)
+
+
+def _runbook_text() -> str:
+    return RUNBOOK_PATH.read_text(encoding="utf-8")
+
+
+# A markdown fenced code block opens with a line starting with ```
+# and closes with a matching line. The negative pin-tests below
+# scan only the *contents* of these blocks, because the runbook
+# necessarily quotes every forbidden imperative in its narrative
+# negative list and those mentions are legitimate. Operators only
+# copy commands out of fenced blocks, so the relevant safety
+# concern is "do not let a fenced block contain a mutating shape".
+_FENCE_RE = re.compile(r"```[^\n]*\n(.*?)```", re.DOTALL)
+
+
+def _runbook_code_blocks() -> str:
+    """Concatenated text of every fenced code block in the runbook.
+
+    Lower-cased so the imperative-shape pins can be written in
+    lowercase without per-phrase ``.lower()`` calls."""
+    text = _runbook_text()
+    return "\n".join(m.group(1) for m in _FENCE_RE.finditer(text)).lower()
+
+
+# ---------------------------------------------------------------------------
+# Existence + shape
+# ---------------------------------------------------------------------------
+
+
+def test_runbook_file_exists() -> None:
+    assert RUNBOOK_PATH.is_file(), (
+        "autonomous-development baseline observation runbook missing: "
+        f"{RUNBOOK_PATH}"
+    )
+
+
+def test_runbook_is_non_empty() -> None:
+    text = _runbook_text()
+    assert len(text) > 4000, (
+        f"baseline observation runbook is too short ({len(text)} "
+        "bytes); the runbook must document the full eight-step "
+        "observation chain."
+    )
+
+
+def test_runbook_is_markdown() -> None:
+    text = _runbook_text()
+    assert text.lstrip().startswith("# "), (
+        "runbook must be a markdown file beginning with a top-level "
+        "heading."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Canonical CLI invocations (Correction 2 — only the confirmed shape).
+# ---------------------------------------------------------------------------
+
+
+_REQUIRED_CLI_INVOCATIONS: tuple[str, ...] = (
+    # The confirmed A18b writer status invocation. The CLI never
+    # writes; this is the canonical status-snapshot shape per
+    # reporting/development_generated_lane_writer.py:_build_parser.
+    "python3 -m reporting.development_generated_lane_writer --no-write",
+    "python3 -m reporting.development_merge_preflight --no-write",
+    "python3 -m reporting.development_step5_loop --no-write",
+    "python3 -m reporting.development_operational_digest --no-write",
+    "python3 -m reporting.recurring_maintenance --list-jobs",
+)
+
+
+def test_runbook_documents_every_required_cli_invocation() -> None:
+    text = _runbook_text()
+    for cmd in _REQUIRED_CLI_INVOCATIONS:
+        assert cmd in text, (
+            "runbook must contain the canonical CLI invocation "
+            f"verbatim: {cmd!r}"
+        )
+
+
+def test_runbook_does_not_use_unsupported_status_flag() -> None:
+    """Correction 2 enforcement: the A18b writer CLI has no
+    ``--status`` flag. The runbook must never reference one."""
+    text = _runbook_text()
+    forbidden = (
+        "python3 -m reporting.development_generated_lane_writer --status",
+        "python -m reporting.development_generated_lane_writer --status",
+        "development_generated_lane_writer --status",
+    )
+    for needle in forbidden:
+        assert needle not in text, (
+            "runbook must not reference the unsupported "
+            f"--status CLI shape: {needle!r}"
+        )
+
+
+def test_runbook_documents_writer_bare_invocation_or_no_write() -> None:
+    """The A18b writer's status snapshot is what the bare CLI emits.
+    The runbook must document at least the ``--no-write`` shape
+    (confirmed parity flag) and the local-dry-run section may also
+    document the bare ``python -m`` shape."""
+    text = _runbook_text()
+    assert (
+        "python3 -m reporting.development_generated_lane_writer --no-write"
+        in text
+    ) or (
+        "python -m reporting.development_generated_lane_writer --no-write"
+        in text
+    ), (
+        "runbook must document the --no-write A18b writer CLI shape."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Canonical seed path (Correction 1 — repo-root, not logs/).
+# ---------------------------------------------------------------------------
+
+
+def test_runbook_references_canonical_seed_path_exactly() -> None:
+    text = _runbook_text()
+    assert "/root/trading-agent/generated_seed.jsonl" in text, (
+        "runbook must reference the canonical seed path "
+        "'/root/trading-agent/generated_seed.jsonl' exactly."
+    )
+
+
+def test_runbook_does_not_reference_non_canonical_seed_path() -> None:
+    """Correction 1 enforcement: the canonical seed path is at the
+    repo root, not under ``logs/development_generated_lane/``."""
+    text = _runbook_text()
+    forbidden = (
+        "logs/development_generated_lane/generated_seed.jsonl",
+        "logs/development_generated_lane/",
+    )
+    for needle in forbidden:
+        assert needle not in text, (
+            "runbook must not reference the non-canonical seed path "
+            f"{needle!r}; the canonical path lives at the repo root "
+            "per reporting.development_generated_lane_writer.GENERATED_SEED_PATH."
+        )
+
+
+def test_runbook_seed_path_agrees_with_writer_module() -> None:
+    """Defense in depth — when the writer module changes its
+    GENERATED_SEED_PATH constant, this test fails until the runbook
+    is re-aligned."""
+    from reporting import (  # noqa: WPS433 — local import intentional
+        development_generated_lane_writer as a18b_writer,
+    )
+
+    # The module constant is repo-relative; the runbook uses the VPS
+    # absolute path. The basename must match exactly, and the path
+    # must be at the repo root (not inside logs/).
+    assert a18b_writer.GENERATED_SEED_PATH.name == "generated_seed.jsonl"
+    parent_rel = a18b_writer.GENERATED_SEED_PATH.parent
+    repo_root = a18b_writer.REPO_ROOT
+    assert parent_rel == repo_root, (
+        f"writer's GENERATED_SEED_PATH parent must be repo root; got "
+        f"{parent_rel} vs {repo_root}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Closed-vocab discipline invariants (Correction 3 — Step 5 stays off).
+# ---------------------------------------------------------------------------
+
+
+def test_runbook_states_step5_implementation_allowed_false() -> None:
+    text = _runbook_text()
+    assert "step5_implementation_allowed" in text, (
+        "runbook must reaffirm step5_implementation_allowed = false."
+    )
+    idx = text.find("step5_implementation_allowed")
+    nearby = text[idx : idx + 200].lower()
+    assert "false" in nearby, (
+        "step5_implementation_allowed must be stated as `false` "
+        "explicitly in the runbook."
+    )
+
+
+def test_runbook_states_step5_enabled_substage_none() -> None:
+    text = _runbook_text()
+    assert (
+        "STEP5_ENABLED_SUBSTAGE" in text
+        or "step5_enabled_substage" in text
+    ), "runbook must reaffirm the STEP5_ENABLED_SUBSTAGE invariant."
+    lowered = text.lower()
+    assert '"none"' in text or " none" in lowered, (
+        "STEP5_ENABLED_SUBSTAGE must be stated as 'none'."
+    )
+
+
+def test_runbook_states_level_6_permanently_disabled() -> None:
+    text = _runbook_text().lower()
+    assert "level 6" in text, "runbook must reaffirm Level 6 doctrine."
+    assert "permanently disabled" in text, (
+        "runbook must state Level 6 remains permanently disabled."
+    )
+
+
+def test_runbook_states_dry_run_only_invariant() -> None:
+    text = _runbook_text()
+    assert "dry_run_only" in text, (
+        "runbook must restate the projector's dry_run_only invariant."
+    )
+    idx = text.find("dry_run_only")
+    nearby = text[idx : idx + 200].lower()
+    assert "true" in nearby, (
+        "dry_run_only must be stated as `true` explicitly in the "
+        "runbook."
+    )
+
+
+def test_runbook_states_live_merge_implemented_false() -> None:
+    text = _runbook_text()
+    assert "live_merge_implemented" in text, (
+        "runbook must restate the live_merge_implemented invariant."
+    )
+    idx = text.find("live_merge_implemented")
+    nearby = text[idx : idx + 200].lower()
+    assert "false" in nearby, (
+        "live_merge_implemented must be stated as `false` explicitly."
+    )
+
+
+def test_runbook_states_deploy_coupled_false() -> None:
+    text = _runbook_text()
+    assert "deploy_coupled" in text, (
+        "runbook must restate the deploy_coupled invariant."
+    )
+    idx = text.find("deploy_coupled")
+    nearby = text[idx : idx + 200].lower()
+    assert "false" in nearby, (
+        "deploy_coupled must be stated as `false` explicitly."
+    )
+
+
+def test_runbook_contains_combined_invariants_block() -> None:
+    """The runbook must somewhere state the six core invariants in
+    a single close block so the operator can read them together
+    without ambiguity. We require all six lowercased substrings to
+    appear within the same 1200-character window."""
+    text = _runbook_text().lower()
+    needles = (
+        "step5_implementation_allowed",
+        "step5_enabled_substage",
+        "level6_enabled",
+        "dry_run_only",
+        "live_merge_implemented",
+        "deploy_coupled",
+    )
+    first_idx = text.find(needles[0])
+    while first_idx != -1:
+        window = text[first_idx : first_idx + 1200]
+        if all(n in window for n in needles):
+            return
+        first_idx = text.find(needles[0], first_idx + 1)
+    raise AssertionError(
+        "runbook must state all six invariants "
+        f"({needles!r}) within a single ~1.2 KiB window so the "
+        "operator can read them together."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Negative pins — the runbook's executable surface (its fenced
+# code blocks) must contain no authority-escalating shape.
+# ---------------------------------------------------------------------------
+
+
+def test_runbook_code_blocks_do_not_enable_a18b_writer() -> None:
+    """The runbook is the Phase 0 observation step. It must NOT
+    contain an export of the A18b writer env flag. Activation is a
+    separate Phase 1 operator-go (``GO enable A18b writer on VPS``)."""
+    code = _runbook_code_blocks()
+    forbidden = (
+        "ade_generated_lane_writer_enabled=true",
+        'ade_generated_lane_writer_enabled="true"',
+        "export ade_generated_lane_writer_enabled",
+    )
+    for phrase in forbidden:
+        assert phrase not in code, (
+            "runbook code block must NOT enable the A18b writer: "
+            f"{phrase!r}"
+        )
+
+
+def test_runbook_code_blocks_do_not_enable_n5b_live_execute() -> None:
+    """N5b Phase 4 live execute is permanently denied without a
+    separate distinct operator-go. The runbook's executable surface
+    must not contain an env-flag enable line."""
+    code = _runbook_code_blocks()
+    forbidden = (
+        "ade_n5b_live_execute_enabled=true",
+        'ade_n5b_live_execute_enabled="true"',
+        "export ade_n5b_live_execute_enabled",
+    )
+    for phrase in forbidden:
+        assert phrase not in code, (
+            "runbook code block must NOT enable N5b live execute: "
+            f"{phrase!r}"
+        )
+
+
+def test_runbook_code_blocks_contain_no_real_merge_command() -> None:
+    """The runbook's executable surface must contain no GitHub
+    mutation command."""
+    code = _runbook_code_blocks()
+    forbidden = (
+        "gh pr merge --squash",
+        "gh pr merge --rebase",
+        "gh pr merge --merge",
+        "gh pr review --approve",
+        "gh pr review --request-changes",
+        "git merge --no-ff",
+        "git push --force",
+        "git push -f ",
+        "git push origin main",
+        "--admin",
+    )
+    for phrase in forbidden:
+        assert phrase not in code, (
+            "runbook code block contains a forbidden "
+            f"mutating-command shape: {phrase!r}"
+        )
+
+
+def test_runbook_code_blocks_do_not_flip_step5_or_level6() -> None:
+    """Imperative Step 5 / Level 6 flips would only ever appear as
+    executable lines. The invariants block prints the literal
+    ``step5_implementation_allowed = false`` etc. so we scan only
+    for the *true*-shaped flips."""
+    code = _runbook_code_blocks()
+    forbidden = (
+        "step5_implementation_allowed = true",
+        'step5_implementation_allowed="true"',
+        "step5_implementation_allowed=true",
+        'step5_enabled_substage = "5.0"',
+        'step5_enabled_substage = "5.1"',
+        'step5_enabled_substage = "5.2"',
+        'step5_enabled_substage="5.0"',
+        'step5_enabled_substage="5.1"',
+        'step5_enabled_substage="5.2"',
+        "level6_enabled = true",
+        "level6_enabled=true",
+    )
+    for phrase in forbidden:
+        assert phrase not in code, (
+            "runbook code block contains a forbidden "
+            f"authority-escalation flip: {phrase!r}"
+        )
+
+
+def test_runbook_code_blocks_do_not_instruct_token_mint_or_verify() -> None:
+    """Phase 0 is pre-token in the sense that it does not invoke
+    the N4b mint/verify CLI. The runbook's executable surface must
+    not contain such an invocation."""
+    code = _runbook_code_blocks()
+    forbidden = (
+        "approval_token_runtime.mint",
+        "approval_token_runtime.verify",
+        "mint_approval_token",
+        "verify_approval_token",
+        "--mint-token",
+        "--verify-token",
+    )
+    for phrase in forbidden:
+        assert phrase not in code, (
+            "runbook code block contains a forbidden token "
+            f"mint/verify invocation: {phrase!r}"
+        )
+
+
+def test_runbook_does_not_instruct_touching_no_touch_paths() -> None:
+    text = _runbook_text().lower()
+    forbidden_imperatives = (
+        "edit .claude",
+        "modify .claude",
+        "write to .claude",
+        "edit .gitleaks.toml",
+        "modify .gitleaks.toml",
+        "disable .gitleaks.toml",
+        "weaken .gitleaks.toml",
+        "edit seed.jsonl",
+        "modify seed.jsonl",
+        "write to seed.jsonl",
+        "append to seed.jsonl",
+        "edit generated_seed.jsonl",
+        "modify generated_seed.jsonl",
+        "write to generated_seed.jsonl",
+        "append to generated_seed.jsonl",
+        "weaken the test",
+        "weaken the tests",
+        "skip the gate",
+        "bypass the hook",
+        "bypass hooks",
+    )
+    for phrase in forbidden_imperatives:
+        assert phrase not in text, (
+            "runbook contains a forbidden no-touch-path / "
+            f"safety-bypass imperative: {phrase!r}"
+        )
+
+
+def test_runbook_does_not_instruct_deploy() -> None:
+    text = _runbook_text().lower()
+    forbidden = (
+        "trigger the deploy workflow",
+        "trigger deploy workflow",
+        "force the deploy",
+        "run the deploy",
+        "dispatch the deploy",
+        "couple this to deploy",
+    )
+    for phrase in forbidden:
+        assert phrase not in text, (
+            "runbook contains a forbidden deploy-coupling "
+            f"instruction: {phrase!r}"
+        )
+
+
+def test_runbook_code_blocks_do_not_authorise_a18c_implementation() -> None:
+    """A18c remains plan-only at Phase 0. The runbook may reference
+    A18c in its narrative negative-list (it does — to document that
+    A18c is plan-only). The pin therefore scans only the runbook's
+    executable surface (fenced code blocks). Narrative negative
+    mentions in prose (``does not plan or implement A18c``) are
+    required and live outside fenced blocks."""
+    code = _runbook_code_blocks()
+    forbidden = (
+        "implement a18c",
+        "build a18c",
+        "ship a18c",
+        "enable a18c",
+        "a18c is implemented",
+        "a18c is enabled",
+    )
+    for phrase in forbidden:
+        assert phrase not in code, (
+            "runbook code block contains a phrase that would "
+            f"authorise A18c implementation: {phrase!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Negative pins — no secret material.
+# ---------------------------------------------------------------------------
+
+
+def test_runbook_contains_no_pem_secret_block() -> None:
+    """Defense-in-depth: the runbook must not contain a real PEM
+    secret block. The PEM markers are assembled at runtime so the
+    test source itself does not embed a literal PEM header."""
+    text = _runbook_text()
+    dashes = "-" * 5
+    pem_kinds = (
+        "PRIVATE KEY",
+        "EC PRIVATE KEY",
+        "RSA PRIVATE KEY",
+        "OPENSSH PRIVATE KEY",
+    )
+    forbidden = [f"{dashes}BEGIN {kind}{dashes}" for kind in pem_kinds]
+    for marker in forbidden:
+        assert marker not in text, (
+            f"runbook contains a PEM-style secret block: {marker!r}"
+        )
+
+
+def test_runbook_contains_no_inline_hex_64_secret() -> None:
+    """A 64-character hex run inside backticks would look like a
+    copy-pasted ``openssl rand -hex 32`` output. The runbook
+    documents read-only inspection commands and has no business
+    quoting an HMAC secret."""
+    text = _runbook_text()
+    pattern = re.compile(r"`[0-9a-fA-F]{64}`")
+    matches = pattern.findall(text)
+    assert not matches, (
+        f"runbook embeds a hex-64 literal that looks like a secret: "
+        f"{matches!r}"
+    )
+
+
+def test_runbook_contains_no_bearer_token_header() -> None:
+    """No literal ``Authorization: Bearer <token>`` line; the
+    Phase 0 chain is unauthenticated stdlib projection plus VPS
+    inspection."""
+    text = _runbook_text().lower()
+    forbidden = (
+        "authorization: bearer ",
+        "x-api-key: ",
+        "ghp_",
+        "github_pat_",
+        "sk-ant-",
+    )
+    for pat in forbidden:
+        assert pat not in text, (
+            f"runbook contains a credential-shaped string: {pat!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Cross-reference pins — the runbook must link back to the doctrine.
+# ---------------------------------------------------------------------------
+
+
+def test_runbook_cross_references_n5b_plan_doc() -> None:
+    text = _runbook_text()
+    assert "n5b_merge_execution_plan.md" in text, (
+        "runbook must cross-reference the N5b plan / governance doc."
+    )
+
+
+def test_runbook_cross_references_n5b_preflight_runbook() -> None:
+    text = _runbook_text()
+    assert "n5b_merge_preflight_runbook.md" in text, (
+        "runbook must cross-reference the N5b Phase 1 preflight "
+        "upstream-refresh runbook."
+    )
+
+
+def test_runbook_cross_references_recurring_maintenance() -> None:
+    text = _runbook_text()
+    assert "recurring_maintenance" in text, (
+        "runbook must mention recurring_maintenance (step 7 of the "
+        "observation chain)."
+    )
+
+
+def test_runbook_cross_references_adr_015() -> None:
+    text = _runbook_text()
+    assert "ADR-015" in text, (
+        "runbook must cross-reference ADR-015 (Level 6 "
+        "permanently-disabled doctrine)."
+    )
+
+
+def test_runbook_cross_references_development_generated_lane_doc() -> None:
+    text = _runbook_text()
+    assert "development_generated_lane.md" in text, (
+        "runbook must cross-reference the A18a/A18b governance doc."
+    )


### PR DESCRIPTION
## Summary

Phase 0 of the accepted autonomous-development-lane phased plan
ships a single durable operator runbook for *\"verify the
autonomous-development-lane safe rest state in one pass\"* plus a
companion pin-test suite that enforces three operator-issued
corrections at every CI run.

## Scope (strictly docs + pin-tests)

| File | Action |
|---|---|
| `docs/governance/autonomous_development_baseline_observation.md` | NEW |
| `tests/unit/test_autonomous_development_baseline_observation_runbook.py` | NEW (32 tests) |

## The eight observation steps

The runbook codifies the exact dry-run-only CLI sequence the
operator runs on VPS (or locally) to confirm rest state:

1. A18b writer artefact absent on the **canonical** path
   `/root/trading-agent/generated_seed.jsonl`.
2. A18b writer status snapshot via the confirmed
   `python3 -m reporting.development_generated_lane_writer --no-write`.
3. A18b env-gate `ADE_GENERATED_LANE_WRITER_ENABLED` unset in the
   dashboard container.
4. N5b Phase 1 preflight rest state.
5. Step 5 loop reporter.
6. Operational digest.
7. Recurring maintenance registry posture (`refresh_merge_preflight`
   enabled, LOW, no-gh, 30 min).
8. Agent service on VPS is stopped.

## Three operator-issued corrections enforced verbatim

* **Correction 1 (canonical seed path):** pins reference the path
  `/root/trading-agent/generated_seed.jsonl` exactly. The runbook
  must NOT reference `logs/development_generated_lane/`. A third
  pin re-validates the writer module constant agrees, so future
  drift in the code fails this test before the runbook can
  silently disagree.
* **Correction 2 (A18b writer CLI shape):** pins reference only
  the confirmed-existing CLI shape. The runbook does NOT reference
  any unsupported `--status` flag — a dedicated pin asserts the
  absence of that shape.
* **Correction 3 (Step 5 activation language):** the runbook
  re-asserts `step5_implementation_allowed=false` and
  `STEP5_ENABLED_SUBSTAGE=\"none\"`. It does NOT imply that any
  later phase automatically promotes the substage; promotion
  remains an operator-only env/flag step gated by a separate
  explicit operator-go phrase per the accepted plan.

## Hard invariants reaffirmed (pinned by tests)

* `step5_implementation_allowed = false`
* `STEP5_ENABLED_SUBSTAGE = \"none\"`
* `level6_enabled = false` (Level 6 permanently disabled per
  ADR-015 §Doctrine 1)
* `dry_run_only = true`
* `live_merge_implemented = false`
* `deploy_coupled = false`

## What is NOT touched

* `reporting/**`, `dashboard/**`, `frontend/**`, `scripts/**`,
  `.github/workflows/**`
* `.claude/**`, `.gitleaks.toml`, `research/**`, `live/**`,
  `paper/**`, `shadow/**`, `risk/**`, `broker/**`, `execution/**`
* No runtime code added
* No env flag exported / flipped
* No A18b activation; no A18c authoring; no Step 5 substage
  promotion; no N5b Phase 2/3/4 introduction
* No Level 6 change
* No GitHub mutation; no token mint/verify; no deploy coupling

## Pin-test highlights

* Existence + non-emptiness of the runbook
* Every required CLI invocation present verbatim (five canonical
  shapes)
* Canonical seed path present exactly; non-canonical path absent
* Writer-module `GENERATED_SEED_PATH` re-validated at test time
  (defense-in-depth against future module drift)
* Closed-vocab discipline invariants restated
* Single ~1.2 KiB window with all six invariants
* Negative pins (scanning **fenced code blocks** only — narrative
  negative mentions in prose are legitimate and required):
  no A18b runtime enable, no N5b live-execute enable, no Step 5
  flip, no Level 6 raise, no GitHub-mutation invocations, no
  approval-token mint/verify CLI, no A18c implementation
  imperative
* No PEM block, no hex-64 inline-code literal, no
  Authorization-Bearer header
* Cross-reference pins for ADR-015,
  `n5b_merge_execution_plan.md`,
  `n5b_merge_preflight_runbook.md`,
  `recurring_maintenance.md`,
  `development_generated_lane.md`

## Test plan

- [x] `python scripts/governance_lint.py`
- [x] `python -m pytest tests/smoke -q` — 18 passed
- [x] `python -m pytest tests/unit/test_autonomous_development_baseline_observation_runbook.py -q` — 32 passed
- [x] `python -m pytest tests/unit/test_n5b_merge_preflight_runbook.py -q` — still green
- [x] `python -m pytest tests/unit/test_n4b_runtime_activation_runbook.py -q` — still green
- [x] `python -m reporting.development_merge_preflight --no-write` — invariants green
- [x] `python -m reporting.development_step5_loop --no-write` — Step 5 invariants green
- [x] `python -m reporting.development_operational_digest --no-write` — Step 5 invariant green
- [x] `python -m reporting.development_generated_lane_writer --no-write` — writer_enabled=false, record_count=0, max_records_cap=256

## Operator verification after merge

Docs+tests-only PR — **no auto-deploy is triggered**. No VPS
verification required for the PR itself. The runbook the PR
ships gives the operator the manual VPS sequence to run on
demand whenever a baseline check is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)