### PR TITLE
chore(a20): mark routing-signals-schema unit as merged in queue seed

### DIFF
--- a/docs/governance/roadmap_task_catalog.md
+++ b/docs/governance/roadmap_task_catalog.md
@@ -847,6 +847,24 @@ implementation unit** opened as its own PR under normal ADE PR
 lifecycle governance. A20e does not open that PR — the operator
 does, using the selector's recommendation as input.
 
+### 11.1 Queue progression log
+
+The A20 projections are deterministic / read-only and do not
+auto-discover merged PRs. When a queue-driven Roadmap v6 unit
+lands on `main`, the operator (or a small follow-up
+`chore/a20-*` PR) advances its status in A20b's `_UNIT_SEED`
+so that A20e can recommend the next eligible downstream unit.
+Each transition is recorded here for traceability:
+
+| Date (UTC) | Unit id | A20b status | Implementing PR | Merge SHA |
+|---|---|---|---|---|
+| 2026-05-18 | `u_v3_15_16_diagnostic_routing_signals_schema_001` | `not_started` → `merged` | [#250](https://github.com/roudjy/trading-agent/pull/250) | `fcb1abbea4bd2ca190fe6e807b3dacd184faa702` |
+
+This table is informational. The authoritative `status` lives in
+[`reporting/roadmap_task_units.py`](../../reporting/roadmap_task_units.py)
+`_UNIT_SEED` and is pinned by
+[`tests/unit/test_roadmap_task_units.py`](../../tests/unit/test_roadmap_task_units.py).
+
 <!-- A20e legacy future-stages section retained below for reference. -->
 ## 12. Future stages — A20 complete
 

--- a/reporting/roadmap_task_units.py
+++ b/reporting/roadmap_task_units.py
@@ -505,7 +505,14 @@ _UNIT_SEED: Final[tuple[dict[str, Any], ...]] = (
         "risk_class": "LOW",
         "authority_hint": "AUTO_ALLOWED_CANDIDATE",
         "operator_gate": "none",
-        "status": "not_started",
+        # Implemented and merged via PR #250 on 2026-05-18.
+        # Merge SHA: fcb1abbea4bd2ca190fe6e807b3dacd184faa702.
+        # Status flipped from "not_started" -> "merged" in a
+        # follow-up queue-status update PR so the A20e selector
+        # can advance to the next eligible v3.15.16 unit. A20
+        # projections are deterministic / read-only and do not
+        # auto-discover merged PRs.
+        "status": "merged",
     },
     {
         "id": "u_v3_15_16_routing_explanation_reporter_001",

--- a/tests/unit/test_roadmap_task_units.py
+++ b/tests/unit/test_roadmap_task_units.py
@@ -903,3 +903,95 @@ def test_governance_doc_pins_no_next_buildable_selector_in_a20b() -> None:
     text = _governance_doc_text()
     assert "a20e" in text
     assert "next-buildable" in text or "next buildable" in text
+
+
+# ---------------------------------------------------------------------------
+# Queue-status update: u_v3_15_16_diagnostic_routing_signals_schema_001
+# was implemented and merged via PR #250. The A20 pipeline is deterministic
+# and read-only — it does not auto-discover merged PRs — so the unit's
+# status was advanced manually in the seed via a small follow-up PR.
+# ---------------------------------------------------------------------------
+
+
+_ROUTING_SIGNALS_SCHEMA_UNIT_ID = (
+    "u_v3_15_16_diagnostic_routing_signals_schema_001"
+)
+
+
+def test_routing_signals_schema_unit_status_is_merged(snap: dict) -> None:
+    """After the queue-status update PR, A20b emits this unit with
+    ``status="merged"``. The A20e selector must therefore stop
+    recommending it."""
+    rows = [
+        u
+        for u in snap["implementation_units"]
+        if u["id"] == _ROUTING_SIGNALS_SCHEMA_UNIT_ID
+    ]
+    assert len(rows) == 1
+    assert rows[0]["status"] == "merged"
+
+
+def test_routing_signals_schema_unit_retains_full_metadata(snap: dict) -> None:
+    """Queue-status update is narrow: only the status field flipped.
+    All other unit metadata that downstream consumers (A20c, A20d,
+    A20e) depend on must remain intact."""
+    rows = [
+        u
+        for u in snap["implementation_units"]
+        if u["id"] == _ROUTING_SIGNALS_SCHEMA_UNIT_ID
+    ]
+    assert len(rows) == 1
+    unit = rows[0]
+    # Mandatory list / scalar fields A20c and A20e read.
+    assert unit["expected_files"], unit
+    assert unit["forbidden_files"], unit
+    assert unit["required_tests"], unit
+    assert unit["definition_of_done"], unit
+    assert unit["stop_conditions"], unit
+    assert isinstance(unit["authority_hint"], str) and unit["authority_hint"]
+    # Authority hint matches the original A20b seed.
+    assert unit["authority_hint"] == "AUTO_ALLOWED_CANDIDATE"
+    assert unit["operator_gate"] == "none"
+    assert unit["risk_class"] == "LOW"
+    assert unit["phase"] == "v3.15.16"
+    assert unit["roadmap_task_id"] == "phase_v3_15_16"
+
+
+def test_other_units_unchanged_by_status_update(snap: dict) -> None:
+    """The queue-status update PR only flipped the routing-signals
+    schema unit's status. All other units in the seed must still
+    carry a status drawn from the closed UNIT_STATUS vocabulary and
+    must not have been altered to ``merged`` by accident."""
+    for u in snap["implementation_units"]:
+        if u["id"] == _ROUTING_SIGNALS_SCHEMA_UNIT_ID:
+            continue
+        assert u["status"] in rtu.UNIT_STATUS, u
+        # Defence-in-depth: no other unit silently flipped to merged.
+        assert u["status"] != "merged", u["id"]
+
+
+def test_routing_signals_schema_unit_is_listed_exactly_once(snap: dict) -> None:
+    ids = [u["id"] for u in snap["implementation_units"]]
+    assert ids.count(_ROUTING_SIGNALS_SCHEMA_UNIT_ID) == 1
+
+
+def test_downstream_v3_15_16_units_still_reference_merged_unit(
+    snap: dict,
+) -> None:
+    """The two downstream v3.15.16 units list the routing-signals
+    schema unit as a prerequisite. After the status update the
+    prerequisite edge is preserved (still listed) and A20e can now
+    treat it as satisfied because the prereq unit's status is
+    ``merged``."""
+    downstream = [
+        u
+        for u in snap["implementation_units"]
+        if u["id"]
+        in (
+            "u_v3_15_16_routing_explanation_reporter_001",
+            "u_v3_15_16_routing_governance_doc_001",
+        )
+    ]
+    assert len(downstream) == 2
+    for u in downstream:
+        assert _ROUTING_SIGNALS_SCHEMA_UNIT_ID in u["prerequisites"], u["id"]


### PR DESCRIPTION
## Summary

Queue-status update only. PR #250 (merge SHA `fcb1abbea4bd2ca190fe6e807b3dacd184faa702`) landed the implementation unit `u_v3_15_16_diagnostic_routing_signals_schema_001`. The A20 projections are deterministic / read-only and do not auto-discover merged PRs, so the unit's A20b status remained `"not_started"` on `main` and the A20e selector kept re-recommending the same already-merged unit.

This PR flips the unit's status in `reporting/roadmap_task_units.py::_UNIT_SEED` from `"not_started"` → `"merged"` and pins the transition with narrow new tests. It adds **no implementation unit** and **no runtime / trading / paper / shadow / live authority**.

## Files changed (exactly 3, allowlist-only)

- `reporting/roadmap_task_units.py` (modified, +9 / −1) — single-unit status flip with a provenance comment.
- `tests/unit/test_roadmap_task_units.py` (modified, +92 / −0) — 5 new queue-status pin tests; no existing tests weakened.
- `docs/governance/roadmap_task_catalog.md` (modified, +18 / −0) — new §11.1 "Queue progression log" with the unit-id / PR / merge-SHA entry.

**Untouched (verified):**

- `dashboard/dashboard.py`
- `.claude/**`, `.github/**`
- `research/research_latest.json`, `research/strategy_matrix.csv`
- `automation/live_gate.py`, `broker/**`, `agent/risk/**`, `agent/execution/**`
- `live/**`, `paper/**`, `shadow/**`, `trading/**`
- `docs/roadmap/Roadmap v6.md`, `docs/roadmap/Roadmap v6 Addendum.md`, `docs/roadmap/autonomous_development.txt`
- `docs/governance/execution_authority.md`, `docs/governance/no_touch_paths.md`
- `reporting/execution_authority.py`
- `reporting/development_queue_admission_policy.py` (existing A17)
- `reporting/roadmap_task_catalog.py` (A20a)
- `reporting/roadmap_unit_authority.py` (A20c)
- `reporting/roadmap_next_unit.py` (A20e)
- `reporting/development_agent_activity_timeline.py` (AAC aggregator)
- `reporting/intelligent_routing_diagnostic_signals.py` (the unit landed in PR #250)
- `docs/development_work_queue/*.jsonl`
- `tests/regression/**`
- any frozen schema under `artifacts/`

## Validation commands and results

- `python -m pytest tests/unit/test_roadmap_task_units.py -v` -> **92 passed** (5 new queue-status pin tests)
- `python -m pytest tests/unit/test_roadmap_next_unit.py -v` -> **73 passed** (unchanged)
- `python -m pytest tests/unit/test_intelligent_routing_diagnostic_signals.py -v` -> **84 passed** (unchanged)
- `python -m pytest tests/unit/test_roadmap_task_catalog.py -v` -> **83 passed** (unchanged)
- `python -m pytest tests/unit/test_roadmap_unit_authority.py -v` -> **86 passed** (unchanged)
- `python -m pytest tests/unit/test_development_agent_activity_timeline.py -v` -> **76 passed** (unchanged)
- `python -m pytest tests/smoke -v` -> **18 passed**
- `python scripts/governance_lint.py` -> **OK** (16 agents, 5 workflows)
- `python scripts/push_body_safety_lint.py` -> **OK** (6 surfaces, 6 tokens)
- Frozen-contract regression set (`test_public_output_contract.py`, `test_v12_contracts_preserved.py`, `test_authority_invariants.py`) -> **16 passed**
- `python -m reporting.roadmap_next_unit --status` -> selector now recommends `u_v3_15_16_routing_explanation_reporter_001` (see "Selector status" below)

Combined A20 + new-unit sweep: **474 passed**.

## Frozen-contract verdict

- `research/research_latest.json` -> **NOT TOUCHED**.
- `research/strategy_matrix.csv` -> **NOT TOUCHED**.
- All atomic-write helpers refuse paths outside their respective `logs/<module>/` directories. Frozen-contract paths explicitly rejected.

## Forbidden-path verdict

`git diff --name-only main` contains exactly the three allowlisted files. None of the forbidden paths above were touched.

## This is queue-status only

- **No implementation unit added.** This PR does NOT add any new module, test, or governance doc. It only flips one field inside an existing seed literal and adds narrow regression tests + a small doc log entry.
- **No runtime / trading / paper / shadow / live authority granted.** All A20 invariants intact: `aac_visibility_present = True`, `next_buildable_selector_present = True`, `no_runtime_trading_authority = True`, `no_step5_runtime = True`, `no_level6 = True`, `no_production_merge_authority = True`. Step 5 BLOCKED. Level 6 permanently disabled. N5b Phase 4 permanently denied for ADE.

## Selector status — before and after

**Before this PR (current `main` HEAD `fcb1abb`):**

```
selected_unit_id        : u_v3_15_16_diagnostic_routing_signals_schema_001
selection_status        : OK_SELECTED
candidates=20, eligible=6, blocked=14
```

The selector kept re-recommending the already-merged unit because A20b's seed still listed it as `not_started`.

**After this PR (local validation against branch HEAD):**

```
selected_unit_id        : u_v3_15_16_routing_explanation_reporter_001
selected_phase          : v3.15.16
selected_authority_class: AUTO_ALLOWED
selected_risk_class     : LOW
selected_operator_gate  : none
requires_operator_go    : False
fail_closed             : False
candidates=20, eligible=8, blocked=12
selection_status        : OK_SELECTED
```

- `u_v3_15_16_diagnostic_routing_signals_schema_001` is now BLOCKED with `non_buildable_status` (correct: merged units leave the buildable set `{not_started, ready}`).
- The two downstream v3.15.16 units (`routing_explanation_reporter`, `routing_governance_doc`) unblock because their prerequisite is now satisfied (status=merged) — eligible count goes 6 → 8.
- Deterministic sort picks `routing_explanation_reporter` over `routing_governance_doc` by lex id tie-break within the v3.15.16 ELIGIBLE tier.

## Next recommended implementation unit selected by A20e

After this PR merges, the operator can run `python -m reporting.roadmap_next_unit --status` and see:

**`u_v3_15_16_routing_explanation_reporter_001`** — v3.15.16, AUTO_ALLOWED, LOW risk, operator_gate=none, requires_operator_go=False. This is the next queue-driven Roadmap v6 implementation unit eligible for an implementation PR under normal ADE PR lifecycle governance.

The operator opens that implementation PR (separately); this PR only advances queue state.

## Test plan

- [x] All local tests + smoke + governance lint + push-body lint + frozen-contract regression all green.
- [x] Selector advancement confirmed locally: `u_v3_15_16_diagnostic_routing_signals_schema_001` → BLOCKED (non_buildable); next recommendation = `u_v3_15_16_routing_explanation_reporter_001`.
- [ ] CI checks complete on PR (squash-merge only — no `--admin`, no force push, no hook bypass, no automatic merge).

Generated with Claude Code (https://claude.com/claude-code).
