### PR TITLE
refactor: migrate QRE artifacts read-only boundary

### DIFF
--- a/docs/architecture/PACKAGE-MIGRATION-005-qre-artifacts-read-only-boundary.md
+++ b/docs/architecture/PACKAGE-MIGRATION-005-qre-artifacts-read-only-boundary.md
@@ -1,0 +1,177 @@
+# PACKAGE-MIGRATION-005 - QRE Artifacts Read-Only Package Boundary
+
+Status: implemented
+Date: 2026-05-22
+Builds on:
+
+- `docs/architecture/PACKAGE-MIGRATION-001-target-layout-skeleton.md`
+- `docs/architecture/PACKAGE-MIGRATION-002-ade-governance-read-only-contracts.md`
+- `docs/architecture/PACKAGE-MIGRATION-003-control-plane-read-only-adapter-boundary.md`
+- `docs/architecture/PACKAGE-MIGRATION-004-qre-diagnostics-read-only-boundary.md`
+- `packages/qre_artifacts/`
+- `research/results.py`
+- `reporting/architecture_import_scan.py`
+
+## Purpose and Scope
+
+PACKAGE-MIGRATION-005 migrates one bounded QRE artifacts read-only package
+boundary into the target `packages/qre_artifacts` namespace.
+
+This unit does not migrate all `research/`, move all `artifacts/`, move
+artifact producers broadly, move dashboard routes, change dashboard runtime
+route wiring, change frozen contracts, add dashboard mutation routes, change
+execution, live, paper, shadow, risk, or broker behavior, or activate Addendum
+1, Addendum 2, or Addendum 3 work.
+
+## Selected Migration Slice
+
+Selected slice:
+
+```text
+research/results.py public output schema/path constants
+```
+
+New canonical namespace:
+
+```text
+packages.qre_artifacts.public_outputs
+```
+
+Compatibility import path:
+
+```text
+research.results
+```
+
+The selected constants are read-only public artifact contracts: the frozen
+`strategy_matrix.csv` row schema, `research_latest.json` top-level and summary
+schemas, and the existing repo-relative output paths. Artifact writer functions
+remain in `research.results`.
+
+## Why This Slice Was Selected
+
+Inspection showed that existing artifact modules include many writer-heavy
+research producers, dashboard read routes, campaign/candidate lifecycle modules,
+and frozen schema guards. Moving those producers or dashboard consumers would
+be broader than this unit.
+
+The public output schema/path constants are the safest artifacts boundary seed
+because they are immutable contract data, already protected by regression tests,
+and can move under `packages.qre_artifacts` while preserving the existing
+`research.results` import surface used by writers and tests.
+
+## Exact Files/Modules Migrated or Introduced
+
+- `packages/qre_artifacts/__init__.py`
+- `packages/qre_artifacts/public_outputs.py`
+- `packages/qre_artifacts/README.md`
+- `research/results.py`
+- `tests/architecture/test_package_migration_001_target_layout.py`
+- `tests/architecture/test_package_migration_005_qre_artifacts_read_only_boundary.py`
+- `docs/architecture/PACKAGE-MIGRATION-005-qre-artifacts-read-only-boundary.md`
+
+## Canonical Namespace
+
+```text
+packages.qre_artifacts.public_outputs
+```
+
+## Old Compatibility Path
+
+```text
+research.results
+```
+
+The compatibility path imports and re-exports the canonical public contract
+objects. Public schema/path constants exposed by `research.results` are
+identity-equivalent to the canonical package objects.
+
+## What Did Not Move
+
+- No dashboard route module moved.
+- No dashboard runtime route wiring changed.
+- No artifact writer function moved.
+- No generated artifact under `research/` or `artifacts/` moved or regenerated.
+- No QRE strategy, registry, research orchestration, campaign, candidate,
+  policy, or authority module moved.
+- No execution, live, paper, shadow, risk, broker, or order behavior moved.
+- No frozen public output file moved or regenerated.
+
+## Runtime Behavior and Equivalence Statement
+
+Runtime behavior is unchanged. Existing imports from `research.results` continue
+to work because `research.results` imports the canonical constants and exposes
+the same object identities at the old path. The writer functions
+`write_results_to_csv` and `write_latest_json` remain in `research.results` and
+use the same schema/path values.
+
+No dashboard runtime route wiring was changed.
+
+## Frozen Contract Status
+
+No frozen research outputs were changed. `research/research_latest.json`,
+`research/strategy_matrix.csv`, frozen schemas, and regression pins are not
+modified.
+
+No `.claude/**` files were changed.
+
+## Dashboard Mutation Route Status
+
+No dashboard mutation routes were added. The migrated artifact contract and
+compatibility import contain no Flask import, route decorator, HTTP method
+declaration, or dashboard route wiring.
+
+## Live/Paper/Shadow/Risk/Broker/Execution Status
+
+No live, paper, shadow, risk, broker, or execution behavior was changed. The
+canonical artifacts contract imports only `__future__`, and the compatibility
+path imports the canonical artifacts package contract.
+
+## Scanner Classification
+
+The existing scanner classifications remain:
+
+```text
+packages/qre_artifacts/ -> QRE
+research/results.py -> QRE
+dashboard/ -> control-plane
+```
+
+The compatibility import creates no cross-domain edge because both the legacy
+and canonical public output contract modules are QRE-domain modules. Existing
+legacy/report-only findings remain visible.
+
+## Validation Commands
+
+```powershell
+pytest tests/architecture/test_package_migration_005_qre_artifacts_read_only_boundary.py -q
+pytest tests/architecture/test_package_migration_001_target_layout.py -q
+pytest tests/regression/test_research_schema_guard.py -q
+pytest tests/regression/test_public_output_contract.py -q
+pytest tests/architecture/test_domain_boundary_smoke.py -q
+pytest tests/architecture/test_domain_import_scanner.py -q
+pytest tests/architecture -q
+pytest tests/unit/test_ci_path_classifier.py -q
+python -m reporting.architecture_import_scan --format summary
+```
+
+## Rollback Plan
+
+Revert the PACKAGE-MIGRATION-005 commit. That restores the public output
+schema/path constants as direct definitions in `research.results` and removes
+the canonical `packages.qre_artifacts.public_outputs` seed without changing
+dashboard routes, artifact writers, frozen outputs, or execution behavior.
+
+## Package Migration Decision
+
+Selected value: `PACKAGE_MIGRATION_CONTINUES_WITH_BOUNDED_NEXT_UNIT`
+
+Rationale: QRE artifacts now has one canonical read-only public output contract
+seed with compatibility preserved and without dashboard route, artifact writer,
+frozen output, or execution behavior changes. The next safest bounded package
+migration is QRE policy because ADR-014 policy/authority surfaces remain the
+next target package boundary and can be evaluated as read-only contracts without
+touching strategy expansion or execution-sensitive behavior.
+
+Exact next recommended unit:
+PACKAGE-MIGRATION-006 - Migrate QRE Policy Read-Only Package Boundary.

