### PR TITLE
refactor: migrate qre data read-only boundary

### DIFF
--- a/data/contracts.py
+++ b/data/contracts.py
@@ -1,52 +1,23 @@
-"""Canonical data contracts for market and macro adapters."""
+"""Compatibility path for canonical QRE data contracts.
+
+The canonical implementation lives in ``packages.qre_data.contracts``. This
+module preserves the historical ``data.contracts`` public API.
+"""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from datetime import datetime
-from typing import Literal
+from packages.qre_data.contracts import (
+    AdapterAuthError,
+    CanonicalBar,
+    Instrument,
+    MacroSeriesPoint,
+    Provenance,
+)
 
-
-class AdapterAuthError(RuntimeError):
-    """Raised when an adapter cannot obtain required credentials."""
-
-
-@dataclass(frozen=True)
-class Instrument:
-    id: str
-    asset_class: Literal["crypto", "equity", "prediction", "macro"]
-    venue: str
-    native_symbol: str
-    quote_ccy: str
-
-
-@dataclass(frozen=True)
-class Provenance:
-    adapter: str
-    fetched_at_utc: datetime
-    config_hash: str
-    source_version: str
-    cache_hit: bool
-
-
-@dataclass(frozen=True)
-class CanonicalBar:
-    instrument: Instrument
-    interval: str
-    timestamp_utc: datetime
-    open: float
-    high: float
-    low: float
-    close: float
-    volume: float
-    provenance: Provenance
-
-
-@dataclass(frozen=True)
-class MacroSeriesPoint:
-    series_id: str
-    timestamp_utc: datetime
-    value: float
-    native_frequency: str
-    vintage_as_of_utc: datetime | None
-    provenance: Provenance
+__all__ = [
+    "AdapterAuthError",
+    "CanonicalBar",
+    "Instrument",
+    "MacroSeriesPoint",
+    "Provenance",
+]

