### PR TITLE
refactor: close package migration lane

### DIFF
--- a/docs/architecture/PACKAGE-MIGRATION-010-package-migration-closure-decision.md
+++ b/docs/architecture/PACKAGE-MIGRATION-010-package-migration-closure-decision.md
@@ -1,0 +1,136 @@
+# PACKAGE-MIGRATION-010 - Package Migration Closure Decision
+
+## Purpose and Scope
+
+This unit closes the bounded package-migration lane by documenting whether the
+current target package skeleton and read-only package boundaries are sufficient
+to return to QRE Feature Build Track.
+
+The scope is closure-only. It does not migrate another module, add runtime
+wiring, introduce dashboard routes, modify frozen outputs, or activate
+execution/live/paper/shadow/risk/broker behavior.
+
+## Selected Migration Slice
+
+Selected slice: package-migration closure validation and terminal decision.
+
+## Why This Slice Was Selected
+
+PACKAGE-MIGRATION-009 validated the future-only execution-sim package guards and
+recommended a closure decision as the next bounded unit. The remaining evidence
+needed by the lane is not another package move; it is a documented terminal
+state after the package skeleton and bounded read-only boundaries have been
+created.
+
+## Exact Files/Modules Migrated or Introduced
+
+- `tests/architecture/test_package_migration_010_closure_decision.py`
+- `docs/architecture/PACKAGE-MIGRATION-010-package-migration-closure-decision.md`
+
+## New Canonical Namespace
+
+None. No new canonical namespace was introduced in this closure unit.
+
+## Old Compatibility Path
+
+None. No existing module moved, so no compatibility import path was needed.
+
+## What Did Not Move
+
+- `research/run_research.py`
+- `registry.py`
+- `research/registry.py`
+- `agent/backtesting/strategies.py`
+- `strategies/`
+- `dashboard/`
+- `reporting/`
+- `execution/`
+- `agent/execution/`
+- `agent/risk/`
+- `automation/live_gate`
+- `broker/`
+- `live/`
+- `paper/`
+- `shadow/`
+- `risk/`
+- `.claude/**`
+
+## Closure Evidence
+
+The package-migration lane now has:
+
+- Target package/app skeleton from PACKAGE-MIGRATION-001.
+- ADE governance read-only contract boundary from PACKAGE-MIGRATION-002.
+- Control-plane read-only adapter boundary from PACKAGE-MIGRATION-003.
+- QRE diagnostics read-only boundary from PACKAGE-MIGRATION-004.
+- QRE artifacts read-only boundary from PACKAGE-MIGRATION-005.
+- QRE policy read-only boundary from PACKAGE-MIGRATION-006.
+- QRE data read-only boundary from PACKAGE-MIGRATION-007.
+- QRE research universe read-only boundary from PACKAGE-MIGRATION-008.
+- Execution-sim future-only guard validation from PACKAGE-MIGRATION-009.
+
+The target package skeleton and bounded read-only boundaries are sufficient for
+now. Further package migration should be driven by concrete QRE Feature Build
+Track needs, not by broad pre-emptive movement.
+
+## Runtime Behavior Equivalence
+
+No runtime behavior was changed. This unit adds only a closure document and an
+architecture test that validates package-migration closure evidence.
+
+## Frozen Contract Statement
+
+No frozen research outputs were changed.
+
+No `.claude/**` files were changed.
+
+## Frozen Schema and Regression Pin Statement
+
+No frozen schemas or regression pins were changed.
+
+## Dashboard Mutation Route Statement
+
+No dashboard mutation routes were added.
+
+No dashboard runtime route wiring was changed.
+
+## Live/Paper/Shadow/Risk/Broker/Execution Statement
+
+No live, paper, shadow, risk, broker, or execution behavior was changed.
+
+## Validation Commands
+
+- `python -m pytest tests/architecture/test_package_migration_010_closure_decision.py -q`
+- `python -m pytest tests/architecture/test_package_migration_001_target_layout.py -q`
+- `python -m pytest tests/architecture/test_domain_boundary_smoke.py -q`
+- `python -m pytest tests/architecture/test_domain_import_scanner.py -q`
+- `python -m pytest tests/unit/test_ci_path_classifier.py -q`
+- `python -m pytest tests/architecture -q`
+- `python -m reporting.architecture_import_scan --format summary`
+
+## Rollback Plan
+
+Revert this closure commit. That removes only the PM010 closure document and
+architecture test, leaving the already merged package boundaries unchanged.
+
+## Package Migration Decision
+
+Selected value:
+`PACKAGE_MIGRATION_READY_FOR_QRE_FEATURE_TRACK`
+
+Rationale:
+The target package skeleton and bounded read-only boundaries are sufficient for
+now. The package-migration lane has established the package layout, preserved
+compatibility imports for moved read-only contracts, validated future-only
+execution-sensitive package guards, and kept frozen contracts, dashboard
+mutation routes, and live/paper/shadow/risk/broker/execution behavior
+unchanged.
+
+No additional package-migration unit is recommended at this time.
+
+Exact next recommended lane:
+`QRE Feature Build Track - operator review for first post-package feature phase`
+
+The next feature phase should select a concrete QRE product goal and may use the
+new package boundaries only where they are directly needed. Any future package
+move must be justified by that concrete feature need and remain bounded.

