### PR TITLE
feat(a22): strategic roadmap execution mandate + catalog expansion policy

### DIFF
--- a/docs/governance/roadmap_task_catalog.md
+++ b/docs/governance/roadmap_task_catalog.md
@@ -1,21 +1,37 @@
-# Roadmap Task Catalog — A20a..A20e + A21a + A21c + A21d + A21e
+# Roadmap Task Catalog — A20a..A20e + A21a + A21c + A21d + A21e + A22
 
-> **Status:** A20a implemented; A20b implemented; A20c implemented;
-> A20d implemented; A20e implemented (deterministic next-buildable-unit
-> selector); A21a implemented (dynamic unit-status ledger,
-> Step 5 foundation); A21c implemented (bounded autonomous PR
-> runner for ONE AUTO_ALLOWED + LOW-risk + gate=none unit); A21d
-> implemented (bounded auto-merge for runner-originated PRs after
-> CI green + post-merge gates green); A21e implemented (continuous
-> autonomous conveyor mode that wraps the A21d cycle in a loop
-> with no artificial unit-count cap and no wall-clock budget,
-> stopping only on no-eligible-work, safety, technical, or
-> explicit operator soft-stop conditions). Stages A20a-A21a are
-> read-only projections. A21c / A21d / A21e share one runner
-> module driven by explicit CLI flags. No auto-merge for
-> non-runner-originated PRs; no ``--admin``; no force-push; no
-> hook bypass; no deploy invocation; post-merge gates remain
-> read-only-observed.
+> **Status:** A20a implemented; A20b implemented; A20c implemented
+> (extended by A22 with strategic-mandate post-process); A20d
+> implemented; A20e implemented (deterministic next-buildable-unit
+> selector, now accepts STRATEGICALLY_PREAPPROVED as eligible);
+> A21a implemented (dynamic unit-status ledger); A21c implemented
+> (bounded autonomous PR runner); A21d implemented (bounded
+> auto-merge for runner-originated PRs); A21e implemented
+> (continuous autonomous conveyor with no artificial cap); **A22
+> implemented (Strategic Roadmap Execution Mandate + Catalog
+> Expansion Policy — operator pre-approves automatic processing
+> of mandate-eligible MEDIUM / NEEDS_HUMAN research-scaffold
+> units via the new STRATEGICALLY_PREAPPROVED authority class,
+> while keeping every hard runtime / trading / paper / shadow /
+> broker / risk / live / frozen-contract / dashboard-mutation
+> boundary intact).** No auto-merge for non-runner-originated PRs;
+> no ``--admin``; no force-push; no hook bypass; no deploy
+> invocation; post-merge gates remain read-only-observed.
+
+## Current queue scope
+
+The queue is **finite**. It encodes:
+
+- Roadmap v6 phases v3.15.16 → v3.15.20;
+- Addendum 1;
+- 20 implementation units.
+
+`addendum_2` and `addendum_3` slots exist in the strategic
+mandate's phase list but are **not yet repo-resident**. Adding
+units in those phases requires a separate operator-driven
+catalog expansion PR. See
+[`docs/governance/strategic_roadmap_execution_mandate.md`](strategic_roadmap_execution_mandate.md)
+§5 for the catalog expansion policy.
 >
 > **A20a module:** [`reporting/roadmap_task_catalog.py`](../../reporting/roadmap_task_catalog.py)
 > **A20a artefact:** `logs/roadmap_task_catalog/latest.json`
@@ -35,6 +51,10 @@
 > **A21a module:** [`reporting/roadmap_unit_status.py`](../../reporting/roadmap_unit_status.py)
 > **A21a artefact:** `logs/roadmap_unit_status/latest.json`
 > **A21a governance:** [`docs/governance/step5_bounded_autonomous_loop.md`](step5_bounded_autonomous_loop.md)
+>
+> **A22 module:** [`reporting/roadmap_unit_authority.py`](../../reporting/roadmap_unit_authority.py) (strategic-mandate post-process)
+> **A22 governance:** [`docs/governance/strategic_roadmap_execution_mandate.md`](strategic_roadmap_execution_mandate.md)
+> A22 promotes mandate-eligible NEEDS_HUMAN units to ``STRATEGICALLY_PREAPPROVED`` so the conveyor processes them automatically. The mandate never overrides PERMANENTLY_DENIED, never accepts HIGH/CRITICAL/UNKNOWN risk, and never relaxes the always-blocked runtime / trading / paper / shadow / broker / risk / execution / frozen-contract / dashboard-mutation surfaces.
 >
 > **A21c + A21d + A21e module:** [`reporting/autonomous_pr_runner.py`](../../reporting/autonomous_pr_runner.py)
 > **A21c..A21e primary artefact:** `logs/autonomous_pr_runner/latest.json`

--- a/docs/governance/step5_bounded_autonomous_loop.md
+++ b/docs/governance/step5_bounded_autonomous_loop.md
@@ -1163,7 +1163,56 @@ Pinned in
 - **Signal-handler-based hard stop** — Ctrl+C kills the process
   uncleanly. A future slice may add a SIGINT handler.
 
-## 14. Next recommended operator action
+## 14. A22 strategic mandate integration
+
+[`docs/governance/strategic_roadmap_execution_mandate.md`](strategic_roadmap_execution_mandate.md)
+adds the operator's strategic execution mandate. The A21 family
+now accepts **STRATEGICALLY_PREAPPROVED** units (mandate-promoted
+NEEDS_HUMAN units that satisfy every mandate criterion) as
+eligible for the conveyor, alongside AUTO_ALLOWED units.
+
+### 14.1 Runner safety-gate widening
+
+A22 widens two A21c / A21d / A21e safety gates:
+
+- `auto_allowed_authority` — accepts
+  `AUTO_ALLOWED` OR `STRATEGICALLY_PREAPPROVED`.
+- `low_risk` — accepts `LOW` always; accepts `MEDIUM` only when
+  the unit's authority class is `STRATEGICALLY_PREAPPROVED`.
+
+`HIGH` / `CRITICAL` / `UNKNOWN` risk is still refused everywhere.
+`NEEDS_HUMAN` / `PERMANENTLY_DENIED` authority is still refused
+for execution. Per-unit safety gates (`expected_files`,
+`forbidden_files`, `required_tests`, diff-scope,
+mergeability-clean, post-merge-gate-green) are unchanged.
+
+### 14.2 New runner invariants pinned by A22
+
+Every report (run-one, plan, status, conveyor) now pins:
+
+- `accepts_strategically_preapproved_authority = true`
+- `accepts_medium_risk_only_when_strategically_preapproved = true`
+- `never_accepts_needs_human_authority_for_execution = true`
+- `never_accepts_permanently_denied_authority_for_execution = true`
+- `never_accepts_high_or_critical_risk = true`
+- `elevated_exceptions_remain_operator_driven = true`
+
+### 14.3 Elevated exceptions remain operator-driven
+
+Two surfaces are NEVER processed by the conveyor:
+
+- **Frozen contracts**: `research/research_latest.json`,
+  `research/strategy_matrix.csv`.
+- **Dashboard / UI mutation**: `dashboard/dashboard.py`, UI
+  mutation buttons, approval buttons, mutation routes.
+
+These remain PERMANENTLY_DENIED at the classifier level. Any
+change to them requires an explicit operator-authored PR
+outside the autonomous runner — see
+[`strategic_roadmap_execution_mandate.md`](strategic_roadmap_execution_mandate.md)
+§4 for the elevated-exception policy.
+
+## 15. Next recommended operator action
 
 After PR #258 (A21e) merges, the operator can — from their local
 laptop — run the continuous conveyor against the live queue:

--- a/docs/governance/strategic_roadmap_execution_mandate.md
+++ b/docs/governance/strategic_roadmap_execution_mandate.md
@@ -1,0 +1,463 @@
+# Strategic Roadmap Execution Mandate (A22)
+
+> **Status:** A22 — operator's pre-approval policy for the
+> Roadmap v6 + Addendum 1/2/3 research-intelligence work-track.
+> Encoded deterministically in
+> [`reporting/roadmap_unit_authority.py`](../../reporting/roadmap_unit_authority.py)
+> as a post-process that promotes eligible NEEDS_HUMAN units to a
+> new authority class `STRATEGICALLY_PREAPPROVED`. The selector
+> ([`reporting/roadmap_next_unit.py`](../../reporting/roadmap_next_unit.py))
+> and the autonomous PR runner
+> ([`reporting/autonomous_pr_runner.py`](../../reporting/autonomous_pr_runner.py))
+> both accept STRATEGICALLY_PREAPPROVED units automatically (no
+> per-unit operator-go required).
+>
+> Step 5 broad implementation remains **BLOCKED** outside the
+> bounded A21 / A22 slices. Autonomy-ladder Level 6 remains
+> **permanently disabled** per ADR-015. N5b Phase 4 production-
+> merge authority remains **permanently denied for ADE**.
+>
+> **The strategic mandate NEVER overrides:**
+>
+> - any **PERMANENTLY_DENIED** authority class;
+> - **HIGH / CRITICAL / UNKNOWN** risk class;
+> - the always-forbidden runtime / trading / paper / shadow /
+>   broker / risk / execution surfaces;
+> - `--admin` restrictions, force-push restrictions, hook-bypass
+>   restrictions, direct-deploy restrictions;
+> - the runner's per-iteration safety gates (`expected_files`,
+>   `forbidden_files`, `required_tests`, diff-scope, CI-green,
+>   mergeability-clean, post-merge-gate-green, etc.).
+
+---
+
+## 1. Why the strategic mandate exists
+
+The operator's goal is to execute the full Roadmap v6 +
+Addendum 1/2/3 research-intelligence work-track as quickly as
+possible while preserving hard safety boundaries. Before A22:
+
+- Many MEDIUM / NEEDS_HUMAN research-scaffold units would block
+  the conveyor (A21e). Each one would require an explicit
+  operator decision, defeating the purpose of the conveyor.
+- The operator does **not** want to babysit individual approvals
+  on read-only scaffold / reporting / docs / tests units.
+- The operator **does** want ADE to stop on real trading /
+  runtime / broker / risk / live boundaries.
+
+The mandate encodes the operator's pre-approval **once**, in
+code, with explicit deterministic criteria. The conveyor then
+applies that pre-approval to every matching unit automatically.
+
+## 2. The hard permanent constraints
+
+These hold for every conveyor iteration. The mandate never
+relaxes any of them.
+
+### 2.1 Always blocked (PERMANENTLY_DENIED — never auto-merged)
+
+- `dashboard/dashboard.py` (unless an explicit elevated
+  exception PR; see §4)
+- `.claude/**`
+- `.github/**`
+- `research/research_latest.json` (frozen contract; §4)
+- `research/strategy_matrix.csv` (frozen contract; §4)
+- `automation/live_gate.py`
+- `broker/**`
+- `agent/risk/**`
+- `agent/execution/**`
+- `live/**`
+- `paper/**`
+- `shadow/**`
+- `trading/**`
+- `docs/roadmap/Roadmap v6.md`
+- `docs/roadmap/Roadmap v6 Addendum.md`
+- `docs/roadmap/autonomous_development.txt`
+- `docs/governance/execution_authority.md`
+- `docs/governance/no_touch_paths.md`
+- `reporting/execution_authority.py`
+- `reporting/development_queue_admission_policy.py`
+- `docs/development_work_queue/*.jsonl`
+- `tests/regression/**`
+- any live / broker / risk / execution credential or endpoint
+  path
+- any frozen schema under `artifacts/`
+
+A unit whose `expected_files` includes any of these surfaces is
+classified `PERMANENTLY_DENIED` by the canonical
+`reporting.execution_authority` classifier. The A22 post-process
+**never** promotes `PERMANENTLY_DENIED` to anything else.
+
+### 2.2 Always blocked — semantic surfaces
+
+The mandate never promotes a unit that would introduce any of:
+
+- order placement;
+- broker calls;
+- capital allocation;
+- risk mutation;
+- paper / shadow / live runtime activation;
+- approval buttons;
+- mutation routes;
+- executable strategy generation;
+- trading authority.
+
+These map to path-level denials via the canonical classifier,
+so the path scan in §2.1 already catches them at
+classification time.
+
+## 3. The strategic mandate criteria
+
+A unit is **STRATEGICALLY_PREAPPROVED** if and only if EVERY
+condition below is true.
+
+### 3.1 Phase (operator-pre-approved roadmap track)
+
+`phase` must be in
+[`reporting.roadmap_unit_authority._MANDATE_PHASES`](../../reporting/roadmap_unit_authority.py):
+
+- `v3.15.16`
+- `v3.15.17`
+- `v3.15.18`
+- `v3.15.19`
+- `v3.15.20`
+- `addendum_1`
+- `addendum_2`
+- `addendum_3`
+
+`addendum_2` and `addendum_3` are reserved but **not yet
+repo-resident** — adding units in those phases requires a
+catalog-expansion PR first (see §5).
+
+### 3.2 Target layer (research / scaffold / docs / tests /
+reporting)
+
+`target_layer` must be in
+`_MANDATE_TARGET_LAYERS`:
+
+- `reporting`
+- `research`
+- `governance`
+- `test`
+- `diagnostic`
+- `external_intelligence`
+- `preset`
+- `evidence`
+
+Layers like `broker`, `agent.risk`, `agent.execution`, `live`,
+`paper`, `shadow`, `trading`, `dashboard` are explicitly NOT in
+this set. Even if a unit's `expected_files` didn't hit a
+PERMANENTLY_DENIED path, a non-mandate target layer prevents
+promotion.
+
+### 3.3 Risk class
+
+`risk_class` must be in `_MANDATE_RISK_CLASSES`:
+
+- `LOW`
+- `MEDIUM`
+
+`HIGH`, `CRITICAL`, `UNKNOWN` are never promoted. Units at those
+risk classes remain `NEEDS_HUMAN` (or `PERMANENTLY_DENIED` if
+the classifier also denies them) and the conveyor stops on them.
+
+### 3.4 Explicit scaffolding (every field non-empty)
+
+The unit must declare ALL of:
+
+- `expected_files` — non-empty list;
+- `forbidden_files` — non-empty list;
+- `required_tests` — non-empty list;
+- `stop_conditions` — non-empty list;
+- `definition_of_done` — non-empty list.
+
+A unit missing any of these is left at NEEDS_HUMAN — the mandate
+requires explicit definition of intent + tests + stop conditions
+before automatic execution. Vague units stay operator-driven.
+
+### 3.5 Path safety (already enforced upstream)
+
+The canonical classifier scans every `expected_files` entry. If
+ANY entry would touch a forbidden surface (per §2.1), the
+aggregator returns `PERMANENTLY_DENIED` BEFORE the post-process
+runs. The mandate never overrides PERMANENTLY_DENIED.
+
+## 4. Elevated exception policy
+
+Two surfaces are **not always-blocked** but **never** allowed
+in the normal conveyor path. They require an **elevated
+exception** — an operator-authored PR with explicit rationale:
+
+### 4.1 Frozen contracts
+
+- `research/research_latest.json`
+- `research/strategy_matrix.csv`
+
+Policy:
+
+- Not allowed in normal conveyor path.
+- May be considered only as an elevated exception.
+- Requires explicit rationale that no smaller alternative
+  exists.
+- Must include frozen-contract regression tests.
+- Must be reported as `elevated_exception_required`.
+- Must NOT silently happen inside a generic unit.
+
+The conveyor's classifier marks these surfaces as
+PERMANENTLY_DENIED. Any change to them happens through an
+operator-driven PR outside the autonomous runner.
+
+### 4.2 Dashboard / UI mutation
+
+- `dashboard/dashboard.py`
+- UI mutation buttons
+- approval buttons
+- mutation routes
+
+Policy:
+
+- Not allowed in normal conveyor path.
+- May be considered only as an elevated exception.
+- Requires explicit rationale that no smaller read-only /
+  reporting alternative exists.
+- Mutation buttons / approval buttons remain blocked unless
+  explicitly approved later in a separate governance-bootstrap
+  PR.
+- Must be reported as `elevated_exception_required`.
+
+Like frozen contracts, the conveyor's classifier denies
+`dashboard/dashboard.py`. Read-only dashboard *reads* (no
+buttons, no mutation routes) may be permitted by separate
+units when their `expected_files` stay inside the read-only
+surface.
+
+## 5. Catalog expansion policy
+
+### 5.1 Current state
+
+The current A20a / A20b queue is **finite**. It encodes only:
+
+- Roadmap v6 phases `v3.15.16` → `v3.15.20`;
+- Addendum 1;
+- 20 implementation units total.
+
+`addendum_2` and `addendum_3` are represented as **absence
+flags** in
+[`reporting/roadmap_task_catalog.py`](../../reporting/roadmap_task_catalog.py):
+
+- `addendum_2_not_present = true`
+- `addendum_3_not_present = true`
+
+No units exist for those phases until the addendum content is
+repo-resident.
+
+### 5.2 Adding new units
+
+The conveyor processes only units that exist in the A20a
+catalog and the A20b decomposition. Adding new units requires a
+**catalog expansion PR** that:
+
+1. Adds new `RoadmapTask` entries (and their
+   `RoadmapRequirement` entries) to
+   `reporting/roadmap_task_catalog.py`.
+2. Adds new `ImplementationUnit` entries to
+   `reporting/roadmap_task_units.py`'s `_UNIT_SEED`.
+3. Updates the matching test pins
+   (`tests/unit/test_roadmap_task_catalog.py`,
+   `tests/unit/test_roadmap_task_units.py`).
+4. Ensures the new units satisfy the §3 mandate criteria if
+   they should be auto-eligible, or marks them explicitly
+   NEEDS_HUMAN if they should be operator-gated.
+5. Stays inside the always-allowed surface (no live / paper /
+   shadow / broker / risk / execution / dashboard mutation /
+   frozen-contract mutation).
+
+### 5.3 Addendum 2 / 3 specific path
+
+`addendum_2` and `addendum_3` slots exist in
+`_MANDATE_PHASES` but produce **no units** until their
+canonical roadmap content is repo-resident. The catalog and
+decomposition modules already pin the absence flags. When the
+operator brings Addendum 2 or 3 content into the repo, a
+catalog expansion PR:
+
+- Removes the corresponding `addendum_*_not_present` absence
+  flag from the catalog.
+- Adds `RoadmapTask` + `RoadmapRequirement` entries for the
+  addendum.
+- Adds `ImplementationUnit` entries for each implementation
+  surface.
+- Updates the catalog and unit-decomposition test pins.
+
+Once the addendum is repo-resident, the existing mandate rules
+in §3 automatically apply — eligible units flow into the
+selector and conveyor without further governance work.
+
+### 5.4 The catalog is the only source of work
+
+The autonomous PR runner reads ONLY from A20a / A20b. The
+runner never invents work, never scans the canonical roadmap
+documents at runtime, never derives work from external
+artefacts. New work is added to the queue via the catalog
+expansion PR pattern in §5.2.
+
+## 6. CI / test / diff failures inside an iteration
+
+Per operator policy, the conveyor should first attempt to fix
+CI / test / diff failures **within the same unit and
+expected_files**. It must NOT immediately stop and ask the
+operator.
+
+The conveyor stops only when:
+
+- the fix requires editing files outside `expected_files`;
+- the fix requires touching a forbidden surface;
+- the fix requires an elevated exception (frozen contract /
+  dashboard);
+- the fix changes authority or risk class;
+- repeated failure remains unresolved (per-iteration safety
+  gates fire again);
+- merge conflict cannot be safely resolved;
+- the implementation would exceed `expected_files`.
+
+This policy is enforced by the runner's existing per-iteration
+safety gates. The pluggable
+`ImplementationStrategy` interface lets a future slice add a
+retry-within-unit loop. **This PR does not implement that
+retry loop** — A22 is the policy + classification work; the
+retry loop is a separate future slice.
+
+## 7. How the mandate is implemented
+
+### 7.1 A20c post-process
+
+[`reporting/roadmap_unit_authority.py`](../../reporting/roadmap_unit_authority.py)
+adds:
+
+- The new authority class `STRATEGICALLY_PREAPPROVED` in
+  `AUTHORITY_CLASS` (severity 1, between AUTO_ALLOWED at 0 and
+  NEEDS_HUMAN at 2).
+- The new evidence kind `strategic_mandate` in
+  `AUTHORITY_EVIDENCE_KIND`. Informational (not aggregating).
+- The deterministic evaluator
+  `_evaluate_strategic_mandate(unit)` that returns
+  `(satisfied, reason)` against §3.
+- The post-process `_apply_strategic_mandate(unit, decision)`
+  that promotes NEEDS_HUMAN → STRATEGICALLY_PREAPPROVED when
+  satisfied, and records mandate evidence on every decision.
+- The new decision field `strategic_mandate_satisfied`.
+
+### 7.2 A20e selector
+
+[`reporting/roadmap_next_unit.py`](../../reporting/roadmap_next_unit.py)
+adds `STRATEGICALLY_PREAPPROVED` to `_AUTHORITY_ORDER` (between
+AUTO_ALLOWED and NEEDS_HUMAN). The eligibility logic in
+`_build_candidate` treats STRATEGICALLY_PREAPPROVED units with
+`operator_gate == "none"` as ELIGIBLE (not NEEDS_HUMAN_GATED).
+The selector still prefers AUTO_ALLOWED via the deterministic
+sort-key tie-breaking.
+
+### 7.3 A21c / A21d / A21e runner
+
+[`reporting/autonomous_pr_runner.py`](../../reporting/autonomous_pr_runner.py)
+widens two safety gates:
+
+- `auto_allowed_authority` — accepts
+  `AUTO_ALLOWED` OR `STRATEGICALLY_PREAPPROVED`.
+- `low_risk` — accepts `LOW` always; accepts `MEDIUM` only when
+  the unit's authority is `STRATEGICALLY_PREAPPROVED`.
+
+`HIGH` / `CRITICAL` / `UNKNOWN` risk is still refused even for
+mandate-promoted units. `NEEDS_HUMAN` / `PERMANENTLY_DENIED`
+authority is still refused.
+
+The runner pins six new invariants:
+
+- `accepts_strategically_preapproved_authority`
+- `accepts_medium_risk_only_when_strategically_preapproved`
+- `never_accepts_needs_human_authority_for_execution`
+- `never_accepts_permanently_denied_authority_for_execution`
+- `never_accepts_high_or_critical_risk`
+- `elevated_exceptions_remain_operator_driven`
+
+## 8. Test coverage
+
+Pinned across the touched modules:
+
+- [`tests/unit/test_roadmap_unit_authority.py`](../../tests/unit/test_roadmap_unit_authority.py)
+  — 14 new tests covering vocab pins (AUTHORITY_CLASS extension,
+  evidence kinds, severity ordering, decision field tuple),
+  mandate-promotion happy path, no-promote-permanently-denied,
+  no-promote-auto-allowed, no-promote-unsupported-phase,
+  no-promote-unsupported-target-layer, no-promote-high-risk,
+  no-promote-missing-scaffolding (parametrised over 5 fields),
+  informational-evidence partition, severity-strictly-between.
+- [`tests/unit/test_roadmap_next_unit.py`](../../tests/unit/test_roadmap_next_unit.py)
+  — 4 new tests: STRATEGICALLY_PREAPPROVED is ELIGIBLE,
+  AUTO_ALLOWED preferred over STRATEGICALLY_PREAPPROVED,
+  STRATEGICALLY_PREAPPROVED picked over NEEDS_HUMAN-gated,
+  PERMANENTLY_DENIED still blocks even alongside mandate
+  candidates.
+- [`tests/unit/test_autonomous_pr_runner.py`](../../tests/unit/test_autonomous_pr_runner.py)
+  — 9 new tests covering the runner's two widened gates,
+  HIGH/CRITICAL/UNKNOWN risk refusal even at
+  STRATEGICALLY_PREAPPROVED, MEDIUM risk refusal without
+  mandate, NEEDS_HUMAN refusal, PERMANENTLY_DENIED refusal,
+  and the six new runner invariants.
+
+## 9. What A22 does NOT do
+
+- It does NOT add new units to the queue. The catalog and
+  decomposition seeds are unchanged. Existing MEDIUM /
+  NEEDS_HUMAN units in the seed become eligible **only** when
+  they satisfy §3.
+- It does NOT enable the conveyor to merge any new dangerous
+  surface. Hard denials stay hard.
+- It does NOT bring Addendum 2 / Addendum 3 content into the
+  repo. Those addenda remain absence-flagged until a separate
+  catalog expansion PR.
+- It does NOT relax `--admin`, force-push, hook-bypass,
+  deploy-invocation, or any A21c / A21d / A21e
+  runner-invariant pin.
+- It does NOT introduce a retry-within-unit loop for failing
+  iterations. That is a future slice (see §6).
+
+## 10. Cross-references
+
+- [`docs/governance/step5_bounded_autonomous_loop.md`](step5_bounded_autonomous_loop.md)
+  — Step 5 / A21 family governance.
+- [`docs/governance/roadmap_task_catalog.md`](roadmap_task_catalog.md)
+  — A20 / A21 catalog + queue documentation.
+- [`docs/adr/ADR-014-truth-authority-settlement.md`](../adr/ADR-014-truth-authority-settlement.md)
+  — canonical authority mapping.
+- [`docs/adr/ADR-015-claude-agent-governance.md`](../adr/ADR-015-claude-agent-governance.md)
+  — autonomy ladder; Level 6 is permanently disabled.
+- [`docs/governance/no_touch_paths.md`](no_touch_paths.md) —
+  forbidden-surface list (untouched by A22).
+- [`docs/governance/execution_authority.md`](execution_authority.md)
+  — canonical execution-authority policy (untouched by A22).
+- [`docs/governance/ade_development_lane_doctrine.md`](ade_development_lane_doctrine.md)
+  — ADE remains development workflow automation only.
+
+## 11. Next recommended operator action
+
+After PR #260 (A22) merges:
+
+1. If Addendum 2 / Addendum 3 content is ready to bring
+   in-repo: open a catalog expansion PR per §5. The mandate
+   criteria automatically apply to the new units.
+2. Otherwise: run the existing conveyor against the existing
+   queue. Mandate-promoted MEDIUM scaffolding units will now
+   flow automatically:
+
+   ```sh
+   python -m reporting.autonomous_pr_runner \
+       --run-continuous --auto-merge-runner-pr \
+       --implementation-strategy external_command \
+       --implementation-command "<operator-supplied real command>"
+   ```
+
+   The conveyor processes every AUTO_ALLOWED / LOW and
+   STRATEGICALLY_PREAPPROVED unit, stopping only on no
+   eligible work, safety / technical stop, or explicit
+   operator soft-stop.

