### PR TITLE
docs: add ADE-QRE-016A evidence closure inventory

### DIFF
--- a/docs/governance/ade_qre_016a_evidence_gap_closure_inventory.md
+++ b/docs/governance/ade_qre_016a_evidence_gap_closure_inventory.md
@@ -1,0 +1,85 @@
+# ADE-QRE-016A - Evidence Gap Closure Inventory
+
+> Status: read-only closure inventory.
+>
+> Scope: governance documentation only. This inventory does not activate QRE
+> Feature Build Track work, v3.15.16 Intelligent Routing, strategy synthesis,
+> Addendum runtime, shadow, paper, live, broker, risk, execution, approval
+> mutation, dashboard mutation, campaign mutation, routing mutation, or frozen
+> contract changes.
+
+## Inventory Result
+
+`ADE-QRE-015B` prioritized seven trusted-loop evidence gaps. This closure
+inventory maps each gap to a bounded closure candidate, current evidence status,
+blocked claims, and validation needs.
+
+Current state remains:
+
+- evidence-visible, not operator-trusted end to end;
+- read-only and fail-closed when evidence is absent, empty, or thin;
+- blocked for strategy synthesis, QRE Feature Build Track implementation,
+  Addendum runtime activation, and execution-like behavior.
+
+No gap is marked closed by this document. A gap is only closure-ready when its
+listed closure evidence exists in a later scoped PR and validation shows that no
+unsupported readiness claim is being inferred.
+
+## Closure Status Vocabulary
+
+| Status | Meaning |
+| --- | --- |
+| `open_missing_evidence` | The current 015 evidence shows the surface is absent, empty, or too thin. |
+| `open_non_ready_evidence` | The surface exists, but current evidence explicitly reports non-ready state. |
+| `open_precision_gap` | Evidence exists, but trust vocabulary or claim boundaries need tightening. |
+| `deferred_low_priority_cleanup` | The gap is known but should not displace higher-priority maturity work. |
+
+## Closure Inventory
+
+| Rank | Gap id | Current evidence status | Closure candidate | Evidence basis | Blocked claims until closed | Validation need |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1 | `GAP-015B-01` reason-record evidence is absent or too thin. | `open_missing_evidence` | Materialize or inventory reason records with durable evidence references, and keep missing records explicit. | `ADE-QRE-015A` records `record_count=0` and `records_with_evidence_refs=0`; `ADE-QRE-015B` ranks this first. | Future recommendations cannot claim full reason-record support, synthesis readiness, or feature-track readiness from current evidence. | A read-only report or doc must show record counts, evidence-reference counts, missing-reference reasons, and fail-closed behavior when records are absent. |
+| 2 | `GAP-015B-02` research-quality KPI values are not promotion-ready. | `open_missing_evidence` | Define numeric KPI evidence requirements or explicit operator-approved substitute criteria without promoting any capability. | `ADE-QRE-015A` records 0 of 7 research-quality KPI values complete; `ADE-QRE-015C` says KPI evidence does not support return-readiness claims. | KPI doctrine cannot be treated as numeric readiness, promotion readiness, or return-to-feature-track readiness. | A read-only checklist must distinguish numeric, fail-closed, missing, and substitute-criterion states for every research-quality KPI. |
+| 3 | `GAP-015B-03` routing readiness remains non-ready. | `open_non_ready_evidence` | Preserve routing as an evidence surface and explain what evidence would be required before any v3.15.16 planning claim. | `ADE-QRE-015A` records routing `final_recommendation=nothing_ready`, `total=0`, and readiness score 0.0; `ADE-QRE-015C` rejects treating this as feature-track readiness. | v3.15.16 Intelligent Routing implementation, campaign routing, or routing-readiness claims remain blocked. | Reporting/docs must keep empty or non-ready routing evidence distinct from implementation readiness and must fail closed on missing routing snapshots. |
+| 4 | `GAP-015B-04` sampling readiness remains non-ready. | `open_non_ready_evidence` | Preserve sampling as an evidence surface and define what non-empty sampling evidence would need to prove. | `ADE-QRE-015A` records sampling `final_recommendation=nothing_ready`, `total=0`, and readiness score 0.0; `ADE-QRE-015E` names routing/sampling readiness as a continuation target. | Sampling readiness, routing/sampling bridge readiness, and feature-track return claims remain blocked. | Reporting/docs must keep empty or non-ready sampling evidence distinct from readiness and must fail closed on missing sampling snapshots. |
+| 5 | `GAP-015B-05` trust classifications are uneven. | `open_precision_gap` | Tighten measurable criteria for scaffold, working capability, and operator-trusted capability without changing runtime authority. | `ADE-QRE-015A` classifies most 014B-O outputs as scaffold or working read-only capability and only 014N/014O as narrow operator-trusted queue-decision surfaces; `ADE-QRE-015B` ranks trust-boundary precision high. | Working read-only surfaces cannot be generalized into operator-trusted capability, approval authority, autonomous scope expansion, synthesis readiness, or execution readiness. | Criteria must be explicit, measurable, evidence-backed, and fail-closed when evidence is missing. |
+| 6 | `GAP-015B-06` failure-action mapping has no actionable failure population. | `open_missing_evidence` | Distinguish absent failure population from non-actionable failure population before making any reroute/action usefulness claim. | `ADE-QRE-015A` records `total_failures=0` and `actionable_failure_count=0`; `ADE-QRE-015B` ranks this medium priority. | Failure-action usefulness, reroute readiness, and actionability claims remain unsupported while there are no failures to map. | A read-only precheck must show failure count, actionable count, and fail-closed status when no failure population exists. |
+| 7 | `GAP-015B-07` historical queue evidence contains non-current audit warnings. | `deferred_low_priority_cleanup` | Clean up or explicitly annotate historical audit warnings only after high-priority maturity gaps are addressed or when a later item scopes it. | `ADE-QRE-015B` records `ADE-QRE-007`, `ADE-QRE-008`, and `ADE-QRE-014A` missing done-evidence warnings from `reporting.ade_queue_status_self_audit --no-write`. | Blanket historical audit-completeness claims remain unsupported. Current queue sequencing can still rely on 015H done and 016A ready state. | A later cleanup must prove that current queue eligibility remains deterministic and that historical warning edits do not mutate runtime behavior. |
+
+## Closure Ordering
+
+The safe closure order follows `ADE-QRE-015B`:
+
+1. reason-record evidence;
+2. research-quality KPI evidence;
+3. routing readiness evidence;
+4. sampling readiness evidence;
+5. trust-boundary precision;
+6. failure-action population precheck;
+7. historical audit warning cleanup only when explicitly scoped.
+
+This order does not authorize any implementation by itself. It only records the
+evidence dependencies that later queue items must satisfy.
+
+## Unsupported Claims Avoided
+
+This inventory does not claim:
+
+- any `GAP-015B-*` gap is closed;
+- QRE Feature Build Track implementation may start;
+- v3.15.16 Intelligent Routing implementation may start;
+- strategy synthesis is eligible;
+- routing or sampling is ready;
+- KPI doctrine is equivalent to numeric KPI evidence;
+- retrieval, diagnostics, source quality, or failure-action mapping can act as
+  authority;
+- the trusted loop is operator-trusted end to end;
+- Addendum 1, Addendum 2, Addendum 3, or Addendum 4 is runtime active;
+- shadow, paper, live, broker, risk, or execution behavior is available.
+
+## Queue Consequence
+
+After this item is merged and marked done through the queue lifecycle,
+`ADE-QRE-016B - Operator Trust Criteria Tightening` may become eligible. That
+follow-up must use this inventory and the 015 evidence to tighten trust criteria
+without expanding runtime authority.


### PR DESCRIPTION
## Summary
- Adds the ADE-QRE-016A read-only evidence gap closure inventory.
- Maps GAP-015B-01 through GAP-015B-07 to closure candidates, evidence status, blocked claims, and validation needs.
- Avoids readiness claims: no gap is marked closed, and synthesis/Addendum/runtime/execution paths remain blocked.

## Validation
- [x] git diff --check
- [x] python -m reporting.architecture_import_scan --format summary (`forbidden_edge_count=0`)
- [x] python scripts/governance_lint.py
- [x] Frozen research outputs unchanged
- [x] Protected strategy/runtime/execution paths untouched

## Scope Guardrails
- Docs-only governance change.
- Does not modify `research/research_latest.json`, `research/strategy_matrix.csv`, `registry.py`, or strategy implementations.
- Does not enable strategy synthesis, Addendum runtime, routing/campaign mutation, dashboard/approval mutation, or shadow/paper/live/broker/risk/execution behavior.