### PR TITLE
docs: mark ADE-QRE-015A done

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -1457,7 +1457,15 @@ Scope constraints:
 
 - queue id: `ADE-QRE-015A`
 - title: Post-014 Final Evidence Inventory.
-- status: `ready`
+- status: `done`
+- completion evidence: PR #364, merge SHA
+  `5469d041e1e1f09648a125b681a73732505e1ef7`; evidence inventory added in
+  `docs/governance/ade_qre_015a_post_014_final_evidence_inventory.md`;
+  post-merge Fast pre-merge gate run `26532026262`, Docker build/push run
+  `26532342682`, and VPS deploy run `26532342816` completed/success; local
+  `git diff --check`, architecture scanner, and governance lint passed; frozen
+  contracts unchanged; protected/execution paths untouched; strategy synthesis
+  remained blocked; Addendum runtime remained inactive.
 - purpose: inventory all evidence produced by `ADE-QRE-014B` through
   `ADE-QRE-014O` and identify what is still scaffold, working capability, or
   operator-trusted capability.
@@ -1525,7 +1533,7 @@ Scope constraints:
 
 - queue id: `ADE-QRE-015B`
 - title: Trusted-Loop Gap Prioritization.
-- status: `blocked until ADE-QRE-015A done`
+- status: `ready`
 - purpose: rank remaining trusted-loop gaps by operator value, safety,
   evidence impact, and implementation risk.
 - depends on: `ADE-QRE-015A done`.

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -148,6 +148,7 @@ def test_ade_qre_014_active_queue_lifecycle_is_consistent() -> None:
     item_n = items["ADE-QRE-014N"]
     item_o = items["ADE-QRE-014O"]
     item_15a = items["ADE-QRE-015A"]
+    item_15b = items["ADE-QRE-015B"]
 
     assert item_a.status == "done"
     assert _done_evidence_is_complete(item_a)
@@ -229,11 +230,17 @@ def test_ade_qre_014_active_queue_lifecycle_is_consistent() -> None:
     assert _dependencies_done(item_o, items) is True
     assert _auto_selectable_status(item_o) is False
 
-    assert item_15a.status == "ready"
+    assert item_15a.status == "done"
+    assert _done_evidence_is_complete(item_15a)
     assert item_15a.dependencies == ("ADE-QRE-014O",)
     assert _dependencies_done(item_15a, items) is True
-    assert _auto_selectable_status(item_15a) is True
-    assert _next_eligible_ready_item(items) == item_15a
+    assert _auto_selectable_status(item_15a) is False
+
+    assert item_15b.status == "ready"
+    assert item_15b.dependencies == ("ADE-QRE-015A",)
+    assert _dependencies_done(item_15b, items) is True
+    assert _auto_selectable_status(item_15b) is True
+    assert _next_eligible_ready_item(items) == item_15b
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:

--- a/tests/unit/test_ade_queue_status_self_audit.py
+++ b/tests/unit/test_ade_queue_status_self_audit.py
@@ -115,18 +115,20 @@ def test_blocked_and_deferred_reason_gaps_are_explicit(tmp_path: Path) -> None:
     )
 
 
-def test_current_queue_selects_ade_qre_015a_after_014o_done() -> None:
+def test_current_queue_selects_ade_qre_015b_after_015a_done() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-05-27T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-015A"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-015B"
     assert "ADE-QRE-011" in snap["summary"]["stale_historical_ready_items"]
     assert rows["ADE-QRE-014N"]["status"] == "done"
     assert rows["ADE-QRE-014N"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-014O"]["status"] == "done"
     assert rows["ADE-QRE-014O"]["done_evidence"]["complete"] is True
-    assert rows["ADE-QRE-015A"]["status"] == "ready"
-    assert rows["ADE-QRE-015A"]["auto_selectable"] is True
+    assert rows["ADE-QRE-015A"]["status"] == "done"
+    assert rows["ADE-QRE-015A"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-015B"]["status"] == "ready"
+    assert rows["ADE-QRE-015B"]["auto_selectable"] is True
     assert snap["safety_invariants"]["adds_approval_mutation"] is False
     assert snap["safety_invariants"]["expands_autonomous_authority"] is False
     assert snap["safety_invariants"]["strategy_synthesis_enabled"] is False


### PR DESCRIPTION
## Summary
- mark ADE-QRE-015A done with PR #364 and post-merge gate evidence
- make ADE-QRE-015B the next ready item
- update queue-status tests that pin the next eligible item

## Validation
- git diff --check
- python -m reporting.architecture_import_scan --format summary
- python scripts/governance_lint.py
- python -m pytest tests/unit/test_ade_queue_status_self_audit.py tests/unit/test_ade_qre_014_queue_lifecycle.py -q
- verified frozen research outputs, registry.py, and strategy implementations unchanged