### PR TITLE
test: add ARCH-003 import boundary enforcement gate

### DIFF
--- a/docs/architecture/ARCH-003-import-boundary-enforcement-gate.md
+++ b/docs/architecture/ARCH-003-import-boundary-enforcement-gate.md
@@ -1,0 +1,119 @@
+# ARCH-003 - Import Boundary Enforcement Gate
+
+Status: enforcement gate
+Date: 2026-05-22
+Branch: `test/arch-003-import-boundary-enforcement-gate`
+Builds on: `docs/architecture/ARCH-000-architecture-diagnosis-gate.md`,
+`docs/architecture/ARCH-002-import-boundary-baseline.md`,
+`reporting/architecture_import_scan.py`
+
+## 1. Purpose and Scope
+
+ARCH-003 adds the first narrow closed import-boundary gate after the ARCH-002
+baseline. It uses the ARCH-001 static scanner and does not move files, rename
+packages, perform package extraction, change runtime behavior, change frozen
+contracts, or activate Addendum 1, Addendum 2, Addendum 3, shadow, paper, or
+live work.
+
+The gate is enforcement-hardening only. Existing mixed-domain dashboard,
+reporting, research, governance-tooling, and legacy `agent` findings remain
+report-only unless a later architecture unit explicitly selects them for
+closed enforcement.
+
+## 2. Selected Closed Boundary
+
+Selected boundary:
+
+```text
+production-to-tests
+```
+
+Rule:
+
+```text
+No non-test Python module may directly import a tracked tests.* module.
+```
+
+Evidence supporting this as the first closed gate:
+
+- The ARCH-001 scanner already classifies tracked test files as the `tests`
+  domain.
+- The ARCH-002 baseline reported test imports separately and exempted test
+  source files from production boundary failures.
+- A repo-local text probe found `tests.*` imports only inside test files.
+- The gate does not depend on generated artifacts and does not touch frozen
+  research outputs.
+- The gate does not intersect the known legacy dashboard-to-QRE,
+  control-plane-to-ADE, ADE-to-QRE, or legacy `agent` execution findings.
+
+This boundary prevents production code from taking a dependency on test
+helpers, fixtures, or regression-only modules. Test-to-test imports remain
+allowed.
+
+## 3. Enforcement Mechanism
+
+`reporting/architecture_import_scan.py` now treats any direct import edge with:
+
+```text
+source_domain != tests
+target_domain == tests
+```
+
+as a hard forbidden edge with rule `production-to-tests`.
+
+The scanner remains static and deterministic:
+
+- it scans tracked Python files only;
+- it parses imports with `ast`;
+- it does not import target modules;
+- it keeps the existing deterministic sort order;
+- it exits non-zero only when hard forbidden edges are present.
+
+## 4. Report-Only Legacy Status
+
+The ARCH-002 report-only legacy categories remain report-only:
+
+| Category | ARCH-003 treatment |
+|---|---|
+| Dashboard/control-plane to QRE direct imports | Report-only legacy unless a new non-allowlisted closed edge is introduced. |
+| Dashboard/control-plane to ADE reporting imports | Report-only mixed-domain debt. |
+| ADE reporting helpers to QRE imports | Report-only legacy unless a new non-allowlisted closed edge is introduced. |
+| QRE to ADE reason-record imports | Report-only mixed-domain debt. |
+| Legacy `agent` imports of execution/risk modules | Report-only until active-runtime ownership is settled. |
+| Governance tooling to ADE reporting imports | Report-only governance-tooling coupling. |
+| Execution automation to ADE reporting imports | Report-only until an execution/ADE audit boundary is designed. |
+
+No new allowlist entry is required for `production-to-tests` because the current
+tracked repository has no production-to-tests imports.
+
+## 5. Validation Expectations
+
+ARCH-003 validation should include:
+
+```powershell
+pytest tests/architecture/test_domain_boundary_smoke.py -q
+pytest tests/architecture/test_domain_import_scanner.py -q
+pytest tests/architecture -q
+python -m reporting.architecture_import_scan --format summary
+```
+
+The summary should continue to show zero hard forbidden-edge failures while
+preserving the ARCH-002 legacy/report-only finding count unless unrelated
+mainline changes alter the measured import graph.
+
+## 6. Next Unit
+
+Next recommended unit:
+
+```text
+ARCH-004 - Control-Plane/QRE Adapter Boundary Plan
+```
+
+Purpose: define the adapter boundary for dashboard/control-plane read surfaces
+that currently import QRE modules directly, starting from the documented
+ARCH-002 dashboard-to-`research` and dashboard-to-`data` findings.
+
+ARCH-004 should still avoid file moves. It should produce an evidence-based
+adapter plan, identify read-only endpoint candidates, document response-schema
+preservation requirements, and keep dashboard mutation routes and execution,
+live, paper, shadow, risk, and broker behavior out of scope.

