### PR TITLE
test: harden control-plane QRE import boundary

### DIFF
--- a/docs/architecture/ARCH-004-control-plane-qre-boundary-hardening.md
+++ b/docs/architecture/ARCH-004-control-plane-qre-boundary-hardening.md
@@ -1,0 +1,166 @@
+# ARCH-004 - Control-Plane/QRE Boundary Hardening
+
+Status: enforcement hardening
+Date: 2026-05-22
+Branch: `arch/004-control-plane-qre-boundary-hardening`
+Builds on:
+
+- `docs/architecture/ARCH-000-architecture-diagnosis-gate.md`
+- `docs/architecture/ARCH-002-import-boundary-baseline.md`
+- `docs/architecture/ARCH-003-import-boundary-enforcement-gate.md`
+- `reporting/architecture_import_scan.py`
+
+## 1. Purpose and Scope
+
+ARCH-004 hardens the control-plane/QRE import boundary without moving files,
+renaming packages, extracting packages, changing runtime behavior, changing
+frozen contracts, or adding dashboard mutation routes.
+
+The unit turns the current dashboard-to-QRE direct imports into an audited
+legacy/report-only exception set and keeps all future non-allowlisted
+control-plane-to-QRE imports as hard failures. It also defines the adapter path
+needed before later package extraction readiness can be decided.
+
+This is architecture enforcement and planning only. It does not activate
+Addendum 1, Addendum 2, Addendum 3, shadow, paper, live, broker, risk, or
+execution work.
+
+## 2. Current Boundary Problem
+
+ARCH-002 measured 18 direct control-plane-to-QRE edges:
+
+- 16 `dashboard` to `research` findings;
+- 2 `dashboard` to `data` findings.
+
+These imports make the dashboard/control-plane layer depend directly on QRE
+artifact paths, presets, diagnostics paths, and research intelligence modules.
+They are acceptable as legacy read/report surfaces in the current monorepo, but
+they are not package-extraction-ready boundaries.
+
+The target shape is:
+
+```text
+direct import -> read-only adapter/facade -> contract tests -> package extraction readiness decision
+```
+
+No file move is authorized by ARCH-004. No runtime behavior change is
+authorized by ARCH-004. No dashboard mutation route is authorized by ARCH-004.
+
+## 3. Legacy/Report-Only Direct Imports
+
+The following exact imports are legacy/report-only exceptions. They remain
+visible in scanner reports and do not broad-fail the current repository.
+
+| Source | Target | Why tolerated now | Sunset condition |
+|---|---|---|---|
+| `dashboard.api_campaigns` | `research.campaign_budget` | Campaign dashboard reads a QRE artifact path. | Replace with read-only campaign artifact facade contract. |
+| `dashboard.api_campaigns` | `research.campaign_digest` | Campaign dashboard reads a QRE artifact path. | Replace with read-only campaign artifact facade contract. |
+| `dashboard.api_campaigns` | `research.campaign_family_policy` | Campaign dashboard reads a QRE artifact path. | Replace with read-only campaign artifact facade contract. |
+| `dashboard.api_campaigns` | `research.campaign_policy` | Campaign dashboard reads a QRE artifact path. | Replace with read-only campaign artifact facade contract. |
+| `dashboard.api_campaigns` | `research.campaign_preset_policy` | Campaign dashboard reads a QRE artifact path. | Replace with read-only campaign artifact facade contract. |
+| `dashboard.api_campaigns` | `research.campaign_queue` | Campaign dashboard reads a QRE artifact path. | Replace with read-only campaign artifact facade contract. |
+| `dashboard.api_campaigns` | `research.campaign_registry` | Campaign dashboard reads a QRE artifact path. | Replace with read-only campaign artifact facade contract. |
+| `dashboard.api_observability` | `research.diagnostics.paths` | Observability API reads QRE diagnostics artifact locations. | Replace with read-only diagnostics artifact facade contract. |
+| `dashboard.api_research_intelligence` | `research.dead_zone_detection` | Research intelligence API reads a QRE artifact path. | Replace with read-only intelligence artifact facade contract. |
+| `dashboard.api_research_intelligence` | `research.funnel_spawn_proposer` | Research intelligence API reads a QRE artifact path. | Replace with read-only intelligence artifact facade contract. |
+| `dashboard.api_research_intelligence` | `research.information_gain` | Research intelligence API reads a QRE artifact path. | Replace with read-only intelligence artifact facade contract. |
+| `dashboard.api_research_intelligence` | `research.research_evidence_ledger` | Research intelligence API reads a QRE artifact path. | Replace with read-only intelligence artifact facade contract. |
+| `dashboard.api_research_intelligence` | `research.stop_condition_engine` | Research intelligence API reads a QRE artifact path. | Replace with read-only intelligence artifact facade contract. |
+| `dashboard.api_research_intelligence` | `research.viability_metrics` | Research intelligence API reads a QRE artifact path. | Replace with read-only intelligence artifact facade contract. |
+| `dashboard.dashboard` | `data.contracts` | Dashboard reads market metadata types for display paths. | Replace with read-only market metadata facade contract. |
+| `dashboard.dashboard` | `data.repository` | Dashboard reads market repository types for display paths. | Replace with read-only market metadata facade contract. |
+| `dashboard.dashboard` | `research.presets` | Dashboard reads QRE preset metadata for operator display. | Replace with read-only preset metadata facade contract. |
+| `dashboard.research_runner` | `research.run_state` | Dashboard runner reads QRE run-state persistence helpers. | Replace with read-only run-state facade contract. |
+
+The ADE-to-QRE reporting exceptions remain legacy/report-only:
+
+- `reporting.hypothesis_discovery_summary` -> `research.hypothesis_discovery.campaign_seed_proposer`
+- `reporting.intelligent_routing` -> `research.presets`
+
+They are not control-plane/QRE imports, but they remain visible because the
+scanner uses one exact legacy allowlist for closed architecture rules.
+
+## 4. Newly Forbidden Imports
+
+Any new non-test source edge with:
+
+```text
+source_domain == control-plane
+target_domain == QRE
+```
+
+is a hard `control-plane-to-qre` failure unless it is added as an exact
+legacy/report-only exception with a reason and sunset condition in the scanner.
+
+ARCH-004 removes stale exact exceptions that were not present in the current
+tracked import graph. This prevents future dashboard imports of additional QRE
+modules from passing only because an old unused exception existed.
+
+The gate does not use wildcard allowlists. Synthetic new control-plane/QRE
+imports must fail with the violating source, target, and domain in the scanner
+text output.
+
+## 5. Selected Enforcement Expansion
+
+ARCH-003 added the `production-to-tests` closed rule. ARCH-004 expands
+enforcement depth for the existing `control-plane-to-qre` closed rule:
+
+- exact allowlist entries now carry `legacy/report-only` status, reason, and
+  sunset criteria;
+- the allowlist is tested against the current tracked control-plane/QRE graph;
+- stale unused exceptions are removed;
+- synthetic future control-plane/QRE imports fail the scanner;
+- legacy exceptions remain reported and do not broad-fail the repository.
+
+This keeps the hard boundary meaningful without failing every known legacy edge.
+
+## 6. Adapter/Facade Direction
+
+The migration sequence is:
+
+1. Keep current direct imports visible as report-only legacy debt.
+2. Introduce read-only adapter/facade modules for one control-plane read
+   surface at a time.
+3. Add contract tests that pin response schema compatibility and read-only
+   authority.
+4. Replace dashboard direct imports with adapter calls.
+5. Decide package extraction readiness only after direct and transitive edges,
+   contract tests, and frozen outputs are stable.
+
+Adapter contracts must be read-only. They must not mutate campaign state,
+research state, approval state, paper state, shadow state, live state, risk
+state, broker state, or execution state.
+
+## 7. Frozen Contract and Protected Path Status
+
+Frozen contracts remain unchanged:
+
+- `research_latest.json` is not modified;
+- `strategy_matrix.csv` is not modified;
+- frozen artifact schemas and regression pin contracts are not modified.
+
+Protected paths remain untouched:
+
+- `.claude/**`;
+- live, paper, shadow, risk, broker, and execution behavior paths;
+- dashboard mutation routes.
+
+## 8. Convergence
+
+The ARCH track should converge by ARCH-006. The target exit is package
+extraction readiness, not an open-ended architecture documentation sequence.
+
+Exactly one next unit is recommended:
+
+```text
+ARCH-005 - Adapter Contract Scaffold
+```
+
+Purpose: define the read-only adapter/facade contract and contract tests for
+control-plane/QRE separation. ARCH-005 should not perform package extraction.
+
+The targeted exit remains:
+
+```text
+ARCH-006 - Package Extraction Readiness Decision
+```

