### PR TITLE
refactor: extract ADE governance import contracts

### DIFF
--- a/docs/architecture/EXTRACT-002-ade-governance-import-contracts.md
+++ b/docs/architecture/EXTRACT-002-ade-governance-import-contracts.md
@@ -1,0 +1,110 @@
+# EXTRACT-002 - ADE Governance Import Contracts Package
+
+Status: implemented
+Date: 2026-05-22
+Builds on:
+
+- `docs/architecture/ARCH-006-package-extraction-readiness-decision.md`
+- `docs/architecture/EXTRACT-001-control-plane-qre-adapter-contract.md`
+- `reporting/architecture_import_scan.py`
+- `packages/control_plane_qre_adapter_contract/`
+
+## Selected Slice
+
+EXTRACT-002 selects one small architecture-support package-boundary slice:
+move the immutable architecture import scanner contract vocabulary and frozen
+report dataclasses into the canonical ADE governance package namespace.
+
+New canonical namespace:
+
+```text
+packages/ade_governance/architecture_import_contracts.py
+```
+
+Compatibility path:
+
+```text
+reporting/architecture_import_scan.py
+```
+
+The scanner continues to expose the same public constants and dataclasses from
+the reporting path by importing and re-exporting the canonical package objects.
+
+## Why This Slice Was Selected
+
+This slice is adjacent to EXTRACT-001 because both changes extract stdlib-only
+contract/support surfaces before any runtime migration. It is bounded because
+it moves only immutable scanner vocabulary and data shapes:
+
+- domain constants;
+- execution-domain prefix constants;
+- frozen dataclasses for import edges, boundary findings, reports, and legacy
+  allowlist entries.
+
+Scanner traversal, scanner policy evaluation, exact legacy allowlists, CLI
+behavior, dashboard code, QRE runtime code, and frozen artifacts remain in their
+current locations.
+
+## Exact Files and Modules
+
+Introduced:
+
+- `packages/ade_governance/__init__.py`
+- `packages/ade_governance/architecture_import_contracts.py`
+- `tests/architecture/test_ade_governance_architecture_import_contracts.py`
+- `docs/architecture/EXTRACT-002-ade-governance-import-contracts.md`
+
+Updated:
+
+- `reporting/architecture_import_scan.py`
+- `tests/architecture/test_domain_import_scanner.py`
+
+## Boundary and Risk Status
+
+No runtime behavior change: the scanner CLI and scan/evaluation functions remain
+in `reporting.architecture_import_scan`.
+
+No frozen contract change: `research_latest.json`, `strategy_matrix.csv`, frozen
+schemas, and regression pins are not modified.
+
+No dashboard mutation route: no dashboard route or API module is changed.
+
+No live/paper/shadow/risk/broker/execution change: no module in those behavior
+paths is modified, and the new canonical package imports only stdlib modules.
+
+No authority semantics change: the closed scanner rules and exact
+legacy/report-only allowlist entries remain in `reporting.architecture_import_scan`.
+
+Legacy/report-only findings remain visible. No broad wildcard allowlist is added.
+
+## Validation Commands
+
+```powershell
+pytest tests/architecture/test_ade_governance_architecture_import_contracts.py -q
+pytest tests/architecture/test_domain_boundary_smoke.py -q
+pytest tests/architecture/test_domain_import_scanner.py -q
+pytest tests/architecture -q
+python -m reporting.architecture_import_scan --format summary
+```
+
+## Rollback Plan
+
+Revert this EXTRACT-002 commit. That restores the scanner constants and
+dataclasses to `reporting/architecture_import_scan.py` and removes the
+`packages/ade_governance` support namespace without changing dashboard, QRE,
+runtime, frozen artifact, or execution behavior.
+
+## EXTRACT Series Decision
+
+Selected value:
+`EXTRACT_SERIES_COMPLETE_READY_FOR_PACKAGE_MIGRATION`
+
+Rationale: EXTRACT-001 established the read-only control-plane/QRE adapter
+contract package, and EXTRACT-002 establishes the minimal ADE governance support
+contract package needed before package migration planning. Continuing extraction
+only because additional small modules exist would violate the EXTRACT-series
+clarity rule.
+
+Exactly one next recommended action: start PACKAGE-MIGRATION-001 to plan the
+first bounded migration step using the package namespaces proven by EXTRACT-001
+and EXTRACT-002.

