### PR TITLE
docs: mark ADE-QRE-014E done

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -589,7 +589,14 @@
 ### ADE-QRE-014E - Trusted-Loop Maturity Follow-up
 
 - queue id: `ADE-QRE-014E`
-- status: `ready`
+- status: `done`
+- completion evidence: PR #331, merge SHA
+  `c413603a6b5f04888385b83c0d66607e932ffdfd`; Fast pre-merge gate
+  run `26356885660`, Docker build/push run `26357012641`, and VPS
+  deploy run `26357012575` completed/success; local post-merge
+  governance lint and architecture scanner passed; Addendum 4 remained
+  `DEFERRED / REFERENCE-ONLY`; frozen contracts unchanged;
+  protected/execution paths untouched; strategy synthesis remained blocked.
 - title: Trusted-Loop Maturity Follow-up.
 - purpose: update the maturity matrix/status based on 014B-D evidence while
   keeping the result docs/reporting only.
@@ -690,7 +697,7 @@
 
 - queue id: `ADE-QRE-014G`
 - title: Synthesis Blocker Explanation Density.
-- status: `blocked until ADE-QRE-014E done`
+- status: `ready`
 - purpose: improve operator-readable explanation of why strategy synthesis
   remains blocked, using current readiness evidence only.
 - depends on: `ADE-QRE-014E done`.

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -132,6 +132,7 @@ def test_ade_qre_014_active_queue_lifecycle_is_consistent() -> None:
     item_c = items["ADE-QRE-014C"]
     item_d = items["ADE-QRE-014D"]
     item_e = items["ADE-QRE-014E"]
+    item_g = items["ADE-QRE-014G"]
 
     assert item_a.status == "done"
     assert _done_evidence_is_complete(item_a)
@@ -149,17 +150,23 @@ def test_ade_qre_014_active_queue_lifecycle_is_consistent() -> None:
     assert _dependencies_done(item_d, items) is True
     assert _auto_selectable_status(item_d) is False
 
-    assert item_e.status == "ready"
+    assert item_e.status == "done"
+    assert _done_evidence_is_complete(item_e)
     assert item_e.dependencies == ("ADE-QRE-014D",)
     assert _dependencies_done(item_e, items) is True
-    assert _auto_selectable_status(item_e) is True
+    assert _auto_selectable_status(item_e) is False
 
     assert "ADE-QRE-011" in _stale_historical_ready_items(items)
-    assert _next_eligible_ready_item(items) == item_e
 
     item_f = items["ADE-QRE-014F"]
     assert item_f.status.startswith("deferred")
     assert _auto_selectable_status(item_f) is False
+
+    assert item_g.status == "ready"
+    assert item_g.dependencies == ("ADE-QRE-014E",)
+    assert _dependencies_done(item_g, items) is True
+    assert _auto_selectable_status(item_g) is True
+    assert _next_eligible_ready_item(items) == item_g
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:


### PR DESCRIPTION
## Summary
- mark ADE-QRE-014E done with PR #331 merge and validation evidence
- keep ADE-QRE-014F deferred
- advance ADE-QRE-014G to ready as the next eligible read-only item

## Validation
- python -m pytest tests/unit/test_ade_qre_014_queue_lifecycle.py -q
- python scripts\governance_lint.py
- python -m reporting.architecture_import_scan --format summary
- git diff --check
- protected/frozen path diff check returned no files

## Safety
- docs/governance and lifecycle test only
- no strategy, registry, research output, frozen-contract, or execution-path changes
- Addendum 4 remains DEFERRED / REFERENCE-ONLY
- strategy synthesis remains blocked