--- a/reporting/architecture_import_scan.py
+++ b/reporting/architecture_import_scan.py
@@ -464,6 +464,8 @@ def _target_root(module_name: str, target_path: Path | None) -> str:
 def _closed_forbidden_rule(edge: ImportEdge) -> str | None:
     if edge.source_domain == DOMAIN_TESTS:
         return None
+    if edge.target_domain == DOMAIN_TESTS:
+        return "production-to-tests"
     if edge.source_domain == DOMAIN_CONTROL_PLANE and edge.target_domain == DOMAIN_QRE:
         return "control-plane-to-qre"
     if edge.source_domain == DOMAIN_ADE and edge.target_domain == DOMAIN_QRE:

--- a/tests/architecture/test_domain_import_scanner.py
+++ b/tests/architecture/test_domain_import_scanner.py
@@ -198,6 +198,36 @@ def test_tests_classification_is_required_for_boundary_exemption() -> None:
     ]
 
 
+def test_production_modules_must_not_import_test_modules() -> None:
+    prod_edge = ImportEdge(
+        source_module="research.new_policy",
+        target_module="tests._harness_helpers",
+        source_path="research/new_policy.py",
+        source_domain=DOMAIN_QRE,
+        target_domain=DOMAIN_TESTS,
+        target_root="tests",
+        line=6,
+        import_kind="from",
+    )
+    test_edge = ImportEdge(
+        source_module="tests.unit.test_new_policy",
+        target_module="tests._harness_helpers",
+        source_path="tests/unit/test_new_policy.py",
+        source_domain=DOMAIN_TESTS,
+        target_domain=DOMAIN_TESTS,
+        target_root="tests",
+        line=4,
+        import_kind="from",
+    )
+
+    report = evaluate_edges((prod_edge, test_edge))
+
+    assert [
+        (finding.rule, finding.source_module) for finding in report.forbidden_edges
+    ] == [("production-to-tests", "research.new_policy")]
+    assert report.legacy_edges == ()
+
+
 def test_scanner_does_not_import_or_execute_target_modules(tmp_path: Path) -> None:
     _git(tmp_path, "init")
     source = tmp_path / "source.py"
@@ -222,6 +252,17 @@ def test_repo_scan_has_no_closed_forbidden_edges_and_reports_legacy() -> None:
 
     assert report.forbidden_edges == ()
     assert report.legacy_edges
+
+
+def test_arch_003_repo_scan_has_no_production_to_tests_imports() -> None:
+    report = scan_repo(REPO_ROOT)
+
+    production_to_tests = [
+        finding
+        for finding in report.forbidden_edges
+        if finding.rule == "production-to-tests"
+    ]
+    assert production_to_tests == []
 
 
 def test_report_surfaces_are_deterministic_json_and_text() -> None:


### PR DESCRIPTION
## Summary
- Added ARCH-003 documentation for the first narrow import-boundary enforcement gate.
- Added a closed `production-to-tests` scanner rule: non-test Python modules may not import tracked `tests.*` modules.
- Added synthetic and repo-scan architecture tests proving production-to-tests imports fail while test-to-test imports remain allowed.

## Selected enforced boundary
`production-to-tests`: no non-test Python module may directly import a tracked `tests.*` module.

## Files changed
- `docs/architecture/ARCH-003-import-boundary-enforcement-gate.md`
- `reporting/architecture_import_scan.py`
- `tests/architecture/test_domain_import_scanner.py`

## Validation commands and results
- `python -m pytest tests/architecture/test_domain_boundary_smoke.py -q` - 40 passed
- `python -m pytest tests/architecture/test_domain_import_scanner.py -q` - 13 passed
- `python -m pytest tests/architecture -q` - 53 passed
- `python -m reporting.architecture_import_scan --format summary` - exit 0, `forbidden_edge_count: 0`, `legacy_edge_count: 74`
- `python -m pytest tests/functional/test_static_import_surface.py -q` - 13 skipped
- `python -m pytest tests/unit/test_observability_static_import_surface.py -q` - 23 passed
- `python -m pytest tests/unit/test_intelligent_routing_import_safety.py -q` - 6 passed
- `git diff --check` - passed

## Frozen contract status
Frozen contracts unchanged. `research/research_latest.json` and `strategy_matrix.csv` were not modified.

## Protected path status
Protected paths untouched. No changes under `.claude/**`, `agent/execution/**`, `agent/risk/**`, `automation/**`, `execution/**`, `broker/**`, `live/**`, `paper/**`, `risk/**`, or `shadow/**`.

## Report-only legacy status
ARCH-002 legacy/mixed-domain findings remain report-only. Scanner summary remains at `forbidden_edge_count: 0` and `legacy_edge_count: 74`; this PR does not broad-fail on dashboard/reporting/research or legacy `agent` edges.

## Next recommended unit
ARCH-004 - Control-Plane/QRE Adapter Boundary Plan. Define the adapter boundary for dashboard/control-plane read surfaces that currently import QRE modules directly, still without file moves or runtime behavior changes.