### PR TITLE
docs: mark ADE-QRE-014H done

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -778,7 +778,15 @@
 
 - queue id: `ADE-QRE-014H`
 - title: Failure-to-Action Actionability Density.
-- status: `ready`
+- status: `done`
+- completion evidence: PR #335, merge SHA
+  `1be8bbcc9b3142e7d17f6f70b10f294391bad812`; Fast pre-merge gate
+  run `26368474272`, Docker build/push run `26368596439`, and VPS
+  deploy run `26368596459` completed/success; local targeted
+  actionability tests, architecture tests, governance lint, ruff, mypy,
+  regression-fast, hook tests, `git diff --check`, and architecture
+  scanner passed; frozen contracts unchanged; protected/execution paths
+  untouched; strategy synthesis remained blocked.
 - purpose: improve measurable density of actionable failure-to-action mappings
   from existing evidence without inventing causes.
 - depends on: `ADE-QRE-014G done`.
@@ -849,7 +857,7 @@
 
 - queue id: `ADE-QRE-014I`
 - title: Operator Decision Surface Readiness.
-- status: `blocked until ADE-QRE-014H done`
+- status: `ready`
 - purpose: make operator-facing decision outputs clearer: why next, why
   blocked, why deferred, and why no synthesis.
 - depends on: `ADE-QRE-014H done`.

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -134,6 +134,7 @@ def test_ade_qre_014_active_queue_lifecycle_is_consistent() -> None:
     item_e = items["ADE-QRE-014E"]
     item_g = items["ADE-QRE-014G"]
     item_h = items["ADE-QRE-014H"]
+    item_i = items["ADE-QRE-014I"]
 
     assert item_a.status == "done"
     assert _done_evidence_is_complete(item_a)
@@ -169,11 +170,17 @@ def test_ade_qre_014_active_queue_lifecycle_is_consistent() -> None:
     assert _dependencies_done(item_g, items) is True
     assert _auto_selectable_status(item_g) is False
 
-    assert item_h.status == "ready"
+    assert item_h.status == "done"
+    assert _done_evidence_is_complete(item_h)
     assert item_h.dependencies == ("ADE-QRE-014G",)
     assert _dependencies_done(item_h, items) is True
-    assert _auto_selectable_status(item_h) is True
-    assert _next_eligible_ready_item(items) == item_h
+    assert _auto_selectable_status(item_h) is False
+
+    assert item_i.status == "ready"
+    assert item_i.dependencies == ("ADE-QRE-014H",)
+    assert _dependencies_done(item_i, items) is True
+    assert _auto_selectable_status(item_i) is True
+    assert _next_eligible_ready_item(items) == item_i
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:


### PR DESCRIPTION
## Summary
- mark ADE-QRE-014H done after implementation PR #335 merged and post-merge gates passed
- record PR, merge SHA, Fast pre-merge, Docker build/push, and VPS deploy evidence
- set ADE-QRE-014I to ready without starting implementation

## Validation
- git diff --check
- python -m reporting.architecture_import_scan --format summary

## Scope checks
- docs/governance queue status only
- no runtime, strategy, frozen contract, routing, campaign, approval, dashboard mutation, Addendum activation, or execution path changes
