### PR TITLE
feat(v3.15.16): read-only routing-decision explanation reporter

### DIFF
--- a/reporting/routing_explanation.py
+++ b/reporting/routing_explanation.py
@@ -1,0 +1,703 @@
+"""v3.15.16 Intelligent Routing Layer — read-only routing-decision
+explanation reporter.
+
+Implements the queue-driven Roadmap v6 implementation unit selected
+by A20e after PR #251 advanced the queue status:
+
+* unit id: ``u_v3_15_16_routing_explanation_reporter_001``
+* phase:   ``v3.15.16`` — Intelligent Routing Layer
+* authority: ``AUTO_ALLOWED`` at LOW risk (per A20c verdict)
+* prerequisite: ``u_v3_15_16_diagnostic_routing_signals_schema_001``
+  (merged via PR #250 / SHA fcb1abb; queue status advanced via
+  PR #251 / SHA dcbed07)
+
+This module is **explanation / reporting only**. It consumes the
+read-only ``RoutingSignalProjection`` emitted by
+:mod:`reporting.intelligent_routing_diagnostic_signals` (PR #250)
+and produces operator-readable explanations for why each diagnostic
+routing signal would support, suppress, or require confirmation
+for research exploration.
+
+The module does NOT make actual routing decisions, does NOT mutate
+any campaign queue, does NOT enqueue campaigns, does NOT change
+research runtime behaviour, does NOT generate strategies, does NOT
+trade. The closed-vocabulary mapping from signal direction to
+explanation effect is hand-encoded as Python literals — no LLM,
+no fuzzy parsing, no hidden scoring.
+
+Hard guarantees (pinned by tests):
+
+* Stdlib + ``reporting.intelligent_routing_diagnostic_signals``
+  (read-only) only.
+* No subprocess, no network, no ``gh``, no ``git``, no GitHub
+  API.
+* No imports of ``dashboard``, ``automation``, ``broker``,
+  ``agent.risk``, ``agent.execution``, ``research``, ``live``,
+  ``paper``, ``shadow``, ``trading``,
+  ``reporting.intelligent_routing``,
+  ``reporting.development_queue_admission_policy``,
+  ``reporting.development_agent_activity_timeline``,
+  ``reporting.execution_authority``, or any of the A20 pipeline
+  modules.
+* No LLM, no external API, no fuzzy parsing, no runtime parsing
+  of canonical roadmap documents.
+* Atomic write only under ``logs/routing_explanation/``.
+* Deterministic output: same input + injected
+  ``generated_at_utc`` → byte-identical artefact.
+* Every emitted explanation carries ``read_only=True`` and
+  ``mutation_allowed=False`` markers.
+* No actual routing decision; no campaign queue mutation; no
+  strategy generation (pinned by ``projection_invariants``).
+* Diagnostics do not trade. External data is not alpha.
+
+CLI::
+
+    python -m reporting.routing_explanation
+    python -m reporting.routing_explanation --no-write
+    python -m reporting.routing_explanation --status
+    python -m reporting.routing_explanation --indent 2
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Final
+
+from reporting import intelligent_routing_diagnostic_signals as rsd
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[str] = "1.0"
+MODULE_VERSION: Final[str] = "v3.15.16.routing_explanation.0"
+REPORT_KIND: Final[str] = "routing_explanation"
+
+
+# ---------------------------------------------------------------------------
+# Step 5 + Level 6 invariants (Final constants — never flipped at runtime)
+# ---------------------------------------------------------------------------
+
+STEP5_ENABLED_SUBSTAGE: Final[str] = "none"
+step5_implementation_allowed: Final[bool] = False
+
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies
+# ---------------------------------------------------------------------------
+
+#: Closed explanation-status vocabulary. Mirrors the routing-signal
+#: directions plus an ``informational`` fallback for any explanation
+#: that does not map to a single direction (currently none — every
+#: signal direction has a matching status, pinned by tests).
+ROUTING_EXPLANATION_STATUS: Final[tuple[str, ...]] = (
+    "advisory_prioritize",
+    "advisory_deprioritize",
+    "advisory_suppress",
+    "advisory_require_confirmation",
+    "advisory_neutral",
+    "informational",
+)
+
+#: Closed reason-kind vocabulary. Each explanation emits at least
+#: one reason; every reason's ``kind`` belongs to this enum.
+ROUTING_EXPLANATION_REASON_KIND: Final[tuple[str, ...]] = (
+    "direction_advice",
+    "expected_information_gain",
+    "dead_zone_risk",
+    "orthogonality",
+    "public_data_quality",
+    "confirmation_requirement",
+    "missing_input_fallback",
+)
+
+#: Closed effect vocabulary. Every reason and every aggregated
+#: explanation effect belongs to this enum. Never a buy/sell verb.
+ROUTING_EXPLANATION_EFFECT: Final[tuple[str, ...]] = (
+    "supports_exploration",
+    "suppresses_exploration",
+    "requires_confirmation",
+    "lowers_priority",
+    "elevates_evidence_requirement",
+    "neutral",
+)
+
+#: Closed target vocabulary. Verbatim re-export of the upstream
+#: ``ROUTING_SIGNAL_TARGET_LAYER`` so explanations and signals
+#: share one target-layer enum.
+ROUTING_EXPLANATION_TARGET: Final[tuple[str, ...]] = (
+    rsd.ROUTING_SIGNAL_TARGET_LAYER
+)
+
+#: Closed source vocabulary. Either the upstream signal module
+#: (the per-signal direction-advice and missing-input-fallback
+#: reasons) or this module (the family-specific reason whose
+#: mapping rule lives here).
+ROUTING_EXPLANATION_SOURCE: Final[tuple[str, ...]] = (
+    "reporting.intelligent_routing_diagnostic_signals",
+    "reporting.routing_explanation",
+    "logs/intelligent_routing_diagnostic_signals/latest.json",
+)
+
+
+# ---------------------------------------------------------------------------
+# Closed deterministic mappings
+# ---------------------------------------------------------------------------
+
+#: Direction (from upstream signal) → explanation status. Closed,
+#: exhaustive over ``ROUTING_SIGNAL_DIRECTION``.
+_DIRECTION_TO_STATUS: Final[dict[str, str]] = {
+    "prioritize": "advisory_prioritize",
+    "deprioritize": "advisory_deprioritize",
+    "suppress": "advisory_suppress",
+    "require_confirmation": "advisory_require_confirmation",
+    "neutral": "advisory_neutral",
+}
+
+#: Direction → direction-advice effect. Closed.
+_DIRECTION_TO_EFFECT: Final[dict[str, str]] = {
+    "prioritize": "supports_exploration",
+    "deprioritize": "lowers_priority",
+    "suppress": "suppresses_exploration",
+    "require_confirmation": "requires_confirmation",
+    "neutral": "neutral",
+}
+
+#: Direction → aggregate-boolean tuple
+#: ``(supports_exploration, suppresses_exploration, requires_confirmation)``.
+#: Closed.
+_DIRECTION_TO_AGGREGATE: Final[dict[str, tuple[bool, bool, bool]]] = {
+    # supports, suppresses, requires_confirmation
+    "prioritize": (True, False, False),
+    "deprioritize": (False, False, True),
+    "suppress": (False, True, False),
+    "require_confirmation": (False, False, True),
+    "neutral": (False, False, False),
+}
+
+#: Family → (family-specific reason kind, family-specific reason
+#: effect). Closed, exhaustive over
+#: ``ROUTING_SIGNAL_FAMILY``. The kind / effect both come from
+#: closed vocabularies above; no fuzzy parsing.
+_FAMILY_TO_REASON: Final[dict[str, tuple[str, str]]] = {
+    "entropy": ("expected_information_gain", "lowers_priority"),
+    "tail": ("confirmation_requirement", "elevates_evidence_requirement"),
+    "criticality": ("dead_zone_risk", "lowers_priority"),
+    "network": ("orthogonality", "supports_exploration"),
+    "quorum": ("confirmation_requirement", "elevates_evidence_requirement"),
+    "external_intelligence": (
+        "public_data_quality",
+        "elevates_evidence_requirement",
+    ),
+    "dead_zone": ("dead_zone_risk", "lowers_priority"),
+    "null_model": ("expected_information_gain", "lowers_priority"),
+    "barrier": ("confirmation_requirement", "elevates_evidence_requirement"),
+    "resonance": (
+        "confirmation_requirement",
+        "elevates_evidence_requirement",
+    ),
+    "adversarial": (
+        "confirmation_requirement",
+        "elevates_evidence_requirement",
+    ),
+    "seismic": ("dead_zone_risk", "lowers_priority"),
+    "turbulence": ("dead_zone_risk", "lowers_priority"),
+    "market_language": ("expected_information_gain", "lowers_priority"),
+}
+
+#: Family → which upstream signal effect string is copied into the
+#: family-specific reason's ``reason`` field. Closed.
+_FAMILY_TO_REASON_FIELD: Final[dict[str, str]] = {
+    "entropy": "expected_information_gain_effect",
+    "tail": "confirmation_requirement_effect",
+    "criticality": "dead_zone_risk_effect",
+    "network": "orthogonality_effect",
+    "quorum": "confirmation_requirement_effect",
+    "external_intelligence": "public_data_quality_effect",
+    "dead_zone": "dead_zone_risk_effect",
+    "null_model": "expected_information_gain_effect",
+    "barrier": "confirmation_requirement_effect",
+    "resonance": "confirmation_requirement_effect",
+    "adversarial": "confirmation_requirement_effect",
+    "seismic": "dead_zone_risk_effect",
+    "turbulence": "dead_zone_risk_effect",
+    "market_language": "expected_information_gain_effect",
+}
+
+
+# ---------------------------------------------------------------------------
+# Schema field tuples (exact, ordered)
+# ---------------------------------------------------------------------------
+
+#: Per-reason schema.
+ROUTING_EXPLANATION_REASON_FIELDS: Final[tuple[str, ...]] = (
+    "kind",
+    "signal_id",
+    "signal_family",
+    "reason",
+    "effect",
+    "source",
+)
+
+#: Per-explanation schema.
+ROUTING_EXPLANATION_FIELDS: Final[tuple[str, ...]] = (
+    "id",
+    "signal_id",
+    "signal_family",
+    "title",
+    "summary",
+    "status",
+    "target",
+    "reasons",
+    "supports_exploration",
+    "suppresses_exploration",
+    "requires_confirmation",
+    "read_only",
+    "mutation_allowed",
+)
+
+#: Top-level projection schema.
+ROUTING_EXPLANATION_PROJECTION_FIELDS: Final[tuple[str, ...]] = (
+    "generated_at_utc",
+    "schema_version",
+    "module_version",
+    "source_signal_schema_version",
+    "explanations",
+    "projection_invariants",
+)
+
+
+# ---------------------------------------------------------------------------
+# Bounds
+# ---------------------------------------------------------------------------
+
+MAX_TITLE_LEN: Final[int] = 200
+MAX_SUMMARY_LEN: Final[int] = 600
+MAX_REASON_LEN: Final[int] = 240
+MAX_REASONS_PER_EXPLANATION: Final[int] = 8
+
+
+# ---------------------------------------------------------------------------
+# Artefact paths
+# ---------------------------------------------------------------------------
+
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "routing_explanation"
+ARTIFACT_LATEST: Final[Path] = ARTIFACT_DIR / "latest.json"
+ARTIFACT_RELATIVE_PATH: Final[str] = "logs/routing_explanation/latest.json"
+
+_WRITE_PREFIX: Final[str] = "logs/routing_explanation/"
+
+
+# ---------------------------------------------------------------------------
+# Projection invariants emitted on every snapshot
+# ---------------------------------------------------------------------------
+
+_BASE_PROJECTION_INVARIANTS: Final[dict[str, bool]] = {
+    # Doctrinal anchors carried forward from the upstream schema.
+    "diagnostics_do_not_trade": True,
+    "external_data_is_not_alpha": True,
+    "read_only": True,
+    "mutation_allowed": False,
+    # A20 authority chain pins.
+    "no_runtime_trading_authority": True,
+    "no_campaign_queue_mutation": True,
+    "no_actual_routing_decision": True,
+    "no_strategy_generation": True,
+    "no_routing_mutation": True,
+    "no_research_runtime_change": True,
+    "no_step5_runtime": True,
+    "no_level6": True,
+    "no_production_merge_authority": True,
+    "step5_implementation_allowed": False,
+    # Operational pins.
+    "no_branch_creation": True,
+    "no_pr_creation": True,
+    "no_merge_or_deploy": True,
+    "no_mutation_routes": True,
+    "no_approval_buttons": True,
+    "writes_only_routing_explanation_log": True,
+    "fuzzy_parsing": False,
+    "uses_subprocess_or_network": False,
+    "calls_llm_or_external_api": False,
+}
+
+
+# ---------------------------------------------------------------------------
+# Utility helpers
+# ---------------------------------------------------------------------------
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _bounded_str(value: Any, max_len: int) -> str:
+    if not isinstance(value, str):
+        return ""
+    if len(value) <= max_len:
+        return value
+    return value[:max_len]
+
+
+# ---------------------------------------------------------------------------
+# Reason builders
+# ---------------------------------------------------------------------------
+
+
+def _direction_advice_reason(signal: dict[str, Any]) -> dict[str, Any]:
+    direction = signal.get("direction", "neutral")
+    if direction not in _DIRECTION_TO_EFFECT:
+        direction = "neutral"
+    effect = _DIRECTION_TO_EFFECT[direction]
+    return {
+        "kind": "direction_advice",
+        "signal_id": signal["id"],
+        "signal_family": signal["family"],
+        "reason": _bounded_str(
+            f"signal direction is {direction}",
+            MAX_REASON_LEN,
+        ),
+        "effect": effect,
+        "source": "reporting.intelligent_routing_diagnostic_signals",
+    }
+
+
+def _family_specific_reason(signal: dict[str, Any]) -> dict[str, Any]:
+    family = signal["family"]
+    if family not in _FAMILY_TO_REASON:
+        # Fail-closed: unknown family yields a missing-input-style
+        # reason rather than guessing. Closed-vocab inputs make
+        # this branch unreachable in practice; tests pin every
+        # family from the upstream seed against the mapping.
+        return {
+            "kind": "missing_input_fallback",
+            "signal_id": signal["id"],
+            "signal_family": family,
+            "reason": _bounded_str(
+                "family-specific reason mapping unavailable",
+                MAX_REASON_LEN,
+            ),
+            "effect": "neutral",
+            "source": "reporting.routing_explanation",
+        }
+    kind, effect = _FAMILY_TO_REASON[family]
+    field_name = _FAMILY_TO_REASON_FIELD[family]
+    reason_text = signal.get(field_name, "")
+    return {
+        "kind": kind,
+        "signal_id": signal["id"],
+        "signal_family": family,
+        "reason": _bounded_str(reason_text, MAX_REASON_LEN),
+        "effect": effect,
+        "source": "reporting.routing_explanation",
+    }
+
+
+def _missing_input_reason(signal: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "kind": "missing_input_fallback",
+        "signal_id": signal["id"],
+        "signal_family": signal["family"],
+        "reason": _bounded_str(
+            signal.get("missing_input_behavior", ""),
+            MAX_REASON_LEN,
+        ),
+        "effect": "neutral",
+        "source": "reporting.intelligent_routing_diagnostic_signals",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Explanation construction
+# ---------------------------------------------------------------------------
+
+
+def _explanation_from_signal(signal: dict[str, Any]) -> dict[str, Any]:
+    direction = signal.get("direction", "neutral")
+    if direction not in _DIRECTION_TO_STATUS:
+        direction = "neutral"
+
+    supports, suppresses, requires_confirmation = (
+        _DIRECTION_TO_AGGREGATE.get(direction, (False, False, False))
+    )
+    status = _DIRECTION_TO_STATUS.get(direction, "informational")
+
+    reasons = [
+        _direction_advice_reason(signal),
+        _family_specific_reason(signal),
+        _missing_input_reason(signal),
+    ]
+    # Cap defensively (never exceeded by today's seed).
+    reasons = reasons[:MAX_REASONS_PER_EXPLANATION]
+
+    family = signal["family"]
+    name = signal.get("name", signal["id"])
+    target_layer = signal["target_layer"]
+
+    title = _bounded_str(
+        f"Routing explanation for {family} signal ({signal['id']})",
+        MAX_TITLE_LEN,
+    )
+    summary = _bounded_str(
+        (
+            f"Routing-signal family={family} advises status={status} for the "
+            f"{target_layer} layer. The signal {name.lower()}. This row is "
+            "read-only / mutation_allowed=false; it makes no actual routing "
+            "decision."
+        ),
+        MAX_SUMMARY_LEN,
+    )
+
+    return {
+        "id": f"re_{signal['id']}",
+        "signal_id": signal["id"],
+        "signal_family": family,
+        "title": title,
+        "summary": summary,
+        "status": status,
+        "target": target_layer,
+        "reasons": reasons,
+        "supports_exploration": supports,
+        "suppresses_exploration": suppresses,
+        "requires_confirmation": requires_confirmation,
+        "read_only": True,
+        "mutation_allowed": False,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Snapshot assembly
+# ---------------------------------------------------------------------------
+
+
+def collect_snapshot(
+    *,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    """Build the deterministic routing-explanation projection.
+
+    Reads the upstream signal schema via the in-process
+    ``intelligent_routing_diagnostic_signals.collect_snapshot()``.
+    Never reads from disk; never mutates upstream state.
+    """
+    ts = generated_at_utc if generated_at_utc is not None else _utcnow()
+
+    upstream = rsd.collect_snapshot(generated_at_utc=ts)
+    signals = upstream.get("signals") or []
+    if not isinstance(signals, list):
+        signals = []
+
+    explanations: list[dict[str, Any]] = []
+    for s in signals:
+        if not isinstance(s, dict):
+            continue
+        if "id" not in s or not isinstance(s["id"], str) or not s["id"]:
+            continue
+        explanations.append(_explanation_from_signal(s))
+
+    # Deterministic ordering: signal_id ascending.
+    explanations.sort(key=lambda e: e["signal_id"])
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": ts,
+        "step5_enabled_substage": STEP5_ENABLED_SUBSTAGE,
+        "step5_implementation_allowed": step5_implementation_allowed,
+        "source_signal_schema_version": upstream.get("schema_version", ""),
+        "source_signal_module_version": upstream.get("module_version", ""),
+        "vocabularies": {
+            "routing_explanation_status": list(ROUTING_EXPLANATION_STATUS),
+            "routing_explanation_reason_kind": list(
+                ROUTING_EXPLANATION_REASON_KIND
+            ),
+            "routing_explanation_effect": list(ROUTING_EXPLANATION_EFFECT),
+            "routing_explanation_target": list(ROUTING_EXPLANATION_TARGET),
+            "routing_explanation_source": list(ROUTING_EXPLANATION_SOURCE),
+        },
+        "explanations": explanations,
+        "projection_invariants": dict(_BASE_PROJECTION_INVARIANTS),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Atomic write
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Atomically write ``payload`` as sorted-key indented JSON.
+    Refuses any path outside ``logs/routing_explanation/``."""
+    posix = path.as_posix()
+    if _WRITE_PREFIX not in posix:
+        raise ValueError(
+            "routing_explanation._atomic_write_json refuses "
+            f"non-explanation-logs output path: {path}"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".routing_explanation.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_outputs(snapshot: dict[str, Any]) -> Path:
+    _atomic_write_json(ARTIFACT_LATEST, snapshot)
+    return ARTIFACT_LATEST
+
+
+# ---------------------------------------------------------------------------
+# Status renderer
+# ---------------------------------------------------------------------------
+
+
+def _render_status(snapshot: dict[str, Any]) -> str:
+    explanations = snapshot["explanations"]
+    inv = snapshot["projection_invariants"]
+    by_status: dict[str, int] = {s: 0 for s in ROUTING_EXPLANATION_STATUS}
+    by_effect_supports = 0
+    by_effect_suppresses = 0
+    by_effect_requires_confirmation = 0
+    for e in explanations:
+        if e["status"] in by_status:
+            by_status[e["status"]] += 1
+        by_effect_supports += int(bool(e["supports_exploration"]))
+        by_effect_suppresses += int(bool(e["suppresses_exploration"]))
+        by_effect_requires_confirmation += int(
+            bool(e["requires_confirmation"])
+        )
+    lines = [
+        f"routing_explanation {snapshot['module_version']} "
+        f"schema={snapshot['schema_version']}",
+        f"generated_at_utc={snapshot['generated_at_utc']}",
+        f"explanations={len(explanations)}",
+        (
+            "step5_implementation_allowed="
+            f"{snapshot['step5_implementation_allowed']} "
+            f"step5_enabled_substage={snapshot['step5_enabled_substage']}"
+        ),
+        (
+            "diagnostics_do_not_trade="
+            f"{inv['diagnostics_do_not_trade']} "
+            "external_data_is_not_alpha="
+            f"{inv['external_data_is_not_alpha']}"
+        ),
+        (
+            "no_runtime_trading_authority="
+            f"{inv['no_runtime_trading_authority']} "
+            f"no_step5_runtime={inv['no_step5_runtime']} "
+            f"no_level6={inv['no_level6']} "
+            "no_production_merge_authority="
+            f"{inv['no_production_merge_authority']}"
+        ),
+        (
+            "no_campaign_queue_mutation="
+            f"{inv['no_campaign_queue_mutation']} "
+            "no_actual_routing_decision="
+            f"{inv['no_actual_routing_decision']} "
+            "no_strategy_generation="
+            f"{inv['no_strategy_generation']}"
+        ),
+        (
+            "read_only="
+            f"{inv['read_only']} "
+            "mutation_allowed="
+            f"{inv['mutation_allowed']}"
+        ),
+        f"by_status={dict(sorted(by_status.items()))}",
+        (
+            f"supports_exploration={by_effect_supports} "
+            f"suppresses_exploration={by_effect_suppresses} "
+            f"requires_confirmation={by_effect_requires_confirmation}"
+        ),
+    ]
+    for e in explanations:
+        lines.append(
+            f"  expl {e['id']} signal={e['signal_id']} "
+            f"family={e['signal_family']} target={e['target']} "
+            f"status={e['status']}"
+        )
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m reporting.routing_explanation",
+        description=(
+            "v3.15.16 Intelligent Routing Layer — read-only routing-"
+            "decision explanation reporter. Consumes the diagnostic-"
+            "aware routing-signals schema and emits operator-readable "
+            "explanations. Explanation only; no actual routing "
+            "decision, no campaign queue mutation, no strategy "
+            "generation, no trading behaviour. Step 5 implementation "
+            "remains BLOCKED."
+        ),
+    )
+    p.add_argument(
+        "--indent",
+        type=int,
+        default=2,
+        help="JSON indent for stdout output (0 for compact).",
+    )
+    p.add_argument(
+        "--no-write",
+        action="store_true",
+        help=(
+            "Do not persist logs/routing_explanation/latest.json "
+            "(stdout only)."
+        ),
+    )
+    p.add_argument(
+        "--status",
+        action="store_true",
+        help=(
+            "Render a compact human-readable status summary to stdout "
+            "and exit. Does not write any artefact."
+        ),
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    snap = collect_snapshot()
+    if args.status:
+        sys.stdout.write(_render_status(snap))
+        return 0
+    indent = args.indent if args.indent and args.indent > 0 else None
+    if not args.no_write:
+        write_outputs(snap)
+    json.dump(snap, sys.stdout, indent=indent, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/unit/test_routing_explanation.py
+++ b/tests/unit/test_routing_explanation.py
@@ -1,0 +1,755 @@
+"""Unit tests for v3.15.16 Intelligent Routing Layer — read-only
+routing-decision explanation reporter
+(``reporting.routing_explanation``).
+
+Pins:
+
+* closed vocabularies (ROUTING_EXPLANATION_STATUS,
+  ROUTING_EXPLANATION_REASON_KIND, ROUTING_EXPLANATION_EFFECT,
+  ROUTING_EXPLANATION_TARGET, ROUTING_EXPLANATION_SOURCE);
+* schema integrity (RoutingExplanationReason, RoutingExplanation,
+  RoutingExplanationProjection field tuples);
+* deterministic output with injected ``generated_at_utc``;
+* byte-identical output for identical input;
+* atomic write only under ``logs/routing_explanation/``;
+* ``--no-write`` does not write; ``--status`` does not write;
+* every upstream diagnostic-routing signal gets exactly one
+  explanation;
+* explanations sorted deterministically by ``signal_id``;
+* every explanation has at least one reason;
+* every explanation has ``read_only=True`` and
+  ``mutation_allowed=False``;
+* ``supports_exploration`` / ``suppresses_exploration`` /
+  ``requires_confirmation`` follow closed deterministic semantics
+  keyed on the upstream signal's ``direction``;
+* projection_invariants pin all required authority and read-only
+  flags;
+* no forbidden imports or runtime tokens appear in the module
+  source.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reporting import intelligent_routing_diagnostic_signals as rsd
+from reporting import routing_explanation as rxn
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+_FROZEN_UTC = "2026-05-18T13:00:00Z"
+
+
+@pytest.fixture
+def snap() -> dict:
+    return rxn.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+
+
+@pytest.fixture
+def upstream_snap() -> dict:
+    return rsd.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies
+# ---------------------------------------------------------------------------
+
+
+def test_routing_explanation_status_is_closed_exact() -> None:
+    assert rxn.ROUTING_EXPLANATION_STATUS == (
+        "advisory_prioritize",
+        "advisory_deprioritize",
+        "advisory_suppress",
+        "advisory_require_confirmation",
+        "advisory_neutral",
+        "informational",
+    )
+
+
+def test_routing_explanation_reason_kind_is_closed_exact() -> None:
+    assert rxn.ROUTING_EXPLANATION_REASON_KIND == (
+        "direction_advice",
+        "expected_information_gain",
+        "dead_zone_risk",
+        "orthogonality",
+        "public_data_quality",
+        "confirmation_requirement",
+        "missing_input_fallback",
+    )
+
+
+def test_routing_explanation_effect_is_closed_exact() -> None:
+    assert rxn.ROUTING_EXPLANATION_EFFECT == (
+        "supports_exploration",
+        "suppresses_exploration",
+        "requires_confirmation",
+        "lowers_priority",
+        "elevates_evidence_requirement",
+        "neutral",
+    )
+
+
+def test_routing_explanation_target_mirrors_upstream() -> None:
+    """Target-layer vocabulary is verbatim re-export from the
+    upstream signal module."""
+    assert rxn.ROUTING_EXPLANATION_TARGET == rsd.ROUTING_SIGNAL_TARGET_LAYER
+
+
+def test_routing_explanation_source_is_closed_exact() -> None:
+    assert rxn.ROUTING_EXPLANATION_SOURCE == (
+        "reporting.intelligent_routing_diagnostic_signals",
+        "reporting.routing_explanation",
+        "logs/intelligent_routing_diagnostic_signals/latest.json",
+    )
+
+
+def test_direction_status_mapping_is_total_over_upstream_directions() -> None:
+    """Every upstream direction must map to an explanation status."""
+    for direction in rsd.ROUTING_SIGNAL_DIRECTION:
+        assert direction in rxn._DIRECTION_TO_STATUS, direction
+        assert (
+            rxn._DIRECTION_TO_STATUS[direction]
+            in rxn.ROUTING_EXPLANATION_STATUS
+        )
+
+
+def test_direction_effect_mapping_is_total_over_upstream_directions() -> None:
+    for direction in rsd.ROUTING_SIGNAL_DIRECTION:
+        assert direction in rxn._DIRECTION_TO_EFFECT, direction
+        assert (
+            rxn._DIRECTION_TO_EFFECT[direction]
+            in rxn.ROUTING_EXPLANATION_EFFECT
+        )
+
+
+def test_direction_aggregate_mapping_is_total_over_upstream_directions() -> None:
+    for direction in rsd.ROUTING_SIGNAL_DIRECTION:
+        assert direction in rxn._DIRECTION_TO_AGGREGATE, direction
+        triple = rxn._DIRECTION_TO_AGGREGATE[direction]
+        assert isinstance(triple, tuple) and len(triple) == 3
+        for v in triple:
+            assert isinstance(v, bool)
+
+
+def test_family_reason_mapping_is_total_over_upstream_families() -> None:
+    """Every upstream signal family must have a family-specific
+    reason mapping with kind + effect drawn from closed vocab."""
+    for family in rsd.ROUTING_SIGNAL_FAMILY:
+        assert family in rxn._FAMILY_TO_REASON, family
+        kind, effect = rxn._FAMILY_TO_REASON[family]
+        assert kind in rxn.ROUTING_EXPLANATION_REASON_KIND, (family, kind)
+        assert effect in rxn.ROUTING_EXPLANATION_EFFECT, (family, effect)
+        # Family also maps to a known upstream effect field name.
+        assert family in rxn._FAMILY_TO_REASON_FIELD, family
+
+
+# ---------------------------------------------------------------------------
+# Schema integrity
+# ---------------------------------------------------------------------------
+
+
+def test_routing_explanation_reason_field_list_exact() -> None:
+    assert rxn.ROUTING_EXPLANATION_REASON_FIELDS == (
+        "kind",
+        "signal_id",
+        "signal_family",
+        "reason",
+        "effect",
+        "source",
+    )
+
+
+def test_routing_explanation_field_list_exact() -> None:
+    assert rxn.ROUTING_EXPLANATION_FIELDS == (
+        "id",
+        "signal_id",
+        "signal_family",
+        "title",
+        "summary",
+        "status",
+        "target",
+        "reasons",
+        "supports_exploration",
+        "suppresses_exploration",
+        "requires_confirmation",
+        "read_only",
+        "mutation_allowed",
+    )
+
+
+def test_routing_explanation_projection_field_list_exact() -> None:
+    assert rxn.ROUTING_EXPLANATION_PROJECTION_FIELDS == (
+        "generated_at_utc",
+        "schema_version",
+        "module_version",
+        "source_signal_schema_version",
+        "explanations",
+        "projection_invariants",
+    )
+
+
+def test_every_explanation_has_every_field(snap: dict) -> None:
+    for e in snap["explanations"]:
+        assert set(e.keys()) == set(rxn.ROUTING_EXPLANATION_FIELDS), e
+
+
+def test_every_reason_has_every_field(snap: dict) -> None:
+    for e in snap["explanations"]:
+        for r in e["reasons"]:
+            assert set(r.keys()) == set(
+                rxn.ROUTING_EXPLANATION_REASON_FIELDS
+            ), r
+
+
+def test_projection_carries_every_top_level_field(snap: dict) -> None:
+    for field in rxn.ROUTING_EXPLANATION_PROJECTION_FIELDS:
+        assert field in snap, field
+
+
+def test_every_field_value_in_closed_vocab(snap: dict) -> None:
+    for e in snap["explanations"]:
+        assert e["status"] in rxn.ROUTING_EXPLANATION_STATUS
+        assert e["target"] in rxn.ROUTING_EXPLANATION_TARGET
+        assert e["signal_family"] in rsd.ROUTING_SIGNAL_FAMILY
+        for r in e["reasons"]:
+            assert r["kind"] in rxn.ROUTING_EXPLANATION_REASON_KIND
+            assert r["effect"] in rxn.ROUTING_EXPLANATION_EFFECT
+            assert r["source"] in rxn.ROUTING_EXPLANATION_SOURCE
+            assert r["signal_family"] in rsd.ROUTING_SIGNAL_FAMILY
+
+
+# ---------------------------------------------------------------------------
+# Coverage and ordering
+# ---------------------------------------------------------------------------
+
+
+def test_one_explanation_per_upstream_signal(
+    snap: dict, upstream_snap: dict
+) -> None:
+    upstream_ids = sorted(s["id"] for s in upstream_snap["signals"])
+    explanation_signal_ids = sorted(
+        e["signal_id"] for e in snap["explanations"]
+    )
+    assert explanation_signal_ids == upstream_ids
+
+
+def test_explanation_count_matches_upstream_signal_count(
+    snap: dict, upstream_snap: dict
+) -> None:
+    assert len(snap["explanations"]) == len(upstream_snap["signals"])
+
+
+def test_explanations_sorted_by_signal_id(snap: dict) -> None:
+    ids = [e["signal_id"] for e in snap["explanations"]]
+    assert ids == sorted(ids)
+
+
+def test_explanation_ids_are_unique(snap: dict) -> None:
+    ids = [e["id"] for e in snap["explanations"]]
+    assert len(ids) == len(set(ids))
+
+
+def test_explanation_id_derives_from_signal_id(snap: dict) -> None:
+    for e in snap["explanations"]:
+        assert e["id"] == f"re_{e['signal_id']}", e
+
+
+# ---------------------------------------------------------------------------
+# Reasons content
+# ---------------------------------------------------------------------------
+
+
+def test_every_explanation_has_at_least_one_reason(snap: dict) -> None:
+    for e in snap["explanations"]:
+        assert isinstance(e["reasons"], list)
+        assert len(e["reasons"]) >= 1, e["id"]
+
+
+def test_every_explanation_has_three_reasons_today(snap: dict) -> None:
+    """Today the deterministic builder emits exactly three reasons:
+    direction_advice, family_specific, missing_input_fallback. If a
+    future operator-approved change adds more reasons, this test is
+    the canonical place to update the expected count."""
+    for e in snap["explanations"]:
+        assert len(e["reasons"]) == 3, (e["id"], len(e["reasons"]))
+
+
+def test_every_explanation_has_direction_advice_reason(snap: dict) -> None:
+    for e in snap["explanations"]:
+        kinds = [r["kind"] for r in e["reasons"]]
+        assert "direction_advice" in kinds, e["id"]
+
+
+def test_every_explanation_has_missing_input_fallback_reason(
+    snap: dict,
+) -> None:
+    for e in snap["explanations"]:
+        kinds = [r["kind"] for r in e["reasons"]]
+        assert "missing_input_fallback" in kinds, e["id"]
+
+
+def test_direction_advice_reason_effect_matches_direction_map(
+    snap: dict, upstream_snap: dict
+) -> None:
+    upstream_by_id = {s["id"]: s for s in upstream_snap["signals"]}
+    for e in snap["explanations"]:
+        upstream = upstream_by_id[e["signal_id"]]
+        expected_effect = rxn._DIRECTION_TO_EFFECT[upstream["direction"]]
+        direction_reasons = [
+            r for r in e["reasons"] if r["kind"] == "direction_advice"
+        ]
+        assert len(direction_reasons) == 1
+        assert direction_reasons[0]["effect"] == expected_effect
+
+
+def test_family_specific_reason_matches_family_map(
+    snap: dict, upstream_snap: dict
+) -> None:
+    upstream_by_id = {s["id"]: s for s in upstream_snap["signals"]}
+    for e in snap["explanations"]:
+        upstream = upstream_by_id[e["signal_id"]]
+        family = upstream["family"]
+        expected_kind, expected_effect = rxn._FAMILY_TO_REASON[family]
+        # The family-specific reason is the one with the
+        # _FAMILY_TO_REASON[family][0] kind (i.e., not
+        # direction_advice and not missing_input_fallback).
+        family_reasons = [
+            r
+            for r in e["reasons"]
+            if r["kind"] not in {"direction_advice", "missing_input_fallback"}
+        ]
+        assert len(family_reasons) == 1, e["id"]
+        r = family_reasons[0]
+        assert r["kind"] == expected_kind, (e["id"], r)
+        assert r["effect"] == expected_effect, (e["id"], r)
+        assert r["source"] == "reporting.routing_explanation"
+
+
+# ---------------------------------------------------------------------------
+# Read-only / mutation_allowed semantics
+# ---------------------------------------------------------------------------
+
+
+def test_every_explanation_is_read_only(snap: dict) -> None:
+    for e in snap["explanations"]:
+        assert e["read_only"] is True
+
+
+def test_every_explanation_has_mutation_allowed_false(snap: dict) -> None:
+    for e in snap["explanations"]:
+        assert e["mutation_allowed"] is False
+
+
+# ---------------------------------------------------------------------------
+# Aggregate boolean semantics (supports / suppresses / requires_confirmation)
+# ---------------------------------------------------------------------------
+
+
+def test_aggregate_booleans_match_direction_aggregate_map(
+    snap: dict, upstream_snap: dict
+) -> None:
+    upstream_by_id = {s["id"]: s for s in upstream_snap["signals"]}
+    for e in snap["explanations"]:
+        upstream = upstream_by_id[e["signal_id"]]
+        direction = upstream["direction"]
+        supports, suppresses, requires_confirmation = (
+            rxn._DIRECTION_TO_AGGREGATE[direction]
+        )
+        assert e["supports_exploration"] is supports, (e["id"], direction)
+        assert e["suppresses_exploration"] is suppresses, (e["id"], direction)
+        assert e["requires_confirmation"] is requires_confirmation, (
+            e["id"],
+            direction,
+        )
+
+
+def test_status_matches_direction_status_map(
+    snap: dict, upstream_snap: dict
+) -> None:
+    upstream_by_id = {s["id"]: s for s in upstream_snap["signals"]}
+    for e in snap["explanations"]:
+        upstream = upstream_by_id[e["signal_id"]]
+        assert (
+            e["status"] == rxn._DIRECTION_TO_STATUS[upstream["direction"]]
+        ), e
+
+
+def test_no_explanation_is_simultaneously_supports_and_suppresses(
+    snap: dict,
+) -> None:
+    """Defence-in-depth: a single explanation cannot both support
+    and suppress exploration."""
+    for e in snap["explanations"]:
+        assert not (
+            e["supports_exploration"] and e["suppresses_exploration"]
+        ), e["id"]
+
+
+# ---------------------------------------------------------------------------
+# Projection invariants
+# ---------------------------------------------------------------------------
+
+
+def test_invariants_pin_diagnostics_do_not_trade(snap: dict) -> None:
+    inv = snap["projection_invariants"]
+    assert inv["diagnostics_do_not_trade"] is True
+
+
+def test_invariants_pin_external_data_is_not_alpha(snap: dict) -> None:
+    inv = snap["projection_invariants"]
+    assert inv["external_data_is_not_alpha"] is True
+
+
+def test_invariants_pin_read_only_and_mutation_allowed_false(
+    snap: dict,
+) -> None:
+    inv = snap["projection_invariants"]
+    assert inv["read_only"] is True
+    assert inv["mutation_allowed"] is False
+
+
+def test_invariants_pin_no_runtime_trading_authority(snap: dict) -> None:
+    inv = snap["projection_invariants"]
+    assert inv["no_runtime_trading_authority"] is True
+
+
+def test_invariants_pin_no_campaign_queue_mutation(snap: dict) -> None:
+    inv = snap["projection_invariants"]
+    assert inv["no_campaign_queue_mutation"] is True
+
+
+def test_invariants_pin_no_actual_routing_decision(snap: dict) -> None:
+    inv = snap["projection_invariants"]
+    assert inv["no_actual_routing_decision"] is True
+
+
+def test_invariants_pin_no_strategy_generation(snap: dict) -> None:
+    inv = snap["projection_invariants"]
+    assert inv["no_strategy_generation"] is True
+
+
+def test_invariants_pin_no_step5_runtime(snap: dict) -> None:
+    inv = snap["projection_invariants"]
+    assert inv["no_step5_runtime"] is True
+    assert snap["step5_implementation_allowed"] is False
+    assert snap["step5_enabled_substage"] == "none"
+
+
+def test_invariants_pin_no_level6(snap: dict) -> None:
+    inv = snap["projection_invariants"]
+    assert inv["no_level6"] is True
+
+
+def test_invariants_pin_no_production_merge_authority(snap: dict) -> None:
+    inv = snap["projection_invariants"]
+    assert inv["no_production_merge_authority"] is True
+
+
+def test_invariants_pin_no_routing_mutation(snap: dict) -> None:
+    inv = snap["projection_invariants"]
+    assert inv["no_routing_mutation"] is True
+    assert inv["no_research_runtime_change"] is True
+
+
+def test_invariants_pin_no_branch_pr_merge_deploy(snap: dict) -> None:
+    inv = snap["projection_invariants"]
+    assert inv["no_branch_creation"] is True
+    assert inv["no_pr_creation"] is True
+    assert inv["no_merge_or_deploy"] is True
+
+
+def test_invariants_pin_no_mutation_routes_or_approval_buttons(
+    snap: dict,
+) -> None:
+    inv = snap["projection_invariants"]
+    assert inv["no_mutation_routes"] is True
+    assert inv["no_approval_buttons"] is True
+
+
+def test_invariants_pin_writes_only_routing_explanation_log(
+    snap: dict,
+) -> None:
+    inv = snap["projection_invariants"]
+    assert inv["writes_only_routing_explanation_log"] is True
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_deterministic_with_injected_ts() -> None:
+    a = rxn.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+    b = rxn.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+    assert a == b
+
+
+def test_serialised_output_byte_identical_with_injected_ts() -> None:
+    a = rxn.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+    b = rxn.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+    out_a = json.dumps(a, indent=2, sort_keys=True) + "\n"
+    out_b = json.dumps(b, indent=2, sort_keys=True) + "\n"
+    assert out_a == out_b
+
+
+def test_upstream_schema_version_recorded(
+    snap: dict, upstream_snap: dict
+) -> None:
+    assert (
+        snap["source_signal_schema_version"]
+        == upstream_snap["schema_version"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Atomic write allowlist
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_write_refuses_path_outside_allowlist(tmp_path: Path) -> None:
+    bad = tmp_path / "logs" / "elsewhere" / "latest.json"
+    bad.parent.mkdir(parents=True, exist_ok=True)
+    with pytest.raises(ValueError):
+        rxn._atomic_write_json(bad, {"x": 1})
+
+
+def test_atomic_write_refuses_frozen_contract_paths(tmp_path: Path) -> None:
+    for forbidden in (
+        "research/research_latest.json",
+        "research/strategy_matrix.csv",
+    ):
+        target = tmp_path / forbidden
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with pytest.raises(ValueError):
+            rxn._atomic_write_json(target, {"x": 1})
+
+
+def test_atomic_write_accepts_allowlisted_path(tmp_path: Path) -> None:
+    good = tmp_path / "logs" / "routing_explanation" / "latest.json"
+    good.parent.mkdir(parents=True, exist_ok=True)
+    rxn._atomic_write_json(good, {"x": 1})
+    assert good.is_file()
+
+
+def test_atomic_write_is_atomic(tmp_path: Path) -> None:
+    target = tmp_path / "logs" / "routing_explanation" / "latest.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    rxn._atomic_write_json(target, {"x": 1})
+    rxn._atomic_write_json(target, {"x": 2})
+    siblings = list(target.parent.iterdir())
+    assert siblings == [target]
+
+
+# ---------------------------------------------------------------------------
+# CLI behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_cli_no_write_does_not_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    sentinel = tmp_path / "logs" / "routing_explanation" / "latest.json"
+    monkeypatch.setattr(rxn, "ARTIFACT_LATEST", sentinel)
+    monkeypatch.setattr(rxn, "ARTIFACT_DIR", sentinel.parent)
+    rc = rxn.main(["--no-write"])
+    assert rc == 0
+    assert not sentinel.exists()
+    out = capsys.readouterr().out
+    assert '"routing_explanation"' in out
+
+
+def test_cli_status_does_not_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    sentinel = tmp_path / "logs" / "routing_explanation" / "latest.json"
+    monkeypatch.setattr(rxn, "ARTIFACT_LATEST", sentinel)
+    monkeypatch.setattr(rxn, "ARTIFACT_DIR", sentinel.parent)
+    rc = rxn.main(["--status"])
+    assert rc == 0
+    assert not sentinel.exists()
+    out = capsys.readouterr().out
+    assert "routing_explanation" in out
+    assert "diagnostics_do_not_trade=True" in out
+    assert "external_data_is_not_alpha=True" in out
+    assert "no_runtime_trading_authority=True" in out
+    assert "no_actual_routing_decision=True" in out
+    assert "no_campaign_queue_mutation=True" in out
+    assert "no_strategy_generation=True" in out
+    assert "read_only=True" in out
+    assert "mutation_allowed=False" in out
+
+
+def test_cli_default_writes_to_allowlisted_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sentinel = tmp_path / "logs" / "routing_explanation" / "latest.json"
+    monkeypatch.setattr(rxn, "ARTIFACT_LATEST", sentinel)
+    monkeypatch.setattr(rxn, "ARTIFACT_DIR", sentinel.parent)
+    rc = rxn.main([])
+    assert rc == 0
+    assert sentinel.is_file()
+    payload = json.loads(sentinel.read_text(encoding="utf-8"))
+    assert payload["report_kind"] == "routing_explanation"
+    assert payload["module_version"].startswith("v3.15.16.routing_explanation")
+
+
+def test_cli_indent_zero_compact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    sentinel = tmp_path / "logs" / "routing_explanation" / "latest.json"
+    monkeypatch.setattr(rxn, "ARTIFACT_LATEST", sentinel)
+    monkeypatch.setattr(rxn, "ARTIFACT_DIR", sentinel.parent)
+    rc = rxn.main(["--no-write", "--indent", "0"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "\n  " not in out
+
+
+# ---------------------------------------------------------------------------
+# Module-source forbidden-import / forbidden-token scans
+# ---------------------------------------------------------------------------
+
+
+def _module_source() -> str:
+    return Path(rxn.__file__).read_text(encoding="utf-8")
+
+
+def _module_imports() -> list[str]:
+    import ast as _ast
+
+    tree = _ast.parse(_module_source())
+    out: list[str] = []
+    for node in _ast.walk(tree):
+        if isinstance(node, _ast.Import):
+            for alias in node.names:
+                out.append(alias.name)
+        elif isinstance(node, _ast.ImportFrom):
+            mod = node.module or ""
+            for alias in node.names:
+                out.append(f"{mod}.{alias.name}" if mod else alias.name)
+    return out
+
+
+def test_no_subprocess_in_module() -> None:
+    src = _module_source()
+    assert "import subprocess" not in src
+    assert "from subprocess" not in src
+    assert "subprocess." not in src
+
+
+def test_no_socket_or_urllib_or_http_or_requests() -> None:
+    src = _module_source()
+    for forbidden in (
+        "import socket",
+        "from socket",
+        "import urllib",
+        "from urllib",
+        "import http",
+        "from http",
+        "import requests",
+        "from requests",
+        "import httpx",
+        "from httpx",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_no_forbidden_runtime_imports_via_ast() -> None:
+    forbidden_prefixes = (
+        "dashboard",
+        "automation",
+        "broker",
+        "agent.risk",
+        "agent.execution",
+        "research",
+        "live",
+        "paper",
+        "shadow",
+        "trading",
+        "reporting.intelligent_routing",  # the legacy module path, distinct from intelligent_routing_diagnostic_signals
+        "reporting.development_queue_admission_policy",
+        "reporting.development_agent_activity_timeline",
+        "reporting.execution_authority",
+        "reporting.roadmap_task_catalog",
+        "reporting.roadmap_task_units",
+        "reporting.roadmap_unit_authority",
+        "reporting.roadmap_next_unit",
+    )
+    for module in _module_imports():
+        # The legitimate import this module uses is
+        # ``reporting.intelligent_routing_diagnostic_signals``.
+        # That is NOT a sub-module of ``reporting.intelligent_routing``;
+        # the underscore boundary matters.
+        if module.startswith("reporting.intelligent_routing_diagnostic_signals"):
+            continue
+        for prefix in forbidden_prefixes:
+            assert not (
+                module == prefix or module.startswith(prefix + ".")
+            ), f"forbidden import: {module}"
+
+
+def test_module_imports_only_canonical_upstream() -> None:
+    """A20-pipeline style: stdlib + exactly the one upstream
+    reporting module."""
+    allowed_reporting_imports = {
+        "reporting.intelligent_routing_diagnostic_signals",
+    }
+    for module in _module_imports():
+        if module.startswith("reporting."):
+            assert module in allowed_reporting_imports, module
+
+
+def test_no_gh_or_git_cli_calls() -> None:
+    src = _module_source()
+    for forbidden in (
+        "subprocess.run",
+        "subprocess.Popen",
+        "os.system(",
+        "os.popen(",
+        "shell=True",
+        "eval(",
+        "exec(",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_no_github_api_or_external_api_calls() -> None:
+    src = _module_source()
+    for forbidden in (
+        "api.github.com",
+        "anthropic",
+        "openai",
+        "Bearer ",
+        "X-API-Key",
+        "X-GitHub-Token",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_module_imports_cleanly() -> None:
+    importlib.reload(rxn)
+    assert callable(rxn.collect_snapshot)
+    assert callable(rxn.write_outputs)
+    assert callable(rxn.main)
+
+
+def test_schema_and_module_version_strings() -> None:
+    assert isinstance(rxn.SCHEMA_VERSION, str) and rxn.SCHEMA_VERSION
+    assert isinstance(rxn.MODULE_VERSION, str) and rxn.MODULE_VERSION
+    assert "v3.15.16.routing_explanation" in rxn.MODULE_VERSION


### PR DESCRIPTION
## Selected A20e unit

- **Unit id:** `u_v3_15_16_routing_explanation_reporter_001`
- **Phase:** v3.15.16 — Intelligent Routing Layer
- **A20c authority:** `AUTO_ALLOWED`, LOW risk, `operator_gate = none`, `requires_operator_go = False`.
- **Prerequisite:** `u_v3_15_16_diagnostic_routing_signals_schema_001` (merged via PR #250 / SHA `fcb1abb`; queue status advanced via PR #251 / SHA `dcbed07`).
- **Recommended by:** `python -m reporting.roadmap_next_unit --status` deterministic selection after PR #251's queue-status update.

## Summary

- Implements the **read-only routing-decision explanation reporter** for v3.15.16 Intelligent Routing Layer.
- Consumes the `RoutingSignalProjection` emitted by `reporting.intelligent_routing_diagnostic_signals` (the schema/projector unit landed in PR #250) and emits one `RoutingExplanation` per upstream signal.
- Exactly one explanation per upstream signal (14 today). Each carries three deterministic reasons: `direction_advice`, family-specific (closed family→kind/effect mapping), `missing_input_fallback`.
- `supports_exploration` / `suppresses_exploration` / `requires_confirmation` aggregate booleans derived from a closed direction-aggregate map keyed on the upstream signal's `direction`. No hidden scoring, no random ordering, no LLM, no fuzzy parsing.
- Explanations sorted deterministically by `signal_id`. Deterministic byte-identical output for identical input with injected `generated_at_utc`.
- Every emitted explanation carries `read_only=True` and `mutation_allowed=False`. The full `projection_invariants` block pins the A20 authority chain (no runtime/trading/paper/shadow/live authority, no Step 5, no Level 6, no production merge authority).
- Closed vocabularies: `ROUTING_EXPLANATION_STATUS` (6), `ROUTING_EXPLANATION_REASON_KIND` (7), `ROUTING_EXPLANATION_EFFECT` (6; no buy/sell verbs), `ROUTING_EXPLANATION_TARGET` (verbatim re-export of upstream `ROUTING_SIGNAL_TARGET_LAYER`), `ROUTING_EXPLANATION_SOURCE` (3).
- Schemas: `RoutingExplanationReason` (6 fields), `RoutingExplanation` (13 fields), `RoutingExplanationProjection` (6 fields).
- New artefact at `logs/routing_explanation/latest.json`. Atomic-write helper refuses every path outside that directory, including the frozen-contract paths.
- CLI: `--no-write`, `--status`, `--indent`.

## Files changed (exactly 2, expected-files-only)

- `reporting/routing_explanation.py` (new) — stdlib + `reporting.intelligent_routing_diagnostic_signals` only.
- `tests/unit/test_routing_explanation.py` (new) — 65 tests.

Untouched (verified):

- `dashboard/dashboard.py`
- `.claude/**`, `.github/**`
- `research/research_latest.json`, `research/strategy_matrix.csv`
- `automation/live_gate.py`, `broker/**`, `agent/risk/**`, `agent/execution/**`
- `live/**`, `paper/**`, `shadow/**`, `trading/**`
- `docs/roadmap/Roadmap v6.md`, `docs/roadmap/Roadmap v6 Addendum.md`, `docs/roadmap/autonomous_development.txt`
- `docs/governance/execution_authority.md`, `docs/governance/no_touch_paths.md`
- `reporting/execution_authority.py`
- `reporting/development_queue_admission_policy.py` (existing A17)
- Full A20 pipeline: `reporting/roadmap_task_catalog.py`, `reporting/roadmap_task_units.py`, `reporting/roadmap_unit_authority.py`, `reporting/roadmap_next_unit.py`, `reporting/development_agent_activity_timeline.py`
- The PR #250 upstream signal module `reporting/intelligent_routing_diagnostic_signals.py` (read-only-consumed only)
- `docs/development_work_queue/*.jsonl`
- `tests/regression/**`
- any frozen schema under `artifacts/`

## Validation commands and results

- `python -m pytest tests/unit/test_routing_explanation.py -v` -> **65 passed**
- `python -m pytest tests/unit/test_intelligent_routing_diagnostic_signals.py -v` -> **84 passed** (unchanged)
- `python -m pytest tests/unit/test_roadmap_next_unit.py -v` -> **73 passed** (unchanged)
- `python -m pytest tests/smoke -v` -> **18 passed**
- `python scripts/governance_lint.py` -> **OK** (16 agents, 5 workflows)
- `python scripts/push_body_safety_lint.py` -> **OK** (6 surfaces, 6 tokens)
- Frozen-contract regression set (`test_public_output_contract.py`, `test_v12_contracts_preserved.py`, `test_authority_invariants.py`) -> **16 passed**

## Frozen-contract verdict

- `research/research_latest.json` -> **NOT TOUCHED**.
- `research/strategy_matrix.csv` -> **NOT TOUCHED**.
- Atomic-write helper refuses every path outside `logs/routing_explanation/`. Frozen-contract paths explicitly rejected.

## Forbidden-path verdict

`git diff --name-only main` contains exactly the two expected files. None of the forbidden paths above were touched.

## Authority statement

- **This is read-only explanation / reporting only.**
- **No actual routing decision implemented.** `projection_invariants.no_actual_routing_decision = True`.
- **No campaign queue mutation implemented.** `projection_invariants.no_campaign_queue_mutation = True`. No write to `docs/development_work_queue/*.jsonl`.
- **No runtime / trading / paper / shadow / live authority granted.** Every emitted explanation carries `read_only=True` and `mutation_allowed=False`. The `projection_invariants` block pins the full A20 authority chain.
- Step 5 implementation remains BLOCKED. Autonomy-ladder Level 6 remains permanently disabled. N5b Phase 4 production merge remains permanently denied for ADE. ADE remains development workflow automation only.

## What this PR does NOT do

- No actual routing decision (the reporter explains; it does not route).
- No campaign queue mutation. No strategy generation. No research-runtime change.
- No `dashboard/dashboard.py` change. No `.claude/**` change. No `.github/**` change.
- No edit to canonical roadmap docs, canonical policy docs, or `autonomous_development.txt`.
- No edit to the A20 pipeline modules. No edit to the PR #250 upstream signal module.
- No mutation routes, no approval buttons, no required-phrase synthesis, no AAC aggregator change.

## Next recommended step

**Merge protocol** after CI green (squash-merge only — no `--admin`, no force push, no hook bypass, no automatic merge).

After merge, if the operator wants the A20 selector to advance past this unit, a small `chore/a20-*` queue-status-update PR should flip this unit's status from `not_started` to `merged` in `reporting/roadmap_task_units.py::_UNIT_SEED` (same pattern as PR #251 used for the previous unit). That status-update PR is not part of this PR.

After that queue-status update, the next deterministic A20e selection will be the third v3.15.16 unit:

- **`u_v3_15_16_routing_governance_doc_001`** — governance doc for routing-signal usage (LOW risk, AUTO_ALLOWED, no operator gate).

## Test plan

- [x] All local tests + smoke + governance lint + push-body lint + frozen-contract regression all green.
- [ ] CI checks complete on PR (squash-merge only — no `--admin`, no force push, no hook bypass, no automatic merge).

Generated with Claude Code (https://claude.com/claude-code).