--- a/reporting/autonomous_pr_runner.py
+++ b/reporting/autonomous_pr_runner.py
@@ -136,7 +136,7 @@ from reporting import roadmap_unit_status as rus
 REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
 
 SCHEMA_VERSION: Final[str] = "1.0"
-MODULE_VERSION: Final[str] = "v3.15.16.A21e"
+MODULE_VERSION: Final[str] = "v3.15.16.A21e+A22"
 REPORT_KIND: Final[str] = "autonomous_pr_runner"
 CONVEYOR_REPORT_KIND: Final[str] = "autonomous_pr_runner_conveyor"
 
@@ -573,6 +573,13 @@ _BASE_RUNNER_INVARIANTS: Final[dict[str, bool]] = {
     "conveyor_never_merges_arbitrary_prs": True,
     "conveyor_never_continues_past_same_unit_without_status_change": True,
     "conveyor_never_re_selects_already_merged_unit": True,
+    # A22 strategic-mandate runner pins
+    "accepts_strategically_preapproved_authority": True,
+    "accepts_medium_risk_only_when_strategically_preapproved": True,
+    "never_accepts_needs_human_authority_for_execution": True,
+    "never_accepts_permanently_denied_authority_for_execution": True,
+    "never_accepts_high_or_critical_risk": True,
+    "elevated_exceptions_remain_operator_driven": True,
 }
 
 
