### PR TITLE
docs: mark ADE-QRE-015H done

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -1954,7 +1954,15 @@ Scope constraints:
 
 - queue id: `ADE-QRE-015H`
 - title: Queue Direction Finalization.
-- status: `ready`
+- status: `done`
+- completion evidence: PR #372, merge SHA
+  `be83e53fd1e577cd074895207d3f2879d8b5a445`; docs-only queue direction
+  finalization added in
+  `docs/governance/ade_qre_015h_queue_direction_finalization.md`; exactly one
+  next direction selected, `start next trusted-loop maturity sprint`; selected
+  direction not implemented; checks green; post-merge Fast, Docker build/push,
+  and VPS deploy gates green; frozen contracts unchanged;
+  protected/execution paths untouched.
 - purpose: finalize exactly one next queue direction after the `ADE-QRE-015`
   branching decision.
 - depends on: `ADE-QRE-015E done`.
@@ -2018,4 +2026,4 @@ Scope constraints:
   - CI failure outside scope.
   - remote auth failure.
   - local git unsafe state.
-- next dependency: none.
+- next dependency: none for this autonomous run; stop after `ADE-QRE-015H`.

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -265,11 +265,12 @@ def test_ade_qre_014_active_queue_lifecycle_is_consistent() -> None:
     assert _auto_selectable_status(item_15f) is False
     assert item_15g.status.startswith("blocked until ADE-QRE-015C done")
     assert _auto_selectable_status(item_15g) is False
-    assert item_15h.status == "ready"
+    assert item_15h.status == "done"
+    assert _done_evidence_is_complete(item_15h)
     assert item_15h.dependencies == ("ADE-QRE-015E",)
     assert _dependencies_done(item_15h, items) is True
-    assert _auto_selectable_status(item_15h) is True
-    assert _next_eligible_ready_item(items) == item_15h
+    assert _auto_selectable_status(item_15h) is False
+    assert _next_eligible_ready_item(items) is None
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:

--- a/tests/unit/test_ade_queue_status_self_audit.py
+++ b/tests/unit/test_ade_queue_status_self_audit.py
@@ -115,11 +115,11 @@ def test_blocked_and_deferred_reason_gaps_are_explicit(tmp_path: Path) -> None:
     )
 
 
-def test_current_queue_selects_ade_qre_015h_after_015e_done() -> None:
+def test_current_queue_has_no_eligible_015_item_after_015h_done() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-05-27T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-015H"
+    assert snap["summary"]["next_eligible_ready_item"] is None
     assert "ADE-QRE-011" in snap["summary"]["stale_historical_ready_items"]
     assert rows["ADE-QRE-014N"]["status"] == "done"
     assert rows["ADE-QRE-014N"]["done_evidence"]["complete"] is True
@@ -137,8 +137,9 @@ def test_current_queue_selects_ade_qre_015h_after_015e_done() -> None:
     assert rows["ADE-QRE-015E"]["auto_selectable"] is False
     assert rows["ADE-QRE-015F"]["auto_selectable"] is False
     assert rows["ADE-QRE-015G"]["auto_selectable"] is False
-    assert rows["ADE-QRE-015H"]["status"] == "ready"
-    assert rows["ADE-QRE-015H"]["auto_selectable"] is True
+    assert rows["ADE-QRE-015H"]["status"] == "done"
+    assert rows["ADE-QRE-015H"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-015H"]["auto_selectable"] is False
     assert snap["safety_invariants"]["adds_approval_mutation"] is False
     assert snap["safety_invariants"]["expands_autonomous_authority"] is False
     assert snap["safety_invariants"]["strategy_synthesis_enabled"] is False


### PR DESCRIPTION
## Summary
- mark ADE-QRE-015H done with PR #372 evidence
- record the selected next direction as start next trusted-loop maturity sprint
- update queue lifecycle tests to expect no eligible 015 item after 015H
- do not start the selected next direction

## Validation
- git diff --check
- python -m reporting.architecture_import_scan --format summary
- python scripts\\governance_lint.py
- python -m pytest tests\\unit\\test_ade_queue_status_self_audit.py tests\\unit\\test_ade_qre_014_queue_lifecycle.py -q
- protected/frozen diff check