### PR TITLE
ARCH-001 Domain Import Scanner

### DIFF
--- a/reporting/architecture_import_scan.py
+++ b/reporting/architecture_import_scan.py
@@ -1,0 +1,502 @@
+"""Deterministic repo-local Python import scanner for architecture review.
+
+The scanner is intentionally static: it enumerates tracked Python files with
+``git ls-files`` and parses import statements with ``ast``. It never imports
+the modules it inspects.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import subprocess
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+DOMAIN_ADE = "ADE"
+DOMAIN_QRE = "QRE"
+DOMAIN_CONTROL_PLANE = "control-plane"
+DOMAIN_EXECUTION = "execution"
+DOMAIN_TESTS = "tests"
+DOMAIN_GOVERNANCE_TOOLING = "governance tooling"
+DOMAIN_UNKNOWN = "unknown"
+
+EXECUTION_PATH_ROOTS = frozenset(
+    {
+        "agent.execution",
+        "agent.risk",
+        "automation.live_gate",
+        "broker",
+        "execution",
+        "live",
+        "paper",
+        "risk",
+        "shadow",
+    }
+)
+
+# Existing mixed-domain imports observed by ARCH-000. These remain visible in
+# legacy reports, but they do not block ARCH-001 while package boundaries are
+# still being prepared.
+KNOWN_LEGACY_EDGE_ALLOWLIST = frozenset(
+    {
+        ("dashboard.api_campaigns", "research.campaign_digest"),
+        ("dashboard.api_campaigns", "research.campaign_budget"),
+        ("dashboard.api_campaigns", "research.campaign_family_policy"),
+        ("dashboard.api_campaigns", "research.campaign_followup"),
+        ("dashboard.api_campaigns", "research.campaign_launcher"),
+        ("dashboard.api_campaigns", "research.campaign_policy"),
+        ("dashboard.api_campaigns", "research.campaign_preset_policy"),
+        ("dashboard.api_campaigns", "research.campaign_queue"),
+        ("dashboard.api_campaigns", "research.campaign_registry"),
+        ("dashboard.api_campaigns", "research.campaign_templates"),
+        ("dashboard.api_observability", "research.diagnostics.paths"),
+        ("dashboard.api_research_intelligence", "research.dead_zone_detection"),
+        ("dashboard.api_research_intelligence", "research.funnel_spawn_proposer"),
+        ("dashboard.api_research_intelligence", "research.information_gain"),
+        ("dashboard.api_research_intelligence", "research.research_evidence_ledger"),
+        ("dashboard.api_research_intelligence", "research.stop_condition_engine"),
+        ("dashboard.api_research_intelligence", "research.viability_metrics"),
+        ("dashboard.dashboard", "data.contracts"),
+        ("dashboard.dashboard", "data.repository"),
+        ("dashboard.dashboard", "research.presets"),
+        ("dashboard.research_runner", "research.run_state"),
+        ("reporting.hypothesis_discovery_summary", "research.hypothesis_discovery"),
+        (
+            "reporting.hypothesis_discovery_summary",
+            "research.hypothesis_discovery.campaign_seed_proposer",
+        ),
+        ("reporting.intelligent_routing", "research.presets"),
+    }
+)
+
+
+@dataclass(frozen=True)
+class ImportEdge:
+    source_module: str
+    target_module: str
+    source_path: str
+    source_domain: str
+    target_domain: str
+    target_root: str
+    line: int
+    import_kind: str
+    target_path: str | None = None
+
+
+@dataclass(frozen=True)
+class BoundaryFinding:
+    source_module: str
+    target_module: str
+    source_path: str
+    source_domain: str
+    target_domain: str
+    target_root: str
+    line: int
+    rule: str
+
+
+@dataclass(frozen=True)
+class BoundaryReport:
+    edges: tuple[ImportEdge, ...]
+    forbidden_edges: tuple[BoundaryFinding, ...]
+    legacy_edges: tuple[BoundaryFinding, ...]
+
+
+def tracked_python_files(repo_root: Path) -> tuple[Path, ...]:
+    """Return tracked Python files relative to ``repo_root`` in stable order."""
+    result = subprocess.run(
+        ["git", "ls-files", "*.py"],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    files = [
+        Path(line.strip())
+        for line in result.stdout.splitlines()
+        if line.strip() and not _is_generated_or_cache_path(line.strip())
+    ]
+    return tuple(sorted(files, key=_path_sort_key))
+
+
+def scan_repo(repo_root: Path) -> BoundaryReport:
+    tracked_files = tracked_python_files(repo_root)
+    return scan_files(repo_root, tracked_files)
+
+
+def scan_files(repo_root: Path, relative_paths: Iterable[Path]) -> BoundaryReport:
+    paths = tuple(sorted(relative_paths, key=_path_sort_key))
+    module_index = _module_index(paths)
+    edges: list[ImportEdge] = []
+    for path in paths:
+        edges.extend(_imports_in_file(repo_root, path, module_index))
+    return evaluate_edges(tuple(sorted(edges, key=_edge_sort_key)))
+
+
+def evaluate_edges(edges: Sequence[ImportEdge]) -> BoundaryReport:
+    forbidden: list[BoundaryFinding] = []
+    legacy: list[BoundaryFinding] = []
+
+    for edge in sorted(edges, key=_edge_sort_key):
+        rule = _closed_forbidden_rule(edge)
+        legacy_rule = _legacy_rule(edge)
+        if rule:
+            finding = _finding(edge, rule)
+            if _is_allowlisted_legacy(edge):
+                legacy.append(finding)
+            else:
+                forbidden.append(finding)
+            continue
+        if legacy_rule:
+            legacy.append(_finding(edge, legacy_rule))
+
+    return BoundaryReport(
+        edges=tuple(sorted(edges, key=_edge_sort_key)),
+        forbidden_edges=tuple(sorted(forbidden, key=_finding_sort_key)),
+        legacy_edges=tuple(sorted(legacy, key=_finding_sort_key)),
+    )
+
+
+def classify_path(path: Path | str) -> str:
+    normalized = _normalize_path(path)
+    first = normalized.split("/", 1)[0]
+
+    if first == "tests":
+        return DOMAIN_TESTS
+    if normalized.startswith(".claude/hooks/") or first == "scripts":
+        return DOMAIN_GOVERNANCE_TOOLING
+    if first == "dashboard" or first == "frontend":
+        return DOMAIN_CONTROL_PLANE
+    if first == "reporting":
+        return DOMAIN_ADE
+    if normalized.startswith("agent/execution/") or normalized.startswith("agent/risk/"):
+        return DOMAIN_EXECUTION
+    if first in {"automation", "broker", "execution", "live", "paper", "risk", "shadow"}:
+        return DOMAIN_EXECUTION
+    if first in {"agent", "data", "research", "strategies"}:
+        return DOMAIN_QRE
+    if first in {"config", "ops", "orchestration", "state"}:
+        return DOMAIN_UNKNOWN
+    return DOMAIN_UNKNOWN
+
+
+def classify_module(module_name: str, module_index: dict[str, Path] | None = None) -> str:
+    if module_index and module_name in module_index:
+        return classify_path(module_index[module_name])
+
+    top = module_name.split(".", 1)[0]
+    if top == "tests":
+        return DOMAIN_TESTS
+    if top == "dashboard":
+        return DOMAIN_CONTROL_PLANE
+    if top == "reporting":
+        return DOMAIN_ADE
+    if module_name.startswith(("agent.execution", "agent.risk")):
+        return DOMAIN_EXECUTION
+    if top in {"automation", "broker", "execution", "live", "paper", "risk", "shadow"}:
+        return DOMAIN_EXECUTION
+    if top in {"agent", "data", "research", "strategies"}:
+        return DOMAIN_QRE
+    if top == "scripts":
+        return DOMAIN_GOVERNANCE_TOOLING
+    return DOMAIN_UNKNOWN
+
+
+def report_to_dict(report: BoundaryReport) -> dict[str, object]:
+    return {
+        "edge_count": len(report.edges),
+        "forbidden_edge_count": len(report.forbidden_edges),
+        "legacy_edge_count": len(report.legacy_edges),
+        "forbidden_edges": [asdict(finding) for finding in report.forbidden_edges],
+        "legacy_edges": [asdict(finding) for finding in report.legacy_edges],
+        "edges": [asdict(edge) for edge in report.edges],
+    }
+
+
+def report_to_text(report: BoundaryReport) -> str:
+    lines = [
+        "ARCH-001 domain import scan",
+        f"edges: {len(report.edges)}",
+        f"forbidden_edges: {len(report.forbidden_edges)}",
+        f"legacy_edges: {len(report.legacy_edges)}",
+        "",
+        "Forbidden edges:",
+    ]
+    lines.extend(_format_findings(report.forbidden_edges))
+    lines.append("")
+    lines.append("Legacy/report-only edges:")
+    lines.extend(_format_findings(report.legacy_edges))
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", default=".", help="Repository root to scan.")
+    parser.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="json",
+        help="Deterministic report format.",
+    )
+    args = parser.parse_args(argv)
+
+    report = scan_repo(Path(args.repo_root).resolve())
+    if args.format == "json":
+        print(json.dumps(report_to_dict(report), indent=2, sort_keys=True))
+    else:
+        print(report_to_text(report), end="")
+    return 1 if report.forbidden_edges else 0
+
+
+def _imports_in_file(
+    repo_root: Path,
+    relative_path: Path,
+    module_index: dict[str, Path],
+) -> list[ImportEdge]:
+    full_path = repo_root / relative_path
+    tree = ast.parse(full_path.read_text(encoding="utf-8"), filename=str(full_path))
+    source_module = _module_name_from_path(relative_path)
+    source_domain = classify_path(relative_path)
+    edges: list[ImportEdge] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in sorted(node.names, key=lambda item: item.name):
+                edges.append(
+                    _edge(
+                        source_module=source_module,
+                        source_path=relative_path,
+                        source_domain=source_domain,
+                        target_module=alias.name,
+                        line=node.lineno,
+                        import_kind="import",
+                        module_index=module_index,
+                    )
+                )
+        elif isinstance(node, ast.ImportFrom):
+            for target in _targets_from_import_from(node, source_module, relative_path, module_index):
+                edges.append(
+                    _edge(
+                        source_module=source_module,
+                        source_path=relative_path,
+                        source_domain=source_domain,
+                        target_module=target,
+                        line=node.lineno,
+                        import_kind="from",
+                        module_index=module_index,
+                    )
+                )
+    return edges
+
+
+def _targets_from_import_from(
+    node: ast.ImportFrom,
+    source_module: str,
+    source_path: Path,
+    module_index: dict[str, Path],
+) -> tuple[str, ...]:
+    if node.level:
+        base = _resolve_relative_base(source_module, source_path, node.level)
+        if base is None:
+            return tuple()
+        module_base = ".".join(part for part in (base, node.module or "") if part)
+    else:
+        module_base = node.module or ""
+
+    if not module_base:
+        return tuple()
+
+    targets = {
+        _resolve_import_from_target(module_base, alias.name, module_index)
+        for alias in node.names
+    }
+    return tuple(sorted(targets))
+
+
+def _edge(
+    *,
+    source_module: str,
+    source_path: Path,
+    source_domain: str,
+    target_module: str,
+    line: int,
+    import_kind: str,
+    module_index: dict[str, Path],
+) -> ImportEdge:
+    resolved_target = _resolve_known_module(target_module, module_index)
+    target_path = module_index.get(resolved_target)
+    target_root = _target_root(resolved_target, target_path)
+    return ImportEdge(
+        source_module=source_module,
+        target_module=resolved_target,
+        source_path=_normalize_path(source_path),
+        source_domain=source_domain,
+        target_domain=classify_module(resolved_target, module_index),
+        target_root=target_root,
+        target_path=_normalize_path(target_path) if target_path else None,
+        line=line,
+        import_kind=import_kind,
+    )
+
+
+def _resolve_import_from_target(
+    module_base: str,
+    imported_name: str,
+    module_index: dict[str, Path],
+) -> str:
+    if imported_name == "*":
+        return _resolve_known_module(module_base, module_index)
+    candidate = f"{module_base}.{imported_name}"
+    if candidate in module_index or _has_module_descendant(candidate, module_index):
+        return _resolve_known_module(candidate, module_index)
+    return _resolve_known_module(module_base, module_index)
+
+
+def _resolve_known_module(module_name: str, module_index: dict[str, Path]) -> str:
+    parts = module_name.split(".")
+    for end in range(len(parts), 0, -1):
+        candidate = ".".join(parts[:end])
+        if candidate in module_index:
+            return candidate
+    return module_name
+
+
+def _resolve_relative_base(
+    source_module: str,
+    source_path: Path,
+    level: int,
+) -> str | None:
+    if source_path.name == "__init__.py":
+        package = source_module
+    elif "." in source_module:
+        package = source_module.rsplit(".", 1)[0]
+    else:
+        package = ""
+    package_parts = package.split(".") if package else []
+    keep = len(package_parts) - level + 1
+    if keep < 0:
+        return None
+    return ".".join(package_parts[:keep])
+
+
+def _module_index(paths: Iterable[Path]) -> dict[str, Path]:
+    return {_module_name_from_path(path): path for path in paths}
+
+
+def _module_name_from_path(path: Path) -> str:
+    normalized = _normalize_path(path)
+    without_suffix = normalized.removesuffix(".py")
+    parts = without_suffix.split("/")
+    if parts[-1] == "__init__":
+        parts = parts[:-1]
+    return ".".join(part for part in parts if part)
+
+
+def _target_root(module_name: str, target_path: Path | None) -> str:
+    if target_path is not None:
+        return _normalize_path(target_path).split("/", 1)[0]
+    return module_name.split(".", 1)[0]
+
+
+def _closed_forbidden_rule(edge: ImportEdge) -> str | None:
+    if edge.source_domain == DOMAIN_TESTS:
+        return None
+    if edge.source_domain == DOMAIN_CONTROL_PLANE and edge.target_domain == DOMAIN_QRE:
+        return "control-plane-to-qre"
+    if edge.source_domain == DOMAIN_ADE and edge.target_domain == DOMAIN_QRE:
+        return "ade-to-qre"
+    if edge.source_domain == DOMAIN_QRE and edge.source_path.startswith("research/") and (
+        edge.target_domain == DOMAIN_EXECUTION or _matches_prefix(edge.target_module, EXECUTION_PATH_ROOTS)
+    ):
+        return "qre-to-execution"
+    return None
+
+
+def _legacy_rule(edge: ImportEdge) -> str | None:
+    if edge.source_domain == DOMAIN_TESTS:
+        return None
+    if edge.source_domain == DOMAIN_UNKNOWN or edge.target_domain == DOMAIN_UNKNOWN:
+        return None
+    if edge.source_domain == edge.target_domain:
+        return None
+    return "mixed-domain"
+
+
+def _is_allowlisted_legacy(edge: ImportEdge) -> bool:
+    return (edge.source_module, edge.target_module) in KNOWN_LEGACY_EDGE_ALLOWLIST
+
+
+def _finding(edge: ImportEdge, rule: str) -> BoundaryFinding:
+    return BoundaryFinding(
+        source_module=edge.source_module,
+        target_module=edge.target_module,
+        source_path=edge.source_path,
+        source_domain=edge.source_domain,
+        target_domain=edge.target_domain,
+        target_root=edge.target_root,
+        line=edge.line,
+        rule=rule,
+    )
+
+
+def _format_findings(findings: Sequence[BoundaryFinding]) -> list[str]:
+    if not findings:
+        return ["- none"]
+    return [
+        (
+            f"- {finding.rule}: {finding.source_module}:{finding.line} -> "
+            f"{finding.target_module} ({finding.source_domain} -> {finding.target_domain})"
+        )
+        for finding in sorted(findings, key=_finding_sort_key)
+    ]
+
+
+def _finding_sort_key(finding: BoundaryFinding) -> tuple[str, int, str, str]:
+    return (
+        finding.source_path,
+        finding.line,
+        finding.source_module,
+        finding.target_module,
+    )
+
+
+def _edge_sort_key(edge: ImportEdge) -> tuple[str, int, str, str, str]:
+    return (
+        edge.source_path,
+        edge.line,
+        edge.source_module,
+        edge.target_module,
+        edge.import_kind,
+    )
+
+
+def _path_sort_key(path: Path | str) -> str:
+    return _normalize_path(path)
+
+
+def _normalize_path(path: Path | str | None) -> str:
+    if path is None:
+        return ""
+    return str(path).replace("\\", "/")
+
+
+def _has_module_descendant(module_name: str, module_index: dict[str, Path]) -> bool:
+    prefix = module_name + "."
+    return any(name.startswith(prefix) for name in module_index)
+
+
+def _matches_prefix(module_name: str, prefixes: Iterable[str]) -> bool:
+    return any(module_name == prefix or module_name.startswith(prefix + ".") for prefix in prefixes)
+
+
+def _is_generated_or_cache_path(path: str) -> bool:
+    normalized = _normalize_path(path)
+    parts = normalized.split("/")
+    return "__pycache__" in parts or normalized.startswith((".tmp/", "tests_tmp/"))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/architecture/test_domain_import_scanner.py
+++ b/tests/architecture/test_domain_import_scanner.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from reporting.architecture_import_scan import (
+    DOMAIN_ADE,
+    DOMAIN_CONTROL_PLANE,
+    DOMAIN_EXECUTION,
+    DOMAIN_GOVERNANCE_TOOLING,
+    DOMAIN_QRE,
+    DOMAIN_TESTS,
+    ImportEdge,
+    classify_path,
+    evaluate_edges,
+    report_to_dict,
+    report_to_text,
+    scan_files,
+    scan_repo,
+    tracked_python_files,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_tracked_python_files_excludes_untracked_files(tmp_path: Path) -> None:
+    _git(tmp_path, "init")
+    tracked = tmp_path / "pkg" / "tracked.py"
+    untracked = tmp_path / "pkg" / "untracked.py"
+    tracked.parent.mkdir()
+    tracked.write_text("import os\n", encoding="utf-8")
+    untracked.write_text("import sys\n", encoding="utf-8")
+    _git(tmp_path, "add", "pkg/tracked.py")
+    _git(tmp_path, "commit", "-m", "add tracked file")
+
+    assert tracked_python_files(tmp_path) == (Path("pkg/tracked.py"),)
+
+
+def test_scanner_parses_imports_deterministically(tmp_path: Path) -> None:
+    source = tmp_path / "dashboard" / "api.py"
+    target = tmp_path / "research" / "campaigns.py"
+    source.parent.mkdir()
+    target.parent.mkdir()
+    source.write_text(
+        "\n".join(
+            [
+                "from research import campaigns",
+                "import reporting.execution_authority",
+                "import os",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    target.write_text("VALUE = 1\n", encoding="utf-8")
+
+    first = scan_files(
+        tmp_path,
+        (Path("dashboard/api.py"), Path("research/campaigns.py")),
+    )
+    second = scan_files(
+        tmp_path,
+        (Path("research/campaigns.py"), Path("dashboard/api.py")),
+    )
+
+    assert first.edges == second.edges
+    assert [
+        (edge.source_module, edge.target_module, edge.source_path, edge.target_root)
+        for edge in first.edges
+    ] == [
+        ("dashboard.api", "research.campaigns", "dashboard/api.py", "research"),
+        (
+            "dashboard.api",
+            "reporting.execution_authority",
+            "dashboard/api.py",
+            "reporting",
+        ),
+        ("dashboard.api", "os", "dashboard/api.py", "os"),
+    ]
+
+
+def test_domain_classifier_assigns_expected_domains() -> None:
+    assert classify_path("reporting/execution_authority.py") == DOMAIN_ADE
+    assert classify_path("research/run_research.py") == DOMAIN_QRE
+    assert classify_path("dashboard/api_campaigns.py") == DOMAIN_CONTROL_PLANE
+    assert classify_path("execution/protocols.py") == DOMAIN_EXECUTION
+    assert classify_path("tests/architecture/test_x.py") == DOMAIN_TESTS
+    assert classify_path(".claude/hooks/deny_no_touch.py") == DOMAIN_GOVERNANCE_TOOLING
+    assert classify_path("scripts/governance_lint.py") == DOMAIN_GOVERNANCE_TOOLING
+
+
+def test_relative_imports_are_resolved(tmp_path: Path) -> None:
+    init_file = tmp_path / "research" / "diagnostics" / "__init__.py"
+    cli_file = tmp_path / "research" / "diagnostics" / "cli.py"
+    io_file = tmp_path / "research" / "diagnostics" / "io.py"
+    init_file.parent.mkdir(parents=True)
+    init_file.write_text("", encoding="utf-8")
+    cli_file.write_text("from . import io\n", encoding="utf-8")
+    io_file.write_text("VALUE = 1\n", encoding="utf-8")
+
+    report = scan_files(
+        tmp_path,
+        (
+            Path("research/diagnostics/__init__.py"),
+            Path("research/diagnostics/cli.py"),
+            Path("research/diagnostics/io.py"),
+        ),
+    )
+
+    targets = {
+        edge.target_module
+        for edge in report.edges
+        if edge.source_module == "research.diagnostics.cli"
+    }
+    assert "research.diagnostics.io" in targets
+
+
+def test_forbidden_edge_rules_fail_on_synthetic_closed_violations() -> None:
+    edges = (
+        ImportEdge(
+            source_module="dashboard.api_new",
+            target_module="research.campaign_policy",
+            source_path="dashboard/api_new.py",
+            source_domain=DOMAIN_CONTROL_PLANE,
+            target_domain=DOMAIN_QRE,
+            target_root="research",
+            line=3,
+            import_kind="from",
+        ),
+        ImportEdge(
+            source_module="research.new_policy",
+            target_module="execution.protocols",
+            source_path="research/new_policy.py",
+            source_domain=DOMAIN_QRE,
+            target_domain=DOMAIN_EXECUTION,
+            target_root="execution",
+            line=7,
+            import_kind="import",
+        ),
+    )
+
+    report = evaluate_edges(edges)
+
+    assert [finding.rule for finding in report.forbidden_edges] == [
+        "control-plane-to-qre",
+        "qre-to-execution",
+    ]
+    assert report.legacy_edges == ()
+
+
+def test_known_legacy_edges_report_without_forbidden_failure() -> None:
+    edge = ImportEdge(
+        source_module="reporting.intelligent_routing",
+        target_module="research.presets",
+        source_path="reporting/intelligent_routing.py",
+        source_domain=DOMAIN_ADE,
+        target_domain=DOMAIN_QRE,
+        target_root="research",
+        line=10,
+        import_kind="from",
+    )
+
+    report = evaluate_edges((edge,))
+
+    assert report.forbidden_edges == ()
+    assert len(report.legacy_edges) == 1
+    assert report.legacy_edges[0].rule == "ade-to-qre"
+
+
+def test_tests_classification_is_required_for_boundary_exemption() -> None:
+    test_edge = ImportEdge(
+        source_module="tests.unit.test_research",
+        target_module="execution.protocols",
+        source_path="tests/unit/test_research.py",
+        source_domain=DOMAIN_TESTS,
+        target_domain=DOMAIN_EXECUTION,
+        target_root="execution",
+        line=5,
+        import_kind="import",
+    )
+    prod_edge = ImportEdge(
+        source_module="research.test_named_helper",
+        target_module="execution.protocols",
+        source_path="research/test_named_helper.py",
+        source_domain=DOMAIN_QRE,
+        target_domain=DOMAIN_EXECUTION,
+        target_root="execution",
+        line=5,
+        import_kind="import",
+    )
+
+    report = evaluate_edges((test_edge, prod_edge))
+
+    assert [finding.source_module for finding in report.forbidden_edges] == [
+        "research.test_named_helper"
+    ]
+
+
+def test_scanner_does_not_import_or_execute_target_modules(tmp_path: Path) -> None:
+    _git(tmp_path, "init")
+    source = tmp_path / "source.py"
+    target = tmp_path / "target.py"
+    sentinel = tmp_path / "executed.txt"
+    source.write_text("import target\n", encoding="utf-8")
+    target.write_text(
+        f"from pathlib import Path\nPath({str(sentinel)!r}).write_text('executed')\n",
+        encoding="utf-8",
+    )
+    _git(tmp_path, "add", "source.py", "target.py")
+    _git(tmp_path, "commit", "-m", "add import graph")
+
+    report = scan_repo(tmp_path)
+
+    assert any(edge.target_module == "target" for edge in report.edges)
+    assert not sentinel.exists()
+
+
+def test_repo_scan_has_no_closed_forbidden_edges_and_reports_legacy() -> None:
+    report = scan_repo(REPO_ROOT)
+
+    assert report.forbidden_edges == ()
+    assert report.legacy_edges
+
+
+def test_report_surfaces_are_deterministic_json_and_text() -> None:
+    edge = ImportEdge(
+        source_module="dashboard.api",
+        target_module="research.run_state",
+        source_path="dashboard/api.py",
+        source_domain=DOMAIN_CONTROL_PLANE,
+        target_domain=DOMAIN_QRE,
+        target_root="research",
+        line=1,
+        import_kind="from",
+    )
+    report = evaluate_edges((edge,))
+
+    rendered_json = json.dumps(report_to_dict(report), indent=2, sort_keys=True)
+    rendered_text = report_to_text(report)
+
+    assert rendered_json == json.dumps(report_to_dict(report), indent=2, sort_keys=True)
+    assert rendered_text == report_to_text(report)
+    assert "ARCH-001 domain import scan" in rendered_text
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.email=architecture-tests@example.invalid",
+            "-c",
+            "user.name=Architecture Tests",
+            *args,
+        ],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )


### PR DESCRIPTION
## Summary
- add a stdlib-only tracked Python import scanner under reporting architecture tooling
- classify source and target domains and separate closed forbidden edges from legacy/report-only edges
- add architecture tests for deterministic parsing, relative imports, closed-boundary failures, legacy reporting, and no module execution

## Validation
- pytest tests/architecture/test_domain_boundary_smoke.py -q
- pytest tests/architecture -q
- pytest tests/unit/test_observability_static_import_surface.py -q
- pytest tests/unit/test_intelligent_routing_import_safety.py -q
- pytest tests/functional/test_static_import_surface.py -q (13 skipped)
- python -m reporting.architecture_import_scan --format text