### PR TITLE
ci: add path-aware PR gate optimization

### DIFF
--- a/.github/workflows/deploy-vps-dashboard.yml
+++ b/.github/workflows/deploy-vps-dashboard.yml
@@ -63,17 +63,56 @@ permissions:
   contents: read
 
 jobs:
+  path-guard:
+    name: path-guard (deploy eligibility)
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.conclusion == 'success')
+    outputs:
+      run_dashboard_deploy: ${{ steps.decision.outputs.run_dashboard_deploy }}
+    steps:
+      - name: Checkout repo for path classification
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
+        with:
+          fetch-depth: 2
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || 'main' }}
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.11"
+      - name: Classify workflow_run merge commit
+        id: classify
+        if: ${{ github.event_name == 'workflow_run' }}
+        run: python scripts/ci_path_classifier.py --base HEAD^ --head HEAD --github-output "${GITHUB_OUTPUT}"
+      - name: Decide deploy eligibility
+        id: decision
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "run_dashboard_deploy=true" >> "${GITHUB_OUTPUT}"
+            echo "Manual dispatch: proceeding to deploy."
+          elif [ "${{ steps.classify.outputs.run_dashboard_deploy }}" = "true" ]; then
+            echo "run_dashboard_deploy=true" >> "${GITHUB_OUTPUT}"
+            echo "Deployment-relevant paths changed; proceeding to deploy."
+          else
+            echo "run_dashboard_deploy=false" >> "${GITHUB_OUTPUT}"
+            echo "No deployment-relevant paths changed; skipping VPS deploy."
+          fi
+
   deploy:
     name: Deploy dashboard + nginx
+    needs: [path-guard]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     # Fire on a successful gate run, OR on a manual operator
     # dispatch. We deliberately do NOT fire on failed gate runs
     # (which would otherwise deploy a commit the gate rejected).
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'workflow_run' &&
-       github.event.workflow_run.conclusion == 'success')
+      needs.path-guard.outputs.run_dashboard_deploy == 'true' &&
+      (github.event_name == 'workflow_dispatch' ||
+       (github.event_name == 'workflow_run' &&
+        github.event.workflow_run.conclusion == 'success'))
 
     steps:
       - name: Checkout repo (for runner-side context only)

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -24,12 +24,39 @@ jobs:
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.conclusion == 'success')
+    outputs:
+      run_docker_build: ${{ steps.decision.outputs.run_docker_build }}
     steps:
-      - run: echo "Fast gate passed; proceeding to build."
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        with:
+          fetch-depth: 2
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || 'main' }}
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.11"
+      - name: Classify workflow_run merge commit
+        id: classify
+        if: ${{ github.event_name == 'workflow_run' }}
+        run: python scripts/ci_path_classifier.py --base HEAD^ --head HEAD --github-output "${GITHUB_OUTPUT}"
+      - name: Decide build eligibility
+        id: decision
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "run_docker_build=true" >> "${GITHUB_OUTPUT}"
+            echo "Manual dispatch: proceeding to build."
+          elif [ "${{ steps.classify.outputs.run_docker_build }}" = "true" ]; then
+            echo "run_docker_build=true" >> "${GITHUB_OUTPUT}"
+            echo "Deployment-relevant paths changed; proceeding to build."
+          else
+            echo "run_docker_build=false" >> "${GITHUB_OUTPUT}"
+            echo "No deployment-relevant paths changed; skipping Docker build."
+          fi
 
   build-grep-push:
     name: build-grep-push
     needs: [guard]
+    if: ${{ needs.guard.outputs.run_docker_build == 'true' }}
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,42 @@ env:
 
 jobs:
   # ---------------------------------------------------------------------------
