### PR TITLE
docs: mark ADE-QRE-014G done

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -697,7 +697,13 @@
 
 - queue id: `ADE-QRE-014G`
 - title: Synthesis Blocker Explanation Density.
-- status: `ready`
+- status: `done`
+- completion evidence: PR #333, merge SHA
+  `51c5c033e7339ebfd6bf23bd4fa8ef4894f8d63d`; Fast pre-merge gate
+  run `26357671265`, Docker build/push run `26357791138`, and VPS
+  deploy run `26357791137` completed/success; local post-merge targeted
+  test and architecture scanner passed; frozen contracts unchanged;
+  protected/execution paths untouched; strategy synthesis remained blocked.
 - purpose: improve operator-readable explanation of why strategy synthesis
   remains blocked, using current readiness evidence only.
 - depends on: `ADE-QRE-014E done`.
@@ -772,7 +778,7 @@
 
 - queue id: `ADE-QRE-014H`
 - title: Failure-to-Action Actionability Density.
-- status: `blocked until ADE-QRE-014G done`
+- status: `ready`
 - purpose: improve measurable density of actionable failure-to-action mappings
   from existing evidence without inventing causes.
 - depends on: `ADE-QRE-014G done`.

--- a/frontend/src/test/AgentControlActivity.test.tsx
+++ b/frontend/src/test/AgentControlActivity.test.tsx
@@ -366,6 +366,7 @@ describe("AgentActivity Pipeline", () => {
   it("renders 11 stage chips in closed-vocab order", async () => {
     mount("/agent-control/activity/pipeline");
     await screen.findByTestId("aac-section-pipeline");
+    await screen.findByTestId("aac-pipeline-chip-discovered");
     const expectedStages = [
       "discovered",
       "queued",

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -133,6 +133,7 @@ def test_ade_qre_014_active_queue_lifecycle_is_consistent() -> None:
     item_d = items["ADE-QRE-014D"]
     item_e = items["ADE-QRE-014E"]
     item_g = items["ADE-QRE-014G"]
+    item_h = items["ADE-QRE-014H"]
 
     assert item_a.status == "done"
     assert _done_evidence_is_complete(item_a)
@@ -162,11 +163,17 @@ def test_ade_qre_014_active_queue_lifecycle_is_consistent() -> None:
     assert item_f.status.startswith("deferred")
     assert _auto_selectable_status(item_f) is False
 
-    assert item_g.status == "ready"
+    assert item_g.status == "done"
+    assert _done_evidence_is_complete(item_g)
     assert item_g.dependencies == ("ADE-QRE-014E",)
     assert _dependencies_done(item_g, items) is True
-    assert _auto_selectable_status(item_g) is True
-    assert _next_eligible_ready_item(items) == item_g
+    assert _auto_selectable_status(item_g) is False
+
+    assert item_h.status == "ready"
+    assert item_h.dependencies == ("ADE-QRE-014G",)
+    assert _dependencies_done(item_h, items) is True
+    assert _auto_selectable_status(item_h) is True
+    assert _next_eligible_ready_item(items) == item_h
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:


### PR DESCRIPTION
## Summary
- mark ADE-QRE-014G done with PR #333 merge and validation evidence
- advance ADE-QRE-014H to ready because its prerequisite is now done
- update queue lifecycle validation to select 014H next

## Validation
- `python -m pytest tests/unit/test_ade_qre_014_queue_lifecycle.py -q`
- `python scripts/governance_lint.py`
- `python -m reporting.architecture_import_scan --format summary` -> `forbidden_edge_count = 0`
- `git diff --check`
- protected/execution path diff check -> no matches

## Guardrails
- docs/test status update only
- no strategy or registry changes
- no frozen contract changes
- no protected/execution path changes
- strategy synthesis remains blocked