### PR TITLE
test: add trusted loop regression fixtures

### DIFF
--- a/tests/fixtures/trusted_loop_regression/evidence_cases.v1.json
+++ b/tests/fixtures/trusted_loop_regression/evidence_cases.v1.json
@@ -1,0 +1,319 @@
+{
+  "schema_version": 1,
+  "fixture_kind": "trusted_loop_regression_evidence_cases",
+  "generated_at_utc": "2026-05-25T00:00:00Z",
+  "safety_invariants": {
+    "read_only": true,
+    "mutates_research_outputs": false,
+    "mutates_frozen_contracts": false,
+    "enables_strategy_synthesis": false,
+    "activates_addendum_runtime": false,
+    "paper_shadow_live_forbidden": true,
+    "broker_risk_execution_forbidden": true
+  },
+  "cases": [
+    {
+      "case_id": "complete",
+      "description": "All numeric KPI, routing, sampling, reason-density, and failure-action evidence is present; synthesis remains governance-blocked only.",
+      "kpi_evidence": {
+        "TTFPRC": {"value": 10.0, "source": "fixture_complete"},
+        "OOS_DSR": {"value": 0.8, "source": "fixture_complete"},
+        "MASQ": {"value": 1.25, "source": "fixture_complete"},
+        "NMBR": {"value": 0.7, "source": "fixture_complete"},
+        "DZCR": {"value": 0.1, "source": "fixture_complete"},
+        "OAB": {
+          "visible_surface_count": 3,
+          "operator_decisions_per_week": 2,
+          "source": "fixture_complete"
+        },
+        "CRSR": {"value": 0.5, "source": "fixture_complete"}
+      },
+      "routing_snapshot": {
+        "final_recommendation": "ready_for_implementation",
+        "counts": {
+          "total": 2,
+          "by_decision": {"prioritize": 1, "defer": 1}
+        }
+      },
+      "sampling_snapshot": {
+        "final_recommendation": "ready_for_sampling",
+        "counts": {"total": 2, "actionable": 1}
+      },
+      "artifact_present": {"routing": true, "sampling": true},
+      "failure_action_mapping": {
+        "status": "ready",
+        "total_failures": 2,
+        "actionable_failure_count": 2
+      },
+      "reason_density": {
+        "final_recommendation": "evidence_density_ready",
+        "metrics": {"record_count": 2, "records_with_evidence_refs": 2}
+      },
+      "block_reasons": ["no_strategy_synthesis_scope_authorized"],
+      "expected": {
+        "kpi_complete_value_count": 7,
+        "kpi_fail_closed_count": 0,
+        "routing_status": "ready",
+        "sampling_status": "ready",
+        "routing_missing_evidence": [],
+        "sampling_missing_evidence": [],
+        "blocker_overall_status": "blocked_explained",
+        "explained_blocker_count": 1,
+        "unexplained_blocker_count": 0
+      }
+    },
+    {
+      "case_id": "thin",
+      "description": "Only partial KPI and partial routing evidence is present; every incomplete surface fails closed with explicit missing evidence.",
+      "kpi_evidence": {
+        "OAB": {
+          "visible_surface_count": 2,
+          "source": "fixture_thin"
+        }
+      },
+      "routing_snapshot": {
+        "final_recommendation": "ready_for_implementation",
+        "counts": {
+          "total": 1,
+          "by_decision": {"prioritize": 0}
+        }
+      },
+      "sampling_snapshot": {
+        "final_recommendation": "nothing_actionable",
+        "counts": {"total": 1, "actionable": 0}
+      },
+      "artifact_present": {"routing": true, "sampling": true},
+      "failure_action_mapping": {
+        "status": "not_ready",
+        "total_failures": 1,
+        "actionable_failure_count": 0
+      },
+      "reason_density": {
+        "final_recommendation": "partial_evidence_density",
+        "metrics": {"record_count": 2, "records_with_evidence_refs": 1}
+      },
+      "block_reasons": [
+        "no_complete_research_quality_kpi_values",
+        "routing_ready_evidence_missing_or_not_ready",
+        "sampling_ready_evidence_missing_or_not_ready",
+        "reason_record_evidence_density_not_ready",
+        "no_strategy_synthesis_scope_authorized"
+      ],
+      "expected": {
+        "kpi_complete_value_count": 0,
+        "kpi_partial_value_count": 1,
+        "kpi_fail_closed_count": 7,
+        "routing_status": "fail_closed",
+        "sampling_status": "fail_closed",
+        "routing_missing_evidence": ["prioritize_count_positive"],
+        "sampling_missing_evidence": [
+          "final_recommendation_ready",
+          "actionable_count_positive"
+        ],
+        "blocker_overall_status": "blocked_explained",
+        "explained_blocker_count": 5,
+        "unexplained_blocker_count": 0
+      }
+    },
+    {
+      "case_id": "missing",
+      "description": "No trusted-loop evidence is present; artifacts are absent and all readiness surfaces fail closed.",
+      "kpi_evidence": {},
+      "routing_snapshot": {},
+      "sampling_snapshot": {},
+      "artifact_present": {"routing": false, "sampling": false},
+      "failure_action_mapping": {},
+      "reason_density": {
+        "final_recommendation": "not_available",
+        "metrics": {}
+      },
+      "block_reasons": [
+        "failure_action_mapping_not_ready_when_total_failures_zero",
+        "no_complete_research_quality_kpi_values",
+        "routing_ready_evidence_missing_or_not_ready",
+        "sampling_ready_evidence_missing_or_not_ready",
+        "reason_record_evidence_density_not_ready",
+        "no_strategy_synthesis_scope_authorized"
+      ],
+      "expected": {
+        "kpi_complete_value_count": 0,
+        "kpi_fail_closed_count": 7,
+        "routing_status": "fail_closed",
+        "sampling_status": "fail_closed",
+        "routing_missing_evidence": [
+          "latest_artifact_present",
+          "final_recommendation_ready",
+          "total_count_positive",
+          "prioritize_count_positive"
+        ],
+        "sampling_missing_evidence": [
+          "latest_artifact_present",
+          "final_recommendation_ready",
+          "total_count_positive",
+          "actionable_count_positive"
+        ],
+        "blocker_overall_status": "blocked_explained",
+        "explained_blocker_count": 6,
+        "unexplained_blocker_count": 0
+      }
+    },
+    {
+      "case_id": "contradictory",
+      "description": "The recommendation says ready, but supporting counts are zero; readiness must fail closed instead of trusting the label.",
+      "kpi_evidence": {
+        "TTFPRC": {"value": "ready", "source": "fixture_contradictory"},
+        "OOS_DSR": {"value": 0.6, "source": "fixture_contradictory"}
+      },
+      "routing_snapshot": {
+        "final_recommendation": "ready_for_implementation",
+        "counts": {
+          "total": 0,
+          "by_decision": {"prioritize": 0}
+        }
+      },
+      "sampling_snapshot": {
+        "final_recommendation": "ready_for_sampling",
+        "counts": {"total": 0, "actionable": 0}
+      },
+      "artifact_present": {"routing": true, "sampling": true},
+      "failure_action_mapping": {
+        "status": "ready",
+        "total_failures": 1,
+        "actionable_failure_count": 1
+      },
+      "reason_density": {
+        "final_recommendation": "evidence_density_ready",
+        "metrics": {"record_count": 1, "records_with_evidence_refs": 1}
+      },
+      "block_reasons": [
+        "no_complete_research_quality_kpi_values",
+        "routing_ready_evidence_missing_or_not_ready",
+        "sampling_ready_evidence_missing_or_not_ready",
+        "no_strategy_synthesis_scope_authorized"
+      ],
+      "expected": {
+        "kpi_complete_value_count": 1,
+        "kpi_fail_closed_count": 6,
+        "routing_status": "fail_closed",
+        "sampling_status": "fail_closed",
+        "routing_missing_evidence": [
+          "total_count_positive",
+          "prioritize_count_positive"
+        ],
+        "sampling_missing_evidence": [
+          "total_count_positive",
+          "actionable_count_positive"
+        ],
+        "blocker_overall_status": "blocked_explained",
+        "explained_blocker_count": 4,
+        "unexplained_blocker_count": 0
+      }
+    },
+    {
+      "case_id": "blocked",
+      "description": "Evidence exists but explicit blockers remain active and operator-readable.",
+      "kpi_evidence": {
+        "TTFPRC": {"value": 15.0, "source": "fixture_blocked"},
+        "OOS_DSR": {"value": 0.4, "source": "fixture_blocked"}
+      },
+      "routing_snapshot": {
+        "final_recommendation": "blocked_by_dependency",
+        "counts": {
+          "total": 3,
+          "by_decision": {"prioritize": 0, "defer": 3}
+        }
+      },
+      "sampling_snapshot": {
+        "final_recommendation": "blocked_by_dependency",
+        "counts": {"total": 3, "actionable": 0}
+      },
+      "artifact_present": {"routing": true, "sampling": true},
+      "failure_action_mapping": {
+        "status": "not_ready",
+        "total_failures": 2,
+        "actionable_failure_count": 0
+      },
+      "reason_density": {
+        "final_recommendation": "not_ready_missing_evidence_refs",
+        "metrics": {"record_count": 3, "records_with_evidence_refs": 0}
+      },
+      "block_reasons": [
+        "no_complete_research_quality_kpi_values",
+        "routing_ready_evidence_missing_or_not_ready",
+        "sampling_ready_evidence_missing_or_not_ready",
+        "reason_record_evidence_density_not_ready",
+        "no_strategy_synthesis_scope_authorized"
+      ],
+      "expected": {
+        "kpi_complete_value_count": 2,
+        "kpi_fail_closed_count": 5,
+        "routing_status": "fail_closed",
+        "sampling_status": "fail_closed",
+        "routing_missing_evidence": [
+          "final_recommendation_ready",
+          "prioritize_count_positive"
+        ],
+        "sampling_missing_evidence": [
+          "final_recommendation_ready",
+          "actionable_count_positive"
+        ],
+        "blocker_overall_status": "blocked_explained",
+        "explained_blocker_count": 5,
+        "unexplained_blocker_count": 0
+      }
+    },
+    {
+      "case_id": "non_actionable",
+      "description": "Failure evidence exists only as a zero-failure/non-actionable state and must not produce executable action.",
+      "kpi_evidence": {},
+      "routing_snapshot": {
+        "final_recommendation": "nothing_ready",
+        "counts": {
+          "total": 0,
+          "by_decision": {}
+        }
+      },
+      "sampling_snapshot": {
+        "final_recommendation": "nothing_ready",
+        "counts": {"total": 0, "actionable": 0}
+      },
+      "artifact_present": {"routing": true, "sampling": true},
+      "failure_action_mapping": {
+        "status": "not_ready",
+        "total_failures": 0,
+        "actionable_failure_count": 0
+      },
+      "reason_density": {
+        "final_recommendation": "not_ready_no_reason_records",
+        "metrics": {"record_count": 0, "records_with_evidence_refs": 0}
+      },
+      "block_reasons": [
+        "failure_action_mapping_not_ready_when_total_failures_zero",
+        "no_strategy_synthesis_scope_authorized"
+      ],
+      "expected": {
+        "kpi_complete_value_count": 0,
+        "kpi_fail_closed_count": 7,
+        "routing_status": "fail_closed",
+        "sampling_status": "fail_closed",
+        "routing_missing_evidence": [
+          "final_recommendation_ready",
+          "total_count_positive",
+          "prioritize_count_positive"
+        ],
+        "sampling_missing_evidence": [
+          "final_recommendation_ready",
+          "total_count_positive",
+          "actionable_count_positive"
+        ],
+        "failure_missing_evidence": [
+          "positive_failure_count",
+          "actionable_failure_mapping"
+        ],
+        "blocker_overall_status": "blocked_explained",
+        "explained_blocker_count": 2,
+        "unexplained_blocker_count": 0
+      }
+    }
+  ]
+}

