### PR TITLE
docs: add ADE-QRE-015E continuation plan

### DIFF
--- a/docs/governance/ade_qre_015e_trusted_loop_continuation_plan.md
+++ b/docs/governance/ade_qre_015e_trusted_loop_continuation_plan.md
@@ -1,0 +1,81 @@
+# ADE-QRE-015E - Trusted-Loop Continuation Planning
+
+> Status: docs-only continuation plan.
+>
+> Scope: governance documentation only. This plan does not implement runtime
+> behavior, strategy synthesis, Addendum runtime, shadow, paper, live, broker,
+> risk, execution, approval mutation, dashboard mutation, routing mutation,
+> campaign mutation, or frozen contract changes.
+
+## Selected Basis
+
+`ADE-QRE-015C` selected `continue_trusted_loop_maturity`. Therefore this is the
+only branch item executed from `ADE-QRE-015D` through `ADE-QRE-015G`.
+`ADE-QRE-015D`, `ADE-QRE-015F`, and `ADE-QRE-015G` remain blocked because their
+required recommendations were not selected.
+
+## Continuation Sprint Objective
+
+Prepare a bounded trusted-loop maturity sprint that improves evidence quality
+before any return to the QRE Feature Build Track. The sprint should target the
+highest-ranked gaps from `ADE-QRE-015B` without adding mutation authority.
+
+## Candidate Work Items
+
+| Candidate | Target gap | Allowed scope | Exit evidence | Dependency gate |
+| --- | --- | --- | --- | --- |
+| `TL-MAT-01` Reason-record evidence maturation | `GAP-015B-01` | Read-only reason-record inventory, missing-evidence taxonomy, deterministic report/docs/tests if reporting changes. | Operator can see which reason records exist, which evidence links are missing, and which claims remain unsupported. | No strategy synthesis; no campaign/routing mutation. |
+| `TL-MAT-02` KPI readiness evidence plan | `GAP-015B-02` | Docs or read-only reporting that distinguishes numeric readiness, fail-closed values, and explicit substitute criteria. | KPI readiness claims are either numeric, explicitly fail-closed, or documented as requiring operator input. | No promotion, approval, strategy, or roadmap activation. |
+| `TL-MAT-03` Routing and sampling readiness evidence bridge | `GAP-015B-03` and `GAP-015B-04` | Read-only evidence inventory and gap explanation for routing/sampling surfaces. | Empty/non-ready routing and sampling states are explained without treating them as implementation readiness. | No v3.15.16 implementation; no routing/campaign mutation. |
+| `TL-MAT-04` Trust-boundary precision note | `GAP-015B-05` | Governance note classifying scaffold, working read-only capability, and operator-trusted capability. | Later queue items can cite a precise trust vocabulary without upgrading authority. | No runtime activation or autonomous authority expansion. |
+| `TL-MAT-05` Failure-action population precheck | `GAP-015B-06` | Read-only report/docs that distinguish absent failure population from non-actionable failure population. | Failure-action claims remain explicit when no failures exist to map. | No reroute, execution, or approval mutation. |
+
+## Recommended Sprint Shape
+
+Run the next maturity sprint in this order:
+
+1. `TL-MAT-01` reason-record evidence maturation.
+2. `TL-MAT-02` KPI readiness evidence plan.
+3. `TL-MAT-03` routing and sampling readiness evidence bridge.
+4. `TL-MAT-04` trust-boundary precision note.
+5. `TL-MAT-05` failure-action population precheck.
+
+This order follows the `ADE-QRE-015B` ranking: reason records and KPIs are the
+largest blockers to evidence-backed decisions, while routing/sampling and trust
+boundary precision prevent accidental feature-track readiness claims.
+
+## Operator Review Checklist
+
+Before any later queue item returns to the QRE Feature Build Track, the operator
+should be able to answer:
+
+- Which reason records exist and which evidence references support them?
+- Which research-quality KPI values are numeric, fail-closed, or explicitly
+  awaiting operator criteria?
+- Are routing and sampling still empty/non-ready, or has new evidence changed
+  that state?
+- Which surfaces are scaffold, which are working read-only capability, and which
+  are operator-trusted for a bounded decision?
+- Does failure-action evidence contain an actual failure population?
+- Are strategy synthesis, Addendum runtime, and execution-sensitive paths still
+  blocked?
+
+## Explicit Non-Goals
+
+This plan does not:
+
+- start QRE Feature Build Track implementation;
+- implement v3.15.16 Intelligent Routing;
+- activate Addendum 1, 2, 3, or 4 as runtime layers;
+- enable strategy synthesis;
+- touch `registry.py`, strategy implementations, frozen research outputs, or
+  execution-sensitive paths;
+- add dashboard mutation routes or approval mutation behavior;
+- create shadow, paper, live, broker, risk, or execution capability.
+
+## Queue Consequence
+
+After this branch item is merged and marked done, `ADE-QRE-015H` may become
+eligible to finalize exactly one next direction. This plan recommends that the
+direction be `start next trusted-loop maturity sprint`, but `ADE-QRE-015H` must
+make the final queue-direction selection and must not implement it.


### PR DESCRIPTION
## Summary
- add docs-only ADE-QRE-015E trusted-loop continuation plan
- preserve the ADE-QRE-015C continue_trusted_loop_maturity branch selection
- keep QRE Feature Build Track, v3.15.16 implementation, Addendum runtime, synthesis, and execution paths inactive

## Validation
- git diff --check
- python -m reporting.architecture_import_scan --format summary
- python scripts\\governance_lint.py
- protected/frozen diff check