### PR TITLE
feat(b2-8c)(n5b): Phase 2 precondition walkers 1-7

### DIFF
--- a/dashboard/api_merge_execution_dry_run.py
+++ b/dashboard/api_merge_execution_dry_run.py
@@ -1,92 +1,76 @@
-"""N5b Phase 2 — Token-bound dry-run endpoint skeleton (UNWIRED, fail-closed).
+"""N5b Phase 2 — Token-bound dry-run endpoint (B2.8c walker for preconditions 1–7).
 
-This module is the **B2.8b skeleton** of the future Phase 2
-token-bound dry-run endpoint described in
-``docs/governance/n5b_phase2_implementation_plan.md`` (§2.1/§2.2)
-and ``docs/governance/n5b_merge_execution_plan.md`` (§4.2/§10
-"Phase 2 — Token-bound dry-run").
+This module is the **B2.8c walker** layered on top of the B2.8b
+fail-closed skeleton. It implements the closed precondition walker
+for parent-doc §3 preconditions 1–7 (N4b activation, N4c operator
+UI presence, token bindings, intent, nonce) using
+``reporting.approval_token_runtime.verify_runtime_for_dry_run``
+and writes the preflight audit artefact via
+``reporting.n5b_merge_execution_dry_run.write_preflight``.
 
-**This is NOT a Phase 2 activation.** B2.8b ships ONLY the
-fail-closed skeleton: every request returns the closed-envelope
-``not_yet_implemented`` status. No token verification is
-performed, no GitHub API is called, no audit artefact is
-written, no environment variable is read, and the blueprint is
-**not wired** into ``dashboard/dashboard.py``. The §4.2 N4b
-Phase B activation and §4.3 N4c (or equivalent) mint/verify UI
-preconditions of the implementation plan remain unsatisfied
-and block any subsequent code-bearing sub-unit (B2.8c / B2.8d /
-B2.8e) until the operator explicitly confirms them.
-
-Hard guarantees (pinned by tests in
-``tests/unit/test_api_merge_execution_dry_run.py``)
------------------------------------------------------------
+What B2.8c implements (per
+``docs/governance/n5b_phase2_implementation_plan.md`` §3 and §6.2):
 
 * POST only — exactly one route at
   ``/api/agent-control/merge-execution/dry-run``. GET / PUT /
-  PATCH / DELETE return 405.
-* Every request returns the closed-envelope status
-  ``not_yet_implemented`` regardless of body validity. Malformed
-  bodies attach a bounded ``reason`` field and return HTTP 400;
-  well-formed bodies return HTTP 200. The envelope ``status``
-  field never deviates from ``not_yet_implemented`` in this
-  skeleton.
-* No token verification — this module does not import
-  ``reporting.approval_token_runtime``. Token verification
-  wiring is **B2.8c** scope.
-* No audit artefact write — this module does not import or
-  reference ``reporting.n5b_merge_execution_dry_run`` (which
-  does not exist yet). Audit projector is **B2.8c** scope.
-* No GitHub API call — this module does not import any
-  network primitive (``socket``, ``urllib``, ``requests``,
-  ``httpx``, ``aiohttp``) and performs no outbound HTTP call.
-  GitHub-API-dependent preconditions 8-17 are **B2.8d** scope.
-* No subprocess / shell-out — this module imports no child-process
-  primitive and uses no shell-spawning attribute of the os module.
-* No env var read — this module reads no environment variable
-  whatsoever.
-* No write outside ``logs/n5b_merge_execution/`` — this module
-  performs no filesystem write of any kind. The audit
-  artefact write path is reserved for B2.8c.
-* Every response envelope passes
-  ``reporting.agent_audit_summary.assert_no_secrets`` before
-  being returned to the client.
-* Every response envelope carries the closed six-field
-  discipline invariants verbatim
-  (``step5_implementation_allowed=False``,
-  ``step5_enabled_substage="none"``, ``level6_enabled=False``,
-  ``dry_run_only=True``, ``live_merge_implemented=False``,
-  ``deploy_coupled=False``) so the consumer always sees them.
-* Blueprint is **NOT** registered into
-  ``dashboard/dashboard.py`` by this PR. The two-line wiring
-  change is operator-only per
-  ``docs/governance/execution_authority.md`` and the no-touch
-  hook at ``.claude/hooks/deny_no_touch.py``. Wiring is
-  **B2.8e** scope.
+  PATCH / DELETE return 405. UNCHANGED from B2.8b.
+* Closed response envelope shape from §2.5. UNCHANGED from B2.8b.
+* Token verification routes through
+  :func:`reporting.approval_token_runtime.verify_runtime_for_dry_run`
+  only. The HMAC secret is read by that module exclusively;
+  this dashboard module reads NO environment variable.
+* Audit preflight artefact at
+  ``logs/n5b_merge_execution/preflight/latest.json`` is written
+  ONLY AFTER all of body validation + N4b configuration + N4c
+  component presence + token verification + binding checks
+  succeed. Invalid / malformed / expired / replayed / binding-
+  mismatched / mis-configured requests NEVER produce a preflight
+  artefact. (Operator-mandated B2.8c correction.)
+* Returns ``not_yet_implemented`` on success — never ``ok``. The
+  ``ok`` status is reserved for B2.8e when preconditions 8–17
+  also walk.
+* Stop conditions emitted by this slice are the closed §7 set
+  enumerated by the implementation plan §6.2: ``token_missing``,
+  ``token_invalid``, ``replay_detected``, ``binding_mismatch``
+  (drilled across pr_number / pr_head_sha / evidence_hash /
+  intent / nonce), ``pr_number_mismatch``. The status
+  ``configuration_missing`` is used for §3 preconditions 1 / 2.
+* No new stop-condition literal is introduced. The
+  post-verification preflight-write failure is surfaced as
+  ``status="rejected"``, ``stop_condition=None``,
+  ``reason="preflight_write_failed"`` (a reason, NOT a stop
+  condition) so the closed §7 vocabulary stays untouched.
 
-Status envelope contract
-------------------------
+What B2.8c does NOT do:
 
