### PR TITLE
feat(a20a): static Roadmap v6 task catalog seed (read-only)

### DIFF
--- a/docs/governance/roadmap_task_catalog.md
+++ b/docs/governance/roadmap_task_catalog.md
@@ -1,0 +1,373 @@
+# Roadmap Task Catalog — A20a (read-only, deterministic seed)
+
+> **Status:** Implemented (read-only, deterministic, dry-run by
+> default).
+>
+> **Module:** [`reporting/roadmap_task_catalog.py`](../../reporting/roadmap_task_catalog.py)
+> **Output artefact:** `logs/roadmap_task_catalog/latest.json`
+>
+> **Authority:** development-governance read-only.
+> The roadmap task catalog is **not** the canonical product roadmap.
+> Roadmap v6 ([`docs/roadmap/Roadmap v6.md`](../roadmap/Roadmap%20v6.md))
+> remains the canonical QRE product roadmap and the only source of
+> truth for product phase order and intent. This catalog is a
+> deterministic *seed* over that source plus the committed Addendum 1.
+>
+> The catalog grants **no** implementation, runtime, trading, paper,
+> shadow, broker, risk, or live authority to any agent. ADE remains
+> development workflow automation only per
+> [`docs/governance/ade_development_lane_doctrine.md`](ade_development_lane_doctrine.md).
+
+---
+
+## 1. Purpose
+
+ADE's autonomous-development surface needs a deterministic,
+repo-resident description of the upcoming QRE Feature Build Track
+phases. The Roadmap Intake Bridge
+([`reporting/development_roadmap_intake.py`](../../reporting/development_roadmap_intake.py))
+already gives ADE a path to pick up explicit
+`<!-- ade_roadmap_intake ... -->` markers, but the canonical roadmap
+documents must remain human-readable; bulk decomposition does not
+belong inline in those files.
+
+A20a fills the gap by hand-encoding the v3.15.16 → v3.15.20 phase
+tasks plus a cross-cutting Addendum 1 task and their normative
+requirements into a deterministic Python literal inside
+`reporting/roadmap_task_catalog.py`. The module emits a single
+read-only projection at `logs/roadmap_task_catalog/latest.json`.
+
+This is a **catalog**, not a queue:
+
+- A20a hand-encodes phase tasks and Addendum 1 requirements.
+- A20b (future) decomposes phases into PR-sized implementation
+  units.
+- A20c (future) attaches per-unit risk and authority classification
+  via the existing [`reporting/execution_authority.py`](../../reporting/execution_authority.py)
+  classifier.
+- A20d (future) exposes read-only AAC / task-board visibility on
+  top of A20a / A20b / A20c artefacts.
+- A20e (future) selects a deterministic next-buildable unit. No
+  hidden LLM judgment.
+
+Each subsequent stage requires a separate operator-go PR. A20a does
+not pre-authorize any of them.
+
+---
+
+## 2. Scope and non-scope
+
+### 2.1 In scope
+
+- Hand-encoded `RoadmapTask` records for Roadmap v6 phases
+  v3.15.16, v3.15.17, v3.15.18, v3.15.19, v3.15.20, plus a
+  cross-cutting `addendum_1` task.
+- Hand-encoded `RoadmapRequirement` records covering the Addendum 1
+  diagnostic families (tails, entropy, criticality, barrier,
+  resonance, null-model, network, adversarial, control-stability,
+  seismic, liquidity-turbulence, quorum, market-language), the
+  external-intelligence intake section, the source-manifest fields,
+  and the public-data quality gates.
+- Closed vocabularies `PHASE`, `SOURCE_DOCUMENT`, `STATUS`,
+  `ADDENDUM_LINK`, `TARGET_LAYER`. Widening any of them requires a
+  code change pinned by an updated unit test.
+- Deterministic, sorted-keys, bounded-scalar projection emitted
+  under `logs/roadmap_task_catalog/latest.json` via an atomic write
+  restricted to that directory.
+- CLI (`--no-write`, `--status`, `--indent`).
+
+### 2.2 Non-scope (hard constraints)
+
+- **Roadmap v6 Addendum 2 and Roadmap v6 Addendum 3 are not
+  present in the repo** at the time of this seed. They are
+  represented **only** as the absence flags
+  `discipline_invariants.addendum_2_not_present = true` and
+  `discipline_invariants.addendum_3_not_present = true`. Their
+  requirements must not be invented by this module and must not be
+  added until the operator commits those source files.
+- No phase-to-PR-unit decomposition. That is A20b scope.
+- No per-unit `execution_authority.classify(...)` calls. That is
+  A20c scope.
+- No AAC / task-board / dashboard surface change. That is A20d
+  scope.
+- No next-buildable-unit selector. That is A20e scope.
+- No mutation of any canonical roadmap document. The catalog does
+  not touch [`docs/roadmap/Roadmap v6.md`](../roadmap/Roadmap%20v6.md),
+  [`docs/roadmap/Roadmap v6 Addendum.md`](../roadmap/Roadmap%20v6%20Addendum.md),
+  [`docs/roadmap/qre_roadmap_v6_phase_prompts.md`](../roadmap/qre_roadmap_v6_phase_prompts.md),
+  [`docs/roadmap/qre_roadmap_v6_ade_operating_manual.md`](../roadmap/qre_roadmap_v6_ade_operating_manual.md),
+  or [`docs/roadmap/autonomous_development.txt`](../roadmap/autonomous_development.txt).
+- No mutation of frozen contracts
+  (`research/research_latest.json`, `research/strategy_matrix.csv`).
+- No mutation of `.claude/**`, `dashboard/dashboard.py`,
+  `automation/live_gate.py`, `broker/**`, `agent/risk/**`,
+  `agent/execution/**`, or any live / paper / shadow / trading
+  path.
+- No writes to `docs/development_work_queue/seed.jsonl`,
+  `docs/development_work_queue/delegation_seed.jsonl`, or any
+  `generated_seed.jsonl` file.
+- No edits to the existing A17 admission-policy surface
+  ([`reporting/development_queue_admission_policy.py`](../../reporting/development_queue_admission_policy.py)).
+- No edits to the AAC aggregator
+  ([`reporting/development_agent_activity_timeline.py`](../../reporting/development_agent_activity_timeline.py))
+  or its 11-entry upstream catalog cardinality. That cardinality
+  amendment, if ever needed, is a separate operator-go PR.
+- No flip of `step5_implementation_allowed` (stays `False`) or
+  `STEP5_ENABLED_SUBSTAGE` (stays `"none"`).
+- No relaxation of the autonomy-ladder ceiling. Level 6 stays
+  permanently disabled per ADR-015 §Doctrine 1.
+- No subprocess, no network, no `gh`, no `git`, no LLM, no fuzzy
+  parsing.
+
+---
+
+## 3. Authority chain
+
+This catalog is **not** an authority surface. It does not classify
+implementation risk and does not grant any agent the right to
+implement, branch, merge, deploy, trade, or move capital. Roadmap v6
+remains canonical; per-action authority remains owned by
+[`docs/governance/execution_authority.md`](execution_authority.md)
+and [`reporting/execution_authority.py`](../../reporting/execution_authority.py).
+
+| Concern | Owner |
+|---|---|
+| Canonical product roadmap | [`docs/roadmap/Roadmap v6.md`](../roadmap/Roadmap%20v6.md) |
+| Diagnostic / external-intelligence extension | [`docs/roadmap/Roadmap v6 Addendum.md`](../roadmap/Roadmap%20v6%20Addendum.md) |
+| ADE governance roadmap | [`docs/roadmap/autonomous_development.txt`](../roadmap/autonomous_development.txt) |
+| ADE development-lane doctrine | [`docs/governance/ade_development_lane_doctrine.md`](ade_development_lane_doctrine.md) |
+| Per-action authority classification | [`docs/governance/execution_authority.md`](execution_authority.md) + [`reporting/execution_authority.py`](../../reporting/execution_authority.py) |
+| Step 5 sub-stage cap | [`docs/governance/step5_design.md`](step5_design.md) §12 + ADR-017 |
+| Autonomy ladder (Level 6 permanently disabled) | [`docs/governance/autonomy_ladder.md`](autonomy_ladder.md) + ADR-015 |
+
+---
+
+## 4. Schemas
+
+### 4.1 `RoadmapTask`
+
+Per-phase intent record. Field list is exact and ordered.
+
+```
+id                : str  (≤96 chars; stable opaque identifier)
+title             : str  (≤200 chars)
+phase             : str  ∈ PHASE
+source_documents  : list[str]  (⊆ SOURCE_DOCUMENT; sorted)
+purpose           : str  (≤1000 chars)
+status            : str  ∈ STATUS
+prerequisites     : list[str]  (other RoadmapTask.id values; sorted)
+```
+
+### 4.2 `RoadmapRequirement`
+
+Per-requirement record. Field list is exact and ordered.
+
+```
+id              : str  (≤96 chars)
+roadmap_task_id : str  (RoadmapTask.id this requirement belongs to)
+source_document : str  ∈ SOURCE_DOCUMENT
+source_anchor   : str  (≤200 chars; section/anchor in source doc)
+phase           : str  ∈ PHASE
+addendum_link   : str  ∈ ADDENDUM_LINK ("none" iff no addendum link)
+statement       : str  (≤500 chars)
+target_layer    : str  ∈ TARGET_LAYER
+status          : str  ∈ STATUS
+```
+
+### 4.3 `TaskCatalogProjection`
+
+Top-level artefact shape. Field list is exact and ordered.
+
+```
+generated_at_utc       : ISO8601 (sole non-deterministic field)
+schema_version         : str
+module_version         : str
+roadmap_tasks          : list[RoadmapTask]
+roadmap_requirements   : list[RoadmapRequirement]
+discipline_invariants  : dict[str, bool]
+```
+
+The artefact also carries `report_kind`, `vocabularies`,
+`step5_enabled_substage`, `step5_implementation_allowed`, and
+`execution_authority_module_version` envelope fields for parity
+with other ADE-core artefacts. These are emitted alongside the
+field list above; the field-list tuple defines the closed set
+that future projectors MUST preserve.
+
+---
+
+## 5. Closed vocabularies
+
+| Vocabulary | Members |
+|---|---|
+| `PHASE` | `v3.15.16`, `v3.15.17`, `v3.15.18`, `v3.15.19`, `v3.15.20`, `addendum_1`, `addendum_2`, `addendum_3` |
+| `SOURCE_DOCUMENT` | `docs/roadmap/Roadmap v6.md`, `docs/roadmap/Roadmap v6 Addendum.md`, `docs/roadmap/qre_roadmap_v6_ade_operating_manual.md`, `docs/roadmap/qre_roadmap_v6_phase_prompts.md` |
+| `STATUS` | `not_started`, `ready`, `in_flight`, `merged`, `blocked`, `human_needed`, `permanently_denied` |
+| `ADDENDUM_LINK` | `addendum_1`, `addendum_2`, `addendum_3`, `none` |
+| `TARGET_LAYER` | `external_intelligence`, `diagnostics`, `market_behavior`, `hypothesis_discovery`, `strategy_mapping`, `preset`, `campaign`, `funnel`, `evidence`, `policy`, `shadow`, `paper`, `live`, `reporting`, `governance`, `docs`, `test` |
+
+`PHASE` deliberately lists `addendum_2` and `addendum_3` so future
+projectors can carry their phase identity even before the source
+documents land. `SOURCE_DOCUMENT` deliberately does **not** list the
+Addendum 2 / Addendum 3 paths until those files are committed.
+
+`ADDENDUM_LINK` uses an explicit `"none"` member so the field is
+never silently missing on a non-addendum requirement.
+
+---
+
+## 6. Addendum 2 / Addendum 3 absence
+
+Roadmap v6 Addendum 2 (State Sequential Knowledge Retrieval) and
+Roadmap v6 Addendum 3 (Source Identity Data Quality and Throughput
+Intelligence) are **not in the repo** at the time of this seed.
+
+A20a represents both as absence flags only:
+
+```
+discipline_invariants.addendum_2_not_present = true
+discipline_invariants.addendum_3_not_present = true
+```
+
+The catalog emits zero `RoadmapTask` records under
+`phase = "addendum_2"` or `phase = "addendum_3"`, and zero
+`RoadmapRequirement` records linked to those phases. Their
+requirements must not be invented by this module. When the operator
+commits the source files, a follow-up PR may:
+
+1. add the path strings to `SOURCE_DOCUMENT`;
+2. flip the corresponding absence flag to `false`;
+3. add hand-encoded `RoadmapTask` + `RoadmapRequirement` records;
+4. update the matching unit tests.
+
+Until then the absence is explicit and asserted.
+
+---
+
+## 7. Future stages (A20b–A20e)
+
+The roadmap task catalog is the foundation of a staged sequence.
+Each subsequent stage requires a separate operator-go PR. None of
+them is pre-authorized by A20a.
+
+- **A20b — Implementation Unit Decomposer.** Converts each
+  `RoadmapTask` into one or more PR-sized `ImplementationUnit`
+  records with explicit `expected_files[]`, `forbidden_files[]`,
+  `required_tests[]`, `definition_of_done[]`, `stop_conditions[]`,
+  and `prerequisites[]`. Deterministic data, no LLM, no fuzzy
+  parsing. Forbidden files must always include the live / paper /
+  shadow / risk / broker / execution globs and the frozen-contract
+  paths, regardless of the unit's primary surface.
+- **A20c — Authority / Risk Classifier Integration.** Annotates
+  each `ImplementationUnit` with an aggregate
+  `UnitAuthorityDecision` derived purely from
+  [`reporting/execution_authority.py`](../../reporting/execution_authority.py).
+  Aggregation is max-severity over per-file decisions. Fail-closed:
+  unknown risk → `NEEDS_HUMAN`; any protected-path / frozen / live
+  surface → `PERMANENTLY_DENIED` or `NEEDS_HUMAN` per the
+  classifier's existing policy.
+- **A20d — Read-only AAC / Task-Board Visibility.** Exposes the
+  catalog + units + authority decisions to the operator through
+  the existing read-only surfaces (`reporting/task_board.py`,
+  `reporting/agent_flow.py`, AAC aggregator). No mutation routes,
+  no approval buttons, no `dashboard/dashboard.py` edit unless a
+  separate operator-authored governance-bootstrap PR enables it.
+  Any AAC aggregator cardinality change requires its own
+  operator-go PR.
+- **A20e — Deterministic Next-Buildable-Unit Selector.**
+  Pure-deterministic filter + sort over A20c output. Eligibility
+  requires: `status ∈ {not_started, ready}`; all prerequisites in
+  `status = merged`; `operator_gate = none`;
+  `aggregate_decision = AUTO_ALLOWED`; no triggered
+  forbidden-surface reasons. Fail-closed: zero eligible →
+  `selected_unit_id = None` with `selection_reason =
+  "no_eligible_units"`. No hidden LLM judgment.
+
+A20a does not produce, imply, or depend on any of the above. Each
+must justify its own scope on its own PR.
+
+---
+
+## 8. CLI
+
+```sh
+# Pure inspection — write the artefact and dump JSON to stdout:
+python -m reporting.roadmap_task_catalog
+
+# Pure inspection — do not write any artefact:
+python -m reporting.roadmap_task_catalog --no-write
+
+# Compact, human-readable status (no artefact write):
+python -m reporting.roadmap_task_catalog --status
+
+# Indented JSON to stdout:
+python -m reporting.roadmap_task_catalog --indent 2
+```
+
+Stdlib + `reporting.execution_authority` (constants only) only. No
+subprocess, no network, no `gh`, no `git`. The atomic write helper
+refuses every path outside `logs/roadmap_task_catalog/`.
+
+---
+
+## 9. Determinism contract
+
+- Tasks are sorted by `(phase, id)` ascending.
+- Requirements are sorted by `(phase, id)` ascending.
+- All free-text fields are bounded.
+- Output is `json.dumps(..., sort_keys=True, indent=2) + "\n"`.
+- `generated_at_utc` is the only non-deterministic field. Tests
+  inject it for byte-identical fixtures.
+- Atomic write via `os.replace(...)` from a same-directory
+  `tempfile.mkstemp(...)`. No tmp files left behind on failure.
+
+---
+
+## 10. Test coverage
+
+Pinned in [`tests/unit/test_roadmap_task_catalog.py`](../../tests/unit/test_roadmap_task_catalog.py):
+
+- Closed vocabularies are exact and complete.
+- Schema field tuples are exact and ordered.
+- Every encoded task / requirement satisfies the closed vocab.
+- Phase-task coverage: every v3.15.16..v3.15.20 phase has a task;
+  the `addendum_1` cross-cutting task exists; `addendum_2` /
+  `addendum_3` have **zero** encoded tasks.
+- Addendum 1 diagnostic-family coverage spans tails, entropy,
+  criticality, barrier, resonance, null-model, network,
+  adversarial, control-stability, seismic, liquidity-turbulence,
+  quorum, market-language, external-intelligence intake,
+  source-manifest fields, and public-data quality gates.
+- Step 5 invariants pinned: `step5_implementation_allowed is False`
+  and `STEP5_ENABLED_SUBSTAGE == "none"`.
+- Discipline invariants pinned for: no runtime / trading / paper /
+  shadow / broker / risk / live authority; no frozen contract
+  mutation; no seed-jsonl writes; diagnostics do not trade;
+  external data is not alpha; Addendum 2 / 3 absence flags.
+- Determinism: byte-identical output for identical input with
+  injected `generated_at_utc`.
+- Atomic-write allowlist refuses any path outside
+  `logs/roadmap_task_catalog/`.
+- CLI `--no-write` does not write; `--status` does not write and
+  emits the expected invariant strings; default writes to the
+  allowlisted path.
+- Module-source scan for forbidden imports / tokens (subprocess,
+  socket, urllib, http, requests, dashboard, automation, broker,
+  agent.risk, agent.execution, live, paper, shadow, trading,
+  research.run_research, research_latest.json, strategy_matrix.csv,
+  `gh`, `git`).
+
+---
+
+## 11. Cross-references
+
+- [`docs/governance/ade_development_lane_doctrine.md`](ade_development_lane_doctrine.md)
+- [`docs/governance/execution_authority.md`](execution_authority.md)
+- [`docs/governance/no_touch_paths.md`](no_touch_paths.md)
+- [`docs/governance/autonomy_ladder.md`](autonomy_ladder.md)
+- [`docs/governance/step5_design.md`](step5_design.md)
+- [`docs/governance/development_roadmap_intake.md`](development_roadmap_intake.md)
+- [`docs/roadmap/Roadmap v6.md`](../roadmap/Roadmap%20v6.md)
+- [`docs/roadmap/Roadmap v6 Addendum.md`](../roadmap/Roadmap%20v6%20Addendum.md)
+- [`docs/roadmap/qre_roadmap_v6_ade_operating_manual.md`](../roadmap/qre_roadmap_v6_ade_operating_manual.md)
+- [`docs/roadmap/qre_roadmap_v6_phase_prompts.md`](../roadmap/qre_roadmap_v6_phase_prompts.md)

