### PR TITLE
feat: add ARCH-005 adapter contract scaffold

### DIFF
--- a/docs/architecture/ARCH-005-adapter-contract-scaffold.md
+++ b/docs/architecture/ARCH-005-adapter-contract-scaffold.md
@@ -1,0 +1,158 @@
+# ARCH-005 - Adapter Contract Scaffold
+
+Status: contract scaffold
+Date: 2026-05-22
+Branch: `arch/005-adapter-contract-scaffold`
+Builds on:
+
+- `docs/architecture/ARCH-000-architecture-diagnosis-gate.md`
+- `docs/architecture/ARCH-002-import-boundary-baseline.md`
+- `docs/architecture/ARCH-003-import-boundary-enforcement-gate.md`
+- `docs/architecture/ARCH-004-control-plane-qre-boundary-hardening.md`
+- `reporting/architecture_import_scan.py`
+
+## 1. Purpose and Scope
+
+ARCH-005 creates the first read-only adapter/facade contract scaffold for the
+control-plane/QRE boundary. It moves the architecture track from diagnosis and
+selected enforcement toward a stable dependency shape that future dashboard/API
+code can use instead of direct QRE domain imports.
+
+This unit is a scaffold only. It does not move files, rename packages, perform
+package extraction, change runtime behavior, change frozen contracts, add
+dashboard mutation routes, or activate Addendum 1, Addendum 2, Addendum 3,
+shadow, paper, live, broker, risk, or execution work.
+
+## 2. Adapter/Facade Role
+
+The adapter contract is the stable read-only surface between future
+control-plane consumers and QRE-owned read models. The control plane should
+depend on the contract shape, not on QRE module paths such as `research.*` or
+`data.*`.
+
+The initial scaffold lives at:
+
+```text
+reporting/control_plane_qre_adapter_contract.py
+```
+
+The module is stdlib-only and declares:
+
+- `ControlPlaneQREReadAdapter`
+- `ReadModelContract`
+- `AdapterContractDescription`
+- `describe_contract()`
+- stable read-only method names: `list_read_models`, `read_json`,
+  `describe_contract`
+
+No dashboard route is wired to this scaffold in ARCH-005.
+
+## 3. What an Adapter May Do
+
+A control-plane/QRE adapter may:
+
+- list available QRE read models;
+- read existing QRE JSON-compatible artifacts or snapshots;
+- return deterministic contract metadata;
+- preserve existing response schemas when a dashboard route is migrated later;
+- fail closed when a read model is unavailable.
+
+The adapter must remain read-only. It may expose existing state, but it must not
+become an authority surface for changing QRE, ADE, execution, paper, shadow,
+live, broker, risk, or dashboard state.
+
+## 4. What an Adapter May Not Do
+
+A control-plane/QRE adapter may not:
+
+- create, update, delete, append, write, save, enqueue, dispatch, execute,
+  approve, spawn, trade, order, or mutate state;
+- add dashboard mutation routes;
+- import live, paper, shadow, risk, broker, or execution paths;
+- hide new direct control-plane-to-QRE imports behind wildcard allowlists;
+- change `research_latest.json`, `strategy_matrix.csv`, frozen schemas, or
+  regression pin contracts;
+- duplicate QRE strategy definitions or bypass registry authority.
+
+## 5. Read-Only Contract Expectations
+
+The scaffold uses frozen dataclasses and a runtime-checkable Protocol so future
+implementations can be validated without importing QRE modules.
+
+Expected method names are stable for future migration tests:
+
+| Method | Responsibility |
+|---|---|
+| `list_read_models` | Return available read-only QRE read-model metadata. |
+| `read_json` | Return an existing read model as JSON-compatible data. |
+| `describe_contract` | Return deterministic contract metadata. |
+
+The contract describes forbidden capabilities explicitly so tests can fail if a
+future implementation adds hidden mutation or execution authority.
+
+## 6. No Runtime Behavior Change
+
+ARCH-005 does not wire the adapter into `dashboard/`, Flask routes, API
+registration, research orchestration, live/paper/shadow/risk/broker/execution
+behavior, or generated research outputs.
+
+Current legacy dashboard-to-QRE imports remain visible as report-only debt under
+the ARCH-004 scanner allowlist. The scaffold prepares a future migration path
+but does not migrate real imports in this unit.
+
+## 7. No File Move or Package Extraction
+
+ARCH-005 performs no physical package extraction and no package rename. The
+target remains package extraction readiness, not a partial package move.
+
+The scaffold is deliberately small so ARCH-006 can decide whether the repo is
+ready for the first physical package extraction slice.
+
+## 8. No Frozen Contract Change
+
+Frozen contracts remain unchanged:
+
+- `research_latest.json` is not modified;
+- `strategy_matrix.csv` is not modified;
+- frozen artifact schemas and regression pin outputs are not modified.
+
+## 9. Contract Test Protection
+
+ARCH-005 adds contract tests under `tests/architecture/` that verify:
+
+- the adapter contract is importable and runtime-checkable;
+- contract metadata and method names are stable;
+- the scaffold imports only stdlib modules;
+- no QRE, dashboard, live, paper, shadow, risk, broker, or execution imports are
+  introduced by the scaffold;
+- no route decorator or mutation-named public method is exposed;
+- a future control-plane import of the adapter contract is not a hard forbidden
+  scanner edge;
+- a future direct control-plane import of QRE remains a hard
+  `control-plane-to-qre` violation unless explicitly allowlisted.
+
+These tests allow migration to proceed one read surface at a time while keeping
+legacy/report-only debt from broad-failing the repository.
+
+## 10. ARCH-006 Readiness Link
+
+ARCH-005 provides the minimal contract object that ARCH-006 can use to decide
+whether package extraction readiness exists. ARCH-006 should evaluate:
+
+- whether the direct and transitive import graph is known enough;
+- whether one low-risk extraction candidate can be identified;
+- which adapter contract tests must gate that extraction;
+- which frozen outputs and protected paths must remain untouched;
+- go/no-go criteria for the first physical package extraction slice.
+
+Exactly one next unit is recommended:
+
+```text
+ARCH-006 - Package Extraction Readiness Decision
+```
+
+Purpose: decide whether the repo is ready for the first physical package
+extraction slice, identify blockers, first extraction candidate, required gates,
+and go/no-go criteria.
+
+No ARCH-007+ unit is recommended by ARCH-005.

