### PR TITLE
feat: add research retrieval coverage report

### DIFF
--- a/docs/governance/qre_research_retrieval_coverage.md
+++ b/docs/governance/qre_research_retrieval_coverage.md
@@ -1,0 +1,40 @@
+# QRE Research Retrieval Coverage
+
+`packages.qre_research.retrieval_coverage` measures whether trusted-loop
+reasons, failures, blockers, and actions are retrievable from local artifacts
+with explicit link signals.
+
+The report uses Roadmap v6 Addendum 2 only as a reference taxonomy for memory
+and retrieval coverage. It does not activate Addendum 2 at runtime, grant
+authority, mutate routing or sampling, create strategies, use embeddings, call
+network services, or use a vector database.
+
+## Commands
+
+Dry-run the coverage report:
+
+```powershell
+python -m packages.qre_research.retrieval_coverage --no-write --frozen-utc 2026-05-25T00:00:00Z
+```
+
+Read latest status:
+
+```powershell
+python -m packages.qre_research.retrieval_coverage --status
+```
+
+Write deterministic sidecars under `logs/qre_research_retrieval_coverage/`:
+
+```powershell
+python -m packages.qre_research.retrieval_coverage
+```
+
+## Operator Output
+
+The output reports:
+
+- which trusted-loop surfaces can be retrieved;
+- which surfaces have matches but lack required link signals;
+- which local artifacts are missing;
+- that retrieval is context only and cannot route, sample, approve, synthesize,
+  or mutate campaigns.

--- a/packages/qre_research/README.md
+++ b/packages/qre_research/README.md
@@ -8,7 +8,8 @@ run-domain contracts.
 
 ## Current Status
 
-Status: active read-only boundary seed plus ADE-QRE-005 research memory helper.
+Status: active read-only boundary seed plus ADE-QRE-005 research memory helper
+and ADE-QRE-014J retrieval-coverage reporter.
 The canonical research universe contract now lives in
 `packages.qre_research.universe`; deterministic local artifact indexing and
 retrieval live in `packages.qre_research.research_memory`; current QRE
@@ -27,6 +28,11 @@ with `research.universe` retained as the compatibility import path.
 retrieval helper. It does not use embeddings, LLM authority, graph databases,
 network calls, subprocess calls, campaign mutation, routing mutation, or
 strategy generation.
+
+`packages.qre_research.retrieval_coverage` measures whether trusted-loop
+reasons, failures, blockers, and actions can be retrieved with explicit local
+links. It is an operator-readable coverage report only; retrieval remains
+context, not authority.
 
 ## Allowed Future Contents
 