--- a/docs/architecture/PACKAGE-MIGRATION-007-qre-data-read-only-boundary.md
+++ b/docs/architecture/PACKAGE-MIGRATION-007-qre-data-read-only-boundary.md
@@ -1,0 +1,187 @@
+# PACKAGE-MIGRATION-007 - QRE Data Read-Only Package Boundary
+
+Status: implemented
+Date: 2026-05-22
+Builds on:
+
+- `docs/architecture/PACKAGE-MIGRATION-001-target-layout-skeleton.md`
+- `docs/architecture/PACKAGE-MIGRATION-004-qre-diagnostics-read-only-boundary.md`
+- `docs/architecture/PACKAGE-MIGRATION-005-qre-artifacts-read-only-boundary.md`
+- `docs/architecture/PACKAGE-MIGRATION-006-qre-policy-read-only-boundary.md`
+- `packages/qre_data/`
+- `data/contracts.py`
+
+## Purpose and Scope
+
+PACKAGE-MIGRATION-007 migrates one bounded QRE data read-only package boundary
+into the target `packages/qre_data` namespace.
+
+This unit does not migrate all `data/`, move repositories, move adapters, move
+data fetchers, move cache files, move dashboard routes, change dashboard
+runtime route wiring, change frozen contracts, add dashboard mutation routes,
+change execution, live, paper, shadow, risk, or broker behavior, or activate
+Addendum 1, Addendum 2, or Addendum 3 work.
+
+## Selected Migration Slice
+
+Selected slice:
+
+```text
+data/contracts.py immutable market and macro data contract types
+```
+
+New canonical namespace:
+
+```text
+packages.qre_data.contracts
+```
+
+Compatibility import path:
+
+```text
+data.contracts
+```
+
+The selected classes are read-only data contracts: `AdapterAuthError`,
+`Instrument`, `Provenance`, `CanonicalBar`, and `MacroSeriesPoint`.
+
+## Why This Slice Was Selected
+
+Inspection showed that data repositories and adapters include cache IO,
+external data fetching, credential handling, dashboard consumers, and runtime
+data loading. Moving those modules would be broader than this unit and would
+risk data-fetch behavior changes.
+
+`data.contracts` is the safest data boundary seed because it contains immutable
+dataclass contract definitions and one exception type only. It has no IO, no
+adapter routing, no cache mutation, and no dashboard route wiring.
+
+## Exact Files/Modules Migrated or Introduced
+
+- `packages/qre_data/__init__.py`
+- `packages/qre_data/contracts.py`
+- `packages/qre_data/README.md`
+- `data/contracts.py`
+- `tests/architecture/test_package_migration_001_target_layout.py`
+- `tests/architecture/test_package_migration_007_qre_data_read_only_boundary.py`
+- `docs/architecture/PACKAGE-MIGRATION-007-qre-data-read-only-boundary.md`
+
+## Canonical Namespace
+
+```text
+packages.qre_data.contracts
+```
+
+## Old Compatibility Path
+
+```text
+data.contracts
+```
+
+The compatibility path imports and re-exports the canonical classes. Public
+classes exposed by `data.contracts` are identity-equivalent to the canonical
+package classes.
+
+## What Did Not Move
+
+- No data repository, adapter, fetcher, cache file, bot-detection, or data
+  runtime module moved.
+- No dashboard route module moved.
+- No dashboard runtime route wiring changed.
+- No generated artifact under `research/`, `artifacts/`, or `data/cache/`
+  moved or regenerated.
+- No strategy, registry, research orchestration, campaign, candidate, policy,
+  or authority module moved.
+- No execution, live, paper, shadow, risk, broker, or order behavior moved.
+- No frozen public output file moved or regenerated.
+
+## Runtime Behavior and Equivalence Statement
+
+Runtime behavior is unchanged. Existing imports from `data.contracts` continue
+to work because `data.contracts` imports the canonical classes and exposes the
+same class identities at the old path. Dataclass frozen behavior, constructor
+fields, equality, and `asdict` behavior are preserved.
+
+No repository, adapter, cache, credential, external IO, or dashboard runtime
+route wiring was changed.
+
+No dashboard runtime route wiring was changed.
+
+## Frozen Contract Status
+
+No frozen research outputs were changed. `research/research_latest.json`,
+`research/strategy_matrix.csv`, frozen schemas, and regression pins are not
+modified.
+
+No `.claude/**` files were changed.
+
+## Frozen Schema / Regression Pin Status
+
+No frozen schema or regression pin was changed. The migration preserves the
+existing data contract dataclass fields and compatibility import path.
+
+## Dashboard Mutation Route Status
+
+No dashboard mutation routes were added. The migrated data contract and
+compatibility import contain no Flask import, route decorator, HTTP method
+declaration, or dashboard route wiring.
+
+## Live/Paper/Shadow/Risk/Broker/Execution Status
+
+No live, paper, shadow, risk, broker, or execution behavior was changed. The
+canonical data contract imports only stdlib dataclass, datetime, and typing
+helpers. The compatibility path imports only the canonical QRE data package
+contract.
+
+## Scanner Classification
+
+The existing scanner classifications remain:
+
+```text
+packages/qre_data/ -> QRE
+data/contracts.py -> QRE
+dashboard/ -> control-plane
+```
+
+The compatibility import creates no cross-domain edge because both the legacy
+and canonical data contract modules are QRE-domain modules. Existing
+legacy/report-only findings remain visible.
+
+## Validation Commands
+
+```powershell
+pytest tests/architecture/test_package_migration_007_qre_data_read_only_boundary.py -q
+pytest tests/architecture/test_package_migration_001_target_layout.py -q
+pytest tests/unit/test_data_contracts.py -q
+pytest tests/unit/test_adapter_protocols.py -q
+pytest tests/unit/test_market_repository.py -q
+pytest tests/unit/test_macro_repository.py -q
+pytest tests/unit/test_yfinance_adapter.py -q
+pytest tests/unit/test_fred_adapter.py -q
+pytest tests/architecture/test_domain_boundary_smoke.py -q
+pytest tests/architecture/test_domain_import_scanner.py -q
+pytest tests/architecture -q
+pytest tests/unit/test_ci_path_classifier.py -q
+python -m reporting.architecture_import_scan --format summary
+```
+
+## Rollback Plan
+
+Revert the PACKAGE-MIGRATION-007 commit. That restores `data.contracts` as the
+direct implementation and removes the canonical `packages.qre_data.contracts`
+seed without changing repositories, adapters, cache files, dashboard routes,
+frozen outputs, or execution behavior.
+
+## Package Migration Decision
+
+Selected value: `PACKAGE_MIGRATION_CONTINUES_WITH_BOUNDED_NEXT_UNIT`
+
+Rationale: QRE data now has one canonical read-only data contract seed with
+compatibility preserved and without repository, adapter, cache, dashboard route,
+frozen output, or execution behavior changes. The next safest bounded package
+migration is QRE research because the target package remains scaffold-only and
+can be evaluated for a read-only research contract seed without moving all
+research orchestration or strategy logic.
+
+Exact next recommended unit:
+PACKAGE-MIGRATION-008 - Migrate QRE Research Read-Only Package Boundary.

