### PR TITLE
docs: mark ADE-QRE-014L done

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -1109,7 +1109,20 @@
 
 - queue id: `ADE-QRE-014L`
 - title: Data/Source Readiness Blocker Coverage.
-- status: `ready`
+- status: `done`
+- completion evidence: PR #355, merge SHA
+  `c1aac7cda8874905d010c19dd635cf496a1e7b13`; post-merge Fast
+  pre-merge gate run `26439212100`, Docker build/push run `26439500230`,
+  and VPS deploy run `26439500103` completed/success; targeted
+  data/source/identity blocker tests, fail-closed missing/unknown evidence
+  tests, architecture tests, architecture scanner, ruff, mypy,
+  regression-fast, hook tests, governance lint, `git diff --check`, and PR
+  Fast pre-merge gate passed; frozen contracts unchanged;
+  protected/execution paths untouched; no source runtime, external adapter,
+  datafeed, data lake rollout, source-quality alpha/promotion authority,
+  Addendum 3 runtime activation, strategy, registry, research output,
+  campaign/routing mutation, dashboard mutation, approval mutation,
+  paper/shadow/live/risk/broker/execution, or dependency PR changes.
 - purpose: improve read-only coverage of data/source/identity readiness
   blockers using Addendum 3 as reference taxonomy only.
 - depends on: `ADE-QRE-014K done`.
@@ -1185,7 +1198,7 @@
 
 - queue id: `ADE-QRE-014M`
 - title: Diagnostic Readiness Blocker Coverage.
-- status: `blocked until ADE-QRE-014L done`
+- status: `ready`
 - purpose: improve read-only coverage of missing diagnostic/quorum/null-model
   blockers using Addendum 1 as reference taxonomy only.
 - depends on: `ADE-QRE-014L done`.

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -138,6 +138,7 @@ def test_ade_qre_014_active_queue_lifecycle_is_consistent() -> None:
     item_j = items["ADE-QRE-014J"]
     item_k = items["ADE-QRE-014K"]
     item_l = items["ADE-QRE-014L"]
+    item_m = items["ADE-QRE-014M"]
 
     assert item_a.status == "done"
     assert _done_evidence_is_complete(item_a)
@@ -195,11 +196,17 @@ def test_ade_qre_014_active_queue_lifecycle_is_consistent() -> None:
     assert _dependencies_done(item_k, items) is True
     assert _auto_selectable_status(item_k) is False
 
-    assert item_l.status == "ready"
+    assert item_l.status == "done"
+    assert _done_evidence_is_complete(item_l)
     assert item_l.dependencies == ("ADE-QRE-014K",)
     assert _dependencies_done(item_l, items) is True
-    assert _auto_selectable_status(item_l) is True
-    assert _next_eligible_ready_item(items) == item_l
+    assert _auto_selectable_status(item_l) is False
+
+    assert item_m.status == "ready"
+    assert item_m.dependencies == ("ADE-QRE-014L",)
+    assert _dependencies_done(item_m, items) is True
+    assert _auto_selectable_status(item_m) is True
+    assert _next_eligible_ready_item(items) == item_m
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:


### PR DESCRIPTION
## Summary
- mark ADE-QRE-014L done after implementation PR #355 merged and post-merge gates passed
- make ADE-QRE-014M the next ready queue item
- update the queue lifecycle guard test to select ADE-QRE-014M

## Validation
- pytest tests/unit/test_ade_qre_014_queue_lifecycle.py -q
- python scripts/governance_lint.py
- python -m reporting.architecture_import_scan --format summary (forbidden_edge_count=0)
- git diff --check
