### PR TITLE
feat: ADE-QRE-002 screening failure attribution depth

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -34,7 +34,8 @@
 ### ADE-QRE-001 - Unknown Failure Reduction
 
 - queue id: `ADE-QRE-001`
-- status: `ready`
+- status: `done`
+- completion evidence: PR #309, merge SHA `d35e9d85f2ffccb102e4b3257cffd8b747283d51`; post-merge gates green; frozen contracts unchanged; protected paths untouched; live/paper/shadow/risk/broker/execution inactive.
 - doel: reduceer `unknown_screening_failure` naar deterministische, evidence-backed subklassen.
 - bron uit target-state roadmap: fase 1 "Unknown Failure Reduction Sprint"; prompt 12.1; trusted loop metrics `unknown_failure_rate`, `actionable_failure_rate`, `attribution_depth_score`.
 - scope: inspecteer bestaande screening/no-candidate evidence, voeg alleen deterministische classificatie toe voor reeds observeerbare failure shapes, en rapporteer before/after unknown counts.
@@ -48,7 +49,8 @@
 ### ADE-QRE-002 - Screening Failure Attribution Depth
 
 - queue id: `ADE-QRE-002`
-- status: `deferred`
+- status: `done`
+- completion evidence: implemented deterministic read-only action hints for existing screening attribution classes and a read-only failure-action mapping adapter; local targeted tests and architecture scanner passed in the implementation branch; PR/merge evidence to be recorded by the next queue item after merge.
 - doel: make screening failures more actionable after unknown reduction by mapping classes to stable failure-to-action recommendations.
 - bron uit target-state roadmap: current weakness "Attribution depth"; fase 7 "Failure -> Action -> Reroute sluiten"; prompt 12.1 follow-up.
 - scope: enrich existing attribution output with deterministic action hints for known non-strategy failure classes and keep them read-only.
@@ -62,7 +64,7 @@
 ### ADE-QRE-003 - Data Foundation Manifest and Coverage
 
 - queue id: `ADE-QRE-003`
-- status: `deferred`
+- status: `ready`
 - doel: introduce a read-only local research cache manifest and coverage reporter before data-aware routing or hypothesis discovery depends on data readiness.
 - bron uit target-state roadmap: fase 2 "Data Foundation als productlaag"; prompt 12.2 "Data Foundation v3.data.1"; data-throughput sections 9.4-9.6.
 - scope: manifest schema, coverage report by source/instrument/timeframe, row counts, min/max timestamps, schema version, content hash, and deterministic sidecar output.

--- a/reporting/failure_action_mapping_minimal.py
+++ b/reporting/failure_action_mapping_minimal.py
@@ -119,15 +119,32 @@ ACTION_BY_FAILURE_CODE: Final[Mapping[str, str]] = {
     "unknown_failure": "hold_no_action",
 }
 
+SCREENING_CLASSIFICATION_TO_FAILURE_CODE: Final[Mapping[str, str]] = {
+    "data_coverage_gap": "technical_failure",
+    "data_coverage_unknown": "technical_failure",
+    "identity_unresolved": "technical_failure",
+    "incomplete_policy_trace": "technical_failure",
+    "insufficient_oos_window": "no_oos_samples",
+    "missing_diagnostics": "technical_failure",
+    "missing_metric_field": "technical_failure",
+    "missing_screening_evidence": "technical_failure",
+    "no_candidate_after_policy_filter": "technical_failure",
+    "no_oos_returns": "no_oos_samples",
+    "no_survivor_after_eval": "technical_failure",
+    "policy_trace_inconsistent": "technical_failure",
+    "synthesis_gate_blocked": "technical_failure",
+    "timeout": "technical_failure",
+    "unsupported_failure_shape": "unknown_failure",
+    "unknown_screening_failure": "unknown_failure",
+}
+
 
 # ---------------------------------------------------------------------------
 # Artifact paths
 # ---------------------------------------------------------------------------
 
 
-ARTIFACT_DIR: Final[Path] = (
-    REPO_ROOT / "logs" / "failure_action_mapping_minimal"
-)
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "failure_action_mapping_minimal"
 ARTIFACT_LATEST: Final[Path] = ARTIFACT_DIR / "latest.json"
 HISTORY: Final[Path] = ARTIFACT_DIR / "history.jsonl"
 _WRITE_PREFIX: Final[str] = "logs/failure_action_mapping_minimal/"
@@ -139,20 +156,14 @@ _WRITE_PREFIX: Final[str] = "logs/failure_action_mapping_minimal/"
 
 
 def _utcnow() -> str:
-    return (
-        _dt.datetime.now(_dt.UTC)
-        .replace(microsecond=0)
-        .isoformat()
-        .replace("+00:00", "Z")
-    )
+    return _dt.datetime.now(_dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
 def _validate_write_target(path: Path) -> None:
     normalised = str(path).replace("\\", "/")
     if _WRITE_PREFIX not in normalised:
         raise ValueError(
-            "failure_action_mapping_minimal: refusing write outside "
-            f"allowlist: {path!r}"
+            "failure_action_mapping_minimal: refusing write outside " f"allowlist: {path!r}"
         )
 
 
@@ -207,9 +218,7 @@ def compute_record_id(
 
 def validate_failures(failures: Sequence[Mapping[str, Any]]) -> None:
     if not isinstance(failures, list | tuple):
-        raise ValueError(
-            "failure_action_mapping_minimal: failures must be a list/tuple"
-        )
+        raise ValueError("failure_action_mapping_minimal: failures must be a list/tuple")
     if len(failures) > MAX_FAILURES:
         raise ValueError(
             "failure_action_mapping_minimal: too many failures "
@@ -218,15 +227,11 @@ def validate_failures(failures: Sequence[Mapping[str, Any]]) -> None:
     seen: set[str] = set()
     for i, failure in enumerate(failures):
         if not isinstance(failure, Mapping):
-            raise ValueError(
-                "failure_action_mapping_minimal: "
-                f"failure[{i}] must be a mapping"
-            )
+            raise ValueError("failure_action_mapping_minimal: " f"failure[{i}] must be a mapping")
         missing = set(INPUT_FAILURE_KEYS) - set(failure.keys())
         if missing:
             raise ValueError(
-                "failure_action_mapping_minimal: "
-                f"failure[{i}] missing fields: {sorted(missing)}"
+                "failure_action_mapping_minimal: " f"failure[{i}] missing fields: {sorted(missing)}"
             )
         subject_id = failure["subject_id"]
         if not isinstance(subject_id, str) or not subject_id:
@@ -236,8 +241,7 @@ def validate_failures(failures: Sequence[Mapping[str, Any]]) -> None:
             )
         if subject_id in seen:
             raise ValueError(
-                "failure_action_mapping_minimal: "
-                f"duplicate subject_id {subject_id!r}"
+                "failure_action_mapping_minimal: " f"duplicate subject_id {subject_id!r}"
             )
         seen.add(subject_id)
         if failure["failure_code"] not in FAILURE_CODES:
@@ -282,10 +286,7 @@ def _reason_for(
             "evidence records; recommendation is bounded and advisory."
         )
     else:
-        text = (
-            f"Failure code {failure_code} maps deterministically to "
-            f"{recommended_action}."
-        )
+        text = f"Failure code {failure_code} maps deterministically to " f"{recommended_action}."
     return reason_codes, text
 
 
@@ -312,9 +313,7 @@ def _build_reason_record(
         evidence_count=evidence_count,
     )
     return {
-        "record_id": compute_record_id(
-            subject_id, failure_code, recommended_action, digest
-        ),
+        "record_id": compute_record_id(subject_id, failure_code, recommended_action, digest),
         "record_kind": "failure_action_mapping_reason",
         "schema_version": SCHEMA_VERSION,
         "subject_id": subject_id,
@@ -398,9 +397,7 @@ def collect_snapshot(
             "actionable_recommendations": actionable_count,
         },
         "items": items,
-        "final_recommendation": (
-            "actions_available" if actionable_count else "nothing_actionable"
-        ),
+        "final_recommendation": ("actions_available" if actionable_count else "nothing_actionable"),
         "note": (
             "Minimal v3.15.20 slice. Deterministic Failure to Action "
             "Mapping only; no adaptive feedback loop, no strategy mutation, "
@@ -408,6 +405,58 @@ def collect_snapshot(
             "behavior."
         ),
     }
+
+
+def screening_attribution_failures(
+    payload: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    """Convert observed non-strategy screening classes into mapper inputs.
+
+    The adapter is intentionally lossy and read-only: strategy/performance
+    screening classes stay in the attribution report, while non-strategy
+    diagnostics get mapped into the existing minimal closed taxonomy.
+    """
+
+    failures: list[dict[str, Any]] = []
+    classifications = payload.get("classifications")
+    if not isinstance(classifications, Sequence) or isinstance(classifications, str | bytes):
+        return failures
+    for row in classifications:
+        if not isinstance(row, Mapping):
+            continue
+        classification = str(row.get("classification") or "")
+        failure_code = SCREENING_CLASSIFICATION_TO_FAILURE_CODE.get(classification)
+        if failure_code is None:
+            continue
+        count = _bounded_int(row.get("count"))
+        if count <= 0:
+            continue
+        severity = "high" if failure_code == "unknown_failure" else "medium"
+        failures.append(
+            {
+                "subject_id": f"screening:{classification}",
+                "failure_code": failure_code,
+                "severity": severity,
+                "evidence_count": count,
+            }
+        )
+    return failures
+
+
+def collect_from_screening_attribution(
+    payload: Mapping[str, Any],
+    *,
+    frozen_utc: str | None = None,
+) -> dict[str, Any]:
+    failures = screening_attribution_failures(payload)
+    snapshot = collect_snapshot(failures, frozen_utc=frozen_utc)
+    snapshot["source_report_kind"] = "screening_failure_attribution"
+    snapshot["source_primary_classification"] = (
+        payload.get("summary", {}).get("primary_classification")
+        if isinstance(payload.get("summary"), Mapping)
+        else None
+    )
+    return snapshot
 
 
 def write_outputs(
@@ -446,9 +495,7 @@ def write_outputs(
     }
 
 
-def read_latest_snapshot(
-    *, artifact_dir: Path | None = None
-) -> dict[str, Any] | None:
+def read_latest_snapshot(*, artifact_dir: Path | None = None) -> dict[str, Any] | None:
     base = artifact_dir or ARTIFACT_DIR
     path = base / ARTIFACT_LATEST.name
     if not path.is_file():

--- a/research/screening_failure_attribution.py
+++ b/research/screening_failure_attribution.py
@@ -21,25 +21,19 @@ SCREENING_FAILURE_ATTRIBUTION_SCHEMA_VERSION: Final[str] = "1.0"
 DEFAULT_REPORT_JSON_PATH: Final[Path] = Path(
     "research/screening_failure_attribution_latest.v1.json"
 )
-DEFAULT_REPORT_MD_PATH: Final[Path] = Path(
-    "research/screening_failure_attribution_latest.md"
-)
+DEFAULT_REPORT_MD_PATH: Final[Path] = Path("research/screening_failure_attribution_latest.md")
 
 ARTIFACT_PATHS: Final[dict[str, Path]] = {
     "screening_evidence": Path("research/screening_evidence_latest.v1.json"),
     "run_filter_summary": Path("research/run_filter_summary_latest.v1.json"),
-    "run_screening_candidates": Path(
-        "research/run_screening_candidates_latest.v1.json"
-    ),
+    "run_screening_candidates": Path("research/run_screening_candidates_latest.v1.json"),
     "empty_run_diagnostics": Path("research/empty_run_diagnostics_latest.v1.json"),
     "run_campaign": Path("research/run_campaign_latest.v1.json"),
     "controlled_eval": Path("research/controlled_eval_latest.v1.json"),
     "campaign_registry": Path("research/campaign_registry_latest.v1.json"),
     "campaign_evidence_ledger": Path("research/campaign_evidence_ledger_latest.v1.jsonl"),
     "research_state": Path("research/research_state_latest.v1.json"),
-    "policy_filter_diagnostics": Path(
-        "research/policy_filter_diagnostics_latest.v1.json"
-    ),
+    "policy_filter_diagnostics": Path("research/policy_filter_diagnostics_latest.v1.json"),
 }
 
 CLASSIFICATIONS: Final[tuple[str, ...]] = (
@@ -151,6 +145,103 @@ BLOCKED_SYNTHESIS_STATES: Final[frozenset[str]] = frozenset(
         "blocked_no_preset_space_exhaustion",
     }
 )
+ACTION_HINT_BY_CLASSIFICATION: Final[dict[str, dict[str, Any]]] = {
+    "insufficient_trades": {
+        "action": "increase_timeframe_or_extend_sample_window",
+        "reason": "Observed candidates do not carry enough trades for reliable screening evidence.",
+    },
+    "no_oos_returns": {
+        "action": "inspect_oos_return_coverage",
+        "reason": "Observed artifacts show missing out-of-sample return evidence.",
+    },
+    "timeout": {
+        "action": "inspect_screening_budget_and_worker_health",
+        "reason": "Observed screening evidence points to timeout or budget exhaustion.",
+    },
+    "cost_sensitivity": {
+        "action": "review_cost_assumptions",
+        "reason": "Observed screening evidence is cost-assumption sensitive.",
+    },
+    "parameter_instability": {
+        "action": "preserve_negative_result_for_unstable_parameter_region",
+        "reason": "Observed evidence points to unstable neighboring parameters.",
+    },
+    "data_coverage_gap": {
+        "action": "repair_data_coverage_before_research_action",
+        "reason": "Observed artifacts show unavailable or incomplete market data coverage.",
+    },
+    "missing_screening_evidence": {
+        "action": "repair_screening_evidence_instrumentation",
+        "reason": "Attribution depends on missing screening evidence sidecars or drop reasons.",
+    },
+    "incomplete_policy_trace": {
+        "action": "repair_policy_trace_instrumentation",
+        "reason": "Policy diagnostics do not expose a complete read-only decision trace.",
+    },
+    "no_candidate_after_policy_filter": {
+        "action": "inspect_policy_filter_inputs",
+        "reason": "Policy evidence shows no candidate survived the read-only policy filter.",
+    },
+    "no_survivor_after_eval": {
+        "action": "inspect_evaluation_survivor_gate",
+        "reason": "Campaign or evaluation evidence completed without surviving candidates.",
+    },
+    "insufficient_oos_window": {
+        "action": "collect_more_oos_window_evidence",
+        "reason": "Observed artifacts show the out-of-sample window is too short.",
+    },
+    "missing_metric_field": {
+        "action": "repair_metric_emission",
+        "reason": "Existing screening records are missing required diagnostic metrics.",
+    },
+    "unsupported_failure_shape": {
+        "action": "operator_review_unsupported_failure_shape",
+        "reason": "The observed failure shape is explicit but not yet actionable by this taxonomy.",
+    },
+    "synthesis_gate_blocked": {
+        "action": "inspect_synthesis_gate_evidence",
+        "reason": "Existing research state reports a blocked synthesis gate.",
+    },
+    "data_coverage_unknown": {
+        "action": "resolve_data_coverage_status",
+        "reason": "Artifacts expose unknown data coverage rather than a deterministic pass/fail state.",
+    },
+    "identity_unresolved": {
+        "action": "resolve_source_identity",
+        "reason": "Artifacts indicate unresolved or fallback source identity.",
+    },
+    "policy_trace_inconsistent": {
+        "action": "repair_policy_trace_consistency",
+        "reason": "Policy counts in existing diagnostics are internally inconsistent.",
+    },
+    "strict_gate_rejection": {
+        "action": "preserve_negative_result",
+        "reason": "Observed metrics failed the current screening gate; no strategy change is implied.",
+    },
+    "missing_diagnostics": {
+        "action": "inspect_screening_instrumentation",
+        "reason": "No usable screening diagnostics were present for attribution.",
+    },
+    "unknown_screening_failure": {
+        "action": "hold_no_action_until_evidence_improves",
+        "reason": "Existing evidence is insufficient for a deterministic failure class.",
+    },
+}
+
+
+def action_hint_for_classification(classification: str) -> dict[str, Any]:
+    hint = ACTION_HINT_BY_CLASSIFICATION.get(
+        classification,
+        ACTION_HINT_BY_CLASSIFICATION["unknown_screening_failure"],
+    )
+    return {
+        "classification": classification,
+        "action": hint["action"],
+        "reason": hint["reason"],
+        "read_only": True,
+        "mutates_routing": False,
+        "mutates_strategy": False,
+    }
 
 
 def _now_utc() -> datetime:
@@ -267,9 +358,7 @@ def _metric_gap_observations(
     metrics: dict[str, Any],
     subject: dict[str, Any],
 ) -> None:
-    missing = sorted(
-        field for field in SCREENING_METRIC_FIELDS if field not in metrics
-    )
+    missing = sorted(field for field in SCREENING_METRIC_FIELDS if field not in metrics)
     if missing:
         _observe(
             observations,
@@ -423,9 +512,10 @@ def _empty_run_observations(payload: dict[str, Any]) -> list[dict[str, Any]]:
             source="empty_run_diagnostics.summary.primary_drop_reasons",
             raw_reason=str(reason),
         )
-    if _safe_int(summary.get("evaluations_with_oos_daily_returns")) == 0 and _safe_int(
-        summary.get("evaluations_count")
-    ) > 0:
+    if (
+        _safe_int(summary.get("evaluations_with_oos_daily_returns")) == 0
+        and _safe_int(summary.get("evaluations_count")) > 0
+    ):
         _observe(
             observations,
             source="empty_run_diagnostics.summary.evaluations_with_oos_daily_returns",
@@ -485,11 +575,7 @@ def _policy_filter_observations(payload: dict[str, Any]) -> list[dict[str, Any]]
             raw_reason="no_policy_candidates",
             subject={"action": action, "reason": reason, "candidates": candidate_count},
         )
-    primary = {
-        str(item)
-        for item in _list_value(payload.get("primary_explanations"))
-        if str(item)
-    }
+    primary = {str(item) for item in _list_value(payload.get("primary_explanations")) if str(item)}
     if "no_eligible_template" in primary:
         _observe(
             observations,
@@ -497,11 +583,7 @@ def _policy_filter_observations(payload: dict[str, Any]) -> list[dict[str, Any]]
             raw_reason="no_eligible_template",
             subject={"primary_explanations": sorted(primary)},
         )
-    diagnostics = [
-        row
-        for row in _list_value(payload.get("diagnostics"))
-        if isinstance(row, dict)
-    ]
+    diagnostics = [row for row in _list_value(payload.get("diagnostics")) if isinstance(row, dict)]
     for row in diagnostics:
         diagnostic_id = row.get("diagnostic_id")
         if (
@@ -603,13 +685,10 @@ def _campaign_outcome_observations(
             legacy_classification="missing_diagnostics",
         )
     policy = _dict_value(research_state.get("policy_summary"))
-    if (
-        research_state.get("policy_state") == "blocked_no_candidates"
-        or (
-            policy.get("action") == "idle_noop"
-            and policy.get("reason") == "no_candidates"
-            and _safe_int(policy.get("candidates_considered")) == 0
-        )
+    if research_state.get("policy_state") == "blocked_no_candidates" or (
+        policy.get("action") == "idle_noop"
+        and policy.get("reason") == "no_candidates"
+        and _safe_int(policy.get("candidates_considered")) == 0
     ):
         _observe(
             observations,
@@ -639,27 +718,19 @@ def collect_observations(
 ) -> list[dict[str, Any]]:
     observations: list[dict[str, Any]] = []
     if isinstance(artifacts.get("screening_evidence"), dict):
-        observations.extend(
-            _screening_evidence_observations(artifacts["screening_evidence"])
-        )
+        observations.extend(_screening_evidence_observations(artifacts["screening_evidence"]))
     if isinstance(artifacts.get("run_filter_summary"), dict):
-        observations.extend(
-            _filter_summary_observations(artifacts["run_filter_summary"])
-        )
+        observations.extend(_filter_summary_observations(artifacts["run_filter_summary"]))
     if isinstance(artifacts.get("run_screening_candidates"), dict):
         observations.extend(
-            _run_screening_candidate_observations(
-                artifacts["run_screening_candidates"]
-            )
+            _run_screening_candidate_observations(artifacts["run_screening_candidates"])
         )
     if isinstance(artifacts.get("empty_run_diagnostics"), dict):
         observations.extend(_empty_run_observations(artifacts["empty_run_diagnostics"]))
     if isinstance(artifacts.get("run_campaign"), dict):
         observations.extend(_run_campaign_observations(artifacts["run_campaign"]))
     if isinstance(artifacts.get("policy_filter_diagnostics"), dict):
-        observations.extend(
-            _policy_filter_observations(artifacts["policy_filter_diagnostics"])
-        )
+        observations.extend(_policy_filter_observations(artifacts["policy_filter_diagnostics"]))
     observations.extend(
         _campaign_outcome_observations(
             artifacts=artifacts,
@@ -695,9 +766,7 @@ def _classification_rows(observations: list[dict[str, Any]]) -> list[dict[str, A
     counts = Counter(str(item["classification"]) for item in observations)
     raw_by_class: dict[str, Counter[str]] = {name: Counter() for name in CLASSIFICATIONS}
     sources_by_class: dict[str, set[str]] = {name: set() for name in CLASSIFICATIONS}
-    examples_by_class: dict[str, list[dict[str, Any]]] = {
-        name: [] for name in CLASSIFICATIONS
-    }
+    examples_by_class: dict[str, list[dict[str, Any]]] = {name: [] for name in CLASSIFICATIONS}
     for item in observations:
         classification = str(item["classification"])
         if classification not in raw_by_class:
@@ -716,6 +785,7 @@ def _classification_rows(observations: list[dict[str, Any]]) -> list[dict[str, A
                 "raw_reasons": dict(sorted(raw_by_class[classification].items())),
                 "sources": sorted(sources_by_class[classification]),
                 "examples": examples_by_class[classification],
+                "action_hint": action_hint_for_classification(classification),
             }
         )
     return rows
@@ -749,21 +819,19 @@ def build_screening_failure_attribution_payload(
     )
     rows = _classification_rows(observations)
     primary = _primary_classification(rows)
-    counts = {
-        row["classification"]: row["count"]
-        for row in rows
-        if int(row["count"]) > 0
-    }
+    counts = {row["classification"]: row["count"] for row in rows if int(row["count"]) > 0}
     legacy_unknown_count = sum(
         1
         for item in observations
         if item.get("legacy_classification") == "unknown_screening_failure"
     )
     unknown_count = sum(
-        1
-        for item in observations
-        if item.get("classification") == "unknown_screening_failure"
+        1 for item in observations if item.get("classification") == "unknown_screening_failure"
     )
+    primary_action_hint = action_hint_for_classification(primary)
+    observed_action_hints = [
+        row["action_hint"] | {"count": row["count"]} for row in rows if int(row["count"]) > 0
+    ]
     return {
         "schema_version": SCREENING_FAILURE_ATTRIBUTION_SCHEMA_VERSION,
         "generated_at_utc": _iso_utc(generated),
@@ -776,16 +844,13 @@ def build_screening_failure_attribution_payload(
             "legacy_unknown_observation_count": legacy_unknown_count,
             "unknown_observation_count": unknown_count,
             "unknown_observation_reduction": legacy_unknown_count - unknown_count,
-            "attributed": primary
-            not in {"missing_diagnostics", "unknown_screening_failure"},
+            "attributed": primary not in {"missing_diagnostics", "unknown_screening_failure"},
+            "primary_action_hint": primary_action_hint,
         },
         "classifications": rows,
         "observations": observations,
-        "recommended_next_action": (
-            "inspect_gate_diagnostics"
-            if primary != "missing_diagnostics"
-            else "inspect_screening_instrumentation"
-        ),
+        "action_hints": observed_action_hints,
+        "recommended_next_action": primary_action_hint["action"],
         "safety_invariants": {
             "runs_research": False,
             "runs_campaign_launcher": False,
@@ -817,21 +882,28 @@ def render_markdown_report(payload: dict[str, Any]) -> str:
             f"reduction {summary.get('unknown_observation_reduction')})"
         ),
         f"- Classification counts: {json.dumps(summary.get('classification_counts') or {}, sort_keys=True)}",
+        f"- Recommended next action: `{payload.get('recommended_next_action')}`",
         "",
         "## Classifications",
         *[
-            f"- `{row['classification']}`: {row['status']} (count {row['count']})"
+            (
+                f"- `{row['classification']}`: {row['status']} "
+                f"(count {row['count']}, action `{row['action_hint']['action']}`)"
+            )
             for row in payload.get("classifications") or []
+        ],
+        "",
+        "## Action Hints",
+        *[
+            (f"- `{hint['classification']}` -> `{hint['action']}`: " f"{hint['reason']}")
+            for hint in payload.get("action_hints") or []
         ],
         "",
         "## Evidence Sources",
         *[
             f"- `{source}`"
             for source in sorted(
-                {
-                    str(obs.get("source"))
-                    for obs in payload.get("observations") or []
-                }
+                {str(obs.get("source")) for obs in payload.get("observations") or []}
             )
         ],
         "",
@@ -912,6 +984,8 @@ __all__ = [
     "DEFAULT_REPORT_JSON_PATH",
     "DEFAULT_REPORT_MD_PATH",
     "SCREENING_FAILURE_ATTRIBUTION_SCHEMA_VERSION",
+    "ACTION_HINT_BY_CLASSIFICATION",
+    "action_hint_for_classification",
     "build_from_current_artifacts",
     "build_screening_failure_attribution_payload",
     "collect_observations",

--- a/tests/unit/test_failure_action_mapping_minimal.py
+++ b/tests/unit/test_failure_action_mapping_minimal.py
@@ -50,6 +50,12 @@ def test_closed_taxonomies_are_pinned() -> None:
         "review_cost_assumptions",
         "hold_no_action",
     )
+    assert fam.SCREENING_CLASSIFICATION_TO_FAILURE_CODE["data_coverage_gap"] == (
+        "technical_failure"
+    )
+    assert fam.SCREENING_CLASSIFICATION_TO_FAILURE_CODE["unknown_screening_failure"] == (
+        "unknown_failure"
+    )
 
 
 def test_schema_keys_are_pinned() -> None:
@@ -87,9 +93,7 @@ def test_failures_must_be_list_or_tuple() -> None:
 
 
 def test_too_many_failures_rejected() -> None:
-    failures = [
-        _f(subject_id=f"s_{i:04d}") for i in range(fam.MAX_FAILURES + 1)
-    ]
+    failures = [_f(subject_id=f"s_{i:04d}") for i in range(fam.MAX_FAILURES + 1)]
     with pytest.raises(ValueError, match="too many"):
         fam.validate_failures(failures)
 
@@ -103,9 +107,7 @@ def test_missing_field_rejected() -> None:
 
 def test_unknown_failure_code_rejected() -> None:
     with pytest.raises(ValueError, match="closed taxonomy"):
-        fam.validate_failures(
-            [_f(subject_id="x", failure_code="not_canonical")]
-        )
+        fam.validate_failures([_f(subject_id="x", failure_code="not_canonical")])
 
 
 def test_unknown_severity_rejected() -> None:
@@ -134,9 +136,7 @@ def test_duplicate_subject_rejected() -> None:
         ("unknown_failure", "hold_no_action"),
     ],
 )
-def test_failure_codes_map_to_bounded_actions(
-    failure_code: str, expected_action: str
-) -> None:
+def test_failure_codes_map_to_bounded_actions(failure_code: str, expected_action: str) -> None:
     snap = fam.collect_snapshot(
         [_f(subject_id="s1", failure_code=failure_code)],
         frozen_utc="2026-05-21T00:00:00Z",
@@ -160,9 +160,7 @@ def test_low_evidence_adds_insufficient_reason() -> None:
         [_f(subject_id="s1", evidence_count=1)],
         frozen_utc="2026-05-21T00:00:00Z",
     )
-    assert "evidence_insufficient" in snap["items"][0]["reason_record"][
-        "reason_codes"
-    ]
+    assert "evidence_insufficient" in snap["items"][0]["reason_record"]["reason_codes"]
 
 
 def test_negative_result_preservation_is_explicit() -> None:
@@ -200,8 +198,7 @@ def test_reason_record_ids_are_deterministic() -> None:
     b = fam.collect_snapshot(inputs, frozen_utc="2026-05-21T00:00:00Z")
     assert json.dumps(a, sort_keys=True) == json.dumps(b, sort_keys=True)
     assert (
-        a["items"][0]["reason_record"]["record_id"]
-        == b["items"][0]["reason_record"]["record_id"]
+        a["items"][0]["reason_record"]["record_id"] == b["items"][0]["reason_record"]["record_id"]
     )
 
 
@@ -215,8 +212,7 @@ def test_record_ids_change_when_inputs_change() -> None:
         frozen_utc="2026-05-21T00:00:00Z",
     )
     assert (
-        a["items"][0]["reason_record"]["record_id"]
-        != b["items"][0]["reason_record"]["record_id"]
+        a["items"][0]["reason_record"]["record_id"] != b["items"][0]["reason_record"]["record_id"]
     )
 
 
@@ -226,6 +222,69 @@ def test_empty_snapshot_is_safe_and_not_actionable() -> None:
     assert snap["safe_to_execute"] is False
     assert snap["mode"] == "dry-run"
     assert snap["final_recommendation"] == "nothing_actionable"
+
+
+def test_screening_attribution_adapter_maps_non_strategy_classes_only() -> None:
+    payload = {
+        "summary": {"primary_classification": "data_coverage_gap"},
+        "classifications": [
+            {
+                "classification": "data_coverage_gap",
+                "status": "observed",
+                "count": 2,
+            },
+            {
+                "classification": "strict_gate_rejection",
+                "status": "observed",
+                "count": 3,
+            },
+            {
+                "classification": "unknown_screening_failure",
+                "status": "observed",
+                "count": 1,
+            },
+        ],
+    }
+
+    failures = fam.screening_attribution_failures(payload)
+
+    assert failures == [
+        {
+            "subject_id": "screening:data_coverage_gap",
+            "failure_code": "technical_failure",
+            "severity": "medium",
+            "evidence_count": 2,
+        },
+        {
+            "subject_id": "screening:unknown_screening_failure",
+            "failure_code": "unknown_failure",
+            "severity": "high",
+            "evidence_count": 1,
+        },
+    ]
+
+
+def test_collect_from_screening_attribution_preserves_read_only_action_snapshot() -> None:
+    payload = {
+        "summary": {"primary_classification": "missing_metric_field"},
+        "classifications": [
+            {
+                "classification": "missing_metric_field",
+                "status": "observed",
+                "count": 4,
+            }
+        ],
+    }
+
+    snap = fam.collect_from_screening_attribution(
+        payload,
+        frozen_utc="2026-05-22T00:00:00Z",
+    )
+
+    assert snap["source_report_kind"] == "screening_failure_attribution"
+    assert snap["source_primary_classification"] == "missing_metric_field"
+    assert snap["items"][0]["recommended_action"] == "review_data_pipeline"
+    assert snap["safe_to_execute"] is False
 
 
 def test_write_outputs_into_allowlisted_path(tmp_path: Path) -> None:

--- a/tests/unit/test_screening_failure_attribution.py
+++ b/tests/unit/test_screening_failure_attribution.py
@@ -181,10 +181,17 @@ def test_no_candidate_after_policy_filter_is_classified_from_policy_diagnostics(
     )
 
     assert _row(payload, "no_candidate_after_policy_filter")["count"] == 2
-    assert payload["summary"]["primary_classification"] == (
-        "no_candidate_after_policy_filter"
-    )
+    assert payload["summary"]["primary_classification"] == ("no_candidate_after_policy_filter")
     assert payload["summary"]["unknown_observation_reduction"] == 2
+    assert payload["summary"]["primary_action_hint"] == {
+        "classification": "no_candidate_after_policy_filter",
+        "action": "inspect_policy_filter_inputs",
+        "reason": "Policy evidence shows no candidate survived the read-only policy filter.",
+        "read_only": True,
+        "mutates_routing": False,
+        "mutates_strategy": False,
+    }
+    assert payload["recommended_next_action"] == "inspect_policy_filter_inputs"
 
 
 def test_incomplete_and_inconsistent_policy_trace_are_classified() -> None:
@@ -293,6 +300,34 @@ def test_unknown_screening_failure_is_preserved_when_no_evidence_matches() -> No
 
     assert _row(payload, "unknown_screening_failure")["count"] == 1
     assert payload["summary"]["unknown_observation_count"] == 1
+    assert payload["recommended_next_action"] == ("hold_no_action_until_evidence_improves")
+    assert _row(payload, "unknown_screening_failure")["action_hint"]["read_only"] is True
+
+
+def test_action_hints_are_emitted_only_from_observed_classifications() -> None:
+    payload = _payload(
+        _base_artifacts(
+            screening_evidence={
+                "summary": {"dominant_failure_reasons": ["coverage_unknown"]},
+                "candidates": [],
+            }
+        )
+    )
+
+    assert payload["action_hints"] == [
+        {
+            "classification": "data_coverage_unknown",
+            "action": "resolve_data_coverage_status",
+            "reason": (
+                "Artifacts expose unknown data coverage rather than a deterministic "
+                "pass/fail state."
+            ),
+            "read_only": True,
+            "mutates_routing": False,
+            "mutates_strategy": False,
+            "count": 1,
+        }
+    ]
 
 
 def test_missing_all_screening_artifacts_is_handled_gracefully_with_cli(


### PR DESCRIPTION
## Queue item
ADE-QRE-002 - Screening Failure Attribution Depth

## Scope completed
- Added deterministic read-only action hints to existing screening failure attribution classifications.
- Preserved unknown classifications where evidence is insufficient.
- Added a read-only adapter from screening attribution classes into the minimal failure-action mapping snapshot for known non-strategy failure classes.

## Queue document status update
- Marked ADE-QRE-001 done with PR #309 and merge SHA d35e9d85f2ffccb102e4b3257cffd8b747283d51.
- Marked ADE-QRE-002 done for this implementation branch after local validation.
- Marked ADE-QRE-003 ready so that state lands only if this PR merges successfully.

## Files changed
- docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
- research/screening_failure_attribution.py
- reporting/failure_action_mapping_minimal.py
- tests/unit/test_screening_failure_attribution.py
- tests/unit/test_failure_action_mapping_minimal.py

## Tests run
- python -m pytest tests\\unit\\test_screening_failure_attribution.py tests\\unit\\test_failure_action_mapping_minimal.py -q
- python -m pytest tests\\architecture -q
- python -m reporting.architecture_import_scan --format summary
- git diff --check

## Frozen contract status
- Unchanged: research/research_latest.json, research/strategy_matrix.csv, tests/regression pins.

## Protected path status
- Untouched: registry.py, agent/backtesting/strategies.py, live/paper/shadow/risk/broker/execution-sensitive paths.

## Architecture/gate status
- Local architecture tests passed.
- Architecture scanner reported forbidden_edge_count = 0; existing legacy/report-only edges remain visible.

## Next queue item
ADE-QRE-003 - Data Foundation Manifest and Coverage