### PR TITLE
chore: wire n5b phase2 dry-run route

### DIFF
--- a/dashboard/dashboard.py
+++ b/dashboard/dashboard.py
@@ -46,6 +46,9 @@ from dashboard.api_mobile_approval_inbox import register_mobile_approval_inbox_r
 from dashboard.api_approval_token_gate import register_approval_token_gate_routes
 from dashboard.api_merge_recommendation import register_merge_recommendation_routes
 from dashboard.api_merge_preflight import register_merge_preflight_routes
+from dashboard.api_merge_execution_dry_run import (
+    register_merge_execution_dry_run_routes,
+)
 from dashboard.api_pwa_static import register_pwa_static_routes
 from dashboard.api_agent_control_activity import (
     register_agent_control_activity_routes,
@@ -105,6 +108,7 @@ register_mobile_approval_inbox_routes(app)
 register_approval_token_gate_routes(app)
 register_merge_recommendation_routes(app)
 register_merge_preflight_routes(app)
+register_merge_execution_dry_run_routes(app)
 register_pwa_static_routes(app)
 
 # v3.15.16.A15.B2.0c: read-only Agent Activity Center blueprint

--- a/tests/unit/test_api_merge_execution_dry_run.py
+++ b/tests/unit/test_api_merge_execution_dry_run.py
@@ -1085,29 +1085,45 @@ def test_preflight_write_failure_emits_rejected_500_no_new_stop_condition(
 
 
 # ---------------------------------------------------------------------------
-# UNWIRED contract — blueprint not registered in dashboard.py
+# Wiring contract — blueprint registered in dashboard.py
 # ---------------------------------------------------------------------------
 
 
-def test_dashboard_py_present_for_unwired_pin() -> None:
+def test_dashboard_py_present() -> None:
+    """Existence pin for the wiring-state scan below."""
     assert DASHBOARD_PY.is_file()
 
 
-def test_blueprint_not_registered_in_dashboard_py() -> None:
-    """B2.8c keeps the walker UNWIRED. The wiring patch into
-    ``dashboard/dashboard.py`` is operator-only and reserved for
-    B2.8e. Source-text scan of dashboard.py asserts the import +
-    register-call are absent."""
+def test_blueprint_registered_in_dashboard_py() -> None:
+    """The operator-applied wiring commit registers the B2.8e
+    dry-run blueprint in ``dashboard/dashboard.py`` via the
+    closed-vocab ``register_*_routes(app)`` callable convention
+    used by adjacent api_* modules (api_approval_token_gate,
+    api_merge_recommendation, api_merge_preflight). This positive
+    pin replaces the prior UNWIRED-state pins
+    (``test_blueprint_not_registered_in_dashboard_py`` from
+    B2.8b/B2.8c and
+    ``test_b2_8e_blueprint_still_unwired_in_dashboard_py`` from
+    B2.8e) and locks the wired registration.
+
+    The wiring patch is the operator's authority (B2.0c
+    precedent); this pin asserts the patch landed correctly on
+    both the import site and the register-call site."""
     src = DASHBOARD_PY.read_text(encoding="utf-8")
-    forbidden_substrings = (
-        "from dashboard.api_merge_execution_dry_run",
-        "import api_merge_execution_dry_run",
+    required_substrings = (
+        # Import site:
+        "from dashboard.api_merge_execution_dry_run import",
+        # Symbol must be imported:
         "register_merge_execution_dry_run_routes",
+        # Register-call site (must invoke the callable on app):
+        "register_merge_execution_dry_run_routes(app)",
     )
-    hits = [s for s in forbidden_substrings if s in src]
-    assert not hits, (
-        "B2.8c walker must remain UNWIRED. dashboard.py contains "
-        f"wiring substrings: {hits!r}. Wiring is B2.8e scope."
+    missing = [s for s in required_substrings if s not in src]
+    assert not missing, (
+        "dashboard.py is missing required B2.8e wiring substrings: "
+        f"{missing!r}. Operator-applied wiring patch must add the "
+        "import + the register_merge_execution_dry_run_routes(app) "
+        "call (B2.0c precedent)."
     )
 
 
@@ -2246,26 +2262,14 @@ def test_b2_8e_would_proceed_field_documented_as_dry_run_only_in_source() -> Non
 
 
 # ---------------------------------------------------------------------------
-# B2.8e UNWIRED-state pin — operator-applied wiring is a separate commit
+# Wiring landed — UNWIRED-state pins retired
+#
+# The B2.8e-era ``test_b2_8e_blueprint_still_unwired_in_dashboard_py``
+# pin was retired by the operator-applied wiring commit. The
+# wired-state contract is now enforced by the positive pin
+# ``test_blueprint_registered_in_dashboard_py`` earlier in this
+# file. The readiness self-pin in
+# ``tests/unit/test_n5b_phase2_precondition_readiness.py`` is
+# updated in the same wiring commit to accept the post-wiring
+# positive pin name.
 # ---------------------------------------------------------------------------
-
-
-def test_b2_8e_blueprint_still_unwired_in_dashboard_py() -> None:
-    """B2.8e MUST NOT wire the blueprint into ``dashboard/dashboard.py``.
-    The operator-applied wiring patch + corresponding test-pin
-    retirement is a separate follow-up commit (B2.0c precedent).
-    This pin is identical to ``test_blueprint_not_registered_in_dashboard_py``;
-    re-asserted explicitly so the B2.8e contract surface is
-    self-documenting."""
-    src = DASHBOARD_PY.read_text(encoding="utf-8")
-    forbidden_substrings = (
-        "from dashboard.api_merge_execution_dry_run",
-        "import api_merge_execution_dry_run",
-        "register_merge_execution_dry_run_routes",
-    )
-    hits = [s for s in forbidden_substrings if s in src]
-    assert not hits, (
-        "B2.8e walker must remain UNWIRED. dashboard.py contains "
-        f"wiring substrings: {hits!r}. Wiring is operator-applied "
-        "in a separate follow-up commit."
-    )

--- a/tests/unit/test_n5b_phase2_precondition_readiness.py
+++ b/tests/unit/test_n5b_phase2_precondition_readiness.py
@@ -593,8 +593,17 @@ def test_existing_b2_8a_pin_test_file_still_exists() -> None:
 
 def test_existing_b2_8b_skeleton_test_file_still_exists() -> None:
     """B2.8b skeleton pin-test file must still be on disk and
-    carry the UNWIRED-contract pin so this readiness PR has not
-    weakened the skeleton's invariants."""
+    carry the dashboard.py wiring-state contract pin so this
+    readiness PR has not weakened the skeleton's invariants.
+
+    Narrowed by the operator-applied wiring commit (B2.0c
+    precedent): the wiring-state contract is now expressed as
+    a positive ``test_blueprint_registered_in_dashboard_py`` pin,
+    landing alongside the actual wiring of
+    ``dashboard/dashboard.py``. Either function name
+    (pre-wiring negative or post-wiring positive) satisfies the
+    readiness invariant — both keep the wiring-state contract
+    on the surface."""
     b2_8b_pin_test = (
         REPO_ROOT
         / "tests"
@@ -605,8 +614,13 @@ def test_existing_b2_8b_skeleton_test_file_still_exists() -> None:
         f"B2.8b skeleton pin-test file missing: {b2_8b_pin_test}"
     )
     src = b2_8b_pin_test.read_text(encoding="utf-8")
-    assert "test_blueprint_not_registered_in_dashboard_py" in src, (
-        "B2.8b skeleton pin-test no longer carries the UNWIRED contract pin"
+    assert (
+        "test_blueprint_not_registered_in_dashboard_py" in src
+        or "test_blueprint_registered_in_dashboard_py" in src
+    ), (
+        "walker pin-test no longer carries the dashboard.py "
+        "wiring-state contract pin (neither pre-wiring negative "
+        "nor post-wiring positive form is present)"
     )
 
 


### PR DESCRIPTION
## Summary — operator-applied wiring + companion test-pin update (B2.0c precedent)

This PR wires the N5b Phase 2 dry-run module (`dashboard/api_merge_execution_dry_run.py`, landed in PR #238 at `b62b135`) into the Flask app at [`dashboard/dashboard.py`](dashboard/dashboard.py) via the existing `register_*_routes(app)` callable convention. No Flask `Blueprint` object, no `url_prefix` — same pattern as adjacent `register_approval_token_gate_routes`, `register_merge_recommendation_routes`, `register_merge_preflight_routes`.

The route `POST /api/agent-control/merge-execution/dry-run` is now reachable on the live dashboard once this PR merges and the VPS redeploys.

### What this PR is NOT

- **NOT a Phase 2 live-execution activation.** The route is dry-run only.
- **NOT a Phase 3 / Phase 4 enablement.** Both remain `Not implemented` in `docs/governance/n5b_merge_execution_plan.md` §10.
- **NOT a Step 5 runtime activation.** `step5_implementation_allowed: Final[False]`, `STEP5_ENABLED_SUBSTAGE: Final["none"]` unchanged.
- **NOT a Level 6 enablement.** Level 6 permanently disabled per ADR-015 §Doctrine 1.
- **NOT a frozen-contract change.** No live/paper/shadow/risk/broker/execution/research paths touched. No `.claude/**`, `.github/**`, `tests/regression/**`, `docs/governance/no_touch_paths.md`.

### Two commits on this branch

| SHA | Author | Files | Change |
|---|---|---|---|
| `b9b5ac1` | operator | `dashboard/dashboard.py` | +4 lines: import block + `register_merge_execution_dry_run_routes(app)` call site |
| `d4df346` | Claude (companion) | `tests/unit/test_api_merge_execution_dry_run.py` + `tests/unit/test_n5b_phase2_precondition_readiness.py` | retire UNWIRED pins; add positive `test_blueprint_registered_in_dashboard_py`; narrow readiness self-pin to accept the post-wiring positive pin name |

`dashboard/dashboard.py` is on the repo no-touch list (per `docs/governance/no_touch_paths.md` and `.claude/hooks/deny_no_touch.py`); Claude cannot edit it. The operator applied that commit manually on this branch (B2.0c precedent — same workflow used when `agent_activity` was wired in [PR #224](https://github.com/roudjy/trading-agent/pull/224)).

### Hard guarantees pinned by tests

- **Route is dry-run only.** Existing B2.8e walker writes preflight + dry_run + history + failure artefacts under `logs/n5b_merge_execution/` (unchanged by this PR). Writes no GitHub mutation. Performs no PR merge / deploy / approve / reject.
- **`status="ok"` + `would_proceed=true`** continue to mean *"dry-run checks passed and audit artefacts written"* — pinned by `test_b2_8e_would_proceed_true_always_co_occurs_with_dry_run_invariants` (co-occurrence with the six discipline invariants) and `test_b2_8e_would_proceed_field_documented_as_dry_run_only_in_source` (positive doc + negative misframing list).
- **N4b anti-replay nonce store** is the only persisted state mutation — existing N4b behaviour, inherited via `verify_runtime_for_dry_run`. No approval *decisions* mutated.
- **No GitHub API / `gh` / `git` / `subprocess` / `socket` / `urllib` / `requests` / `httpx` / `aiohttp`** added — pinned by AST + source-text scans.
- **`step5_implementation_allowed` / `STEP5_ENABLED_SUBSTAGE` / Level 6** unchanged.
- **Phase 3 + Phase 4** remain `Not implemented` in both `n5b_merge_execution_plan.md` and `n5b_phase2_implementation_plan.md`.

### Local test gates

| Gate | Result |
|---|---|
| Targeted suite (walker tests + readiness self-pin) | **169 passed** in 3.45s |
| `tests/smoke/` | **18 passed** in 11.06s |
| `python scripts/governance_lint.py` | **OK** (16 agents, 5 workflows checked) |
| `python scripts/push_body_safety_lint.py` | **OK** (6 surfaces, 6 tokens checked) |

### Diff scope (3 files exactly)

```
dashboard/dashboard.py                              +4 / 0 lines (operator commit b9b5ac1)
tests/unit/test_api_merge_execution_dry_run.py     +30 / -45 lines (Claude commit d4df346)
tests/unit/test_n5b_phase2_precondition_readiness.py +18 / -7 lines (Claude commit d4df346)
```

No other files. No untracked items staged (`.claude/scheduled_tasks.lock`, `.t/`, `research/discovery_sprints/` remain pre-existing untracked).

## Test plan

- [ ] CI Fast pre-merge gate passes
- [ ] `unit (smoke + unit)` passes including the new positive wiring pin
- [ ] Diff scope on PR still exactly the 3 approved files
- [ ] Squash-merge after green CI
- [ ] Post-merge VPS deploy activates the dry-run route on the live dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)