### PR TITLE
feat(a24): unit-templated external implementation command

### DIFF
--- a/docs/governance/roadmap_task_catalog.md
+++ b/docs/governance/roadmap_task_catalog.md
@@ -1,4 +1,4 @@
-# Roadmap Task Catalog — A20a..A20e + A21a + A21c + A21d + A21e + A22
+# Roadmap Task Catalog — A20a..A20e + A21a + A21c + A21d + A21e + A22 + A24
 
 > **Status:** A20a implemented; A20b implemented; A20c implemented
 > (extended by A22 with strategic-mandate post-process); A20d
@@ -65,6 +65,9 @@ requirements) still follows the catalog-expansion-PR pattern in
 > **A22 module:** [`reporting/roadmap_unit_authority.py`](../../reporting/roadmap_unit_authority.py) (strategic-mandate post-process)
 > **A22 governance:** [`docs/governance/strategic_roadmap_execution_mandate.md`](strategic_roadmap_execution_mandate.md)
 > A22 promotes mandate-eligible NEEDS_HUMAN units to ``STRATEGICALLY_PREAPPROVED`` so the conveyor processes them automatically. The mandate never overrides PERMANENTLY_DENIED, never accepts HIGH/CRITICAL/UNKNOWN risk, and never relaxes the always-blocked runtime / trading / paper / shadow / broker / risk / execution / frozen-contract / dashboard-mutation surfaces.
+>
+> **A24 governance:** [`docs/governance/step5_bounded_autonomous_loop.md`](step5_bounded_autonomous_loop.md) §A24
+> A24 extends the A21c/A21d/A21e runner with unit-templated `--implementation-command` expansion. The operator-supplied template is expanded against the selected unit's closed-vocab metadata (`{unit_id}`, `{phase}`, `{title}`, `{risk_class}`, `{operator_gate}`, `{expected_files_json}`, `{forbidden_files_json}`, `{required_tests_json}`, `{definition_of_done_json}`, `{stop_conditions_json}`) before `shlex.split`. Unknown tokens, missing fields, oversize values, newline-bearing scalars, non-list JSON fields, and malformed braces all fail closed. No `eval`, no `exec`, no `shell=True`.
 >
 > **A21c + A21d + A21e module:** [`reporting/autonomous_pr_runner.py`](../../reporting/autonomous_pr_runner.py)
 > **A21c..A21e primary artefact:** `logs/autonomous_pr_runner/latest.json`

--- a/docs/governance/step5_bounded_autonomous_loop.md
+++ b/docs/governance/step5_bounded_autonomous_loop.md
@@ -1163,6 +1163,155 @@ Pinned in
 - **Signal-handler-based hard stop** — Ctrl+C kills the process
   uncleanly. A future slice may add a SIGINT handler.
 