--- a/packages/qre_artifacts/README.md
+++ b/packages/qre_artifacts/README.md
@@ -7,24 +7,29 @@ schemas, deterministic artifact IO contracts, and compatibility definitions.
 
 ## Current Status
 
-Status: scaffold-only. Current artifact schemas and generated outputs remain in
-their existing repo paths.
+Status: active read-only seed. The package owns the read-only public output
+schema/path constants in `packages.qre_artifacts.public_outputs`. Current
+artifact writers and generated outputs remain in their existing repo paths.
 
 ## Source of Truth / Authority Boundary
 
+`packages.qre_artifacts.public_outputs` is the canonical namespace for the
+frozen public output schema/path constants used by `research.results`.
+
 `research/research_latest.json`, `research/strategy_matrix.csv`, tracked schema
-fixtures, and existing artifact producers remain authoritative until a bounded
-artifact migration pins compatibility.
+fixtures, and existing artifact producers remain authoritative and are not
+moved by this package seed.
 
 ## Allowed Future Contents
 
 - Artifact schema contracts.
+- Read-only artifact path contracts.
 - Deterministic read/write interfaces after compatibility tests exist.
 - Artifact validation helpers selected by a named migration unit.
 
 ## Forbidden Contents
 
-- Changes to frozen output schemas without explicit artifact-contract intent.
+- Changes to frozen output schema values without explicit artifact-contract intent.
 - Strategy, registry, dashboard route, or ADE authority logic.
 - Live, paper, shadow, risk, broker, or order-execution behavior.
 
@@ -36,9 +41,10 @@ artifact migration pins compatibility.
 
 ## Current Compatibility Policy
 
-Existing artifact paths and schemas remain authoritative. This scaffold exports
-no runtime API.
+Existing imports from `research.results` remain compatible for the public output
+schema/path constants. The canonical package module exports the same immutable
+tuple/string contract values.
 
 ## Activation Status
 
-Activation status: scaffold-only.
+Activation status: read-only public output contract seed only.

