### PR TITLE
feat(maintenance): register refresh_a18_promotion_report (read-only, hard-pinned no-promotion projector)

### DIFF
--- a/reporting/recurring_maintenance.py
+++ b/reporting/recurring_maintenance.py
@@ -135,6 +135,20 @@ JOB_REFRESH_MERGE_PREFLIGHT: str = "refresh_merge_preflight"
 # no gh; no external network; no mutation of A17; A17 remains
 # authoritative; A18c never bypasses A17 filters.
 JOB_REFRESH_GENERATED_LANE_A18C: str = "refresh_generated_lane_a18c"
+# v3.15.16.A18.promotion_report — read-only / report-only A18
+# promotion-readiness report. Reads the A18c artefact at
+# logs/development_generated_lane_a18c/latest.json and emits a
+# closed-schema report at
+# logs/development_generated_lane_promotion_report/latest.json.
+# Module-level hard pin: every emitted report row carries
+# promotion_allowed=False; envelope-level promotable_row_count is
+# asserted == 0 before write. NEVER promotes, NEVER admits queue
+# rows, NEVER mutates A17 / A18b / A18c, NEVER writes to
+# generated_seed.jsonl / seed.jsonl / delegation_seed.jsonl,
+# NEVER calls gh, NEVER merges, NEVER deploys. LOW risk; no gh;
+# no external network; no env gate (the module is always-on
+# read-only).
+JOB_REFRESH_A18_PROMOTION_REPORT: str = "refresh_a18_promotion_report"
 
 JOB_TYPES: tuple[str, ...] = (
     JOB_REFRESH_WORKLOOP_RUNTIME,
@@ -150,6 +164,7 @@ JOB_TYPES: tuple[str, ...] = (
     JOB_REFRESH_AUTONOMOUS_BACKLOG,
     JOB_REFRESH_MERGE_PREFLIGHT,
     JOB_REFRESH_GENERATED_LANE_A18C,
+    JOB_REFRESH_A18_PROMOTION_REPORT,
 )
 
 
@@ -511,6 +526,67 @@ def _exec_refresh_merge_preflight() -> dict[str, Any]:
     }
 
 