--- a/reporting/architecture_import_scan.py
+++ b/reporting/architecture_import_scan.py
@@ -38,41 +38,6 @@ EXECUTION_PATH_ROOTS = frozenset(
     }
 )
 
-# Existing mixed-domain imports observed by ARCH-000. These remain visible in
-# legacy reports, but they do not block ARCH-001 while package boundaries are
-# still being prepared.
-KNOWN_LEGACY_EDGE_ALLOWLIST = frozenset(
-    {
-        ("dashboard.api_campaigns", "research.campaign_digest"),
-        ("dashboard.api_campaigns", "research.campaign_budget"),
-        ("dashboard.api_campaigns", "research.campaign_family_policy"),
-        ("dashboard.api_campaigns", "research.campaign_followup"),
-        ("dashboard.api_campaigns", "research.campaign_launcher"),
-        ("dashboard.api_campaigns", "research.campaign_policy"),
-        ("dashboard.api_campaigns", "research.campaign_preset_policy"),
-        ("dashboard.api_campaigns", "research.campaign_queue"),
-        ("dashboard.api_campaigns", "research.campaign_registry"),
-        ("dashboard.api_campaigns", "research.campaign_templates"),
-        ("dashboard.api_observability", "research.diagnostics.paths"),
-        ("dashboard.api_research_intelligence", "research.dead_zone_detection"),
-        ("dashboard.api_research_intelligence", "research.funnel_spawn_proposer"),
-        ("dashboard.api_research_intelligence", "research.information_gain"),
-        ("dashboard.api_research_intelligence", "research.research_evidence_ledger"),
-        ("dashboard.api_research_intelligence", "research.stop_condition_engine"),
-        ("dashboard.api_research_intelligence", "research.viability_metrics"),
-        ("dashboard.dashboard", "data.contracts"),
-        ("dashboard.dashboard", "data.repository"),
-        ("dashboard.dashboard", "research.presets"),
-        ("dashboard.research_runner", "research.run_state"),
-        ("reporting.hypothesis_discovery_summary", "research.hypothesis_discovery"),
-        (
-            "reporting.hypothesis_discovery_summary",
-            "research.hypothesis_discovery.campaign_seed_proposer",
-        ),
-        ("reporting.intelligent_routing", "research.presets"),
-    }
-)
-
 
 @dataclass(frozen=True)
 class ImportEdge:
