### PR TITLE
refactor: migrate QRE diagnostics read-only boundary

### DIFF
--- a/docs/architecture/PACKAGE-MIGRATION-004-qre-diagnostics-read-only-boundary.md
+++ b/docs/architecture/PACKAGE-MIGRATION-004-qre-diagnostics-read-only-boundary.md
@@ -1,0 +1,178 @@
+# PACKAGE-MIGRATION-004 - QRE Diagnostics Read-Only Package Boundary
+
+Status: implemented
+Date: 2026-05-22
+Builds on:
+
+- `docs/architecture/PACKAGE-MIGRATION-001-target-layout-skeleton.md`
+- `docs/architecture/PACKAGE-MIGRATION-002-ade-governance-read-only-contracts.md`
+- `docs/architecture/PACKAGE-MIGRATION-003-control-plane-read-only-adapter-boundary.md`
+- `packages/qre_diagnostics/`
+- `research/diagnostics/paths.py`
+- `reporting/architecture_import_scan.py`
+
+## Purpose and Scope
+
+PACKAGE-MIGRATION-004 migrates one bounded QRE diagnostics read-only package
+boundary into the target `packages/qre_diagnostics` namespace.
+
+This unit does not migrate all `research/`, move all `research/diagnostics/`,
+move dashboard routes, change dashboard runtime route wiring, change frozen
+contracts, add dashboard mutation routes, change execution, live, paper,
+shadow, risk, or broker behavior, or activate Addendum 1, Addendum 2, or
+Addendum 3 work.
+
+## Selected Migration Slice
+
+Selected slice:
+
+```text
+research/diagnostics/paths.py
+```
+
+New canonical namespace:
+
+```text
+packages.qre_diagnostics.paths
+```
+
+Compatibility import path:
+
+```text
+research.diagnostics.paths
+```
+
+The selected module is a read-only diagnostics path contract. It defines
+deterministic `Path` constants, string constants, tuples, dictionaries, and a
+pure threshold lookup helper. The canonical module imports only `pathlib`.
+
+## Why This Slice Was Selected
+
+Inspection showed that `dashboard.api_observability` already depends on
+`research.diagnostics.paths` as a read-only artifact-location contract, while
+the rest of `research/diagnostics/` includes builders, CLI entry points, and
+artifact writers under `research/observability/`. Moving those builders or
+dashboard routes would be broader than this unit.
+
+The path contract is the safest migration boundary because it is already
+stdlib-only, has existing path-drift tests, and can be moved with a compatibility
+shim without changing dashboard wiring or diagnostics runtime behavior.
+
+## Exact Files/Modules Migrated or Introduced
+
+- `packages/qre_diagnostics/__init__.py`
+- `packages/qre_diagnostics/paths.py`
+- `packages/qre_diagnostics/README.md`
+- `research/diagnostics/paths.py`
+- `tests/architecture/test_package_migration_003_control_plane_read_only_adapter_boundary.py`
+- `tests/architecture/test_package_migration_001_target_layout.py`
+- `tests/architecture/test_package_migration_004_qre_diagnostics_read_only_boundary.py`
+- `tests/unit/test_observability_paths.py`
+- `tests/unit/test_observability_static_import_surface.py`
+- `tests/unit/test_dashboard_api_observability.py`
+- `docs/architecture/PACKAGE-MIGRATION-004-qre-diagnostics-read-only-boundary.md`
+
+## Canonical Namespace
+
+```text
+packages.qre_diagnostics.paths
+```
+
+## Old Compatibility Path
+
+```text
+research.diagnostics.paths
+```
+
+The compatibility path re-exports the canonical public contract exactly. Public
+objects exposed through `__all__` are identity-equivalent between the canonical
+and compatibility modules.
+
+## What Did Not Move
+
+- No dashboard route module moved.
+- No dashboard runtime route wiring changed.
+- No diagnostics builder, CLI, aggregator, artifact-health, failure-mode,
+  throughput, system-integrity, clock, or IO module moved.
+- No QRE strategy, registry, research orchestration, campaign, candidate,
+  policy, or authority module moved.
+- No execution, live, paper, shadow, risk, broker, or order behavior moved.
+- No frozen research output moved or regenerated.
+
+## Runtime Behavior and Equivalence Statement
+
+Runtime behavior is unchanged. Existing imports of `research.diagnostics.paths`
+continue to work through a compatibility shim. The canonical and compatibility
+imports expose the same public contract objects.
+
+No dashboard runtime route wiring was changed. `dashboard.api_observability`
+continues to import the compatibility path, so endpoint behavior is unchanged.
+
+## Frozen Contract Status
+
+No frozen research outputs were changed. `research/research_latest.json`,
+`strategy_matrix.csv`, frozen schemas, and regression pins are not modified.
+
+No `.claude/**` files were changed.
+
+## Dashboard Mutation Route Status
+
+No dashboard mutation routes were added. The migrated path contract and
+compatibility shim contain no Flask import, route decorator, HTTP method
+declaration, or dashboard route wiring.
+
+## Live/Paper/Shadow/Risk/Broker/Execution Status
+
+No live, paper, shadow, risk, broker, or execution behavior was changed. The
+canonical diagnostics path contract imports only `pathlib`, and the
+compatibility shim imports only the canonical diagnostics package contract.
+
+## Scanner Classification
+
+The existing scanner classifications remain:
+
+```text
+packages/qre_diagnostics/ -> QRE
+research/diagnostics/ -> QRE
+dashboard/ -> control-plane
+```
+
+The compatibility import creates no cross-domain edge because both the legacy
+and canonical diagnostics path modules are QRE-domain modules. Existing
+legacy/report-only findings remain visible.
+
+## Validation Commands
+
+```powershell
+pytest tests/architecture/test_package_migration_004_qre_diagnostics_read_only_boundary.py -q
+pytest tests/architecture/test_package_migration_001_target_layout.py -q
+pytest tests/unit/test_observability_paths.py -q
+pytest tests/unit/test_observability_static_import_surface.py -q
+pytest tests/unit/test_dashboard_api_observability.py -q
+pytest tests/architecture/test_domain_boundary_smoke.py -q
+pytest tests/architecture/test_domain_import_scanner.py -q
+pytest tests/architecture -q
+pytest tests/unit/test_ci_path_classifier.py -q
+python -m reporting.architecture_import_scan --format summary
+```
+
+## Rollback Plan
+
+Revert the PACKAGE-MIGRATION-004 commit. That restores
+`research.diagnostics.paths` as the direct implementation and removes the
+canonical `packages.qre_diagnostics.paths` seed without changing dashboard
+routes, diagnostics builders, frozen outputs, or execution behavior.
+
+## Package Migration Decision
+
+Selected value: `PACKAGE_MIGRATION_CONTINUES_WITH_BOUNDED_NEXT_UNIT`
+
+Rationale: QRE diagnostics now has one canonical read-only package-boundary
+seed with compatibility preserved and without dashboard route or runtime
+behavior changes. The next safest bounded package migration is QRE artifacts
+because artifact read models are the next dependency for replacing legacy
+report-only dashboard and ADE reads without touching execution-sensitive
+behavior.
+
+Exact next recommended unit:
+PACKAGE-MIGRATION-005 - Migrate QRE Artifacts Read-Only Package Boundary.

--- a/packages/qre_diagnostics/README.md
+++ b/packages/qre_diagnostics/README.md
@@ -7,13 +7,16 @@ read models, health evidence, and research observability helpers.
 
 ## Current Status
 
