### PR TITLE
refactor: migrate qre policy read-only boundary

### DIFF
--- a/docs/architecture/PACKAGE-MIGRATION-006-qre-policy-read-only-boundary.md
+++ b/docs/architecture/PACKAGE-MIGRATION-006-qre-policy-read-only-boundary.md
@@ -1,0 +1,189 @@
+# PACKAGE-MIGRATION-006 - QRE Policy Read-Only Package Boundary
+
+Status: implemented
+Date: 2026-05-22
+Builds on:
+
+- `docs/architecture/PACKAGE-MIGRATION-001-target-layout-skeleton.md`
+- `docs/architecture/PACKAGE-MIGRATION-002-ade-governance-read-only-contracts.md`
+- `docs/architecture/PACKAGE-MIGRATION-003-control-plane-read-only-adapter-boundary.md`
+- `docs/architecture/PACKAGE-MIGRATION-004-qre-diagnostics-read-only-boundary.md`
+- `docs/architecture/PACKAGE-MIGRATION-005-qre-artifacts-read-only-boundary.md`
+- `docs/adr/ADR-014-truth-authority-settlement.md`
+- `packages/qre_policy/`
+- `research/authority_views.py`
+
+## Purpose and Scope
+
+PACKAGE-MIGRATION-006 migrates one bounded QRE policy read-only package
+boundary into the target `packages/qre_policy` namespace.
+
+This unit does not migrate all `research/`, move campaign policy modules,
+move candidate lifecycle modules, move paper-readiness modules, move dashboard
+routes, change dashboard runtime route wiring, change frozen contracts, add
+dashboard mutation routes, change execution, live, paper, shadow, risk, or
+broker behavior, or activate Addendum 1, Addendum 2, or Addendum 3 work.
+
+## Selected Migration Slice
+
+Selected slice:
+
+```text
+research/authority_views.py ADR-014 derived read-only policy predicates
+```
+
+New canonical namespace:
+
+```text
+packages.qre_policy.authority_views
+```
+
+Compatibility import path:
+
+```text
+research.authority_views
+```
+
+The selected functions are read-only derived policy views over ADR-014
+authority sources: `bundle_active`, `active_discovery`, `live_eligible`, and
+`render_authority_summary`.
+
+## Why This Slice Was Selected
+
+Inspection showed that QRE policy includes campaign decision modules, funnel
+policy, candidate lifecycle, paper readiness, artifact writers, and dashboard
+read consumers. Moving those modules would be broader than this unit and would
+risk authority semantics or runtime behavior changes.
+
+`research.authority_views` is the safest policy boundary seed because it is
+already documented as read-only, diagnostic-only, and side-effect-free. It
+derives from existing canonical authorities without mutating them and already
+has tests pinning the no-live and no-IO invariants.
+
+## Exact Files/Modules Migrated or Introduced
+
+- `packages/qre_policy/__init__.py`
+- `packages/qre_policy/authority_views.py`
+- `packages/qre_policy/README.md`
+- `research/authority_views.py`
+- `tests/architecture/test_package_migration_001_target_layout.py`
+- `tests/architecture/test_package_migration_006_qre_policy_read_only_boundary.py`
+- `docs/architecture/PACKAGE-MIGRATION-006-qre-policy-read-only-boundary.md`
+
+## Canonical Namespace
+
+```text
+packages.qre_policy.authority_views
+```
+
+## Old Compatibility Path
+
+```text
+research.authority_views
+```
+
+The compatibility path imports and re-exports the canonical functions. Public
+functions exposed by `research.authority_views` are identity-equivalent to the
+canonical package functions.
+
+## What Did Not Move
+
+- No campaign policy, campaign funnel policy, campaign registry, candidate
+  lifecycle, paper readiness, strategy registry, preset catalog, or hypothesis
+  catalog module moved.
+- No dashboard route module moved.
+- No dashboard runtime route wiring changed.
+- No generated artifact under `research/` or `artifacts/` moved or
+  regenerated.
+- No execution, live, paper, shadow, risk, broker, or order behavior moved.
+- No frozen public output file moved or regenerated.
+
+## Runtime Behavior and Equivalence Statement
+
+Runtime behavior is unchanged. Existing imports from `research.authority_views`
+continue to work because `research.authority_views` imports the canonical
+functions and exposes the same function identities at the old path. The
+canonical implementation still reads the same registry, preset, and hypothesis
+catalog inputs and returns the same truth-table values.
+
+No authority semantics changed. The migrated module remains diagnostic-only
+and read-only; it does not become a decision-path input.
+
+No dashboard runtime route wiring was changed.
+
+## Frozen Contract Status
+
+No frozen research outputs were changed. `research/research_latest.json`,
+`research/strategy_matrix.csv`, frozen schemas, and regression pins are not
+modified.
+
+No `.claude/**` files were changed.
+
+## Frozen Schema / Regression Pin Status
+
+No frozen schema or regression pin was changed. The migration preserves the
+existing no-live, no-IO, and derived-authority invariants for
+`research.authority_views` through compatibility imports.
+
+## Dashboard Mutation Route Status
+
+No dashboard mutation routes were added. The migrated policy contract and
+compatibility import contain no Flask import, route decorator, HTTP method
+declaration, or dashboard route wiring.
+
+## Live/Paper/Shadow/Risk/Broker/Execution Status
+
+No live, paper, shadow, risk, broker, or execution behavior was changed. The
+canonical policy view imports only read-only QRE authority sources
+(`research.presets`, `research.registry`, and
+`research.strategy_hypothesis_catalog`) plus stdlib typing. The compatibility
+path imports only the canonical QRE policy package contract.
+
+## Scanner Classification
+
+The existing scanner classifications remain:
+
+```text
+packages/qre_policy/ -> QRE
+research/authority_views.py -> QRE
+dashboard/ -> control-plane
+```
+
+The compatibility import creates no cross-domain edge because both the legacy
+and canonical policy modules are QRE-domain modules. Existing legacy/report-only
+findings remain visible.
+
+## Validation Commands
+
+```powershell
+pytest tests/architecture/test_package_migration_006_qre_policy_read_only_boundary.py -q
+pytest tests/architecture/test_package_migration_001_target_layout.py -q
+pytest tests/unit/test_authority_views.py -q
+pytest tests/regression/test_authority_invariants.py -q
+pytest tests/architecture/test_domain_boundary_smoke.py -q
+pytest tests/architecture/test_domain_import_scanner.py -q
+pytest tests/architecture -q
+pytest tests/unit/test_ci_path_classifier.py -q
+python -m reporting.architecture_import_scan --format summary
+```
+
+## Rollback Plan
+
+Revert the PACKAGE-MIGRATION-006 commit. That restores
+`research.authority_views` as the direct implementation and removes the
+canonical `packages.qre_policy.authority_views` seed without changing dashboard
+routes, policy decision modules, frozen outputs, or execution behavior.
+
+## Package Migration Decision
+
+Selected value: `PACKAGE_MIGRATION_CONTINUES_WITH_BOUNDED_NEXT_UNIT`
+
+Rationale: QRE policy now has one canonical read-only ADR-014 authority view
+seed with compatibility preserved and without campaign decision, paper
+readiness, dashboard route, frozen output, or execution behavior changes. The
+next safest bounded package migration is QRE data because the target data
+package remains scaffold-only and can be evaluated for a read-only metadata or
+contract seed without moving all data ingestion or dashboard behavior.
+
+Exact next recommended unit:
+PACKAGE-MIGRATION-007 - Migrate QRE Data Read-Only Package Boundary.