--- a/packages/ade_governance/__init__.py
+++ b/packages/ade_governance/__init__.py
@@ -1,0 +1,39 @@
+"""ADE governance support contracts.
+
+The package is stdlib-only and contains governance support surfaces that can be
+shared before broader package migration.
+"""
+
+from __future__ import annotations
+
+from packages.ade_governance.architecture_import_contracts import (
+    DOMAIN_ADAPTER_CONTRACT,
+    DOMAIN_ADE,
+    DOMAIN_CONTROL_PLANE,
+    DOMAIN_EXECUTION,
+    DOMAIN_GOVERNANCE_TOOLING,
+    DOMAIN_QRE,
+    DOMAIN_TESTS,
+    DOMAIN_UNKNOWN,
+    EXECUTION_PATH_ROOTS,
+    BoundaryFinding,
+    BoundaryReport,
+    ImportEdge,
+    LegacyEdgeAllowlistEntry,
+)
+
+__all__ = [
+    "BoundaryFinding",
+    "BoundaryReport",
+    "DOMAIN_ADAPTER_CONTRACT",
+    "DOMAIN_ADE",
+    "DOMAIN_CONTROL_PLANE",
+    "DOMAIN_EXECUTION",
+    "DOMAIN_GOVERNANCE_TOOLING",
+    "DOMAIN_QRE",
+    "DOMAIN_TESTS",
+    "DOMAIN_UNKNOWN",
+    "EXECUTION_PATH_ROOTS",
+    "ImportEdge",
+    "LegacyEdgeAllowlistEntry",
+]