+def _exec_refresh_a18_promotion_report() -> dict[str, Any]:
+    """Run the v3.15.16.A18.promotion_report read-only / report-
+    only projector. Reads the A18c artefact at
+    ``logs/development_generated_lane_a18c/latest.json`` and
+    writes
+    ``logs/development_generated_lane_promotion_report/latest.json``.
+    Never admits queue rows, never modifies A17 / A18b / A18c,
+    never writes to generated_seed.jsonl / seed.jsonl /
+    delegation_seed.jsonl, never invokes gh, never merges, never
+    deploys. The closed envelope is hard-pinned at the projector
+    layer: every report row carries ``promotion_allowed=False``
+    and the envelope-level ``promotable_row_count`` is asserted
+    ``== 0`` before write — the maintenance entry does not relax
+    this.
+
+    Step 5 + Level 6 invariants stay pinned by the projector:
+    ``step5_implementation_allowed=false``,
+    ``step5_enabled_substage="none"``, ``level6_enabled=false``,
+    ``dry_run_only=true``, ``live_merge_implemented=false``,
+    ``deploy_coupled=false``.
+    """
+    from reporting.development_generated_lane_promotion_report import (
+        collect_snapshot,
+        write_outputs,
+    )
+
+    snap = collect_snapshot()
+    write_outputs(snap)
+    return {
+        "summary": (
+            f"development_generated_lane_promotion_report "
+            f"source_row_count={snap.get('source_row_count', 0)} "
+            f"promotable_row_count={snap.get('promotable_row_count', 0)} "
+            f"blocked_row_count={snap.get('blocked_row_count', 0)} "
+            f"readiness_note={snap.get('readiness_note') or 'no note'}"
+        ),
+        "evidence": {
+            "a18c_artifact_available": snap.get("a18c_artifact_available"),
+            "source_row_count": snap.get("source_row_count"),
+            "promotable_row_count": snap.get("promotable_row_count"),
+            "blocked_row_count": snap.get("blocked_row_count"),
+            "readiness_note": snap.get("readiness_note"),
+            "validation_warnings": snap.get("validation_warnings"),
+            "operator_go_phrase_required": snap.get(
+                "operator_go_phrase_required"
+            ),
+            "promotion_allowed_default": snap.get(
+                "promotion_allowed_default"
+            ),
+            "dry_run_only": snap.get("dry_run_only"),
+            "live_merge_implemented": snap.get("live_merge_implemented"),
+            "deploy_coupled": snap.get("deploy_coupled"),
+            "level6_enabled": snap.get("level6_enabled"),
+            "step5_implementation_allowed": snap.get(
+                "step5_implementation_allowed"
+            ),
+            "step5_enabled_substage": snap.get("step5_enabled_substage"),
+        },
+    }
+
+
 def _exec_refresh_generated_lane_a18c() -> dict[str, Any]:
     """Run the v3.15.16.A18c admission projector (read-only,
     default-disabled). When the projector's env-gate
@@ -761,6 +837,24 @@ _JOB_REGISTRY: dict[str, dict[str, Any]] = {
             "without reading the seed file. Never calls gh, never "
             "merges, never deploys, never admits to the queue, "
             "never modifies A17."
+        ),
+        "risk_class": RISK_LOW,
+        "needs_gh": False,
+        "timeout_seconds": DEFAULT_JOB_TIMEOUT_SECONDS,
+    },
+    JOB_REFRESH_A18_PROMOTION_REPORT: {
+        "default_interval_seconds": 30 * 60,
+        "default_enabled": True,
+        "executor": _exec_refresh_a18_promotion_report,
+        "description": (
+            "Refresh A18 promotion-readiness report "
+            "(read-only / report-only projection over the A18c "
+            "artefact). Hard-pinned at the projector layer: every "
+            "row carries promotion_allowed=False; envelope "
+            "promotable_row_count is asserted == 0 before write. "
+            "Never calls gh, never merges, never deploys, never "
+            "admits to the queue, never modifies A17 / A18b / "
+            "A18c."
         ),
         "risk_class": RISK_LOW,
         "needs_gh": False,

--- a/tests/unit/test_recurring_maintenance.py
+++ b/tests/unit/test_recurring_maintenance.py
@@ -178,10 +178,17 @@ def test_job_registry_contains_only_approved_types() -> None:
         # Never merges, never deploys, never calls gh, never modifies
         # A17.
         "refresh_generated_lane_a18c",
+        # v3.15.16.A18.promotion_report — read-only / report-only
+        # A18 promotion-readiness report. Reads A18c's artefact and
+        # writes logs/development_generated_lane_promotion_report/
+        # latest.json. Hard-pinned promotable_row_count == 0; the
+        # report module never promotes. Never merges, never deploys,
+        # never calls gh, never modifies A17 / A18b / A18c.
+        "refresh_a18_promotion_report",
     }
     assert set(rm.JOB_TYPES) == expected
     assert set(rm._JOB_REGISTRY.keys()) == expected
-    assert len(rm.JOB_TYPES) == 13
+    assert len(rm.JOB_TYPES) == 14
 
 
 def test_roadmap_priority_job_is_low_risk_no_gh_enabled_by_default() -> None:

--- a/tests/unit/test_recurring_maintenance_a18_promotion_report.py
+++ b/tests/unit/test_recurring_maintenance_a18_promotion_report.py
@@ -1,0 +1,571 @@
+"""Targeted pin-tests for the v3.15.16.A18.promotion_report
+recurring maintenance integration of the read-only / report-only
+promotion-readiness projector.
+
+These tests pin that the A18 promotion-report projector
+(``reporting.development_generated_lane_promotion_report``) is
+registered in the recurring-maintenance scheduler as a LOW-risk,
+no-``gh``-needed, default-enabled job, and that its executor:
+
+* returns the documented ``{"summary": str, "evidence": dict}``
+  envelope;
+* writes ``logs/development_generated_lane_promotion_report/latest.json``
+  atomically via the projector's own sentinel-restricted write
+  path;
+* is failure-non-fatal when the upstream A18c artefact is
+  absent (the projector default-denies with closed-vocab
+  warnings, never raises);
+* preserves the hard-pinned safety property
+  ``promotable_row_count == 0`` in the persisted snapshot
+  regardless of upstream state;
+* preserves the dry-run / no-live-merge / no-deploy-coupling /
+  Step 5 / Level 6 invariants in the persisted snapshot
+  regardless of upstream state;
+* never calls ``gh``, ``git``, ``subprocess``, or the network;
+* never mutates the environment, never enables A18b's writer
+  gate, never enables N5b's live-execute gate;
+* never synthesises the operator-go phrase in its own function
+  source — the phrase reaches the executor's evidence dict
+  only via ``snap.get("operator_go_phrase_required")``.
+
+These tests do **not** enable any runtime gate. They do not flip
+Step 5 / Level 6 invariants. They do not call ``gh``. They do not
+merge or deploy. They do not write to ``seed.jsonl`` /
+``delegation_seed.jsonl`` / ``generated_seed.jsonl``.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reporting import development_generated_lane_a18c as a18c
+from reporting import (
+    development_generated_lane_promotion_report as dmgl_promo,
+)
+from reporting import recurring_maintenance as rm
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_latest(repo_logs: Path) -> dict[str, Any]:
+    """Read the promotion-report artefact from a tmp-rooted
+    ``logs/development_generated_lane_promotion_report/latest.json``."""
+    path = (
+        repo_logs
+        / "development_generated_lane_promotion_report"
+        / "latest.json"
+    )
+    assert path.is_file(), f"promotion-report artefact missing under tmp: {path}"
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _patch_projector_paths_to_tmp(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Path:
+    """Redirect the projector's write target into a hermetic tmp
+    directory so the executor cannot pollute the repo's real
+    ``logs/`` tree during test execution.
+
+    The projector's atomic-write sentinel restricts writes to
+    ``logs/development_generated_lane_promotion_report/``; we
+    keep that substring in the redirected path so the sentinel
+    passes."""
+    tmp_logs = tmp_path / "logs"
+    tmp_artifact_dir = (
+        tmp_logs / "development_generated_lane_promotion_report"
+    )
+    tmp_artifact_dir.mkdir(parents=True, exist_ok=True)
+    tmp_artifact_latest = tmp_artifact_dir / "latest.json"
+    monkeypatch.setattr(dmgl_promo, "ARTIFACT_LATEST", tmp_artifact_latest)
+    return tmp_logs
+
+
+def _redirect_upstream_a18c_to_tmp(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    payload: dict[str, Any] | None = None,
+) -> Path:
+    """Redirect the upstream A18c ``ARTIFACT_LATEST`` to a tmp
+    path. If ``payload`` is provided, write it as the artefact
+    contents; otherwise leave the path nonexistent so the
+    projector's ``a18c_artifact_absent`` branch fires."""
+    tmp_a18c_dir = tmp_path / "logs" / "development_generated_lane_a18c"
+    tmp_a18c_dir.mkdir(parents=True, exist_ok=True)
+    tmp_a18c_latest = tmp_a18c_dir / "latest.json"
+    if payload is not None:
+        tmp_a18c_latest.write_text(
+            json.dumps(payload, sort_keys=True), encoding="utf-8"
+        )
+    monkeypatch.setattr(a18c, "ARTIFACT_LATEST", tmp_a18c_latest)
+    return tmp_a18c_latest
+
+
+# ---------------------------------------------------------------------------
+# Closed-registry pins
+# ---------------------------------------------------------------------------
+
+
+def test_a18_promotion_report_job_constant_value() -> None:
+    """The exact CLI-facing job_type string is pinned. Operators
+    invoke it via ``--run-once refresh_a18_promotion_report``; if
+    that string ever drifts, this test fails before the rename
+    can land."""
+    assert (
+        rm.JOB_REFRESH_A18_PROMOTION_REPORT
+        == "refresh_a18_promotion_report"
+    )
+
+
+def test_a18_promotion_report_job_is_in_closed_registry() -> None:
+    assert rm.JOB_REFRESH_A18_PROMOTION_REPORT in rm.JOB_TYPES
+    assert rm.JOB_REFRESH_A18_PROMOTION_REPORT in rm._JOB_REGISTRY
+
+
+def test_a18_promotion_report_job_is_low_risk_no_gh_enabled_by_default() -> None:
+    """The promotion-report projector is pure stdlib + closed
+    metadata; it reads only one on-disk artefact. The job must
+    therefore be LOW risk, ``needs_gh=False``, default-enabled."""
+    spec = rm._JOB_REGISTRY[rm.JOB_REFRESH_A18_PROMOTION_REPORT]
+    assert spec["risk_class"] == rm.RISK_LOW
+    assert spec["needs_gh"] is False
+    assert spec["default_enabled"] is True
+
+
+def test_a18_promotion_report_registry_interval_is_thirty_minutes() -> None:
+    """30-minute cadence mirrors the A18c / A22-adjacent
+    projections and the upstream ``refresh_merge_preflight``
+    cadence. A deliberate change here must update the runbook in
+    the same PR."""
+    spec = rm._JOB_REGISTRY[rm.JOB_REFRESH_A18_PROMOTION_REPORT]
+    assert spec["default_interval_seconds"] == 30 * 60
+
+
+def test_a18_promotion_report_job_timeout_is_default() -> None:
+    """No bespoke timeout — the projector reads one small JSON
+    file and writes one. The default 90-second budget is more
+    than enough."""
+    spec = rm._JOB_REGISTRY[rm.JOB_REFRESH_A18_PROMOTION_REPORT]
+    assert spec["timeout_seconds"] == rm.DEFAULT_JOB_TIMEOUT_SECONDS
+
+
+def test_a18_promotion_report_executor_is_the_documented_function() -> None:
+    """The registry's executor handle must point at the documented
+    in-process function. A drift here would silently re-route the
+    refresh."""
+    spec = rm._JOB_REGISTRY[rm.JOB_REFRESH_A18_PROMOTION_REPORT]
+    assert spec["executor"] is rm._exec_refresh_a18_promotion_report
+
+
+def test_registry_entry_for_a18_promotion_report_carries_no_runtime_authority() -> None:
+    """Registry entry must not silently elevate the job to MEDIUM
+    risk, mark ``needs_gh`` true, or expose any execute-safe-style
+    flag — those are reserved for the Dependabot path."""
+    spec = rm._JOB_REGISTRY[rm.JOB_REFRESH_A18_PROMOTION_REPORT]
+    # The registry shape is closed to a fixed key-set; if a future
+    # change introduces a new key (e.g. an opt-in flag), this test
+    # forces a deliberate update.
+    assert set(spec.keys()) == {
+        "default_interval_seconds",
+        "default_enabled",
+        "executor",
+        "description",
+        "risk_class",
+        "needs_gh",
+        "timeout_seconds",
+    }
+    assert spec["risk_class"] == rm.RISK_LOW
+    assert spec["needs_gh"] is False
+
+
+# ---------------------------------------------------------------------------
+# Executor behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_executor_returns_documented_envelope_when_a18c_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With the upstream A18c artefact absent, the projector
+    default-denies. The executor must return a valid
+    ``{"summary", "evidence"}`` envelope and never raise. The
+    Step 5 / Level 6 invariants must be present in evidence."""
+    _patch_projector_paths_to_tmp(monkeypatch, tmp_path)
+    _redirect_upstream_a18c_to_tmp(monkeypatch, tmp_path, payload=None)
+    out = rm._exec_refresh_a18_promotion_report()
+    assert isinstance(out, dict)
+    assert isinstance(out.get("summary"), str)
+    assert isinstance(out.get("evidence"), dict)
+    ev = out["evidence"]
+    assert ev["a18c_artifact_available"] is False
+    assert ev["source_row_count"] == 0
+    assert ev["promotable_row_count"] == 0
+    assert ev["readiness_note"] == "a18c_artifact_absent"
+    # Evidence carries the closed dry-run invariants verbatim.
+    assert ev["dry_run_only"] is True
+    assert ev["live_merge_implemented"] is False
+    assert ev["deploy_coupled"] is False
+    assert ev["level6_enabled"] is False
+    assert ev["step5_implementation_allowed"] is False
+    assert ev["step5_enabled_substage"] == "none"
+
+
+def test_executor_persists_snapshot_under_tmp_with_real_a18c_artefact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Hand-craft a minimal valid A18c envelope on disk and
+    verify the executor's persisted snapshot pins the Step 5 /
+    Level 6 invariants even with a real upstream row present."""
+    tmp_logs = _patch_projector_paths_to_tmp(monkeypatch, tmp_path)
+    # Minimal A18c envelope that the projector's reader accepts —
+    # one synthetic row with needs_human admission (matching the
+    # current live A18c state).
+    a18c_payload = {
+        "schema_version": a18c.SCHEMA_VERSION,
+        "module_version": a18c.MODULE_VERSION,
+        "report_kind": a18c.REPORT_KIND,
+        "generated_at_utc": "2026-05-13T16:00:00Z",
+        "enabled": True,
+        "env_gate_name": a18c.ENV_GATE,
+        "generated_seed_path": "logs/development_generated_lane/generated_seed.jsonl",
+        "rows": [
+            {
+                "a18c_candidate_id": "a18c-syn-needs-human-001",
+                "generated_candidate_id": "syn-needs-human-001",
+                "evidence_hash": "0" * 64,
+                "admission_decision": "needs_human",
+                "admission_reason": "needs_human_authority_decision",
+                "would_target_lane": "none",
+                "would_require_operator_go": True,
+            }
+        ],
+        "counts": {
+            "total": 1,
+            "admissible": 0,
+            "by_admission_decision": {
+                "admissible": 0,
+                "needs_human": 1,
+                "permanently_denied": 0,
+            },
+        },
+        "note": "ok",
+        "validation_warnings": [],
+    }
+    _redirect_upstream_a18c_to_tmp(monkeypatch, tmp_path, payload=a18c_payload)
+    rm._exec_refresh_a18_promotion_report()
+    snap = _read_latest(tmp_logs)
+    assert snap["report_kind"] == dmgl_promo.REPORT_KIND
+    assert snap["dry_run_only"] is True
+    assert snap["live_merge_implemented"] is False
+    assert snap["deploy_coupled"] is False
+    assert snap["level6_enabled"] is False
+    assert snap["step5_implementation_allowed"] is False
+    assert snap["step5_enabled_substage"] == "none"
+
+
+def test_executor_persisted_snapshot_pins_promotable_row_count_zero(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The hard-pinned safety property is
+    ``promotable_row_count == 0``. Verify both that the executor
+    surfaces it in evidence AND that the persisted snapshot
+    asserts it, regardless of upstream state."""
+    tmp_logs = _patch_projector_paths_to_tmp(monkeypatch, tmp_path)
+    # Provide a synthetic A18c envelope with a single needs_human
+    # row. Even if a future change ever caused A18c to report an
+    # admissible row, the promotion report module still pins
+    # promotion_allowed=False per row + promotable_row_count == 0
+    # at envelope level. We don't simulate the admissible case
+    # here (the projector's own tests own that pin); we simply
+    # verify the maintenance executor doesn't introduce a path
+    # that bypasses the projector's hard pin.
+    a18c_payload = {
+        "schema_version": a18c.SCHEMA_VERSION,
+        "module_version": a18c.MODULE_VERSION,
+        "report_kind": a18c.REPORT_KIND,
+        "generated_at_utc": "2026-05-13T16:05:00Z",
+        "enabled": True,
+        "env_gate_name": a18c.ENV_GATE,
+        "generated_seed_path": "logs/development_generated_lane/generated_seed.jsonl",
+        "rows": [
+            {
+                "a18c_candidate_id": "a18c-syn-needs-human-002",
+                "generated_candidate_id": "syn-needs-human-002",
+                "evidence_hash": "1" * 64,
+                "admission_decision": "needs_human",
+                "admission_reason": "needs_human_authority_decision",
+                "would_target_lane": "none",
+                "would_require_operator_go": True,
+            }
+        ],
+        "counts": {
+            "total": 1,
+            "admissible": 0,
+            "by_admission_decision": {
+                "admissible": 0,
+                "needs_human": 1,
+                "permanently_denied": 0,
+            },
+        },
+        "note": "ok",
+        "validation_warnings": [],
+    }
+    _redirect_upstream_a18c_to_tmp(monkeypatch, tmp_path, payload=a18c_payload)
+    out = rm._exec_refresh_a18_promotion_report()
+    # Executor evidence surfaces the safety property.
+    assert out["evidence"]["promotable_row_count"] == 0
+    assert out["evidence"]["promotion_allowed_default"] is False
+    # Persisted snapshot pins the safety property.
+    snap = _read_latest(tmp_logs)
+    assert snap["promotable_row_count"] == 0
+    assert snap["promotion_allowed_default"] is False
+    # Every emitted row carries promotion_allowed=False.
+    for row in snap["rows"]:
+        assert row["promotion_allowed"] is False
+
+
+def test_executor_failure_non_fatal_under_supervisor(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end through the recurring-maintenance supervisor:
+    with the upstream A18c artefact absent, the executor must
+    return cleanly and the supervisor must classify the run as
+    ``STATUS_SUCCEEDED`` (not ``STATUS_FAILED`` /
+    ``STATUS_TIMEOUT`` / ``STATUS_NOT_AVAILABLE``)."""
+    _patch_projector_paths_to_tmp(monkeypatch, tmp_path)
+    _redirect_upstream_a18c_to_tmp(monkeypatch, tmp_path, payload=None)
+    monkeypatch.setattr(rm, "DIGEST_DIR_JSON", tmp_path / "rm")
+    snap = rm.run_one_job(
+        rm.JOB_REFRESH_A18_PROMOTION_REPORT, persist=True
+    )
+    job_row = next(
+        j
+        for j in snap["jobs"]
+        if j["job_type"] == rm.JOB_REFRESH_A18_PROMOTION_REPORT
+    )
+    assert job_row["last_status"] == rm.STATUS_SUCCEEDED
+    # The supervisor must not have flagged a consecutive failure.
+    assert job_row["consecutive_failures"] == 0
+
+
+# ---------------------------------------------------------------------------
+# AST / source-text scan: the executor and the projector module
+# never reach for gh / git / subprocess / network.
+# ---------------------------------------------------------------------------
+
+
+def test_executor_source_contains_no_subprocess_or_network() -> None:
+    """The supervisor isolates the executor in a daemon thread but
+    still runs it in the same Python process. The executor's own
+    source must therefore not import or invoke subprocess / socket
+    / gh / git. The projector module it reaches is independently
+    pinned by ``test_projector_module_does_not_import_subprocess_or_network``
+    below."""
+    src = inspect.getsource(rm._exec_refresh_a18_promotion_report)
+    lowered = src.lower()
+    forbidden = (
+        "subprocess",
+        "socket",
+        "urllib",
+        "requests",
+        "httpx",
+        "aiohttp",
+        "popen",
+        "shell=true",
+        " gh ",
+        " git ",
+        "os.system",
+    )
+    for needle in forbidden:
+        assert needle not in lowered, (
+            f"_exec_refresh_a18_promotion_report source contains "
+            f"forbidden token {needle!r}"
+        )
+
+
+def test_projector_module_does_not_import_subprocess_or_network() -> None:
+    """The A18 promotion-report projector module that backs the
+    executor must not import subprocess, socket, urllib, requests,
+    httpx, aiohttp. AST-level scan — catches indirect re-exports."""
+    src = Path(dmgl_promo.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    forbidden_top = {
+        "subprocess",
+        "socket",
+        "urllib",
+        "requests",
+        "httpx",
+        "aiohttp",
+    }
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in forbidden_top, (
+                    f"projector imports forbidden module: "
+                    f"{alias.name!r}"
+                )
+        if isinstance(node, ast.ImportFrom) and node.module is not None:
+            top = node.module.split(".", 1)[0]
+            assert top not in forbidden_top, (
+                f"projector imports forbidden module: "
+                f"from {node.module!r}"
+            )
+    # Belt-and-braces literal-source scan for the canonical
+    # ``import <module>`` shapes.
+    forbidden_literal = {
+        "subprocess",
+        "socket",
+        "urllib",
+        "urllib.request",
+        "urllib.parse",
+        "requests",
+        "httpx",
+        "aiohttp",
+        "http.client",
+    }
+    for forbidden in forbidden_literal:
+        assert f"import {forbidden}" not in src, (
+            f"projector source contains literal import of "
+            f"{forbidden!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Negative pins — the refresh path must not introduce env mutation,
+# A18b writer enablement, N5b live-execute authority, or operator-go
+# phrase synthesis from inside the executor function.
+# ---------------------------------------------------------------------------
+
+
+def test_executor_source_does_not_mutate_environment() -> None:
+    """The executor must not mutate or export environment
+    variables. The promotion-report projector has no env gate of
+    its own, but the executor must still be defensive: no code
+    path may assign to ``os.environ``, call
+    ``os.environ.setdefault``, call ``os.putenv``, or use a
+    shell-style export."""
+    src = inspect.getsource(rm._exec_refresh_a18_promotion_report)
+    forbidden_substrings = (
+        "os.environ[",
+        "os.environ.setdefault",
+        "os.putenv",
+        "putenv(",
+        "export ADE_",
+    )
+    for needle in forbidden_substrings:
+        assert needle not in src, (
+            f"_exec_refresh_a18_promotion_report source contains "
+            f"forbidden env-mutation token {needle!r}"
+        )
+    # AST-level pin: assert the executor body assigns nothing to
+    # any ``os.environ[...]`` Subscript and never calls
+    # ``os.environ.setdefault(...)`` / ``os.putenv(...)``.
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Subscript):
+                    value = target.value
+                    if (
+                        isinstance(value, ast.Attribute)
+                        and value.attr == "environ"
+                    ):
+                        raise AssertionError(
+                            "_exec_refresh_a18_promotion_report body "
+                            "assigns to os.environ[...]"
+                        )
+        if isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Attribute):
+                if func.attr in {"setdefault", "putenv"}:
+                    parent = func.value
+                    if (
+                        isinstance(parent, ast.Attribute)
+                        and parent.attr == "environ"
+                    ):
+                        raise AssertionError(
+                            "_exec_refresh_a18_promotion_report body calls "
+                            "os.environ.setdefault(...)"
+                        )
+                    if (
+                        isinstance(parent, ast.Name)
+                        and parent.id == "os"
+                        and func.attr == "putenv"
+                    ):
+                        raise AssertionError(
+                            "_exec_refresh_a18_promotion_report body calls "
+                            "os.putenv(...)"
+                        )
+
+
+def test_executor_source_does_not_enable_a18b_or_n5b_live_execute() -> None:
+    """The executor must not export, set, or read the two gating
+    env flags for A18b writer activation and N5b live execute.
+    These flags govern *other* default-disabled surfaces and must
+    not be touched by the promotion-report maintenance entry."""
+    src = inspect.getsource(rm._exec_refresh_a18_promotion_report)
+    forbidden = (
+        "ADE_GENERATED_LANE_WRITER_ENABLED",
+        "ADE_N5B_LIVE_EXECUTE_ENABLED",
+    )
+    for needle in forbidden:
+        assert needle not in src, (
+            f"_exec_refresh_a18_promotion_report source contains "
+            f"forbidden runtime-gate flag {needle!r}"
+        )
+
+
+def test_executor_source_does_not_flip_step5_or_level6() -> None:
+    """The executor must not assign to / mutate any Step 5 or
+    Level 6 marker. (The projector module's own tests separately
+    pin that the artefact's invariants stay false / none.)"""
+    src = inspect.getsource(rm._exec_refresh_a18_promotion_report)
+    forbidden = (
+        "step5_implementation_allowed = True",
+        "step5_implementation_allowed=True",
+        'STEP5_ENABLED_SUBSTAGE = "5',
+        "STEP5_ENABLED_SUBSTAGE='5",
+        "level6_enabled = True",
+        "level6_enabled=True",
+    )
+    for needle in forbidden:
+        assert needle not in src, (
+            f"_exec_refresh_a18_promotion_report source contains "
+            f"forbidden Step 5 / Level 6 flip: {needle!r}"
+        )
+
+
+def test_executor_source_does_not_synthesize_operator_go_phrase() -> None:
+    """B1.1-specific safety pin: the executor function source
+    must not synthesise / hard-code the operator-go phrase as an
+    authority token. The phrase reaches the executor's evidence
+    dict only via ``snap.get("operator_go_phrase_required")``,
+    which means the executor's own bytes never need to contain
+    the literal.
+
+    Scope: this scan inspects **only** the executor function
+    source via ``inspect.getsource(rm._exec_refresh_a18_promotion_report)``.
+    The projector module itself legitimately owns the phrase as
+    closed metadata (``OPERATOR_GO_PHRASE`` in
+    ``reporting/development_generated_lane_promotion_report.py``)
+    and test fixtures may freely reference it; neither is in
+    scope for this scan."""
+    src = inspect.getsource(rm._exec_refresh_a18_promotion_report)
+    forbidden = "GO A18 promotion operator-promote"
+    assert forbidden not in src, (
+        f"_exec_refresh_a18_promotion_report function source "
+        f"hard-codes the operator-go phrase {forbidden!r}; the "
+        f"phrase must reach evidence only via snap.get(...), not "
+        f"by being synthesised in the executor's own bytes"
+    )


### PR DESCRIPTION
## Summary

Revised Batch 1, **unit B1.1 of 3** (last unit B1.4 still gated by operator continue). Registers the A18 promotion-readiness report (PR #216, merged) in the recurring-maintenance scheduler as a LOW-risk, no-\`gh\`, default-enabled job (30-min cadence, 90 s timeout). The projector itself remains read-only / report-only with a hard-pinned safety property — every emitted report row carries \`promotion_allowed=False\` and envelope-level \`promotable_row_count\` is asserted \`== 0\` before write. The maintenance entry does not relax this.

Rationale: B1.1 closes the upstream→downstream scheduling chain begun by B1.2 (A18c). The promotion-report consumes the A18c artefact; scheduling the downstream now that the upstream is scheduled completes the read-only shelf.

## File map (3 files, additive)

- \`reporting/recurring_maintenance.py\` — new \`JOB_REFRESH_A18_PROMOTION_REPORT\` constant, new \`_exec_refresh_a18_promotion_report\` executor, new \`_JOB_REGISTRY\` entry, new \`JOB_TYPES\` tuple member.
- \`tests/unit/test_recurring_maintenance.py\` — closed-set expected entry + cardinality bump (13 → 14).
- \`tests/unit/test_recurring_maintenance_a18_promotion_report.py\` — **new file, 17 pin-tests**: registry shape (constant value, membership, LOW/needs_gh=False/default_enabled=True, 30-min interval, 90 s timeout, executor handle, closed 7-key set), executor behaviour (envelope on A18c-absent path, persisted snapshot with synthetic needs_human A18c row, hard-pinned \`promotable_row_count == 0\` + per-row \`promotion_allowed=False\`, supervisor non-fatal classification), AST/source-text scans (no subprocess/socket/urllib/requests/httpx/aiohttp/popen/shell/gh/git/os.system; no env mutation; no A18b/N5b enablement; no Step 5/Level 6 flip; **no executor-source synthesis of the operator-go phrase** — scoped to the executor function source only, projector and fixtures excluded per operator brief).

## Job-field pins

| Field | Value |
|---|---|
| \`job_type\` | \`refresh_a18_promotion_report\` |
| \`default_enabled\` | \`True\` |
| \`risk_class\` | \`LOW\` |
| \`needs_gh\` | \`False\` |
| \`default_interval_seconds\` | \`1800\` (30 min) |
| \`timeout_seconds\` | \`90\` (\`DEFAULT_JOB_TIMEOUT_SECONDS\`) |

## Validation evidence

- \`python -m pytest tests/unit/test_recurring_maintenance_a18_promotion_report.py -q\` → **17 passed**.
- \`python -m pytest tests/unit/test_recurring_maintenance.py tests/unit/test_recurring_maintenance_a18c.py tests/unit/test_recurring_maintenance_a18_promotion_report.py tests/unit/test_recurring_maintenance_merge_preflight.py -q\` → **89 passed**.
- \`python -m pytest tests/smoke -q\` → **18 passed**.
- \`python scripts/governance_lint.py\` → \`Governance lint OK (16 agents, 5 workflows checked).\`
- \`python -m reporting.recurring_maintenance --list-jobs\` shows \`refresh_a18_promotion_report\` with \`risk_class=LOW\`, \`needs_gh=false\`, \`schedule.interval_seconds=1800\`, \`last_status=not_run\`.

## Not in scope (explicitly excluded)

- No edits to \`reporting/development_generated_lane_promotion_report.py\` (projector source byte-identical post-merge).
- No edits to A18c, A17, or A18b source.
- No env flip.
- No queue admission, no PR creation, no merge, no deploy.
- No \`seed.jsonl\` / \`delegation_seed.jsonl\` / \`generated_seed.jsonl\` writes.
- No \`tests/regression/\` edit.
- No \`.claude/\`, \`.github/\`, no-touch path, frozen v1 schema, ADR, canonical_policy_doc edit.
- No \`step5_implementation_allowed\` flip; stays \`False\`. No \`STEP5_ENABLED_SUBSTAGE\` flip; stays \`\"none\"\`. Level 6 stays permanently disabled.
- No operator-promote authority — that remains a separately gated future unit; the report module surfaces the required operator-go phrase as data only.

## Rollback

Single \`git revert\`. The scheduler entry is purely additive; removing it restores the prior 13-job registry. Artefact files at \`logs/development_generated_lane_promotion_report/latest.json\` are read-only emitter output and can be wiped without affecting any other surface.

## Test plan

- [x] All unit tests pass locally (89/89 maintenance suite, 17/17 new file).
- [x] Smoke green (18/18).
- [x] Governance lint green.
- [ ] CI green.
- [ ] Diff allowlist + mergeability confirmed.
- [ ] Squash-merge to main.
- [ ] Post-merge gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)