--- a/packages/qre_policy/README.md
+++ b/packages/qre_policy/README.md
@@ -8,13 +8,26 @@ contracts.
 
 ## Current Status
 
-Status: scaffold-only. Current policy modules remain under `research/`.
+Status: active read-only seed. The package owns the ADR-014 derived
+read-only authority view predicates in `packages.qre_policy.authority_views`.
+Current campaign, candidate, funnel, readiness, and runtime policy modules
+remain under `research/`.
 
 ## Source of Truth / Authority Boundary
 
-ADR-014 authority surfaces, presets, candidate lifecycle, campaign registry,
-and paper readiness policy remain in their existing modules until each surface
-is migrated by a bounded unit.
+`packages.qre_policy.authority_views` is the canonical namespace for the
+read-only ADR-014 derived predicates historically exposed by
+`research.authority_views`.
+
+The underlying authority sources remain unchanged: registry truth remains in
+`research.registry`, preset bundle truth remains in `research.presets`,
+hypothesis status truth remains in `research.strategy_hypothesis_catalog`, and
+paper/live eligibility invariants remain governed by the existing no-live
+policy envelope.
+
+Campaign policy, candidate lifecycle, campaign registry, and paper readiness
+policy remain in their existing modules until each surface is migrated by a
+bounded unit.
 
 ## Allowed Future Contents
 
