### PR TITLE
feat(v3.15.16): diagnostic-aware routing signals schema + projector

### DIFF
--- a/docs/governance/intelligent_routing_diagnostic_signals.md
+++ b/docs/governance/intelligent_routing_diagnostic_signals.md
@@ -1,0 +1,388 @@
+# Intelligent Routing — Diagnostic-aware Routing Signals (v3.15.16, schema/projector)
+
+> **Status:** Implemented as a read-only schema and deterministic
+> projector. **No routing mutation, no campaign queue mutation, no
+> strategy generation, no trading behaviour.**
+>
+> **Module:** [`reporting/intelligent_routing_diagnostic_signals.py`](../../reporting/intelligent_routing_diagnostic_signals.py)
+> **Artefact:** `logs/intelligent_routing_diagnostic_signals/latest.json`
+>
+> **A20e unit anchor:** `u_v3_15_16_diagnostic_routing_signals_schema_001`
+> **Phase:** v3.15.16 — Intelligent Routing Layer.
+> **Authority class on merge:** `AUTO_ALLOWED` (LOW risk, `operator_gate = none`,
+> `requires_operator_go = false`).
+
+---
+
+## 1. Purpose
+
+Roadmap v6 §v3.15.16 mandates that campaign routing become
+**behavior-aware** instead of preset-count-aware. The Roadmap v6
+Addendum §9 v3.15.16 extends this with **diagnostic-aware** routing
+signals (entropy / tail / criticality / network / quorum /
+external-intelligence / dead-zone suppression / null-model /
+barrier / resonance / adversarial / seismic / turbulence /
+market-language).
+
+This unit ships the **first** of the routing-related artefacts:
+the schema and deterministic projector for the routing signals
+themselves. The projector emits a closed-vocabulary description
+of each signal family — what it advises, what it forbids, which
+upstream input it depends on, what to do when that input is
+missing — without performing any actual routing decision.
+
+This is a **schema/projector foundation**. It exists so that a
+future operator-approved unit can implement the actual deterministic
+routing integration on top of a stable, pinned signal vocabulary.
+
+---
+
+## 2. Relationship to v3.15.16 Intelligent Routing Layer
+
+The intelligent-routing build path is:
+
+```
+schema + projector  (this unit)
+   ↓
+deterministic routing-signal evaluation  (future unit, operator-go)
+   ↓
+campaign routing integration  (future unit, operator-go)
+   ↓
+routing-decision explanation reporter  (future unit, operator-go)
+```
+
+Today this unit only declares **what a signal looks like and what
+it may / may not do**. The next units in the A20b decomposition
+list (`u_v3_15_16_routing_explanation_reporter_001`,
+`u_v3_15_16_routing_governance_doc_001`) consume the signal schema
+once that ordering is unblocked by an A20a/A20b status update.
+
+---
+
+## 3. Schema / projector only
+
+This unit ships:
+
+- a closed `ROUTING_SIGNAL_FAMILY` vocabulary covering 14 Roadmap v6
+  + Addendum 1 diagnostic families;
+- closed vocabularies for `ROUTING_SIGNAL_STATUS`,
+  `ROUTING_SIGNAL_DIRECTION`, `ROUTING_SIGNAL_SOURCE`,
+  `ROUTING_SIGNAL_TARGET_LAYER`;
+- one `RoutingDiagnosticSignal` record per family (today);
+- a deterministic `RoutingSignalProjection` artefact at
+  `logs/intelligent_routing_diagnostic_signals/latest.json`;
+- a CLI with `--no-write`, `--status`, `--indent` flags following
+  the same shape as the A20-series modules.
+
+It does **not** ship:
+
+- any actual routing-priority computation;
+- any campaign queue update;
+- any campaign execution change;
+- any research-runtime behaviour change;
+- any strategy-mapping output;
+- any trading / paper / shadow / live behaviour.
+
+---
+
+## 4. No actual routing mutation is implemented yet
+
+Every signal in this projection lands at `status="schema_only"`.
+The `direction` field describes the *routing priority effect* the
+signal would have once a future integration unit consumes it — it
+is never a buy/sell direction and it is never executed.
+
+The module's `projection_invariants` block pins this loudly on
+every artefact:
+
+- `no_routing_mutation = true`
+- `no_campaign_queue_mutation = true`
+- `no_strategy_generation = true`
+- `no_research_runtime_change = true`
+
+The status hard-codes to `schema_only` inside `_normalise_signal`
+so that a future seed entry cannot drift its own status without
+operator review. Per-signal status lifecycle is reserved for a
+future operator-approved unit.
+
+---
+
+## 5. Diagnostics do not trade
+
+Verbatim from Roadmap v6 Addendum §2 (Core Rule):
+
+> *Diagnostics do not trade. A diagnostic may influence hypothesis
+> priority, sampling, routing, evidence scoring, cooldown,
+> confirmation, suppression or observability. A diagnostic may not
+> directly create strategies, place trades, mutate live risk,
+> allocate capital, bypass policy governance, or change frozen
+> output contracts.*
+
+This unit's `projection_invariants` block pins
+`diagnostics_do_not_trade = true` on every emitted artefact.
+
+Every emitted signal carries a **baseline** `forbidden_use[]`
+list, prepended verbatim to every record:
+
+- diagnostics may not place trades
+- diagnostics may not mutate live risk
+- diagnostics may not allocate capital
+- diagnostics may not write to `live/**` or `paper/**` or `shadow/**` paths
+- diagnostics may not write to `broker/**` or `agent/risk/**` or `agent/execution/**` paths
+- diagnostics may not mutate `research/research_latest.json` or `research/strategy_matrix.csv`
+- diagnostics may not be used as a direct trade trigger
+- diagnostics may not bypass policy governance
+- diagnostics may not bypass promotion gates
+- diagnostics may not produce executable strategy code
+
+Per-signal `extra_forbidden_use` entries are appended after the
+baseline; duplicates are deterministically de-duplicated; order
+is stable. Tests pin each of these properties.
+
+---
+
+## 6. External data is not alpha
+
+Verbatim from Roadmap v6 Addendum §8.1 (External Intelligence
+Intake Principle):
+
+> *External / public data is not alpha. It is an unvalidated
+> prior. Only QRE-validated, OOS-stable, cost-aware,
+> execution-realistic, policy-approved behavior can become edge.*
+
+The `projection_invariants` block pins
+`external_data_is_not_alpha = true`. The
+`rs_external_intelligence_routing` signal carries an explicit
+`extra_forbidden_use` entry that diagnostics may not treat
+external data as alpha and may not call paid feeds or vendor-alpha
+endpoints.
+
+---
+
+## 7. Signal families included
+
+Exactly 14 signal records ship today, one per family:
+
+| `family` | `id` | `target_layer` | `direction` |
+|---|---|---|---|
+| `entropy` | `rs_entropy_information_density` | `campaign` | `deprioritize` |
+| `tail` | `rs_tail_power_law` | `evidence` | `require_confirmation` |
+| `criticality` | `rs_criticality_phase_transition` | `policy` | `deprioritize` |
+| `network` | `rs_network_correlation_graph` | `campaign` | `suppress` |
+| `quorum` | `rs_quorum_independent_evidence` | `evidence` | `require_confirmation` |
+| `external_intelligence` | `rs_external_intelligence_routing` | `campaign` | `require_confirmation` |
+| `dead_zone` | `rs_dead_zone_suppression` | `campaign` | `suppress` |
+| `null_model` | `rs_null_model_falsification` | `evidence` | `deprioritize` |
+| `barrier` | `rs_barrier_breakout_pressure` | `strategy_mapping` | `require_confirmation` |
+| `resonance` | `rs_resonance_cycle_confluence` | `preset` | `require_confirmation` |
+| `adversarial` | `rs_adversarial_market_behavior` | `evidence` | `require_confirmation` |
+| `seismic` | `rs_seismic_shock_aftershock` | `campaign` | `suppress` |
+| `turbulence` | `rs_turbulence_liquidity` | `policy` | `deprioritize` |
+| `market_language` | `rs_market_language_grammar` | `hypothesis_discovery` | `neutral` |
+
+Each signal record includes:
+
+- five **bounded-prose effect** fields describing the routing
+  effect on `expected_information_gain`, `dead_zone_risk`,
+  `orthogonality`, `public_data_quality`, and
+  `confirmation_requirement`. These are operator-readable
+  explanatory hints, not authority-bearing decision fields. Tests
+  pin them as non-empty, ≤200 chars, no newline, and free of
+  authority-granting / trade / execute / order / capital-allocation
+  semantics;
+- a closed-vocab `family`, `source`, `target_layer`, `direction`,
+  `status`;
+- a non-empty `allowed_use` list;
+- a `forbidden_use` list that carries the full baseline + any
+  per-signal extras;
+- a non-empty `required_inputs` list;
+- a non-empty `missing_input_behavior` string.
+
+---
+
+## 8. Allowed uses
+
+Per Roadmap v6 Addendum §2, a routing signal **may**:
+
+- influence hypothesis priority;
+- influence sampling strategy;
+- influence routing prioritisation, deprioritisation, and
+  suppression;
+- influence evidence scoring (raise confirmation requirement);
+- influence cooldown and dead-zone suppression;
+- support observability and operator-readable explanation;
+- support failure-to-action mapping (v3.15.20 scope).
+
+Each signal record records the relevant subset of these uses in
+its `allowed_use[]` list.
+
+---
+
+## 9. Forbidden uses
+
+Per Roadmap v6 Addendum §2 and §8.1, a routing signal **must not**:
+
+- create executable strategies directly;
+- place trades, mutate live risk, allocate capital;
+- bypass policy governance or promotion gates;
+- change frozen output contracts;
+- be used as a hidden ML / RL selector;
+- be used as stochastic strategy mutation;
+- be treated as alpha;
+- call paid feeds or vendor-alpha endpoints;
+- write to live / paper / shadow / trading / broker / risk /
+  execution paths.
+
+The baseline `forbidden_use[]` list pins these on every emitted
+signal. Signal-family extras pin family-specific forbids on top
+of the baseline (for example, the network signal's "may not
+migrate capital across assets" extra; the language signal's "may
+not mine candle patterns" extra).
+
+---
+
+## 10. Missing-input behaviour
+
+Every signal declares its `required_inputs[]` list and a
+`missing_input_behavior` string. The universal pattern is **fail
+closed**: if any required input is missing, the signal status falls
+to `suppressed` and the signal contributes neutral effect — no
+authority is granted, no routing decision is made, no escalation
+fires. The string explicitly describes the fall-back behaviour for
+the specific signal.
+
+This is consistent with the A20 fail-closed contract that the
+roadmap-to-task pipeline already enforces upstream: ambiguity →
+no positive action.
+
+---
+
+## 11. Sidecar artefact path
+
+The projection is written to:
+
+```
+logs/intelligent_routing_diagnostic_signals/latest.json
+```
+
+The atomic-write helper refuses every path outside that directory
+(`logs/intelligent_routing_diagnostic_signals/`). Frozen-contract
+paths (`research/research_latest.json`,
+`research/strategy_matrix.csv`) are rejected explicitly. Tests pin
+the allowlist + frozen-contract refusal.
+
+The artefact is gitignored under `logs/` and is produced on demand
+by the CLI:
+
+```sh
+python -m reporting.intelligent_routing_diagnostic_signals          # writes + stdout
+python -m reporting.intelligent_routing_diagnostic_signals --no-write
+python -m reporting.intelligent_routing_diagnostic_signals --status
+python -m reporting.intelligent_routing_diagnostic_signals --indent 2
+```
+
+The `--status` and `--no-write` modes never write any file.
+
+---
+
+## 12. Likely follow-up units
+
+A20b's hand-encoded `_UNIT_SEED` already lists the two next
+v3.15.16 follow-up units that depend on this schema:
+
+- `u_v3_15_16_routing_explanation_reporter_001` — read-only
+  routing-decision explanation reporter (LOW risk, AUTO_ALLOWED
+  candidate, depends on this unit). Once this unit is merged,
+  A20e will surface that follow-up as eligible after an A20b
+  `status="merged"` update is staged for this unit.
+- `u_v3_15_16_routing_governance_doc_001` — governance doc for
+  the routing signals (LOW risk, AUTO_ALLOWED candidate). Closely
+  related to this doc; may be folded in or kept separate per a
+  future operator decision.
+
+Beyond v3.15.16, the actual deterministic-routing integration
+unit (consuming the signal schema to produce campaign-priority
+projections) is **not** in A20b's seed today. Adding it requires
+an A20b seed-data amendment under operator-go, plus the new
+unit's own schema + module + tests + governance doc PR.
+
+Until those follow-up units land, the signals shipped in this
+artefact are advisory-only schema records: they describe the
+intended routing-signal contract, they do not perform any routing
+decision.
+
+---
+
+## 13. Authority pins carried forward
+
+The `projection_invariants` block on every emitted artefact pins:
+
+- `diagnostics_do_not_trade = true`
+- `external_data_is_not_alpha = true`
+- `read_only = true`
+- `no_runtime_trading_authority = true`
+- `no_campaign_queue_mutation = true`
+- `no_strategy_generation = true`
+- `no_routing_mutation = true`
+- `no_research_runtime_change = true`
+- `no_step5_runtime = true`
+- `no_level6 = true`
+- `no_production_merge_authority = true`
+- `no_branch_creation = true`
+- `no_pr_creation = true`
+- `no_merge_or_deploy = true`
+- `no_mutation_routes = true`
+- `no_approval_buttons = true`
+- `step5_implementation_allowed = false`
+
+Step 5 implementation remains BLOCKED. Autonomy-ladder Level 6
+remains permanently disabled. N5b Phase 4 production merge
+remains permanently denied for ADE. ADE remains development
+workflow automation only.
+
+---
+
+## 14. Test coverage
+
+Pinned in [`tests/unit/test_intelligent_routing_diagnostic_signals.py`](../../tests/unit/test_intelligent_routing_diagnostic_signals.py):
+
+- Closed vocabularies are exact.
+- Schema field tuples are exact and ordered.
+- All 14 Roadmap v6 + Addendum 1 signal families are represented.
+- Every emitted signal has non-empty `allowed_use`,
+  `forbidden_use`, `required_inputs`, and `missing_input_behavior`.
+- Effect fields are bounded prose: non-empty, ≤200 chars, no
+  newline, no authority-granting / trade / execute / order /
+  capital-allocation phrases.
+- `status="schema_only"` is hard-coded in `_normalise_signal`
+  (a synthetic seed with a different status still emits
+  `schema_only`).
+- Baseline `forbidden_use` is prepended on every signal;
+  per-signal extras are appended without replacing the baseline;
+  duplicates are deterministically de-duplicated; order is
+  stable across runs.
+- All projection invariants pin at `True` (or `False` for
+  `step5_implementation_allowed`).
+- Deterministic byte-identical output for identical input with
+  injected `generated_at_utc`.
+- Atomic-write allowlist refuses every path outside
+  `logs/intelligent_routing_diagnostic_signals/`, including
+  frozen-contract paths.
+- CLI `--no-write` and `--status` modes do not write any file.
+- Module-source scan: stdlib only; no `subprocess`, no `socket`,
+  no `urllib`, no `http`, no `requests`, no `gh`, no `git`, no
+  `os.system`, no `eval(`, no `exec(`, no GitHub API host, no
+  LLM endpoint, no `dashboard` / `automation` / `broker` /
+  `agent.risk` / `agent.execution` / `research` / `live` /
+  `paper` / `shadow` / `trading` / `reporting.execution_authority`
+  / A20-pipeline import.
+
+---
+
+## 15. Cross-references
+
+- [`docs/roadmap/Roadmap v6.md`](../roadmap/Roadmap%20v6.md) — §v3.15.16 Intelligent Routing Layer.
+- [`docs/roadmap/Roadmap v6 Addendum.md`](../roadmap/Roadmap%20v6%20Addendum.md) — §9 v3.15.16 diagnostic-aware routing.
+- [`docs/governance/roadmap_task_catalog.md`](roadmap_task_catalog.md) — the A20 roadmap-to-task pipeline that selected this unit.
+- [`docs/governance/ade_development_lane_doctrine.md`](ade_development_lane_doctrine.md) — ADE remains development workflow automation only.
+- [`docs/governance/execution_authority.md`](execution_authority.md) — canonical agent execution authority policy (untouched by this PR).

--- a/reporting/intelligent_routing_diagnostic_signals.py
+++ b/reporting/intelligent_routing_diagnostic_signals.py
@@ -1,0 +1,1157 @@
+"""v3.15.16 Intelligent Routing Layer — diagnostic-aware routing
+signals schema and read-only projector.
+
+Implements the first queue-driven Roadmap v6 implementation unit
+selected by A20e:
+
+* unit id: ``u_v3_15_16_diagnostic_routing_signals_schema_001``
+* phase:   ``v3.15.16`` — Intelligent Routing Layer
+* authority: ``AUTO_ALLOWED`` at LOW risk (per A20c verdict)
+
+This module is **schema and projector only**. It does NOT perform
+routing decisions, does NOT mutate any campaign queue, does NOT
+alter campaign execution, does NOT change research runtime
+behavior, does NOT add strategy logic, and does NOT trade. The
+emitted projection is a closed-vocabulary description of the
+diagnostic-aware routing signal families that future v3.15.16
+follow-up units may consume — once an actual deterministic
+routing integration unit is approved by the operator and selected
+through A20e.
+
+Roadmap v6 + Addendum 1 anchor:
+
+* Roadmap v6 §v3.15.16 — Intelligent Routing Layer
+* Roadmap v6 Addendum §9 v3.15.16 — diagnostic-aware routing
+  signals (entropy / tail / criticality / network / quorum /
+  external-intelligence / dead-zone suppression).
+
+Hard guarantees (pinned by tests):
+
+* Stdlib only.
+* No subprocess, no network, no ``gh``, no ``git``, no GitHub
+  API.
+* No imports of ``dashboard``, ``automation``, ``broker``,
+  ``agent.risk``, ``agent.execution``, ``research``, ``live``,
+  ``paper``, ``shadow``, ``trading``,
+  ``reporting.intelligent_routing``,
+  ``reporting.development_queue_admission_policy``,
+  ``reporting.development_agent_activity_timeline``,
+  ``reporting.execution_authority``.
+* No LLM, no external API, no fuzzy parsing, no file-content
+  parsing of any canonical roadmap document at runtime.
+* Atomic write only under
+  ``logs/intelligent_routing_diagnostic_signals/``.
+* Deterministic output: same input + injected
+  ``generated_at_utc`` → byte-identical artefact.
+* Closed vocabularies for ``ROUTING_SIGNAL_FAMILY``,
+  ``ROUTING_SIGNAL_STATUS``, ``ROUTING_SIGNAL_DIRECTION``,
+  ``ROUTING_SIGNAL_SOURCE``, ``ROUTING_SIGNAL_TARGET_LAYER``.
+* No campaign queue mutation; no strategy generation; no
+  runtime / trading / paper / shadow / broker / risk / live
+  authority granted (pinned by ``projection_invariants``).
+* Diagnostics do not trade. External data is not alpha.
+
+CLI::
+
+    python -m reporting.intelligent_routing_diagnostic_signals
+    python -m reporting.intelligent_routing_diagnostic_signals --no-write
+    python -m reporting.intelligent_routing_diagnostic_signals --status
+    python -m reporting.intelligent_routing_diagnostic_signals --indent 2
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Final
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[str] = "1.0"
+MODULE_VERSION: Final[str] = "v3.15.16.routing_signals.0"
+REPORT_KIND: Final[str] = "intelligent_routing_diagnostic_signals"
+
+
+# ---------------------------------------------------------------------------
+# Step 5 + Level 6 invariants (Final constants — never flipped at runtime)
+# ---------------------------------------------------------------------------
+
+STEP5_ENABLED_SUBSTAGE: Final[str] = "none"
+step5_implementation_allowed: Final[bool] = False
+
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies
+# ---------------------------------------------------------------------------
+
+#: Closed signal-family vocabulary. Mirrors the Addendum 1
+#: diagnostic families plus the routing-specific ``dead_zone`` and
+#: ``external_intelligence`` buckets.
+ROUTING_SIGNAL_FAMILY: Final[tuple[str, ...]] = (
+    "entropy",
+    "tail",
+    "criticality",
+    "network",
+    "quorum",
+    "external_intelligence",
+    "dead_zone",
+    "null_model",
+    "barrier",
+    "resonance",
+    "adversarial",
+    "seismic",
+    "turbulence",
+    "market_language",
+)
+
+#: Closed signal-status vocabulary. Every emitted signal lands in
+#: ``schema_only`` today — this unit defines the schema, not the
+#: runtime integration. Future approved units may lift signals to
+#: other statuses through A20a/A20b/A20c amendments.
+ROUTING_SIGNAL_STATUS: Final[tuple[str, ...]] = (
+    "schema_only",
+    "advisory_planned",
+    "advisory_active",
+    "suppressed",
+    "deprecated",
+)
+
+#: Closed signal-direction vocabulary. Describes how a signal
+#: contributes to routing priority. Never a buy/sell direction —
+#: diagnostics do not trade.
+ROUTING_SIGNAL_DIRECTION: Final[tuple[str, ...]] = (
+    "prioritize",
+    "deprioritize",
+    "suppress",
+    "neutral",
+    "require_confirmation",
+)
+
+#: Closed signal-source vocabulary. Lists the upstream artefact
+#: or module each signal logically depends on. Today every entry
+#: is a future / planned module; this unit only declares the
+#: shape.
+ROUTING_SIGNAL_SOURCE: Final[tuple[str, ...]] = (
+    "research/diagnostics/null_models.py",
+    "research/diagnostics/tail.py",
+    "research/diagnostics/entropy.py",
+    "research/diagnostics/criticality.py",
+    "research/diagnostics/network.py",
+    "research/diagnostics/quorum.py",
+    "research/diagnostics/barrier.py",
+    "research/diagnostics/resonance.py",
+    "research/diagnostics/adversarial.py",
+    "research/diagnostics/seismic.py",
+    "research/diagnostics/turbulence.py",
+    "research/diagnostics/language.py",
+    "research/external_intelligence/source_registry.py",
+    "research/external_intelligence/quality_gates.py",
+    "research/external_intelligence/freshness_checks.py",
+    "research/external_intelligence/public_data_seed_registry.py",
+)
+
+#: Closed target-layer vocabulary. Mirrors the Roadmap v6 layer
+#: stack: signals describe the layer they advise, not the layer
+#: they execute on (none execute — they are diagnostics).
+ROUTING_SIGNAL_TARGET_LAYER: Final[tuple[str, ...]] = (
+    "market_behavior",
+    "hypothesis_discovery",
+    "strategy_mapping",
+    "preset",
+    "campaign",
+    "funnel",
+    "evidence",
+    "policy",
+)
+
+
+# ---------------------------------------------------------------------------
+# Schema field tuples (exact, ordered)
+# ---------------------------------------------------------------------------
+
+#: Per-signal schema.
+ROUTING_DIAGNOSTIC_SIGNAL_FIELDS: Final[tuple[str, ...]] = (
+    "id",
+    "family",
+    "name",
+    "description",
+    "source",
+    "target_layer",
+    "direction",
+    "status",
+    "expected_information_gain_effect",
+    "dead_zone_risk_effect",
+    "orthogonality_effect",
+    "public_data_quality_effect",
+    "confirmation_requirement_effect",
+    "allowed_use",
+    "forbidden_use",
+    "required_inputs",
+    "missing_input_behavior",
+)
+
+#: Top-level projection schema.
+ROUTING_SIGNAL_PROJECTION_FIELDS: Final[tuple[str, ...]] = (
+    "generated_at_utc",
+    "schema_version",
+    "module_version",
+    "signals",
+    "projection_invariants",
+)
+
+
+# ---------------------------------------------------------------------------
+# Bounds
+# ---------------------------------------------------------------------------
+
+MAX_NAME_LEN: Final[int] = 200
+MAX_DESCRIPTION_LEN: Final[int] = 600
+MAX_EFFECT_LEN: Final[int] = 200
+MAX_ALLOWED_USE_ITEMS: Final[int] = 8
+MAX_FORBIDDEN_USE_ITEMS: Final[int] = 12
+MAX_REQUIRED_INPUTS: Final[int] = 6
+MAX_LIST_ITEM_LEN: Final[int] = 200
+MAX_MISSING_INPUT_BEHAVIOR_LEN: Final[int] = 200
+
+
+# ---------------------------------------------------------------------------
+# Artefact paths
+# ---------------------------------------------------------------------------
+
+ARTIFACT_DIR: Final[Path] = (
+    REPO_ROOT / "logs" / "intelligent_routing_diagnostic_signals"
+)
+ARTIFACT_LATEST: Final[Path] = ARTIFACT_DIR / "latest.json"
+ARTIFACT_RELATIVE_PATH: Final[str] = (
+    "logs/intelligent_routing_diagnostic_signals/latest.json"
+)
+
+#: Atomic-write allowlist (POSIX substring form). Any write target
+#: whose path does not contain this substring is refused with
+#: ``ValueError``.
+_WRITE_PREFIX: Final[str] = "logs/intelligent_routing_diagnostic_signals/"
+
+
+# ---------------------------------------------------------------------------
+# Projection invariants emitted on every snapshot
+# ---------------------------------------------------------------------------
+
+_BASE_PROJECTION_INVARIANTS: Final[dict[str, bool]] = {
+    # Doctrinal anchors — these must remain True forever.
+    "diagnostics_do_not_trade": True,
+    "external_data_is_not_alpha": True,
+    "read_only": True,
+    # Authority pins carried forward from the A20 invariant chain.
+    "no_runtime_trading_authority": True,
+    "no_campaign_queue_mutation": True,
+    "no_strategy_generation": True,
+    "no_step5_runtime": True,
+    "no_level6": True,
+    "no_production_merge_authority": True,
+    "no_routing_mutation": True,
+    "no_research_runtime_change": True,
+    "step5_implementation_allowed": False,
+    "no_branch_creation": True,
+    "no_pr_creation": True,
+    "no_merge_or_deploy": True,
+    "no_mutation_routes": True,
+    "no_approval_buttons": True,
+    "writes_only_intelligent_routing_diagnostic_signals_log": True,
+    "fuzzy_parsing": False,
+    "uses_subprocess_or_network": False,
+    "calls_llm_or_external_api": False,
+}
+
+
+# ---------------------------------------------------------------------------
+# Utility helpers
+# ---------------------------------------------------------------------------
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _bounded_str(value: Any, max_len: int) -> str:
+    if not isinstance(value, str):
+        return ""
+    if len(value) <= max_len:
+        return value
+    return value[:max_len]
+
+
+def _bounded_str_tuple(
+    values: tuple[str, ...] | list[str], max_items: int, max_len: int
+) -> list[str]:
+    out: list[str] = []
+    seen: set[str] = set()
+    for v in values:
+        if not isinstance(v, str):
+            continue
+        b = _bounded_str(v, max_len)
+        if not b or b in seen:
+            continue
+        seen.add(b)
+        out.append(b)
+        if len(out) >= max_items:
+            break
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Re-usable forbidden-use baselines
+# ---------------------------------------------------------------------------
+
+_BASE_FORBIDDEN_USE: Final[tuple[str, ...]] = (
+    "diagnostics may not place trades",
+    "diagnostics may not mutate live risk",
+    "diagnostics may not allocate capital",
+    "diagnostics may not write to live/** or paper/** or shadow/** paths",
+    "diagnostics may not write to broker/** or agent/risk/** or agent/execution/** paths",
+    "diagnostics may not mutate research/research_latest.json or research/strategy_matrix.csv",
+    "diagnostics may not be used as a direct trade trigger",
+    "diagnostics may not bypass policy governance",
+    "diagnostics may not bypass promotion gates",
+    "diagnostics may not produce executable strategy code",
+)
+
+
+def _merge_forbidden_use(extra: tuple[str, ...]) -> list[str]:
+    return _bounded_str_tuple(
+        tuple(_BASE_FORBIDDEN_USE) + extra,
+        MAX_FORBIDDEN_USE_ITEMS,
+        MAX_LIST_ITEM_LEN,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Hand-encoded signal seed
+# ---------------------------------------------------------------------------
+#
+# Closed Roadmap v6 + Addendum 1 family coverage. Each entry is a
+# bounded-scalar declaration; this unit ships schema only.
+
+_SIGNALS_SEED: Final[tuple[dict[str, Any], ...]] = (
+    {
+        "id": "rs_entropy_information_density",
+        "family": "entropy",
+        "name": "Entropy / information-density routing signal",
+        "description": (
+            "Shannon and approximate entropy of returns / signals as a "
+            "routing input. High entropy deprioritizes directional "
+            "campaigns; low entropy may prioritize trend / continuation "
+            "exploration."
+        ),
+        "source": "research/diagnostics/entropy.py",
+        "target_layer": "campaign",
+        "direction": "deprioritize",
+        "expected_information_gain_effect": (
+            "high entropy reduces expected information gain on directional "
+            "exploration"
+        ),
+        "dead_zone_risk_effect": "raises dead-zone risk in high-entropy regimes",
+        "orthogonality_effect": "neutral",
+        "public_data_quality_effect": "neutral",
+        "confirmation_requirement_effect": (
+            "high entropy raises confirmation requirement for directional "
+            "campaigns"
+        ),
+        "allowed_use": (
+            "advisory routing input",
+            "suppress directional campaigns in high-entropy regimes",
+            "prioritize continuation campaigns in low-entropy regimes",
+        ),
+        "extra_forbidden_use": (
+            "may not directly mute or unmute live execution",
+        ),
+        "required_inputs": (
+            "return-series source",
+            "regime-window length",
+        ),
+        "missing_input_behavior": (
+            "if any required input is missing, signal status falls "
+            "to suppressed and contributes neutral effect"
+        ),
+    },
+    {
+        "id": "rs_tail_power_law",
+        "family": "tail",
+        "name": "Tail / power-law routing signal",
+        "description": (
+            "Return / drawdown tail exponent, left-tail fragility, and "
+            "tail asymmetry as routing inputs. Left-tail-fragile units "
+            "are deprioritized or require stronger confirmation."
+        ),
+        "source": "research/diagnostics/tail.py",
+        "target_layer": "evidence",
+        "direction": "require_confirmation",
+        "expected_information_gain_effect": (
+            "tail-convex hypotheses gain priority when tail-fit quality is high"
+        ),
+        "dead_zone_risk_effect": (
+            "raises dead-zone risk for strategies dependent on a single "
+            "outlier"
+        ),
+        "orthogonality_effect": "neutral",
+        "public_data_quality_effect": "neutral",
+        "confirmation_requirement_effect": (
+            "left-tail fragility raises confirmation requirement"
+        ),
+        "allowed_use": (
+            "advisory evidence-layer input",
+            "raise confirmation requirement for left-tail-fragile candidates",
+        ),
+        "extra_forbidden_use": (
+            "may not directly promote a candidate based on tail evidence "
+            "alone",
+        ),
+        "required_inputs": (
+            "return-series source",
+            "drawdown-series source",
+        ),
+        "missing_input_behavior": (
+            "if tail-fit quality cannot be computed, signal status falls "
+            "to suppressed"
+        ),
+    },
+    {
+        "id": "rs_criticality_phase_transition",
+        "family": "criticality",
+        "name": "Criticality / phase-transition routing signal",
+        "description": (
+            "Autocorrelation drift, variance increase, and regime-switch "
+            "warnings as routing inputs. Unstable regimes deprioritize "
+            "fragile campaigns."
+        ),
+        "source": "research/diagnostics/criticality.py",
+        "target_layer": "policy",
+        "direction": "deprioritize",
+        "expected_information_gain_effect": (
+            "criticality regions raise expected information gain for "
+            "regime-switch hypotheses"
+        ),
+        "dead_zone_risk_effect": (
+            "raises dead-zone risk near unstable phase transitions"
+        ),
+        "orthogonality_effect": "neutral",
+        "public_data_quality_effect": "neutral",
+        "confirmation_requirement_effect": (
+            "criticality warnings raise confirmation requirement"
+        ),
+        "allowed_use": (
+            "advisory policy-layer input",
+            "pause or suppress fragile campaigns near instability",
+            "require regime segmentation for unstable candidates",
+        ),
+        "extra_forbidden_use": (
+            "may not predict crashes as deterministic events",
+        ),
+        "required_inputs": (
+            "volatility-series source",
+            "regime-window length",
+        ),
+        "missing_input_behavior": (
+            "if criticality cannot be computed, signal status falls to "
+            "suppressed"
+        ),
+    },
+    {
+        "id": "rs_network_correlation_graph",
+        "family": "network",
+        "name": "Network / correlation-graph routing signal",
+        "description": (
+            "Correlation networks, MST concentration, contagion, and "
+            "diversification breakdown as routing inputs. High "
+            "concentration suppresses overlapping campaigns."
+        ),
+        "source": "research/diagnostics/network.py",
+        "target_layer": "campaign",
+        "direction": "suppress",
+        "expected_information_gain_effect": (
+            "high network concentration lowers expected information gain "
+            "for redundant exploration"
+        ),
+        "dead_zone_risk_effect": (
+            "raises dead-zone risk for portfolio-overlapping campaigns"
+        ),
+        "orthogonality_effect": "primary",
+        "public_data_quality_effect": "neutral",
+        "confirmation_requirement_effect": "neutral",
+        "allowed_use": (
+            "advisory campaign-layer input",
+            "suppress portfolio-overlapping campaigns",
+            "support cross-asset behaviour hypotheses",
+        ),
+        "extra_forbidden_use": (
+            "may not migrate capital across assets",
+        ),
+        "required_inputs": (
+            "cross-asset return matrix",
+            "correlation-window length",
+        ),
+        "missing_input_behavior": (
+            "if the correlation matrix cannot be built, signal status "
+            "falls to suppressed"
+        ),
+    },
+    {
+        "id": "rs_quorum_independent_evidence",
+        "family": "quorum",
+        "name": "Independent-evidence quorum routing signal",
+        "description": (
+            "Independent confirmations, confirmation diversity, and "
+            "single-source dependency flags as routing inputs. "
+            "Insufficient quorum keeps a hypothesis as a seed, never "
+            "escalating to candidate."
+        ),
+        "source": "research/diagnostics/quorum.py",
+        "target_layer": "evidence",
+        "direction": "require_confirmation",
+        "expected_information_gain_effect": (
+            "quorum confirmation raises expected information gain on "
+            "promotion"
+        ),
+        "dead_zone_risk_effect": (
+            "raises dead-zone risk on single-source-dependent hypotheses"
+        ),
+        "orthogonality_effect": "primary",
+        "public_data_quality_effect": "primary",
+        "confirmation_requirement_effect": (
+            "insufficient quorum keeps a hypothesis seed-only"
+        ),
+        "allowed_use": (
+            "advisory evidence-layer input",
+            "promotion / evidence guardrail",
+            "block single-diagnostic false positives",
+        ),
+        "extra_forbidden_use": (
+            "may not function as a live ensemble vote",
+            "may not allocate capital across confirmations",
+        ),
+        "required_inputs": (
+            "per-asset confirmation tally",
+            "per-timeframe confirmation tally",
+        ),
+        "missing_input_behavior": (
+            "if no confirmation tally is available, signal status falls "
+            "to suppressed"
+        ),
+    },
+    {
+        "id": "rs_external_intelligence_routing",
+        "family": "external_intelligence",
+        "name": "External-intelligence routing signal",
+        "description": (
+            "Public / free data manifest quality, freshness, and "
+            "license metadata as routing inputs. Failed quality gates "
+            "suppress promotion from a public-data-seeded hypothesis."
+        ),
+        "source": "research/external_intelligence/source_registry.py",
+        "target_layer": "campaign",
+        "direction": "require_confirmation",
+        "expected_information_gain_effect": (
+            "high public-data quality raises expected information gain "
+            "on seed promotion"
+        ),
+        "dead_zone_risk_effect": (
+            "raises dead-zone risk on stale or single-source seeds"
+        ),
+        "orthogonality_effect": "neutral",
+        "public_data_quality_effect": "primary",
+        "confirmation_requirement_effect": (
+            "failed quality gates block promotion from a public-data "
+            "seed"
+        ),
+        "allowed_use": (
+            "advisory campaign-layer input",
+            "block promotion when license / freshness / source-agreement "
+            "gates fail",
+            "support public-data-seeded hypothesis discovery",
+        ),
+        "extra_forbidden_use": (
+            "may not treat external data as alpha",
+            "may not call paid feeds or vendor-alpha endpoints",
+        ),
+        "required_inputs": (
+            "public-source manifest",
+            "public-data quality-gate verdict",
+        ),
+        "missing_input_behavior": (
+            "if the manifest or quality-gate verdict is missing, signal "
+            "status falls to suppressed and external seeds are blocked"
+        ),
+    },
+    {
+        "id": "rs_dead_zone_suppression",
+        "family": "dead_zone",
+        "name": "Dead-zone-aware suppression routing signal",
+        "description": (
+            "Aggregated dead-zone risk from upstream diagnostic "
+            "failures as a routing-suppression input. High dead-zone "
+            "risk suppresses further exploration in the same regime."
+        ),
+        "source": "research/diagnostics/null_models.py",
+        "target_layer": "campaign",
+        "direction": "suppress",
+        "expected_information_gain_effect": (
+            "high dead-zone risk lowers expected information gain"
+        ),
+        "dead_zone_risk_effect": (
+            "primary — directly drives dead-zone suppression"
+        ),
+        "orthogonality_effect": "neutral",
+        "public_data_quality_effect": "neutral",
+        "confirmation_requirement_effect": (
+            "high dead-zone risk raises confirmation requirement"
+        ),
+        "allowed_use": (
+            "advisory campaign-layer suppression input",
+            "deprioritize known dead-zone regimes",
+        ),
+        "extra_forbidden_use": (
+            "may not retire a candidate without policy approval",
+        ),
+        "required_inputs": (
+            "null-model verdict",
+            "regime-window length",
+        ),
+        "missing_input_behavior": (
+            "if null-model verdict is missing, signal status falls to "
+            "suppressed"
+        ),
+    },
+    {
+        "id": "rs_null_model_falsification",
+        "family": "null_model",
+        "name": "Null-model / Brownian-baseline routing signal",
+        "description": (
+            "Random-walk / shuffled-return / surrogate-data baselines "
+            "as falsification routing inputs. Failure to beat a null "
+            "model demotes the hypothesis family."
+        ),
+        "source": "research/diagnostics/null_models.py",
+        "target_layer": "evidence",
+        "direction": "deprioritize",
+        "expected_information_gain_effect": (
+            "failure to beat a null model lowers expected information "
+            "gain"
+        ),
+        "dead_zone_risk_effect": (
+            "raises dead-zone risk on null-model failures"
+        ),
+        "orthogonality_effect": "neutral",
+        "public_data_quality_effect": "neutral",
+        "confirmation_requirement_effect": (
+            "null-model failure raises confirmation requirement"
+        ),
+        "allowed_use": (
+            "advisory evidence-layer input",
+            "reject hypotheses that do not beat simple null models",
+            "baseline for entropy / tail / phase diagnostics",
+        ),
+        "extra_forbidden_use": (),
+        "required_inputs": (
+            "shuffled-return baseline",
+            "surrogate-data baseline",
+        ),
+        "missing_input_behavior": (
+            "if any null model is missing, signal status falls to "
+            "suppressed and falsification cannot fire"
+        ),
+    },
+    {
+        "id": "rs_barrier_breakout_pressure",
+        "family": "barrier",
+        "name": "Barrier / breakout-pressure routing signal",
+        "description": (
+            "Probabilistic barrier crossing, range-escape probability, "
+            "and post-breakout decay as routing inputs. False-breakout "
+            "regions raise confirmation requirements."
+        ),
+        "source": "research/diagnostics/barrier.py",
+        "target_layer": "strategy_mapping",
+        "direction": "require_confirmation",
+        "expected_information_gain_effect": (
+            "high barrier pressure raises expected information gain on "
+            "breakout hypotheses"
+        ),
+        "dead_zone_risk_effect": (
+            "raises dead-zone risk in high false-breakout regimes"
+        ),
+        "orthogonality_effect": "neutral",
+        "public_data_quality_effect": "neutral",
+        "confirmation_requirement_effect": (
+            "high false-breakout rate raises confirmation requirement"
+        ),
+        "allowed_use": (
+            "advisory strategy-mapping input",
+            "seed probabilistic breakout hypotheses",
+        ),
+        "extra_forbidden_use": (
+            "may not create deterministic support / resistance rules",
+        ),
+        "required_inputs": (
+            "OHLC source",
+            "barrier-zone definition",
+        ),
+        "missing_input_behavior": (
+            "if OHLC or barrier-zone source is missing, signal status "
+            "falls to suppressed"
+        ),
+    },
+    {
+        "id": "rs_resonance_cycle_confluence",
+        "family": "resonance",
+        "name": "Resonance / cycle-confluence routing signal",
+        "description": (
+            "Dominant-cycle period, cycle-stability, and resonance "
+            "confluence as routing inputs. Cycle fits without null-model "
+            "validation are demoted."
+        ),
+        "source": "research/diagnostics/resonance.py",
+        "target_layer": "preset",
+        "direction": "require_confirmation",
+        "expected_information_gain_effect": (
+            "strong resonance raises expected information gain on "
+            "cycle-confluence hypotheses"
+        ),
+        "dead_zone_risk_effect": (
+            "raises dead-zone risk on unstable cycle fits"
+        ),
+        "orthogonality_effect": "neutral",
+        "public_data_quality_effect": "neutral",
+        "confirmation_requirement_effect": (
+            "cycle fit without null-model validation raises confirmation "
+            "requirement"
+        ),
+        "allowed_use": (
+            "advisory preset-layer input",
+            "adapt candidate preset windows to cycle regimes",
+            "prioritize hypotheses where short / long cycles align",
+        ),
+        "extra_forbidden_use": (
+            "may not assume cycle equals alpha",
+        ),
+        "required_inputs": (
+            "price-series source",
+            "cycle-window length",
+        ),
+        "missing_input_behavior": (
+            "if cycle window cannot be computed, signal status falls to "
+            "suppressed"
+        ),
+    },
+    {
+        "id": "rs_adversarial_market_behavior",
+        "family": "adversarial",
+        "name": "Adversarial-market-behavior routing signal",
+        "description": (
+            "Crowding, adverse selection, fake-breakout rate, and "
+            "post-signal decay as routing inputs. Predatory regimes "
+            "raise confirmation requirements."
+        ),
+        "source": "research/diagnostics/adversarial.py",
+        "target_layer": "evidence",
+        "direction": "require_confirmation",
+        "expected_information_gain_effect": (
+            "adversarial regimes lower expected information gain on "
+            "fragile breakout hypotheses"
+        ),
+        "dead_zone_risk_effect": (
+            "raises dead-zone risk in predatory regimes"
+        ),
+        "orthogonality_effect": "neutral",
+        "public_data_quality_effect": "neutral",
+        "confirmation_requirement_effect": (
+            "adversarial regime raises confirmation requirement"
+        ),
+        "allowed_use": (
+            "advisory evidence-layer input",
+            "route to liquidity-aware behaviour families",
+            "evaluate signal decay in shadow",
+        ),
+        "extra_forbidden_use": (
+            "may not randomize preset selection",
+            "may not mix live strategies stochastically",
+        ),
+        "required_inputs": (
+            "post-signal decay series",
+            "fake-breakout statistic",
+        ),
+        "missing_input_behavior": (
+            "if adversarial statistics are missing, signal status falls "
+            "to suppressed"
+        ),
+    },
+    {
+        "id": "rs_seismic_shock_aftershock",
+        "family": "seismic",
+        "name": "Seismic shock / aftershock routing signal",
+        "description": (
+            "Mainshock detection, aftershock decay rate, and "
+            "post-shock directional bias as routing inputs. Active "
+            "aftershock regimes cool down new campaigns."
+        ),
+        "source": "research/diagnostics/seismic.py",
+        "target_layer": "campaign",
+        "direction": "suppress",
+        "expected_information_gain_effect": (
+            "active aftershock regimes lower expected information gain "
+            "on new campaigns"
+        ),
+        "dead_zone_risk_effect": (
+            "raises dead-zone risk in unstable aftershock regimes"
+        ),
+        "orthogonality_effect": "neutral",
+        "public_data_quality_effect": "neutral",
+        "confirmation_requirement_effect": (
+            "active shock regime raises confirmation requirement"
+        ),
+        "allowed_use": (
+            "advisory campaign-layer cooldown input",
+            "generate post-shock continuation / reversal hypotheses",
+            "test volatility decay profiles",
+        ),
+        "extra_forbidden_use": (
+            "may not predict crashes as deterministic events",
+        ),
+        "required_inputs": (
+            "shock-detection statistic",
+            "aftershock-decay statistic",
+        ),
+        "missing_input_behavior": (
+            "if shock-detection statistic is missing, signal status falls "
+            "to suppressed"
+        ),
+    },
+    {
+        "id": "rs_turbulence_liquidity",
+        "family": "turbulence",
+        "name": "Liquidity-turbulence routing signal",
+        "description": (
+            "Liquidity turbulence score, slippage-convexity proxy, and "
+            "flow-break risk as routing inputs. Turbulent regimes defer "
+            "execution-sensitive mappings."
+        ),
+        "source": "research/diagnostics/turbulence.py",
+        "target_layer": "policy",
+        "direction": "deprioritize",
+        "expected_information_gain_effect": (
+            "turbulent regimes lower expected information gain on "
+            "execution-sensitive mappings"
+        ),
+        "dead_zone_risk_effect": (
+            "raises dead-zone risk in turbulent regimes"
+        ),
+        "orthogonality_effect": "neutral",
+        "public_data_quality_effect": "neutral",
+        "confirmation_requirement_effect": (
+            "turbulent regime raises confirmation requirement"
+        ),
+        "allowed_use": (
+            "advisory policy-layer input",
+            "defer execution-sensitive mappings to shadow / paper "
+            "validation in their future approved phases",
+        ),
+        "extra_forbidden_use": (
+            "may not adjust order size or order routing",
+            "may not enable execution-layer behaviour outside an "
+            "approved phase",
+        ),
+        "required_inputs": (
+            "volume-imbalance series",
+            "realized-volatility burst statistic",
+        ),
+        "missing_input_behavior": (
+            "if turbulence statistics are missing, signal status falls "
+            "to suppressed"
+        ),
+    },
+    {
+        "id": "rs_market_language_grammar",
+        "family": "market_language",
+        "name": "Market-language / grammar-shift routing signal",
+        "description": (
+            "Tokenized return / volatility / volume states, Zipf slope, "
+            "and grammar-shift score as routing inputs. Must be "
+            "null-model tested before any promotion."
+        ),
+        "source": "research/diagnostics/language.py",
+        "target_layer": "hypothesis_discovery",
+        "direction": "neutral",
+        "expected_information_gain_effect": (
+            "grammar shifts may raise expected information gain on "
+            "symbolic-behaviour hypotheses"
+        ),
+        "dead_zone_risk_effect": (
+            "raises dead-zone risk on rare-pattern-as-alpha assumptions"
+        ),
+        "orthogonality_effect": "neutral",
+        "public_data_quality_effect": "neutral",
+        "confirmation_requirement_effect": (
+            "raises confirmation requirement when null-model not "
+            "tested"
+        ),
+        "allowed_use": (
+            "advisory hypothesis-discovery input",
+            "seed hypotheses about compression -> expansion sequences",
+            "explain market behaviour in observable token language",
+        ),
+        "extra_forbidden_use": (
+            "may not mine candle patterns",
+            "may not assume rare patterns equal alpha",
+            "may not enable NLP-heavy social pipelines before quality "
+            "gates exist",
+        ),
+        "required_inputs": (
+            "tokenized state-sequence source",
+            "null-model token baseline",
+        ),
+        "missing_input_behavior": (
+            "if the null-model baseline is missing, signal status falls "
+            "to suppressed"
+        ),
+    },
+)
+
+
+# ---------------------------------------------------------------------------
+# Signal normalisation
+# ---------------------------------------------------------------------------
+
+
+def _normalise_signal(raw: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": _bounded_str(raw["id"], 96),
+        "family": raw["family"],
+        "name": _bounded_str(raw["name"], MAX_NAME_LEN),
+        "description": _bounded_str(raw["description"], MAX_DESCRIPTION_LEN),
+        "source": raw["source"],
+        "target_layer": raw["target_layer"],
+        "direction": raw["direction"],
+        # Every signal in this unit ships at status="schema_only". A
+        # later approved unit may lift specific signals to
+        # advisory_planned / advisory_active.
+        "status": "schema_only",
+        "expected_information_gain_effect": _bounded_str(
+            raw["expected_information_gain_effect"], MAX_EFFECT_LEN
+        ),
+        "dead_zone_risk_effect": _bounded_str(
+            raw["dead_zone_risk_effect"], MAX_EFFECT_LEN
+        ),
+        "orthogonality_effect": _bounded_str(
+            raw["orthogonality_effect"], MAX_EFFECT_LEN
+        ),
+        "public_data_quality_effect": _bounded_str(
+            raw["public_data_quality_effect"], MAX_EFFECT_LEN
+        ),
+        "confirmation_requirement_effect": _bounded_str(
+            raw["confirmation_requirement_effect"], MAX_EFFECT_LEN
+        ),
+        "allowed_use": _bounded_str_tuple(
+            raw["allowed_use"], MAX_ALLOWED_USE_ITEMS, MAX_LIST_ITEM_LEN
+        ),
+        "forbidden_use": _merge_forbidden_use(raw.get("extra_forbidden_use", ())),
+        "required_inputs": _bounded_str_tuple(
+            raw["required_inputs"], MAX_REQUIRED_INPUTS, MAX_LIST_ITEM_LEN
+        ),
+        "missing_input_behavior": _bounded_str(
+            raw["missing_input_behavior"], MAX_MISSING_INPUT_BEHAVIOR_LEN
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Snapshot assembly
+# ---------------------------------------------------------------------------
+
+
+def collect_snapshot(
+    *,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    """Build the deterministic routing-signals projection."""
+    ts = generated_at_utc if generated_at_utc is not None else _utcnow()
+    signals = [_normalise_signal(s) for s in _SIGNALS_SEED]
+    signals.sort(key=lambda s: (s["family"], s["id"]))
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": ts,
+        "step5_enabled_substage": STEP5_ENABLED_SUBSTAGE,
+        "step5_implementation_allowed": step5_implementation_allowed,
+        "vocabularies": {
+            "routing_signal_family": list(ROUTING_SIGNAL_FAMILY),
+            "routing_signal_status": list(ROUTING_SIGNAL_STATUS),
+            "routing_signal_direction": list(ROUTING_SIGNAL_DIRECTION),
+            "routing_signal_source": list(ROUTING_SIGNAL_SOURCE),
+            "routing_signal_target_layer": list(ROUTING_SIGNAL_TARGET_LAYER),
+        },
+        "signals": signals,
+        "projection_invariants": dict(_BASE_PROJECTION_INVARIANTS),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Atomic write
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Atomically write ``payload`` as sorted-key indented JSON.
+    Refuses any path outside
+    ``logs/intelligent_routing_diagnostic_signals/``."""
+    posix = path.as_posix()
+    if _WRITE_PREFIX not in posix:
+        raise ValueError(
+            "intelligent_routing_diagnostic_signals._atomic_write_json "
+            f"refuses non-signals-logs output path: {path}"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".intelligent_routing_diagnostic_signals.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_outputs(snapshot: dict[str, Any]) -> Path:
+    _atomic_write_json(ARTIFACT_LATEST, snapshot)
+    return ARTIFACT_LATEST
+
+
+# ---------------------------------------------------------------------------
+# Status renderer
+# ---------------------------------------------------------------------------
+
+
+def _render_status(snapshot: dict[str, Any]) -> str:
+    signals = snapshot["signals"]
+    inv = snapshot["projection_invariants"]
+    by_family: dict[str, int] = {f: 0 for f in ROUTING_SIGNAL_FAMILY}
+    for s in signals:
+        if s["family"] in by_family:
+            by_family[s["family"]] += 1
+    lines = [
+        f"intelligent_routing_diagnostic_signals {snapshot['module_version']} "
+        f"schema={snapshot['schema_version']}",
+        f"generated_at_utc={snapshot['generated_at_utc']}",
+        f"signals={len(signals)}",
+        (
+            "step5_implementation_allowed="
+            f"{snapshot['step5_implementation_allowed']} "
+            f"step5_enabled_substage={snapshot['step5_enabled_substage']}"
+        ),
+        (
+            "diagnostics_do_not_trade="
+            f"{inv['diagnostics_do_not_trade']} "
+            "external_data_is_not_alpha="
+            f"{inv['external_data_is_not_alpha']}"
+        ),
+        (
+            "no_runtime_trading_authority="
+            f"{inv['no_runtime_trading_authority']} "
+            f"no_step5_runtime={inv['no_step5_runtime']} "
+            f"no_level6={inv['no_level6']} "
+            "no_production_merge_authority="
+            f"{inv['no_production_merge_authority']}"
+        ),
+        (
+            "no_campaign_queue_mutation="
+            f"{inv['no_campaign_queue_mutation']} "
+            "no_strategy_generation="
+            f"{inv['no_strategy_generation']} "
+            "no_routing_mutation="
+            f"{inv['no_routing_mutation']}"
+        ),
+        f"by_family={dict(sorted(by_family.items()))}",
+    ]
+    for s in signals:
+        lines.append(
+            f"  signal {s['id']} family={s['family']} "
+            f"target_layer={s['target_layer']} "
+            f"direction={s['direction']} status={s['status']}"
+        )
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m reporting.intelligent_routing_diagnostic_signals",
+        description=(
+            "v3.15.16 Intelligent Routing Layer — diagnostic-aware "
+            "routing signals schema and read-only projector. Schema "
+            "and projector only; no routing mutation, no campaign "
+            "queue mutation, no strategy generation, no trading "
+            "behaviour. Step 5 implementation remains BLOCKED."
+        ),
+    )
+    p.add_argument(
+        "--indent",
+        type=int,
+        default=2,
+        help="JSON indent for stdout output (0 for compact).",
+    )
+    p.add_argument(
+        "--no-write",
+        action="store_true",
+        help=(
+            "Do not persist "
+            "logs/intelligent_routing_diagnostic_signals/latest.json "
+            "(stdout only)."
+        ),
+    )
+    p.add_argument(
+        "--status",
+        action="store_true",
+        help=(
+            "Render a compact human-readable status summary to stdout "
+            "and exit. Does not write any artefact."
+        ),
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    snap = collect_snapshot()
+    if args.status:
+        sys.stdout.write(_render_status(snap))
+        return 0
+    indent = args.indent if args.indent and args.indent > 0 else None
+    if not args.no_write:
+        write_outputs(snap)
+    json.dump(snap, sys.stdout, indent=indent, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/unit/test_intelligent_routing_diagnostic_signals.py
+++ b/tests/unit/test_intelligent_routing_diagnostic_signals.py
@@ -1,0 +1,878 @@
+"""Unit tests for v3.15.16 Intelligent Routing Layer —
+diagnostic-aware routing signals schema and projector.
+
+Pins:
+
+* closed vocabularies (ROUTING_SIGNAL_FAMILY,
+  ROUTING_SIGNAL_STATUS, ROUTING_SIGNAL_DIRECTION,
+  ROUTING_SIGNAL_SOURCE, ROUTING_SIGNAL_TARGET_LAYER);
+* schema integrity (RoutingDiagnosticSignal,
+  RoutingSignalProjection field tuples);
+* deterministic output with injected ``generated_at_utc``;
+* byte-identical output for identical input;
+* atomic write only under
+  ``logs/intelligent_routing_diagnostic_signals/``;
+* ``--no-write`` does not write; ``--status`` does not write;
+* every Roadmap v6 + Addendum 1 signal family is represented
+  with at least one signal;
+* every signal has non-empty ``allowed_use``, ``forbidden_use``,
+  and ``missing_input_behavior``;
+* effect fields are bounded prose: non-empty, ≤200 chars, no
+  newline, no authority-granting / trade / execute / order /
+  capital-allocation phrases;
+* ``status="schema_only"`` is hard-coded in ``_normalise_signal``
+  (a synthetic seed with a different status is still emitted as
+  ``schema_only``);
+* baseline ``forbidden_use`` is prepended on every signal;
+  per-signal extras append without replacing the baseline;
+  duplicates are deterministically de-duplicated; order is
+  stable;
+* projection_invariants pin: diagnostics_do_not_trade,
+  external_data_is_not_alpha, no_runtime_trading_authority,
+  no_campaign_queue_mutation, no_strategy_generation,
+  no_step5_runtime, no_level6,
+  no_production_merge_authority, read_only;
+* no forbidden imports or forbidden runtime tokens appear in the
+  module source.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reporting import intelligent_routing_diagnostic_signals as rsd
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+_FROZEN_UTC = "2026-05-18T22:00:00Z"
+
+
+@pytest.fixture
+def snap() -> dict:
+    return rsd.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies
+# ---------------------------------------------------------------------------
+
+
+def test_routing_signal_family_is_closed_exact() -> None:
+    """Roadmap v6 + Addendum 1 diagnostic families. Exactly 14
+    entries; order matters for deterministic projection."""
+    assert rsd.ROUTING_SIGNAL_FAMILY == (
+        "entropy",
+        "tail",
+        "criticality",
+        "network",
+        "quorum",
+        "external_intelligence",
+        "dead_zone",
+        "null_model",
+        "barrier",
+        "resonance",
+        "adversarial",
+        "seismic",
+        "turbulence",
+        "market_language",
+    )
+
+
+def test_routing_signal_status_is_closed() -> None:
+    assert rsd.ROUTING_SIGNAL_STATUS == (
+        "schema_only",
+        "advisory_planned",
+        "advisory_active",
+        "suppressed",
+        "deprecated",
+    )
+
+
+def test_routing_signal_direction_is_closed() -> None:
+    """Direction values describe routing priority effect only; no
+    buy/sell direction — diagnostics do not trade."""
+    assert rsd.ROUTING_SIGNAL_DIRECTION == (
+        "prioritize",
+        "deprioritize",
+        "suppress",
+        "neutral",
+        "require_confirmation",
+    )
+    # Forbid trading-direction words.
+    for value in rsd.ROUTING_SIGNAL_DIRECTION:
+        for forbidden in ("buy", "sell", "long", "short", "exit"):
+            assert forbidden != value, (value, forbidden)
+
+
+def test_routing_signal_source_is_closed_and_non_empty() -> None:
+    assert isinstance(rsd.ROUTING_SIGNAL_SOURCE, tuple)
+    assert len(rsd.ROUTING_SIGNAL_SOURCE) >= 14
+    for s in rsd.ROUTING_SIGNAL_SOURCE:
+        assert isinstance(s, str) and s
+
+
+def test_routing_signal_target_layer_is_closed_exact() -> None:
+    assert rsd.ROUTING_SIGNAL_TARGET_LAYER == (
+        "market_behavior",
+        "hypothesis_discovery",
+        "strategy_mapping",
+        "preset",
+        "campaign",
+        "funnel",
+        "evidence",
+        "policy",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Schema integrity
+# ---------------------------------------------------------------------------
+
+
+def test_routing_diagnostic_signal_field_list_exact() -> None:
+    assert rsd.ROUTING_DIAGNOSTIC_SIGNAL_FIELDS == (
+        "id",
+        "family",
+        "name",
+        "description",
+        "source",
+        "target_layer",
+        "direction",
+        "status",
+        "expected_information_gain_effect",
+        "dead_zone_risk_effect",
+        "orthogonality_effect",
+        "public_data_quality_effect",
+        "confirmation_requirement_effect",
+        "allowed_use",
+        "forbidden_use",
+        "required_inputs",
+        "missing_input_behavior",
+    )
+
+
+def test_routing_signal_projection_field_list_exact() -> None:
+    assert rsd.ROUTING_SIGNAL_PROJECTION_FIELDS == (
+        "generated_at_utc",
+        "schema_version",
+        "module_version",
+        "signals",
+        "projection_invariants",
+    )
+
+
+def test_every_signal_has_every_field(snap: dict) -> None:
+    for s in snap["signals"]:
+        assert set(s.keys()) == set(
+            rsd.ROUTING_DIAGNOSTIC_SIGNAL_FIELDS
+        ), s
+
+
+def test_projection_carries_every_top_level_field(snap: dict) -> None:
+    for field in rsd.ROUTING_SIGNAL_PROJECTION_FIELDS:
+        assert field in snap, field
+
+
+def test_every_signal_value_in_closed_vocab(snap: dict) -> None:
+    for s in snap["signals"]:
+        assert s["family"] in rsd.ROUTING_SIGNAL_FAMILY
+        assert s["status"] in rsd.ROUTING_SIGNAL_STATUS
+        assert s["direction"] in rsd.ROUTING_SIGNAL_DIRECTION
+        assert s["source"] in rsd.ROUTING_SIGNAL_SOURCE
+        assert s["target_layer"] in rsd.ROUTING_SIGNAL_TARGET_LAYER
+
+
+def test_signal_ids_are_unique(snap: dict) -> None:
+    ids = [s["id"] for s in snap["signals"]]
+    assert len(ids) == len(set(ids))
+
+
+# ---------------------------------------------------------------------------
+# All Roadmap v6 + Addendum 1 families are represented
+# ---------------------------------------------------------------------------
+
+
+_REQUIRED_FAMILIES = (
+    "entropy",
+    "tail",
+    "criticality",
+    "network",
+    "quorum",
+    "external_intelligence",
+    "dead_zone",
+    "null_model",
+    "barrier",
+    "resonance",
+    "adversarial",
+    "seismic",
+    "turbulence",
+    "market_language",
+)
+
+
+@pytest.mark.parametrize("family", _REQUIRED_FAMILIES)
+def test_every_required_family_has_at_least_one_signal(
+    snap: dict, family: str
+) -> None:
+    matched = [s for s in snap["signals"] if s["family"] == family]
+    assert len(matched) >= 1, family
+
+
+def test_signal_count_matches_family_count(snap: dict) -> None:
+    """Today there is exactly one signal per family. Future
+    operator-approved units may add more; if they do, this test is
+    the canonical place to update the expected count."""
+    assert len(snap["signals"]) == len(_REQUIRED_FAMILIES)
+
+
+# ---------------------------------------------------------------------------
+# Mandatory list / scalar fields are non-empty
+# ---------------------------------------------------------------------------
+
+
+def test_every_signal_has_non_empty_allowed_use(snap: dict) -> None:
+    for s in snap["signals"]:
+        assert isinstance(s["allowed_use"], list)
+        assert s["allowed_use"], s["id"]
+
+
+def test_every_signal_has_non_empty_forbidden_use(snap: dict) -> None:
+    for s in snap["signals"]:
+        assert isinstance(s["forbidden_use"], list)
+        assert s["forbidden_use"], s["id"]
+
+
+def test_every_signal_has_non_empty_required_inputs(snap: dict) -> None:
+    for s in snap["signals"]:
+        assert isinstance(s["required_inputs"], list)
+        assert s["required_inputs"], s["id"]
+
+
+def test_every_signal_has_missing_input_behavior(snap: dict) -> None:
+    for s in snap["signals"]:
+        assert isinstance(s["missing_input_behavior"], str)
+        assert s["missing_input_behavior"].strip(), s["id"]
+
+
+# ---------------------------------------------------------------------------
+# Effect fields are bounded prose: non-empty, <=200 chars, no newline,
+# no authority-granting / trade / execute / order / capital phrases.
+# ---------------------------------------------------------------------------
+
+
+_EFFECT_FIELDS = (
+    "expected_information_gain_effect",
+    "dead_zone_risk_effect",
+    "orthogonality_effect",
+    "public_data_quality_effect",
+    "confirmation_requirement_effect",
+)
+
+
+@pytest.mark.parametrize("field", _EFFECT_FIELDS)
+def test_effect_field_is_non_empty_bounded_string(
+    snap: dict, field: str
+) -> None:
+    for s in snap["signals"]:
+        v = s[field]
+        assert isinstance(v, str), (s["id"], field, type(v))
+        assert v.strip(), (s["id"], field, "empty")
+        assert len(v) <= rsd.MAX_EFFECT_LEN, (s["id"], field, len(v))
+
+
+@pytest.mark.parametrize("field", _EFFECT_FIELDS)
+def test_effect_field_has_no_newline(snap: dict, field: str) -> None:
+    for s in snap["signals"]:
+        v = s[field]
+        assert "\n" not in v, (s["id"], field)
+        assert "\r" not in v, (s["id"], field)
+
+
+_FORBIDDEN_EFFECT_SEMANTICS = (
+    # Authority-granting verb phrases on the signal itself.
+    "places order",
+    "places orders",
+    "place orders",
+    "places trade",
+    "places trades",
+    "place trades",
+    "place a trade",
+    "executes trade",
+    "executes trades",
+    "execute trade",
+    "execute trades",
+    "execute orders",
+    "allocates capital",
+    "allocate capital",
+    "moves funds",
+    "moves capital",
+    "move capital",
+    "mutates live",
+    "mutates risk",
+    "mutate live",
+    "mutate risk",
+    "opens position",
+    "opens positions",
+    "open position",
+    "open positions",
+    "submits order",
+    "submit order",
+    "submits orders",
+    "submit orders",
+    "should trade",
+    "should execute",
+    "should allocate",
+    "should place",
+)
+
+
+@pytest.mark.parametrize("field", _EFFECT_FIELDS)
+def test_effect_field_has_no_authority_granting_semantics(
+    snap: dict, field: str
+) -> None:
+    for s in snap["signals"]:
+        lo = s[field].lower()
+        for forbidden in _FORBIDDEN_EFFECT_SEMANTICS:
+            assert forbidden not in lo, (s["id"], field, forbidden)
+
+
+# ---------------------------------------------------------------------------
+# status="schema_only" is hard-coded in _normalise_signal
+# ---------------------------------------------------------------------------
+
+
+def test_every_emitted_signal_has_status_schema_only(snap: dict) -> None:
+    for s in snap["signals"]:
+        assert s["status"] == "schema_only", s["id"]
+
+
+def test_normalise_signal_overrides_status_with_schema_only() -> None:
+    """Synthetic seed with a different status must STILL emit
+    status='schema_only'. This pins the hard-coded override in
+    `_normalise_signal()`."""
+    synthetic_raw = {
+        "id": "synthetic_signal",
+        "family": "entropy",
+        "name": "Synthetic signal for status-override test",
+        "description": "Test fixture.",
+        "source": "research/diagnostics/entropy.py",
+        "target_layer": "campaign",
+        "direction": "neutral",
+        # Deliberately wrong: the seed claims advisory_active.
+        "status": "advisory_active",
+        "expected_information_gain_effect": "neutral",
+        "dead_zone_risk_effect": "neutral",
+        "orthogonality_effect": "neutral",
+        "public_data_quality_effect": "neutral",
+        "confirmation_requirement_effect": "neutral",
+        "allowed_use": ("advisory routing input",),
+        "extra_forbidden_use": (),
+        "required_inputs": ("synthetic input",),
+        "missing_input_behavior": "fall to suppressed",
+    }
+    out = rsd._normalise_signal(synthetic_raw)
+    assert out["status"] == "schema_only"
+
+
+# ---------------------------------------------------------------------------
+# Baseline forbidden_use prepended on every signal; per-signal extras
+# appended without replacing baseline; duplicates dedup'd; stable order.
+# ---------------------------------------------------------------------------
+
+
+def test_every_signal_carries_all_baseline_forbidden_use_entries(
+    snap: dict,
+) -> None:
+    for s in snap["signals"]:
+        for required in rsd._BASE_FORBIDDEN_USE:
+            assert required in s["forbidden_use"], (s["id"], required)
+
+
+def test_baseline_forbidden_use_appears_before_per_signal_extras() -> None:
+    """The baseline order is preserved at the front of every emitted
+    forbidden_use list. Per-signal extras are appended after the
+    baseline."""
+    synthetic_raw = {
+        "id": "synthetic_for_order_test",
+        "family": "entropy",
+        "name": "Synthetic order-pin",
+        "description": "Order-pin test fixture.",
+        "source": "research/diagnostics/entropy.py",
+        "target_layer": "campaign",
+        "direction": "neutral",
+        "status": "schema_only",
+        "expected_information_gain_effect": "neutral",
+        "dead_zone_risk_effect": "neutral",
+        "orthogonality_effect": "neutral",
+        "public_data_quality_effect": "neutral",
+        "confirmation_requirement_effect": "neutral",
+        "allowed_use": ("advisory routing input",),
+        "extra_forbidden_use": (
+            "may not synthetically forbid one extra thing",
+        ),
+        "required_inputs": ("synthetic input",),
+        "missing_input_behavior": "fall to suppressed",
+    }
+    out = rsd._normalise_signal(synthetic_raw)
+    forbidden = out["forbidden_use"]
+    # The baseline list appears in order at the head of the merged
+    # list, then the extra entry.
+    baseline_indices = [
+        forbidden.index(b) for b in rsd._BASE_FORBIDDEN_USE if b in forbidden
+    ]
+    assert baseline_indices == sorted(baseline_indices), forbidden
+    extra_idx = forbidden.index(
+        "may not synthetically forbid one extra thing"
+    )
+    for i in baseline_indices:
+        assert i < extra_idx, (forbidden, i, extra_idx)
+
+
+def test_per_signal_extra_does_not_replace_baseline(snap: dict) -> None:
+    """No signal-specific forbid replaces the baseline list. The
+    baseline survives every merge."""
+    for s in snap["signals"]:
+        for required in rsd._BASE_FORBIDDEN_USE:
+            assert required in s["forbidden_use"], (s["id"], required)
+
+
+def test_duplicate_forbidden_use_entries_are_deduplicated() -> None:
+    """Per-signal extras that duplicate a baseline entry are
+    deterministically dropped; the order remains stable."""
+    duplicate_extra = rsd._BASE_FORBIDDEN_USE[0]
+    synthetic_raw = {
+        "id": "synthetic_for_dedup_test",
+        "family": "entropy",
+        "name": "Synthetic dedup-pin",
+        "description": "Dedup-pin test fixture.",
+        "source": "research/diagnostics/entropy.py",
+        "target_layer": "campaign",
+        "direction": "neutral",
+        "status": "schema_only",
+        "expected_information_gain_effect": "neutral",
+        "dead_zone_risk_effect": "neutral",
+        "orthogonality_effect": "neutral",
+        "public_data_quality_effect": "neutral",
+        "confirmation_requirement_effect": "neutral",
+        "allowed_use": ("advisory routing input",),
+        "extra_forbidden_use": (
+            duplicate_extra,  # exact baseline duplicate
+            "may not do something specific",
+        ),
+        "required_inputs": ("synthetic input",),
+        "missing_input_behavior": "fall to suppressed",
+    }
+    out = rsd._normalise_signal(synthetic_raw)
+    forbidden = out["forbidden_use"]
+    # The duplicate baseline entry appears exactly once.
+    assert forbidden.count(duplicate_extra) == 1
+    # The unique extra is appended.
+    assert "may not do something specific" in forbidden
+
+
+def test_forbidden_use_order_is_stable_across_runs(snap: dict) -> None:
+    a = rsd.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+    b = rsd.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+    for sa, sb in zip(a["signals"], b["signals"]):
+        assert sa["forbidden_use"] == sb["forbidden_use"]
+
+
+# ---------------------------------------------------------------------------
+# Projection invariants
+# ---------------------------------------------------------------------------
+
+
+def test_projection_invariants_pin_diagnostics_do_not_trade(
+    snap: dict,
+) -> None:
+    inv = snap["projection_invariants"]
+    assert inv["diagnostics_do_not_trade"] is True
+
+
+def test_projection_invariants_pin_external_data_is_not_alpha(
+    snap: dict,
+) -> None:
+    inv = snap["projection_invariants"]
+    assert inv["external_data_is_not_alpha"] is True
+
+
+def test_projection_invariants_pin_read_only(snap: dict) -> None:
+    inv = snap["projection_invariants"]
+    assert inv["read_only"] is True
+
+
+def test_projection_invariants_pin_no_runtime_trading_authority(
+    snap: dict,
+) -> None:
+    inv = snap["projection_invariants"]
+    assert inv["no_runtime_trading_authority"] is True
+
+
+def test_projection_invariants_pin_no_campaign_queue_mutation(
+    snap: dict,
+) -> None:
+    inv = snap["projection_invariants"]
+    assert inv["no_campaign_queue_mutation"] is True
+
+
+def test_projection_invariants_pin_no_strategy_generation(
+    snap: dict,
+) -> None:
+    inv = snap["projection_invariants"]
+    assert inv["no_strategy_generation"] is True
+
+
+def test_projection_invariants_pin_no_step5_runtime(snap: dict) -> None:
+    inv = snap["projection_invariants"]
+    assert inv["no_step5_runtime"] is True
+    assert snap["step5_implementation_allowed"] is False
+    assert snap["step5_enabled_substage"] == "none"
+
+
+def test_projection_invariants_pin_no_level6(snap: dict) -> None:
+    inv = snap["projection_invariants"]
+    assert inv["no_level6"] is True
+
+
+def test_projection_invariants_pin_no_production_merge_authority(
+    snap: dict,
+) -> None:
+    inv = snap["projection_invariants"]
+    assert inv["no_production_merge_authority"] is True
+
+
+def test_projection_invariants_pin_no_routing_mutation(snap: dict) -> None:
+    inv = snap["projection_invariants"]
+    assert inv["no_routing_mutation"] is True
+    assert inv["no_research_runtime_change"] is True
+
+
+def test_projection_invariants_pin_no_branch_pr_merge_deploy(
+    snap: dict,
+) -> None:
+    inv = snap["projection_invariants"]
+    assert inv["no_branch_creation"] is True
+    assert inv["no_pr_creation"] is True
+    assert inv["no_merge_or_deploy"] is True
+
+
+def test_projection_invariants_pin_no_mutation_routes_or_approval_buttons(
+    snap: dict,
+) -> None:
+    inv = snap["projection_invariants"]
+    assert inv["no_mutation_routes"] is True
+    assert inv["no_approval_buttons"] is True
+
+
+def test_projection_invariants_pin_writes_only_signals_log(
+    snap: dict,
+) -> None:
+    inv = snap["projection_invariants"]
+    assert inv["writes_only_intelligent_routing_diagnostic_signals_log"] is True
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_deterministic_with_injected_ts() -> None:
+    a = rsd.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+    b = rsd.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+    assert a == b
+
+
+def test_serialised_output_byte_identical_with_injected_ts() -> None:
+    a = rsd.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+    b = rsd.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+    out_a = json.dumps(a, indent=2, sort_keys=True) + "\n"
+    out_b = json.dumps(b, indent=2, sort_keys=True) + "\n"
+    assert out_a == out_b
+
+
+def test_signals_sorted_stably_by_family_then_id(snap: dict) -> None:
+    pairs = [(s["family"], s["id"]) for s in snap["signals"]]
+    assert pairs == sorted(pairs)
+
+
+# ---------------------------------------------------------------------------
+# Atomic write allowlist
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_write_refuses_path_outside_allowlist(tmp_path: Path) -> None:
+    bad = tmp_path / "logs" / "elsewhere" / "latest.json"
+    bad.parent.mkdir(parents=True, exist_ok=True)
+    with pytest.raises(ValueError):
+        rsd._atomic_write_json(bad, {"x": 1})
+
+
+def test_atomic_write_refuses_frozen_contract_paths(tmp_path: Path) -> None:
+    for forbidden in (
+        "research/research_latest.json",
+        "research/strategy_matrix.csv",
+    ):
+        target = tmp_path / forbidden
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with pytest.raises(ValueError):
+            rsd._atomic_write_json(target, {"x": 1})
+
+
+def test_atomic_write_accepts_allowlisted_path(tmp_path: Path) -> None:
+    good = (
+        tmp_path
+        / "logs"
+        / "intelligent_routing_diagnostic_signals"
+        / "latest.json"
+    )
+    good.parent.mkdir(parents=True, exist_ok=True)
+    rsd._atomic_write_json(good, {"x": 1})
+    assert good.is_file()
+
+
+def test_atomic_write_is_atomic(tmp_path: Path) -> None:
+    target = (
+        tmp_path
+        / "logs"
+        / "intelligent_routing_diagnostic_signals"
+        / "latest.json"
+    )
+    target.parent.mkdir(parents=True, exist_ok=True)
+    rsd._atomic_write_json(target, {"x": 1})
+    rsd._atomic_write_json(target, {"x": 2})
+    siblings = list(target.parent.iterdir())
+    assert siblings == [target]
+
+
+# ---------------------------------------------------------------------------
+# CLI behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_cli_no_write_does_not_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    sentinel = (
+        tmp_path
+        / "logs"
+        / "intelligent_routing_diagnostic_signals"
+        / "latest.json"
+    )
+    monkeypatch.setattr(rsd, "ARTIFACT_LATEST", sentinel)
+    monkeypatch.setattr(rsd, "ARTIFACT_DIR", sentinel.parent)
+    rc = rsd.main(["--no-write"])
+    assert rc == 0
+    assert not sentinel.exists()
+    out = capsys.readouterr().out
+    assert '"intelligent_routing_diagnostic_signals"' in out
+
+
+def test_cli_status_does_not_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    sentinel = (
+        tmp_path
+        / "logs"
+        / "intelligent_routing_diagnostic_signals"
+        / "latest.json"
+    )
+    monkeypatch.setattr(rsd, "ARTIFACT_LATEST", sentinel)
+    monkeypatch.setattr(rsd, "ARTIFACT_DIR", sentinel.parent)
+    rc = rsd.main(["--status"])
+    assert rc == 0
+    assert not sentinel.exists()
+    out = capsys.readouterr().out
+    assert "intelligent_routing_diagnostic_signals" in out
+    assert "diagnostics_do_not_trade=True" in out
+    assert "external_data_is_not_alpha=True" in out
+    assert "no_runtime_trading_authority=True" in out
+    assert "no_step5_runtime=True" in out
+    assert "no_level6=True" in out
+    assert "no_production_merge_authority=True" in out
+
+
+def test_cli_default_writes_to_allowlisted_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sentinel = (
+        tmp_path
+        / "logs"
+        / "intelligent_routing_diagnostic_signals"
+        / "latest.json"
+    )
+    monkeypatch.setattr(rsd, "ARTIFACT_LATEST", sentinel)
+    monkeypatch.setattr(rsd, "ARTIFACT_DIR", sentinel.parent)
+    rc = rsd.main([])
+    assert rc == 0
+    assert sentinel.is_file()
+    payload = json.loads(sentinel.read_text(encoding="utf-8"))
+    assert payload["report_kind"] == "intelligent_routing_diagnostic_signals"
+    assert payload["module_version"].startswith("v3.15.16.routing_signals")
+
+
+def test_cli_indent_zero_compact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    sentinel = (
+        tmp_path
+        / "logs"
+        / "intelligent_routing_diagnostic_signals"
+        / "latest.json"
+    )
+    monkeypatch.setattr(rsd, "ARTIFACT_LATEST", sentinel)
+    monkeypatch.setattr(rsd, "ARTIFACT_DIR", sentinel.parent)
+    rc = rsd.main(["--no-write", "--indent", "0"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "\n  " not in out
+
+
+# ---------------------------------------------------------------------------
+# Module-source forbidden-import / forbidden-token scans
+# ---------------------------------------------------------------------------
+
+
+def _module_source() -> str:
+    return Path(rsd.__file__).read_text(encoding="utf-8")
+
+
+def _module_imports() -> list[str]:
+    import ast as _ast
+
+    tree = _ast.parse(_module_source())
+    out: list[str] = []
+    for node in _ast.walk(tree):
+        if isinstance(node, _ast.Import):
+            for alias in node.names:
+                out.append(alias.name)
+        elif isinstance(node, _ast.ImportFrom):
+            mod = node.module or ""
+            for alias in node.names:
+                out.append(f"{mod}.{alias.name}" if mod else alias.name)
+    return out
+
+
+def test_no_subprocess_in_module() -> None:
+    src = _module_source()
+    assert "import subprocess" not in src
+    assert "from subprocess" not in src
+    assert "subprocess." not in src
+
+
+def test_no_socket_or_urllib_or_http_or_requests() -> None:
+    src = _module_source()
+    for forbidden in (
+        "import socket",
+        "from socket",
+        "import urllib",
+        "from urllib",
+        "import http",
+        "from http",
+        "import requests",
+        "from requests",
+        "import httpx",
+        "from httpx",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_no_forbidden_runtime_imports_via_ast() -> None:
+    forbidden_prefixes = (
+        "dashboard",
+        "automation",
+        "broker",
+        "agent.risk",
+        "agent.execution",
+        "research",
+        "live",
+        "paper",
+        "shadow",
+        "trading",
+        "reporting.intelligent_routing",
+        "reporting.development_queue_admission_policy",
+        "reporting.development_agent_activity_timeline",
+        "reporting.execution_authority",
+        "reporting.roadmap_task_catalog",
+        "reporting.roadmap_task_units",
+        "reporting.roadmap_unit_authority",
+        "reporting.roadmap_next_unit",
+    )
+    for module in _module_imports():
+        for prefix in forbidden_prefixes:
+            assert not (
+                module == prefix or module.startswith(prefix + ".")
+            ), f"forbidden import: {module}"
+
+
+def test_module_has_no_third_party_imports() -> None:
+    """Stdlib only — pin the import set explicitly."""
+    allowed_stdlib_modules = {
+        "__future__.annotations",
+        "argparse",
+        "datetime",
+        "json",
+        "os",
+        "sys",
+        "tempfile",
+        "pathlib.Path",
+        "typing.Any",
+        "typing.Final",
+    }
+    for module in _module_imports():
+        assert module in allowed_stdlib_modules, module
+
+
+def test_no_gh_or_git_cli_calls() -> None:
+    src = _module_source()
+    for forbidden in (
+        "subprocess.run",
+        "subprocess.Popen",
+        "os.system(",
+        "os.popen(",
+        "shell=True",
+        "eval(",
+        "exec(",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_no_github_api_or_external_api_calls() -> None:
+    src = _module_source()
+    for forbidden in (
+        "api.github.com",
+        "anthropic",
+        "openai",
+        "Bearer ",
+        "X-API-Key",
+        "X-GitHub-Token",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_module_imports_cleanly() -> None:
+    importlib.reload(rsd)
+    assert callable(rsd.collect_snapshot)
+    assert callable(rsd.write_outputs)
+    assert callable(rsd.main)
+
+
+def test_schema_and_module_version_strings() -> None:
+    assert isinstance(rsd.SCHEMA_VERSION, str) and rsd.SCHEMA_VERSION
+    assert isinstance(rsd.MODULE_VERSION, str) and rsd.MODULE_VERSION
+    assert "v3.15.16.routing_signals" in rsd.MODULE_VERSION


### PR DESCRIPTION
## Selected A20e unit

- **Unit id:** `u_v3_15_16_diagnostic_routing_signals_schema_001`
- **Phase:** v3.15.16 — Intelligent Routing Layer
- **A20c authority:** `AUTO_ALLOWED`, LOW risk, `operator_gate = none`, `requires_operator_go = False`.
- **Recommended by:** `python -m reporting.roadmap_next_unit --status` deterministic selection.

## Summary

- Implements the **schema and read-only projector** for diagnostic-aware routing signals under Roadmap v6 §v3.15.16 and Roadmap v6 Addendum §9 v3.15.16.
- One signal record per Roadmap v6 + Addendum 1 diagnostic family (14 families: entropy, tail, criticality, network, quorum, external_intelligence, dead_zone, null_model, barrier, resonance, adversarial, seismic, turbulence, market_language).
- Closed vocabularies for `ROUTING_SIGNAL_FAMILY`, `ROUTING_SIGNAL_STATUS`, `ROUTING_SIGNAL_DIRECTION`, `ROUTING_SIGNAL_SOURCE`, `ROUTING_SIGNAL_TARGET_LAYER`.
- Schemas `RoutingDiagnosticSignal` (17 fields) and `RoutingSignalProjection` (5 fields).
- Deterministic projection emitted at `logs/intelligent_routing_diagnostic_signals/latest.json`.
- CLI: `--no-write`, `--status`, `--indent` (same shape as A20-series).

## Design choices pinned by tests

- **Effect fields are bounded prose.** Five operator-readable explanatory hints per signal (`expected_information_gain_effect`, `dead_zone_risk_effect`, `orthogonality_effect`, `public_data_quality_effect`, `confirmation_requirement_effect`). Tests pin non-empty, ≤200 chars, no newline, no authority-granting / trade / execute / order / capital-allocation phrases.
- **`status="schema_only"` hard-coded** in `_normalise_signal()` regardless of the seed-entry value. A synthetic seed with a different status still emits `schema_only`. Future lifecycle variants require a separate operator-go unit.
- **Baseline `forbidden_use` prepended** on every signal (10 baseline entries enforcing "diagnostics do not trade", "no live/paper/shadow path writes", "no frozen-contract mutation", "no executable strategy code", etc.). Per-signal extras append without replacing the baseline. Duplicates de-duplicated. Order stable across runs.

## Files changed (exactly 3, expected-files-only)

- `reporting/intelligent_routing_diagnostic_signals.py` (new) — stdlib only.
- `tests/unit/test_intelligent_routing_diagnostic_signals.py` (new) — 84 tests.
- `docs/governance/intelligent_routing_diagnostic_signals.md` (new).

**Untouched (verified):**

- `dashboard/dashboard.py`
- `.claude/**`, `.github/**`
- `research/research_latest.json`, `research/strategy_matrix.csv`
- `automation/live_gate.py`, `broker/**`, `agent/risk/**`, `agent/execution/**`
- `live/**`, `paper/**`, `shadow/**`, `trading/**`
- `docs/roadmap/Roadmap v6.md`, `docs/roadmap/Roadmap v6 Addendum.md`, `docs/roadmap/autonomous_development.txt`
- `docs/governance/execution_authority.md`, `docs/governance/no_touch_paths.md`
- `reporting/execution_authority.py`
- `reporting/development_queue_admission_policy.py` (existing A17)
- `reporting/roadmap_task_catalog.py`, `reporting/roadmap_task_units.py`, `reporting/roadmap_unit_authority.py`, `reporting/roadmap_next_unit.py`, `reporting/development_agent_activity_timeline.py` (the A20 pipeline — read-only-consumed only)
- `docs/development_work_queue/*.jsonl`
- `tests/regression/**`
- any frozen schema under `artifacts/`

## Validation commands and results

- `python -m pytest tests/unit/test_intelligent_routing_diagnostic_signals.py -v` -> **84 passed**
- `python -m pytest tests/unit/test_roadmap_next_unit.py -v` -> **73 passed** (unchanged)
- `python -m pytest tests/smoke -v` -> **18 passed**
- `python scripts/governance_lint.py` -> **OK** (16 agents, 5 workflows)
- `python scripts/push_body_safety_lint.py` -> **OK** (6 surfaces, 6 tokens)
- Frozen-contract regression set (`test_public_output_contract.py`, `test_v12_contracts_preserved.py`, `test_authority_invariants.py`) -> **16 passed**

## Frozen-contract verdict

- `research/research_latest.json` -> **NOT TOUCHED**.
- `research/strategy_matrix.csv` -> **NOT TOUCHED**.
- Atomic-write helper refuses every path outside `logs/intelligent_routing_diagnostic_signals/`. Frozen-contract paths explicitly rejected (pinned by `test_atomic_write_refuses_frozen_contract_paths`).

## Forbidden-path verdict

`git diff --name-only main` contains exactly the three expected files. None of the forbidden paths above were touched.

## Authority statement

- **This is schema/projector only.**
- **No campaign routing mutation is implemented yet.** `projection_invariants.no_routing_mutation = True`, `no_campaign_queue_mutation = True`, `no_strategy_generation = True`, `no_research_runtime_change = True`.
- **No runtime / trading / paper / shadow / live authority is granted.** Every signal carries the full doctrine baseline in `forbidden_use[]`. Effect fields are pinned free of authority-granting / trade / execute / order / capital-allocation phrases.
- Step 5 implementation remains BLOCKED.
- Autonomy-ladder Level 6 remains permanently disabled.
- N5b Phase 4 production merge remains permanently denied for ADE.
- ADE remains development workflow automation only.

## What this PR does NOT do

- No actual routing decision (signal status pinned to `schema_only`).
- No campaign queue mutation, no strategy generation, no research-runtime change.
- No `dashboard/dashboard.py` change, no `.claude/**` change, no `.github/**` change.
- No edit to canonical roadmap docs, canonical policy docs, or `autonomous_development.txt`.
- No edit to the A20 pipeline modules (they remain read-only consumers).
- No mutation routes, no approval buttons, no required-phrase synthesis, no AAC aggregator change.

## Next recommended step

**Merge protocol** after CI green (squash-merge only — no `--admin`, no force push, no hook bypass, no automatic merge).

After merge, if/when the operator wants the A20 pipeline to mark this unit as `status="merged"` so downstream v3.15.16 follow-up units become eligible in `python -m reporting.roadmap_next_unit --status`, the operator opens a **separate** PR that amends A20b's `_UNIT_SEED` to set `"status": "merged"` for this unit and updates the matching tests. That A20b-status-update PR is not part of this PR.

## Test plan

- [x] All local tests + smoke + governance lint + push-body lint + frozen-contract regression all green.
- [ ] CI checks complete on PR (squash-merge only — no `--admin`, no force push, no hook bypass, no automatic merge).

Generated with Claude Code (https://claude.com/claude-code).
