### PR TITLE
feat(step5)(a21a): dynamic unit-status ledger + A20e overlay

### DIFF
--- a/docs/governance/roadmap_task_catalog.md
+++ b/docs/governance/roadmap_task_catalog.md
@@ -1,9 +1,10 @@
-# Roadmap Task Catalog — A20a + A20b + A20c + A20d + A20e (read-only, deterministic)
+# Roadmap Task Catalog — A20a + A20b + A20c + A20d + A20e + A21a (read-only, deterministic)
 
 > **Status:** A20a implemented; A20b implemented; A20c implemented;
 > A20d implemented; A20e implemented (deterministic next-buildable-unit
-> selector). All five stages are read-only projections; none
-> mutates anything; the selector never executes work, opens
+> selector); A21a implemented (dynamic unit-status ledger,
+> Step 5 foundation). All six stages are read-only projections;
+> none mutates anything; the selector never executes work, opens
 > branches / PRs, merges, or deploys.
 >
 > **A20a module:** [`reporting/roadmap_task_catalog.py`](../../reporting/roadmap_task_catalog.py)
@@ -20,6 +21,10 @@
 >
 > **A20e module:** [`reporting/roadmap_next_unit.py`](../../reporting/roadmap_next_unit.py)
 > **A20e artefact:** `logs/roadmap_next_unit/latest.json`
+>
+> **A21a module:** [`reporting/roadmap_unit_status.py`](../../reporting/roadmap_unit_status.py)
+> **A21a artefact:** `logs/roadmap_unit_status/latest.json`
+> **A21a governance:** [`docs/governance/step5_bounded_autonomous_loop.md`](step5_bounded_autonomous_loop.md)
 >
 > **Authority:** development-governance read-only.
 > The roadmap task catalog is **not** the canonical product roadmap.
@@ -847,24 +852,50 @@ implementation unit** opened as its own PR under normal ADE PR
 lifecycle governance. A20e does not open that PR — the operator
 does, using the selector's recommendation as input.
 
-### 11.1 Queue progression log
+### 11.1 Queue progression log (legacy — A20b seed-edit path)
 
