### PR TITLE
docs: mark ADE-QRE-014C done

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -461,7 +461,14 @@
 ### ADE-QRE-014C - KPI Numeric Readiness Completion
 
 - queue id: `ADE-QRE-014C`
-- status: `ready`
+- status: `done`
+- completion evidence: PR #327, merge SHA
+  `9e7380451ea4866f10cba298e05e897e3a284a48`; Fast pre-merge gate
+  run `26355563454`, Docker build/push run `26355688905`, and VPS
+  deploy run `26355688895` completed/success; local post-merge
+  targeted tests and architecture scanner passed; frozen contracts
+  unchanged; protected/execution paths untouched; strategy synthesis
+  remained blocked.
 - title: KPI Numeric Readiness Completion.
 - purpose: make trusted-loop readiness KPIs numerically complete and
   fail-closed where values are missing, unknown, or not derivable from
@@ -521,7 +528,7 @@
 ### ADE-QRE-014D - Routing/Sampling Readiness Density
 
 - queue id: `ADE-QRE-014D`
-- status: `blocked until ADE-QRE-014C done`
+- status: `ready`
 - title: Routing/Sampling Readiness Density.
 - purpose: increase `routing_ready` and `sampling_ready` evidence density
   using existing artifacts and read-only readiness evaluation only.

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -131,23 +131,30 @@ def test_ade_qre_014_active_queue_lifecycle_is_consistent() -> None:
     item_b = items["ADE-QRE-014B"]
     item_c = items["ADE-QRE-014C"]
     item_d = items["ADE-QRE-014D"]
+    item_e = items["ADE-QRE-014E"]
 
     assert item_a.status == "done"
     assert _done_evidence_is_complete(item_a)
     assert item_b.status == "done"
     assert _done_evidence_is_complete(item_b)
 
-    assert item_c.status == "ready"
+    assert item_c.status == "done"
+    assert _done_evidence_is_complete(item_c)
     assert item_c.dependencies == ("ADE-QRE-014B",)
     assert _dependencies_done(item_c, items) is True
 
-    assert item_d.status == "blocked until ADE-QRE-014C done"
+    assert item_d.status == "ready"
     assert item_d.dependencies == ("ADE-QRE-014C",)
-    assert _dependencies_done(item_d, items) is False
-    assert _auto_selectable_status(item_d) is False
+    assert _dependencies_done(item_d, items) is True
+    assert _auto_selectable_status(item_d) is True
+
+    assert item_e.status == "blocked until ADE-QRE-014D done"
+    assert item_e.dependencies == ("ADE-QRE-014D",)
+    assert _dependencies_done(item_e, items) is False
+    assert _auto_selectable_status(item_e) is False
 
     assert "ADE-QRE-011" in _stale_historical_ready_items(items)
-    assert _next_eligible_ready_item(items) == item_c
+    assert _next_eligible_ready_item(items) == item_d
 
     item_f = items["ADE-QRE-014F"]
     assert item_f.status.startswith("deferred")


### PR DESCRIPTION
## Summary
- mark ADE-QRE-014C done with PR #327 merge and post-merge validation evidence
- advance ADE-QRE-014D from blocked to ready now that its prerequisite is done
- update the queue lifecycle guardrail test for the new active queue state

## Validation
- pytest tests/unit/test_ade_qre_014_queue_lifecycle.py -q
- python scripts/governance_lint.py
- python -m reporting.architecture_import_scan --format summary
- git diff --check
- protected/frozen path diff check returned no files

## Scope
- queue status docs and lifecycle test only
- no runtime behavior, strategy, registry, frozen research output, or execution path changes