### PR TITLE
feat(b2-2)(step5): Step 5.2 PR dry-run — default-disabled additive schema

### DIFF
--- a/reporting/development_step5_loop.py
+++ b/reporting/development_step5_loop.py
@@ -234,6 +234,76 @@ def _fresh_step5_5_1_proposed() -> dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# B2.2 — Step 5.2 PR dry-run (default-disabled, additive schema)
+# ---------------------------------------------------------------------------
+
+#: v3.15.16.A15.B2.2 — Default-disabled "would do" preview for a
+#: hypothetical Step 5.2 cycle (the substage that would actually
+#: open a code-review request against ``main``). Every Boolean
+#: field is pinned False, every string field is empty, and every
+#: list field is empty. The block is emitted into every plan
+#: payload as METADATA ONLY; no runtime gate reads it.
+#:
+#: Flipping any field here requires:
+#:   (a) a coordinated source change pinned by updated tests, AND
+#:   (b) the Path B / Path C governance amendments documented in
+#:       docs/governance/step5_gate_truth_table.md section 6.
+#:
+#: ``step5_implementation_allowed`` remains ``Final[False]`` and
+#: ``STEP5_ENABLED_SUBSTAGE`` remains ``Final["none"]`` regardless
+#: of changes to this block — the B2.4a AST pin still holds, and
+#: the existing ``test_no_runtime_consumer_of_step5_gate_constants``
+#: test continues to assert no branch reads the gating constants.
+#:
+#: This constant declares the closed schema (used by tests).
+#: Emitted payloads MUST call ``_fresh_step5_5_2_proposed()`` instead
+#: of shallow-copying this constant — see helper below for why.
+_STEP5_5_2_PROPOSED_DEFAULT: Final[dict[str, Any]] = {
+    "mode": "dry_run_only",
+    "would_create_branch": False,
+    "would_open_pr": False,
+    "would_target_branch": "",
+    "would_branch_name": "",
+    "would_pr_title": "",
+    "would_pr_body": "",
+    "would_labels": [],
+    "would_reviewers": [],
+    "would_assignees": [],
+    "would_emit_release_gate_evidence": False,
+}
+
+
+def _fresh_step5_5_2_proposed() -> dict[str, Any]:
+    """Return a fresh Step 5.2 PR dry-run default block per payload.
+
+    The three list fields (``would_labels``, ``would_reviewers``,
+    ``would_assignees``) must each be a fresh empty list per
+    payload — never a shared object reference with the module-level
+    ``_STEP5_5_2_PROPOSED_DEFAULT`` constant. A shallow
+    ``dict(...)`` copy of the constant would leak the same lists
+    across every emitted payload, which a future caller could
+    mutate and silently affect prior snapshots. This helper
+    rebuilds the block from scratch so every emitted list field
+    is a fresh, independent ``[]``. String fields are immutable
+    in Python so they cannot exhibit the same aliasing hazard;
+    they are pinned to the empty literal regardless.
+    """
+    return {
+        "mode": "dry_run_only",
+        "would_create_branch": False,
+        "would_open_pr": False,
+        "would_target_branch": "",
+        "would_branch_name": "",
+        "would_pr_title": "",
+        "would_pr_body": "",
+        "would_labels": [],
+        "would_reviewers": [],
+        "would_assignees": [],
+        "would_emit_release_gate_evidence": False,
+    }
+
+
+# ---------------------------------------------------------------------------
 # Utility helpers
 # ---------------------------------------------------------------------------
 
