### PR TITLE
test: add data source readiness blocker coverage

### DIFF
--- a/packages/qre_data/README.md
+++ b/packages/qre_data/README.md
@@ -33,6 +33,11 @@ research output contracts.
 cache manifest only. It does not activate vendor sources, infer alpha, fetch
 data, modify cache files, or change research output contracts.
 
+ADE-QRE-014L uses Roadmap v6 Addendum 3 as reference taxonomy only for
+data/source/identity readiness blocker labels. Runtime Addendum 3 activation,
+new source adapters, new datafeeds, source quality as alpha, and source quality
+as promotion authority remain forbidden.
+
 ## Allowed Future Contents
 
 - Data contract types and metadata.

--- a/packages/qre_data/source_quality_readiness.py
+++ b/packages/qre_data/source_quality_readiness.py
@@ -26,6 +26,17 @@ DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_data_source_quality_readiness")
 HISTORY_NAME: Final[str] = "history.jsonl"
 _WRITE_PREFIX: Final[str] = "logs/qre_data_source_quality_readiness/"
 _UNKNOWN_VALUES: Final[set[str]] = {"", "unknown", "none", "null", "nan"}
+READINESS_BLOCKER_CATEGORIES: Final[tuple[str, ...]] = ("data", "source", "identity")
+ADDENDUM3_REFERENCE_TAXONOMY: Final[tuple[str, ...]] = (
+    "source_manifest",
+    "source_identity",
+    "freshness",
+    "coverage",
+    "missing_data",
+    "timestamp_integrity",
+    "source_agreement",
+    "schema_version",
+)
 
 
 def _utcnow() -> str:
@@ -78,6 +89,130 @@ def _blocking_reasons(row: Mapping[str, Any], confidence: str) -> list[str]:
     return reasons
 
 