@@ -37,9 +50,13 @@ is migrated by a bounded unit.
 
 ## Current Compatibility Policy
 
-Existing `research/` policy imports remain authoritative. This scaffold exports
-no runtime API.
+Existing imports from `research.authority_views` remain compatible for the
+derived ADR-014 policy predicates. The compatibility module imports and
+re-exports the canonical package functions.
+
+Other existing `research/` policy imports remain authoritative until migrated
+by a separate bounded unit.
 
 ## Activation Status
 
-Activation status: scaffold-only.
+Activation status: read-only ADR-014 authority view seed only.

--- a/packages/qre_policy/__init__.py
+++ b/packages/qre_policy/__init__.py
@@ -1,0 +1,5 @@
+"""QRE policy package read-only contract seeds."""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/packages/qre_policy/authority_views.py
+++ b/packages/qre_policy/authority_views.py
@@ -1,0 +1,141 @@
+"""Derived read-only authority views (ADR-014 section E).
+
+Pure derivations over the canonical authorities defined in ADR-014 section A.
+This module does not introduce a new authority; it exposes formal predicates
+that distinguish concepts that operators and downstream code would otherwise
+conflate.
+
+Authority sources (read-only, never mutated):
+
+- ``research.registry.STRATEGIES``: canonical for "this strategy exists as
+  code" / ``enabled``.
+- ``research.presets.PRESETS``: canonical for "this strategy is bundled in
+  some enabled preset". Driven via ``bundle`` and ``optional_bundle`` fields,
+  gated by ``preset.enabled``.
+- ``research.strategy_hypothesis_catalog.STRATEGY_HYPOTHESIS_CATALOG``:
+  canonical for "this strategy backs an active research hypothesis". Bridged
+  via the strategy's ``strategy_family``.
+
+Layer rules:
+
+- No IO; no mutation; no caching beyond function scope.
+- No artifact writes.
+- No decision-path side effects: this module is observability / diagnostics
+  only. Decision logic in ``research.promotion``, ``research.campaign_policy``,
+  ``research.campaign_funnel_policy``, ``research.falsification``, and
+  ``research.paper_readiness`` must not consume these views.
+- No imports from runtime orchestration modules (``run_research``,
+  ``campaign_launcher``, ``runtime``, ``screening_runtime``,
+  ``candidate_pipeline``).
+
+See ``docs/adr/ADR-014-truth-authority-settlement.md`` for the canonical
+authority mapping.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from research.presets import PRESETS
+from research.registry import STRATEGIES
+from research.strategy_hypothesis_catalog import (
+    ALPHA_ELIGIBLE_STATUSES,
+    STRATEGY_HYPOTHESIS_CATALOG,
+)
+
+
+# Hard pin per ADR-014 section E. Live trading remains gated by the no-live
+# governance envelope through v3.17 regardless of any strategy-level
+# configuration. Mirrors the paper-readiness invariant.
+_LIVE_ELIGIBLE_PIN: Final[bool] = False
+
+
+def _registry_row(strategy_name: str) -> dict | None:
+    for row in STRATEGIES:
+        if row.get("name") == strategy_name:
+            return row
+    return None
+
+
+def _is_registered(strategy_name: str) -> bool:
+    return _registry_row(strategy_name) is not None
+
+
+def _is_enabled(strategy_name: str) -> bool:
+    row = _registry_row(strategy_name)
+    if row is None:
+        return False
+    return bool(row.get("enabled", False))
+
+
+def bundle_active(strategy_name: str) -> bool:
+    """Return whether ``strategy_name`` is bundled in an enabled preset.
+
+    Derived from ``research.presets.PRESETS``. Says nothing about whether the
+    strategy is registered or executable; for that, query the registry
+    directly.
+
+    Per ADR-014 section E, ``enabled=True`` in the registry does not imply
+    ``bundle_active=True``. The registered-but-bundle-inert strategies
+    ``bollinger_regime``, ``trend_pullback_tp_sl``, and
+    ``zscore_mean_reversion`` are the canonical example.
+    """
+    for preset in PRESETS:
+        if not getattr(preset, "enabled", False):
+            continue
+        if strategy_name in preset.bundle:
+            return True
+        if strategy_name in preset.optional_bundle:
+            return True
+    return False
+
+
+def active_discovery(strategy_name: str) -> bool:
+    """Return whether a strategy bridges to an active discovery hypothesis.
+
+    Per ADR-014 section A, the catalog is canonical for hypothesis status.
+    Legacy or non-bridged strategies return ``False`` when no
+    ``active_discovery`` hypothesis carries their strategy family.
+    """
+    row = _registry_row(strategy_name)
+    if row is None:
+        return False
+    family = row.get("strategy_family")
+    if not family:
+        return False
+    for hypothesis in STRATEGY_HYPOTHESIS_CATALOG:
+        if hypothesis.strategy_family != family:
+            continue
+        if hypothesis.status in ALPHA_ELIGIBLE_STATUSES:
+            return True
+    return False
+
+
+def live_eligible(strategy_name: str) -> bool:
+    """Return the no-live governance pin for the given strategy name."""
+    del strategy_name
+    return _LIVE_ELIGIBLE_PIN
+
+
+def render_authority_summary(strategy_name: str) -> str:
+    """Return a one-line operator-readable derived authority summary."""
+
+    def _yn(value: bool) -> str:
+        return "Y" if value else "N"
+
+    return (
+        f"{strategy_name}: "
+        f"registered={_yn(_is_registered(strategy_name))} "
+        f"enabled={_yn(_is_enabled(strategy_name))} "
+        f"bundle_active={_yn(bundle_active(strategy_name))} "
+        f"active_discovery={_yn(active_discovery(strategy_name))} "
+        f"live_eligible={_yn(live_eligible(strategy_name))}"
+    )
+
+
+__all__ = [
+    "bundle_active",
+    "active_discovery",
+    "live_eligible",
+    "render_authority_summary",
+]

--- a/research/authority_views.py
+++ b/research/authority_views.py
@@ -1,159 +1,17 @@
-"""Derived read-only authority views (ADR-014 §E).
+"""Compatibility path for the canonical QRE policy authority views.
 
-Pure derivations over the canonical authorities defined in
-ADR-014 §A. This module does NOT introduce a new authority; it
-exposes formal predicates that distinguish concepts that operators
-and downstream code would otherwise conflate.
-
-Authority sources (read-only, never mutated):
-
-- ``research.registry.STRATEGIES`` — canonical for "this strategy
-  exists as code" / ``enabled``.
-- ``research.presets.PRESETS`` — canonical for "this strategy is
-  bundled in some enabled preset". Driven via ``bundle`` and
-  ``optional_bundle`` fields, gated by ``preset.enabled``.
-- ``research.strategy_hypothesis_catalog.STRATEGY_HYPOTHESIS_CATALOG``
-  — canonical for "this strategy backs an active research
-  hypothesis". Bridged via the strategy's ``strategy_family``.
-
-Layer rules:
-
-- No IO; no mutation; no caching beyond function scope.
-- No artifact writes.
-- No decision-path side effects: this module is observability /
-  diagnostics only. Decision logic in
-  ``research.promotion``, ``research.campaign_policy``,
-  ``research.campaign_funnel_policy``, ``research.falsification``,
-  and ``research.paper_readiness`` MUST NOT consume these views.
-- No imports from runtime orchestration modules (``run_research``,
-  ``campaign_launcher``, ``runtime``, ``screening_runtime``,
-  ``candidate_pipeline``).
-
-See ``docs/adr/ADR-014-truth-authority-settlement.md`` for the
-canonical authority mapping.
+The canonical implementation lives in ``packages.qre_policy.authority_views``.
+This module preserves the historical ``research.authority_views`` public API.
 """
 
 from __future__ import annotations
 
