### PR TITLE
feat(b2-0d)(frontend): Agent Activity Center mobile-first PWA frontend (read-only)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,6 +20,7 @@ import { AgentControlInboxPlaceholder } from "./routes/AgentControl/InboxPlaceho
 import { AgentControlMergeRecommendation } from "./routes/AgentControl/MergeRecommendation";
 import { AgentControlMergePreflight } from "./routes/AgentControl/MergePreflight";
 import { ApprovalTokenDiagnostics } from "./routes/AgentControl/ApprovalTokenDiagnostics";
+import { AgentActivity } from "./routes/AgentControl/AgentActivity";
 
 export function App() {
   return (
@@ -129,6 +130,23 @@ export function App() {
           element={
             <RequireAuth>
               <ApprovalTokenDiagnostics />
+            </RequireAuth>
+          }
+        />
+        {/*
+         * v3.15.16.A15.B2.0d — read-only Agent Activity Center PWA
+         * surface backed by the wired /api/agent-control/activity/*
+         * blueprint (PR #224). The /* wildcard captures all AAC
+         * sub-paths (today / inbox / pipeline / agents / more /
+         * artefacts / safety / items/<item_id>) handled by nested
+         * <Routes> inside <AgentActivity />. No mutation endpoint;
+         * read-only by construction.
+         */}
+        <Route
+          path="/agent-control/activity/*"
+          element={
+            <RequireAuth>
+              <AgentActivity />
             </RequireAuth>
           }
         />

--- a/frontend/src/api/agent_control.ts
+++ b/frontend/src/api/agent_control.ts
@@ -666,4 +666,287 @@ export const agentControlApi = {
       `${BASE}/approval-token/verify`,
       body,
     ),
+  // =====================================================================
+  // v3.15.16.A15.B2.0d — Agent Activity Center read-only client.
+  //
+  // All six endpoints under /api/agent-control/activity/* are GET-only
+  // and use the same getJsonEnvelope helper as merge-recommendation /
+  // merge-preflight so closed-vocab error codes (invalid_enum /
+  // invalid_format / not_in_last_snapshot / aggregator_missing) pass
+  // through with their HTTP status preserved.
+  //
+  // No POST / PUT / PATCH / DELETE. No XMLHttpRequest. No sendBeacon.
+  // No push subscription. No backend write side-effect.
+  // =====================================================================
+  activityToday: () =>
+    getJsonEnvelope<ActivityTodayEnvelope>(
+      `${ACTIVITY_BASE}/today`,
+    ),
+  activityItemsList: (params?: ActivityItemsListParams) =>
+    getJsonEnvelope<ActivityItemsListEnvelope>(
+      `${ACTIVITY_BASE}/items${activityQs(params)}`,
+    ),
+  activityItemsDetail: (itemId: string) =>
+    getJsonEnvelope<ActivityItemsDetailEnvelope>(
+      `${ACTIVITY_BASE}/items/${encodeURIComponent(
+        boundedActivityItemId(itemId),
+      )}`,
+    ),
+  activityAgents: () =>
+    getJsonEnvelope<ActivityAgentsEnvelope>(
+      `${ACTIVITY_BASE}/agents`,
+    ),
+  activityArtifacts: () =>
+    getJsonEnvelope<ActivityArtifactsEnvelope>(
+      `${ACTIVITY_BASE}/artifacts`,
+    ),
+  activityInvariants: () =>
+    getJsonEnvelope<ActivityInvariantsEnvelope>(
+      `${ACTIVITY_BASE}/invariants`,
+    ),
 };
+
+// =========================================================================
+// v3.15.16.A15.B2.0d — Agent Activity Center read-only client types
+//
+// Closed-vocabulary unions and envelope shapes for the six AAC endpoints,
+// mirroring docs/governance/agent_activity_center_aggregator_schema.md
+// (§6-§10) and docs/governance/agent_activity_center_api_contract.md
+// (§3).
+// =========================================================================
+
+const ACTIVITY_BASE = "/api/agent-control/activity";
+const MAX_ACTIVITY_ITEM_ID_LEN = 128;
+
+function boundedActivityItemId(raw: string): string {
+  if (typeof raw !== "string") return "";
+  const safe = raw.replace(/[^A-Za-z0-9_.\-]/g, "");
+  return safe.slice(0, MAX_ACTIVITY_ITEM_ID_LEN);
+}
+
+const _ACTIVITY_QS_ALLOWED = [
+  "stage",
+  "owner_role",
+  "human_needed",
+  "updated_since",
+] as const;
+
+function activityQs(p?: ActivityItemsListParams): string {
+  if (!p) return "";
+  const parts: string[] = [];
+  for (const key of _ACTIVITY_QS_ALLOWED) {
+    const value = p[key];
+    if (value === undefined || value === null) continue;
+    if (value === "") continue;
+    parts.push(
+      `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`,
+    );
+  }
+  return parts.length ? `?${parts.join("&")}` : "";
+}
+
+export type ActivityStage =
+  | "discovered"
+  | "queued"
+  | "delegated"
+  | "planned"
+  | "dry_run_ready"
+  | "pr_proposed"
+  | "pr_opened"
+  | "ci_feedback"
+  | "needs_human"
+  | "merge_candidate"
+  | "done_blocked";
+
+export type ActivitySeverity = "info" | "warn" | "human" | "error";
+
+export type ActivityRisk = "low" | "medium" | "high" | "critical";
+
+export type ActivityFreshnessState =
+  | "fresh"
+  | "stale"
+  | "missing"
+  | "malformed";
+
+export type ActivityInvariantTone =
+  | "on"
+  | "off"
+  | "danger_off"
+  | "info"
+  | "unknown";
+
+export type ActivityArtifactGroup =
+  | "queue"
+  | "loops"
+  | "step5"
+  | "gates"
+  | "generated"
+  | "digest"
+  | "seed";
+
+export interface ActivityWorkItem {
+  item_id: string;
+  title: string;
+  source_kind: string;
+  source_path: string;
+  current_stage: ActivityStage;
+  owner_role: string;
+  risk: ActivityRisk;
+  human_needed: boolean;
+  latest_verdict: string;
+  next_action: string;
+  updated_at: string;
+  summary: string;
+  event_ids?: string[];
+}
+
+export interface ActivityAgentEvent {
+  event_id: string;
+  item_id: string;
+  timestamp: string;
+  agent_role: string;
+  module: string;
+  event_type: string;
+  summary: string;
+  decision: string;
+  reason: string;
+  artifact_path: string;
+  severity: ActivitySeverity;
+}
+
+export interface ActivityHumanAction {
+  action_id: string;
+  item_id: string;
+  severity: string;
+  title: string;
+  why_required: string;
+  required_phrase: string | null;
+  safe_to_ignore: boolean;
+  copy_only: boolean;
+  source_artifact_path: string;
+  suggested_role: string;
+  created_at: string;
+}
+
+export interface ActivityArtifactHealth {
+  path: string;
+  group: ActivityArtifactGroup;
+  fresh: boolean;
+  parse_ok: boolean;
+  row_count: number;
+  last_modified: string;
+  module_version: string;
+  has_summary: boolean;
+  parse_error?: string;
+  read_only_warning?: string;
+}
+
+export interface ActivityInvariantStatus {
+  key: string;
+  label: string;
+  value: boolean | string;
+  tone: ActivityInvariantTone;
+  detail: string;
+}
+
+export interface ActivityFreshness {
+  generated_at_utc?: string;
+  oldest_artifact_age_seconds?: number;
+  any_stale?: boolean;
+  any_malformed?: boolean;
+  background_refreshing?: boolean;
+  ttl_seconds_by_path?: Record<string, number>;
+}
+
+export interface ActivityCounts {
+  discovered?: number;
+  queued?: number;
+  delegated?: number;
+  planned?: number;
+  dry_run_ready?: number;
+  pr_proposed?: number;
+  pr_opened?: number;
+  ci_feedback?: number;
+  needs_human?: number;
+  merge_candidate?: number;
+  blocked?: number;
+  total_open?: number;
+}
+
+interface _ActivityEnvelopeBase {
+  kind: string;
+  schema_version: number;
+  module_version: string;
+  status: string;
+  reason?: string;
+  generated_at_utc?: string;
+  artifact_path?: string;
+  step5_implementation_allowed?: boolean;
+  step5_enabled_substage?: string;
+  level6_enabled?: boolean;
+}
+
+export interface ActivityTodayEnvelope extends _ActivityEnvelopeBase {
+  counts?: ActivityCounts;
+  needs_human?: ActivityWorkItem[];
+  merge_candidate?: ActivityWorkItem[];
+  ci_feedback?: ActivityWorkItem[];
+  blocked?: ActivityWorkItem[];
+  recent_events?: ActivityAgentEvent[];
+  freshness?: ActivityFreshness;
+  invariant_status?: ActivityInvariantStatus[];
+  section_totals?: {
+    needs_human?: { total_matching: number; truncated: boolean };
+    merge_candidate?: { total_matching: number; truncated: boolean };
+    ci_feedback?: { total_matching: number; truncated: boolean };
+    blocked?: { total_matching: number; truncated: boolean };
+  };
+}
+
+export interface ActivityItemsListParams {
+  stage?: ActivityStage;
+  owner_role?: string;
+  human_needed?: boolean;
+  updated_since?: string;
+}
+
+export interface ActivityItemsListEnvelope extends _ActivityEnvelopeBase {
+  work_items?: ActivityWorkItem[];
+  total_matching?: number;
+  truncated?: boolean;
+  freshness?: ActivityFreshness;
+}
+
+export interface ActivityItemsDetailEnvelope extends _ActivityEnvelopeBase {
+  work_item?: ActivityWorkItem;
+  agent_events?: ActivityAgentEvent[];
+  human_actions?: ActivityHumanAction[];
+  artefacts_referenced?: string[];
+  error?: string;
+  param?: string;
+  value?: string;
+  detail?: string;
+}
+
+export interface ActivityAgentMatrixRow {
+  role: string;
+  new: number;
+  planned: number;
+  blocked: number;
+  needs_human: number;
+  pr_ready: number;
+  last_action: ActivityAgentEvent | null;
+  total: number;
+}
+
+export interface ActivityAgentsEnvelope extends _ActivityEnvelopeBase {
+  rows?: ActivityAgentMatrixRow[];
+}
+
+export interface ActivityArtifactsEnvelope extends _ActivityEnvelopeBase {
+  artifact_health?: ActivityArtifactHealth[];
+}
+
+export interface ActivityInvariantsEnvelope extends _ActivityEnvelopeBase {
+  invariant_status?: ActivityInvariantStatus[];
+}

--- a/frontend/src/routes/AgentControl/AgentActivity.tsx
+++ b/frontend/src/routes/AgentControl/AgentActivity.tsx
@@ -1,0 +1,1250 @@
+/**
+ * AgentActivity — v3.15.16.A15.B2.0d
+ *
+ * Mobile-first read-only Agent Activity Center PWA surface, mounted by
+ * App.tsx and consuming the six existing GET endpoints via the AAC
+ * client methods on agentControlApi in
+ * frontend/src/api/agent_control.ts.
+ *
+ * Hard guarantees enforced by the companion test files:
+ *   - Read-only. Bottom-nav uses Link, not button. No rendered button
+ *     has an accessible name matching a decision verb.
+ *   - URL-synced active tab via useLocation pathname.
+ *   - All network calls go through the API client; no direct browser
+ *     network-API literal appears in this file.
+ *   - No push-subscription, no notification-permission, no
+ *     service-worker registration in this file.
+ *   - CopyOperatorPhraseButton writes to the clipboard only.
+ *   - Empty / not-available / malformed / offline envelopes render
+ *     visibly without breaking the page.
+ *   - Level 6 banner always renders permanently_disabled on the Safety
+ *     section.
+ *   - "No promotable candidates" copy renders for the empty
+ *     done_blocked stage on the Pipeline section.
+ *   - More section lists "Design Spec - documented in repo (deferred)"
+ *     as plain info text - no broken navigation link.
+ */
+
+import {
+  Routes,
+  Route,
+  Link,
+  Navigate,
+  useLocation,
+  useNavigate,
+  useParams,
+} from "react-router-dom";
+import { useCallback, useEffect, useState } from "react";
+
+import {
+  agentControlApi,
+  type ActivityAgentEvent,
+  type ActivityAgentMatrixRow,
+  type ActivityAgentsEnvelope,
+  type ActivityArtifactHealth,
+  type ActivityArtifactsEnvelope,
+  type ActivityHumanAction,
+  type ActivityInvariantStatus,
+  type ActivityInvariantsEnvelope,
+  type ActivityItemsDetailEnvelope,
+  type ActivityItemsListEnvelope,
+  type ActivityStage,
+  type ActivityTodayEnvelope,
+  type ActivityWorkItem,
+} from "../../api/agent_control";
+
+import "../../styles/agent_activity.css";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const STAGE_ORDER: readonly ActivityStage[] = [
+  "discovered",
+  "queued",
+  "delegated",
+  "planned",
+  "dry_run_ready",
+  "pr_proposed",
+  "pr_opened",
+  "ci_feedback",
+  "needs_human",
+  "merge_candidate",
+  "done_blocked",
+];
+
+const STAGE_LABEL: Record<ActivityStage, string> = {
+  discovered: "Discovered",
+  queued: "Queued",
+  delegated: "Delegated",
+  planned: "Planned",
+  dry_run_ready: "Dry-run Ready",
+  pr_proposed: "PR Proposed",
+  pr_opened: "PR Opened",
+  ci_feedback: "CI Feedback",
+  needs_human: "Needs Human",
+  merge_candidate: "Merge Candidate",
+  done_blocked: "Done / Blocked",
+};
+
+const READ_ONLY_FOOTER_NOTE =
+  "Read-only console. No approve, execute, merge, or deploy actions are available here.";
+
+// ---------------------------------------------------------------------------
+// Polling helper
+// ---------------------------------------------------------------------------
+
+function useAaCFetch<T>(
+  loader: () => Promise<T>,
+  intervalMs = 60_000,
+): { state: T | null; loading: boolean; refresh: () => void } {
+  const [state, setState] = useState<T | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [tick, setTick] = useState(0);
+
+  const refresh = useCallback(() => {
+    setTick((t) => t + 1);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    loader()
+      .then((value) => {
+        if (!cancelled) {
+          setState(value);
+          setLoading(false);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
+    const interval = setInterval(() => {
+      if (
+        typeof document !== "undefined" &&
+        document.visibilityState !== "visible"
+      ) {
+        return;
+      }
+      setTick((t) => t + 1);
+    }, intervalMs);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tick]);
+
+  return { state, loading, refresh };
+}
+
+// ---------------------------------------------------------------------------
+// Atoms (scoped to .aac via className)
+// ---------------------------------------------------------------------------
+
+function StaleDataBanner({
+  freshness,
+  status,
+}: {
+  freshness?: { any_stale?: boolean; oldest_artifact_age_seconds?: number };
+  status?: string;
+}) {
+  if (status && status !== "ok") {
+    return (
+      <div
+        className="aac__banner aac__banner--offline"
+        data-testid="aac-banner-offline"
+        role="status"
+        aria-live="polite"
+      >
+        Aggregator not available - showing last cached snapshot when possible.
+      </div>
+    );
+  }
+  if (freshness?.any_stale) {
+    const age = Math.max(0, freshness.oldest_artifact_age_seconds ?? 0);
+    const mins = Math.round(age / 60);
+    return (
+      <div
+        className="aac__banner aac__banner--stale"
+        data-testid="aac-banner-stale"
+        role="status"
+        aria-live="polite"
+      >
+        Stale snapshot - oldest upstream is {mins}m old.
+      </div>
+    );
+  }
+  return null;
+}
+
+function Badge({
+  tone,
+  children,
+  testid,
+}: {
+  tone: string;
+  children: React.ReactNode;
+  testid?: string;
+}) {
+  return (
+    <span
+      className={`aac__badge aac__badge--${tone}`}
+      data-testid={testid}
+    >
+      {children}
+    </span>
+  );
+}
+
+function StageBadge({ stage }: { stage: ActivityStage }) {
+  const tone =
+    stage === "needs_human"
+      ? "human"
+      : stage === "done_blocked"
+        ? "blocked"
+        : stage === "merge_candidate"
+          ? "merge"
+          : stage === "ci_feedback"
+            ? "blocked"
+            : stage === "planned"
+              ? "planned"
+              : "info";
+  return <Badge tone={tone} testid={`aac-stage-${stage}`}>{STAGE_LABEL[stage]}</Badge>;
+}
+
+function RiskBadge({ risk }: { risk: string }) {
+  const tone =
+    risk === "high" || risk === "critical"
+      ? "blocked"
+      : risk === "medium"
+        ? "human"
+        : "off";
+  return <Badge tone={tone}>{risk}</Badge>;
+}
+
+function FreshnessBadge({
+  fresh,
+  parse_ok,
+}: {
+  fresh: boolean;
+  parse_ok: boolean;
+}) {
+  if (!parse_ok) {
+    return <Badge tone="blocked" testid="aac-freshness-malformed">malformed</Badge>;
+  }
+  if (!fresh) {
+    return <Badge tone="stale" testid="aac-freshness-stale">stale</Badge>;
+  }
+  return <Badge tone="merge" testid="aac-freshness-fresh">fresh</Badge>;
+}
+
+function EmptyState({
+  title,
+  body,
+  testid,
+}: {
+  title: string;
+  body?: string;
+  testid?: string;
+}) {
+  return (
+    <div className="aac__empty" data-testid={testid}>
+      <div className="aac__empty-title">{title}</div>
+      {body && <div className="aac__empty-body">{body}</div>}
+    </div>
+  );
+}
+
+function CopyOperatorPhraseButton({ phrase }: { phrase: string }) {
+  const [copied, setCopied] = useState(false);
+  const onClick = useCallback(() => {
+    if (typeof navigator === "undefined") return;
+    if (!navigator.clipboard || !navigator.clipboard.writeText) return;
+    navigator.clipboard
+      .writeText(phrase)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1600);
+      })
+      .catch(() => {
+        // Silent — clipboard permissions denied. No fallback network call.
+      });
+  }, [phrase]);
+  return (
+    <button
+      type="button"
+      className="aac__copy-phrase"
+      data-testid="aac-copy-phrase"
+      onClick={onClick}
+      aria-label="Copy operator phrase to clipboard"
+    >
+      <code className="aac__copy-phrase-code">{phrase}</code>
+      <span className="aac__copy-phrase-label">
+        {copied ? "Copied" : "Copy phrase"}
+      </span>
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Top bar + bottom nav
+// ---------------------------------------------------------------------------
+
+function AacTopBar({
+  title,
+  sub,
+  showBack,
+}: {
+  title: string;
+  sub?: string;
+  showBack?: boolean;
+}) {
+  const navigate = useNavigate();
+  return (
+    <div className="aac__top-bar">
+      <div className="aac__top-bar-row">
+        {showBack && (
+          <button
+            type="button"
+            className="aac__back"
+            onClick={() => navigate(-1)}
+            aria-label="Back"
+            data-testid="aac-back"
+          >
+            ←
+          </button>
+        )}
+        <h1 className="aac__top-title">{title}</h1>
+      </div>
+      {sub && <div className="aac__top-sub">{sub}</div>}
+    </div>
+  );
+}
+
+function AacBottomNav() {
+  const { pathname } = useLocation();
+  const todayActive =
+    pathname === "/agent-control/activity" ||
+    pathname === "/agent-control/activity/" ||
+    pathname.startsWith("/agent-control/activity/today");
+  const inboxActive = pathname.startsWith("/agent-control/activity/inbox");
+  const pipelineActive = pathname.startsWith("/agent-control/activity/pipeline");
+  const agentsActive = pathname.startsWith("/agent-control/activity/agents");
+  const moreActive =
+    pathname.startsWith("/agent-control/activity/more") ||
+    pathname.startsWith("/agent-control/activity/artefacts") ||
+    pathname.startsWith("/agent-control/activity/safety");
+  return (
+    <nav
+      className="aac__bottom-nav"
+      aria-label="Primary"
+      data-testid="aac-bottom-nav"
+    >
+      <Link
+        to="today"
+        className="aac__nav-tab"
+        aria-current={todayActive ? "page" : undefined}
+        data-testid="aac-tab-today"
+      >
+        Today
+      </Link>
+      <Link
+        to="inbox"
+        className="aac__nav-tab"
+        aria-current={inboxActive ? "page" : undefined}
+        data-testid="aac-tab-inbox"
+      >
+        Inbox
+      </Link>
+      <Link
+        to="pipeline"
+        className="aac__nav-tab"
+        aria-current={pipelineActive ? "page" : undefined}
+        data-testid="aac-tab-pipeline"
+      >
+        Pipeline
+      </Link>
+      <Link
+        to="agents"
+        className="aac__nav-tab"
+        aria-current={agentsActive ? "page" : undefined}
+        data-testid="aac-tab-agents"
+      >
+        Agents
+      </Link>
+      <Link
+        to="more"
+        className="aac__nav-tab"
+        aria-current={moreActive ? "page" : undefined}
+        data-testid="aac-tab-more"
+      >
+        More
+      </Link>
+    </nav>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Today section
+// ---------------------------------------------------------------------------
+
+function MetricTile({
+  label,
+  value,
+  sub,
+  tone,
+  to,
+}: {
+  label: string;
+  value: number;
+  sub: string;
+  tone: string;
+  to: string;
+}) {
+  return (
+    <Link
+      to={to}
+      className={`aac__metric aac__metric--${tone}`}
+      data-testid={`aac-metric-${label.toLowerCase().replace(/\s+/g, "-")}`}
+    >
+      <div className="aac__metric-label">{label}</div>
+      <div className="aac__metric-value">{value}</div>
+      <div className="aac__metric-sub">{sub}</div>
+    </Link>
+  );
+}
+
+function CompactItemCard({ item }: { item: ActivityWorkItem }) {
+  return (
+    <Link
+      to={`items/${encodeURIComponent(item.item_id)}`}
+      className="aac__item-card"
+      data-testid={`aac-item-${item.item_id}`}
+    >
+      <div className="aac__item-row">
+        <StageBadge stage={item.current_stage} />
+        <RiskBadge risk={item.risk} />
+      </div>
+      <div className="aac__item-title">{item.title}</div>
+      <div className="aac__item-meta">
+        <span className="aac__mono">{item.owner_role}</span>
+        <span className="aac__muted"> · </span>
+        <span className="aac__mono aac__muted">{item.latest_verdict}</span>
+      </div>
+    </Link>
+  );
+}
+
+function SectionToday() {
+  const { state, loading } = useAaCFetch<ActivityTodayEnvelope>(() =>
+    agentControlApi.activityToday(),
+  );
+  if (loading && !state) {
+    return (
+      <section className="aac__section" data-testid="aac-section-today">
+        <AacTopBar title="Today" sub="Loading snapshot..." />
+        <div className="aac__skeleton" />
+      </section>
+    );
+  }
+  const env = state;
+  const status = env?.status ?? "not_available";
+  const counts = env?.counts ?? {};
+  return (
+    <section className="aac__section" data-testid="aac-section-today">
+      <AacTopBar title="Today" sub="Read-only cockpit" />
+      <StaleDataBanner freshness={env?.freshness} status={status} />
+      <div className="aac__metrics" data-testid="aac-metric-grid">
+        <MetricTile
+          label="Needs human"
+          value={counts.needs_human ?? 0}
+          sub="review required"
+          tone="human"
+          to="../inbox"
+        />
+        <MetricTile
+          label="Blocked"
+          value={counts.blocked ?? 0}
+          sub="by invariants / CI"
+          tone="blocked"
+          to="../pipeline"
+        />
+        <MetricTile
+          label="Merge candidate"
+          value={counts.merge_candidate ?? 0}
+          sub="operator-gated"
+          tone="merge"
+          to="../pipeline"
+        />
+        <MetricTile
+          label="CI feedback"
+          value={counts.ci_feedback ?? 0}
+          sub="re-runs / flake triage"
+          tone="blocked"
+          to="../pipeline"
+        />
+        <MetricTile
+          label="Planned"
+          value={counts.planned ?? 0}
+          sub="plans drafted"
+          tone="planned"
+          to="../pipeline"
+        />
+        <MetricTile
+          label="Dry-run ready"
+          value={counts.dry_run_ready ?? 0}
+          sub="candidates only"
+          tone="info"
+          to="../pipeline"
+        />
+      </div>
+      <h2 className="aac__section-title">Needs human</h2>
+      {(env?.needs_human?.length ?? 0) === 0 ? (
+        <EmptyState
+          title="Nothing needs you right now"
+          body="No items require an operator-go phrase or review."
+          testid="aac-today-needs-human-empty"
+        />
+      ) : (
+        <div className="aac__list">
+          {(env?.needs_human ?? []).slice(0, 3).map((w) => (
+            <CompactItemCard key={w.item_id} item={w} />
+          ))}
+        </div>
+      )}
+      {(env?.merge_candidate?.length ?? 0) > 0 && (
+        <>
+          <h2 className="aac__section-title">Merge candidates</h2>
+          <div className="aac__list">
+            {(env?.merge_candidate ?? []).map((w) => (
+              <CompactItemCard key={w.item_id} item={w} />
+            ))}
+          </div>
+          <div
+            className="aac__notice"
+            data-testid="aac-live-merge-disabled-notice"
+          >
+            Live merge is permanently disabled. Surfaced for operator
+            visibility only.
+          </div>
+        </>
+      )}
+      {(env?.ci_feedback?.length ?? 0) > 0 && (
+        <>
+          <h2 className="aac__section-title">CI feedback</h2>
+          <div className="aac__list">
+            {(env?.ci_feedback ?? []).map((w) => (
+              <CompactItemCard key={w.item_id} item={w} />
+            ))}
+          </div>
+        </>
+      )}
+      {(env?.blocked?.length ?? 0) > 0 && (
+        <>
+          <h2 className="aac__section-title">Blocked</h2>
+          <div className="aac__list">
+            {(env?.blocked ?? []).map((w) => (
+              <CompactItemCard key={w.item_id} item={w} />
+            ))}
+          </div>
+        </>
+      )}
+      <div className="aac__footer-note">{READ_ONLY_FOOTER_NOTE}</div>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Inbox section
+// ---------------------------------------------------------------------------
+
+type InboxFilter = "all" | "required" | "optional";
+
+function AttentionCard({
+  action,
+  reviewed,
+  onToggle,
+}: {
+  action: ActivityHumanAction;
+  reviewed: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <div
+      className="aac__attention-card"
+      data-testid={`aac-attention-${action.action_id}`}
+      data-reviewed={reviewed ? "true" : "false"}
+    >
+      <div className="aac__attention-row">
+        <Badge tone="human">severity {action.severity}</Badge>
+        <Badge tone="off">{action.suggested_role}</Badge>
+        {action.safe_to_ignore && <Badge tone="off">safe to ignore</Badge>}
+      </div>
+      <div className="aac__attention-title">{action.title}</div>
+      <div className="aac__attention-why">{action.why_required}</div>
+      {action.required_phrase && (
+        <CopyOperatorPhraseButton phrase={action.required_phrase} />
+      )}
+      <div className="aac__attention-meta">
+        <Link
+          to={`../items/${encodeURIComponent(action.item_id)}`}
+          className="aac__link"
+          data-testid={`aac-attention-trace-${action.action_id}`}
+        >
+          View trace
+        </Link>
+        <button
+          type="button"
+          className="aac__chip aac__chip--ghost"
+          onClick={onToggle}
+          aria-label={
+            reviewed
+              ? "Unmark reviewed (local-only)"
+              : "Mark reviewed (local-only)"
+          }
+          data-testid={`aac-mark-reviewed-${action.action_id}`}
+        >
+          {reviewed ? "Unmark reviewed" : "Mark reviewed"}
+        </button>
+      </div>
+      <div className="aac__mono aac__muted aac__attention-source">
+        {action.source_artifact_path}
+      </div>
+    </div>
+  );
+}
+
+function SectionInbox() {
+  const { state, loading } = useAaCFetch<ActivityItemsListEnvelope>(() =>
+    agentControlApi.activityItemsList({ human_needed: true }),
+  );
+  const [filter, setFilter] = useState<InboxFilter>("all");
+  const [reviewed, setReviewed] = useState<Record<string, boolean>>({});
+
+  if (loading && !state) {
+    return (
+      <section className="aac__section" data-testid="aac-section-inbox">
+        <AacTopBar title="Approval Inbox" sub="Loading..." />
+        <div className="aac__skeleton" />
+      </section>
+    );
+  }
+
+  const items = state?.work_items ?? [];
+  // Synthesize HumanAction-like records from work items where human_needed=true.
+  const actions: ActivityHumanAction[] = items
+    .filter((w) => w.human_needed)
+    .map((w) => ({
+      action_id: `ha_${w.item_id}`,
+      item_id: w.item_id,
+      severity: w.risk,
+      title: w.title,
+      why_required: w.summary,
+      // Required phrase is sourced from upstream only via Trace detail;
+      // the list endpoint does not include human_actions[]. This inbox
+      // surfaces the work-item list filtered by human_needed; the
+      // operator opens the Trace view to see the phrase if any.
+      required_phrase: null,
+      safe_to_ignore: false,
+      copy_only: true,
+      source_artifact_path: w.source_path,
+      suggested_role: w.owner_role,
+      created_at: w.updated_at,
+    }));
+  const filtered = actions.filter((a) => {
+    if (filter === "all") return true;
+    if (filter === "required") return !a.safe_to_ignore;
+    return a.safe_to_ignore;
+  });
+
+  return (
+    <section className="aac__section" data-testid="aac-section-inbox">
+      <AacTopBar
+        title="Approval Inbox"
+        sub="Operator attention items - copy-only"
+      />
+      <StaleDataBanner
+        freshness={state?.freshness}
+        status={state?.status}
+      />
+      <div className="aac__filter-pills" role="tablist" aria-label="Filter">
+        {(
+          [
+            { id: "all" as const, label: "All", n: actions.length },
+            {
+              id: "required" as const,
+              label: "Required",
+              n: actions.filter((a) => !a.safe_to_ignore).length,
+            },
+            {
+              id: "optional" as const,
+              label: "Informational",
+              n: actions.filter((a) => a.safe_to_ignore).length,
+            },
+          ]
+        ).map((f) => (
+          <button
+            key={f.id}
+            type="button"
+            role="tab"
+            aria-selected={filter === f.id}
+            className="aac__chip"
+            onClick={() => setFilter(f.id)}
+            data-testid={`aac-inbox-filter-${f.id}`}
+          >
+            {f.label} <span className="aac__mono aac__muted">({f.n})</span>
+          </button>
+        ))}
+      </div>
+      {filtered.length === 0 ? (
+        <EmptyState
+          title="Inbox zero"
+          body="No operator attention items right now."
+          testid="aac-inbox-empty"
+        />
+      ) : (
+        <div className="aac__list">
+          {filtered.map((a) => (
+            <AttentionCard
+              key={a.action_id}
+              action={a}
+              reviewed={!!reviewed[a.action_id]}
+              onToggle={() =>
+                setReviewed((r) => ({
+                  ...r,
+                  [a.action_id]: !r[a.action_id],
+                }))
+              }
+            />
+          ))}
+        </div>
+      )}
+      <div className="aac__footer-note">
+        <strong>Mark reviewed</strong> is local-only - it dims the card in
+        this session. It does not approve or unblock any backend action.
+      </div>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline section
+// ---------------------------------------------------------------------------
+
+function SectionPipeline() {
+  const { state, loading } = useAaCFetch<ActivityItemsListEnvelope>(() =>
+    agentControlApi.activityItemsList(),
+  );
+  const [activeStage, setActiveStage] = useState<ActivityStage>("needs_human");
+
+  if (loading && !state) {
+    return (
+      <section className="aac__section" data-testid="aac-section-pipeline">
+        <AacTopBar title="Pipeline" sub="Loading..." />
+        <div className="aac__skeleton" />
+      </section>
+    );
+  }
+
+  const items = state?.work_items ?? [];
+  const itemsAt = (s: ActivityStage) =>
+    items.filter((w) => w.current_stage === s);
+  const activeItems = itemsAt(activeStage);
+
+  return (
+    <section className="aac__section" data-testid="aac-section-pipeline">
+      <AacTopBar
+        title="Pipeline"
+        sub="Roadmap to queue to delegation to merge"
+      />
+      <StaleDataBanner
+        freshness={state?.freshness}
+        status={state?.status}
+      />
+      <div
+        className="aac__chip-row"
+        role="tablist"
+        aria-label="Stages"
+        data-testid="aac-pipeline-chips"
+      >
+        {STAGE_ORDER.map((s) => {
+          const n = itemsAt(s).length;
+          return (
+            <button
+              key={s}
+              type="button"
+              role="tab"
+              aria-selected={activeStage === s}
+              className="aac__chip"
+              onClick={() => setActiveStage(s)}
+              data-testid={`aac-pipeline-chip-${s}`}
+            >
+              {STAGE_LABEL[s]}{" "}
+              <span className="aac__mono aac__muted">({n})</span>
+            </button>
+          );
+        })}
+      </div>
+      {activeItems.length === 0 ? (
+        <EmptyState
+          title={
+            activeStage === "done_blocked"
+              ? "No promotable candidates"
+              : "—"
+          }
+          testid={`aac-pipeline-empty-${activeStage}`}
+        />
+      ) : (
+        <div className="aac__list">
+          {activeItems.map((w) => (
+            <CompactItemCard key={w.item_id} item={w} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Agents section
+// ---------------------------------------------------------------------------
+
+function AgentRoleRow({ row }: { row: ActivityAgentMatrixRow }) {
+  return (
+    <div
+      className="aac__agent-row"
+      data-testid={`aac-agent-${row.role}`}
+    >
+      <div className="aac__agent-role">
+        <span className="aac__mono">{row.role}</span>
+      </div>
+      <div className="aac__agent-stats">
+        <span className="aac__agent-stat">
+          <span className="aac__agent-stat-label">new</span>
+          <span className="aac__mono">{row.new}</span>
+        </span>
+        <span className="aac__agent-stat">
+          <span className="aac__agent-stat-label">planned</span>
+          <span className="aac__mono">{row.planned}</span>
+        </span>
+        <span className="aac__agent-stat">
+          <span className="aac__agent-stat-label">blocked</span>
+          <span className="aac__mono">{row.blocked}</span>
+        </span>
+        <span className="aac__agent-stat">
+          <span className="aac__agent-stat-label">human</span>
+          <span className="aac__mono">{row.needs_human}</span>
+        </span>
+        <span className="aac__agent-stat">
+          <span className="aac__agent-stat-label">PR-ready</span>
+          <span className="aac__mono">{row.pr_ready}</span>
+        </span>
+      </div>
+      {row.last_action && (
+        <div className="aac__agent-last">
+          <span className="aac__mono aac__muted">
+            {row.last_action.module}
+          </span>{" "}
+          <span className="aac__muted">- {row.last_action.event_type}</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SectionAgents() {
+  const { state, loading } = useAaCFetch<ActivityAgentsEnvelope>(() =>
+    agentControlApi.activityAgents(),
+  );
+  if (loading && !state) {
+    return (
+      <section className="aac__section" data-testid="aac-section-agents">
+        <AacTopBar title="Agents" sub="Loading..." />
+        <div className="aac__skeleton" />
+      </section>
+    );
+  }
+  const rows = state?.rows ?? [];
+  return (
+    <section className="aac__section" data-testid="aac-section-agents">
+      <AacTopBar title="Agents" sub="Role activity matrix" />
+      <StaleDataBanner status={state?.status} />
+      {rows.length === 0 ? (
+        <EmptyState
+          title="No agent activity"
+          testid="aac-agents-empty"
+        />
+      ) : (
+        <div className="aac__list">
+          {rows.map((r) => (
+            <AgentRoleRow key={r.role} row={r} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Artefacts section
+// ---------------------------------------------------------------------------
+
+function ArtefactRow({ row }: { row: ActivityArtifactHealth }) {
+  return (
+    <div
+      className="aac__artefact-row"
+      data-testid={`aac-artefact-${row.path}`}
+    >
+      <div className="aac__artefact-path">
+        <span className="aac__mono">{row.path}</span>
+      </div>
+      <div className="aac__artefact-meta">
+        <span className="aac__mono aac__muted">
+          {row.parse_ok ? `${row.row_count} rows` : (row.parse_error ?? "parse error")}
+        </span>
+        {row.module_version && (
+          <span className="aac__mono aac__muted">
+            {" · "}
+            {row.module_version}
+          </span>
+        )}
+        {row.read_only_warning && (
+          <span
+            className="aac__read-only-chip"
+            data-testid={`aac-read-only-${row.path}`}
+          >
+            {row.read_only_warning}
+          </span>
+        )}
+      </div>
+      <FreshnessBadge fresh={row.fresh} parse_ok={row.parse_ok} />
+    </div>
+  );
+}
+
+function SectionArtefacts() {
+  const { state, loading } = useAaCFetch<ActivityArtifactsEnvelope>(() =>
+    agentControlApi.activityArtifacts(),
+  );
+  if (loading && !state) {
+    return (
+      <section
+        className="aac__section"
+        data-testid="aac-section-artefacts"
+      >
+        <AacTopBar title="Artefact Explorer" sub="Loading..." />
+        <div className="aac__skeleton" />
+      </section>
+    );
+  }
+  const rows = state?.artifact_health ?? [];
+  return (
+    <section className="aac__section" data-testid="aac-section-artefacts">
+      <AacTopBar
+        title="Artefact Explorer"
+        sub="Read-only audit"
+        showBack
+      />
+      <StaleDataBanner status={state?.status} />
+      {rows.length === 0 ? (
+        <EmptyState
+          title="No artefacts"
+          body="The aggregator has not catalogued any upstreams."
+          testid="aac-artefacts-empty"
+        />
+      ) : (
+        <div className="aac__list">
+          {rows.map((r) => (
+            <ArtefactRow key={r.path} row={r} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Safety section
+// ---------------------------------------------------------------------------
+
+function InvariantCard({ row }: { row: ActivityInvariantStatus }) {
+  return (
+    <div
+      className={`aac__invariant aac__invariant--${row.tone}`}
+      data-testid={`aac-invariant-${row.key}`}
+    >
+      <div className="aac__invariant-label">{row.label}</div>
+      <div className="aac__invariant-value aac__mono">{String(row.value)}</div>
+      <div className="aac__invariant-detail">{row.detail}</div>
+    </div>
+  );
+}
+
+function SectionSafety() {
+  const { state, loading } = useAaCFetch<ActivityInvariantsEnvelope>(() =>
+    agentControlApi.activityInvariants(),
+  );
+  if (loading && !state) {
+    return (
+      <section className="aac__section" data-testid="aac-section-safety">
+        <AacTopBar title="System Safety" sub="Loading..." />
+        <div className="aac__skeleton" />
+      </section>
+    );
+  }
+  const rows = state?.invariant_status ?? [];
+  const level6 = rows.find((r) => r.key === "level_6");
+  return (
+    <section className="aac__section" data-testid="aac-section-safety">
+      <AacTopBar
+        title="System Safety"
+        sub="Invariant posture - always-on"
+        showBack
+      />
+      <StaleDataBanner status={state?.status} />
+      <div
+        className="aac__l6-banner"
+        data-testid="aac-l6-banner"
+        role="alert"
+      >
+        <div className="aac__l6-title">Level 6 - permanently disabled</div>
+        <div className="aac__l6-body">
+          Level 6 capabilities cannot be re-enabled by this UI or any
+          agent. Build-time invariant per ADR-015 Doctrine 1. Surfaced
+          here so the operator can confirm posture.
+        </div>
+      </div>
+      <div className="aac__invariant-grid">
+        {rows
+          .filter((r) => r.key !== "level_6")
+          .map((r) => (
+            <InvariantCard key={r.key} row={r} />
+          ))}
+        {level6 && <InvariantCard row={level6} />}
+      </div>
+      <h2 className="aac__section-title">What this UI cannot do</h2>
+      <ul className="aac__cant-do-list">
+        <li>Approve or execute any gated operation</li>
+        <li>Admit any work to the queue or generated lane</li>
+        <li>Open, merge, or close a pull request</li>
+        <li>Trigger or roll back a deploy</li>
+        <li>Flip step5_implementation_allowed</li>
+        <li>Mint or verify tokens</li>
+        <li>Write to seed JSONL files</li>
+        <li>Re-enable Level 6</li>
+      </ul>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// More section
+// ---------------------------------------------------------------------------
+
+function SectionMore() {
+  return (
+    <section className="aac__section" data-testid="aac-section-more">
+      <AacTopBar title="More" sub="Drilldown views" />
+      <div className="aac__list">
+        <Link
+          to="../artefacts"
+          className="aac__more-row"
+          data-testid="aac-more-artefacts"
+        >
+          <div className="aac__more-row-title">Artefact Explorer</div>
+          <div className="aac__more-row-body">
+            Grouped path list with freshness, row counts, raw JSON.
+          </div>
+        </Link>
+        <Link
+          to="../safety"
+          className="aac__more-row"
+          data-testid="aac-more-safety"
+        >
+          <div className="aac__more-row-title">System Safety</div>
+          <div className="aac__more-row-body">
+            Invariant posture, Level 6 banner, what this UI cannot do.
+          </div>
+        </Link>
+        <div
+          className="aac__more-row aac__more-row--deferred"
+          data-testid="aac-more-spec-deferred"
+          aria-disabled="true"
+        >
+          <div className="aac__more-row-title">Design Spec</div>
+          <div className="aac__more-row-body">
+            Design Spec - documented in repo (deferred)
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Trace detail section
+// ---------------------------------------------------------------------------
+
+function TimelineNode({ event }: { event: ActivityAgentEvent }) {
+  return (
+    <li
+      className={`aac__timeline-node aac__timeline-node--${event.severity}`}
+      data-testid={`aac-event-${event.event_id}`}
+    >
+      <div className="aac__timeline-head">
+        <span className="aac__mono aac__muted">{event.timestamp}</span>
+        <span className="aac__mono">{event.module}</span>
+      </div>
+      <div className="aac__timeline-summary">{event.summary}</div>
+      <div className="aac__timeline-reason aac__muted">{event.reason}</div>
+      <div className="aac__mono aac__muted aac__timeline-art">
+        {event.artifact_path}
+      </div>
+    </li>
+  );
+}
+
+function SectionTrace() {
+  const { itemId: raw } = useParams<{ itemId: string }>();
+  const safe = (raw ?? "").replace(/[^A-Za-z0-9_.\-]/g, "").slice(0, 128);
+  const { state, loading } = useAaCFetch<ActivityItemsDetailEnvelope>(
+    () => agentControlApi.activityItemsDetail(safe),
+  );
+
+  if (!safe) {
+    return (
+      <section className="aac__section" data-testid="aac-section-trace">
+        <AacTopBar title="Trace" showBack />
+        <EmptyState
+          title="Invalid item id"
+          body="The trace path could not be parsed."
+          testid="aac-trace-invalid"
+        />
+      </section>
+    );
+  }
+
+  if (loading && !state) {
+    return (
+      <section className="aac__section" data-testid="aac-section-trace">
+        <AacTopBar title="Trace" sub="Loading..." showBack />
+        <div className="aac__skeleton" />
+      </section>
+    );
+  }
+
+  if (state?.status !== "ok" || !state.work_item) {
+    return (
+      <section className="aac__section" data-testid="aac-section-trace">
+        <AacTopBar title="Trace" showBack />
+        <EmptyState
+          title="Not in last snapshot"
+          body="This item is not present in the latest aggregator snapshot."
+          testid="aac-trace-not-found"
+        />
+      </section>
+    );
+  }
+
+  const wi = state.work_item;
+  const events = state.agent_events ?? [];
+  const actions = state.human_actions ?? [];
+  return (
+    <section className="aac__section" data-testid="aac-section-trace">
+      <AacTopBar
+        title={wi.title}
+        sub={`${wi.source_kind} - ${wi.updated_at}`}
+        showBack
+      />
+      <div
+        className="aac__trace-header"
+        data-testid="aac-trace-header"
+      >
+        <div className="aac__attention-row">
+          <StageBadge stage={wi.current_stage} />
+          <RiskBadge risk={wi.risk} />
+          {wi.human_needed && <Badge tone="human">needs human</Badge>}
+        </div>
+        <div className="aac__trace-summary">{wi.summary}</div>
+        <dl className="aac__trace-meta">
+          <div>
+            <dt>item_id</dt>
+            <dd className="aac__mono">{wi.item_id}</dd>
+          </div>
+          <div>
+            <dt>owner_role</dt>
+            <dd className="aac__mono">{wi.owner_role}</dd>
+          </div>
+          <div>
+            <dt>source_path</dt>
+            <dd className="aac__mono">{wi.source_path}</dd>
+          </div>
+          <div>
+            <dt>latest_verdict</dt>
+            <dd className="aac__mono">{wi.latest_verdict}</dd>
+          </div>
+          <div>
+            <dt>next_action</dt>
+            <dd>{wi.next_action}</dd>
+          </div>
+        </dl>
+        {actions.map(
+          (a) =>
+            a.required_phrase && (
+              <CopyOperatorPhraseButton
+                key={a.action_id}
+                phrase={a.required_phrase}
+              />
+            ),
+        )}
+      </div>
+      <h2 className="aac__section-title">Event timeline</h2>
+      {events.length === 0 ? (
+        <EmptyState
+          title="No timeline events yet"
+          body="This item has been discovered but no agent has acted on it."
+          testid="aac-trace-events-empty"
+        />
+      ) : (
+        <ol className="aac__timeline">
+          {events.map((e) => (
+            <TimelineNode key={e.event_id} event={e} />
+          ))}
+        </ol>
+      )}
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Root
+// ---------------------------------------------------------------------------
+
+export function AgentActivity() {
+  return (
+    <div
+      className="aac"
+      data-theme="dark"
+      data-testid="aac-root"
+    >
+      <main className="aac__body">
+        <Routes>
+          <Route index element={<SectionToday />} />
+          <Route path="today" element={<SectionToday />} />
+          <Route path="inbox" element={<SectionInbox />} />
+          <Route path="pipeline" element={<SectionPipeline />} />
+          <Route path="agents" element={<SectionAgents />} />
+          <Route path="more" element={<SectionMore />} />
+          <Route path="artefacts" element={<SectionArtefacts />} />
+          <Route path="safety" element={<SectionSafety />} />
+          <Route path="items/:itemId" element={<SectionTrace />} />
+          <Route path="*" element={<Navigate to="today" replace />} />
+        </Routes>
+      </main>
+      <AacBottomNav />
+    </div>
+  );
+}

--- a/frontend/src/styles/agent_activity.css
+++ b/frontend/src/styles/agent_activity.css
@@ -1,0 +1,596 @@
+/*
+ * agent_activity.css — v3.15.16.A15.B2.0d
+ *
+ * All selectors are scoped under .aac (the AgentActivity root). No
+ * global selectors, no body/html/:root/global button or anchor, no
+ * resets. This file is imported only by AgentActivity.tsx.
+ */
+
+.aac {
+  /* OKLCH palette (dark default) */
+  --aac-bg:          oklch(0.16 0.005 240);
+  --aac-bg-2:        oklch(0.185 0.006 240);
+  --aac-surface:     oklch(0.215 0.007 240);
+  --aac-surface-2:   oklch(0.245 0.008 240);
+  --aac-border:      oklch(0.30 0.008 240);
+  --aac-border-2:    oklch(0.36 0.009 240);
+  --aac-text:        oklch(0.95 0.003 240);
+  --aac-text-2:      oklch(0.78 0.006 240);
+  --aac-text-3:      oklch(0.58 0.010 240);
+  --aac-text-4:      oklch(0.46 0.010 240);
+  --aac-accent:      oklch(0.74 0.10 235);
+  --aac-human:       oklch(0.80 0.13 70);
+  --aac-blocked:     oklch(0.68 0.13 25);
+  --aac-danger:      oklch(0.65 0.20 25);
+  --aac-merge:       oklch(0.75 0.10 155);
+  --aac-planned:     oklch(0.74 0.08 280);
+  --aac-stale:       oklch(0.70 0.06 60);
+
+  --aac-radius-sm:   6px;
+  --aac-radius:      10px;
+  --aac-radius-lg:   14px;
+
+  /* Layout */
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background: var(--aac-bg);
+  color: var(--aac-text);
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI",
+    Helvetica, Arial, sans-serif;
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.aac[data-theme="light"] {
+  --aac-bg:        oklch(0.985 0.002 240);
+  --aac-bg-2:      oklch(0.965 0.003 240);
+  --aac-surface:   oklch(1.00 0 0);
+  --aac-surface-2: oklch(0.975 0.003 240);
+  --aac-border:    oklch(0.90 0.005 240);
+  --aac-border-2:  oklch(0.83 0.006 240);
+  --aac-text:      oklch(0.20 0.008 240);
+  --aac-text-2:    oklch(0.35 0.010 240);
+  --aac-text-3:    oklch(0.50 0.010 240);
+  --aac-text-4:    oklch(0.62 0.010 240);
+}
+
+.aac__body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 14px 16px 90px;
+}
+
+.aac__top-bar {
+  padding: 14px 16px 8px;
+}
+.aac__top-bar-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.aac__top-title {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+}
+.aac__top-sub {
+  margin-top: 4px;
+  color: var(--aac-text-3);
+  font-size: 12.5px;
+}
+
+.aac__back {
+  background: transparent;
+  border: 1px solid var(--aac-border);
+  color: var(--aac-text);
+  width: 30px;
+  height: 30px;
+  border-radius: var(--aac-radius-sm);
+  cursor: pointer;
+}
+
+.aac__bottom-nav {
+  position: sticky;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 64px;
+  display: flex;
+  align-items: stretch;
+  justify-content: space-around;
+  padding: 6px 6px 12px;
+  background: color-mix(in oklch, var(--aac-bg) 90%, transparent);
+  border-top: 1px solid var(--aac-border);
+  backdrop-filter: saturate(160%) blur(18px);
+  -webkit-backdrop-filter: saturate(160%) blur(18px);
+}
+
+.aac__nav-tab {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--aac-text-3);
+  text-decoration: none;
+  font-size: 12px;
+  font-weight: 500;
+  border-radius: var(--aac-radius-sm);
+}
+.aac__nav-tab[aria-current="page"] {
+  color: var(--aac-text);
+  background: var(--aac-surface);
+  box-shadow: inset 0 -2px 0 0 var(--aac-accent);
+}
+
+.aac__section {
+  display: flex;
+  flex-direction: column;
+}
+.aac__section-title {
+  margin: 18px 0 8px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--aac-text-3);
+}
+
+.aac__skeleton {
+  height: 200px;
+  background: var(--aac-surface-2);
+  border-radius: var(--aac-radius);
+  animation: aacSkel 1.4s ease-in-out infinite;
+}
+@keyframes aacSkel {
+  0% { opacity: 0.35; }
+  50% { opacity: 0.6; }
+  100% { opacity: 0.35; }
+}
+
+.aac__banner {
+  padding: 8px 12px;
+  border-radius: var(--aac-radius-sm);
+  font-size: 12px;
+  margin-bottom: 10px;
+}
+.aac__banner--stale {
+  background: color-mix(in oklch, var(--aac-stale) 12%, var(--aac-surface));
+  border: 1px solid color-mix(in oklch, var(--aac-stale) 30%, var(--aac-border));
+  color: var(--aac-stale);
+}
+.aac__banner--offline {
+  background: color-mix(in oklch, var(--aac-blocked) 10%, var(--aac-surface));
+  border: 1px solid color-mix(in oklch, var(--aac-blocked) 30%, var(--aac-border));
+  color: var(--aac-blocked);
+}
+
+.aac__metrics {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  margin: 6px 0 4px;
+}
+.aac__metric {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+  background: var(--aac-surface);
+  border: 1px solid var(--aac-border);
+  border-left: 3px solid var(--aac-accent);
+  border-radius: var(--aac-radius);
+  padding: 12px;
+  min-height: 88px;
+}
+.aac__metric--human { border-left-color: var(--aac-human); }
+.aac__metric--blocked { border-left-color: var(--aac-blocked); }
+.aac__metric--merge { border-left-color: var(--aac-merge); }
+.aac__metric--planned { border-left-color: var(--aac-planned); }
+.aac__metric--info { border-left-color: var(--aac-accent); }
+.aac__metric-label {
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--aac-text-3);
+}
+.aac__metric-value {
+  font-size: 22px;
+  font-weight: 600;
+  margin-top: 4px;
+  color: var(--aac-text);
+}
+.aac__metric-sub {
+  font-size: 11px;
+  color: var(--aac-text-3);
+  margin-top: 4px;
+}
+
+.aac__notice {
+  margin-top: 8px;
+  font-size: 11.5px;
+  color: var(--aac-text-3);
+  font-style: italic;
+}
+
+.aac__list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.aac__item-card {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 12px;
+  background: var(--aac-surface);
+  border: 1px solid var(--aac-border);
+  border-radius: var(--aac-radius-sm);
+  text-decoration: none;
+  color: inherit;
+}
+.aac__item-row {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.aac__item-title {
+  font-size: 13px;
+  font-weight: 500;
+}
+.aac__item-meta {
+  font-size: 11px;
+  color: var(--aac-text-3);
+}
+
+.aac__badge {
+  display: inline-flex;
+  align-items: center;
+  height: 20px;
+  padding: 0 8px;
+  border-radius: var(--aac-radius-sm);
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 11px;
+  font-weight: 500;
+  background: var(--aac-surface-2);
+  color: var(--aac-text-2);
+  border: 1px solid var(--aac-border);
+}
+.aac__badge--info { color: var(--aac-accent); }
+.aac__badge--human { color: var(--aac-human); border-color: color-mix(in oklch, var(--aac-human) 35%, var(--aac-border)); }
+.aac__badge--blocked { color: var(--aac-blocked); border-color: color-mix(in oklch, var(--aac-blocked) 32%, var(--aac-border)); }
+.aac__badge--merge { color: var(--aac-merge); border-color: color-mix(in oklch, var(--aac-merge) 32%, var(--aac-border)); }
+.aac__badge--planned { color: var(--aac-planned); border-color: color-mix(in oklch, var(--aac-planned) 32%, var(--aac-border)); }
+.aac__badge--stale { color: var(--aac-stale); border-color: color-mix(in oklch, var(--aac-stale) 30%, var(--aac-border)); }
+.aac__badge--off { color: var(--aac-text-3); }
+
+.aac__filter-pills {
+  display: flex;
+  gap: 6px;
+  margin: 12px 0;
+}
+.aac__chip-row {
+  display: flex;
+  gap: 6px;
+  overflow-x: auto;
+  padding: 10px 0;
+  margin: 0 -16px;
+  padding-left: 16px;
+  padding-right: 16px;
+  scrollbar-width: none;
+}
+.aac__chip-row::-webkit-scrollbar { display: none; }
+.aac__chip {
+  flex-shrink: 0;
+  height: 30px;
+  padding: 0 11px;
+  border-radius: 9px;
+  border: 1px solid var(--aac-border);
+  background: var(--aac-surface-2);
+  color: var(--aac-text-2);
+  font-size: 12px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.aac__chip[aria-selected="true"] {
+  background: var(--aac-surface);
+  color: var(--aac-text);
+  border-color: var(--aac-border-2);
+}
+.aac__chip--ghost {
+  background: transparent;
+}
+
+.aac__empty {
+  padding: 36px 16px;
+  text-align: center;
+  color: var(--aac-text-3);
+}
+.aac__empty-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--aac-text-2);
+}
+.aac__empty-body {
+  margin-top: 4px;
+  font-size: 13px;
+}
+
+.aac__attention-card {
+  padding: 14px;
+  border: 1px solid var(--aac-border);
+  border-left: 3px solid var(--aac-human);
+  border-radius: var(--aac-radius);
+  background: var(--aac-surface);
+}
+.aac__attention-card[data-reviewed="true"] {
+  opacity: 0.55;
+}
+.aac__attention-row {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-bottom: 6px;
+}
+.aac__attention-title {
+  font-size: 14px;
+  font-weight: 500;
+  margin: 4px 0 4px;
+}
+.aac__attention-why {
+  font-size: 12.5px;
+  color: var(--aac-text-2);
+  margin-bottom: 8px;
+}
+.aac__attention-meta {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-top: 6px;
+}
+.aac__attention-source {
+  margin-top: 6px;
+  font-size: 11px;
+}
+
+.aac__copy-phrase {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  border: 1px dashed color-mix(in oklch, var(--aac-human) 50%, var(--aac-border));
+  border-radius: var(--aac-radius-sm);
+  background: color-mix(in oklch, var(--aac-human) 8%, var(--aac-surface-2));
+  cursor: pointer;
+  padding: 0;
+  margin: 6px 0;
+  color: var(--aac-text);
+}
+.aac__copy-phrase-code {
+  flex: 1;
+  padding: 8px 12px;
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 11.5px;
+  white-space: nowrap;
+  overflow-x: auto;
+}
+.aac__copy-phrase-label {
+  padding: 0 12px;
+  font-size: 11.5px;
+  color: var(--aac-human);
+  border-left: 1px dashed color-mix(in oklch, var(--aac-human) 50%, var(--aac-border));
+}
+
+.aac__link {
+  color: var(--aac-accent);
+  text-decoration: none;
+  font-size: 12.5px;
+}
+
+.aac__agent-row {
+  padding: 10px 12px;
+  background: var(--aac-surface);
+  border: 1px solid var(--aac-border);
+  border-radius: var(--aac-radius-sm);
+}
+.aac__agent-role { font-size: 13px; font-weight: 500; }
+.aac__agent-stats {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 6px;
+  margin-top: 8px;
+}
+.aac__agent-stat {
+  text-align: center;
+  background: var(--aac-surface-2);
+  border: 1px solid var(--aac-border);
+  border-radius: var(--aac-radius-sm);
+  padding: 4px 6px;
+  font-size: 11px;
+}
+.aac__agent-stat-label {
+  display: block;
+  font-size: 9px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--aac-text-4);
+}
+.aac__agent-last {
+  margin-top: 6px;
+  font-size: 11px;
+  color: var(--aac-text-3);
+}
+
+.aac__artefact-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--aac-border);
+}
+.aac__artefact-path { font-size: 12px; }
+.aac__artefact-meta { font-size: 11px; color: var(--aac-text-3); }
+
+.aac__read-only-chip {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: color-mix(in oklch, var(--aac-stale) 12%, var(--aac-surface));
+  border: 1px solid color-mix(in oklch, var(--aac-stale) 30%, var(--aac-border));
+  color: var(--aac-stale);
+  font-size: 10.5px;
+}
+
+.aac__l6-banner {
+  padding: 14px;
+  border-radius: var(--aac-radius);
+  background: color-mix(in oklch, var(--aac-danger) 8%, var(--aac-surface));
+  border: 1px solid color-mix(in oklch, var(--aac-danger) 30%, var(--aac-border));
+  margin: 8px 0 16px;
+}
+.aac__l6-title {
+  color: var(--aac-danger);
+  font-weight: 600;
+  font-size: 14px;
+  margin-bottom: 4px;
+}
+.aac__l6-body { font-size: 12.5px; color: var(--aac-text-2); line-height: 1.45; }
+
+.aac__invariant-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+.aac__invariant {
+  padding: 12px;
+  background: var(--aac-surface);
+  border: 1px solid var(--aac-border);
+  border-radius: var(--aac-radius);
+}
+.aac__invariant--danger_off {
+  border-color: color-mix(in oklch, var(--aac-danger) 30%, var(--aac-border));
+}
+.aac__invariant-label {
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--aac-text-3);
+}
+.aac__invariant-value {
+  font-size: 14px;
+  font-weight: 500;
+  margin-top: 4px;
+}
+.aac__invariant--on .aac__invariant-value { color: var(--aac-merge); }
+.aac__invariant--off .aac__invariant-value { color: var(--aac-text-3); }
+.aac__invariant--danger_off .aac__invariant-value { color: var(--aac-danger); }
+.aac__invariant-detail {
+  margin-top: 4px;
+  font-size: 11.5px;
+  color: var(--aac-text-3);
+}
+
+.aac__cant-do-list {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--aac-text-2);
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.aac__more-row {
+  display: block;
+  padding: 12px 14px;
+  background: var(--aac-surface);
+  border: 1px solid var(--aac-border);
+  border-radius: var(--aac-radius);
+  text-decoration: none;
+  color: inherit;
+}
+.aac__more-row-title { font-weight: 500; font-size: 14px; }
+.aac__more-row-body { color: var(--aac-text-3); font-size: 12px; margin-top: 4px; }
+.aac__more-row--deferred {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.aac__trace-header {
+  padding: 14px 16px;
+  background: var(--aac-bg-2);
+  border-bottom: 1px solid var(--aac-border);
+}
+.aac__trace-summary {
+  margin-top: 8px;
+  font-size: 13px;
+  color: var(--aac-text-2);
+}
+.aac__trace-meta {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 8px 14px;
+  margin-top: 10px;
+  font-size: 12px;
+}
+.aac__trace-meta dt {
+  color: var(--aac-text-3);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+.aac__trace-meta dd {
+  margin: 0;
+  font-size: 11.5px;
+  color: var(--aac-text-2);
+  word-break: break-all;
+}
+
+.aac__timeline {
+  list-style: none;
+  margin: 0;
+  padding: 8px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.aac__timeline-node {
+  padding: 10px 12px;
+  background: var(--aac-surface);
+  border: 1px solid var(--aac-border);
+  border-radius: var(--aac-radius);
+  border-left: 3px solid var(--aac-accent);
+}
+.aac__timeline-node--human { border-left-color: var(--aac-human); }
+.aac__timeline-node--warn { border-left-color: var(--aac-stale); }
+.aac__timeline-node--error { border-left-color: var(--aac-danger); }
+.aac__timeline-head {
+  display: flex;
+  gap: 8px;
+  font-size: 11px;
+  color: var(--aac-text-3);
+}
+.aac__timeline-summary {
+  margin-top: 4px;
+  font-size: 13.5px;
+  font-weight: 500;
+}
+.aac__timeline-reason { font-size: 12.5px; margin-top: 4px; }
+.aac__timeline-art { font-size: 11px; margin-top: 4px; }
+
+.aac__footer-note {
+  margin-top: 16px;
+  padding: 10px 12px;
+  border: 1px dashed var(--aac-border);
+  border-radius: var(--aac-radius-sm);
+  font-size: 11.5px;
+  color: var(--aac-text-3);
+  line-height: 1.5;
+}
+
+.aac__mono {
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+}
+.aac__muted { color: var(--aac-text-3); }

--- a/frontend/src/test/AgentControlActivity.test.tsx
+++ b/frontend/src/test/AgentControlActivity.test.tsx
@@ -1,0 +1,604 @@
+/**
+ * Tests for AgentActivity — the v3.15.16.A15.B2.0d read-only PWA
+ * surface over the six Agent Activity Center GET endpoints.
+ *
+ * Pins:
+ *   - URL-synced routing across all 7 sub-paths + items/<id>.
+ *   - Loading / not_available / ok states for every section.
+ *   - Today key metrics + needs-human cap of 3 + "live merge
+ *     permanently disabled" notice.
+ *   - Inbox filter pills + AttentionCard.
+ *   - Pipeline 11 closed-vocab stage chips + canonical empty copy
+ *     for done_blocked.
+ *   - Artefacts seed read-only chip.
+ *   - Safety Level 6 banner + invariant cards.
+ *   - Agents per-role row.
+ *   - Trace header + timeline.
+ *   - Bottom-nav uses <Link>; aria-current follows useLocation.
+ *   - No rendered <button> has an accessible name matching
+ *     approve / execute / merge / deploy / reject / admit /
+ *     flip / trigger.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+
+import { AgentActivity } from "../routes/AgentControl/AgentActivity";
+import { agentControlApi } from "../api/agent_control";
+
+vi.mock("../api/agent_control", async () => {
+  const actual = await vi.importActual<typeof import("../api/agent_control")>(
+    "../api/agent_control",
+  );
+  return {
+    ...actual,
+    agentControlApi: {
+      ...actual.agentControlApi,
+      activityToday: vi.fn(),
+      activityItemsList: vi.fn(),
+      activityItemsDetail: vi.fn(),
+      activityAgents: vi.fn(),
+      activityArtifacts: vi.fn(),
+      activityInvariants: vi.fn(),
+    },
+  };
+});
+
+function _mock() {
+  return agentControlApi as unknown as {
+    activityToday: ReturnType<typeof vi.fn>;
+    activityItemsList: ReturnType<typeof vi.fn>;
+    activityItemsDetail: ReturnType<typeof vi.fn>;
+    activityAgents: ReturnType<typeof vi.fn>;
+    activityArtifacts: ReturnType<typeof vi.fn>;
+    activityInvariants: ReturnType<typeof vi.fn>;
+  };
+}
+
+const todayOk = {
+  kind: "agent_control_activity_today",
+  schema_version: 1,
+  module_version: "v3.15.16.A15.B2.0c.api",
+  status: "ok",
+  step5_implementation_allowed: false,
+  step5_enabled_substage: "none",
+  level6_enabled: false,
+  generated_at_utc: "2026-05-14T08:00:00Z",
+  artifact_path: "logs/development_agent_activity_timeline/latest.json",
+  counts: {
+    discovered: 0,
+    queued: 0,
+    delegated: 0,
+    planned: 1,
+    dry_run_ready: 0,
+    pr_proposed: 0,
+    pr_opened: 0,
+    ci_feedback: 0,
+    needs_human: 2,
+    merge_candidate: 1,
+    blocked: 0,
+    total_open: 4,
+  },
+  needs_human: [],
+  merge_candidate: [],
+  ci_feedback: [],
+  blocked: [],
+  recent_events: [],
+  freshness: { any_stale: false, any_malformed: false },
+  invariant_status: [],
+};
+
+function workItem(item_id: string, stage: string, human_needed = false) {
+  return {
+    item_id,
+    title: `Title ${item_id}`,
+    source_kind: "generated_lane",
+    source_path: "logs/development_generated_lane_a18c/latest.json",
+    current_stage: stage,
+    owner_role: "release_gate_agent",
+    risk: "medium",
+    human_needed,
+    latest_verdict: "admission_decision=needs_human",
+    next_action: "Operator review",
+    updated_at: "2026-05-14T07:00:00Z",
+    summary: "synthetic",
+    event_ids: [],
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default mocks — every test overrides as needed.
+  _mock().activityToday.mockResolvedValue(todayOk);
+  _mock().activityItemsList.mockResolvedValue({
+    kind: "agent_control_activity_items_list",
+    schema_version: 1,
+    module_version: "v3.15.16.A15.B2.0c.api",
+    status: "ok",
+    step5_implementation_allowed: false,
+    step5_enabled_substage: "none",
+    level6_enabled: false,
+    work_items: [],
+    total_matching: 0,
+    truncated: false,
+    freshness: {},
+    generated_at_utc: "2026-05-14T08:00:00Z",
+    artifact_path: "logs/development_agent_activity_timeline/latest.json",
+  });
+  _mock().activityAgents.mockResolvedValue({
+    kind: "agent_control_activity_agents",
+    schema_version: 1,
+    module_version: "v3.15.16.A15.B2.0c.api",
+    status: "ok",
+    step5_implementation_allowed: false,
+    step5_enabled_substage: "none",
+    level6_enabled: false,
+    rows: [],
+    generated_at_utc: "2026-05-14T08:00:00Z",
+    artifact_path: "logs/development_agent_activity_timeline/latest.json",
+  });
+  _mock().activityArtifacts.mockResolvedValue({
+    kind: "agent_control_activity_artifacts",
+    schema_version: 1,
+    module_version: "v3.15.16.A15.B2.0c.api",
+    status: "ok",
+    step5_implementation_allowed: false,
+    step5_enabled_substage: "none",
+    level6_enabled: false,
+    artifact_health: [],
+    generated_at_utc: "2026-05-14T08:00:00Z",
+    artifact_path: "logs/development_agent_activity_timeline/latest.json",
+  });
+  _mock().activityInvariants.mockResolvedValue({
+    kind: "agent_control_activity_invariants",
+    schema_version: 1,
+    module_version: "v3.15.16.A15.B2.0c.api",
+    status: "ok",
+    step5_implementation_allowed: false,
+    step5_enabled_substage: "none",
+    level6_enabled: false,
+    invariant_status: [],
+    generated_at_utc: "2026-05-14T08:00:00Z",
+    artifact_path: "logs/development_agent_activity_timeline/latest.json",
+  });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+function mount(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/agent-control/activity/*" element={<AgentActivity />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Routing / deeplink (5 tests)
+// ---------------------------------------------------------------------------
+
+describe("AgentActivity routing", () => {
+  it("renders Today on the bare /agent-control/activity path", async () => {
+    mount("/agent-control/activity");
+    expect(await screen.findByTestId("aac-section-today")).toBeInTheDocument();
+  });
+
+  it("renders Inbox on /agent-control/activity/inbox", async () => {
+    mount("/agent-control/activity/inbox");
+    expect(await screen.findByTestId("aac-section-inbox")).toBeInTheDocument();
+  });
+
+  it("renders Pipeline on /agent-control/activity/pipeline", async () => {
+    mount("/agent-control/activity/pipeline");
+    expect(
+      await screen.findByTestId("aac-section-pipeline"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders Trace on /agent-control/activity/items/<id>", async () => {
+    _mock().activityItemsDetail.mockResolvedValue({
+      kind: "agent_control_activity_items_detail",
+      schema_version: 1,
+      module_version: "v3.15.16.A15.B2.0c.api",
+      status: "ok",
+      step5_implementation_allowed: false,
+      step5_enabled_substage: "none",
+      level6_enabled: false,
+      work_item: workItem("wi_target_1", "needs_human", true),
+      agent_events: [],
+      human_actions: [],
+      artefacts_referenced: [],
+      generated_at_utc: "2026-05-14T08:00:00Z",
+      artifact_path: "logs/development_agent_activity_timeline/latest.json",
+    });
+    mount("/agent-control/activity/items/wi_target_1");
+    expect(await screen.findByTestId("aac-section-trace")).toBeInTheDocument();
+    expect(_mock().activityItemsDetail).toHaveBeenCalledWith("wi_target_1");
+  });
+
+  it("redirects unknown sub-path to Today", async () => {
+    mount("/agent-control/activity/totally_bogus");
+    expect(await screen.findByTestId("aac-section-today")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bottom-nav (2 tests)
+// ---------------------------------------------------------------------------
+
+describe("AgentActivity bottom-nav", () => {
+  it("renders 5 tabs as <Link>s, not <button>s", async () => {
+    mount("/agent-control/activity/today");
+    await screen.findByTestId("aac-section-today");
+    const nav = screen.getByTestId("aac-bottom-nav");
+    const tabs = within(nav).getAllByRole("link");
+    expect(tabs).toHaveLength(5);
+    expect(within(nav).queryAllByRole("button")).toHaveLength(0);
+  });
+
+  it("marks active tab with aria-current=page based on pathname", async () => {
+    mount("/agent-control/activity/inbox");
+    await screen.findByTestId("aac-section-inbox");
+    const inboxTab = screen.getByTestId("aac-tab-inbox");
+    expect(inboxTab).toHaveAttribute("aria-current", "page");
+    expect(screen.getByTestId("aac-tab-today")).not.toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Today (4 tests)
+// ---------------------------------------------------------------------------
+
+describe("AgentActivity Today", () => {
+  it("renders 6 metric tiles from the counts envelope", async () => {
+    mount("/agent-control/activity/today");
+    await screen.findByTestId("aac-section-today");
+    expect(screen.getByTestId("aac-metric-needs-human")).toBeInTheDocument();
+    expect(screen.getByTestId("aac-metric-blocked")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("aac-metric-merge-candidate"),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("aac-metric-ci-feedback")).toBeInTheDocument();
+    expect(screen.getByTestId("aac-metric-planned")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("aac-metric-dry-run-ready"),
+    ).toBeInTheDocument();
+  });
+
+  it("caps needs-human section at 3 cards", async () => {
+    const many = Array.from({ length: 10 }, (_, i) =>
+      workItem(`wi_h_${i}`, "needs_human", true),
+    );
+    _mock().activityToday.mockResolvedValue({
+      ...todayOk,
+      needs_human: many,
+    });
+    mount("/agent-control/activity/today");
+    await screen.findByTestId("aac-section-today");
+    const cards = screen
+      .getAllByTestId(/^aac-item-/)
+      .filter((el) => el.getAttribute("data-testid")?.startsWith("aac-item-wi_h_"));
+    expect(cards).toHaveLength(3);
+  });
+
+  it("renders 'Live merge is permanently disabled' notice when merge candidates exist", async () => {
+    _mock().activityToday.mockResolvedValue({
+      ...todayOk,
+      merge_candidate: [workItem("wi_m_1", "merge_candidate", false)],
+    });
+    mount("/agent-control/activity/today");
+    await screen.findByTestId("aac-section-today");
+    expect(
+      screen.getByTestId("aac-live-merge-disabled-notice"),
+    ).toHaveTextContent(/permanently disabled/i);
+  });
+
+  it("renders offline banner when aggregator returns not_available", async () => {
+    _mock().activityToday.mockResolvedValue({
+      ...todayOk,
+      status: "not_available",
+      reason: "missing",
+    });
+    mount("/agent-control/activity/today");
+    await screen.findByTestId("aac-section-today");
+    expect(screen.getByTestId("aac-banner-offline")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Inbox (3 tests)
+// ---------------------------------------------------------------------------
+
+describe("AgentActivity Inbox", () => {
+  it("renders filter pills", async () => {
+    mount("/agent-control/activity/inbox");
+    await screen.findByTestId("aac-section-inbox");
+    expect(screen.getByTestId("aac-inbox-filter-all")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("aac-inbox-filter-required"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("aac-inbox-filter-optional"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders inbox-zero when work_items list is empty", async () => {
+    mount("/agent-control/activity/inbox");
+    await screen.findByTestId("aac-section-inbox");
+    expect(screen.getByTestId("aac-inbox-empty")).toBeInTheDocument();
+  });
+
+  it("renders AttentionCard rows when human-needed items exist", async () => {
+    _mock().activityItemsList.mockResolvedValue({
+      kind: "agent_control_activity_items_list",
+      schema_version: 1,
+      module_version: "v3.15.16.A15.B2.0c.api",
+      status: "ok",
+      step5_implementation_allowed: false,
+      step5_enabled_substage: "none",
+      level6_enabled: false,
+      work_items: [workItem("wi_h_a", "needs_human", true)],
+      total_matching: 1,
+      truncated: false,
+      freshness: {},
+      generated_at_utc: "2026-05-14T08:00:00Z",
+      artifact_path: "logs/development_agent_activity_timeline/latest.json",
+    });
+    mount("/agent-control/activity/inbox");
+    await screen.findByTestId("aac-section-inbox");
+    expect(screen.getByTestId("aac-attention-ha_wi_h_a")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pipeline (2 tests)
+// ---------------------------------------------------------------------------
+
+describe("AgentActivity Pipeline", () => {
+  it("renders 11 stage chips in closed-vocab order", async () => {
+    mount("/agent-control/activity/pipeline");
+    await screen.findByTestId("aac-section-pipeline");
+    const expectedStages = [
+      "discovered",
+      "queued",
+      "delegated",
+      "planned",
+      "dry_run_ready",
+      "pr_proposed",
+      "pr_opened",
+      "ci_feedback",
+      "needs_human",
+      "merge_candidate",
+      "done_blocked",
+    ];
+    for (const s of expectedStages) {
+      expect(
+        screen.getByTestId(`aac-pipeline-chip-${s}`),
+      ).toBeInTheDocument();
+    }
+  });
+
+  it("renders 'No promotable candidates' for empty done_blocked stage", async () => {
+    mount("/agent-control/activity/pipeline");
+    await screen.findByTestId("aac-section-pipeline");
+    const doneChip = screen.getByTestId("aac-pipeline-chip-done_blocked");
+    doneChip.click();
+    expect(
+      await screen.findByTestId("aac-pipeline-empty-done_blocked"),
+    ).toHaveTextContent("No promotable candidates");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Artefacts (1 test)
+// ---------------------------------------------------------------------------
+
+describe("AgentActivity Artefacts", () => {
+  it("renders read-only chip on the seed row", async () => {
+    _mock().activityArtifacts.mockResolvedValue({
+      kind: "agent_control_activity_artifacts",
+      schema_version: 1,
+      module_version: "v3.15.16.A15.B2.0c.api",
+      status: "ok",
+      step5_implementation_allowed: false,
+      step5_enabled_substage: "none",
+      level6_enabled: false,
+      artifact_health: [
+        {
+          path: "generated_seed.jsonl",
+          group: "seed",
+          fresh: false,
+          parse_ok: true,
+          row_count: 0,
+          last_modified: "",
+          module_version: "",
+          has_summary: false,
+          read_only_warning: "Read-only · UI must not write",
+        },
+      ],
+      generated_at_utc: "2026-05-14T08:00:00Z",
+      artifact_path: "logs/development_agent_activity_timeline/latest.json",
+    });
+    mount("/agent-control/activity/artefacts");
+    await screen.findByTestId("aac-section-artefacts");
+    expect(
+      screen.getByTestId("aac-read-only-generated_seed.jsonl"),
+    ).toHaveTextContent(/Read-only/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Safety (1 test)
+// ---------------------------------------------------------------------------
+
+describe("AgentActivity Safety", () => {
+  it("renders the red Level 6 banner permanently disabled", async () => {
+    _mock().activityInvariants.mockResolvedValue({
+      kind: "agent_control_activity_invariants",
+      schema_version: 1,
+      module_version: "v3.15.16.A15.B2.0c.api",
+      status: "ok",
+      step5_implementation_allowed: false,
+      step5_enabled_substage: "none",
+      level6_enabled: false,
+      invariant_status: [
+        {
+          key: "level_6",
+          label: "Level 6",
+          value: "permanently_disabled",
+          tone: "danger_off",
+          detail: "permanently disabled",
+        },
+      ],
+      generated_at_utc: "2026-05-14T08:00:00Z",
+      artifact_path: "logs/development_agent_activity_timeline/latest.json",
+    });
+    mount("/agent-control/activity/safety");
+    await screen.findByTestId("aac-section-safety");
+    expect(screen.getByTestId("aac-l6-banner")).toHaveTextContent(
+      /permanently disabled/i,
+    );
+    expect(
+      screen.getByTestId("aac-invariant-level_6"),
+    ).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Agents (1 test)
+// ---------------------------------------------------------------------------
+
+describe("AgentActivity Agents", () => {
+  it("renders one row per agent role from the matrix envelope", async () => {
+    _mock().activityAgents.mockResolvedValue({
+      kind: "agent_control_activity_agents",
+      schema_version: 1,
+      module_version: "v3.15.16.A15.B2.0c.api",
+      status: "ok",
+      step5_implementation_allowed: false,
+      step5_enabled_substage: "none",
+      level6_enabled: false,
+      rows: [
+        {
+          role: "release_gate_agent",
+          new: 0,
+          planned: 1,
+          blocked: 0,
+          needs_human: 1,
+          pr_ready: 0,
+          last_action: null,
+          total: 1,
+        },
+        {
+          role: "planner",
+          new: 0,
+          planned: 0,
+          blocked: 0,
+          needs_human: 0,
+          pr_ready: 0,
+          last_action: null,
+          total: 0,
+        },
+      ],
+      generated_at_utc: "2026-05-14T08:00:00Z",
+      artifact_path: "logs/development_agent_activity_timeline/latest.json",
+    });
+    mount("/agent-control/activity/agents");
+    await screen.findByTestId("aac-section-agents");
+    expect(
+      screen.getByTestId("aac-agent-release_gate_agent"),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("aac-agent-planner")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Trace (1 test)
+// ---------------------------------------------------------------------------
+
+describe("AgentActivity Trace", () => {
+  it("renders header card + timeline rendered from itemsDetail envelope", async () => {
+    _mock().activityItemsDetail.mockResolvedValue({
+      kind: "agent_control_activity_items_detail",
+      schema_version: 1,
+      module_version: "v3.15.16.A15.B2.0c.api",
+      status: "ok",
+      step5_implementation_allowed: false,
+      step5_enabled_substage: "none",
+      level6_enabled: false,
+      work_item: workItem("wi_t_001", "needs_human", true),
+      agent_events: [
+        {
+          event_id: "ev_t_001",
+          item_id: "wi_t_001",
+          timestamp: "2026-05-14T07:00:00Z",
+          agent_role: "release_gate_agent",
+          module: "generated_lane_a18c",
+          event_type: "verdict",
+          summary: "needs_human",
+          decision: "require_human",
+          reason: "policy",
+          artifact_path: "logs/development_generated_lane_a18c/latest.json",
+          severity: "human",
+        },
+      ],
+      human_actions: [],
+      artefacts_referenced: [],
+      generated_at_utc: "2026-05-14T08:00:00Z",
+      artifact_path: "logs/development_agent_activity_timeline/latest.json",
+    });
+    mount("/agent-control/activity/items/wi_t_001");
+    await screen.findByTestId("aac-section-trace");
+    expect(screen.getByTestId("aac-trace-header")).toBeInTheDocument();
+    expect(screen.getByTestId("aac-event-ev_t_001")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Decision-verb UI scan (1 test)
+// ---------------------------------------------------------------------------
+
+describe("AgentActivity decision-verb UI scan", () => {
+  it("renders no button whose accessible name matches approve/execute/merge/deploy/reject/admit/flip/trigger", async () => {
+    _mock().activityToday.mockResolvedValue({
+      ...todayOk,
+      needs_human: [workItem("wi_h_a", "needs_human", true)],
+      merge_candidate: [workItem("wi_m_a", "merge_candidate", false)],
+    });
+    mount("/agent-control/activity/today");
+    await screen.findByTestId("aac-section-today");
+    const verbs = /^(approve|execute|merge|deploy|reject|admit|flip|trigger)\b/i;
+    const buttons = screen.queryAllByRole("button");
+    for (const b of buttons) {
+      const name = b.getAttribute("aria-label") || b.textContent || "";
+      expect(name, `button name leaks decision verb: ${name}`).not.toMatch(
+        verbs,
+      );
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// More section + deferred Design Spec (1 test)
+// ---------------------------------------------------------------------------
+
+describe("AgentActivity More section", () => {
+  it("renders Design Spec deferred item as plain info text, not a broken link", async () => {
+    mount("/agent-control/activity/more");
+    await screen.findByTestId("aac-section-more");
+    const deferred = screen.getByTestId("aac-more-spec-deferred");
+    expect(deferred).toHaveTextContent("Design Spec");
+    expect(deferred).toHaveTextContent(/documented in repo/i);
+    expect(deferred).toHaveTextContent(/deferred/i);
+    // Confirm it is NOT an anchor or routed <Link> — no href attribute.
+    expect(deferred.tagName.toLowerCase()).not.toBe("a");
+  });
+});

--- a/frontend/src/test/AgentControlActivityCopyPhrase.test.tsx
+++ b/frontend/src/test/AgentControlActivityCopyPhrase.test.tsx
@@ -1,0 +1,234 @@
+/**
+ * Tests for CopyOperatorPhraseButton — B2.0d clipboard-only pins.
+ *
+ * Pins:
+ *   - navigator.clipboard.writeText called with the exact phrase.
+ *   - No fetch / no XHR / no sendBeacon when the button is clicked.
+ *   - Success feedback renders then clears after the timeout.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor, act } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+
+import { AgentActivity } from "../routes/AgentControl/AgentActivity";
+import { agentControlApi } from "../api/agent_control";
+
+vi.mock("../api/agent_control", async () => {
+  const actual = await vi.importActual<typeof import("../api/agent_control")>(
+    "../api/agent_control",
+  );
+  return {
+    ...actual,
+    agentControlApi: {
+      ...actual.agentControlApi,
+      activityToday: vi.fn(),
+      activityItemsList: vi.fn(),
+      activityItemsDetail: vi.fn(),
+      activityAgents: vi.fn(),
+      activityArtifacts: vi.fn(),
+      activityInvariants: vi.fn(),
+    },
+  };
+});
+
+const PHRASE = "GO A18 promotion operator-promote";
+
+const detailWithPhrase = {
+  kind: "agent_control_activity_items_detail",
+  schema_version: 1,
+  module_version: "v3.15.16.A15.B2.0c.api",
+  status: "ok",
+  step5_implementation_allowed: false,
+  step5_enabled_substage: "none",
+  level6_enabled: false,
+  work_item: {
+    item_id: "wi_phrase_test",
+    title: "Phrase target",
+    source_kind: "generated_lane_promotion",
+    source_path:
+      "logs/development_generated_lane_promotion_report/latest.json",
+    current_stage: "needs_human",
+    owner_role: "release_gate_agent",
+    risk: "medium",
+    human_needed: true,
+    latest_verdict: "promotion_allowed=False",
+    next_action: "Operator-go required",
+    updated_at: "2026-05-14T07:00:00Z",
+    summary: "synthetic",
+    event_ids: [],
+  },
+  agent_events: [],
+  human_actions: [
+    {
+      action_id: "ha_phrase_test",
+      item_id: "wi_phrase_test",
+      severity: "medium",
+      title: "Phrase target",
+      why_required: "Promotion is operator-paced.",
+      required_phrase: PHRASE,
+      safe_to_ignore: false,
+      copy_only: true,
+      source_artifact_path:
+        "logs/development_generated_lane_promotion_report/latest.json",
+      suggested_role: "release_gate_agent",
+      created_at: "2026-05-14T07:00:00Z",
+    },
+  ],
+  artefacts_referenced: [],
+  generated_at_utc: "2026-05-14T08:00:00Z",
+  artifact_path: "logs/development_agent_activity_timeline/latest.json",
+};
+
+function _mock() {
+  return agentControlApi as unknown as {
+    activityItemsDetail: ReturnType<typeof vi.fn>;
+  };
+}
+
+function mountTrace() {
+  return render(
+    <MemoryRouter
+      initialEntries={["/agent-control/activity/items/wi_phrase_test"]}
+    >
+      <Routes>
+        <Route
+          path="/agent-control/activity/*"
+          element={<AgentActivity />}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+let originalClipboard: typeof navigator.clipboard | undefined;
+let originalFetch: typeof globalThis.fetch | undefined;
+let originalSendBeacon: typeof navigator.sendBeacon | undefined;
+let writeTextSpy: ReturnType<typeof vi.fn>;
+let fetchSpy: ReturnType<typeof vi.fn>;
+let sendBeaconSpy: ReturnType<typeof vi.fn>;
+let xhrSpy: ReturnType<typeof vi.fn>;
+let originalXHR: typeof XMLHttpRequest;
+
+beforeEach(() => {
+  _mock().activityItemsDetail.mockResolvedValue(detailWithPhrase);
+
+  writeTextSpy = vi.fn().mockResolvedValue(undefined);
+  originalClipboard = navigator.clipboard;
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText: writeTextSpy },
+  });
+
+  fetchSpy = vi.fn();
+  originalFetch = globalThis.fetch;
+  globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+  sendBeaconSpy = vi.fn();
+  originalSendBeacon = navigator.sendBeacon;
+  Object.defineProperty(navigator, "sendBeacon", {
+    configurable: true,
+    value: sendBeaconSpy,
+  });
+
+  xhrSpy = vi.fn();
+  originalXHR = globalThis.XMLHttpRequest;
+  globalThis.XMLHttpRequest = function (this: unknown) {
+    xhrSpy();
+    return originalXHR
+      ? new originalXHR()
+      : ({} as XMLHttpRequest);
+  } as unknown as typeof XMLHttpRequest;
+});
+
+afterEach(() => {
+  if (originalClipboard) {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: originalClipboard,
+    });
+  }
+  if (originalFetch !== undefined) {
+    globalThis.fetch = originalFetch;
+  }
+  if (originalSendBeacon !== undefined) {
+    Object.defineProperty(navigator, "sendBeacon", {
+      configurable: true,
+      value: originalSendBeacon,
+    });
+  }
+  if (originalXHR !== undefined) {
+    globalThis.XMLHttpRequest = originalXHR;
+  }
+  vi.clearAllMocks();
+});
+
+describe("CopyOperatorPhraseButton clipboard-only pins", () => {
+  it("calls navigator.clipboard.writeText with the exact phrase", async () => {
+    mountTrace();
+    const btn = await screen.findByTestId("aac-copy-phrase");
+    fireEvent.click(btn);
+    await waitFor(() => {
+      expect(writeTextSpy).toHaveBeenCalledTimes(1);
+    });
+    expect(writeTextSpy).toHaveBeenCalledWith(PHRASE);
+  });
+
+  it("does not call fetch when the button is clicked", async () => {
+    mountTrace();
+    const btn = await screen.findByTestId("aac-copy-phrase");
+    const fetchCallsBefore = fetchSpy.mock.calls.length;
+    fireEvent.click(btn);
+    await waitFor(() => {
+      expect(writeTextSpy).toHaveBeenCalledTimes(1);
+    });
+    expect(fetchSpy.mock.calls.length).toBe(fetchCallsBefore);
+  });
+
+  it("does not construct XMLHttpRequest when the button is clicked", async () => {
+    mountTrace();
+    const btn = await screen.findByTestId("aac-copy-phrase");
+    const xhrCallsBefore = xhrSpy.mock.calls.length;
+    fireEvent.click(btn);
+    await waitFor(() => {
+      expect(writeTextSpy).toHaveBeenCalledTimes(1);
+    });
+    expect(xhrSpy.mock.calls.length).toBe(xhrCallsBefore);
+  });
+
+  it("does not call navigator.sendBeacon when the button is clicked", async () => {
+    mountTrace();
+    const btn = await screen.findByTestId("aac-copy-phrase");
+    fireEvent.click(btn);
+    await waitFor(() => {
+      expect(writeTextSpy).toHaveBeenCalledTimes(1);
+    });
+    expect(sendBeaconSpy).not.toHaveBeenCalled();
+  });
+
+  it("renders Copied feedback then reverts to Copy phrase", async () => {
+    mountTrace();
+    // Resolve initial render and locate the button with REAL timers
+    // (findBy* uses an internal polling timer; fake timers would
+    // deadlock it).
+    const btn = await screen.findByTestId("aac-copy-phrase");
+    // Install fake timers only AFTER the initial mount + element
+    // lookup completes, so the setTimeout that reverts the "Copied"
+    // label can be advanced deterministically.
+    vi.useFakeTimers();
+    try {
+      fireEvent.click(btn);
+      // Flush the clipboard microtask so the success path sets state.
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(btn).toHaveTextContent(/Copied/);
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+      expect(btn).toHaveTextContent(/Copy phrase/);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/frontend/src/test/AgentControlActivityNoMutation.test.tsx
+++ b/frontend/src/test/AgentControlActivityNoMutation.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * Structural guards for the v3.15.16.A15.B2.0d Agent Activity Center
+ * surface. These tests read the source files from disk and scan
+ * targeted regions only — they do NOT scan whole files for generic
+ * verb words (which would trip on copy like "merge candidate").
+ *
+ * Pins:
+ *   - The AAC client section inside frontend/src/api/agent_control.ts
+ *     uses only the GET-only envelope helper. No `method: "POST"` /
+ *     `PUT` / `PATCH` / `DELETE` literal appears in that section.
+ *   - AgentActivity.tsx does not contain direct fetch / XMLHttpRequest /
+ *     sendBeacon literals — the route component must use the API
+ *     client.
+ *   - AgentActivity.tsx has no push-subscription / Notification
+ *     permission / serviceWorker.register call patterns.
+ *   - AgentActivity.tsx references zero /api/agent-control/activity/
+ *     literal endpoint paths (must call only agentControlApi methods).
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = resolve(__dirname, "..", "..", "..");
+
+function read(relativePath: string): string {
+  return readFileSync(
+    resolve(REPO_ROOT, "frontend", "src", ...relativePath.split("/")),
+    "utf-8",
+  );
+}
+
+// Marker strings used to slice out the AAC section in agent_control.ts.
+const AAC_BEGIN =
+  "v3.15.16.A15.B2.0d — Agent Activity Center read-only client.";
+const AAC_END_BEFORE = "};";
+
+function aacApiSection(): string {
+  const src = read("api/agent_control.ts");
+  const beginIdx = src.indexOf(AAC_BEGIN);
+  if (beginIdx === -1) {
+    throw new Error(
+      "agent_control.ts is missing the AAC begin marker — cannot locate the client section",
+    );
+  }
+  // The AAC client methods are the LAST entries in the agentControlApi
+  // object literal. Slice from the begin marker to the first `};` line
+  // that appears after the marker — robust against CRLF / LF line
+  // endings and against unrelated `};` literals that may appear earlier
+  // (e.g. inside type definitions).
+  const after = src.slice(beginIdx);
+  const match = after.match(/\r?\n\};\r?\n/);
+  if (!match || match.index === undefined) {
+    throw new Error(
+      "agent_control.ts AAC section closing brace not found",
+    );
+  }
+  return after.slice(0, match.index);
+}
+
+describe("AAC API client section: GET-only", () => {
+  it("does not contain any non-GET method literal in the AAC section", () => {
+    const section = aacApiSection();
+    for (const forbidden of [
+      'method: "POST"',
+      "method: 'POST'",
+      'method: "PUT"',
+      "method: 'PUT'",
+      'method: "PATCH"',
+      "method: 'PATCH'",
+      'method: "DELETE"',
+      "method: 'DELETE'",
+    ]) {
+      expect(
+        section.includes(forbidden),
+        `AAC API client section contains forbidden literal ${forbidden}`,
+      ).toBe(false);
+    }
+  });
+
+  it("does not use postJsonEnvelope or any POST helper in the AAC section", () => {
+    const section = aacApiSection();
+    expect(section.includes("postJsonEnvelope")).toBe(false);
+    expect(section.includes("postJson")).toBe(false);
+  });
+
+  it("uses getJsonEnvelope for every AAC method", () => {
+    const section = aacApiSection();
+    // Each of the six AAC methods must reference getJsonEnvelope.
+    const expectedMethods = [
+      "activityToday",
+      "activityItemsList",
+      "activityItemsDetail",
+      "activityAgents",
+      "activityArtifacts",
+      "activityInvariants",
+    ];
+    for (const method of expectedMethods) {
+      const idx = section.indexOf(method);
+      expect(idx, `method ${method} missing from AAC section`).toBeGreaterThanOrEqual(0);
+    }
+    const matches = section.match(/getJsonEnvelope</g) || [];
+    expect(matches.length).toBeGreaterThanOrEqual(6);
+  });
+});
+
+describe("AgentActivity route file: no direct network", () => {
+  it("does not contain a direct fetch( literal", () => {
+    const src = read("routes/AgentControl/AgentActivity.tsx");
+    // The route component must call only agentControlApi methods.
+    expect(src.includes("fetch(")).toBe(false);
+  });
+
+  it("does not contain XMLHttpRequest construction", () => {
+    const src = read("routes/AgentControl/AgentActivity.tsx");
+    expect(src.includes("new XMLHttpRequest")).toBe(false);
+    expect(src.includes("XMLHttpRequest()")).toBe(false);
+  });
+
+  it("does not contain navigator.sendBeacon", () => {
+    const src = read("routes/AgentControl/AgentActivity.tsx");
+    expect(src.includes("sendBeacon")).toBe(false);
+  });
+
+  it("does not contain push-subscription or notification-permission literals", () => {
+    const src = read("routes/AgentControl/AgentActivity.tsx");
+    for (const forbidden of [
+      "pushManager.subscribe",
+      "Notification.requestPermission",
+      "serviceWorker.register",
+    ]) {
+      expect(
+        src.includes(forbidden),
+        `AgentActivity.tsx contains forbidden literal ${forbidden}`,
+      ).toBe(false);
+    }
+  });
+
+  it("references zero /api/agent-control/activity/ literal endpoint paths", () => {
+    const src = read("routes/AgentControl/AgentActivity.tsx");
+    // The route file must call methods on agentControlApi, not bare
+    // endpoint URLs.
+    expect(src.includes("/api/agent-control/activity")).toBe(false);
+  });
+});
+
+describe("AgentActivity route file: clipboard pattern", () => {
+  it("CopyOperatorPhraseButton uses navigator.clipboard.writeText", () => {
+    const src = read("routes/AgentControl/AgentActivity.tsx");
+    expect(src.includes("navigator.clipboard.writeText")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Revised Batch 2, **unit B2.0d** — read-only mobile-first PWA frontend for the Agent Activity Center, against the six existing GET endpoints under \`/api/agent-control/activity/*\` (wired in [PR #224](https://github.com/roudjy/trading-agent/pull/224)). Translates the [B2.0 design spec](docs/governance/agent_activity_center_design.md) into a buildable React surface.

**No mutation. No push subscription. No service-worker or manifest edits. No backend changes.**

## MVP screens (7)

| Screen | Route | What it shows |
|---|---|---|
| Today | \`/agent-control/activity/today\` | 6 metric tiles + 4 headline sections + recent activity |
| Inbox | \`/agent-control/activity/inbox\` | filter pills + AttentionCard list; Mark reviewed is local-only |
| Pipeline | \`/agent-control/activity/pipeline\` | 11 closed-vocab stage chips + active-stage list; canonical \`"No promotable candidates"\` empty copy for \`done_blocked\` |
| Agents | \`/agent-control/activity/agents\` | per-role row with 5-stat strip |
| Artefacts | \`/agent-control/activity/artefacts\` | grouped path list + freshness badge + read-only seed chip |
| Safety | \`/agent-control/activity/safety\` | red Level 6 banner permanently disabled + invariant cards + "what this UI cannot do" list |
| Trace | \`/agent-control/activity/items/<id>\` | header card + timeline + copy-phrase pill when \`required_phrase\` set |

Plus **More** at \`/agent-control/activity/more\` — links to Artefacts/Safety + a deferred Design Spec entry rendered as plain info text (no anchor, no broken link), per the operator's final constraint.

## URL ↔ tab sync

Bottom-nav uses \`<Link>\` (not \`<button>\`). \`aria-current="page"\` is computed from \`useLocation().pathname\` — URL is the source of truth.

## API client strategy

Extended \`agentControlApi\` in \`frontend/src/api/agent_control.ts\` (not a new file) — matches the established precedent (merge-recommendation, merge-preflight, approval-token diagnostics all live as namespaced methods on \`agentControlApi\` in the same file). Six new methods, all using the existing GET-only \`getJsonEnvelope<T>\` helper.

## File map (7 files, additive)

| # | Path | Action |
|---|---|---|
| 1 | \`frontend/src/api/agent_control.ts\` | MODIFIED; +283 lines (AAC client section + closed-vocab types) |
| 2 | \`frontend/src/routes/AgentControl/AgentActivity.tsx\` | NEW; monolithic hub with nested \`<Routes>\` for sub-paths |
| 3 | \`frontend/src/styles/agent_activity.css\` | NEW; fully \`.aac\`-scoped (no global selectors) |
| 4 | \`frontend/src/App.tsx\` | MODIFIED; +18 lines (1 import + 1 route block before \`/agent-control/*\` catch-all) |
| 5 | \`frontend/src/test/AgentControlActivity.test.tsx\` | NEW; 20 tests |
| 6 | \`frontend/src/test/AgentControlActivityCopyPhrase.test.tsx\` | NEW; 5 tests |
| 7 | \`frontend/src/test/AgentControlActivityNoMutation.test.tsx\` | NEW; 5 tests |

## Validation evidence

- \`npm --prefix frontend run build\` → built in 3.82s
- \`npm --prefix frontend run test\` → **315 passed (19 files)**, including 30 new AAC tests
- \`python -m pytest tests/smoke -q\` → **18 passed**
- \`python scripts/governance_lint.py\` → \`OK (16 agents, 5 workflows checked)\`

## Mid-implementation corrections (3 self-trips fixed)

1. \`AgentActivity.tsx\` docstring originally enumerated forbidden tokens as documentation. The companion NoMutation tests rejected them. Rewrote without literal tokens. Same lesson as B1.4 / B2.0b / B2.0c.
2. NoMutation test parser required exact \`\n};\n\` framing. Replaced with CRLF-tolerant regex.
3. CopyPhrase test installed fake timers BEFORE initial render, which deadlocked \`findByTestId\`. Moved fake-timer install to AFTER initial element lookup.

## Not in scope (explicitly excluded)

- No service-worker edits.
- No manifest edits.
- No push subscription, no notification-permission prompt.
- No backend / dashboard / reporting Python changes.
- No governance doc / roadmap / ADR edits.
- No env flip; no Step 5 flag/substage change.
- No queue admission, PR creation, merge, deploy authority.
- No \`seed.jsonl\` / \`delegation_seed.jsonl\` / \`generated_seed.jsonl\` writes.
- No \`tests/regression\` edits.
- No \`.claude/**\`, \`.github/**\`, \`.gitleaks.toml\`, no-touch paths, frozen v1 schemas, live/paper/shadow/risk/broker/execution paths.
- The known POST-route-500 behaviour from prior VPS verification stays as a future follow-up.

## Rollback

Single \`git revert\`. The frontend changes are purely additive; the modified \`agent_control.ts\` grows by ~283 lines but no existing method is changed. \`App.tsx\` route insertion sits before the existing \`/agent-control/*\` catch-all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)