### PR TITLE
fix: run gitleaks without licensed action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -112,11 +112,14 @@ jobs:
       - name: Run gitleaks
         env:
           BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         run: |
           set -euo pipefail
           if [ -z "${BASE_SHA}" ] || [ "${BASE_SHA}" = "0000000000000000000000000000000000000000" ]; then
-            log_opts="--all"
+            base_ref="origin/${DEFAULT_BRANCH}"
+            base_sha="$(git merge-base HEAD "${base_ref}")"
+            log_opts="${base_sha}..${HEAD_SHA}"
           else
             log_opts="${BASE_SHA}..${HEAD_SHA}"
           fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,22 +91,36 @@ jobs:
   secret-scan:
     name: secret-scan (gitleaks)
     runs-on: ubuntu-latest
-    # gitleaks-action calls GET /repos/{owner}/{repo}/pulls/{n}/commits
-    # on pull_request events. The default workflow-level
-    # `contents: read` does not include `pull-requests: read`, so the
-    # action errors with "Resource not accessible by integration".
-    # Grant only the minimum required scopes at the job level.
     permissions:
       contents: read
-      pull-requests: read
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
         with:
           fetch-depth: 0  # gitleaks needs full history for diff mode
-      - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7  # v2.3.9
+      - name: Install gitleaks CLI
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_SHA256: 551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
+          GITLEAKS_VERSION: 8.30.1
+        run: |
+          set -euo pipefail
+          archive="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          curl -sSfL -o "${archive}" "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${archive}"
+          echo "${GITLEAKS_SHA256}  ${archive}" | sha256sum -c -
+          tar -xzf "${archive}" gitleaks
+          sudo install -m 0755 gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+      - name: Run gitleaks
+        env:
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          if [ -z "${BASE_SHA}" ] || [ "${BASE_SHA}" = "0000000000000000000000000000000000000000" ]; then
+            log_opts="--all"
+          else
+            log_opts="${BASE_SHA}..${HEAD_SHA}"
+          fi
+          gitleaks git --config .gitleaks.toml --log-opts="${log_opts}" --redact --verbose .
 
   # ---------------------------------------------------------------------------
   # typecheck — mypy on the narrow scope defined in pyproject.toml.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -118,7 +118,7 @@ jobs:
           set -euo pipefail
           if [ -z "${BASE_SHA}" ] || [ "${BASE_SHA}" = "0000000000000000000000000000000000000000" ]; then
             base_ref="origin/${DEFAULT_BRANCH}"
-            base_sha="$(git merge-base HEAD "${base_ref}")"
+            base_sha="$(git show-branch --merge-base HEAD "${base_ref}")"
             log_opts="${base_sha}..${HEAD_SHA}"
           else
             log_opts="${BASE_SHA}..${HEAD_SHA}"


### PR DESCRIPTION
## Summary
- replace licensed `gitleaks/gitleaks-action` invocation with the OSS Gitleaks CLI
- pin Gitleaks to v8.30.1 and verify the Linux x64 release SHA-256 before install
- preserve diff-based scanning for PRs and pushes using `.gitleaks.toml`

## Validation
- YAML parse: ok
- `git diff --check`: ok
- local `gitleaks git --config .gitleaks.toml --log-opts='origin/main..HEAD' --redact --verbose .` with v8.30.1: no leaks found

## Scope
CI/tooling only. No strategy, registry, frozen contract, paper/shadow/live, broker/risk/execution changes.
