### PR TITLE
docs: add ADE-QRE-015A evidence inventory

### DIFF
--- a/docs/governance/ade_qre_015a_post_014_final_evidence_inventory.md
+++ b/docs/governance/ade_qre_015a_post_014_final_evidence_inventory.md
@@ -1,0 +1,87 @@
+# ADE-QRE-015A - Post-014 Final Evidence Inventory
+
+> Status: read-only evidence inventory.
+>
+> Scope: governance documentation only. This inventory does not activate
+> Addendum 1, Addendum 2, Addendum 3, Addendum 4, strategy synthesis, shadow,
+> paper, live, broker, risk, execution, approval mutation, dashboard mutation,
+> campaign mutation, routing mutation, or frozen contract changes.
+
+## Inventory Result
+
+ADE-QRE-014B through ADE-QRE-014O produced a useful trusted-loop evidence
+surface, but the trust level remains bounded. The current state is best
+described as:
+
+- working read-only reporting and validation surfaces for blocker visibility;
+- deterministic queue/status evidence for the next governance action;
+- no end-to-end operator-trusted capability for strategy synthesis, QRE Feature
+  Build Track implementation, Addendum runtime activation, or execution-like
+  behavior.
+
+The only safe follow-up from this inventory is the already dependency-gated
+`ADE-QRE-015B` gap-prioritization item. This document does not select an
+`ADE-QRE-015C` branch path.
+
+## Classification Rules
+
+| Classification | Meaning in this inventory |
+| --- | --- |
+| Scaffold | Documentation, fixture, taxonomy, or reference structure that is useful but does not by itself prove operational readiness. |
+| Working capability | Deterministic read-only reporting, tests, or validation exists and can be used to inspect state without mutation authority. |
+| Operator-trusted capability | Evidence is mature enough to support a bounded operator decision without hidden missing inputs, unsupported readiness claims, or runtime authority expansion. |
+
+## Evidence Inventory
+
+| Queue item | Evidence produced | Current classification | Trust limitation |
+| --- | --- | --- | --- |
+| `ADE-QRE-014B` Reason-Record Evidence Density | Read-only reason-record density inspection and missing-evidence visibility. | Working capability | The latest reviewed state still had `record_count=0`; density is measurable, not mature. |
+| `ADE-QRE-014C` KPI Numeric Readiness Completion | Numeric-or-fail-closed KPI readiness behavior for the trusted loop. | Working capability | KPI doctrine is visible, but reviewed KPI values remain fail-closed rather than promotion-ready. |
+| `ADE-QRE-014D` Routing/Sampling Readiness Density | Read-only routing and sampling readiness density checks. | Working capability | Routing and sampling remain read-only and non-ready; no routing or sampling mutation is authorized. |
+| `ADE-QRE-014E` Trusted-Loop Maturity Follow-up | Governance maturity update grounded in 014B-D evidence. | Scaffold | It frames maturity state and preserves Addendum 4 as reference-only; it does not prove trusted-loop completion. |
+| `ADE-QRE-014F` Addendum 4 Planning | Deferred/reference-only Addendum 4 planning lane. | Scaffold | Addendum 4 remains `DEFERRED / REFERENCE-ONLY`; no runtime layer is active. |
+| `ADE-QRE-014G` Synthesis Blocker Explanation Density | Operator-readable synthesis blocker explanations from current readiness evidence. | Working capability | It improves why synthesis is blocked; it does not unblock synthesis. |
+| `ADE-QRE-014H` Failure-to-Action Actionability Density | Deterministic actionability metrics and no-invented-cause handling. | Working capability | Current evidence has no failure population to map into actionable reroute behavior. |
+| `ADE-QRE-014I` Operator Decision Surface Readiness | Read-only operator decision surface for next queue state and blockers. | Working capability | It presents options and blockers only; it does not add approvals, buttons, or mutation authority. |
+| `ADE-QRE-014J` Research Memory Retrieval Coverage | Deterministic retrieval coverage for prior trusted-loop reasons, failures, blockers, and evidence. | Working capability | Retrieval remains context, not authority; it cannot approve routing, synthesis, or execution. |
+| `ADE-QRE-014K` Trusted Loop Regression Fixtures | Stable complete, thin, missing, contradictory, blocked, and non-actionable fixture cases. | Working capability | Fixtures pin reporting behavior; they do not create live evidence or runtime readiness. |
+| `ADE-QRE-014L` Data/Source Readiness Blocker Coverage | Data/source/identity blocker coverage using Addendum 3 as reference taxonomy only. | Working capability | No source runtime, external adapter, datafeed, or source-quality alpha authority is active. |
+| `ADE-QRE-014M` Diagnostic Readiness Blocker Coverage | Diagnostic/quorum/null-model blocker coverage using Addendum 1 as reference taxonomy only. | Working capability | Diagnostics remain evidence surfaces; no diagnostic runtime layer or synthesis authority is active. |
+| `ADE-QRE-014N` Queue/Status Self-Audit Coverage | Read-only self-audit of queue statuses, dependencies, done evidence, and blocked/deferred reasons. | Operator-trusted capability for queue sequencing only | Trust is limited to queue consistency inspection; it does not authorize autonomous scope expansion. |
+| `ADE-QRE-014O` Final Trusted-Loop Queue Readiness Review | Final read-only review selecting `continue trusted-loop maturity sprint` as the next direction. | Operator-trusted capability for the 014O next-direction decision only | The review explicitly says trusted-loop state is evidence-visible, not operator-trusted end to end. |
+
+## Explicit Gaps
+
+The following gaps remain after 014O and must be ranked before any return
+readiness decision:
+
+| Gap | Evidence basis | Why it matters |
+| --- | --- | --- |
+| Reason-record evidence is thin or absent. | 014O reviewed `record_count=0` and `records_with_evidence_refs=0`. | Future decisions need inspectable reasons before strategy synthesis or feature-track return claims. |
+| Research-quality KPI values are not promotion-ready. | 014O reviewed 0 of 7 research-quality KPI values as complete. | KPI doctrine exists, but numeric evidence does not yet support promotion decisions. |
+| Routing readiness remains non-ready. | 014O reviewed routing `final_recommendation=nothing_ready`, `total=0`, and readiness score 0.0. | v3.15.16 work cannot be treated as ready from current routing evidence alone. |
+| Sampling readiness remains non-ready. | 014O reviewed sampling `final_recommendation=nothing_ready`, `total=0`, and readiness score 0.0. | Sampling cannot support feature-track return without more evidence. |
+| Failure-action mapping has no actionable failure population. | 014O reviewed `total_failures=0` and `actionable_failure_count=0`. | Action mapping is visible but cannot prove reroute/action usefulness yet. |
+| Trust classifications are uneven. | 014B-O include scaffold, working capability, and narrow queue-decision trust. | 015B must rank gaps by operator value, safety, evidence impact, and implementation risk before 015C chooses a direction. |
+
+## Unsupported Trust Claims Rejected
+
+This inventory does not claim:
+
+- strategy synthesis is safe or eligible;
+- QRE Feature Build Track implementation may start;
+- v3.15.16 Intelligent Routing implementation may start;
+- Addendum 1, 2, 3, or 4 is runtime active;
+- retrieval can act as authority;
+- diagnostics can act as synthesis authority;
+- source quality is alpha or promotion authority;
+- queue sequencing trust expands autonomous authority;
+- shadow, paper, live, broker, risk, or execution paths are available.
+
+## Queue Consequence
+
+`ADE-QRE-015A` leaves the transition queue in a single deterministic state:
+`ADE-QRE-015B - Trusted-Loop Gap Prioritization` is the next dependency-gated
+item once this inventory is merged and then marked done through the normal
+status-update lifecycle.
+


### PR DESCRIPTION
## Summary
- add ADE-QRE-015A post-014 evidence inventory
- classify 014B-014O evidence as scaffold, working capability, or narrow operator-trusted capability
- keep strategy synthesis, Addendum runtime, execution paths, and frozen contracts inactive

## Validation
- git diff --check
- python -m reporting.architecture_import_scan --format summary
- python scripts/governance_lint.py
- verified frozen research outputs, registry.py, and strategy implementations unchanged