### PR TITLE
docs: mark ADE-QRE-015B done

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -1533,7 +1533,16 @@ Scope constraints:
 
 - queue id: `ADE-QRE-015B`
 - title: Trusted-Loop Gap Prioritization.
-- status: `ready`
+- status: `done`
+- completion evidence: PR #366, merge SHA
+  `eca3666092d0cbe9681115c9180d91e6a0a8d8c6`; deterministic trusted-loop
+  gap prioritization added in
+  `docs/governance/ade_qre_015b_trusted_loop_gap_prioritization.md`;
+  post-merge Fast pre-merge gate run `26533816388`, Docker build/push run
+  `26534136899`, and VPS deploy run `26534140225` completed/success; local
+  `git diff --check`, architecture scanner, and governance lint passed; frozen
+  contracts unchanged; protected/execution paths untouched; strategy synthesis
+  remained blocked; Addendum runtime remained inactive.
 - purpose: rank remaining trusted-loop gaps by operator value, safety,
   evidence impact, and implementation risk.
 - depends on: `ADE-QRE-015A done`.
@@ -1600,7 +1609,7 @@ Scope constraints:
 
 - queue id: `ADE-QRE-015C`
 - title: QRE Feature Track Return Readiness Check.
-- status: `blocked until ADE-QRE-015B done`
+- status: `ready`
 - purpose: determine whether the project is ready to return to the QRE
   Feature Build Track after the trusted-loop sprint.
 - depends on: `ADE-QRE-015B done`.

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -149,6 +149,7 @@ def test_ade_qre_014_active_queue_lifecycle_is_consistent() -> None:
     item_o = items["ADE-QRE-014O"]
     item_15a = items["ADE-QRE-015A"]
     item_15b = items["ADE-QRE-015B"]
+    item_15c = items["ADE-QRE-015C"]
 
     assert item_a.status == "done"
     assert _done_evidence_is_complete(item_a)
@@ -236,11 +237,17 @@ def test_ade_qre_014_active_queue_lifecycle_is_consistent() -> None:
     assert _dependencies_done(item_15a, items) is True
     assert _auto_selectable_status(item_15a) is False
 
-    assert item_15b.status == "ready"
+    assert item_15b.status == "done"
+    assert _done_evidence_is_complete(item_15b)
     assert item_15b.dependencies == ("ADE-QRE-015A",)
     assert _dependencies_done(item_15b, items) is True
-    assert _auto_selectable_status(item_15b) is True
-    assert _next_eligible_ready_item(items) == item_15b
+    assert _auto_selectable_status(item_15b) is False
+
+    assert item_15c.status == "ready"
+    assert item_15c.dependencies == ("ADE-QRE-015B",)
+    assert _dependencies_done(item_15c, items) is True
+    assert _auto_selectable_status(item_15c) is True
+    assert _next_eligible_ready_item(items) == item_15c
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:

--- a/tests/unit/test_ade_queue_status_self_audit.py
+++ b/tests/unit/test_ade_queue_status_self_audit.py
@@ -115,11 +115,11 @@ def test_blocked_and_deferred_reason_gaps_are_explicit(tmp_path: Path) -> None:
     )
 
 
-def test_current_queue_selects_ade_qre_015b_after_015a_done() -> None:
+def test_current_queue_selects_ade_qre_015c_after_015b_done() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-05-27T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-015B"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-015C"
     assert "ADE-QRE-011" in snap["summary"]["stale_historical_ready_items"]
     assert rows["ADE-QRE-014N"]["status"] == "done"
     assert rows["ADE-QRE-014N"]["done_evidence"]["complete"] is True
@@ -127,8 +127,10 @@ def test_current_queue_selects_ade_qre_015b_after_015a_done() -> None:
     assert rows["ADE-QRE-014O"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-015A"]["status"] == "done"
     assert rows["ADE-QRE-015A"]["done_evidence"]["complete"] is True
-    assert rows["ADE-QRE-015B"]["status"] == "ready"
-    assert rows["ADE-QRE-015B"]["auto_selectable"] is True
+    assert rows["ADE-QRE-015B"]["status"] == "done"
+    assert rows["ADE-QRE-015B"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-015C"]["status"] == "ready"
+    assert rows["ADE-QRE-015C"]["auto_selectable"] is True
     assert snap["safety_invariants"]["adds_approval_mutation"] is False
     assert snap["safety_invariants"]["expands_autonomous_authority"] is False
     assert snap["safety_invariants"]["strategy_synthesis_enabled"] is False


### PR DESCRIPTION
Marks ADE-QRE-015B done after the merged gap prioritization PR and advances ADE-QRE-015C to ready. Updates the queue lifecycle tests to pin the new active item.\n\nLocal validation:\n- git diff --check\n- python -m reporting.architecture_import_scan --format summary\n- python scripts\\governance_lint.py\n- python -m pytest tests/unit/test_ade_queue_status_self_audit.py tests/unit/test_ade_qre_014_queue_lifecycle.py -q\n\nScope guards:\n- frozen research outputs unchanged\n- registry and strategy implementations untouched\n- protected/execution paths untouched\n- strategy synthesis remains blocked\n- Addendum runtime remains inactive