+## A24 — Unit-templated external implementation command
+
+[`reporting/autonomous_pr_runner.py`](../../reporting/autonomous_pr_runner.py)
+now expands the operator-supplied `--implementation-command` template
+against the selected unit before `shlex.split`. Without this, a static
+command had no per-iteration context (no way to know which unit was
+selected, which `expected_files` to write, which `required_tests` to
+satisfy), so the continuous conveyor was not practically usable across
+multiple units.
+
+### Why this exists
+
+The A21e conveyor processes one unit per iteration. Between
+iterations the selected unit changes (different `unit_id`,
+different `expected_files`, different `required_tests`). Without
+templating, a static `--implementation-command` would produce the
+same shell args every iteration and either:
+
+- do nothing → conveyor stops with `diff_empty`; or
+- produce changes outside iteration 2's `expected_files` → conveyor
+  stops with `diff_outside_expected_files`.
+
+A24 lets the operator write **one** template that the runner expands
+per iteration with the current unit's identity and scaffolding
+metadata.
+
+### Allowed template tokens (closed vocab)
+
+| Token | Source field | Type | Cap |
+|---|---|---|---|
+| `{unit_id}` | `id` | str | 240 |
+| `{phase}` | `phase` | str | 240 |
+| `{title}` | `title` | str | 240 |
+| `{risk_class}` | `risk_class` | str | 240 |
+| `{operator_gate}` | `operator_gate` | str | 240 |
+| `{expected_files_json}` | `expected_files` | list[str] → compact JSON | 8000 |
+| `{forbidden_files_json}` | `forbidden_files` | list[str] → compact JSON | 8000 |
+| `{required_tests_json}` | `required_tests` | list[str] → compact JSON | 8000 |
+| `{definition_of_done_json}` | `definition_of_done` | list[str] → compact JSON | 8000 |
+| `{stop_conditions_json}` | `stop_conditions` | list[str] → compact JSON | 8000 |
+
+Pinned in code: `EXTERNAL_COMMAND_SCALAR_TOKENS`,
+`EXTERNAL_COMMAND_JSON_TOKENS`, `EXTERNAL_COMMAND_ALLOWED_TOKENS`.
+
+### Templates are operator-supplied and explicit
+
+- The template is the operator's `--implementation-command` string.
+- The runner does NOT invent commands.
+- The runner does NOT call any LLM or external API on its own; only
+  the operator-configured command does that.
+- Per A22 the operator pre-approves bounded execution of safe
+  scaffold units only. The template inherits that pre-approval; it
+  does not unlock any new authority.
+
+### Fail-closed rules (every rule pinned by tests)
+
+The expansion helper refuses BEFORE any shell invocation when:
+
+- the template contains a token not in
+  `EXTERNAL_COMMAND_ALLOWED_TOKENS` → `template_unknown_token:<name>`;
+- the unit record is missing the field a token references →
+  `template_missing_field:<token>:<field>`;
+- a scalar field is not a `str` → `template_scalar_not_string:<token>`;
+- a scalar value contains `\n` or `\r` →
+  `template_scalar_has_newline:<token>`;
+- a scalar value exceeds 240 chars →
+  `template_scalar_too_long:<token>`;
+- a JSON field is not a list/tuple →
+  `template_json_field_not_list:<token>`;
+- the JSON-serialised value exceeds 8000 chars →
+  `template_json_too_long:<token>`;
+- the expanded string still contains an unmatched `{` or `}` →
+  `template_unmatched_brace` (catches typos like `{unit_id` and
+  uppercase tokens like `{Unit_ID}` and attribute access like
+  `{unit_id.upper}` and indexing like `{expected_files[0]}`);
+- the expanded string is empty / whitespace-only →
+  `template_expanded_empty`.
+
+Each failure surfaces as `ImplementationResult(success=False, reason=…)`
+which the runner maps to the existing closed-vocab stop reason
+`implementation_strategy_failed`.
+
+### What A24 does NOT do
+
+- It does NOT use `eval`, `exec`, `shell=True`, or any dynamic
+  Python evaluation. Pinned by an AST-stripped module-source scan.
+- It does NOT allow arbitrary unit-field access — only the
+  closed-vocab tokens map to specific unit fields.
+- It does NOT allow attribute access (`{foo.bar}`), indexing
+  (`{foo[0]}`), format specs (`{foo:fmt}`), or positional refs
+  (`{0}`) — the regex pattern is `\{[a-z_]+\}` and any leftover
+  brace after substitution fails closed.
+- It does NOT add auto-merge behaviour beyond A21d/A21e.
+- It does NOT add deploy invocation, arbitrary PR merge, or any
+  runtime / trading / paper / shadow / live authority.
+- It does NOT mutate frozen contracts or touch any forbidden path.
+- It does NOT bypass hooks; does NOT use `--admin`; does NOT
+  force-push.
+
+### Backward compatibility
+
+A template with no `{token}` placeholders expands to itself.
+Existing A21c / A21d / A21e tests that pass static commands like
+`"echo test"` continue to pass unchanged.
+
+### Example PowerShell command (post A24 merge)
+
+From `C:\Users\joery.van.rooij\trading-agent` on Windows PowerShell:
+
+```powershell
+python -m reporting.autonomous_pr_runner `
+    --run-continuous `
+    --auto-merge-runner-pr `
+    --implementation-strategy external_command `
+    --implementation-command 'claude --print "Implement Roadmap v6 unit {unit_id} ({phase}: {title}). Touch ONLY the files in {expected_files_json}. NEVER touch any file in {forbidden_files_json}. The required tests are {required_tests_json} and must pass. Definition of done: {definition_of_done_json}. Stop conditions: {stop_conditions_json}. Do not run the conveyor or any other runtime. Do not modify research/research_latest.json or research/strategy_matrix.csv. Do not modify dashboard/dashboard.py."'
+```
+
+Single quotes around the command keep PowerShell from interpolating
+`$` and similar; double quotes inside (around the prompt) keep the
+text on one logical line so `shlex.split` produces one big argv
+slot for the prompt. The conveyor will:
+
+1. read A20e for the next eligible unit;
+2. substitute the closed-vocab tokens against that unit;
+3. run the expanded `claude` command (single PR-sized prompt);
+4. verify the diff is within `expected_files` and never touches a
+   forbidden path;
+5. run required tests + smoke + governance lint;
+6. commit / push / open a runner-originated PR;
+7. watch CI to green;
+8. squash-merge (no `--admin`, no force-push, no hook bypass);
+9. append an evidence-backed merged record to
+   `logs/roadmap_unit_status/runner_merges.json`;
+10. refresh the status artefact and loop to the next eligible unit;
+11. stop on no-eligible-work, safety/technical stop, or operator
+    soft-stop.
+
+### New runner invariants pinned by A24
+
+Every emitted report carries:
+
+- `external_command_strategy_supports_unit_templating = true`
+- `external_command_template_uses_closed_vocab_tokens_only = true`
+- `external_command_template_rejects_unknown_tokens = true`
+- `external_command_template_rejects_attribute_or_index_access = true`
+- `external_command_template_uses_no_eval_or_exec = true`
+- `external_command_template_uses_no_shell_true = true`
+- `external_command_template_bounds_scalar_and_json_token_length = true`
+
 ## 14. A22 strategic mandate integration
 
 [`docs/governance/strategic_roadmap_execution_mandate.md`](strategic_roadmap_execution_mandate.md)

--- a/docs/governance/strategic_roadmap_execution_mandate.md
+++ b/docs/governance/strategic_roadmap_execution_mandate.md
@@ -351,6 +351,21 @@ retry-within-unit loop. **This PR does not implement that
 retry loop** — A22 is the policy + classification work; the
 retry loop is a separate future slice.
 
+### 6.1 How the conveyor implementation backend receives unit context
+
+After A24, the operator's `--implementation-command` is a template
+that the runner expands per iteration with the selected unit's
+closed-vocab metadata (`{unit_id}`, `{phase}`, `{title}`,
+`{risk_class}`, `{operator_gate}`, and the JSON-serialised lists
+`{expected_files_json}`, `{forbidden_files_json}`,
+`{required_tests_json}`, `{definition_of_done_json}`,
+`{stop_conditions_json}`). See
+[`step5_bounded_autonomous_loop.md`](step5_bounded_autonomous_loop.md)
+§A24 for the full token table, fail-closed rules, and example
+command. This is what makes the continuous conveyor practically
+usable across the mandate-eligible queue — without templating, a
+static command had no per-iteration unit context.
+
 ## 7. How the mandate is implemented
 
 ### 7.1 A20c post-process

--- a/reporting/autonomous_pr_runner.py
+++ b/reporting/autonomous_pr_runner.py
@@ -123,6 +123,7 @@ import dataclasses
 import datetime as _dt
 import json
 import os
+import re
 import shlex
 import sys
 import tempfile
@@ -136,7 +137,7 @@ from reporting import roadmap_unit_status as rus
 REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
 
 SCHEMA_VERSION: Final[str] = "1.0"
-MODULE_VERSION: Final[str] = "v3.15.16.A21e+A22"
+MODULE_VERSION: Final[str] = "v3.15.16.A21e+A22+A24"
 REPORT_KIND: Final[str] = "autonomous_pr_runner"
 CONVEYOR_REPORT_KIND: Final[str] = "autonomous_pr_runner_conveyor"
 
@@ -407,6 +408,66 @@ CONVEYOR_STOP_SIGNAL_REL_PATH: Final[str] = (
     "logs/autonomous_pr_runner/STOP_AFTER_CURRENT.signal"
 )
 