--- a/packages/ade_governance/architecture_import_contracts.py
+++ b/packages/ade_governance/architecture_import_contracts.py
@@ -1,0 +1,92 @@
+"""Frozen contracts for deterministic architecture import scans.
+
+This module intentionally contains only immutable vocabulary and data shapes.
+Scanner traversal, policy evaluation, allowlists, and CLI behavior remain in
+``reporting.architecture_import_scan``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+DOMAIN_ADE = "ADE"
+DOMAIN_QRE = "QRE"
+DOMAIN_CONTROL_PLANE = "control-plane"
+DOMAIN_EXECUTION = "execution"
+DOMAIN_ADAPTER_CONTRACT = "adapter-contract"
+DOMAIN_TESTS = "tests"
+DOMAIN_GOVERNANCE_TOOLING = "governance tooling"
+DOMAIN_UNKNOWN = "unknown"
+
+EXECUTION_PATH_ROOTS = frozenset(
+    {
+        "agent.execution",
+        "agent.risk",
+        "automation.live_gate",
+        "broker",
+        "execution",
+        "live",
+        "paper",
+        "risk",
+        "shadow",
+    }
+)
+
+
+@dataclass(frozen=True)
+class ImportEdge:
+    source_module: str
+    target_module: str
+    source_path: str
+    source_domain: str
+    target_domain: str
+    target_root: str
+    line: int
+    import_kind: str
+    target_path: str | None = None
+
+
+@dataclass(frozen=True)
+class BoundaryFinding:
+    source_module: str
+    target_module: str
+    source_path: str
+    source_domain: str
+    target_domain: str
+    target_root: str
+    line: int
+    rule: str
+
+
+@dataclass(frozen=True)
+class BoundaryReport:
+    edges: tuple[ImportEdge, ...]
+    forbidden_edges: tuple[BoundaryFinding, ...]
+    legacy_edges: tuple[BoundaryFinding, ...]
+
+
+@dataclass(frozen=True)
+class LegacyEdgeAllowlistEntry:
+    source_module: str
+    target_module: str
+    rule: str
+    status: str
+    reason: str
+    sunset: str
+
+
+__all__ = [
+    "BoundaryFinding",
+    "BoundaryReport",
+    "DOMAIN_ADAPTER_CONTRACT",
+    "DOMAIN_ADE",
+    "DOMAIN_CONTROL_PLANE",
+    "DOMAIN_EXECUTION",
+    "DOMAIN_GOVERNANCE_TOOLING",
+    "DOMAIN_QRE",
+    "DOMAIN_TESTS",
+    "DOMAIN_UNKNOWN",
+    "EXECUTION_PATH_ROOTS",
+    "ImportEdge",
+    "LegacyEdgeAllowlistEntry",
+]

--- a/reporting/architecture_import_scan.py
+++ b/reporting/architecture_import_scan.py
@@ -12,74 +12,25 @@ import ast
 import json
 import subprocess
 from collections import Counter
-from dataclasses import asdict, dataclass
+from dataclasses import asdict
 from pathlib import Path
 from typing import Iterable, Sequence
 
-DOMAIN_ADE = "ADE"
-DOMAIN_QRE = "QRE"
-DOMAIN_CONTROL_PLANE = "control-plane"
-DOMAIN_EXECUTION = "execution"
-DOMAIN_ADAPTER_CONTRACT = "adapter-contract"
-DOMAIN_TESTS = "tests"
-DOMAIN_GOVERNANCE_TOOLING = "governance tooling"
-DOMAIN_UNKNOWN = "unknown"
-
-EXECUTION_PATH_ROOTS = frozenset(
-    {
-        "agent.execution",
-        "agent.risk",
-        "automation.live_gate",
-        "broker",
-        "execution",
-        "live",
-        "paper",
-        "risk",
-        "shadow",
-    }
+from packages.ade_governance.architecture_import_contracts import (
+    DOMAIN_ADAPTER_CONTRACT,
+    DOMAIN_ADE,
+    DOMAIN_CONTROL_PLANE,
+    DOMAIN_EXECUTION,
+    DOMAIN_GOVERNANCE_TOOLING,
+    DOMAIN_QRE,
+    DOMAIN_TESTS,
+    DOMAIN_UNKNOWN,
+    EXECUTION_PATH_ROOTS,
+    BoundaryFinding,
+    BoundaryReport,
+    ImportEdge,
+    LegacyEdgeAllowlistEntry,
 )
-
-
-@dataclass(frozen=True)
-class ImportEdge:
-    source_module: str
-    target_module: str
-    source_path: str
-    source_domain: str
-    target_domain: str
-    target_root: str
-    line: int
-    import_kind: str
-    target_path: str | None = None
-
-
-@dataclass(frozen=True)
-class BoundaryFinding:
-    source_module: str
-    target_module: str
-    source_path: str
-    source_domain: str
-    target_domain: str
-    target_root: str
-    line: int
-    rule: str
-
-
-@dataclass(frozen=True)
-class BoundaryReport:
-    edges: tuple[ImportEdge, ...]
-    forbidden_edges: tuple[BoundaryFinding, ...]
-    legacy_edges: tuple[BoundaryFinding, ...]
-
-
-@dataclass(frozen=True)
-class LegacyEdgeAllowlistEntry:
-    source_module: str
-    target_module: str
-    rule: str
-    status: str
-    reason: str
-    sunset: str
 
 
 LEGACY_EDGE_ALLOWLIST: tuple[LegacyEdgeAllowlistEntry, ...] = (
@@ -332,6 +283,8 @@ def classify_path(path: Path | str) -> str:
         return DOMAIN_TESTS
     if normalized.startswith(".claude/hooks/") or first == "scripts":
         return DOMAIN_GOVERNANCE_TOOLING
+    if normalized.startswith("packages/ade_governance/"):
+        return DOMAIN_ADE
     if normalized.startswith("packages/control_plane_qre_adapter_contract/"):
         return DOMAIN_ADAPTER_CONTRACT
     if first == "dashboard" or first == "frontend":
@@ -359,6 +312,10 @@ def classify_module(module_name: str, module_index: dict[str, Path] | None = Non
     if top == "dashboard":
         return DOMAIN_CONTROL_PLANE
     if top == "reporting":
+        return DOMAIN_ADE
+    if module_name == "packages.ade_governance" or module_name.startswith(
+        "packages.ade_governance."
+    ):
         return DOMAIN_ADE
     if (
         module_name == "packages.control_plane_qre_adapter_contract"

--- a/tests/architecture/test_ade_governance_architecture_import_contracts.py
+++ b/tests/architecture/test_ade_governance_architecture_import_contracts.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import packages.ade_governance.architecture_import_contracts as canonical_contracts
+import reporting.architecture_import_scan as compatibility_scanner
+from reporting.architecture_import_scan import (
+    DOMAIN_ADE,
+    DOMAIN_CONTROL_PLANE,
+    DOMAIN_EXECUTION,
+    DOMAIN_QRE,
+    BoundaryReport,
+    ImportEdge,
+    classify_module,
+    classify_path,
+    report_to_summary_dict,
+    scan_repo,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CANONICAL_CONTRACT_PATH = (
+    REPO_ROOT / "packages" / "ade_governance" / "architecture_import_contracts.py"
+)
+
+PUBLIC_CONTRACT_NAMES = (
+    "BoundaryFinding",
+    "BoundaryReport",
+    "DOMAIN_ADAPTER_CONTRACT",
+    "DOMAIN_ADE",
+    "DOMAIN_CONTROL_PLANE",
+    "DOMAIN_EXECUTION",
+    "DOMAIN_GOVERNANCE_TOOLING",
+    "DOMAIN_QRE",
+    "DOMAIN_TESTS",
+    "DOMAIN_UNKNOWN",
+    "EXECUTION_PATH_ROOTS",
+    "ImportEdge",
+    "LegacyEdgeAllowlistEntry",
+)
+
+FORBIDDEN_IMPORT_PREFIXES = (
+    "agent.execution",
+    "agent.risk",
+    "automation.live_gate",
+    "broker",
+    "dashboard",
+    "execution",
+    "flask",
+    "live",
+    "paper",
+    "research",
+    "risk",
+    "shadow",
+)
+
+
+def test_architecture_import_contracts_have_canonical_package_path() -> None:
+    edge = ImportEdge(
+        source_module="reporting.future_architecture_tool",
+        target_module="packages.ade_governance.architecture_import_contracts",
+        source_path="reporting/future_architecture_tool.py",
+        source_domain=DOMAIN_ADE,
+        target_domain=DOMAIN_ADE,
+        target_root="packages",
+        line=3,
+        import_kind="from",
+    )
+
+    report = BoundaryReport(edges=(edge,), forbidden_edges=(), legacy_edges=())
+
+    assert classify_path(CANONICAL_CONTRACT_PATH.relative_to(REPO_ROOT)) == DOMAIN_ADE
+    assert (
+        classify_module("packages.ade_governance.architecture_import_contracts")
+        == DOMAIN_ADE
+    )
+    assert report_to_summary_dict(report)["forbidden_edge_count"] == 0
+
+
+def test_reporting_scanner_reexports_same_public_contract_objects() -> None:
+    assert canonical_contracts.__all__ == list(PUBLIC_CONTRACT_NAMES)
+    for name in PUBLIC_CONTRACT_NAMES:
+        assert getattr(compatibility_scanner, name) is getattr(
+            canonical_contracts,
+            name,
+        )
+
+
+def test_architecture_import_contracts_are_stdlib_only() -> None:
+    imported_modules = _imported_modules(CANONICAL_CONTRACT_PATH)
+    violations = [
+        module
+        for module in imported_modules
+        if any(
+            module == prefix or module.startswith(prefix + ".")
+            for prefix in FORBIDDEN_IMPORT_PREFIXES
+        )
+    ]
+
+    assert violations == []
+    assert imported_modules == ["__future__", "dataclasses"]
+
+
+def test_architecture_import_contracts_introduce_no_runtime_or_dashboard_edges() -> None:
+    report = scan_repo(REPO_ROOT)
+    contract_edges = [
+        edge
+        for edge in report.edges
+        if edge.source_module
+        == "packages.ade_governance.architecture_import_contracts"
+    ]
+    contract_forbidden = [
+        finding
+        for finding in report.forbidden_edges
+        if finding.source_module
+        == "packages.ade_governance.architecture_import_contracts"
+    ]
+    contract_legacy = [
+        finding
+        for finding in report.legacy_edges
+        if finding.source_module
+        == "packages.ade_governance.architecture_import_contracts"
+    ]
+
+    assert [(edge.target_module, edge.target_domain) for edge in contract_edges] == [
+        ("__future__", "unknown"),
+        ("dataclasses", "unknown"),
+    ]
+    assert contract_forbidden == []
+    assert contract_legacy == []
+
+
+def test_scanner_summary_still_reports_legacy_without_hard_failures() -> None:
+    summary = report_to_summary_dict(scan_repo(REPO_ROOT))
+    legacy_by_rule_and_domain = {
+        (row["rule"], row["source_domain"], row["target_domain"]): row[
+            "finding_count"
+        ]
+        for row in summary["legacy_finding_categories"]
+    }
+
+    assert summary["forbidden_edge_count"] == 0
+    assert summary["legacy_edge_count"] > 0
+    assert (
+        legacy_by_rule_and_domain[
+            ("control-plane-to-qre", DOMAIN_CONTROL_PLANE, DOMAIN_QRE)
+        ]
+        == 18
+    )
+    assert legacy_by_rule_and_domain[
+        ("mixed-domain", DOMAIN_QRE, DOMAIN_EXECUTION)
+    ] == 11
+
+
+def _imported_modules(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    imported_modules: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_modules.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported_modules.append(node.module)
+    return imported_modules

--- a/tests/architecture/test_domain_import_scanner.py
+++ b/tests/architecture/test_domain_import_scanner.py
@@ -94,8 +94,16 @@ def test_domain_classifier_assigns_expected_domains() -> None:
         == DOMAIN_ADAPTER_CONTRACT
     )
     assert (
+        classify_path("packages/ade_governance/architecture_import_contracts.py")
+        == DOMAIN_ADE
+    )
+    assert (
         classify_module("packages.control_plane_qre_adapter_contract")
         == DOMAIN_ADAPTER_CONTRACT
+    )
+    assert (
+        classify_module("packages.ade_governance.architecture_import_contracts")
+        == DOMAIN_ADE
     )
     assert classify_path("tests/architecture/test_x.py") == DOMAIN_TESTS
     assert classify_path(".claude/hooks/deny_no_touch.py") == DOMAIN_GOVERNANCE_TOOLING


### PR DESCRIPTION
## Summary
- extract immutable architecture import scanner constants and frozen dataclasses into `packages.ade_governance.architecture_import_contracts`
- preserve `reporting.architecture_import_scan` compatibility imports and scanner CLI behavior
- document EXTRACT-002 and decide `EXTRACT_SERIES_COMPLETE_READY_FOR_PACKAGE_MIGRATION`

## Scope controls
- no runtime behavior change
- no dashboard route or mutation route change
- no frozen contract change
- no live/paper/shadow/risk/broker/execution path change
- legacy/report-only scanner findings remain visible; no wildcard allowlist added

## Validation
- `pytest tests/architecture/test_ade_governance_architecture_import_contracts.py -q`
- `pytest tests/architecture/test_domain_boundary_smoke.py -q`
- `pytest tests/architecture/test_domain_import_scanner.py -q`
- `pytest tests/architecture -q`
- `python -m reporting.architecture_import_scan --format summary` -> `forbidden_edge_count: 0`, `legacy_edge_count: 75`