### PR TITLE
refactor: migrate ADE governance read-only contracts

### DIFF
--- a/docs/architecture/PACKAGE-MIGRATION-002-ade-governance-read-only-contracts.md
+++ b/docs/architecture/PACKAGE-MIGRATION-002-ade-governance-read-only-contracts.md
@@ -1,0 +1,116 @@
+# PACKAGE-MIGRATION-002 - ADE Governance Read-Only Contracts
+
+Status: implemented
+Date: 2026-05-22
+Builds on:
+
+- `docs/architecture/PACKAGE-MIGRATION-001-target-layout-skeleton.md`
+- `docs/architecture/EXTRACT-002-ade-governance-import-contracts.md`
+- `reporting/architecture_import_scan.py`
+
+## Purpose and Scope
+
+PACKAGE-MIGRATION-002 migrates the already-extracted ADE governance read-only
+architecture import contracts into the narrower package layout established by
+PACKAGE-MIGRATION-001.
+
+This is a bounded migration slice. It does not migrate all `reporting/`, move
+dashboard routes, move QRE runtime modules, change execution, live, paper,
+shadow, risk, or broker behavior, change frozen contracts, or activate Addendum
+1, Addendum 2, or Addendum 3 work.
+
+## Selected Migration Slice
+
+Source contract prepared by EXTRACT-002:
+
+```text
+packages/ade_governance/architecture_import_contracts.py
+```
+
+New canonical namespace:
+
+```text
+packages/ade_governance/import_contracts/architecture_import.py
+```
+
+Compatibility import paths:
+
+```text
+packages/ade_governance/architecture_import_contracts.py
+reporting/architecture_import_scan.py
+packages/ade_governance/__init__.py
+packages/ade_governance/import_contracts/__init__.py
+```
+
+The compatibility paths re-export the exact canonical public objects.
+
+## Files Changed
+
+- `packages/ade_governance/import_contracts/__init__.py`
+- `packages/ade_governance/import_contracts/architecture_import.py`
+- `packages/ade_governance/architecture_import_contracts.py`
+- `packages/ade_governance/__init__.py`
+- `packages/ade_governance/README.md`
+- `reporting/architecture_import_scan.py`
+- `tests/architecture/test_ade_governance_architecture_import_contracts.py`
+- `tests/architecture/test_domain_import_scanner.py`
+- `tests/architecture/test_package_migration_002_ade_governance_read_only_contracts.py`
+- `docs/architecture/PACKAGE-MIGRATION-002-ade-governance-read-only-contracts.md`
+
+## Boundary and Risk Status
+
+No runtime behavior change: scanner traversal, policy evaluation, allowlists,
+reporting CLI behavior, dashboard code, QRE runtime code, and execution paths
+remain in place.
+
+No frozen research outputs were changed. `research/research_latest.json`,
+`strategy_matrix.csv`, frozen schemas, and regression pins are not modified.
+
+No `.claude/**` files were changed.
+
+No dashboard mutation routes were added. No dashboard route, frontend route, or
+control-plane runtime route wiring is added.
+
+No live, paper, shadow, risk, broker, or execution behavior was changed.
+
+Legacy/report-only findings remain visible. No broad wildcard allowlist is
+added.
+
+## Scanner Classification
+
+`packages/ade_governance/` remains classified as `ADE`.
+
+The new canonical contract module
+`packages.ade_governance.import_contracts.architecture_import` is classified as
+`ADE`, not QRE, control-plane, or execution.
+
+## Validation Commands
+
+```powershell
+pytest tests/architecture/test_package_migration_002_ade_governance_read_only_contracts.py -q
+pytest tests/architecture/test_ade_governance_architecture_import_contracts.py -q
+pytest tests/architecture/test_domain_boundary_smoke.py -q
+pytest tests/architecture/test_domain_import_scanner.py -q
+pytest tests/architecture -q
+pytest tests/unit/test_ci_path_classifier.py -q
+python -m reporting.architecture_import_scan --format summary
+```
+
+## Rollback Plan
+
+Revert the PACKAGE-MIGRATION-002 commit. That restores
+`packages.ade_governance.architecture_import_contracts` as the direct
+implementation and removes the narrower `import_contracts` namespace without
+changing dashboard, QRE runtime, frozen artifact, or execution behavior.
+
+## Package Migration Decision
+
+Selected value: `PACKAGE_MIGRATION_CONTINUES_WITH_BOUNDED_NEXT_UNIT`
+
+Rationale: ADE governance read-only contracts now live under the target
+package namespace with compatibility preserved and without runtime movement.
+The next safest migration is the already-proven control-plane read-only adapter
+consumer or package boundary, selected as one bounded unit.
+
+Exact next recommended unit:
+PACKAGE-MIGRATION-003 - Migrate Control-Plane Read-Only Adapter Consumer or Package Boundary.

