### PR TITLE
feat(a20e): deterministic next-buildable-unit selector (read-only)

### DIFF
--- a/docs/governance/roadmap_task_catalog.md
+++ b/docs/governance/roadmap_task_catalog.md
@@ -1,10 +1,10 @@
-# Roadmap Task Catalog — A20a + A20b + A20c + A20d (read-only, deterministic)
+# Roadmap Task Catalog — A20a + A20b + A20c + A20d + A20e (read-only, deterministic)
 
 > **Status:** A20a implemented; A20b implemented; A20c implemented;
-> A20d implemented (read-only operator visibility via the existing
-> Agent Activity Center aggregator). All four stages are
-> read-only projections; none mutates anything; none selects a
-> next-buildable unit (that remains A20e scope).
+> A20d implemented; A20e implemented (deterministic next-buildable-unit
+> selector). All five stages are read-only projections; none
+> mutates anything; the selector never executes work, opens
+> branches / PRs, merges, or deploys.
 >
 > **A20a module:** [`reporting/roadmap_task_catalog.py`](../../reporting/roadmap_task_catalog.py)
 > **A20a artefact:** `logs/roadmap_task_catalog/latest.json`
@@ -17,6 +17,9 @@
 >
 > **A20d module (extension):** [`reporting/development_agent_activity_timeline.py`](../../reporting/development_agent_activity_timeline.py)
 > **A20d artefact:** existing `logs/development_agent_activity_timeline/latest.json` envelope; three new `source_kind` values inside `work_items[]`.
+>
+> **A20e module:** [`reporting/roadmap_next_unit.py`](../../reporting/roadmap_next_unit.py)
+> **A20e artefact:** `logs/roadmap_next_unit/latest.json`
 >
 > **Authority:** development-governance read-only.
 > The roadmap task catalog is **not** the canonical product roadmap.
@@ -687,33 +690,172 @@ And the following stay `True` (no weakening):
 - `no_level6 = True`
 - `no_production_merge_authority = True`
 
-## 10. Future stages (A20e)
+## 10. A20e — Deterministic Next-Buildable-Unit Selector (implemented)
 
-- **A20e — Deterministic Next-Buildable-Unit Selector.** Exposes the
-  catalog + units + authority decisions to the operator through
-  the existing read-only surfaces (`reporting/task_board.py`,
-  `reporting/agent_flow.py`, AAC aggregator). No mutation routes,
-  no approval buttons, no `dashboard/dashboard.py` edit unless a
-  separate operator-authored governance-bootstrap PR enables it.
-  Any AAC aggregator cardinality change requires its own
-  operator-go PR. A20d will flip `aac_visibility_present` to
-  `true`.
-- **A20e — Deterministic Next-Buildable-Unit Selector.**
-  Pure-deterministic filter + sort over A20c output. Eligibility
-  requires: `status ∈ {not_started, ready}`; all prerequisites in
-  `status = merged`; `operator_gate = none`;
-  `aggregate_decision = AUTO_ALLOWED`; no triggered
-  forbidden-surface reasons. Fail-closed: zero eligible →
-  `selected_unit_id = None` with `selection_reason =
-  "no_eligible_units"`. No hidden LLM judgment. A20e will flip
-  `next_buildable_selector_present` to `true`.
+A20e is a pure stdlib-only read-only consumer of the A20b
+implementation-unit projection and the A20c unit-authority
+projection. It emits a deterministic projection at
+`logs/roadmap_next_unit/latest.json` that names at most one
+`NextBuildableUnitSelection` plus the full filterable candidates
+list.
 
-Neither A20a nor A20b produces, implies, or depends on any of the
-above. Each must justify its own scope on its own PR.
+### 10.1 Purpose of deterministic next-buildable-unit selection
 
----
+Before A20e the operator had to scan the A20b and A20c artefacts
+manually to identify which implementation unit should be the next
+PR. A20e applies a closed deterministic filter + sort and surfaces
+either the single recommended unit or the closed-vocab reason no
+unit is eligible. The recommendation is **informational only**;
+A20e never opens a branch / PR / merge / deploy.
 
