### PR TITLE
docs: mark ADE-QRE-016D done

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -2281,7 +2281,18 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-016D`
 - title: Cross-Surface Consistency Audit.
-- status: `ready`
+- status: `done`
+- completion evidence: PR #382, merge SHA
+  `c6ded3af85897fbe8e3888085d6934075bc8b473`; read-only cross-surface
+  consistency audit added in
+  `reporting/trusted_loop_consistency_audit.py`, with governance note
+  `docs/governance/ade_qre_016d_cross_surface_consistency_audit.md`;
+  post-merge Fast pre-merge gate run `26568549334`, Docker build/push run
+  `26568813970`, and VPS deploy run `26568813985` completed/success; local
+  targeted consistency and fail-closed tests, reporter CLI, ruff,
+  `git diff --check`, architecture scanner, and governance lint passed; frozen
+  contracts unchanged; protected/execution paths untouched; strategy synthesis
+  remained blocked; Addendum runtime remained inactive.
 - purpose: verify consistency across reason records, KPI readiness,
   routing/sampling readiness, diagnostics blockers, retrieval coverage, and
   queue status.
@@ -2349,7 +2360,7 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-016E`
 - title: Trusted-Loop Operator Summary v2.
-- status: `blocked until ADE-QRE-016D done`
+- status: `ready`
 - purpose: produce a clearer operator-facing summary of what the trusted loop
   can and cannot currently do.
 - depends on: `ADE-QRE-016D done`.

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -294,14 +294,15 @@ def test_ade_qre_active_queue_lifecycle_is_consistent() -> None:
     assert _dependencies_done(item_16c, items) is True
     assert _done_evidence_is_complete(item_16c)
     assert _auto_selectable_status(item_16c) is False
-    assert item_16d.status == "ready"
+    assert item_16d.status == "done"
     assert item_16d.dependencies == ("ADE-QRE-016C",)
     assert _dependencies_done(item_16d, items) is True
-    assert _auto_selectable_status(item_16d) is True
-    assert item_16e.status == "blocked until ADE-QRE-016D done"
+    assert _done_evidence_is_complete(item_16d)
+    assert _auto_selectable_status(item_16d) is False
+    assert item_16e.status == "ready"
     assert item_16e.dependencies == ("ADE-QRE-016D",)
-    assert _dependencies_done(item_16e, items) is False
-    assert _auto_selectable_status(item_16e) is False
+    assert _dependencies_done(item_16e, items) is True
+    assert _auto_selectable_status(item_16e) is True
     assert item_16f.status == "blocked until ADE-QRE-016E done"
     assert item_16f.dependencies == ("ADE-QRE-016E",)
     assert _dependencies_done(item_16f, items) is False
@@ -315,7 +316,7 @@ def test_ade_qre_active_queue_lifecycle_is_consistent() -> None:
     assert _dependencies_done(item_16h, items) is False
     assert _auto_selectable_status(item_16h) is False
     assert _stale_historical_ready_items(items) == ("ADE-QRE-011",)
-    assert _next_eligible_ready_item(items) == item_16d
+    assert _next_eligible_ready_item(items) == item_16e
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:

--- a/tests/unit/test_ade_queue_status_self_audit.py
+++ b/tests/unit/test_ade_queue_status_self_audit.py
@@ -115,11 +115,11 @@ def test_blocked_and_deferred_reason_gaps_are_explicit(tmp_path: Path) -> None:
     )
 
 
-def test_current_queue_selects_016d_after_016c_done() -> None:
+def test_current_queue_selects_016e_after_016d_done() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-05-27T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-016D"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-016E"
     assert "ADE-QRE-011" in snap["summary"]["stale_historical_ready_items"]
     assert rows["ADE-QRE-014N"]["status"] == "done"
     assert rows["ADE-QRE-014N"]["done_evidence"]["complete"] is True
@@ -149,10 +149,11 @@ def test_current_queue_selects_016d_after_016c_done() -> None:
     assert rows["ADE-QRE-016C"]["status"] == "done"
     assert rows["ADE-QRE-016C"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-016C"]["auto_selectable"] is False
-    assert rows["ADE-QRE-016D"]["status"] == "ready"
-    assert rows["ADE-QRE-016D"]["auto_selectable"] is True
-    assert rows["ADE-QRE-016E"]["status"] == "blocked until ADE-QRE-016D done"
-    assert rows["ADE-QRE-016E"]["auto_selectable"] is False
+    assert rows["ADE-QRE-016D"]["status"] == "done"
+    assert rows["ADE-QRE-016D"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-016D"]["auto_selectable"] is False
+    assert rows["ADE-QRE-016E"]["status"] == "ready"
+    assert rows["ADE-QRE-016E"]["auto_selectable"] is True
     assert rows["ADE-QRE-016F"]["status"] == "blocked until ADE-QRE-016E done"
     assert rows["ADE-QRE-016F"]["auto_selectable"] is False
     assert rows["ADE-QRE-016G"]["status"] == "blocked until ADE-QRE-016F done"


### PR DESCRIPTION
## Summary
- mark ADE-QRE-016D done with PR #382 and post-merge gate evidence
- make ADE-QRE-016E the next ready queue item
- update queue self-audit and lifecycle tests for the new queue state

## Validation
- pytest tests\\unit\\test_ade_queue_status_self_audit.py tests\\unit\\test_ade_qre_014_queue_lifecycle.py -q
- git diff --check
- python -m reporting.architecture_import_scan --format summary
- python scripts\\governance_lint.py
- git diff -- research\\research_latest.json research\\strategy_matrix.csv registry.py agent\\backtesting\\strategies.py
- queue audit selected exactly ADE-QRE-016E