### PR TITLE
feat(a18c): admission projector, default-disabled, env-gated (Phase 4)

### DIFF
--- a/docs/governance/development_generated_lane.md
+++ b/docs/governance/development_generated_lane.md
@@ -411,6 +411,7 @@ itself remains unchanged:
 > For the operational caveat that A18b writes must run host-side
 > while the canonical seed file is a file-level bind mount, see
 > [`a18b_writer_host_side_write_runbook.md`](a18b_writer_host_side_write_runbook.md).
-> For the A18c admission-integration plan (plan-only; not
-> implemented), see
+> For the A18c admission-integration design / governance
+> source-of-truth (implemented default-disabled; not yet
+> activated on VPS), see
 > [`development_generated_lane_a18c_plan.md`](development_generated_lane_a18c_plan.md).

--- a/docs/governance/development_generated_lane_a18c_plan.md
+++ b/docs/governance/development_generated_lane_a18c_plan.md
@@ -1,17 +1,24 @@
-# A18c Admission Integration — Plan-Only Governance Doc
+# A18c Admission Integration — Design / Governance Source-of-Truth
 
-> **Status:** Plan only. Not implemented. No runtime authority.
-> No admission integration exists. No UI action exists. No code
-> module named `reporting.development_generated_lane_a18c` exists
-> on disk.
+> **Status:** **Implemented (default-disabled, env-gated).** This
+> doc remains the design / governance source-of-truth for the
+> A18c admission projector. The implementation lives at
+> [`reporting/development_generated_lane_a18c.py`](../../reporting/development_generated_lane_a18c.py)
+> with companion tests at
+> [`tests/unit/test_development_generated_lane_a18c.py`](../../tests/unit/test_development_generated_lane_a18c.py).
+> The env-gate `ADE_GENERATED_LANE_A18C_ENABLED` (enabled value:
+> the exact literal string `"true"`) is **unset** in all
+> environments today; runtime activation remains a strictly
+> later operator-only VPS step gated by
+> `GO enable A18c on VPS`.
 >
-> **Authority:** development-governance read-only documentation.
-> This doc grants ADE **zero** new authority. It exists solely to
-> document how a future A18c admission integration could be
-> safely designed if and when the operator separately authorises
-> implementation and then runtime activation. No code in this PR
-> can perform an admission, project a queue candidate, mint an
-> action-bearing token, deploy anything, or change Step 5 state.
+> **Authority:** development-governance read-only documentation
+> plus a default-disabled projector module. This doc and module
+> together grant ADE **zero** new runtime authority while the
+> env-gate stays unset. The module is the canonical surface; this
+> doc is the design / governance source-of-truth. A17 remains
+> authoritative; A18c never modifies A17 and never relaxes any
+> A17 filter.
 >
 > **Permanent denials (re-asserted):**
 >
@@ -30,9 +37,12 @@
 
 ## 1. Status
 
-* **Plan only** with respect to *admission integration*. This
-  document remains the design / governance / planning slice for
-  any future A18c implementation.
+* **Implemented (default-disabled, env-gated).** This document
+  remains the design / governance source-of-truth for the A18c
+  admission projector module. The implementation is **default-
+  disabled** — when the env-gate is unset (or set to anything
+  other than the exact string `"true"`), A18c returns a no-op
+  envelope without reading `generated_seed.jsonl` at all.
 * **A18a** dry-run / report-only projector is implemented at
   [`reporting/development_generated_lane.py`](../../reporting/development_generated_lane.py).
 * **A18b** `generated_seed.jsonl` writer is implemented at
@@ -40,26 +50,29 @@
   It is default-disabled, env-gated, and was exercised in the
   Phase 2 controlled production write smoke; one diagnostic row
   exists on disk.
-* **A18c** admission integration is **not implemented**. No
-  module named `reporting.development_generated_lane_a18c`
-  exists. The A17 admission policy module
+* **A18c** admission projector is implemented at
+  [`reporting/development_generated_lane_a18c.py`](../../reporting/development_generated_lane_a18c.py).
+  Phase 4 implementation was authorised by the explicit
+  operator-go phrase `GO A18c admission integration`. The
+  module reads `generated_seed.jsonl` only when the env-gate
+  `ADE_GENERATED_LANE_A18C_ENABLED` is set to exactly the
+  literal string `"true"` (case-sensitive, no aliases). A17
+  remains authoritative; A18c calls
+  `a17.evaluate_promotion_record(...)` verbatim and never
+  modifies A17. The A17 admission policy module
   ([`reporting/development_queue_admission_policy.py`](../../reporting/development_queue_admission_policy.py))
-  does not read `generated_seed.jsonl` at any code path; its
-  references to the filename are narrative (docstring) plus the
-  discipline-invariant flag `writes_to_generated_seed_jsonl=False`.
-* **No runtime authority.** This plan doc grants ADE zero new
-  capability. It does not authorise any implementation; that
-  remains a separate operator-paced action.
+  is byte-identical pre- and post-Phase-4 — A18c is an
+  independent projector that consumes A17's public surface.
+* **No runtime authority while env-gate unset.** A18c grants
+  ADE zero new capability until an operator separately exports
+  the env on VPS. Setting the env is a strictly later
+  operator-only step gated by `GO enable A18c on VPS`.
 * **No UI action exists.** The PWA's `/agent-control/*` surface
   must not render an A18c admission button pointed at any
   endpoint.
-* **A18c implementation and any later runtime activation
-  require separate explicit operator-go phrases.** The plan
-  doc identifies them but does not request either of them:
-  * `GO A18c admission integration` — Phase 4 implementation
-    (default-disabled).
-  * `GO enable A18c on VPS` — Phase 4-followup runtime
-    activation (operator-only VPS env-export step).
+* **Runtime activation requires the separate explicit
+  operator-go phrase** `GO enable A18c on VPS`. The plan doc
+  identifies it but does not request it.
 
 The companion pin-tests in
 [`tests/unit/test_development_generated_lane_a18c_plan.py`](../../tests/unit/test_development_generated_lane_a18c_plan.py)
@@ -121,10 +134,10 @@ A17 and not an alternative admission path.
 
 ---
 
-## 3. Future purpose
+## 3. Operational purpose
 
-When (and only when) Phase 4 implementation lands and an
-operator separately activates the env-gate, A18c will:
+When (and only when) an operator separately activates the
+env-gate on VPS, A18c will:
 
 1. Read the on-disk `generated_seed.jsonl` rows at the canonical
    path `/root/trading-agent/generated_seed.jsonl` (host) or

