### PR TITLE
feat: add minimal hypothesis discovery

### DIFF
--- a/reporting/hypothesis_discovery_summary.py
+++ b/reporting/hypothesis_discovery_summary.py
@@ -1,0 +1,69 @@
+"""Read-only summary for minimal v3.15.19 Hypothesis Discovery."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Final
+
+from research.hypothesis_discovery import campaign_seed_proposer as proposer
+
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+MODULE_VERSION: Final[str] = "v3.15.19-minimal-2026-05-21"
+REPORT_KIND: Final[str] = "hypothesis_discovery_summary"
+
+
+def read_latest_snapshot(path: Path | None = None) -> dict[str, Any] | None:
+    p = path or proposer.ARTIFACT_LATEST
+    if not p.is_file():
+        return None
+    try:
+        payload = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def collect_summary(path: Path | None = None) -> dict[str, Any]:
+    snap = read_latest_snapshot(path)
+    if snap is None:
+        return {
+            "module_version": MODULE_VERSION,
+            "report_kind": REPORT_KIND,
+            "available": False,
+            "safe_to_execute": False,
+            "proposal_only": True,
+            "final_recommendation": "not_available",
+        }
+    return {
+        "module_version": MODULE_VERSION,
+        "report_kind": REPORT_KIND,
+        "available": True,
+        "safe_to_execute": False,
+        "proposal_only": True,
+        "source_module_version": snap.get("module_version"),
+        "generated_at_utc": snap.get("generated_at_utc"),
+        "counts": dict(snap.get("counts") or {}),
+        "active_diagnostics": list(snap.get("active_diagnostics") or []),
+        "score_semantics": snap.get("score_semantics"),
+        "final_recommendation": snap.get("final_recommendation"),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="reporting.hypothesis_discovery_summary",
+        description="Read-only Hypothesis Discovery summary.",
+    )
+    parser.add_argument("--status", action="store_true")
+    args = parser.parse_args(argv)
+    _ = args.status
+    print(json.dumps(collect_summary(), sort_keys=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/hypothesis_discovery/__init__.py
+++ b/research/hypothesis_discovery/__init__.py
@@ -1,0 +1,46 @@
+"""Minimal v3.15.19 Hypothesis Discovery package.
+
+The package is proposal-only. It builds deterministic discovery seeds
+from the existing hypothesis catalog and preset universe; it does not
+create candidates, strategies, campaigns, orders, or execution state.
+"""
+
+from research.hypothesis_discovery.behavior_catalog import (
+    BEHAVIOR_FAMILIES,
+    BehaviorDescriptor,
+    get_behavior,
+    list_behaviors,
+)
+from research.hypothesis_discovery.behavior_hypotheses import (
+    BehaviorHypothesis,
+    build_behavior_hypotheses,
+)
+from research.hypothesis_discovery.campaign_seed_proposer import (
+    collect_snapshot,
+    write_outputs,
+)
+from research.hypothesis_discovery.opportunity_scoring import (
+    ACTIVE_DIAGNOSTICS,
+    OpportunityScore,
+    score_opportunity,
+)
+from research.hypothesis_discovery.preset_feasibility import (
+    PresetFeasibility,
+    evaluate_preset_feasibility,
+)
+
+__all__ = [
+    "ACTIVE_DIAGNOSTICS",
+    "BEHAVIOR_FAMILIES",
+    "BehaviorDescriptor",
+    "BehaviorHypothesis",
+    "OpportunityScore",
+    "PresetFeasibility",
+    "build_behavior_hypotheses",
+    "collect_snapshot",
+    "evaluate_preset_feasibility",
+    "get_behavior",
+    "list_behaviors",
+    "score_opportunity",
+    "write_outputs",
+]

--- a/research/hypothesis_discovery/behavior_catalog.py
+++ b/research/hypothesis_discovery/behavior_catalog.py
@@ -1,0 +1,111 @@
+"""Behavior-first catalog for minimal Hypothesis Discovery.
+
+This is a closed, hand-authored bridge from market behaviors to the
+existing strategy families. It intentionally does not register new
+strategies and does not infer families from free text.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+
+SCHEMA_VERSION: Final[int] = 1
+MODULE_VERSION: Final[str] = "v3.15.19-minimal-2026-05-21"
+
+BEHAVIOR_FAMILIES: Final[tuple[str, ...]] = (
+    "trend_pullback",
+    "volatility_breakout",
+)
+
+
+@dataclass(frozen=True)
+class BehaviorDescriptor:
+    behavior_family: str
+    market_behavior: str
+    strategy_family: str
+    required_features: tuple[str, ...]
+    required_diagnostics: tuple[str, ...]
+    required_null_model: str
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "behavior_family": self.behavior_family,
+            "market_behavior": self.market_behavior,
+            "strategy_family": self.strategy_family,
+            "required_features": list(self.required_features),
+            "required_diagnostics": list(self.required_diagnostics),
+            "required_null_model": self.required_null_model,
+        }
+
+
+_CATALOG: Final[tuple[BehaviorDescriptor, ...]] = (
+    BehaviorDescriptor(
+        behavior_family="trend_pullback",
+        market_behavior=(
+            "temporary pullback inside an established directional trend"
+        ),
+        strategy_family="trend_pullback",
+        required_features=(
+            "ema_fast",
+            "ema_slow",
+            "rolling_volatility",
+            "pullback_distance",
+        ),
+        required_diagnostics=(
+            "null_model",
+            "tail_asymmetry",
+            "entropy_structure",
+        ),
+        required_null_model="shuffle_returns",
+    ),
+    BehaviorDescriptor(
+        behavior_family="volatility_breakout",
+        market_behavior=(
+            "range breakout following a compressed-volatility regime"
+        ),
+        strategy_family="volatility_compression_breakout",
+        required_features=(
+            "atr_short",
+            "atr_long",
+            "compression_ratio",
+            "rolling_high_previous",
+            "rolling_low_previous",
+        ),
+        required_diagnostics=(
+            "null_model",
+            "tail_asymmetry",
+            "entropy_structure",
+        ),
+        required_null_model="shuffle_returns",
+    ),
+)
+
+
+def list_behaviors() -> list[BehaviorDescriptor]:
+    return list(_CATALOG)
+
+
+def get_behavior(strategy_family: str) -> BehaviorDescriptor:
+    for behavior in _CATALOG:
+        if behavior.strategy_family == strategy_family:
+            return behavior
+    known = [b.strategy_family for b in _CATALOG]
+    raise KeyError(
+        f"no behavior descriptor for strategy_family {strategy_family!r}; "
+        f"known={known}"
+    )
+
+
+def behavior_catalog_payload() -> dict[str, object]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "behavior_families": list(BEHAVIOR_FAMILIES),
+        "behaviors": [
+            behavior.to_payload()
+            for behavior in sorted(_CATALOG, key=lambda b: b.behavior_family)
+        ],
+    }

