### PR TITLE
docs: mark ADE-QRE-016C done

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -2204,7 +2204,18 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-016C`
 - title: Missing Evidence Fail-Closed Coverage.
-- status: `ready`
+- status: `done`
+- completion evidence: PR #380, merge SHA
+  `5f56b67d6f730e0687976d801fe80fc4b046246b`; read-only missing-evidence
+  fail-closed reporter added in
+  `reporting/trusted_loop_missing_evidence_fail_closed.py`, with coverage note
+  `docs/governance/ade_qre_016c_missing_evidence_fail_closed_coverage.md`;
+  post-merge Fast pre-merge gate run `26566607659`, Docker build/push run
+  `26566886782`, and VPS deploy run `26566886794` completed/success; local
+  targeted fail-closed tests, reporter CLI, ruff, `git diff --check`,
+  architecture scanner, and governance lint passed; frozen contracts
+  unchanged; protected/execution paths untouched; strategy synthesis remained
+  blocked; Addendum runtime remained inactive.
 - purpose: improve tests/reporting that prove missing evidence cannot be
   interpreted as readiness across key trusted-loop surfaces.
 - depends on: `ADE-QRE-016B done`.
@@ -2270,7 +2281,7 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-016D`
 - title: Cross-Surface Consistency Audit.
-- status: `blocked until ADE-QRE-016C done`
+- status: `ready`
 - purpose: verify consistency across reason records, KPI readiness,
   routing/sampling readiness, diagnostics blockers, retrieval coverage, and
   queue status.

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -289,14 +289,15 @@ def test_ade_qre_active_queue_lifecycle_is_consistent() -> None:
     assert _dependencies_done(item_16b, items) is True
     assert _done_evidence_is_complete(item_16b)
     assert _auto_selectable_status(item_16b) is False
-    assert item_16c.status == "ready"
+    assert item_16c.status == "done"
     assert item_16c.dependencies == ("ADE-QRE-016B",)
     assert _dependencies_done(item_16c, items) is True
-    assert _auto_selectable_status(item_16c) is True
-    assert item_16d.status == "blocked until ADE-QRE-016C done"
+    assert _done_evidence_is_complete(item_16c)
+    assert _auto_selectable_status(item_16c) is False
+    assert item_16d.status == "ready"
     assert item_16d.dependencies == ("ADE-QRE-016C",)
-    assert _dependencies_done(item_16d, items) is False
-    assert _auto_selectable_status(item_16d) is False
+    assert _dependencies_done(item_16d, items) is True
+    assert _auto_selectable_status(item_16d) is True
     assert item_16e.status == "blocked until ADE-QRE-016D done"
     assert item_16e.dependencies == ("ADE-QRE-016D",)
     assert _dependencies_done(item_16e, items) is False
@@ -314,7 +315,7 @@ def test_ade_qre_active_queue_lifecycle_is_consistent() -> None:
     assert _dependencies_done(item_16h, items) is False
     assert _auto_selectable_status(item_16h) is False
     assert _stale_historical_ready_items(items) == ("ADE-QRE-011",)
-    assert _next_eligible_ready_item(items) == item_16c
+    assert _next_eligible_ready_item(items) == item_16d
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:

--- a/tests/unit/test_ade_queue_status_self_audit.py
+++ b/tests/unit/test_ade_queue_status_self_audit.py
@@ -115,11 +115,11 @@ def test_blocked_and_deferred_reason_gaps_are_explicit(tmp_path: Path) -> None:
     )
 
 
-def test_current_queue_selects_016c_after_016b_done() -> None:
+def test_current_queue_selects_016d_after_016c_done() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-05-27T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-016C"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-016D"
     assert "ADE-QRE-011" in snap["summary"]["stale_historical_ready_items"]
     assert rows["ADE-QRE-014N"]["status"] == "done"
     assert rows["ADE-QRE-014N"]["done_evidence"]["complete"] is True
@@ -146,10 +146,11 @@ def test_current_queue_selects_016c_after_016b_done() -> None:
     assert rows["ADE-QRE-016B"]["status"] == "done"
     assert rows["ADE-QRE-016B"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-016B"]["auto_selectable"] is False
-    assert rows["ADE-QRE-016C"]["status"] == "ready"
-    assert rows["ADE-QRE-016C"]["auto_selectable"] is True
-    assert rows["ADE-QRE-016D"]["status"] == "blocked until ADE-QRE-016C done"
-    assert rows["ADE-QRE-016D"]["auto_selectable"] is False
+    assert rows["ADE-QRE-016C"]["status"] == "done"
+    assert rows["ADE-QRE-016C"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-016C"]["auto_selectable"] is False
+    assert rows["ADE-QRE-016D"]["status"] == "ready"
+    assert rows["ADE-QRE-016D"]["auto_selectable"] is True
     assert rows["ADE-QRE-016E"]["status"] == "blocked until ADE-QRE-016D done"
     assert rows["ADE-QRE-016E"]["auto_selectable"] is False
     assert rows["ADE-QRE-016F"]["status"] == "blocked until ADE-QRE-016E done"


### PR DESCRIPTION
## Summary
- mark ADE-QRE-016C done with PR #380 merge and post-merge gate evidence
- unblock ADE-QRE-016D as the next eligible ready item
- update queue lifecycle tests for the 016D handoff

## Validation
- git diff --check
- python -m reporting.architecture_import_scan --format summary
- python scripts\\governance_lint.py
- pytest tests\\unit\\test_ade_queue_status_self_audit.py tests\\unit\\test_ade_qre_014_queue_lifecycle.py -q
- protected/frozen diff check for research outputs, registry.py, and strategies.py