### PR TITLE
feat(step5)(a21c): bounded autonomous PR runner for one safe unit

### DIFF
--- a/docs/governance/roadmap_task_catalog.md
+++ b/docs/governance/roadmap_task_catalog.md
@@ -1,11 +1,14 @@
-# Roadmap Task Catalog — A20a + A20b + A20c + A20d + A20e + A21a (read-only, deterministic)
+# Roadmap Task Catalog — A20a + A20b + A20c + A20d + A20e + A21a + A21c
 
 > **Status:** A20a implemented; A20b implemented; A20c implemented;
 > A20d implemented; A20e implemented (deterministic next-buildable-unit
 > selector); A21a implemented (dynamic unit-status ledger,
-> Step 5 foundation). All six stages are read-only projections;
-> none mutates anything; the selector never executes work, opens
-> branches / PRs, merges, or deploys.
+> Step 5 foundation); A21c implemented (bounded autonomous PR
+> runner for ONE AUTO_ALLOWED + LOW-risk + gate=none unit; no
+> auto-merge, no deploy). Stages A20a-A21a are read-only
+> projections. A21c executes a bounded PR-creation slice when
+> the operator explicitly invokes ``--run-one`` with a configured
+> implementation strategy; otherwise it is read-only.
 >
 > **A20a module:** [`reporting/roadmap_task_catalog.py`](../../reporting/roadmap_task_catalog.py)
 > **A20a artefact:** `logs/roadmap_task_catalog/latest.json`
@@ -25,6 +28,11 @@
 > **A21a module:** [`reporting/roadmap_unit_status.py`](../../reporting/roadmap_unit_status.py)
 > **A21a artefact:** `logs/roadmap_unit_status/latest.json`
 > **A21a governance:** [`docs/governance/step5_bounded_autonomous_loop.md`](step5_bounded_autonomous_loop.md)
+>
+> **A21c module:** [`reporting/autonomous_pr_runner.py`](../../reporting/autonomous_pr_runner.py)
+> **A21c artefact:** `logs/autonomous_pr_runner/latest.json`
+> **A21c governance:** [`docs/governance/step5_bounded_autonomous_loop.md`](step5_bounded_autonomous_loop.md) §11
+> A21c is the **first real Step 5 execution slice** — it creates a real branch + PR for ONE selected safe unit. No auto-merge, no deploy, no second-unit continuation.
 >
 > **Authority:** development-governance read-only.
 > The roadmap task catalog is **not** the canonical product roadmap.

--- a/docs/governance/step5_bounded_autonomous_loop.md
+++ b/docs/governance/step5_bounded_autonomous_loop.md
@@ -1,25 +1,31 @@
-# Step 5 — Bounded Autonomous Implementation Loop (Foundation)
+# Step 5 — Bounded Autonomous Implementation Loop
 
-> **Status:** Step 5 implementation remains **BLOCKED**.
+> **Status:** Step 5 broad implementation remains **BLOCKED**.
 > Autonomy-ladder Level 6 remains **permanently disabled** per
 > ADR-015 §Doctrine 1. N5b Phase 4 production-merge authority
-> remains **permanently denied for ADE**.
+> remains **permanently denied for ADE**. The A21c **bounded
+> PR-creation slice** is the only carve-out, and is itself
+> bounded (max 1 unit per run, no auto-merge, no deploy, no
+> NEEDS_HUMAN, no MEDIUM/HIGH/CRITICAL risk).
 >
-> This document specifies the **foundation** for the future
-> bounded autonomous implementation loop. The foundation lives in
-> [`reporting/roadmap_unit_status.py`](../../reporting/roadmap_unit_status.py)
-> (the **A21a dynamic unit-status ledger**) and the matching A20e
-> selector overlay in
-> [`reporting/roadmap_next_unit.py`](../../reporting/roadmap_next_unit.py).
-> The actual loop (branch / implement / PR / merge / deploy) is
-> **not implemented in this PR**.
+> The Step 5 implementation surface today consists of:
 >
-> **Phase:** Step 5 / A21 foundation. Each future slice (A21b,
-> A21c, …) ships its own governance section in this doc plus its
-> own implementation PR.
-> **Authority class on this PR:** `AUTO_ALLOWED` (LOW risk,
-> `operator_gate = none`, read-only deterministic projections +
-> documentation).
+> * **A21a** — dynamic unit-status ledger in
+>   [`reporting/roadmap_unit_status.py`](../../reporting/roadmap_unit_status.py)
+>   (foundation: replaces manual seed-edit PRs).
+> * **A20e overlay** — selector consumes A21a in
+>   [`reporting/roadmap_next_unit.py`](../../reporting/roadmap_next_unit.py)
+>   (foundation: skips dynamically-merged units).
+> * **A21c** — bounded autonomous PR runner in
+>   [`reporting/autonomous_pr_runner.py`](../../reporting/autonomous_pr_runner.py)
+>   (real branch + commit + push + PR creation for ONE safe unit;
+>   no auto-merge, no deploy).
+>
+> **Phase:** Step 5 / A21 family. Each slice ships its own
+> governance section in this doc plus its own implementation PR.
+> **Authority class on every slice so far:** `AUTO_ALLOWED` (LOW
+> risk, `operator_gate = none`, deterministic projections or
+> bounded-execution code).
 
 ---
 
@@ -473,20 +479,278 @@ Pinned in
 * [`docs/governance/ade_development_lane_doctrine.md`](ade_development_lane_doctrine.md)
   — ADE remains development workflow automation only.
 
-## 11. Next recommended PR
+## 11. A21c — Bounded Autonomous PR Runner
 
-A21b — bounded **dry-run** autonomous loop slice that:
+[`reporting/autonomous_pr_runner.py`](../../reporting/autonomous_pr_runner.py)
+is the **first real Step 5 execution surface**. It takes exactly
+ONE A20e-selected unit, validates a closed set of safety gates,
+creates one branch, invokes a pluggable implementation strategy,
+verifies the resulting git diff is contained within the unit's
+`expected_files`, runs required tests + smoke + governance lint,
+commits, pushes, opens a PR, watches CI to first verdict, and
+stops with a deterministic run report at
+`logs/autonomous_pr_runner/latest.json`.
 
-* invokes A20e to read the next selected unit;
-* validates the eight selection-level stop conditions in §4.1;
-* prints a deterministic dry-run plan to stdout naming the unit,
-  the expected files, the forbidden files, and the required
-  tests;
-* writes a dry-run report under `logs/step5_loop/dry_run/`;
-* **does not** create a branch, **does not** edit any file,
-  **does not** open a PR, **does not** merge, **does not**
-  deploy.
+### 11.1 Hard boundaries (A21c)
 
-A21b is the next safe step toward bounded autonomy. Its merge
-remains blocked behind operator-explicit authorisation and an
-updated A20b seed entry that lists it as an eligible unit.
+A21c does **not**:
+
+* squash-merge — the PR remains operator-driven to merge;
+* use `--admin` — `--admin` does not appear in any shell-call
+  argument list in the module code;
+* force-push — `--force` does not appear in any shell-call
+  argument list;
+* bypass hooks — `--no-verify` / `--no-gpg-sign` do not appear;
+* delete the branch after merge — the runner exits before merge;
+* deploy anything — no `Build & Push Docker Image` invocation,
+  no `Deploy VPS Dashboard` invocation, no `docker push`, no
+  `ssh root@`;
+* update the dynamic unit-status ledger to `merged` — A21a
+  remains seed-driven; A21c emits its OWN report at
+  `logs/autonomous_pr_runner/latest.json`;
+* continue to a second unit — `max_units_per_run` is hard-capped
+  at 1;
+* touch any forbidden path — every safety gate refusal lists the
+  full no-touch surface (see §11.4 below);
+* mutate any approval inbox, mutation route, or approval button;
+* grant runtime / trading / paper / shadow / live authority;
+* call any LLM, external API, or hidden judgment on its own —
+  the only LLM / external surface is opt-in through
+  `--implementation-strategy external_command
+  --implementation-command "<operator-supplied command>"`.
+
+### 11.2 Import-safety contract
+
+The module is **safe to import**. No subprocess is invoked on
+import, no git / gh / network call is made on import, no file
+write happens on import. The `subprocess` module is imported
+**lazily** inside the real shell-runner factory so the top-level
+`import reporting.autonomous_pr_runner` is fully side-effect free.
+This is pinned by a module-source AST scan in
+[`tests/unit/test_autonomous_pr_runner.py`](../../tests/unit/test_autonomous_pr_runner.py).
+
+### 11.3 Closed vocabularies (pinned by tests)
+
+* `RUN_STATUS` (13 values): `not_run`, `status_only`, `plan_only`,
+  `refused_unsafe`, `executed_pr_opened`,
+  `executed_blocked_at_implementation`,
+  `executed_blocked_at_diff`, `executed_blocked_at_tests`,
+  `executed_blocked_at_governance_lint`,
+  `executed_blocked_at_commit`, `executed_blocked_at_push`,
+  `executed_blocked_at_pr_create`, `executed_blocked_at_ci`.
+* `SAFETY_GATE` (14 values): `selector_available`,
+  `selection_status_ok`, `unit_present`,
+  `auto_allowed_authority`, `low_risk`, `no_operator_gate`,
+  `no_operator_go_required`, `expected_files_nonempty`,
+  `forbidden_files_nonempty`, `required_tests_nonempty`,
+  `no_forbidden_in_expected`, `not_terminal_status`,
+  `max_units_per_run_one`, `implementation_strategy_configured`.
+* `GATE_RESULT` (3 values): `PASS`, `FAIL`, `NOT_CHECKED`.
+* `RUNNER_MODE` (3 values): `status_only`, `plan_only`, `run_one`.
+* `IMPLEMENTATION_STRATEGY` (2 values): `none` (default,
+  refuses), `external_command` (operator opts in).
+* `STOP_REASON` (33 values): one closed-vocab reason per stop
+  condition listed in §4.
+
+### 11.4 Forbidden-path patterns (no-touch list)
+
+Every entry of `FORBIDDEN_PATH_PATTERNS` is checked twice:
+
+1. **Pre-execution:** the selected unit's `expected_files` is
+   scanned. Any match refuses the run at the
+   `no_forbidden_in_expected` gate with stop reason
+   `forbidden_path_in_expected_files`.
+2. **Post-implementation:** the git diff after the implementation
+   strategy is scanned. Any match refuses the run at the
+   diff-scope check with stop reason
+   `diff_touches_forbidden_path`. The runner does NOT commit.
+
+Pinned no-touch patterns: `.claude/`, `.github/`,
+`dashboard/dashboard.py`, `automation/live_gate.py`, `broker/`,
+`agent/risk/`, `agent/execution/`, `live/`, `paper/`, `shadow/`,
+`trading/`, `docs/roadmap/Roadmap v6.md`,
+`docs/roadmap/Roadmap v6 Addendum.md`,
+`docs/roadmap/autonomous_development.txt`,
+`docs/governance/execution_authority.md`,
+`docs/governance/no_touch_paths.md`,
+`reporting/execution_authority.py`,
+`reporting/development_queue_admission_policy.py`,
+`docs/development_work_queue/`, `tests/regression/`,
+`research/research_latest.json`, `research/strategy_matrix.csv`,
+`artifacts/`.
+
+### 11.5 Implementation strategy injection
+
+The runner exposes a `ImplementationStrategy` Protocol with one
+method:
+
+```python
+def invoke(
+    unit: dict[str, Any],
+    *,
+    repo_root: Path,
+    shell: ShellRunner,
+) -> ImplementationResult: ...
+```
+
+A21c ships **two** concrete strategies:
+
+* **`none`** — the default. Refuses to run; the runner stops at
+  the `implementation_strategy_configured` gate with stop reason
+  `implementation_strategy_not_configured`. This is the safe
+  default: bare `--run-one` does not act.
+* **`external_command`** — the operator opts in via
+  `--implementation-strategy external_command
+  --implementation-command "<command>"`. The command is parsed
+  via `shlex.split` and invoked through the injected shell
+  runner. The command is expected to mutate the filesystem under
+  the repo root in a way that satisfies the unit's
+  `expected_files` contract. The runner does not interpret the
+  command output; it only checks the exit code and the resulting
+  diff.
+
+Tests inject a `FakeImplementationStrategy` directly via the
+`implementation_strategy=` keyword argument to `run_one(...)`. No
+real shell command is invoked by unit tests.
+
+### 11.6 CLI
+
+```sh
+# Safe default — status snapshot only:
+python -m reporting.autonomous_pr_runner --status
+
+# Plan-only — evaluate every safety gate against the current
+# A20e recommendation but execute nothing:
+python -m reporting.autonomous_pr_runner --plan-only
+
+# Real execution (requires explicit operator strategy choice):
+python -m reporting.autonomous_pr_runner \
+    --run-one --max-units 1 \
+    --implementation-strategy external_command \
+    --implementation-command "<operator-supplied real command>"
+```
+
+The runner refuses `--max-units > 1` (A21c hard cap = 1) and
+refuses `--implementation-strategy none` even when `--run-one` is
+passed.
+
+### 11.7 Authority pins (every emitted report)
+
+Every report carries a `runner_invariants` block with these pins:
+
+* `step5_implementation_allowed = false` (broad Step 5 stays
+  BLOCKED; A21c carves out a bounded slice via
+  `step5_enabled_substage = "a21c_bounded_pr_creation"`);
+* `bounded_step5_pr_creation_only = true`;
+* `max_units_per_run_hard_capped_at_one = true`;
+* `import_is_side_effect_free = true`;
+* `subprocess_module_used_only_inside_run_one = true`;
+* `uses_subprocess_outside_run_one = false`;
+* `uses_network = false`;
+* `calls_llm_or_external_api = false`;
+* `calls_execution_authority_classifier = false`;
+* `no_runtime_trading_authority = true`;
+* `no_step5_broad = true`;
+* `no_level6 = true`;
+* `no_production_merge_authority = true`;
+* `no_auto_merge = true`;
+* `no_admin_merge = true`;
+* `no_force_push = true`;
+* `no_hook_bypass = true`;
+* `no_deploy = true`;
+* `no_deploy_watcher = true`;
+* `no_ledger_mutation = true`;
+* `no_second_unit_continuation = true`;
+* `no_branch_creation_outside_run_one = true`;
+* `no_pr_creation_outside_run_one = true`;
+* `no_mutation_routes = true`;
+* `no_approval_buttons = true`;
+* `no_approval_inbox_mutation = true`;
+* `no_test_weakening = true`;
+* `writes_only_autonomous_pr_runner_log = true`;
+* `writes_to_dynamic_status_ledger = false`;
+* `fail_closed_on_unsafe_unit = true`;
+* `fail_closed_on_diff_outside_expected_files = true`;
+* `fail_closed_on_forbidden_diff_path = true`;
+* `fail_closed_on_test_failure = true`;
+* `fail_closed_on_governance_lint_failure = true`;
+* `fail_closed_on_ci_failure = true`.
+
+### 11.8 Test coverage
+
+Pinned in
+[`tests/unit/test_autonomous_pr_runner.py`](../../tests/unit/test_autonomous_pr_runner.py)
+(114 tests):
+
+* import is side-effect free; `subprocess` is NOT at module top;
+* closed vocabularies (5 of them) and schema field tuple are
+  pinned exactly;
+* every gate-failure path produces the correct closed-vocab stop
+  reason;
+* NEEDS_HUMAN / PERMANENTLY_DENIED authority refused;
+* MEDIUM / HIGH / CRITICAL / UNKNOWN risk refused;
+* non-`none` operator gate refused;
+* `requires_operator_go = True` refused;
+* missing `expected_files` / `forbidden_files` / `required_tests`
+  refused;
+* every no-touch path in `expected_files` refused (17
+  parametrised cases);
+* terminal static status (`merged` / `blocked` / `skipped` /
+  `failed`) refused;
+* `max_units > 1` refused (5 parametrised cases);
+* default `implementation_strategy = "none"` refused;
+* diff outside `expected_files` refused;
+* diff touching a forbidden path refused;
+* empty diff refused;
+* required-tests failure surfaces `tests_failed`;
+* governance-lint failure surfaces `governance_lint_failed`;
+* implementation-strategy failure surfaces
+  `implementation_strategy_failed`;
+* branch-creation failure / branch-already-exists / push failure /
+  PR-create failure / CI failure / CI timeout each surface the
+  correct closed-vocab stop reason;
+* no auto-merge invocation appears in module code (AST-stripped
+  scan); no `--admin` argument list; no `--force` / `--no-verify`;
+  no deploy invocation;
+* injectable fakes for shell + implementation strategy; no real
+  git / gh / subprocess invoked by unit tests;
+* every `runner_invariants` pin asserted on every emitted report.
+
+### 11.9 Bootstrap selection on merged main
+
+When PR #255 (A21a / A20e overlay) merged, the A20e selector
+recommended `u_v3_15_17_sampling_plan_reporter_001` as the next
+eligible unit. The A21c runner, once merged and invoked with an
+operator-supplied implementation command, will create branch
+`step5-a21c/u_v3_15_17_sampling_plan_reporter_001` and attempt the
+sampling-plan reporter unit. The runner does NOT pre-pick another
+unit, does NOT escalate, and does NOT continue past one PR.
+
+### 11.10 Future Step 5 slices
+
+After A21c lands, the natural next slices are:
+
+* **A21d** — bounded auto-merge for **PRs the runner itself
+  opened**, plus a post-merge status-update step that appends a
+  `merged` record to A21a's `_STATUS_LEDGER_SEED`. Hard-capped at
+  PRs originated by the runner; never enabled for human-opened
+  PRs. Squash-merge only; no `--admin`; no force-push; no hook
+  bypass; CI-green required.
+* **A21e** — bounded post-merge deploy watcher that observes
+  `Build & Push Docker Image` + `Deploy VPS Dashboard` runs on
+  the merge commit and reports their outcome. Read-only: never
+  triggers a deploy, never re-runs a deploy, never modifies any
+  deploy workflow.
+
+Each future slice gets its own governance section in this doc and
+its own operator-approved PR.
+
+## 12. Next recommended PR
+
+**A21d — bounded auto-merge for runner-originated PRs.** Adds
+the post-PR merge step the operator currently performs manually,
+plus the A21a ledger update that flips the unit to `merged`.
+Hard-capped: only PRs the runner itself originated; only after
+CI-green; squash-merge only; no `--admin`; no force-push; no hook
+bypass; max 1 merge per run. The deploy watcher (A21e) remains a
+separate later slice.