--- a/reporting/control_plane_qre_adapter_contract.py
+++ b/reporting/control_plane_qre_adapter_contract.py
@@ -1,0 +1,97 @@
+"""ARCH-005 read-only contract for future control-plane/QRE adapters.
+
+This module is intentionally a scaffold. It defines the stable shape that
+future dashboard/API code can depend on before any QRE package extraction.
+It imports only stdlib modules and does not import QRE, dashboard, execution,
+paper, shadow, live, broker, or risk modules.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Protocol, runtime_checkable
+
+CONTRACT_VERSION = "arch-005.v1"
+CONTRACT_NAME = "control-plane-qre-read-adapter"
+
+READ_ONLY_METHODS: tuple[str, ...] = (
+    "list_read_models",
+    "read_json",
+    "describe_contract",
+)
+
+FORBIDDEN_CAPABILITIES: tuple[str, ...] = (
+    "approve",
+    "broker",
+    "create",
+    "delete",
+    "dispatch",
+    "enqueue",
+    "execute",
+    "live",
+    "mutate",
+    "order",
+    "paper",
+    "risk",
+    "save",
+    "shadow",
+    "spawn",
+    "trade",
+    "update",
+    "write",
+)
+
+
+@dataclass(frozen=True)
+class ReadModelContract:
+    """Read-only JSON surface exposed by a future QRE adapter."""
+
+    name: str
+    schema_version: str
+    description: str
+
+
+@dataclass(frozen=True)
+class AdapterContractDescription:
+    """Deterministic metadata for architecture tests and future adapters."""
+
+    name: str
+    version: str
+    read_only_methods: tuple[str, ...]
+    forbidden_capabilities: tuple[str, ...]
+
+
+@runtime_checkable
+class ControlPlaneQREReadAdapter(Protocol):
+    """Protocol future dashboard/API code can consume without QRE imports."""
+
+    def list_read_models(self) -> tuple[ReadModelContract, ...]:
+        """Return available read-only QRE read models."""
+
+    def read_json(self, read_model: str) -> Mapping[str, Any]:
+        """Return an existing QRE read model as JSON-compatible data."""
+
+    def describe_contract(self) -> AdapterContractDescription:
+        """Return deterministic contract metadata."""
+
+
+def describe_contract() -> AdapterContractDescription:
+    """Return the ARCH-005 adapter contract description."""
+    return AdapterContractDescription(
+        name=CONTRACT_NAME,
+        version=CONTRACT_VERSION,
+        read_only_methods=READ_ONLY_METHODS,
+        forbidden_capabilities=FORBIDDEN_CAPABILITIES,
+    )
+
+
+__all__ = [
+    "AdapterContractDescription",
+    "CONTRACT_NAME",
+    "CONTRACT_VERSION",
+    "ControlPlaneQREReadAdapter",
+    "FORBIDDEN_CAPABILITIES",
+    "READ_ONLY_METHODS",
+    "ReadModelContract",
+    "describe_contract",
+]

--- a/tests/architecture/test_control_plane_qre_adapter_contract.py
+++ b/tests/architecture/test_control_plane_qre_adapter_contract.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import ast
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+
+import pytest
+
+from reporting.architecture_import_scan import (
+    DOMAIN_ADE,
+    DOMAIN_CONTROL_PLANE,
+    DOMAIN_QRE,
+    ImportEdge,
+    evaluate_edges,
+)
+from reporting.control_plane_qre_adapter_contract import (
+    CONTRACT_NAME,
+    CONTRACT_VERSION,
+    FORBIDDEN_CAPABILITIES,
+    READ_ONLY_METHODS,
+    AdapterContractDescription,
+    ControlPlaneQREReadAdapter,
+    ReadModelContract,
+    describe_contract,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONTRACT_PATH = REPO_ROOT / "reporting" / "control_plane_qre_adapter_contract.py"
+
+FORBIDDEN_IMPORT_PREFIXES = (
+    "agent.execution",
+    "agent.risk",
+    "automation.live_gate",
+    "broker",
+    "dashboard",
+    "execution",
+    "flask",
+    "live",
+    "paper",
+    "research",
+    "risk",
+    "shadow",
+)
+MUTATION_VERBS = (
+    "append",
+    "approve",
+    "create",
+    "delete",
+    "dispatch",
+    "enqueue",
+    "execute",
+    "mutate",
+    "order",
+    "post",
+    "put",
+    "save",
+    "spawn",
+    "trade",
+    "update",
+    "write",
+)
+
+
+class _StubReadAdapter:
+    def list_read_models(self) -> tuple[ReadModelContract, ...]:
+        return (
+            ReadModelContract(
+                name="campaign_registry",
+                schema_version="1.0",
+                description="Existing campaign registry read model.",
+            ),
+        )
+
+    def read_json(self, read_model: str) -> dict[str, object]:
+        return {"schema_version": "1.0", "read_model": read_model}
+
+    def describe_contract(self) -> AdapterContractDescription:
+        return describe_contract()
+
+
+def test_adapter_contract_is_runtime_checkable_and_read_only() -> None:
+    adapter = _StubReadAdapter()
+
+    assert isinstance(adapter, ControlPlaneQREReadAdapter)
+    assert adapter.list_read_models()[0].name == "campaign_registry"
+    assert adapter.read_json("campaign_registry") == {
+        "schema_version": "1.0",
+        "read_model": "campaign_registry",
+    }
+    assert adapter.describe_contract() == describe_contract()
+
+
+def test_adapter_contract_metadata_is_stable_and_frozen() -> None:
+    description = describe_contract()
+    read_model = ReadModelContract(
+        name="run_state",
+        schema_version="1.0",
+        description="Existing QRE run-state read model.",
+    )
+
+    assert description == AdapterContractDescription(
+        name=CONTRACT_NAME,
+        version=CONTRACT_VERSION,
+        read_only_methods=READ_ONLY_METHODS,
+        forbidden_capabilities=FORBIDDEN_CAPABILITIES,
+    )
+    assert description.read_only_methods == (
+        "list_read_models",
+        "read_json",
+        "describe_contract",
+    )
+    assert "write" in description.forbidden_capabilities
+    assert read_model.schema_version == "1.0"
+    with pytest.raises(FrozenInstanceError):
+        read_model.name = "mutated"  # type: ignore[misc]
+
+
+def test_adapter_contract_is_stdlib_only_and_has_no_domain_imports() -> None:
+    tree = ast.parse(CONTRACT_PATH.read_text(encoding="utf-8"))
+    imported_modules: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_modules.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported_modules.append(node.module)
+
+    violations = [
+        module
+        for module in imported_modules
+        if any(
+            module == prefix or module.startswith(prefix + ".")
+            for prefix in FORBIDDEN_IMPORT_PREFIXES
+        )
+    ]
+
+    assert violations == []
+    assert sorted(imported_modules) == [
+        "__future__",
+        "dataclasses",
+        "typing",
+    ]
+
+
+def test_adapter_contract_exposes_no_mutation_or_route_surface() -> None:
+    tree = ast.parse(CONTRACT_PATH.read_text(encoding="utf-8"))
+    public_functions = [
+        node.name
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and not node.name.startswith("_")
+    ]
+    route_decorators = [
+        decorator
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        for decorator in node.decorator_list
+        if isinstance(decorator, ast.Call)
+        and isinstance(decorator.func, ast.Attribute)
+        and decorator.func.attr == "route"
+    ]
+
+    assert sorted(public_functions) == [
+        "describe_contract",
+        "describe_contract",
+        "list_read_models",
+        "read_json",
+    ]
+    assert route_decorators == []
+    assert not any(
+        verb in function_name.lower()
+        for verb in MUTATION_VERBS
+        for function_name in public_functions
+    )
+
+
+def test_adapter_path_import_is_allowed_for_future_control_plane_code() -> None:
+    edge = ImportEdge(
+        source_module="dashboard.api_future_read_model",
+        target_module="reporting.control_plane_qre_adapter_contract",
+        source_path="dashboard/api_future_read_model.py",
+        source_domain=DOMAIN_CONTROL_PLANE,
+        target_domain=DOMAIN_ADE,
+        target_root="reporting",
+        line=4,
+        import_kind="from",
+    )
+
+    report = evaluate_edges((edge,))
+
+    assert report.forbidden_edges == ()
+    assert [(finding.rule, finding.source_module) for finding in report.legacy_edges] == [
+        ("mixed-domain", "dashboard.api_future_read_model")
+    ]
+
+
+def test_direct_control_plane_qre_import_remains_forbidden() -> None:
+    edge = ImportEdge(
+        source_module="dashboard.api_future_read_model",
+        target_module="research.future_read_model",
+        source_path="dashboard/api_future_read_model.py",
+        source_domain=DOMAIN_CONTROL_PLANE,
+        target_domain=DOMAIN_QRE,
+        target_root="research",
+        line=4,
+        import_kind="from",
+    )
+
+    report = evaluate_edges((edge,))
+
+    assert [
+        (finding.rule, finding.source_module, finding.target_module)
+        for finding in report.forbidden_edges
+    ] == [
+        (
+            "control-plane-to-qre",
+            "dashboard.api_future_read_model",
+            "research.future_read_model",
+        )
+    ]
+    assert report.legacy_edges == ()


### PR DESCRIPTION
## Summary
- Adds ARCH-005 architecture documentation for the adapter contract scaffold.
- Adds a stdlib-only read-only control-plane/QRE adapter contract scaffold in `reporting/control_plane_qre_adapter_contract.py`.
- Adds architecture contract tests proving the adapter path is allowed while direct control-plane-to-QRE imports remain forbidden.

## Adapter Contract Scope
- Read-only scaffold only: `list_read_models`, `read_json`, and `describe_contract`.
- No dashboard route wiring, no QRE runtime import, no package extraction, and no behavior migration.
- Contract explicitly forbids mutation, execution, live, paper, shadow, broker, risk, and trading capabilities.

## Files Changed
- `docs/architecture/ARCH-005-adapter-contract-scaffold.md`
- `reporting/control_plane_qre_adapter_contract.py`
- `tests/architecture/test_control_plane_qre_adapter_contract.py`

## Validation Commands and Results
- `python -m pytest tests/architecture/test_domain_boundary_smoke.py -q` -> 40 passed
- `python -m pytest tests/architecture/test_domain_import_scanner.py -q` -> 16 passed
- `python -m pytest tests/architecture/test_control_plane_qre_adapter_contract.py -q` -> 6 passed
- `python -m pytest tests/architecture -q` -> 62 passed
- `python -m reporting.architecture_import_scan --format summary` -> forbidden_edge_count 0, legacy_edge_count 74
- `python -m pytest tests/functional/test_static_import_surface.py -q` -> 13 skipped
- `python -m pytest tests/unit/test_observability_static_import_surface.py -q` -> 23 passed
- `python -m pytest tests/unit/test_intelligent_routing_import_safety.py -q` -> 6 passed

## Frozen Contract Status
- `research_latest.json` unchanged.
- `strategy_matrix.csv` unchanged.
- No frozen artifact schemas or regression pin contracts changed.

## Protected Path Status
- `.claude/**` untouched.
- live/paper/shadow/risk/broker/execution behavior paths untouched.
- Local transcript and weekly summary files remain untracked and untouched.

## Runtime Behavior Status
- No runtime behavior change.
- No dashboard/API route wiring changed.
- No package extraction or file moves.

## Dashboard Mutation Route Status
- No dashboard mutation routes added.
- Contract tests assert no route decorator and no mutation-named public API on the scaffold.

## Convergence Note
- ARCH track remains targeted to converge by ARCH-006.
- ARCH-005 recommends no ARCH-007+ sequence.

## Next Recommended Unit Only
- ARCH-006 - Package Extraction Readiness Decision