@@ -411,6 +481,7 @@ def _build_plan_payload(
         "target_paths": target_paths,
         "discipline_invariants": dict(_DISCIPLINE_INVARIANTS),
         "step5_5_1_proposed": _fresh_step5_5_1_proposed(),
+        "step5_5_2_proposed": _fresh_step5_5_2_proposed(),
         "vocabularies": {
             "step5_substages": list(STEP5_SUBSTAGES),
             "halt_reasons": list(STEP5_HALT_REASONS),
@@ -444,6 +515,7 @@ def _build_no_op_plan_payload(*, generated_at_utc: str) -> dict[str, Any]:
         "target_paths": [],
         "discipline_invariants": dict(_DISCIPLINE_INVARIANTS),
         "step5_5_1_proposed": _fresh_step5_5_1_proposed(),
+        "step5_5_2_proposed": _fresh_step5_5_2_proposed(),
         "vocabularies": {
             "step5_substages": list(STEP5_SUBSTAGES),
             "halt_reasons": list(STEP5_HALT_REASONS),

--- a/tests/unit/test_development_step5_loop.py
+++ b/tests/unit/test_development_step5_loop.py
@@ -1436,3 +1436,244 @@ def test_step5_5_1_proposed_would_touch_paths_is_fresh_list_per_payload() -> Non
     assert list_b == []
     assert list_noop == []
     assert s5l._STEP5_5_1_PROPOSED_DEFAULT["would_touch_paths"] == []
+
+
+# ---------------------------------------------------------------------------
+# B2.2 — Step 5.2 PR dry-run (default-disabled, additive schema)
+#
+# These pin tests cover the closed schema and pinned-False/empty
+# defaults of the ``step5_5_2_proposed`` metadata block emitted
+# into every plan payload alongside the B2.1
+# ``step5_5_1_proposed`` block. The block is METADATA ONLY — no
+# runtime gate reads it.
+#
+# Note on the runtime-consumer property: the existing B2.4a test
+# ``test_no_runtime_consumer_of_step5_gate_constants`` already
+# scans the post-B2.2 module source on every CI run and asserts
+# that neither gating constant is read inside any ``if`` /
+# ``while`` / ``assert`` test expression. A separate B2.2 test
+# duplicating that AST walker would be redundant; the existing
+# test is the single source of truth.
+#
+# Per the operator's freshness requirement, the three list fields
+# (``would_labels``, ``would_reviewers``, ``would_assignees``)
+# emitted into each payload must be fresh, independent ``[]``
+# objects — never shared with the module-level
+# ``_STEP5_5_2_PROPOSED_DEFAULT`` constant or with sibling
+# payloads. The helper ``_fresh_step5_5_2_proposed`` exists for
+# exactly this reason.
+# ---------------------------------------------------------------------------
+
+
+_STEP5_5_2_PROPOSED_EXPECTED_KEYS: frozenset[str] = frozenset(
+    {
+        "mode",
+        "would_create_branch",
+        "would_open_pr",
+        "would_target_branch",
+        "would_branch_name",
+        "would_pr_title",
+        "would_pr_body",
+        "would_labels",
+        "would_reviewers",
+        "would_assignees",
+        "would_emit_release_gate_evidence",
+    }
+)
+
+
+def test_step5_5_2_proposed_default_constant_keys_are_closed() -> None:
+    """The module-level ``_STEP5_5_2_PROPOSED_DEFAULT`` constant has
+    exactly the closed key set declared by B2.2. Adding or removing
+    a key requires updating both the constant and this pin."""
+    assert (
+        set(s5l._STEP5_5_2_PROPOSED_DEFAULT.keys())
+        == _STEP5_5_2_PROPOSED_EXPECTED_KEYS
+    )
+
+
+def test_step5_5_2_proposed_default_values_are_safe() -> None:
+    """All Boolean fields default to False, all list fields are
+    empty, all string fields except ``mode`` are the empty
+    literal, and ``mode`` is the pinned literal ``"dry_run_only"``.
+    Flipping any value here requires a coordinated source change
+    pinned by an updated test plus Path B / Path C governance
+    amendments (truth-table doc section 6)."""
+    default = s5l._STEP5_5_2_PROPOSED_DEFAULT
+    assert default["mode"] == "dry_run_only"
+    assert default["would_create_branch"] is False
+    assert default["would_open_pr"] is False
+    assert default["would_target_branch"] == ""
+    assert default["would_branch_name"] == ""
+    assert default["would_pr_title"] == ""
+    assert default["would_pr_body"] == ""
+    assert default["would_labels"] == []
+    assert default["would_reviewers"] == []
+    assert default["would_assignees"] == []
+    assert default["would_emit_release_gate_evidence"] is False
+
+
+def test_step5_5_2_proposed_block_present_in_eligible_plan_payload() -> None:
+    """An eligible plan payload (AUTO_ALLOWED outcome) emits the
+    ``step5_5_2_proposed`` block with the closed schema and pinned
+    safe defaults."""
+    item = {
+        "candidate_id": "syn_b22_eligible",
+        "execution_authority": "AUTO_ALLOWED",
+        "acceptance_criteria": [],
+        "target_paths": [],
+    }
+    plan = s5l._build_plan_payload(
+        source_kind="bugfix",
+        item=item,
+        cycle_id="cid",
+        decision="AUTO_ALLOWED",
+        halt_reason="ok",
+        outcome="plan_emitted",
+        generated_at_utc="2026-05-15T00:00:00Z",
+    )
+    assert "step5_5_2_proposed" in plan
+    block = plan["step5_5_2_proposed"]
+    assert set(block.keys()) == _STEP5_5_2_PROPOSED_EXPECTED_KEYS
+    assert block["mode"] == "dry_run_only"
+    assert block["would_create_branch"] is False
+    assert block["would_open_pr"] is False
+    assert block["would_target_branch"] == ""
+    assert block["would_branch_name"] == ""
+    assert block["would_pr_title"] == ""
+    assert block["would_pr_body"] == ""
+    assert block["would_labels"] == []
+    assert block["would_reviewers"] == []
+    assert block["would_assignees"] == []
+    assert block["would_emit_release_gate_evidence"] is False
+
+
+def test_step5_5_2_proposed_block_present_in_no_op_plan_payload() -> None:
+    """The no_eligible_item plan payload emits the
+    ``step5_5_2_proposed`` block with the same closed schema and
+    pinned safe defaults as the eligible-item path."""
+    plan = s5l._build_no_op_plan_payload(
+        generated_at_utc="2026-05-15T00:00:00Z"
+    )
+    assert "step5_5_2_proposed" in plan
+    block = plan["step5_5_2_proposed"]
+    assert set(block.keys()) == _STEP5_5_2_PROPOSED_EXPECTED_KEYS
+    assert block["mode"] == "dry_run_only"
+    assert block["would_create_branch"] is False
+    assert block["would_open_pr"] is False
+    assert block["would_target_branch"] == ""
+    assert block["would_branch_name"] == ""
+    assert block["would_pr_title"] == ""
+    assert block["would_pr_body"] == ""
+    assert block["would_labels"] == []
+    assert block["would_reviewers"] == []
+    assert block["would_assignees"] == []
+    assert block["would_emit_release_gate_evidence"] is False
+
+
+def test_step5_5_2_does_not_bump_schema_version() -> None:
+    """B2.2 is an *additive* schema change. The module's
+    ``SCHEMA_VERSION`` and ``MODULE_VERSION`` constants are not
+    bumped by adding the ``step5_5_2_proposed`` block — adding an
+    optional metadata field with all-default values is
+    backward-compatible with consumers reading version 1.0."""
+    assert s5l.SCHEMA_VERSION == "1.0"
+    assert s5l.MODULE_VERSION == "v3.15.16.A14"
+
+
+def test_step5_5_2_proposed_list_fields_are_fresh_per_payload() -> None:
+    """Freshness assertion (operator-mandated): each of the three
+    list fields (``would_labels``, ``would_reviewers``,
+    ``would_assignees``) emitted into each plan payload is a fresh,
+    independent ``[]`` — NOT the same object as the module-level
+    ``_STEP5_5_2_PROPOSED_DEFAULT`` entry, and NOT shared between
+    payloads.
+
+    A future caller could otherwise mutate a returned payload's
+    list field and silently affect every other payload holding the
+    same list reference (including prior snapshots written to
+    disk). This test guarantees that scenario is structurally
+    impossible for every list field in the block.
+    """
+    list_field_names = ("would_labels", "would_reviewers", "would_assignees")
+
+    plan_a = s5l._build_plan_payload(
+        source_kind="bugfix",
+        item={
+            "candidate_id": "syn_b22_fresh_a",
+            "execution_authority": "AUTO_ALLOWED",
+            "acceptance_criteria": [],
+            "target_paths": [],
+        },
+        cycle_id="cid_a",
+        decision="AUTO_ALLOWED",
+        halt_reason="ok",
+        outcome="plan_emitted",
+        generated_at_utc="2026-05-15T00:00:00Z",
+    )
+    plan_b = s5l._build_plan_payload(
+        source_kind="bugfix",
+        item={
+            "candidate_id": "syn_b22_fresh_b",
+            "execution_authority": "AUTO_ALLOWED",
+            "acceptance_criteria": [],
+            "target_paths": [],
+        },
+        cycle_id="cid_b",
+        decision="AUTO_ALLOWED",
+        halt_reason="ok",
+        outcome="plan_emitted",
+        generated_at_utc="2026-05-15T00:00:00Z",
+    )
+    plan_noop = s5l._build_no_op_plan_payload(
+        generated_at_utc="2026-05-15T00:00:00Z"
+    )
+
+    block_a = plan_a["step5_5_2_proposed"]
+    block_b = plan_b["step5_5_2_proposed"]
+    block_noop = plan_noop["step5_5_2_proposed"]
+
+    for field in list_field_names:
+        module_default_list = s5l._STEP5_5_2_PROPOSED_DEFAULT[field]
+        list_a = block_a[field]
+        list_b = block_b[field]
+        list_noop = block_noop[field]
+
+        # Each emitted list has the expected empty value.
+        assert list_a == [], f"{field} not empty in plan A"
+        assert list_b == [], f"{field} not empty in plan B"
+        assert list_noop == [], f"{field} not empty in no-op plan"
+
+        # None of the emitted lists is the module-level default's list.
+        assert list_a is not module_default_list, (
+            f"{field}: plan A shares object with module default"
+        )
+        assert list_b is not module_default_list, (
+            f"{field}: plan B shares object with module default"
+        )
+        assert list_noop is not module_default_list, (
+            f"{field}: no-op plan shares object with module default"
+        )
+
+        # No two emitted lists share a reference with each other.
+        assert list_a is not list_b, f"{field}: plan A and plan B share object"
+        assert list_a is not list_noop, (
+            f"{field}: plan A and no-op plan share object"
+        )
+        assert list_b is not list_noop, (
+            f"{field}: plan B and no-op plan share object"
+        )
+
+        # Sanity check by mutation: mutating one emitted list must
+        # NOT propagate to any other emitted list or to the
+        # module-level default.
+        list_a.append("contaminant")
+        assert list_b == [], (
+            f"{field}: mutation of plan A leaked into plan B"
+        )
+        assert list_noop == [], (
+            f"{field}: mutation of plan A leaked into no-op plan"
+        )
+        assert s5l._STEP5_5_2_PROPOSED_DEFAULT[field] == [], (
+            f"{field}: mutation of plan A leaked into module default"
+        )


### PR DESCRIPTION
## Scope

B2.2 — Step 5.2 PR dry-run additive schema, scoped to **two files only**:

- `reporting/development_step5_loop.py` (+72 lines)
- `tests/unit/test_development_step5_loop.py` (+241 lines)

Net: 313 insertions, 0 deletions, 0 modifications.

No change to `reporting/development_operational_digest.py`. No change under `tests/regression/`. No new env flag. No removal of Final annotations. No new runtime consumer.

## Summary

Adds a metadata-only `step5_5_2_proposed` block to every plan payload emitted by `_build_plan_payload` and `_build_no_op_plan_payload`. The block declares a closed 11-field schema describing what a hypothetical Step 5.2 cycle (the substage that would actually open a code-review request against `main`) would propose:

| Field | Pinned value |
| --- | --- |
| `mode` | `\"dry_run_only\"` (literal) |
| `would_create_branch` | `False` |
| `would_open_pr` | `False` |
| `would_target_branch` | `\"\"` |
| `would_branch_name` | `\"\"` |
| `would_pr_title` | `\"\"` |
| `would_pr_body` | `\"\"` |
| `would_labels` | `[]` (fresh per payload) |
| `would_reviewers` | `[]` (fresh per payload) |
| `would_assignees` | `[]` (fresh per payload) |
| `would_emit_release_gate_evidence` | `False` |

## Architecture — runtime-unreachability invariant preserved

The block is **metadata only**. No runtime branch reads it. The existing B2.4a AST pin `test_no_runtime_consumer_of_step5_gate_constants` continues to scan the post-B2.2 module source on every CI run and asserts that neither gating constant is read inside any `if` / `while` / `assert` test expression:

- `step5_implementation_allowed: Final[bool] = False`
- `STEP5_ENABLED_SUBSTAGE: Final[str] = \"none\"`

**No parallel B2.2 AST scanner is introduced** (per operator refinement). The existing B2.4a test is the single source of truth for the architectural-unreachability property; adding a duplicate walker would be redundant and risk divergent logic.

Flipping any field in the new metadata block requires (a) a coordinated source change pinned by an updated test, AND (b) the Path B / Path C governance amendments documented in `docs/governance/step5_gate_truth_table.md` section 6.

## Freshness contract (operator-mandated)

Each of the three list fields (`would_labels`, `would_reviewers`, `would_assignees`) emitted into each payload is a fresh, independent `[]` — never a shared object reference with the module-level `_STEP5_5_2_PROPOSED_DEFAULT` constant or with sibling payloads. This is enforced by the new helper `_fresh_step5_5_2_proposed()` which rebuilds the block from scratch on every call.

The new test `test_step5_5_2_proposed_list_fields_are_fresh_per_payload` exercises this contract for every list field in turn: it emits three payloads (two eligible, one no-op), asserts none share a list reference, then appends a contaminant to one and proves siblings + module-level default remain `[]`.

String fields are immutable in Python so they cannot exhibit the same aliasing hazard; they are pinned to the empty literal regardless.

## New pin tests (6)

1. `test_step5_5_2_proposed_default_constant_keys_are_closed` — closed 11-key set.
2. `test_step5_5_2_proposed_default_values_are_safe` — pinned-False / empty-string / empty-list / `\"dry_run_only\"` defaults.
3. `test_step5_5_2_proposed_block_present_in_eligible_plan_payload` — emission contract for AUTO_ALLOWED path.
4. `test_step5_5_2_proposed_block_present_in_no_op_plan_payload` — emission contract for no_eligible_item path.
5. `test_step5_5_2_does_not_bump_schema_version` — additive change preserves `SCHEMA_VERSION == \"1.0\"` and `MODULE_VERSION == \"v3.15.16.A14\"`.
6. `test_step5_5_2_proposed_list_fields_are_fresh_per_payload` — freshness contract for all three list fields.

## Local gate evidence

- [x] `pytest tests/unit/test_development_step5_loop.py -q` — 73 passed (67 prior + 6 new B2.2)
- [x] `pytest tests/unit/test_recurring_maintenance_step5_loop.py tests/regression/test_v3_step5_artifacts_deterministic.py tests/smoke -q` — 39 passed
- [x] `python scripts/governance_lint.py` — OK (16 agents, 5 workflows checked)
- [x] `python scripts/push_body_safety_lint.py` — OK (6 surfaces, 6 tokens checked)
- [x] `python -m reporting.development_step5_loop --no-write` — verified emission of new block with closed schema and safe defaults

## Test plan

- [ ] CI green on all required checks
- [ ] B2.4a AST pin stays green (no runtime consumer of gating constants on post-B2.2 source)
- [ ] Mergeability `CLEAN` / `MERGEABLE`
- [ ] Squash-merge if green; post-merge gates run