--- a/research/hypothesis_discovery/behavior_hypotheses.py
+++ b/research/hypothesis_discovery/behavior_hypotheses.py
@@ -1,0 +1,85 @@
+"""Behavior hypothesis objects derived from the existing catalog.
+
+The derivation is intentionally narrow: only current
+``active_discovery`` rows become proposal inputs. Planned, disabled,
+and diagnostic rows remain visible in the source catalog but do not
+seed Hypothesis Discovery.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+from research.hypothesis_discovery.behavior_catalog import get_behavior
+from research.strategy_hypothesis_catalog import (
+    StrategyHypothesis,
+    list_active_discovery,
+)
+
+
+SCHEMA_VERSION: Final[int] = 1
+MODULE_VERSION: Final[str] = "v3.15.19-minimal-2026-05-21"
+
+
+@dataclass(frozen=True)
+class BehaviorHypothesis:
+    hypothesis_id: str
+    behavior_family: str
+    strategy_family: str
+    strategy_mapping_ref: str
+    status: str
+    expected_failure_modes: tuple[str, ...]
+    parameter_count: int
+    default_grid_size: int
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "hypothesis_id": self.hypothesis_id,
+            "behavior_family": self.behavior_family,
+            "strategy_family": self.strategy_family,
+            "strategy_mapping_ref": self.strategy_mapping_ref,
+            "status": self.status,
+            "expected_failure_modes": list(self.expected_failure_modes),
+            "parameter_count": self.parameter_count,
+            "default_grid_size": self.default_grid_size,
+        }
+
+
+def _from_catalog_row(row: StrategyHypothesis) -> BehaviorHypothesis:
+    behavior = get_behavior(row.strategy_family)
+    return BehaviorHypothesis(
+        hypothesis_id=row.hypothesis_id,
+        behavior_family=behavior.behavior_family,
+        strategy_family=row.strategy_family,
+        strategy_mapping_ref=f"strategy_hypothesis_catalog:{row.hypothesis_id}",
+        status=row.status,
+        expected_failure_modes=tuple(row.expected_failure_modes),
+        parameter_count=len(row.parameter_schema),
+        default_grid_size=len(row.default_parameter_grid),
+    )
+
+
+def build_behavior_hypotheses(
+    *, catalog: tuple[StrategyHypothesis, ...] | None = None
+) -> list[BehaviorHypothesis]:
+    rows = (
+        [row for row in catalog if row.status == "active_discovery"]
+        if catalog is not None
+        else list_active_discovery()
+    )
+    hypotheses = [_from_catalog_row(row) for row in rows]
+    hypotheses.sort(key=lambda h: h.hypothesis_id)
+    return hypotheses
+
+
+def behavior_hypotheses_payload(
+    *, catalog: tuple[StrategyHypothesis, ...] | None = None
+) -> dict[str, object]:
+    hypotheses = build_behavior_hypotheses(catalog=catalog)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "hypotheses": [h.to_payload() for h in hypotheses],
+    }

--- a/research/hypothesis_discovery/campaign_seed_proposer.py
+++ b/research/hypothesis_discovery/campaign_seed_proposer.py
@@ -1,0 +1,275 @@
+"""Proposal-only campaign seed scaffold for Hypothesis Discovery."""
+
+from __future__ import annotations
+
+import datetime as _dt
+import hashlib
+import json
+import os
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Final
+
+from reporting import reason_records as _rr
+from research.hypothesis_discovery.behavior_catalog import get_behavior
+from research.hypothesis_discovery.behavior_hypotheses import (
+    build_behavior_hypotheses,
+)
+from research.hypothesis_discovery.opportunity_scoring import (
+    ACTIVE_DIAGNOSTICS,
+    MODULE_VERSION as SCORING_MODULE_VERSION,
+    score_opportunity,
+)
+from research.hypothesis_discovery.preset_feasibility import (
+    evaluate_preset_feasibility,
+)
+
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[2]
+SCHEMA_VERSION: Final[int] = 1
+SEED_SCHEMA_VERSION: Final[str] = "v1"
+MODULE_VERSION: Final[str] = "v3.15.19-minimal-2026-05-21"
+REPORT_KIND: Final[str] = "hypothesis_discovery_minimal_digest"
+
+ARTIFACT_DIR: Final[Path] = (
+    REPO_ROOT / "logs" / "hypothesis_discovery_minimal"
+)
+ARTIFACT_LATEST: Final[Path] = ARTIFACT_DIR / "latest.json"
+SEED_LOG: Final[Path] = ARTIFACT_DIR / "seeds_v1.jsonl"
+HISTORY: Final[Path] = ARTIFACT_DIR / "history.jsonl"
+_WRITE_PREFIX: Final[str] = "logs/hypothesis_discovery_minimal/"
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _validate_write_target(path: Path) -> None:
+    normalised = str(path).replace("\\", "/")
+    if _WRITE_PREFIX not in normalised:
+        raise ValueError(
+            "hypothesis_discovery_minimal: refusing write outside "
+            f"allowlist: {path!r}"
+        )
+
+
+def _rel(p: Path) -> str:
+    try:
+        return str(p.relative_to(REPO_ROOT)).replace("\\", "/")
+    except ValueError:
+        return str(p).replace("\\", "/")
+
+
+def _hash_id(prefix: str, *parts: str) -> str:
+    h = hashlib.sha256()
+    for part in parts:
+        h.update(part.encode("utf-8"))
+        h.update(b"\x1f")
+    return prefix + h.hexdigest()[:16]
+
+
+def _seed_from(
+    *,
+    generated_at_utc: str,
+    hypothesis_id: str,
+    behavior_family: str,
+    strategy_mapping_ref: str,
+    preset_feasibility_ref: str,
+    opportunity_probability_score: float,
+    required_diagnostics: tuple[str, ...],
+    required_null_model: str,
+    scoring_reason_record_id: str,
+    inputs_digest: str,
+) -> dict[str, object]:
+    seed_id = _hash_id(
+        "hds_",
+        inputs_digest,
+        "campaign_seed_proposal",
+        behavior_family,
+        hypothesis_id,
+    )
+    return {
+        "seed_id": seed_id,
+        "generated_at_utc": generated_at_utc,
+        "behavior_family": behavior_family,
+        "strategy_mapping_ref": strategy_mapping_ref,
+        "preset_feasibility_ref": preset_feasibility_ref,
+        "opportunity_probability_score": opportunity_probability_score,
+        "exploration_priority": "proposal_only",
+        "required_diagnostics": list(required_diagnostics),
+        "required_null_model": required_null_model,
+        "multiplicity_ledger_event_id": _hash_id(
+            "ml_pending_", seed_id, inputs_digest
+        ),
+        "scoring_reason_record_id": scoring_reason_record_id,
+        "schema_version": SEED_SCHEMA_VERSION,
+    }
+
+
+def collect_snapshot(
+    diagnostics_by_hypothesis: Mapping[str, Mapping[str, Any]] | None = None,
+    *,
+    frozen_utc: str | None = None,
+    reason_records_artifact_dir: Path | None = None,
+    emit_reason_records: bool = True,
+) -> dict[str, Any]:
+    ts = frozen_utc or _utcnow()
+    diagnostics = diagnostics_by_hypothesis or {}
+    hypotheses = build_behavior_hypotheses()
+
+    items: list[dict[str, object]] = []
+    seeds: list[dict[str, object]] = []
+    for hyp in hypotheses:
+        behavior = get_behavior(hyp.strategy_family)
+        feasibility = evaluate_preset_feasibility(hyp.hypothesis_id)
+        score = score_opportunity(
+            hyp.hypothesis_id,
+            diagnostics.get(hyp.hypothesis_id, {}),
+            preset_feasible=feasibility.feasible,
+            frozen_utc=ts,
+        )
+        reason_record = _rr.build_record(
+            decision_kind=_rr.DECISION_KIND_SCORING,
+            subject_id=hyp.hypothesis_id,
+            decision=score.decision,
+            reason_codes=score.reason_codes,
+            reason_text=score.reason_text,
+            inputs={
+                "hypothesis_id": hyp.hypothesis_id,
+                "score_inputs_digest": score.inputs_digest,
+                "proposal_surface": "hypothesis_discovery_minimal",
+            },
+            inputs_digest=score.inputs_digest,
+            frozen_utc=ts,
+        )
+        if emit_reason_records:
+            _rr.append(
+                reason_record,
+                artifact_dir=reason_records_artifact_dir,
+            )
+
+        seed: dict[str, object] | None = None
+        if score.decision == "keep":
+            seed = _seed_from(
+                generated_at_utc=ts,
+                hypothesis_id=hyp.hypothesis_id,
+                behavior_family=hyp.behavior_family,
+                strategy_mapping_ref=hyp.strategy_mapping_ref,
+                preset_feasibility_ref=feasibility.preset_feasibility_ref,
+                opportunity_probability_score=(
+                    score.opportunity_probability_score
+                ),
+                required_diagnostics=behavior.required_diagnostics,
+                required_null_model=behavior.required_null_model,
+                scoring_reason_record_id=score.scoring_reason_record_id,
+                inputs_digest=score.inputs_digest,
+            )
+            seeds.append(seed)
+
+        items.append({
+            "hypothesis_id": hyp.hypothesis_id,
+            "behavior_family": hyp.behavior_family,
+            "strategy_mapping_ref": hyp.strategy_mapping_ref,
+            "preset_feasibility": feasibility.to_payload(),
+            "score": score.to_payload(),
+            "proposal_emitted": seed is not None,
+            "seed_id": seed["seed_id"] if seed is not None else "",
+        })
+
+    items.sort(key=lambda it: str(it["hypothesis_id"]))
+    seeds.sort(key=lambda seed: str(seed["seed_id"]))
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": ts,
+        "mode": "dry-run",
+        "safe_to_execute": False,
+        "proposal_only": True,
+        "score_semantics": "expected_research_value_not_probability",
+        "proposal_order": "seed_id_ascending_not_score_ranked",
+        "active_diagnostics": list(ACTIVE_DIAGNOSTICS),
+        "scoring_module_version": SCORING_MODULE_VERSION,
+        "multiplicity_ledger_write_effect": "none_writer_deferred",
+        "counts": {
+            "hypotheses": len(items),
+            "seeds": len(seeds),
+            "filtered": len(items) - len(seeds),
+        },
+        "items": items,
+        "seeds": seeds,
+        "final_recommendation": (
+            "proposal_seeds_available" if seeds else "nothing_to_propose"
+        ),
+        "note": (
+            "Minimal v3.15.19 Hypothesis Discovery. Seeds are proposals "
+            "only; funnel policy and campaign mechanics remain the only "
+            "candidate-promotion authority."
+        ),
+    }
+
+
+def _read_existing_seed_ids(path: Path) -> set[str]:
+    if not path.is_file():
+        return set()
+    ids: set[str] = set()
+    with path.open(encoding="utf-8") as f:
+        for line in f:
+            s = line.strip()
+            if not s:
+                continue
+            try:
+                row = json.loads(s)
+            except json.JSONDecodeError:
+                continue
+            sid = row.get("seed_id")
+            if isinstance(sid, str) and sid:
+                ids.add(sid)
+    return ids
+
+
+def write_outputs(
+    snapshot: Mapping[str, Any],
+    *,
+    artifact_dir: Path | None = None,
+) -> dict[str, str]:
+    base = artifact_dir or ARTIFACT_DIR
+    base.mkdir(parents=True, exist_ok=True)
+    latest = base / ARTIFACT_LATEST.name
+    seed_log = base / SEED_LOG.name
+    history = base / HISTORY.name
+    for path in (latest, seed_log, history):
+        _validate_write_target(path)
+
+    payload = json.dumps(snapshot, sort_keys=True, indent=2)
+    tmp_latest = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_latest.write_text(payload, encoding="utf-8")
+    os.replace(tmp_latest, latest)
+
+    existing_seed_ids = _read_existing_seed_ids(seed_log)
+    with seed_log.open("a", encoding="utf-8") as f:
+        for seed in snapshot.get("seeds", []):
+            if not isinstance(seed, Mapping):
+                continue
+            seed_id = seed.get("seed_id")
+            if not isinstance(seed_id, str) or seed_id in existing_seed_ids:
+                continue
+            f.write(json.dumps(seed, sort_keys=True, separators=(",", ":")))
+            f.write("\n")
+            existing_seed_ids.add(seed_id)
+
+    compact = json.dumps(snapshot, sort_keys=True, separators=(",", ":"))
+    with history.open("a", encoding="utf-8") as f:
+        f.write(compact + "\n")
+
+    return {
+        "latest": _rel(latest),
+        "seed_log": _rel(seed_log),
+        "history": _rel(history),
+    }

--- a/research/hypothesis_discovery/opportunity_scoring.py
+++ b/research/hypothesis_discovery/opportunity_scoring.py
@@ -1,0 +1,235 @@
+"""Deterministic closed-form opportunity scoring.
+
+The score is expected research value, not alpha certainty, prediction
+probability, promotion authority, or execution authority.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Final
+
+from reporting import reason_records as _rr
+
+
+SCHEMA_VERSION: Final[int] = 1
+MODULE_VERSION: Final[str] = "v3.15.19-minimal-2026-05-21"
+
+ACTIVE_DIAGNOSTICS: Final[tuple[str, ...]] = (
+    "null_model",
+    "tail_asymmetry",
+    "entropy_structure",
+)
+
+DEFAULT_TAIL_FILTER_THRESHOLD: Final[float] = 0.75
+DEFAULT_ENTROPY_FILTER_THRESHOLD: Final[float] = 0.75
+DEFAULT_NULL_BEAT_MARGIN_THRESHOLD: Final[float] = 0.05
+DEFAULT_EVIDENCE_QUORUM_MAX: Final[int] = 3
+DEFAULT_MULTIPLICITY_BUDGET_MAX: Final[int] = 10
+
+COMPONENT_WEIGHTS: Final[dict[str, float]] = {
+    "null_model": 0.30,
+    "tail_asymmetry": 0.20,
+    "entropy_structure": 0.20,
+    "evidence_quorum": 0.15,
+    "preset_feasibility": 0.10,
+    "multiplicity_budget": 0.05,
+}
+
+SCORING_DECISIONS: Final[tuple[str, ...]] = _rr.DECISIONS_BY_KIND["scoring"]
+
+
+@dataclass(frozen=True)
+class OpportunityScore:
+    hypothesis_id: str
+    decision: str
+    opportunity_probability_score: float
+    reason_codes: tuple[str, ...]
+    reason_text: str
+    components: dict[str, float]
+    scoring_reason_record_id: str
+    inputs_digest: str
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "hypothesis_id": self.hypothesis_id,
+            "decision": self.decision,
+            "opportunity_probability_score": (
+                self.opportunity_probability_score
+            ),
+            "reason_codes": list(self.reason_codes),
+            "reason_text": self.reason_text,
+            "components": dict(sorted(self.components.items())),
+            "scoring_reason_record_id": self.scoring_reason_record_id,
+            "inputs_digest": self.inputs_digest,
+        }
+
+
+def _bounded_float(value: Any) -> float:
+    if not isinstance(value, (int, float)):
+        return 0.0
+    f = float(value)
+    if f != f:
+        return 0.0
+    if f < 0.0:
+        return 0.0
+    if f > 1.0:
+        return 1.0
+    return f
+
+
+def _bounded_int(value: Any, *, maximum: int) -> int:
+    if not isinstance(value, int):
+        return 0
+    if value < 0:
+        return 0
+    if value > maximum:
+        return maximum
+    return value
+
+
+def normalise_inputs(
+    diagnostics: Mapping[str, Any] | None,
+    *,
+    preset_feasible: bool,
+) -> dict[str, object]:
+    src = diagnostics or {}
+    null_margin = _bounded_float(src.get("null_model_beat_margin"))
+    tail_fragility = _bounded_float(src.get("tail_fragility_score"))
+    entropy_conflict = _bounded_float(src.get("entropy_conflict_score"))
+    quorum_count = _bounded_int(
+        src.get("evidence_quorum_count"),
+        maximum=DEFAULT_EVIDENCE_QUORUM_MAX,
+    )
+    budget_remaining = _bounded_int(
+        src.get("multiplicity_budget_remaining"),
+        maximum=DEFAULT_MULTIPLICITY_BUDGET_MAX,
+    )
+    return {
+        "null_model_beat_margin": null_margin,
+        "tail_fragility_score": tail_fragility,
+        "entropy_conflict_score": entropy_conflict,
+        "evidence_quorum_count": quorum_count,
+        "multiplicity_budget_remaining": budget_remaining,
+        "preset_feasible": bool(preset_feasible),
+    }
+
+
+def score_components(inputs: Mapping[str, object]) -> dict[str, float]:
+    quorum = (
+        int(inputs["evidence_quorum_count"])
+        / float(DEFAULT_EVIDENCE_QUORUM_MAX)
+    )
+    budget = (
+        int(inputs["multiplicity_budget_remaining"])
+        / float(DEFAULT_MULTIPLICITY_BUDGET_MAX)
+    )
+    return {
+        "null_model": _bounded_float(inputs["null_model_beat_margin"]),
+        "tail_asymmetry": 1.0 - _bounded_float(
+            inputs["tail_fragility_score"]
+        ),
+        "entropy_structure": 1.0 - _bounded_float(
+            inputs["entropy_conflict_score"]
+        ),
+        "evidence_quorum": _bounded_float(quorum),
+        "preset_feasibility": 1.0 if inputs["preset_feasible"] else 0.0,
+        "multiplicity_budget": _bounded_float(budget),
+    }
+
+
+def opportunity_probability_score(inputs: Mapping[str, object]) -> float:
+    components = score_components(inputs)
+    raw = sum(
+        components[name] * COMPONENT_WEIGHTS[name]
+        for name in sorted(COMPONENT_WEIGHTS)
+    )
+    return round(_bounded_float(raw), 6)
+
+
+def _decision_for(inputs: Mapping[str, object]) -> tuple[str, tuple[str, ...], str]:
+    if not inputs["preset_feasible"]:
+        return (
+            "filter_cost",
+            ("cost_gate_fail",),
+            "No stable enabled preset resolves for this hypothesis.",
+        )
+    if (
+        _bounded_float(inputs["null_model_beat_margin"])
+        < DEFAULT_NULL_BEAT_MARGIN_THRESHOLD
+    ):
+        return (
+            "filter_null",
+            ("null_p_value_above_threshold",),
+            "Null-model beat margin is below the discovery threshold.",
+        )
+    if (
+        _bounded_float(inputs["tail_fragility_score"])
+        >= DEFAULT_TAIL_FILTER_THRESHOLD
+    ):
+        return (
+            "filter_tail",
+            ("tail_fragility_high",),
+            "Left-tail fragility is above the discovery threshold.",
+        )
+    if (
+        _bounded_float(inputs["entropy_conflict_score"])
+        >= DEFAULT_ENTROPY_FILTER_THRESHOLD
+    ):
+        return (
+            "filter_entropy",
+            ("entropy_regime_incompatible",),
+            "Entropy structure is incompatible with the behavior premise.",
+        )
+    return (
+        "keep",
+        (
+            "null_p_value_below_threshold",
+            "tail_fragility_low",
+            "entropy_regime_compatible",
+            "cost_gate_pass",
+        ),
+        "All active diagnostics pass as filters; proposal seed may be emitted.",
+    )
+
+
+def score_opportunity(
+    hypothesis_id: str,
+    diagnostics: Mapping[str, Any] | None,
+    *,
+    preset_feasible: bool,
+    frozen_utc: str,
+) -> OpportunityScore:
+    inputs = normalise_inputs(diagnostics, preset_feasible=preset_feasible)
+    components = score_components(inputs)
+    score = opportunity_probability_score(inputs)
+    decision, reason_codes, reason_text = _decision_for(inputs)
+    reason_inputs = {
+        "hypothesis_id": hypothesis_id,
+        "active_diagnostics": list(ACTIVE_DIAGNOSTICS),
+        "inputs": inputs,
+        "components": dict(sorted(components.items())),
+        "component_weights": dict(sorted(COMPONENT_WEIGHTS.items())),
+        "score_semantics": "expected_research_value_not_probability",
+    }
+    record = _rr.build_record(
+        decision_kind=_rr.DECISION_KIND_SCORING,
+        subject_id=hypothesis_id,
+        decision=decision,
+        reason_codes=reason_codes,
+        reason_text=reason_text,
+        inputs=reason_inputs,
+        frozen_utc=frozen_utc,
+    )
+    return OpportunityScore(
+        hypothesis_id=hypothesis_id,
+        decision=decision,
+        opportunity_probability_score=score,
+        reason_codes=reason_codes,
+        reason_text=reason_text,
+        components=components,
+        scoring_reason_record_id=record["record_id"],
+        inputs_digest=record["inputs_digest"],
+    )