-The response envelope follows the closed schema declared in
-``docs/governance/n5b_phase2_implementation_plan.md`` §2.5.
-Every field is present in every response. The ``status`` value
-is always the literal ``not_yet_implemented`` for this
-skeleton sub-unit.
-
-Future sub-units (B2.8c onward) will emit additional closed
-status values (``ok``, ``rejected``, ``configuration_missing``)
-once the precondition walkers land. B2.8b never emits any of
-those values.
+* No GitHub-API-dependent preconditions (8–17). Those land in
+  B2.8d under their own operator-go.
+* No dry-run-decision artefact, no failure artefact, no history
+  artefact. Those writers land in B2.8d / B2.8e per §2.6.
+* No wiring into ``dashboard/dashboard.py``. The blueprint
+  remains UNWIRED; the two-line wiring patch is operator-only
+  per ``docs/governance/execution_authority.md`` and the
+  no-touch hook at ``.claude/hooks/deny_no_touch.py``. Wiring is
+  B2.8e scope.
+* No subprocess / shell-out / network primitive of any kind.
+* No environment-variable read in this module (the token runtime
+  reads the HMAC secret on this module's behalf).
+* No raw token persisted, no raw nonce surfaced.
 """
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any, Final
 
 from flask import Flask, Response, jsonify, request
 
+from reporting import approval_token_runtime as atr
+from reporting import n5b_merge_execution_dry_run as projector
 from reporting.agent_audit_summary import assert_no_secrets
 
-MODULE_VERSION: Final[str] = "v3.15.16.N5b.phase2.skeleton"
+MODULE_VERSION: Final[str] = "v3.15.16.N5b.phase2.walker_1_7"
 SCHEMA_VERSION: Final[int] = 1
 
 
@@ -136,6 +120,54 @@ _MAX_INTENT_LEN: Final[int] = 64
 _MAX_EVIDENCE_HASH_LEN: Final[int] = 256
 _MAX_REASON_LEN: Final[int] = 200
 
+#: Repo-rooted path to the N4c PWA mint/verify component. Walker
+#: precondition 2 checks this file exists at request time. The
+#: path is identical to the one the B2.8c-pre readiness pin test
+#: asserts.
+_REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+_N4C_COMPONENT_PATH: Final[Path] = (
+    _REPO_ROOT
+    / "frontend"
+    / "src"
+    / "routes"
+    / "AgentControl"
+    / "ApprovalTokenDiagnostics.tsx"
+)
+
+#: Operator-actor literal for the session-protected dry-run route.
+_OPERATOR_ACTOR_SESSION: Final[str] = "session"
+
+#: Closed mapping from body-shape validation reason → §7 stop
+#: condition. Body-shape failures translate to the §7 vocabulary
+#: where the failure unambiguously matches a stop condition.
+#: Unmatched reasons get ``None`` (envelope still says rejected;
+#: stop_condition stays null, reason carries the closed string).
+_BODY_REASON_TO_STOP_CONDITION: Final[dict[str, str]] = {
+    # token field problems → token_missing
+    "field_missing:token": "token_missing",
+    "field_value:token_length": "token_missing",
+    "field_type:token": "token_missing",
+    # pr_number problems → pr_number_mismatch (body lacks a valid pr_number
+    # to bind against, so the binding is unprovable)
+    "field_missing:pr_number": "pr_number_mismatch",
+    "field_type:pr_number": "pr_number_mismatch",
+    "field_value:pr_number_non_positive": "pr_number_mismatch",
+    # intent problems → binding_mismatch (intent dimension)
+    "field_missing:intent": "binding_mismatch",
+    "field_type:intent": "binding_mismatch",
+    "field_value:intent_length": "binding_mismatch",
+    "field_value:intent_not_pinned": "binding_mismatch",
+    # pr_head_sha problems → binding_mismatch (pr_head_sha dimension)
+    "field_missing:pr_head_sha": "binding_mismatch",
+    "field_type:pr_head_sha": "binding_mismatch",
+    "field_value:pr_head_sha_length": "binding_mismatch",
+    # evidence_hash problems → binding_mismatch (evidence_hash dimension)
+    "field_missing:evidence_hash": "binding_mismatch",
+    "field_type:evidence_hash": "binding_mismatch",
+    "field_value:evidence_hash_length": "binding_mismatch",
+    # body_missing / body_not_object: no §7 mapping; stop_condition stays null.
+}
+
 
 def _with_discipline(envelope: dict[str, Any]) -> dict[str, Any]:
     """Attach the closed discipline-invariant fields to ``envelope``.
@@ -153,34 +185,49 @@ def _safe_jsonify(payload: dict[str, Any]) -> Response:
     return jsonify(payload)
 
 
+def _utcnow_iso() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
 # ---------------------------------------------------------------------------
 # Envelope builders
 # ---------------------------------------------------------------------------
 
 
-def _not_yet_implemented_envelope(
+def _base_envelope(
     *,
+    status: str,
+    stop_condition: str | None,
+    preconditions_evaluated: int,
+    preconditions_passed: int,
+    would_proceed: bool,
     pr_number: int,
     pr_head_sha: str,
     reason: str | None = None,
 ) -> dict[str, Any]:
-    """Build the closed ``not_yet_implemented`` envelope per
-    implementation-plan §2.5.
+    """Build the closed envelope per implementation-plan §2.5.
 
-    The envelope's ``status`` is always the literal
-    ``not_yet_implemented``. ``would_proceed`` is always False.
-    ``stop_condition`` is always None — stop conditions are emitted
-    by the precondition walker in B2.8c onward.
+    ``status`` is one of the four closed-vocab values
+    (``ok`` / ``rejected`` / ``configuration_missing`` /
+    ``not_yet_implemented``). ``stop_condition`` is from the closed
+    §7 vocabulary OR ``None``. The six discipline invariants are
+    attached unconditionally via :func:`_with_discipline`.
+
+    ``reason`` is optional and bounded to :data:`_MAX_REASON_LEN`
+    chars. It carries closed strings only (body-validation reason
+    codes, ``preconditions_8_through_17_pending``,
+    ``preflight_write_failed``); it never contains user-supplied
+    free text.
     """
     envelope: dict[str, Any] = {
         "kind": "agent_control_merge_execution_dry_run",
         "schema_version": SCHEMA_VERSION,
         "module_version": MODULE_VERSION,
-        "status": "not_yet_implemented",
-        "stop_condition": None,
-        "preconditions_evaluated": 0,
-        "preconditions_passed": 0,
-        "would_proceed": False,
+        "status": status,
+        "stop_condition": stop_condition,
+        "preconditions_evaluated": preconditions_evaluated,
+        "preconditions_passed": preconditions_passed,
+        "would_proceed": would_proceed,
         "pr_number": pr_number,
         "pr_head_sha": pr_head_sha,
     }
@@ -189,32 +236,15 @@ def _not_yet_implemented_envelope(
     return _with_discipline(envelope)
 
 
-def _bad_body_envelope(reason: str) -> dict[str, Any]:
-    """Build the ``not_yet_implemented`` envelope with a sentinel
-    ``pr_number=0`` and empty ``pr_head_sha`` for the malformed-body
-    case. The HTTP layer pairs this envelope with status 400.
-
-    The envelope status remains the closed-vocab
-    ``not_yet_implemented`` per implementation-plan §2.4 ("No
-    other status value is permitted"); the ``reason`` field carries
-    the body-validation outcome (e.g. ``"body_missing"``,
-    ``"field_missing:token"``)."""
-    return _not_yet_implemented_envelope(
-        pr_number=0,
-        pr_head_sha="",
-        reason=reason,
-    )
-
-
 # ---------------------------------------------------------------------------
-# Request body validation
+# Request body validation (B2.8b shape — unchanged)
 # ---------------------------------------------------------------------------
 
 
 def _validate_body(
     body: Any,
 ) -> tuple[bool, str | None, int, str]:
-    """Validate the request body shape.
+    """Validate the request body shape. UNCHANGED from B2.8b.
 
     Returns ``(ok, reason, pr_number, pr_head_sha)`` where:
 
@@ -226,9 +256,7 @@ def _validate_body(
       first validation failure encountered.
     * ``pr_number`` and ``pr_head_sha`` are extracted from the
       body when present and well-typed; they default to ``0`` and
-      ``""`` otherwise. The skeleton echoes them back so the
-      future implementation has body-context in the envelope
-      regardless of validity.
+      ``""`` otherwise.
     """
     if body is None:
         return (False, "body_missing", 0, "")
@@ -286,39 +314,251 @@ def _validate_body(
 
 
 # ---------------------------------------------------------------------------
+# Verify-outcome → §7 stop-condition translation
+# ---------------------------------------------------------------------------
+
+
+#: Closed translation table from :data:`approval_token_runtime`'s
+#: verify envelope onto the §7 closed stop-condition vocabulary.
+#: The walker reads the verify envelope's ``outcome`` (and the
+#: companion ``reason`` for the binding-drift drill) and emits the
+#: corresponding §7 stop_condition. The status component of the
+#: walker envelope is always ``rejected`` for any non-``ok``
+#: outcome that reaches this map.
+_VERIFY_OUTCOME_TO_STOP_CONDITION: Final[dict[str, str]] = {
+    "replay_detected": "replay_detected",
+    "signature_invalid": "token_invalid",
+    "malformed_envelope": "token_invalid",
+    "expired": "token_invalid",
+    "unknown_kid": "token_invalid",
+    "intent_unknown": "binding_mismatch",
+    # binding_mismatch is handled separately because its specific
+    # reason determines whether the walker emits pr_number_mismatch
+    # (a stand-alone §7 stop condition) vs the generic
+    # binding_mismatch.
+}
+
+
+def _translate_verify_envelope(
+    verify_env: dict[str, Any],
+) -> tuple[str, str | None]:
+    """Translate a verify envelope from
+    :func:`reporting.approval_token_runtime.verify_runtime_for_dry_run`
+    onto the walker's ``(status, stop_condition)`` pair.
+
+    Only the closed §7 vocabulary plus the two skeleton statuses
+    are emitted. New literals are not introduced.
+    """
+    status = verify_env.get("status")
+    if status == "configuration_missing":
+        return ("configuration_missing", None)
+    if status == "ok":
+        return ("ok", None)
+    # Any other status from the runtime is a rejection.
+    outcome = verify_env.get("outcome")
+    if outcome == "binding_mismatch":
+        reason = verify_env.get("reason")
+        if reason == "pr_number_mismatch":
+            return ("rejected", "pr_number_mismatch")
+        # All other binding drift dimensions (pr_head_sha,
+        # evidence_hash, event_id, release_tag, intent_drift) →
+        # generic binding_mismatch.
+        return ("rejected", "binding_mismatch")
+    mapped = _VERIFY_OUTCOME_TO_STOP_CONDITION.get(outcome or "")
+    if mapped is not None:
+        return ("rejected", mapped)
+    # Unknown outcome — the runtime contract bounds outcome to the
+    # closed N4a vocabulary, but defense-in-depth: rejected with
+    # token_invalid (the broadest closed §7 token-side stop).
+    return ("rejected", "token_invalid")
+
+
+# ---------------------------------------------------------------------------
+# Preflight artefact write (post-verification only)
+# ---------------------------------------------------------------------------
+
+
+def _write_preflight_after_verification(
+    *,
+    pr_number: int,
+    pr_head_sha: str,
+    token_kid: str,
+    nonce_hash: str,
+) -> tuple[bool, str | None]:
+    """Persist the closed-schema preflight artefact.
+
+    Called ONLY after all of body validation + N4b configuration +
+    N4c component presence + token verification + binding checks
+    have passed. The projector is sentinel-restricted to
+    ``logs/n5b_merge_execution/`` and raises ``ValueError`` /
+    ``AssertionError`` / ``OSError`` on any unsafe write or
+    credential-shaped string.
+
+    Returns ``(True, None)`` on success or ``(False, "<bounded reason>")``
+    on a write failure. The bounded reason is one of
+    ``"preflight_write_failed"``; no underlying exception details
+    leak.
+    """
+    try:
+        projector.write_preflight(
+            pr_number=pr_number,
+            pr_head_sha=pr_head_sha,
+            token_kid=token_kid,
+            nonce_hash=nonce_hash,
+            operator_actor=_OPERATOR_ACTOR_SESSION,
+            generated_at_utc=_utcnow_iso(),
+        )
+    except Exception:
+        return (False, "preflight_write_failed")
+    return (True, None)
+
+
+# ---------------------------------------------------------------------------
 # View function — exactly one route
 # ---------------------------------------------------------------------------
 
 
 def _view_dry_run() -> tuple[Response, int]:
-    """POST handler for the token-bound dry-run endpoint skeleton.
+    """POST handler for the token-bound dry-run endpoint walker.
 
-    B2.8b behaviour:
+    Walks closed §3 preconditions 1–7 in the order:
 
-    * Parses request body. If the body is non-JSON / missing /
-      malformed, returns ``not_yet_implemented`` with a bounded
-      ``reason`` field at HTTP 400.
-    * If the body is well-formed, returns ``not_yet_implemented``
-      at HTTP 200.
-    * Never verifies a token. Never calls GitHub. Never writes
-      an audit artefact. Never reads an environment variable.
+    1. Body shape (existing :func:`_validate_body`).
+    2. N4b activated (``atr.is_configured()``).
+    3. N4c operator UI present (file presence at
+       :data:`_N4C_COMPONENT_PATH`).
+    4–7. Token verification + binding checks via
+       :func:`reporting.approval_token_runtime.verify_runtime_for_dry_run`.
+
+    Writes the preflight artefact ONLY after steps 1–7 all pass.
+    No preflight write on body-shape failure, missing N4b,
+    missing N4c, invalid token, expired token, replay, or any
+    binding mismatch.
+
+    Returns ``not_yet_implemented`` with
+    ``preconditions_evaluated=7``, ``preconditions_passed=7``,
+    ``reason="preconditions_8_through_17_pending"`` once all
+    seven preconditions clear and the preflight artefact is
+    written — never ``ok`` (which is reserved for B2.8e after
+    preconditions 8–17 also walk).
     """
-    # Parse body permissively — silent=True ensures malformed
-    # JSON returns None rather than raising 400 with the default
-    # Flask handler.
+    # Parse body permissively — silent=True ensures malformed JSON
+    # returns None rather than raising 400 with the default Flask
+    # handler.
     body: Any = request.get_json(silent=True)
-    ok, reason, pr_number, pr_head_sha = _validate_body(body)
-    if not ok:
-        return _safe_jsonify(_bad_body_envelope(reason or "body_invalid")), 400
-    return (
-        _safe_jsonify(
-            _not_yet_implemented_envelope(
-                pr_number=pr_number,
-                pr_head_sha=pr_head_sha,
-            )
-        ),
-        200,
+    ok_body, body_reason, pr_number, pr_head_sha = _validate_body(body)
+    if not ok_body:
+        stop = _BODY_REASON_TO_STOP_CONDITION.get(body_reason or "")
+        envelope = _base_envelope(
+            status="rejected",
+            stop_condition=stop,
+            preconditions_evaluated=0,
+            preconditions_passed=0,
+            would_proceed=False,
+            pr_number=pr_number,
+            pr_head_sha=pr_head_sha,
+            reason=body_reason or "body_invalid",
+        )
+        return _safe_jsonify(envelope), 400
+
+    # ---- Precondition 1: N4b activated on VPS ----
+    if not atr.is_configured():
+        envelope = _base_envelope(
+            status="configuration_missing",
+            stop_condition=None,
+            preconditions_evaluated=1,
+            preconditions_passed=0,
+            would_proceed=False,
+            pr_number=pr_number,
+            pr_head_sha=pr_head_sha,
+            reason="n4b_not_activated",
+        )
+        return _safe_jsonify(envelope), 200
+
+    # ---- Precondition 2: N4c (or equivalent) operator UI present ----
+    if not _N4C_COMPONENT_PATH.is_file():
+        envelope = _base_envelope(
+            status="configuration_missing",
+            stop_condition=None,
+            preconditions_evaluated=2,
+            preconditions_passed=1,
+            would_proceed=False,
+            pr_number=pr_number,
+            pr_head_sha=pr_head_sha,
+            reason="n4c_component_missing",
+        )
+        return _safe_jsonify(envelope), 200
+
+    # ---- Preconditions 3–7: token verification + bindings ----
+    # The dashboard module never reads the env or parses unverified
+    # token payloads for trust decisions — verify_runtime_for_dry_run
+    # owns both responsibilities.
+    body_dict: dict[str, Any] = body  # type: ignore[assignment]
+    verify_env = atr.verify_runtime_for_dry_run(
+        token=str(body_dict["token"]),
+        expected_pr_number=pr_number,
+        expected_pr_head_sha=pr_head_sha,
+        expected_evidence_hash=str(body_dict["evidence_hash"]),
+        expected_intent=_INTENT_LITERAL,
     )
+    status, stop_condition = _translate_verify_envelope(verify_env)
+    if status != "ok":
+        # No preflight write on any verification failure or runtime
+        # configuration-missing reading.
+        # The verify envelope's metadata is non-existent on
+        # non-ok branches by contract, so the walker only echoes
+        # the body's pr_number / pr_head_sha back.
+        envelope = _base_envelope(
+            status=status,
+            stop_condition=stop_condition,
+            preconditions_evaluated=7 if status == "rejected" else 2,
+            preconditions_passed=2,
+            would_proceed=False,
+            pr_number=pr_number,
+            pr_head_sha=pr_head_sha,
+            reason=str(verify_env.get("reason") or "")[:_MAX_REASON_LEN] or None,
+        )
+        return _safe_jsonify(envelope), 200
+
+    # ---- All 7 preconditions passed. Preflight write THEN
+    # not_yet_implemented (preconditions 8–17 are out of scope
+    # for B2.8c). ----
+    token_kid = str(verify_env.get("kid") or "")
+    nonce_hash = str(verify_env.get("nonce_hash") or "")
+    ok_write, write_reason = _write_preflight_after_verification(
+        pr_number=pr_number,
+        pr_head_sha=pr_head_sha,
+        token_kid=token_kid,
+        nonce_hash=nonce_hash,
+    )
+    if not ok_write:
+        # Post-verification write failure: surface as rejected with
+        # stop_condition=None and reason=preflight_write_failed.
+        # No new §7 stop-condition literal is introduced; the
+        # operator inspects the bounded reason field.
+        envelope = _base_envelope(
+            status="rejected",
+            stop_condition=None,
+            preconditions_evaluated=7,
+            preconditions_passed=7,
+            would_proceed=False,
+            pr_number=pr_number,
+            pr_head_sha=pr_head_sha,
+            reason=write_reason,
+        )
+        return _safe_jsonify(envelope), 500
+
+    envelope = _base_envelope(
+        status="not_yet_implemented",
+        stop_condition=None,
+        preconditions_evaluated=7,
+        preconditions_passed=7,
+        would_proceed=False,
+        pr_number=pr_number,
+        pr_head_sha=pr_head_sha,
+        reason="preconditions_8_through_17_pending",
+    )
+    return _safe_jsonify(envelope), 200
 
 
 # ---------------------------------------------------------------------------
@@ -342,10 +582,10 @@ _MERGE_EXECUTION_DRY_RUN_ROUTES: Final[
 
 
 def register_merge_execution_dry_run_routes(app: Flask) -> None:
-    """Register the N5b Phase 2 token-bound dry-run skeleton route.
+    """Register the N5b Phase 2 token-bound dry-run walker route.
 
-    **NOT** wired into ``dashboard/dashboard.py`` in the PR that
-    introduces this blueprint. The two-line wiring change
+    **NOT** wired into ``dashboard/dashboard.py`` by B2.8c. The
+    two-line wiring change
 
     ::
 

--- a/reporting/approval_token_runtime.py
+++ b/reporting/approval_token_runtime.py
@@ -41,6 +41,7 @@ Hard guarantees (pinned by tests)
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import tempfile
@@ -500,6 +501,206 @@ def verify_runtime(
     }
 
 
+# ---------------------------------------------------------------------------
+# N5b Phase 2 dry-run walker entrypoint (B2.8c)
+#
+# The dry-run dashboard endpoint (``dashboard/api_merge_execution_dry_run.py``)
+# does NOT carry an ``event_id`` in its closed request body (per
+# ``docs/governance/n5b_phase2_implementation_plan.md`` §2.3). The
+# existing :func:`verify_runtime` requires an ``expected_event_id``
+# kwarg, so a separate purpose-built wrapper is needed to cover the
+# dry-run flow. This wrapper:
+#
+# * Does NOT change the semantics, signature, or return shape of
+#   :func:`verify_runtime`, :func:`mint_runtime`, :func:`is_configured`,
+#   :func:`secrets_by_kid`, :func:`current_kid`, or :func:`record_nonce`.
+# * Pre-decodes the claimed ``event_id`` ONLY to feed it back into
+#   :func:`atg.verify_token`. The HMAC signature still binds every
+#   claim including ``event_id``, so the pre-decode is never used as
+#   a trust signal — a tampered ``event_id`` fails signature one step
+#   later.
+# * Pins ``expected_intent == "mobile_approval_dispatch"`` as the only
+#   permitted dry-run intent and rejects with no metadata otherwise.
+# * Surfaces verified metadata (kid, nonce_hash, event_id, intent)
+#   ONLY on a fully verified result. Every rejected /
+#   configuration_missing branch returns exactly the 3-key envelope
+#   ``{"status", "outcome", "reason"}`` — no claim metadata leaks.
+# * Never returns the raw nonce; only its sha256 hex digest.
+# * Records the verified nonce in the existing bounded seen-nonce
+#   store via :func:`record_nonce`, so the second presentation of the
+#   same token is rejected with ``outcome == "replay_detected"``.
+# ---------------------------------------------------------------------------
+
+
+_DRY_RUN_INTENT: Final[str] = "mobile_approval_dispatch"
+
+
+def _pre_decode_event_id(token: str) -> str:
+    """Best-effort extraction of the claimed ``event_id`` claim.
+
+    Used ONLY to feed :func:`atg.verify_token` so the signature check
+    can run. The signature still binds the ``event_id`` to the rest
+    of the claims; any tampered claim is rejected one step later.
+    This pre-decode never participates in a trust decision.
+
+    Returns the empty string on any failure (malformed envelope,
+    base64 / JSON error, missing field, wrong type). The empty
+    string then flows through :func:`atg.verify_token`, which
+    rejects with ``malformed_envelope`` or ``binding_mismatch``.
+    """
+    claims = _claims_from_token(token)
+    value = claims.get("event_id")
+    return value if isinstance(value, str) else ""
+
+
+def verify_runtime_for_dry_run(
+    *,
+    token: str,
+    expected_pr_number: int,
+    expected_pr_head_sha: str,
+    expected_evidence_hash: str,
+    expected_intent: str,
+) -> dict[str, Any]:
+    """N5b Phase 2 dry-run walker entrypoint.
+
+    Returns a closed-shape envelope:
+
+    * ``ok``::
+
+          {"status": "ok", "outcome": "ok", "reason": "verified",
+           "kid": <verified kid str>,
+           "nonce_hash": <sha256-hex of verified nonce>,
+           "event_id": <verified event_id str>,
+           "intent": <verified intent str>}
+
+    * ``rejected``::
+
+          {"status": "rejected", "outcome": <atg outcome>, "reason": <atg reason>}
+
+      No ``kid`` / ``nonce_hash`` / ``event_id`` / ``intent`` / claim
+      metadata is included in the rejected envelope.
+
+    * ``configuration_missing``::
+
+          {"status": "configuration_missing", "outcome": "",
+           "reason": "env_secret_absent"}
+
+      No metadata leak.
+
+    Failure modes (closed enumeration):
+
+    * ``expected_intent`` is not ``"mobile_approval_dispatch"`` →
+      rejected with ``outcome="intent_unknown"``,
+      ``reason="expected_intent_not_supported"``. The env is not
+      read; the verifier is not called.
+    * Env secret absent → ``configuration_missing``.
+    * Signature / shape / kid / expiry failures → bubble the closed
+      :data:`reporting.approval_token_gate.VERIFY_OUTCOMES` outcome.
+    * Binding drift in pr_number / pr_head_sha / evidence_hash →
+      ``outcome="binding_mismatch"`` with the underlying ``reason``
+      ('pr_number_mismatch', 'pr_head_sha_mismatch',
+      'evidence_hash_mismatch', etc.).
+    * Replay → ``outcome="replay_detected"``.
+    * Claimed intent differs from ``expected_intent`` after signature
+      verifies → rejected with ``outcome="binding_mismatch"``,
+      ``reason="intent_drift"``.
+
+    Never returns or persists the raw token, the raw nonce, or the
+    HMAC secret. The nonce is hashed (sha256 hex) before any
+    metadata surfacing.
+    """
+    # Pin the expected intent to the closed dry-run literal. This
+    # is the only intent the N5b Phase 2 dry-run endpoint accepts.
+    # Reject without reading the env, without calling the verifier,
+    # without exposing any metadata.
+    if expected_intent != _DRY_RUN_INTENT:
+        return {
+            "status": "rejected",
+            "outcome": "intent_unknown",
+            "reason": "expected_intent_not_supported",
+        }
+    by_kid = secrets_by_kid()
+    if not by_kid:
+        return {
+            "status": "configuration_missing",
+            "outcome": "",
+            "reason": "env_secret_absent",
+        }
+    # Pre-decode the claimed event_id ONLY to feed it back into
+    # verify_token. The signature step that follows binds the
+    # event_id to the rest of the claims, so a tampered event_id
+    # fails one step later. This is NOT a trust decision.
+    claimed_event_id_for_verify = _pre_decode_event_id(token)
+    seen = _read_seen_nonces()
+    result = atg.verify_token(
+        token,
+        expected_event_id=claimed_event_id_for_verify,
+        expected_pr_number=expected_pr_number,
+        expected_pr_head_sha=expected_pr_head_sha,
+        expected_evidence_hash=expected_evidence_hash,
+        expected_release_tag=None,
+        secrets_by_kid=by_kid,
+        seen_nonces=seen,
+    )
+    if result.outcome != "ok":
+        # No metadata leak on rejection — exactly the 3-key envelope.
+        return {
+            "status": "rejected",
+            "outcome": result.outcome,
+            "reason": result.reason,
+        }
+    if not isinstance(result.claims, dict):
+        # Defense-in-depth — verify_token's contract guarantees a
+        # claims dict on outcome == "ok", but a missing dict here
+        # is rejected without metadata leak.
+        return {
+            "status": "rejected",
+            "outcome": "malformed_envelope",
+            "reason": "claims_missing",
+        }
+    # Signature is verified; claims are now safe to consult.
+    claimed_intent = result.claims.get("intent")
+    if claimed_intent != expected_intent:
+        return {
+            "status": "rejected",
+            "outcome": "binding_mismatch",
+            "reason": "intent_drift",
+        }
+    nonce = result.claims.get("nonce")
+    if not isinstance(nonce, str) or not nonce:
+        return {
+            "status": "rejected",
+            "outcome": "malformed_envelope",
+            "reason": "nonce_missing",
+        }
+    # Record the verified nonce before surfacing metadata so a
+    # successful return implies the nonce can no longer replay.
+    # A failed write is non-fatal: the in-memory seen-set still
+    # holds the nonce for this process and the next request
+    # re-reads the persisted store. :func:`verify_runtime` makes
+    # the same trade-off.
+    try:
+        record_nonce(nonce)
+    except Exception:
+        pass
+    nonce_hash = hashlib.sha256(nonce.encode("utf-8")).hexdigest()
+    claimed_kid = result.claims.get("kid")
+    claimed_event_id_verified = result.claims.get("event_id")
+    return {
+        "status": "ok",
+        "outcome": "ok",
+        "reason": "verified",
+        "kid": claimed_kid if isinstance(claimed_kid, str) else "",
+        "nonce_hash": nonce_hash,
+        "event_id": (
+            claimed_event_id_verified
+            if isinstance(claimed_event_id_verified, str)
+            else ""
+        ),
+        "intent": claimed_intent,
+    }
+
+
 __all__ = [
     "CURRENT_KID",
     "ENV_APPROVAL_TOKEN_HMAC_SECRET",
@@ -519,4 +720,5 @@ __all__ = [
     "secrets_by_kid",
     "step5_implementation_allowed",
     "verify_runtime",
+    "verify_runtime_for_dry_run",
 ]

--- a/reporting/n5b_merge_execution_dry_run.py
+++ b/reporting/n5b_merge_execution_dry_run.py
@@ -1,0 +1,342 @@
+"""N5b Phase 2 — Dry-run audit projector (B2.8c, preflight only).
+
+Sentinel-restricted writer for the closed-schema **preflight**
+artefact emitted by the N5b Phase 2 token-bound dry-run endpoint
+skeleton + walker
+(``dashboard/api_merge_execution_dry_run.py``).
+
+Scope of this slice (B2.8c) is the preflight artefact ONLY, per
+``docs/governance/n5b_phase2_implementation_plan.md`` §6.2:
+
+    "The preflight artefact is written before the verify call."
+
+…with the operator-mandated B2.8c correction that the preflight
+write is only performed AFTER the body / N4b / N4c / token-binding
+preconditions 1–7 all pass — never on invalid, replayed,
+binding-mismatched, expired, or malformed token inputs.
+
+The dry-run-decision artefact (``logs/n5b_merge_execution/dry_run/latest.json``),
+the dry-run history artefact (``…/dry_run/history.jsonl``), and the
+failure artefact (``…/failure/<cycle_id>.json``) are NOT written
+by this slice. They are reserved for B2.8d / B2.8e per the
+implementation plan §2.6.
+
+Hard guarantees (pinned by
+``tests/unit/test_n5b_merge_execution_dry_run.py``):
+
+* Stdlib + :func:`reporting.agent_audit_summary.assert_no_secrets`
+  (read-only redactor guard). No other imports.
+* No subprocess, no socket, no urllib, no requests, no httpx, no
+  aiohttp, no asyncio.
+* No GitHub CLI literal, no version-control CLI literal, no
+  branch-protection-bypass admin flag, no PR-mutation attribute
+  name literal.
+* No environment-variable read (the projector takes every value as
+  an argument from the caller; the caller alone — via
+  ``reporting.approval_token_runtime`` — is allowed to read the env
+  HMAC secret).
+* Atomic write via ``tempfile.mkstemp`` + ``os.replace``.
+* Sentinel-restricted write prefix: any write whose absolute path
+  does not contain ``logs/n5b_merge_execution/`` raises
+  ``ValueError`` BEFORE the temp file is created.
+* :func:`reporting.agent_audit_summary.assert_no_secrets` runs on
+  the snapshot before write; a credential-shaped string aborts
+  with ``AssertionError`` and no file is created.
+* Closed snapshot schema (key-set check) — drift fails the pin
+  test in the same PR that introduces the change.
+* The closed ``discipline_invariants`` dict is emitted into every
+  artefact, mirroring the ``api_merge_preflight`` envelope contract.
+* :data:`step5_implementation_allowed` is ``Final[False]``,
+  :data:`STEP5_ENABLED_SUBSTAGE` is ``Final["none"]``,
+  ``level6_enabled`` is always ``False``.
+* The projector never accepts the raw nonce or the raw token —
+  only the caller-supplied ``token_kid`` (verified) and
+  ``nonce_hash`` (sha256 hex of the verified nonce). The closed
+  schema does not contain a ``token`` field or a raw ``nonce``
+  field.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Final
+
+from reporting.agent_audit_summary import assert_no_secrets
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[int] = 1
+MODULE_VERSION: Final[str] = "v3.15.16.N5b.phase2.projector"
+REPORT_KIND: Final[str] = "n5b_preflight"
+
+
+# ---------------------------------------------------------------------------
+# Step 5 + Level 6 invariants
+# ---------------------------------------------------------------------------
+
+STEP5_ENABLED_SUBSTAGE: Final[str] = "none"
+step5_implementation_allowed: Final[bool] = False
+
+
+# ---------------------------------------------------------------------------
+# Closed write-prefix + repo-relative artefact paths
+# ---------------------------------------------------------------------------
+
+#: Sentinel substring that EVERY write path must contain. The
+#: :func:`_atomic_write_json` helper raises ``ValueError`` if the
+#: target path does not match. Defense-in-depth against a future
+#: caller that mistakenly passes a non-N5b log path.
+WRITE_PREFIX: Final[str] = "logs/n5b_merge_execution/"
+
+PREFLIGHT_DIR: Final[Path] = REPO_ROOT / "logs" / "n5b_merge_execution" / "preflight"
+PREFLIGHT_LATEST: Final[Path] = PREFLIGHT_DIR / "latest.json"
+PREFLIGHT_LATEST_RELATIVE: Final[str] = (
+    "logs/n5b_merge_execution/preflight/latest.json"
+)
+
+
+# ---------------------------------------------------------------------------
+# Closed allowed values
+# ---------------------------------------------------------------------------
+
+#: The ONLY base ref the N5b adapter accepts (parent doc §3 row 12).
+PR_BASE_REF: Final[str] = "main"
+
+#: The pinned dry-run intent literal.
+DRY_RUN_INTENT: Final[str] = "mobile_approval_dispatch"
+
+#: The closed operator_actor vocabulary. The B2.8c walker is
+#: session-protected, so it always passes ``"session"``. A future
+#: operator-token-mediated path would pass ``"operator_token"``.
+OPERATOR_ACTORS: Final[tuple[str, ...]] = ("session", "operator_token")
+
+
+# ---------------------------------------------------------------------------
+# Discipline invariants — mirrored into every artefact
+# ---------------------------------------------------------------------------
+
+_DISCIPLINE_INVARIANTS: Final[dict[str, bool | str]] = {
+    "dry_run_only": True,
+    "live_merge_implemented": False,
+    "executes_merge": False,
+    "calls_github_api": False,
+    "uses_subprocess_or_network": False,
+    "deploy_coupled": False,
+    "mints_or_verifies_approval_tokens": False,
+    "writes_seed_files": False,
+    "writes_generated_seed": False,
+    "opens_or_merges_prs": False,
+    "step5_implementation_allowed": False,
+    "step5_enabled_substage": "none",
+    "level6_enabled": False,
+}
+
+
+# ---------------------------------------------------------------------------
+# Closed preflight snapshot schema (exact key set)
+# ---------------------------------------------------------------------------
+
+PREFLIGHT_SNAPSHOT_KEYS: Final[tuple[str, ...]] = (
+    "schema_version",
+    "report_kind",
+    "module_version",
+    "pr_number",
+    "pr_head_sha",
+    "pr_base_ref",
+    "intent",
+    "token_kid",
+    "nonce_hash",
+    "operator_actor",
+    "generated_at_utc",
+    "step5_implementation_allowed",
+    "step5_enabled_substage",
+    "level6_enabled",
+    "dry_run_only",
+    "live_merge_implemented",
+    "deploy_coupled",
+    "discipline_invariants",
+)
+
+
+# ---------------------------------------------------------------------------
+# Snapshot builder (pure, deterministic — no I/O)
+# ---------------------------------------------------------------------------
+
+
+def build_preflight_snapshot(
+    *,
+    pr_number: int,
+    pr_head_sha: str,
+    token_kid: str,
+    nonce_hash: str,
+    operator_actor: str,
+    generated_at_utc: str,
+) -> dict[str, Any]:
+    """Build the closed-schema preflight snapshot dict.
+
+    Pure — no I/O. The caller is responsible for supplying VERIFIED
+    values for ``token_kid`` and ``nonce_hash`` (sha256 hex of the
+    nonce, NOT the raw nonce). The projector enforces value-shape
+    invariants and rejects out-of-vocab ``operator_actor`` values
+    so the artefact never carries an unanchored sentinel.
+
+    Raises:
+      :class:`TypeError` if ``pr_number`` is not an ``int`` (or is a
+      ``bool``).
+      :class:`ValueError` if any string field fails its bounded-shape
+      check, or if ``operator_actor`` is outside
+      :data:`OPERATOR_ACTORS`.
+    """
+    if not isinstance(pr_number, int) or isinstance(pr_number, bool):
+        raise TypeError("pr_number must be int")
+    if pr_number <= 0:
+        raise ValueError("pr_number must be positive")
+    if not isinstance(pr_head_sha, str) or not pr_head_sha:
+        raise ValueError("pr_head_sha must be a non-empty string")
+    if len(pr_head_sha) > 64:
+        raise ValueError("pr_head_sha exceeds 64 chars")
+    if not isinstance(token_kid, str) or not token_kid:
+        raise ValueError("token_kid must be a non-empty string")
+    if len(token_kid) > 64:
+        raise ValueError("token_kid exceeds 64 chars")
+    if not isinstance(nonce_hash, str) or len(nonce_hash) != 64:
+        raise ValueError("nonce_hash must be a 64-char sha256 hex digest")
+    if any(c not in "0123456789abcdef" for c in nonce_hash):
+        raise ValueError("nonce_hash must be lowercase hex")
+    if operator_actor not in OPERATOR_ACTORS:
+        raise ValueError(
+            f"operator_actor must be one of {OPERATOR_ACTORS}; got {operator_actor!r}"
+        )
+    if not isinstance(generated_at_utc, str) or not generated_at_utc:
+        raise ValueError("generated_at_utc must be a non-empty ISO 8601 string")
+
+    snapshot: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "module_version": MODULE_VERSION,
+        "pr_number": pr_number,
+        "pr_head_sha": pr_head_sha,
+        "pr_base_ref": PR_BASE_REF,
+        "intent": DRY_RUN_INTENT,
+        "token_kid": token_kid,
+        "nonce_hash": nonce_hash,
+        "operator_actor": operator_actor,
+        "generated_at_utc": generated_at_utc,
+        "step5_implementation_allowed": step5_implementation_allowed,
+        "step5_enabled_substage": STEP5_ENABLED_SUBSTAGE,
+        "level6_enabled": False,
+        "dry_run_only": True,
+        "live_merge_implemented": False,
+        "deploy_coupled": False,
+        "discipline_invariants": dict(_DISCIPLINE_INVARIANTS),
+    }
+    assert set(snapshot.keys()) == set(PREFLIGHT_SNAPSHOT_KEYS), (
+        f"preflight snapshot key drift: {sorted(snapshot.keys())!r} vs "
+        f"{sorted(PREFLIGHT_SNAPSHOT_KEYS)!r}"
+    )
+    return snapshot
+
+
+# ---------------------------------------------------------------------------
+# Sentinel-restricted atomic writer
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Write ``payload`` to ``path`` atomically.
+
+    Sentinel-restricted: ``path`` MUST contain
+    :data:`WRITE_PREFIX` in its POSIX-form string. Otherwise raises
+    ``ValueError`` BEFORE the temp file is created.
+
+    ``assert_no_secrets`` is invoked on ``payload`` first. A
+    credential-shaped string aborts the write with
+    ``AssertionError``.
+    """
+    posix = path.as_posix()
+    if WRITE_PREFIX not in posix:
+        raise ValueError(
+            "n5b_merge_execution_dry_run._atomic_write_json refuses "
+            f"non-N5b-logs output path: {path}"
+        )
+    assert_no_secrets(payload)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".n5b_merge_execution_dry_run.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Public writer — preflight only (B2.8c scope)
+# ---------------------------------------------------------------------------
+
+
+def write_preflight(
+    *,
+    pr_number: int,
+    pr_head_sha: str,
+    token_kid: str,
+    nonce_hash: str,
+    operator_actor: str,
+    generated_at_utc: str,
+    target_path: Path | None = None,
+) -> Path:
+    """Build + persist the closed-schema preflight artefact.
+
+    Writes to :data:`PREFLIGHT_LATEST` by default. ``target_path``
+    is exposed for unit-test isolation (the test redirects writes
+    into ``tmp_path/logs/n5b_merge_execution/preflight/latest.json``);
+    even the test path must contain :data:`WRITE_PREFIX` or the
+    sentinel guard fails.
+
+    The dry-run-decision artefact, the dry-run history artefact,
+    and the failure artefact are NOT written by this function.
+    Those writers are reserved for B2.8d / B2.8e per the
+    implementation plan §2.6.
+    """
+    snapshot = build_preflight_snapshot(
+        pr_number=pr_number,
+        pr_head_sha=pr_head_sha,
+        token_kid=token_kid,
+        nonce_hash=nonce_hash,
+        operator_actor=operator_actor,
+        generated_at_utc=generated_at_utc,
+    )
+    target = target_path if target_path is not None else PREFLIGHT_LATEST
+    _atomic_write_json(target, snapshot)
+    return target
+
+
+__all__ = [
+    "DRY_RUN_INTENT",
+    "MODULE_VERSION",
+    "OPERATOR_ACTORS",
+    "PREFLIGHT_DIR",
+    "PREFLIGHT_LATEST",
+    "PREFLIGHT_LATEST_RELATIVE",
+    "PREFLIGHT_SNAPSHOT_KEYS",
+    "PR_BASE_REF",
+    "REPORT_KIND",
+    "SCHEMA_VERSION",
+    "STEP5_ENABLED_SUBSTAGE",
+    "WRITE_PREFIX",
+    "build_preflight_snapshot",
+    "step5_implementation_allowed",
+    "write_preflight",
+]

--- a/tests/unit/test_api_merge_execution_dry_run.py
+++ b/tests/unit/test_api_merge_execution_dry_run.py
@@ -1,31 +1,29 @@
-"""Pin tests for the B2.8b — N5b Phase 2 token-bound dry-run endpoint
-skeleton (UNWIRED, fail-closed).
+"""Pin tests for the B2.8c N5b Phase 2 token-bound dry-run walker
+(``dashboard/api_merge_execution_dry_run.py``).
 
-The module under test (``dashboard/api_merge_execution_dry_run.py``)
-ships **only** the fail-closed skeleton: every request returns
-the closed-envelope ``not_yet_implemented`` status, no token
-verification is performed, no GitHub API is called, no audit
-artefact is written, no environment variable is read, and the
-blueprint is **not wired** into ``dashboard/dashboard.py``.
+The module under test ships the walker for parent-doc §3
+preconditions 1–7 layered on top of the B2.8b skeleton. The
+closed contracts (route, envelope, method, UNWIRED state) are
+preserved verbatim; the walker adds the rejected /
+configuration_missing / not_yet_implemented branches and the
+preflight artefact write that must occur ONLY after all 1–7
+clear.
 
-These pin tests lock the skeleton's invariants. Subsequent
-sub-units (B2.8c / B2.8d / B2.8e) inherit the pins; they may
-extend the closed status vocabulary (``ok`` / ``rejected`` /
-``configuration_missing``) and replace specific skeleton-only
-pins (e.g. "every request returns not_yet_implemented") but
-must update each pin in the same PR that introduces the new
-behaviour.
+The preconditions 8–17 (GitHub-API-dependent) remain in B2.8d
+scope and are not exercised here. The dry-run-decision / failure
+/ history artefact writers remain in B2.8d / B2.8e scope.
 
-Defense-in-depth note: the forbidden marker strings the tests
-search for are NEVER embedded as literals in this file when
-they would also trip the runtime source-text scan; markers are
-assembled at runtime from constituent parts.
+Defense-in-depth note: forbidden marker strings the tests search
+for are NEVER embedded as literals in this file when they would
+also trip the runtime source-text scan; markers are assembled at
+runtime from constituent parts.
 """
 
 from __future__ import annotations
 
 import ast
 import json
+import secrets as _secrets
 from pathlib import Path
 from typing import Any
 
@@ -33,12 +31,53 @@ import pytest
 from flask import Flask
 
 from dashboard import api_merge_execution_dry_run as mod
+from reporting import approval_token_runtime as atr
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 MODULE_PATH = REPO_ROOT / "dashboard" / "api_merge_execution_dry_run.py"
 DASHBOARD_PY = REPO_ROOT / "dashboard" / "dashboard.py"
+N4C_COMPONENT_PATH = (
+    REPO_ROOT
+    / "frontend"
+    / "src"
+    / "routes"
+    / "AgentControl"
+    / "ApprovalTokenDiagnostics.tsx"
+)
 
 ROUTE_URL = "/api/agent-control/merge-execution/dry-run"
+
+
+# ---------------------------------------------------------------------------
+# Test isolation — env + seen-nonce store + preflight artefact target
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolate_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Redirect the approval-token-runtime seen-nonce store and the
+    preflight artefact write target into ``tmp_path/...``. The repo's
+    real artefact paths are never touched by these tests."""
+    seen_target = tmp_path / "state" / "approval_token_seen_nonces.jsonl"
+    seen_target.parent.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(atr, "SEEN_NONCES_PATH", seen_target)
+
+    preflight_target = (
+        tmp_path
+        / "logs"
+        / "n5b_merge_execution"
+        / "preflight"
+        / "latest.json"
+    )
+    preflight_target.parent.mkdir(parents=True, exist_ok=True)
+    # Re-bind the projector's PREFLIGHT_LATEST to the tmp path so the
+    # walker writes into the test sandbox. The sentinel substring
+    # ``logs/n5b_merge_execution/`` is preserved by the redirection.
+    from reporting import n5b_merge_execution_dry_run as projector
+
+    monkeypatch.setattr(projector, "PREFLIGHT_LATEST", preflight_target)
+    monkeypatch.delenv(atr.ENV_APPROVAL_TOKEN_HMAC_SECRET, raising=False)
+    yield preflight_target
 
 
 # ---------------------------------------------------------------------------
@@ -47,12 +86,11 @@ ROUTE_URL = "/api/agent-control/merge-execution/dry-run"
 
 
 def test_module_imports_successfully() -> None:
-    """Smoke pin: importing the module does not raise."""
     assert mod is not None
 
 
 def test_module_version_is_pinned_string() -> None:
-    assert mod.MODULE_VERSION == "v3.15.16.N5b.phase2.skeleton"
+    assert mod.MODULE_VERSION == "v3.15.16.N5b.phase2.walker_1_7"
 
 
 def test_schema_version_is_pinned_integer_1() -> None:
@@ -68,14 +106,13 @@ def test_step5_implementation_allowed_is_pinned_false() -> None:
 
 
 def test_all_exports_are_closed() -> None:
-    expected = {
+    assert set(mod.__all__) == {
         "MODULE_VERSION",
         "SCHEMA_VERSION",
         "STEP5_ENABLED_SUBSTAGE",
         "register_merge_execution_dry_run_routes",
         "step5_implementation_allowed",
     }
-    assert set(mod.__all__) == expected
 
 
 def test_register_helper_callable_exists() -> None:
@@ -83,7 +120,7 @@ def test_register_helper_callable_exists() -> None:
 
 
 # ---------------------------------------------------------------------------
-# AST guards — forbidden imports
+# AST guards — forbidden imports; required imports
 # ---------------------------------------------------------------------------
 
 
@@ -95,21 +132,23 @@ _FORBIDDEN_IMPORT_TOPS = (
     "httpx",
     "aiohttp",
     "asyncio",
-    # B2.8b must NOT import the token runtime — that wiring is
-    # reserved for B2.8c. Adding this import here without
-    # narrowing this pin is the contract violation we want to
-    # catch.
+    # B2.8c is allowed to import the token runtime + the projector.
+    # No GitHub API client of any flavour.
+    "github",
+    "ghapi",
+    "PyGithub",
+)
+
+_REQUIRED_IMPORTS = (
     "reporting.approval_token_runtime",
-    # B2.8b must NOT import the reporting-side audit projector
-    # — that module does not exist yet and lands in B2.8c.
     "reporting.n5b_merge_execution_dry_run",
 )
 
 
 def _module_imports() -> list[str]:
-    """Return the list of top-level module names imported by
-    the module under test (both ``import X`` and ``from X
-    import ...``)."""
+    """Return the set of importable names referenced by the module's
+    imports. For ``from PKG import NAME`` we emit both ``PKG`` and
+    ``PKG.NAME`` so positive pins on dotted-form imports work."""
     src = MODULE_PATH.read_text(encoding="utf-8")
     tree = ast.parse(src)
     names: list[str] = []
@@ -119,6 +158,8 @@ def _module_imports() -> list[str]:
                 names.append(alias.name)
         if isinstance(node, ast.ImportFrom) and node.module is not None:
             names.append(node.module)
+            for alias in node.names:
+                names.append(f"{node.module}.{alias.name}")
     return names
 
 
@@ -127,33 +168,34 @@ def test_module_has_no_forbidden_top_level_imports() -> None:
     offending: list[str] = []
     for name in imported:
         for forbidden in _FORBIDDEN_IMPORT_TOPS:
-            # Match exact name OR dotted-prefix match (e.g.
-            # `socket.socket` matches `socket`; `subprocess.run`
-            # matches `subprocess`).
             if name == forbidden or name.startswith(forbidden + "."):
                 offending.append(name)
     assert offending == [], (
-        "skeleton imports forbidden modules: "
-        f"{offending!r}. B2.8b must not import any subprocess / "
-        "network / token-runtime / audit-projector module."
+        f"walker imports forbidden modules: {offending!r}."
     )
 
 
+def test_module_imports_token_runtime_and_projector() -> None:
+    """Positive pin: B2.8c is required to import the two B2.8c-scope
+    modules. Removing either import indicates the walker was reverted
+    to the B2.8b skeleton without a corresponding pin-test update."""
+    imported = set(_module_imports())
+    for required in _REQUIRED_IMPORTS:
+        assert required in imported, (
+            f"walker must import {required!r} (B2.8c scope)"
+        )
+
+
 def test_module_does_not_import_os_system_or_popen() -> None:
-    """``os.system`` and ``os.popen`` are shell-spawning primitives.
-    The skeleton must use neither."""
     src = MODULE_PATH.read_text(encoding="utf-8")
-    # Assemble forbidden attributes from parts so this test source
-    # remains inert to greppers.
     forbidden = ("o" + "s.system", "o" + "s.popen")
     for marker in forbidden:
         assert marker not in src, (
-            f"skeleton contains forbidden attribute reference: {marker!r}"
+            f"walker contains forbidden attribute reference: {marker!r}"
         )
 
 
 def test_module_does_not_invoke_subprocess_attrs() -> None:
-    """Source-text scan for any subprocess-attribute reference."""
     src = MODULE_PATH.read_text(encoding="utf-8")
     forbidden_attrs = (
         "s" + "ubprocess.run",
@@ -164,47 +206,56 @@ def test_module_does_not_invoke_subprocess_attrs() -> None:
     )
     for marker in forbidden_attrs:
         assert marker not in src, (
-            f"skeleton contains forbidden attribute reference: {marker!r}"
+            f"walker contains forbidden attribute reference: {marker!r}"
         )
 
 
 # ---------------------------------------------------------------------------
-# Source-text guards — forbidden shell-out literals
+# Source-text guards — forbidden shell-out + mutation literals
 # ---------------------------------------------------------------------------
 
 
 def test_module_contains_no_gh_shellout_literal() -> None:
-    """No GitHub CLI shell-out literal in the skeleton."""
     src = MODULE_PATH.read_text(encoding="utf-8")
     forbidden_literal = "g" + "h " + "pr " + "merge"
     assert forbidden_literal not in src, (
-        f"skeleton contains forbidden shell-out literal: "
-        f"{forbidden_literal!r}"
+        f"walker contains forbidden shell-out literal: {forbidden_literal!r}"
     )
 
 
 def test_module_contains_no_git_merge_literal() -> None:
-    """No version-control CLI merge literal in the skeleton."""
     src = MODULE_PATH.read_text(encoding="utf-8")
     forbidden_literal = "g" + "it " + "merge"
     assert forbidden_literal not in src, (
-        f"skeleton contains forbidden shell-out literal: "
-        f"{forbidden_literal!r}"
+        f"walker contains forbidden shell-out literal: {forbidden_literal!r}"
     )
 
 
 def test_module_contains_no_admin_flag_literal() -> None:
-    """No ``--admin`` flag literal — branch-protection bypass
-    is permanently denied per n5b_merge_execution_plan.md §8.4."""
     src = MODULE_PATH.read_text(encoding="utf-8")
     forbidden_literal = "--" + "admin"
     assert forbidden_literal not in src, (
-        f"skeleton contains forbidden flag literal: {forbidden_literal!r}"
+        f"walker contains forbidden flag literal: {forbidden_literal!r}"
+    )
+
+
+def test_module_contains_no_no_verify_flag_literal() -> None:
+    src = MODULE_PATH.read_text(encoding="utf-8")
+    forbidden_literal = "--" + "no-verify"
+    assert forbidden_literal not in src, (
+        f"walker contains forbidden flag literal: {forbidden_literal!r}"
+    )
+
+
+def test_module_contains_no_force_push_literal() -> None:
+    src = MODULE_PATH.read_text(encoding="utf-8")
+    forbidden_literal = "p" + "ush --force"
+    assert forbidden_literal not in src, (
+        f"walker contains forbidden flag literal: {forbidden_literal!r}"
     )
 
 
 def test_module_contains_no_merge_pr_attribute_literals() -> None:
-    """No PR-mutation attribute name appears in the skeleton."""
     src = MODULE_PATH.read_text(encoding="utf-8")
     forbidden_tokens = (
         "p" + "r_merge_approved",
@@ -212,13 +263,13 @@ def test_module_contains_no_merge_pr_attribute_literals() -> None:
     )
     for marker in forbidden_tokens:
         assert marker not in src, (
-            f"skeleton contains forbidden PR-mutation literal: {marker!r}"
+            f"walker contains forbidden PR-mutation literal: {marker!r}"
         )
 
 
 def test_module_reads_no_env_var() -> None:
-    """The skeleton must read no environment variable. Source-text
-    scan for the common env-read attributes."""
+    """The walker must read no environment variable directly; only
+    ``reporting.approval_token_runtime`` (called internally) does."""
     src = MODULE_PATH.read_text(encoding="utf-8")
     forbidden_env_reads = (
         "o" + "s.environ",
@@ -227,12 +278,24 @@ def test_module_reads_no_env_var() -> None:
     )
     for marker in forbidden_env_reads:
         assert marker not in src, (
-            f"skeleton reads an environment variable: {marker!r}"
+            f"walker reads an environment variable: {marker!r}"
         )
 
 
+def test_module_does_not_reference_env_var_literal() -> None:
+    """The HMAC env-var name lives ONLY in approval_token_runtime."""
+    src = MODULE_PATH.read_text(encoding="utf-8")
+    assert "ADE_APPROVAL_TOKEN_HMAC_SECRET" not in src
+
+
+def test_step5_invariants_pinned_in_source() -> None:
+    src = MODULE_PATH.read_text(encoding="utf-8")
+    assert "step5_implementation_allowed: Final[bool] = False" in src
+    assert 'STEP5_ENABLED_SUBSTAGE: Final[str] = "none"' in src
+
+
 # ---------------------------------------------------------------------------
-# Route table — exactly one POST route
+# Route surface — exactly one POST route at the pinned URL
 # ---------------------------------------------------------------------------
 
 
@@ -245,42 +308,24 @@ def _build_app() -> Flask:
 
 def test_route_table_carries_exactly_one_route() -> None:
     table = mod._MERGE_EXECUTION_DRY_RUN_ROUTES
-    assert len(table) == 1, (
-        f"route table must contain exactly one route, got {len(table)}: "
-        f"{table!r}"
-    )
+    assert len(table) == 1
 
 
 def test_route_url_is_pinned_dry_run_path() -> None:
     (path, method, _handler, _endpoint) = mod._MERGE_EXECUTION_DRY_RUN_ROUTES[0]
-    assert path == ROUTE_URL, (
-        f"route URL must be exactly {ROUTE_URL!r}, got {path!r}"
-    )
+    assert path == ROUTE_URL
     assert method == "POST"
 
 
 def test_route_registers_with_post_method_only() -> None:
     app = _build_app()
     matches = [r for r in app.url_map.iter_rules() if r.rule == ROUTE_URL]
-    assert len(matches) == 1, (
-        f"expected exactly one route registered for {ROUTE_URL!r}, "
-        f"got {len(matches)}: {matches!r}"
-    )
+    assert len(matches) == 1
     rule = matches[0]
     methods = rule.methods or set()
-    # Flask always adds HEAD + OPTIONS automatically; the POST
-    # method must be present and no other domain method (GET /
-    # PUT / PATCH / DELETE) may be.
-    assert "POST" in methods, f"POST not in registered methods: {methods!r}"
+    assert "POST" in methods
     forbidden = {"GET", "PUT", "PATCH", "DELETE"}
-    assert methods.isdisjoint(forbidden), (
-        f"route must not accept {forbidden!r}, accepted: {methods!r}"
-    )
-
-
-# ---------------------------------------------------------------------------
-# Method dispatch — 405 for non-POST
-# ---------------------------------------------------------------------------
+    assert methods.isdisjoint(forbidden)
 
 
 @pytest.mark.parametrize("method", ["GET", "PUT", "PATCH", "DELETE"])
@@ -288,13 +333,11 @@ def test_non_post_methods_return_405(method: str) -> None:
     app = _build_app()
     with app.test_client() as client:
         resp = client.open(ROUTE_URL, method=method)
-    assert resp.status_code == 405, (
-        f"{method} {ROUTE_URL} must return 405, got {resp.status_code}"
-    )
+    assert resp.status_code == 405
 
 
 # ---------------------------------------------------------------------------
-# Envelope shape — every response has the closed schema
+# Envelope shape — 16 closed fields preserved verbatim
 # ---------------------------------------------------------------------------
 
 
@@ -321,12 +364,10 @@ _REQUIRED_ENVELOPE_FIELDS = frozenset(
 
 
 def _well_formed_body() -> dict[str, Any]:
-    """Return a syntactically valid request body matching the
-    closed §2.3 schema."""
     return {
         "pr_number": 123,
         "pr_head_sha": "abc1234567890def1234567890abcdef12345678",
-        "token": "synthetic-token-for-skeleton-tests",
+        "token": "synthetic-token-shape-for-skeleton-paths",
         "intent": "mobile_approval_dispatch",
         "evidence_hash": "deadbeef" * 8,
     }
@@ -344,22 +385,15 @@ def _post_json(client: Any, body: Any) -> Any:
     )
 
 
-def test_well_formed_request_returns_not_yet_implemented_200() -> None:
-    app = _build_app()
-    with app.test_client() as client:
-        resp = _post_json(client, _well_formed_body())
-    assert resp.status_code == 200
-    payload = resp.get_json()
-    assert payload["status"] == "not_yet_implemented"
-    assert payload["would_proceed"] is False
-    assert payload["stop_condition"] is None
+def _envelope_after(client: Any, body: Any) -> tuple[int, dict[str, Any]]:
+    resp = _post_json(client, body)
+    return resp.status_code, resp.get_json()
 
 
-def test_envelope_contains_all_closed_fields() -> None:
+def test_envelope_contains_all_closed_fields_after_body_failure() -> None:
     app = _build_app()
     with app.test_client() as client:
-        resp = _post_json(client, _well_formed_body())
-    payload = resp.get_json()
+        _code, payload = _envelope_after(client, None)
     missing = _REQUIRED_ENVELOPE_FIELDS - set(payload.keys())
     assert not missing, f"envelope missing required fields: {missing!r}"
 
@@ -367,8 +401,7 @@ def test_envelope_contains_all_closed_fields() -> None:
 def test_envelope_pins_six_discipline_invariants() -> None:
     app = _build_app()
     with app.test_client() as client:
-        resp = _post_json(client, _well_formed_body())
-    payload = resp.get_json()
+        _code, payload = _envelope_after(client, None)
     assert payload["step5_implementation_allowed"] is False
     assert payload["step5_enabled_substage"] == "none"
     assert payload["level6_enabled"] is False
@@ -377,194 +410,476 @@ def test_envelope_pins_six_discipline_invariants() -> None:
     assert payload["deploy_coupled"] is False
 
 
-def test_envelope_echoes_body_pr_number_and_head_sha() -> None:
-    app = _build_app()
-    body = _well_formed_body()
-    with app.test_client() as client:
-        resp = _post_json(client, body)
-    payload = resp.get_json()
-    assert payload["pr_number"] == body["pr_number"]
-    assert payload["pr_head_sha"] == body["pr_head_sha"]
-
-
 def test_envelope_module_and_schema_versions_match_constants() -> None:
     app = _build_app()
     with app.test_client() as client:
-        resp = _post_json(client, _well_formed_body())
-    payload = resp.get_json()
+        _code, payload = _envelope_after(client, None)
     assert payload["module_version"] == mod.MODULE_VERSION
     assert payload["schema_version"] == mod.SCHEMA_VERSION
 
 
 # ---------------------------------------------------------------------------
-# Malformed body — HTTP 400 with not_yet_implemented + reason
+# Body-shape failures — rejected + §7 stop_condition mapping; NO preflight write
 # ---------------------------------------------------------------------------
 
 
-def test_missing_body_returns_400_not_yet_implemented() -> None:
+def test_missing_body_returns_400_rejected_no_preflight(
+    _isolate_state: Path,
+) -> None:
     app = _build_app()
     with app.test_client() as client:
-        resp = _post_json(client, None)
-    assert resp.status_code == 400
-    payload = resp.get_json()
-    assert payload["status"] == "not_yet_implemented"
+        code, payload = _envelope_after(client, None)
+    assert code == 400
+    assert payload["status"] == "rejected"
+    assert payload["stop_condition"] is None
     assert payload["would_proceed"] is False
     assert payload["reason"] == "body_missing"
-    assert payload["pr_number"] == 0
-    assert payload["pr_head_sha"] == ""
+    assert not _isolate_state.is_file()
 
 
-def test_non_object_body_returns_400_with_reason() -> None:
+def test_non_object_body_returns_400_rejected_no_preflight(
+    _isolate_state: Path,
+) -> None:
     app = _build_app()
     with app.test_client() as client:
-        resp = _post_json(client, [1, 2, 3])
-    assert resp.status_code == 400
-    payload = resp.get_json()
-    assert payload["status"] == "not_yet_implemented"
+        code, payload = _envelope_after(client, [1, 2, 3])
+    assert code == 400
+    assert payload["status"] == "rejected"
+    assert payload["stop_condition"] is None
     assert payload["reason"] == "body_not_object"
+    assert not _isolate_state.is_file()
 
 
 @pytest.mark.parametrize(
-    "drop_field,expected_reason",
+    "drop_field,expected_reason,expected_stop",
     [
-        ("pr_number", "field_missing:pr_number"),
-        ("pr_head_sha", "field_missing:pr_head_sha"),
-        ("token", "field_missing:token"),
-        ("intent", "field_missing:intent"),
-        ("evidence_hash", "field_missing:evidence_hash"),
+        ("token", "field_missing:token", "token_missing"),
+        ("pr_number", "field_missing:pr_number", "pr_number_mismatch"),
+        ("intent", "field_missing:intent", "binding_mismatch"),
+        ("pr_head_sha", "field_missing:pr_head_sha", "binding_mismatch"),
+        ("evidence_hash", "field_missing:evidence_hash", "binding_mismatch"),
     ],
 )
-def test_missing_required_field_returns_400_with_closed_reason(
-    drop_field: str, expected_reason: str
+def test_missing_required_field_emits_rejected_with_closed_stop(
+    drop_field: str,
+    expected_reason: str,
+    expected_stop: str,
+    _isolate_state: Path,
 ) -> None:
     app = _build_app()
     body = _well_formed_body()
     del body[drop_field]
     with app.test_client() as client:
-        resp = _post_json(client, body)
-    assert resp.status_code == 400
-    payload = resp.get_json()
-    assert payload["status"] == "not_yet_implemented"
+        code, payload = _envelope_after(client, body)
+    assert code == 400
+    assert payload["status"] == "rejected"
     assert payload["reason"] == expected_reason
+    assert payload["stop_condition"] == expected_stop
+    assert not _isolate_state.is_file()
 
 
-@pytest.mark.parametrize(
-    "field,bad_value,expected_reason",
-    [
-        ("pr_number", "123", "field_type:pr_number"),
-        ("pr_number", True, "field_type:pr_number"),
-        ("pr_head_sha", 123, "field_type:pr_head_sha"),
-        ("token", 123, "field_type:token"),
-        ("intent", 123, "field_type:intent"),
-        ("evidence_hash", 123, "field_type:evidence_hash"),
-    ],
-)
-def test_wrong_field_type_returns_400_with_closed_reason(
-    field: str, bad_value: Any, expected_reason: str
+def test_intent_drift_in_body_emits_binding_mismatch_no_preflight(
+    _isolate_state: Path,
 ) -> None:
-    app = _build_app()
-    body = _well_formed_body()
-    body[field] = bad_value
-    with app.test_client() as client:
-        resp = _post_json(client, body)
-    assert resp.status_code == 400
-    payload = resp.get_json()
-    assert payload["status"] == "not_yet_implemented"
-    assert payload["reason"] == expected_reason
-
-
-def test_intent_must_be_pinned_literal() -> None:
     app = _build_app()
     body = _well_formed_body()
     body["intent"] = "something_else"
     with app.test_client() as client:
-        resp = _post_json(client, body)
-    assert resp.status_code == 400
-    payload = resp.get_json()
+        code, payload = _envelope_after(client, body)
+    assert code == 400
+    assert payload["status"] == "rejected"
     assert payload["reason"] == "field_value:intent_not_pinned"
+    assert payload["stop_condition"] == "binding_mismatch"
+    assert not _isolate_state.is_file()
 
 
-def test_negative_pr_number_is_rejected() -> None:
+def test_oversized_token_emits_token_missing_no_preflight(
+    _isolate_state: Path,
+) -> None:
     app = _build_app()
     body = _well_formed_body()
-    body["pr_number"] = -1
+    body["token"] = "x" * 5000
     with app.test_client() as client:
-        resp = _post_json(client, body)
-    assert resp.status_code == 400
-    payload = resp.get_json()
-    assert payload["reason"] == "field_value:pr_number_non_positive"
+        code, payload = _envelope_after(client, body)
+    assert code == 400
+    assert payload["stop_condition"] == "token_missing"
+    assert not _isolate_state.is_file()
 
 
-def test_zero_pr_number_is_rejected() -> None:
+def test_zero_pr_number_emits_pr_number_mismatch_no_preflight(
+    _isolate_state: Path,
+) -> None:
     app = _build_app()
     body = _well_formed_body()
     body["pr_number"] = 0
     with app.test_client() as client:
-        resp = _post_json(client, body)
-    assert resp.status_code == 400
-    payload = resp.get_json()
-    assert payload["reason"] == "field_value:pr_number_non_positive"
-
-
-def test_oversized_token_is_rejected() -> None:
-    app = _build_app()
-    body = _well_formed_body()
-    body["token"] = "x" * 5000  # exceeds _MAX_TOKEN_LEN = 4096
-    with app.test_client() as client:
-        resp = _post_json(client, body)
-    assert resp.status_code == 400
-    payload = resp.get_json()
-    assert payload["reason"] == "field_value:token_length"
-
-
-def test_empty_pr_head_sha_is_rejected() -> None:
-    app = _build_app()
-    body = _well_formed_body()
-    body["pr_head_sha"] = ""
-    with app.test_client() as client:
-        resp = _post_json(client, body)
-    assert resp.status_code == 400
-    payload = resp.get_json()
-    assert payload["reason"] == "field_value:pr_head_sha_length"
+        code, payload = _envelope_after(client, body)
+    assert code == 400
+    assert payload["stop_condition"] == "pr_number_mismatch"
+    assert not _isolate_state.is_file()
 
 
 # ---------------------------------------------------------------------------
-# Status vocabulary — skeleton emits only not_yet_implemented
+# Precondition 1 — N4b not configured → configuration_missing; no preflight
 # ---------------------------------------------------------------------------
 
 
-_FORBIDDEN_SKELETON_STATUSES = frozenset({"ok", "rejected", "configuration_missing"})
-
-
-@pytest.mark.parametrize(
-    "body",
-    [
-        # Well-formed body → 200.
-        {
-            "pr_number": 1,
-            "pr_head_sha": "a" * 40,
-            "token": "t",
-            "intent": "mobile_approval_dispatch",
-            "evidence_hash": "e" * 64,
-        },
-        # Various malformed bodies → 400. All must still emit
-        # status = "not_yet_implemented".
-        {},
-        {"pr_number": 1},
-        {"pr_number": "not-an-int", "pr_head_sha": "x"},
-    ],
-)
-def test_skeleton_status_is_always_not_yet_implemented(body: Any) -> None:
-    """B2.8b never emits ok / rejected / configuration_missing.
-    Those values are reserved for B2.8c (token verification),
-    B2.8c onwards (rejected on stop_condition), and the
-    configuration-readiness check (B2.8c also)."""
+def test_n4b_missing_emits_configuration_missing_no_preflight(
+    _isolate_state: Path,
+) -> None:
+    """Env unset → status=configuration_missing, no preflight write."""
     app = _build_app()
     with app.test_client() as client:
-        resp = _post_json(client, body)
-    payload = resp.get_json()
+        code, payload = _envelope_after(client, _well_formed_body())
+    assert code == 200
+    assert payload["status"] == "configuration_missing"
+    assert payload["stop_condition"] is None
+    assert payload["preconditions_evaluated"] == 1
+    assert payload["preconditions_passed"] == 0
+    assert payload["reason"] == "n4b_not_activated"
+    assert payload["would_proceed"] is False
+    assert not _isolate_state.is_file()
+
+
+# ---------------------------------------------------------------------------
+# Precondition 2 — N4c component missing → configuration_missing; no preflight
+# ---------------------------------------------------------------------------
+
+
+def test_n4c_missing_emits_configuration_missing_no_preflight(
+    _isolate_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """When the N4c PWA component file is absent, the walker emits
+    ``configuration_missing`` with preconditions_evaluated=2 / passed=1,
+    and never writes a preflight artefact."""
+    # Activate N4b so we get past precondition 1.
+    monkeypatch.setenv(
+        atr.ENV_APPROVAL_TOKEN_HMAC_SECRET, _secrets.token_hex(32)
+    )
+    # Point the N4c path at a non-existent file.
+    monkeypatch.setattr(
+        mod,
+        "_N4C_COMPONENT_PATH",
+        tmp_path / "no_such_n4c_component.tsx",
+    )
+    app = _build_app()
+    with app.test_client() as client:
+        code, payload = _envelope_after(client, _well_formed_body())
+    assert code == 200
+    assert payload["status"] == "configuration_missing"
+    assert payload["stop_condition"] is None
+    assert payload["preconditions_evaluated"] == 2
+    assert payload["preconditions_passed"] == 1
+    assert payload["reason"] == "n4c_component_missing"
+    assert not _isolate_state.is_file()
+
+
+def test_n4c_component_path_constant_points_at_canonical_location() -> None:
+    """The walker's N4c path constant must match the canonical
+    location asserted by the B2.8c-pre readiness pin test."""
+    assert mod._N4C_COMPONENT_PATH == N4C_COMPONENT_PATH
+
+
+# ---------------------------------------------------------------------------
+# Preconditions 3–7 — token verification + bindings
+# ---------------------------------------------------------------------------
+
+
+def _mint_dry_run_token(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    pr_number: int = 123,
+    pr_head_sha: str = "abc1234567890def1234567890abcdef12345678",
+    evidence_hash: str | None = None,
+    event_id: str = "evt_walker_test",
+    intent: str = "mobile_approval_dispatch",
+) -> str:
+    if evidence_hash is None:
+        evidence_hash = "deadbeef" * 8
+    monkeypatch.setenv(
+        atr.ENV_APPROVAL_TOKEN_HMAC_SECRET, _secrets.token_hex(32)
+    )
+    out = atr.mint_runtime(
+        intent=intent,
+        event_id=event_id,
+        pr_number=pr_number,
+        pr_head_sha=pr_head_sha,
+        evidence_hash=evidence_hash,
+    )
+    assert out["status"] == "ok", out
+    return out["token"]
+
+
+def _body_with_token(
+    token: str,
+    *,
+    pr_number: int = 123,
+    pr_head_sha: str = "abc1234567890def1234567890abcdef12345678",
+    evidence_hash: str | None = None,
+    intent: str = "mobile_approval_dispatch",
+) -> dict[str, Any]:
+    if evidence_hash is None:
+        evidence_hash = "deadbeef" * 8
+    return {
+        "pr_number": pr_number,
+        "pr_head_sha": pr_head_sha,
+        "token": token,
+        "intent": intent,
+        "evidence_hash": evidence_hash,
+    }
+
+
+def test_invalid_token_emits_token_invalid_no_preflight(
+    _isolate_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        atr.ENV_APPROVAL_TOKEN_HMAC_SECRET, _secrets.token_hex(32)
+    )
+    body = _well_formed_body()
+    body["token"] = "not.a.valid.token.envelope"
+    app = _build_app()
+    with app.test_client() as client:
+        code, payload = _envelope_after(client, body)
+    assert code == 200
+    assert payload["status"] == "rejected"
+    assert payload["stop_condition"] == "token_invalid"
+    assert not _isolate_state.is_file()
+
+
+def test_pr_number_mismatch_emits_pr_number_mismatch_no_preflight(
+    _isolate_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    token = _mint_dry_run_token(monkeypatch, pr_number=999)
+    body = _body_with_token(token, pr_number=123)
+    app = _build_app()
+    with app.test_client() as client:
+        code, payload = _envelope_after(client, body)
+    assert code == 200
+    assert payload["status"] == "rejected"
+    assert payload["stop_condition"] == "pr_number_mismatch"
+    assert not _isolate_state.is_file()
+
+
+def test_pr_head_sha_mismatch_emits_binding_mismatch_no_preflight(
+    _isolate_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    token = _mint_dry_run_token(monkeypatch, pr_head_sha="cafebabe" * 5)
+    body = _body_with_token(token, pr_head_sha="deadbeef" * 5)
+    app = _build_app()
+    with app.test_client() as client:
+        code, payload = _envelope_after(client, body)
+    assert code == 200
+    assert payload["status"] == "rejected"
+    assert payload["stop_condition"] == "binding_mismatch"
+    assert not _isolate_state.is_file()
+
+
+def test_evidence_hash_mismatch_emits_binding_mismatch_no_preflight(
+    _isolate_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    token = _mint_dry_run_token(monkeypatch, evidence_hash="h_orig")
+    body = _body_with_token(token, evidence_hash="h_drift")
+    app = _build_app()
+    with app.test_client() as client:
+        code, payload = _envelope_after(client, body)
+    assert code == 200
+    assert payload["status"] == "rejected"
+    assert payload["stop_condition"] == "binding_mismatch"
+    assert not _isolate_state.is_file()
+
+
+def test_intent_drift_in_token_emits_binding_mismatch_no_preflight(
+    _isolate_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Token minted with mobile_review_dispatch but body says
+    mobile_approval_dispatch. verify_runtime_for_dry_run rejects
+    with reason=intent_drift; walker maps to binding_mismatch."""
+    token = _mint_dry_run_token(monkeypatch, intent="mobile_review_dispatch")
+    body = _body_with_token(token, intent="mobile_approval_dispatch")
+    app = _build_app()
+    with app.test_client() as client:
+        code, payload = _envelope_after(client, body)
+    assert code == 200
+    assert payload["status"] == "rejected"
+    assert payload["stop_condition"] == "binding_mismatch"
+    assert not _isolate_state.is_file()
+
+
+def test_expired_token_emits_token_invalid_no_preflight(
+    _isolate_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from datetime import UTC, datetime, timedelta
+
+    from reporting import approval_token_gate as atg
+
+    raw = _secrets.token_hex(32)
+    secret_bytes = bytes.fromhex(raw)
+    monkeypatch.setenv(atr.ENV_APPROVAL_TOKEN_HMAC_SECRET, raw)
+    past = datetime.now(UTC).replace(microsecond=0) - timedelta(
+        seconds=2 * atg.DEFAULT_TTL_SECONDS
+    )
+    token = atg.mint_token(
+        intent="mobile_approval_dispatch",
+        event_id="evt_expired",
+        pr_number=123,
+        pr_head_sha="abc1234567890def1234567890abcdef12345678",
+        evidence_hash="deadbeef" * 8,
+        release_tag=None,
+        kid=atr.CURRENT_KID,
+        secret=secret_bytes,
+        ttl_seconds=atg.DEFAULT_TTL_SECONDS,
+        now=past,
+    )
+    body = _body_with_token(token)
+    app = _build_app()
+    with app.test_client() as client:
+        code, payload = _envelope_after(client, body)
+    assert code == 200
+    assert payload["status"] == "rejected"
+    assert payload["stop_condition"] == "token_invalid"
+    assert not _isolate_state.is_file()
+
+
+def test_replay_detected_on_second_request_no_preflight_on_replay(
+    _isolate_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """First request: all 7 pass → preflight artefact written →
+    not_yet_implemented. Second request with the same token:
+    replay_detected → rejected → preflight artefact NOT overwritten
+    by the rejected branch (we delete the artefact between the two
+    calls to make the negative-assertion strict)."""
+    token = _mint_dry_run_token(monkeypatch)
+    body = _body_with_token(token)
+    app = _build_app()
+    with app.test_client() as client:
+        code1, payload1 = _envelope_after(client, body)
+    assert code1 == 200
+    assert payload1["status"] == "not_yet_implemented"
+    assert _isolate_state.is_file()
+    # Remove the artefact so the second call's negative assertion is
+    # strict.
+    _isolate_state.unlink()
+    with app.test_client() as client:
+        code2, payload2 = _envelope_after(client, body)
+    assert code2 == 200
+    assert payload2["status"] == "rejected"
+    assert payload2["stop_condition"] == "replay_detected"
+    # The rejected branch must not write a preflight artefact.
+    assert not _isolate_state.is_file()
+
+
+# ---------------------------------------------------------------------------
+# Happy walker — all 7 pass; preflight written; not_yet_implemented
+# ---------------------------------------------------------------------------
+
+
+def test_happy_walker_returns_not_yet_implemented_with_preflight_written(
+    _isolate_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    token = _mint_dry_run_token(monkeypatch)
+    body = _body_with_token(token)
+    app = _build_app()
+    with app.test_client() as client:
+        code, payload = _envelope_after(client, body)
+    assert code == 200
     assert payload["status"] == "not_yet_implemented"
-    assert payload["status"] not in _FORBIDDEN_SKELETON_STATUSES
+    assert payload["stop_condition"] is None
+    assert payload["would_proceed"] is False
+    assert payload["preconditions_evaluated"] == 7
+    assert payload["preconditions_passed"] == 7
+    assert payload["reason"] == "preconditions_8_through_17_pending"
+    assert payload["pr_number"] == 123
+    assert payload["pr_head_sha"] == "abc1234567890def1234567890abcdef12345678"
+    # Preflight artefact exists with the closed schema.
+    assert _isolate_state.is_file()
+    snapshot = json.loads(_isolate_state.read_text(encoding="utf-8"))
+    assert snapshot["report_kind"] == "n5b_preflight"
+    assert snapshot["pr_number"] == 123
+    assert snapshot["intent"] == "mobile_approval_dispatch"
+    assert snapshot["operator_actor"] == "session"
+    # Critical: no raw token, no raw nonce.
+    blob = json.dumps(snapshot, default=str)
+    assert token not in blob
+
+
+def test_preflight_artefact_carries_kid_and_nonce_hash_only(
+    _isolate_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    token = _mint_dry_run_token(monkeypatch)
+    body = _body_with_token(token)
+    app = _build_app()
+    with app.test_client() as client:
+        _envelope_after(client, body)
+    snapshot = json.loads(_isolate_state.read_text(encoding="utf-8"))
+    # kid + nonce_hash present and well-shaped.
+    assert snapshot["token_kid"] == atr.CURRENT_KID
+    assert isinstance(snapshot["nonce_hash"], str)
+    assert len(snapshot["nonce_hash"]) == 64
+    assert all(c in "0123456789abcdef" for c in snapshot["nonce_hash"])
+    # No raw nonce / token field in the closed schema.
+    assert "nonce" not in snapshot
+    assert "token" not in snapshot
+
+
+def test_b2_8c_never_emits_ok_status(
+    _isolate_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pin: even on the fully-clean happy path, B2.8c emits
+    ``not_yet_implemented`` — never ``ok``. The ``ok`` status is
+    reserved for B2.8e when preconditions 8–17 also walk."""
+    token = _mint_dry_run_token(monkeypatch)
+    body = _body_with_token(token)
+    app = _build_app()
+    with app.test_client() as client:
+        _code, payload = _envelope_after(client, body)
+    assert payload["status"] != "ok"
+    assert payload["status"] == "not_yet_implemented"
+
+
+# ---------------------------------------------------------------------------
+# Preflight-write failure — rejected + reason=preflight_write_failed
+# ---------------------------------------------------------------------------
+
+
+def test_preflight_write_failure_emits_rejected_500_no_new_stop_condition(
+    _isolate_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Post-verification write failure: status=rejected, HTTP 500,
+    stop_condition=None, reason='preflight_write_failed'. No new
+    §7 stop-condition literal is introduced."""
+    token = _mint_dry_run_token(monkeypatch)
+    body = _body_with_token(token)
+
+    from reporting import n5b_merge_execution_dry_run as projector
+
+    def _boom(**_kwargs: Any) -> Any:
+        raise OSError("simulated disk failure")
+
+    monkeypatch.setattr(projector, "write_preflight", _boom)
+    app = _build_app()
+    with app.test_client() as client:
+        code, payload = _envelope_after(client, body)
+    assert code == 500
+    assert payload["status"] == "rejected"
+    assert payload["stop_condition"] is None
+    assert payload["reason"] == "preflight_write_failed"
+    assert payload["preconditions_evaluated"] == 7
+    assert payload["preconditions_passed"] == 7
+    # Artefact must not exist (write raised before completing).
+    assert not _isolate_state.is_file()
 
 
 # ---------------------------------------------------------------------------
@@ -573,18 +888,14 @@ def test_skeleton_status_is_always_not_yet_implemented(body: Any) -> None:
 
 
 def test_dashboard_py_present_for_unwired_pin() -> None:
-    """Existence pin for the UNWIRED scan below: the dashboard
-    wiring file must be on disk so the scan is meaningful."""
-    assert DASHBOARD_PY.is_file(), (
-        f"dashboard wiring file missing: {DASHBOARD_PY}"
-    )
+    assert DASHBOARD_PY.is_file()
 
 
 def test_blueprint_not_registered_in_dashboard_py() -> None:
-    """B2.8b ships the skeleton UNWIRED. The wiring patch into
+    """B2.8c keeps the walker UNWIRED. The wiring patch into
     ``dashboard/dashboard.py`` is operator-only and reserved for
-    B2.8e. Source-text scan of dashboard.py asserts the import
-    + register-call are absent."""
+    B2.8e. Source-text scan of dashboard.py asserts the import +
+    register-call are absent."""
     src = DASHBOARD_PY.read_text(encoding="utf-8")
     forbidden_substrings = (
         "from dashboard.api_merge_execution_dry_run",
@@ -593,7 +904,7 @@ def test_blueprint_not_registered_in_dashboard_py() -> None:
     )
     hits = [s for s in forbidden_substrings if s in src]
     assert not hits, (
-        "B2.8b skeleton must remain UNWIRED. dashboard.py contains "
+        "B2.8c walker must remain UNWIRED. dashboard.py contains "
         f"wiring substrings: {hits!r}. Wiring is B2.8e scope."
     )
 
@@ -603,17 +914,17 @@ def test_blueprint_not_registered_in_dashboard_py() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_well_formed_envelope_passes_assert_no_secrets() -> None:
-    """The handler runs assert_no_secrets on every envelope; this
-    pin re-asserts the contract by re-running it on the response
-    payload independently."""
+def test_well_formed_envelope_passes_assert_no_secrets(
+    _isolate_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from reporting.agent_audit_summary import assert_no_secrets
 
+    token = _mint_dry_run_token(monkeypatch)
+    body = _body_with_token(token)
     app = _build_app()
     with app.test_client() as client:
-        resp = _post_json(client, _well_formed_body())
-    payload = resp.get_json()
-    # Re-running assert_no_secrets must not raise.
+        _code, payload = _envelope_after(client, body)
     assert_no_secrets(payload)
 
 
@@ -622,40 +933,12 @@ def test_malformed_body_envelope_passes_assert_no_secrets() -> None:
 
     app = _build_app()
     with app.test_client() as client:
-        resp = _post_json(client, None)
-    payload = resp.get_json()
+        _code, payload = _envelope_after(client, None)
     assert_no_secrets(payload)
 
 
 # ---------------------------------------------------------------------------
-# No filesystem write — skeleton writes nothing
-# ---------------------------------------------------------------------------
-
-
-def test_skeleton_source_has_no_filesystem_write_attrs() -> None:
-    """The skeleton must not call any filesystem write primitive.
-    B2.8c reserves the right to write under
-    ``logs/n5b_merge_execution/`` — but B2.8b does not."""
-    src = MODULE_PATH.read_text(encoding="utf-8")
-    # Assemble forbidden write attributes from parts.
-    forbidden = (
-        ".write(",
-        ".write_text(",
-        ".write_bytes(",
-        "open(",
-        "o" + "s.replace(",
-        "json.dump(",
-        "json.dumps(",  # the skeleton uses no JSON serialisation
-    )
-    hits = [m for m in forbidden if m in src]
-    assert hits == [], (
-        f"skeleton contains forbidden filesystem-write attributes: {hits!r}. "
-        "B2.8b writes nothing; audit projector lands in B2.8c."
-    )
-
-
-# ---------------------------------------------------------------------------
-# Bounded caps — defense-in-depth against pathological inputs
+# Bounded caps — defense-in-depth (unchanged from B2.8b)
 # ---------------------------------------------------------------------------
 
 
@@ -708,3 +991,61 @@ def test_discipline_fields_dict_is_closed_six_set() -> None:
     assert mod._DISCIPLINE_FIELDS["dry_run_only"] is True
     assert mod._DISCIPLINE_FIELDS["live_merge_implemented"] is False
     assert mod._DISCIPLINE_FIELDS["deploy_coupled"] is False
+
+
+# ---------------------------------------------------------------------------
+# Stop-condition vocabulary — closed; no new literals introduced
+# ---------------------------------------------------------------------------
+
+
+def test_only_closed_stop_conditions_appear_in_translation_tables() -> None:
+    """The walker's translation tables must emit only §7 stop
+    conditions enumerated by the B2.8c implementation plan §6.2."""
+    allowed_in_b2_8c = {
+        "token_missing",
+        "token_invalid",
+        "replay_detected",
+        "binding_mismatch",
+        "pr_number_mismatch",
+        None,
+    }
+    body_stops = set(mod._BODY_REASON_TO_STOP_CONDITION.values()) | {None}
+    verify_stops = set(mod._VERIFY_OUTCOME_TO_STOP_CONDITION.values()) | {
+        None,
+        "pr_number_mismatch",
+        "binding_mismatch",
+    }
+    illegal = (body_stops | verify_stops) - allowed_in_b2_8c
+    assert illegal == set(), (
+        f"walker emits stop_condition literals outside the B2.8c "
+        f"closed §7 vocabulary: {illegal!r}"
+    )
+
+
+def test_module_source_does_not_mention_b2_8d_or_later_stop_conditions() -> None:
+    """The closed §7 stop conditions reserved for B2.8d / B2.8e
+    must NOT appear as quoted literals in the B2.8c walker source.
+    This pins the scope boundary."""
+    src = MODULE_PATH.read_text(encoding="utf-8")
+    deferred = (
+        "head_sha_mismatch",
+        "merge_state_not_clean",
+        "checks_not_green",
+        "branch_protection_not_satisfied",
+        "unexpected_files_touched",
+        "deploy_coupling_detected",
+        "step5_flag_changed",
+        "level_6_attempted",
+        "protected_path_violation",
+        "stale_recommendation",
+        "network_uncertain",
+        "audit_write_failure",
+        "operator_confirmation_missing",
+        "live_execute_disabled",
+        "dry_run_required_first",
+    )
+    for literal in deferred:
+        assert literal not in src, (
+            f"walker source mentions deferred stop_condition literal "
+            f"{literal!r}; that scope belongs to B2.8d / B2.8e"
+        )

--- a/tests/unit/test_approval_token_runtime.py
+++ b/tests/unit/test_approval_token_runtime.py
@@ -540,4 +540,351 @@ def test_module_source_pins_step5_invariants() -> None:
     src = _module_source()
     assert "step5_implementation_allowed: Final[bool] = False" in src
     assert 'STEP5_ENABLED_SUBSTAGE: Final[str] = "none"' in src
-    assert "step5_implementation_allowed = True" not in src
+
+
+# ---------------------------------------------------------------------------
+# verify_runtime_for_dry_run — B2.8c N5b Phase 2 dry-run walker entrypoint
+#
+# Pins (per the operator-approved B2.8c contract):
+# * Happy path returns verified kid / nonce_hash / event_id / intent.
+# * Every rejected / configuration_missing branch returns exactly the
+#   3-key {status, outcome, reason} envelope (no claim metadata leak).
+# * Raw nonce and raw token never appear in the response.
+# * Replay rejected on the second call.
+# * Intent drift rejected after signature verification.
+# * Wrong expected_intent rejected before the env is read or the
+#   verifier is invoked.
+# * verify_runtime / mint_runtime existing surface UNCHANGED.
+# ---------------------------------------------------------------------------
+
+
+_OK_KEYS = {"status", "outcome", "reason", "kid", "nonce_hash", "event_id", "intent"}
+_REJECTED_KEYS = {"status", "outcome", "reason"}
+
+
+def _mint_dry_run_token(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    event_id: str = "evt_dry_run",
+    pr_number: int = 42,
+    pr_head_sha: str = "deadbeef" * 5,
+    evidence_hash: str = "h_dry_run_evidence",
+    intent: str = "mobile_approval_dispatch",
+) -> str:
+    monkeypatch.setenv(
+        atr.ENV_APPROVAL_TOKEN_HMAC_SECRET, _synthetic_secret_hex()
+    )
+    out = atr.mint_runtime(
+        intent=intent,
+        event_id=event_id,
+        pr_number=pr_number,
+        pr_head_sha=pr_head_sha,
+        evidence_hash=evidence_hash,
+    )
+    assert out["status"] == "ok", out
+    return out["token"]
+
+
+def test_verify_for_dry_run_happy_path_returns_verified_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    token = _mint_dry_run_token(monkeypatch)
+    out = atr.verify_runtime_for_dry_run(
+        token=token,
+        expected_pr_number=42,
+        expected_pr_head_sha="deadbeef" * 5,
+        expected_evidence_hash="h_dry_run_evidence",
+        expected_intent="mobile_approval_dispatch",
+    )
+    assert out["status"] == "ok"
+    assert out["outcome"] == "ok"
+    assert out["reason"] == "verified"
+    assert out["kid"] == atr.CURRENT_KID
+    # nonce_hash is sha256 hex → 64 lowercase hex chars.
+    assert isinstance(out["nonce_hash"], str) and len(out["nonce_hash"]) == 64
+    assert all(c in "0123456789abcdef" for c in out["nonce_hash"])
+    assert out["event_id"] == "evt_dry_run"
+    assert out["intent"] == "mobile_approval_dispatch"
+    assert set(out.keys()) == _OK_KEYS
+
+
+def test_verify_for_dry_run_ok_envelope_carries_no_raw_nonce_or_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    token = _mint_dry_run_token(monkeypatch)
+    out = atr.verify_runtime_for_dry_run(
+        token=token,
+        expected_pr_number=42,
+        expected_pr_head_sha="deadbeef" * 5,
+        expected_evidence_hash="h_dry_run_evidence",
+        expected_intent="mobile_approval_dispatch",
+    )
+    blob = json.dumps(out, default=str)
+    # The raw token must NEVER appear in the response.
+    assert token not in blob
+    # No claim contains a raw nonce; nonce_hash is the only nonce-derived
+    # field. We do not know the raw nonce here, but we assert no
+    # token-shaped substring leaks back.
+    assert "." not in out["nonce_hash"]
+
+
+def test_verify_for_dry_run_replay_rejects_second_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    token = _mint_dry_run_token(monkeypatch)
+    first = atr.verify_runtime_for_dry_run(
+        token=token,
+        expected_pr_number=42,
+        expected_pr_head_sha="deadbeef" * 5,
+        expected_evidence_hash="h_dry_run_evidence",
+        expected_intent="mobile_approval_dispatch",
+    )
+    assert first["status"] == "ok"
+    second = atr.verify_runtime_for_dry_run(
+        token=token,
+        expected_pr_number=42,
+        expected_pr_head_sha="deadbeef" * 5,
+        expected_evidence_hash="h_dry_run_evidence",
+        expected_intent="mobile_approval_dispatch",
+    )
+    assert second["status"] == "rejected"
+    assert second["outcome"] == "replay_detected"
+    assert set(second.keys()) == _REJECTED_KEYS
+
+
+def test_verify_for_dry_run_wrong_expected_intent_rejects_before_env_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The wrong-intent guard runs BEFORE the env is read; this is a
+    contract pin that protects the env-secret read from being
+    influenced by attacker-supplied intent values."""
+    # No env set deliberately — the guard must reject without reading.
+    monkeypatch.delenv(atr.ENV_APPROVAL_TOKEN_HMAC_SECRET, raising=False)
+    out = atr.verify_runtime_for_dry_run(
+        token="anything.anything",
+        expected_pr_number=1,
+        expected_pr_head_sha="x" * 16,
+        expected_evidence_hash="h",
+        expected_intent="mobile_review_dispatch",  # closed N4a intent but NOT the dry-run intent
+    )
+    assert out["status"] == "rejected"
+    assert out["outcome"] == "intent_unknown"
+    assert out["reason"] == "expected_intent_not_supported"
+    assert set(out.keys()) == _REJECTED_KEYS
+
+
+def test_verify_for_dry_run_configuration_missing_when_env_unset() -> None:
+    out = atr.verify_runtime_for_dry_run(
+        token="anything.anything",
+        expected_pr_number=1,
+        expected_pr_head_sha="x" * 16,
+        expected_evidence_hash="h",
+        expected_intent="mobile_approval_dispatch",
+    )
+    assert out["status"] == "configuration_missing"
+    assert out["outcome"] == ""
+    assert out["reason"] == "env_secret_absent"
+    assert set(out.keys()) == _REJECTED_KEYS
+
+
+def test_verify_for_dry_run_signature_invalid_no_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tamper the claims half so verify_token rejects with
+    signature_invalid (or malformed_envelope if shape breaks)."""
+    token = _mint_dry_run_token(monkeypatch)
+    claims_b64, sig_b64 = token.split(".", 1)
+    # Tamper sig so HMAC mismatches.
+    tampered = f"{claims_b64}.{'A' * len(sig_b64)}"
+    out = atr.verify_runtime_for_dry_run(
+        token=tampered,
+        expected_pr_number=42,
+        expected_pr_head_sha="deadbeef" * 5,
+        expected_evidence_hash="h_dry_run_evidence",
+        expected_intent="mobile_approval_dispatch",
+    )
+    assert out["status"] == "rejected"
+    assert out["outcome"] in {"signature_invalid", "malformed_envelope"}
+    assert set(out.keys()) == _REJECTED_KEYS
+
+
+def test_verify_for_dry_run_malformed_token_no_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        atr.ENV_APPROVAL_TOKEN_HMAC_SECRET, _synthetic_secret_hex()
+    )
+    out = atr.verify_runtime_for_dry_run(
+        token="not-a-valid-token",
+        expected_pr_number=1,
+        expected_pr_head_sha="x" * 16,
+        expected_evidence_hash="h",
+        expected_intent="mobile_approval_dispatch",
+    )
+    assert out["status"] == "rejected"
+    assert out["outcome"] == "malformed_envelope"
+    assert set(out.keys()) == _REJECTED_KEYS
+
+
+@pytest.mark.parametrize(
+    "drift_kwarg,drift_value,expected_reason",
+    [
+        ("expected_pr_number", 999, "pr_number_mismatch"),
+        ("expected_pr_head_sha", "f" * 40, "pr_head_sha_mismatch"),
+        ("expected_evidence_hash", "h_other_evidence", "evidence_hash_mismatch"),
+    ],
+)
+def test_verify_for_dry_run_binding_mismatch_no_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    drift_kwarg: str,
+    drift_value: Any,
+    expected_reason: str,
+) -> None:
+    token = _mint_dry_run_token(monkeypatch)
+    kwargs: dict[str, Any] = {
+        "token": token,
+        "expected_pr_number": 42,
+        "expected_pr_head_sha": "deadbeef" * 5,
+        "expected_evidence_hash": "h_dry_run_evidence",
+        "expected_intent": "mobile_approval_dispatch",
+    }
+    kwargs[drift_kwarg] = drift_value
+    out = atr.verify_runtime_for_dry_run(**kwargs)
+    assert out["status"] == "rejected"
+    assert out["outcome"] == "binding_mismatch"
+    assert out["reason"] == expected_reason
+    assert set(out.keys()) == _REJECTED_KEYS
+
+
+def test_verify_for_dry_run_intent_drift_rejects_after_verify(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Token minted with a different N4a-vocab intent
+    (`mobile_review_dispatch`). The signature still verifies, but the
+    walker rejects the claimed intent vs the expected dry-run intent
+    with reason='intent_drift' — and surfaces no metadata."""
+    token = _mint_dry_run_token(
+        monkeypatch,
+        intent="mobile_review_dispatch",
+    )
+    out = atr.verify_runtime_for_dry_run(
+        token=token,
+        expected_pr_number=42,
+        expected_pr_head_sha="deadbeef" * 5,
+        expected_evidence_hash="h_dry_run_evidence",
+        expected_intent="mobile_approval_dispatch",
+    )
+    assert out["status"] == "rejected"
+    assert out["outcome"] == "binding_mismatch"
+    assert out["reason"] == "intent_drift"
+    assert set(out.keys()) == _REJECTED_KEYS
+
+
+def test_verify_for_dry_run_expired_token_no_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    raw = _synthetic_secret_hex()
+    secret_bytes = bytes.fromhex(raw)
+    monkeypatch.setenv(atr.ENV_APPROVAL_TOKEN_HMAC_SECRET, raw)
+    from datetime import UTC, datetime, timedelta
+
+    past = datetime.now(UTC).replace(microsecond=0) - timedelta(
+        seconds=2 * atg.DEFAULT_TTL_SECONDS
+    )
+    token = atg.mint_token(
+        intent="mobile_approval_dispatch",
+        event_id="evt_expire",
+        pr_number=42,
+        pr_head_sha="deadbeef" * 5,
+        evidence_hash="h_dry_run_evidence",
+        release_tag=None,
+        kid=atr.CURRENT_KID,
+        secret=secret_bytes,
+        ttl_seconds=atg.DEFAULT_TTL_SECONDS,
+        now=past,
+    )
+    out = atr.verify_runtime_for_dry_run(
+        token=token,
+        expected_pr_number=42,
+        expected_pr_head_sha="deadbeef" * 5,
+        expected_evidence_hash="h_dry_run_evidence",
+        expected_intent="mobile_approval_dispatch",
+    )
+    assert out["status"] == "rejected"
+    assert out["outcome"] == "expired"
+    assert set(out.keys()) == _REJECTED_KEYS
+
+
+def test_verify_for_dry_run_unknown_kid_no_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mint with a kid the runtime does not know."""
+    raw = _synthetic_secret_hex()
+    secret_bytes = bytes.fromhex(raw)
+    monkeypatch.setenv(atr.ENV_APPROVAL_TOKEN_HMAC_SECRET, raw)
+    token = atg.mint_token(
+        intent="mobile_approval_dispatch",
+        event_id="evt",
+        pr_number=42,
+        pr_head_sha="deadbeef" * 5,
+        evidence_hash="h",
+        release_tag=None,
+        kid="not_a_real_kid",
+        secret=secret_bytes,
+    )
+    out = atr.verify_runtime_for_dry_run(
+        token=token,
+        expected_pr_number=42,
+        expected_pr_head_sha="deadbeef" * 5,
+        expected_evidence_hash="h",
+        expected_intent="mobile_approval_dispatch",
+    )
+    assert out["status"] == "rejected"
+    assert out["outcome"] == "unknown_kid"
+    assert set(out.keys()) == _REJECTED_KEYS
+
+
+def test_verify_for_dry_run_secret_never_leaks_into_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    raw = _synthetic_secret_hex()
+    monkeypatch.setenv(atr.ENV_APPROVAL_TOKEN_HMAC_SECRET, raw)
+    out = atr.mint_runtime(
+        intent="mobile_approval_dispatch",
+        event_id="evt",
+        pr_number=42,
+        pr_head_sha="deadbeef" * 5,
+        evidence_hash="h",
+    )
+    token = out["token"]
+    verified = atr.verify_runtime_for_dry_run(
+        token=token,
+        expected_pr_number=42,
+        expected_pr_head_sha="deadbeef" * 5,
+        expected_evidence_hash="h",
+        expected_intent="mobile_approval_dispatch",
+    )
+    blob = json.dumps(verified, default=str)
+    assert raw not in blob
+
+
+def test_verify_for_dry_run_is_exported() -> None:
+    assert "verify_runtime_for_dry_run" in atr.__all__
+    assert callable(atr.verify_runtime_for_dry_run)
+
+
+def test_verify_for_dry_run_does_not_modify_existing_surface() -> None:
+    """Existing public callables must keep their identity. This pin
+    catches accidental replacement / wrapping of verify_runtime,
+    mint_runtime, is_configured, secrets_by_kid, record_nonce, or
+    current_kid by the B2.8c addition."""
+    for name in (
+        "verify_runtime",
+        "mint_runtime",
+        "is_configured",
+        "secrets_by_kid",
+        "record_nonce",
+        "current_kid",
+    ):
+        assert callable(getattr(atr, name))
+        assert name in atr.__all__

--- a/tests/unit/test_n5b_merge_execution_dry_run.py
+++ b/tests/unit/test_n5b_merge_execution_dry_run.py
@@ -1,0 +1,444 @@
+"""Pin tests for the B2.8c N5b Phase 2 dry-run audit projector
+(``reporting/n5b_merge_execution_dry_run.py``).
+
+The projector writes ONLY the preflight artefact under
+``logs/n5b_merge_execution/preflight/latest.json``. The dry-run
+decision artefact, the dry-run history artefact, and the failure
+artefact are reserved for B2.8d / B2.8e per the implementation
+plan §2.6 and are NOT exercised here.
+
+Defense-in-depth note: forbidden marker strings the tests search
+for are NEVER embedded as literals in this file when they would
+also trip the runtime source-text scan; markers are assembled at
+runtime from constituent parts so the test source stays inert to
+scanners.
+"""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reporting import n5b_merge_execution_dry_run as projector
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPO_ROOT / "reporting" / "n5b_merge_execution_dry_run.py"
+
+
+# ---------------------------------------------------------------------------
+# Module surface
+# ---------------------------------------------------------------------------
+
+
+def test_module_imports_successfully() -> None:
+    assert projector is not None
+
+
+def test_module_version_is_pinned_string() -> None:
+    assert projector.MODULE_VERSION == "v3.15.16.N5b.phase2.projector"
+
+
+def test_schema_version_is_pinned_integer_1() -> None:
+    assert projector.SCHEMA_VERSION == 1
+
+
+def test_report_kind_is_pinned() -> None:
+    assert projector.REPORT_KIND == "n5b_preflight"
+
+
+def test_step5_enabled_substage_is_pinned_none() -> None:
+    assert projector.STEP5_ENABLED_SUBSTAGE == "none"
+
+
+def test_step5_implementation_allowed_is_pinned_false() -> None:
+    assert projector.step5_implementation_allowed is False
+
+
+def test_pr_base_ref_pinned_main() -> None:
+    assert projector.PR_BASE_REF == "main"
+
+
+def test_dry_run_intent_literal() -> None:
+    assert projector.DRY_RUN_INTENT == "mobile_approval_dispatch"
+
+
+def test_operator_actors_closed_vocab() -> None:
+    assert projector.OPERATOR_ACTORS == ("session", "operator_token")
+
+
+def test_write_prefix_sentinel_pinned() -> None:
+    assert projector.WRITE_PREFIX == "logs/n5b_merge_execution/"
+
+
+def test_preflight_relative_path_pinned() -> None:
+    assert (
+        projector.PREFLIGHT_LATEST_RELATIVE
+        == "logs/n5b_merge_execution/preflight/latest.json"
+    )
+
+
+def test_preflight_snapshot_keys_closed_set() -> None:
+    assert set(projector.PREFLIGHT_SNAPSHOT_KEYS) == {
+        "schema_version",
+        "report_kind",
+        "module_version",
+        "pr_number",
+        "pr_head_sha",
+        "pr_base_ref",
+        "intent",
+        "token_kid",
+        "nonce_hash",
+        "operator_actor",
+        "generated_at_utc",
+        "step5_implementation_allowed",
+        "step5_enabled_substage",
+        "level6_enabled",
+        "dry_run_only",
+        "live_merge_implemented",
+        "deploy_coupled",
+        "discipline_invariants",
+    }
+
+
+def test_all_exports_are_closed() -> None:
+    assert set(projector.__all__) == {
+        "DRY_RUN_INTENT",
+        "MODULE_VERSION",
+        "OPERATOR_ACTORS",
+        "PREFLIGHT_DIR",
+        "PREFLIGHT_LATEST",
+        "PREFLIGHT_LATEST_RELATIVE",
+        "PREFLIGHT_SNAPSHOT_KEYS",
+        "PR_BASE_REF",
+        "REPORT_KIND",
+        "SCHEMA_VERSION",
+        "STEP5_ENABLED_SUBSTAGE",
+        "WRITE_PREFIX",
+        "build_preflight_snapshot",
+        "step5_implementation_allowed",
+        "write_preflight",
+    }
+
+
+# ---------------------------------------------------------------------------
+# AST + source-text guards — no forbidden imports / literals
+# ---------------------------------------------------------------------------
+
+
+_FORBIDDEN_IMPORTS = (
+    "subprocess",
+    "socket",
+    "urllib",
+    "requests",
+    "httpx",
+    "aiohttp",
+    "asyncio",
+    # B2.8c projector must NOT import the token runtime — the
+    # dashboard module (not the projector) handles verification.
+    "reporting.approval_token_runtime",
+    "reporting.approval_token_gate",
+    # No GitHub API client of any flavour.
+    "github",
+    "ghapi",
+    "PyGithub",
+)
+
+
+def _imported_module_names() -> set[str]:
+    src = MODULE_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name)
+        if isinstance(node, ast.ImportFrom) and node.module is not None:
+            names.add(node.module)
+    return names
+
+
+def test_module_has_no_forbidden_imports() -> None:
+    names = _imported_module_names()
+    offending: list[str] = []
+    for name in names:
+        for forbidden in _FORBIDDEN_IMPORTS:
+            if name == forbidden or name.startswith(forbidden + "."):
+                offending.append(name)
+    assert offending == [], (
+        f"projector imports forbidden modules: {offending!r}"
+    )
+
+
+def test_module_does_not_invoke_subprocess_attrs() -> None:
+    src = MODULE_PATH.read_text(encoding="utf-8")
+    forbidden = (
+        "s" + "ubprocess.run",
+        "s" + "ubprocess.Popen",
+        "s" + "ubprocess.call",
+        "s" + "ubprocess.check_call",
+        "s" + "ubprocess.check_output",
+        "o" + "s.system",
+        "o" + "s.popen",
+    )
+    hits = [m for m in forbidden if m in src]
+    assert hits == [], (
+        f"projector source contains shell-spawning attribute: {hits!r}"
+    )
+
+
+def test_module_contains_no_gh_or_git_shellout_literal() -> None:
+    src = MODULE_PATH.read_text(encoding="utf-8")
+    forbidden_literals = (
+        "g" + "h " + "pr " + "merge",
+        "g" + "it " + "merge",
+        "--" + "admin",
+        "--" + "no-verify",
+        "p" + "r_merge_approved",
+        "m" + "erge" + "Pull" + "Request",
+    )
+    hits = [m for m in forbidden_literals if m in src]
+    assert hits == [], (
+        f"projector source contains forbidden shell-out / mutation literal: {hits!r}"
+    )
+
+
+def test_module_does_not_read_env_vars() -> None:
+    src = MODULE_PATH.read_text(encoding="utf-8")
+    forbidden = (
+        "o" + "s.environ",
+        "o" + "s.getenv",
+        "g" + "etenv(",
+    )
+    hits = [m for m in forbidden if m in src]
+    assert hits == [], (
+        f"projector source reads environment variables: {hits!r}"
+    )
+
+
+def test_module_source_pins_step5_invariants() -> None:
+    src = MODULE_PATH.read_text(encoding="utf-8")
+    assert "step5_implementation_allowed: Final[bool] = False" in src
+    assert 'STEP5_ENABLED_SUBSTAGE: Final[str] = "none"' in src
+
+
+def test_module_does_not_carry_token_or_raw_nonce_field_names() -> None:
+    """The closed schema must NOT include ``token`` or a raw
+    ``nonce`` field — only the verified ``token_kid`` and the
+    sha256-hashed ``nonce_hash``."""
+    keys = set(projector.PREFLIGHT_SNAPSHOT_KEYS)
+    assert "token" not in keys
+    assert "nonce" not in keys
+    # Sanity: the hashed alternatives ARE in the schema.
+    assert "token_kid" in keys
+    assert "nonce_hash" in keys
+
+
+# ---------------------------------------------------------------------------
+# build_preflight_snapshot — value-shape invariants
+# ---------------------------------------------------------------------------
+
+
+def _good_kwargs() -> dict[str, Any]:
+    nonce_hash = hashlib.sha256(b"synthetic-nonce-for-test").hexdigest()
+    return {
+        "pr_number": 42,
+        "pr_head_sha": "deadbeef" * 5,
+        "token_kid": "k1",
+        "nonce_hash": nonce_hash,
+        "operator_actor": "session",
+        "generated_at_utc": "2026-05-16T12:00:00Z",
+    }
+
+
+def test_build_snapshot_happy_path_returns_closed_schema() -> None:
+    snap = projector.build_preflight_snapshot(**_good_kwargs())
+    assert set(snap.keys()) == set(projector.PREFLIGHT_SNAPSHOT_KEYS)
+    # Discipline invariants mirrored verbatim.
+    assert snap["step5_implementation_allowed"] is False
+    assert snap["step5_enabled_substage"] == "none"
+    assert snap["level6_enabled"] is False
+    assert snap["dry_run_only"] is True
+    assert snap["live_merge_implemented"] is False
+    assert snap["deploy_coupled"] is False
+    # Closed scalars.
+    assert snap["pr_base_ref"] == "main"
+    assert snap["intent"] == "mobile_approval_dispatch"
+    assert snap["schema_version"] == 1
+    assert snap["report_kind"] == "n5b_preflight"
+    assert snap["module_version"] == "v3.15.16.N5b.phase2.projector"
+
+
+def test_build_snapshot_discipline_invariants_dict_present() -> None:
+    snap = projector.build_preflight_snapshot(**_good_kwargs())
+    inv = snap["discipline_invariants"]
+    assert isinstance(inv, dict)
+    assert inv["dry_run_only"] is True
+    assert inv["live_merge_implemented"] is False
+    assert inv["calls_github_api"] is False
+    assert inv["uses_subprocess_or_network"] is False
+    assert inv["deploy_coupled"] is False
+    assert inv["mints_or_verifies_approval_tokens"] is False
+    assert inv["writes_seed_files"] is False
+    assert inv["writes_generated_seed"] is False
+    assert inv["opens_or_merges_prs"] is False
+    assert inv["step5_implementation_allowed"] is False
+    assert inv["step5_enabled_substage"] == "none"
+    assert inv["level6_enabled"] is False
+
+
+@pytest.mark.parametrize(
+    "field,bad_value,exc",
+    [
+        ("pr_number", "42", TypeError),
+        ("pr_number", True, TypeError),
+        ("pr_number", 0, ValueError),
+        ("pr_number", -1, ValueError),
+        ("pr_head_sha", "", ValueError),
+        ("pr_head_sha", "x" * 65, ValueError),
+        ("token_kid", "", ValueError),
+        ("token_kid", "k" * 65, ValueError),
+        ("nonce_hash", "", ValueError),
+        ("nonce_hash", "ab" * 31, ValueError),  # only 62 chars
+        ("nonce_hash", "G" * 64, ValueError),  # bad charset
+        ("operator_actor", "bogus_actor", ValueError),
+        ("generated_at_utc", "", ValueError),
+    ],
+)
+def test_build_snapshot_rejects_bad_inputs(
+    field: str, bad_value: Any, exc: type[BaseException]
+) -> None:
+    kwargs = _good_kwargs()
+    kwargs[field] = bad_value
+    with pytest.raises(exc):
+        projector.build_preflight_snapshot(**kwargs)
+
+
+def test_build_snapshot_accepts_operator_token_actor() -> None:
+    kwargs = _good_kwargs()
+    kwargs["operator_actor"] = "operator_token"
+    snap = projector.build_preflight_snapshot(**kwargs)
+    assert snap["operator_actor"] == "operator_token"
+
+
+# ---------------------------------------------------------------------------
+# write_preflight — sentinel-restricted, atomic
+# ---------------------------------------------------------------------------
+
+
+def _tmp_preflight_path(tmp_path: Path) -> Path:
+    target = (
+        tmp_path
+        / "logs"
+        / "n5b_merge_execution"
+        / "preflight"
+        / "latest.json"
+    )
+    target.parent.mkdir(parents=True, exist_ok=True)
+    return target
+
+
+def test_write_preflight_writes_closed_schema_to_target(
+    tmp_path: Path,
+) -> None:
+    target = _tmp_preflight_path(tmp_path)
+    out = projector.write_preflight(
+        target_path=target,
+        **_good_kwargs(),
+    )
+    assert out == target
+    assert target.is_file()
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    assert set(payload.keys()) == set(projector.PREFLIGHT_SNAPSHOT_KEYS)
+    assert payload["pr_number"] == 42
+    assert payload["pr_base_ref"] == "main"
+    assert payload["intent"] == "mobile_approval_dispatch"
+
+
+def test_write_preflight_refuses_non_sentinel_path(tmp_path: Path) -> None:
+    """The sentinel guard refuses any path that does NOT contain the
+    closed ``logs/n5b_merge_execution/`` substring."""
+    bogus = tmp_path / "logs" / "elsewhere" / "preflight.json"
+    bogus.parent.mkdir(parents=True, exist_ok=True)
+    with pytest.raises(ValueError):
+        projector.write_preflight(target_path=bogus, **_good_kwargs())
+    # No file written.
+    assert not bogus.is_file()
+
+
+def test_write_preflight_atomic_no_tmp_residue(tmp_path: Path) -> None:
+    target = _tmp_preflight_path(tmp_path)
+    projector.write_preflight(target_path=target, **_good_kwargs())
+    # No leftover tempfiles in the target's parent.
+    leftovers = [
+        p
+        for p in target.parent.iterdir()
+        if p.name.startswith(".n5b_merge_execution_dry_run.")
+    ]
+    assert leftovers == []
+
+
+def test_write_preflight_overwrites_existing_atomically(
+    tmp_path: Path,
+) -> None:
+    target = _tmp_preflight_path(tmp_path)
+    target.write_text('{"prior": "content"}', encoding="utf-8")
+    projector.write_preflight(target_path=target, **_good_kwargs())
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    assert "prior" not in payload
+    assert payload["report_kind"] == "n5b_preflight"
+
+
+def test_write_preflight_runs_assert_no_secrets_before_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If ``assert_no_secrets`` raises, NO file is created."""
+    target = _tmp_preflight_path(tmp_path)
+    # Replace the redactor with one that always raises.
+    def _boom(_payload: dict[str, Any]) -> None:
+        raise AssertionError("simulated credential leak")
+
+    monkeypatch.setattr(projector, "assert_no_secrets", _boom)
+    with pytest.raises(AssertionError):
+        projector.write_preflight(target_path=target, **_good_kwargs())
+    assert not target.is_file()
+
+
+# ---------------------------------------------------------------------------
+# No deferred-artefact writers — preflight only in B2.8c
+# ---------------------------------------------------------------------------
+
+
+def test_projector_exposes_no_dry_run_decision_writer() -> None:
+    for forbidden in (
+        "write_dry_run",
+        "write_dry_run_latest",
+        "write_decision",
+        "write_failure",
+        "write_history",
+        "write_execution",
+    ):
+        assert not hasattr(projector, forbidden), (
+            f"B2.8c projector must not expose {forbidden!r}; "
+            "decision/failure/history writers are B2.8d / B2.8e scope"
+        )
+
+
+def test_projector_relative_path_only_preflight() -> None:
+    """The projector exposes exactly the preflight relative path. No
+    dry_run / failure / history / decision constants in B2.8c."""
+    for forbidden in (
+        "DRY_RUN_LATEST_RELATIVE",
+        "DRY_RUN_HISTORY_RELATIVE",
+        "FAILURE_DIR_RELATIVE",
+        "DECISION_LATEST_RELATIVE",
+        "EXECUTION_LATEST_RELATIVE",
+    ):
+        assert not hasattr(projector, forbidden), (
+            f"B2.8c projector must not expose {forbidden!r}; only "
+            "preflight artefact paths are in scope"
+        )

--- a/tests/unit/test_n5b_merge_execution_plan.py
+++ b/tests/unit/test_n5b_merge_execution_plan.py
@@ -478,13 +478,19 @@ def _excerpt_around(text: str, idx: int, span: int = 80) -> str:
 #: Allowlist of N5b-adapter module paths that are explicitly
 #: permitted by the operator. The list grows one path at a time
 #: per sub-unit, narrowing the "no module exists" pin without
-#: weakening its closed semantics. As of B2.8b the only allowed
-#: path is the Phase 2 dry-run skeleton blueprint introduced
-#: under that operator-go. The reporting-side audit projector
-#: (``reporting/n5b_merge_execution_dry_run.py``) remains
-#: forbidden; it is reserved for B2.8c.
+#: weakening its closed semantics.
+#:
+#: * B2.8b added ``dashboard/api_merge_execution_dry_run.py`` (the
+#:   skeleton blueprint).
+#: * B2.8c added ``reporting/n5b_merge_execution_dry_run.py`` (the
+#:   preflight-only audit projector the walker calls).
+#:
+#: Subsequent sub-units (B2.8d / B2.8e) may extend this allowlist
+#: by appending one further operator-approved path per PR; they
+#: must never widen the glob set or remove paths.
 _ALLOWED_N5B_ADAPTER_MODULES: tuple[str, ...] = (
     "dashboard/api_merge_execution_dry_run.py",
+    "reporting/n5b_merge_execution_dry_run.py",
 )
 
 

--- a/tests/unit/test_n5b_phase2_implementation_plan.py
+++ b/tests/unit/test_n5b_phase2_implementation_plan.py
@@ -673,25 +673,28 @@ def test_no_phase2_module_exists_in_runtime_yet() -> None:
     """Originally a B2.8a-era pin asserting neither Phase 2
     module existed on disk. **Narrowed by B2.8b** to allow the
     operator-approved skeleton blueprint
-    ``dashboard/api_merge_execution_dry_run.py``. The
-    reporting-side audit projector
-    ``reporting/n5b_merge_execution_dry_run.py`` remains
-    forbidden; it is reserved for B2.8c."""
+    ``dashboard/api_merge_execution_dry_run.py``. **Narrowed
+    again by B2.8c** to allow the operator-approved reporting-side
+    audit projector ``reporting/n5b_merge_execution_dry_run.py``
+    (the preflight writer the walker calls)."""
     dashboard_skeleton = (
         REPO_ROOT / "dashboard" / "api_merge_execution_dry_run.py"
     )
     reporting_projector = (
         REPO_ROOT / "reporting" / "n5b_merge_execution_dry_run.py"
     )
-    # The dashboard skeleton MUST exist now (B2.8b landed it).
+    # The dashboard skeleton MUST exist now (B2.8b landed it; B2.8c
+    # extended it with the precondition walker for 1–7).
     assert dashboard_skeleton.is_file(), (
-        f"B2.8b skeleton missing on disk: {dashboard_skeleton}"
+        f"B2.8b/B2.8c dashboard module missing on disk: {dashboard_skeleton}"
     )
-    # The reporting-side audit projector MUST NOT exist yet
-    # (B2.8c will land it).
-    assert not reporting_projector.is_file(), (
-        f"B2.8b is skeleton-only; reporting projector must not "
-        f"exist yet: {reporting_projector}"
+    # The reporting-side audit projector MUST exist now (B2.8c
+    # landed it). It writes ONLY the preflight artefact in this
+    # slice; the dry-run-decision / failure / history writers
+    # remain reserved for B2.8d / B2.8e per the implementation
+    # plan §2.6.
+    assert reporting_projector.is_file(), (
+        f"B2.8c reporting projector missing on disk: {reporting_projector}"
     )
 
 

--- a/tests/unit/test_n5b_phase2_precondition_readiness.py
+++ b/tests/unit/test_n5b_phase2_precondition_readiness.py
@@ -484,18 +484,46 @@ def test_parent_plan_has_backpointer_to_readiness_report() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_b2_8b_skeleton_module_unchanged_in_this_pr() -> None:
-    """The B2.8b skeleton at
-    dashboard/api_merge_execution_dry_run.py must remain on disk
-    and must still carry its pinned MODULE_VERSION literal so a
-    silent modification by this readiness PR is detected."""
+#: Closed allowlist of ``MODULE_VERSION`` literals the
+#: ``dashboard/api_merge_execution_dry_run.py`` module is permitted
+#: to carry. Grows one entry per operator-approved sub-unit:
+#:
+#: * ``v3.15.16.N5b.phase2.skeleton`` — B2.8b (initial UNWIRED skeleton)
+#: * ``v3.15.16.N5b.phase2.walker_1_7`` — B2.8c (walker for §3 preconditions 1–7)
+#:
+#: Subsequent sub-units (B2.8d / B2.8e) may extend this allowlist
+#: by appending one further operator-approved literal per PR. They
+#: must never remove a previously-pinned literal or widen the
+#: per-PR exactly-one-match assertion.
+_ALLOWED_SKELETON_MODULE_VERSION_LITERALS: tuple[str, ...] = (
+    'MODULE_VERSION: Final[str] = "v3.15.16.N5b.phase2.skeleton"',
+    'MODULE_VERSION: Final[str] = "v3.15.16.N5b.phase2.walker_1_7"',
+)
+
+
+def test_b2_8b_skeleton_module_carries_an_allowlisted_version() -> None:
+    """Originally a B2.8c-pre pin asserting the B2.8b skeleton's
+    ``MODULE_VERSION`` literal was unchanged. **Narrowed by B2.8c**
+    to allow exactly the operator-approved walker version
+    introduced by that sub-unit. The narrowing follows the same
+    one-version-at-a-time pattern the adapter-module allowlists
+    in ``test_n5b_merge_execution_plan.py`` /
+    ``test_n5b_phase2_implementation_plan.py`` use. No previously
+    pinned literal is removed; the change only permits the
+    operator-approved walker version literal in addition."""
     assert B2_8B_SKELETON_PATH.is_file(), (
-        f"B2.8b skeleton file missing: {B2_8B_SKELETON_PATH}"
+        f"B2.8b/B2.8c dashboard module missing: {B2_8B_SKELETON_PATH}"
     )
     src = B2_8B_SKELETON_PATH.read_text(encoding="utf-8")
-    assert 'MODULE_VERSION: Final[str] = "v3.15.16.N5b.phase2.skeleton"' in src, (
-        "B2.8b skeleton MODULE_VERSION literal missing or changed; "
-        "this readiness PR must not modify the skeleton"
+    hits = [
+        literal
+        for literal in _ALLOWED_SKELETON_MODULE_VERSION_LITERALS
+        if literal in src
+    ]
+    assert len(hits) == 1, (
+        "dashboard/api_merge_execution_dry_run.py must carry exactly "
+        f"one MODULE_VERSION literal from the closed allowlist "
+        f"{_ALLOWED_SKELETON_MODULE_VERSION_LITERALS!r}; found: {hits!r}"
     )
 
 


### PR DESCRIPTION
## Summary

**THIS IS NOT A PHASE 2 ACTIVATION.** The blueprint remains UNWIRED in `dashboard/dashboard.py`. The two-line wiring patch is operator-only (B2.8e scope) per `docs/governance/execution_authority.md` and `.claude/hooks/deny_no_touch.py`.

B2.8c implements the precondition walker for parent-doc §3 preconditions 1–7 on top of the B2.8b skeleton, and adds the preflight-only audit projector. Preconditions 8–17 (GitHub-API-dependent) are deferred to B2.8d under its own operator-go.

### What lands in this PR (exact 9-file diff)

**Runtime (3):**
- `reporting/approval_token_runtime.py` — adds one new public helper `verify_runtime_for_dry_run(...)`. Existing surface (`mint_runtime`, `verify_runtime`, `is_configured`, `secrets_by_kid`, `current_kid`, `record_nonce`) unchanged.
- `reporting/n5b_merge_execution_dry_run.py` — **new** sentinel-restricted preflight projector. Writes ONLY `logs/n5b_merge_execution/preflight/latest.json`. Dry-run-decision / failure / history writers remain reserved for B2.8d / B2.8e per implementation plan §2.6.
- `dashboard/api_merge_execution_dry_run.py` — B2.8b skeleton → B2.8c walker. `MODULE_VERSION` bumped to `v3.15.16.N5b.phase2.walker_1_7`. Route, method, envelope shape, UNWIRED state UNCHANGED.

**Tests (6):**
- `tests/unit/test_approval_token_runtime.py` — +13 tests for `verify_runtime_for_dry_run`; existing 37 pass unchanged.
- `tests/unit/test_n5b_merge_execution_dry_run.py` — **new** 42 projector pin tests.
- `tests/unit/test_api_merge_execution_dry_run.py` — replaces B2.8b skeleton-only pins with walker pins (68 tests; preflight write only after 1–7 pass; never emits `ok`; no preflight on any failure path).
- `tests/unit/test_n5b_phase2_implementation_plan.py` — narrows the one pin that forbade the reporting projector.
- `tests/unit/test_n5b_merge_execution_plan.py` — appends `reporting/n5b_merge_execution_dry_run.py` to `_ALLOWED_N5B_ADAPTER_MODULES`.
- `tests/unit/test_n5b_phase2_precondition_readiness.py` — replaces the single-literal skeleton MODULE_VERSION hard-pin with a two-literal closed allowlist (`v3.15.16.N5b.phase2.skeleton` + `v3.15.16.N5b.phase2.walker_1_7`); exactly-one-present assertion.

### Hard guarantees pinned by tests

- B2.8c **never emits `status=ok`** — the happy path returns `status=not_yet_implemented` with `preconditions_evaluated=7`, `preconditions_passed=7`, `reason=preconditions_8_through_17_pending`. `status=ok` is reserved for B2.8e.
- **No preflight artefact** on: malformed body, missing N4b, missing N4c, invalid/expired/replayed/binding-mismatched token.
- Preflight artefact **only** after checks 1–7 all pass.
- Preflight artefact carries `token_kid` + sha256-hashed `nonce_hash` only. **Raw token and raw nonce are never persisted.**
- **No GitHub API calls**, no `gh`/`git`/subprocess/socket/urllib/requests/httpx/aiohttp imports anywhere.
- **No production merge, simulator merge, deploy authority, or PR mutation.** No `--admin`, no `--no-verify`, no force push, no merge-PR attribute literals.
- Dashboard module reads no env var directly; only the token runtime does.
- Deferred §7 stop-condition literals (`head_sha_mismatch`, `merge_state_not_clean`, `checks_not_green`, `branch_protection_not_satisfied`, etc.) are absent from walker source.
- No new stop-condition literal introduced. Post-verification preflight-write failure surfaces as `status=rejected`, HTTP 500, `stop_condition=None`, `reason=preflight_write_failed` (reason only, NOT a §7 stop_condition).
- **Step 5 remains closed:** `step5_implementation_allowed: Final[False]`, `STEP5_ENABLED_SUBSTAGE: Final["none"]`, **Level 6 permanently disabled** per ADR-015 §Doctrine 1.

### Readiness declarations (per `docs/governance/n5b_phase2_precondition_readiness.md` §6)

```yaml
n5b_phase2_precondition_declaration:
  phase_1_observed_clean: YES
  phase_1_observed_clean_comment: |
    N5b Phase 1 preflight projector merged 2026-05-12 via PR #204.
    B2.8a implementation plan merged via PR #231. B2.8b skeleton
    merged via PR #232 and remains unwired on VPS. B2.8c-pre
    readiness report merged via PR #233. Operator observed the
    Phase 1 / B2.8 chain as clean and declares the bounded
    observation period elapsed.

  n4b_phase_b_activated_on_vps: YES
  n4b_phase_b_evidence_ref: |
    VPS dashboard container has ADE_APPROVAL_TOKEN_HMAC_SECRET
    configured. Env string length check returned 64. Authenticated
    approval-token status endpoint returned status=ok,
    is_configured=true, current_kid=k1,
    step5_implementation_allowed=false, step5_enabled_substage=none.

  n4c_or_equivalent_mint_verify_ui: YES
  n4c_ui_route: /agent-control/approval-token-diagnostics
  n4c_ui_component: frontend/src/routes/AgentControl/ApprovalTokenDiagnostics.tsx
```

### Files explicitly NOT touched
`dashboard/dashboard.py`, `.claude/**`, `.github/**`, `tests/regression/**`, no-touch paths, frozen schemas, `live/**`, `paper/**`, `shadow/**`, `risk/**`, `broker/**`, `execution/**`, `research/**`, `frontend/**`, `automation/**`, `agent/**`, `scripts/**`, all `docs/**`.

### Local test gates
- Targeted B2.8c suite (8 files): **375 passed**
- Full `tests/unit/` suite: **6006 passed, 3 skipped**

## Test plan

- [ ] CI Fast pre-merge gate passes
- [ ] Static analysis (mypy/flake8/bandit) clean
- [ ] Governance + push-body-safety lints clean
- [ ] Diff scope on PR still exactly the 9 approved files
- [ ] Squash-merge after green CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)