+  # path-classifier - deterministic changed-path categories for path-aware jobs.
+  # This job never replaces safety gates; it only controls explicitly
+  # path-aware expensive jobs below.
+  # ---------------------------------------------------------------------------
+  path-classifier:
+    name: path-classifier
+    runs-on: ubuntu-latest
+    outputs:
+      architecture_only: ${{ steps.classify.outputs.architecture_only }}
+      ci_or_governance: ${{ steps.classify.outputs.ci_or_governance }}
+      dashboard_or_control_plane: ${{ steps.classify.outputs.dashboard_or_control_plane }}
+      deployment_sensitive: ${{ steps.classify.outputs.deployment_sensitive }}
+      docs_only: ${{ steps.classify.outputs.docs_only }}
+      execution_sensitive: ${{ steps.classify.outputs.execution_sensitive }}
+      frontend: ${{ steps.classify.outputs.frontend }}
+      packages: ${{ steps.classify.outputs.packages }}
+      qre_research: ${{ steps.classify.outputs.qre_research }}
+      run_docker_build: ${{ steps.classify.outputs.run_docker_build }}
+      run_dashboard_deploy: ${{ steps.classify.outputs.run_dashboard_deploy }}
+      run_frontend: ${{ steps.classify.outputs.run_frontend }}
+      tests: ${{ steps.classify.outputs.tests }}
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v5.1.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Classify changed paths
+        id: classify
+        env:
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: python scripts/ci_path_classifier.py --base "${BASE_SHA}" --head "${HEAD_SHA}" --github-output "${GITHUB_OUTPUT}"
+
+  # ---------------------------------------------------------------------------
   # lint — ruff, fast (<30s)
   # ---------------------------------------------------------------------------
   lint:
@@ -134,6 +170,25 @@ jobs:
         run: pytest tests/regression -q -k "pin or deterministic or digest or invariant"
 
   # ---------------------------------------------------------------------------
+  # architecture-boundary - always-on architecture boundary enforcement.
+  # ---------------------------------------------------------------------------
+  architecture-boundary:
+    name: architecture-boundary
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v5.1.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install pytest
+      - name: Run architecture boundary tests
+        run: pytest tests/architecture -q
+
+  # ---------------------------------------------------------------------------
   # hook-tests — required gate for the governance hook layer (v3.15.15.12.3).
   # If hooks are bypassed or weakened, this job fails and merge is blocked.
   # ---------------------------------------------------------------------------
@@ -158,6 +213,8 @@ jobs:
   # ---------------------------------------------------------------------------
   frontend:
     name: frontend (vitest)
