### PR TITLE
docs: add ADE-QRE-013 trusted loop maturity addendum

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -8,6 +8,7 @@
 > `docs/architecture/PACKAGE-MIGRATION-010-package-migration-closure-decision.md`.
 >
 > This document does not activate Addendum 1, Addendum 2, Addendum 3,
+> Addendum 4,
 > v4.x Shadow, v5.x Paper, v6.x Live, or any live/paper/shadow/risk/broker/
 > execution behavior. It also does not update `docs/development_work_queue/seed.jsonl`.
 
@@ -16,7 +17,7 @@
 - Work starts from the post-package QRE Feature Build Track.
 - `QRE_ADE_How_To_Target_State_Roadmap.md` is the queue's primary product/research source.
 - The first executable item must improve research evidence or diagnostics before any strategy synthesis.
-- Addendum 1, Addendum 2, and Addendum 3 remain reference-only unless a future operator-approved ADR activates a specific subsection.
+- Addendum 1, Addendum 2, Addendum 3, and Addendum 4 remain reference-only unless a future operator-approved ADR activates a specific subsection.
 - Frozen contracts stay unchanged: `research/research_latest.json`, `research/strategy_matrix.csv`, frozen schemas, and regression pins.
 - The architecture scanner must keep `forbidden_edge_count = 0`.
 - Transcript and weekly files remain untracked and out of commits.
@@ -235,5 +236,61 @@
   - ADE-QRE-011 defined with explicit allowed scope, forbidden scope,
     promote/defer/block criteria, stop conditions, tests, and merge criteria.
   - validation commands pass, with scanner `forbidden_edge_count=0`.
+- expected next queue item: `ADE-QRE-013`.
+
+### ADE-QRE-013 - Trusted Loop Maturity Matrix and Roadmap v6 Addendum 4
+
+- queue id: `ADE-QRE-013`
+- status: `ready`
+- goal: document that the trusted-loop foundation exists, but is still
+  scaffold/readiness evidence rather than operator-trusted research capability.
+- addendum record:
+  `docs/roadmap/Roadmap v6 Addendum 4 - Trusted Loop Readiness and Operator Trust.md`.
+- sequencing note: the local work queue has no committed `ADE-QRE-012` entry at
+  the time this docs-only item is added. `ADE-QRE-013` is therefore appended as
+  the next available queue entry without backfilling or inventing `ADE-QRE-012`
+  scope.
+- allowed scope: documentation only; maturity matrix; readiness taxonomy;
+  operator-trust gates; missing-evidence inventory; safe next docs/readiness
+  queue candidates.
+- forbidden scope: runtime functionality, strategy synthesis, strategy
+  implementations, `registry.py`, research output mutation, tests unless docs
+  lint requires them, logs, generated artifacts, frozen contracts,
+  paper/shadow/live, broker/risk/execution, Addendum runtime activation, and
+  broad refactors.
+- current maturity finding:
+  - ADE-QRE-001 through ADE-QRE-007 established trusted-loop scaffolding and
+    read-only diagnostics/observability surfaces.
+  - ADE-QRE-008 and ADE-QRE-011 established readiness decisions and gates, not
+    strategy authority.
+  - ADE-QRE-012 has no committed queue record in this branch and contributes no
+    maturity credit.
+  - strategy synthesis remains blocked.
+- missing evidence:
+  - reason records are 0.
+  - routing snapshot has 0 ready items.
+  - sampling snapshot has 0 ready items.
+  - KPI numeric values are incomplete.
+  - `failure_action_mapping` has no actionable failures.
+  - approved strategies are 0.
+  - no paper-ready candidate exists.
+- safe next queue candidates: docs/readiness-only evidence inventory,
+  operator-trust checklist, KPI completeness decision record, and
+  reason-record/routing/sampling readiness audit. None may implement runtime
+  behavior or activate strategy synthesis.
+- tests/validation:
+  - `git diff --check`
+  - `python -m reporting.architecture_import_scan --format summary`
+  - `git status --short`
+- merge criteria:
+  - exactly docs-only diff for this item.
+  - Addendum 4 is marked `DEFERRED / REFERENCE-ONLY`.
+  - Addendum 1, Addendum 2, Addendum 3, and Addendum 4 remain inactive.
+  - no strategy synthesis, registry, strategy, frozen contract, research output,
+    paper/shadow/live, broker/risk/execution, log, or generated artifact file is
+    changed.
+  - validation commands pass, with scanner `forbidden_edge_count=0`.
+- operator review required: yes. This item documents readiness limits and must
+  not be used as implementation authorization.
 - expected next queue item: none unless the operator explicitly approves a
