### PR TITLE
docs: mark ADE-QRE-015C done

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -1609,7 +1609,16 @@ Scope constraints:
 
 - queue id: `ADE-QRE-015C`
 - title: QRE Feature Track Return Readiness Check.
-- status: `ready`
+- status: `done`
+- completion evidence: PR #368, merge SHA
+  `69df8aaaea07393f5a13c89e61c5b40910be3fc9`; read-only readiness check added
+  in `docs/governance/ade_qre_015c_qre_feature_track_return_readiness_check.md`
+  with explicit recommendation `continue_trusted_loop_maturity`; post-merge
+  Fast pre-merge gate run `26535691624`, Docker build/push run `26535984857`,
+  and VPS deploy run `26535985000` completed/success; local `git diff --check`,
+  architecture scanner, and governance lint passed; frozen contracts unchanged;
+  protected/execution paths untouched; strategy synthesis remained blocked;
+  Addendum runtime remained inactive.
 - purpose: determine whether the project is ready to return to the QRE
   Feature Build Track after the trusted-loop sprint.
 - depends on: `ADE-QRE-015B done`.
@@ -1750,7 +1759,7 @@ Scope constraints:
 
 - queue id: `ADE-QRE-015E`
 - title: Trusted-Loop Continuation Planning Docs Only.
-- status: `blocked until ADE-QRE-015C done and recommendation is continue_trusted_loop_maturity`
+- status: `ready`
 - purpose: prepare a docs-only next trusted-loop maturity sprint if returning
   to QRE Feature Track is not yet safe.
 - depends on: `ADE-QRE-015C done`.

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -150,6 +150,10 @@ def test_ade_qre_014_active_queue_lifecycle_is_consistent() -> None:
     item_15a = items["ADE-QRE-015A"]
     item_15b = items["ADE-QRE-015B"]
     item_15c = items["ADE-QRE-015C"]
+    item_15d = items["ADE-QRE-015D"]
+    item_15e = items["ADE-QRE-015E"]
+    item_15f = items["ADE-QRE-015F"]
+    item_15g = items["ADE-QRE-015G"]
 
     assert item_a.status == "done"
     assert _done_evidence_is_complete(item_a)
@@ -243,11 +247,23 @@ def test_ade_qre_014_active_queue_lifecycle_is_consistent() -> None:
     assert _dependencies_done(item_15b, items) is True
     assert _auto_selectable_status(item_15b) is False
 
-    assert item_15c.status == "ready"
+    assert item_15c.status == "done"
+    assert _done_evidence_is_complete(item_15c)
     assert item_15c.dependencies == ("ADE-QRE-015B",)
     assert _dependencies_done(item_15c, items) is True
-    assert _auto_selectable_status(item_15c) is True
-    assert _next_eligible_ready_item(items) == item_15c
+    assert _auto_selectable_status(item_15c) is False
+
+    assert item_15d.status.startswith("blocked until ADE-QRE-015C done")
+    assert _auto_selectable_status(item_15d) is False
+    assert item_15e.status == "ready"
+    assert item_15e.dependencies == ("ADE-QRE-015C",)
+    assert _dependencies_done(item_15e, items) is True
+    assert _auto_selectable_status(item_15e) is True
+    assert item_15f.status.startswith("blocked until ADE-QRE-015C done")
+    assert _auto_selectable_status(item_15f) is False
+    assert item_15g.status.startswith("blocked until ADE-QRE-015C done")
+    assert _auto_selectable_status(item_15g) is False
+    assert _next_eligible_ready_item(items) == item_15e
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:

--- a/tests/unit/test_ade_queue_status_self_audit.py
+++ b/tests/unit/test_ade_queue_status_self_audit.py
@@ -115,11 +115,11 @@ def test_blocked_and_deferred_reason_gaps_are_explicit(tmp_path: Path) -> None:
     )
 
 
-def test_current_queue_selects_ade_qre_015c_after_015b_done() -> None:
+def test_current_queue_selects_ade_qre_015e_after_015c_done() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-05-27T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-015C"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-015E"
     assert "ADE-QRE-011" in snap["summary"]["stale_historical_ready_items"]
     assert rows["ADE-QRE-014N"]["status"] == "done"
     assert rows["ADE-QRE-014N"]["done_evidence"]["complete"] is True
@@ -129,8 +129,13 @@ def test_current_queue_selects_ade_qre_015c_after_015b_done() -> None:
     assert rows["ADE-QRE-015A"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-015B"]["status"] == "done"
     assert rows["ADE-QRE-015B"]["done_evidence"]["complete"] is True
-    assert rows["ADE-QRE-015C"]["status"] == "ready"
-    assert rows["ADE-QRE-015C"]["auto_selectable"] is True
+    assert rows["ADE-QRE-015C"]["status"] == "done"
+    assert rows["ADE-QRE-015C"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-015D"]["auto_selectable"] is False
+    assert rows["ADE-QRE-015E"]["status"] == "ready"
+    assert rows["ADE-QRE-015E"]["auto_selectable"] is True
+    assert rows["ADE-QRE-015F"]["auto_selectable"] is False
+    assert rows["ADE-QRE-015G"]["auto_selectable"] is False
     assert snap["safety_invariants"]["adds_approval_mutation"] is False
     assert snap["safety_invariants"]["expands_autonomous_authority"] is False
     assert snap["safety_invariants"]["strategy_synthesis_enabled"] is False


### PR DESCRIPTION
Marks ADE-QRE-015C done after the merged readiness-check PR and advances exactly one selected branch item, ADE-QRE-015E, to ready. ADE-QRE-015D/F/G remain blocked because their recommendations were not selected.\n\nLocal validation:\n- git diff --check\n- python -m reporting.architecture_import_scan --format summary\n- python scripts\\governance_lint.py\n- python -m pytest tests/unit/test_ade_queue_status_self_audit.py tests/unit/test_ade_qre_014_queue_lifecycle.py -q\n\nScope guards:\n- frozen research outputs unchanged\n- registry and strategy implementations untouched\n- protected/execution paths untouched\n- strategy synthesis remains blocked\n- Addendum runtime remains inactive