--- a/packages/qre_artifacts/__init__.py
+++ b/packages/qre_artifacts/__init__.py
@@ -1,0 +1,5 @@
+"""QRE artifacts package boundary."""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/packages/qre_artifacts/public_outputs.py
+++ b/packages/qre_artifacts/public_outputs.py
@@ -1,0 +1,57 @@
+"""Read-only public output artifact contracts.
+
+This module owns the frozen public research output schema and repo-relative
+output paths. It contains no artifact writers, readers, dashboard wiring, or
+execution-sensitive behavior.
+"""
+
+from __future__ import annotations
+
+# Frozen public output contracts. Do NOT edit without an approved
+# artifact-contract change. Writers import these constants; this package does
+# not import writer modules.
+ROW_SCHEMA: tuple[str, ...] = (
+    "timestamp_utc",
+    "strategy_name",
+    "family",
+    "hypothesis",
+    "asset",
+    "interval",
+    "params_json",
+    "success",
+    "error",
+    "win_rate",
+    "sharpe",
+    "deflated_sharpe",
+    "max_drawdown",
+    "trades_per_maand",
+    "consistentie",
+    "totaal_trades",
+    "goedgekeurd",
+    "criteria_checks_json",
+    "reden",
+)
+
+JSON_TOP_LEVEL_SCHEMA: tuple[str, ...] = (
+    "generated_at_utc",
+    "count",
+    "summary",
+    "results",
+)
+
+JSON_SUMMARY_SCHEMA: tuple[str, ...] = (
+    "success",
+    "failed",
+    "goedgekeurd",
+)
+
+CSV_PATH = "research/strategy_matrix.csv"
+JSON_PATH = "research/research_latest.json"
+
+__all__ = [
+    "CSV_PATH",
+    "JSON_PATH",
+    "JSON_SUMMARY_SCHEMA",
+    "JSON_TOP_LEVEL_SCHEMA",
+    "ROW_SCHEMA",
+]

--- a/research/results.py
+++ b/research/results.py
@@ -7,52 +7,18 @@ import csv
 import json
 from datetime import datetime, timezone
 
