### PR TITLE
feat(a20c): authority/risk classifier integration for roadmap task units (read-only)

### DIFF
--- a/docs/governance/roadmap_task_catalog.md
+++ b/docs/governance/roadmap_task_catalog.md
@@ -1,15 +1,18 @@
-# Roadmap Task Catalog — A20a + A20b (read-only, deterministic)
+# Roadmap Task Catalog — A20a + A20b + A20c (read-only, deterministic)
 
-> **Status:** A20a implemented; A20b implemented (read-only,
-> deterministic, dry-run by default). Both modules are projections;
-> neither classifies authority, nor surfaces to the AAC / dashboard,
-> nor selects a next-buildable unit.
+> **Status:** A20a implemented; A20b implemented; A20c implemented
+> (read-only, deterministic, dry-run by default). All three modules
+> are projections; none surfaces to the AAC / dashboard, none
+> selects a next-buildable unit.
 >
 > **A20a module:** [`reporting/roadmap_task_catalog.py`](../../reporting/roadmap_task_catalog.py)
 > **A20a artefact:** `logs/roadmap_task_catalog/latest.json`
 >
 > **A20b module:** [`reporting/roadmap_task_units.py`](../../reporting/roadmap_task_units.py)
 > **A20b artefact:** `logs/roadmap_task_units/latest.json`
+>
+> **A20c module:** [`reporting/roadmap_task_authority.py`](../../reporting/roadmap_task_authority.py)
+> **A20c artefact:** `logs/roadmap_task_authority/latest.json`
 >
 > **Authority:** development-governance read-only.
 > The roadmap task catalog is **not** the canonical product roadmap.
@@ -400,23 +403,107 @@ hint is informational only. Unknown inputs fail closed to
   decomposer reads the A20a catalog at runtime and skips any
   unit whose phase is not present in the catalog's task list.
 
-## 8. Future stages (A20c–A20e)
+## 8. A20c — Authority / Risk Classifier Integration (implemented)
 
-The roadmap task catalog + unit decomposer is the foundation of a
-staged sequence. Each subsequent stage requires a separate
-operator-go PR. None of them is pre-authorized by A20a or A20b.
+A20c is a **pure consumer** of two read-only upstreams:
 