--- a/packages/ade_governance/README.md
+++ b/packages/ade_governance/README.md
@@ -8,9 +8,10 @@ deterministic governance support surfaces.
 
 ## Current Status
 
-Status: active extracted seed content. EXTRACT-002 placed immutable architecture
-import scan contracts in this package while scanner execution remains in
-`reporting/architecture_import_scan.py`.
+Status: active extracted seed content. PACKAGE-MIGRATION-002 re-homed the
+immutable architecture import scan contracts under
+`packages.ade_governance.import_contracts.architecture_import` while scanner
+execution remains in `reporting/architecture_import_scan.py`.
 
 ## Source of Truth / Authority Boundary
 
@@ -43,7 +44,9 @@ until each surface is migrated by a bounded package-migration unit.
 
 Existing `reporting/` paths remain compatible surfaces unless a future unit
 explicitly replaces them. Current seed content is importable as
-`packages.ade_governance`.
+`packages.ade_governance`. The EXTRACT-002 module path
+`packages.ade_governance.architecture_import_contracts` remains a compatibility
+shim.
 
 ## Activation Status
 

--- a/packages/ade_governance/architecture_import_contracts.py
+++ b/packages/ade_governance/architecture_import_contracts.py
@@ -1,78 +1,26 @@
-"""Frozen contracts for deterministic architecture import scans.
+"""Compatibility shim for ADE architecture import contracts.
 
