### PR TITLE
docs: mark ADE-QRE-014M done

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -1204,10 +1204,10 @@
   confirmed `d459829 test: add diagnostic readiness blocker coverage (#357)`.
   Targeted diagnostic readiness blocker tests passed; architecture scanner
   passed with `forbidden_edge_count = 0`; `git diff --check` validation
-  passed; CI/checks were green; main Fast pre-merge gate, Docker build/push,
-  and VPS deploy were green; frozen contracts unchanged; protected/execution
-  paths untouched; strategy synthesis remained blocked; Addendum runtime
-  remained inactive.
+  passed; CI/checks green; main Fast pre-merge gate green; Docker build/push
+  and VPS deploy green; frozen contracts unchanged; protected/execution paths
+  untouched; strategy synthesis remained blocked; Addendum runtime remained
+  inactive.
 - purpose: improve read-only coverage of missing diagnostic/quorum/null-model
   blockers using Addendum 1 as reference taxonomy only.
 - depends on: `ADE-QRE-014L done`.

--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -1198,7 +1198,16 @@
 
 - queue id: `ADE-QRE-014M`
 - title: Diagnostic Readiness Blocker Coverage.
-- status: `ready`
+- status: `done`
+- completion evidence: PR #357, merge SHA
+  `d459829fa988a47a19e6531814b68c05cfc8ff3a`; local `main` git log
+  confirmed `d459829 test: add diagnostic readiness blocker coverage (#357)`.
+  Targeted diagnostic readiness blocker tests passed; architecture scanner
+  passed with `forbidden_edge_count = 0`; `git diff --check` validation
+  passed; CI/checks were green; main Fast pre-merge gate, Docker build/push,
+  and VPS deploy were green; frozen contracts unchanged; protected/execution
+  paths untouched; strategy synthesis remained blocked; Addendum runtime
+  remained inactive.
 - purpose: improve read-only coverage of missing diagnostic/quorum/null-model
   blockers using Addendum 1 as reference taxonomy only.
 - depends on: `ADE-QRE-014L done`.
@@ -1271,7 +1280,7 @@
 
 - queue id: `ADE-QRE-014N`
 - title: Queue/Status Self-Audit Coverage.
-- status: `blocked until ADE-QRE-014M done`
+- status: `ready`
 - purpose: improve read-only self-audit of queue statuses, dependencies, done
   evidence, and blocked/deferred reasons.
 - depends on: `ADE-QRE-014M done`.

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -139,6 +139,7 @@ def test_ade_qre_014_active_queue_lifecycle_is_consistent() -> None:
     item_k = items["ADE-QRE-014K"]
     item_l = items["ADE-QRE-014L"]
     item_m = items["ADE-QRE-014M"]
+    item_n = items["ADE-QRE-014N"]
 
     assert item_a.status == "done"
     assert _done_evidence_is_complete(item_a)
@@ -202,11 +203,17 @@ def test_ade_qre_014_active_queue_lifecycle_is_consistent() -> None:
     assert _dependencies_done(item_l, items) is True
     assert _auto_selectable_status(item_l) is False
 
-    assert item_m.status == "ready"
+    assert item_m.status == "done"
+    assert _done_evidence_is_complete(item_m)
     assert item_m.dependencies == ("ADE-QRE-014L",)
     assert _dependencies_done(item_m, items) is True
-    assert _auto_selectable_status(item_m) is True
-    assert _next_eligible_ready_item(items) == item_m
+    assert _auto_selectable_status(item_m) is False
+
+    assert item_n.status == "ready"
+    assert item_n.dependencies == ("ADE-QRE-014M",)
+    assert _dependencies_done(item_n, items) is True
+    assert _auto_selectable_status(item_n) is True
+    assert _next_eligible_ready_item(items) == item_n
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:


### PR DESCRIPTION
## Summary
- Mark ADE-QRE-014M done with PR #357 merge evidence.
- Make ADE-QRE-014N the next eligible ready item.
- Update the ADE-QRE-014 queue lifecycle guardrail pin after CI showed it still expected 014M ready.
- No implementation, strategy, frozen contract, protected/execution, or Addendum runtime changes.

## Validation
- git diff --check
- python -m reporting.architecture_import_scan --format summary (forbidden_edge_count = 0)
- python scripts/governance_lint.py
- python -m pytest tests/unit/test_ade_qre_014_queue_lifecycle.py -q