### PR TITLE
feat(a20b): roadmap implementation unit decomposer (read-only)

### DIFF
--- a/docs/governance/roadmap_task_catalog.md
+++ b/docs/governance/roadmap_task_catalog.md
@@ -1,10 +1,15 @@
-# Roadmap Task Catalog — A20a (read-only, deterministic seed)
+# Roadmap Task Catalog — A20a + A20b (read-only, deterministic)
 
-> **Status:** Implemented (read-only, deterministic, dry-run by
-> default).
+> **Status:** A20a implemented; A20b implemented (read-only,
+> deterministic, dry-run by default). Both modules are projections;
+> neither classifies authority, nor surfaces to the AAC / dashboard,
+> nor selects a next-buildable unit.
 >
-> **Module:** [`reporting/roadmap_task_catalog.py`](../../reporting/roadmap_task_catalog.py)
-> **Output artefact:** `logs/roadmap_task_catalog/latest.json`
+> **A20a module:** [`reporting/roadmap_task_catalog.py`](../../reporting/roadmap_task_catalog.py)
+> **A20a artefact:** `logs/roadmap_task_catalog/latest.json`
+>
+> **A20b module:** [`reporting/roadmap_task_units.py`](../../reporting/roadmap_task_units.py)
+> **A20b artefact:** `logs/roadmap_task_units/latest.json`
 >
 > **Authority:** development-governance read-only.
 > The roadmap task catalog is **not** the canonical product roadmap.
@@ -244,20 +249,163 @@ Until then the absence is explicit and asserted.
 
 ---
 
-## 7. Future stages (A20b–A20e)
+## 7. A20b — Implementation Unit Decomposer (implemented)
 
-The roadmap task catalog is the foundation of a staged sequence.
-Each subsequent stage requires a separate operator-go PR. None of
-them is pre-authorized by A20a.
+A20b consumes the A20a catalog and emits a deterministic
+projection of **PR-sized implementation units** at
+`logs/roadmap_task_units/latest.json`. Each unit records exactly
+how a future PR may slice the work for one `RoadmapTask` — what it
+expects to write, what it must never write, the tests it must run,
+its definition of done, its stop conditions, and the units it
+depends on.
 
-- **A20b — Implementation Unit Decomposer.** Converts each
-  `RoadmapTask` into one or more PR-sized `ImplementationUnit`
-  records with explicit `expected_files[]`, `forbidden_files[]`,
-  `required_tests[]`, `definition_of_done[]`, `stop_conditions[]`,
-  and `prerequisites[]`. Deterministic data, no LLM, no fuzzy
-  parsing. Forbidden files must always include the live / paper /
-  shadow / risk / broker / execution globs and the frozen-contract
-  paths, regardless of the unit's primary surface.
+A20b is **decomposition data**, not heuristics. The
+unit→file mapping is hand-authored as a Python literal inside
+[`reporting/roadmap_task_units.py`](../../reporting/roadmap_task_units.py)
+and pinned by [`tests/unit/test_roadmap_task_units.py`](../../tests/unit/test_roadmap_task_units.py).
+There is no LLM, no fuzzy parsing, and no runtime parsing of
+canonical roadmap documents. The decomposer derives task identity
+from the in-memory A20a catalog only.
+
+### 7.1 PR-sized unit principle
+
+Each `ImplementationUnit` represents one coherent, atomic, mergeable
+slice of future work. Phases with multiple distinct concerns
+(routing signals + routing explanation + governance doc) are
+decomposed into multiple units rather than one giant unit. Each
+unit's `prerequisites[]` records its dependency edges so a future
+A20e selector can topologically order them.
+
+### 7.2 `ImplementationUnit` schema
+
+Per-unit field list is exact and ordered:
+
+```
+id                        : str  ≤128 chars; stable opaque identifier
+roadmap_task_id           : str  RoadmapTask.id this unit belongs to
+title                     : str  ≤200 chars
+phase                     : str  ∈ roadmap_task_catalog.PHASE
+unit_kind                 : str  ∈ UNIT_KIND
+target_layer              : str  ∈ TARGET_LAYER (mirror of catalog)
+source_requirement_ids    : list[str]  RoadmapRequirement.id values
+expected_files            : list[str]  paths the unit may write to
+forbidden_files           : list[str]  paths the unit must NOT touch
+forbidden_surface_reasons : list[str]  ⊆ FORBIDDEN_SURFACE_REASON
+required_tests            : list[str]  pytest selectors + governance lint
+definition_of_done        : list[str]  bounded DoD bullets
+stop_conditions           : list[str]  bounded STOP conditions
+prerequisites             : list[str]  other ImplementationUnit.id values
+risk_class                : str  ∈ {LOW, MEDIUM, HIGH, UNKNOWN}
+authority_hint            : str  ∈ AUTHORITY_HINT (NOT final authority)
+operator_gate             : str  ∈ OPERATOR_GATE
+status                    : str  ∈ UNIT_STATUS (seed value: not_started)
+```
+
+### 7.3 `expected_files` / `forbidden_files` semantics
+
+`expected_files[]` enumerates the **only** paths the future
+implementation PR is permitted to touch. Anything outside this list
+is forbidden by construction. The decomposer never emits a unit
+whose `expected_files[]` overlaps a paper / shadow / live /
+trading / broker / agent.risk / agent.execution surface, the
+`.claude/` tree, `dashboard/dashboard.py`, or the frozen contracts.
+
+`forbidden_files[]` enumerates additional paths the future PR must
+explicitly **not** touch. Every unit's `forbidden_files[]` carries
+the full baseline at minimum:
+
+- `.claude/**`
+- `dashboard/dashboard.py`
+- `research/research_latest.json`, `research/strategy_matrix.csv`
+- `automation/live_gate.py`, `broker/**`, `agent/risk/**`,
+  `agent/execution/**`
+- `live/**`, `paper/**`, `shadow/**`, `trading/**`
+- `.github/branch_protection_main.yml`
+- the canonical policy docs and the canonical roadmap docs
+- the existing A17 admission-policy module and the AAC aggregator
+- `tests/regression/**`
+- frozen schemas under `artifacts/`
+
+These paths appear in the unit records only as **forbidden-path
+declarations**. The unit-decomposer module itself never imports
+those packages and never touches those paths at runtime; the
+strings are metadata.
+
+### 7.4 `forbidden_surface_reasons` semantics
+
+Each unit declares the closed-vocabulary reasons that justify its
+baseline + extra `forbidden_files` entries. Every unit includes
+`frozen_contract`, `live_path`, `claude_governance_hook`,
+`dashboard_wiring`, and `branch_protection_config` at minimum.
+
+### 7.5 `required_tests` / `definition_of_done` / `stop_conditions`
+
+- `required_tests[]` lists pytest selectors (or `scripts/`
+  invocations) the future PR must run green. Every unit inherits a
+  baseline: smoke, governance_lint, and the actual frozen-contract
+  / public-output / authority regression tests present in this
+  repo.
+- `definition_of_done[]` lists the observable conditions that must
+  be true at PR-open time. The baseline includes: clean module
+  import, atomic-write allowlist enforcement, deterministic output,
+  frozen contracts unchanged, no live / paper / shadow / broker /
+  risk / execution path changes, no `dashboard/dashboard.py` change,
+  no `.claude/**` change, no canonical-roadmap or canonical-policy
+  edit, PR opened via the standard `gh pr create` lifecycle (no
+  `--admin`, no force push, no hook bypass).
+- `stop_conditions[]` lists immediate-abort triggers. The baseline
+  includes: forbidden import / token in source, forbidden path in
+  diff, regression-test failure, hook failure, any attempt to
+  grant runtime / trading authority.
+
+### 7.6 `prerequisites` semantics
+
+`prerequisites[]` lists other `ImplementationUnit.id` values that
+must be `status = merged` before this unit becomes eligible to
+implement. A20e (future) will use this for deterministic topological
+ordering. A20b verifies that every prerequisite references a known
+unit.
+
+### 7.7 `authority_hint` is **not** final authority
+
+`authority_hint ∈ {AUTO_ALLOWED_CANDIDATE, NEEDS_HUMAN_CANDIDATE,
+PERMANENTLY_DENIED_SURFACE}`. The hint is a deterministic,
+conservative classification produced by hand-authored seed data; it
+is **not** a substitute for the real classifier output. A20c will
+replace each hint with the actual `reporting.execution_authority`
+verdict aggregated across per-file decisions. Until A20c lands, the
+hint is informational only. Unknown inputs fail closed to
+`NEEDS_HUMAN_CANDIDATE`.
+
+### 7.8 What A20b explicitly does NOT do
+
+- **No final authority classification.** A20b does not import or
+  call `reporting.execution_authority`. A20c will integrate the
+  real classifier and replace each unit's hint with the actual
+  verdict.
+- **No AAC / dashboard visibility.** A20b emits only
+  `logs/roadmap_task_units/latest.json`. The AAC aggregator and
+  `dashboard/dashboard.py` are untouched. A20d will (in a separate
+  operator-go PR) extend the AAC aggregator's pinned upstream
+  catalog to consume A20b's artefact.
+- **No next-buildable-unit selector.** A20e will (in a separate
+  operator-go PR) compute eligibility and emit a deterministic
+  `selected_unit_id` over A20c output.
+- **No unit grants runtime / trading / paper / shadow / live
+  authority.** Each unit's `forbidden_files[]` blocks those
+  surfaces and the projection's `decomposition_invariants` pin
+  `grants_*_authority = false` across every authority lane.
+- **No new units under `phase == "addendum_2"` or
+  `phase == "addendum_3"`.** Catalog absence propagates: the
+  decomposer reads the A20a catalog at runtime and skips any
+  unit whose phase is not present in the catalog's task list.
+
+## 8. Future stages (A20c–A20e)
+
+The roadmap task catalog + unit decomposer is the foundation of a
+staged sequence. Each subsequent stage requires a separate
+operator-go PR. None of them is pre-authorized by A20a or A20b.
+
 - **A20c — Authority / Risk Classifier Integration.** Annotates
   each `ImplementationUnit` with an aggregate
   `UnitAuthorityDecision` derived purely from
@@ -265,7 +413,10 @@ them is pre-authorized by A20a.
   Aggregation is max-severity over per-file decisions. Fail-closed:
   unknown risk → `NEEDS_HUMAN`; any protected-path / frozen / live
   surface → `PERMANENTLY_DENIED` or `NEEDS_HUMAN` per the