--- a/reporting/autonomous_pr_runner.py
+++ b/reporting/autonomous_pr_runner.py
@@ -1,0 +1,1748 @@
+"""A21c -- Bounded Autonomous PR Runner (Step 5 / A21c slice).
+
+Takes exactly ONE A20e-selected unit from the queue, validates a
+closed set of safety gates, creates one branch, invokes a
+pluggable implementation strategy, verifies the resulting git diff
+is contained within the unit's ``expected_files``, runs the unit's
+required tests plus smoke and governance lint, commits, pushes,
+opens a PR, watches CI to first verdict, and stops with a
+deterministic run report at
+``logs/autonomous_pr_runner/latest.json``.
+
+The runner is the **first concrete Step 5 slice**. It is bounded:
+
+* exactly one unit per invocation (``max_units_per_run = 1``);
+* AUTO_ALLOWED + LOW risk + ``operator_gate = none`` only;
+* no auto-merge, no production-merge authority;
+* no deploy, no deploy watcher;
+* no ledger mutation (the dynamic unit-status ledger remains
+  seed-driven; runner emits its OWN report, separate from the
+  ledger);
+* no second-unit continuation; the runner stops after one PR;
+* no ``--admin``, no force-push, no hook bypass;
+* no LLM, no external API calls except via the explicit
+  ``external_command`` implementation strategy that the operator
+  opts into via CLI flag.
+
+Hard guarantees (pinned by tests):
+
+* **Safe to import.** Stdlib + (read-only) consumer of A20b /
+  A20e / A21a. No subprocess invocation on import, no git, no gh,
+  no file writes, no network. The ``subprocess`` module is
+  imported lazily inside the real shell runner factory so the
+  module-level ``import reporting.autonomous_pr_runner`` is
+  side-effect free.
+* **Default CLI behaviour is safe.** ``--status`` and
+  ``--plan-only`` never invoke git / gh / subprocess and never
+  write anything outside ``logs/autonomous_pr_runner/``.
+* **Tests inject fakes for shell / git / gh and the
+  implementation strategy.** No real branch, commit, push, PR,
+  merge, or deploy is ever performed by unit tests.
+* **Fail-closed on every safety-gate failure.** Closed
+  ``STOP_REASON`` vocab; closed ``SAFETY_GATE`` vocab; closed
+  ``GATE_RESULT`` vocab; closed ``RUN_STATUS`` vocab; closed
+  ``RUNNER_MODE`` vocab; closed ``IMPLEMENTATION_STRATEGY``
+  vocab. Widening any requires a code + test change.
+* **Bounded slice.** ``max_units_per_run > 1`` is rejected;
+  ``--implementation-strategy none`` (the default) refuses to
+  execute and reports
+  ``implementation_strategy_not_configured``; auto-merge / deploy
+  paths do not exist in the module source (asserted by tests
+  scanning the module text for forbidden tokens).
+
+CLI::
+
+    # Inspection-only (default; no execution, no writes outside
+    # logs/autonomous_pr_runner/):
+    python -m reporting.autonomous_pr_runner --status
+    python -m reporting.autonomous_pr_runner --plan-only
+    python -m reporting.autonomous_pr_runner --no-write
+
+    # Real execution (requires explicit operator strategy choice):
+    python -m reporting.autonomous_pr_runner \\
+        --run-one --max-units 1 \\
+        --implementation-strategy external_command \\
+        --implementation-command "<operator-provided real command>"
+
+The runner DOES NOT:
+
+* squash-merge;
+* use ``--admin``;
+* force-push;
+* bypass hooks;
+* delete the branch after merge;
+* deploy anything;
+* update the dynamic unit-status ledger to merged;
+* continue to a second unit;
+* touch any forbidden path;
+* mutate any approval inbox, mutation route, or approval button;
+* grant runtime / trading / paper / shadow / live authority;
+* call any LLM, external API, or hidden judgment on its own;
+* activate Step 5 broadly (this slice is the bounded carve-out)
+  or Level 6 (permanently disabled per ADR-015) or relax any
+  branch-protection invariant.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime as _dt
+import json
+import os
+import shlex
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Callable, Final, Protocol
+
+from reporting import roadmap_next_unit as rnu
+from reporting import roadmap_task_units as rtu
+from reporting import roadmap_unit_status as rus
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[str] = "1.0"
+MODULE_VERSION: Final[str] = "v3.15.16.A21c"
+REPORT_KIND: Final[str] = "autonomous_pr_runner"
+
+
+# ---------------------------------------------------------------------------
+# Step 5 + Level 6 invariants (Final constants; never flipped at runtime)
+# ---------------------------------------------------------------------------
+
+#: The A21c slice carves out a bounded PR-creation slice of Step 5.
+#: The broad Step 5 lock remains BLOCKED everywhere else.
+STEP5_ENABLED_SUBSTAGE: Final[str] = "a21c_bounded_pr_creation"
+step5_implementation_allowed: Final[bool] = False
+
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies
+# ---------------------------------------------------------------------------
+
+#: Top-level runner status. Exactly one value per run.
+RUN_STATUS: Final[tuple[str, ...]] = (
+    "not_run",
+    "status_only",
+    "plan_only",
+    "refused_unsafe",
+    "executed_pr_opened",
+    "executed_blocked_at_implementation",
+    "executed_blocked_at_diff",
+    "executed_blocked_at_tests",
+    "executed_blocked_at_governance_lint",
+    "executed_blocked_at_commit",
+    "executed_blocked_at_push",
+    "executed_blocked_at_pr_create",
+    "executed_blocked_at_ci",
+)
+
+#: Closed per-run stop-reason vocabulary. Exactly one value per run.
+STOP_REASON: Final[tuple[str, ...]] = (
+    "status_only_mode",
+    "plan_only_mode",
+    "selector_unavailable",
+    "no_eligible_unit",
+    "ambiguous_selection",
+    "unsafe_authority_class",
+    "unsafe_risk_class",
+    "unsafe_operator_gate",
+    "requires_operator_go",
+    "missing_expected_files",
+    "missing_forbidden_files",
+    "missing_required_tests",
+    "forbidden_path_in_expected_files",
+    "terminal_status",
+    "max_units_exceeded",
+    "implementation_strategy_not_configured",
+    "implementation_strategy_failed",
+    "diff_outside_expected_files",
+    "diff_touches_forbidden_path",
+    "diff_empty",
+    "tests_failed",
+    "governance_lint_failed",
+    "commit_failed",
+    "hook_failed",
+    "branch_creation_failed",
+    "branch_already_exists",
+    "push_failed",
+    "pr_creation_failed",
+    "ci_failed",
+    "ci_timeout",
+    "ci_not_clean",
+    "unknown_evidence",
+    "ok_pr_opened",
+)
+
+#: Closed safety-gate vocabulary. Each gate evaluates PASS / FAIL.
+SAFETY_GATE: Final[tuple[str, ...]] = (
+    "selector_available",
+    "selection_status_ok",
+    "unit_present",
+    "auto_allowed_authority",
+    "low_risk",
+    "no_operator_gate",
+    "no_operator_go_required",
+    "expected_files_nonempty",
+    "forbidden_files_nonempty",
+    "required_tests_nonempty",
+    "no_forbidden_in_expected",
+    "not_terminal_status",
+    "max_units_per_run_one",
+    "implementation_strategy_configured",
+)
+
+#: Closed gate-result vocabulary.
+GATE_RESULT: Final[tuple[str, ...]] = ("PASS", "FAIL", "NOT_CHECKED")
+
+#: Closed runner-mode vocabulary.
+RUNNER_MODE: Final[tuple[str, ...]] = ("status_only", "plan_only", "run_one")
+
+#: Closed implementation-strategy vocabulary. ``none`` is the default
+#: and refuses to execute. ``external_command`` shells out to an
+#: operator-supplied command via ``--implementation-command``.
+IMPLEMENTATION_STRATEGY: Final[tuple[str, ...]] = (
+    "none",
+    "external_command",
+)
+
+
+# ---------------------------------------------------------------------------
+# Forbidden-path patterns (no-touch list). Any expected_files entry
+# matching these refuses the run at the no_forbidden_in_expected gate.
+# Any diff path matching these refuses the run at the diff-scope check.
+# Patterns match by ``startswith`` after normalising to POSIX.
+# ---------------------------------------------------------------------------
+
+FORBIDDEN_PATH_PATTERNS: Final[tuple[str, ...]] = (
+    ".claude/",
+    ".github/",
+    "dashboard/dashboard.py",
+    "automation/live_gate.py",
+    "broker/",
+    "agent/risk/",
+    "agent/execution/",
+    "live/",
+    "paper/",
+    "shadow/",
+    "trading/",
+    "docs/roadmap/Roadmap v6.md",
+    "docs/roadmap/Roadmap v6 Addendum.md",
+    "docs/roadmap/autonomous_development.txt",
+    "docs/governance/execution_authority.md",
+    "docs/governance/no_touch_paths.md",
+    "reporting/execution_authority.py",
+    "reporting/development_queue_admission_policy.py",
+    "docs/development_work_queue/",
+    "tests/regression/",
+    "research/research_latest.json",
+    "research/strategy_matrix.csv",
+    "artifacts/",
+)
+
+
+# ---------------------------------------------------------------------------
+# Schema field tuples (exact, ordered)
+# ---------------------------------------------------------------------------
+
+SAFETY_GATE_RESULT_FIELDS: Final[tuple[str, ...]] = (
+    "gate",
+    "result",
+    "detail",
+)
+
+COMMAND_RUN_FIELDS: Final[tuple[str, ...]] = (
+    "command",
+    "exit_code",
+    "duration_ms",
+    "stdout_excerpt",
+    "stderr_excerpt",
+)
+
+RUNNER_REPORT_FIELDS: Final[tuple[str, ...]] = (
+    "schema_version",
+    "module_version",
+    "report_kind",
+    "generated_at_utc",
+    "mode",
+    "max_units_per_run",
+    "implementation_strategy",
+    "selected_unit_id",
+    "selected_phase",
+    "selected_authority_class",
+    "selected_risk_class",
+    "selected_operator_gate",
+    "branch_name",
+    "safety_gate_results",
+    "commands_run",
+    "files_changed",
+    "tests_run",
+    "pr_number",
+    "ci_status",
+    "stop_reason",
+    "final_runner_status",
+    "next_required_operator_action",
+    "step5_enabled_substage",
+    "step5_implementation_allowed",
+    "runner_invariants",
+)
+
+
+# ---------------------------------------------------------------------------
+# Bounds
+# ---------------------------------------------------------------------------
+
+MAX_UNITS_PER_RUN_HARD_CAP: Final[int] = 1
+MAX_BRANCH_NAME_LEN: Final[int] = 200
+MAX_COMMAND_EXCERPT_LEN: Final[int] = 4000
+MAX_DETAIL_LEN: Final[int] = 240
+MAX_COMMANDS_RECORDED: Final[int] = 32
+MAX_FILES_CHANGED_RECORDED: Final[int] = 64
+MAX_TESTS_RECORDED: Final[int] = 64
+MAX_BRANCH_NAME_PREFIX_LEN: Final[int] = 64
+DEFAULT_COMMAND_TIMEOUT_SECONDS: Final[int] = 600
+DEFAULT_CI_WATCH_TIMEOUT_SECONDS: Final[int] = 1800
+
+
+# ---------------------------------------------------------------------------
+# Artefact paths
+# ---------------------------------------------------------------------------
+
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "autonomous_pr_runner"
+ARTIFACT_LATEST: Final[Path] = ARTIFACT_DIR / "latest.json"
+
+_WRITE_PREFIX: Final[str] = "logs/autonomous_pr_runner/"
+
+
+# ---------------------------------------------------------------------------
+# Runner invariants emitted on every report
+# ---------------------------------------------------------------------------
+
+_BASE_RUNNER_INVARIANTS: Final[dict[str, bool]] = {
+    "deterministic_evaluation": True,
+    "import_is_side_effect_free": True,
+    "subprocess_module_used_only_inside_run_one": True,
+    "no_runtime_trading_authority": True,
+    "no_step5_broad": True,
+    "no_level6": True,
+    "no_production_merge_authority": True,
+    "no_auto_merge": True,
+    "no_admin_merge": True,
+    "no_force_push": True,
+    "no_hook_bypass": True,
+    "no_deploy": True,
+    "no_deploy_watcher": True,
+    "no_ledger_mutation": True,
+    "no_second_unit_continuation": True,
+    "no_branch_creation_outside_run_one": True,
+    "no_pr_creation_outside_run_one": True,
+    "no_mutation_routes": True,
+    "no_approval_buttons": True,
+    "no_approval_inbox_mutation": True,
+    "no_test_weakening": True,
+    "writes_only_autonomous_pr_runner_log": True,
+    "writes_to_seed_jsonl": False,
+    "writes_to_delegation_seed_jsonl": False,
+    "writes_to_generated_seed_jsonl": False,
+    "writes_to_work_queue_jsonl": False,
+    "writes_to_dynamic_status_ledger": False,
+    "calls_llm_or_external_api": False,
+    "uses_network": False,
+    "uses_subprocess_outside_run_one": False,
+    "calls_execution_authority_classifier": False,
+    "bounded_step5_pr_creation_only": True,
+    "fail_closed_on_unsafe_unit": True,
+    "fail_closed_on_diff_outside_expected_files": True,
+    "fail_closed_on_forbidden_diff_path": True,
+    "fail_closed_on_test_failure": True,
+    "fail_closed_on_governance_lint_failure": True,
+    "fail_closed_on_ci_failure": True,
+    "fail_closed_on_unknown_evidence": True,
+    "step5_implementation_allowed": False,
+    "max_units_per_run_hard_capped_at_one": True,
+}
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses (deterministic typed records)
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class CommandResult:
+    """Result of a single shell command. Returned by ShellRunner."""
+
+    exit_code: int
+    stdout: str
+    stderr: str
+    duration_ms: int
+
+
+@dataclasses.dataclass(frozen=True)
+class ImplementationResult:
+    """Result of an implementation strategy invocation."""
+
+    success: bool
+    reason: str
+    files_changed: tuple[str, ...]
+
+
+# ---------------------------------------------------------------------------
+# Injectable interfaces (Protocols)
+# ---------------------------------------------------------------------------
+
+
+class ShellRunner(Protocol):
+    """Pluggable shell-command runner.
+
+    Concrete implementations: ``_RealShellRunner`` (uses
+    ``subprocess`` lazily; constructed only inside ``run_one``) and
+    test-injected fakes.
+    """
+
+    def run(
+        self,
+        args: list[str],
+        *,
+        cwd: Path | None = None,
+        timeout: int = DEFAULT_COMMAND_TIMEOUT_SECONDS,
+    ) -> CommandResult: ...
+
+
+class ImplementationStrategy(Protocol):
+    """Pluggable implementation strategy.
+
+    ``invoke(unit, repo_root)`` is expected to mutate the filesystem
+    under ``repo_root`` in a way that satisfies the unit's
+    ``expected_files`` contract. The default in-module strategies are
+    ``_NoneStrategy`` (refuses) and ``_ExternalCommandStrategy``
+    (shells out to a configured command).
+    """
+
+    def invoke(
+        self,
+        unit: dict[str, Any],
+        *,
+        repo_root: Path,
+        shell: ShellRunner,
+    ) -> ImplementationResult: ...
+
+
+# ---------------------------------------------------------------------------
+# Utility helpers
+# ---------------------------------------------------------------------------
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _bounded_str(value: Any, max_len: int) -> str:
+    if not isinstance(value, str):
+        return ""
+    if len(value) <= max_len:
+        return value
+    return value[:max_len]
+
+
+def _is_forbidden_path(path: str) -> bool:
+    posix = path.replace("\\", "/")
+    for pattern in FORBIDDEN_PATH_PATTERNS:
+        if pattern.endswith("/"):
+            if posix.startswith(pattern):
+                return True
+        else:
+            if posix == pattern:
+                return True
+    return False
+
+
+def _gate(name: str, result: str, detail: str = "") -> dict[str, Any]:
+    if name not in SAFETY_GATE:
+        raise ValueError(f"unknown safety gate: {name}")
+    if result not in GATE_RESULT:
+        raise ValueError(f"unknown gate result: {result}")
+    return {
+        "gate": name,
+        "result": result,
+        "detail": _bounded_str(detail, MAX_DETAIL_LEN),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Safety gate evaluation
+# ---------------------------------------------------------------------------
+
+
+def evaluate_safety_gates(
+    *,
+    selector_snapshot: dict[str, Any] | None,
+    unit: dict[str, Any] | None,
+    max_units: int,
+    implementation_strategy: str,
+) -> tuple[list[dict[str, Any]], str | None]:
+    """Run every safety gate. Return ``(results, first_failure_reason)``.
+
+    ``first_failure_reason`` is a closed-vocab STOP_REASON value or
+    ``None`` if every gate passed. Gates that depend on a previous
+    gate's pass are recorded as ``NOT_CHECKED`` if that previous gate
+    failed (defence in depth, no silent cascade).
+    """
+    results: list[dict[str, Any]] = []
+    fail: str | None = None
+
+    # selector_available
+    if selector_snapshot is None:
+        results.append(
+            _gate(
+                "selector_available",
+                "FAIL",
+                "no selector snapshot provided",
+            )
+        )
+        fail = "selector_unavailable"
+        for g in SAFETY_GATE:
+            if g != "selector_available":
+                results.append(_gate(g, "NOT_CHECKED", "blocked upstream"))
+        return results, fail
+    results.append(_gate("selector_available", "PASS", ""))
+
+    # selection_status_ok
+    #
+    # ``OK_SELECTED`` is the happy path. ``ALL_NEEDS_HUMAN_GATED``
+    # also names a specific selected unit (just one that needs
+    # operator-go); we let the per-authority gate catch that so the
+    # operator sees the more specific stop reason
+    # (``unsafe_authority_class`` / ``unsafe_operator_gate`` /
+    # ``requires_operator_go``). Any other status means the selector
+    # did not pick a single unit and we stop here.
+    sel = selector_snapshot.get("selection") or {}
+    sel_status = _bounded_str(sel.get("selection_status"), 64)
+    if sel_status not in {"OK_SELECTED", "ALL_NEEDS_HUMAN_GATED"}:
+        results.append(
+            _gate(
+                "selection_status_ok",
+                "FAIL",
+                f"selection_status={sel_status}",
+            )
+        )
+        if sel_status == "":
+            fail = "selector_unavailable"
+        elif sel_status in {"NO_ELIGIBLE_UNITS", "UPSTREAM_UNAVAILABLE"}:
+            fail = "no_eligible_unit"
+        else:
+            fail = "ambiguous_selection"
+        for g in SAFETY_GATE:
+            if g not in {"selector_available", "selection_status_ok"}:
+                results.append(_gate(g, "NOT_CHECKED", "blocked upstream"))
+        return results, fail
+    results.append(_gate("selection_status_ok", "PASS", ""))
+
+    # unit_present
+    if unit is None:
+        results.append(
+            _gate(
+                "unit_present",
+                "FAIL",
+                "selected unit not found in A20b decomposition",
+            )
+        )
+        fail = "no_eligible_unit"
+        for g in SAFETY_GATE:
+            if g not in {
+                "selector_available",
+                "selection_status_ok",
+                "unit_present",
+            }:
+                results.append(_gate(g, "NOT_CHECKED", "blocked upstream"))
+        return results, fail
+    results.append(_gate("unit_present", "PASS", ""))
+
+    # auto_allowed_authority
+    final_class = _bounded_str(sel.get("selected_authority_class"), 32)
+    if final_class != "AUTO_ALLOWED":
+        results.append(
+            _gate(
+                "auto_allowed_authority",
+                "FAIL",
+                f"authority_class={final_class}",
+            )
+        )
+        if fail is None:
+            fail = "unsafe_authority_class"
+    else:
+        results.append(_gate("auto_allowed_authority", "PASS", ""))
+
+    # low_risk
+    risk_class = _bounded_str(sel.get("selected_risk_class"), 16)
+    if risk_class != "LOW":
+        results.append(
+            _gate("low_risk", "FAIL", f"risk_class={risk_class}")
+        )
+        if fail is None:
+            fail = "unsafe_risk_class"
+    else:
+        results.append(_gate("low_risk", "PASS", ""))
+
+    # no_operator_gate
+    gate_val = _bounded_str(sel.get("selected_operator_gate"), 64)
+    if gate_val != "none":
+        results.append(
+            _gate(
+                "no_operator_gate",
+                "FAIL",
+                f"operator_gate={gate_val}",
+            )
+        )
+        if fail is None:
+            fail = "unsafe_operator_gate"
+    else:
+        results.append(_gate("no_operator_gate", "PASS", ""))
+
+    # no_operator_go_required
+    requires_go = bool(sel.get("requires_operator_go"))
+    if requires_go:
+        results.append(
+            _gate(
+                "no_operator_go_required",
+                "FAIL",
+                "requires_operator_go=True",
+            )
+        )
+        if fail is None:
+            fail = "requires_operator_go"
+    else:
+        results.append(_gate("no_operator_go_required", "PASS", ""))
+
+    # expected_files_nonempty
+    expected = unit.get("expected_files") or []
+    if not isinstance(expected, list) or not expected:
+        results.append(
+            _gate(
+                "expected_files_nonempty",
+                "FAIL",
+                "expected_files is empty or not a list",
+            )
+        )
+        if fail is None:
+            fail = "missing_expected_files"
+    else:
+        results.append(_gate("expected_files_nonempty", "PASS", ""))
+
+    # forbidden_files_nonempty
+    forbidden = unit.get("forbidden_files") or []
+    if not isinstance(forbidden, list) or not forbidden:
+        results.append(
+            _gate(
+                "forbidden_files_nonempty",
+                "FAIL",
+                "forbidden_files is empty or not a list",
+            )
+        )
+        if fail is None:
+            fail = "missing_forbidden_files"
+    else:
+        results.append(_gate("forbidden_files_nonempty", "PASS", ""))
+
+    # required_tests_nonempty
+    required_tests = unit.get("required_tests") or []
+    if not isinstance(required_tests, list) or not required_tests:
+        results.append(
+            _gate(
+                "required_tests_nonempty",
+                "FAIL",
+                "required_tests is empty or not a list",
+            )
+        )
+        if fail is None:
+            fail = "missing_required_tests"
+    else:
+        results.append(_gate("required_tests_nonempty", "PASS", ""))
+
+    # no_forbidden_in_expected
+    forbidden_hits = [
+        p for p in expected
+        if isinstance(p, str) and _is_forbidden_path(p)
+    ]
+    if forbidden_hits:
+        detail = ",".join(forbidden_hits[:3])
+        results.append(
+            _gate("no_forbidden_in_expected", "FAIL", detail)
+        )
+        if fail is None:
+            fail = "forbidden_path_in_expected_files"
+    else:
+        results.append(_gate("no_forbidden_in_expected", "PASS", ""))
+
+    # not_terminal_status
+    static_status = _bounded_str(unit.get("status"), 32)
+    if static_status in {"merged", "blocked", "skipped", "failed"}:
+        results.append(
+            _gate(
+                "not_terminal_status",
+                "FAIL",
+                f"status={static_status}",
+            )
+        )
+        if fail is None:
+            fail = "terminal_status"
+    else:
+        results.append(_gate("not_terminal_status", "PASS", ""))
+
+    # max_units_per_run_one
+    if max_units != MAX_UNITS_PER_RUN_HARD_CAP:
+        results.append(
+            _gate(
+                "max_units_per_run_one",
+                "FAIL",
+                f"requested={max_units}",
+            )
+        )
+        if fail is None:
+            fail = "max_units_exceeded"
+    else:
+        results.append(_gate("max_units_per_run_one", "PASS", ""))
+
+    # implementation_strategy_configured
+    if implementation_strategy == "none":
+        results.append(
+            _gate(
+                "implementation_strategy_configured",
+                "FAIL",
+                "default 'none' refuses to run",
+            )
+        )
+        if fail is None:
+            fail = "implementation_strategy_not_configured"
+    elif implementation_strategy not in IMPLEMENTATION_STRATEGY:
+        results.append(
+            _gate(
+                "implementation_strategy_configured",
+                "FAIL",
+                f"unknown strategy={implementation_strategy}",
+            )
+        )
+        if fail is None:
+            fail = "implementation_strategy_not_configured"
+    else:
+        results.append(_gate("implementation_strategy_configured", "PASS", ""))
+
+    return results, fail
+
+
+# ---------------------------------------------------------------------------
+# Real shell runner factory (subprocess imported lazily)
+# ---------------------------------------------------------------------------
+
+
+def _real_shell_runner_factory() -> ShellRunner:
+    """Construct a real ShellRunner.
+
+    ``subprocess`` is imported inside this function so the top-level
+    ``import reporting.autonomous_pr_runner`` is import-safe. This
+    factory is only invoked inside ``run_one`` when the operator has
+    passed ``--run-one`` AND ``--implementation-strategy`` other than
+    ``none``.
+    """
+    import subprocess as _subprocess  # local import: lazy on purpose
+    import time as _time
+
+    class _RealShellRunner:
+        def run(
+            self,
+            args: list[str],
+            *,
+            cwd: Path | None = None,
+            timeout: int = DEFAULT_COMMAND_TIMEOUT_SECONDS,
+        ) -> CommandResult:
+            start = _time.monotonic()
+            try:
+                proc = _subprocess.run(
+                    args,
+                    cwd=str(cwd) if cwd else None,
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout,
+                    check=False,
+                )
+            except _subprocess.TimeoutExpired as exc:
+                duration_ms = int((_time.monotonic() - start) * 1000)
+                return CommandResult(
+                    exit_code=124,
+                    stdout="",
+                    stderr=f"timeout after {timeout}s: {exc}",
+                    duration_ms=duration_ms,
+                )
+            except OSError as exc:
+                duration_ms = int((_time.monotonic() - start) * 1000)
+                return CommandResult(
+                    exit_code=127,
+                    stdout="",
+                    stderr=f"command not found: {exc}",
+                    duration_ms=duration_ms,
+                )
+            duration_ms = int((_time.monotonic() - start) * 1000)
+            return CommandResult(
+                exit_code=proc.returncode,
+                stdout=proc.stdout or "",
+                stderr=proc.stderr or "",
+                duration_ms=duration_ms,
+            )
+
+    return _RealShellRunner()
+
+
+# ---------------------------------------------------------------------------
+# Built-in implementation strategies
+# ---------------------------------------------------------------------------
+
+
+class _NoneStrategy:
+    """Refuse-to-run strategy. The default."""
+
+    name = "none"
+
+    def invoke(
+        self,
+        unit: dict[str, Any],
+        *,
+        repo_root: Path,
+        shell: ShellRunner,
+    ) -> ImplementationResult:
+        return ImplementationResult(
+            success=False,
+            reason="implementation_strategy_not_configured",
+            files_changed=(),
+        )
+
+
+class _ExternalCommandStrategy:
+    """Shell out to an operator-supplied command.
+
+    The command is parsed via :func:`shlex.split`. The command is
+    expected to mutate the filesystem under ``repo_root`` in a way
+    the diff-scope check downstream will validate. The runner does
+    not interpret the command output; it only checks the exit code
+    and the resulting git diff.
+    """
+
+    name = "external_command"
+
+    def __init__(self, command: str, timeout: int) -> None:
+        if not isinstance(command, str) or not command.strip():
+            raise ValueError("external_command requires a non-empty command")
+        self._command = command
+        self._timeout = max(1, int(timeout))
+
+    def invoke(
+        self,
+        unit: dict[str, Any],
+        *,
+        repo_root: Path,
+        shell: ShellRunner,
+    ) -> ImplementationResult:
+        try:
+            args = shlex.split(self._command)
+        except ValueError as exc:
+            return ImplementationResult(
+                success=False,
+                reason=f"command_parse_error:{exc}",
+                files_changed=(),
+            )
+        if not args:
+            return ImplementationResult(
+                success=False,
+                reason="command_parse_empty",
+                files_changed=(),
+            )
+        result = shell.run(args, cwd=repo_root, timeout=self._timeout)
+        if result.exit_code != 0:
+            return ImplementationResult(
+                success=False,
+                reason=(
+                    f"external_command_exit_code={result.exit_code}"
+                ),
+                files_changed=(),
+            )
+        return ImplementationResult(
+            success=True,
+            reason="external_command_ok",
+            files_changed=(),
+        )
+
+
+def _build_strategy(
+    name: str,
+    *,
+    external_command: str | None,
+    external_timeout: int,
+) -> ImplementationStrategy:
+    if name == "none":
+        return _NoneStrategy()
+    if name == "external_command":
+        return _ExternalCommandStrategy(
+            command=external_command or "",
+            timeout=external_timeout,
+        )
+    raise ValueError(f"unknown implementation strategy: {name}")
+
+
+# ---------------------------------------------------------------------------
+# Plan + report assembly
+# ---------------------------------------------------------------------------
+
+
+def _empty_report(
+    *,
+    mode: str,
+    ts: str,
+    max_units: int,
+    implementation_strategy: str,
+) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": ts,
+        "mode": mode,
+        "max_units_per_run": max_units,
+        "implementation_strategy": implementation_strategy,
+        "selected_unit_id": "",
+        "selected_phase": "",
+        "selected_authority_class": "",
+        "selected_risk_class": "",
+        "selected_operator_gate": "",
+        "branch_name": "",
+        "safety_gate_results": [],
+        "commands_run": [],
+        "files_changed": [],
+        "tests_run": [],
+        "pr_number": 0,
+        "ci_status": "",
+        "stop_reason": "",
+        "final_runner_status": "not_run",
+        "next_required_operator_action": "",
+        "step5_enabled_substage": STEP5_ENABLED_SUBSTAGE,
+        "step5_implementation_allowed": step5_implementation_allowed,
+        "runner_invariants": dict(_BASE_RUNNER_INVARIANTS),
+    }
+
+
+def _attach_selection(
+    report: dict[str, Any],
+    selector_snapshot: dict[str, Any] | None,
+    unit: dict[str, Any] | None,
+) -> None:
+    if selector_snapshot is None:
+        return
+    sel = selector_snapshot.get("selection") or {}
+    report["selected_unit_id"] = _bounded_str(
+        sel.get("selected_unit_id"), 200
+    )
+    report["selected_phase"] = _bounded_str(sel.get("selected_phase"), 64)
+    report["selected_authority_class"] = _bounded_str(
+        sel.get("selected_authority_class"), 32
+    )
+    report["selected_risk_class"] = _bounded_str(
+        sel.get("selected_risk_class"), 16
+    )
+    report["selected_operator_gate"] = _bounded_str(
+        sel.get("selected_operator_gate"), 64
+    )
+    _ = unit  # unit may be used by callers later; signature stable
+
+
+def _branch_name_for_unit(unit_id: str) -> str:
+    sanitized = "".join(
+        ch if (ch.isalnum() or ch in "-_/") else "-"
+        for ch in unit_id
+    )
+    prefix = "step5-a21c"
+    return _bounded_str(
+        f"{prefix}/{sanitized}",
+        MAX_BRANCH_NAME_LEN,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Selector + unit lookup
+# ---------------------------------------------------------------------------
+
+
+def _load_selector_snapshot(
+    *, repo_root: Path
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Best-effort selector load. Returns ``(snapshot, error)``."""
+    try:
+        snap = rnu.collect_snapshot(repo_root=repo_root)
+    except Exception as exc:  # defensive
+        return None, _bounded_str(repr(exc), MAX_DETAIL_LEN)
+    return snap, None
+
+
+def _find_unit_in_a20b(
+    *,
+    unit_id: str,
+    repo_root: Path,
+) -> dict[str, Any] | None:
+    """Find the unit record in the A20b artefact by id."""
+    units_path = repo_root / "logs" / "roadmap_task_units" / "latest.json"
+    if not units_path.is_file():
+        return None
+    try:
+        payload = json.loads(units_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, ValueError):
+        return None
+    units = payload.get("implementation_units")
+    if not isinstance(units, list):
+        return None
+    for u in units:
+        if isinstance(u, dict) and u.get("id") == unit_id:
+            return u
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Mode entry points
+# ---------------------------------------------------------------------------
+
+
+def status(
+    *,
+    repo_root: Path | None = None,
+    generated_at_utc: str | None = None,
+    max_units: int = MAX_UNITS_PER_RUN_HARD_CAP,
+    implementation_strategy: str = "none",
+) -> dict[str, Any]:
+    """Read-only status mode. Never executes anything."""
+    root = repo_root if repo_root is not None else REPO_ROOT
+    ts = generated_at_utc if generated_at_utc is not None else _utcnow()
+    report = _empty_report(
+        mode="status_only",
+        ts=ts,
+        max_units=max_units,
+        implementation_strategy=implementation_strategy,
+    )
+    snap, _err = _load_selector_snapshot(repo_root=root)
+    _attach_selection(report, snap, None)
+    report["final_runner_status"] = "status_only"
+    report["stop_reason"] = "status_only_mode"
+    report["next_required_operator_action"] = (
+        "review_selector_recommendation_then_invoke_plan_only"
+    )
+    return report
+
+
+def plan(
+    *,
+    repo_root: Path | None = None,
+    generated_at_utc: str | None = None,
+    max_units: int = MAX_UNITS_PER_RUN_HARD_CAP,
+    implementation_strategy: str = "none",
+) -> dict[str, Any]:
+    """Plan-only mode. Evaluates safety gates but executes nothing.
+
+    Useful for the operator to inspect which gates would PASS / FAIL
+    before authorising ``--run-one``. The plan never invokes git,
+    gh, subprocess, or any implementation strategy.
+    """
+    root = repo_root if repo_root is not None else REPO_ROOT
+    ts = generated_at_utc if generated_at_utc is not None else _utcnow()
+    report = _empty_report(
+        mode="plan_only",
+        ts=ts,
+        max_units=max_units,
+        implementation_strategy=implementation_strategy,
+    )
+    snap, _err = _load_selector_snapshot(repo_root=root)
+    unit = None
+    if snap is not None:
+        sel = snap.get("selection") or {}
+        uid = _bounded_str(sel.get("selected_unit_id"), 200)
+        if uid:
+            unit = _find_unit_in_a20b(unit_id=uid, repo_root=root)
+    _attach_selection(report, snap, unit)
+    gates, fail_reason = evaluate_safety_gates(
+        selector_snapshot=snap,
+        unit=unit,
+        max_units=max_units,
+        implementation_strategy=implementation_strategy,
+    )
+    report["safety_gate_results"] = gates
+    report["final_runner_status"] = "plan_only"
+    report["stop_reason"] = (
+        fail_reason if fail_reason is not None else "plan_only_mode"
+    )
+    if unit is not None and report["selected_unit_id"]:
+        report["branch_name"] = _branch_name_for_unit(
+            report["selected_unit_id"]
+        )
+    if fail_reason is not None:
+        report["next_required_operator_action"] = (
+            "address_safety_gate_failure_before_run_one"
+        )
+    else:
+        report["next_required_operator_action"] = (
+            "invoke_run_one_with_explicit_implementation_strategy"
+        )
+    return report
+
+
+def _record_command(
+    commands: list[dict[str, Any]],
+    command_args: list[str],
+    result: CommandResult,
+) -> None:
+    if len(commands) >= MAX_COMMANDS_RECORDED:
+        return
+    commands.append(
+        {
+            "command": _bounded_str(" ".join(command_args), 480),
+            "exit_code": int(result.exit_code),
+            "duration_ms": int(result.duration_ms),
+            "stdout_excerpt": _bounded_str(
+                result.stdout, MAX_COMMAND_EXCERPT_LEN
+            ),
+            "stderr_excerpt": _bounded_str(
+                result.stderr, MAX_COMMAND_EXCERPT_LEN
+            ),
+        }
+    )
+
+
+def _diff_paths_after_implementation(
+    shell: ShellRunner,
+    *,
+    repo_root: Path,
+    commands: list[dict[str, Any]],
+) -> tuple[list[str], CommandResult]:
+    """Run ``git status --porcelain`` and parse changed paths."""
+    args = ["git", "status", "--porcelain"]
+    result = shell.run(args, cwd=repo_root)
+    _record_command(commands, args, result)
+    paths: list[str] = []
+    if result.exit_code != 0:
+        return paths, result
+    for line in result.stdout.splitlines():
+        if len(line) < 4:
+            continue
+        path = line[3:].strip().replace("\\", "/")
+        if " -> " in path:
+            path = path.split(" -> ", 1)[1]
+        if path and path not in paths:
+            paths.append(path)
+        if len(paths) >= MAX_FILES_CHANGED_RECORDED:
+            break
+    return paths, result
+
+
+def run_one(
+    *,
+    repo_root: Path | None = None,
+    generated_at_utc: str | None = None,
+    max_units: int = MAX_UNITS_PER_RUN_HARD_CAP,
+    implementation_strategy_name: str = "none",
+    external_command: str | None = None,
+    external_command_timeout: int = DEFAULT_COMMAND_TIMEOUT_SECONDS,
+    shell: ShellRunner | None = None,
+    implementation_strategy: ImplementationStrategy | None = None,
+) -> dict[str, Any]:
+    """Bounded autonomous PR runner for exactly one selected unit.
+
+    Tests inject ``shell`` and ``implementation_strategy`` so no real
+    shell command is invoked. The CLI path constructs real ones from
+    the operator-supplied flags.
+    """
+    root = repo_root if repo_root is not None else REPO_ROOT
+    ts = generated_at_utc if generated_at_utc is not None else _utcnow()
+    report = _empty_report(
+        mode="run_one",
+        ts=ts,
+        max_units=max_units,
+        implementation_strategy=implementation_strategy_name,
+    )
+
+    # ---- Safety gates first (no execution) ---------------------------------
+    snap, _err = _load_selector_snapshot(repo_root=root)
+    unit = None
+    if snap is not None:
+        sel = snap.get("selection") or {}
+        uid = _bounded_str(sel.get("selected_unit_id"), 200)
+        if uid:
+            unit = _find_unit_in_a20b(unit_id=uid, repo_root=root)
+    _attach_selection(report, snap, unit)
+    gates, fail_reason = evaluate_safety_gates(
+        selector_snapshot=snap,
+        unit=unit,
+        max_units=max_units,
+        implementation_strategy=implementation_strategy_name,
+    )
+    report["safety_gate_results"] = gates
+    if fail_reason is not None:
+        report["final_runner_status"] = "refused_unsafe"
+        report["stop_reason"] = fail_reason
+        report["next_required_operator_action"] = (
+            "address_safety_gate_failure_before_retry"
+        )
+        return report
+
+    assert unit is not None  # gates guaranteed unit_present passed
+
+    branch_name = _branch_name_for_unit(report["selected_unit_id"])
+    report["branch_name"] = branch_name
+
+    # ---- Construct injectable surfaces if not provided ---------------------
+    if shell is None:
+        shell = _real_shell_runner_factory()
+    if implementation_strategy is None:
+        implementation_strategy = _build_strategy(
+            implementation_strategy_name,
+            external_command=external_command,
+            external_timeout=external_command_timeout,
+        )
+
+    commands: list[dict[str, Any]] = []
+    report["commands_run"] = commands
+
+    # ---- Branch creation ---------------------------------------------------
+    args = ["git", "checkout", "-b", branch_name]
+    res = shell.run(args, cwd=root)
+    _record_command(commands, args, res)
+    if res.exit_code != 0:
+        report["final_runner_status"] = "executed_blocked_at_implementation"
+        # Distinguish "already exists" from generic failure.
+        if (
+            "already exists" in (res.stderr or "")
+            or "already exists" in (res.stdout or "")
+        ):
+            report["stop_reason"] = "branch_already_exists"
+        else:
+            report["stop_reason"] = "branch_creation_failed"
+        report["next_required_operator_action"] = (
+            "clean_up_branch_state_and_retry"
+        )
+        return report
+
+    # ---- Invoke implementation strategy ------------------------------------
+    impl_result = implementation_strategy.invoke(
+        unit, repo_root=root, shell=shell
+    )
+    if not impl_result.success:
+        report["final_runner_status"] = "executed_blocked_at_implementation"
+        if impl_result.reason == "implementation_strategy_not_configured":
+            report["stop_reason"] = "implementation_strategy_not_configured"
+        else:
+            report["stop_reason"] = "implementation_strategy_failed"
+        report["next_required_operator_action"] = (
+            "review_implementation_strategy_logs_then_retry"
+        )
+        return report
+
+    # ---- Diff scope check --------------------------------------------------
+    changed_paths, diff_res = _diff_paths_after_implementation(
+        shell, repo_root=root, commands=commands
+    )
+    report["files_changed"] = changed_paths
+    if diff_res.exit_code != 0:
+        report["final_runner_status"] = "executed_blocked_at_diff"
+        report["stop_reason"] = "unknown_evidence"
+        report["next_required_operator_action"] = "inspect_git_status"
+        return report
+    if not changed_paths:
+        report["final_runner_status"] = "executed_blocked_at_diff"
+        report["stop_reason"] = "diff_empty"
+        report["next_required_operator_action"] = (
+            "implementation_strategy_produced_no_changes_review_strategy"
+        )
+        return report
+
+    expected_files = [
+        _bounded_str(p, 300).replace("\\", "/")
+        for p in (unit.get("expected_files") or [])
+        if isinstance(p, str)
+    ]
+    expected_set = set(expected_files)
+    for p in changed_paths:
+        if _is_forbidden_path(p):
+            report["final_runner_status"] = "executed_blocked_at_diff"
+            report["stop_reason"] = "diff_touches_forbidden_path"
+            report["next_required_operator_action"] = (
+                "revert_branch_strategy_violated_forbidden_path"
+            )
+            return report
+        if p not in expected_set:
+            report["final_runner_status"] = "executed_blocked_at_diff"
+            report["stop_reason"] = "diff_outside_expected_files"
+            report["next_required_operator_action"] = (
+                "revert_branch_strategy_exceeded_expected_files"
+            )
+            return report
+
+    # ---- Required tests ----------------------------------------------------
+    required_tests = [
+        _bounded_str(t, 240)
+        for t in (unit.get("required_tests") or [])
+        if isinstance(t, str)
+    ]
+    tests_run: list[str] = []
+    for test_target in required_tests[:MAX_TESTS_RECORDED]:
+        tests_run.append(test_target)
+        targets = [test_target]
+        args = ["python", "-m", "pytest", "-q", *targets]
+        res = shell.run(args, cwd=root)
+        _record_command(commands, args, res)
+        if res.exit_code != 0:
+            report["final_runner_status"] = "executed_blocked_at_tests"
+            report["stop_reason"] = "tests_failed"
+            report["tests_run"] = tests_run
+            report["next_required_operator_action"] = (
+                "review_failing_tests_then_revert_or_fix_branch"
+            )
+            return report
+    report["tests_run"] = tests_run
+
+    # ---- Smoke tests + governance lint ------------------------------------
+    args = ["python", "-m", "pytest", "-q", "tests/smoke"]
+    res = shell.run(args, cwd=root)
+    _record_command(commands, args, res)
+    if res.exit_code != 0:
+        report["final_runner_status"] = "executed_blocked_at_tests"
+        report["stop_reason"] = "tests_failed"
+        report["next_required_operator_action"] = (
+            "review_smoke_failures_then_revert_branch"
+        )
+        return report
+
+    args = ["python", "scripts/governance_lint.py"]
+    res = shell.run(args, cwd=root)
+    _record_command(commands, args, res)
+    if res.exit_code != 0:
+        report["final_runner_status"] = "executed_blocked_at_governance_lint"
+        report["stop_reason"] = "governance_lint_failed"
+        report["next_required_operator_action"] = (
+            "review_governance_lint_failures_then_revert_branch"
+        )
+        return report
+
+    # ---- Stage + commit ----------------------------------------------------
+    for p in changed_paths:
+        args = ["git", "add", "--", p]
+        res = shell.run(args, cwd=root)
+        _record_command(commands, args, res)
+        if res.exit_code != 0:
+            report["final_runner_status"] = "executed_blocked_at_commit"
+            report["stop_reason"] = "commit_failed"
+            report["next_required_operator_action"] = (
+                "inspect_git_status_then_resolve"
+            )
+            return report
+
+    commit_message = _commit_message_for_unit(unit)
+    args = ["git", "commit", "-m", commit_message]
+    res = shell.run(args, cwd=root)
+    _record_command(commands, args, res)
+    if res.exit_code != 0:
+        report["final_runner_status"] = "executed_blocked_at_commit"
+        # Distinguish hook failure from generic commit failure.
+        text = (res.stdout or "") + (res.stderr or "")
+        if "hook" in text.lower() and "fail" in text.lower():
+            report["stop_reason"] = "hook_failed"
+        else:
+            report["stop_reason"] = "commit_failed"
+        report["next_required_operator_action"] = (
+            "review_commit_or_hook_output_then_resolve"
+        )
+        return report
+
+    # ---- Push --------------------------------------------------------------
+    args = ["git", "push", "-u", "origin", branch_name]
+    res = shell.run(args, cwd=root)
+    _record_command(commands, args, res)
+    if res.exit_code != 0:
+        report["final_runner_status"] = "executed_blocked_at_push"
+        report["stop_reason"] = "push_failed"
+        report["next_required_operator_action"] = (
+            "review_push_output_then_resolve"
+        )
+        return report
+
+    # ---- Open PR -----------------------------------------------------------
+    pr_title = _pr_title_for_unit(unit)
+    pr_body = _pr_body_for_unit(unit, branch_name)
+    args = [
+        "gh",
+        "pr",
+        "create",
+        "--base",
+        "main",
+        "--head",
+        branch_name,
+        "--title",
+        pr_title,
+        "--body",
+        pr_body,
+    ]
+    res = shell.run(args, cwd=root)
+    _record_command(commands, args, res)
+    if res.exit_code != 0:
+        report["final_runner_status"] = "executed_blocked_at_pr_create"
+        report["stop_reason"] = "pr_creation_failed"
+        report["next_required_operator_action"] = (
+            "review_gh_pr_create_output_then_resolve"
+        )
+        return report
+    pr_number = _parse_pr_number(res.stdout)
+    report["pr_number"] = pr_number
+
+    # ---- CI watch (first verdict only) -------------------------------------
+    if pr_number > 0:
+        args = [
+            "gh",
+            "pr",
+            "checks",
+            str(pr_number),
+            "--watch",
+            "--required",
+        ]
+        res = shell.run(args, cwd=root, timeout=DEFAULT_CI_WATCH_TIMEOUT_SECONDS)
+        _record_command(commands, args, res)
+        if res.exit_code == 124:
+            report["final_runner_status"] = "executed_blocked_at_ci"
+            report["stop_reason"] = "ci_timeout"
+            report["ci_status"] = "TIMEOUT"
+            report["next_required_operator_action"] = (
+                "inspect_ci_run_manually"
+            )
+            return report
+        if res.exit_code != 0:
+            report["final_runner_status"] = "executed_blocked_at_ci"
+            report["stop_reason"] = "ci_failed"
+            report["ci_status"] = "FAIL"
+            report["next_required_operator_action"] = (
+                "review_failing_ci_jobs_then_resolve"
+            )
+            return report
+        report["ci_status"] = "PASS"
+
+    report["final_runner_status"] = "executed_pr_opened"
+    report["stop_reason"] = "ok_pr_opened"
+    report["next_required_operator_action"] = (
+        "review_pr_and_decide_merge_protocol"
+    )
+    return report
+
+
+# ---------------------------------------------------------------------------
+# PR body / commit message helpers
+# ---------------------------------------------------------------------------
+
+
+def _commit_message_for_unit(unit: dict[str, Any]) -> str:
+    uid = _bounded_str(unit.get("id"), 200)
+    title = _bounded_str(unit.get("title"), 200)
+    return (
+        f"feat({uid}): {title}\n"
+        "\n"
+        "Auto-prepared by reporting.autonomous_pr_runner (A21c "
+        "bounded slice).\n"
+        "\n"
+        "No auto-merge; no deploy; no runtime authority granted."
+    )
+
+
+def _pr_title_for_unit(unit: dict[str, Any]) -> str:
+    uid = _bounded_str(unit.get("id"), 200)
+    title = _bounded_str(unit.get("title"), 200)
+    return f"feat({uid}): {title}"
+
+
+def _pr_body_for_unit(unit: dict[str, Any], branch_name: str) -> str:
+    uid = _bounded_str(unit.get("id"), 200)
+    title = _bounded_str(unit.get("title"), 200)
+    expected = unit.get("expected_files") or []
+    expected_lines = "\n".join(
+        f"- `{p}`" for p in expected if isinstance(p, str)
+    ) or "- (none)"
+    required = unit.get("required_tests") or []
+    required_lines = "\n".join(
+        f"- `{t}`" for t in required if isinstance(t, str)
+    ) or "- (none)"
+    return (
+        f"## Summary\n\n"
+        f"Auto-prepared by `reporting.autonomous_pr_runner` (A21c "
+        f"bounded slice) on branch `{branch_name}`.\n\n"
+        f"- **Selected A20e unit id:** `{uid}`\n"
+        f"- **Title:** {title}\n"
+        f"- **Authority class:** `AUTO_ALLOWED` (LOW risk, "
+        f"`operator_gate = none`).\n"
+        f"- **No auto-merge.** Operator decides squash-merge after CI.\n"
+        f"- **No deploy.** Deploy gates run only after operator-driven "
+        f"merge to `main`.\n"
+        f"- **No runtime / trading / paper / shadow / live authority "
+        f"granted.**\n\n"
+        f"## Expected files\n\n{expected_lines}\n\n"
+        f"## Required tests\n\n{required_lines}\n\n"
+        f"## Authority posture\n\n"
+        f"- Step 5 broad implementation remains BLOCKED.\n"
+        f"- Autonomy-ladder Level 6 remains permanently disabled.\n"
+        f"- N5b Phase 4 production merge remains permanently denied "
+        f"for ADE.\n"
+        f"- ADE remains development workflow automation only.\n"
+    )
+
+
+def _parse_pr_number(stdout: str) -> int:
+    """Extract a PR number from a typical `gh pr create` stdout
+    line such as ``https://github.com/owner/repo/pull/256``."""
+    if not isinstance(stdout, str):
+        return 0
+    for token in stdout.split():
+        if "/pull/" in token:
+            tail = token.rsplit("/pull/", 1)[1]
+            digits = "".join(ch for ch in tail if ch.isdigit())
+            if digits:
+                try:
+                    return int(digits)
+                except ValueError:
+                    return 0
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Atomic write
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    posix = path.as_posix()
+    if _WRITE_PREFIX not in posix:
+        raise ValueError(
+            "autonomous_pr_runner._atomic_write_json refuses "
+            f"non-runner-logs output path: {path}"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".autonomous_pr_runner.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_outputs(report: dict[str, Any]) -> Path:
+    _atomic_write_json(ARTIFACT_LATEST, report)
+    return ARTIFACT_LATEST
+
+
+# ---------------------------------------------------------------------------
+# Status renderer
+# ---------------------------------------------------------------------------
+
+
+def _render_status(report: dict[str, Any]) -> str:
+    inv = report["runner_invariants"]
+    gates = report["safety_gate_results"]
+    lines = [
+        f"autonomous_pr_runner {report['module_version']} "
+        f"schema={report['schema_version']}",
+        f"generated_at_utc={report['generated_at_utc']}",
+        f"mode={report['mode']}",
+        f"selected_unit_id={report['selected_unit_id']}",
+        f"selected_phase={report['selected_phase']}",
+        f"authority={report['selected_authority_class']} "
+        f"risk={report['selected_risk_class']} "
+        f"gate={report['selected_operator_gate']}",
+        f"implementation_strategy={report['implementation_strategy']}",
+        f"max_units_per_run={report['max_units_per_run']}",
+        f"final_runner_status={report['final_runner_status']}",
+        f"stop_reason={report['stop_reason']}",
+        f"next_required_operator_action="
+        f"{report['next_required_operator_action']}",
+        (
+            "no_runtime_trading_authority="
+            f"{inv['no_runtime_trading_authority']} "
+            f"no_step5_broad={inv['no_step5_broad']} "
+            f"no_level6={inv['no_level6']} "
+            "no_production_merge_authority="
+            f"{inv['no_production_merge_authority']}"
+        ),
+        (
+            "no_auto_merge="
+            f"{inv['no_auto_merge']} "
+            f"no_admin_merge={inv['no_admin_merge']} "
+            f"no_force_push={inv['no_force_push']} "
+            f"no_hook_bypass={inv['no_hook_bypass']} "
+            f"no_deploy={inv['no_deploy']}"
+        ),
+        (
+            "no_ledger_mutation="
+            f"{inv['no_ledger_mutation']} "
+            "no_second_unit_continuation="
+            f"{inv['no_second_unit_continuation']} "
+            "bounded_step5_pr_creation_only="
+            f"{inv['bounded_step5_pr_creation_only']}"
+        ),
+    ]
+    for g in gates:
+        lines.append(
+            f"  gate {g['gate']}={g['result']}"
+            + (f" ({g['detail']})" if g["detail"] else "")
+        )
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m reporting.autonomous_pr_runner",
+        description=(
+            "A21c Bounded Autonomous PR Runner. Takes ONE A20e-"
+            "selected unit and opens a real PR. Does NOT auto-merge, "
+            "does NOT deploy, does NOT continue to another unit. "
+            "Step 5 broad implementation remains BLOCKED."
+        ),
+    )
+    p.add_argument(
+        "--indent",
+        type=int,
+        default=2,
+        help="JSON indent for stdout output (0 for compact).",
+    )
+    p.add_argument(
+        "--no-write",
+        action="store_true",
+        help=(
+            "Do not persist logs/autonomous_pr_runner/latest.json "
+            "(stdout only)."
+        ),
+    )
+    p.add_argument(
+        "--status",
+        action="store_true",
+        help=(
+            "Render a compact human-readable status summary to "
+            "stdout and exit. Does not execute anything."
+        ),
+    )
+    p.add_argument(
+        "--plan-only",
+        action="store_true",
+        help=(
+            "Evaluate every safety gate against the current "
+            "selector recommendation but do not execute anything."
+        ),
+    )
+    p.add_argument(
+        "--run-one",
+        action="store_true",
+        help=(
+            "Execute exactly one bounded PR creation cycle. Must "
+            "be combined with --implementation-strategy != none."
+        ),
+    )
+    p.add_argument(
+        "--max-units",
+        type=int,
+        default=1,
+        help=(
+            "Maximum units per run. A21c hard-caps this at 1; any "
+            "other value is rejected by the safety gates."
+        ),
+    )
+    p.add_argument(
+        "--implementation-strategy",
+        choices=list(IMPLEMENTATION_STRATEGY),
+        default="none",
+        help=(
+            "Implementation strategy. Default 'none' refuses to "
+            "execute."
+        ),
+    )
+    p.add_argument(
+        "--implementation-command",
+        default="",
+        help=(
+            "Operator-supplied implementation command for the "
+            "external_command strategy."
+        ),
+    )
+    p.add_argument(
+        "--implementation-timeout",
+        type=int,
+        default=DEFAULT_COMMAND_TIMEOUT_SECONDS,
+        help=(
+            "Timeout (seconds) for the implementation command "
+            "(external_command strategy only)."
+        ),
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+
+    if args.status:
+        report = status(
+            max_units=args.max_units,
+            implementation_strategy=args.implementation_strategy,
+        )
+        sys.stdout.write(_render_status(report))
+        return 0
+
+    if args.plan_only:
+        report = plan(
+            max_units=args.max_units,
+            implementation_strategy=args.implementation_strategy,
+        )
+        indent = args.indent if args.indent and args.indent > 0 else None
+        if not args.no_write:
+            write_outputs(report)
+        json.dump(report, sys.stdout, indent=indent, sort_keys=True)
+        sys.stdout.write("\n")
+        return 0
+
+    if args.run_one:
+        report = run_one(
+            max_units=args.max_units,
+            implementation_strategy_name=args.implementation_strategy,
+            external_command=args.implementation_command,
+            external_command_timeout=args.implementation_timeout,
+        )
+        indent = args.indent if args.indent and args.indent > 0 else None
+        if not args.no_write:
+            write_outputs(report)
+        json.dump(report, sys.stdout, indent=indent, sort_keys=True)
+        sys.stdout.write("\n")
+        return 0 if report["stop_reason"] == "ok_pr_opened" else 1
+
+    # No explicit mode flag. Default to status-only (safe).
+    report = status(
+        max_units=args.max_units,
+        implementation_strategy=args.implementation_strategy,
+    )
+    sys.stdout.write(_render_status(report))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/reporting/roadmap_unit_status.py
+++ b/reporting/roadmap_unit_status.py
@@ -114,10 +114,21 @@ step5_implementation_allowed: Final[bool] = False
 # Closed vocabularies
 # ---------------------------------------------------------------------------
 
-#: Closed dynamic unit-status vocabulary. 7 values.
+#: Closed dynamic unit-status vocabulary. 11 values.
+#:
+#: The four runner-lifecycle states (``selected``, ``branch_created``,
+#: ``implementation_complete``, ``tests_passed``) are reserved for
+#: Step 5 / A21 slices (A21c onwards). The A21c bounded PR runner
+#: itself does NOT mutate the dynamic ledger today — the ledger
+#: remains seed-driven — but the vocabulary widening lets future
+#: slices record runner progress without another vocab change.
 DYNAMIC_UNIT_STATUS: Final[tuple[str, ...]] = (
     "not_started",
+    "selected",
+    "branch_created",
     "in_progress",
+    "implementation_complete",
+    "tests_passed",
     "pr_open",
     "merged",
     "failed",

--- a/tests/unit/test_autonomous_pr_runner.py
+++ b/tests/unit/test_autonomous_pr_runner.py
@@ -1,0 +1,1599 @@
+"""Unit tests for A21c -- Bounded Autonomous PR Runner.
+
+Pins:
+
+* import is side-effect free (no subprocess, no git, no gh, no
+  network, no file writes at module level);
+* closed vocabularies (RUN_STATUS, STOP_REASON, SAFETY_GATE,
+  GATE_RESULT, RUNNER_MODE, IMPLEMENTATION_STRATEGY) and schema
+  field tuples;
+* every safety gate refusal path produces the correct closed-vocab
+  stop reason and runner status;
+* unsafe authority / risk / gate / requires_operator_go are
+  refused;
+* missing expected_files / forbidden_files / required_tests are
+  refused;
+* forbidden expected_files (live / paper / shadow / broker /
+  agent.risk / agent.execution / dashboard.dashboard.py /
+  research/research_latest.json / research/strategy_matrix.csv /
+  tests/regression / docs/development_work_queue / .claude / etc)
+  are refused at the no_forbidden_in_expected gate;
+* terminal statuses (merged / blocked / skipped / failed) are
+  refused;
+* max_units > 1 is refused (A21c hard cap = 1);
+* default implementation_strategy = "none" is refused;
+* diff outside expected_files is refused;
+* diff touching a forbidden path is refused even if it was in
+  expected_files;
+* empty diff is refused;
+* required tests failing => tests_failed stop;
+* governance lint failing => governance_lint_failed stop;
+* commit / push / PR-create / CI failures each surface the
+  matching closed-vocab stop reason;
+* no auto-merge path exists in module source;
+* no deploy path exists in module source;
+* no force-push / no --admin / no hook bypass tokens in module
+  source;
+* shell / git / gh / implementation strategy are all injectable in
+  tests; no real git / gh / subprocess is invoked by the unit
+  test suite;
+* runner_invariants pin every Step 5 / Level 6 / runtime / merge /
+  deploy / mutation route / approval button / ledger-mutation /
+  test-weakening guard.
+"""
+
+from __future__ import annotations
+
+import ast as _ast
+import importlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reporting import autonomous_pr_runner as apr
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures: fake shell + fake implementation strategy
+# ---------------------------------------------------------------------------
+
+
+class _FakeShell:
+    """Deterministic injectable ShellRunner.
+
+    The fake matches commands by their first two tokens (e.g.
+    ``("git", "checkout")``) and returns a queued result. Tests
+    pre-load expected commands.
+    """
+
+    def __init__(self) -> None:
+        self.results: list[tuple[tuple[str, ...], apr.CommandResult]] = []
+        self.calls: list[tuple[list[str], Path | None, int]] = []
+
+    def queue(
+        self,
+        prefix: tuple[str, ...],
+        exit_code: int = 0,
+        stdout: str = "",
+        stderr: str = "",
+        duration_ms: int = 1,
+    ) -> None:
+        self.results.append(
+            (
+                prefix,
+                apr.CommandResult(
+                    exit_code=exit_code,
+                    stdout=stdout,
+                    stderr=stderr,
+                    duration_ms=duration_ms,
+                ),
+            )
+        )
+
+    def run(
+        self,
+        args: list[str],
+        *,
+        cwd: Path | None = None,
+        timeout: int = apr.DEFAULT_COMMAND_TIMEOUT_SECONDS,
+    ) -> apr.CommandResult:
+        self.calls.append((list(args), cwd, timeout))
+        for i, (prefix, result) in enumerate(self.results):
+            if tuple(args[: len(prefix)]) == prefix:
+                self.results.pop(i)
+                return result
+        return apr.CommandResult(
+            exit_code=0, stdout="", stderr="", duration_ms=1
+        )
+
+
+class _FakeStrategy:
+    """Deterministic injectable ImplementationStrategy."""
+
+    name = "fake"
+
+    def __init__(
+        self,
+        *,
+        success: bool = True,
+        reason: str = "fake_ok",
+    ) -> None:
+        self._success = success
+        self._reason = reason
+        self.calls: list[dict[str, Any]] = []
+
+    def invoke(
+        self,
+        unit: dict[str, Any],
+        *,
+        repo_root: Path,
+        shell: apr.ShellRunner,
+    ) -> apr.ImplementationResult:
+        self.calls.append({"unit_id": unit.get("id"), "root": repo_root})
+        return apr.ImplementationResult(
+            success=self._success,
+            reason=self._reason,
+            files_changed=(),
+        )
+
+
+_FROZEN_UTC = "2026-05-18T20:00:00Z"
+
+
+def _write_minimal_upstreams(
+    tmp_path: Path,
+    *,
+    unit_overrides: dict[str, Any] | None = None,
+    decision_overrides: dict[str, Any] | None = None,
+) -> None:
+    """Write tiny A20b + A20c artefacts pinning ONE eligible unit."""
+    unit: dict[str, Any] = {
+        "id": "u_runner_synth",
+        "roadmap_task_id": "phase_v3_15_17",
+        "title": "Synthetic eligible runner unit",
+        "phase": "v3.15.17",
+        "unit_kind": "reporting_module",
+        "target_layer": "reporting",
+        "source_requirement_ids": [],
+        "expected_files": [
+            "reporting/synthetic_runner_target.py",
+            "tests/unit/test_synthetic_runner_target.py",
+        ],
+        "forbidden_files": [
+            ".claude/**",
+            "dashboard/dashboard.py",
+        ],
+        "forbidden_surface_reasons": [],
+        "required_tests": [
+            "tests/unit/test_synthetic_runner_target.py",
+        ],
+        "definition_of_done": [],
+        "stop_conditions": [],
+        "prerequisites": [],
+        "risk_class": "LOW",
+        "authority_hint": "AUTO_ALLOWED_CANDIDATE",
+        "operator_gate": "none",
+        "status": "not_started",
+    }
+    if unit_overrides:
+        unit.update(unit_overrides)
+    decision: dict[str, Any] = {
+        "implementation_unit_id": unit["id"],
+        "roadmap_task_id": unit["roadmap_task_id"],
+        "phase": unit["phase"],
+        "final_authority_class": "AUTO_ALLOWED",
+        "max_severity": 0,
+        "evidence": [],
+        "requires_operator_go": False,
+        "permanently_denied": False,
+        "deny_reasons": [],
+        "classifier_used": True,
+        "fail_closed": False,
+    }
+    if decision_overrides:
+        decision.update(decision_overrides)
+
+    units_dir = tmp_path / "logs" / "roadmap_task_units"
+    units_dir.mkdir(parents=True, exist_ok=True)
+    (units_dir / "latest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0",
+                "module_version": "v3.15.16.A20b",
+                "report_kind": "roadmap_task_units",
+                "generated_at_utc": "2026-05-18T08:00:00Z",
+                "implementation_units": [unit],
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    auth_dir = tmp_path / "logs" / "roadmap_unit_authority"
+    auth_dir.mkdir(parents=True, exist_ok=True)
+    (auth_dir / "latest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0",
+                "module_version": "v3.15.16.A20c",
+                "report_kind": "roadmap_unit_authority",
+                "generated_at_utc": "2026-05-18T08:00:00Z",
+                "authority_decisions": [decision],
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Module-level guarantees: import safety + module-source scans
+# ---------------------------------------------------------------------------
+
+
+def _module_source() -> str:
+    return Path(apr.__file__).read_text(encoding="utf-8")
+
+
+def _module_top_level_imports() -> list[str]:
+    """Module-level (not function-level) import statements."""
+    tree = _ast.parse(_module_source())
+    out: list[str] = []
+    for node in tree.body:
+        if isinstance(node, _ast.Import):
+            for alias in node.names:
+                out.append(alias.name)
+        elif isinstance(node, _ast.ImportFrom):
+            mod = node.module or ""
+            for alias in node.names:
+                out.append(f"{mod}.{alias.name}" if mod else alias.name)
+    return out
+
+
+def test_module_imports_cleanly() -> None:
+    importlib.reload(apr)
+    assert callable(apr.status)
+    assert callable(apr.plan)
+    assert callable(apr.run_one)
+    assert callable(apr.main)
+
+
+def test_import_does_not_use_subprocess_at_module_level() -> None:
+    """``subprocess`` must NOT be imported at module top level. It
+    is imported lazily inside the real shell runner factory so the
+    module is import-safe."""
+    top = _module_top_level_imports()
+    for module in top:
+        assert not module.startswith("subprocess"), module
+
+
+def test_no_socket_or_urllib_or_http_or_requests() -> None:
+    src = _module_source()
+    for forbidden in (
+        "import socket",
+        "from socket",
+        "import urllib",
+        "from urllib",
+        "import http\n",
+        "from http",
+        "import requests",
+        "from requests",
+        "import httpx",
+        "from httpx",
+    ):
+        assert forbidden not in src, forbidden
+
+
+def test_no_forbidden_runtime_imports_via_ast() -> None:
+    forbidden_prefixes = (
+        "dashboard",
+        "automation",
+        "broker",
+        "agent.risk",
+        "agent.execution",
+        "research",
+        "live",
+        "paper",
+        "shadow",
+        "trading",
+        "reporting.intelligent_routing",
+        "reporting.execution_authority",
+        "reporting.development_queue_admission_policy",
+        "reporting.development_agent_activity_timeline",
+    )
+    for module in _module_top_level_imports():
+        for prefix in forbidden_prefixes:
+            assert not (
+                module == prefix or module.startswith(prefix + ".")
+            ), f"forbidden import: {module}"
+
+
+def _code_lines() -> str:
+    """Module source with docstrings + comment lines stripped, so
+    documentation references to forbidden tokens (e.g. ``--admin`` in
+    a 'no --admin' docstring) do not falsely trip the source-scan
+    invariants. Removes triple-quoted strings and ``#`` line comments
+    via AST."""
+    src = _module_source()
+    tree = _ast.parse(src)
+    # Collect (line range, kind) for every triple-quoted string
+    # literal. Strip those line ranges from the source.
+    bad_lines: set[int] = set()
+    for node in _ast.walk(tree):
+        if isinstance(node, _ast.Expr) and isinstance(
+            node.value, _ast.Constant
+        ):
+            if isinstance(node.value.value, str):
+                # This catches module / function / class docstrings.
+                start = node.lineno
+                end = node.end_lineno or start
+                for ln in range(start, end + 1):
+                    bad_lines.add(ln)
+    out: list[str] = []
+    for i, line in enumerate(src.splitlines(), start=1):
+        if i in bad_lines:
+            continue
+        if line.lstrip().startswith("#"):
+            continue
+        out.append(line)
+    return "\n".join(out)
+
+
+def test_no_admin_merge_invocation_in_module_code() -> None:
+    """The runner code must not invoke ``gh pr merge`` or pass
+    ``--admin`` as a shell argument. Auto-merge is explicitly out of
+    scope for A21c. Docstring references are excluded via
+    :func:`_code_lines` so the no-* doctrine in the module docstring
+    does not trip the scan."""
+    code = _code_lines()
+    assert "--admin" not in code
+    assert "pr merge" not in code
+    assert "pr_merge_admin" not in code
+
+
+def test_no_force_push_in_module_code() -> None:
+    code = _code_lines()
+    assert "--force" not in code
+    assert "push --force" not in code
+    assert "--force-with-lease" not in code
+
+
+def test_no_hook_bypass_in_module_code() -> None:
+    code = _code_lines()
+    assert "--no-verify" not in code
+    assert "--no-gpg-sign" not in code
+
+
+def test_no_deploy_invocation_in_module_code() -> None:
+    """No deploy-related shell invocation exists in the runner code.
+    The docstring may legitimately say 'no deploy' and 'no deploy
+    watcher'; :func:`_code_lines` excludes docstring content from
+    this scan."""
+    code = _code_lines()
+    for token in (
+        "Deploy VPS Dashboard",
+        "deploy_vps",
+        "docker push",
+        "ssh root@",
+    ):
+        assert token not in code, token
+
+
+def test_no_eval_or_exec_in_module_code() -> None:
+    code = _code_lines()
+    assert "eval(" not in code
+    assert "exec(" not in code
+    assert "os.system(" not in code
+    assert "shell=True" not in code
+
+
+def test_no_github_api_or_external_api_calls() -> None:
+    src = _module_source()
+    for forbidden in (
+        "api.github.com",
+        "anthropic",
+        "openai",
+        "X-API-Key",
+        "X-GitHub-Token",
+    ):
+        assert forbidden not in src, forbidden
+
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies + schema integrity
+# ---------------------------------------------------------------------------
+
+
+def test_run_status_vocab_is_closed_exact() -> None:
+    assert apr.RUN_STATUS == (
+        "not_run",
+        "status_only",
+        "plan_only",
+        "refused_unsafe",
+        "executed_pr_opened",
+        "executed_blocked_at_implementation",
+        "executed_blocked_at_diff",
+        "executed_blocked_at_tests",
+        "executed_blocked_at_governance_lint",
+        "executed_blocked_at_commit",
+        "executed_blocked_at_push",
+        "executed_blocked_at_pr_create",
+        "executed_blocked_at_ci",
+    )
+
+
+def test_safety_gate_vocab_is_closed_exact() -> None:
+    assert apr.SAFETY_GATE == (
+        "selector_available",
+        "selection_status_ok",
+        "unit_present",
+        "auto_allowed_authority",
+        "low_risk",
+        "no_operator_gate",
+        "no_operator_go_required",
+        "expected_files_nonempty",
+        "forbidden_files_nonempty",
+        "required_tests_nonempty",
+        "no_forbidden_in_expected",
+        "not_terminal_status",
+        "max_units_per_run_one",
+        "implementation_strategy_configured",
+    )
+
+
+def test_gate_result_vocab_is_closed_exact() -> None:
+    assert apr.GATE_RESULT == ("PASS", "FAIL", "NOT_CHECKED")
+
+
+def test_runner_mode_vocab_is_closed_exact() -> None:
+    assert apr.RUNNER_MODE == ("status_only", "plan_only", "run_one")
+
+
+def test_implementation_strategy_vocab_is_closed_exact() -> None:
+    assert apr.IMPLEMENTATION_STRATEGY == ("none", "external_command")
+
+
+def test_stop_reason_vocab_contains_every_required_value() -> None:
+    """Every refusal path in the runner must map to a closed-vocab
+    STOP_REASON value. This pin protects against silent drift."""
+    required = {
+        "status_only_mode",
+        "plan_only_mode",
+        "selector_unavailable",
+        "no_eligible_unit",
+        "ambiguous_selection",
+        "unsafe_authority_class",
+        "unsafe_risk_class",
+        "unsafe_operator_gate",
+        "requires_operator_go",
+        "missing_expected_files",
+        "missing_forbidden_files",
+        "missing_required_tests",
+        "forbidden_path_in_expected_files",
+        "terminal_status",
+        "max_units_exceeded",
+        "implementation_strategy_not_configured",
+        "implementation_strategy_failed",
+        "diff_outside_expected_files",
+        "diff_touches_forbidden_path",
+        "diff_empty",
+        "tests_failed",
+        "governance_lint_failed",
+        "commit_failed",
+        "hook_failed",
+        "branch_creation_failed",
+        "branch_already_exists",
+        "push_failed",
+        "pr_creation_failed",
+        "ci_failed",
+        "ci_timeout",
+        "ci_not_clean",
+        "unknown_evidence",
+        "ok_pr_opened",
+    }
+    assert required.issubset(set(apr.STOP_REASON))
+
+
+def test_runner_report_field_list_exact() -> None:
+    assert apr.RUNNER_REPORT_FIELDS == (
+        "schema_version",
+        "module_version",
+        "report_kind",
+        "generated_at_utc",
+        "mode",
+        "max_units_per_run",
+        "implementation_strategy",
+        "selected_unit_id",
+        "selected_phase",
+        "selected_authority_class",
+        "selected_risk_class",
+        "selected_operator_gate",
+        "branch_name",
+        "safety_gate_results",
+        "commands_run",
+        "files_changed",
+        "tests_run",
+        "pr_number",
+        "ci_status",
+        "stop_reason",
+        "final_runner_status",
+        "next_required_operator_action",
+        "step5_enabled_substage",
+        "step5_implementation_allowed",
+        "runner_invariants",
+    )
+
+
+def test_forbidden_path_patterns_cover_no_touch_list() -> None:
+    required = {
+        ".claude/",
+        ".github/",
+        "dashboard/dashboard.py",
+        "automation/live_gate.py",
+        "broker/",
+        "agent/risk/",
+        "agent/execution/",
+        "live/",
+        "paper/",
+        "shadow/",
+        "trading/",
+        "docs/development_work_queue/",
+        "tests/regression/",
+        "research/research_latest.json",
+        "research/strategy_matrix.csv",
+        "artifacts/",
+    }
+    assert required.issubset(set(apr.FORBIDDEN_PATH_PATTERNS))
+
+
+def test_max_units_per_run_hard_capped_at_one() -> None:
+    assert apr.MAX_UNITS_PER_RUN_HARD_CAP == 1
+
+
+def test_step5_implementation_allowed_is_final_false() -> None:
+    assert apr.step5_implementation_allowed is False
+
+
+def test_step5_enabled_substage_is_a21c() -> None:
+    assert apr.STEP5_ENABLED_SUBSTAGE == "a21c_bounded_pr_creation"
+
+
+def test_module_version_string() -> None:
+    assert apr.MODULE_VERSION.endswith("A21c")
+
+
+# ---------------------------------------------------------------------------
+# Default CLI surface: status / plan-only do not execute anything
+# ---------------------------------------------------------------------------
+
+
+def test_cli_default_does_not_execute(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Bare ``python -m reporting.autonomous_pr_runner`` (no flag)
+    falls back to status-only and writes nothing."""
+    sentinel = tmp_path / "logs" / "autonomous_pr_runner" / "latest.json"
+    monkeypatch.setattr(apr, "ARTIFACT_LATEST", sentinel)
+    monkeypatch.setattr(apr, "ARTIFACT_DIR", sentinel.parent)
+    rc = apr.main([])
+    assert rc == 0
+    assert not sentinel.exists()
+    out = capsys.readouterr().out
+    assert "mode=status_only" in out
+    assert "final_runner_status=status_only" in out
+
+
+def test_cli_status_does_not_execute(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    sentinel = tmp_path / "logs" / "autonomous_pr_runner" / "latest.json"
+    monkeypatch.setattr(apr, "ARTIFACT_LATEST", sentinel)
+    monkeypatch.setattr(apr, "ARTIFACT_DIR", sentinel.parent)
+    rc = apr.main(["--status"])
+    assert rc == 0
+    assert not sentinel.exists()
+    out = capsys.readouterr().out
+    assert "no_runtime_trading_authority=True" in out
+    assert "no_auto_merge=True" in out
+    assert "no_deploy=True" in out
+    assert "no_step5_broad=True" in out
+    assert "no_level6=True" in out
+
+
+def test_cli_plan_only_does_not_execute(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    sentinel = tmp_path / "logs" / "autonomous_pr_runner" / "latest.json"
+    monkeypatch.setattr(apr, "ARTIFACT_LATEST", sentinel)
+    monkeypatch.setattr(apr, "ARTIFACT_DIR", sentinel.parent)
+    rc = apr.main(["--plan-only", "--no-write"])
+    assert rc == 0
+    assert not sentinel.exists()
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+    assert payload["mode"] == "plan_only"
+    assert payload["final_runner_status"] == "plan_only"
+    # No git / gh command should have been recorded.
+    for cmd in payload["commands_run"]:
+        first = cmd["command"].split()[:1]
+        assert first not in (["git"], ["gh"])
+
+
+def test_cli_run_one_with_default_strategy_refuses(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--run-one`` without an explicit strategy is refused at
+    the implementation_strategy_configured gate."""
+    sentinel = tmp_path / "logs" / "autonomous_pr_runner" / "latest.json"
+    monkeypatch.setattr(apr, "ARTIFACT_LATEST", sentinel)
+    monkeypatch.setattr(apr, "ARTIFACT_DIR", sentinel.parent)
+    # Use --no-write to avoid touching the real repo logs/ dir.
+    rc = apr.main(["--run-one", "--no-write"])
+    # Exit code is non-zero because stop_reason != ok_pr_opened.
+    assert rc != 0
+
+
+# ---------------------------------------------------------------------------
+# Safety gate evaluation
+# ---------------------------------------------------------------------------
+
+
+def _baseline_selector_snapshot(unit_id: str = "u_runner_synth") -> dict[str, Any]:
+    return {
+        "selection": {
+            "selection_status": "OK_SELECTED",
+            "selected_unit_id": unit_id,
+            "selected_phase": "v3.15.17",
+            "selected_authority_class": "AUTO_ALLOWED",
+            "selected_risk_class": "LOW",
+            "selected_operator_gate": "none",
+            "requires_operator_go": False,
+        }
+    }
+
+
+def _baseline_unit() -> dict[str, Any]:
+    return {
+        "id": "u_runner_synth",
+        "expected_files": [
+            "reporting/synthetic_runner_target.py",
+            "tests/unit/test_synthetic_runner_target.py",
+        ],
+        "forbidden_files": [".claude/**"],
+        "required_tests": ["tests/unit/test_synthetic_runner_target.py"],
+        "status": "not_started",
+    }
+
+
+def test_gates_pass_on_happy_path() -> None:
+    gates, fail = apr.evaluate_safety_gates(
+        selector_snapshot=_baseline_selector_snapshot(),
+        unit=_baseline_unit(),
+        max_units=1,
+        implementation_strategy="external_command",
+    )
+    assert fail is None
+    for g in gates:
+        assert g["result"] == "PASS", g
+
+
+def test_gates_fail_when_selector_unavailable() -> None:
+    gates, fail = apr.evaluate_safety_gates(
+        selector_snapshot=None,
+        unit=None,
+        max_units=1,
+        implementation_strategy="external_command",
+    )
+    assert fail == "selector_unavailable"
+    # Every other gate must be NOT_CHECKED.
+    for g in gates[1:]:
+        assert g["result"] == "NOT_CHECKED", g
+
+
+def test_gates_pass_selection_status_when_all_needs_human_gated() -> None:
+    """``ALL_NEEDS_HUMAN_GATED`` names a specific gated unit; the
+    selection_status_ok gate intentionally lets it through so the
+    downstream per-authority gate produces the more specific stop
+    reason (``unsafe_authority_class`` / ``unsafe_operator_gate`` /
+    ``requires_operator_go``)."""
+    snap = _baseline_selector_snapshot()
+    snap["selection"]["selection_status"] = "ALL_NEEDS_HUMAN_GATED"
+    snap["selection"]["selected_authority_class"] = "NEEDS_HUMAN"
+    snap["selection"]["requires_operator_go"] = True
+    gates, fail = apr.evaluate_safety_gates(
+        selector_snapshot=snap,
+        unit=_baseline_unit(),
+        max_units=1,
+        implementation_strategy="external_command",
+    )
+    # selection_status_ok gate PASSES; authority gate FAILS first.
+    assert fail == "unsafe_authority_class"
+    by_gate = {g["gate"]: g for g in gates}
+    assert by_gate["selection_status_ok"]["result"] == "PASS"
+    assert by_gate["auto_allowed_authority"]["result"] == "FAIL"
+
+
+@pytest.mark.parametrize(
+    "bad_status,expected_fail",
+    [
+        ("NO_ELIGIBLE_UNITS", "no_eligible_unit"),
+        ("UPSTREAM_UNAVAILABLE", "no_eligible_unit"),
+        ("ALL_PERMANENTLY_DENIED", "ambiguous_selection"),
+        ("ALL_BLOCKED_BY_PREREQUISITES", "ambiguous_selection"),
+        ("FAIL_CLOSED_INVARIANT", "ambiguous_selection"),
+    ],
+)
+def test_gates_fail_when_selection_status_terminal_no_unit(
+    bad_status: str, expected_fail: str
+) -> None:
+    snap = _baseline_selector_snapshot()
+    snap["selection"]["selection_status"] = bad_status
+    gates, fail = apr.evaluate_safety_gates(
+        selector_snapshot=snap,
+        unit=_baseline_unit(),
+        max_units=1,
+        implementation_strategy="external_command",
+    )
+    assert fail == expected_fail
+
+
+def test_gates_fail_on_needs_human_authority() -> None:
+    snap = _baseline_selector_snapshot()
+    snap["selection"]["selected_authority_class"] = "NEEDS_HUMAN"
+    gates, fail = apr.evaluate_safety_gates(
+        selector_snapshot=snap,
+        unit=_baseline_unit(),
+        max_units=1,
+        implementation_strategy="external_command",
+    )
+    assert fail == "unsafe_authority_class"
+
+
+def test_gates_fail_on_permanently_denied_authority() -> None:
+    snap = _baseline_selector_snapshot()
+    snap["selection"]["selected_authority_class"] = "PERMANENTLY_DENIED"
+    gates, fail = apr.evaluate_safety_gates(
+        selector_snapshot=snap,
+        unit=_baseline_unit(),
+        max_units=1,
+        implementation_strategy="external_command",
+    )
+    assert fail == "unsafe_authority_class"
+
+
+@pytest.mark.parametrize("risk", ["MEDIUM", "HIGH", "CRITICAL", "UNKNOWN"])
+def test_gates_fail_on_non_low_risk(risk: str) -> None:
+    snap = _baseline_selector_snapshot()
+    snap["selection"]["selected_risk_class"] = risk
+    gates, fail = apr.evaluate_safety_gates(
+        selector_snapshot=snap,
+        unit=_baseline_unit(),
+        max_units=1,
+        implementation_strategy="external_command",
+    )
+    assert fail == "unsafe_risk_class"
+
+
+@pytest.mark.parametrize(
+    "gate_value",
+    ["operator_go_required", "governance_bootstrap_pr_required"],
+)
+def test_gates_fail_on_non_none_operator_gate(gate_value: str) -> None:
+    snap = _baseline_selector_snapshot()
+    snap["selection"]["selected_operator_gate"] = gate_value
+    gates, fail = apr.evaluate_safety_gates(
+        selector_snapshot=snap,
+        unit=_baseline_unit(),
+        max_units=1,
+        implementation_strategy="external_command",
+    )
+    assert fail == "unsafe_operator_gate"
+
+
+def test_gates_fail_on_requires_operator_go() -> None:
+    snap = _baseline_selector_snapshot()
+    snap["selection"]["requires_operator_go"] = True
+    gates, fail = apr.evaluate_safety_gates(
+        selector_snapshot=snap,
+        unit=_baseline_unit(),
+        max_units=1,
+        implementation_strategy="external_command",
+    )
+    assert fail == "requires_operator_go"
+
+
+def test_gates_fail_when_expected_files_empty() -> None:
+    unit = _baseline_unit()
+    unit["expected_files"] = []
+    gates, fail = apr.evaluate_safety_gates(
+        selector_snapshot=_baseline_selector_snapshot(),
+        unit=unit,
+        max_units=1,
+        implementation_strategy="external_command",
+    )
+    assert fail == "missing_expected_files"
+
+
+def test_gates_fail_when_forbidden_files_empty() -> None:
+    unit = _baseline_unit()
+    unit["forbidden_files"] = []
+    gates, fail = apr.evaluate_safety_gates(
+        selector_snapshot=_baseline_selector_snapshot(),
+        unit=unit,
+        max_units=1,
+        implementation_strategy="external_command",
+    )
+    assert fail == "missing_forbidden_files"
+
+
+def test_gates_fail_when_required_tests_empty() -> None:
+    unit = _baseline_unit()
+    unit["required_tests"] = []
+    gates, fail = apr.evaluate_safety_gates(
+        selector_snapshot=_baseline_selector_snapshot(),
+        unit=unit,
+        max_units=1,
+        implementation_strategy="external_command",
+    )
+    assert fail == "missing_required_tests"
+
+
+@pytest.mark.parametrize(
+    "forbidden_in_expected",
+    [
+        "dashboard/dashboard.py",
+        ".claude/hooks/x.py",
+        ".github/workflows/main.yml",
+        "automation/live_gate.py",
+        "broker/router.py",
+        "agent/risk/limits.py",
+        "agent/execution/runner.py",
+        "live/strategy.py",
+        "paper/strategy.py",
+        "shadow/strategy.py",
+        "trading/api.py",
+        "research/research_latest.json",
+        "research/strategy_matrix.csv",
+        "tests/regression/test_authority_invariants.py",
+        "docs/development_work_queue/admission.jsonl",
+        "reporting/execution_authority.py",
+        "reporting/development_queue_admission_policy.py",
+    ],
+)
+def test_gates_fail_when_expected_files_contains_forbidden_path(
+    forbidden_in_expected: str,
+) -> None:
+    unit = _baseline_unit()
+    unit["expected_files"] = [forbidden_in_expected]
+    gates, fail = apr.evaluate_safety_gates(
+        selector_snapshot=_baseline_selector_snapshot(),
+        unit=unit,
+        max_units=1,
+        implementation_strategy="external_command",
+    )
+    assert fail == "forbidden_path_in_expected_files"
+
+
+@pytest.mark.parametrize(
+    "terminal_status",
+    ["merged", "blocked", "skipped", "failed"],
+)
+def test_gates_fail_on_terminal_static_status(
+    terminal_status: str,
+) -> None:
+    unit = _baseline_unit()
+    unit["status"] = terminal_status
+    gates, fail = apr.evaluate_safety_gates(
+        selector_snapshot=_baseline_selector_snapshot(),
+        unit=unit,
+        max_units=1,
+        implementation_strategy="external_command",
+    )
+    assert fail == "terminal_status"
+
+
+@pytest.mark.parametrize("requested", [0, 2, 3, 5, 10])
+def test_gates_fail_when_max_units_not_one(requested: int) -> None:
+    gates, fail = apr.evaluate_safety_gates(
+        selector_snapshot=_baseline_selector_snapshot(),
+        unit=_baseline_unit(),
+        max_units=requested,
+        implementation_strategy="external_command",
+    )
+    assert fail == "max_units_exceeded"
+
+
+def test_gates_fail_when_implementation_strategy_is_default_none() -> None:
+    gates, fail = apr.evaluate_safety_gates(
+        selector_snapshot=_baseline_selector_snapshot(),
+        unit=_baseline_unit(),
+        max_units=1,
+        implementation_strategy="none",
+    )
+    assert fail == "implementation_strategy_not_configured"
+
+
+def test_gates_fail_on_unknown_implementation_strategy() -> None:
+    gates, fail = apr.evaluate_safety_gates(
+        selector_snapshot=_baseline_selector_snapshot(),
+        unit=_baseline_unit(),
+        max_units=1,
+        implementation_strategy="some_unknown_strategy",
+    )
+    assert fail == "implementation_strategy_not_configured"
+
+
+# ---------------------------------------------------------------------------
+# status() / plan() do not execute
+# ---------------------------------------------------------------------------
+
+
+def test_status_does_not_invoke_shell_or_strategy(tmp_path: Path) -> None:
+    _write_minimal_upstreams(tmp_path)
+    report = apr.status(
+        repo_root=tmp_path, generated_at_utc=_FROZEN_UTC
+    )
+    assert report["mode"] == "status_only"
+    assert report["final_runner_status"] == "status_only"
+    assert report["stop_reason"] == "status_only_mode"
+    assert report["commands_run"] == []
+
+
+def test_plan_evaluates_gates_but_does_not_execute(tmp_path: Path) -> None:
+    _write_minimal_upstreams(tmp_path)
+    report = apr.plan(
+        repo_root=tmp_path,
+        generated_at_utc=_FROZEN_UTC,
+        implementation_strategy="external_command",
+    )
+    assert report["mode"] == "plan_only"
+    assert report["final_runner_status"] == "plan_only"
+    assert report["commands_run"] == []
+    assert report["branch_name"].startswith("step5-a21c/")
+    for g in report["safety_gate_results"]:
+        assert g["result"] in apr.GATE_RESULT
+
+
+def test_plan_with_default_strategy_marks_gate_fail(tmp_path: Path) -> None:
+    _write_minimal_upstreams(tmp_path)
+    report = apr.plan(
+        repo_root=tmp_path,
+        generated_at_utc=_FROZEN_UTC,
+    )
+    assert report["stop_reason"] == "implementation_strategy_not_configured"
+
+
+# ---------------------------------------------------------------------------
+# run_one(...) end-to-end with fakes
+# ---------------------------------------------------------------------------
+
+
+def _run_one_with_fakes(
+    tmp_path: Path,
+    *,
+    shell: _FakeShell,
+    strategy: _FakeStrategy,
+    unit_overrides: dict[str, Any] | None = None,
+    decision_overrides: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    _write_minimal_upstreams(
+        tmp_path,
+        unit_overrides=unit_overrides,
+        decision_overrides=decision_overrides,
+    )
+    return apr.run_one(
+        repo_root=tmp_path,
+        generated_at_utc=_FROZEN_UTC,
+        implementation_strategy_name="external_command",
+        shell=shell,
+        implementation_strategy=strategy,
+    )
+
+
+def _queue_happy_path_shell(
+    shell: _FakeShell,
+    *,
+    changed_paths: list[str],
+    pr_number: int = 999,
+) -> None:
+    # git checkout -b
+    shell.queue(("git", "checkout"), exit_code=0)
+    # git status --porcelain (after implementation)
+    porcelain = "\n".join(f" M {p}" for p in changed_paths)
+    shell.queue(
+        ("git", "status"),
+        exit_code=0,
+        stdout=porcelain,
+    )
+    # required tests (one per required_test entry)
+    shell.queue(("python", "-m", "pytest"), exit_code=0)
+    # smoke tests
+    shell.queue(("python", "-m", "pytest"), exit_code=0)
+    # governance lint
+    shell.queue(("python", "scripts/governance_lint.py"), exit_code=0)
+    # git add (one per changed_path)
+    for _ in changed_paths:
+        shell.queue(("git", "add"), exit_code=0)
+    # git commit
+    shell.queue(("git", "commit"), exit_code=0)
+    # git push
+    shell.queue(("git", "push"), exit_code=0)
+    # gh pr create
+    shell.queue(
+        ("gh", "pr", "create"),
+        exit_code=0,
+        stdout=f"https://github.com/test/test/pull/{pr_number}\n",
+    )
+    # gh pr checks --watch
+    shell.queue(("gh", "pr", "checks"), exit_code=0)
+
+
+def test_run_one_happy_path_opens_pr_and_stops(tmp_path: Path) -> None:
+    shell = _FakeShell()
+    strategy = _FakeStrategy(success=True)
+    _queue_happy_path_shell(
+        shell,
+        changed_paths=[
+            "reporting/synthetic_runner_target.py",
+            "tests/unit/test_synthetic_runner_target.py",
+        ],
+        pr_number=999,
+    )
+    report = _run_one_with_fakes(
+        tmp_path, shell=shell, strategy=strategy
+    )
+    assert report["final_runner_status"] == "executed_pr_opened"
+    assert report["stop_reason"] == "ok_pr_opened"
+    assert report["pr_number"] == 999
+    assert report["ci_status"] == "PASS"
+    assert strategy.calls == [
+        {"unit_id": "u_runner_synth", "root": tmp_path}
+    ]
+
+
+def test_run_one_does_not_auto_merge_or_deploy(tmp_path: Path) -> None:
+    """No shell invocation should be ``gh pr merge``, carry
+    ``--admin``, or be a deploy command. Commit / PR body arguments
+    are excluded because their text legitimately states the no-deploy
+    posture."""
+    shell = _FakeShell()
+    strategy = _FakeStrategy(success=True)
+    _queue_happy_path_shell(
+        shell,
+        changed_paths=[
+            "reporting/synthetic_runner_target.py",
+            "tests/unit/test_synthetic_runner_target.py",
+        ],
+    )
+    _run_one_with_fakes(
+        tmp_path, shell=shell, strategy=strategy
+    )
+    for call_args, _cwd, _timeout in shell.calls:
+        # No gh-pr-merge command and no deploy command.
+        assert call_args[:3] != ["gh", "pr", "merge"]
+        assert call_args[:1] != ["deploy"]
+        # The first token (program name) must not be deploy-related.
+        first = call_args[0] if call_args else ""
+        assert "deploy" not in first.lower()
+        # Inspect each argument individually so we can skip commit /
+        # PR body text. The body intentionally states 'no auto-merge'
+        # and 'no deploy' as part of the safety posture.
+        for i, arg in enumerate(call_args):
+            # Commit message follows ``git commit -m``.
+            if (
+                i >= 1
+                and call_args[0] == "git"
+                and len(call_args) > 1
+                and call_args[1] == "commit"
+                and call_args[i - 1] == "-m"
+            ):
+                continue
+            # PR title follows ``--title`` and PR body follows
+            # ``--body`` in ``gh pr create``.
+            if i >= 1 and call_args[i - 1] in {"--title", "--body"}:
+                continue
+            assert "--admin" not in arg
+            # Reject deploy as a literal arg in any non-message
+            # position (e.g. ``deploy --target prod``).
+            assert arg.lower() != "deploy"
+
+
+def test_run_one_refuses_unsafe_authority(tmp_path: Path) -> None:
+    shell = _FakeShell()
+    strategy = _FakeStrategy()
+    report = _run_one_with_fakes(
+        tmp_path,
+        shell=shell,
+        strategy=strategy,
+        decision_overrides={
+            "final_authority_class": "NEEDS_HUMAN",
+            "requires_operator_go": True,
+        },
+        unit_overrides={"authority_hint": "NEEDS_HUMAN_CANDIDATE"},
+    )
+    assert report["final_runner_status"] == "refused_unsafe"
+    assert report["stop_reason"] == "unsafe_authority_class"
+    # No shell call should have happened — refusal is pre-execution.
+    assert shell.calls == []
+    assert strategy.calls == []
+
+
+def test_run_one_refuses_diff_outside_expected_files(
+    tmp_path: Path,
+) -> None:
+    shell = _FakeShell()
+    strategy = _FakeStrategy(success=True)
+    shell.queue(("git", "checkout"), exit_code=0)
+    shell.queue(
+        ("git", "status"),
+        exit_code=0,
+        stdout=" M reporting/somewhere_unexpected.py\n",
+    )
+    report = _run_one_with_fakes(
+        tmp_path, shell=shell, strategy=strategy
+    )
+    assert report["final_runner_status"] == "executed_blocked_at_diff"
+    assert report["stop_reason"] == "diff_outside_expected_files"
+
+
+def test_run_one_refuses_diff_touching_forbidden_path(
+    tmp_path: Path,
+) -> None:
+    shell = _FakeShell()
+    strategy = _FakeStrategy(success=True)
+    shell.queue(("git", "checkout"), exit_code=0)
+    shell.queue(
+        ("git", "status"),
+        exit_code=0,
+        stdout=" M dashboard/dashboard.py\n",
+    )
+    report = _run_one_with_fakes(
+        tmp_path, shell=shell, strategy=strategy
+    )
+    assert report["final_runner_status"] == "executed_blocked_at_diff"
+    assert report["stop_reason"] == "diff_touches_forbidden_path"
+
+
+def test_run_one_refuses_empty_diff(tmp_path: Path) -> None:
+    shell = _FakeShell()
+    strategy = _FakeStrategy(success=True)
+    shell.queue(("git", "checkout"), exit_code=0)
+    shell.queue(("git", "status"), exit_code=0, stdout="")
+    report = _run_one_with_fakes(
+        tmp_path, shell=shell, strategy=strategy
+    )
+    assert report["final_runner_status"] == "executed_blocked_at_diff"
+    assert report["stop_reason"] == "diff_empty"
+
+
+def test_run_one_stops_on_failing_required_tests(tmp_path: Path) -> None:
+    shell = _FakeShell()
+    strategy = _FakeStrategy(success=True)
+    shell.queue(("git", "checkout"), exit_code=0)
+    shell.queue(
+        ("git", "status"),
+        exit_code=0,
+        stdout=(
+            " M reporting/synthetic_runner_target.py\n"
+            " M tests/unit/test_synthetic_runner_target.py\n"
+        ),
+    )
+    # Required test fails.
+    shell.queue(("python", "-m", "pytest"), exit_code=1, stdout="FAIL")
+    report = _run_one_with_fakes(
+        tmp_path, shell=shell, strategy=strategy
+    )
+    assert report["final_runner_status"] == "executed_blocked_at_tests"
+    assert report["stop_reason"] == "tests_failed"
+
+
+def test_run_one_stops_on_failing_governance_lint(tmp_path: Path) -> None:
+    shell = _FakeShell()
+    strategy = _FakeStrategy(success=True)
+    shell.queue(("git", "checkout"), exit_code=0)
+    shell.queue(
+        ("git", "status"),
+        exit_code=0,
+        stdout=(
+            " M reporting/synthetic_runner_target.py\n"
+            " M tests/unit/test_synthetic_runner_target.py\n"
+        ),
+    )
+    # required tests pass
+    shell.queue(("python", "-m", "pytest"), exit_code=0)
+    # smoke pass
+    shell.queue(("python", "-m", "pytest"), exit_code=0)
+    # governance lint fails
+    shell.queue(("python", "scripts/governance_lint.py"), exit_code=1)
+    report = _run_one_with_fakes(
+        tmp_path, shell=shell, strategy=strategy
+    )
+    assert report["final_runner_status"] == (
+        "executed_blocked_at_governance_lint"
+    )
+    assert report["stop_reason"] == "governance_lint_failed"
+
+
+def test_run_one_stops_on_implementation_strategy_failure(
+    tmp_path: Path,
+) -> None:
+    shell = _FakeShell()
+    strategy = _FakeStrategy(success=False, reason="strategy_died")
+    shell.queue(("git", "checkout"), exit_code=0)
+    report = _run_one_with_fakes(
+        tmp_path, shell=shell, strategy=strategy
+    )
+    assert report["final_runner_status"] == (
+        "executed_blocked_at_implementation"
+    )
+    assert report["stop_reason"] == "implementation_strategy_failed"
+
+
+def test_run_one_stops_on_branch_creation_failure(tmp_path: Path) -> None:
+    shell = _FakeShell()
+    strategy = _FakeStrategy(success=True)
+    shell.queue(
+        ("git", "checkout"),
+        exit_code=1,
+        stderr="fatal: cannot create branch",
+    )
+    report = _run_one_with_fakes(
+        tmp_path, shell=shell, strategy=strategy
+    )
+    assert report["final_runner_status"] == (
+        "executed_blocked_at_implementation"
+    )
+    assert report["stop_reason"] == "branch_creation_failed"
+    # Strategy must not have been invoked.
+    assert strategy.calls == []
+
+
+def test_run_one_detects_branch_already_exists(tmp_path: Path) -> None:
+    shell = _FakeShell()
+    strategy = _FakeStrategy(success=True)
+    shell.queue(
+        ("git", "checkout"),
+        exit_code=128,
+        stderr="fatal: a branch named 'step5-a21c/u_runner_synth' already exists",
+    )
+    report = _run_one_with_fakes(
+        tmp_path, shell=shell, strategy=strategy
+    )
+    assert report["stop_reason"] == "branch_already_exists"
+
+
+def test_run_one_stops_on_push_failure(tmp_path: Path) -> None:
+    shell = _FakeShell()
+    strategy = _FakeStrategy(success=True)
+    shell.queue(("git", "checkout"), exit_code=0)
+    shell.queue(
+        ("git", "status"),
+        exit_code=0,
+        stdout=(
+            " M reporting/synthetic_runner_target.py\n"
+            " M tests/unit/test_synthetic_runner_target.py\n"
+        ),
+    )
+    shell.queue(("python", "-m", "pytest"), exit_code=0)
+    shell.queue(("python", "-m", "pytest"), exit_code=0)
+    shell.queue(("python", "scripts/governance_lint.py"), exit_code=0)
+    shell.queue(("git", "add"), exit_code=0)
+    shell.queue(("git", "add"), exit_code=0)
+    shell.queue(("git", "commit"), exit_code=0)
+    shell.queue(("git", "push"), exit_code=1, stderr="rejected")
+    report = _run_one_with_fakes(
+        tmp_path, shell=shell, strategy=strategy
+    )
+    assert report["final_runner_status"] == "executed_blocked_at_push"
+    assert report["stop_reason"] == "push_failed"
+
+
+def test_run_one_stops_on_pr_creation_failure(tmp_path: Path) -> None:
+    shell = _FakeShell()
+    strategy = _FakeStrategy(success=True)
+    shell.queue(("git", "checkout"), exit_code=0)
+    shell.queue(
+        ("git", "status"),
+        exit_code=0,
+        stdout=(
+            " M reporting/synthetic_runner_target.py\n"
+            " M tests/unit/test_synthetic_runner_target.py\n"
+        ),
+    )
+    shell.queue(("python", "-m", "pytest"), exit_code=0)
+    shell.queue(("python", "-m", "pytest"), exit_code=0)
+    shell.queue(("python", "scripts/governance_lint.py"), exit_code=0)
+    shell.queue(("git", "add"), exit_code=0)
+    shell.queue(("git", "add"), exit_code=0)
+    shell.queue(("git", "commit"), exit_code=0)
+    shell.queue(("git", "push"), exit_code=0)
+    shell.queue(("gh", "pr", "create"), exit_code=1, stderr="boom")
+    report = _run_one_with_fakes(
+        tmp_path, shell=shell, strategy=strategy
+    )
+    assert report["final_runner_status"] == (
+        "executed_blocked_at_pr_create"
+    )
+    assert report["stop_reason"] == "pr_creation_failed"
+
+
+def test_run_one_stops_on_ci_failure(tmp_path: Path) -> None:
+    shell = _FakeShell()
+    strategy = _FakeStrategy(success=True)
+    _queue_happy_path_shell(
+        shell,
+        changed_paths=[
+            "reporting/synthetic_runner_target.py",
+            "tests/unit/test_synthetic_runner_target.py",
+        ],
+    )
+    # Replace the CI-watch queued entry (last entry) with a failure.
+    # Easier: pop the last entry and re-queue a failing one.
+    for i, (prefix, _r) in enumerate(shell.results):
+        if prefix == ("gh", "pr", "checks"):
+            shell.results.pop(i)
+            break
+    shell.queue(("gh", "pr", "checks"), exit_code=1, stderr="failing")
+    report = _run_one_with_fakes(
+        tmp_path, shell=shell, strategy=strategy
+    )
+    assert report["final_runner_status"] == "executed_blocked_at_ci"
+    assert report["stop_reason"] == "ci_failed"
+    assert report["ci_status"] == "FAIL"
+
+
+def test_run_one_stops_on_ci_timeout(tmp_path: Path) -> None:
+    shell = _FakeShell()
+    strategy = _FakeStrategy(success=True)
+    _queue_happy_path_shell(
+        shell,
+        changed_paths=[
+            "reporting/synthetic_runner_target.py",
+            "tests/unit/test_synthetic_runner_target.py",
+        ],
+    )
+    for i, (prefix, _r) in enumerate(shell.results):
+        if prefix == ("gh", "pr", "checks"):
+            shell.results.pop(i)
+            break
+    shell.queue(("gh", "pr", "checks"), exit_code=124, stderr="timeout")
+    report = _run_one_with_fakes(
+        tmp_path, shell=shell, strategy=strategy
+    )
+    assert report["final_runner_status"] == "executed_blocked_at_ci"
+    assert report["stop_reason"] == "ci_timeout"
+    assert report["ci_status"] == "TIMEOUT"
+
+
+# ---------------------------------------------------------------------------
+# Runner invariants pinned on every report
+# ---------------------------------------------------------------------------
+
+
+def test_runner_invariants_pin_no_runtime_trading_authority(
+    tmp_path: Path,
+) -> None:
+    _write_minimal_upstreams(tmp_path)
+    report = apr.status(repo_root=tmp_path, generated_at_utc=_FROZEN_UTC)
+    inv = report["runner_invariants"]
+    assert inv["no_runtime_trading_authority"] is True
+
+
+def test_runner_invariants_pin_no_auto_merge_no_deploy(
+    tmp_path: Path,
+) -> None:
+    _write_minimal_upstreams(tmp_path)
+    report = apr.status(repo_root=tmp_path, generated_at_utc=_FROZEN_UTC)
+    inv = report["runner_invariants"]
+    assert inv["no_auto_merge"] is True
+    assert inv["no_admin_merge"] is True
+    assert inv["no_force_push"] is True
+    assert inv["no_hook_bypass"] is True
+    assert inv["no_deploy"] is True
+    assert inv["no_deploy_watcher"] is True
+
+
+def test_runner_invariants_pin_no_step5_broad_no_level6(
+    tmp_path: Path,
+) -> None:
+    _write_minimal_upstreams(tmp_path)
+    report = apr.status(repo_root=tmp_path, generated_at_utc=_FROZEN_UTC)
+    inv = report["runner_invariants"]
+    assert inv["no_step5_broad"] is True
+    assert inv["no_level6"] is True
+    assert inv["no_production_merge_authority"] is True
+    assert report["step5_implementation_allowed"] is False
+
+
+def test_runner_invariants_pin_bounded_step5_pr_creation_only(
+    tmp_path: Path,
+) -> None:
+    _write_minimal_upstreams(tmp_path)
+    report = apr.status(repo_root=tmp_path, generated_at_utc=_FROZEN_UTC)
+    inv = report["runner_invariants"]
+    assert inv["bounded_step5_pr_creation_only"] is True
+    assert inv["max_units_per_run_hard_capped_at_one"] is True
+
+
+def test_runner_invariants_pin_no_ledger_or_seed_mutation(
+    tmp_path: Path,
+) -> None:
+    _write_minimal_upstreams(tmp_path)
+    report = apr.status(repo_root=tmp_path, generated_at_utc=_FROZEN_UTC)
+    inv = report["runner_invariants"]
+    assert inv["no_ledger_mutation"] is True
+    assert inv["writes_to_dynamic_status_ledger"] is False
+    assert inv["writes_to_seed_jsonl"] is False
+    assert inv["writes_to_work_queue_jsonl"] is False
+
+
+def test_runner_invariants_pin_no_mutation_routes_or_approval_buttons(
+    tmp_path: Path,
+) -> None:
+    _write_minimal_upstreams(tmp_path)
+    report = apr.status(repo_root=tmp_path, generated_at_utc=_FROZEN_UTC)
+    inv = report["runner_invariants"]
+    assert inv["no_mutation_routes"] is True
+    assert inv["no_approval_buttons"] is True
+    assert inv["no_approval_inbox_mutation"] is True
+
+
+def test_runner_invariants_pin_no_subprocess_outside_run_one(
+    tmp_path: Path,
+) -> None:
+    _write_minimal_upstreams(tmp_path)
+    report = apr.status(repo_root=tmp_path, generated_at_utc=_FROZEN_UTC)
+    inv = report["runner_invariants"]
+    assert inv["subprocess_module_used_only_inside_run_one"] is True
+    assert inv["uses_subprocess_outside_run_one"] is False
+    assert inv["uses_network"] is False
+    assert inv["calls_llm_or_external_api"] is False
+
+
+def test_runner_invariants_pin_fail_closed_contracts(
+    tmp_path: Path,
+) -> None:
+    _write_minimal_upstreams(tmp_path)
+    report = apr.status(repo_root=tmp_path, generated_at_utc=_FROZEN_UTC)
+    inv = report["runner_invariants"]
+    assert inv["fail_closed_on_unsafe_unit"] is True
+    assert inv["fail_closed_on_diff_outside_expected_files"] is True
+    assert inv["fail_closed_on_forbidden_diff_path"] is True
+    assert inv["fail_closed_on_test_failure"] is True
+    assert inv["fail_closed_on_governance_lint_failure"] is True
+    assert inv["fail_closed_on_ci_failure"] is True
+
+
+# ---------------------------------------------------------------------------
+# Atomic write allowlist
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_write_refuses_path_outside_allowlist(
+    tmp_path: Path,
+) -> None:
+    bad = tmp_path / "logs" / "elsewhere" / "latest.json"
+    bad.parent.mkdir(parents=True, exist_ok=True)
+    with pytest.raises(ValueError):
+        apr._atomic_write_json(bad, {"x": 1})
+
+
+def test_atomic_write_refuses_frozen_contract_paths(
+    tmp_path: Path,
+) -> None:
+    for forbidden in (
+        "research/research_latest.json",
+        "research/strategy_matrix.csv",
+        "docs/development_work_queue/latest.jsonl",
+    ):
+        target = tmp_path / forbidden
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with pytest.raises(ValueError):
+            apr._atomic_write_json(target, {"x": 1})
+
+
+def test_atomic_write_accepts_allowlisted_path(tmp_path: Path) -> None:
+    good = tmp_path / "logs" / "autonomous_pr_runner" / "latest.json"
+    good.parent.mkdir(parents=True, exist_ok=True)
+    apr._atomic_write_json(good, {"x": 1})
+    assert good.is_file()
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+def test_status_deterministic_with_injected_ts(tmp_path: Path) -> None:
+    _write_minimal_upstreams(tmp_path)
+    a = apr.status(repo_root=tmp_path, generated_at_utc=_FROZEN_UTC)
+    b = apr.status(repo_root=tmp_path, generated_at_utc=_FROZEN_UTC)
+    assert a == b
+
+
+def test_plan_deterministic_with_injected_ts(tmp_path: Path) -> None:
+    _write_minimal_upstreams(tmp_path)
+    a = apr.plan(
+        repo_root=tmp_path,
+        generated_at_utc=_FROZEN_UTC,
+        implementation_strategy="external_command",
+    )
+    b = apr.plan(
+        repo_root=tmp_path,
+        generated_at_utc=_FROZEN_UTC,
+        implementation_strategy="external_command",
+    )
+    out_a = json.dumps(a, indent=2, sort_keys=True)
+    out_b = json.dumps(b, indent=2, sort_keys=True)
+    assert out_a == out_b
+
+
+# ---------------------------------------------------------------------------
+# Real shell runner factory invariants
+# ---------------------------------------------------------------------------
+
+
+def test_real_shell_runner_factory_imports_subprocess_lazily() -> None:
+    """The real shell runner factory must import ``subprocess`` at
+    invocation time, not at module load time. This is what keeps
+    ``import reporting.autonomous_pr_runner`` import-safe."""
+    src = _module_source()
+    # Module-level: subprocess MUST NOT be imported at top.
+    top = _module_top_level_imports()
+    for module in top:
+        assert not module.startswith("subprocess"), module
+    # But the factory body must contain a deferred subprocess import.
+    assert "import subprocess" in src
+
+
+def test_real_shell_runner_factory_is_called_only_inside_run_one() -> None:
+    """The factory is named ``_real_shell_runner_factory``. The
+    runner only calls it when ``shell is None`` inside ``run_one``.
+    Counted as ``= _real_shell_runner_factory()`` to exclude the
+    function-definition line."""
+    src = _module_source()
+    call_sites = src.count("= _real_shell_runner_factory()")
+    assert call_sites == 1
+
+
+def test_module_imports_only_canonical_upstreams() -> None:
+    """The runner may only import from A20b / A20e / A21a (read-only)
+    and may NOT import the canonical execution_authority classifier
+    or any runtime trading module."""
+    allowed = {
+        "reporting.roadmap_task_units",
+        "reporting.roadmap_unit_authority",
+        "reporting.roadmap_next_unit",
+        "reporting.roadmap_unit_status",
+    }
+    for module in _module_top_level_imports():
+        if module.startswith("reporting."):
+            assert module in allowed, module
+
+
+# ---------------------------------------------------------------------------
+# parse_pr_number helper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "stdout,expected",
+    [
+        ("https://github.com/owner/repo/pull/256\n", 256),
+        ("https://github.com/owner/repo/pull/9999", 9999),
+        ("Opened PR #42\nhttps://github.com/owner/repo/pull/42", 42),
+        ("", 0),
+        ("no url here", 0),
+        ("https://example.com/no/pull/here/0", 0),
+    ],
+)
+def test_parse_pr_number(stdout: str, expected: int) -> None:
+    assert apr._parse_pr_number(stdout) == expected

--- a/tests/unit/test_roadmap_unit_status.py
+++ b/tests/unit/test_roadmap_unit_status.py
@@ -77,13 +77,46 @@ def _snap_with(
 def test_dynamic_unit_status_vocab_is_closed_exact() -> None:
     assert rus.DYNAMIC_UNIT_STATUS == (
         "not_started",
+        "selected",
+        "branch_created",
         "in_progress",
+        "implementation_complete",
+        "tests_passed",
         "pr_open",
         "merged",
         "failed",
         "blocked",
         "skipped",
     )
+
+
+def test_runner_lifecycle_statuses_are_valid_for_validator() -> None:
+    """The four new runner-lifecycle statuses must pass the
+    validator when emitted with a deterministic source."""
+    for status_value in (
+        "selected",
+        "branch_created",
+        "implementation_complete",
+        "tests_passed",
+    ):
+        snap = rus.collect_snapshot(
+            seed=(
+                {
+                    "unit_id": "u_runner_synth",
+                    "status": status_value,
+                    "source": "loop_state",
+                    "updated_at_utc": "2026-05-18T18:00:00Z",
+                    "pr_number": 0,
+                    "merge_sha": "",
+                    "reason": "",
+                    "evidence": [],
+                },
+            ),
+            generated_at_utc=_FROZEN_UTC,
+        )
+        rec = snap["ledger_records"][0]
+        assert rec["valid"] is True, status_value
+        assert rec["validation_reason"] == "", status_value
 
 
 def test_dynamic_status_source_vocab_is_closed_exact() -> None:


### PR DESCRIPTION
## Summary

A21c is the **first real Step 5 execution surface** for ADE. It takes exactly ONE A20e-selected unit, validates a closed set of safety gates, creates one branch, invokes a pluggable implementation strategy, verifies the resulting git diff is contained within the unit's `expected_files` (and never touches a forbidden path), runs the unit's required tests + smoke + governance lint, commits, pushes, opens a PR, watches CI to first verdict, and stops with a deterministic run report.

- **Selected A20e unit anchor for the runner's first real invocation:** `u_v3_15_17_sampling_plan_reporter_001` (phase v3.15.17, AUTO_ALLOWED, LOW, gate=none).
- **Phase:** Step 5 / A21c — bounded PR-creation slice.
- **Authority class on this PR (the A21c slice itself):** `AUTO_ALLOWED` (LOW risk, `operator_gate = none`).
- **No auto-merge** in this PR. The runner stops at PR creation + first-verdict CI watch; the operator decides squash-merge.
- **No deploy** in this PR. Deploy gates remain post-merge and operator-driven.
- **No second-unit continuation.** `max_units_per_run` is hard-capped at 1.
- **No NEEDS_HUMAN, no PERMANENTLY_DENIED, no MEDIUM/HIGH/CRITICAL risk** — all refused at the safety-gate evaluation step before any branch is created.
- **No runtime / trading / paper / shadow / live authority is granted.** Every report pins this.

## Exact files changed (6 files, +3700 / -37)

- `reporting/autonomous_pr_runner.py` (new) — the A21c runner module.
- `tests/unit/test_autonomous_pr_runner.py` (new) — 114 tests.
- `reporting/roadmap_unit_status.py` (modified) — widen `DYNAMIC_UNIT_STATUS` from 7 to 11 values, adding 4 runner-lifecycle states (`selected`, `branch_created`, `implementation_complete`, `tests_passed`). The A21c runner itself does NOT mutate the ledger; the new statuses are reserved for A21d onwards.
- `tests/unit/test_roadmap_unit_status.py` (modified) — update closed-vocab pin and add a validator pin for the four new lifecycle statuses.
- `docs/governance/step5_bounded_autonomous_loop.md` (modified) — new section 11 (A21c) with 10 subsections covering hard boundaries, import-safety contract, closed vocabs, forbidden-path patterns, strategy injection, CLI, authority pins, test coverage, bootstrap selection, future slices. Header lists all three live Step 5 surfaces.
- `docs/governance/roadmap_task_catalog.md` (modified) — header lists A21c; pointer block adds A21c module + artefact + governance link with the no-auto-merge / no-deploy posture statement.

## Bounded autonomous PR runner design

### Hard boundaries

A21c does **not**: squash-merge; use `--admin`; force-push; bypass hooks; delete the branch after merge; deploy anything; update the dynamic unit-status ledger to `merged`; continue to a second unit; touch any forbidden path; mutate any approval inbox, mutation route, or approval button; grant runtime / trading / paper / shadow / live authority; call any LLM, external API, or hidden judgment on its own.

### Import-safety contract

The module is **safe to import**. No subprocess invocation, no git / gh, no network, no file write at module level. The `subprocess` module is imported **lazily** inside the real shell-runner factory so the top-level `import reporting.autonomous_pr_runner` is fully side-effect free. Pinned by a module-source AST scan.

### Closed vocabularies

- `RUN_STATUS` (13 values): `not_run`, `status_only`, `plan_only`, `refused_unsafe`, `executed_pr_opened`, `executed_blocked_at_implementation`, `executed_blocked_at_diff`, `executed_blocked_at_tests`, `executed_blocked_at_governance_lint`, `executed_blocked_at_commit`, `executed_blocked_at_push`, `executed_blocked_at_pr_create`, `executed_blocked_at_ci`.
- `SAFETY_GATE` (14 values).
- `GATE_RESULT` (3 values): `PASS`, `FAIL`, `NOT_CHECKED`.
- `RUNNER_MODE` (3 values): `status_only`, `plan_only`, `run_one`.
- `IMPLEMENTATION_STRATEGY` (2 values): `none` (default, refuses), `external_command` (operator opt-in).
- `STOP_REASON` (33 values) covering every refusal path.

### Forbidden-path patterns (23 entries, checked twice)

`.claude/`, `.github/`, `dashboard/dashboard.py`, `automation/live_gate.py`, `broker/`, `agent/risk/`, `agent/execution/`, `live/`, `paper/`, `shadow/`, `trading/`, `docs/roadmap/Roadmap v6.md`, `docs/roadmap/Roadmap v6 Addendum.md`, `docs/roadmap/autonomous_development.txt`, `docs/governance/execution_authority.md`, `docs/governance/no_touch_paths.md`, `reporting/execution_authority.py`, `reporting/development_queue_admission_policy.py`, `docs/development_work_queue/`, `tests/regression/`, `research/research_latest.json`, `research/strategy_matrix.csv`, `artifacts/`.

Pre-execution: scanned against the selected unit's `expected_files`. Any match refuses the run at the `no_forbidden_in_expected` gate. Post-implementation: scanned against the git diff. Any match refuses the run at the diff-scope check, before commit.

### Implementation strategy injection

`ImplementationStrategy` is a Protocol. Two concrete strategies ship:

- **`none`** — the default. Refuses to run; the runner stops at the `implementation_strategy_configured` gate.
- **`external_command`** — operator opts in via `--implementation-strategy external_command --implementation-command "<cmd>"`. The command is parsed via `shlex.split` and invoked through the injected shell runner. The command is expected to mutate the filesystem in a way that satisfies the diff-scope check.

Tests inject `FakeImplementationStrategy` directly via the `implementation_strategy=` keyword argument to `run_one(...)`. No real shell command is invoked by unit tests.

### CLI

```sh
# Safe default (status snapshot, no execution):
python -m reporting.autonomous_pr_runner --status

# Plan-only (evaluate all safety gates, execute nothing):
python -m reporting.autonomous_pr_runner --plan-only

# Real execution (requires explicit operator strategy choice):
python -m reporting.autonomous_pr_runner \
    --run-one --max-units 1 \
    --implementation-strategy external_command \
    --implementation-command "<operator-supplied real command>"
```

## Stop conditions covered

Every refusal path produces a closed-vocab `STOP_REASON`. The runner stops and reports if any of: selector unavailable; no eligible unit; ambiguous selection; unsafe authority / risk / operator-gate; requires operator-go; missing expected_files / forbidden_files / required_tests; forbidden path in expected_files; terminal status; max_units > 1; implementation strategy not configured; implementation strategy failed; diff outside expected_files; diff touches forbidden path; empty diff; tests failed; governance lint failed; commit failed; hook failed; branch creation failed; branch already exists; push failed; PR creation failed; CI failed; CI timeout; CI not clean; unknown evidence.

## Validation commands and results

- `python -m pytest tests/unit/test_autonomous_pr_runner.py -v` — **114 passed**.
- `python -m pytest tests/unit/test_roadmap_unit_status.py -v` — **62 passed**.
- `python -m pytest tests/unit/test_roadmap_next_unit.py -v` — **88 passed**.
- Combined roadmap-pipeline run (runner + ledger + selector + units + authority + catalog): **264 passed**.
- `python -m pytest tests/smoke -v` — **18 passed**.
- `python -m pytest tests/regression/test_public_output_contract.py tests/regression/test_v12_contracts_preserved.py tests/regression/test_authority_invariants.py -v` — **16 passed**.
- `python scripts/governance_lint.py` — `Governance lint OK (16 agents, 5 workflows checked).`

## Frozen-contract verdict

PASS. No mutation of `research/research_latest.json`, no mutation of `research/strategy_matrix.csv`, no mutation of any frozen schema under `artifacts/`.

## Forbidden-path verdict

PASS. Diff touches **only** the 6 spec-allowed files. None of the no-touch paths changed: not `dashboard/dashboard.py`, not `.claude/**`, not `.github/**`, not `automation/live_gate.py`, not `broker/**`, not `agent/risk/**`, not `agent/execution/**`, not `live/**`, not `paper/**`, not `shadow/**`, not `trading/**`, not `docs/roadmap/Roadmap v6.md`, not `docs/roadmap/Roadmap v6 Addendum.md`, not `docs/roadmap/autonomous_development.txt`, not `docs/governance/execution_authority.md`, not `docs/governance/no_touch_paths.md`, not `reporting/execution_authority.py`, not `reporting/development_queue_admission_policy.py`, not `docs/development_work_queue/*.jsonl`, not `tests/regression/**`.

## Statement of constraints honoured

- **This PR introduces bounded autonomous PR creation for ONE safe unit.** The runner takes a single A20e-selected unit, opens one PR, and stops.
- **Auto-merge is NOT implemented yet.** The runner does not invoke `gh pr merge` and does not use `--admin`. Pinned by a module-source scan.
- **Deploy automation is NOT implemented yet.** The runner does not invoke any deploy workflow.
- **No runtime / trading / paper / shadow / live authority is granted.** Every authority pin in `runner_invariants` asserts this.
- **`step5_implementation_allowed` remains `Final[bool] = False`.** A21c carves out a bounded slice via `step5_enabled_substage = "a21c_bounded_pr_creation"`; the broad Step 5 lock stays in place everywhere else.
- **Autonomy-ladder Level 6 remains permanently disabled per ADR-015.**
- **N5b Phase 4 production-merge authority remains permanently denied for ADE.**

## Test plan

- [ ] CI completes green on this branch (lint, secret-scan, typecheck, unit, regression-fast, hook-tests, frontend, governance-lint).
- [ ] No frozen-contract regression test newly fails.
- [ ] No governance-lint regression.
- [ ] No new agent-allowlist surfaces appear.

## Next recommended PR

**A21d -- bounded auto-merge for runner-originated PRs.** Adds the post-PR merge step the operator currently performs manually, plus the A21a ledger append that flips the unit to `merged`. Hard-capped: only PRs the runner itself originated; only after CI-green; squash-merge only; no `--admin`; no force-push; no hook bypass; max 1 merge per run. The deploy watcher (A21e) remains a separate later slice.