### PR TITLE
docs(a18c): admission-integration plan-only governance doc (Phase 3)

### DIFF
--- a/docs/governance/development_generated_lane.md
+++ b/docs/governance/development_generated_lane.md
@@ -411,3 +411,6 @@ itself remains unchanged:
 > For the operational caveat that A18b writes must run host-side
 > while the canonical seed file is a file-level bind mount, see
 > [`a18b_writer_host_side_write_runbook.md`](a18b_writer_host_side_write_runbook.md).
+> For the A18c admission-integration plan (plan-only; not
+> implemented), see
+> [`development_generated_lane_a18c_plan.md`](development_generated_lane_a18c_plan.md).

--- a/docs/governance/development_generated_lane_a18c_plan.md
+++ b/docs/governance/development_generated_lane_a18c_plan.md
@@ -1,0 +1,572 @@
+# A18c Admission Integration — Plan-Only Governance Doc
+
+> **Status:** Plan only. Not implemented. No runtime authority.
+> No admission integration exists. No UI action exists. No code
+> module named `reporting.development_generated_lane_a18c` exists
+> on disk.
+>
+> **Authority:** development-governance read-only documentation.
+> This doc grants ADE **zero** new authority. It exists solely to
+> document how a future A18c admission integration could be
+> safely designed if and when the operator separately authorises
+> implementation and then runtime activation. No code in this PR
+> can perform an admission, project a queue candidate, mint an
+> action-bearing token, deploy anything, or change Step 5 state.
+>
+> **Permanent denials (re-asserted):**
+>
+> * `step5_implementation_allowed = false` (unchanged)
+> * `STEP5_ENABLED_SUBSTAGE = "none"` (unchanged)
+> * Level 6 is permanently disabled per ADR-015 §Doctrine 1.
+> * No autonomous merge / deploy / trade / approval.
+> * No approval can happen from a notification click alone.
+> * No `gh pr merge`, no `gh pr review --approve`, no `--admin`,
+>   no branch-protection bypass, no force push, no
+>   `seed.jsonl` / `delegation_seed.jsonl` write, no `.claude/**`
+>   edit, no `.gitleaks.toml` edit, no test weakening, no hook
+>   bypass.
+
+---
+
+## 1. Status
+
+* **Plan only** with respect to *admission integration*. This
+  document remains the design / governance / planning slice for
+  any future A18c implementation.
+* **A18a** dry-run / report-only projector is implemented at
+  [`reporting/development_generated_lane.py`](../../reporting/development_generated_lane.py).
+* **A18b** `generated_seed.jsonl` writer is implemented at
+  [`reporting/development_generated_lane_writer.py`](../../reporting/development_generated_lane_writer.py).
+  It is default-disabled, env-gated, and was exercised in the
+  Phase 2 controlled production write smoke; one diagnostic row
+  exists on disk.
+* **A18c** admission integration is **not implemented**. No
+  module named `reporting.development_generated_lane_a18c`
+  exists. The A17 admission policy module
+  ([`reporting/development_queue_admission_policy.py`](../../reporting/development_queue_admission_policy.py))
+  does not read `generated_seed.jsonl` at any code path; its
+  references to the filename are narrative (docstring) plus the
+  discipline-invariant flag `writes_to_generated_seed_jsonl=False`.
+* **No runtime authority.** This plan doc grants ADE zero new
+  capability. It does not authorise any implementation; that
+  remains a separate operator-paced action.
+* **No UI action exists.** The PWA's `/agent-control/*` surface
+  must not render an A18c admission button pointed at any
+  endpoint.
+* **A18c implementation and any later runtime activation
+  require separate explicit operator-go phrases.** The plan
+  doc identifies them but does not request either of them:
+  * `GO A18c admission integration` — Phase 4 implementation
+    (default-disabled).
+  * `GO enable A18c on VPS` — Phase 4-followup runtime
+    activation (operator-only VPS env-export step).
+
+The companion pin-tests in
+[`tests/unit/test_development_generated_lane_a18c_plan.py`](../../tests/unit/test_development_generated_lane_a18c_plan.py)
+enforce these claims.
+
+---
+
+## 2. Scope
+
+### 2.1 What A18c would eventually cover (if ever approved)
+
+A bounded, default-disabled, env-gated **projector** that reads
+the existing `generated_seed.jsonl` file (which A18b writes) and
+projects eligible rows into the A17 admission flow as an
+additional, closed-vocab admission source.
+
+The hypothetical adapter, if ever built, would:
+
+* read `generated_seed.jsonl` only when the env-gate is
+  exactly `"true"` (default-disabled);
+* project each row into A17's existing closed
+  `ADMISSION_DECISIONS` and `ADMISSION_REASONS` vocabularies
+  with no new decision verbs;
+* never execute work;
+* never mint or verify approval tokens;
+* never open / merge / close a PR;
+* never deploy;
+* never modify `generated_seed.jsonl` (A18b writer is the only
+  authority for that file);
+* never modify `seed.jsonl` or `delegation_seed.jsonl`;
+* never re-classify A17's existing closed vocabularies;
+* never write outside its own bounded artefact path under
+  `logs/development_generated_lane_a18c/` (sentinel-restricted).
+
+A17 remains authoritative. A18c is a **source projector** that
+fans into A17's existing policy — it is not a replacement for
+A17 and not an alternative admission path.
+
+### 2.2 What A18c explicitly does not cover
+
+* **Autonomous execution.** Forbidden. A18c is read-only.
+* **Autonomous PR creation.** Forbidden. PR creation is Step 5.2
+  territory and remains plan-only at this stage.
+* **Autonomous merge.** Forbidden. Live merge is N5b Phase 2/3/4
+  territory and remains plan-only.
+* **Autonomous deploy.** Forbidden. Deploy stays
+  `workflow_run`-chained after Fast pre-merge gate.
+* **Autonomous trading.** Forbidden. A18c is a development-lane
+  surface and never touches `live/**`, `paper/**`, `shadow/**`,
+  `risk/**`, `broker/**`, `execution/**`, `research/**`, or any
+  agent / strategy / portfolio module.
+* **Step 5 substage promotion.** Forbidden. `step5_implementation_allowed`
+  remains `false` and `STEP5_ENABLED_SUBSTAGE` remains `"none"`.
+* **Level 6.** Forbidden. Level 6 is permanently disabled per
+  ADR-015 §Doctrine 1.
+* **Seed-file mutation.** Forbidden. A18c does not write any
+  `seed.jsonl`, `delegation_seed.jsonl`, or `generated_seed.jsonl`
+  record.
+
+---
+
+## 3. Future purpose
+
+When (and only when) Phase 4 implementation lands and an
+operator separately activates the env-gate, A18c will:
+
+1. Read the on-disk `generated_seed.jsonl` rows at the canonical
+   path `/root/trading-agent/generated_seed.jsonl` (host) or
+   `/app/generated_seed.jsonl` (dashboard container — same inode
+   when the file-level bind mount is in place, see §16).
+2. Apply A18b's closed schema validation (12 keys, exact
+   match; otherwise default-deny).
+3. For each valid row, build a closed-schema admission record
+   keyed in A17's existing `ADMISSION_SCHEMA_KEYS` vocabulary —
+   no new keys, no new decision verbs.
+4. Apply A17's existing filters verbatim. No filter is relaxed
+   for the generated-lane source. No "soft" path is added.
+5. Emit a closed envelope under
+   `logs/development_generated_lane_a18c/latest.json` (atomic
+   tmp + `os.replace`; sentinel-restricted to that prefix).
+
+A17 remains the policy authority. A18c does not promote, admit,
+or queue any record — it produces a read-only projection that an
+operator (or a future operator-paced Phase-5 promotion rule)
+inspects and decides about.
+
+---
+
+## 4. Proposed admission schema
+
+A18c's per-row projection record uses **A17's existing closed
+`ADMISSION_SCHEMA_KEYS` vocabulary verbatim**. The full key set
+appears in
+[`reporting/development_queue_admission_policy.py`](../../reporting/development_queue_admission_policy.py)
+and is reproduced here for traceability (any drift in the A17
+module's key set fails the companion pin-test):
+
+```
+candidate_id                              # bounded; derived per §7
+title                                     # from A18b row's proposed_title
+source_document                           # canonical generated_seed.jsonl path
+source_kind                               # "generated_seed_lane"
+roadmap_phase                             # "" (not surfaced by A18b)
+candidate_kind                            # from A18b row's proposed_kind
+required_agent_role                       # "" or "operator" per §5
+risk_level                                # closed A17 vocab; per §5
+target_path                               # "" (not surfaced by A18b)
+upstream_intake_status                    # "generated_seed_present"
+upstream_decision_state                   # closed; per §5
+upstream_execution_authority_decision     # closed; "needs_human" default
+reclassified_execution_authority_decision # closed; mirrors upstream by default
+classification_drift                      # bool; false by default
+human_needed                              # bool; per §5
+human_needed_reason                       # closed A17 vocab
+admission_decision                        # closed A17 ADMISSION_DECISIONS
+admission_reason                          # closed A17 ADMISSION_REASONS
+would_target_lane                         # closed A17 PROMOTION_TARGETS
+already_in_seed_jsonl                     # bool; A17 cross-check
+already_in_delegation_seed                # bool; A17 cross-check
+policy_version                            # A17's MODULE_VERSION
+evaluated_at                              # ISO 8601 UTC, Z-terminated
+```
+
+All scalars bounded; no PR body, no diff content, no commit
+message, no execution payload. The closed key set is exact; any
+key drift fails admission with the closed-vocab equivalent of
+A17's `invalid_record_schema`-style outcome.
+
+---
+
+## 5. Closed admission-decision and admission-reason mapping
+
+A18c MUST emit only values from A17's existing closed
+`ADMISSION_DECISIONS` and `ADMISSION_REASONS` tuples. No new
+decision verb is introduced.
+
+**Decision mapping (default semantics; per-row evaluation):**
+
+| A18b row attribute | A18c default admission_decision |
+|---|---|
+| `would_require_operator_go = True` | `needs_human` (never `admissible`) |
+| `would_require_operator_go = False` and any A17 filter fails | corresponding A17 outcome (`needs_human` / `blocked` / `duplicate_of_existing` / `not_eligible_upstream`) |
+| `would_require_operator_go = False` and every A17 filter passes | `admissible` **only** if a future Phase-5-style operator-approved promotion rule explicitly authorises the row's promotion; otherwise `needs_human` |
+| `evidence_hash` matches an existing seed row's hash | `duplicate_of_existing` with reason `already_in_seed_jsonl` or `already_in_delegation_seed` per A17 cross-check |
+| A18b `proposed_kind` not in closed A18a `PROPOSED_KINDS` | `blocked` with reason `blocked_classification_drift_to_denied` |
+
+**Reason mapping (canonical, partial; see A17's full
+`ADMISSION_REASONS` for the closed set):**
+
+* `would_require_operator_go = True` → `needs_human_authority_decision`.
+* Protected target path detected by A17 filter → `needs_human_protected_target_path`.
+* Upstream intake status non-eligible → `upstream_intake_status_not_eligible`.
+* Already promoted upstream → `already_in_seed_jsonl` / `already_in_delegation_seed`.
+
+The safety property this encodes: **A18b rows with
+`would_require_operator_go=True` can never be auto-admissible.**
+
+---
+
+## 6. Proposed env gate
+
+* **Name:** `ADE_GENERATED_LANE_A18C_ENABLED`
+* **Enabled value:** the exact literal string `true` (case-sensitive,
+  no aliases). Anything else — empty, `"false"`, `"1"`, `"yes"`,
+  `"True"`, `"TRUE"`, unset — leaves A18c in zero-projection
+  mode.
+* **Default:** unset. The env-gate is **not** flipped by this
+  plan PR. It is **not** flipped by the eventual Phase 4
+  implementation PR either. Flipping it is a strictly later,
+  operator-only VPS step gated by `GO enable A18c on VPS`.
+* **Read at call time** (not at import time). The Phase 4
+  implementation must mirror A18b's pattern: read the env
+  mapping at each evaluate call, never cache, never read at
+  import time.
+* **Kill switch.** Unsetting the env-gate immediately returns
+  A18c to zero-projection mode on the next tick. No state
+  persists across the env flip. See §13.
+
+---
+
+## 7. Candidate id and idempotency
+
+A18c-projected candidate ids are deterministic functions of the
+underlying A18b row:
+
+```
+candidate_id_a18c = f"a18c-{generated_candidate_id_a18b}-{evidence_hash_short}"
+```
+
+where `evidence_hash_short = evidence_hash[:16]`. The full
+A18b `generated_candidate_id` and full `evidence_hash` are
+preserved in the A18c admission record's other fields; the
+candidate-id derivation is for downstream-stable identification
+only.
+
+**Idempotency:** A18c may run repeatedly (per-tick under the
+recurring-maintenance scheduler, once Phase 4 ships and is
+activated). The same A18b row across N ticks yields the same
+A18c candidate-id, the same closed schema, the same closed
+admission decision and reason. No tick produces side effects on
+the upstream `generated_seed.jsonl`.
+
+---
+
+## 8. Duplicate handling
+
+* **Duplicate candidate-id within A18c's own projection** → hard
+  reject the second occurrence; closed-vocab equivalent of
+  A18b's `duplicate_candidate_id`. The projection envelope
+  records the rejection but does not delete the prior row from
+  the artefact.
+* **Duplicate `evidence_hash` with a different
+  `generated_candidate_id`** → soft warning (mirrors A18b's
+  `duplicate_evidence_hash` pattern). The projection is still
+  emitted; A17's `already_in_seed_jsonl` / `already_in_delegation_seed`
+  filters fire if the duplicate evidence-hash also matches an
+  existing seed-row provenance.
+* **A18b row already represented in `seed.jsonl` or
+  `delegation_seed.jsonl`** → `duplicate_of_existing` with the
+  appropriate `already_in_*` reason. A17's existing cross-check
+  is reused verbatim.
+
+---
+
+## 9. Evidence-hash / provenance binding
+
+A18c surfaces the A18b row's `evidence_hash` value **verbatim**
+in the admission record. It does not recompute, hash again, or
+re-anchor provenance. The hash's interpretation is whatever
+the operator chose at A18b write time (per the
+[`a18b_writer_host_side_write_runbook.md`](a18b_writer_host_side_write_runbook.md)
+the canonical shape is `hashlib.sha256(<non-secret-marker>.encode("utf-8")).hexdigest()`).
+
+A18c does not infer execution-authority or admission-authority
+from the evidence hash; the hash is a provenance marker for
+forensic traceability, not an authorisation token.
+
+---
+
+## 10. Max caps per tick / per day
+
+* **Per-tick cap:** `8` projections. Any A18c tick that finds
+  more than 8 eligible A18b rows projects only the first 8
+  (oldest-first ordering) and surfaces a closed-vocab warning;
+  remaining rows are eligible on the next tick.
+* **Per-day cap:** `32` projections (UTC day-boundary). Any
+  A18c tick that would push the running per-day projection count
+  past 32 stops emitting and surfaces a closed-vocab warning;
+  remaining rows are eligible on the next UTC day.
+
+These caps are intentionally low relative to A18b's `256` max
+records and to A17's own bounds, reflecting the operator-paced
+rollout posture. The caps are advisory — A17's filters remain
+authoritative; A18c never bypasses an A17 filter by hitting a
+cap.
+
+The exact integer values are pinned in the companion test so
+any future change is a deliberate doc + test update.
+
+---
+
+## 11. Stop conditions
+
+A18c must default-deny and emit a closed-vocab failure envelope
+when any of:
+
+* `generated_seed.jsonl` is unreadable or absent;
+* any line of `generated_seed.jsonl` fails A18b's closed-schema
+  validation;
+* the per-tick or per-day cap is reached;
+* an A17 filter trips on a projected row;
+* the env-gate flag value is not exactly `"true"`;
+* the audit-artefact path is not within the sentinel prefix
+  `logs/development_generated_lane_a18c/`;
+* `assert_no_secrets` raises on the projection record or the
+  envelope;
+* the Phase-2 diagnostic row is encountered (see §15) — A18c
+  must project it as `needs_human` regardless of other filter
+  outcomes.
+
+None of these conditions raise; A18c surfaces them as closed
+envelope statuses.
+
+---
+
+## 12. Rollback
+
+A18c rollback is the env-flag flip plus a single PR revert at
+most:
+
+1. **Env-flag off** (`unset ADE_GENERATED_LANE_A18C_ENABLED` or
+   set to anything other than the exact string `"true"`).
+2. A18c's next tick returns zero projections.
+3. Existing A17 artefacts under
+   `logs/development_queue_admission_policy/` remain unchanged.
+4. Existing `generated_seed.jsonl` remains unchanged (A18c never
+   writes to it).
+5. If desired, revert the Phase 4 implementation PR; A18c's
+   on-disk projection artefacts under
+   `logs/development_generated_lane_a18c/` may be deleted
+   manually by the operator (not by code).
+
+No on-disk state outside `logs/development_generated_lane_a18c/`
+is touched by A18c, so rollback never threatens upstream A17 or
+A18a/A18b state.
+
+---
+
+## 13. Kill switch
+
+The env-gate **is** the kill switch. Setting
+`ADE_GENERATED_LANE_A18C_ENABLED` to anything other than the
+exact string `"true"` immediately returns A18c to
+zero-projection mode on the next call. The kill switch is
+host-controlled (operator unsets the env in the dashboard
+container) and is independent of A18b's
+`ADE_GENERATED_LANE_WRITER_ENABLED` flag — disabling A18c does
+not disable A18b's writer, and vice versa.
+
+---
+
+## 14. Malformed `generated_seed.jsonl` — default-deny
+
+If any line of `generated_seed.jsonl` fails A18b's closed-schema
+validation (12 keys exact, type/bound checks), A18c does NOT
+crash and does NOT skip the malformed line silently. It:
+
+* halts that tick's projection;
+* surfaces a closed-vocab warning (mirroring A18b's
+  `existing_file_malformed` pattern);
+* emits zero admission projections for that tick;
+* logs the event in its own bounded audit artefact;
+* does not modify the upstream `generated_seed.jsonl`.
+
+Default-deny is a hard invariant. A18c never makes a "best
+effort" projection on partial data.
+
+---
+
+## 15. Phase-2 diagnostic row handling
+
+The Phase-2 controlled production write smoke wrote exactly one
+diagnostic row to `generated_seed.jsonl`:
+
+* `generated_candidate_id`: `a18b-phase2-smoke-2026-05-13-001`
+* `source_module`: `operator_phase2_smoke`
+* `proposed_kind`: `e2e_proof`
+* `admission_preview`: `generated_seed_written`
+* `would_require_operator_go`: `true`
+* `proposed_summary` explicitly forbids admission, execution,
+  promotion, merge, deploy.
+
+**Mandatory A18c behaviour:** this diagnostic row must NEVER
+become auto-admissible, NEVER become executable, and NEVER
+become a queue-execution candidate. The decision-mapping table
+in §5 already enforces this via the
+`would_require_operator_go = True → needs_human` rule. The
+plan additionally pins:
+
+* A18c's evaluation of the diagnostic row produces
+  `admission_decision = "needs_human"` with reason
+  `needs_human_authority_decision` regardless of any other
+  attribute matching the auto-admissible filter set.
+* The row may be re-classified `blocked` if a future filter
+  detects a protected-target-path attempt or a
+  classification-drift signal, but never `admissible`.
+* The row may only become `admissible` if a future
+  Phase-5-style operator-approved promotion rule explicitly
+  authorises this exact `generated_candidate_id`. Without such
+  an explicit promotion rule, the row remains diagnostic /
+  blocked indefinitely.
+
+The companion pin-test asserts the plan doc contains the exact
+`generated_candidate_id` string and the safety-property
+language verbatim.
+
+---
+
+## 16. A18b writer topology decision
+
+The A18b writer performs an atomic-replace
+(`os.replace(tmp, target)`); the canonical seed path on VPS is
+currently a **file-level bind mount**
+`/root/trading-agent/generated_seed.jsonl → /app/generated_seed.jsonl`.
+The Phase 2 incident proved that container-side
+`os.replace` against the bind-mount target produces
+`OSError: [Errno 16] Device or resource busy`. The
+operationally-pinned procedure is captured in
+[`a18b_writer_host_side_write_runbook.md`](a18b_writer_host_side_write_runbook.md):
+
+* **Option α — currently operationally pinned.** Host-side
+  write under a per-command env prefix, followed by a dashboard
+  recreate so the container's bind-mount view resolves the new
+  inode. This is what the Phase 2 smoke used. Sufficient for
+  operator-paced writes (Phase 2, future Phase 5b/5c
+  operator-promotions).
+* **Option β2 — future decision, not implemented here.**
+  Migrate `generated_seed.jsonl` to a dedicated subdirectory
+  (e.g. `/root/trading-agent/var/generated_lane/`) and add a
+  directory-level bind mount of that subdirectory to the
+  dashboard container. The writer's `os.replace` would then
+  succeed in-container because both `tmp` and `target` would
+  live inside the same bind-mounted directory. The writer
+  module's `GENERATED_SEED_PATH` constant would need to move; a
+  small code PR plus a compose change would be required.
+
+A18c implementation (Phase 4) does NOT depend on Option β2 in
+the simple case: A18c is a **reader** of `generated_seed.jsonl`,
+and reads work fine through the existing file-level bind mount.
+The Option β2 question becomes a real correctness issue only if
+a future write-then-read-within-same-process pattern emerges
+(e.g. a Phase-5b operator-promotion that writes from inside the
+dashboard process and immediately admits via A18c without a
+container recreate). In that scenario, Option β2 is the
+principled fix and the Phase 4 implementation PR or a
+subsequent Phase 5 PR may include it.
+
+**This plan-only PR does not implement Option β2.** The plan
+records it as an explicit future decision point that the
+operator may raise between Phase 4 implementation merge and
+`GO enable A18c on VPS`.
+
+---
+
+## 17. Explicit hard denials
+
+A18c, in this plan and in any future implementation, must not:
+
+* execute work;
+* open / merge / close a PR;
+* trigger a deploy workflow;
+* trigger a trade, broker, risk, execution, or research path;
+* mint or verify approval tokens;
+* enable Step 5.0 / 5.1 / 5.2;
+* flip `step5_implementation_allowed`;
+* change `STEP5_ENABLED_SUBSTAGE`;
+* enable Level 6 (permanently disabled per ADR-015);
+* write `seed.jsonl` or `delegation_seed.jsonl`;
+* mutate `generated_seed.jsonl` (A18b writer is the only
+  authority);
+* bypass any A17 filter;
+* introduce a new admission decision or reason value;
+* re-classify an A17 closed-vocab value;
+* send any push notification;
+* register a Flask blueprint;
+* touch `dashboard/dashboard.py` (no-touch hook applies);
+* touch `frontend/**`;
+* touch `.claude/**`, `.gitleaks.toml`, `research/**`,
+  `live/**`, `paper/**`, `shadow/**`, `risk/**`, `broker/**`,
+  `execution/**`;
+* store secrets in repo, logs, public artifacts, PR bodies, or
+  test output.
+
+The companion pin-test scans the plan doc's executable surface
+(its fenced code blocks) for the imperative shapes of each
+denial above and refuses any future drift.
+
+---
+
+## 18. Step 5 and Level 6 invariants
+
+Level 6 is **permanently disabled** per ADR-015 §Doctrine 1 and
+is **never** raised by this plan. The six invariants below are
+re-asserted on every line of this plan:
+
+```
+step5_implementation_allowed = false
+STEP5_ENABLED_SUBSTAGE        = "none"
+level6_enabled                = false
+dry_run_only                  = true
+live_merge_implemented        = false
+deploy_coupled                = false
+```
+
+A18c emits these literal values into its `discipline_invariants`
+dict on every projection envelope when (and only when) the
+Phase 4 implementation lands. Until then no envelope is
+emitted.
+
+---
+
+## 19. Cross-references
+
+* [`docs/governance/development_generated_lane.md`](development_generated_lane.md)
+  — A18a / A18b governance and writer contract.
+* [`docs/governance/a18b_writer_host_side_write_runbook.md`](a18b_writer_host_side_write_runbook.md)
+  — Phase-2 follow-up runbook codifying Option α host-side
+  write + remount; referenced by §16 above.
+* [`docs/governance/autonomous_development_baseline_observation.md`](autonomous_development_baseline_observation.md)
+  — Phase 0 baseline observation chain; the rest state every
+  A18c projection must converge to before and after.
+* [`docs/governance/queue_admission_policy.md`](queue_admission_policy.md)
+  — A17 admission policy governance doc; A18c projects through
+  A17's existing closed vocabularies.
+* [`reporting/development_queue_admission_policy.py`](../../reporting/development_queue_admission_policy.py)
+  — A17 implementation; A18c's projection schema mirrors A17's
+  `ADMISSION_SCHEMA_KEYS` verbatim.
+* [`reporting/development_generated_lane_writer.py`](../../reporting/development_generated_lane_writer.py)
+  — A18b implementation; A18c reads the file A18b writes.
+* [`docs/governance/n5b_merge_execution_plan.md`](n5b_merge_execution_plan.md)
+  — N5b governance / plan-only doc; reasserts the live-merge
+  invariants A18c also preserves.
+* [`docs/adr/ADR-014-truth-authority-settlement.md`](../adr/ADR-014-truth-authority-settlement.md)
+  — authority doctrine.
+* [`docs/adr/ADR-015-claude-agent-governance.md`](../adr/ADR-015-claude-agent-governance.md)
+  — Level 6 permanently-disabled doctrine.
+* [`docs/governance/execution_authority.md`](execution_authority.md)
+  — per-action authority decisions.
+* [`docs/governance/no_touch_paths.md`](no_touch_paths.md) —
+  the protected paths.

--- a/tests/unit/test_development_generated_lane_a18c_plan.py
+++ b/tests/unit/test_development_generated_lane_a18c_plan.py
@@ -1,0 +1,758 @@
+"""Pin-tests for the A18c admission-integration plan-only doc.
+
+These tests do **not** activate any runtime gate. They pin that
+the plan doc at
+``docs/governance/development_generated_lane_a18c_plan.md``:
+
+* exists, is non-trivial, and is plain markdown;
+* states explicitly that A18c is plan-only / not implemented;
+* identifies the future operator-go phrases verbatim
+  (``GO A18c admission integration`` and
+  ``GO enable A18c on VPS``);
+* documents the proposed env-gate name
+  ``ADE_GENERATED_LANE_A18C_ENABLED`` with the exact enabled
+  value ``"true"``;
+* documents the per-tick (8) and per-day (32) caps verbatim;
+* documents the Phase-2 diagnostic row protection (the row
+  with ``generated_candidate_id = a18b-phase2-smoke-2026-05-13-001``
+  and ``would_require_operator_go=True`` must remain
+  diagnostic / blocked / needs_human until a future
+  operator-approved promotion rule explicitly authorises it);
+* documents the A18b topology caveat (Option α host-side write
+  + remount currently operationally pinned; Option β2
+  directory-mount migration is a future decision and is NOT
+  implemented by this plan PR);
+* re-asserts the Step 5 + Level 6 + dry-run / live-merge /
+  deploy-coupled invariants explicitly;
+* cross-references A18a/A18b doc, the A18b host-side write
+  runbook, the Phase 0 baseline observation runbook, the A17
+  queue-admission policy doc and module, and ADR-015.
+
+In addition, the test suite verifies:
+
+* **No A18c module exists on disk** —
+  ``reporting/development_generated_lane_a18c.py`` (and any
+  ``a18c``-suffixed sibling) must not exist.
+* **A17 admission module contains no active code path that reads
+  ``generated_seed.jsonl``** — narrative docstring references and
+  the discipline-invariant flag ``writes_to_generated_seed_jsonl=False``
+  are legitimate and required; the test forbids only an active
+  read code path.
+
+This is a documentation pin-test, not a runtime gate. The plan
+doc grants ADE zero new authority.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PLAN_PATH = (
+    REPO_ROOT
+    / "docs"
+    / "governance"
+    / "development_generated_lane_a18c_plan.md"
+)
+
+
+def _plan_text() -> str:
+    return PLAN_PATH.read_text(encoding="utf-8")
+
+
+# A markdown fenced code block opens with a line starting with ```
+# and closes with a matching line. The negative pin-tests below
+# scan only the *contents* of these blocks, because the plan doc
+# necessarily quotes every forbidden imperative in its narrative
+# negative list and those mentions are legitimate. Operators only
+# copy commands out of fenced blocks, so the relevant safety
+# concern is "do not let a fenced block contain a mutating shape".
+_FENCE_RE = re.compile(r"```[^\n]*\n(.*?)```", re.DOTALL)
+
+
+def _plan_code_blocks() -> str:
+    """Concatenated text of every fenced code block in the plan
+    doc. Lower-cased so the imperative-shape pins can be written
+    in lowercase without per-phrase ``.lower()`` calls."""
+    text = _plan_text()
+    return "\n".join(m.group(1) for m in _FENCE_RE.finditer(text)).lower()
+
+
+# ---------------------------------------------------------------------------
+# Existence + shape
+# ---------------------------------------------------------------------------
+
+
+def test_plan_file_exists() -> None:
+    assert PLAN_PATH.is_file(), (
+        f"A18c plan-only doc missing: {PLAN_PATH}"
+    )
+
+
+def test_plan_is_non_empty() -> None:
+    text = _plan_text()
+    assert len(text) > 6000, (
+        f"A18c plan doc is too short ({len(text)} bytes); "
+        "the plan must document the full admission-integration design."
+    )
+
+
+def test_plan_is_markdown() -> None:
+    text = _plan_text()
+    assert text.lstrip().startswith("# "), (
+        "plan must be a markdown file beginning with a top-level "
+        "heading."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Plan-only / not-implemented language.
+# ---------------------------------------------------------------------------
+
+
+def test_plan_states_plan_only() -> None:
+    text = _plan_text().lower()
+    assert "plan only" in text or "plan-only" in text, (
+        "plan must explicitly state it is plan-only."
+    )
+
+
+def test_plan_states_not_implemented() -> None:
+    text = _plan_text().lower()
+    assert "not implemented" in text, (
+        "plan must explicitly state A18c is not implemented."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Operator-go phrases verbatim.
+# ---------------------------------------------------------------------------
+
+
+def test_plan_documents_phase4_implementation_go_phrase() -> None:
+    text = _plan_text()
+    assert "GO A18c admission integration" in text, (
+        "plan must document the exact Phase 4 implementation "
+        "operator-go phrase 'GO A18c admission integration'."
+    )
+
+
+def test_plan_documents_runtime_activation_go_phrase() -> None:
+    text = _plan_text()
+    assert "GO enable A18c on VPS" in text, (
+        "plan must document the exact runtime activation "
+        "operator-go phrase 'GO enable A18c on VPS'."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Env gate proposal.
+# ---------------------------------------------------------------------------
+
+
+def test_plan_documents_env_gate_name() -> None:
+    text = _plan_text()
+    assert "ADE_GENERATED_LANE_A18C_ENABLED" in text, (
+        "plan must document the proposed env-gate name "
+        "'ADE_GENERATED_LANE_A18C_ENABLED' verbatim."
+    )
+
+
+def test_plan_documents_env_gate_enabled_value() -> None:
+    """The plan documents that the env-gate enabled value is the
+    exact literal string ``"true"``. The value must appear in
+    quoted form near the env-gate-name discussion."""
+    text = _plan_text()
+    idx = text.find("ADE_GENERATED_LANE_A18C_ENABLED")
+    assert idx != -1
+    nearby = text[idx : idx + 600]
+    assert '`true`' in nearby or '"true"' in nearby, (
+        "plan must document the env-gate enabled value as the "
+        "exact literal string 'true' near the env-gate name."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Caps verbatim.
+# ---------------------------------------------------------------------------
+
+
+def test_plan_documents_per_tick_cap_of_eight() -> None:
+    text = _plan_text()
+    # The integer 8 should appear with the per-tick description.
+    # Allow either the bare integer in a code fence (`8`) or a
+    # backtick form, plus the explicit "per-tick" phrasing.
+    assert "per-tick" in text.lower() or "per tick" in text.lower(), (
+        "plan must document a per-tick cap with the phrase 'per-tick'."
+    )
+    assert "`8`" in text, (
+        "plan must document the per-tick cap as the exact integer 8."
+    )
+
+
+def test_plan_documents_per_day_cap_of_thirtytwo() -> None:
+    text = _plan_text()
+    assert "per-day" in text.lower() or "per day" in text.lower(), (
+        "plan must document a per-day cap with the phrase 'per-day'."
+    )
+    assert "`32`" in text, (
+        "plan must document the per-day cap as the exact integer 32."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Phase-2 diagnostic row protection.
+# ---------------------------------------------------------------------------
+
+
+def test_plan_references_phase2_diagnostic_candidate_id() -> None:
+    """The plan must reference the exact Phase-2 diagnostic
+    ``generated_candidate_id`` so it cannot be silently relaxed
+    in a future drift."""
+    text = _plan_text()
+    assert "a18b-phase2-smoke-2026-05-13-001" in text, (
+        "plan must reference the Phase-2 diagnostic "
+        "generated_candidate_id 'a18b-phase2-smoke-2026-05-13-001' "
+        "verbatim."
+    )
+
+
+def test_plan_pins_would_require_operator_go_true_maps_to_needs_human() -> None:
+    text = _plan_text()
+    assert "would_require_operator_go" in text, (
+        "plan must reference would_require_operator_go."
+    )
+    # The doc must document that True maps to needs_human (never
+    # admissible).
+    lowered = text.lower()
+    assert "would_require_operator_go = true" in lowered or (
+        "would_require_operator_go` = true" in lowered
+    ) or "would_require_operator_go = `true`" in lowered or (
+        "would_require_operator_go=true" in lowered
+    ) or "would_require_operator_go = `true`" in lowered or (
+        "would_require_operator_go` = `true`" in lowered
+    ) or "would_require_operator_go=true" in lowered, (
+        "plan must contain a 'would_require_operator_go = True' "
+        "shape in the decision-mapping table."
+    )
+    # The mapping must explicitly include needs_human.
+    assert "needs_human" in lowered, (
+        "plan must document the 'needs_human' admission decision "
+        "for would_require_operator_go=True rows."
+    )
+
+
+def test_plan_pins_phase2_row_never_admissible() -> None:
+    text = _plan_text().lower()
+    # The doc must state that the diagnostic row never becomes
+    # admissible / executable without a separate operator-approved
+    # promotion rule.
+    assert "never become" in text or "must remain diagnostic" in text or (
+        "remain diagnostic" in text
+    ) or "remains diagnostic" in text, (
+        "plan must state explicitly that the Phase-2 diagnostic "
+        "row remains diagnostic / never becomes admissible."
+    )
+    assert "executable" in text, (
+        "plan must mention 'executable' so its negation is explicit."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Topology caveat (Option α / Option β2).
+# ---------------------------------------------------------------------------
+
+
+def test_plan_documents_option_alpha_currently_pinned() -> None:
+    text = _plan_text().lower()
+    assert "option α" in text or "option alpha" in text, (
+        "plan must reference Option α (host-side write + remount)."
+    )
+    # "currently" / "operationally pinned" / similar phrasing.
+    assert "operationally pinned" in text or "currently" in text, (
+        "plan must state Option α is currently / operationally pinned."
+    )
+
+
+def test_plan_documents_option_beta2_not_implemented_here() -> None:
+    text = _plan_text().lower()
+    assert "option β2" in text or "option beta2" in text or "option b2" in text, (
+        "plan must reference Option β2 (directory-mount migration)."
+    )
+    # The plan must say β2 is not implemented in this PR.
+    assert "does not implement option β2" in text or (
+        "does not implement option beta2" in text
+    ) or "not implemented by this plan" in text or (
+        "does not implement" in text
+    ), (
+        "plan must state explicitly that Option β2 is not "
+        "implemented by this plan-only PR."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Closed-vocab discipline invariants.
+# ---------------------------------------------------------------------------
+
+
+def test_plan_states_step5_implementation_allowed_false() -> None:
+    text = _plan_text()
+    assert "step5_implementation_allowed" in text
+    idx = text.find("step5_implementation_allowed")
+    nearby = text[idx : idx + 200].lower()
+    assert "false" in nearby, (
+        "step5_implementation_allowed must be stated as `false` "
+        "explicitly in the plan."
+    )
+
+
+def test_plan_states_step5_enabled_substage_none() -> None:
+    text = _plan_text()
+    assert (
+        "STEP5_ENABLED_SUBSTAGE" in text
+        or "step5_enabled_substage" in text
+    )
+    lowered = text.lower()
+    assert '"none"' in text or " none" in lowered, (
+        "STEP5_ENABLED_SUBSTAGE must be stated as 'none'."
+    )
+
+
+def test_plan_states_level_6_permanently_disabled() -> None:
+    text = _plan_text().lower()
+    assert "level 6" in text
+    assert "permanently disabled" in text, (
+        "plan must state Level 6 remains permanently disabled."
+    )
+
+
+def test_plan_states_dry_run_only_invariant() -> None:
+    text = _plan_text()
+    assert "dry_run_only" in text
+    idx = text.find("dry_run_only")
+    nearby = text[idx : idx + 200].lower()
+    assert "true" in nearby, (
+        "dry_run_only must be stated as `true` explicitly."
+    )
+
+
+def test_plan_states_live_merge_implemented_false() -> None:
+    text = _plan_text()
+    assert "live_merge_implemented" in text
+    idx = text.find("live_merge_implemented")
+    nearby = text[idx : idx + 200].lower()
+    assert "false" in nearby, (
+        "live_merge_implemented must be stated as `false`."
+    )
+
+
+def test_plan_states_deploy_coupled_false() -> None:
+    text = _plan_text()
+    assert "deploy_coupled" in text
+    idx = text.find("deploy_coupled")
+    nearby = text[idx : idx + 200].lower()
+    assert "false" in nearby, (
+        "deploy_coupled must be stated as `false`."
+    )
+
+
+def test_plan_contains_combined_invariants_block() -> None:
+    """The plan must state the six core invariants in a single
+    ~1.2 KiB window."""
+    text = _plan_text().lower()
+    needles = (
+        "step5_implementation_allowed",
+        "step5_enabled_substage",
+        "level6_enabled",
+        "dry_run_only",
+        "live_merge_implemented",
+        "deploy_coupled",
+    )
+    first_idx = text.find(needles[0])
+    while first_idx != -1:
+        window = text[first_idx : first_idx + 1200]
+        if all(n in window for n in needles):
+            return
+        first_idx = text.find(needles[0], first_idx + 1)
+    raise AssertionError(
+        "plan must state all six invariants "
+        f"({needles!r}) within a single ~1.2 KiB window."
+    )
+
+
+# ---------------------------------------------------------------------------
+# No-existence pins: A18c module must NOT exist on disk; A17
+# admission module must NOT contain an active read code path for
+# generated_seed.jsonl.
+# ---------------------------------------------------------------------------
+
+
+_FORBIDDEN_A18C_MODULES: tuple[str, ...] = (
+    "reporting/development_generated_lane_a18c.py",
+    "reporting/development_generated_lane_a18c_status.py",
+    "reporting/development_generated_lane_a18c_writer.py",
+    "reporting/development_generated_lane_a18c_admission.py",
+)
+
+
+def test_no_a18c_module_exists() -> None:
+    """A18c is plan-only. No production module may exist on disk."""
+    for rel in _FORBIDDEN_A18C_MODULES:
+        path = REPO_ROOT / rel
+        assert not path.exists(), (
+            f"A18c module must not exist (plan-only): {rel}"
+        )
+
+
+def test_a17_admission_module_has_no_active_generated_seed_read() -> None:
+    """A17's admission module must not actively read
+    generated_seed.jsonl. Narrative docstring references and the
+    discipline-invariant flag ``writes_to_generated_seed_jsonl=False``
+    are legitimate and required; the test forbids only an active
+    read code path (read_text / open / Path() with
+    'generated_seed' in the call-site source-text).
+
+    The strategy: parse the A17 admission module's AST; flag any
+    Call node whose argument literal contains the string
+    'generated_seed'. (Narrative mentions in module docstrings and
+    constant-dict values like
+    ``"writes_to_generated_seed_jsonl": False`` are Str literals
+    not inside Call expressions, so they are not flagged.)"""
+    a17_path = (
+        REPO_ROOT
+        / "reporting"
+        / "development_queue_admission_policy.py"
+    )
+    src = a17_path.read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    offenders: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        for arg in list(node.args) + [kw.value for kw in node.keywords]:
+            if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                if "generated_seed" in arg.value.lower():
+                    offenders.append(
+                        f"line {node.lineno}: Call with string "
+                        f"arg containing 'generated_seed': "
+                        f"{arg.value!r}"
+                    )
+    assert not offenders, (
+        "A17 admission module must not contain a Call expression "
+        "whose argument references 'generated_seed' (no active "
+        f"read code path). Offenders: {offenders}"
+    )
+
+
+def test_a18b_writer_constants_agree() -> None:
+    """Defense-in-depth: when the writer module changes its env
+    var name, this plan doc would silently disagree. We re-validate
+    the writer constants at test time."""
+    from reporting import (  # noqa: WPS433 — local import intentional
+        development_generated_lane_writer as w,
+    )
+
+    assert w.ENV_WRITER_ENABLED == "ADE_GENERATED_LANE_WRITER_ENABLED"
+    assert w.GENERATED_SEED_PATH.name == "generated_seed.jsonl"
+
+
+def test_a17_module_version_constant_agrees() -> None:
+    """The plan documents A17's MODULE_VERSION as v3.15.16.A17.
+    Test re-validates at import time."""
+    from reporting import (  # noqa: WPS433 — local import intentional
+        development_queue_admission_policy as a17,
+    )
+
+    assert a17.MODULE_VERSION == "v3.15.16.A17"
+
+
+# ---------------------------------------------------------------------------
+# Negative pins — plan's executable surface (fenced code blocks)
+# must contain no env enable, no Step 5 / Level 6 flip, no
+# GitHub-mutation command, no token mint/verify CLI, no A18c
+# implementation imperative.
+# ---------------------------------------------------------------------------
+
+
+def test_plan_code_blocks_do_not_enable_a18c_env_flag() -> None:
+    """The plan documents the proposed env-gate value but must NOT
+    actually export the flag in any executable block."""
+    code = _plan_code_blocks()
+    forbidden = (
+        "ade_generated_lane_a18c_enabled=true",
+        'ade_generated_lane_a18c_enabled="true"',
+        "export ade_generated_lane_a18c_enabled",
+    )
+    for phrase in forbidden:
+        assert phrase not in code, (
+            f"plan code block must NOT enable the A18c env flag: "
+            f"{phrase!r}"
+        )
+
+
+def test_plan_code_blocks_do_not_enable_a18b_writer() -> None:
+    code = _plan_code_blocks()
+    forbidden = (
+        "ade_generated_lane_writer_enabled=true",
+        'ade_generated_lane_writer_enabled="true"',
+        "export ade_generated_lane_writer_enabled",
+    )
+    for phrase in forbidden:
+        assert phrase not in code, (
+            f"plan code block must NOT enable the A18b writer: "
+            f"{phrase!r}"
+        )
+
+
+def test_plan_code_blocks_do_not_enable_n5b_live_execute() -> None:
+    code = _plan_code_blocks()
+    forbidden = (
+        "ade_n5b_live_execute_enabled=true",
+        'ade_n5b_live_execute_enabled="true"',
+        "export ade_n5b_live_execute_enabled",
+    )
+    for phrase in forbidden:
+        assert phrase not in code, (
+            f"plan code block must NOT enable N5b live execute: "
+            f"{phrase!r}"
+        )
+
+
+def test_plan_code_blocks_contain_no_real_merge_command() -> None:
+    code = _plan_code_blocks()
+    forbidden = (
+        "gh pr merge --squash",
+        "gh pr merge --rebase",
+        "gh pr merge --merge",
+        "gh pr review --approve",
+        "gh pr review --request-changes",
+        "git merge --no-ff",
+        "git push --force",
+        "git push -f ",
+        "git push origin main",
+        "--admin",
+    )
+    for phrase in forbidden:
+        assert phrase not in code, (
+            f"plan code block contains a forbidden mutating-command "
+            f"shape: {phrase!r}"
+        )
+
+
+def test_plan_code_blocks_do_not_flip_step5_or_level6() -> None:
+    code = _plan_code_blocks()
+    forbidden = (
+        "step5_implementation_allowed = true",
+        'step5_implementation_allowed="true"',
+        "step5_implementation_allowed=true",
+        'step5_enabled_substage = "5.0"',
+        'step5_enabled_substage = "5.1"',
+        'step5_enabled_substage = "5.2"',
+        'step5_enabled_substage="5.0"',
+        'step5_enabled_substage="5.1"',
+        'step5_enabled_substage="5.2"',
+        "level6_enabled = true",
+        "level6_enabled=true",
+    )
+    for phrase in forbidden:
+        assert phrase not in code, (
+            "plan code block contains a forbidden "
+            f"authority-escalation flip: {phrase!r}"
+        )
+
+
+def test_plan_code_blocks_do_not_instruct_token_mint_or_verify() -> None:
+    code = _plan_code_blocks()
+    forbidden = (
+        "approval_token_runtime.mint",
+        "approval_token_runtime.verify",
+        "mint_approval_token",
+        "verify_approval_token",
+        "--mint-token",
+        "--verify-token",
+    )
+    for phrase in forbidden:
+        assert phrase not in code, (
+            f"plan code block contains a forbidden token "
+            f"mint/verify invocation: {phrase!r}"
+        )
+
+
+def test_plan_code_blocks_do_not_use_unsupported_writer_status_flag() -> None:
+    """The A18b writer CLI has no '--status' flag; the plan must
+    not reference one in executable form."""
+    code = _plan_code_blocks()
+    forbidden = (
+        "development_generated_lane_writer --status",
+        "python3 -m reporting.development_generated_lane_writer --status",
+        "python -m reporting.development_generated_lane_writer --status",
+    )
+    for phrase in forbidden:
+        assert phrase not in code, (
+            f"plan code block contains the unsupported writer "
+            f"'--status' flag: {phrase!r}"
+        )
+
+
+def test_plan_code_blocks_do_not_authorise_a18c_implementation() -> None:
+    """Narrative negative mentions ('A18c is not implemented')
+    are required and legitimate. The plan's executable surface
+    must NOT contain an imperative that authorises implementation."""
+    code = _plan_code_blocks()
+    forbidden = (
+        "implement a18c",
+        "build a18c",
+        "ship a18c",
+        "enable a18c",
+        "a18c is implemented",
+        "a18c is enabled",
+    )
+    for phrase in forbidden:
+        assert phrase not in code, (
+            f"plan code block contains a phrase that would "
+            f"authorise A18c implementation: {phrase!r}"
+        )
+
+
+def test_plan_does_not_instruct_touching_no_touch_paths() -> None:
+    text = _plan_text().lower()
+    forbidden_imperatives = (
+        "edit .claude",
+        "modify .claude",
+        "write to .claude",
+        "edit .gitleaks.toml",
+        "modify .gitleaks.toml",
+        "disable .gitleaks.toml",
+        "weaken .gitleaks.toml",
+        "edit seed.jsonl",
+        "modify seed.jsonl",
+        "write to seed.jsonl",
+        "append to seed.jsonl",
+        "edit delegation_seed.jsonl",
+        "modify delegation_seed.jsonl",
+        "write to delegation_seed.jsonl",
+        "append to delegation_seed.jsonl",
+        "weaken the test",
+        "weaken the tests",
+        "skip the gate",
+        "bypass the hook",
+        "bypass hooks",
+    )
+    for phrase in forbidden_imperatives:
+        assert phrase not in text, (
+            f"plan contains a forbidden no-touch-path / "
+            f"safety-bypass imperative: {phrase!r}"
+        )
+
+
+def test_plan_does_not_instruct_deploy() -> None:
+    text = _plan_text().lower()
+    forbidden = (
+        "trigger the deploy workflow",
+        "trigger deploy workflow",
+        "force the deploy",
+        "couple this to deploy",
+    )
+    for phrase in forbidden:
+        assert phrase not in text, (
+            f"plan contains a forbidden deploy-coupling "
+            f"instruction: {phrase!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Negative pins — no secret material.
+# ---------------------------------------------------------------------------
+
+
+def test_plan_contains_no_pem_secret_block() -> None:
+    text = _plan_text()
+    dashes = "-" * 5
+    pem_kinds = (
+        "PRIVATE KEY",
+        "EC PRIVATE KEY",
+        "RSA PRIVATE KEY",
+        "OPENSSH PRIVATE KEY",
+    )
+    forbidden = [f"{dashes}BEGIN {kind}{dashes}" for kind in pem_kinds]
+    for marker in forbidden:
+        assert marker not in text, (
+            f"plan contains a PEM-style secret block: {marker!r}"
+        )
+
+
+def test_plan_contains_no_inline_hex_64_secret() -> None:
+    text = _plan_text()
+    pattern = re.compile(r"`[0-9a-fA-F]{64}`")
+    matches = pattern.findall(text)
+    assert not matches, (
+        f"plan embeds a hex-64 literal that looks like a secret: "
+        f"{matches!r}"
+    )
+
+
+def test_plan_contains_no_bearer_token_header() -> None:
+    text = _plan_text().lower()
+    forbidden = (
+        "authorization: bearer ",
+        "x-api-key: ",
+        "ghp_",
+        "github_pat_",
+        "sk-ant-",
+    )
+    for pat in forbidden:
+        assert pat not in text, (
+            f"plan contains a credential-shaped string: {pat!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Cross-reference pins.
+# ---------------------------------------------------------------------------
+
+
+def test_plan_cross_references_development_generated_lane_doc() -> None:
+    text = _plan_text()
+    assert "development_generated_lane.md" in text, (
+        "plan must cross-reference the A18a/A18b governance doc."
+    )
+
+
+def test_plan_cross_references_a18b_host_side_runbook() -> None:
+    text = _plan_text()
+    assert "a18b_writer_host_side_write_runbook.md" in text, (
+        "plan must cross-reference the A18b host-side write runbook."
+    )
+
+
+def test_plan_cross_references_baseline_observation_runbook() -> None:
+    text = _plan_text()
+    assert "autonomous_development_baseline_observation.md" in text, (
+        "plan must cross-reference the Phase 0 baseline "
+        "observation runbook."
+    )
+
+
+def test_plan_cross_references_a17_doctrine_doc() -> None:
+    text = _plan_text()
+    assert "queue_admission_policy.md" in text, (
+        "plan must cross-reference the A17 queue-admission policy "
+        "doctrine doc."
+    )
+
+
+def test_plan_cross_references_a17_module() -> None:
+    text = _plan_text()
+    assert "reporting/development_queue_admission_policy.py" in text, (
+        "plan must cross-reference the A17 admission module path."
+    )
+
+
+def test_plan_cross_references_adr_015() -> None:
+    text = _plan_text()
+    assert "ADR-015" in text, (
+        "plan must cross-reference ADR-015 (Level 6 "
+        "permanently-disabled doctrine)."
+    )


### PR DESCRIPTION
## Summary

Phase 3 of the accepted autonomous-development-lane phased plan.
Ships the canonical A18c admission-integration plan as docs +
pin-tests only. **No implementation. No A18c module. No A17
admission code-path change. No env activation.**

This is Item 2 of today's three-item ordered execution. Item 3
(Phase 4 A18c admission integration, default-disabled) remains
gated by the separate explicit operator-go phrase
\`GO A18c admission integration\`.

## Scope (strictly docs + pin-tests — three files)

| File | Action |
|---|---|
| \`docs/governance/development_generated_lane_a18c_plan.md\` | NEW |
| \`tests/unit/test_development_generated_lane_a18c_plan.py\` | NEW (46 tests) |
| \`docs/governance/development_generated_lane.md\` | EDIT — one three-line cross-reference block appended below the existing A18b host-side runbook cross-reference |

## Plan doc highlights

* A18c remains plan-only; no module
  \`reporting.development_generated_lane_a18c\` exists on disk.
* A17 remains authoritative. A18c fans into A17 via A17's existing
  closed \`ADMISSION_DECISIONS\` / \`ADMISSION_REASONS\` /
  \`ADMISSION_SCHEMA_KEYS\` vocabularies — **no new decision verbs,
  no relaxed filters**.
* Proposed env-gate name **\`ADE_GENERATED_LANE_A18C_ENABLED\`**
  with exact enabled value **\`true\`**. Default unset. Flipping
  the env is operator-only and requires the separate explicit
  operator-go \`GO enable A18c on VPS\`.
* Future implementation requires the separate explicit
  operator-go \`GO A18c admission integration\`.
* Candidate-id idempotency: deterministic derivation from the
  A18b row's \`generated_candidate_id\` + \`evidence_hash\` short
  prefix.
* Duplicate handling mirrors A18b's pattern: hard reject on
  duplicate candidate-id; soft warning on duplicate evidence-hash
  with different candidate-id.
* Caps: **per-tick 8**, **per-day 32**. Intentionally low for
  operator-paced rollout.
* Stop conditions / rollback / kill switch all documented.

## Phase-2 diagnostic row protection (key safety property)

* \`generated_candidate_id = \"a18b-phase2-smoke-2026-05-13-001\"\`
  with \`would_require_operator_go=True\` must NEVER become
  auto-admissible / executable / queue-execution candidate.
* Decision mapping pinned: \`would_require_operator_go=True\` →
  \`needs_human\` (never \`admissible\`).
* Auto-admissible only via a future operator-approved
  promotion rule that explicitly authorises this exact
  generated_candidate_id.

## A18b writer topology decision recorded in plan §16

* Option α (host-side write + remount) is currently
  **operationally pinned** per PR #213.
* Option β2 (directory-level mount + \`GENERATED_SEED_PATH\`
  migration) is a future decision and is explicitly **NOT
  implemented by this plan PR**. The plan adds an explicit
  decision moment between Phase 4 implementation merge and
  \`GO enable A18c on VPS\`.

## Pin-test highlights (46 tests total)

* plan-only / not-implemented language pinned
* operator-go phrases verbatim
  (\`GO A18c admission integration\`, \`GO enable A18c on VPS\`)
* env-gate name + exact enabled value
* per-tick cap **8** and per-day cap **32** verbatim
* Phase-2 diagnostic candidate-id verbatim + safety language
* Option α currently / operationally pinned
* Option β2 not implemented by this plan
* six-invariant block within single ~1.2 KiB window
* **defense-in-depth pin**: no A18c module exists on disk
  (\`reporting/development_generated_lane_a18c*.py\` glob)
* **defense-in-depth pin**: A17 admission module AST scan
  refuses any Call expression with a string arg containing
  \`generated_seed\` (narrative docstring references and the
  invariant flag \`writes_to_generated_seed_jsonl=False\` are
  legitimate and required; only an active read code path is
  forbidden)
* writer module constants agree at import time
* A17 \`MODULE_VERSION\` agrees at import time
* negative pins (scanning fenced code blocks only):
  no env enable for A18c / A18b / N5b live execute; no Step 5
  flip; no Level 6 raise; no GitHub-mutation command shape; no
  approval-token mint/verify CLI; no unsupported writer
  \`--status\` flag; no A18c implementation imperative
* no PEM block, no hex-64 inline literal, no Authorization
  Bearer header
* cross-references for A18a/A18b doc, A18b host-side runbook,
  Phase 0 baseline runbook, A17 doctrine doc, A17 module path,
  ADR-015

## What is NOT touched

* \`reporting/**\` (no admission/queue/writer module change)
* \`dashboard/**\`, \`frontend/**\`, \`scripts/**\`,
  \`.github/workflows/**\`
* \`.claude/**\`, \`.gitleaks.toml\`, \`research/**\`, \`live/**\`,
  \`paper/**\`, \`shadow/**\`, \`risk/**\`, \`broker/**\`,
  \`execution/**\`
* No compose file edit (Option β2 migration explicitly out of
  scope)
* No \`generated_seed.jsonl\` record written
* No A18c env activation
* No Step 5 substage promotion or flag flip
* No N5b phase change
* No Level 6 change
* No GitHub mutation; no token mint/verify; no deploy coupling

## Test plan

- [x] \`python scripts/governance_lint.py\` — OK
- [x] \`python -m pytest tests/smoke -q\` — 18 passed
- [x] \`python -m pytest tests/unit/test_development_generated_lane_a18c_plan.py -q\` — 46 passed
- [x] \`python -m pytest tests/unit/test_a18b_writer_host_side_write_runbook.py -q\` — still green
- [x] \`python -m pytest tests/unit/test_autonomous_development_baseline_observation_runbook.py -q\` — still green
- [x] \`python -m reporting.development_generated_lane_writer --no-write\` — invariants green
- [x] \`python -m reporting.development_step5_loop --no-write\` — invariants green
- [x] \`python -m reporting.development_operational_digest --no-write\` — invariant green

## Operator verification after merge

Docs + tests only — **no auto-deploy triggered**. No VPS
verification required for the PR itself. The plan doc becomes
the source-of-truth for the eventual Phase 4 implementation PR
(gated by \`GO A18c admission integration\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)