### PR TITLE
refactor: migrate control-plane read-only adapter boundary

### DIFF
--- a/apps/control-plane/README.md
+++ b/apps/control-plane/README.md
@@ -7,8 +7,18 @@ control-plane UI and API surfaces.
 
 ## Current Status
 
-Status: scaffold-only. Current runtime dashboard and frontend code remains in
-`dashboard/` and `frontend/`.
+Status: package-boundary skeleton. Current runtime dashboard and frontend code
+remains in `dashboard/` and `frontend/`.
+
+PACKAGE-MIGRATION-003 adds one non-routed read-only adapter boundary module:
+
+```text
+apps/control-plane/read_only_adapter_boundary.py
+```
+
+The module consumes only the canonical
+`packages.control_plane_qre_adapter_contract` package and exposes no Flask
+route, dashboard wiring, mutation surface, or QRE runtime import.
 
 ## Source of Truth / Authority Boundary
 
@@ -40,8 +50,10 @@ behavior.
 ## Current Compatibility Policy
 
 Existing `dashboard/` and `frontend/` imports remain authoritative. This
-directory provides no compatibility import and no executable runtime surface.
+directory provides no dashboard route compatibility import and no executable
+runtime surface. The read-only adapter boundary exists only to pin the target
+control-plane package boundary against the canonical adapter contract.
 
 ## Activation Status
 
-Activation status: scaffold-only.
+Activation status: boundary-only; not runtime-wired.

--- a/apps/control-plane/read_only_adapter_boundary.py
+++ b/apps/control-plane/read_only_adapter_boundary.py
@@ -1,0 +1,21 @@
+"""Control-plane read-only boundary for the QRE adapter contract.
+
+This module is intentionally not wired into dashboard routes. It proves the
+target control-plane app boundary can consume the extracted adapter contract
+without importing QRE runtime modules.
+"""
+
+from __future__ import annotations
+
+from packages.control_plane_qre_adapter_contract import (
+    AdapterContractDescription,
+    describe_contract,
+)
+
+
+def describe_read_only_adapter_boundary() -> AdapterContractDescription:
+    """Return the canonical control-plane/QRE read adapter contract."""
+    return describe_contract()
+
+
+__all__ = ["describe_read_only_adapter_boundary"]