-Status: scaffold-only. Current diagnostics remain under `research/diagnostics/`
-and related research observability modules.
+Status: active read-only boundary seed. The canonical diagnostics path contract
+lives in `packages/qre_diagnostics/paths.py`. Other diagnostics remain under
+`research/diagnostics/` and related research observability modules.
 
 ## Source of Truth / Authority Boundary
 
-Existing diagnostics modules remain authoritative. Diagnostics are read-only
-evidence surfaces and do not own trade decisions or execution behavior.
+The canonical diagnostics path contract is authoritative under
+`packages.qre_diagnostics.paths`. Existing diagnostics builders remain
+authoritative in `research/diagnostics/`. Diagnostics are read-only evidence
+surfaces and do not own trade decisions or execution behavior.
 
 ## Allowed Future Contents
 
@@ -36,9 +39,9 @@ evidence surfaces and do not own trade decisions or execution behavior.
 
 ## Current Compatibility Policy
 
-Existing `research/diagnostics/` imports remain authoritative. This scaffold
-exports no runtime API.
+`research.diagnostics.paths` remains a compatibility import path that re-exports
+the canonical `packages.qre_diagnostics.paths` public contract.
 
 ## Activation Status
 
-Activation status: scaffold-only.
+Activation status: active read-only path-contract seed only.