-  future scoped item.
+  future docs/readiness-only item.

--- a/docs/roadmap/Roadmap v6 Addendum 4 - Trusted Loop Readiness and Operator Trust.md
+++ b/docs/roadmap/Roadmap v6 Addendum 4 - Trusted Loop Readiness and Operator Trust.md
@@ -1,0 +1,145 @@
+# Roadmap v6 Addendum 4
+## Trusted Loop Readiness and Operator Trust
+
+## Execution Status (as of 2026-05-23)
+
+Status: **DEFERRED / REFERENCE-ONLY**
+
+Implementation-scope sections: **NOT ACTIVE**
+
+This addendum is a documentation and readiness reference only. It does not
+activate Addendum 1, Addendum 2, Addendum 3, Addendum 4, strategy synthesis,
+paper, shadow, live, broker, risk, execution, dashboard mutation, source
+activation, registry changes, strategy files, frozen contract changes, or any
+runtime behavior.
+
+Addendum 1, Addendum 2, and Addendum 3 remain **DEFERRED / REFERENCE-ONLY**
+unless an explicit future operator-approved ADR activates a specific subsection.
+This Addendum 4 is subject to the same rule.
+
+## 1. Purpose
+
+The ADE-QRE trusted-loop foundation now exists as a set of read-only governance,
+diagnostic, data-readiness, memory, and observability surfaces. That foundation
+is not yet operator-trusted research capability.
+
+This addendum documents the maturity distinction:
+
+- **Scaffold:** a deterministic structure, contract, digest, or governance
+  record exists, but it has not yet demonstrated that it changes research
+  outcomes or operator decisions.
+- **Working capability:** the scaffold produces complete, current, and
+  reproducible evidence on real research inputs, with non-empty records where
+  the capability claims coverage.
+- **Operator-trusted capability:** the working capability has been reviewed by
+  the operator, has demonstrated decision usefulness, has known failure modes,
+  and has explicit promote/defer/block criteria.
+
+The current state is scaffold-heavy. It is not permission to synthesize
+strategies.
+
+## 2. Strategy Synthesis Block
+
+Strategy synthesis remains blocked.
+
+No item in ADE-QRE-001 through ADE-QRE-013 authorizes:
+
+- writing or modifying strategy implementations;
+- changing `registry.py`;
+- generating executable strategy code;
+- mutating research outputs;
+- activating paper, shadow, live, broker, risk, or execution paths;
+- treating retrieval, diagnostics, source quality, routing, sampling, or
+  observability as trading authority.
+
+Any future strategy-synthesis implementation item requires a separate explicit
+operator decision after the promotion gates in this addendum are satisfied.
+
+## 3. Maturity Matrix
+
+| Queue item | Current maturity | Classification rationale |
+|---|---|---|
+| ADE-QRE-001 - Unknown Failure Reduction | Scaffold | Failure classification structure exists, but current reason-record evidence is empty. |
+| ADE-QRE-002 - Screening Failure Attribution Depth | Scaffold | Action mapping doctrine exists, but `failure_action_mapping` has no actionable failures. |
+| ADE-QRE-003 - Data Foundation Manifest and Coverage | Working capability | Data-readiness surfaces report ready state, but operator trust still depends on downstream decision usefulness. |
+| ADE-QRE-004 - Source Identity and Quality Readiness | Working capability | Source-quality readiness can support research gating, but does not authorize new source activation or alpha claims. |
+| ADE-QRE-005 - Research Memory v1 | Scaffold | Read-only memory/retrieval structure exists, but it is context only and not authority. |
+| ADE-QRE-006 - Research Diagnostics Loop | Scaffold | Digest structure exists, but no non-empty failure-to-action loop has demonstrated decision impact. |
+| ADE-QRE-007 - Operator-Grade Observability | Scaffold | Operator-facing summary exists, but KPI numeric completeness and ready-item evidence are incomplete. |
+| ADE-QRE-008 - Strategy Synthesis Readiness Gate | Scaffold | Readiness gate exists and explicitly blocks implementation until evidence gaps close. |
+| ADE-QRE-009 | No maturity credit | No committed queue item is present in the current work queue. |
+| ADE-QRE-010 | No maturity credit | No committed queue item is present in the current work queue. |
+| ADE-QRE-011 - Bounded Strategy Synthesis Readiness Item | Scaffold | Docs/governance readiness criteria exist, but they do not authorize strategy synthesis. |
+| ADE-QRE-012 | No maturity credit | No committed queue item is present in the current work queue. |
+
+ADE-QRE-013 adds this maturity matrix and readiness addendum only. It does not
+move any prior item to operator-trusted capability.
+
+## 4. Promotion Gates
+
+### 4.1 Scaffold to Working Capability
+
+A scaffold may be promoted to working capability only when all of the following
+are true:
+
+- the relevant artifact or digest is materialized from current repository data;
+- outputs are deterministic and reproducible;
+- schemas are stable or explicitly versioned;
+- stale, missing, or empty upstream evidence fails closed;
+- the capability has non-empty records where it claims operational coverage;
+- validation preserves `forbidden_edge_count=0`;
+- no frozen contract, strategy, registry, paper, shadow, live, broker, risk, or
+  execution file is changed as part of the promotion.
+
+### 4.2 Working Capability to Operator-Trusted Capability
+
+A working capability may be promoted to operator-trusted only when all of the
+following are true:
+
+- the operator reviews the evidence pack and records an explicit decision;
+- the capability changes at least one research decision, stop decision, or
+  diagnostic priority in a reproducible way;
+- failure modes and stale-data behavior are documented;
+- KPI values are complete enough for the claimed decision;
+- there is a clear promote/defer/block rule for subsequent work;
+- the capability remains read-only unless a separate operator-approved ADR grants
+  narrower runtime authority.
+
+## 5. Missing Evidence
+
+The following evidence is still missing or incomplete:
+
+- reason records are 0;
+- routing snapshot has 0 ready items;
+- sampling snapshot has 0 ready items;
+- KPI numeric values are incomplete;
+- `failure_action_mapping` has no actionable failures;
+- approved strategies are 0;
+- no paper-ready candidate exists.
+
+These gaps mean the trusted-loop foundation has not yet reached
+operator-trusted research capability.
+
+## 6. Safe Next Queue Candidates
+
+The only safe next queue candidates are docs/readiness items. Examples:
+
+- reason-record evidence inventory;
+- routing and sampling readiness audit;
+- KPI numeric completeness decision record;
+- operator-trust checklist for a single read-only capability;
+- paper-readiness gap inventory confirming that no candidate is paper-ready.
+
+These candidates must not implement runtime functionality, mutate artifacts, add
+strategy code, change `registry.py`, activate deferred addendums, or open
+paper/shadow/live/risk/broker/execution paths.
+
+## 7. Invariants
+
+- Addendum 4 is deferred/reference-only.
+- Addendum 1, Addendum 2, and Addendum 3 remain deferred/reference-only unless
+  explicitly activated later by operator-approved ADR.
+- Strategy synthesis remains blocked.
+- The trusted loop is evidence infrastructure, not strategy authority.
+- Operator trust must be earned from complete, reproducible, non-empty evidence,
+  not inferred from the presence of scaffolding.


### PR DESCRIPTION
## Summary
- Add ADE-QRE-013 as a docs-only Trusted Loop Maturity Matrix queue item.
- Add Roadmap v6 Addendum 4 as DEFERRED / REFERENCE-ONLY documentation.
- Document scaffold vs working capability vs operator-trusted capability, missing evidence, and docs/readiness-only safe next candidates.
- Reaffirm that strategy synthesis and Addendum 1/2/3/4 runtime activation remain blocked.

## Validation
- git diff --check: passed
- python -m reporting.architecture_import_scan --format summary: passed, forbidden_edge_count=0, legacy_edge_count=76
- git status --short: clean

## Operator review
Required. This PR is documentation/readiness only and does not authorize runtime functionality or strategy synthesis.