### PR TITLE
feat: materialize trusted-loop evidence snapshots

### DIFF
--- a/reporting/intelligent_routing_minimal.py
+++ b/reporting/intelligent_routing_minimal.py
@@ -500,8 +500,7 @@ def write_outputs(
 def read_latest_snapshot(
     *, artifact_dir: Path | None = None
 ) -> dict[str, Any] | None:
-    base = artifact_dir or ARTIFACT_DIR
-    p = base / ARTIFACT_LATEST.name
+    p = (artifact_dir / ARTIFACT_LATEST.name) if artifact_dir else ARTIFACT_LATEST
     if not p.is_file():
         return None
     try:

--- a/reporting/reason_records.py
+++ b/reporting/reason_records.py
@@ -502,6 +502,29 @@ def collect_manifest(
     }
 
 
+def write_manifest(
+    *,
+    artifact_dir: Path | None = None,
+    frozen_utc: str | None = None,
+) -> dict[str, Any]:
+    """Materialise ``manifest.v1.json`` from existing JSONL records.
+
+    This does not create or append reason records. It is intentionally
+    safe for empty evidence directories so callers can make the
+    absence of records explicit without inventing records.
+    """
+    base = artifact_dir or ARTIFACT_DIR
+    manifest_path = base / MANIFEST_PATH.name
+    _validate_write_target(manifest_path)
+    base.mkdir(parents=True, exist_ok=True)
+    manifest = collect_manifest(artifact_dir=base, frozen_utc=frozen_utc)
+    payload = json.dumps(manifest, sort_keys=True, indent=2)
+    tmp = manifest_path.with_suffix(manifest_path.suffix + ".tmp")
+    tmp.write_text(payload, encoding="utf-8")
+    os.replace(tmp, manifest_path)
+    return manifest
+
+
 # ---------------------------------------------------------------------------
 # Write API (RR-I1 append-only, RR-I2 idempotent)
 # ---------------------------------------------------------------------------

--- a/reporting/research_observability_minimal.py
+++ b/reporting/research_observability_minimal.py
@@ -919,8 +919,7 @@ def write_outputs(
 def read_latest_snapshot(
     *, artifact_dir: Path | None = None
 ) -> dict[str, Any] | None:
-    base = artifact_dir or ARTIFACT_DIR
-    p = base / ARTIFACT_LATEST.name
+    p = (artifact_dir / ARTIFACT_LATEST.name) if artifact_dir else ARTIFACT_LATEST
     return _read_json(p)
 
 

--- a/reporting/sampling_intelligence_minimal.py
+++ b/reporting/sampling_intelligence_minimal.py
@@ -534,8 +534,7 @@ def write_outputs(
 def read_latest_snapshot(
     *, artifact_dir: Path | None = None
 ) -> dict[str, Any] | None:
-    base = artifact_dir or ARTIFACT_DIR
-    p = base / ARTIFACT_LATEST.name
+    p = (artifact_dir / ARTIFACT_LATEST.name) if artifact_dir else ARTIFACT_LATEST
     if not p.is_file():
         return None
     try:

--- a/reporting/trusted_loop_materialization.py
+++ b/reporting/trusted_loop_materialization.py
@@ -1,0 +1,424 @@
+"""ADE-QRE-012 trusted-loop evidence materializer.
+
+Read-only helper that materialises missing trusted-loop evidence
+snapshots from artifacts that already exist locally. It never emits
+synthetic reason records, routing candidates, sampling strata, failure
+actions, strategies, registry entries, or trading behavior.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Final
+
+from reporting import intelligent_routing_minimal as _routing
+from reporting import reason_records as _rr
+from reporting import research_observability_minimal as _observability
+from reporting import sampling_intelligence_minimal as _sampling
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+MODULE_VERSION: Final[str] = "ade-qre-012-2026-05-23"
+SCHEMA_VERSION: Final[int] = 1
+REPORT_KIND: Final[str] = "trusted_loop_materialization_digest"
+
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "trusted_loop_materialization"
+ARTIFACT_LATEST: Final[Path] = ARTIFACT_DIR / "latest.json"
+HISTORY: Final[Path] = ARTIFACT_DIR / "history.jsonl"
+_WRITE_PREFIX: Final[str] = "logs/trusted_loop_materialization/"
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _rel(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(REPO_ROOT.resolve())).replace("\\", "/")
+    except ValueError:
+        return str(path).replace("\\", "/")
+
+
+def _validate_write_target(path: Path) -> None:
+    normalised = str(path).replace("\\", "/")
+    if _WRITE_PREFIX not in normalised:
+        raise ValueError(
+            "trusted_loop_materialization: refusing write outside "
+            f"allowlist: {path!r}"
+        )
+
+
+def _is_number(value: Any) -> bool:
+    return isinstance(value, int | float) and not isinstance(value, bool)
+
+
+def _numeric_or_none(value: Any) -> int | float | None:
+    return value if _is_number(value) else None
+
+
+def _trusted_loop_metric_values(
+    observability_snapshot: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Return only numeric values already present in evidence.
+
+    Null rates caused by zero denominators are reported as not-ready,
+    not converted to zero.
+    """
+    qre = observability_snapshot.get("qre_operator_summary")
+    qre = qre if isinstance(qre, Mapping) else {}
+    oab = observability_snapshot.get("operator_attention_budget")
+    oab = oab if isinstance(oab, Mapping) else {}
+
+    values: dict[str, dict[str, Any]] = {}
+    for key in (
+        "unknown_failure_rate",
+        "actionable_failure_rate",
+        "attribution_depth_score",
+    ):
+        numeric = _numeric_or_none(qre.get(key))
+        values[key] = {
+            "ready": numeric is not None,
+            "value": numeric,
+            "source": "logs/research_observability_minimal/latest.json",
+            "note": (
+                "evidence_backed"
+                if numeric is not None
+                else "not_ready_zero_denominator_or_missing_evidence"
+            ),
+        }
+
+    for key in (
+        "visible_surfaces_per_campaign_cap",
+        "subjects_observed",
+        "attention_overflow_count",
+        "near_cap_count",
+    ):
+        numeric = _numeric_or_none(oab.get(key))
+        values[f"operator_attention_budget_{key}"] = {
+            "ready": numeric is not None,
+            "value": numeric,
+            "source": "logs/research_observability_minimal/latest.json",
+            "note": "evidence_backed" if numeric is not None else "not_ready",
+        }
+    return values
+
+
+def _research_quality_kpi_readiness(
+    observability_snapshot: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Surface KPI numeric readiness without inventing values.
+
+    Of the seven pinned research-quality KPIs, ADE-QRE-012 can only
+    expose OAB components from the current observability snapshot.
+    The other KPI values require paper-readiness, survivor, null,
+    dead-zone-compute, or robustness evidence that is not present in
+    the current trusted-loop artifacts.
+    """
+    oab = observability_snapshot.get("operator_attention_budget")
+    oab = oab if isinstance(oab, Mapping) else {}
+    oab_components = {
+        key: oab.get(key)
+        for key in (
+            "visible_surfaces_per_campaign_cap",
+            "subjects_observed",
+            "attention_overflow_count",
+            "near_cap_count",
+        )
+        if _is_number(oab.get(key))
+    }
+    readiness = {
+        "TTFPRC": {
+            "status": "not_ready",
+            "value": None,
+            "missing_evidence": "paper_readiness_checklist_overall_yes",
+        },
+        "OOS_DSR": {
+            "status": "not_ready",
+            "value": None,
+            "missing_evidence": "oos_survivor_deflated_sharpe_distribution",
+        },
+        "MASQ": {
+            "status": "not_ready",
+            "value": None,
+            "missing_evidence": "active_survivor_multiplicity_adjusted_sharpe",
+        },
+        "NMBR": {
+            "status": "not_ready",
+            "value": None,
+            "missing_evidence": "promotion_candidate_null_model_results",
+        },
+        "DZCR": {
+            "status": "not_ready",
+            "value": None,
+            "missing_evidence": "dead_zone_compute_telemetry_baseline",
+        },
+        "OAB": {
+            "status": "partial",
+            "value": None,
+            "numeric_components": oab_components,
+            "missing_evidence": "operator_decisions_per_week_component",
+        },
+        "CRSR": {
+            "status": "not_ready",
+            "value": None,
+            "missing_evidence": "promotion_candidate_robustness_checks",
+        },
+    }
+    return {
+        "kpi_ids": list(_observability.RESEARCH_QUALITY_KPI_IDS),
+        "values": readiness,
+        "complete_value_count": sum(
+            1 for row in readiness.values() if row.get("status") == "ready"
+        ),
+        "partial_value_count": sum(
+            1 for row in readiness.values() if row.get("status") == "partial"
+        ),
+        "note": (
+            "No complete seven-KPI numeric value is created without its "
+            "required evidence. OAB components are surfaced because the "
+            "observability snapshot already computes them."
+        ),
+    }
+
+
+def collect_snapshot(
+    *,
+    frozen_utc: str | None = None,
+    reason_records_artifact_dir: Path | None = None,
+    routing_artifact_dir: Path | None = None,
+    sampling_artifact_dir: Path | None = None,
+    observability_artifact_dir: Path | None = None,
+) -> dict[str, Any]:
+    ts = frozen_utc or _utcnow()
+    rr_dir = reason_records_artifact_dir or _rr.ARTIFACT_DIR
+    routing_dir = routing_artifact_dir or _routing.ARTIFACT_DIR
+    sampling_dir = sampling_artifact_dir or _sampling.ARTIFACT_DIR
+    observability_dir = observability_artifact_dir or _observability.ARTIFACT_DIR
+
+    reason_manifest = _rr.collect_manifest(
+        artifact_dir=rr_dir,
+        frozen_utc=ts,
+    )
+    routing_snapshot = _routing.collect_snapshot(
+        candidates=[],
+        frozen_utc=ts,
+        emit_reason_records=False,
+    )
+    sampling_snapshot = _sampling.collect_snapshot(
+        candidates=[],
+        frozen_utc=ts,
+        emit_reason_records=False,
+    )
+    observability_snapshot = _observability.collect_snapshot(
+        routing_minimal_path=routing_dir / _routing.ARTIFACT_LATEST.name,
+        sampling_minimal_path=sampling_dir / _sampling.ARTIFACT_LATEST.name,
+        reason_records_artifact_dir=rr_dir,
+        frozen_utc=ts,
+    )
+    metrics = _trusted_loop_metric_values(observability_snapshot)
+    kpis = _research_quality_kpi_readiness(observability_snapshot)
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": ts,
+        "mode": "dry-run",
+        "safe_to_execute": False,
+        "materialized_artifacts": {
+            "reason_records_manifest": {
+                "path": _rel(rr_dir / _rr.MANIFEST_PATH.name),
+                "total_records": reason_manifest["total_records"],
+                "note": reason_manifest["note"],
+            },
+            "routing_minimal_latest": {
+                "path": _rel(routing_dir / _routing.ARTIFACT_LATEST.name),
+                "total": routing_snapshot["counts"]["total"],
+                "final_recommendation": routing_snapshot["final_recommendation"],
+            },
+            "sampling_minimal_latest": {
+                "path": _rel(sampling_dir / _sampling.ARTIFACT_LATEST.name),
+                "total": sampling_snapshot["counts"]["total"],
+                "final_recommendation": sampling_snapshot["final_recommendation"],
+            },
+            "research_observability_latest": {
+                "path": _rel(observability_dir / _observability.ARTIFACT_LATEST.name),
+                "final_recommendation": observability_snapshot["final_recommendation"],
+            },
+        },
+        "trusted_loop_metric_values": metrics,
+        "research_quality_kpi_readiness": kpis,
+        "failure_action_mapping": (
+            observability_snapshot.get("qre_operator_summary", {})
+            .get("failure_action_mapping", {})
+        ),
+        "synthesis_remains_blocked": True,
+        "block_reasons": [
+            "failure_action_mapping_not_ready_when_total_failures_zero",
+            "no_complete_research_quality_kpi_values",
+            "no_strategy_synthesis_scope_authorized",
+        ],
+        "safety_invariants": {
+            "read_only": True,
+            "emits_reason_records": False,
+            "emits_routing_candidates": False,
+            "emits_sampling_strata": False,
+            "mutates_strategy_or_registry": False,
+            "mutates_frozen_contracts": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+        },
+    }
+
+
+def write_outputs(
+    snapshot: Mapping[str, Any],
+    *,
+    artifact_dir: Path | None = None,
+) -> dict[str, str]:
+    base = artifact_dir or ARTIFACT_DIR
+    ts = str(snapshot["generated_at_utc"]).replace(":", "-")
+    base.mkdir(parents=True, exist_ok=True)
+    json_now = base / f"{ts}.json"
+    json_latest = base / ARTIFACT_LATEST.name
+    history = base / HISTORY.name
+    payload = json.dumps(snapshot, sort_keys=True, indent=2)
+
+    _validate_write_target(json_now)
+    _validate_write_target(json_latest)
+    _validate_write_target(history)
+
+    tmp_now = json_now.with_suffix(json_now.suffix + ".tmp")
+    tmp_now.write_text(payload, encoding="utf-8")
+    os.replace(tmp_now, json_now)
+
+    tmp_latest = json_latest.with_suffix(json_latest.suffix + ".tmp")
+    tmp_latest.write_text(payload, encoding="utf-8")
+    os.replace(tmp_latest, json_latest)
+
+    compact = json.dumps(snapshot, sort_keys=True, separators=(",", ":"))
+    with history.open("a", encoding="utf-8") as handle:
+        handle.write(compact + "\n")
+
+    return {
+        "latest": _rel(json_latest),
+        "timestamped": _rel(json_now),
+        "history": _rel(history),
+    }
+
+
+def materialize(
+    *,
+    frozen_utc: str | None = None,
+    write: bool = True,
+    reason_records_artifact_dir: Path | None = None,
+    routing_artifact_dir: Path | None = None,
+    sampling_artifact_dir: Path | None = None,
+    observability_artifact_dir: Path | None = None,
+    artifact_dir: Path | None = None,
+) -> dict[str, Any]:
+    ts = frozen_utc or _utcnow()
+    rr_dir = reason_records_artifact_dir or _rr.ARTIFACT_DIR
+    routing_dir = routing_artifact_dir or _routing.ARTIFACT_DIR
+    sampling_dir = sampling_artifact_dir or _sampling.ARTIFACT_DIR
+    observability_dir = observability_artifact_dir or _observability.ARTIFACT_DIR
+
+    if write:
+        _rr.write_manifest(artifact_dir=rr_dir, frozen_utc=ts)
+        _routing.write_outputs(
+            _routing.collect_snapshot(
+                candidates=[],
+                frozen_utc=ts,
+                emit_reason_records=False,
+            ),
+            artifact_dir=routing_dir,
+        )
+        _sampling.write_outputs(
+            _sampling.collect_snapshot(
+                candidates=[],
+                frozen_utc=ts,
+                emit_reason_records=False,
+            ),
+            artifact_dir=sampling_dir,
+        )
+
+    snapshot = collect_snapshot(
+        frozen_utc=ts,
+        reason_records_artifact_dir=rr_dir,
+        routing_artifact_dir=routing_dir,
+        sampling_artifact_dir=sampling_dir,
+        observability_artifact_dir=observability_dir,
+    )
+
+    if write:
+        observability_snapshot = _observability.collect_snapshot(
+            routing_minimal_path=routing_dir / _routing.ARTIFACT_LATEST.name,
+            sampling_minimal_path=sampling_dir / _sampling.ARTIFACT_LATEST.name,
+            reason_records_artifact_dir=rr_dir,
+            frozen_utc=ts,
+        )
+        _observability.write_outputs(
+            observability_snapshot,
+            artifact_dir=observability_dir,
+        )
+        snapshot["_artifact_paths"] = write_outputs(snapshot, artifact_dir=artifact_dir)
+    return snapshot
+
+
+def read_latest_snapshot(
+    *,
+    artifact_dir: Path | None = None,
+) -> dict[str, Any] | None:
+    base = artifact_dir or ARTIFACT_DIR
+    path = base / ARTIFACT_LATEST.name
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="reporting.trusted_loop_materialization",
+        description="Materialize ADE-QRE-012 read-only trusted-loop artifacts.",
+    )
+    parser.add_argument("--no-write", action="store_true")
+    parser.add_argument("--status", action="store_true")
+    parser.add_argument("--frozen-utc", type=str, default=None)
+    args = parser.parse_args(argv)
+
+    if args.status:
+        snapshot = read_latest_snapshot()
+        if snapshot is None:
+            snapshot = {
+                "schema_version": SCHEMA_VERSION,
+                "module_version": MODULE_VERSION,
+                "report_kind": REPORT_KIND,
+                "final_recommendation": "not_available",
+            }
+        print(json.dumps(snapshot, sort_keys=True, indent=2))
+        return 0
+
+    snapshot = materialize(
+        frozen_utc=args.frozen_utc,
+        write=not args.no_write,
+    )
+    print(json.dumps(snapshot, sort_keys=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_reason_records.py
+++ b/tests/unit/test_reason_records.py
@@ -427,6 +427,23 @@ def test_collect_manifest_empty_returns_no_records_note(tmp_path: Path) -> None:
     assert m["by_kind"] == {"routing": 0, "sampling": 0, "scoring": 0}
 
 
+def test_write_manifest_materialises_empty_manifest_without_records(
+    tmp_path: Path,
+) -> None:
+    base = tmp_path / "logs" / "reason_records"
+    manifest = rr.write_manifest(
+        artifact_dir=base,
+        frozen_utc="2026-05-21T01:00:00Z",
+    )
+    manifest_path = base / "manifest.v1.json"
+    assert manifest_path.is_file()
+    assert manifest["total_records"] == 0
+    assert manifest["note"] == "no_records"
+    assert not (base / "routing_v1.jsonl").exists()
+    persisted = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert persisted == manifest
+
+
 # ---------------------------------------------------------------------------
 # Reader purity + execution-import deny (RR-I7, RR-I9)
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_research_observability_minimal.py
+++ b/tests/unit/test_research_observability_minimal.py
@@ -150,6 +150,13 @@ def test_snapshot_top_level_keys_when_sources_absent(tmp_path: Path) -> None:
         sampling_minimal_path=tmp_path / "no_sampling.json",
         reason_records_artifact_dir=tmp_path / "no_reason_records",
         kpi_doc_path=tmp_path / "no_kpi.md",
+        screening_failure_attribution_path=tmp_path / "no_screening.json",
+        failure_action_mapping_path=tmp_path / "no_actions.json",
+        data_manifest_path=tmp_path / "no_manifest.json",
+        source_quality_path=tmp_path / "no_quality.json",
+        research_memory_path=tmp_path / "no_memory.json",
+        research_diagnostics_loop_path=tmp_path / "no_diagnostics.json",
+        ade_queue_doc_path=tmp_path / "no_queue.md",
         frozen_utc="2026-05-21T00:00:00Z",
     )
     expected = {

--- a/tests/unit/test_trusted_loop_materialization.py
+++ b/tests/unit/test_trusted_loop_materialization.py
@@ -1,0 +1,221 @@
+"""Tests for ADE-QRE-012 trusted-loop materialization."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from reporting import trusted_loop_materialization as tlm
+
+
+FROZEN = "2026-05-23T00:00:00Z"
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=True, indent=2), encoding="utf-8")
+
+
+def _seed_operator_sources(tmp_path: Path) -> dict[str, Path]:
+    screening = tmp_path / "research" / "screening_failure_attribution_latest.v1.json"
+    failure_actions = tmp_path / "logs" / "failure_action_mapping_minimal" / "latest.json"
+    data_manifest = tmp_path / "logs" / "qre_data_cache_manifest" / "latest.json"
+    source_quality = tmp_path / "logs" / "qre_data_source_quality_readiness" / "latest.json"
+    memory = tmp_path / "logs" / "qre_research_memory" / "latest.json"
+    diagnostics = tmp_path / "logs" / "qre_research_diagnostics_loop" / "latest.json"
+    queue = tmp_path / "docs" / "governance" / "queue.md"
+
+    _write_json(
+        screening,
+        {
+            "summary": {
+                "observation_count": 2,
+                "unknown_observation_count": 0,
+                "primary_classification": "insufficient_trades",
+            },
+            "recommended_next_action": "increase_timeframe",
+            "classifications": [
+                {
+                    "classification": "insufficient_trades",
+                    "count": 2,
+                    "sources": ["run_filter_summary"],
+                    "raw_reasons": {"insufficient_trades": 2},
+                    "action_hint": {"action": "increase_timeframe"},
+                }
+            ],
+        },
+    )
+    _write_json(
+        failure_actions,
+        {
+            "counts": {"total": 0, "actionable_recommendations": 0},
+            "final_recommendation": "nothing_actionable",
+        },
+    )
+    _write_json(data_manifest, {"summary": {"research_ready": True}})
+    _write_json(source_quality, {"summary": {"research_ready": True}})
+    _write_json(
+        memory,
+        {
+            "summary": {"research_memory_ready": True, "entry_count": 1},
+            "entries": [{"ontology_tags": ["failure"]}],
+        },
+    )
+    _write_json(
+        diagnostics,
+        {
+            "summary": {
+                "status": "ready",
+                "diagnostic_count": 1,
+                "recommended_operator_step": "inspect_next_diagnostic",
+                "blocking_reasons": [],
+            }
+        },
+    )
+    queue.parent.mkdir(parents=True, exist_ok=True)
+    queue.write_text("- queue id: `ADE-QRE-008`\n- status: `done`\n", encoding="utf-8")
+    return {
+        "screening_failure_attribution_path": screening,
+        "failure_action_mapping_path": failure_actions,
+        "data_manifest_path": data_manifest,
+        "source_quality_path": source_quality,
+        "research_memory_path": memory,
+        "research_diagnostics_loop_path": diagnostics,
+        "ade_queue_doc_path": queue,
+    }
+
+
+def test_materialize_writes_empty_evidence_artifacts_without_reason_records(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    sources = _seed_operator_sources(tmp_path)
+    monkeypatch.setattr(
+        tlm._observability,
+        "SCREENING_FAILURE_ATTRIBUTION_LATEST",
+        sources["screening_failure_attribution_path"],
+    )
+    monkeypatch.setattr(
+        tlm._observability,
+        "FAILURE_ACTION_MAPPING_LATEST",
+        sources["failure_action_mapping_path"],
+    )
+    monkeypatch.setattr(
+        tlm._observability,
+        "QRE_DATA_MANIFEST_LATEST",
+        sources["data_manifest_path"],
+    )
+    monkeypatch.setattr(
+        tlm._observability,
+        "QRE_SOURCE_QUALITY_LATEST",
+        sources["source_quality_path"],
+    )
+    monkeypatch.setattr(
+        tlm._observability,
+        "QRE_RESEARCH_MEMORY_LATEST",
+        sources["research_memory_path"],
+    )
+    monkeypatch.setattr(
+        tlm._observability,
+        "QRE_RESEARCH_DIAGNOSTICS_LOOP_LATEST",
+        sources["research_diagnostics_loop_path"],
+    )
+    monkeypatch.setattr(tlm._observability, "ADE_QUEUE_DOC", sources["ade_queue_doc_path"])
+
+    rr_dir = tmp_path / "logs" / "reason_records"
+    routing_dir = tmp_path / "logs" / "intelligent_routing_minimal"
+    sampling_dir = tmp_path / "logs" / "sampling_intelligence_minimal"
+    observability_dir = tmp_path / "logs" / "research_observability_minimal"
+    materialization_dir = tmp_path / "logs" / "trusted_loop_materialization"
+
+    snapshot = tlm.materialize(
+        frozen_utc=FROZEN,
+        reason_records_artifact_dir=rr_dir,
+        routing_artifact_dir=routing_dir,
+        sampling_artifact_dir=sampling_dir,
+        observability_artifact_dir=observability_dir,
+        artifact_dir=materialization_dir,
+    )
+
+    assert (rr_dir / "manifest.v1.json").is_file()
+    assert not (rr_dir / "routing_v1.jsonl").exists()
+    assert not (rr_dir / "sampling_v1.jsonl").exists()
+    assert (routing_dir / "latest.json").is_file()
+    assert (sampling_dir / "latest.json").is_file()
+    assert (observability_dir / "latest.json").is_file()
+    assert (materialization_dir / "latest.json").is_file()
+    assert snapshot["materialized_artifacts"]["reason_records_manifest"]["total_records"] == 0
+    assert snapshot["materialized_artifacts"]["routing_minimal_latest"]["total"] == 0
+    assert snapshot["materialized_artifacts"]["sampling_minimal_latest"]["total"] == 0
+    assert snapshot["failure_action_mapping"]["status"] == "not_ready"
+    assert snapshot["failure_action_mapping"]["total_failures"] == 0
+    assert snapshot["synthesis_remains_blocked"] is True
+
+
+def test_collect_snapshot_surfaces_only_evidence_backed_numeric_values(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    sources = _seed_operator_sources(tmp_path)
+    monkeypatch.setattr(
+        tlm._observability,
+        "SCREENING_FAILURE_ATTRIBUTION_LATEST",
+        sources["screening_failure_attribution_path"],
+    )
+    monkeypatch.setattr(
+        tlm._observability,
+        "FAILURE_ACTION_MAPPING_LATEST",
+        sources["failure_action_mapping_path"],
+    )
+    monkeypatch.setattr(
+        tlm._observability,
+        "QRE_DATA_MANIFEST_LATEST",
+        sources["data_manifest_path"],
+    )
+    monkeypatch.setattr(
+        tlm._observability,
+        "QRE_SOURCE_QUALITY_LATEST",
+        sources["source_quality_path"],
+    )
+    monkeypatch.setattr(
+        tlm._observability,
+        "QRE_RESEARCH_MEMORY_LATEST",
+        sources["research_memory_path"],
+    )
+    monkeypatch.setattr(
+        tlm._observability,
+        "QRE_RESEARCH_DIAGNOSTICS_LOOP_LATEST",
+        sources["research_diagnostics_loop_path"],
+    )
+    monkeypatch.setattr(tlm._observability, "ADE_QUEUE_DOC", sources["ade_queue_doc_path"])
+
+    snapshot = tlm.collect_snapshot(
+        frozen_utc=FROZEN,
+        reason_records_artifact_dir=tmp_path / "logs" / "reason_records",
+        routing_artifact_dir=tmp_path / "logs" / "intelligent_routing_minimal",
+        sampling_artifact_dir=tmp_path / "logs" / "sampling_intelligence_minimal",
+        observability_artifact_dir=tmp_path / "logs" / "research_observability_minimal",
+    )
+    metrics = snapshot["trusted_loop_metric_values"]
+    assert metrics["unknown_failure_rate"]["ready"] is True
+    assert metrics["unknown_failure_rate"]["value"] == 0.0
+    assert metrics["attribution_depth_score"]["ready"] is True
+    assert metrics["attribution_depth_score"]["value"] == 1.0
+    assert metrics["actionable_failure_rate"]["ready"] is False
+    assert metrics["actionable_failure_rate"]["value"] is None
+
+    kpis = snapshot["research_quality_kpi_readiness"]
+    assert kpis["values"]["OAB"]["status"] == "partial"
+    assert kpis["values"]["TTFPRC"]["status"] == "not_ready"
+    assert kpis["complete_value_count"] == 0
+
+
+def test_write_outputs_refuses_outside_allowlist(tmp_path: Path) -> None:
+    bad = tmp_path / "elsewhere" / "latest.json"
+    bad.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        tlm._validate_write_target(bad)
+    except ValueError as exc:
+        assert "outside allowlist" in str(exc)
+    else:
+        raise AssertionError("expected outside-allowlist refusal")


### PR DESCRIPTION
## Summary
- add ADE-QRE-012 trusted-loop materialization helper for reason-records manifest, routing latest, sampling latest, refreshed observability, and materialization digest
- materialize empty/no-record evidence without emitting synthetic reason records, routing candidates, or sampling strata
- surface only evidence-backed trusted-loop numeric values and partial OAB KPI components; keep failure_action_mapping not_ready when total_failures=0
- make existing status readers respect patched latest paths so tests remain hermetic once local logs are materialized

## Scope guardrails
- no strategy code
- no registry.py changes
- no paper/shadow/live
- no broker/risk/execution changes
- no frozen contract mutations

## Validation
- python -m pytest tests/unit/test_reason_records.py tests/unit/test_intelligent_routing_minimal.py tests/unit/test_sampling_intelligence_minimal.py tests/unit/test_research_observability_minimal.py tests/unit/test_trusted_loop_materialization.py -q
- python -m json.tool logs/reason_records/manifest.v1.json
- python -m json.tool logs/intelligent_routing_minimal/latest.json
- python -m json.tool logs/sampling_intelligence_minimal/latest.json
- python -m json.tool logs/research_observability_minimal/latest.json
- python -m json.tool logs/trusted_loop_materialization/latest.json
- git diff --check
- python -m reporting.architecture_import_scan --format summary (forbidden_edge_count=0)
- frozen hashes unchanged: research_latest.json 4A567BD6FEB98EB7AA32DB4A90A3201456843088314936C5E484A2AE6A93666C; strategy_matrix.csv FF15B8C4F35CC37B6941B712106AE71A1B82A1B5043DA197731D42518D258D66