### PR TITLE
docs: add ADE-QRE-014O readiness review

### DIFF
--- a/docs/governance/ade_qre_014o_final_trusted_loop_queue_readiness_review.md
+++ b/docs/governance/ade_qre_014o_final_trusted_loop_queue_readiness_review.md
@@ -1,0 +1,92 @@
+# ADE-QRE-014O - Final Trusted-Loop Queue Readiness Review
+
+> Status: read-only final review record.
+>
+> Scope: governance documentation only. This record does not activate Addendum
+> 4 runtime, strategy synthesis, shadow, paper, live, broker, risk, execution,
+> approval mutation, dashboard mutation, campaign mutation, routing mutation, or
+> frozen contract changes.
+
+## Final Recommendation
+
+Selected next direction: **continue trusted-loop maturity sprint**.
+
+This is the only selected next direction for ADE-QRE-014O. The other allowed
+directions remain unselected:
+
+- `return to QRE Feature Build Track` is not selected because current evidence
+  still fails closed on reason-record density, research-quality KPI values,
+  routing readiness, sampling readiness, and failure-action actionability.
+- `operator review required` is not selected because the queue already defines
+  the next bounded read-only transition item, `ADE-QRE-015A`, after
+  `ADE-QRE-014O` is done.
+- `no eligible work remains` is not selected because `ADE-QRE-015A` is prepared
+  as the next dependency-gated inventory item once `ADE-QRE-014O` is done.
+
+The immediate follow-up remains queue-governed: after this item is marked done,
+`ADE-QRE-015A` may become eligible. This review does not authorize skipping to
+`ADE-QRE-015B`, any `ADE-QRE-015C` branch path, or QRE Feature Build Track
+implementation.
+
+## Evidence Reviewed
+
+| Evidence source | Current signal | Readiness implication |
+| --- | --- | --- |
+| `reporting.ade_queue_status_self_audit --no-write` | `ADE-QRE-014O` is the single next eligible ready item; `ADE-QRE-015A` is blocked until `ADE-QRE-014O done`; blocked/deferred reason gaps are empty; dependency gaps are empty. | Queue sequencing is deterministic enough to complete 014O and then let the queue expose 015A. |
+| `reporting.trusted_loop_materialization --no-write` | `synthesis_remains_blocked=true`; active blocker count is 6; explained blocker count is 6. | The blocker surface is explainable, but this is not a synthesis approval. |
+| `reporting.reason_record_evidence_density --no-write` | `final_recommendation=not_ready_no_reason_records`; `record_count=0`; `records_with_evidence_refs=0`. | Reason-record evidence is visible but not mature enough to support feature-track return claims. |
+| `reporting.trusted_loop_materialization --no-write` KPI section | 0 of 7 research-quality KPI values are complete; 7 fail closed. | KPI doctrine is represented, but numeric evidence is not mature. |
+| `reporting.trusted_loop_materialization --no-write` routing/sampling section | Routing and sampling each report `final_recommendation=nothing_ready`, `total=0`, and readiness score 0.0. | Routing and sampling remain non-ready and read-only. |
+| `reporting.trusted_loop_materialization --no-write` failure-action section | `status=not_ready`; `total_failures=0`; `actionable_failure_count=0`. | Failure-action mapping is not actionable in the current evidence state. |
+| `reporting.operator_decision_surface --no-write` | `ADE-QRE-014O` is next; `ADE-QRE-015A` through `ADE-QRE-015H` are blocked/dependency-gated; strategy synthesis is blocked. | Operator-facing sequencing is available without granting mutation authority. |
+| `docs/roadmap/Roadmap v6 Addendum 4 - Trusted Loop Readiness and Operator Trust.md` | Addendum 4 remains `DEFERRED / REFERENCE-ONLY`. | Addendum 4 can remain a reference taxonomy only. |
+| `research/research_latest.json` | 24 successful historical result rows, 0 failed rows, 0 approved rows. | Existing frozen research output does not provide approved strategy evidence. |
+
+## Maturity Assessment
+
+ADE-QRE-014 improved trusted-loop observability, blocker explanations,
+retrieval coverage, regression fixtures, data/source blocker coverage,
+diagnostic blocker coverage, and queue self-audit coverage. The maturity level
+is still evidence-visible, not operator-trusted. The review can say that
+blockers are more inspectable and that queue selection is deterministic; it
+cannot claim that the trusted loop is ready for synthesis, live-like behavior,
+or QRE Feature Build Track implementation.
+
+The active gaps are material enough to continue trusted-loop maturity work:
+
+- no reason records are present for evidence-density review;
+- research-quality KPIs are numeric-or-fail-closed but not numerically ready;
+- routing and sampling latest artifacts are present but empty/not ready;
+- failure-action mapping has no failure population to map;
+- `ADE-QRE-015A` has not yet inventoried which ADE-QRE-014 outputs are
+  scaffold, working capability, or operator-trusted capability.
+
+## Safety Invariants
+
+- Strategy synthesis remains blocked.
+- Addendum 1, Addendum 2, Addendum 3, and Addendum 4 remain reference-only and
+  not runtime activated.
+- Addendum 4 remains `DEFERRED / REFERENCE-ONLY`.
+- Shadow, paper, live, broker, risk, and execution paths remain inactive.
+- `registry.py`, strategy implementations, frozen research outputs, approval
+  mutation, dashboard mutation routes, campaign mutation, and routing mutation
+  remain out of scope.
+
+## Rejected Trust Claims
+
+This review does not claim:
+
+- strategy synthesis is safe;
+- QRE Feature Build Track implementation is ready;
+- Addendum 4 is active;
+- the trusted loop is operator-trusted end to end;
+- KPI evidence supports promotion decisions;
+- routing or sampling has actionable candidate volume;
+- failure-action mapping can reroute or mutate campaigns.
+
+## Queue Consequence
+
+When `ADE-QRE-014O` is merged and then marked done through the normal status
+update lifecycle, the next queue-consistent action is `ADE-QRE-015A - Post-014
+Final Evidence Inventory`. That item should inventory ADE-QRE-014 evidence
+before any branch decision under `ADE-QRE-015C`.

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -10,6 +10,12 @@ _QUEUE_DOC = (
     / "governance"
     / "ade_queue_001_post_package_qre_ade_work_queue.md"
 )
