### PR TITLE
feat: add ADE-QRE-016C fail-closed coverage

### DIFF
--- a/docs/governance/ade_qre_016c_missing_evidence_fail_closed_coverage.md
+++ b/docs/governance/ade_qre_016c_missing_evidence_fail_closed_coverage.md
@@ -1,0 +1,58 @@
+# ADE-QRE-016C - Missing Evidence Fail-Closed Coverage
+
+> Status: read-only coverage note.
+>
+> Scope: reporting/tests/docs only. This does not create runtime promotion
+> logic, strategy synthesis, Addendum runtime activation, routing/campaign
+> mutation, dashboard mutation, approval mutation, shadow, paper, live, broker,
+> risk, execution, or frozen contract changes.
+
+## Purpose
+
+`ADE-QRE-016B` tightened the distinction between scaffold, working capability,
+and operator-trusted capability. This item adds explicit read-only coverage that
+missing evidence across the trusted-loop surfaces remains blocking and cannot be
+interpreted as readiness.
+
+## Coverage Added
+
+The read-only reporter
+`reporting.trusted_loop_missing_evidence_fail_closed` aggregates existing
+evidence surfaces and classifies each required surface as either `ready` or
+`fail_closed`.
+
+Required surfaces:
+
+- reason records;
+- research-quality KPIs;
+- routing readiness;
+- sampling readiness;
+- diagnostics loop;
+- retrieval coverage;
+- queue status.
+
+Missing, malformed, incomplete, unknown, empty, or warning-only evidence remains
+`fail_closed`. The report may show a bounded current queue selection separately,
+but that does not upgrade broader queue-status trust when done evidence or other
+queue evidence is incomplete.
+
+## Non-Authority
+
+The reporter is evidence-only:
+
+- it does not write artifacts;
+- it does not emit reason records;
+- it does not mutate queue status;
+- it does not mutate routing or sampling;
+- it does not modify strategies, `registry.py`, frozen contracts, or research
+  outputs;
+- it does not enable strategy synthesis;
+- it does not activate Addendum runtime layers;
+- it does not touch shadow, paper, live, broker, risk, or execution behavior.
+
+## Validation
+
+Targeted tests prove that missing reason-record, KPI, routing, sampling,
+diagnostics, retrieval, and queue-status evidence all fail closed. The tests also
+pin that a single visible next queue item does not override missing done
+evidence, and that the reporter remains read-only and serializable.

