### PR TITLE
docs: mark ADE-QRE-014N done

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -1280,7 +1280,15 @@
 
 - queue id: `ADE-QRE-014N`
 - title: Queue/Status Self-Audit Coverage.
-- status: `ready`
+- status: `done`
+- completion evidence: PR #360, merge SHA
+  `4e3e48e0ce37029cfc5eeef04b88f22a97f24f8e`; Fast pre-merge gate,
+  Docker build/push, and VPS deploy post-merge gates completed/success;
+  targeted queue/status self-audit tests, queue lifecycle tests, architecture
+  tests, architecture scanner, ruff, mypy, governance lint, and
+  `git diff --check` passed; frozen contracts unchanged; protected/execution
+  paths untouched; strategy synthesis remained blocked; Addendum runtime
+  remained inactive.
 - purpose: improve read-only self-audit of queue statuses, dependencies, done
   evidence, and blocked/deferred reasons.
 - depends on: `ADE-QRE-014M done`.
@@ -1350,7 +1358,7 @@
 
 - queue id: `ADE-QRE-014O`
 - title: Final Trusted-Loop Queue Readiness Review.
-- status: `blocked until ADE-QRE-014N done`
+- status: `ready`
 - purpose: produce a final read-only review of ADE-QRE-014 maturity and
   recommend exactly one next queue direction.
 - depends on: `ADE-QRE-014N done`.

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -140,6 +140,7 @@ def test_ade_qre_014_active_queue_lifecycle_is_consistent() -> None:
     item_l = items["ADE-QRE-014L"]
     item_m = items["ADE-QRE-014M"]
     item_n = items["ADE-QRE-014N"]
+    item_o = items["ADE-QRE-014O"]
 
     assert item_a.status == "done"
     assert _done_evidence_is_complete(item_a)
@@ -209,11 +210,17 @@ def test_ade_qre_014_active_queue_lifecycle_is_consistent() -> None:
     assert _dependencies_done(item_m, items) is True
     assert _auto_selectable_status(item_m) is False
 
-    assert item_n.status == "ready"
+    assert item_n.status == "done"
+    assert _done_evidence_is_complete(item_n)
     assert item_n.dependencies == ("ADE-QRE-014M",)
     assert _dependencies_done(item_n, items) is True
-    assert _auto_selectable_status(item_n) is True
-    assert _next_eligible_ready_item(items) == item_n
+    assert _auto_selectable_status(item_n) is False
+
+    assert item_o.status == "ready"
+    assert item_o.dependencies == ("ADE-QRE-014N",)
+    assert _dependencies_done(item_o, items) is True
+    assert _auto_selectable_status(item_o) is True
+    assert _next_eligible_ready_item(items) == item_o
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:

--- a/tests/unit/test_ade_queue_status_self_audit.py
+++ b/tests/unit/test_ade_queue_status_self_audit.py
@@ -115,16 +115,16 @@ def test_blocked_and_deferred_reason_gaps_are_explicit(tmp_path: Path) -> None:
     )
 
 
-def test_current_queue_selects_ade_qre_014n_and_keeps_014o_blocked() -> None:
+def test_current_queue_selects_ade_qre_014o_after_014n_done() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-05-27T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-014N"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-014O"
     assert "ADE-QRE-011" in snap["summary"]["stale_historical_ready_items"]
-    assert rows["ADE-QRE-014N"]["auto_selectable"] is True
-    assert rows["ADE-QRE-014O"]["status_family"] == "blocked"
-    assert rows["ADE-QRE-014O"]["blocked_deferred_reason"]["explicit"] is True
-    assert rows["ADE-QRE-014O"]["auto_selectable"] is False
+    assert rows["ADE-QRE-014N"]["status"] == "done"
+    assert rows["ADE-QRE-014N"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-014O"]["status"] == "ready"
+    assert rows["ADE-QRE-014O"]["auto_selectable"] is True
     assert snap["safety_invariants"]["adds_approval_mutation"] is False
     assert snap["safety_invariants"]["expands_autonomous_authority"] is False
     assert snap["safety_invariants"]["strategy_synthesis_enabled"] is False


### PR DESCRIPTION
## Summary
- Marks ADE-QRE-014N done with PR #360 merge evidence and post-merge gates.
- Advances ADE-QRE-014O from blocked to ready because ADE-QRE-014N is now done.
- Updates queue-status tests so the live queue invariant selects ADE-QRE-014O.

## Validation
- `python -m pytest tests/unit/test_ade_queue_status_self_audit.py tests/unit/test_ade_qre_014_queue_lifecycle.py -q`
- `python -m reporting.ade_queue_status_self_audit --no-write --frozen-utc 2026-05-27T00:00:00Z` (next eligible: ADE-QRE-014O)
- `python -m reporting.architecture_import_scan --format summary` (`forbidden_edge_count=0`)
- `python -m ruff check tests\unit\test_ade_qre_014_queue_lifecycle.py tests\unit\test_ade_queue_status_self_audit.py`
- `python -m mypy --explicit-package-bases tests\unit\test_ade_qre_014_queue_lifecycle.py tests\unit\test_ade_queue_status_self_audit.py`
- `python scripts\governance_lint.py`
- `git diff --check`

## Scope guardrails
- No frozen contracts changed.
- No protected/execution paths touched.
- No strategy synthesis, registry, strategy code, Addendum runtime, dashboard mutation route, approval mutation, campaign/routing mutation, or dependency PR changes.