### PR TITLE
docs: mark ADE-QRE-016B done

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -2127,7 +2127,16 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-016B`
 - title: Operator Trust Criteria Tightening.
-- status: `ready`
+- status: `done`
+- completion evidence: PR #378, merge SHA
+  `0d114c003d0c3860db06ee4eea838f3c5534e1a0`; read-only operator trust
+  criteria added in
+  `docs/governance/ade_qre_016b_operator_trust_criteria.md`; post-merge Fast
+  pre-merge gate run `26564059058`, Docker build/push run `26564340950`, and
+  VPS deploy run `26564340949` completed/success; local `git diff --check`,
+  architecture scanner, and governance lint passed; frozen contracts
+  unchanged; protected/execution paths untouched; strategy synthesis remained
+  blocked; Addendum runtime remained inactive.
 - purpose: define stricter criteria for scaffold, working capability, and
   operator-trusted capability, using the 015 evidence and 016A closure
   inventory.
@@ -2195,7 +2204,7 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-016C`
 - title: Missing Evidence Fail-Closed Coverage.
-- status: `blocked until ADE-QRE-016B done`
+- status: `ready`
 - purpose: improve tests/reporting that prove missing evidence cannot be
   interpreted as readiness across key trusted-loop surfaces.
 - depends on: `ADE-QRE-016B done`.

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -284,14 +284,15 @@ def test_ade_qre_active_queue_lifecycle_is_consistent() -> None:
     assert _dependencies_done(item_16a, items) is True
     assert _done_evidence_is_complete(item_16a)
     assert _auto_selectable_status(item_16a) is False
-    assert item_16b.status == "ready"
+    assert item_16b.status == "done"
     assert item_16b.dependencies == ("ADE-QRE-016A",)
     assert _dependencies_done(item_16b, items) is True
-    assert _auto_selectable_status(item_16b) is True
-    assert item_16c.status == "blocked until ADE-QRE-016B done"
+    assert _done_evidence_is_complete(item_16b)
+    assert _auto_selectable_status(item_16b) is False
+    assert item_16c.status == "ready"
     assert item_16c.dependencies == ("ADE-QRE-016B",)
-    assert _dependencies_done(item_16c, items) is False
-    assert _auto_selectable_status(item_16c) is False
+    assert _dependencies_done(item_16c, items) is True
+    assert _auto_selectable_status(item_16c) is True
     assert item_16d.status == "blocked until ADE-QRE-016C done"
     assert item_16d.dependencies == ("ADE-QRE-016C",)
     assert _dependencies_done(item_16d, items) is False
@@ -313,7 +314,7 @@ def test_ade_qre_active_queue_lifecycle_is_consistent() -> None:
     assert _dependencies_done(item_16h, items) is False
     assert _auto_selectable_status(item_16h) is False
     assert _stale_historical_ready_items(items) == ("ADE-QRE-011",)
-    assert _next_eligible_ready_item(items) == item_16b
+    assert _next_eligible_ready_item(items) == item_16c
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:

--- a/tests/unit/test_ade_queue_status_self_audit.py
+++ b/tests/unit/test_ade_queue_status_self_audit.py
@@ -115,11 +115,11 @@ def test_blocked_and_deferred_reason_gaps_are_explicit(tmp_path: Path) -> None:
     )
 
 
-def test_current_queue_selects_016b_after_016a_done() -> None:
+def test_current_queue_selects_016c_after_016b_done() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-05-27T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-016B"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-016C"
     assert "ADE-QRE-011" in snap["summary"]["stale_historical_ready_items"]
     assert rows["ADE-QRE-014N"]["status"] == "done"
     assert rows["ADE-QRE-014N"]["done_evidence"]["complete"] is True
@@ -143,10 +143,11 @@ def test_current_queue_selects_016b_after_016a_done() -> None:
     assert rows["ADE-QRE-016A"]["status"] == "done"
     assert rows["ADE-QRE-016A"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-016A"]["auto_selectable"] is False
-    assert rows["ADE-QRE-016B"]["status"] == "ready"
-    assert rows["ADE-QRE-016B"]["auto_selectable"] is True
-    assert rows["ADE-QRE-016C"]["status"] == "blocked until ADE-QRE-016B done"
-    assert rows["ADE-QRE-016C"]["auto_selectable"] is False
+    assert rows["ADE-QRE-016B"]["status"] == "done"
+    assert rows["ADE-QRE-016B"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-016B"]["auto_selectable"] is False
+    assert rows["ADE-QRE-016C"]["status"] == "ready"
+    assert rows["ADE-QRE-016C"]["auto_selectable"] is True
     assert rows["ADE-QRE-016D"]["status"] == "blocked until ADE-QRE-016C done"
     assert rows["ADE-QRE-016D"]["auto_selectable"] is False
     assert rows["ADE-QRE-016E"]["status"] == "blocked until ADE-QRE-016D done"


### PR DESCRIPTION
## Summary
- mark ADE-QRE-016B done with PR #378 merge and post-merge gate evidence
- unblock ADE-QRE-016C as the next eligible ready item
- update queue lifecycle tests for the 016C handoff

## Validation
- git diff --check
- python -m reporting.architecture_import_scan --format summary
- python scripts\\governance_lint.py
- pytest tests\\unit\\test_ade_queue_status_self_audit.py tests\\unit\\test_ade_qre_014_queue_lifecycle.py -q
- protected/frozen diff check for research outputs, registry.py, and strategies.py