### PR TITLE
docs: mark ADE-QRE-014I done

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -857,7 +857,17 @@
 
 - queue id: `ADE-QRE-014I`
 - title: Operator Decision Surface Readiness.
-- status: `ready`
+- status: `done`
+- completion evidence: PR #337, merge SHA
+  `010d2ca652141bb4d304aad59820d51fdc5435ed`; post-merge Fast
+  pre-merge gate run `26371365964`, Docker build/push run
+  `26371490198`, and VPS deploy run `26371490206` completed/success;
+  local targeted decision-surface tests, queue lifecycle tests,
+  trusted-loop materialization tests, architecture tests, governance lint,
+  ruff, mypy, regression-fast, hook tests, `git diff --check`, and
+  architecture scanner passed; frozen contracts unchanged;
+  protected/execution paths untouched; strategy synthesis remained blocked;
+  Addendum runtime remained inactive.
 - purpose: make operator-facing decision outputs clearer: why next, why
   blocked, why deferred, and why no synthesis.
 - depends on: `ADE-QRE-014H done`.
@@ -928,7 +938,7 @@
 
 - queue id: `ADE-QRE-014J`
 - title: Research Memory Retrieval Coverage.
-- status: `blocked until ADE-QRE-014I done`
+- status: `ready`
 - purpose: measure whether prior trusted-loop reasons, failures, blockers, and
   actions are retrievable and linked enough for later routing/sampling
   calibration.

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -135,6 +135,7 @@ def test_ade_qre_014_active_queue_lifecycle_is_consistent() -> None:
     item_g = items["ADE-QRE-014G"]
     item_h = items["ADE-QRE-014H"]
     item_i = items["ADE-QRE-014I"]
+    item_j = items["ADE-QRE-014J"]
 
     assert item_a.status == "done"
     assert _done_evidence_is_complete(item_a)
@@ -176,11 +177,17 @@ def test_ade_qre_014_active_queue_lifecycle_is_consistent() -> None:
     assert _dependencies_done(item_h, items) is True
     assert _auto_selectable_status(item_h) is False
 
-    assert item_i.status == "ready"
+    assert item_i.status == "done"
+    assert _done_evidence_is_complete(item_i)
     assert item_i.dependencies == ("ADE-QRE-014H",)
     assert _dependencies_done(item_i, items) is True
-    assert _auto_selectable_status(item_i) is True
-    assert _next_eligible_ready_item(items) == item_i
+    assert _auto_selectable_status(item_i) is False
+
+    assert item_j.status == "ready"
+    assert item_j.dependencies == ("ADE-QRE-014I",)
+    assert _dependencies_done(item_j, items) is True
+    assert _auto_selectable_status(item_j) is True
+    assert _next_eligible_ready_item(items) == item_j
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:


### PR DESCRIPTION
## Summary
- Marks ADE-QRE-014I done after implementation PR #337 merged and post-merge gates passed.
- Moves ADE-QRE-014J from blocked to ready, without starting 014J.
- Updates the ADE-QRE-014 lifecycle guard test to expect 014J as the next eligible ready item.

## Local validation
- `python -m pytest tests/unit/test_ade_qre_014_queue_lifecycle.py tests/unit/test_operator_decision_surface.py -q` -> 16 passed
- `python -m reporting.operator_decision_surface --no-write --frozen-utc 2026-05-24T00:00:00Z` -> reports ADE-QRE-014J as next, remaining blockers/deferred/no-synthesis explicit
- `python -m ruff check tests/unit/test_ade_qre_014_queue_lifecycle.py` -> passed
- `python -m reporting.architecture_import_scan --format summary` -> `forbidden_edge_count=0`
- `git diff --check --cached` -> passed

## Gate evidence recorded
- PR #337 merged at `010d2ca652141bb4d304aad59820d51fdc5435ed`
- Fast pre-merge gate run `26371365964` completed/success
- Docker build/push run `26371490198` completed/success
- VPS deploy run `26371490206` completed/success

## Scope
Docs/test lifecycle update only. No strategy synthesis, Addendum runtime activation, frozen contract changes, registry/strategy changes, campaign/routing mutation, dashboard mutation routes, or execution paths.
