### PR TITLE
feat: add controlled eval no-candidate diagnostics

### DIFF
--- a/research/controlled_eval.py
+++ b/research/controlled_eval.py
@@ -15,6 +15,7 @@ import subprocess  # nosec B404 - fixed argv subprocess wrapper
 import sys
 import time
 from collections import Counter
+from contextlib import suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -23,12 +24,16 @@ from typing import Any, Final
 from research import discovery_sprint as ds
 from research._sidecar_io import write_sidecar_atomic
 from research.campaign_evidence_ledger import load_events
+from research.campaign_policy import POLICY_DECISION_PATH
+from research.campaign_queue import (
+    ACTIVE_QUEUE_STATES,
+    QUEUE_ARTIFACT_PATH,
+    load_queue,
+)
 from research.campaign_registry import REGISTRY_ARTIFACT_PATH, load_registry
 
 CONTROLLED_EVAL_SCHEMA_VERSION: Final[str] = "1.0"
-DEFAULT_REPORT_JSON_PATH: Final[Path] = Path(
-    "research/controlled_eval_latest.v1.json"
-)
+DEFAULT_REPORT_JSON_PATH: Final[Path] = Path("research/controlled_eval_latest.v1.json")
 DEFAULT_REPORT_MD_PATH: Final[Path] = Path("research/controlled_eval_latest.md")
 DEFAULT_TIMEOUT_SECONDS_PER_CAMPAIGN: Final[int] = 3600
 DEFAULT_POLL_SECONDS: Final[int] = 5
@@ -38,22 +43,24 @@ MIN_TIMEOUT_SECONDS_PER_CAMPAIGN: Final[int] = 60
 MAX_TIMEOUT_SECONDS_PER_CAMPAIGN: Final[int] = 21_600
 MAX_POLL_SECONDS: Final[int] = 300
 
-LEDGER_PATH: Final[Path] = Path(
-    "research/campaign_evidence_ledger_latest.v1.jsonl"
-)
+LEDGER_PATH: Final[Path] = Path("research/campaign_evidence_ledger_latest.v1.jsonl")
 RUN_CAMPAIGN_PATH: Final[Path] = Path("research/run_campaign_latest.v1.json")
 INFORMATION_GAIN_PATH: Final[Path] = Path(
     "research/campaigns/evidence/information_gain_latest.v1.json"
 )
-VIABILITY_PATH: Final[Path] = Path(
-    "research/campaigns/evidence/viability_latest.v1.json"
-)
+VIABILITY_PATH: Final[Path] = Path("research/campaigns/evidence/viability_latest.v1.json")
 STOP_CONDITIONS_PATH: Final[Path] = Path(
     "research/campaigns/evidence/stop_conditions_latest.v1.json"
 )
 SPAWN_PROPOSALS_PATH: Final[Path] = Path(
     "research/campaigns/evidence/spawn_proposals_latest.v1.json"
 )