@@ -104,6 +69,203 @@ class BoundaryReport:
     edges: tuple[ImportEdge, ...]
     forbidden_edges: tuple[BoundaryFinding, ...]
     legacy_edges: tuple[BoundaryFinding, ...]
+
+
+@dataclass(frozen=True)
+class LegacyEdgeAllowlistEntry:
+    source_module: str
+    target_module: str
+    rule: str
+    status: str
+    reason: str
+    sunset: str
+
+
+LEGACY_EDGE_ALLOWLIST: tuple[LegacyEdgeAllowlistEntry, ...] = (
+    LegacyEdgeAllowlistEntry(
+        "dashboard.api_campaigns",
+        "research.campaign_budget",
+        "control-plane-to-qre",
+        "legacy/report-only",
+        "Campaign dashboard reads the QRE budget artifact path.",
+        "Replace with read-only campaign artifact facade contract.",
+    ),
+    LegacyEdgeAllowlistEntry(
+        "dashboard.api_campaigns",
+        "research.campaign_digest",
+        "control-plane-to-qre",
+        "legacy/report-only",
+        "Campaign dashboard reads the QRE digest artifact path.",
+        "Replace with read-only campaign artifact facade contract.",
+    ),
+    LegacyEdgeAllowlistEntry(
+        "dashboard.api_campaigns",
+        "research.campaign_family_policy",
+        "control-plane-to-qre",
+        "legacy/report-only",
+        "Campaign dashboard reads the QRE family policy artifact path.",
+        "Replace with read-only campaign artifact facade contract.",
+    ),
+    LegacyEdgeAllowlistEntry(
+        "dashboard.api_campaigns",
+        "research.campaign_policy",
+        "control-plane-to-qre",
+        "legacy/report-only",
+        "Campaign dashboard reads the QRE policy decision artifact path.",
+        "Replace with read-only campaign artifact facade contract.",
+    ),
+    LegacyEdgeAllowlistEntry(
+        "dashboard.api_campaigns",
+        "research.campaign_preset_policy",
+        "control-plane-to-qre",
+        "legacy/report-only",
+        "Campaign dashboard reads the QRE preset policy artifact path.",
+        "Replace with read-only campaign artifact facade contract.",
+    ),
+    LegacyEdgeAllowlistEntry(
+        "dashboard.api_campaigns",
+        "research.campaign_queue",
+        "control-plane-to-qre",
+        "legacy/report-only",
+        "Campaign dashboard reads the QRE queue artifact path.",
+        "Replace with read-only campaign artifact facade contract.",
+    ),
+    LegacyEdgeAllowlistEntry(
+        "dashboard.api_campaigns",
+        "research.campaign_registry",
+        "control-plane-to-qre",
+        "legacy/report-only",
+        "Campaign dashboard reads the QRE registry artifact path.",
+        "Replace with read-only campaign artifact facade contract.",
+    ),
+    LegacyEdgeAllowlistEntry(
+        "dashboard.api_observability",
+        "research.diagnostics.paths",
+        "control-plane-to-qre",
+        "legacy/report-only",
+        "Observability API reads QRE diagnostics artifact locations.",
+        "Replace with read-only diagnostics artifact facade contract.",
+    ),
+    LegacyEdgeAllowlistEntry(
+        "dashboard.api_research_intelligence",
+        "research.dead_zone_detection",
+        "control-plane-to-qre",
+        "legacy/report-only",
+        "Research intelligence API reads dead-zone artifact location.",
+        "Replace with read-only intelligence artifact facade contract.",
+    ),
+    LegacyEdgeAllowlistEntry(
+        "dashboard.api_research_intelligence",
+        "research.funnel_spawn_proposer",
+        "control-plane-to-qre",
+        "legacy/report-only",
+        "Research intelligence API reads funnel proposal artifact location.",
+        "Replace with read-only intelligence artifact facade contract.",
+    ),
+    LegacyEdgeAllowlistEntry(
+        "dashboard.api_research_intelligence",
+        "research.information_gain",
+        "control-plane-to-qre",
+        "legacy/report-only",
+        "Research intelligence API reads information-gain artifact location.",
+        "Replace with read-only intelligence artifact facade contract.",
+    ),
+    LegacyEdgeAllowlistEntry(
+        "dashboard.api_research_intelligence",
+        "research.research_evidence_ledger",
+        "control-plane-to-qre",
+        "legacy/report-only",
+        "Research intelligence API reads evidence ledger artifact location.",
+        "Replace with read-only intelligence artifact facade contract.",
+    ),
+    LegacyEdgeAllowlistEntry(
+        "dashboard.api_research_intelligence",
+        "research.stop_condition_engine",
+        "control-plane-to-qre",
+        "legacy/report-only",
+        "Research intelligence API reads stop-condition artifact location.",
+        "Replace with read-only intelligence artifact facade contract.",
+    ),
+    LegacyEdgeAllowlistEntry(
+        "dashboard.api_research_intelligence",
+        "research.viability_metrics",
+        "control-plane-to-qre",
+        "legacy/report-only",
+        "Research intelligence API reads viability artifact location.",
+        "Replace with read-only intelligence artifact facade contract.",
+    ),
+    LegacyEdgeAllowlistEntry(
+        "dashboard.dashboard",
+        "data.contracts",
+        "control-plane-to-qre",
+        "legacy/report-only",
+        "Dashboard reads market data contract types for display paths.",
+        "Replace with read-only market metadata facade contract.",
+    ),
+    LegacyEdgeAllowlistEntry(
+        "dashboard.dashboard",
+        "data.repository",
+        "control-plane-to-qre",
+        "legacy/report-only",
+        "Dashboard reads market repository types for display paths.",
+        "Replace with read-only market metadata facade contract.",
+    ),
+    LegacyEdgeAllowlistEntry(
+        "dashboard.dashboard",
+        "research.presets",
+        "control-plane-to-qre",
+        "legacy/report-only",
+        "Dashboard reads QRE preset metadata for operator display.",
+        "Replace with read-only preset metadata facade contract.",
+    ),
+    LegacyEdgeAllowlistEntry(
+        "dashboard.research_runner",
+        "research.run_state",
+        "control-plane-to-qre",
+        "legacy/report-only",
+        "Dashboard runner reads QRE run-state persistence helpers.",
+        "Replace with read-only run-state facade contract.",
+    ),
+    LegacyEdgeAllowlistEntry(
+        "reporting.hypothesis_discovery_summary",
+        "research.hypothesis_discovery.campaign_seed_proposer",
+        "ade-to-qre",
+        "legacy/report-only",
+        "ADE summary reports on QRE hypothesis-discovery output.",
+        "Replace with QRE summary adapter contract.",
+    ),
+    LegacyEdgeAllowlistEntry(
+        "reporting.intelligent_routing",
+        "research.presets",
+        "ade-to-qre",
+        "legacy/report-only",
+        "ADE advisory routing reads QRE preset metadata.",
+        "Replace with QRE preset metadata adapter contract.",
+    ),
+)
+
+KNOWN_LEGACY_EDGE_ALLOWLIST = frozenset(
+    (entry.source_module, entry.target_module) for entry in LEGACY_EDGE_ALLOWLIST
+)
+
+
+def legacy_edge_allowlist_entries(
+    rule: str | None = None,
+) -> tuple[LegacyEdgeAllowlistEntry, ...]:
+    """Return exact legacy import exceptions in deterministic order."""
+    entries = LEGACY_EDGE_ALLOWLIST
+    if rule is not None:
+        entries = tuple(entry for entry in entries if entry.rule == rule)
+    return tuple(
+        sorted(
+            entries,
+            key=lambda entry: (
+                entry.rule,
+                entry.source_module,
+                entry.target_module,
+            ),
+        )
+    )
 
 
 def tracked_python_files(repo_root: Path) -> tuple[Path, ...]:

