### PR TITLE
governance-bootstrap: accept ADR-019 hypothesis discovery doctrine

### DIFF
--- a/docs/adr/ADR-019-hypothesis-discovery-doctrine.md
+++ b/docs/adr/ADR-019-hypothesis-discovery-doctrine.md
@@ -1,6 +1,6 @@
 # ADR-019 — Hypothesis Discovery doctrine and scoring spec
 
-Status: **Draft** — 2026-05-21
+Status: **Accepted** — 2026-05-21
 Predecessor: ADR-014 (truth authority settlement), ADR-018
 (roadmap execution reset).
 Gates: v3.15.19 minimal Hypothesis Discovery slice.
@@ -40,7 +40,7 @@ promotions. A seed is a structured proposal that names:
 A seed has no execution authority, no promotion authority, and no
 capital authority. Seeds become candidates only via the funnel
 policy
-([`research/campaign_funnel_policy.py`](../../../research/campaign_funnel_policy.py)
+([`research/campaign_funnel_policy.py`](../../research/campaign_funnel_policy.py)
 and ADR-014 §A) and the existing campaign mechanics, which this
 ADR does **not** modify.
 
@@ -67,11 +67,11 @@ The score, when implemented, must satisfy all of the following.
    capital-allocation surface.
 5. **Inspectable.** The score's inputs and intermediate transforms
    are emitted to a scoring-reason record
-   ([`research_quality_sprint_plan.md`](../../governance/research_quality_sprint_plan.md)
+   ([`research_quality_sprint_plan.md`](../governance/research_quality_sprint_plan.md)
    §10).
 6. **Falsifiable on noise.** Under the null-pipeline integration
    test
-   ([`research_quality_sprint_plan.md`](../../governance/research_quality_sprint_plan.md)
+   ([`research_quality_sprint_plan.md`](../governance/research_quality_sprint_plan.md)
    §8), the score distribution on surrogate data must be
    statistically indistinguishable from the score distribution on
    random shuffles of the surrogate. The test pins this as a
@@ -85,18 +85,18 @@ The score, when implemented, must satisfy all of the following.
 ### What Discovery may consume
 
 Only the **three active diagnostics** declared in
-[`roadmap_scope_status.md`](../../governance/roadmap_scope_status.md)
+[`roadmap_scope_status.md`](../governance/roadmap_scope_status.md)
 §5.1: null-model, tail asymmetry, entropy structure. Diagnostics
 beyond those three are deferred and must not feed Discovery until
 they pass the promote-or-retire rule.
 
 Discovery may also consume:
 
-- the existing preset universe ([`research/presets.py`](../../../research/presets.py));
+- the existing preset universe ([`research/presets.py`](../../research/presets.py));
 - the existing strategy hypothesis catalog
-  ([`research/strategy_hypothesis_catalog.py`](../../../research/strategy_hypothesis_catalog.py));
+  ([`research/strategy_hypothesis_catalog.py`](../../research/strategy_hypothesis_catalog.py));
 - the multiplicity ledger
-  ([`research_quality_sprint_plan.md`](../../governance/research_quality_sprint_plan.md)
+  ([`research_quality_sprint_plan.md`](../governance/research_quality_sprint_plan.md)
   §6);
 - the diagnostic utility ledger (planned as part of the v3.15.19
   slice).
@@ -177,16 +177,19 @@ Negative / accepted:
 
 ## Promotion
 
-This ADR is in `_drafts/`. Promotion to
-`docs/adr/ADR-019-hypothesis-discovery-doctrine.md` is a separate
-operator-driven governance-bootstrap PR before the v3.15.19
-implementation PR.
+This ADR was promoted from `docs/adr/_drafts/` to
+`docs/adr/ADR-019-hypothesis-discovery-doctrine.md` on
+**2026-05-21** via the operator-driven governance-bootstrap PR
+that gates the v3.15.19 minimal Hypothesis Discovery slice.
+Status was flipped from **Draft** to **Accepted** at the same
+time; the doctrine and scoring-axiom content above is unchanged
+from the draft.
 
 ## Cross-references
 
-- [`docs/governance/roadmap_scope_status.md`](../../governance/roadmap_scope_status.md)
-- [`docs/governance/research_quality_sprint_plan.md`](../../governance/research_quality_sprint_plan.md)
-- [`docs/governance/research_quality_kpis.md`](../../governance/research_quality_kpis.md)
-- [`docs/adr/_drafts/ADR-018-roadmap-execution-reset.md`](ADR-018-roadmap-execution-reset.md)
-- [`docs/adr/_drafts/ADR-020-paper-shadow-live-separation.md`](ADR-020-paper-shadow-live-separation.md)
-- [`docs/adr/ADR-014-truth-authority-settlement.md`](../ADR-014-truth-authority-settlement.md)
+- [`docs/governance/roadmap_scope_status.md`](../governance/roadmap_scope_status.md)
+- [`docs/governance/research_quality_sprint_plan.md`](../governance/research_quality_sprint_plan.md)
+- [`docs/governance/research_quality_kpis.md`](../governance/research_quality_kpis.md)
+- [`docs/adr/_drafts/ADR-018-roadmap-execution-reset.md`](_drafts/ADR-018-roadmap-execution-reset.md)
+- [`docs/adr/_drafts/ADR-020-paper-shadow-live-separation.md`](_drafts/ADR-020-paper-shadow-live-separation.md)
+- [`docs/adr/ADR-014-truth-authority-settlement.md`](ADR-014-truth-authority-settlement.md)

--- a/docs/adr/_drafts/ADR-018-roadmap-execution-reset.md
+++ b/docs/adr/_drafts/ADR-018-roadmap-execution-reset.md
@@ -173,7 +173,7 @@ G8).
 - [`docs/governance/roadmap_scope_status.md`](../../governance/roadmap_scope_status.md)
 - [`docs/governance/research_quality_sprint_plan.md`](../../governance/research_quality_sprint_plan.md)
 - [`docs/governance/research_quality_kpis.md`](../../governance/research_quality_kpis.md)
-- [`docs/adr/_drafts/ADR-019-hypothesis-discovery-doctrine.md`](ADR-019-hypothesis-discovery-doctrine.md)
+- [`docs/adr/ADR-019-hypothesis-discovery-doctrine.md`](../ADR-019-hypothesis-discovery-doctrine.md)
 - [`docs/adr/_drafts/ADR-020-paper-shadow-live-separation.md`](ADR-020-paper-shadow-live-separation.md)
 - [`docs/adr/ADR-014-truth-authority-settlement.md`](../ADR-014-truth-authority-settlement.md)
 - [`docs/adr/ADR-015-claude-agent-governance.md`](../ADR-015-claude-agent-governance.md)

--- a/docs/adr/_drafts/ADR-020-paper-shadow-live-separation.md
+++ b/docs/adr/_drafts/ADR-020-paper-shadow-live-separation.md
@@ -170,7 +170,7 @@ future ADRs not authored here.
 - [`docs/governance/strategic_roadmap_execution_mandate.md`](../../governance/strategic_roadmap_execution_mandate.md)
 - [`docs/governance/ade_development_lane_doctrine.md`](../../governance/ade_development_lane_doctrine.md)
 - [`docs/adr/_drafts/ADR-018-roadmap-execution-reset.md`](ADR-018-roadmap-execution-reset.md)
-- [`docs/adr/_drafts/ADR-019-hypothesis-discovery-doctrine.md`](ADR-019-hypothesis-discovery-doctrine.md)
+- [`docs/adr/ADR-019-hypothesis-discovery-doctrine.md`](../ADR-019-hypothesis-discovery-doctrine.md)
 - [`docs/adr/ADR-014-truth-authority-settlement.md`](../ADR-014-truth-authority-settlement.md)
 - [`docs/adr/ADR-015-claude-agent-governance.md`](../ADR-015-claude-agent-governance.md)
 - [`docs/adr/ADR-017-step5-autonomous-implementation-loop.md`](../ADR-017-step5-autonomous-implementation-loop.md)

--- a/docs/governance/multiplicity_ledger.md
+++ b/docs/governance/multiplicity_ledger.md
@@ -16,7 +16,7 @@
 > §6,
 > [`research_quality_kpis.md`](research_quality_kpis.md),
 > [`docs/adr/_drafts/ADR-018-roadmap-execution-reset.md`](../adr/_drafts/ADR-018-roadmap-execution-reset.md),
-> [`docs/adr/_drafts/ADR-019-hypothesis-discovery-doctrine.md`](../adr/_drafts/ADR-019-hypothesis-discovery-doctrine.md).
+> [`docs/adr/ADR-019-hypothesis-discovery-doctrine.md`](../adr/ADR-019-hypothesis-discovery-doctrine.md).
 
 ## 1. Purpose
 

--- a/docs/governance/reason_records.md
+++ b/docs/governance/reason_records.md
@@ -17,7 +17,7 @@
 > §10,
 > [`multiplicity_ledger.md`](multiplicity_ledger.md),
 > [`paper_readiness_checklist.md`](paper_readiness_checklist.md),
-> [`docs/adr/_drafts/ADR-019-hypothesis-discovery-doctrine.md`](../adr/_drafts/ADR-019-hypothesis-discovery-doctrine.md).
+> [`docs/adr/ADR-019-hypothesis-discovery-doctrine.md`](../adr/ADR-019-hypothesis-discovery-doctrine.md).
 
 ## 1. Purpose
 

--- a/docs/governance/research_quality_sprint_plan.md
+++ b/docs/governance/research_quality_sprint_plan.md
@@ -10,7 +10,7 @@
 > **Cross-refs:**
 > [`roadmap_scope_status.md`](roadmap_scope_status.md),
 > [`docs/adr/_drafts/ADR-018-roadmap-execution-reset.md`](../adr/_drafts/ADR-018-roadmap-execution-reset.md),
-> [`docs/adr/_drafts/ADR-019-hypothesis-discovery-doctrine.md`](../adr/_drafts/ADR-019-hypothesis-discovery-doctrine.md),
+> [`docs/adr/ADR-019-hypothesis-discovery-doctrine.md`](../adr/ADR-019-hypothesis-discovery-doctrine.md),
 > [`docs/adr/_drafts/ADR-020-paper-shadow-live-separation.md`](../adr/_drafts/ADR-020-paper-shadow-live-separation.md),
 > [`research_quality_kpis.md`](research_quality_kpis.md).
 
@@ -39,7 +39,8 @@ specs merge.
 
 ### S2. ADR-019 — Hypothesis Discovery doctrine and scoring spec
 
-- File: [`docs/adr/_drafts/ADR-019-hypothesis-discovery-doctrine.md`](../adr/_drafts/ADR-019-hypothesis-discovery-doctrine.md).
+- File: [`docs/adr/ADR-019-hypothesis-discovery-doctrine.md`](../adr/ADR-019-hypothesis-discovery-doctrine.md)
+  (promoted from `_drafts/` and accepted on 2026-05-21).
 - Specifies `opportunity_probability_score` axioms (deterministic,
   bounded, monotone in stated inputs, independent of execution-side
   state).

--- a/docs/governance/roadmap_scope_status.md
+++ b/docs/governance/roadmap_scope_status.md
@@ -309,7 +309,7 @@ operator-approved follow-up that will update those pins.
 
 - [`docs/adr/_drafts/ADR-018-roadmap-execution-reset.md`](../adr/_drafts/ADR-018-roadmap-execution-reset.md)
   — formal ADR for this reset.
-- [`docs/adr/_drafts/ADR-019-hypothesis-discovery-doctrine.md`](../adr/_drafts/ADR-019-hypothesis-discovery-doctrine.md)
+- [`docs/adr/ADR-019-hypothesis-discovery-doctrine.md`](../adr/ADR-019-hypothesis-discovery-doctrine.md)
   — gates v3.15.19.
 - [`docs/adr/_drafts/ADR-020-paper-shadow-live-separation.md`](../adr/_drafts/ADR-020-paper-shadow-live-separation.md)
   — makes the implicit separation a doctrinal invariant.

--- a/docs/governance/sprint_completion_2026_05_21.md
+++ b/docs/governance/sprint_completion_2026_05_21.md
@@ -27,7 +27,7 @@ This record covers all eleven.
 | ID | Item | Delivered by | Path |
 |---|---|---|---|
 | S1 | ADR-018 — Roadmap Execution Reset | PR #264 (`ae0a459`) | [`docs/adr/_drafts/ADR-018-roadmap-execution-reset.md`](../adr/_drafts/ADR-018-roadmap-execution-reset.md) |
-| S2 | ADR-019 — Hypothesis Discovery doctrine and scoring spec | PR #264 (`ae0a459`) | [`docs/adr/_drafts/ADR-019-hypothesis-discovery-doctrine.md`](../adr/_drafts/ADR-019-hypothesis-discovery-doctrine.md) |
+| S2 | ADR-019 — Hypothesis Discovery doctrine and scoring spec | PR #264 (`ae0a459`); promoted out of `_drafts/` in this governance-bootstrap PR | [`docs/adr/ADR-019-hypothesis-discovery-doctrine.md`](../adr/ADR-019-hypothesis-discovery-doctrine.md) |
 | S3 | ADR-020 — Paper/Shadow/Live separation doctrine | PR #264 (`ae0a459`) | [`docs/adr/_drafts/ADR-020-paper-shadow-live-separation.md`](../adr/_drafts/ADR-020-paper-shadow-live-separation.md) |
 | S4 | Global multiplicity ledger spec | this PR | [`multiplicity_ledger.md`](multiplicity_ledger.md) + [`multiplicity_ledger/schema.v1.md`](multiplicity_ledger/schema.v1.md) |
 | S5 | Sequestered hold-out discipline spec | this PR | [`holdout_discipline.md`](holdout_discipline.md) |


### PR DESCRIPTION
Promotes ADR-019 Hypothesis Discovery Doctrine to accepted status as prerequisite for Minimal v3.15.19 Hypothesis Discovery.

Local validation:
- 80 passed, 2 deselected
- governance_lint OK
- frozen contracts unchanged
- no protected runtime paths touched