### PR TITLE
feat(a20c): roadmap unit authority classifier integration (read-only)

### DIFF
--- a/docs/governance/roadmap_task_catalog.md
+++ b/docs/governance/roadmap_task_catalog.md
@@ -1,15 +1,18 @@
-# Roadmap Task Catalog — A20a + A20b (read-only, deterministic)
+# Roadmap Task Catalog — A20a + A20b + A20c (read-only, deterministic)
 
-> **Status:** A20a implemented; A20b implemented (read-only,
-> deterministic, dry-run by default). Both modules are projections;
-> neither classifies authority, nor surfaces to the AAC / dashboard,
-> nor selects a next-buildable unit.
+> **Status:** A20a implemented; A20b implemented; A20c implemented
+> (read-only, deterministic, dry-run by default). All three modules
+> are projections; none surfaces to the AAC / dashboard, none
+> selects a next-buildable unit.
 >
 > **A20a module:** [`reporting/roadmap_task_catalog.py`](../../reporting/roadmap_task_catalog.py)
 > **A20a artefact:** `logs/roadmap_task_catalog/latest.json`
 >
 > **A20b module:** [`reporting/roadmap_task_units.py`](../../reporting/roadmap_task_units.py)
 > **A20b artefact:** `logs/roadmap_task_units/latest.json`
+>
+> **A20c module:** [`reporting/roadmap_unit_authority.py`](../../reporting/roadmap_unit_authority.py)
+> **A20c artefact:** `logs/roadmap_unit_authority/latest.json`
 >
 > **Authority:** development-governance read-only.
 > The roadmap task catalog is **not** the canonical product roadmap.
@@ -400,23 +403,201 @@ hint is informational only. Unknown inputs fail closed to
   decomposer reads the A20a catalog at runtime and skips any
   unit whose phase is not present in the catalog's task list.
 
-## 8. Future stages (A20c–A20e)
+## 8. A20c — Roadmap Unit Authority Classifier Integration (implemented)
 
-The roadmap task catalog + unit decomposer is the foundation of a
-staged sequence. Each subsequent stage requires a separate
-operator-go PR. None of them is pre-authorized by A20a or A20b.
+A20c is a **pure consumer** of two read-only upstreams: the A20b
+implementation-unit projection
+([`reporting/roadmap_task_units.py`](../../reporting/roadmap_task_units.py))
+and the canonical Execution Authority classifier
+([`reporting/execution_authority.py`](../../reporting/execution_authority.py)).
+The A20c module is
+[`reporting/roadmap_unit_authority.py`](../../reporting/roadmap_unit_authority.py);
+its artefact is `logs/roadmap_unit_authority/latest.json`.
 
