### PR TITLE
refactor: extract control-plane QRE adapter contract

### DIFF
--- a/docs/architecture/EXTRACT-001-control-plane-qre-adapter-contract.md
+++ b/docs/architecture/EXTRACT-001-control-plane-qre-adapter-contract.md
@@ -1,0 +1,83 @@
+# EXTRACT-001 - Control-Plane/QRE Adapter Contract Package
+
+Status: implemented
+Date: 2026-05-22
+Builds on:
+
+- `docs/architecture/ARCH-005-adapter-contract-scaffold.md`
+- `docs/architecture/ARCH-006-package-extraction-readiness-decision.md`
+- `reporting/control_plane_qre_adapter_contract.py`
+- `reporting/architecture_import_scan.py`
+
+## 1. Purpose and Scope
+
+EXTRACT-001 performs the first physical package extraction slice selected by
+ARCH-006. The slice is deliberately narrow: only the control-plane/QRE read-only
+adapter contract scaffold moves into a dedicated package namespace.
+
+This unit does not migrate dashboard routes, move QRE read models, change
+runtime behavior, update frozen outputs, or touch live, paper, shadow, risk,
+broker, or execution behavior.
+
+## 2. Canonical Namespace
+
+The canonical adapter contract now lives at:
+
+```text
+packages/control_plane_qre_adapter_contract/
+```
+
+The package is classified by the architecture import scanner as
+`adapter-contract`. It is not QRE runtime, dashboard/control-plane runtime,
+execution, or ADE authority.
+
+The canonical package remains stdlib-only and exposes the stable ARCH-005
+contract surface:
+
+- `ControlPlaneQREReadAdapter`
+- `ReadModelContract`
+- `AdapterContractDescription`
+- `describe_contract()`
+- `list_read_models`
+- `read_json`
+- `describe_contract`
+
+## 3. Compatibility Import
+
+The legacy reporting path remains importable:
+
+```text
+reporting/control_plane_qre_adapter_contract.py
+```
+
+It is now a small compatibility shim that re-exports the canonical package
+objects. Existing tests and consumers using the reporting import path continue
+to receive the same public contract objects.
+
+## 4. Scanner and Boundary Status
+
+The scanner has an explicit `adapter-contract` classification for the extracted
+package. This keeps the package visible in architecture summaries without
+classifying it as QRE, control-plane, execution, or ADE authority.
+
+The extraction does not add control-plane-to-QRE imports. Existing exact
+legacy/report-only findings remain visible; no wildcard allowlist is added.
+
+## 5. Frozen and Protected Paths
+
+Frozen outputs remain unchanged:
+
+- `research_latest.json`
+- `strategy_matrix.csv`
+
+Protected behavior paths remain untouched:
+
+- `.claude/**`
+- live/paper/shadow/risk/broker/execution behavior
+
+No dashboard mutation routes or runtime dashboard wiring are added.
+
+## 6. Recommended Next Action
+
+Recommended next action: continue with the next explicitly selected extraction
+item only after EXTRACT-001 validation and CI complete successfully.

