### PR TITLE
feat: ADE-QRE-003 data foundation manifest

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -50,7 +50,7 @@
 
 - queue id: `ADE-QRE-002`
 - status: `done`
-- completion evidence: implemented deterministic read-only action hints for existing screening attribution classes and a read-only failure-action mapping adapter; local targeted tests and architecture scanner passed in the implementation branch; PR/merge evidence to be recorded by the next queue item after merge.
+- completion evidence: PR #310, merge SHA `d4fc1d35362262ab59f23a3734c4fe5ba2910f6d`; Fast pre-merge gate, Docker build/push, and VPS deploy post-merge gates green; frozen contracts unchanged; protected paths untouched; live/paper/shadow/risk/broker/execution inactive.
 - doel: make screening failures more actionable after unknown reduction by mapping classes to stable failure-to-action recommendations.
 - bron uit target-state roadmap: current weakness "Attribution depth"; fase 7 "Failure -> Action -> Reroute sluiten"; prompt 12.1 follow-up.
 - scope: enrich existing attribution output with deterministic action hints for known non-strategy failure classes and keep them read-only.
@@ -64,7 +64,8 @@
 ### ADE-QRE-003 - Data Foundation Manifest and Coverage
 
 - queue id: `ADE-QRE-003`
-- status: `ready`
+- status: `done`
+- completion evidence: implemented read-only local cache manifest schema and coverage reporter with row counts, min/max timestamps, content hashes, deterministic sidecar writer, and fail-closed missing-manifest status; local targeted tests and architecture scanner passed in the implementation branch; PR/merge evidence to be recorded by the next queue item after merge.
 - doel: introduce a read-only local research cache manifest and coverage reporter before data-aware routing or hypothesis discovery depends on data readiness.
 - bron uit target-state roadmap: fase 2 "Data Foundation als productlaag"; prompt 12.2 "Data Foundation v3.data.1"; data-throughput sections 9.4-9.6.
 - scope: manifest schema, coverage report by source/instrument/timeframe, row counts, min/max timestamps, schema version, content hash, and deterministic sidecar output.
@@ -78,7 +79,7 @@
 ### ADE-QRE-004 - Source Identity and Quality Readiness
 
 - queue id: `ADE-QRE-004`
-- status: `deferred`
+- status: `ready`
 - doel: make source identity and source quality visible enough to explain data-related research failures.
 - bron uit target-state roadmap: fase 2 `v3.data.2` and `v3.data.3`; sections 9.5-9.7; lessons learned "Eerst data als productlaag".
 - scope: deterministic source-quality checks over existing manifest data, identity confidence fields, fail-closed readiness statuses, and operator-readable sidecar summary.

--- a/docs/governance/qre_data_cache_manifest.md
+++ b/docs/governance/qre_data_cache_manifest.md
@@ -1,0 +1,39 @@
+# QRE Data Cache Manifest
+
+## Purpose
+
+`packages.qre_data.cache_manifest` builds a deterministic read-only manifest
+over existing local research cache files.
+
+## Scope
+
+- Reads local `data/cache/*/*.parquet` files.
+- Reports source, instrument, timeframe, row count, min/max timestamps, file
+  size, content hash, and aggregate coverage rows.
+- Writes only optional sidecars under `logs/qre_data_cache_manifest/`.
+- Fails closed when the manifest is missing, invalid, empty, or not research
+  ready.
+
+## Out Of Scope
+
+- No live fetching.
+- No paid data activation.
+- No source adapter activation.
+- No cache backfill.
+- No strategy, registry, campaign, routing, paper, shadow, live, broker, risk,
+  or execution behavior.
+- No changes to `research/research_latest.json` or `research/strategy_matrix.csv`.
+
+## Commands
+
+```powershell
+python -m packages.qre_data.cache_manifest --no-write --frozen-utc 2026-05-23T00:00:00Z
+python -m packages.qre_data.cache_manifest --status
+python -m packages.qre_data.cache_manifest
+```
+
+## Readiness Semantics
+
+`research_ready` is true only when at least one cache file exists, total rows are
+positive, and no inspected cache file is unreadable. Missing manifest status is
+`missing_manifest` with `research_ready=false` and `fails_closed=true`.

--- a/packages/qre_data/README.md
+++ b/packages/qre_data/README.md
@@ -7,10 +7,12 @@ market-data access abstractions, and deterministic data-source metadata.
 
 ## Current Status
 