-
-# Frozen public output contracts. Do NOT edit without an approved
-# contract change. These tuples are consumed by the guards below.
-ROW_SCHEMA: tuple[str, ...] = (
-    "timestamp_utc",
-    "strategy_name",
-    "family",
-    "hypothesis",
-    "asset",
-    "interval",
-    "params_json",
-    "success",
-    "error",
-    "win_rate",
-    "sharpe",
-    "deflated_sharpe",
-    "max_drawdown",
-    "trades_per_maand",
-    "consistentie",
-    "totaal_trades",
-    "goedgekeurd",
-    "criteria_checks_json",
-    "reden",
-)
-
-JSON_TOP_LEVEL_SCHEMA: tuple[str, ...] = (
-    "generated_at_utc",
-    "count",
-    "summary",
-    "results",
-)
-
-JSON_SUMMARY_SCHEMA: tuple[str, ...] = (
-    "success",
-    "failed",
-    "goedgekeurd",
+from packages.qre_artifacts.public_outputs import (
+    CSV_PATH,
+    JSON_PATH,
+    JSON_SUMMARY_SCHEMA,
+    JSON_TOP_LEVEL_SCHEMA,
+    ROW_SCHEMA,
 )
 
 
 class SchemaDriftError(RuntimeError):
     """Raised when a research output row or payload drifts from the
     frozen contract. Never catch broadly - drift must surface."""
-
-
-CSV_PATH = "research/strategy_matrix.csv"
-JSON_PATH = "research/research_latest.json"
 
 
 def utc_now():

--- a/tests/architecture/test_package_migration_001_target_layout.py
+++ b/tests/architecture/test_package_migration_001_target_layout.py
@@ -47,7 +47,6 @@ README_REQUIRED_SECTIONS = (
 SCAFFOLD_ONLY_TARGETS = (
     REPO_ROOT / "packages" / "qre_research",
     REPO_ROOT / "packages" / "qre_data",
-    REPO_ROOT / "packages" / "qre_artifacts",
     REPO_ROOT / "packages" / "qre_policy",
     REPO_ROOT / "packages" / "qre_execution_sim",
     REPO_ROOT / "packages" / "qre_shadow",
@@ -109,12 +108,24 @@ def test_package_migration_001_qre_diagnostics_has_only_bounded_read_only_seed()
     assert files == ["README.md", "__init__.py", "paths.py"], target
 
 
+def test_package_migration_001_qre_artifacts_has_only_bounded_read_only_seed() -> None:
+    target = REPO_ROOT / "packages" / "qre_artifacts"
+    files = sorted(
+        path.relative_to(target).as_posix()
+        for path in target.rglob("*")
+        if path.is_file() and "__pycache__" not in path.parts
+    )
+
+    assert files == ["README.md", "__init__.py", "public_outputs.py"], target
+
+
 def test_package_migration_001_scanner_classifies_target_paths() -> None:
     assert classify_path("apps/control-plane/README.md") == DOMAIN_CONTROL_PLANE
     assert classify_path("packages/ade_governance/README.md") == DOMAIN_ADE
     assert classify_path("packages/qre_research/README.md") == DOMAIN_QRE
     assert classify_path("packages/qre_data/README.md") == DOMAIN_QRE
     assert classify_path("packages/qre_artifacts/README.md") == DOMAIN_QRE
+    assert classify_path("packages/qre_artifacts/public_outputs.py") == DOMAIN_QRE
     assert classify_path("packages/qre_diagnostics/README.md") == DOMAIN_QRE
     assert classify_path("packages/qre_policy/README.md") == DOMAIN_QRE
     assert classify_path("packages/qre_execution_sim/README.md") == DOMAIN_EXECUTION
@@ -123,6 +134,7 @@ def test_package_migration_001_scanner_classifies_target_paths() -> None:
     assert classify_path("packages/qre_live/README.md") == DOMAIN_EXECUTION
 
     assert classify_module("packages.qre_research.contracts") == DOMAIN_QRE
+    assert classify_module("packages.qre_artifacts.public_outputs") == DOMAIN_QRE
     assert classify_module("packages.qre_live.contracts") == DOMAIN_EXECUTION
 
 

--- a/tests/architecture/test_package_migration_005_qre_artifacts_read_only_boundary.py
+++ b/tests/architecture/test_package_migration_005_qre_artifacts_read_only_boundary.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import ast
+import subprocess
+from pathlib import Path
+
+import packages.qre_artifacts.public_outputs as canonical_outputs
+import research.results as compatibility_outputs
+from reporting.architecture_import_scan import (
+    DOMAIN_ADE,
+    DOMAIN_CONTROL_PLANE,
+    DOMAIN_QRE,
+    classify_module,
+    classify_path,
+    report_to_summary_dict,
+    scan_repo,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CANONICAL_PATH = REPO_ROOT / "packages" / "qre_artifacts" / "public_outputs.py"
+COMPATIBILITY_PATH = REPO_ROOT / "research" / "results.py"
+MIGRATION_DOC = (
+    REPO_ROOT
+    / "docs"
+    / "architecture"
+    / "PACKAGE-MIGRATION-005-qre-artifacts-read-only-boundary.md"
+)
+FROZEN_CONTRACT_PATHS = {
+    "research/research_latest.json",
+    "research/strategy_matrix.csv",
+    "strategy_matrix.csv",
+}
+PROTECTED_PATH_PREFIXES = (
+    ".claude/",
+    "agent/execution/",
+    "agent/risk/",
+    "automation/live_gate",
+    "broker/",
+    "execution/",
+    "live/",
+    "paper/",
+    "risk/",
+    "shadow/",
+)
+ALLOWED_CHANGED_PATH_PREFIXES = (
+    "docs/architecture/",
+    "packages/qre_artifacts/",
+    "research/results.py",
+    "tests/architecture/",
+)
+FORBIDDEN_IMPORT_PREFIXES = (
+    "agent.execution",
+    "agent.risk",
+    "automation.live_gate",
+    "broker",
+    "dashboard",
+    "execution",
+    "flask",
+    "live",
+    "paper",
+    "risk",
+    "shadow",
+)
+FORBIDDEN_HTTP_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
+
+
+def test_package_migration_005_canonical_import_path_works() -> None:
+    assert classify_path(CANONICAL_PATH.relative_to(REPO_ROOT)) == DOMAIN_QRE
+    assert classify_module("packages.qre_artifacts.public_outputs") == DOMAIN_QRE
+    assert canonical_outputs.CSV_PATH == "research/strategy_matrix.csv"
+    assert canonical_outputs.JSON_PATH == "research/research_latest.json"
+    assert canonical_outputs.JSON_TOP_LEVEL_SCHEMA == (
+        "generated_at_utc",
+        "count",
+        "summary",
+        "results",
+    )
+
+
+def test_package_migration_005_compatibility_import_path_preserves_contract() -> None:
+    for name in canonical_outputs.__all__:
+        assert getattr(compatibility_outputs, name) is getattr(canonical_outputs, name)
+
+
+def test_package_migration_005_canonical_module_is_stdlib_only() -> None:
+    imported_modules = _imported_modules(CANONICAL_PATH)
+
+    assert imported_modules == ["__future__"]
+    assert not any(_has_forbidden_import_prefix(module) for module in imported_modules)
+
+
+def test_package_migration_005_compatibility_imports_only_canonical_artifact_contract() -> None:
+    imported_modules = _imported_modules(COMPATIBILITY_PATH)
+
+    assert "packages.qre_artifacts.public_outputs" in imported_modules
+    assert not any(_has_forbidden_import_prefix(module) for module in imported_modules)
+
+
+def test_package_migration_005_adds_no_dashboard_mutation_or_runtime_route() -> None:
+    for path in (CANONICAL_PATH, COMPATIBILITY_PATH):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        route_decorators = [
+            decorator
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            for decorator in node.decorator_list
+            if isinstance(decorator, ast.Call)
+            and isinstance(decorator.func, ast.Attribute)
+            and decorator.func.attr == "route"
+        ]
+        string_constants = [
+            node.value for node in ast.walk(tree) if isinstance(node, ast.Constant)
+        ]
+
+        assert route_decorators == []
+        assert "flask" not in _imported_modules(path)
+        assert "Flask" not in string_constants
+        assert "Blueprint" not in string_constants
+        assert not any(value in FORBIDDEN_HTTP_METHODS for value in string_constants)
+
+
+def test_package_migration_005_scanner_has_no_forbidden_edges_and_keeps_legacy_visible() -> None:
+    summary = report_to_summary_dict(scan_repo(REPO_ROOT))
+    legacy_by_rule_and_domain = {
+        (row["rule"], row["source_domain"], row["target_domain"]): row[
+            "finding_count"
+        ]
+        for row in summary["legacy_finding_categories"]
+    }
+
+    assert summary["forbidden_edge_count"] == 0
+    assert summary["legacy_edge_count"] > 0
+    assert (
+        legacy_by_rule_and_domain[
+            ("control-plane-to-qre", DOMAIN_CONTROL_PLANE, DOMAIN_QRE)
+        ]
+        == 18
+    )
+    assert legacy_by_rule_and_domain[("ade-to-qre", DOMAIN_ADE, DOMAIN_QRE)] == 2
+
+
+def test_package_migration_005_changed_paths_stay_inside_bounded_slice() -> None:
+    changed_paths = _changed_paths()
+
+    assert changed_paths
+    assert FROZEN_CONTRACT_PATHS.isdisjoint(changed_paths)
+    assert not any(path.startswith(".claude/") for path in changed_paths)
+    assert not any(
+        path.startswith(prefix)
+        for path in changed_paths
+        for prefix in PROTECTED_PATH_PREFIXES
+    )
+    assert all(path.startswith(ALLOWED_CHANGED_PATH_PREFIXES) for path in changed_paths)
+
+
+def test_package_migration_005_decision_doc_is_bounded_to_one_next_unit() -> None:
+    text = MIGRATION_DOC.read_text(encoding="utf-8")
+
+    assert "PACKAGE_MIGRATION_CONTINUES_WITH_BOUNDED_NEXT_UNIT" in text
+    assert text.count("Exact next recommended unit:") == 1
+    assert "PACKAGE-MIGRATION-006 - Migrate QRE Policy Read-Only Package Boundary" in text
+    assert "No frozen research outputs were changed." in text
+    assert "No `.claude/**` files were changed." in text
+    assert "No dashboard mutation routes were added." in text
+    assert (
+        "No live, paper, shadow, risk, broker, or execution behavior was changed."
+        in text
+    )
+    assert "No dashboard runtime route wiring was changed." in text
+
+
+def _imported_modules(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    imported_modules: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_modules.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported_modules.append(node.module)
+    return imported_modules
+
+
+def _has_forbidden_import_prefix(module_name: str) -> bool:
+    return any(
+        module_name == prefix or module_name.startswith(prefix + ".")
+        for prefix in FORBIDDEN_IMPORT_PREFIXES
+    )
+
+
+def _changed_paths() -> set[str]:
+    paths: set[str] = set()
+    for args in (
+        ["diff", "--name-only", "main...HEAD"],
+        ["diff", "--name-only", "origin/main...HEAD"],
+        ["diff", "--name-only"],
+        ["diff", "--name-only", "--cached"],
+    ):
+        result = subprocess.run(
+            ["git", *args],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            continue
+        paths.update(
+            line.strip().replace("\\", "/")
+            for line in result.stdout.splitlines()
+            if line.strip()
+        )
+    declared_paths = _declared_migration_paths()
+    relevant_paths = paths & declared_paths
+    return relevant_paths or declared_paths
+
+
+def _declared_migration_paths() -> set[str]:
+    text = MIGRATION_DOC.read_text(encoding="utf-8")
+    marker = "## Exact Files/Modules Migrated or Introduced"
+    start = text.index(marker)
+    next_section = text.index("\n## ", start + len(marker))
+    section = text[start:next_section]
+    return {
+        line.strip().removeprefix("- `").removesuffix("`")
+        for line in section.splitlines()
+        if line.strip().startswith("- `")
+    }


### PR DESCRIPTION
## Summary

Migrates one bounded QRE artifacts read-only package boundary by moving the frozen public output schema/path constants into `packages.qre_artifacts.public_outputs` while preserving `research.results` as the compatibility import surface.

## Selected Migration Slice

`research/results.py` public output schema/path constants only:
- `ROW_SCHEMA`
- `JSON_TOP_LEVEL_SCHEMA`
- `JSON_SUMMARY_SCHEMA`
- `CSV_PATH`
- `JSON_PATH`

Artifact writer functions remain in `research.results`.

## Canonical Namespace

`packages.qre_artifacts.public_outputs`

## Compatibility Import Path(s)

`research.results` continues to expose the same public contract objects by importing the canonical constants.

## Files Changed

- `docs/architecture/PACKAGE-MIGRATION-005-qre-artifacts-read-only-boundary.md`
- `packages/qre_artifacts/README.md`
- `packages/qre_artifacts/__init__.py`
- `packages/qre_artifacts/public_outputs.py`
- `research/results.py`
- `tests/architecture/test_package_migration_001_target_layout.py`
- `tests/architecture/test_package_migration_005_qre_artifacts_read_only_boundary.py`

## Validation Commands and Results

- `pytest tests/architecture/test_package_migration_005_qre_artifacts_read_only_boundary.py -q` -> 8 passed
- `pytest tests/architecture/test_package_migration_001_target_layout.py -q` -> 10 passed
- `pytest tests/regression/test_research_schema_guard.py -q` -> 9 passed
- `pytest tests/regression/test_public_output_contract.py -q` -> 8 passed
- `pytest tests/architecture/test_domain_boundary_smoke.py -q` -> 40 passed
- `pytest tests/architecture/test_domain_import_scanner.py -q` -> 16 passed
- `pytest tests/architecture -q` -> 114 passed
- `pytest tests/unit/test_ci_path_classifier.py -q` -> 6 passed
- `pytest tests/regression/test_research_schema_stability.py -q` -> 1 passed
- `pytest tests/integration/test_orchestration_bytewise_equivalence.py -q` -> 2 passed
- `pytest tests/integration/test_integrity_pipeline.py -q` -> 9 passed
- `python -m reporting.architecture_import_scan --format summary` -> forbidden_edge_count 0, legacy_edge_count 76

## Scanner Summary Result

Architecture import scanner reports zero hard forbidden-edge failures. Legacy/report-only findings remain visible: 76 legacy findings, including 18 control-plane-to-QRE and 2 ADE-to-QRE allowlisted report-only findings.

## Frozen Contract Status

No frozen research outputs were changed. `research/research_latest.json` and `research/strategy_matrix.csv` are untouched.

## Frozen Schema / Regression Pin Status

Frozen schema values are unchanged and regression pins passed. Frozen fixtures and regression pins were not modified.

## Protected Path Status

No `.claude/**`, live, paper, shadow, risk, broker, execution, dashboard route, or generated artifact path was modified. Known local transcript and weekly summary files remain untracked and were not staged.

## Runtime Behavior Status

No runtime behavior change beyond a strictly equivalent read-only import-path compatibility change: `research.results` re-exports the canonical constants and writer functions remain in place.

## Dashboard Mutation Route Status

No dashboard mutation routes were added. No dashboard route or runtime route wiring was changed.

## Live/Paper/Shadow/Risk/Broker/Execution Behavior Status

No live, paper, shadow, risk, broker, or execution behavior changed.

## Exact Next Recommended Unit

PACKAGE-MIGRATION-006 - Migrate QRE Policy Read-Only Package Boundary