### PR TITLE
feat(b2-0c)(dashboard): Agent Activity Center read-only Flask blueprint (6 GET endpoints, UNWIRED)

### DIFF
--- a/dashboard/api_agent_control_activity.py
+++ b/dashboard/api_agent_control_activity.py
@@ -1,0 +1,915 @@
+"""Agent Activity Center — read-only Flask blueprint (B2.0c, UNWIRED).
+
+GET-only Flask blueprint that exposes the existing
+``reporting.development_agent_activity_timeline`` aggregator
+artefact at
+``logs/development_agent_activity_timeline/latest.json`` through
+six closed-shape endpoints under ``/api/agent-control/activity/*``.
+
+This blueprint surfaces what the AAC aggregator already wrote.
+It does **not** perform any mutation. It does **not** open, merge,
+or deploy anything. It does **not** mint or verify approval
+tokens. It does **not** invoke the GitHub CLI, the version-control
+CLI, child processes, or any network library. It is auth-agnostic
+and shipped UNWIRED; the two-line wiring diff in
+``dashboard/dashboard.py`` is the operator's separate act per
+``docs/governance/execution_authority.md`` (``dashboard_wiring`` =
+NEEDS_HUMAN) and the no-touch hook on ``dashboard/dashboard.py``.
+
+Hard guarantees (pinned by tests)
+---------------------------------
+
+* GET only — no POST / PUT / PATCH / DELETE handler is registered.
+* Exactly six routes, all under ``/api/agent-control/activity/*``::
+
+      GET /api/agent-control/activity/today
+      GET /api/agent-control/activity/items
+      GET /api/agent-control/activity/items/<string:item_id>
+      GET /api/agent-control/activity/agents
+      GET /api/agent-control/activity/artifacts
+      GET /api/agent-control/activity/invariants
+
+* Reads only the AAC aggregator artefact via
+  ``reporting.development_agent_activity_timeline.ARTIFACT_LATEST``.
+  Never mutates the upstream artefact. Never mutates any PR.
+  Never reads ``os.environ``.
+* Never imports a Web Push library, never imports an approval-token
+  runtime, never imports a network library, never imports a CLI
+  subprocess library.
+* Every response payload is run through
+  ``reporting.agent_audit_summary.assert_no_secrets`` before send.
+* HTTP cache headers per
+  ``docs/governance/agent_activity_center_api_contract.md`` §4::
+
+      Cache-Control: private, max-age=10
+      ETag: "<sha256-hex-prefix of generated_at_utc>"
+
+  On a matching ``If-None-Match`` request, the endpoint returns
+  ``304 Not Modified`` with empty body and the same ``ETag``.
+* Closed error-code vocabulary per the API contract §8::
+
+      invalid_enum         — query param outside closed vocab
+      invalid_format       — query param violates regex
+      not_in_last_snapshot — items/<id> path param not present
+      aggregator_failed    — 500 case
+      aggregator_missing   — 503 case
+
+* The blueprint is intentionally **NOT** wired into
+  ``dashboard/dashboard.py`` in the PR that introduces it.
+* No decision-verb call appears in any code path. The companion
+  unit-test source-text scan rejects approve/reject/merge/deploy/
+  token-mint/token-verify call patterns at the syntactic level.
+* Every envelope carries the closed Step 5 + Level 6 invariants
+  verbatim::
+
+      step5_implementation_allowed = False
+      step5_enabled_substage       = "none"
+      level6_enabled               = False
+
+Routes contract
+---------------
+
+See ``docs/governance/agent_activity_center_api_contract.md`` for
+the full per-endpoint response shape.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from pathlib import Path
+from typing import Any, Final
+
+from flask import Flask, Response, jsonify, make_response, request
+
+from reporting import development_agent_activity_timeline as aat
+from reporting.agent_audit_summary import assert_no_secrets
+
+
+# ---------------------------------------------------------------------------
+# Module anchors
+# ---------------------------------------------------------------------------
+
+MODULE_VERSION: Final[str] = "v3.15.16.A15.B2.0c.api"
+SCHEMA_VERSION: Final[int] = 1
+
+ARTIFACT_RELATIVE_PATH: Final[str] = (
+    "logs/development_agent_activity_timeline/latest.json"
+)
+
+
+# ---------------------------------------------------------------------------
+# Step 5 + Level 6 invariants (Final constants — never flipped)
+# ---------------------------------------------------------------------------
+
+STEP5_ENABLED_SUBSTAGE: Final[str] = "none"
+step5_implementation_allowed: Final[bool] = False
+
+
+# ---------------------------------------------------------------------------
+# Bounded item_id surface
+# ---------------------------------------------------------------------------
+
+#: Maximum item_id length accepted on the detail route. The
+#: aggregator's id format is ``wi_<source>_<short>`` (≤ 64 chars in
+#: practice); the cap exists as defense-in-depth.
+_MAX_ITEM_ID_LEN: Final[int] = 128
+
+#: Closed item_id charset. ASCII letters, digits, underscore,
+#: hyphen, dot.
+_ITEM_ID_PATTERN: Final[re.Pattern[str]] = re.compile(
+    r"^[A-Za-z0-9_.\-]+$"
+)
+
+
+# ---------------------------------------------------------------------------
+# Closed error-code vocabulary
+# ---------------------------------------------------------------------------
+
+_ERR_INVALID_ENUM: Final[str] = "invalid_enum"
+_ERR_INVALID_FORMAT: Final[str] = "invalid_format"
+_ERR_NOT_IN_LAST_SNAPSHOT: Final[str] = "not_in_last_snapshot"
+_ERR_AGGREGATOR_FAILED: Final[str] = "aggregator_failed"
+_ERR_AGGREGATOR_MISSING: Final[str] = "aggregator_missing"
+
+
+# ---------------------------------------------------------------------------
+# HTTP cache semantics
+# ---------------------------------------------------------------------------
+
+_CACHE_CONTROL: Final[str] = "private, max-age=10"
+
+
+# ---------------------------------------------------------------------------
+# Bounded sizes
+# ---------------------------------------------------------------------------
+
+#: Today headline-section cap per the API contract §3.1.
+_TODAY_SECTION_CAP: Final[int] = 16
+
+#: Items list cap (matches aggregator MAX_WORK_ITEMS).
+_ITEMS_LIST_CAP: Final[int] = 256
+
+#: Recent-events cap on the Today endpoint.
+_RECENT_EVENTS_CAP: Final[int] = 16
+
+
+# ---------------------------------------------------------------------------
+# Discipline invariants every envelope carries
+# ---------------------------------------------------------------------------
+
+_DISCIPLINE_FIELDS: Final[dict[str, bool | str]] = {
+    "step5_implementation_allowed": False,
+    "step5_enabled_substage": STEP5_ENABLED_SUBSTAGE,
+    "level6_enabled": False,
+}
+
+
+def _with_discipline(envelope: dict[str, Any]) -> dict[str, Any]:
+    """Attach the closed discipline-invariant fields to ``envelope``.
+    Callers never overwrite these values."""
+    out = dict(envelope)
+    out.update(_DISCIPLINE_FIELDS)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Aggregator artefact reader (read-only, never raises)
+# ---------------------------------------------------------------------------
+
+
+def _read_artifact() -> tuple[str, dict[str, Any]]:
+    """Return ``(status, payload)`` for the AAC aggregator artefact.
+
+    Status ∈ ``{"ok", "not_available"}``. The not_available path
+    carries a ``reason`` string suitable for the error envelope.
+    """
+    path: Path = aat.ARTIFACT_LATEST
+    if not path.is_file():
+        return "not_available", {"reason": "missing"}
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return "not_available", {
+            "reason": f"unreadable: {type(exc).__name__}"
+        }
+    try:
+        import json as _json
+
+        data = _json.loads(text)
+    except (TypeError, ValueError) as exc:
+        return "not_available", {
+            "reason": f"malformed: {type(exc).__name__}"
+        }
+    if not isinstance(data, dict):
+        return "not_available", {"reason": "malformed: not_an_object"}
+    return "ok", data
+
+
+# ---------------------------------------------------------------------------
+# Response builders — ETag + Cache-Control + 304 semantics
+# ---------------------------------------------------------------------------
+
+
+def _etag_for(generated_at_utc: str) -> str:
+    """Build a quoted ETag from the upstream ``generated_at_utc``.
+    Stable across runs: the sha256 prefix is deterministic."""
+    digest = hashlib.sha256(
+        (generated_at_utc or "").encode("utf-8")
+    ).hexdigest()[:16]
+    return f'"{digest}"'
+
+
+def _respond_json(
+    envelope: dict[str, Any], http_status: int = 200
+) -> Response:
+    """Run ``assert_no_secrets`` on the envelope then wrap in a
+    ``Response`` with ``Cache-Control`` and ``ETag``. Honours an
+    incoming ``If-None-Match`` header by returning a bare
+    ``304 Not Modified`` with the same ETag.
+    """
+    assert_no_secrets(envelope)
+    generated_at = str(envelope.get("generated_at_utc") or "")
+    etag = _etag_for(generated_at)
+
+    # Conditional request handling — 304 only on successful (200)
+    # responses where the client's ETag matches.
+    if http_status == 200:
+        inm = request.headers.get("If-None-Match")
+        if inm and inm == etag:
+            resp = make_response("", 304)
+            resp.headers["ETag"] = etag
+            resp.headers["Cache-Control"] = _CACHE_CONTROL
+            return resp
+
+    resp = make_response(jsonify(envelope), http_status)
+    resp.headers["ETag"] = etag
+    resp.headers["Cache-Control"] = _CACHE_CONTROL
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Error envelope helper
+# ---------------------------------------------------------------------------
+
+
+def _error_envelope(
+    kind: str,
+    code: str,
+    *,
+    param: str | None = None,
+    value: str | None = None,
+    detail: str | None = None,
+) -> dict[str, Any]:
+    """Build a closed-vocab error envelope per API contract §8."""
+    env: dict[str, Any] = {
+        "kind": kind,
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "status": code,
+        "error": code,
+    }
+    if param is not None:
+        env["param"] = param
+    if value is not None:
+        env["value"] = value
+    if detail is not None:
+        env["detail"] = detail
+    env["artifact_path"] = ARTIFACT_RELATIVE_PATH
+    return _with_discipline(env)
+
+
+# ---------------------------------------------------------------------------
+# Query-param validation helpers
+# ---------------------------------------------------------------------------
+
+
+def _validate_enum_param(
+    param: str, value: str, vocab: tuple[str, ...]
+) -> tuple[bool, str | None]:
+    """Return ``(ok, error_reason)``. ``ok=True`` means the value
+    is in the closed vocab."""
+    if value in vocab:
+        return True, None
+    return False, "not_in_closed_vocab"
+
+
+_ISO_UTC_PATTERN: Final[re.Pattern[str]] = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$"
+)
+
+
+def _validate_iso_utc(value: str) -> bool:
+    return bool(_ISO_UTC_PATTERN.match(value))
+
+
+# ---------------------------------------------------------------------------
+# Filtering and projection helpers
+# ---------------------------------------------------------------------------
+
+
+def _safe_list(data: dict[str, Any], key: str) -> list[dict[str, Any]]:
+    """Return ``data[key]`` if it is a list of dicts; else []."""
+    raw = data.get(key)
+    if not isinstance(raw, list):
+        return []
+    return [r for r in raw if isinstance(r, dict)]
+
+
+def _filter_items(
+    rows: list[dict[str, Any]],
+    *,
+    stage: str | None,
+    owner_role: str | None,
+    human_needed: bool | None,
+    updated_since: str | None,
+) -> list[dict[str, Any]]:
+    """Apply all four closed-vocab filters."""
+    out: list[dict[str, Any]] = []
+    for r in rows:
+        if stage is not None and r.get("current_stage") != stage:
+            continue
+        if owner_role is not None and r.get("owner_role") != owner_role:
+            continue
+        if human_needed is not None:
+            if bool(r.get("human_needed")) != human_needed:
+                continue
+        if updated_since is not None:
+            ru = str(r.get("updated_at") or "")
+            if ru < updated_since:
+                continue
+        out.append(r)
+    return out
+
+
+def _derive_agent_matrix(
+    work_items: list[dict[str, Any]],
+    agent_events: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Compute the per-role activity matrix per design doc §5.5."""
+    by_role: dict[str, dict[str, Any]] = {}
+    for role in aat.AGENT_ROLES:
+        by_role[role] = {
+            "role": role,
+            "new": 0,
+            "planned": 0,
+            "blocked": 0,
+            "needs_human": 0,
+            "pr_ready": 0,
+            "last_action": None,
+            "total": 0,
+        }
+    for w in work_items:
+        role = w.get("owner_role")
+        if not isinstance(role, str) or role not in by_role:
+            continue
+        row = by_role[role]
+        row["total"] += 1
+        stage = w.get("current_stage")
+        if stage in ("discovered", "queued"):
+            row["new"] += 1
+        if stage == "planned":
+            row["planned"] += 1
+        if stage == "done_blocked":
+            row["blocked"] += 1
+        if w.get("human_needed"):
+            row["needs_human"] += 1
+        if stage in ("dry_run_ready", "pr_proposed", "merge_candidate"):
+            row["pr_ready"] += 1
+    # Last action per role from agent_events[]; events arrive sorted
+    # ascending by (timestamp, event_id) — the last one matches.
+    for ev in agent_events:
+        role = ev.get("agent_role")
+        if not isinstance(role, str) or role not in by_role:
+            continue
+        by_role[role]["last_action"] = ev
+    return [by_role[role] for role in aat.AGENT_ROLES]
+
+
+def _today_section(
+    rows: list[dict[str, Any]],
+    predicate,
+    cap: int = _TODAY_SECTION_CAP,
+) -> tuple[list[dict[str, Any]], int, bool]:
+    """Apply ``predicate`` and cap. Returns ``(slice, total, truncated)``."""
+    matching = [r for r in rows if predicate(r)]
+    total = len(matching)
+    truncated = total > cap
+    return matching[:cap], total, truncated
+
+
+# ---------------------------------------------------------------------------
+# View functions
+# ---------------------------------------------------------------------------
+
+
+def _view_today() -> Response:
+    status, data = _read_artifact()
+    if status != "ok":
+        env = _with_discipline(
+            {
+                "kind": "agent_control_activity_today",
+                "schema_version": SCHEMA_VERSION,
+                "module_version": MODULE_VERSION,
+                "status": "not_available",
+                "reason": data.get("reason", "missing"),
+                "counts": {},
+                "needs_human": [],
+                "merge_candidate": [],
+                "ci_feedback": [],
+                "blocked": [],
+                "recent_events": [],
+                "freshness": {},
+                "invariant_status": [],
+                "generated_at_utc": "",
+                "artifact_path": ARTIFACT_RELATIVE_PATH,
+            }
+        )
+        return _respond_json(env, 200)
+
+    work_items = _safe_list(data, "work_items")
+    agent_events = _safe_list(data, "agent_events")
+    invariants = _safe_list(data, "invariant_status")
+    freshness = data.get("freshness") if isinstance(
+        data.get("freshness"), dict
+    ) else {}
+    counts = data.get("counts") if isinstance(
+        data.get("counts"), dict
+    ) else {}
+
+    needs_human, nh_total, nh_trunc = _today_section(
+        work_items, lambda r: bool(r.get("human_needed"))
+    )
+    merge_cand, mc_total, mc_trunc = _today_section(
+        work_items, lambda r: r.get("current_stage") == "merge_candidate"
+    )
+    ci_fb, ci_total, ci_trunc = _today_section(
+        work_items, lambda r: r.get("current_stage") == "ci_feedback"
+    )
+    blocked, bl_total, bl_trunc = _today_section(
+        work_items, lambda r: r.get("current_stage") == "done_blocked"
+    )
+    recent_events = agent_events[-_RECENT_EVENTS_CAP:][::-1]
+
+    env = _with_discipline(
+        {
+            "kind": "agent_control_activity_today",
+            "schema_version": SCHEMA_VERSION,
+            "module_version": MODULE_VERSION,
+            "status": "ok",
+            "counts": counts,
+            "needs_human": needs_human,
+            "merge_candidate": merge_cand,
+            "ci_feedback": ci_fb,
+            "blocked": blocked,
+            "recent_events": recent_events,
+            "freshness": freshness,
+            "invariant_status": invariants,
+            "section_totals": {
+                "needs_human": {
+                    "total_matching": nh_total,
+                    "truncated": nh_trunc,
+                },
+                "merge_candidate": {
+                    "total_matching": mc_total,
+                    "truncated": mc_trunc,
+                },
+                "ci_feedback": {
+                    "total_matching": ci_total,
+                    "truncated": ci_trunc,
+                },
+                "blocked": {
+                    "total_matching": bl_total,
+                    "truncated": bl_trunc,
+                },
+            },
+            "generated_at_utc": str(data.get("generated_at_utc") or ""),
+            "artifact_path": ARTIFACT_RELATIVE_PATH,
+        }
+    )
+    return _respond_json(env, 200)
+
+
+def _view_items_list() -> Response | tuple[Response, int]:
+    # Parse query params (all optional).
+    stage = request.args.get("stage")
+    owner_role = request.args.get("owner_role")
+    human_needed_raw = request.args.get("human_needed")
+    updated_since = request.args.get("updated_since")
+
+    if stage is not None:
+        ok, _r = _validate_enum_param("stage", stage, aat.STAGES)
+        if not ok:
+            return (
+                _respond_json(
+                    _error_envelope(
+                        "agent_control_activity_items_list",
+                        _ERR_INVALID_ENUM,
+                        param="stage",
+                        value=stage,
+                    ),
+                    400,
+                ),
+                400,
+            )
+    if owner_role is not None:
+        ok, _r = _validate_enum_param(
+            "owner_role", owner_role, aat.AGENT_ROLES
+        )
+        if not ok:
+            return (
+                _respond_json(
+                    _error_envelope(
+                        "agent_control_activity_items_list",
+                        _ERR_INVALID_ENUM,
+                        param="owner_role",
+                        value=owner_role,
+                    ),
+                    400,
+                ),
+                400,
+            )
+    human_needed: bool | None = None
+    if human_needed_raw is not None:
+        if human_needed_raw == "true":
+            human_needed = True
+        elif human_needed_raw == "false":
+            human_needed = False
+        else:
+            return (
+                _respond_json(
+                    _error_envelope(
+                        "agent_control_activity_items_list",
+                        _ERR_INVALID_ENUM,
+                        param="human_needed",
+                        value=human_needed_raw,
+                    ),
+                    400,
+                ),
+                400,
+            )
+    if updated_since is not None and not _validate_iso_utc(updated_since):
+        return (
+            _respond_json(
+                _error_envelope(
+                    "agent_control_activity_items_list",
+                    _ERR_INVALID_FORMAT,
+                    param="updated_since",
+                    value=updated_since,
+                ),
+                400,
+            ),
+            400,
+        )
+
+    status, data = _read_artifact()
+    if status != "ok":
+        env = _with_discipline(
+            {
+                "kind": "agent_control_activity_items_list",
+                "schema_version": SCHEMA_VERSION,
+                "module_version": MODULE_VERSION,
+                "status": "not_available",
+                "reason": data.get("reason", "missing"),
+                "work_items": [],
+                "freshness": {},
+                "generated_at_utc": "",
+                "artifact_path": ARTIFACT_RELATIVE_PATH,
+            }
+        )
+        return _respond_json(env, 200)
+
+    work_items = _safe_list(data, "work_items")
+    filtered = _filter_items(
+        work_items,
+        stage=stage,
+        owner_role=owner_role,
+        human_needed=human_needed,
+        updated_since=updated_since,
+    )
+    total = len(filtered)
+    truncated = total > _ITEMS_LIST_CAP
+    capped = filtered[:_ITEMS_LIST_CAP]
+    freshness = data.get("freshness") if isinstance(
+        data.get("freshness"), dict
+    ) else {}
+
+    env = _with_discipline(
+        {
+            "kind": "agent_control_activity_items_list",
+            "schema_version": SCHEMA_VERSION,
+            "module_version": MODULE_VERSION,
+            "status": "ok",
+            "work_items": capped,
+            "total_matching": total,
+            "truncated": truncated,
+            "freshness": freshness,
+            "generated_at_utc": str(data.get("generated_at_utc") or ""),
+            "artifact_path": ARTIFACT_RELATIVE_PATH,
+        }
+    )
+    return _respond_json(env, 200)
+
+
+def _view_items_detail(
+    item_id: str,
+) -> Response | tuple[Response, int]:
+    if not isinstance(item_id, str) or not item_id:
+        return (
+            _respond_json(
+                _error_envelope(
+                    "agent_control_activity_items_detail",
+                    _ERR_INVALID_FORMAT,
+                    param="item_id",
+                    detail="empty",
+                ),
+                400,
+            ),
+            400,
+        )
+    if len(item_id) > _MAX_ITEM_ID_LEN:
+        return (
+            _respond_json(
+                _error_envelope(
+                    "agent_control_activity_items_detail",
+                    _ERR_INVALID_FORMAT,
+                    param="item_id",
+                    detail="too_long",
+                ),
+                400,
+            ),
+            400,
+        )
+    if not _ITEM_ID_PATTERN.match(item_id):
+        return (
+            _respond_json(
+                _error_envelope(
+                    "agent_control_activity_items_detail",
+                    _ERR_INVALID_FORMAT,
+                    param="item_id",
+                    detail="bad_charset",
+                ),
+                400,
+            ),
+            400,
+        )
+
+    status, data = _read_artifact()
+    if status != "ok":
+        return (
+            _respond_json(
+                _error_envelope(
+                    "agent_control_activity_items_detail",
+                    _ERR_AGGREGATOR_MISSING,
+                    detail=data.get("reason", "missing"),
+                ),
+                503,
+            ),
+            503,
+        )
+
+    work_items = _safe_list(data, "work_items")
+    target: dict[str, Any] | None = None
+    for w in work_items:
+        if w.get("item_id") == item_id:
+            target = w
+            break
+
+    if target is None:
+        return (
+            _respond_json(
+                _error_envelope(
+                    "agent_control_activity_items_detail",
+                    _ERR_NOT_IN_LAST_SNAPSHOT,
+                    param="item_id",
+                    value=item_id,
+                ),
+                404,
+            ),
+            404,
+        )
+
+    related_event_ids = set(target.get("event_ids") or [])
+    agent_events = [
+        e
+        for e in _safe_list(data, "agent_events")
+        if e.get("item_id") == item_id
+        or (
+            isinstance(e.get("event_id"), str)
+            and e["event_id"] in related_event_ids
+        )
+    ]
+    human_actions = [
+        a
+        for a in _safe_list(data, "human_actions")
+        if a.get("item_id") == item_id
+    ]
+    artefacts_referenced: list[str] = []
+    seen_paths: set[str] = set()
+    src = target.get("source_path")
+    if isinstance(src, str) and src not in seen_paths:
+        artefacts_referenced.append(src)
+        seen_paths.add(src)
+    for e in agent_events:
+        ap = e.get("artifact_path")
+        if isinstance(ap, str) and ap not in seen_paths:
+            artefacts_referenced.append(ap)
+            seen_paths.add(ap)
+    for a in human_actions:
+        ap = a.get("source_artifact_path")
+        if isinstance(ap, str) and ap not in seen_paths:
+            artefacts_referenced.append(ap)
+            seen_paths.add(ap)
+
+    env = _with_discipline(
+        {
+            "kind": "agent_control_activity_items_detail",
+            "schema_version": SCHEMA_VERSION,
+            "module_version": MODULE_VERSION,
+            "status": "ok",
+            "work_item": target,
+            "agent_events": agent_events,
+            "human_actions": human_actions,
+            "artefacts_referenced": artefacts_referenced,
+            "generated_at_utc": str(data.get("generated_at_utc") or ""),
+            "artifact_path": ARTIFACT_RELATIVE_PATH,
+        }
+    )
+    return _respond_json(env, 200)
+
+
+def _view_agents() -> Response:
+    status, data = _read_artifact()
+    if status != "ok":
+        env = _with_discipline(
+            {
+                "kind": "agent_control_activity_agents",
+                "schema_version": SCHEMA_VERSION,
+                "module_version": MODULE_VERSION,
+                "status": "not_available",
+                "reason": data.get("reason", "missing"),
+                "rows": [],
+                "generated_at_utc": "",
+                "artifact_path": ARTIFACT_RELATIVE_PATH,
+            }
+        )
+        return _respond_json(env, 200)
+    work_items = _safe_list(data, "work_items")
+    agent_events = _safe_list(data, "agent_events")
+    rows = _derive_agent_matrix(work_items, agent_events)
+    env = _with_discipline(
+        {
+            "kind": "agent_control_activity_agents",
+            "schema_version": SCHEMA_VERSION,
+            "module_version": MODULE_VERSION,
+            "status": "ok",
+            "rows": rows,
+            "generated_at_utc": str(data.get("generated_at_utc") or ""),
+            "artifact_path": ARTIFACT_RELATIVE_PATH,
+        }
+    )
+    return _respond_json(env, 200)
+
+
+def _view_artifacts() -> Response:
+    status, data = _read_artifact()
+    if status != "ok":
+        env = _with_discipline(
+            {
+                "kind": "agent_control_activity_artifacts",
+                "schema_version": SCHEMA_VERSION,
+                "module_version": MODULE_VERSION,
+                "status": "not_available",
+                "reason": data.get("reason", "missing"),
+                "artifact_health": [],
+                "generated_at_utc": "",
+                "artifact_path": ARTIFACT_RELATIVE_PATH,
+            }
+        )
+        return _respond_json(env, 200)
+    env = _with_discipline(
+        {
+            "kind": "agent_control_activity_artifacts",
+            "schema_version": SCHEMA_VERSION,
+            "module_version": MODULE_VERSION,
+            "status": "ok",
+            "artifact_health": _safe_list(data, "artifact_health"),
+            "generated_at_utc": str(data.get("generated_at_utc") or ""),
+            "artifact_path": ARTIFACT_RELATIVE_PATH,
+        }
+    )
+    return _respond_json(env, 200)
+
+
+def _view_invariants() -> Response:
+    status, data = _read_artifact()
+    if status != "ok":
+        env = _with_discipline(
+            {
+                "kind": "agent_control_activity_invariants",
+                "schema_version": SCHEMA_VERSION,
+                "module_version": MODULE_VERSION,
+                "status": "not_available",
+                "reason": data.get("reason", "missing"),
+                "invariant_status": [],
+                "generated_at_utc": "",
+                "artifact_path": ARTIFACT_RELATIVE_PATH,
+            }
+        )
+        return _respond_json(env, 200)
+    env = _with_discipline(
+        {
+            "kind": "agent_control_activity_invariants",
+            "schema_version": SCHEMA_VERSION,
+            "module_version": MODULE_VERSION,
+            "status": "ok",
+            "invariant_status": _safe_list(data, "invariant_status"),
+            "generated_at_utc": str(data.get("generated_at_utc") or ""),
+            "artifact_path": ARTIFACT_RELATIVE_PATH,
+        }
+    )
+    return _respond_json(env, 200)
+
+
+# ---------------------------------------------------------------------------
+# Route table + registrar
+# ---------------------------------------------------------------------------
+
+
+_AGENT_CONTROL_ACTIVITY_ROUTES: tuple[
+    tuple[str, str, Any, str], ...
+] = (
+    (
+        "/api/agent-control/activity/today",
+        "GET",
+        _view_today,
+        "agent_control_activity_today",
+    ),
+    (
+        "/api/agent-control/activity/items",
+        "GET",
+        _view_items_list,
+        "agent_control_activity_items_list",
+    ),
+    (
+        "/api/agent-control/activity/items/<string:item_id>",
+        "GET",
+        _view_items_detail,
+        "agent_control_activity_items_detail",
+    ),
+    (
+        "/api/agent-control/activity/agents",
+        "GET",
+        _view_agents,
+        "agent_control_activity_agents",
+    ),
+    (
+        "/api/agent-control/activity/artifacts",
+        "GET",
+        _view_artifacts,
+        "agent_control_activity_artifacts",
+    ),
+    (
+        "/api/agent-control/activity/invariants",
+        "GET",
+        _view_invariants,
+        "agent_control_activity_invariants",
+    ),
+)
+
+
+def register_agent_control_activity_routes(app: Flask) -> None:
+    """Register the read-only Agent Activity Center routes.
+
+    NOT wired into ``dashboard/dashboard.py`` in the PR that
+    introduces this blueprint. The two-line wiring change
+
+    ::
+
+        from dashboard.api_agent_control_activity import (
+            register_agent_control_activity_routes,
+        )
+        register_agent_control_activity_routes(app)
+
+    is operator-only per
+    ``docs/governance/execution_authority.md``
+    (``dashboard_wiring`` = NEEDS_HUMAN) and the no-touch hook at
+    ``.claude/hooks/deny_no_touch.py`` (which protects
+    ``dashboard/dashboard.py``).
+    """
+    for path, method, handler, endpoint in _AGENT_CONTROL_ACTIVITY_ROUTES:
+        app.add_url_rule(
+            path,
+            endpoint=endpoint,
+            view_func=handler,
+            methods=[method],
+        )
+
+
+__all__ = [
+    "MODULE_VERSION",
+    "SCHEMA_VERSION",
+    "STEP5_ENABLED_SUBSTAGE",
+    "register_agent_control_activity_routes",
+    "step5_implementation_allowed",
+]

