### PR TITLE
docs(a18b): host-side write + remount operator runbook (Phase 2 follow-up)

### DIFF
--- a/docs/governance/a18b_writer_host_side_write_runbook.md
+++ b/docs/governance/a18b_writer_host_side_write_runbook.md
@@ -1,0 +1,571 @@
+# A18b Writer — Host-Side Write + Remount Operator Runbook
+
+> **Status:** Operationally-pinned runbook for any A18b
+> `generated_seed.jsonl` write that follows the Phase-2 controlled
+> production write smoke. Codifies the EBUSY incident's root cause
+> and the safe procedure.
+>
+> **Authority:** development-governance read-only documentation.
+> This runbook grants ADE **zero** new authority. It documents the
+> exact dry-run-only CLI sequence the operator runs on the VPS
+> when a new A18b metadata record must be appended.
+>
+> **Permanent denials (re-asserted):**
+>
+> * `step5_implementation_allowed = false` (unchanged)
+> * `STEP5_ENABLED_SUBSTAGE = "none"` (unchanged)
+> * Level 6 is permanently disabled per ADR-015 §Doctrine 1.
+> * No autonomous merge / deploy / trade / approval.
+> * No approval can happen from a notification click alone.
+> * No `gh pr merge`, no `gh pr review --approve`, no `--admin`,
+>   no branch-protection bypass, no force push, no
+>   `seed.jsonl` / `delegation_seed.jsonl` write, no `.claude/**`
+>   edit, no `.gitleaks.toml` edit, no test weakening, no hook
+>   bypass.
+> * No `ADE_N5B_LIVE_EXECUTE_ENABLED=true` export is requested by
+>   this runbook.
+> * No A18c admission integration is performed; A18c remains
+>   plan-only, gated by the explicit operator-go phrase.
+> * No queue admission, no execution, no PR creation, no merge,
+>   no deploy.
+
+---
+
+## 1. Purpose
+
+The Phase 2 controlled production write smoke succeeded only on
+the host process. The first attempt — a container-side append via
+`docker compose exec dashboard python3 …` — failed with
+`OSError: [Errno 16] Device or resource busy` because the writer
+performs an atomic-replace at
+[`reporting/development_generated_lane_writer.py:514`](../../reporting/development_generated_lane_writer.py)
+(`os.replace(tmp_name, path)`), and the canonical target
+`/app/generated_seed.jsonl` is a **file-level bind mount** from
+the host's `/root/trading-agent/generated_seed.jsonl`. The kernel
+refuses to swap the target inode across a file-level bind-mount
+boundary.
+
+This runbook documents:
+
+* the verified Phase-2 state;
+* the EBUSY root cause;
+* the forbidden in-container append shape (must not be retried
+  while the file-level bind mount exists);
+* the safe host-side append procedure with a per-command env
+  prefix;
+* the required post-write dashboard remount so the container's
+  bind-mount view resolves the new inode;
+* the invariants every write must preserve;
+* the rollback procedure for the rare case where a diagnostic
+  row must be removed.
+
+The runbook is **not** an authorisation to perform a write. A
+write is a separate Phase-2-shaped operator-paced action with
+its own per-write approval. This runbook codifies the procedure
+the operator follows when they elect to perform one.
+
+---
+
+## 2. Hard constraints
+
+This runbook, the commands it prescribes, and any caller acting
+on them must not:
+
+* perform more than one write per invocation;
+* retry automatically after any failure;
+* modify the proposed record and retry without explicit operator
+  re-approval;
+* append from inside the dashboard container while
+  `/app/generated_seed.jsonl` remains a file-level bind mount;
+* merge any PR;
+* push to `main` or force-push any branch;
+* call `gh pr merge`, `gh pr review --approve`, or any other
+  GitHub mutation;
+* call `git merge` against `main`, `git push`, or any equivalent
+  mutating Git operation;
+* mint or verify approval tokens;
+* execute an approve / reject decision;
+* deploy anything;
+* send any real push notification;
+* register a Flask blueprint or wire into
+  `dashboard/dashboard.py`;
+* touch `frontend/**`;
+* admit any record into the A17 queue (A18c remains plan-only);
+* execute any code from the admitted/written record;
+* enable Step 5.1 or Step 5.2;
+* flip `step5_implementation_allowed`;
+* change `STEP5_ENABLED_SUBSTAGE`;
+* raise Level 6 (Level 6 is permanently disabled per ADR-015 §Doctrine 1);
+* change QRE behaviour;
+* mutate research artifacts;
+* touch live / paper / shadow / risk / broker / execution paths;
+* edit `.claude/**`;
+* edit `.gitleaks.toml`;
+* weaken or bypass tests, hooks, gates, or pin-tests;
+* export `ADE_N5B_LIVE_EXECUTE_ENABLED=true`;
+* write a `seed.jsonl` or `delegation_seed.jsonl` record;
+* store secrets in repo, logs, public artifacts, PR bodies,
+  screenshots, test output, or chat.
+
+---
+
+## 3. Verified Phase-2 state at the moment this runbook landed
+
+The Phase-2 controlled production write smoke closed green with:
+
+* host `/root/trading-agent/generated_seed.jsonl` has **1**
+  diagnostic row.
+* host `/root/trading-agent/logs/development_generated_lane_writer/audit.jsonl`
+  has **1** audit row.
+* latest audit row `attempt_kind = "written"`,
+  `stop_status = "none"`.
+* generated_candidate_id = `a18b-phase2-smoke-2026-05-13-001`.
+* dashboard container `writer_enabled = true`,
+  `record_count = 1` (after the post-write remount).
+* host writer status (no env prefix) reports `writer_enabled = false`,
+  `record_count = 1` (the status snapshot reads the file
+  regardless of env-gate state).
+* `step5_implementation_allowed = false`.
+* `STEP5_ENABLED_SUBSTAGE = "none"`.
+* `level6_enabled = false` (Level 6 permanently disabled per
+  ADR-015 §Doctrine 1).
+* N5b preflight `dry_run_only = true`,
+  `live_merge_implemented = false`,
+  `deploy_coupled = false`,
+  `candidate_count = 0`.
+* `seed.jsonl` and `delegation_seed.jsonl` remain **absent** on
+  both host and container.
+* dashboard + nginx services running; agent service stopped.
+
+---
+
+## 4. EBUSY root cause
+
+The A18b writer's `_atomic_replace_jsonl` helper performs an
+atomic-replace at
+[`reporting/development_generated_lane_writer.py`](../../reporting/development_generated_lane_writer.py):
+
+```
+tempfile.mkstemp(dir=str(path.parent))
+...
+os.replace(tmp_name, path)
+```
+
+This is the correct pattern for atomic JSONL replacement on a
+single filesystem: both `tmp_name` and `path` live in
+`path.parent`, so the `os.replace` is a same-directory rename
+that the kernel can satisfy atomically.
+
+The Phase-2 caveat is mount-topological, not a writer bug:
+
+* On the **host**, the writer's `path` is
+  `/root/trading-agent/generated_seed.jsonl`. The tmp file lives
+  in `/root/trading-agent/` — a single regular filesystem. The
+  rename succeeds.
+* Inside the **dashboard container**, the writer's `path` is
+  `/app/generated_seed.jsonl`. That path is a **file-level bind
+  mount** whose source is the host file. The tmp file lives in
+  `/app/` — a layered union filesystem distinct from the
+  bind-mount target's backing filesystem. `os.replace` is asked
+  to swap the target inode across a mount boundary the kernel
+  marks **`EBUSY`** (`Errno 16: Device or resource busy`).
+
+The writer surfaces this as a Python `OSError` rather than a
+closed-vocab `stop_status`. The Phase-2 failed attempt left no
+seed row, no audit row, no tmp residue — operator-confirmed
+clean.
+
+**Implication.** A container-side append is forbidden while the
+file-level bind mount remains in place. Any future appends must
+run on the **host** process (which performs the atomic-replace
+on a regular filesystem) followed by a dashboard remount (so the
+container's bind-mount view resolves the new inode).
+
+A future operator may decide to migrate to a directory-level
+bind-mount strategy (e.g. relocate the seed file under
+`/root/trading-agent/var/generated_lane/` and bind-mount the
+directory). That migration is a **separate** operator-paced
+action with its own scope proposal; until it lands, this runbook
+is the operationally-pinned path.
+
+---
+
+## 5. Forbidden shape (must not be attempted)
+
+Do **NOT** run the following while the file-level bind mount
+remains in place. Each shape will trigger `EBUSY` (or worse —
+silent partial state — if the writer's tmp-cleanup ever
+regressed):
+
+* any `docker compose -p trading-agent exec dashboard python3 -m
+  reporting.development_generated_lane_writer` invocation that
+  attempts to write (the CLI is status-only, but the negative
+  pin defends against future drift);
+* any `docker compose -p trading-agent exec dashboard python3`
+  invocation that imports
+  `reporting.development_generated_lane_writer` and calls
+  `append_generated_seed_record(...)`;
+* any in-container shell-out that constructs and pipes a record
+  body into the writer's public API.
+
+The runbook's pin-tests enforce that the executable surface of
+this document (its fenced code blocks) contains no such shape.
+
+---
+
+## 6. Safe host-side append procedure
+
+Run this on the **VPS host** (not inside the dashboard
+container). The per-command env prefix scopes the writer-enable
+flag only to the single Python child process — no global env
+mutation, no compose change.
+
+### 6.1 Preflight (read-only)
+
+```bash
+test -f /root/trading-agent/generated_seed.jsonl \
+   && wc -l /root/trading-agent/generated_seed.jsonl \
+   || echo "host_seed_absent"
+```
+
+```bash
+cd /root/trading-agent
+ADE_GENERATED_LANE_WRITER_ENABLED=true \
+   python3 -m reporting.development_generated_lane_writer --no-write
+```
+
+**Expected.** Snapshot reports `writer_enabled=true` (because of
+the per-command prefix), current `record_count`, and the
+canonical paths. Step 5 / Level 6 invariants intact (Level 6 stays permanently disabled per ADR-015).
+
+### 6.2 The append — exactly one attempt
+
+Substitute the operator-chosen bounded values for the record
+fields. None of the placeholder values below may contain a
+secret. The marker passed to `hashlib.sha256(...)` must be a
+non-secret bounded synthetic string.
+
+```bash
+cd /root/trading-agent
+ADE_GENERATED_LANE_WRITER_ENABLED=true python3 - <<'PY'
+import hashlib
+import json
+
+from reporting import development_generated_lane_writer as w
+
+marker = "<operator-chosen-non-secret-marker>"
+evidence_hash = hashlib.sha256(marker.encode("utf-8")).hexdigest()
+
+now = w._utcnow()
+record = {
+    "generated_candidate_id": "<operator-chosen-bounded-id>",
+    "source_module": "operator_paced_smoke",
+    "source_id": "<operator-chosen-bounded-id>",
+    "proposed_kind": "<one of: bugfix | delegation | e2e_proof | unknown>",
+    "proposed_title": "<bounded, diagnostic title>",
+    "proposed_summary": (
+        "<bounded summary; must NOT contain a decision verb; "
+        "must NOT instruct admission/execution/promotion/merge/deploy>"
+    ),
+    "evidence_hash": evidence_hash,
+    "admission_preview": "generated_seed_written",
+    "block_reason": "none",
+    "would_require_operator_go": True,
+    "generated_at_utc": now,
+    "writer_module_version": w.MODULE_VERSION,
+}
+
+envelope = w.append_generated_seed_record(record)
+print(json.dumps(envelope, indent=2, sort_keys=True))
+PY
+```
+
+**Required envelope shape.** The printed envelope must satisfy:
+
+* `status = "written"`
+* `stop_status = "none"`
+* `writer_enabled = true`
+* `generated_candidate_id = <the operator-chosen id>`
+* `generated_seed_path = "/root/trading-agent/generated_seed.jsonl"`
+* `audit_path` ends in `logs/development_generated_lane_writer/audit.jsonl`
+* `warnings = []`
+* every `discipline_invariants.*` value matches the closed
+  defaults of the writer module (`default_disabled=true`,
+  `admits_queue_items=false`, `executes_work=false`,
+  `creates_branches=false`, `opens_prs=false`,
+  `merges_prs=false`, `deploys=false`, `calls_network=false`,
+  `uses_subprocess=false`, `touches_step5_flags=false`,
+  `level6_enabled=false`, `writes_seed_jsonl=false`,
+  `writes_delegation_seed_jsonl=false`,
+  `writes_only_generated_seed_jsonl=true`).
+
+**Stop conditions.** Any deviation from the table above triggers
+a hard stop. Do **NOT**:
+
+* retry the heredoc with the same record;
+* modify the record body and retry;
+* attempt a container-side fallback.
+
+Instead: paste the envelope back to the operator's review
+channel; classify the failure mode against the writer's closed
+`WRITER_BLOCK_REASONS` and `AUDIT_ATTEMPT_KINDS` vocabularies;
+decide next steps separately.
+
+### 6.3 Confirm the per-command env prefix did not leak
+
+```bash
+echo "post_command_env=${ADE_GENERATED_LANE_WRITER_ENABLED-unset}"
+```
+
+**Expected.** Exactly `post_command_env=unset`. Anything else
+means the per-command prefix leaked into the shell session;
+`unset ADE_GENERATED_LANE_WRITER_ENABLED` before any further
+command.
+
+---
+
+## 7. Required post-write remount
+
+After the host-side atomic-replace, the **inode** that backs
+`/root/trading-agent/generated_seed.jsonl` is **new** (the
+writer's atomic-replace produced a fresh inode and renamed it
+into place). The container's file-level bind mount still
+remembers the **old** inode (now unlinked from the host
+directory entry but kept alive by the open mount reference).
+The container will see a stale 0-line view until the dashboard
+is recreated.
+
+### 7.1 Recreate the dashboard service
+
+```bash
+cd /root/trading-agent
+docker compose -p trading-agent up -d --force-recreate dashboard
+```
+
+**Expected.** The dashboard service restarts cleanly. Other
+services (nginx, agent) are not recreated by this command.
+
+### 7.2 Verify host + container convergence
+
+```bash
+wc -l /root/trading-agent/generated_seed.jsonl
+docker compose -p trading-agent exec dashboard \
+   wc -l /app/generated_seed.jsonl
+```
+
+**Expected.** Identical line counts on both sides.
+
+```bash
+stat --printf 'host inode=%i device=%d size=%s path=%n\n' \
+   /root/trading-agent/generated_seed.jsonl
+docker compose -p trading-agent exec dashboard \
+   stat --printf 'ctr  inode=%i device=%d size=%s path=%n\n' \
+   /app/generated_seed.jsonl
+```
+
+**Expected.** Identical `inode` and `device` values. (After the
+remount the bind mount resolves the new inode; the two `stat`
+lines should agree byte-for-byte except the path string.)
+
+### 7.3 Verify dashboard writer status matches the host
+
+```bash
+docker compose -p trading-agent exec dashboard \
+   python3 -m reporting.development_generated_lane_writer --no-write \
+   | grep -E '"(writer_enabled|record_count|step5_implementation_allowed|step5_enabled_substage|level6_enabled)"'
+```
+
+**Expected.** `writer_enabled=true`, `record_count` equal to the
+host's line count, Step 5 / Level 6 invariants intact (Level 6 stays permanently disabled per ADR-015).
+
+### 7.4 Confirm invariants unchanged after write + remount
+
+```bash
+python3 -m reporting.development_step5_loop --no-write \
+   | grep -E '"(step5_implementation_allowed|step5_enabled_substage)"'
+python3 -m reporting.development_operational_digest --no-write \
+   | grep -E '"step5_implementation_allowed"'
+python3 -m reporting.development_merge_preflight --no-write \
+   | grep -E '"(dry_run_only|live_merge_implemented|deploy_coupled|level6_enabled|step5_implementation_allowed|step5_enabled_substage|candidate_count)"'
+```
+
+**Expected.** Every closed-vocab value matches the rest-state
+values documented in
+[`autonomous_development_baseline_observation.md`](autonomous_development_baseline_observation.md).
+No invariant flipped by the write or by the remount.
+
+### 7.5 Confirm forbidden seed files remain absent
+
+```bash
+ls -la /root/trading-agent/seed.jsonl 2>&1 | head -3
+ls -la /root/trading-agent/delegation_seed.jsonl 2>&1 | head -3
+docker compose -p trading-agent exec dashboard \
+   sh -c 'ls -la /app/seed.jsonl 2>&1; ls -la /app/delegation_seed.jsonl 2>&1' \
+   | head -10
+```
+
+**Expected.** Every path reports `No such file or directory`.
+
+---
+
+## 8. Required invariants every write must preserve
+
+The runbook's safe procedure is operationally green only when
+every closed-vocab assertion below holds **before and after**
+the write + remount:
+
+```
+step5_implementation_allowed = false
+STEP5_ENABLED_SUBSTAGE        = "none"
+level6_enabled                = false
+dry_run_only                  = true
+live_merge_implemented        = false
+deploy_coupled                = false
+```
+
+Plus:
+
+* `generated_seed.jsonl` line count advanced by exactly **one**
+  row (the just-appended record) or remained the same on
+  failure.
+* `audit.jsonl` line count advanced by exactly **one** row (the
+  closed-vocab `attempt_kind` for the outcome) regardless of
+  success or failure mode.
+* `seed.jsonl` and `delegation_seed.jsonl` remain absent.
+* No queue admission row was created in any A17 / proposal /
+  queue artefact.
+* No execution surface fired.
+* No PR / branch / merge / deploy / push / `gh` invocation
+  fired.
+* No env-flag enable / disable other than the per-command env
+  prefix on the single writer-Python process.
+
+If any invariant fails, the writer's path-sentinel and
+default-deny behaviour already refused or rolled back the write;
+the operator must still verify the closed-vocab values above
+before treating the write as complete.
+
+---
+
+## 9. Rollback — operator-only, manual
+
+The runbook does **not** authorise any agent code to remove a
+diagnostic row from `generated_seed.jsonl`. The writer module
+exposes **no** delete API; the file's append-only forensic
+posture is a hard invariant.
+
+If the operator determines that a diagnostic row must be
+removed (e.g. it was written with a wrong synthetic field and
+will confuse a future A18c projector), the only authorised path
+is:
+
+1. **Stop the dashboard service** so the bind mount is released:
+   `docker compose -p trading-agent stop dashboard`.
+2. **Inspect the existing file** and confirm the exact row to
+   remove: `cat /root/trading-agent/generated_seed.jsonl`.
+3. **Truncate** the file manually with a single redirect:
+   `: > /root/trading-agent/generated_seed.jsonl` (or use any
+   text editor to remove the single line).
+4. **Append a human-readable audit-trail note** to the audit log
+   marking the operator-paced rollback:
+   ```bash
+   ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+   printf '%s\n' '{"attempt_kind":"operator_manual_truncation_note","stop_status":"none","generated_candidate_id":"<id>","operator_note":"manual truncation per a18b_writer_host_side_write_runbook §9","generated_at_utc":"'"$ts"'"}' \
+      >> /root/trading-agent/logs/development_generated_lane_writer/audit.jsonl
+   ```
+   (The audit append above is a **plain text JSON line** the
+   operator hand-writes; it is not produced by the writer module.
+   The writer module's audit schema does not include an
+   `operator_manual_truncation_note` `attempt_kind` — the manual
+   note documents the rollback for forensic purposes but is
+   intentionally outside the writer's closed-vocab list. A
+   future A18c admission projector, if/when implemented, will
+   ignore audit rows whose `attempt_kind` is not in the writer
+   module's `AUDIT_ATTEMPT_KINDS` tuple.)
+5. **Recreate the dashboard** so the bind mount resolves the
+   truncated file:
+   `docker compose -p trading-agent up -d --force-recreate dashboard`.
+6. **Verify** convergence via §7.2 / §7.3 / §7.4. The host and
+   container line counts should both be zero (or the post-removal
+   row count); writer `record_count=0` (or the post-removal
+   count); Step 5 / Level 6 invariants intact (Level 6 stays permanently disabled per ADR-015).
+
+The runbook does **not** authorise any agent action under §9. A
+truncation is an operator decision; the agent participates only
+by documenting the procedure here.
+
+---
+
+## 10. Step 5 and Level 6 invariants
+
+Level 6 is **permanently disabled** per ADR-015 §Doctrine 1 and
+is **never** raised by this runbook. The six invariants below
+are re-asserted on every line of this runbook:
+
+```
+step5_implementation_allowed = false
+STEP5_ENABLED_SUBSTAGE        = "none"
+level6_enabled                = false
+dry_run_only                  = true
+live_merge_implemented        = false
+deploy_coupled                = false
+```
+
+The writer module emits these literal values into its
+`_DISCIPLINE_INVARIANTS` dict on every envelope. This runbook
+does not authorise the operator to flip any of them. Any future
+change requires a separate operator-authored ADR and a separate
+PR.
+
+---
+
+## 11. What this runbook does NOT do
+
+* Does **not** authorise any agent code to perform a write. The
+  write is a separate Phase-2-shaped operator-paced action.
+* Does **not** modify the writer module, its constants, its
+  schema, its env-gate, its sentinels, or its closed
+  vocabularies.
+* Does **not** modify `docker-compose.yml`,
+  `docker-compose.override.yml`, or the established file-level
+  bind mount. Any migration to a directory-level bind mount
+  (Option β2 of the post-Phase-2 design notes) is a **separate**
+  operator-paced action with its own scope proposal.
+* Does **not** activate A18c. A18c remains plan-only, gated by
+  the explicit operator-go phrase `GO A18c plan-only`.
+* Does **not** plan, implement, or activate any Step 5 substage.
+* Does **not** introduce N5b Phase 2 token-bound dry-run, Phase
+  3 sacrificial-repo live merge, or Phase 4 production merge.
+* Does **not** grant ADE permission to merge any PR, push to
+  `main`, force-push, deploy, mint an approval token, verify an
+  approval token, send a real push notification, or open / close
+  / comment on any PR.
+* Does **not** mark any roadmap status field complete or
+  advance any phase counter.
+
+---
+
+## 12. Cross-references
+
+* [`docs/governance/development_generated_lane.md`](development_generated_lane.md)
+  — A18a / A18b governance and writer contract. Cross-references
+  back to this runbook for the operational caveat.
+* [`docs/governance/autonomous_development_baseline_observation.md`](autonomous_development_baseline_observation.md)
+  — Phase 0 baseline observation chain; the rest state to which
+  every A18b write must return.
+* [`docs/governance/n5b_merge_execution_plan.md`](n5b_merge_execution_plan.md)
+  — N5b governance / plan-only doc; reasserts the live-merge
+  invariants this runbook also preserves.
+* [`docs/governance/n5b_merge_preflight_runbook.md`](n5b_merge_preflight_runbook.md)
+  — sister runbook for the N5b Phase 1 dry-run preflight refresh
+  chain.
+* [`docs/governance/n4b_runtime_activation.md`](n4b_runtime_activation.md)
+  — N4b Phase B runtime activation runbook (already complete).
+* [`docs/adr/ADR-014-truth-authority-settlement.md`](../adr/ADR-014-truth-authority-settlement.md)
+  — authority doctrine.
+* [`docs/adr/ADR-015-claude-agent-governance.md`](../adr/ADR-015-claude-agent-governance.md)
+  — Level 6 permanently-disabled doctrine.
+* [`docs/governance/execution_authority.md`](execution_authority.md)
+  — per-action authority decisions.
+* [`docs/governance/no_touch_paths.md`](no_touch_paths.md) — the
+  protected paths.

--- a/docs/governance/development_generated_lane.md
+++ b/docs/governance/development_generated_lane.md
@@ -407,3 +407,7 @@ itself remains unchanged:
 * Level 6 stays permanently disabled.
 * A18c (A17 admission integration) remains **not implemented**
   and requires its own explicit operator go-signal.
+
+> For the operational caveat that A18b writes must run host-side
+> while the canonical seed file is a file-level bind mount, see
+> [`a18b_writer_host_side_write_runbook.md`](a18b_writer_host_side_write_runbook.md).

--- a/tests/unit/test_a18b_writer_host_side_write_runbook.py
+++ b/tests/unit/test_a18b_writer_host_side_write_runbook.py
@@ -1,0 +1,581 @@
+"""Pin-tests for the A18b host-side write + remount operator runbook.
+
+These tests do **not** activate any runtime gate. They pin that the
+operator runbook at
+``docs/governance/a18b_writer_host_side_write_runbook.md``:
+
+* exists, is non-trivial, and is plain markdown;
+* references the canonical host seed path
+  ``/root/trading-agent/generated_seed.jsonl`` exactly;
+* references the canonical container path
+  ``/app/generated_seed.jsonl`` exactly;
+* references the A18b writer env gate
+  ``ADE_GENERATED_LANE_WRITER_ENABLED=true``;
+* references the public writer API name
+  ``append_generated_seed_record``;
+* references ``os.replace`` (writer atomic-replace caveat);
+* references ``EBUSY`` and the kernel message
+  ``Device or resource busy``;
+* references the dashboard recreate / remount command shape;
+* re-asserts the Step 5 + Level 6 + dry-run / live-merge /
+  deploy-coupled invariants explicitly;
+* contains a Phase-2 verified state section;
+* contains a §"What this runbook does NOT do" block;
+* does NOT instruct an in-container append while the file-level
+  bind mount remains in place (the fenced-code-block negative
+  pins enforce this);
+* does NOT enable Step 5, Level 6, N5b live execute, or any
+  approval-token mint/verify CLI;
+* does NOT reference the unsupported ``--status`` writer CLI
+  flag;
+* does NOT embed a PEM block, a hex-64 inline-code literal, or
+  a bearer-token header;
+* cross-references the canonical doctrine documents.
+
+This is a documentation pin-test, not a runtime gate. The writer
+module is not modified by this PR.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUNBOOK_PATH = (
+    REPO_ROOT
+    / "docs"
+    / "governance"
+    / "a18b_writer_host_side_write_runbook.md"
+)
+
+
+def _runbook_text() -> str:
+    return RUNBOOK_PATH.read_text(encoding="utf-8")
+
+
+# A markdown fenced code block opens with a line starting with ```
+# and closes with a matching line. The negative pin-tests below
+# scan only the *contents* of these blocks, because the runbook
+# necessarily quotes every forbidden imperative in its narrative
+# negative list and those mentions are legitimate. Operators only
+# copy commands out of fenced blocks, so the relevant safety
+# concern is "do not let a fenced block contain a mutating shape".
+_FENCE_RE = re.compile(r"```[^\n]*\n(.*?)```", re.DOTALL)
+
+
+def _runbook_code_blocks() -> str:
+    """Concatenated text of every fenced code block in the runbook.
+
+    Lower-cased so the imperative-shape pins can be written in
+    lowercase without per-phrase ``.lower()`` calls."""
+    text = _runbook_text()
+    return "\n".join(m.group(1) for m in _FENCE_RE.finditer(text)).lower()
+
+
+# ---------------------------------------------------------------------------
+# Existence + shape
+# ---------------------------------------------------------------------------
+
+
+def test_runbook_file_exists() -> None:
+    assert RUNBOOK_PATH.is_file(), (
+        "A18b host-side write runbook missing: "
+        f"{RUNBOOK_PATH}"
+    )
+
+
+def test_runbook_is_non_empty() -> None:
+    text = _runbook_text()
+    assert len(text) > 4000, (
+        f"A18b host-side write runbook is too short ({len(text)} "
+        "bytes); the runbook must document the full procedure."
+    )
+
+
+def test_runbook_is_markdown() -> None:
+    text = _runbook_text()
+    assert text.lstrip().startswith("# "), (
+        "runbook must be a markdown file beginning with a top-level "
+        "heading."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Canonical paths and constants the runbook must reference.
+# ---------------------------------------------------------------------------
+
+
+def test_runbook_references_canonical_host_seed_path() -> None:
+    text = _runbook_text()
+    assert "/root/trading-agent/generated_seed.jsonl" in text, (
+        "runbook must reference the canonical host seed path "
+        "'/root/trading-agent/generated_seed.jsonl' exactly."
+    )
+
+
+def test_runbook_references_canonical_container_seed_path() -> None:
+    text = _runbook_text()
+    assert "/app/generated_seed.jsonl" in text, (
+        "runbook must reference the canonical container seed path "
+        "'/app/generated_seed.jsonl' exactly."
+    )
+
+
+def test_runbook_references_env_gate_value_pair() -> None:
+    text = _runbook_text()
+    assert "ADE_GENERATED_LANE_WRITER_ENABLED=true" in text, (
+        "runbook must reference the env-gate value pair "
+        "'ADE_GENERATED_LANE_WRITER_ENABLED=true'."
+    )
+
+
+def test_runbook_references_public_api_function_name() -> None:
+    text = _runbook_text()
+    assert "append_generated_seed_record" in text, (
+        "runbook must reference the public writer API name "
+        "'append_generated_seed_record'."
+    )
+
+
+def test_runbook_references_os_replace_caveat() -> None:
+    text = _runbook_text()
+    assert "os.replace" in text, (
+        "runbook must reference 'os.replace' (the atomic-replace "
+        "site that triggers EBUSY across the file-level bind "
+        "mount)."
+    )
+
+
+def test_runbook_references_ebusy_root_cause() -> None:
+    text = _runbook_text()
+    assert "EBUSY" in text, (
+        "runbook must reference EBUSY (the kernel error code)."
+    )
+    assert "Device or resource busy" in text, (
+        "runbook must reference 'Device or resource busy' (the "
+        "human-readable kernel message)."
+    )
+
+
+def test_runbook_references_dashboard_remount_command_shape() -> None:
+    text = _runbook_text()
+    assert (
+        "docker compose -p trading-agent up -d --force-recreate dashboard"
+        in text
+    ), (
+        "runbook must reference the canonical dashboard "
+        "recreate / remount command shape."
+    )
+
+
+def test_runbook_writer_constants_agree_with_module() -> None:
+    """Defense in depth: when the writer module changes its env
+    var name or seed path constant, this test fails until the
+    runbook is re-aligned."""
+    from reporting import (  # noqa: WPS433 — local import intentional
+        development_generated_lane_writer as w,
+    )
+
+    assert w.ENV_WRITER_ENABLED == "ADE_GENERATED_LANE_WRITER_ENABLED"
+    assert w.GENERATED_SEED_PATH.name == "generated_seed.jsonl"
+    # The host-side absolute path documented in the runbook is the
+    # canonical VPS path; on local checkouts the writer module's
+    # constant is repo-root-relative. We assert the basename agrees;
+    # the runbook's path is the operational VPS deployment path.
+    text = _runbook_text()
+    assert w.GENERATED_SEED_PATH.name in text
+
+
+# ---------------------------------------------------------------------------
+# Closed-vocab discipline invariants
+# ---------------------------------------------------------------------------
+
+
+def test_runbook_states_step5_implementation_allowed_false() -> None:
+    text = _runbook_text()
+    assert "step5_implementation_allowed" in text, (
+        "runbook must reaffirm step5_implementation_allowed = false."
+    )
+    idx = text.find("step5_implementation_allowed")
+    nearby = text[idx : idx + 200].lower()
+    assert "false" in nearby, (
+        "step5_implementation_allowed must be stated as `false` "
+        "explicitly in the runbook."
+    )
+
+
+def test_runbook_states_step5_enabled_substage_none() -> None:
+    text = _runbook_text()
+    assert (
+        "STEP5_ENABLED_SUBSTAGE" in text
+        or "step5_enabled_substage" in text
+    ), "runbook must reaffirm the STEP5_ENABLED_SUBSTAGE invariant."
+    lowered = text.lower()
+    assert '"none"' in text or " none" in lowered, (
+        "STEP5_ENABLED_SUBSTAGE must be stated as 'none'."
+    )
+
+
+def test_runbook_states_level_6_permanently_disabled() -> None:
+    text = _runbook_text().lower()
+    assert "level 6" in text, "runbook must reaffirm Level 6 doctrine."
+    assert "permanently disabled" in text, (
+        "runbook must state Level 6 remains permanently disabled."
+    )
+
+
+def test_runbook_states_dry_run_only_invariant() -> None:
+    text = _runbook_text()
+    assert "dry_run_only" in text, (
+        "runbook must restate the dry_run_only invariant."
+    )
+    idx = text.find("dry_run_only")
+    nearby = text[idx : idx + 200].lower()
+    assert "true" in nearby, (
+        "dry_run_only must be stated as `true` explicitly."
+    )
+
+
+def test_runbook_states_live_merge_implemented_false() -> None:
+    text = _runbook_text()
+    assert "live_merge_implemented" in text, (
+        "runbook must restate the live_merge_implemented invariant."
+    )
+    idx = text.find("live_merge_implemented")
+    nearby = text[idx : idx + 200].lower()
+    assert "false" in nearby, (
+        "live_merge_implemented must be stated as `false`."
+    )
+
+
+def test_runbook_states_deploy_coupled_false() -> None:
+    text = _runbook_text()
+    assert "deploy_coupled" in text, (
+        "runbook must restate the deploy_coupled invariant."
+    )
+    idx = text.find("deploy_coupled")
+    nearby = text[idx : idx + 200].lower()
+    assert "false" in nearby, (
+        "deploy_coupled must be stated as `false`."
+    )
+
+
+def test_runbook_contains_combined_invariants_block() -> None:
+    """The runbook must somewhere state the six core invariants in
+    a single close block so the operator can read them together."""
+    text = _runbook_text().lower()
+    needles = (
+        "step5_implementation_allowed",
+        "step5_enabled_substage",
+        "level6_enabled",
+        "dry_run_only",
+        "live_merge_implemented",
+        "deploy_coupled",
+    )
+    first_idx = text.find(needles[0])
+    while first_idx != -1:
+        window = text[first_idx : first_idx + 1200]
+        if all(n in window for n in needles):
+            return
+        first_idx = text.find(needles[0], first_idx + 1)
+    raise AssertionError(
+        "runbook must state all six invariants "
+        f"({needles!r}) within a single ~1.2 KiB window."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Phase-2 verified state + §"What this runbook does NOT do".
+# ---------------------------------------------------------------------------
+
+
+def test_runbook_documents_phase_2_verified_state() -> None:
+    text = _runbook_text().lower()
+    assert "phase 2" in text or "phase-2" in text, (
+        "runbook must reference the Phase 2 verified state."
+    )
+    assert "verified" in text or "rest state" in text or "smoke" in text, (
+        "runbook must state that Phase 2 closed in a verified rest "
+        "state."
+    )
+
+
+def test_runbook_contains_what_this_runbook_does_not_do_section() -> None:
+    text = _runbook_text().lower()
+    assert "does not do" in text or "does **not** do" in text, (
+        "runbook must contain a 'What this runbook does NOT do' "
+        "section."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Negative pins — the runbook's executable surface (its fenced
+# code blocks) must contain no in-container append, no Step 5 /
+# Level 6 / N5b-live-execute flip, no GitHub mutation command,
+# no token mint/verify CLI, no unsupported writer CLI flag.
+# ---------------------------------------------------------------------------
+
+
+def test_runbook_code_blocks_do_not_attempt_in_container_append() -> None:
+    """The runbook is the operationally-pinned host-side procedure.
+    Its executable surface must NOT contain any container-side
+    append invocation while the file-level bind mount remains in
+    place. The narrative §"Forbidden shape" section may discuss the
+    forbidden command in prose; we scan only the executable surface
+    via fenced code blocks."""
+    code = _runbook_code_blocks()
+    forbidden = (
+        # Direct CLI write attempt (the CLI is status-only but the
+        # negative pin defends against future drift).
+        "docker compose -p trading-agent exec dashboard "
+        "python3 -m reporting.development_generated_lane_writer "
+        "--write",
+        # Any in-container python heredoc that imports the writer
+        # and calls append_generated_seed_record — verbatim shape.
+        "docker compose -p trading-agent exec dashboard python3 - <<",
+        "docker compose -p trading-agent exec -t dashboard python3 - <<",
+        "docker compose exec dashboard python3 - <<",
+    )
+    for phrase in forbidden:
+        assert phrase not in code, (
+            "runbook code block contains a forbidden in-container "
+            f"append shape: {phrase!r}"
+        )
+
+
+def test_runbook_code_blocks_do_not_use_unsupported_status_flag() -> None:
+    """The writer CLI has no '--status' flag. The runbook must
+    never reference one in executable form."""
+    code = _runbook_code_blocks()
+    forbidden = (
+        "development_generated_lane_writer --status",
+        "python3 -m reporting.development_generated_lane_writer --status",
+        "python -m reporting.development_generated_lane_writer --status",
+    )
+    for phrase in forbidden:
+        assert phrase not in code, (
+            "runbook code block contains the unsupported '--status' "
+            f"flag: {phrase!r}"
+        )
+
+
+def test_runbook_code_blocks_do_not_enable_n5b_live_execute() -> None:
+    code = _runbook_code_blocks()
+    forbidden = (
+        "ade_n5b_live_execute_enabled=true",
+        'ade_n5b_live_execute_enabled="true"',
+        "export ade_n5b_live_execute_enabled",
+    )
+    for phrase in forbidden:
+        assert phrase not in code, (
+            "runbook code block must NOT enable N5b live execute: "
+            f"{phrase!r}"
+        )
+
+
+def test_runbook_code_blocks_contain_no_real_merge_command() -> None:
+    code = _runbook_code_blocks()
+    forbidden = (
+        "gh pr merge --squash",
+        "gh pr merge --rebase",
+        "gh pr merge --merge",
+        "gh pr review --approve",
+        "gh pr review --request-changes",
+        "git merge --no-ff",
+        "git push --force",
+        "git push -f ",
+        "git push origin main",
+        "--admin",
+    )
+    for phrase in forbidden:
+        assert phrase not in code, (
+            "runbook code block contains a forbidden "
+            f"mutating-command shape: {phrase!r}"
+        )
+
+
+def test_runbook_code_blocks_do_not_flip_step5_or_level6() -> None:
+    code = _runbook_code_blocks()
+    forbidden = (
+        "step5_implementation_allowed = true",
+        'step5_implementation_allowed="true"',
+        "step5_implementation_allowed=true",
+        'step5_enabled_substage = "5.0"',
+        'step5_enabled_substage = "5.1"',
+        'step5_enabled_substage = "5.2"',
+        'step5_enabled_substage="5.0"',
+        'step5_enabled_substage="5.1"',
+        'step5_enabled_substage="5.2"',
+        "level6_enabled = true",
+        "level6_enabled=true",
+    )
+    for phrase in forbidden:
+        assert phrase not in code, (
+            "runbook code block contains a forbidden "
+            f"authority-escalation flip: {phrase!r}"
+        )
+
+
+def test_runbook_code_blocks_do_not_instruct_token_mint_or_verify() -> None:
+    code = _runbook_code_blocks()
+    forbidden = (
+        "approval_token_runtime.mint",
+        "approval_token_runtime.verify",
+        "mint_approval_token",
+        "verify_approval_token",
+        "--mint-token",
+        "--verify-token",
+    )
+    for phrase in forbidden:
+        assert phrase not in code, (
+            "runbook code block contains a forbidden token "
+            f"mint/verify invocation: {phrase!r}"
+        )
+
+
+def test_runbook_code_blocks_do_not_authorise_a18c_implementation() -> None:
+    """A18c remains plan-only at this stage. The runbook may
+    reference A18c (it does — to document that A18c is plan-only)
+    but its executable surface must NOT contain an imperative
+    that authorises A18c implementation or activation."""
+    code = _runbook_code_blocks()
+    forbidden = (
+        "implement a18c",
+        "build a18c",
+        "ship a18c",
+        "enable a18c",
+        "a18c is implemented",
+        "a18c is enabled",
+        "ade_generated_lane_a18c_enabled=true",
+    )
+    for phrase in forbidden:
+        assert phrase not in code, (
+            "runbook code block contains a phrase that would "
+            f"authorise A18c implementation: {phrase!r}"
+        )
+
+
+def test_runbook_does_not_instruct_touching_no_touch_paths() -> None:
+    text = _runbook_text().lower()
+    forbidden_imperatives = (
+        "edit .claude",
+        "modify .claude",
+        "write to .claude",
+        "edit .gitleaks.toml",
+        "modify .gitleaks.toml",
+        "disable .gitleaks.toml",
+        "weaken .gitleaks.toml",
+        "edit seed.jsonl",
+        "modify seed.jsonl",
+        "write to seed.jsonl",
+        "append to seed.jsonl",
+        "edit delegation_seed.jsonl",
+        "modify delegation_seed.jsonl",
+        "write to delegation_seed.jsonl",
+        "append to delegation_seed.jsonl",
+        "weaken the test",
+        "weaken the tests",
+        "skip the gate",
+        "bypass the hook",
+        "bypass hooks",
+    )
+    for phrase in forbidden_imperatives:
+        assert phrase not in text, (
+            "runbook contains a forbidden no-touch-path / "
+            f"safety-bypass imperative: {phrase!r}"
+        )
+
+
+def test_runbook_does_not_instruct_deploy() -> None:
+    text = _runbook_text().lower()
+    forbidden = (
+        "trigger the deploy workflow",
+        "trigger deploy workflow",
+        "force the deploy",
+        "couple this to deploy",
+    )
+    for phrase in forbidden:
+        assert phrase not in text, (
+            "runbook contains a forbidden deploy-coupling "
+            f"instruction: {phrase!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Negative pins — no secret material.
+# ---------------------------------------------------------------------------
+
+
+def test_runbook_contains_no_pem_secret_block() -> None:
+    text = _runbook_text()
+    dashes = "-" * 5
+    pem_kinds = (
+        "PRIVATE KEY",
+        "EC PRIVATE KEY",
+        "RSA PRIVATE KEY",
+        "OPENSSH PRIVATE KEY",
+    )
+    forbidden = [f"{dashes}BEGIN {kind}{dashes}" for kind in pem_kinds]
+    for marker in forbidden:
+        assert marker not in text, (
+            f"runbook contains a PEM-style secret block: {marker!r}"
+        )
+
+
+def test_runbook_contains_no_inline_hex_64_secret() -> None:
+    """A 64-character hex run inside backticks would look like a
+    copy-pasted ``openssl rand -hex 32`` output. The runbook
+    documents read-only procedure commands and a synthetic-marker
+    SHA-256 example; the example is computed at runtime by the
+    operator's shell, not embedded as a literal in the doc."""
+    text = _runbook_text()
+    pattern = re.compile(r"`[0-9a-fA-F]{64}`")
+    matches = pattern.findall(text)
+    assert not matches, (
+        f"runbook embeds a hex-64 literal that looks like a secret: "
+        f"{matches!r}"
+    )
+
+
+def test_runbook_contains_no_bearer_token_header() -> None:
+    text = _runbook_text().lower()
+    forbidden = (
+        "authorization: bearer ",
+        "x-api-key: ",
+        "ghp_",
+        "github_pat_",
+        "sk-ant-",
+    )
+    for pat in forbidden:
+        assert pat not in text, (
+            f"runbook contains a credential-shaped string: {pat!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Cross-reference pins — the runbook must link back to the doctrine.
+# ---------------------------------------------------------------------------
+
+
+def test_runbook_cross_references_development_generated_lane_doc() -> None:
+    text = _runbook_text()
+    assert "development_generated_lane.md" in text, (
+        "runbook must cross-reference the A18a/A18b governance doc."
+    )
+
+
+def test_runbook_cross_references_baseline_observation_runbook() -> None:
+    text = _runbook_text()
+    assert "autonomous_development_baseline_observation.md" in text, (
+        "runbook must cross-reference the Phase-0 baseline "
+        "observation runbook."
+    )
+
+
+def test_runbook_cross_references_adr_015() -> None:
+    text = _runbook_text()
+    assert "ADR-015" in text, (
+        "runbook must cross-reference ADR-015 (Level 6 "
+        "permanently-disabled doctrine)."
+    )


### PR DESCRIPTION
## Summary

Phase 2 follow-up. Codifies the EBUSY incident's root cause and
the operationally-pinned host-side write procedure so any future
A18b `generated_seed.jsonl` append follows the same safe steps the
operator used to close Phase 2 green.

This is **Item 1** of today's three-item ordered execution
(runbook now; Phase 3 A18c plan-only next, only on operator-go;
Phase 4 A18c implementation only on a separate operator-go).

## Scope (strictly docs + pin-tests — three files)

| File | Action |
|---|---|
| `docs/governance/a18b_writer_host_side_write_runbook.md` | NEW |
| `tests/unit/test_a18b_writer_host_side_write_runbook.py` | NEW (35 tests) |
| `docs/governance/development_generated_lane.md` | EDIT — one four-line cross-reference block appended at the bottom of section 7.12 |

## Runbook contents

| Section | Pin |
|---|---|
| §1 Purpose | EBUSY incident + the writer's atomic-replace site |
| §2 Hard constraints | full negative list (no merge / deploy / token / A18c / Step 5 / Level 6) |
| §3 Verified Phase-2 state | 1 row, 1 audit row, `attempt_kind=written`, invariants intact |
| §4 EBUSY root cause | `os.replace` site at L514; file-level bind mount incompatibility |
| §5 Forbidden shape | no in-container append while the bind mount remains |
| §6 Safe host-side procedure | per-command env prefix + writer public API + one attempt |
| §7 Required post-write remount | `up -d --force-recreate dashboard`; verify host+container converge |
| §8 Required invariants | six-invariant block restated |
| §9 Rollback — operator-only, manual | explicit; no agent code path |
| §10 Step 5 + Level 6 invariants | restated |
| §11 What this runbook does NOT do | full denial list |
| §12 Cross-references | ADR-015, baseline observation runbook, A18a/A18b doc, etc. |

## Pin-test highlights

* canonical paths verbatim:
  `/root/trading-agent/generated_seed.jsonl` and
  `/app/generated_seed.jsonl`
* env-gate value pair: `ADE_GENERATED_LANE_WRITER_ENABLED=true`
* public API: `append_generated_seed_record`
* `os.replace` caveat reference
* `EBUSY` + `Device or resource busy` references
* dashboard remount command shape verbatim
* writer module constants re-validated at test time
  (defense-in-depth against future drift in
  `GENERATED_SEED_PATH` / `ENV_WRITER_ENABLED`)
* six discipline invariants within a single ~1.2 KiB window
* Phase-2 verified state section present
* \"What this runbook does NOT do\" section present
* negative pins scan **fenced code blocks only** (narrative
  negative prose stays legitimate): no in-container append, no
  unsupported `--status` writer flag, no N5b live-execute env
  enable, no Step 5 flip, no Level 6 raise, no GitHub-mutation
  command shape, no approval-token mint/verify CLI, no A18c
  implementation imperative
* no PEM block, no hex-64 inline literal, no
  Authorization-Bearer header
* cross-references for `development_generated_lane.md`,
  `autonomous_development_baseline_observation.md`, ADR-015

## What is NOT touched

* `reporting/**` (no writer-module change)
* `dashboard/**`, `frontend/**`, `scripts/**`,
  `.github/workflows/**`
* `.claude/**`, `.gitleaks.toml`, `research/**`, `live/**`,
  `paper/**`, `shadow/**`, `risk/**`, `broker/**`, `execution/**`
* No compose file edit (Option α is the runbook posture; the
  existing file-level bind mount stays in place; Option β2
  directory-mount migration is a separate operator-paced action
  with its own scope proposal)
* No A18b record written
* No A18c implementation
* No Step 5 substage promotion or flag flip
* No N5b Phase 2/3/4 introduction
* No Level 6 change
* No GitHub mutation; no token mint/verify; no deploy coupling

## Test plan

- [x] `python scripts/governance_lint.py`
- [x] `python -m pytest tests/smoke -q` — 18 passed
- [x] `python -m pytest tests/unit/test_a18b_writer_host_side_write_runbook.py -q` — 35 passed
- [x] `python -m pytest tests/unit/test_autonomous_development_baseline_observation_runbook.py -q` — still green
- [x] `python -m pytest tests/unit/test_n5b_merge_preflight_runbook.py -q` — still green
- [x] `python -m pytest tests/unit/test_n4b_runtime_activation_runbook.py -q` — still green
- [x] `python -m reporting.development_generated_lane_writer --no-write` — invariants green
- [x] `python -m reporting.development_step5_loop --no-write` — invariants green
- [x] `python -m reporting.development_operational_digest --no-write` — invariant green

## Operator verification after merge

Docs + tests only — **no auto-deploy triggered**. No VPS
verification required for the PR itself. The runbook the PR
ships gives the canonical procedure the operator runs **only**
when (and if) a new A18b record write is desired. This PR does
not write any record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)