-Status: active read-only seed. The package owns the immutable market and macro
-data contract types in `packages.qre_data.contracts`. Current data
-repositories, adapters, fetchers, cache behavior, and dashboard consumers
-remain in their existing paths.
+Status: active read-only seed plus ADE-QRE-003 local cache manifest helper. The
+package owns the immutable market and macro data contract types in
+`packages.qre_data.contracts` and the deterministic read-only cache manifest in
+`packages.qre_data.cache_manifest`. Current data repositories, adapters,
+fetchers, cache behavior, and dashboard consumers remain in their existing
+paths.
 
 ## Source of Truth / Authority Boundary
 
@@ -21,11 +23,16 @@ Existing `data/` repositories, adapters, fetchers, cache files, and dashboard
 consumers remain the source of truth until each surface is migrated by a
 bounded unit.
 
+`packages.qre_data.cache_manifest` is a read-only reporter over existing local
+cache files only. It does not fetch, backfill, modify cache files, or change
+research output contracts.
+
 ## Allowed Future Contents
 
 - Data contract types and metadata.
 - Read-only repository abstractions and adapter interfaces.
 - Deterministic data validation helpers.
+- Read-only local cache manifests and coverage summaries.
 
 ## Forbidden Contents
 
@@ -53,4 +60,5 @@ separate bounded unit.
 
 ## Activation Status
 
-Activation status: read-only data contract seed only.
+Activation status: read-only data contract seed and read-only local cache
+manifest only.

