### PR TITLE
feat(b2-0b)(reporting): Agent Activity Center aggregator + recurring-maintenance entry (read-only)

### DIFF
--- a/reporting/development_agent_activity_timeline.py
+++ b/reporting/development_agent_activity_timeline.py
@@ -1,0 +1,1525 @@
+"""Agent Activity Center — read-only aggregator (B2.0b).
+
+Pure-stdlib aggregator that reads the closed 11-entry catalog of
+upstream ADE-core artefacts on disk and writes a single canonical
+artefact at ``logs/development_agent_activity_timeline/latest.json``
+satisfying the closed schema defined in
+``docs/governance/agent_activity_center_aggregator_schema.md``.
+
+Catalog cardinality
+-------------------
+
+* ``UPSTREAM_CATALOG_LEN = 11`` — 10 ADE-core upstream artefact paths
+  + 1 read-only seed health entry.
+* ``PROJECTABLE_UPSTREAM_LEN = 4`` — A18c, A18 promotion report,
+  Step 5.0 loop snapshot, N5b merge preflight. These four sources
+  contribute ``work_items[]`` rows in v0.1.
+* ``HEALTH_ONLY_UPSTREAM_LEN = 7`` — work_queue (A8), delegation
+  (A11), bugfix_loop (A10), release_gate (A9), step5_plan history,
+  operational_digest (A12), plus the read-only ``generated_seed.jsonl``
+  health entry. These contribute ``artifact_health[]`` rows only.
+
+Hard guarantees (pinned by tests)
+---------------------------------
+
+* Stdlib + ``reporting.agent_audit_summary.assert_no_secrets`` only.
+* No imports of ``subprocess``, ``socket``, ``urllib``,
+  ``urllib.request``, ``urllib.parse``, ``requests``, ``httpx``,
+  ``aiohttp``, ``http.client``.
+* No imports of ``research``, ``dashboard.dashboard``,
+  ``automation``, ``broker``, ``agent.risk``, ``agent.execution``,
+  ``reporting.intelligent_routing``.
+* No ``os.environ`` read of any kind. Invariants are sourced from
+  upstream artefacts or constants — never from process env.
+* No GitHub CLI invocation, no version-control CLI invocation, no
+  child-process spawn, no ``os.system``, no ``popen``, no
+  shell-mode subprocess flag.
+* Atomic write only under
+  ``logs/development_agent_activity_timeline/...`` via
+  ``tempfile.mkstemp`` + ``os.replace``. Sentinel-restricted to the
+  closed write prefix.
+* No write to ``seed.jsonl``, ``generated_seed.jsonl``, or
+  ``delegation_seed.jsonl``. The module mentions
+  ``generated_seed.jsonl`` only as a read path in the catalog.
+* Deterministic output: sorted-keys indented JSON. Same upstream
+  contents + same injected ``generated_at_utc`` → byte-identical
+  artefact.
+* Read-only over upstreams: pinned by a before/after sha256 test.
+* ``step5_implementation_allowed = False`` (Final constant).
+* ``STEP5_ENABLED_SUBSTAGE = "none"`` (Final constant).
+* Per-record bounded sizes per schema §13.
+
+What this module is NOT
+-----------------------
+
+* Not a Flask blueprint. B2.0c is a separate future unit.
+* Not a PWA frontend. B2.0d is a separate future unit.
+* Not a push-notification publisher. B2.0e is a separate future
+  unit.
+* Not a mutation endpoint. Read-only by construction.
+* Not authorised to flip ``step5_implementation_allowed`` or
+  ``STEP5_ENABLED_SUBSTAGE``. Both stay ``Final`` at their
+  default-deny values.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import hashlib
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Final
+
+from reporting.agent_audit_summary import assert_no_secrets
+
+
+# ---------------------------------------------------------------------------
+# Schema / module anchors
+# ---------------------------------------------------------------------------
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[int] = 1
+MODULE_VERSION: Final[str] = "aat.v0.1"
+REPORT_KIND: Final[str] = "agent_activity_timeline"
+
+
+# ---------------------------------------------------------------------------
+# Step 5 + Level 6 invariants (Final constants — never flipped)
+# ---------------------------------------------------------------------------
+
+STEP5_ENABLED_SUBSTAGE: Final[str] = "none"
+step5_implementation_allowed: Final[bool] = False
+
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies (echoed in the ``vocabularies`` envelope block)
+# ---------------------------------------------------------------------------
+
+STAGES: Final[tuple[str, ...]] = (
+    "discovered",
+    "queued",
+    "delegated",
+    "planned",
+    "dry_run_ready",
+    "pr_proposed",
+    "pr_opened",
+    "ci_feedback",
+    "needs_human",
+    "merge_candidate",
+    "done_blocked",
+)
+
+SEVERITIES: Final[tuple[str, ...]] = ("info", "warn", "human", "error")
+
+DECISIONS: Final[tuple[str, ...]] = (
+    "queue",
+    "delegate",
+    "plan",
+    "generate",
+    "approve_dry_run",
+    "require_human",
+    "flag",
+    "flag_flaky",
+    "quarantine",
+    "review",
+    "rerun",
+    "surface",
+    "advise_merge",
+    "no_op",
+    "ingest",
+    "annotate",
+)
+
+RISKS: Final[tuple[str, ...]] = ("low", "medium", "high", "critical")
+
+FRESHNESS_STATES: Final[tuple[str, ...]] = (
+    "fresh",
+    "stale",
+    "missing",
+    "malformed",
+)
+
+ARTIFACT_HEALTH_STATES: Final[tuple[str, ...]] = (
+    "ok",
+    "stale",
+    "malformed",
+    "missing",
+    "unreadable",
+)
+
+HUMAN_ACTION_TYPES: Final[tuple[str, ...]] = (
+    "operator_go_required",
+    "review_recommended",
+    "copy_only",
+    "informational",
+)
+
+INVARIANT_STATES: Final[tuple[str, ...]] = (
+    "on",
+    "off",
+    "danger_off",
+    "info",
+    "unknown",
+)
+
+SOURCE_KINDS: Final[tuple[str, ...]] = (
+    "roadmap_v6",
+    "work_queue",
+    "delegation",
+    "bugfix_loop",
+    "release_gate",
+    "generated_lane",
+    "generated_lane_promotion",
+    "step5_plan",
+    "step5_loop",
+    "ci_feedback",
+    "merge_preflight",
+    "operational_digest",
+    "addendum_loop",
+)
+
+AGENT_ROLES: Final[tuple[str, ...]] = (
+    "product_owner",
+    "strategic_advisor",
+    "quant_research_architect",
+    "planner",
+    "architecture_guardian",
+    "ci_guardian",
+    "implementation_agent",
+    "frontend_agent",
+    "test_agent",
+    "determinism_guardian",
+    "evidence_verifier",
+    "observability_guardian",
+    "deployment_safety_agent",
+    "adversarial_reviewer",
+    "release_gate_agent",
+    "human_operator",
+)
+
+EVENT_TYPES: Final[tuple[str, ...]] = (
+    "discovered",
+    "annotated",
+    "queued",
+    "delegated",
+    "plan_drafted",
+    "review",
+    "verdict",
+    "generated",
+    "detected",
+    "ci_result",
+    "rerun_queued",
+    "dry_run",
+    "preflight",
+    "quarantined",
+    "in_review",
+    "surfaced",
+)
+
+
+# ---------------------------------------------------------------------------
+# Closed upstream catalog
+#
+# Each entry: (group, source_kind_or_None, relative_artifact_path,
+#              projectable_in_v0_1).
+#
+# ``projectable_in_v0_1=True`` means the v0.1 aggregator emits
+# WorkItem rows from this upstream. ``False`` means the upstream
+# contributes ArtifactHealth only.
+# ---------------------------------------------------------------------------
+
+UPSTREAM_CATALOG: Final[
+    tuple[tuple[str, str | None, str, bool], ...]
+] = (
+    (
+        "queue",
+        "work_queue",
+        "logs/development_work_queue/latest.json",
+        False,
+    ),
+    (
+        "queue",
+        "delegation",
+        "logs/development_delegation/latest.json",
+        False,
+    ),
+    (
+        "loops",
+        "bugfix_loop",
+        "logs/development_bugfix_loop/latest.json",
+        False,
+    ),
+    (
+        "gates",
+        "release_gate",
+        "logs/development_release_gate/latest.json",
+        False,
+    ),
+    (
+        "step5",
+        "step5_loop",
+        "logs/step5_loop/latest.json",
+        True,
+    ),
+    (
+        "step5",
+        "step5_plan",
+        "logs/step5_plan/history.jsonl",
+        False,
+    ),
+    (
+        "generated",
+        "generated_lane",
+        "logs/development_generated_lane_a18c/latest.json",
+        True,
+    ),
+    (
+        "generated",
+        "generated_lane_promotion",
+        "logs/development_generated_lane_promotion_report/latest.json",
+        True,
+    ),
+    (
+        "gates",
+        "merge_preflight",
+        "logs/development_merge_preflight/latest.json",
+        True,
+    ),
+    (
+        "digest",
+        "operational_digest",
+        "logs/development_operational_digest/latest.json",
+        False,
+    ),
+    (
+        "seed",
+        None,
+        "generated_seed.jsonl",
+        False,
+    ),
+)
+
+UPSTREAM_CATALOG_LEN: Final[int] = 11
+PROJECTABLE_UPSTREAM_LEN: Final[int] = 4
+HEALTH_ONLY_UPSTREAM_LEN: Final[int] = 7
+
+
+# ---------------------------------------------------------------------------
+# Operator-approved TTL defaults (seconds)
+# ---------------------------------------------------------------------------
+
+TTL_BY_GROUP: Final[dict[str, int]] = {
+    "queue": 600,
+    "loops": 1800,
+    "step5": 1800,
+    "gates": 1800,
+    "generated": 1800,
+    "digest": 1800,
+    "seed": 86400,
+}
+
+
+# ---------------------------------------------------------------------------
+# Bounded sizes (mirrors schema §13)
+# ---------------------------------------------------------------------------
+
+MAX_WORK_ITEMS: Final[int] = 256
+MAX_AGENT_EVENTS: Final[int] = 2048
+MAX_HUMAN_ACTIONS: Final[int] = 64
+MAX_ARTIFACT_HEALTH: Final[int] = 64
+MAX_INVARIANT_STATUS: Final[int] = 32
+
+
+# ---------------------------------------------------------------------------
+# Per-row scalar caps
+# ---------------------------------------------------------------------------
+
+MAX_TITLE_LEN: Final[int] = 200
+MAX_VERDICT_LEN: Final[int] = 200
+MAX_NEXT_ACTION_LEN: Final[int] = 200
+MAX_SUMMARY_LEN: Final[int] = 600
+MAX_REASON_LEN: Final[int] = 200
+MAX_PARSE_ERROR_LEN: Final[int] = 200
+MAX_INVARIANT_DETAIL_LEN: Final[int] = 200
+
+
+# ---------------------------------------------------------------------------
+# Read-only seed warning chip
+# ---------------------------------------------------------------------------
+
+SEED_READ_ONLY_WARNING: Final[str] = "Read-only · UI must not write"
+
+
+# ---------------------------------------------------------------------------
+# Repo-relative artefact paths
+# ---------------------------------------------------------------------------
+
+ARTIFACT_DIR: Final[Path] = (
+    REPO_ROOT / "logs" / "development_agent_activity_timeline"
+)
+ARTIFACT_LATEST: Final[Path] = ARTIFACT_DIR / "latest.json"
+ARTIFACT_RELATIVE_PATH: Final[str] = (
+    "logs/development_agent_activity_timeline/latest.json"
+)
+
+#: Atomic-write allowlist. Any path whose POSIX form does not
+#: contain this prefix raises ``ValueError``.
+_WRITE_PREFIX: Final[str] = "logs/development_agent_activity_timeline/"
+
+
+# ---------------------------------------------------------------------------
+# Time helpers
+# ---------------------------------------------------------------------------
+
+
+def _utcnow() -> str:
+    """Return an ISO 8601 UTC timestamp truncated to seconds."""
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _parse_iso_utc(s: str | None) -> _dt.datetime | None:
+    """Parse an ISO 8601 UTC string. Returns ``None`` on failure."""
+    if not s or not isinstance(s, str):
+        return None
+    try:
+        if s.endswith("Z"):
+            s = s[:-1] + "+00:00"
+        return _dt.datetime.fromisoformat(s)
+    except (TypeError, ValueError):
+        return None
+
+
+def _utc_seconds_age(reference_utc: str, candidate_utc: str | None) -> int:
+    """Return the non-negative integer age in seconds between
+    ``reference_utc`` and ``candidate_utc``. Returns 0 when either
+    side is missing or unparseable."""
+    ref = _parse_iso_utc(reference_utc)
+    cand = _parse_iso_utc(candidate_utc)
+    if ref is None or cand is None:
+        return 0
+    delta_s = int((ref - cand).total_seconds())
+    return max(0, delta_s)
+
+
+def _file_mtime_iso(path: Path) -> str | None:
+    """Return the file's mtime as an ISO 8601 UTC string truncated
+    to seconds. Returns ``None`` if the file does not exist."""
+    try:
+        st = path.stat()
+    except (OSError, ValueError):
+        return None
+    return (
+        _dt.datetime.fromtimestamp(st.st_mtime, _dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bounded helpers
+# ---------------------------------------------------------------------------
+
+
+def _truncate(s: Any, cap: int) -> str:
+    """Coerce to string and truncate to ``cap`` characters."""
+    if s is None:
+        return ""
+    text = str(s)
+    if len(text) > cap:
+        return text[: cap - 1] + "…"
+    return text
+
+
+def _short_id_from(*parts: str) -> str:
+    """Deterministic short id derived from the parts. Stable across
+    Python invocations (hash randomisation does not affect sha256)."""
+    raw = "|".join(parts).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()[:16]
+
+
+# ---------------------------------------------------------------------------
+# Filesystem read helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_json(path: Path) -> tuple[str, dict[str, Any] | None, str | None]:
+    """Best-effort JSON read.
+
+    Returns ``(status, payload, error_detail)`` where ``status`` is
+    one of:
+
+    * ``"ok"`` — file present, parsed cleanly. ``payload`` is the dict.
+    * ``"absent"`` — file does not exist. ``payload`` is ``None``.
+    * ``"malformed"`` — file present, parse failed. ``payload`` is
+      ``None`` and ``error_detail`` carries a bounded error string.
+
+    No exceptions escape. No subprocess. No network.
+    """
+    if not path.is_file():
+        return ("absent", None, None)
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        return ("malformed", None, _truncate(repr(exc), MAX_PARSE_ERROR_LEN))
+    try:
+        payload = json.loads(text)
+    except (TypeError, ValueError) as exc:
+        return ("malformed", None, _truncate(str(exc), MAX_PARSE_ERROR_LEN))
+    if not isinstance(payload, dict):
+        return ("ok", None, None)
+    return ("ok", payload, None)
+
+
+def _count_jsonl_rows(path: Path) -> tuple[str, int, str | None]:
+    """Best-effort JSONL row count. Returns ``(status, row_count,
+    error_detail)``. ``status`` ∈ ``{"ok", "absent", "malformed"}``."""
+    if not path.is_file():
+        return ("absent", 0, None)
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        return ("malformed", 0, _truncate(repr(exc), MAX_PARSE_ERROR_LEN))
+    rows = [line for line in text.splitlines() if line.strip()]
+    return ("ok", len(rows), None)
+
+
+# ---------------------------------------------------------------------------
+# Atomic write helper — sentinel-restricted
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Atomically write ``payload`` as sorted-key indented JSON.
+
+    Refuses any path whose POSIX form does not contain
+    ``logs/development_agent_activity_timeline/`` — the closed
+    write allowlist.
+    """
+    posix = path.as_posix()
+    if _WRITE_PREFIX not in posix and not posix.startswith(_WRITE_PREFIX):
+        raise ValueError(
+            "development_agent_activity_timeline._atomic_write_json "
+            f"refuses non-aggregator-logs output path: {path}"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".development_agent_activity_timeline.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Projection helpers — v0.1 emits WorkItems from 4 sources only
+# ---------------------------------------------------------------------------
+
+
+def _project_step5_loop(
+    payload: dict[str, Any] | None,
+    *,
+    generated_at_utc: str,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    """Project ``logs/step5_loop/latest.json``.
+
+    Emits at most one WorkItem when the loop carries a non-no-op
+    ``current_plan``. Returns ``(work_items, agent_events, human_actions)``.
+    """
+    if not isinstance(payload, dict):
+        return ([], [], [])
+    plan = payload.get("current_plan") or {}
+    if not isinstance(plan, dict):
+        return ([], [], [])
+    outcome = plan.get("outcome")
+    if outcome in (None, "no_op_no_eligible_item"):
+        return ([], [], [])
+
+    cycle_id = str(plan.get("cycle_id") or "")
+    source_id = str(plan.get("source_id") or "")
+    halt_reason = plan.get("halt_reason")
+    decision = plan.get("execution_authority_decision")
+    upstream_source_kind = plan.get("source_kind") or ""
+
+    if outcome == "halt_needs_human":
+        stage = "needs_human"
+        human_needed = True
+        risk = "medium"
+    elif outcome in ("halt_permanently_denied", "halt_out_of_allowlist"):
+        stage = "done_blocked"
+        human_needed = False
+        risk = "high"
+    elif outcome == "plan_emitted":
+        stage = "planned"
+        human_needed = False
+        risk = "low"
+    else:
+        # Unknown outcome — surface as needs_human (fail-safe).
+        stage = "needs_human"
+        human_needed = True
+        risk = "medium"
+
+    short = _short_id_from("step5_loop", cycle_id or source_id)
+    item_id = f"wi_step5_{short}"
+    title = _truncate(
+        f"Step 5.0 cycle {short} ({upstream_source_kind or 'unknown'})",
+        MAX_TITLE_LEN,
+    )
+    verdict = _truncate(
+        f"outcome={outcome} halt_reason={halt_reason} decision={decision}",
+        MAX_VERDICT_LEN,
+    )
+    next_action = _truncate(
+        "Operator review" if human_needed else "Awaiting next cycle",
+        MAX_NEXT_ACTION_LEN,
+    )
+    summary = _truncate(
+        (
+            f"Step 5.0 dry-run loop produced outcome={outcome}. "
+            f"Authority decision={decision}. Halt reason={halt_reason}. "
+            "Loop remains dry-run-only; substage stays \"none\"."
+        ),
+        MAX_SUMMARY_LEN,
+    )
+    updated_at = (
+        payload.get("generated_at_utc")
+        if isinstance(payload.get("generated_at_utc"), str)
+        else generated_at_utc
+    )
+    event_id = f"ev_step5_{short}"
+
+    work_item = {
+        "item_id": item_id,
+        "title": title,
+        "source_kind": "step5_loop",
+        "source_path": "logs/step5_loop/latest.json",
+        "current_stage": stage,
+        "owner_role": "determinism_guardian",
+        "risk": risk,
+        "human_needed": human_needed,
+        "latest_verdict": verdict,
+        "next_action": next_action,
+        "updated_at": updated_at,
+        "summary": summary,
+        "event_ids": [event_id],
+    }
+
+    agent_event = {
+        "event_id": event_id,
+        "item_id": item_id,
+        "timestamp": updated_at,
+        "agent_role": "determinism_guardian",
+        "module": "step5_loop",
+        "event_type": "plan_drafted" if outcome == "plan_emitted" else "verdict",
+        "summary": _truncate(verdict, MAX_REASON_LEN),
+        "decision": (
+            "plan"
+            if outcome == "plan_emitted"
+            else ("require_human" if human_needed else "flag")
+        ),
+        "reason": _truncate(
+            f"step5_loop outcome={outcome}",
+            MAX_REASON_LEN,
+        ),
+        "artifact_path": "logs/step5_loop/latest.json",
+        "severity": "human" if human_needed else "info",
+    }
+
+    human_actions: list[dict[str, Any]] = []
+    if human_needed:
+        action_id = f"ha_step5_{short}"
+        human_actions.append(
+            {
+                "action_id": action_id,
+                "item_id": item_id,
+                "severity": "medium",
+                "title": title,
+                "why_required": _truncate(
+                    (
+                        "Step 5.0 loop halted with needs_human. Operator "
+                        "review required before any further cycle."
+                    ),
+                    MAX_SUMMARY_LEN,
+                ),
+                "required_phrase": None,
+                "safe_to_ignore": False,
+                "copy_only": True,
+                "source_artifact_path": "logs/step5_loop/latest.json",
+                "suggested_role": "determinism_guardian",
+                "created_at": updated_at,
+            }
+        )
+
+    return ([work_item], [agent_event], human_actions)
+
+
+def _project_a18c(
+    payload: dict[str, Any] | None,
+    *,
+    generated_at_utc: str,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    """Project ``logs/development_generated_lane_a18c/latest.json``."""
+    if not isinstance(payload, dict):
+        return ([], [], [])
+    rows = payload.get("rows") or []
+    if not isinstance(rows, list):
+        return ([], [], [])
+
+    work_items: list[dict[str, Any]] = []
+    events: list[dict[str, Any]] = []
+    actions: list[dict[str, Any]] = []
+
+    bounded = rows[:16]
+    upstream_ts = payload.get("generated_at_utc")
+    upstream_ts_str = (
+        upstream_ts if isinstance(upstream_ts, str) else generated_at_utc
+    )
+
+    for row in bounded:
+        if not isinstance(row, dict):
+            continue
+        cand_id = str(row.get("a18c_candidate_id") or row.get("generated_candidate_id") or "")
+        if not cand_id:
+            continue
+        admission_decision = row.get("admission_decision") or "needs_human"
+        admission_reason = row.get("admission_reason") or "needs_human_authority_decision"
+        target_lane = row.get("would_target_lane") or "none"
+        requires_go = bool(row.get("would_require_operator_go"))
+
+        short = _short_id_from("a18c", cand_id)
+        item_id = f"wi_a18c_{short}"
+
+        if admission_decision == "admissible":
+            stage = "queued"
+            human_needed = False
+            risk = "low"
+        elif admission_decision == "permanently_denied":
+            stage = "done_blocked"
+            human_needed = False
+            risk = "high"
+        else:
+            stage = "needs_human"
+            human_needed = True
+            risk = "medium"
+
+        title = _truncate(
+            f"A18c admission · {cand_id}", MAX_TITLE_LEN
+        )
+        verdict = _truncate(
+            (
+                f"admission_decision={admission_decision} "
+                f"admission_reason={admission_reason} "
+                f"would_target_lane={target_lane}"
+            ),
+            MAX_VERDICT_LEN,
+        )
+        next_action = _truncate(
+            "Operator review · A17 admission gate"
+            if human_needed
+            else "Awaiting downstream promotion report",
+            MAX_NEXT_ACTION_LEN,
+        )
+        summary = _truncate(
+            (
+                "Generated-lane A18c projected this row through the A17 "
+                "admission policy. The A18c projector never admits to "
+                "the queue; admission stays operator-paced."
+            ),
+            MAX_SUMMARY_LEN,
+        )
+        event_id = f"ev_a18c_{short}"
+        work_items.append(
+            {
+                "item_id": item_id,
+                "title": title,
+                "source_kind": "generated_lane",
+                "source_path": "logs/development_generated_lane_a18c/latest.json",
+                "current_stage": stage,
+                "owner_role": "release_gate_agent",
+                "risk": risk,
+                "human_needed": human_needed,
+                "latest_verdict": verdict,
+                "next_action": next_action,
+                "updated_at": upstream_ts_str,
+                "summary": summary,
+                "event_ids": [event_id],
+            }
+        )
+        events.append(
+            {
+                "event_id": event_id,
+                "item_id": item_id,
+                "timestamp": upstream_ts_str,
+                "agent_role": "release_gate_agent",
+                "module": "generated_lane_a18c",
+                "event_type": "verdict",
+                "summary": verdict,
+                "decision": "require_human" if human_needed else "surface",
+                "reason": _truncate(
+                    f"a18c admission decision={admission_decision}",
+                    MAX_REASON_LEN,
+                ),
+                "artifact_path": (
+                    "logs/development_generated_lane_a18c/latest.json"
+                ),
+                "severity": "human" if human_needed else "info",
+            }
+        )
+        if human_needed:
+            actions.append(
+                {
+                    "action_id": f"ha_a18c_{short}",
+                    "item_id": item_id,
+                    "severity": "medium",
+                    "title": title,
+                    "why_required": _truncate(
+                        (
+                            "A18c projector returned needs_human. "
+                            "Promotion remains operator-paced; no "
+                            "phrase is synthesised here."
+                        ),
+                        MAX_SUMMARY_LEN,
+                    ),
+                    # Pinned default: A18c rows never synthesise a phrase.
+                    "required_phrase": None,
+                    "safe_to_ignore": False,
+                    "copy_only": True,
+                    "source_artifact_path": (
+                        "logs/development_generated_lane_a18c/latest.json"
+                    ),
+                    "suggested_role": "release_gate_agent",
+                    "created_at": upstream_ts_str,
+                }
+            )
+        # Suppress the requires_go signal in v0.1 — informational only.
+        _ = requires_go
+
+    return (work_items, events, actions)
+
+
+def _project_promotion_report(
+    payload: dict[str, Any] | None,
+    *,
+    generated_at_utc: str,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    """Project ``logs/development_generated_lane_promotion_report/latest.json``."""
+    if not isinstance(payload, dict):
+        return ([], [], [])
+    rows = payload.get("rows") or []
+    if not isinstance(rows, list):
+        return ([], [], [])
+
+    work_items: list[dict[str, Any]] = []
+    events: list[dict[str, Any]] = []
+    actions: list[dict[str, Any]] = []
+
+    envelope_phrase = payload.get("operator_go_phrase_required")
+    if not isinstance(envelope_phrase, str):
+        envelope_phrase = None
+
+    bounded = rows[:16]
+    upstream_ts = payload.get("generated_at_utc")
+    upstream_ts_str = (
+        upstream_ts if isinstance(upstream_ts, str) else generated_at_utc
+    )
+
+    for row in bounded:
+        if not isinstance(row, dict):
+            continue
+        cand_id = str(
+            row.get("a18c_candidate_id")
+            or row.get("generated_candidate_id")
+            or row.get("item_id")
+            or ""
+        )
+        if not cand_id:
+            continue
+        block_reason = row.get("block_reason") or "promotion_disabled_by_default"
+
+        short = _short_id_from("a18_promotion", cand_id)
+        item_id = f"wi_a18prom_{short}"
+        title = _truncate(
+            f"A18 promotion report · {cand_id}", MAX_TITLE_LEN
+        )
+        verdict = _truncate(
+            (
+                f"promotion_allowed=False block_reason={block_reason}"
+            ),
+            MAX_VERDICT_LEN,
+        )
+        next_action = _truncate(
+            "Operator-go required to advance promotion",
+            MAX_NEXT_ACTION_LEN,
+        )
+        summary = _truncate(
+            (
+                "A18 promotion-readiness report row. Every row is "
+                "hard-pinned promotion_allowed=False; the module "
+                "never promotes. Operator-go is required to advance."
+            ),
+            MAX_SUMMARY_LEN,
+        )
+        event_id = f"ev_a18prom_{short}"
+        work_items.append(
+            {
+                "item_id": item_id,
+                "title": title,
+                "source_kind": "generated_lane_promotion",
+                "source_path": (
+                    "logs/development_generated_lane_promotion_report/latest.json"
+                ),
+                "current_stage": "needs_human",
+                "owner_role": "release_gate_agent",
+                "risk": "medium",
+                "human_needed": True,
+                "latest_verdict": verdict,
+                "next_action": next_action,
+                "updated_at": upstream_ts_str,
+                "summary": summary,
+                "event_ids": [event_id],
+            }
+        )
+        events.append(
+            {
+                "event_id": event_id,
+                "item_id": item_id,
+                "timestamp": upstream_ts_str,
+                "agent_role": "release_gate_agent",
+                "module": "generated_lane_promotion",
+                "event_type": "verdict",
+                "summary": verdict,
+                "decision": "require_human",
+                "reason": _truncate(
+                    f"promotion-report block_reason={block_reason}",
+                    MAX_REASON_LEN,
+                ),
+                "artifact_path": (
+                    "logs/development_generated_lane_promotion_report/latest.json"
+                ),
+                "severity": "human",
+            }
+        )
+        # Operator-go phrase: source from the row's own
+        # ``required_operator_go_phrase`` field, falling back to the
+        # envelope-level ``operator_go_phrase_required`` field. Never
+        # synthesise.
+        row_phrase = row.get("required_operator_go_phrase")
+        if not isinstance(row_phrase, str):
+            row_phrase = envelope_phrase
+        actions.append(
+            {
+                "action_id": f"ha_a18prom_{short}",
+                "item_id": item_id,
+                "severity": "medium",
+                "title": title,
+                "why_required": _truncate(
+                    (
+                        "Promotion remains operator-paced; phrase "
+                        "originates from the promotion-report row "
+                        "metadata, not from the aggregator."
+                    ),
+                    MAX_SUMMARY_LEN,
+                ),
+                "required_phrase": row_phrase,
+                "safe_to_ignore": False,
+                "copy_only": True,
+                "source_artifact_path": (
+                    "logs/development_generated_lane_promotion_report/latest.json"
+                ),
+                "suggested_role": "release_gate_agent",
+                "created_at": upstream_ts_str,
+            }
+        )
+
+    return (work_items, events, actions)
+
+
+def _project_merge_preflight(
+    payload: dict[str, Any] | None,
+    *,
+    generated_at_utc: str,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    """Project ``logs/development_merge_preflight/latest.json``."""
+    if not isinstance(payload, dict):
+        return ([], [], [])
+    candidates = payload.get("candidates") or payload.get("rows") or []
+    if not isinstance(candidates, list):
+        return ([], [], [])
+
+    work_items: list[dict[str, Any]] = []
+    events: list[dict[str, Any]] = []
+    actions: list[dict[str, Any]] = []
+
+    bounded = candidates[:16]
+    upstream_ts = payload.get("generated_at_utc")
+    upstream_ts_str = (
+        upstream_ts if isinstance(upstream_ts, str) else generated_at_utc
+    )
+
+    for cand in bounded:
+        if not isinstance(cand, dict):
+            continue
+        cand_id = str(
+            cand.get("preflight_id")
+            or cand.get("recommendation_id")
+            or cand.get("pr_number")
+            or ""
+        )
+        if not cand_id:
+            continue
+        verdict_value = cand.get("dry_run_verdict") or "would_block"
+
+        short = _short_id_from("merge_preflight", cand_id)
+        item_id = f"wi_mp_{short}"
+
+        if verdict_value == "would_be_live_candidate_if_authorized":
+            stage = "merge_candidate"
+            risk = "low"
+        elif verdict_value == "would_require_operator":
+            stage = "needs_human"
+            risk = "medium"
+        else:
+            stage = "done_blocked"
+            risk = "low"
+
+        title = _truncate(
+            f"Merge preflight · {cand_id}", MAX_TITLE_LEN
+        )
+        verdict = _truncate(
+            f"dry_run_verdict={verdict_value}", MAX_VERDICT_LEN
+        )
+        next_action = _truncate(
+            "Live merge is permanently disabled — surfaced for operator visibility only",
+            MAX_NEXT_ACTION_LEN,
+        )
+        summary = _truncate(
+            (
+                "N5b Phase 1 dry-run merge preflight projection. The "
+                "live merge path is not implemented; this surfaces "
+                "what a hypothetical live merge would require."
+            ),
+            MAX_SUMMARY_LEN,
+        )
+        event_id = f"ev_mp_{short}"
+        work_items.append(
+            {
+                "item_id": item_id,
+                "title": title,
+                "source_kind": "merge_preflight",
+                "source_path": "logs/development_merge_preflight/latest.json",
+                "current_stage": stage,
+                "owner_role": "release_gate_agent",
+                "risk": risk,
+                "human_needed": stage == "needs_human",
+                "latest_verdict": verdict,
+                "next_action": next_action,
+                "updated_at": upstream_ts_str,
+                "summary": summary,
+                "event_ids": [event_id],
+            }
+        )
+        events.append(
+            {
+                "event_id": event_id,
+                "item_id": item_id,
+                "timestamp": upstream_ts_str,
+                "agent_role": "release_gate_agent",
+                "module": "development_merge_preflight",
+                "event_type": "preflight",
+                "summary": verdict,
+                "decision": (
+                    "advise_merge"
+                    if stage == "merge_candidate"
+                    else "require_human"
+                ),
+                "reason": _truncate(
+                    f"merge_preflight verdict={verdict_value}",
+                    MAX_REASON_LEN,
+                ),
+                "artifact_path": (
+                    "logs/development_merge_preflight/latest.json"
+                ),
+                "severity": (
+                    "human" if stage == "needs_human" else "info"
+                ),
+            }
+        )
+
+    return (work_items, events, actions)
+
+
+# ---------------------------------------------------------------------------
+# Artefact health, freshness, invariants, counts
+# ---------------------------------------------------------------------------
+
+
+def _compute_artifact_health(
+    *,
+    repo_root: Path,
+    generated_at_utc: str,
+    parsed: dict[str, tuple[str, dict[str, Any] | None, str | None]],
+    jsonl_rows: dict[str, tuple[str, int, str | None]],
+) -> list[dict[str, Any]]:
+    """Build one ArtifactHealth row per catalog entry (11 rows)."""
+    out: list[dict[str, Any]] = []
+    for group, _kind, rel_path, _proj in UPSTREAM_CATALOG:
+        full_path = repo_root / rel_path
+        ttl = TTL_BY_GROUP.get(group, 1800)
+        is_jsonl = rel_path.endswith(".jsonl")
+
+        if is_jsonl:
+            status, rows, err = jsonl_rows.get(rel_path, ("absent", 0, None))
+            parse_ok = status != "malformed"
+            payload: dict[str, Any] | None = None
+        else:
+            status, payload, err = parsed.get(rel_path, ("absent", None, None))
+            parse_ok = status != "malformed"
+            rows = 0
+            if isinstance(payload, dict):
+                # Try to derive a row count from common shapes.
+                for key in ("rows", "candidates", "items"):
+                    val = payload.get(key)
+                    if isinstance(val, list):
+                        rows = len(val)
+                        break
+
+        mtime = _file_mtime_iso(full_path)
+        if mtime is None:
+            fresh = False
+        else:
+            age = _utc_seconds_age(generated_at_utc, mtime)
+            fresh = age <= ttl
+
+        module_version = ""
+        if isinstance(payload, dict):
+            mv = payload.get("module_version")
+            if isinstance(mv, str):
+                module_version = mv
+
+        has_summary = False
+        if isinstance(payload, dict):
+            has_summary = bool(
+                payload.get("summary")
+                or payload.get("note")
+                or payload.get("readiness_note")
+            )
+
+        row: dict[str, Any] = {
+            "path": rel_path,
+            "group": group,
+            "fresh": bool(fresh),
+            "parse_ok": bool(parse_ok),
+            "row_count": int(rows),
+            "last_modified": mtime if mtime is not None else "",
+            "module_version": module_version,
+            "has_summary": bool(has_summary),
+        }
+        if err is not None:
+            row["parse_error"] = _truncate(err, MAX_PARSE_ERROR_LEN)
+        if group == "seed":
+            row["read_only_warning"] = SEED_READ_ONLY_WARNING
+        out.append(row)
+
+    out.sort(key=lambda r: r["path"])
+    return out[:MAX_ARTIFACT_HEALTH]
+
+
+def _compute_freshness(
+    *,
+    generated_at_utc: str,
+    artifact_health: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Derive the freshness block from artefact-health rows."""
+    any_stale = False
+    any_malformed = False
+    oldest_age = 0
+    ttl_map: dict[str, int] = {}
+    for row in artifact_health:
+        if not row.get("parse_ok"):
+            any_malformed = True
+        if not row.get("fresh"):
+            any_stale = True
+        path = row["path"]
+        group = row["group"]
+        ttl_map[path] = TTL_BY_GROUP.get(group, 1800)
+        mtime = row.get("last_modified") or None
+        if mtime:
+            age = _utc_seconds_age(generated_at_utc, mtime)
+            if age > oldest_age:
+                oldest_age = age
+    return {
+        "generated_at_utc": generated_at_utc,
+        "oldest_artifact_age_seconds": int(oldest_age),
+        "any_stale": bool(any_stale),
+        "any_malformed": bool(any_malformed),
+        "background_refreshing": False,
+        "ttl_seconds_by_path": dict(sorted(ttl_map.items())),
+    }
+
+
+def _compute_invariant_status(
+    *,
+    parsed: dict[str, tuple[str, dict[str, Any] | None, str | None]],
+) -> list[dict[str, Any]]:
+    """Build the 9-row closed InvariantStatus list. ``a18c_enabled``
+    is sourced from the A18c artefact's ``enabled`` field when
+    present; everything else is static."""
+    a18c_status, a18c_payload, _ = parsed.get(
+        "logs/development_generated_lane_a18c/latest.json",
+        ("absent", None, None),
+    )
+    if a18c_status == "ok" and isinstance(a18c_payload, dict):
+        a18c_value = bool(a18c_payload.get("enabled"))
+        a18c_tone = "on" if a18c_value else "off"
+    else:
+        a18c_value = False
+        a18c_tone = "unknown"
+
+    invariants = [
+        {
+            "key": "level_6",
+            "label": "Level 6",
+            "value": "permanently_disabled",
+            "tone": "danger_off",
+            "detail": _truncate(
+                (
+                    "Level 6 stays permanently disabled per ADR-015 "
+                    "Doctrine 1. Cannot be re-enabled by this UI or "
+                    "any agent."
+                ),
+                MAX_INVARIANT_DETAIL_LEN,
+            ),
+        },
+        {
+            "key": "step5_substage",
+            "label": "Step 5 substage",
+            "value": STEP5_ENABLED_SUBSTAGE,
+            "tone": "info",
+            "detail": _truncate(
+                "Current Step 5 substage cap. Default-deny is 'none'.",
+                MAX_INVARIANT_DETAIL_LEN,
+            ),
+        },
+        {
+            "key": "step5_implementation_allowed",
+            "label": "Step 5 impl. allowed",
+            "value": step5_implementation_allowed,
+            "tone": "off",
+            "detail": _truncate(
+                "Final constant; Step 5 plans stay dry-run only.",
+                MAX_INVARIANT_DETAIL_LEN,
+            ),
+        },
+        {
+            "key": "live_merge_implemented",
+            "label": "Live merge",
+            "value": False,
+            "tone": "off",
+            "detail": _truncate(
+                "Autonomous merge is not implemented; operator merges only.",
+                MAX_INVARIANT_DETAIL_LEN,
+            ),
+        },
+        {
+            "key": "deploy_coupled",
+            "label": "Deploy coupled to merge",
+            "value": False,
+            "tone": "off",
+            "detail": _truncate(
+                "Merge does not trigger deploy. Deploy is fully manual.",
+                MAX_INVARIANT_DETAIL_LEN,
+            ),
+        },
+        {
+            "key": "a18c_enabled",
+            "label": "A18c lane",
+            "value": a18c_value,
+            "tone": a18c_tone,
+            "detail": _truncate(
+                "Generated lane A18c. Value sourced from the A18c artefact.",
+                MAX_INVARIANT_DETAIL_LEN,
+            ),
+        },
+        {
+            "key": "a18b_writer_enabled",
+            "label": "A18b writer",
+            "value": False,
+            "tone": "off",
+            "detail": _truncate(
+                "A18b writer disabled by default; aggregator reads only.",
+                MAX_INVARIANT_DETAIL_LEN,
+            ),
+        },
+        {
+            "key": "n5b_live_execute",
+            "label": "N5b live execute",
+            "value": False,
+            "tone": "off",
+            "detail": _truncate(
+                "No live execution path is enabled.",
+                MAX_INVARIANT_DETAIL_LEN,
+            ),
+        },
+        {
+            "key": "agent_service",
+            "label": "Agent service",
+            "value": "healthy",
+            "tone": "on",
+            "detail": _truncate(
+                (
+                    "Static placeholder in v0.1; a future revision "
+                    "may wire to a heartbeat source."
+                ),
+                MAX_INVARIANT_DETAIL_LEN,
+            ),
+        },
+    ]
+    invariants.sort(key=lambda r: r["key"])
+    return invariants[:MAX_INVARIANT_STATUS]
+
+
+def _aggregate_counts(
+    work_items: list[dict[str, Any]],
+) -> dict[str, int]:
+    """Compute the counts block from work_items[]."""
+    by_stage = {stage: 0 for stage in STAGES}
+    for w in work_items:
+        stage = w.get("current_stage")
+        if isinstance(stage, str) and stage in by_stage:
+            by_stage[stage] += 1
+    needs_human = sum(1 for w in work_items if w.get("human_needed"))
+    total_open = sum(
+        1 for w in work_items if w.get("current_stage") != "done_blocked"
+    )
+    return {
+        "discovered": by_stage["discovered"],
+        "queued": by_stage["queued"],
+        "delegated": by_stage["delegated"],
+        "planned": by_stage["planned"],
+        "dry_run_ready": by_stage["dry_run_ready"],
+        "pr_proposed": by_stage["pr_proposed"],
+        "pr_opened": by_stage["pr_opened"],
+        "ci_feedback": by_stage["ci_feedback"],
+        "needs_human": needs_human,
+        "merge_candidate": by_stage["merge_candidate"],
+        "blocked": by_stage["done_blocked"],
+        "total_open": total_open,
+    }
+
+
+def _vocabularies_block() -> dict[str, list[str]]:
+    """Return the closed-vocabularies echo block."""
+    return {
+        "stage": list(STAGES),
+        "severity": list(SEVERITIES),
+        "decision": list(DECISIONS),
+        "risk": list(RISKS),
+        "freshness": list(FRESHNESS_STATES),
+        "artifact_health": list(ARTIFACT_HEALTH_STATES),
+        "human_action": list(HUMAN_ACTION_TYPES),
+        "invariant_state": list(INVARIANT_STATES),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def collect_snapshot(
+    *,
+    repo_root: Path | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    """Pure scorer. Reads the closed 11-entry upstream catalog and
+    returns a sorted-key envelope dict satisfying the AAC schema."""
+    root = repo_root if repo_root is not None else REPO_ROOT
+    ts = generated_at_utc if generated_at_utc is not None else _utcnow()
+
+    # Read every catalog entry exactly once.
+    parsed: dict[
+        str, tuple[str, dict[str, Any] | None, str | None]
+    ] = {}
+    jsonl_rows: dict[str, tuple[str, int, str | None]] = {}
+    for _group, _kind, rel_path, _proj in UPSTREAM_CATALOG:
+        full_path = root / rel_path
+        if rel_path.endswith(".jsonl"):
+            jsonl_rows[rel_path] = _count_jsonl_rows(full_path)
+        else:
+            parsed[rel_path] = _read_json(full_path)
+
+    # Project the v0.1 projectable upstreams (4 only).
+    work_items: list[dict[str, Any]] = []
+    agent_events: list[dict[str, Any]] = []
+    human_actions: list[dict[str, Any]] = []
+
+    step5_status, step5_payload, _ = parsed.get(
+        "logs/step5_loop/latest.json", ("absent", None, None)
+    )
+    if step5_status == "ok":
+        wi, ev, ha = _project_step5_loop(
+            step5_payload, generated_at_utc=ts
+        )
+        work_items.extend(wi)
+        agent_events.extend(ev)
+        human_actions.extend(ha)
+
+    a18c_status, a18c_payload, _ = parsed.get(
+        "logs/development_generated_lane_a18c/latest.json",
+        ("absent", None, None),
+    )
+    if a18c_status == "ok":
+        wi, ev, ha = _project_a18c(a18c_payload, generated_at_utc=ts)
+        work_items.extend(wi)
+        agent_events.extend(ev)
+        human_actions.extend(ha)
+
+    prom_status, prom_payload, _ = parsed.get(
+        "logs/development_generated_lane_promotion_report/latest.json",
+        ("absent", None, None),
+    )
+    if prom_status == "ok":
+        wi, ev, ha = _project_promotion_report(
+            prom_payload, generated_at_utc=ts
+        )
+        work_items.extend(wi)
+        agent_events.extend(ev)
+        human_actions.extend(ha)
+
+    mp_status, mp_payload, _ = parsed.get(
+        "logs/development_merge_preflight/latest.json",
+        ("absent", None, None),
+    )
+    if mp_status == "ok":
+        wi, ev, ha = _project_merge_preflight(
+            mp_payload, generated_at_utc=ts
+        )
+        work_items.extend(wi)
+        agent_events.extend(ev)
+        human_actions.extend(ha)
+
+    # Deterministic ordering.
+    work_items.sort(key=lambda w: w["item_id"])
+    agent_events.sort(key=lambda e: (e["timestamp"], e["event_id"]))
+    human_actions.sort(key=lambda a: a["action_id"])
+
+    # Apply bounded caps.
+    work_items = work_items[:MAX_WORK_ITEMS]
+    agent_events = agent_events[:MAX_AGENT_EVENTS]
+    human_actions = human_actions[:MAX_HUMAN_ACTIONS]
+
+    artifact_health = _compute_artifact_health(
+        repo_root=root,
+        generated_at_utc=ts,
+        parsed=parsed,
+        jsonl_rows=jsonl_rows,
+    )
+    invariant_status = _compute_invariant_status(parsed=parsed)
+    freshness = _compute_freshness(
+        generated_at_utc=ts,
+        artifact_health=artifact_health,
+    )
+    counts = _aggregate_counts(work_items)
+
+    snapshot = {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": ts,
+        "freshness": freshness,
+        "counts": counts,
+        "work_items": work_items,
+        "agent_events": agent_events,
+        "human_actions": human_actions,
+        "artifact_health": artifact_health,
+        "invariant_status": invariant_status,
+        "vocabularies": _vocabularies_block(),
+    }
+
+    # Defense-in-depth: scrub the envelope before write.
+    assert_no_secrets(snapshot)
+    return snapshot
+
+
+def write_outputs(snapshot: dict[str, Any]) -> Path:
+    """Persist the snapshot to
+    ``logs/development_agent_activity_timeline/latest.json``.
+    Sentinel-restricted via ``_atomic_write_json``."""
+    _atomic_write_json(ARTIFACT_LATEST, snapshot)
+    return ARTIFACT_LATEST
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m reporting.development_agent_activity_timeline",
+        description=(
+            "Agent Activity Center read-only aggregator. Reads the "
+            "closed 11-entry upstream catalog and writes "
+            "logs/development_agent_activity_timeline/latest.json. "
+            "NEVER mutates upstream state. NEVER opens, merges, or "
+            "deploys anything. NEVER writes outside the canonical "
+            "aggregator path. NEVER writes to any seed JSONL."
+        ),
+    )
+    p.add_argument(
+        "--no-write",
+        action="store_true",
+        help=(
+            "Do not persist "
+            "logs/development_agent_activity_timeline/latest.json "
+            "(stdout only)."
+        ),
+    )
+    p.add_argument(
+        "--indent",
+        type=int,
+        default=2,
+        help="JSON indent (0 for compact).",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    indent = args.indent if args.indent and args.indent > 0 else None
+    try:
+        snap = collect_snapshot()
+        if not args.no_write:
+            write_outputs(snap)
+        json.dump(snap, sys.stdout, indent=indent, sort_keys=True)
+        sys.stdout.write("\n")
+        return 0
+    except Exception as exc:  # noqa: BLE001
+        sys.stderr.write(
+            f"development_agent_activity_timeline failed: {exc!r}\n"
+        )
+        return 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/reporting/recurring_maintenance.py
+++ b/reporting/recurring_maintenance.py
@@ -162,6 +162,16 @@ JOB_REFRESH_A18_PROMOTION_REPORT: str = "refresh_a18_promotion_report"
 # NEVER merges, NEVER deploys, NEVER calls gh, NEVER touches the
 # QRE surface. LOW risk; no gh; no external network.
 JOB_REFRESH_STEP5_LOOP: str = "refresh_step5_loop"
+# v3.15.16.A15.B2.0b — read-only Agent Activity Center aggregator
+# emitter. Reads the 11-entry closed catalog of ADE-core upstream
+# artefacts plus the read-only seed health entry and writes
+# logs/development_agent_activity_timeline/latest.json satisfying
+# the closed schema in docs/governance/agent_activity_center_
+# aggregator_schema.md. NEVER opens PRs, NEVER merges, NEVER
+# deploys, NEVER writes outside the canonical aggregator path,
+# NEVER writes to seed.jsonl / generated_seed.jsonl /
+# delegation_seed.jsonl. LOW risk; no external network.
+JOB_REFRESH_AGENT_ACTIVITY_TIMELINE: str = "refresh_agent_activity_timeline"
 
 JOB_TYPES: tuple[str, ...] = (
     JOB_REFRESH_WORKLOOP_RUNTIME,
@@ -179,6 +189,7 @@ JOB_TYPES: tuple[str, ...] = (
     JOB_REFRESH_GENERATED_LANE_A18C,
     JOB_REFRESH_A18_PROMOTION_REPORT,
     JOB_REFRESH_STEP5_LOOP,
+    JOB_REFRESH_AGENT_ACTIVITY_TIMELINE,
 )
 
 
@@ -536,6 +547,49 @@ def _exec_refresh_merge_preflight() -> dict[str, Any]:
             "deploy_coupled": snap.get("deploy_coupled"),
             "note": snap.get("note"),
             "validation_warnings": snap.get("validation_warnings"),
+        },
+    }
+
+
+def _exec_refresh_agent_activity_timeline() -> dict[str, Any]:
+    """Run the v3.15.16.A15.B2.0b read-only Agent Activity Center
+    aggregator. Reads the 11-entry closed upstream catalog and
+    writes a single canonical artefact at
+    ``logs/development_agent_activity_timeline/latest.json``
+    satisfying the closed schema in
+    ``docs/governance/agent_activity_center_aggregator_schema.md``.
+    Never opens PRs. Never merges. Never deploys. Never invokes
+    the GitHub CLI. Never invokes the version-control CLI. Never
+    spawns child processes. Never touches QRE-internal modules.
+    Autonomy-ladder Level 6 stays permanently disabled per
+    ADR-015 Doctrine 1.
+    """
+    from reporting.development_agent_activity_timeline import (
+        collect_snapshot,
+        write_outputs,
+    )
+
+    snap = collect_snapshot()
+    write_outputs(snap)
+    counts = snap.get("counts") or {}
+    freshness = snap.get("freshness") or {}
+    return {
+        "summary": (
+            f"development_agent_activity_timeline "
+            f"total_open={counts.get('total_open', 0)} "
+            f"needs_human={counts.get('needs_human', 0)} "
+            f"any_stale={freshness.get('any_stale', False)}"
+        ),
+        "evidence": {
+            "total_open": counts.get("total_open"),
+            "needs_human": counts.get("needs_human"),
+            "merge_candidate": counts.get("merge_candidate"),
+            "blocked": counts.get("blocked"),
+            "any_stale": freshness.get("any_stale"),
+            "any_malformed": freshness.get("any_malformed"),
+            "oldest_artifact_age_seconds": freshness.get(
+                "oldest_artifact_age_seconds"
+            ),
         },
     }
 
@@ -947,6 +1001,23 @@ _JOB_REGISTRY: dict[str, dict[str, Any]] = {
             "remains False; STEP5_ENABLED_SUBSTAGE remains "
             "\"none\". Never creates branches, never opens PRs, "
             "never merges, never deploys, never calls gh."
+        ),
+        "risk_class": RISK_LOW,
+        "needs_gh": False,
+        "timeout_seconds": DEFAULT_JOB_TIMEOUT_SECONDS,
+    },
+    JOB_REFRESH_AGENT_ACTIVITY_TIMELINE: {
+        "default_interval_seconds": 30 * 60,
+        "default_enabled": True,
+        "executor": _exec_refresh_agent_activity_timeline,
+        "description": (
+            "Refresh Agent Activity Center aggregator "
+            "(read-only projection over the 11-entry closed "
+            "upstream catalog). Writes logs/development_agent_"
+            "activity_timeline/latest.json. Never calls the "
+            "GitHub CLI, never merges, never deploys, never "
+            "writes outside the canonical aggregator path, never "
+            "writes seed JSONL files."
         ),
         "risk_class": RISK_LOW,
         "needs_gh": False,

--- a/tests/unit/test_development_agent_activity_timeline.py
+++ b/tests/unit/test_development_agent_activity_timeline.py
@@ -1,0 +1,1141 @@
+"""Pin tests for the v3.15.16.A15.B2.0b Agent Activity Center
+read-only aggregator (``reporting.development_agent_activity_timeline``).
+
+These tests pin:
+
+* closed vocabularies and module-version anchor;
+* AST-level absence of subprocess / network / QRE imports;
+* AST-level absence of ``os.environ`` reads;
+* source-text absence of GitHub CLI / version-control CLI tokens
+  and ``os.system`` / ``popen`` / ``shell=True``;
+* context-aware AST scan rejecting any *write-call context*
+  targeting ``seed.jsonl`` / ``generated_seed.jsonl`` /
+  ``delegation_seed.jsonl`` (the module is permitted to mention
+  ``generated_seed.jsonl`` as a *read path* in the catalog);
+* the sentinel-restricted write helper refuses non-allowlist
+  paths;
+* the persisted envelope carries all 12 required top-level keys;
+* deterministic output across two consecutive calls with the same
+  injected ``generated_at_utc``;
+* graceful absence (every upstream missing) → valid empty
+  envelope;
+* graceful malformation → ``parse_ok=False`` with ``parse_error``,
+  no raise;
+* read-only over upstreams (sha256 byte-equality before/after a
+  run);
+* narrow v0.1 projection: WorkItems emitted only from
+  ``step5_loop``, ``generated_lane_a18c``,
+  ``generated_lane_promotion``, ``merge_preflight``;
+* health-only upstreams emit no WorkItems;
+* operator-approved invariant defaults (``agent_service`` static
+  ``healthy`` / ``on``);
+* A18c rows: ``required_phrase`` stays ``None`` (no synthesis);
+* A18 promotion-report rows: ``required_phrase`` sourced from the
+  row when present;
+* CLI ``--no-write`` does not mutate ``logs/`` and the default run
+  materialises the tmp-redirected canonical path.
+
+These tests are stdlib + pytest only. No subprocess. No network.
+No env writes. No mutation outside ``tmp_path``.
+"""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import inspect
+import io
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reporting import development_agent_activity_timeline as aat
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+
+def _module_source() -> str:
+    return Path(aat.__file__).read_text(encoding="utf-8")
+
+
+def _module_ast() -> ast.AST:
+    return ast.parse(_module_source())
+
+
+def _redirect_to_tmp(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> Path:
+    """Redirect aggregator paths into a hermetic tmp tree."""
+    tmp_logs = tmp_path / "logs"
+    tmp_aat_dir = tmp_logs / "development_agent_activity_timeline"
+    tmp_aat_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(aat, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(aat, "ARTIFACT_DIR", tmp_aat_dir)
+    monkeypatch.setattr(
+        aat, "ARTIFACT_LATEST", tmp_aat_dir / "latest.json"
+    )
+    return tmp_logs
+
+
+def _write_upstream(
+    tmp_path: Path, rel_path: str, payload: dict[str, Any]
+) -> Path:
+    """Write an upstream JSON file into the hermetic tmp tree."""
+    target = tmp_path / rel_path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        json.dumps(payload, sort_keys=True), encoding="utf-8"
+    )
+    return target
+
+
+def _sha256_of(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Closed vocab and constants
+# ---------------------------------------------------------------------------
+
+
+def test_module_version_is_aat_v0_1() -> None:
+    assert aat.MODULE_VERSION == "aat.v0.1"
+
+
+def test_report_kind_is_agent_activity_timeline() -> None:
+    assert aat.REPORT_KIND == "agent_activity_timeline"
+
+
+def test_schema_version_is_1() -> None:
+    assert aat.SCHEMA_VERSION == 1
+
+
+def test_step5_implementation_allowed_is_false_constant() -> None:
+    assert aat.step5_implementation_allowed is False
+
+
+def test_step5_enabled_substage_is_none_constant() -> None:
+    assert aat.STEP5_ENABLED_SUBSTAGE == "none"
+
+
+def test_closed_vocab_cardinalities() -> None:
+    """Pin the cardinalities of every closed vocab and the three
+    catalog cardinality constants."""
+    assert len(aat.STAGES) == 11
+    assert len(aat.SEVERITIES) == 4
+    assert len(aat.DECISIONS) == 16
+    assert len(aat.RISKS) == 4
+    assert len(aat.FRESHNESS_STATES) == 4
+    assert len(aat.ARTIFACT_HEALTH_STATES) == 5
+    assert len(aat.HUMAN_ACTION_TYPES) == 4
+    assert len(aat.INVARIANT_STATES) == 5
+    assert len(aat.SOURCE_KINDS) == 13
+    assert len(aat.AGENT_ROLES) == 16
+    assert len(aat.EVENT_TYPES) == 16
+    assert aat.UPSTREAM_CATALOG_LEN == 11
+    assert aat.PROJECTABLE_UPSTREAM_LEN == 4
+    assert aat.HEALTH_ONLY_UPSTREAM_LEN == 7
+    assert len(aat.UPSTREAM_CATALOG) == aat.UPSTREAM_CATALOG_LEN
+
+
+def test_upstream_catalog_partition_is_exhaustive_and_mutually_exclusive() -> None:
+    """Every catalog entry is either projectable or health-only;
+    never both, never neither. Counts match the constants."""
+    projectable = [c for c in aat.UPSTREAM_CATALOG if c[3] is True]
+    health_only = [c for c in aat.UPSTREAM_CATALOG if c[3] is False]
+    assert len(projectable) == aat.PROJECTABLE_UPSTREAM_LEN
+    assert len(health_only) == aat.HEALTH_ONLY_UPSTREAM_LEN
+    assert (
+        len(projectable) + len(health_only) == aat.UPSTREAM_CATALOG_LEN
+    )
+    # Exhaustive: every entry has a boolean (not None) in slot 3.
+    for entry in aat.UPSTREAM_CATALOG:
+        assert isinstance(entry[3], bool)
+
+
+def test_invariant_keys_match_schema_invariant_state_vocab() -> None:
+    """Every InvariantStatus row's ``tone`` belongs to the closed
+    ``invariant_state`` vocab."""
+    snap = aat.collect_snapshot(
+        repo_root=Path("/nonexistent"),
+        generated_at_utc="2026-05-14T00:00:00Z",
+    )
+    for row in snap["invariant_status"]:
+        assert row["tone"] in aat.INVARIANT_STATES
+
+
+def test_ttl_defaults_match_operator_pinned_values() -> None:
+    """TTL defaults are pinned per operator approval."""
+    assert aat.TTL_BY_GROUP == {
+        "queue": 600,
+        "loops": 1800,
+        "step5": 1800,
+        "gates": 1800,
+        "generated": 1800,
+        "digest": 1800,
+        "seed": 86400,
+    }
+
+
+# ---------------------------------------------------------------------------
+# AST scans
+# ---------------------------------------------------------------------------
+
+
+_FORBIDDEN_TOP_LEVEL_IMPORTS = (
+    "subprocess",
+    "socket",
+    "urllib",
+    "requests",
+    "httpx",
+    "aiohttp",
+)
+
+_FORBIDDEN_QRE_IMPORTS = (
+    "research",
+    "automation",
+    "broker",
+)
+
+_FORBIDDEN_QRE_FROM_PREFIXES = (
+    "research",
+    "automation",
+    "broker",
+    "agent.risk",
+    "agent.execution",
+    "reporting.intelligent_routing",
+)
+
+
+def test_module_has_no_subprocess_or_network_imports() -> None:
+    tree = _module_ast()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                top = alias.name.split(".", 1)[0]
+                assert top not in _FORBIDDEN_TOP_LEVEL_IMPORTS, (
+                    f"forbidden import: {alias.name!r}"
+                )
+        if isinstance(node, ast.ImportFrom) and node.module is not None:
+            top = node.module.split(".", 1)[0]
+            assert top not in _FORBIDDEN_TOP_LEVEL_IMPORTS, (
+                f"forbidden import: from {node.module!r}"
+            )
+
+
+def test_module_has_no_qre_or_dashboard_imports() -> None:
+    tree = _module_ast()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                top = alias.name.split(".", 1)[0]
+                assert top not in _FORBIDDEN_QRE_IMPORTS, (
+                    f"forbidden QRE import: {alias.name!r}"
+                )
+                assert alias.name != "dashboard.dashboard"
+        if isinstance(node, ast.ImportFrom) and node.module is not None:
+            for prefix in _FORBIDDEN_QRE_FROM_PREFIXES:
+                assert not (
+                    node.module == prefix or node.module.startswith(prefix + ".")
+                ), f"forbidden QRE/dashboard import: from {node.module!r}"
+            assert node.module != "dashboard.dashboard"
+
+
+def test_module_has_no_os_environ_read() -> None:
+    """Stricter than merge-preflight: ``_compute_invariant_status``
+    must source from artefacts only."""
+    tree = _module_ast()
+    for node in ast.walk(tree):
+        # ``os.environ[...]`` subscript or attribute chain.
+        if isinstance(node, ast.Attribute):
+            if (
+                node.attr == "environ"
+                and isinstance(node.value, ast.Name)
+                and node.value.id == "os"
+            ):
+                raise AssertionError(
+                    "aggregator references os.environ — forbidden"
+                )
+        # ``os.getenv(...)`` call.
+        if isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Attribute):
+                if (
+                    func.attr == "getenv"
+                    and isinstance(func.value, ast.Name)
+                    and func.value.id == "os"
+                ):
+                    raise AssertionError(
+                        "aggregator calls os.getenv — forbidden"
+                    )
+
+
+def test_module_source_has_no_gh_or_git_or_os_system_tokens() -> None:
+    """Source-text scan for write-call CLI tokens. Module-level
+    scan; bare docstring mentions of ``subprocess`` are tolerated
+    where the actual scan targets a syntactic pattern."""
+    src = _module_source()
+    # The exact patterns we forbid are syntactic, not bare words.
+    forbidden = (
+        "subprocess.run(",
+        "subprocess.Popen(",
+        "subprocess.call(",
+        "os.system(",
+        "os.popen(",
+        "shell=True",
+        "shell = True",
+    )
+    for needle in forbidden:
+        assert needle not in src, (
+            f"aggregator source contains forbidden invocation: {needle!r}"
+        )
+
+
+def test_module_writes_no_seed_files_context_aware() -> None:
+    """Context-aware scan: the module is permitted to mention
+    ``generated_seed.jsonl`` as a *read path* in the catalog, but
+    must not call any write helper with a path argument that
+    contains a seed-JSONL filename.
+
+    Closed list of write contexts scanned:
+
+    * ``open(<lit>, mode=<lit>)`` where mode contains 'w'/'a'/'x';
+    * ``<x>.write_text(...)`` / ``<x>.write_bytes(...)``;
+    * ``os.replace(<src>, <dst>)`` where ``<dst>`` resolves to a
+      seed literal;
+    * ``_atomic_write_json(<target>, ...)`` where ``<target>``
+      resolves to a seed literal.
+
+    The aggregator's only write context in v0.1 is
+    ``_atomic_write_json(ARTIFACT_LATEST, snapshot)``, which is
+    sentinel-restricted to ``logs/development_agent_activity_timeline/``.
+    """
+    src = _module_source()
+    tree = ast.parse(src)
+    seed_names = (
+        "seed.jsonl",
+        "generated_seed.jsonl",
+        "delegation_seed.jsonl",
+    )
+
+    def _string_contains_seed(node: ast.AST) -> bool:
+        return (
+            isinstance(node, ast.Constant)
+            and isinstance(node.value, str)
+            and any(name in node.value for name in seed_names)
+        )
+
+    for call in ast.walk(tree):
+        if not isinstance(call, ast.Call):
+            continue
+        func = call.func
+
+        # Case A: open(<lit>, "w"|"a"|"x"|...).
+        is_open = (
+            isinstance(func, ast.Name) and func.id == "open"
+        ) or (
+            isinstance(func, ast.Attribute) and func.attr == "open"
+        )
+        if is_open and call.args:
+            first = call.args[0]
+            mode_is_write = False
+            if len(call.args) >= 2 and isinstance(
+                call.args[1], ast.Constant
+            ):
+                mode = call.args[1].value
+                if isinstance(mode, str) and any(
+                    ch in mode for ch in ("w", "a", "x")
+                ):
+                    mode_is_write = True
+            for kw in call.keywords:
+                if kw.arg == "mode" and isinstance(kw.value, ast.Constant):
+                    mode = kw.value.value
+                    if isinstance(mode, str) and any(
+                        ch in mode for ch in ("w", "a", "x")
+                    ):
+                        mode_is_write = True
+            if mode_is_write and _string_contains_seed(first):
+                raise AssertionError(
+                    f"forbidden seed write via open(): {ast.dump(call)}"
+                )
+
+        # Case B: <x>.write_text(<lit>...) / <x>.write_bytes(<lit>...).
+        if isinstance(func, ast.Attribute) and func.attr in {
+            "write_text",
+            "write_bytes",
+        }:
+            # The receiver must not be a Constant string with a
+            # seed filename (uncommon but pinned).
+            if _string_contains_seed(func.value):
+                raise AssertionError(
+                    f"forbidden seed write_text/_bytes: {ast.dump(call)}"
+                )
+
+        # Case C: os.replace(<src>, <dst>) where <dst> is a seed
+        # literal.
+        if (
+            isinstance(func, ast.Attribute)
+            and func.attr == "replace"
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "os"
+            and len(call.args) >= 2
+        ):
+            dst = call.args[1]
+            if _string_contains_seed(dst):
+                raise AssertionError(
+                    f"forbidden seed os.replace target: {ast.dump(call)}"
+                )
+
+        # Case D: _atomic_write_json(<target>, ...).
+        is_atomic_write = (
+            isinstance(func, ast.Name)
+            and func.id == "_atomic_write_json"
+        ) or (
+            isinstance(func, ast.Attribute)
+            and func.attr == "_atomic_write_json"
+        )
+        if is_atomic_write and call.args:
+            first = call.args[0]
+            if _string_contains_seed(first):
+                raise AssertionError(
+                    "forbidden seed _atomic_write_json target"
+                )
+
+
+# ---------------------------------------------------------------------------
+# Write-path sentinel
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_write_refuses_paths_outside_logs_aat(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(ValueError):
+        aat._atomic_write_json(
+            tmp_path / "foo.json", {"hello": "world"}
+        )
+
+
+def test_write_outputs_writes_to_canonical_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    tmp_logs = _redirect_to_tmp(monkeypatch, tmp_path)
+    snap = aat.collect_snapshot(
+        repo_root=tmp_path,
+        generated_at_utc="2026-05-14T00:00:00Z",
+    )
+    written = aat.write_outputs(snap)
+    assert written == (
+        tmp_logs / "development_agent_activity_timeline" / "latest.json"
+    )
+    assert written.is_file()
+
+
+# ---------------------------------------------------------------------------
+# Schema fidelity
+# ---------------------------------------------------------------------------
+
+
+def test_envelope_contains_all_required_top_level_keys() -> None:
+    snap = aat.collect_snapshot(
+        repo_root=Path("/nonexistent"),
+        generated_at_utc="2026-05-14T00:00:00Z",
+    )
+    required = {
+        "schema_version",
+        "module_version",
+        "report_kind",
+        "generated_at_utc",
+        "freshness",
+        "counts",
+        "work_items",
+        "agent_events",
+        "human_actions",
+        "artifact_health",
+        "invariant_status",
+        "vocabularies",
+    }
+    assert required.issubset(set(snap.keys()))
+
+
+def test_envelope_carries_module_version_anchor() -> None:
+    snap = aat.collect_snapshot(
+        repo_root=Path("/nonexistent"),
+        generated_at_utc="2026-05-14T00:00:00Z",
+    )
+    assert snap["module_version"] == "aat.v0.1"
+    assert snap["schema_version"] == 1
+    assert snap["report_kind"] == "agent_activity_timeline"
+
+
+def test_envelope_vocabularies_block_matches_constants() -> None:
+    snap = aat.collect_snapshot(
+        repo_root=Path("/nonexistent"),
+        generated_at_utc="2026-05-14T00:00:00Z",
+    )
+    vocab = snap["vocabularies"]
+    assert vocab["stage"] == list(aat.STAGES)
+    assert vocab["severity"] == list(aat.SEVERITIES)
+    assert vocab["decision"] == list(aat.DECISIONS)
+    assert vocab["risk"] == list(aat.RISKS)
+    assert vocab["freshness"] == list(aat.FRESHNESS_STATES)
+    assert vocab["artifact_health"] == list(aat.ARTIFACT_HEALTH_STATES)
+    assert vocab["human_action"] == list(aat.HUMAN_ACTION_TYPES)
+    assert vocab["invariant_state"] == list(aat.INVARIANT_STATES)
+
+
+def test_envelope_invariant_status_includes_level_6_danger_off() -> None:
+    snap = aat.collect_snapshot(
+        repo_root=Path("/nonexistent"),
+        generated_at_utc="2026-05-14T00:00:00Z",
+    )
+    l6 = [r for r in snap["invariant_status"] if r["key"] == "level_6"]
+    assert len(l6) == 1
+    assert l6[0]["value"] == "permanently_disabled"
+    assert l6[0]["tone"] == "danger_off"
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+def test_collect_snapshot_is_deterministic_with_injected_timestamp(
+    tmp_path: Path,
+) -> None:
+    snap_a = aat.collect_snapshot(
+        repo_root=tmp_path,
+        generated_at_utc="2026-05-14T08:00:00Z",
+    )
+    snap_b = aat.collect_snapshot(
+        repo_root=tmp_path,
+        generated_at_utc="2026-05-14T08:00:00Z",
+    )
+    serialized_a = json.dumps(snap_a, sort_keys=True, indent=2)
+    serialized_b = json.dumps(snap_b, sort_keys=True, indent=2)
+    assert serialized_a == serialized_b
+
+
+def test_collect_snapshot_arrays_are_sorted_deterministically(
+    tmp_path: Path,
+) -> None:
+    """Build two A18c rows in non-sorted order and verify the
+    aggregator's output is sorted by ``item_id``."""
+    _write_upstream(
+        tmp_path,
+        "logs/development_generated_lane_a18c/latest.json",
+        {
+            "schema_version": 1,
+            "module_version": "a18c.v1.3",
+            "enabled": True,
+            "rows": [
+                {
+                    "a18c_candidate_id": "zzz",
+                    "admission_decision": "needs_human",
+                },
+                {
+                    "a18c_candidate_id": "aaa",
+                    "admission_decision": "needs_human",
+                },
+            ],
+            "generated_at_utc": "2026-05-14T07:00:00Z",
+        },
+    )
+    snap = aat.collect_snapshot(
+        repo_root=tmp_path,
+        generated_at_utc="2026-05-14T08:00:00Z",
+    )
+    ids = [w["item_id"] for w in snap["work_items"]]
+    assert ids == sorted(ids)
+    health_paths = [r["path"] for r in snap["artifact_health"]]
+    assert health_paths == sorted(health_paths)
+    invariant_keys = [r["key"] for r in snap["invariant_status"]]
+    assert invariant_keys == sorted(invariant_keys)
+
+
+# ---------------------------------------------------------------------------
+# Graceful absence / malformation
+# ---------------------------------------------------------------------------
+
+
+def test_collect_snapshot_with_all_upstreams_absent_returns_valid_envelope(
+    tmp_path: Path,
+) -> None:
+    snap = aat.collect_snapshot(
+        repo_root=tmp_path,
+        generated_at_utc="2026-05-14T08:00:00Z",
+    )
+    assert snap["work_items"] == []
+    assert snap["counts"]["total_open"] == 0
+    assert len(snap["artifact_health"]) == aat.UPSTREAM_CATALOG_LEN
+    assert len(snap["invariant_status"]) == 9
+
+
+def test_freshness_pins_any_stale_when_upstreams_absent(
+    tmp_path: Path,
+) -> None:
+    snap = aat.collect_snapshot(
+        repo_root=tmp_path,
+        generated_at_utc="2026-05-14T08:00:00Z",
+    )
+    assert snap["freshness"]["any_stale"] is True
+
+
+def test_artifact_health_includes_one_row_per_catalog_entry(
+    tmp_path: Path,
+) -> None:
+    snap = aat.collect_snapshot(
+        repo_root=tmp_path,
+        generated_at_utc="2026-05-14T08:00:00Z",
+    )
+    paths = [r["path"] for r in snap["artifact_health"]]
+    expected_paths = [c[2] for c in aat.UPSTREAM_CATALOG]
+    assert sorted(paths) == sorted(expected_paths)
+
+
+def test_collect_snapshot_with_malformed_upstream_emits_warning_not_raise(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "logs" / "development_work_queue" / "latest.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("{not valid json", encoding="utf-8")
+    snap = aat.collect_snapshot(
+        repo_root=tmp_path,
+        generated_at_utc="2026-05-14T08:00:00Z",
+    )
+    wq = next(
+        r
+        for r in snap["artifact_health"]
+        if r["path"] == "logs/development_work_queue/latest.json"
+    )
+    assert wq["parse_ok"] is False
+    assert isinstance(wq.get("parse_error"), str)
+    assert len(wq["parse_error"]) <= aat.MAX_PARSE_ERROR_LEN
+
+
+def test_freshness_pins_any_malformed_when_upstream_malformed(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "logs" / "development_work_queue" / "latest.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("nope", encoding="utf-8")
+    snap = aat.collect_snapshot(
+        repo_root=tmp_path,
+        generated_at_utc="2026-05-14T08:00:00Z",
+    )
+    assert snap["freshness"]["any_malformed"] is True
+
+
+# ---------------------------------------------------------------------------
+# Read-only over upstreams
+# ---------------------------------------------------------------------------
+
+
+def test_collect_snapshot_does_not_mutate_upstream_artefacts(
+    tmp_path: Path,
+) -> None:
+    """Write hand-crafted upstreams and verify byte-equality
+    before and after a ``collect_snapshot`` call."""
+    target_a18c = _write_upstream(
+        tmp_path,
+        "logs/development_generated_lane_a18c/latest.json",
+        {
+            "schema_version": 1,
+            "module_version": "a18c.v1.3",
+            "enabled": True,
+            "rows": [
+                {
+                    "a18c_candidate_id": "abc",
+                    "admission_decision": "needs_human",
+                }
+            ],
+            "generated_at_utc": "2026-05-14T07:00:00Z",
+        },
+    )
+    target_mp = _write_upstream(
+        tmp_path,
+        "logs/development_merge_preflight/latest.json",
+        {
+            "schema_version": "1.0",
+            "module_version": "mp.v1.1",
+            "candidates": [
+                {
+                    "preflight_id": "mp_001",
+                    "dry_run_verdict": "would_require_operator",
+                }
+            ],
+            "generated_at_utc": "2026-05-14T07:00:00Z",
+        },
+    )
+    before = (_sha256_of(target_a18c), _sha256_of(target_mp))
+    aat.collect_snapshot(
+        repo_root=tmp_path,
+        generated_at_utc="2026-05-14T08:00:00Z",
+    )
+    after = (_sha256_of(target_a18c), _sha256_of(target_mp))
+    assert before == after
+
+
+# ---------------------------------------------------------------------------
+# Projection correctness — narrow v0.1 slice
+# ---------------------------------------------------------------------------
+
+
+def test_step5_loop_no_op_does_not_emit_workitem(tmp_path: Path) -> None:
+    _write_upstream(
+        tmp_path,
+        "logs/step5_loop/latest.json",
+        {
+            "module_version": "v3.15.16.A14",
+            "report_kind": "step5_loop",
+            "step5_enabled_substage": "none",
+            "step5_implementation_allowed": False,
+            "current_plan": {
+                "cycle_id": "noop-id",
+                "outcome": "no_op_no_eligible_item",
+                "halt_reason": "ok",
+                "source_kind": "queue",
+                "source_id": "",
+                "execution_authority_decision": "AUTO_ALLOWED",
+            },
+            "generated_at_utc": "2026-05-14T07:00:00Z",
+        },
+    )
+    snap = aat.collect_snapshot(
+        repo_root=tmp_path,
+        generated_at_utc="2026-05-14T08:00:00Z",
+    )
+    step5_items = [
+        w for w in snap["work_items"] if w["source_kind"] == "step5_loop"
+    ]
+    assert step5_items == []
+
+
+def test_step5_loop_plan_emitted_produces_workitem(tmp_path: Path) -> None:
+    _write_upstream(
+        tmp_path,
+        "logs/step5_loop/latest.json",
+        {
+            "module_version": "v3.15.16.A14",
+            "report_kind": "step5_loop",
+            "step5_enabled_substage": "none",
+            "step5_implementation_allowed": False,
+            "current_plan": {
+                "cycle_id": "plan-cycle-001",
+                "outcome": "plan_emitted",
+                "halt_reason": "ok",
+                "source_kind": "queue",
+                "source_id": "dwq_001",
+                "execution_authority_decision": "AUTO_ALLOWED",
+            },
+            "generated_at_utc": "2026-05-14T07:00:00Z",
+        },
+    )
+    snap = aat.collect_snapshot(
+        repo_root=tmp_path,
+        generated_at_utc="2026-05-14T08:00:00Z",
+    )
+    step5_items = [
+        w for w in snap["work_items"] if w["source_kind"] == "step5_loop"
+    ]
+    assert len(step5_items) == 1
+    assert step5_items[0]["current_stage"] == "planned"
+    assert step5_items[0]["human_needed"] is False
+
+
+def test_a18c_row_produces_workitem(tmp_path: Path) -> None:
+    _write_upstream(
+        tmp_path,
+        "logs/development_generated_lane_a18c/latest.json",
+        {
+            "schema_version": 1,
+            "module_version": "a18c.v1.3",
+            "enabled": True,
+            "rows": [
+                {
+                    "a18c_candidate_id": "cand_x",
+                    "admission_decision": "needs_human",
+                    "admission_reason": "needs_human_authority_decision",
+                    "would_target_lane": "none",
+                    "would_require_operator_go": True,
+                }
+            ],
+            "generated_at_utc": "2026-05-14T07:00:00Z",
+        },
+    )
+    snap = aat.collect_snapshot(
+        repo_root=tmp_path,
+        generated_at_utc="2026-05-14T08:00:00Z",
+    )
+    a18c_items = [
+        w
+        for w in snap["work_items"]
+        if w["source_kind"] == "generated_lane"
+    ]
+    assert len(a18c_items) == 1
+    assert a18c_items[0]["human_needed"] is True
+    assert a18c_items[0]["current_stage"] == "needs_human"
+
+
+def test_a18c_needs_human_row_does_not_synthesize_required_phrase(
+    tmp_path: Path,
+) -> None:
+    """Operator-pinned default: A18c rows must not synthesise a
+    phrase. ``required_phrase`` must be ``None``."""
+    _write_upstream(
+        tmp_path,
+        "logs/development_generated_lane_a18c/latest.json",
+        {
+            "schema_version": 1,
+            "module_version": "a18c.v1.3",
+            "enabled": True,
+            "rows": [
+                {
+                    "a18c_candidate_id": "cand_phrase_test",
+                    "admission_decision": "needs_human",
+                    "would_require_operator_go": True,
+                }
+            ],
+            "generated_at_utc": "2026-05-14T07:00:00Z",
+        },
+    )
+    snap = aat.collect_snapshot(
+        repo_root=tmp_path,
+        generated_at_utc="2026-05-14T08:00:00Z",
+    )
+    a18c_actions = [
+        a
+        for a in snap["human_actions"]
+        if a["source_artifact_path"].endswith(
+            "development_generated_lane_a18c/latest.json"
+        )
+    ]
+    assert len(a18c_actions) == 1
+    assert a18c_actions[0]["required_phrase"] is None
+
+
+def test_promotion_report_row_produces_workitem(tmp_path: Path) -> None:
+    _write_upstream(
+        tmp_path,
+        "logs/development_generated_lane_promotion_report/latest.json",
+        {
+            "schema_version": "1.0",
+            "module_version": "v3.15.16.A18.promotion_report",
+            "rows": [
+                {
+                    "a18c_candidate_id": "cand_prom",
+                    "promotion_allowed": False,
+                    "block_reason": "promotion_disabled_by_default",
+                }
+            ],
+            "generated_at_utc": "2026-05-14T07:00:00Z",
+        },
+    )
+    snap = aat.collect_snapshot(
+        repo_root=tmp_path,
+        generated_at_utc="2026-05-14T08:00:00Z",
+    )
+    prom_items = [
+        w
+        for w in snap["work_items"]
+        if w["source_kind"] == "generated_lane_promotion"
+    ]
+    assert len(prom_items) == 1
+    assert prom_items[0]["human_needed"] is True
+
+
+def test_promotion_report_required_phrase_sourced_from_row(
+    tmp_path: Path,
+) -> None:
+    """Operator-pinned default: promotion-report rows MAY carry
+    ``required_phrase`` sourced from ``required_operator_go_phrase``."""
+    _write_upstream(
+        tmp_path,
+        "logs/development_generated_lane_promotion_report/latest.json",
+        {
+            "schema_version": "1.0",
+            "module_version": "v3.15.16.A18.promotion_report",
+            "operator_go_phrase_required": (
+                "GO A18 promotion operator-promote"
+            ),
+            "rows": [
+                {
+                    "a18c_candidate_id": "cand_with_phrase",
+                    "promotion_allowed": False,
+                    "block_reason": "needs_human_per_a17_policy",
+                    "required_operator_go_phrase": (
+                        "GO A18 promotion operator-promote"
+                    ),
+                }
+            ],
+            "generated_at_utc": "2026-05-14T07:00:00Z",
+        },
+    )
+    snap = aat.collect_snapshot(
+        repo_root=tmp_path,
+        generated_at_utc="2026-05-14T08:00:00Z",
+    )
+    prom_actions = [
+        a
+        for a in snap["human_actions"]
+        if a["source_artifact_path"].endswith(
+            "development_generated_lane_promotion_report/latest.json"
+        )
+    ]
+    assert len(prom_actions) == 1
+    assert (
+        prom_actions[0]["required_phrase"]
+        == "GO A18 promotion operator-promote"
+    )
+
+
+def test_merge_preflight_candidate_produces_workitem(
+    tmp_path: Path,
+) -> None:
+    _write_upstream(
+        tmp_path,
+        "logs/development_merge_preflight/latest.json",
+        {
+            "schema_version": "1.0",
+            "module_version": "mp.v1.1",
+            "candidates": [
+                {
+                    "preflight_id": "pf_001",
+                    "dry_run_verdict": "would_require_operator",
+                    "pr_number": 42,
+                }
+            ],
+            "generated_at_utc": "2026-05-14T07:00:00Z",
+        },
+    )
+    snap = aat.collect_snapshot(
+        repo_root=tmp_path,
+        generated_at_utc="2026-05-14T08:00:00Z",
+    )
+    mp_items = [
+        w
+        for w in snap["work_items"]
+        if w["source_kind"] == "merge_preflight"
+    ]
+    assert len(mp_items) == 1
+    assert mp_items[0]["current_stage"] == "needs_human"
+
+
+def test_health_only_upstreams_emit_no_workitems(tmp_path: Path) -> None:
+    """Hand-craft fixtures for the 6 health-only ADE upstreams +
+    the seed entry, then verify zero WorkItems are produced."""
+    _write_upstream(
+        tmp_path,
+        "logs/development_work_queue/latest.json",
+        {
+            "module_version": "wq.v4.2",
+            "rows": [
+                {
+                    "item_id": "wq_001",
+                    "title": "hand-crafted queue row",
+                    "current_state": "queued",
+                }
+            ],
+            "generated_at_utc": "2026-05-14T07:00:00Z",
+        },
+    )
+    _write_upstream(
+        tmp_path,
+        "logs/development_delegation/latest.json",
+        {
+            "module_version": "del.v3.1",
+            "rows": [],
+            "generated_at_utc": "2026-05-14T07:00:00Z",
+        },
+    )
+    _write_upstream(
+        tmp_path,
+        "logs/development_bugfix_loop/latest.json",
+        {
+            "module_version": "bug.v2.0",
+            "rows": [],
+            "generated_at_utc": "2026-05-14T07:00:00Z",
+        },
+    )
+    _write_upstream(
+        tmp_path,
+        "logs/development_release_gate/latest.json",
+        {
+            "module_version": "rg.v5.0",
+            "rows": [],
+            "generated_at_utc": "2026-05-14T07:00:00Z",
+        },
+    )
+    _write_upstream(
+        tmp_path,
+        "logs/development_operational_digest/latest.json",
+        {
+            "module_version": "od.v3.0",
+            "summary": "ok",
+            "generated_at_utc": "2026-05-14T07:00:00Z",
+        },
+    )
+    # step5_plan history is JSONL
+    history = tmp_path / "logs" / "step5_plan" / "history.jsonl"
+    history.parent.mkdir(parents=True, exist_ok=True)
+    history.write_text(
+        json.dumps({"cycle_id": "abc"}) + "\n", encoding="utf-8"
+    )
+    # seed file (read-only, no projection)
+    seed = tmp_path / "generated_seed.jsonl"
+    seed.write_text(
+        json.dumps({"generated_candidate_id": "syn_001"}) + "\n",
+        encoding="utf-8",
+    )
+
+    snap = aat.collect_snapshot(
+        repo_root=tmp_path,
+        generated_at_utc="2026-05-14T08:00:00Z",
+    )
+    # No upstream from the projectable subset is present, so no
+    # WorkItems are emitted.
+    assert snap["work_items"] == []
+    # Every health-only upstream is represented in artifact_health.
+    paths = {r["path"] for r in snap["artifact_health"]}
+    for rel in (
+        "logs/development_work_queue/latest.json",
+        "logs/development_delegation/latest.json",
+        "logs/development_bugfix_loop/latest.json",
+        "logs/development_release_gate/latest.json",
+        "logs/development_operational_digest/latest.json",
+        "logs/step5_plan/history.jsonl",
+        "generated_seed.jsonl",
+    ):
+        assert rel in paths
+
+
+def test_artifact_health_includes_seed_read_only_warning(
+    tmp_path: Path,
+) -> None:
+    snap = aat.collect_snapshot(
+        repo_root=tmp_path,
+        generated_at_utc="2026-05-14T08:00:00Z",
+    )
+    seed_row = next(
+        r
+        for r in snap["artifact_health"]
+        if r["path"] == "generated_seed.jsonl"
+    )
+    assert (
+        seed_row.get("read_only_warning")
+        == aat.SEED_READ_ONLY_WARNING
+    )
+
+
+# ---------------------------------------------------------------------------
+# Invariant block pins
+# ---------------------------------------------------------------------------
+
+
+def test_invariant_status_pins_step5_invariants(tmp_path: Path) -> None:
+    snap = aat.collect_snapshot(
+        repo_root=tmp_path,
+        generated_at_utc="2026-05-14T08:00:00Z",
+    )
+    by_key = {r["key"]: r for r in snap["invariant_status"]}
+    assert by_key["step5_implementation_allowed"]["value"] is False
+    assert by_key["step5_implementation_allowed"]["tone"] == "off"
+    assert by_key["step5_substage"]["value"] == "none"
+    assert by_key["live_merge_implemented"]["value"] is False
+    assert by_key["live_merge_implemented"]["tone"] == "off"
+    assert by_key["deploy_coupled"]["value"] is False
+    assert by_key["deploy_coupled"]["tone"] == "off"
+    assert by_key["n5b_live_execute"]["value"] is False
+    assert by_key["agent_service"]["value"] == "healthy"
+    assert by_key["agent_service"]["tone"] == "on"
+
+
+def test_invariant_status_a18c_enabled_sourced_from_artefact(
+    tmp_path: Path,
+) -> None:
+    """When the A18c artefact is present with ``enabled=true``, the
+    invariant pins ``a18c_enabled.value == True / tone == "on"``.
+    When the artefact is absent, ``tone == "unknown"``."""
+    # Case A: absent.
+    snap_absent = aat.collect_snapshot(
+        repo_root=tmp_path,
+        generated_at_utc="2026-05-14T08:00:00Z",
+    )
+    by_key_absent = {
+        r["key"]: r for r in snap_absent["invariant_status"]
+    }
+    assert by_key_absent["a18c_enabled"]["tone"] == "unknown"
+
+    # Case B: enabled=True in the artefact.
+    _write_upstream(
+        tmp_path,
+        "logs/development_generated_lane_a18c/latest.json",
+        {
+            "schema_version": 1,
+            "module_version": "a18c.v1.3",
+            "enabled": True,
+            "rows": [],
+            "generated_at_utc": "2026-05-14T07:00:00Z",
+        },
+    )
+    snap_on = aat.collect_snapshot(
+        repo_root=tmp_path,
+        generated_at_utc="2026-05-14T08:00:00Z",
+    )
+    by_key_on = {r["key"]: r for r in snap_on["invariant_status"]}
+    assert by_key_on["a18c_enabled"]["value"] is True
+    assert by_key_on["a18c_enabled"]["tone"] == "on"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def test_cli_no_write_does_not_mutate_logs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _redirect_to_tmp(monkeypatch, tmp_path)
+    rc = aat.main(["--no-write"])
+    assert rc == 0
+    # The redirected canonical path must not exist after --no-write.
+    canonical = (
+        tmp_path
+        / "logs"
+        / "development_agent_activity_timeline"
+        / "latest.json"
+    )
+    assert not canonical.is_file()
+    out = capsys.readouterr().out
+    # Output must be valid JSON.
+    parsed = json.loads(out)
+    assert parsed["module_version"] == "aat.v0.1"
+
+
+def test_cli_default_writes_to_canonical_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _redirect_to_tmp(monkeypatch, tmp_path)
+    rc = aat.main([])
+    assert rc == 0
+    canonical = (
+        tmp_path
+        / "logs"
+        / "development_agent_activity_timeline"
+        / "latest.json"
+    )
+    assert canonical.is_file()
+    snap = json.loads(canonical.read_text(encoding="utf-8"))
+    assert snap["report_kind"] == "agent_activity_timeline"

--- a/tests/unit/test_recurring_maintenance.py
+++ b/tests/unit/test_recurring_maintenance.py
@@ -193,10 +193,17 @@ def test_job_registry_contains_only_approved_types() -> None:
         # Never creates branches, never opens PRs, never merges,
         # never deploys, never calls gh.
         "refresh_step5_loop",
+        # v3.15.16.A15.B2.0b — read-only Agent Activity Center
+        # aggregator. Reads the 11-entry closed upstream catalog
+        # and writes logs/development_agent_activity_timeline/
+        # latest.json. Never calls the GitHub CLI, never merges,
+        # never deploys, never writes outside the canonical
+        # aggregator path.
+        "refresh_agent_activity_timeline",
     }
     assert set(rm.JOB_TYPES) == expected
     assert set(rm._JOB_REGISTRY.keys()) == expected
-    assert len(rm.JOB_TYPES) == 15
+    assert len(rm.JOB_TYPES) == 16
 
 
 def test_roadmap_priority_job_is_low_risk_no_gh_enabled_by_default() -> None:

--- a/tests/unit/test_recurring_maintenance_agent_activity_timeline.py
+++ b/tests/unit/test_recurring_maintenance_agent_activity_timeline.py
@@ -1,0 +1,395 @@
+"""Targeted pin-tests for the v3.15.16.A15.B2.0b recurring
+maintenance integration of the Agent Activity Center aggregator.
+
+These tests pin that the AAC aggregator
+(``reporting.development_agent_activity_timeline``) is registered
+in the recurring-maintenance scheduler as a LOW-risk,
+no-``gh``-needed, default-enabled job, and that its executor:
+
+* returns the documented ``{"summary": str, "evidence": dict}``
+  envelope;
+* writes
+  ``logs/development_agent_activity_timeline/latest.json``
+  atomically via the projector's own sentinel-restricted write
+  helper (``aat.v0.1`` / ``schema_version=1``);
+* is failure-non-fatal when every upstream artefact is absent
+  (the projector default-denies with closed-vocab warnings and
+  never raises);
+* preserves the closed Step 5 / Level 6 invariants in the
+  persisted envelope;
+* never calls ``gh``, ``git``, ``subprocess``, or the network;
+* never mutates the environment, never enables A18b's writer
+  gate, never enables N5b's live-execute gate;
+* never flips Step 5 / Level 6 markers in its own function source.
+
+These tests do **not** enable any runtime gate. They do not flip
+Step 5 / Level 6 invariants. They do not call ``gh``. They do not
+merge or deploy. They do not write to ``seed.jsonl`` /
+``delegation_seed.jsonl`` / ``generated_seed.jsonl``.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reporting import development_agent_activity_timeline as aat
+from reporting import recurring_maintenance as rm
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_latest(repo_logs: Path) -> dict[str, Any]:
+    """Read the AAC artefact from a tmp-rooted
+    ``logs/development_agent_activity_timeline/latest.json``."""
+    path = (
+        repo_logs / "development_agent_activity_timeline" / "latest.json"
+    )
+    assert path.is_file(), f"AAC artefact missing under tmp: {path}"
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _patch_aggregator_paths_to_tmp(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Path:
+    """Redirect the aggregator's write target into a hermetic tmp
+    directory so the executor cannot pollute the repo's real
+    ``logs/`` tree during test execution.
+
+    The aggregator's atomic-write sentinel restricts writes to
+    paths containing ``logs/development_agent_activity_timeline/``;
+    we keep that substring in the redirected path so the sentinel
+    passes. We also redirect ``REPO_ROOT`` so the aggregator reads
+    its 11 upstreams from a hermetic tree."""
+    tmp_logs = tmp_path / "logs"
+    tmp_aat_dir = tmp_logs / "development_agent_activity_timeline"
+    tmp_aat_dir.mkdir(parents=True, exist_ok=True)
+    tmp_aat_latest = tmp_aat_dir / "latest.json"
+    monkeypatch.setattr(aat, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(aat, "ARTIFACT_DIR", tmp_aat_dir)
+    monkeypatch.setattr(aat, "ARTIFACT_LATEST", tmp_aat_latest)
+    return tmp_logs
+
+
+# ---------------------------------------------------------------------------
+# Closed-registry pins
+# ---------------------------------------------------------------------------
+
+
+def test_agent_activity_timeline_job_constant_value() -> None:
+    """The exact CLI-facing job_type string is pinned. Operators
+    invoke it via ``--run-once refresh_agent_activity_timeline``;
+    if that string ever drifts, this test fails before the rename
+    can land."""
+    assert (
+        rm.JOB_REFRESH_AGENT_ACTIVITY_TIMELINE
+        == "refresh_agent_activity_timeline"
+    )
+
+
+def test_agent_activity_timeline_job_is_in_closed_registry() -> None:
+    assert rm.JOB_REFRESH_AGENT_ACTIVITY_TIMELINE in rm.JOB_TYPES
+    assert rm.JOB_REFRESH_AGENT_ACTIVITY_TIMELINE in rm._JOB_REGISTRY
+
+
+def test_agent_activity_timeline_job_is_low_risk_no_gh_enabled_by_default() -> None:
+    """The AAC aggregator is pure stdlib + read-only artefact reads.
+    The job must therefore be LOW risk, ``needs_gh=False``,
+    default-enabled."""
+    spec = rm._JOB_REGISTRY[rm.JOB_REFRESH_AGENT_ACTIVITY_TIMELINE]
+    assert spec["risk_class"] == rm.RISK_LOW
+    assert spec["needs_gh"] is False
+    assert spec["default_enabled"] is True
+
+
+def test_agent_activity_timeline_registry_interval_is_thirty_minutes() -> None:
+    """30-minute cadence mirrors the rest of the A22-adjacent /
+    A18-adjacent reporters."""
+    spec = rm._JOB_REGISTRY[rm.JOB_REFRESH_AGENT_ACTIVITY_TIMELINE]
+    assert spec["default_interval_seconds"] == 30 * 60
+
+
+def test_agent_activity_timeline_job_timeout_is_default() -> None:
+    """No bespoke timeout — the aggregator reads 11 small JSON
+    artefacts and writes one. The default 90-second budget is more
+    than enough."""
+    spec = rm._JOB_REGISTRY[rm.JOB_REFRESH_AGENT_ACTIVITY_TIMELINE]
+    assert spec["timeout_seconds"] == rm.DEFAULT_JOB_TIMEOUT_SECONDS
+
+
+def test_agent_activity_timeline_executor_is_the_documented_function() -> None:
+    """The registry's executor handle must point at the documented
+    in-process function. A drift here would silently re-route the
+    refresh."""
+    spec = rm._JOB_REGISTRY[rm.JOB_REFRESH_AGENT_ACTIVITY_TIMELINE]
+    assert spec["executor"] is rm._exec_refresh_agent_activity_timeline
+
+
+def test_registry_entry_for_agent_activity_timeline_carries_no_runtime_authority() -> None:
+    """Registry entry must not silently elevate the job to MEDIUM
+    risk, mark ``needs_gh`` true, or expose any execute-safe-style
+    flag — those are reserved for the Dependabot path."""
+    spec = rm._JOB_REGISTRY[rm.JOB_REFRESH_AGENT_ACTIVITY_TIMELINE]
+    assert set(spec.keys()) == {
+        "default_interval_seconds",
+        "default_enabled",
+        "executor",
+        "description",
+        "risk_class",
+        "needs_gh",
+        "timeout_seconds",
+    }
+    assert spec["risk_class"] == rm.RISK_LOW
+    assert spec["needs_gh"] is False
+
+
+# ---------------------------------------------------------------------------
+# Executor behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_executor_returns_documented_envelope_when_upstreams_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With every upstream artefact absent (tmp tree has no
+    ``logs/development_*`` files), the aggregator emits a valid
+    envelope with empty arrays and ``any_stale=True``. The
+    executor returns ``{"summary", "evidence"}`` and never raises."""
+    _patch_aggregator_paths_to_tmp(monkeypatch, tmp_path)
+    out = rm._exec_refresh_agent_activity_timeline()
+    assert isinstance(out, dict)
+    assert isinstance(out.get("summary"), str)
+    assert isinstance(out.get("evidence"), dict)
+    ev = out["evidence"]
+    assert ev["total_open"] == 0
+    assert ev["needs_human"] == 0
+    assert ev["any_stale"] is True
+    assert ev["any_malformed"] is False
+
+
+def test_executor_persists_snapshot_under_tmp(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The executor calls the aggregator's ``write_outputs`` which
+    is sentinel-restricted to
+    ``logs/development_agent_activity_timeline/``. Verify the
+    persisted snapshot carries the schema anchors verbatim."""
+    tmp_logs = _patch_aggregator_paths_to_tmp(monkeypatch, tmp_path)
+    rm._exec_refresh_agent_activity_timeline()
+    snap = _read_latest(tmp_logs)
+    assert snap["schema_version"] == 1
+    assert snap["module_version"] == "aat.v0.1"
+    assert snap["report_kind"] == "agent_activity_timeline"
+
+
+def test_executor_persisted_snapshot_pins_invariant_block(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The persisted envelope must carry the 9-row closed
+    ``invariant_status[]`` block with ``level_6`` ``danger_off``
+    and ``step5_implementation_allowed`` ``off``."""
+    tmp_logs = _patch_aggregator_paths_to_tmp(monkeypatch, tmp_path)
+    rm._exec_refresh_agent_activity_timeline()
+    snap = _read_latest(tmp_logs)
+    invariants = snap.get("invariant_status") or []
+    by_key = {row["key"]: row for row in invariants}
+    assert by_key["level_6"]["value"] == "permanently_disabled"
+    assert by_key["level_6"]["tone"] == "danger_off"
+    assert by_key["step5_implementation_allowed"]["value"] is False
+    assert by_key["step5_implementation_allowed"]["tone"] == "off"
+    assert by_key["step5_substage"]["value"] == "none"
+    assert by_key["live_merge_implemented"]["value"] is False
+    assert by_key["deploy_coupled"]["value"] is False
+    assert by_key["n5b_live_execute"]["value"] is False
+    assert by_key["agent_service"]["value"] == "healthy"
+    assert by_key["agent_service"]["tone"] == "on"
+
+
+def test_executor_failure_non_fatal_under_supervisor(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end through the recurring-maintenance supervisor:
+    with every upstream absent, the executor returns cleanly and
+    the supervisor classifies the run as ``STATUS_SUCCEEDED``."""
+    _patch_aggregator_paths_to_tmp(monkeypatch, tmp_path)
+    monkeypatch.setattr(rm, "DIGEST_DIR_JSON", tmp_path / "rm")
+    snap = rm.run_one_job(
+        rm.JOB_REFRESH_AGENT_ACTIVITY_TIMELINE, persist=True
+    )
+    job_row = next(
+        j
+        for j in snap["jobs"]
+        if j["job_type"] == rm.JOB_REFRESH_AGENT_ACTIVITY_TIMELINE
+    )
+    assert job_row["last_status"] == rm.STATUS_SUCCEEDED
+    assert job_row["consecutive_failures"] == 0
+
+
+# ---------------------------------------------------------------------------
+# AST / source-text scans
+# ---------------------------------------------------------------------------
+
+
+def test_executor_source_contains_no_forbidden_tokens() -> None:
+    """The supervisor isolates the executor in a daemon thread but
+    still runs it in the same Python process. The executor's own
+    source must therefore not import or invoke subprocess / socket
+    / gh / git. Scoped to ``_exec_refresh_agent_activity_timeline``
+    only — the aggregator module is independently pinned below."""
+    src = inspect.getsource(rm._exec_refresh_agent_activity_timeline)
+    lowered = src.lower()
+    forbidden = (
+        "subprocess",
+        "socket",
+        "urllib",
+        "requests",
+        "httpx",
+        "aiohttp",
+        "popen",
+        "shell=true",
+        " gh ",
+        " git ",
+        "os.system",
+    )
+    for needle in forbidden:
+        assert needle not in lowered, (
+            f"_exec_refresh_agent_activity_timeline source contains "
+            f"forbidden token {needle!r}"
+        )
+
+
+def test_aggregator_module_does_not_import_subprocess_or_network() -> None:
+    """Defense-in-depth re-pin from the maintenance side: the
+    AAC aggregator module that backs the executor must not import
+    subprocess, socket, urllib, requests, httpx, aiohttp."""
+    src = Path(aat.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    forbidden_top = {
+        "subprocess",
+        "socket",
+        "urllib",
+        "requests",
+        "httpx",
+        "aiohttp",
+    }
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in forbidden_top, (
+                    f"aggregator imports forbidden module: "
+                    f"{alias.name!r}"
+                )
+        if isinstance(node, ast.ImportFrom) and node.module is not None:
+            top = node.module.split(".", 1)[0]
+            assert top not in forbidden_top, (
+                f"aggregator imports forbidden module: "
+                f"from {node.module!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Negative pins
+# ---------------------------------------------------------------------------
+
+
+def test_executor_source_does_not_mutate_environment() -> None:
+    """The executor must not mutate or export environment
+    variables."""
+    src = inspect.getsource(rm._exec_refresh_agent_activity_timeline)
+    forbidden_substrings = (
+        "os.environ[",
+        "os.environ.setdefault",
+        "os.putenv",
+        "putenv(",
+        "os.getenv",
+        "export ADE_",
+    )
+    for needle in forbidden_substrings:
+        assert needle not in src, (
+            f"_exec_refresh_agent_activity_timeline source contains "
+            f"forbidden env-mutation token {needle!r}"
+        )
+    # AST-level pin: assert the executor body assigns nothing to
+    # any ``os.environ[...]`` Subscript and never calls
+    # ``os.environ.setdefault(...)`` / ``os.putenv(...)``.
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Subscript):
+                    value = target.value
+                    if (
+                        isinstance(value, ast.Attribute)
+                        and value.attr == "environ"
+                    ):
+                        raise AssertionError(
+                            "_exec_refresh_agent_activity_timeline body "
+                            "assigns to os.environ[...]"
+                        )
+        if isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Attribute):
+                if func.attr in {"setdefault", "putenv"}:
+                    parent = func.value
+                    if (
+                        isinstance(parent, ast.Attribute)
+                        and parent.attr == "environ"
+                    ):
+                        raise AssertionError(
+                            "_exec_refresh_agent_activity_timeline body "
+                            "calls os.environ.setdefault(...)"
+                        )
+                    if (
+                        isinstance(parent, ast.Name)
+                        and parent.id == "os"
+                        and func.attr == "putenv"
+                    ):
+                        raise AssertionError(
+                            "_exec_refresh_agent_activity_timeline body "
+                            "calls os.putenv(...)"
+                        )
+
+
+def test_executor_source_does_not_enable_a18b_or_n5b_live_execute() -> None:
+    """The executor must not export, set, or read the A18b writer
+    enablement env or the N5b live-execute enablement env."""
+    src = inspect.getsource(rm._exec_refresh_agent_activity_timeline)
+    forbidden = (
+        "ADE_GENERATED_LANE_WRITER_ENABLED",
+        "ADE_N5B_LIVE_EXECUTE_ENABLED",
+    )
+    for needle in forbidden:
+        assert needle not in src, (
+            f"_exec_refresh_agent_activity_timeline source contains "
+            f"forbidden runtime-gate flag {needle!r}"
+        )
+
+
+def test_executor_source_does_not_flip_step5_or_level6() -> None:
+    """The executor must not assign to / mutate any Step 5 or
+    Level 6 marker."""
+    src = inspect.getsource(rm._exec_refresh_agent_activity_timeline)
+    forbidden = (
+        "step5_implementation_allowed = True",
+        "step5_implementation_allowed=True",
+        'STEP5_ENABLED_SUBSTAGE = "5',
+        "STEP5_ENABLED_SUBSTAGE='5",
+        "level6_enabled = True",
+        "level6_enabled=True",
+    )
+    for needle in forbidden:
+        assert needle not in src, (
+            f"_exec_refresh_agent_activity_timeline source contains "
+            f"forbidden Step 5 / Level 6 flip: {needle!r}"
+        )


### PR DESCRIPTION
## Summary

Revised Batch 2, **unit B2.0b — Agent Activity Center aggregator + recurring-maintenance entry**. Ships the read-only aggregator that the Visual ADE Control Plane (B2.0 design, §A15) requires. The aggregator reads the closed **11-entry upstream catalog** (10 ADE-core artefact paths + 1 read-only seed health entry) and writes a single canonical artefact at \`logs/development_agent_activity_timeline/latest.json\` satisfying the closed schema in [\`docs/governance/agent_activity_center_aggregator_schema.md\`](docs/governance/agent_activity_center_aggregator_schema.md).

## Operator-pinned defaults (mirrored in test pins)

| Default | Pinned value |
|---|---|
| HumanAction.required_phrase — A18 promotion-report rows | sourced verbatim from \`required_operator_go_phrase\` / envelope \`operator_go_phrase_required\` |
| HumanAction.required_phrase — A18c rows | always \`None\` (no synthesis) |
| Step 5 plan history mining | health-only in v0.1; no \`agent_events\` mining |
| TTL defaults (seconds) | queue=600 · loops=1800 · step5=1800 · gates=1800 · generated=1800 · digest=1800 · seed=86400 |
| InvariantStatus.agent_service | static placeholder \`value=\"healthy\"\`, \`tone=\"on\"\` |
| InvariantStatus.a18c_enabled | sourced from A18c artefact's \`enabled\` field; \`tone=\"unknown\"\` when artefact absent |

## v0.1 projection posture

- **Projectable (4)**: \`step5_loop\`, \`generated_lane_a18c\`, \`generated_lane_promotion\`, \`merge_preflight\` — contribute WorkItem rows.
- **Health-only (7)**: \`work_queue\`, \`delegation\`, \`bugfix_loop\`, \`release_gate\`, \`step5_plan history\`, \`operational_digest\`, \`generated_seed.jsonl\` (read-only) — contribute \`artifact_health\` rows only.
- Catalog cardinality pins: \`UPSTREAM_CATALOG_LEN=11\`, \`PROJECTABLE_UPSTREAM_LEN=4\`, \`HEALTH_ONLY_UPSTREAM_LEN=7\`. Partition is exhaustive and mutually exclusive (test-pinned).
- \`generated_seed.jsonl\` carries a \`read_only_warning\` chip in its artifact_health row. The aggregator mentions it only as a *read path* — context-aware AST scan confirms zero write contexts target it.

## File map (5 files, additive)

| # | Path | What it adds |
|---|---|---|
| 1 | [\`reporting/development_agent_activity_timeline.py\`](reporting/development_agent_activity_timeline.py) | NEW — aggregator module. Module version \`aat.v0.1\`. Stdlib + \`reporting.agent_audit_summary.assert_no_secrets\` only. Sentinel-restricted write to \`logs/development_agent_activity_timeline/\`. |
| 2 | [\`tests/unit/test_development_agent_activity_timeline.py\`](tests/unit/test_development_agent_activity_timeline.py) | NEW — 41 module pin tests. |
| 3 | [\`reporting/recurring_maintenance.py\`](reporting/recurring_maintenance.py) | additive: \`JOB_REFRESH_AGENT_ACTIVITY_TIMELINE\` constant, \`_exec_refresh_agent_activity_timeline\` executor, registry entry, tuple member. |
| 4 | [\`tests/unit/test_recurring_maintenance.py\`](tests/unit/test_recurring_maintenance.py) | additive: closed-set expected entry + cardinality bump (15 → 16). |
| 5 | [\`tests/unit/test_recurring_maintenance_agent_activity_timeline.py\`](tests/unit/test_recurring_maintenance_agent_activity_timeline.py) | NEW — 16 maintenance pin tests, mirrors B1.1/B1.2/B1.4 structure. |

## Job-field pins

| Field | Value |
|---|---|
| \`job_type\` | \`refresh_agent_activity_timeline\` |
| \`default_enabled\` | \`True\` |
| \`risk_class\` | \`LOW\` |
| \`needs_gh\` | \`False\` |
| \`default_interval_seconds\` | \`1800\` (30 min) |
| \`timeout_seconds\` | \`90\` |

## Validation evidence

- \`python -m pytest tests/unit/test_development_agent_activity_timeline.py -q\` → **41 passed**
- \`python -m pytest tests/unit/test_recurring_maintenance.py tests/unit/test_recurring_maintenance_agent_activity_timeline.py -q\` → **56 passed**
- \`python -m pytest tests/unit/test_recurring_maintenance_a18c.py tests/unit/test_recurring_maintenance_a18_promotion_report.py tests/unit/test_recurring_maintenance_step5_loop.py tests/unit/test_recurring_maintenance_merge_preflight.py -q\` → **66 passed**
- \`python -m pytest tests/unit/test_agent_activity_center_governance_docs.py -q\` → **25 passed**
- \`python -m pytest tests/smoke -q\` → **18 passed**
- \`python scripts/governance_lint.py\` → \`Governance lint OK (16 agents, 5 workflows checked)\`
- \`python -m reporting.recurring_maintenance --list-jobs\` shows \`refresh_agent_activity_timeline\` with \`risk_class=LOW\`, \`needs_gh=false\`, \`interval_seconds=1800\`, \`last_status=not_run\`.
- \`python -m reporting.development_agent_activity_timeline --no-write\` emits a valid envelope JSON from the live \`logs/\` tree on this checkout.

## Mid-implementation correction applied

One self-trip fixed: the aggregator's own module docstring contained the literal \`shell=True\` token (in a sentence describing what the module does NOT do), which tripped the source-text scan. Rephrased to \"shell-mode subprocess flag\" — same lesson as B1.4's docstring fix. No other corrections.

## Not in scope (explicitly excluded)

- No dashboard route or Flask blueprint (B2.0c remains separately gated).
- No PWA frontend, service worker, or manifest (B2.0d remains separately gated).
- No push-notification publisher (B2.0e remains separately gated).
- No mutation endpoint anywhere.
- No env flip.
- No \`step5_implementation_allowed\` / \`STEP5_ENABLED_SUBSTAGE\` flip.
- No queue admission, no PR creation, no merge, no deploy.
- No writes to \`seed.jsonl\` / \`delegation_seed.jsonl\` / \`generated_seed.jsonl\` (the aggregator mentions \`generated_seed.jsonl\` only as a read path; context-aware AST scan confirms zero write contexts).
- No \`tests/regression/\` edits.
- No \`.claude/**\`, \`.github/**\`, no-touch path, frozen v1 schema, ADR, governance doc, roadmap, or live/paper/shadow/risk/broker/execution edits.

## Rollback

Single \`git revert\`. The aggregator is purely additive; removing the module and the maintenance entry restores the prior 15-job registry.

## Test plan

- [x] All unit tests pass locally (41 + 16 new + 25 + 18 + 66 sibling = 166 directly, broader maintenance suite 56).
- [x] Smoke green (18/18).
- [x] Governance lint green.
- [x] Manual \`--list-jobs\` and aggregator \`--no-write\` sanity checks pass.
- [ ] CI green.
- [ ] Diff allowlist + mergeability confirmed.
- [ ] Squash-merge to main.
- [ ] Post-merge gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)