-This module intentionally contains only immutable vocabulary and data shapes.
-Scanner traversal, policy evaluation, allowlists, and CLI behavior remain in
-``reporting.architecture_import_scan``.
+The canonical implementation lives in
+``packages.ade_governance.import_contracts.architecture_import``.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-
-DOMAIN_ADE = "ADE"
-DOMAIN_QRE = "QRE"
-DOMAIN_CONTROL_PLANE = "control-plane"
-DOMAIN_EXECUTION = "execution"
-DOMAIN_ADAPTER_CONTRACT = "adapter-contract"
-DOMAIN_TESTS = "tests"
-DOMAIN_GOVERNANCE_TOOLING = "governance tooling"
-DOMAIN_UNKNOWN = "unknown"
-
-EXECUTION_PATH_ROOTS = frozenset(
-    {
-        "agent.execution",
-        "agent.risk",
-        "automation.live_gate",
-        "broker",
-        "execution",
-        "live",
-        "paper",
-        "risk",
-        "shadow",
-    }
+from packages.ade_governance.import_contracts.architecture_import import (
+    DOMAIN_ADAPTER_CONTRACT,
+    DOMAIN_ADE,
+    DOMAIN_CONTROL_PLANE,
+    DOMAIN_EXECUTION,
+    DOMAIN_GOVERNANCE_TOOLING,
+    DOMAIN_QRE,
+    DOMAIN_TESTS,
+    DOMAIN_UNKNOWN,
+    EXECUTION_PATH_ROOTS,
+    BoundaryFinding,
+    BoundaryReport,
+    ImportEdge,
+    LegacyEdgeAllowlistEntry,
 )
-
-
-@dataclass(frozen=True)
-class ImportEdge:
-    source_module: str
-    target_module: str
-    source_path: str
-    source_domain: str
-    target_domain: str
-    target_root: str
-    line: int
-    import_kind: str
-    target_path: str | None = None
-
-
-@dataclass(frozen=True)
-class BoundaryFinding:
-    source_module: str
-    target_module: str
-    source_path: str
-    source_domain: str
-    target_domain: str
-    target_root: str
-    line: int
-    rule: str
-
-
-@dataclass(frozen=True)
-class BoundaryReport:
-    edges: tuple[ImportEdge, ...]
-    forbidden_edges: tuple[BoundaryFinding, ...]
-    legacy_edges: tuple[BoundaryFinding, ...]
-
-
-@dataclass(frozen=True)
-class LegacyEdgeAllowlistEntry:
-    source_module: str
-    target_module: str
-    rule: str
-    status: str
-    reason: str
-    sunset: str
 
 
 __all__ = [

--- a/packages/ade_governance/import_contracts/__init__.py
+++ b/packages/ade_governance/import_contracts/__init__.py
@@ -1,8 +1,4 @@
-"""ADE governance support contracts.
-
-The package is stdlib-only and contains governance support surfaces that can be
-shared before broader package migration.
-"""
+"""Read-only ADE governance import contracts."""
 
 from __future__ import annotations
 

--- a/packages/ade_governance/import_contracts/architecture_import.py
+++ b/packages/ade_governance/import_contracts/architecture_import.py
@@ -1,0 +1,92 @@
+"""Frozen contracts for deterministic architecture import scans.
+
+This module intentionally contains only immutable vocabulary and data shapes.
+Scanner traversal, policy evaluation, allowlists, and CLI behavior remain in
+``reporting.architecture_import_scan``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+DOMAIN_ADE = "ADE"
+DOMAIN_QRE = "QRE"
+DOMAIN_CONTROL_PLANE = "control-plane"
+DOMAIN_EXECUTION = "execution"
+DOMAIN_ADAPTER_CONTRACT = "adapter-contract"
+DOMAIN_TESTS = "tests"
+DOMAIN_GOVERNANCE_TOOLING = "governance tooling"
+DOMAIN_UNKNOWN = "unknown"
+
+EXECUTION_PATH_ROOTS = frozenset(
+    {
+        "agent.execution",
+        "agent.risk",
+        "automation.live_gate",
+        "broker",
+        "execution",
+        "live",
+        "paper",
+        "risk",
+        "shadow",
+    }
+)
+
+
+@dataclass(frozen=True)
+class ImportEdge:
+    source_module: str
+    target_module: str
+    source_path: str
+    source_domain: str
+    target_domain: str
+    target_root: str
+    line: int
+    import_kind: str
+    target_path: str | None = None
+
+
+@dataclass(frozen=True)
+class BoundaryFinding:
+    source_module: str
+    target_module: str
+    source_path: str
+    source_domain: str
+    target_domain: str
+    target_root: str
+    line: int
+    rule: str
+
+
+@dataclass(frozen=True)
+class BoundaryReport:
+    edges: tuple[ImportEdge, ...]
+    forbidden_edges: tuple[BoundaryFinding, ...]
+    legacy_edges: tuple[BoundaryFinding, ...]
+
+
+@dataclass(frozen=True)
+class LegacyEdgeAllowlistEntry:
+    source_module: str
+    target_module: str
+    rule: str
+    status: str
+    reason: str
+    sunset: str
+
+
+__all__ = [
+    "BoundaryFinding",
+    "BoundaryReport",
+    "DOMAIN_ADAPTER_CONTRACT",
+    "DOMAIN_ADE",
+    "DOMAIN_CONTROL_PLANE",
+    "DOMAIN_EXECUTION",
+    "DOMAIN_GOVERNANCE_TOOLING",
+    "DOMAIN_QRE",
+    "DOMAIN_TESTS",
+    "DOMAIN_UNKNOWN",
+    "EXECUTION_PATH_ROOTS",
+    "ImportEdge",
+    "LegacyEdgeAllowlistEntry",
+]

--- a/reporting/architecture_import_scan.py
+++ b/reporting/architecture_import_scan.py
@@ -16,7 +16,7 @@ from collections.abc import Iterable, Sequence
 from dataclasses import asdict
 from pathlib import Path
 
-from packages.ade_governance.architecture_import_contracts import (
+from packages.ade_governance.import_contracts.architecture_import import (
     DOMAIN_ADAPTER_CONTRACT,
     DOMAIN_ADE,
     DOMAIN_CONTROL_PLANE,

--- a/tests/architecture/test_ade_governance_architecture_import_contracts.py
+++ b/tests/architecture/test_ade_governance_architecture_import_contracts.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-import packages.ade_governance.architecture_import_contracts as canonical_contracts
+import packages.ade_governance.architecture_import_contracts as legacy_contracts
+import packages.ade_governance.import_contracts.architecture_import as canonical_contracts
 import reporting.architecture_import_scan as compatibility_scanner
 from reporting.architecture_import_scan import (
     DOMAIN_ADE,
@@ -20,6 +21,13 @@ from reporting.architecture_import_scan import (
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CANONICAL_CONTRACT_PATH = (
+    REPO_ROOT
+    / "packages"
+    / "ade_governance"
+    / "import_contracts"
+    / "architecture_import.py"
+)
+LEGACY_CONTRACT_PATH = (
     REPO_ROOT / "packages" / "ade_governance" / "architecture_import_contracts.py"
 )
 
@@ -58,7 +66,7 @@ FORBIDDEN_IMPORT_PREFIXES = (
 def test_architecture_import_contracts_have_canonical_package_path() -> None:
     edge = ImportEdge(
         source_module="reporting.future_architecture_tool",
-        target_module="packages.ade_governance.architecture_import_contracts",
+        target_module="packages.ade_governance.import_contracts.architecture_import",
         source_path="reporting/future_architecture_tool.py",
         source_domain=DOMAIN_ADE,
         target_domain=DOMAIN_ADE,
@@ -71,15 +79,25 @@ def test_architecture_import_contracts_have_canonical_package_path() -> None:
 
     assert classify_path(CANONICAL_CONTRACT_PATH.relative_to(REPO_ROOT)) == DOMAIN_ADE
     assert (
+        classify_module("packages.ade_governance.import_contracts.architecture_import")
+        == DOMAIN_ADE
+    )
+    assert classify_path(LEGACY_CONTRACT_PATH.relative_to(REPO_ROOT)) == DOMAIN_ADE
+    assert (
         classify_module("packages.ade_governance.architecture_import_contracts")
         == DOMAIN_ADE
     )
     assert report_to_summary_dict(report)["forbidden_edge_count"] == 0
 
 
-def test_reporting_scanner_reexports_same_public_contract_objects() -> None:
+def test_legacy_and_reporting_paths_reexport_same_public_contract_objects() -> None:
     assert canonical_contracts.__all__ == list(PUBLIC_CONTRACT_NAMES)
+    assert legacy_contracts.__all__ == list(PUBLIC_CONTRACT_NAMES)
     for name in PUBLIC_CONTRACT_NAMES:
+        assert getattr(legacy_contracts, name) is getattr(
+            canonical_contracts,
+            name,
+        )
         assert getattr(compatibility_scanner, name) is getattr(
             canonical_contracts,
             name,
@@ -107,19 +125,19 @@ def test_architecture_import_contracts_introduce_no_runtime_or_dashboard_edges()
         edge
         for edge in report.edges
         if edge.source_module
-        == "packages.ade_governance.architecture_import_contracts"
+        == "packages.ade_governance.import_contracts.architecture_import"
     ]
     contract_forbidden = [
         finding
         for finding in report.forbidden_edges
         if finding.source_module
-        == "packages.ade_governance.architecture_import_contracts"
+        == "packages.ade_governance.import_contracts.architecture_import"
     ]
     contract_legacy = [
         finding
         for finding in report.legacy_edges
         if finding.source_module
-        == "packages.ade_governance.architecture_import_contracts"
+        == "packages.ade_governance.import_contracts.architecture_import"
     ]
 
     assert [(edge.target_module, edge.target_domain) for edge in contract_edges] == [

--- a/tests/architecture/test_domain_import_scanner.py
+++ b/tests/architecture/test_domain_import_scanner.py
@@ -98,11 +98,23 @@ def test_domain_classifier_assigns_expected_domains() -> None:
         == DOMAIN_ADE
     )
     assert (
+        classify_path(
+            "packages/ade_governance/import_contracts/architecture_import.py"
+        )
+        == DOMAIN_ADE
+    )
+    assert (
         classify_module("packages.control_plane_qre_adapter_contract")
         == DOMAIN_ADAPTER_CONTRACT
     )
     assert (
         classify_module("packages.ade_governance.architecture_import_contracts")
+        == DOMAIN_ADE
+    )
+    assert (
+        classify_module(
+            "packages.ade_governance.import_contracts.architecture_import"
+        )
         == DOMAIN_ADE
     )
     assert classify_path("tests/architecture/test_x.py") == DOMAIN_TESTS

--- a/tests/architecture/test_package_migration_002_ade_governance_read_only_contracts.py
+++ b/tests/architecture/test_package_migration_002_ade_governance_read_only_contracts.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import ast
+import subprocess
+from pathlib import Path
+
+import packages.ade_governance as package_exports
+import packages.ade_governance.architecture_import_contracts as legacy_contracts
+import packages.ade_governance.import_contracts as import_contracts
+import packages.ade_governance.import_contracts.architecture_import as canonical_contracts
+import reporting.architecture_import_scan as scanner_compatibility
+from reporting.architecture_import_scan import (
+    DOMAIN_ADE,
+    DOMAIN_CONTROL_PLANE,
+    DOMAIN_EXECUTION,
+    DOMAIN_QRE,
+    classify_module,
+    classify_path,
+    report_to_summary_dict,
+    scan_repo,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MIGRATION_DOC = (
+    REPO_ROOT
+    / "docs"
+    / "architecture"
+    / "PACKAGE-MIGRATION-002-ade-governance-read-only-contracts.md"
+)
+CANONICAL_CONTRACT_PATH = (
+    REPO_ROOT
+    / "packages"
+    / "ade_governance"
+    / "import_contracts"
+    / "architecture_import.py"
+)
+LEGACY_CONTRACT_PATH = (
+    REPO_ROOT / "packages" / "ade_governance" / "architecture_import_contracts.py"
+)
+FROZEN_CONTRACT_PATHS = {
+    "research/research_latest.json",
+    "strategy_matrix.csv",
+}
+PROTECTED_PATH_PREFIXES = (
+    ".claude/",
+    "agent/execution/",
+    "agent/risk/",
+    "automation/live_gate",
+    "broker/",
+    "execution/",
+    "live/",
+    "paper/",
+    "risk/",
+    "shadow/",
+)
+FORBIDDEN_IMPORT_PREFIXES = (
+    "agent.execution",
+    "agent.risk",
+    "automation.live_gate",
+    "broker",
+    "dashboard",
+    "execution",
+    "flask",
+    "live",
+    "paper",
+    "research",
+    "risk",
+    "shadow",
+)
+RUNTIME_ROUTE_PATH_PREFIXES = (
+    "dashboard/",
+    "frontend/",
+    "apps/control-plane/",
+)
+PUBLIC_CONTRACT_NAMES = (
+    "BoundaryFinding",
+    "BoundaryReport",
+    "DOMAIN_ADAPTER_CONTRACT",
+    "DOMAIN_ADE",
+    "DOMAIN_CONTROL_PLANE",
+    "DOMAIN_EXECUTION",
+    "DOMAIN_GOVERNANCE_TOOLING",
+    "DOMAIN_QRE",
+    "DOMAIN_TESTS",
+    "DOMAIN_UNKNOWN",
+    "EXECUTION_PATH_ROOTS",
+    "ImportEdge",
+    "LegacyEdgeAllowlistEntry",
+)
+
+
+def test_package_migration_002_canonical_namespace_imports() -> None:
+    assert canonical_contracts.__all__ == list(PUBLIC_CONTRACT_NAMES)
+    assert import_contracts.ImportEdge is canonical_contracts.ImportEdge
+    assert package_exports.ImportEdge is canonical_contracts.ImportEdge
+    assert (
+        classify_module("packages.ade_governance.import_contracts")
+        == DOMAIN_ADE
+    )
+    assert (
+        classify_module("packages.ade_governance.import_contracts.architecture_import")
+        == DOMAIN_ADE
+    )
+    assert classify_path(CANONICAL_CONTRACT_PATH.relative_to(REPO_ROOT)) == DOMAIN_ADE
+
+
+def test_package_migration_002_compatibility_imports_are_preserved() -> None:
+    for name in PUBLIC_CONTRACT_NAMES:
+        canonical_object = getattr(canonical_contracts, name)
+        assert getattr(legacy_contracts, name) is canonical_object
+        assert getattr(scanner_compatibility, name) is canonical_object
+
+
+def test_package_migration_002_contract_modules_are_stdlib_only() -> None:
+    assert _imported_modules(CANONICAL_CONTRACT_PATH) == [
+        "__future__",
+        "dataclasses",
+    ]
+    legacy_imports = _imported_modules(LEGACY_CONTRACT_PATH)
+    assert legacy_imports == [
+        "__future__",
+        "packages.ade_governance.import_contracts.architecture_import",
+    ]
+
+    for module in _imported_modules(CANONICAL_CONTRACT_PATH) + legacy_imports:
+        assert not _has_forbidden_import_prefix(module)
+
+
+def test_package_migration_002_scanner_has_no_forbidden_edges_and_keeps_legacy_visible() -> None:
+    summary = report_to_summary_dict(scan_repo(REPO_ROOT))
+    legacy_by_rule_and_domain = {
+        (row["rule"], row["source_domain"], row["target_domain"]): row[
+            "finding_count"
+        ]
+        for row in summary["legacy_finding_categories"]
+    }
+
+    assert summary["forbidden_edge_count"] == 0
+    assert summary["legacy_edge_count"] > 0
+    assert (
+        legacy_by_rule_and_domain[
+            ("control-plane-to-qre", DOMAIN_CONTROL_PLANE, DOMAIN_QRE)
+        ]
+        == 18
+    )
+    assert legacy_by_rule_and_domain[("ade-to-qre", DOMAIN_ADE, DOMAIN_QRE)] == 2
+    assert legacy_by_rule_and_domain[
+        ("mixed-domain", DOMAIN_QRE, DOMAIN_EXECUTION)
+    ] == 11
+
+
+def test_package_migration_002_changed_paths_stay_inside_bounded_slice() -> None:
+    changed_paths = _changed_paths()
+
+    assert changed_paths
+    assert FROZEN_CONTRACT_PATHS.isdisjoint(changed_paths)
+    assert not any(path.startswith(".claude/") for path in changed_paths)
+    assert not any(
+        path.startswith(prefix)
+        for path in changed_paths
+        for prefix in PROTECTED_PATH_PREFIXES
+    )
+    assert not any(
+        path.startswith(prefix)
+        for path in changed_paths
+        for prefix in RUNTIME_ROUTE_PATH_PREFIXES
+    )
+    assert all(
+        path.startswith(
+            (
+                "docs/architecture/",
+                "packages/ade_governance/",
+                "reporting/architecture_import_scan.py",
+                "tests/architecture/",
+            )
+        )
+        for path in changed_paths
+    )
+
+
+def test_package_migration_002_decision_doc_is_bounded_to_one_next_unit() -> None:
+    text = MIGRATION_DOC.read_text(encoding="utf-8")
+
+    assert "PACKAGE_MIGRATION_CONTINUES_WITH_BOUNDED_NEXT_UNIT" in text
+    assert text.count("Exact next recommended unit:") == 1
+    assert (
+        "PACKAGE-MIGRATION-003 - Migrate Control-Plane Read-Only Adapter Consumer "
+        "or Package Boundary"
+    ) in text
+    assert "No dashboard mutation routes were added." in text
+    assert (
+        "No live, paper, shadow, risk, broker, or execution behavior was changed."
+        in text
+    )
+    assert "No frozen research outputs were changed." in text
+    assert "No `.claude/**` files were changed." in text
+
+
+def _imported_modules(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    imported_modules: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_modules.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported_modules.append(node.module)
+    return imported_modules
+
+
+def _has_forbidden_import_prefix(module_name: str) -> bool:
+    return any(
+        module_name == prefix or module_name.startswith(prefix + ".")
+        for prefix in FORBIDDEN_IMPORT_PREFIXES
+    )
+
+
+def _changed_paths() -> set[str]:
+    paths: set[str] = set()
+    for args in (
+        ["diff", "--name-only", "main...HEAD"],
+        ["diff", "--name-only", "origin/main...HEAD"],
+        ["diff", "--name-only"],
+        ["diff", "--name-only", "--cached"],
+    ):
+        result = subprocess.run(
+            ["git", *args],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            continue
+        paths.update(
+            line.strip().replace("\\", "/")
+            for line in result.stdout.splitlines()
+            if line.strip()
+        )
+    return paths or _declared_migration_paths()
+
+
+def _declared_migration_paths() -> set[str]:
+    text = MIGRATION_DOC.read_text(encoding="utf-8")
+    marker = "## Files Changed"
+    start = text.index(marker)
+    next_section = text.index("\n## ", start + len(marker))
+    section = text[start:next_section]
+    return {
+        line.strip().removeprefix("- `").removesuffix("`")
+        for line in section.splitlines()
+        if line.strip().startswith("- `")
+    }


### PR DESCRIPTION
## Summary

Migrate the ADE governance read-only architecture import contracts into the narrower target package namespace created for PACKAGE-MIGRATION-002 while preserving all compatibility imports.

## Selected migration slice

- Source prepared by EXTRACT-002: `packages.ade_governance.architecture_import_contracts`
- Bounded target package slice only: ADE governance import contracts
- No broad `reporting/`, dashboard, QRE runtime, execution, live, paper, shadow, risk, or broker migration

## Canonical namespace

`packages.ade_governance.import_contracts.architecture_import`

## Compatibility import path(s)

- `packages.ade_governance.architecture_import_contracts`
- `packages.ade_governance.import_contracts`
- `packages.ade_governance`
- `reporting.architecture_import_scan` re-exports the same public contract objects

## Files changed

- `docs/architecture/PACKAGE-MIGRATION-002-ade-governance-read-only-contracts.md`
- `packages/ade_governance/README.md`
- `packages/ade_governance/__init__.py`
- `packages/ade_governance/architecture_import_contracts.py`
- `packages/ade_governance/import_contracts/__init__.py`
- `packages/ade_governance/import_contracts/architecture_import.py`
- `reporting/architecture_import_scan.py`
- `tests/architecture/test_ade_governance_architecture_import_contracts.py`
- `tests/architecture/test_domain_import_scanner.py`
- `tests/architecture/test_package_migration_002_ade_governance_read_only_contracts.py`

## Validation commands and results

- `pytest tests/architecture/test_package_migration_002_ade_governance_read_only_contracts.py -q` -> 6 passed
- `pytest tests/architecture/test_ade_governance_architecture_import_contracts.py -q` -> 5 passed
- `pytest tests/architecture/test_domain_boundary_smoke.py -q` -> 40 passed
- `pytest tests/architecture/test_domain_import_scanner.py -q` -> 16 passed
- `pytest tests/architecture -q` -> 89 passed
- `pytest tests/unit/test_ci_path_classifier.py -q` -> 6 passed
- `python -m ruff check packages/ade_governance reporting/architecture_import_scan.py tests/architecture/test_ade_governance_architecture_import_contracts.py tests/architecture/test_domain_import_scanner.py tests/architecture/test_package_migration_002_ade_governance_read_only_contracts.py` -> passed
- `python -m mypy --config-file pyproject.toml --explicit-package-bases` -> passed
- `python -m reporting.architecture_import_scan --format summary` -> passed

## Scanner summary result

- `forbidden_edge_count`: 0
- `legacy_edge_count`: 75
- Legacy/report-only findings remain visible.
- No broad wildcard allowlists were added.

## Frozen contract status

Unchanged: `research/research_latest.json`, `strategy_matrix.csv`, frozen schemas, and regression pins.

## Protected path status

Unchanged: `.claude/**` and protected execution/live/paper/shadow/risk/broker paths.

## No runtime behavior change status

No scanner traversal, scanner policy evaluation, allowlist semantics, CLI behavior, dashboard runtime, QRE runtime, or reporting runtime behavior changed.

## No dashboard mutation route status

No dashboard mutation route, frontend route, or control-plane runtime route wiring was added.

## No live/paper/shadow/risk/broker/execution behavior change status

No live, paper, shadow, risk, broker, or execution behavior was modified or activated.

## Exact next recommended unit

PACKAGE-MIGRATION-003 - Migrate Control-Plane Read-Only Adapter Consumer or Package Boundary.