--- a/research/hypothesis_discovery/preset_feasibility.py
+++ b/research/hypothesis_discovery/preset_feasibility.py
@@ -1,0 +1,84 @@
+"""Preset feasibility for proposal-only Hypothesis Discovery."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+from research.presets import PRESETS, ResearchPreset, resolve_preset_bundle
+
+
+SCHEMA_VERSION: Final[int] = 1
+MODULE_VERSION: Final[str] = "v3.15.19-minimal-2026-05-21"
+
+
+@dataclass(frozen=True)
+class PresetFeasibility:
+    hypothesis_id: str
+    feasible: bool
+    preset_names: tuple[str, ...]
+    preset_feasibility_ref: str
+    reason_codes: tuple[str, ...]
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "hypothesis_id": self.hypothesis_id,
+            "feasible": self.feasible,
+            "preset_names": list(self.preset_names),
+            "preset_feasibility_ref": self.preset_feasibility_ref,
+            "reason_codes": list(self.reason_codes),
+        }
+
+
+def _is_feasible_preset(preset: ResearchPreset) -> bool:
+    return (
+        preset.enabled
+        and preset.status == "stable"
+        and not preset.diagnostic_only
+        and bool(resolve_preset_bundle(preset))
+    )
+
+
+def evaluate_preset_feasibility(
+    hypothesis_id: str,
+    *,
+    presets: tuple[ResearchPreset, ...] = PRESETS,
+) -> PresetFeasibility:
+    bound = [
+        p for p in presets
+        if p.hypothesis_id == hypothesis_id and _is_feasible_preset(p)
+    ]
+    names = tuple(sorted(p.name for p in bound))
+    if names:
+        ref = "preset:" + ",".join(names)
+        return PresetFeasibility(
+            hypothesis_id=hypothesis_id,
+            feasible=True,
+            preset_names=names,
+            preset_feasibility_ref=ref,
+            reason_codes=("preset_stable_enabled", "bundle_resolves"),
+        )
+    return PresetFeasibility(
+        hypothesis_id=hypothesis_id,
+        feasible=False,
+        preset_names=(),
+        preset_feasibility_ref="preset:none",
+        reason_codes=("no_stable_enabled_preset",),
+    )
+
+
+def preset_feasibility_payload(
+    hypothesis_ids: tuple[str, ...],
+    *,
+    presets: tuple[ResearchPreset, ...] = PRESETS,
+) -> dict[str, object]:
+    rows = [
+        evaluate_preset_feasibility(hid, presets=presets).to_payload()
+        for hid in sorted(hypothesis_ids)
+    ]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "items": rows,
+    }

--- a/tests/integration/test_null_pipeline.py
+++ b/tests/integration/test_null_pipeline.py
@@ -1,0 +1,56 @@
+"""Minimal null-pipeline integration coverage.
+
+Pins ADR-019's falsifiability requirement for the v3.15.19 minimal
+Hypothesis Discovery slice: deterministic surrogate diagnostics and
+their shuffled-control counterpart must not produce distinguishable
+Discovery scores.
+"""
+
+from __future__ import annotations
+
+from research.hypothesis_discovery import campaign_seed_proposer as csp
+from research.hypothesis_discovery import opportunity_scoring as oscore
+
+
+def _surrogate_diagnostics() -> dict[str, float | int]:
+    return {
+        "null_model_beat_margin": 0.25,
+        "tail_fragility_score": 0.50,
+        "entropy_conflict_score": 0.50,
+        "evidence_quorum_count": 1,
+        "multiplicity_budget_remaining": 5,
+    }
+
+
+def test_hypothesis_discovery_scores_surrogate_and_shuffle_equally() -> None:
+    surrogate = oscore.normalise_inputs(
+        _surrogate_diagnostics(),
+        preset_feasible=True,
+    )
+    shuffled_control = dict(reversed(list(surrogate.items())))
+
+    assert oscore.opportunity_probability_score(
+        surrogate
+    ) == oscore.opportunity_probability_score(shuffled_control)
+
+
+def test_hypothesis_discovery_enabled_does_not_execute_on_surrogate(
+    tmp_path,
+) -> None:
+    snap = csp.collect_snapshot(
+        {
+            "trend_pullback_v1": _surrogate_diagnostics(),
+            "volatility_compression_breakout_v0": _surrogate_diagnostics(),
+        },
+        frozen_utc="2026-05-21T00:00:00Z",
+        reason_records_artifact_dir=tmp_path / "logs" / "reason_records",
+    )
+
+    assert snap["safe_to_execute"] is False
+    assert snap["proposal_only"] is True
+    assert snap["score_semantics"] == "expected_research_value_not_probability"
+    assert all(
+        row["score"]["opportunity_probability_score"]
+        == snap["items"][0]["score"]["opportunity_probability_score"]
+        for row in snap["items"]
+    )

--- a/tests/unit/test_hypothesis_discovery_minimal.py
+++ b/tests/unit/test_hypothesis_discovery_minimal.py
@@ -1,0 +1,322 @@
+"""Tests for minimal v3.15.19 Hypothesis Discovery."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reporting import reason_records as rr
+from reporting import hypothesis_discovery_summary as hds
+from research.hypothesis_discovery import behavior_catalog as bc
+from research.hypothesis_discovery import behavior_hypotheses as bh
+from research.hypothesis_discovery import campaign_seed_proposer as csp
+from research.hypothesis_discovery import opportunity_scoring as oscore
+from research.hypothesis_discovery import preset_feasibility as pf
+
+
+def _diag(
+    *,
+    null_margin: float = 0.80,
+    tail: float = 0.10,
+    entropy: float = 0.10,
+    quorum: int = 3,
+    budget: int = 10,
+) -> dict[str, Any]:
+    return {
+        "null_model_beat_margin": null_margin,
+        "tail_fragility_score": tail,
+        "entropy_conflict_score": entropy,
+        "evidence_quorum_count": quorum,
+        "multiplicity_budget_remaining": budget,
+    }
+
+
+def test_behavior_catalog_is_closed_and_behavior_first() -> None:
+    assert bc.BEHAVIOR_FAMILIES == (
+        "trend_pullback",
+        "volatility_breakout",
+    )
+    payload = bc.behavior_catalog_payload()
+    families = [row["behavior_family"] for row in payload["behaviors"]]
+    assert families == sorted(families)
+    assert {row["strategy_family"] for row in payload["behaviors"]} == {
+        "trend_pullback",
+        "volatility_compression_breakout",
+    }
+
+
+def test_behavior_hypotheses_are_active_discovery_only() -> None:
+    rows = bh.build_behavior_hypotheses()
+    assert [row.hypothesis_id for row in rows] == [
+        "trend_pullback_v1",
+        "volatility_compression_breakout_v0",
+    ]
+    assert all(row.status == "active_discovery" for row in rows)
+    assert all(row.strategy_mapping_ref for row in rows)
+
+
+def test_preset_feasibility_uses_existing_preset_bridge() -> None:
+    feasible = pf.evaluate_preset_feasibility("trend_pullback_v1")
+    assert feasible.feasible is True
+    assert feasible.preset_names == ("trend_pullback_crypto_1h",)
+    assert feasible.preset_feasibility_ref == "preset:trend_pullback_crypto_1h"
+
+    missing = pf.evaluate_preset_feasibility("unknown_hypothesis")
+    assert missing.feasible is False
+    assert missing.preset_feasibility_ref == "preset:none"
+
+
+def test_score_axiom_deterministic() -> None:
+    inputs = oscore.normalise_inputs(_diag(), preset_feasible=True)
+    a = oscore.opportunity_probability_score(inputs)
+    b = oscore.opportunity_probability_score(dict(reversed(list(inputs.items()))))
+    assert a == b
+
+
+def test_score_axiom_bounded() -> None:
+    bad = oscore.normalise_inputs(
+        _diag(null_margin=99.0, tail=-1.0, entropy=42.0, quorum=99, budget=99),
+        preset_feasible=True,
+    )
+    score = oscore.opportunity_probability_score(bad)
+    assert 0.0 <= score <= 1.0
+
+
+def test_score_axiom_monotone_positive_inputs() -> None:
+    base = oscore.normalise_inputs(
+        _diag(null_margin=0.20, quorum=1, budget=2),
+        preset_feasible=True,
+    )
+    higher_null = dict(base)
+    higher_null["null_model_beat_margin"] = 0.60
+    higher_quorum = dict(base)
+    higher_quorum["evidence_quorum_count"] = 3
+    higher_budget = dict(base)
+    higher_budget["multiplicity_budget_remaining"] = 10
+
+    base_score = oscore.opportunity_probability_score(base)
+    assert oscore.opportunity_probability_score(higher_null) >= base_score
+    assert oscore.opportunity_probability_score(higher_quorum) >= base_score
+    assert oscore.opportunity_probability_score(higher_budget) >= base_score
+
+
+def test_score_axiom_monotone_negative_inputs() -> None:
+    base = oscore.normalise_inputs(
+        _diag(tail=0.10, entropy=0.10),
+        preset_feasible=True,
+    )
+    higher_tail = dict(base)
+    higher_tail["tail_fragility_score"] = 0.70
+    higher_entropy = dict(base)
+    higher_entropy["entropy_conflict_score"] = 0.70
+
+    base_score = oscore.opportunity_probability_score(base)
+    assert oscore.opportunity_probability_score(higher_tail) <= base_score
+    assert oscore.opportunity_probability_score(higher_entropy) <= base_score
+
+
+def test_score_axiom_independent_of_execution_side_state() -> None:
+    src = Path(oscore.__file__).resolve().read_text(encoding="utf-8")
+    forbidden = (
+        "research_latest.json",
+        "strategy_matrix.csv",
+        "agent.execution",
+        "agent.risk",
+        "broker.",
+        "live.",
+        "paper.",
+        "shadow.",
+        "trading.",
+    )
+    for needle in forbidden:
+        assert needle not in src
+
+
+def test_score_axiom_inspectable_reason_record(tmp_path: Path) -> None:
+    base = tmp_path / "logs" / "reason_records"
+    snap = csp.collect_snapshot(
+        {"trend_pullback_v1": _diag()},
+        frozen_utc="2026-05-21T00:00:00Z",
+        reason_records_artifact_dir=base,
+    )
+    records = rr.read_kind("scoring", artifact_dir=base)
+    assert records
+    ids = {r["record_id"] for r in records}
+    assert snap["items"][0]["score"]["scoring_reason_record_id"] in ids
+    assert records[0]["decision_kind"] == "scoring"
+
+
+def test_score_axiom_noise_equivalence_on_identical_surrogate_inputs() -> None:
+    surrogate = oscore.normalise_inputs(
+        _diag(null_margin=0.25, tail=0.50, entropy=0.50, quorum=1, budget=5),
+        preset_feasible=True,
+    )
+    shuffled_surrogate = dict(reversed(list(surrogate.items())))
+    assert oscore.opportunity_probability_score(
+        surrogate
+    ) == oscore.opportunity_probability_score(shuffled_surrogate)
+
+
+def test_diagnostics_filter_do_not_seed_when_null_fails(tmp_path: Path) -> None:
+    base = tmp_path / "logs" / "reason_records"
+    snap = csp.collect_snapshot(
+        {"trend_pullback_v1": _diag(null_margin=0.0)},
+        frozen_utc="2026-05-21T00:00:00Z",
+        reason_records_artifact_dir=base,
+    )
+    item = [
+        row for row in snap["items"]
+        if row["hypothesis_id"] == "trend_pullback_v1"
+    ][0]
+    assert item["score"]["decision"] == "filter_null"
+    assert item["proposal_emitted"] is False
+    assert all(
+        seed["strategy_mapping_ref"] != item["strategy_mapping_ref"]
+        for seed in snap["seeds"]
+    )
+
+
+def test_tail_and_entropy_are_filters_not_seed_sources(tmp_path: Path) -> None:
+    snap_tail = csp.collect_snapshot(
+        {"trend_pullback_v1": _diag(tail=0.99)},
+        frozen_utc="2026-05-21T00:00:00Z",
+        reason_records_artifact_dir=tmp_path / "a" / "logs" / "reason_records",
+    )
+    row_tail = [
+        row for row in snap_tail["items"]
+        if row["hypothesis_id"] == "trend_pullback_v1"
+    ][0]
+    assert row_tail["score"]["decision"] == "filter_tail"
+
+    snap_entropy = csp.collect_snapshot(
+        {"trend_pullback_v1": _diag(entropy=0.99)},
+        frozen_utc="2026-05-21T00:00:00Z",
+        reason_records_artifact_dir=tmp_path / "b" / "logs" / "reason_records",
+    )
+    row_entropy = [
+        row for row in snap_entropy["items"]
+        if row["hypothesis_id"] == "trend_pullback_v1"
+    ][0]
+    assert row_entropy["score"]["decision"] == "filter_entropy"
+
+
+def test_snapshot_emits_proposal_only_seeds_with_adr_fields(
+    tmp_path: Path,
+) -> None:
+    snap = csp.collect_snapshot(
+        {
+            "trend_pullback_v1": _diag(),
+            "volatility_compression_breakout_v0": _diag(),
+        },
+        frozen_utc="2026-05-21T00:00:00Z",
+        reason_records_artifact_dir=tmp_path / "logs" / "reason_records",
+    )
+    assert snap["safe_to_execute"] is False
+    assert snap["proposal_only"] is True
+    assert snap["score_semantics"] == "expected_research_value_not_probability"
+    assert snap["counts"]["seeds"] == 2
+    required = {
+        "seed_id",
+        "generated_at_utc",
+        "behavior_family",
+        "strategy_mapping_ref",
+        "preset_feasibility_ref",
+        "opportunity_probability_score",
+        "required_diagnostics",
+        "required_null_model",
+        "multiplicity_ledger_event_id",
+        "scoring_reason_record_id",
+        "schema_version",
+    }
+    for seed in snap["seeds"]:
+        assert required.issubset(seed.keys())
+        assert seed["schema_version"] == "v1"
+        assert seed["required_diagnostics"] == list(oscore.ACTIVE_DIAGNOSTICS)
+        assert 0.0 <= seed["opportunity_probability_score"] <= 1.0
+        assert str(seed["multiplicity_ledger_event_id"]).startswith(
+            "ml_pending_"
+        )
+
+
+def test_snapshot_is_byte_deterministic_with_frozen_timestamp(
+    tmp_path: Path,
+) -> None:
+    base = tmp_path / "logs" / "reason_records"
+    inputs = {"trend_pullback_v1": _diag()}
+    a = csp.collect_snapshot(
+        inputs,
+        frozen_utc="2026-05-21T00:00:00Z",
+        reason_records_artifact_dir=base,
+    )
+    b = csp.collect_snapshot(
+        inputs,
+        frozen_utc="2026-05-21T00:00:00Z",
+        reason_records_artifact_dir=base,
+    )
+    assert json.dumps(a, sort_keys=True) == json.dumps(b, sort_keys=True)
+
+
+def test_seed_log_is_append_only_and_idempotent(tmp_path: Path) -> None:
+    base = tmp_path / "logs" / "hypothesis_discovery_minimal"
+    snap = csp.collect_snapshot(
+        {"trend_pullback_v1": _diag()},
+        frozen_utc="2026-05-21T00:00:00Z",
+        reason_records_artifact_dir=tmp_path / "logs" / "reason_records",
+        emit_reason_records=False,
+    )
+    csp.write_outputs(snap, artifact_dir=base)
+    csp.write_outputs(snap, artifact_dir=base)
+    lines = (base / "seeds_v1.jsonl").read_text(encoding="utf-8").splitlines()
+    seed_ids = [json.loads(line)["seed_id"] for line in lines]
+    assert len(seed_ids) == len(set(seed_ids)) == snap["counts"]["seeds"]
+
+
+def test_write_outputs_refuses_outside_allowlist(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="outside allowlist"):
+        csp._validate_write_target(tmp_path / "not_logs" / "latest.json")
+
+
+def test_summary_reports_not_available_when_no_snapshot(tmp_path: Path) -> None:
+    summary = hds.collect_summary(tmp_path / "missing.json")
+    assert summary["available"] is False
+    assert summary["safe_to_execute"] is False
+    assert summary["proposal_only"] is True
+
+
+def test_module_sources_do_not_import_execution_surfaces() -> None:
+    modules = [bc, bh, pf, oscore, csp, hds]
+    forbidden = (
+        "import subprocess",
+        "from subprocess",
+        "import socket",
+        "from socket",
+        "import requests",
+        "from requests",
+        "import urllib.request",
+        "from urllib.request",
+        "agent.execution",
+        "agent.risk",
+        "automation.live",
+        "automation.broker",
+        "broker.",
+        "execution.live",
+        "live.",
+        "paper.",
+        "shadow.",
+        "trading.",
+    )
+    for module in modules:
+        src = Path(module.__file__).resolve().read_text(encoding="utf-8")
+        for needle in forbidden:
+            assert needle not in src, f"{module.__name__} contains {needle}"
+
+
+def test_cli_summary_smoke(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = hds.main(["--status"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    parsed = json.loads(out)
+    assert parsed["safe_to_execute"] is False


### PR DESCRIPTION
## Summary
- Adds minimal v3.15.19 Hypothesis Discovery modules under `research/hypothesis_discovery/`.
- Implements behavior-first hypothesis objects, preset feasibility, deterministic ADR-019 opportunity scoring, proposal-only seed scaffolding, and a read-only reporting summary.
- Adds targeted unit tests plus `tests/integration/test_null_pipeline.py` to pin the required surrogate/null-pipeline behavior.

## Governance / Scope
- Proposal seeds only; no candidates, campaign enqueue, strategy generation, or execution authority.
- Active diagnostics (`null_model`, `tail_asymmetry`, `entropy_structure`) are filters, not seed sources.
- No frozen contract mutation: `research/research_latest.json` and `research/strategy_matrix.csv` untouched.
- Protected live/paper/shadow/risk/broker/execution paths untouched.

## Tests
- `python -m pytest tests/unit/test_hypothesis_discovery_minimal.py tests/integration/test_null_pipeline.py -v`
- `python -m pytest tests/smoke -v`
- `python scripts\governance_lint.py`
- `python -m pytest tests/regression/test_public_output_contract.py tests/regression/test_v12_contracts_preserved.py tests/regression/test_authority_invariants.py -v`
- `python -m pytest tests/functional/test_static_import_surface.py -v`