--- a/docs/architecture/PACKAGE-MIGRATION-003-control-plane-read-only-adapter-boundary.md
+++ b/docs/architecture/PACKAGE-MIGRATION-003-control-plane-read-only-adapter-boundary.md
@@ -1,0 +1,171 @@
+# PACKAGE-MIGRATION-003 - Control-Plane Read-Only Adapter Boundary
+
+Status: implemented
+Date: 2026-05-22
+Builds on:
+
+- `docs/architecture/PACKAGE-MIGRATION-001-target-layout-skeleton.md`
+- `docs/architecture/PACKAGE-MIGRATION-002-ade-governance-read-only-contracts.md`
+- `docs/architecture/EXTRACT-001-control-plane-qre-adapter-contract.md`
+- `docs/architecture/EXTRACT-002-ade-governance-import-contracts.md`
+- `packages/control_plane_qre_adapter_contract/`
+- `packages/ade_governance/`
+- `reporting/architecture_import_scan.py`
+
+## Purpose and Scope
+
+PACKAGE-MIGRATION-003 migrates one bounded control-plane package-boundary
+slice toward the target app layout by introducing a read-only adapter boundary
+inside `apps/control-plane`.
+
+This unit does not migrate all `dashboard/`, move all `apps/control-plane`,
+move QRE runtime modules, change runtime dashboard route wiring, change frozen
+contracts, add dashboard mutation routes, or activate live, paper, shadow,
+risk, broker, or execution behavior.
+
+## Selected Migration Slice
+
+Selected slice:
+
+```text
+apps/control-plane/read_only_adapter_boundary.py
+```
+
+The module consumes the canonical adapter contract:
+
+```text
+packages.control_plane_qre_adapter_contract
+```
+
+and exposes a single non-routed boundary helper:
+
+```text
+describe_read_only_adapter_boundary()
+```
+
+## Why This Slice Was Selected
+
+Inspection showed that existing dashboard read-only API modules still import
+QRE artifact path constants directly under exact legacy/report-only scanner
+allowlists. Migrating one of those runtime consumers now would require either a
+new QRE facade package or dashboard route wiring changes, which is broader than
+this unit.
+
+The safer bounded slice is therefore the control-plane app boundary itself:
+create one scanner-visible, non-routed consumer of the already extracted
+adapter contract. This proves the target control-plane boundary can depend on
+the adapter contract package without importing QRE runtime modules and without
+moving dashboard routes.
+
+## Exact Files/Modules Migrated or Introduced
+
+- `apps/control-plane/read_only_adapter_boundary.py`
+- `apps/control-plane/README.md`
+- `tests/architecture/test_package_migration_001_target_layout.py`
+- `tests/architecture/test_package_migration_003_control_plane_read_only_adapter_boundary.py`
+- `docs/architecture/PACKAGE-MIGRATION-003-control-plane-read-only-adapter-boundary.md`
+
+## New Canonical Namespace
+
+No new importable Python namespace is introduced because the target app path is
+the filesystem boundary `apps/control-plane/`.
+
+The canonical adapter contract remains:
+
+```text
+packages.control_plane_qre_adapter_contract
+```
+
+## Old Compatibility Path
+
+The existing compatibility import path remains:
+
+```text
+reporting.control_plane_qre_adapter_contract
+```
+
+It continues to re-export the canonical adapter contract objects. The new
+control-plane boundary imports the canonical package directly.
+
+## What Did Not Move
+
+- No dashboard route module moved.
+- No `dashboard/` runtime registration changed.
+- No QRE research, strategy, registry, orchestration, or artifact writer moved.
+- No ADE governance runtime implementation moved.
+- No execution, live, paper, shadow, risk, broker, or order behavior moved.
+- No frozen research output moved or regenerated.
+
+## Runtime Behavior and Equivalence Statement
+
+No runtime behavior changed. The new boundary module is not imported or wired by
+dashboard runtime code. It exposes the same deterministic
+`AdapterContractDescription` returned by the canonical
+`packages.control_plane_qre_adapter_contract.describe_contract()` function.
+
+## Frozen Contract Status
+
+No frozen research outputs were changed. `research/research_latest.json`,
+`strategy_matrix.csv`, frozen schemas, and regression pins are not modified.
+
+No `.claude/**` files were changed.
+
+## Dashboard Mutation Route Status
+
+No dashboard mutation routes were added. The new boundary module contains no
+Flask import, route decorator, HTTP method declaration, or dashboard route
+wiring.
+
+## Live/Paper/Shadow/Risk/Broker/Execution Status
+
+No live, paper, shadow, risk, broker, or execution behavior was changed. The new
+boundary module imports only the canonical read-only adapter contract package.
+
+## Scanner Classification
+
+The existing scanner classifications remain:
+
+```text
+apps/control-plane/ -> control-plane
+packages/control_plane_qre_adapter_contract/ -> adapter-contract
+packages/ade_governance/ -> ADE
+```
+
+The new boundary creates one visible mixed-domain edge from control-plane to
+adapter-contract. It creates no control-plane-to-QRE, ADE-to-QRE, or
+QRE-to-execution hard forbidden edge.
+
+## Validation Commands
+
+```powershell
+pytest tests/architecture/test_package_migration_003_control_plane_read_only_adapter_boundary.py -q
+pytest tests/architecture/test_package_migration_001_target_layout.py -q
+pytest tests/architecture/test_control_plane_qre_adapter_contract.py -q
+pytest tests/architecture/test_domain_boundary_smoke.py -q
+pytest tests/architecture/test_domain_import_scanner.py -q
+pytest tests/architecture -q
+pytest tests/unit/test_ci_path_classifier.py -q
+python -m reporting.architecture_import_scan --format summary
+```
+
+## Rollback Plan
+
+Revert the PACKAGE-MIGRATION-003 commit. That removes the non-routed
+`apps/control-plane/read_only_adapter_boundary.py` module and restores
+`apps/control-plane` to the previous scaffold-only status without changing
+dashboard runtime routes, QRE runtime modules, frozen outputs, or execution
+behavior.
+
+## Package Migration Decision
+
+Selected value: `PACKAGE_MIGRATION_CONTINUES_WITH_BOUNDED_NEXT_UNIT`
+
+Rationale: The control-plane boundary now has one scanner-visible read-only
+adapter contract consumer while dashboard runtime migration remains deferred.
+The next safest bounded package migration is the QRE diagnostics read-only
+package boundary, because current dashboard observability imports are
+diagnostics read-only path constants and can be evaluated as a narrow
+diagnostics facade without moving execution-sensitive behavior.
+
+Exact next recommended unit:
+PACKAGE-MIGRATION-004 - Migrate QRE Diagnostics Read-Only Package Boundary.