--- a/packages/qre_diagnostics/__init__.py
+++ b/packages/qre_diagnostics/__init__.py
@@ -1,0 +1,5 @@
+"""QRE diagnostics package boundary."""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/packages/qre_diagnostics/paths.py
+++ b/packages/qre_diagnostics/paths.py
@@ -1,0 +1,289 @@
+"""Single source of truth for observability paths and constants.
+
+Every other module in ``research.observability`` consumes the
+constants defined here. Path values are written as ``Path`` literals,
+NOT imported from the writer modules — this guarantees zero coupling
+to runtime/decision modules. A drift test
+(``tests/unit/test_observability_paths.py``) verifies that these
+literal paths still match the writer modules' constants by parsing
+those files as TEXT (no ``import``).
+
+Hard rule: this module imports only ``pathlib``. No other project
+module is imported here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# --- Repo layout anchors ---------------------------------------------------
+
+# All paths are relative to the project root. The CLI / writers expect
+# the cwd to be the repo root (consistent with how the rest of the
+# project resolves ``research/...`` paths).
+RESEARCH_DIR: Path = Path("research")
+OBSERVABILITY_DIR: Path = RESEARCH_DIR / "observability"
+
+# --- Output artifacts (written by this package) ----------------------------
+
+# Schema version of the observability artifacts written by v3.15.15.2.
+# Bumping requires updating consumer adapters; consumers MUST tolerate
+# unknown fields (additive evolution).
+OBSERVABILITY_SCHEMA_VERSION: str = "1.0"
+
+ARTIFACT_HEALTH_PATH: Path = OBSERVABILITY_DIR / "artifact_health_latest.v1.json"
+FAILURE_MODES_PATH: Path = OBSERVABILITY_DIR / "failure_modes_latest.v1.json"
+THROUGHPUT_METRICS_PATH: Path = OBSERVABILITY_DIR / "throughput_metrics_latest.v1.json"
+SYSTEM_INTEGRITY_PATH: Path = OBSERVABILITY_DIR / "system_integrity_latest.v1.json"
+OBSERVABILITY_SUMMARY_PATH: Path = OBSERVABILITY_DIR / "observability_summary_latest.v1.json"
+
+# Components in the v3.15.15.2 release. Six more
+# (funnel_stage_summary, campaign_timeline, parameter_coverage,
+# data_freshness, policy_decision_trace, no_touch_health) are reserved
+# for a future release; they are listed below in
+# ``DEFERRED_COMPONENTS`` so the aggregator can report them as
+# ``unavailable`` rather than ``unknown``.
+
+# (component_name, slug, output_path)
+ACTIVE_COMPONENTS: tuple[tuple[str, str, Path], ...] = (
+    ("artifact_health", "artifact-health", ARTIFACT_HEALTH_PATH),
+    ("failure_modes", "failure-modes", FAILURE_MODES_PATH),
+    ("throughput_metrics", "throughput", THROUGHPUT_METRICS_PATH),
+    ("system_integrity", "system-integrity", SYSTEM_INTEGRITY_PATH),
+)
+
+# Components reserved for v3.15.15.4. The aggregator surfaces these as
+# ``unavailable`` so frontends can render an "Unavailable — pending
+# release" badge without crashing.
+DEFERRED_COMPONENTS: tuple[tuple[str, str], ...] = (
+    ("funnel_stage_summary", "funnel"),
+    ("campaign_timeline", "campaign-timeline"),
+    ("parameter_coverage", "parameter-coverage"),
+    ("data_freshness", "data-freshness"),
+    ("policy_decision_trace", "policy-trace"),
+    ("no_touch_health", "no-touch-health"),
+)
+
+# --- Input artifacts (read by this package; NEVER mutated) -----------------
+
+# (canonical_name, contract_class, path)
+#
+# contract_class values:
+#   "frozen_public_contract"  — research_latest.json, strategy_matrix.csv
+#   "campaign_artifact"       — registry / queue / digest / templates
+#   "evidence_artifact"       — campaign_evidence_ledger / screening_evidence
+#   "sprint_artifact"         — discovery sprint registry / progress / report
+#   "observability_sidecar"   — anything under research/observability/
+#   "research_meta_artifact"  — public_artifact_status, run_state, run_*
+
+INPUT_ARTIFACTS: tuple[tuple[str, str, Path], ...] = (
+    # Frozen public contracts. Inspected for size/mtime/parse_ok only.
+    (
+        "research_latest.json",
+        "frozen_public_contract",
+        RESEARCH_DIR / "research_latest.json",
+    ),
+    (
+        "strategy_matrix.csv",
+        "frozen_public_contract",
+        RESEARCH_DIR / "strategy_matrix.csv",
+    ),
+    # Public-artifact freshness sidecar.
+    (
+        "public_artifact_status_latest.v1.json",
+        "research_meta_artifact",
+        RESEARCH_DIR / "public_artifact_status_latest.v1.json",
+    ),
+    # Campaign Operating Layer artifacts.
+    (
+        "campaign_registry_latest.v1.json",
+        "campaign_artifact",
+        RESEARCH_DIR / "campaign_registry_latest.v1.json",
+    ),
+    (
+        "campaign_queue_latest.v1.json",
+        "campaign_artifact",
+        RESEARCH_DIR / "campaign_queue_latest.v1.json",
+    ),
+    (
+        "campaign_digest_latest.v1.json",
+        "campaign_artifact",
+        RESEARCH_DIR / "campaign_digest_latest.v1.json",
+    ),
+    (
+        "screening_evidence_latest.v1.json",
+        "evidence_artifact",
+        RESEARCH_DIR / "screening_evidence_latest.v1.json",
+    ),
+    # Campaign evidence ledger (JSONL — append-only event stream).
+    # v3.15.15.7 — fixed canonical filename to match the launcher's writer
+    # constant in ``research/campaign_launcher.py:139``.
+    (
+        "campaign_evidence_ledger_latest.v1.jsonl",
+        "evidence_artifact",
+        RESEARCH_DIR / "campaign_evidence_ledger_latest.v1.jsonl",
+    ),
+    # Rolled-up evidence snapshot (v3.15.11).
+    (
+        "evidence_ledger_latest.v1.json",
+        "evidence_artifact",
+        RESEARCH_DIR / "campaigns" / "evidence" / "evidence_ledger_latest.v1.json",
+    ),
+    # Spawn proposals (v3.15.12).
+    (
+        "spawn_proposals_latest.v1.json",
+        "evidence_artifact",
+        RESEARCH_DIR / "campaigns" / "evidence" / "spawn_proposals_latest.v1.json",
+    ),
+    # Discovery sprint sidecars.
+    (
+        "sprint_registry_latest.v1.json",
+        "sprint_artifact",
+        RESEARCH_DIR / "discovery_sprints" / "sprint_registry_latest.v1.json",
+    ),
+    (
+        "discovery_sprint_progress_latest.v1.json",
+        "sprint_artifact",
+        RESEARCH_DIR / "discovery_sprints" / "discovery_sprint_progress_latest.v1.json",
+    ),
+    (
+        "discovery_sprint_report_latest.v1.json",
+        "sprint_artifact",
+        RESEARCH_DIR / "discovery_sprints" / "discovery_sprint_report_latest.v1.json",
+    ),
+)
+
+# Path used by failure_modes for the bounded JSONL ledger read. Kept
+# separate from INPUT_ARTIFACTS so failure_modes does not depend on
+# the entire input map.
+# v3.15.15.7 — bug fix: the launcher writes the campaign event ledger to
+# ``research/campaign_evidence_ledger_latest.v1.jsonl`` (the project-wide
+# ``_latest.v1`` snapshot-current convention). Pre-v3.15.15.7 this constant
+# was missing the ``_latest.v1`` suffix, causing ``read_jsonl_tail_safe``
+# to find no file and report ``ledger_available=false`` even though the
+# launcher had been writing the artifact since the project's start. The
+# corresponding writer constant is ``EVIDENCE_LEDGER_PATH`` defined in
+# ``research/campaign_launcher.py:139``; the path-drift test in
+# ``tests/unit/test_observability_paths.py`` pins both sides as text so a
+# future rename on either side fails loudly.
+CAMPAIGN_EVIDENCE_LEDGER_PATH: Path = RESEARCH_DIR / "campaign_evidence_ledger_latest.v1.jsonl"
+CAMPAIGN_REGISTRY_PATH: Path = RESEARCH_DIR / "campaign_registry_latest.v1.json"
+
+# --- Bounded read constants ------------------------------------------------
+
+# Maximum number of trailing lines to read from the campaign evidence
+# ledger. Beyond this, observability output is bounded and labeled as
+# "within last N events", never claimed as global totals. This keeps:
+#   * memory bounded (no OOM after long uptime),
+#   * outputs deterministic for a given (input, cap),
+#   * compute bounded (one pass, fixed work).
+MAX_LEDGER_LINES: int = 10_000
+
+# Maximum bytes to read backwards from the end of the ledger when
+# locating MAX_LEDGER_LINES line breaks. Belt-and-braces guard.
+MAX_LEDGER_TAIL_BYTES: int = 25 * 1024 * 1024  # 25 MB
+
+# --- Staleness thresholds --------------------------------------------------
+#
+# Used by artifact_health to classify stale vs fresh. Conservative
+# defaults; observability is descriptive — these are reporting
+# thresholds, NOT enforcement thresholds.
+
+STALE_THRESHOLD_SECONDS: dict[str, int] = {
+    "frozen_public_contract": 7 * 24 * 3600,    # 7 days
+    "campaign_artifact":      4 * 3600,         # 4 hours
+    "evidence_artifact":      4 * 3600,         # 4 hours
+    "sprint_artifact":        24 * 3600,        # 24 hours
+    "research_meta_artifact": 4 * 3600,         # 4 hours
+    "observability_sidecar":  60 * 60,          # 1 hour (own outputs)
+}
+
+DEFAULT_STALE_THRESHOLD_SECONDS: int = 24 * 3600
+
+
+def stale_threshold_for(contract_class: str) -> int:
+    """Return the staleness threshold in seconds for a contract class."""
+    return STALE_THRESHOLD_SECONDS.get(contract_class, DEFAULT_STALE_THRESHOLD_SECONDS)
+
+
+# v3.15.15.6 — Sprint-progress vs campaign-registry staleness threshold.
+#
+# When ``discovery_sprint_progress_latest.v1.json`` is older than
+# ``campaign_registry_latest.v1.json`` by more than this many seconds,
+# the aggregator emits a warning ``sprint_progress_stale_relative_to_registry``
+# with the actual delta. This is a **warning ONLY** — it never sets
+# ``infrastructure_status`` to degraded (sprint progress is a sidecar,
+# not infrastructure). Default: 1 hour. Active sprints update progress
+# at least hourly via the launcher tick.
+SPRINT_PROGRESS_STALE_VS_REGISTRY_SECONDS: int = 60 * 60
+
+
+# v3.15.15.6 — diagnostic_context vocabulary.
+#
+# Listed here as the single source of truth so unit tests, the
+# aggregator's warning propagation, and the future-writer-enrichment
+# tracker can refer to the same string keys.
+
+DIAGNOSTIC_MODES: tuple[str, ...] = (
+    "registry_only",
+    "registry_plus_queue",
+    "registry_plus_digest_enriched",
+    "ledger_enriched",
+    "screening_evidence_enriched",
+    "full_funnel_evidence",
+)
+
+DIAGNOSTIC_EVIDENCE_STATUSES: tuple[str, ...] = (
+    "sufficient",
+    "partial",
+    "insufficient",
+    "unavailable",
+)
+
+# Documented limitation codes the diagnostics layer may emit. Any
+# string in ``diagnostic_context.limitations`` should appear here so
+# consumers (frontend, alerting) can render stable text for each.
+DIAGNOSTIC_LIMITATION_CODES: tuple[str, ...] = (
+    "registry_only_mode",
+    "registry_plus_digest_only_mode",
+    "campaign_evidence_ledger_absent",
+    "screening_evidence_absent",
+    "spawn_proposals_absent",
+    "rolled_up_evidence_ledger_absent",
+    "failure_reason_detail_unavailable",
+    "asset_timeframe_fields_absent",
+    "hypothesis_id_missing_from_source_artifact",
+    "strategy_family_field_present_but_unpopulated_by_writer",
+    "asset_class_field_present_but_unpopulated_by_writer",
+    "timeframe_derivable_from_preset_only",
+    "sprint_progress_stale_relative_to_registry",
+    "conflicting_failure_reason_fields",
+    "registry_absent",
+    "registry_corrupt",
+)
+
+
+__all__ = [
+    "ACTIVE_COMPONENTS",
+    "ARTIFACT_HEALTH_PATH",
+    "CAMPAIGN_EVIDENCE_LEDGER_PATH",
+    "CAMPAIGN_REGISTRY_PATH",
+    "DEFAULT_STALE_THRESHOLD_SECONDS",
+    "DEFERRED_COMPONENTS",
+    "DIAGNOSTIC_EVIDENCE_STATUSES",
+    "DIAGNOSTIC_LIMITATION_CODES",
+    "DIAGNOSTIC_MODES",
+    "FAILURE_MODES_PATH",
+    "INPUT_ARTIFACTS",
+    "MAX_LEDGER_LINES",
+    "MAX_LEDGER_TAIL_BYTES",
+    "OBSERVABILITY_DIR",
+    "OBSERVABILITY_SCHEMA_VERSION",
+    "OBSERVABILITY_SUMMARY_PATH",
+    "RESEARCH_DIR",
+    "SPRINT_PROGRESS_STALE_VS_REGISTRY_SECONDS",
+    "STALE_THRESHOLD_SECONDS",
+    "SYSTEM_INTEGRITY_PATH",
+    "THROUGHPUT_METRICS_PATH",
+    "stale_threshold_for",
+]

--- a/research/diagnostics/paths.py
+++ b/research/diagnostics/paths.py
@@ -1,267 +1,37 @@
-"""Single source of truth for observability paths and constants.
+"""Compatibility import for QRE diagnostics path contracts.
 
-Every other module in ``research.observability`` consumes the
-constants defined here. Path values are written as ``Path`` literals,
-NOT imported from the writer modules — this guarantees zero coupling
-to runtime/decision modules. A drift test
-(``tests/unit/test_observability_paths.py``) verifies that these
-literal paths still match the writer modules' constants by parsing
-those files as TEXT (no ``import``).
-
-Hard rule: this module imports only ``pathlib``. No other project
-module is imported here.
+The canonical read-only path contract lives in
+``packages.qre_diagnostics.paths``. This module preserves the original
+``research.diagnostics.paths`` import path for existing diagnostics and
+dashboard consumers.
 """
 
 from __future__ import annotations
 