--- a/packages/qre_data/README.md
+++ b/packages/qre_data/README.md
@@ -7,12 +7,19 @@ market-data access abstractions, and deterministic data-source metadata.
 
 ## Current Status
 
-Status: scaffold-only. Current data modules remain under `data/`.
+Status: active read-only seed. The package owns the immutable market and macro
+data contract types in `packages.qre_data.contracts`. Current data
+repositories, adapters, fetchers, cache behavior, and dashboard consumers
+remain in their existing paths.
 
 ## Source of Truth / Authority Boundary
 
-Existing `data/` contracts, repositories, adapters, and fetchers remain the
-source of truth until a bounded data-package migration is authorized.
+`packages.qre_data.contracts` is the canonical namespace for immutable data
+contract types historically exposed by `data.contracts`.
+
+Existing `data/` repositories, adapters, fetchers, cache files, and dashboard
+consumers remain the source of truth until each surface is migrated by a
+bounded unit.
 
 ## Allowed Future Contents
 
@@ -37,9 +44,13 @@ source of truth until a bounded data-package migration is authorized.
 
 ## Current Compatibility Policy
 
-Existing `data/` imports remain authoritative. This scaffold exports no runtime
-API.
+Existing imports from `data.contracts` remain compatible for the immutable
+data contract types. The compatibility module imports and re-exports the
+canonical package classes.
+
+Other existing `data/` imports remain authoritative until migrated by a
+separate bounded unit.
 
 ## Activation Status
 
-Activation status: scaffold-only.
+Activation status: read-only data contract seed only.