--- a/reporting/roadmap_task_catalog.py
+++ b/reporting/roadmap_task_catalog.py
@@ -1,0 +1,1155 @@
+"""A20a — Static Roadmap v6 Task Catalog Seed (read-only, deterministic).
+
+Pure, stdlib-only, repo-resident task-catalog **seed**. Hand-encodes the
+Roadmap v6 phase tasks (v3.15.16 through v3.15.20) plus a cross-cutting
+Addendum 1 task, and the per-requirement Addendum 1 diagnostic coverage,
+into a deterministic projection emitted at
+``logs/roadmap_task_catalog/latest.json``.
+
+This module is a **catalog**, not a queue. It does not:
+
+* mutate the canonical roadmap documents;
+* mutate frozen contracts;
+* promote anything into ``docs/development_work_queue/seed.jsonl`` or
+  ``docs/development_work_queue/delegation_seed.jsonl``;
+* select a next-buildable unit (A20e scope);
+* decompose phases into PR-sized implementation units (A20b scope);
+* call ``execution_authority.classify(...)`` for risk/authority mapping
+  (A20c scope);
+* surface anything to the AAC / task board / dashboard (A20d scope);
+* enable or hint at Step 5 substages or autonomy-ladder Level 6;
+* grant trading, paper, shadow, broker, risk, or live execution
+  authority to any agent.
+
+Roadmap v6 remains canonical for product. Roadmap v6 Addendum is the
+diagnostic / external-intelligence extension. Roadmap v6 Addendum 2
+and Addendum 3 are **not in the repo** at the time of this seed and
+are represented only as absence flags on the projection. They must
+not be invented here.
+
+Hard guarantees (pinned by tests):
+
+* Stdlib + ``reporting.execution_authority`` (read-only constants
+  only — no ``classify(...)`` calls in this PR).
+* No subprocess, no network, no ``gh``, no ``git``.
+* No imports of ``dashboard``, ``automation``, ``broker``,
+  ``agent.risk``, ``agent.execution``, ``research``, ``live``,
+  ``paper``, ``shadow``, ``trading``,
+  ``reporting.intelligent_routing``.
+* No LLM, no external API, no fuzzy parsing.
+* Closed vocabularies for ``PHASE``, ``SOURCE_DOCUMENT``, ``STATUS``,
+  ``ADDENDUM_LINK``, ``TARGET_LAYER``. Widening any of them requires
+  a code change pinned by an updated unit test.
+* Atomic write only under ``logs/roadmap_task_catalog/``.
+* Deterministic output: same input + injected ``generated_at_utc`` →
+  byte-identical artefact across runs.
+* ``step5_implementation_allowed`` remains ``False`` and
+  ``STEP5_ENABLED_SUBSTAGE`` remains ``"none"``.
+
+CLI::
+
+    python -m reporting.roadmap_task_catalog
+    python -m reporting.roadmap_task_catalog --no-write
+    python -m reporting.roadmap_task_catalog --status
+    python -m reporting.roadmap_task_catalog --indent 2
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Final
+
+from reporting import execution_authority as ea
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[str] = "1.0"
+MODULE_VERSION: Final[str] = "v3.15.16.A20a"
+REPORT_KIND: Final[str] = "roadmap_task_catalog"
+
+
+# ---------------------------------------------------------------------------
+# Step 5 + Level 6 invariants (Final constants — never flipped at runtime)
+# ---------------------------------------------------------------------------
+
+#: Closed Step 5 sub-stage cap. Mirrors the value asserted across the
+#: ADE-core reporting modules. Default-deny: ``"none"`` means this
+#: catalog does not escalate any phase.
+STEP5_ENABLED_SUBSTAGE: Final[str] = "none"
+
+#: Hard-pinned literal: Step 5 implementation remains BLOCKED.
+step5_implementation_allowed: Final[bool] = False
+
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies
+# ---------------------------------------------------------------------------
+
+#: Closed roadmap-phase vocabulary. Addendum 2 / Addendum 3 are listed
+#: so consumers can carry their phase identity, but neither has a file
+#: committed to the repo at the time of this seed; their requirements
+#: remain empty and absence flags are emitted on every projection.
+PHASE: Final[tuple[str, ...]] = (
+    "v3.15.16",
+    "v3.15.17",
+    "v3.15.18",
+    "v3.15.19",
+    "v3.15.20",
+    "addendum_1",
+    "addendum_2",
+    "addendum_3",
+)
+
+#: Closed source-document vocabulary. Only Roadmap v6 and the
+#: committed Addendum 1 file are present today. The Addendum 2 / 3
+#: paths are intentionally absent until those files land in repo.
+SOURCE_DOCUMENT: Final[tuple[str, ...]] = (
+    "docs/roadmap/Roadmap v6.md",
+    "docs/roadmap/Roadmap v6 Addendum.md",
+    "docs/roadmap/qre_roadmap_v6_ade_operating_manual.md",
+    "docs/roadmap/qre_roadmap_v6_phase_prompts.md",
+)
+
+#: Closed task / requirement status vocabulary. Today every entry
+#: lands in ``not_started`` — the catalog records intent, not
+#: in-flight or completed work. Future projections (A20b / A20c) may
+#: lift records to other values; this seed never does.
+STATUS: Final[tuple[str, ...]] = (
+    "not_started",
+    "ready",
+    "in_flight",
+    "merged",
+    "blocked",
+    "human_needed",
+    "permanently_denied",
+)
+
+#: Closed addendum-link vocabulary. ``"none"`` is the explicit value
+#: for "no addendum link" so the field is never silently missing.
+ADDENDUM_LINK: Final[tuple[str, ...]] = (
+    "addendum_1",
+    "addendum_2",
+    "addendum_3",
+    "none",
+)
+
+#: Closed target-layer vocabulary. Mirrors the Addendum 1 architecture
+#: stack plus the ADE-side surfaces this catalog can describe without
+#: pretending to govern runtime/trading behaviour.
+TARGET_LAYER: Final[tuple[str, ...]] = (
+    "external_intelligence",
+    "diagnostics",
+    "market_behavior",
+    "hypothesis_discovery",
+    "strategy_mapping",
+    "preset",
+    "campaign",
+    "funnel",
+    "evidence",
+    "policy",
+    "shadow",
+    "paper",
+    "live",
+    "reporting",
+    "governance",
+    "docs",
+    "test",
+)
+
+
+# ---------------------------------------------------------------------------
+# Schema field tuples (exact, ordered)
+# ---------------------------------------------------------------------------
+
+#: ``RoadmapTask`` field list. Exact and ordered.
+ROADMAP_TASK_FIELDS: Final[tuple[str, ...]] = (
+    "id",
+    "title",
+    "phase",
+    "source_documents",
+    "purpose",
+    "status",
+    "prerequisites",
+)
+
+#: ``RoadmapRequirement`` field list. Exact and ordered.
+ROADMAP_REQUIREMENT_FIELDS: Final[tuple[str, ...]] = (
+    "id",
+    "roadmap_task_id",
+    "source_document",
+    "source_anchor",
+    "phase",
+    "addendum_link",
+    "statement",
+    "target_layer",
+    "status",
+)
+
+#: ``TaskCatalogProjection`` field list. Exact and ordered.
+TASK_CATALOG_PROJECTION_FIELDS: Final[tuple[str, ...]] = (
+    "generated_at_utc",
+    "schema_version",
+    "module_version",
+    "roadmap_tasks",
+    "roadmap_requirements",
+    "discipline_invariants",
+)
+
+
+# ---------------------------------------------------------------------------
+# Bounds
+# ---------------------------------------------------------------------------
+
+MAX_TITLE_LEN: Final[int] = 200
+MAX_PURPOSE_LEN: Final[int] = 1000
+MAX_STATEMENT_LEN: Final[int] = 500
+MAX_ID_LEN: Final[int] = 96
+MAX_ANCHOR_LEN: Final[int] = 200
+
+
+# ---------------------------------------------------------------------------
+# Artefact paths
+# ---------------------------------------------------------------------------
+
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "roadmap_task_catalog"
+ARTIFACT_LATEST: Final[Path] = ARTIFACT_DIR / "latest.json"
+ARTIFACT_RELATIVE_PATH: Final[str] = "logs/roadmap_task_catalog/latest.json"
+
+#: Atomic-write allowlist (POSIX path substring form). Any write
+#: target whose path does not contain this substring is refused with
+#: ``ValueError``.
+_WRITE_PREFIX: Final[str] = "logs/roadmap_task_catalog/"
+
+
+# ---------------------------------------------------------------------------
+# Discipline invariants emitted on every projection
+# ---------------------------------------------------------------------------
+
+_DISCIPLINE_INVARIANTS: Final[dict[str, bool]] = {
+    "actually_modifies_target": False,
+    "creates_real_branches": False,
+    "opens_real_prs": False,
+    "mergeable_by_agent": False,
+    "deployable_by_agent": False,
+    "writes_to_seed_jsonl": False,
+    "writes_to_delegation_seed_jsonl": False,
+    "writes_to_generated_seed_jsonl": False,
+    "fuzzy_parsing": False,
+    "uses_subprocess_or_network": False,
+    "calls_llm_or_external_api": False,
+    "mutates_research_artifacts": False,
+    "mutates_roadmap_status_fields": False,
+    "marks_phase_complete": False,
+    "operator_promotion_required": True,
+    "step5_implementation_allowed": False,
+    "diagnostics_do_not_trade": True,
+    "external_data_is_not_alpha": True,
+    "addendum_2_not_present": True,
+    "addendum_3_not_present": True,
+    "grants_runtime_authority": False,
+    "grants_trading_authority": False,
+    "grants_paper_authority": False,
+    "grants_shadow_authority": False,
+    "grants_broker_authority": False,
+    "grants_risk_authority": False,
+    "grants_live_authority": False,
+}
+
+
+# ---------------------------------------------------------------------------
+# Hand-encoded RoadmapTask seed data
+# ---------------------------------------------------------------------------
+
+#: One entry per Roadmap v6 phase v3.15.16..20, plus a cross-cutting
+#: ``addendum_1`` task. Order matches ``PHASE`` declaration order;
+#: ``sort`` at projection time keeps the artefact stable regardless.
+_ROADMAP_TASKS_SEED: Final[tuple[dict[str, Any], ...]] = (
+    {
+        "id": "phase_v3_15_16",
+        "title": "Intelligent Routing Layer",
+        "phase": "v3.15.16",
+        "source_documents": (
+            "docs/roadmap/Roadmap v6.md",
+            "docs/roadmap/Roadmap v6 Addendum.md",
+            "docs/roadmap/qre_roadmap_v6_ade_operating_manual.md",
+        ),
+        "purpose": (
+            "Make campaign routing behavior-aware instead of "
+            "preset-count-aware. Prioritize most informative exploration "
+            "via deterministic, inspectable, artifact-driven routing "
+            "decisions. Diagnostics inform routing only; they do not "
+            "trade."
+        ),
+        "status": "not_started",
+        "prerequisites": (),
+    },
+    {
+        "id": "phase_v3_15_17",
+        "title": "Sampling Intelligence",
+        "phase": "v3.15.17",
+        "source_documents": (
+            "docs/roadmap/Roadmap v6.md",
+            "docs/roadmap/Roadmap v6 Addendum.md",
+            "docs/roadmap/qre_roadmap_v6_ade_operating_manual.md",
+        ),
+        "purpose": (
+            "Replace brute-force parameter-grid exploration with "
+            "deterministic intelligent sampling: stratified, "
+            "low-information suppression, signal-density-aware. "
+            "Diagnostics inform sampling only."
+        ),
+        "status": "not_started",
+        "prerequisites": ("phase_v3_15_16",),
+    },
+    {
+        "id": "phase_v3_15_18",
+        "title": "Research Observability Expansion",
+        "phase": "v3.15.18",
+        "source_documents": (
+            "docs/roadmap/Roadmap v6.md",
+            "docs/roadmap/Roadmap v6 Addendum.md",
+            "docs/roadmap/qre_roadmap_v6_ade_operating_manual.md",
+        ),
+        "purpose": (
+            "Expose read-only observability surfaces explaining why a "
+            "campaign / hypothesis was explored, which diagnostics "
+            "supported or contradicted it, and why it failed or "
+            "survived. No mutation endpoints; no approval buttons."
+        ),
+        "status": "not_started",
+        "prerequisites": ("phase_v3_15_17",),
+    },
+    {
+        "id": "phase_v3_15_19",
+        "title": "Hypothesis Discovery Engine",
+        "phase": "v3.15.19",
+        "source_documents": (
+            "docs/roadmap/Roadmap v6.md",
+            "docs/roadmap/Roadmap v6 Addendum.md",
+            "docs/roadmap/qre_roadmap_v6_ade_operating_manual.md",
+        ),
+        "purpose": (
+            "Introduce the autonomous research-front-door layer. "
+            "Behavior-first hypothesis proposals with explainable "
+            "opportunity scoring as expected research value, not "
+            "prediction certainty. No executable strategy auto-writing; "
+            "no hidden AI logic; no direct promotion to trading."
+        ),
+        "status": "not_started",
+        "prerequisites": ("phase_v3_15_18",),
+    },
+    {
+        "id": "phase_v3_15_20",
+        "title": "Failure to Action Mapping",
+        "phase": "v3.15.20",
+        "source_documents": (
+            "docs/roadmap/Roadmap v6.md",
+            "docs/roadmap/Roadmap v6 Addendum.md",
+            "docs/roadmap/qre_roadmap_v6_ade_operating_manual.md",
+        ),
+        "purpose": (
+            "Convert research failures into deterministic adaptive "
+            "actions. Failure taxonomy + closed action mapping that "
+            "affects routing / suppression / cooldown / confirmation. "
+            "No live risk mutation; no capital allocation; no trade "
+            "placement."
+        ),
+        "status": "not_started",
+        "prerequisites": ("phase_v3_15_19",),
+    },
+    {
+        "id": "addendum_1_diagnostics_intake",
+        "title": (
+            "Mechanistic Behavior Diagnostics and External Intelligence "
+            "Intake"
+        ),
+        "phase": "addendum_1",
+        "source_documents": (
+            "docs/roadmap/Roadmap v6 Addendum.md",
+            "docs/roadmap/qre_roadmap_v6_ade_operating_manual.md",
+        ),
+        "purpose": (
+            "Cross-cutting Roadmap v6 Addendum 1 task. Establish the "
+            "Behavior Diagnostics Library / Research Diagnostics "
+            "Primitives + External Intelligence Intake. Diagnostics "
+            "do not trade. External / public data is an unvalidated "
+            "prior, not alpha. New diagnostic information lives in "
+            "sidecar artifacts; research_latest.json and "
+            "strategy_matrix.csv remain frozen."
+        ),
+        "status": "not_started",
+        "prerequisites": (),
+    },
+)
+
+
+# ---------------------------------------------------------------------------
+# Hand-encoded Addendum 1 + Roadmap v6 phase requirement seed data
+# ---------------------------------------------------------------------------
+#
+# Each entry maps to one ``RoadmapRequirement``. The catalog only
+# encodes requirements that have a normative anchor in Roadmap v6 or
+# the committed Addendum 1 file. Addendum 2 / 3 requirements are NOT
+# encoded here — their source documents are not in the repo.
+
+_ROADMAP_REQUIREMENTS_SEED: Final[tuple[dict[str, Any], ...]] = (
+    # ---- Addendum 1 — Core principles ----------------------------------
+    {
+        "id": "req_addendum_1_diagnostics_do_not_trade",
+        "roadmap_task_id": "addendum_1_diagnostics_intake",
+        "source_document": "docs/roadmap/Roadmap v6 Addendum.md",
+        "source_anchor": "Section 2 Core Rule",
+        "phase": "addendum_1",
+        "addendum_link": "addendum_1",
+        "statement": (
+            "Diagnostics do not trade. A diagnostic may influence "
+            "hypothesis priority, sampling, routing, evidence scoring, "
+            "cooldown, confirmation, suppression or observability; it "
+            "may not place trades, mutate live risk, allocate capital, "
+            "bypass policy governance, or change frozen output "
+            "contracts."
+        ),
+        "target_layer": "policy",
+        "status": "not_started",
+    },
+    {
+        "id": "req_addendum_1_external_data_not_alpha",
+        "roadmap_task_id": "addendum_1_diagnostics_intake",
+        "source_document": "docs/roadmap/Roadmap v6 Addendum.md",
+        "source_anchor": "Section 8.1 Principle",
+        "phase": "addendum_1",
+        "addendum_link": "addendum_1",
+        "statement": (
+            "External / public data is not alpha. It is an unvalidated "
+            "prior. Only QRE-validated, OOS-stable, cost-aware, "
+            "execution-realistic, policy-approved behavior can become "
+            "edge."
+        ),
+        "target_layer": "external_intelligence",
+        "status": "not_started",
+    },
+    {
+        "id": "req_addendum_1_sidecar_artifacts_only",
+        "roadmap_task_id": "addendum_1_diagnostics_intake",
+        "source_document": "docs/roadmap/Roadmap v6 Addendum.md",
+        "source_anchor": "Section 5 Proposed Repo Structure",
+        "phase": "addendum_1",
+        "addendum_link": "addendum_1",
+        "statement": (
+            "Diagnostic and external-intelligence information must "
+            "live in sidecar artifacts. Do not mutate "
+            "research_latest.json or strategy_matrix.csv."
+        ),
+        "target_layer": "evidence",
+        "status": "not_started",
+    },
+    # ---- Addendum 1 — Diagnostic families (Section 6 + 7) --------------
+    {
+        "id": "req_addendum_1_tail_power_law",
+        "roadmap_task_id": "addendum_1_diagnostics_intake",
+        "source_document": "docs/roadmap/Roadmap v6 Addendum.md",
+        "source_anchor": "Section 6.2.A Power Laws",
+        "phase": "addendum_1",
+        "addendum_link": "addendum_1",
+        "statement": (
+            "Tail / power-law diagnostics: return tail exponent, "
+            "drawdown tail exponent, tail asymmetry, expected "
+            "shortfall proxy, outlier dependency flag. Tail evidence "
+            "may support a hypothesis; it may not directly promote a "
+            "candidate."
+        ),
+        "target_layer": "diagnostics",
+        "status": "not_started",
+    },
+    {
+        "id": "req_addendum_1_entropy_information_density",
+        "roadmap_task_id": "addendum_1_diagnostics_intake",
+        "source_document": "docs/roadmap/Roadmap v6 Addendum.md",
+        "source_anchor": "Section 6.2.B Entropy",
+        "phase": "addendum_1",
+        "addendum_link": "addendum_1",
+        "statement": (
+            "Entropy / information-density diagnostics: Shannon and "
+            "approximate entropy of returns / signals, entropy regime "
+            "classification, market orderliness, information density. "
+            "Used as a routing / policy state, not as a directional "
+            "signal."
+        ),
+        "target_layer": "diagnostics",
+        "status": "not_started",
+    },
+    {
+        "id": "req_addendum_1_criticality_phase_transitions",
+        "roadmap_task_id": "addendum_1_diagnostics_intake",
+        "source_document": "docs/roadmap/Roadmap v6 Addendum.md",
+        "source_anchor": "Section 6.2.C Phase Transitions / Criticality",
+        "phase": "addendum_1",
+        "addendum_link": "addendum_1",
+        "statement": (
+            "Criticality / phase-transition diagnostics: autocorrelation "
+            "drift, variance increase, critical slowing down, regime "
+            "switch warnings. May trigger caution or segmentation; "
+            "must not predict crashes as deterministic events."
+        ),
+        "target_layer": "diagnostics",
+        "status": "not_started",
+    },
+    {
+        "id": "req_addendum_1_barrier_breakout_pressure",
+        "roadmap_task_id": "addendum_1_diagnostics_intake",
+        "source_document": "docs/roadmap/Roadmap v6 Addendum.md",
+        "source_anchor": "Section 6.2.D Barrier / Tunneling",
+        "phase": "addendum_1",
+        "addendum_link": "addendum_1",
+        "statement": (
+            "Barrier / breakout-pressure diagnostics: probabilistic "
+            "barrier crossing, range escape, post-breakout decay, "
+            "failed-breakout rate. Seed breakout hypotheses; do not "
+            "create deterministic support / resistance rules."
+        ),
+        "target_layer": "diagnostics",
+        "status": "not_started",
+    },
+    {
+        "id": "req_addendum_1_resonance_cycle",
+        "roadmap_task_id": "addendum_1_diagnostics_intake",
+        "source_document": "docs/roadmap/Roadmap v6 Addendum.md",
+        "source_anchor": "Section 6.2.E Resonance / Harmonic Oscillators",
+        "phase": "addendum_1",
+        "addendum_link": "addendum_1",
+        "statement": (
+            "Resonance / cycle diagnostics: dominant cycle period, "
+            "cycle stability, resonance confluence, window alignment. "
+            "Cycle fit must be checked against null models; no "
+            "cycle-equals-alpha assumption."
+        ),
+        "target_layer": "diagnostics",
+        "status": "not_started",
+    },
+    {
+        "id": "req_addendum_1_null_model_brownian",
+        "roadmap_task_id": "addendum_1_diagnostics_intake",
+        "source_document": "docs/roadmap/Roadmap v6 Addendum.md",
+        "source_anchor": "Section 6.2.F Brownian / Random Walk / Null Models",
+        "phase": "addendum_1",
+        "addendum_link": "addendum_1",
+        "statement": (
+            "Null-model / Brownian / random-walk diagnostics: "
+            "shuffled-return tests, surrogate data tests, "
+            "noise-baseline excess return, false-discovery warnings. "
+            "Every exotic diagnostic must eventually face a "
+            "null-model challenge."
+        ),
+        "target_layer": "evidence",
+        "status": "not_started",
+    },
+    {
+        "id": "req_addendum_1_network_diagnostics",
+        "roadmap_task_id": "addendum_1_diagnostics_intake",
+        "source_document": "docs/roadmap/Roadmap v6 Addendum.md",
+        "source_anchor": "Section 7.2 Network Theory",
+        "phase": "addendum_1",
+        "addendum_link": "addendum_1",
+        "statement": (
+            "Network diagnostics: correlation networks, minimum "
+            "spanning trees, asset clustering, contagion, cross-asset "
+            "lead / lag, network fragility, diversification breakdown. "
+            "Used for behavior hypotheses and portfolio research, not "
+            "live allocation."
+        ),
+        "target_layer": "diagnostics",
+        "status": "not_started",
+    },
+    {
+        "id": "req_addendum_1_adversarial_market_behavior",
+        "roadmap_task_id": "addendum_1_diagnostics_intake",
+        "source_document": "docs/roadmap/Roadmap v6 Addendum.md",
+        "source_anchor": "Section 7.4 Game Theory",
+        "phase": "addendum_1",
+        "addendum_link": "addendum_1",
+        "statement": (
+            "Adversarial market-behavior diagnostics: crowding, "
+            "adverse selection, fake-breakout rate, post-signal decay, "
+            "liquidity-trap and predatory-regime warnings. Used to "
+            "model adversarial market structure, not to randomize the "
+            "QRE."
+        ),
+        "target_layer": "diagnostics",
+        "status": "not_started",
+    },
+    {
+        "id": "req_addendum_1_control_stability",
+        "roadmap_task_id": "addendum_1_diagnostics_intake",
+        "source_document": "docs/roadmap/Roadmap v6 Addendum.md",
+        "source_anchor": "Section 7.3 Control Theory",
+        "phase": "addendum_1",
+        "addendum_link": "addendum_1",
+        "statement": (
+            "Control-stability diagnostics: policy stability, evidence "
+            "drift, signal-density drift, control oscillation, "
+            "degradation rate, throttle recommendation. Not allowed "
+            "now: PID position sizing, automatic exposure increase, "
+            "equity-curve chasing, live risk mutation."
+        ),
+        "target_layer": "policy",
+        "status": "not_started",
+    },
+    {
+        "id": "req_addendum_1_seismic_aftershock",
+        "roadmap_task_id": "addendum_1_diagnostics_intake",
+        "source_document": "docs/roadmap/Roadmap v6 Addendum.md",
+        "source_anchor": "Section 7.6 Seismology / Aftershock Modeling",
+        "phase": "addendum_1",
+        "addendum_link": "addendum_1",
+        "statement": (
+            "Seismic shock / aftershock diagnostics: mainshock "
+            "detection, shock magnitude, aftershock decay rate, "
+            "volatility half-life, shock-cluster intensity, "
+            "post-shock directional bias, cooldown recommendation. "
+            "Models shock processes; does not deterministically "
+            "predict crashes."
+        ),
+        "target_layer": "diagnostics",
+        "status": "not_started",
+    },
+    {
+        "id": "req_addendum_1_liquidity_turbulence",
+        "roadmap_task_id": "addendum_1_diagnostics_intake",
+        "source_document": "docs/roadmap/Roadmap v6 Addendum.md",
+        "source_anchor": "Section 7.8 Fluid Dynamics / Turbulence",
+        "phase": "addendum_1",
+        "addendum_link": "addendum_1",
+        "statement": (
+            "Liquidity-turbulence diagnostics: liquidity turbulence "
+            "score, slippage convexity proxy, flow-break risk, "
+            "order-size stress score. Informs research and shadow / "
+            "paper / live realism in their future approved phases; "
+            "does not directly trade."
+        ),
+        "target_layer": "diagnostics",
+        "status": "not_started",
+    },
+    {
+        "id": "req_addendum_1_independent_evidence_quorum",
+        "roadmap_task_id": "addendum_1_diagnostics_intake",
+        "source_document": "docs/roadmap/Roadmap v6 Addendum.md",
+        "source_anchor": "Section 7.9 Biomimicry / Quorum Sensing",
+        "phase": "addendum_1",
+        "addendum_link": "addendum_1",
+        "statement": (
+            "Independent evidence quorum: independent confirmations, "
+            "required confirmations, quorum status, confirmation "
+            "diversity score, single-source dependency flag. Quorum "
+            "sensing is a promotion / evidence guardrail, not a live "
+            "trade trigger."
+        ),
+        "target_layer": "evidence",
+        "status": "not_started",
+    },
+    {
+        "id": "req_addendum_1_market_language",
+        "roadmap_task_id": "addendum_1_diagnostics_intake",
+        "source_document": "docs/roadmap/Roadmap v6 Addendum.md",
+        "source_anchor": "Section 7.10 Linguistics / Information Foraging",
+        "phase": "addendum_1",
+        "addendum_link": "addendum_1",
+        "statement": (
+            "Market-language diagnostics: token entropy, Zipf slope, "
+            "sequence rarity, grammar shift, vocabulary collapse. "
+            "Must be null-model tested. Not candle folklore; no "
+            "rare-pattern-equals-alpha assumption."
+        ),
+        "target_layer": "diagnostics",
+        "status": "not_started",
+    },
+    # ---- Addendum 1 — External intelligence intake ---------------------
+    {
+        "id": "req_addendum_1_external_intelligence_intake",
+        "roadmap_task_id": "addendum_1_diagnostics_intake",
+        "source_document": "docs/roadmap/Roadmap v6 Addendum.md",
+        "source_anchor": "Section 8 External Intelligence Intake",
+        "phase": "addendum_1",
+        "addendum_link": "addendum_1",
+        "statement": (
+            "External intelligence intake from public / free data "
+            "sources only: Yahoo / yfinance, Stooq, Binance public "
+            "klines, Bitvavo public candles, CoinGecko free, FRED, "
+            "SEC EDGAR. No paid feeds, no vendor alpha, no commercial "
+            "signal libraries, no private alternative-data vendors."
+        ),
+        "target_layer": "external_intelligence",
+        "status": "not_started",
+    },
+    {
+        "id": "req_addendum_1_public_source_manifest_fields",
+        "roadmap_task_id": "addendum_1_diagnostics_intake",
+        "source_document": "docs/roadmap/Roadmap v6 Addendum.md",
+        "source_anchor": "Section 8.4 Source Manifest Fields",
+        "phase": "addendum_1",
+        "addendum_link": "addendum_1",
+        "statement": (
+            "Each public-source manifest must declare: source_id, "
+            "source_type, access_method, expected_latency, "
+            "expected_freshness, asset_coverage, timeframe_coverage, "
+            "allowed_use, known_limitations, license_terms_reference, "
+            "reproducibility_method, quality_gates."
+        ),
+        "target_layer": "external_intelligence",
+        "status": "not_started",
+    },
+    {
+        "id": "req_addendum_1_public_data_quality_gates",
+        "roadmap_task_id": "addendum_1_diagnostics_intake",
+        "source_document": "docs/roadmap/Roadmap v6 Addendum.md",
+        "source_anchor": "Section 8.5 Public Data Quality Gates",
+        "phase": "addendum_1",
+        "addendum_link": "addendum_1",
+        "statement": (
+            "Required public-data quality gates: freshness, missing "
+            "data, timestamp monotonicity, duplicate bar, outlier, "
+            "coverage, source-agreement where possible, and "
+            "license / terms metadata. No hypothesis seed may be "
+            "promoted from public data without passing these checks."
+        ),
+        "target_layer": "external_intelligence",
+        "status": "not_started",
+    },
+    # ---- Roadmap v6 — phase v3.15.16 -----------------------------------
+    {
+        "id": "req_v3_15_16_behavior_aware_routing",
+        "roadmap_task_id": "phase_v3_15_16",
+        "source_document": "docs/roadmap/Roadmap v6.md",
+        "source_anchor": "v3.15.16 Intelligent Routing Layer",
+        "phase": "v3.15.16",
+        "addendum_link": "none",
+        "statement": (
+            "Replace preset-count-aware campaign routing with "
+            "behavior-aware routing that prioritizes the most "
+            "informative exploration, with orthogonality-aware queue "
+            "discipline and dead-zone-aware suppression."
+        ),
+        "target_layer": "campaign",
+        "status": "not_started",
+    },
+    {
+        "id": "req_v3_15_16_diagnostic_aware_routing",
+        "roadmap_task_id": "phase_v3_15_16",
+        "source_document": "docs/roadmap/Roadmap v6 Addendum.md",
+        "source_anchor": "Section 9 v3.15.16 Intelligent Routing Layer",
+        "phase": "v3.15.16",
+        "addendum_link": "addendum_1",
+        "statement": (
+            "Add diagnostic-aware routing signals: entropy-aware, "
+            "tail-aware, criticality-aware, network-aware, "
+            "quorum-aware, external-intelligence-aware, and "
+            "dead-zone suppression by diagnostic failure. Routing "
+            "remains deterministic, inspectable, and artifact-backed."
+        ),
+        "target_layer": "campaign",
+        "status": "not_started",
+    },
+    # ---- Roadmap v6 — phase v3.15.17 -----------------------------------
+    {
+        "id": "req_v3_15_17_deterministic_sampling",
+        "roadmap_task_id": "phase_v3_15_17",
+        "source_document": "docs/roadmap/Roadmap v6.md",
+        "source_anchor": "v3.15.17 Sampling Intelligence",
+        "phase": "v3.15.17",
+        "addendum_link": "none",
+        "statement": (
+            "Introduce stratified, adaptive deterministic coverage; "
+            "low-information-region suppression; exploratory breadth "
+            "balancing; signal-density-aware sampling. Replace "
+            "brute-force parameter grids with high-information "
+            "exploration."
+        ),
+        "target_layer": "preset",
+        "status": "not_started",
+    },
+    {
+        "id": "req_v3_15_17_diagnostic_aware_sampling",
+        "roadmap_task_id": "phase_v3_15_17",
+        "source_document": "docs/roadmap/Roadmap v6 Addendum.md",
+        "source_anchor": "Section 9 v3.15.17 Sampling Intelligence",
+        "phase": "v3.15.17",
+        "addendum_link": "addendum_1",
+        "statement": (
+            "Add tail-aware, entropy-stratified, "
+            "phase-transition-zone, barrier-condition, "
+            "resonance-window, network-regime, post-shock, and "
+            "null-model control sampling. Sampling must remain "
+            "deterministic and reproducible."
+        ),
+        "target_layer": "preset",
+        "status": "not_started",
+    },
+    # ---- Roadmap v6 — phase v3.15.18 -----------------------------------
+    {
+        "id": "req_v3_15_18_research_observability",
+        "roadmap_task_id": "phase_v3_15_18",
+        "source_document": "docs/roadmap/Roadmap v6.md",
+        "source_anchor": "v3.15.18 Research Observability Expansion",
+        "phase": "v3.15.18",
+        "addendum_link": "none",
+        "statement": (
+            "Expose behavior-level diagnostics, exploration lineage, "
+            "campaign decomposition, hypothesis traceability, "
+            "information-gain surfaces, explanation artifacts, and "
+            "failure-clustering visibility. Read-only; no mutation "
+            "endpoints."
+        ),
+        "target_layer": "reporting",
+        "status": "not_started",
+    },
+    {
+        "id": "req_v3_15_18_diagnostic_surfaces",
+        "roadmap_task_id": "phase_v3_15_18",
+        "source_document": "docs/roadmap/Roadmap v6 Addendum.md",
+        "source_anchor": "Section 9 v3.15.18 Research Observability Expansion",
+        "phase": "v3.15.18",
+        "addendum_link": "addendum_1",
+        "statement": (
+            "Expose read-only surfaces for diagnostic contribution "
+            "explanation, external data lineage, public data quality "
+            "status, hypothesis-seed provenance, null-model "
+            "comparison, quorum status, network state, and the "
+            "entropy / tail / criticality regime."
+        ),
+        "target_layer": "reporting",
+        "status": "not_started",
+    },
+    # ---- Roadmap v6 — phase v3.15.19 -----------------------------------
+    {
+        "id": "req_v3_15_19_hypothesis_discovery_modules",
+        "roadmap_task_id": "phase_v3_15_19",
+        "source_document": "docs/roadmap/Roadmap v6.md",
+        "source_anchor": "v3.15.19 Hypothesis Discovery Engine",
+        "phase": "v3.15.19",
+        "addendum_link": "none",
+        "statement": (
+            "Introduce research/hypothesis_discovery/ with "
+            "behavior_catalog, behavior_hypotheses, "
+            "opportunity_scoring, preset_feasibility, and "
+            "campaign_seed_proposer. Reason in market behaviors, not "
+            "indicator combinations. Deterministic, inspectable, "
+            "non-black-box."
+        ),
+        "target_layer": "hypothesis_discovery",
+        "status": "not_started",
+    },
+    {
+        "id": "req_v3_15_19_opportunity_probability_score",
+        "roadmap_task_id": "phase_v3_15_19",
+        "source_document": "docs/roadmap/Roadmap v6.md",
+        "source_anchor": "v3.15.19 Probability Scoring",
+        "phase": "v3.15.19",
+        "addendum_link": "none",
+        "statement": (
+            "opportunity_probability_score is expected research "
+            "value: feasibility, expected signal density, "
+            "orthogonality, prior evidence alignment, regime "
+            "compatibility, information gain, compute efficiency, "
+            "historical survival similarity. It is NOT prediction "
+            "certainty, alpha certainty, or ML confidence."
+        ),
+        "target_layer": "hypothesis_discovery",
+        "status": "not_started",
+    },
+    {
+        "id": "req_v3_15_19_addendum_modules",
+        "roadmap_task_id": "phase_v3_15_19",
+        "source_document": "docs/roadmap/Roadmap v6 Addendum.md",
+        "source_anchor": "Section 9 v3.15.19 Hypothesis Discovery Engine",
+        "phase": "v3.15.19",
+        "addendum_link": "addendum_1",
+        "statement": (
+            "Extend hypothesis-discovery modules with "
+            "external_intelligence_catalog, public_data_seed_registry, "
+            "physics_behavior_catalog, mechanistic_behavior_catalog, "
+            "and diagnostic_hypothesis_adapter. No auto-writing of "
+            "executable strategies; no hidden AI logic."
+        ),
+        "target_layer": "hypothesis_discovery",
+        "status": "not_started",
+    },
+    # ---- Roadmap v6 — phase v3.15.20 -----------------------------------
+    {
+        "id": "req_v3_15_20_failure_action_mappings",
+        "roadmap_task_id": "phase_v3_15_20",
+        "source_document": "docs/roadmap/Roadmap v6.md",
+        "source_anchor": "v3.15.20 Failure to Action Mapping",
+        "phase": "v3.15.20",
+        "addendum_link": "none",
+        "statement": (
+            "Convert failures into deterministic actions. Base "
+            "mappings: insufficient_trades -> higher timeframe; "
+            "high_drawdown -> volatility normalization; "
+            "weak_stability -> regime segmentation."
+        ),
+        "target_layer": "policy",
+        "status": "not_started",
+    },
+    {
+        "id": "req_v3_15_20_addendum_mappings",
+        "roadmap_task_id": "phase_v3_15_20",
+        "source_document": "docs/roadmap/Roadmap v6 Addendum.md",
+        "source_anchor": "Section 9 v3.15.20 Failure to Action Mapping",
+        "phase": "v3.15.20",
+        "addendum_link": "addendum_1",
+        "statement": (
+            "Add deterministic Addendum 1 mappings: high_entropy, "
+            "weak_tail_fit, left_tail_fragility, "
+            "phase_transition_unstable, barrier_false_positive_high, "
+            "resonance_not_persistent, network_concentration_high, "
+            "post_shock_aftershock_unstable, "
+            "liquidity_turbulence_high, quorum_insufficient, "
+            "null_model_not_beaten. Mappings affect research routing / "
+            "suppression / cooldown only; never trade execution."
+        ),
+        "target_layer": "policy",
+        "status": "not_started",
+    },
+)
+
+
+# ---------------------------------------------------------------------------
+# Utility helpers
+# ---------------------------------------------------------------------------
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _bounded_str(value: Any, max_len: int) -> str:
+    if not isinstance(value, str):
+        return ""
+    if len(value) <= max_len:
+        return value
+    return value[:max_len]
+
+
+def _normalize_task(raw: dict[str, Any]) -> dict[str, Any]:
+    """Project a seed task tuple into a schema-conformant dict.
+
+    All free-text fields are bounded; tuples are coerced to sorted
+    lists with stable order; closed-vocab fields are echoed verbatim.
+    Schema integrity is enforced by tests, not by silent coercion.
+    """
+    return {
+        "id": _bounded_str(raw["id"], MAX_ID_LEN),
+        "title": _bounded_str(raw["title"], MAX_TITLE_LEN),
+        "phase": raw["phase"],
+        "source_documents": sorted(raw["source_documents"]),
+        "purpose": _bounded_str(raw["purpose"], MAX_PURPOSE_LEN),
+        "status": raw["status"],
+        "prerequisites": sorted(raw["prerequisites"]),
+    }
+
+
+def _normalize_requirement(raw: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": _bounded_str(raw["id"], MAX_ID_LEN),
+        "roadmap_task_id": _bounded_str(raw["roadmap_task_id"], MAX_ID_LEN),
+        "source_document": raw["source_document"],
+        "source_anchor": _bounded_str(raw["source_anchor"], MAX_ANCHOR_LEN),
+        "phase": raw["phase"],
+        "addendum_link": raw["addendum_link"],
+        "statement": _bounded_str(raw["statement"], MAX_STATEMENT_LEN),
+        "target_layer": raw["target_layer"],
+        "status": raw["status"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Snapshot assembly
+# ---------------------------------------------------------------------------
+
+
+def collect_snapshot(
+    *,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    """Build the deterministic Roadmap v6 task catalog projection.
+
+    Args:
+        generated_at_utc: override the wrapper's report timestamp.
+            Tests inject this for byte-stable output.
+    """
+    ts = generated_at_utc if generated_at_utc is not None else _utcnow()
+
+    tasks = [_normalize_task(t) for t in _ROADMAP_TASKS_SEED]
+    tasks.sort(key=lambda r: (r["phase"], r["id"]))
+
+    requirements = [_normalize_requirement(r) for r in _ROADMAP_REQUIREMENTS_SEED]
+    requirements.sort(key=lambda r: (r["phase"], r["id"]))
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": ts,
+        "step5_enabled_substage": STEP5_ENABLED_SUBSTAGE,
+        "step5_implementation_allowed": step5_implementation_allowed,
+        "execution_authority_module_version": ea.MODULE_VERSION,
+        "vocabularies": {
+            "phase": list(PHASE),
+            "source_document": list(SOURCE_DOCUMENT),
+            "status": list(STATUS),
+            "addendum_link": list(ADDENDUM_LINK),
+            "target_layer": list(TARGET_LAYER),
+        },
+        "roadmap_tasks": tasks,
+        "roadmap_requirements": requirements,
+        "discipline_invariants": dict(_DISCIPLINE_INVARIANTS),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Atomic write
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Write ``payload`` as sorted-key indented JSON to ``path``,
+    atomically, refusing any path outside ``logs/roadmap_task_catalog/``."""
+    posix = path.as_posix()
+    if _WRITE_PREFIX not in posix:
+        raise ValueError(
+            "roadmap_task_catalog._atomic_write_json refuses "
+            f"non-catalog-logs output path: {path}"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".roadmap_task_catalog.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_outputs(snapshot: dict[str, Any]) -> Path:
+    _atomic_write_json(ARTIFACT_LATEST, snapshot)
+    return ARTIFACT_LATEST
+
+
+# ---------------------------------------------------------------------------
+# Status renderer
+# ---------------------------------------------------------------------------
+
+
+def _render_status(snapshot: dict[str, Any]) -> str:
+    """Render a compact, human-readable status string. Deterministic."""
+    tasks = snapshot["roadmap_tasks"]
+    reqs = snapshot["roadmap_requirements"]
+    inv = snapshot["discipline_invariants"]
+    lines = [
+        f"roadmap_task_catalog {snapshot['module_version']} "
+        f"schema={snapshot['schema_version']}",
+        f"generated_at_utc={snapshot['generated_at_utc']}",
+        f"roadmap_tasks={len(tasks)} roadmap_requirements={len(reqs)}",
+        (
+            "step5_implementation_allowed="
+            f"{snapshot['step5_implementation_allowed']} "
+            f"step5_enabled_substage={snapshot['step5_enabled_substage']}"
+        ),
+        (
+            "addendum_2_not_present="
+            f"{inv['addendum_2_not_present']} "
+            "addendum_3_not_present="
+            f"{inv['addendum_3_not_present']}"
+        ),
+        (
+            "diagnostics_do_not_trade="
+            f"{inv['diagnostics_do_not_trade']} "
+            "external_data_is_not_alpha="
+            f"{inv['external_data_is_not_alpha']}"
+        ),
+    ]
+    for t in tasks:
+        lines.append(
+            f"  task {t['id']} phase={t['phase']} status={t['status']}"
+        )
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m reporting.roadmap_task_catalog",
+        description=(
+            "A20a Static Roadmap v6 Task Catalog Seed. Read-only "
+            "deterministic seed for v3.15.16..v3.15.20 plus Addendum 1. "
+            "Addendum 2 / Addendum 3 are absent from the repo and "
+            "represented only as absence flags. This catalog grants no "
+            "implementation, runtime, trading, paper, shadow, broker, "
+            "risk, or live authority. Step 5 implementation remains "
+            "BLOCKED."
+        ),
+    )
+    p.add_argument(
+        "--indent",
+        type=int,
+        default=2,
+        help="JSON indent for stdout output (0 for compact).",
+    )
+    p.add_argument(
+        "--no-write",
+        action="store_true",
+        help=(
+            "Do not persist logs/roadmap_task_catalog/latest.json "
+            "(stdout only)."
+        ),
+    )
+    p.add_argument(
+        "--status",
+        action="store_true",
+        help=(
+            "Render a compact human-readable status summary to stdout "
+            "and exit. Does not write any artefact."
+        ),
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    snap = collect_snapshot()
+    if args.status:
+        sys.stdout.write(_render_status(snap))
+        return 0
+    indent = args.indent if args.indent and args.indent > 0 else None
+    if not args.no_write:
+        write_outputs(snap)
+    json.dump(snap, sys.stdout, indent=indent, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/unit/test_roadmap_task_catalog.py
+++ b/tests/unit/test_roadmap_task_catalog.py
@@ -1,0 +1,734 @@
+"""Unit tests for A20a — Static Roadmap v6 Task Catalog Seed.
+
+Pins:
+
+* closed vocabularies (PHASE, SOURCE_DOCUMENT, STATUS, ADDENDUM_LINK,
+  TARGET_LAYER);
+* schema integrity (RoadmapTask, RoadmapRequirement,
+  TaskCatalogProjection fields);
+* deterministic output with injected generated_at_utc;
+* byte-identical output for identical input;
+* atomic write only allowed under logs/roadmap_task_catalog/;
+* --no-write does not write;
+* --status prints a compact human-readable summary and writes
+  nothing;
+* Addendum 2 / Addendum 3 absence flags are present and true;
+* all v3.15.16..v3.15.20 phase tasks exist;
+* Addendum 1 cross-cutting task exists;
+* Addendum 1 diagnostic families are represented;
+* no forbidden imports or forbidden tokens appear in the module
+  source.
+"""
+
+from __future__ import annotations
+
+import importlib
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from reporting import roadmap_task_catalog as rtc
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+_FROZEN_UTC = "2026-05-17T12:00:00Z"
+
+
+@pytest.fixture
+def snap() -> dict:
+    return rtc.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies
+# ---------------------------------------------------------------------------
+
+
+def test_phase_vocabulary_is_closed_and_complete() -> None:
+    assert rtc.PHASE == (
+        "v3.15.16",
+        "v3.15.17",
+        "v3.15.18",
+        "v3.15.19",
+        "v3.15.20",
+        "addendum_1",
+        "addendum_2",
+        "addendum_3",
+    )
+
+
+def test_source_document_vocabulary_excludes_absent_addenda() -> None:
+    # Addendum 2 and Addendum 3 files are NOT in the repo. They must
+    # NOT appear in SOURCE_DOCUMENT until those files land.
+    assert rtc.SOURCE_DOCUMENT == (
+        "docs/roadmap/Roadmap v6.md",
+        "docs/roadmap/Roadmap v6 Addendum.md",
+        "docs/roadmap/qre_roadmap_v6_ade_operating_manual.md",
+        "docs/roadmap/qre_roadmap_v6_phase_prompts.md",
+    )
+    for entry in rtc.SOURCE_DOCUMENT:
+        assert "addendum 2" not in entry.lower()
+        assert "addendum 3" not in entry.lower()
+
+
+def test_status_vocabulary_is_closed() -> None:
+    assert rtc.STATUS == (
+        "not_started",
+        "ready",
+        "in_flight",
+        "merged",
+        "blocked",
+        "human_needed",
+        "permanently_denied",
+    )
+
+
+def test_addendum_link_vocabulary_is_closed() -> None:
+    assert rtc.ADDENDUM_LINK == (
+        "addendum_1",
+        "addendum_2",
+        "addendum_3",
+        "none",
+    )
+
+
+def test_target_layer_vocabulary_is_closed() -> None:
+    assert rtc.TARGET_LAYER == (
+        "external_intelligence",
+        "diagnostics",
+        "market_behavior",
+        "hypothesis_discovery",
+        "strategy_mapping",
+        "preset",
+        "campaign",
+        "funnel",
+        "evidence",
+        "policy",
+        "shadow",
+        "paper",
+        "live",
+        "reporting",
+        "governance",
+        "docs",
+        "test",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Schema integrity
+# ---------------------------------------------------------------------------
+
+
+def test_roadmap_task_field_list_exact() -> None:
+    assert rtc.ROADMAP_TASK_FIELDS == (
+        "id",
+        "title",
+        "phase",
+        "source_documents",
+        "purpose",
+        "status",
+        "prerequisites",
+    )
+
+
+def test_roadmap_requirement_field_list_exact() -> None:
+    assert rtc.ROADMAP_REQUIREMENT_FIELDS == (
+        "id",
+        "roadmap_task_id",
+        "source_document",
+        "source_anchor",
+        "phase",
+        "addendum_link",
+        "statement",
+        "target_layer",
+        "status",
+    )
+
+
+def test_task_catalog_projection_field_list_exact() -> None:
+    assert rtc.TASK_CATALOG_PROJECTION_FIELDS == (
+        "generated_at_utc",
+        "schema_version",
+        "module_version",
+        "roadmap_tasks",
+        "roadmap_requirements",
+        "discipline_invariants",
+    )
+
+
+def test_every_task_has_every_field(snap: dict) -> None:
+    for task in snap["roadmap_tasks"]:
+        assert set(task.keys()) == set(rtc.ROADMAP_TASK_FIELDS), task
+
+
+def test_every_requirement_has_every_field(snap: dict) -> None:
+    for req in snap["roadmap_requirements"]:
+        assert set(req.keys()) == set(rtc.ROADMAP_REQUIREMENT_FIELDS), req
+
+
+def test_projection_carries_every_required_top_level_field(snap: dict) -> None:
+    for field in rtc.TASK_CATALOG_PROJECTION_FIELDS:
+        assert field in snap, field
+
+
+# ---------------------------------------------------------------------------
+# Closed-vocab compliance on the encoded data
+# ---------------------------------------------------------------------------
+
+
+def test_every_task_phase_is_in_phase_vocab(snap: dict) -> None:
+    for task in snap["roadmap_tasks"]:
+        assert task["phase"] in rtc.PHASE
+
+
+def test_every_task_status_is_in_status_vocab(snap: dict) -> None:
+    for task in snap["roadmap_tasks"]:
+        assert task["status"] in rtc.STATUS
+
+
+def test_every_task_source_document_is_in_source_vocab(snap: dict) -> None:
+    for task in snap["roadmap_tasks"]:
+        for src in task["source_documents"]:
+            assert src in rtc.SOURCE_DOCUMENT
+
+
+def test_every_requirement_phase_is_in_phase_vocab(snap: dict) -> None:
+    for req in snap["roadmap_requirements"]:
+        assert req["phase"] in rtc.PHASE
+
+
+def test_every_requirement_source_document_is_in_source_vocab(
+    snap: dict,
+) -> None:
+    for req in snap["roadmap_requirements"]:
+        assert req["source_document"] in rtc.SOURCE_DOCUMENT
+
+
+def test_every_requirement_addendum_link_is_in_vocab(snap: dict) -> None:
+    for req in snap["roadmap_requirements"]:
+        assert req["addendum_link"] in rtc.ADDENDUM_LINK
+
+
+def test_every_requirement_target_layer_is_in_vocab(snap: dict) -> None:
+    for req in snap["roadmap_requirements"]:
+        assert req["target_layer"] in rtc.TARGET_LAYER
+
+
+def test_every_requirement_status_is_in_status_vocab(snap: dict) -> None:
+    for req in snap["roadmap_requirements"]:
+        assert req["status"] in rtc.STATUS
+
+
+def test_every_requirement_references_a_known_task(snap: dict) -> None:
+    task_ids = {t["id"] for t in snap["roadmap_tasks"]}
+    for req in snap["roadmap_requirements"]:
+        assert req["roadmap_task_id"] in task_ids, req["id"]
+
+
+def test_task_prerequisites_reference_known_tasks(snap: dict) -> None:
+    task_ids = {t["id"] for t in snap["roadmap_tasks"]}
+    for task in snap["roadmap_tasks"]:
+        for prereq in task["prerequisites"]:
+            assert prereq in task_ids, (task["id"], prereq)
+
+
+# ---------------------------------------------------------------------------
+# Phase-task coverage
+# ---------------------------------------------------------------------------
+
+
+def _tasks_by_phase(snap: dict) -> dict[str, dict]:
+    return {t["phase"]: t for t in snap["roadmap_tasks"]}
+
+
+def test_phase_v3_15_16_task_present(snap: dict) -> None:
+    t = _tasks_by_phase(snap)["v3.15.16"]
+    assert t["id"] == "phase_v3_15_16"
+    assert "Intelligent Routing Layer" in t["title"]
+
+
+def test_phase_v3_15_17_task_present(snap: dict) -> None:
+    t = _tasks_by_phase(snap)["v3.15.17"]
+    assert t["id"] == "phase_v3_15_17"
+    assert "Sampling Intelligence" in t["title"]
+
+
+def test_phase_v3_15_18_task_present(snap: dict) -> None:
+    t = _tasks_by_phase(snap)["v3.15.18"]
+    assert t["id"] == "phase_v3_15_18"
+    assert "Observability" in t["title"]
+
+
+def test_phase_v3_15_19_task_present(snap: dict) -> None:
+    t = _tasks_by_phase(snap)["v3.15.19"]
+    assert t["id"] == "phase_v3_15_19"
+    assert "Hypothesis Discovery" in t["title"]
+
+
+def test_phase_v3_15_20_task_present(snap: dict) -> None:
+    t = _tasks_by_phase(snap)["v3.15.20"]
+    assert t["id"] == "phase_v3_15_20"
+    # Title intentionally uses ASCII 'to' to keep the artefact ASCII-clean.
+    assert "Failure" in t["title"] and "Action Mapping" in t["title"]
+
+
+def test_addendum_1_task_present(snap: dict) -> None:
+    t = _tasks_by_phase(snap)["addendum_1"]
+    assert t["id"] == "addendum_1_diagnostics_intake"
+    assert "Diagnostics" in t["title"] or "diagnostics" in t["title"]
+    assert "External Intelligence Intake" in t["title"]
+
+
+def test_addendum_2_and_3_have_no_tasks(snap: dict) -> None:
+    phases = {t["phase"] for t in snap["roadmap_tasks"]}
+    assert "addendum_2" not in phases
+    assert "addendum_3" not in phases
+
+
+def test_v3_15_16_to_v3_15_20_all_present_in_order(snap: dict) -> None:
+    phases = [t["phase"] for t in snap["roadmap_tasks"]]
+    for expected in (
+        "v3.15.16",
+        "v3.15.17",
+        "v3.15.18",
+        "v3.15.19",
+        "v3.15.20",
+    ):
+        assert expected in phases
+
+
+# ---------------------------------------------------------------------------
+# Addendum 1 diagnostic-family coverage
+# ---------------------------------------------------------------------------
+
+
+def _addendum1_requirements(snap: dict) -> list[dict]:
+    return [r for r in snap["roadmap_requirements"] if r["phase"] == "addendum_1"]
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [
+        "tail",
+        "entropy",
+        "criticality",
+        "barrier",
+        "resonance",
+        "null-model",
+        "network",
+        "adversarial",
+        "control-stability",
+        "seismic",
+        "liquidity-turbulence",
+        "quorum",
+        "market-language",
+        "external-intelligence",
+        "manifest",
+        "quality gate",
+        "diagnostics do not trade",
+        "not alpha",
+        "sidecar",
+    ],
+)
+def test_addendum_1_diagnostic_family_present(snap: dict, marker: str) -> None:
+    # Normalize hyphens / spaces for a tolerant substring check across
+    # statements + ids.
+    blob = " ".join(
+        (r["id"] + " " + r["statement"]).lower().replace("_", "-")
+        for r in _addendum1_requirements(snap)
+    )
+    needle = marker.lower().replace("_", "-")
+    assert needle in blob, marker
+
+
+def test_addendum_1_has_at_least_one_requirement_per_family(snap: dict) -> None:
+    assert len(_addendum1_requirements(snap)) >= 13
+
+
+# ---------------------------------------------------------------------------
+# Step 5 / Level 6 invariants
+# ---------------------------------------------------------------------------
+
+
+def test_step5_implementation_allowed_is_false() -> None:
+    assert rtc.step5_implementation_allowed is False
+
+
+def test_step5_enabled_substage_is_none_literal() -> None:
+    assert rtc.STEP5_ENABLED_SUBSTAGE == "none"
+
+
+def test_projection_carries_step5_invariants(snap: dict) -> None:
+    assert snap["step5_implementation_allowed"] is False
+    assert snap["step5_enabled_substage"] == "none"
+
+
+def test_discipline_invariants_have_addendum_absence_flags(snap: dict) -> None:
+    inv = snap["discipline_invariants"]
+    assert inv["addendum_2_not_present"] is True
+    assert inv["addendum_3_not_present"] is True
+
+
+def test_discipline_invariants_pin_no_runtime_authority(snap: dict) -> None:
+    inv = snap["discipline_invariants"]
+    for key in (
+        "grants_runtime_authority",
+        "grants_trading_authority",
+        "grants_paper_authority",
+        "grants_shadow_authority",
+        "grants_broker_authority",
+        "grants_risk_authority",
+        "grants_live_authority",
+    ):
+        assert inv[key] is False, key
+
+
+def test_discipline_invariants_pin_diagnostics_do_not_trade(snap: dict) -> None:
+    inv = snap["discipline_invariants"]
+    assert inv["diagnostics_do_not_trade"] is True
+    assert inv["external_data_is_not_alpha"] is True
+
+
+def test_discipline_invariants_pin_no_frozen_mutation(snap: dict) -> None:
+    inv = snap["discipline_invariants"]
+    assert inv["mutates_research_artifacts"] is False
+    assert inv["mutates_roadmap_status_fields"] is False
+    assert inv["marks_phase_complete"] is False
+
+
+def test_discipline_invariants_pin_no_seed_jsonl_writes(snap: dict) -> None:
+    inv = snap["discipline_invariants"]
+    assert inv["writes_to_seed_jsonl"] is False
+    assert inv["writes_to_delegation_seed_jsonl"] is False
+    assert inv["writes_to_generated_seed_jsonl"] is False
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+def test_collect_snapshot_deterministic_with_injected_ts() -> None:
+    a = rtc.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+    b = rtc.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+    assert a == b
+
+
+def test_serialised_output_byte_identical_with_injected_ts() -> None:
+    a = rtc.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+    b = rtc.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+    out_a = json.dumps(a, indent=2, sort_keys=True) + "\n"
+    out_b = json.dumps(b, indent=2, sort_keys=True) + "\n"
+    assert out_a == out_b
+
+
+def test_task_order_stable(snap: dict) -> None:
+    sorted_pairs = [(t["phase"], t["id"]) for t in snap["roadmap_tasks"]]
+    assert sorted_pairs == sorted(sorted_pairs)
+
+
+def test_requirement_order_stable(snap: dict) -> None:
+    sorted_pairs = [(r["phase"], r["id"]) for r in snap["roadmap_requirements"]]
+    assert sorted_pairs == sorted(sorted_pairs)
+
+
+def test_all_task_ids_unique(snap: dict) -> None:
+    ids = [t["id"] for t in snap["roadmap_tasks"]]
+    assert len(ids) == len(set(ids))
+
+
+def test_all_requirement_ids_unique(snap: dict) -> None:
+    ids = [r["id"] for r in snap["roadmap_requirements"]]
+    assert len(ids) == len(set(ids))
+
+
+# ---------------------------------------------------------------------------
+# Atomic write allowlist
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_write_refuses_path_outside_allowlist(tmp_path: Path) -> None:
+    bad = tmp_path / "logs" / "elsewhere" / "latest.json"
+    bad.parent.mkdir(parents=True, exist_ok=True)
+    with pytest.raises(ValueError):
+        rtc._atomic_write_json(bad, {"x": 1})
+
+
+def test_atomic_write_accepts_allowlisted_path(tmp_path: Path) -> None:
+    good = tmp_path / "logs" / "roadmap_task_catalog" / "latest.json"
+    good.parent.mkdir(parents=True, exist_ok=True)
+    rtc._atomic_write_json(good, {"x": 1})
+    assert good.is_file()
+    assert json.loads(good.read_text(encoding="utf-8")) == {"x": 1}
+
+
+def test_atomic_write_is_atomic(tmp_path: Path) -> None:
+    target = tmp_path / "logs" / "roadmap_task_catalog" / "latest.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    rtc._atomic_write_json(target, {"x": 1})
+    rtc._atomic_write_json(target, {"x": 2})
+    # No tmp files left behind alongside the target.
+    siblings = list(target.parent.iterdir())
+    assert siblings == [target], siblings
+
+
+# ---------------------------------------------------------------------------
+# CLI behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_cli_no_write_does_not_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    sentinel = tmp_path / "logs" / "roadmap_task_catalog" / "latest.json"
+    monkeypatch.setattr(rtc, "ARTIFACT_LATEST", sentinel)
+    monkeypatch.setattr(rtc, "ARTIFACT_DIR", sentinel.parent)
+    rc = rtc.main(["--no-write"])
+    assert rc == 0
+    assert not sentinel.exists()
+    # stdout must contain the JSON payload
+    out = capsys.readouterr().out
+    assert '"roadmap_task_catalog"' in out
+
+
+def test_cli_status_does_not_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    sentinel = tmp_path / "logs" / "roadmap_task_catalog" / "latest.json"
+    monkeypatch.setattr(rtc, "ARTIFACT_LATEST", sentinel)
+    monkeypatch.setattr(rtc, "ARTIFACT_DIR", sentinel.parent)
+    rc = rtc.main(["--status"])
+    assert rc == 0
+    assert not sentinel.exists()
+    out = capsys.readouterr().out
+    assert "roadmap_task_catalog" in out
+    assert "step5_implementation_allowed=False" in out
+    assert "addendum_2_not_present=True" in out
+    assert "addendum_3_not_present=True" in out
+
+
+def test_cli_default_writes_to_allowlisted_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    sentinel = tmp_path / "logs" / "roadmap_task_catalog" / "latest.json"
+    monkeypatch.setattr(rtc, "ARTIFACT_LATEST", sentinel)
+    monkeypatch.setattr(rtc, "ARTIFACT_DIR", sentinel.parent)
+    rc = rtc.main([])
+    assert rc == 0
+    assert sentinel.is_file()
+    payload = json.loads(sentinel.read_text(encoding="utf-8"))
+    assert payload["report_kind"] == "roadmap_task_catalog"
+    assert payload["module_version"].startswith("v3.15.16.A20a")
+
+
+def test_cli_indent_zero_compact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    sentinel = tmp_path / "logs" / "roadmap_task_catalog" / "latest.json"
+    monkeypatch.setattr(rtc, "ARTIFACT_LATEST", sentinel)
+    monkeypatch.setattr(rtc, "ARTIFACT_DIR", sentinel.parent)
+    rc = rtc.main(["--no-write", "--indent", "0"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    # indent=0 collapses to compact output (no leading two-space lines)
+    assert "\n  " not in out
+
+
+# ---------------------------------------------------------------------------
+# Module-source forbidden-import / forbidden-token scans
+# ---------------------------------------------------------------------------
+
+
+def _module_source() -> str:
+    return Path(rtc.__file__).read_text(encoding="utf-8")
+
+
+def test_no_subprocess_in_module() -> None:
+    src = _module_source()
+    # docstring may mention 'subprocess' only inside the negative
+    # guarantees block, but no import or attribute reference must
+    # appear.
+    assert "import subprocess" not in src
+    assert "from subprocess" not in src
+    assert "subprocess." not in src
+
+
+def test_no_socket_or_urllib_or_http_or_requests() -> None:
+    src = _module_source()
+    for forbidden in (
+        "import socket",
+        "from socket",
+        "import urllib",
+        "from urllib",
+        "import http",
+        "from http",
+        "import requests",
+        "from requests",
+        "import httpx",
+        "from httpx",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_no_forbidden_module_imports() -> None:
+    src = _module_source()
+    for forbidden in (
+        "from dashboard",
+        "import dashboard",
+        "from automation",
+        "import automation",
+        "from broker",
+        "import broker",
+        "from agent.risk",
+        "import agent.risk",
+        "from agent.execution",
+        "import agent.execution",
+        "from research.run_research",
+        "import research.run_research",
+        "from research ",
+        "import research\n",
+        "from live",
+        "import live",
+        "from paper",
+        "import paper",
+        "from shadow",
+        "import shadow",
+        "from trading",
+        "import trading",
+        "from reporting.intelligent_routing",
+        "import reporting.intelligent_routing",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_no_gh_or_git_subprocess_references() -> None:
+    src = _module_source()
+    for forbidden in (
+        "subprocess.run",
+        "subprocess.Popen",
+        "os.system",
+        "os.popen",
+        "shell=True",
+        " gh ",
+        "`gh ",
+        " git ",
+        "`git ",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_module_never_writes_frozen_contracts() -> None:
+    """The actual no-mutation invariant for frozen contracts is
+    pinned by (a) the atomic-write allowlist refusing any path
+    outside ``logs/roadmap_task_catalog/`` and (b) the
+    ``mutates_research_artifacts: False`` discipline invariant.
+
+    The module source legitimately *names* the frozen contracts in
+    docstrings and inside the Addendum 1 ``do not mutate ...``
+    requirement statement — those are negative guarantees, not
+    write-path references. This test asserts the operational
+    invariant directly: the atomic-write helper rejects every
+    frozen-contract path.
+    """
+    src = _module_source()
+    # Confirm the actual write helper exists and is the only write
+    # surface the module exposes.
+    assert "_atomic_write_json" in src
+    # The closed write-prefix substring must be present and must be
+    # the catalog directory — not any research / frozen / live path.
+    assert 'logs/roadmap_task_catalog/' in src
+    # Refusal path: any frozen contract path must be refused.
+    import tempfile
+    from pathlib import Path as _Path
+    with tempfile.TemporaryDirectory() as td:
+        for forbidden in (
+            "research/research_latest.json",
+            "research/strategy_matrix.csv",
+        ):
+            target = _Path(td) / forbidden
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with pytest.raises(ValueError):
+                rtc._atomic_write_json(target, {"x": 1})
+
+
+def test_no_llm_or_external_api_calls() -> None:
+    src = _module_source()
+    for forbidden in (
+        "anthropic",
+        "openai",
+        "Bearer ",
+        "X-API-Key",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_module_imports_cleanly() -> None:
+    importlib.reload(rtc)
+    assert callable(rtc.collect_snapshot)
+    assert callable(rtc.write_outputs)
+    assert callable(rtc.main)
+
+
+def test_schema_and_module_version_strings() -> None:
+    assert isinstance(rtc.SCHEMA_VERSION, str) and rtc.SCHEMA_VERSION
+    assert isinstance(rtc.MODULE_VERSION, str) and rtc.MODULE_VERSION
+
+
+# ---------------------------------------------------------------------------
+# Governance doc cross-references
+# ---------------------------------------------------------------------------
+
+
+def _governance_doc_text() -> str:
+    doc = (
+        Path(__file__).resolve().parents[2]
+        / "docs"
+        / "governance"
+        / "roadmap_task_catalog.md"
+    )
+    return doc.read_text(encoding="utf-8").lower()
+
+
+def test_governance_doc_marks_read_only() -> None:
+    text = _governance_doc_text()
+    assert "read-only" in text or "read only" in text
+
+
+def test_governance_doc_marks_not_canonical_product_roadmap() -> None:
+    text = _governance_doc_text()
+    assert "canonical" in text
+    assert "roadmap v6" in text
+
+
+def test_governance_doc_pins_addendum_2_3_absence() -> None:
+    text = _governance_doc_text()
+    assert "addendum 2" in text
+    assert "addendum 3" in text
+    assert "not present" in text or "absent" in text or "not in the repo" in text
+
+
+def test_governance_doc_pins_no_runtime_or_trading_authority() -> None:
+    text = _governance_doc_text()
+    for forbidden in (
+        "runtime",
+        "trading",
+        "paper",
+        "shadow",
+        "broker",
+        "risk",
+        "live",
+    ):
+        assert forbidden in text, forbidden
+
+
+def test_governance_doc_lists_future_a20b_a20e_stages() -> None:
+    text = _governance_doc_text()
+    for stage in ("a20b", "a20c", "a20d", "a20e"):
+        assert stage in text, stage


### PR DESCRIPTION
## Summary

- Hand-encodes Roadmap v6 phases v3.15.16..v3.15.20 plus a cross-cutting Addendum 1 task and the per-requirement Addendum 1 diagnostic-family coverage into a deterministic, repo-resident, read-only catalog at `logs/roadmap_task_catalog/latest.json`.
- Closed vocabularies for `PHASE`, `SOURCE_DOCUMENT`, `STATUS`, `ADDENDUM_LINK`, `TARGET_LAYER`; widening any requires a code change pinned by an updated unit test.
- Roadmap v6 remains canonical. The catalog is **not** the canonical product roadmap.
- **Roadmap v6 Addendum 2 and Addendum 3 are not in the repo.** They are represented **only** as absence flags (`addendum_2_not_present=true`, `addendum_3_not_present=true`). No Addendum 2 / 3 requirements are invented here. No Addendum 2 / 3 paths are added to `SOURCE_DOCUMENT`.
- This PR creates **no** implementation-unit decomposer (A20b).
- This PR creates **no** authority / risk classifier integration (A20c).
- This PR creates **no** AAC / task-board / dashboard visibility surface (A20d).
- This PR creates **no** next-buildable-unit selector (A20e).

## Files changed (exactly 3, allowlist-only)

- `reporting/roadmap_task_catalog.py` (new) — stdlib + `reporting.execution_authority` constants only.
- `tests/unit/test_roadmap_task_catalog.py` (new) — 83 tests.
- `docs/governance/roadmap_task_catalog.md` (new) — operator runbook.

## Validation commands and results

- `python -m pytest tests/unit/test_roadmap_task_catalog.py -v` → **83 passed**
- `python -m pytest tests/smoke -v` → **18 passed**
- `python scripts/governance_lint.py` → **OK** (16 agents, 5 workflows checked)
- `python -m pytest tests/regression/test_frozen_hashes.py -v` → **file does not exist in this repo**; substituted with the actual frozen-contract / authority regression tests:
  - `tests/regression/test_public_output_contract.py` → **8 passed**
  - `tests/regression/test_v12_contracts_preserved.py` → **4 passed**
  - `tests/regression/test_authority_invariants.py` → **4 passed**

## Frozen-contract verdict

- `research/research_latest.json` — **not touched**.
- `research/strategy_matrix.csv` — **not touched**.
- All frozen-contract / public-output / authority regression tests green.
- The module never writes to a frozen-contract path: `_atomic_write_json` refuses every path outside `logs/roadmap_task_catalog/` (pinned by `test_module_never_writes_frozen_contracts` and `test_atomic_write_refuses_path_outside_allowlist`).

## Forbidden-path verdict

`git diff --name-only main` contains **only**:

```
docs/governance/roadmap_task_catalog.md
reporting/roadmap_task_catalog.py
tests/unit/test_roadmap_task_catalog.py
```

None of the following were touched:

- `dashboard/dashboard.py`
- `.claude/**`
- `research/research_latest.json`
- `research/strategy_matrix.csv`
- `automation/live_gate.py`
- `broker/**`, `agent/risk/**`, `agent/execution/**`
- `live/**`, `paper/**`, `shadow/**`, `trading/**`
- `docs/roadmap/Roadmap v6.md`
- `docs/roadmap/Roadmap v6 Addendum.md`
- `docs/roadmap/autonomous_development.txt`
- `docs/governance/execution_authority.md`
- `docs/governance/no_touch_paths.md`
- `reporting/execution_authority.py`
- `reporting/development_queue_admission_policy.py` (the existing A17 surface)
- `reporting/development_agent_activity_timeline.py` (AAC aggregator)
- `docs/development_work_queue/*.jsonl`
- `tests/regression/**`
- any frozen schema under `artifacts/`

## Authority statement

- ADE remains development workflow automation only. This PR grants no QRE runtime, trading, paper, shadow, broker, risk, or live authority.
- Step 5 implementation remains BLOCKED (`step5_implementation_allowed=False`, `STEP5_ENABLED_SUBSTAGE="none"`).
- Autonomy-ladder Level 6 remains permanently disabled.
- N5b Phase 4 production merge remains permanently denied for ADE.
- The catalog grants **no** implementation, runtime, trading, paper, shadow, broker, risk, or live authority. Discipline-invariant flags pin this explicitly on every projection.

## Addendum 2 / Addendum 3 framing

Both files are absent from the repo at the time of this seed. They are represented **only** as `discipline_invariants.addendum_2_not_present=true` / `discipline_invariants.addendum_3_not_present=true`. Their requirements are intentionally not encoded. When (and if) the operator commits those source files, a follow-up PR may add their paths to `SOURCE_DOCUMENT`, flip the absence flags, and add their hand-encoded requirements — that is out of scope here.

## What this PR does NOT do

- **No** implementation-unit decomposer (A20b).
- **No** AAC / task-board / dashboard visibility surface (A20d).
- **No** next-buildable-unit selector (A20e).
- **No** classifier integration (A20c).
- **No** edit to `reporting/development_queue_admission_policy.py` (the existing A17 surface).
- **No** edit to canonical roadmap docs.
- **No** edit to `autonomous_development.txt`.
- **No** Step 5 substage flip.
- **No** Level 6 amendment.

## Next recommended PR

**A20b — Implementation Unit Decomposer.** Convert each `RoadmapTask` in this catalog into one or more PR-sized `ImplementationUnit` records with explicit `expected_files[]`, `forbidden_files[]`, `required_tests[]`, `definition_of_done[]`, `stop_conditions[]`, and `prerequisites[]`. Deterministic data, no LLM, no fuzzy parsing. Each unit's `forbidden_files[]` MUST include every live / paper / shadow / risk / broker / execution glob and the frozen-contract paths.

## Test plan

- [x] `python -m pytest tests/unit/test_roadmap_task_catalog.py -v` — 83 passed locally
- [x] `python -m pytest tests/smoke -v` — 18 passed locally
- [x] `python scripts/governance_lint.py` — OK locally
- [x] `python -m pytest tests/regression/test_public_output_contract.py tests/regression/test_v12_contracts_preserved.py tests/regression/test_authority_invariants.py -v` — 16 passed locally
- [ ] CI checks complete on PR (squash-merge only — no `--admin`, no force push, no hook bypass, no automatic merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)