-from pathlib import Path
-
-# --- Repo layout anchors ---------------------------------------------------
-
-# All paths are relative to the project root. The CLI / writers expect
-# the cwd to be the repo root (consistent with how the rest of the
-# project resolves ``research/...`` paths).
-RESEARCH_DIR: Path = Path("research")
-OBSERVABILITY_DIR: Path = RESEARCH_DIR / "observability"
-
-# --- Output artifacts (written by this package) ----------------------------
-
-# Schema version of the observability artifacts written by v3.15.15.2.
-# Bumping requires updating consumer adapters; consumers MUST tolerate
-# unknown fields (additive evolution).
-OBSERVABILITY_SCHEMA_VERSION: str = "1.0"
-
-ARTIFACT_HEALTH_PATH: Path = OBSERVABILITY_DIR / "artifact_health_latest.v1.json"
-FAILURE_MODES_PATH: Path = OBSERVABILITY_DIR / "failure_modes_latest.v1.json"
-THROUGHPUT_METRICS_PATH: Path = OBSERVABILITY_DIR / "throughput_metrics_latest.v1.json"
-SYSTEM_INTEGRITY_PATH: Path = OBSERVABILITY_DIR / "system_integrity_latest.v1.json"
-OBSERVABILITY_SUMMARY_PATH: Path = OBSERVABILITY_DIR / "observability_summary_latest.v1.json"
-
-# Components in the v3.15.15.2 release. Six more
-# (funnel_stage_summary, campaign_timeline, parameter_coverage,
-# data_freshness, policy_decision_trace, no_touch_health) are reserved
-# for a future release; they are listed below in
-# ``DEFERRED_COMPONENTS`` so the aggregator can report them as
-# ``unavailable`` rather than ``unknown``.
-
-# (component_name, slug, output_path)
-ACTIVE_COMPONENTS: tuple[tuple[str, str, Path], ...] = (
-    ("artifact_health", "artifact-health", ARTIFACT_HEALTH_PATH),
-    ("failure_modes", "failure-modes", FAILURE_MODES_PATH),
-    ("throughput_metrics", "throughput", THROUGHPUT_METRICS_PATH),
-    ("system_integrity", "system-integrity", SYSTEM_INTEGRITY_PATH),
+from packages.qre_diagnostics.paths import (
+    ACTIVE_COMPONENTS,
+    ARTIFACT_HEALTH_PATH,
+    CAMPAIGN_EVIDENCE_LEDGER_PATH,
+    CAMPAIGN_REGISTRY_PATH,
+    DEFAULT_STALE_THRESHOLD_SECONDS,
+    DEFERRED_COMPONENTS,
+    DIAGNOSTIC_EVIDENCE_STATUSES,
+    DIAGNOSTIC_LIMITATION_CODES,
+    DIAGNOSTIC_MODES,
+    FAILURE_MODES_PATH,
+    INPUT_ARTIFACTS,
+    MAX_LEDGER_LINES,
+    MAX_LEDGER_TAIL_BYTES,
+    OBSERVABILITY_DIR,
+    OBSERVABILITY_SCHEMA_VERSION,
+    OBSERVABILITY_SUMMARY_PATH,
+    RESEARCH_DIR,
+    SPRINT_PROGRESS_STALE_VS_REGISTRY_SECONDS,
+    STALE_THRESHOLD_SECONDS,
+    SYSTEM_INTEGRITY_PATH,
+    THROUGHPUT_METRICS_PATH,
+    stale_threshold_for,
 )
-
-# Components reserved for v3.15.15.4. The aggregator surfaces these as
-# ``unavailable`` so frontends can render an "Unavailable — pending
-# release" badge without crashing.
-DEFERRED_COMPONENTS: tuple[tuple[str, str], ...] = (
-    ("funnel_stage_summary", "funnel"),
-    ("campaign_timeline", "campaign-timeline"),
-    ("parameter_coverage", "parameter-coverage"),
-    ("data_freshness", "data-freshness"),
-    ("policy_decision_trace", "policy-trace"),
-    ("no_touch_health", "no-touch-health"),
-)
-
-# --- Input artifacts (read by this package; NEVER mutated) -----------------
-
-# (canonical_name, contract_class, path)
-#
-# contract_class values:
-#   "frozen_public_contract"  — research_latest.json, strategy_matrix.csv
-#   "campaign_artifact"       — registry / queue / digest / templates
-#   "evidence_artifact"       — campaign_evidence_ledger / screening_evidence
-#   "sprint_artifact"         — discovery sprint registry / progress / report
-#   "observability_sidecar"   — anything under research/observability/
-#   "research_meta_artifact"  — public_artifact_status, run_state, run_*
-
-INPUT_ARTIFACTS: tuple[tuple[str, str, Path], ...] = (
-    # Frozen public contracts. Inspected for size/mtime/parse_ok only.
-    (
-        "research_latest.json",
-        "frozen_public_contract",
-        RESEARCH_DIR / "research_latest.json",
-    ),
-    (
-        "strategy_matrix.csv",
-        "frozen_public_contract",
-        RESEARCH_DIR / "strategy_matrix.csv",
-    ),
-    # Public-artifact freshness sidecar.
-    (
-        "public_artifact_status_latest.v1.json",
-        "research_meta_artifact",
-        RESEARCH_DIR / "public_artifact_status_latest.v1.json",
-    ),
-    # Campaign Operating Layer artifacts.
-    (
-        "campaign_registry_latest.v1.json",
-        "campaign_artifact",
-        RESEARCH_DIR / "campaign_registry_latest.v1.json",
-    ),
-    (
-        "campaign_queue_latest.v1.json",
-        "campaign_artifact",
-        RESEARCH_DIR / "campaign_queue_latest.v1.json",
-    ),
-    (
-        "campaign_digest_latest.v1.json",
-        "campaign_artifact",
-        RESEARCH_DIR / "campaign_digest_latest.v1.json",
-    ),
-    (
-        "screening_evidence_latest.v1.json",
-        "evidence_artifact",
-        RESEARCH_DIR / "screening_evidence_latest.v1.json",
-    ),
-    # Campaign evidence ledger (JSONL — append-only event stream).
-    # v3.15.15.7 — fixed canonical filename to match the launcher's writer
-    # constant in ``research/campaign_launcher.py:139``.
-    (
-        "campaign_evidence_ledger_latest.v1.jsonl",
-        "evidence_artifact",
-        RESEARCH_DIR / "campaign_evidence_ledger_latest.v1.jsonl",
-    ),
-    # Rolled-up evidence snapshot (v3.15.11).
-    (
-        "evidence_ledger_latest.v1.json",
-        "evidence_artifact",
-        RESEARCH_DIR / "campaigns" / "evidence" / "evidence_ledger_latest.v1.json",
-    ),
-    # Spawn proposals (v3.15.12).
-    (
-        "spawn_proposals_latest.v1.json",
-        "evidence_artifact",
-        RESEARCH_DIR / "campaigns" / "evidence" / "spawn_proposals_latest.v1.json",
-    ),
-    # Discovery sprint sidecars.
-    (
-        "sprint_registry_latest.v1.json",
-        "sprint_artifact",
-        RESEARCH_DIR / "discovery_sprints" / "sprint_registry_latest.v1.json",
-    ),
-    (
-        "discovery_sprint_progress_latest.v1.json",
-        "sprint_artifact",
-        RESEARCH_DIR / "discovery_sprints" / "discovery_sprint_progress_latest.v1.json",
-    ),
-    (
-        "discovery_sprint_report_latest.v1.json",
-        "sprint_artifact",
-        RESEARCH_DIR / "discovery_sprints" / "discovery_sprint_report_latest.v1.json",
-    ),
-)
-
-# Path used by failure_modes for the bounded JSONL ledger read. Kept
-# separate from INPUT_ARTIFACTS so failure_modes does not depend on
-# the entire input map.
-# v3.15.15.7 — bug fix: the launcher writes the campaign event ledger to
-# ``research/campaign_evidence_ledger_latest.v1.jsonl`` (the project-wide
-# ``_latest.v1`` snapshot-current convention). Pre-v3.15.15.7 this constant
-# was missing the ``_latest.v1`` suffix, causing ``read_jsonl_tail_safe``
-# to find no file and report ``ledger_available=false`` even though the
-# launcher had been writing the artifact since the project's start. The
-# corresponding writer constant is ``EVIDENCE_LEDGER_PATH`` defined in
-# ``research/campaign_launcher.py:139``; the path-drift test in
-# ``tests/unit/test_observability_paths.py`` pins both sides as text so a
-# future rename on either side fails loudly.
-CAMPAIGN_EVIDENCE_LEDGER_PATH: Path = RESEARCH_DIR / "campaign_evidence_ledger_latest.v1.jsonl"
-CAMPAIGN_REGISTRY_PATH: Path = RESEARCH_DIR / "campaign_registry_latest.v1.json"
-
-# --- Bounded read constants ------------------------------------------------
-
-# Maximum number of trailing lines to read from the campaign evidence
-# ledger. Beyond this, observability output is bounded and labeled as
-# "within last N events", never claimed as global totals. This keeps:
-#   * memory bounded (no OOM after long uptime),
-#   * outputs deterministic for a given (input, cap),
-#   * compute bounded (one pass, fixed work).
-MAX_LEDGER_LINES: int = 10_000
-
-# Maximum bytes to read backwards from the end of the ledger when
-# locating MAX_LEDGER_LINES line breaks. Belt-and-braces guard.
-MAX_LEDGER_TAIL_BYTES: int = 25 * 1024 * 1024  # 25 MB
-
-# --- Staleness thresholds --------------------------------------------------
-#
-# Used by artifact_health to classify stale vs fresh. Conservative
-# defaults; observability is descriptive — these are reporting
-# thresholds, NOT enforcement thresholds.
-
-STALE_THRESHOLD_SECONDS: dict[str, int] = {
-    "frozen_public_contract": 7 * 24 * 3600,    # 7 days
-    "campaign_artifact":      4 * 3600,         # 4 hours
-    "evidence_artifact":      4 * 3600,         # 4 hours
-    "sprint_artifact":        24 * 3600,        # 24 hours
-    "research_meta_artifact": 4 * 3600,         # 4 hours
-    "observability_sidecar":  60 * 60,          # 1 hour (own outputs)
-}
-
-DEFAULT_STALE_THRESHOLD_SECONDS: int = 24 * 3600
-
-
-def stale_threshold_for(contract_class: str) -> int:
-    """Return the staleness threshold in seconds for a contract class."""
-    return STALE_THRESHOLD_SECONDS.get(contract_class, DEFAULT_STALE_THRESHOLD_SECONDS)
-
-
-# v3.15.15.6 — Sprint-progress vs campaign-registry staleness threshold.
-#
-# When ``discovery_sprint_progress_latest.v1.json`` is older than
-# ``campaign_registry_latest.v1.json`` by more than this many seconds,
-# the aggregator emits a warning ``sprint_progress_stale_relative_to_registry``
-# with the actual delta. This is a **warning ONLY** — it never sets
-# ``infrastructure_status`` to degraded (sprint progress is a sidecar,
-# not infrastructure). Default: 1 hour. Active sprints update progress
-# at least hourly via the launcher tick.
-SPRINT_PROGRESS_STALE_VS_REGISTRY_SECONDS: int = 60 * 60
-
-
-# v3.15.15.6 — diagnostic_context vocabulary.
-#
-# Listed here as the single source of truth so unit tests, the
-# aggregator's warning propagation, and the future-writer-enrichment
-# tracker can refer to the same string keys.
-
-DIAGNOSTIC_MODES: tuple[str, ...] = (
-    "registry_only",
-    "registry_plus_queue",
-    "registry_plus_digest_enriched",
-    "ledger_enriched",
-    "screening_evidence_enriched",
-    "full_funnel_evidence",
-)
-
-DIAGNOSTIC_EVIDENCE_STATUSES: tuple[str, ...] = (
-    "sufficient",
-    "partial",
-    "insufficient",
-    "unavailable",
-)
-
-# Documented limitation codes the diagnostics layer may emit. Any
-# string in ``diagnostic_context.limitations`` should appear here so
-# consumers (frontend, alerting) can render stable text for each.
-DIAGNOSTIC_LIMITATION_CODES: tuple[str, ...] = (
-    "registry_only_mode",
-    "registry_plus_digest_only_mode",
-    "campaign_evidence_ledger_absent",
-    "screening_evidence_absent",
-    "spawn_proposals_absent",
-    "rolled_up_evidence_ledger_absent",
-    "failure_reason_detail_unavailable",
-    "asset_timeframe_fields_absent",
-    "hypothesis_id_missing_from_source_artifact",
-    "strategy_family_field_present_but_unpopulated_by_writer",
-    "asset_class_field_present_but_unpopulated_by_writer",
-    "timeframe_derivable_from_preset_only",
-    "sprint_progress_stale_relative_to_registry",
-    "conflicting_failure_reason_fields",
-    "registry_absent",
-    "registry_corrupt",
-)
-
 
 __all__ = [
     "ACTIVE_COMPONENTS",

--- a/tests/architecture/test_package_migration_001_target_layout.py
+++ b/tests/architecture/test_package_migration_001_target_layout.py
@@ -48,7 +48,6 @@ SCAFFOLD_ONLY_TARGETS = (
     REPO_ROOT / "packages" / "qre_research",
     REPO_ROOT / "packages" / "qre_data",
     REPO_ROOT / "packages" / "qre_artifacts",
-    REPO_ROOT / "packages" / "qre_diagnostics",
     REPO_ROOT / "packages" / "qre_policy",
     REPO_ROOT / "packages" / "qre_execution_sim",
     REPO_ROOT / "packages" / "qre_shadow",
@@ -91,8 +90,23 @@ def test_package_migration_001_future_and_disabled_packages_stay_inactive() -> N
 
 def test_package_migration_001_scaffold_targets_do_not_contain_runtime_modules() -> None:
     for target in SCAFFOLD_ONLY_TARGETS:
-        files = sorted(path.relative_to(target).as_posix() for path in target.rglob("*") if path.is_file())
+        files = sorted(
+            path.relative_to(target).as_posix()
+            for path in target.rglob("*")
+            if path.is_file() and "__pycache__" not in path.parts
+        )
         assert files == ["README.md"], target
+
+
+def test_package_migration_001_qre_diagnostics_has_only_bounded_read_only_seed() -> None:
+    target = REPO_ROOT / "packages" / "qre_diagnostics"
+    files = sorted(
+        path.relative_to(target).as_posix()
+        for path in target.rglob("*")
+        if path.is_file() and "__pycache__" not in path.parts
+    )
+
+    assert files == ["README.md", "__init__.py", "paths.py"], target
 
 
 def test_package_migration_001_scanner_classifies_target_paths() -> None:

--- a/tests/architecture/test_package_migration_004_qre_diagnostics_read_only_boundary.py
+++ b/tests/architecture/test_package_migration_004_qre_diagnostics_read_only_boundary.py
@@ -1,16 +1,12 @@
 from __future__ import annotations
 
 import ast
-import importlib.util
 import subprocess
 from pathlib import Path
-from types import ModuleType
 
-import packages.control_plane_qre_adapter_contract as canonical_contract
-import reporting.control_plane_qre_adapter_contract as compatibility_contract
-from packages.control_plane_qre_adapter_contract import describe_contract
+import packages.qre_diagnostics.paths as canonical_paths
+import research.diagnostics.paths as compatibility_paths
 from reporting.architecture_import_scan import (
-    DOMAIN_ADAPTER_CONTRACT,
     DOMAIN_ADE,
     DOMAIN_CONTROL_PLANE,
     DOMAIN_QRE,
@@ -21,12 +17,13 @@ from reporting.architecture_import_scan import (
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-BOUNDARY_PATH = REPO_ROOT / "apps" / "control-plane" / "read_only_adapter_boundary.py"
+CANONICAL_PATH = REPO_ROOT / "packages" / "qre_diagnostics" / "paths.py"
+COMPATIBILITY_PATH = REPO_ROOT / "research" / "diagnostics" / "paths.py"
 MIGRATION_DOC = (
     REPO_ROOT
     / "docs"
     / "architecture"
-    / "PACKAGE-MIGRATION-003-control-plane-read-only-adapter-boundary.md"
+    / "PACKAGE-MIGRATION-004-qre-diagnostics-read-only-boundary.md"
 )
 FROZEN_CONTRACT_PATHS = {
     "research/research_latest.json",
@@ -45,9 +42,11 @@ PROTECTED_PATH_PREFIXES = (
     "shadow/",
 )
 ALLOWED_CHANGED_PATH_PREFIXES = (
-    "apps/control-plane/",
     "docs/architecture/",
+    "packages/qre_diagnostics/",
+    "research/diagnostics/paths.py",
     "tests/architecture/",
+    "tests/unit/",
 )
 FORBIDDEN_IMPORT_PREFIXES = (
     "agent.execution",
@@ -59,78 +58,65 @@ FORBIDDEN_IMPORT_PREFIXES = (
     "flask",
     "live",
     "paper",
-    "research",
     "risk",
     "shadow",
-)
-PUBLIC_CONTRACT_NAMES = (
-    "AdapterContractDescription",
-    "CONTRACT_NAME",
-    "CONTRACT_VERSION",
-    "ControlPlaneQREReadAdapter",
-    "FORBIDDEN_CAPABILITIES",
-    "READ_ONLY_METHODS",
-    "ReadModelContract",
-    "describe_contract",
 )
 FORBIDDEN_HTTP_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
 
 
-def test_package_migration_003_boundary_imports_canonical_contract() -> None:
-    boundary = _load_boundary_module()
-
-    assert boundary.describe_read_only_adapter_boundary() == describe_contract()
-    assert classify_path(BOUNDARY_PATH.relative_to(REPO_ROOT)) == DOMAIN_CONTROL_PLANE
-    assert (
-        classify_module("packages.control_plane_qre_adapter_contract")
-        == DOMAIN_ADAPTER_CONTRACT
+def test_package_migration_004_canonical_import_path_works() -> None:
+    assert classify_path(CANONICAL_PATH.relative_to(REPO_ROOT)) == DOMAIN_QRE
+    assert classify_module("packages.qre_diagnostics.paths") == DOMAIN_QRE
+    assert str(canonical_paths.OBSERVABILITY_DIR).replace("\\", "/") == (
+        "research/observability"
     )
-    assert classify_path("packages/ade_governance/README.md") == DOMAIN_ADE
+    assert canonical_paths.OBSERVABILITY_SCHEMA_VERSION == "1.0"
 
 
-def test_package_migration_003_compatibility_path_still_exposes_same_contract() -> None:
-    assert canonical_contract.__all__ == list(PUBLIC_CONTRACT_NAMES)
-    assert compatibility_contract.__all__ == list(PUBLIC_CONTRACT_NAMES)
-    for name in PUBLIC_CONTRACT_NAMES:
-        assert getattr(compatibility_contract, name) is getattr(
-            canonical_contract,
-            name,
-        )
+def test_package_migration_004_compatibility_import_path_preserves_contract() -> None:
+    assert compatibility_paths.__all__ == canonical_paths.__all__
+    for name in canonical_paths.__all__:
+        assert getattr(compatibility_paths, name) is getattr(canonical_paths, name)
 
 
-def test_package_migration_003_boundary_is_stdlib_plus_adapter_contract_only() -> None:
-    imported_modules = _imported_modules(BOUNDARY_PATH)
+def test_package_migration_004_canonical_module_is_stdlib_only() -> None:
+    imported_modules = _imported_modules(CANONICAL_PATH)
 
-    assert imported_modules == [
-        "__future__",
-        "packages.control_plane_qre_adapter_contract",
-    ]
+    assert imported_modules == ["__future__", "pathlib"]
     assert not any(_has_forbidden_import_prefix(module) for module in imported_modules)
 
 
-def test_package_migration_003_adds_no_dashboard_mutation_or_runtime_route() -> None:
-    tree = ast.parse(BOUNDARY_PATH.read_text(encoding="utf-8"))
-    route_decorators = [
-        decorator
-        for node in ast.walk(tree)
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
-        for decorator in node.decorator_list
-        if isinstance(decorator, ast.Call)
-        and isinstance(decorator.func, ast.Attribute)
-        and decorator.func.attr == "route"
-    ]
-    string_constants = [
-        node.value for node in ast.walk(tree) if isinstance(node, ast.Constant)
-    ]
+def test_package_migration_004_compatibility_shim_imports_only_canonical_contract() -> None:
+    imported_modules = _imported_modules(COMPATIBILITY_PATH)
 
-    assert route_decorators == []
-    assert "flask" not in _imported_modules(BOUNDARY_PATH)
-    assert "Flask" not in string_constants
-    assert "Blueprint" not in string_constants
-    assert not any(value in FORBIDDEN_HTTP_METHODS for value in string_constants)
+    assert imported_modules == ["__future__", "packages.qre_diagnostics.paths"]
+    assert not any(_has_forbidden_import_prefix(module) for module in imported_modules)
 
 
-def test_package_migration_003_scanner_has_no_forbidden_edges_and_keeps_legacy_visible() -> None:
+def test_package_migration_004_adds_no_dashboard_mutation_or_runtime_route() -> None:
+    for path in (CANONICAL_PATH, COMPATIBILITY_PATH):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        route_decorators = [
+            decorator
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            for decorator in node.decorator_list
+            if isinstance(decorator, ast.Call)
+            and isinstance(decorator.func, ast.Attribute)
+            and decorator.func.attr == "route"
+        ]
+        string_constants = [
+            node.value for node in ast.walk(tree) if isinstance(node, ast.Constant)
+        ]
+
+        assert route_decorators == []
+        assert "flask" not in _imported_modules(path)
+        assert "Flask" not in string_constants
+        assert "Blueprint" not in string_constants
+        assert not any(value in FORBIDDEN_HTTP_METHODS for value in string_constants)
+
+
+def test_package_migration_004_scanner_has_no_forbidden_edges_and_keeps_legacy_visible() -> None:
     summary = report_to_summary_dict(scan_repo(REPO_ROOT))
     legacy_by_rule_and_domain = {
         (row["rule"], row["source_domain"], row["target_domain"]): row[
@@ -148,12 +134,9 @@ def test_package_migration_003_scanner_has_no_forbidden_edges_and_keeps_legacy_v
         == 18
     )
     assert legacy_by_rule_and_domain[("ade-to-qre", DOMAIN_ADE, DOMAIN_QRE)] == 2
-    assert legacy_by_rule_and_domain[
-        ("mixed-domain", DOMAIN_CONTROL_PLANE, DOMAIN_ADAPTER_CONTRACT)
-    ] == 1
 
 
-def test_package_migration_003_changed_paths_stay_inside_bounded_slice() -> None:
+def test_package_migration_004_changed_paths_stay_inside_bounded_slice() -> None:
     changed_paths = _changed_paths()
 
     assert changed_paths
@@ -164,19 +147,16 @@ def test_package_migration_003_changed_paths_stay_inside_bounded_slice() -> None
         for path in changed_paths
         for prefix in PROTECTED_PATH_PREFIXES
     )
-    assert all(
-        path.startswith(ALLOWED_CHANGED_PATH_PREFIXES)
-        for path in changed_paths
-    )
+    assert all(path.startswith(ALLOWED_CHANGED_PATH_PREFIXES) for path in changed_paths)
 
 
-def test_package_migration_003_decision_doc_is_bounded_to_one_next_unit() -> None:
+def test_package_migration_004_decision_doc_is_bounded_to_one_next_unit() -> None:
     text = MIGRATION_DOC.read_text(encoding="utf-8")
 
     assert "PACKAGE_MIGRATION_CONTINUES_WITH_BOUNDED_NEXT_UNIT" in text
     assert text.count("Exact next recommended unit:") == 1
     assert (
-        "PACKAGE-MIGRATION-004 - Migrate QRE Diagnostics Read-Only Package Boundary"
+        "PACKAGE-MIGRATION-005 - Migrate QRE Artifacts Read-Only Package Boundary"
         in text
     )
     assert "No frozen research outputs were changed." in text
@@ -186,18 +166,7 @@ def test_package_migration_003_decision_doc_is_bounded_to_one_next_unit() -> Non
         "No live, paper, shadow, risk, broker, or execution behavior was changed."
         in text
     )
-
-
-def _load_boundary_module() -> ModuleType:
-    spec = importlib.util.spec_from_file_location(
-        "control_plane_read_only_adapter_boundary",
-        BOUNDARY_PATH,
-    )
-    assert spec is not None
-    assert spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+    assert "No dashboard runtime route wiring was changed." in text
 
 
 def _imported_modules(path: Path) -> list[str]:

--- a/tests/unit/test_dashboard_api_observability.py
+++ b/tests/unit/test_dashboard_api_observability.py
@@ -411,11 +411,13 @@ def test_api_module_only_imports_safe_modules():
 def test_paths_module_does_not_pull_in_forbidden_modules():
     """``research.diagnostics.paths`` is the ONLY project module the API imports.
 
-    This test ensures paths.py itself is still stdlib-only by re-running
-    the same AST check on it.
+    The compatibility shim may import only the canonical package contract. The
+    canonical contract must remain stdlib-only.
     """
-    src_path = Path(diag_paths.__file__)
-    tree = ast.parse(src_path.read_text(encoding="utf-8"), filename=str(src_path))
+    compatibility_path = Path(diag_paths.__file__)
+    canonical_path = (
+        compatibility_path.parents[2] / "packages" / "qre_diagnostics" / "paths.py"
+    )
     project_roots = {
         "agent",
         "strategies",
@@ -429,17 +431,37 @@ def test_paths_module_does_not_pull_in_forbidden_modules():
         "config",
         "ops",
         "dashboard",
+        "packages",
     }
-    for node in ast.walk(tree):
+
+    compatibility_tree = ast.parse(
+        compatibility_path.read_text(encoding="utf-8"),
+        filename=str(compatibility_path),
+    )
+    compatibility_imports = [
+        node.module
+        for node in ast.walk(compatibility_tree)
+        if isinstance(node, ast.ImportFrom) and node.module
+    ]
+    assert compatibility_imports == [
+        "__future__",
+        "packages.qre_diagnostics.paths",
+    ]
+
+    canonical_tree = ast.parse(
+        canonical_path.read_text(encoding="utf-8"),
+        filename=str(canonical_path),
+    )
+    for node in ast.walk(canonical_tree):
         if isinstance(node, ast.ImportFrom):
             if node.level:
                 continue
             module = node.module or ""
             assert module.split(".", 1)[0] not in project_roots, (
-                f"research/diagnostics/paths.py imports project module {module}"
+                f"packages/qre_diagnostics/paths.py imports project module {module}"
             )
         elif isinstance(node, ast.Import):
             for alias in node.names:
                 assert alias.name.split(".", 1)[0] not in project_roots, (
-                    f"research/diagnostics/paths.py imports project module {alias.name}"
+                    f"packages/qre_diagnostics/paths.py imports project module {alias.name}"
                 )

--- a/tests/unit/test_observability_paths.py
+++ b/tests/unit/test_observability_paths.py
@@ -8,6 +8,7 @@ Verifies that the path literals in
 
 from __future__ import annotations
 
+import ast
 import re
 from pathlib import Path
 
@@ -15,6 +16,8 @@ import pytest
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 RESEARCH_DIR = PROJECT_ROOT / "research"
+CANONICAL_PATHS_PY = PROJECT_ROOT / "packages" / "qre_diagnostics" / "paths.py"
+COMPATIBILITY_PATHS_PY = PROJECT_ROOT / "research" / "diagnostics" / "paths.py"
 
 # Each entry: (filename_to_find, writer_module_filename)
 #
@@ -47,9 +50,7 @@ DRIFT_CHECKS = [
     ids=[f"{c[0]}-vs-{c[1]}" for c in DRIFT_CHECKS],
 )
 def test_writer_module_still_uses_filename(filename: str, writer_filename: str):
-    paths_py = (
-        PROJECT_ROOT / "research" / "diagnostics" / "paths.py"
-    ).read_text(encoding="utf-8")
+    paths_py = CANONICAL_PATHS_PY.read_text(encoding="utf-8")
     assert filename in paths_py, (
         f"paths.py no longer mentions {filename!r}; "
         f"observability path constants are out of date."
@@ -65,9 +66,7 @@ def test_writer_module_still_uses_filename(filename: str, writer_filename: str):
 
 def test_paths_module_does_not_import_other_research_modules():
     """paths.py must import nothing from research.* — single source of truth."""
-    text = (
-        PROJECT_ROOT / "research" / "diagnostics" / "paths.py"
-    ).read_text(encoding="utf-8")
+    text = CANONICAL_PATHS_PY.read_text(encoding="utf-8")
     forbidden = re.findall(
         r"^\s*(?:from|import)\s+research\.(?!diagnostics|_sidecar_io)\S+",
         text,
@@ -104,13 +103,17 @@ def test_no_pre_v3_15_15_7_wrong_ledger_path_anywhere_in_diagnostics():
     literal alongside ``campaign_evidence_ledger`` (the prefix). Allowed: the
     correct full filename ``campaign_evidence_ledger_latest.v1.jsonl``.
     """
-    diagnostics_dir = PROJECT_ROOT / "research" / "diagnostics"
+    diagnostics_dirs = (
+        PROJECT_ROOT / "research" / "diagnostics",
+        PROJECT_ROOT / "packages" / "qre_diagnostics",
+    )
     bad_literal = '"campaign_evidence_ledger.jsonl"'
     offenders: list[str] = []
-    for py_path in sorted(diagnostics_dir.glob("*.py")):
-        text = py_path.read_text(encoding="utf-8")
-        if bad_literal in text:
-            offenders.append(py_path.name)
+    for diagnostics_dir in diagnostics_dirs:
+        for py_path in sorted(diagnostics_dir.glob("*.py")):
+            text = py_path.read_text(encoding="utf-8")
+            if bad_literal in text:
+                offenders.append(py_path.relative_to(PROJECT_ROOT).as_posix())
     assert not offenders, (
         f"v3.15.15.7 regression: the pre-fix filename "
         f"'campaign_evidence_ledger.jsonl' (no '_latest.v1' suffix) "
@@ -141,3 +144,27 @@ def test_campaign_evidence_ledger_path_constant_uses_latest_v1_suffix():
         str(CAMPAIGN_EVIDENCE_LEDGER_PATH).replace("\\", "/")
         == "research/campaign_evidence_ledger_latest.v1.jsonl"
     )
+
+
+def test_compatibility_path_reexports_canonical_public_contract():
+    import packages.qre_diagnostics.paths as canonical_paths
+    import research.diagnostics.paths as compatibility_paths
+
+    assert compatibility_paths.__all__ == canonical_paths.__all__
+    for name in canonical_paths.__all__:
+        assert getattr(compatibility_paths, name) is getattr(canonical_paths, name)
+
+
+def test_compatibility_paths_module_only_imports_canonical_contract():
+    tree = ast.parse(
+        COMPATIBILITY_PATHS_PY.read_text(encoding="utf-8"),
+        filename=str(COMPATIBILITY_PATHS_PY),
+    )
+    imports: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.append(node.module)
+
+    assert imports == ["__future__", "packages.qre_diagnostics.paths"]

--- a/tests/unit/test_observability_static_import_surface.py
+++ b/tests/unit/test_observability_static_import_surface.py
@@ -90,6 +90,7 @@ FORBIDDEN_PREFIXES = (
 
 # Modules from inside the project that ARE allowed. Tightly enumerated.
 ALLOWED_PROJECT_IMPORTS = {
+    "packages.qre_diagnostics.paths",
     "research._sidecar_io",
 }
 
@@ -192,6 +193,7 @@ def test_only_whitelisted_project_imports(module_path: Path):
         "reporting",
         "config",
         "ops",
+        "packages",
     }
     imports = _imports_in(module_path)
     project_imports = [


### PR DESCRIPTION
## Summary

Migrates one bounded QRE diagnostics read-only package boundary by moving the diagnostics path contract to the canonical `packages.qre_diagnostics.paths` namespace and preserving `research.diagnostics.paths` as a compatibility shim.

## Selected migration slice

- `research/diagnostics/paths.py` read-only diagnostics path contract

## Canonical namespace

- `packages.qre_diagnostics.paths`

## Compatibility import path(s)

- `research.diagnostics.paths`

## Files changed

- `packages/qre_diagnostics/__init__.py`
- `packages/qre_diagnostics/paths.py`
- `packages/qre_diagnostics/README.md`
- `research/diagnostics/paths.py`
- `docs/architecture/PACKAGE-MIGRATION-004-qre-diagnostics-read-only-boundary.md`
- `tests/architecture/test_package_migration_001_target_layout.py`
- `tests/architecture/test_package_migration_003_control_plane_read_only_adapter_boundary.py`
- `tests/architecture/test_package_migration_004_qre_diagnostics_read_only_boundary.py`
- `tests/unit/test_observability_paths.py`
- `tests/unit/test_observability_static_import_surface.py`
- `tests/unit/test_dashboard_api_observability.py`

## Validation commands and results

- `pytest tests/architecture/test_package_migration_004_qre_diagnostics_read_only_boundary.py -q` - 8 passed
- `pytest tests/architecture/test_package_migration_001_target_layout.py -q` - 9 passed
- `pytest tests/architecture/test_package_migration_003_control_plane_read_only_adapter_boundary.py -q` - 7 passed
- `pytest tests/unit/test_observability_paths.py -q` - 14 passed
- `pytest tests/unit/test_observability_static_import_surface.py -q` - 23 passed
- `pytest tests/unit/test_dashboard_api_observability.py -q` - 37 passed
- `pytest tests/architecture/test_domain_boundary_smoke.py -q` - 40 passed
- `pytest tests/architecture/test_domain_import_scanner.py -q` - 16 passed
- `pytest tests/unit/test_ci_path_classifier.py -q` - 6 passed
- `pytest tests/architecture -q` - 105 passed
- `python -m reporting.architecture_import_scan --format summary` - forbidden_edge_count 0, legacy_edge_count 76

## Scanner summary result

`forbidden_edge_count` is 0. Legacy/report-only findings remain visible with `legacy_edge_count` 76.

## Frozen contract status

No frozen research outputs were changed. `research/research_latest.json`, `strategy_matrix.csv`, frozen schemas, and regression pins are untouched.

## Protected path status

No `.claude/**`, execution, live, paper, shadow, risk, broker, or protected authority path was changed.

## Runtime behavior status

No runtime behavior change. Existing `research.diagnostics.paths` imports continue to resolve through a compatibility shim, and equivalence tests prove the canonical and compatibility imports expose the same public contract objects.

## Dashboard mutation route status

No dashboard mutation route was added. No dashboard route module moved, and no dashboard runtime route wiring changed.

## Live/paper/shadow/risk/broker/execution behavior status

No live, paper, shadow, risk, broker, or execution behavior was changed.

## Exact next recommended unit

PACKAGE-MIGRATION-005 - Migrate QRE Artifacts Read-Only Package Boundary.

## Package Migration Decision

Selected value: `PACKAGE_MIGRATION_CONTINUES_WITH_BOUNDED_NEXT_UNIT`.