### PR TITLE
docs: add ADE-QRE-016G decision check

### DIFF
--- a/docs/governance/ade_qre_016g_next_sprint_decision_check.md
+++ b/docs/governance/ade_qre_016g_next_sprint_decision_check.md
@@ -1,0 +1,97 @@
+# ADE-QRE-016G - Next Sprint Decision Check
+
+> Status: docs-only decision check.
+>
+> Scope: governance documentation only. This decision record does not start the
+> selected direction implementation, activate strategy synthesis, activate
+> Addendum runtime layers, touch execution paths, or expand runtime authority.
+
+## Selected Recommendation
+
+Recommendation: `continue_trusted_loop_maturity`
+
+This is exactly one of the allowed `ADE-QRE-016G` outputs. It is the only
+selected recommendation in this decision check.
+
+Allowed outputs reviewed:
+
+| Allowed output | Selected | Evidence-backed rationale |
+| --- | --- | --- |
+| `continue_trusted_loop_maturity` | Yes | Current evidence identifies open, ordered maturity gaps that can be addressed without starting QRE Feature Build Track implementation or runtime behavior. |
+| `return_to_qre_feature_track_planning` | No | `ADE-QRE-016F` marks return criteria `not_met`; reason-record, KPI, routing, sampling, and end-to-end trust gates remain incomplete. |
+| `operator_review_required` | No | The evidence does not present an unresolved tie among allowed directions; it deterministically rejects return planning and supports another bounded maturity queue. |
+| `no_eligible_work_remains` | No | Remaining maturity work is explicitly evidenced by open `RTF-*` and `GAP-015B-*` blockers. |
+
+## Decision Basis
+
+The current trusted-loop evidence supports another maturity sprint, not feature
+planning or operator escalation.
+
+| Evidence source | Signal | Decision implication |
+| --- | --- | --- |
+| `ADE-QRE-016A` closure inventory | Prioritized gaps remain open across reason records, KPI values, routing, sampling, trust precision, failure-action population, and historical audit warnings. | Eligible next work exists and should stay maturity-focused. |
+| `ADE-QRE-016B` trust criteria | Operator-trusted capability requires measurable evidence and fails closed when evidence is missing. | Working read-only surfaces cannot be generalized into feature-track readiness. |
+| `ADE-QRE-016C` missing-evidence coverage | Missing evidence blocks readiness across key trusted-loop surfaces. | Empty or missing evidence cannot justify return planning. |
+| `ADE-QRE-016D` consistency audit | Cross-surface state is consistent as blocked-by-evidence, not ready. | The next queue should close evidence gaps rather than implement behavior. |
+| `ADE-QRE-016E` operator summary | Trusted loop is evidence-visible and partially working read-only, but not operator-trusted end to end. | Operator-facing state is clear enough to avoid escalation solely for direction choice. |
+| `ADE-QRE-016F` return criteria | Return criteria status is `not_met`. | `return_to_qre_feature_track_planning` is rejected for this decision. |
+
+## Non-Selection Reasons
+
+`return_to_qre_feature_track_planning` is not selected because:
+
+- reason-record evidence remains absent or too thin;
+- research-quality KPI values remain incomplete;
+- routing evidence remains empty or non-ready;
+- sampling evidence remains empty or non-ready;
+- the trusted loop is not operator-trusted end to end;
+- missing evidence must continue to fail closed;
+- strategy synthesis remains blocked;
+- Addendum runtime, shadow, paper, live, broker, risk, and execution paths
+  remain inactive.
+
+`operator_review_required` is not selected because:
+
+- the decision is not ambiguous;
+- there is no competing evidence that supports feature-track planning now;
+- no HIGH or UNKNOWN authority is needed to select another docs/governance
+  maturity queue;
+- the selected direction does not require approval mutation, dashboard
+  mutation, autonomous authority expansion, routing behavior, or execution
+  behavior.
+
+`no_eligible_work_remains` is not selected because:
+
+- open evidence gates remain concrete and ordered;
+- continued maturity work can remain docs/read-only reporting/tests scoped;
+- the queue can continue without activating forbidden runtime surfaces.
+
+## Selected Direction Constraints
+
+The selected direction means only that a future queue may be prepared for
+trusted-loop maturity work. It does not authorize implementation of that future
+queue in this PR or in `ADE-QRE-016G`.
+
+Any future maturity queue must preserve:
+
+- retrieval as context, not authority;
+- diagnostics as evidence surfaces only;
+- source quality as not alpha;
+- throughput as not lowering evidence standards;
+- no strategy synthesis;
+- no Addendum runtime activation;
+- no shadow, paper, live, broker, risk, or execution behavior;
+- no approval mutation;
+- no dashboard mutation routes;
+- no autonomous authority expansion.
+
+## Safety Invariants
+
+- Strategy synthesis remains blocked.
+- Addendum 1, Addendum 2, Addendum 3, and Addendum 4 remain reference-only and
+  inactive at runtime.
+- Addendum 4 remains `DEFERRED / REFERENCE-ONLY`.
+- Shadow, paper, live, broker, risk, and execution paths remain inactive.
+- `registry.py`, strategy implementations, frozen research outputs, approval
+  mutation, dashboard mutation routes, routing implementation, campaign
+  mutation, external data adapters, and new datafeeds remain out of scope.


### PR DESCRIPTION
## Summary
- add docs-only ADE-QRE-016G next sprint decision check
- select exactly one allowed output: continue_trusted_loop_maturity
- document non-selection reasons for return planning, operator review, and no eligible work

## Validation
- git diff --check
- python -m reporting.architecture_import_scan --format summary
- python scripts\\governance_lint.py
- protected/frozen/research-output diff empty
- decision record has exactly one Recommendation line