--- a/packages/qre_research/retrieval_coverage.py
+++ b/packages/qre_research/retrieval_coverage.py
@@ -1,0 +1,388 @@
+"""Deterministic no-authority retrieval coverage over trusted-loop memory."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import sys
+from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+from packages.qre_research import research_memory
+
+SCHEMA_VERSION: Final[int] = 1
+MODULE_VERSION: Final[str] = "ade-qre-014j-2026-05-25"
+REPORT_KIND: Final[str] = "qre_research_memory_retrieval_coverage"
+
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_research_retrieval_coverage")
+LATEST_NAME: Final[str] = "latest.json"
+HISTORY_NAME: Final[str] = "history.jsonl"
+_WRITE_PREFIX: Final[str] = "logs/qre_research_retrieval_coverage/"
+
+DEFAULT_ARTIFACT_PATHS: Final[tuple[Path, ...]] = (
+    Path("docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md"),
+    Path("logs/reason_records/manifest.v1.json"),
+    Path("logs/reason_record_evidence_density/latest.json"),
+    Path("logs/failure_action_mapping_minimal/latest.json"),
+    Path("logs/qre_research_diagnostics_loop/latest.json"),
+    Path("logs/research_observability_minimal/latest.json"),
+    Path("logs/trusted_loop_materialization/latest.json"),
+    Path("logs/intelligent_routing_minimal/latest.json"),
+    Path("logs/sampling_intelligence_minimal/latest.json"),
+)
+
+_COVERAGE_SPECS: Final[tuple[dict[str, Any], ...]] = (
+    {
+        "coverage_id": "trusted_loop_reasons",
+        "label": "prior trusted-loop reasons",
+        "query": "reason reason_codes reason_text evidence_refs trusted loop",
+        "required_link_signals": (
+            "evidence_refs",
+            "reason_codes",
+            "record_id",
+            "subject_id",
+            "source_ref",
+        ),
+        "operator_need": "find why a prior routing, sampling, scoring, or blocker decision existed",
+    },
+    {
+        "coverage_id": "trusted_loop_failures",
+        "label": "prior trusted-loop failures",
+        "query": "failure failed classification raw_reasons failure_action_mapping",
+        "required_link_signals": (
+            "action_hint",
+            "classification",
+            "failure_action",
+            "raw_reasons",
+            "total_failures",
+        ),
+        "operator_need": "find earlier failure context before repeating similar research",
+    },
+    {
+        "coverage_id": "trusted_loop_blockers",
+        "label": "prior trusted-loop blockers",
+        "query": "blocker blocked block_reasons missing_evidence fail_closed",
+        "required_link_signals": (
+            "block_reasons",
+            "blocking_reasons",
+            "fail_closed",
+            "missing_evidence",
+            "synthesis_blocker",
+        ),
+        "operator_need": "find active or historical blockers and the evidence they lack",
+    },
+    {
+        "coverage_id": "trusted_loop_actions",
+        "label": "prior trusted-loop actions",
+        "query": "action policy_action recommended_next_action recommended_operator_step action_hint",
+        "required_link_signals": (
+            "action_hint",
+            "actionable",
+            "operator_explanation",
+            "policy_action",
+            "recommended_next_action",
+            "recommended_operator_step",
+        ),
+        "operator_need": "find the prior next-action or stop-action attached to evidence",
+    },
+)
+
+
+def _utcnow() -> str:
+    return _dt.datetime.now(_dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _rel(path: Path, *, root: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _match_link_signals(
+    match: Mapping[str, Any],
+    *,
+    required_link_signals: Sequence[str],
+) -> list[str]:
+    haystack = " ".join(
+        str(match.get(key) or "")
+        for key in (
+            "artifact_id",
+            "artifact_path",
+            "record_kind",
+            "title",
+            "text_preview",
+        )
+    ).lower()
+    return sorted({signal for signal in required_link_signals if signal in haystack})
+
+
+def _coverage_row(
+    *,
+    memory: Mapping[str, Any],
+    spec: Mapping[str, Any],
+    limit: int,
+) -> dict[str, Any]:
+    matches = research_memory.retrieve(memory, str(spec["query"]), limit=limit)
+    required = tuple(str(signal) for signal in spec["required_link_signals"])
+    annotated_matches: list[dict[str, Any]] = []
+    linked_count = 0
+    for match in matches:
+        signals = _match_link_signals(match, required_link_signals=required)
+        linked = bool(signals)
+        linked_count += int(linked)
+        annotated_matches.append(
+            {
+                "artifact_id": match["artifact_id"],
+                "artifact_path": match["artifact_path"],
+                "record_kind": match["record_kind"],
+                "title": match["title"],
+                "score": match["score"],
+                "ontology_tags": match["ontology_tags"],
+                "link_signals": signals,
+                "linked_enough_for_calibration_context": linked,
+                "text_preview": match["text_preview"],
+            }
+        )
+
+    if not matches:
+        status = "missing_retrieval"
+        missing_links = ["no_retrieval_matches"]
+    elif linked_count == 0:
+        status = "missing_link"
+        missing_links = [f"no_required_link_signals:{','.join(required)}"]
+    else:
+        status = "covered"
+        missing_links = []
+
+    return {
+        "coverage_id": spec["coverage_id"],
+        "label": spec["label"],
+        "status": status,
+        "query": spec["query"],
+        "operator_need": spec["operator_need"],
+        "required_link_signals": list(required),
+        "retrieved_match_count": len(matches),
+        "linked_match_count": linked_count,
+        "missing_retrieval_links": missing_links,
+        "matches": annotated_matches,
+        "retrieval_role": "context_only_not_authority",
+    }
+
+
+def _operator_summary(rows: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    can_retrieve = [str(row["label"]) for row in rows if row.get("status") == "covered"]
+    cannot_retrieve = [
+        {
+            "label": row["label"],
+            "status": row["status"],
+            "missing_retrieval_links": row["missing_retrieval_links"],
+        }
+        for row in rows
+        if row.get("status") != "covered"
+    ]
+    if not cannot_retrieve:
+        text = (
+            "Trusted-loop reasons, failures, blockers, and actions are retrievable "
+            "as context with explicit local links. Retrieval remains non-authoritative."
+        )
+    else:
+        text = (
+            "Some trusted-loop retrieval surfaces are missing matches or link "
+            "signals; inspect missing_retrieval_links before using retrieval for "
+            "routing or sampling calibration context."
+        )
+    return {
+        "can_retrieve": can_retrieve,
+        "cannot_retrieve": cannot_retrieve,
+        "summary": text,
+    }
+
+
+def build_retrieval_coverage(
+    *,
+    artifact_paths: Iterable[Path] | None = None,
+    repo_root: Path = Path("."),
+    generated_at_utc: str | None = None,
+    limit: int = 8,
+) -> dict[str, Any]:
+    ts = generated_at_utc or _utcnow()
+    memory = research_memory.build_research_memory(
+        artifact_paths=artifact_paths or DEFAULT_ARTIFACT_PATHS,
+        repo_root=repo_root,
+        generated_at_utc=ts,
+    )
+    rows = [
+        _coverage_row(memory=memory, spec=spec, limit=limit)
+        for spec in _COVERAGE_SPECS
+    ]
+    covered_count = sum(1 for row in rows if row["status"] == "covered")
+    missing_count = len(rows) - covered_count
+    summary = {
+        "status": "ready" if missing_count == 0 else "not_ready",
+        "retrieval_coverage_ready": missing_count == 0,
+        "required_surface_count": len(rows),
+        "covered_surface_count": covered_count,
+        "missing_or_unlinked_surface_count": missing_count,
+        "coverage_score": round(covered_count / len(rows), 6) if rows else 0.0,
+        "memory_entry_count": memory["summary"]["entry_count"],
+        "missing_artifact_count": memory["summary"]["missing_artifact_count"],
+        "missing_artifacts": memory["missing_artifacts"],
+    }
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": ts,
+        "mode": "dry-run",
+        "safe_to_execute": False,
+        "summary": summary,
+        "addendum_reference": {
+            "source": "Roadmap v6 Addendum 2",
+            "usage": "reference_taxonomy_only",
+            "runtime_activation": False,
+        },
+        "coverage": rows,
+        "operator_summary": _operator_summary(rows),
+        "memory_summary": memory["summary"],
+        "artifact_paths": memory["artifact_paths"],
+        "missing_artifacts": memory["missing_artifacts"],
+        "authority_boundary": {
+            "retrieval_is_context_not_authority": True,
+            "can_inform_later_calibration_review": True,
+            "can_route_or_sample": False,
+            "can_mutate_campaigns": False,
+            "can_approve_or_synthesize_strategies": False,
+        },
+        "safety_invariants": {
+            "read_only": True,
+            "uses_local_artifacts_only": True,
+            "uses_vector_database": False,
+            "uses_embeddings": False,
+            "uses_hidden_ml": False,
+            "uses_llm_authority": False,
+            "uses_network": False,
+            "uses_subprocess": False,
+            "activates_addendum_runtime": False,
+            "mutates_campaigns": False,
+            "mutates_routing": False,
+            "mutates_research_outputs": False,
+            "enables_strategy_synthesis": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+        },
+    }
+
+
+def _validate_write_target(path: Path) -> None:
+    normalized = path.as_posix()
+    if _WRITE_PREFIX not in normalized:
+        raise ValueError(f"retrieval_coverage: refusing write outside allowlist: {path!r}")
+
+
+def write_retrieval_coverage_outputs(
+    snapshot: Mapping[str, Any],
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = Path("."),
+) -> dict[str, str]:
+    base = repo_root / output_dir
+    base.mkdir(parents=True, exist_ok=True)
+    timestamp = str(snapshot["generated_at_utc"]).replace(":", "-")
+    latest = base / LATEST_NAME
+    timestamped = base / f"{timestamp}.json"
+    history = base / HISTORY_NAME
+    payload = json.dumps(snapshot, sort_keys=True, indent=2) + "\n"
+
+    for target in (latest, timestamped, history):
+        _validate_write_target(target)
+
+    tmp_latest = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_latest.write_text(payload, encoding="utf-8")
+    os.replace(tmp_latest, latest)
+
+    tmp_timestamped = timestamped.with_suffix(timestamped.suffix + ".tmp")
+    tmp_timestamped.write_text(payload, encoding="utf-8")
+    os.replace(tmp_timestamped, timestamped)
+
+    compact = json.dumps(snapshot, sort_keys=True, separators=(",", ":"))
+    with history.open("a", encoding="utf-8") as handle:
+        handle.write(compact + "\n")
+
+    return {
+        "latest": _rel(latest, root=repo_root),
+        "timestamped": _rel(timestamped, root=repo_root),
+        "history": _rel(history, root=repo_root),
+    }
+
+
+def read_retrieval_coverage_status(
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = Path("."),
+) -> dict[str, Any]:
+    latest = repo_root / output_dir / LATEST_NAME
+    if not latest.is_file():
+        return {
+            "status": "missing_retrieval_coverage",
+            "retrieval_coverage_ready": False,
+            "path": _rel(latest, root=repo_root),
+            "fails_closed": True,
+        }
+    try:
+        payload = json.loads(latest.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {
+            "status": "invalid_retrieval_coverage",
+            "retrieval_coverage_ready": False,
+            "path": _rel(latest, root=repo_root),
+            "fails_closed": True,
+        }
+    summary = payload.get("summary") if isinstance(payload, dict) else None
+    ready = bool(summary.get("retrieval_coverage_ready")) if isinstance(summary, dict) else False
+    return {
+        "status": "ready" if ready else "not_ready",
+        "retrieval_coverage_ready": ready,
+        "path": _rel(latest, root=repo_root),
+        "fails_closed": not ready,
+        "schema_version": payload.get("schema_version") if isinstance(payload, dict) else None,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="packages.qre_research.retrieval_coverage",
+        description="Measure deterministic no-authority trusted-loop retrieval coverage.",
+    )
+    parser.add_argument("--no-write", action="store_true")
+    parser.add_argument("--status", action="store_true")
+    parser.add_argument("--frozen-utc", type=str, default=None)
+    args = parser.parse_args(argv)
+
+    if args.status:
+        print(json.dumps(read_retrieval_coverage_status(), sort_keys=True, indent=2))
+        return 0
+
+    snapshot = build_retrieval_coverage(generated_at_utc=args.frozen_utc)
+    if not args.no_write:
+        snapshot["_artifact_paths"] = write_retrieval_coverage_outputs(snapshot)
+    print(json.dumps(snapshot, sort_keys=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())
+
+
+__all__ = [
+    "DEFAULT_ARTIFACT_PATHS",
+    "DEFAULT_OUTPUT_DIR",
+    "REPORT_KIND",
+    "SCHEMA_VERSION",
+    "build_retrieval_coverage",
+    "read_retrieval_coverage_status",
+    "write_retrieval_coverage_outputs",
+]

--- a/tests/architecture/test_package_migration_001_target_layout.py
+++ b/tests/architecture/test_package_migration_001_target_layout.py
@@ -161,6 +161,7 @@ def test_package_migration_001_qre_research_has_only_bounded_read_only_seed() ->
         "README.md",
         "__init__.py",
         "research_memory.py",
+        "retrieval_coverage.py",
         "universe.py",
     ], target
 
@@ -170,6 +171,7 @@ def test_package_migration_001_scanner_classifies_target_paths() -> None:
     assert classify_path("packages/ade_governance/README.md") == DOMAIN_ADE
     assert classify_path("packages/qre_research/README.md") == DOMAIN_QRE
     assert classify_path("packages/qre_research/research_memory.py") == DOMAIN_QRE
+    assert classify_path("packages/qre_research/retrieval_coverage.py") == DOMAIN_QRE
     assert classify_path("packages/qre_research/universe.py") == DOMAIN_QRE
     assert classify_path("packages/qre_data/README.md") == DOMAIN_QRE
     assert classify_path("packages/qre_data/cache_manifest.py") == DOMAIN_QRE

--- a/tests/architecture/test_package_migration_010_closure_decision.py
+++ b/tests/architecture/test_package_migration_010_closure_decision.py
@@ -35,6 +35,7 @@ BOUNDED_PACKAGE_CONTENTS = {
         "README.md",
         "__init__.py",
         "research_memory.py",
+        "retrieval_coverage.py",
         "universe.py",
     ],
     "qre_data": [

--- a/tests/unit/test_qre_research_retrieval_coverage.py
+++ b/tests/unit/test_qre_research_retrieval_coverage.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from packages.qre_research import retrieval_coverage
+
+FROZEN = "2026-05-25T00:00:00Z"
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=True, indent=2), encoding="utf-8")
+
+
+def _seed_linked_trusted_loop_artifacts(tmp_path: Path) -> list[Path]:
+    reason_density = tmp_path / "logs" / "reason_record_evidence_density" / "latest.json"
+    failure_actions = tmp_path / "logs" / "failure_action_mapping_minimal" / "latest.json"
+    diagnostics = tmp_path / "logs" / "qre_research_diagnostics_loop" / "latest.json"
+    materialization = tmp_path / "logs" / "trusted_loop_materialization" / "latest.json"
+
+    _write_json(
+        reason_density,
+        {
+            "report_kind": "reason_record_evidence_density",
+            "records_top": [
+                {
+                    "record_id": "rr_1",
+                    "subject_id": "campaign-a",
+                    "reason_codes": ["info_gain_low"],
+                    "reason_text": "routing reason kept for trusted loop review",
+                    "evidence_refs": ["logs/intelligent_routing_minimal/latest.json"],
+                }
+            ],
+        },
+    )
+    _write_json(
+        failure_actions,
+        {
+            "report_kind": "failure_action_mapping_minimal",
+            "items": [
+                {
+                    "subject_id": "screening-a",
+                    "classification": "insufficient_trades",
+                    "raw_reasons": {"insufficient_trades": 1},
+                    "action_hint": {"action": "increase_timeframe"},
+                    "reason_record": {
+                        "reason_codes": ["operator_directive"],
+                        "evidence_refs": [
+                            "research/screening_failure_attribution_latest.v1.json"
+                        ],
+                    },
+                }
+            ],
+            "total_failures": 1,
+        },
+    )
+    _write_json(
+        diagnostics,
+        {
+            "report_kind": "qre_research_diagnostics_loop",
+            "summary": {
+                "recommended_operator_step": "inspect_failure_action_mapping",
+                "blocking_reasons": [],
+            },
+        },
+    )
+    _write_json(
+        materialization,
+        {
+            "report_kind": "trusted_loop_materialization_digest",
+            "block_reasons": [
+                "routing_ready_evidence_missing_or_not_ready",
+                "no_complete_research_quality_kpi_values",
+            ],
+            "synthesis_blocker_explanation_density": {
+                "values": {
+                    "routing_ready_evidence_missing_or_not_ready": {
+                        "source_ref": "logs/intelligent_routing_minimal/latest.json",
+                        "missing_evidence": ["prioritize_count_positive"],
+                        "operator_explanation": "Routing remains fail_closed.",
+                    }
+                }
+            },
+        },
+    )
+
+    return [
+        Path("logs/reason_record_evidence_density/latest.json"),
+        Path("logs/failure_action_mapping_minimal/latest.json"),
+        Path("logs/qre_research_diagnostics_loop/latest.json"),
+        Path("logs/trusted_loop_materialization/latest.json"),
+    ]
+
+
+def test_retrieval_coverage_is_deterministic_and_linked(tmp_path: Path) -> None:
+    artifact_paths = _seed_linked_trusted_loop_artifacts(tmp_path)
+
+    left = retrieval_coverage.build_retrieval_coverage(
+        artifact_paths=artifact_paths,
+        repo_root=tmp_path,
+        generated_at_utc=FROZEN,
+    )
+    right = retrieval_coverage.build_retrieval_coverage(
+        artifact_paths=artifact_paths,
+        repo_root=tmp_path,
+        generated_at_utc=FROZEN,
+    )
+
+    assert left == right
+    assert left["summary"]["status"] == "ready"
+    assert left["summary"]["coverage_score"] == 1.0
+    assert left["operator_summary"]["cannot_retrieve"] == []
+    assert left["authority_boundary"] == {
+        "retrieval_is_context_not_authority": True,
+        "can_inform_later_calibration_review": True,
+        "can_route_or_sample": False,
+        "can_mutate_campaigns": False,
+        "can_approve_or_synthesize_strategies": False,
+    }
+    assert all(row["status"] == "covered" for row in left["coverage"])
+    assert all(row["linked_match_count"] >= 1 for row in left["coverage"])
+    assert all(
+        row["retrieval_role"] == "context_only_not_authority"
+        for row in left["coverage"]
+    )
+
+
+def test_missing_retrieval_links_are_explicit(tmp_path: Path) -> None:
+    doc = tmp_path / "docs" / "memory.md"
+    doc.parent.mkdir(parents=True, exist_ok=True)
+    doc.write_text(
+        "reason failure blocker action trusted loop context without durable links",
+        encoding="utf-8",
+    )
+
+    snapshot = retrieval_coverage.build_retrieval_coverage(
+        artifact_paths=[Path("docs/memory.md")],
+        repo_root=tmp_path,
+        generated_at_utc=FROZEN,
+    )
+
+    assert snapshot["summary"]["status"] == "not_ready"
+    assert snapshot["summary"]["covered_surface_count"] == 0
+    assert snapshot["operator_summary"]["can_retrieve"] == []
+    for row in snapshot["coverage"]:
+        assert row["status"] == "missing_link"
+        assert row["retrieved_match_count"] == 1
+        assert row["linked_match_count"] == 0
+        assert row["missing_retrieval_links"][0].startswith("no_required_link_signals:")
+
+
+def test_missing_artifacts_fail_closed_with_no_matches(tmp_path: Path) -> None:
+    snapshot = retrieval_coverage.build_retrieval_coverage(
+        artifact_paths=[Path("logs/missing/latest.json")],
+        repo_root=tmp_path,
+        generated_at_utc=FROZEN,
+    )
+
+    assert snapshot["summary"]["status"] == "not_ready"
+    assert snapshot["summary"]["missing_artifacts"] == ["logs/missing/latest.json"]
+    assert {row["status"] for row in snapshot["coverage"]} == {"missing_retrieval"}
+    assert all(row["missing_retrieval_links"] == ["no_retrieval_matches"] for row in snapshot["coverage"])
+    assert snapshot["safety_invariants"]["uses_network"] is False
+    assert snapshot["safety_invariants"]["uses_vector_database"] is False
+    assert snapshot["safety_invariants"]["uses_hidden_ml"] is False
+    assert snapshot["safety_invariants"]["enables_strategy_synthesis"] is False
+
+
+def test_retrieval_coverage_source_avoids_network_and_subprocess_imports() -> None:
+    source = Path(retrieval_coverage.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module.split(".")[0])
+
+    assert imported.isdisjoint({"requests", "socket", "httpx", "urllib", "subprocess"})
+    assert "requests." not in source
+    assert "qdrant" not in source.lower()
+    assert "chromadb" not in source.lower()
+
+
+def test_write_outputs_refuses_outside_allowlist(tmp_path: Path) -> None:
+    bad = tmp_path / "elsewhere" / "latest.json"
+    bad.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        retrieval_coverage._validate_write_target(bad)
+    except ValueError as exc:
+        assert "outside allowlist" in str(exc)
+    else:
+        raise AssertionError("expected outside-allowlist refusal")


### PR DESCRIPTION
## Summary
- Adds a deterministic read-only retrieval coverage reporter for trusted-loop reasons, failures, blockers, and actions.
- Reports missing retrieval links explicitly and keeps retrieval as context, not authority.
- Documents the operator command and updates package-boundary architecture pins for the new bounded QRE research module.

## Safety / Scope
- No vector database, embeddings, hidden ML, network dependency, strategy synthesis, Addendum runtime activation, routing/campaign mutation, approval mutation, or execution behavior.
- Frozen research outputs unchanged.
- Dependency PRs #340-#348 were not touched.

## Validation
- pytest tests/unit/test_qre_research_retrieval_coverage.py tests/unit/test_qre_research_memory.py -q -> 12 passed
- ruff check . -> passed
- mypy --config-file pyproject.toml --explicit-package-bases -> passed
- pytest tests/regression -q -k "pin or deterministic or digest or invariant" -> 53 passed, 116 deselected
- pytest tests/architecture -q -> 157 passed
- python -m reporting.architecture_import_scan --format summary -> forbidden_edge_count=0
- explicit hook tests -> 240 passed
- pytest tests/smoke -q -> 18 passed
- python scripts/governance_lint.py -> passed
- git diff --check -> passed

Local note: pytest tests/smoke tests/unit -q timed out locally after 10 minutes without a result; targeted unit, smoke, hook, and architecture suites above passed. Required CI should be treated as authoritative for the full aggregate unit job.