+
+ACTIVE_CAMPAIGN_STATES: Final[frozenset[str]] = frozenset({"pending", "leased", "running"})
+TERMINAL_CAMPAIGN_STATES: Final[frozenset[str]] = frozenset(
+    {"completed", "failed", "canceled", "archived"}
+)
+MAX_ACTIVE_CAMPAIGN_IDS: Final[int] = 10
 
 MEANINGFUL_CLASSIFICATIONS: Final[frozenset[str]] = frozenset(
     {
@@ -126,7 +133,7 @@ def _profile_name_from_sprint(registry_payload: dict[str, Any] | None) -> str | 
 
 
 def _plan_presets(registry_payload: dict[str, Any] | None) -> frozenset[str]:
-    entries = (((registry_payload or {}).get("plan") or {}).get("entries") or [])
+    entries = ((registry_payload or {}).get("plan") or {}).get("entries") or []
     names: set[str] = set()
     for entry in entries:
         if not isinstance(entry, dict):
@@ -141,9 +148,7 @@ def _parse_dt(value: Any) -> datetime | None:
     if not isinstance(value, str) or not value:
         return None
     try:
-        return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(
-            UTC
-        )
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
     except ValueError:
         return None
 
@@ -213,9 +218,7 @@ def summarize_campaign_records(
             continue
         if not _record_matches_sprint(record, sprint_registry=sprint_registry):
             continue
-        meaningful = meaningful_by_campaign.get(str(cid)) or record.get(
-            "meaningful_classification"
-        )
+        meaningful = meaningful_by_campaign.get(str(cid)) or record.get("meaningful_classification")
         records.append(
             {
                 "campaign_id": str(record.get("campaign_id") or cid),
@@ -244,11 +247,7 @@ def summarize_latest_run(run_campaign_payload: dict[str, Any] | None) -> dict[st
     summary = run_campaign_payload.get("summary") or {}
     batches = run_campaign_payload.get("batches") or []
     failed_batch = next(
-        (
-            batch
-            for batch in batches
-            if isinstance(batch, dict) and batch.get("error_type")
-        ),
+        (batch for batch in batches if isinstance(batch, dict) and batch.get("error_type")),
         {},
     )
     screening_rejected = summary.get("screening_rejected_count")
@@ -262,10 +261,81 @@ def summarize_latest_run(run_campaign_payload: dict[str, Any] | None) -> dict[st
         "status": run_campaign_payload.get("status"),
         "screening_rejected_count": int(screening_rejected or 0),
         "validation_candidate_count": int(validation_count or 0),
-        "error_type": run_campaign_payload.get("error_type")
-        or failed_batch.get("error_type"),
+        "error_type": run_campaign_payload.get("error_type") or failed_batch.get("error_type"),
         "error_message": run_campaign_payload.get("error_message")
         or failed_batch.get("reason_detail"),
+    }
+
+
+def summarize_latest_policy_decision(
+    payload: dict[str, Any] | None,
+) -> dict[str, Any]:
+    if not payload:
+        return {
+            "latest_policy_decision_present": False,
+            "latest_policy_action": None,
+            "latest_policy_reason": None,
+            "latest_policy_candidates_considered_count": 0,
+            "latest_policy_rules_summary": {},
+        }
+
+    decision = payload.get("decision") if isinstance(payload.get("decision"), dict) else {}
+    candidates = payload.get("candidates_considered")
+    candidate_count = len(candidates) if isinstance(candidates, list) else 0
+    rules_summary: dict[str, dict[str, Any]] = {}
+    rules = payload.get("rules_evaluated")
+    if isinstance(rules, list):
+        for rule in rules:
+            if not isinstance(rule, dict):
+                continue
+            rule_id = rule.get("rule_id")
+            if not rule_id:
+                continue
+            rules_summary[str(rule_id)] = {str(k): v for k, v in rule.items() if k != "rule_id"}
+
+    return {
+        "latest_policy_decision_present": True,
+        "latest_policy_action": decision.get("action"),
+        "latest_policy_reason": decision.get("reason"),
+        "latest_policy_candidates_considered_count": candidate_count,
+        "latest_policy_rules_summary": rules_summary,
+    }
+
+
+def summarize_active_campaigns(registry: dict[str, Any]) -> dict[str, Any]:
+    active_ids: list[str] = []
+    for cid, record in (registry.get("campaigns") or {}).items():
+        if not isinstance(record, dict):
+            continue
+        state = str(record.get("state") or "")
+        if state not in ACTIVE_CAMPAIGN_STATES:
+            continue
+        active_ids.append(str(record.get("campaign_id") or cid))
+    active_ids.sort()
+    return {
+        "active_campaign_count": len(active_ids),
+        "active_campaign_ids": active_ids[:MAX_ACTIVE_CAMPAIGN_IDS],
+    }
+
+
+def summarize_queue_state(queue_payload: dict[str, Any] | None) -> dict[str, Any]:
+    entries = (queue_payload or {}).get("queue")
+    if not isinstance(entries, list):
+        entries = []
+    active_count = 0
+    terminal_count = 0
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        state = str(entry.get("state") or "")
+        if state in ACTIVE_QUEUE_STATES:
+            active_count += 1
+        elif state in TERMINAL_CAMPAIGN_STATES:
+            terminal_count += 1
+    return {
+        "queue_item_count": len(entries),
+        "queue_active_count": active_count,
+        "queue_terminal_count": terminal_count,
     }
 
 
@@ -293,6 +363,7 @@ def _classify_verdict(
     campaign_records: list[dict[str, Any]],
     ticks: list[LauncherTick],
     intelligence_artifact_status: dict[str, str],
+    latest_policy_summary: dict[str, Any],
 ) -> tuple[dict[str, Any], str]:
     reason_codes: list[str] = []
     timed_out = any(tick.timed_out for tick in ticks)
@@ -321,6 +392,22 @@ def _classify_verdict(
         )
     if not completed:
         reason_codes.append("no_campaign_completed")
+        if (
+            latest_policy_summary.get("latest_policy_action") == "idle_noop"
+            and latest_policy_summary.get("latest_policy_reason") == "no_candidates"
+        ):
+            reason_codes.append("no_candidates_policy_block")
+            return (
+                {
+                    "status": "no_campaign_completed",
+                    "reason_codes": reason_codes,
+                    "human_summary": (
+                        "No campaign completed because the latest launcher "
+                        "policy decision idled with no candidates."
+                    ),
+                },
+                "inspect_campaign_policy_filters",
+            )
         return (
             {
                 "status": "no_campaign_completed",
@@ -331,13 +418,9 @@ def _classify_verdict(
         )
 
     outcomes = {str(r.get("outcome") or "") for r in completed}
-    meaningful = {
-        str(r.get("meaningful_classification") or "") for r in completed
-    }
+    meaningful = {str(r.get("meaningful_classification") or "") for r in completed}
     missing_intelligence = [
-        name
-        for name, status in intelligence_artifact_status.items()
-        if status != "present"
+        name for name, status in intelligence_artifact_status.items() if status != "present"
     ]
     has_meaningful_failure = bool(outcomes & MEANINGFUL_FAILURE_OUTCOMES) or bool(
         meaningful & MEANINGFUL_CLASSIFICATIONS
@@ -408,6 +491,8 @@ def build_report_payload(
     registry: dict[str, Any],
     ledger_events: list[dict[str, Any]],
     run_campaign_payload: dict[str, Any] | None,
+    latest_policy_decision_payload: dict[str, Any] | None,
+    queue_payload: dict[str, Any] | None,
     intelligence_artifact_status: dict[str, str],
     ticks: list[LauncherTick],
     generated_at_utc: datetime | None = None,
@@ -418,19 +503,17 @@ def build_report_payload(
         sprint_registry=sprint_registry,
         ledger_events=ledger_events,
     )
-    completed_records = [
-        r for r in campaign_records if r.get("state") == "completed"
-    ]
-    by_preset = Counter(
-        str(r.get("preset_name") or "unknown") for r in completed_records
-    )
-    by_outcome = Counter(
-        str(r.get("outcome") or "unknown") for r in completed_records
-    )
+    completed_records = [r for r in campaign_records if r.get("state") == "completed"]
+    by_preset = Counter(str(r.get("preset_name") or "unknown") for r in completed_records)
+    by_outcome = Counter(str(r.get("outcome") or "unknown") for r in completed_records)
+    latest_policy_summary = summarize_latest_policy_decision(latest_policy_decision_payload)
+    active_campaign_summary = summarize_active_campaigns(registry)
+    queue_summary = summarize_queue_state(queue_payload)
     verdict, next_action = _classify_verdict(
         campaign_records=campaign_records,
         ticks=ticks,
         intelligence_artifact_status=intelligence_artifact_status,
+        latest_policy_summary=latest_policy_summary,
     )
     return {
         "schema_version": CONTROLLED_EVAL_SCHEMA_VERSION,
@@ -450,6 +533,9 @@ def build_report_payload(
         "campaigns_by_outcome": dict(sorted(by_outcome.items())),
         "campaign_records": campaign_records,
         "latest_run_summary": summarize_latest_run(run_campaign_payload),
+        **latest_policy_summary,
+        **active_campaign_summary,
+        **queue_summary,
         "intelligence_artifact_status": intelligence_artifact_status,
         "launcher_ticks": [tick.to_payload() for tick in ticks],
         "verdict": verdict,
@@ -463,9 +549,10 @@ def render_markdown_report(report: dict[str, Any]) -> str:
     verdict = report.get("verdict") or {}
     artifacts = report.get("intelligence_artifact_status") or {}
     by_outcome = report.get("campaigns_by_outcome") or {}
-    missing_artifacts = [
-        name for name, status in artifacts.items() if status != "present"
-    ]
+    missing_artifacts = [name for name, status in artifacts.items() if status != "present"]
+    rules_summary = report.get("latest_policy_rules_summary") or {}
+    filtering = rules_summary.get("R4_R7_filtering") or {}
+    idle = rules_summary.get("R8_idle") or {}
     lines = [
         "# Controlled Evaluation Report",
         "",
@@ -487,6 +574,20 @@ def render_markdown_report(report: dict[str, Any]) -> str:
         "",
         "## Bottleneck",
         (
+            "- Latest launcher decision: "
+            f"{report.get('latest_policy_action') or 'missing'} / "
+            f"{report.get('latest_policy_reason') or 'missing'}"
+        ),
+        ("- Candidates considered: " f"{report.get('latest_policy_candidates_considered_count')}"),
+        f"- R4_R7 surviving: {filtering.get('surviving', 'unknown')}",
+        f"- R4_R7 rejected: {filtering.get('rejected', 'unknown')}",
+        f"- R8 idle: {idle.get('result', 'unknown')}",
+        f"- Active campaigns: {report.get('active_campaign_count')}",
+        (
+            "- Policy/no-candidate condition, not a running campaign: "
+            f"{_is_policy_no_candidate_condition(report)}"
+        ),
+        (
             "- Missing intelligence artifacts: "
             + (", ".join(missing_artifacts) if missing_artifacts else "none")
         ),
@@ -497,6 +598,15 @@ def render_markdown_report(report: dict[str, Any]) -> str:
         "",
     ]
     return "\n".join(lines)
+
+
+def _is_policy_no_candidate_condition(report: dict[str, Any]) -> bool:
+    return (
+        report.get("campaigns_completed") == 0
+        and report.get("latest_policy_action") == "idle_noop"
+        and report.get("latest_policy_reason") == "no_candidates"
+        and int(report.get("active_campaign_count") or 0) == 0
+    )
 
 
 def _write_text_atomic(path: Path, content: str) -> None:
@@ -542,14 +652,10 @@ def _run_launcher_tick(
             else exc.stderr
         )
     elapsed = int((_now_utc() - started).total_seconds())
-    try:
+    with suppress(Exception):
         ds.update_sprint_progress()
-    except Exception:
-        pass
     after_registry = load_registry(REGISTRY_ARTIFACT_PATH)
-    after_completed_ids = _completed_campaign_ids(
-        after_registry, sprint_registry=sprint_registry
-    )
+    after_completed_ids = _completed_campaign_ids(after_registry, sprint_registry=sprint_registry)
     new_completed = tuple(sorted(after_completed_ids - before_completed_ids))
     return LauncherTick(
         tick_index=tick_index,
@@ -590,18 +696,14 @@ def run_controlled_eval(
     out=sys.stdout,
 ) -> int:
     if max_campaigns < 1 or max_campaigns > MAX_CAMPAIGNS_HARD_LIMIT:
-        raise ValueError(
-            f"max_campaigns must be between 1 and {MAX_CAMPAIGNS_HARD_LIMIT}"
-        )
+        raise ValueError(f"max_campaigns must be between 1 and {MAX_CAMPAIGNS_HARD_LIMIT}")
     sprint_started, sprint_reused = _ensure_active_sprint(profile)
     ds.update_sprint_progress()
     initial_progress = ds.load_sprint_progress() or {}
     observed_before = int(initial_progress.get("observed_total") or 0)
     sprint_registry = ds.load_sprint_registry()
     registry_before = load_registry(REGISTRY_ARTIFACT_PATH)
-    completed_ids = _completed_campaign_ids(
-        registry_before, sprint_registry=sprint_registry
-    )
+    completed_ids = _completed_campaign_ids(registry_before, sprint_registry=sprint_registry)
 
     ticks: list[LauncherTick] = []
     for tick_index in range(1, max_campaigns + 1):
@@ -613,9 +715,7 @@ def run_controlled_eval(
         )
         ticks.append(tick)
         registry_now = load_registry(REGISTRY_ARTIFACT_PATH)
-        completed_ids = _completed_campaign_ids(
-            registry_now, sprint_registry=sprint_registry
-        )
+        completed_ids = _completed_campaign_ids(registry_now, sprint_registry=sprint_registry)
         out.write(
             f"tick {tick_index}/{max_campaigns}: "
             f"rc={tick.returncode if tick.returncode is not None else 'timeout'} "
@@ -644,6 +744,8 @@ def run_controlled_eval(
         registry=campaign_registry,
         ledger_events=ledger_events,
         run_campaign_payload=_read_json(RUN_CAMPAIGN_PATH),
+        latest_policy_decision_payload=_read_json(POLICY_DECISION_PATH),
+        queue_payload=load_queue(QUEUE_ARTIFACT_PATH),
         intelligence_artifact_status=build_intelligence_artifact_status(),
         ticks=ticks,
     )
@@ -670,9 +772,7 @@ def _bounded_int(
     except ValueError as exc:
         raise argparse.ArgumentTypeError(f"{name} must be an integer") from exc
     if parsed < minimum or parsed > maximum:
-        raise argparse.ArgumentTypeError(
-            f"{name} must be between {minimum} and {maximum}"
-        )
+        raise argparse.ArgumentTypeError(f"{name} must be between {minimum} and {maximum}")
     return parsed
 
 
@@ -715,9 +815,7 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
         default=DEFAULT_POLL_SECONDS,
     )
-    parser.add_argument(
-        "--report-json", type=Path, default=DEFAULT_REPORT_JSON_PATH
-    )
+    parser.add_argument("--report-json", type=Path, default=DEFAULT_REPORT_JSON_PATH)
     parser.add_argument("--report-md", type=Path, default=DEFAULT_REPORT_MD_PATH)
     return parser
 
@@ -753,6 +851,9 @@ __all__ = [
     "main",
     "render_markdown_report",
     "run_controlled_eval",
+    "summarize_active_campaigns",
     "summarize_campaign_records",
     "summarize_latest_run",
+    "summarize_latest_policy_decision",
+    "summarize_queue_state",
 ]

--- a/tests/unit/test_controlled_eval.py
+++ b/tests/unit/test_controlled_eval.py
@@ -51,6 +51,23 @@ def _registry(record: dict | None = None) -> dict:
     return {"campaigns": {record["campaign_id"]: record} if record else {}}
 
 
+def _idle_no_candidates_policy() -> dict:
+    return {
+        "decision": {"action": "idle_noop", "reason": "no_candidates"},
+        "rules_evaluated": [
+            {"rule_id": "R3_single_worker", "result": "allow"},
+            {
+                "rule_id": "R4_R7_filtering",
+                "result": "candidates",
+                "surviving": 0,
+                "rejected": 7,
+            },
+            {"rule_id": "R8_idle", "result": "fire"},
+        ],
+        "candidates_considered": [],
+    }
+
+
 def _ledger_event(
     *,
     campaign_id: str = "col-1",
@@ -91,6 +108,8 @@ def test_report_summarization_from_fake_payloads() -> None:
             "stop_conditions": "present",
             "spawn_proposals": "present",
         },
+        latest_policy_decision_payload=None,
+        queue_payload={"queue": []},
         ticks=[],
         generated_at_utc=datetime(2026, 5, 22, 12, 0, tzinfo=UTC),
     )
@@ -127,6 +146,8 @@ def test_degenerate_no_survivors_is_useful_meaningful_failure() -> None:
             "stop_conditions": "present",
             "spawn_proposals": "present",
         },
+        latest_policy_decision_payload=None,
+        queue_payload={"queue": []},
         ticks=[],
     )
 
@@ -158,6 +179,8 @@ def test_missing_intelligence_artifacts_are_reported_as_observability_gap() -> N
             "stop_conditions": "missing",
             "spawn_proposals": "missing",
         },
+        latest_policy_decision_payload=None,
+        queue_payload={"queue": []},
         ticks=[],
     )
 
@@ -165,6 +188,162 @@ def test_missing_intelligence_artifacts_are_reported_as_observability_gap() -> N
     assert "missing_intelligence_artifacts" in payload["verdict"]["reason_codes"]
     assert payload["recommended_next_action"] == "inspect_failure_observability"
     assert payload["intelligence_artifact_status"]["information_gain"] == "missing"
+
+
+def test_no_completed_campaign_with_no_candidates_policy_is_diagnostic() -> None:
+    payload = ce.build_report_payload(
+        profile="crypto_exploratory_v1",
+        max_campaigns=3,
+        sprint_started_by_harness=False,
+        sprint_reused=True,
+        observed_total_before=0,
+        observed_total_after=0,
+        campaigns_attempted=3,
+        sprint_registry=_sprint_registry(),
+        sprint_progress={"state": "active"},
+        registry=_registry(),
+        ledger_events=[],
+        run_campaign_payload=None,
+        latest_policy_decision_payload=_idle_no_candidates_policy(),
+        queue_payload={
+            "queue": [
+                {"campaign_id": "old-done", "state": "completed"},
+                {"campaign_id": "old-failed", "state": "failed"},
+            ]
+        },
+        intelligence_artifact_status={
+            "information_gain": "missing",
+            "viability": "missing",
+            "stop_conditions": "missing",
+            "spawn_proposals": "missing",
+        },
+        ticks=[
+            ce.LauncherTick(
+                tick_index=1,
+                returncode=0,
+                timed_out=False,
+                elapsed_seconds=0,
+                stdout_tail="",
+                stderr_tail="",
+                completed_campaign_ids=(),
+            )
+        ],
+    )
+
+    assert payload["campaigns_completed"] == 0
+    assert payload["latest_policy_decision_present"] is True
+    assert payload["latest_policy_action"] == "idle_noop"
+    assert payload["latest_policy_reason"] == "no_candidates"
+    assert payload["latest_policy_candidates_considered_count"] == 0
+    assert payload["latest_policy_rules_summary"]["R4_R7_filtering"]["surviving"] == 0
+    assert payload["latest_policy_rules_summary"]["R4_R7_filtering"]["rejected"] == 7
+    assert payload["latest_policy_rules_summary"]["R8_idle"]["result"] == "fire"
+    assert payload["active_campaign_count"] == 0
+    assert payload["queue_item_count"] == 2
+    assert payload["queue_active_count"] == 0
+    assert payload["queue_terminal_count"] == 2
+    assert payload["verdict"]["status"] == "no_campaign_completed"
+    assert "no_candidates_policy_block" in payload["verdict"]["reason_codes"]
+    assert payload["recommended_next_action"] == "inspect_campaign_policy_filters"
+
+    markdown = ce.render_markdown_report(payload)
+    assert "- Latest launcher decision: idle_noop / no_candidates" in markdown
+    assert "- Candidates considered: 0" in markdown
+    assert "- R4_R7 surviving: 0" in markdown
+    assert "- Active campaigns: 0" in markdown
+    assert "- Policy/no-candidate condition, not a running campaign: True" in markdown
+
+
+def test_active_campaign_count_includes_nonterminal_registry_records() -> None:
+    registry = {
+        "campaigns": {
+            "col-leased": {
+                "campaign_id": "col-leased",
+                "preset_name": "trend_pullback_crypto_1h",
+                "state": "leased",
+                "spawned_at_utc": "2026-05-22T10:01:00Z",
+                "extra": {"sprint_id": "sprt-test"},
+            },
+            "col-running": {
+                "campaign_id": "col-running",
+                "preset_name": "trend_pullback_crypto_1h",
+                "state": "running",
+                "spawned_at_utc": "2026-05-22T10:02:00Z",
+                "extra": {"sprint_id": "sprt-test"},
+            },
+            "col-completed": _completed_campaign(campaign_id="col-completed"),
+        }
+    }
+    payload = ce.build_report_payload(
+        profile="crypto_exploratory_v1",
+        max_campaigns=3,
+        sprint_started_by_harness=False,
+        sprint_reused=True,
+        observed_total_before=0,
+        observed_total_after=0,
+        campaigns_attempted=1,
+        sprint_registry=_sprint_registry(),
+        sprint_progress={"state": "active"},
+        registry=registry,
+        ledger_events=[],
+        run_campaign_payload=None,
+        latest_policy_decision_payload=None,
+        queue_payload={
+            "queue": [
+                {"campaign_id": "col-leased", "state": "leased"},
+                {"campaign_id": "col-running", "state": "running"},
+                {"campaign_id": "old-failed", "state": "failed"},
+            ]
+        },
+        intelligence_artifact_status={
+            "information_gain": "present",
+            "viability": "present",
+            "stop_conditions": "present",
+            "spawn_proposals": "present",
+        },
+        ticks=[],
+    )
+
+    assert payload["active_campaign_count"] == 2
+    assert payload["active_campaign_ids"] == ["col-leased", "col-running"]
+    assert payload["queue_item_count"] == 3
+    assert payload["queue_active_count"] == 2
+    assert payload["queue_terminal_count"] == 1
+
+
+def test_missing_policy_decision_is_handled_gracefully() -> None:
+    payload = ce.build_report_payload(
+        profile="crypto_exploratory_v1",
+        max_campaigns=1,
+        sprint_started_by_harness=True,
+        sprint_reused=False,
+        observed_total_before=0,
+        observed_total_after=0,
+        campaigns_attempted=1,
+        sprint_registry=_sprint_registry(),
+        sprint_progress={"state": "active"},
+        registry=_registry(),
+        ledger_events=[],
+        run_campaign_payload=None,
+        latest_policy_decision_payload=None,
+        queue_payload=None,
+        intelligence_artifact_status={
+            "information_gain": "missing",
+            "viability": "missing",
+            "stop_conditions": "missing",
+            "spawn_proposals": "missing",
+        },
+        ticks=[],
+    )
+
+    assert payload["latest_policy_decision_present"] is False
+    assert payload["latest_policy_action"] is None
+    assert payload["latest_policy_reason"] is None
+    assert payload["latest_policy_candidates_considered_count"] == 0
+    assert payload["latest_policy_rules_summary"] == {}
+    assert payload["verdict"]["status"] == "no_campaign_completed"
+    assert payload["verdict"]["reason_codes"] == ["no_campaign_completed"]
+    assert payload["recommended_next_action"] == "rerun_with_more_campaigns"
 
 
 def test_max_campaigns_cap_is_enforced(
@@ -194,6 +373,7 @@ def test_max_campaigns_cap_is_enforced(
     )
     monkeypatch.setattr(ce.ds, "load_sprint_registry", _sprint_registry)
     monkeypatch.setattr(ce, "load_registry", lambda _path: {"campaigns": {}})
+    monkeypatch.setattr(ce, "load_queue", lambda _path: {"queue": []})
     monkeypatch.setattr(ce, "load_events", lambda _path: [])
     monkeypatch.setattr(ce, "_read_json", lambda _path: None)
     monkeypatch.setattr(
@@ -243,6 +423,7 @@ def test_cli_smoke_with_mocked_launcher_invocation(
     )
     monkeypatch.setattr(ce.ds, "load_sprint_registry", _sprint_registry)
     monkeypatch.setattr(ce, "load_registry", lambda _path: {"campaigns": {}})
+    monkeypatch.setattr(ce, "load_queue", lambda _path: {"queue": []})
     monkeypatch.setattr(ce, "load_events", lambda _path: [])
     monkeypatch.setattr(ce, "_read_json", lambda _path: None)
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- Add controlled_eval diagnostics for latest idle_noop/no_candidates policy decisions.
- Report active registry campaigns and queue active/terminal counts for zero-completion runs.
- Update markdown bottleneck output and unit coverage for missing policy artifacts and active campaigns.

## Validation
- python -m pytest tests/unit/test_controlled_eval.py
- python -m pytest tests/unit/test_campaign_queue.py tests/unit/test_campaign_policy.py
- python -m ruff check research/controlled_eval.py tests/unit/test_controlled_eval.py
- python -m ruff format --check research/controlled_eval.py tests/unit/test_controlled_eval.py