### PR TITLE
refactor: validate execution-sim future-only guards

### DIFF
--- a/docs/architecture/PACKAGE-MIGRATION-009-execution-sim-future-only-guards.md
+++ b/docs/architecture/PACKAGE-MIGRATION-009-execution-sim-future-only-guards.md
@@ -1,0 +1,120 @@
+# PACKAGE-MIGRATION-009 - Execution-Sim Future-Only Package Guards
+
+## Purpose and Scope
+
+This unit validates and pins the future-only guardrails for
+`packages/qre_execution_sim` before package-migration closure can be evaluated.
+
+The scope is intentionally limited to README guard text, architecture tests, and
+path-aware CI classification. It does not move execution code, introduce a
+runtime API, add package modules, add dashboard routes, or activate any
+live/paper/shadow/risk/broker behavior.
+
+## Selected Migration Slice
+
+Selected slice: future-only guard validation for `packages/qre_execution_sim`
+and conservative path-aware CI classification for future execution-sensitive
+package prefixes.
+
+## Why This Slice Was Selected
+
+PACKAGE-MIGRATION-008 created the first bounded QRE research package boundary
+and recommended validating `packages/qre_execution_sim` before the migration
+lane can close. The target architecture includes `packages/qre_execution_sim`,
+but that package must remain inactive until a separate approved unit authorizes
+a specific deterministic research simulation contract.
+
+Guarding the package now prevents future package files under execution-sensitive
+prefixes from being treated as ordinary package-only changes.
+
+## Exact Files/Modules Migrated or Introduced
+
+- `packages/qre_execution_sim/README.md`
+- `scripts/ci_path_classifier.py`
+- `tests/unit/test_ci_path_classifier.py`
+- `tests/architecture/test_package_migration_009_execution_sim_future_only_guards.py`
+- `docs/architecture/PACKAGE-MIGRATION-009-execution-sim-future-only-guards.md`
+
+## New Canonical Namespace
+
+None. No importable execution-simulation namespace was introduced.
+
+## Old Compatibility Path
+
+None. No existing module moved, so no compatibility shim was needed.
+
+## What Did Not Move
+
+- `execution/`
+- `agent/execution/`
+- `agent/risk/`
+- `automation/live_gate`
+- `broker/`
+- `live/`
+- `paper/`
+- `shadow/`
+- `risk/`
+- `research/`
+- `dashboard/`
+- `.claude/**`
+
+## Runtime Behavior Equivalence
+
+No runtime behavior was changed. PM009 is guard-only: it strengthens README
+constraints, verifies scanner classification, and makes path-aware CI classify
+future execution package prefixes as execution-sensitive.
+
+## Frozen Contract Statement
+
+No frozen research outputs were changed.
+
+No `.claude/**` files were changed.
+
+## Frozen Schema and Regression Pin Statement
+
+No frozen schemas or regression pins were changed.
+
+## Dashboard Mutation Route Statement
+
+No dashboard mutation routes were added.
+
+No dashboard runtime route wiring was changed.
+
+## Live/Paper/Shadow/Risk/Broker/Execution Statement
+
+No live, paper, shadow, risk, broker, or execution behavior was changed.
+
+## Validation Commands
+
+- `python -m pytest tests/architecture/test_package_migration_009_execution_sim_future_only_guards.py -q`
+- `python -m pytest tests/architecture/test_package_migration_001_target_layout.py -q`
+- `python -m pytest tests/unit/test_ci_path_classifier.py -q`
+- `python -m pytest tests/architecture/test_domain_boundary_smoke.py -q`
+- `python -m pytest tests/architecture/test_domain_import_scanner.py -q`
+- `python -m pytest tests/architecture -q`
+- `python -m reporting.architecture_import_scan --format summary`
+
+## Rollback Plan
+
+Revert this migration commit. That restores the previous
+`packages/qre_execution_sim` README text, removes PM009 architecture coverage
+and documentation, and restores the previous CI path classifier behavior.
+
+## Package Migration Decision
+
+Selected value:
+`PACKAGE_MIGRATION_CONTINUES_WITH_BOUNDED_NEXT_UNIT`
+
+Rationale:
+The execution-sim package guard is now pinned, and the remaining package
+migration work should be a closure decision rather than another package move.
+The next unit is bounded because it should inspect the completed package
+skeleton and read-only boundaries, validate terminal readiness, and choose
+whether the package-migration lane can return to QRE Feature Build Track.
+
+Exact next recommended unit:
+`PACKAGE-MIGRATION-010 - Package Migration Closure Decision`
+
+This is necessary before returning to QRE Feature Build Track because the lane
+needs a documented terminal decision after the target package skeleton and
+bounded read-only boundaries have been established.

