### PR TITLE
feat(b2-8d)(n5b): Phase 2 precondition walkers 8-17

### DIFF
--- a/dashboard/api_merge_execution_dry_run.py
+++ b/dashboard/api_merge_execution_dry_run.py
@@ -60,6 +60,7 @@ What B2.8c does NOT do:
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Final
@@ -70,7 +71,7 @@ from reporting import approval_token_runtime as atr
 from reporting import n5b_merge_execution_dry_run as projector
 from reporting.agent_audit_summary import assert_no_secrets
 
-MODULE_VERSION: Final[str] = "v3.15.16.N5b.phase2.walker_1_7"
+MODULE_VERSION: Final[str] = "v3.15.16.N5b.phase2.walker_1_17"
 SCHEMA_VERSION: Final[int] = 1
 
 
@@ -136,6 +137,57 @@ _N4C_COMPONENT_PATH: Final[Path] = (
 
 #: Operator-actor literal for the session-protected dry-run route.
 _OPERATOR_ACTOR_SESSION: Final[str] = "session"
+
+# ---------------------------------------------------------------------------
+# B2.8d walker — upstream artefact paths (READ-ONLY).
+#
+# The walker reads pre-existing artefacts maintained by the
+# operator-paced upstream workloop. The walker NEVER calls ``gh``,
+# ``git``, subprocess, sockets, urllib, requests, httpx, or aiohttp
+# directly. It NEVER imports ``reporting.github_pr_lifecycle`` (the
+# module that produces ``logs/github_pr_lifecycle/latest.json``)
+# because that module legitimately uses ``subprocess`` — the walker
+# reads its on-disk artefact instead.
+#
+# Missing / malformed / no-matching-row artefacts fail closed with
+# the closed §7 ``network_uncertain`` stop_condition.
+# ---------------------------------------------------------------------------
+
+_N5A_ARTIFACT_PATH: Final[Path] = (
+    _REPO_ROOT / "logs" / "development_merge_recommendation" / "latest.json"
+)
+_A22_ARTIFACT_PATH: Final[Path] = (
+    _REPO_ROOT / "logs" / "development_pr_lifecycle_observer" / "latest.json"
+)
+_GITHUB_PR_LIFECYCLE_ARTIFACT_PATH: Final[Path] = (
+    _REPO_ROOT / "logs" / "github_pr_lifecycle" / "latest.json"
+)
+
+#: Closed canonical mergeStateStatus values that count as "merge is
+#: safe to attempt right now". Per §6.3 the adapter accepts only
+#: ``CLEAN``. The walker upper-cases A22 values before comparing.
+_CLEAN_MERGE_STATES: Final[frozenset[str]] = frozenset({"CLEAN"})
+
+#: Closed canonical check-conclusion values that count as "all
+#: required checks green". Per §6.3 the adapter accepts only
+#: ``success``-equivalents. A22 emits canonical-cased rollups
+#: (``SUCCESS``, ``PASSED``, ``PASSING``).
+_GREEN_CHECK_STATES: Final[frozenset[str]] = frozenset(
+    {"SUCCESS", "PASSING", "PASSED"}
+)
+
+#: Closed N5a recommendation that means "human merge is the
+#: appropriate next step". Anything else triggers
+#: ``stale_recommendation`` (per the operator-approved §7 semantic
+#: stretch — N5a's snapshot is not in the eligible state at
+#: evaluation time).
+_N5A_ELIGIBLE_ACTION: Final[str] = "recommend_human_merge"
+_N5A_ELIGIBLE_REASON: Final[str] = "pr_clean_and_no_blocking_inbox"
+
+#: Bounded freshness window for the N5a recommendation snapshot.
+#: Per parent doc §3 row 13 — N5a older than this is flagged with
+#: ``stale_recommendation``.
+_N5A_FRESHNESS_SECONDS: Final[int] = 60 * 60  # 60 minutes
 
 #: Closed mapping from body-shape validation reason → §7 stop
 #: condition. Body-shape failures translate to the §7 vocabulary
@@ -378,6 +430,286 @@ def _translate_verify_envelope(
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Upstream-artefact readers (READ-ONLY; never raise; defense-in-depth)
+# ---------------------------------------------------------------------------
+
+
+def _read_json_artifact(path: Path) -> tuple[str, dict[str, Any] | None]:
+    """Return ``(status, payload)`` where ``status`` ∈
+    {``"ok"``, ``"absent"``, ``"malformed"``}. Never raises."""
+    if not path.is_file():
+        return "absent", None
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return "malformed", None
+    try:
+        data = json.loads(text)
+    except (ValueError, json.JSONDecodeError):
+        return "malformed", None
+    if not isinstance(data, dict):
+        return "malformed", None
+    return "ok", data
+
+
+def _find_row_for_pr(
+    payload: dict[str, Any], rows_key: str, pr_number: int
+) -> dict[str, Any] | None:
+    """Locate the row in ``payload[rows_key]`` whose ``pr_number``
+    matches. Returns the matched dict, or ``None`` if no match."""
+    raw = payload.get(rows_key)
+    if not isinstance(raw, list):
+        return None
+    for row in raw:
+        if not isinstance(row, dict):
+            continue
+        candidate = row.get("pr_number") or row.get("number")
+        try:
+            if int(candidate or 0) == pr_number:
+                return row
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def _parse_iso_utc(value: Any) -> datetime | None:
+    """Best-effort ISO-8601 parser. Returns ``None`` on any failure."""
+    if not isinstance(value, str) or not value:
+        return None
+    candidate = value.strip()
+    if candidate.endswith("Z"):
+        candidate = candidate[:-1] + "+00:00"
+    try:
+        return datetime.fromisoformat(candidate)
+    except ValueError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# B2.8d walker (preconditions 8–17)
+# ---------------------------------------------------------------------------
+
+
+def _walk_preconditions_8_through_17(
+    *,
+    pr_number: int,
+    pr_head_sha: str,
+) -> tuple[str | None, str | None, int]:
+    """Walk parent-doc §3 preconditions 8–17 from the on-disk
+    upstream artefacts.
+
+    Returns ``(stop_condition, stop_reason, preconditions_evaluated)``
+    where:
+
+    * ``stop_condition`` is ``None`` on full success, or one of the
+      closed §6.3 / §7 vocabulary strings on the first failure.
+    * ``stop_reason`` is ``None`` on full success, or a bounded
+      redacted closed-string describing the failure dimension.
+    * ``preconditions_evaluated`` is the number of §3 rows the walker
+      reached. On full success this is 17 (rows 8–17 plus the
+      auto-pass row 17, added to the 7 rows already evaluated by
+      the B2.8c walker outside this function).
+
+    The walker NEVER calls ``gh`` / ``git`` / subprocess / network.
+    Every check reads from existing on-disk artefacts via
+    :func:`_read_json_artifact`. Missing / malformed / no-matching-row
+    artefacts fail closed with ``network_uncertain``.
+
+    For optional B2.8d extended fields on the
+    ``logs/github_pr_lifecycle/latest.json`` row
+    (``step5_flag_changed``, ``level_6_attempted``,
+    ``deploy_coupling_detected``, ``branch_protection_satisfied``,
+    ``no_touch_path_violation``), missing fields fail closed with
+    ``network_uncertain`` rather than silently auto-passing. Tests
+    inject these fields via monkeypatched artefacts; production
+    today does not yet emit them, so the walker rejects every
+    invocation with ``network_uncertain`` until upstream is
+    extended — by design, since the endpoint is also UNWIRED.
+    """
+    # ---- Read upstream artefacts. Missing / malformed → network_uncertain.
+    n5a_status, n5a_payload = _read_json_artifact(_N5A_ARTIFACT_PATH)
+    if n5a_status != "ok" or n5a_payload is None:
+        return ("network_uncertain", "n5a_artifact_unavailable", 7)
+    a22_status, a22_payload = _read_json_artifact(_A22_ARTIFACT_PATH)
+    if a22_status != "ok" or a22_payload is None:
+        return ("network_uncertain", "a22_artifact_unavailable", 7)
+    gh_status, gh_payload = _read_json_artifact(_GITHUB_PR_LIFECYCLE_ARTIFACT_PATH)
+    if gh_status != "ok" or gh_payload is None:
+        return ("network_uncertain", "gh_pr_lifecycle_artifact_unavailable", 7)
+
+    n5a_row = _find_row_for_pr(n5a_payload, "rows", pr_number)
+    if n5a_row is None:
+        return ("network_uncertain", "n5a_row_missing_for_pr", 7)
+    a22_row = _find_row_for_pr(a22_payload, "rows", pr_number)
+    if a22_row is None:
+        return ("network_uncertain", "a22_row_missing_for_pr", 7)
+    gh_row = _find_row_for_pr(gh_payload, "prs", pr_number)
+    if gh_row is None:
+        return ("network_uncertain", "gh_pr_lifecycle_row_missing_for_pr", 7)
+
+    # ---- Precondition 8: N5a says eligible.
+    rec_action = n5a_row.get("recommendation_action")
+    rec_reason = n5a_row.get("recommendation_reason")
+    if rec_action != _N5A_ELIGIBLE_ACTION:
+        return ("stale_recommendation", "n5a_action_not_eligible", 8)
+    if rec_reason != _N5A_ELIGIBLE_REASON:
+        return ("stale_recommendation", "n5a_reason_not_eligible", 8)
+
+    # ---- Precondition 9: mergeStateStatus = CLEAN (+ branch protection).
+    mss = a22_row.get("merge_state_status")
+    if not isinstance(mss, str):
+        return ("network_uncertain", "merge_state_status_missing", 9)
+    if mss.upper() not in _CLEAN_MERGE_STATES:
+        return ("merge_state_not_clean", "merge_state_status_not_clean", 9)
+    bp_satisfied = gh_row.get("branch_protection_satisfied")
+    if not isinstance(bp_satisfied, bool):
+        return ("network_uncertain", "branch_protection_field_missing", 9)
+    if not bp_satisfied:
+        return (
+            "branch_protection_not_satisfied",
+            "branch_protection_unsatisfied",
+            9,
+        )
+
+    # ---- Precondition 10: all required checks green.
+    checks = a22_row.get("checks_summary")
+    if not isinstance(checks, str):
+        return ("network_uncertain", "checks_summary_missing", 10)
+    if checks.upper() not in _GREEN_CHECK_STATES:
+        return ("checks_not_green", "checks_summary_not_green", 10)
+
+    # ---- Precondition 11: current head SHA equals token-bound head SHA.
+    observed_head = a22_row.get("head_sha")
+    if not isinstance(observed_head, str) or not observed_head:
+        return ("network_uncertain", "head_sha_missing_in_a22", 11)
+    if observed_head != pr_head_sha:
+        return ("head_sha_mismatch", "a22_head_sha_differs_from_bound", 11)
+
+    # ---- Precondition 12: base ref = main.
+    base_ref = a22_row.get("base_ref")
+    if not isinstance(base_ref, str):
+        return ("network_uncertain", "base_ref_missing", 12)
+    if base_ref.lower() != "main":
+        return ("merge_state_not_clean", "base_ref_not_main", 12)
+
+    # ---- Precondition 13: N5a freshness within bounded window.
+    evaluated_at = _parse_iso_utc(n5a_row.get("evaluated_at"))
+    if evaluated_at is None:
+        return ("network_uncertain", "n5a_evaluated_at_unparseable", 13)
+    age = datetime.now(UTC) - evaluated_at
+    if age.total_seconds() > _N5A_FRESHNESS_SECONDS:
+        return ("stale_recommendation", "n5a_age_exceeds_freshness_window", 13)
+
+    # ---- Precondition 14: no critical inbox rows.
+    try:
+        crit = int(n5a_row.get("inbox_critical_count") or 0)
+    except (TypeError, ValueError):
+        return ("network_uncertain", "inbox_critical_count_unparseable", 14)
+    if crit > 0:
+        return (
+            "stale_recommendation",
+            "n5a_reports_inbox_criticals_inconsistency",
+            14,
+        )
+
+    # ---- Precondition 15: no protected-path violations
+    # (covers unexpected_files_touched + protected_path_violation +
+    # deploy_coupling_detected sub-checks).
+    pp_touched = gh_row.get("protected_paths_touched")
+    if not isinstance(pp_touched, bool):
+        return ("network_uncertain", "protected_paths_field_missing", 15)
+    if pp_touched:
+        return (
+            "unexpected_files_touched",
+            "gh_pr_lifecycle_flags_protected_path",
+            15,
+        )
+    no_touch_violation = gh_row.get("no_touch_path_violation")
+    if not isinstance(no_touch_violation, bool):
+        return ("network_uncertain", "no_touch_path_violation_field_missing", 15)
+    if no_touch_violation:
+        return (
+            "protected_path_violation",
+            "gh_pr_lifecycle_flags_no_touch_path",
+            15,
+        )
+    deploy_coupling = gh_row.get("deploy_coupling_detected")
+    if not isinstance(deploy_coupling, bool):
+        return ("network_uncertain", "deploy_coupling_field_missing", 15)
+    if deploy_coupling:
+        return (
+            "deploy_coupling_detected",
+            "gh_pr_lifecycle_flags_deploy_coupling",
+            15,
+        )
+
+    # ---- Precondition 16: no Step 5 / Level 6 bypass.
+    step5_changed = gh_row.get("step5_flag_changed")
+    if not isinstance(step5_changed, bool):
+        return ("network_uncertain", "step5_flag_field_missing", 16)
+    if step5_changed:
+        return ("step5_flag_changed", "gh_pr_lifecycle_flags_step5_change", 16)
+    level_6_attempted = gh_row.get("level_6_attempted")
+    if not isinstance(level_6_attempted, bool):
+        return ("network_uncertain", "level_6_field_missing", 16)
+    if level_6_attempted:
+        return ("level_6_attempted", "gh_pr_lifecycle_flags_level_6", 16)
+
+    # ---- Precondition 17: auto-pass (dry-run has no execution boundary).
+    # Per operator authority: this is the ONLY precondition auto-passed
+    # in B2.8d.
+
+    return (None, None, 17)
+
+
+# ---------------------------------------------------------------------------
+# Failure-artefact write helper
+# ---------------------------------------------------------------------------
+
+
+def _make_cycle_id(*, pr_number: int, generated_at_utc: str) -> str:
+    """Derive a cycle_id from pr_number + UTC timestamp. The projector
+    additionally charset-validates the result."""
+    compact_ts = (
+        generated_at_utc.replace("-", "").replace(":", "").replace(".", "")
+    )
+    return f"pr{pr_number}_{compact_ts}"
+
+
+def _write_failure_after_walker(
+    *,
+    pr_number: int,
+    pr_head_sha: str,
+    stop_condition: str,
+    stop_reason: str,
+    preconditions_evaluated: int,
+    preconditions_passed: int,
+    generated_at_utc: str,
+) -> tuple[bool, str | None]:
+    """Persist the closed-schema failure artefact. Returns
+    ``(True, None)`` on success or ``(False, "<bounded reason>")``
+    on a write failure."""
+    cycle_id = _make_cycle_id(
+        pr_number=pr_number, generated_at_utc=generated_at_utc
+    )
+    try:
+        projector.write_failure(
+            cycle_id=cycle_id,
+            pr_number=pr_number,
+            pr_head_sha=pr_head_sha,
+            stop_condition=stop_condition,
+            stop_reason=stop_reason,
+            preconditions_evaluated=preconditions_evaluated,
+            preconditions_passed=preconditions_passed,
+            operator_actor=_OPERATOR_ACTOR_SESSION,
+            generated_at_utc=generated_at_utc,
+        )
+    except Exception:
+        return (False, "failure_write_failed")
+    return (True, None)
+
+
 def _write_preflight_after_verification(
     *,
     pr_number: int,
@@ -520,9 +852,8 @@ def _view_dry_run() -> tuple[Response, int]:
         )
         return _safe_jsonify(envelope), 200
 
-    # ---- All 7 preconditions passed. Preflight write THEN
-    # not_yet_implemented (preconditions 8–17 are out of scope
-    # for B2.8c). ----
+    # ---- All 7 preconditions passed. Write preflight artefact, THEN
+    # walk preconditions 8–17 (B2.8d). ----
     token_kid = str(verify_env.get("kid") or "")
     nonce_hash = str(verify_env.get("nonce_hash") or "")
     ok_write, write_reason = _write_preflight_after_verification(
@@ -532,10 +863,11 @@ def _view_dry_run() -> tuple[Response, int]:
         nonce_hash=nonce_hash,
     )
     if not ok_write:
-        # Post-verification write failure: surface as rejected with
-        # stop_condition=None and reason=preflight_write_failed.
-        # No new §7 stop-condition literal is introduced; the
-        # operator inspects the bounded reason field.
+        # Post-verification preflight-write failure: surface as
+        # rejected with stop_condition=None and
+        # reason=preflight_write_failed. No new §7 stop-condition
+        # literal is introduced; the operator inspects the bounded
+        # reason field.
         envelope = _base_envelope(
             status="rejected",
             stop_condition=None,
@@ -548,15 +880,68 @@ def _view_dry_run() -> tuple[Response, int]:
         )
         return _safe_jsonify(envelope), 500
 
+    # ---- B2.8d walker for preconditions 8–17 ----
+    walker_stop, walker_reason, walker_evaluated = (
+        _walk_preconditions_8_through_17(
+            pr_number=pr_number,
+            pr_head_sha=pr_head_sha,
+        )
+    )
+    walker_now = _utcnow_iso()
+    if walker_stop is not None:
+        # §7 stop hit. Write the failure artefact (closed schema,
+        # bounded reason) and emit rejected.
+        passed_count = walker_evaluated - 1
+        write_ok, _write_err = _write_failure_after_walker(
+            pr_number=pr_number,
+            pr_head_sha=pr_head_sha,
+            stop_condition=walker_stop,
+            stop_reason=walker_reason or "",
+            preconditions_evaluated=walker_evaluated,
+            preconditions_passed=passed_count,
+            generated_at_utc=walker_now,
+        )
+        if not write_ok:
+            # Failure-artefact write itself failed. Per §7
+            # vocabulary, emit audit_write_failure.
+            envelope = _base_envelope(
+                status="rejected",
+                stop_condition="audit_write_failure",
+                preconditions_evaluated=walker_evaluated,
+                preconditions_passed=passed_count,
+                would_proceed=False,
+                pr_number=pr_number,
+                pr_head_sha=pr_head_sha,
+                reason="failure_artefact_write_failed",
+            )
+            return _safe_jsonify(envelope), 500
+        envelope = _base_envelope(
+            status="rejected",
+            stop_condition=walker_stop,
+            preconditions_evaluated=walker_evaluated,
+            preconditions_passed=passed_count,
+            would_proceed=False,
+            pr_number=pr_number,
+            pr_head_sha=pr_head_sha,
+            reason=walker_reason,
+        )
+        return _safe_jsonify(envelope), 200
+
+    # ---- All 17 preconditions passed.
+    # Per operator-approved deferral: B2.8d emits
+    # not_yet_implemented with reason="b2_8e_implementation_pending".
+    # B2.8d MUST NOT emit status=ok. B2.8d MUST NOT write
+    # dry_run/latest.json or history.jsonl. Those flips land in
+    # B2.8e along with the wiring patch + doc updates.
     envelope = _base_envelope(
         status="not_yet_implemented",
         stop_condition=None,
-        preconditions_evaluated=7,
-        preconditions_passed=7,
+        preconditions_evaluated=17,
+        preconditions_passed=17,
         would_proceed=False,
         pr_number=pr_number,
         pr_head_sha=pr_head_sha,
-        reason="preconditions_8_through_17_pending",
+        reason="b2_8e_implementation_pending",
     )
     return _safe_jsonify(envelope), 200
 

--- a/reporting/n5b_merge_execution_dry_run.py
+++ b/reporting/n5b_merge_execution_dry_run.py
@@ -69,8 +69,9 @@ from reporting.agent_audit_summary import assert_no_secrets
 REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
 
 SCHEMA_VERSION: Final[int] = 1
-MODULE_VERSION: Final[str] = "v3.15.16.N5b.phase2.projector"
+MODULE_VERSION: Final[str] = "v3.15.16.N5b.phase2.projector_with_failure"
 REPORT_KIND: Final[str] = "n5b_preflight"
+FAILURE_REPORT_KIND: Final[str] = "n5b_failure"
 
 
 # ---------------------------------------------------------------------------
@@ -96,6 +97,14 @@ PREFLIGHT_LATEST: Final[Path] = PREFLIGHT_DIR / "latest.json"
 PREFLIGHT_LATEST_RELATIVE: Final[str] = (
     "logs/n5b_merge_execution/preflight/latest.json"
 )
+
+#: B2.8d failure artefact directory. Per parent-doc §6 / §2.6, each
+#: §7 stop condition the walker emits writes a failure artefact at
+#: ``logs/n5b_merge_execution/failure/<cycle_id>.json`` with the
+#: closed schema below and a redacted ``stop_reason``. No raw nonce,
+#: no raw token, no PR diff content.
+FAILURE_DIR: Final[Path] = REPO_ROOT / "logs" / "n5b_merge_execution" / "failure"
+FAILURE_DIR_RELATIVE: Final[str] = "logs/n5b_merge_execution/failure/"
 
 
 # ---------------------------------------------------------------------------
@@ -133,6 +142,44 @@ _DISCIPLINE_INVARIANTS: Final[dict[str, bool | str]] = {
     "step5_enabled_substage": "none",
     "level6_enabled": False,
 }
+
+
+# ---------------------------------------------------------------------------
+# Closed §7 stop-condition vocabulary the B2.8d walker is permitted
+# to emit. Mirrors the parent-doc
+# ``docs/governance/n5b_merge_execution_plan.md`` §7 enumeration
+# narrowed to the §6.3 list for B2.8d. The walker writes one of
+# these values into the failure artefact's ``stop_condition`` field.
+# New literals must NOT be added without a doc update.
+# ---------------------------------------------------------------------------
+
+B2_8D_STOP_CONDITIONS: Final[tuple[str, ...]] = (
+    # Token-side (also emitted by B2.8c walker for 1–7; included
+    # here so the failure artefact's schema validator accepts them).
+    "token_missing",
+    "token_invalid",
+    "replay_detected",
+    "binding_mismatch",
+    "pr_number_mismatch",
+    # B2.8d additions for preconditions 8–17 (closed per §6.3).
+    "head_sha_mismatch",
+    "merge_state_not_clean",
+    "checks_not_green",
+    "branch_protection_not_satisfied",
+    "unexpected_files_touched",
+    "deploy_coupling_detected",
+    "step5_flag_changed",
+    "level_6_attempted",
+    "protected_path_violation",
+    "stale_recommendation",
+    "network_uncertain",
+    "audit_write_failure",
+)
+
+#: Maximum bounded length of the failure ``stop_reason`` field.
+#: Defense-in-depth against arbitrary upstream-provided strings
+#: leaking secret-shaped material.
+MAX_STOP_REASON_LEN: Final[int] = 200
 
 
 # ---------------------------------------------------------------------------
@@ -323,8 +370,196 @@ def write_preflight(
     return target
 
 
+# ---------------------------------------------------------------------------
+# B2.8d failure artefact — closed schema
+# ---------------------------------------------------------------------------
+
+
+FAILURE_SNAPSHOT_KEYS: Final[tuple[str, ...]] = (
+    "schema_version",
+    "report_kind",
+    "module_version",
+    "cycle_id",
+    "pr_number",
+    "pr_head_sha",
+    "pr_base_ref",
+    "intent",
+    "stop_condition",
+    "stop_reason",
+    "preconditions_evaluated",
+    "preconditions_passed",
+    "operator_actor",
+    "generated_at_utc",
+    "step5_implementation_allowed",
+    "step5_enabled_substage",
+    "level6_enabled",
+    "dry_run_only",
+    "live_merge_implemented",
+    "deploy_coupled",
+    "discipline_invariants",
+)
+
+
+def _validate_cycle_id(cycle_id: str) -> None:
+    """``cycle_id`` is used as a filename segment, so it must be
+    charset-restricted to safe ASCII (alphanumeric + underscore +
+    hyphen). Any other character raises ``ValueError``."""
+    if not isinstance(cycle_id, str) or not cycle_id:
+        raise ValueError("cycle_id must be a non-empty string")
+    if len(cycle_id) > 128:
+        raise ValueError("cycle_id exceeds 128 chars")
+    for ch in cycle_id:
+        if not (ch.isalnum() or ch in ("_", "-")):
+            raise ValueError(
+                f"cycle_id contains unsafe character: {ch!r}"
+            )
+
+
+def build_failure_snapshot(
+    *,
+    cycle_id: str,
+    pr_number: int,
+    pr_head_sha: str,
+    stop_condition: str,
+    stop_reason: str,
+    preconditions_evaluated: int,
+    preconditions_passed: int,
+    operator_actor: str,
+    generated_at_utc: str,
+) -> dict[str, Any]:
+    """Build the closed-schema failure snapshot dict.
+
+    Pure — no I/O. Caller is responsible for supplying a
+    ``stop_condition`` from :data:`B2_8D_STOP_CONDITIONS` and a
+    ``stop_reason`` that has been bounded / redacted at the caller
+    side. The projector additionally truncates ``stop_reason`` to
+    :data:`MAX_STOP_REASON_LEN` chars defense-in-depth.
+
+    Raises:
+      :class:`TypeError` if ``pr_number`` /
+      ``preconditions_evaluated`` / ``preconditions_passed`` are not
+      ``int`` (or are ``bool``).
+      :class:`ValueError` for any string-shape or vocabulary failure.
+    """
+    _validate_cycle_id(cycle_id)
+    if not isinstance(pr_number, int) or isinstance(pr_number, bool):
+        raise TypeError("pr_number must be int")
+    if pr_number <= 0:
+        raise ValueError("pr_number must be positive")
+    if not isinstance(pr_head_sha, str) or not pr_head_sha:
+        raise ValueError("pr_head_sha must be a non-empty string")
+    if len(pr_head_sha) > 64:
+        raise ValueError("pr_head_sha exceeds 64 chars")
+    if stop_condition not in B2_8D_STOP_CONDITIONS:
+        raise ValueError(
+            f"stop_condition must be one of {B2_8D_STOP_CONDITIONS}; "
+            f"got {stop_condition!r}"
+        )
+    if not isinstance(stop_reason, str):
+        raise TypeError("stop_reason must be str")
+    if not isinstance(preconditions_evaluated, int) or isinstance(
+        preconditions_evaluated, bool
+    ):
+        raise TypeError("preconditions_evaluated must be int")
+    if not isinstance(preconditions_passed, int) or isinstance(
+        preconditions_passed, bool
+    ):
+        raise TypeError("preconditions_passed must be int")
+    if preconditions_evaluated < 0 or preconditions_passed < 0:
+        raise ValueError(
+            "preconditions_evaluated / preconditions_passed must be non-negative"
+        )
+    if preconditions_passed > preconditions_evaluated:
+        raise ValueError(
+            "preconditions_passed must not exceed preconditions_evaluated"
+        )
+    if operator_actor not in OPERATOR_ACTORS:
+        raise ValueError(
+            f"operator_actor must be one of {OPERATOR_ACTORS}; got {operator_actor!r}"
+        )
+    if not isinstance(generated_at_utc, str) or not generated_at_utc:
+        raise ValueError("generated_at_utc must be a non-empty ISO 8601 string")
+
+    snapshot: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": FAILURE_REPORT_KIND,
+        "module_version": MODULE_VERSION,
+        "cycle_id": cycle_id,
+        "pr_number": pr_number,
+        "pr_head_sha": pr_head_sha,
+        "pr_base_ref": PR_BASE_REF,
+        "intent": DRY_RUN_INTENT,
+        "stop_condition": stop_condition,
+        "stop_reason": stop_reason[:MAX_STOP_REASON_LEN],
+        "preconditions_evaluated": preconditions_evaluated,
+        "preconditions_passed": preconditions_passed,
+        "operator_actor": operator_actor,
+        "generated_at_utc": generated_at_utc,
+        "step5_implementation_allowed": step5_implementation_allowed,
+        "step5_enabled_substage": STEP5_ENABLED_SUBSTAGE,
+        "level6_enabled": False,
+        "dry_run_only": True,
+        "live_merge_implemented": False,
+        "deploy_coupled": False,
+        "discipline_invariants": dict(_DISCIPLINE_INVARIANTS),
+    }
+    assert set(snapshot.keys()) == set(FAILURE_SNAPSHOT_KEYS), (
+        f"failure snapshot key drift: {sorted(snapshot.keys())!r} vs "
+        f"{sorted(FAILURE_SNAPSHOT_KEYS)!r}"
+    )
+    return snapshot
+
+
+def write_failure(
+    *,
+    cycle_id: str,
+    pr_number: int,
+    pr_head_sha: str,
+    stop_condition: str,
+    stop_reason: str,
+    preconditions_evaluated: int,
+    preconditions_passed: int,
+    operator_actor: str,
+    generated_at_utc: str,
+    target_path: Path | None = None,
+) -> Path:
+    """Build + persist the closed-schema failure artefact.
+
+    Writes to ``FAILURE_DIR / f"{cycle_id}.json"`` by default.
+    ``target_path`` is exposed for unit-test isolation; even the
+    test path must contain :data:`WRITE_PREFIX` or the sentinel
+    guard raises ``ValueError``.
+
+    The dry-run-decision artefact and the dry-run history artefact
+    are NOT written by this function. Those writers remain
+    reserved for B2.8e per the implementation plan §2.6.
+    """
+    snapshot = build_failure_snapshot(
+        cycle_id=cycle_id,
+        pr_number=pr_number,
+        pr_head_sha=pr_head_sha,
+        stop_condition=stop_condition,
+        stop_reason=stop_reason,
+        preconditions_evaluated=preconditions_evaluated,
+        preconditions_passed=preconditions_passed,
+        operator_actor=operator_actor,
+        generated_at_utc=generated_at_utc,
+    )
+    target = (
+        target_path if target_path is not None else FAILURE_DIR / f"{cycle_id}.json"
+    )
+    _atomic_write_json(target, snapshot)
+    return target
+
+
 __all__ = [
+    "B2_8D_STOP_CONDITIONS",
     "DRY_RUN_INTENT",
+    "FAILURE_DIR",
+    "FAILURE_DIR_RELATIVE",
+    "FAILURE_REPORT_KIND",
+    "FAILURE_SNAPSHOT_KEYS",
+    "MAX_STOP_REASON_LEN",
     "MODULE_VERSION",
     "OPERATOR_ACTORS",
     "PREFLIGHT_DIR",
@@ -336,7 +571,9 @@ __all__ = [
     "SCHEMA_VERSION",
     "STEP5_ENABLED_SUBSTAGE",
     "WRITE_PREFIX",
+    "build_failure_snapshot",
     "build_preflight_snapshot",
     "step5_implementation_allowed",
+    "write_failure",
     "write_preflight",
 ]

--- a/tests/unit/test_api_merge_execution_dry_run.py
+++ b/tests/unit/test_api_merge_execution_dry_run.py
@@ -76,8 +76,172 @@ def _isolate_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     from reporting import n5b_merge_execution_dry_run as projector
 
     monkeypatch.setattr(projector, "PREFLIGHT_LATEST", preflight_target)
+
+    # Re-bind the projector's FAILURE_DIR to tmp_path so the walker
+    # writes B2.8d failure artefacts into the test sandbox.
+    failure_dir = (
+        tmp_path / "logs" / "n5b_merge_execution" / "failure"
+    )
+    failure_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(projector, "FAILURE_DIR", failure_dir)
+
+    # Re-bind the walker's three upstream-artefact paths to tmp_path
+    # so tests can inject synthetic N5a / A22 / github_pr_lifecycle
+    # artefacts to exercise the B2.8d walker.
+    for attr, rel in (
+        ("_N5A_ARTIFACT_PATH",
+         "logs/development_merge_recommendation/latest.json"),
+        ("_A22_ARTIFACT_PATH",
+         "logs/development_pr_lifecycle_observer/latest.json"),
+        ("_GITHUB_PR_LIFECYCLE_ARTIFACT_PATH",
+         "logs/github_pr_lifecycle/latest.json"),
+    ):
+        target = tmp_path / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setattr(mod, attr, target)
+
     monkeypatch.delenv(atr.ENV_APPROVAL_TOKEN_HMAC_SECRET, raising=False)
     yield preflight_target
+
+
+# ---------------------------------------------------------------------------
+# Synthetic upstream-artefact helpers for B2.8d walker exercises
+# ---------------------------------------------------------------------------
+
+
+def _write_synthetic_n5a(
+    *,
+    pr_number: int,
+    head_sha: str,
+    action: str = "recommend_human_merge",
+    reason: str = "pr_clean_and_no_blocking_inbox",
+    inbox_critical_count: int = 0,
+    evaluated_at: str | None = None,
+) -> None:
+    """Write a synthetic N5a artefact at the tmp-redirected path."""
+    if evaluated_at is None:
+        from datetime import UTC, datetime
+
+        evaluated_at = (
+            datetime.now(UTC).replace(microsecond=0).isoformat().replace(
+                "+00:00", "Z"
+            )
+        )
+    payload = {
+        "rows": [
+            {
+                "recommendation_id": "rec_synth",
+                "pr_number": pr_number,
+                "head_sha": head_sha,
+                "head_ref": "feature/synth",
+                "base_ref": "main",
+                "observer_classification": "open",
+                "inbox_blocked_count": 0,
+                "inbox_critical_count": inbox_critical_count,
+                "inbox_needs_review_count": 0,
+                "recommendation_action": action,
+                "recommendation_reason": reason,
+                "evaluated_at": evaluated_at,
+            }
+        ]
+    }
+    mod._N5A_ARTIFACT_PATH.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _write_synthetic_a22(
+    *,
+    pr_number: int,
+    head_sha: str,
+    merge_state_status: str = "CLEAN",
+    checks_summary: str = "SUCCESS",
+    base_ref: str = "main",
+) -> None:
+    """Write a synthetic A22 artefact at the tmp-redirected path."""
+    payload = {
+        "rows": [
+            {
+                "pr_number": pr_number,
+                "title": "synth",
+                "head_ref": "feature/synth",
+                "head_sha": head_sha,
+                "base_ref": base_ref,
+                "state": "open",
+                "is_draft": False,
+                "merge_state_status": merge_state_status,
+                "mergeable": True,
+                "checks_summary": checks_summary,
+                "author_login": "synth-author",
+                "is_dependabot": False,
+                "observer_classification": "open",
+                "url": "https://example/pr",
+                "created_at": "2026-05-16T00:00:00Z",
+                "updated_at": "2026-05-16T00:00:00Z",
+            }
+        ]
+    }
+    mod._A22_ARTIFACT_PATH.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _write_synthetic_gh_pr_lifecycle(
+    *,
+    pr_number: int,
+    protected_paths_touched: bool = False,
+    no_touch_path_violation: bool = False,
+    deploy_coupling_detected: bool = False,
+    step5_flag_changed: bool = False,
+    level_6_attempted: bool = False,
+    branch_protection_satisfied: bool = True,
+) -> None:
+    """Write a synthetic github_pr_lifecycle artefact at the
+    tmp-redirected path. Includes the B2.8d extended optional fields
+    that production today does not yet emit — by design, until those
+    fields are added upstream the walker fails closed with
+    ``network_uncertain``."""
+    payload = {
+        "prs": [
+            {
+                "number": pr_number,
+                "title": "synth",
+                "branch": "feature/synth",
+                "base": "main",
+                "author": "synth-author",
+                "package": "synth",
+                "merge_state": "clean",
+                "checks_state": "passed",
+                "additions": 1,
+                "deletions": 0,
+                "files_count": 1,
+                "protected_paths_touched": protected_paths_touched,
+                "no_touch_path_violation": no_touch_path_violation,
+                "deploy_coupling_detected": deploy_coupling_detected,
+                "step5_flag_changed": step5_flag_changed,
+                "level_6_attempted": level_6_attempted,
+                "branch_protection_satisfied": branch_protection_satisfied,
+                "risk_class": "LOW",
+                "risk_reason": "synth",
+                "decision": "merge_allowed",
+                "reason": "synth",
+                "actions_taken": [],
+                "url": "https://example/pr",
+            }
+        ]
+    }
+    mod._GITHUB_PR_LIFECYCLE_ARTIFACT_PATH.write_text(
+        json.dumps(payload), encoding="utf-8"
+    )
+
+
+def _seed_all_clean_upstream_artefacts(
+    *,
+    pr_number: int = 123,
+    head_sha: str = "abc1234567890def1234567890abcdef12345678",
+) -> None:
+    """Write all three synthetic upstream artefacts in the
+    all-pass / all-clean configuration. Used by the happy-walker
+    test to drive preconditions 8–17 to success."""
+    _write_synthetic_n5a(pr_number=pr_number, head_sha=head_sha)
+    _write_synthetic_a22(pr_number=pr_number, head_sha=head_sha)
+    _write_synthetic_gh_pr_lifecycle(pr_number=pr_number)
 
 
 # ---------------------------------------------------------------------------
@@ -90,7 +254,7 @@ def test_module_imports_successfully() -> None:
 
 
 def test_module_version_is_pinned_string() -> None:
-    assert mod.MODULE_VERSION == "v3.15.16.N5b.phase2.walker_1_7"
+    assert mod.MODULE_VERSION == "v3.15.16.N5b.phase2.walker_1_17"
 
 
 def test_schema_version_is_pinned_integer_1() -> None:
@@ -752,12 +916,14 @@ def test_replay_detected_on_second_request_no_preflight_on_replay(
     _isolate_state: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """First request: all 7 pass → preflight artefact written →
-    not_yet_implemented. Second request with the same token:
-    replay_detected → rejected → preflight artefact NOT overwritten
-    by the rejected branch (we delete the artefact between the two
-    calls to make the negative-assertion strict)."""
+    """First request: all 1–7 pass + all 1–17 pass → preflight
+    artefact written → not_yet_implemented. Second request with
+    the same token: replay_detected → rejected → preflight
+    artefact NOT overwritten by the rejected branch (we delete
+    the artefact between the two calls to make the negative
+    assertion strict)."""
     token = _mint_dry_run_token(monkeypatch)
+    _seed_all_clean_upstream_artefacts()
     body = _body_with_token(token)
     app = _build_app()
     with app.test_client() as client:
@@ -782,11 +948,19 @@ def test_replay_detected_on_second_request_no_preflight_on_replay(
 # ---------------------------------------------------------------------------
 
 
-def test_happy_walker_returns_not_yet_implemented_with_preflight_written(
+def test_happy_walker_returns_not_yet_implemented_after_all_17_pass(
     _isolate_state: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """B2.8d happy path: all 17 preconditions pass.
+
+    Per the operator-approved deferral, B2.8d returns
+    ``not_yet_implemented`` with
+    ``preconditions_evaluated=17``, ``preconditions_passed=17``,
+    ``reason="b2_8e_implementation_pending"``. B2.8e flips the
+    literal to ``ok``."""
     token = _mint_dry_run_token(monkeypatch)
+    _seed_all_clean_upstream_artefacts()
     body = _body_with_token(token)
     app = _build_app()
     with app.test_client() as client:
@@ -795,9 +969,9 @@ def test_happy_walker_returns_not_yet_implemented_with_preflight_written(
     assert payload["status"] == "not_yet_implemented"
     assert payload["stop_condition"] is None
     assert payload["would_proceed"] is False
-    assert payload["preconditions_evaluated"] == 7
-    assert payload["preconditions_passed"] == 7
-    assert payload["reason"] == "preconditions_8_through_17_pending"
+    assert payload["preconditions_evaluated"] == 17
+    assert payload["preconditions_passed"] == 17
+    assert payload["reason"] == "b2_8e_implementation_pending"
     assert payload["pr_number"] == 123
     assert payload["pr_head_sha"] == "abc1234567890def1234567890abcdef12345678"
     # Preflight artefact exists with the closed schema.
@@ -817,6 +991,7 @@ def test_preflight_artefact_carries_kid_and_nonce_hash_only(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     token = _mint_dry_run_token(monkeypatch)
+    _seed_all_clean_upstream_artefacts()
     body = _body_with_token(token)
     app = _build_app()
     with app.test_client() as client:
@@ -832,14 +1007,15 @@ def test_preflight_artefact_carries_kid_and_nonce_hash_only(
     assert "token" not in snapshot
 
 
-def test_b2_8c_never_emits_ok_status(
+def test_b2_8d_never_emits_ok_status(
     _isolate_state: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Pin: even on the fully-clean happy path, B2.8c emits
-    ``not_yet_implemented`` — never ``ok``. The ``ok`` status is
-    reserved for B2.8e when preconditions 8–17 also walk."""
+    """Pin: even on the fully-clean happy path (1–17 all pass),
+    B2.8d emits ``not_yet_implemented`` — never ``ok``. The ``ok``
+    status is deferred to B2.8e per operator preference."""
     token = _mint_dry_run_token(monkeypatch)
+    _seed_all_clean_upstream_artefacts()
     body = _body_with_token(token)
     app = _build_app()
     with app.test_client() as client:
@@ -857,10 +1033,14 @@ def test_preflight_write_failure_emits_rejected_500_no_new_stop_condition(
     _isolate_state: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Post-verification write failure: status=rejected, HTTP 500,
-    stop_condition=None, reason='preflight_write_failed'. No new
-    §7 stop-condition literal is introduced."""
+    """Post-verification preflight-write failure: status=rejected,
+    HTTP 500, stop_condition=None,
+    reason='preflight_write_failed'. No new §7 stop-condition
+    literal is introduced. This boundary is between B2.8c
+    verification + B2.8d walker."""
     token = _mint_dry_run_token(monkeypatch)
+    # Seed upstream so the walker would otherwise proceed past 1–7.
+    _seed_all_clean_upstream_artefacts()
     body = _body_with_token(token)
 
     from reporting import n5b_merge_execution_dry_run as projector
@@ -999,9 +1179,12 @@ def test_discipline_fields_dict_is_closed_six_set() -> None:
 
 
 def test_only_closed_stop_conditions_appear_in_translation_tables() -> None:
-    """The walker's translation tables must emit only §7 stop
-    conditions enumerated by the B2.8c implementation plan §6.2."""
-    allowed_in_b2_8c = {
+    """The B2.8c body / verify translation tables must emit only
+    the closed §7 vocabulary subset documented for §6.2 (B2.8c).
+    The B2.8d walker for preconditions 8–17 emits additional
+    closed §6.3 stops; those are NOT in the body/verify tables and
+    are pinned separately."""
+    allowed_in_b2_8c_tables = {
         "token_missing",
         "token_invalid",
         "replay_detected",
@@ -1015,19 +1198,557 @@ def test_only_closed_stop_conditions_appear_in_translation_tables() -> None:
         "pr_number_mismatch",
         "binding_mismatch",
     }
-    illegal = (body_stops | verify_stops) - allowed_in_b2_8c
+    illegal = (body_stops | verify_stops) - allowed_in_b2_8c_tables
     assert illegal == set(), (
-        f"walker emits stop_condition literals outside the B2.8c "
-        f"closed §7 vocabulary: {illegal!r}"
+        f"B2.8c translation tables emit stop_condition literals "
+        f"outside the §6.2 closed vocabulary: {illegal!r}"
     )
 
 
-def test_module_source_does_not_mention_b2_8d_or_later_stop_conditions() -> None:
-    """The closed §7 stop conditions reserved for B2.8d / B2.8e
-    must NOT appear as quoted literals in the B2.8c walker source.
-    This pins the scope boundary."""
+def test_walker_does_not_mention_b2_8e_or_later_stop_conditions() -> None:
+    """B2.8d walker source must NOT mention the §7 stop conditions
+    reserved for B2.8e and later phases. The B2.8d-permitted §6.3
+    vocabulary is documented in
+    ``reporting.n5b_merge_execution_dry_run.B2_8D_STOP_CONDITIONS``."""
     src = MODULE_PATH.read_text(encoding="utf-8")
     deferred = (
+        # §7 stops reserved for Phase 3+ / live execute paths.
+        "operator_confirmation_missing",
+        "live_execute_disabled",
+        "dry_run_required_first",
+    )
+    for literal in deferred:
+        assert literal not in src, (
+            f"B2.8d walker source mentions deferred stop_condition literal "
+            f"{literal!r}; that scope belongs to B2.8e or later phases"
+        )
+
+
+# ---------------------------------------------------------------------------
+# B2.8d walker — preconditions 8–17
+# ---------------------------------------------------------------------------
+
+
+def _failure_files(_isolate_state: Path) -> list[Path]:
+    """Return any failure artefacts written under the tmp failure
+    dir. The fixture redirected projector.FAILURE_DIR to
+    tmp_path/.../failure."""
+    failure_dir = _isolate_state.parent.parent / "failure"
+    if not failure_dir.is_dir():
+        return []
+    return sorted(failure_dir.glob("*.json"))
+
+
+def _exercise_walker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[int, dict[str, Any]]:
+    """Mint a valid token + run the walker against the currently
+    seeded upstream artefacts. Returns ``(status_code, payload)``."""
+    token = _mint_dry_run_token(monkeypatch)
+    body = _body_with_token(token)
+    app = _build_app()
+    with app.test_client() as client:
+        return _envelope_after(client, body)
+
+
+def test_walker_8_17_n5a_artifact_absent_emits_network_uncertain(
+    _isolate_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """N5a artefact missing → status=rejected,
+    stop_condition=network_uncertain. Preflight is written (after
+    1–7 pass), but the walker fails on the FIRST upstream read.
+    A failure artefact is written; no dry_run/latest.json."""
+    # Seed A22 + gh_pr_lifecycle, but NOT N5a.
+    _write_synthetic_a22(
+        pr_number=123,
+        head_sha="abc1234567890def1234567890abcdef12345678",
+    )
+    _write_synthetic_gh_pr_lifecycle(pr_number=123)
+    code, payload = _exercise_walker(monkeypatch)
+    assert code == 200
+    assert payload["status"] == "rejected"
+    assert payload["stop_condition"] == "network_uncertain"
+    assert payload["preconditions_evaluated"] == 7
+    # Preflight was written (after 1–7).
+    assert _isolate_state.is_file()
+    # One failure artefact written.
+    files = _failure_files(_isolate_state)
+    assert len(files) == 1
+    snapshot = json.loads(files[0].read_text(encoding="utf-8"))
+    assert snapshot["report_kind"] == "n5b_failure"
+    assert snapshot["stop_condition"] == "network_uncertain"
+
+
+def test_walker_8_17_a22_artifact_absent_emits_network_uncertain(
+    _isolate_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_synthetic_n5a(
+        pr_number=123,
+        head_sha="abc1234567890def1234567890abcdef12345678",
+    )
+    _write_synthetic_gh_pr_lifecycle(pr_number=123)
+    code, payload = _exercise_walker(monkeypatch)
+    assert code == 200
+    assert payload["status"] == "rejected"
+    assert payload["stop_condition"] == "network_uncertain"
+    assert len(_failure_files(_isolate_state)) == 1
+
+
+def test_walker_8_17_gh_artifact_absent_emits_network_uncertain(
+    _isolate_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_synthetic_n5a(
+        pr_number=123,
+        head_sha="abc1234567890def1234567890abcdef12345678",
+    )
+    _write_synthetic_a22(
+        pr_number=123,
+        head_sha="abc1234567890def1234567890abcdef12345678",
+    )
+    code, payload = _exercise_walker(monkeypatch)
+    assert code == 200
+    assert payload["status"] == "rejected"
+    assert payload["stop_condition"] == "network_uncertain"
+
+
+def test_walker_8_17_n5a_no_matching_row_emits_network_uncertain(
+    _isolate_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_synthetic_n5a(
+        pr_number=999,  # different PR
+        head_sha="abc1234567890def1234567890abcdef12345678",
+    )
+    _write_synthetic_a22(
+        pr_number=123,
+        head_sha="abc1234567890def1234567890abcdef12345678",
+    )
+    _write_synthetic_gh_pr_lifecycle(pr_number=123)
+    code, payload = _exercise_walker(monkeypatch)
+    assert code == 200
+    assert payload["status"] == "rejected"
+    assert payload["stop_condition"] == "network_uncertain"
+
+
+def test_walker_8_n5a_action_not_eligible_emits_stale_recommendation(
+    _isolate_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_all_clean_upstream_artefacts()
+    # Override N5a with non-eligible action.
+    _write_synthetic_n5a(
+        pr_number=123,
+        head_sha="abc1234567890def1234567890abcdef12345678",
+        action="recommend_hold",
+    )
+    code, payload = _exercise_walker(monkeypatch)
+    assert code == 200
+    assert payload["status"] == "rejected"
+    assert payload["stop_condition"] == "stale_recommendation"
+    assert payload["preconditions_evaluated"] == 8
+
+
+def test_walker_8_n5a_reason_not_eligible_emits_stale_recommendation(
+    _isolate_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_all_clean_upstream_artefacts()
+    _write_synthetic_n5a(
+        pr_number=123,
+        head_sha="abc1234567890def1234567890abcdef12345678",
+        reason="pr_clean_but_inbox_has_critical_attention",
+    )
+    code, payload = _exercise_walker(monkeypatch)
+    assert payload["stop_condition"] == "stale_recommendation"
+    assert payload["preconditions_evaluated"] == 8
+
+
+@pytest.mark.parametrize(
+    "merge_state",
+    ["DIRTY", "BLOCKED", "BEHIND", "UNSTABLE", "HAS_HOOKS", "UNKNOWN"],
+)
+def test_walker_9_non_clean_merge_state_emits_merge_state_not_clean(
+    _isolate_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    merge_state: str,
+) -> None:
+    """Per §6.3: adapter accepts ONLY ``CLEAN`` for mergeStateStatus."""
+    _seed_all_clean_upstream_artefacts()
+    _write_synthetic_a22(
+        pr_number=123,
+        head_sha="abc1234567890def1234567890abcdef12345678",
+        merge_state_status=merge_state,
+    )
+    code, payload = _exercise_walker(monkeypatch)
+    assert payload["status"] == "rejected"
+    assert payload["stop_condition"] == "merge_state_not_clean"
+    assert payload["preconditions_evaluated"] == 9
+
+
+def test_walker_9_clean_merge_state_accepted(
+    _isolate_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Per §6.3: ``CLEAN`` is the only accepted mergeStateStatus.
+    Companion to the negative parametrization above."""
+    _seed_all_clean_upstream_artefacts()
+    code, payload = _exercise_walker(monkeypatch)
+    assert payload["status"] == "not_yet_implemented"
+    assert payload["preconditions_passed"] == 17
+
+
+def test_walker_9_branch_protection_unsatisfied_emits_stop(
+    _isolate_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_all_clean_upstream_artefacts()
+    _write_synthetic_gh_pr_lifecycle(
+        pr_number=123,
+        branch_protection_satisfied=False,
+    )
+    code, payload = _exercise_walker(monkeypatch)
+    assert payload["status"] == "rejected"
+    assert payload["stop_condition"] == "branch_protection_not_satisfied"
+    assert payload["preconditions_evaluated"] == 9
+
+
+@pytest.mark.parametrize(
+    "checks_state",
+    ["FAILURE", "CANCELLED", "SKIPPED", "IN_PROGRESS", "NULL"],
+)
+def test_walker_10_non_success_checks_emit_checks_not_green(
+    _isolate_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    checks_state: str,
+) -> None:
+    """Per §6.3: adapter accepts only success-equivalents for required checks."""
+    _seed_all_clean_upstream_artefacts()
+    _write_synthetic_a22(
+        pr_number=123,
+        head_sha="abc1234567890def1234567890abcdef12345678",
+        checks_summary=checks_state,
+    )
+    code, payload = _exercise_walker(monkeypatch)
+    assert payload["status"] == "rejected"
+    assert payload["stop_condition"] == "checks_not_green"
+    assert payload["preconditions_evaluated"] == 10
+
+
+def test_walker_11_head_sha_mismatch_emits_head_sha_mismatch(
+    _isolate_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A22 head_sha differs from token-bound head_sha → head_sha_mismatch."""
+    _seed_all_clean_upstream_artefacts()
+    _write_synthetic_a22(
+        pr_number=123,
+        head_sha="cafe" * 10,  # different SHA
+    )
+    code, payload = _exercise_walker(monkeypatch)
+    assert payload["status"] == "rejected"
+    assert payload["stop_condition"] == "head_sha_mismatch"
+    assert payload["preconditions_evaluated"] == 11
+
+
+def test_walker_12_base_ref_not_main_emits_merge_state_not_clean(
+    _isolate_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """base_ref != main → operator-approved semantic stretch:
+    merge_state_not_clean."""
+    _seed_all_clean_upstream_artefacts()
+    _write_synthetic_a22(
+        pr_number=123,
+        head_sha="abc1234567890def1234567890abcdef12345678",
+        base_ref="develop",
+    )
+    code, payload = _exercise_walker(monkeypatch)
+    assert payload["status"] == "rejected"
+    assert payload["stop_condition"] == "merge_state_not_clean"
+    assert payload["preconditions_evaluated"] == 12
+
+
+def test_walker_13_stale_n5a_emits_stale_recommendation(
+    _isolate_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """N5a evaluated_at older than 60 minutes → stale_recommendation."""
+    from datetime import UTC, datetime, timedelta
+
+    old = (datetime.now(UTC) - timedelta(hours=2)).replace(
+        microsecond=0
+    ).isoformat().replace("+00:00", "Z")
+    _seed_all_clean_upstream_artefacts()
+    _write_synthetic_n5a(
+        pr_number=123,
+        head_sha="abc1234567890def1234567890abcdef12345678",
+        evaluated_at=old,
+    )
+    code, payload = _exercise_walker(monkeypatch)
+    assert payload["status"] == "rejected"
+    assert payload["stop_condition"] == "stale_recommendation"
+    assert payload["preconditions_evaluated"] == 13
+
+
+def test_walker_14_inbox_criticals_emits_stale_recommendation(
+    _isolate_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """N5a inbox_critical_count > 0 (with N5a still saying merge) →
+    operator-approved semantic stretch: stale_recommendation."""
+    _seed_all_clean_upstream_artefacts()
+    _write_synthetic_n5a(
+        pr_number=123,
+        head_sha="abc1234567890def1234567890abcdef12345678",
+        inbox_critical_count=2,
+    )
+    code, payload = _exercise_walker(monkeypatch)
+    assert payload["status"] == "rejected"
+    assert payload["stop_condition"] == "stale_recommendation"
+    assert payload["preconditions_evaluated"] == 14
+
+
+def test_walker_15_protected_paths_emits_unexpected_files_touched(
+    _isolate_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_all_clean_upstream_artefacts()
+    _write_synthetic_gh_pr_lifecycle(
+        pr_number=123,
+        protected_paths_touched=True,
+    )
+    code, payload = _exercise_walker(monkeypatch)
+    assert payload["status"] == "rejected"
+    assert payload["stop_condition"] == "unexpected_files_touched"
+    assert payload["preconditions_evaluated"] == 15
+
+
+def test_walker_15_no_touch_violation_emits_protected_path_violation(
+    _isolate_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_all_clean_upstream_artefacts()
+    _write_synthetic_gh_pr_lifecycle(
+        pr_number=123,
+        no_touch_path_violation=True,
+    )
+    code, payload = _exercise_walker(monkeypatch)
+    assert payload["status"] == "rejected"
+    assert payload["stop_condition"] == "protected_path_violation"
+    assert payload["preconditions_evaluated"] == 15
+
+
+def test_walker_15_deploy_coupling_emits_deploy_coupling_detected(
+    _isolate_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_all_clean_upstream_artefacts()
+    _write_synthetic_gh_pr_lifecycle(
+        pr_number=123,
+        deploy_coupling_detected=True,
+    )
+    code, payload = _exercise_walker(monkeypatch)
+    assert payload["status"] == "rejected"
+    assert payload["stop_condition"] == "deploy_coupling_detected"
+    assert payload["preconditions_evaluated"] == 15
+
+
+def test_walker_16_step5_change_emits_step5_flag_changed(
+    _isolate_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_all_clean_upstream_artefacts()
+    _write_synthetic_gh_pr_lifecycle(
+        pr_number=123,
+        step5_flag_changed=True,
+    )
+    code, payload = _exercise_walker(monkeypatch)
+    assert payload["status"] == "rejected"
+    assert payload["stop_condition"] == "step5_flag_changed"
+    assert payload["preconditions_evaluated"] == 16
+
+
+def test_walker_16_level_6_attempt_emits_level_6_attempted(
+    _isolate_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_all_clean_upstream_artefacts()
+    _write_synthetic_gh_pr_lifecycle(
+        pr_number=123,
+        level_6_attempted=True,
+    )
+    code, payload = _exercise_walker(monkeypatch)
+    assert payload["status"] == "rejected"
+    assert payload["stop_condition"] == "level_6_attempted"
+    assert payload["preconditions_evaluated"] == 16
+
+
+def test_walker_8_17_missing_optional_field_fails_closed_network_uncertain(
+    _isolate_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Critical operator-mandated pin: missing optional B2.8d
+    extended field (no silent auto-pass). When gh_pr_lifecycle row
+    lacks ``step5_flag_changed`` (and other B2.8d fields), walker
+    rejects with network_uncertain. This is what makes B2.8d
+    safe in production today, where these fields don't exist yet."""
+    _write_synthetic_n5a(
+        pr_number=123,
+        head_sha="abc1234567890def1234567890abcdef12345678",
+    )
+    _write_synthetic_a22(
+        pr_number=123,
+        head_sha="abc1234567890def1234567890abcdef12345678",
+    )
+    # gh_pr_lifecycle row without the B2.8d extended fields (mimics
+    # current production state).
+    bare_payload = {
+        "prs": [
+            {
+                "number": 123,
+                "title": "synth",
+                "branch": "feature/synth",
+                "base": "main",
+                "author": "synth-author",
+                "package": "synth",
+                "merge_state": "clean",
+                "checks_state": "passed",
+                "additions": 1,
+                "deletions": 0,
+                "files_count": 1,
+                # NO protected_paths_touched, NO step5_flag_changed, etc.
+                "risk_class": "LOW",
+                "risk_reason": "synth",
+                "decision": "merge_allowed",
+                "reason": "synth",
+                "actions_taken": [],
+                "url": "https://example/pr",
+            }
+        ]
+    }
+    mod._GITHUB_PR_LIFECYCLE_ARTIFACT_PATH.write_text(
+        json.dumps(bare_payload), encoding="utf-8"
+    )
+    code, payload = _exercise_walker(monkeypatch)
+    assert payload["status"] == "rejected"
+    assert payload["stop_condition"] == "network_uncertain"
+    # The walker rejects on the FIRST missing optional field.
+    # ``branch_protection_satisfied`` is checked inside precondition
+    # 9 (mergeStateStatus + branch protection block), so the walker
+    # stops at preconditions_evaluated=9 before even reaching the
+    # precondition-15 protected-paths fields.
+    assert payload["preconditions_evaluated"] == 9
+
+
+def test_walker_8_17_failure_write_failure_emits_audit_write_failure(
+    _isolate_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the failure-artefact write itself raises, the walker
+    emits ``audit_write_failure``, HTTP 500."""
+    _seed_all_clean_upstream_artefacts()
+    # Force a §7 stop in the walker (use stale_recommendation via
+    # non-eligible action).
+    _write_synthetic_n5a(
+        pr_number=123,
+        head_sha="abc1234567890def1234567890abcdef12345678",
+        action="recommend_hold",
+    )
+    from reporting import n5b_merge_execution_dry_run as projector
+
+    def _boom(**_kwargs: Any) -> Any:
+        raise OSError("simulated failure-artefact disk failure")
+
+    monkeypatch.setattr(projector, "write_failure", _boom)
+    code, payload = _exercise_walker(monkeypatch)
+    assert code == 500
+    assert payload["status"] == "rejected"
+    assert payload["stop_condition"] == "audit_write_failure"
+    assert payload["reason"] == "failure_artefact_write_failed"
+
+
+def test_walker_no_dry_run_latest_or_history_written_on_all_pass(
+    _isolate_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """B2.8d must NOT write dry_run/latest.json or history.jsonl.
+    Those writers remain B2.8e scope."""
+    _seed_all_clean_upstream_artefacts()
+    code, payload = _exercise_walker(monkeypatch)
+    assert payload["status"] == "not_yet_implemented"
+    # dry_run + history MUST NOT exist.
+    dry_run_dir = _isolate_state.parent.parent / "dry_run"
+    assert not dry_run_dir.exists() or not any(dry_run_dir.iterdir())
+
+
+def test_walker_failure_artefact_carries_closed_schema(
+    _isolate_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify the failure artefact closed schema includes pinned
+    fields and excludes raw token / nonce."""
+    from reporting import n5b_merge_execution_dry_run as projector
+
+    _seed_all_clean_upstream_artefacts()
+    _write_synthetic_a22(
+        pr_number=123,
+        head_sha="abc1234567890def1234567890abcdef12345678",
+        merge_state_status="BLOCKED",
+    )
+    token = _mint_dry_run_token(monkeypatch)
+    body = _body_with_token(token)
+    app = _build_app()
+    with app.test_client() as client:
+        _envelope_after(client, body)
+    files = _failure_files(_isolate_state)
+    assert len(files) == 1
+    snapshot = json.loads(files[0].read_text(encoding="utf-8"))
+    assert set(snapshot.keys()) == set(projector.FAILURE_SNAPSHOT_KEYS)
+    assert snapshot["stop_condition"] == "merge_state_not_clean"
+    assert snapshot["report_kind"] == "n5b_failure"
+    # No raw token / nonce / secret in failure artefact.
+    blob = json.dumps(snapshot, default=str)
+    assert token not in blob
+
+
+# ---------------------------------------------------------------------------
+# B2.8d source-text guards
+# ---------------------------------------------------------------------------
+
+
+def test_walker_does_not_import_github_pr_lifecycle_module() -> None:
+    """The github_pr_lifecycle module legitimately uses subprocess
+    to call ``gh``. The walker reads its on-disk artefact instead
+    and MUST NOT import it directly."""
+    imported = set(_module_imports())
+    forbidden = (
+        "reporting.github_pr_lifecycle",
+    )
+    for name in forbidden:
+        assert name not in imported, (
+            f"walker imports {name!r}; it must read its on-disk "
+            "artefact instead"
+        )
+
+
+def test_walker_emits_only_closed_b2_8d_stop_vocab() -> None:
+    """Every literal the B2.8d walker passes to ``write_failure`` or
+    sets on the envelope's ``stop_condition`` field must come from
+    ``projector.B2_8D_STOP_CONDITIONS``. Source-text scan finds
+    the literals used in the walker and asserts none are outside
+    the closed list (modulo the deferred literals pinned above)."""
+    from reporting import n5b_merge_execution_dry_run as projector
+
+    src = MODULE_PATH.read_text(encoding="utf-8")
+    # Closed list of §6.3 stops B2.8d may emit.
+    closed = set(projector.B2_8D_STOP_CONDITIONS)
+    # Any literal the walker quotes that LOOKS like a stop must be
+    # in the closed list. We scan only inside the walker body for
+    # quoted strings that map to §7 vocabulary.
+    candidates = [
         "head_sha_mismatch",
         "merge_state_not_clean",
         "checks_not_green",
@@ -1040,12 +1761,11 @@ def test_module_source_does_not_mention_b2_8d_or_later_stop_conditions() -> None
         "stale_recommendation",
         "network_uncertain",
         "audit_write_failure",
-        "operator_confirmation_missing",
-        "live_execute_disabled",
-        "dry_run_required_first",
-    )
-    for literal in deferred:
-        assert literal not in src, (
-            f"walker source mentions deferred stop_condition literal "
-            f"{literal!r}; that scope belongs to B2.8d / B2.8e"
-        )
+    ]
+    for literal in candidates:
+        if f'"{literal}"' in src:
+            assert literal in closed, (
+                f"walker source uses stop_condition literal "
+                f"{literal!r} but it's outside the closed "
+                f"B2.8d vocabulary {sorted(closed)!r}"
+            )

--- a/tests/unit/test_n5b_merge_execution_dry_run.py
+++ b/tests/unit/test_n5b_merge_execution_dry_run.py
@@ -40,7 +40,7 @@ def test_module_imports_successfully() -> None:
 
 
 def test_module_version_is_pinned_string() -> None:
-    assert projector.MODULE_VERSION == "v3.15.16.N5b.phase2.projector"
+    assert projector.MODULE_VERSION == "v3.15.16.N5b.phase2.projector_with_failure"
 
 
 def test_schema_version_is_pinned_integer_1() -> None:
@@ -107,7 +107,13 @@ def test_preflight_snapshot_keys_closed_set() -> None:
 
 def test_all_exports_are_closed() -> None:
     assert set(projector.__all__) == {
+        "B2_8D_STOP_CONDITIONS",
         "DRY_RUN_INTENT",
+        "FAILURE_DIR",
+        "FAILURE_DIR_RELATIVE",
+        "FAILURE_REPORT_KIND",
+        "FAILURE_SNAPSHOT_KEYS",
+        "MAX_STOP_REASON_LEN",
         "MODULE_VERSION",
         "OPERATOR_ACTORS",
         "PREFLIGHT_DIR",
@@ -119,8 +125,10 @@ def test_all_exports_are_closed() -> None:
         "SCHEMA_VERSION",
         "STEP5_ENABLED_SUBSTAGE",
         "WRITE_PREFIX",
+        "build_failure_snapshot",
         "build_preflight_snapshot",
         "step5_implementation_allowed",
+        "write_failure",
         "write_preflight",
     }
 
@@ -270,7 +278,7 @@ def test_build_snapshot_happy_path_returns_closed_schema() -> None:
     assert snap["intent"] == "mobile_approval_dispatch"
     assert snap["schema_version"] == 1
     assert snap["report_kind"] == "n5b_preflight"
-    assert snap["module_version"] == "v3.15.16.N5b.phase2.projector"
+    assert snap["module_version"] == "v3.15.16.N5b.phase2.projector_with_failure"
 
 
 def test_build_snapshot_discipline_invariants_dict_present() -> None:
@@ -414,31 +422,274 @@ def test_write_preflight_runs_assert_no_secrets_before_write(
 
 
 def test_projector_exposes_no_dry_run_decision_writer() -> None:
+    """B2.8d adds ``write_failure`` only. Dry-run-decision /
+    history / execution writers remain reserved for B2.8e per the
+    implementation plan §2.6."""
     for forbidden in (
         "write_dry_run",
         "write_dry_run_latest",
         "write_decision",
-        "write_failure",
         "write_history",
         "write_execution",
     ):
         assert not hasattr(projector, forbidden), (
-            f"B2.8c projector must not expose {forbidden!r}; "
-            "decision/failure/history writers are B2.8d / B2.8e scope"
+            f"B2.8d projector must not expose {forbidden!r}; "
+            "decision/history/execution writers are B2.8e scope"
         )
 
 
-def test_projector_relative_path_only_preflight() -> None:
-    """The projector exposes exactly the preflight relative path. No
-    dry_run / failure / history / decision constants in B2.8c."""
+def test_projector_relative_path_no_decision_or_history() -> None:
+    """B2.8d adds the FAILURE_DIR_RELATIVE constant. The dry_run /
+    decision / execution path constants remain reserved for B2.8e."""
     for forbidden in (
         "DRY_RUN_LATEST_RELATIVE",
         "DRY_RUN_HISTORY_RELATIVE",
-        "FAILURE_DIR_RELATIVE",
         "DECISION_LATEST_RELATIVE",
         "EXECUTION_LATEST_RELATIVE",
     ):
         assert not hasattr(projector, forbidden), (
-            f"B2.8c projector must not expose {forbidden!r}; only "
-            "preflight artefact paths are in scope"
+            f"B2.8d projector must not expose {forbidden!r}; only "
+            "preflight + failure artefact paths are in scope"
         )
+
+
+# ---------------------------------------------------------------------------
+# B2.8d additions — failure artefact closed schema + write_failure
+# ---------------------------------------------------------------------------
+
+
+def test_failure_report_kind_pinned() -> None:
+    assert projector.FAILURE_REPORT_KIND == "n5b_failure"
+
+
+def test_failure_dir_relative_pinned() -> None:
+    assert projector.FAILURE_DIR_RELATIVE == "logs/n5b_merge_execution/failure/"
+
+
+def test_failure_snapshot_keys_closed_set() -> None:
+    assert set(projector.FAILURE_SNAPSHOT_KEYS) == {
+        "schema_version",
+        "report_kind",
+        "module_version",
+        "cycle_id",
+        "pr_number",
+        "pr_head_sha",
+        "pr_base_ref",
+        "intent",
+        "stop_condition",
+        "stop_reason",
+        "preconditions_evaluated",
+        "preconditions_passed",
+        "operator_actor",
+        "generated_at_utc",
+        "step5_implementation_allowed",
+        "step5_enabled_substage",
+        "level6_enabled",
+        "dry_run_only",
+        "live_merge_implemented",
+        "deploy_coupled",
+        "discipline_invariants",
+    }
+
+
+def test_b2_8d_stop_conditions_closed_vocab() -> None:
+    """The B2.8d stop-condition closed list. Adding a literal here
+    requires a paired doc update (governance §6.3) AND an updated
+    pin in the same PR."""
+    assert set(projector.B2_8D_STOP_CONDITIONS) == {
+        "token_missing",
+        "token_invalid",
+        "replay_detected",
+        "binding_mismatch",
+        "pr_number_mismatch",
+        "head_sha_mismatch",
+        "merge_state_not_clean",
+        "checks_not_green",
+        "branch_protection_not_satisfied",
+        "unexpected_files_touched",
+        "deploy_coupling_detected",
+        "step5_flag_changed",
+        "level_6_attempted",
+        "protected_path_violation",
+        "stale_recommendation",
+        "network_uncertain",
+        "audit_write_failure",
+    }
+
+
+def test_max_stop_reason_len_pinned() -> None:
+    assert projector.MAX_STOP_REASON_LEN == 200
+
+
+def _good_failure_kwargs() -> dict[str, Any]:
+    return {
+        "cycle_id": "pr123_20260516T093417Z",
+        "pr_number": 123,
+        "pr_head_sha": "deadbeef" * 5,
+        "stop_condition": "merge_state_not_clean",
+        "stop_reason": "A22 merge_state_status = BLOCKED",
+        "preconditions_evaluated": 9,
+        "preconditions_passed": 8,
+        "operator_actor": "session",
+        "generated_at_utc": "2026-05-16T09:34:17Z",
+    }
+
+
+def test_build_failure_snapshot_happy_path() -> None:
+    snap = projector.build_failure_snapshot(**_good_failure_kwargs())
+    assert set(snap.keys()) == set(projector.FAILURE_SNAPSHOT_KEYS)
+    assert snap["report_kind"] == "n5b_failure"
+    assert snap["cycle_id"] == "pr123_20260516T093417Z"
+    assert snap["stop_condition"] == "merge_state_not_clean"
+    assert snap["preconditions_evaluated"] == 9
+    assert snap["preconditions_passed"] == 8
+    # Discipline invariants mirrored.
+    assert snap["step5_implementation_allowed"] is False
+    assert snap["step5_enabled_substage"] == "none"
+    assert snap["level6_enabled"] is False
+    assert snap["dry_run_only"] is True
+    assert snap["live_merge_implemented"] is False
+    assert snap["deploy_coupled"] is False
+    assert snap["pr_base_ref"] == "main"
+    assert snap["intent"] == "mobile_approval_dispatch"
+
+
+def test_build_failure_snapshot_truncates_stop_reason() -> None:
+    kwargs = _good_failure_kwargs()
+    kwargs["stop_reason"] = "x" * 500
+    snap = projector.build_failure_snapshot(**kwargs)
+    assert len(snap["stop_reason"]) == projector.MAX_STOP_REASON_LEN
+
+
+def test_build_failure_snapshot_rejects_unknown_stop_condition() -> None:
+    kwargs = _good_failure_kwargs()
+    kwargs["stop_condition"] = "not_a_real_stop_condition"
+    with pytest.raises(ValueError):
+        projector.build_failure_snapshot(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "field,bad_value,exc",
+    [
+        ("cycle_id", "", ValueError),
+        ("cycle_id", "with space", ValueError),
+        ("cycle_id", "with/slash", ValueError),
+        ("cycle_id", "with.dot", ValueError),
+        ("cycle_id", "x" * 200, ValueError),
+        ("pr_number", "123", TypeError),
+        ("pr_number", True, TypeError),
+        ("pr_number", 0, ValueError),
+        ("pr_head_sha", "", ValueError),
+        ("pr_head_sha", "x" * 65, ValueError),
+        ("preconditions_evaluated", "9", TypeError),
+        ("preconditions_evaluated", True, TypeError),
+        ("preconditions_evaluated", -1, ValueError),
+        ("preconditions_passed", -1, ValueError),
+        ("operator_actor", "bogus", ValueError),
+        ("generated_at_utc", "", ValueError),
+    ],
+)
+def test_build_failure_snapshot_rejects_bad_inputs(
+    field: str, bad_value: Any, exc: type[BaseException]
+) -> None:
+    kwargs = _good_failure_kwargs()
+    kwargs[field] = bad_value
+    with pytest.raises(exc):
+        projector.build_failure_snapshot(**kwargs)
+
+
+def test_build_failure_snapshot_rejects_passed_gt_evaluated() -> None:
+    kwargs = _good_failure_kwargs()
+    kwargs["preconditions_passed"] = 10
+    kwargs["preconditions_evaluated"] = 5
+    with pytest.raises(ValueError):
+        projector.build_failure_snapshot(**kwargs)
+
+
+def _tmp_failure_path(tmp_path: Path, cycle_id: str) -> Path:
+    target = (
+        tmp_path
+        / "logs"
+        / "n5b_merge_execution"
+        / "failure"
+        / f"{cycle_id}.json"
+    )
+    target.parent.mkdir(parents=True, exist_ok=True)
+    return target
+
+
+def test_write_failure_writes_closed_schema_to_target(tmp_path: Path) -> None:
+    kwargs = _good_failure_kwargs()
+    target = _tmp_failure_path(tmp_path, kwargs["cycle_id"])
+    out = projector.write_failure(target_path=target, **kwargs)
+    assert out == target
+    assert target.is_file()
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    assert set(payload.keys()) == set(projector.FAILURE_SNAPSHOT_KEYS)
+    assert payload["stop_condition"] == "merge_state_not_clean"
+    assert payload["cycle_id"] == "pr123_20260516T093417Z"
+
+
+def test_write_failure_refuses_non_sentinel_path(tmp_path: Path) -> None:
+    """The sentinel guard refuses any path that does NOT contain
+    ``logs/n5b_merge_execution/``."""
+    kwargs = _good_failure_kwargs()
+    bogus = tmp_path / "logs" / "elsewhere" / f"{kwargs['cycle_id']}.json"
+    bogus.parent.mkdir(parents=True, exist_ok=True)
+    with pytest.raises(ValueError):
+        projector.write_failure(target_path=bogus, **kwargs)
+    assert not bogus.is_file()
+
+
+def test_write_failure_atomic_no_tmp_residue(tmp_path: Path) -> None:
+    kwargs = _good_failure_kwargs()
+    target = _tmp_failure_path(tmp_path, kwargs["cycle_id"])
+    projector.write_failure(target_path=target, **kwargs)
+    leftovers = [
+        p
+        for p in target.parent.iterdir()
+        if p.name.startswith(".n5b_merge_execution_dry_run.")
+    ]
+    assert leftovers == []
+
+
+def test_write_failure_runs_assert_no_secrets_before_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If ``assert_no_secrets`` raises, NO failure file is created."""
+    kwargs = _good_failure_kwargs()
+    target = _tmp_failure_path(tmp_path, kwargs["cycle_id"])
+
+    def _boom(_payload: dict[str, Any]) -> None:
+        raise AssertionError("simulated credential leak")
+
+    monkeypatch.setattr(projector, "assert_no_secrets", _boom)
+    with pytest.raises(AssertionError):
+        projector.write_failure(target_path=target, **kwargs)
+    assert not target.is_file()
+
+
+@pytest.mark.parametrize(
+    "stop_condition",
+    sorted({
+        "token_missing", "token_invalid", "replay_detected",
+        "binding_mismatch", "pr_number_mismatch",
+        "head_sha_mismatch", "merge_state_not_clean", "checks_not_green",
+        "branch_protection_not_satisfied", "unexpected_files_touched",
+        "deploy_coupling_detected", "step5_flag_changed",
+        "level_6_attempted", "protected_path_violation",
+        "stale_recommendation", "network_uncertain", "audit_write_failure",
+    }),
+)
+def test_write_failure_accepts_each_closed_stop(
+    stop_condition: str, tmp_path: Path
+) -> None:
+    """Every closed §6.3 / B2.8c stop must be writable as a
+    failure artefact."""
+    kwargs = _good_failure_kwargs()
+    kwargs["stop_condition"] = stop_condition
+    kwargs["cycle_id"] = f"pr1_{stop_condition[:20]}"
+    target = _tmp_failure_path(tmp_path, kwargs["cycle_id"])
+    projector.write_failure(target_path=target, **kwargs)
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    assert payload["stop_condition"] == stop_condition

--- a/tests/unit/test_n5b_phase2_precondition_readiness.py
+++ b/tests/unit/test_n5b_phase2_precondition_readiness.py
@@ -490,14 +490,16 @@ def test_parent_plan_has_backpointer_to_readiness_report() -> None:
 #:
 #: * ``v3.15.16.N5b.phase2.skeleton`` — B2.8b (initial UNWIRED skeleton)
 #: * ``v3.15.16.N5b.phase2.walker_1_7`` — B2.8c (walker for §3 preconditions 1–7)
+#: * ``v3.15.16.N5b.phase2.walker_1_17`` — B2.8d (walker for §3 preconditions 1–17)
 #:
-#: Subsequent sub-units (B2.8d / B2.8e) may extend this allowlist
-#: by appending one further operator-approved literal per PR. They
+#: Subsequent sub-units (B2.8e) may extend this allowlist by
+#: appending one further operator-approved literal per PR. They
 #: must never remove a previously-pinned literal or widen the
 #: per-PR exactly-one-match assertion.
 _ALLOWED_SKELETON_MODULE_VERSION_LITERALS: tuple[str, ...] = (
     'MODULE_VERSION: Final[str] = "v3.15.16.N5b.phase2.skeleton"',
     'MODULE_VERSION: Final[str] = "v3.15.16.N5b.phase2.walker_1_7"',
+    'MODULE_VERSION: Final[str] = "v3.15.16.N5b.phase2.walker_1_17"',
 )
 
 


### PR DESCRIPTION
## Summary

**THIS IS NOT A PHASE 2 ACTIVATION.** The blueprint remains UNWIRED in `dashboard/dashboard.py`. The two-line wiring patch is operator-only (B2.8e scope) per `docs/governance/execution_authority.md` and `.claude/hooks/deny_no_touch.py`.

B2.8d layers the precondition walker for parent-doc §3 preconditions 8–17 onto the B2.8c walker for 1–7. The endpoint now walks all 17 preconditions but per operator-approved deferral **does NOT emit `status=ok`** — the walker returns `status=not_yet_implemented` with `reason="b2_8e_implementation_pending"` on the all-pass happy path. B2.8e will flip the literal and add the dry-run/decision/history writers + wiring patch + doc updates.

### What lands in this PR (exact 5-file diff)

**Runtime (2):**
- `dashboard/api_merge_execution_dry_run.py` — walker for §3 preconditions 8–17. Reads three pre-existing on-disk artefacts (`logs/development_merge_recommendation/latest.json`, `logs/development_pr_lifecycle_observer/latest.json`, `logs/github_pr_lifecycle/latest.json`) read-only. `MODULE_VERSION` bumped to `v3.15.16.N5b.phase2.walker_1_17`. Stays UNWIRED in `dashboard/dashboard.py`.
- `reporting/n5b_merge_execution_dry_run.py` — adds `write_failure(cycle_id, ...)` + closed `n5b_failure` schema + `B2_8D_STOP_CONDITIONS` closed vocab + `FAILURE_DIR` constant. `MODULE_VERSION` bumped to `v3.15.16.N5b.phase2.projector_with_failure`. Sentinel guard unchanged. No `dry_run/latest.json` or `history.jsonl` writer (deferred to B2.8e).

**Tests (3):**
- `tests/unit/test_api_merge_execution_dry_run.py` — +34 tests for walker 8–17 (every §6.3 stop reproduced deterministically; canonical `mergeStateStatus` + check-conclusion parametrizations; happy-walker happy path; preflight-write-failure boundary; failure-write-failure → `audit_write_failure`).
- `tests/unit/test_n5b_merge_execution_dry_run.py` — +46 tests for `write_failure()` + closed failure schema + sentinel-restricted writes + `assert_no_secrets` enforcement + per-stop-condition parametrization.
- `tests/unit/test_n5b_phase2_precondition_readiness.py` — appends `v3.15.16.N5b.phase2.walker_1_17` to the closed skeleton MODULE_VERSION allowlist (one-version-at-a-time pattern from B2.8b/B2.8c).

### Walker stop-condition coverage (closed §6.3 vocabulary, all reproduced deterministically)
- `stale_recommendation` (preconditions 8, 13, 14 — operator-approved semantic stretch covering literal staleness, N5a-action-not-eligible, inbox-criticals-inconsistency)
- `merge_state_not_clean` (preconditions 9, 12 — operator-approved semantic stretch covering mergeStateStatus≠CLEAN and base_ref≠main)
- `branch_protection_not_satisfied` (precondition 9 sub-check)
- `checks_not_green` (precondition 10)
- `head_sha_mismatch` (precondition 11)
- `unexpected_files_touched` (precondition 15)
- `protected_path_violation` (precondition 15 sub-check)
- `deploy_coupling_detected` (precondition 15 sub-check)
- `step5_flag_changed` (precondition 16)
- `level_6_attempted` (precondition 16)
- `network_uncertain` (any artefact / field missing or malformed)
- `audit_write_failure` (failure-artefact write itself raises)

### Hard guarantees pinned by tests
- **No GitHub API call**, no `gh`/`git`/`subprocess`/`socket`/`urllib`/`requests`/`httpx`/`aiohttp` imports. The walker does NOT import `reporting.github_pr_lifecycle` (that module uses `subprocess`); it reads the on-disk artefact instead.
- No `--admin`, no `--no-verify`, no force push, no merge-PR attribute literals.
- Dashboard module reads no env var directly; only `approval_token_runtime` does.
- **Raw token and raw nonce never persisted.** Preflight carries `token_kid` + sha256 `nonce_hash` only. Failure artefact carries no token / nonce material at all.
- Preflight write only after 1–7 pass (unchanged from B2.8c). Failure artefact only on §7 stop after 7 pass.
- **No `dry_run/latest.json` or `history.jsonl` writers in B2.8d** (pinned absent; deferred to B2.8e).
- **B2.8d never emits `status=ok`** (pinned).
- **Only precondition 17 auto-passes** (dry-run has no execution boundary). All other preconditions fail closed with `network_uncertain` when their upstream signal is missing or malformed — per operator's explicit "no silent auto-pass for missing optional fields" directive.
- Blueprint stays **UNWIRED** in `dashboard/dashboard.py`.
- `step5_implementation_allowed: Final[False]`, `STEP5_ENABLED_SUBSTAGE: Final["none"]`, **Level 6 permanently disabled** per ADR-015 §Doctrine 1.
- No new stop_condition literal introduced; closed §6.3 vocabulary is the source of truth.

### Files explicitly NOT touched
`dashboard/dashboard.py`, `.claude/**`, `.github/**`, `tests/regression/**`, no-touch paths, frozen schemas, `live/**`, `paper/**`, `shadow/**`, `risk/**`, `broker/**`, `execution/**`, `research/**`, `frontend/**`, `automation/**`, `agent/**`, `scripts/**`, all `docs/**`.

### Local test gates
- Targeted B2.8d suite (8 files): **455 passed** in 6.58s
- `tests/smoke/`: **18 passed** in 10.89s
- `python scripts/governance_lint.py`: **OK**
- `python scripts/push_body_safety_lint.py`: **OK**
- Full `tests/unit/`: **6084 passed, 3 skipped, 2 failed**

### Note on the 2 full-suite failures (operator-acknowledged before commit)

- `tests/unit/test_approval_token_runtime.py::test_seen_nonce_store_bounded_to_max`
- `tests/unit/test_development_step5_loop.py::test_history_truncates_to_max_history_entries`

Both PASS in isolation, PASS when run together (123 passed), PASS in a 3-file combination including the new B2.8d walker tests (225 passed). Both are pre-existing bounded-store / history-truncation tests vulnerable to cross-suite state contamination. The B2.8d module code does not directly touch the seen-nonce path or step5_loop history outside fixture-redirected tmp_path. Per operator decision (option 1), proceeding with PR — if CI reproduces the same 2 failures, the operator instructed to stop and report rather than broaden scope.

## Test plan

- [ ] CI Fast pre-merge gate passes
- [ ] Static analysis (mypy/flake8/bandit) clean
- [ ] Governance + push-body-safety lints clean
- [ ] Diff scope on PR still exactly the 5 approved files
- [ ] Squash-merge after green CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)