### PR TITLE
docs: mark ADE-QRE-016F done

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -2437,7 +2437,17 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-016F`
 - title: Return-to-Feature-Track Criteria Refinement.
-- status: `ready`
+- status: `done`
+- completion evidence: PR #386, merge SHA
+  `7b8d692f9377f147c606a665de4be1207828de26`; docs-only return-to-feature-track
+  criteria added in
+  `docs/governance/ade_qre_016f_return_to_feature_track_criteria.md`;
+  post-merge Fast pre-merge gate run `26571922528`, Docker build/push run
+  `26572222841`, and VPS deploy run `26572222812` completed/success; local
+  `git diff --check`, architecture scanner, governance lint, and queue
+  self-audit passed; frozen contracts unchanged; protected/execution paths
+  untouched; strategy synthesis remained blocked; Addendum runtime remained
+  inactive.
 - purpose: refine exact evidence requirements for a future return to QRE
   Feature Build Track without starting it.
 - depends on: `ADE-QRE-016E done`.
@@ -2506,7 +2516,7 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-016G`
 - title: Next Sprint Decision Check.
-- status: `blocked until ADE-QRE-016F done`
+- status: `ready`
 - purpose: decide whether the next direction should be another maturity
   sprint, operator review, return-to-feature-track planning, or no eligible
   work.

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -304,20 +304,21 @@ def test_ade_qre_active_queue_lifecycle_is_consistent() -> None:
     assert _dependencies_done(item_16e, items) is True
     assert _done_evidence_is_complete(item_16e)
     assert _auto_selectable_status(item_16e) is False
-    assert item_16f.status == "ready"
+    assert item_16f.status == "done"
     assert item_16f.dependencies == ("ADE-QRE-016E",)
     assert _dependencies_done(item_16f, items) is True
-    assert _auto_selectable_status(item_16f) is True
-    assert item_16g.status == "blocked until ADE-QRE-016F done"
+    assert _done_evidence_is_complete(item_16f)
+    assert _auto_selectable_status(item_16f) is False
+    assert item_16g.status == "ready"
     assert item_16g.dependencies == ("ADE-QRE-016F",)
-    assert _dependencies_done(item_16g, items) is False
-    assert _auto_selectable_status(item_16g) is False
+    assert _dependencies_done(item_16g, items) is True
+    assert _auto_selectable_status(item_16g) is True
     assert item_16h.status == "blocked until ADE-QRE-016G done"
     assert item_16h.dependencies == ("ADE-QRE-016G",)
     assert _dependencies_done(item_16h, items) is False
     assert _auto_selectable_status(item_16h) is False
     assert _stale_historical_ready_items(items) == ("ADE-QRE-011",)
-    assert _next_eligible_ready_item(items) == item_16f
+    assert _next_eligible_ready_item(items) == item_16g
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:

--- a/tests/unit/test_ade_queue_status_self_audit.py
+++ b/tests/unit/test_ade_queue_status_self_audit.py
@@ -115,11 +115,11 @@ def test_blocked_and_deferred_reason_gaps_are_explicit(tmp_path: Path) -> None:
     )
 
 
-def test_current_queue_selects_016f_after_016e_done() -> None:
+def test_current_queue_selects_016g_after_016f_done() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-05-28T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-016F"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-016G"
     assert "ADE-QRE-011" in snap["summary"]["stale_historical_ready_items"]
     assert rows["ADE-QRE-014N"]["status"] == "done"
     assert rows["ADE-QRE-014N"]["done_evidence"]["complete"] is True
@@ -155,10 +155,11 @@ def test_current_queue_selects_016f_after_016e_done() -> None:
     assert rows["ADE-QRE-016E"]["status"] == "done"
     assert rows["ADE-QRE-016E"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-016E"]["auto_selectable"] is False
-    assert rows["ADE-QRE-016F"]["status"] == "ready"
-    assert rows["ADE-QRE-016F"]["auto_selectable"] is True
-    assert rows["ADE-QRE-016G"]["status"] == "blocked until ADE-QRE-016F done"
-    assert rows["ADE-QRE-016G"]["auto_selectable"] is False
+    assert rows["ADE-QRE-016F"]["status"] == "done"
+    assert rows["ADE-QRE-016F"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-016F"]["auto_selectable"] is False
+    assert rows["ADE-QRE-016G"]["status"] == "ready"
+    assert rows["ADE-QRE-016G"]["auto_selectable"] is True
     assert rows["ADE-QRE-016H"]["status"] == "blocked until ADE-QRE-016G done"
     assert rows["ADE-QRE-016H"]["auto_selectable"] is False
     assert snap["safety_invariants"]["adds_approval_mutation"] is False


### PR DESCRIPTION
## Summary
- mark ADE-QRE-016F done with PR #386 and post-merge gate evidence
- move ADE-QRE-016G to ready
- update queue self-audit expectations for the next eligible item

## Validation
- pytest tests\\unit\\test_ade_queue_status_self_audit.py tests\\unit\\test_ade_qre_014_queue_lifecycle.py -q
- git diff --check
- python -m reporting.architecture_import_scan --format summary
- python scripts\\governance_lint.py
- protected/frozen/research-output diff empty
- queue audit selects exactly ADE-QRE-016G