--- a/tests/architecture/test_domain_import_scanner.py
+++ b/tests/architecture/test_domain_import_scanner.py
@@ -14,6 +14,7 @@ from reporting.architecture_import_scan import (
     ImportEdge,
     classify_path,
     evaluate_edges,
+    legacy_edge_allowlist_entries,
     report_to_dict,
     report_to_summary_dict,
     report_to_text,
@@ -226,6 +227,69 @@ def test_production_modules_must_not_import_test_modules() -> None:
         (finding.rule, finding.source_module) for finding in report.forbidden_edges
     ] == [("production-to-tests", "research.new_policy")]
     assert report.legacy_edges == ()
+
+
+def test_control_plane_qre_allowlist_is_exact_current_report_only_boundary() -> None:
+    report = scan_repo(REPO_ROOT)
+
+    control_plane_qre_edges = {
+        (finding.source_module, finding.target_module)
+        for finding in report.legacy_edges
+        if finding.rule == "control-plane-to-qre"
+    }
+    allowed_control_plane_qre_edges = {
+        (entry.source_module, entry.target_module)
+        for entry in legacy_edge_allowlist_entries("control-plane-to-qre")
+    }
+
+    assert control_plane_qre_edges == allowed_control_plane_qre_edges
+    assert len(control_plane_qre_edges) == 18
+    assert all(
+        entry.status == "legacy/report-only" and entry.reason and entry.sunset
+        for entry in legacy_edge_allowlist_entries("control-plane-to-qre")
+    )
+
+
+def test_control_plane_qre_allowlist_uses_exact_edges_without_wildcards() -> None:
+    entries = legacy_edge_allowlist_entries()
+
+    assert entries
+    for entry in entries:
+        assert "*" not in entry.source_module
+        assert "*" not in entry.target_module
+        assert entry.source_module
+        assert entry.target_module
+        assert entry.reason
+        assert entry.sunset
+
+
+def test_new_control_plane_qre_edge_fails_with_source_target_and_domain() -> None:
+    edge = ImportEdge(
+        source_module="dashboard.api_new_read_model",
+        target_module="research.new_read_model",
+        source_path="dashboard/api_new_read_model.py",
+        source_domain=DOMAIN_CONTROL_PLANE,
+        target_domain=DOMAIN_QRE,
+        target_root="research",
+        line=12,
+        import_kind="from",
+    )
+
+    report = evaluate_edges((edge,))
+    rendered = report_to_text(report)
+
+    assert [
+        (finding.rule, finding.source_module, finding.target_module)
+        for finding in report.forbidden_edges
+    ] == [
+        (
+            "control-plane-to-qre",
+            "dashboard.api_new_read_model",
+            "research.new_read_model",
+        )
+    ]
+    assert "dashboard.api_new_read_model:12 -> research.new_read_model" in rendered
+    assert "(control-plane -> QRE)" in rendered
 
 
 def test_scanner_does_not_import_or_execute_target_modules(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Added ARCH-004 control-plane/QRE boundary hardening documentation.
- Converted the scanner legacy allowlist into exact audited entries with status, reason, and sunset criteria.
- Removed stale unused control-plane/QRE allowlist edges and added tests that fail synthetic future non-allowlisted dashboard-to-QRE imports.

## Selected Enforced Boundary
- `control-plane-to-qre`: non-test control-plane modules must not directly import QRE modules unless the exact edge is explicitly listed as legacy/report-only.
- Existing 18 tracked control-plane/QRE edges remain report-only legacy findings, not hard failures.

## Allowlist Policy
- Exact source/target module pairs only.
- No wildcard allowlists.
- Each entry carries `legacy/report-only` status, reason, and sunset criteria.
- Stale unused exceptions were removed so future dashboard-to-QRE imports cannot pass through historical allowance.

## Files Changed
- `docs/architecture/ARCH-004-control-plane-qre-boundary-hardening.md`
- `reporting/architecture_import_scan.py`
- `tests/architecture/test_domain_import_scanner.py`

## Validation Commands and Results
- `pytest tests/architecture/test_domain_boundary_smoke.py -q` - passed, 40 passed.
- `pytest tests/architecture/test_domain_import_scanner.py -q` - passed, 16 passed.
- `pytest tests/architecture -q` - passed, 56 passed.
- `pytest tests/functional/test_static_import_surface.py -q` - skipped as expected, 13 skipped.
- `pytest tests/unit/test_observability_static_import_surface.py -q` - passed, 23 passed.
- `pytest tests/unit/test_intelligent_routing_import_safety.py -q` - passed, 6 passed.
- `python -m reporting.architecture_import_scan --format summary` - passed, 5279 edges, 0 forbidden edges, 74 legacy/report-only findings.
- `git diff --cached --check` - passed.

Note: local `.venv` activation could not be performed because this checkout has no `.venv` directory; tests were run with the available Python environment.

## Frozen Contract Status
- `research_latest.json` unchanged.
- `strategy_matrix.csv` unchanged.
- Frozen schema/regression contracts not modified.

## Protected Path Status
- `.claude/**` untouched.
- live/paper/shadow/risk/broker/execution behavior paths untouched.
- dashboard mutation routes untouched.
- Addendum 1, Addendum 2, Addendum 3 inactive.

## Report-Only Legacy Status
- Existing 18 control-plane/QRE edges remain visible as report-only legacy findings.
- Existing ADE-to-QRE reporting edges remain report-only legacy findings.
- The scanner still reports known mixed-domain debt and does not broad-fail all legacy edges.

## Convergence Note
- ARCH track remains targeted to converge by ARCH-006.
- Target exit is package extraction readiness, not open-ended architecture documentation.

## Next Recommended Unit Only
- ARCH-005 - Adapter Contract Scaffold: define read-only adapter/facade contract and contract tests for control-plane/QRE separation. Do not implement package extraction in ARCH-005.