--- a/tests/architecture/test_package_migration_010_closure_decision.py
+++ b/tests/architecture/test_package_migration_010_closure_decision.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from reporting.architecture_import_scan import (
+    DOMAIN_ADE,
+    DOMAIN_CONTROL_PLANE,
+    DOMAIN_QRE,
+    report_to_summary_dict,
+    scan_repo,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MIGRATION_DOC = (
+    REPO_ROOT
+    / "docs"
+    / "architecture"
+    / "PACKAGE-MIGRATION-010-package-migration-closure-decision.md"
+)
+EXPECTED_MIGRATION_DOCS = (
+    "PACKAGE-MIGRATION-001-target-layout-skeleton.md",
+    "PACKAGE-MIGRATION-002-ade-governance-read-only-contracts.md",
+    "PACKAGE-MIGRATION-003-control-plane-read-only-adapter-boundary.md",
+    "PACKAGE-MIGRATION-004-qre-diagnostics-read-only-boundary.md",
+    "PACKAGE-MIGRATION-005-qre-artifacts-read-only-boundary.md",
+    "PACKAGE-MIGRATION-006-qre-policy-read-only-boundary.md",
+    "PACKAGE-MIGRATION-007-qre-data-read-only-boundary.md",
+    "PACKAGE-MIGRATION-008-qre-research-read-only-boundary.md",
+    "PACKAGE-MIGRATION-009-execution-sim-future-only-guards.md",
+    "PACKAGE-MIGRATION-010-package-migration-closure-decision.md",
+)
+BOUNDED_PACKAGE_CONTENTS = {
+    "qre_research": ["README.md", "__init__.py", "universe.py"],
+    "qre_data": ["README.md", "__init__.py", "contracts.py"],
+    "qre_artifacts": ["README.md", "__init__.py", "public_outputs.py"],
+    "qre_diagnostics": ["README.md", "__init__.py", "paths.py"],
+    "qre_policy": ["README.md", "__init__.py", "authority_views.py"],
+    "qre_execution_sim": ["README.md"],
+    "qre_shadow": ["README.md"],
+    "qre_paper": ["README.md"],
+    "qre_live": ["README.md"],
+}
+FROZEN_CONTRACT_PATHS = {
+    "research/research_latest.json",
+    "research/strategy_matrix.csv",
+    "strategy_matrix.csv",
+}
+PROTECTED_PATH_PREFIXES = (
+    ".claude/",
+    "agent/execution/",
+    "agent/risk/",
+    "automation/live_gate",
+    "broker/",
+    "execution/",
+    "live/",
+    "paper/",
+    "risk/",
+    "shadow/",
+)
+ALLOWED_CHANGED_PATH_PREFIXES = (
+    "docs/architecture/",
+    "tests/architecture/",
+)
+
+
+def test_package_migration_010_all_required_migration_docs_exist() -> None:
+    architecture_dir = REPO_ROOT / "docs" / "architecture"
+
+    for filename in EXPECTED_MIGRATION_DOCS:
+        assert (architecture_dir / filename).exists(), filename
+
+
+def test_package_migration_010_package_boundaries_are_bounded_or_inactive() -> None:
+    for package_name, expected_files in BOUNDED_PACKAGE_CONTENTS.items():
+        package_root = REPO_ROOT / "packages" / package_name
+        files = sorted(
+            path.relative_to(package_root).as_posix()
+            for path in package_root.rglob("*")
+            if path.is_file() and "__pycache__" not in path.parts
+        )
+
+        assert files == expected_files, package_name
+
+
+def test_package_migration_010_future_execution_packages_remain_inactive() -> None:
+    execution_sim = (
+        REPO_ROOT / "packages" / "qre_execution_sim" / "README.md"
+    ).read_text(encoding="utf-8")
+    shadow = (REPO_ROOT / "packages" / "qre_shadow" / "README.md").read_text(
+        encoding="utf-8"
+    )
+    paper = (REPO_ROOT / "packages" / "qre_paper" / "README.md").read_text(
+        encoding="utf-8"
+    )
+    live = (REPO_ROOT / "packages" / "qre_live" / "README.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "Status: future-only and inactive." in execution_sim
+    assert "exports no runtime API" in execution_sim
+    assert "future-only and inactive until Roadmap v4.x" in shadow
+    assert "future-only and inactive until Roadmap v5.x" in paper
+    assert "hard-disabled until Roadmap v6.x and explicit operator approval" in live
+
+
+def test_package_migration_010_scanner_has_no_forbidden_edges_and_keeps_legacy_visible() -> None:
+    summary = report_to_summary_dict(scan_repo(REPO_ROOT))
+    legacy_by_rule_and_domain = {
+        (row["rule"], row["source_domain"], row["target_domain"]): row[
+            "finding_count"
+        ]
+        for row in summary["legacy_finding_categories"]
+    }
+
+    assert summary["forbidden_edge_count"] == 0
+    assert summary["legacy_edge_count"] > 0
+    assert (
+        legacy_by_rule_and_domain[
+            ("control-plane-to-qre", DOMAIN_CONTROL_PLANE, DOMAIN_QRE)
+        ]
+        == 18
+    )
+    assert legacy_by_rule_and_domain[("ade-to-qre", DOMAIN_ADE, DOMAIN_QRE)] == 2
+
+
+def test_package_migration_010_changed_paths_stay_inside_closure_slice() -> None:
+    changed_paths = _changed_paths()
+
+    assert changed_paths
+    assert FROZEN_CONTRACT_PATHS.isdisjoint(changed_paths)
+    assert not any(path.startswith(".claude/") for path in changed_paths)
+    assert not any(
+        path.startswith(prefix)
+        for path in changed_paths
+        for prefix in PROTECTED_PATH_PREFIXES
+    )
+    assert all(path.startswith(ALLOWED_CHANGED_PATH_PREFIXES) for path in changed_paths)
+
+
+def test_package_migration_010_decision_doc_is_terminal_ready_state() -> None:
+    text = MIGRATION_DOC.read_text(encoding="utf-8")
+
+    assert "PACKAGE_MIGRATION_READY_FOR_QRE_FEATURE_TRACK" in text
+    assert "PACKAGE_MIGRATION_CONTINUES_WITH_BOUNDED_NEXT_UNIT" not in text
+    assert "Exact next recommended unit:" not in text
+    assert "Exact next recommended lane:" in text
+    assert (
+        "QRE Feature Build Track - operator review for first post-package feature phase"
+        in text
+    )
+    assert (
+        "target package skeleton and bounded read-only boundaries are sufficient"
+        in text.lower()
+    )
+    assert "No frozen research outputs were changed." in text
+    assert "No `.claude/**` files were changed." in text
+    assert "No dashboard mutation routes were added." in text
+    assert (
+        "No live, paper, shadow, risk, broker, or execution behavior was changed."
+        in text
+    )
+    assert "No dashboard runtime route wiring was changed." in text
+
+
+def _changed_paths() -> set[str]:
+    paths: set[str] = set()
+    for args in (
+        ["diff", "--name-only", "main...HEAD"],
+        ["diff", "--name-only", "origin/main...HEAD"],
+        ["diff", "--name-only"],
+        ["diff", "--name-only", "--cached"],
+    ):
+        result = subprocess.run(
+            ["git", *args],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            continue
+        paths.update(
+            line.strip().replace("\\", "/")
+            for line in result.stdout.splitlines()
+            if line.strip()
+        )
+    declared_paths = _declared_migration_paths()
+    relevant_paths = paths & declared_paths
+    return relevant_paths or declared_paths
+
+
+def _declared_migration_paths() -> set[str]:
+    text = MIGRATION_DOC.read_text(encoding="utf-8")
+    marker = "## Exact Files/Modules Migrated or Introduced"
+    start = text.index(marker)
+    next_section = text.index("\n## ", start + len(marker))
+    section = text[start:next_section]
+    return {
+        line.strip().removeprefix("- `").removesuffix("`")
+        for line in section.splitlines()
+        if line.strip().startswith("- `")
+    }


### PR DESCRIPTION
## Summary
- add PACKAGE-MIGRATION-010 closure decision document
- select PACKAGE_MIGRATION_READY_FOR_QRE_FEATURE_TRACK
- add closure architecture tests for package boundaries, inactive future execution packages, and scanner state

## Validation
- python -m pytest tests/architecture/test_package_migration_010_closure_decision.py -q
- python -m pytest tests/architecture/test_package_migration_001_target_layout.py -q
- python -m pytest tests/architecture/test_domain_boundary_smoke.py -q
- python -m pytest tests/architecture/test_domain_import_scanner.py -q
- python -m pytest tests/unit/test_ci_path_classifier.py -q
- python -m pytest tests/architecture -q
- python -m reporting.architecture_import_scan --format summary