--- a/packages/qre_data/__init__.py
+++ b/packages/qre_data/__init__.py
@@ -1,0 +1,5 @@
+"""QRE data package read-only contract seeds."""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/packages/qre_data/contracts.py
+++ b/packages/qre_data/contracts.py
@@ -1,0 +1,61 @@
+"""Canonical read-only data contracts for market and macro adapters."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal
+
+
+class AdapterAuthError(RuntimeError):
+    """Raised when an adapter cannot obtain required credentials."""
+
+
+@dataclass(frozen=True)
+class Instrument:
+    id: str
+    asset_class: Literal["crypto", "equity", "prediction", "macro"]
+    venue: str
+    native_symbol: str
+    quote_ccy: str
+
+
+@dataclass(frozen=True)
+class Provenance:
+    adapter: str
+    fetched_at_utc: datetime
+    config_hash: str
+    source_version: str
+    cache_hit: bool
+
+
+@dataclass(frozen=True)
+class CanonicalBar:
+    instrument: Instrument
+    interval: str
+    timestamp_utc: datetime
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float
+    provenance: Provenance
+
+
+@dataclass(frozen=True)
+class MacroSeriesPoint:
+    series_id: str
+    timestamp_utc: datetime
+    value: float
+    native_frequency: str
+    vintage_as_of_utc: datetime | None
+    provenance: Provenance
+
+
+__all__ = [
+    "AdapterAuthError",
+    "CanonicalBar",
+    "Instrument",
+    "MacroSeriesPoint",
+    "Provenance",
+]

--- a/tests/architecture/test_package_migration_001_target_layout.py
+++ b/tests/architecture/test_package_migration_001_target_layout.py
@@ -46,7 +46,6 @@ README_REQUIRED_SECTIONS = (
 
 SCAFFOLD_ONLY_TARGETS = (
     REPO_ROOT / "packages" / "qre_research",
-    REPO_ROOT / "packages" / "qre_data",
     REPO_ROOT / "packages" / "qre_execution_sim",
     REPO_ROOT / "packages" / "qre_shadow",
     REPO_ROOT / "packages" / "qre_paper",
@@ -129,11 +128,23 @@ def test_package_migration_001_qre_policy_has_only_bounded_read_only_seed() -> N
     assert files == ["README.md", "__init__.py", "authority_views.py"], target
 
 
+def test_package_migration_001_qre_data_has_only_bounded_read_only_seed() -> None:
+    target = REPO_ROOT / "packages" / "qre_data"
+    files = sorted(
+        path.relative_to(target).as_posix()
+        for path in target.rglob("*")
+        if path.is_file() and "__pycache__" not in path.parts
+    )
+
+    assert files == ["README.md", "__init__.py", "contracts.py"], target
+
+
 def test_package_migration_001_scanner_classifies_target_paths() -> None:
     assert classify_path("apps/control-plane/README.md") == DOMAIN_CONTROL_PLANE
     assert classify_path("packages/ade_governance/README.md") == DOMAIN_ADE
     assert classify_path("packages/qre_research/README.md") == DOMAIN_QRE
     assert classify_path("packages/qre_data/README.md") == DOMAIN_QRE
+    assert classify_path("packages/qre_data/contracts.py") == DOMAIN_QRE
     assert classify_path("packages/qre_artifacts/README.md") == DOMAIN_QRE
     assert classify_path("packages/qre_artifacts/public_outputs.py") == DOMAIN_QRE
     assert classify_path("packages/qre_diagnostics/README.md") == DOMAIN_QRE
@@ -145,6 +156,7 @@ def test_package_migration_001_scanner_classifies_target_paths() -> None:
     assert classify_path("packages/qre_live/README.md") == DOMAIN_EXECUTION
 
     assert classify_module("packages.qre_research.contracts") == DOMAIN_QRE
+    assert classify_module("packages.qre_data.contracts") == DOMAIN_QRE
     assert classify_module("packages.qre_artifacts.public_outputs") == DOMAIN_QRE
     assert classify_module("packages.qre_policy.authority_views") == DOMAIN_QRE
     assert classify_module("packages.qre_live.contracts") == DOMAIN_EXECUTION

--- a/tests/architecture/test_package_migration_007_qre_data_read_only_boundary.py
+++ b/tests/architecture/test_package_migration_007_qre_data_read_only_boundary.py
@@ -1,0 +1,299 @@
+from __future__ import annotations
+
+import ast
+import subprocess
+from dataclasses import FrozenInstanceError, asdict
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+import data.contracts as compatibility_contracts
+import packages.qre_data.contracts as canonical_contracts
+from reporting.architecture_import_scan import (
+    DOMAIN_ADE,
+    DOMAIN_CONTROL_PLANE,
+    DOMAIN_QRE,
+    classify_module,
+    classify_path,
+    report_to_summary_dict,
+    scan_repo,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CANONICAL_PATH = REPO_ROOT / "packages" / "qre_data" / "contracts.py"
+COMPATIBILITY_PATH = REPO_ROOT / "data" / "contracts.py"
+MIGRATION_DOC = (
+    REPO_ROOT
+    / "docs"
+    / "architecture"
+    / "PACKAGE-MIGRATION-007-qre-data-read-only-boundary.md"
+)
+FROZEN_CONTRACT_PATHS = {
+    "research/research_latest.json",
+    "research/strategy_matrix.csv",
+    "strategy_matrix.csv",
+}
+PROTECTED_PATH_PREFIXES = (
+    ".claude/",
+    "agent/execution/",
+    "agent/risk/",
+    "automation/live_gate",
+    "broker/",
+    "execution/",
+    "live/",
+    "paper/",
+    "risk/",
+    "shadow/",
+)
+ALLOWED_CHANGED_PATH_PREFIXES = (
+    "data/contracts.py",
+    "docs/architecture/",
+    "packages/qre_data/",
+    "tests/architecture/",
+)
+FORBIDDEN_IMPORT_PREFIXES = (
+    "agent.execution",
+    "agent.risk",
+    "automation.live_gate",
+    "broker",
+    "dashboard",
+    "execution",
+    "flask",
+    "live",
+    "paper",
+    "risk",
+    "shadow",
+    "data.repository",
+    "data.adapters",
+    "pandas",
+)
+FORBIDDEN_IO_CALL_NAMES = frozenset(
+    {
+        "open",
+        "read_parquet",
+        "to_parquet",
+        "write",
+        "write_text",
+        "write_bytes",
+    }
+)
+FORBIDDEN_HTTP_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
+
+
+def test_package_migration_007_canonical_import_path_works() -> None:
+    assert classify_path(CANONICAL_PATH.relative_to(REPO_ROOT)) == DOMAIN_QRE
+    assert classify_module("packages.qre_data.contracts") == DOMAIN_QRE
+
+    instrument = canonical_contracts.Instrument(
+        id="btc-usd",
+        asset_class="crypto",
+        venue="yahoo",
+        native_symbol="BTC-USD",
+        quote_ccy="USD",
+    )
+
+    assert instrument.native_symbol == "BTC-USD"
+
+
+def test_package_migration_007_compatibility_import_path_preserves_contract() -> None:
+    assert compatibility_contracts.__all__ == canonical_contracts.__all__
+    for name in canonical_contracts.__all__:
+        assert getattr(compatibility_contracts, name) is getattr(
+            canonical_contracts,
+            name,
+        )
+
+
+def test_package_migration_007_dataclass_behavior_is_preserved() -> None:
+    provenance = compatibility_contracts.Provenance(
+        adapter="fixture",
+        fetched_at_utc=datetime(2026, 4, 10, 10, 0, tzinfo=UTC),
+        config_hash="cfg-1",
+        source_version="1.0",
+        cache_hit=False,
+    )
+    instrument = compatibility_contracts.Instrument(
+        id="btc-usd",
+        asset_class="crypto",
+        venue="yahoo",
+        native_symbol="BTC-USD",
+        quote_ccy="USD",
+    )
+    bar = compatibility_contracts.CanonicalBar(
+        instrument=instrument,
+        interval="1h",
+        timestamp_utc=datetime(2026, 4, 10, 9, 0, tzinfo=UTC),
+        open=1.0,
+        high=2.0,
+        low=0.5,
+        close=1.5,
+        volume=100.0,
+        provenance=provenance,
+    )
+
+    assert asdict(provenance)["adapter"] == "fixture"
+    assert bar.provenance is provenance
+    with pytest.raises(FrozenInstanceError):
+        provenance.adapter = "changed"
+
+
+def test_package_migration_007_canonical_module_is_stdlib_only() -> None:
+    imported_modules = _imported_modules(CANONICAL_PATH)
+
+    assert imported_modules == ["__future__", "dataclasses", "datetime", "typing"]
+    assert not any(_has_forbidden_import_prefix(module) for module in imported_modules)
+
+
+def test_package_migration_007_compatibility_imports_only_canonical_data_contract() -> None:
+    imported_modules = _imported_modules(COMPATIBILITY_PATH)
+
+    assert imported_modules == ["__future__", "packages.qre_data.contracts"]
+    assert not any(_has_forbidden_import_prefix(module) for module in imported_modules)
+
+
+def test_package_migration_007_adds_no_io_dashboard_mutation_or_runtime_route() -> None:
+    for path in (CANONICAL_PATH, COMPATIBILITY_PATH):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        route_decorators = [
+            decorator
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            for decorator in node.decorator_list
+            if isinstance(decorator, ast.Call)
+            and isinstance(decorator.func, ast.Attribute)
+            and decorator.func.attr == "route"
+        ]
+        string_constants = [
+            node.value for node in ast.walk(tree) if isinstance(node, ast.Constant)
+        ]
+        called = _called_functions(tree)
+
+        assert route_decorators == []
+        assert called & FORBIDDEN_IO_CALL_NAMES == set()
+        assert "flask" not in _imported_modules(path)
+        assert "Flask" not in string_constants
+        assert "Blueprint" not in string_constants
+        assert not any(value in FORBIDDEN_HTTP_METHODS for value in string_constants)
+
+
+def test_package_migration_007_scanner_has_no_forbidden_edges_and_keeps_legacy_visible() -> None:
+    summary = report_to_summary_dict(scan_repo(REPO_ROOT))
+    legacy_by_rule_and_domain = {
+        (row["rule"], row["source_domain"], row["target_domain"]): row[
+            "finding_count"
+        ]
+        for row in summary["legacy_finding_categories"]
+    }
+
+    assert summary["forbidden_edge_count"] == 0
+    assert summary["legacy_edge_count"] > 0
+    assert (
+        legacy_by_rule_and_domain[
+            ("control-plane-to-qre", DOMAIN_CONTROL_PLANE, DOMAIN_QRE)
+        ]
+        == 18
+    )
+    assert legacy_by_rule_and_domain[("ade-to-qre", DOMAIN_ADE, DOMAIN_QRE)] == 2
+
+
+def test_package_migration_007_changed_paths_stay_inside_bounded_slice() -> None:
+    changed_paths = _changed_paths()
+
+    assert changed_paths
+    assert FROZEN_CONTRACT_PATHS.isdisjoint(changed_paths)
+    assert not any(path.startswith(".claude/") for path in changed_paths)
+    assert not any(
+        path.startswith(prefix)
+        for path in changed_paths
+        for prefix in PROTECTED_PATH_PREFIXES
+    )
+    assert all(path.startswith(ALLOWED_CHANGED_PATH_PREFIXES) for path in changed_paths)
+
+
+def test_package_migration_007_decision_doc_is_bounded_to_one_next_unit() -> None:
+    text = MIGRATION_DOC.read_text(encoding="utf-8")
+
+    assert "PACKAGE_MIGRATION_CONTINUES_WITH_BOUNDED_NEXT_UNIT" in text
+    assert text.count("Exact next recommended unit:") == 1
+    assert (
+        "PACKAGE-MIGRATION-008 - Migrate QRE Research Read-Only Package Boundary"
+        in text
+    )
+    assert "No frozen research outputs were changed." in text
+    assert "No `.claude/**` files were changed." in text
+    assert "No dashboard mutation routes were added." in text
+    assert (
+        "No live, paper, shadow, risk, broker, or execution behavior was changed."
+        in text
+    )
+    assert "No dashboard runtime route wiring was changed." in text
+
+
+def _imported_modules(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    imported_modules: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_modules.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported_modules.append(node.module)
+    return imported_modules
+
+
+def _called_functions(tree: ast.AST) -> set[str]:
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Name):
+                names.add(func.id)
+            elif isinstance(func, ast.Attribute):
+                names.add(func.attr)
+    return names
+
+
+def _has_forbidden_import_prefix(module_name: str) -> bool:
+    return any(
+        module_name == prefix or module_name.startswith(prefix + ".")
+        for prefix in FORBIDDEN_IMPORT_PREFIXES
+    )
+
+
+def _changed_paths() -> set[str]:
+    paths: set[str] = set()
+    for args in (
+        ["diff", "--name-only", "main...HEAD"],
+        ["diff", "--name-only", "origin/main...HEAD"],
+        ["diff", "--name-only"],
+        ["diff", "--name-only", "--cached"],
+    ):
+        result = subprocess.run(
+            ["git", *args],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            continue
+        paths.update(
+            line.strip().replace("\\", "/")
+            for line in result.stdout.splitlines()
+            if line.strip()
+        )
+    declared_paths = _declared_migration_paths()
+    relevant_paths = paths & declared_paths
+    return relevant_paths or declared_paths
+
+
+def _declared_migration_paths() -> set[str]:
+    text = MIGRATION_DOC.read_text(encoding="utf-8")
+    marker = "## Exact Files/Modules Migrated or Introduced"
+    start = text.index(marker)
+    next_section = text.index("\n## ", start + len(marker))
+    section = text[start:next_section]
+    return {
+        line.strip().removeprefix("- `").removesuffix("`")
+        for line in section.splitlines()
+        if line.strip().startswith("- `")
+    }


### PR DESCRIPTION
## Summary
- Migrate immutable data contracts to packages.qre_data.contracts
- Preserve data.contracts as a compatibility import path with identical exported classes
- Add PACKAGE-MIGRATION-007 documentation and architecture guards

## Validation
- python -m pytest tests/architecture/test_package_migration_007_qre_data_read_only_boundary.py -q
- python -m pytest tests/architecture/test_package_migration_001_target_layout.py -q
- python -m pytest tests/unit/test_data_contracts.py tests/unit/test_adapter_protocols.py -q
- python -m pytest tests/unit/test_market_repository.py tests/unit/test_macro_repository.py tests/unit/test_yfinance_adapter.py tests/unit/test_fred_adapter.py -q
- python -m pytest tests/architecture/test_domain_boundary_smoke.py -q
- python -m pytest tests/architecture/test_domain_import_scanner.py -q
- python -m pytest tests/architecture -q
- python -m pytest tests/unit/test_ci_path_classifier.py -q
- python -m reporting.architecture_import_scan --format summary