-- **A20c — Authority / Risk Classifier Integration.** Annotates
-  each `ImplementationUnit` with an aggregate
-  `UnitAuthorityDecision` derived purely from
-  [`reporting/execution_authority.py`](../../reporting/execution_authority.py).
-  Aggregation is max-severity over per-file decisions. Fail-closed:
-  unknown risk → `NEEDS_HUMAN`; any protected-path / frozen / live
-  surface → `PERMANENTLY_DENIED` or `NEEDS_HUMAN` per the
-  classifier's existing policy. A20c will flip
-  `calls_execution_authority_classifier` and
-  `final_authority_classified` from `false` to `true` in the
-  projection's invariant block.
+A20c MUST NOT create a second source of truth for path-level
+authority. Every per-file evidence record carries the verbatim
+`decision` / `reason` returned by
+`reporting.execution_authority.classify(...)`. Non-path evidence
+kinds (`target_layer`, `risk_class`, `operator_gate`,
+`authority_hint`, `unit_kind`, `stop_conditions`) have their own
+deterministic, closed-vocab rules pinned by unit tests.
+
+### 8.1 Purpose of `UnitAuthorityDecision`
+
+For every A20b `ImplementationUnit`, A20c emits one
+`UnitAuthorityDecision` recording the **final authority class** the
+unit must satisfy before any future implementation PR may proceed.
+The class is one of the canonical
+`reporting.execution_authority.DECISIONS` values:
+
+- `AUTO_ALLOWED` — the unit may proceed under normal squash-merge
+  review (no extra operator gate).
+- `NEEDS_HUMAN` — the unit may proceed only with explicit operator
+  approval (operator-go required).
+- `PERMANENTLY_DENIED` — the unit is impossible under current
+  policy and may not be implemented at all without a future,
+  explicitly authorising governance-bootstrap PR.
+
+### 8.2 A20b `authority_hint` vs A20c `final_authority_class`
+
+A20b emits a non-authoritative `authority_hint` per unit, drawn
+from `{AUTO_ALLOWED_CANDIDATE, NEEDS_HUMAN_CANDIDATE,
+PERMANENTLY_DENIED_SURFACE}`. The hint is a deterministic seed-data
+value, not a classifier verdict.
+
+A20c emits the authoritative `final_authority_class` per unit,
+drawn from `{AUTO_ALLOWED, NEEDS_HUMAN, PERMANENTLY_DENIED}`. The
+hint enters as one piece of evidence (kind `authority_hint`) and
+contributes to aggregation alongside every other evidence kind —
+but it never overrides the canonical classifier verdict on a
+per-file path.
+
+### 8.3 Evidence schema
+
+Per-evidence record (`UnitAuthorityEvidence`):
+
+```
+kind     : str ∈ AUTHORITY_EVIDENCE_KIND
+value    : str (≤300 chars; bounded scalar)
+decision : str ∈ AUTHORITY_CLASS
+reason   : str ∈ AUTHORITY_REASON
+source   : str ("reporting.execution_authority" for path-based
+           evidence; "reporting.roadmap_unit_authority" for A20c
+           non-path rules)
+```
+
+Per-unit decision (`UnitAuthorityDecision`):
+
+```
+implementation_unit_id : str  A20b ImplementationUnit.id
+roadmap_task_id        : str  A20b ImplementationUnit.roadmap_task_id
+phase                  : str  A20b ImplementationUnit.phase
+final_authority_class  : str  ∈ AUTHORITY_CLASS
+max_severity           : int  0=AUTO_ALLOWED, 1=NEEDS_HUMAN, 2=PERMANENTLY_DENIED
+evidence               : list[UnitAuthorityEvidence]
+requires_operator_go   : bool true iff final_authority_class == NEEDS_HUMAN
+permanently_denied     : bool true iff final_authority_class == PERMANENTLY_DENIED
+deny_reasons           : list[str]  populated iff permanently_denied
+classifier_used        : bool true if at least one evidence record sources
+                              the canonical classifier
+fail_closed            : bool true if any evidence triggered
+                              fail_closed_unknown_* fallback
+```
+
+Top-level projection (`UnitAuthorityProjection`):
+
+```
+generated_at_utc            : ISO8601
+schema_version              : str
+module_version              : str
+source_units_schema_version : str  matches A20b.SCHEMA_VERSION
+authority_decisions         : list[UnitAuthorityDecision]
+authority_invariants        : dict[str, bool]
+```
+
+### 8.4 Aggregation: max-severity over **aggregating** evidence kinds
+
+A20c aggregates per-unit decisions over the canonical decision
+ordering `AUTO_ALLOWED < NEEDS_HUMAN < PERMANENTLY_DENIED`. Only
+the following evidence kinds contribute to the aggregate:
+
+- `expected_file_classifier` — verbatim verdict from the canonical
+  classifier for each `expected_files[]` entry;
+- `target_layer` — `live` → `PERMANENTLY_DENIED`; `paper` / `shadow`
+  → `NEEDS_HUMAN`; all other layers contribute the baseline;
+- `risk_class` — `UNKNOWN` → `NEEDS_HUMAN` with reason
+  `unknown_risk_or_target_fail_safe`;
+- `operator_gate` — `operator_go_required` /
+  `governance_bootstrap_pr_required` → `NEEDS_HUMAN`;
+- `authority_hint` — the A20b hint contributes the corresponding
+  class as a floor;
+- `unit_kind` — `research_module` / `diagnostic_primitive` /
+  `external_intelligence_source` → `NEEDS_HUMAN` (these surfaces
+  require human review even when the path classifier is permissive).
+
+The following evidence kinds are recorded for transparency but do
+**not** elevate the aggregate:
+
+- `forbidden_file_classifier` — canonical-classifier verdict for
+  each `forbidden_files[]` entry. Every A20b unit's baseline
+  forbidden list contains live / frozen / governance paths that
+  the classifier rightly denies; including them in aggregation
+  would force every unit to `PERMANENTLY_DENIED` and is therefore
+  explicitly excluded.
+- `stop_conditions` — descriptive STOP triggers from A20b. Recorded
+  as informational evidence only.
+
+This partition is pinned by
+`test_aggregating_and_informational_partition_the_vocab`.
+
+### 8.5 Fail-closed contract
+
+A20c fails closed in every ambiguous case:
+
+| Condition | Result |
+|---|---|
+| `risk_class == "UNKNOWN"` | `NEEDS_HUMAN` |
+| Invalid `risk_class` string (not in `RISK_CLASSES`) | `NEEDS_HUMAN`; `fail_closed = true` |
+| Invalid `target_layer` string | `NEEDS_HUMAN`; `fail_closed = true` |
+| Invalid `operator_gate` string | `NEEDS_HUMAN`; `fail_closed = true` |
+| Invalid `authority_hint` string | `NEEDS_HUMAN`; `fail_closed = true` |
+| Invalid `unit_kind` string | `NEEDS_HUMAN`; `fail_closed = true` |
+| No aggregating evidence at all (defence in depth) | `NEEDS_HUMAN`; deny_reasons `["fail_closed_unknown_evidence"]` |
+
+### 8.6 AUTO_ALLOWED only when no protected/runtime surface present
+
+A unit's `final_authority_class` is `AUTO_ALLOWED` if and only if
+**every** aggregating-evidence record classifies as `AUTO_ALLOWED`.
+Adding any `expected_files[]` entry whose canonical-classifier
+verdict is `NEEDS_HUMAN` or `PERMANENTLY_DENIED` — for example a
+`canonical_policy_doc`, `canonical_roadmap`, `claude_governance_hook`,
+`dashboard_wiring`, `live_path`, or `frozen_contract` path —
+immediately demotes the unit. Pinned by per-category tests in
+`tests/unit/test_roadmap_unit_authority.py`.
+
+### 8.7 Runtime / trading authority pinned **off**
+
+A20c does not grant any QRE runtime, trading, paper, shadow,
+broker, risk, or live authority. The projection's
+`authority_invariants` block pins:
+
+- `calls_execution_authority_classifier = true`
+- `final_authority_classified = true`
+- `no_runtime_trading_authority = true`
+- `no_step5_runtime = true`
+- `no_level6 = true`
+- `no_production_merge_authority = true`
+- `writes_only_roadmap_unit_authority_log = true`
+- `step5_implementation_allowed = false`
+- `aac_visibility_present = false`
+- `next_buildable_selector_present = false`
+
+A20d (read-only operator visibility) and A20e (next-buildable-unit
+selector) remain unimplemented. Pinned by
+`test_invariants_pin_aac_and_next_buildable_remain_false`.
+
+### 8.8 What A20c does NOT do
+
+- **No modification of the canonical classifier** or its doc.
+  `reporting/execution_authority.py` and
+  `docs/governance/execution_authority.md` are untouched.
+- **No mutation of A20a or A20b artefacts.** Pinned by sha256
+  before/after tests.
+- **No AAC / dashboard visibility.** A20d scope; AAC aggregator
+  cardinality pin is unchanged.
+- **No next-buildable-unit selector.** A20e scope.
+- **No edit to canonical roadmap docs or `autonomous_development.txt`.**
+- **No Step 5 / Level 6 / N5b weakening.** Step 5 implementation
+  remains BLOCKED; Level 6 remains permanently disabled; N5b
+  Phase 4 production merge remains permanently denied for ADE.
+
+## 9. Future stages (A20d–A20e)
+
+The roadmap task catalog + unit decomposer + unit-authority
+projection is the foundation of the remaining staged sequence.
+Each subsequent stage requires a separate operator-go PR. None of
+them is pre-authorized by A20a, A20b, or A20c.
+
 - **A20d — Read-only AAC / Task-Board Visibility.** Exposes the
   catalog + units + authority decisions to the operator through
   the existing read-only surfaces (`reporting/task_board.py`,
@@ -577,6 +758,80 @@ intentionally allowed to appear inside the baseline `forbidden_files`
 declarations and inside this governance doc. They are forbidden as
 import targets, write targets, and runtime call surfaces; they are
 **not** forbidden as forbidden-path declarations.
+
+### 10.3 A20c
+
+Pinned in [`tests/unit/test_roadmap_unit_authority.py`](../../tests/unit/test_roadmap_unit_authority.py):
+
+- Closed vocabularies (`AUTHORITY_CLASS`, `AUTHORITY_REASON`,
+  `AUTHORITY_EVIDENCE_KIND`, `AUTHORITY_PROJECTION_STATUS`) are
+  exact; `AUTHORITY_CLASS` matches the canonical
+  `reporting.execution_authority.DECISIONS` verbatim.
+- Schema field tuples (`UNIT_AUTHORITY_EVIDENCE_FIELDS`,
+  `UNIT_AUTHORITY_DECISION_FIELDS`,
+  `UNIT_AUTHORITY_PROJECTION_FIELDS`) are exact and ordered.
+- Every A20b `ImplementationUnit` receives exactly one
+  `UnitAuthorityDecision`; phase + roadmap_task_id match upstream.
+- `final_authority_class` is in the closed vocab;
+  `max_severity` matches its severity index;
+  `requires_operator_go` and `permanently_denied` flags are
+  consistent.
+- Synthetic-unit aggregation tests cover each tier:
+  - all `AUTO_ALLOWED` evidence → `AUTO_ALLOWED`;
+  - `canonical_policy_doc` / `canonical_roadmap` / `claude_governance_hook`
+    / `dashboard_wiring` in `expected_files[]` → `NEEDS_HUMAN`;
+  - `broker/**`, `agent/risk/**`, `agent/execution/**`,
+    `automation/live_gate.py` in `expected_files[]` →
+    `PERMANENTLY_DENIED`;
+  - `research/research_latest.json` /
+    `research/strategy_matrix.csv` in `expected_files[]` →
+    `PERMANENTLY_DENIED`;
+  - `target_layer == "live"` → `PERMANENTLY_DENIED`;
+  - `target_layer == "paper"` / `"shadow"` → `NEEDS_HUMAN`
+    (never `AUTO_ALLOWED`);
+  - `operator_gate ∈ {"operator_go_required",
+    "governance_bootstrap_pr_required"}` → `NEEDS_HUMAN`;
+  - `unit_kind ∈ {"research_module", "diagnostic_primitive",
+    "external_intelligence_source"}` → `NEEDS_HUMAN`.
+- Fail-closed tests cover each non-path evidence kind:
+  unknown / invalid `risk_class` / `target_layer` /
+  `operator_gate` / `authority_hint` / `unit_kind` →
+  `NEEDS_HUMAN`; `fail_closed = true`.
+- `forbidden_file_classifier` evidence is recorded but is in
+  `_INFORMATIONAL_EVIDENCE_KINDS`; the baseline synthetic unit
+  proves its forbidden list does not elevate its aggregate.
+- For every emitted decision on `main`,
+  `classifier_used = true` (every unit has non-empty
+  `expected_files`).
+- No `AUTO_ALLOWED` aggregate on `main` rests on a `live_path` /
+  `frozen_contract` / `branch_protection_config` per-file
+  evidence record.
+- Authority invariants pin: `calls_execution_authority_classifier
+  = true`, `final_authority_classified = true`,
+  `no_runtime_trading_authority = true`, `no_step5_runtime = true`,
+  `no_level6 = true`, `no_production_merge_authority = true`,
+  `writes_only_roadmap_unit_authority_log = true`,
+  `aac_visibility_present = false`,
+  `next_buildable_selector_present = false`,
+  `mutates_a20a_artifact = false`, `mutates_a20b_artifact = false`.
+- Deterministic byte-identical output for identical input with
+  injected `generated_at_utc`.
+- Sha256-before-vs-after confirms `collect_snapshot()` does not
+  mutate the A20b in-memory artefact.
+- Atomic-write allowlist refuses every path outside
+  `logs/roadmap_unit_authority/`, including the frozen-contract
+  paths.
+- Module source carries no forbidden imports
+  (subprocess, socket, urllib, http, requests, dashboard,
+  automation, broker, agent.risk, agent.execution, research,
+  live, paper, shadow, trading, reporting.intelligent_routing,
+  reporting.development_queue_admission_policy,
+  reporting.development_agent_activity_timeline) and no forbidden
+  runtime tokens (`subprocess.run`, `subprocess.Popen`,
+  `os.system(`, `os.popen(`, `shell=True`, `eval(`, `exec(`,
+  `anthropic`, `openai`, GitHub API hosts).
+- Module imports are restricted to stdlib +
+  `reporting.execution_authority` + `reporting.roadmap_task_units`.
 
 ---
 

--- a/reporting/roadmap_unit_authority.py
+++ b/reporting/roadmap_unit_authority.py
@@ -1,0 +1,919 @@
+"""A20c — Roadmap Unit Authority Classifier Integration (read-only).
+
+Per-unit projection that derives a deterministic
+``UnitAuthorityDecision`` for every A20b ``ImplementationUnit`` by
+calling the canonical Execution Authority classifier
+(:func:`reporting.execution_authority.classify`) and aggregating its
+verdicts together with A20c's own deterministic evidence rules for
+the non-path inputs (``target_layer``, ``risk_class``,
+``operator_gate``, ``authority_hint``, ``unit_kind``,
+``stop_conditions``).
+
+A20c MUST NOT create a second source of truth for path-level
+authority. Every per-file evidence record carries the verbatim
+``decision`` / ``reason`` returned by the canonical classifier.
+Non-path evidence kinds have their own deterministic, closed-vocab
+rules pinned by tests.
+
+Aggregation is a pure max-severity reduction over the **aggregating
+evidence kinds**: ``expected_file_classifier``, ``target_layer``,
+``risk_class``, ``operator_gate``, ``authority_hint``,
+``unit_kind``. The **informational evidence kinds**
+(``forbidden_file_classifier``, ``stop_conditions``) are recorded
+for transparency but do not elevate the aggregate. Including
+forbidden-file decisions in aggregation would force every unit to
+``PERMANENTLY_DENIED`` (because every A20b unit's baseline
+``forbidden_files`` contains live / frozen / governance paths that
+the canonical classifier rightly denies) — that would be
+operationally useless and is therefore explicitly excluded.
+
+Hard guarantees (pinned by tests):
+
+* Stdlib + ``reporting.execution_authority`` (read-only) +
+  ``reporting.roadmap_task_units`` (read-only) only.
+* No subprocess, no network, no ``gh``, no ``git``, no GitHub API.
+* No imports of ``dashboard``, ``automation``, ``broker``,
+  ``agent.risk``, ``agent.execution``, ``research``, ``live``,
+  ``paper``, ``shadow``, ``trading``,
+  ``reporting.intelligent_routing``,
+  ``reporting.development_queue_admission_policy``,
+  ``reporting.development_agent_activity_timeline``.
+* No LLM, no external API, no fuzzy parsing, no file-content
+  parsing of any canonical document at runtime.
+* Atomic write only under ``logs/roadmap_unit_authority/``.
+* Deterministic output: same upstream + injected
+  ``generated_at_utc`` → byte-identical artefact.
+* No mutation of A20a or A20b artefacts (pinned by sha256
+  before/after tests).
+* No runtime / trading / paper / shadow / broker / risk / live
+  authority granted. ``permanently_denied=true`` for any unit
+  whose evidence touches those surfaces; pinned by tests.
+* ``step5_implementation_allowed`` remains ``False``;
+  ``STEP5_ENABLED_SUBSTAGE`` remains ``"none"``.
+* AAC visibility and next-buildable-unit selector remain
+  unimplemented; pinned by invariants.
+
+CLI::
+
+    python -m reporting.roadmap_unit_authority
+    python -m reporting.roadmap_unit_authority --no-write
+    python -m reporting.roadmap_unit_authority --status
+    python -m reporting.roadmap_unit_authority --indent 2
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Final
+
+from reporting import execution_authority as ea
+from reporting import roadmap_task_units as rtu
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[str] = "1.0"
+MODULE_VERSION: Final[str] = "v3.15.16.A20c"
+REPORT_KIND: Final[str] = "roadmap_unit_authority"
+
+
+# ---------------------------------------------------------------------------
+# Step 5 + Level 6 invariants (Final constants — never flipped at runtime)
+# ---------------------------------------------------------------------------
+
+STEP5_ENABLED_SUBSTAGE: Final[str] = "none"
+step5_implementation_allowed: Final[bool] = False
+
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies
+# ---------------------------------------------------------------------------
+
+#: Closed final authority classes. Exactly the canonical classifier's
+#: ``DECISIONS`` enum, pinned to the same tuple values.
+AUTHORITY_CLASS: Final[tuple[str, ...]] = ea.DECISIONS
+
+_AUTO_ALLOWED: Final[str] = ea.DECISION_AUTO_ALLOWED
+_NEEDS_HUMAN: Final[str] = ea.DECISION_NEEDS_HUMAN
+_PERMANENTLY_DENIED: Final[str] = ea.DECISION_PERMANENTLY_DENIED
+
+#: Severity ordering. Higher value = more restrictive.
+_SEVERITY: Final[dict[str, int]] = {
+    _AUTO_ALLOWED: 0,
+    _NEEDS_HUMAN: 1,
+    _PERMANENTLY_DENIED: 2,
+}
+
+#: Closed authority reason vocabulary. The first segment mirrors
+#: ``reporting.execution_authority.REASONS`` verbatim so per-file
+#: evidence carries reasons the canonical classifier itself emits.
+#: The second segment carries A20c-specific reasons for the non-path
+#: evidence kinds.
+_CANONICAL_REASONS: Final[tuple[str, ...]] = ea.REASONS
+_A20C_ONLY_REASONS: Final[tuple[str, ...]] = (
+    "paper_runtime_activation_not_authorised",
+    "shadow_runtime_activation_not_authorised",
+    "live_runtime_activation_not_authorised",
+    "trading_runtime_activation_not_authorised",
+    "operator_gate_required",
+    "governance_bootstrap_pr_required",
+    "no_protected_or_runtime_surface",
+    "fail_closed_unknown_evidence",
+    "fail_closed_unknown_risk_class",
+    "fail_closed_unknown_target_layer",
+    "fail_closed_unknown_operator_gate",
+    "fail_closed_unknown_authority_hint",
+    "fail_closed_unknown_unit_kind",
+    "research_module_requires_human_review",
+    "external_intelligence_source_requires_human_review",
+    "diagnostic_primitive_requires_human_review",
+    "stop_conditions_informational_only",
+    "forbidden_file_informational_only",
+    "non_path_evidence_baseline",
+)
+AUTHORITY_REASON: Final[tuple[str, ...]] = tuple(
+    dict.fromkeys(_CANONICAL_REASONS + _A20C_ONLY_REASONS)
+)
+
+#: Closed evidence-kind vocabulary. Each value names one of the
+#: bounded-scalar inputs the spec lists.
+AUTHORITY_EVIDENCE_KIND: Final[tuple[str, ...]] = (
+    "expected_file_classifier",
+    "forbidden_file_classifier",
+    "target_layer",
+    "risk_class",
+    "operator_gate",
+    "authority_hint",
+    "unit_kind",
+    "stop_conditions",
+)
+
+#: Evidence kinds that contribute to the unit-level aggregate. The
+#: rest are informational only.
+_AGGREGATING_EVIDENCE_KINDS: Final[frozenset[str]] = frozenset(
+    {
+        "expected_file_classifier",
+        "target_layer",
+        "risk_class",
+        "operator_gate",
+        "authority_hint",
+        "unit_kind",
+    }
+)
+
+_INFORMATIONAL_EVIDENCE_KINDS: Final[frozenset[str]] = frozenset(
+    {
+        "forbidden_file_classifier",
+        "stop_conditions",
+    }
+)
+
+#: Closed projection-status vocabulary.
+AUTHORITY_PROJECTION_STATUS: Final[tuple[str, ...]] = (
+    "ok",
+    "no_units",
+    "upstream_unavailable",
+    "fail_closed_invariant",
+)
+
+
+# ---------------------------------------------------------------------------
+# Evidence sources (for the ``source`` field on each evidence record)
+# ---------------------------------------------------------------------------
+
+_SOURCE_CLASSIFIER: Final[str] = "reporting.execution_authority"
+_SOURCE_A20C: Final[str] = "reporting.roadmap_unit_authority"
+
+
+# ---------------------------------------------------------------------------
+# Schema field tuples (exact, ordered)
+# ---------------------------------------------------------------------------
+
+#: Per-evidence record schema.
+UNIT_AUTHORITY_EVIDENCE_FIELDS: Final[tuple[str, ...]] = (
+    "kind",
+    "value",
+    "decision",
+    "reason",
+    "source",
+)
+
+#: Per-unit decision schema.
+UNIT_AUTHORITY_DECISION_FIELDS: Final[tuple[str, ...]] = (
+    "implementation_unit_id",
+    "roadmap_task_id",
+    "phase",
+    "final_authority_class",
+    "max_severity",
+    "evidence",
+    "requires_operator_go",
+    "permanently_denied",
+    "deny_reasons",
+    "classifier_used",
+    "fail_closed",
+)
+
+#: Top-level projection schema.
+UNIT_AUTHORITY_PROJECTION_FIELDS: Final[tuple[str, ...]] = (
+    "generated_at_utc",
+    "schema_version",
+    "module_version",
+    "source_units_schema_version",
+    "authority_decisions",
+    "authority_invariants",
+)
+
+
+# ---------------------------------------------------------------------------
+# Bounds
+# ---------------------------------------------------------------------------
+
+MAX_EVIDENCE_VALUE_LEN: Final[int] = 300
+MAX_REASON_LEN: Final[int] = 80
+MAX_DENY_REASONS: Final[int] = 16
+
+
+# ---------------------------------------------------------------------------
+# Artefact paths
+# ---------------------------------------------------------------------------
+
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "roadmap_unit_authority"
+ARTIFACT_LATEST: Final[Path] = ARTIFACT_DIR / "latest.json"
+ARTIFACT_RELATIVE_PATH: Final[str] = "logs/roadmap_unit_authority/latest.json"
+
+#: Atomic-write allowlist (POSIX substring form). Any write target
+#: not containing this substring is refused with ``ValueError``.
+_WRITE_PREFIX: Final[str] = "logs/roadmap_unit_authority/"
+
+
+# ---------------------------------------------------------------------------
+# Authority invariants emitted on every projection
+# ---------------------------------------------------------------------------
+
+_BASE_AUTHORITY_INVARIANTS: Final[dict[str, bool]] = {
+    # A20c flips these from A20b's false values:
+    "calls_execution_authority_classifier": True,
+    "final_authority_classified": True,
+    # Carry forward the authority chain pins:
+    "no_runtime_trading_authority": True,
+    "no_step5_runtime": True,
+    "no_level6": True,
+    "no_production_merge_authority": True,
+    "writes_only_roadmap_unit_authority_log": True,
+    "step5_implementation_allowed": False,
+    "mutates_a20a_artifact": False,
+    "mutates_a20b_artifact": False,
+    "mutates_roadmap_status_fields": False,
+    "marks_phase_complete": False,
+    "fuzzy_parsing": False,
+    "uses_subprocess_or_network": False,
+    "calls_llm_or_external_api": False,
+    "writes_to_seed_jsonl": False,
+    "writes_to_delegation_seed_jsonl": False,
+    "writes_to_generated_seed_jsonl": False,
+    # A20d / A20e still pending:
+    "aac_visibility_present": False,
+    "next_buildable_selector_present": False,
+}
+
+
+# ---------------------------------------------------------------------------
+# Utility helpers
+# ---------------------------------------------------------------------------
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _bounded_str(value: Any, max_len: int = MAX_EVIDENCE_VALUE_LEN) -> str:
+    if not isinstance(value, str):
+        return ""
+    if len(value) <= max_len:
+        return value
+    return value[:max_len]
+
+
+def _make_evidence(
+    *,
+    kind: str,
+    value: str,
+    decision: str,
+    reason: str,
+    source: str,
+) -> dict[str, Any]:
+    """Construct a bounded-scalar evidence record."""
+    return {
+        "kind": kind,
+        "value": _bounded_str(value, MAX_EVIDENCE_VALUE_LEN),
+        "decision": decision,
+        "reason": _bounded_str(reason, MAX_REASON_LEN),
+        "source": source,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Evidence builders — one per evidence kind
+# ---------------------------------------------------------------------------
+
+
+def _classify_path(
+    path: str, *, risk_class: str
+) -> tuple[str, str, str]:
+    """Call the canonical classifier for one path. Returns
+    ``(decision, reason, target_path_category)``."""
+    decision = ea.classify(
+        action_type="file_edit",
+        target_path=path,
+        risk_class=risk_class,
+    )
+    return decision.decision, decision.reason, decision.target_path_category
+
+
+def _build_expected_file_evidence(
+    unit: dict[str, Any], *, risk_class: str
+) -> list[dict[str, Any]]:
+    evidence: list[dict[str, Any]] = []
+    for path in unit.get("expected_files", []) or []:
+        decision, reason, _ = _classify_path(path, risk_class=risk_class)
+        evidence.append(
+            _make_evidence(
+                kind="expected_file_classifier",
+                value=path,
+                decision=decision,
+                reason=reason,
+                source=_SOURCE_CLASSIFIER,
+            )
+        )
+    return evidence
+
+
+def _build_forbidden_file_evidence(
+    unit: dict[str, Any], *, risk_class: str
+) -> list[dict[str, Any]]:
+    """Record the classifier verdict for every forbidden_files entry.
+    These records are informational — they do not contribute to the
+    unit's aggregate (see ``_AGGREGATING_EVIDENCE_KINDS``). They
+    exist so operators can audit that forbidden surfaces are indeed
+    being denied by the canonical classifier."""
+    evidence: list[dict[str, Any]] = []
+    for path in unit.get("forbidden_files", []) or []:
+        decision, reason, _ = _classify_path(path, risk_class=risk_class)
+        evidence.append(
+            _make_evidence(
+                kind="forbidden_file_classifier",
+                value=path,
+                decision=decision,
+                reason=reason,
+                source=_SOURCE_CLASSIFIER,
+            )
+        )
+    return evidence
+
+
+_TARGET_LAYER_DECISIONS: Final[dict[str, tuple[str, str]]] = {
+    "live": (_PERMANENTLY_DENIED, "live_runtime_activation_not_authorised"),
+    "paper": (_NEEDS_HUMAN, "paper_runtime_activation_not_authorised"),
+    "shadow": (_NEEDS_HUMAN, "shadow_runtime_activation_not_authorised"),
+}
+
+
+def _build_target_layer_evidence(
+    unit: dict[str, Any],
+) -> list[dict[str, Any]]:
+    target_layer = unit.get("target_layer")
+    if not isinstance(target_layer, str):
+        return [
+            _make_evidence(
+                kind="target_layer",
+                value="(missing)",
+                decision=_NEEDS_HUMAN,
+                reason="fail_closed_unknown_target_layer",
+                source=_SOURCE_A20C,
+            )
+        ]
+    if target_layer not in rtu.TARGET_LAYER:
+        return [
+            _make_evidence(
+                kind="target_layer",
+                value=target_layer,
+                decision=_NEEDS_HUMAN,
+                reason="fail_closed_unknown_target_layer",
+                source=_SOURCE_A20C,
+            )
+        ]
+    rule = _TARGET_LAYER_DECISIONS.get(target_layer)
+    if rule is not None:
+        decision, reason = rule
+        return [
+            _make_evidence(
+                kind="target_layer",
+                value=target_layer,
+                decision=decision,
+                reason=reason,
+                source=_SOURCE_A20C,
+            )
+        ]
+    return [
+        _make_evidence(
+            kind="target_layer",
+            value=target_layer,
+            decision=_AUTO_ALLOWED,
+            reason="non_path_evidence_baseline",
+            source=_SOURCE_A20C,
+        )
+    ]
+
+
+def _build_risk_class_evidence(
+    unit: dict[str, Any], *, risk_class: str
+) -> list[dict[str, Any]]:
+    raw = unit.get("risk_class")
+    if raw not in ea.RISK_CLASSES:
+        return [
+            _make_evidence(
+                kind="risk_class",
+                value=str(raw),
+                decision=_NEEDS_HUMAN,
+                reason="fail_closed_unknown_risk_class",
+                source=_SOURCE_A20C,
+            )
+        ]
+    if raw == ea.RISK_UNKNOWN:
+        return [
+            _make_evidence(
+                kind="risk_class",
+                value=raw,
+                decision=_NEEDS_HUMAN,
+                reason="unknown_risk_or_target_fail_safe",
+                source=_SOURCE_A20C,
+            )
+        ]
+    return [
+        _make_evidence(
+            kind="risk_class",
+            value=raw,
+            decision=_AUTO_ALLOWED,
+            reason="non_path_evidence_baseline",
+            source=_SOURCE_A20C,
+        )
+    ]
+
+
+def _build_operator_gate_evidence(
+    unit: dict[str, Any],
+) -> list[dict[str, Any]]:
+    gate = unit.get("operator_gate")
+    if not isinstance(gate, str) or gate not in rtu.OPERATOR_GATE:
+        return [
+            _make_evidence(
+                kind="operator_gate",
+                value=str(gate),
+                decision=_NEEDS_HUMAN,
+                reason="fail_closed_unknown_operator_gate",
+                source=_SOURCE_A20C,
+            )
+        ]
+    if gate == "operator_go_required":
+        return [
+            _make_evidence(
+                kind="operator_gate",
+                value=gate,
+                decision=_NEEDS_HUMAN,
+                reason="operator_gate_required",
+                source=_SOURCE_A20C,
+            )
+        ]
+    if gate == "governance_bootstrap_pr_required":
+        return [
+            _make_evidence(
+                kind="operator_gate",
+                value=gate,
+                decision=_NEEDS_HUMAN,
+                reason="governance_bootstrap_pr_required",
+                source=_SOURCE_A20C,
+            )
+        ]
+    # gate == "none"
+    return [
+        _make_evidence(
+            kind="operator_gate",
+            value=gate,
+            decision=_AUTO_ALLOWED,
+            reason="non_path_evidence_baseline",
+            source=_SOURCE_A20C,
+        )
+    ]
+
+
+_HINT_TO_DECISION: Final[dict[str, str]] = {
+    "AUTO_ALLOWED_CANDIDATE": _AUTO_ALLOWED,
+    "NEEDS_HUMAN_CANDIDATE": _NEEDS_HUMAN,
+    "PERMANENTLY_DENIED_SURFACE": _PERMANENTLY_DENIED,
+}
+
+
+def _build_authority_hint_evidence(
+    unit: dict[str, Any],
+) -> list[dict[str, Any]]:
+    hint = unit.get("authority_hint")
+    if not isinstance(hint, str) or hint not in rtu.AUTHORITY_HINT:
+        return [
+            _make_evidence(
+                kind="authority_hint",
+                value=str(hint),
+                decision=_NEEDS_HUMAN,
+                reason="fail_closed_unknown_authority_hint",
+                source=_SOURCE_A20C,
+            )
+        ]
+    decision = _HINT_TO_DECISION[hint]
+    if decision == _AUTO_ALLOWED:
+        reason = "non_path_evidence_baseline"
+    elif decision == _NEEDS_HUMAN:
+        reason = "operator_gate_required"
+    else:
+        reason = "denied_live_path_modification"
+    return [
+        _make_evidence(
+            kind="authority_hint",
+            value=hint,
+            decision=decision,
+            reason=reason,
+            source=_SOURCE_A20C,
+        )
+    ]
+
+
+_UNIT_KIND_REASONS: Final[dict[str, tuple[str, str]]] = {
+    "research_module": (_NEEDS_HUMAN, "research_module_requires_human_review"),
+    "diagnostic_primitive": (
+        _NEEDS_HUMAN,
+        "diagnostic_primitive_requires_human_review",
+    ),
+    "external_intelligence_source": (
+        _NEEDS_HUMAN,
+        "external_intelligence_source_requires_human_review",
+    ),
+}
+
+
+def _build_unit_kind_evidence(unit: dict[str, Any]) -> list[dict[str, Any]]:
+    kind = unit.get("unit_kind")
+    if not isinstance(kind, str) or kind not in rtu.UNIT_KIND:
+        return [
+            _make_evidence(
+                kind="unit_kind",
+                value=str(kind),
+                decision=_NEEDS_HUMAN,
+                reason="fail_closed_unknown_unit_kind",
+                source=_SOURCE_A20C,
+            )
+        ]
+    rule = _UNIT_KIND_REASONS.get(kind)
+    if rule is not None:
+        decision, reason = rule
+        return [
+            _make_evidence(
+                kind="unit_kind",
+                value=kind,
+                decision=decision,
+                reason=reason,
+                source=_SOURCE_A20C,
+            )
+        ]
+    return [
+        _make_evidence(
+            kind="unit_kind",
+            value=kind,
+            decision=_AUTO_ALLOWED,
+            reason="non_path_evidence_baseline",
+            source=_SOURCE_A20C,
+        )
+    ]
+
+
+def _build_stop_conditions_evidence(
+    unit: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Record the unit's stop_conditions as bounded-scalar
+    informational evidence. Stop conditions describe what the future
+    PR must NOT do; they are recorded for transparency but do not
+    elevate aggregation (this kind is in
+    :data:`_INFORMATIONAL_EVIDENCE_KINDS`)."""
+    out: list[dict[str, Any]] = []
+    for sc in unit.get("stop_conditions", []) or []:
+        out.append(
+            _make_evidence(
+                kind="stop_conditions",
+                value=sc,
+                decision=_AUTO_ALLOWED,
+                reason="stop_conditions_informational_only",
+                source=_SOURCE_A20C,
+            )
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Aggregation
+# ---------------------------------------------------------------------------
+
+
+def _aggregate(evidence: list[dict[str, Any]]) -> tuple[str, list[str]]:
+    """Reduce evidence to ``(final_class, deny_reasons)`` via
+    max-severity over the aggregating-kinds subset. Fail-closed:
+    if there is no aggregating evidence at all (defence in depth),
+    return ``NEEDS_HUMAN`` + ``["fail_closed_unknown_evidence"]``."""
+    aggregating = [
+        e for e in evidence if e["kind"] in _AGGREGATING_EVIDENCE_KINDS
+    ]
+    if not aggregating:
+        return _NEEDS_HUMAN, ["fail_closed_unknown_evidence"]
+
+    # First-match wins per severity tier — preserves the first
+    # contributing reason for transparency.
+    for e in aggregating:
+        if e["decision"] == _PERMANENTLY_DENIED:
+            deny_reasons = [
+                ev["reason"]
+                for ev in aggregating
+                if ev["decision"] == _PERMANENTLY_DENIED
+            ]
+            return _PERMANENTLY_DENIED, deny_reasons[:MAX_DENY_REASONS]
+    for e in aggregating:
+        if e["decision"] == _NEEDS_HUMAN:
+            return _NEEDS_HUMAN, []
+    return _AUTO_ALLOWED, []
+
+
+def _decide_for_unit(unit: dict[str, Any]) -> dict[str, Any]:
+    """Build one ``UnitAuthorityDecision`` from one A20b unit."""
+    raw_risk = unit.get("risk_class")
+    # Normalise risk for the classifier call only. The risk-class
+    # evidence builder records the *raw* value so fail-closed
+    # detection is auditable.
+    risk_class_for_classifier = (
+        raw_risk if raw_risk in ea.RISK_CLASSES else ea.RISK_UNKNOWN
+    )
+
+    evidence: list[dict[str, Any]] = []
+    evidence.extend(
+        _build_expected_file_evidence(unit, risk_class=risk_class_for_classifier)
+    )
+    evidence.extend(
+        _build_forbidden_file_evidence(unit, risk_class=risk_class_for_classifier)
+    )
+    evidence.extend(_build_target_layer_evidence(unit))
+    evidence.extend(
+        _build_risk_class_evidence(unit, risk_class=risk_class_for_classifier)
+    )
+    evidence.extend(_build_operator_gate_evidence(unit))
+    evidence.extend(_build_authority_hint_evidence(unit))
+    evidence.extend(_build_unit_kind_evidence(unit))
+    evidence.extend(_build_stop_conditions_evidence(unit))
+
+    final_class, deny_reasons = _aggregate(evidence)
+
+    classifier_used = any(
+        e["source"] == _SOURCE_CLASSIFIER for e in evidence
+    )
+    fail_closed = any(
+        e["reason"].startswith("fail_closed_") for e in evidence
+    )
+
+    return {
+        "implementation_unit_id": unit["id"],
+        "roadmap_task_id": unit["roadmap_task_id"],
+        "phase": unit["phase"],
+        "final_authority_class": final_class,
+        "max_severity": _SEVERITY[final_class],
+        "evidence": evidence,
+        "requires_operator_go": final_class == _NEEDS_HUMAN,
+        "permanently_denied": final_class == _PERMANENTLY_DENIED,
+        "deny_reasons": deny_reasons,
+        "classifier_used": classifier_used,
+        "fail_closed": fail_closed,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Snapshot assembly
+# ---------------------------------------------------------------------------
+
+
+def collect_snapshot(
+    *,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    """Build the deterministic Roadmap-unit-authority projection."""
+    ts = generated_at_utc if generated_at_utc is not None else _utcnow()
+
+    units_snapshot = rtu.collect_snapshot(generated_at_utc=ts)
+    decisions = [
+        _decide_for_unit(u) for u in units_snapshot["implementation_units"]
+    ]
+    decisions.sort(key=lambda r: (r["phase"], r["implementation_unit_id"]))
+
+    if not decisions:
+        status = "no_units"
+    else:
+        status = "ok"
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": ts,
+        "step5_enabled_substage": STEP5_ENABLED_SUBSTAGE,
+        "step5_implementation_allowed": step5_implementation_allowed,
+        "projection_status": status,
+        "source_units_module_version": units_snapshot["module_version"],
+        "source_units_schema_version": units_snapshot["schema_version"],
+        "classifier_module_version": ea.MODULE_VERSION,
+        "classifier_schema_version": ea.SCHEMA_VERSION,
+        "vocabularies": {
+            "authority_class": list(AUTHORITY_CLASS),
+            "authority_reason": list(AUTHORITY_REASON),
+            "authority_evidence_kind": list(AUTHORITY_EVIDENCE_KIND),
+            "authority_projection_status": list(AUTHORITY_PROJECTION_STATUS),
+            "aggregating_evidence_kinds": sorted(_AGGREGATING_EVIDENCE_KINDS),
+            "informational_evidence_kinds": sorted(
+                _INFORMATIONAL_EVIDENCE_KINDS
+            ),
+        },
+        "authority_decisions": decisions,
+        "authority_invariants": dict(_BASE_AUTHORITY_INVARIANTS),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Atomic write
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Write ``payload`` as sorted-key indented JSON to ``path``,
+    atomically, refusing any path outside
+    ``logs/roadmap_unit_authority/``."""
+    posix = path.as_posix()
+    if _WRITE_PREFIX not in posix:
+        raise ValueError(
+            "roadmap_unit_authority._atomic_write_json refuses "
+            f"non-authority-logs output path: {path}"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".roadmap_unit_authority.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_outputs(snapshot: dict[str, Any]) -> Path:
+    _atomic_write_json(ARTIFACT_LATEST, snapshot)
+    return ARTIFACT_LATEST
+
+
+# ---------------------------------------------------------------------------
+# Status renderer
+# ---------------------------------------------------------------------------
+
+
+def _render_status(snapshot: dict[str, Any]) -> str:
+    decisions = snapshot["authority_decisions"]
+    inv = snapshot["authority_invariants"]
+    by_class: dict[str, int] = {c: 0 for c in AUTHORITY_CLASS}
+    fail_closed_count = 0
+    classifier_used_count = 0
+    for d in decisions:
+        by_class[d["final_authority_class"]] += 1
+        if d["fail_closed"]:
+            fail_closed_count += 1
+        if d["classifier_used"]:
+            classifier_used_count += 1
+    lines = [
+        f"roadmap_unit_authority {snapshot['module_version']} "
+        f"schema={snapshot['schema_version']}",
+        f"generated_at_utc={snapshot['generated_at_utc']}",
+        f"authority_decisions={len(decisions)} status={snapshot['projection_status']}",
+        (
+            "step5_implementation_allowed="
+            f"{snapshot['step5_implementation_allowed']} "
+            f"step5_enabled_substage={snapshot['step5_enabled_substage']}"
+        ),
+        (
+            "calls_execution_authority_classifier="
+            f"{inv['calls_execution_authority_classifier']} "
+            "final_authority_classified="
+            f"{inv['final_authority_classified']}"
+        ),
+        (
+            "no_runtime_trading_authority="
+            f"{inv['no_runtime_trading_authority']} "
+            f"no_step5_runtime={inv['no_step5_runtime']} "
+            f"no_level6={inv['no_level6']} "
+            "no_production_merge_authority="
+            f"{inv['no_production_merge_authority']}"
+        ),
+        (
+            "aac_visibility_present="
+            f"{inv['aac_visibility_present']} "
+            "next_buildable_selector_present="
+            f"{inv['next_buildable_selector_present']}"
+        ),
+        f"classifier_used_count={classifier_used_count}",
+        f"fail_closed_count={fail_closed_count}",
+        f"by_final_authority_class={dict(sorted(by_class.items()))}",
+    ]
+    for d in decisions:
+        lines.append(
+            f"  unit {d['implementation_unit_id']} "
+            f"phase={d['phase']} "
+            f"final={d['final_authority_class']} "
+            f"requires_operator_go={d['requires_operator_go']} "
+            f"permanently_denied={d['permanently_denied']}"
+        )
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m reporting.roadmap_unit_authority",
+        description=(
+            "A20c Roadmap Unit Authority Classifier Integration. "
+            "Read-only deterministic projection that classifies every "
+            "A20b implementation unit via the canonical "
+            "reporting.execution_authority classifier plus closed-vocab "
+            "rules for non-path evidence kinds. No second source of "
+            "truth for path authority. Step 5 implementation remains "
+            "BLOCKED."
+        ),
+    )
+    p.add_argument(
+        "--indent",
+        type=int,
+        default=2,
+        help="JSON indent for stdout output (0 for compact).",
+    )
+    p.add_argument(
+        "--no-write",
+        action="store_true",
+        help=(
+            "Do not persist logs/roadmap_unit_authority/latest.json "
+            "(stdout only)."
+        ),
+    )
+    p.add_argument(
+        "--status",
+        action="store_true",
+        help=(
+            "Render a compact human-readable status summary to stdout "
+            "and exit. Does not write any artefact."
+        ),
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    snap = collect_snapshot()
+    if args.status:
+        sys.stdout.write(_render_status(snap))
+        return 0
+    indent = args.indent if args.indent and args.indent > 0 else None
+    if not args.no_write:
+        write_outputs(snap)
+    json.dump(snap, sys.stdout, indent=indent, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/unit/test_roadmap_unit_authority.py
+++ b/tests/unit/test_roadmap_unit_authority.py
@@ -1,0 +1,1006 @@
+"""Unit tests for A20c — Roadmap Unit Authority Classifier Integration.
+
+Pins:
+
+* closed vocabularies (AUTHORITY_CLASS, AUTHORITY_REASON,
+  AUTHORITY_EVIDENCE_KIND, AUTHORITY_PROJECTION_STATUS);
+* schema integrity (UnitAuthorityEvidence,
+  UnitAuthorityDecision, UnitAuthorityProjection);
+* deterministic byte-identical output with injected
+  generated_at_utc;
+* atomic write only under logs/roadmap_unit_authority/;
+* --no-write does not write; --status does not write;
+* every A20b ImplementationUnit receives exactly one
+  UnitAuthorityDecision;
+* final authority class is one of AUTO_ALLOWED / NEEDS_HUMAN /
+  PERMANENTLY_DENIED;
+* aggregation max severity works (synthetic units cover each tier);
+* unknown evidence fails closed to NEEDS_HUMAN;
+* docs/tests/reporting-only units can be AUTO_ALLOWED only if no
+  protected/runtime surface is present;
+* protected governance surfaces require NEEDS_HUMAN or stricter;
+* frozen contract surfaces become PERMANENTLY_DENIED;
+* live/broker/order/capital/risk/execution surfaces become
+  PERMANENTLY_DENIED via the canonical classifier;
+* paper/shadow runtime activation is not AUTO_ALLOWED;
+* no unit grants QRE runtime/trading/paper/shadow/live authority;
+* classifier_used is true for normal decisions;
+* fail_closed is true for unknown/unsupported evidence;
+* A20d visibility remains false; A20e selector remains false;
+* no forbidden imports or runtime tokens in the module source.
+
+The strings ``research/research_latest.json``,
+``research/strategy_matrix.csv``, ``live/**``, ``paper/**``,
+``shadow/**``, ``broker/**``, ``agent/risk/**``, and
+``agent/execution/**`` are explicitly allowed inside evidence
+values and inside this test file. They are forbidden as imports,
+write targets, runtime calls, or authority-granting semantics —
+those are pinned separately.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import json
+from pathlib import Path
+
+import pytest
+
+from reporting import execution_authority as ea
+from reporting import roadmap_task_units as rtu
+from reporting import roadmap_unit_authority as rua
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+_FROZEN_UTC = "2026-05-18T18:00:00Z"
+
+
+@pytest.fixture
+def snap() -> dict:
+    return rua.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+
+
+@pytest.fixture
+def units_snap() -> dict:
+    return rtu.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+
+
+def _baseline_unit(**overrides) -> dict:
+    """Synthetic A20b-shape unit used by aggregation tests. Every
+    field A20c reads is present."""
+    base = {
+        "id": "syn_unit_001",
+        "roadmap_task_id": "phase_v3_15_16",
+        "phase": "v3.15.16",
+        "title": "synthetic test unit",
+        "unit_kind": "reporting_module",
+        "target_layer": "reporting",
+        "source_requirement_ids": [],
+        "expected_files": [
+            "reporting/synthetic_module.py",
+            "tests/unit/test_synthetic_module.py",
+            "docs/governance/synthetic_module.md",
+        ],
+        "forbidden_files": [
+            ".claude/**",
+            "dashboard/dashboard.py",
+            "research/research_latest.json",
+            "research/strategy_matrix.csv",
+            "automation/live_gate.py",
+            "broker/**",
+            "agent/risk/**",
+            "agent/execution/**",
+            "live/**",
+            "paper/**",
+            "shadow/**",
+            "trading/**",
+        ],
+        "forbidden_surface_reasons": ["frozen_contract", "live_path"],
+        "required_tests": [],
+        "definition_of_done": [],
+        "stop_conditions": ["fail-closed sample"],
+        "prerequisites": [],
+        "risk_class": "LOW",
+        "authority_hint": "AUTO_ALLOWED_CANDIDATE",
+        "operator_gate": "none",
+        "status": "not_started",
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies
+# ---------------------------------------------------------------------------
+
+
+def test_authority_class_matches_canonical_decisions_verbatim() -> None:
+    assert rua.AUTHORITY_CLASS == ea.DECISIONS
+    assert rua.AUTHORITY_CLASS == (
+        "AUTO_ALLOWED",
+        "NEEDS_HUMAN",
+        "PERMANENTLY_DENIED",
+    )
+
+
+def test_authority_evidence_kind_is_closed_exact() -> None:
+    assert rua.AUTHORITY_EVIDENCE_KIND == (
+        "expected_file_classifier",
+        "forbidden_file_classifier",
+        "target_layer",
+        "risk_class",
+        "operator_gate",
+        "authority_hint",
+        "unit_kind",
+        "stop_conditions",
+    )
+
+
+def test_authority_projection_status_is_closed_exact() -> None:
+    assert rua.AUTHORITY_PROJECTION_STATUS == (
+        "ok",
+        "no_units",
+        "upstream_unavailable",
+        "fail_closed_invariant",
+    )
+
+
+def test_authority_reason_includes_canonical_reasons() -> None:
+    for canonical in ea.REASONS:
+        assert canonical in rua.AUTHORITY_REASON, canonical
+
+
+def test_authority_reason_includes_a20c_specific_reasons() -> None:
+    required = (
+        "paper_runtime_activation_not_authorised",
+        "shadow_runtime_activation_not_authorised",
+        "live_runtime_activation_not_authorised",
+        "operator_gate_required",
+        "governance_bootstrap_pr_required",
+        "fail_closed_unknown_evidence",
+        "fail_closed_unknown_risk_class",
+        "fail_closed_unknown_target_layer",
+        "fail_closed_unknown_operator_gate",
+        "fail_closed_unknown_authority_hint",
+        "fail_closed_unknown_unit_kind",
+        "research_module_requires_human_review",
+        "external_intelligence_source_requires_human_review",
+        "diagnostic_primitive_requires_human_review",
+        "stop_conditions_informational_only",
+        "non_path_evidence_baseline",
+    )
+    for r in required:
+        assert r in rua.AUTHORITY_REASON, r
+
+
+def test_authority_reason_has_no_duplicates() -> None:
+    assert len(rua.AUTHORITY_REASON) == len(set(rua.AUTHORITY_REASON))
+
+
+def test_severity_ordering_matches_canonical_decisions() -> None:
+    assert rua._SEVERITY == {
+        ea.DECISION_AUTO_ALLOWED: 0,
+        ea.DECISION_NEEDS_HUMAN: 1,
+        ea.DECISION_PERMANENTLY_DENIED: 2,
+    }
+
+
+def test_aggregating_evidence_kinds_subset_of_vocab() -> None:
+    assert rua._AGGREGATING_EVIDENCE_KINDS.issubset(
+        set(rua.AUTHORITY_EVIDENCE_KIND)
+    )
+
+
+def test_informational_evidence_kinds_subset_of_vocab() -> None:
+    assert rua._INFORMATIONAL_EVIDENCE_KINDS.issubset(
+        set(rua.AUTHORITY_EVIDENCE_KIND)
+    )
+
+
+def test_aggregating_and_informational_partition_the_vocab() -> None:
+    union = rua._AGGREGATING_EVIDENCE_KINDS | rua._INFORMATIONAL_EVIDENCE_KINDS
+    assert union == set(rua.AUTHORITY_EVIDENCE_KIND)
+    assert rua._AGGREGATING_EVIDENCE_KINDS.isdisjoint(
+        rua._INFORMATIONAL_EVIDENCE_KINDS
+    )
+
+
+# ---------------------------------------------------------------------------
+# Schema integrity
+# ---------------------------------------------------------------------------
+
+
+def test_unit_authority_evidence_field_list_exact() -> None:
+    assert rua.UNIT_AUTHORITY_EVIDENCE_FIELDS == (
+        "kind",
+        "value",
+        "decision",
+        "reason",
+        "source",
+    )
+
+
+def test_unit_authority_decision_field_list_exact() -> None:
+    assert rua.UNIT_AUTHORITY_DECISION_FIELDS == (
+        "implementation_unit_id",
+        "roadmap_task_id",
+        "phase",
+        "final_authority_class",
+        "max_severity",
+        "evidence",
+        "requires_operator_go",
+        "permanently_denied",
+        "deny_reasons",
+        "classifier_used",
+        "fail_closed",
+    )
+
+
+def test_unit_authority_projection_field_list_exact() -> None:
+    assert rua.UNIT_AUTHORITY_PROJECTION_FIELDS == (
+        "generated_at_utc",
+        "schema_version",
+        "module_version",
+        "source_units_schema_version",
+        "authority_decisions",
+        "authority_invariants",
+    )
+
+
+def test_every_decision_has_every_field(snap: dict) -> None:
+    for d in snap["authority_decisions"]:
+        assert set(d.keys()) == set(rua.UNIT_AUTHORITY_DECISION_FIELDS), d
+
+
+def test_every_evidence_record_has_every_field(snap: dict) -> None:
+    for d in snap["authority_decisions"]:
+        for ev in d["evidence"]:
+            assert set(ev.keys()) == set(
+                rua.UNIT_AUTHORITY_EVIDENCE_FIELDS
+            ), ev
+
+
+def test_projection_carries_every_required_top_level_field(snap: dict) -> None:
+    for field in rua.UNIT_AUTHORITY_PROJECTION_FIELDS:
+        assert field in snap, field
+
+
+# ---------------------------------------------------------------------------
+# Coverage: every A20b unit gets exactly one decision
+# ---------------------------------------------------------------------------
+
+
+def test_every_a20b_unit_receives_exactly_one_decision(
+    snap: dict, units_snap: dict
+) -> None:
+    unit_ids = [u["id"] for u in units_snap["implementation_units"]]
+    decided_ids = [d["implementation_unit_id"] for d in snap["authority_decisions"]]
+    assert sorted(unit_ids) == sorted(decided_ids)
+    assert len(decided_ids) == len(set(decided_ids))
+
+
+def test_decision_phase_and_task_id_match_upstream(
+    snap: dict, units_snap: dict
+) -> None:
+    by_id = {u["id"]: u for u in units_snap["implementation_units"]}
+    for d in snap["authority_decisions"]:
+        u = by_id[d["implementation_unit_id"]]
+        assert d["roadmap_task_id"] == u["roadmap_task_id"]
+        assert d["phase"] == u["phase"]
+
+
+# ---------------------------------------------------------------------------
+# Final authority class is from the closed vocab
+# ---------------------------------------------------------------------------
+
+
+def test_every_final_class_is_in_authority_class_vocab(snap: dict) -> None:
+    for d in snap["authority_decisions"]:
+        assert d["final_authority_class"] in rua.AUTHORITY_CLASS
+
+
+def test_every_max_severity_matches_final_class(snap: dict) -> None:
+    for d in snap["authority_decisions"]:
+        assert d["max_severity"] == rua._SEVERITY[d["final_authority_class"]]
+
+
+def test_requires_operator_go_iff_needs_human(snap: dict) -> None:
+    for d in snap["authority_decisions"]:
+        assert d["requires_operator_go"] == (
+            d["final_authority_class"] == ea.DECISION_NEEDS_HUMAN
+        )
+
+
+def test_permanently_denied_flag_consistent(snap: dict) -> None:
+    for d in snap["authority_decisions"]:
+        assert d["permanently_denied"] == (
+            d["final_authority_class"] == ea.DECISION_PERMANENTLY_DENIED
+        )
+        if d["permanently_denied"]:
+            assert d["deny_reasons"], d
+        else:
+            assert d["deny_reasons"] == [], d
+
+
+# ---------------------------------------------------------------------------
+# Aggregation max-severity rules — synthetic units
+# ---------------------------------------------------------------------------
+
+
+def test_auto_allowed_unit_aggregates_to_auto_allowed() -> None:
+    unit = _baseline_unit(
+        expected_files=[
+            "reporting/synthetic_module.py",
+            "tests/unit/test_synthetic_module.py",
+            "docs/governance/synthetic_module.md",
+        ],
+        risk_class="LOW",
+        operator_gate="none",
+        authority_hint="AUTO_ALLOWED_CANDIDATE",
+        unit_kind="reporting_module",
+        target_layer="reporting",
+    )
+    d = rua._decide_for_unit(unit)
+    assert d["final_authority_class"] == ea.DECISION_AUTO_ALLOWED
+    assert d["max_severity"] == 0
+    assert d["requires_operator_go"] is False
+    assert d["permanently_denied"] is False
+    assert d["classifier_used"] is True
+    assert d["fail_closed"] is False
+
+
+def test_needs_human_unit_elevates_via_canonical_policy_doc() -> None:
+    """A LOW-risk reporting unit that lists a canonical_policy_doc in
+    expected_files MUST elevate to NEEDS_HUMAN (the canonical
+    classifier emits high_risk_canonical_policy_change for that
+    path)."""
+    unit = _baseline_unit(
+        expected_files=[
+            "reporting/synthetic_module.py",
+            "docs/governance/execution_authority.md",
+        ],
+    )
+    d = rua._decide_for_unit(unit)
+    assert d["final_authority_class"] == ea.DECISION_NEEDS_HUMAN
+    assert d["max_severity"] == 1
+    assert d["requires_operator_go"] is True
+
+
+def test_permanently_denied_unit_via_live_path() -> None:
+    unit = _baseline_unit(
+        expected_files=[
+            "reporting/synthetic_module.py",
+            "broker/synthetic_broker.py",  # live_path -> PERMANENTLY_DENIED
+        ],
+    )
+    d = rua._decide_for_unit(unit)
+    assert d["final_authority_class"] == ea.DECISION_PERMANENTLY_DENIED
+    assert d["max_severity"] == 2
+    assert d["permanently_denied"] is True
+    assert "denied_live_path_modification" in d["deny_reasons"]
+
+
+def test_permanently_denied_unit_via_frozen_contract() -> None:
+    unit = _baseline_unit(
+        expected_files=[
+            "reporting/synthetic_module.py",
+            "research/research_latest.json",
+        ],
+    )
+    d = rua._decide_for_unit(unit)
+    assert d["final_authority_class"] == ea.DECISION_PERMANENTLY_DENIED
+    assert "denied_frozen_contract_mutation" in d["deny_reasons"]
+
+
+def test_strategy_matrix_csv_is_permanently_denied_too() -> None:
+    unit = _baseline_unit(
+        expected_files=[
+            "reporting/synthetic_module.py",
+            "research/strategy_matrix.csv",
+        ],
+    )
+    d = rua._decide_for_unit(unit)
+    assert d["final_authority_class"] == ea.DECISION_PERMANENTLY_DENIED
+    assert "denied_frozen_contract_mutation" in d["deny_reasons"]
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "broker/foo.py",
+        "agent/risk/policy.py",
+        "agent/execution/runner.py",
+        "automation/live_gate.py",
+    ],
+)
+def test_runtime_trading_paths_drive_unit_to_permanently_denied(
+    path: str,
+) -> None:
+    unit = _baseline_unit(
+        expected_files=["reporting/synthetic_module.py", path],
+    )
+    d = rua._decide_for_unit(unit)
+    assert d["final_authority_class"] == ea.DECISION_PERMANENTLY_DENIED
+
+
+def test_live_target_layer_drives_unit_to_permanently_denied() -> None:
+    unit = _baseline_unit(target_layer="live")
+    d = rua._decide_for_unit(unit)
+    assert d["final_authority_class"] == ea.DECISION_PERMANENTLY_DENIED
+    assert any(
+        r == "live_runtime_activation_not_authorised" for r in d["deny_reasons"]
+    )
+
+
+def test_paper_target_layer_is_needs_human_not_auto_allowed() -> None:
+    unit = _baseline_unit(target_layer="paper")
+    d = rua._decide_for_unit(unit)
+    assert d["final_authority_class"] == ea.DECISION_NEEDS_HUMAN
+    assert d["final_authority_class"] != ea.DECISION_AUTO_ALLOWED
+
+
+def test_shadow_target_layer_is_needs_human_not_auto_allowed() -> None:
+    unit = _baseline_unit(target_layer="shadow")
+    d = rua._decide_for_unit(unit)
+    assert d["final_authority_class"] == ea.DECISION_NEEDS_HUMAN
+    assert d["final_authority_class"] != ea.DECISION_AUTO_ALLOWED
+
+
+def test_operator_gate_operator_go_required_elevates_to_needs_human() -> None:
+    unit = _baseline_unit(operator_gate="operator_go_required")
+    d = rua._decide_for_unit(unit)
+    assert d["final_authority_class"] == ea.DECISION_NEEDS_HUMAN
+
+
+def test_operator_gate_governance_bootstrap_pr_required_elevates() -> None:
+    unit = _baseline_unit(operator_gate="governance_bootstrap_pr_required")
+    d = rua._decide_for_unit(unit)
+    assert d["final_authority_class"] == ea.DECISION_NEEDS_HUMAN
+
+
+def test_research_module_unit_kind_elevates_to_needs_human() -> None:
+    """A unit_kind of 'research_module' must elevate even if the
+    expected_files happen to be auto-allowed by path classification."""
+    unit = _baseline_unit(unit_kind="research_module")
+    d = rua._decide_for_unit(unit)
+    assert d["final_authority_class"] == ea.DECISION_NEEDS_HUMAN
+
+
+def test_external_intelligence_source_unit_kind_elevates() -> None:
+    unit = _baseline_unit(unit_kind="external_intelligence_source")
+    d = rua._decide_for_unit(unit)
+    assert d["final_authority_class"] == ea.DECISION_NEEDS_HUMAN
+
+
+def test_diagnostic_primitive_unit_kind_elevates() -> None:
+    unit = _baseline_unit(unit_kind="diagnostic_primitive")
+    d = rua._decide_for_unit(unit)
+    assert d["final_authority_class"] == ea.DECISION_NEEDS_HUMAN
+
+
+# ---------------------------------------------------------------------------
+# Unknown / unsupported evidence fails closed to NEEDS_HUMAN
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_risk_class_string_fails_closed() -> None:
+    unit = _baseline_unit(risk_class="NOT_A_RISK_CLASS")
+    d = rua._decide_for_unit(unit)
+    assert d["final_authority_class"] == ea.DECISION_NEEDS_HUMAN
+    assert d["fail_closed"] is True
+
+
+def test_risk_class_unknown_fails_closed() -> None:
+    unit = _baseline_unit(risk_class="UNKNOWN")
+    d = rua._decide_for_unit(unit)
+    assert d["final_authority_class"] == ea.DECISION_NEEDS_HUMAN
+
+
+def test_unknown_target_layer_fails_closed() -> None:
+    unit = _baseline_unit(target_layer="not_a_layer")
+    d = rua._decide_for_unit(unit)
+    assert d["final_authority_class"] == ea.DECISION_NEEDS_HUMAN
+    assert d["fail_closed"] is True
+
+
+def test_unknown_operator_gate_fails_closed() -> None:
+    unit = _baseline_unit(operator_gate="not_a_gate")
+    d = rua._decide_for_unit(unit)
+    assert d["final_authority_class"] == ea.DECISION_NEEDS_HUMAN
+    assert d["fail_closed"] is True
+
+
+def test_unknown_authority_hint_fails_closed() -> None:
+    unit = _baseline_unit(authority_hint="MAYBE")
+    d = rua._decide_for_unit(unit)
+    assert d["final_authority_class"] == ea.DECISION_NEEDS_HUMAN
+    assert d["fail_closed"] is True
+
+
+def test_unknown_unit_kind_fails_closed() -> None:
+    unit = _baseline_unit(unit_kind="not_a_kind")
+    d = rua._decide_for_unit(unit)
+    assert d["final_authority_class"] == ea.DECISION_NEEDS_HUMAN
+    assert d["fail_closed"] is True
+
+
+# ---------------------------------------------------------------------------
+# Forbidden_files records are informational only (do not elevate)
+# ---------------------------------------------------------------------------
+
+
+def test_forbidden_file_classifier_evidence_is_recorded_but_not_aggregating(
+    snap: dict,
+) -> None:
+    """Every emitted decision should carry forbidden_file_classifier
+    evidence (transparency) AND that evidence kind must be in
+    _INFORMATIONAL_EVIDENCE_KINDS."""
+    assert "forbidden_file_classifier" in rua._INFORMATIONAL_EVIDENCE_KINDS
+    for d in snap["authority_decisions"]:
+        forbidden_evidence = [
+            e for e in d["evidence"] if e["kind"] == "forbidden_file_classifier"
+        ]
+        # A20b always seeds at least baseline forbidden_files; A20c
+        # must have classified them.
+        assert forbidden_evidence
+
+
+def test_baseline_unit_does_not_get_elevated_by_its_forbidden_files() -> None:
+    """The baseline synthetic unit lists every protected/runtime/
+    frozen path in forbidden_files. Those paths classify as
+    PERMANENTLY_DENIED in the canonical classifier — but they MUST
+    NOT elevate this unit, because forbidden_file_classifier is
+    informational only."""
+    unit = _baseline_unit()
+    d = rua._decide_for_unit(unit)
+    assert d["final_authority_class"] == ea.DECISION_AUTO_ALLOWED
+
+
+# ---------------------------------------------------------------------------
+# Real A20b units: no AUTO_ALLOWED decision rests on a protected surface
+# ---------------------------------------------------------------------------
+
+
+def test_no_auto_allowed_decision_in_main_rests_on_protected_path(
+    snap: dict,
+) -> None:
+    protected_categories = {
+        "live_path",
+        "frozen_contract",
+        "branch_protection_config",
+    }
+    for d in snap["authority_decisions"]:
+        if d["final_authority_class"] != ea.DECISION_AUTO_ALLOWED:
+            continue
+        for ev in d["evidence"]:
+            if ev["kind"] != "expected_file_classifier":
+                continue
+            decision = ea.classify(
+                action_type="file_edit",
+                target_path=ev["value"],
+                risk_class=ea.RISK_LOW,
+            )
+            assert decision.target_path_category not in protected_categories, (
+                d["implementation_unit_id"],
+                ev["value"],
+            )
+
+
+def test_canonical_policy_doc_in_expected_files_blocks_auto_allowed() -> None:
+    """A docs/tests/reporting-only unit can be AUTO_ALLOWED only if no
+    protected surface is present. Adding a canonical_policy_doc path
+    must demote the unit to NEEDS_HUMAN."""
+    unit = _baseline_unit(
+        expected_files=[
+            "reporting/synthetic_module.py",
+            "docs/governance/no_touch_paths.md",  # canonical_policy_doc
+        ],
+    )
+    d = rua._decide_for_unit(unit)
+    assert d["final_authority_class"] != ea.DECISION_AUTO_ALLOWED
+
+
+def test_canonical_roadmap_in_expected_files_blocks_auto_allowed() -> None:
+    unit = _baseline_unit(
+        expected_files=[
+            "reporting/synthetic_module.py",
+            "docs/roadmap/Roadmap v6.md",  # canonical_roadmap
+        ],
+    )
+    d = rua._decide_for_unit(unit)
+    assert d["final_authority_class"] != ea.DECISION_AUTO_ALLOWED
+
+
+def test_dashboard_wiring_in_expected_files_blocks_auto_allowed() -> None:
+    unit = _baseline_unit(
+        expected_files=[
+            "reporting/synthetic_module.py",
+            "dashboard/dashboard.py",
+        ],
+    )
+    d = rua._decide_for_unit(unit)
+    assert d["final_authority_class"] != ea.DECISION_AUTO_ALLOWED
+
+
+def test_claude_governance_hook_in_expected_files_blocks_auto_allowed() -> None:
+    unit = _baseline_unit(
+        expected_files=[
+            "reporting/synthetic_module.py",
+            ".claude/hooks/foo.py",
+        ],
+    )
+    d = rua._decide_for_unit(unit)
+    assert d["final_authority_class"] != ea.DECISION_AUTO_ALLOWED
+
+
+# ---------------------------------------------------------------------------
+# classifier_used and fail_closed flags
+# ---------------------------------------------------------------------------
+
+
+def test_classifier_used_is_true_for_normal_decisions(snap: dict) -> None:
+    """Every decision in the on-disk projection must have called the
+    canonical classifier (each unit has non-empty expected_files)."""
+    for d in snap["authority_decisions"]:
+        assert d["classifier_used"] is True
+
+
+def test_fail_closed_is_true_when_unknown_evidence_detected() -> None:
+    unit = _baseline_unit(risk_class="NOT_A_RISK")
+    d = rua._decide_for_unit(unit)
+    assert d["fail_closed"] is True
+
+
+def test_fail_closed_is_false_for_well_formed_auto_allowed_unit() -> None:
+    unit = _baseline_unit()
+    d = rua._decide_for_unit(unit)
+    assert d["fail_closed"] is False
+
+
+# ---------------------------------------------------------------------------
+# Invariants pin authority chain
+# ---------------------------------------------------------------------------
+
+
+def test_invariants_flip_calls_execution_authority_classifier(snap: dict) -> None:
+    assert snap["authority_invariants"]["calls_execution_authority_classifier"] is True
+
+
+def test_invariants_flip_final_authority_classified(snap: dict) -> None:
+    assert snap["authority_invariants"]["final_authority_classified"] is True
+
+
+def test_invariants_pin_no_runtime_trading_authority(snap: dict) -> None:
+    assert snap["authority_invariants"]["no_runtime_trading_authority"] is True
+
+
+def test_invariants_pin_no_step5_runtime(snap: dict) -> None:
+    assert snap["authority_invariants"]["no_step5_runtime"] is True
+    assert snap["step5_implementation_allowed"] is False
+    assert snap["step5_enabled_substage"] == "none"
+
+
+def test_invariants_pin_no_level6(snap: dict) -> None:
+    assert snap["authority_invariants"]["no_level6"] is True
+
+
+def test_invariants_pin_no_production_merge_authority(snap: dict) -> None:
+    assert snap["authority_invariants"]["no_production_merge_authority"] is True
+
+
+def test_invariants_pin_writes_only_roadmap_unit_authority_log(
+    snap: dict,
+) -> None:
+    assert (
+        snap["authority_invariants"]["writes_only_roadmap_unit_authority_log"]
+        is True
+    )
+
+
+def test_invariants_pin_aac_and_next_buildable_remain_false(snap: dict) -> None:
+    inv = snap["authority_invariants"]
+    assert inv["aac_visibility_present"] is False
+    assert inv["next_buildable_selector_present"] is False
+
+
+def test_invariants_pin_no_seed_jsonl_writes(snap: dict) -> None:
+    inv = snap["authority_invariants"]
+    assert inv["writes_to_seed_jsonl"] is False
+    assert inv["writes_to_delegation_seed_jsonl"] is False
+    assert inv["writes_to_generated_seed_jsonl"] is False
+
+
+def test_invariants_pin_no_upstream_mutation(snap: dict) -> None:
+    inv = snap["authority_invariants"]
+    assert inv["mutates_a20a_artifact"] is False
+    assert inv["mutates_a20b_artifact"] is False
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_deterministic_with_injected_ts() -> None:
+    a = rua.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+    b = rua.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+    assert a == b
+
+
+def test_serialised_output_byte_identical_with_injected_ts() -> None:
+    a = rua.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+    b = rua.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+    out_a = json.dumps(a, indent=2, sort_keys=True) + "\n"
+    out_b = json.dumps(b, indent=2, sort_keys=True) + "\n"
+    assert out_a == out_b
+
+
+def test_decisions_sorted_stably(snap: dict) -> None:
+    sorted_pairs = [
+        (d["phase"], d["implementation_unit_id"])
+        for d in snap["authority_decisions"]
+    ]
+    assert sorted_pairs == sorted(sorted_pairs)
+
+
+def test_source_units_versions_match(snap: dict, units_snap: dict) -> None:
+    assert snap["source_units_module_version"] == units_snap["module_version"]
+    assert snap["source_units_schema_version"] == units_snap["schema_version"]
+
+
+# ---------------------------------------------------------------------------
+# Upstream mutation: sha256 before/after
+# ---------------------------------------------------------------------------
+
+
+def _sha256(b: bytes) -> str:
+    return hashlib.sha256(b).hexdigest()
+
+
+def test_collect_snapshot_does_not_mutate_a20b_artifact_in_memory() -> None:
+    before = json.dumps(
+        rtu.collect_snapshot(generated_at_utc=_FROZEN_UTC),
+        sort_keys=True,
+    ).encode("utf-8")
+    rua.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+    after = json.dumps(
+        rtu.collect_snapshot(generated_at_utc=_FROZEN_UTC),
+        sort_keys=True,
+    ).encode("utf-8")
+    assert _sha256(before) == _sha256(after)
+
+
+# ---------------------------------------------------------------------------
+# Atomic write allowlist
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_write_refuses_path_outside_allowlist(tmp_path: Path) -> None:
+    bad = tmp_path / "logs" / "elsewhere" / "latest.json"
+    bad.parent.mkdir(parents=True, exist_ok=True)
+    with pytest.raises(ValueError):
+        rua._atomic_write_json(bad, {"x": 1})
+
+
+def test_atomic_write_refuses_frozen_contract_paths(tmp_path: Path) -> None:
+    for forbidden in (
+        "research/research_latest.json",
+        "research/strategy_matrix.csv",
+    ):
+        target = tmp_path / forbidden
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with pytest.raises(ValueError):
+            rua._atomic_write_json(target, {"x": 1})
+
+
+def test_atomic_write_accepts_allowlisted_path(tmp_path: Path) -> None:
+    good = tmp_path / "logs" / "roadmap_unit_authority" / "latest.json"
+    good.parent.mkdir(parents=True, exist_ok=True)
+    rua._atomic_write_json(good, {"x": 1})
+    assert good.is_file()
+    assert json.loads(good.read_text(encoding="utf-8")) == {"x": 1}
+
+
+def test_atomic_write_is_atomic(tmp_path: Path) -> None:
+    target = tmp_path / "logs" / "roadmap_unit_authority" / "latest.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    rua._atomic_write_json(target, {"x": 1})
+    rua._atomic_write_json(target, {"x": 2})
+    siblings = list(target.parent.iterdir())
+    assert siblings == [target]
+
+
+# ---------------------------------------------------------------------------
+# CLI behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_cli_no_write_does_not_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    sentinel = tmp_path / "logs" / "roadmap_unit_authority" / "latest.json"
+    monkeypatch.setattr(rua, "ARTIFACT_LATEST", sentinel)
+    monkeypatch.setattr(rua, "ARTIFACT_DIR", sentinel.parent)
+    rc = rua.main(["--no-write"])
+    assert rc == 0
+    assert not sentinel.exists()
+    out = capsys.readouterr().out
+    assert '"roadmap_unit_authority"' in out
+
+
+def test_cli_status_does_not_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    sentinel = tmp_path / "logs" / "roadmap_unit_authority" / "latest.json"
+    monkeypatch.setattr(rua, "ARTIFACT_LATEST", sentinel)
+    monkeypatch.setattr(rua, "ARTIFACT_DIR", sentinel.parent)
+    rc = rua.main(["--status"])
+    assert rc == 0
+    assert not sentinel.exists()
+    out = capsys.readouterr().out
+    assert "roadmap_unit_authority" in out
+    assert "calls_execution_authority_classifier=True" in out
+    assert "final_authority_classified=True" in out
+    assert "no_runtime_trading_authority=True" in out
+    assert "aac_visibility_present=False" in out
+    assert "next_buildable_selector_present=False" in out
+
+
+def test_cli_default_writes_to_allowlisted_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sentinel = tmp_path / "logs" / "roadmap_unit_authority" / "latest.json"
+    monkeypatch.setattr(rua, "ARTIFACT_LATEST", sentinel)
+    monkeypatch.setattr(rua, "ARTIFACT_DIR", sentinel.parent)
+    rc = rua.main([])
+    assert rc == 0
+    assert sentinel.is_file()
+    payload = json.loads(sentinel.read_text(encoding="utf-8"))
+    assert payload["report_kind"] == "roadmap_unit_authority"
+    assert payload["module_version"].endswith("A20c")
+
+
+def test_cli_indent_zero_compact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    sentinel = tmp_path / "logs" / "roadmap_unit_authority" / "latest.json"
+    monkeypatch.setattr(rua, "ARTIFACT_LATEST", sentinel)
+    monkeypatch.setattr(rua, "ARTIFACT_DIR", sentinel.parent)
+    rc = rua.main(["--no-write", "--indent", "0"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "\n  " not in out
+
+
+# ---------------------------------------------------------------------------
+# Module-source forbidden-import / forbidden-token scans
+# ---------------------------------------------------------------------------
+
+
+def _module_source() -> str:
+    return Path(rua.__file__).read_text(encoding="utf-8")
+
+
+def _module_imports() -> list[str]:
+    import ast as _ast
+
+    tree = _ast.parse(_module_source())
+    out: list[str] = []
+    for node in _ast.walk(tree):
+        if isinstance(node, _ast.Import):
+            for alias in node.names:
+                out.append(alias.name)
+        elif isinstance(node, _ast.ImportFrom):
+            mod = node.module or ""
+            for alias in node.names:
+                out.append(f"{mod}.{alias.name}" if mod else alias.name)
+    return out
+
+
+def test_no_subprocess_in_module() -> None:
+    src = _module_source()
+    assert "import subprocess" not in src
+    assert "from subprocess" not in src
+    assert "subprocess." not in src
+
+
+def test_no_socket_or_urllib_or_http_or_requests() -> None:
+    src = _module_source()
+    for forbidden in (
+        "import socket",
+        "from socket",
+        "import urllib",
+        "from urllib",
+        "import http",
+        "from http",
+        "import requests",
+        "from requests",
+        "import httpx",
+        "from httpx",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_no_forbidden_runtime_imports_via_ast() -> None:
+    forbidden_prefixes = (
+        "dashboard",
+        "automation",
+        "broker",
+        "agent.risk",
+        "agent.execution",
+        "research",
+        "live",
+        "paper",
+        "shadow",
+        "trading",
+        "reporting.intelligent_routing",
+        "reporting.development_queue_admission_policy",
+        "reporting.development_agent_activity_timeline",
+    )
+    for module in _module_imports():
+        for prefix in forbidden_prefixes:
+            assert not (
+                module == prefix or module.startswith(prefix + ".")
+            ), f"forbidden import: {module}"
+
+
+def test_no_gh_or_git_cli_calls() -> None:
+    src = _module_source()
+    for forbidden in (
+        "subprocess.run",
+        "subprocess.Popen",
+        "os.system(",
+        "os.popen(",
+        "shell=True",
+        "eval(",
+        "exec(",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_no_github_api_or_external_api_calls() -> None:
+    src = _module_source()
+    for forbidden in (
+        "api.github.com",
+        "anthropic",
+        "openai",
+        "Bearer ",
+        "X-API-Key",
+        "X-GitHub-Token",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_module_imports_only_canonical_upstreams() -> None:
+    allowed_reporting_imports = {
+        "reporting.execution_authority",
+        "reporting.roadmap_task_units",
+    }
+    for module in _module_imports():
+        if module.startswith("reporting."):
+            assert module in allowed_reporting_imports, module
+
+
+def test_module_imports_cleanly() -> None:
+    importlib.reload(rua)
+    assert callable(rua.collect_snapshot)
+    assert callable(rua.write_outputs)
+    assert callable(rua.main)
+
+
+def test_schema_and_module_version_strings() -> None:
+    assert isinstance(rua.SCHEMA_VERSION, str) and rua.SCHEMA_VERSION
+    assert isinstance(rua.MODULE_VERSION, str) and rua.MODULE_VERSION
+    assert rua.MODULE_VERSION.endswith("A20c")


### PR DESCRIPTION
## Summary

- Per-unit projection that derives a deterministic `UnitAuthorityDecision` for every A20b `ImplementationUnit` by calling the canonical Execution Authority classifier (`reporting.execution_authority.classify(...)`) and aggregating its verdicts with A20c's own deterministic, closed-vocab rules for the non-path evidence kinds.
- **A20c integrates final authority classification for units.** The projection's `authority_invariants` block flips `calls_execution_authority_classifier` and `final_authority_classified` to `true`; all other authority pins remain in their A20b-posture (`no_runtime_trading_authority = true`, `no_step5_runtime = true`, `no_level6 = true`, `no_production_merge_authority = true`).
- Emits a deterministic artefact at `logs/roadmap_unit_authority/latest.json`.
- A20c MUST NOT create a second source of truth for path-level authority. Every per-file evidence record carries the verbatim `decision` / `reason` returned by the canonical classifier (pinned by `test_authority_class_matches_canonical_decisions_verbatim`).
- A20b's `authority_hint` is preserved as one evidence record (`kind=\"authority_hint\"`); it never overrides the canonical classifier's per-path verdict.

## Files changed (exactly 3, approved scope only)

- `reporting/roadmap_unit_authority.py` (new) — stdlib + `reporting.execution_authority` + `reporting.roadmap_task_units` only.
- `tests/unit/test_roadmap_unit_authority.py` (new) — 86 tests.
- `docs/governance/roadmap_task_catalog.md` (modified) — A20c section (§8) + test-coverage block (§10.3); A20a / A20b content preserved.

Untouched (verified):
- `reporting/execution_authority.py` (canonical classifier)
- `docs/governance/execution_authority.md`
- `reporting/roadmap_task_catalog.py` (A20a)
- `reporting/roadmap_task_units.py` (A20b)
- `tests/unit/test_roadmap_task_catalog.py` (A20a tests)
- `tests/unit/test_roadmap_task_units.py` (A20b tests)
- `reporting/development_queue_admission_policy.py` (existing A17)
- `reporting/development_agent_activity_timeline.py` (AAC aggregator)

## Validation commands and results

- \`python -m pytest tests/unit/test_roadmap_task_catalog.py -v\` → **83 passed** (unchanged)
- \`python -m pytest tests/unit/test_roadmap_task_units.py -v\` → **87 passed** (unchanged)
- \`python -m pytest tests/unit/test_roadmap_unit_authority.py -v\` → **86 passed**
- \`python -m pytest tests/unit/test_execution_authority.py -v\` → **110 passed** (unchanged)
- \`python -m pytest tests/smoke -v\` → **18 passed**
- \`python scripts/governance_lint.py\` → **OK** (16 agents, 5 workflows)
- Frozen-contract regression set (\`tests/regression/test_public_output_contract.py\`, \`test_v12_contracts_preserved.py\`, \`test_authority_invariants.py\`) → **16 passed**

## Frozen-contract verdict

- \`research/research_latest.json\` — **not touched**.
- \`research/strategy_matrix.csv\` — **not touched**.
- Atomic-write helper rejects every path outside \`logs/roadmap_unit_authority/\` (pinned by \`test_atomic_write_refuses_path_outside_allowlist\` + \`test_atomic_write_refuses_frozen_contract_paths\`).
- Sha256-before-vs-after pin: \`collect_snapshot()\` does not mutate the A20b in-memory artefact.
- Parametrised classifier tests confirm frozen-contract paths classify as \`PERMANENTLY_DENIED\` with reason \`denied_frozen_contract_mutation\` at every \`risk_class\`.

## Forbidden-path verdict

\`git diff --name-only main\` contains exactly the three approved files:

\`\`\`
docs/governance/roadmap_task_catalog.md
reporting/roadmap_unit_authority.py
tests/unit/test_roadmap_unit_authority.py
\`\`\`

None of the following were touched:

- \`dashboard/dashboard.py\`
- \`.claude/**\`
- \`.github/**\`
- \`research/research_latest.json\`, \`research/strategy_matrix.csv\`
- \`automation/live_gate.py\`, \`broker/**\`, \`agent/risk/**\`, \`agent/execution/**\`
- \`live/**\`, \`paper/**\`, \`shadow/**\`, \`trading/**\`
- \`docs/roadmap/Roadmap v6.md\`, \`docs/roadmap/Roadmap v6 Addendum.md\`, \`docs/roadmap/autonomous_development.txt\`
- \`docs/governance/execution_authority.md\`, \`docs/governance/no_touch_paths.md\`
- \`reporting/execution_authority.py\`
- \`reporting/roadmap_task_catalog.py\`, \`reporting/roadmap_task_units.py\`
- \`reporting/development_queue_admission_policy.py\` (existing A17)
- \`reporting/development_agent_activity_timeline.py\` (AAC aggregator)
- \`docs/development_work_queue/*.jsonl\`
- \`tests/regression/**\`
- any frozen schema under \`artifacts/\`

## Authority statement (still pinned on \`main\`)

- ADE remains development workflow automation only.
- **A20c integrates final authority classification for units** (closed authority classes: \`AUTO_ALLOWED\`, \`NEEDS_HUMAN\`, \`PERMANENTLY_DENIED\` — verbatim re-export from the canonical \`reporting.execution_authority.DECISIONS\` enum).
- No QRE runtime / trading / paper / shadow / broker / risk / live authority granted.
- Step 5 implementation remains BLOCKED (\`step5_implementation_allowed = False\`, \`STEP5_ENABLED_SUBSTAGE = \"none\"\`).
- Autonomy-ladder Level 6 remains permanently disabled.
- N5b Phase 4 production merge remains permanently denied for ADE.
- The projection's \`authority_invariants\` block pins: \`calls_execution_authority_classifier = true\`; \`final_authority_classified = true\`; \`no_runtime_trading_authority = true\`; \`no_step5_runtime = true\`; \`no_level6 = true\`; \`no_production_merge_authority = true\`; \`writes_only_roadmap_unit_authority_log = true\`; \`aac_visibility_present = false\`; \`next_buildable_selector_present = false\`.

## What this PR does NOT do

- **A20c creates no AAC/dashboard visibility yet.** The AAC aggregator (\`reporting/development_agent_activity_timeline.py\`) and its 11-entry pinned upstream catalog are unchanged. A20d scope.
- **A20c creates no next-buildable-unit selector yet.** A20e scope.
- No modification of \`reporting/execution_authority.py\` or its governance doc.
- No modification of \`reporting/roadmap_task_catalog.py\` (A20a) or \`reporting/roadmap_task_units.py\` (A20b) or their tests.
- No edit to canonical roadmap docs, canonical policy docs, or \`autonomous_development.txt\`.
- No Step 5 / Level 6 / N5b weakening.

## Note on the prior A20c attempt (PR #246)

A previous A20c attempt is open as PR #246 (\`feature/a20c-roadmap-task-authority-classification\`, module \`reporting/roadmap_task_authority.py\`) with a different schema. This PR (#TBD) implements the freshly-specified A20c under the explicit naming \`reporting/roadmap_unit_authority.py\` per the new spec. **Recommendation: close PR #246 in favour of this one.** I did not close PR #246 myself — that is an operator action.

## Next recommended PR

**A20d — Read-only Operator Visibility.** Extend the AAC aggregator's pinned upstream catalog to surface \`logs/roadmap_unit_authority/latest.json\` (and optionally \`logs/roadmap_task_units/latest.json\`) as read-only work-item rows. **Operator-go required** because the AAC aggregator's pinned upstream catalog cardinality changes; the B2.0b structural-pin test must be updated in the same PR. No mutation routes, no approval buttons, no \`dashboard/dashboard.py\` edit.

## Test plan

- [x] Local unit tests + smoke + governance lint + frozen-contract regression all green (see above)
- [ ] CI checks complete on PR (squash-merge only — no \`--admin\`, no force push, no hook bypass, no automatic merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)