-## 11. CLI
+### 10.2 Read-only by construction
+
+- A20e never executes any unit's implementation.
+- A20e never creates a branch.
+- A20e never opens a PR.
+- A20e never merges or deploys anything.
+- A20e never mutates any approval inbox, seed JSONL, queue, or
+  upstream artefact (pinned by sha256-before-vs-after tests on
+  the A20b / A20c artefacts).
+- A20e never calls the canonical Execution Authority classifier
+  directly; A20c remains the only classifier call site.
+- A20e never grants runtime / trading / paper / shadow / live
+  authority.
+- A20e never activates Step 5; never enables Level 6; never
+  creates production-merge authority.
+
+### 10.3 Deterministic selection rules
+
+For each A20b implementation unit:
+
+1. **A20b status check.** The unit's status must be in the closed
+   buildable set `{"not_started", "ready"}`. Any other status
+   (e.g. `in_flight`, `merged`, `blocked`, `human_needed`,
+   `permanently_denied`) blocks the candidate with
+   `non_buildable_status`. An unknown status string blocks with
+   `unknown_unit_status`.
+2. **A20c authority lookup.** Find the matching A20c
+   `UnitAuthorityDecision` by `implementation_unit_id`:
+   - zero matches → block with `missing_authority_decision`;
+   - more than one match → block with
+     `duplicate_authority_decision`;
+   - `final_authority_class == "PERMANENTLY_DENIED"` → block with
+     `permanently_denied_authority`;
+   - `final_authority_class` outside `{AUTO_ALLOWED, NEEDS_HUMAN}`
+     → block with `unknown_authority`.
+3. **Prerequisite check.** Every entry in the unit's
+   `prerequisites[]` must resolve to a known A20b unit with
+   `status = "merged"`. Otherwise:
+   - unknown target → block with `unknown_prerequisite_target`;
+   - target not merged → block with `unsatisfied_prerequisite`.
+4. **Eligibility classification.** If no block reasons accumulated:
+   - `final_authority_class == "NEEDS_HUMAN"` OR
+     `operator_gate != "none"` → `NEEDS_HUMAN_GATED`;
+   - else → `ELIGIBLE`.
+
+Sort key (tuple-as-list, fully deterministic, no timestamps):
+
+1. Roadmap phase order: `v3.15.16`, `v3.15.17`, `v3.15.18`,
+   `v3.15.19`, `v3.15.20`, `addendum_1`, `addendum_2`,
+   `addendum_3`. Unknown phases sort last.
+2. Authority order: `AUTO_ALLOWED` before `NEEDS_HUMAN`.
+3. Risk order: `LOW` before `MEDIUM` before `HIGH` before
+   `UNKNOWN`.
+4. Operator-gate order: `none` before `operator_go_required`
+   before `governance_bootstrap_pr_required`.
+5. Implementation-unit id lex order.
+
+Selection prefers `ELIGIBLE` over `NEEDS_HUMAN_GATED`. Ties within
+a tier resolve by the sort key above.
+
+### 10.4 Authority handling
+
+- `AUTO_ALLOWED` units may be selected as the next buildable
+  candidate. A20e records the recommendation; the operator
+  decides whether to open a PR via the normal lifecycle. A20e
+  itself never opens a branch.
+- `NEEDS_HUMAN` units may be selected **only** as the operator-gated
+  candidate. The selected row carries `requires_operator_go=True`
+  and the projection's `selection_status` is
+  `ALL_NEEDS_HUMAN_GATED`.
+- `PERMANENTLY_DENIED` units are never selected. Pinned by
+  `selector_invariants.permanently_denied_units_never_selected`.
+
+### 10.5 Fail-closed behavior
+
+A20e fails closed in every ambiguous case:
+
+| Condition | Result |
+|---|---|
+| Either upstream artefact absent or malformed | `selection_status = "UPSTREAM_UNAVAILABLE"`, `fail_closed = true`, `selected_unit_id = ""` |
+| Zero units in A20b | `NO_ELIGIBLE_UNITS`, `fail_closed = true` |
+| Every candidate `PERMANENTLY_DENIED` | `ALL_PERMANENTLY_DENIED`, `fail_closed = true` |
+| Every candidate blocked by unresolved prerequisites | `ALL_BLOCKED_BY_PREREQUISITES`, `fail_closed = true` |
+| Unknown / duplicate authority on every candidate | `FAIL_CLOSED_INVARIANT`, `fail_closed = true` |
+| Mixed blocking reasons with zero eligible | `NO_ELIGIBLE_UNITS`, `fail_closed = true` |
+| Selection succeeds with at least one `ELIGIBLE` | `OK_SELECTED`, `fail_closed = false` |
+| Selection succeeds but every eligible candidate is `NEEDS_HUMAN_GATED` | `ALL_NEEDS_HUMAN_GATED`, `fail_closed = false`, `requires_operator_go = true` |
+
+### 10.6 A20e does NOT expose itself in AAC visibility yet
+
+The smallest-safe A20e implementation keeps the AAC aggregator
+unchanged. The operator can read the selector projection directly
+via:
+
+```sh
+python -m reporting.roadmap_next_unit --status
+```
+
+or by reading `logs/roadmap_next_unit/latest.json`. A future
+operator-go PR may extend the AAC aggregator's pinned upstream
+catalog with a 15th `roadmap_next_unit` entry; that change would
+require updating the B2.0b structural-pin test in the same PR. It
+is not in A20e scope.
+
+### 10.7 Invariant flips landing under A20e
+
+A20e flips one flag in the A20b `_DECOMPOSITION_INVARIANTS` and
+A20c `_BASE_AUTHORITY_INVARIANTS` blocks from `False` to `True`:
+
+- `next_buildable_selector_present = True`
+
+The following remain `True` (no weakening):
+
+- `no_runtime_trading_authority = True`
+- `no_step5_runtime = True`
+- `no_level6 = True`
+- `no_production_merge_authority = True`
+- `aac_visibility_present = True`
+
+## 11. A20 overall status after A20e
+
+A20a → A20e form the read-only "roadmap-to-task pipeline":
+
+1. **A20a** seeds the deterministic Roadmap v6 + Addendum 1 task
+   catalog as in-source Python data.
+2. **A20b** decomposes each task into PR-sized
+   `ImplementationUnit` records.
+3. **A20c** annotates each unit with the canonical Execution
+   Authority verdict.
+4. **A20d** surfaces all three projections as read-only AAC
+   work-item rows.
+5. **A20e** deterministically selects the next-buildable unit.
+
+The next step after A20e is **operator review** of the selector
+output, followed by the **first queue-driven Roadmap v6
+implementation unit** opened as its own PR under normal ADE PR
+lifecycle governance. A20e does not open that PR — the operator
+does, using the selector's recommendation as input.
+
+<!-- A20e legacy future-stages section retained below for reference. -->
+## 12. Future stages — A20 complete
+
+The A20 series is complete. No further A20 stages are planned.
+Future work continues under the QRE Feature Build Track on the
+Roadmap v6 phase order (v3.15.16 → v3.15.17 → v3.15.18 →
+v3.15.19 → v3.15.20 → v3.16.x → v4.x → v5.x → v6.x).
+
+## 13. CLI
 
 ```sh
 # Pure inspection — write the artefact and dump JSON to stdout:
@@ -735,7 +877,7 @@ refuses every path outside `logs/roadmap_task_catalog/`.
 
 ---
 
-## 12. Determinism contract
+## 14. Determinism contract
 
 - Tasks are sorted by `(phase, id)` ascending.
 - Requirements are sorted by `(phase, id)` ascending.
@@ -748,9 +890,9 @@ refuses every path outside `logs/roadmap_task_catalog/`.
 
 ---
 
-## 13. Test coverage
+## 15. Test coverage
 
-### 13.1 A20a
+### 15.1 A20a
 
 Pinned in [`tests/unit/test_roadmap_task_catalog.py`](../../tests/unit/test_roadmap_task_catalog.py):
 
@@ -784,7 +926,7 @@ Pinned in [`tests/unit/test_roadmap_task_catalog.py`](../../tests/unit/test_road
   research.run_research, research_latest.json, strategy_matrix.csv,
   `gh`, `git`).
 
-### 13.2 A20b
+### 15.2 A20b
 
 Pinned in [`tests/unit/test_roadmap_task_units.py`](../../tests/unit/test_roadmap_task_units.py):
 
@@ -850,7 +992,7 @@ declarations and inside this governance doc. They are forbidden as
 import targets, write targets, and runtime call surfaces; they are
 **not** forbidden as forbidden-path declarations.
 
-### 13.3 A20c
+### 15.3 A20c
 
 Pinned in [`tests/unit/test_roadmap_unit_authority.py`](../../tests/unit/test_roadmap_unit_authority.py):
 
@@ -926,7 +1068,7 @@ Pinned in [`tests/unit/test_roadmap_unit_authority.py`](../../tests/unit/test_ro
 
 ---
 
-### 13.4 A20d
+### 15.4 A20d
 
 Pinned in [`tests/unit/test_development_agent_activity_timeline.py`](../../tests/unit/test_development_agent_activity_timeline.py):
 
@@ -971,10 +1113,94 @@ Pinned in [`tests/unit/test_development_agent_activity_timeline.py`](../../tests
   `level_6=permanently_disabled` / `danger_off`,
   `step5_implementation_allowed=False`, `step5_substage="none"`.
 - A20d does NOT introduce a `next_buildable_unit` / `selected_next_unit`
-  / `next_unit_selection` key into the envelope; that surface
-  remains A20e scope.
+  / `next_unit_selection` key into the envelope (A20e emits its own
+  artefact at `logs/roadmap_next_unit/latest.json` instead of
+  extending the AAC envelope).
 
-## 14. Cross-references
+### 15.5 A20e
+
+Pinned in [`tests/unit/test_roadmap_next_unit.py`](../../tests/unit/test_roadmap_next_unit.py):
+
+- Closed vocabularies (`NEXT_UNIT_SELECTION_STATUS`,
+  `NEXT_UNIT_BLOCK_REASON`, `NEXT_UNIT_ELIGIBILITY`,
+  `NEXT_UNIT_SOURCE`, `NEXT_UNIT_SELECTOR_MODE`) are exact.
+- Schema field tuples (`NEXT_BUILDABLE_UNIT_CANDIDATE_FIELDS`,
+  `NEXT_BUILDABLE_UNIT_SELECTION_FIELDS`,
+  `NEXT_BUILDABLE_UNIT_PROJECTION_FIELDS`) are exact and ordered.
+- Phase order matches A20a/A20b PHASE; authority order excludes
+  `PERMANENTLY_DENIED`; risk order matches classifier enum;
+  operator-gate order matches A20b enum; buildable-status set is
+  a subset of A20b `UNIT_STATUS`.
+- Happy path: an AUTO_ALLOWED unit is selected with
+  `selection_status="OK_SELECTED"`, `requires_operator_go=False`,
+  `fail_closed=False`.
+- `PERMANENTLY_DENIED` units are blocked with
+  `permanently_denied_authority`; the selector never selects
+  them; a mixed pool prefers the AUTO_ALLOWED unit over the
+  denied one.
+- Unknown authority class blocks with `unknown_authority`;
+  missing authority decision blocks with
+  `missing_authority_decision`; duplicate authority decisions
+  block with `duplicate_authority_decision`.
+- Unknown prerequisite target blocks with
+  `unknown_prerequisite_target`; unsatisfied prerequisite
+  (status ≠ "merged") blocks with `unsatisfied_prerequisite`;
+  satisfied prerequisite (all merged) allows the candidate.
+- All-blocked-by-prerequisites case yields
+  `selection_status="ALL_BLOCKED_BY_PREREQUISITES"`,
+  `fail_closed=True`.
+- NEEDS_HUMAN units may be selected only as
+  `NEEDS_HUMAN_GATED`; selection_status is
+  `ALL_NEEDS_HUMAN_GATED`; `requires_operator_go=True`.
+- Operator_gate ≠ "none" promotes an AUTO_ALLOWED unit to
+  `NEEDS_HUMAN_GATED`.
+- ELIGIBLE candidates are preferred over NEEDS_HUMAN_GATED even
+  when the gated candidate would otherwise sort earlier.
+- Non-buildable A20b status (`in_flight`, `merged`, `blocked`,
+  `human_needed`, `permanently_denied`) blocks the candidate
+  with `non_buildable_status`. Unknown A20b status blocks with
+  `unknown_unit_status` → `fail_closed=True`.
+- Deterministic sort: phase order → authority order → risk order
+  → operator-gate order → unit-id lex tie-break. No ISO 8601
+  timestamps anywhere in any sort key.
+- Selection is stable across two consecutive runs with the same
+  injected `generated_at_utc`.
+- Missing unit artefact / missing authority artefact / both
+  missing / malformed unit artefact all yield
+  `selection_status="UPSTREAM_UNAVAILABLE"` with
+  `fail_closed=True`; the matching upstream identifier appears
+  in `selection_reason`.
+- Empty units list yields `NO_ELIGIBLE_UNITS` with
+  `fail_closed=True`.
+- Byte-identical output for identical input with injected
+  `generated_at_utc`. Sha256-before-vs-after pins assert the
+  upstream A20b and A20c artefacts are not mutated.
+- Atomic-write allowlist refuses every path outside
+  `logs/roadmap_next_unit/`, including the frozen-contract paths.
+- CLI: `--no-write` writes nothing; `--status` writes nothing
+  and emits the expected invariant strings; default writes to
+  the allowlisted path; `--indent 0` produces compact output.
+- Selector invariants pin: `no_work_execution=True`,
+  `no_branch_creation=True`, `no_pr_creation=True`,
+  `no_merge_or_deploy=True`, `no_mutation_routes=True`,
+  `no_approval_buttons=True`, `no_runtime_trading_authority=True`,
+  `no_step5_runtime=True`, `no_level6=True`,
+  `no_production_merge_authority=True`,
+  `mutates_a20b_artifact=False`, `mutates_a20c_artifact=False`,
+  `writes_to_seed_jsonl=False`,
+  `fail_closed_on_unknown_evidence=True`,
+  `fail_closed_on_duplicate_authority=True`,
+  `fail_closed_on_missing_artifact=True`,
+  `permanently_denied_units_never_selected=True`,
+  `needs_human_units_require_operator_go=True`,
+  `calls_execution_authority_classifier=False` (A20c is the only
+  classifier call site).
+- Module-source scan: stdlib + `reporting.roadmap_task_units` +
+  `reporting.roadmap_unit_authority` imports only; no
+  subprocess, no network, no `gh`, no `git`, no GitHub API, no
+  LLM, no `reporting.execution_authority` import.
+
+## 16. Cross-references
 
 - [`docs/governance/ade_development_lane_doctrine.md`](ade_development_lane_doctrine.md)
 - [`docs/governance/execution_authority.md`](execution_authority.md)

--- a/reporting/roadmap_next_unit.py
+++ b/reporting/roadmap_next_unit.py
@@ -1,0 +1,925 @@
+"""A20e — Deterministic Next-Buildable-Unit Selector (read-only).
+
+Pure stdlib-only read-only consumer of the A20b implementation-unit
+projection and the A20c unit-authority projection. Emits a
+deterministic projection at ``logs/roadmap_next_unit/latest.json``
+that names the single ``NextBuildableUnitSelection`` (or no
+selection at all if no unit is eligible) and the full filterable
+candidate list.
+
+A20e MUST NOT:
+
+* execute work;
+* create branches;
+* open PRs;
+* run tests or governance lint;
+* merge or deploy anything;
+* mutate any approval inbox, seed JSONL, queue, or upstream
+  artefact;
+* call the canonical ``execution_authority`` classifier (A20c is
+  the only authority surface);
+* activate Step 5 or Level 6 or grant N5b production-merge
+  authority;
+* grant runtime / trading / paper / shadow / live authority.
+
+A20e MAY:
+
+* read ``logs/roadmap_task_units/latest.json`` (A20b output);
+* read ``logs/roadmap_unit_authority/latest.json`` (A20c output);
+* apply deterministic filter + sort rules pinned by tests;
+* emit a sorted candidates[] list and at most one selected unit;
+* fail closed loudly with ``selection_status`` in a closed enum
+  and ``fail_closed = true`` on any ambiguity.
+
+Selection rules (pinned by tests):
+
+1. A unit is **BLOCKED** when:
+   - the A20b ``status`` is not in ``{"not_started", "ready"}``
+     (non-buildable status);
+   - no matching A20c authority decision exists;
+   - more than one matching A20c authority decision exists
+     (defence in depth);
+   - the A20c ``final_authority_class`` is
+     ``"PERMANENTLY_DENIED"``;
+   - the A20c ``final_authority_class`` is not in
+     ``{"AUTO_ALLOWED", "NEEDS_HUMAN"}``;
+   - any prerequisite is unknown (no unit by that id), or any
+     prerequisite has ``status != "merged"``.
+2. A unit is **NEEDS_HUMAN_GATED** when:
+   - it is not BLOCKED, and
+   - ``final_authority_class == "NEEDS_HUMAN"`` or
+     ``operator_gate != "none"``.
+3. A unit is **ELIGIBLE** when it is neither BLOCKED nor
+   NEEDS_HUMAN_GATED — i.e. ``AUTO_ALLOWED`` + ``operator_gate ==
+   "none"``.
+
+Selection prefers ``ELIGIBLE`` over ``NEEDS_HUMAN_GATED``. Ties
+within a tier are broken by the deterministic sort key:
+
+1. Roadmap phase order: v3.15.16, v3.15.17, …, v3.15.20,
+   addendum_1, addendum_2, addendum_3.
+2. Authority order: AUTO_ALLOWED before NEEDS_HUMAN.
+3. Risk order: LOW before MEDIUM before HIGH before UNKNOWN.
+4. Operator gate order: none before operator_go_required before
+   governance_bootstrap_pr_required.
+5. Implementation-unit id lex order.
+
+There are no hidden heuristics, no random ordering, and no
+timestamps anywhere except ``generated_at_utc``.
+
+CLI::
+
+    python -m reporting.roadmap_next_unit
+    python -m reporting.roadmap_next_unit --no-write
+    python -m reporting.roadmap_next_unit --status
+    python -m reporting.roadmap_next_unit --indent 2
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Final
+
+from reporting import roadmap_task_units as rtu
+from reporting import roadmap_unit_authority as rua
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[str] = "1.0"
+MODULE_VERSION: Final[str] = "v3.15.16.A20e"
+REPORT_KIND: Final[str] = "roadmap_next_unit"
+
+
+# ---------------------------------------------------------------------------
+# Step 5 + Level 6 invariants (Final constants — never flipped at runtime)
+# ---------------------------------------------------------------------------
+
+STEP5_ENABLED_SUBSTAGE: Final[str] = "none"
+step5_implementation_allowed: Final[bool] = False
+
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies
+# ---------------------------------------------------------------------------
+
+#: Selection-status vocabulary. Exactly seven values.
+NEXT_UNIT_SELECTION_STATUS: Final[tuple[str, ...]] = (
+    "OK_SELECTED",
+    "ALL_NEEDS_HUMAN_GATED",
+    "NO_ELIGIBLE_UNITS",
+    "ALL_PERMANENTLY_DENIED",
+    "ALL_BLOCKED_BY_PREREQUISITES",
+    "UPSTREAM_UNAVAILABLE",
+    "FAIL_CLOSED_INVARIANT",
+)
+
+#: Closed per-candidate block-reason vocabulary.
+NEXT_UNIT_BLOCK_REASON: Final[tuple[str, ...]] = (
+    "missing_unit_artifact",
+    "missing_authority_artifact",
+    "unknown_unit_status",
+    "non_buildable_status",
+    "permanently_denied_authority",
+    "unknown_authority",
+    "missing_authority_decision",
+    "duplicate_authority_decision",
+    "unsatisfied_prerequisite",
+    "unknown_prerequisite_target",
+    "operator_gate_required",
+    "fail_closed_unknown_evidence",
+)
+
+#: Per-candidate eligibility vocabulary.
+NEXT_UNIT_ELIGIBILITY: Final[tuple[str, ...]] = (
+    "ELIGIBLE",
+    "NEEDS_HUMAN_GATED",
+    "BLOCKED",
+)
+
+#: Closed source-artifact vocabulary. Exactly two upstreams.
+NEXT_UNIT_SOURCE: Final[tuple[str, ...]] = (
+    "logs/roadmap_task_units/latest.json",
+    "logs/roadmap_unit_authority/latest.json",
+)
+
+#: Selector-mode vocabulary. Today exactly one mode: ``default``
+#: (deterministic phase order). Future modes may be added under
+#: separate operator-go PRs.
+NEXT_UNIT_SELECTOR_MODE: Final[tuple[str, ...]] = ("default",)
+
+
+# ---------------------------------------------------------------------------
+# Pinned deterministic orderings
+# ---------------------------------------------------------------------------
+
+#: Roadmap-phase order as defined by A20a/A20b.
+_PHASE_ORDER: Final[tuple[str, ...]] = (
+    "v3.15.16",
+    "v3.15.17",
+    "v3.15.18",
+    "v3.15.19",
+    "v3.15.20",
+    "addendum_1",
+    "addendum_2",
+    "addendum_3",
+)
+
+#: Authority priority: AUTO_ALLOWED before NEEDS_HUMAN.
+#: ``PERMANENTLY_DENIED`` is never used in the sort key because
+#: such units are BLOCKED and never reach the eligible tier.
+_AUTHORITY_ORDER: Final[tuple[str, ...]] = (
+    "AUTO_ALLOWED",
+    "NEEDS_HUMAN",
+)
+
+#: Risk priority: LOW before MEDIUM before HIGH; UNKNOWN last.
+_RISK_ORDER: Final[tuple[str, ...]] = (
+    "LOW",
+    "MEDIUM",
+    "HIGH",
+    "UNKNOWN",
+)
+
+#: Operator-gate priority: none before operator_go_required before
+#: governance_bootstrap_pr_required.
+_OPERATOR_GATE_ORDER: Final[tuple[str, ...]] = (
+    "none",
+    "operator_go_required",
+    "governance_bootstrap_pr_required",
+)
+
+#: A unit's A20b status is **buildable** when it is in this closed
+#: set. Other A20b status values (``in_flight``, ``merged``,
+#: ``blocked``, ``human_needed``, ``permanently_denied``) keep the
+#: unit out of the candidate pool.
+_BUILDABLE_STATUS: Final[frozenset[str]] = frozenset({"not_started", "ready"})
+
+
+# ---------------------------------------------------------------------------
+# Schema field tuples (exact, ordered)
+# ---------------------------------------------------------------------------
+
+#: Per-candidate schema.
+NEXT_BUILDABLE_UNIT_CANDIDATE_FIELDS: Final[tuple[str, ...]] = (
+    "implementation_unit_id",
+    "roadmap_task_id",
+    "phase",
+    "title",
+    "status",
+    "risk_class",
+    "final_authority_class",
+    "operator_gate",
+    "prerequisites",
+    "prerequisites_satisfied",
+    "eligibility",
+    "block_reasons",
+    "deterministic_sort_key",
+    "source_units_artifact",
+    "source_authority_artifact",
+)
+
+#: Selection record schema.
+NEXT_BUILDABLE_UNIT_SELECTION_FIELDS: Final[tuple[str, ...]] = (
+    "selected_unit_id",
+    "selected_roadmap_task_id",
+    "selected_phase",
+    "selected_title",
+    "selection_status",
+    "selection_reason",
+    "selected_authority_class",
+    "selected_risk_class",
+    "selected_operator_gate",
+    "requires_operator_go",
+    "deterministic_sort_key",
+    "candidate_count",
+    "eligible_candidate_count",
+    "blocked_candidate_count",
+    "fail_closed",
+)
+
+#: Top-level projection schema.
+NEXT_BUILDABLE_UNIT_PROJECTION_FIELDS: Final[tuple[str, ...]] = (
+    "generated_at_utc",
+    "schema_version",
+    "module_version",
+    "source_units_schema_version",
+    "source_authority_schema_version",
+    "selector_mode",
+    "candidates",
+    "selection",
+    "selector_invariants",
+)
+
+
+# ---------------------------------------------------------------------------
+# Bounds
+# ---------------------------------------------------------------------------
+
+MAX_TITLE_LEN: Final[int] = 200
+MAX_REASON_LEN: Final[int] = 80
+MAX_CANDIDATES: Final[int] = 256
+MAX_BLOCK_REASONS_PER_CANDIDATE: Final[int] = 8
+
+
+# ---------------------------------------------------------------------------
+# Artefact paths
+# ---------------------------------------------------------------------------
+
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "roadmap_next_unit"
+ARTIFACT_LATEST: Final[Path] = ARTIFACT_DIR / "latest.json"
+ARTIFACT_RELATIVE_PATH: Final[str] = "logs/roadmap_next_unit/latest.json"
+
+#: Atomic-write allowlist (POSIX substring). Any write target whose
+#: path does not contain this substring is refused with
+#: ``ValueError``.
+_WRITE_PREFIX: Final[str] = "logs/roadmap_next_unit/"
+
+#: Upstream relative paths.
+_UNITS_REL_PATH: Final[str] = "logs/roadmap_task_units/latest.json"
+_AUTHORITY_REL_PATH: Final[str] = "logs/roadmap_unit_authority/latest.json"
+
+
+# ---------------------------------------------------------------------------
+# Selector invariants emitted on every projection
+# ---------------------------------------------------------------------------
+
+_BASE_SELECTOR_INVARIANTS: Final[dict[str, bool]] = {
+    "deterministic_selection": True,
+    "no_random_ordering": True,
+    "no_llm_judgment": True,
+    "no_fuzzy_parsing": True,
+    "no_work_execution": True,
+    "no_branch_creation": True,
+    "no_pr_creation": True,
+    "no_merge_or_deploy": True,
+    "no_mutation_routes": True,
+    "no_approval_buttons": True,
+    "no_runtime_trading_authority": True,
+    "no_step5_runtime": True,
+    "no_level6": True,
+    "no_production_merge_authority": True,
+    "step5_implementation_allowed": False,
+    "mutates_a20b_artifact": False,
+    "mutates_a20c_artifact": False,
+    "writes_only_roadmap_next_unit_log": True,
+    "writes_to_seed_jsonl": False,
+    "writes_to_delegation_seed_jsonl": False,
+    "writes_to_generated_seed_jsonl": False,
+    "calls_llm_or_external_api": False,
+    "uses_subprocess_or_network": False,
+    "calls_execution_authority_classifier": False,  # A20c is the only classifier call site
+    "fail_closed_on_unknown_evidence": True,
+    "fail_closed_on_duplicate_authority": True,
+    "fail_closed_on_missing_artifact": True,
+    "permanently_denied_units_never_selected": True,
+    "needs_human_units_require_operator_go": True,
+}
+
+
+# ---------------------------------------------------------------------------
+# Utility helpers
+# ---------------------------------------------------------------------------
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _bounded_str(value: Any, max_len: int) -> str:
+    if not isinstance(value, str):
+        return ""
+    if len(value) <= max_len:
+        return value
+    return value[:max_len]
+
+
+def _order_index(value: Any, ordering: tuple[str, ...]) -> int:
+    """Return the index of ``value`` in ``ordering``, or
+    ``len(ordering)`` for unknown values (sorts last)."""
+    if not isinstance(value, str):
+        return len(ordering)
+    try:
+        return ordering.index(value)
+    except ValueError:
+        return len(ordering)
+
+
+def _load_json_artifact(
+    path: Path,
+) -> tuple[str, dict[str, Any] | None, str | None]:
+    """Best-effort JSON read. Returns ``(status, payload, error)``
+    where ``status ∈ {"ok", "absent", "malformed"}``. Never raises.
+    """
+    if not path.is_file():
+        return ("absent", None, None)
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        return ("malformed", None, _bounded_str(repr(exc), MAX_REASON_LEN))
+    try:
+        payload = json.loads(text)
+    except (TypeError, ValueError) as exc:
+        return ("malformed", None, _bounded_str(str(exc), MAX_REASON_LEN))
+    if not isinstance(payload, dict):
+        return ("malformed", None, "payload_is_not_a_dict")
+    return ("ok", payload, None)
+
+
+# ---------------------------------------------------------------------------
+# Candidate construction
+# ---------------------------------------------------------------------------
+
+
+def _build_candidate(
+    unit: dict[str, Any],
+    *,
+    units_by_id: dict[str, dict[str, Any]],
+    decisions_by_unit_id: dict[str, list[dict[str, Any]]],
+) -> dict[str, Any]:
+    """Build one ``NextBuildableUnitCandidate`` record."""
+    unit_id = _bounded_str(unit.get("id"), 200)
+    task_id = _bounded_str(unit.get("roadmap_task_id"), 200)
+    phase = _bounded_str(unit.get("phase"), 64)
+    title = _bounded_str(unit.get("title"), MAX_TITLE_LEN)
+    status = _bounded_str(unit.get("status"), 32)
+    risk_class = _bounded_str(unit.get("risk_class"), 16)
+    operator_gate = _bounded_str(unit.get("operator_gate"), 64)
+    raw_prereqs = unit.get("prerequisites") or []
+    if isinstance(raw_prereqs, list):
+        prerequisites = [
+            _bounded_str(p, 200) for p in raw_prereqs if isinstance(p, str)
+        ]
+    else:
+        prerequisites = []
+
+    block_reasons: list[str] = []
+
+    # --- A20b status check -------------------------------------------------
+    if status not in rtu.UNIT_STATUS:
+        block_reasons.append("unknown_unit_status")
+    elif status not in _BUILDABLE_STATUS:
+        block_reasons.append("non_buildable_status")
+
+    # --- A20c authority lookup --------------------------------------------
+    matching = decisions_by_unit_id.get(unit_id, [])
+    final_authority_class = ""
+    if not matching:
+        block_reasons.append("missing_authority_decision")
+    elif len(matching) > 1:
+        block_reasons.append("duplicate_authority_decision")
+    else:
+        decision = matching[0]
+        final_authority_class = _bounded_str(
+            decision.get("final_authority_class"), 32
+        )
+        if final_authority_class == "PERMANENTLY_DENIED":
+            block_reasons.append("permanently_denied_authority")
+        elif final_authority_class not in _AUTHORITY_ORDER:
+            # Unknown / missing / fail-safe value.
+            block_reasons.append("unknown_authority")
+
+    # --- Prerequisite check ------------------------------------------------
+    prereqs_satisfied = True
+    if prerequisites:
+        for prereq_id in prerequisites:
+            prereq_unit = units_by_id.get(prereq_id)
+            if prereq_unit is None:
+                if "unknown_prerequisite_target" not in block_reasons:
+                    block_reasons.append("unknown_prerequisite_target")
+                prereqs_satisfied = False
+            else:
+                prereq_status = prereq_unit.get("status")
+                if prereq_status != "merged":
+                    if "unsatisfied_prerequisite" not in block_reasons:
+                        block_reasons.append("unsatisfied_prerequisite")
+                    prereqs_satisfied = False
+
+    # --- Eligibility -------------------------------------------------------
+    if block_reasons:
+        eligibility = "BLOCKED"
+    elif (
+        final_authority_class == "NEEDS_HUMAN"
+        or operator_gate != "none"
+    ):
+        eligibility = "NEEDS_HUMAN_GATED"
+        # Annotate the gate reason as a non-blocking note (does not
+        # appear in block_reasons because the unit is not BLOCKED).
+    else:
+        eligibility = "ELIGIBLE"
+
+    # --- Deterministic sort key -------------------------------------------
+    # The eligibility tier (ELIGIBLE first, then NEEDS_HUMAN_GATED,
+    # then BLOCKED) is applied at selection time, not in this key.
+    # This key gives a fully deterministic intra-tier ordering.
+    sort_key: list[Any] = [
+        _order_index(phase, _PHASE_ORDER),
+        _order_index(final_authority_class, _AUTHORITY_ORDER),
+        _order_index(risk_class, _RISK_ORDER),
+        _order_index(operator_gate, _OPERATOR_GATE_ORDER),
+        unit_id,
+    ]
+
+    # Bound the block-reasons list.
+    bounded_block_reasons = block_reasons[:MAX_BLOCK_REASONS_PER_CANDIDATE]
+    # Defensive: every block reason must be in the closed vocab.
+    bounded_block_reasons = [
+        r for r in bounded_block_reasons if r in NEXT_UNIT_BLOCK_REASON
+    ]
+
+    return {
+        "implementation_unit_id": unit_id,
+        "roadmap_task_id": task_id,
+        "phase": phase,
+        "title": title,
+        "status": status,
+        "risk_class": risk_class,
+        "final_authority_class": final_authority_class,
+        "operator_gate": operator_gate,
+        "prerequisites": list(prerequisites),
+        "prerequisites_satisfied": prereqs_satisfied,
+        "eligibility": eligibility,
+        "block_reasons": bounded_block_reasons,
+        "deterministic_sort_key": sort_key,
+        "source_units_artifact": _UNITS_REL_PATH,
+        "source_authority_artifact": _AUTHORITY_REL_PATH,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Selection
+# ---------------------------------------------------------------------------
+
+
+def _empty_selection(
+    *,
+    status: str,
+    reason: str,
+    candidate_count: int,
+    eligible_count: int,
+    blocked_count: int,
+    fail_closed: bool,
+) -> dict[str, Any]:
+    return {
+        "selected_unit_id": "",
+        "selected_roadmap_task_id": "",
+        "selected_phase": "",
+        "selected_title": "",
+        "selection_status": status,
+        "selection_reason": _bounded_str(reason, MAX_REASON_LEN),
+        "selected_authority_class": "",
+        "selected_risk_class": "",
+        "selected_operator_gate": "",
+        "requires_operator_go": False,
+        "deterministic_sort_key": [],
+        "candidate_count": candidate_count,
+        "eligible_candidate_count": eligible_count,
+        "blocked_candidate_count": blocked_count,
+        "fail_closed": fail_closed,
+    }
+
+
+def _select_from_candidates(candidates: list[dict[str, Any]]) -> dict[str, Any]:
+    total = len(candidates)
+    eligible = [c for c in candidates if c["eligibility"] != "BLOCKED"]
+    blocked = [c for c in candidates if c["eligibility"] == "BLOCKED"]
+    eligible_count = len(eligible)
+    blocked_count = len(blocked)
+
+    if total == 0:
+        return _empty_selection(
+            status="NO_ELIGIBLE_UNITS",
+            reason="upstream_returned_zero_units",
+            candidate_count=0,
+            eligible_count=0,
+            blocked_count=0,
+            fail_closed=True,
+        )
+
+    if not eligible:
+        # All blocked. Drill into the dominant reason category.
+        reasons: set[str] = set()
+        for c in candidates:
+            for r in c["block_reasons"]:
+                reasons.add(r)
+        if reasons == {"permanently_denied_authority"}:
+            status = "ALL_PERMANENTLY_DENIED"
+            reason_str = "all_units_permanently_denied_by_a20c"
+        elif reasons and reasons.issubset(
+            {"unsatisfied_prerequisite", "unknown_prerequisite_target"}
+        ):
+            status = "ALL_BLOCKED_BY_PREREQUISITES"
+            reason_str = "all_units_blocked_by_unresolved_prerequisites"
+        elif reasons & {
+            "duplicate_authority_decision",
+            "unknown_authority",
+            "missing_authority_decision",
+            "unknown_unit_status",
+            "fail_closed_unknown_evidence",
+        }:
+            status = "FAIL_CLOSED_INVARIANT"
+            reason_str = "fail_closed_on_unknown_or_duplicate_evidence"
+        else:
+            status = "NO_ELIGIBLE_UNITS"
+            reason_str = "no_buildable_unit_among_candidates"
+        return _empty_selection(
+            status=status,
+            reason=reason_str,
+            candidate_count=total,
+            eligible_count=0,
+            blocked_count=blocked_count,
+            fail_closed=True,
+        )
+
+    # Have eligible — prefer ELIGIBLE over NEEDS_HUMAN_GATED.
+    # The candidates list is already sorted by deterministic_sort_key
+    # ascending; partition stably to preserve intra-tier order.
+    pure_eligible = [c for c in eligible if c["eligibility"] == "ELIGIBLE"]
+    gated_eligible = [
+        c for c in eligible if c["eligibility"] == "NEEDS_HUMAN_GATED"
+    ]
+
+    if pure_eligible:
+        selected = pure_eligible[0]
+        status = "OK_SELECTED"
+        reason_str = "auto_allowed_candidate_selected_by_deterministic_sort"
+    else:
+        # Every eligible candidate needs operator-go. Still
+        # deterministic; still read-only; still no execution.
+        selected = gated_eligible[0]
+        status = "ALL_NEEDS_HUMAN_GATED"
+        reason_str = "all_eligible_candidates_require_operator_go"
+
+    requires_go = bool(
+        selected["final_authority_class"] == "NEEDS_HUMAN"
+        or selected["operator_gate"] != "none"
+    )
+
+    return {
+        "selected_unit_id": selected["implementation_unit_id"],
+        "selected_roadmap_task_id": selected["roadmap_task_id"],
+        "selected_phase": selected["phase"],
+        "selected_title": selected["title"],
+        "selection_status": status,
+        "selection_reason": _bounded_str(reason_str, MAX_REASON_LEN),
+        "selected_authority_class": selected["final_authority_class"],
+        "selected_risk_class": selected["risk_class"],
+        "selected_operator_gate": selected["operator_gate"],
+        "requires_operator_go": requires_go,
+        "deterministic_sort_key": list(selected["deterministic_sort_key"]),
+        "candidate_count": total,
+        "eligible_candidate_count": eligible_count,
+        "blocked_candidate_count": blocked_count,
+        "fail_closed": False,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Snapshot assembly
+# ---------------------------------------------------------------------------
+
+
+def collect_snapshot(
+    *,
+    repo_root: Path | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    """Build the deterministic next-buildable-unit projection.
+
+    Reads ``logs/roadmap_task_units/latest.json`` and
+    ``logs/roadmap_unit_authority/latest.json`` from disk. Fails
+    closed if either upstream is absent or malformed.
+    """
+    root = repo_root if repo_root is not None else REPO_ROOT
+    ts = generated_at_utc if generated_at_utc is not None else _utcnow()
+
+    units_status, units_payload, units_err = _load_json_artifact(
+        root / _UNITS_REL_PATH
+    )
+    auth_status, auth_payload, auth_err = _load_json_artifact(
+        root / _AUTHORITY_REL_PATH
+    )
+
+    units_schema_version: str | int = ""
+    auth_schema_version: str | int = ""
+
+    if units_status != "ok" or auth_status != "ok":
+        # Fail closed loudly. Record the missing artefact in
+        # selection_reason; selection_status carries the closed-vocab
+        # signal.
+        if units_status != "ok":
+            block_reason = "missing_unit_artifact"
+            err_detail = units_err or units_status
+        else:
+            block_reason = "missing_authority_artifact"
+            err_detail = auth_err or auth_status
+        selection = _empty_selection(
+            status="UPSTREAM_UNAVAILABLE",
+            reason=f"{block_reason}:{err_detail}",
+            candidate_count=0,
+            eligible_count=0,
+            blocked_count=0,
+            fail_closed=True,
+        )
+        return _envelope(
+            ts=ts,
+            units_schema_version=units_schema_version,
+            auth_schema_version=auth_schema_version,
+            candidates=[],
+            selection=selection,
+        )
+
+    units = units_payload.get("implementation_units") or []
+    decisions = auth_payload.get("authority_decisions") or []
+    units_schema_version = units_payload.get("schema_version", "")
+    auth_schema_version = auth_payload.get("schema_version", "")
+
+    if not isinstance(units, list):
+        units = []
+    if not isinstance(decisions, list):
+        decisions = []
+
+    # Index helpers.
+    units_by_id: dict[str, dict[str, Any]] = {}
+    for u in units:
+        if isinstance(u, dict):
+            uid = u.get("id")
+            if isinstance(uid, str) and uid:
+                units_by_id[uid] = u
+
+    decisions_by_unit_id: dict[str, list[dict[str, Any]]] = {}
+    for d in decisions:
+        if isinstance(d, dict):
+            did = d.get("implementation_unit_id")
+            if isinstance(did, str) and did:
+                decisions_by_unit_id.setdefault(did, []).append(d)
+
+    # Build candidates.
+    candidates: list[dict[str, Any]] = []
+    for u in units[:MAX_CANDIDATES]:
+        if not isinstance(u, dict):
+            continue
+        uid = u.get("id")
+        if not isinstance(uid, str) or not uid:
+            continue
+        cand = _build_candidate(
+            u,
+            units_by_id=units_by_id,
+            decisions_by_unit_id=decisions_by_unit_id,
+        )
+        candidates.append(cand)
+
+    candidates.sort(key=lambda c: tuple(c["deterministic_sort_key"]))
+
+    selection = _select_from_candidates(candidates)
+
+    return _envelope(
+        ts=ts,
+        units_schema_version=units_schema_version,
+        auth_schema_version=auth_schema_version,
+        candidates=candidates,
+        selection=selection,
+    )
+
+
+def _envelope(
+    *,
+    ts: str,
+    units_schema_version: str | int,
+    auth_schema_version: str | int,
+    candidates: list[dict[str, Any]],
+    selection: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": ts,
+        "step5_enabled_substage": STEP5_ENABLED_SUBSTAGE,
+        "step5_implementation_allowed": step5_implementation_allowed,
+        "source_units_module_version": rtu.MODULE_VERSION,
+        "source_units_schema_version": units_schema_version,
+        "source_authority_module_version": rua.MODULE_VERSION,
+        "source_authority_schema_version": auth_schema_version,
+        "selector_mode": "default",
+        "vocabularies": {
+            "next_unit_selection_status": list(NEXT_UNIT_SELECTION_STATUS),
+            "next_unit_block_reason": list(NEXT_UNIT_BLOCK_REASON),
+            "next_unit_eligibility": list(NEXT_UNIT_ELIGIBILITY),
+            "next_unit_source": list(NEXT_UNIT_SOURCE),
+            "next_unit_selector_mode": list(NEXT_UNIT_SELECTOR_MODE),
+            "phase_order": list(_PHASE_ORDER),
+            "authority_order": list(_AUTHORITY_ORDER),
+            "risk_order": list(_RISK_ORDER),
+            "operator_gate_order": list(_OPERATOR_GATE_ORDER),
+            "buildable_status": sorted(_BUILDABLE_STATUS),
+        },
+        "candidates": candidates,
+        "selection": selection,
+        "selector_invariants": dict(_BASE_SELECTOR_INVARIANTS),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Atomic write
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Atomically write ``payload`` as sorted-key indented JSON.
+    Refuses any path outside ``logs/roadmap_next_unit/``."""
+    posix = path.as_posix()
+    if _WRITE_PREFIX not in posix:
+        raise ValueError(
+            "roadmap_next_unit._atomic_write_json refuses "
+            f"non-selector-logs output path: {path}"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".roadmap_next_unit.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_outputs(snapshot: dict[str, Any]) -> Path:
+    _atomic_write_json(ARTIFACT_LATEST, snapshot)
+    return ARTIFACT_LATEST
+
+
+# ---------------------------------------------------------------------------
+# Status renderer
+# ---------------------------------------------------------------------------
+
+
+def _render_status(snapshot: dict[str, Any]) -> str:
+    sel = snapshot["selection"]
+    inv = snapshot["selector_invariants"]
+    cands = snapshot["candidates"]
+    lines = [
+        f"roadmap_next_unit {snapshot['module_version']} "
+        f"schema={snapshot['schema_version']}",
+        f"generated_at_utc={snapshot['generated_at_utc']}",
+        f"selector_mode={snapshot['selector_mode']}",
+        f"candidates={len(cands)} eligible={sel['eligible_candidate_count']} "
+        f"blocked={sel['blocked_candidate_count']}",
+        f"selection_status={sel['selection_status']}",
+        f"selection_reason={sel['selection_reason']}",
+        f"selected_unit_id={sel['selected_unit_id']}",
+        f"selected_phase={sel['selected_phase']}",
+        f"selected_authority_class={sel['selected_authority_class']}",
+        f"selected_risk_class={sel['selected_risk_class']}",
+        f"selected_operator_gate={sel['selected_operator_gate']}",
+        f"requires_operator_go={sel['requires_operator_go']}",
+        f"fail_closed={sel['fail_closed']}",
+        (
+            "no_runtime_trading_authority="
+            f"{inv['no_runtime_trading_authority']} "
+            f"no_step5_runtime={inv['no_step5_runtime']} "
+            f"no_level6={inv['no_level6']} "
+            "no_production_merge_authority="
+            f"{inv['no_production_merge_authority']}"
+        ),
+        (
+            "no_work_execution="
+            f"{inv['no_work_execution']} "
+            f"no_branch_creation={inv['no_branch_creation']} "
+            f"no_pr_creation={inv['no_pr_creation']} "
+            f"no_merge_or_deploy={inv['no_merge_or_deploy']}"
+        ),
+        (
+            "deterministic_selection="
+            f"{inv['deterministic_selection']} "
+            "permanently_denied_units_never_selected="
+            f"{inv['permanently_denied_units_never_selected']}"
+        ),
+    ]
+    for c in cands:
+        lines.append(
+            f"  cand {c['implementation_unit_id']} phase={c['phase']} "
+            f"eligibility={c['eligibility']} "
+            f"authority={c['final_authority_class']} "
+            f"risk={c['risk_class']} "
+            f"gate={c['operator_gate']}"
+        )
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m reporting.roadmap_next_unit",
+        description=(
+            "A20e Deterministic Next-Buildable-Unit Selector. Read-only "
+            "deterministic projection over the A20b unit decomposition "
+            "and A20c authority verdicts. Does NOT execute work, "
+            "does NOT create branches, does NOT open PRs, does NOT "
+            "merge or deploy. Step 5 implementation remains BLOCKED."
+        ),
+    )
+    p.add_argument(
+        "--indent",
+        type=int,
+        default=2,
+        help="JSON indent for stdout output (0 for compact).",
+    )
+    p.add_argument(
+        "--no-write",
+        action="store_true",
+        help=(
+            "Do not persist logs/roadmap_next_unit/latest.json "
+            "(stdout only)."
+        ),
+    )
+    p.add_argument(
+        "--status",
+        action="store_true",
+        help=(
+            "Render a compact human-readable status summary to stdout "
+            "and exit. Does not write any artefact."
+        ),
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    snap = collect_snapshot()
+    if args.status:
+        sys.stdout.write(_render_status(snap))
+        return 0
+    indent = args.indent if args.indent and args.indent > 0 else None
+    if not args.no_write:
+        write_outputs(snap)
+    json.dump(snap, sys.stdout, indent=indent, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/reporting/roadmap_task_units.py
+++ b/reporting/roadmap_task_units.py
@@ -389,7 +389,7 @@ _DECOMPOSITION_INVARIANTS: Final[dict[str, bool]] = {
     "grants_live_authority": False,
     "calls_execution_authority_classifier": False,  # A20c flipped this on in its own projection
     "final_authority_classified": False,  # A20c flipped this on in its own projection
-    "next_buildable_selector_present": False,  # A20e will flip this on
+    "next_buildable_selector_present": True,  # A20e selects a deterministic next-buildable unit from A20b rows
     "aac_visibility_present": True,  # A20d surfaces A20b rows via the AAC aggregator
 }
 

--- a/reporting/roadmap_unit_authority.py
+++ b/reporting/roadmap_unit_authority.py
@@ -277,9 +277,10 @@ _BASE_AUTHORITY_INVARIANTS: Final[dict[str, bool]] = {
     "writes_to_delegation_seed_jsonl": False,
     "writes_to_generated_seed_jsonl": False,
     # A20d surfaces this projection in the AAC aggregator; A20e
-    # (next-buildable selector) remains unimplemented.
+    # selects a deterministic next-buildable unit from A20c
+    # authority decisions.
     "aac_visibility_present": True,
-    "next_buildable_selector_present": False,
+    "next_buildable_selector_present": True,
 }
 
 

--- a/tests/unit/test_roadmap_next_unit.py
+++ b/tests/unit/test_roadmap_next_unit.py
@@ -1,0 +1,1136 @@
+"""Unit tests for A20e — Deterministic Next-Buildable-Unit Selector.
+
+Pins:
+
+* closed vocabularies (NEXT_UNIT_SELECTION_STATUS,
+  NEXT_UNIT_BLOCK_REASON, NEXT_UNIT_ELIGIBILITY,
+  NEXT_UNIT_SOURCE, NEXT_UNIT_SELECTOR_MODE);
+* schema integrity (NextBuildableUnitCandidate,
+  NextBuildableUnitSelection, NextBuildableUnitProjection);
+* deterministic output with injected ``generated_at_utc``;
+* byte-identical output for identical input;
+* atomic write only under ``logs/roadmap_next_unit/``;
+* ``--no-write`` does not write; ``--status`` does not write;
+* missing unit artefact -> UPSTREAM_UNAVAILABLE, fail_closed=True;
+* missing authority artefact -> UPSTREAM_UNAVAILABLE,
+  fail_closed=True;
+* every candidate carries deterministic_sort_key;
+* selected candidate is stable across runs;
+* PERMANENTLY_DENIED units are never selected;
+* unknown authority -> BLOCKED;
+* missing authority decision -> BLOCKED;
+* duplicate authority decisions -> BLOCKED with
+  ``duplicate_authority_decision``;
+* missing prerequisite target -> BLOCKED;
+* unsatisfied prerequisite (status != "merged") -> BLOCKED;
+* satisfied prerequisite (all merged) -> not blocked on that
+  account;
+* NEEDS_HUMAN units may be selected only as operator-gated
+  candidate; ``requires_operator_go`` is True for any selected
+  unit whose authority is NEEDS_HUMAN or whose operator_gate is
+  not "none";
+* the selector never executes work, never creates branches /
+  PRs, never merges or deploys;
+* selector_invariants pin no Step 5, no Level 6, no production
+  merge authority, no runtime/trading authority, no mutation
+  routes, no approval buttons;
+* no forbidden imports / runtime tokens in module source.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reporting import roadmap_next_unit as rnu
+from reporting import roadmap_task_units as rtu
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+_FROZEN_UTC = "2026-05-18T20:00:00Z"
+
+
+def _baseline_unit(**overrides: Any) -> dict[str, Any]:
+    """Synthetic A20b-shape unit. Every field A20e reads is present."""
+    base: dict[str, Any] = {
+        "id": "syn_unit_a",
+        "roadmap_task_id": "phase_v3_15_16",
+        "title": "Synthetic eligible unit",
+        "phase": "v3.15.16",
+        "unit_kind": "reporting_module",
+        "target_layer": "reporting",
+        "source_requirement_ids": [],
+        "expected_files": ["reporting/synthetic.py"],
+        "forbidden_files": [],
+        "forbidden_surface_reasons": [],
+        "required_tests": [],
+        "definition_of_done": [],
+        "stop_conditions": [],
+        "prerequisites": [],
+        "risk_class": "LOW",
+        "authority_hint": "AUTO_ALLOWED_CANDIDATE",
+        "operator_gate": "none",
+        "status": "not_started",
+    }
+    base.update(overrides)
+    return base
+
+
+def _baseline_decision(**overrides: Any) -> dict[str, Any]:
+    """Synthetic A20c-shape authority decision."""
+    base: dict[str, Any] = {
+        "implementation_unit_id": "syn_unit_a",
+        "roadmap_task_id": "phase_v3_15_16",
+        "phase": "v3.15.16",
+        "final_authority_class": "AUTO_ALLOWED",
+        "max_severity": 0,
+        "evidence": [],
+        "requires_operator_go": False,
+        "permanently_denied": False,
+        "deny_reasons": [],
+        "classifier_used": True,
+        "fail_closed": False,
+    }
+    base.update(overrides)
+    return base
+
+
+def _write_units_artifact(
+    tmp_path: Path, units: list[dict[str, Any]]
+) -> Path:
+    target = tmp_path / "logs" / "roadmap_task_units" / "latest.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0",
+                "module_version": "v3.15.16.A20b",
+                "report_kind": "roadmap_task_units",
+                "generated_at_utc": "2026-05-18T08:00:00Z",
+                "implementation_units": units,
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    return target
+
+
+def _write_authority_artifact(
+    tmp_path: Path, decisions: list[dict[str, Any]]
+) -> Path:
+    target = tmp_path / "logs" / "roadmap_unit_authority" / "latest.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0",
+                "module_version": "v3.15.16.A20c",
+                "report_kind": "roadmap_unit_authority",
+                "generated_at_utc": "2026-05-18T08:00:00Z",
+                "authority_decisions": decisions,
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    return target
+
+
+def _snap(tmp_path: Path) -> dict[str, Any]:
+    return rnu.collect_snapshot(
+        repo_root=tmp_path, generated_at_utc=_FROZEN_UTC
+    )
+
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies
+# ---------------------------------------------------------------------------
+
+
+def test_selection_status_vocab_is_closed_exact() -> None:
+    assert rnu.NEXT_UNIT_SELECTION_STATUS == (
+        "OK_SELECTED",
+        "ALL_NEEDS_HUMAN_GATED",
+        "NO_ELIGIBLE_UNITS",
+        "ALL_PERMANENTLY_DENIED",
+        "ALL_BLOCKED_BY_PREREQUISITES",
+        "UPSTREAM_UNAVAILABLE",
+        "FAIL_CLOSED_INVARIANT",
+    )
+
+
+def test_block_reason_vocab_is_closed_exact() -> None:
+    assert rnu.NEXT_UNIT_BLOCK_REASON == (
+        "missing_unit_artifact",
+        "missing_authority_artifact",
+        "unknown_unit_status",
+        "non_buildable_status",
+        "permanently_denied_authority",
+        "unknown_authority",
+        "missing_authority_decision",
+        "duplicate_authority_decision",
+        "unsatisfied_prerequisite",
+        "unknown_prerequisite_target",
+        "operator_gate_required",
+        "fail_closed_unknown_evidence",
+    )
+
+
+def test_eligibility_vocab_is_closed_exact() -> None:
+    assert rnu.NEXT_UNIT_ELIGIBILITY == (
+        "ELIGIBLE",
+        "NEEDS_HUMAN_GATED",
+        "BLOCKED",
+    )
+
+
+def test_source_vocab_is_closed_exact() -> None:
+    assert rnu.NEXT_UNIT_SOURCE == (
+        "logs/roadmap_task_units/latest.json",
+        "logs/roadmap_unit_authority/latest.json",
+    )
+
+
+def test_selector_mode_vocab_is_closed_exact() -> None:
+    assert rnu.NEXT_UNIT_SELECTOR_MODE == ("default",)
+
+
+def test_phase_order_matches_a20a_phase_list() -> None:
+    """Phase order must include every PHASE value A20b can emit."""
+    # A20a defines the canonical phase list. A20b mirrors it via
+    # rtu.collect_snapshot()'s catalog cross-reference.
+    for phase in (
+        "v3.15.16",
+        "v3.15.17",
+        "v3.15.18",
+        "v3.15.19",
+        "v3.15.20",
+        "addendum_1",
+    ):
+        assert phase in rnu._PHASE_ORDER
+
+
+def test_authority_order_does_not_include_permanently_denied() -> None:
+    """PERMANENTLY_DENIED is never used as a sort tier; it is a
+    block-only verdict and is filtered out before sorting."""
+    assert "PERMANENTLY_DENIED" not in rnu._AUTHORITY_ORDER
+    assert rnu._AUTHORITY_ORDER == ("AUTO_ALLOWED", "NEEDS_HUMAN")
+
+
+def test_risk_order_matches_classifier_enum() -> None:
+    assert rnu._RISK_ORDER == ("LOW", "MEDIUM", "HIGH", "UNKNOWN")
+
+
+def test_operator_gate_order_matches_a20b_enum() -> None:
+    assert rnu._OPERATOR_GATE_ORDER == rtu.OPERATOR_GATE
+
+
+def test_buildable_status_subset_of_a20b_unit_status() -> None:
+    for s in rnu._BUILDABLE_STATUS:
+        assert s in rtu.UNIT_STATUS
+
+
+# ---------------------------------------------------------------------------
+# Schema integrity
+# ---------------------------------------------------------------------------
+
+
+def test_candidate_field_list_exact() -> None:
+    assert rnu.NEXT_BUILDABLE_UNIT_CANDIDATE_FIELDS == (
+        "implementation_unit_id",
+        "roadmap_task_id",
+        "phase",
+        "title",
+        "status",
+        "risk_class",
+        "final_authority_class",
+        "operator_gate",
+        "prerequisites",
+        "prerequisites_satisfied",
+        "eligibility",
+        "block_reasons",
+        "deterministic_sort_key",
+        "source_units_artifact",
+        "source_authority_artifact",
+    )
+
+
+def test_selection_field_list_exact() -> None:
+    assert rnu.NEXT_BUILDABLE_UNIT_SELECTION_FIELDS == (
+        "selected_unit_id",
+        "selected_roadmap_task_id",
+        "selected_phase",
+        "selected_title",
+        "selection_status",
+        "selection_reason",
+        "selected_authority_class",
+        "selected_risk_class",
+        "selected_operator_gate",
+        "requires_operator_go",
+        "deterministic_sort_key",
+        "candidate_count",
+        "eligible_candidate_count",
+        "blocked_candidate_count",
+        "fail_closed",
+    )
+
+
+def test_projection_field_list_exact() -> None:
+    assert rnu.NEXT_BUILDABLE_UNIT_PROJECTION_FIELDS == (
+        "generated_at_utc",
+        "schema_version",
+        "module_version",
+        "source_units_schema_version",
+        "source_authority_schema_version",
+        "selector_mode",
+        "candidates",
+        "selection",
+        "selector_invariants",
+    )
+
+
+def test_every_candidate_has_every_field(tmp_path: Path) -> None:
+    _write_units_artifact(tmp_path, [_baseline_unit()])
+    _write_authority_artifact(tmp_path, [_baseline_decision()])
+    snap = _snap(tmp_path)
+    for c in snap["candidates"]:
+        assert set(c.keys()) == set(
+            rnu.NEXT_BUILDABLE_UNIT_CANDIDATE_FIELDS
+        ), c
+
+
+def test_selection_has_every_field(tmp_path: Path) -> None:
+    _write_units_artifact(tmp_path, [_baseline_unit()])
+    _write_authority_artifact(tmp_path, [_baseline_decision()])
+    snap = _snap(tmp_path)
+    assert set(snap["selection"].keys()) == set(
+        rnu.NEXT_BUILDABLE_UNIT_SELECTION_FIELDS
+    )
+
+
+def test_projection_carries_every_top_level_field(tmp_path: Path) -> None:
+    _write_units_artifact(tmp_path, [_baseline_unit()])
+    _write_authority_artifact(tmp_path, [_baseline_decision()])
+    snap = _snap(tmp_path)
+    for field in rnu.NEXT_BUILDABLE_UNIT_PROJECTION_FIELDS:
+        assert field in snap, field
+
+
+# ---------------------------------------------------------------------------
+# Happy path: AUTO_ALLOWED unit gets selected
+# ---------------------------------------------------------------------------
+
+
+def test_auto_allowed_unit_is_selected(tmp_path: Path) -> None:
+    _write_units_artifact(tmp_path, [_baseline_unit()])
+    _write_authority_artifact(tmp_path, [_baseline_decision()])
+    snap = _snap(tmp_path)
+    sel = snap["selection"]
+    assert sel["selection_status"] == "OK_SELECTED"
+    assert sel["selected_unit_id"] == "syn_unit_a"
+    assert sel["selected_authority_class"] == "AUTO_ALLOWED"
+    assert sel["requires_operator_go"] is False
+    assert sel["fail_closed"] is False
+
+
+def test_eligibility_marker_on_candidate(tmp_path: Path) -> None:
+    _write_units_artifact(tmp_path, [_baseline_unit()])
+    _write_authority_artifact(tmp_path, [_baseline_decision()])
+    snap = _snap(tmp_path)
+    assert snap["candidates"][0]["eligibility"] == "ELIGIBLE"
+    assert snap["candidates"][0]["block_reasons"] == []
+    assert snap["candidates"][0]["prerequisites_satisfied"] is True
+
+
+# ---------------------------------------------------------------------------
+# PERMANENTLY_DENIED units are never selected
+# ---------------------------------------------------------------------------
+
+
+def test_permanently_denied_unit_is_never_selected(tmp_path: Path) -> None:
+    _write_units_artifact(tmp_path, [_baseline_unit()])
+    _write_authority_artifact(
+        tmp_path,
+        [
+            _baseline_decision(
+                final_authority_class="PERMANENTLY_DENIED",
+                permanently_denied=True,
+                deny_reasons=["denied_live_path_modification"],
+            )
+        ],
+    )
+    snap = _snap(tmp_path)
+    sel = snap["selection"]
+    assert sel["selected_unit_id"] == ""
+    assert sel["selection_status"] == "ALL_PERMANENTLY_DENIED"
+    assert sel["fail_closed"] is True
+    assert snap["candidates"][0]["eligibility"] == "BLOCKED"
+    assert (
+        "permanently_denied_authority"
+        in snap["candidates"][0]["block_reasons"]
+    )
+
+
+def test_mixed_pool_picks_auto_allowed_not_denied(tmp_path: Path) -> None:
+    """A pool with one PERMANENTLY_DENIED + one AUTO_ALLOWED must
+    select the AUTO_ALLOWED unit."""
+    auto_unit = _baseline_unit(id="syn_auto", title="auto-allowed unit")
+    denied_unit = _baseline_unit(
+        id="syn_denied", title="denied unit", phase="v3.15.17"
+    )
+    _write_units_artifact(tmp_path, [auto_unit, denied_unit])
+    _write_authority_artifact(
+        tmp_path,
+        [
+            _baseline_decision(implementation_unit_id="syn_auto"),
+            _baseline_decision(
+                implementation_unit_id="syn_denied",
+                phase="v3.15.17",
+                final_authority_class="PERMANENTLY_DENIED",
+                permanently_denied=True,
+                deny_reasons=["denied_live_path_modification"],
+            ),
+        ],
+    )
+    snap = _snap(tmp_path)
+    assert snap["selection"]["selected_unit_id"] == "syn_auto"
+
+
+# ---------------------------------------------------------------------------
+# Unknown / missing / duplicate authority fail closed
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_authority_blocks_candidate(tmp_path: Path) -> None:
+    _write_units_artifact(tmp_path, [_baseline_unit()])
+    _write_authority_artifact(
+        tmp_path,
+        [_baseline_decision(final_authority_class="NOT_A_REAL_CLASS")],
+    )
+    snap = _snap(tmp_path)
+    cand = snap["candidates"][0]
+    assert cand["eligibility"] == "BLOCKED"
+    assert "unknown_authority" in cand["block_reasons"]
+    assert snap["selection"]["selection_status"] == "FAIL_CLOSED_INVARIANT"
+    assert snap["selection"]["fail_closed"] is True
+
+
+def test_missing_authority_decision_blocks_candidate(tmp_path: Path) -> None:
+    _write_units_artifact(tmp_path, [_baseline_unit()])
+    _write_authority_artifact(tmp_path, [])
+    snap = _snap(tmp_path)
+    cand = snap["candidates"][0]
+    assert cand["eligibility"] == "BLOCKED"
+    assert "missing_authority_decision" in cand["block_reasons"]
+    assert snap["selection"]["fail_closed"] is True
+
+
+def test_duplicate_authority_decisions_block_candidate(
+    tmp_path: Path,
+) -> None:
+    _write_units_artifact(tmp_path, [_baseline_unit()])
+    _write_authority_artifact(
+        tmp_path,
+        [_baseline_decision(), _baseline_decision()],
+    )
+    snap = _snap(tmp_path)
+    cand = snap["candidates"][0]
+    assert cand["eligibility"] == "BLOCKED"
+    assert "duplicate_authority_decision" in cand["block_reasons"]
+    assert snap["selection"]["selection_status"] == "FAIL_CLOSED_INVARIANT"
+    assert snap["selection"]["fail_closed"] is True
+
+
+# ---------------------------------------------------------------------------
+# Prerequisites
+# ---------------------------------------------------------------------------
+
+
+def test_missing_prerequisite_target_blocks_candidate(tmp_path: Path) -> None:
+    unit = _baseline_unit(prerequisites=["nonexistent_unit"])
+    _write_units_artifact(tmp_path, [unit])
+    _write_authority_artifact(tmp_path, [_baseline_decision()])
+    snap = _snap(tmp_path)
+    cand = snap["candidates"][0]
+    assert cand["eligibility"] == "BLOCKED"
+    assert cand["prerequisites_satisfied"] is False
+    assert "unknown_prerequisite_target" in cand["block_reasons"]
+
+
+def test_unsatisfied_prerequisite_blocks_candidate(tmp_path: Path) -> None:
+    prereq = _baseline_unit(id="prereq_unit", status="in_flight")
+    unit = _baseline_unit(prerequisites=["prereq_unit"])
+    _write_units_artifact(tmp_path, [prereq, unit])
+    _write_authority_artifact(
+        tmp_path,
+        [
+            _baseline_decision(implementation_unit_id="prereq_unit"),
+            _baseline_decision(),
+        ],
+    )
+    snap = _snap(tmp_path)
+    main_cand = next(
+        c
+        for c in snap["candidates"]
+        if c["implementation_unit_id"] == "syn_unit_a"
+    )
+    assert main_cand["eligibility"] == "BLOCKED"
+    assert main_cand["prerequisites_satisfied"] is False
+    assert "unsatisfied_prerequisite" in main_cand["block_reasons"]
+
+
+def test_satisfied_prerequisite_allows_candidate(tmp_path: Path) -> None:
+    prereq = _baseline_unit(id="prereq_unit", status="merged")
+    unit = _baseline_unit(prerequisites=["prereq_unit"])
+    _write_units_artifact(tmp_path, [prereq, unit])
+    _write_authority_artifact(
+        tmp_path,
+        [
+            _baseline_decision(implementation_unit_id="prereq_unit"),
+            _baseline_decision(),
+        ],
+    )
+    snap = _snap(tmp_path)
+    main_cand = next(
+        c
+        for c in snap["candidates"]
+        if c["implementation_unit_id"] == "syn_unit_a"
+    )
+    assert main_cand["prerequisites_satisfied"] is True
+    # The prereq itself has status=merged which is not buildable, so
+    # only the main unit can be picked.
+    assert snap["selection"]["selected_unit_id"] == "syn_unit_a"
+
+
+def test_all_blocked_by_prerequisites_status(tmp_path: Path) -> None:
+    """If every candidate is blocked by unsatisfied / unknown
+    prerequisites, the selection_status is
+    ALL_BLOCKED_BY_PREREQUISITES."""
+    u1 = _baseline_unit(id="u1", prerequisites=["missing"])
+    u2 = _baseline_unit(
+        id="u2", prerequisites=["missing2"], phase="v3.15.17"
+    )
+    _write_units_artifact(tmp_path, [u1, u2])
+    _write_authority_artifact(
+        tmp_path,
+        [
+            _baseline_decision(implementation_unit_id="u1"),
+            _baseline_decision(implementation_unit_id="u2", phase="v3.15.17"),
+        ],
+    )
+    snap = _snap(tmp_path)
+    assert snap["selection"]["selection_status"] == "ALL_BLOCKED_BY_PREREQUISITES"
+
+
+# ---------------------------------------------------------------------------
+# NEEDS_HUMAN gated selection
+# ---------------------------------------------------------------------------
+
+
+def test_needs_human_units_can_be_selected_only_as_gated(tmp_path: Path) -> None:
+    unit = _baseline_unit(authority_hint="NEEDS_HUMAN_CANDIDATE")
+    _write_units_artifact(tmp_path, [unit])
+    _write_authority_artifact(
+        tmp_path,
+        [
+            _baseline_decision(
+                final_authority_class="NEEDS_HUMAN",
+                requires_operator_go=True,
+            )
+        ],
+    )
+    snap = _snap(tmp_path)
+    cand = snap["candidates"][0]
+    assert cand["eligibility"] == "NEEDS_HUMAN_GATED"
+    sel = snap["selection"]
+    assert sel["selection_status"] == "ALL_NEEDS_HUMAN_GATED"
+    assert sel["selected_unit_id"] == "syn_unit_a"
+    assert sel["requires_operator_go"] is True
+    assert sel["fail_closed"] is False
+
+
+def test_operator_gate_required_makes_unit_needs_human_gated(
+    tmp_path: Path,
+) -> None:
+    """An AUTO_ALLOWED authority with operator_gate != none must
+    classify as NEEDS_HUMAN_GATED, not ELIGIBLE."""
+    unit = _baseline_unit(operator_gate="operator_go_required")
+    _write_units_artifact(tmp_path, [unit])
+    _write_authority_artifact(tmp_path, [_baseline_decision()])
+    snap = _snap(tmp_path)
+    cand = snap["candidates"][0]
+    assert cand["eligibility"] == "NEEDS_HUMAN_GATED"
+    assert snap["selection"]["requires_operator_go"] is True
+
+
+def test_eligible_preferred_over_gated(tmp_path: Path) -> None:
+    """When both pure-ELIGIBLE and NEEDS_HUMAN_GATED candidates
+    exist, the selector picks the ELIGIBLE one even if the gated
+    candidate would otherwise come earlier in the sort key."""
+    # Eligible unit in phase v3.15.20 (later in phase order).
+    eligible = _baseline_unit(
+        id="eligible_late", phase="v3.15.20", risk_class="LOW"
+    )
+    # Gated unit in phase v3.15.16 (would normally come first).
+    gated = _baseline_unit(
+        id="gated_early",
+        phase="v3.15.16",
+        authority_hint="NEEDS_HUMAN_CANDIDATE",
+        operator_gate="operator_go_required",
+    )
+    _write_units_artifact(tmp_path, [gated, eligible])
+    _write_authority_artifact(
+        tmp_path,
+        [
+            _baseline_decision(
+                implementation_unit_id="gated_early",
+                phase="v3.15.16",
+                final_authority_class="NEEDS_HUMAN",
+                requires_operator_go=True,
+            ),
+            _baseline_decision(
+                implementation_unit_id="eligible_late",
+                phase="v3.15.20",
+            ),
+        ],
+    )
+    snap = _snap(tmp_path)
+    assert snap["selection"]["selected_unit_id"] == "eligible_late"
+
+
+# ---------------------------------------------------------------------------
+# Non-buildable status
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "non_buildable_status",
+    ["in_flight", "merged", "blocked", "human_needed", "permanently_denied"],
+)
+def test_non_buildable_status_blocks_candidate(
+    tmp_path: Path, non_buildable_status: str
+) -> None:
+    unit = _baseline_unit(status=non_buildable_status)
+    _write_units_artifact(tmp_path, [unit])
+    _write_authority_artifact(tmp_path, [_baseline_decision()])
+    snap = _snap(tmp_path)
+    cand = snap["candidates"][0]
+    assert cand["eligibility"] == "BLOCKED"
+    assert "non_buildable_status" in cand["block_reasons"]
+
+
+def test_unknown_unit_status_blocks_candidate(tmp_path: Path) -> None:
+    unit = _baseline_unit(status="not_a_real_status")
+    _write_units_artifact(tmp_path, [unit])
+    _write_authority_artifact(tmp_path, [_baseline_decision()])
+    snap = _snap(tmp_path)
+    cand = snap["candidates"][0]
+    assert cand["eligibility"] == "BLOCKED"
+    assert "unknown_unit_status" in cand["block_reasons"]
+    assert snap["selection"]["fail_closed"] is True
+
+
+# ---------------------------------------------------------------------------
+# Deterministic sort key
+# ---------------------------------------------------------------------------
+
+
+def test_every_candidate_has_deterministic_sort_key(tmp_path: Path) -> None:
+    units = [
+        _baseline_unit(id="ux", phase="v3.15.17"),
+        _baseline_unit(id="uy", phase="v3.15.16"),
+    ]
+    decisions = [
+        _baseline_decision(implementation_unit_id="ux", phase="v3.15.17"),
+        _baseline_decision(implementation_unit_id="uy", phase="v3.15.16"),
+    ]
+    _write_units_artifact(tmp_path, units)
+    _write_authority_artifact(tmp_path, decisions)
+    snap = _snap(tmp_path)
+    for c in snap["candidates"]:
+        assert isinstance(c["deterministic_sort_key"], list)
+        assert len(c["deterministic_sort_key"]) == 5
+
+
+def test_candidates_sorted_by_phase_then_authority_then_risk(
+    tmp_path: Path,
+) -> None:
+    # Three units with different phases; the v3.15.16 one wins.
+    u_late = _baseline_unit(id="u_late", phase="v3.15.20")
+    u_early = _baseline_unit(id="u_early", phase="v3.15.16")
+    u_mid = _baseline_unit(id="u_mid", phase="v3.15.18")
+    _write_units_artifact(tmp_path, [u_late, u_mid, u_early])
+    _write_authority_artifact(
+        tmp_path,
+        [
+            _baseline_decision(implementation_unit_id="u_late", phase="v3.15.20"),
+            _baseline_decision(implementation_unit_id="u_mid", phase="v3.15.18"),
+            _baseline_decision(implementation_unit_id="u_early", phase="v3.15.16"),
+        ],
+    )
+    snap = _snap(tmp_path)
+    assert snap["selection"]["selected_unit_id"] == "u_early"
+
+
+def test_sort_breaks_ties_with_id_lex_order(tmp_path: Path) -> None:
+    u_b = _baseline_unit(id="u_b")
+    u_a = _baseline_unit(id="u_a")
+    _write_units_artifact(tmp_path, [u_b, u_a])
+    _write_authority_artifact(
+        tmp_path,
+        [
+            _baseline_decision(implementation_unit_id="u_b"),
+            _baseline_decision(implementation_unit_id="u_a"),
+        ],
+    )
+    snap = _snap(tmp_path)
+    # Same phase / authority / risk / gate → id lex order picks "u_a".
+    assert snap["selection"]["selected_unit_id"] == "u_a"
+
+
+def test_selection_stable_across_runs(tmp_path: Path) -> None:
+    units = [_baseline_unit(id="u1"), _baseline_unit(id="u2")]
+    decisions = [
+        _baseline_decision(implementation_unit_id="u1"),
+        _baseline_decision(implementation_unit_id="u2"),
+    ]
+    _write_units_artifact(tmp_path, units)
+    _write_authority_artifact(tmp_path, decisions)
+    snap_a = _snap(tmp_path)
+    snap_b = _snap(tmp_path)
+    assert (
+        snap_a["selection"]["selected_unit_id"]
+        == snap_b["selection"]["selected_unit_id"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed on missing artefacts
+# ---------------------------------------------------------------------------
+
+
+def test_missing_unit_artifact_fails_closed(tmp_path: Path) -> None:
+    _write_authority_artifact(tmp_path, [_baseline_decision()])
+    snap = _snap(tmp_path)
+    sel = snap["selection"]
+    assert sel["selection_status"] == "UPSTREAM_UNAVAILABLE"
+    assert sel["fail_closed"] is True
+    assert sel["selected_unit_id"] == ""
+    assert "missing_unit_artifact" in sel["selection_reason"]
+
+
+def test_missing_authority_artifact_fails_closed(tmp_path: Path) -> None:
+    _write_units_artifact(tmp_path, [_baseline_unit()])
+    snap = _snap(tmp_path)
+    sel = snap["selection"]
+    assert sel["selection_status"] == "UPSTREAM_UNAVAILABLE"
+    assert sel["fail_closed"] is True
+    assert "missing_authority_artifact" in sel["selection_reason"]
+
+
+def test_both_artifacts_missing_fails_closed(tmp_path: Path) -> None:
+    snap = _snap(tmp_path)
+    sel = snap["selection"]
+    assert sel["selection_status"] == "UPSTREAM_UNAVAILABLE"
+    assert sel["fail_closed"] is True
+
+
+def test_malformed_unit_artifact_fails_closed(tmp_path: Path) -> None:
+    target = tmp_path / "logs" / "roadmap_task_units" / "latest.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("{not valid json", encoding="utf-8")
+    _write_authority_artifact(tmp_path, [_baseline_decision()])
+    snap = _snap(tmp_path)
+    assert snap["selection"]["selection_status"] == "UPSTREAM_UNAVAILABLE"
+    assert snap["selection"]["fail_closed"] is True
+
+
+def test_empty_units_returns_no_eligible(tmp_path: Path) -> None:
+    _write_units_artifact(tmp_path, [])
+    _write_authority_artifact(tmp_path, [])
+    snap = _snap(tmp_path)
+    assert snap["selection"]["selection_status"] == "NO_ELIGIBLE_UNITS"
+    assert snap["selection"]["fail_closed"] is True
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_deterministic_with_injected_ts(tmp_path: Path) -> None:
+    _write_units_artifact(tmp_path, [_baseline_unit()])
+    _write_authority_artifact(tmp_path, [_baseline_decision()])
+    a = _snap(tmp_path)
+    b = _snap(tmp_path)
+    assert a == b
+
+
+def test_serialised_output_byte_identical_with_injected_ts(
+    tmp_path: Path,
+) -> None:
+    _write_units_artifact(tmp_path, [_baseline_unit()])
+    _write_authority_artifact(tmp_path, [_baseline_decision()])
+    a = _snap(tmp_path)
+    b = _snap(tmp_path)
+    out_a = json.dumps(a, indent=2, sort_keys=True) + "\n"
+    out_b = json.dumps(b, indent=2, sort_keys=True) + "\n"
+    assert out_a == out_b
+
+
+def test_no_timestamps_in_sort_keys(tmp_path: Path) -> None:
+    _write_units_artifact(tmp_path, [_baseline_unit()])
+    _write_authority_artifact(tmp_path, [_baseline_decision()])
+    snap = _snap(tmp_path)
+    for c in snap["candidates"]:
+        for value in c["deterministic_sort_key"]:
+            text = str(value)
+            assert "T" not in text or "Z" not in text  # no ISO 8601
+            assert "2026" not in text
+
+
+# ---------------------------------------------------------------------------
+# Atomic write allowlist
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_write_refuses_path_outside_allowlist(tmp_path: Path) -> None:
+    bad = tmp_path / "logs" / "elsewhere" / "latest.json"
+    bad.parent.mkdir(parents=True, exist_ok=True)
+    with pytest.raises(ValueError):
+        rnu._atomic_write_json(bad, {"x": 1})
+
+
+def test_atomic_write_refuses_frozen_contract_paths(tmp_path: Path) -> None:
+    for forbidden in (
+        "research/research_latest.json",
+        "research/strategy_matrix.csv",
+    ):
+        target = tmp_path / forbidden
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with pytest.raises(ValueError):
+            rnu._atomic_write_json(target, {"x": 1})
+
+
+def test_atomic_write_accepts_allowlisted_path(tmp_path: Path) -> None:
+    good = tmp_path / "logs" / "roadmap_next_unit" / "latest.json"
+    good.parent.mkdir(parents=True, exist_ok=True)
+    rnu._atomic_write_json(good, {"x": 1})
+    assert good.is_file()
+
+
+# ---------------------------------------------------------------------------
+# CLI behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_cli_no_write_does_not_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    sentinel = tmp_path / "logs" / "roadmap_next_unit" / "latest.json"
+    monkeypatch.setattr(rnu, "ARTIFACT_LATEST", sentinel)
+    monkeypatch.setattr(rnu, "ARTIFACT_DIR", sentinel.parent)
+    rc = rnu.main(["--no-write"])
+    assert rc == 0
+    assert not sentinel.exists()
+    out = capsys.readouterr().out
+    assert '"roadmap_next_unit"' in out
+
+
+def test_cli_status_does_not_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    sentinel = tmp_path / "logs" / "roadmap_next_unit" / "latest.json"
+    monkeypatch.setattr(rnu, "ARTIFACT_LATEST", sentinel)
+    monkeypatch.setattr(rnu, "ARTIFACT_DIR", sentinel.parent)
+    rc = rnu.main(["--status"])
+    assert rc == 0
+    assert not sentinel.exists()
+    out = capsys.readouterr().out
+    assert "roadmap_next_unit" in out
+    assert "no_runtime_trading_authority=True" in out
+    assert "no_step5_runtime=True" in out
+    assert "no_level6=True" in out
+    assert "no_production_merge_authority=True" in out
+    assert "deterministic_selection=True" in out
+    assert "permanently_denied_units_never_selected=True" in out
+
+
+def test_cli_default_writes_to_allowlisted_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sentinel = tmp_path / "logs" / "roadmap_next_unit" / "latest.json"
+    monkeypatch.setattr(rnu, "ARTIFACT_LATEST", sentinel)
+    monkeypatch.setattr(rnu, "ARTIFACT_DIR", sentinel.parent)
+    rc = rnu.main([])
+    assert rc == 0
+    assert sentinel.is_file()
+    payload = json.loads(sentinel.read_text(encoding="utf-8"))
+    assert payload["report_kind"] == "roadmap_next_unit"
+    assert payload["module_version"].endswith("A20e")
+
+
+def test_cli_indent_zero_compact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    sentinel = tmp_path / "logs" / "roadmap_next_unit" / "latest.json"
+    monkeypatch.setattr(rnu, "ARTIFACT_LATEST", sentinel)
+    monkeypatch.setattr(rnu, "ARTIFACT_DIR", sentinel.parent)
+    rc = rnu.main(["--no-write", "--indent", "0"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "\n  " not in out
+
+
+# ---------------------------------------------------------------------------
+# Read-only invariants
+# ---------------------------------------------------------------------------
+
+
+def test_collect_snapshot_does_not_mutate_upstream_artifacts(
+    tmp_path: Path,
+) -> None:
+    units_path = _write_units_artifact(tmp_path, [_baseline_unit()])
+    auth_path = _write_authority_artifact(tmp_path, [_baseline_decision()])
+    before_units = hashlib.sha256(units_path.read_bytes()).hexdigest()
+    before_auth = hashlib.sha256(auth_path.read_bytes()).hexdigest()
+    _snap(tmp_path)
+    after_units = hashlib.sha256(units_path.read_bytes()).hexdigest()
+    after_auth = hashlib.sha256(auth_path.read_bytes()).hexdigest()
+    assert before_units == after_units
+    assert before_auth == after_auth
+
+
+# ---------------------------------------------------------------------------
+# Selector invariants (no execution, no Step 5, no Level 6, etc.)
+# ---------------------------------------------------------------------------
+
+
+def test_invariants_pin_no_work_execution(tmp_path: Path) -> None:
+    _write_units_artifact(tmp_path, [_baseline_unit()])
+    _write_authority_artifact(tmp_path, [_baseline_decision()])
+    inv = _snap(tmp_path)["selector_invariants"]
+    assert inv["no_work_execution"] is True
+    assert inv["no_branch_creation"] is True
+    assert inv["no_pr_creation"] is True
+    assert inv["no_merge_or_deploy"] is True
+
+
+def test_invariants_pin_no_mutation_routes_or_approval_buttons(
+    tmp_path: Path,
+) -> None:
+    _write_units_artifact(tmp_path, [_baseline_unit()])
+    _write_authority_artifact(tmp_path, [_baseline_decision()])
+    inv = _snap(tmp_path)["selector_invariants"]
+    assert inv["no_mutation_routes"] is True
+    assert inv["no_approval_buttons"] is True
+
+
+def test_invariants_pin_no_runtime_trading_authority(tmp_path: Path) -> None:
+    _write_units_artifact(tmp_path, [_baseline_unit()])
+    _write_authority_artifact(tmp_path, [_baseline_decision()])
+    inv = _snap(tmp_path)["selector_invariants"]
+    assert inv["no_runtime_trading_authority"] is True
+
+
+def test_invariants_pin_no_step5_no_level6_no_production_merge(
+    tmp_path: Path,
+) -> None:
+    _write_units_artifact(tmp_path, [_baseline_unit()])
+    _write_authority_artifact(tmp_path, [_baseline_decision()])
+    snap = _snap(tmp_path)
+    inv = snap["selector_invariants"]
+    assert inv["no_step5_runtime"] is True
+    assert inv["no_level6"] is True
+    assert inv["no_production_merge_authority"] is True
+    assert snap["step5_implementation_allowed"] is False
+    assert snap["step5_enabled_substage"] == "none"
+
+
+def test_invariants_pin_no_upstream_mutation(tmp_path: Path) -> None:
+    _write_units_artifact(tmp_path, [_baseline_unit()])
+    _write_authority_artifact(tmp_path, [_baseline_decision()])
+    inv = _snap(tmp_path)["selector_invariants"]
+    assert inv["mutates_a20b_artifact"] is False
+    assert inv["mutates_a20c_artifact"] is False
+
+
+def test_invariants_pin_no_seed_jsonl_writes(tmp_path: Path) -> None:
+    _write_units_artifact(tmp_path, [_baseline_unit()])
+    _write_authority_artifact(tmp_path, [_baseline_decision()])
+    inv = _snap(tmp_path)["selector_invariants"]
+    assert inv["writes_to_seed_jsonl"] is False
+    assert inv["writes_to_delegation_seed_jsonl"] is False
+    assert inv["writes_to_generated_seed_jsonl"] is False
+
+
+def test_invariants_pin_fail_closed_contracts(tmp_path: Path) -> None:
+    _write_units_artifact(tmp_path, [_baseline_unit()])
+    _write_authority_artifact(tmp_path, [_baseline_decision()])
+    inv = _snap(tmp_path)["selector_invariants"]
+    assert inv["fail_closed_on_unknown_evidence"] is True
+    assert inv["fail_closed_on_duplicate_authority"] is True
+    assert inv["fail_closed_on_missing_artifact"] is True
+
+
+def test_invariants_pin_permanently_denied_never_selected(
+    tmp_path: Path,
+) -> None:
+    _write_units_artifact(tmp_path, [_baseline_unit()])
+    _write_authority_artifact(tmp_path, [_baseline_decision()])
+    inv = _snap(tmp_path)["selector_invariants"]
+    assert inv["permanently_denied_units_never_selected"] is True
+    assert inv["needs_human_units_require_operator_go"] is True
+
+
+def test_invariants_pin_calls_execution_authority_classifier_false(
+    tmp_path: Path,
+) -> None:
+    """A20e is a downstream consumer of A20c. It does not itself
+    call the canonical classifier — A20c is the only call site."""
+    _write_units_artifact(tmp_path, [_baseline_unit()])
+    _write_authority_artifact(tmp_path, [_baseline_decision()])
+    inv = _snap(tmp_path)["selector_invariants"]
+    assert inv["calls_execution_authority_classifier"] is False
+
+
+# ---------------------------------------------------------------------------
+# Module-source forbidden-import / forbidden-token scans
+# ---------------------------------------------------------------------------
+
+
+def _module_source() -> str:
+    return Path(rnu.__file__).read_text(encoding="utf-8")
+
+
+def _module_imports() -> list[str]:
+    import ast as _ast
+
+    tree = _ast.parse(_module_source())
+    out: list[str] = []
+    for node in _ast.walk(tree):
+        if isinstance(node, _ast.Import):
+            for alias in node.names:
+                out.append(alias.name)
+        elif isinstance(node, _ast.ImportFrom):
+            mod = node.module or ""
+            for alias in node.names:
+                out.append(f"{mod}.{alias.name}" if mod else alias.name)
+    return out
+
+
+def test_no_subprocess_in_module() -> None:
+    src = _module_source()
+    assert "import subprocess" not in src
+    assert "from subprocess" not in src
+    assert "subprocess." not in src
+
+
+def test_no_socket_or_urllib_or_http_or_requests() -> None:
+    src = _module_source()
+    for forbidden in (
+        "import socket",
+        "from socket",
+        "import urllib",
+        "from urllib",
+        "import http",
+        "from http",
+        "import requests",
+        "from requests",
+        "import httpx",
+        "from httpx",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_no_forbidden_runtime_imports_via_ast() -> None:
+    forbidden_prefixes = (
+        "dashboard",
+        "automation",
+        "broker",
+        "agent.risk",
+        "agent.execution",
+        "research",
+        "live",
+        "paper",
+        "shadow",
+        "trading",
+        "reporting.intelligent_routing",
+        "reporting.development_queue_admission_policy",
+        "reporting.development_agent_activity_timeline",
+        "reporting.execution_authority",
+    )
+    for module in _module_imports():
+        for prefix in forbidden_prefixes:
+            assert not (
+                module == prefix or module.startswith(prefix + ".")
+            ), f"forbidden import: {module}"
+
+
+def test_no_gh_or_git_cli_calls() -> None:
+    src = _module_source()
+    for forbidden in (
+        "subprocess.run",
+        "subprocess.Popen",
+        "os.system(",
+        "os.popen(",
+        "shell=True",
+        "eval(",
+        "exec(",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_no_github_api_or_external_api_calls() -> None:
+    src = _module_source()
+    for forbidden in (
+        "api.github.com",
+        "anthropic",
+        "openai",
+        "Bearer ",
+        "X-API-Key",
+        "X-GitHub-Token",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_module_imports_only_canonical_upstreams() -> None:
+    """A20e may only import from A20b + A20c. It MUST NOT import
+    from reporting.execution_authority directly."""
+    allowed = {
+        "reporting.roadmap_task_units",
+        "reporting.roadmap_unit_authority",
+    }
+    for module in _module_imports():
+        if module.startswith("reporting."):
+            assert module in allowed, module
+
+
+def test_module_imports_cleanly() -> None:
+    importlib.reload(rnu)
+    assert callable(rnu.collect_snapshot)
+    assert callable(rnu.write_outputs)
+    assert callable(rnu.main)
+
+
+def test_schema_and_module_version_strings() -> None:
+    assert isinstance(rnu.SCHEMA_VERSION, str) and rnu.SCHEMA_VERSION
+    assert isinstance(rnu.MODULE_VERSION, str) and rnu.MODULE_VERSION
+    assert rnu.MODULE_VERSION.endswith("A20e")

--- a/tests/unit/test_roadmap_task_units.py
+++ b/tests/unit/test_roadmap_task_units.py
@@ -470,14 +470,15 @@ def test_invariants_pin_no_final_authority(snap: dict) -> None:
     """A20b itself does not call the canonical classifier and does
     not record final authority — those are A20c's responsibilities,
     pinned by ``False`` here. A20c flips them to ``True`` in its own
-    projection's invariant block, not A20b's. The next-buildable
-    selector is A20e scope and remains ``False``. AAC visibility is
+    projection's invariant block, not A20b's. AAC visibility is
     ``True`` post-A20d because the AAC aggregator surfaces A20b
-    rows as read-only work items."""
+    rows. Next-buildable-unit selection is ``True`` post-A20e
+    because reporting.roadmap_next_unit selects deterministically
+    over A20b candidates."""
     inv = snap["decomposition_invariants"]
     assert inv["calls_execution_authority_classifier"] is False
     assert inv["final_authority_classified"] is False
-    assert inv["next_buildable_selector_present"] is False
+    assert inv["next_buildable_selector_present"] is True
     assert inv["aac_visibility_present"] is True
 
 

--- a/tests/unit/test_roadmap_unit_authority.py
+++ b/tests/unit/test_roadmap_unit_authority.py
@@ -704,12 +704,13 @@ def test_invariants_pin_writes_only_roadmap_unit_authority_log(
 
 def test_invariants_pin_aac_visibility_true_after_a20d(snap: dict) -> None:
     """After A20d landed, the AAC aggregator surfaces A20c rows as
-    read-only work items. ``aac_visibility_present`` therefore flips
-    to ``True``. The next-buildable-unit selector (A20e) remains
-    unimplemented; its flag stays ``False``."""
+    read-only work items. ``aac_visibility_present`` is ``True``.
+    After A20e landed, ``reporting.roadmap_next_unit`` deterministically
+    selects from A20c authority decisions, so
+    ``next_buildable_selector_present`` is ``True``."""
     inv = snap["authority_invariants"]
     assert inv["aac_visibility_present"] is True
-    assert inv["next_buildable_selector_present"] is False
+    assert inv["next_buildable_selector_present"] is True
 
 
 def test_invariants_pin_no_seed_jsonl_writes(snap: dict) -> None:
@@ -856,7 +857,7 @@ def test_cli_status_does_not_write(
     assert "final_authority_classified=True" in out
     assert "no_runtime_trading_authority=True" in out
     assert "aac_visibility_present=True" in out
-    assert "next_buildable_selector_present=False" in out
+    assert "next_buildable_selector_present=True" in out
 
 
 def test_cli_default_writes_to_allowlisted_path(


### PR DESCRIPTION
## Summary

- A20e adds deterministic next-buildable-unit selection. New module `reporting/roadmap_next_unit.py` is a pure stdlib-only read-only consumer of the A20b unit projection and A20c authority projection. Emits a deterministic projection at `logs/roadmap_next_unit/latest.json` naming at most one `NextBuildableUnitSelection` plus the full filterable candidates list.
- A20e does not execute work. No branch creation, no PR creation, no merge or deploy. Pinned by `selector_invariants.no_work_execution = no_branch_creation = no_pr_creation = no_merge_or_deploy = True`.
- A20e adds no branch/PR/merge/deploy behavior. The module is a pure projection; the operator opens any subsequent PR via the normal lifecycle.
- A20e adds no mutation routes and no approval buttons. Read-only artefact only. AAC aggregator unchanged.
- A20e grants no runtime / trading / paper / shadow / live authority. Pinned across A20b / A20c / A20e invariant blocks.
- Selection rules are fully deterministic: phase order then authority order then risk order then operator-gate order then unit-id lex tie-break. No LLM judgment, no random ordering, no timestamps in sort keys.
- Selection prefers ELIGIBLE (AUTO_ALLOWED + operator_gate="none") over NEEDS_HUMAN_GATED. PERMANENTLY_DENIED units are never selected.
- Fail-closed contract: missing/malformed upstream -> UPSTREAM_UNAVAILABLE; all denied -> ALL_PERMANENTLY_DENIED; all blocked by prereqs -> ALL_BLOCKED_BY_PREREQUISITES; unknown/duplicate authority -> FAIL_CLOSED_INVARIANT.

## Files changed (exactly 7, allowlist-only)

- `reporting/roadmap_next_unit.py` (new) - stdlib + `reporting.roadmap_task_units` + `reporting.roadmap_unit_authority` only.
- `tests/unit/test_roadmap_next_unit.py` (new) - 73 tests.
- `reporting/roadmap_task_units.py` (modified) - A20b invariant flip `next_buildable_selector_present: False -> True`.
- `reporting/roadmap_unit_authority.py` (modified) - A20c invariant flip `next_buildable_selector_present: False -> True`.
- `tests/unit/test_roadmap_task_units.py` (modified) - one invariant assertion flipped.
- `tests/unit/test_roadmap_unit_authority.py` (modified) - one invariant + one CLI-status assertion flipped.
- `docs/governance/roadmap_task_catalog.md` (modified) - new §10 A20e section, new §11 A20 overall-status section, new §15.5 test-coverage block, legacy future-stages block removed, downstream section renumbering.

Untouched (verified):

- `dashboard/dashboard.py`
- `.claude/**`, `.github/**`
- `research/research_latest.json`, `research/strategy_matrix.csv`
- `automation/live_gate.py`, `broker/**`, `agent/risk/**`, `agent/execution/**`
- `live/**`, `paper/**`, `shadow/**`, `trading/**`
- `docs/roadmap/Roadmap v6.md`, `docs/roadmap/Roadmap v6 Addendum.md`, `docs/roadmap/autonomous_development.txt`
- `docs/governance/execution_authority.md`, `docs/governance/no_touch_paths.md`
- `reporting/execution_authority.py`
- `reporting/development_queue_admission_policy.py` (existing A17)
- `reporting/development_agent_activity_timeline.py` (AAC aggregator - A20e intentionally does NOT extend AAC cardinality)
- `docs/development_work_queue/*.jsonl`
- `tests/regression/**`
- any frozen schema under `artifacts/`

## Validation commands and results

- `python -m pytest tests/unit/test_roadmap_task_catalog.py -v` -> 83 passed (unchanged)
- `python -m pytest tests/unit/test_roadmap_task_units.py -v` -> 87 passed (1 assertion flipped)
- `python -m pytest tests/unit/test_roadmap_unit_authority.py -v` -> 86 passed (2 assertions flipped)
- `python -m pytest tests/unit/test_roadmap_next_unit.py -v` -> 73 passed
- `python -m pytest tests/unit/test_development_agent_activity_timeline.py -v` -> 76 passed (unchanged)
- `python -m pytest tests/smoke -v` -> 18 passed
- `python scripts/governance_lint.py` -> OK (16 agents, 5 workflows)
- `python scripts/push_body_safety_lint.py` -> OK (6 surfaces, 6 tokens)
- Frozen-contract regression set (`test_public_output_contract.py`, `test_v12_contracts_preserved.py`, `test_authority_invariants.py`) -> 16 passed

Combined A20-series + AAC sweep: 385 passed in 4.48s.

## Frozen-contract verdict

- `research/research_latest.json` - not touched.
- `research/strategy_matrix.csv` - not touched.
- Atomic-write helper rejects every path outside `logs/roadmap_next_unit/`.
- Sha256-before-vs-after pins: `collect_snapshot()` does not mutate the A20b or A20c on-disk artefacts.

## Forbidden-path verdict

`git diff --name-only main` contains exactly the seven approved files. None of the forbidden paths above were touched.

## Authority statement (still pinned on main)

- ADE remains development workflow automation only.
- A20e adds deterministic next-buildable-unit selection, nothing more.
- A20e does not execute work. Pinned by `selector_invariants.no_work_execution=True`, `no_branch_creation=True`, `no_pr_creation=True`, `no_merge_or_deploy=True`.
- A20e adds no branch/PR/merge/deploy behavior.
- A20e adds no mutation routes and no approval buttons.
- A20e grants no runtime / trading / paper / shadow / live authority.
- Step 5 implementation remains BLOCKED.
- Autonomy-ladder Level 6 remains permanently disabled.
- N5b Phase 4 production merge remains permanently denied for ADE.
- A20b and A20c `next_buildable_selector_present` invariants flipped False -> True. All other authority flags carried forward unchanged.

## What this PR does NOT do

- A20e does not execute work. Even an AUTO_ALLOWED selection is informational; the operator opens any subsequent PR.
- No AAC aggregator change. A20e artefact lives at `logs/roadmap_next_unit/latest.json` and is read via the module CLI. A future operator-go PR may extend the AAC pinned upstream catalog (currently 14 entries) with a 15th `roadmap_next_unit` entry; that is deliberately out of A20e scope to keep the PR small and safe.
- No `dashboard/dashboard.py` change.
- No edit to canonical roadmap docs, canonical policy docs, or `autonomous_development.txt`.
- No edit to `reporting/execution_authority.py` or its governance doc. A20e never imports or calls the canonical classifier; A20c remains the only call site.
- No Step 5 / Level 6 / N5b weakening.

## A20 overall status after A20e

The A20 series is COMPLETE after this PR:

1. A20a - static Roadmap v6 + Addendum 1 task catalog seed.
2. A20b - implementation-unit decomposer.
3. A20c - authority/risk classifier integration.
4. A20d - read-only operator visibility via AAC aggregator.
5. A20e - deterministic next-buildable-unit selector. <- this PR

The five stages form a complete read-only roadmap-to-task pipeline:

Roadmap v6 + Addendum 1 -> catalog -> units -> authority decisions -> AAC visibility -> next-buildable selection.

## Next recommended step after merge

A20 completion review, then the first queue-driven Roadmap v6 implementation unit opened as its own PR under normal ADE PR lifecycle governance. The operator reads `python -m reporting.roadmap_next_unit --status` to identify the recommended unit, then opens a feature branch + PR for that unit's `expected_files[]` scope. A20e does not open that PR; the operator does, using the selector's deterministic recommendation as input.

## Test plan

- [x] All local unit/smoke/governance/regression tests green (see above).
- [ ] CI checks complete on PR (squash-merge only - no `--admin`, no force push, no hook bypass, no automatic merge).

Generated with Claude Code (https://claude.com/claude-code).