+    needs: [path-classifier]
+    if: ${{ needs.path-classifier.outputs.run_frontend == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1

--- a/docs/governance/ci_path_aware_gates.md
+++ b/docs/governance/ci_path_aware_gates.md
@@ -1,0 +1,100 @@
+# CI Path-Aware Gates
+
+## Purpose
+
+CI-001 introduces deterministic changed-path classification so the repository
+can avoid unrelated expensive validation without weakening safety gates. The
+classifier is `scripts/ci_path_classifier.py`; it emits coarse booleans for
+workflow decisions and has unit coverage in `tests/unit/test_ci_path_classifier.py`.
+
+## Always-On Checks
+
+The fast pre-merge gate still runs these checks for every pull request and
+main push:
+
+- `path-classifier`.
+- `secret-scan (gitleaks)`.
+- `governance-lint`.
+- `architecture-boundary`.
+- `lint (ruff)`.
+- `typecheck (mypy narrow)`.
+- `unit (smoke + unit)`.
+- `regression-fast (determinism pins)`.
+- `hook-tests (governance hooks)`.
+
+These jobs are not path-skipped by CI-001. This preserves the existing
+branch-protection check names and keeps governance, hook, smoke, and
+determinism coverage active on every PR.
+
+## Path-Aware Checks
+
+The classifier reports at least these categories:
+
+- `docs_only`
+- `architecture_only`
+- `frontend`
+- `dashboard_or_control_plane`
+- `ade_governance_or_reporting`
+- `qre_research`
+- `packages`
+- `tests`
+- `ci_or_governance`
+- `execution_sensitive`
+
+The `frontend (vitest)` job runs only when changed paths touch frontend,
+dashboard/control-plane, CI/governance, or execution-sensitive surfaces. Plain
+docs-only, architecture-only, and package-contract-only changes avoid unrelated
+Vitest execution.
+
+## Deployment Gating
+
+`Build & Push Docker Image` and `Deploy VPS Dashboard` still trigger only after
+`Fast pre-merge gate` succeeds on `main`, or by explicit `workflow_dispatch`.
+For automatic `workflow_run` events, each workflow classifies the merge commit
+and proceeds only for deployment-relevant paths:
+
+- frontend paths;
+- dashboard/control-plane paths;
+- packages;
+- CI/governance paths;
+- execution-sensitive paths;
+- Docker/deploy/runtime configuration files.
+
+Docs-only and architecture-only changes safely skip image build and VPS deploy.
+Manual dispatch remains an operator-controlled override and is not path-skipped.
+
+## Safety Non-Regression Rules
+
+- Do not remove secret scanning.
+- Do not remove governance lint.
+- Do not remove hook tests.
+- Do not remove smoke/unit or regression-fast determinism checks.
+- Do not remove architecture boundary enforcement.
+- Do not change frozen contracts to make a path gate pass.
+- Do not use path gating to skip tests for changed code just because they are
+  slow.
+- Preserve existing required check names unless branch protection is updated by
+  an operator-controlled governance change.
+
+## Interpreting Skipped Jobs
+
+A skipped path-aware job means the classifier found no relevant changed path for
+that job. It does not mean the PR skipped safety validation: always-on checks
+must still pass. If a reviewer believes a skipped job should have run, treat the
+classifier rule as the defect and update it with a focused test.
+
+## Rollback Plan
+
+Revert the CI-001 workflow and classifier changes in one PR. The rollback
+returns frontend, Docker build, and dashboard deploy behavior to unconditional
+execution after the fast gate. Always-on checks require no rollback because they
+were not made conditional.
+
+## Known Limitations
+
+- Classification is path-based. It does not inspect imports or runtime call
+  graphs.
+- Automatic Docker/deploy gating compares the merge commit against its first
+  parent, which is appropriate for the repository's squash-merge lifecycle.
+- Package changes remain deployment-relevant because packages can be included in
+  built images.

--- a/scripts/ci_path_classifier.py
+++ b/scripts/ci_path_classifier.py
@@ -1,0 +1,194 @@
+"""Classify changed files for path-aware CI gates.
+
+The classifier is intentionally deterministic and conservative. It emits
+coarse domain booleans only; workflows decide which jobs consume them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+ZERO_SHA = "0" * 40
+
+
+def _norm(path: str) -> str:
+    return path.strip().replace("\\", "/").lstrip("./")
+
+
+def _matches_any(path: str, prefixes: tuple[str, ...]) -> bool:
+    return any(path == prefix.rstrip("/") or path.startswith(prefix) for prefix in prefixes)
+
+
+def _git_changed_files(base: str, head: str) -> list[str]:
+    if not base or base == ZERO_SHA:
+        args = ["git", "diff-tree", "--no-commit-id", "--name-only", "-r", head]
+    else:
+        args = ["git", "diff", "--name-only", f"{base}...{head}"]
+        probe = subprocess.run(
+            ["git", "merge-base", base, head],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        if probe.returncode != 0:
+            args = ["git", "diff", "--name-only", base, head]
+
+    result = subprocess.run(
+        args,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [line for line in result.stdout.splitlines() if line.strip()]
+
+
+def _is_docs_path(path: str) -> bool:
+    return path.startswith("docs/") or (
+        "/" not in path and path.lower().endswith((".md", ".rst", ".txt"))
+    )
+
+
+def _is_architecture_path(path: str) -> bool:
+    return path.startswith(("docs/architecture/", "docs/adr/", "tests/architecture/")) or path in {
+        "reporting/architecture_import_scan.py",
+    }
+
+
+def classify_paths(paths: list[str]) -> dict[str, bool]:
+    changed = sorted({p for p in (_norm(path) for path in paths) if p})
+
+    categories = {
+        "docs_only": False,
+        "architecture_only": False,
+        "frontend": False,
+        "dashboard_or_control_plane": False,
+        "ade_governance_or_reporting": False,
+        "qre_research": False,
+        "packages": False,
+        "tests": False,
+        "ci_or_governance": False,
+        "deployment_sensitive": False,
+        "execution_sensitive": False,
+    }
+
+    for path in changed:
+        if path.startswith("frontend/"):
+            categories["frontend"] = True
+        if path.startswith(("dashboard/", "apps/control-plane/")):
+            categories["dashboard_or_control_plane"] = True
+        if path.startswith(("packages/ade_governance/", "reporting/", "orchestration/")):
+            categories["ade_governance_or_reporting"] = True
+        if path.startswith(("research/", "strategies/", "agent/backtesting/")) or path in {
+            "registry.py",
+            "researchctl.py",
+        }:
+            categories["qre_research"] = True
+        if path.startswith("packages/"):
+            categories["packages"] = True
+        if path.startswith("tests/"):
+            categories["tests"] = True
+        if (
+            path.startswith((".github/", "docs/governance/"))
+            or path in {
+                ".gitleaks.toml",
+                ".pre-commit-config.yaml",
+                "pyproject.toml",
+                "pytest.ini",
+                "requirements.txt",
+                "SECURITY.md",
+            }
+            or _matches_any(path, ("scripts/", ".claude/"))
+        ):
+            categories["ci_or_governance"] = True
+        if path.startswith(("ops/", "config/")) or path in {
+            ".dockerignore",
+            "Dockerfile",
+            "docker-compose.prod.yml",
+            "docker-compose.yml",
+            "requirements.txt",
+            "VERSION",
+        }:
+            categories["deployment_sensitive"] = True
+        if path in {"scripts/deploy.sh", "scripts/deploy_vps_dashboard.sh"}:
+            categories["deployment_sensitive"] = True
+        if path.startswith(
+            (
+                "agent/execution/",
+                "agent/risk/",
+                "automation/",
+                "broker/",
+                "execution/",
+                "live/",
+                "paper/",
+                "shadow/",
+                "trading/",
+            )
+        ):
+            categories["execution_sensitive"] = True
+
+    if changed:
+        categories["docs_only"] = all(_is_docs_path(path) for path in changed) and not categories[
+            "ci_or_governance"
+        ]
+        categories["architecture_only"] = all(_is_architecture_path(path) for path in changed)
+
+    categories["run_frontend"] = (
+        categories["frontend"]
+        or categories["dashboard_or_control_plane"]
+        or categories["ci_or_governance"]
+        or categories["execution_sensitive"]
+    )
+    categories["run_docker_build"] = (
+        categories["frontend"]
+        or categories["dashboard_or_control_plane"]
+        or categories["packages"]
+        or categories["ci_or_governance"]
+        or categories["deployment_sensitive"]
+        or categories["execution_sensitive"]
+    )
+    categories["run_dashboard_deploy"] = categories["run_docker_build"]
+
+    return categories
+
+
+def _bool(value: bool) -> str:
+    return "true" if value else "false"
+
+
+def _write_outputs(outputs: dict[str, bool], path: str | None) -> None:
+    lines = [f"{key}={_bool(value)}" for key, value in sorted(outputs.items())]
+    if path:
+        with Path(path).open("a", encoding="utf-8") as fh:
+            for line in lines:
+                fh.write(f"{line}\n")
+    for line in lines:
+        print(line)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("paths", nargs="*", help="Changed paths to classify.")
+    parser.add_argument("--base", help="Base git revision for diff classification.")
+    parser.add_argument("--head", help="Head git revision for diff classification.")
+    parser.add_argument("--github-output", help="Path to the GitHub Actions output file.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    paths = list(args.paths)
+    if args.base or args.head:
+        if not args.head:
+            raise SystemExit("--head is required when --base is provided")
+        paths.extend(_git_changed_files(args.base or "", args.head))
+    outputs = classify_paths(paths)
+    _write_outputs(outputs, args.github_output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_ci_path_classifier.py
+++ b/tests/unit/test_ci_path_classifier.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from scripts.ci_path_classifier import classify_paths
+
+
+def test_docs_only_excludes_frontend_and_deploy_domains() -> None:
+    result = classify_paths(["docs/research_quality_kpis.md", "CHANGELOG.md"])
+
+    assert result["docs_only"] is True
+    assert result["frontend"] is False
+    assert result["dashboard_or_control_plane"] is False
+    assert result["ci_or_governance"] is False
+    assert result["run_frontend"] is False
+    assert result["run_docker_build"] is False
+
+
+def test_governance_docs_are_ci_or_governance_not_docs_only() -> None:
+    result = classify_paths(["docs/governance/ci_path_aware_gates.md"])
+
+    assert result["ci_or_governance"] is True
+    assert result["docs_only"] is False
+    assert result["run_frontend"] is True
+    assert result["run_docker_build"] is True
+
+
+def test_architecture_only_accepts_adr_and_architecture_tests() -> None:
+    result = classify_paths(
+        [
+            "docs/adr/ADR-014-truth-authority-settlement.md",
+            "tests/architecture/test_domain_boundary_smoke.py",
+        ]
+    )
+
+    assert result["architecture_only"] is True
+    assert result["tests"] is True
+    assert result["run_frontend"] is False
+    assert result["run_docker_build"] is False
+
+
+def test_frontend_dashboard_packages_and_research_domains() -> None:
+    result = classify_paths(
+        [
+            "frontend/src/App.test.tsx",
+            "dashboard/api_agent_control.py",
+            "packages/qre_control_plane_adapter/__init__.py",
+            "research/run_research.py",
+        ]
+    )
+
+    assert result["frontend"] is True
+    assert result["dashboard_or_control_plane"] is True
+    assert result["packages"] is True
+    assert result["qre_research"] is True
+    assert result["run_frontend"] is True
+    assert result["run_docker_build"] is True
+
+
+def test_ci_and_execution_sensitive_paths_are_explicit() -> None:
+    result = classify_paths(
+        [
+            ".github/workflows/tests.yml",
+            "scripts/governance_lint.py",
+            "execution/protocols.py",
+            "agent/risk/limits.py",
+        ]
+    )
+
+    assert result["ci_or_governance"] is True
+    assert result["execution_sensitive"] is True
+    assert result["deployment_sensitive"] is False
+    assert result["run_dashboard_deploy"] is True
+
+
+def test_deployment_sensitive_runtime_files_trigger_build_and_deploy() -> None:
+    result = classify_paths(["Dockerfile", "scripts/deploy_vps_dashboard.sh"])
+
+    assert result["deployment_sensitive"] is True
+    assert result["run_docker_build"] is True
+    assert result["run_dashboard_deploy"] is True


### PR DESCRIPTION
## Summary
- Add deterministic changed-path classification for CI path-aware gates.
- Keep existing safety gates always-on and preserve existing required check names.
- Gate unrelated frontend Vitest plus post-merge Docker build / VPS deploy based on changed paths.

## Path-aware behavior added
- Added `scripts/ci_path_classifier.py` with categories for docs, architecture, frontend, dashboard/control-plane, governance/reporting, QRE research, packages, tests, CI/governance, deployment-sensitive, and execution-sensitive paths.
- Added `path-classifier` to `Fast pre-merge gate`.
- `frontend (vitest)` now runs only for frontend, dashboard/control-plane, CI/governance, or execution-sensitive changes.
- Added classifier unit coverage in `tests/unit/test_ci_path_classifier.py`.

## Always-on checks preserved
- Secret scan remains always-on.
- Governance lint remains always-on.
- Ruff lint, mypy narrow, smoke/unit, regression-fast, and hook tests remain always-on.
- Added an always-on `architecture-boundary` job for `pytest tests/architecture -q`.

## Deployment gating behavior
- Docker build and dashboard deploy still require successful `Fast pre-merge gate` on `main` or explicit manual dispatch.
- Automatic workflow_run build/deploy now proceeds only for deployment-relevant changed paths.
- Docs-only and architecture-only changes safely skip Docker build and VPS deploy.
- Manual dispatch remains operator-controlled and is not path-skipped.

## Files changed
- `.github/workflows/tests.yml`
- `.github/workflows/docker-build.yml`
- `.github/workflows/deploy-vps-dashboard.yml`
- `scripts/ci_path_classifier.py`
- `tests/unit/test_ci_path_classifier.py`
- `docs/governance/ci_path_aware_gates.md`

## Validation commands and results
- `python -m pytest tests\unit\test_ci_path_classifier.py -q` — 6 passed.
- `python -m pytest tests\architecture\test_domain_boundary_smoke.py -q` — 40 passed.
- `python -m pytest tests\architecture\test_domain_import_scanner.py -q` — 16 passed.
- `python -m pytest tests\architecture -q` — 70 passed.
- `python -m pytest tests\unit\test_vps_deploy_invariants.py -q` — 40 passed.
- `python -m pytest tests\unit\test_ci_path_classifier.py tests\unit\test_vps_deploy_invariants.py -q` — 46 passed.
- `python -m ruff check scripts\ci_path_classifier.py tests\unit\test_ci_path_classifier.py` — passed.
- Workflow YAML parse with PyYAML for `.github/workflows/*.yml` — passed.
- `python scripts\governance_lint.py` in clean temporary worktree — `Governance lint OK (16 agents, 5 workflows checked)`.
- `actionlint` is not installed locally; GitHub Actions CI remains the workflow semantics validator.

## Frozen contract status
- `research/research_latest.json` unchanged.
- `research/strategy_matrix.csv` unchanged.

## Protected path status
- No `.claude/**` changes.
- No live/paper/shadow/risk/broker/execution behavior changes.
- No dashboard mutation routes added.
- Known local transcript and weekly summary files remain untracked and unstaged.

## No runtime behavior change status
- Runtime application code is unchanged.
- Changes are limited to CI workflows, CI classifier tooling, tests, and governance documentation.

## Safety-gate preservation statement
- This PR targets validation selection only; it does not remove secret scanning, governance lint, hook tests, architecture enforcement, smoke/unit checks, or determinism pins.

## Known limitations
- Classification is path-based and does not inspect import graphs.
- Automatic build/deploy gating uses the squash-merge commit diff against its first parent.
- Package changes remain deployment-relevant because packages can be included in built images.

## Recommended next action only
return to QRE Feature Build Track: review next Roadmap v6 research-intelligence phase