### PR TITLE
feat: add routing sampling readiness density

### DIFF
--- a/reporting/trusted_loop_materialization.py
+++ b/reporting/trusted_loop_materialization.py
@@ -24,7 +24,7 @@ from reporting import research_observability_minimal as _observability
 from reporting import sampling_intelligence_minimal as _sampling
 
 REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
-MODULE_VERSION: Final[str] = "ade-qre-014c-2026-05-24"
+MODULE_VERSION: Final[str] = "ade-qre-014d-2026-05-24"
 SCHEMA_VERSION: Final[int] = 1
 REPORT_KIND: Final[str] = "trusted_loop_materialization_digest"
 
@@ -301,6 +301,128 @@ def _research_quality_kpi_readiness(
     }
 
 
+def _readiness_evidence_score(
+    required_evidence: tuple[str, ...],
+    missing_evidence: list[str],
+) -> float:
+    ready_count = len(required_evidence) - len(missing_evidence)
+    return round(ready_count / len(required_evidence), 6)
+
+
+def _routing_sampling_readiness_row(
+    *,
+    kind: str,
+    snapshot: Mapping[str, Any],
+    artifact_path: Path,
+) -> dict[str, Any]:
+    counts = _mapping_or_empty(snapshot.get("counts"))
+    by_decision = _mapping_or_empty(counts.get("by_decision"))
+    total = _numeric_or_none(counts.get("total"))
+    recommendation = snapshot.get("final_recommendation")
+    recommendation = recommendation if isinstance(recommendation, str) else "unknown"
+
+    if kind == "routing":
+        ready_recommendation = "ready_for_implementation"
+        ready_count_key = "prioritize_count"
+        ready_count = _numeric_or_none(by_decision.get("prioritize"))
+        ready_decision = "prioritize"
+    elif kind == "sampling":
+        ready_recommendation = "ready_for_sampling"
+        ready_count_key = "actionable_count"
+        ready_count = _numeric_or_none(counts.get("actionable"))
+        ready_decision = "actionable_sampling_decision"
+    else:
+        raise ValueError(f"unknown readiness kind: {kind!r}")
+
+    required_evidence = (
+        "latest_artifact_present",
+        "final_recommendation_ready",
+        "total_count_positive",
+        f"{ready_count_key}_positive",
+    )
+    missing_evidence: list[str] = []
+    artifact_exists = artifact_path.is_file()
+    if not artifact_exists:
+        missing_evidence.append("latest_artifact_present")
+    if recommendation != ready_recommendation:
+        missing_evidence.append("final_recommendation_ready")
+    if total is None or total <= 0:
+        missing_evidence.append("total_count_positive")
+    if ready_count is None or ready_count <= 0:
+        missing_evidence.append(f"{ready_count_key}_positive")
+
+    ready = not missing_evidence
+    return {
+        "status": "ready" if ready else "fail_closed",
+        "ready": ready,
+        "fail_closed": not ready,
+        "artifact_path": _rel(artifact_path),
+        "artifact_present": artifact_exists,
+        "final_recommendation": recommendation,
+        "expected_final_recommendation": ready_recommendation,
+        "total": total,
+        ready_count_key: ready_count,
+        "ready_decision": ready_decision,
+        "required_evidence": list(required_evidence),
+        "missing_evidence": missing_evidence,
+        "readiness_score": 1.0 if ready else 0.0,
+        "evidence_density_score": _readiness_evidence_score(
+            required_evidence,
+            missing_evidence,
+        ),
+        "source": "existing_read_only_artifact_snapshot",
+    }
+
+
+def _routing_sampling_readiness_density(
+    *,
+    routing_snapshot: Mapping[str, Any],
+    sampling_snapshot: Mapping[str, Any],
+    routing_artifact_path: Path,
+    sampling_artifact_path: Path,
+) -> dict[str, Any]:
+    """Fail-closed read-only readiness over routing/sampling artifacts."""
+    rows = {
+        "routing_ready": _routing_sampling_readiness_row(
+            kind="routing",
+            snapshot=routing_snapshot,
+            artifact_path=routing_artifact_path,
+        ),
+        "sampling_ready": _routing_sampling_readiness_row(
+            kind="sampling",
+            snapshot=sampling_snapshot,
+            artifact_path=sampling_artifact_path,
+        ),
+    }
+    ready_count = sum(1 for row in rows.values() if row["ready"] is True)
+    fail_closed_count = len(rows) - ready_count
+    missing_evidence_count = sum(
+        len(row["missing_evidence"]) for row in rows.values()
+    )
+    required_evidence_count = sum(
+        len(row["required_evidence"]) for row in rows.values()
+    )
+    return {
+        "values": rows,
+        "ready_count": ready_count,
+        "fail_closed_count": fail_closed_count,
+        "missing_evidence_count": missing_evidence_count,
+        "required_evidence_count": required_evidence_count,
+        "overall_status": "ready" if fail_closed_count == 0 else "fail_closed",
+        "overall_evidence_density_score": round(
+            (required_evidence_count - missing_evidence_count)
+            / required_evidence_count,
+            6,
+        ),
+        "all_reported_readiness_numeric_or_fail_closed": True,
+        "note": (
+            "Routing and sampling readiness become ready only when existing "
+            "read-only artifacts contain positive ready evidence; missing, "
+            "empty, unknown, or non-ready evidence fails closed."
+        ),
+    }
+
+
 def collect_snapshot(
     *,
     frozen_utc: str | None = None,
@@ -344,6 +466,27 @@ def collect_snapshot(
     )
     metrics = _trusted_loop_metric_values(observability_snapshot)
     kpis = _research_quality_kpi_readiness(observability_snapshot)
+    routing_sampling_readiness = _routing_sampling_readiness_density(
+        routing_snapshot=routing_snapshot,
+        sampling_snapshot=sampling_snapshot,
+        routing_artifact_path=routing_dir / _routing.ARTIFACT_LATEST.name,
+        sampling_artifact_path=sampling_dir / _sampling.ARTIFACT_LATEST.name,
+    )
+    block_reasons = [
+        "failure_action_mapping_not_ready_when_total_failures_zero",
+        "no_complete_research_quality_kpi_values",
+        "no_strategy_synthesis_scope_authorized",
+    ]
+    if (
+        routing_sampling_readiness["values"]["routing_ready"]["fail_closed"]
+        is True
+    ):
+        block_reasons.append("routing_ready_evidence_missing_or_not_ready")
+    if (
+        routing_sampling_readiness["values"]["sampling_ready"]["fail_closed"]
+        is True
+    ):
+        block_reasons.append("sampling_ready_evidence_missing_or_not_ready")
 
     return {
         "schema_version": SCHEMA_VERSION,
@@ -383,16 +526,13 @@ def collect_snapshot(
         "trusted_loop_metric_values": metrics,
         "reason_record_evidence_density": reason_density,
         "research_quality_kpi_readiness": kpis,
+        "routing_sampling_readiness_density": routing_sampling_readiness,
         "failure_action_mapping": (
             observability_snapshot.get("qre_operator_summary", {})
             .get("failure_action_mapping", {})
         ),
         "synthesis_remains_blocked": True,
-        "block_reasons": [
-            "failure_action_mapping_not_ready_when_total_failures_zero",
-            "no_complete_research_quality_kpi_values",
-            "no_strategy_synthesis_scope_authorized",
-        ],
+        "block_reasons": block_reasons,
         "safety_invariants": {
             "read_only": True,
             "emits_reason_records": False,

--- a/tests/unit/test_trusted_loop_materialization.py
+++ b/tests/unit/test_trusted_loop_materialization.py
@@ -149,6 +149,10 @@ def test_materialize_writes_empty_evidence_artifacts_without_reason_records(
     assert snapshot["materialized_artifacts"]["sampling_minimal_latest"]["total"] == 0
     assert snapshot["failure_action_mapping"]["status"] == "not_ready"
     assert snapshot["failure_action_mapping"]["total_failures"] == 0
+    density = snapshot["routing_sampling_readiness_density"]
+    assert density["overall_status"] == "fail_closed"
+    assert density["values"]["routing_ready"]["status"] == "fail_closed"
+    assert density["values"]["sampling_ready"]["status"] == "fail_closed"
     assert snapshot["synthesis_remains_blocked"] is True
 
 
@@ -277,6 +281,125 @@ def test_research_quality_kpis_fail_closed_on_unknown_non_numeric_evidence() -> 
     assert kpis["values"]["TTFPRC"]["source"] == "fixture"
     assert kpis["values"]["NMBR"]["status"] == "fail_closed"
     assert kpis["values"]["NMBR"]["source"] == "fixture"
+
+
+def test_routing_sampling_readiness_density_ready_with_existing_ready_artifacts(
+    tmp_path: Path,
+) -> None:
+    routing_path = tmp_path / "logs" / "intelligent_routing_minimal" / "latest.json"
+    sampling_path = tmp_path / "logs" / "sampling_intelligence_minimal" / "latest.json"
+    routing_snapshot = tlm._routing.collect_snapshot(
+        [
+            {
+                "campaign_id": "c1",
+                "info_gain_estimate": 0.8,
+                "dead_zone_dwell": 0,
+                "dependency_unmet": False,
+                "multiplicity_budget_remaining": 1,
+            }
+        ],
+        frozen_utc=FROZEN,
+        emit_reason_records=False,
+    )
+    sampling_snapshot = tlm._sampling.collect_snapshot(
+        [
+            {
+                "stratum_id": "s1",
+                "coverage_actual": 0.1,
+                "coverage_target": 0.3,
+                "regime_match": True,
+                "null_baseline_required": False,
+                "multiplicity_budget_remaining": 1,
+            }
+        ],
+        frozen_utc=FROZEN,
+        emit_reason_records=False,
+    )
+    _write_json(routing_path, routing_snapshot)
+    _write_json(sampling_path, sampling_snapshot)
+
+    density = tlm._routing_sampling_readiness_density(
+        routing_snapshot=routing_snapshot,
+        sampling_snapshot=sampling_snapshot,
+        routing_artifact_path=routing_path,
+        sampling_artifact_path=sampling_path,
+    )
+
+    assert density["overall_status"] == "ready"
+    assert density["ready_count"] == 2
+    assert density["fail_closed_count"] == 0
+    assert density["overall_evidence_density_score"] == 1.0
+    assert density["values"]["routing_ready"]["status"] == "ready"
+    assert density["values"]["routing_ready"]["prioritize_count"] == 1
+    assert density["values"]["sampling_ready"]["status"] == "ready"
+    assert density["values"]["sampling_ready"]["actionable_count"] == 1
+
+
+def test_routing_sampling_readiness_density_fails_closed_on_empty_artifacts(
+    tmp_path: Path,
+) -> None:
+    routing_path = tmp_path / "logs" / "intelligent_routing_minimal" / "latest.json"
+    sampling_path = tmp_path / "logs" / "sampling_intelligence_minimal" / "latest.json"
+    routing_snapshot = tlm._routing.collect_snapshot(
+        [],
+        frozen_utc=FROZEN,
+        emit_reason_records=False,
+    )
+    sampling_snapshot = tlm._sampling.collect_snapshot(
+        [],
+        frozen_utc=FROZEN,
+        emit_reason_records=False,
+    )
+    _write_json(routing_path, routing_snapshot)
+    _write_json(sampling_path, sampling_snapshot)
+
+    density = tlm._routing_sampling_readiness_density(
+        routing_snapshot=routing_snapshot,
+        sampling_snapshot=sampling_snapshot,
+        routing_artifact_path=routing_path,
+        sampling_artifact_path=sampling_path,
+    )
+
+    assert density["overall_status"] == "fail_closed"
+    assert density["ready_count"] == 0
+    assert density["fail_closed_count"] == 2
+    assert density["missing_evidence_count"] == 6
+    assert density["values"]["routing_ready"]["missing_evidence"] == [
+        "final_recommendation_ready",
+        "total_count_positive",
+        "prioritize_count_positive",
+    ]
+    assert density["values"]["sampling_ready"]["missing_evidence"] == [
+        "final_recommendation_ready",
+        "total_count_positive",
+        "actionable_count_positive",
+    ]
+
+
+def test_routing_sampling_readiness_density_fails_closed_on_missing_or_unknown(
+    tmp_path: Path,
+) -> None:
+    density = tlm._routing_sampling_readiness_density(
+        routing_snapshot={"counts": {"total": "unknown"}},
+        sampling_snapshot={"counts": {"total": None, "actionable": "unknown"}},
+        routing_artifact_path=(
+            tmp_path / "logs" / "intelligent_routing_minimal" / "latest.json"
+        ),
+        sampling_artifact_path=(
+            tmp_path / "logs" / "sampling_intelligence_minimal" / "latest.json"
+        ),
+    )
+
+    assert density["overall_status"] == "fail_closed"
+    assert density["fail_closed_count"] == 2
+    assert density["values"]["routing_ready"]["final_recommendation"] == "unknown"
+    assert density["values"]["sampling_ready"]["final_recommendation"] == "unknown"
+    assert "latest_artifact_present" in density["values"]["routing_ready"][
+        "missing_evidence"
+    ]
+    assert "latest_artifact_present" in density["values"]["sampling_ready"][
+        "missing_evidence"
+    ]
 
 
 def test_write_outputs_refuses_outside_allowlist(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add read-only routing/sampling readiness density rows to trusted-loop materialization
- fail closed when routing or sampling artifacts are missing, empty, unknown, or not ready
- keep synthesis blocked and expose missing-evidence reasons without mutating routing/sampling state

## Validation
- python -m pytest tests/unit/test_trusted_loop_materialization.py tests/unit/test_research_observability_minimal.py -q
- python -m pytest tests/unit/test_intelligent_routing_minimal.py tests/unit/test_sampling_intelligence_minimal.py tests/unit/test_trusted_loop_materialization.py tests/unit/test_research_observability_minimal.py -q
- python -m reporting.trusted_loop_materialization --no-write --frozen-utc 2026-05-24T00:00:00Z
- python scripts\governance_lint.py
- python -m reporting.architecture_import_scan --format summary
- python -m pytest tests/smoke -q
- git diff --check
- protected/frozen path diff check returned no files

## Safety
- read-only reporting/tests only
- no registry.py or strategy implementation changes
- no research_latest.json or strategy_matrix.csv mutation
- no live/paper/shadow/risk/broker/execution changes
- no strategy synthesis enablement