### PR TITLE
feat(a18-phase5a): promotion-readiness report (read-only, no promotion)

### DIFF
--- a/docs/governance/development_generated_lane_a18c_plan.md
+++ b/docs/governance/development_generated_lane_a18c_plan.md
@@ -583,3 +583,8 @@ emitted.
   — per-action authority decisions.
 * [`docs/governance/no_touch_paths.md`](no_touch_paths.md) —
   the protected paths.
+* [`reporting/development_generated_lane_promotion_report.py`](../../reporting/development_generated_lane_promotion_report.py)
+  — read-only promotion-readiness report consumer (Phase 5a).
+  Reports on what *would* be required for operator-promote;
+  never promotes. Hard-pinned `promotion_allowed=false` on every
+  row.

--- a/reporting/development_generated_lane_promotion_report.py
+++ b/reporting/development_generated_lane_promotion_report.py
@@ -1,0 +1,581 @@
+"""A18 promotion-readiness report (read-only / report-only).
+
+Pure stdlib projector that reads the existing A18c artefact at
+``logs/development_generated_lane_a18c/latest.json`` and emits a
+closed-schema **report-only** snapshot at
+``logs/development_generated_lane_promotion_report/latest.json``.
+
+This module is the Phase 5a slice. It surfaces what *would* be
+required to promote any A18c-projected row into the queue
+admission path, **without ever promoting anything**. The
+hard-pinned safety property is: for **every** row this module
+emits, ``promotion_allowed = False``. Promotion remains a
+separate operator-paced future step gated by the explicit
+operator-go phrase ``GO A18 promotion operator-promote``.
+
+Hard guarantees pinned by the companion tests
+---------------------------------------------
+
+* Stdlib + ``reporting.development_generated_lane_a18c`` (closed
+  vocab + artefact path constants) +
+  ``reporting.development_queue_admission_policy`` (closed
+  ADMISSION_DECISIONS / ADMISSION_REASONS for vocab pinning) +
+  ``reporting.agent_audit_summary.assert_no_secrets`` (read-only
+  redactor guard).
+* No subprocess, no network, no ``gh``, no ``git``.
+* No imports of ``dashboard``, ``frontend``, ``automation``,
+  ``broker``, ``agent.risk``, ``agent.execution``, ``research``,
+  ``reporting.intelligent_routing``, ``live``, ``paper``,
+  ``shadow``, ``trading``, ``reporting.approval_token_gate``,
+  ``reporting.approval_token_runtime``,
+  ``reporting.development_generated_lane_writer`` (this module
+  never touches A18b; it consumes A18c's already-projected
+  artefact).
+* Atomic write only under
+  ``logs/development_generated_lane_promotion_report/...``.
+* The closed envelope schema carries every report row's
+  ``promotion_allowed`` field as **hard-pinned False** —
+  regardless of the A18c admission decision, even an A18c row
+  that ever returned ``admissible`` would have
+  ``promotion_allowed=False`` in the report. The report is
+  forensic / oversight only; the report module itself NEVER
+  enables a promotion path.
+* The closed envelope carries the required operator-go phrase
+  literally (``"GO A18 promotion operator-promote"``) so a
+  consumer can render it verbatim.
+* Closed ``BLOCK_REASONS`` and ``READINESS_NOTES`` vocabularies.
+* Per-row schema is closed and exact; bounded scalars only.
+* ``step5_implementation_allowed`` remains ``False`` and
+  ``STEP5_ENABLED_SUBSTAGE`` remains ``"none"``.
+* Level 6 is permanently disabled per ADR-015 §Doctrine 1.
+
+What this module is NOT
+-----------------------
+
+* It is **not** a promotion engine. It never writes to
+  ``generated_seed.jsonl`` (A18b territory). It never admits a
+  queue row (A17 territory). It never executes work.
+* It is **not** an A18c re-projector. It reads A18c's
+  ``latest.json`` once per call and never triggers A18c.
+* It is **not** an A17 mutation. The A17 admission policy
+  module's artefact is never created, mutated, or read for
+  writing by this module.
+* It is **not** authorised to promote the Phase-2 diagnostic
+  row (``a18b-phase2-smoke-2026-05-13-001``). Every row the
+  report emits carries ``promotion_allowed=False``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Final
+
+from reporting import development_generated_lane_a18c as a18c
+from reporting import development_queue_admission_policy as a17
+from reporting.agent_audit_summary import assert_no_secrets
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[str] = "1.0"
+MODULE_VERSION: Final[str] = "v3.15.16.A18.promotion_report"
+REPORT_KIND: Final[str] = "development_generated_lane_promotion_report"
+
+
+# ---------------------------------------------------------------------------
+# Step 5 invariants
+# ---------------------------------------------------------------------------
+
+STEP5_ENABLED_SUBSTAGE: Final[str] = "none"
+step5_implementation_allowed: Final[bool] = False
+
+
+# ---------------------------------------------------------------------------
+# Pinned safety constants
+# ---------------------------------------------------------------------------
+
+#: For every report row, promotion_allowed is hard-pinned to False.
+#: This module never enables a promotion path. The constant exists
+#: so consumers (and the companion test) can pin it explicitly.
+PROMOTION_ALLOWED_DEFAULT: Final[bool] = False
+
+#: Exact operator-go phrase a future PR would issue to actually
+#: build operator-promote functionality. The report surfaces this
+#: phrase verbatim so a consumer can render it. The phrase itself
+#: is NOT issued by this module; it identifies the future-go.
+OPERATOR_GO_PHRASE: Final[str] = "GO A18 promotion operator-promote"
+
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies
+# ---------------------------------------------------------------------------
+
+#: Closed per-row block-reason vocabulary. The first four values
+#: mirror A17's admission_decision outcomes via a deterministic
+#: mapping. The fifth value is defense-in-depth: even if an A18c
+#: row ever carried admission_decision="admissible", this report
+#: would emit promotion_disabled_by_default and STILL set
+#: promotion_allowed=False.
+BLOCK_REASONS: Final[tuple[str, ...]] = (
+    "needs_human_per_a17_policy",
+    "blocked_per_a17_policy",
+    "duplicate_per_a17_policy",
+    "not_eligible_upstream_per_a17_policy",
+    "promotion_disabled_by_default",
+)
+
+#: Closed envelope-level readiness-note vocabulary.
+READINESS_NOTES: Final[tuple[str, ...]] = (
+    "a18c_artifact_absent",
+    "a18c_artifact_malformed",
+    "no_source_rows",
+    "rows_present_none_promotable",
+)
+
+
+# ---------------------------------------------------------------------------
+# Per-row closed schema
+# ---------------------------------------------------------------------------
+
+REPORT_ROW_KEYS: Final[tuple[str, ...]] = (
+    "candidate_id",
+    "source_kind",
+    "candidate_kind",
+    "admission_decision",
+    "admission_reason",
+    "would_target_lane",
+    "human_needed",
+    "human_needed_reason",
+    "risk_level",
+    "promotion_allowed",
+    "block_reason",
+    "required_operator_go_phrase",
+    "readiness_reason",
+    "evaluated_at",
+)
+
+
+# ---------------------------------------------------------------------------
+# Repo-relative paths
+# ---------------------------------------------------------------------------
+
+ARTIFACT_DIR: Final[Path] = (
+    REPO_ROOT / "logs" / "development_generated_lane_promotion_report"
+)
+ARTIFACT_LATEST: Final[Path] = ARTIFACT_DIR / "latest.json"
+ARTIFACT_RELATIVE_PATH: Final[str] = (
+    "logs/development_generated_lane_promotion_report/latest.json"
+)
+
+#: Atomic-write allowlist (substring form). Any attempt to write
+#: outside this prefix raises ``ValueError``.
+_WRITE_PREFIX: Final[str] = (
+    "logs/development_generated_lane_promotion_report/"
+)
+
+
+# ---------------------------------------------------------------------------
+# Discipline invariants
+# ---------------------------------------------------------------------------
+
+_DISCIPLINE_INVARIANTS: Final[dict[str, bool | str]] = {
+    "default_disabled": False,
+    "promotes_anything": False,
+    "writes_to_seed_jsonl": False,
+    "writes_to_delegation_seed_jsonl": False,
+    "writes_to_generated_seed_jsonl": False,
+    "mutates_a18c_artifact": False,
+    "mutates_a17_artifact": False,
+    "admits_to_queue": False,
+    "executes_work": False,
+    "creates_branches": False,
+    "opens_prs": False,
+    "merges_prs": False,
+    "deploys": False,
+    "calls_network": False,
+    "uses_subprocess": False,
+    "touches_step5_flags": False,
+    "level6_enabled": False,
+}
+
+
+# ---------------------------------------------------------------------------
+# Utility helpers
+# ---------------------------------------------------------------------------
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _read_a18c_artifact(
+    path: Path,
+) -> tuple[str, dict[str, Any] | None]:
+    """Return ``("ok", payload)``, ``("absent", None)``, or
+    ``("malformed", None)``. Never raises."""
+    if not path.is_file():
+        return ("absent", None)
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return ("malformed", None)
+    try:
+        data = json.loads(text)
+    except (ValueError, json.JSONDecodeError):
+        return ("malformed", None)
+    if not isinstance(data, dict):
+        return ("malformed", None)
+    return ("ok", data)
+
+
+# ---------------------------------------------------------------------------
+# Per-row block-reason mapping
+# ---------------------------------------------------------------------------
+
+
+def _map_block_reason(admission_decision: str) -> str:
+    """Map an A17 admission_decision to this report's closed
+    ``BLOCK_REASONS`` vocabulary.
+
+    The default-deny case (any decision not in the closed map,
+    including the hypothetical ``"admissible"`` value that the
+    A18c first-cut posture never emits) returns
+    ``"promotion_disabled_by_default"`` — the defense-in-depth
+    catch-all that still asserts the report does not promote.
+    """
+    mapping = {
+        "needs_human": "needs_human_per_a17_policy",
+        "blocked": "blocked_per_a17_policy",
+        "duplicate_of_existing": "duplicate_per_a17_policy",
+        "not_eligible_upstream": "not_eligible_upstream_per_a17_policy",
+    }
+    return mapping.get(admission_decision, "promotion_disabled_by_default")
+
+
+# ---------------------------------------------------------------------------
+# Per-row construction
+# ---------------------------------------------------------------------------
+
+
+def _build_report_row(
+    a18c_row: dict[str, Any],
+) -> dict[str, Any]:
+    """Build a single closed-schema report row from an A18c row.
+    Hard-pinned: ``promotion_allowed=False`` regardless of the
+    A18c decision."""
+    admission_decision = str(a18c_row.get("admission_decision") or "")
+    admission_reason = str(a18c_row.get("admission_reason") or "")
+    candidate_id = str(a18c_row.get("candidate_id") or "")
+    source_kind = str(a18c_row.get("source_kind") or "")
+    candidate_kind = str(a18c_row.get("candidate_kind") or "")
+    would_target_lane = str(a18c_row.get("would_target_lane") or "none")
+    human_needed = bool(a18c_row.get("human_needed"))
+    human_needed_reason = str(a18c_row.get("human_needed_reason") or "")
+    risk_level = str(a18c_row.get("risk_level") or "")
+    evaluated_at = str(a18c_row.get("evaluated_at") or "")
+
+    block_reason = _map_block_reason(admission_decision)
+
+    # The readiness-reason mirrors the block-reason for forensic
+    # clarity; both are emitted because consumers may prefer one
+    # framing over the other (block-reason answers "why blocked?",
+    # readiness-reason answers "what would it take to ready?").
+    readiness_reason = block_reason
+
+    row: dict[str, Any] = {
+        "candidate_id": candidate_id,
+        "source_kind": source_kind,
+        "candidate_kind": candidate_kind,
+        "admission_decision": admission_decision,
+        "admission_reason": admission_reason,
+        "would_target_lane": would_target_lane,
+        "human_needed": human_needed,
+        "human_needed_reason": human_needed_reason,
+        "risk_level": risk_level,
+        # HARD-PINNED False — this module never promotes.
+        "promotion_allowed": PROMOTION_ALLOWED_DEFAULT,
+        "block_reason": block_reason,
+        "required_operator_go_phrase": OPERATOR_GO_PHRASE,
+        "readiness_reason": readiness_reason,
+        "evaluated_at": evaluated_at,
+    }
+    assert set(row.keys()) == set(REPORT_ROW_KEYS), (
+        "report row key drift: "
+        f"{sorted(row.keys())!r} vs {sorted(REPORT_ROW_KEYS)!r}"
+    )
+    # Defense in depth — this module never promotes; pin again.
+    assert row["promotion_allowed"] is False
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Aggregation
+# ---------------------------------------------------------------------------
+
+
+def _aggregate_by_decision(rows: list[dict[str, Any]]) -> dict[str, int]:
+    counts: dict[str, int] = {d: 0 for d in a17.ADMISSION_DECISIONS}
+    for r in rows:
+        d = r.get("admission_decision")
+        if d in counts:
+            counts[d] += 1
+    return counts
+
+
+# ---------------------------------------------------------------------------
+# Envelope assembly
+# ---------------------------------------------------------------------------
+
+
+def _build_envelope(
+    *,
+    a18c_artifact_path: Path,
+    a18c_artifact_available: bool,
+    a18c_module_version: str | None,
+    a17_policy_version: str | None,
+    rows: list[dict[str, Any]],
+    readiness_note: str,
+    validation_warnings: list[str],
+    generated_at_utc: str,
+) -> dict[str, Any]:
+    """Build the closed-schema envelope. Always carries the
+    discipline invariants and the report's safety constants."""
+    source_row_count = len(rows)
+    # Hard-pinned: zero promotable rows in this report module.
+    promotable_row_count = sum(
+        1 for r in rows if r["promotion_allowed"] is True
+    )
+    blocked_row_count = source_row_count - promotable_row_count
+    snapshot: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": generated_at_utc,
+        "a18c_artifact_path": str(a18c_artifact_path),
+        "a18c_artifact_available": a18c_artifact_available,
+        "a18c_module_version": a18c_module_version,
+        "a17_policy_version": a17_policy_version,
+        "source_row_count": source_row_count,
+        "promotable_row_count": promotable_row_count,
+        "blocked_row_count": blocked_row_count,
+        "rows_by_admission_decision": _aggregate_by_decision(rows),
+        "rows": rows,
+        "readiness_note": readiness_note,
+        "validation_warnings": list(validation_warnings),
+        "operator_go_phrase_required": OPERATOR_GO_PHRASE,
+        "policy_version": a17.MODULE_VERSION,
+        "a18c_module_version_pin": a18c.MODULE_VERSION,
+        "promotion_allowed_default": PROMOTION_ALLOWED_DEFAULT,
+        "vocabularies": {
+            "block_reasons": list(BLOCK_REASONS),
+            "readiness_notes": list(READINESS_NOTES),
+            "admission_decisions": list(a17.ADMISSION_DECISIONS),
+            "admission_reasons": list(a17.ADMISSION_REASONS),
+            "row_keys": list(REPORT_ROW_KEYS),
+        },
+        "step5_implementation_allowed": step5_implementation_allowed,
+        "step5_enabled_substage": STEP5_ENABLED_SUBSTAGE,
+        "level6_enabled": False,
+        "dry_run_only": True,
+        "live_merge_implemented": False,
+        "deploy_coupled": False,
+        "discipline_invariants": dict(_DISCIPLINE_INVARIANTS),
+    }
+    # Hard pin: defense-in-depth.
+    assert snapshot["promotable_row_count"] == 0, (
+        "promotable_row_count must be 0 — this module never promotes"
+    )
+    # Scrub the envelope before write.
+    assert_no_secrets(snapshot)
+    return snapshot
+
+
+def collect_snapshot(
+    *,
+    a18c_artifact_path: Path | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    """Build the deterministic promotion-readiness report
+    snapshot. Pure — reads one read-only artefact (A18c's
+    ``latest.json``), performs no write of any kind."""
+    a18c_path = (
+        a18c_artifact_path
+        if a18c_artifact_path is not None
+        else a18c.ARTIFACT_LATEST
+    )
+    ts = generated_at_utc if generated_at_utc is not None else _utcnow()
+
+    status, payload = _read_a18c_artifact(a18c_path)
+
+    if status == "absent":
+        return _build_envelope(
+            a18c_artifact_path=a18c_path,
+            a18c_artifact_available=False,
+            a18c_module_version=None,
+            a17_policy_version=None,
+            rows=[],
+            readiness_note="a18c_artifact_absent",
+            validation_warnings=["a18c_artifact_absent"],
+            generated_at_utc=ts,
+        )
+
+    if status == "malformed":
+        return _build_envelope(
+            a18c_artifact_path=a18c_path,
+            a18c_artifact_available=False,
+            a18c_module_version=None,
+            a17_policy_version=None,
+            rows=[],
+            readiness_note="a18c_artifact_malformed",
+            validation_warnings=["a18c_artifact_malformed"],
+            generated_at_utc=ts,
+        )
+
+    # payload is a dict (status="ok")
+    assert payload is not None  # type narrowing
+    a18c_module_version = (
+        str(payload.get("module_version") or "")
+        or None
+    )
+    a17_policy_version = (
+        str(payload.get("policy_version") or "")
+        or None
+    )
+
+    raw_rows = payload.get("rows")
+    a18c_rows: list[dict[str, Any]] = []
+    if isinstance(raw_rows, list):
+        for r in raw_rows:
+            if isinstance(r, dict):
+                a18c_rows.append(r)
+
+    rows: list[dict[str, Any]] = [_build_report_row(r) for r in a18c_rows]
+
+    if not rows:
+        return _build_envelope(
+            a18c_artifact_path=a18c_path,
+            a18c_artifact_available=True,
+            a18c_module_version=a18c_module_version,
+            a17_policy_version=a17_policy_version,
+            rows=[],
+            readiness_note="no_source_rows",
+            validation_warnings=[],
+            generated_at_utc=ts,
+        )
+
+    return _build_envelope(
+        a18c_artifact_path=a18c_path,
+        a18c_artifact_available=True,
+        a18c_module_version=a18c_module_version,
+        a17_policy_version=a17_policy_version,
+        rows=rows,
+        readiness_note="rows_present_none_promotable",
+        validation_warnings=[],
+        generated_at_utc=ts,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Atomic write (sentinel-restricted)
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    posix = path.as_posix()
+    if _WRITE_PREFIX not in posix and not posix.startswith(_WRITE_PREFIX):
+        raise ValueError(
+            "development_generated_lane_promotion_report._atomic_write_json "
+            f"refuses non-report-logs output path: {path}"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".development_generated_lane_promotion_report.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_outputs(snapshot: dict[str, Any]) -> Path:
+    """Persist the snapshot to
+    ``logs/development_generated_lane_promotion_report/latest.json``.
+    Sentinel-restricted via :func:`_atomic_write_json`."""
+    _atomic_write_json(ARTIFACT_LATEST, snapshot)
+    return ARTIFACT_LATEST
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m reporting.development_generated_lane_promotion_report",
+        description=(
+            "A18 promotion-readiness report (read-only / "
+            "report-only). Reads the existing A18c artefact at "
+            "logs/development_generated_lane_a18c/latest.json "
+            "and emits a closed-schema report at "
+            "logs/development_generated_lane_promotion_report/latest.json. "
+            "NEVER promotes, NEVER mutates A18c or A17 artefacts, "
+            "NEVER writes to generated_seed.jsonl / seed.jsonl / "
+            "delegation_seed.jsonl, NEVER admits queue rows, "
+            "NEVER executes work, NEVER opens / merges a PR, "
+            "NEVER deploys. The report surfaces the exact "
+            "operator-go phrase that a future PR would issue to "
+            "build operator-promote functionality, but the phrase "
+            "itself is NOT issued here."
+        ),
+    )
+    p.add_argument(
+        "--no-write",
+        action="store_true",
+        help=(
+            "Do not persist "
+            "logs/development_generated_lane_promotion_report/latest.json "
+            "(stdout only)."
+        ),
+    )
+    p.add_argument(
+        "--indent",
+        type=int,
+        default=2,
+        help="JSON indent (0 for compact).",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    indent = args.indent if args.indent and args.indent > 0 else None
+    snap = collect_snapshot()
+    if not args.no_write:
+        write_outputs(snap)
+    json.dump(snap, sys.stdout, indent=indent, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/unit/test_development_generated_lane_promotion_report.py
+++ b/tests/unit/test_development_generated_lane_promotion_report.py
@@ -1,0 +1,807 @@
+"""Tests for the A18 promotion-readiness report (read-only).
+
+Hard guarantees verified here:
+
+* Default-disabled-style invariants: this module is read-only
+  by construction; it never promotes any row. ``PROMOTION_ALLOWED_DEFAULT``
+  is the pinned constant False; every emitted row carries
+  ``promotion_allowed=False`` regardless of the underlying A18c
+  admission decision.
+* A18c artefact absent → safe ``not_available`` envelope
+  (``a18c_artifact_available=False``, ``readiness_note="a18c_artifact_absent"``).
+* A18c artefact malformed → safe ``not_available`` envelope
+  (``readiness_note="a18c_artifact_malformed"``), no crash.
+* Phase-2 diagnostic row (the
+  ``a18b-phase2-smoke-2026-05-13-001`` candidate-id, projected
+  by A18c with ``admission_decision="needs_human"``) → one
+  report row, ``promotion_allowed=False``,
+  ``block_reason="needs_human_per_a17_policy"``,
+  ``required_operator_go_phrase="GO A18 promotion operator-promote"``.
+* Defense-in-depth: an A18c row carrying
+  ``admission_decision="admissible"`` (the A18c first-cut
+  posture never emits this, but if a future change did) STILL
+  produces a report row with ``promotion_allowed=False`` and
+  ``block_reason="promotion_disabled_by_default"``.
+* Closed envelope schema and closed BLOCK_REASONS / READINESS_NOTES
+  vocabularies.
+* Atomic write sentinel refuses any path outside
+  ``logs/development_generated_lane_promotion_report/``.
+* Source / AST scans: no subprocess, no socket / urllib /
+  requests / httpx / aiohttp / gh / git, no dashboard /
+  frontend / approval-token / A18b writer imports, no
+  seed.jsonl / delegation_seed.jsonl / generated_seed.jsonl
+  write Call (the module never opens those files for write).
+* CLI ``--no-write`` works; default invocation writes the
+  canonical report path.
+* Step 5 / Level 6 invariants intact.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reporting import development_generated_lane_a18c as a18c
+from reporting import development_generated_lane_promotion_report as report
+from reporting import development_queue_admission_policy as a17
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _a18c_row(
+    *,
+    candidate_id: str,
+    admission_decision: str = "needs_human",
+    admission_reason: str = "needs_human_authority_decision",
+    would_target_lane: str = "none",
+    human_needed: bool = True,
+    human_needed_reason: str = "would_require_operator_go",
+    candidate_kind: str = "e2e_proof",
+    risk_level: str = "UNKNOWN",
+    source_kind: str = "generated_seed_lane",
+    evaluated_at: str = "2026-05-13T13:00:00Z",
+) -> dict[str, Any]:
+    """Build a single A18c-shape row matching A17's
+    ADMISSION_SCHEMA_KEYS verbatim. The promotion-report consumes
+    only a subset of these fields; we set every key present in
+    A17's schema so a future A18c key addition does not silently
+    break the test fixture."""
+    return {
+        "candidate_id": candidate_id,
+        "title": "diagnostic title",
+        "source_document": "/app/generated_seed.jsonl",
+        "source_kind": source_kind,
+        "roadmap_phase": "",
+        "candidate_kind": candidate_kind,
+        "required_agent_role": "operator" if human_needed else "",
+        "risk_level": risk_level,
+        "target_path": "",
+        "upstream_intake_status": "generated_seed_present",
+        "upstream_decision_state": "needs_human",
+        "upstream_execution_authority_decision": "NEEDS_HUMAN",
+        "reclassified_execution_authority_decision": "NEEDS_HUMAN",
+        "classification_drift": False,
+        "human_needed": human_needed,
+        "human_needed_reason": human_needed_reason,
+        "admission_decision": admission_decision,
+        "admission_reason": admission_reason,
+        "would_target_lane": would_target_lane,
+        "already_in_seed_jsonl": False,
+        "already_in_delegation_seed": False,
+        "policy_version": "v3.15.16.A17",
+        "evaluated_at": evaluated_at,
+    }
+
+
+def _a18c_artifact(
+    rows: list[dict[str, Any]],
+    *,
+    module_version: str = "v3.15.16.A18c",
+    policy_version: str = "v3.15.16.A17",
+    enabled: bool = True,
+    note: str = "candidates_projected",
+) -> dict[str, Any]:
+    """Build a closed-shape A18c snapshot envelope."""
+    return {
+        "schema_version": "1.0",
+        "module_version": module_version,
+        "report_kind": "development_generated_lane_a18c",
+        "generated_at_utc": "2026-05-13T13:00:00Z",
+        "enabled": enabled,
+        "env_gate_name": "ADE_GENERATED_LANE_A18C_ENABLED",
+        "generated_seed_path": "/app/generated_seed.jsonl",
+        "rows": rows,
+        "counts": {"total": len(rows)},
+        "note": note,
+        "validation_warnings": [],
+        "vocabularies": {},
+        "policy_version": policy_version,
+        "a18b_writer_module_version": "v3.15.16.A18b",
+        "per_tick_cap": 8,
+        "per_day_cap": 32,
+        "step5_implementation_allowed": False,
+        "step5_enabled_substage": "none",
+        "level6_enabled": False,
+        "dry_run_only": True,
+        "live_merge_implemented": False,
+        "deploy_coupled": False,
+        "discipline_invariants": {},
+    }
+
+
+def _write_a18c_artifact(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Closed-vocab module surface
+# ---------------------------------------------------------------------------
+
+
+def test_module_version_pin() -> None:
+    assert report.MODULE_VERSION == "v3.15.16.A18.promotion_report"
+
+
+def test_report_kind_pin() -> None:
+    assert report.REPORT_KIND == (
+        "development_generated_lane_promotion_report"
+    )
+
+
+def test_artifact_relative_path_pin() -> None:
+    assert report.ARTIFACT_RELATIVE_PATH == (
+        "logs/development_generated_lane_promotion_report/latest.json"
+    )
+
+
+def test_operator_go_phrase_pin() -> None:
+    """The exact operator-go phrase a future PR would issue to
+    build operator-promote functionality. The phrase itself is
+    NOT issued by this module; it identifies the future-go."""
+    assert report.OPERATOR_GO_PHRASE == (
+        "GO A18 promotion operator-promote"
+    )
+
+
+def test_promotion_allowed_default_is_false() -> None:
+    assert report.PROMOTION_ALLOWED_DEFAULT is False
+
+
+def test_block_reasons_closed_vocab() -> None:
+    assert set(report.BLOCK_REASONS) == {
+        "needs_human_per_a17_policy",
+        "blocked_per_a17_policy",
+        "duplicate_per_a17_policy",
+        "not_eligible_upstream_per_a17_policy",
+        "promotion_disabled_by_default",
+    }
+
+
+def test_readiness_notes_closed_vocab() -> None:
+    assert set(report.READINESS_NOTES) == {
+        "a18c_artifact_absent",
+        "a18c_artifact_malformed",
+        "no_source_rows",
+        "rows_present_none_promotable",
+    }
+
+
+def test_step5_invariants_intact_by_import() -> None:
+    assert report.step5_implementation_allowed is False
+    assert report.STEP5_ENABLED_SUBSTAGE == "none"
+
+
+# ---------------------------------------------------------------------------
+# Absent / malformed source artefact.
+# ---------------------------------------------------------------------------
+
+
+def test_absent_a18c_artifact_returns_safe_envelope(tmp_path: Path) -> None:
+    a18c_path = tmp_path / "logs" / "development_generated_lane_a18c" / "latest.json"
+    snap = report.collect_snapshot(a18c_artifact_path=a18c_path)
+    assert snap["a18c_artifact_available"] is False
+    assert snap["readiness_note"] == "a18c_artifact_absent"
+    assert "a18c_artifact_absent" in snap["validation_warnings"]
+    assert snap["source_row_count"] == 0
+    assert snap["promotable_row_count"] == 0
+    assert snap["blocked_row_count"] == 0
+    assert snap["rows"] == []
+
+
+def test_malformed_a18c_artifact_returns_safe_envelope(tmp_path: Path) -> None:
+    a18c_path = tmp_path / "a18c.json"
+    a18c_path.write_text("not json at all\n", encoding="utf-8")
+    snap = report.collect_snapshot(a18c_artifact_path=a18c_path)
+    assert snap["readiness_note"] == "a18c_artifact_malformed"
+    assert snap["rows"] == []
+    assert snap["promotable_row_count"] == 0
+
+
+def test_a18c_artifact_non_object_returns_malformed(tmp_path: Path) -> None:
+    a18c_path = tmp_path / "a18c.json"
+    a18c_path.write_text("[1, 2, 3]", encoding="utf-8")
+    snap = report.collect_snapshot(a18c_artifact_path=a18c_path)
+    assert snap["readiness_note"] == "a18c_artifact_malformed"
+    assert snap["rows"] == []
+
+
+def test_a18c_artifact_empty_rows_returns_no_source_rows(
+    tmp_path: Path,
+) -> None:
+    a18c_path = tmp_path / "a18c.json"
+    _write_a18c_artifact(a18c_path, _a18c_artifact([], note="no_eligible_a18b_rows"))
+    snap = report.collect_snapshot(a18c_artifact_path=a18c_path)
+    assert snap["a18c_artifact_available"] is True
+    assert snap["readiness_note"] == "no_source_rows"
+    assert snap["source_row_count"] == 0
+    assert snap["promotable_row_count"] == 0
+    assert snap["rows"] == []
+
+
+# ---------------------------------------------------------------------------
+# Phase-2 diagnostic row protection (key safety property).
+# ---------------------------------------------------------------------------
+
+
+def test_phase2_diagnostic_row_emits_promotion_allowed_false(
+    tmp_path: Path,
+) -> None:
+    """The exact Phase-2 candidate-id from the operator's
+    confirmed VPS state. A18c projects it with
+    admission_decision='needs_human'. The report must surface
+    one row with promotion_allowed=False and block_reason
+    'needs_human_per_a17_policy'."""
+    a18c_path = tmp_path / "a18c.json"
+    a18c_row = _a18c_row(
+        candidate_id=(
+            "a18c-a18b-phase2-smoke-2026-05-13-001-abcdef0123456789"
+        ),
+        admission_decision="needs_human",
+        admission_reason="needs_human_authority_decision",
+    )
+    _write_a18c_artifact(a18c_path, _a18c_artifact([a18c_row]))
+    snap = report.collect_snapshot(a18c_artifact_path=a18c_path)
+    assert snap["a18c_artifact_available"] is True
+    assert snap["source_row_count"] == 1
+    assert snap["promotable_row_count"] == 0
+    assert snap["blocked_row_count"] == 1
+    assert snap["readiness_note"] == "rows_present_none_promotable"
+    [r] = snap["rows"]
+    assert r["candidate_id"] == (
+        "a18c-a18b-phase2-smoke-2026-05-13-001-abcdef0123456789"
+    )
+    assert r["admission_decision"] == "needs_human"
+    assert r["admission_reason"] == "needs_human_authority_decision"
+    assert r["promotion_allowed"] is False
+    assert r["block_reason"] == "needs_human_per_a17_policy"
+    assert r["required_operator_go_phrase"] == (
+        "GO A18 promotion operator-promote"
+    )
+    assert r["would_target_lane"] == "none"
+    assert r["human_needed"] is True
+    assert r["human_needed_reason"] == "would_require_operator_go"
+
+
+def test_phase2_diagnostic_row_carries_readiness_reason(
+    tmp_path: Path,
+) -> None:
+    a18c_path = tmp_path / "a18c.json"
+    a18c_row = _a18c_row(
+        candidate_id="a18c-a18b-phase2-smoke-2026-05-13-001-deadbeefdeadbeef",
+        admission_decision="needs_human",
+    )
+    _write_a18c_artifact(a18c_path, _a18c_artifact([a18c_row]))
+    snap = report.collect_snapshot(a18c_artifact_path=a18c_path)
+    [r] = snap["rows"]
+    assert r["readiness_reason"] == "needs_human_per_a17_policy"
+
+
+# ---------------------------------------------------------------------------
+# Defense-in-depth: even an admissible row never gets
+# promotion_allowed=True.
+# ---------------------------------------------------------------------------
+
+
+def test_admissible_a18c_row_still_emits_promotion_allowed_false(
+    tmp_path: Path,
+) -> None:
+    """The A18c first-cut posture never emits admission_decision
+    'admissible'. But IF a future A18c change ever did, the
+    report's hard-pinned safety property forces
+    promotion_allowed=False AND block_reason
+    'promotion_disabled_by_default'."""
+    a18c_path = tmp_path / "a18c.json"
+    a18c_row = _a18c_row(
+        candidate_id="a18c-hypothetical-admissible-row-cafef00d12345678",
+        admission_decision="admissible",
+        admission_reason="auto_allowed_low_risk_eligible_promotion",
+        would_target_lane="development_work_queue",
+        human_needed=False,
+        human_needed_reason="",
+    )
+    _write_a18c_artifact(a18c_path, _a18c_artifact([a18c_row]))
+    snap = report.collect_snapshot(a18c_artifact_path=a18c_path)
+    [r] = snap["rows"]
+    assert r["admission_decision"] == "admissible"
+    # Hard-pinned safety property:
+    assert r["promotion_allowed"] is False
+    assert r["block_reason"] == "promotion_disabled_by_default"
+    # The envelope's promotable_row_count is still 0.
+    assert snap["promotable_row_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Mixed-decision aggregation.
+# ---------------------------------------------------------------------------
+
+
+def test_mixed_decisions_aggregate_correctly(tmp_path: Path) -> None:
+    a18c_path = tmp_path / "a18c.json"
+    rows = [
+        _a18c_row(
+            candidate_id="a18c-row-1",
+            admission_decision="needs_human",
+            admission_reason="needs_human_authority_decision",
+        ),
+        _a18c_row(
+            candidate_id="a18c-row-2",
+            admission_decision="blocked",
+            admission_reason="blocked_authority_permanently_denied",
+        ),
+        _a18c_row(
+            candidate_id="a18c-row-3",
+            admission_decision="duplicate_of_existing",
+            admission_reason="already_in_seed_jsonl",
+        ),
+        _a18c_row(
+            candidate_id="a18c-row-4",
+            admission_decision="not_eligible_upstream",
+            admission_reason="upstream_intake_status_not_eligible",
+        ),
+    ]
+    _write_a18c_artifact(a18c_path, _a18c_artifact(rows))
+    snap = report.collect_snapshot(a18c_artifact_path=a18c_path)
+    assert snap["source_row_count"] == 4
+    assert snap["promotable_row_count"] == 0
+    assert snap["blocked_row_count"] == 4
+    by_dec = snap["rows_by_admission_decision"]
+    assert by_dec["needs_human"] == 1
+    assert by_dec["blocked"] == 1
+    assert by_dec["duplicate_of_existing"] == 1
+    assert by_dec["not_eligible_upstream"] == 1
+    assert by_dec["admissible"] == 0
+    # Each row's block_reason maps deterministically.
+    reasons = {r["candidate_id"]: r["block_reason"] for r in snap["rows"]}
+    assert reasons["a18c-row-1"] == "needs_human_per_a17_policy"
+    assert reasons["a18c-row-2"] == "blocked_per_a17_policy"
+    assert reasons["a18c-row-3"] == "duplicate_per_a17_policy"
+    assert reasons["a18c-row-4"] == (
+        "not_eligible_upstream_per_a17_policy"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Closed schema invariants.
+# ---------------------------------------------------------------------------
+
+
+def test_every_report_row_uses_closed_key_set(tmp_path: Path) -> None:
+    a18c_path = tmp_path / "a18c.json"
+    rows = [
+        _a18c_row(candidate_id=f"a18c-shape-{i}")
+        for i in range(3)
+    ]
+    _write_a18c_artifact(a18c_path, _a18c_artifact(rows))
+    snap = report.collect_snapshot(a18c_artifact_path=a18c_path)
+    for r in snap["rows"]:
+        assert set(r.keys()) == set(report.REPORT_ROW_KEYS)
+
+
+def test_envelope_carries_step5_and_level6_invariants(
+    tmp_path: Path,
+) -> None:
+    a18c_path = tmp_path / "a18c.json"
+    _write_a18c_artifact(
+        a18c_path, _a18c_artifact([_a18c_row(candidate_id="inv-1")])
+    )
+    snap = report.collect_snapshot(a18c_artifact_path=a18c_path)
+    assert snap["step5_implementation_allowed"] is False
+    assert snap["step5_enabled_substage"] == "none"
+    assert snap["level6_enabled"] is False
+    assert snap["dry_run_only"] is True
+    assert snap["live_merge_implemented"] is False
+    assert snap["deploy_coupled"] is False
+
+
+def test_envelope_carries_full_discipline_invariants(
+    tmp_path: Path,
+) -> None:
+    a18c_path = tmp_path / "a18c.json"
+    _write_a18c_artifact(
+        a18c_path, _a18c_artifact([_a18c_row(candidate_id="disc-1")])
+    )
+    snap = report.collect_snapshot(a18c_artifact_path=a18c_path)
+    di = snap["discipline_invariants"]
+    assert di["promotes_anything"] is False
+    assert di["writes_to_seed_jsonl"] is False
+    assert di["writes_to_delegation_seed_jsonl"] is False
+    assert di["writes_to_generated_seed_jsonl"] is False
+    assert di["mutates_a18c_artifact"] is False
+    assert di["mutates_a17_artifact"] is False
+    assert di["admits_to_queue"] is False
+    assert di["executes_work"] is False
+    assert di["creates_branches"] is False
+    assert di["opens_prs"] is False
+    assert di["merges_prs"] is False
+    assert di["deploys"] is False
+    assert di["calls_network"] is False
+    assert di["uses_subprocess"] is False
+    assert di["touches_step5_flags"] is False
+    assert di["level6_enabled"] is False
+
+
+def test_envelope_carries_operator_go_phrase_at_top_level(
+    tmp_path: Path,
+) -> None:
+    a18c_path = tmp_path / "a18c.json"
+    _write_a18c_artifact(a18c_path, _a18c_artifact([]))
+    snap = report.collect_snapshot(a18c_artifact_path=a18c_path)
+    assert snap["operator_go_phrase_required"] == (
+        "GO A18 promotion operator-promote"
+    )
+    assert snap["promotion_allowed_default"] is False
+
+
+def test_envelope_carries_a17_and_a18c_version_pins(
+    tmp_path: Path,
+) -> None:
+    a18c_path = tmp_path / "a18c.json"
+    _write_a18c_artifact(
+        a18c_path,
+        _a18c_artifact(
+            [_a18c_row(candidate_id="v-1")],
+            module_version="v3.15.16.A18c",
+            policy_version="v3.15.16.A17",
+        ),
+    )
+    snap = report.collect_snapshot(a18c_artifact_path=a18c_path)
+    # Top-level version pins agree with the upstream artefacts.
+    assert snap["a18c_module_version"] == "v3.15.16.A18c"
+    assert snap["a17_policy_version"] == "v3.15.16.A17"
+    # The module's own internal pins agree at import time.
+    assert snap["a18c_module_version_pin"] == a18c.MODULE_VERSION
+    assert snap["policy_version"] == a17.MODULE_VERSION
+
+
+# ---------------------------------------------------------------------------
+# Atomic-write sentinel.
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_write_refuses_non_report_path(tmp_path: Path) -> None:
+    bad_path = tmp_path / "not_report.json"
+    with pytest.raises(ValueError, match="non-report-logs"):
+        report._atomic_write_json(bad_path, {"k": "v"})
+
+
+def test_atomic_write_succeeds_under_report_prefix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target_dir = (
+        tmp_path / "logs" / "development_generated_lane_promotion_report"
+    )
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target = target_dir / "latest.json"
+    monkeypatch.setattr(report, "ARTIFACT_LATEST", target)
+    snap = report.collect_snapshot(
+        a18c_artifact_path=tmp_path / "no_a18c.json"
+    )
+    report.write_outputs(snap)
+    assert target.is_file()
+    loaded = json.loads(target.read_text(encoding="utf-8"))
+    assert loaded["promotion_allowed_default"] is False
+
+
+# ---------------------------------------------------------------------------
+# A18c artefact must not be mutated by the report.
+# ---------------------------------------------------------------------------
+
+
+def test_a18c_artifact_unchanged_after_collect_snapshot(
+    tmp_path: Path,
+) -> None:
+    a18c_path = tmp_path / "a18c.json"
+    rows = [_a18c_row(candidate_id="immut-1")]
+    payload = _a18c_artifact(rows)
+    _write_a18c_artifact(a18c_path, payload)
+    before = a18c_path.read_text(encoding="utf-8")
+    report.collect_snapshot(a18c_artifact_path=a18c_path)
+    after = a18c_path.read_text(encoding="utf-8")
+    assert before == after
+
+
+# ---------------------------------------------------------------------------
+# Source-text + AST scans.
+# ---------------------------------------------------------------------------
+
+
+def _module_source() -> str:
+    return Path(report.__file__).read_text(encoding="utf-8")
+
+
+def _imported_module_names() -> set[str]:
+    tree = ast.parse(_module_source())
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module is not None:
+                names.add(node.module)
+    return names
+
+
+def test_no_subprocess_import() -> None:
+    src = _module_source()
+    assert "import subprocess" not in src
+    assert "from subprocess" not in src
+
+
+def test_no_network_library_import() -> None:
+    names = _imported_module_names()
+    forbidden_top = {"socket", "urllib", "requests", "httpx", "aiohttp"}
+    for n in names:
+        top = n.split(".", 1)[0]
+        assert top not in forbidden_top, n
+
+
+def test_no_gh_or_git_in_module_source() -> None:
+    src = _module_source()
+    for needle in ("subprocess.run", " gh ", " git ", "Popen"):
+        assert needle not in src, needle
+
+
+def test_no_dashboard_or_frontend_import() -> None:
+    names = _imported_module_names()
+    for n in names:
+        top = n.split(".", 1)[0]
+        assert top != "dashboard"
+        assert top != "frontend"
+
+
+def test_no_approval_token_import() -> None:
+    names = _imported_module_names()
+    for forbidden in (
+        "reporting.approval_token_gate",
+        "reporting.approval_token_runtime",
+    ):
+        assert forbidden not in names, forbidden
+
+
+def test_no_a18b_writer_import() -> None:
+    """The report never touches A18b directly. It consumes A18c's
+    already-projected artefact."""
+    names = _imported_module_names()
+    assert "reporting.development_generated_lane_writer" not in names
+
+
+_WRITE_METHOD_NAMES: frozenset[str] = frozenset(
+    {
+        "open",
+        "write_text",
+        "write_bytes",
+        "replace",
+        "rename",
+        "unlink",
+        "remove",
+        "dump",  # json.dump(...) is a write sink
+    }
+)
+
+
+def _is_write_call(node: ast.Call) -> bool:
+    """Return True iff the Call's target name suggests a file
+    write / replace / rename / removal."""
+    func = node.func
+    if isinstance(func, ast.Attribute):
+        return func.attr in _WRITE_METHOD_NAMES
+    if isinstance(func, ast.Name):
+        return func.id in _WRITE_METHOD_NAMES
+    return False
+
+
+def test_no_seed_or_delegation_seed_write_call_in_source() -> None:
+    """AST scan — every WRITE-shaped Call (open/write_text/replace
+    /rename/unlink/remove/dump) whose string argument references
+    seed.jsonl (and is not generated_seed.jsonl) or
+    delegation_seed.jsonl is forbidden.
+
+    The pin scans only write-shaped Calls — narrative mentions
+    of the basenames inside ``argparse.ArgumentParser(description=...)``
+    or in docstrings are legitimate and not flagged.
+
+    Belt-and-braces over the runtime sentinel
+    (``_atomic_write_json`` already refuses any path outside
+    the report's own ``logs/development_generated_lane_promotion_report/``
+    prefix; see ``test_atomic_write_refuses_non_report_path``)."""
+    tree = ast.parse(_module_source())
+    offenders: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not _is_write_call(node):
+            continue
+        for arg in list(node.args) + [kw.value for kw in node.keywords]:
+            if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                lowered = arg.value.lower()
+                if "delegation_seed.jsonl" in lowered:
+                    offenders.append(
+                        f"line {node.lineno}: WRITE Call references "
+                        f"delegation_seed.jsonl: {arg.value!r}"
+                    )
+                if "seed.jsonl" in lowered and (
+                    "generated_seed.jsonl" not in lowered
+                ):
+                    offenders.append(
+                        f"line {node.lineno}: WRITE Call references "
+                        f"seed.jsonl (not generated_seed): "
+                        f"{arg.value!r}"
+                    )
+                if "generated_seed.jsonl" in lowered:
+                    offenders.append(
+                        f"line {node.lineno}: WRITE Call references "
+                        f"generated_seed.jsonl: {arg.value!r}"
+                    )
+    assert not offenders, (
+        "promotion-report module must not contain a WRITE Call "
+        "whose argument references seed.jsonl, "
+        "delegation_seed.jsonl, or generated_seed.jsonl: "
+        f"{offenders}"
+    )
+
+
+def test_no_a18b_writer_module_used() -> None:
+    """Layered: the module must not import (and therefore cannot
+    accidentally call) the A18b writer module. A separate test
+    (``test_no_a18b_writer_import``) covers the import side. This
+    test verifies the import-allowlist test exists by re-checking
+    via the same import-names path."""
+    names = _imported_module_names()
+    assert "reporting.development_generated_lane_writer" not in names
+    # The string "development_generated_lane_writer" must not
+    # appear as a Name-resolution target in any Call site either.
+    src = _module_source()
+    assert "development_generated_lane_writer(" not in src
+    assert "development_generated_lane_writer." not in src
+
+
+def test_module_imports_only_allowed_reporting_modules() -> None:
+    names = _imported_module_names()
+    allowed_reporting = {
+        "reporting",
+        "reporting.development_generated_lane_a18c",
+        "reporting.development_queue_admission_policy",
+        "reporting.agent_audit_summary",
+    }
+    for n in names:
+        if n == "reporting" or n.startswith("reporting."):
+            assert n in allowed_reporting, n
+
+
+def test_module_source_pins_step5_invariants() -> None:
+    src = _module_source()
+    assert "step5_implementation_allowed: Final[bool] = False" in src
+    assert 'STEP5_ENABLED_SUBSTAGE: Final[str] = "none"' in src
+    assert "step5_implementation_allowed = True" not in src
+
+
+def test_module_source_pins_promotion_allowed_default_false() -> None:
+    src = _module_source()
+    assert "PROMOTION_ALLOWED_DEFAULT: Final[bool] = False" in src
+    assert "PROMOTION_ALLOWED_DEFAULT = True" not in src
+
+
+# ---------------------------------------------------------------------------
+# CLI.
+# ---------------------------------------------------------------------------
+
+
+def test_cli_no_write_emits_envelope(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rc = report.main(["--no-write"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    snap = json.loads(out)
+    assert snap["promotion_allowed_default"] is False
+    assert snap["operator_go_phrase_required"] == (
+        "GO A18 promotion operator-promote"
+    )
+    assert snap["step5_implementation_allowed"] is False
+    assert snap["level6_enabled"] is False
+
+
+def test_cli_default_write_path_is_report_artifact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When --no-write is omitted, the CLI writes the envelope to
+    the canonical artefact path. Defense-in-depth: redirect
+    ARTIFACT_LATEST into tmp so we never touch the repo's real
+    logs/ tree."""
+    target_dir = (
+        tmp_path / "logs" / "development_generated_lane_promotion_report"
+    )
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target = target_dir / "latest.json"
+    monkeypatch.setattr(report, "ARTIFACT_LATEST", target)
+    rc = report.main([])
+    assert rc == 0
+    assert target.is_file()
+
+
+def test_cli_indent_zero_emits_compact(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rc = report.main(["--no-write", "--indent", "0"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    # Compact JSON (indent=None) has no leading whitespace lines.
+    assert "  " not in out.split("\n")[0]
+
+
+# ---------------------------------------------------------------------------
+# Hard-pinned safety: promotable_row_count is always 0.
+# ---------------------------------------------------------------------------
+
+
+def test_promotable_row_count_is_always_zero_across_envelopes(
+    tmp_path: Path,
+) -> None:
+    """Across every artefact state — absent, malformed, empty,
+    one-row, multi-row, mixed-decision — promotable_row_count
+    must be 0."""
+    # Absent.
+    snap = report.collect_snapshot(
+        a18c_artifact_path=tmp_path / "missing.json"
+    )
+    assert snap["promotable_row_count"] == 0
+
+    # Malformed.
+    bad = tmp_path / "bad.json"
+    bad.write_text("not json", encoding="utf-8")
+    snap = report.collect_snapshot(a18c_artifact_path=bad)
+    assert snap["promotable_row_count"] == 0
+
+    # Empty rows.
+    empty = tmp_path / "empty.json"
+    _write_a18c_artifact(empty, _a18c_artifact([]))
+    snap = report.collect_snapshot(a18c_artifact_path=empty)
+    assert snap["promotable_row_count"] == 0
+
+    # Mixed-decision (including hypothetical admissible).
+    multi = tmp_path / "multi.json"
+    rows = [
+        _a18c_row(candidate_id="row-1", admission_decision="needs_human"),
+        _a18c_row(candidate_id="row-2", admission_decision="blocked"),
+        _a18c_row(
+            candidate_id="row-3",
+            admission_decision="admissible",
+            admission_reason="auto_allowed_low_risk_eligible_promotion",
+        ),
+    ]
+    _write_a18c_artifact(multi, _a18c_artifact(rows))
+    snap = report.collect_snapshot(a18c_artifact_path=multi)
+    assert snap["promotable_row_count"] == 0
+    for r in snap["rows"]:
+        assert r["promotion_allowed"] is False


### PR DESCRIPTION
## Summary

Phase 5a of the autonomous-development-lane phased plan. Adds a
single read-only / report-only projector that consumes the
existing A18c artefact and surfaces, for each A18c-projected row,
the closed-vocab block reason and the exact operator-go phrase
that a future PR would issue to build operator-promote
functionality.

> **Hard-pinned safety property:** every emitted report row has
> \`promotion_allowed=False\`, regardless of the underlying A18c
> admission decision. Even a hypothetical A18c row carrying
> \`admission_decision=\"admissible\"\` (the A18c first-cut
> posture never emits this) STILL produces a report row with
> \`promotion_allowed=False\` and
> \`block_reason=\"promotion_disabled_by_default\"\`.

This PR ships the report-only surface only. **Operator-promote
remains gated** by the separate explicit operator-go phrase
\`GO A18 promotion operator-promote\`, which this PR does NOT
request.

## Scope (three files)

| File | Action |
|---|---|
| \`reporting/development_generated_lane_promotion_report.py\` | NEW |
| \`tests/unit/test_development_generated_lane_promotion_report.py\` | NEW (39 tests) |
| \`docs/governance/development_generated_lane_a18c_plan.md\` | EDIT — single cross-reference block appended to §19 |

## Module pins

* \`MODULE_VERSION = \"v3.15.16.A18.promotion_report\"\`
* \`REPORT_KIND = \"development_generated_lane_promotion_report\"\`
* \`ARTIFACT_RELATIVE_PATH = \"logs/development_generated_lane_promotion_report/latest.json\"\`
* \`PROMOTION_ALLOWED_DEFAULT = False\` (hard pin)
* \`OPERATOR_GO_PHRASE = \"GO A18 promotion operator-promote\"\`
* \`STEP5_ENABLED_SUBSTAGE = \"none\"\`
* \`step5_implementation_allowed = False\`
* Closed \`BLOCK_REASONS\` vocabulary (5 values)
* Closed \`READINESS_NOTES\` vocabulary (4 values)
* Closed \`REPORT_ROW_KEYS\` schema (14 keys)

## Module behaviour (pinned by 39 tests)

* **A18c artefact absent** → safe envelope:
  \`a18c_artifact_available=False\`,
  \`readiness_note=\"a18c_artifact_absent\"\`.
* **A18c artefact malformed** → safe envelope:
  \`readiness_note=\"a18c_artifact_malformed\"\`, no crash.
* **A18c artefact valid empty** →
  \`readiness_note=\"no_source_rows\"\`.
* **A18c artefact valid with rows** → one report row per source
  row, closed-vocab \`BLOCK_REASONS\` mapping from
  \`admission_decision\`,
  \`readiness_note=\"rows_present_none_promotable\"\`.
* Phase-2 diagnostic row
  \`a18b-phase2-smoke-2026-05-13-001\` →
  \`promotion_allowed=False\`,
  \`block_reason=\"needs_human_per_a17_policy\"\`,
  \`required_operator_go_phrase=\"GO A18 promotion operator-promote\"\`.
* Atomic-write sentinel restricts writes to
  \`logs/development_generated_lane_promotion_report/\`.
* \`assert_no_secrets\` on every envelope before write.

## What is NOT touched

* A18b writer module (no import, no name resolution at any
  Call site)
* A18c projector module (read-only consumer of its artefact)
* A17 admission module (no mutation, no admission)
* \`dashboard/**\`, \`frontend/**\`, \`scripts/**\`,
  \`.github/workflows/**\`
* \`.claude/**\`, \`.gitleaks.toml\`, \`research/**\`,
  \`live/**\`, \`paper/**\`, \`shadow/**\`, \`risk/**\`,
  \`broker/**\`, \`execution/**\`
* \`recurring_maintenance.py\` — no recurring job registration
  (deliberately out of scope for this PR)
* \`docker-compose*.yml\` — no compose change
* No \`generated_seed.jsonl\` write
* No env activation
* No Step 5 substage promotion or flag flip
* No Level 6 change
* No N5b phase change
* No GitHub mutation
* No token mint/verify
* No deploy coupling

## Test plan

- [x] \`python scripts/governance_lint.py\` — OK
- [x] \`python -m pytest tests/smoke -q\` — 18 passed
- [x] \`python -m pytest tests/unit/test_development_generated_lane_promotion_report.py -q\` — 39 passed
- [x] \`python -m pytest tests/unit/test_development_generated_lane_a18c.py -q\` — still green
- [x] \`python -m pytest tests/unit/test_development_generated_lane_a18c_plan.py -q\` — still green
- [x] \`python -m pytest tests/unit/test_a18b_writer_host_side_write_runbook.py -q\` — still green
- [x] \`python -m pytest tests/unit/test_autonomous_development_baseline_observation_runbook.py -q\` — still green
- [x] \`python -m reporting.development_generated_lane_writer --no-write\` — invariants green
- [x] \`python -m reporting.development_generated_lane_a18c --no-write\` — invariants green
- [x] \`python -m reporting.development_step5_loop --no-write\` — invariants green
- [x] \`python -m reporting.development_operational_digest --no-write\` — invariants green
- [x] \`python -m reporting.development_generated_lane_promotion_report --no-write\` —
  \`promotable_row_count=0\`, \`promotion_allowed_default=false\`,
  \`operator_go_phrase_required=\"GO A18 promotion operator-promote\"\`,
  Step 5 / Level 6 invariants intact

## Operator verification after merge (auto-deploy expected)

Auto-deploy will rebuild the dashboard image to include the new
\`reporting/\` module. No new route, no new schedule, no new env.
The CLI is invocable on VPS post-deploy:

\`\`\`bash
cd /root/trading-agent
python3 -m reporting.development_generated_lane_promotion_report --no-write
# expected:
#   a18c_artifact_available=true (A18c's latest.json is on disk from Stage D)
#   source_row_count=1
#   promotable_row_count=0
#   blocked_row_count=1
#   rows[0].promotion_allowed=false
#   rows[0].block_reason=\"needs_human_per_a17_policy\"
#   rows[0].required_operator_go_phrase=\"GO A18 promotion operator-promote\"
#   step5_implementation_allowed=false
#   step5_enabled_substage=\"none\"
#   level6_enabled=false
\`\`\`

Optionally also persist the artefact (default invocation,
no \`--no-write\`); the report writes only to
\`logs/development_generated_lane_promotion_report/latest.json\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)