### PR TITLE
docs: mark ADE-QRE-016G done

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -2516,7 +2516,18 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-016G`
 - title: Next Sprint Decision Check.
-- status: `ready`
+- status: `done`
+- completion evidence: PR #388, merge SHA
+  `fa11434a2572ddf42e3f8ed0dce318783e158634`; docs-only next sprint
+  decision check added in
+  `docs/governance/ade_qre_016g_next_sprint_decision_check.md`, selecting
+  exactly one allowed output, `continue_trusted_loop_maturity`; post-merge
+  Fast pre-merge gate run `26573650469`, Docker build/push run `26573907736`,
+  and VPS deploy run `26573907739` completed/success; local
+  `git diff --check`, architecture scanner, governance lint, queue self-audit,
+  and exactly-one-recommendation check passed; frozen contracts unchanged;
+  protected/execution paths untouched; strategy synthesis remained blocked;
+  Addendum runtime remained inactive.
 - purpose: decide whether the next direction should be another maturity
   sprint, operator review, return-to-feature-track planning, or no eligible
   work.
@@ -2589,7 +2600,7 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-016H`
 - title: Queue Direction Finalization.
-- status: `blocked until ADE-QRE-016G done`
+- status: `ready`
 - purpose: finalize exactly one next queue direction after `ADE-QRE-016`.
 - depends on: `ADE-QRE-016G done`.
 - risk class: LOW.

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -309,16 +309,17 @@ def test_ade_qre_active_queue_lifecycle_is_consistent() -> None:
     assert _dependencies_done(item_16f, items) is True
     assert _done_evidence_is_complete(item_16f)
     assert _auto_selectable_status(item_16f) is False
-    assert item_16g.status == "ready"
+    assert item_16g.status == "done"
     assert item_16g.dependencies == ("ADE-QRE-016F",)
     assert _dependencies_done(item_16g, items) is True
-    assert _auto_selectable_status(item_16g) is True
-    assert item_16h.status == "blocked until ADE-QRE-016G done"
+    assert _done_evidence_is_complete(item_16g)
+    assert _auto_selectable_status(item_16g) is False
+    assert item_16h.status == "ready"
     assert item_16h.dependencies == ("ADE-QRE-016G",)
-    assert _dependencies_done(item_16h, items) is False
-    assert _auto_selectable_status(item_16h) is False
+    assert _dependencies_done(item_16h, items) is True
+    assert _auto_selectable_status(item_16h) is True
     assert _stale_historical_ready_items(items) == ("ADE-QRE-011",)
-    assert _next_eligible_ready_item(items) == item_16g
+    assert _next_eligible_ready_item(items) == item_16h
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:

--- a/tests/unit/test_ade_queue_status_self_audit.py
+++ b/tests/unit/test_ade_queue_status_self_audit.py
@@ -115,11 +115,11 @@ def test_blocked_and_deferred_reason_gaps_are_explicit(tmp_path: Path) -> None:
     )
 
 
-def test_current_queue_selects_016g_after_016f_done() -> None:
+def test_current_queue_selects_016h_after_016g_done() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-05-28T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-016G"
+    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-016H"
     assert "ADE-QRE-011" in snap["summary"]["stale_historical_ready_items"]
     assert rows["ADE-QRE-014N"]["status"] == "done"
     assert rows["ADE-QRE-014N"]["done_evidence"]["complete"] is True
@@ -158,10 +158,11 @@ def test_current_queue_selects_016g_after_016f_done() -> None:
     assert rows["ADE-QRE-016F"]["status"] == "done"
     assert rows["ADE-QRE-016F"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-016F"]["auto_selectable"] is False
-    assert rows["ADE-QRE-016G"]["status"] == "ready"
-    assert rows["ADE-QRE-016G"]["auto_selectable"] is True
-    assert rows["ADE-QRE-016H"]["status"] == "blocked until ADE-QRE-016G done"
-    assert rows["ADE-QRE-016H"]["auto_selectable"] is False
+    assert rows["ADE-QRE-016G"]["status"] == "done"
+    assert rows["ADE-QRE-016G"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-016G"]["auto_selectable"] is False
+    assert rows["ADE-QRE-016H"]["status"] == "ready"
+    assert rows["ADE-QRE-016H"]["auto_selectable"] is True
     assert snap["safety_invariants"]["adds_approval_mutation"] is False
     assert snap["safety_invariants"]["expands_autonomous_authority"] is False
     assert snap["safety_invariants"]["strategy_synthesis_enabled"] is False


### PR DESCRIPTION
## Summary
- mark ADE-QRE-016G done with PR #388 and post-merge gate evidence
- mark ADE-QRE-016H ready
- update queue self-audit expectations for the next eligible item

## Validation
- pytest tests\\unit\\test_ade_queue_status_self_audit.py tests\\unit\\test_ade_qre_014_queue_lifecycle.py -q
- git diff --check
- python -m reporting.architecture_import_scan --format summary
- python scripts\\governance_lint.py
- protected/frozen diff check: empty
- queue self-audit selects ADE-QRE-016H as the only eligible ready item