-The A20 projections are deterministic / read-only and do not
-auto-discover merged PRs. When a queue-driven Roadmap v6 unit
-lands on `main`, the operator (or a small follow-up
-`chore/a20-*` PR) advances its status in A20b's `_UNIT_SEED`
-so that A20e can recommend the next eligible downstream unit.
-Each transition is recorded here for traceability:
+Until A21a shipped, the A20 projections did not auto-discover
+merged PRs. Each queue-driven Roadmap v6 unit that landed on
+`main` required a small follow-up `chore/a20-*` PR to advance its
+status in A20b's `_UNIT_SEED` so A20e could recommend the next
+eligible downstream unit. Two transitions were recorded by that
+path before §11.2 superseded it:
 
 | Date (UTC) | Unit id | A20b status | Implementing PR | Merge SHA |
 |---|---|---|---|---|
 | 2026-05-18 | `u_v3_15_16_diagnostic_routing_signals_schema_001` | `not_started` → `merged` | [#250](https://github.com/roudjy/trading-agent/pull/250) | `fcb1abbea4bd2ca190fe6e807b3dacd184faa702` |
 | 2026-05-18 | `u_v3_15_16_routing_explanation_reporter_001` | `not_started` → `merged` | [#252](https://github.com/roudjy/trading-agent/pull/252) | `6f588a89b43a2cfec40f92252bde530220877b37` |
 
-This table is informational. The authoritative `status` lives in
-[`reporting/roadmap_task_units.py`](../../reporting/roadmap_task_units.py)
-`_UNIT_SEED` and is pinned by
-[`tests/unit/test_roadmap_task_units.py`](../../tests/unit/test_roadmap_task_units.py).
+This table is informational and frozen. Future merged units are
+recorded in §11.2 via the A21a dynamic ledger instead.
+
+### 11.2 Queue progression log (A21a dynamic ledger path)
+
+[`reporting/roadmap_unit_status.py`](../../reporting/roadmap_unit_status.py)
+(Step 5 / A21a foundation) is now the authoritative source for
+per-unit execution status. The static A20b seed remains the
+authoritative source for **unit definitions** (id, expected
+files, forbidden files, prerequisites, risk hint, authority
+hint), but **execution status** is overlaid by the A21a ledger.
+
+This means a merged unit no longer requires a
+`chore/a20-mark-*-merged` follow-up PR. The bootstrap A21a seed
+already pins the three v3.15.16 routing-layer units as merged
+with their PR numbers and merge SHAs, and the A20e selector
+treats them as `effective_status = "merged"` without any A20b
+edit:
+
+| Date (UTC) | Unit id | Effective status | Implementing PR | Merge SHA | Source |
+|---|---|---|---|---|---|
+| 2026-05-18 | `u_v3_15_16_diagnostic_routing_signals_schema_001` | `merged` | [#250](https://github.com/roudjy/trading-agent/pull/250) | `fcb1abbea4bd2ca190fe6e807b3dacd184faa702` | A21a ledger |
+| 2026-05-18 | `u_v3_15_16_routing_explanation_reporter_001` | `merged` | [#252](https://github.com/roudjy/trading-agent/pull/252) | `6f588a89b43a2cfec40f92252bde530220877b37` | A21a ledger |
+| 2026-05-18 | `u_v3_15_16_routing_governance_doc_001` | `merged` | [#254](https://github.com/roudjy/trading-agent/pull/254) | `df7dc6562ec3cd3a9f87e83e758881bd6fdb16f8` | A21a ledger |
+
+Future merged units append a new record to the A21a seed in the
+same shape. See
+[`docs/governance/step5_bounded_autonomous_loop.md`](step5_bounded_autonomous_loop.md)
+for the dynamic-ledger schema, the closed vocabularies, and the
+validation / fail-closed contract.
 
 <!-- A20e legacy future-stages section retained below for reference. -->
 ## 12. Future stages — A20 complete

--- a/docs/governance/step5_bounded_autonomous_loop.md
+++ b/docs/governance/step5_bounded_autonomous_loop.md
@@ -1,0 +1,492 @@
+# Step 5 — Bounded Autonomous Implementation Loop (Foundation)
+
+> **Status:** Step 5 implementation remains **BLOCKED**.
+> Autonomy-ladder Level 6 remains **permanently disabled** per
+> ADR-015 §Doctrine 1. N5b Phase 4 production-merge authority
+> remains **permanently denied for ADE**.
+>
+> This document specifies the **foundation** for the future
+> bounded autonomous implementation loop. The foundation lives in
+> [`reporting/roadmap_unit_status.py`](../../reporting/roadmap_unit_status.py)
+> (the **A21a dynamic unit-status ledger**) and the matching A20e
+> selector overlay in
+> [`reporting/roadmap_next_unit.py`](../../reporting/roadmap_next_unit.py).
+> The actual loop (branch / implement / PR / merge / deploy) is
+> **not implemented in this PR**.
+>
+> **Phase:** Step 5 / A21 foundation. Each future slice (A21b,
+> A21c, …) ships its own governance section in this doc plus its
+> own implementation PR.
+> **Authority class on this PR:** `AUTO_ALLOWED` (LOW risk,
+> `operator_gate = none`, read-only deterministic projections +
+> documentation).
+
+---
+
+## 1. Why a bounded autonomous loop is needed
+
+After A20a–A20e shipped, the Roadmap v6 development queue is fully
+deterministic and operator-readable, but the operator still has to
+hand-walk Claude through every unit:
+
+1. "Tell Claude to implement the next selected unit."
+2. "Tell Claude to merge the PR."
+3. "Tell Claude to mark the unit as merged in A20b's `_UNIT_SEED`."
+4. "Tell Claude to continue."
+
+That four-step manual cycle defeats the purpose of ADE. The
+operator wants to focus on strategic QRE direction (which roadmap
+phase to fund next, which research bets to take), **not** on
+engineering-loop babysitting.
+
+The bounded autonomous loop is the path off the babysitting
+treadmill. The two foundation surfaces it requires — neither of
+which executes anything — are:
+
+* a **dynamic unit-status ledger** so completing a unit no longer
+  requires editing
+  [`reporting/roadmap_task_units.py`](../../reporting/roadmap_task_units.py)
+  (the A20b static decomposition); and
+* a **selector overlay** so A20e advances past completed units
+  using the ledger instead of the static seed.
+
+This PR ships exactly those two surfaces. It does **not** ship the
+loop itself.
+
+## 2. Hard permanent constraints (carried into every future slice)
+
+Every future Step 5 / A21 slice — and every future bounded
+autonomous loop run — MUST honour the following invariants without
+exception. They are pinned on every emitted projection of A21a and
+A20e:
+
+* No live trading.
+* No paper / shadow runtime activation unless a future explicit
+  operator-approved roadmap phase enables it.
+* No broker / order / risk / execution path changes.
+* No capital allocation.
+* No live / paper / shadow / broker credentials.
+* No mutation of `research/research_latest.json`.
+* No mutation of `research/strategy_matrix.csv`.
+* No `.claude/**` mutation.
+* No `dashboard/dashboard.py` mutation unless explicitly
+  operator-approved.
+* No approval-inbox mutation.
+* No mutation routes.
+* No approval buttons.
+* No direct `main` push.
+* No force push.
+* No `--admin` merge.
+* No hook bypass.
+* No test weakening.
+* No execution of `NEEDS_HUMAN` units.
+* No execution of `PERMANENTLY_DENIED` units.
+* No execution of `MEDIUM` / `HIGH` / `CRITICAL` risk units.
+* No execution if `expected_files` / `forbidden_files` are missing.
+* No execution if the selector result is ambiguous.
+* No hidden LLM judgment overriding the queue.
+
+`step5_implementation_allowed` remains `Final[bool] = False`
+everywhere in the A21 / A20 surface. Autonomy-ladder Level 6
+remains permanently disabled.
+
+## 3. The two foundation surfaces shipped by this PR
+
+### 3.1 A21a — Dynamic Unit Status Ledger
+
+[`reporting/roadmap_unit_status.py`](../../reporting/roadmap_unit_status.py)
+emits a deterministic projection at
+`logs/roadmap_unit_status/latest.json` containing one
+`DynamicUnitStatusRecord` per pinned ledger entry.
+
+**Schema (10 fields, pinned by tests):**
+
+| Field | Type | Notes |
+|---|---|---|
+| `unit_id` | string | implementation unit id |
+| `status` | closed enum | one of `DYNAMIC_UNIT_STATUS` |
+| `source` | closed enum | one of `DYNAMIC_STATUS_SOURCE` |
+| `updated_at_utc` | string | ISO-8601 |
+| `pr_number` | int | required for `merged` |
+| `merge_sha` | string | required for `merged`; hex-only |
+| `reason` | string | required for `merged` |
+| `evidence` | list[string] | optional, bounded |
+| `valid` | bool | computed by validator |
+| `validation_reason` | closed enum | empty for valid records |
+
+**Closed `DYNAMIC_UNIT_STATUS` vocabulary (7 values):**
+
+* `not_started` — no work begun
+* `in_progress` — implementation underway (future loop state)
+* `pr_open` — PR opened, awaiting review / merge
+* `merged` — PR squash-merged (terminal)
+* `failed` — implementation aborted (e.g. CI failure)
+* `blocked` — operator blocked (terminal)
+* `skipped` — operator skipped (terminal)
+
+**Closed `DYNAMIC_STATUS_SOURCE` vocabulary (5 values):**
+
+* `pr_merge` — observed PR merge fact (bootstrap path used today)
+* `operator_override` — operator manually set
+* `loop_state` — set by a future Step 5 loop slice
+* `ci_failure` — set by a future CI watcher slice
+* `operator_block` — operator blocked
+
+**Validation rules:**
+
+* `merged` requires a positive `pr_number`, a hex `merge_sha`, and a
+  non-empty `reason`. Any of these missing => `valid = False`.
+* Unknown `status` or unknown `source` => `valid = False`.
+* Empty `unit_id` => `valid = False`.
+* Missing `updated_at_utc` => `valid = False`.
+* `evidence` not a list / tuple => `valid = False`.
+* `merge_sha` not hex-only (length 7..64) => `valid = False`.
+* Duplicate `unit_id` => every record sharing that id is
+  `valid = False` with `validation_reason = "duplicate_unit_id"`.
+  No implicit resurrection of `merged` units.
+
+**Status transition rules (advisory; selector enforces buildable
+filter on its own):**
+
+* `not_started -> in_progress`
+* `in_progress -> pr_open`
+* `pr_open -> merged`
+* `pr_open -> failed`
+* `in_progress -> failed`
+* `not_started -> blocked`
+* `not_started -> skipped`
+* `failed -> blocked`
+* `blocked`, `skipped`, `merged` are terminal unless an explicit
+  operator-override record is appended.
+
+**Atomic write allowlist:** every write target must contain
+`logs/roadmap_unit_status/`. Any other path (including frozen
+contract paths and `docs/development_work_queue/*.jsonl`) is
+refused with `ValueError`.
+
+**Imports:** stdlib + `reporting.roadmap_task_units` (read-only,
+for the cross-reference module version). Nothing else.
+
+### 3.2 A20e selector overlay
+
+[`reporting/roadmap_next_unit.py`](../../reporting/roadmap_next_unit.py)
+now reads the A21a artefact in addition to the existing A20b /
+A20c upstreams. When a valid dynamic record exists for a unit:
+
+* `effective_status = dynamic.status` (the static A20b status is
+  still emitted on `status` for traceability);
+* `dynamic_status_source = dynamic.source`;
+* terminal dynamic statuses (`merged` / `blocked` / `skipped`)
+  surface as the new `dynamic_status_terminal` block reason;
+* non-terminal non-buildable dynamic statuses (`in_progress` /
+  `pr_open` / `failed`) surface as the existing
+  `non_buildable_status` block reason on the candidate.
+
+When the dynamic record is invalid:
+
+* `invalid_dynamic_status` is appended to `block_reasons`;
+* the selector falls back to fail-closed via
+  `FAIL_CLOSED_INVARIANT`.
+
+When the artefact is absent:
+
+* every unit silently falls back to its A20b static status.
+
+When the artefact is corrupt JSON:
+
+* the selector fails closed with `UPSTREAM_UNAVAILABLE` and the
+  reason `malformed_dynamic_status_artifact:<error>`.
+
+**Prerequisite check** likewise consults the dynamic ledger: a
+prerequisite whose effective status is `merged` (via either the
+A20b static seed or a valid A21a record) satisfies the
+prerequisite. This is what removes the need to edit the A20b seed
+every time a unit lands.
+
+## 4. The stop-condition matrix (future loop)
+
+The Step 5 bounded loop, when its execution slice ships, MUST stop
+and produce an operator-readable report if any of the following
+fire. None of these checks are implemented today; this section is
+the **contract** the future slice will inherit.
+
+### 4.1 Selection-level stop conditions
+
+* Selected unit is not `AUTO_ALLOWED`.
+* `risk_class` is not `LOW`.
+* `operator_gate` is not `none`.
+* `expected_files` is missing or empty.
+* `forbidden_files` is missing or empty.
+* `required_tests` is missing or empty.
+* Selector result is ambiguous
+  (`selection_status != "OK_SELECTED"`).
+* The same unit_id is selected twice in a single run (the loop
+  re-runs the selector after each merge; a repeat selection means
+  the ledger update did not land or the A20a/A20b artefact
+  re-projected to a stale state).
+* Unknown risk / authority / status appears on the candidate.
+
+### 4.2 Implementation-level stop conditions
+
+* Generated diff touches **any** file in `forbidden_files`.
+* Generated diff exceeds `expected_files` (any unlisted modified
+  path).
+* Any `live/**`, `paper/**`, `shadow/**`, `broker/**`,
+  `agent/risk/**`, `agent/execution/**`, `automation/live_gate.py`,
+  `dashboard/dashboard.py`, `.claude/**`, `.github/**`,
+  frozen-contract path, or canonical roadmap path appears in the
+  diff.
+* Local tests fail.
+* `python scripts/governance_lint.py` fails.
+* Any pre-commit / pre-push hook blocks commit or push.
+* Merge conflict occurs.
+
+### 4.3 CI-level stop conditions
+
+* Any required check fails: `lint`, `secret-scan`, `typecheck`,
+  `unit (smoke + unit)`, `regression-fast`, `hook-tests`,
+  `frontend`, `governance-lint`.
+* PR mergeability is not `CLEAN`.
+* Post-merge gates fail: `Build & Push Docker Image`,
+  `Deploy VPS Dashboard`.
+
+### 4.4 Ledger-level stop conditions
+
+* Dynamic status update fails to write (atomic-write allowlist
+  rejects the path; only `logs/roadmap_unit_status/` is allowed).
+* Status ledger is inconsistent (duplicate `unit_id` produces
+  `valid = False` records on the affected ids).
+* A21a snapshot reports `fail_closed = true`.
+
+### 4.5 Bound stop conditions
+
+* `max_units_per_run` reached (see §5).
+* Wall-clock budget exceeded (loop-config knob; not yet defined).
+
+When any of these fire, the loop must:
+
+1. Stop immediately.
+2. Emit a deterministic stop report under `logs/step5_loop/`.
+3. Surface a non-zero exit code to whatever invoked it (cron,
+   GitHub Actions, manual operator CLI).
+4. Never escalate, never `--admin`, never force-push, never
+   bypass hooks.
+
+## 5. `max_units_per_run` design
+
+The future loop slice must accept a `max_units_per_run` parameter
+(default proposed: **1**) which bounds how many implementation
+units it will attempt in a single invocation. The default of `1`
+means the loop performs **exactly one** implementation + merge
+cycle and stops, even if A20e still recommends more eligible
+units after the ledger update.
+
+Rationale:
+
+* `1` keeps the early loop runs operator-observable.
+* `1` keeps the blast radius of any new bug to a single PR.
+* `1` aligns with the existing PR-lifecycle pattern that every
+  v3.15.16 unit has followed (one PR, one merge, one queue update).
+
+The loop slice may expose `max_units_per_run` as a CLI argument
+later, but it MUST never default to anything higher than 1 without
+an explicit operator-authored PR raising the ceiling, and MUST
+never accept a value higher than a small cap (≤ 5) without
+ADR-014 / ADR-015 amendment.
+
+`max_units_per_run` is **not implemented in this PR**. The number
+is documented here as a binding design choice the future slice
+must honour.
+
+## 6. What this PR does **not** implement
+
+The following are out of scope for the foundation slice. Each
+requires its own operator-approved PR (likely A21b, A21c, …):
+
+* Actual branch creation by the loop. No call to
+  `git checkout -b`, no use of `git` or `gh` in any A21 module.
+* Actual code implementation by the loop. No edits to any
+  `reporting/**`, `tests/**`, or `docs/**` file from inside the
+  loop.
+* Actual PR creation by the loop. No call to `gh pr create`.
+* Actual CI watcher. No reading of GitHub Actions runs.
+* Actual squash-merge. No call to `gh pr merge`.
+* Actual deploy watcher. No reading of `Deploy VPS Dashboard`
+  runs.
+* Repeated autonomous loop execution. The loop is one-shot, even
+  when its execution slice ships.
+
+## 7. Bootstrap status records
+
+The bootstrap A21a seed pins exactly three merged records — the
+v3.15.16 routing-layer units already on `main`:
+
+| unit_id | PR | merge_sha |
+|---|---|---|
+| `u_v3_15_16_diagnostic_routing_signals_schema_001` | [#250](https://github.com/roudjy/trading-agent/pull/250) | `fcb1abbea4bd2ca190fe6e807b3dacd184faa702` |
+| `u_v3_15_16_routing_explanation_reporter_001` | [#252](https://github.com/roudjy/trading-agent/pull/252) | `6f588a89b43a2cfec40f92252bde530220877b37` |
+| `u_v3_15_16_routing_governance_doc_001` | [#254](https://github.com/roudjy/trading-agent/pull/254) | `df7dc6562ec3cd3a9f87e83e758881bd6fdb16f8` |
+
+This means PR #254 does **not** require a follow-up
+`chore/a20-mark-routing-governance-doc-merged` PR. The A20e
+selector advances past PR #254's unit through the dynamic ledger,
+not through editing the A20b static seed. This eliminates the
+manual queue-status PR overhead for all three already-merged units
+and for every future merged unit (assuming a future operator PR
+appends a record).
+
+## 8. Authority posture
+
+Every A21a / A20e artefact pins (verbatim from the projection's
+`ledger_invariants` / `selector_invariants` blocks):
+
+* `step5_implementation_allowed = false`
+* `no_step5_runtime = true`
+* `no_level6 = true`
+* `no_production_merge_authority = true`
+* `no_runtime_trading_authority = true`
+* `no_work_execution = true`
+* `no_branch_creation = true`
+* `no_pr_creation = true`
+* `no_merge_or_deploy = true`
+* `no_mutation_routes = true`
+* `no_approval_buttons = true`
+* `calls_execution_authority_classifier = false` (A20c is the only
+  call site)
+* `calls_llm_or_external_api = false`
+* `uses_subprocess_or_network = false`
+* `mutates_a20b_artifact = false` (A21a never edits the A20b seed)
+* `writes_only_roadmap_unit_status_log = true`
+* `writes_to_seed_jsonl = false`
+* `writes_to_delegation_seed_jsonl = false`
+* `writes_to_generated_seed_jsonl = false`
+* `writes_to_approval_inbox = false`
+* `writes_to_work_queue_jsonl = false`
+* `merged_status_requires_evidence = true`
+* `duplicate_unit_id_fails_closed = true`
+* `invalid_record_fails_closed = true`
+* `no_implicit_merged_resurrection = true`
+* `consumes_dynamic_status_ledger = true`
+* `dynamic_status_overrides_static_when_valid = true`
+* `fail_closed_on_invalid_dynamic_status = true`
+* `fail_closed_on_duplicate_dynamic_status = true`
+* `dynamic_status_absence_falls_back_to_static = true`
+* `merged_units_never_reselected = true`
+
+## 9. Test coverage
+
+Pinned in
+[`tests/unit/test_roadmap_unit_status.py`](../../tests/unit/test_roadmap_unit_status.py)
+(A21a, 61 tests):
+
+* closed `DYNAMIC_UNIT_STATUS` vocabulary;
+* closed `DYNAMIC_STATUS_SOURCE` vocabulary;
+* closed `DYNAMIC_STATUS_INVALID_REASON` vocabulary;
+* record schema (10 ordered fields) and projection schema
+  (10 ordered fields);
+* deterministic output with injected `generated_at_utc`;
+* byte-identical output for identical input;
+* atomic write only under `logs/roadmap_unit_status/`;
+  rejects frozen contract paths and work-queue paths;
+* `--no-write` does not write; `--status` does not write;
+  `--indent 0` emits compact output;
+* `merged` validation: positive `pr_number`, hex `merge_sha`,
+  non-empty `reason`;
+* unknown status / source / empty unit_id / missing
+  `updated_at_utc` / non-list `evidence` fail closed via a
+  closed-vocab `validation_reason`;
+* duplicate unit_id fails closed deterministically (all duplicate
+  records become `valid = False`);
+* no implicit `merged` resurrection;
+* bootstrap seed pins exactly the three v3.15.16 routing-layer
+  PR / SHA / merged-status records;
+* every projection pins `step5_implementation_allowed = false`,
+  `no_step5_runtime = true`, `no_level6 = true`,
+  `no_production_merge_authority = true`,
+  `no_runtime_trading_authority = true`,
+  `no_work_execution = true`, `no_branch_creation = true`,
+  `no_pr_creation = true`, `no_merge_or_deploy = true`,
+  `no_mutation_routes = true`, `no_approval_buttons = true`,
+  `mutates_a20b_artifact = false`,
+  `calls_execution_authority_classifier = false`,
+  `calls_llm_or_external_api = false`,
+  `uses_subprocess_or_network = false`;
+* module-source scan: stdlib only; no `subprocess`, no `socket`,
+  no `urllib`, no `http`, no `requests`, no `gh`, no `git`, no
+  `os.system`, no dynamic-eval, no dynamic-exec, no GitHub API
+  host, no LLM endpoint, no dashboard / automation / broker /
+  agent.risk / agent.execution / research / live / paper /
+  shadow / trading / reporting.execution_authority /
+  reporting.roadmap_next_unit / reporting.roadmap_unit_authority
+  / reporting.roadmap_task_catalog import.
+
+Pinned in
+[`tests/unit/test_roadmap_next_unit.py`](../../tests/unit/test_roadmap_next_unit.py)
+(A20e selector overlay, additions):
+
+* widened `NEXT_UNIT_BLOCK_REASON` to include
+  `invalid_dynamic_status` and `dynamic_status_terminal`;
+* widened `NEXT_UNIT_SOURCE` to include
+  `logs/roadmap_unit_status/latest.json`;
+* new closed vocab
+  `NEXT_UNIT_DYNAMIC_STATUS_SOURCE` (6 values, `""` + 5
+  dynamic-source values);
+* widened candidate schema to include `effective_status`,
+  `dynamic_status_source`, `source_status_artifact`;
+* widened projection schema to include
+  `source_status_schema_version`;
+* dynamic merged status excludes unit from selector;
+* dynamic status absent => fall back to static A20b status;
+* invalid dynamic status fails closed via
+  `FAIL_CLOSED_INVARIANT`;
+* unknown dynamic status value fails closed;
+* dynamic `pr_open` / `in_progress` / `failed` block the
+  candidate;
+* dynamic `merged` satisfies a prerequisite even if the static
+  A20b status is `not_started`;
+* the three v3.15.16 routing-layer merged units in the bootstrap
+  seed are never reselected;
+* malformed dynamic status artefact fails closed with
+  `UPSTREAM_UNAVAILABLE`;
+* static `status` field is preserved verbatim alongside
+  `effective_status`;
+* `source_status_artifact` pinned at
+  `logs/roadmap_unit_status/latest.json`;
+* selector invariants pin every new dynamic-overlay invariant
+  listed in §8.
+
+## 10. Cross-references
+
+* [`docs/governance/roadmap_task_catalog.md`](roadmap_task_catalog.md)
+  — A20 roadmap-to-task pipeline (the upstream consumer surface).
+* [`docs/governance/step5_design.md`](step5_design.md) — the
+  earlier Step 5 design doc. Step 5 implementation remains
+  BLOCKED there too.
+* [`docs/adr/ADR-014-truth-authority-settlement.md`](../adr/ADR-014-truth-authority-settlement.md)
+  — canonical authority mapping.
+* [`docs/adr/ADR-015-claude-agent-governance.md`](../adr/ADR-015-claude-agent-governance.md)
+  — autonomy ladder; Level 6 is permanently disabled.
+* [`docs/governance/no_touch_paths.md`](no_touch_paths.md) — the
+  forbidden-surface list every future Step 5 slice inherits.
+* [`docs/governance/execution_authority.md`](execution_authority.md)
+  — canonical execution-authority policy (untouched by this PR).
+* [`docs/governance/ade_development_lane_doctrine.md`](ade_development_lane_doctrine.md)
+  — ADE remains development workflow automation only.
+
+## 11. Next recommended PR
+
+A21b — bounded **dry-run** autonomous loop slice that:
+
+* invokes A20e to read the next selected unit;
+* validates the eight selection-level stop conditions in §4.1;
+* prints a deterministic dry-run plan to stdout naming the unit,
+  the expected files, the forbidden files, and the required
+  tests;
+* writes a dry-run report under `logs/step5_loop/dry_run/`;
+* **does not** create a branch, **does not** edit any file,
+  **does not** open a PR, **does not** merge, **does not**
+  deploy.
+
+A21b is the next safe step toward bounded autonomy. Its merge
+remains blocked behind operator-explicit authorisation and an
+updated A20b seed entry that lists it as an eligible unit.

--- a/reporting/roadmap_next_unit.py
+++ b/reporting/roadmap_next_unit.py
@@ -1,11 +1,28 @@
 """A20e — Deterministic Next-Buildable-Unit Selector (read-only).
 
 Pure stdlib-only read-only consumer of the A20b implementation-unit
-projection and the A20c unit-authority projection. Emits a
-deterministic projection at ``logs/roadmap_next_unit/latest.json``
-that names the single ``NextBuildableUnitSelection`` (or no
-selection at all if no unit is eligible) and the full filterable
-candidate list.
+projection, the A20c unit-authority projection, and the optional
+A21a dynamic unit-status ledger. Emits a deterministic projection
+at ``logs/roadmap_next_unit/latest.json`` that names the single
+``NextBuildableUnitSelection`` (or no selection at all if no unit
+is eligible) and the full filterable candidate list.
+
+A21a integration (Step 5 / A21 foundation):
+
+* When ``logs/roadmap_unit_status/latest.json`` is present, the
+  selector overlays the dynamic ledger on top of the A20b static
+  status: a unit marked ``merged`` in the dynamic ledger is treated
+  as ``merged`` for buildable purposes, even if A20b's seed still
+  says ``not_started``. This removes the need for a manual A20b
+  seed-status PR after every merge.
+* Dynamic ledger absence is silent: every unit falls back to its
+  A20b static status. Dynamic ledger top-level malformedness fails
+  closed with ``UPSTREAM_UNAVAILABLE``. Per-record invalidity
+  surfaces as the new ``invalid_dynamic_status`` block reason for
+  the affected unit.
+* The selector still does not execute work, does not create
+  branches, does not open PRs, does not merge or deploy. Step 5
+  implementation remains BLOCKED.
 
 A20e MUST NOT:
 
@@ -26,6 +43,8 @@ A20e MAY:
 
 * read ``logs/roadmap_task_units/latest.json`` (A20b output);
 * read ``logs/roadmap_unit_authority/latest.json`` (A20c output);
+* read ``logs/roadmap_unit_status/latest.json`` (A21a output;
+  optional);
 * apply deterministic filter + sort rules pinned by tests;
 * emit a sorted candidates[] list and at most one selected unit;
 * fail closed loudly with ``selection_status`` in a closed enum
@@ -88,6 +107,7 @@ from typing import Any, Final
 
 from reporting import roadmap_task_units as rtu
 from reporting import roadmap_unit_authority as rua
+from reporting import roadmap_unit_status as rus
 
 REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
 
@@ -133,6 +153,8 @@ NEXT_UNIT_BLOCK_REASON: Final[tuple[str, ...]] = (
     "unknown_prerequisite_target",
     "operator_gate_required",
     "fail_closed_unknown_evidence",
+    "invalid_dynamic_status",
+    "dynamic_status_terminal",
 )
 
 #: Per-candidate eligibility vocabulary.
@@ -142,10 +164,24 @@ NEXT_UNIT_ELIGIBILITY: Final[tuple[str, ...]] = (
     "BLOCKED",
 )
 
-#: Closed source-artifact vocabulary. Exactly two upstreams.
+#: Closed source-artifact vocabulary. Three upstreams: A20b units,
+#: A20c authority, and the optional A21a dynamic status ledger.
 NEXT_UNIT_SOURCE: Final[tuple[str, ...]] = (
     "logs/roadmap_task_units/latest.json",
     "logs/roadmap_unit_authority/latest.json",
+    "logs/roadmap_unit_status/latest.json",
+)
+
+#: Closed dynamic-status overlay-source vocabulary surfaced on
+#: each candidate. ``""`` denotes no dynamic record exists for
+#: that unit (selector falls back to the A20b static status).
+NEXT_UNIT_DYNAMIC_STATUS_SOURCE: Final[tuple[str, ...]] = (
+    "",
+    "pr_merge",
+    "operator_override",
+    "loop_state",
+    "ci_failure",
+    "operator_block",
 )
 
 #: Selector-mode vocabulary. Today exactly one mode: ``default``
@@ -212,6 +248,8 @@ NEXT_BUILDABLE_UNIT_CANDIDATE_FIELDS: Final[tuple[str, ...]] = (
     "phase",
     "title",
     "status",
+    "effective_status",
+    "dynamic_status_source",
     "risk_class",
     "final_authority_class",
     "operator_gate",
@@ -222,6 +260,7 @@ NEXT_BUILDABLE_UNIT_CANDIDATE_FIELDS: Final[tuple[str, ...]] = (
     "deterministic_sort_key",
     "source_units_artifact",
     "source_authority_artifact",
+    "source_status_artifact",
 )
 
 #: Selection record schema.
@@ -250,6 +289,7 @@ NEXT_BUILDABLE_UNIT_PROJECTION_FIELDS: Final[tuple[str, ...]] = (
     "module_version",
     "source_units_schema_version",
     "source_authority_schema_version",
+    "source_status_schema_version",
     "selector_mode",
     "candidates",
     "selection",
@@ -283,6 +323,7 @@ _WRITE_PREFIX: Final[str] = "logs/roadmap_next_unit/"
 #: Upstream relative paths.
 _UNITS_REL_PATH: Final[str] = "logs/roadmap_task_units/latest.json"
 _AUTHORITY_REL_PATH: Final[str] = "logs/roadmap_unit_authority/latest.json"
+_STATUS_REL_PATH: Final[str] = "logs/roadmap_unit_status/latest.json"
 
 
 # ---------------------------------------------------------------------------
@@ -319,6 +360,12 @@ _BASE_SELECTOR_INVARIANTS: Final[dict[str, bool]] = {
     "fail_closed_on_missing_artifact": True,
     "permanently_denied_units_never_selected": True,
     "needs_human_units_require_operator_go": True,
+    "consumes_dynamic_status_ledger": True,
+    "dynamic_status_overrides_static_when_valid": True,
+    "fail_closed_on_invalid_dynamic_status": True,
+    "fail_closed_on_duplicate_dynamic_status": True,
+    "dynamic_status_absence_falls_back_to_static": True,
+    "merged_units_never_reselected": True,
 }
 
 
@@ -386,8 +433,21 @@ def _build_candidate(
     *,
     units_by_id: dict[str, dict[str, Any]],
     decisions_by_unit_id: dict[str, list[dict[str, Any]]],
+    dynamic_status_by_unit_id: dict[str, dict[str, Any]],
 ) -> dict[str, Any]:
-    """Build one ``NextBuildableUnitCandidate`` record."""
+    """Build one ``NextBuildableUnitCandidate`` record.
+
+    The dynamic-status overlay (A21a) is applied on top of the
+    A20b static status:
+
+    * If a valid dynamic record exists, its status overrides the
+      static A20b status for buildable purposes (the static value
+      is still emitted on ``status`` for traceability).
+    * If a dynamic record exists but is invalid, the candidate is
+      blocked with ``invalid_dynamic_status`` (fail-closed).
+    * If no dynamic record exists, the candidate falls back to
+      A20b's static status (legacy behaviour).
+    """
     unit_id = _bounded_str(unit.get("id"), 200)
     task_id = _bounded_str(unit.get("roadmap_task_id"), 200)
     phase = _bounded_str(unit.get("phase"), 64)
@@ -405,11 +465,52 @@ def _build_candidate(
 
     block_reasons: list[str] = []
 
-    # --- A20b status check -------------------------------------------------
+    # --- A21a dynamic-status overlay --------------------------------------
+    dyn_record = dynamic_status_by_unit_id.get(unit_id)
+    dyn_status_source = ""
+    if dyn_record is None:
+        # No dynamic record. Fall back to A20b static status.
+        effective_status = status
+    else:
+        dyn_valid = bool(dyn_record.get("valid"))
+        if not dyn_valid:
+            # Fail closed: invalid dynamic record blocks the unit.
+            block_reasons.append("invalid_dynamic_status")
+            effective_status = status
+        else:
+            dyn_status_raw = _bounded_str(dyn_record.get("status"), 32)
+            dyn_source_raw = _bounded_str(dyn_record.get("source"), 64)
+            if dyn_status_raw not in rus.DYNAMIC_UNIT_STATUS:
+                block_reasons.append("invalid_dynamic_status")
+                effective_status = status
+            else:
+                effective_status = dyn_status_raw
+                if dyn_source_raw in rus.DYNAMIC_STATUS_SOURCE:
+                    dyn_status_source = dyn_source_raw
+                # Surface terminal-dynamic-status as a distinct reason
+                # so the operator can see at a glance why a unit no
+                # longer appears in the candidate list.
+                if dyn_status_raw in {"merged", "blocked", "skipped"}:
+                    block_reasons.append("dynamic_status_terminal")
+
+    # --- A20b status check (applied to effective_status) -------------------
+    # The unknown-unit-status check still fires only on truly unknown
+    # A20b static values; the dynamic overlay extends the valid-status
+    # universe but never resurrects an unknown A20b record.
     if status not in rtu.UNIT_STATUS:
         block_reasons.append("unknown_unit_status")
-    elif status not in _BUILDABLE_STATUS:
-        block_reasons.append("non_buildable_status")
+    elif (
+        effective_status != status
+        and effective_status not in rus.DYNAMIC_UNIT_STATUS
+    ):
+        block_reasons.append("invalid_dynamic_status")
+    elif effective_status not in _BUILDABLE_STATUS:
+        # Both static "non_buildable" (e.g. merged in A20b seed) and
+        # dynamic-overlay "non_buildable" (e.g. in_progress / pr_open
+        # / failed) end up here. ``dynamic_status_terminal`` already
+        # covered the explicit terminal case above.
+        if "dynamic_status_terminal" not in block_reasons:
+            block_reasons.append("non_buildable_status")
 
     # --- A20c authority lookup --------------------------------------------
     matching = decisions_by_unit_id.get(unit_id, [])
@@ -430,6 +531,11 @@ def _build_candidate(
             block_reasons.append("unknown_authority")
 
     # --- Prerequisite check ------------------------------------------------
+    # A prerequisite is "satisfied" when its effective status is
+    # ``merged`` — either via the A20b static seed or via a valid
+    # A21a dynamic ledger record. This is what makes the dynamic
+    # overlay useful: a prereq merged through the ledger no longer
+    # requires editing the A20b static seed.
     prereqs_satisfied = True
     if prerequisites:
         for prereq_id in prerequisites:
@@ -438,12 +544,20 @@ def _build_candidate(
                 if "unknown_prerequisite_target" not in block_reasons:
                     block_reasons.append("unknown_prerequisite_target")
                 prereqs_satisfied = False
-            else:
-                prereq_status = prereq_unit.get("status")
-                if prereq_status != "merged":
-                    if "unsatisfied_prerequisite" not in block_reasons:
-                        block_reasons.append("unsatisfied_prerequisite")
-                    prereqs_satisfied = False
+                continue
+            prereq_static = prereq_unit.get("status")
+            prereq_dyn = dynamic_status_by_unit_id.get(prereq_id)
+            prereq_effective = prereq_static
+            if (
+                prereq_dyn is not None
+                and prereq_dyn.get("valid")
+                and prereq_dyn.get("status") in rus.DYNAMIC_UNIT_STATUS
+            ):
+                prereq_effective = prereq_dyn["status"]
+            if prereq_effective != "merged":
+                if "unsatisfied_prerequisite" not in block_reasons:
+                    block_reasons.append("unsatisfied_prerequisite")
+                prereqs_satisfied = False
 
     # --- Eligibility -------------------------------------------------------
     if block_reasons:
@@ -483,6 +597,8 @@ def _build_candidate(
         "phase": phase,
         "title": title,
         "status": status,
+        "effective_status": effective_status,
+        "dynamic_status_source": dyn_status_source,
         "risk_class": risk_class,
         "final_authority_class": final_authority_class,
         "operator_gate": operator_gate,
@@ -493,6 +609,7 @@ def _build_candidate(
         "deterministic_sort_key": sort_key,
         "source_units_artifact": _UNITS_REL_PATH,
         "source_authority_artifact": _AUTHORITY_REL_PATH,
+        "source_status_artifact": _STATUS_REL_PATH,
     }
 
 
@@ -566,6 +683,7 @@ def _select_from_candidates(candidates: list[dict[str, Any]]) -> dict[str, Any]:
             "missing_authority_decision",
             "unknown_unit_status",
             "fail_closed_unknown_evidence",
+            "invalid_dynamic_status",
         }:
             status = "FAIL_CLOSED_INVARIANT"
             reason_str = "fail_closed_on_unknown_or_duplicate_evidence"
@@ -636,9 +754,12 @@ def collect_snapshot(
 ) -> dict[str, Any]:
     """Build the deterministic next-buildable-unit projection.
 
-    Reads ``logs/roadmap_task_units/latest.json`` and
-    ``logs/roadmap_unit_authority/latest.json`` from disk. Fails
-    closed if either upstream is absent or malformed.
+    Reads ``logs/roadmap_task_units/latest.json``,
+    ``logs/roadmap_unit_authority/latest.json``, and (optionally)
+    ``logs/roadmap_unit_status/latest.json`` from disk. Fails closed
+    if A20b or A20c is absent or malformed. The A21a dynamic-status
+    artefact is optional: absence is silent (legacy fallback);
+    top-level malformedness fails closed UPSTREAM_UNAVAILABLE.
     """
     root = repo_root if repo_root is not None else REPO_ROOT
     ts = generated_at_utc if generated_at_utc is not None else _utcnow()
@@ -649,9 +770,13 @@ def collect_snapshot(
     auth_status, auth_payload, auth_err = _load_json_artifact(
         root / _AUTHORITY_REL_PATH
     )
+    status_status, status_payload, status_err = _load_json_artifact(
+        root / _STATUS_REL_PATH
+    )
 
     units_schema_version: str | int = ""
     auth_schema_version: str | int = ""
+    status_schema_version: str | int = ""
 
     if units_status != "ok" or auth_status != "ok":
         # Fail closed loudly. Record the missing artefact in
@@ -675,6 +800,28 @@ def collect_snapshot(
             ts=ts,
             units_schema_version=units_schema_version,
             auth_schema_version=auth_schema_version,
+            status_schema_version=status_schema_version,
+            candidates=[],
+            selection=selection,
+        )
+
+    # A21a is optional. Absence => empty mapping, every unit falls
+    # back to A20b static status. Top-level malformedness => fail
+    # closed (treat as corrupt upstream).
+    if status_status == "malformed":
+        selection = _empty_selection(
+            status="UPSTREAM_UNAVAILABLE",
+            reason=f"malformed_dynamic_status_artifact:{status_err}",
+            candidate_count=0,
+            eligible_count=0,
+            blocked_count=0,
+            fail_closed=True,
+        )
+        return _envelope(
+            ts=ts,
+            units_schema_version=units_schema_version,
+            auth_schema_version=auth_schema_version,
+            status_schema_version=status_schema_version,
             candidates=[],
             selection=selection,
         )
@@ -704,6 +851,24 @@ def collect_snapshot(
             if isinstance(did, str) and did:
                 decisions_by_unit_id.setdefault(did, []).append(d)
 
+    # A21a dynamic status overlay (optional).
+    dynamic_status_by_unit_id: dict[str, dict[str, Any]] = {}
+    if status_status == "ok" and isinstance(status_payload, dict):
+        status_schema_version = status_payload.get("schema_version", "")
+        ledger_records = status_payload.get("ledger_records") or []
+        if isinstance(ledger_records, list):
+            for rec in ledger_records:
+                if not isinstance(rec, dict):
+                    continue
+                ruid = rec.get("unit_id")
+                if not isinstance(ruid, str) or not ruid:
+                    continue
+                # Last-wins is fine because the ledger module itself
+                # surfaces duplicates as ``valid=False`` for every
+                # affected record. Either the existing entry or this
+                # one is already invalid; the candidate will block.
+                dynamic_status_by_unit_id[ruid] = rec
+
     # Build candidates.
     candidates: list[dict[str, Any]] = []
     for u in units[:MAX_CANDIDATES]:
@@ -716,6 +881,7 @@ def collect_snapshot(
             u,
             units_by_id=units_by_id,
             decisions_by_unit_id=decisions_by_unit_id,
+            dynamic_status_by_unit_id=dynamic_status_by_unit_id,
         )
         candidates.append(cand)
 
@@ -727,6 +893,7 @@ def collect_snapshot(
         ts=ts,
         units_schema_version=units_schema_version,
         auth_schema_version=auth_schema_version,
+        status_schema_version=status_schema_version,
         candidates=candidates,
         selection=selection,
     )
@@ -737,6 +904,7 @@ def _envelope(
     ts: str,
     units_schema_version: str | int,
     auth_schema_version: str | int,
+    status_schema_version: str | int,
     candidates: list[dict[str, Any]],
     selection: dict[str, Any],
 ) -> dict[str, Any]:
@@ -751,6 +919,8 @@ def _envelope(
         "source_units_schema_version": units_schema_version,
         "source_authority_module_version": rua.MODULE_VERSION,
         "source_authority_schema_version": auth_schema_version,
+        "source_status_module_version": rus.MODULE_VERSION,
+        "source_status_schema_version": status_schema_version,
         "selector_mode": "default",
         "vocabularies": {
             "next_unit_selection_status": list(NEXT_UNIT_SELECTION_STATUS),
@@ -758,6 +928,9 @@ def _envelope(
             "next_unit_eligibility": list(NEXT_UNIT_ELIGIBILITY),
             "next_unit_source": list(NEXT_UNIT_SOURCE),
             "next_unit_selector_mode": list(NEXT_UNIT_SELECTOR_MODE),
+            "next_unit_dynamic_status_source": list(
+                NEXT_UNIT_DYNAMIC_STATUS_SOURCE
+            ),
             "phase_order": list(_PHASE_ORDER),
             "authority_order": list(_AUTHORITY_ORDER),
             "risk_order": list(_RISK_ORDER),

--- a/reporting/roadmap_unit_status.py
+++ b/reporting/roadmap_unit_status.py
@@ -1,0 +1,686 @@
+"""A21a — Dynamic Unit Status Ledger (read-only, deterministic).
+
+Step 5 / A21 foundation. Records per-unit execution status as a
+pinned Python literal seed so the A20e selector can advance past
+completed units without editing
+``reporting/roadmap_task_units.py`` (the A20b static decomposition).
+
+Static unit definitions (catalog, decomposition) remain in
+``reporting/roadmap_task_units.py``. **Dynamic execution status**
+lives here. The two surfaces are deliberately separated so a unit
+moving from ``not_started`` to ``merged`` no longer requires
+touching the A20b seed every time.
+
+This module is **Step 5 foundation only**. It does **not**:
+
+* execute work;
+* create branches;
+* open PRs;
+* run tests or governance lint;
+* merge or deploy;
+* call any LLM, external API, or hidden judgment;
+* mutate any approval inbox, seed JSONL, queue, or upstream
+  artefact;
+* call the canonical ``execution_authority`` classifier;
+* grant runtime / trading / paper / shadow / live authority;
+* grant production-merge authority;
+* activate Step 5 or Level 6 or relax any branch-protection
+  invariant.
+
+Hard guarantees (pinned by tests):
+
+* Stdlib + (read-only) ``reporting.roadmap_task_units`` only —
+  the only reason to read A20b is to expose the cross-reference
+  module version on the projection; no A20b mutation, no
+  per-unit status mirror.
+* No subprocess, no network, no ``gh``, no ``git``, no
+  ``os.system``, no dynamic-eval, no dynamic-exec, no API
+  authorization headers.
+* No imports of ``dashboard``, ``automation``, ``broker``,
+  ``agent.risk``, ``agent.execution``, ``research``, ``live``,
+  ``paper``, ``shadow``, ``trading``,
+  ``reporting.intelligent_routing``,
+  ``reporting.execution_authority``,
+  ``reporting.development_queue_admission_policy``,
+  ``reporting.development_agent_activity_timeline``.
+* Closed ``DYNAMIC_UNIT_STATUS`` vocabulary (7 values) and
+  closed ``DYNAMIC_STATUS_SOURCE`` vocabulary (5 values).
+* Atomic write only under ``logs/roadmap_unit_status/``.
+* Deterministic output: same seed + injected
+  ``generated_at_utc`` => byte-identical artefact.
+* ``merged`` status requires non-empty ``pr_number``,
+  non-empty ``merge_sha``, non-empty ``reason``.
+* Duplicate records for the same ``unit_id`` fail closed
+  deterministically (the duplicate ``unit_id`` is appended to
+  ``duplicate_unit_ids`` and every record sharing that id is
+  marked ``valid = False``).
+* Invalid records are surfaced (``valid = False``) instead of
+  silently dropped; the selector must fail closed on them.
+
+CLI::
+
+    python -m reporting.roadmap_unit_status
+    python -m reporting.roadmap_unit_status --no-write
+    python -m reporting.roadmap_unit_status --status
+    python -m reporting.roadmap_unit_status --indent 2
+
+Status transition rules (advisory; selector enforces buildable
+filter on its own):
+
+* ``not_started -> in_progress``
+* ``in_progress -> pr_open``
+* ``pr_open -> merged``
+* ``pr_open -> failed``
+* ``in_progress -> failed``
+* ``not_started -> blocked``
+* ``not_started -> skipped``
+* ``failed -> blocked``
+* ``blocked``, ``skipped``, ``merged`` are terminal unless an
+  explicit operator override record is appended.
+* No implicit resurrection of merged units. A duplicate record
+  for a unit_id that already has a ``merged`` record fails closed
+  via duplicate detection.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Final
+
+from reporting import roadmap_task_units as rtu
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[str] = "1.0"
+MODULE_VERSION: Final[str] = "v3.15.16.A21a"
+REPORT_KIND: Final[str] = "roadmap_unit_status"
+
+
+# ---------------------------------------------------------------------------
+# Step 5 + Level 6 invariants (Final constants — never flipped at runtime)
+# ---------------------------------------------------------------------------
+
+STEP5_ENABLED_SUBSTAGE: Final[str] = "none"
+step5_implementation_allowed: Final[bool] = False
+
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies
+# ---------------------------------------------------------------------------
+
+#: Closed dynamic unit-status vocabulary. 7 values.
+DYNAMIC_UNIT_STATUS: Final[tuple[str, ...]] = (
+    "not_started",
+    "in_progress",
+    "pr_open",
+    "merged",
+    "failed",
+    "blocked",
+    "skipped",
+)
+
+#: Statuses that are terminal unless an explicit operator override
+#: is appended. The validator does not currently support overrides;
+#: ``merged`` records that conflict with later records produce a
+#: duplicate fail-closed verdict.
+_TERMINAL_STATUSES: Final[frozenset[str]] = frozenset(
+    {"merged", "blocked", "skipped"}
+)
+
+#: Closed dynamic-source vocabulary. 5 values.
+DYNAMIC_STATUS_SOURCE: Final[tuple[str, ...]] = (
+    "pr_merge",
+    "operator_override",
+    "loop_state",
+    "ci_failure",
+    "operator_block",
+)
+
+#: Closed per-record ``validation_reason`` vocabulary. ``""`` denotes
+#: a valid record.
+DYNAMIC_STATUS_INVALID_REASON: Final[tuple[str, ...]] = (
+    "",
+    "unknown_status",
+    "unknown_source",
+    "empty_unit_id",
+    "merged_without_pr_number",
+    "merged_without_merge_sha",
+    "merged_without_reason",
+    "duplicate_unit_id",
+    "missing_updated_at_utc",
+    "evidence_not_a_list",
+    "pr_number_not_a_positive_int",
+    "merge_sha_not_a_hex_string",
+)
+
+#: Closed source-of-truth artefact path (single output).
+DYNAMIC_STATUS_OUTPUT_PATH: Final[str] = (
+    "logs/roadmap_unit_status/latest.json"
+)
+
+
+# ---------------------------------------------------------------------------
+# Schema field tuples (exact, ordered)
+# ---------------------------------------------------------------------------
+
+#: Per-record schema. Exact and ordered.
+DYNAMIC_UNIT_STATUS_RECORD_FIELDS: Final[tuple[str, ...]] = (
+    "unit_id",
+    "status",
+    "source",
+    "updated_at_utc",
+    "pr_number",
+    "merge_sha",
+    "reason",
+    "evidence",
+    "valid",
+    "validation_reason",
+)
+
+#: Top-level projection schema. Exact and ordered.
+ROADMAP_UNIT_STATUS_PROJECTION_FIELDS: Final[tuple[str, ...]] = (
+    "generated_at_utc",
+    "schema_version",
+    "module_version",
+    "source_units_module_version",
+    "ledger_records",
+    "duplicate_unit_ids",
+    "invalid_record_count",
+    "valid_record_count",
+    "fail_closed",
+    "ledger_invariants",
+)
+
+
+# ---------------------------------------------------------------------------
+# Bounds
+# ---------------------------------------------------------------------------
+
+MAX_UNIT_ID_LEN: Final[int] = 128
+MAX_REASON_LEN: Final[int] = 240
+MAX_SHA_LEN: Final[int] = 64
+MAX_SHA_MIN: Final[int] = 7
+MAX_EVIDENCE_ITEMS: Final[int] = 8
+MAX_EVIDENCE_ITEM_LEN: Final[int] = 240
+MAX_PR_NUMBER: Final[int] = 1_000_000
+
+
+# ---------------------------------------------------------------------------
+# Artefact paths
+# ---------------------------------------------------------------------------
+
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "roadmap_unit_status"
+ARTIFACT_LATEST: Final[Path] = ARTIFACT_DIR / "latest.json"
+
+#: Atomic-write allowlist (POSIX substring). Any write target whose
+#: path does not contain this substring is refused with
+#: ``ValueError``.
+_WRITE_PREFIX: Final[str] = "logs/roadmap_unit_status/"
+
+
+# ---------------------------------------------------------------------------
+# Ledger invariants emitted on every projection
+# ---------------------------------------------------------------------------
+
+_BASE_LEDGER_INVARIANTS: Final[dict[str, bool]] = {
+    "deterministic_projection": True,
+    "no_random_ordering": True,
+    "no_llm_judgment": True,
+    "no_fuzzy_parsing": True,
+    "no_work_execution": True,
+    "no_branch_creation": True,
+    "no_pr_creation": True,
+    "no_merge_or_deploy": True,
+    "no_mutation_routes": True,
+    "no_approval_buttons": True,
+    "no_runtime_trading_authority": True,
+    "no_step5_runtime": True,
+    "no_level6": True,
+    "no_production_merge_authority": True,
+    "step5_implementation_allowed": False,
+    "mutates_a20b_artifact": False,
+    "writes_only_roadmap_unit_status_log": True,
+    "writes_to_seed_jsonl": False,
+    "writes_to_delegation_seed_jsonl": False,
+    "writes_to_generated_seed_jsonl": False,
+    "writes_to_approval_inbox": False,
+    "writes_to_work_queue_jsonl": False,
+    "calls_llm_or_external_api": False,
+    "uses_subprocess_or_network": False,
+    "calls_execution_authority_classifier": False,
+    "merged_status_requires_evidence": True,
+    "duplicate_unit_id_fails_closed": True,
+    "invalid_record_fails_closed": True,
+    "no_implicit_merged_resurrection": True,
+}
+
+
+# ---------------------------------------------------------------------------
+# Pinned status ledger seed
+# ---------------------------------------------------------------------------
+#
+# Each record describes one observed execution-status fact for one
+# implementation unit. Append-only by convention: appending a new
+# record (e.g. flipping a unit to ``merged``) does NOT require editing
+# ``reporting/roadmap_task_units.py``.
+#
+# Bootstrap records (3 entries) capture the three already-merged
+# v3.15.16 routing-layer units. Their merge SHAs are pinned verbatim;
+# editing them counts as evidence tampering and is rejected by review.
+
+_STATUS_LEDGER_SEED: Final[tuple[dict[str, Any], ...]] = (
+    {
+        "unit_id": "u_v3_15_16_diagnostic_routing_signals_schema_001",
+        "status": "merged",
+        "source": "pr_merge",
+        "updated_at_utc": "2026-05-18T11:46:10Z",
+        "pr_number": 250,
+        "merge_sha": "fcb1abbea4bd2ca190fe6e807b3dacd184faa702",
+        "reason": "implemented by PR #250",
+        "evidence": (
+            "github_pr_number=250",
+            "github_merge_sha=fcb1abbea4bd2ca190fe6e807b3dacd184faa702",
+        ),
+    },
+    {
+        "unit_id": "u_v3_15_16_routing_explanation_reporter_001",
+        "status": "merged",
+        "source": "pr_merge",
+        "updated_at_utc": "2026-05-18T12:16:21Z",
+        "pr_number": 252,
+        "merge_sha": "6f588a89b43a2cfec40f92252bde530220877b37",
+        "reason": "implemented by PR #252",
+        "evidence": (
+            "github_pr_number=252",
+            "github_merge_sha=6f588a89b43a2cfec40f92252bde530220877b37",
+        ),
+    },
+    {
+        "unit_id": "u_v3_15_16_routing_governance_doc_001",
+        "status": "merged",
+        "source": "pr_merge",
+        "updated_at_utc": "2026-05-18T14:36:27Z",
+        "pr_number": 254,
+        "merge_sha": "df7dc6562ec3cd3a9f87e83e758881bd6fdb16f8",
+        "reason": "implemented by PR #254",
+        "evidence": (
+            "github_pr_number=254",
+            "github_merge_sha=df7dc6562ec3cd3a9f87e83e758881bd6fdb16f8",
+        ),
+    },
+)
+
+
+# ---------------------------------------------------------------------------
+# Utility helpers
+# ---------------------------------------------------------------------------
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _bounded_str(value: Any, max_len: int) -> str:
+    if not isinstance(value, str):
+        return ""
+    if len(value) <= max_len:
+        return value
+    return value[:max_len]
+
+
+def _normalise_evidence(value: Any) -> list[str]:
+    if not isinstance(value, (list, tuple)):
+        return []
+    out: list[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            continue
+        out.append(_bounded_str(item, MAX_EVIDENCE_ITEM_LEN))
+        if len(out) >= MAX_EVIDENCE_ITEMS:
+            break
+    return out
+
+
+def _is_hex_sha(value: str) -> bool:
+    if not value:
+        return False
+    if not (MAX_SHA_MIN <= len(value) <= MAX_SHA_LEN):
+        return False
+    return all(ch in "0123456789abcdefABCDEF" for ch in value)
+
+
+# ---------------------------------------------------------------------------
+# Per-record validation
+# ---------------------------------------------------------------------------
+
+
+def _validate_record(raw: dict[str, Any]) -> tuple[bool, str]:
+    """Return ``(valid, validation_reason)`` for a single record.
+
+    ``validation_reason`` is a closed-vocab string from
+    :data:`DYNAMIC_STATUS_INVALID_REASON`. ``""`` denotes a valid
+    record. Duplicate detection happens at the projection layer,
+    not here.
+    """
+    unit_id = _bounded_str(raw.get("unit_id"), MAX_UNIT_ID_LEN)
+    if not unit_id:
+        return False, "empty_unit_id"
+    status = _bounded_str(raw.get("status"), 32)
+    if status not in DYNAMIC_UNIT_STATUS:
+        return False, "unknown_status"
+    source = _bounded_str(raw.get("source"), 64)
+    if source not in DYNAMIC_STATUS_SOURCE:
+        return False, "unknown_source"
+    updated_at = _bounded_str(raw.get("updated_at_utc"), 32)
+    if not updated_at:
+        return False, "missing_updated_at_utc"
+    if status == "merged":
+        pr_num = raw.get("pr_number")
+        if not isinstance(pr_num, int) or pr_num <= 0 or pr_num > MAX_PR_NUMBER:
+            return False, "pr_number_not_a_positive_int"
+        sha = _bounded_str(raw.get("merge_sha"), MAX_SHA_LEN)
+        if not sha:
+            return False, "merged_without_merge_sha"
+        if not _is_hex_sha(sha):
+            return False, "merge_sha_not_a_hex_string"
+        reason = _bounded_str(raw.get("reason"), MAX_REASON_LEN)
+        if not reason:
+            return False, "merged_without_reason"
+    evidence_raw = raw.get("evidence")
+    if evidence_raw is not None and not isinstance(
+        evidence_raw, (list, tuple)
+    ):
+        return False, "evidence_not_a_list"
+    return True, ""
+
+
+# ---------------------------------------------------------------------------
+# Record normalisation
+# ---------------------------------------------------------------------------
+
+
+def _normalise_record(raw: dict[str, Any]) -> dict[str, Any]:
+    """Convert a raw seed record into a deterministic emitted record.
+
+    Always returns a fully-shaped record (every field in
+    :data:`DYNAMIC_UNIT_STATUS_RECORD_FIELDS` is present). Invalid
+    records keep their declared fields where possible but carry
+    ``valid = False`` and a validation_reason in closed vocab.
+    """
+    valid, reason = _validate_record(raw)
+    unit_id = _bounded_str(raw.get("unit_id"), MAX_UNIT_ID_LEN)
+    status = _bounded_str(raw.get("status"), 32)
+    source = _bounded_str(raw.get("source"), 64)
+    updated_at = _bounded_str(raw.get("updated_at_utc"), 32)
+    pr_number_raw = raw.get("pr_number")
+    if isinstance(pr_number_raw, int) and pr_number_raw > 0:
+        pr_number = pr_number_raw
+    else:
+        pr_number = 0
+    sha = _bounded_str(raw.get("merge_sha"), MAX_SHA_LEN)
+    record_reason = _bounded_str(raw.get("reason"), MAX_REASON_LEN)
+    evidence = _normalise_evidence(raw.get("evidence"))
+    return {
+        "unit_id": unit_id,
+        "status": status if status in DYNAMIC_UNIT_STATUS else "",
+        "source": source if source in DYNAMIC_STATUS_SOURCE else "",
+        "updated_at_utc": updated_at,
+        "pr_number": pr_number,
+        "merge_sha": sha,
+        "reason": record_reason,
+        "evidence": evidence,
+        "valid": valid,
+        "validation_reason": reason if reason in DYNAMIC_STATUS_INVALID_REASON
+        else "",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Snapshot assembly
+# ---------------------------------------------------------------------------
+
+
+def collect_snapshot(
+    *,
+    seed: tuple[dict[str, Any], ...] | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    """Build the deterministic dynamic unit-status projection.
+
+    ``seed`` is the pinned ``_STATUS_LEDGER_SEED`` by default;
+    tests override this to exercise validation paths.
+    """
+    src = seed if seed is not None else _STATUS_LEDGER_SEED
+    ts = generated_at_utc if generated_at_utc is not None else _utcnow()
+
+    normalised: list[dict[str, Any]] = []
+    for raw in src:
+        if not isinstance(raw, dict):
+            normalised.append(
+                {
+                    "unit_id": "",
+                    "status": "",
+                    "source": "",
+                    "updated_at_utc": "",
+                    "pr_number": 0,
+                    "merge_sha": "",
+                    "reason": "",
+                    "evidence": [],
+                    "valid": False,
+                    "validation_reason": "empty_unit_id",
+                }
+            )
+            continue
+        normalised.append(_normalise_record(raw))
+
+    # Duplicate detection.
+    seen_unit_ids: dict[str, int] = {}
+    for rec in normalised:
+        uid = rec["unit_id"]
+        if not uid:
+            continue
+        seen_unit_ids[uid] = seen_unit_ids.get(uid, 0) + 1
+    duplicate_unit_ids = sorted(
+        uid for uid, count in seen_unit_ids.items() if count > 1
+    )
+    if duplicate_unit_ids:
+        dup_set = set(duplicate_unit_ids)
+        for rec in normalised:
+            if rec["unit_id"] in dup_set:
+                rec["valid"] = False
+                rec["validation_reason"] = "duplicate_unit_id"
+
+    # Stable deterministic sort: by unit_id, then updated_at_utc.
+    normalised.sort(
+        key=lambda r: (r["unit_id"], r["updated_at_utc"], r["status"])
+    )
+
+    invalid_count = sum(1 for r in normalised if not r["valid"])
+    valid_count = sum(1 for r in normalised if r["valid"])
+    fail_closed = bool(duplicate_unit_ids) or invalid_count > 0
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": ts,
+        "step5_enabled_substage": STEP5_ENABLED_SUBSTAGE,
+        "step5_implementation_allowed": step5_implementation_allowed,
+        "source_units_module_version": rtu.MODULE_VERSION,
+        "vocabularies": {
+            "dynamic_unit_status": list(DYNAMIC_UNIT_STATUS),
+            "dynamic_status_source": list(DYNAMIC_STATUS_SOURCE),
+            "dynamic_status_invalid_reason": list(
+                DYNAMIC_STATUS_INVALID_REASON
+            ),
+        },
+        "ledger_records": normalised,
+        "duplicate_unit_ids": list(duplicate_unit_ids),
+        "invalid_record_count": invalid_count,
+        "valid_record_count": valid_count,
+        "fail_closed": fail_closed,
+        "ledger_invariants": dict(_BASE_LEDGER_INVARIANTS),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Atomic write
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Atomically write ``payload`` as sorted-key indented JSON.
+    Refuses any path outside ``logs/roadmap_unit_status/``."""
+    posix = path.as_posix()
+    if _WRITE_PREFIX not in posix:
+        raise ValueError(
+            "roadmap_unit_status._atomic_write_json refuses "
+            f"non-ledger-logs output path: {path}"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".roadmap_unit_status.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_outputs(snapshot: dict[str, Any]) -> Path:
+    _atomic_write_json(ARTIFACT_LATEST, snapshot)
+    return ARTIFACT_LATEST
+
+
+# ---------------------------------------------------------------------------
+# Status renderer
+# ---------------------------------------------------------------------------
+
+
+def _render_status(snapshot: dict[str, Any]) -> str:
+    inv = snapshot["ledger_invariants"]
+    recs = snapshot["ledger_records"]
+    lines = [
+        f"roadmap_unit_status {snapshot['module_version']} "
+        f"schema={snapshot['schema_version']}",
+        f"generated_at_utc={snapshot['generated_at_utc']}",
+        (
+            f"records_total={len(recs)} "
+            f"valid={snapshot['valid_record_count']} "
+            f"invalid={snapshot['invalid_record_count']} "
+            f"fail_closed={snapshot['fail_closed']}"
+        ),
+        f"duplicate_unit_ids={','.join(snapshot['duplicate_unit_ids']) or '-'}",
+        (
+            "no_runtime_trading_authority="
+            f"{inv['no_runtime_trading_authority']} "
+            f"no_step5_runtime={inv['no_step5_runtime']} "
+            f"no_level6={inv['no_level6']} "
+            "no_production_merge_authority="
+            f"{inv['no_production_merge_authority']}"
+        ),
+        (
+            "no_work_execution="
+            f"{inv['no_work_execution']} "
+            f"no_branch_creation={inv['no_branch_creation']} "
+            f"no_pr_creation={inv['no_pr_creation']} "
+            f"no_merge_or_deploy={inv['no_merge_or_deploy']}"
+        ),
+        (
+            "merged_status_requires_evidence="
+            f"{inv['merged_status_requires_evidence']} "
+            "duplicate_unit_id_fails_closed="
+            f"{inv['duplicate_unit_id_fails_closed']} "
+            "invalid_record_fails_closed="
+            f"{inv['invalid_record_fails_closed']} "
+            "no_implicit_merged_resurrection="
+            f"{inv['no_implicit_merged_resurrection']}"
+        ),
+    ]
+    for r in recs:
+        lines.append(
+            f"  rec {r['unit_id']} status={r['status']} "
+            f"source={r['source']} pr={r['pr_number']} "
+            f"sha={r['merge_sha'][:7] if r['merge_sha'] else '-'} "
+            f"valid={r['valid']}"
+        )
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m reporting.roadmap_unit_status",
+        description=(
+            "A21a Dynamic Unit Status Ledger. Read-only deterministic "
+            "projection over a pinned seed of per-unit execution "
+            "statuses. Does NOT execute work, does NOT create "
+            "branches, does NOT open PRs, does NOT merge or deploy. "
+            "Step 5 implementation remains BLOCKED."
+        ),
+    )
+    p.add_argument(
+        "--indent",
+        type=int,
+        default=2,
+        help="JSON indent for stdout output (0 for compact).",
+    )
+    p.add_argument(
+        "--no-write",
+        action="store_true",
+        help=(
+            "Do not persist logs/roadmap_unit_status/latest.json "
+            "(stdout only)."
+        ),
+    )
+    p.add_argument(
+        "--status",
+        action="store_true",
+        help=(
+            "Render a compact human-readable status summary to stdout "
+            "and exit. Does not write any artefact."
+        ),
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    snap = collect_snapshot()
+    if args.status:
+        sys.stdout.write(_render_status(snap))
+        return 0
+    indent = args.indent if args.indent and args.indent > 0 else None
+    if not args.no_write:
+        write_outputs(snap)
+    json.dump(snap, sys.stdout, indent=indent, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/unit/test_roadmap_next_unit.py
+++ b/tests/unit/test_roadmap_next_unit.py
@@ -183,6 +183,8 @@ def test_block_reason_vocab_is_closed_exact() -> None:
         "unknown_prerequisite_target",
         "operator_gate_required",
         "fail_closed_unknown_evidence",
+        "invalid_dynamic_status",
+        "dynamic_status_terminal",
     )
 
 
@@ -198,6 +200,18 @@ def test_source_vocab_is_closed_exact() -> None:
     assert rnu.NEXT_UNIT_SOURCE == (
         "logs/roadmap_task_units/latest.json",
         "logs/roadmap_unit_authority/latest.json",
+        "logs/roadmap_unit_status/latest.json",
+    )
+
+
+def test_dynamic_status_source_vocab_is_closed_exact() -> None:
+    assert rnu.NEXT_UNIT_DYNAMIC_STATUS_SOURCE == (
+        "",
+        "pr_merge",
+        "operator_override",
+        "loop_state",
+        "ci_failure",
+        "operator_block",
     )
 
 
@@ -252,6 +266,8 @@ def test_candidate_field_list_exact() -> None:
         "phase",
         "title",
         "status",
+        "effective_status",
+        "dynamic_status_source",
         "risk_class",
         "final_authority_class",
         "operator_gate",
@@ -262,6 +278,7 @@ def test_candidate_field_list_exact() -> None:
         "deterministic_sort_key",
         "source_units_artifact",
         "source_authority_artifact",
+        "source_status_artifact",
     )
 
 
@@ -292,6 +309,7 @@ def test_projection_field_list_exact() -> None:
         "module_version",
         "source_units_schema_version",
         "source_authority_schema_version",
+        "source_status_schema_version",
         "selector_mode",
         "candidates",
         "selection",
@@ -1011,6 +1029,319 @@ def test_invariants_pin_calls_execution_authority_classifier_false(
     assert inv["calls_execution_authority_classifier"] is False
 
 
+def test_invariants_pin_dynamic_status_ledger_consumed(
+    tmp_path: Path,
+) -> None:
+    _write_units_artifact(tmp_path, [_baseline_unit()])
+    _write_authority_artifact(tmp_path, [_baseline_decision()])
+    inv = _snap(tmp_path)["selector_invariants"]
+    assert inv["consumes_dynamic_status_ledger"] is True
+    assert inv["dynamic_status_overrides_static_when_valid"] is True
+    assert inv["fail_closed_on_invalid_dynamic_status"] is True
+    assert inv["fail_closed_on_duplicate_dynamic_status"] is True
+    assert inv["dynamic_status_absence_falls_back_to_static"] is True
+    assert inv["merged_units_never_reselected"] is True
+
+
+# ---------------------------------------------------------------------------
+# A21a dynamic-status overlay integration
+# ---------------------------------------------------------------------------
+
+
+def _write_dynamic_status_artifact(
+    tmp_path: Path, records: list[dict[str, Any]]
+) -> Path:
+    target = tmp_path / "logs" / "roadmap_unit_status" / "latest.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0",
+                "module_version": "v3.15.16.A21a",
+                "report_kind": "roadmap_unit_status",
+                "generated_at_utc": "2026-05-18T08:00:00Z",
+                "ledger_records": records,
+                "fail_closed": False,
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    return target
+
+
+def _dyn_merged_record(unit_id: str, pr_number: int = 999) -> dict[str, Any]:
+    return {
+        "unit_id": unit_id,
+        "status": "merged",
+        "source": "pr_merge",
+        "updated_at_utc": "2026-05-18T10:00:00Z",
+        "pr_number": pr_number,
+        "merge_sha": "abc1234def567890abc1234def567890abc1234d",
+        "reason": "implemented by synthetic PR",
+        "evidence": ["github_pr_number=" + str(pr_number)],
+        "valid": True,
+        "validation_reason": "",
+    }
+
+
+def test_dynamic_merged_status_excludes_unit_from_selector(
+    tmp_path: Path,
+) -> None:
+    """Static A20b says ``not_started``; dynamic ledger says
+    ``merged``. The selector must treat the unit as merged and not
+    select it."""
+    _write_units_artifact(tmp_path, [_baseline_unit()])
+    _write_authority_artifact(tmp_path, [_baseline_decision()])
+    _write_dynamic_status_artifact(
+        tmp_path, [_dyn_merged_record("syn_unit_a")]
+    )
+    snap = _snap(tmp_path)
+    cand = snap["candidates"][0]
+    assert cand["status"] == "not_started"  # A20b static unchanged
+    assert cand["effective_status"] == "merged"
+    assert cand["dynamic_status_source"] == "pr_merge"
+    assert cand["eligibility"] == "BLOCKED"
+    assert "dynamic_status_terminal" in cand["block_reasons"]
+    assert snap["selection"]["selected_unit_id"] == ""
+
+
+def test_dynamic_status_absent_falls_back_to_static(tmp_path: Path) -> None:
+    _write_units_artifact(tmp_path, [_baseline_unit()])
+    _write_authority_artifact(tmp_path, [_baseline_decision()])
+    # No dynamic ledger artefact.
+    snap = _snap(tmp_path)
+    cand = snap["candidates"][0]
+    assert cand["status"] == "not_started"
+    assert cand["effective_status"] == "not_started"
+    assert cand["dynamic_status_source"] == ""
+    assert cand["eligibility"] == "ELIGIBLE"
+    assert snap["selection"]["selected_unit_id"] == "syn_unit_a"
+
+
+def test_invalid_dynamic_status_fails_closed(tmp_path: Path) -> None:
+    """A dynamic record with ``valid = False`` blocks the unit and
+    surfaces fail-closed at the selection level."""
+    _write_units_artifact(tmp_path, [_baseline_unit()])
+    _write_authority_artifact(tmp_path, [_baseline_decision()])
+    bad = _dyn_merged_record("syn_unit_a")
+    bad["valid"] = False
+    bad["validation_reason"] = "merged_without_merge_sha"
+    _write_dynamic_status_artifact(tmp_path, [bad])
+    snap = _snap(tmp_path)
+    cand = snap["candidates"][0]
+    assert "invalid_dynamic_status" in cand["block_reasons"]
+    assert cand["eligibility"] == "BLOCKED"
+    assert snap["selection"]["selection_status"] == "FAIL_CLOSED_INVARIANT"
+    assert snap["selection"]["fail_closed"] is True
+
+
+def test_unknown_dynamic_status_value_fails_closed(tmp_path: Path) -> None:
+    """A dynamic record whose ``status`` is outside the closed
+    DYNAMIC_UNIT_STATUS vocab fails closed even if ``valid=True``
+    (defence in depth)."""
+    _write_units_artifact(tmp_path, [_baseline_unit()])
+    _write_authority_artifact(tmp_path, [_baseline_decision()])
+    rec = _dyn_merged_record("syn_unit_a")
+    rec["status"] = "not_a_real_dynamic_status"
+    _write_dynamic_status_artifact(tmp_path, [rec])
+    snap = _snap(tmp_path)
+    cand = snap["candidates"][0]
+    assert "invalid_dynamic_status" in cand["block_reasons"]
+
+
+def test_dynamic_pr_open_status_blocks_candidate(tmp_path: Path) -> None:
+    """``pr_open`` is a valid non-buildable dynamic status."""
+    _write_units_artifact(tmp_path, [_baseline_unit()])
+    _write_authority_artifact(tmp_path, [_baseline_decision()])
+    rec = _dyn_merged_record("syn_unit_a")
+    rec["status"] = "pr_open"
+    rec["pr_number"] = 0
+    rec["merge_sha"] = ""
+    rec["reason"] = ""
+    _write_dynamic_status_artifact(tmp_path, [rec])
+    snap = _snap(tmp_path)
+    cand = snap["candidates"][0]
+    assert cand["effective_status"] == "pr_open"
+    assert cand["eligibility"] == "BLOCKED"
+    assert "non_buildable_status" in cand["block_reasons"]
+
+
+def test_dynamic_in_progress_status_blocks_candidate(tmp_path: Path) -> None:
+    _write_units_artifact(tmp_path, [_baseline_unit()])
+    _write_authority_artifact(tmp_path, [_baseline_decision()])
+    rec = _dyn_merged_record("syn_unit_a")
+    rec["status"] = "in_progress"
+    rec["source"] = "loop_state"
+    rec["pr_number"] = 0
+    rec["merge_sha"] = ""
+    rec["reason"] = ""
+    _write_dynamic_status_artifact(tmp_path, [rec])
+    snap = _snap(tmp_path)
+    cand = snap["candidates"][0]
+    assert cand["effective_status"] == "in_progress"
+    assert cand["eligibility"] == "BLOCKED"
+    assert "non_buildable_status" in cand["block_reasons"]
+
+
+def test_dynamic_failed_status_blocks_candidate(tmp_path: Path) -> None:
+    _write_units_artifact(tmp_path, [_baseline_unit()])
+    _write_authority_artifact(tmp_path, [_baseline_decision()])
+    rec = _dyn_merged_record("syn_unit_a")
+    rec["status"] = "failed"
+    rec["source"] = "ci_failure"
+    rec["pr_number"] = 0
+    rec["merge_sha"] = ""
+    rec["reason"] = ""
+    _write_dynamic_status_artifact(tmp_path, [rec])
+    snap = _snap(tmp_path)
+    cand = snap["candidates"][0]
+    assert cand["effective_status"] == "failed"
+    assert cand["eligibility"] == "BLOCKED"
+
+
+def test_dynamic_merged_satisfies_prerequisite(tmp_path: Path) -> None:
+    """A unit whose static prereq is ``not_started`` but whose
+    dynamic prereq is ``merged`` must be considered satisfied."""
+    prereq = _baseline_unit(id="prereq_unit", status="not_started")
+    unit = _baseline_unit(prerequisites=["prereq_unit"])
+    _write_units_artifact(tmp_path, [prereq, unit])
+    _write_authority_artifact(
+        tmp_path,
+        [
+            _baseline_decision(implementation_unit_id="prereq_unit"),
+            _baseline_decision(),
+        ],
+    )
+    _write_dynamic_status_artifact(
+        tmp_path, [_dyn_merged_record("prereq_unit", pr_number=100)]
+    )
+    snap = _snap(tmp_path)
+    main_cand = next(
+        c
+        for c in snap["candidates"]
+        if c["implementation_unit_id"] == "syn_unit_a"
+    )
+    assert main_cand["prerequisites_satisfied"] is True
+    assert main_cand["eligibility"] == "ELIGIBLE"
+    assert snap["selection"]["selected_unit_id"] == "syn_unit_a"
+
+
+def test_pinned_three_merged_units_are_not_reselected(tmp_path: Path) -> None:
+    """The bootstrap A21a seed pins the three v3.15.16 routing-layer
+    units as merged. When the live ledger artefact carries those
+    records, the selector must not reselect any of them."""
+    schema_unit = _baseline_unit(
+        id="u_v3_15_16_diagnostic_routing_signals_schema_001",
+        phase="v3.15.16",
+    )
+    expl_unit = _baseline_unit(
+        id="u_v3_15_16_routing_explanation_reporter_001",
+        phase="v3.15.16",
+    )
+    gov_unit = _baseline_unit(
+        id="u_v3_15_16_routing_governance_doc_001",
+        phase="v3.15.16",
+    )
+    next_unit = _baseline_unit(
+        id="u_v3_15_17_synthetic_next",
+        phase="v3.15.17",
+    )
+    _write_units_artifact(
+        tmp_path, [schema_unit, expl_unit, gov_unit, next_unit]
+    )
+    _write_authority_artifact(
+        tmp_path,
+        [
+            _baseline_decision(
+                implementation_unit_id=schema_unit["id"]
+            ),
+            _baseline_decision(
+                implementation_unit_id=expl_unit["id"]
+            ),
+            _baseline_decision(
+                implementation_unit_id=gov_unit["id"]
+            ),
+            _baseline_decision(
+                implementation_unit_id=next_unit["id"],
+                phase="v3.15.17",
+            ),
+        ],
+    )
+    _write_dynamic_status_artifact(
+        tmp_path,
+        [
+            _dyn_merged_record(schema_unit["id"], pr_number=250),
+            _dyn_merged_record(expl_unit["id"], pr_number=252),
+            _dyn_merged_record(gov_unit["id"], pr_number=254),
+        ],
+    )
+    snap = _snap(tmp_path)
+    # The three merged units must not appear as the selection.
+    merged_ids = {schema_unit["id"], expl_unit["id"], gov_unit["id"]}
+    assert snap["selection"]["selected_unit_id"] not in merged_ids
+    assert snap["selection"]["selected_unit_id"] == next_unit["id"]
+
+
+def test_malformed_dynamic_status_artifact_fails_closed(
+    tmp_path: Path,
+) -> None:
+    """If the dynamic ledger artefact is corrupt JSON, fail closed
+    with UPSTREAM_UNAVAILABLE (same posture as units / authority)."""
+    _write_units_artifact(tmp_path, [_baseline_unit()])
+    _write_authority_artifact(tmp_path, [_baseline_decision()])
+    target = tmp_path / "logs" / "roadmap_unit_status" / "latest.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("{not valid json", encoding="utf-8")
+    snap = _snap(tmp_path)
+    assert snap["selection"]["selection_status"] == "UPSTREAM_UNAVAILABLE"
+    assert snap["selection"]["fail_closed"] is True
+    assert (
+        "malformed_dynamic_status_artifact"
+        in snap["selection"]["selection_reason"]
+    )
+
+
+def test_static_status_field_unchanged_by_dynamic_overlay(
+    tmp_path: Path,
+) -> None:
+    """The candidate's ``status`` field always carries the A20b
+    static value verbatim. Only ``effective_status`` reflects the
+    overlay. This preserves traceability."""
+    _write_units_artifact(tmp_path, [_baseline_unit()])
+    _write_authority_artifact(tmp_path, [_baseline_decision()])
+    _write_dynamic_status_artifact(
+        tmp_path, [_dyn_merged_record("syn_unit_a")]
+    )
+    snap = _snap(tmp_path)
+    cand = snap["candidates"][0]
+    assert cand["status"] == "not_started"  # A20b static
+    assert cand["effective_status"] == "merged"  # dynamic overlay
+
+
+def test_dynamic_status_artifact_path_pinned(tmp_path: Path) -> None:
+    _write_units_artifact(tmp_path, [_baseline_unit()])
+    _write_authority_artifact(tmp_path, [_baseline_decision()])
+    snap = _snap(tmp_path)
+    cand = snap["candidates"][0]
+    assert (
+        cand["source_status_artifact"]
+        == "logs/roadmap_unit_status/latest.json"
+    )
+
+
+def test_top_level_projection_carries_status_schema_version(
+    tmp_path: Path,
+) -> None:
+    _write_units_artifact(tmp_path, [_baseline_unit()])
+    _write_authority_artifact(tmp_path, [_baseline_decision()])
+    _write_dynamic_status_artifact(
+        tmp_path, [_dyn_merged_record("syn_unit_a")]
+    )
+    snap = _snap(tmp_path)
+    assert snap["source_status_schema_version"] == "1.0"
+
+
 # ---------------------------------------------------------------------------
 # Module-source forbidden-import / forbidden-token scans
 # ---------------------------------------------------------------------------
@@ -1112,11 +1443,12 @@ def test_no_github_api_or_external_api_calls() -> None:
 
 
 def test_module_imports_only_canonical_upstreams() -> None:
-    """A20e may only import from A20b + A20c. It MUST NOT import
-    from reporting.execution_authority directly."""
+    """A20e may only import from A20b + A20c + A21a (read-only). It
+    MUST NOT import from reporting.execution_authority directly."""
     allowed = {
         "reporting.roadmap_task_units",
         "reporting.roadmap_unit_authority",
+        "reporting.roadmap_unit_status",
     }
     for module in _module_imports():
         if module.startswith("reporting."):

--- a/tests/unit/test_roadmap_unit_status.py
+++ b/tests/unit/test_roadmap_unit_status.py
@@ -1,0 +1,786 @@
+"""Unit tests for A21a — Dynamic Unit Status Ledger.
+
+Pins:
+
+* closed vocabularies (DYNAMIC_UNIT_STATUS,
+  DYNAMIC_STATUS_SOURCE, DYNAMIC_STATUS_INVALID_REASON);
+* schema field tuples (DYNAMIC_UNIT_STATUS_RECORD_FIELDS,
+  ROADMAP_UNIT_STATUS_PROJECTION_FIELDS);
+* deterministic output with injected ``generated_at_utc``;
+* byte-identical output for identical input;
+* atomic write only under ``logs/roadmap_unit_status/``;
+* ``--no-write`` does not write; ``--status`` does not write;
+* merged status requires non-empty pr_number, merge_sha, reason;
+* invalid records (bad status, bad source, missing fields,
+  non-hex SHA) carry ``valid = False`` and a closed-vocab
+  validation_reason;
+* duplicate unit_ids fail closed deterministically;
+* bootstrap seed contains exactly the three already-merged
+  v3.15.16 routing-layer units with pinned PR numbers and
+  merge SHAs;
+* ``step5_implementation_allowed`` remains ``False``;
+* no Step 5, no Level 6, no production-merge authority, no
+  runtime/trading/paper/shadow/live authority;
+* no forbidden imports / runtime tokens in module source.
+"""
+
+from __future__ import annotations
+
+import ast as _ast
+import hashlib
+import importlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reporting import roadmap_unit_status as rus
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+_FROZEN_UTC = "2026-05-18T20:00:00Z"
+
+
+def _valid_merged_record(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "unit_id": "u_syn_unit",
+        "status": "merged",
+        "source": "pr_merge",
+        "updated_at_utc": "2026-05-18T10:00:00Z",
+        "pr_number": 999,
+        "merge_sha": "abc1234def567890abc1234def567890abc1234d",
+        "reason": "implemented by synthetic PR",
+        "evidence": ["github_pr_number=999"],
+    }
+    base.update(overrides)
+    return base
+
+
+def _snap_with(
+    *records: dict[str, Any], ts: str = _FROZEN_UTC
+) -> dict[str, Any]:
+    return rus.collect_snapshot(
+        seed=tuple(records), generated_at_utc=ts
+    )
+
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies
+# ---------------------------------------------------------------------------
+
+
+def test_dynamic_unit_status_vocab_is_closed_exact() -> None:
+    assert rus.DYNAMIC_UNIT_STATUS == (
+        "not_started",
+        "in_progress",
+        "pr_open",
+        "merged",
+        "failed",
+        "blocked",
+        "skipped",
+    )
+
+
+def test_dynamic_status_source_vocab_is_closed_exact() -> None:
+    assert rus.DYNAMIC_STATUS_SOURCE == (
+        "pr_merge",
+        "operator_override",
+        "loop_state",
+        "ci_failure",
+        "operator_block",
+    )
+
+
+def test_dynamic_status_invalid_reason_vocab_includes_empty_string() -> None:
+    """`""` denotes a valid record (no invalidity reason)."""
+    assert "" in rus.DYNAMIC_STATUS_INVALID_REASON
+
+
+def test_dynamic_status_invalid_reason_vocab_is_closed_exact() -> None:
+    assert rus.DYNAMIC_STATUS_INVALID_REASON == (
+        "",
+        "unknown_status",
+        "unknown_source",
+        "empty_unit_id",
+        "merged_without_pr_number",
+        "merged_without_merge_sha",
+        "merged_without_reason",
+        "duplicate_unit_id",
+        "missing_updated_at_utc",
+        "evidence_not_a_list",
+        "pr_number_not_a_positive_int",
+        "merge_sha_not_a_hex_string",
+    )
+
+
+def test_dynamic_status_output_path_pinned() -> None:
+    assert rus.DYNAMIC_STATUS_OUTPUT_PATH == (
+        "logs/roadmap_unit_status/latest.json"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Schema integrity
+# ---------------------------------------------------------------------------
+
+
+def test_record_field_list_exact() -> None:
+    assert rus.DYNAMIC_UNIT_STATUS_RECORD_FIELDS == (
+        "unit_id",
+        "status",
+        "source",
+        "updated_at_utc",
+        "pr_number",
+        "merge_sha",
+        "reason",
+        "evidence",
+        "valid",
+        "validation_reason",
+    )
+
+
+def test_projection_field_list_exact() -> None:
+    assert rus.ROADMAP_UNIT_STATUS_PROJECTION_FIELDS == (
+        "generated_at_utc",
+        "schema_version",
+        "module_version",
+        "source_units_module_version",
+        "ledger_records",
+        "duplicate_unit_ids",
+        "invalid_record_count",
+        "valid_record_count",
+        "fail_closed",
+        "ledger_invariants",
+    )
+
+
+def test_every_record_has_every_field() -> None:
+    snap = _snap_with(_valid_merged_record())
+    for r in snap["ledger_records"]:
+        assert set(r.keys()) == set(
+            rus.DYNAMIC_UNIT_STATUS_RECORD_FIELDS
+        ), r
+
+
+def test_top_level_carries_every_projection_field() -> None:
+    snap = _snap_with(_valid_merged_record())
+    for field in rus.ROADMAP_UNIT_STATUS_PROJECTION_FIELDS:
+        assert field in snap, field
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap seed pins
+# ---------------------------------------------------------------------------
+
+
+def test_bootstrap_seed_has_three_v3_15_16_records() -> None:
+    """The bootstrap ledger seed must encode exactly the three
+    already-merged v3.15.16 routing-layer units."""
+    snap = rus.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+    seed_unit_ids = sorted(r["unit_id"] for r in snap["ledger_records"])
+    assert seed_unit_ids == [
+        "u_v3_15_16_diagnostic_routing_signals_schema_001",
+        "u_v3_15_16_routing_explanation_reporter_001",
+        "u_v3_15_16_routing_governance_doc_001",
+    ]
+
+
+def test_bootstrap_seed_pr_numbers_pinned() -> None:
+    snap = rus.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+    by_unit = {r["unit_id"]: r for r in snap["ledger_records"]}
+    assert by_unit["u_v3_15_16_diagnostic_routing_signals_schema_001"][
+        "pr_number"
+    ] == 250
+    assert by_unit["u_v3_15_16_routing_explanation_reporter_001"][
+        "pr_number"
+    ] == 252
+    assert by_unit["u_v3_15_16_routing_governance_doc_001"][
+        "pr_number"
+    ] == 254
+
+
+def test_bootstrap_seed_merge_shas_pinned() -> None:
+    snap = rus.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+    by_unit = {r["unit_id"]: r for r in snap["ledger_records"]}
+    assert by_unit["u_v3_15_16_diagnostic_routing_signals_schema_001"][
+        "merge_sha"
+    ] == "fcb1abbea4bd2ca190fe6e807b3dacd184faa702"
+    assert by_unit["u_v3_15_16_routing_explanation_reporter_001"][
+        "merge_sha"
+    ] == "6f588a89b43a2cfec40f92252bde530220877b37"
+    assert by_unit["u_v3_15_16_routing_governance_doc_001"][
+        "merge_sha"
+    ] == "df7dc6562ec3cd3a9f87e83e758881bd6fdb16f8"
+
+
+def test_bootstrap_seed_all_records_are_valid() -> None:
+    snap = rus.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+    for r in snap["ledger_records"]:
+        assert r["valid"] is True, r
+        assert r["validation_reason"] == "", r
+    assert snap["fail_closed"] is False
+    assert snap["invalid_record_count"] == 0
+    assert snap["valid_record_count"] == 3
+    assert snap["duplicate_unit_ids"] == []
+
+
+def test_bootstrap_seed_all_records_are_pr_merge_source() -> None:
+    snap = rus.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+    for r in snap["ledger_records"]:
+        assert r["source"] == "pr_merge"
+
+
+def test_bootstrap_seed_all_records_are_merged_status() -> None:
+    snap = rus.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+    for r in snap["ledger_records"]:
+        assert r["status"] == "merged"
+
+
+# ---------------------------------------------------------------------------
+# Validation rules
+# ---------------------------------------------------------------------------
+
+
+def test_merged_status_requires_pr_number() -> None:
+    snap = _snap_with(_valid_merged_record(pr_number=0))
+    rec = snap["ledger_records"][0]
+    assert rec["valid"] is False
+    assert rec["validation_reason"] == "pr_number_not_a_positive_int"
+    assert snap["fail_closed"] is True
+
+
+def test_merged_status_requires_merge_sha() -> None:
+    snap = _snap_with(_valid_merged_record(merge_sha=""))
+    rec = snap["ledger_records"][0]
+    assert rec["valid"] is False
+    assert rec["validation_reason"] == "merged_without_merge_sha"
+    assert snap["fail_closed"] is True
+
+
+def test_merged_status_requires_reason() -> None:
+    snap = _snap_with(_valid_merged_record(reason=""))
+    rec = snap["ledger_records"][0]
+    assert rec["valid"] is False
+    assert rec["validation_reason"] == "merged_without_reason"
+    assert snap["fail_closed"] is True
+
+
+def test_merged_status_rejects_non_hex_sha() -> None:
+    snap = _snap_with(_valid_merged_record(merge_sha="not-a-hex-sha"))
+    rec = snap["ledger_records"][0]
+    assert rec["valid"] is False
+    assert rec["validation_reason"] == "merge_sha_not_a_hex_string"
+
+
+def test_unknown_status_value_is_invalid() -> None:
+    snap = _snap_with(
+        _valid_merged_record(status="not_a_real_status")
+    )
+    rec = snap["ledger_records"][0]
+    assert rec["valid"] is False
+    assert rec["validation_reason"] == "unknown_status"
+
+
+def test_unknown_source_value_is_invalid() -> None:
+    snap = _snap_with(
+        _valid_merged_record(source="not_a_real_source")
+    )
+    rec = snap["ledger_records"][0]
+    assert rec["valid"] is False
+    assert rec["validation_reason"] == "unknown_source"
+
+
+def test_empty_unit_id_is_invalid() -> None:
+    snap = _snap_with(_valid_merged_record(unit_id=""))
+    rec = snap["ledger_records"][0]
+    assert rec["valid"] is False
+    assert rec["validation_reason"] == "empty_unit_id"
+
+
+def test_missing_updated_at_is_invalid() -> None:
+    snap = _snap_with(_valid_merged_record(updated_at_utc=""))
+    rec = snap["ledger_records"][0]
+    assert rec["valid"] is False
+    assert rec["validation_reason"] == "missing_updated_at_utc"
+
+
+def test_non_list_evidence_is_invalid() -> None:
+    snap = _snap_with(_valid_merged_record(evidence="not-a-list"))
+    rec = snap["ledger_records"][0]
+    assert rec["valid"] is False
+    assert rec["validation_reason"] == "evidence_not_a_list"
+
+
+def test_pr_open_status_does_not_require_pr_number() -> None:
+    """``pr_open`` is a valid non-terminal status. It records that a
+    PR has been opened but does not yet require a merge SHA."""
+    snap = _snap_with(
+        _valid_merged_record(
+            status="pr_open", pr_number=0, merge_sha="", reason=""
+        )
+    )
+    rec = snap["ledger_records"][0]
+    assert rec["valid"] is True
+    assert rec["validation_reason"] == ""
+
+
+def test_in_progress_status_does_not_require_evidence() -> None:
+    snap = _snap_with(
+        _valid_merged_record(
+            status="in_progress",
+            source="loop_state",
+            pr_number=0,
+            merge_sha="",
+            reason="",
+        )
+    )
+    rec = snap["ledger_records"][0]
+    assert rec["valid"] is True
+
+
+# ---------------------------------------------------------------------------
+# Duplicate detection
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_unit_id_fails_closed() -> None:
+    snap = _snap_with(
+        _valid_merged_record(unit_id="u_dup"),
+        _valid_merged_record(unit_id="u_dup", pr_number=12345),
+    )
+    assert snap["duplicate_unit_ids"] == ["u_dup"]
+    assert snap["fail_closed"] is True
+    for r in snap["ledger_records"]:
+        assert r["valid"] is False
+        assert r["validation_reason"] == "duplicate_unit_id"
+
+
+def test_duplicate_does_not_taint_unrelated_records() -> None:
+    snap = _snap_with(
+        _valid_merged_record(unit_id="u_a"),
+        _valid_merged_record(unit_id="u_b"),
+        _valid_merged_record(unit_id="u_b", pr_number=42),
+    )
+    by_id = {r["unit_id"]: r for r in snap["ledger_records"]}
+    # u_a is untouched.
+    a_records = [r for r in snap["ledger_records"] if r["unit_id"] == "u_a"]
+    assert len(a_records) == 1
+    assert a_records[0]["valid"] is True
+    # u_b duplicates both invalid.
+    b_records = [r for r in snap["ledger_records"] if r["unit_id"] == "u_b"]
+    assert len(b_records) == 2
+    assert all(r["valid"] is False for r in b_records)
+    assert snap["duplicate_unit_ids"] == ["u_b"]
+    _ = by_id  # silence unused
+
+
+def test_duplicate_detection_is_deterministic() -> None:
+    """Duplicates list is stable across runs (sorted)."""
+    snap_a = _snap_with(
+        _valid_merged_record(unit_id="u_b"),
+        _valid_merged_record(unit_id="u_b", pr_number=2),
+        _valid_merged_record(unit_id="u_a"),
+        _valid_merged_record(unit_id="u_a", pr_number=2),
+    )
+    snap_b = _snap_with(
+        _valid_merged_record(unit_id="u_a"),
+        _valid_merged_record(unit_id="u_a", pr_number=2),
+        _valid_merged_record(unit_id="u_b"),
+        _valid_merged_record(unit_id="u_b", pr_number=2),
+    )
+    assert snap_a["duplicate_unit_ids"] == snap_b["duplicate_unit_ids"]
+
+
+def test_no_implicit_merged_resurrection() -> None:
+    """A duplicate that tries to replace a ``merged`` record with
+    ``not_started`` is rejected via duplicate fail-closed."""
+    snap = _snap_with(
+        _valid_merged_record(unit_id="u_x"),
+        _valid_merged_record(
+            unit_id="u_x",
+            status="not_started",
+            source="operator_override",
+            pr_number=0,
+            merge_sha="",
+            reason="",
+        ),
+    )
+    assert "u_x" in snap["duplicate_unit_ids"]
+    assert snap["fail_closed"] is True
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_deterministic_with_injected_ts() -> None:
+    a = rus.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+    b = rus.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+    assert a == b
+
+
+def test_serialised_output_byte_identical_with_injected_ts() -> None:
+    a = rus.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+    b = rus.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+    out_a = json.dumps(a, indent=2, sort_keys=True) + "\n"
+    out_b = json.dumps(b, indent=2, sort_keys=True) + "\n"
+    assert out_a == out_b
+
+
+def test_records_sorted_stably_by_unit_id() -> None:
+    snap = _snap_with(
+        _valid_merged_record(unit_id="u_zz"),
+        _valid_merged_record(unit_id="u_aa", pr_number=2),
+        _valid_merged_record(unit_id="u_mm", pr_number=3),
+    )
+    unit_ids = [r["unit_id"] for r in snap["ledger_records"]]
+    assert unit_ids == sorted(unit_ids)
+
+
+# ---------------------------------------------------------------------------
+# Step 5 / Level 6 / authority invariants
+# ---------------------------------------------------------------------------
+
+
+def test_step5_implementation_allowed_is_final_false() -> None:
+    assert rus.step5_implementation_allowed is False
+
+
+def test_step5_enabled_substage_is_none() -> None:
+    assert rus.STEP5_ENABLED_SUBSTAGE == "none"
+
+
+def test_projection_pins_step5_implementation_allowed_false() -> None:
+    snap = _snap_with(_valid_merged_record())
+    assert snap["step5_implementation_allowed"] is False
+    assert snap["step5_enabled_substage"] == "none"
+
+
+def test_ledger_invariants_pin_no_runtime_trading_authority() -> None:
+    snap = _snap_with(_valid_merged_record())
+    inv = snap["ledger_invariants"]
+    assert inv["no_runtime_trading_authority"] is True
+
+
+def test_ledger_invariants_pin_no_step5_no_level6_no_production_merge() -> None:
+    snap = _snap_with(_valid_merged_record())
+    inv = snap["ledger_invariants"]
+    assert inv["no_step5_runtime"] is True
+    assert inv["no_level6"] is True
+    assert inv["no_production_merge_authority"] is True
+    assert inv["step5_implementation_allowed"] is False
+
+
+def test_ledger_invariants_pin_no_work_execution() -> None:
+    snap = _snap_with(_valid_merged_record())
+    inv = snap["ledger_invariants"]
+    assert inv["no_work_execution"] is True
+    assert inv["no_branch_creation"] is True
+    assert inv["no_pr_creation"] is True
+    assert inv["no_merge_or_deploy"] is True
+
+
+def test_ledger_invariants_pin_no_mutation_routes_or_approval_buttons() -> None:
+    snap = _snap_with(_valid_merged_record())
+    inv = snap["ledger_invariants"]
+    assert inv["no_mutation_routes"] is True
+    assert inv["no_approval_buttons"] is True
+
+
+def test_ledger_invariants_pin_no_a20b_mutation() -> None:
+    snap = _snap_with(_valid_merged_record())
+    inv = snap["ledger_invariants"]
+    assert inv["mutates_a20b_artifact"] is False
+    assert inv["writes_only_roadmap_unit_status_log"] is True
+
+
+def test_ledger_invariants_pin_no_seed_jsonl_writes() -> None:
+    snap = _snap_with(_valid_merged_record())
+    inv = snap["ledger_invariants"]
+    assert inv["writes_to_seed_jsonl"] is False
+    assert inv["writes_to_delegation_seed_jsonl"] is False
+    assert inv["writes_to_generated_seed_jsonl"] is False
+    assert inv["writes_to_approval_inbox"] is False
+    assert inv["writes_to_work_queue_jsonl"] is False
+
+
+def test_ledger_invariants_pin_no_classifier_or_llm_calls() -> None:
+    snap = _snap_with(_valid_merged_record())
+    inv = snap["ledger_invariants"]
+    assert inv["calls_execution_authority_classifier"] is False
+    assert inv["calls_llm_or_external_api"] is False
+    assert inv["uses_subprocess_or_network"] is False
+
+
+def test_ledger_invariants_pin_fail_closed_contracts() -> None:
+    snap = _snap_with(_valid_merged_record())
+    inv = snap["ledger_invariants"]
+    assert inv["merged_status_requires_evidence"] is True
+    assert inv["duplicate_unit_id_fails_closed"] is True
+    assert inv["invalid_record_fails_closed"] is True
+    assert inv["no_implicit_merged_resurrection"] is True
+
+
+# ---------------------------------------------------------------------------
+# Atomic write allowlist
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_write_refuses_path_outside_allowlist(
+    tmp_path: Path,
+) -> None:
+    bad = tmp_path / "logs" / "elsewhere" / "latest.json"
+    bad.parent.mkdir(parents=True, exist_ok=True)
+    with pytest.raises(ValueError):
+        rus._atomic_write_json(bad, {"x": 1})
+
+
+def test_atomic_write_refuses_frozen_contract_paths(
+    tmp_path: Path,
+) -> None:
+    for forbidden in (
+        "research/research_latest.json",
+        "research/strategy_matrix.csv",
+        "docs/development_work_queue/latest.jsonl",
+    ):
+        target = tmp_path / forbidden
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with pytest.raises(ValueError):
+            rus._atomic_write_json(target, {"x": 1})
+
+
+def test_atomic_write_accepts_allowlisted_path(tmp_path: Path) -> None:
+    good = tmp_path / "logs" / "roadmap_unit_status" / "latest.json"
+    good.parent.mkdir(parents=True, exist_ok=True)
+    rus._atomic_write_json(good, {"x": 1})
+    assert good.is_file()
+
+
+def test_atomic_write_is_atomic(tmp_path: Path) -> None:
+    good = tmp_path / "logs" / "roadmap_unit_status" / "latest.json"
+    good.parent.mkdir(parents=True, exist_ok=True)
+    rus._atomic_write_json(good, {"a": 1})
+    rus._atomic_write_json(good, {"b": 2})
+    # No leftover temp files in the directory.
+    leftovers = [
+        p
+        for p in good.parent.iterdir()
+        if p.name.startswith(".roadmap_unit_status.")
+    ]
+    assert leftovers == []
+
+
+# ---------------------------------------------------------------------------
+# CLI behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_cli_no_write_does_not_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    sentinel = tmp_path / "logs" / "roadmap_unit_status" / "latest.json"
+    monkeypatch.setattr(rus, "ARTIFACT_LATEST", sentinel)
+    monkeypatch.setattr(rus, "ARTIFACT_DIR", sentinel.parent)
+    rc = rus.main(["--no-write"])
+    assert rc == 0
+    assert not sentinel.exists()
+    out = capsys.readouterr().out
+    assert '"roadmap_unit_status"' in out
+
+
+def test_cli_status_does_not_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    sentinel = tmp_path / "logs" / "roadmap_unit_status" / "latest.json"
+    monkeypatch.setattr(rus, "ARTIFACT_LATEST", sentinel)
+    monkeypatch.setattr(rus, "ARTIFACT_DIR", sentinel.parent)
+    rc = rus.main(["--status"])
+    assert rc == 0
+    assert not sentinel.exists()
+    out = capsys.readouterr().out
+    assert "roadmap_unit_status" in out
+    assert "no_runtime_trading_authority=True" in out
+    assert "no_step5_runtime=True" in out
+    assert "no_level6=True" in out
+    assert "no_production_merge_authority=True" in out
+
+
+def test_cli_default_writes_to_allowlisted_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sentinel = tmp_path / "logs" / "roadmap_unit_status" / "latest.json"
+    monkeypatch.setattr(rus, "ARTIFACT_LATEST", sentinel)
+    monkeypatch.setattr(rus, "ARTIFACT_DIR", sentinel.parent)
+    rc = rus.main([])
+    assert rc == 0
+    assert sentinel.is_file()
+    payload = json.loads(sentinel.read_text(encoding="utf-8"))
+    assert payload["report_kind"] == "roadmap_unit_status"
+    assert payload["module_version"].endswith("A21a")
+
+
+def test_cli_indent_zero_compact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    sentinel = tmp_path / "logs" / "roadmap_unit_status" / "latest.json"
+    monkeypatch.setattr(rus, "ARTIFACT_LATEST", sentinel)
+    monkeypatch.setattr(rus, "ARTIFACT_DIR", sentinel.parent)
+    rc = rus.main(["--no-write", "--indent", "0"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "\n  " not in out
+
+
+# ---------------------------------------------------------------------------
+# Read-only invariants (no work execution)
+# ---------------------------------------------------------------------------
+
+
+def test_collect_snapshot_does_not_mutate_upstream_or_seed(
+    tmp_path: Path,
+) -> None:
+    """The seed is a Final tuple; the snapshot does not mutate it."""
+    seed_before = hashlib.sha256(
+        repr(rus._STATUS_LEDGER_SEED).encode("utf-8")
+    ).hexdigest()
+    rus.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+    seed_after = hashlib.sha256(
+        repr(rus._STATUS_LEDGER_SEED).encode("utf-8")
+    ).hexdigest()
+    assert seed_before == seed_after
+
+
+# ---------------------------------------------------------------------------
+# Module-source forbidden-import / forbidden-token scans
+# ---------------------------------------------------------------------------
+
+
+def _module_source() -> str:
+    return Path(rus.__file__).read_text(encoding="utf-8")
+
+
+def _module_imports() -> list[str]:
+    tree = _ast.parse(_module_source())
+    out: list[str] = []
+    for node in _ast.walk(tree):
+        if isinstance(node, _ast.Import):
+            for alias in node.names:
+                out.append(alias.name)
+        elif isinstance(node, _ast.ImportFrom):
+            mod = node.module or ""
+            for alias in node.names:
+                out.append(f"{mod}.{alias.name}" if mod else alias.name)
+    return out
+
+
+def test_no_subprocess_in_module() -> None:
+    src = _module_source()
+    assert "import subprocess" not in src
+    assert "from subprocess" not in src
+    assert "subprocess." not in src
+
+
+def test_no_socket_or_urllib_or_http_or_requests() -> None:
+    src = _module_source()
+    for forbidden in (
+        "import socket",
+        "from socket",
+        "import urllib",
+        "from urllib",
+        "import http",
+        "from http",
+        "import requests",
+        "from requests",
+        "import httpx",
+        "from httpx",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_no_forbidden_runtime_imports_via_ast() -> None:
+    forbidden_prefixes = (
+        "dashboard",
+        "automation",
+        "broker",
+        "agent.risk",
+        "agent.execution",
+        "research",
+        "live",
+        "paper",
+        "shadow",
+        "trading",
+        "reporting.intelligent_routing",
+        "reporting.execution_authority",
+        "reporting.development_queue_admission_policy",
+        "reporting.development_agent_activity_timeline",
+        "reporting.roadmap_next_unit",
+        "reporting.roadmap_unit_authority",
+        "reporting.roadmap_task_catalog",
+    )
+    for module in _module_imports():
+        for prefix in forbidden_prefixes:
+            assert not (
+                module == prefix or module.startswith(prefix + ".")
+            ), f"forbidden import: {module}"
+
+
+def test_no_gh_or_git_cli_calls() -> None:
+    src = _module_source()
+    for forbidden in (
+        "subprocess.run",
+        "subprocess.Popen",
+        "os.system(",
+        "os.popen(",
+        "shell=True",
+        "eval(",
+        "exec(",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_no_github_api_or_external_api_calls() -> None:
+    src = _module_source()
+    for forbidden in (
+        "api.github.com",
+        "anthropic",
+        "openai",
+        "Bearer ",
+        "X-API-Key",
+        "X-GitHub-Token",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_module_imports_only_canonical_upstream() -> None:
+    """A21a may only import from A20b (read-only) to expose its
+    cross-reference module version on the projection."""
+    allowed = {"reporting.roadmap_task_units"}
+    for module in _module_imports():
+        if module.startswith("reporting."):
+            assert module in allowed, module
+
+
+def test_module_imports_cleanly() -> None:
+    importlib.reload(rus)
+    assert callable(rus.collect_snapshot)
+    assert callable(rus.write_outputs)
+    assert callable(rus.main)
+
+
+def test_schema_and_module_version_strings() -> None:
+    assert isinstance(rus.SCHEMA_VERSION, str) and rus.SCHEMA_VERSION
+    assert isinstance(rus.MODULE_VERSION, str) and rus.MODULE_VERSION
+    assert rus.MODULE_VERSION.endswith("A21a")


### PR DESCRIPTION
## Summary

Step 5 / A21a foundation: a read-only deterministic dynamic unit-status ledger plus the matching A20e selector overlay.

- **Selected A20e unit id (current foundation slice):** Step 5 / A21a — the dynamic unit-status ledger foundation. No A20b seed entry exists for this slice because the foundation is the prerequisite that lets A20b seed entries land without a follow-up `chore/a20-*` PR.
- **Phase:** Step 5 / A21 foundation (development workflow only).
- **Authority class on this PR:** `AUTO_ALLOWED` (LOW risk, `operator_gate = none`, read-only deterministic projections + documentation).
- **Step 5 implementation remains BLOCKED.** Autonomy-ladder Level 6 remains **permanently disabled** per ADR-015. N5b Phase 4 production merge remains **permanently denied for ADE**.
- **No actual branch / PR / merge / deploy automation is implemented in this PR.** Per the spec, this slice is foundation only.
- **Manual per-unit status PRs are eliminated by the dynamic ledger design.** The bootstrap A21a seed pins PR #250, PR #252, and PR #254 as merged; A20e treats them as `effective_status = "merged"` without editing the A20b `_UNIT_SEED`.
- **No runtime / trading / paper / shadow / live authority is granted.**

## Exact files changed (6 files, +2535 / -35)

- `reporting/roadmap_unit_status.py` (new) — A21a module: closed `DYNAMIC_UNIT_STATUS` (7 values), closed `DYNAMIC_STATUS_SOURCE` (5 values), closed `DYNAMIC_STATUS_INVALID_REASON` (12 values), 10-field record schema, 10-field projection schema, merged-status validation, duplicate-unit-id fail-closed, no implicit merged resurrection, atomic write only under `logs/roadmap_unit_status/`, full `--no-write` / `--status` / `--indent` CLI surface. Bootstrap seed pins the three v3.15.16 routing-layer merged units (PR #250 / #252 / #254) with verified PR numbers + merge SHAs.
- `tests/unit/test_roadmap_unit_status.py` (new) — 61 tests pinning vocabularies, schema, validation, duplicate detection, determinism, atomic-write allowlist, CLI surfaces, and module-source forbidden-import / forbidden-token scans.
- `docs/governance/step5_bounded_autonomous_loop.md` (new) — governance doc: hard permanent constraints carried into every future Step 5 slice, the two surfaces shipped today, the stop-condition matrix (4 categories) the future loop must honour, the `max_units_per_run = 1` default design, the bootstrap status records, and the authority pins.
- `reporting/roadmap_next_unit.py` (modified) — A20e selector now reads the optional A21a artefact. Adds two new block reasons (`invalid_dynamic_status`, `dynamic_status_terminal`), one new closed-vocab (`NEXT_UNIT_DYNAMIC_STATUS_SOURCE`), three new candidate fields (`effective_status`, `dynamic_status_source`, `source_status_artifact`), one new projection field (`source_status_schema_version`), and six new selector invariants. Prerequisite check now satisfied when prereq effective status is `merged` via either the A20b static seed or a valid A21a record.
- `tests/unit/test_roadmap_next_unit.py` (modified) — 15 new tests cover dynamic merged excludes unit; dynamic absent falls back to static; invalid dynamic fails closed; unknown dynamic status fails closed; `pr_open` / `in_progress` / `failed` all block; dynamic `merged` satisfies prerequisite; the three v3.15.16 bootstrap units are never reselected; malformed ledger artefact fails closed with `UPSTREAM_UNAVAILABLE`; static `status` field is preserved verbatim alongside `effective_status`; widened pin tests for the vocab / schema / import-allowlist changes.
- `docs/governance/roadmap_task_catalog.md` (modified) — header now lists A21a alongside A20a-A20e; section 11.1 retained as "legacy A20b seed-edit path"; new section 11.2 "Queue progression log (A21a dynamic ledger path)" records the three v3.15.16 routing-layer units with PR #250 / #252 / #254 + merge SHAs, sourced from the A21a ledger.

## Stop-condition matrix (future Step 5 loop contract — not implemented today)

See `docs/governance/step5_bounded_autonomous_loop.md` section 4. Four categories:

- **Selection-level:** not `AUTO_ALLOWED` / risk not `LOW` / gate not `none` / missing `expected_files` / `forbidden_files` / `required_tests` / ambiguous selector result / repeat selection of same unit_id / unknown enum value.
- **Implementation-level:** diff touches `forbidden_files`; diff exceeds `expected_files`; any `live/**` / `paper/**` / `shadow/**` / `broker/**` / `agent/risk/**` / `agent/execution/**` / `automation/live_gate.py` / `dashboard/dashboard.py` / `.claude/**` / `.github/**` / frozen-contract / canonical-roadmap path appears in diff; local tests fail; governance lint fails; hook blocks commit/push; merge conflict.
- **CI-level:** any required check fails (lint / secret-scan / typecheck / unit / regression-fast / hook-tests / frontend / governance-lint); mergeability not `CLEAN`; post-merge gates fail (Build & Push Docker Image / Deploy VPS Dashboard).
- **Ledger-level:** atomic-write allowlist rejects path; duplicate `unit_id` in ledger; A21a `fail_closed = true`.

Plus bound: `max_units_per_run` reached (proposed default = 1; cap = 5 without ADR amendment).

When any condition fires, the future loop must: stop immediately; emit a deterministic stop report under `logs/step5_loop/`; surface non-zero exit; never escalate, never `--admin`, never force-push, never bypass hooks.

## Status transition rules (advisory; selector enforces buildable filter on its own)

`not_started -> in_progress`; `in_progress -> pr_open`; `pr_open -> merged`; `pr_open -> failed`; `in_progress -> failed`; `not_started -> blocked`; `not_started -> skipped`; `failed -> blocked`. `blocked`, `skipped`, `merged` are terminal unless an explicit operator-override record is appended. **No implicit resurrection of merged units** — duplicate records for the same unit_id fail closed.

## Validation commands and results

All run locally before push:

- `python -m pytest tests/unit/test_roadmap_unit_status.py -v` — **61 passed**.
- `python -m pytest tests/unit/test_roadmap_next_unit.py -v` — **88 passed** (73 pre-existing + 15 new dynamic-overlay tests).
- `python -m pytest tests/unit/test_roadmap_task_units.py tests/unit/test_roadmap_unit_authority.py -v` — passed (within the 332-test combined run).
- Combined roadmap-pipeline run: **332 passed**.
- `python -m pytest tests/smoke -v` — **18 passed**.
- `python -m pytest tests/regression/test_public_output_contract.py tests/regression/test_v12_contracts_preserved.py tests/regression/test_authority_invariants.py -v` — **16 passed**.
- `python scripts/governance_lint.py` — `Governance lint OK (16 agents, 5 workflows checked).`

## End-to-end verification

With the A21a artefact written under `logs/roadmap_unit_status/latest.json`, the A20e selector now correctly recommends `u_v3_15_17_sampling_plan_reporter_001` (next phase v3.15.17 unit), skipping all three already-merged v3.15.16 routing-layer units, **without** editing `reporting/roadmap_task_units.py`'s `_UNIT_SEED`. The three v3.15.16 candidates appear with `eligibility = BLOCKED` and `effective_status = merged`. This is the design's primary acceptance criterion.

## Frozen-contract verdict

PASS. No mutation of `research/research_latest.json`, no mutation of `research/strategy_matrix.csv`, no mutation of any frozen schema under `artifacts/`. `regression-fast (determinism pins)` checks pass locally.

## Forbidden-path verdict

PASS. Diff touches **only** these 6 allowed files:

- `docs/governance/step5_bounded_autonomous_loop.md` (new)
- `reporting/roadmap_unit_status.py` (new)
- `tests/unit/test_roadmap_unit_status.py` (new)
- `reporting/roadmap_next_unit.py` (modified — allowed)
- `tests/unit/test_roadmap_next_unit.py` (modified — allowed)
- `docs/governance/roadmap_task_catalog.md` (modified — allowed)

**None** of the no-touch paths changed: not `dashboard/dashboard.py`, not `.claude/**`, not `.github/**`, not `research/research_latest.json`, not `research/strategy_matrix.csv`, not `automation/live_gate.py`, not `broker/**`, not `agent/risk/**`, not `agent/execution/**`, not `live/**`, not `paper/**`, not `shadow/**`, not `trading/**`, not `docs/roadmap/Roadmap v6.md`, not `docs/roadmap/Roadmap v6 Addendum.md`, not `docs/roadmap/autonomous_development.txt`, not `docs/governance/execution_authority.md`, not `docs/governance/no_touch_paths.md`, not `reporting/execution_authority.py`, not `reporting/development_queue_admission_policy.py`, not `docs/development_work_queue/*.jsonl`, not `tests/regression/**`.

## Statement of constraints honoured

- **Step 5 foundation only.** No actual implementation loop. No branch / PR / merge / deploy automation in this PR.
- **Manual per-unit status PRs replaced by dynamic ledger design.** The `chore/a20-mark-*-merged` PR pattern is now obsolete.
- **No runtime / trading / paper / shadow / live authority is granted.** Every authority pin in the spec is asserted in the projection ledger_invariants and selector_invariants blocks.
- **No mutation routes, no approval buttons.**
- **No .claude path change, no dashboard/dashboard.py change, no docs/development_work_queue/*.jsonl change.**
- **`step5_implementation_allowed` remains `Final[bool] = False`** in every A21 / A20 module.

## Test plan

- [ ] CI completes green on this branch (lint, secret-scan, typecheck, unit, regression-fast, hook-tests, frontend, governance-lint).
- [ ] No frozen-contract regression test newly fails.
- [ ] No governance-lint regression.
- [ ] No new agent-allowlist surfaces appear.

## Next recommended PR

**Step5c / A21c — bounded dry-run autonomous loop slice.** Invokes A20e to read the next selected unit, validates the eight selection-level stop conditions in section 4.1, prints a deterministic dry-run plan naming the unit + expected files + forbidden files + required tests, writes a dry-run report under `logs/step5_loop/dry_run/`. **Does not** create a branch, **does not** edit any file, **does not** open a PR, **does not** merge, **does not** deploy. A21c merge remains blocked behind operator-explicit authorisation and an updated A20b seed entry listing it as an eligible unit.