### PR TITLE
docs: mark ADE-QRE-016A done

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -2046,7 +2046,16 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-016A`
 - title: Evidence Gap Closure Inventory.
-- status: `ready`
+- status: `done`
+- completion evidence: PR #376, merge SHA
+  `21ad5a26a496c6f1e185c2c64596a3ba3426c4cd`; read-only evidence gap
+  closure inventory added in
+  `docs/governance/ade_qre_016a_evidence_gap_closure_inventory.md`; post-merge
+  Fast pre-merge gate run `26562379703`, Docker build/push run `26562640607`,
+  and VPS deploy run `26562640663` completed/success; local
+  `git diff --check`, architecture scanner, and governance lint passed; frozen
+  contracts unchanged; protected/execution paths untouched; strategy synthesis
+  remained blocked; Addendum runtime remained inactive.
 - purpose: turn the prioritized `ADE-QRE-015B` gap list into a concrete,
   evidence-backed closure inventory without claiming unsupported readiness.
 - depends on: `ADE-QRE-015H done`.
@@ -2118,7 +2127,7 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-016B`
 - title: Operator Trust Criteria Tightening.
-- status: `blocked until ADE-QRE-016A done`
+- status: `ready`
 - purpose: define stricter criteria for scaffold, working capability, and
   operator-trusted capability, using the 015 evidence and 016A closure
   inventory.

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -279,14 +279,15 @@ def test_ade_qre_active_queue_lifecycle_is_consistent() -> None:
     assert _dependencies_done(item_15h, items) is True
     assert _auto_selectable_status(item_15h) is False
 
-    assert item_16a.status == "ready"
+    assert item_16a.status == "done"
     assert item_16a.dependencies == ("ADE-QRE-015H",)
     assert _dependencies_done(item_16a, items) is True
-    assert _auto_selectable_status(item_16a) is True
-    assert item_16b.status == "blocked until ADE-QRE-016A done"
+    assert _done_evidence_is_complete(item_16a)
+    assert _auto_selectable_status(item_16a) is False
+    assert item_16b.status == "ready"
     assert item_16b.dependencies == ("ADE-QRE-016A",)
-    assert _dependencies_done(item_16b, items) is False
-    assert _auto_selectable_status(item_16b) is False
+    assert _dependencies_done(item_16b, items) is True
+    assert _auto_selectable_status(item_16b) is True
     assert item_16c.status == "blocked until ADE-QRE-016B done"
     assert item_16c.dependencies == ("ADE-QRE-016B",)
     assert _dependencies_done(item_16c, items) is False
@@ -312,7 +313,7 @@ def test_ade_qre_active_queue_lifecycle_is_consistent() -> None:
     assert _dependencies_done(item_16h, items) is False
     assert _auto_selectable_status(item_16h) is False
     assert _stale_historical_ready_items(items) == ("ADE-QRE-011",)
-    assert _next_eligible_ready_item(items) == item_16a
+    assert _next_eligible_ready_item(items) == item_16b
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:

--- a/tests/unit/test_ade_queue_status_self_audit.py
+++ b/tests/unit/test_ade_queue_status_self_audit.py
@@ -115,11 +115,11 @@ def test_blocked_and_deferred_reason_gaps_are_explicit(tmp_path: Path) -> None:
     )
 
 
-def test_current_queue_selects_016a_after_015h_done() -> None:
+def test_current_queue_selects_016b_after_016a_done() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-05-27T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-016A"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-016B"
     assert "ADE-QRE-011" in snap["summary"]["stale_historical_ready_items"]
     assert rows["ADE-QRE-014N"]["status"] == "done"
     assert rows["ADE-QRE-014N"]["done_evidence"]["complete"] is True
@@ -140,10 +140,11 @@ def test_current_queue_selects_016a_after_015h_done() -> None:
     assert rows["ADE-QRE-015H"]["status"] == "done"
     assert rows["ADE-QRE-015H"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-015H"]["auto_selectable"] is False
-    assert rows["ADE-QRE-016A"]["status"] == "ready"
-    assert rows["ADE-QRE-016A"]["auto_selectable"] is True
-    assert rows["ADE-QRE-016B"]["status"] == "blocked until ADE-QRE-016A done"
-    assert rows["ADE-QRE-016B"]["auto_selectable"] is False
+    assert rows["ADE-QRE-016A"]["status"] == "done"
+    assert rows["ADE-QRE-016A"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-016A"]["auto_selectable"] is False
+    assert rows["ADE-QRE-016B"]["status"] == "ready"
+    assert rows["ADE-QRE-016B"]["auto_selectable"] is True
     assert rows["ADE-QRE-016C"]["status"] == "blocked until ADE-QRE-016B done"
     assert rows["ADE-QRE-016C"]["auto_selectable"] is False
     assert rows["ADE-QRE-016D"]["status"] == "blocked until ADE-QRE-016C done"


### PR DESCRIPTION
## Summary
- Marks ADE-QRE-016A done with PR #376, merge SHA, and post-merge gate evidence.
- Makes ADE-QRE-016B the single ready next item.
- Updates existing queue-status tests that pin the next eligible ready item.

## Validation
- [x] git diff --check
- [x] python -m reporting.architecture_import_scan --format summary (`forbidden_edge_count=0`)
- [x] python scripts/governance_lint.py
- [x] pytest tests/unit/test_ade_queue_status_self_audit.py tests/unit/test_ade_qre_014_queue_lifecycle.py -q
- [x] Frozen research outputs unchanged
- [x] Protected strategy/runtime/execution paths untouched

## Scope Guardrails
- Queue/status update only.
- Does not modify `research/research_latest.json`, `research/strategy_matrix.csv`, `registry.py`, or strategy implementations.
- Does not enable strategy synthesis, Addendum runtime, routing/campaign mutation, dashboard/approval mutation, or shadow/paper/live/broker/risk/execution behavior.