### PR TITLE
docs: mark ADE-QRE-016E done

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -2360,7 +2360,17 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-016E`
 - title: Trusted-Loop Operator Summary v2.
-- status: `ready`
+- status: `done`
+- completion evidence: PR #384, merge SHA
+  `bc8b13806589f7acc4213dd2d0c0a4ba12592c3f`; docs-only trusted-loop
+  operator summary v2 added in
+  `docs/governance/ade_qre_016e_trusted_loop_operator_summary_v2.md`;
+  post-merge Fast pre-merge gate run `26570241313`, Docker build/push run
+  `26570496441`, and VPS deploy run `26570496538` completed/success; local
+  `git diff --check`, architecture scanner, governance lint, and queue
+  self-audit passed; frozen contracts unchanged; protected/execution paths
+  untouched; strategy synthesis remained blocked; Addendum runtime remained
+  inactive.
 - purpose: produce a clearer operator-facing summary of what the trusted loop
   can and cannot currently do.
 - depends on: `ADE-QRE-016D done`.
@@ -2427,7 +2437,7 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-016F`
 - title: Return-to-Feature-Track Criteria Refinement.
-- status: `blocked until ADE-QRE-016E done`
+- status: `ready`
 - purpose: refine exact evidence requirements for a future return to QRE
   Feature Build Track without starting it.
 - depends on: `ADE-QRE-016E done`.

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -299,14 +299,15 @@ def test_ade_qre_active_queue_lifecycle_is_consistent() -> None:
     assert _dependencies_done(item_16d, items) is True
     assert _done_evidence_is_complete(item_16d)
     assert _auto_selectable_status(item_16d) is False
-    assert item_16e.status == "ready"
+    assert item_16e.status == "done"
     assert item_16e.dependencies == ("ADE-QRE-016D",)
     assert _dependencies_done(item_16e, items) is True
-    assert _auto_selectable_status(item_16e) is True
-    assert item_16f.status == "blocked until ADE-QRE-016E done"
+    assert _done_evidence_is_complete(item_16e)
+    assert _auto_selectable_status(item_16e) is False
+    assert item_16f.status == "ready"
     assert item_16f.dependencies == ("ADE-QRE-016E",)
-    assert _dependencies_done(item_16f, items) is False
-    assert _auto_selectable_status(item_16f) is False
+    assert _dependencies_done(item_16f, items) is True
+    assert _auto_selectable_status(item_16f) is True
     assert item_16g.status == "blocked until ADE-QRE-016F done"
     assert item_16g.dependencies == ("ADE-QRE-016F",)
     assert _dependencies_done(item_16g, items) is False
@@ -316,7 +317,7 @@ def test_ade_qre_active_queue_lifecycle_is_consistent() -> None:
     assert _dependencies_done(item_16h, items) is False
     assert _auto_selectable_status(item_16h) is False
     assert _stale_historical_ready_items(items) == ("ADE-QRE-011",)
-    assert _next_eligible_ready_item(items) == item_16e
+    assert _next_eligible_ready_item(items) == item_16f
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:

--- a/tests/unit/test_ade_queue_status_self_audit.py
+++ b/tests/unit/test_ade_queue_status_self_audit.py
@@ -115,11 +115,11 @@ def test_blocked_and_deferred_reason_gaps_are_explicit(tmp_path: Path) -> None:
     )
 
 
-def test_current_queue_selects_016e_after_016d_done() -> None:
-    snap = audit.collect_snapshot(frozen_utc="2026-05-27T00:00:00Z")
+def test_current_queue_selects_016f_after_016e_done() -> None:
+    snap = audit.collect_snapshot(frozen_utc="2026-05-28T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-016E"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-016F"
     assert "ADE-QRE-011" in snap["summary"]["stale_historical_ready_items"]
     assert rows["ADE-QRE-014N"]["status"] == "done"
     assert rows["ADE-QRE-014N"]["done_evidence"]["complete"] is True
@@ -152,10 +152,11 @@ def test_current_queue_selects_016e_after_016d_done() -> None:
     assert rows["ADE-QRE-016D"]["status"] == "done"
     assert rows["ADE-QRE-016D"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-016D"]["auto_selectable"] is False
-    assert rows["ADE-QRE-016E"]["status"] == "ready"
-    assert rows["ADE-QRE-016E"]["auto_selectable"] is True
-    assert rows["ADE-QRE-016F"]["status"] == "blocked until ADE-QRE-016E done"
-    assert rows["ADE-QRE-016F"]["auto_selectable"] is False
+    assert rows["ADE-QRE-016E"]["status"] == "done"
+    assert rows["ADE-QRE-016E"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-016E"]["auto_selectable"] is False
+    assert rows["ADE-QRE-016F"]["status"] == "ready"
+    assert rows["ADE-QRE-016F"]["auto_selectable"] is True
     assert rows["ADE-QRE-016G"]["status"] == "blocked until ADE-QRE-016F done"
     assert rows["ADE-QRE-016G"]["auto_selectable"] is False
     assert rows["ADE-QRE-016H"]["status"] == "blocked until ADE-QRE-016G done"


### PR DESCRIPTION
## Summary
- mark ADE-QRE-016E done with PR #384 and post-merge gate evidence
- move ADE-QRE-016F to ready
- update queue self-audit expectations for the next eligible item

## Validation
- pytest tests\\unit\\test_ade_queue_status_self_audit.py tests\\unit\\test_ade_qre_014_queue_lifecycle.py -q
- git diff --check
- python -m reporting.architecture_import_scan --format summary
- python scripts\\governance_lint.py
- protected/frozen/research-output diff empty
- queue audit selects exactly ADE-QRE-016F