--- a/packages/control_plane_qre_adapter_contract/__init__.py
+++ b/packages/control_plane_qre_adapter_contract/__init__.py
@@ -1,0 +1,96 @@
+"""Read-only contract for future control-plane/QRE adapters.
+
+This package is intentionally stdlib-only. It defines the stable shape that
+future dashboard/API code can depend on without importing QRE, dashboard,
+execution, paper, shadow, live, broker, or risk modules.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Protocol, runtime_checkable
+
+CONTRACT_VERSION = "arch-005.v1"
+CONTRACT_NAME = "control-plane-qre-read-adapter"
+
+READ_ONLY_METHODS: tuple[str, ...] = (
+    "list_read_models",
+    "read_json",
+    "describe_contract",
+)
+
+FORBIDDEN_CAPABILITIES: tuple[str, ...] = (
+    "approve",
+    "broker",
+    "create",
+    "delete",
+    "dispatch",
+    "enqueue",
+    "execute",
+    "live",
+    "mutate",
+    "order",
+    "paper",
+    "risk",
+    "save",
+    "shadow",
+    "spawn",
+    "trade",
+    "update",
+    "write",
+)
+
+
+@dataclass(frozen=True)
+class ReadModelContract:
+    """Read-only JSON surface exposed by a future QRE adapter."""
+
+    name: str
+    schema_version: str
+    description: str
+
+
+@dataclass(frozen=True)
+class AdapterContractDescription:
+    """Deterministic metadata for architecture tests and future adapters."""
+
+    name: str
+    version: str
+    read_only_methods: tuple[str, ...]
+    forbidden_capabilities: tuple[str, ...]
+
+
+@runtime_checkable
+class ControlPlaneQREReadAdapter(Protocol):
+    """Protocol future dashboard/API code can consume without QRE imports."""
+
+    def list_read_models(self) -> tuple[ReadModelContract, ...]:
+        """Return available read-only QRE read models."""
+
+    def read_json(self, read_model: str) -> Mapping[str, Any]:
+        """Return an existing QRE read model as JSON-compatible data."""
+
+    def describe_contract(self) -> AdapterContractDescription:
+        """Return deterministic contract metadata."""
+
+
+def describe_contract() -> AdapterContractDescription:
+    """Return the adapter contract description."""
+    return AdapterContractDescription(
+        name=CONTRACT_NAME,
+        version=CONTRACT_VERSION,
+        read_only_methods=READ_ONLY_METHODS,
+        forbidden_capabilities=FORBIDDEN_CAPABILITIES,
+    )
+
+
+__all__ = [
+    "AdapterContractDescription",
+    "CONTRACT_NAME",
+    "CONTRACT_VERSION",
+    "ControlPlaneQREReadAdapter",
+    "FORBIDDEN_CAPABILITIES",
+    "READ_ONLY_METHODS",
+    "ReadModelContract",
+    "describe_contract",
+]

--- a/reporting/architecture_import_scan.py
+++ b/reporting/architecture_import_scan.py
@@ -20,6 +20,7 @@ DOMAIN_ADE = "ADE"
 DOMAIN_QRE = "QRE"
 DOMAIN_CONTROL_PLANE = "control-plane"
 DOMAIN_EXECUTION = "execution"
+DOMAIN_ADAPTER_CONTRACT = "adapter-contract"
 DOMAIN_TESTS = "tests"
 DOMAIN_GOVERNANCE_TOOLING = "governance tooling"
 DOMAIN_UNKNOWN = "unknown"
@@ -331,6 +332,8 @@ def classify_path(path: Path | str) -> str:
         return DOMAIN_TESTS
     if normalized.startswith(".claude/hooks/") or first == "scripts":
         return DOMAIN_GOVERNANCE_TOOLING
+    if normalized.startswith("packages/control_plane_qre_adapter_contract/"):
+        return DOMAIN_ADAPTER_CONTRACT
     if first == "dashboard" or first == "frontend":
         return DOMAIN_CONTROL_PLANE
     if first == "reporting":
@@ -357,6 +360,11 @@ def classify_module(module_name: str, module_index: dict[str, Path] | None = Non
         return DOMAIN_CONTROL_PLANE
     if top == "reporting":
         return DOMAIN_ADE
+    if (
+        module_name == "packages.control_plane_qre_adapter_contract"
+        or module_name.startswith("packages.control_plane_qre_adapter_contract.")
+    ):
+        return DOMAIN_ADAPTER_CONTRACT
     if module_name.startswith(("agent.execution", "agent.risk")):
         return DOMAIN_EXECUTION
     if top in {"automation", "broker", "execution", "live", "paper", "risk", "shadow"}:

--- a/reporting/control_plane_qre_adapter_contract.py
+++ b/reporting/control_plane_qre_adapter_contract.py
@@ -1,88 +1,22 @@
-"""ARCH-005 read-only contract for future control-plane/QRE adapters.
+"""Compatibility import for the control-plane/QRE adapter contract.
 
-This module is intentionally a scaffold. It defines the stable shape that
-future dashboard/API code can depend on before any QRE package extraction.
-It imports only stdlib modules and does not import QRE, dashboard, execution,
-paper, shadow, live, broker, or risk modules.
+The canonical implementation lives in
+``packages.control_plane_qre_adapter_contract``. This module preserves the
+ARCH-005 reporting import path until consumers migrate intentionally.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any, Mapping, Protocol, runtime_checkable
-
-CONTRACT_VERSION = "arch-005.v1"
-CONTRACT_NAME = "control-plane-qre-read-adapter"
-
-READ_ONLY_METHODS: tuple[str, ...] = (
-    "list_read_models",
-    "read_json",
-    "describe_contract",
+from packages.control_plane_qre_adapter_contract import (
+    CONTRACT_NAME,
+    CONTRACT_VERSION,
+    FORBIDDEN_CAPABILITIES,
+    READ_ONLY_METHODS,
+    AdapterContractDescription,
+    ControlPlaneQREReadAdapter,
+    ReadModelContract,
+    describe_contract,
 )
-
-FORBIDDEN_CAPABILITIES: tuple[str, ...] = (
-    "approve",
-    "broker",
-    "create",
-    "delete",
-    "dispatch",
-    "enqueue",
-    "execute",
-    "live",
-    "mutate",
-    "order",
-    "paper",
-    "risk",
-    "save",
-    "shadow",
-    "spawn",
-    "trade",
-    "update",
-    "write",
-)
-
-
-@dataclass(frozen=True)
-class ReadModelContract:
-    """Read-only JSON surface exposed by a future QRE adapter."""
-
-    name: str
-    schema_version: str
-    description: str
-
-
-@dataclass(frozen=True)
-class AdapterContractDescription:
-    """Deterministic metadata for architecture tests and future adapters."""
-
-    name: str
-    version: str
-    read_only_methods: tuple[str, ...]
-    forbidden_capabilities: tuple[str, ...]
-
-
-@runtime_checkable
-class ControlPlaneQREReadAdapter(Protocol):
-    """Protocol future dashboard/API code can consume without QRE imports."""
-
-    def list_read_models(self) -> tuple[ReadModelContract, ...]:
-        """Return available read-only QRE read models."""
-
-    def read_json(self, read_model: str) -> Mapping[str, Any]:
-        """Return an existing QRE read model as JSON-compatible data."""
-
-    def describe_contract(self) -> AdapterContractDescription:
-        """Return deterministic contract metadata."""
-
-
-def describe_contract() -> AdapterContractDescription:
-    """Return the ARCH-005 adapter contract description."""
-    return AdapterContractDescription(
-        name=CONTRACT_NAME,
-        version=CONTRACT_VERSION,
-        read_only_methods=READ_ONLY_METHODS,
-        forbidden_capabilities=FORBIDDEN_CAPABILITIES,
-    )
 
 
 __all__ = [

--- a/tests/architecture/test_arch_006_package_extraction_readiness.py
+++ b/tests/architecture/test_arch_006_package_extraction_readiness.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from reporting.architecture_import_scan import (
+    DOMAIN_ADAPTER_CONTRACT,
     DOMAIN_ADE,
     DOMAIN_CONTROL_PLANE,
     DOMAIN_EXECUTION,
@@ -82,23 +83,23 @@ def test_arch_006_readiness_gates_are_represented_in_scanner_summary() -> None:
     assert legacy_by_source_root[("reporting", "research", "ade-to-qre")] == 2
 
 
-def test_arch_006_first_candidate_has_no_domain_or_forbidden_edges() -> None:
+def test_arch_006_extracted_candidate_has_no_domain_or_forbidden_edges() -> None:
     report = scan_repo(REPO_ROOT)
 
     candidate_edges = [
         edge
         for edge in report.edges
-        if edge.source_module == "reporting.control_plane_qre_adapter_contract"
+        if edge.source_module == "packages.control_plane_qre_adapter_contract"
     ]
     candidate_forbidden = [
         finding
         for finding in report.forbidden_edges
-        if finding.source_module == "reporting.control_plane_qre_adapter_contract"
+        if finding.source_module == "packages.control_plane_qre_adapter_contract"
     ]
     candidate_legacy = [
         finding
         for finding in report.legacy_edges
-        if finding.source_module == "reporting.control_plane_qre_adapter_contract"
+        if finding.source_module == "packages.control_plane_qre_adapter_contract"
     ]
 
     assert [(edge.target_module, edge.target_domain) for edge in candidate_edges] == [
@@ -108,3 +109,37 @@ def test_arch_006_first_candidate_has_no_domain_or_forbidden_edges() -> None:
     ]
     assert candidate_forbidden == []
     assert candidate_legacy == []
+
+
+def test_arch_006_reporting_candidate_path_is_compatibility_only() -> None:
+    report = scan_repo(REPO_ROOT)
+
+    compatibility_edges = [
+        edge
+        for edge in report.edges
+        if edge.source_module == "reporting.control_plane_qre_adapter_contract"
+    ]
+    compatibility_forbidden = [
+        finding
+        for finding in report.forbidden_edges
+        if finding.source_module == "reporting.control_plane_qre_adapter_contract"
+    ]
+    compatibility_legacy = [
+        finding
+        for finding in report.legacy_edges
+        if finding.source_module == "reporting.control_plane_qre_adapter_contract"
+    ]
+
+    assert [
+        (edge.target_module, edge.target_domain) for edge in compatibility_edges
+    ] == [
+        ("__future__", "unknown"),
+        ("packages.control_plane_qre_adapter_contract", DOMAIN_ADAPTER_CONTRACT),
+    ]
+    assert compatibility_forbidden == []
+    assert [
+        (finding.rule, finding.target_module)
+        for finding in compatibility_legacy
+    ] == [
+        ("mixed-domain", "packages.control_plane_qre_adapter_contract"),
+    ]

--- a/tests/architecture/test_control_plane_qre_adapter_contract.py
+++ b/tests/architecture/test_control_plane_qre_adapter_contract.py
@@ -6,14 +6,17 @@ from pathlib import Path
 
 import pytest
 
+import packages.control_plane_qre_adapter_contract as canonical_contract
+import reporting.control_plane_qre_adapter_contract as compatibility_contract
 from reporting.architecture_import_scan import (
+    DOMAIN_ADAPTER_CONTRACT,
     DOMAIN_ADE,
     DOMAIN_CONTROL_PLANE,
     DOMAIN_QRE,
     ImportEdge,
     evaluate_edges,
 )
-from reporting.control_plane_qre_adapter_contract import (
+from packages.control_plane_qre_adapter_contract import (
     CONTRACT_NAME,
     CONTRACT_VERSION,
     FORBIDDEN_CAPABILITIES,
@@ -25,7 +28,12 @@ from reporting.control_plane_qre_adapter_contract import (
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-CONTRACT_PATH = REPO_ROOT / "reporting" / "control_plane_qre_adapter_contract.py"
+CANONICAL_CONTRACT_PATH = (
+    REPO_ROOT / "packages" / "control_plane_qre_adapter_contract" / "__init__.py"
+)
+COMPATIBILITY_CONTRACT_PATH = (
+    REPO_ROOT / "reporting" / "control_plane_qre_adapter_contract.py"
+)
 
 FORBIDDEN_IMPORT_PREFIXES = (
     "agent.execution",
@@ -60,6 +68,17 @@ MUTATION_VERBS = (
     "write",
 )
 
+PUBLIC_CONTRACT_NAMES = (
+    "AdapterContractDescription",
+    "CONTRACT_NAME",
+    "CONTRACT_VERSION",
+    "ControlPlaneQREReadAdapter",
+    "FORBIDDEN_CAPABILITIES",
+    "READ_ONLY_METHODS",
+    "ReadModelContract",
+    "describe_contract",
+)
+
 
 class _StubReadAdapter:
     def list_read_models(self) -> tuple[ReadModelContract, ...]:
@@ -90,6 +109,16 @@ def test_adapter_contract_is_runtime_checkable_and_read_only() -> None:
     assert adapter.describe_contract() == describe_contract()
 
 
+def test_canonical_and_compatibility_imports_expose_same_public_contract() -> None:
+    assert canonical_contract.__all__ == list(PUBLIC_CONTRACT_NAMES)
+    assert compatibility_contract.__all__ == list(PUBLIC_CONTRACT_NAMES)
+    for name in PUBLIC_CONTRACT_NAMES:
+        assert getattr(compatibility_contract, name) is getattr(
+            canonical_contract,
+            name,
+        )
+
+
 def test_adapter_contract_metadata_is_stable_and_frozen() -> None:
     description = describe_contract()
     read_model = ReadModelContract(
@@ -116,14 +145,7 @@ def test_adapter_contract_metadata_is_stable_and_frozen() -> None:
 
 
 def test_adapter_contract_is_stdlib_only_and_has_no_domain_imports() -> None:
-    tree = ast.parse(CONTRACT_PATH.read_text(encoding="utf-8"))
-    imported_modules: list[str] = []
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Import):
-            imported_modules.extend(alias.name for alias in node.names)
-        elif isinstance(node, ast.ImportFrom) and node.module:
-            imported_modules.append(node.module)
-
+    imported_modules = _imported_modules(CANONICAL_CONTRACT_PATH)
     violations = [
         module
         for module in imported_modules
@@ -141,8 +163,26 @@ def test_adapter_contract_is_stdlib_only_and_has_no_domain_imports() -> None:
     ]
 
 
+def test_reporting_compatibility_import_only_reexports_canonical_contract() -> None:
+    imported_modules = _imported_modules(COMPATIBILITY_CONTRACT_PATH)
+    violations = [
+        module
+        for module in imported_modules
+        if any(
+            module == prefix or module.startswith(prefix + ".")
+            for prefix in FORBIDDEN_IMPORT_PREFIXES
+        )
+    ]
+
+    assert violations == []
+    assert sorted(imported_modules) == [
+        "__future__",
+        "packages.control_plane_qre_adapter_contract",
+    ]
+
+
 def test_adapter_contract_exposes_no_mutation_or_route_surface() -> None:
-    tree = ast.parse(CONTRACT_PATH.read_text(encoding="utf-8"))
+    tree = ast.parse(CANONICAL_CONTRACT_PATH.read_text(encoding="utf-8"))
     public_functions = [
         node.name
         for node in ast.walk(tree)
@@ -173,7 +213,38 @@ def test_adapter_contract_exposes_no_mutation_or_route_surface() -> None:
     )
 
 
-def test_adapter_path_import_is_allowed_for_future_control_plane_code() -> None:
+def _imported_modules(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    imported_modules: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_modules.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported_modules.append(node.module)
+    return imported_modules
+
+
+def test_canonical_adapter_import_is_allowed_for_future_control_plane_code() -> None:
+    edge = ImportEdge(
+        source_module="dashboard.api_future_read_model",
+        target_module="packages.control_plane_qre_adapter_contract",
+        source_path="dashboard/api_future_read_model.py",
+        source_domain=DOMAIN_CONTROL_PLANE,
+        target_domain=DOMAIN_ADAPTER_CONTRACT,
+        target_root="packages",
+        line=4,
+        import_kind="from",
+    )
+
+    report = evaluate_edges((edge,))
+
+    assert report.forbidden_edges == ()
+    assert [(finding.rule, finding.source_module) for finding in report.legacy_edges] == [
+        ("mixed-domain", "dashboard.api_future_read_model")
+    ]
+
+
+def test_compatibility_adapter_import_is_allowed_for_future_control_plane_code() -> None:
     edge = ImportEdge(
         source_module="dashboard.api_future_read_model",
         target_module="reporting.control_plane_qre_adapter_contract",

--- a/tests/architecture/test_domain_import_scanner.py
+++ b/tests/architecture/test_domain_import_scanner.py
@@ -5,6 +5,7 @@ import subprocess
 from pathlib import Path
 
 from reporting.architecture_import_scan import (
+    DOMAIN_ADAPTER_CONTRACT,
     DOMAIN_ADE,
     DOMAIN_CONTROL_PLANE,
     DOMAIN_EXECUTION,
@@ -12,6 +13,7 @@ from reporting.architecture_import_scan import (
     DOMAIN_QRE,
     DOMAIN_TESTS,
     ImportEdge,
+    classify_module,
     classify_path,
     evaluate_edges,
     legacy_edge_allowlist_entries,
@@ -87,6 +89,14 @@ def test_domain_classifier_assigns_expected_domains() -> None:
     assert classify_path("research/run_research.py") == DOMAIN_QRE
     assert classify_path("dashboard/api_campaigns.py") == DOMAIN_CONTROL_PLANE
     assert classify_path("execution/protocols.py") == DOMAIN_EXECUTION
+    assert (
+        classify_path("packages/control_plane_qre_adapter_contract/__init__.py")
+        == DOMAIN_ADAPTER_CONTRACT
+    )
+    assert (
+        classify_module("packages.control_plane_qre_adapter_contract")
+        == DOMAIN_ADAPTER_CONTRACT
+    )
     assert classify_path("tests/architecture/test_x.py") == DOMAIN_TESTS
     assert classify_path(".claude/hooks/deny_no_touch.py") == DOMAIN_GOVERNANCE_TOOLING
     assert classify_path("scripts/governance_lint.py") == DOMAIN_GOVERNANCE_TOOLING


### PR DESCRIPTION
## Summary
- Extracts the control-plane/QRE read-only adapter contract into the canonical package namespace `packages.control_plane_qre_adapter_contract`.
- Keeps `reporting.control_plane_qre_adapter_contract` as a compatibility import shim that re-exports the canonical public contract.
- Adds narrow scanner classification for the new `adapter-contract` namespace and updates architecture tests.
- Documents the slice in `docs/architecture/EXTRACT-001-control-plane-qre-adapter-contract.md`.

## ARCH-006 Decision Reference
ARCH-006 decision: `GO_FIRST_EXTRACTION_SLICE`.

## New Canonical Namespace
`packages.control_plane_qre_adapter_contract`

## Compatibility Import Status
`reporting.control_plane_qre_adapter_contract` remains importable and re-exports the same public contract objects as the canonical package.

## Files Changed
- `docs/architecture/EXTRACT-001-control-plane-qre-adapter-contract.md`
- `packages/control_plane_qre_adapter_contract/__init__.py`
- `reporting/architecture_import_scan.py`
- `reporting/control_plane_qre_adapter_contract.py`
- `tests/architecture/test_arch_006_package_extraction_readiness.py`
- `tests/architecture/test_control_plane_qre_adapter_contract.py`
- `tests/architecture/test_domain_import_scanner.py`

## Validation Commands and Results
- `python -m pytest tests/architecture/test_control_plane_qre_adapter_contract.py -q` -> passed, 9 passed.
- `python -m pytest tests/architecture/test_domain_boundary_smoke.py -q` -> passed, 40 passed.
- `python -m pytest tests/architecture/test_domain_import_scanner.py -q` -> passed, 16 passed.
- `python -m pytest tests/architecture -q` -> passed, 70 passed.
- `python -m pytest tests/architecture/test_arch_006_package_extraction_readiness.py -q` -> passed, 5 passed.
- `python -m pytest tests/regression/test_authority_invariants.py -q` -> passed, 4 passed.

## Scanner Summary Result
`python -m reporting.architecture_import_scan --format summary` -> passed with `forbidden_edge_count: 0`, `legacy_edge_count: 75`, including visible legacy/report-only control-plane-to-QRE and ADE-to-QRE findings.

## Frozen Contract Status
Unchanged: `research/research_latest.json` and `strategy_matrix.csv`.

## Protected Path Status
Untouched: `.claude/**`, live/paper/shadow/risk/broker/execution behavior paths, dashboard runtime paths.

## No Runtime Behavior Change Status
No runtime behavior changes; this is a package-boundary extraction plus compatibility shim.

## No Dashboard Mutation Route Status
No dashboard mutation routes added.

## No Live/Paper/Shadow/Risk/Broker/Execution Change Status
No live, paper, shadow, risk, broker, or execution behavior changes.

## Recommended Next Action
continue with the next explicitly selected extraction item after EXTRACT-001 CI and post-merge gates pass.