--- a/tests/architecture/test_package_migration_001_target_layout.py
+++ b/tests/architecture/test_package_migration_001_target_layout.py
@@ -45,7 +45,6 @@ README_REQUIRED_SECTIONS = (
 )
 
 SCAFFOLD_ONLY_TARGETS = (
-    REPO_ROOT / "apps" / "control-plane",
     REPO_ROOT / "packages" / "qre_research",
     REPO_ROOT / "packages" / "qre_data",
     REPO_ROOT / "packages" / "qre_artifacts",

--- a/tests/architecture/test_package_migration_003_control_plane_read_only_adapter_boundary.py
+++ b/tests/architecture/test_package_migration_003_control_plane_read_only_adapter_boundary.py
@@ -1,18 +1,18 @@
 from __future__ import annotations
 
 import ast
+import importlib.util
 import subprocess
 from pathlib import Path
+from types import ModuleType
 
-import packages.ade_governance as package_exports
-import packages.ade_governance.architecture_import_contracts as legacy_contracts
-import packages.ade_governance.import_contracts as import_contracts
-import packages.ade_governance.import_contracts.architecture_import as canonical_contracts
-import reporting.architecture_import_scan as scanner_compatibility
+import packages.control_plane_qre_adapter_contract as canonical_contract
+import reporting.control_plane_qre_adapter_contract as compatibility_contract
+from packages.control_plane_qre_adapter_contract import describe_contract
 from reporting.architecture_import_scan import (
+    DOMAIN_ADAPTER_CONTRACT,
     DOMAIN_ADE,
     DOMAIN_CONTROL_PLANE,
-    DOMAIN_EXECUTION,
     DOMAIN_QRE,
     classify_module,
     classify_path,
@@ -21,21 +21,12 @@ from reporting.architecture_import_scan import (
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+BOUNDARY_PATH = REPO_ROOT / "apps" / "control-plane" / "read_only_adapter_boundary.py"
 MIGRATION_DOC = (
     REPO_ROOT
     / "docs"
     / "architecture"
-    / "PACKAGE-MIGRATION-002-ade-governance-read-only-contracts.md"
-)
-CANONICAL_CONTRACT_PATH = (
-    REPO_ROOT
-    / "packages"
-    / "ade_governance"
-    / "import_contracts"
-    / "architecture_import.py"
-)
-LEGACY_CONTRACT_PATH = (
-    REPO_ROOT / "packages" / "ade_governance" / "architecture_import_contracts.py"
+    / "PACKAGE-MIGRATION-003-control-plane-read-only-adapter-boundary.md"
 )
 FROZEN_CONTRACT_PATHS = {
     "research/research_latest.json",
@@ -53,6 +44,11 @@ PROTECTED_PATH_PREFIXES = (
     "risk/",
     "shadow/",
 )
+ALLOWED_CHANGED_PATH_PREFIXES = (
+    "apps/control-plane/",
+    "docs/architecture/",
+    "tests/architecture/",
+)
 FORBIDDEN_IMPORT_PREFIXES = (
     "agent.execution",
     "agent.risk",
@@ -67,66 +63,74 @@ FORBIDDEN_IMPORT_PREFIXES = (
     "risk",
     "shadow",
 )
-RUNTIME_ROUTE_PATH_PREFIXES = (
-    "dashboard/",
-    "frontend/",
-    "apps/control-plane/",
-)
 PUBLIC_CONTRACT_NAMES = (
-    "BoundaryFinding",
-    "BoundaryReport",
-    "DOMAIN_ADAPTER_CONTRACT",
-    "DOMAIN_ADE",
-    "DOMAIN_CONTROL_PLANE",
-    "DOMAIN_EXECUTION",
-    "DOMAIN_GOVERNANCE_TOOLING",
-    "DOMAIN_QRE",
-    "DOMAIN_TESTS",
-    "DOMAIN_UNKNOWN",
-    "EXECUTION_PATH_ROOTS",
-    "ImportEdge",
-    "LegacyEdgeAllowlistEntry",
+    "AdapterContractDescription",
+    "CONTRACT_NAME",
+    "CONTRACT_VERSION",
+    "ControlPlaneQREReadAdapter",
+    "FORBIDDEN_CAPABILITIES",
+    "READ_ONLY_METHODS",
+    "ReadModelContract",
+    "describe_contract",
 )
+FORBIDDEN_HTTP_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
 
 
-def test_package_migration_002_canonical_namespace_imports() -> None:
-    assert canonical_contracts.__all__ == list(PUBLIC_CONTRACT_NAMES)
-    assert import_contracts.ImportEdge is canonical_contracts.ImportEdge
-    assert package_exports.ImportEdge is canonical_contracts.ImportEdge
+def test_package_migration_003_boundary_imports_canonical_contract() -> None:
+    boundary = _load_boundary_module()
+
+    assert boundary.describe_read_only_adapter_boundary() == describe_contract()
+    assert classify_path(BOUNDARY_PATH.relative_to(REPO_ROOT)) == DOMAIN_CONTROL_PLANE
     assert (
-        classify_module("packages.ade_governance.import_contracts")
-        == DOMAIN_ADE
+        classify_module("packages.control_plane_qre_adapter_contract")
+        == DOMAIN_ADAPTER_CONTRACT
     )
-    assert (
-        classify_module("packages.ade_governance.import_contracts.architecture_import")
-        == DOMAIN_ADE
-    )
-    assert classify_path(CANONICAL_CONTRACT_PATH.relative_to(REPO_ROOT)) == DOMAIN_ADE
+    assert classify_path("packages/ade_governance/README.md") == DOMAIN_ADE
 
 
-def test_package_migration_002_compatibility_imports_are_preserved() -> None:
+def test_package_migration_003_compatibility_path_still_exposes_same_contract() -> None:
+    assert canonical_contract.__all__ == list(PUBLIC_CONTRACT_NAMES)
+    assert compatibility_contract.__all__ == list(PUBLIC_CONTRACT_NAMES)
     for name in PUBLIC_CONTRACT_NAMES:
-        canonical_object = getattr(canonical_contracts, name)
-        assert getattr(legacy_contracts, name) is canonical_object
-        assert getattr(scanner_compatibility, name) is canonical_object
+        assert getattr(compatibility_contract, name) is getattr(
+            canonical_contract,
+            name,
+        )
 
 
-def test_package_migration_002_contract_modules_are_stdlib_only() -> None:
-    assert _imported_modules(CANONICAL_CONTRACT_PATH) == [
+def test_package_migration_003_boundary_is_stdlib_plus_adapter_contract_only() -> None:
+    imported_modules = _imported_modules(BOUNDARY_PATH)
+
+    assert imported_modules == [
         "__future__",
-        "dataclasses",
+        "packages.control_plane_qre_adapter_contract",
     ]
-    legacy_imports = _imported_modules(LEGACY_CONTRACT_PATH)
-    assert legacy_imports == [
-        "__future__",
-        "packages.ade_governance.import_contracts.architecture_import",
+    assert not any(_has_forbidden_import_prefix(module) for module in imported_modules)
+
+
+def test_package_migration_003_adds_no_dashboard_mutation_or_runtime_route() -> None:
+    tree = ast.parse(BOUNDARY_PATH.read_text(encoding="utf-8"))
+    route_decorators = [
+        decorator
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        for decorator in node.decorator_list
+        if isinstance(decorator, ast.Call)
+        and isinstance(decorator.func, ast.Attribute)
+        and decorator.func.attr == "route"
+    ]
+    string_constants = [
+        node.value for node in ast.walk(tree) if isinstance(node, ast.Constant)
     ]
 
-    for module in _imported_modules(CANONICAL_CONTRACT_PATH) + legacy_imports:
-        assert not _has_forbidden_import_prefix(module)
+    assert route_decorators == []
+    assert "flask" not in _imported_modules(BOUNDARY_PATH)
+    assert "Flask" not in string_constants
+    assert "Blueprint" not in string_constants
+    assert not any(value in FORBIDDEN_HTTP_METHODS for value in string_constants)
 
 
-def test_package_migration_002_scanner_has_no_forbidden_edges_and_keeps_legacy_visible() -> None:
+def test_package_migration_003_scanner_has_no_forbidden_edges_and_keeps_legacy_visible() -> None:
     summary = report_to_summary_dict(scan_repo(REPO_ROOT))
     legacy_by_rule_and_domain = {
         (row["rule"], row["source_domain"], row["target_domain"]): row[
@@ -145,12 +149,12 @@ def test_package_migration_002_scanner_has_no_forbidden_edges_and_keeps_legacy_v
     )
     assert legacy_by_rule_and_domain[("ade-to-qre", DOMAIN_ADE, DOMAIN_QRE)] == 2
     assert legacy_by_rule_and_domain[
-        ("mixed-domain", DOMAIN_QRE, DOMAIN_EXECUTION)
-    ] == 11
+        ("mixed-domain", DOMAIN_CONTROL_PLANE, DOMAIN_ADAPTER_CONTRACT)
+    ] == 1
 
 
-def test_package_migration_002_changed_paths_stay_inside_bounded_slice() -> None:
-    changed_paths = _declared_migration_paths()
+def test_package_migration_003_changed_paths_stay_inside_bounded_slice() -> None:
+    changed_paths = _changed_paths()
 
     assert changed_paths
     assert FROZEN_CONTRACT_PATHS.isdisjoint(changed_paths)
@@ -160,40 +164,40 @@ def test_package_migration_002_changed_paths_stay_inside_bounded_slice() -> None
         for path in changed_paths
         for prefix in PROTECTED_PATH_PREFIXES
     )
-    assert not any(
-        path.startswith(prefix)
-        for path in changed_paths
-        for prefix in RUNTIME_ROUTE_PATH_PREFIXES
-    )
     assert all(
-        path.startswith(
-            (
-                "docs/architecture/",
-                "packages/ade_governance/",
-                "reporting/architecture_import_scan.py",
-                "tests/architecture/",
-            )
-        )
+        path.startswith(ALLOWED_CHANGED_PATH_PREFIXES)
         for path in changed_paths
     )
 
 
-def test_package_migration_002_decision_doc_is_bounded_to_one_next_unit() -> None:
+def test_package_migration_003_decision_doc_is_bounded_to_one_next_unit() -> None:
     text = MIGRATION_DOC.read_text(encoding="utf-8")
 
     assert "PACKAGE_MIGRATION_CONTINUES_WITH_BOUNDED_NEXT_UNIT" in text
     assert text.count("Exact next recommended unit:") == 1
     assert (
-        "PACKAGE-MIGRATION-003 - Migrate Control-Plane Read-Only Adapter Consumer "
-        "or Package Boundary"
-    ) in text
+        "PACKAGE-MIGRATION-004 - Migrate QRE Diagnostics Read-Only Package Boundary"
+        in text
+    )
+    assert "No frozen research outputs were changed." in text
+    assert "No `.claude/**` files were changed." in text
     assert "No dashboard mutation routes were added." in text
     assert (
         "No live, paper, shadow, risk, broker, or execution behavior was changed."
         in text
     )
-    assert "No frozen research outputs were changed." in text
-    assert "No `.claude/**` files were changed." in text
+
+
+def _load_boundary_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "control_plane_read_only_adapter_boundary",
+        BOUNDARY_PATH,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def _imported_modules(path: Path) -> list[str]:
@@ -240,7 +244,7 @@ def _changed_paths() -> set[str]:
 
 def _declared_migration_paths() -> set[str]:
     text = MIGRATION_DOC.read_text(encoding="utf-8")
-    marker = "## Files Changed"
+    marker = "## Exact Files/Modules Migrated or Introduced"
     start = text.index(marker)
     next_section = text.index("\n## ", start + len(marker))
     section = text[start:next_section]


### PR DESCRIPTION
## Summary
- Migrates PACKAGE-MIGRATION-003 as one bounded control-plane package-boundary slice.
- Adds a non-routed `apps/control-plane/read_only_adapter_boundary.py` consumer of the canonical read-only adapter contract.
- Updates control-plane README and architecture tests/docs for the new boundary-only status.

## Selected Migration Slice
`apps/control-plane/read_only_adapter_boundary.py` only. Existing dashboard runtime consumers remain deferred because moving a dashboard read-only API route now would require a broader QRE facade or runtime route wiring change.

## Canonical Namespace
Canonical adapter contract remains `packages.control_plane_qre_adapter_contract`.

## Compatibility Import Paths
Existing compatibility path remains `reporting.control_plane_qre_adapter_contract`; tests verify canonical and compatibility imports expose the same public contract objects.

## Files Changed
- `apps/control-plane/read_only_adapter_boundary.py`
- `apps/control-plane/README.md`
- `docs/architecture/PACKAGE-MIGRATION-003-control-plane-read-only-adapter-boundary.md`
- `tests/architecture/test_package_migration_001_target_layout.py`
- `tests/architecture/test_package_migration_002_ade_governance_read_only_contracts.py`
- `tests/architecture/test_package_migration_003_control_plane_read_only_adapter_boundary.py`

## Validation Commands and Results
- `pytest tests/architecture/test_domain_boundary_smoke.py -q` -> 40 passed
- `pytest tests/architecture/test_domain_import_scanner.py -q` -> 16 passed
- `pytest tests/architecture/test_package_migration_003_control_plane_read_only_adapter_boundary.py -q` -> 7 passed
- `pytest tests/architecture/test_package_migration_002_ade_governance_read_only_contracts.py -q` -> 6 passed
- `pytest tests/architecture -q` -> 96 passed
- `pytest tests/unit/test_ci_path_classifier.py -q` -> 6 passed
- `python -m reporting.architecture_import_scan --format summary` -> `forbidden_edge_count: 0`, `legacy_edge_count: 76`

## Scanner Summary Result
`forbidden_edge_count: 0`. Legacy/report-only findings remain visible, including 18 control-plane-to-QRE legacy findings and 2 ADE-to-QRE legacy findings. The new boundary adds one visible mixed-domain control-plane-to-adapter-contract edge.

## Frozen Contract Status
Frozen outputs unchanged: `research/research_latest.json` and `strategy_matrix.csv` were not modified.

## Protected Path Status
`.claude/**` and execution/live/paper/shadow/risk/broker paths were untouched.

## Runtime Behavior Status
No runtime behavior change. The new module is not wired into dashboard runtime, imports only the canonical adapter contract, and returns the same deterministic `AdapterContractDescription` from `describe_contract()`.

## Dashboard Mutation Route Status
No dashboard mutation routes added. No Flask import, route decorator, HTTP method declaration, or dashboard route wiring was introduced.

## Live/Paper/Shadow/Risk/Broker/Execution Behavior Status
No live, paper, shadow, risk, broker, or execution behavior changed.

## Exact Next Recommended Unit
PACKAGE-MIGRATION-004 - Migrate QRE Diagnostics Read-Only Package Boundary.

## Package Migration Decision
Selected value: `PACKAGE_MIGRATION_CONTINUES_WITH_BOUNDED_NEXT_UNIT`.