--- a/packages/qre_data/cache_manifest.py
+++ b/packages/qre_data/cache_manifest.py
@@ -1,0 +1,400 @@
+"""Read-only local research cache manifest and coverage reporter."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import hashlib
+import json
+import os
+import sys
+from collections import Counter
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Final
+
+try:  # pragma: no cover - exercised when dependency is absent.
+    import pyarrow.parquet as _pq
+except Exception:  # pragma: no cover
+    _pq = None
+
+SCHEMA_VERSION: Final[str] = "1.0"
+REPORT_KIND: Final[str] = "qre_data_cache_manifest"
+DEFAULT_CACHE_DIRS: Final[dict[str, Path]] = {
+    "market": Path("data/cache/market"),
+    "macro": Path("data/cache/macro"),
+}
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_data_cache_manifest")
+LATEST_NAME: Final[str] = "latest.json"
+HISTORY_NAME: Final[str] = "history.jsonl"
+_WRITE_PREFIX: Final[str] = "logs/qre_data_cache_manifest/"
+
+
+def _utcnow() -> str:
+    return _dt.datetime.now(_dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _rel(path: Path, *, root: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _hash_file(path: Path) -> str | None:
+    h = hashlib.sha256()
+    try:
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                h.update(chunk)
+    except OSError:
+        return None
+    return f"sha256:{h.hexdigest()}"
+
+
+def _parse_market_filename(path: Path) -> dict[str, Any]:
+    parts = path.stem.split("__")
+    if len(parts) != 6:
+        return {
+            "source": "unknown",
+            "instrument": "unknown",
+            "timeframe": "unknown",
+            "requested_start": None,
+            "requested_end": None,
+            "cache_key": None,
+        }
+    source, instrument, timeframe, start, end, cache_key = parts
+    return {
+        "source": source,
+        "instrument": instrument,
+        "timeframe": timeframe,
+        "requested_start": _date_key_to_iso(start),
+        "requested_end": _date_key_to_iso(end),
+        "cache_key": cache_key,
+    }
+
+
+def _parse_macro_filename(path: Path) -> dict[str, Any]:
+    parts = path.stem.split("__")
+    series_id = parts[0] if parts and parts[0] else "unknown"
+    return {
+        "source": "macro_cache",
+        "instrument": series_id,
+        "timeframe": "native",
+        "requested_start": None,
+        "requested_end": None,
+        "cache_key": parts[1] if len(parts) > 1 else None,
+    }
+
+
+def _date_key_to_iso(value: str) -> str | None:
+    if len(value) != 8 or not value.isdigit():
+        return None
+    return f"{value[:4]}-{value[4:6]}-{value[6:8]}"
+
+
+def _timestamp_to_iso(value: Any) -> str | None:
+    if value is None:
+        return None
+    if hasattr(value, "as_py"):
+        value = value.as_py()
+    if hasattr(value, "to_pydatetime"):
+        value = value.to_pydatetime()
+    if isinstance(value, _dt.date) and not isinstance(value, _dt.datetime):
+        value = _dt.datetime(value.year, value.month, value.day, tzinfo=_dt.UTC)
+    if isinstance(value, _dt.datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=_dt.UTC)
+        else:
+            value = value.astimezone(_dt.UTC)
+        return value.isoformat().replace("+00:00", "Z")
+    return str(value)
+
+
+def _parquet_stats(path: Path) -> tuple[int | None, str | None, str | None, str]:
+    if _pq is None:
+        return None, None, None, "unreadable"
+    try:
+        parquet_file = _pq.ParquetFile(path)
+        row_count = int(parquet_file.metadata.num_rows)
+        schema_names = set(parquet_file.schema_arrow.names)
+        if row_count <= 0:
+            return row_count, None, None, "empty"
+        if "timestamp_utc" not in schema_names:
+            return row_count, None, None, "missing_timestamp"
+        table = _pq.read_table(path, columns=["timestamp_utc"])
+        values = [value for value in table.column("timestamp_utc").to_pylist() if value is not None]
+    except Exception:
+        return None, None, None, "unreadable"
+    if not values:
+        return row_count, None, None, "missing_timestamp"
+    try:
+        return row_count, _timestamp_to_iso(min(values)), _timestamp_to_iso(max(values)), "ready"
+    except TypeError:
+        normalized = sorted(str(value) for value in values)
+        return row_count, normalized[0], normalized[-1], "ready"
+
+
+def _inspect_cache_file(
+    path: Path,
+    *,
+    cache_kind: str,
+    repo_root: Path,
+) -> dict[str, Any]:
+    parsed = _parse_market_filename(path) if cache_kind == "market" else _parse_macro_filename(path)
+    row_count, min_ts, max_ts, status = _parquet_stats(path)
+    content_hash = _hash_file(path)
+    try:
+        size_bytes = int(path.stat().st_size)
+    except OSError:
+        size_bytes = None
+        status = "unreadable"
+    if content_hash is None:
+        status = "unreadable"
+    return {
+        "path": _rel(path, root=repo_root),
+        "cache_kind": cache_kind,
+        "source": parsed["source"],
+        "instrument": parsed["instrument"],
+        "timeframe": parsed["timeframe"],
+        "requested_start": parsed["requested_start"],
+        "requested_end": parsed["requested_end"],
+        "cache_key": parsed["cache_key"],
+        "status": status,
+        "row_count": row_count,
+        "min_timestamp_utc": min_ts,
+        "max_timestamp_utc": max_ts,
+        "size_bytes": size_bytes,
+        "content_hash": content_hash,
+    }
+
+
+def _coverage_rows(files: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    grouped: dict[tuple[str, str, str], list[dict[str, Any]]] = {}
+    for row in files:
+        key = (
+            str(row["source"]),
+            str(row["instrument"]),
+            str(row["timeframe"]),
+        )
+        grouped.setdefault(key, []).append(row)
+
+    coverage: list[dict[str, Any]] = []
+    for (source, instrument, timeframe), rows in grouped.items():
+        row_counts = [
+            int(row["row_count"]) for row in rows if isinstance(row.get("row_count"), int)
+        ]
+        min_values = sorted(
+            str(row["min_timestamp_utc"]) for row in rows if row.get("min_timestamp_utc")
+        )
+        max_values = sorted(
+            str(row["max_timestamp_utc"]) for row in rows if row.get("max_timestamp_utc")
+        )
+        hashes = sorted(str(row["content_hash"]) for row in rows if row.get("content_hash"))
+        status_counts = Counter(str(row["status"]) for row in rows)
+        digest = hashlib.sha256("|".join(hashes).encode("utf-8")).hexdigest()
+        coverage.append(
+            {
+                "source": source,
+                "instrument": instrument,
+                "timeframe": timeframe,
+                "file_count": len(rows),
+                "row_count": sum(row_counts),
+                "min_timestamp_utc": min_values[0] if min_values else None,
+                "max_timestamp_utc": max_values[-1] if max_values else None,
+                "content_hash": f"sha256:{digest}",
+                "status_counts": dict(sorted(status_counts.items())),
+                "ready": bool(row_counts) and status_counts.get("unreadable", 0) == 0,
+            }
+        )
+    coverage.sort(key=lambda row: (row["source"], row["instrument"], row["timeframe"]))
+    return coverage
+
+
+def build_cache_manifest(
+    *,
+    cache_dirs: Mapping[str, Path] | None = None,
+    repo_root: Path = Path("."),
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    when = generated_at_utc or _utcnow()
+    roots = dict(cache_dirs or DEFAULT_CACHE_DIRS)
+    root_status: list[dict[str, Any]] = []
+    files: list[dict[str, Any]] = []
+
+    for cache_kind, cache_dir in sorted(roots.items()):
+        path = repo_root / cache_dir
+        exists = path.is_dir()
+        root_status.append(
+            {
+                "cache_kind": cache_kind,
+                "path": _rel(path, root=repo_root),
+                "status": "present" if exists else "missing",
+            }
+        )
+        if not exists:
+            continue
+        for file_path in sorted(path.glob("*.parquet")):
+            files.append(
+                _inspect_cache_file(
+                    file_path,
+                    cache_kind=cache_kind,
+                    repo_root=repo_root,
+                )
+            )
+
+    files.sort(key=lambda row: row["path"])
+    coverage = _coverage_rows(files)
+    status_counts = Counter(str(row["status"]) for row in files)
+    total_rows = sum(
+        int(row["row_count"]) for row in files if isinstance(row.get("row_count"), int)
+    )
+    manifest_hash = hashlib.sha256(
+        "|".join(str(row.get("content_hash") or "") for row in files).encode("utf-8")
+    ).hexdigest()
+    research_ready = bool(files) and total_rows > 0 and status_counts.get("unreadable", 0) == 0
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": when,
+        "mode": "dry-run",
+        "safe_to_execute": False,
+        "summary": {
+            "status": "ready" if research_ready else "not_ready",
+            "research_ready": research_ready,
+            "cache_file_count": len(files),
+            "coverage_row_count": len(coverage),
+            "total_rows": total_rows,
+            "source_count": len({row["source"] for row in files}),
+            "instrument_count": len({row["instrument"] for row in files}),
+            "timeframe_count": len({row["timeframe"] for row in files}),
+            "status_counts": dict(sorted(status_counts.items())),
+            "missing_roots": sum(1 for row in root_status if row["status"] == "missing"),
+            "manifest_content_hash": f"sha256:{manifest_hash}",
+            "missing_manifest_fails_closed": True,
+        },
+        "cache_roots": root_status,
+        "files": files,
+        "coverage": coverage,
+        "safety_invariants": {
+            "read_only": True,
+            "fetches_external_data": False,
+            "mutates_cache": False,
+            "mutates_research_outputs": False,
+            "frozen_contracts_unchanged": True,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+        },
+    }
+
+
+def _validate_write_target(path: Path) -> None:
+    normalized = path.as_posix()
+    if _WRITE_PREFIX not in normalized:
+        raise ValueError("qre_data_cache_manifest: refusing write outside allowlist: " f"{path!r}")
+
+
+def write_manifest_outputs(
+    manifest: Mapping[str, Any],
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = Path("."),
+) -> dict[str, str]:
+    base = repo_root / output_dir
+    base.mkdir(parents=True, exist_ok=True)
+    timestamp = str(manifest["generated_at_utc"]).replace(":", "-")
+    latest = base / LATEST_NAME
+    timestamped = base / f"{timestamp}.json"
+    history = base / HISTORY_NAME
+    payload = json.dumps(manifest, sort_keys=True, indent=2) + "\n"
+
+    for target in (latest, timestamped, history):
+        _validate_write_target(target)
+
+    tmp_latest = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_latest.write_text(payload, encoding="utf-8")
+    os.replace(tmp_latest, latest)
+
+    tmp_timestamped = timestamped.with_suffix(timestamped.suffix + ".tmp")
+    tmp_timestamped.write_text(payload, encoding="utf-8")
+    os.replace(tmp_timestamped, timestamped)
+
+    compact = json.dumps(manifest, sort_keys=True, separators=(",", ":"))
+    with history.open("a", encoding="utf-8") as handle:
+        handle.write(compact + "\n")
+
+    return {
+        "latest": _rel(latest, root=repo_root),
+        "timestamped": _rel(timestamped, root=repo_root),
+        "history": _rel(history, root=repo_root),
+    }
+
+
+def read_manifest_status(
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = Path("."),
+) -> dict[str, Any]:
+    latest = repo_root / output_dir / LATEST_NAME
+    if not latest.is_file():
+        return {
+            "status": "missing_manifest",
+            "research_ready": False,
+            "path": _rel(latest, root=repo_root),
+            "fails_closed": True,
+        }
+    try:
+        payload = json.loads(latest.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {
+            "status": "invalid_manifest",
+            "research_ready": False,
+            "path": _rel(latest, root=repo_root),
+            "fails_closed": True,
+        }
+    summary = payload.get("summary") if isinstance(payload, dict) else None
+    ready = bool(summary.get("research_ready")) if isinstance(summary, dict) else False
+    return {
+        "status": "ready" if ready else "not_ready",
+        "research_ready": ready,
+        "path": _rel(latest, root=repo_root),
+        "fails_closed": not ready,
+        "schema_version": payload.get("schema_version") if isinstance(payload, dict) else None,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="packages.qre_data.cache_manifest",
+        description="Build a read-only local QRE data cache manifest.",
+    )
+    parser.add_argument("--no-write", action="store_true")
+    parser.add_argument("--status", action="store_true")
+    parser.add_argument("--frozen-utc", type=str, default=None)
+    args = parser.parse_args(argv)
+
+    if args.status:
+        print(json.dumps(read_manifest_status(), sort_keys=True, indent=2))
+        return 0
+
+    manifest = build_cache_manifest(generated_at_utc=args.frozen_utc)
+    if not args.no_write:
+        manifest["_artifact_paths"] = write_manifest_outputs(manifest)
+    print(json.dumps(manifest, sort_keys=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())
+
+
+__all__ = [
+    "DEFAULT_CACHE_DIRS",
+    "DEFAULT_OUTPUT_DIR",
+    "REPORT_KIND",
+    "SCHEMA_VERSION",
+    "build_cache_manifest",
+    "read_manifest_status",
+    "write_manifest_outputs",
+]

--- a/tests/architecture/test_package_migration_001_target_layout.py
+++ b/tests/architecture/test_package_migration_001_target_layout.py
@@ -135,7 +135,7 @@ def test_package_migration_001_qre_data_has_only_bounded_read_only_seed() -> Non
         if path.is_file() and "__pycache__" not in path.parts
     )
 
-    assert files == ["README.md", "__init__.py", "contracts.py"], target
+    assert files == ["README.md", "__init__.py", "cache_manifest.py", "contracts.py"], target
 
 
 def test_package_migration_001_qre_research_has_only_bounded_read_only_seed() -> None:
@@ -155,6 +155,7 @@ def test_package_migration_001_scanner_classifies_target_paths() -> None:
     assert classify_path("packages/qre_research/README.md") == DOMAIN_QRE
     assert classify_path("packages/qre_research/universe.py") == DOMAIN_QRE
     assert classify_path("packages/qre_data/README.md") == DOMAIN_QRE
+    assert classify_path("packages/qre_data/cache_manifest.py") == DOMAIN_QRE
     assert classify_path("packages/qre_data/contracts.py") == DOMAIN_QRE
     assert classify_path("packages/qre_artifacts/README.md") == DOMAIN_QRE
     assert classify_path("packages/qre_artifacts/public_outputs.py") == DOMAIN_QRE
@@ -167,6 +168,7 @@ def test_package_migration_001_scanner_classifies_target_paths() -> None:
     assert classify_path("packages/qre_live/README.md") == DOMAIN_EXECUTION
 
     assert classify_module("packages.qre_research.universe") == DOMAIN_QRE
+    assert classify_module("packages.qre_data.cache_manifest") == DOMAIN_QRE
     assert classify_module("packages.qre_data.contracts") == DOMAIN_QRE
     assert classify_module("packages.qre_artifacts.public_outputs") == DOMAIN_QRE
     assert classify_module("packages.qre_policy.authority_views") == DOMAIN_QRE

--- a/tests/architecture/test_package_migration_010_closure_decision.py
+++ b/tests/architecture/test_package_migration_010_closure_decision.py
@@ -32,7 +32,7 @@ EXPECTED_MIGRATION_DOCS = (
 )
 BOUNDED_PACKAGE_CONTENTS = {
     "qre_research": ["README.md", "__init__.py", "universe.py"],
-    "qre_data": ["README.md", "__init__.py", "contracts.py"],
+    "qre_data": ["README.md", "__init__.py", "cache_manifest.py", "contracts.py"],
     "qre_artifacts": ["README.md", "__init__.py", "public_outputs.py"],
     "qre_diagnostics": ["README.md", "__init__.py", "paths.py"],
     "qre_policy": ["README.md", "__init__.py", "authority_views.py"],

--- a/tests/unit/test_qre_data_cache_manifest.py
+++ b/tests/unit/test_qre_data_cache_manifest.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from packages.qre_data import cache_manifest as manifest
+
+
+def _write_parquet(path: Path, timestamps: list[datetime]) -> None:
+    table = pa.table(
+        {
+            "instrument_id": ["btc-usd"] * len(timestamps),
+            "interval": ["1h"] * len(timestamps),
+            "timestamp_utc": timestamps,
+            "close": [100.0 + i for i, _ in enumerate(timestamps)],
+        }
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    pq.write_table(table, path)
+
+
+def test_build_cache_manifest_reports_file_and_coverage_rows(tmp_path: Path) -> None:
+    cache = tmp_path / "data" / "cache" / "market"
+    _write_parquet(
+        cache / "yfinance__BTC-USD__1h__20260401__20260403__abc123.parquet",
+        [
+            datetime(2026, 4, 1, 0, 0, tzinfo=UTC),
+            datetime(2026, 4, 1, 1, 0, tzinfo=UTC),
+            datetime(2026, 4, 1, 2, 0, tzinfo=UTC),
+        ],
+    )
+
+    payload = manifest.build_cache_manifest(
+        cache_dirs={"market": Path("data/cache/market")},
+        repo_root=tmp_path,
+        generated_at_utc="2026-05-23T00:00:00Z",
+    )
+
+    assert payload["schema_version"] == "1.0"
+    assert payload["summary"]["research_ready"] is True
+    assert payload["summary"]["cache_file_count"] == 1
+    assert payload["summary"]["total_rows"] == 3
+    assert payload["files"][0]["source"] == "yfinance"
+    assert payload["files"][0]["instrument"] == "BTC-USD"
+    assert payload["files"][0]["timeframe"] == "1h"
+    assert payload["files"][0]["row_count"] == 3
+    assert payload["files"][0]["min_timestamp_utc"] == "2026-04-01T00:00:00Z"
+    assert payload["files"][0]["max_timestamp_utc"] == "2026-04-01T02:00:00Z"
+    assert payload["files"][0]["content_hash"].startswith("sha256:")
+    assert payload["coverage"] == [
+        {
+            "source": "yfinance",
+            "instrument": "BTC-USD",
+            "timeframe": "1h",
+            "file_count": 1,
+            "row_count": 3,
+            "min_timestamp_utc": "2026-04-01T00:00:00Z",
+            "max_timestamp_utc": "2026-04-01T02:00:00Z",
+            "content_hash": payload["coverage"][0]["content_hash"],
+            "status_counts": {"ready": 1},
+            "ready": True,
+        }
+    ]
+
+
+def test_missing_cache_root_fails_closed(tmp_path: Path) -> None:
+    payload = manifest.build_cache_manifest(
+        cache_dirs={"market": Path("data/cache/market")},
+        repo_root=tmp_path,
+        generated_at_utc="2026-05-23T00:00:00Z",
+    )
+
+    assert payload["summary"]["research_ready"] is False
+    assert payload["summary"]["status"] == "not_ready"
+    assert payload["summary"]["missing_roots"] == 1
+    assert payload["cache_roots"] == [
+        {
+            "cache_kind": "market",
+            "path": "data/cache/market",
+            "status": "missing",
+        }
+    ]
+    assert payload["files"] == []
+    assert payload["coverage"] == []
+
+
+def test_manifest_output_is_deterministic_for_same_inputs(tmp_path: Path) -> None:
+    cache = tmp_path / "data" / "cache" / "market"
+    _write_parquet(
+        cache / "yfinance__ETH-USD__4h__20260401__20260402__def456.parquet",
+        [datetime(2026, 4, 1, 0, 0, tzinfo=UTC)],
+    )
+
+    left = manifest.build_cache_manifest(
+        cache_dirs={"market": Path("data/cache/market")},
+        repo_root=tmp_path,
+        generated_at_utc="2026-05-23T00:00:00Z",
+    )
+    right = manifest.build_cache_manifest(
+        cache_dirs={"market": Path("data/cache/market")},
+        repo_root=tmp_path,
+        generated_at_utc="2026-05-23T00:00:00Z",
+    )
+
+    assert left == right
+
+
+def test_read_manifest_status_fails_closed_until_manifest_exists(tmp_path: Path) -> None:
+    missing = manifest.read_manifest_status(
+        output_dir=Path("logs/qre_data_cache_manifest"),
+        repo_root=tmp_path,
+    )
+
+    assert missing == {
+        "status": "missing_manifest",
+        "research_ready": False,
+        "path": "logs/qre_data_cache_manifest/latest.json",
+        "fails_closed": True,
+    }
+
+    cache = tmp_path / "data" / "cache" / "market"
+    _write_parquet(
+        cache / "yfinance__AAPL__1d__20260401__20260402__ghi789.parquet",
+        [datetime(2026, 4, 1, 0, 0, tzinfo=UTC)],
+    )
+    payload = manifest.build_cache_manifest(
+        cache_dirs={"market": Path("data/cache/market")},
+        repo_root=tmp_path,
+        generated_at_utc="2026-05-23T00:00:00Z",
+    )
+    manifest.write_manifest_outputs(
+        payload,
+        output_dir=Path("logs/qre_data_cache_manifest"),
+        repo_root=tmp_path,
+    )
+
+    present = manifest.read_manifest_status(
+        output_dir=Path("logs/qre_data_cache_manifest"),
+        repo_root=tmp_path,
+    )
+
+    assert present == {
+        "status": "ready",
+        "research_ready": True,
+        "path": "logs/qre_data_cache_manifest/latest.json",
+        "fails_closed": False,
+        "schema_version": "1.0",
+    }
+
+
+def test_safety_invariants_keep_manifest_read_only(tmp_path: Path) -> None:
+    payload = manifest.build_cache_manifest(repo_root=tmp_path)
+
+    assert payload["safe_to_execute"] is False
+    assert payload["safety_invariants"] == {
+        "read_only": True,
+        "fetches_external_data": False,
+        "mutates_cache": False,
+        "mutates_research_outputs": False,
+        "frozen_contracts_unchanged": True,
+        "paper_shadow_live_forbidden": True,
+        "broker_risk_execution_forbidden": True,
+    }


### PR DESCRIPTION
## Queue item
ADE-QRE-003 - Data Foundation Manifest and Coverage

## Scope completed
- Added `packages.qre_data.cache_manifest`, a read-only local cache manifest and coverage reporter for existing parquet cache files.
- Reports source/instrument/timeframe coverage, row counts, min/max timestamps, content hashes, cache root status, and fail-closed manifest status.
- Added optional deterministic sidecar output under `logs/qre_data_cache_manifest/`; no sidecar was generated or committed.
- Added a narrow governance runbook for operator use.

## Queue document status update
- Recorded ADE-QRE-002 completion evidence: PR #310, merge SHA d4fc1d35362262ab59f23a3734c4fe5ba2910f6d, green post-merge gates.
- Marked ADE-QRE-003 done for this implementation branch after local validation.
- Marked ADE-QRE-004 ready so that state lands only if this PR merges successfully.

## Files changed
- docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
- docs/governance/qre_data_cache_manifest.md
- packages/qre_data/README.md
- packages/qre_data/cache_manifest.py
- tests/unit/test_qre_data_cache_manifest.py
- tests/architecture/test_package_migration_001_target_layout.py
- tests/architecture/test_package_migration_010_closure_decision.py

## Tests run
- python -m pytest tests\\unit\\test_qre_data_cache_manifest.py -q
- python -m pytest tests\\architecture -q
- python -m pytest tests\\architecture\\test_package_migration_001_target_layout.py tests\\architecture\\test_package_migration_010_closure_decision.py -q
- python -m reporting.architecture_import_scan --format summary
- python -m packages.qre_data.cache_manifest --no-write --frozen-utc 2026-05-23T00:00:00Z
- python -m packages.qre_data.cache_manifest --status
- git diff --check

## Frozen contract status
- Unchanged: research/research_latest.json, research/strategy_matrix.csv, regression pins, registry.py, agent/backtesting/strategies.py.

## Protected path status
- Untouched: live/paper/shadow/risk/broker/execution-sensitive paths and protected strategy/registry paths.

## Architecture/gate status
- Local architecture tests passed.
- Architecture scanner reported forbidden_edge_count = 0; existing legacy/report-only edges remain visible.

## Next queue item
ADE-QRE-004 - Source Identity and Quality Readiness