### PR TITLE
feat: add failure actionability density

### DIFF
--- a/docs/governance/failure_action_actionability_density.md
+++ b/docs/governance/failure_action_actionability_density.md
@@ -1,0 +1,57 @@
+# Failure-Action Actionability Density
+
+> Status: ADE-QRE-014H implementation note.
+>
+> Runtime authority: read-only reporting. This note does not activate strategy
+> synthesis, routing mutation, campaign mutation, dashboard mutation routes,
+> approval mutation, Addendum runtime behavior, or paper/shadow/live execution.
+
+`reporting.failure_action_mapping_minimal` measures actionability density over
+existing failure-action mappings only. It does not infer causes, run research,
+generate strategies, or mutate any queue.
+
+## Density Rule
+
+A mapping is actionable only when all of the following are true:
+
+- the failure code is already in the closed failure taxonomy;
+- the recommended action is already in the bounded action vocabulary;
+- `evidence_count` is at least
+  `MIN_EVIDENCE_FOR_RESEARCH_ACTION`;
+- the recommendation is not `hold_no_action`;
+- the recommendation is not `preserve_negative_result`.
+
+The density is:
+
+```text
+actionability_density = actionable_mappings / total_mappings
+```
+
+When there are no mappings, density is `null` and the report fails closed.
+
+## Non-Actionable Reasons
+
+Non-actionable mappings remain explicit under
+`counts.non_actionable_by_reason` and each item carries an
+`actionability.reason_codes` list.
+
+Closed non-actionable reasons:
+
+- `insufficient_evidence`
+- `hold_action`
+- `negative_result_preservation`
+
+These reasons are derived only from existing input fields and the closed mapping
+policy. They are not root-cause claims.
+
+## Operator Output
+
+The report emits:
+
+- per-item `actionability` status and operator explanation;
+- aggregate `counts.actionable_recommendations`;
+- aggregate `counts.non_actionable_recommendations`;
+- aggregate `actionability.actionability_density`;
+- aggregate `actionability.operator_summary`.
+
+`safe_to_execute` remains `false` and `mode` remains `dry-run`.

--- a/reporting/failure_action_mapping_minimal.py
+++ b/reporting/failure_action_mapping_minimal.py
@@ -26,7 +26,7 @@ from pathlib import Path
 from typing import Any, Final
 
 REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
-MODULE_VERSION: Final[str] = "v3.15.20-minimal-reactivated-2026-05-21"
+MODULE_VERSION: Final[str] = "v3.15.20-ade-qre-014h-actionability-density-2026-05-24"
 SCHEMA_VERSION: Final[int] = 1
 REPORT_KIND: Final[str] = "failure_action_mapping_minimal_digest"
 
@@ -61,6 +61,14 @@ NEXT_ACTIONS: Final[tuple[str, ...]] = (
     "hold_no_action",
 )
 