+_FINAL_REVIEW_DOC = (
+    Path(__file__).resolve().parents[2]
+    / "docs"
+    / "governance"
+    / "ade_qre_014o_final_trusted_loop_queue_readiness_review.md"
+)
 
 
 @dataclass(frozen=True)
@@ -340,3 +346,29 @@ def test_stale_historical_ready_item_does_not_override_new_dependency_chain() ->
 
     assert _stale_historical_ready_items(items) == ("ITEM-A",)
     assert _next_eligible_ready_item(items) == items["ITEM-C"]
+
+
+def test_ade_qre_014o_review_selects_one_allowed_next_direction() -> None:
+    text = _FINAL_REVIEW_DOC.read_text(encoding="utf-8")
+
+    allowed_directions = (
+        "continue trusted-loop maturity sprint",
+        "return to QRE Feature Build Track",
+        "operator review required",
+        "no eligible work remains",
+    )
+    selected_lines = [
+        line.strip()
+        for line in text.splitlines()
+        if line.startswith("Selected next direction:")
+    ]
+
+    assert selected_lines == [
+        "Selected next direction: **continue trusted-loop maturity sprint**."
+    ]
+    assert sum(direction in selected_lines[0] for direction in allowed_directions) == 1
+    assert "`return to QRE Feature Build Track` is not selected" in text
+    assert "`operator review required` is not selected" in text
+    assert "`no eligible work remains` is not selected" in text
+    assert "Strategy synthesis remains blocked." in text
+    assert "Addendum 4 remains `DEFERRED / REFERENCE-ONLY`." in text


### PR DESCRIPTION
## Summary
- adds the ADE-QRE-014O final trusted-loop queue readiness review
- selects exactly one allowed next direction: continue trusted-loop maturity sprint
- pins the review recommendation and safety statements in the ADE-QRE-014 lifecycle test

## Validation
- python -m pytest tests/unit/test_ade_qre_014_queue_lifecycle.py -q
- python -m pytest tests/unit/test_ade_queue_status_self_audit.py tests/unit/test_ade_qre_014_queue_lifecycle.py -q
- git diff --check
- git diff --cached --check
- python -m reporting.architecture_import_scan --format summary
- python -m reporting.trusted_loop_materialization --no-write --frozen-utc 2026-05-27T00:00:00Z
- python -m reporting.operator_decision_surface --no-write --frozen-utc 2026-05-27T00:00:00Z

## Safety
- docs/test-only change
- no frozen contracts touched
- no registry or strategy implementation changes
- strategy synthesis remains blocked
- Addendum runtime remains inactive
- no shadow/paper/live/broker/risk/execution path changes