+def _blocker(
+    *,
+    category: str,
+    reason: str,
+    evidence_field: str,
+    evidence_status: str,
+    operator_explanation: str,
+) -> dict[str, Any]:
+    if category not in READINESS_BLOCKER_CATEGORIES:
+        raise ValueError(f"unknown readiness blocker category: {category!r}")
+    return {
+        "category": category,
+        "reason": reason,
+        "evidence_field": evidence_field,
+        "evidence_status": evidence_status,
+        "fail_closed": True,
+        "operator_explanation": operator_explanation,
+    }
+
+
+def _unknown_identity_blockers(row: Mapping[str, Any]) -> list[dict[str, Any]]:
+    fields = (
+        ("source", "identity_source_unknown"),
+        ("instrument", "identity_instrument_unknown"),
+        ("timeframe", "identity_timeframe_unknown"),
+        ("cache_kind", "identity_cache_kind_unknown"),
+    )
+    blockers: list[dict[str, Any]] = []
+    for field, reason in fields:
+        if _is_known(row.get(field)):
+            continue
+        blockers.append(
+            _blocker(
+                category="identity",
+                reason=reason,
+                evidence_field=field,
+                evidence_status="missing_or_unknown",
+                operator_explanation=(
+                    f"Identity evidence field {field} is missing or unknown; "
+                    "source readiness fails closed until the manifest identifies it."
+                ),
+            )
+        )
+    return blockers
+
+
+def _readiness_blockers(
+    row: Mapping[str, Any],
+    *,
+    confidence: str,
+) -> list[dict[str, Any]]:
+    blockers = _unknown_identity_blockers(row)
+    if confidence != "high" and not blockers:
+        blockers.append(
+            _blocker(
+                category="identity",
+                reason="identity_not_high_confidence",
+                evidence_field="source_identity",
+                evidence_status=confidence,
+                operator_explanation=(
+                    "Source identity evidence is not high confidence; readiness "
+                    "fails closed until identity is complete."
+                ),
+            )
+        )
+
+    manifest_status = row.get("status")
+    if manifest_status != "ready":
+        status = str(manifest_status or "missing")
+        blockers.append(
+            _blocker(
+                category="source",
+                reason="source_manifest_status_not_ready",
+                evidence_field="status",
+                evidence_status=status,
+                operator_explanation=(
+                    f"Source manifest status is {status}; source readiness "
+                    "requires ready manifest evidence."
+                ),
+            )
+        )
+    if not row.get("content_hash"):
+        blockers.append(
+            _blocker(
+                category="source",
+                reason="source_content_hash_missing",
+                evidence_field="content_hash",
+                evidence_status="missing",
+                operator_explanation=(
+                    "Source content hash is missing; reproducibility evidence "
+                    "is incomplete."
+                ),
+            )
+        )
+
+    if not isinstance(row.get("row_count"), int) or int(row["row_count"]) <= 0:
+        blockers.append(
+            _blocker(
+                category="data",
+                reason="data_row_count_not_positive",
+                evidence_field="row_count",
+                evidence_status="missing_or_non_positive",
+                operator_explanation=(
+                    "Data row count is missing, unknown, or non-positive; "
+                    "data readiness fails closed."
+                ),
+            )
+        )
+    if not row.get("min_timestamp_utc") or not row.get("max_timestamp_utc"):
+        blockers.append(
+            _blocker(
+                category="data",
+                reason="data_timestamp_range_missing",
+                evidence_field="timestamp_range",
+                evidence_status="missing",
+                operator_explanation=(
+                    "Data timestamp range is missing; freshness and coverage "
+                    "cannot be verified."
+                ),
+            )
+        )
+    return sorted(blockers, key=lambda row: (row["category"], row["reason"]))
+
+
 def _explanation(
     row: Mapping[str, Any],
     *,
@@ -100,6 +235,7 @@ def _explanation(
 def _evaluate_file(row: Mapping[str, Any]) -> dict[str, Any]:
     confidence = _identity_confidence(row)
     reasons = _blocking_reasons(row, confidence)
+    readiness_blockers = _readiness_blockers(row, confidence=confidence)
     quality_status = "ready" if not reasons else "blocked"
     return {
         "path": row.get("path"),
@@ -110,6 +246,7 @@ def _evaluate_file(row: Mapping[str, Any]) -> dict[str, Any]:
         "identity_confidence": confidence,
         "quality_status": quality_status,
         "blocking_reasons": reasons,
+        "readiness_blockers": readiness_blockers,
         "manifest_status": row.get("status"),
         "row_count": row.get("row_count"),
         "min_timestamp_utc": row.get("min_timestamp_utc"),
@@ -135,6 +272,18 @@ def _source_summaries(rows: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]
         blocking = Counter(
             reason for row in source_rows for reason in row.get("blocking_reasons", [])
         )
+        readiness_blockers = [
+            blocker
+            for row in source_rows
+            for blocker in row.get("readiness_blockers", [])
+            if isinstance(blocker, Mapping)
+        ]
+        blocker_categories = Counter(
+            str(blocker.get("category")) for blocker in readiness_blockers
+        )
+        blocker_reasons = Counter(
+            str(blocker.get("reason")) for blocker in readiness_blockers
+        )
         summaries.append(
             {
                 "source": source,
@@ -142,6 +291,8 @@ def _source_summaries(rows: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]
                 "identity_confidence_counts": dict(sorted(confidence_counts.items())),
                 "quality_status_counts": dict(sorted(quality_counts.items())),
                 "blocking_reason_counts": dict(sorted(blocking.items())),
+                "readiness_blocker_category_counts": dict(sorted(blocker_categories.items())),
+                "readiness_blocker_reason_counts": dict(sorted(blocker_reasons.items())),
                 "ready": quality_counts.get("blocked", 0) == 0,
             }
         )
@@ -170,6 +321,16 @@ def build_source_quality_report(
     identity_counts = Counter(str(row["identity_confidence"]) for row in rows)
     quality_counts = Counter(str(row["quality_status"]) for row in rows)
     blocking_counts = Counter(reason for row in rows for reason in row.get("blocking_reasons", []))
+    readiness_blockers = [
+        blocker
+        for row in rows
+        for blocker in row.get("readiness_blockers", [])
+        if isinstance(blocker, Mapping)
+    ]
+    blocker_category_counts = Counter(
+        str(blocker.get("category")) for blocker in readiness_blockers
+    )
+    blocker_reason_counts = Counter(str(blocker.get("reason")) for blocker in readiness_blockers)
     manifest_summary = (
         manifest.get("summary") if isinstance(manifest.get("summary"), Mapping) else {}
     )
@@ -181,13 +342,47 @@ def build_source_quality_report(
     ).hexdigest()
 
     if not files:
-        operator_summary = "No manifest file rows are available; source quality fails closed."
+        operator_summary = (
+            "No manifest file rows are available; data/source/identity readiness "
+            "fails closed."
+        )
     elif research_ready:
         operator_summary = (
             "All manifest rows have high-confidence source identity and ready quality evidence."
         )
     else:
-        operator_summary = "Source quality is not research-ready; inspect blocking_reason_counts and row explanations."
+        categories = ", ".join(sorted(blocker_category_counts)) or "unknown"
+        operator_summary = (
+            "Source quality is not research-ready; inspect data/source/identity "
+            f"readiness blockers ({categories}) and row explanations."
+        )
+    report_readiness_blockers = []
+    if not files:
+        report_readiness_blockers.append(
+            _blocker(
+                category="data",
+                reason="data_source_rows_missing",
+                evidence_field="files",
+                evidence_status="missing",
+                operator_explanation=(
+                    "No manifest file rows are available, so data/source/identity "
+                    "readiness cannot be established."
+                ),
+            )
+        )
+    if not manifest_ready:
+        report_readiness_blockers.append(
+            _blocker(
+                category="source",
+                reason="source_manifest_research_not_ready",
+                evidence_field="summary.research_ready",
+                evidence_status="false_or_missing",
+                operator_explanation=(
+                    "The upstream cache manifest is not research-ready; source "
+                    "readiness fails closed."
+                ),
+            )
+        )
 
     return {
         "schema_version": SCHEMA_VERSION,
@@ -207,6 +402,9 @@ def build_source_quality_report(
             "identity_confidence_counts": dict(sorted(identity_counts.items())),
             "quality_status_counts": dict(sorted(quality_counts.items())),
             "blocking_reason_counts": dict(sorted(blocking_counts.items())),
+            "readiness_blocker_category_counts": dict(sorted(blocker_category_counts.items())),
+            "readiness_blocker_reason_counts": dict(sorted(blocker_reason_counts.items())),
+            "report_readiness_blockers": report_readiness_blockers,
             "evidence_content_hash": f"sha256:{evidence_hash}",
             "operator_summary": operator_summary,
         },
@@ -221,6 +419,15 @@ def build_source_quality_report(
             "frozen_contracts_unchanged": True,
             "paper_shadow_live_forbidden": True,
             "broker_risk_execution_forbidden": True,
+            "addendum3_reference_taxonomy_only": True,
+            "activates_addendum3_runtime": False,
+            "source_quality_as_alpha": False,
+            "source_quality_as_promotion_authority": False,
+        },
+        "reference_taxonomy": {
+            "source": "Roadmap v6 Addendum 3",
+            "runtime_activation": False,
+            "terms": list(ADDENDUM3_REFERENCE_TAXONOMY),
         },
     }
 
@@ -356,8 +563,10 @@ if __name__ == "__main__":  # pragma: no cover
 
 
 __all__ = [
+    "ADDENDUM3_REFERENCE_TAXONOMY",
     "DEFAULT_OUTPUT_DIR",
     "REPORT_KIND",
+    "READINESS_BLOCKER_CATEGORIES",
     "SCHEMA_VERSION",
     "build_source_quality_report",
     "read_source_quality_status",

--- a/packages/qre_diagnostics/research_diagnostics_loop.py
+++ b/packages/qre_diagnostics/research_diagnostics_loop.py
@@ -329,7 +329,7 @@ def _bounded_failure_action(row: Mapping[str, Any]) -> dict[str, Any]:
 def _summarize_sources(sources: Mapping[str, Mapping[str, Any]]) -> dict[str, Any]:
     summary: dict[str, Any] = {}
     for source_id, source in sorted(sources.items()):
-        summary[source_id] = {
+        source_summary = {
             key: source.get(key)
             for key in (
                 "source_id",
@@ -342,6 +342,21 @@ def _summarize_sources(sources: Mapping[str, Mapping[str, Any]]) -> dict[str, An
             )
             if key in source
         }
+        payload = source.get("payload")
+        payload_summary = (
+            payload.get("summary")
+            if isinstance(payload, Mapping) and isinstance(payload.get("summary"), Mapping)
+            else {}
+        )
+        for key in (
+            "operator_summary",
+            "readiness_blocker_category_counts",
+            "readiness_blocker_reason_counts",
+            "report_readiness_blockers",
+        ):
+            if key in payload_summary:
+                source_summary[key] = payload_summary[key]
+        summary[source_id] = source_summary
     return summary
 
 

--- a/tests/unit/test_qre_data_source_quality_readiness.py
+++ b/tests/unit/test_qre_data_source_quality_readiness.py
@@ -45,7 +45,11 @@ def test_source_quality_report_marks_high_confidence_manifest_rows_ready() -> No
     assert report["rows"][0]["identity_confidence"] == "high"
     assert report["rows"][0]["quality_status"] == "ready"
     assert report["rows"][0]["blocking_reasons"] == []
+    assert report["rows"][0]["readiness_blockers"] == []
+    assert report["summary"]["readiness_blocker_category_counts"] == {}
+    assert report["summary"]["readiness_blocker_reason_counts"] == {}
     assert "high-confidence source identity" in report["summary"]["operator_summary"]
+    assert report["reference_taxonomy"]["runtime_activation"] is False
 
 
 def test_source_quality_blocks_unknown_identity_without_guessing() -> None:
@@ -58,8 +62,53 @@ def test_source_quality_blocks_unknown_identity_without_guessing() -> None:
     assert report["summary"]["source_quality_ready"] is False
     assert report["summary"]["identity_confidence_counts"] == {"low": 1}
     assert report["summary"]["blocking_reason_counts"] == {"identity_not_high_confidence": 1}
+    assert report["summary"]["readiness_blocker_category_counts"] == {"identity": 1}
+    assert report["summary"]["readiness_blocker_reason_counts"] == {
+        "identity_source_unknown": 1
+    }
     assert report["rows"][0]["quality_status"] == "blocked"
     assert report["rows"][0]["blocking_reasons"] == ["identity_not_high_confidence"]
+    assert report["rows"][0]["readiness_blockers"] == [
+        {
+            "category": "identity",
+            "reason": "identity_source_unknown",
+            "evidence_field": "source",
+            "evidence_status": "missing_or_unknown",
+            "fail_closed": True,
+            "operator_explanation": (
+                "Identity evidence field source is missing or unknown; "
+                "source readiness fails closed until the manifest identifies it."
+            ),
+        }
+    ]
+
+
+def test_source_quality_blocks_missing_identity_evidence_by_field() -> None:
+    report = readiness.build_source_quality_report(
+        _manifest(
+            _manifest_row(
+                source=None,
+                instrument="",
+                timeframe="unknown",
+                cache_kind=None,
+            )
+        ),
+        generated_at_utc="2026-05-23T00:00:00Z",
+    )
+
+    assert report["summary"]["research_ready"] is False
+    assert report["summary"]["identity_confidence_counts"] == {"unknown": 1}
+    assert report["summary"]["readiness_blocker_category_counts"] == {"identity": 4}
+    assert report["summary"]["readiness_blocker_reason_counts"] == {
+        "identity_cache_kind_unknown": 1,
+        "identity_instrument_unknown": 1,
+        "identity_source_unknown": 1,
+        "identity_timeframe_unknown": 1,
+    }
+    assert all(
+        blocker["fail_closed"] is True
+        for blocker in report["rows"][0]["readiness_blockers"]
+    )
 
 
 def test_source_quality_blocks_manifest_quality_failures() -> None:
@@ -81,6 +130,14 @@ def test_source_quality_blocks_manifest_quality_failures() -> None:
         "manifest_status_missing_timestamp": 1,
         "timestamp_range_missing": 1,
     }
+    assert report["summary"]["readiness_blocker_category_counts"] == {
+        "data": 1,
+        "source": 1,
+    }
+    assert report["summary"]["readiness_blocker_reason_counts"] == {
+        "data_timestamp_range_missing": 1,
+        "source_manifest_status_not_ready": 1,
+    }
     assert report["rows"][0]["operator_explanation"].startswith(
         "yfinance/BTC-USD/1h is not research-ready"
     )
@@ -96,6 +153,19 @@ def test_source_quality_fails_closed_when_manifest_is_not_ready() -> None:
     assert report["summary"]["source_quality_ready"] is True
     assert report["summary"]["manifest_research_ready"] is False
     assert report["summary"]["fail_closed"] is True
+    assert report["summary"]["report_readiness_blockers"] == [
+        {
+            "category": "source",
+            "reason": "source_manifest_research_not_ready",
+            "evidence_field": "summary.research_ready",
+            "evidence_status": "false_or_missing",
+            "fail_closed": True,
+            "operator_explanation": (
+                "The upstream cache manifest is not research-ready; source "
+                "readiness fails closed."
+            ),
+        }
+    ]
 
 
 def test_source_quality_fails_closed_without_manifest_rows() -> None:
@@ -108,8 +178,61 @@ def test_source_quality_fails_closed_without_manifest_rows() -> None:
     assert report["summary"]["source_quality_ready"] is False
     assert report["summary"]["file_count"] == 0
     assert report["summary"]["operator_summary"] == (
-        "No manifest file rows are available; source quality fails closed."
+        "No manifest file rows are available; data/source/identity readiness "
+        "fails closed."
     )
+    assert report["summary"]["report_readiness_blockers"] == [
+        {
+            "category": "data",
+            "reason": "data_source_rows_missing",
+            "evidence_field": "files",
+            "evidence_status": "missing",
+            "fail_closed": True,
+            "operator_explanation": (
+                "No manifest file rows are available, so data/source/identity "
+                "readiness cannot be established."
+            ),
+        },
+        {
+            "category": "source",
+            "reason": "source_manifest_research_not_ready",
+            "evidence_field": "summary.research_ready",
+            "evidence_status": "false_or_missing",
+            "fail_closed": True,
+            "operator_explanation": (
+                "The upstream cache manifest is not research-ready; source "
+                "readiness fails closed."
+            ),
+        },
+    ]
+
+
+def test_source_quality_blocks_missing_data_and_source_evidence() -> None:
+    report = readiness.build_source_quality_report(
+        _manifest(
+            _manifest_row(
+                row_count=None,
+                min_timestamp_utc=None,
+                max_timestamp_utc=None,
+                content_hash=None,
+            )
+        ),
+        generated_at_utc="2026-05-23T00:00:00Z",
+    )
+
+    assert report["summary"]["research_ready"] is False
+    assert report["summary"]["readiness_blocker_category_counts"] == {
+        "data": 2,
+        "source": 1,
+    }
+    assert report["summary"]["readiness_blocker_reason_counts"] == {
+        "data_row_count_not_positive": 1,
+        "data_timestamp_range_missing": 1,
+        "source_content_hash_missing": 1,
+    }
+    assert "data/source/identity readiness blockers" in report["summary"][
+        "operator_summary"
+    ]
 
 
 def test_read_source_quality_status_fails_closed_until_report_exists(tmp_path: Path) -> None:
@@ -161,4 +284,13 @@ def test_safety_invariants_keep_source_quality_read_only() -> None:
         "frozen_contracts_unchanged": True,
         "paper_shadow_live_forbidden": True,
         "broker_risk_execution_forbidden": True,
+        "addendum3_reference_taxonomy_only": True,
+        "activates_addendum3_runtime": False,
+        "source_quality_as_alpha": False,
+        "source_quality_as_promotion_authority": False,
+    }
+    assert set(readiness.READINESS_BLOCKER_CATEGORIES) == {
+        "data",
+        "source",
+        "identity",
     }

--- a/tests/unit/test_qre_research_diagnostics_loop.py
+++ b/tests/unit/test_qre_research_diagnostics_loop.py
@@ -119,6 +119,64 @@ def test_diagnostics_loop_missing_sources_fail_closed(tmp_path: Path) -> None:
     assert "missing_failure_diagnostic_chain" in digest["summary"]["blocking_reasons"]
 
 
+def test_diagnostics_loop_surfaces_data_source_identity_blockers(
+    tmp_path: Path,
+) -> None:
+    _write_json(
+        tmp_path / "logs" / "qre_data_source_quality_readiness" / "latest.json",
+        {
+            "schema_version": "1.0",
+            "generated_at_utc": "2026-05-23T00:00:00Z",
+            "summary": {
+                "research_ready": False,
+                "operator_summary": (
+                    "Source quality is not research-ready; inspect "
+                    "data/source/identity readiness blockers."
+                ),
+                "readiness_blocker_category_counts": {
+                    "data": 2,
+                    "identity": 1,
+                    "source": 1,
+                },
+                "readiness_blocker_reason_counts": {
+                    "data_row_count_not_positive": 1,
+                    "data_timestamp_range_missing": 1,
+                    "identity_source_unknown": 1,
+                    "source_content_hash_missing": 1,
+                },
+                "report_readiness_blockers": [
+                    {
+                        "category": "source",
+                        "reason": "source_manifest_research_not_ready",
+                        "fail_closed": True,
+                    }
+                ],
+            },
+        },
+    )
+
+    digest = build_diagnostics_loop_digest(
+        repo_root=tmp_path,
+        generated_at_utc="2026-05-23T00:00:00Z",
+    )
+
+    source_quality = digest["sources"]["source_quality"]
+    assert source_quality["status"] == "not_ready"
+    assert source_quality["fails_closed"] is True
+    assert source_quality["readiness_blocker_category_counts"] == {
+        "data": 2,
+        "identity": 1,
+        "source": 1,
+    }
+    assert source_quality["readiness_blocker_reason_counts"][
+        "identity_source_unknown"
+    ] == 1
+    assert source_quality["report_readiness_blockers"][0]["fail_closed"] is True
+    assert "data/source/identity readiness blockers" in source_quality[
+        "operator_summary"
+    ]
+
+
 def test_diagnostics_loop_invalid_source_count_is_separate_from_missing(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- add explicit read-only data/source/identity readiness blocker rows to qre_data.source_quality_readiness
- surface source-quality blocker category/reason summaries in the diagnostics-loop source summary
- document that Addendum 3 is taxonomy-only and does not activate runtime source scope

## Scope Controls
- no external source adapters or datafeeds added
- no Addendum 3 runtime activation
- no source quality as alpha or promotion authority
- no frozen contract, strategy, execution, routing, campaign, dashboard mutation, paper/shadow/live/risk/broker path changes

## Validation
- pytest tests/unit/test_qre_data_source_quality_readiness.py tests/unit/test_qre_research_diagnostics_loop.py
- python -m reporting.architecture_import_scan --format summary (forbidden_edge_count=0)
- pytest tests/architecture -q
- git diff --check
- ruff check .
- mypy --config-file pyproject.toml --explicit-package-bases
- python scripts/governance_lint.py
- pytest tests/regression -q -k pin_or_deterministic_or_digest_or_invariant
- PowerShell-expanded hook tests passed
- pytest tests/smoke tests/unit -q