+ACTIONABILITY_STATUSES: Final[tuple[str, ...]] = ("actionable", "non_actionable")
+
+NON_ACTIONABLE_REASON_CODES: Final[tuple[str, ...]] = (
+    "insufficient_evidence",
+    "hold_action",
+    "negative_result_preservation",
+)
+
 SEVERITIES: Final[tuple[str, ...]] = ("low", "medium", "high")
 
 REASON_CODES: Final[tuple[str, ...]] = (
@@ -84,6 +92,7 @@ OUTPUT_ITEM_KEYS: Final[tuple[str, ...]] = (
     "severity",
     "evidence_count",
     "recommended_action",
+    "actionability",
     "rank",
     "reason_record",
 )
@@ -178,6 +187,12 @@ def _bounded_int(value: Any) -> int:
     if isinstance(value, bool) or not isinstance(value, int | float):
         return 0
     return max(0, int(value))
+
+
+def _ratio(numerator: int, denominator: int) -> float | None:
+    if denominator <= 0:
+        return None
+    return round(numerator / denominator, 6)
 
 
 def _canonical_json(value: Mapping[str, Any]) -> str:
@@ -295,7 +310,8 @@ def _reason_for(
     elif evidence_count < MIN_EVIDENCE_FOR_RESEARCH_ACTION:
         text = (
             f"Failure code {failure_code} has only {evidence_count} "
-            "evidence records; recommendation is bounded and advisory."
+            "evidence records; recommendation is not actionable until "
+            "evidence meets the minimum threshold."
         )
     else:
         text = f"Failure code {failure_code} maps deterministically to " f"{recommended_action}."
@@ -340,6 +356,43 @@ def _build_reason_record(
     }
 
 
+def _actionability_for(
+    *,
+    failure_code: str,
+    evidence_count: int,
+    recommended_action: str,
+) -> dict[str, Any]:
+    reason_codes: list[str] = []
+    if evidence_count < MIN_EVIDENCE_FOR_RESEARCH_ACTION:
+        reason_codes.append("insufficient_evidence")
+    if recommended_action == "hold_no_action" or failure_code == "unknown_failure":
+        reason_codes.append("hold_action")
+    if recommended_action == "preserve_negative_result":
+        reason_codes.append("negative_result_preservation")
+
+    is_actionable = not reason_codes
+    status = "actionable" if is_actionable else "non_actionable"
+    if is_actionable:
+        explanation = (
+            f"{failure_code} has {evidence_count} evidence records and maps "
+            f"to operator action {recommended_action}."
+        )
+    else:
+        explanation = (
+            f"{failure_code} maps to {recommended_action} but remains "
+            f"non-actionable because {', '.join(reason_codes)}."
+        )
+    return {
+        "status": status,
+        "is_actionable": is_actionable,
+        "reason_codes": reason_codes,
+        "evidence_count": evidence_count,
+        "minimum_evidence_count": MIN_EVIDENCE_FOR_RESEARCH_ACTION,
+        "evidence_refs": _evidence_refs_for_failure(),
+        "operator_explanation": explanation,
+    }
+
+
 def collect_snapshot(
     failures: Sequence[Mapping[str, Any]] | None = None,
     *,
@@ -363,6 +416,11 @@ def collect_snapshot(
             evidence_count=evidence_count,
             recommended_action=recommended_action,
         )
+        actionability = _actionability_for(
+            failure_code=failure_code,
+            evidence_count=evidence_count,
+            recommended_action=recommended_action,
+        )
         items.append(
             {
                 "subject_id": subject_id,
@@ -370,6 +428,7 @@ def collect_snapshot(
                 "severity": severity,
                 "evidence_count": evidence_count,
                 "recommended_action": recommended_action,
+                "actionability": actionability,
                 "rank": -1,
                 "reason_record": record,
             }
@@ -392,11 +451,25 @@ def collect_snapshot(
         counts_by_action[item["recommended_action"]] += 1
         counts_by_failure[item["failure_code"]] += 1
 
-    actionable_count = sum(
-        count
-        for action, count in counts_by_action.items()
-        if action not in {"hold_no_action", "preserve_negative_result"}
-    )
+    actionable_count = sum(1 for item in items if item["actionability"]["is_actionable"])
+    non_actionable_by_reason = {code: 0 for code in NON_ACTIONABLE_REASON_CODES}
+    for item in items:
+        for code in item["actionability"]["reason_codes"]:
+            non_actionable_by_reason[code] += 1
+    non_actionable_count = len(items) - actionable_count
+    density = _ratio(actionable_count, len(items))
+    if not items:
+        operator_summary = "No failure evidence is available; actionability fails closed."
+    elif actionable_count:
+        operator_summary = (
+            f"{actionable_count}/{len(items)} failure-action mappings are actionable "
+            f"(density={density})."
+        )
+    else:
+        operator_summary = (
+            "No failure-action mappings are actionable with current evidence; "
+            "non-actionable mappings remain explicit."
+        )
 
     return {
         "schema_version": SCHEMA_VERSION,
@@ -410,6 +483,19 @@ def collect_snapshot(
             "by_failure_code": counts_by_failure,
             "by_recommended_action": counts_by_action,
             "actionable_recommendations": actionable_count,
+            "non_actionable_recommendations": non_actionable_count,
+            "non_actionable_by_reason": non_actionable_by_reason,
+        },
+        "actionability": {
+            "status": "ready" if actionable_count else "not_ready",
+            "fail_closed": actionable_count == 0,
+            "total_mappings": len(items),
+            "actionable_mappings": actionable_count,
+            "non_actionable_mappings": non_actionable_count,
+            "actionability_density": density,
+            "minimum_evidence_count": MIN_EVIDENCE_FOR_RESEARCH_ACTION,
+            "non_actionable_by_reason": non_actionable_by_reason,
+            "operator_summary": operator_summary,
         },
         "items": items,
         "final_recommendation": ("actions_available" if actionable_count else "nothing_actionable"),

--- a/tests/unit/test_failure_action_mapping_minimal.py
+++ b/tests/unit/test_failure_action_mapping_minimal.py
@@ -50,6 +50,12 @@ def test_closed_taxonomies_are_pinned() -> None:
         "review_cost_assumptions",
         "hold_no_action",
     )
+    assert fam.ACTIONABILITY_STATUSES == ("actionable", "non_actionable")
+    assert fam.NON_ACTIONABLE_REASON_CODES == (
+        "insufficient_evidence",
+        "hold_action",
+        "negative_result_preservation",
+    )
     assert fam.SCREENING_CLASSIFICATION_TO_FAILURE_CODE["data_coverage_gap"] == (
         "technical_failure"
     )
@@ -71,6 +77,7 @@ def test_schema_keys_are_pinned() -> None:
         "severity",
         "evidence_count",
         "recommended_action",
+        "actionability",
         "rank",
         "reason_record",
     )
@@ -163,6 +170,10 @@ def test_low_evidence_adds_insufficient_reason() -> None:
         frozen_utc="2026-05-21T00:00:00Z",
     )
     assert "evidence_insufficient" in snap["items"][0]["reason_record"]["reason_codes"]
+    assert snap["items"][0]["actionability"]["status"] == "non_actionable"
+    assert snap["items"][0]["actionability"]["reason_codes"] == ["insufficient_evidence"]
+    assert snap["counts"]["actionable_recommendations"] == 0
+    assert snap["actionability"]["fail_closed"] is True
 
 
 def test_negative_result_preservation_is_explicit() -> None:
@@ -173,6 +184,84 @@ def test_negative_result_preservation_is_explicit() -> None:
     record = snap["items"][0]["reason_record"]
     assert snap["items"][0]["recommended_action"] == "preserve_negative_result"
     assert "negative_result_preserved" in record["reason_codes"]
+    assert snap["items"][0]["actionability"]["status"] == "non_actionable"
+    assert snap["items"][0]["actionability"]["reason_codes"] == [
+        "negative_result_preservation"
+    ]
+
+
+def test_actionability_density_counts_only_evidence_backed_actions() -> None:
+    snap = fam.collect_snapshot(
+        [
+            _f(subject_id="a", failure_code="high_drawdown", evidence_count=3),
+            _f(subject_id="b", failure_code="weak_stability", evidence_count=4),
+            _f(subject_id="c", failure_code="insufficient_trades", evidence_count=1),
+            _f(subject_id="d", failure_code="unknown_failure", evidence_count=8),
+            _f(subject_id="e", failure_code="low_win_rate", evidence_count=8),
+        ],
+        frozen_utc="2026-05-21T00:00:00Z",
+    )
+
+    assert snap["counts"]["total"] == 5
+    assert snap["counts"]["actionable_recommendations"] == 2
+    assert snap["counts"]["non_actionable_recommendations"] == 3
+    assert snap["counts"]["non_actionable_by_reason"] == {
+        "insufficient_evidence": 1,
+        "hold_action": 1,
+        "negative_result_preservation": 1,
+    }
+    assert snap["actionability"] == {
+        "status": "ready",
+        "fail_closed": False,
+        "total_mappings": 5,
+        "actionable_mappings": 2,
+        "non_actionable_mappings": 3,
+        "actionability_density": 0.4,
+        "minimum_evidence_count": fam.MIN_EVIDENCE_FOR_RESEARCH_ACTION,
+        "non_actionable_by_reason": {
+            "insufficient_evidence": 1,
+            "hold_action": 1,
+            "negative_result_preservation": 1,
+        },
+        "operator_summary": "2/5 failure-action mappings are actionable (density=0.4).",
+    }
+    assert [
+        item["subject_id"] for item in snap["items"] if item["actionability"]["is_actionable"]
+    ] == [
+        "a",
+        "b",
+    ]
+
+
+def test_missing_or_thin_evidence_fails_closed_without_inventing_cause() -> None:
+    snap = fam.collect_snapshot(
+        [
+            _f(subject_id="unknown", failure_code="unknown_failure", evidence_count=0),
+            _f(subject_id="thin", failure_code="high_drawdown", evidence_count=1),
+        ],
+        frozen_utc="2026-05-21T00:00:00Z",
+    )
+
+    assert snap["final_recommendation"] == "nothing_actionable"
+    assert snap["actionability"]["status"] == "not_ready"
+    assert snap["actionability"]["fail_closed"] is True
+    assert snap["actionability"]["actionability_density"] == 0.0
+    by_subject = {item["subject_id"]: item for item in snap["items"]}
+    assert by_subject["unknown"]["failure_code"] == "unknown_failure"
+    assert by_subject["unknown"]["recommended_action"] == "hold_no_action"
+    assert by_subject["unknown"]["actionability"]["reason_codes"] == [
+        "insufficient_evidence",
+        "hold_action",
+    ]
+    assert by_subject["thin"]["failure_code"] == "high_drawdown"
+    assert by_subject["thin"]["recommended_action"] == "apply_volatility_filter"
+    assert by_subject["thin"]["actionability"]["reason_codes"] == [
+        "insufficient_evidence"
+    ]
+    rendered = json.dumps(snap, sort_keys=True).lower()
+    assert "root_cause" not in rendered
+    assert "inferred_cause" not in rendered
+    assert "probable_cause" not in rendered
 
 
 def test_ranking_orders_by_severity_then_failure_then_subject() -> None:
@@ -221,6 +310,9 @@ def test_record_ids_change_when_inputs_change() -> None:
 def test_empty_snapshot_is_safe_and_not_actionable() -> None:
     snap = fam.collect_snapshot([], frozen_utc="2026-05-21T00:00:00Z")
     assert snap["counts"]["total"] == 0
+    assert snap["counts"]["non_actionable_recommendations"] == 0
+    assert snap["actionability"]["actionability_density"] is None
+    assert snap["actionability"]["fail_closed"] is True
     assert snap["safe_to_execute"] is False
     assert snap["mode"] == "dry-run"
     assert snap["final_recommendation"] == "nothing_actionable"


### PR DESCRIPTION
## Summary
- add deterministic per-mapping actionability status and density metrics to failure-action mapping output
- fail closed for missing/thin evidence and keep non-actionable mappings explicit
- document ADE-QRE-014H actionability density semantics

## Validation
- python -m pytest tests\unit\test_failure_action_mapping_minimal.py tests\unit\test_research_observability_minimal.py tests\unit\test_qre_research_diagnostics_loop.py -q
- python -m pytest tests\architecture -q
- python -m reporting.architecture_import_scan --format summary
- git diff --cached --check
- python -m ruff check reporting\failure_action_mapping_minimal.py tests\unit\test_failure_action_mapping_minimal.py
- python scripts\governance_lint.py
- python -m pytest tests\regression -q -k "pin or deterministic or digest or invariant"
- python -m pytest tests\unit\test_hook_runtime.py tests\unit\test_hooks_audit_emit.py tests\unit\test_hooks_config_read.py tests\unit\test_hooks_dangerous_bash.py tests\unit\test_hooks_live_connector.py tests\unit\test_hooks_no_touch.py tests\unit\test_hooks_outside_allowlist.py tests\unit\test_hooks_precompact.py tests\unit\test_hooks_test_weakening.py tests\unit\test_agent_audit.py -q

Note: local full smoke+unit timed out after 10 minutes without a summary; PR CI remains the required Fast pre-merge gate.

## Scope checks
- no registry, strategy, frozen research outputs, or execution paths touched
- no strategy synthesis, routing mutation, campaign mutation, approval mutation, or Addendum runtime activation
