### PR TITLE
feat(b2-1)(step5): Step 5.1 adapter — default-disabled additive schema

### DIFF
--- a/reporting/development_step5_loop.py
+++ b/reporting/development_step5_loop.py
@@ -181,6 +181,59 @@ _DISCIPLINE_INVARIANTS: Final[dict[str, bool]] = {
 
 
 # ---------------------------------------------------------------------------
+# B2.1 — Step 5.1 adapter (default-disabled, additive schema)
+# ---------------------------------------------------------------------------
+
+#: v3.15.16.A15.B2.1 — Default-disabled "would do" preview for a
+#: hypothetical Step 5.1 cycle. Every Boolean field is pinned False
+#: and ``would_touch_paths`` is empty. The block is emitted into
+#: every plan payload as METADATA ONLY; no runtime gate reads it.
+#:
+#: Flipping any field here requires:
+#:   (a) a coordinated source change pinned by updated tests, AND
+#:   (b) the Path B / Path C governance amendments documented in
+#:       docs/governance/step5_gate_truth_table.md section 6.
+#:
+#: ``step5_implementation_allowed`` remains ``Final[False]`` and
+#: ``STEP5_ENABLED_SUBSTAGE`` remains ``Final["none"]`` regardless
+#: of changes to this block — the B2.4a AST pin still holds.
+#:
+#: This constant declares the closed schema (used by tests).
+#: Emitted payloads MUST call ``_fresh_step5_5_1_proposed()`` instead
+#: of shallow-copying this constant — see helper below for why.
+_STEP5_5_1_PROPOSED_DEFAULT: Final[dict[str, Any]] = {
+    "mode": "dry_run_only",
+    "would_create_branch": False,
+    "would_open_pr": False,
+    "would_touch_paths": [],
+    "would_run_targeted_tests": False,
+    "would_emit_release_gate_evidence": False,
+}
+
+
+def _fresh_step5_5_1_proposed() -> dict[str, Any]:
+    """Return a fresh Step 5.1 adapter default block per payload.
+
+    ``would_touch_paths`` must be a fresh empty list per payload —
+    never a shared object reference with the module-level
+    ``_STEP5_5_1_PROPOSED_DEFAULT`` constant. A shallow ``dict(...)``
+    copy of the constant would leak the same list across every
+    emitted payload, which a future caller could mutate and
+    silently affect prior snapshots. This helper rebuilds the
+    block from scratch so every emitted ``would_touch_paths`` is
+    a fresh, independent ``[]``.
+    """
+    return {
+        "mode": "dry_run_only",
+        "would_create_branch": False,
+        "would_open_pr": False,
+        "would_touch_paths": [],
+        "would_run_targeted_tests": False,
+        "would_emit_release_gate_evidence": False,
+    }
+
+
+# ---------------------------------------------------------------------------
 # Utility helpers
 # ---------------------------------------------------------------------------
 
@@ -357,6 +410,7 @@ def _build_plan_payload(
         "acceptance_criteria": acceptance,
         "target_paths": target_paths,
         "discipline_invariants": dict(_DISCIPLINE_INVARIANTS),
+        "step5_5_1_proposed": _fresh_step5_5_1_proposed(),
         "vocabularies": {
             "step5_substages": list(STEP5_SUBSTAGES),
             "halt_reasons": list(STEP5_HALT_REASONS),
@@ -389,6 +443,7 @@ def _build_no_op_plan_payload(*, generated_at_utc: str) -> dict[str, Any]:
         "acceptance_criteria": [],
         "target_paths": [],
         "discipline_invariants": dict(_DISCIPLINE_INVARIANTS),
+        "step5_5_1_proposed": _fresh_step5_5_1_proposed(),
         "vocabularies": {
             "step5_substages": list(STEP5_SUBSTAGES),
             "halt_reasons": list(STEP5_HALT_REASONS),

--- a/tests/unit/test_development_step5_loop.py
+++ b/tests/unit/test_development_step5_loop.py
@@ -1244,3 +1244,195 @@ def test_no_step5_5_2_env_flag_in_step5_module() -> None:
         "ADE_STEP5_5_2_ENABLED env flag introduced without a "
         "separate B2.3 / B2.4b PR (truth-table doc section 6 Path B)"
     )
+
+
+# ---------------------------------------------------------------------------
+# B2.1 — Step 5.1 adapter (default-disabled, additive schema)
+#
+# These pin tests cover the closed schema and pinned-False/empty
+# defaults of the ``step5_5_1_proposed`` metadata block emitted into
+# every plan payload by ``_build_plan_payload`` and
+# ``_build_no_op_plan_payload``. The block is METADATA ONLY — no
+# runtime gate reads it. The B2.4a AST pin
+# (``test_no_runtime_consumer_of_step5_gate_constants``) continues
+# to prove the load-bearing gating constants are never read by
+# branching expressions.
+#
+# Per the operator's freshness requirement, the
+# ``would_touch_paths`` list emitted into each payload must be a
+# fresh, independent ``[]`` — never a shared object reference with
+# the module-level ``_STEP5_5_1_PROPOSED_DEFAULT`` constant. The
+# helper ``_fresh_step5_5_1_proposed`` exists for exactly this
+# reason and is exercised by the assertion below.
+# ---------------------------------------------------------------------------
+
+
+_STEP5_5_1_PROPOSED_EXPECTED_KEYS: frozenset[str] = frozenset(
+    {
+        "mode",
+        "would_create_branch",
+        "would_open_pr",
+        "would_touch_paths",
+        "would_run_targeted_tests",
+        "would_emit_release_gate_evidence",
+    }
+)
+
+
+def test_step5_5_1_proposed_default_constant_keys_are_closed() -> None:
+    """The module-level ``_STEP5_5_1_PROPOSED_DEFAULT`` constant has
+    exactly the closed key set declared by B2.1. Adding or removing
+    a key requires updating both the constant and this pin."""
+    assert (
+        set(s5l._STEP5_5_1_PROPOSED_DEFAULT.keys())
+        == _STEP5_5_1_PROPOSED_EXPECTED_KEYS
+    )
+
+
+def test_step5_5_1_proposed_default_values_are_safe() -> None:
+    """All Boolean fields default to False, ``would_touch_paths`` is
+    an empty list, and ``mode`` is the pinned literal
+    ``"dry_run_only"``. Flipping any value here requires a coordinated
+    source change pinned by an updated test plus Path B / Path C
+    governance amendments (truth-table doc section 6)."""
+    default = s5l._STEP5_5_1_PROPOSED_DEFAULT
+    assert default["mode"] == "dry_run_only"
+    assert default["would_create_branch"] is False
+    assert default["would_open_pr"] is False
+    assert default["would_touch_paths"] == []
+    assert default["would_run_targeted_tests"] is False
+    assert default["would_emit_release_gate_evidence"] is False
+
+
+def test_step5_5_1_proposed_block_present_in_eligible_plan_payload() -> None:
+    """An eligible plan payload (AUTO_ALLOWED outcome) emits the
+    ``step5_5_1_proposed`` block with the closed schema and pinned
+    safe defaults."""
+    item = {
+        "candidate_id": "syn_b21_eligible",
+        "execution_authority": "AUTO_ALLOWED",
+        "acceptance_criteria": [],
+        "target_paths": [],
+    }
+    plan = s5l._build_plan_payload(
+        source_kind="bugfix",
+        item=item,
+        cycle_id="cid",
+        decision="AUTO_ALLOWED",
+        halt_reason="ok",
+        outcome="plan_emitted",
+        generated_at_utc="2026-05-15T00:00:00Z",
+    )
+    assert "step5_5_1_proposed" in plan
+    block = plan["step5_5_1_proposed"]
+    assert set(block.keys()) == _STEP5_5_1_PROPOSED_EXPECTED_KEYS
+    assert block["mode"] == "dry_run_only"
+    assert block["would_create_branch"] is False
+    assert block["would_open_pr"] is False
+    assert block["would_touch_paths"] == []
+    assert block["would_run_targeted_tests"] is False
+    assert block["would_emit_release_gate_evidence"] is False
+
+
+def test_step5_5_1_proposed_block_present_in_no_op_plan_payload() -> None:
+    """The no_eligible_item plan payload emits the
+    ``step5_5_1_proposed`` block with the same closed schema and
+    pinned safe defaults as the eligible-item path."""
+    plan = s5l._build_no_op_plan_payload(
+        generated_at_utc="2026-05-15T00:00:00Z"
+    )
+    assert "step5_5_1_proposed" in plan
+    block = plan["step5_5_1_proposed"]
+    assert set(block.keys()) == _STEP5_5_1_PROPOSED_EXPECTED_KEYS
+    assert block["mode"] == "dry_run_only"
+    assert block["would_create_branch"] is False
+    assert block["would_open_pr"] is False
+    assert block["would_touch_paths"] == []
+    assert block["would_run_targeted_tests"] is False
+    assert block["would_emit_release_gate_evidence"] is False
+
+
+def test_step5_5_1_does_not_bump_schema_version() -> None:
+    """B2.1 is an *additive* schema change. The module's
+    ``SCHEMA_VERSION`` and ``MODULE_VERSION`` constants are not
+    bumped by adding the ``step5_5_1_proposed`` block — adding an
+    optional metadata field with all-default values is
+    backward-compatible with consumers reading version 1.0."""
+    assert s5l.SCHEMA_VERSION == "1.0"
+    assert s5l.MODULE_VERSION == "v3.15.16.A14"
+
+
+def test_step5_5_1_proposed_would_touch_paths_is_fresh_list_per_payload() -> None:
+    """Freshness assertion (operator-mandated): the
+    ``would_touch_paths`` list emitted into each plan payload is a
+    fresh, independent ``[]`` — NOT the same object as the
+    module-level ``_STEP5_5_1_PROPOSED_DEFAULT["would_touch_paths"]``
+    list, and NOT shared between payloads.
+
+    A future caller could otherwise mutate a returned payload's
+    ``would_touch_paths`` and silently affect every other payload
+    holding the same list reference (including prior snapshots
+    written to disk). This test guarantees that scenario is
+    structurally impossible.
+    """
+    module_default_list = s5l._STEP5_5_1_PROPOSED_DEFAULT["would_touch_paths"]
+
+    plan_a = s5l._build_plan_payload(
+        source_kind="bugfix",
+        item={
+            "candidate_id": "syn_b21_fresh_a",
+            "execution_authority": "AUTO_ALLOWED",
+            "acceptance_criteria": [],
+            "target_paths": [],
+        },
+        cycle_id="cid_a",
+        decision="AUTO_ALLOWED",
+        halt_reason="ok",
+        outcome="plan_emitted",
+        generated_at_utc="2026-05-15T00:00:00Z",
+    )
+    plan_b = s5l._build_plan_payload(
+        source_kind="bugfix",
+        item={
+            "candidate_id": "syn_b21_fresh_b",
+            "execution_authority": "AUTO_ALLOWED",
+            "acceptance_criteria": [],
+            "target_paths": [],
+        },
+        cycle_id="cid_b",
+        decision="AUTO_ALLOWED",
+        halt_reason="ok",
+        outcome="plan_emitted",
+        generated_at_utc="2026-05-15T00:00:00Z",
+    )
+    plan_noop = s5l._build_no_op_plan_payload(
+        generated_at_utc="2026-05-15T00:00:00Z"
+    )
+
+    list_a = plan_a["step5_5_1_proposed"]["would_touch_paths"]
+    list_b = plan_b["step5_5_1_proposed"]["would_touch_paths"]
+    list_noop = plan_noop["step5_5_1_proposed"]["would_touch_paths"]
+
+    # Each emitted list has the expected empty value.
+    assert list_a == []
+    assert list_b == []
+    assert list_noop == []
+
+    # None of the emitted lists is the module-level default's list.
+    assert list_a is not module_default_list
+    assert list_b is not module_default_list
+    assert list_noop is not module_default_list
+
+    # And no two emitted lists share an object reference with each
+    # other, so mutating one cannot affect the others.
+    assert list_a is not list_b
+    assert list_a is not list_noop
+    assert list_b is not list_noop
+
+    # Sanity check the freshness contract by mutation: mutating one
+    # emitted list must NOT propagate to any other emitted list or
+    # to the module-level default.
+    list_a.append("contaminant")
+    assert list_b == []
+    assert list_noop == []
+    assert s5l._STEP5_5_1_PROPOSED_DEFAULT["would_touch_paths"] == []


### PR DESCRIPTION
## Scope

B2.1 — Step 5.1 adapter additive schema, scoped to **two files only**:

- `reporting/development_step5_loop.py` (+55 lines)
- `tests/unit/test_development_step5_loop.py` (+192 lines)

Net: 247 insertions, 0 deletions, 0 modifications.

No change to `reporting/development_operational_digest.py`. No change under `tests/regression/`. No new env flag.

## Summary

Adds a metadata-only `step5_5_1_proposed` block to every plan payload emitted by `_build_plan_payload` and `_build_no_op_plan_payload`. The block declares a closed six-field schema:

- `mode`: pinned to the literal `\"dry_run_only\"`
- `would_create_branch`: `False`
- `would_open_pr`: `False`
- `would_touch_paths`: **fresh empty list per payload**
- `would_run_targeted_tests`: `False`
- `would_emit_release_gate_evidence`: `False`

## Architecture

The block is **metadata only**. No runtime branch reads it. The B2.4a AST pin (`test_no_runtime_consumer_of_step5_gate_constants`) continues to prove the load-bearing gating constants are unreachable from any `if` / `while` / `assert` test expression:

- `step5_implementation_allowed: Final[bool] = False`
- `STEP5_ENABLED_SUBSTAGE: Final[str] = \"none\"`

Flipping any field in the new metadata block requires (a) a coordinated source change pinned by an updated test, AND (b) the Path B / Path C governance amendments documented in `docs/governance/step5_gate_truth_table.md` section 6.

## Freshness contract (operator-mandated)

Each emitted `would_touch_paths` is a fresh, independent `[]` — never a shared object reference with the module-level `_STEP5_5_1_PROPOSED_DEFAULT` constant. This is enforced by the new helper `_fresh_step5_5_1_proposed()` which rebuilds the block from scratch on every call. A shallow `dict(...)` copy of the constant would have leaked the same list across every payload, allowing a future caller to mutate one returned payload and silently contaminate every prior snapshot.

The new test `test_step5_5_1_proposed_would_touch_paths_is_fresh_list_per_payload` exercises this contract: it emits three payloads (two eligible, one no-op), asserts none share a list reference, then appends a contaminant to one and proves the siblings + module-level default remain `[]`.

## New pin tests (6)

1. `test_step5_5_1_proposed_default_constant_keys_are_closed` — closed schema key set
2. `test_step5_5_1_proposed_default_values_are_safe` — pinned-False/empty/`\"dry_run_only\"` defaults
3. `test_step5_5_1_proposed_block_present_in_eligible_plan_payload` — emission contract for AUTO_ALLOWED path
4. `test_step5_5_1_proposed_block_present_in_no_op_plan_payload` — emission contract for no_eligible_item path
5. `test_step5_5_1_does_not_bump_schema_version` — additive change preserves `SCHEMA_VERSION == \"1.0\"` and `MODULE_VERSION == \"v3.15.16.A14\"`
6. `test_step5_5_1_proposed_would_touch_paths_is_fresh_list_per_payload` — freshness contract

## Local gate evidence

- [x] `pytest tests/unit/test_development_step5_loop.py -q` — 66 passed, 1 pre-existing Windows tempfile flake (unrelated to B2.1; CI on Linux passes)
- [x] `pytest tests/unit/test_recurring_maintenance_step5_loop.py tests/regression/test_v3_step5_artifacts_deterministic.py tests/smoke -q` — 39 passed
- [x] `python scripts/governance_lint.py` — OK (16 agents, 5 workflows checked)
- [x] `python scripts/push_body_safety_lint.py` — OK (6 surfaces, 6 tokens checked)
- [x] `python -m reporting.development_step5_loop --no-write` — verified emission of new block with closed schema and safe defaults

## Test plan

- [ ] CI green on all required checks
- [ ] B2.4a AST pin stays green (no runtime consumer of gating constants)
- [ ] Mergeability `CLEAN` / `MERGEABLE`
- [ ] Squash-merge if green; post-merge gates run