### PR TITLE
docs: finalize ADE-QRE-016H queue direction

### DIFF
--- a/docs/governance/ade_qre_016h_queue_direction_finalization.md
+++ b/docs/governance/ade_qre_016h_queue_direction_finalization.md
@@ -1,0 +1,109 @@
+# ADE-QRE-016H - Queue Direction Finalization
+
+> Status: docs-only queue direction finalization.
+>
+> Scope: governance documentation only. This record finalizes the next queue
+> direction after `ADE-QRE-016`; it does not implement that queue, activate
+> strategy synthesis, activate Addendum runtime layers, touch shadow, paper,
+> live, broker, risk, or execution paths, or expand runtime authority.
+
+## Finalized Direction
+
+Finalized next queue direction:
+`ADE-QRE-017 trusted-loop evidence closure maturity queue`.
+
+This is the single selected direction after `ADE-QRE-016`. It implements the
+`ADE-QRE-016G` recommendation `continue_trusted_loop_maturity` as a future
+queue direction only. It does not start `ADE-QRE-017` work in this record.
+
+## Decision Basis
+
+The next queue should remain a trusted-loop maturity queue because the current
+evidence rejects return-to-feature-track planning and still identifies bounded,
+read-only closure work.
+
+| Evidence source | Signal | Direction implication |
+| --- | --- | --- |
+| `ADE-QRE-016A` evidence gap closure inventory | Prioritized gaps remain open across reason records, KPI values, routing, sampling, trust precision, failure-action population, and historical audit warnings. | A future queue can be ordered around evidence closure without runtime activation. |
+| `ADE-QRE-016B` operator trust criteria | Operator-trusted capability requires explicit, measurable, fail-closed evidence. | The next queue should tighten evidence until capability can be classified precisely. |
+| `ADE-QRE-016C` missing-evidence coverage | Missing evidence cannot be interpreted as readiness across trusted-loop surfaces. | Future work must preserve fail-closed behavior while closing missing evidence. |
+| `ADE-QRE-016D` consistency audit | Cross-surface state is consistently blocked by evidence gaps rather than ready. | The next queue should resolve or explicitly preserve those blockers. |
+| `ADE-QRE-016E` operator summary | Current trusted-loop state is visible but not operator-trusted end to end. | Operator-facing maturity can continue without approval mutation or dashboard mutation. |
+| `ADE-QRE-016F` return criteria | Return-to-feature-track criteria are `not_met`. | Return planning remains blocked until required evidence gates are met. |
+| `ADE-QRE-016G` decision check | Exactly one recommendation was selected: `continue_trusted_loop_maturity`. | The finalized next direction must be another maturity queue, not feature-track implementation. |
+
+## Future Queue Boundaries
+
+The future `ADE-QRE-017` queue should be prepared as a trusted-loop evidence
+closure maturity queue. Its items should be admitted only if they are bounded,
+reviewable, and tied to an open evidence blocker already surfaced by
+`ADE-QRE-016`.
+
+Eligible future themes include:
+
+- reason-record evidence materialization or explicit non-requirement rationale;
+- research-quality KPI evidence completion or operator-approved substitute
+  criteria;
+- read-only routing readiness evidence that remains readiness input only;
+- read-only sampling readiness evidence that remains readiness input only;
+- evidence-backed trust classification precision;
+- fail-closed reporting coverage where upstream evidence is still absent;
+- historical queue audit warning clarification if it is needed for trusted-loop
+  claims.
+
+This finalization does not create, order, or start individual `ADE-QRE-017`
+items. A separate future queue proposal must define any concrete entries,
+dependencies, validation, and merge criteria.
+
+## Blocked Or Deferred Directions
+
+`return_to_qre_feature_track_planning` remains blocked because:
+
+- `ADE-QRE-016F` records current return criteria status as `not_met`;
+- reason-record evidence remains absent or too thin;
+- KPI values remain incomplete without operator-approved substitute criteria;
+- routing and sampling readiness remain empty or non-ready;
+- the trusted loop is not operator-trusted end to end.
+
+`operator_review_required` is not selected because:
+
+- `ADE-QRE-016G` found no unresolved tie among allowed directions;
+- another maturity queue is supported by current evidence;
+- no HIGH or UNKNOWN authority is required to finalize a docs-only future queue
+  direction.
+
+`no_eligible_work_remains` is not selected because:
+
+- open evidence blockers remain concrete and bounded;
+- continued maturity work can stay docs, tests, and read-only reporting scoped;
+- no strategy synthesis, Addendum runtime, or execution behavior is needed to
+  continue maturity work.
+
+Strategy synthesis remains blocked. Addendum 1, Addendum 2, Addendum 3, and
+Addendum 4 remain reference-only and inactive at runtime. Addendum 4 remains
+`DEFERRED / REFERENCE-ONLY`.
+
+## Return Criteria
+
+A future return-to-feature-track planning direction may be reconsidered only
+after every `ADE-QRE-016F` required evidence gate is met or explicitly replaced
+by operator-approved substitute criteria. Missing, empty, stale, or context-only
+evidence must continue to block return readiness.
+
+The future `ADE-QRE-017` queue must not weaken the following principles:
+
+- diagnostics are evidence surfaces only;
+- retrieval is context, not authority;
+- source quality is not alpha;
+- throughput does not lower evidence standards;
+- queue status is sequencing evidence, not runtime authority.
+
+## Safety Invariants
+
+- No next queue implementation is started by this record.
+- Strategy synthesis remains blocked.
+- Addendum runtime layers remain inactive.
+- Shadow, paper, live, broker, risk, and execution paths remain inactive.
+- `registry.py`, strategy implementations, frozen research outputs, approval
+  mutation, dashboard mutation routes, routing implementation, campaign
+  mutation, external data adapters, and new datafeeds remain out of scope.


### PR DESCRIPTION
## Summary
- add the ADE-QRE-016H docs-only queue direction finalization record
- select exactly one next direction: ADE-QRE-017 trusted-loop evidence closure maturity queue
- keep unsupported directions blocked or not selected without starting next-queue work

## Validation
- git diff --cached --check
- python -m reporting.architecture_import_scan --format summary
- python scripts\\governance_lint.py
- protected/frozen diff check: empty
- queue self-audit still selects ADE-QRE-016H as the only eligible ready item
- exactly-one-finalized-direction text check