### PR TITLE
feat: add reason record evidence density reporting

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -387,7 +387,7 @@
 ### ADE-QRE-014B - Reason-Record Evidence Density
 
 - queue id: `ADE-QRE-014B`
-- status: `blocked until ADE-QRE-014A done`
+- status: `in_progress`
 - title: Reason-Record Evidence Density.
 - purpose: improve trusted-loop reason-record evidence density so ADE/QRE
   decisions are more inspectable, measurable, and operator-readable before
@@ -413,6 +413,10 @@
 - allowed changes:
   - deterministic read-only reason-record inventory, schema completion, density
     metrics, fail-closed missing evidence status, and focused tests.
+- active implementation note:
+  - 014A is done on `main`; 014B implementation is limited to read-only
+    reporting sidecars, reason/evidence density inspection, focused tests, and
+    this queue status update.
 - forbidden changes:
   - campaign mutation, routing mutation, strategy generation, registry edits,
     research output mutation, Addendum activation, dashboard mutation routes,

--- a/docs/governance/reason_record_evidence_density.md
+++ b/docs/governance/reason_record_evidence_density.md
@@ -1,0 +1,56 @@
+# Reason Record Evidence Density
+
+> Status: ADE-QRE-014B read-only reporting sidecar.
+>
+> Module: `reporting.reason_record_evidence_density`.
+>
+> Scope: inspect reason-record and adjacent decision sidecars for
+> operator-readable reasons and bounded evidence references. This sidecar does
+> not append reason records, mutate campaigns, enable strategy synthesis, or
+> touch frozen research outputs.
+
+## Purpose
+
+The trusted loop needs reason records that an operator can inspect without
+reading source code. This reporter counts whether current reason surfaces have:
+
+- structured `reason_codes`;
+- bounded `reason_text`;
+- explicit `evidence_refs`;
+- an operator-readable summary.
+
+Missing or empty evidence references fail closed with
+`not_ready_missing_evidence_refs`. No record inventory fails closed with
+`not_ready_no_reason_records`.
+
+## Inputs
+
+The reporter reads existing sidecars only:
+
+- `logs/reason_records/*.jsonl`;
+- `logs/intelligent_routing_minimal/latest.json`;
+- `logs/sampling_intelligence_minimal/latest.json`;
+- `logs/failure_action_mapping_minimal/latest.json`;
+- `research/synthesis_gate_latest.v1.json` as reference-only synthesis-gate
+  evidence.
+
+The synthesis gate remains blocked/reference-only. The reporter does not call
+or activate synthesis behavior.
+
+## Output
+
+Run:
+
+```text
+python -m reporting.reason_record_evidence_density --no-write
+```
+
+The optional write mode stores a deterministic sidecar under:
+
+```text
+logs/reason_record_evidence_density/latest.json
+```
+
+The output includes `baseline_without_sidecars` and `after_with_sidecars` so
+operators can see the density lift provided by bounded sidecar evidence
+references without changing the strict reason-record JSONL schema.

