### PR TITLE
docs: mark ADE-QRE-014D done

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -528,7 +528,14 @@
 ### ADE-QRE-014D - Routing/Sampling Readiness Density
 
 - queue id: `ADE-QRE-014D`
-- status: `ready`
+- status: `done`
+- completion evidence: PR #329, merge SHA
+  `586606d88e88373eb580d3b76ab48bd22c3cc3e6`; Fast pre-merge gate
+  run `26356277317`, Docker build/push run `26356382172`, and VPS
+  deploy run `26356382164` completed/success; local post-merge
+  targeted tests and architecture scanner passed; frozen contracts
+  unchanged; protected/execution paths untouched; strategy synthesis
+  remained blocked.
 - title: Routing/Sampling Readiness Density.
 - purpose: increase `routing_ready` and `sampling_ready` evidence density
   using existing artifacts and read-only readiness evaluation only.
@@ -582,7 +589,7 @@
 ### ADE-QRE-014E - Trusted-Loop Maturity Follow-up
 
 - queue id: `ADE-QRE-014E`
-- status: `blocked until ADE-QRE-014D done`
+- status: `ready`
 - title: Trusted-Loop Maturity Follow-up.
 - purpose: update the maturity matrix/status based on 014B-D evidence while
   keeping the result docs/reporting only.

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -53,7 +53,7 @@ def _parse_queue_items(text: str) -> dict[str, QueueItem]:
 
 
 def _done_evidence_is_complete(item: QueueItem) -> bool:
-    text = item.body.lower()
+    text = re.sub(r"\s+", " ", item.body.lower())
     has_pr = re.search(r"\bpr #\d+\b", item.body, re.I) is not None
     has_merge_sha = "merge" in text and (
         re.search(r"\b[0-9a-f]{7,40}\b", item.body) is not None
@@ -143,18 +143,19 @@ def test_ade_qre_014_active_queue_lifecycle_is_consistent() -> None:
     assert item_c.dependencies == ("ADE-QRE-014B",)
     assert _dependencies_done(item_c, items) is True
 
-    assert item_d.status == "ready"
+    assert item_d.status == "done"
+    assert _done_evidence_is_complete(item_d)
     assert item_d.dependencies == ("ADE-QRE-014C",)
     assert _dependencies_done(item_d, items) is True
-    assert _auto_selectable_status(item_d) is True
+    assert _auto_selectable_status(item_d) is False
 
-    assert item_e.status == "blocked until ADE-QRE-014D done"
+    assert item_e.status == "ready"
     assert item_e.dependencies == ("ADE-QRE-014D",)
-    assert _dependencies_done(item_e, items) is False
-    assert _auto_selectable_status(item_e) is False
+    assert _dependencies_done(item_e, items) is True
+    assert _auto_selectable_status(item_e) is True
 
     assert "ADE-QRE-011" in _stale_historical_ready_items(items)
-    assert _next_eligible_ready_item(items) == item_d
+    assert _next_eligible_ready_item(items) == item_e
 
     item_f = items["ADE-QRE-014F"]
     assert item_f.status.startswith("deferred")


### PR DESCRIPTION
## Summary
- mark ADE-QRE-014D done with PR #329 merge and validation evidence
- advance ADE-QRE-014E to ready
- update lifecycle validation to expect ADE-QRE-014E as the next eligible item

## Validation
- python -m pytest tests/unit/test_ade_qre_014_queue_lifecycle.py -q
- python scripts\governance_lint.py
- python -m reporting.architecture_import_scan --format summary
- git diff --check
- protected/frozen path diff check returned no files

## Safety
- docs/governance and lifecycle test only
- no strategy, registry, research output, frozen-contract, or execution-path changes
- strategy synthesis remains blocked