+# ---------------------------------------------------------------------------
+# A24 — External-command template constants (closed-vocab)
+# ---------------------------------------------------------------------------
+
+#: Bounded length cap on scalar token values after stringification.
+MAX_EXTERNAL_COMMAND_SCALAR_TOKEN_LEN: Final[int] = 240
+
+#: Bounded length cap on JSON-serialised list-token values.
+MAX_EXTERNAL_COMMAND_JSON_TOKEN_LEN: Final[int] = 8000
+
+#: Closed set of scalar tokens. Each maps to one unit-dict field
+#: that must be a non-empty ``str``. Substituted verbatim into the
+#: operator-supplied template before ``shlex.split``.
+EXTERNAL_COMMAND_SCALAR_TOKENS: Final[tuple[str, ...]] = (
+    "unit_id",
+    "phase",
+    "title",
+    "risk_class",
+    "operator_gate",
+)
+
+#: Closed set of JSON-list tokens. Each maps to one unit-dict field
+#: that must be a ``list`` (or ``tuple``) of strings. The value is
+#: compact-JSON-serialised deterministically before substitution.
+EXTERNAL_COMMAND_JSON_TOKENS: Final[tuple[str, ...]] = (
+    "expected_files_json",
+    "forbidden_files_json",
+    "required_tests_json",
+    "definition_of_done_json",
+    "stop_conditions_json",
+)
+
+#: Union of allowed tokens. Any ``{token}`` in the template that is
+#: not in this set fails closed before invocation.
+EXTERNAL_COMMAND_ALLOWED_TOKENS: Final[tuple[str, ...]] = (
+    EXTERNAL_COMMAND_SCALAR_TOKENS + EXTERNAL_COMMAND_JSON_TOKENS
+)
+
+#: Map every template token to the unit-dict field it sources from.
+#: Tokens are surface names; fields are the A20b unit-record keys.
+_EXTERNAL_COMMAND_TOKEN_TO_UNIT_FIELD: Final[dict[str, str]] = {
+    "unit_id": "id",
+    "phase": "phase",
+    "title": "title",
+    "risk_class": "risk_class",
+    "operator_gate": "operator_gate",
+    "expected_files_json": "expected_files",
+    "forbidden_files_json": "forbidden_files",
+    "required_tests_json": "required_tests",
+    "definition_of_done_json": "definition_of_done",
+    "stop_conditions_json": "stop_conditions",
+}
+
+#: Pattern for the only allowed template syntax: ``{lowercase_token}``.
+#: No attribute access (``{foo.bar}``), no indexing (``{foo[0]}``),
+#: no format specs (``{foo:fmt}``), no positional refs (``{0}``).
+_EXTERNAL_COMMAND_TOKEN_PATTERN: Final[re.Pattern[str]] = re.compile(
+    r"\{([a-z_]+)\}"
+)
+
 #: A21e per-iteration summary schema. Exact and ordered.
 CONVEYOR_ITERATION_SUMMARY_FIELDS: Final[tuple[str, ...]] = (
     "iteration",
@@ -580,6 +641,14 @@ _BASE_RUNNER_INVARIANTS: Final[dict[str, bool]] = {
     "never_accepts_permanently_denied_authority_for_execution": True,
     "never_accepts_high_or_critical_risk": True,
     "elevated_exceptions_remain_operator_driven": True,
+    # A24 external-command templating pins
+    "external_command_strategy_supports_unit_templating": True,
+    "external_command_template_uses_closed_vocab_tokens_only": True,
+    "external_command_template_rejects_unknown_tokens": True,
+    "external_command_template_rejects_attribute_or_index_access": True,
+    "external_command_template_uses_no_eval_or_exec": True,
+    "external_command_template_uses_no_shell_true": True,
+    "external_command_template_bounds_scalar_and_json_token_length": True,
 }
 
 
@@ -1064,6 +1133,143 @@ def _real_shell_runner_factory() -> ShellRunner:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# A24 — Unit-templated external command expansion
+# ---------------------------------------------------------------------------
+
+
+def expand_external_command_template(
+    template: str, unit: dict[str, Any]
+) -> tuple[str | None, str | None]:
+    """Substitute closed-vocab unit-aware tokens into an operator-
+    supplied ``--implementation-command`` template.
+
+    Returns ``(expanded, None)`` on success or
+    ``(None, error_reason)`` on failure. ``error_reason`` is a
+    bounded diagnostic string suitable for the
+    :attr:`ImplementationResult.reason` field; the runner maps every
+    such failure to the closed-vocab stop reason
+    ``implementation_strategy_failed``.
+
+    Allowed template tokens are pinned by
+    :data:`EXTERNAL_COMMAND_ALLOWED_TOKENS`. Scalar tokens
+    (``unit_id``, ``phase``, ``title``, ``risk_class``,
+    ``operator_gate``) substitute the unit-record string value
+    verbatim. JSON tokens (``expected_files_json`` etc.) serialise
+    the corresponding list field as compact deterministic JSON.
+
+    Fail-closed rules:
+
+    * unknown token name (not in
+      :data:`EXTERNAL_COMMAND_ALLOWED_TOKENS`);
+    * unit-dict is missing the field a token references;
+    * scalar field is not a ``str``;
+    * scalar value exceeds
+      :data:`MAX_EXTERNAL_COMMAND_SCALAR_TOKEN_LEN`;
+    * scalar value contains a newline (``\\n`` or ``\\r``);
+    * JSON field is not a list/tuple;
+    * JSON-serialised value exceeds
+      :data:`MAX_EXTERNAL_COMMAND_JSON_TOKEN_LEN`;
+    * expanded string still contains an unmatched ``{`` or ``}``
+      (defence against typos like ``{unit_id``);
+    * expanded string is empty / whitespace-only after substitution.
+
+    This function does NOT call :func:`shlex.split` itself — the
+    caller (:class:`_ExternalCommandStrategy`) does that downstream.
+    The two-step layout keeps templating logic unit-testable in
+    isolation.
+    """
+    if not isinstance(template, str):
+        return None, "template_not_a_string"
+
+    # Step 1: enumerate every {token} occurrence (preserving
+    # duplicates) and reject any unknown token before we substitute.
+    found_tokens = _EXTERNAL_COMMAND_TOKEN_PATTERN.findall(template)
+    allowed = set(EXTERNAL_COMMAND_ALLOWED_TOKENS)
+    for token in found_tokens:
+        if token not in allowed:
+            return None, _bounded_str(
+                f"template_unknown_token:{token}", MAX_DETAIL_LEN
+            )
+
+    # Step 2: build the substitution map from the unit record.
+    substitutions: dict[str, str] = {}
+    scalar_tokens = set(EXTERNAL_COMMAND_SCALAR_TOKENS)
+    json_tokens = set(EXTERNAL_COMMAND_JSON_TOKENS)
+    for token in set(found_tokens):
+        field = _EXTERNAL_COMMAND_TOKEN_TO_UNIT_FIELD[token]
+        if field not in unit:
+            return None, _bounded_str(
+                f"template_missing_field:{token}:{field}",
+                MAX_DETAIL_LEN,
+            )
+        raw_value = unit[field]
+        if token in scalar_tokens:
+            if not isinstance(raw_value, str):
+                return None, _bounded_str(
+                    f"template_scalar_not_string:{token}",
+                    MAX_DETAIL_LEN,
+                )
+            if "\n" in raw_value or "\r" in raw_value:
+                return None, _bounded_str(
+                    f"template_scalar_has_newline:{token}",
+                    MAX_DETAIL_LEN,
+                )
+            if len(raw_value) > MAX_EXTERNAL_COMMAND_SCALAR_TOKEN_LEN:
+                return None, _bounded_str(
+                    f"template_scalar_too_long:{token}",
+                    MAX_DETAIL_LEN,
+                )
+            substitutions[token] = raw_value
+        else:
+            # JSON token — must serialise a list/tuple.
+            if not isinstance(raw_value, (list, tuple)):
+                return None, _bounded_str(
+                    f"template_json_field_not_list:{token}",
+                    MAX_DETAIL_LEN,
+                )
+            # Compact, deterministic. List ordering preserved as
+            # given by the seed.
+            try:
+                serialised = json.dumps(
+                    list(raw_value),
+                    separators=(",", ":"),
+                    sort_keys=False,
+                    ensure_ascii=True,
+                )
+            except (TypeError, ValueError) as exc:
+                return None, _bounded_str(
+                    f"template_json_serialise_error:{token}:{exc}",
+                    MAX_DETAIL_LEN,
+                )
+            if len(serialised) > MAX_EXTERNAL_COMMAND_JSON_TOKEN_LEN:
+                return None, _bounded_str(
+                    f"template_json_too_long:{token}",
+                    MAX_DETAIL_LEN,
+                )
+            substitutions[token] = serialised
+
+    # Step 3: perform the substitution.
+    def _replace_one(match: re.Match[str]) -> str:
+        return substitutions[match.group(1)]
+
+    expanded = _EXTERNAL_COMMAND_TOKEN_PATTERN.sub(
+        _replace_one, template
+    )
+
+    # Step 4: defence-in-depth — any leftover {/} indicates a
+    # malformed template (e.g. ``{unit_id`` with no closing brace,
+    # or ``{Unit_ID}`` that escaped the lower-case regex).
+    if "{" in expanded or "}" in expanded:
+        return None, "template_unmatched_brace"
+
+    # Step 5: defence-in-depth — empty / whitespace-only expansion.
+    if not expanded.strip():
+        return None, "template_expanded_empty"
+
+    return expanded, None
+
+
 class _NoneStrategy:
     """Refuse-to-run strategy. The default."""
 
@@ -1084,13 +1290,22 @@ class _NoneStrategy:
 
 
 class _ExternalCommandStrategy:
-    """Shell out to an operator-supplied command.
+    """Shell out to an operator-supplied command template.
 
-    The command is parsed via :func:`shlex.split`. The command is
-    expected to mutate the filesystem under ``repo_root`` in a way
-    the diff-scope check downstream will validate. The runner does
-    not interpret the command output; it only checks the exit code
-    and the resulting git diff.
+    The template is expanded via
+    :func:`expand_external_command_template` against the selected
+    A20b unit BEFORE :func:`shlex.split`. The closed-vocab token
+    set (see :data:`EXTERNAL_COMMAND_ALLOWED_TOKENS`) lets the
+    operator parametrise one template across every iteration of
+    the continuous conveyor without giving the strategy arbitrary
+    field access. Unknown tokens, missing fields, oversize values,
+    newline-bearing scalars, or non-list JSON fields all fail
+    closed before any shell invocation.
+
+    A template with no ``{token}`` placeholders is still accepted
+    (backward-compat with A21c / A21d static-command tests). The
+    runner does not interpret the command output; it only checks
+    the exit code and the resulting git diff.
     """
 
     name = "external_command"
@@ -1108,12 +1323,27 @@ class _ExternalCommandStrategy:
         repo_root: Path,
         shell: ShellRunner,
     ) -> ImplementationResult:
+        # A24: expand operator-supplied template against the unit
+        # record before shlex.split. Returns (None, reason) on every
+        # fail-closed condition pinned by tests.
+        expanded, expand_err = expand_external_command_template(
+            self._command, unit
+        )
+        if expand_err is not None:
+            return ImplementationResult(
+                success=False,
+                reason=expand_err,
+                files_changed=(),
+            )
+        assert expanded is not None  # noqa: S101 (type-narrow only)
         try:
-            args = shlex.split(self._command)
+            args = shlex.split(expanded)
         except ValueError as exc:
             return ImplementationResult(
                 success=False,
-                reason=f"command_parse_error:{exc}",
+                reason=_bounded_str(
+                    f"command_parse_error:{exc}", MAX_DETAIL_LEN
+                ),
                 files_changed=(),
             )
         if not args:

--- a/tests/unit/test_autonomous_pr_runner.py
+++ b/tests/unit/test_autonomous_pr_runner.py
@@ -3846,3 +3846,436 @@ def test_conveyor_does_not_use_real_shell_in_unit_tests() -> None:
             "every apr.run_continuous call must pass "
             "implementation_strategy="
         )
+
+
+# ===========================================================================
+# A24 — Unit-templated external-command tests
+# ===========================================================================
+
+
+def _a24_unit(**overrides: Any) -> dict[str, Any]:
+    """Synthetic A20b-shape unit record used by the A24 templating
+    tests. Includes every field the closed-vocab tokens touch."""
+    base: dict[str, Any] = {
+        "id": "u_v3_15_17_sampling_plan_reporter_001",
+        "roadmap_task_id": "phase_v3_15_17",
+        "title": "Sampling plan reporter (read-only)",
+        "phase": "v3.15.17",
+        "unit_kind": "reporting_module",
+        "target_layer": "reporting",
+        "source_requirement_ids": (),
+        "expected_files": [
+            "reporting/sampling_plan.py",
+            "tests/unit/test_sampling_plan.py",
+        ],
+        "forbidden_files": [
+            ".claude/**",
+            "dashboard/dashboard.py",
+            "broker/**",
+        ],
+        "forbidden_surface_reasons": [],
+        "required_tests": ["tests/unit/test_sampling_plan.py"],
+        "definition_of_done": [
+            "module imports cleanly",
+            "atomic write only under logs/sampling_plan/",
+        ],
+        "stop_conditions": [
+            "any LLM-based ranker introduced -> STOP",
+            "any external API call -> STOP",
+        ],
+        "prerequisites": [],
+        "risk_class": "LOW",
+        "authority_hint": "AUTO_ALLOWED_CANDIDATE",
+        "operator_gate": "none",
+        "status": "not_started",
+    }
+    base.update(overrides)
+    return base
+
+
+# ---- closed-vocab pins ----------------------------------------------------
+
+
+def test_external_command_scalar_tokens_pinned_exact() -> None:
+    assert apr.EXTERNAL_COMMAND_SCALAR_TOKENS == (
+        "unit_id",
+        "phase",
+        "title",
+        "risk_class",
+        "operator_gate",
+    )
+
+
+def test_external_command_json_tokens_pinned_exact() -> None:
+    assert apr.EXTERNAL_COMMAND_JSON_TOKENS == (
+        "expected_files_json",
+        "forbidden_files_json",
+        "required_tests_json",
+        "definition_of_done_json",
+        "stop_conditions_json",
+    )
+
+
+def test_external_command_allowed_tokens_is_union() -> None:
+    assert set(apr.EXTERNAL_COMMAND_ALLOWED_TOKENS) == (
+        set(apr.EXTERNAL_COMMAND_SCALAR_TOKENS)
+        | set(apr.EXTERNAL_COMMAND_JSON_TOKENS)
+    )
+    # No duplicates.
+    assert len(apr.EXTERNAL_COMMAND_ALLOWED_TOKENS) == len(
+        set(apr.EXTERNAL_COMMAND_ALLOWED_TOKENS)
+    )
+
+
+def test_external_command_token_pattern_only_lowercase_underscore() -> None:
+    """Token regex must NOT match attribute access ``{foo.bar}``,
+    indexing ``{foo[0]}``, format specs ``{foo:fmt}``, or
+    upper-case tokens."""
+    pat = apr._EXTERNAL_COMMAND_TOKEN_PATTERN
+    assert pat.findall("{unit_id}") == ["unit_id"]
+    assert pat.findall("{foo.bar}") == []
+    assert pat.findall("{foo[0]}") == []
+    assert pat.findall("{foo:fmt}") == []
+    assert pat.findall("{Unit_ID}") == []
+    assert pat.findall("{0}") == []
+
+
+# ---- scalar substitution --------------------------------------------------
+
+
+def test_expand_substitutes_unit_id() -> None:
+    out, err = apr.expand_external_command_template(
+        "claude {unit_id}", _a24_unit()
+    )
+    assert err is None
+    assert out == "claude u_v3_15_17_sampling_plan_reporter_001"
+
+
+def test_expand_substitutes_every_scalar_token() -> None:
+    template = (
+        "u={unit_id} p={phase} t={title} "
+        "r={risk_class} g={operator_gate}"
+    )
+    out, err = apr.expand_external_command_template(template, _a24_unit())
+    assert err is None
+    assert out == (
+        "u=u_v3_15_17_sampling_plan_reporter_001 "
+        "p=v3.15.17 t=Sampling plan reporter (read-only) "
+        "r=LOW g=none"
+    )
+
+
+def test_expand_substitutes_repeated_token() -> None:
+    """The same token appearing twice in the template substitutes
+    consistently."""
+    out, err = apr.expand_external_command_template(
+        "first={unit_id} second={unit_id}", _a24_unit()
+    )
+    assert err is None
+    assert (
+        out
+        == "first=u_v3_15_17_sampling_plan_reporter_001 "
+        "second=u_v3_15_17_sampling_plan_reporter_001"
+    )
+
+
+# ---- JSON substitution ----------------------------------------------------
+
+
+def test_expand_substitutes_expected_files_as_compact_json() -> None:
+    out, err = apr.expand_external_command_template(
+        "claude --files {expected_files_json}", _a24_unit()
+    )
+    assert err is None
+    assert out == (
+        'claude --files ["reporting/sampling_plan.py",'
+        '"tests/unit/test_sampling_plan.py"]'
+    )
+
+
+def test_expand_substitutes_every_json_token_deterministically() -> None:
+    template = (
+        "ef={expected_files_json} ff={forbidden_files_json} "
+        "rt={required_tests_json} dod={definition_of_done_json} "
+        "sc={stop_conditions_json}"
+    )
+    out, err = apr.expand_external_command_template(template, _a24_unit())
+    assert err is None
+    # Compact JSON, list ordering preserved as-given by the seed.
+    assert (
+        '"reporting/sampling_plan.py","tests/unit/test_sampling_plan.py"'
+        in out
+    )
+    assert '".claude/**","dashboard/dashboard.py","broker/**"' in out
+    assert '"tests/unit/test_sampling_plan.py"' in out
+
+
+def test_expand_repeats_json_token_deterministically() -> None:
+    """Two expansions against the same unit produce byte-identical
+    output."""
+    template = "{expected_files_json} {expected_files_json}"
+    a, err_a = apr.expand_external_command_template(template, _a24_unit())
+    b, err_b = apr.expand_external_command_template(template, _a24_unit())
+    assert err_a is None and err_b is None
+    assert a == b
+
+
+# ---- fail-closed: unknown token / malformed --------------------------------
+
+
+def test_expand_rejects_unknown_token() -> None:
+    out, err = apr.expand_external_command_template(
+        "claude {not_a_real_token}", _a24_unit()
+    )
+    assert out is None
+    assert err is not None
+    assert err.startswith("template_unknown_token:not_a_real_token")
+
+
+def test_expand_rejects_attribute_access_via_unknown_token() -> None:
+    """``{foo.bar}`` is NOT matched by the token pattern at all (no
+    dots allowed), so leftover ``{`` / ``}`` triggers
+    ``template_unmatched_brace``."""
+    out, err = apr.expand_external_command_template(
+        "claude {unit_id.upper}", _a24_unit()
+    )
+    assert out is None
+    assert err == "template_unmatched_brace"
+
+
+def test_expand_rejects_indexing_via_unmatched_brace() -> None:
+    out, err = apr.expand_external_command_template(
+        "claude {expected_files[0]}", _a24_unit()
+    )
+    assert out is None
+    assert err == "template_unmatched_brace"
+
+
+def test_expand_rejects_unmatched_open_brace() -> None:
+    out, err = apr.expand_external_command_template(
+        "claude {unit_id", _a24_unit()
+    )
+    assert out is None
+    assert err == "template_unmatched_brace"
+
+
+def test_expand_rejects_uppercase_token_via_unmatched_brace() -> None:
+    out, err = apr.expand_external_command_template(
+        "claude {Unit_ID}", _a24_unit()
+    )
+    assert out is None
+    assert err == "template_unmatched_brace"
+
+
+# ---- fail-closed: scalar checks -------------------------------------------
+
+
+def test_expand_rejects_missing_unit_field() -> None:
+    unit = _a24_unit()
+    del unit["id"]
+    out, err = apr.expand_external_command_template(
+        "claude {unit_id}", unit
+    )
+    assert out is None
+    assert err is not None
+    assert err.startswith("template_missing_field:unit_id:id")
+
+
+def test_expand_rejects_scalar_not_a_string() -> None:
+    unit = _a24_unit(phase=12345)  # not a string
+    out, err = apr.expand_external_command_template(
+        "claude {phase}", unit
+    )
+    assert out is None
+    assert err == "template_scalar_not_string:phase"
+
+
+def test_expand_rejects_scalar_with_newline() -> None:
+    unit = _a24_unit(title="hi\nthere")
+    out, err = apr.expand_external_command_template(
+        "claude {title}", unit
+    )
+    assert out is None
+    assert err == "template_scalar_has_newline:title"
+
+
+def test_expand_rejects_scalar_with_carriage_return() -> None:
+    unit = _a24_unit(title="hi\r\nthere")
+    out, err = apr.expand_external_command_template(
+        "claude {title}", unit
+    )
+    assert out is None
+    assert err == "template_scalar_has_newline:title"
+
+
+def test_expand_rejects_overly_long_scalar() -> None:
+    unit = _a24_unit(title="x" * (apr.MAX_EXTERNAL_COMMAND_SCALAR_TOKEN_LEN + 1))
+    out, err = apr.expand_external_command_template(
+        "claude {title}", unit
+    )
+    assert out is None
+    assert err == "template_scalar_too_long:title"
+
+
+# ---- fail-closed: JSON checks ---------------------------------------------
+
+
+def test_expand_rejects_json_field_not_a_list() -> None:
+    unit = _a24_unit(expected_files="not-a-list")
+    out, err = apr.expand_external_command_template(
+        "claude {expected_files_json}", unit
+    )
+    assert out is None
+    assert err == "template_json_field_not_list:expected_files_json"
+
+
+def test_expand_rejects_overly_long_json_value() -> None:
+    # Build a list whose JSON serialisation blows past the cap.
+    big = ["x" * 100] * 200  # ~ 20k bytes after JSON encoding
+    unit = _a24_unit(expected_files=big)
+    out, err = apr.expand_external_command_template(
+        "claude {expected_files_json}", unit
+    )
+    assert out is None
+    assert err == "template_json_too_long:expected_files_json"
+
+
+def test_expand_accepts_tuple_as_json_list() -> None:
+    """Seed records sometimes use tuples; both list and tuple are
+    valid JSON list inputs."""
+    unit = _a24_unit(expected_files=("a.py", "b.py"))
+    out, err = apr.expand_external_command_template(
+        "claude {expected_files_json}", unit
+    )
+    assert err is None
+    assert out == 'claude ["a.py","b.py"]'
+
+
+# ---- backward compat ------------------------------------------------------
+
+
+def test_expand_passes_through_token_free_template_unchanged() -> None:
+    """A template with no ``{token}`` placeholders expands to itself
+    (backward-compat with A21c / A21d static-command behaviour)."""
+    out, err = apr.expand_external_command_template(
+        "echo hello world", _a24_unit()
+    )
+    assert err is None
+    assert out == "echo hello world"
+
+
+# ---- integration: strategy uses expanded command --------------------------
+
+
+def test_external_command_strategy_invokes_expanded_command() -> None:
+    """Fake shell receives the EXPANDED args, not the raw template."""
+    shell = _FakeShell()
+    shell.queue(("claude",), exit_code=0)
+    strategy = apr._ExternalCommandStrategy(
+        command='claude --unit-id {unit_id} --files {expected_files_json}',
+        timeout=apr.DEFAULT_COMMAND_TIMEOUT_SECONDS,
+    )
+    res = strategy.invoke(_a24_unit(), repo_root=Path("."), shell=shell)
+    assert res.success is True
+    assert res.reason == "external_command_ok"
+    assert len(shell.calls) == 1
+    call_args = shell.calls[0][0]
+    assert call_args[0] == "claude"
+    # The expanded unit_id and JSON list are both present somewhere
+    # in the post-shlex.split argv:
+    joined = " ".join(call_args)
+    assert "u_v3_15_17_sampling_plan_reporter_001" in joined
+    assert "reporting/sampling_plan.py" in joined
+
+
+def test_external_command_strategy_propagates_template_error() -> None:
+    """A template with an unknown token surfaces as a strategy
+    failure with the templating error reason."""
+    shell = _FakeShell()
+    strategy = apr._ExternalCommandStrategy(
+        command="claude --bad {nonexistent_token}",
+        timeout=apr.DEFAULT_COMMAND_TIMEOUT_SECONDS,
+    )
+    res = strategy.invoke(_a24_unit(), repo_root=Path("."), shell=shell)
+    assert res.success is False
+    assert res.reason.startswith("template_unknown_token:")
+    assert shell.calls == []  # no shell invocation
+
+
+def test_external_command_strategy_runs_different_commands_per_unit() -> None:
+    """The same template against two different unit IDs produces two
+    distinct expanded commands; tests the per-iteration context flow
+    A24 was created to enable."""
+    shell = _FakeShell()
+    shell.queue(("claude",), exit_code=0)
+    shell.queue(("claude",), exit_code=0)
+    strategy = apr._ExternalCommandStrategy(
+        command="claude {unit_id}",
+        timeout=apr.DEFAULT_COMMAND_TIMEOUT_SECONDS,
+    )
+    res1 = strategy.invoke(
+        _a24_unit(id="u_alpha"), repo_root=Path("."), shell=shell
+    )
+    res2 = strategy.invoke(
+        _a24_unit(id="u_beta"), repo_root=Path("."), shell=shell
+    )
+    assert res1.success and res2.success
+    assert len(shell.calls) == 2
+    assert "u_alpha" in " ".join(shell.calls[0][0])
+    assert "u_beta" in " ".join(shell.calls[1][0])
+    # Backward-compat sanity: the two iterations produced
+    # DIFFERENT shell args, even though the template was identical.
+    assert shell.calls[0][0] != shell.calls[1][0]
+
+
+# ---- runner_invariants pins ------------------------------------------------
+
+
+def test_runner_invariants_pin_a24_templating(tmp_path: Path) -> None:
+    _write_minimal_upstreams(tmp_path)
+    report = apr.status(repo_root=tmp_path, generated_at_utc=_FROZEN_UTC)
+    inv = report["runner_invariants"]
+    assert inv["external_command_strategy_supports_unit_templating"] is True
+    assert (
+        inv["external_command_template_uses_closed_vocab_tokens_only"]
+        is True
+    )
+    assert inv["external_command_template_rejects_unknown_tokens"] is True
+    assert (
+        inv["external_command_template_rejects_attribute_or_index_access"]
+        is True
+    )
+    assert inv["external_command_template_uses_no_eval_or_exec"] is True
+    assert inv["external_command_template_uses_no_shell_true"] is True
+    assert (
+        inv["external_command_template_bounds_scalar_and_json_token_length"]
+        is True
+    )
+
+
+# ---- module-source scan: no eval / exec / shell=True in A24 helper -------
+
+
+def test_a24_template_expansion_helper_uses_no_dynamic_eval() -> None:
+    """The A24 expansion helper must not use eval, exec, or
+    shell=True anywhere in the module source. Pinned by an AST-
+    stripped scan."""
+    code = _code_lines()
+    assert "eval(" not in code
+    assert "exec(" not in code
+    assert "shell=True" not in code
+    assert "os.system(" not in code
+
+
+def test_real_shell_runner_factory_still_lazy_after_a24() -> None:
+    """Importing reporting.autonomous_pr_runner must remain side-
+    effect free even after A24's regex/json additions. Subprocess
+    is still imported lazily inside the factory."""
+    top = _module_top_level_imports()
+    for mod in top:
+        assert not mod.startswith("subprocess"), mod
+    # ``re`` and ``json`` ARE imported at module level (stdlib only,
+    # no side effects); pinning them here so future PRs don't try to
+    # claim they were forbidden.
+    assert "re" in top
+    assert "json" in top


### PR DESCRIPTION
## Summary

A24 extends `_ExternalCommandStrategy` so the operator-supplied `--implementation-command` is a **template** that the runner expands against the selected A20b unit before `shlex.split`. Without this, the A21e continuous conveyor could not practically process multiple units across iterations — a static command had no per-iteration context, would either do nothing on iteration 1 (-> `diff_empty` stop) or produce the same changes on iteration 2 (-> `diff_outside_expected_files` stop because iteration 2's `expected_files` differ from iteration 1's).

- **Phase:** A24 — unit-templated external implementation command for the continuous conveyor.
- **Authority class on this PR:** `AUTO_ALLOWED` (LOW risk, `operator_gate = none`).
- **No new authority granted.** Tokens read unit fields only; the operator's command is still the only thing invoking external tooling; the safety gates already bound which units the conveyor processes.
- **Unknown tokens fail closed.** Closed-vocab `EXTERNAL_COMMAND_ALLOWED_TOKENS` enforced at expansion time.
- **No `eval`, no `exec`, no `shell=True`** anywhere in the new code (asserted by an AST-stripped module-source scan).
- **No runtime / trading / paper / shadow / live authority granted.** Step 5 broad implementation remains BLOCKED; A22 mandate / A21d auto-merge contract / A21e conveyor invariants all unchanged.

## Exact files changed (5 files, +841 / -11)

- `reporting/autonomous_pr_runner.py` (modified, +250 / -8): adds the closed-vocab token allowlists, the regex pattern (lowercase + underscore only, no attribute access / indexing / format specs / positional refs / uppercase), the `expand_external_command_template` helper with nine fail-closed branches, the call site inside `_ExternalCommandStrategy.invoke`, seven new `runner_invariants` pins, and `re` as a stdlib module-level import. `MODULE_VERSION` bumped to `v3.15.16.A21e+A22+A24`. `subprocess` remains lazy inside the real shell-runner factory.
- `tests/unit/test_autonomous_pr_runner.py` (modified, +433): 30 new A24 tests (225 total runner tests, up from 195).
- `docs/governance/step5_bounded_autonomous_loop.md` (modified, +149): full A24 section with closed-vocab token table, fail-closed rules, example PowerShell command, new invariants.
- `docs/governance/strategic_roadmap_execution_mandate.md` (modified, +15): §6.1 documents how the conveyor backend receives unit context after A24.
- `docs/governance/roadmap_task_catalog.md` (modified, +5): header + pointer block updated.

## Closed-vocab template tokens

| Token | Source field | Type | Cap |
|---|---|---|---|
| `{unit_id}` | `id` | str | 240 |
| `{phase}` | `phase` | str | 240 |
| `{title}` | `title` | str | 240 |
| `{risk_class}` | `risk_class` | str | 240 |
| `{operator_gate}` | `operator_gate` | str | 240 |
| `{expected_files_json}` | `expected_files` | list[str] → compact JSON | 8000 |
| `{forbidden_files_json}` | `forbidden_files` | list[str] → compact JSON | 8000 |
| `{required_tests_json}` | `required_tests` | list[str] → compact JSON | 8000 |
| `{definition_of_done_json}` | `definition_of_done` | list[str] → compact JSON | 8000 |
| `{stop_conditions_json}` | `stop_conditions` | list[str] → compact JSON | 8000 |

## Fail-closed branches (every one pinned by tests)

`template_unknown_token:<name>`, `template_missing_field:<token>:<field>`, `template_scalar_not_string:<token>`, `template_scalar_has_newline:<token>`, `template_scalar_too_long:<token>`, `template_json_field_not_list:<token>`, `template_json_too_long:<token>`, `template_unmatched_brace`, `template_expanded_empty`. Each surfaces as `ImplementationResult(success=False, reason=…)` which the runner maps to the existing closed-vocab stop reason `implementation_strategy_failed`.

## Validation commands and results

- `python -m pytest tests/unit/test_autonomous_pr_runner.py -v` — **225 passed** (195 pre-existing + 30 new A24 tests).
- `python -m pytest tests/unit/test_roadmap_next_unit.py -v` — passed (unchanged behavior).
- `python -m pytest tests/unit/test_roadmap_unit_status.py -v` — passed (unchanged behavior).
- Combined runner + selector + ledger run: **394 passed**.
- `python -m pytest tests/smoke -v` — **18 passed**.
- `python -m pytest tests/regression/test_public_output_contract.py tests/regression/test_v12_contracts_preserved.py tests/regression/test_authority_invariants.py -v` — **16 passed**.
- `python scripts/governance_lint.py` — `Governance lint OK (16 agents, 5 workflows checked).`

## Frozen-contract verdict

PASS. No mutation of `research/research_latest.json`, no mutation of `research/strategy_matrix.csv`, no mutation of any frozen schema under `artifacts/`. `regression-fast (determinism pins)` green.

## Forbidden-path verdict

PASS. Diff touches only the 5 spec-allowed files. None of the always-forbidden paths changed.

## Statement of constraints honoured

- **This adds unit-templated external implementation commands.** Operator writes one template; the runner expands it per iteration with the selected unit's closed-vocab metadata.
- **Unknown tokens fail closed** at expansion time, before any shell invocation.
- **No `eval`, no `exec`, no `shell=True`** anywhere in the module (AST-stripped source scan).
- **No attribute access, no indexing, no format specs, no positional refs, no uppercase tokens** — pinned by the regex (`\{[a-z_]+\}`) plus a defence-in-depth leftover-brace check.
- **No runtime / trading / paper / shadow / live authority granted.** Step 5 broad implementation BLOCKED. Level 6 permanently disabled. N5b Phase 4 permanently denied for ADE.
- **Frozen contracts unchanged. No --admin, no force-push, no hook bypass, no deploy invocation.**

## Test plan

- [ ] CI completes green on this branch (lint, secret-scan, typecheck, unit, regression-fast, hook-tests, frontend, governance-lint).
- [ ] No frozen-contract regression test newly fails.
- [ ] No governance-lint regression.
- [ ] No new agent-allowlist surfaces appear.

## Example final conveyor command for Windows PowerShell (after merge)

From `C:\Users\joery.van.rooij\trading-agent` on Windows PowerShell:

```powershell
Set-Location C:\Users\joery.van.rooij\trading-agent
git checkout main
git pull --ff-only
python -m reporting.roadmap_task_units
python -m reporting.roadmap_unit_authority
python -m reporting.roadmap_unit_status
python -m reporting.autonomous_pr_runner `
    --run-continuous `
    --auto-merge-runner-pr `
    --implementation-strategy external_command `
    --implementation-command 'claude --print "Implement Roadmap v6 unit {unit_id} ({phase}: {title}). Touch ONLY the files in {expected_files_json}. NEVER touch any file in {forbidden_files_json}. The required tests are {required_tests_json} and must pass. Definition of done: {definition_of_done_json}. Stop conditions: {stop_conditions_json}. Do not run the conveyor or any other runtime. Do not modify research/research_latest.json or research/strategy_matrix.csv. Do not modify dashboard/dashboard.py."'
```

The single quotes around the command keep PowerShell from interpolating `$` and similar. The double quotes inside (around the prompt) ensure the entire prompt is one logical argv slot post-`shlex.split`. The conveyor will then:

1. read A20e for the next eligible unit;
2. substitute the closed-vocab tokens against that unit;
3. run the expanded `claude` command (one PR-sized prompt);
4. verify the diff is within `expected_files` and never touches a forbidden path;
5. run required tests + smoke + governance lint;
6. commit / push / open a runner-originated PR;
7. watch CI to green;
8. squash-merge (no `--admin`, no force-push, no hook bypass);
9. append an evidence-backed merged record to `logs/roadmap_unit_status/runner_merges.json`;
10. refresh the status artefact and loop to the next eligible unit;
11. stop on no-eligible-work, safety / technical stop, or operator soft-stop.

## Next recommended operator action

1. **Merge A24** via the standard squash-merge protocol (no `--admin`).
2. **Start the continuous conveyor locally** with the PowerShell command above (after substituting the real `claude` command line / API key configuration appropriate for the operator's environment).
3. The conveyor will start with `u_v3_15_17_sampling_plan_reporter_001` (the current top selector pick), then work through the dependency graph in deterministic phase order. Soft-stop at any time via `--stop-after-current` flag or the `logs/autonomous_pr_runner/STOP_AFTER_CURRENT.signal` sentinel file.