### PR TITLE
docs: mark ADE-QRE-015E done

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -1759,7 +1759,15 @@ Scope constraints:
 
 - queue id: `ADE-QRE-015E`
 - title: Trusted-Loop Continuation Planning Docs Only.
-- status: `ready`
+- status: `done`
+- completion evidence: PR #370, merge SHA
+  `31093867c481513cf90b81f40d38fe7685bcc83b`; docs-only trusted-loop
+  continuation plan added in
+  `docs/governance/ade_qre_015e_trusted_loop_continuation_plan.md`;
+  `ADE-QRE-015C` recommendation `continue_trusted_loop_maturity` preserved;
+  `ADE-QRE-015D`, `ADE-QRE-015F`, and `ADE-QRE-015G` remain blocked;
+  checks green; post-merge Fast, Docker build/push, and VPS deploy gates green;
+  frozen contracts unchanged; protected/execution paths untouched.
 - purpose: prepare a docs-only next trusted-loop maturity sprint if returning
   to QRE Feature Track is not yet safe.
 - depends on: `ADE-QRE-015C done`.
@@ -1814,7 +1822,7 @@ Scope constraints:
   - CI failure outside scope.
   - remote auth failure.
   - local git unsafe state.
-- next dependency: `ADE-QRE-015F`.
+- next dependency: `ADE-QRE-015H`.
 
 ### ADE-QRE-015F - Operator Review Packet
 
@@ -1946,10 +1954,10 @@ Scope constraints:
 
 - queue id: `ADE-QRE-015H`
 - title: Queue Direction Finalization.
-- status: `blocked until one of ADE-QRE-015D, ADE-QRE-015E, ADE-QRE-015F, or ADE-QRE-015G is done`
+- status: `ready`
 - purpose: finalize exactly one next queue direction after the `ADE-QRE-015`
   branching decision.
-- depends on: one selected branch path done.
+- depends on: `ADE-QRE-015E done`.
 - risk class: LOW.
 - target layer: `docs/governance`.
 - expected files or file families:

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -154,6 +154,7 @@ def test_ade_qre_014_active_queue_lifecycle_is_consistent() -> None:
     item_15e = items["ADE-QRE-015E"]
     item_15f = items["ADE-QRE-015F"]
     item_15g = items["ADE-QRE-015G"]
+    item_15h = items["ADE-QRE-015H"]
 
     assert item_a.status == "done"
     assert _done_evidence_is_complete(item_a)
@@ -255,15 +256,20 @@ def test_ade_qre_014_active_queue_lifecycle_is_consistent() -> None:
 
     assert item_15d.status.startswith("blocked until ADE-QRE-015C done")
     assert _auto_selectable_status(item_15d) is False
-    assert item_15e.status == "ready"
+    assert item_15e.status == "done"
+    assert _done_evidence_is_complete(item_15e)
     assert item_15e.dependencies == ("ADE-QRE-015C",)
     assert _dependencies_done(item_15e, items) is True
-    assert _auto_selectable_status(item_15e) is True
+    assert _auto_selectable_status(item_15e) is False
     assert item_15f.status.startswith("blocked until ADE-QRE-015C done")
     assert _auto_selectable_status(item_15f) is False
     assert item_15g.status.startswith("blocked until ADE-QRE-015C done")
     assert _auto_selectable_status(item_15g) is False
-    assert _next_eligible_ready_item(items) == item_15e
+    assert item_15h.status == "ready"
+    assert item_15h.dependencies == ("ADE-QRE-015E",)
+    assert _dependencies_done(item_15h, items) is True
+    assert _auto_selectable_status(item_15h) is True
+    assert _next_eligible_ready_item(items) == item_15h
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:

--- a/tests/unit/test_ade_queue_status_self_audit.py
+++ b/tests/unit/test_ade_queue_status_self_audit.py
@@ -115,11 +115,11 @@ def test_blocked_and_deferred_reason_gaps_are_explicit(tmp_path: Path) -> None:
     )
 
 
-def test_current_queue_selects_ade_qre_015e_after_015c_done() -> None:
+def test_current_queue_selects_ade_qre_015h_after_015e_done() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-05-27T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-015E"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-015H"
     assert "ADE-QRE-011" in snap["summary"]["stale_historical_ready_items"]
     assert rows["ADE-QRE-014N"]["status"] == "done"
     assert rows["ADE-QRE-014N"]["done_evidence"]["complete"] is True
@@ -132,10 +132,13 @@ def test_current_queue_selects_ade_qre_015e_after_015c_done() -> None:
     assert rows["ADE-QRE-015C"]["status"] == "done"
     assert rows["ADE-QRE-015C"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-015D"]["auto_selectable"] is False
-    assert rows["ADE-QRE-015E"]["status"] == "ready"
-    assert rows["ADE-QRE-015E"]["auto_selectable"] is True
+    assert rows["ADE-QRE-015E"]["status"] == "done"
+    assert rows["ADE-QRE-015E"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-015E"]["auto_selectable"] is False
     assert rows["ADE-QRE-015F"]["auto_selectable"] is False
     assert rows["ADE-QRE-015G"]["auto_selectable"] is False
+    assert rows["ADE-QRE-015H"]["status"] == "ready"
+    assert rows["ADE-QRE-015H"]["auto_selectable"] is True
     assert snap["safety_invariants"]["adds_approval_mutation"] is False
     assert snap["safety_invariants"]["expands_autonomous_authority"] is False
     assert snap["safety_invariants"]["strategy_synthesis_enabled"] is False


### PR DESCRIPTION
## Summary
- mark ADE-QRE-015E done with PR #370 evidence
- leave unselected branch paths blocked
- make ADE-QRE-015H the only selected next ready queue item
- update queue lifecycle tests

## Validation
- git diff --check
- python -m reporting.architecture_import_scan --format summary
- python scripts\\governance_lint.py
- python -m pytest tests\\unit\\test_ade_queue_status_self_audit.py tests\\unit\\test_ade_qre_014_queue_lifecycle.py -q
- protected/frozen diff check