### PR TITLE
docs: add ADE-QRE-016E operator summary

### DIFF
--- a/docs/governance/ade_qre_016e_trusted_loop_operator_summary_v2.md
+++ b/docs/governance/ade_qre_016e_trusted_loop_operator_summary_v2.md
@@ -1,0 +1,94 @@
+# ADE-QRE-016E - Trusted-Loop Operator Summary v2
+
+> Status: docs-only operator summary.
+>
+> Scope: governance documentation only. This summary does not add dashboard
+> mutation routes, approval mutation, runtime authority expansion, strategy
+> synthesis, Addendum runtime activation, routing/campaign mutation, shadow,
+> paper, live, broker, risk, execution, or frozen contract changes.
+
+## Operator State
+
+The trusted loop is evidence-visible and partially working as read-only
+governance/reporting, but it is not operator-trusted end to end.
+
+Current operator answer:
+
+- queue sequencing is trusted only for the bounded ADE-QRE-016 queue decision;
+- diagnostics and retrieval are evidence/context surfaces, not authority;
+- missing reason-record, KPI, routing, sampling, retrieval, and historical
+  queue evidence still block broader readiness claims;
+- strategy synthesis remains blocked;
+- Addendum 1, 2, 3, and 4 remain reference-only and inactive at runtime;
+- shadow, paper, live, broker, risk, and execution paths remain inactive.
+
+## Ready
+
+| Surface | Current ready claim | Evidence |
+| --- | --- | --- |
+| Queue selection | `ADE-QRE-016E` is the single current eligible ready item after `ADE-QRE-016D` completion. | Queue self-audit reports exactly one current eligible ready item, with stale `ADE-QRE-011` treated as historical and non-selectable. |
+| Read-only fail-closed coverage | Missing evidence is visible and blocks readiness across key trusted-loop surfaces. | `ADE-QRE-016C` added `reporting.trusted_loop_missing_evidence_fail_closed` and tests. |
+| Cross-surface consistency visibility | Current surfaces are consistent as blocked-by-evidence, not as trusted readiness. | `ADE-QRE-016D` added `reporting.trusted_loop_consistency_audit` and tests. |
+| Narrow operator vocabulary | Scaffold, working capability, and operator-trusted capability have explicit fail-closed criteria. | `ADE-QRE-016B` trust criteria. |
+
+## Blocked
+
+| Blocked claim | Reason |
+| --- | --- |
+| End-to-end operator-trusted trusted loop | Required evidence is still incomplete across reason records, KPI values, routing, sampling, retrieval, and historical queue evidence. |
+| Return to QRE Feature Build Track implementation | Feature-track return requires explicit evidence requirements and a later decision; `ADE-QRE-016F` is not done yet. |
+| v3.15.16 Intelligent Routing implementation | Routing readiness remains non-ready and empty; no routing or campaign behavior may start from the current evidence. |
+| Sampling readiness | Sampling evidence remains non-ready and empty; no routing/sampling bridge readiness is proven. |
+| Failure-action usefulness | Current failure-action evidence has no actionable failure population to evaluate. |
+| Historical audit completeness | `ADE-QRE-007`, `ADE-QRE-008`, and `ADE-QRE-014A` retain historical done-evidence warnings; current queue selection can proceed, but broad audit-completeness claims remain blocked. |
+
+## Deferred
+
+| Deferred direction | Reason |
+| --- | --- |
+| Addendum 1 runtime diagnostics/intelligence activation | Reference-only until a future operator-approved ADR activates a specific subsection. |
+| Addendum 2 runtime retrieval/knowledge activation | Retrieval may provide local context only; it cannot route, approve, synthesize, or expand authority. |
+| Addendum 3 source/data adapter activation | No external data adapter or new datafeed is authorized by ADE-QRE-016. |
+| Addendum 4 trusted-loop maturity matrix runtime activation | Addendum 4 remains deferred/reference-only. |
+| Historical queue evidence cleanup | Lower priority than current trusted-loop maturity items unless explicitly scoped later. |
+
+## Not Trusted
+
+| Surface | Current trust level | Not-trusted reason |
+| --- | --- | --- |
+| Reason records | Working visibility only | Durable reason records with evidence references are absent or too thin. |
+| Research-quality KPIs | Working visibility only | KPI doctrine exists, but numeric KPI values are incomplete. |
+| Routing readiness | Working visibility only | Routing reports no ready implementation evidence. |
+| Sampling readiness | Working visibility only | Sampling reports no actionable sampling evidence. |
+| Diagnostics | Evidence surface only | Diagnostics can explain blockers but cannot authorize readiness or behavior. |
+| Retrieval | Context surface only | Retrieval coverage cannot act as authority. |
+| Queue status | Narrow operator trust for current sequencing only | Historical audit warnings prevent broad queue-status trust. |
+
+## No-Synthesis Reasons
+
+Strategy synthesis remains blocked because:
+
+- no operator-approved strategy synthesis implementation scope exists;
+- reason-record evidence is not mature enough to support synthesis readiness;
+- KPI numeric readiness is incomplete;
+- routing and sampling are not ready;
+- failure-action evidence has no actionable failure population;
+- synthesis would require touching forbidden strategy or registry surfaces unless
+  separately and explicitly authorized in a future queue item;
+- ADE-QRE-016 explicitly forbids strategy synthesis and runtime authority
+  expansion.
+
+## Operator Use
+
+Use this summary to decide what the trusted loop can currently support:
+
+- It can support the next bounded ADE-QRE-016 queue item.
+- It can support read-only review of why broader trusted-loop readiness is
+  blocked.
+- It cannot support feature-track implementation, strategy synthesis,
+  approvals, dashboard mutation controls, routing/campaign behavior, Addendum
+  runtime activation, or execution-like behavior.
+
+The next eligible item after this summary is
+`ADE-QRE-016F - Return-to-Feature-Track Criteria Refinement`, but only after
+this item is merged and marked done through the queue lifecycle.


### PR DESCRIPTION
## Summary
- add the docs-only ADE-QRE-016E trusted-loop operator summary v2
- make ready, blocked, deferred, not-trusted, and no-synthesis reasons explicit
- preserve no dashboard mutation, approval mutation, synthesis, Addendum runtime, or execution behavior

## Validation
- git diff --check
- python -m reporting.architecture_import_scan --format summary
- python scripts\\governance_lint.py
- git diff -- research\\research_latest.json research\\strategy_matrix.csv registry.py agent\\backtesting\\strategies.py
- queue audit still selects exactly ADE-QRE-016E