--- a/packages/qre_execution_sim/README.md
+++ b/packages/qre_execution_sim/README.md
@@ -9,6 +9,8 @@ research-only execution simulation contracts.
 
 Status: future-only and inactive. Current execution-adjacent simulation code
 remains in existing `execution/`, `research/`, and legacy `agent/` paths.
+This package is intentionally README-only until a separately approved migration
+unit authorizes a specific read-only contract.
 
 ## Source of Truth / Authority Boundary
 
@@ -39,7 +41,10 @@ separate execution-simulation migration unit is approved.
 ## Current Compatibility Policy
 
 Existing execution simulation imports remain authoritative. This scaffold
-exports no runtime API.
+exports no runtime API. Adding importable Python modules under
+`packages/qre_execution_sim` requires a named package-migration unit and tests
+proving no broker, live, paper, shadow, risk, or order-execution behavior was
+activated.
 
 ## Activation Status
 

--- a/scripts/ci_path_classifier.py
+++ b/scripts/ci_path_classifier.py
@@ -124,6 +124,10 @@ def classify_paths(paths: list[str]) -> dict[str, bool]:
                 "execution/",
                 "live/",
                 "paper/",
+                "packages/qre_execution_sim/",
+                "packages/qre_live/",
+                "packages/qre_paper/",
+                "packages/qre_shadow/",
                 "shadow/",
                 "trading/",
             )

