### PR TITLE
docs: add ADE-QRE-015C readiness check

### DIFF
--- a/docs/governance/ade_qre_015c_qre_feature_track_return_readiness_check.md
+++ b/docs/governance/ade_qre_015c_qre_feature_track_return_readiness_check.md
@@ -1,0 +1,90 @@
+# ADE-QRE-015C - QRE Feature Track Return Readiness Check
+
+> Status: read-only readiness recommendation.
+>
+> Scope: governance documentation only. This check does not start QRE Feature
+> Build Track implementation, does not implement v3.15.16 Intelligent Routing,
+> and does not activate strategy synthesis, Addendum runtime, shadow, paper,
+> live, broker, risk, execution, approval mutation, dashboard mutation,
+> campaign mutation, routing mutation, or frozen contract changes.
+
+## Readiness Recommendation
+
+Recommendation: `continue_trusted_loop_maturity`
+
+This is exactly one of the allowed `ADE-QRE-015C` output values and is the only
+selected recommendation. The evidence does not support returning to the QRE
+Feature Build Track yet, but it is sufficient to choose a bounded docs-only
+trusted-loop continuation path without requiring operator review.
+
+## Decision Rule
+
+Return to the QRE Feature Build Track requires all of the following to be true:
+
+- high-priority evidence gaps are either closed or explicitly non-blocking;
+- routing and sampling readiness are not being inferred from empty/non-ready
+  surfaces;
+- research-quality KPI evidence can support a readiness claim or has an
+  explicit substitute criterion;
+- the trusted-loop evidence state is more than scaffold or read-only working
+  capability for the relevant feature-track entry point;
+- no runtime authority, approval mutation, dashboard mutation, strategy
+  synthesis, Addendum runtime, or execution-sensitive path is needed.
+
+Current evidence fails the first four conditions. The safe recommendation is to
+continue trusted-loop maturity planning.
+
+## Evidence Basis
+
+| Evidence source | Current signal | Readiness implication |
+| --- | --- | --- |
+| `ADE-QRE-015A` evidence inventory | Most ADE-QRE-014B through ADE-QRE-014O outputs are classified as scaffold or working read-only capability; only queue sequencing and final 014O direction have narrow operator-trusted status. | The evidence surface is useful, but not broad enough to claim feature-track return readiness. |
+| `ADE-QRE-015A` reason-record evidence gap | `record_count=0` and `records_with_evidence_refs=0` were preserved as explicit gaps. | Readiness recommendations still need stronger reason-record evidence before feature implementation claims. |
+| `ADE-QRE-015A` KPI gap | 0 of 7 research-quality KPI values were complete in the reviewed trusted-loop state. | KPI doctrine exists, but numeric evidence is not mature enough for promotion or return-readiness claims. |
+| `ADE-QRE-015A` routing/sampling gaps | Routing and sampling each had `final_recommendation=nothing_ready`, `total=0`, and readiness score 0.0. | v3.15.16 Intelligent Routing re-entry would be premature if this evidence were treated as readiness. |
+| `ADE-QRE-015A` failure-action gap | `total_failures=0` and `actionable_failure_count=0`. | Failure-action mapping is visible but cannot prove useful continuation or reroute behavior yet. |
+| `ADE-QRE-015B` gap prioritization | Five high-priority gaps remain: reason records, KPI numeric readiness, routing readiness, sampling readiness, and trust-boundary precision. | The next safe work should plan a bounded maturity continuation that targets these gaps, not implement feature-track code. |
+| `ADE-QRE-014O` final review | Selected `continue trusted-loop maturity sprint` and rejected feature-track return because evidence still failed closed on the same blocker families. | 015A and 015B refine the evidence, but do not overturn the 014O direction. |
+
+## Recommendation Options Reviewed
+
+| Allowed output | Selected | Evidence-backed rationale |
+| --- | --- | --- |
+| `return_to_qre_feature_track` | No | High-priority gaps remain open, and routing/sampling evidence is empty/non-ready. Starting v3.15.16 implementation would overstate readiness. |
+| `continue_trusted_loop_maturity` | Yes | The next safe step can be docs-only planning for a bounded maturity sprint that targets the ranked gaps without runtime mutation. |
+| `operator_review_required` | No | The evidence deterministically favors continued maturity planning; no unresolved tie between branch paths remains. |
+| `no_eligible_work_remains` | No | `ADE-QRE-015E` is a dependency-gated docs-only continuation planning item when this recommendation is selected. |
+
+## Branch Consequence
+
+Only `ADE-QRE-015E - Trusted-Loop Continuation Planning Docs Only` may become
+eligible after this item is merged and marked done. `ADE-QRE-015D`,
+`ADE-QRE-015F`, and `ADE-QRE-015G` remain blocked because their required
+recommendations were not selected.
+
+This document does not run `ADE-QRE-015E`; it only supplies the explicit
+`ADE-QRE-015C` recommendation needed for the normal queue status update.
+
+## Safety Invariants
+
+- Strategy synthesis remains blocked.
+- Addendum 1, Addendum 2, Addendum 3, and Addendum 4 remain reference-only and
+  not runtime activated.
+- Addendum 4 remains `DEFERRED / REFERENCE-ONLY`.
+- Shadow, paper, live, broker, risk, and execution paths remain inactive.
+- `registry.py`, strategy implementations, frozen research outputs, approval
+  mutation, dashboard mutation routes, campaign mutation, and routing mutation
+  remain out of scope.
+
+## Rejected Trust Claims
+
+This readiness check does not claim:
+
+- QRE Feature Build Track implementation may start now;
+- v3.15.16 Intelligent Routing implementation may start now;
+- the trusted loop is operator-trusted end to end;
+- reason-record evidence is mature;
+- KPI evidence is promotion-ready;
+- routing or sampling has actionable candidate volume;
+- failure-action mapping has an actionable population;
+- retrieval, diagnostics, or source-quality surfaces can act as authority.


### PR DESCRIPTION
Adds the docs-only ADE-QRE-015C readiness check with exactly one allowed recommendation: continue_trusted_loop_maturity. The document keeps branch selection bounded to the later status update and does not implement the selected direction.\n\nLocal validation:\n- git diff --check\n- python -m reporting.architecture_import_scan --format summary\n- python scripts\\governance_lint.py\n\nScope guards:\n- docs-only change\n- frozen research outputs unchanged\n- registry and strategy implementations untouched\n- protected/execution paths untouched\n- strategy synthesis remains blocked\n- Addendum runtime remains inactive