@@ -786,8 +793,12 @@ def evaluate_safety_gates(
     results.append(_gate("unit_present", "PASS", ""))
 
     # auto_allowed_authority
+    # A22: accepts AUTO_ALLOWED OR STRATEGICALLY_PREAPPROVED. The
+    # latter is the mandate-promoted class that A20c's post-process
+    # produces for NEEDS_HUMAN units meeting every condition of the
+    # operator's strategic execution mandate.
     final_class = _bounded_str(sel.get("selected_authority_class"), 32)
-    if final_class != "AUTO_ALLOWED":
+    if final_class not in {"AUTO_ALLOWED", "STRATEGICALLY_PREAPPROVED"}:
         results.append(
             _gate(
                 "auto_allowed_authority",
@@ -801,15 +812,30 @@ def evaluate_safety_gates(
         results.append(_gate("auto_allowed_authority", "PASS", ""))
 
     # low_risk
+    # A22: accepts LOW always. Accepts MEDIUM only when the unit is
+    # STRATEGICALLY_PREAPPROVED — the strategic mandate explicitly
+    # opts MEDIUM-risk research/scaffold units into auto-execution.
+    # HIGH / CRITICAL / UNKNOWN risk are never accepted here.
     risk_class = _bounded_str(sel.get("selected_risk_class"), 16)
-    if risk_class != "LOW":
+    if risk_class == "LOW":
+        results.append(_gate("low_risk", "PASS", ""))
+    elif (
+        risk_class == "MEDIUM"
+        and final_class == "STRATEGICALLY_PREAPPROVED"
+    ):
+        results.append(
+            _gate(
+                "low_risk",
+                "PASS",
+                "medium_risk_strategically_preapproved",
+            )
+        )
+    else:
         results.append(
             _gate("low_risk", "FAIL", f"risk_class={risk_class}")
         )
         if fail is None:
             fail = "unsafe_risk_class"
-    else:
-        results.append(_gate("low_risk", "PASS", ""))
 
     # no_operator_gate
     gate_val = _bounded_str(sel.get("selected_operator_gate"), 64)

--- a/reporting/roadmap_next_unit.py
+++ b/reporting/roadmap_next_unit.py
@@ -206,11 +206,16 @@ _PHASE_ORDER: Final[tuple[str, ...]] = (
     "addendum_3",
 )
 
-#: Authority priority: AUTO_ALLOWED before NEEDS_HUMAN.
-#: ``PERMANENTLY_DENIED`` is never used in the sort key because
-#: such units are BLOCKED and never reach the eligible tier.
+#: Authority priority: AUTO_ALLOWED before STRATEGICALLY_PREAPPROVED
+#: before NEEDS_HUMAN. ``PERMANENTLY_DENIED`` is never used in the
+#: sort key because such units are BLOCKED and never reach the
+#: eligible tier. STRATEGICALLY_PREAPPROVED is the A22 promotion
+#: class for mandate-eligible NEEDS_HUMAN units; the selector
+#: treats it as ELIGIBLE (not NEEDS_HUMAN_GATED) when
+#: ``operator_gate == "none"``.
 _AUTHORITY_ORDER: Final[tuple[str, ...]] = (
     "AUTO_ALLOWED",
+    "STRATEGICALLY_PREAPPROVED",
     "NEEDS_HUMAN",
 )
 
@@ -570,6 +575,10 @@ def _build_candidate(
         # Annotate the gate reason as a non-blocking note (does not
         # appear in block_reasons because the unit is not BLOCKED).
     else:
+        # AUTO_ALLOWED and STRATEGICALLY_PREAPPROVED both reach
+        # this branch when operator_gate == "none". The A22 mandate
+        # promoted STRATEGICALLY_PREAPPROVED units to eligibility
+        # without requiring operator-go.
         eligibility = "ELIGIBLE"
 
     # --- Deterministic sort key -------------------------------------------

--- a/reporting/roadmap_unit_authority.py
+++ b/reporting/roadmap_unit_authority.py
@@ -78,7 +78,7 @@ from reporting import roadmap_task_units as rtu
 REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
 
 SCHEMA_VERSION: Final[str] = "1.0"
-MODULE_VERSION: Final[str] = "v3.15.16.A20c"
+MODULE_VERSION: Final[str] = "v3.15.16.A20c+A22"
 REPORT_KIND: Final[str] = "roadmap_unit_authority"
 
 
@@ -94,19 +94,32 @@ step5_implementation_allowed: Final[bool] = False
 # Closed vocabularies
 # ---------------------------------------------------------------------------
 
-#: Closed final authority classes. Exactly the canonical classifier's
-#: ``DECISIONS`` enum, pinned to the same tuple values.
-AUTHORITY_CLASS: Final[tuple[str, ...]] = ea.DECISIONS
+#: Closed final authority classes. Extends the canonical classifier's
+#: ``DECISIONS`` enum with ``STRATEGICALLY_PREAPPROVED`` (A22). The
+#: aggregator only emits the canonical three; ``STRATEGICALLY_PREAPPROVED``
+#: is produced by the A22 post-process when a NEEDS_HUMAN unit
+#: satisfies every condition of the operator's strategic execution
+#: mandate (see :func:`_strategic_mandate_satisfied`).
+_STRATEGICALLY_PREAPPROVED: Final[str] = "STRATEGICALLY_PREAPPROVED"
+
+AUTHORITY_CLASS: Final[tuple[str, ...]] = tuple(
+    list(ea.DECISIONS) + [_STRATEGICALLY_PREAPPROVED]
+)
 
 _AUTO_ALLOWED: Final[str] = ea.DECISION_AUTO_ALLOWED
 _NEEDS_HUMAN: Final[str] = ea.DECISION_NEEDS_HUMAN
 _PERMANENTLY_DENIED: Final[str] = ea.DECISION_PERMANENTLY_DENIED
 
 #: Severity ordering. Higher value = more restrictive.
+#:
+#: ``STRATEGICALLY_PREAPPROVED`` is severity 1, between AUTO_ALLOWED
+#: and NEEDS_HUMAN. PERMANENTLY_DENIED's severity moves from 2 to 3
+#: to keep a single contiguous ordering.
 _SEVERITY: Final[dict[str, int]] = {
     _AUTO_ALLOWED: 0,
-    _NEEDS_HUMAN: 1,
-    _PERMANENTLY_DENIED: 2,
+    _STRATEGICALLY_PREAPPROVED: 1,
+    _NEEDS_HUMAN: 2,
+    _PERMANENTLY_DENIED: 3,
 }
 
 #: Closed authority reason vocabulary. The first segment mirrors
@@ -135,6 +148,14 @@ _A20C_ONLY_REASONS: Final[tuple[str, ...]] = (
     "stop_conditions_informational_only",
     "forbidden_file_informational_only",
     "non_path_evidence_baseline",
+    # A22 strategic-mandate reasons
+    "strategic_mandate_satisfied",
+    "strategic_mandate_not_satisfied_unsupported_phase",
+    "strategic_mandate_not_satisfied_unsupported_target_layer",
+    "strategic_mandate_not_satisfied_missing_scaffolding",
+    "strategic_mandate_not_satisfied_unsupported_risk_class",
+    "strategic_mandate_not_applicable_already_auto_allowed",
+    "strategic_mandate_not_applicable_permanently_denied",
 )
 AUTHORITY_REASON: Final[tuple[str, ...]] = tuple(
     dict.fromkeys(_CANONICAL_REASONS + _A20C_ONLY_REASONS)
@@ -151,6 +172,8 @@ AUTHORITY_EVIDENCE_KIND: Final[tuple[str, ...]] = (
     "authority_hint",
     "unit_kind",
     "stop_conditions",
+    # A22 post-process kind
+    "strategic_mandate",
 )
 
 #: Evidence kinds that contribute to the unit-level aggregate. The
@@ -170,6 +193,11 @@ _INFORMATIONAL_EVIDENCE_KINDS: Final[frozenset[str]] = frozenset(
     {
         "forbidden_file_classifier",
         "stop_conditions",
+        # ``strategic_mandate`` is informational at aggregation
+        # time; it is applied as a post-process AFTER aggregation.
+        # Including it in the aggregator would create a circular
+        # dependency.
+        "strategic_mandate",
     }
 )
 
@@ -216,6 +244,60 @@ UNIT_AUTHORITY_DECISION_FIELDS: Final[tuple[str, ...]] = (
     "deny_reasons",
     "classifier_used",
     "fail_closed",
+    # A22 — explicit boolean so downstream consumers (selector,
+    # runner) can introspect mandate-satisfaction without re-parsing
+    # the evidence list.
+    "strategic_mandate_satisfied",
+)
+
+
+# ---------------------------------------------------------------------------
+# A22 strategic execution mandate (constants)
+# ---------------------------------------------------------------------------
+
+#: Phases the strategic mandate covers. Any phase outside this set
+#: keeps NEEDS_HUMAN authority and the conveyor stops on it.
+_MANDATE_PHASES: Final[frozenset[str]] = frozenset({
+    "v3.15.16",
+    "v3.15.17",
+    "v3.15.18",
+    "v3.15.19",
+    "v3.15.20",
+    "addendum_1",
+    "addendum_2",
+    "addendum_3",
+})
+
+#: Target layers the strategic mandate covers. The set names the
+#: research / scaffold / docs / tests / reporting surfaces the
+#: operator pre-approved. Layers outside this set (``broker``,
+#: ``agent.risk``, ``agent.execution``, ``live``, ``paper``,
+#: ``shadow``, ``trading``, ``dashboard``) are never promoted.
+_MANDATE_TARGET_LAYERS: Final[frozenset[str]] = frozenset({
+    "reporting",
+    "research",
+    "governance",
+    "test",
+    "diagnostic",
+    "external_intelligence",
+    "preset",
+    "evidence",
+})
+
+#: Risk classes the strategic mandate covers. ``HIGH`` / ``CRITICAL``
+#: / ``UNKNOWN`` remain NEEDS_HUMAN (or PERMANENTLY_DENIED if
+#: classified so) and require explicit operator action.
+_MANDATE_RISK_CLASSES: Final[frozenset[str]] = frozenset({"LOW", "MEDIUM"})
+
+#: Required unit scaffolding. A unit lacking any of these stays
+#: NEEDS_HUMAN — the mandate requires explicit definition of intent
+#: + tests + stop conditions before automatic execution.
+_MANDATE_REQUIRED_SCAFFOLD_FIELDS: Final[tuple[str, ...]] = (
+    "expected_files",
+    "forbidden_files",
+    "required_tests",
+    "stop_conditions",
+    "definition_of_done",
 )
 
 #: Top-level projection schema.
@@ -281,6 +363,11 @@ _BASE_AUTHORITY_INVARIANTS: Final[dict[str, bool]] = {
     # authority decisions.
     "aac_visibility_present": True,
     "next_buildable_selector_present": True,
+    # A22 strategic execution mandate post-process pins.
+    "strategic_mandate_post_process_applied": True,
+    "strategic_mandate_never_overrides_permanently_denied": True,
+    "strategic_mandate_never_promotes_unknown_risk": True,
+    "strategic_mandate_requires_explicit_scaffolding": True,
 }
 
 
@@ -636,7 +723,13 @@ def _aggregate(evidence: list[dict[str, Any]]) -> tuple[str, list[str]]:
     """Reduce evidence to ``(final_class, deny_reasons)`` via
     max-severity over the aggregating-kinds subset. Fail-closed:
     if there is no aggregating evidence at all (defence in depth),
-    return ``NEEDS_HUMAN`` + ``["fail_closed_unknown_evidence"]``."""
+    return ``NEEDS_HUMAN`` + ``["fail_closed_unknown_evidence"]``.
+
+    The aggregator only emits the canonical three classes
+    (``AUTO_ALLOWED`` / ``NEEDS_HUMAN`` / ``PERMANENTLY_DENIED``).
+    ``STRATEGICALLY_PREAPPROVED`` is applied as a post-process by
+    :func:`_apply_strategic_mandate`.
+    """
     aggregating = [
         e for e in evidence if e["kind"] in _AGGREGATING_EVIDENCE_KINDS
     ]
@@ -657,6 +750,128 @@ def _aggregate(evidence: list[dict[str, Any]]) -> tuple[str, list[str]]:
         if e["decision"] == _NEEDS_HUMAN:
             return _NEEDS_HUMAN, []
     return _AUTO_ALLOWED, []
+
+
+# ---------------------------------------------------------------------------
+# A22 strategic-mandate evaluator + post-process
+# ---------------------------------------------------------------------------
+
+
+def _evaluate_strategic_mandate(
+    unit: dict[str, Any],
+) -> tuple[bool, str]:
+    """Evaluate the operator's strategic execution mandate against
+    one A20b unit. Returns ``(satisfied, reason)`` where ``reason``
+    is a closed-vocab token from
+    :data:`_A20C_ONLY_REASONS`.
+
+    The mandate is satisfied when ALL of these hold:
+
+    1. ``phase`` is in :data:`_MANDATE_PHASES` (Roadmap v6 or any
+       Addendum slot).
+    2. ``target_layer`` is in :data:`_MANDATE_TARGET_LAYERS`
+       (research / scaffold / docs / tests / reporting surfaces).
+    3. ``risk_class`` is in :data:`_MANDATE_RISK_CLASSES` (``LOW``
+       or ``MEDIUM``; ``HIGH`` / ``CRITICAL`` / ``UNKNOWN`` remain
+       NEEDS_HUMAN).
+    4. Every field in :data:`_MANDATE_REQUIRED_SCAFFOLD_FIELDS`
+       (``expected_files`` / ``forbidden_files`` / ``required_tests``
+       / ``stop_conditions`` / ``definition_of_done``) is a
+       non-empty list.
+
+    Path safety (no forbidden surface in ``expected_files``, no
+    executable strategy / order placement / broker / risk
+    surface) is enforced by the pre-existing per-path classifier
+    aggregation: any such path produces a PERMANENTLY_DENIED
+    aggregate, and this post-process never promotes
+    PERMANENTLY_DENIED.
+    """
+    phase = unit.get("phase")
+    if not isinstance(phase, str) or phase not in _MANDATE_PHASES:
+        return False, "strategic_mandate_not_satisfied_unsupported_phase"
+    target_layer = unit.get("target_layer")
+    if (
+        not isinstance(target_layer, str)
+        or target_layer not in _MANDATE_TARGET_LAYERS
+    ):
+        return (
+            False,
+            "strategic_mandate_not_satisfied_unsupported_target_layer",
+        )
+    risk = unit.get("risk_class")
+    if not isinstance(risk, str) or risk not in _MANDATE_RISK_CLASSES:
+        return (
+            False,
+            "strategic_mandate_not_satisfied_unsupported_risk_class",
+        )
+    for field in _MANDATE_REQUIRED_SCAFFOLD_FIELDS:
+        value = unit.get(field)
+        if not isinstance(value, (list, tuple)) or len(value) == 0:
+            return (
+                False,
+                "strategic_mandate_not_satisfied_missing_scaffolding",
+            )
+    return True, "strategic_mandate_satisfied"
+
+
+def _apply_strategic_mandate(
+    unit: dict[str, Any], decision: dict[str, Any]
+) -> dict[str, Any]:
+    """Apply the A22 strategic-mandate post-process to one
+    aggregated decision.
+
+    * ``AUTO_ALLOWED`` decisions are left as-is — the mandate only
+      promotes upward from NEEDS_HUMAN. AUTO_ALLOWED records still
+      get a ``strategic_mandate`` evidence record with the
+      not-applicable reason for audit transparency.
+    * ``PERMANENTLY_DENIED`` decisions are left as-is — denied
+      surfaces stay denied; the mandate never overrides a hard
+      denial.
+    * ``NEEDS_HUMAN`` decisions are promoted to
+      ``STRATEGICALLY_PREAPPROVED`` if and only if every condition
+      in :func:`_evaluate_strategic_mandate` holds.
+    """
+    final_class = decision["final_authority_class"]
+    # Default: not satisfied, with a kind-of-default reason.
+    satisfied = False
+    reason: str
+
+    if final_class == _PERMANENTLY_DENIED:
+        reason = "strategic_mandate_not_applicable_permanently_denied"
+        mandate_decision = _NEEDS_HUMAN  # informational only
+    elif final_class == _AUTO_ALLOWED:
+        reason = "strategic_mandate_not_applicable_already_auto_allowed"
+        mandate_decision = _AUTO_ALLOWED  # informational only
+    else:
+        # NEEDS_HUMAN candidate — evaluate the mandate.
+        satisfied, reason = _evaluate_strategic_mandate(unit)
+        mandate_decision = (
+            _STRATEGICALLY_PREAPPROVED if satisfied else _NEEDS_HUMAN
+        )
+
+    evidence_record = _make_evidence(
+        kind="strategic_mandate",
+        value=("satisfied" if satisfied else "not_satisfied"),
+        decision=mandate_decision,
+        reason=reason,
+        source=_SOURCE_A20C,
+    )
+    new_evidence = list(decision["evidence"]) + [evidence_record]
+
+    if satisfied:
+        promoted_class = _STRATEGICALLY_PREAPPROVED
+        new_decision = dict(decision)
+        new_decision["final_authority_class"] = promoted_class
+        new_decision["max_severity"] = _SEVERITY[promoted_class]
+        new_decision["requires_operator_go"] = False
+        new_decision["evidence"] = new_evidence
+        new_decision["strategic_mandate_satisfied"] = True
+        return new_decision
+
+    new_decision = dict(decision)
+    new_decision["evidence"] = new_evidence
+    new_decision["strategic_mandate_satisfied"] = False
+    return new_decision
 
 
 def _decide_for_unit(unit: dict[str, Any]) -> dict[str, Any]:
@@ -694,7 +909,7 @@ def _decide_for_unit(unit: dict[str, Any]) -> dict[str, Any]:
         e["reason"].startswith("fail_closed_") for e in evidence
     )
 
-    return {
+    base_decision: dict[str, Any] = {
         "implementation_unit_id": unit["id"],
         "roadmap_task_id": unit["roadmap_task_id"],
         "phase": unit["phase"],
@@ -706,7 +921,11 @@ def _decide_for_unit(unit: dict[str, Any]) -> dict[str, Any]:
         "deny_reasons": deny_reasons,
         "classifier_used": classifier_used,
         "fail_closed": fail_closed,
+        "strategic_mandate_satisfied": False,
     }
+    # A22: apply the operator's strategic execution mandate as a
+    # post-process. May promote NEEDS_HUMAN to STRATEGICALLY_PREAPPROVED.
+    return _apply_strategic_mandate(unit, base_decision)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_autonomous_pr_runner.py
+++ b/tests/unit/test_autonomous_pr_runner.py
@@ -618,7 +618,10 @@ def test_step5_enabled_substage_is_a21e() -> None:
 
 
 def test_module_version_string() -> None:
-    assert apr.MODULE_VERSION.endswith("A21e")
+    # A22 extends A21e with strategic-mandate acceptance; the version
+    # tag carries both anchors.
+    assert "A21e" in apr.MODULE_VERSION
+    assert "A22" in apr.MODULE_VERSION
 
 
 # ---------------------------------------------------------------------------
@@ -3693,6 +3696,130 @@ def test_conveyor_module_code_contains_no_deploy_invocation() -> None:
         "workflow_dispatch",
     ):
         assert token not in code, token
+
+
+# ===========================================================================
+# A22 strategic-mandate runner safety-gate tests
+# ===========================================================================
+
+
+def test_runner_invariants_pin_a22_strategic_mandate(
+    tmp_path: Path,
+) -> None:
+    _write_minimal_upstreams(tmp_path)
+    report = apr.status(repo_root=tmp_path, generated_at_utc=_FROZEN_UTC)
+    inv = report["runner_invariants"]
+    assert inv["accepts_strategically_preapproved_authority"] is True
+    assert inv["accepts_medium_risk_only_when_strategically_preapproved"] is True
+    assert inv["never_accepts_needs_human_authority_for_execution"] is True
+    assert inv["never_accepts_permanently_denied_authority_for_execution"] is True
+    assert inv["never_accepts_high_or_critical_risk"] is True
+    assert inv["elevated_exceptions_remain_operator_driven"] is True
+
+
+def test_gates_pass_on_strategically_preapproved_low_risk() -> None:
+    snap = _baseline_selector_snapshot()
+    snap["selection"]["selected_authority_class"] = (
+        "STRATEGICALLY_PREAPPROVED"
+    )
+    gates, fail = apr.evaluate_safety_gates(
+        selector_snapshot=snap,
+        unit=_baseline_unit(),
+        max_units=1,
+        implementation_strategy="external_command",
+    )
+    assert fail is None
+    for g in gates:
+        assert g["result"] == "PASS", g
+
+
+def test_gates_pass_on_strategically_preapproved_medium_risk() -> None:
+    """STRATEGICALLY_PREAPPROVED + MEDIUM risk is explicitly the
+    operator's strategic mandate. The runner must accept it."""
+    snap = _baseline_selector_snapshot()
+    snap["selection"]["selected_authority_class"] = (
+        "STRATEGICALLY_PREAPPROVED"
+    )
+    snap["selection"]["selected_risk_class"] = "MEDIUM"
+    gates, fail = apr.evaluate_safety_gates(
+        selector_snapshot=snap,
+        unit=_baseline_unit(),
+        max_units=1,
+        implementation_strategy="external_command",
+    )
+    assert fail is None
+    # The low_risk gate passes with a specific detail note.
+    by_gate = {g["gate"]: g for g in gates}
+    assert by_gate["low_risk"]["result"] == "PASS"
+    assert (
+        "medium_risk_strategically_preapproved"
+        in by_gate["low_risk"]["detail"]
+    )
+
+
+def test_gates_refuse_needs_human_authority_even_at_low_risk() -> None:
+    """NEEDS_HUMAN authority is never accepted by the runner — even
+    at LOW risk. The mandate promotes to STRATEGICALLY_PREAPPROVED
+    when criteria match; un-promoted NEEDS_HUMAN stays gated."""
+    snap = _baseline_selector_snapshot()
+    snap["selection"]["selected_authority_class"] = "NEEDS_HUMAN"
+    gates, fail = apr.evaluate_safety_gates(
+        selector_snapshot=snap,
+        unit=_baseline_unit(),
+        max_units=1,
+        implementation_strategy="external_command",
+    )
+    assert fail == "unsafe_authority_class"
+
+
+def test_gates_refuse_medium_risk_without_strategic_mandate() -> None:
+    """MEDIUM risk + AUTO_ALLOWED must FAIL — the mandate is the
+    only way MEDIUM risk passes the low_risk gate."""
+    snap = _baseline_selector_snapshot()
+    snap["selection"]["selected_authority_class"] = "AUTO_ALLOWED"
+    snap["selection"]["selected_risk_class"] = "MEDIUM"
+    gates, fail = apr.evaluate_safety_gates(
+        selector_snapshot=snap,
+        unit=_baseline_unit(),
+        max_units=1,
+        implementation_strategy="external_command",
+    )
+    assert fail == "unsafe_risk_class"
+
+
+@pytest.mark.parametrize(
+    "high_risk", ["HIGH", "CRITICAL", "UNKNOWN"]
+)
+def test_gates_refuse_high_risk_even_when_strategically_preapproved(
+    high_risk: str,
+) -> None:
+    """HIGH / CRITICAL / UNKNOWN risk is ALWAYS refused, even when
+    the authority is STRATEGICALLY_PREAPPROVED. The mandate is
+    scoped to LOW and MEDIUM only."""
+    snap = _baseline_selector_snapshot()
+    snap["selection"]["selected_authority_class"] = (
+        "STRATEGICALLY_PREAPPROVED"
+    )
+    snap["selection"]["selected_risk_class"] = high_risk
+    gates, fail = apr.evaluate_safety_gates(
+        selector_snapshot=snap,
+        unit=_baseline_unit(),
+        max_units=1,
+        implementation_strategy="external_command",
+    )
+    assert fail == "unsafe_risk_class"
+
+
+def test_gates_refuse_permanently_denied_even_at_low_risk() -> None:
+    snap = _baseline_selector_snapshot()
+    snap["selection"]["selected_authority_class"] = "PERMANENTLY_DENIED"
+    gates, fail = apr.evaluate_safety_gates(
+        selector_snapshot=snap,
+        unit=_baseline_unit(),
+        max_units=1,
+        implementation_strategy="external_command",
+    )
+    assert fail == "unsafe_authority_class"
 
 
 def test_conveyor_does_not_use_real_shell_in_unit_tests() -> None:

--- a/tests/unit/test_roadmap_next_unit.py
+++ b/tests/unit/test_roadmap_next_unit.py
@@ -236,9 +236,14 @@ def test_phase_order_matches_a20a_phase_list() -> None:
 
 def test_authority_order_does_not_include_permanently_denied() -> None:
     """PERMANENTLY_DENIED is never used as a sort tier; it is a
-    block-only verdict and is filtered out before sorting."""
+    block-only verdict and is filtered out before sorting. A22 adds
+    STRATEGICALLY_PREAPPROVED between AUTO_ALLOWED and NEEDS_HUMAN."""
     assert "PERMANENTLY_DENIED" not in rnu._AUTHORITY_ORDER
-    assert rnu._AUTHORITY_ORDER == ("AUTO_ALLOWED", "NEEDS_HUMAN")
+    assert rnu._AUTHORITY_ORDER == (
+        "AUTO_ALLOWED",
+        "STRATEGICALLY_PREAPPROVED",
+        "NEEDS_HUMAN",
+    )
 
 
 def test_risk_order_matches_classifier_enum() -> None:
@@ -1340,6 +1345,129 @@ def test_top_level_projection_carries_status_schema_version(
     )
     snap = _snap(tmp_path)
     assert snap["source_status_schema_version"] == "1.0"
+
+
+# ---------------------------------------------------------------------------
+# A22 strategic-mandate selector integration
+# ---------------------------------------------------------------------------
+
+
+def test_strategically_preapproved_unit_is_eligible(tmp_path: Path) -> None:
+    """A unit with final_authority_class STRATEGICALLY_PREAPPROVED
+    and operator_gate=none must be ELIGIBLE (not NEEDS_HUMAN_GATED)."""
+    unit = _baseline_unit()
+    _write_units_artifact(tmp_path, [unit])
+    _write_authority_artifact(
+        tmp_path,
+        [
+            _baseline_decision(
+                final_authority_class="STRATEGICALLY_PREAPPROVED",
+                requires_operator_go=False,
+            )
+        ],
+    )
+    snap = _snap(tmp_path)
+    cand = snap["candidates"][0]
+    assert cand["eligibility"] == "ELIGIBLE"
+    assert cand["final_authority_class"] == "STRATEGICALLY_PREAPPROVED"
+    assert snap["selection"]["selection_status"] == "OK_SELECTED"
+    assert snap["selection"]["requires_operator_go"] is False
+
+
+def test_auto_allowed_preferred_over_strategically_preapproved(
+    tmp_path: Path,
+) -> None:
+    """When both an AUTO_ALLOWED and a STRATEGICALLY_PREAPPROVED
+    candidate exist, the AUTO_ALLOWED one wins via the
+    authority-order sort key (severity 0 vs 1)."""
+    auto_unit = _baseline_unit(id="u_auto", phase="v3.15.16")
+    strat_unit = _baseline_unit(id="u_strat", phase="v3.15.16")
+    _write_units_artifact(tmp_path, [auto_unit, strat_unit])
+    _write_authority_artifact(
+        tmp_path,
+        [
+            _baseline_decision(implementation_unit_id="u_auto"),
+            _baseline_decision(
+                implementation_unit_id="u_strat",
+                final_authority_class="STRATEGICALLY_PREAPPROVED",
+                requires_operator_go=False,
+            ),
+        ],
+    )
+    snap = _snap(tmp_path)
+    assert snap["selection"]["selected_unit_id"] == "u_auto"
+
+
+def test_strategically_preapproved_picked_before_needs_human(
+    tmp_path: Path,
+) -> None:
+    """STRATEGICALLY_PREAPPROVED is ELIGIBLE; NEEDS_HUMAN is
+    NEEDS_HUMAN_GATED. The selector prefers ELIGIBLE so the
+    mandate-promoted unit wins over the gated one."""
+    strat_unit = _baseline_unit(id="u_strat", phase="v3.15.16")
+    gated_unit = _baseline_unit(
+        id="u_gated",
+        phase="v3.15.16",
+        authority_hint="NEEDS_HUMAN_CANDIDATE",
+        operator_gate="operator_go_required",
+    )
+    _write_units_artifact(tmp_path, [strat_unit, gated_unit])
+    _write_authority_artifact(
+        tmp_path,
+        [
+            _baseline_decision(
+                implementation_unit_id="u_strat",
+                final_authority_class="STRATEGICALLY_PREAPPROVED",
+                requires_operator_go=False,
+            ),
+            _baseline_decision(
+                implementation_unit_id="u_gated",
+                final_authority_class="NEEDS_HUMAN",
+                requires_operator_go=True,
+            ),
+        ],
+    )
+    snap = _snap(tmp_path)
+    assert snap["selection"]["selected_unit_id"] == "u_strat"
+    assert snap["selection"]["selection_status"] == "OK_SELECTED"
+
+
+def test_permanently_denied_still_wins_over_strategically_preapproved(
+    tmp_path: Path,
+) -> None:
+    """PERMANENTLY_DENIED units remain BLOCKED — they never get
+    selected even if STRATEGICALLY_PREAPPROVED options exist
+    (defence in depth; the post-process never overrides hard
+    denial, so this case shouldn't happen in practice but the
+    selector still handles it correctly)."""
+    strat_unit = _baseline_unit(id="u_strat", phase="v3.15.16")
+    denied_unit = _baseline_unit(id="u_denied", phase="v3.15.16")
+    _write_units_artifact(tmp_path, [strat_unit, denied_unit])
+    _write_authority_artifact(
+        tmp_path,
+        [
+            _baseline_decision(
+                implementation_unit_id="u_strat",
+                final_authority_class="STRATEGICALLY_PREAPPROVED",
+                requires_operator_go=False,
+            ),
+            _baseline_decision(
+                implementation_unit_id="u_denied",
+                final_authority_class="PERMANENTLY_DENIED",
+                permanently_denied=True,
+                deny_reasons=["denied_live_path_modification"],
+            ),
+        ],
+    )
+    snap = _snap(tmp_path)
+    # u_strat wins; u_denied is BLOCKED.
+    assert snap["selection"]["selected_unit_id"] == "u_strat"
+    denied_candidate = next(
+        c
+        for c in snap["candidates"]
+        if c["implementation_unit_id"] == "u_denied"
+    )
+    assert denied_candidate["eligibility"] == "BLOCKED"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_roadmap_unit_authority.py
+++ b/tests/unit/test_roadmap_unit_authority.py
@@ -119,12 +119,16 @@ def _baseline_unit(**overrides) -> dict:
 # ---------------------------------------------------------------------------
 
 
-def test_authority_class_matches_canonical_decisions_verbatim() -> None:
-    assert rua.AUTHORITY_CLASS == ea.DECISIONS
+def test_authority_class_extends_canonical_decisions_with_strategic() -> None:
+    """A22 extends AUTHORITY_CLASS with ``STRATEGICALLY_PREAPPROVED``.
+    The canonical classifier's three values remain in order at the
+    start; the A22 promotion class is appended last."""
+    assert rua.AUTHORITY_CLASS[:3] == ea.DECISIONS
     assert rua.AUTHORITY_CLASS == (
         "AUTO_ALLOWED",
         "NEEDS_HUMAN",
         "PERMANENTLY_DENIED",
+        "STRATEGICALLY_PREAPPROVED",
     )
 
 
@@ -138,6 +142,7 @@ def test_authority_evidence_kind_is_closed_exact() -> None:
         "authority_hint",
         "unit_kind",
         "stop_conditions",
+        "strategic_mandate",
     )
 
 
@@ -182,11 +187,15 @@ def test_authority_reason_has_no_duplicates() -> None:
     assert len(rua.AUTHORITY_REASON) == len(set(rua.AUTHORITY_REASON))
 
 
-def test_severity_ordering_matches_canonical_decisions() -> None:
+def test_severity_ordering_includes_strategic_between_auto_and_needs_human() -> None:
+    """A22 inserts ``STRATEGICALLY_PREAPPROVED`` at severity 1.
+    ``NEEDS_HUMAN`` moves to 2 and ``PERMANENTLY_DENIED`` to 3, so
+    the ordering remains contiguous and monotone."""
     assert rua._SEVERITY == {
         ea.DECISION_AUTO_ALLOWED: 0,
-        ea.DECISION_NEEDS_HUMAN: 1,
-        ea.DECISION_PERMANENTLY_DENIED: 2,
+        "STRATEGICALLY_PREAPPROVED": 1,
+        ea.DECISION_NEEDS_HUMAN: 2,
+        ea.DECISION_PERMANENTLY_DENIED: 3,
     }
 
 
@@ -238,6 +247,7 @@ def test_unit_authority_decision_field_list_exact() -> None:
         "deny_reasons",
         "classifier_used",
         "fail_closed",
+        "strategic_mandate_satisfied",
     )
 
 
@@ -358,7 +368,15 @@ def test_needs_human_unit_elevates_via_canonical_policy_doc() -> None:
     """A LOW-risk reporting unit that lists a canonical_policy_doc in
     expected_files MUST elevate to NEEDS_HUMAN (the canonical
     classifier emits high_risk_canonical_policy_change for that
-    path)."""
+    path).
+
+    Under A22, NEEDS_HUMAN units are post-process candidates for
+    promotion to STRATEGICALLY_PREAPPROVED. The baseline unit's
+    target_layer ``reporting`` and risk ``LOW`` satisfy the mandate
+    if the unit also has all the required scaffolding. The default
+    ``_baseline_unit`` lacks ``stop_conditions`` / ``definition_of_done``,
+    so the post-process leaves it at NEEDS_HUMAN.
+    """
     unit = _baseline_unit(
         expected_files=[
             "reporting/synthetic_module.py",
@@ -367,7 +385,7 @@ def test_needs_human_unit_elevates_via_canonical_policy_doc() -> None:
     )
     d = rua._decide_for_unit(unit)
     assert d["final_authority_class"] == ea.DECISION_NEEDS_HUMAN
-    assert d["max_severity"] == 1
+    assert d["max_severity"] == 2
     assert d["requires_operator_go"] is True
 
 
@@ -380,7 +398,7 @@ def test_permanently_denied_unit_via_live_path() -> None:
     )
     d = rua._decide_for_unit(unit)
     assert d["final_authority_class"] == ea.DECISION_PERMANENTLY_DENIED
-    assert d["max_severity"] == 2
+    assert d["max_severity"] == 3
     assert d["permanently_denied"] is True
     assert "denied_live_path_modification" in d["deny_reasons"]
 
@@ -872,7 +890,7 @@ def test_cli_default_writes_to_allowlisted_path(
     assert sentinel.is_file()
     payload = json.loads(sentinel.read_text(encoding="utf-8"))
     assert payload["report_kind"] == "roadmap_unit_authority"
-    assert payload["module_version"].endswith("A20c")
+    assert "A20c" in payload["module_version"]
 
 
 def test_cli_indent_zero_compact(
@@ -1008,4 +1026,184 @@ def test_module_imports_cleanly() -> None:
 def test_schema_and_module_version_strings() -> None:
     assert isinstance(rua.SCHEMA_VERSION, str) and rua.SCHEMA_VERSION
     assert isinstance(rua.MODULE_VERSION, str) and rua.MODULE_VERSION
-    assert rua.MODULE_VERSION.endswith("A20c")
+    # A22 extends A20c with the strategic-mandate post-process; the
+    # version tag carries both anchors.
+    assert "A20c" in rua.MODULE_VERSION
+    assert "A22" in rua.MODULE_VERSION
+
+
+# ===========================================================================
+# A22 strategic execution mandate post-process tests
+# ===========================================================================
+
+
+def _mandate_eligible_unit(**overrides: object) -> dict:
+    """Synthetic unit that satisfies every mandate criterion: phase
+    in Roadmap v6 + Addendum 1; target_layer in the mandate set;
+    risk LOW (default) or MEDIUM (override); all scaffolding fields
+    populated. The unit's authority_hint NEEDS_HUMAN_CANDIDATE
+    ensures the aggregator returns NEEDS_HUMAN so the post-process
+    can promote it."""
+    base = _baseline_unit(
+        authority_hint="NEEDS_HUMAN_CANDIDATE",
+        risk_class="MEDIUM",
+        expected_files=["reporting/synthetic_target.py"],
+        forbidden_files=["broker/**", "dashboard/dashboard.py"],
+        required_tests=["tests/unit/test_synthetic_target.py"],
+        stop_conditions=("stop if external API access is added",),
+        definition_of_done=("synthetic module imports cleanly",),
+    )
+    base.update(overrides)
+    return base
+
+
+def test_mandate_promotes_eligible_needs_human_unit() -> None:
+    unit = _mandate_eligible_unit()
+    d = rua._decide_for_unit(unit)
+    assert d["final_authority_class"] == "STRATEGICALLY_PREAPPROVED"
+    assert d["max_severity"] == 1
+    assert d["requires_operator_go"] is False
+    assert d["strategic_mandate_satisfied"] is True
+    # Mandate evidence is recorded explicitly on the decision.
+    mandate_evidence = [
+        e for e in d["evidence"] if e["kind"] == "strategic_mandate"
+    ]
+    assert len(mandate_evidence) == 1
+    assert mandate_evidence[0]["decision"] == "STRATEGICALLY_PREAPPROVED"
+    assert mandate_evidence[0]["reason"] == "strategic_mandate_satisfied"
+
+
+def test_mandate_does_not_promote_permanently_denied_unit() -> None:
+    """A unit with a forbidden path in expected_files must STAY
+    PERMANENTLY_DENIED — the mandate never overrides hard denial."""
+    unit = _mandate_eligible_unit(
+        expected_files=[
+            "reporting/synthetic_target.py",
+            "broker/synthetic_broker.py",  # live_path -> PERMANENTLY_DENIED
+        ],
+    )
+    d = rua._decide_for_unit(unit)
+    assert d["final_authority_class"] == "PERMANENTLY_DENIED"
+    assert d["strategic_mandate_satisfied"] is False
+    mandate_evidence = [
+        e for e in d["evidence"] if e["kind"] == "strategic_mandate"
+    ]
+    assert len(mandate_evidence) == 1
+    assert mandate_evidence[0]["reason"] == (
+        "strategic_mandate_not_applicable_permanently_denied"
+    )
+
+
+def test_mandate_does_not_promote_auto_allowed_unit() -> None:
+    """An AUTO_ALLOWED unit stays AUTO_ALLOWED. The mandate only
+    promotes upward from NEEDS_HUMAN."""
+    unit = _baseline_unit(
+        authority_hint="AUTO_ALLOWED_CANDIDATE",
+        risk_class="LOW",
+    )
+    d = rua._decide_for_unit(unit)
+    assert d["final_authority_class"] == "AUTO_ALLOWED"
+    assert d["strategic_mandate_satisfied"] is False
+    mandate_evidence = [
+        e for e in d["evidence"] if e["kind"] == "strategic_mandate"
+    ]
+    assert len(mandate_evidence) == 1
+    assert mandate_evidence[0]["reason"] == (
+        "strategic_mandate_not_applicable_already_auto_allowed"
+    )
+
+
+def test_mandate_refuses_unsupported_phase() -> None:
+    unit = _mandate_eligible_unit(phase="v3.14.0")  # outside mandate
+    d = rua._decide_for_unit(unit)
+    assert d["final_authority_class"] == "NEEDS_HUMAN"
+    assert d["strategic_mandate_satisfied"] is False
+    mandate_evidence = [
+        e for e in d["evidence"] if e["kind"] == "strategic_mandate"
+    ]
+    assert mandate_evidence[0]["reason"] == (
+        "strategic_mandate_not_satisfied_unsupported_phase"
+    )
+
+
+def test_mandate_refuses_unsupported_target_layer() -> None:
+    """``broker`` is not a mandate target layer (even though most
+    broker units are PERMANENTLY_DENIED via path classification; we
+    cover the case where the layer alone is the problem)."""
+    unit = _mandate_eligible_unit(target_layer="broker")
+    d = rua._decide_for_unit(unit)
+    # broker is not in mandate target layers; aggregator returns
+    # NEEDS_HUMAN; post-process refuses.
+    assert d["strategic_mandate_satisfied"] is False
+    mandate_evidence = [
+        e for e in d["evidence"] if e["kind"] == "strategic_mandate"
+    ]
+    # Either unsupported_target_layer OR another reason fired first.
+    # Either way, satisfied must be False.
+    assert mandate_evidence[0]["reason"].startswith(
+        "strategic_mandate_not_"
+    )
+
+
+def test_mandate_refuses_unsupported_risk_class() -> None:
+    """HIGH/CRITICAL/UNKNOWN risk is never promoted by the mandate."""
+    for high_risk in ("HIGH", "CRITICAL", "UNKNOWN"):
+        unit = _mandate_eligible_unit(risk_class=high_risk)
+        d = rua._decide_for_unit(unit)
+        assert d["strategic_mandate_satisfied"] is False, high_risk
+        if d["final_authority_class"] not in {
+            "PERMANENTLY_DENIED",
+            "STRATEGICALLY_PREAPPROVED",
+        }:
+            assert d["final_authority_class"] == "NEEDS_HUMAN"
+
+
+@pytest.mark.parametrize(
+    "missing_field",
+    [
+        "expected_files",
+        "forbidden_files",
+        "required_tests",
+        "stop_conditions",
+        "definition_of_done",
+    ],
+)
+def test_mandate_refuses_missing_scaffolding(missing_field: str) -> None:
+    unit = _mandate_eligible_unit(**{missing_field: ()})
+    d = rua._decide_for_unit(unit)
+    assert d["strategic_mandate_satisfied"] is False
+    if missing_field == "expected_files":
+        # Empty expected_files makes the aggregator fail-closed.
+        assert d["final_authority_class"] in {
+            "NEEDS_HUMAN", "PERMANENTLY_DENIED"
+        }
+    else:
+        assert d["final_authority_class"] == "NEEDS_HUMAN"
+
+
+def test_mandate_invariants_pinned_on_projection() -> None:
+    snap = rua.collect_snapshot(generated_at_utc=_FROZEN_UTC)
+    inv = snap["authority_invariants"]
+    assert inv["strategic_mandate_post_process_applied"] is True
+    assert inv["strategic_mandate_never_overrides_permanently_denied"] is True
+    assert inv["strategic_mandate_never_promotes_unknown_risk"] is True
+    assert inv["strategic_mandate_requires_explicit_scaffolding"] is True
+
+
+def test_mandate_evidence_kind_is_informational_not_aggregating() -> None:
+    """``strategic_mandate`` is in the informational bucket. The
+    aggregator must NOT consider it during max-severity reduction
+    (it's a post-process)."""
+    assert "strategic_mandate" in rua._INFORMATIONAL_EVIDENCE_KINDS
+    assert "strategic_mandate" not in rua._AGGREGATING_EVIDENCE_KINDS
+
+
+def test_mandate_severity_strictly_between_auto_and_needs_human() -> None:
+    """STRATEGICALLY_PREAPPROVED severity (1) is strictly between
+    AUTO_ALLOWED (0) and NEEDS_HUMAN (2). The conveyor uses this to
+    prefer AUTO_ALLOWED over mandate-promoted units at sort time."""
+    assert (
+        rua._SEVERITY["AUTO_ALLOWED"]
+        < rua._SEVERITY["STRATEGICALLY_PREAPPROVED"]
+        < rua._SEVERITY["NEEDS_HUMAN"]
+    )


### PR DESCRIPTION
## Summary

A22 encodes the operator's strategic execution mandate for the Roadmap v6 + Addendum 1/2/3 research-intelligence work-track. Mandate-eligible MEDIUM / NEEDS_HUMAN scaffold units are now automatically processed by the A21e conveyor via a new authority class `STRATEGICALLY_PREAPPROVED`. Hard runtime / trading / paper / shadow / broker / risk / live / frozen-contract / dashboard-mutation boundaries remain absolutely intact.

- **Phase:** A22 — strategic roadmap execution mandate + catalog expansion policy.
- **Authority class on this PR:** `AUTO_ALLOWED` (LOW risk, `operator_gate = none`).
- **The mandate NEVER overrides PERMANENTLY_DENIED authority.** The canonical classifier still scans every expected_files entry for live / paper / shadow / broker / risk / execution paths and denies them BEFORE the mandate post-process runs.
- **The mandate NEVER accepts HIGH / CRITICAL / UNKNOWN risk.** Scoped to LOW and MEDIUM only.
- **The mandate NEVER relaxes the always-blocked surfaces.** No --admin, no force-push, no hook bypass, no deploy invocation, no .claude/** mutation, no .github/** mutation, no docs/development_work_queue/*.jsonl mutation, no tests/regression/** mutation, no frozen schemas under artifacts/, no canonical roadmap/governance/execution_authority/no_touch_paths docs.
- **Elevated exceptions (frozen contracts + dashboard mutation) remain operator-driven** outside the autonomous runner. The conveyor never touches them.
- **The current queue stays finite.** Addendum 2 and Addendum 3 remain absence-flagged. New units require an operator-driven catalog expansion PR.
- **No runtime / trading / paper / shadow / live authority is granted.** Every authority pin in `runner_invariants` asserts this.

## Exact files changed (9 files, +1287 / -48)

- `docs/governance/strategic_roadmap_execution_mandate.md` (new) — the operator-pre-approved mandate doc with 11 sections (why; hard constraints; criteria; elevated exception policy; catalog expansion policy; CI/test/diff retry-within-unit policy; implementation map; test coverage; what A22 does NOT do; cross-references; next operator action).
- `reporting/roadmap_unit_authority.py` (modified) — adds STRATEGICALLY_PREAPPROVED to AUTHORITY_CLASS at severity 1; adds `strategic_mandate` evidence kind (informational, not aggregating); adds seven new closed-vocab AUTHORITY_REASON values; adds `_MANDATE_PHASES`, `_MANDATE_TARGET_LAYERS`, `_MANDATE_RISK_CLASSES`, `_MANDATE_REQUIRED_SCAFFOLD_FIELDS` constants; adds `_evaluate_strategic_mandate(unit)` deterministic evaluator and `_apply_strategic_mandate(unit, decision)` post-process; adds `strategic_mandate_satisfied` field on UNIT_AUTHORITY_DECISION_FIELDS; adds 4 new authority_invariants pins.
- `tests/unit/test_roadmap_unit_authority.py` (modified) — updates 8 pin tests for the schema/vocab widenings; adds 14 new tests for the mandate post-process (vocab, schema, severity, promotion happy path, no-promote-permanently-denied, no-promote-auto-allowed, no-promote-unsupported-phase, no-promote-unsupported-target-layer, no-promote-high-risk parametrised, no-promote-missing-scaffolding parametrised over 5 fields, informational kind partition, severity strictly between).
- `reporting/roadmap_next_unit.py` (modified) — adds STRATEGICALLY_PREAPPROVED to `_AUTHORITY_ORDER` between AUTO_ALLOWED and NEEDS_HUMAN. Eligibility logic treats STRATEGICALLY_PREAPPROVED + operator_gate=none as ELIGIBLE (not NEEDS_HUMAN_GATED). The selector still prefers AUTO_ALLOWED via the sort-key.
- `tests/unit/test_roadmap_next_unit.py` (modified) — updates 1 pin test; adds 4 selector tests (STRATEGICALLY_PREAPPROVED is ELIGIBLE; AUTO_ALLOWED preferred over STRATEGICALLY_PREAPPROVED; STRATEGICALLY_PREAPPROVED preferred over NEEDS_HUMAN-gated; PERMANENTLY_DENIED still blocks alongside mandate candidates).
- `reporting/autonomous_pr_runner.py` (modified) — widens `auto_allowed_authority` to accept AUTO_ALLOWED OR STRATEGICALLY_PREAPPROVED; widens `low_risk` to accept LOW always or MEDIUM only when authority is STRATEGICALLY_PREAPPROVED; adds 6 new runner_invariants pins.
- `tests/unit/test_autonomous_pr_runner.py` (modified) — updates 1 pin test; adds 9 runner safety-gate tests covering STRATEGICALLY_PREAPPROVED+LOW PASS, STRATEGICALLY_PREAPPROVED+MEDIUM PASS with detail note, NEEDS_HUMAN refuse, MEDIUM without mandate refuse, HIGH/CRITICAL/UNKNOWN with STRATEGICALLY_PREAPPROVED refuse parametrised, PERMANENTLY_DENIED refuse, A22 runner_invariants pinned.
- `docs/governance/step5_bounded_autonomous_loop.md` (modified) — new section 14 covers the A22 integration: runner safety-gate widening, new runner invariants, elevated exception policy summary.
- `docs/governance/roadmap_task_catalog.md` (modified) — header lists A22; pointer block adds A22 module + governance link; documents that the queue is finite and that addendum_2 / addendum_3 are not yet repo-resident.

## Strategic mandate summary

A unit is promoted to STRATEGICALLY_PREAPPROVED iff ALL of:

1. **Phase** in {v3.15.16, v3.15.17, v3.15.18, v3.15.19, v3.15.20, addendum_1, addendum_2, addendum_3}.
2. **Target layer** in {reporting, research, governance, test, diagnostic, external_intelligence, preset, evidence}.
3. **Risk class** in {LOW, MEDIUM}.
4. **All five scaffolding fields non-empty:** expected_files, forbidden_files, required_tests, stop_conditions, definition_of_done.

Plus the upstream path-classifier check: any forbidden surface in expected_files produces PERMANENTLY_DENIED first, which the post-process never overrides.

## Elevated exception policy summary

Two surfaces are PERMANENTLY_DENIED at the classifier level and require operator-authored PRs outside the autonomous runner if a change is genuinely necessary:

- **Frozen contracts:** `research/research_latest.json`, `research/strategy_matrix.csv`. Requires explicit rationale that no smaller alternative exists; must include frozen-contract regression tests; must be reported as `elevated_exception_required`.
- **Dashboard / UI mutation:** `dashboard/dashboard.py`, UI mutation buttons, approval buttons, mutation routes. Requires explicit rationale that no smaller read-only / reporting alternative exists; must be reported as `elevated_exception_required`. Mutation buttons / approval buttons remain blocked unless explicitly approved in a separate governance-bootstrap PR.

## Catalog expansion policy summary

- The current A20a / A20b queue is FINITE: Roadmap v6 phases v3.15.16 → v3.15.20 + Addendum 1 + 20 implementation units.
- Addendum 2 and Addendum 3 slots exist in the mandate's phase list but are **not yet repo-resident**. The catalog still pins `addendum_2_not_present = true` and `addendum_3_not_present = true`.
- Adding new units requires a **catalog expansion PR** that adds entries to `reporting/roadmap_task_catalog.py` + `reporting/roadmap_task_units.py` + matching test pins. The mandate criteria automatically apply to new units that satisfy them.
- The runner never invents work and never scans canonical roadmap documents at runtime.

## Validation commands and results

- `python -m pytest tests/unit/test_roadmap_unit_authority.py -v` — **100 passed** (86 pre-existing + 14 new A22 tests).
- `python -m pytest tests/unit/test_roadmap_next_unit.py -v` — **92 passed** (88 pre-existing + 4 new A22 tests).
- `python -m pytest tests/unit/test_autonomous_pr_runner.py -v` — **195 passed** (186 pre-existing + 9 new A22 tests).
- `python -m pytest tests/unit/test_roadmap_task_catalog.py -v` — passed (unchanged).
- `python -m pytest tests/unit/test_roadmap_task_units.py -v` — passed (unchanged).
- `python -m pytest tests/unit/test_roadmap_unit_status.py -v` — passed (unchanged).
- Combined roadmap-pipeline run: **644 passed**.
- `python -m pytest tests/smoke -v` — **18 passed**.
- `python -m pytest tests/regression/test_public_output_contract.py tests/regression/test_v12_contracts_preserved.py tests/regression/test_authority_invariants.py -v` — **16 passed**.
- `python scripts/governance_lint.py` — `Governance lint OK (16 agents, 5 workflows checked).`

## Frozen-contract verdict

PASS. No mutation of `research/research_latest.json`, no mutation of `research/strategy_matrix.csv`, no mutation of any frozen schema under `artifacts/`. `regression-fast (determinism pins)` green.

## Forbidden-path verdict

PASS. Diff touches **only** the 9 spec-allowed files (one new doc + 8 modifications). None of the always-forbidden paths changed: not `dashboard/dashboard.py`, not `.claude/**`, not `.github/**`, not `automation/live_gate.py`, not `broker/**`, not `agent/risk/**`, not `agent/execution/**`, not `live/**`, not `paper/**`, not `shadow/**`, not `trading/**`, not `docs/roadmap/Roadmap v6.md`, not `docs/roadmap/Roadmap v6 Addendum.md`, not `docs/roadmap/autonomous_development.txt`, not `docs/governance/execution_authority.md`, not `docs/governance/no_touch_paths.md`, not `reporting/execution_authority.py`, not `reporting/development_queue_admission_policy.py`, not `docs/development_work_queue/*.jsonl`, not `tests/regression/**`.

## Statement of constraints honoured

- **Trading / runtime / paper / shadow / live authority remains forbidden.** A22 widens only the authority and risk-class gates; it never relaxes path-level denials, force-push, --admin, hook bypass, or deploy-invocation guards.
- **The current queue is finite and must be expanded by catalog expansion PRs.** A22 does NOT add new units; it changes how the classifier categorises existing eligible NEEDS_HUMAN units.
- **Frozen-contract changes remain elevated exceptions** outside the autonomous runner.
- **Dashboard mutation changes remain elevated exceptions** outside the autonomous runner.

## Test plan

- [ ] CI completes green on this branch (lint, secret-scan, typecheck, unit, regression-fast, hook-tests, frontend, governance-lint).
- [ ] No frozen-contract regression test newly fails.
- [ ] No governance-lint regression.
- [ ] No new agent-allowlist surfaces appear.

## Next recommended PR

Two paths, operator picks:

1. **Addendum 2/3 repo-resident catalog expansion** — if the operator provides Addendum 2/3 content in a subsequent prompt, open a catalog expansion PR that adds RoadmapTask + RoadmapRequirement + ImplementationUnit entries for the addendum and removes the corresponding absence flag.
2. **Run the continuous conveyor against the existing queue** — invoke `python -m reporting.autonomous_pr_runner --run-continuous --auto-merge-runner-pr --implementation-strategy external_command --implementation-command "<cmd>"` from the local laptop. Mandate-promoted MEDIUM scaffolding units in the existing seed (sampling intelligence, diagnostic explanation, lineage provenance, etc.) will now flow automatically.