### PR TITLE
docs: add ADE-QRE-015H direction finalization

### DIFF
--- a/docs/governance/ade_qre_015h_queue_direction_finalization.md
+++ b/docs/governance/ade_qre_015h_queue_direction_finalization.md
@@ -1,0 +1,81 @@
+# ADE-QRE-015H - Queue Direction Finalization
+
+> Status: docs-only queue direction finalization.
+>
+> Scope: governance documentation only. This finalization does not start the
+> selected direction and does not implement QRE Feature Build Track work,
+> v3.15.16 Intelligent Routing, runtime Addendum layers, strategy synthesis,
+> shadow, paper, live, broker, risk, execution, dashboard mutation, approval
+> mutation, routing mutation, campaign mutation, or frozen contract changes.
+
+## Selected Branch Basis
+
+`ADE-QRE-015C` selected exactly one recommendation:
+`continue_trusted_loop_maturity`.
+
+Because of that recommendation, exactly one branch item was executed:
+`ADE-QRE-015E`. The unselected branch items remain blocked:
+
+| Branch item | Required recommendation | Status for this run |
+| --- | --- | --- |
+| `ADE-QRE-015D` | `return_to_qre_feature_track` | Not selected; remains blocked. |
+| `ADE-QRE-015E` | `continue_trusted_loop_maturity` | Selected and completed. |
+| `ADE-QRE-015F` | `operator_review_required` | Not selected; remains blocked. |
+| `ADE-QRE-015G` | `no_eligible_work_remains` | Not selected; remains blocked. |
+
+## Allowed Direction Decision
+
+Selected next direction: **start next trusted-loop maturity sprint**.
+
+This is exactly one of the allowed `ADE-QRE-015H` next directions. The other
+allowed directions are not selected:
+
+| Allowed direction | Decision | Evidence basis |
+| --- | --- | --- |
+| start QRE Feature Build Track v3.15.16 implementation prompt | Not selected. | `ADE-QRE-015C` did not recommend `return_to_qre_feature_track`. |
+| start next trusted-loop maturity sprint | Selected. | `ADE-QRE-015C` recommended `continue_trusted_loop_maturity`, and `ADE-QRE-015E` produced a bounded continuation plan. |
+| wait for operator decision | Not selected. | `ADE-QRE-015C` did not recommend `operator_review_required`; no ambiguity remains after the selected branch path. |
+| stop because no eligible work remains | Not selected. | `ADE-QRE-015C` did not recommend `no_eligible_work_remains`, and `ADE-QRE-015E` identified bounded next sprint candidates. |
+
+## Evidence Chain
+
+- `ADE-QRE-015A` inventoried post-014 evidence and separated scaffold, working
+  read-only capability, and operator-trusted capability.
+- `ADE-QRE-015B` ranked trusted-loop gaps and placed reason-record evidence,
+  KPI readiness, routing/sampling readiness, trust vocabulary, and failure
+  population checks ahead of feature-track return.
+- `ADE-QRE-015C` explicitly recommended `continue_trusted_loop_maturity`.
+- `ADE-QRE-015E` prepared a docs-only continuation plan with bounded candidate
+  work items `TL-MAT-01` through `TL-MAT-05`.
+
+## Next Sprint Boundary
+
+The selected next direction may prepare a future trusted-loop maturity sprint
+around the `ADE-QRE-015E` candidates:
+
+1. `TL-MAT-01` reason-record evidence maturation.
+2. `TL-MAT-02` KPI readiness evidence plan.
+3. `TL-MAT-03` routing and sampling readiness evidence bridge.
+4. `TL-MAT-04` trust-boundary precision note.
+5. `TL-MAT-05` failure-action population precheck.
+
+This finalization does not create runtime work. Any future sprint item must
+still be independently queued, dependency-gated, validated, and merged through
+the normal PR lifecycle.
+
+## Blocked And Deferred Directions
+
+- QRE Feature Build Track v3.15.16 implementation remains blocked for this run.
+- v3.15.16 Intelligent Routing implementation remains not started.
+- Strategy synthesis remains blocked.
+- Addendum 1, Addendum 2, Addendum 3, and Addendum 4 remain reference-only and
+  runtime inactive.
+- Addendum 4 remains `DEFERRED / REFERENCE-ONLY`.
+- Shadow, paper, live, broker, risk, and execution paths remain inactive.
+- Dashboard mutation routes and approval mutation behavior remain blocked.
+
+## Run Closure
+
+After `ADE-QRE-015H` is merged and marked done, this autonomous run must stop.
+The selected next direction is a handoff target only; it is not implemented in
+this run.


### PR DESCRIPTION
## Summary
- add docs-only ADE-QRE-015H queue direction finalization
- select exactly one allowed next direction: start next trusted-loop maturity sprint
- keep QRE Feature Build Track, v3.15.16 implementation, Addendum runtime, synthesis, and execution paths inactive

## Validation
- git diff --check
- python -m reporting.architecture_import_scan --format summary
- python scripts\\governance_lint.py
- protected/frozen diff check