-  classifier's existing policy.
+  classifier's existing policy. A20c will flip
+  `calls_execution_authority_classifier` and
+  `final_authority_classified` from `false` to `true` in the
+  projection's invariant block.
 - **A20d — Read-only AAC / Task-Board Visibility.** Exposes the
   catalog + units + authority decisions to the operator through
   the existing read-only surfaces (`reporting/task_board.py`,
@@ -273,7 +424,8 @@ them is pre-authorized by A20a.
   no approval buttons, no `dashboard/dashboard.py` edit unless a
   separate operator-authored governance-bootstrap PR enables it.
   Any AAC aggregator cardinality change requires its own
-  operator-go PR.
+  operator-go PR. A20d will flip `aac_visibility_present` to
+  `true`.
 - **A20e — Deterministic Next-Buildable-Unit Selector.**
   Pure-deterministic filter + sort over A20c output. Eligibility
   requires: `status ∈ {not_started, ready}`; all prerequisites in
@@ -281,10 +433,11 @@ them is pre-authorized by A20a.
   `aggregate_decision = AUTO_ALLOWED`; no triggered
   forbidden-surface reasons. Fail-closed: zero eligible →
   `selected_unit_id = None` with `selection_reason =
-  "no_eligible_units"`. No hidden LLM judgment.
+  "no_eligible_units"`. No hidden LLM judgment. A20e will flip
+  `next_buildable_selector_present` to `true`.
 
-A20a does not produce, imply, or depend on any of the above. Each
-must justify its own scope on its own PR.
+Neither A20a nor A20b produces, implies, or depends on any of the
+above. Each must justify its own scope on its own PR.
 
 ---
 
@@ -325,6 +478,8 @@ refuses every path outside `logs/roadmap_task_catalog/`.
 
 ## 10. Test coverage
 
+### 10.1 A20a
+
 Pinned in [`tests/unit/test_roadmap_task_catalog.py`](../../tests/unit/test_roadmap_task_catalog.py):
 
 - Closed vocabularies are exact and complete.
@@ -356,6 +511,72 @@ Pinned in [`tests/unit/test_roadmap_task_catalog.py`](../../tests/unit/test_road
   agent.risk, agent.execution, live, paper, shadow, trading,
   research.run_research, research_latest.json, strategy_matrix.csv,
   `gh`, `git`).
+
+### 10.2 A20b
+
+Pinned in [`tests/unit/test_roadmap_task_units.py`](../../tests/unit/test_roadmap_task_units.py):
+
+- Closed vocabularies (`UNIT_KIND`, `RISK_CLASS`, `AUTHORITY_HINT`,
+  `OPERATOR_GATE`, `UNIT_STATUS`, `TARGET_LAYER`,
+  `FORBIDDEN_SURFACE_REASON`) are exact.
+- Schema field tuples (`IMPLEMENTATION_UNIT_FIELDS`,
+  `UNIT_DECOMPOSITION_PROJECTION_FIELDS`) are exact and ordered.
+- Every emitted unit satisfies the closed vocabularies on every
+  closed-vocab field.
+- Every emitted unit has non-empty `expected_files`,
+  `forbidden_files`, `forbidden_surface_reasons`, `required_tests`,
+  `definition_of_done`, `stop_conditions`.
+- Every emitted unit has a `prerequisites` field (list, may be
+  empty); every referenced prerequisite resolves to a known unit.
+- Every A20a `RoadmapTask` is decomposed into at least one unit;
+  v3.15.16, v3.15.17, v3.15.18, v3.15.19, v3.15.20 each have more
+  than one unit; Addendum 1 has ≥3 units.
+- No unit is emitted under `phase == "addendum_2"` or
+  `phase == "addendum_3"`.
+- No unit declares paper / shadow / live / trading / broker /
+  agent.risk / agent.execution / `.claude/` / `dashboard.py` /
+  frozen-contract surfaces as `expected_files` targets.
+- Every unit's `forbidden_files` includes the full baseline list.
+- Every unit's `forbidden_surface_reasons` includes the baseline
+  reasons (`frozen_contract`, `live_path`,
+  `claude_governance_hook`, `dashboard_wiring`,
+  `branch_protection_config`).
+- `authority_hint` fail-closed: unknown inputs resolve to
+  `NEEDS_HUMAN_CANDIDATE`.
+- Decomposition invariants pin: no runtime / trading / paper /
+  shadow / broker / risk / live authority granted;
+  `step5_implementation_allowed = false`;
+  `STEP5_ENABLED_SUBSTAGE = "none"`; Addendum 2 / 3 absence flags;
+  no execution_authority classifier called; no AAC visibility;
+  no next-buildable-unit selector.
+- Deterministic byte-identical output for identical input with
+  injected `generated_at_utc`.
+- Atomic-write allowlist refuses any path outside
+  `logs/roadmap_task_units/` — frozen-contract paths in particular.
+- CLI: `--no-write` writes nothing; `--status` writes nothing and
+  emits invariant strings; default writes to the allowlisted path
+  with correct schema; `--indent 0` produces compact output.
+- Module source carries no forbidden imports (subprocess, socket,
+  urllib, http, requests, dashboard, automation, broker,
+  agent.risk, agent.execution, research.run_research,
+  reporting.intelligent_routing, reporting.execution_authority,
+  reporting.development_queue_admission_policy,
+  reporting.development_agent_activity_timeline) and no forbidden
+  runtime tokens (`subprocess.run`, `subprocess.Popen`,
+  `os.system`, `os.popen`, `shell=True`, `gh pr`, `git push`,
+  `git commit`, `eval(`, `exec(`, `anthropic`, `openai`).
+- Module does NOT import or call `reporting.execution_authority`
+  (the canonical classifier integration is A20c's job).
+- Module does NOT reference canonical roadmap file paths as
+  runtime read targets (no fuzzy parsing of the roadmap docs).
+
+The strings `research/research_latest.json`,
+`research/strategy_matrix.csv`, `live/**`, `paper/**`, `shadow/**`,
+`broker/**`, `agent/risk/**`, and `agent/execution/**` are
+intentionally allowed to appear inside the baseline `forbidden_files`
+declarations and inside this governance doc. They are forbidden as
+import targets, write targets, and runtime call surfaces; they are
+**not** forbidden as forbidden-path declarations.
 
 ---
 

--- a/reporting/roadmap_task_units.py
+++ b/reporting/roadmap_task_units.py
@@ -1,0 +1,1743 @@
+"""A20b — Implementation Unit Decomposer (read-only, deterministic).
+
+Converts each :pyfunc:`reporting.roadmap_task_catalog.collect_snapshot`
+``RoadmapTask`` into one or more deterministic, PR-sized
+``ImplementationUnit`` records and emits a projection at
+``logs/roadmap_task_units/latest.json``.
+
+This module is **decomposition data**, not heuristics. The
+unit→file mapping is hand-authored as a Python literal pinned by
+tests. There is **no** LLM, no fuzzy parsing, no file-content
+parsing of canonical roadmap documents at runtime. The decomposer
+trusts the A20a catalog as the only upstream and re-classifies
+nothing.
+
+This module does **not** call ``execution_authority.classify(...)``.
+Per-unit ``authority_hint`` is a deterministic, conservative
+projection. Final authority classification is A20c's responsibility
+and will replace the hint with the actual classifier output. A20b's
+hint never grants implementation authority by itself.
+
+Hard guarantees (pinned by tests):
+
+* Stdlib + ``reporting.roadmap_task_catalog`` (read-only) only.
+* No subprocess, no network, no ``gh``, no ``git``.
+* No imports of ``dashboard``, ``automation``, ``broker``,
+  ``agent.risk``, ``agent.execution``, ``research``, ``live``,
+  ``paper``, ``shadow``, ``trading``,
+  ``reporting.intelligent_routing``,
+  ``reporting.execution_authority``,
+  ``reporting.development_queue_admission_policy``,
+  ``reporting.development_agent_activity_timeline``.
+* No LLM, no external API, no fuzzy parsing, no file-content
+  parsing of any canonical document at runtime.
+* Closed vocabularies for ``UNIT_KIND``, ``RISK_CLASS``,
+  ``AUTHORITY_HINT``, ``OPERATOR_GATE``, ``UNIT_STATUS``,
+  ``TARGET_LAYER``, ``FORBIDDEN_SURFACE_REASON``. Widening any
+  requires a code change pinned by an updated unit test.
+* Atomic write only under ``logs/roadmap_task_units/``.
+* Deterministic output: same upstream + injected
+  ``generated_at_utc`` → byte-identical artefact.
+* Every emitted unit's ``forbidden_files`` includes the full
+  baseline: ``.claude/**``, ``dashboard/dashboard.py``,
+  ``research/research_latest.json``,
+  ``research/strategy_matrix.csv``,
+  ``automation/live_gate.py``, ``broker/**``, ``agent/risk/**``,
+  ``agent/execution/**``, ``live/**``, ``paper/**``, ``shadow/**``,
+  ``trading/**``, plus the canonical-roadmap and branch-protection
+  paths.
+* Every unit's ``forbidden_surface_reasons`` includes
+  ``frozen_contract``, ``live_path``, ``claude_governance_hook``,
+  ``dashboard_wiring``, and ``branch_protection_config`` at
+  minimum.
+* No unit declares a paper / shadow / live / broker / risk /
+  execution surface as an ``expected_files`` target. Each such
+  surface is in ``forbidden_files`` of every unit.
+* Decomposer creates **zero** units under ``phase == "addendum_2"``
+  or ``phase == "addendum_3"`` while the matching source documents
+  are absent. Catalog absence flags propagate.
+* No unit grants runtime, trading, paper, shadow, broker, risk,
+  or live authority.
+* ``step5_implementation_allowed`` remains ``False``;
+  ``STEP5_ENABLED_SUBSTAGE`` remains ``"none"``.
+
+CLI::
+
+    python -m reporting.roadmap_task_units
+    python -m reporting.roadmap_task_units --no-write
+    python -m reporting.roadmap_task_units --status
+    python -m reporting.roadmap_task_units --indent 2
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Final
+
+from reporting import roadmap_task_catalog as rtc
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[str] = "1.0"
+MODULE_VERSION: Final[str] = "v3.15.16.A20b"
+REPORT_KIND: Final[str] = "roadmap_task_units"
+
+
+# ---------------------------------------------------------------------------
+# Step 5 + Level 6 invariants (Final constants — never flipped at runtime)
+# ---------------------------------------------------------------------------
+
+STEP5_ENABLED_SUBSTAGE: Final[str] = "none"
+step5_implementation_allowed: Final[bool] = False
+
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies
+# ---------------------------------------------------------------------------
+
+#: Closed implementation-unit kind. Mirrors the surface a unit
+#: primarily writes to; aligned with the existing repo layout.
+UNIT_KIND: Final[tuple[str, ...]] = (
+    "reporting_module",
+    "research_module",
+    "governance_doc",
+    "test_only",
+    "schema_only",
+    "diagnostic_primitive",
+    "external_intelligence_source",
+)
+
+#: Closed risk-class vocabulary. Mirrors the four-value enum used by
+#: ``reporting.execution_authority`` without importing that module.
+#: A20c will replace this hint with the actual classifier output.
+RISK_CLASS: Final[tuple[str, ...]] = (
+    "LOW",
+    "MEDIUM",
+    "HIGH",
+    "UNKNOWN",
+)
+
+#: Closed authority-hint vocabulary. A20b values are *candidates*
+#: only. A20c will resolve them against the canonical classifier and
+#: replace each unit's hint with a real ``ExecutionDecision``.
+#: ``UNKNOWN`` inputs MUST fail closed to ``NEEDS_HUMAN_CANDIDATE``.
+AUTHORITY_HINT: Final[tuple[str, ...]] = (
+    "AUTO_ALLOWED_CANDIDATE",
+    "NEEDS_HUMAN_CANDIDATE",
+    "PERMANENTLY_DENIED_SURFACE",
+)
+
+#: Closed operator-gate vocabulary. ``governance_bootstrap_pr_required``
+#: is the strongest gate: only an operator-authored PR may modify the
+#: unit's surface.
+OPERATOR_GATE: Final[tuple[str, ...]] = (
+    "none",
+    "operator_go_required",
+    "governance_bootstrap_pr_required",
+)
+
+#: Closed unit-status vocabulary. Today every unit lands in
+#: ``not_started`` — the decomposer records intent, not progress.
+UNIT_STATUS: Final[tuple[str, ...]] = (
+    "not_started",
+    "ready",
+    "in_flight",
+    "merged",
+    "blocked",
+    "human_needed",
+    "permanently_denied",
+)
+
+#: Closed target-layer vocabulary. Verbatim from
+#: ``reporting.roadmap_task_catalog.TARGET_LAYER`` so the catalog and
+#: the decomposer stay aligned without runtime coupling.
+TARGET_LAYER: Final[tuple[str, ...]] = rtc.TARGET_LAYER
+
+#: Closed forbidden-surface-reason vocabulary. Each unit declares
+#: the reasons that justify its baseline / extra forbidden_files
+#: entries.
+FORBIDDEN_SURFACE_REASON: Final[tuple[str, ...]] = (
+    "live_path",
+    "frozen_contract",
+    "claude_governance_hook",
+    "dashboard_wiring",
+    "branch_protection_config",
+    "ci_workflow",
+    "canonical_policy_doc",
+    "canonical_roadmap",
+    "deploy_script",
+    "step5_blocked",
+    "level6_disabled",
+    "n5b_phase4_denied",
+    "addendum_2_not_present",
+    "addendum_3_not_present",
+    "aac_aggregator_pinned",
+    "existing_a17_admission_policy",
+    "frozen_seed_files",
+    "regression_tests_operator_only",
+    "frozen_schema_artifacts",
+)
+
+
+# ---------------------------------------------------------------------------
+# Schema field tuples (exact, ordered)
+# ---------------------------------------------------------------------------
+
+#: ``ImplementationUnit`` field list. Exact and ordered.
+IMPLEMENTATION_UNIT_FIELDS: Final[tuple[str, ...]] = (
+    "id",
+    "roadmap_task_id",
+    "title",
+    "phase",
+    "unit_kind",
+    "target_layer",
+    "source_requirement_ids",
+    "expected_files",
+    "forbidden_files",
+    "forbidden_surface_reasons",
+    "required_tests",
+    "definition_of_done",
+    "stop_conditions",
+    "prerequisites",
+    "risk_class",
+    "authority_hint",
+    "operator_gate",
+    "status",
+)
+
+#: ``UnitDecompositionProjection`` field list. Exact and ordered.
+UNIT_DECOMPOSITION_PROJECTION_FIELDS: Final[tuple[str, ...]] = (
+    "generated_at_utc",
+    "schema_version",
+    "module_version",
+    "source_catalog_schema_version",
+    "implementation_units",
+    "decomposition_invariants",
+)
+
+
+# ---------------------------------------------------------------------------
+# Bounds
+# ---------------------------------------------------------------------------
+
+MAX_TITLE_LEN: Final[int] = 200
+MAX_ID_LEN: Final[int] = 128
+MAX_PATH_LEN: Final[int] = 300
+MAX_REASON_LEN: Final[int] = 80
+MAX_LIST_ITEM_LEN: Final[int] = 240
+MAX_EXPECTED_FILES: Final[int] = 16
+MAX_FORBIDDEN_FILES: Final[int] = 32
+MAX_REQUIRED_TESTS: Final[int] = 16
+MAX_DOD_ITEMS: Final[int] = 16
+MAX_STOP_CONDITIONS: Final[int] = 16
+MAX_PREREQUISITES: Final[int] = 16
+MAX_SOURCE_REQUIREMENT_IDS: Final[int] = 32
+MAX_FORBIDDEN_SURFACE_REASONS: Final[int] = 16
+
+
+# ---------------------------------------------------------------------------
+# Artefact paths
+# ---------------------------------------------------------------------------
+
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "roadmap_task_units"
+ARTIFACT_LATEST: Final[Path] = ARTIFACT_DIR / "latest.json"
+ARTIFACT_RELATIVE_PATH: Final[str] = "logs/roadmap_task_units/latest.json"
+
+#: Atomic-write allowlist (POSIX path substring form). Any write
+#: target whose path does not contain this substring is refused with
+#: ``ValueError``.
+_WRITE_PREFIX: Final[str] = "logs/roadmap_task_units/"
+
+
+# ---------------------------------------------------------------------------
+# Baseline forbidden files / reasons applied to every unit
+# ---------------------------------------------------------------------------
+
+#: Forbidden-file baseline injected into every emitted unit. The
+#: ``__contains__`` test fixture asserts that the full baseline is
+#: present in every unit's ``forbidden_files``.
+BASELINE_FORBIDDEN_FILES: Final[tuple[str, ...]] = (
+    ".claude/**",
+    "dashboard/dashboard.py",
+    "research/research_latest.json",
+    "research/strategy_matrix.csv",
+    "automation/live_gate.py",
+    "broker/**",
+    "agent/risk/**",
+    "agent/execution/**",
+    "live/**",
+    "paper/**",
+    "shadow/**",
+    "trading/**",
+    ".github/branch_protection_main.yml",
+    "docs/governance/execution_authority.md",
+    "docs/governance/no_touch_paths.md",
+    "docs/roadmap/Roadmap v6.md",
+    "docs/roadmap/Roadmap v6 Addendum.md",
+    "docs/roadmap/autonomous_development.txt",
+    "docs/development_work_queue/seed.jsonl",
+    "docs/development_work_queue/delegation_seed.jsonl",
+    "reporting/development_queue_admission_policy.py",
+    "reporting/development_agent_activity_timeline.py",
+    "reporting/execution_authority.py",
+    "tests/regression/**",
+    "artifacts/build_provenance.schema.json",
+)
+
+#: Reason-baseline injected into every emitted unit's
+#: ``forbidden_surface_reasons``.
+BASELINE_FORBIDDEN_SURFACE_REASONS: Final[tuple[str, ...]] = (
+    "frozen_contract",
+    "live_path",
+    "claude_governance_hook",
+    "dashboard_wiring",
+    "branch_protection_config",
+    "canonical_policy_doc",
+    "canonical_roadmap",
+    "existing_a17_admission_policy",
+    "aac_aggregator_pinned",
+    "frozen_seed_files",
+    "regression_tests_operator_only",
+    "frozen_schema_artifacts",
+    "level6_disabled",
+    "n5b_phase4_denied",
+)
+
+#: Standard test selectors that every unit must execute as part of
+#: its validation. Individual units add their own targeted tests on
+#: top of this baseline.
+BASELINE_REQUIRED_TESTS: Final[tuple[str, ...]] = (
+    "python -m pytest tests/smoke -v",
+    "python scripts/governance_lint.py",
+    "python -m pytest tests/regression/test_public_output_contract.py "
+    "tests/regression/test_v12_contracts_preserved.py "
+    "tests/regression/test_authority_invariants.py -v",
+)
+
+#: Standard DoD bullets every unit must satisfy on top of its
+#: targeted DoD list.
+BASELINE_DEFINITION_OF_DONE: Final[tuple[str, ...]] = (
+    "module imports cleanly with no forbidden imports",
+    "atomic write restricted to the unit's own logs/<module>/ directory",
+    "deterministic byte-identical output with injected generated_at_utc",
+    "frozen contracts unchanged (research_latest.json, strategy_matrix.csv)",
+    (
+        "no live / paper / shadow / broker / risk / execution path "
+        "changes in the diff"
+    ),
+    "no dashboard/dashboard.py change",
+    "no .claude/** change",
+    "no edit to canonical roadmap or canonical policy docs",
+    (
+        "PR opened via gh pr create (no --admin, no force push, no "
+        "hook bypass)"
+    ),
+)
+
+#: Standard stop conditions every unit honours on top of its targeted
+#: stop conditions.
+BASELINE_STOP_CONDITIONS: Final[tuple[str, ...]] = (
+    "forbidden import or forbidden token found in module source -> STOP, "
+    "fix, do not weaken the scan",
+    "any forbidden path appears in git diff -> STOP, abort the PR",
+    (
+        "frozen-contract / public-output regression test fails -> STOP, "
+        "do not bypass"
+    ),
+    "pre-commit or pre-push hook fails -> STOP, fix root cause; no --no-verify",
+    "any attempt to grant runtime / trading authority -> STOP, abort",
+)
+
+
+# ---------------------------------------------------------------------------
+# Discipline invariants emitted on every projection
+# ---------------------------------------------------------------------------
+
+_DECOMPOSITION_INVARIANTS: Final[dict[str, bool]] = {
+    "actually_modifies_target": False,
+    "creates_real_branches": False,
+    "opens_real_prs": False,
+    "mergeable_by_agent": False,
+    "deployable_by_agent": False,
+    "writes_to_seed_jsonl": False,
+    "writes_to_delegation_seed_jsonl": False,
+    "writes_to_generated_seed_jsonl": False,
+    "fuzzy_parsing": False,
+    "uses_subprocess_or_network": False,
+    "calls_llm_or_external_api": False,
+    "mutates_research_artifacts": False,
+    "mutates_roadmap_status_fields": False,
+    "marks_phase_complete": False,
+    "operator_promotion_required": True,
+    "step5_implementation_allowed": False,
+    "diagnostics_do_not_trade": True,
+    "external_data_is_not_alpha": True,
+    "addendum_2_not_present": True,
+    "addendum_3_not_present": True,
+    "grants_runtime_authority": False,
+    "grants_trading_authority": False,
+    "grants_paper_authority": False,
+    "grants_shadow_authority": False,
+    "grants_broker_authority": False,
+    "grants_risk_authority": False,
+    "grants_live_authority": False,
+    "calls_execution_authority_classifier": False,  # A20c will flip this on
+    "final_authority_classified": False,  # A20c will flip this on
+    "next_buildable_selector_present": False,  # A20e will flip this on
+    "aac_visibility_present": False,  # A20d will flip this on
+}
+
+
+# ---------------------------------------------------------------------------
+# Hand-encoded ImplementationUnit seed data
+# ---------------------------------------------------------------------------
+#
+# Each entry below is a partial unit. The decomposer merges baseline
+# ``forbidden_files`` + baseline ``forbidden_surface_reasons`` +
+# baseline ``required_tests`` + baseline ``definition_of_done`` +
+# baseline ``stop_conditions`` into every record so the emitted
+# projection always satisfies the per-unit invariants pinned by the
+# test suite.
+
+# Re-usable helpers --------------------------------------------------------
+
+
+def _targeted_unit_tests(test_path: str) -> tuple[str, ...]:
+    return (
+        f"python -m pytest {test_path} -v",
+    )
+
+
+def _governance_doc_dod(doc_path: str) -> tuple[str, ...]:
+    return (
+        f"{doc_path} written and pinned by an existence-or-content unit test",
+        "doc marks the unit as read-only by construction",
+        (
+            "doc explicitly disclaims runtime / trading / paper / "
+            "shadow / broker / risk / live authority"
+        ),
+    )
+
+
+def _reporting_module_dod(
+    module_dotted: str, artefact_logs_dir: str
+) -> tuple[str, ...]:
+    return (
+        f"{module_dotted} module imports cleanly under stdlib + roadmap_task_catalog only",
+        (
+            "module exposes deterministic collect_snapshot(...) "
+            "with closed vocabularies and bounded scalars"
+        ),
+        (
+            f"atomic write helper refuses every path outside "
+            f"{artefact_logs_dir}"
+        ),
+    )
+
+
+def _research_module_dod(target_path: str) -> tuple[str, ...]:
+    return (
+        f"{target_path} created with stdlib-only scaffold",
+        (
+            "no executable strategy generation; no LLM; no fuzzy "
+            "parsing; no broker / order / risk / execution import"
+        ),
+        (
+            "sidecar artefacts only; research_latest.json and "
+            "strategy_matrix.csv remain byte-frozen"
+        ),
+    )
+
+
+# Unit seed records -------------------------------------------------------
+
+_UNIT_SEED: Final[tuple[dict[str, Any], ...]] = (
+    # -------------------- v3.15.16 Intelligent Routing Layer ------------
+    {
+        "id": "u_v3_15_16_diagnostic_routing_signals_schema_001",
+        "roadmap_task_id": "phase_v3_15_16",
+        "title": (
+            "Read-only diagnostic-aware routing-signals schema and "
+            "projector"
+        ),
+        "phase": "v3.15.16",
+        "unit_kind": "reporting_module",
+        "target_layer": "campaign",
+        "source_requirement_ids": (
+            "req_v3_15_16_behavior_aware_routing",
+            "req_v3_15_16_diagnostic_aware_routing",
+        ),
+        "expected_files": (
+            "reporting/intelligent_routing_diagnostic_signals.py",
+            "tests/unit/test_intelligent_routing_diagnostic_signals.py",
+            "docs/governance/intelligent_routing_diagnostic_signals.md",
+        ),
+        "extra_forbidden_files": (),
+        "extra_forbidden_surface_reasons": ("step5_blocked",),
+        "extra_required_tests": _targeted_unit_tests(
+            "tests/unit/test_intelligent_routing_diagnostic_signals.py"
+        ),
+        "extra_definition_of_done": _reporting_module_dod(
+            "reporting.intelligent_routing_diagnostic_signals",
+            "logs/intelligent_routing_diagnostic_signals/",
+        )
+        + (
+            (
+                "schema exposes closed vocabularies for "
+                "entropy / tail / criticality / network / quorum "
+                "signal kinds"
+            ),
+            "no executable routing change; this PR is schema-only",
+        ),
+        "extra_stop_conditions": (
+            (
+                "any change to the existing routing executor surface "
+                "-> STOP, abort"
+            ),
+        ),
+        "prerequisites": (),
+        "risk_class": "LOW",
+        "authority_hint": "AUTO_ALLOWED_CANDIDATE",
+        "operator_gate": "none",
+        "status": "not_started",
+    },
+    {
+        "id": "u_v3_15_16_routing_explanation_reporter_001",
+        "roadmap_task_id": "phase_v3_15_16",
+        "title": (
+            "Read-only routing-decision explanation reporter "
+            "(deterministic projector)"
+        ),
+        "phase": "v3.15.16",
+        "unit_kind": "reporting_module",
+        "target_layer": "reporting",
+        "source_requirement_ids": (
+            "req_v3_15_16_behavior_aware_routing",
+            "req_v3_15_16_diagnostic_aware_routing",
+        ),
+        "expected_files": (
+            "reporting/routing_explanation.py",
+            "tests/unit/test_routing_explanation.py",
+        ),
+        "extra_forbidden_files": (),
+        "extra_forbidden_surface_reasons": (),
+        "extra_required_tests": _targeted_unit_tests(
+            "tests/unit/test_routing_explanation.py"
+        ),
+        "extra_definition_of_done": _reporting_module_dod(
+            "reporting.routing_explanation",
+            "logs/routing_explanation/",
+        )
+        + (
+            (
+                "report exposes why each candidate was routed / "
+                "deprioritised, with bounded-scalar evidence only"
+            ),
+        ),
+        "extra_stop_conditions": (),
+        "prerequisites": (
+            "u_v3_15_16_diagnostic_routing_signals_schema_001",
+        ),
+        "risk_class": "LOW",
+        "authority_hint": "AUTO_ALLOWED_CANDIDATE",
+        "operator_gate": "none",
+        "status": "not_started",
+    },
+    {
+        "id": "u_v3_15_16_routing_governance_doc_001",
+        "roadmap_task_id": "phase_v3_15_16",
+        "title": (
+            "Governance doc for diagnostic-aware routing signals "
+            "(read-only)"
+        ),
+        "phase": "v3.15.16",
+        "unit_kind": "governance_doc",
+        "target_layer": "governance",
+        "source_requirement_ids": (
+            "req_v3_15_16_diagnostic_aware_routing",
+        ),
+        "expected_files": (
+            "docs/governance/intelligent_routing_diagnostic_signals.md",
+        ),
+        "extra_forbidden_files": (),
+        "extra_forbidden_surface_reasons": (),
+        "extra_required_tests": (),
+        "extra_definition_of_done": _governance_doc_dod(
+            "docs/governance/intelligent_routing_diagnostic_signals.md"
+        ),
+        "extra_stop_conditions": (),
+        "prerequisites": (
+            "u_v3_15_16_diagnostic_routing_signals_schema_001",
+        ),
+        "risk_class": "LOW",
+        "authority_hint": "AUTO_ALLOWED_CANDIDATE",
+        "operator_gate": "none",
+        "status": "not_started",
+    },
+    # -------------------- v3.15.17 Sampling Intelligence ----------------
+    {
+        "id": "u_v3_15_17_sampling_plan_reporter_001",
+        "roadmap_task_id": "phase_v3_15_17",
+        "title": (
+            "Deterministic sampling-plan projector (read-only "
+            "reporting module)"
+        ),
+        "phase": "v3.15.17",
+        "unit_kind": "reporting_module",
+        "target_layer": "preset",
+        "source_requirement_ids": (
+            "req_v3_15_17_deterministic_sampling",
+            "req_v3_15_17_diagnostic_aware_sampling",
+        ),
+        "expected_files": (
+            "reporting/sampling_plan.py",
+            "tests/unit/test_sampling_plan.py",
+            "docs/governance/sampling_plan.md",
+        ),
+        "extra_forbidden_files": (),
+        "extra_forbidden_surface_reasons": ("step5_blocked",),
+        "extra_required_tests": _targeted_unit_tests(
+            "tests/unit/test_sampling_plan.py"
+        ),
+        "extra_definition_of_done": _reporting_module_dod(
+            "reporting.sampling_plan",
+            "logs/sampling_plan/",
+        )
+        + (
+            (
+                "plan exposes diagnostic-conditioned sampling "
+                "metadata (tail / entropy / phase-transition / "
+                "barrier / resonance / network / post-shock / "
+                "null-model) without executing samples"
+            ),
+        ),
+        "extra_stop_conditions": (
+            (
+                "any stochastic search introduced -> STOP, sampling "
+                "must remain deterministic"
+            ),
+        ),
+        "prerequisites": (
+            "u_v3_15_16_diagnostic_routing_signals_schema_001",
+        ),
+        "risk_class": "LOW",
+        "authority_hint": "AUTO_ALLOWED_CANDIDATE",
+        "operator_gate": "none",
+        "status": "not_started",
+    },
+    {
+        "id": "u_v3_15_17_sampling_coverage_metrics_001",
+        "roadmap_task_id": "phase_v3_15_17",
+        "title": (
+            "Sampling coverage metrics reporter (read-only "
+            "deterministic projector)"
+        ),
+        "phase": "v3.15.17",
+        "unit_kind": "reporting_module",
+        "target_layer": "evidence",
+        "source_requirement_ids": (
+            "req_v3_15_17_deterministic_sampling",
+        ),
+        "expected_files": (
+            "reporting/sampling_coverage_metrics.py",
+            "tests/unit/test_sampling_coverage_metrics.py",
+        ),
+        "extra_forbidden_files": (),
+        "extra_forbidden_surface_reasons": (),
+        "extra_required_tests": _targeted_unit_tests(
+            "tests/unit/test_sampling_coverage_metrics.py"
+        ),
+        "extra_definition_of_done": _reporting_module_dod(
+            "reporting.sampling_coverage_metrics",
+            "logs/sampling_coverage_metrics/",
+        )
+        + (
+            (
+                "coverage / low-information / null-control regions "
+                "are reported as bounded scalars"
+            ),
+        ),
+        "extra_stop_conditions": (),
+        "prerequisites": ("u_v3_15_17_sampling_plan_reporter_001",),
+        "risk_class": "LOW",
+        "authority_hint": "AUTO_ALLOWED_CANDIDATE",
+        "operator_gate": "none",
+        "status": "not_started",
+    },
+    # -------------------- v3.15.18 Research Observability Expansion -----
+    {
+        "id": "u_v3_15_18_diagnostic_explanation_reporter_001",
+        "roadmap_task_id": "phase_v3_15_18",
+        "title": (
+            "Research diagnostic-contribution explanation reporter "
+            "(read-only)"
+        ),
+        "phase": "v3.15.18",
+        "unit_kind": "reporting_module",
+        "target_layer": "reporting",
+        "source_requirement_ids": (
+            "req_v3_15_18_research_observability",
+            "req_v3_15_18_diagnostic_surfaces",
+        ),
+        "expected_files": (
+            "reporting/research_diagnostic_explanation.py",
+            "tests/unit/test_research_diagnostic_explanation.py",
+            "docs/governance/research_diagnostic_explanation.md",
+        ),
+        "extra_forbidden_files": (),
+        "extra_forbidden_surface_reasons": (),
+        "extra_required_tests": _targeted_unit_tests(
+            "tests/unit/test_research_diagnostic_explanation.py"
+        ),
+        "extra_definition_of_done": _reporting_module_dod(
+            "reporting.research_diagnostic_explanation",
+            "logs/research_diagnostic_explanation/",
+        )
+        + (
+            (
+                "reporter explains which diagnostics supported / "
+                "contradicted each candidate"
+            ),
+            "no mutation endpoints; no approval buttons; no frontend change",
+        ),
+        "extra_stop_conditions": (
+            (
+                "any approval verb (approve / reject / merge / "
+                "deploy) introduced -> STOP, abort"
+            ),
+        ),
+        "prerequisites": (),
+        "risk_class": "LOW",
+        "authority_hint": "AUTO_ALLOWED_CANDIDATE",
+        "operator_gate": "none",
+        "status": "not_started",
+    },
+    {
+        "id": "u_v3_15_18_lineage_provenance_reporter_001",
+        "roadmap_task_id": "phase_v3_15_18",
+        "title": (
+            "Hypothesis-seed lineage / external-data provenance "
+            "reporter (read-only)"
+        ),
+        "phase": "v3.15.18",
+        "unit_kind": "reporting_module",
+        "target_layer": "reporting",
+        "source_requirement_ids": (
+            "req_v3_15_18_research_observability",
+            "req_v3_15_18_diagnostic_surfaces",
+            "req_addendum_1_public_source_manifest_fields",
+        ),
+        "expected_files": (
+            "reporting/research_lineage_provenance.py",
+            "tests/unit/test_research_lineage_provenance.py",
+        ),
+        "extra_forbidden_files": (),
+        "extra_forbidden_surface_reasons": (),
+        "extra_required_tests": _targeted_unit_tests(
+            "tests/unit/test_research_lineage_provenance.py"
+        ),
+        "extra_definition_of_done": _reporting_module_dod(
+            "reporting.research_lineage_provenance",
+            "logs/research_lineage_provenance/",
+        )
+        + (
+            (
+                "exposes the public-source manifest fields and the "
+                "quality-gate verdicts as a bounded-scalar projection"
+            ),
+        ),
+        "extra_stop_conditions": (),
+        "prerequisites": (
+            "u_v3_15_18_diagnostic_explanation_reporter_001",
+        ),
+        "risk_class": "LOW",
+        "authority_hint": "AUTO_ALLOWED_CANDIDATE",
+        "operator_gate": "none",
+        "status": "not_started",
+    },
+    {
+        "id": "u_v3_15_18_quorum_state_reporter_001",
+        "roadmap_task_id": "phase_v3_15_18",
+        "title": (
+            "Independent-evidence quorum-state reporter (read-only "
+            "deterministic projector)"
+        ),
+        "phase": "v3.15.18",
+        "unit_kind": "reporting_module",
+        "target_layer": "evidence",
+        "source_requirement_ids": (
+            "req_addendum_1_independent_evidence_quorum",
+        ),
+        "expected_files": (
+            "reporting/quorum_state.py",
+            "tests/unit/test_quorum_state.py",
+        ),
+        "extra_forbidden_files": (),
+        "extra_forbidden_surface_reasons": (),
+        "extra_required_tests": _targeted_unit_tests(
+            "tests/unit/test_quorum_state.py"
+        ),
+        "extra_definition_of_done": _reporting_module_dod(
+            "reporting.quorum_state",
+            "logs/quorum_state/",
+        )
+        + (
+            (
+                "exposes quorum status, confirmation diversity, "
+                "single-source dependency flag"
+            ),
+            (
+                "quorum is a promotion guardrail only; never a "
+                "live-trade trigger"
+            ),
+        ),
+        "extra_stop_conditions": (),
+        "prerequisites": (
+            "u_v3_15_18_diagnostic_explanation_reporter_001",
+        ),
+        "risk_class": "LOW",
+        "authority_hint": "AUTO_ALLOWED_CANDIDATE",
+        "operator_gate": "none",
+        "status": "not_started",
+    },
+    # -------------------- v3.15.19 Hypothesis Discovery Engine ----------
+    {
+        "id": "u_v3_15_19_behavior_catalog_scaffold_001",
+        "roadmap_task_id": "phase_v3_15_19",
+        "title": (
+            "research/hypothesis_discovery/behavior_catalog.py "
+            "scaffold (deterministic, non-executable)"
+        ),
+        "phase": "v3.15.19",
+        "unit_kind": "research_module",
+        "target_layer": "hypothesis_discovery",
+        "source_requirement_ids": (
+            "req_v3_15_19_hypothesis_discovery_modules",
+        ),
+        "expected_files": (
+            "research/hypothesis_discovery/__init__.py",
+            "research/hypothesis_discovery/behavior_catalog.py",
+            "tests/unit/test_hypothesis_discovery_behavior_catalog.py",
+        ),
+        "extra_forbidden_files": (),
+        "extra_forbidden_surface_reasons": ("step5_blocked",),
+        "extra_required_tests": _targeted_unit_tests(
+            "tests/unit/test_hypothesis_discovery_behavior_catalog.py"
+        ),
+        "extra_definition_of_done": _research_module_dod(
+            "research/hypothesis_discovery/behavior_catalog.py"
+        )
+        + (
+            (
+                "behavior catalog records named market behaviours, "
+                "not indicator combinations"
+            ),
+        ),
+        "extra_stop_conditions": (
+            (
+                "auto-writing executable strategy code "
+                "-> STOP, abort"
+            ),
+        ),
+        "prerequisites": (
+            "u_v3_15_18_diagnostic_explanation_reporter_001",
+        ),
+        "risk_class": "MEDIUM",
+        "authority_hint": "NEEDS_HUMAN_CANDIDATE",
+        "operator_gate": "operator_go_required",
+        "status": "not_started",
+    },
+    {
+        "id": "u_v3_15_19_behavior_hypotheses_scaffold_001",
+        "roadmap_task_id": "phase_v3_15_19",
+        "title": (
+            "research/hypothesis_discovery/behavior_hypotheses.py "
+            "scaffold (deterministic hypothesis records)"
+        ),
+        "phase": "v3.15.19",
+        "unit_kind": "research_module",
+        "target_layer": "hypothesis_discovery",
+        "source_requirement_ids": (
+            "req_v3_15_19_hypothesis_discovery_modules",
+        ),
+        "expected_files": (
+            "research/hypothesis_discovery/behavior_hypotheses.py",
+            "tests/unit/test_hypothesis_discovery_behavior_hypotheses.py",
+        ),
+        "extra_forbidden_files": (),
+        "extra_forbidden_surface_reasons": ("step5_blocked",),
+        "extra_required_tests": _targeted_unit_tests(
+            "tests/unit/test_hypothesis_discovery_behavior_hypotheses.py"
+        ),
+        "extra_definition_of_done": _research_module_dod(
+            "research/hypothesis_discovery/behavior_hypotheses.py"
+        )
+        + (
+            (
+                "hypotheses are behaviour-first records with "
+                "bounded scalars and source provenance"
+            ),
+        ),
+        "extra_stop_conditions": (
+            (
+                "stochastic mutation introduced -> STOP, abort"
+            ),
+        ),
+        "prerequisites": ("u_v3_15_19_behavior_catalog_scaffold_001",),
+        "risk_class": "MEDIUM",
+        "authority_hint": "NEEDS_HUMAN_CANDIDATE",
+        "operator_gate": "operator_go_required",
+        "status": "not_started",
+    },
+    {
+        "id": "u_v3_15_19_opportunity_scoring_scaffold_001",
+        "roadmap_task_id": "phase_v3_15_19",
+        "title": (
+            "research/hypothesis_discovery/opportunity_scoring.py "
+            "scaffold (deterministic, explainable)"
+        ),
+        "phase": "v3.15.19",
+        "unit_kind": "research_module",
+        "target_layer": "hypothesis_discovery",
+        "source_requirement_ids": (
+            "req_v3_15_19_hypothesis_discovery_modules",
+            "req_v3_15_19_opportunity_probability_score",
+        ),
+        "expected_files": (
+            "research/hypothesis_discovery/opportunity_scoring.py",
+            "tests/unit/test_hypothesis_discovery_opportunity_scoring.py",
+        ),
+        "extra_forbidden_files": (),
+        "extra_forbidden_surface_reasons": (),
+        "extra_required_tests": _targeted_unit_tests(
+            "tests/unit/test_hypothesis_discovery_opportunity_scoring.py"
+        ),
+        "extra_definition_of_done": _research_module_dod(
+            "research/hypothesis_discovery/opportunity_scoring.py"
+        )
+        + (
+            (
+                "opportunity_probability_score = expected research "
+                "value; not alpha certainty, not ML confidence, not "
+                "prediction certainty"
+            ),
+            "scoring is deterministic and explainable",
+        ),
+        "extra_stop_conditions": (
+            (
+                "any hidden ML / RL / opaque selector introduced "
+                "-> STOP, abort"
+            ),
+        ),
+        "prerequisites": ("u_v3_15_19_behavior_hypotheses_scaffold_001",),
+        "risk_class": "MEDIUM",
+        "authority_hint": "NEEDS_HUMAN_CANDIDATE",
+        "operator_gate": "operator_go_required",
+        "status": "not_started",
+    },
+    {
+        "id": "u_v3_15_19_diagnostic_hypothesis_adapter_scaffold_001",
+        "roadmap_task_id": "phase_v3_15_19",
+        "title": (
+            "research/hypothesis_discovery/diagnostic_hypothesis_adapter.py "
+            "scaffold (deterministic bridge)"
+        ),
+        "phase": "v3.15.19",
+        "unit_kind": "research_module",
+        "target_layer": "hypothesis_discovery",
+        "source_requirement_ids": (
+            "req_v3_15_19_addendum_modules",
+        ),
+        "expected_files": (
+            "research/hypothesis_discovery/diagnostic_hypothesis_adapter.py",
+            "tests/unit/test_hypothesis_discovery_diagnostic_adapter.py",
+        ),
+        "extra_forbidden_files": (),
+        "extra_forbidden_surface_reasons": (),
+        "extra_required_tests": _targeted_unit_tests(
+            "tests/unit/test_hypothesis_discovery_diagnostic_adapter.py"
+        ),
+        "extra_definition_of_done": _research_module_dod(
+            "research/hypothesis_discovery/diagnostic_hypothesis_adapter.py"
+        )
+        + (
+            (
+                "adapter maps Addendum 1 diagnostic outputs to "
+                "behaviour-first hypothesis seeds (no strategy "
+                "invention)"
+            ),
+        ),
+        "extra_stop_conditions": (),
+        "prerequisites": ("u_v3_15_19_opportunity_scoring_scaffold_001",),
+        "risk_class": "MEDIUM",
+        "authority_hint": "NEEDS_HUMAN_CANDIDATE",
+        "operator_gate": "operator_go_required",
+        "status": "not_started",
+    },
+    {
+        "id": "u_v3_15_19_hypothesis_discovery_reporter_001",
+        "roadmap_task_id": "phase_v3_15_19",
+        "title": (
+            "Read-only hypothesis-discovery summary reporter "
+            "(reporting module)"
+        ),
+        "phase": "v3.15.19",
+        "unit_kind": "reporting_module",
+        "target_layer": "reporting",
+        "source_requirement_ids": (
+            "req_v3_15_19_hypothesis_discovery_modules",
+            "req_v3_15_19_opportunity_probability_score",
+        ),
+        "expected_files": (
+            "reporting/hypothesis_discovery_summary.py",
+            "tests/unit/test_hypothesis_discovery_summary.py",
+        ),
+        "extra_forbidden_files": (),
+        "extra_forbidden_surface_reasons": (),
+        "extra_required_tests": _targeted_unit_tests(
+            "tests/unit/test_hypothesis_discovery_summary.py"
+        ),
+        "extra_definition_of_done": _reporting_module_dod(
+            "reporting.hypothesis_discovery_summary",
+            "logs/hypothesis_discovery_summary/",
+        )
+        + (
+            (
+                "summary projects bounded-scalar opportunity scores "
+                "and seed provenance"
+            ),
+        ),
+        "extra_stop_conditions": (),
+        "prerequisites": (
+            "u_v3_15_19_diagnostic_hypothesis_adapter_scaffold_001",
+        ),
+        "risk_class": "LOW",
+        "authority_hint": "AUTO_ALLOWED_CANDIDATE",
+        "operator_gate": "none",
+        "status": "not_started",
+    },
+    # -------------------- v3.15.20 Failure -> Action Mapping ------------
+    {
+        "id": "u_v3_15_20_failure_taxonomy_reporter_001",
+        "roadmap_task_id": "phase_v3_15_20",
+        "title": (
+            "Deterministic failure-taxonomy reporter (read-only "
+            "projection module)"
+        ),
+        "phase": "v3.15.20",
+        "unit_kind": "reporting_module",
+        "target_layer": "policy",
+        "source_requirement_ids": (
+            "req_v3_15_20_failure_action_mappings",
+            "req_v3_15_20_addendum_mappings",
+        ),
+        "expected_files": (
+            "reporting/failure_taxonomy.py",
+            "tests/unit/test_failure_taxonomy.py",
+            "docs/governance/failure_taxonomy.md",
+        ),
+        "extra_forbidden_files": (),
+        "extra_forbidden_surface_reasons": (),
+        "extra_required_tests": _targeted_unit_tests(
+            "tests/unit/test_failure_taxonomy.py"
+        ),
+        "extra_definition_of_done": _reporting_module_dod(
+            "reporting.failure_taxonomy",
+            "logs/failure_taxonomy/",
+        )
+        + (
+            (
+                "taxonomy is closed-vocab; widening requires a code "
+                "change + matching test"
+            ),
+        ),
+        "extra_stop_conditions": (),
+        "prerequisites": (),
+        "risk_class": "LOW",
+        "authority_hint": "AUTO_ALLOWED_CANDIDATE",
+        "operator_gate": "none",
+        "status": "not_started",
+    },
+    {
+        "id": "u_v3_15_20_failure_action_mapping_reporter_001",
+        "roadmap_task_id": "phase_v3_15_20",
+        "title": (
+            "Failure -> action mapping reporter (deterministic, "
+            "research-routing only)"
+        ),
+        "phase": "v3.15.20",
+        "unit_kind": "reporting_module",
+        "target_layer": "policy",
+        "source_requirement_ids": (
+            "req_v3_15_20_failure_action_mappings",
+            "req_v3_15_20_addendum_mappings",
+        ),
+        "expected_files": (
+            "reporting/failure_action_mapping.py",
+            "tests/unit/test_failure_action_mapping.py",
+        ),
+        "extra_forbidden_files": (),
+        "extra_forbidden_surface_reasons": (),
+        "extra_required_tests": _targeted_unit_tests(
+            "tests/unit/test_failure_action_mapping.py"
+        ),
+        "extra_definition_of_done": _reporting_module_dod(
+            "reporting.failure_action_mapping",
+            "logs/failure_action_mapping/",
+        )
+        + (
+            (
+                "mappings affect routing / suppression / cooldown / "
+                "confirmation only; never trade execution"
+            ),
+            (
+                "mapping deterministic; failure-class -> action is a "
+                "pure function"
+            ),
+        ),
+        "extra_stop_conditions": (
+            (
+                "any mapping that touches live risk / capital "
+                "allocation / order placement -> STOP, abort"
+            ),
+        ),
+        "prerequisites": (
+            "u_v3_15_20_failure_taxonomy_reporter_001",
+        ),
+        "risk_class": "LOW",
+        "authority_hint": "AUTO_ALLOWED_CANDIDATE",
+        "operator_gate": "none",
+        "status": "not_started",
+    },
+    # -------------------- Addendum 1 cross-cutting groundwork -----------
+    {
+        "id": "u_addendum_1_diagnostics_library_scaffold_001",
+        "roadmap_task_id": "addendum_1_diagnostics_intake",
+        "title": (
+            "Behavior Diagnostics Library scaffold under "
+            "research/diagnostics/ (null-models first)"
+        ),
+        "phase": "addendum_1",
+        "unit_kind": "diagnostic_primitive",
+        "target_layer": "diagnostics",
+        "source_requirement_ids": (
+            "req_addendum_1_diagnostics_do_not_trade",
+            "req_addendum_1_null_model_brownian",
+            "req_addendum_1_sidecar_artifacts_only",
+        ),
+        "expected_files": (
+            "research/diagnostics/__init__.py",
+            "research/diagnostics/null_models.py",
+            "tests/unit/test_research_diagnostics_null_models.py",
+        ),
+        "extra_forbidden_files": (),
+        "extra_forbidden_surface_reasons": ("step5_blocked",),
+        "extra_required_tests": _targeted_unit_tests(
+            "tests/unit/test_research_diagnostics_null_models.py"
+        ),
+        "extra_definition_of_done": _research_module_dod(
+            "research/diagnostics/null_models.py"
+        )
+        + (
+            (
+                "diagnostic primitives are pure functions; no "
+                "executable strategy generation; no broker / order "
+                "/ risk / execution surface touched"
+            ),
+            "diagnostics do not trade",
+        ),
+        "extra_stop_conditions": (
+            (
+                "any diagnostic that mutates live risk or places a "
+                "trade -> STOP, abort"
+            ),
+        ),
+        "prerequisites": (),
+        "risk_class": "MEDIUM",
+        "authority_hint": "NEEDS_HUMAN_CANDIDATE",
+        "operator_gate": "operator_go_required",
+        "status": "not_started",
+    },
+    {
+        "id": "u_addendum_1_external_intelligence_source_registry_001",
+        "roadmap_task_id": "addendum_1_diagnostics_intake",
+        "title": (
+            "External Intelligence source registry + source-manifest "
+            "schema (no fetchers)"
+        ),
+        "phase": "addendum_1",
+        "unit_kind": "external_intelligence_source",
+        "target_layer": "external_intelligence",
+        "source_requirement_ids": (
+            "req_addendum_1_external_intelligence_intake",
+            "req_addendum_1_public_source_manifest_fields",
+        ),
+        "expected_files": (
+            "research/external_intelligence/__init__.py",
+            "research/external_intelligence/source_registry.py",
+            "research/external_intelligence/source_manifest_schema.py",
+            "tests/unit/test_external_intelligence_source_registry.py",
+        ),
+        "extra_forbidden_files": (),
+        "extra_forbidden_surface_reasons": (),
+        "extra_required_tests": _targeted_unit_tests(
+            "tests/unit/test_external_intelligence_source_registry.py"
+        ),
+        "extra_definition_of_done": _research_module_dod(
+            "research/external_intelligence/source_registry.py"
+        )
+        + (
+            (
+                "manifest fields verbatim from Addendum 1 Section "
+                "8.4; no paid feeds, no vendor alpha"
+            ),
+            (
+                "no network calls; this unit only models sources, "
+                "it does not fetch"
+            ),
+        ),
+        "extra_stop_conditions": (
+            (
+                "any paid-feed / vendor-alpha import introduced "
+                "-> STOP, abort"
+            ),
+        ),
+        "prerequisites": (),
+        "risk_class": "MEDIUM",
+        "authority_hint": "NEEDS_HUMAN_CANDIDATE",
+        "operator_gate": "operator_go_required",
+        "status": "not_started",
+    },
+    {
+        "id": "u_addendum_1_public_data_quality_gates_001",
+        "roadmap_task_id": "addendum_1_diagnostics_intake",
+        "title": (
+            "Public-data quality-gate primitives (freshness / "
+            "missing / monotonicity / duplicate / outlier / coverage)"
+        ),
+        "phase": "addendum_1",
+        "unit_kind": "external_intelligence_source",
+        "target_layer": "external_intelligence",
+        "source_requirement_ids": (
+            "req_addendum_1_public_data_quality_gates",
+            "req_addendum_1_external_data_not_alpha",
+        ),
+        "expected_files": (
+            "research/external_intelligence/quality_gates.py",
+            "tests/unit/test_external_intelligence_quality_gates.py",
+        ),
+        "extra_forbidden_files": (),
+        "extra_forbidden_surface_reasons": (),
+        "extra_required_tests": _targeted_unit_tests(
+            "tests/unit/test_external_intelligence_quality_gates.py"
+        ),
+        "extra_definition_of_done": _research_module_dod(
+            "research/external_intelligence/quality_gates.py"
+        )
+        + (
+            (
+                "quality gates are pure functions; no hypothesis "
+                "seed promoted from public data without passing all "
+                "gates"
+            ),
+            "external data is an unvalidated prior, not alpha",
+        ),
+        "extra_stop_conditions": (),
+        "prerequisites": (
+            "u_addendum_1_external_intelligence_source_registry_001",
+        ),
+        "risk_class": "MEDIUM",
+        "authority_hint": "NEEDS_HUMAN_CANDIDATE",
+        "operator_gate": "operator_go_required",
+        "status": "not_started",
+    },
+    {
+        "id": "u_addendum_1_diagnostic_sidecar_writer_001",
+        "roadmap_task_id": "addendum_1_diagnostics_intake",
+        "title": (
+            "Diagnostic sidecar artefact writer "
+            "(research/diagnostics/seed_artifact_writer.py)"
+        ),
+        "phase": "addendum_1",
+        "unit_kind": "diagnostic_primitive",
+        "target_layer": "diagnostics",
+        "source_requirement_ids": (
+            "req_addendum_1_sidecar_artifacts_only",
+        ),
+        "expected_files": (
+            "research/diagnostics/seed_artifact_writer.py",
+            "tests/unit/test_research_diagnostics_seed_artifact_writer.py",
+        ),
+        "extra_forbidden_files": (),
+        "extra_forbidden_surface_reasons": ("frozen_seed_files",),
+        "extra_required_tests": _targeted_unit_tests(
+            "tests/unit/test_research_diagnostics_seed_artifact_writer.py"
+        ),
+        "extra_definition_of_done": _research_module_dod(
+            "research/diagnostics/seed_artifact_writer.py"
+        )
+        + (
+            (
+                "writes only under artifacts/diagnostics/*.v1.json "
+                "(atomic, allowlist-restricted)"
+            ),
+            (
+                "never writes to research/research_latest.json or "
+                "research/strategy_matrix.csv"
+            ),
+        ),
+        "extra_stop_conditions": (
+            (
+                "any write path outside artifacts/diagnostics/ "
+                "-> STOP, abort"
+            ),
+        ),
+        "prerequisites": (
+            "u_addendum_1_diagnostics_library_scaffold_001",
+        ),
+        "risk_class": "MEDIUM",
+        "authority_hint": "NEEDS_HUMAN_CANDIDATE",
+        "operator_gate": "operator_go_required",
+        "status": "not_started",
+    },
+    {
+        "id": "u_addendum_1_diagnostics_governance_doc_001",
+        "roadmap_task_id": "addendum_1_diagnostics_intake",
+        "title": (
+            "Governance doc for the Behavior Diagnostics Library "
+            "(read-only)"
+        ),
+        "phase": "addendum_1",
+        "unit_kind": "governance_doc",
+        "target_layer": "governance",
+        "source_requirement_ids": (
+            "req_addendum_1_diagnostics_do_not_trade",
+            "req_addendum_1_external_data_not_alpha",
+            "req_addendum_1_sidecar_artifacts_only",
+        ),
+        "expected_files": (
+            "docs/governance/research_diagnostics_library.md",
+        ),
+        "extra_forbidden_files": (),
+        "extra_forbidden_surface_reasons": (),
+        "extra_required_tests": (),
+        "extra_definition_of_done": _governance_doc_dod(
+            "docs/governance/research_diagnostics_library.md"
+        )
+        + (
+            (
+                "doc pins the Diagnostics-do-not-trade and "
+                "External-data-is-not-alpha principles verbatim"
+            ),
+        ),
+        "extra_stop_conditions": (),
+        "prerequisites": (),
+        "risk_class": "LOW",
+        "authority_hint": "AUTO_ALLOWED_CANDIDATE",
+        "operator_gate": "none",
+        "status": "not_started",
+    },
+)
+
+
+# ---------------------------------------------------------------------------
+# Decomposition helpers
+# ---------------------------------------------------------------------------
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _bounded_str(value: Any, max_len: int) -> str:
+    if not isinstance(value, str):
+        return ""
+    if len(value) <= max_len:
+        return value
+    return value[:max_len]
+
+
+def _bounded_str_tuple(values: Any, max_items: int, max_len: int) -> tuple[str, ...]:
+    if not isinstance(values, (list, tuple)):
+        return ()
+    out: list[str] = []
+    seen: set[str] = set()
+    for v in values:
+        if not isinstance(v, str):
+            continue
+        b = _bounded_str(v, max_len)
+        if not b or b in seen:
+            continue
+        seen.add(b)
+        out.append(b)
+        if len(out) >= max_items:
+            break
+    return tuple(out)
+
+
+def _merge_forbidden_files(extra: tuple[str, ...]) -> list[str]:
+    merged = list(BASELINE_FORBIDDEN_FILES) + list(extra)
+    seen: set[str] = set()
+    out: list[str] = []
+    for entry in merged:
+        if entry in seen:
+            continue
+        seen.add(entry)
+        out.append(entry)
+    out.sort()
+    return out[:MAX_FORBIDDEN_FILES]
+
+
+def _merge_forbidden_surface_reasons(
+    extra: tuple[str, ...],
+) -> list[str]:
+    merged = list(BASELINE_FORBIDDEN_SURFACE_REASONS) + list(extra)
+    seen: set[str] = set()
+    out: list[str] = []
+    for r in merged:
+        if r in seen:
+            continue
+        if r not in FORBIDDEN_SURFACE_REASON:
+            continue
+        seen.add(r)
+        out.append(r)
+    out.sort()
+    return out[:MAX_FORBIDDEN_SURFACE_REASONS]
+
+
+def _merge_required_tests(extra: tuple[str, ...]) -> list[str]:
+    merged = list(extra) + list(BASELINE_REQUIRED_TESTS)
+    seen: set[str] = set()
+    out: list[str] = []
+    for t in merged:
+        if t in seen:
+            continue
+        seen.add(t)
+        out.append(t)
+    return out[:MAX_REQUIRED_TESTS]
+
+
+def _merge_definition_of_done(extra: tuple[str, ...]) -> list[str]:
+    merged = list(extra) + list(BASELINE_DEFINITION_OF_DONE)
+    seen: set[str] = set()
+    out: list[str] = []
+    for d in merged:
+        b = _bounded_str(d, MAX_LIST_ITEM_LEN)
+        if not b or b in seen:
+            continue
+        seen.add(b)
+        out.append(b)
+    return out[:MAX_DOD_ITEMS]
+
+
+def _merge_stop_conditions(extra: tuple[str, ...]) -> list[str]:
+    merged = list(extra) + list(BASELINE_STOP_CONDITIONS)
+    seen: set[str] = set()
+    out: list[str] = []
+    for s in merged:
+        b = _bounded_str(s, MAX_LIST_ITEM_LEN)
+        if not b or b in seen:
+            continue
+        seen.add(b)
+        out.append(b)
+    return out[:MAX_STOP_CONDITIONS]
+
+
+def _resolve_authority_hint(value: Any) -> str:
+    """Fail-closed authority-hint resolver. Anything outside the
+    closed vocabulary falls back to NEEDS_HUMAN_CANDIDATE."""
+    if value in AUTHORITY_HINT:
+        return value
+    return "NEEDS_HUMAN_CANDIDATE"
+
+
+def _normalize_unit(raw: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": _bounded_str(raw["id"], MAX_ID_LEN),
+        "roadmap_task_id": _bounded_str(raw["roadmap_task_id"], MAX_ID_LEN),
+        "title": _bounded_str(raw["title"], MAX_TITLE_LEN),
+        "phase": raw["phase"],
+        "unit_kind": raw["unit_kind"],
+        "target_layer": raw["target_layer"],
+        "source_requirement_ids": list(
+            _bounded_str_tuple(
+                raw.get("source_requirement_ids", ()),
+                MAX_SOURCE_REQUIREMENT_IDS,
+                MAX_ID_LEN,
+            )
+        ),
+        "expected_files": list(
+            _bounded_str_tuple(
+                raw.get("expected_files", ()),
+                MAX_EXPECTED_FILES,
+                MAX_PATH_LEN,
+            )
+        ),
+        "forbidden_files": _merge_forbidden_files(
+            raw.get("extra_forbidden_files", ())
+        ),
+        "forbidden_surface_reasons": _merge_forbidden_surface_reasons(
+            raw.get("extra_forbidden_surface_reasons", ())
+        ),
+        "required_tests": _merge_required_tests(
+            raw.get("extra_required_tests", ())
+        ),
+        "definition_of_done": _merge_definition_of_done(
+            raw.get("extra_definition_of_done", ())
+        ),
+        "stop_conditions": _merge_stop_conditions(
+            raw.get("extra_stop_conditions", ())
+        ),
+        "prerequisites": list(
+            _bounded_str_tuple(
+                raw.get("prerequisites", ()),
+                MAX_PREREQUISITES,
+                MAX_ID_LEN,
+            )
+        ),
+        "risk_class": raw["risk_class"]
+        if raw.get("risk_class") in RISK_CLASS
+        else "UNKNOWN",
+        "authority_hint": _resolve_authority_hint(raw.get("authority_hint")),
+        "operator_gate": raw["operator_gate"]
+        if raw.get("operator_gate") in OPERATOR_GATE
+        else "operator_go_required",
+        "status": raw["status"]
+        if raw.get("status") in UNIT_STATUS
+        else "not_started",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Snapshot assembly
+# ---------------------------------------------------------------------------
+
+
+def collect_snapshot(
+    *,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    """Build the deterministic implementation-unit decomposition.
+
+    Args:
+        generated_at_utc: override the report timestamp. Tests inject
+            this for byte-stable output.
+    """
+    ts = generated_at_utc if generated_at_utc is not None else _utcnow()
+
+    # Read the upstream catalog to derive the known-task-id set. We
+    # only use it as a closed reference; we do not invent units for
+    # tasks that the catalog has not committed. This is what keeps
+    # Addendum 2 / Addendum 3 absence from leaking into the unit
+    # projection.
+    catalog = rtc.collect_snapshot(generated_at_utc=ts)
+    known_task_ids: set[str] = {t["id"] for t in catalog["roadmap_tasks"]}
+    known_phases: set[str] = {t["phase"] for t in catalog["roadmap_tasks"]}
+
+    units: list[dict[str, Any]] = []
+    skipped_warnings: list[str] = []
+    for seed in _UNIT_SEED:
+        if seed["roadmap_task_id"] not in known_task_ids:
+            skipped_warnings.append(
+                f"unit_skipped_unknown_task:{seed['id']}:"
+                f"{seed['roadmap_task_id']}"
+            )
+            continue
+        if seed["phase"] not in known_phases:
+            skipped_warnings.append(
+                f"unit_skipped_unknown_phase:{seed['id']}:{seed['phase']}"
+            )
+            continue
+        if seed["phase"] in ("addendum_2", "addendum_3"):
+            # Defensive: the catalog must not encode these phases as
+            # tasks, but reassert it here too so a future drift cannot
+            # smuggle invented units through.
+            skipped_warnings.append(
+                f"unit_skipped_addendum_absence:{seed['id']}:{seed['phase']}"
+            )
+            continue
+        units.append(_normalize_unit(seed))
+
+    units.sort(key=lambda u: (u["phase"], u["id"]))
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": ts,
+        "step5_enabled_substage": STEP5_ENABLED_SUBSTAGE,
+        "step5_implementation_allowed": step5_implementation_allowed,
+        "source_catalog_module_version": catalog["module_version"],
+        "source_catalog_schema_version": catalog["schema_version"],
+        "vocabularies": {
+            "unit_kind": list(UNIT_KIND),
+            "risk_class": list(RISK_CLASS),
+            "authority_hint": list(AUTHORITY_HINT),
+            "operator_gate": list(OPERATOR_GATE),
+            "unit_status": list(UNIT_STATUS),
+            "target_layer": list(TARGET_LAYER),
+            "forbidden_surface_reason": list(FORBIDDEN_SURFACE_REASON),
+        },
+        "skipped_warnings": skipped_warnings,
+        "implementation_units": units,
+        "decomposition_invariants": dict(_DECOMPOSITION_INVARIANTS),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Atomic write
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Write ``payload`` as sorted-key indented JSON to ``path``,
+    atomically, refusing any path outside ``logs/roadmap_task_units/``."""
+    posix = path.as_posix()
+    if _WRITE_PREFIX not in posix:
+        raise ValueError(
+            "roadmap_task_units._atomic_write_json refuses "
+            f"non-units-logs output path: {path}"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".roadmap_task_units.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_outputs(snapshot: dict[str, Any]) -> Path:
+    _atomic_write_json(ARTIFACT_LATEST, snapshot)
+    return ARTIFACT_LATEST
+
+
+# ---------------------------------------------------------------------------
+# Status renderer
+# ---------------------------------------------------------------------------
+
+
+def _render_status(snapshot: dict[str, Any]) -> str:
+    units = snapshot["implementation_units"]
+    inv = snapshot["decomposition_invariants"]
+    by_phase: dict[str, int] = {}
+    by_hint: dict[str, int] = {h: 0 for h in AUTHORITY_HINT}
+    by_risk: dict[str, int] = {r: 0 for r in RISK_CLASS}
+    for u in units:
+        by_phase[u["phase"]] = by_phase.get(u["phase"], 0) + 1
+        by_hint[u["authority_hint"]] += 1
+        by_risk[u["risk_class"]] += 1
+    lines = [
+        f"roadmap_task_units {snapshot['module_version']} "
+        f"schema={snapshot['schema_version']}",
+        f"generated_at_utc={snapshot['generated_at_utc']}",
+        f"implementation_units={len(units)}",
+        (
+            "step5_implementation_allowed="
+            f"{snapshot['step5_implementation_allowed']} "
+            f"step5_enabled_substage={snapshot['step5_enabled_substage']}"
+        ),
+        (
+            "addendum_2_not_present="
+            f"{inv['addendum_2_not_present']} "
+            "addendum_3_not_present="
+            f"{inv['addendum_3_not_present']}"
+        ),
+        (
+            "calls_execution_authority_classifier="
+            f"{inv['calls_execution_authority_classifier']} "
+            "final_authority_classified="
+            f"{inv['final_authority_classified']}"
+        ),
+        f"by_phase={dict(sorted(by_phase.items()))}",
+        f"by_authority_hint={by_hint}",
+        f"by_risk_class={by_risk}",
+    ]
+    for u in units:
+        lines.append(
+            f"  unit {u['id']} phase={u['phase']} "
+            f"risk={u['risk_class']} hint={u['authority_hint']} "
+            f"gate={u['operator_gate']}"
+        )
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m reporting.roadmap_task_units",
+        description=(
+            "A20b Implementation Unit Decomposer. Read-only "
+            "deterministic projection of A20a Roadmap v6 task catalog "
+            "into PR-sized implementation units. No final authority "
+            "classification (A20c). No AAC / dashboard visibility "
+            "(A20d). No next-buildable-unit selector (A20e). Step 5 "
+            "implementation remains BLOCKED."
+        ),
+    )
+    p.add_argument(
+        "--indent",
+        type=int,
+        default=2,
+        help="JSON indent for stdout output (0 for compact).",
+    )
+    p.add_argument(
+        "--no-write",
+        action="store_true",
+        help=(
+            "Do not persist logs/roadmap_task_units/latest.json "
+            "(stdout only)."
+        ),
+    )
+    p.add_argument(
+        "--status",
+        action="store_true",
+        help=(
+            "Render a compact human-readable status summary to stdout "
+            "and exit. Does not write any artefact."
+        ),
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    snap = collect_snapshot()
+    if args.status:
+        sys.stdout.write(_render_status(snap))
+        return 0
+    indent = args.indent if args.indent and args.indent > 0 else None
+    if not args.no_write:
+        write_outputs(snap)
+    json.dump(snap, sys.stdout, indent=indent, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/unit/test_roadmap_task_units.py
+++ b/tests/unit/test_roadmap_task_units.py
@@ -1,0 +1,897 @@
+"""Unit tests for A20b — Implementation Unit Decomposer.
+
+Pins:
+
+* closed vocabularies (UNIT_KIND, RISK_CLASS, AUTHORITY_HINT,
+  OPERATOR_GATE, UNIT_STATUS, TARGET_LAYER,
+  FORBIDDEN_SURFACE_REASON);
+* schema integrity (ImplementationUnit, UnitDecompositionProjection);
+* deterministic output with injected ``generated_at_utc``;
+* byte-identical output for identical input;
+* atomic write only allowed under ``logs/roadmap_task_units/``;
+* ``--no-write`` does not write; ``--status`` does not write;
+* every A20a roadmap task has at least one implementation unit;
+* phases v3.15.16..v3.15.20 each have more than one unit;
+* baseline forbidden_files and forbidden_surface_reasons appear on
+  every unit;
+* every unit's mandatory fields are populated;
+* Addendum 2 / Addendum 3 phases are not decomposed into invented
+  units;
+* no unit declares paper / shadow / live / broker / risk / execution
+  surface as an ``expected_files`` target;
+* no unit grants runtime / trading / paper / shadow / live
+  authority;
+* module source contains no forbidden imports or forbidden runtime
+  tokens (subprocess / socket / urllib / http / requests / dashboard
+  import / automation import / broker import / agent.risk import /
+  agent.execution import / research.run_research import / gh pr /
+  git push / git commit / os.system / eval( / exec(); the strings
+  ``research/research_latest.json``, ``research/strategy_matrix.csv``,
+  ``live/**``, ``paper/**``, ``shadow/**``, ``broker/**``,
+  ``agent/risk/**``, ``agent/execution/**`` are intentionally allowed
+  to appear inside the baseline-forbidden-files list and are not
+  treated as runtime-token violations.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+import pytest
+
+from reporting import roadmap_task_catalog as rtc
+from reporting import roadmap_task_units as rtu
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+_FROZEN_UTC = "2026-05-18T00:00:00Z"
+
+
+@pytest.fixture
+def snap() -> dict:
+    return rtu.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+
+
+@pytest.fixture
+def catalog_snap() -> dict:
+    return rtc.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies
+# ---------------------------------------------------------------------------
+
+
+def test_unit_kind_vocabulary_is_closed() -> None:
+    assert rtu.UNIT_KIND == (
+        "reporting_module",
+        "research_module",
+        "governance_doc",
+        "test_only",
+        "schema_only",
+        "diagnostic_primitive",
+        "external_intelligence_source",
+    )
+
+
+def test_risk_class_vocabulary_matches_classifier_enum() -> None:
+    assert rtu.RISK_CLASS == ("LOW", "MEDIUM", "HIGH", "UNKNOWN")
+
+
+def test_authority_hint_vocabulary_is_closed() -> None:
+    assert rtu.AUTHORITY_HINT == (
+        "AUTO_ALLOWED_CANDIDATE",
+        "NEEDS_HUMAN_CANDIDATE",
+        "PERMANENTLY_DENIED_SURFACE",
+    )
+
+
+def test_operator_gate_vocabulary_is_closed() -> None:
+    assert rtu.OPERATOR_GATE == (
+        "none",
+        "operator_go_required",
+        "governance_bootstrap_pr_required",
+    )
+
+
+def test_unit_status_vocabulary_is_closed() -> None:
+    assert rtu.UNIT_STATUS == (
+        "not_started",
+        "ready",
+        "in_flight",
+        "merged",
+        "blocked",
+        "human_needed",
+        "permanently_denied",
+    )
+
+
+def test_target_layer_vocabulary_matches_catalog() -> None:
+    assert rtu.TARGET_LAYER == rtc.TARGET_LAYER
+
+
+def test_forbidden_surface_reason_vocabulary_is_closed() -> None:
+    assert "live_path" in rtu.FORBIDDEN_SURFACE_REASON
+    assert "frozen_contract" in rtu.FORBIDDEN_SURFACE_REASON
+    assert "claude_governance_hook" in rtu.FORBIDDEN_SURFACE_REASON
+    assert "dashboard_wiring" in rtu.FORBIDDEN_SURFACE_REASON
+    assert "branch_protection_config" in rtu.FORBIDDEN_SURFACE_REASON
+    assert "canonical_roadmap" in rtu.FORBIDDEN_SURFACE_REASON
+    assert "canonical_policy_doc" in rtu.FORBIDDEN_SURFACE_REASON
+    assert "step5_blocked" in rtu.FORBIDDEN_SURFACE_REASON
+    assert "level6_disabled" in rtu.FORBIDDEN_SURFACE_REASON
+    assert "n5b_phase4_denied" in rtu.FORBIDDEN_SURFACE_REASON
+    assert "addendum_2_not_present" in rtu.FORBIDDEN_SURFACE_REASON
+    assert "addendum_3_not_present" in rtu.FORBIDDEN_SURFACE_REASON
+
+
+def test_authority_hint_fail_closed_on_unknown() -> None:
+    assert rtu._resolve_authority_hint("nonsense") == "NEEDS_HUMAN_CANDIDATE"
+    assert rtu._resolve_authority_hint(None) == "NEEDS_HUMAN_CANDIDATE"
+    assert (
+        rtu._resolve_authority_hint("AUTO_ALLOWED_CANDIDATE")
+        == "AUTO_ALLOWED_CANDIDATE"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Schema integrity
+# ---------------------------------------------------------------------------
+
+
+def test_implementation_unit_field_list_exact() -> None:
+    assert rtu.IMPLEMENTATION_UNIT_FIELDS == (
+        "id",
+        "roadmap_task_id",
+        "title",
+        "phase",
+        "unit_kind",
+        "target_layer",
+        "source_requirement_ids",
+        "expected_files",
+        "forbidden_files",
+        "forbidden_surface_reasons",
+        "required_tests",
+        "definition_of_done",
+        "stop_conditions",
+        "prerequisites",
+        "risk_class",
+        "authority_hint",
+        "operator_gate",
+        "status",
+    )
+
+
+def test_unit_decomposition_projection_field_list_exact() -> None:
+    assert rtu.UNIT_DECOMPOSITION_PROJECTION_FIELDS == (
+        "generated_at_utc",
+        "schema_version",
+        "module_version",
+        "source_catalog_schema_version",
+        "implementation_units",
+        "decomposition_invariants",
+    )
+
+
+def test_every_unit_has_every_field(snap: dict) -> None:
+    for u in snap["implementation_units"]:
+        assert set(u.keys()) == set(rtu.IMPLEMENTATION_UNIT_FIELDS), u
+
+
+def test_projection_carries_every_required_top_level_field(snap: dict) -> None:
+    for field in rtu.UNIT_DECOMPOSITION_PROJECTION_FIELDS:
+        assert field in snap, field
+
+
+def test_every_unit_phase_is_in_catalog_phase_vocab(snap: dict) -> None:
+    for u in snap["implementation_units"]:
+        assert u["phase"] in rtc.PHASE
+
+
+def test_every_unit_target_layer_is_in_vocab(snap: dict) -> None:
+    for u in snap["implementation_units"]:
+        assert u["target_layer"] in rtu.TARGET_LAYER
+
+
+def test_every_unit_unit_kind_is_in_vocab(snap: dict) -> None:
+    for u in snap["implementation_units"]:
+        assert u["unit_kind"] in rtu.UNIT_KIND
+
+
+def test_every_unit_risk_class_is_in_vocab(snap: dict) -> None:
+    for u in snap["implementation_units"]:
+        assert u["risk_class"] in rtu.RISK_CLASS
+
+
+def test_every_unit_authority_hint_is_in_vocab(snap: dict) -> None:
+    for u in snap["implementation_units"]:
+        assert u["authority_hint"] in rtu.AUTHORITY_HINT
+
+
+def test_every_unit_operator_gate_is_in_vocab(snap: dict) -> None:
+    for u in snap["implementation_units"]:
+        assert u["operator_gate"] in rtu.OPERATOR_GATE
+
+
+def test_every_unit_status_is_in_vocab(snap: dict) -> None:
+    for u in snap["implementation_units"]:
+        assert u["status"] in rtu.UNIT_STATUS
+
+
+def test_every_unit_forbidden_surface_reason_in_closed_vocab(snap: dict) -> None:
+    for u in snap["implementation_units"]:
+        for r in u["forbidden_surface_reasons"]:
+            assert r in rtu.FORBIDDEN_SURFACE_REASON, (u["id"], r)
+
+
+# ---------------------------------------------------------------------------
+# Mandatory field population
+# ---------------------------------------------------------------------------
+
+
+def test_every_unit_has_non_empty_expected_files(snap: dict) -> None:
+    for u in snap["implementation_units"]:
+        assert u["expected_files"], u["id"]
+
+
+def test_every_unit_has_non_empty_forbidden_files(snap: dict) -> None:
+    for u in snap["implementation_units"]:
+        assert u["forbidden_files"], u["id"]
+
+
+def test_every_unit_has_forbidden_surface_reasons(snap: dict) -> None:
+    for u in snap["implementation_units"]:
+        assert u["forbidden_surface_reasons"], u["id"]
+
+
+def test_every_unit_has_required_tests(snap: dict) -> None:
+    for u in snap["implementation_units"]:
+        assert u["required_tests"], u["id"]
+
+
+def test_every_unit_has_definition_of_done(snap: dict) -> None:
+    for u in snap["implementation_units"]:
+        assert u["definition_of_done"], u["id"]
+
+
+def test_every_unit_has_stop_conditions(snap: dict) -> None:
+    for u in snap["implementation_units"]:
+        assert u["stop_conditions"], u["id"]
+
+
+def test_every_unit_has_prerequisites_field_even_if_empty(snap: dict) -> None:
+    for u in snap["implementation_units"]:
+        assert "prerequisites" in u, u["id"]
+        assert isinstance(u["prerequisites"], list), u["id"]
+
+
+# ---------------------------------------------------------------------------
+# Baseline forbidden-file / reason injection
+# ---------------------------------------------------------------------------
+
+
+_REQUIRED_FORBIDDEN_FILES = (
+    ".claude/**",
+    "dashboard/dashboard.py",
+    "research/research_latest.json",
+    "research/strategy_matrix.csv",
+    "automation/live_gate.py",
+    "broker/**",
+    "agent/risk/**",
+    "agent/execution/**",
+    "live/**",
+    "paper/**",
+    "shadow/**",
+    "trading/**",
+)
+
+
+@pytest.mark.parametrize("required", _REQUIRED_FORBIDDEN_FILES)
+def test_every_unit_forbidden_files_contains_required_entry(
+    snap: dict, required: str
+) -> None:
+    for u in snap["implementation_units"]:
+        assert required in u["forbidden_files"], (u["id"], required)
+
+
+def test_every_unit_forbidden_files_includes_frozen_contracts(
+    snap: dict,
+) -> None:
+    for u in snap["implementation_units"]:
+        assert "research/research_latest.json" in u["forbidden_files"]
+        assert "research/strategy_matrix.csv" in u["forbidden_files"]
+
+
+def test_every_unit_forbidden_surface_reasons_includes_baseline(
+    snap: dict,
+) -> None:
+    for u in snap["implementation_units"]:
+        reasons = set(u["forbidden_surface_reasons"])
+        for required in (
+            "frozen_contract",
+            "live_path",
+            "claude_governance_hook",
+            "dashboard_wiring",
+            "branch_protection_config",
+        ):
+            assert required in reasons, (u["id"], required)
+
+
+# ---------------------------------------------------------------------------
+# Expected-files safety: no live / paper / shadow / risk / broker / exec
+# surface as an EXPECTED target.
+# ---------------------------------------------------------------------------
+
+
+_FORBIDDEN_EXPECTED_PREFIXES = (
+    "automation/live_gate",
+    "broker/",
+    "agent/risk/",
+    "agent/execution/",
+    "live/",
+    "paper/",
+    "shadow/",
+    "trading/",
+    ".claude/",
+    "dashboard/dashboard.py",
+    "research/research_latest.json",
+    "research/strategy_matrix.csv",
+)
+
+
+def test_no_unit_expects_to_modify_forbidden_surface(snap: dict) -> None:
+    for u in snap["implementation_units"]:
+        for path in u["expected_files"]:
+            for forbidden in _FORBIDDEN_EXPECTED_PREFIXES:
+                assert not path.startswith(forbidden) and path != forbidden, (
+                    u["id"],
+                    path,
+                )
+
+
+# ---------------------------------------------------------------------------
+# Phase coverage
+# ---------------------------------------------------------------------------
+
+
+def _units_by_task(snap: dict) -> dict[str, list[dict]]:
+    out: dict[str, list[dict]] = {}
+    for u in snap["implementation_units"]:
+        out.setdefault(u["roadmap_task_id"], []).append(u)
+    return out
+
+
+def _units_by_phase(snap: dict) -> dict[str, list[dict]]:
+    out: dict[str, list[dict]] = {}
+    for u in snap["implementation_units"]:
+        out.setdefault(u["phase"], []).append(u)
+    return out
+
+
+def test_every_catalog_task_has_at_least_one_unit(
+    snap: dict, catalog_snap: dict
+) -> None:
+    by_task = _units_by_task(snap)
+    for t in catalog_snap["roadmap_tasks"]:
+        assert by_task.get(t["id"]), t["id"]
+
+
+@pytest.mark.parametrize(
+    "phase",
+    ["v3.15.16", "v3.15.17", "v3.15.18", "v3.15.19", "v3.15.20"],
+)
+def test_v3_phases_have_more_than_one_unit(snap: dict, phase: str) -> None:
+    by_phase = _units_by_phase(snap)
+    assert len(by_phase.get(phase, [])) > 1, (
+        phase,
+        len(by_phase.get(phase, [])),
+    )
+
+
+def test_addendum_1_has_multiple_units(snap: dict) -> None:
+    by_phase = _units_by_phase(snap)
+    assert len(by_phase.get("addendum_1", [])) >= 3
+
+
+def test_addendum_2_has_no_units(snap: dict) -> None:
+    by_phase = _units_by_phase(snap)
+    assert by_phase.get("addendum_2", []) == []
+
+
+def test_addendum_3_has_no_units(snap: dict) -> None:
+    by_phase = _units_by_phase(snap)
+    assert by_phase.get("addendum_3", []) == []
+
+
+def test_no_unit_targets_addendum_2_or_3(snap: dict) -> None:
+    for u in snap["implementation_units"]:
+        assert u["phase"] not in ("addendum_2", "addendum_3"), u["id"]
+
+
+def test_every_unit_roadmap_task_id_matches_catalog(
+    snap: dict, catalog_snap: dict
+) -> None:
+    task_ids = {t["id"] for t in catalog_snap["roadmap_tasks"]}
+    for u in snap["implementation_units"]:
+        assert u["roadmap_task_id"] in task_ids, u["id"]
+
+
+def test_unit_prerequisites_reference_known_units(snap: dict) -> None:
+    unit_ids = {u["id"] for u in snap["implementation_units"]}
+    for u in snap["implementation_units"]:
+        for prereq in u["prerequisites"]:
+            assert prereq in unit_ids, (u["id"], prereq)
+
+
+def test_all_unit_ids_unique(snap: dict) -> None:
+    ids = [u["id"] for u in snap["implementation_units"]]
+    assert len(ids) == len(set(ids))
+
+
+# ---------------------------------------------------------------------------
+# Authority / runtime guarantees
+# ---------------------------------------------------------------------------
+
+
+def test_no_unit_grants_runtime_authority(snap: dict) -> None:
+    inv = snap["decomposition_invariants"]
+    for key in (
+        "grants_runtime_authority",
+        "grants_trading_authority",
+        "grants_paper_authority",
+        "grants_shadow_authority",
+        "grants_broker_authority",
+        "grants_risk_authority",
+        "grants_live_authority",
+    ):
+        assert inv[key] is False, key
+
+
+def test_invariants_pin_step5_blocked(snap: dict) -> None:
+    inv = snap["decomposition_invariants"]
+    assert inv["step5_implementation_allowed"] is False
+    assert snap["step5_implementation_allowed"] is False
+    assert snap["step5_enabled_substage"] == "none"
+
+
+def test_invariants_pin_addendum_2_3_absence(snap: dict) -> None:
+    inv = snap["decomposition_invariants"]
+    assert inv["addendum_2_not_present"] is True
+    assert inv["addendum_3_not_present"] is True
+
+
+def test_invariants_pin_no_final_authority(snap: dict) -> None:
+    inv = snap["decomposition_invariants"]
+    assert inv["calls_execution_authority_classifier"] is False
+    assert inv["final_authority_classified"] is False
+    assert inv["next_buildable_selector_present"] is False
+    assert inv["aac_visibility_present"] is False
+
+
+def test_invariants_pin_diagnostics_do_not_trade(snap: dict) -> None:
+    inv = snap["decomposition_invariants"]
+    assert inv["diagnostics_do_not_trade"] is True
+    assert inv["external_data_is_not_alpha"] is True
+
+
+def test_invariants_pin_no_seed_jsonl_writes(snap: dict) -> None:
+    inv = snap["decomposition_invariants"]
+    assert inv["writes_to_seed_jsonl"] is False
+    assert inv["writes_to_delegation_seed_jsonl"] is False
+    assert inv["writes_to_generated_seed_jsonl"] is False
+
+
+def test_no_unit_paper_or_shadow_runtime_activation(snap: dict) -> None:
+    for u in snap["implementation_units"]:
+        # No expected_files path may indicate paper/shadow runtime
+        # activation surfaces — those remain blocked until an
+        # explicit, future, operator-go phase.
+        for path in u["expected_files"]:
+            lo = path.lower()
+            assert not lo.startswith("paper/"), (u["id"], path)
+            assert not lo.startswith("shadow/"), (u["id"], path)
+            assert not lo.startswith("live/"), (u["id"], path)
+            assert not lo.startswith("trading/"), (u["id"], path)
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_deterministic_with_injected_ts() -> None:
+    a = rtu.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+    b = rtu.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+    assert a == b
+
+
+def test_serialised_output_byte_identical_with_injected_ts() -> None:
+    a = rtu.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+    b = rtu.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+    out_a = json.dumps(a, indent=2, sort_keys=True) + "\n"
+    out_b = json.dumps(b, indent=2, sort_keys=True) + "\n"
+    assert out_a == out_b
+
+
+def test_unit_order_stable(snap: dict) -> None:
+    sorted_pairs = [(u["phase"], u["id"]) for u in snap["implementation_units"]]
+    assert sorted_pairs == sorted(sorted_pairs)
+
+
+def test_snapshot_includes_source_catalog_schema_version(
+    snap: dict, catalog_snap: dict
+) -> None:
+    assert (
+        snap["source_catalog_schema_version"] == catalog_snap["schema_version"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Atomic write allowlist
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_write_refuses_path_outside_allowlist(tmp_path: Path) -> None:
+    bad = tmp_path / "logs" / "elsewhere" / "latest.json"
+    bad.parent.mkdir(parents=True, exist_ok=True)
+    with pytest.raises(ValueError):
+        rtu._atomic_write_json(bad, {"x": 1})
+
+
+def test_atomic_write_accepts_allowlisted_path(tmp_path: Path) -> None:
+    good = tmp_path / "logs" / "roadmap_task_units" / "latest.json"
+    good.parent.mkdir(parents=True, exist_ok=True)
+    rtu._atomic_write_json(good, {"x": 1})
+    assert good.is_file()
+    assert json.loads(good.read_text(encoding="utf-8")) == {"x": 1}
+
+
+def test_atomic_write_is_atomic(tmp_path: Path) -> None:
+    target = tmp_path / "logs" / "roadmap_task_units" / "latest.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    rtu._atomic_write_json(target, {"x": 1})
+    rtu._atomic_write_json(target, {"x": 2})
+    siblings = list(target.parent.iterdir())
+    assert siblings == [target], siblings
+
+
+def test_atomic_write_refuses_frozen_contract_paths(tmp_path: Path) -> None:
+    """Reassert that the atomic write helper rejects every
+    frozen-contract path, even though the strings appear inside
+    the baseline forbidden_files list (which is allowed)."""
+    for forbidden in (
+        "research/research_latest.json",
+        "research/strategy_matrix.csv",
+    ):
+        target = tmp_path / forbidden
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with pytest.raises(ValueError):
+            rtu._atomic_write_json(target, {"x": 1})
+
+
+# ---------------------------------------------------------------------------
+# CLI behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_cli_no_write_does_not_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    sentinel = tmp_path / "logs" / "roadmap_task_units" / "latest.json"
+    monkeypatch.setattr(rtu, "ARTIFACT_LATEST", sentinel)
+    monkeypatch.setattr(rtu, "ARTIFACT_DIR", sentinel.parent)
+    rc = rtu.main(["--no-write"])
+    assert rc == 0
+    assert not sentinel.exists()
+    out = capsys.readouterr().out
+    assert '"roadmap_task_units"' in out
+
+
+def test_cli_status_does_not_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    sentinel = tmp_path / "logs" / "roadmap_task_units" / "latest.json"
+    monkeypatch.setattr(rtu, "ARTIFACT_LATEST", sentinel)
+    monkeypatch.setattr(rtu, "ARTIFACT_DIR", sentinel.parent)
+    rc = rtu.main(["--status"])
+    assert rc == 0
+    assert not sentinel.exists()
+    out = capsys.readouterr().out
+    assert "roadmap_task_units" in out
+    assert "step5_implementation_allowed=False" in out
+    assert "addendum_2_not_present=True" in out
+    assert "addendum_3_not_present=True" in out
+
+
+def test_cli_default_writes_to_allowlisted_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sentinel = tmp_path / "logs" / "roadmap_task_units" / "latest.json"
+    monkeypatch.setattr(rtu, "ARTIFACT_LATEST", sentinel)
+    monkeypatch.setattr(rtu, "ARTIFACT_DIR", sentinel.parent)
+    rc = rtu.main([])
+    assert rc == 0
+    assert sentinel.is_file()
+    payload = json.loads(sentinel.read_text(encoding="utf-8"))
+    assert payload["report_kind"] == "roadmap_task_units"
+    assert payload["module_version"].startswith("v3.15.16.A20b")
+
+
+def test_cli_indent_zero_compact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    sentinel = tmp_path / "logs" / "roadmap_task_units" / "latest.json"
+    monkeypatch.setattr(rtu, "ARTIFACT_LATEST", sentinel)
+    monkeypatch.setattr(rtu, "ARTIFACT_DIR", sentinel.parent)
+    rc = rtu.main(["--no-write", "--indent", "0"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "\n  " not in out
+
+
+# ---------------------------------------------------------------------------
+# Module-source forbidden-import / forbidden-token scans
+# ---------------------------------------------------------------------------
+
+
+def _module_source() -> str:
+    return Path(rtu.__file__).read_text(encoding="utf-8")
+
+
+def test_no_subprocess_in_module() -> None:
+    src = _module_source()
+    assert "import subprocess" not in src
+    assert "from subprocess" not in src
+    assert "subprocess." not in src
+
+
+def test_no_socket_or_urllib_or_http_or_requests() -> None:
+    src = _module_source()
+    for forbidden in (
+        "import socket",
+        "from socket",
+        "import urllib",
+        "from urllib",
+        "import http",
+        "from http",
+        "import requests",
+        "from requests",
+        "import httpx",
+        "from httpx",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_no_forbidden_module_imports() -> None:
+    src = _module_source()
+    for forbidden in (
+        "from dashboard",
+        "import dashboard",
+        "from automation",
+        "import automation",
+        "from broker",
+        "import broker",
+        "from agent.risk",
+        "import agent.risk",
+        "from agent.execution",
+        "import agent.execution",
+        "from research.run_research",
+        "import research.run_research",
+        "from reporting.intelligent_routing",
+        "import reporting.intelligent_routing",
+        "from reporting.execution_authority",
+        "import reporting.execution_authority",
+        "from reporting.development_queue_admission_policy",
+        "import reporting.development_queue_admission_policy",
+        "from reporting.development_agent_activity_timeline",
+        "import reporting.development_agent_activity_timeline",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_no_forbidden_runtime_tokens() -> None:
+    """Scans for runtime *use* tokens — process execution, dynamic
+    eval / exec, shell invocation. Docstring mentions of ``gh`` /
+    ``git`` / ``subprocess`` as negative guarantees are explicitly
+    allowed (they are pinned by the import / subprocess scans
+    above). The strings ``gh pr create``, ``git push``,
+    ``git commit`` legitimately appear in baseline DoD bullets as
+    descriptive text for the future PR's lifecycle; they are not
+    runtime calls from this module.
+    """
+    src = _module_source()
+    for forbidden in (
+        "subprocess.run(",
+        "subprocess.Popen(",
+        "os.system(",
+        "os.popen(",
+        "shell=True",
+        "eval(",
+        "exec(",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_no_llm_or_external_api_calls() -> None:
+    src = _module_source()
+    for forbidden in (
+        "anthropic",
+        "openai",
+        "Bearer ",
+        "X-API-Key",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def _module_imports() -> list[str]:
+    """Return the list of dotted module names imported by the A20b
+    module via static AST analysis. Distinguishes real import
+    statements from docstring mentions of the same names."""
+    import ast as _ast
+
+    tree = _ast.parse(_module_source())
+    out: list[str] = []
+    for node in _ast.walk(tree):
+        if isinstance(node, _ast.Import):
+            for alias in node.names:
+                out.append(alias.name)
+        elif isinstance(node, _ast.ImportFrom):
+            mod = node.module or ""
+            for alias in node.names:
+                out.append(f"{mod}.{alias.name}" if mod else alias.name)
+    return out
+
+
+def test_module_does_not_call_execution_authority_classifier() -> None:
+    """A20b must NOT import or call execution_authority.classify.
+    Real authority classification is A20c's job. We check actual
+    imports via AST rather than docstring mentions of the module
+    name, since the docstring legitimately lists
+    ``reporting.execution_authority`` as a forbidden import.
+    """
+    imports = _module_imports()
+    for forbidden_import in imports:
+        assert "execution_authority" not in forbidden_import, forbidden_import
+    src = _module_source()
+    # Real call patterns: a) `ea.classify(...)` if imported aliased,
+    # b) `execution_authority.classify(...)` if imported plain. The
+    # docstring uses backticked Sphinx-style references, never the
+    # raw call form.
+    assert "ea.classify(" not in src
+    # Bare `execution_authority.classify(` would indicate a real
+    # call. Docstring mentions use the form
+    # ``execution_authority.classify(...)`` inside double backticks.
+    # Strip the docstring before scanning to avoid false positives.
+    import ast as _ast
+
+    tree = _ast.parse(src)
+    module_doc = _ast.get_docstring(tree) or ""
+    code_only = src.replace(module_doc, "")
+    assert "execution_authority.classify(" not in code_only
+
+
+def test_module_does_not_touch_canonical_roadmap_files_at_runtime() -> None:
+    """A20b derives task identity from the in-memory catalog. It must
+    not parse canonical roadmap files at runtime — those reads belong
+    only to A20a + the Roadmap Intake Bridge. We check by AST: there
+    are zero ``open(...)`` / ``read_text(...)`` / ``read_bytes(...)``
+    / ``Path(canonical_roadmap_path)`` call sites in the module
+    code. Docstring mentions of the canonical roadmap paths as
+    negative guarantees are explicitly allowed.
+    """
+    import ast as _ast
+
+    src = _module_source()
+    tree = _ast.parse(src)
+    module_doc = _ast.get_docstring(tree) or ""
+
+    # Walk the AST for any call site invoking common file-read APIs.
+    # ``open(...)`` / ``Path(...).read_text(...)`` / ``read_bytes`` /
+    # ``read``. The canonical roadmap paths legitimately appear in
+    # the BASELINE_FORBIDDEN_FILES tuple as forbidden-path string
+    # literals; the semantic invariant is that they are never
+    # passed to any file-read call, which is enforced here at the
+    # AST level rather than via fragile substring scans.
+    forbidden_call_names = {"open", "read_text", "read_bytes", "read"}
+    found_calls: list[str] = []
+    for node in _ast.walk(tree):
+        if not isinstance(node, _ast.Call):
+            continue
+        if isinstance(node.func, _ast.Attribute):
+            name = node.func.attr
+        elif isinstance(node.func, _ast.Name):
+            name = node.func.id
+        else:
+            continue
+        if name in forbidden_call_names:
+            found_calls.append(name)
+    assert not found_calls, found_calls
+    # silence unused-variable lint for module_doc
+    assert isinstance(module_doc, str)
+
+
+def test_module_imports_cleanly() -> None:
+    importlib.reload(rtu)
+    assert callable(rtu.collect_snapshot)
+    assert callable(rtu.write_outputs)
+    assert callable(rtu.main)
+
+
+def test_schema_and_module_version_strings() -> None:
+    assert isinstance(rtu.SCHEMA_VERSION, str) and rtu.SCHEMA_VERSION
+    assert isinstance(rtu.MODULE_VERSION, str) and rtu.MODULE_VERSION
+    assert rtu.MODULE_VERSION.endswith("A20b")
+
+
+# ---------------------------------------------------------------------------
+# Governance doc cross-references (A20b extension)
+# ---------------------------------------------------------------------------
+
+
+def _governance_doc_text() -> str:
+    doc = (
+        Path(__file__).resolve().parents[2]
+        / "docs"
+        / "governance"
+        / "roadmap_task_catalog.md"
+    )
+    return doc.read_text(encoding="utf-8").lower()
+
+
+def test_governance_doc_documents_a20b() -> None:
+    text = _governance_doc_text()
+    for needle in (
+        "a20b",
+        "implementationunit",
+        "pr-sized",
+        "forbidden_files",
+        "forbidden_surface_reasons",
+        "required_tests",
+        "definition of done",
+        "stop conditions",
+        "prerequisites",
+        "authority_hint",
+    ):
+        assert needle in text, needle
+
+
+def test_governance_doc_pins_a20b_no_final_authority() -> None:
+    text = _governance_doc_text()
+    assert "a20c" in text
+    # The doc must somewhere make clear that A20b's authority_hint
+    # is not the final authority classification — A20c integrates
+    # the real classifier.
+    not_final_phrasing = (
+        "authority_hint is not final authority",
+        "authority_hint is not final",
+        "not a substitute for the real classifier",
+        "not the final authority",
+        "is **not** a substitute",
+        "is not a substitute",
+    )
+    assert any(p in text for p in not_final_phrasing), text[:500]
+
+
+def test_governance_doc_pins_no_dashboard_or_aac_changes_in_a20b() -> None:
+    text = _governance_doc_text()
+    assert "a20d" in text
+    assert "aac" in text or "agent activity" in text
+
+
+def test_governance_doc_pins_no_next_buildable_selector_in_a20b() -> None:
+    text = _governance_doc_text()
+    assert "a20e" in text
+    assert "next-buildable" in text or "next buildable" in text


### PR DESCRIPTION
## Summary

- Converts each A20a `RoadmapTask` into deterministic, **PR-sized** `ImplementationUnit` records and emits the projection at `logs/roadmap_task_units/latest.json`.
- Hand-encoded `_UNIT_SEED` literal pinned by 87 unit tests. No LLM, no fuzzy parsing, no runtime parsing of canonical roadmap documents. Decomposer trusts the in-memory A20a catalog as the only upstream and re-classifies nothing.
- Closed vocabularies: `UNIT_KIND`, `RISK_CLASS`, `AUTHORITY_HINT`, `OPERATOR_GATE`, `UNIT_STATUS`, `TARGET_LAYER`, `FORBIDDEN_SURFACE_REASON`.
- Phase coverage:
  - v3.15.16 Intelligent Routing Layer — **3 units**
  - v3.15.17 Sampling Intelligence — **2 units**
  - v3.15.18 Research Observability Expansion — **3 units**
  - v3.15.19 Hypothesis Discovery Engine — **5 units**
  - v3.15.20 Failure → Action Mapping — **2 units**
  - Addendum 1 cross-cutting groundwork — **5 units**
- Every emitted unit's `forbidden_files` includes the full baseline list (`.claude/**`, `dashboard/dashboard.py`, `research/research_latest.json`, `research/strategy_matrix.csv`, `automation/live_gate.py`, `broker/**`, `agent/risk/**`, `agent/execution/**`, `live/**`, `paper/**`, `shadow/**`, `trading/**`, plus branch-protection / canonical-roadmap / canonical-policy paths).
- No unit declares paper / shadow / live / broker / risk / execution surfaces as `expected_files` targets.
- No unit is emitted under `phase == "addendum_2"` or `phase == "addendum_3"` — the catalog absence flags propagate.
- `authority_hint ∈ {AUTO_ALLOWED_CANDIDATE, NEEDS_HUMAN_CANDIDATE, PERMANENTLY_DENIED_SURFACE}`; unknown inputs fail closed to `NEEDS_HUMAN_CANDIDATE`. **This is a hint, not final authority** — A20c will integrate the real classifier.

## Files changed (exactly 3, allowlist-only)

- `reporting/roadmap_task_units.py` (new) — stdlib + `reporting.roadmap_task_catalog` only.
- `tests/unit/test_roadmap_task_units.py` (new) — 87 tests.
- `docs/governance/roadmap_task_catalog.md` (modified) — extended with the A20b section (§7) and A20b test-coverage block (§10.2).

`tests/unit/test_roadmap_task_catalog.py` was **not** modified — existing A20a tests remain green unchanged.

## Validation commands and results

- `python -m pytest tests/unit/test_roadmap_task_units.py -v` → **87 passed**
- `python -m pytest tests/unit/test_roadmap_task_catalog.py -v` → **83 passed** (unchanged)
- `python -m pytest tests/smoke -v` → **18 passed**
- `python scripts/governance_lint.py` → **OK** (16 agents, 5 workflows)
- Actual frozen-contract / authority regression tests present in this repo (`tests/regression/test_frozen_hashes.py` does not exist):
  - `tests/regression/test_public_output_contract.py` → **8 passed**
  - `tests/regression/test_v12_contracts_preserved.py` → **4 passed**
  - `tests/regression/test_authority_invariants.py` → **4 passed**

## Frozen-contract verdict

- `research/research_latest.json` — **not touched**.
- `research/strategy_matrix.csv` — **not touched**.
- Atomic-write helper refuses every path outside `logs/roadmap_task_units/` (pinned by `test_atomic_write_refuses_path_outside_allowlist` and `test_atomic_write_refuses_frozen_contract_paths`).
- The strings `research/research_latest.json` and `research/strategy_matrix.csv` legitimately appear inside the unit records as forbidden-path declarations and inside the governance doc. They are NOT used as runtime read/write targets (verified by AST scan: zero `open()` / `read_text()` / `read_bytes()` / `read()` call sites in the module).

## Forbidden-path verdict

`git diff --name-only main` contains **only**:

```
docs/governance/roadmap_task_catalog.md
reporting/roadmap_task_units.py
tests/unit/test_roadmap_task_units.py
```

None of the following were touched:

- `dashboard/dashboard.py`
- `.claude/**`
- `research/research_latest.json`, `research/strategy_matrix.csv`
- `automation/live_gate.py`
- `broker/**`, `agent/risk/**`, `agent/execution/**`
- `live/**`, `paper/**`, `shadow/**`, `trading/**`
- `docs/roadmap/Roadmap v6.md`, `docs/roadmap/Roadmap v6 Addendum.md`, `docs/roadmap/autonomous_development.txt`
- `docs/governance/execution_authority.md`, `docs/governance/no_touch_paths.md`
- `reporting/execution_authority.py`
- `reporting/development_queue_admission_policy.py` (the existing A17 surface)
- `reporting/development_agent_activity_timeline.py` (AAC aggregator)
- `docs/development_work_queue/*.jsonl`
- `tests/regression/**`
- any frozen schema under `artifacts/`

## Authority statement (still pinned)

- ADE remains development workflow automation only.
- No QRE runtime / trading / paper / shadow / broker / risk / live authority granted.
- Step 5 implementation remains BLOCKED (`step5_implementation_allowed = False`, `STEP5_ENABLED_SUBSTAGE = "none"`).
- Autonomy-ladder Level 6 remains permanently disabled.
- N5b Phase 4 production merge remains permanently denied for ADE.
- The decomposition invariants pin: `calls_execution_authority_classifier = false`, `final_authority_classified = false`, `aac_visibility_present = false`, `next_buildable_selector_present = false`. A20c / A20d / A20e will flip them in their own operator-go PRs.

## What this PR does NOT do

- **No final authority classifier integration** — that is A20c's scope. `authority_hint` values are deterministic candidates, not the real `execution_authority.classify(...)` verdict.
- **No AAC / task-board / dashboard visibility** — that is A20d's scope. The AAC aggregator's pinned upstream catalog cardinality is untouched.
- **No next-buildable-unit selector** — that is A20e's scope.
- **No edit to `reporting/development_queue_admission_policy.py`** (the existing A17 surface).
- **No edit to canonical roadmap docs or canonical policy docs.**
- **No edit to `autonomous_development.txt`.**
- **No Step 5 substage flip; no Level 6 amendment; no N5b weakening.**

## Next recommended PR

**A20c — Authority/Risk Classifier Integration.** Annotate each `ImplementationUnit` with an aggregate `UnitAuthorityDecision` derived purely from `reporting.execution_authority.classify(...)`. Aggregation is max-severity over per-file decisions (`AUTO_ALLOWED < NEEDS_HUMAN < PERMANENTLY_DENIED`). Fail-closed: unknown risk → `NEEDS_HUMAN`; any protected-path / frozen / live surface → `PERMANENTLY_DENIED` or `NEEDS_HUMAN` per the canonical policy. A20c will flip `calls_execution_authority_classifier` and `final_authority_classified` from `false` to `true` in the projection's invariant block.

## Test plan

- [x] `python -m pytest tests/unit/test_roadmap_task_units.py -v` — 87 passed locally
- [x] `python -m pytest tests/unit/test_roadmap_task_catalog.py -v` — 83 passed locally (unchanged)
- [x] `python -m pytest tests/smoke -v` — 18 passed locally
- [x] `python scripts/governance_lint.py` — OK locally
- [x] `python -m pytest tests/regression/test_public_output_contract.py tests/regression/test_v12_contracts_preserved.py tests/regression/test_authority_invariants.py -v` — 16 passed locally
- [ ] CI checks complete on PR (squash-merge only — no `--admin`, no force push, no hook bypass, no automatic merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)