--- a/reporting/failure_action_mapping_minimal.py
+++ b/reporting/failure_action_mapping_minimal.py
@@ -93,6 +93,7 @@ REASON_RECORD_KEYS: Final[tuple[str, ...]] = (
     "record_kind",
     "schema_version",
     "subject_id",
+    "evidence_refs",
     "failure_code",
     "recommended_action",
     "reason_codes",
@@ -211,6 +212,17 @@ def compute_record_id(
     return "fam_" + h.hexdigest()[:16]
 
 
+def _evidence_refs_for_failure() -> list[str]:
+    return [
+        "failure_input.subject_id",
+        "failure_input.failure_code",
+        "failure_input.severity",
+        "failure_input.evidence_count",
+        "policy.min_evidence_for_research_action",
+        "mapping.action_by_failure_code",
+    ]
+
+
 # ---------------------------------------------------------------------------
 # Validation
 # ---------------------------------------------------------------------------
@@ -298,6 +310,7 @@ def _build_reason_record(
     evidence_count: int,
     recommended_action: str,
 ) -> dict[str, Any]:
+    evidence_refs = _evidence_refs_for_failure()
     inputs_payload = {
         "subject_id": subject_id,
         "failure_code": failure_code,
@@ -305,6 +318,7 @@ def _build_reason_record(
         "evidence_count": evidence_count,
         "recommended_action": recommended_action,
         "min_evidence_for_research_action": MIN_EVIDENCE_FOR_RESEARCH_ACTION,
+        "evidence_refs": evidence_refs,
     }
     digest = compute_inputs_digest(inputs_payload)
     reason_codes, reason_text = _reason_for(
@@ -317,6 +331,7 @@ def _build_reason_record(
         "record_kind": "failure_action_mapping_reason",
         "schema_version": SCHEMA_VERSION,
         "subject_id": subject_id,
+        "evidence_refs": evidence_refs,
         "failure_code": failure_code,
         "recommended_action": recommended_action,
         "reason_codes": reason_codes,
@@ -496,8 +511,7 @@ def write_outputs(
 
 
 def read_latest_snapshot(*, artifact_dir: Path | None = None) -> dict[str, Any] | None:
-    base = artifact_dir or ARTIFACT_DIR
-    path = base / ARTIFACT_LATEST.name
+    path = (artifact_dir / ARTIFACT_LATEST.name) if artifact_dir else ARTIFACT_LATEST
     if not path.is_file():
         return None
     try:

--- a/reporting/intelligent_routing_minimal.py
+++ b/reporting/intelligent_routing_minimal.py
@@ -139,6 +139,7 @@ INPUT_CANDIDATE_KEYS: Final[tuple[str, ...]] = (
 OUTPUT_CANDIDATE_KEYS: Final[tuple[str, ...]] = (
     "campaign_id",
     "decision",
+    "evidence_refs",
     "priority_score",
     "rank",
     "reason_codes",
@@ -199,6 +200,19 @@ def _rel(p: Path) -> str:
         return str(p.relative_to(REPO_ROOT)).replace("\\", "/")
     except ValueError:
         return str(p).replace("\\", "/")
+
+
+def _evidence_refs_for_candidate() -> list[str]:
+    """Stable sidecar references that explain the routing decision inputs."""
+    return [
+        "candidate.campaign_id",
+        "candidate.info_gain_estimate",
+        "candidate.dead_zone_dwell",
+        "candidate.dependency_unmet",
+        "candidate.multiplicity_budget_remaining",
+        "thresholds.dead_zone_dwell_threshold",
+        "thresholds.low_info_gain_threshold",
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -379,6 +393,8 @@ def collect_snapshot(
             "dead_zone_threshold": dead_zone_threshold,
             "low_info_threshold": low_info_threshold,
         }
+        evidence_refs = _evidence_refs_for_candidate()
+        inputs_payload["evidence_refs"] = evidence_refs
         record = _rr.build_record(
             decision_kind=_rr.DECISION_KIND_ROUTING,
             subject_id=str(c["campaign_id"]),
@@ -396,6 +412,7 @@ def collect_snapshot(
             {
                 "campaign_id": str(c["campaign_id"]),
                 "decision": decision,
+                "evidence_refs": evidence_refs,
                 "priority_score": round(score, 6),
                 "rank": -1,
                 "reason_codes": list(reason_codes),

--- a/reporting/reason_record_evidence_density.py
+++ b/reporting/reason_record_evidence_density.py
@@ -1,0 +1,500 @@
+"""Read-only reason-record evidence-density reporter.
+
+ADE-QRE-014B sidecar. The module inspects existing reason/evidence
+surfaces and reports whether operator-readable reason records carry
+bounded evidence references. It never appends reason records, mutates
+campaigns, enables synthesis, or touches frozen research outputs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import hashlib
+import json
+import os
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+from reporting import failure_action_mapping_minimal as _fam
+from reporting import intelligent_routing_minimal as _routing
+from reporting import reason_records as _rr
+from reporting import sampling_intelligence_minimal as _sampling
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+MODULE_VERSION: Final[str] = "ade-qre-014b-2026-05-24"
+SCHEMA_VERSION: Final[int] = 1
+REPORT_KIND: Final[str] = "reason_record_evidence_density"
+
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "reason_record_evidence_density"
+ARTIFACT_LATEST: Final[Path] = ARTIFACT_DIR / "latest.json"
+HISTORY: Final[Path] = ARTIFACT_DIR / "history.jsonl"
+_WRITE_PREFIX: Final[str] = "logs/reason_record_evidence_density/"
+
+SYNTHESIS_GATE_LATEST: Final[Path] = (
+    REPO_ROOT / "research" / "synthesis_gate_latest.v1.json"
+)
+MAX_THIN_RECORDS: Final[int] = 16
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _rel(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(REPO_ROOT.resolve())).replace("\\", "/")
+    except ValueError:
+        return str(path).replace("\\", "/")
+
+
+def _validate_write_target(path: Path) -> None:
+    normalised = str(path).replace("\\", "/")
+    if _WRITE_PREFIX not in normalised:
+        raise ValueError(
+            "reason_record_evidence_density: refusing write outside "
+            f"allowlist: {path!r}"
+        )
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _bounded_refs(value: Any) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, str | bytes):
+        return []
+    refs: list[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            continue
+        ref = item.strip()
+        if ref and ref not in refs:
+            refs.append(ref[:160])
+    return refs[:16]
+
+
+def _reason_text(value: Any) -> str:
+    if not isinstance(value, str):
+        return ""
+    return " ".join(value.split())[:300]
+
+
+def _reason_codes(value: Any) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, str | bytes):
+        return []
+    codes: list[str] = []
+    for item in value:
+        if isinstance(item, str) and item and item not in codes:
+            codes.append(item[:80])
+    return codes[:16]
+
+
+def _short_hash(payload: Mapping[str, Any]) -> str:
+    blob = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()[:16]
+
+
+def _normalised_record(
+    *,
+    source_id: str,
+    record_family: str,
+    record_id: str,
+    subject_id: str,
+    reason_codes: Sequence[str],
+    reason_text: str,
+    evidence_refs: Sequence[str],
+) -> dict[str, Any]:
+    refs = _bounded_refs(evidence_refs)
+    text = _reason_text(reason_text)
+    codes = _reason_codes(reason_codes)
+    return {
+        "source_id": source_id,
+        "record_family": record_family,
+        "record_id": record_id[:96],
+        "subject_id": subject_id[:96],
+        "reason_codes": codes,
+        "reason_text": text,
+        "evidence_refs": refs,
+        "operator_summary": _operator_summary(
+            record_family=record_family,
+            subject_id=subject_id,
+            reason_codes=codes,
+            reason_text=text,
+            evidence_refs=refs,
+        ),
+    }
+
+
+def _operator_summary(
+    *,
+    record_family: str,
+    subject_id: str,
+    reason_codes: Sequence[str],
+    reason_text: str,
+    evidence_refs: Sequence[str],
+) -> str:
+    code_text = ", ".join(reason_codes) if reason_codes else "no reason codes"
+    evidence_text = (
+        f"{len(evidence_refs)} evidence refs"
+        if evidence_refs
+        else "missing evidence refs"
+    )
+    detail = reason_text or "no readable reason text"
+    return f"{record_family}:{subject_id} -> {code_text}; {evidence_text}; {detail}"[:300]
+
+
+def _records_from_reason_jsonls(
+    *,
+    artifact_dir: Path | None,
+) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for kind in _rr.DECISION_KINDS:
+        for record in _rr.read_kind(kind, artifact_dir=artifact_dir):
+            records.append(
+                _normalised_record(
+                    source_id="reason_records_jsonl",
+                    record_family=f"{kind}_reason_record",
+                    record_id=str(record.get("record_id") or ""),
+                    subject_id=str(record.get("subject_id") or ""),
+                    reason_codes=_reason_codes(record.get("reason_codes")),
+                    reason_text=_reason_text(record.get("reason_text")),
+                    evidence_refs=_bounded_refs(record.get("evidence_refs")),
+                )
+            )
+    return records
+
+
+def _records_from_routing(path: Path) -> list[dict[str, Any]]:
+    payload = _read_json(path)
+    if payload is None:
+        return []
+    records: list[dict[str, Any]] = []
+    for item in payload.get("items") or []:
+        if not isinstance(item, Mapping):
+            continue
+        records.append(
+            _normalised_record(
+                source_id="intelligent_routing_minimal",
+                record_family="routing_sidecar",
+                record_id=str(item.get("record_id") or ""),
+                subject_id=str(item.get("campaign_id") or ""),
+                reason_codes=_reason_codes(item.get("reason_codes")),
+                reason_text=_reason_text(item.get("reason_text")),
+                evidence_refs=_bounded_refs(item.get("evidence_refs")),
+            )
+        )
+    return records
+
+
+def _records_from_sampling(path: Path) -> list[dict[str, Any]]:
+    payload = _read_json(path)
+    if payload is None:
+        return []
+    records: list[dict[str, Any]] = []
+    for item in payload.get("items") or []:
+        if not isinstance(item, Mapping):
+            continue
+        records.append(
+            _normalised_record(
+                source_id="sampling_intelligence_minimal",
+                record_family="sampling_sidecar",
+                record_id=str(item.get("record_id") or ""),
+                subject_id=str(item.get("stratum_id") or ""),
+                reason_codes=_reason_codes(item.get("reason_codes")),
+                reason_text=_reason_text(item.get("reason_text")),
+                evidence_refs=_bounded_refs(item.get("evidence_refs")),
+            )
+        )
+    return records
+
+
+def _records_from_failure_actions(path: Path) -> list[dict[str, Any]]:
+    payload = _read_json(path)
+    if payload is None:
+        return []
+    records: list[dict[str, Any]] = []
+    for item in payload.get("items") or []:
+        if not isinstance(item, Mapping):
+            continue
+        record = item.get("reason_record")
+        if not isinstance(record, Mapping):
+            continue
+        records.append(
+            _normalised_record(
+                source_id="failure_action_mapping_minimal",
+                record_family=str(record.get("record_kind") or "failure_action"),
+                record_id=str(record.get("record_id") or ""),
+                subject_id=str(record.get("subject_id") or item.get("subject_id") or ""),
+                reason_codes=_reason_codes(record.get("reason_codes")),
+                reason_text=_reason_text(record.get("reason_text")),
+                evidence_refs=_bounded_refs(record.get("evidence_refs")),
+            )
+        )
+    return records
+
+
+def _records_from_synthesis_gate(path: Path) -> list[dict[str, Any]]:
+    payload = _read_json(path)
+    if payload is None:
+        return []
+    artifact_inputs = (
+        payload.get("supporting_evidence", {}).get("artifact_inputs", {})
+        if isinstance(payload.get("supporting_evidence"), Mapping)
+        else {}
+    )
+    refs: list[str] = []
+    if isinstance(artifact_inputs, Mapping):
+        for name, status in sorted(artifact_inputs.items()):
+            if isinstance(status, Mapping):
+                refs.append(f"artifact_inputs.{name}:{status.get('path')}")
+    for item in payload.get("required_missing_evidence") or []:
+        refs.append(f"required_missing_evidence.{item}")
+    record_id = "synth_" + _short_hash(
+        {
+            "state": payload.get("synthesis_gate_state"),
+            "reason_codes": payload.get("reason_codes"),
+            "missing": payload.get("required_missing_evidence"),
+        }
+    )
+    return [
+        _normalised_record(
+            source_id="synthesis_gate",
+            record_family="synthesis_gate_sidecar",
+            record_id=record_id,
+            subject_id=str(payload.get("synthesis_gate_state") or "unknown"),
+            reason_codes=_reason_codes(payload.get("reason_codes")),
+            reason_text=str(payload.get("synthesis_gate_state") or ""),
+            evidence_refs=refs,
+        )
+    ]
+
+
+def _density(records: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    total = len(records)
+    with_codes = sum(1 for r in records if r.get("reason_codes"))
+    with_text = sum(1 for r in records if r.get("reason_text"))
+    with_refs = sum(1 for r in records if r.get("evidence_refs"))
+    total_refs = sum(len(r.get("evidence_refs") or []) for r in records)
+    by_family: dict[str, int] = {}
+    thin: list[dict[str, Any]] = []
+    for record in records:
+        family = str(record.get("record_family") or "unknown")
+        by_family[family] = by_family.get(family, 0) + 1
+        missing = []
+        if not record.get("reason_codes"):
+            missing.append("reason_codes")
+        if not record.get("reason_text"):
+            missing.append("reason_text")
+        if not record.get("evidence_refs"):
+            missing.append("evidence_refs")
+        if missing and len(thin) < MAX_THIN_RECORDS:
+            thin.append(
+                {
+                    "record_id": record.get("record_id"),
+                    "record_family": family,
+                    "missing_fields": missing,
+                }
+            )
+    return {
+        "record_count": total,
+        "records_with_reason_codes": with_codes,
+        "records_with_reason_text": with_text,
+        "records_with_evidence_refs": with_refs,
+        "records_missing_evidence_refs": total - with_refs,
+        "total_evidence_refs": total_refs,
+        "evidence_ref_density": round(total_refs / total, 6) if total else None,
+        "by_family": dict(sorted(by_family.items())),
+        "thin_records_top": thin,
+    }
+
+
+def _merge_by_record_id(
+    records: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    merged: dict[str, dict[str, Any]] = {}
+    for record in records:
+        record_id = str(record.get("record_id") or f"anonymous_{len(merged)}")
+        if record_id not in merged:
+            merged[record_id] = dict(record)
+            continue
+        current = merged[record_id]
+        current["source_id"] = "+".join(
+            sorted({
+                str(current.get("source_id") or ""),
+                str(record.get("source_id") or ""),
+            })
+        ).strip("+")
+        current["reason_codes"] = _reason_codes(
+            list(current.get("reason_codes") or [])
+            + list(record.get("reason_codes") or [])
+        )
+        if not current.get("reason_text") and record.get("reason_text"):
+            current["reason_text"] = record.get("reason_text")
+        current["evidence_refs"] = _bounded_refs(
+            list(current.get("evidence_refs") or [])
+            + list(record.get("evidence_refs") or [])
+        )
+        current["operator_summary"] = _operator_summary(
+            record_family=str(current.get("record_family") or "unknown"),
+            subject_id=str(current.get("subject_id") or ""),
+            reason_codes=current.get("reason_codes") or [],
+            reason_text=str(current.get("reason_text") or ""),
+            evidence_refs=current.get("evidence_refs") or [],
+        )
+    return sorted(
+        merged.values(),
+        key=lambda row: (
+            str(row.get("record_family") or ""),
+            str(row.get("record_id") or ""),
+        ),
+    )
+
+
+def _final_recommendation(metrics: Mapping[str, Any]) -> str:
+    total = int(metrics.get("record_count") or 0)
+    missing_refs = int(metrics.get("records_missing_evidence_refs") or 0)
+    if total == 0:
+        return "not_ready_no_reason_records"
+    if missing_refs:
+        return "not_ready_missing_evidence_refs"
+    return "evidence_density_ready"
+
+
+def collect_snapshot(
+    *,
+    frozen_utc: str | None = None,
+    reason_records_artifact_dir: Path | None = None,
+    routing_minimal_path: Path | None = None,
+    sampling_minimal_path: Path | None = None,
+    failure_action_mapping_path: Path | None = None,
+    synthesis_gate_path: Path | None = None,
+) -> dict[str, Any]:
+    ts = frozen_utc or _utcnow()
+    rr_records = _records_from_reason_jsonls(
+        artifact_dir=reason_records_artifact_dir
+    )
+    sidecar_records: list[dict[str, Any]] = []
+    sidecar_records.extend(
+        _records_from_routing(routing_minimal_path or _routing.ARTIFACT_LATEST)
+    )
+    sidecar_records.extend(
+        _records_from_sampling(sampling_minimal_path or _sampling.ARTIFACT_LATEST)
+    )
+    sidecar_records.extend(
+        _records_from_failure_actions(
+            failure_action_mapping_path or _fam.ARTIFACT_LATEST
+        )
+    )
+    sidecar_records.extend(
+        _records_from_synthesis_gate(synthesis_gate_path or SYNTHESIS_GATE_LATEST)
+    )
+    all_records = _merge_by_record_id(rr_records + sidecar_records)
+    metrics = _density(all_records)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": ts,
+        "mode": "dry-run",
+        "safe_to_execute": False,
+        "metrics": metrics,
+        "baseline_without_sidecars": _density(rr_records),
+        "after_with_sidecars": metrics,
+        "records_top": all_records[:MAX_THIN_RECORDS],
+        "final_recommendation": _final_recommendation(metrics),
+        "safety_invariants": {
+            "read_only": True,
+            "emits_reason_records": False,
+            "mutates_campaign_queue": False,
+            "mutates_strategy_or_registry": False,
+            "mutates_frozen_contracts": False,
+            "strategy_synthesis_enabled": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+        },
+    }
+
+
+def write_outputs(
+    snapshot: Mapping[str, Any],
+    *,
+    artifact_dir: Path | None = None,
+) -> dict[str, str]:
+    base = artifact_dir or ARTIFACT_DIR
+    ts = str(snapshot["generated_at_utc"]).replace(":", "-")
+    base.mkdir(parents=True, exist_ok=True)
+    json_now = base / f"{ts}.json"
+    json_latest = base / ARTIFACT_LATEST.name
+    history = base / HISTORY.name
+    payload = json.dumps(snapshot, sort_keys=True, indent=2)
+    _validate_write_target(json_now)
+    _validate_write_target(json_latest)
+    _validate_write_target(history)
+    tmp_now = json_now.with_suffix(json_now.suffix + ".tmp")
+    tmp_now.write_text(payload, encoding="utf-8")
+    os.replace(tmp_now, json_now)
+    tmp_latest = json_latest.with_suffix(json_latest.suffix + ".tmp")
+    tmp_latest.write_text(payload, encoding="utf-8")
+    os.replace(tmp_latest, json_latest)
+    compact = json.dumps(snapshot, sort_keys=True, separators=(",", ":"))
+    with history.open("a", encoding="utf-8") as handle:
+        handle.write(compact + "\n")
+    return {
+        "latest": _rel(json_latest),
+        "timestamped": _rel(json_now),
+        "history": _rel(history),
+    }
+
+
+def read_latest_snapshot(
+    *, artifact_dir: Path | None = None
+) -> dict[str, Any] | None:
+    base = artifact_dir or ARTIFACT_DIR
+    return _read_json(base / ARTIFACT_LATEST.name)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="reporting.reason_record_evidence_density",
+        description="Read-only reason-record evidence-density inspector.",
+    )
+    parser.add_argument("--status", action="store_true")
+    parser.add_argument("--no-write", action="store_true")
+    parser.add_argument("--frozen-utc", type=str, default=None)
+    args = parser.parse_args(argv)
+
+    if args.status:
+        snapshot = read_latest_snapshot()
+        if snapshot is None:
+            snapshot = {
+                "schema_version": SCHEMA_VERSION,
+                "module_version": MODULE_VERSION,
+                "report_kind": REPORT_KIND,
+                "final_recommendation": "not_available",
+            }
+        print(json.dumps(snapshot, sort_keys=True, indent=2))
+        return 0
+
+    snapshot = collect_snapshot(frozen_utc=args.frozen_utc)
+    if not args.no_write:
+        snapshot["_artifact_paths"] = write_outputs(snapshot)
+    print(json.dumps(snapshot, sort_keys=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/reporting/sampling_intelligence_minimal.py
+++ b/reporting/sampling_intelligence_minimal.py
@@ -139,6 +139,7 @@ INPUT_CANDIDATE_KEYS: Final[tuple[str, ...]] = (
 OUTPUT_CANDIDATE_KEYS: Final[tuple[str, ...]] = (
     "stratum_id",
     "decision",
+    "evidence_refs",
     "priority_score",
     "rank",
     "reason_codes",
@@ -199,6 +200,19 @@ def _rel(p: Path) -> str:
         return str(p.relative_to(REPO_ROOT)).replace("\\", "/")
     except ValueError:
         return str(p).replace("\\", "/")
+
+
+def _evidence_refs_for_candidate() -> list[str]:
+    """Stable sidecar references that explain the sampling decision inputs."""
+    return [
+        "candidate.stratum_id",
+        "candidate.coverage_actual",
+        "candidate.coverage_target",
+        "candidate.regime_match",
+        "candidate.null_baseline_required",
+        "candidate.multiplicity_budget_remaining",
+        "thresholds.coverage_imbalance_threshold",
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -405,6 +419,8 @@ def collect_snapshot(
             ),
             "coverage_imbalance_threshold": coverage_imbalance_threshold,
         }
+        evidence_refs = _evidence_refs_for_candidate()
+        inputs_payload["evidence_refs"] = evidence_refs
         record = _rr.build_record(
             decision_kind=_rr.DECISION_KIND_SAMPLING,
             subject_id=str(c["stratum_id"]),
@@ -422,6 +438,7 @@ def collect_snapshot(
             {
                 "stratum_id": str(c["stratum_id"]),
                 "decision": decision,
+                "evidence_refs": evidence_refs,
                 "priority_score": round(score, 6),
                 "rank": -1,
                 "reason_codes": list(reason_codes),

--- a/reporting/trusted_loop_materialization.py
+++ b/reporting/trusted_loop_materialization.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any, Final
 
 from reporting import intelligent_routing_minimal as _routing
+from reporting import reason_record_evidence_density as _rr_density
 from reporting import reason_records as _rr
 from reporting import research_observability_minimal as _observability
 from reporting import sampling_intelligence_minimal as _sampling
@@ -209,6 +210,13 @@ def collect_snapshot(
         artifact_dir=rr_dir,
         frozen_utc=ts,
     )
+    reason_density = _rr_density.collect_snapshot(
+        frozen_utc=ts,
+        reason_records_artifact_dir=rr_dir,
+        routing_minimal_path=routing_dir / _routing.ARTIFACT_LATEST.name,
+        sampling_minimal_path=sampling_dir / _sampling.ARTIFACT_LATEST.name,
+        failure_action_mapping_path=_observability.FAILURE_ACTION_MAPPING_LATEST,
+    )
     routing_snapshot = _routing.collect_snapshot(
         candidates=[],
         frozen_utc=ts,
@@ -241,6 +249,13 @@ def collect_snapshot(
                 "total_records": reason_manifest["total_records"],
                 "note": reason_manifest["note"],
             },
+            "reason_record_evidence_density": {
+                "record_count": reason_density["metrics"]["record_count"],
+                "records_with_evidence_refs": reason_density["metrics"][
+                    "records_with_evidence_refs"
+                ],
+                "final_recommendation": reason_density["final_recommendation"],
+            },
             "routing_minimal_latest": {
                 "path": _rel(routing_dir / _routing.ARTIFACT_LATEST.name),
                 "total": routing_snapshot["counts"]["total"],
@@ -257,6 +272,7 @@ def collect_snapshot(
             },
         },
         "trusted_loop_metric_values": metrics,
+        "reason_record_evidence_density": reason_density,
         "research_quality_kpi_readiness": kpis,
         "failure_action_mapping": (
             observability_snapshot.get("qre_operator_summary", {})

--- a/tests/unit/test_failure_action_mapping_minimal.py
+++ b/tests/unit/test_failure_action_mapping_minimal.py
@@ -79,6 +79,7 @@ def test_schema_keys_are_pinned() -> None:
         "record_kind",
         "schema_version",
         "subject_id",
+        "evidence_refs",
         "failure_code",
         "recommended_action",
         "reason_codes",
@@ -153,6 +154,7 @@ def test_technical_failure_reason_is_not_research_action() -> None:
     record = snap["items"][0]["reason_record"]
     assert snap["items"][0]["recommended_action"] == "review_data_pipeline"
     assert "technical_not_research" in record["reason_codes"]
+    assert "failure_input.evidence_count" in record["evidence_refs"]
 
 
 def test_low_evidence_adds_insufficient_reason() -> None:

--- a/tests/unit/test_intelligent_routing_minimal.py
+++ b/tests/unit/test_intelligent_routing_minimal.py
@@ -74,6 +74,7 @@ def test_output_candidate_keys_are_closed() -> None:
     assert irm.OUTPUT_CANDIDATE_KEYS == (
         "campaign_id",
         "decision",
+        "evidence_refs",
         "priority_score",
         "rank",
         "reason_codes",
@@ -141,6 +142,7 @@ def test_prioritize_when_info_gain_high(tmp_path: Path) -> None:
     )
     assert snap["items"][0]["decision"] == "prioritize"
     assert snap["items"][0]["reason_codes"] == ["info_gain_high"]
+    assert "candidate.info_gain_estimate" in snap["items"][0]["evidence_refs"]
     assert snap["counts"]["by_decision"]["prioritize"] == 1
     assert snap["final_recommendation"] == "ready_for_implementation"
 
@@ -346,6 +348,7 @@ def test_each_candidate_emits_exactly_one_routing_reason_record(
     snapshot_ids = {it["record_id"] for it in snap["items"]}
     ledger_ids = {r["record_id"] for r in records}
     assert snapshot_ids == ledger_ids
+    assert all(it["evidence_refs"] for it in snap["items"])
 
 
 def test_record_ids_are_deterministic_across_runs(tmp_path: Path) -> None:

--- a/tests/unit/test_reason_record_evidence_density.py
+++ b/tests/unit/test_reason_record_evidence_density.py
@@ -1,0 +1,189 @@
+"""Tests for ADE-QRE-014B reason-record evidence density."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from reporting import failure_action_mapping_minimal as fam
+from reporting import intelligent_routing_minimal as routing
+from reporting import reason_record_evidence_density as density
+from reporting import sampling_intelligence_minimal as sampling
+
+
+FROZEN = "2026-05-24T00:00:00Z"
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=True, indent=2), encoding="utf-8")
+
+
+def test_density_counts_sidecar_evidence_refs(tmp_path: Path) -> None:
+    routing_dir = tmp_path / "logs" / "intelligent_routing_minimal"
+    sampling_dir = tmp_path / "logs" / "sampling_intelligence_minimal"
+    failure_dir = tmp_path / "logs" / "failure_action_mapping_minimal"
+
+    routing_snap = routing.collect_snapshot(
+        [
+            {
+                "campaign_id": "c1",
+                "info_gain_estimate": 0.8,
+                "dead_zone_dwell": 0,
+                "dependency_unmet": False,
+                "multiplicity_budget_remaining": 2,
+            }
+        ],
+        frozen_utc=FROZEN,
+        emit_reason_records=False,
+    )
+    sampling_snap = sampling.collect_snapshot(
+        [
+            {
+                "stratum_id": "s1",
+                "coverage_actual": 0.1,
+                "coverage_target": 0.4,
+                "regime_match": True,
+                "null_baseline_required": False,
+                "multiplicity_budget_remaining": 2,
+            }
+        ],
+        frozen_utc=FROZEN,
+        emit_reason_records=False,
+    )
+    failure_snap = fam.collect_snapshot(
+        [
+            {
+                "subject_id": "screening:missing_metric_field",
+                "failure_code": "technical_failure",
+                "severity": "medium",
+                "evidence_count": 4,
+            }
+        ],
+        frozen_utc=FROZEN,
+    )
+    routing.write_outputs(routing_snap, artifact_dir=routing_dir)
+    sampling.write_outputs(sampling_snap, artifact_dir=sampling_dir)
+    fam.write_outputs(failure_snap, artifact_dir=failure_dir)
+
+    snapshot = density.collect_snapshot(
+        frozen_utc=FROZEN,
+        reason_records_artifact_dir=tmp_path / "logs" / "reason_records",
+        routing_minimal_path=routing_dir / "latest.json",
+        sampling_minimal_path=sampling_dir / "latest.json",
+        failure_action_mapping_path=failure_dir / "latest.json",
+        synthesis_gate_path=tmp_path / "missing_synthesis.json",
+    )
+
+    metrics = snapshot["metrics"]
+    assert metrics["record_count"] == 3
+    assert metrics["records_with_reason_codes"] == 3
+    assert metrics["records_with_reason_text"] == 3
+    assert metrics["records_with_evidence_refs"] == 3
+    assert metrics["records_missing_evidence_refs"] == 0
+    assert snapshot["final_recommendation"] == "evidence_density_ready"
+    assert "routing_sidecar" in metrics["by_family"]
+
+
+def test_missing_evidence_refs_fail_closed(tmp_path: Path) -> None:
+    routing_path = tmp_path / "logs" / "intelligent_routing_minimal" / "latest.json"
+    _write_json(
+        routing_path,
+        {
+            "items": [
+                {
+                    "campaign_id": "thin",
+                    "record_id": "rr_thin",
+                    "reason_codes": ["info_gain_high"],
+                    "reason_text": "thin record",
+                }
+            ]
+        },
+    )
+
+    snapshot = density.collect_snapshot(
+        frozen_utc=FROZEN,
+        reason_records_artifact_dir=tmp_path / "logs" / "reason_records",
+        routing_minimal_path=routing_path,
+        sampling_minimal_path=tmp_path / "missing_sampling.json",
+        failure_action_mapping_path=tmp_path / "missing_failure.json",
+        synthesis_gate_path=tmp_path / "missing_synthesis.json",
+    )
+
+    assert snapshot["final_recommendation"] == "not_ready_missing_evidence_refs"
+    assert snapshot["metrics"]["thin_records_top"][0]["missing_fields"] == [
+        "evidence_refs"
+    ]
+
+
+def test_sidecar_refs_join_to_jsonl_reason_records(tmp_path: Path) -> None:
+    rr_dir = tmp_path / "logs" / "reason_records"
+    routing_dir = tmp_path / "logs" / "intelligent_routing_minimal"
+    routing_snap = routing.collect_snapshot(
+        [
+            {
+                "campaign_id": "joined",
+                "info_gain_estimate": 0.8,
+                "dead_zone_dwell": 0,
+                "dependency_unmet": False,
+                "multiplicity_budget_remaining": 2,
+            }
+        ],
+        frozen_utc=FROZEN,
+        artifact_dir_for_reasons=rr_dir,
+    )
+    routing.write_outputs(routing_snap, artifact_dir=routing_dir)
+
+    snapshot = density.collect_snapshot(
+        frozen_utc=FROZEN,
+        reason_records_artifact_dir=rr_dir,
+        routing_minimal_path=routing_dir / "latest.json",
+        sampling_minimal_path=tmp_path / "missing_sampling.json",
+        failure_action_mapping_path=tmp_path / "missing_failure.json",
+        synthesis_gate_path=tmp_path / "missing_synthesis.json",
+    )
+
+    assert snapshot["baseline_without_sidecars"]["records_missing_evidence_refs"] == 1
+    assert snapshot["after_with_sidecars"]["record_count"] == 1
+    assert snapshot["after_with_sidecars"]["records_with_evidence_refs"] == 1
+    assert snapshot["final_recommendation"] == "evidence_density_ready"
+
+
+def test_synthesis_gate_is_read_as_reference_only_sidecar(tmp_path: Path) -> None:
+    synthesis_path = tmp_path / "research" / "synthesis_gate_latest.v1.json"
+    _write_json(
+        synthesis_path,
+        {
+            "synthesis_gate_state": "blocked_missing_market_context",
+            "reason_codes": ["missing_linked_market_context_insight"],
+            "required_missing_evidence": ["linked_market_context_insight"],
+            "supporting_evidence": {
+                "artifact_inputs": {
+                    "research_state": {
+                        "path": "research/research_state_latest.v1.json",
+                        "status": "missing",
+                    }
+                }
+            },
+        },
+    )
+
+    snapshot = density.collect_snapshot(
+        frozen_utc=FROZEN,
+        reason_records_artifact_dir=tmp_path / "logs" / "reason_records",
+        routing_minimal_path=tmp_path / "missing_routing.json",
+        sampling_minimal_path=tmp_path / "missing_sampling.json",
+        failure_action_mapping_path=tmp_path / "missing_failure.json",
+        synthesis_gate_path=synthesis_path,
+    )
+
+    assert snapshot["metrics"]["record_count"] == 1
+    assert snapshot["metrics"]["records_with_evidence_refs"] == 1
+    assert snapshot["safety_invariants"]["strategy_synthesis_enabled"] is False
+
+
+def test_write_outputs_refuses_outside_allowlist(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="outside allowlist"):
+        density._validate_write_target(tmp_path / "elsewhere" / "latest.json")

--- a/tests/unit/test_sampling_intelligence_minimal.py
+++ b/tests/unit/test_sampling_intelligence_minimal.py
@@ -77,6 +77,7 @@ def test_output_candidate_keys_are_closed() -> None:
     assert sim.OUTPUT_CANDIDATE_KEYS == (
         "stratum_id",
         "decision",
+        "evidence_refs",
         "priority_score",
         "rank",
         "reason_codes",
@@ -158,6 +159,7 @@ def test_stratify_when_coverage_within_threshold(tmp_path: Path) -> None:
     assert snap["items"][0]["reason_codes"] == [
         "multiplicity_budget_remaining"
     ]
+    assert "candidate.coverage_actual" in snap["items"][0]["evidence_refs"]
     assert snap["counts"]["by_decision"]["stratify"] == 1
     assert snap["counts"]["actionable"] == 1
     assert snap["final_recommendation"] == "ready_for_sampling"
@@ -467,6 +469,7 @@ def test_each_candidate_emits_exactly_one_sampling_reason_record(
     snapshot_ids = {it["record_id"] for it in snap["items"]}
     ledger_ids = {r["record_id"] for r in records}
     assert snapshot_ids == ledger_ids
+    assert all(it["evidence_refs"] for it in snap["items"])
 
 
 def test_emitted_records_use_sampling_kind_only(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Adds bounded `evidence_refs` to routing, sampling, and failure-action reason sidecars without changing the strict reason-record JSONL schema.
- Adds `reporting.reason_record_evidence_density`, a read-only density inspector with before/after sidecar metrics, thin-record reporting, operator summaries, and fail-closed states.
- Surfaces reason-record evidence density inside trusted-loop materialization and documents the ADE-QRE-014B runbook.
- Marks ADE-QRE-014B `in_progress`; ADE-QRE-014C remains blocked.

## Safety scope

- No strategy synthesis enablement.
- No strategy implementations or `registry.py` changes.
- No campaign, routing, sampling, paper, shadow, live, broker, risk, or execution mutation.
- No frozen research output mutation.
- Addendum 4 remains deferred/reference-only.

## Validation

- `python -m pytest tests/unit/test_intelligent_routing_minimal.py tests/unit/test_sampling_intelligence_minimal.py tests/unit/test_failure_action_mapping_minimal.py tests/unit/test_reason_record_evidence_density.py tests/unit/test_trusted_loop_materialization.py -q` -> 115 passed
- `python -m pytest tests/architecture -q` -> 157 passed
- `python -m pytest tests/smoke -q` -> 18 passed
- `git diff --check` -> passed
- `python -m reporting.architecture_import_scan --format summary` -> `forbidden_edge_count=0`
- `python -m reporting.reason_record_evidence_density --no-write --frozen-utc 2026-05-24T00:00:00Z` -> `not_ready_no_reason_records` on current empty local artifacts