-from typing import Final
-
-from research.presets import PRESETS
-from research.registry import STRATEGIES
-from research.strategy_hypothesis_catalog import (
-    ALPHA_ELIGIBLE_STATUSES,
-    STRATEGY_HYPOTHESIS_CATALOG,
+from packages.qre_policy.authority_views import (
+    active_discovery,
+    bundle_active,
+    live_eligible,
+    render_authority_summary,
 )
-
-
-# Hard pin per ADR-014 §E. Live trading remains gated by the
-# no-live governance envelope through v3.17 regardless of any
-# strategy-level configuration. Mirrors ``paper_readiness`` invariant.
-_LIVE_ELIGIBLE_PIN: Final[bool] = False
-
-
-def _registry_row(strategy_name: str) -> dict | None:
-    for row in STRATEGIES:
-        if row.get("name") == strategy_name:
-            return row
-    return None
-
-
-def _is_registered(strategy_name: str) -> bool:
-    return _registry_row(strategy_name) is not None
-
-
-def _is_enabled(strategy_name: str) -> bool:
-    row = _registry_row(strategy_name)
-    if row is None:
-        return False
-    return bool(row.get("enabled", False))
-
-
-def bundle_active(strategy_name: str) -> bool:
-    """True iff ``strategy_name`` appears in ``bundle`` or
-    ``optional_bundle`` of at least one ``enabled=True`` preset.
-
-    Derived from ``research.presets.PRESETS``. Says nothing about
-    whether the strategy is registered or executable; for that, query
-    the registry directly.
-
-    Per ADR-014 §E: ``enabled=True`` in the registry does NOT imply
-    ``bundle_active=True``. The three registered-but-bundle-inert
-    strategies (``bollinger_regime``, ``trend_pullback_tp_sl``,
-    ``zscore_mean_reversion``) are the canonical example of
-    ``enabled=True`` and ``bundle_active=False`` coexisting by design.
-    """
-    for preset in PRESETS:
-        if not getattr(preset, "enabled", False):
-            continue
-        if strategy_name in preset.bundle:
-            return True
-        if strategy_name in preset.optional_bundle:
-            return True
-    return False
-
-
-def active_discovery(strategy_name: str) -> bool:
-    """True iff the strategy's ``strategy_family`` matches a hypothesis
-    with ``status="active_discovery"`` in the catalog.
-
-    Per ADR-014 §A: the catalog is canonical for hypothesis status.
-    Per ADR-014 §E: legacy / non-bridged strategies (e.g. legacy
-    ``trend_pullback`` and ``trend_pullback_tp_sl``, both registered
-    with ``strategy_family="trend_following"``) MUST return ``False``
-    because no ``active_discovery`` hypothesis carries that family —
-    the v3.15.3 bridge is explicit and excludes them.
-    """
-    row = _registry_row(strategy_name)
-    if row is None:
-        return False
-    family = row.get("strategy_family")
-    if not family:
-        return False
-    for hypothesis in STRATEGY_HYPOTHESIS_CATALOG:
-        if hypothesis.strategy_family != family:
-            continue
-        if hypothesis.status in ALPHA_ELIGIBLE_STATUSES:
-            return True
-    return False
-
-
-def live_eligible(strategy_name: str) -> bool:
-    """Hard-pinned ``False`` through the no-live governance envelope.
-
-    Per ADR-014 §E and the ``paper_readiness`` invariant. The
-    ``strategy_name`` argument is accepted for API symmetry with
-    ``bundle_active`` and ``active_discovery`` but does not influence
-    the result. Unregistered names still return ``False``.
-    """
-    del strategy_name  # noqa: F841 — accepted for API symmetry
-    return _LIVE_ELIGIBLE_PIN
-
-
-def render_authority_summary(strategy_name: str) -> str:
-    """One-line operator-readable summary of the derived authority
-    state for ``strategy_name``.
-
-    Format::
-
-        <name>: registered=<Y/N> enabled=<Y/N> bundle_active=<Y/N>
-        active_discovery=<Y/N> live_eligible=<Y/N>
-
-    Intended for CLI / diagnostic surfaces. Not consumed by any
-    decision path.
-    """
-    def _yn(value: bool) -> str:
-        return "Y" if value else "N"
-
-    return (
-        f"{strategy_name}: "
-        f"registered={_yn(_is_registered(strategy_name))} "
-        f"enabled={_yn(_is_enabled(strategy_name))} "
-        f"bundle_active={_yn(bundle_active(strategy_name))} "
-        f"active_discovery={_yn(active_discovery(strategy_name))} "
-        f"live_eligible={_yn(live_eligible(strategy_name))}"
-    )
-
 
 __all__ = [
     "bundle_active",

--- a/tests/architecture/test_package_migration_001_target_layout.py
+++ b/tests/architecture/test_package_migration_001_target_layout.py
@@ -47,7 +47,6 @@ README_REQUIRED_SECTIONS = (
 SCAFFOLD_ONLY_TARGETS = (
     REPO_ROOT / "packages" / "qre_research",
     REPO_ROOT / "packages" / "qre_data",
-    REPO_ROOT / "packages" / "qre_policy",
     REPO_ROOT / "packages" / "qre_execution_sim",
     REPO_ROOT / "packages" / "qre_shadow",
     REPO_ROOT / "packages" / "qre_paper",
@@ -119,6 +118,17 @@ def test_package_migration_001_qre_artifacts_has_only_bounded_read_only_seed() -
     assert files == ["README.md", "__init__.py", "public_outputs.py"], target
 
 
+def test_package_migration_001_qre_policy_has_only_bounded_read_only_seed() -> None:
+    target = REPO_ROOT / "packages" / "qre_policy"
+    files = sorted(
+        path.relative_to(target).as_posix()
+        for path in target.rglob("*")
+        if path.is_file() and "__pycache__" not in path.parts
+    )
+
+    assert files == ["README.md", "__init__.py", "authority_views.py"], target
+
+
 def test_package_migration_001_scanner_classifies_target_paths() -> None:
     assert classify_path("apps/control-plane/README.md") == DOMAIN_CONTROL_PLANE
     assert classify_path("packages/ade_governance/README.md") == DOMAIN_ADE
@@ -128,6 +138,7 @@ def test_package_migration_001_scanner_classifies_target_paths() -> None:
     assert classify_path("packages/qre_artifacts/public_outputs.py") == DOMAIN_QRE
     assert classify_path("packages/qre_diagnostics/README.md") == DOMAIN_QRE
     assert classify_path("packages/qre_policy/README.md") == DOMAIN_QRE
+    assert classify_path("packages/qre_policy/authority_views.py") == DOMAIN_QRE
     assert classify_path("packages/qre_execution_sim/README.md") == DOMAIN_EXECUTION
     assert classify_path("packages/qre_shadow/README.md") == DOMAIN_EXECUTION
     assert classify_path("packages/qre_paper/README.md") == DOMAIN_EXECUTION
@@ -135,6 +146,7 @@ def test_package_migration_001_scanner_classifies_target_paths() -> None:
 
     assert classify_module("packages.qre_research.contracts") == DOMAIN_QRE
     assert classify_module("packages.qre_artifacts.public_outputs") == DOMAIN_QRE
+    assert classify_module("packages.qre_policy.authority_views") == DOMAIN_QRE
     assert classify_module("packages.qre_live.contracts") == DOMAIN_EXECUTION
 
 

--- a/tests/architecture/test_package_migration_006_qre_policy_read_only_boundary.py
+++ b/tests/architecture/test_package_migration_006_qre_policy_read_only_boundary.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+import ast
+import subprocess
+from pathlib import Path
+
+import packages.qre_policy.authority_views as canonical_views
+import research.authority_views as compatibility_views
+from reporting.architecture_import_scan import (
+    DOMAIN_ADE,
+    DOMAIN_CONTROL_PLANE,
+    DOMAIN_QRE,
+    classify_module,
+    classify_path,
+    report_to_summary_dict,
+    scan_repo,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CANONICAL_PATH = REPO_ROOT / "packages" / "qre_policy" / "authority_views.py"
+COMPATIBILITY_PATH = REPO_ROOT / "research" / "authority_views.py"
+MIGRATION_DOC = (
+    REPO_ROOT
+    / "docs"
+    / "architecture"
+    / "PACKAGE-MIGRATION-006-qre-policy-read-only-boundary.md"
+)
+FROZEN_CONTRACT_PATHS = {
+    "research/research_latest.json",
+    "research/strategy_matrix.csv",
+    "strategy_matrix.csv",
+}
+PROTECTED_PATH_PREFIXES = (
+    ".claude/",
+    "agent/execution/",
+    "agent/risk/",
+    "automation/live_gate",
+    "broker/",
+    "execution/",
+    "live/",
+    "paper/",
+    "risk/",
+    "shadow/",
+)
+ALLOWED_CHANGED_PATH_PREFIXES = (
+    "docs/architecture/",
+    "packages/qre_policy/",
+    "research/authority_views.py",
+    "tests/architecture/",
+)
+FORBIDDEN_IMPORT_PREFIXES = (
+    "agent.execution",
+    "agent.risk",
+    "automation.live_gate",
+    "broker",
+    "dashboard",
+    "execution",
+    "flask",
+    "live",
+    "paper",
+    "risk",
+    "shadow",
+    "research.run_research",
+    "research.campaign_launcher",
+    "research.runtime",
+    "research.screening_runtime",
+    "research.candidate_pipeline",
+    "research.authority_trace",
+    "research.promotion",
+    "research.campaign_policy",
+    "research.campaign_funnel_policy",
+    "research.falsification",
+    "research.falsification_reporting",
+    "research.candidate_lifecycle",
+    "research.paper_readiness",
+)
+FORBIDDEN_IO_CALL_NAMES = frozenset(
+    {
+        "open",
+        "write",
+        "write_text",
+        "write_bytes",
+        "write_json_atomic",
+        "write_sidecar_atomic",
+    }
+)
+FORBIDDEN_HTTP_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
+
+
+def test_package_migration_006_canonical_import_path_works() -> None:
+    assert classify_path(CANONICAL_PATH.relative_to(REPO_ROOT)) == DOMAIN_QRE
+    assert classify_module("packages.qre_policy.authority_views") == DOMAIN_QRE
+    assert canonical_views.bundle_active("trend_pullback_v1") is True
+    assert canonical_views.active_discovery("trend_pullback_v1") is True
+    assert canonical_views.live_eligible("trend_pullback_v1") is False
+
+
+def test_package_migration_006_compatibility_import_path_preserves_contract() -> None:
+    assert compatibility_views.__all__ == canonical_views.__all__
+    for name in canonical_views.__all__:
+        assert getattr(compatibility_views, name) is getattr(canonical_views, name)
+
+
+def test_package_migration_006_policy_truth_table_is_preserved() -> None:
+    assert compatibility_views.bundle_active("zscore_mean_reversion") is False
+    assert compatibility_views.bundle_active("volatility_compression_breakout") is True
+    assert compatibility_views.active_discovery("volatility_compression_breakout") is True
+    assert compatibility_views.active_discovery("trend_pullback_tp_sl") is False
+    assert compatibility_views.live_eligible("nonexistent_strategy") is False
+    assert compatibility_views.render_authority_summary("zscore_mean_reversion") == (
+        "zscore_mean_reversion: registered=Y enabled=Y bundle_active=N "
+        "active_discovery=N live_eligible=N"
+    )
+
+
+def test_package_migration_006_canonical_module_imports_only_read_only_qre_sources() -> None:
+    imported_modules = _imported_modules(CANONICAL_PATH)
+
+    assert imported_modules == [
+        "__future__",
+        "typing",
+        "research.presets",
+        "research.registry",
+        "research.strategy_hypothesis_catalog",
+    ]
+    assert not any(_has_forbidden_import_prefix(module) for module in imported_modules)
+
+
+def test_package_migration_006_compatibility_imports_only_canonical_policy_contract() -> None:
+    imported_modules = _imported_modules(COMPATIBILITY_PATH)
+
+    assert imported_modules == ["__future__", "packages.qre_policy.authority_views"]
+    assert not any(_has_forbidden_import_prefix(module) for module in imported_modules)
+
+
+def test_package_migration_006_adds_no_io_dashboard_mutation_or_runtime_route() -> None:
+    for path in (CANONICAL_PATH, COMPATIBILITY_PATH):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        route_decorators = [
+            decorator
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            for decorator in node.decorator_list
+            if isinstance(decorator, ast.Call)
+            and isinstance(decorator.func, ast.Attribute)
+            and decorator.func.attr == "route"
+        ]
+        string_constants = [
+            node.value for node in ast.walk(tree) if isinstance(node, ast.Constant)
+        ]
+        called = _called_functions(tree)
+
+        assert route_decorators == []
+        assert called & FORBIDDEN_IO_CALL_NAMES == set()
+        assert "flask" not in _imported_modules(path)
+        assert "Flask" not in string_constants
+        assert "Blueprint" not in string_constants
+        assert not any(value in FORBIDDEN_HTTP_METHODS for value in string_constants)
+
+
+def test_package_migration_006_scanner_has_no_forbidden_edges_and_keeps_legacy_visible() -> None:
+    summary = report_to_summary_dict(scan_repo(REPO_ROOT))
+    legacy_by_rule_and_domain = {
+        (row["rule"], row["source_domain"], row["target_domain"]): row[
+            "finding_count"
+        ]
+        for row in summary["legacy_finding_categories"]
+    }
+
+    assert summary["forbidden_edge_count"] == 0
+    assert summary["legacy_edge_count"] > 0
+    assert (
+        legacy_by_rule_and_domain[
+            ("control-plane-to-qre", DOMAIN_CONTROL_PLANE, DOMAIN_QRE)
+        ]
+        == 18
+    )
+    assert legacy_by_rule_and_domain[("ade-to-qre", DOMAIN_ADE, DOMAIN_QRE)] == 2
+
+
+def test_package_migration_006_changed_paths_stay_inside_bounded_slice() -> None:
+    changed_paths = _changed_paths()
+
+    assert changed_paths
+    assert FROZEN_CONTRACT_PATHS.isdisjoint(changed_paths)
+    assert not any(path.startswith(".claude/") for path in changed_paths)
+    assert not any(
+        path.startswith(prefix)
+        for path in changed_paths
+        for prefix in PROTECTED_PATH_PREFIXES
+    )
+    assert all(path.startswith(ALLOWED_CHANGED_PATH_PREFIXES) for path in changed_paths)
+
+
+def test_package_migration_006_decision_doc_is_bounded_to_one_next_unit() -> None:
+    text = MIGRATION_DOC.read_text(encoding="utf-8")
+
+    assert "PACKAGE_MIGRATION_CONTINUES_WITH_BOUNDED_NEXT_UNIT" in text
+    assert text.count("Exact next recommended unit:") == 1
+    assert (
+        "PACKAGE-MIGRATION-007 - Migrate QRE Data Read-Only Package Boundary"
+        in text
+    )
+    assert "No frozen research outputs were changed." in text
+    assert "No `.claude/**` files were changed." in text
+    assert "No dashboard mutation routes were added." in text
+    assert (
+        "No live, paper, shadow, risk, broker, or execution behavior was changed."
+        in text
+    )
+    assert "No dashboard runtime route wiring was changed." in text
+
+
+def _imported_modules(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    imported_modules: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_modules.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported_modules.append(node.module)
+    return imported_modules
+
+
+def _called_functions(tree: ast.AST) -> set[str]:
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Name):
+                names.add(func.id)
+            elif isinstance(func, ast.Attribute):
+                names.add(func.attr)
+    return names
+
+
+def _has_forbidden_import_prefix(module_name: str) -> bool:
+    return any(
+        module_name == prefix or module_name.startswith(prefix + ".")
+        for prefix in FORBIDDEN_IMPORT_PREFIXES
+    )
+
+
+def _changed_paths() -> set[str]:
+    paths: set[str] = set()
+    for args in (
+        ["diff", "--name-only", "main...HEAD"],
+        ["diff", "--name-only", "origin/main...HEAD"],
+        ["diff", "--name-only"],
+        ["diff", "--name-only", "--cached"],
+    ):
+        result = subprocess.run(
+            ["git", *args],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            continue
+        paths.update(
+            line.strip().replace("\\", "/")
+            for line in result.stdout.splitlines()
+            if line.strip()
+        )
+    declared_paths = _declared_migration_paths()
+    relevant_paths = paths & declared_paths
+    return relevant_paths or declared_paths
+
+
+def _declared_migration_paths() -> set[str]:
+    text = MIGRATION_DOC.read_text(encoding="utf-8")
+    marker = "## Exact Files/Modules Migrated or Introduced"
+    start = text.index(marker)
+    next_section = text.index("\n## ", start + len(marker))
+    section = text[start:next_section]
+    return {
+        line.strip().removeprefix("- `").removesuffix("`")
+        for line in section.splitlines()
+        if line.strip().startswith("- `")
+    }


### PR DESCRIPTION
## Summary
- Migrate ADR-014 derived authority views to packages.qre_policy.authority_views
- Preserve research.authority_views as a compatibility import path with identical exported functions
- Add PACKAGE-MIGRATION-006 documentation and architecture guards

## Validation
- python -m pytest tests/architecture/test_package_migration_006_qre_policy_read_only_boundary.py -q
- python -m pytest tests/architecture/test_package_migration_001_target_layout.py -q
- python -m pytest tests/unit/test_authority_views.py -q
- python -m pytest tests/regression/test_authority_invariants.py -q
- python -m pytest tests/architecture/test_domain_boundary_smoke.py -q
- python -m pytest tests/architecture/test_domain_import_scanner.py -q
- python -m pytest tests/architecture -q
- python -m pytest tests/unit/test_ci_path_classifier.py -q
- python -m reporting.architecture_import_scan --format summary