--- a/reporting/development_generated_lane_a18c.py
+++ b/reporting/development_generated_lane_a18c.py
@@ -1,0 +1,737 @@
+"""A18c — generated_seed.jsonl admission projector (default-disabled).
+
+Read-only projector that reads the existing A18b-written
+``generated_seed.jsonl`` file and projects eligible rows into the
+existing A17 admission flow as an additional, closed-vocab admission
+source. A17 remains authoritative; A18c never modifies A17's
+``reporting.development_queue_admission_policy`` module, never
+relaxes any A17 filter, and never bypasses A17's policy table.
+
+Hard, default-deny posture
+--------------------------
+
+The projector is **disabled by default**. It only reads
+``generated_seed.jsonl`` when the operator has explicitly exported
+the exact-string env value::
+
+    ADE_GENERATED_LANE_A18C_ENABLED=true
+
+Anything else — empty, ``"false"``, ``"1"``, ``"yes"``, ``"True"``,
+``"TRUE"``, unset — leaves the projector in zero-projection mode.
+The public ``collect_snapshot`` returns immediately with an
+``enabled=False`` envelope and **does not read** the seed file.
+
+Hard guarantees pinned by the companion tests
+---------------------------------------------
+
+* Default-disabled unless the env var matches the exact literal
+  string ``"true"`` (case-sensitive, no aliases).
+* Env-off: zero file reads of ``generated_seed.jsonl``, zero
+  projections, no admission rows.
+* Env-on + seed file absent → safe ``generated_seed_absent``
+  envelope.
+* Env-on + seed file malformed line → default-deny
+  ``generated_seed_malformed`` envelope, zero rows, no crash.
+* Env-on + seed file ok → A18c constructs A17-shaped upstream
+  rows and calls
+  ``a17.evaluate_promotion_record(synth_upstream)`` verbatim.
+* **Defense in depth**: any A18b row with
+  ``would_require_operator_go=True`` whose A17 decision comes
+  back ``admissible`` is forced to ``needs_human`` /
+  ``needs_human_authority_decision``. A17's rule #5 already
+  fires for the same condition because A18c sets
+  ``human_needed=True`` on the synth upstream; the post-A17
+  check is belt-and-braces.
+* Writes only to ``logs/development_generated_lane_a18c/`` via
+  atomic tmp + ``os.replace``. The write-path sentinel refuses
+  any other prefix.
+* Per-tick cap of 8 projections. Per-day cap of 32 projections,
+  applied by reading the prior ``latest.json`` snapshot's
+  ``counts.total`` when its ``generated_at_utc`` is the same
+  UTC day.
+* Deterministic A18c candidate id derived from the A18b row's
+  ``generated_candidate_id`` + first 16 hex chars of
+  ``evidence_hash``.
+* Duplicate candidate-id within a single tick is hard-suppressed
+  (forensic-safe; no second row emitted).
+* Duplicate ``evidence_hash`` across different A18b rows surfaces
+  the closed warning ``duplicate_evidence_hash_in_a18b``.
+* ``assert_no_secrets`` runs on every envelope before write.
+* No subprocess, no network, no GitHub CLI, no ``git``, no
+  ``approval-token`` runtime/gate import, no dashboard import,
+  no frontend import, no execution surface.
+* ``step5_implementation_allowed`` remains ``False`` and
+  ``STEP5_ENABLED_SUBSTAGE`` remains ``"none"``.
+* Level 6 is permanently disabled per ADR-015 §Doctrine 1.
+
+What this module is NOT
+-----------------------
+
+* It is **not** a queue admission engine. A17 remains the only
+  authority that decides whether a record is admissible; A18c
+  projects through A17's existing closed vocabulary.
+* It is **not** an executor. No work is started.
+* It is **not** a PR / branch / merge / deploy surface.
+* It is **not** authorised to admit the Phase-2 diagnostic row
+  (``a18b-phase2-smoke-2026-05-13-001``); that row carries
+  ``would_require_operator_go=True`` and therefore maps to
+  ``needs_human`` regardless of other attributes.
+* It is **not** a writer. ``generated_seed.jsonl`` is read-only
+  to A18c; A18b is the only authority that appends to that file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Final, Mapping
+
+from reporting import development_generated_lane_writer as a18b
+from reporting import development_queue_admission_policy as a17
+from reporting import execution_authority as ea
+from reporting.agent_audit_summary import assert_no_secrets
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[str] = "1.0"
+MODULE_VERSION: Final[str] = "v3.15.16.A18c"
+REPORT_KIND: Final[str] = "development_generated_lane_a18c"
+
+
+# ---------------------------------------------------------------------------
+# Step 5 invariants
+# ---------------------------------------------------------------------------
+
+STEP5_ENABLED_SUBSTAGE: Final[str] = "none"
+step5_implementation_allowed: Final[bool] = False
+
+
+# ---------------------------------------------------------------------------
+# Env-gate constants
+# ---------------------------------------------------------------------------
+
+ENV_GATE: Final[str] = "ADE_GENERATED_LANE_A18C_ENABLED"
+_ENABLED_VALUE: Final[str] = "true"
+
+
+# ---------------------------------------------------------------------------
+# Bounded caps
+# ---------------------------------------------------------------------------
+
+PER_TICK_CAP: Final[int] = 8
+PER_DAY_CAP: Final[int] = 32
+
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies
+# ---------------------------------------------------------------------------
+
+NOTES: Final[tuple[str, ...]] = (
+    "env_gate_off",
+    "generated_seed_absent",
+    "generated_seed_malformed",
+    "no_eligible_a18b_rows",
+    "candidates_projected",
+)
+
+WARNINGS: Final[tuple[str, ...]] = (
+    "env_gate_off_no_op",
+    "generated_seed_absent",
+    "generated_seed_malformed",
+    "per_tick_cap_reached",
+    "per_day_cap_reached",
+    "duplicate_evidence_hash_in_a18b",
+)
+
+
+# ---------------------------------------------------------------------------
+# Repo-relative paths
+# ---------------------------------------------------------------------------
+
+ARTIFACT_DIR: Final[Path] = (
+    REPO_ROOT / "logs" / "development_generated_lane_a18c"
+)
+ARTIFACT_LATEST: Final[Path] = ARTIFACT_DIR / "latest.json"
+ARTIFACT_RELATIVE_PATH: Final[str] = (
+    "logs/development_generated_lane_a18c/latest.json"
+)
+
+#: Atomic-write allowlist (substring form). Any attempt to write
+#: outside this prefix raises ``ValueError``.
+_WRITE_PREFIX: Final[str] = "logs/development_generated_lane_a18c/"
+
+
+# ---------------------------------------------------------------------------
+# Discipline invariants — emitted into every envelope.
+# ---------------------------------------------------------------------------
+
+_DISCIPLINE_INVARIANTS: Final[dict[str, bool | str]] = {
+    "default_disabled": True,
+    "reads_generated_seed_only_when_enabled": True,
+    "writes_to_seed_jsonl": False,
+    "writes_to_delegation_seed_jsonl": False,
+    "writes_to_generated_seed_jsonl": False,
+    "modifies_a17_admission_policy": False,
+    "admits_to_queue": False,
+    "executes_work": False,
+    "creates_branches": False,
+    "opens_prs": False,
+    "merges_prs": False,
+    "deploys": False,
+    "calls_network": False,
+    "uses_subprocess": False,
+    "touches_step5_flags": False,
+    "level6_enabled": False,
+    "always_needs_human_in_first_cut": True,
+    "bypasses_a17_filters": False,
+}
+
+
+# ---------------------------------------------------------------------------
+# Utility helpers
+# ---------------------------------------------------------------------------
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _utc_date_prefix(ts: str) -> str:
+    """Return the ``YYYY-MM-DD`` prefix of an ISO-8601 UTC string,
+    or an empty string if the input is not parseable."""
+    if not isinstance(ts, str) or len(ts) < 10:
+        return ""
+    return ts[:10]
+
+
+# ---------------------------------------------------------------------------
+# Public API: env gate
+# ---------------------------------------------------------------------------
+
+
+def env_enabled(env: Mapping[str, str] | None = None) -> bool:
+    """Return True iff the operator has exported the exact-string
+    env value enabling A18c projection.
+
+    Reads the env mapping at *call time*, not at import time."""
+    source: Mapping[str, str] = env if env is not None else os.environ
+    value = source.get(ENV_GATE)
+    if not isinstance(value, str):
+        return False
+    return value == _ENABLED_VALUE
+
+
+# ---------------------------------------------------------------------------
+# Internal: read generated_seed.jsonl
+# ---------------------------------------------------------------------------
+
+
+def _read_generated_seed(
+    path: Path,
+) -> tuple[str, list[dict[str, Any]]]:
+    """Return ``("ok", rows)``, ``("absent", [])``, or
+    ``("malformed", [])``. Never raises.
+
+    Rows are filtered to those whose key-set matches A18b's
+    closed ``GENERATED_RECORD_KEYS`` exactly; any line that fails
+    A18b's closed-schema shape triggers a full-file default-deny
+    (``malformed``)."""
+    if not path.is_file():
+        return ("absent", [])
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return ("malformed", [])
+    out: list[dict[str, Any]] = []
+    expected_keys = set(a18b.GENERATED_RECORD_KEYS)
+    for line in text.splitlines():
+        s = line.strip()
+        if not s:
+            continue
+        try:
+            obj = json.loads(s)
+        except ValueError:
+            return ("malformed", [])
+        if not isinstance(obj, dict):
+            return ("malformed", [])
+        if set(obj.keys()) != expected_keys:
+            return ("malformed", [])
+        out.append(obj)
+    return ("ok", out)
+
+
+# ---------------------------------------------------------------------------
+# Internal: read prior per-day count
+# ---------------------------------------------------------------------------
+
+
+def _read_prior_today_total(
+    prior_path: Path,
+    *,
+    today_utc_prefix: str,
+) -> int:
+    """Read the prior A18c ``latest.json`` snapshot (if any) and
+    return ``counts.total`` only when its ``generated_at_utc``
+    starts with ``today_utc_prefix``. Returns 0 on any error /
+    missing / different-day / malformed."""
+    if not prior_path.is_file():
+        return 0
+    try:
+        text = prior_path.read_text(encoding="utf-8")
+        data = json.loads(text)
+    except (OSError, ValueError):
+        return 0
+    if not isinstance(data, dict):
+        return 0
+    prior_ts = data.get("generated_at_utc")
+    if not isinstance(prior_ts, str) or not prior_ts.startswith(
+        today_utc_prefix
+    ):
+        return 0
+    counts = data.get("counts")
+    if not isinstance(counts, dict):
+        return 0
+    total = counts.get("total")
+    if not isinstance(total, int) or total < 0:
+        return 0
+    return total
+
+
+# ---------------------------------------------------------------------------
+# A17 row synthesis + projection
+# ---------------------------------------------------------------------------
+
+
+def _a18c_candidate_id(generated_candidate_id: str, evidence_hash: str) -> str:
+    """Deterministic A18c candidate-id. The hash short prefix is
+    capped at 16 chars; the full hash stays in the projected row's
+    `evidence_hash` field for forensic traceability."""
+    hash_prefix = ""
+    if isinstance(evidence_hash, str):
+        hash_prefix = evidence_hash[:16]
+    return f"a18c-{generated_candidate_id}-{hash_prefix}"
+
+
+def _synth_a17_upstream(
+    a18b_row: dict[str, Any],
+    *,
+    a18c_candidate_id: str,
+) -> dict[str, Any]:
+    """Build an A17-shaped upstream row from an A18b record. The
+    shape mirrors what A17's `evaluate_promotion_record` reads;
+    every field is conservative by default so the projection
+    defaults to `needs_human` in this first cut."""
+    requires_op_go = bool(a18b_row.get("would_require_operator_go"))
+    return {
+        "candidate_id": a18c_candidate_id,
+        "title": str(a18b_row.get("proposed_title") or ""),
+        "source_document": str(a18b.GENERATED_SEED_PATH),
+        "source_kind": "generated_seed_lane",
+        "roadmap_phase": "",
+        "candidate_kind": str(a18b_row.get("proposed_kind") or ""),
+        "required_agent_role": (
+            "operator" if requires_op_go else ""
+        ),
+        # Conservative default: UNKNOWN forces A17 rule #9 →
+        # needs_human. A future Phase-5 promotion rule may
+        # override this for explicitly authorised rows.
+        "risk_level": ea.RISK_UNKNOWN,
+        "target_path": "",
+        "upstream_intake_status": "generated_seed_present",
+        # Not "eligible" → A17 rule #7 fires.
+        "decision_state": "needs_human",
+        # Both upstream and reclassified are NEEDS_HUMAN by
+        # default → A17 rule #4 fires.
+        "upstream_execution_authority_decision": ea.DECISION_NEEDS_HUMAN,
+        "reclassified_execution_authority_decision": (
+            ea.DECISION_NEEDS_HUMAN
+        ),
+        "classification_drift": False,
+        # human_needed=True when would_require_operator_go=True
+        # → A17 rule #5 fires deterministically.
+        "human_needed": requires_op_go,
+        "human_needed_reason": (
+            "would_require_operator_go" if requires_op_go else ""
+        ),
+        # A18c's first cut does NOT cross-reference seed/delegation
+        # presence; A17's `already_in_*` fields would require an
+        # additional read of seed.jsonl/delegation_seed.jsonl which
+        # is out of scope for the default-disabled posture.
+        "already_in_seed_jsonl": False,
+        "already_in_delegation_seed": False,
+    }
+
+
+def _build_a18c_row(
+    a18b_row: dict[str, Any],
+    *,
+    evaluated_at: str,
+) -> dict[str, Any]:
+    """Build a single A18c admission row (matches A17's
+    ADMISSION_SCHEMA_KEYS verbatim).
+
+    Calls A17's public `evaluate_promotion_record` and applies
+    a defense-in-depth force: any row with A18b's
+    `would_require_operator_go=True` whose A17 decision came
+    back `admissible` is rewritten to `needs_human`."""
+    requires_op_go = bool(a18b_row.get("would_require_operator_go"))
+    a18c_id = _a18c_candidate_id(
+        str(a18b_row.get("generated_candidate_id") or ""),
+        str(a18b_row.get("evidence_hash") or ""),
+    )
+    synth = _synth_a17_upstream(a18b_row, a18c_candidate_id=a18c_id)
+    decision, reason = a17.evaluate_promotion_record(synth)
+
+    # ---- Defense-in-depth: would_require_operator_go=True
+    #      can NEVER be admissible, even if A17's policy table
+    #      ever changes upstream.
+    if requires_op_go and decision == "admissible":
+        decision = "needs_human"
+        reason = "needs_human_authority_decision"
+
+    row: dict[str, Any] = {
+        "candidate_id": synth["candidate_id"],
+        "title": synth["title"],
+        "source_document": synth["source_document"],
+        "source_kind": synth["source_kind"],
+        "roadmap_phase": synth["roadmap_phase"],
+        "candidate_kind": synth["candidate_kind"],
+        "required_agent_role": synth["required_agent_role"],
+        "risk_level": synth["risk_level"],
+        "target_path": synth["target_path"],
+        "upstream_intake_status": synth["upstream_intake_status"],
+        "upstream_decision_state": synth["decision_state"],
+        "upstream_execution_authority_decision": (
+            synth["upstream_execution_authority_decision"]
+        ),
+        "reclassified_execution_authority_decision": (
+            synth["reclassified_execution_authority_decision"]
+        ),
+        "classification_drift": synth["classification_drift"],
+        "human_needed": synth["human_needed"],
+        "human_needed_reason": synth["human_needed_reason"],
+        "admission_decision": decision,
+        "admission_reason": reason,
+        "would_target_lane": (
+            "development_work_queue"
+            if decision == "admissible"
+            else "none"
+        ),
+        "already_in_seed_jsonl": synth["already_in_seed_jsonl"],
+        "already_in_delegation_seed": synth["already_in_delegation_seed"],
+        "policy_version": a17.POLICY_VERSION,
+        "evaluated_at": evaluated_at,
+    }
+    # Closed-schema invariant: every key in A17's
+    # ADMISSION_SCHEMA_KEYS must be present.
+    assert set(row.keys()) == set(a17.ADMISSION_SCHEMA_KEYS), (
+        "A18c row key-set drift versus A17 ADMISSION_SCHEMA_KEYS: "
+        f"{sorted(row.keys())!r} vs {sorted(a17.ADMISSION_SCHEMA_KEYS)!r}"
+    )
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Aggregation
+# ---------------------------------------------------------------------------
+
+
+def _empty_counts() -> dict[str, Any]:
+    counts: dict[str, Any] = {
+        "total": 0,
+        "admissible": 0,
+        "needs_human": 0,
+        "blocked": 0,
+        "duplicate_of_existing": 0,
+        "not_eligible_upstream": 0,
+        "by_admission_decision": {d: 0 for d in a17.ADMISSION_DECISIONS},
+        "by_admission_reason": {r: 0 for r in a17.ADMISSION_REASONS},
+        "by_promotion_target": {t: 0 for t in a17.PROMOTION_TARGETS},
+    }
+    return counts
+
+
+def _aggregate_counts(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    counts = _empty_counts()
+    counts["total"] = len(rows)
+    for r in rows:
+        d = r.get("admission_decision")
+        if d in counts:
+            counts[d] += 1
+        if d in counts["by_admission_decision"]:
+            counts["by_admission_decision"][d] += 1
+        reason = r.get("admission_reason")
+        if reason in counts["by_admission_reason"]:
+            counts["by_admission_reason"][reason] += 1
+        target = r.get("would_target_lane")
+        if target in counts["by_promotion_target"]:
+            counts["by_promotion_target"][target] += 1
+    return counts
+
+
+# ---------------------------------------------------------------------------
+# Snapshot assembly
+# ---------------------------------------------------------------------------
+
+
+def _build_envelope(
+    *,
+    enabled: bool,
+    generated_seed_path: Path,
+    rows: list[dict[str, Any]],
+    note: str,
+    warnings: list[str],
+    generated_at_utc: str,
+) -> dict[str, Any]:
+    """Build the closed-schema envelope. Always carries the
+    discipline invariants."""
+    snapshot: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": generated_at_utc,
+        "enabled": enabled,
+        "env_gate_name": ENV_GATE,
+        "generated_seed_path": str(generated_seed_path),
+        "rows": rows,
+        "counts": _aggregate_counts(rows),
+        "note": note,
+        "validation_warnings": list(warnings),
+        "vocabularies": {
+            "notes": list(NOTES),
+            "warnings": list(WARNINGS),
+            "admission_decisions": list(a17.ADMISSION_DECISIONS),
+            "admission_reasons": list(a17.ADMISSION_REASONS),
+            "promotion_targets": list(a17.PROMOTION_TARGETS),
+        },
+        "policy_version": a17.POLICY_VERSION,
+        "a18b_writer_module_version": a18b.MODULE_VERSION,
+        "per_tick_cap": PER_TICK_CAP,
+        "per_day_cap": PER_DAY_CAP,
+        "step5_implementation_allowed": step5_implementation_allowed,
+        "step5_enabled_substage": STEP5_ENABLED_SUBSTAGE,
+        "level6_enabled": False,
+        "dry_run_only": True,
+        "live_merge_implemented": False,
+        "deploy_coupled": False,
+        "discipline_invariants": dict(_DISCIPLINE_INVARIANTS),
+    }
+    # Defense in depth: scrub the envelope before write.
+    assert_no_secrets(snapshot)
+    return snapshot
+
+
+def collect_snapshot(
+    *,
+    env: Mapping[str, str] | None = None,
+    generated_seed_path: Path | None = None,
+    prior_artifact_path: Path | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    """Build the A18c projection snapshot. Default-disabled — when
+    the env-gate is off, returns immediately without reading any
+    seed file."""
+    ts = generated_at_utc if generated_at_utc is not None else _utcnow()
+    seed_path = (
+        generated_seed_path
+        if generated_seed_path is not None
+        else a18b.GENERATED_SEED_PATH
+    )
+    prior_path = (
+        prior_artifact_path
+        if prior_artifact_path is not None
+        else ARTIFACT_LATEST
+    )
+
+    enabled = env_enabled(env)
+
+    if not enabled:
+        # ENV-OFF PATH: no file read, no projection, no error.
+        return _build_envelope(
+            enabled=False,
+            generated_seed_path=seed_path,
+            rows=[],
+            note="env_gate_off",
+            warnings=["env_gate_off_no_op"],
+            generated_at_utc=ts,
+        )
+
+    # ---- Env enabled: read generated_seed.jsonl ----
+    read_status, a18b_rows = _read_generated_seed(seed_path)
+
+    if read_status == "absent":
+        return _build_envelope(
+            enabled=True,
+            generated_seed_path=seed_path,
+            rows=[],
+            note="generated_seed_absent",
+            warnings=["generated_seed_absent"],
+            generated_at_utc=ts,
+        )
+
+    if read_status == "malformed":
+        return _build_envelope(
+            enabled=True,
+            generated_seed_path=seed_path,
+            rows=[],
+            note="generated_seed_malformed",
+            warnings=["generated_seed_malformed"],
+            generated_at_utc=ts,
+        )
+
+    # ---- Per-day cap: read prior latest.json (best-effort) ----
+    today_prefix = _utc_date_prefix(ts)
+    prior_today = _read_prior_today_total(
+        prior_path, today_utc_prefix=today_prefix
+    )
+    per_day_remaining = max(0, PER_DAY_CAP - prior_today)
+
+    warnings: list[str] = []
+
+    # ---- Per-tick cap ----
+    pre_cap_count = len(a18b_rows)
+    if pre_cap_count > PER_TICK_CAP:
+        a18b_rows = a18b_rows[:PER_TICK_CAP]
+        warnings.append("per_tick_cap_reached")
+
+    # ---- Per-day cap (binding limit after per-tick) ----
+    if len(a18b_rows) > per_day_remaining:
+        a18b_rows = a18b_rows[:per_day_remaining]
+        warnings.append("per_day_cap_reached")
+
+    # ---- Project each row through A17 (with idempotency + dedup) ----
+    rows: list[dict[str, Any]] = []
+    seen_candidate_ids: set[str] = set()
+    seen_evidence_hashes: dict[str, str] = {}
+
+    for a18b_row in a18b_rows:
+        gen_id = str(a18b_row.get("generated_candidate_id") or "")
+        ev_hash = str(a18b_row.get("evidence_hash") or "")
+        a18c_id = _a18c_candidate_id(gen_id, ev_hash)
+
+        # Hard suppress duplicates within the same tick (defense
+        # in depth against an unusual A18b file shape).
+        if a18c_id in seen_candidate_ids:
+            continue
+        seen_candidate_ids.add(a18c_id)
+
+        # Soft warning on duplicate evidence_hash with a different
+        # generated_candidate_id (mirrors A18b's pattern).
+        if ev_hash and ev_hash in seen_evidence_hashes and (
+            seen_evidence_hashes[ev_hash] != gen_id
+        ):
+            if "duplicate_evidence_hash_in_a18b" not in warnings:
+                warnings.append("duplicate_evidence_hash_in_a18b")
+        seen_evidence_hashes.setdefault(ev_hash, gen_id)
+
+        rows.append(_build_a18c_row(a18b_row, evaluated_at=ts))
+
+    note = "candidates_projected" if rows else "no_eligible_a18b_rows"
+
+    return _build_envelope(
+        enabled=True,
+        generated_seed_path=seed_path,
+        rows=rows,
+        note=note,
+        warnings=warnings,
+        generated_at_utc=ts,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Atomic write (sentinel-restricted)
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    posix = path.as_posix()
+    if _WRITE_PREFIX not in posix and not posix.startswith(_WRITE_PREFIX):
+        raise ValueError(
+            "development_generated_lane_a18c._atomic_write_json refuses "
+            f"non-a18c-logs output path: {path}"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".development_generated_lane_a18c.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_outputs(snapshot: dict[str, Any]) -> Path:
+    """Persist the snapshot to
+    ``logs/development_generated_lane_a18c/latest.json``.
+    Sentinel-restricted via :func:`_atomic_write_json`."""
+    _atomic_write_json(ARTIFACT_LATEST, snapshot)
+    return ARTIFACT_LATEST
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m reporting.development_generated_lane_a18c",
+        description=(
+            "A18c admission projector — default-disabled, env-gated. "
+            "Reads generated_seed.jsonl only when "
+            "ADE_GENERATED_LANE_A18C_ENABLED=true (exact match); "
+            "otherwise emits a no-op envelope without reading the "
+            "seed file. NEVER admits, executes, merges, deploys, "
+            "or mutates upstream state. A17 remains authoritative."
+        ),
+    )
+    p.add_argument(
+        "--no-write",
+        action="store_true",
+        help=(
+            "Do not persist "
+            "logs/development_generated_lane_a18c/latest.json "
+            "(stdout only)."
+        ),
+    )
+    p.add_argument(
+        "--indent",
+        type=int,
+        default=2,
+        help="JSON indent (0 for compact).",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    indent = args.indent if args.indent and args.indent > 0 else None
+    snap = collect_snapshot()
+    if not args.no_write:
+        write_outputs(snap)
+    json.dump(snap, sys.stdout, indent=indent, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/unit/test_development_generated_lane_a18c.py
+++ b/tests/unit/test_development_generated_lane_a18c.py
@@ -1,0 +1,869 @@
+"""Tests for the v3.15.16.A18c admission projector
+(default-disabled).
+
+Hard guarantees verified here:
+
+* Default-disabled — env unset / off / aliased / non-exact-match
+  → no-op envelope, `enabled=False`, no `generated_seed.jsonl`
+  read. The "no read" property is asserted by monkey-patching
+  ``_read_generated_seed`` to a sentinel that fails the test if
+  called.
+* Env on + absent ``generated_seed.jsonl`` → safe
+  `generated_seed_absent` envelope.
+* Env on + malformed line → default-deny
+  `generated_seed_malformed` envelope, zero rows, no crash.
+* Env on + valid seed → A17-shaped rows projected via
+  ``a17.evaluate_promotion_record(synth)``. Every row uses
+  closed A17 vocabularies.
+* Phase-2 diagnostic row (``a18b-phase2-smoke-2026-05-13-001``)
+  maps to ``needs_human`` — never ``admissible`` /
+  ``executable``.
+* ``would_require_operator_go=True`` always maps to
+  ``needs_human``, even with otherwise-eligible attributes.
+* ``would_require_operator_go=False`` projection still maps to
+  ``needs_human`` by default (conservative first-cut posture).
+* Duplicate A18c candidate-id within a single tick is
+  hard-suppressed.
+* Duplicate evidence-hash across rows surfaces the closed
+  warning ``duplicate_evidence_hash_in_a18b``.
+* Per-tick cap of 8 enforced; per-day cap of 32 enforced via
+  reading the prior ``latest.json`` snapshot.
+* Envelope always carries the closed `discipline_invariants`
+  dict; Step 5 / Level 6 invariants intact.
+* Atomic-write path sentinel refuses any path outside
+  ``logs/development_generated_lane_a18c/``.
+* AST / source-text scans: no subprocess, no network, no
+  ``gh`` / ``git``, no dashboard / frontend / approval-token
+  imports, no seed.jsonl / delegation_seed.jsonl writes.
+* A17 module is byte-identical (not mutated by import or by
+  any code path here).
+* CLI `--no-write` works and defaults to env-off safe.
+"""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reporting import development_generated_lane_a18c as a18c
+from reporting import development_generated_lane_writer as a18b
+from reporting import development_queue_admission_policy as a17
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _evidence(marker: str) -> str:
+    return hashlib.sha256(marker.encode("utf-8")).hexdigest()
+
+
+def _valid_a18b_row(
+    candidate_id: str,
+    *,
+    proposed_kind: str = "e2e_proof",
+    would_require_operator_go: bool = True,
+    evidence_marker: str | None = None,
+    proposed_title: str = "diagnostic title",
+    proposed_summary: str = "diagnostic summary; must not be admitted",
+) -> dict[str, Any]:
+    marker = evidence_marker or f"marker-{candidate_id}"
+    return {
+        "generated_candidate_id": candidate_id,
+        "source_module": "operator_smoke",
+        "source_id": candidate_id,
+        "proposed_kind": proposed_kind,
+        "proposed_title": proposed_title,
+        "proposed_summary": proposed_summary,
+        "evidence_hash": _evidence(marker),
+        "admission_preview": "generated_seed_written",
+        "block_reason": "none",
+        "would_require_operator_go": would_require_operator_go,
+        "generated_at_utc": "2026-05-13T12:00:00Z",
+        "writer_module_version": a18b.MODULE_VERSION,
+    }
+
+
+def _write_seed(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [json.dumps(r, sort_keys=True) for r in rows]
+    path.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Closed-vocab module surface
+# ---------------------------------------------------------------------------
+
+
+def test_env_gate_constant_value() -> None:
+    """The exact CLI-facing env-gate name is pinned. Operators
+    export it via the verbatim string; drift fails this test
+    before any rename can land."""
+    assert a18c.ENV_GATE == "ADE_GENERATED_LANE_A18C_ENABLED"
+
+
+def test_env_gate_enabled_value() -> None:
+    assert a18c._ENABLED_VALUE == "true"
+
+
+def test_module_version_is_a18c_pin() -> None:
+    assert a18c.MODULE_VERSION == "v3.15.16.A18c"
+
+
+def test_step5_invariants_intact_by_import() -> None:
+    assert a18c.step5_implementation_allowed is False
+    assert a18c.STEP5_ENABLED_SUBSTAGE == "none"
+
+
+def test_caps_are_pinned() -> None:
+    assert a18c.PER_TICK_CAP == 8
+    assert a18c.PER_DAY_CAP == 32
+
+
+def test_artifact_path_is_under_a18c_logs_dir() -> None:
+    assert a18c.ARTIFACT_RELATIVE_PATH == (
+        "logs/development_generated_lane_a18c/latest.json"
+    )
+    assert "logs/development_generated_lane_a18c/" in (
+        a18c.ARTIFACT_LATEST.as_posix()
+    )
+
+
+# ---------------------------------------------------------------------------
+# Env gate
+# ---------------------------------------------------------------------------
+
+
+def test_env_enabled_returns_false_when_unset() -> None:
+    assert a18c.env_enabled({}) is False
+
+
+def test_env_enabled_returns_false_for_non_exact_match() -> None:
+    for alias in ("True", "TRUE", "1", "yes", "YES", "on", "false", ""):
+        assert a18c.env_enabled({a18c.ENV_GATE: alias}) is False, alias
+
+
+def test_env_enabled_returns_true_only_for_exact_lowercase_true() -> None:
+    assert a18c.env_enabled({a18c.ENV_GATE: "true"}) is True
+
+
+# ---------------------------------------------------------------------------
+# Env-off path: no file read, no rows, safe envelope.
+# ---------------------------------------------------------------------------
+
+
+def test_env_off_returns_no_op_envelope() -> None:
+    snap = a18c.collect_snapshot(env={})
+    assert snap["enabled"] is False
+    assert snap["note"] == "env_gate_off"
+    assert snap["validation_warnings"] == ["env_gate_off_no_op"]
+    assert snap["rows"] == []
+    assert snap["counts"]["total"] == 0
+
+
+def test_env_off_does_not_read_generated_seed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Defense-in-depth: when the env-gate is off, A18c must NOT
+    call ``_read_generated_seed``. Monkey-patch the helper with a
+    sentinel that fails the test if invoked."""
+
+    def fail_if_called(path: Path) -> tuple[str, list[Any]]:
+        raise AssertionError(
+            "_read_generated_seed must NOT be called when env-off"
+        )
+
+    monkeypatch.setattr(a18c, "_read_generated_seed", fail_if_called)
+    snap = a18c.collect_snapshot(env={})
+    assert snap["enabled"] is False
+    assert snap["note"] == "env_gate_off"
+
+
+def test_env_off_envelope_carries_invariants() -> None:
+    snap = a18c.collect_snapshot(env={})
+    assert snap["step5_implementation_allowed"] is False
+    assert snap["step5_enabled_substage"] == "none"
+    assert snap["level6_enabled"] is False
+    assert snap["dry_run_only"] is True
+    assert snap["live_merge_implemented"] is False
+    assert snap["deploy_coupled"] is False
+
+
+# ---------------------------------------------------------------------------
+# Env-on + absent / malformed / empty
+# ---------------------------------------------------------------------------
+
+
+def test_env_on_absent_seed_returns_safe_envelope(tmp_path: Path) -> None:
+    seed_path = tmp_path / "generated_seed.jsonl"
+    # File does NOT exist.
+    snap = a18c.collect_snapshot(
+        env={a18c.ENV_GATE: "true"},
+        generated_seed_path=seed_path,
+        prior_artifact_path=tmp_path / "no_prior.json",
+    )
+    assert snap["enabled"] is True
+    assert snap["note"] == "generated_seed_absent"
+    assert "generated_seed_absent" in snap["validation_warnings"]
+    assert snap["rows"] == []
+    assert snap["counts"]["total"] == 0
+
+
+def test_env_on_malformed_seed_returns_safe_envelope(tmp_path: Path) -> None:
+    seed_path = tmp_path / "generated_seed.jsonl"
+    seed_path.write_text("not json at all\n", encoding="utf-8")
+    snap = a18c.collect_snapshot(
+        env={a18c.ENV_GATE: "true"},
+        generated_seed_path=seed_path,
+        prior_artifact_path=tmp_path / "no_prior.json",
+    )
+    assert snap["note"] == "generated_seed_malformed"
+    assert "generated_seed_malformed" in snap["validation_warnings"]
+    assert snap["rows"] == []
+
+
+def test_env_on_wrong_schema_keys_returns_malformed(tmp_path: Path) -> None:
+    """A line that parses as JSON but does not have the closed
+    A18b GENERATED_RECORD_KEYS triggers full-file default-deny."""
+    seed_path = tmp_path / "generated_seed.jsonl"
+    seed_path.write_text(
+        json.dumps({"generated_candidate_id": "partial"}) + "\n",
+        encoding="utf-8",
+    )
+    snap = a18c.collect_snapshot(
+        env={a18c.ENV_GATE: "true"},
+        generated_seed_path=seed_path,
+        prior_artifact_path=tmp_path / "no_prior.json",
+    )
+    assert snap["note"] == "generated_seed_malformed"
+    assert snap["rows"] == []
+
+
+def test_env_on_empty_seed_file_is_no_eligible_rows(tmp_path: Path) -> None:
+    seed_path = tmp_path / "generated_seed.jsonl"
+    seed_path.write_text("", encoding="utf-8")
+    snap = a18c.collect_snapshot(
+        env={a18c.ENV_GATE: "true"},
+        generated_seed_path=seed_path,
+        prior_artifact_path=tmp_path / "no_prior.json",
+    )
+    assert snap["note"] == "no_eligible_a18b_rows"
+    assert snap["rows"] == []
+
+
+# ---------------------------------------------------------------------------
+# Phase-2 diagnostic row protection.
+# ---------------------------------------------------------------------------
+
+
+def test_phase2_diagnostic_row_maps_to_needs_human(tmp_path: Path) -> None:
+    """The Phase-2 diagnostic row carries
+    ``would_require_operator_go=True``. Under A18c projection it
+    MUST map to ``needs_human``. It MUST NEVER be ``admissible``
+    or otherwise executable."""
+    seed_path = tmp_path / "generated_seed.jsonl"
+    row = _valid_a18b_row(
+        "a18b-phase2-smoke-2026-05-13-001",
+        would_require_operator_go=True,
+    )
+    _write_seed(seed_path, [row])
+    snap = a18c.collect_snapshot(
+        env={a18c.ENV_GATE: "true"},
+        generated_seed_path=seed_path,
+        prior_artifact_path=tmp_path / "no_prior.json",
+    )
+    assert snap["counts"]["total"] == 1
+    [r] = snap["rows"]
+    assert r["admission_decision"] == "needs_human"
+    assert r["admission_decision"] != "admissible"
+    assert r["admission_reason"] in {
+        "needs_human_authority_decision",
+        "needs_human_unknown_or_invalid_risk",
+        "needs_human_classification_drift",
+        "needs_human_protected_target_path",
+    }
+    # Defense in depth — also pin the would_target_lane is "none"
+    # for a non-admissible row.
+    assert r["would_target_lane"] == "none"
+
+
+def test_phase2_diagnostic_row_carries_exact_candidate_id(
+    tmp_path: Path,
+) -> None:
+    """The projected row's candidate_id is the deterministic
+    A18c id derived from the A18b row."""
+    seed_path = tmp_path / "generated_seed.jsonl"
+    row = _valid_a18b_row(
+        "a18b-phase2-smoke-2026-05-13-001",
+        would_require_operator_go=True,
+        evidence_marker="phase2",
+    )
+    _write_seed(seed_path, [row])
+    snap = a18c.collect_snapshot(
+        env={a18c.ENV_GATE: "true"},
+        generated_seed_path=seed_path,
+        prior_artifact_path=tmp_path / "no_prior.json",
+    )
+    [r] = snap["rows"]
+    ev = _evidence("phase2")
+    assert r["candidate_id"] == (
+        f"a18c-a18b-phase2-smoke-2026-05-13-001-{ev[:16]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# would_require_operator_go semantics.
+# ---------------------------------------------------------------------------
+
+
+def test_would_require_operator_go_true_always_needs_human(
+    tmp_path: Path,
+) -> None:
+    seed_path = tmp_path / "generated_seed.jsonl"
+    row = _valid_a18b_row(
+        "force-op-go-true",
+        would_require_operator_go=True,
+        proposed_kind="bugfix",
+    )
+    _write_seed(seed_path, [row])
+    snap = a18c.collect_snapshot(
+        env={a18c.ENV_GATE: "true"},
+        generated_seed_path=seed_path,
+        prior_artifact_path=tmp_path / "no_prior.json",
+    )
+    [r] = snap["rows"]
+    assert r["admission_decision"] == "needs_human"
+
+
+def test_would_require_operator_go_false_still_needs_human_by_default(
+    tmp_path: Path,
+) -> None:
+    """Conservative first-cut posture: even without operator-go
+    flagged on the row, the synthesised RISK_UNKNOWN / non-eligible
+    upstream filters drive the projection to needs_human or
+    not_eligible_upstream — never admissible."""
+    seed_path = tmp_path / "generated_seed.jsonl"
+    row = _valid_a18b_row(
+        "force-op-go-false",
+        would_require_operator_go=False,
+        proposed_kind="delegation",
+    )
+    _write_seed(seed_path, [row])
+    snap = a18c.collect_snapshot(
+        env={a18c.ENV_GATE: "true"},
+        generated_seed_path=seed_path,
+        prior_artifact_path=tmp_path / "no_prior.json",
+    )
+    [r] = snap["rows"]
+    assert r["admission_decision"] != "admissible"
+    assert r["admission_decision"] in {
+        "needs_human",
+        "not_eligible_upstream",
+        "blocked",
+    }
+
+
+def test_no_row_in_snapshot_is_ever_admissible(tmp_path: Path) -> None:
+    """Across a mixed fixture, A18c's first-cut posture never
+    surfaces an admissible decision."""
+    seed_path = tmp_path / "generated_seed.jsonl"
+    rows = [
+        _valid_a18b_row(
+            f"mixed-{i}",
+            would_require_operator_go=(i % 2 == 0),
+            proposed_kind="e2e_proof" if i % 2 == 0 else "bugfix",
+            evidence_marker=f"mixed-{i}",
+        )
+        for i in range(5)
+    ]
+    _write_seed(seed_path, rows)
+    snap = a18c.collect_snapshot(
+        env={a18c.ENV_GATE: "true"},
+        generated_seed_path=seed_path,
+        prior_artifact_path=tmp_path / "no_prior.json",
+    )
+    for r in snap["rows"]:
+        assert r["admission_decision"] != "admissible"
+    assert snap["counts"]["admissible"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Duplicate handling.
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_candidate_id_is_hard_suppressed(tmp_path: Path) -> None:
+    """Two rows with the same candidate_id and same evidence_hash
+    produce a single projected row (duplicate A18c id is
+    hard-suppressed). This is defense-in-depth; A18b already
+    rejects duplicate ids at write time."""
+    seed_path = tmp_path / "generated_seed.jsonl"
+    row_a = _valid_a18b_row("dup-id", evidence_marker="dup-1")
+    row_b = _valid_a18b_row("dup-id", evidence_marker="dup-1")
+    _write_seed(seed_path, [row_a, row_b])
+    snap = a18c.collect_snapshot(
+        env={a18c.ENV_GATE: "true"},
+        generated_seed_path=seed_path,
+        prior_artifact_path=tmp_path / "no_prior.json",
+    )
+    assert snap["counts"]["total"] == 1
+
+
+def test_duplicate_evidence_hash_different_candidate_ids_warns(
+    tmp_path: Path,
+) -> None:
+    seed_path = tmp_path / "generated_seed.jsonl"
+    row_a = _valid_a18b_row("hash-a", evidence_marker="shared")
+    row_b = _valid_a18b_row("hash-b", evidence_marker="shared")
+    _write_seed(seed_path, [row_a, row_b])
+    snap = a18c.collect_snapshot(
+        env={a18c.ENV_GATE: "true"},
+        generated_seed_path=seed_path,
+        prior_artifact_path=tmp_path / "no_prior.json",
+    )
+    assert "duplicate_evidence_hash_in_a18b" in snap["validation_warnings"]
+    # Both rows ARE projected (warning is soft, not blocking).
+    assert snap["counts"]["total"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Per-tick + per-day caps.
+# ---------------------------------------------------------------------------
+
+
+def test_per_tick_cap_enforced(tmp_path: Path) -> None:
+    seed_path = tmp_path / "generated_seed.jsonl"
+    rows = [
+        _valid_a18b_row(f"tick-{i}", evidence_marker=f"tick-{i}")
+        for i in range(12)
+    ]
+    _write_seed(seed_path, rows)
+    snap = a18c.collect_snapshot(
+        env={a18c.ENV_GATE: "true"},
+        generated_seed_path=seed_path,
+        prior_artifact_path=tmp_path / "no_prior.json",
+    )
+    assert snap["counts"]["total"] == 8
+    assert "per_tick_cap_reached" in snap["validation_warnings"]
+
+
+def test_per_day_cap_enforced(tmp_path: Path) -> None:
+    """If a prior latest.json from today already reports 30
+    projections, the current tick can emit at most 2 more before
+    hitting the 32/day cap."""
+    seed_path = tmp_path / "generated_seed.jsonl"
+    prior_path = tmp_path / "prior_latest.json"
+    # The current tick's generated_at_utc must be on the same UTC
+    # day as the prior snapshot's. We control both timestamps so
+    # the test is deterministic.
+    today_ts = "2026-05-13T13:00:00Z"
+    prior_payload = {
+        "generated_at_utc": "2026-05-13T01:00:00Z",
+        "counts": {"total": 30},
+    }
+    prior_path.write_text(json.dumps(prior_payload), encoding="utf-8")
+    rows = [
+        _valid_a18b_row(f"day-{i}", evidence_marker=f"day-{i}")
+        for i in range(5)
+    ]
+    _write_seed(seed_path, rows)
+    snap = a18c.collect_snapshot(
+        env={a18c.ENV_GATE: "true"},
+        generated_seed_path=seed_path,
+        prior_artifact_path=prior_path,
+        generated_at_utc=today_ts,
+    )
+    assert snap["counts"]["total"] == 2
+    assert "per_day_cap_reached" in snap["validation_warnings"]
+
+
+def test_per_day_cap_ignores_yesterdays_prior(tmp_path: Path) -> None:
+    """A prior snapshot from a *different* UTC day must be ignored
+    for the per-day count."""
+    seed_path = tmp_path / "generated_seed.jsonl"
+    prior_path = tmp_path / "prior_latest.json"
+    today_ts = "2026-05-13T13:00:00Z"
+    prior_payload = {
+        "generated_at_utc": "2026-05-12T23:59:00Z",
+        "counts": {"total": 31},
+    }
+    prior_path.write_text(json.dumps(prior_payload), encoding="utf-8")
+    rows = [
+        _valid_a18b_row(f"newday-{i}", evidence_marker=f"newday-{i}")
+        for i in range(3)
+    ]
+    _write_seed(seed_path, rows)
+    snap = a18c.collect_snapshot(
+        env={a18c.ENV_GATE: "true"},
+        generated_seed_path=seed_path,
+        prior_artifact_path=prior_path,
+        generated_at_utc=today_ts,
+    )
+    assert snap["counts"]["total"] == 3
+    assert "per_day_cap_reached" not in snap["validation_warnings"]
+
+
+def test_per_day_cap_truncates_to_zero_when_quota_exceeded(
+    tmp_path: Path,
+) -> None:
+    """If today's prior already reaches the cap, the next tick
+    emits zero rows."""
+    seed_path = tmp_path / "generated_seed.jsonl"
+    prior_path = tmp_path / "prior_latest.json"
+    today_ts = "2026-05-13T23:00:00Z"
+    prior_payload = {
+        "generated_at_utc": "2026-05-13T01:00:00Z",
+        "counts": {"total": 32},
+    }
+    prior_path.write_text(json.dumps(prior_payload), encoding="utf-8")
+    rows = [
+        _valid_a18b_row(f"over-{i}", evidence_marker=f"over-{i}")
+        for i in range(3)
+    ]
+    _write_seed(seed_path, rows)
+    snap = a18c.collect_snapshot(
+        env={a18c.ENV_GATE: "true"},
+        generated_seed_path=seed_path,
+        prior_artifact_path=prior_path,
+        generated_at_utc=today_ts,
+    )
+    assert snap["counts"]["total"] == 0
+    assert "per_day_cap_reached" in snap["validation_warnings"]
+
+
+# ---------------------------------------------------------------------------
+# Closed-schema envelope shape + invariants.
+# ---------------------------------------------------------------------------
+
+
+def test_envelope_uses_a17_admission_schema_keys(tmp_path: Path) -> None:
+    """Every projected row's key-set matches A17's
+    ADMISSION_SCHEMA_KEYS exactly. This is the closed-schema
+    invariant that lets A17 consumers consume A18c rows without
+    re-schema work."""
+    seed_path = tmp_path / "generated_seed.jsonl"
+    _write_seed(seed_path, [_valid_a18b_row("shape-1")])
+    snap = a18c.collect_snapshot(
+        env={a18c.ENV_GATE: "true"},
+        generated_seed_path=seed_path,
+        prior_artifact_path=tmp_path / "no_prior.json",
+    )
+    [r] = snap["rows"]
+    assert set(r.keys()) == set(a17.ADMISSION_SCHEMA_KEYS)
+
+
+def test_envelope_carries_step5_and_level6_invariants(
+    tmp_path: Path,
+) -> None:
+    seed_path = tmp_path / "generated_seed.jsonl"
+    _write_seed(seed_path, [_valid_a18b_row("inv-1")])
+    snap = a18c.collect_snapshot(
+        env={a18c.ENV_GATE: "true"},
+        generated_seed_path=seed_path,
+        prior_artifact_path=tmp_path / "no_prior.json",
+    )
+    assert snap["step5_implementation_allowed"] is False
+    assert snap["step5_enabled_substage"] == "none"
+    assert snap["level6_enabled"] is False
+    assert snap["dry_run_only"] is True
+    assert snap["live_merge_implemented"] is False
+    assert snap["deploy_coupled"] is False
+
+
+def test_envelope_carries_full_discipline_invariants(tmp_path: Path) -> None:
+    seed_path = tmp_path / "generated_seed.jsonl"
+    _write_seed(seed_path, [_valid_a18b_row("disc-1")])
+    snap = a18c.collect_snapshot(
+        env={a18c.ENV_GATE: "true"},
+        generated_seed_path=seed_path,
+        prior_artifact_path=tmp_path / "no_prior.json",
+    )
+    di = snap["discipline_invariants"]
+    assert di["default_disabled"] is True
+    assert di["reads_generated_seed_only_when_enabled"] is True
+    assert di["writes_to_seed_jsonl"] is False
+    assert di["writes_to_delegation_seed_jsonl"] is False
+    assert di["writes_to_generated_seed_jsonl"] is False
+    assert di["modifies_a17_admission_policy"] is False
+    assert di["admits_to_queue"] is False
+    assert di["executes_work"] is False
+    assert di["creates_branches"] is False
+    assert di["opens_prs"] is False
+    assert di["merges_prs"] is False
+    assert di["deploys"] is False
+    assert di["calls_network"] is False
+    assert di["uses_subprocess"] is False
+    assert di["touches_step5_flags"] is False
+    assert di["level6_enabled"] is False
+    assert di["always_needs_human_in_first_cut"] is True
+    assert di["bypasses_a17_filters"] is False
+
+
+# ---------------------------------------------------------------------------
+# Atomic write sentinel.
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_write_refuses_non_a18c_path(tmp_path: Path) -> None:
+    bad_path = tmp_path / "not_a18c.json"
+    with pytest.raises(ValueError, match="non-a18c-logs"):
+        a18c._atomic_write_json(bad_path, {"k": "v"})
+
+
+def test_atomic_write_succeeds_under_a18c_prefix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Redirect ARTIFACT_LATEST into tmp so the write target lives
+    in a path that contains the sentinel substring."""
+    target_dir = tmp_path / "logs" / "development_generated_lane_a18c"
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target = target_dir / "latest.json"
+    monkeypatch.setattr(a18c, "ARTIFACT_LATEST", target)
+    snap = a18c.collect_snapshot(env={})
+    a18c.write_outputs(snap)
+    assert target.is_file()
+    loaded = json.loads(target.read_text(encoding="utf-8"))
+    assert loaded["enabled"] is False
+
+
+# ---------------------------------------------------------------------------
+# A17 byte-identical invariant: A18c module does not mutate A17.
+# ---------------------------------------------------------------------------
+
+
+def test_a17_module_admission_decisions_unchanged_after_a18c_import() -> None:
+    """Defense in depth: importing A18c must not mutate A17's
+    closed vocabularies."""
+    assert a17.ADMISSION_DECISIONS == (
+        "admissible",
+        "needs_human",
+        "blocked",
+        "duplicate_of_existing",
+        "not_eligible_upstream",
+    )
+    assert a17.MODULE_VERSION == "v3.15.16.A17"
+
+
+def test_a17_evaluate_promotion_record_is_callable() -> None:
+    """A18c relies on A17's public function. Confirm it is
+    callable and lives at the expected path."""
+    assert callable(a17.evaluate_promotion_record)
+    # Calling it with a synthetic upstream row produces a closed
+    # decision/reason tuple.
+    synth = a18c._synth_a17_upstream(
+        _valid_a18b_row("api-check"), a18c_candidate_id="api"
+    )
+    decision, reason = a17.evaluate_promotion_record(synth)
+    assert decision in a17.ADMISSION_DECISIONS
+    assert reason in a17.ADMISSION_REASONS
+
+
+# ---------------------------------------------------------------------------
+# Source-text + AST scans.
+# ---------------------------------------------------------------------------
+
+
+def _module_source() -> str:
+    return Path(a18c.__file__).read_text(encoding="utf-8")
+
+
+def _imported_module_names() -> set[str]:
+    tree = ast.parse(_module_source())
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module is not None:
+                names.add(node.module)
+    return names
+
+
+def test_no_subprocess_import() -> None:
+    src = _module_source()
+    assert "import subprocess" not in src
+    assert "from subprocess" not in src
+
+
+def test_no_network_library_import() -> None:
+    names = _imported_module_names()
+    forbidden_top = {"socket", "urllib", "requests", "httpx", "aiohttp"}
+    for n in names:
+        top = n.split(".", 1)[0]
+        assert top not in forbidden_top, n
+
+
+def test_no_gh_or_git_in_module_source() -> None:
+    src = _module_source()
+    for needle in ("subprocess.run", " gh ", " git ", "Popen"):
+        assert needle not in src, needle
+
+
+def test_no_dashboard_or_frontend_import() -> None:
+    names = _imported_module_names()
+    for n in names:
+        top = n.split(".", 1)[0]
+        assert top != "dashboard"
+        assert top != "frontend"
+
+
+def test_no_approval_token_import() -> None:
+    names = _imported_module_names()
+    for forbidden in (
+        "reporting.approval_token_gate",
+        "reporting.approval_token_runtime",
+    ):
+        assert forbidden not in names, forbidden
+
+
+def test_no_seed_or_delegation_seed_write_call_in_source() -> None:
+    """The module legitimately references the closed A17 schema
+    keys ``already_in_seed_jsonl`` and ``already_in_delegation_seed``
+    (per ADMISSION_SCHEMA_KEYS), and may include narrative
+    comments mentioning those filenames. What it must NOT do is
+    contain an actual write *call* whose target literal mentions
+    those filenames. AST-level scan: every Call expression whose
+    string argument literal contains 'seed.jsonl' (and isn't
+    'generated_seed.jsonl') is forbidden, and similarly for
+    'delegation_seed.jsonl'."""
+    tree = ast.parse(_module_source())
+    offenders: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        for arg in list(node.args) + [kw.value for kw in node.keywords]:
+            if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                lowered = arg.value.lower()
+                if "delegation_seed.jsonl" in lowered:
+                    offenders.append(
+                        f"line {node.lineno}: Call arg references "
+                        f"delegation_seed.jsonl: {arg.value!r}"
+                    )
+                # Match seed.jsonl but NOT generated_seed.jsonl.
+                if "seed.jsonl" in lowered and (
+                    "generated_seed.jsonl" not in lowered
+                ):
+                    offenders.append(
+                        f"line {node.lineno}: Call arg references "
+                        f"seed.jsonl (not generated_seed): "
+                        f"{arg.value!r}"
+                    )
+    assert not offenders, (
+        "A18c module must not contain a Call whose argument "
+        f"references seed.jsonl or delegation_seed.jsonl: {offenders}"
+    )
+
+
+def test_module_imports_only_allowed_reporting_modules() -> None:
+    names = _imported_module_names()
+    allowed_reporting = {
+        "reporting",
+        "reporting.development_generated_lane_writer",
+        "reporting.development_queue_admission_policy",
+        "reporting.execution_authority",
+        "reporting.agent_audit_summary",
+    }
+    for n in names:
+        if n == "reporting" or n.startswith("reporting."):
+            assert n in allowed_reporting, n
+
+
+def test_module_source_pins_step5_invariants() -> None:
+    src = _module_source()
+    assert "step5_implementation_allowed: Final[bool] = False" in src
+    assert 'STEP5_ENABLED_SUBSTAGE: Final[str] = "none"' in src
+    assert "step5_implementation_allowed = True" not in src
+
+
+def test_module_source_pins_level6_disabled() -> None:
+    src = _module_source().lower()
+    # The module emits ``"level6_enabled": False`` in the envelope
+    # and the discipline_invariants dict; True is never assigned.
+    assert "level6_enabled" in src
+    assert "level6_enabled = true" not in src
+    assert "level6_enabled=true" not in src
+
+
+# ---------------------------------------------------------------------------
+# CLI.
+# ---------------------------------------------------------------------------
+
+
+def test_cli_no_write_emits_env_off_envelope(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = a18c.main(["--no-write"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    snap = json.loads(out)
+    assert snap["enabled"] is False
+    assert snap["note"] == "env_gate_off"
+    assert snap["step5_implementation_allowed"] is False
+    assert snap["level6_enabled"] is False
+
+
+def test_cli_indent_zero_emits_compact(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = a18c.main(["--no-write", "--indent", "0"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    # Compact JSON (indent=None) has no leading whitespace lines.
+    assert "  " not in out.split("\n")[0]
+
+
+def test_cli_default_write_path_is_a18c_artifact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When --no-write is omitted, the CLI must write the envelope
+    to the canonical artefact path. Defense-in-depth: redirect
+    ARTIFACT_LATEST into tmp so we never touch the repo's real
+    logs/ tree."""
+    target_dir = tmp_path / "logs" / "development_generated_lane_a18c"
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target = target_dir / "latest.json"
+    monkeypatch.setattr(a18c, "ARTIFACT_LATEST", target)
+    rc = a18c.main([])
+    assert rc == 0
+    assert target.is_file()
+
+
+# ---------------------------------------------------------------------------
+# Idempotency under monkeypatched a17.evaluate_promotion_record.
+# ---------------------------------------------------------------------------
+
+
+def test_defense_in_depth_force_overrides_a17_admissible(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Even if a future A17 change returned 'admissible' for a row
+    whose would_require_operator_go=True, A18c's defense-in-depth
+    force rewrites the decision to needs_human."""
+    monkeypatch.setattr(
+        a17,
+        "evaluate_promotion_record",
+        lambda row: ("admissible", "auto_allowed_low_risk_eligible_promotion"),
+    )
+    seed_path = tmp_path / "generated_seed.jsonl"
+    _write_seed(
+        seed_path,
+        [
+            _valid_a18b_row(
+                "force-override", would_require_operator_go=True
+            )
+        ],
+    )
+    snap = a18c.collect_snapshot(
+        env={a18c.ENV_GATE: "true"},
+        generated_seed_path=seed_path,
+        prior_artifact_path=tmp_path / "no_prior.json",
+    )
+    [r] = snap["rows"]
+    assert r["admission_decision"] == "needs_human"
+    assert r["admission_reason"] == "needs_human_authority_decision"
+    assert r["would_target_lane"] == "none"

--- a/tests/unit/test_development_generated_lane_a18c_plan.py
+++ b/tests/unit/test_development_generated_lane_a18c_plan.py
@@ -112,17 +112,27 @@ def test_plan_is_markdown() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_plan_states_plan_only() -> None:
+def test_plan_states_design_source_of_truth() -> None:
+    """Post-Phase-4 the plan doc is no longer plan-only — it is
+    the design / governance source-of-truth for the now-implemented
+    A18c projector. This pin enforces the new framing."""
     text = _plan_text().lower()
-    assert "plan only" in text or "plan-only" in text, (
-        "plan must explicitly state it is plan-only."
+    assert "source-of-truth" in text or "source of truth" in text, (
+        "plan must explicitly describe itself as the design / "
+        "governance source-of-truth for the implemented A18c "
+        "projector."
     )
 
 
-def test_plan_states_not_implemented() -> None:
+def test_plan_states_default_disabled_implementation() -> None:
+    """Phase 4 lands A18c default-disabled. The plan doc must
+    state both 'implemented' and 'default-disabled' verbatim."""
     text = _plan_text().lower()
-    assert "not implemented" in text, (
-        "plan must explicitly state A18c is not implemented."
+    assert "implemented" in text, (
+        "plan must state A18c is implemented (default-disabled)."
+    )
+    assert "default-disabled" in text, (
+        "plan must state A18c is default-disabled."
     )
 
 
@@ -389,20 +399,46 @@ def test_plan_contains_combined_invariants_block() -> None:
 # ---------------------------------------------------------------------------
 
 
-_FORBIDDEN_A18C_MODULES: tuple[str, ...] = (
-    "reporting/development_generated_lane_a18c.py",
+_FORBIDDEN_A18C_SIBLING_MODULES: tuple[str, ...] = (
     "reporting/development_generated_lane_a18c_status.py",
     "reporting/development_generated_lane_a18c_writer.py",
     "reporting/development_generated_lane_a18c_admission.py",
 )
 
 
-def test_no_a18c_module_exists() -> None:
-    """A18c is plan-only. No production module may exist on disk."""
-    for rel in _FORBIDDEN_A18C_MODULES:
+def test_a18c_module_exists_default_disabled() -> None:
+    """Post-Phase-4 the A18c projector module exists on disk and
+    is importable. Its ``env_enabled()`` returns ``False`` under
+    an empty env mapping — i.e. default-disabled at import time."""
+    a18c_path = (
+        REPO_ROOT / "reporting" / "development_generated_lane_a18c.py"
+    )
+    assert a18c_path.is_file(), (
+        "A18c module must exist post-Phase-4: "
+        f"{a18c_path}"
+    )
+
+    from reporting import (  # noqa: WPS433 — local import intentional
+        development_generated_lane_a18c as a18c,
+    )
+
+    assert a18c.env_enabled({}) is False, (
+        "A18c must be default-disabled — env_enabled() must return "
+        "False under an empty env mapping."
+    )
+    # Exact-string env-gate name and enabled value are pinned.
+    assert a18c.ENV_GATE == "ADE_GENERATED_LANE_A18C_ENABLED"
+    assert a18c._ENABLED_VALUE == "true"
+
+
+def test_no_a18c_sibling_modules_exist() -> None:
+    """Phase 4 ships a single A18c module. Any sibling status /
+    writer / admission-specific module would expand the surface
+    beyond the approved scope; this pin enforces "one module only"."""
+    for rel in _FORBIDDEN_A18C_SIBLING_MODULES:
         path = REPO_ROOT / rel
         assert not path.exists(), (
-            f"A18c module must not exist (plan-only): {rel}"
+            f"A18c sibling module must not exist: {rel}"
         )
 
 


### PR DESCRIPTION
## Summary

Phase 4 of the autonomous-development-lane phased plan. Ships
the A18c admission projector as an **independent module** that
reads `generated_seed.jsonl` only when env-gated, and projects
eligible rows through A17's existing closed admission
vocabulary by calling
`reporting.development_queue_admission_policy.evaluate_promotion_record()`
verbatim. **A17 is byte-identical post-Phase-4.**

This is Item 3 of today's three-item ordered execution.
Runtime activation on VPS remains gated by the separate
explicit operator-go phrase **\`GO enable A18c on VPS\`** —
which **this PR does not request**.

## Scope (five files, Option II independent projector, no compose change)

| File | Action |
|---|---|
| `reporting/development_generated_lane_a18c.py` | NEW |
| `tests/unit/test_development_generated_lane_a18c.py` | NEW (47 tests) |
| `docs/governance/development_generated_lane_a18c_plan.md` | surgical: plan-only → implemented default-disabled |
| `tests/unit/test_development_generated_lane_a18c_plan.py` | surgical: replaces three pre-Phase-4 pins |
| `docs/governance/development_generated_lane.md` | single-line cross-reference update |

## Module pins (verified by tests)

* `ENV_GATE = \"ADE_GENERATED_LANE_A18C_ENABLED\"`
* enabled value = exact literal string `\"true\"`
* `PER_TICK_CAP = 8`
* `PER_DAY_CAP = 32`
* `MODULE_VERSION = \"v3.15.16.A18c\"`
* `STEP5_ENABLED_SUBSTAGE = \"none\"`
* `step5_implementation_allowed = False`

## Module behavior (pinned by 47 tests)

* **env-off**: returns no-op envelope (`enabled=False`,
  `note=env_gate_off`, `warnings=[env_gate_off_no_op]`). Does
  NOT read `generated_seed.jsonl`. Pinned by a test that
  monkey-patches `_read_generated_seed` to fail-if-called.
* **env-on + absent seed**: safe `generated_seed_absent`
  envelope.
* **env-on + malformed seed** (any line fails JSON parse or
  fails A18b's `GENERATED_RECORD_KEYS` closed schema):
  default-deny `generated_seed_malformed` envelope, zero rows,
  no crash.
* **env-on + valid seed**: synthesises A17-shaped upstream
  rows and calls `a17.evaluate_promotion_record(synth)`
  verbatim. **Defense in depth**: if
  `would_require_operator_go=True` and A17's decision came
  back `\"admissible\"`, the decision is rewritten to
  `\"needs_human\"` / reason
  `\"needs_human_authority_decision\"`.
* Deterministic A18c candidate-id:
  `a18c-{generated_candidate_id}-{evidence_hash[:16]}`.
* Per-tick cap 8 + per-day cap 32 enforced. Per-day cap reads
  the prior `latest.json` snapshot's `counts.total` when its
  `generated_at_utc` matches today's UTC date prefix.
* Duplicate candidate-id within a tick → hard-suppressed.
* Duplicate evidence-hash across rows → soft warning
  `duplicate_evidence_hash_in_a18b`.
* Atomic-write sentinel restricts writes to
  `logs/development_generated_lane_a18c/`.
* `assert_no_secrets` on every envelope before write.
* CLI: `python -m reporting.development_generated_lane_a18c`
  with `--no-write` and `--indent` flags.

## Phase-2 diagnostic row protection (key safety property)

The Phase-2 diagnostic row
\`generated_candidate_id=\"a18b-phase2-smoke-2026-05-13-001\"\`
with \`would_require_operator_go=True\` **always** maps to
\`needs_human\` under A18c projection. Never \`admissible\`,
never executable. Pinned by two dedicated tests.

No row in any mixed test fixture surfaces as \`admissible\` —
the first-cut posture is conservative.

## Hard guarantees pinned by tests

* Default-disabled at import time (`env_enabled({}) is False`).
* Closed schema mirrors A17's `ADMISSION_SCHEMA_KEYS` exactly
  (23 keys verbatim).
* Six discipline invariants present in every envelope.
* 18-key `discipline_invariants` dict in every envelope.
* A17 `ADMISSION_DECISIONS` / `MODULE_VERSION` unchanged
  post-import.
* AST / source-text scans: no \`subprocess\`, \`socket\`,
  \`urllib\`, \`requests\`, \`httpx\`, \`aiohttp\`, \` gh \`,
  \` git \`, no \`dashboard.\` / \`frontend.\` /
  \`approval_token_gate\` / \`approval_token_runtime\` import,
  no \`seed.jsonl\` / \`delegation_seed.jsonl\` write Call.
* Import allowlist: stdlib +
  \`reporting.development_generated_lane_writer\` +
  \`reporting.development_queue_admission_policy\` +
  \`reporting.execution_authority\` +
  \`reporting.agent_audit_summary\` only.

## What is NOT touched

* `reporting/development_queue_admission_policy.py` — A17
  byte-identical
* `reporting/development_generated_lane_writer.py` — A18b
  byte-identical
* `reporting/recurring_maintenance.py` — A18c is **not**
  registered as a recurring job (separate later PR)
* \`dashboard/**\`, \`frontend/**\`, \`scripts/**\`,
  \`.github/workflows/**\`
* \`.claude/**\`, \`.gitleaks.toml\`, \`research/**\`,
  \`live/**\`, \`paper/**\`, \`shadow/**\`, \`risk/**\`,
  \`broker/**\`, \`execution/**\`
* \`docker-compose*.yml\` — Option β2 directory-mount migration
  is explicitly NOT required for default-disabled posture (A18c
  is a reader; reads work fine through the existing
  file-level bind mount per the A18b host-side write runbook)
* No \`generated_seed.jsonl\` record written
* No env activation
* No Step 5 substage promotion or flag flip
* No Level 6 change
* No N5b phase change
* No GitHub mutation; no token mint/verify; no deploy coupling
* No A18c runtime activation

## Test plan

- [x] \`python scripts/governance_lint.py\` — OK
- [x] \`python -m pytest tests/smoke -q\` — 18 passed
- [x] \`python -m pytest tests/unit/test_development_generated_lane_a18c.py -q\` — 47 passed
- [x] \`python -m pytest tests/unit/test_development_generated_lane_a18c_plan.py -q\` — 47 passed
- [x] \`python -m pytest tests/unit/test_a18b_writer_host_side_write_runbook.py -q\` — still green
- [x] \`python -m pytest tests/unit/test_autonomous_development_baseline_observation_runbook.py -q\` — still green
- [x] \`python -m pytest tests/unit/test_development_queue_admission_policy.py -q\` — A17 tests still green
- [x] \`python -m reporting.development_generated_lane_writer --no-write\` — invariants green
- [x] \`python -m reporting.development_step5_loop --no-write\` — invariants green
- [x] \`python -m reporting.development_operational_digest --no-write\` — invariant green
- [x] \`python -m reporting.development_generated_lane_a18c --no-write\` —
  \`enabled=false\`, \`note=env_gate_off\`, \`per_tick_cap=8\`,
  \`per_day_cap=32\`, Step 5 / Level 6 invariants intact

## Operator verification after merge

Auto-deploy will redeploy the dashboard image (new
\`reporting/\` module present). No new route, no new
schedule, no new env. The CLI is invocable on VPS:

\`\`\`bash
cd /root/trading-agent
python3 -m reporting.development_generated_lane_a18c --no-write
# expected: enabled=false, note=env_gate_off,
# Step 5 / Level 6 invariants intact, generated_seed.jsonl NOT read.
\`\`\`

Runtime activation **remains gated** by the separate explicit
operator-go: \`GO enable A18c on VPS\`. **No env export by this
PR.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)