--- a/tests/unit/test_api_agent_control_activity.py
+++ b/tests/unit/test_api_agent_control_activity.py
@@ -1,0 +1,1183 @@
+"""Unit tests for B2.0c — ``dashboard.api_agent_control_activity``
+(UNWIRED).
+
+Pins:
+
+* exactly six GET routes; no other HTTP method registered;
+* every endpoint returns ``not_available`` envelope when the
+  aggregator artefact is missing / unreadable / malformed;
+* ``today`` endpoint sections capped to 16 with
+  ``total_matching`` / ``truncated`` fields;
+* ``items`` list endpoint with closed-vocab filters
+  (``stage`` / ``owner_role`` / ``human_needed`` / ``updated_since``)
+  returns 400 ``invalid_enum`` / ``invalid_format`` on bad values;
+* ``items/<id>`` detail endpoint returns 200 with single match,
+  404 ``not_in_last_snapshot`` when id absent, 400
+  ``invalid_format`` on bad-charset / too-long / empty;
+* ``items/<id>`` returns 503 ``aggregator_missing`` when artefact
+  absent;
+* ``agents`` endpoint emits one row per closed agent role with
+  derived counts and last_action;
+* ``artifacts`` / ``invariants`` endpoints surface their slices;
+* HTTP cache semantics: ``Cache-Control: private, max-age=10`` +
+  ``ETag`` header + 304 on matching ``If-None-Match``;
+* every envelope carries closed Step 5 + Level 6 invariants
+  verbatim;
+* AST + source-text scans: no subprocess / GitHub CLI /
+  version-control CLI / network library / approval-token /
+  decision-verb call patterns / no mutating HTTP method
+  registration;
+* dashboard.py wiring is enforced as a both-or-neither
+  skip-or-enforce pin;
+* Step 5 invariants intact by import.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from flask import Flask
+
+from dashboard import api_agent_control_activity as aaca
+from reporting import development_agent_activity_timeline as aat
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolate_artifact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Path:
+    target = (
+        tmp_path
+        / "logs"
+        / "development_agent_activity_timeline"
+        / "latest.json"
+    )
+    target.parent.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(aat, "ARTIFACT_LATEST", target)
+    return target
+
+
+def _make_app() -> Flask:
+    app = Flask(__name__)
+    aaca.register_agent_control_activity_routes(app)
+    return app
+
+
+def _valid_work_item(
+    *,
+    item_id: str = "wi_a18c_aaa",
+    title: str = "A18c row · cand_aaa",
+    source_kind: str = "generated_lane",
+    source_path: str = (
+        "logs/development_generated_lane_a18c/latest.json"
+    ),
+    current_stage: str = "needs_human",
+    owner_role: str = "release_gate_agent",
+    risk: str = "medium",
+    human_needed: bool = True,
+    latest_verdict: str = "admission_decision=needs_human",
+    next_action: str = "Operator review",
+    updated_at: str = "2026-05-14T07:00:00Z",
+    summary: str = "synthetic work item",
+    event_ids: list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "item_id": item_id,
+        "title": title,
+        "source_kind": source_kind,
+        "source_path": source_path,
+        "current_stage": current_stage,
+        "owner_role": owner_role,
+        "risk": risk,
+        "human_needed": human_needed,
+        "latest_verdict": latest_verdict,
+        "next_action": next_action,
+        "updated_at": updated_at,
+        "summary": summary,
+        "event_ids": event_ids or [],
+    }
+
+
+def _valid_agent_event(
+    *,
+    event_id: str = "ev_aaa",
+    item_id: str = "wi_a18c_aaa",
+    timestamp: str = "2026-05-14T07:00:00Z",
+    agent_role: str = "release_gate_agent",
+    module: str = "generated_lane_a18c",
+    event_type: str = "verdict",
+    summary: str = "needs_human",
+    decision: str = "require_human",
+    reason: str = "policy",
+    artifact_path: str = (
+        "logs/development_generated_lane_a18c/latest.json"
+    ),
+    severity: str = "human",
+) -> dict[str, Any]:
+    return {
+        "event_id": event_id,
+        "item_id": item_id,
+        "timestamp": timestamp,
+        "agent_role": agent_role,
+        "module": module,
+        "event_type": event_type,
+        "summary": summary,
+        "decision": decision,
+        "reason": reason,
+        "artifact_path": artifact_path,
+        "severity": severity,
+    }
+
+
+def _valid_human_action(
+    *,
+    action_id: str = "ha_aaa",
+    item_id: str = "wi_a18c_aaa",
+    severity: str = "medium",
+    title: str = "Operator review",
+    why_required: str = "needs_human",
+    required_phrase: str | None = None,
+    safe_to_ignore: bool = False,
+    copy_only: bool = True,
+    source_artifact_path: str = (
+        "logs/development_generated_lane_a18c/latest.json"
+    ),
+    suggested_role: str = "release_gate_agent",
+    created_at: str = "2026-05-14T07:00:00Z",
+) -> dict[str, Any]:
+    return {
+        "action_id": action_id,
+        "item_id": item_id,
+        "severity": severity,
+        "title": title,
+        "why_required": why_required,
+        "required_phrase": required_phrase,
+        "safe_to_ignore": safe_to_ignore,
+        "copy_only": copy_only,
+        "source_artifact_path": source_artifact_path,
+        "suggested_role": suggested_role,
+        "created_at": created_at,
+    }
+
+
+def _valid_artifact_health(
+    *,
+    path: str = "logs/development_work_queue/latest.json",
+    group: str = "queue",
+    fresh: bool = True,
+    parse_ok: bool = True,
+    row_count: int = 0,
+    last_modified: str = "2026-05-14T07:00:00Z",
+    module_version: str = "wq.v4.2",
+    has_summary: bool = True,
+) -> dict[str, Any]:
+    return {
+        "path": path,
+        "group": group,
+        "fresh": fresh,
+        "parse_ok": parse_ok,
+        "row_count": row_count,
+        "last_modified": last_modified,
+        "module_version": module_version,
+        "has_summary": has_summary,
+    }
+
+
+def _valid_invariant(
+    *,
+    key: str = "level_6",
+    label: str = "Level 6",
+    value: Any = "permanently_disabled",
+    tone: str = "danger_off",
+    detail: str = "Level 6 stays permanently disabled.",
+) -> dict[str, Any]:
+    return {
+        "key": key,
+        "label": label,
+        "value": value,
+        "tone": tone,
+        "detail": detail,
+    }
+
+
+def _write_artifact(
+    artifact_path: Path,
+    *,
+    work_items: list[dict[str, Any]] | None = None,
+    agent_events: list[dict[str, Any]] | None = None,
+    human_actions: list[dict[str, Any]] | None = None,
+    artifact_health: list[dict[str, Any]] | None = None,
+    invariant_status: list[dict[str, Any]] | None = None,
+    generated_at_utc: str = "2026-05-14T08:00:00Z",
+) -> None:
+    payload = {
+        "schema_version": 1,
+        "module_version": "aat.v0.1",
+        "report_kind": "agent_activity_timeline",
+        "generated_at_utc": generated_at_utc,
+        "freshness": {
+            "generated_at_utc": generated_at_utc,
+            "oldest_artifact_age_seconds": 0,
+            "any_stale": False,
+            "any_malformed": False,
+            "background_refreshing": False,
+            "ttl_seconds_by_path": {},
+        },
+        "counts": {
+            "discovered": 0,
+            "queued": 0,
+            "delegated": 0,
+            "planned": 0,
+            "dry_run_ready": 0,
+            "pr_proposed": 0,
+            "pr_opened": 0,
+            "ci_feedback": 0,
+            "needs_human": 0,
+            "merge_candidate": 0,
+            "blocked": 0,
+            "total_open": 0,
+        },
+        "work_items": work_items or [],
+        "agent_events": agent_events or [],
+        "human_actions": human_actions or [],
+        "artifact_health": artifact_health or [],
+        "invariant_status": invariant_status or [_valid_invariant()],
+        "vocabularies": {
+            "stage": list(aat.STAGES),
+            "severity": list(aat.SEVERITIES),
+            "decision": list(aat.DECISIONS),
+            "risk": list(aat.RISKS),
+            "freshness": list(aat.FRESHNESS_STATES),
+            "artifact_health": list(aat.ARTIFACT_HEALTH_STATES),
+            "human_action": list(aat.HUMAN_ACTION_TYPES),
+            "invariant_state": list(aat.INVARIANT_STATES),
+        },
+    }
+    artifact_path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Module surface
+# ---------------------------------------------------------------------------
+
+
+def test_module_version_anchor() -> None:
+    assert aaca.MODULE_VERSION == "v3.15.16.A15.B2.0c.api"
+
+
+def test_schema_version_is_1() -> None:
+    assert aaca.SCHEMA_VERSION == 1
+
+
+def test_step5_invariants_intact_by_import() -> None:
+    assert aaca.step5_implementation_allowed is False
+    assert aaca.STEP5_ENABLED_SUBSTAGE == "none"
+
+
+def test_artifact_relative_path_is_canonical() -> None:
+    assert (
+        aaca.ARTIFACT_RELATIVE_PATH
+        == "logs/development_agent_activity_timeline/latest.json"
+    )
+
+
+def test_registrar_is_exported() -> None:
+    assert "register_agent_control_activity_routes" in aaca.__all__
+
+
+# ---------------------------------------------------------------------------
+# Route registration
+# ---------------------------------------------------------------------------
+
+
+def test_blueprint_registers_exactly_six_get_routes() -> None:
+    app = _make_app()
+    rules = [
+        r for r in app.url_map.iter_rules()
+        if r.rule.startswith("/api/agent-control/activity/")
+    ]
+    assert len(rules) == 6
+    paths = sorted(r.rule for r in rules)
+    assert paths == sorted(
+        [
+            "/api/agent-control/activity/today",
+            "/api/agent-control/activity/items",
+            "/api/agent-control/activity/items/<string:item_id>",
+            "/api/agent-control/activity/agents",
+            "/api/agent-control/activity/artifacts",
+            "/api/agent-control/activity/invariants",
+        ]
+    )
+
+
+def test_blueprint_registers_only_get_method() -> None:
+    """Closed-verb pin: every route under the activity prefix has
+    methods exactly {GET, HEAD, OPTIONS} (Flask auto-adds the last
+    two)."""
+    app = _make_app()
+    for rule in app.url_map.iter_rules():
+        if not rule.rule.startswith("/api/agent-control/activity/"):
+            continue
+        methods = set(rule.methods or set())
+        for forbidden in ("POST", "PUT", "PATCH", "DELETE"):
+            assert forbidden not in methods, (
+                f"forbidden method on {rule.rule}: {methods}"
+            )
+        assert "GET" in methods
+
+
+def test_blueprint_rejects_mutating_methods_at_request_time() -> None:
+    """Every endpoint returns 405 on POST/PUT/PATCH/DELETE."""
+    client = _make_app().test_client()
+    for path in (
+        "/api/agent-control/activity/today",
+        "/api/agent-control/activity/items",
+        "/api/agent-control/activity/agents",
+        "/api/agent-control/activity/artifacts",
+        "/api/agent-control/activity/invariants",
+    ):
+        for verb in ("post", "put", "patch", "delete"):
+            res = getattr(client, verb)(path)
+            assert res.status_code in (
+                405,
+                404,
+            ), f"{verb} {path} returned {res.status_code}"
+
+
+def test_blueprint_registers_no_routes_outside_activity_prefix() -> None:
+    """The blueprint owns ``/api/agent-control/activity/*`` exclusively."""
+    app = _make_app()
+    rules = [
+        r
+        for r in app.url_map.iter_rules()
+        if r.endpoint
+        and r.endpoint.startswith("agent_control_activity_")
+    ]
+    for r in rules:
+        assert r.rule.startswith("/api/agent-control/activity/"), (
+            f"unexpected route prefix: {r.rule}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# BOTH-or-NEITHER wiring pin
+# ---------------------------------------------------------------------------
+
+
+def test_blueprint_not_yet_wired_into_dashboard_dashboard() -> None:
+    """Operator step pending: dashboard.py must contain BOTH the
+    import and the register call for api_agent_control_activity, or
+    NEITHER. The two-line wiring diff is operator-applied per the
+    no-touch hook on ``dashboard/dashboard.py``."""
+    text = (REPO_ROOT / "dashboard" / "dashboard.py").read_text(
+        encoding="utf-8"
+    )
+    wiring_present = (
+        "from dashboard.api_agent_control_activity "
+        "import register_agent_control_activity_routes" in text
+        or "from dashboard.api_agent_control_activity import (" in text
+    )
+    register_present = (
+        "register_agent_control_activity_routes(app)" in text
+    )
+    assert wiring_present == register_present, (
+        "dashboard.py must contain BOTH the import and the register "
+        "call for api_agent_control_activity, or NEITHER."
+    )
+
+
+# ---------------------------------------------------------------------------
+# `today` endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_today_missing_artifact_returns_not_available() -> None:
+    res = _make_app().test_client().get(
+        "/api/agent-control/activity/today"
+    )
+    assert res.status_code == 200
+    body = res.get_json()
+    assert body["status"] == "not_available"
+    assert body["needs_human"] == []
+    assert body["counts"] == {}
+    assert body["step5_implementation_allowed"] is False
+
+
+def test_today_ok_returns_capped_sections(_isolate_artifact: Path) -> None:
+    work_items = [
+        _valid_work_item(
+            item_id=f"wi_h_{i}",
+            current_stage="needs_human",
+            human_needed=True,
+        )
+        for i in range(20)
+    ]
+    _write_artifact(_isolate_artifact, work_items=work_items)
+    res = _make_app().test_client().get(
+        "/api/agent-control/activity/today"
+    )
+    assert res.status_code == 200
+    body = res.get_json()
+    assert body["status"] == "ok"
+    assert len(body["needs_human"]) == 16
+    assert (
+        body["section_totals"]["needs_human"]["total_matching"] == 20
+    )
+    assert (
+        body["section_totals"]["needs_human"]["truncated"] is True
+    )
+
+
+def test_today_includes_merge_candidate_and_ci_feedback_sections(
+    _isolate_artifact: Path,
+) -> None:
+    work_items = [
+        _valid_work_item(
+            item_id="wi_merge",
+            current_stage="merge_candidate",
+            human_needed=False,
+        ),
+        _valid_work_item(
+            item_id="wi_ci",
+            current_stage="ci_feedback",
+            human_needed=False,
+        ),
+        _valid_work_item(
+            item_id="wi_blocked",
+            current_stage="done_blocked",
+            human_needed=False,
+        ),
+    ]
+    _write_artifact(_isolate_artifact, work_items=work_items)
+    body = (
+        _make_app()
+        .test_client()
+        .get("/api/agent-control/activity/today")
+        .get_json()
+    )
+    assert len(body["merge_candidate"]) == 1
+    assert len(body["ci_feedback"]) == 1
+    assert len(body["blocked"]) == 1
+
+
+def test_today_recent_events_capped(_isolate_artifact: Path) -> None:
+    events = [
+        _valid_agent_event(
+            event_id=f"ev_{i:03d}",
+            timestamp=f"2026-05-14T07:00:{i:02d}Z",
+        )
+        for i in range(40)
+    ]
+    _write_artifact(_isolate_artifact, agent_events=events)
+    body = (
+        _make_app()
+        .test_client()
+        .get("/api/agent-control/activity/today")
+        .get_json()
+    )
+    assert len(body["recent_events"]) == 16
+
+
+def test_today_carries_invariant_status(_isolate_artifact: Path) -> None:
+    _write_artifact(
+        _isolate_artifact,
+        invariant_status=[
+            _valid_invariant(),
+            _valid_invariant(
+                key="step5_implementation_allowed",
+                label="Step 5 impl. allowed",
+                value=False,
+                tone="off",
+                detail="off",
+            ),
+        ],
+    )
+    body = (
+        _make_app()
+        .test_client()
+        .get("/api/agent-control/activity/today")
+        .get_json()
+    )
+    keys = {row["key"] for row in body["invariant_status"]}
+    assert "level_6" in keys
+    assert "step5_implementation_allowed" in keys
+
+
+def test_today_malformed_artifact_returns_not_available(
+    _isolate_artifact: Path,
+) -> None:
+    _isolate_artifact.write_text("{not json", encoding="utf-8")
+    body = (
+        _make_app()
+        .test_client()
+        .get("/api/agent-control/activity/today")
+        .get_json()
+    )
+    assert body["status"] == "not_available"
+    assert "malformed" in body.get("reason", "")
+
+
+# ---------------------------------------------------------------------------
+# `items` list endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_items_list_ok_returns_work_items(_isolate_artifact: Path) -> None:
+    _write_artifact(
+        _isolate_artifact,
+        work_items=[_valid_work_item()],
+    )
+    body = (
+        _make_app()
+        .test_client()
+        .get("/api/agent-control/activity/items")
+        .get_json()
+    )
+    assert body["status"] == "ok"
+    assert body["total_matching"] == 1
+    assert body["truncated"] is False
+    assert len(body["work_items"]) == 1
+
+
+def test_items_list_filter_stage_accepts_closed_vocab(
+    _isolate_artifact: Path,
+) -> None:
+    _write_artifact(
+        _isolate_artifact,
+        work_items=[
+            _valid_work_item(
+                item_id="wi_p", current_stage="planned", human_needed=False
+            ),
+            _valid_work_item(
+                item_id="wi_h",
+                current_stage="needs_human",
+                human_needed=True,
+            ),
+        ],
+    )
+    body = (
+        _make_app()
+        .test_client()
+        .get("/api/agent-control/activity/items?stage=planned")
+        .get_json()
+    )
+    assert body["total_matching"] == 1
+    assert body["work_items"][0]["current_stage"] == "planned"
+
+
+def test_items_list_filter_stage_rejects_unknown_value() -> None:
+    res = _make_app().test_client().get(
+        "/api/agent-control/activity/items?stage=bogus_stage"
+    )
+    assert res.status_code == 400
+    body = res.get_json()
+    assert body["error"] == "invalid_enum"
+    assert body["param"] == "stage"
+
+
+def test_items_list_filter_owner_role_accepts_closed_vocab(
+    _isolate_artifact: Path,
+) -> None:
+    _write_artifact(
+        _isolate_artifact,
+        work_items=[
+            _valid_work_item(
+                item_id="wi_a",
+                owner_role="release_gate_agent",
+            ),
+            _valid_work_item(
+                item_id="wi_b",
+                owner_role="planner",
+            ),
+        ],
+    )
+    body = (
+        _make_app()
+        .test_client()
+        .get(
+            "/api/agent-control/activity/items?owner_role=planner"
+        )
+        .get_json()
+    )
+    assert body["total_matching"] == 1
+
+
+def test_items_list_filter_owner_role_rejects_unknown_value() -> None:
+    res = _make_app().test_client().get(
+        "/api/agent-control/activity/items?owner_role=trickster"
+    )
+    assert res.status_code == 400
+    assert res.get_json()["error"] == "invalid_enum"
+
+
+def test_items_list_filter_human_needed_true(
+    _isolate_artifact: Path,
+) -> None:
+    _write_artifact(
+        _isolate_artifact,
+        work_items=[
+            _valid_work_item(item_id="wi_h", human_needed=True),
+            _valid_work_item(item_id="wi_n", human_needed=False),
+        ],
+    )
+    body = (
+        _make_app()
+        .test_client()
+        .get(
+            "/api/agent-control/activity/items?human_needed=true"
+        )
+        .get_json()
+    )
+    assert body["total_matching"] == 1
+    assert body["work_items"][0]["human_needed"] is True
+
+
+def test_items_list_filter_human_needed_rejects_garbage() -> None:
+    res = _make_app().test_client().get(
+        "/api/agent-control/activity/items?human_needed=yes_please"
+    )
+    assert res.status_code == 400
+    assert res.get_json()["error"] == "invalid_enum"
+
+
+def test_items_list_filter_updated_since_rejects_malformed_ts() -> None:
+    res = _make_app().test_client().get(
+        "/api/agent-control/activity/items?updated_since=yesterday"
+    )
+    assert res.status_code == 400
+    assert res.get_json()["error"] == "invalid_format"
+
+
+# ---------------------------------------------------------------------------
+# `items/<id>` detail endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_items_detail_ok(_isolate_artifact: Path) -> None:
+    target = _valid_work_item(item_id="wi_target_001")
+    event = _valid_agent_event(item_id="wi_target_001", event_id="ev_x")
+    ha = _valid_human_action(item_id="wi_target_001")
+    _write_artifact(
+        _isolate_artifact,
+        work_items=[target],
+        agent_events=[event],
+        human_actions=[ha],
+    )
+    res = (
+        _make_app()
+        .test_client()
+        .get("/api/agent-control/activity/items/wi_target_001")
+    )
+    assert res.status_code == 200
+    body = res.get_json()
+    assert body["status"] == "ok"
+    assert body["work_item"]["item_id"] == "wi_target_001"
+    assert len(body["agent_events"]) == 1
+    assert len(body["human_actions"]) == 1
+    assert (
+        "logs/development_generated_lane_a18c/latest.json"
+        in body["artefacts_referenced"]
+    )
+
+
+def test_items_detail_not_in_last_snapshot_returns_404(
+    _isolate_artifact: Path,
+) -> None:
+    _write_artifact(_isolate_artifact, work_items=[])
+    res = (
+        _make_app()
+        .test_client()
+        .get("/api/agent-control/activity/items/wi_nonexistent")
+    )
+    assert res.status_code == 404
+    body = res.get_json()
+    assert body["error"] == "not_in_last_snapshot"
+
+
+def test_items_detail_bad_charset_returns_400() -> None:
+    res = (
+        _make_app()
+        .test_client()
+        .get("/api/agent-control/activity/items/has%20space")
+    )
+    assert res.status_code in (400, 404)
+    if res.status_code == 400:
+        body = res.get_json()
+        assert body["error"] == "invalid_format"
+
+
+def test_items_detail_too_long_returns_400() -> None:
+    long_id = "a" * 200
+    res = (
+        _make_app()
+        .test_client()
+        .get(f"/api/agent-control/activity/items/{long_id}")
+    )
+    assert res.status_code == 400
+    body = res.get_json()
+    assert body["error"] == "invalid_format"
+    assert body["detail"] == "too_long"
+
+
+def test_items_detail_aggregator_missing_returns_503() -> None:
+    res = (
+        _make_app()
+        .test_client()
+        .get("/api/agent-control/activity/items/wi_anything")
+    )
+    assert res.status_code == 503
+    body = res.get_json()
+    assert body["error"] == "aggregator_missing"
+
+
+# ---------------------------------------------------------------------------
+# `agents` endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_agents_missing_returns_not_available() -> None:
+    body = (
+        _make_app()
+        .test_client()
+        .get("/api/agent-control/activity/agents")
+        .get_json()
+    )
+    assert body["status"] == "not_available"
+    assert body["rows"] == []
+
+
+def test_agents_ok_emits_one_row_per_closed_role(
+    _isolate_artifact: Path,
+) -> None:
+    _write_artifact(
+        _isolate_artifact,
+        work_items=[
+            _valid_work_item(
+                item_id="wi_a",
+                owner_role="release_gate_agent",
+                current_stage="needs_human",
+                human_needed=True,
+            ),
+            _valid_work_item(
+                item_id="wi_b",
+                owner_role="planner",
+                current_stage="planned",
+                human_needed=False,
+            ),
+        ],
+    )
+    body = (
+        _make_app()
+        .test_client()
+        .get("/api/agent-control/activity/agents")
+        .get_json()
+    )
+    assert body["status"] == "ok"
+    assert len(body["rows"]) == len(aat.AGENT_ROLES)
+    by_role = {r["role"]: r for r in body["rows"]}
+    assert by_role["release_gate_agent"]["needs_human"] == 1
+    assert by_role["planner"]["planned"] == 1
+
+
+def test_agents_last_action_carries_latest_event(
+    _isolate_artifact: Path,
+) -> None:
+    _write_artifact(
+        _isolate_artifact,
+        work_items=[
+            _valid_work_item(
+                item_id="wi_a",
+                owner_role="release_gate_agent",
+            ),
+        ],
+        agent_events=[
+            _valid_agent_event(event_id="ev_old", timestamp="2026-05-14T06:00:00Z"),
+            _valid_agent_event(event_id="ev_new", timestamp="2026-05-14T07:00:00Z"),
+        ],
+    )
+    body = (
+        _make_app()
+        .test_client()
+        .get("/api/agent-control/activity/agents")
+        .get_json()
+    )
+    by_role = {r["role"]: r for r in body["rows"]}
+    last = by_role["release_gate_agent"]["last_action"]
+    assert last is not None
+    assert last["event_id"] == "ev_new"
+
+
+# ---------------------------------------------------------------------------
+# `artifacts` endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_artifacts_missing_returns_not_available() -> None:
+    body = (
+        _make_app()
+        .test_client()
+        .get("/api/agent-control/activity/artifacts")
+        .get_json()
+    )
+    assert body["status"] == "not_available"
+
+
+def test_artifacts_ok_passes_through_artifact_health(
+    _isolate_artifact: Path,
+) -> None:
+    _write_artifact(
+        _isolate_artifact,
+        artifact_health=[
+            _valid_artifact_health(),
+            _valid_artifact_health(
+                path="generated_seed.jsonl",
+                group="seed",
+                fresh=False,
+            ),
+        ],
+    )
+    body = (
+        _make_app()
+        .test_client()
+        .get("/api/agent-control/activity/artifacts")
+        .get_json()
+    )
+    assert body["status"] == "ok"
+    assert len(body["artifact_health"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# `invariants` endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_invariants_missing_returns_not_available() -> None:
+    body = (
+        _make_app()
+        .test_client()
+        .get("/api/agent-control/activity/invariants")
+        .get_json()
+    )
+    assert body["status"] == "not_available"
+
+
+def test_invariants_ok_passes_through_invariant_status(
+    _isolate_artifact: Path,
+) -> None:
+    _write_artifact(
+        _isolate_artifact,
+        invariant_status=[
+            _valid_invariant(),
+            _valid_invariant(
+                key="step5_implementation_allowed",
+                label="Step 5 impl. allowed",
+                value=False,
+                tone="off",
+                detail="off",
+            ),
+        ],
+    )
+    body = (
+        _make_app()
+        .test_client()
+        .get("/api/agent-control/activity/invariants")
+        .get_json()
+    )
+    assert body["status"] == "ok"
+    keys = {r["key"] for r in body["invariant_status"]}
+    assert "level_6" in keys
+    assert "step5_implementation_allowed" in keys
+
+
+# ---------------------------------------------------------------------------
+# HTTP cache semantics
+# ---------------------------------------------------------------------------
+
+
+def test_response_carries_cache_control_header(
+    _isolate_artifact: Path,
+) -> None:
+    _write_artifact(_isolate_artifact)
+    res = _make_app().test_client().get(
+        "/api/agent-control/activity/today"
+    )
+    assert res.headers.get("Cache-Control") == "private, max-age=10"
+
+
+def test_response_carries_etag_header(_isolate_artifact: Path) -> None:
+    _write_artifact(_isolate_artifact)
+    res = _make_app().test_client().get(
+        "/api/agent-control/activity/today"
+    )
+    etag = res.headers.get("ETag")
+    assert etag is not None
+    assert etag.startswith('"') and etag.endswith('"')
+
+
+def test_if_none_match_returns_304(_isolate_artifact: Path) -> None:
+    _write_artifact(_isolate_artifact)
+    client = _make_app().test_client()
+    first = client.get("/api/agent-control/activity/today")
+    etag = first.headers["ETag"]
+    second = client.get(
+        "/api/agent-control/activity/today",
+        headers={"If-None-Match": etag},
+    )
+    assert second.status_code == 304
+    assert second.headers.get("ETag") == etag
+    assert second.data == b""
+
+
+def test_etag_changes_when_generated_at_utc_changes(
+    _isolate_artifact: Path,
+) -> None:
+    _write_artifact(
+        _isolate_artifact, generated_at_utc="2026-05-14T08:00:00Z"
+    )
+    first = (
+        _make_app()
+        .test_client()
+        .get("/api/agent-control/activity/today")
+    )
+    _write_artifact(
+        _isolate_artifact, generated_at_utc="2026-05-14T09:00:00Z"
+    )
+    second = (
+        _make_app()
+        .test_client()
+        .get("/api/agent-control/activity/today")
+    )
+    assert first.headers["ETag"] != second.headers["ETag"]
+
+
+# ---------------------------------------------------------------------------
+# Discipline-invariant mirroring
+# ---------------------------------------------------------------------------
+
+
+def test_every_endpoint_mirrors_step5_invariants(
+    _isolate_artifact: Path,
+) -> None:
+    _write_artifact(_isolate_artifact, work_items=[_valid_work_item()])
+    client = _make_app().test_client()
+    paths = [
+        "/api/agent-control/activity/today",
+        "/api/agent-control/activity/items",
+        "/api/agent-control/activity/items/wi_a18c_aaa",
+        "/api/agent-control/activity/agents",
+        "/api/agent-control/activity/artifacts",
+        "/api/agent-control/activity/invariants",
+    ]
+    for path in paths:
+        body = client.get(path).get_json()
+        assert body["step5_implementation_allowed"] is False, path
+        assert body["step5_enabled_substage"] == "none", path
+        assert body["level6_enabled"] is False, path
+
+
+def test_today_envelope_carries_invariants_even_when_artifact_missing() -> None:
+    body = (
+        _make_app()
+        .test_client()
+        .get("/api/agent-control/activity/today")
+        .get_json()
+    )
+    assert body["step5_implementation_allowed"] is False
+    assert body["step5_enabled_substage"] == "none"
+    assert body["level6_enabled"] is False
+
+
+def test_error_envelope_carries_invariants() -> None:
+    res = _make_app().test_client().get(
+        "/api/agent-control/activity/items?stage=bogus"
+    )
+    body = res.get_json()
+    assert body["step5_implementation_allowed"] is False
+    assert body["step5_enabled_substage"] == "none"
+    assert body["level6_enabled"] is False
+
+
+def test_detail_404_envelope_carries_invariants(
+    _isolate_artifact: Path,
+) -> None:
+    _write_artifact(_isolate_artifact, work_items=[])
+    res = (
+        _make_app()
+        .test_client()
+        .get("/api/agent-control/activity/items/wi_nonexistent")
+    )
+    body = res.get_json()
+    assert body["step5_implementation_allowed"] is False
+    assert body["step5_enabled_substage"] == "none"
+    assert body["level6_enabled"] is False
+
+
+# ---------------------------------------------------------------------------
+# AST scans
+# ---------------------------------------------------------------------------
+
+
+_FORBIDDEN_IMPORT_TOPS = (
+    "subprocess",
+    "socket",
+    "urllib",
+    "requests",
+    "httpx",
+    "aiohttp",
+)
+
+_FORBIDDEN_FROM_PREFIXES = (
+    "research",
+    "automation",
+    "broker",
+    "agent.risk",
+    "agent.execution",
+    "reporting.intelligent_routing",
+)
+
+
+def _module_ast() -> ast.AST:
+    return ast.parse(Path(aaca.__file__).read_text(encoding="utf-8"))
+
+
+def test_blueprint_module_has_no_subprocess_or_network_imports() -> None:
+    tree = _module_ast()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                top = alias.name.split(".", 1)[0]
+                assert top not in _FORBIDDEN_IMPORT_TOPS, (
+                    f"forbidden import: {alias.name!r}"
+                )
+        if isinstance(node, ast.ImportFrom) and node.module is not None:
+            top = node.module.split(".", 1)[0]
+            assert top not in _FORBIDDEN_IMPORT_TOPS, (
+                f"forbidden import: from {node.module!r}"
+            )
+
+
+def test_blueprint_module_has_no_qre_or_dashboard_dashboard_imports() -> None:
+    tree = _module_ast()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name != "dashboard.dashboard"
+        if isinstance(node, ast.ImportFrom) and node.module is not None:
+            assert node.module != "dashboard.dashboard"
+            for prefix in _FORBIDDEN_FROM_PREFIXES:
+                assert not (
+                    node.module == prefix
+                    or node.module.startswith(prefix + ".")
+                ), f"forbidden import: from {node.module!r}"
+
+
+def test_blueprint_module_has_no_os_environ_read() -> None:
+    tree = _module_ast()
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Attribute)
+            and node.attr == "environ"
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "os"
+        ):
+            raise AssertionError(
+                "blueprint references os.environ — forbidden"
+            )
+        if isinstance(node, ast.Call):
+            func = node.func
+            if (
+                isinstance(func, ast.Attribute)
+                and func.attr == "getenv"
+                and isinstance(func.value, ast.Name)
+                and func.value.id == "os"
+            ):
+                raise AssertionError(
+                    "blueprint calls os.getenv — forbidden"
+                )
+
+
+# ---------------------------------------------------------------------------
+# Source-text scans
+# ---------------------------------------------------------------------------
+
+
+def test_blueprint_source_has_no_mutating_methods_literal() -> None:
+    src = Path(aaca.__file__).read_text(encoding="utf-8")
+    for forbidden in (
+        'methods=["POST"',
+        "methods=['POST'",
+        'methods=["PUT"',
+        "methods=['PUT'",
+        'methods=["PATCH"',
+        "methods=['PATCH'",
+        'methods=["DELETE"',
+        "methods=['DELETE'",
+    ):
+        assert forbidden not in src, (
+            f"blueprint source contains forbidden methods literal: "
+            f"{forbidden!r}"
+        )
+
+
+def test_blueprint_source_has_no_decision_verb_call_patterns() -> None:
+    src = Path(aaca.__file__).read_text(encoding="utf-8")
+    forbidden_patterns = (
+        "approve(",
+        "reject(",
+        "merge_pr(",
+        "deploy(",
+        "mint_token(",
+        "verify_token(",
+        "subprocess.run(",
+        "subprocess.Popen(",
+        "os.system(",
+        "os.popen(",
+    )
+    for needle in forbidden_patterns:
+        assert needle not in src, (
+            f"blueprint source contains forbidden call pattern: "
+            f"{needle!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# assert_no_secrets boundary
+# ---------------------------------------------------------------------------
+
+
+def test_assert_no_secrets_called_on_every_envelope(
+    _isolate_artifact: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_artifact(_isolate_artifact, work_items=[_valid_work_item()])
+    calls: list[Any] = []
+
+    def _spy(payload):
+        calls.append(payload)
+
+    monkeypatch.setattr(aaca, "assert_no_secrets", _spy)
+    client = _make_app().test_client()
+    for path in (
+        "/api/agent-control/activity/today",
+        "/api/agent-control/activity/items",
+        "/api/agent-control/activity/items/wi_a18c_aaa",
+        "/api/agent-control/activity/agents",
+        "/api/agent-control/activity/artifacts",
+        "/api/agent-control/activity/invariants",
+    ):
+        client.get(path)
+    assert len(calls) >= 6


### PR DESCRIPTION
## Summary

Revised Batch 2, **unit B2.0c — Agent Activity Center Flask blueprint**. Ships the read-only Flask blueprint that exposes the AAC aggregator artefact (produced by B2.0b) through the six closed-shape \`GET\` endpoints under \`/api/agent-control/activity/*\` documented in [\`docs/governance/agent_activity_center_api_contract.md\`](docs/governance/agent_activity_center_api_contract.md). Mirrors the [api_merge_preflight.py](dashboard/api_merge_preflight.py) precedent exactly: blueprint registered via \`register_*_routes(app)\` factory, **shipped UNWIRED** so the operator applies the two-line wiring diff to \`dashboard/dashboard.py\` (a no-touch path) in a separate PR.

## Six GET endpoints

| Path | Returns |
|---|---|
| \`GET /api/agent-control/activity/today\` | counts + 4 headline sections (capped to 16; \`total_matching\`/\`truncated\` fields) + recent_events (capped to 16) + freshness + invariant_status |
| \`GET /api/agent-control/activity/items?stage=&owner_role=&human_needed=&updated_since=\` | filtered work_items; closed-vocab filter validation; 400 \`invalid_enum\` / \`invalid_format\` on bad values |
| \`GET /api/agent-control/activity/items/<string:item_id>\` | one work_item + its events + actions + artefacts_referenced; 200/400/404/503 |
| \`GET /api/agent-control/activity/agents\` | per-role activity matrix derived from work_items + agent_events |
| \`GET /api/agent-control/activity/artifacts\` | \`artifact_health[]\` slice |
| \`GET /api/agent-control/activity/invariants\` | \`invariant_status[]\` slice |

## HTTP cache semantics (per API contract §4)

- \`Cache-Control: private, max-age=10\`
- \`ETag\` derived from \`generated_at_utc\` via sha256 hex prefix
- \`304 Not Modified\` on matching \`If-None-Match\`

## Closed error-code vocabulary (per API contract §8)

\`invalid_enum\` · \`invalid_format\` · \`not_in_last_snapshot\` · \`aggregator_failed\` · \`aggregator_missing\`

## File map (2 files, additive)

| # | Path | What it adds |
|---|---|---|
| 1 | [\`dashboard/api_agent_control_activity.py\`](dashboard/api_agent_control_activity.py) | NEW — 6 GET routes registered via \`register_agent_control_activity_routes(app)\`. Stdlib + Flask + \`reporting.development_agent_activity_timeline\` + \`reporting.agent_audit_summary.assert_no_secrets\`. |
| 2 | [\`tests/unit/test_api_agent_control_activity.py\`](tests/unit/test_api_agent_control_activity.py) | NEW — 50 pin tests. |

## Validation evidence

- \`python -m pytest tests/unit/test_api_agent_control_activity.py -q\` → **50 passed**
- \`python -m pytest tests/unit/test_api_merge_preflight.py tests/unit/test_development_agent_activity_timeline.py tests/unit/test_agent_activity_center_governance_docs.py -q\` → **104 passed**
- \`python -m pytest tests/smoke -q\` → **18 passed**
- \`python scripts/governance_lint.py\` → \`Governance lint OK (16 agents, 5 workflows checked)\`

## Mid-implementation correction applied

The module docstring originally enumerated forbidden verb-call patterns as documentation of the forbidden set. The companion source-text scan rejected these. Rewrote the docstring to describe the patterns without the literal call syntax. Same self-trip lesson as B1.4 and B2.0b.

## Not in scope (explicitly excluded)

- No edit to \`dashboard/dashboard.py\` (no-touch path; the BOTH-or-NEITHER wiring pin enforces this).
- No PWA frontend code, service worker, or manifest (B2.0d remains separately gated).
- No push-notification publisher (B2.0e remains separately gated).
- No mutation endpoint anywhere.
- No env flip; no Step 5 flag/substage change; no queue admission; no PR creation; no merge; no deploy.
- No writes to \`seed.jsonl\` / \`delegation_seed.jsonl\` / \`generated_seed.jsonl\`.
- No \`tests/regression/\` edits.
- No \`.claude/**\` / \`.github/**\` / no-touch path / frozen v1 schema / ADR / governance doc / roadmap / aggregator module edits.

## Rollback

Single \`git revert\`. The blueprint is purely additive; removing the module restores the prior state. \`dashboard/dashboard.py\` is untouched.

## Test plan

- [x] All unit tests pass locally (50 new + 104 sibling + 18 smoke).
- [x] Governance lint green.
- [ ] CI green.
- [ ] Diff allowlist + mergeability confirmed.
- [ ] Squash-merge to main.
- [ ] Post-merge gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)