--- a/reporting/trusted_loop_missing_evidence_fail_closed.py
+++ b/reporting/trusted_loop_missing_evidence_fail_closed.py
@@ -1,0 +1,402 @@
+"""Read-only missing-evidence fail-closed check for trusted-loop surfaces.
+
+ADE-QRE-016C coverage. This module aggregates existing read-only evidence
+surfaces and reports whether missing evidence is still treated as blocking. It
+does not materialize artifacts, mutate queues, grant authority, or enable
+strategy synthesis.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+from packages.qre_diagnostics import research_diagnostics_loop as _diagnostics
+from packages.qre_research import retrieval_coverage as _retrieval
+from reporting import ade_queue_status_self_audit as _queue
+from reporting import trusted_loop_materialization as _tlm
+
+SCHEMA_VERSION: Final[int] = 1
+MODULE_VERSION: Final[str] = "ade-qre-016c-2026-05-28"
+REPORT_KIND: Final[str] = "trusted_loop_missing_evidence_fail_closed"
+
+_SURFACE_IDS: Final[tuple[str, ...]] = (
+    "reason_records",
+    "research_quality_kpis",
+    "routing_readiness",
+    "sampling_readiness",
+    "diagnostics_loop",
+    "retrieval_coverage",
+    "queue_status",
+)
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _sequence(value: Any) -> Sequence[Any]:
+    return value if isinstance(value, Sequence) and not isinstance(value, str) else ()
+
+
+def _strings(value: Any) -> list[str]:
+    return [str(item) for item in _sequence(value)]
+
+
+def _surface_row(
+    *,
+    surface_id: str,
+    status: str,
+    ready: bool,
+    missing_evidence: Sequence[str],
+    evidence: Mapping[str, Any],
+    trust_claim_blocked: str,
+    notes: Sequence[str] = (),
+) -> dict[str, Any]:
+    return {
+        "surface_id": surface_id,
+        "status": status,
+        "ready": ready,
+        "fail_closed": not ready,
+        "missing_evidence": list(missing_evidence),
+        "evidence": dict(evidence),
+        "trust_claim_blocked": trust_claim_blocked,
+        "notes": list(notes),
+    }
+
+
+def _reason_record_surface(snapshot: Mapping[str, Any]) -> dict[str, Any]:
+    density = _mapping(snapshot.get("reason_record_evidence_density"))
+    metrics = _mapping(density.get("metrics"))
+    final = str(density.get("final_recommendation") or "unknown")
+    record_count = int(metrics.get("record_count") or 0)
+    records_with_refs = int(metrics.get("records_with_evidence_refs") or 0)
+    ready = final == "evidence_density_ready"
+    missing: list[str] = []
+    if record_count <= 0:
+        missing.append("reason_records_present")
+    if records_with_refs <= 0:
+        missing.append("reason_records_with_evidence_refs")
+    return _surface_row(
+        surface_id="reason_records",
+        status="ready" if ready else "fail_closed",
+        ready=ready,
+        missing_evidence=missing,
+        evidence={
+            "final_recommendation": final,
+            "record_count": record_count,
+            "records_with_evidence_refs": records_with_refs,
+        },
+        trust_claim_blocked=(
+            "Reason records cannot support trusted-loop readiness until durable "
+            "records with evidence references are present."
+        ),
+    )
+
+
+def _kpi_surface(snapshot: Mapping[str, Any]) -> dict[str, Any]:
+    kpis = _mapping(snapshot.get("research_quality_kpi_readiness"))
+    values = _mapping(kpis.get("values"))
+    required = _strings(kpis.get("kpi_ids"))
+    complete = int(kpis.get("complete_value_count") or 0)
+    fail_closed = int(kpis.get("fail_closed_count") or 0)
+    ready = bool(required) and complete == len(required) and fail_closed == 0
+    missing = [
+        kpi_id
+        for kpi_id, row in sorted(values.items())
+        if _mapping(row).get("numeric_value_ready") is not True
+    ]
+    if not required:
+        missing.append("research_quality_kpi_ids_present")
+    return _surface_row(
+        surface_id="research_quality_kpis",
+        status="ready" if ready else "fail_closed",
+        ready=ready,
+        missing_evidence=missing,
+        evidence={
+            "required_kpi_count": len(required),
+            "complete_value_count": complete,
+            "fail_closed_count": fail_closed,
+        },
+        trust_claim_blocked=(
+            "KPI doctrine or partial KPI evidence cannot be interpreted as "
+            "numeric research-quality readiness."
+        ),
+    )
+
+
+def _routing_sampling_surface(
+    snapshot: Mapping[str, Any],
+    *,
+    surface_id: str,
+    row_id: str,
+) -> dict[str, Any]:
+    density = _mapping(snapshot.get("routing_sampling_readiness_density"))
+    row = _mapping(_mapping(density.get("values")).get(row_id))
+    ready = row.get("ready") is True
+    status = str(row.get("status") or "missing")
+    return _surface_row(
+        surface_id=surface_id,
+        status="ready" if ready else "fail_closed",
+        ready=ready,
+        missing_evidence=_strings(row.get("missing_evidence"))
+        or ["readiness_evidence_present"],
+        evidence={
+            "source_status": status,
+            "artifact_present": row.get("artifact_present"),
+            "final_recommendation": row.get("final_recommendation"),
+            "readiness_score": row.get("readiness_score"),
+        },
+        trust_claim_blocked=(
+            f"{surface_id} cannot be treated as ready until the existing "
+            "read-only artifact contains positive ready evidence."
+        ),
+    )
+
+
+def _diagnostics_surface(status: Mapping[str, Any]) -> dict[str, Any]:
+    ready = status.get("diagnostics_loop_ready") is True
+    missing = [] if ready else ["diagnostics_loop_ready"]
+    return _surface_row(
+        surface_id="diagnostics_loop",
+        status="ready" if ready else "fail_closed",
+        ready=ready,
+        missing_evidence=missing,
+        evidence={
+            "source_status": status.get("status"),
+            "path": status.get("path"),
+            "schema_version": status.get("schema_version"),
+        },
+        trust_claim_blocked=(
+            "Diagnostics are evidence surfaces only; missing or invalid "
+            "diagnostics cannot authorize readiness."
+        ),
+    )
+
+
+def _retrieval_surface(status: Mapping[str, Any]) -> dict[str, Any]:
+    ready = status.get("retrieval_coverage_ready") is True
+    missing = [] if ready else ["retrieval_coverage_ready"]
+    return _surface_row(
+        surface_id="retrieval_coverage",
+        status="ready" if ready else "fail_closed",
+        ready=ready,
+        missing_evidence=missing,
+        evidence={
+            "source_status": status.get("status"),
+            "path": status.get("path"),
+            "schema_version": status.get("schema_version"),
+        },
+        trust_claim_blocked=(
+            "Retrieval remains context, not authority; missing retrieval "
+            "coverage cannot be treated as trusted-loop readiness."
+        ),
+    )
+
+
+def _queue_surface(snapshot: Mapping[str, Any]) -> dict[str, Any]:
+    summary = _mapping(snapshot.get("summary"))
+    eligible = _strings(summary.get("eligible_ready_items"))
+    missing_done = _strings(summary.get("missing_done_evidence_items"))
+    dependency_gaps = _strings(summary.get("dependency_gap_items"))
+    stale_ready = _strings(summary.get("stale_historical_ready_items"))
+    blocked_missing = _strings(summary.get("blocked_items_missing_reason"))
+    deferred_missing = _strings(summary.get("deferred_items_missing_reason"))
+    next_item = snapshot.get("summary", {}).get("next_eligible_ready_item")
+    exact_one_next = len(eligible) == 1 and next_item == eligible[0]
+    missing = []
+    if not exact_one_next:
+        missing.append("exactly_one_next_eligible_ready_item")
+    if missing_done:
+        missing.append("complete_done_evidence_for_all_done_items")
+    if dependency_gaps:
+        missing.append("queue_dependencies_resolved")
+    if blocked_missing:
+        missing.append("blocked_items_have_reasons")
+    if deferred_missing:
+        missing.append("deferred_items_have_reasons")
+
+    ready = not missing
+    status = (
+        "ready"
+        if ready
+        else "bounded_selection_ready_with_warnings"
+        if exact_one_next
+        else "fail_closed"
+    )
+    return _surface_row(
+        surface_id="queue_status",
+        status=status,
+        ready=ready,
+        missing_evidence=missing,
+        evidence={
+            "final_recommendation": snapshot.get("final_recommendation"),
+            "eligible_ready_items": eligible,
+            "next_eligible_ready_item": next_item,
+            "missing_done_evidence_items": missing_done,
+            "dependency_gap_items": dependency_gaps,
+            "stale_historical_ready_items": stale_ready,
+            "bounded_current_selection_ready": exact_one_next,
+        },
+        trust_claim_blocked=(
+            "Queue status cannot be treated as broadly trusted while done "
+            "evidence, dependency, blocked, deferred, or unique-next-item "
+            "evidence is missing."
+        ),
+        notes=(
+            (
+                "A single bounded next item can still be visible while broader "
+                "queue-status trust fails closed."
+            ),
+        )
+        if exact_one_next and not ready
+        else (),
+    )
+
+
+def collect_snapshot(
+    *,
+    frozen_utc: str | None = None,
+    repo_root: Path = Path("."),
+    reason_records_artifact_dir: Path | None = None,
+    routing_artifact_dir: Path | None = None,
+    sampling_artifact_dir: Path | None = None,
+    observability_artifact_dir: Path | None = None,
+    diagnostics_output_dir: Path = _diagnostics.DEFAULT_OUTPUT_DIR,
+    retrieval_output_dir: Path = _retrieval.DEFAULT_OUTPUT_DIR,
+    queue_doc_path: Path | None = None,
+    materialization_snapshot: Mapping[str, Any] | None = None,
+    diagnostics_status: Mapping[str, Any] | None = None,
+    retrieval_status: Mapping[str, Any] | None = None,
+    queue_snapshot: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    ts = frozen_utc or _utcnow()
+    materialized = materialization_snapshot or _tlm.collect_snapshot(
+        frozen_utc=ts,
+        reason_records_artifact_dir=reason_records_artifact_dir,
+        routing_artifact_dir=routing_artifact_dir,
+        sampling_artifact_dir=sampling_artifact_dir,
+        observability_artifact_dir=observability_artifact_dir,
+    )
+    diagnostics = diagnostics_status or _diagnostics.read_diagnostics_loop_status(
+        output_dir=diagnostics_output_dir,
+        repo_root=repo_root,
+    )
+    retrieval = retrieval_status or _retrieval.read_retrieval_coverage_status(
+        output_dir=retrieval_output_dir,
+        repo_root=repo_root,
+    )
+    queue = queue_snapshot or _queue.collect_snapshot(
+        queue_doc_path=queue_doc_path,
+        frozen_utc=ts,
+    )
+
+    rows = [
+        _reason_record_surface(materialized),
+        _kpi_surface(materialized),
+        _routing_sampling_surface(
+            materialized,
+            surface_id="routing_readiness",
+            row_id="routing_ready",
+        ),
+        _routing_sampling_surface(
+            materialized,
+            surface_id="sampling_readiness",
+            row_id="sampling_ready",
+        ),
+        _diagnostics_surface(diagnostics),
+        _retrieval_surface(retrieval),
+        _queue_surface(queue),
+    ]
+    ready_count = sum(1 for row in rows if row["ready"] is True)
+    fail_closed_count = len(rows) - ready_count
+    missing_evidence_count = sum(len(row["missing_evidence"]) for row in rows)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": ts,
+        "mode": "dry-run",
+        "safe_to_execute": False,
+        "summary": {
+            "required_surfaces": list(_SURFACE_IDS),
+            "required_surface_count": len(rows),
+            "ready_surface_count": ready_count,
+            "fail_closed_surface_count": fail_closed_count,
+            "missing_evidence_count": missing_evidence_count,
+            "trusted_loop_ready": fail_closed_count == 0,
+        },
+        "surfaces": rows,
+        "final_recommendation": (
+            "ready_all_required_evidence_present"
+            if fail_closed_count == 0
+            else "not_ready_missing_evidence"
+        ),
+        "operator_summary": (
+            "All required trusted-loop evidence surfaces are present."
+            if fail_closed_count == 0
+            else (
+                f"{fail_closed_count}/{len(rows)} trusted-loop surfaces fail "
+                "closed because required evidence is missing, incomplete, or "
+                "not trusted."
+            )
+        ),
+        "safety_invariants": {
+            "read_only": True,
+            "writes_artifacts": False,
+            "mutates_queue": False,
+            "mutates_routing": False,
+            "mutates_sampling": False,
+            "mutates_strategy_or_registry": False,
+            "mutates_frozen_contracts": False,
+            "strategy_synthesis_enabled": False,
+            "addendum_runtime_activated": False,
+            "dashboard_mutation_route_added": False,
+            "approval_mutation_added": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+        },
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="reporting.trusted_loop_missing_evidence_fail_closed",
+        description="Check that missing trusted-loop evidence fails closed.",
+    )
+    parser.add_argument("--frozen-utc", type=str, default=None)
+    args = parser.parse_args(argv)
+
+    print(
+        json.dumps(
+            collect_snapshot(frozen_utc=args.frozen_utc),
+            sort_keys=True,
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+
+
+__all__ = [
+    "REPORT_KIND",
+    "SCHEMA_VERSION",
+    "collect_snapshot",
+]

--- a/reporting/trusted_loop_missing_evidence_fail_closed.py
+++ b/reporting/trusted_loop_missing_evidence_fail_closed.py
@@ -16,14 +16,15 @@ from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any, Final
 
-from packages.qre_diagnostics import research_diagnostics_loop as _diagnostics
-from packages.qre_research import retrieval_coverage as _retrieval
 from reporting import ade_queue_status_self_audit as _queue
 from reporting import trusted_loop_materialization as _tlm
 
 SCHEMA_VERSION: Final[int] = 1
 MODULE_VERSION: Final[str] = "ade-qre-016c-2026-05-28"
 REPORT_KIND: Final[str] = "trusted_loop_missing_evidence_fail_closed"
+DIAGNOSTICS_OUTPUT_DIR: Final[Path] = Path("logs/qre_research_diagnostics_loop")
+RETRIEVAL_OUTPUT_DIR: Final[Path] = Path("logs/qre_research_retrieval_coverage")
+LATEST_NAME: Final[str] = "latest.json"
 
 _SURFACE_IDS: Final[tuple[str, ...]] = (
     "reason_records",
@@ -55,6 +56,81 @@ def _sequence(value: Any) -> Sequence[Any]:
 
 def _strings(value: Any) -> list[str]:
     return [str(item) for item in _sequence(value)]
+
+
+def _rel(path: Path, *, repo_root: Path) -> str:
+    try:
+        return path.resolve().relative_to(repo_root.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _read_json(path: Path) -> Mapping[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, Mapping) else None
+
+
+def _read_diagnostics_status(
+    *,
+    output_dir: Path,
+    repo_root: Path,
+) -> dict[str, Any]:
+    latest = repo_root / output_dir / LATEST_NAME
+    payload = _read_json(latest)
+    if payload is None:
+        return {
+            "status": (
+                "invalid_research_diagnostics_loop"
+                if latest.is_file()
+                else "missing_research_diagnostics_loop"
+            ),
+            "diagnostics_loop_ready": False,
+            "path": _rel(latest, repo_root=repo_root),
+            "fails_closed": True,
+        }
+    summary = _mapping(payload.get("summary"))
+    ready = summary.get("status") == "ready"
+    return {
+        "status": "ready" if ready else "not_ready",
+        "diagnostics_loop_ready": ready,
+        "path": _rel(latest, repo_root=repo_root),
+        "fails_closed": not ready,
+        "schema_version": payload.get("schema_version"),
+    }
+
+
+def _read_retrieval_status(
+    *,
+    output_dir: Path,
+    repo_root: Path,
+) -> dict[str, Any]:
+    latest = repo_root / output_dir / LATEST_NAME
+    payload = _read_json(latest)
+    if payload is None:
+        return {
+            "status": (
+                "invalid_retrieval_coverage"
+                if latest.is_file()
+                else "missing_retrieval_coverage"
+            ),
+            "retrieval_coverage_ready": False,
+            "path": _rel(latest, repo_root=repo_root),
+            "fails_closed": True,
+        }
+    summary = _mapping(payload.get("summary"))
+    ready = summary.get("retrieval_coverage_ready") is True
+    return {
+        "status": "ready" if ready else "not_ready",
+        "retrieval_coverage_ready": ready,
+        "path": _rel(latest, repo_root=repo_root),
+        "fails_closed": not ready,
+        "schema_version": payload.get("schema_version"),
+    }
 
 
 def _surface_row(
@@ -276,8 +352,8 @@ def collect_snapshot(
     routing_artifact_dir: Path | None = None,
     sampling_artifact_dir: Path | None = None,
     observability_artifact_dir: Path | None = None,
-    diagnostics_output_dir: Path = _diagnostics.DEFAULT_OUTPUT_DIR,
-    retrieval_output_dir: Path = _retrieval.DEFAULT_OUTPUT_DIR,
+    diagnostics_output_dir: Path = DIAGNOSTICS_OUTPUT_DIR,
+    retrieval_output_dir: Path = RETRIEVAL_OUTPUT_DIR,
     queue_doc_path: Path | None = None,
     materialization_snapshot: Mapping[str, Any] | None = None,
     diagnostics_status: Mapping[str, Any] | None = None,
@@ -292,11 +368,11 @@ def collect_snapshot(
         sampling_artifact_dir=sampling_artifact_dir,
         observability_artifact_dir=observability_artifact_dir,
     )
-    diagnostics = diagnostics_status or _diagnostics.read_diagnostics_loop_status(
+    diagnostics = diagnostics_status or _read_diagnostics_status(
         output_dir=diagnostics_output_dir,
         repo_root=repo_root,
     )
-    retrieval = retrieval_status or _retrieval.read_retrieval_coverage_status(
+    retrieval = retrieval_status or _read_retrieval_status(
         output_dir=retrieval_output_dir,
         repo_root=repo_root,
     )

--- a/tests/unit/test_trusted_loop_missing_evidence_fail_closed.py
+++ b/tests/unit/test_trusted_loop_missing_evidence_fail_closed.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from reporting import trusted_loop_missing_evidence_fail_closed as fail_closed
+
+FROZEN = "2026-05-28T00:00:00Z"
+
+
+def _missing_materialization_snapshot() -> dict:
+    return {
+        "reason_record_evidence_density": {
+            "final_recommendation": "not_ready_no_reason_records",
+            "metrics": {
+                "record_count": 0,
+                "records_with_evidence_refs": 0,
+            },
+        },
+        "research_quality_kpi_readiness": {
+            "kpi_ids": ["TTFPRC", "OOS_DSR"],
+            "complete_value_count": 0,
+            "fail_closed_count": 2,
+            "values": {
+                "TTFPRC": {"numeric_value_ready": False},
+                "OOS_DSR": {"numeric_value_ready": False},
+            },
+        },
+        "routing_sampling_readiness_density": {
+            "values": {
+                "routing_ready": {
+                    "status": "fail_closed",
+                    "ready": False,
+                    "artifact_present": False,
+                    "final_recommendation": "unknown",
+                    "readiness_score": 0.0,
+                    "missing_evidence": [
+                        "latest_artifact_present",
+                        "final_recommendation_ready",
+                    ],
+                },
+                "sampling_ready": {
+                    "status": "fail_closed",
+                    "ready": False,
+                    "artifact_present": False,
+                    "final_recommendation": "unknown",
+                    "readiness_score": 0.0,
+                    "missing_evidence": [
+                        "latest_artifact_present",
+                        "final_recommendation_ready",
+                    ],
+                },
+            },
+        },
+    }
+
+
+def _missing_queue_snapshot() -> dict:
+    return {
+        "final_recommendation": "operator_review_required_queue_selection_ambiguous",
+        "summary": {
+            "eligible_ready_items": [],
+            "next_eligible_ready_item": None,
+            "missing_done_evidence_items": ["ADE-QRE-X"],
+            "dependency_gap_items": ["ADE-QRE-Y"],
+            "stale_historical_ready_items": [],
+            "blocked_items_missing_reason": ["ADE-QRE-Z"],
+            "deferred_items_missing_reason": [],
+        },
+    }
+
+
+def test_missing_evidence_fails_closed_across_required_surfaces() -> None:
+    snapshot = fail_closed.collect_snapshot(
+        frozen_utc=FROZEN,
+        materialization_snapshot=_missing_materialization_snapshot(),
+        diagnostics_status={
+            "status": "missing_research_diagnostics_loop",
+            "diagnostics_loop_ready": False,
+            "path": "logs/qre_research_diagnostics_loop/latest.json",
+            "fails_closed": True,
+        },
+        retrieval_status={
+            "status": "missing_retrieval_coverage",
+            "retrieval_coverage_ready": False,
+            "path": "logs/qre_research_retrieval_coverage/latest.json",
+            "fails_closed": True,
+        },
+        queue_snapshot=_missing_queue_snapshot(),
+    )
+    rows = {row["surface_id"]: row for row in snapshot["surfaces"]}
+
+    assert snapshot["final_recommendation"] == "not_ready_missing_evidence"
+    assert snapshot["summary"]["trusted_loop_ready"] is False
+    assert snapshot["summary"]["ready_surface_count"] == 0
+    assert snapshot["summary"]["fail_closed_surface_count"] == 7
+    assert set(rows) == set(snapshot["summary"]["required_surfaces"])
+    assert rows["reason_records"]["fail_closed"] is True
+    assert rows["research_quality_kpis"]["fail_closed"] is True
+    assert rows["routing_readiness"]["fail_closed"] is True
+    assert rows["sampling_readiness"]["fail_closed"] is True
+    assert rows["diagnostics_loop"]["fail_closed"] is True
+    assert rows["retrieval_coverage"]["fail_closed"] is True
+    assert rows["queue_status"]["fail_closed"] is True
+    assert "reason_records_present" in rows["reason_records"]["missing_evidence"]
+    assert "TTFPRC" in rows["research_quality_kpis"]["missing_evidence"]
+    assert "latest_artifact_present" in rows["routing_readiness"]["missing_evidence"]
+    assert "diagnostics_loop_ready" in rows["diagnostics_loop"]["missing_evidence"]
+    assert "retrieval_coverage_ready" in rows["retrieval_coverage"]["missing_evidence"]
+    assert (
+        "exactly_one_next_eligible_ready_item"
+        in rows["queue_status"]["missing_evidence"]
+    )
+    assert snapshot["safety_invariants"]["strategy_synthesis_enabled"] is False
+    assert snapshot["safety_invariants"]["addendum_runtime_activated"] is False
+
+
+def test_queue_single_next_item_does_not_override_missing_done_evidence() -> None:
+    queue = {
+        "final_recommendation": "queue_status_audit_ready_with_warnings",
+        "summary": {
+            "eligible_ready_items": ["ADE-QRE-016C"],
+            "next_eligible_ready_item": "ADE-QRE-016C",
+            "missing_done_evidence_items": ["ADE-QRE-007"],
+            "dependency_gap_items": [],
+            "stale_historical_ready_items": ["ADE-QRE-011"],
+            "blocked_items_missing_reason": [],
+            "deferred_items_missing_reason": [],
+        },
+    }
+
+    snapshot = fail_closed.collect_snapshot(
+        frozen_utc=FROZEN,
+        materialization_snapshot=_missing_materialization_snapshot(),
+        diagnostics_status={"status": "ready", "diagnostics_loop_ready": True},
+        retrieval_status={"status": "ready", "retrieval_coverage_ready": True},
+        queue_snapshot=queue,
+    )
+    row = {row["surface_id"]: row for row in snapshot["surfaces"]}["queue_status"]
+
+    assert row["status"] == "bounded_selection_ready_with_warnings"
+    assert row["ready"] is False
+    assert row["fail_closed"] is True
+    assert row["evidence"]["bounded_current_selection_ready"] is True
+    assert "complete_done_evidence_for_all_done_items" in row["missing_evidence"]
+    assert row["notes"] == [
+        "A single bounded next item can still be visible while broader "
+        "queue-status trust fails closed."
+    ]
+
+
+def test_current_repo_snapshot_is_read_only_and_serializable() -> None:
+    snapshot = fail_closed.collect_snapshot(frozen_utc=FROZEN)
+
+    assert snapshot["report_kind"] == fail_closed.REPORT_KIND
+    assert snapshot["mode"] == "dry-run"
+    assert snapshot["safe_to_execute"] is False
+    assert snapshot["safety_invariants"]["read_only"] is True
+    assert snapshot["safety_invariants"]["writes_artifacts"] is False
+    assert snapshot["safety_invariants"]["mutates_strategy_or_registry"] is False
+    assert snapshot["safety_invariants"]["mutates_frozen_contracts"] is False
+    assert snapshot["safety_invariants"]["strategy_synthesis_enabled"] is False
+    assert json.loads(json.dumps(snapshot))["schema_version"] == (
+        fail_closed.SCHEMA_VERSION
+    )
+
+
+def test_module_does_not_import_mutation_or_runtime_surfaces() -> None:
+    source = Path(fail_closed.__file__).read_text(encoding="utf-8")
+
+    forbidden_tokens = (
+        "from dashboard",
+        "import dashboard",
+        "from registry",
+        "import registry",
+        "strategies.py",
+        "approval mutation",
+    )
+    for token in forbidden_tokens:
+        assert token not in source


### PR DESCRIPTION
## Summary
- add a read-only trusted-loop missing-evidence fail-closed reporter
- cover reason records, KPIs, routing, sampling, diagnostics, retrieval, and queue status
- document ADE-QRE-016C coverage and non-authority boundaries

## Validation
- pytest tests\\unit\\test_trusted_loop_missing_evidence_fail_closed.py -q
- python -m reporting.trusted_loop_missing_evidence_fail_closed --frozen-utc 2026-05-28T00:00:00Z
- python -m ruff check reporting\\trusted_loop_missing_evidence_fail_closed.py tests\\unit\\test_trusted_loop_missing_evidence_fail_closed.py
- git diff --check
- python -m reporting.architecture_import_scan --format summary
- python scripts\\governance_lint.py
- protected/frozen diff check for research outputs, registry.py, and strategies.py