-- **A20c — Authority / Risk Classifier Integration.** Annotates
-  each `ImplementationUnit` with an aggregate
-  `UnitAuthorityDecision` derived purely from
-  [`reporting/execution_authority.py`](../../reporting/execution_authority.py).
-  Aggregation is max-severity over per-file decisions. Fail-closed:
-  unknown risk → `NEEDS_HUMAN`; any protected-path / frozen / live
-  surface → `PERMANENTLY_DENIED` or `NEEDS_HUMAN` per the
-  classifier's existing policy. A20c will flip
-  `calls_execution_authority_classifier` and
+* the A20b implementation-unit projection
+  ([`reporting/roadmap_task_units.py`](../../reporting/roadmap_task_units.py));
+* the canonical Execution Authority classifier
+  ([`reporting/execution_authority.py`](../../reporting/execution_authority.py)).
+
+A20c MUST NOT create a second source of truth for authority. For
+every `ImplementationUnit`, A20c calls
+``execution_authority.classify(action_type="file_edit",
+target_path=<entry>, risk_class=<unit.risk_class>)`` for each
+`expected_files[]` and `forbidden_files[]` entry. The per-file
+decision is the verbatim `ExecutionDecision` returned by the
+classifier; A20c stores the bounded-scalar projection
+(`path`, `action_type`, `risk_class`, `decision`, `reason`,
+`target_path_category`).
+
+### 8.1 `UnitAuthorityDecision` schema
+
+Per-unit field list is exact and ordered:
+
+```
+unit_id                    : str  matches A20b ImplementationUnit.id
+parent_task_id             : str  matches A20b ImplementationUnit.roadmap_task_id
+expected_files_decisions   : list[per-file decision record]
+forbidden_files_decisions  : list[per-file decision record]
+aggregate_decision         : str  ∈ reporting.execution_authority.DECISIONS
+aggregate_reason           : str  ∈ reporting.execution_authority.REASONS
+authority_hint_from_a20b   : str  preserved A20b hint (non-authoritative)
+classifier_schema_version  : int  reporting.execution_authority.SCHEMA_VERSION
+classifier_module          : str  "reporting.execution_authority"
+forbidden_surface_reasons  : list[str]  echoed verbatim from A20b unit
+```
+
+### 8.2 Aggregation rules
+
+`aggregate_decision` is a pure max-severity reduction over
+`expected_files_decisions` using the canonical decision ordering
+`AUTO_ALLOWED < NEEDS_HUMAN < PERMANENTLY_DENIED`:
+
+| Condition | Aggregate |
+|---|---|
+| Any `expected_files[]` entry classifies `PERMANENTLY_DENIED` | `PERMANENTLY_DENIED` (with that entry's reason) |
+| Any `expected_files[]` entry classifies `NEEDS_HUMAN` and none denied | `NEEDS_HUMAN` (with that entry's reason) |
+| All `expected_files[]` entries classify `AUTO_ALLOWED` | `AUTO_ALLOWED` (with the first entry's reason in deterministic order) |
+| Empty `expected_files[]` (defence in depth) | `NEEDS_HUMAN` / `unknown_risk_or_target_fail_safe` |
+
+`forbidden_files_decisions` are emitted for transparency but do
+**not** enter the aggregation; A20b enforces that no unit ever
+writes to a forbidden file at implementation time.
+
+### 8.3 Fail-closed contract
+
+* `unit.risk_class == "UNKNOWN"` (or any invalid string) → unit
+  aggregate is `NEEDS_HUMAN` with reason
+  `unknown_risk_or_target_fail_safe`.
+* Any unit whose `expected_files[]` resolves to a `live_path` /
+  `frozen_contract` / `branch_protection_config` category →
+  `PERMANENTLY_DENIED`.
+* Any unit whose `expected_files[]` resolves to a
+  `canonical_roadmap` / `canonical_policy_doc` /
+  `claude_governance_hook` / `dashboard_wiring` / `deploy_script` /
+  `ci_workflow` category → `NEEDS_HUMAN`.
+
+### 8.4 Authority hint preservation (not authority)
+
+A20b's `authority_hint` field is preserved verbatim under
+`authority_hint_from_a20b` for transparency / debugging only. It
+is **not** authority. The classifier verdict is the only authority
+A20c records. Pinned by
+`test_hint_never_overrides_classifier_aggregate`.
+
+### 8.5 What A20c does NOT do
+
+- **No mutation of A20a or A20b artefacts.** Pinned by sha256
+  before/after tests.
+- **No modification of the canonical classifier doc or module.**
+  A20c is a consumer; `reporting/execution_authority.py` and
+  `docs/governance/execution_authority.md` are untouched.
+- **No AAC / dashboard visibility.** A20c emits only
+  `logs/roadmap_task_authority/latest.json`. The AAC aggregator's
+  pinned upstream catalog cardinality remains unchanged (A20d
+  scope).
+- **No next-buildable-unit selector.** A20e scope.
+- **No flip of Step 5 / Level 6 / N5b denials.** Step 5
+  implementation remains BLOCKED, autonomy-ladder Level 6 remains
+  permanently disabled, and N5b Phase 4 production merge remains
+  permanently denied for ADE — verbatim as they were after A20b.
+  A20c flips only `calls_execution_authority_classifier` and
   `final_authority_classified` from `false` to `true` in the
-  projection's invariant block.
+  projection's `classification_invariants` block.
+
+## 9. Future stages (A20d–A20e)
+
+The roadmap task catalog + unit decomposer + authority projection
+is the foundation of the remaining staged sequence. Each subsequent
+stage requires a separate operator-go PR. None of them is
+pre-authorized by A20a, A20b, or A20c.
+
 - **A20d — Read-only AAC / Task-Board Visibility.** Exposes the
   catalog + units + authority decisions to the operator through
   the existing read-only surfaces (`reporting/task_board.py`,
@@ -577,6 +664,69 @@ intentionally allowed to appear inside the baseline `forbidden_files`
 declarations and inside this governance doc. They are forbidden as
 import targets, write targets, and runtime call surfaces; they are
 **not** forbidden as forbidden-path declarations.
+
+### 10.3 A20c
+
+Pinned in [`tests/unit/test_roadmap_task_authority.py`](../../tests/unit/test_roadmap_task_authority.py):
+
+- Re-exported vocabularies (`DECISIONS`, `RISK_CLASSES`) match the
+  canonical classifier verbatim (no second source of truth).
+- Schema field tuples (`PER_FILE_DECISION_FIELDS`,
+  `UNIT_AUTHORITY_DECISION_FIELDS`,
+  `UNIT_AUTHORITY_PROJECTION_FIELDS`) are exact and ordered.
+- Every A20b implementation unit receives exactly one
+  `UnitAuthorityDecision`; unit IDs are unique.
+- Every `expected_files` and `forbidden_files` per-file decision
+  matches the verbatim output of
+  `reporting.execution_authority.classify(...)` for the same
+  `(action_type, target_path, risk_class)` triple.
+- `aggregate_decision` follows max-severity over the canonical
+  decision ordering `AUTO_ALLOWED < NEEDS_HUMAN <
+  PERMANENTLY_DENIED`.
+- Synthetic-unit tests confirm: any `PERMANENTLY_DENIED`
+  expected file drives the unit to `PERMANENTLY_DENIED`; any
+  `NEEDS_HUMAN` expected file with no denied entry drives the unit
+  to `NEEDS_HUMAN`; all `AUTO_ALLOWED` entries yield an
+  `AUTO_ALLOWED` aggregate.
+- Fail-closed: `UNKNOWN` risk -> `NEEDS_HUMAN`; an invalid
+  risk-class string is coerced to `UNKNOWN` and fails closed;
+  empty `expected_files` yields `NEEDS_HUMAN` with reason
+  `unknown_risk_or_target_fail_safe`.
+- Runtime / trading surfaces (`broker/**`, `agent/risk/**`,
+  `agent/execution/**`, `automation/live_gate.py`) are never
+  `AUTO_ALLOWED` at any `risk_class`.
+- `live/**`, `paper/**`, `shadow/**`, `trading/**`, `execution/**`
+  classify as `other` -> `NEEDS_HUMAN` on every modify action, so
+  they are never `AUTO_ALLOWED`.
+- Frozen contracts (`research/research_latest.json`,
+  `research/strategy_matrix.csv`) classify as
+  `PERMANENTLY_DENIED` with reason
+  `denied_frozen_contract_mutation` at every `risk_class`.
+- Canonical roadmap / canonical policy doc paths classify as
+  `NEEDS_HUMAN` (or stronger) at every `risk_class`.
+- A20b's `authority_hint` is preserved verbatim as
+  non-authoritative metadata; the hint never enters the
+  aggregation.
+- Classification invariants pin: `calls_execution_authority_classifier
+  = true`, `final_authority_classified = true`,
+  `no_runtime_trading_authority = true`, `no_step5_runtime =
+  true`, `no_level6 = true`, `no_production_merge_authority =
+  true`, `writes_only_roadmap_task_authority_log = true`,
+  `aac_visibility_present = false`,
+  `next_buildable_selector_present = false`.
+- Deterministic byte-identical output for identical input with
+  injected `generated_at_utc`.
+- Sha256-before-vs-after confirms `collect_snapshot()` does not
+  mutate the A20a or A20b in-memory artefacts.
+- Atomic-write allowlist refuses any path outside
+  `logs/roadmap_task_authority/`, including the frozen-contract
+  paths.
+- Module-source scan: stdlib + `reporting.execution_authority` +
+  `reporting.roadmap_task_units` + `reporting.roadmap_task_catalog`
+  imports only; no `subprocess`, no network, no `gh`, no `git`, no
+  GitHub API, no LLM, no dashboard / automation / broker /
+  agent.risk / agent.execution / research / live / paper / shadow /
+  trading imports.
 
 ---
 

--- a/reporting/roadmap_task_authority.py
+++ b/reporting/roadmap_task_authority.py
@@ -1,0 +1,534 @@
+"""A20c — Authority / Risk Classifier Integration (read-only, deterministic).
+
+Per-unit projection that joins the A20b implementation-unit
+decomposition with the canonical Execution Authority classifier
+(:func:`reporting.execution_authority.classify`). Emits a
+deterministic artefact at ``logs/roadmap_task_authority/latest.json``.
+
+This module is a **pure consumer** of two read-only upstreams:
+
+* :mod:`reporting.roadmap_task_units` — the A20b implementation
+  units (which themselves derive from the A20a catalog);
+* :mod:`reporting.execution_authority` — the canonical agent
+  execution-authority classifier and the only source of truth for
+  per-action / per-target authority verdicts.
+
+A20c MUST NOT create a second source of truth for authority. Every
+per-file decision is the verbatim ``ExecutionDecision`` returned by
+``execution_authority.classify(...)``. Aggregation is a pure
+max-severity reduction (``AUTO_ALLOWED < NEEDS_HUMAN <
+PERMANENTLY_DENIED``).
+
+A20b's ``authority_hint`` is preserved as **non-authoritative
+metadata only**, side-by-side with the canonical aggregate. The
+hint never overrides the classifier verdict.
+
+Hard guarantees (pinned by tests):
+
+* Stdlib + ``reporting.execution_authority`` (read-only) +
+  ``reporting.roadmap_task_units`` (read-only) +
+  ``reporting.roadmap_task_catalog`` (read-only, version pin only)
+  only.
+* No subprocess, no network, no ``gh``, no ``git``, no GitHub API.
+* No imports of ``dashboard``, ``automation``, ``broker``,
+  ``agent.risk``, ``agent.execution``, ``research``, ``live``,
+  ``paper``, ``shadow``, ``trading``,
+  ``reporting.intelligent_routing``,
+  ``reporting.development_queue_admission_policy``,
+  ``reporting.development_agent_activity_timeline``.
+* No LLM, no external API, no fuzzy parsing, no file-content
+  parsing of any canonical document at runtime.
+* Atomic write only under ``logs/roadmap_task_authority/``.
+* Deterministic output: same upstream + injected
+  ``generated_at_utc`` → byte-identical artefact.
+* No mutation of A20a or A20b artefacts (pinned by sha256
+  before/after tests).
+* No runtime / trading / paper / shadow / broker / risk / live
+  authority granted; pinned by closed invariants on every
+  projection.
+* ``step5_implementation_allowed`` remains ``False``;
+  ``STEP5_ENABLED_SUBSTAGE`` remains ``"none"``.
+
+CLI::
+
+    python -m reporting.roadmap_task_authority
+    python -m reporting.roadmap_task_authority --no-write
+    python -m reporting.roadmap_task_authority --status
+    python -m reporting.roadmap_task_authority --indent 2
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime as _dt
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Final
+
+from reporting import execution_authority as ea
+from reporting import roadmap_task_catalog as rtc
+from reporting import roadmap_task_units as rtu
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[str] = "1.0"
+MODULE_VERSION: Final[str] = "v3.15.16.A20c"
+REPORT_KIND: Final[str] = "roadmap_task_authority"
+
+
+# ---------------------------------------------------------------------------
+# Step 5 + Level 6 invariants (Final constants — never flipped at runtime)
+# ---------------------------------------------------------------------------
+
+STEP5_ENABLED_SUBSTAGE: Final[str] = "none"
+step5_implementation_allowed: Final[bool] = False
+
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies (re-exported from the canonical classifier)
+# ---------------------------------------------------------------------------
+
+#: Verbatim re-export from the canonical classifier. Pinned by tests.
+DECISIONS: Final[tuple[str, ...]] = ea.DECISIONS
+
+#: Verbatim re-export from the canonical classifier. Pinned by tests.
+RISK_CLASSES: Final[tuple[str, ...]] = ea.RISK_CLASSES
+
+#: Action type passed for every per-file classification. ``file_edit``
+#: is the modify-action that A20b's emitted units describe (writing
+#: new files into a unit's ``expected_files`` set).
+_ACTION_TYPE: Final[str] = "file_edit"
+
+#: Severity ordering for unit-level aggregation. Higher value = more
+#: restrictive. Pinned by a unit test.
+_SEVERITY: Final[dict[str, int]] = {
+    ea.DECISION_AUTO_ALLOWED: 0,
+    ea.DECISION_NEEDS_HUMAN: 1,
+    ea.DECISION_PERMANENTLY_DENIED: 2,
+}
+
+#: Fail-closed authority value emitted when a unit declares an
+#: empty ``expected_files`` list (defence in depth — A20b's tests
+#: forbid empty ``expected_files``, but A20c stays safe even if a
+#: future A20b regression slipped one through).
+_AGGREGATE_FAIL_CLOSED: Final[str] = ea.DECISION_NEEDS_HUMAN
+_AGGREGATE_FAIL_CLOSED_REASON: Final[str] = "unknown_risk_or_target_fail_safe"
+
+
+# ---------------------------------------------------------------------------
+# Schema field tuples (exact, ordered)
+# ---------------------------------------------------------------------------
+
+#: Per-file ``ExecutionDecision`` record shape (the bounded-scalar
+#: projection of an :class:`ea.ExecutionDecision`).
+PER_FILE_DECISION_FIELDS: Final[tuple[str, ...]] = (
+    "path",
+    "action_type",
+    "risk_class",
+    "decision",
+    "reason",
+    "target_path_category",
+)
+
+#: ``UnitAuthorityDecision`` field list. Exact and ordered.
+UNIT_AUTHORITY_DECISION_FIELDS: Final[tuple[str, ...]] = (
+    "unit_id",
+    "parent_task_id",
+    "expected_files_decisions",
+    "forbidden_files_decisions",
+    "aggregate_decision",
+    "aggregate_reason",
+    "authority_hint_from_a20b",
+    "classifier_schema_version",
+    "classifier_module",
+    "forbidden_surface_reasons",
+)
+
+#: ``UnitAuthorityProjection`` field list. Exact and ordered.
+UNIT_AUTHORITY_PROJECTION_FIELDS: Final[tuple[str, ...]] = (
+    "generated_at_utc",
+    "schema_version",
+    "module_version",
+    "source_catalog_module_version",
+    "source_units_module_version",
+    "authority_decisions",
+    "classification_invariants",
+)
+
+
+# ---------------------------------------------------------------------------
+# Artefact paths
+# ---------------------------------------------------------------------------
+
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "roadmap_task_authority"
+ARTIFACT_LATEST: Final[Path] = ARTIFACT_DIR / "latest.json"
+ARTIFACT_RELATIVE_PATH: Final[str] = "logs/roadmap_task_authority/latest.json"
+
+#: Atomic-write allowlist (POSIX path substring form). Any write
+#: target whose path does not contain this substring is refused with
+#: ``ValueError``.
+_WRITE_PREFIX: Final[str] = "logs/roadmap_task_authority/"
+
+
+# ---------------------------------------------------------------------------
+# Classification invariants emitted on every projection
+# ---------------------------------------------------------------------------
+
+_BASE_CLASSIFICATION_INVARIANTS: Final[dict[str, bool]] = {
+    # The two flips A20c performs vs A20b's invariants:
+    "calls_execution_authority_classifier": True,
+    "final_authority_classified": True,
+    # Authority chain — carry forward A20b's posture verbatim:
+    "no_runtime_trading_authority": True,
+    "no_step5_runtime": True,
+    "no_level6": True,
+    "no_production_merge_authority": True,
+    "writes_only_roadmap_task_authority_log": True,
+    "step5_implementation_allowed": False,
+    # Upstream-mutation invariants (pinned by sha256 before/after
+    # tests):
+    "mutates_a20a_artifact": False,
+    "mutates_a20b_artifact": False,
+    "mutates_roadmap_status_fields": False,
+    "marks_phase_complete": False,
+    "fuzzy_parsing": False,
+    "uses_subprocess_or_network": False,
+    "calls_llm_or_external_api": False,
+    "writes_to_seed_jsonl": False,
+    "writes_to_delegation_seed_jsonl": False,
+    "writes_to_generated_seed_jsonl": False,
+    # Downstream surfaces not yet implemented; A20d / A20e will
+    # flip these when they land.
+    "aac_visibility_present": False,
+    "next_buildable_selector_present": False,
+}
+
+
+# ---------------------------------------------------------------------------
+# Utility helpers
+# ---------------------------------------------------------------------------
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _project_decision(
+    decision: ea.ExecutionDecision,
+    *,
+    path: str,
+    risk_class: str,
+) -> dict[str, Any]:
+    """Project an :class:`ea.ExecutionDecision` into a bounded-scalar
+    record. Schema is :data:`PER_FILE_DECISION_FIELDS`."""
+    return {
+        "path": path,
+        "action_type": _ACTION_TYPE,
+        "risk_class": risk_class,
+        "decision": decision.decision,
+        "reason": decision.reason,
+        "target_path_category": decision.target_path_category,
+    }
+
+
+def _classify_one(
+    path: str, *, risk_class: str
+) -> tuple[ea.ExecutionDecision, dict[str, Any]]:
+    """Single per-path call into the canonical classifier. Returns
+    both the raw decision (for aggregation) and the bounded-scalar
+    projection (for the artefact)."""
+    decision = ea.classify(
+        action_type=_ACTION_TYPE,
+        target_path=path,
+        risk_class=risk_class,
+    )
+    return decision, _project_decision(decision, path=path, risk_class=risk_class)
+
+
+def _aggregate_expected_decisions(
+    expected_decisions: list[ea.ExecutionDecision],
+) -> tuple[str, str]:
+    """Reduce per-file decisions on ``expected_files`` to a unit-level
+    ``(aggregate_decision, aggregate_reason)`` pair using max-severity
+    over the canonical ``DECISIONS`` ordering.
+
+    Fail-closed contract:
+
+    * empty list (defence in depth — A20b forbids empty
+      ``expected_files`` but A20c stays safe) → ``NEEDS_HUMAN`` /
+      ``unknown_risk_or_target_fail_safe``;
+    * any ``PERMANENTLY_DENIED`` → ``PERMANENTLY_DENIED`` (with that
+      decision's reason);
+    * any ``NEEDS_HUMAN`` and no denied → ``NEEDS_HUMAN`` (with that
+      decision's reason);
+    * all ``AUTO_ALLOWED`` → ``AUTO_ALLOWED`` (with the first
+      decision's reason in input order; A20a/A20b emit deterministic
+      ordered ``expected_files``).
+    """
+    if not expected_decisions:
+        return _AGGREGATE_FAIL_CLOSED, _AGGREGATE_FAIL_CLOSED_REASON
+
+    # First-match wins per severity tier.
+    for d in expected_decisions:
+        if d.decision == ea.DECISION_PERMANENTLY_DENIED:
+            return d.decision, d.reason
+    for d in expected_decisions:
+        if d.decision == ea.DECISION_NEEDS_HUMAN:
+            return d.decision, d.reason
+    # All AUTO_ALLOWED — pick the first decision's reason.
+    return expected_decisions[0].decision, expected_decisions[0].reason
+
+
+def _decide_for_unit(unit: dict[str, Any]) -> dict[str, Any]:
+    """Build one ``UnitAuthorityDecision`` from one A20b unit."""
+    raw_risk = unit.get("risk_class")
+    risk_class = raw_risk if raw_risk in RISK_CLASSES else ea.RISK_UNKNOWN
+
+    expected_decisions: list[ea.ExecutionDecision] = []
+    expected_records: list[dict[str, Any]] = []
+    for path in unit.get("expected_files", []):
+        decision, record = _classify_one(path, risk_class=risk_class)
+        expected_decisions.append(decision)
+        expected_records.append(record)
+
+    forbidden_decisions: list[ea.ExecutionDecision] = []
+    forbidden_records: list[dict[str, Any]] = []
+    for path in unit.get("forbidden_files", []):
+        decision, record = _classify_one(path, risk_class=risk_class)
+        forbidden_decisions.append(decision)
+        forbidden_records.append(record)
+
+    aggregate_decision, aggregate_reason = _aggregate_expected_decisions(
+        expected_decisions
+    )
+
+    return {
+        "unit_id": unit["id"],
+        "parent_task_id": unit["roadmap_task_id"],
+        "expected_files_decisions": expected_records,
+        "forbidden_files_decisions": forbidden_records,
+        "aggregate_decision": aggregate_decision,
+        "aggregate_reason": aggregate_reason,
+        "authority_hint_from_a20b": unit.get("authority_hint", ""),
+        "classifier_schema_version": ea.SCHEMA_VERSION,
+        "classifier_module": "reporting.execution_authority",
+        "forbidden_surface_reasons": list(
+            unit.get("forbidden_surface_reasons", [])
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Snapshot assembly
+# ---------------------------------------------------------------------------
+
+
+def collect_snapshot(
+    *,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    """Build the deterministic Roadmap-task-authority projection.
+
+    Args:
+        generated_at_utc: override the report timestamp. Tests inject
+            this for byte-stable output.
+    """
+    ts = generated_at_utc if generated_at_utc is not None else _utcnow()
+
+    # Read upstream A20b units. The A20b snapshot already reads A20a
+    # transitively; we do not re-read the A20a catalog content here
+    # except to record its module_version for cross-reference.
+    units_snapshot = rtu.collect_snapshot(generated_at_utc=ts)
+    catalog_snapshot = rtc.collect_snapshot(generated_at_utc=ts)
+
+    decisions = [_decide_for_unit(u) for u in units_snapshot["implementation_units"]]
+    decisions.sort(key=lambda r: (r["parent_task_id"], r["unit_id"]))
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": ts,
+        "step5_enabled_substage": STEP5_ENABLED_SUBSTAGE,
+        "step5_implementation_allowed": step5_implementation_allowed,
+        "source_catalog_module_version": catalog_snapshot["module_version"],
+        "source_catalog_schema_version": catalog_snapshot["schema_version"],
+        "source_units_module_version": units_snapshot["module_version"],
+        "source_units_schema_version": units_snapshot["schema_version"],
+        "classifier_module_version": ea.MODULE_VERSION,
+        "classifier_schema_version": ea.SCHEMA_VERSION,
+        "vocabularies": {
+            "decisions": list(DECISIONS),
+            "risk_classes": list(RISK_CLASSES),
+            "action_type": [_ACTION_TYPE],
+            "severity_ordering": [
+                ea.DECISION_AUTO_ALLOWED,
+                ea.DECISION_NEEDS_HUMAN,
+                ea.DECISION_PERMANENTLY_DENIED,
+            ],
+        },
+        "authority_decisions": decisions,
+        "classification_invariants": dict(_BASE_CLASSIFICATION_INVARIANTS),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Atomic write
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Write ``payload`` as sorted-key indented JSON to ``path``,
+    atomically, refusing any path outside
+    ``logs/roadmap_task_authority/``."""
+    posix = path.as_posix()
+    if _WRITE_PREFIX not in posix:
+        raise ValueError(
+            "roadmap_task_authority._atomic_write_json refuses "
+            f"non-authority-logs output path: {path}"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".roadmap_task_authority.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_outputs(snapshot: dict[str, Any]) -> Path:
+    _atomic_write_json(ARTIFACT_LATEST, snapshot)
+    return ARTIFACT_LATEST
+
+
+# ---------------------------------------------------------------------------
+# Status renderer
+# ---------------------------------------------------------------------------
+
+
+def _render_status(snapshot: dict[str, Any]) -> str:
+    decisions = snapshot["authority_decisions"]
+    inv = snapshot["classification_invariants"]
+    by_aggregate: dict[str, int] = {d: 0 for d in DECISIONS}
+    by_hint: dict[str, int] = {}
+    for d in decisions:
+        by_aggregate[d["aggregate_decision"]] += 1
+        hint = d["authority_hint_from_a20b"] or "(none)"
+        by_hint[hint] = by_hint.get(hint, 0) + 1
+    lines = [
+        f"roadmap_task_authority {snapshot['module_version']} "
+        f"schema={snapshot['schema_version']}",
+        f"generated_at_utc={snapshot['generated_at_utc']}",
+        f"authority_decisions={len(decisions)}",
+        (
+            "step5_implementation_allowed="
+            f"{snapshot['step5_implementation_allowed']} "
+            f"step5_enabled_substage={snapshot['step5_enabled_substage']}"
+        ),
+        (
+            "calls_execution_authority_classifier="
+            f"{inv['calls_execution_authority_classifier']} "
+            "final_authority_classified="
+            f"{inv['final_authority_classified']}"
+        ),
+        (
+            "no_runtime_trading_authority="
+            f"{inv['no_runtime_trading_authority']} "
+            f"no_step5_runtime={inv['no_step5_runtime']} "
+            f"no_level6={inv['no_level6']} "
+            "no_production_merge_authority="
+            f"{inv['no_production_merge_authority']}"
+        ),
+        (
+            "writes_only_roadmap_task_authority_log="
+            f"{inv['writes_only_roadmap_task_authority_log']}"
+        ),
+        f"by_aggregate_decision={dict(sorted(by_aggregate.items()))}",
+        f"by_authority_hint={dict(sorted(by_hint.items()))}",
+    ]
+    for d in decisions:
+        lines.append(
+            f"  unit {d['unit_id']} parent={d['parent_task_id']} "
+            f"aggregate={d['aggregate_decision']} "
+            f"hint={d['authority_hint_from_a20b']}"
+        )
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m reporting.roadmap_task_authority",
+        description=(
+            "A20c Authority/Risk Classifier Integration. Read-only "
+            "deterministic projection that classifies every A20b "
+            "implementation unit's expected_files and forbidden_files "
+            "via the canonical reporting.execution_authority "
+            "classifier. No second source of truth for authority. "
+            "Step 5 implementation remains BLOCKED."
+        ),
+    )
+    p.add_argument(
+        "--indent",
+        type=int,
+        default=2,
+        help="JSON indent for stdout output (0 for compact).",
+    )
+    p.add_argument(
+        "--no-write",
+        action="store_true",
+        help=(
+            "Do not persist logs/roadmap_task_authority/latest.json "
+            "(stdout only)."
+        ),
+    )
+    p.add_argument(
+        "--status",
+        action="store_true",
+        help=(
+            "Render a compact human-readable status summary to stdout "
+            "and exit. Does not write any artefact."
+        ),
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    snap = collect_snapshot()
+    if args.status:
+        sys.stdout.write(_render_status(snap))
+        return 0
+    indent = args.indent if args.indent and args.indent > 0 else None
+    if not args.no_write:
+        write_outputs(snap)
+    json.dump(snap, sys.stdout, indent=indent, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/unit/test_roadmap_task_authority.py
+++ b/tests/unit/test_roadmap_task_authority.py
@@ -1,0 +1,924 @@
+"""Unit tests for A20c — Authority/Risk Classifier Integration.
+
+Pins:
+
+* Re-exported vocabularies match the canonical classifier verbatim
+  (no second source of truth).
+* Schema field tuples are exact and ordered.
+* Every A20b unit receives an authority decision.
+* Every ``expected_files`` and ``forbidden_files`` entry's per-file
+  decision matches the verbatim output of
+  ``reporting.execution_authority.classify(...)``.
+* Aggregation is max-severity over the canonical decision ordering.
+* Fail-closed: UNKNOWN risk -> NEEDS_HUMAN; empty expected_files
+  -> NEEDS_HUMAN.
+* Runtime / trading surfaces (broker, agent.risk, agent.execution,
+  automation.live_gate) are never AUTO_ALLOWED.
+* Frozen contracts are PERMANENTLY_DENIED.
+* canonical_roadmap / canonical_policy_doc paths classify as
+  NEEDS_HUMAN or stronger.
+* Atomic write only under ``logs/roadmap_task_authority/``.
+* No mutation of A20a or A20b artefacts (sha256 before/after).
+* Deterministic byte-identical output for identical input with
+  injected ``generated_at_utc``.
+* Module source carries no forbidden imports / runtime tokens.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import json
+from pathlib import Path
+
+import pytest
+
+from reporting import execution_authority as ea
+from reporting import roadmap_task_authority as rta
+from reporting import roadmap_task_catalog as rtc
+from reporting import roadmap_task_units as rtu
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+_FROZEN_UTC = "2026-05-18T12:00:00Z"
+
+
+@pytest.fixture
+def snap() -> dict:
+    return rta.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+
+
+@pytest.fixture
+def units_snap() -> dict:
+    return rtu.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+
+
+@pytest.fixture
+def catalog_snap() -> dict:
+    return rtc.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies — verbatim re-export from the canonical classifier
+# ---------------------------------------------------------------------------
+
+
+def test_decisions_are_verbatim_classifier_reexport() -> None:
+    assert rta.DECISIONS == ea.DECISIONS
+
+
+def test_risk_classes_are_verbatim_classifier_reexport() -> None:
+    assert rta.RISK_CLASSES == ea.RISK_CLASSES
+
+
+def test_severity_ordering_matches_decision_enum() -> None:
+    assert rta._SEVERITY == {
+        ea.DECISION_AUTO_ALLOWED: 0,
+        ea.DECISION_NEEDS_HUMAN: 1,
+        ea.DECISION_PERMANENTLY_DENIED: 2,
+    }
+
+
+def test_action_type_is_file_edit() -> None:
+    # A20b units describe creating new tracked files; the modify
+    # action passed to the classifier must be ``file_edit``.
+    assert rta._ACTION_TYPE == "file_edit"
+    assert rta._ACTION_TYPE in ea.ACTION_TYPES
+
+
+# ---------------------------------------------------------------------------
+# Schema integrity
+# ---------------------------------------------------------------------------
+
+
+def test_per_file_decision_field_list_exact() -> None:
+    assert rta.PER_FILE_DECISION_FIELDS == (
+        "path",
+        "action_type",
+        "risk_class",
+        "decision",
+        "reason",
+        "target_path_category",
+    )
+
+
+def test_unit_authority_decision_field_list_exact() -> None:
+    assert rta.UNIT_AUTHORITY_DECISION_FIELDS == (
+        "unit_id",
+        "parent_task_id",
+        "expected_files_decisions",
+        "forbidden_files_decisions",
+        "aggregate_decision",
+        "aggregate_reason",
+        "authority_hint_from_a20b",
+        "classifier_schema_version",
+        "classifier_module",
+        "forbidden_surface_reasons",
+    )
+
+
+def test_unit_authority_projection_field_list_exact() -> None:
+    assert rta.UNIT_AUTHORITY_PROJECTION_FIELDS == (
+        "generated_at_utc",
+        "schema_version",
+        "module_version",
+        "source_catalog_module_version",
+        "source_units_module_version",
+        "authority_decisions",
+        "classification_invariants",
+    )
+
+
+def test_every_authority_decision_has_every_field(snap: dict) -> None:
+    for d in snap["authority_decisions"]:
+        assert set(d.keys()) == set(rta.UNIT_AUTHORITY_DECISION_FIELDS), d
+
+
+def test_projection_carries_every_required_top_level_field(snap: dict) -> None:
+    for field in rta.UNIT_AUTHORITY_PROJECTION_FIELDS:
+        assert field in snap, field
+
+
+def test_every_per_file_record_has_every_field(snap: dict) -> None:
+    for d in snap["authority_decisions"]:
+        for rec in d["expected_files_decisions"]:
+            assert set(rec.keys()) == set(rta.PER_FILE_DECISION_FIELDS), rec
+        for rec in d["forbidden_files_decisions"]:
+            assert set(rec.keys()) == set(rta.PER_FILE_DECISION_FIELDS), rec
+
+
+# ---------------------------------------------------------------------------
+# Coverage: every A20b unit receives an authority decision
+# ---------------------------------------------------------------------------
+
+
+def test_every_a20b_unit_receives_a_decision(
+    snap: dict, units_snap: dict
+) -> None:
+    unit_ids = {u["id"] for u in units_snap["implementation_units"]}
+    decided_ids = {d["unit_id"] for d in snap["authority_decisions"]}
+    assert unit_ids == decided_ids
+
+
+def test_decision_unit_ids_unique(snap: dict) -> None:
+    ids = [d["unit_id"] for d in snap["authority_decisions"]]
+    assert len(ids) == len(set(ids))
+
+
+def test_every_decision_records_classifier_module(snap: dict) -> None:
+    for d in snap["authority_decisions"]:
+        assert d["classifier_module"] == "reporting.execution_authority"
+        assert d["classifier_schema_version"] == ea.SCHEMA_VERSION
+
+
+# ---------------------------------------------------------------------------
+# Per-file decisions are the verbatim classifier output (no second source)
+# ---------------------------------------------------------------------------
+
+
+def test_expected_file_decisions_match_classifier_verbatim(
+    snap: dict, units_snap: dict
+) -> None:
+    units_by_id = {u["id"]: u for u in units_snap["implementation_units"]}
+    for d in snap["authority_decisions"]:
+        unit = units_by_id[d["unit_id"]]
+        risk_class = (
+            unit["risk_class"]
+            if unit["risk_class"] in ea.RISK_CLASSES
+            else ea.RISK_UNKNOWN
+        )
+        for rec in d["expected_files_decisions"]:
+            canonical = ea.classify(
+                action_type="file_edit",
+                target_path=rec["path"],
+                risk_class=risk_class,
+            )
+            assert rec["decision"] == canonical.decision, rec
+            assert rec["reason"] == canonical.reason, rec
+            assert (
+                rec["target_path_category"] == canonical.target_path_category
+            ), rec
+
+
+def test_forbidden_file_decisions_match_classifier_verbatim(
+    snap: dict, units_snap: dict
+) -> None:
+    units_by_id = {u["id"]: u for u in units_snap["implementation_units"]}
+    for d in snap["authority_decisions"]:
+        unit = units_by_id[d["unit_id"]]
+        risk_class = (
+            unit["risk_class"]
+            if unit["risk_class"] in ea.RISK_CLASSES
+            else ea.RISK_UNKNOWN
+        )
+        for rec in d["forbidden_files_decisions"]:
+            canonical = ea.classify(
+                action_type="file_edit",
+                target_path=rec["path"],
+                risk_class=risk_class,
+            )
+            assert rec["decision"] == canonical.decision, rec
+            assert rec["reason"] == canonical.reason, rec
+            assert (
+                rec["target_path_category"] == canonical.target_path_category
+            ), rec
+
+
+def test_per_file_action_type_and_risk_class_are_consistent(
+    snap: dict, units_snap: dict
+) -> None:
+    units_by_id = {u["id"]: u for u in units_snap["implementation_units"]}
+    for d in snap["authority_decisions"]:
+        unit = units_by_id[d["unit_id"]]
+        expected_risk = (
+            unit["risk_class"]
+            if unit["risk_class"] in ea.RISK_CLASSES
+            else ea.RISK_UNKNOWN
+        )
+        for rec in d["expected_files_decisions"] + d["forbidden_files_decisions"]:
+            assert rec["action_type"] == "file_edit"
+            assert rec["risk_class"] == expected_risk
+
+
+# ---------------------------------------------------------------------------
+# Aggregation rules
+# ---------------------------------------------------------------------------
+
+
+def test_aggregate_decision_is_in_canonical_decisions_enum(snap: dict) -> None:
+    for d in snap["authority_decisions"]:
+        assert d["aggregate_decision"] in ea.DECISIONS
+
+
+def test_aggregate_reason_is_in_canonical_reasons_enum(snap: dict) -> None:
+    for d in snap["authority_decisions"]:
+        assert d["aggregate_reason"] in ea.REASONS, d
+
+
+def test_aggregate_follows_max_severity_over_expected_files(snap: dict) -> None:
+    for d in snap["authority_decisions"]:
+        if not d["expected_files_decisions"]:
+            # Fail-closed branch is checked elsewhere.
+            continue
+        per_file_decisions = [
+            rec["decision"] for rec in d["expected_files_decisions"]
+        ]
+        expected_aggregate = max(
+            per_file_decisions, key=lambda v: rta._SEVERITY[v]
+        )
+        assert d["aggregate_decision"] == expected_aggregate, d
+
+
+def test_any_permanently_denied_expected_file_drives_unit_to_denied() -> None:
+    fake_unit = {
+        "id": "syn_unit_denied",
+        "roadmap_task_id": "phase_v3_15_16",
+        "risk_class": "LOW",
+        "expected_files": [
+            "reporting/intelligent_routing_diagnostic_signals.py",
+            "broker/foo.py",  # live_path -> PERMANENTLY_DENIED on modify
+            "tests/unit/test_intelligent_routing_diagnostic_signals.py",
+        ],
+        "forbidden_files": [],
+        "authority_hint": "AUTO_ALLOWED_CANDIDATE",
+        "forbidden_surface_reasons": [],
+    }
+    decision = rta._decide_for_unit(fake_unit)
+    assert decision["aggregate_decision"] == ea.DECISION_PERMANENTLY_DENIED
+    assert decision["aggregate_reason"] == "denied_live_path_modification"
+
+
+def test_any_needs_human_no_denied_drives_unit_to_needs_human() -> None:
+    fake_unit = {
+        "id": "syn_unit_needs_human",
+        "roadmap_task_id": "phase_v3_15_16",
+        "risk_class": "LOW",
+        "expected_files": [
+            "reporting/intelligent_routing_diagnostic_signals.py",  # auto-allowed
+            "docs/governance/execution_authority.md",  # canonical_policy_doc -> NEEDS_HUMAN
+        ],
+        "forbidden_files": [],
+        "authority_hint": "AUTO_ALLOWED_CANDIDATE",
+        "forbidden_surface_reasons": [],
+    }
+    decision = rta._decide_for_unit(fake_unit)
+    assert decision["aggregate_decision"] == ea.DECISION_NEEDS_HUMAN
+    assert decision["aggregate_reason"] == "high_risk_canonical_policy_change"
+
+
+def test_all_auto_allowed_drives_unit_to_auto_allowed() -> None:
+    fake_unit = {
+        "id": "syn_unit_auto",
+        "roadmap_task_id": "phase_v3_15_16",
+        "risk_class": "LOW",
+        "expected_files": [
+            "reporting/intelligent_routing_diagnostic_signals.py",
+            "tests/unit/test_intelligent_routing_diagnostic_signals.py",
+            "docs/governance/intelligent_routing_diagnostic_signals.md",
+        ],
+        "forbidden_files": [],
+        "authority_hint": "AUTO_ALLOWED_CANDIDATE",
+        "forbidden_surface_reasons": [],
+    }
+    decision = rta._decide_for_unit(fake_unit)
+    assert decision["aggregate_decision"] == ea.DECISION_AUTO_ALLOWED
+
+
+def test_empty_expected_files_falls_closed_to_needs_human() -> None:
+    fake_unit = {
+        "id": "syn_unit_empty",
+        "roadmap_task_id": "phase_v3_15_16",
+        "risk_class": "LOW",
+        "expected_files": [],
+        "forbidden_files": [],
+        "authority_hint": "AUTO_ALLOWED_CANDIDATE",
+        "forbidden_surface_reasons": [],
+    }
+    decision = rta._decide_for_unit(fake_unit)
+    assert decision["aggregate_decision"] == ea.DECISION_NEEDS_HUMAN
+    assert decision["aggregate_reason"] == "unknown_risk_or_target_fail_safe"
+
+
+# ---------------------------------------------------------------------------
+# UNKNOWN risk fails closed to NEEDS_HUMAN
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_risk_class_falls_closed_to_needs_human() -> None:
+    fake_unit = {
+        "id": "syn_unit_unknown_risk",
+        "roadmap_task_id": "phase_v3_15_16",
+        "risk_class": "UNKNOWN",
+        "expected_files": [
+            "reporting/intelligent_routing_diagnostic_signals.py",
+        ],
+        "forbidden_files": [],
+        "authority_hint": "NEEDS_HUMAN_CANDIDATE",
+        "forbidden_surface_reasons": [],
+    }
+    decision = rta._decide_for_unit(fake_unit)
+    assert decision["aggregate_decision"] == ea.DECISION_NEEDS_HUMAN
+    assert decision["aggregate_reason"] == "unknown_risk_or_target_fail_safe"
+
+
+def test_invalid_risk_string_is_coerced_to_unknown_and_fails_closed() -> None:
+    fake_unit = {
+        "id": "syn_unit_bad_risk",
+        "roadmap_task_id": "phase_v3_15_16",
+        "risk_class": "NOT_A_RISK_CLASS",
+        "expected_files": [
+            "reporting/intelligent_routing_diagnostic_signals.py",
+        ],
+        "forbidden_files": [],
+        "authority_hint": "AUTO_ALLOWED_CANDIDATE",
+        "forbidden_surface_reasons": [],
+    }
+    decision = rta._decide_for_unit(fake_unit)
+    assert decision["aggregate_decision"] == ea.DECISION_NEEDS_HUMAN
+
+
+# ---------------------------------------------------------------------------
+# Runtime / trading surfaces never AUTO_ALLOWED
+# ---------------------------------------------------------------------------
+
+
+_NEVER_AUTO_ALLOWED_SAMPLES = (
+    "broker/foo.py",
+    "broker/x/y/z.py",
+    "agent/risk/policy.py",
+    "agent/execution/runner.py",
+    "automation/live_gate.py",
+    # Globs that A20b actually emits inside forbidden_files. The
+    # classifier reads them as path strings and categorises them
+    # by prefix.
+    "broker/**",
+    "agent/risk/**",
+    "agent/execution/**",
+)
+
+
+@pytest.mark.parametrize("path", _NEVER_AUTO_ALLOWED_SAMPLES)
+def test_runtime_trading_surface_is_never_auto_allowed_via_classifier(
+    path: str,
+) -> None:
+    for risk_class in ea.RISK_CLASSES:
+        decision = ea.classify(
+            action_type="file_edit",
+            target_path=path,
+            risk_class=risk_class,
+        )
+        assert decision.decision != ea.DECISION_AUTO_ALLOWED, (
+            path,
+            risk_class,
+            decision,
+        )
+
+
+_LIVE_PAPER_SHADOW_TRADING_GLOBS = (
+    "live/**",
+    "paper/**",
+    "shadow/**",
+    "trading/**",
+    "execution/**",
+)
+
+
+@pytest.mark.parametrize("path", _LIVE_PAPER_SHADOW_TRADING_GLOBS)
+def test_live_paper_shadow_trading_execution_paths_never_auto_allowed(
+    path: str,
+) -> None:
+    """live/**, paper/**, shadow/**, trading/**, execution/** are not
+    canonical ``live_path`` predicates in the classifier (those
+    cover ``broker/**``, ``agent/risk/**``, ``agent/execution/**``,
+    ``automation/live_gate.py``). The canonical classifier treats
+    them as ``other`` -> ``NEEDS_HUMAN`` on every modify action,
+    which still satisfies the 'never AUTO_ALLOWED' invariant.
+    """
+    for risk_class in ea.RISK_CLASSES:
+        decision = ea.classify(
+            action_type="file_edit",
+            target_path=path,
+            risk_class=risk_class,
+        )
+        assert decision.decision != ea.DECISION_AUTO_ALLOWED, (
+            path,
+            risk_class,
+        )
+
+
+def test_no_unit_in_main_aggregates_to_auto_allowed_on_a_runtime_surface(
+    snap: dict,
+) -> None:
+    """Across every unit on main, no AUTO_ALLOWED aggregate may rest
+    on a per-file decision against a broker / agent.risk /
+    agent.execution / live_gate path. Catches a future A20b
+    regression that would smuggle a runtime surface into
+    expected_files."""
+    runtime_categories = {"live_path"}
+    for d in snap["authority_decisions"]:
+        if d["aggregate_decision"] != ea.DECISION_AUTO_ALLOWED:
+            continue
+        for rec in d["expected_files_decisions"]:
+            assert rec["target_path_category"] not in runtime_categories, rec
+
+
+# ---------------------------------------------------------------------------
+# Frozen contracts remain denied
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "research/research_latest.json",
+        "research/strategy_matrix.csv",
+    ],
+)
+def test_frozen_contract_paths_are_permanently_denied(path: str) -> None:
+    for risk_class in ea.RISK_CLASSES:
+        decision = ea.classify(
+            action_type="file_edit",
+            target_path=path,
+            risk_class=risk_class,
+        )
+        assert decision.decision == ea.DECISION_PERMANENTLY_DENIED, (
+            path,
+            risk_class,
+        )
+        assert decision.reason == "denied_frozen_contract_mutation"
+
+
+def test_no_unit_in_main_aggregates_to_auto_allowed_on_frozen_contract(
+    snap: dict,
+) -> None:
+    for d in snap["authority_decisions"]:
+        if d["aggregate_decision"] != ea.DECISION_AUTO_ALLOWED:
+            continue
+        for rec in d["expected_files_decisions"]:
+            assert rec["target_path_category"] != "frozen_contract", rec
+
+
+# ---------------------------------------------------------------------------
+# Canonical roadmap / canonical policy doc paths are NEEDS_HUMAN or stronger
+# ---------------------------------------------------------------------------
+
+
+_CANONICAL_PROTECTED_SAMPLES = (
+    "docs/governance/execution_authority.md",
+    "docs/governance/no_touch_paths.md",
+    "docs/governance/observability_security_hardening.md",
+    "docs/roadmap/Roadmap v6.md",
+    "docs/roadmap/autonomous_development.txt",
+)
+
+
+@pytest.mark.parametrize("path", _CANONICAL_PROTECTED_SAMPLES)
+def test_canonical_roadmap_or_policy_path_is_needs_human_or_stronger(
+    path: str,
+) -> None:
+    for risk_class in ea.RISK_CLASSES:
+        decision = ea.classify(
+            action_type="file_edit",
+            target_path=path,
+            risk_class=risk_class,
+        )
+        assert decision.decision in (
+            ea.DECISION_NEEDS_HUMAN,
+            ea.DECISION_PERMANENTLY_DENIED,
+        ), (path, risk_class, decision)
+
+
+# ---------------------------------------------------------------------------
+# Authority-hint preservation (A20b hint is NOT authority)
+# ---------------------------------------------------------------------------
+
+
+def test_authority_hint_from_a20b_is_preserved(
+    snap: dict, units_snap: dict
+) -> None:
+    units_by_id = {u["id"]: u for u in units_snap["implementation_units"]}
+    for d in snap["authority_decisions"]:
+        unit = units_by_id[d["unit_id"]]
+        assert d["authority_hint_from_a20b"] == unit["authority_hint"]
+
+
+def test_hint_never_overrides_classifier_aggregate(snap: dict) -> None:
+    """The A20b hint is metadata only. A unit's aggregate_decision
+    must be derivable purely from its expected_files_decisions via
+    max-severity; the hint never enters the aggregation."""
+    for d in snap["authority_decisions"]:
+        if not d["expected_files_decisions"]:
+            continue
+        per_file_decisions = [
+            rec["decision"] for rec in d["expected_files_decisions"]
+        ]
+        expected_aggregate = max(
+            per_file_decisions, key=lambda v: rta._SEVERITY[v]
+        )
+        assert d["aggregate_decision"] == expected_aggregate
+
+
+# ---------------------------------------------------------------------------
+# Classification invariants
+# ---------------------------------------------------------------------------
+
+
+def test_invariants_flip_calls_execution_authority_classifier(snap: dict) -> None:
+    inv = snap["classification_invariants"]
+    assert inv["calls_execution_authority_classifier"] is True
+
+
+def test_invariants_flip_final_authority_classified(snap: dict) -> None:
+    inv = snap["classification_invariants"]
+    assert inv["final_authority_classified"] is True
+
+
+def test_invariants_pin_no_runtime_trading_authority(snap: dict) -> None:
+    inv = snap["classification_invariants"]
+    assert inv["no_runtime_trading_authority"] is True
+
+
+def test_invariants_pin_no_step5_runtime(snap: dict) -> None:
+    inv = snap["classification_invariants"]
+    assert inv["no_step5_runtime"] is True
+    assert snap["step5_implementation_allowed"] is False
+    assert snap["step5_enabled_substage"] == "none"
+
+
+def test_invariants_pin_no_level6(snap: dict) -> None:
+    inv = snap["classification_invariants"]
+    assert inv["no_level6"] is True
+
+
+def test_invariants_pin_no_production_merge_authority(snap: dict) -> None:
+    inv = snap["classification_invariants"]
+    assert inv["no_production_merge_authority"] is True
+
+
+def test_invariants_pin_writes_only_roadmap_task_authority_log(
+    snap: dict,
+) -> None:
+    inv = snap["classification_invariants"]
+    assert inv["writes_only_roadmap_task_authority_log"] is True
+
+
+def test_invariants_pin_aac_and_next_buildable_not_implemented(
+    snap: dict,
+) -> None:
+    inv = snap["classification_invariants"]
+    # A20d / A20e are still pending.
+    assert inv["aac_visibility_present"] is False
+    assert inv["next_buildable_selector_present"] is False
+
+
+def test_invariants_pin_no_seed_jsonl_writes(snap: dict) -> None:
+    inv = snap["classification_invariants"]
+    assert inv["writes_to_seed_jsonl"] is False
+    assert inv["writes_to_delegation_seed_jsonl"] is False
+    assert inv["writes_to_generated_seed_jsonl"] is False
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_deterministic_with_injected_ts() -> None:
+    a = rta.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+    b = rta.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+    assert a == b
+
+
+def test_serialised_output_byte_identical_with_injected_ts() -> None:
+    a = rta.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+    b = rta.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+    out_a = json.dumps(a, indent=2, sort_keys=True) + "\n"
+    out_b = json.dumps(b, indent=2, sort_keys=True) + "\n"
+    assert out_a == out_b
+
+
+def test_authority_decisions_order_stable(snap: dict) -> None:
+    sorted_pairs = [
+        (d["parent_task_id"], d["unit_id"]) for d in snap["authority_decisions"]
+    ]
+    assert sorted_pairs == sorted(sorted_pairs)
+
+
+def test_source_module_versions_match_upstream(
+    snap: dict, units_snap: dict, catalog_snap: dict
+) -> None:
+    assert snap["source_units_module_version"] == units_snap["module_version"]
+    assert snap["source_catalog_module_version"] == catalog_snap["module_version"]
+
+
+# ---------------------------------------------------------------------------
+# No upstream mutation (sha256 before/after)
+# ---------------------------------------------------------------------------
+
+
+def _sha256(b: bytes) -> str:
+    return hashlib.sha256(b).hexdigest()
+
+
+def test_collect_snapshot_does_not_mutate_a20a_artifact_in_memory() -> None:
+    before = json.dumps(
+        rtc.collect_snapshot(generated_at_utc=_FROZEN_UTC),
+        sort_keys=True,
+    ).encode("utf-8")
+    rta.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+    after = json.dumps(
+        rtc.collect_snapshot(generated_at_utc=_FROZEN_UTC),
+        sort_keys=True,
+    ).encode("utf-8")
+    assert _sha256(before) == _sha256(after)
+
+
+def test_collect_snapshot_does_not_mutate_a20b_artifact_in_memory() -> None:
+    before = json.dumps(
+        rtu.collect_snapshot(generated_at_utc=_FROZEN_UTC),
+        sort_keys=True,
+    ).encode("utf-8")
+    rta.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+    after = json.dumps(
+        rtu.collect_snapshot(generated_at_utc=_FROZEN_UTC),
+        sort_keys=True,
+    ).encode("utf-8")
+    assert _sha256(before) == _sha256(after)
+
+
+# ---------------------------------------------------------------------------
+# Atomic write allowlist
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_write_refuses_path_outside_allowlist(tmp_path: Path) -> None:
+    bad = tmp_path / "logs" / "elsewhere" / "latest.json"
+    bad.parent.mkdir(parents=True, exist_ok=True)
+    with pytest.raises(ValueError):
+        rta._atomic_write_json(bad, {"x": 1})
+
+
+def test_atomic_write_refuses_frozen_contract_paths(tmp_path: Path) -> None:
+    for forbidden in (
+        "research/research_latest.json",
+        "research/strategy_matrix.csv",
+    ):
+        target = tmp_path / forbidden
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with pytest.raises(ValueError):
+            rta._atomic_write_json(target, {"x": 1})
+
+
+def test_atomic_write_accepts_allowlisted_path(tmp_path: Path) -> None:
+    good = tmp_path / "logs" / "roadmap_task_authority" / "latest.json"
+    good.parent.mkdir(parents=True, exist_ok=True)
+    rta._atomic_write_json(good, {"x": 1})
+    assert good.is_file()
+    assert json.loads(good.read_text(encoding="utf-8")) == {"x": 1}
+
+
+def test_atomic_write_is_atomic(tmp_path: Path) -> None:
+    target = tmp_path / "logs" / "roadmap_task_authority" / "latest.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    rta._atomic_write_json(target, {"x": 1})
+    rta._atomic_write_json(target, {"x": 2})
+    siblings = list(target.parent.iterdir())
+    assert siblings == [target], siblings
+
+
+# ---------------------------------------------------------------------------
+# CLI behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_cli_no_write_does_not_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    sentinel = tmp_path / "logs" / "roadmap_task_authority" / "latest.json"
+    monkeypatch.setattr(rta, "ARTIFACT_LATEST", sentinel)
+    monkeypatch.setattr(rta, "ARTIFACT_DIR", sentinel.parent)
+    rc = rta.main(["--no-write"])
+    assert rc == 0
+    assert not sentinel.exists()
+    out = capsys.readouterr().out
+    assert '"roadmap_task_authority"' in out
+
+
+def test_cli_status_does_not_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    sentinel = tmp_path / "logs" / "roadmap_task_authority" / "latest.json"
+    monkeypatch.setattr(rta, "ARTIFACT_LATEST", sentinel)
+    monkeypatch.setattr(rta, "ARTIFACT_DIR", sentinel.parent)
+    rc = rta.main(["--status"])
+    assert rc == 0
+    assert not sentinel.exists()
+    out = capsys.readouterr().out
+    assert "roadmap_task_authority" in out
+    assert "calls_execution_authority_classifier=True" in out
+    assert "final_authority_classified=True" in out
+    assert "no_runtime_trading_authority=True" in out
+
+
+def test_cli_default_writes_to_allowlisted_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sentinel = tmp_path / "logs" / "roadmap_task_authority" / "latest.json"
+    monkeypatch.setattr(rta, "ARTIFACT_LATEST", sentinel)
+    monkeypatch.setattr(rta, "ARTIFACT_DIR", sentinel.parent)
+    rc = rta.main([])
+    assert rc == 0
+    assert sentinel.is_file()
+    payload = json.loads(sentinel.read_text(encoding="utf-8"))
+    assert payload["report_kind"] == "roadmap_task_authority"
+    assert payload["module_version"].startswith("v3.15.16.A20c")
+
+
+def test_cli_indent_zero_compact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    sentinel = tmp_path / "logs" / "roadmap_task_authority" / "latest.json"
+    monkeypatch.setattr(rta, "ARTIFACT_LATEST", sentinel)
+    monkeypatch.setattr(rta, "ARTIFACT_DIR", sentinel.parent)
+    rc = rta.main(["--no-write", "--indent", "0"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "\n  " not in out
+
+
+# ---------------------------------------------------------------------------
+# Module-source forbidden-import / forbidden-token scans
+# ---------------------------------------------------------------------------
+
+
+def _module_source() -> str:
+    return Path(rta.__file__).read_text(encoding="utf-8")
+
+
+def _module_imports() -> list[str]:
+    import ast as _ast
+
+    tree = _ast.parse(_module_source())
+    out: list[str] = []
+    for node in _ast.walk(tree):
+        if isinstance(node, _ast.Import):
+            for alias in node.names:
+                out.append(alias.name)
+        elif isinstance(node, _ast.ImportFrom):
+            mod = node.module or ""
+            for alias in node.names:
+                out.append(f"{mod}.{alias.name}" if mod else alias.name)
+    return out
+
+
+def test_no_subprocess_in_module() -> None:
+    src = _module_source()
+    assert "import subprocess" not in src
+    assert "from subprocess" not in src
+    assert "subprocess." not in src
+
+
+def test_no_socket_or_urllib_or_http_or_requests() -> None:
+    src = _module_source()
+    for forbidden in (
+        "import socket",
+        "from socket",
+        "import urllib",
+        "from urllib",
+        "import http",
+        "from http",
+        "import requests",
+        "from requests",
+        "import httpx",
+        "from httpx",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_no_forbidden_runtime_imports_via_ast() -> None:
+    forbidden_prefixes = (
+        "dashboard",
+        "automation",
+        "broker",
+        "agent.risk",
+        "agent.execution",
+        "research",
+        "live",
+        "paper",
+        "shadow",
+        "trading",
+        "reporting.intelligent_routing",
+        "reporting.development_queue_admission_policy",
+        "reporting.development_agent_activity_timeline",
+    )
+    for module in _module_imports():
+        for prefix in forbidden_prefixes:
+            assert not (
+                module == prefix or module.startswith(prefix + ".")
+            ), f"forbidden import: {module}"
+
+
+def test_no_gh_or_git_cli_calls() -> None:
+    """No process-level invocation of gh / git. Docstring mentions
+    are explicitly allowed."""
+    src = _module_source()
+    for forbidden in (
+        "subprocess.run",
+        "subprocess.Popen",
+        "os.system(",
+        "os.popen(",
+        "shell=True",
+        "eval(",
+        "exec(",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_no_github_api_or_external_api_calls() -> None:
+    src = _module_source()
+    for forbidden in (
+        "api.github.com",
+        "anthropic",
+        "openai",
+        "Bearer ",
+        "X-API-Key",
+        "X-GitHub-Token",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_module_imports_only_canonical_upstreams() -> None:
+    """A20c may only import from the canonical classifier + A20a +
+    A20b. Any other third-party reporting module is forbidden."""
+    allowed_reporting_imports = {
+        "reporting.execution_authority",
+        "reporting.roadmap_task_catalog",
+        "reporting.roadmap_task_units",
+    }
+    for module in _module_imports():
+        if module.startswith("reporting."):
+            assert module in allowed_reporting_imports, module
+
+
+def test_module_imports_cleanly() -> None:
+    importlib.reload(rta)
+    assert callable(rta.collect_snapshot)
+    assert callable(rta.write_outputs)
+    assert callable(rta.main)
+
+
+def test_schema_and_module_version_strings() -> None:
+    assert isinstance(rta.SCHEMA_VERSION, str) and rta.SCHEMA_VERSION
+    assert isinstance(rta.MODULE_VERSION, str) and rta.MODULE_VERSION
+    assert rta.MODULE_VERSION.endswith("A20c")


### PR DESCRIPTION
## Summary

- Per-unit projection that joins the A20b implementation-unit decomposition with the canonical Execution Authority classifier (`reporting.execution_authority.classify(...)`).
- Emits a deterministic artefact at `logs/roadmap_task_authority/latest.json`.
- **A20c is a pure consumer.** No second source of truth: every per-file decision is the verbatim `ExecutionDecision` returned by the canonical classifier. Aggregation is a pure max-severity reduction over `AUTO_ALLOWED < NEEDS_HUMAN < PERMANENTLY_DENIED`.
- **A20b's `authority_hint` is preserved verbatim** under `authority_hint_from_a20b` as non-authoritative metadata. The hint never enters the aggregation (pinned by `test_hint_never_overrides_classifier_aggregate`).

## Files changed (exactly 3, approved scope only)

- `reporting/roadmap_task_authority.py` (new) — stdlib + `reporting.execution_authority` + `reporting.roadmap_task_units` + `reporting.roadmap_task_catalog` only.
- `tests/unit/test_roadmap_task_authority.py` (new) — 80 tests.
- `docs/governance/roadmap_task_catalog.md` (modified) — A20c section (§8) + test-coverage block (§10.3); A20a / A20b content preserved.

Untouched: `reporting/execution_authority.py`, `docs/governance/execution_authority.md`, `reporting/roadmap_task_catalog.py`, `reporting/roadmap_task_units.py`, `reporting/development_queue_admission_policy.py` (existing A17), `reporting/development_agent_activity_timeline.py` (AAC aggregator).

## Validation commands and results

- `python -m pytest tests/unit/test_roadmap_task_authority.py -q` → **80 passed**
- `python -m pytest tests/unit/test_roadmap_task_units.py -q` → **87 passed** (unchanged)
- `python -m pytest tests/unit/test_roadmap_task_catalog.py -q` → **83 passed** (unchanged)
- `python -m pytest tests/unit/test_execution_authority.py -q` → **110 passed** (unchanged)
- `python -m pytest tests/smoke -x --no-header -q` → **18 passed**
- `python scripts/governance_lint.py` → **OK** (16 agents, 5 workflows)
- `python scripts/push_body_safety_lint.py` → **OK** (6 surfaces, 6 tokens)

Combined unit-test sweep: **360 passed** in 1.36s.

## Frozen-contract verdict

- `research/research_latest.json` — **not touched**.
- `research/strategy_matrix.csv` — **not touched**.
- A20c's atomic-write helper rejects every path outside `logs/roadmap_task_authority/` (pinned by `test_atomic_write_refuses_path_outside_allowlist` and `test_atomic_write_refuses_frozen_contract_paths`).
- Sha256-before-vs-after pins assert `collect_snapshot()` does not mutate the A20a or A20b in-memory artefacts.
- Parametrised classifier tests confirm frozen-contract paths classify as `PERMANENTLY_DENIED` at every `risk_class` with reason `denied_frozen_contract_mutation`.

## Forbidden-path verdict

`git diff --name-only main` contains exactly the three approved files:

```
docs/governance/roadmap_task_catalog.md
reporting/roadmap_task_authority.py
tests/unit/test_roadmap_task_authority.py
```

None of the following were touched:

- `dashboard/dashboard.py`
- `.claude/**`
- `.github/**`
- `research/research_latest.json`, `research/strategy_matrix.csv`
- `automation/live_gate.py`, `broker/**`, `agent/risk/**`, `agent/execution/**`
- `live/**`, `paper/**`, `shadow/**`, `trading/**`
- `docs/roadmap/Roadmap v6.md`, `docs/roadmap/Roadmap v6 Addendum.md`, `docs/roadmap/autonomous_development.txt`
- `docs/governance/execution_authority.md`, `docs/governance/no_touch_paths.md`
- `reporting/execution_authority.py`
- `reporting/roadmap_task_catalog.py`, `reporting/roadmap_task_units.py`
- `reporting/development_queue_admission_policy.py` (existing A17 surface)
- `reporting/development_agent_activity_timeline.py` (AAC aggregator)
- `docs/development_work_queue/*.jsonl`
- `tests/regression/**`
- any frozen schema under `artifacts/`

## Authority statement (still pinned on `main`)

- ADE remains development workflow automation only.
- No QRE runtime / trading / paper / shadow / broker / risk / live authority granted.
- Step 5 implementation remains BLOCKED (`step5_implementation_allowed = False`, `STEP5_ENABLED_SUBSTAGE = \"none\"`).
- Autonomy-ladder Level 6 remains permanently disabled.
- N5b Phase 4 production merge remains permanently denied for ADE.
- A20c's `classification_invariants` block additionally pins: `calls_execution_authority_classifier = true`; `final_authority_classified = true`; `no_runtime_trading_authority = true`; `no_step5_runtime = true`; `no_level6 = true`; `no_production_merge_authority = true`; `writes_only_roadmap_task_authority_log = true`; `aac_visibility_present = false`; `next_buildable_selector_present = false`.

## What this PR does NOT do

- **No final authority classifier modification.** A20c uses the canonical classifier as a pure read-only dependency; `reporting/execution_authority.py` and `docs/governance/execution_authority.md` remain byte-stable.
- **No AAC / dashboard visibility.** A20d scope. The AAC aggregator's pinned upstream catalog cardinality is unchanged.
- **No next-buildable-unit selector.** A20e scope.
- **No edit to canonical roadmap docs, canonical policy docs, or `autonomous_development.txt`.**
- **No Step 5 / Level 6 / N5b weakening.**
- **No modification of A20a or A20b modules or their artefacts.**

## Next recommended PR

**A20d — Read-only AAC / Task-Board Visibility.** Extend `reporting.development_agent_activity_timeline.UPSTREAM_CATALOG_LEN` to surface `logs/roadmap_task_authority/latest.json` (and optionally `logs/roadmap_task_units/latest.json`) as read-only work-item rows. **Operator-go required** because the AAC aggregator's pinned upstream catalog cardinality is changed; the B2.0b structural-pin test must be updated in the same PR. No mutation routes, no approval buttons, no `dashboard/dashboard.py` edit.

## Test plan

- [x] `python -m pytest tests/unit/test_roadmap_task_authority.py -q` — 80 passed locally
- [x] `python -m pytest tests/unit/test_roadmap_task_units.py -q` — 87 passed locally
- [x] `python -m pytest tests/unit/test_roadmap_task_catalog.py -q` — 83 passed locally
- [x] `python -m pytest tests/unit/test_execution_authority.py -q` — 110 passed locally
- [x] `python -m pytest tests/smoke -x --no-header -q` — 18 passed locally
- [x] `python scripts/governance_lint.py` — OK locally
- [x] `python scripts/push_body_safety_lint.py` — OK locally
- [ ] CI checks complete on PR (squash-merge only — no \`--admin\`, no force push, no hook bypass, no automatic merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)