--- a/tests/unit/test_trusted_loop_regression_fixtures.py
+++ b/tests/unit/test_trusted_loop_regression_fixtures.py
@@ -1,0 +1,143 @@
+"""Regression fixture coverage for ADE-QRE-014K trusted-loop evidence."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reporting import trusted_loop_materialization as tlm
+
+FIXTURE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "fixtures"
+    / "trusted_loop_regression"
+    / "evidence_cases.v1.json"
+)
+
+EXPECTED_CASE_IDS = {
+    "complete",
+    "thin",
+    "missing",
+    "contradictory",
+    "blocked",
+    "non_actionable",
+}
+
+
+def _load_fixture() -> dict[str, Any]:
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def _write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=True, indent=2), encoding="utf-8")
+
+
+def _case_summary(case: Mapping[str, Any], tmp_path: Path) -> dict[str, Any]:
+    case_root = tmp_path / str(case["case_id"])
+    routing_path = case_root / "logs" / "intelligent_routing_minimal" / "latest.json"
+    sampling_path = case_root / "logs" / "sampling_intelligence_minimal" / "latest.json"
+    artifact_present = case["artifact_present"]
+
+    if artifact_present["routing"]:
+        _write_json(routing_path, case["routing_snapshot"])
+    if artifact_present["sampling"]:
+        _write_json(sampling_path, case["sampling_snapshot"])
+
+    kpis = tlm._research_quality_kpi_readiness(
+        {"research_quality_kpi_evidence": case["kpi_evidence"]}
+    )
+    routing_sampling = tlm._routing_sampling_readiness_density(
+        routing_snapshot=case["routing_snapshot"],
+        sampling_snapshot=case["sampling_snapshot"],
+        routing_artifact_path=routing_path,
+        sampling_artifact_path=sampling_path,
+    )
+    blockers = tlm._synthesis_blocker_explanation_density(
+        block_reasons=list(case["block_reasons"]),
+        failure_action_mapping=case["failure_action_mapping"],
+        kpi_readiness=kpis,
+        routing_sampling_readiness=routing_sampling,
+        reason_density=case["reason_density"],
+    )
+
+    routing_ready = routing_sampling["values"]["routing_ready"]
+    sampling_ready = routing_sampling["values"]["sampling_ready"]
+    failure_blocker = blockers["values"].get(
+        "failure_action_mapping_not_ready_when_total_failures_zero",
+        {},
+    )
+    return {
+        "case_id": case["case_id"],
+        "kpi_complete_value_count": kpis["complete_value_count"],
+        "kpi_partial_value_count": kpis["partial_value_count"],
+        "kpi_fail_closed_count": kpis["fail_closed_count"],
+        "routing_status": routing_ready["status"],
+        "sampling_status": sampling_ready["status"],
+        "routing_missing_evidence": routing_ready["missing_evidence"],
+        "sampling_missing_evidence": sampling_ready["missing_evidence"],
+        "failure_missing_evidence": failure_blocker.get("missing_evidence", []),
+        "blocker_overall_status": blockers["overall_status"],
+        "explained_blocker_count": blockers["explained_blocker_count"],
+        "unexplained_blocker_count": blockers["unexplained_blocker_count"],
+        "synthesis_remains_blocked": blockers["synthesis_remains_blocked"],
+        "read_only": blockers["read_only"],
+        "all_blockers_read_only": all(
+            row["read_only"] is True for row in blockers["values"].values()
+        ),
+        "no_blocker_enables_strategy_synthesis": all(
+            row["enables_strategy_synthesis"] is False
+            for row in blockers["values"].values()
+        ),
+    }
+
+
+def _cases() -> list[dict[str, Any]]:
+    return list(_load_fixture()["cases"])
+
+
+def test_fixture_inventory_is_complete_and_read_only() -> None:
+    fixture = _load_fixture()
+
+    assert fixture["schema_version"] == 1
+    assert {case["case_id"] for case in fixture["cases"]} == EXPECTED_CASE_IDS
+    assert fixture["safety_invariants"] == {
+        "read_only": True,
+        "mutates_research_outputs": False,
+        "mutates_frozen_contracts": False,
+        "enables_strategy_synthesis": False,
+        "activates_addendum_runtime": False,
+        "paper_shadow_live_forbidden": True,
+        "broker_risk_execution_forbidden": True,
+    }
+
+
+@pytest.mark.parametrize("case", _cases(), ids=lambda case: case["case_id"])
+def test_trusted_loop_fixture_cases_are_deterministic(
+    case: Mapping[str, Any],
+    tmp_path: Path,
+) -> None:
+    left = _case_summary(case, tmp_path)
+    right = _case_summary(case, tmp_path)
+
+    assert left == right
+
+
+@pytest.mark.parametrize("case", _cases(), ids=lambda case: case["case_id"])
+def test_trusted_loop_fixture_cases_match_expected_reporting_outcomes(
+    case: Mapping[str, Any],
+    tmp_path: Path,
+) -> None:
+    summary = _case_summary(case, tmp_path)
+    expected = case["expected"]
+
+    for key, value in expected.items():
+        assert summary[key] == value
+    assert summary["synthesis_remains_blocked"] is True
+    assert summary["read_only"] is True
+    assert summary["all_blockers_read_only"] is True
+    assert summary["no_blocker_enables_strategy_synthesis"] is True


### PR DESCRIPTION
## Summary
- Add fixture-backed ADE-QRE-014K trusted-loop regression cases for complete, thin, missing, contradictory, blocked, and non-actionable evidence.
- Validate fixtures through existing trusted-loop materialization reporting helpers.
- Keep the diff limited to tests and fixtures; no production, frozen contract, research output, registry, strategy, or execution path changes.

## Validation
- pytest tests/unit/test_trusted_loop_regression_fixtures.py -q
- pytest tests/unit/test_trusted_loop_regression_fixtures.py tests/unit/test_trusted_loop_materialization.py -q
- pytest tests/architecture -q
- python -m reporting.architecture_import_scan --format summary (forbidden_edge_count=0)
- ruff check .
- mypy --config-file pyproject.toml --explicit-package-bases
- pytest tests/regression -q -k "pin or deterministic or digest or invariant"
- python scripts/governance_lint.py
- pytest tests/unit/test_hook_runtime.py tests/unit/test_hooks_audit_emit.py tests/unit/test_hooks_config_read.py tests/unit/test_hooks_dangerous_bash.py tests/unit/test_hooks_live_connector.py tests/unit/test_hooks_no_touch.py tests/unit/test_hooks_outside_allowlist.py tests/unit/test_hooks_precompact.py tests/unit/test_hooks_test_weakening.py tests/unit/test_agent_audit.py -q
- git diff --cached --check

## Local note
- Full local `pytest tests/smoke tests/unit -q` exceeded the 10-minute local timeout before producing a result; CI Fast pre-merge gate remains the authoritative full smoke/unit result.