--- a/tests/architecture/test_package_migration_009_execution_sim_future_only_guards.py
+++ b/tests/architecture/test_package_migration_009_execution_sim_future_only_guards.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from reporting.architecture_import_scan import (
+    DOMAIN_ADE,
+    DOMAIN_CONTROL_PLANE,
+    DOMAIN_EXECUTION,
+    DOMAIN_QRE,
+    classify_module,
+    classify_path,
+    report_to_summary_dict,
+    scan_repo,
+)
+from scripts.ci_path_classifier import classify_paths
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PACKAGE_ROOT = REPO_ROOT / "packages" / "qre_execution_sim"
+README_PATH = PACKAGE_ROOT / "README.md"
+MIGRATION_DOC = (
+    REPO_ROOT
+    / "docs"
+    / "architecture"
+    / "PACKAGE-MIGRATION-009-execution-sim-future-only-guards.md"
+)
+FROZEN_CONTRACT_PATHS = {
+    "research/research_latest.json",
+    "research/strategy_matrix.csv",
+    "strategy_matrix.csv",
+}
+PROTECTED_PATH_PREFIXES = (
+    ".claude/",
+    "agent/execution/",
+    "agent/risk/",
+    "automation/live_gate",
+    "broker/",
+    "execution/",
+    "live/",
+    "paper/",
+    "risk/",
+    "shadow/",
+)
+ALLOWED_CHANGED_PATH_PREFIXES = (
+    "docs/architecture/",
+    "packages/qre_execution_sim/README.md",
+    "scripts/ci_path_classifier.py",
+    "tests/architecture/",
+    "tests/unit/test_ci_path_classifier.py",
+)
+
+
+def test_package_migration_009_execution_sim_package_stays_readme_only() -> None:
+    files = sorted(
+        path.relative_to(PACKAGE_ROOT).as_posix()
+        for path in PACKAGE_ROOT.rglob("*")
+        if path.is_file() and "__pycache__" not in path.parts
+    )
+
+    assert files == ["README.md"]
+
+
+def test_package_migration_009_execution_sim_readme_pins_inactive_boundary() -> None:
+    text = README_PATH.read_text(encoding="utf-8")
+
+    assert "Status: future-only and inactive." in text
+    assert "exports no runtime API" in text
+    assert "separately approved migration" in text
+    assert "No execution simulation authority is transferred by this scaffold" in text
+    assert "Live order placement, broker mutation, or capital allocation" in text
+    assert "Dashboard mutation routes" in text
+    assert "broker, live, paper, shadow, risk, or order-execution behavior" in text
+
+
+def test_package_migration_009_scanner_classifies_execution_sim_as_execution() -> None:
+    assert classify_path("packages/qre_execution_sim/README.md") == DOMAIN_EXECUTION
+    assert classify_module("packages.qre_execution_sim.contracts") == DOMAIN_EXECUTION
+
+
+def test_package_migration_009_ci_classifier_treats_future_execution_packages_as_sensitive() -> None:
+    result = classify_paths(
+        [
+            "packages/qre_execution_sim/README.md",
+            "packages/qre_shadow/README.md",
+            "packages/qre_paper/README.md",
+            "packages/qre_live/README.md",
+        ]
+    )
+
+    assert result["packages"] is True
+    assert result["execution_sensitive"] is True
+    assert result["run_frontend"] is True
+    assert result["run_docker_build"] is True
+    assert result["run_dashboard_deploy"] is True
+
+
+def test_package_migration_009_scanner_has_no_forbidden_edges_and_keeps_legacy_visible() -> None:
+    summary = report_to_summary_dict(scan_repo(REPO_ROOT))
+    legacy_by_rule_and_domain = {
+        (row["rule"], row["source_domain"], row["target_domain"]): row[
+            "finding_count"
+        ]
+        for row in summary["legacy_finding_categories"]
+    }
+
+    assert summary["forbidden_edge_count"] == 0
+    assert summary["legacy_edge_count"] > 0
+    assert (
+        legacy_by_rule_and_domain[
+            ("control-plane-to-qre", DOMAIN_CONTROL_PLANE, DOMAIN_QRE)
+        ]
+        == 18
+    )
+    assert legacy_by_rule_and_domain[("ade-to-qre", DOMAIN_ADE, DOMAIN_QRE)] == 2
+
+
+def test_package_migration_009_changed_paths_stay_inside_bounded_guard_slice() -> None:
+    changed_paths = _changed_paths()
+
+    assert changed_paths
+    assert FROZEN_CONTRACT_PATHS.isdisjoint(changed_paths)
+    assert not any(path.startswith(".claude/") for path in changed_paths)
+    assert not any(
+        path.startswith(prefix)
+        for path in changed_paths
+        for prefix in PROTECTED_PATH_PREFIXES
+    )
+    assert all(path.startswith(ALLOWED_CHANGED_PATH_PREFIXES) for path in changed_paths)
+
+
+def test_package_migration_009_decision_doc_is_bounded_to_one_next_unit() -> None:
+    text = MIGRATION_DOC.read_text(encoding="utf-8")
+
+    assert "PACKAGE_MIGRATION_CONTINUES_WITH_BOUNDED_NEXT_UNIT" in text
+    assert text.count("Exact next recommended unit:") == 1
+    assert "PACKAGE-MIGRATION-010 - Package Migration Closure Decision" in text
+    assert "No frozen research outputs were changed." in text
+    assert "No `.claude/**` files were changed." in text
+    assert "No dashboard mutation routes were added." in text
+    assert (
+        "No live, paper, shadow, risk, broker, or execution behavior was changed."
+        in text
+    )
+    assert "No dashboard runtime route wiring was changed." in text
+
+
+def _changed_paths() -> set[str]:
+    paths: set[str] = set()
+    for args in (
+        ["diff", "--name-only", "main...HEAD"],
+        ["diff", "--name-only", "origin/main...HEAD"],
+        ["diff", "--name-only"],
+        ["diff", "--name-only", "--cached"],
+    ):
+        result = subprocess.run(
+            ["git", *args],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            continue
+        paths.update(
+            line.strip().replace("\\", "/")
+            for line in result.stdout.splitlines()
+            if line.strip()
+        )
+    declared_paths = _declared_migration_paths()
+    relevant_paths = paths & declared_paths
+    return relevant_paths or declared_paths
+
+
+def _declared_migration_paths() -> set[str]:
+    text = MIGRATION_DOC.read_text(encoding="utf-8")
+    marker = "## Exact Files/Modules Migrated or Introduced"
+    start = text.index(marker)
+    next_section = text.index("\n## ", start + len(marker))
+    section = text[start:next_section]
+    return {
+        line.strip().removeprefix("- `").removesuffix("`")
+        for line in section.splitlines()
+        if line.strip().startswith("- `")
+    }

--- a/tests/unit/test_ci_path_classifier.py
+++ b/tests/unit/test_ci_path_classifier.py
@@ -77,3 +77,20 @@ def test_deployment_sensitive_runtime_files_trigger_build_and_deploy() -> None:
     assert result["deployment_sensitive"] is True
     assert result["run_docker_build"] is True
     assert result["run_dashboard_deploy"] is True
+
+
+def test_future_execution_packages_are_execution_sensitive() -> None:
+    result = classify_paths(
+        [
+            "packages/qre_execution_sim/README.md",
+            "packages/qre_shadow/README.md",
+            "packages/qre_paper/README.md",
+            "packages/qre_live/README.md",
+        ]
+    )
+
+    assert result["packages"] is True
+    assert result["execution_sensitive"] is True
+    assert result["run_frontend"] is True
+    assert result["run_docker_build"] is True
+    assert result["run_dashboard_deploy"] is True


### PR DESCRIPTION
## Summary
- pin packages/qre_execution_sim as README-only, future-only, and inactive
- classify future execution package prefixes as execution-sensitive in path-aware CI
- add PM009 architecture documentation and guard tests

## Validation
- python -m pytest tests/architecture/test_package_migration_009_execution_sim_future_only_guards.py -q
- python -m pytest tests/architecture/test_package_migration_001_target_layout.py -q
- python -m pytest tests/unit/test_ci_path_classifier.py -q
- python -m pytest tests/architecture/test_domain_boundary_smoke.py -q
- python -m pytest tests/architecture/test_domain_import_scanner.py -q
- python -m pytest tests/architecture -q
- python -m reporting.architecture_import_scan --format summary