### PR TITLE
docs: mark ADE-QRE-016H done

### DIFF
--- a/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
+++ b/docs/governance/ade_queue_001_post_package_qre_ade_work_queue.md
@@ -2600,7 +2600,19 @@ live, broker, risk, or execution work.
 
 - queue id: `ADE-QRE-016H`
 - title: Queue Direction Finalization.
-- status: `ready`
+- status: `done`
+- completion evidence: PR #390, merge SHA
+  `bdba23846c04f575015c1f29b56748e9feefc09c`; docs-only queue direction
+  finalization added in
+  `docs/governance/ade_qre_016h_queue_direction_finalization.md`, selecting
+  exactly one next direction, `ADE-QRE-017 trusted-loop evidence closure
+  maturity queue`, without starting that direction; post-merge Fast pre-merge
+  gate run `26576056772`, Docker build/push run `26576372752`, and VPS deploy
+  run `26576372754` completed/success; local `git diff --check`,
+  architecture scanner, governance lint, protected/frozen diff check, queue
+  self-audit, and exactly-one-finalized-direction check passed; frozen
+  contracts unchanged; protected/execution paths untouched; strategy synthesis
+  remained blocked; Addendum runtime remained inactive.
 - purpose: finalize exactly one next queue direction after `ADE-QRE-016`.
 - depends on: `ADE-QRE-016G done`.
 - risk class: LOW.

--- a/tests/unit/test_ade_qre_014_queue_lifecycle.py
+++ b/tests/unit/test_ade_qre_014_queue_lifecycle.py
@@ -314,12 +314,13 @@ def test_ade_qre_active_queue_lifecycle_is_consistent() -> None:
     assert _dependencies_done(item_16g, items) is True
     assert _done_evidence_is_complete(item_16g)
     assert _auto_selectable_status(item_16g) is False
-    assert item_16h.status == "ready"
+    assert item_16h.status == "done"
     assert item_16h.dependencies == ("ADE-QRE-016G",)
     assert _dependencies_done(item_16h, items) is True
-    assert _auto_selectable_status(item_16h) is True
+    assert _done_evidence_is_complete(item_16h)
+    assert _auto_selectable_status(item_16h) is False
     assert _stale_historical_ready_items(items) == ("ADE-QRE-011",)
-    assert _next_eligible_ready_item(items) == item_16h
+    assert _next_eligible_ready_item(items) is None
 
 
 def test_done_queue_item_without_merge_evidence_is_rejected() -> None:

--- a/tests/unit/test_ade_queue_status_self_audit.py
+++ b/tests/unit/test_ade_queue_status_self_audit.py
@@ -115,11 +115,11 @@ def test_blocked_and_deferred_reason_gaps_are_explicit(tmp_path: Path) -> None:
     )
 
 
-def test_current_queue_selects_016h_after_016g_done() -> None:
+def test_current_queue_has_no_eligible_item_after_016h_done() -> None:
     snap = audit.collect_snapshot(frozen_utc="2026-05-28T00:00:00Z")
     rows = {row["queue_item"]: row for row in snap["items"]}
 
-    assert snap["summary"]["next_eligible_ready_item"] == "ADE-QRE-016H"
+    assert snap["summary"]["next_eligible_ready_item"] is None
     assert "ADE-QRE-011" in snap["summary"]["stale_historical_ready_items"]
     assert rows["ADE-QRE-014N"]["status"] == "done"
     assert rows["ADE-QRE-014N"]["done_evidence"]["complete"] is True
@@ -161,8 +161,9 @@ def test_current_queue_selects_016h_after_016g_done() -> None:
     assert rows["ADE-QRE-016G"]["status"] == "done"
     assert rows["ADE-QRE-016G"]["done_evidence"]["complete"] is True
     assert rows["ADE-QRE-016G"]["auto_selectable"] is False
-    assert rows["ADE-QRE-016H"]["status"] == "ready"
-    assert rows["ADE-QRE-016H"]["auto_selectable"] is True
+    assert rows["ADE-QRE-016H"]["status"] == "done"
+    assert rows["ADE-QRE-016H"]["done_evidence"]["complete"] is True
+    assert rows["ADE-QRE-016H"]["auto_selectable"] is False
     assert snap["safety_invariants"]["adds_approval_mutation"] is False
     assert snap["safety_invariants"]["expands_autonomous_authority"] is False
     assert snap["safety_invariants"]["strategy_synthesis_enabled"] is False


### PR DESCRIPTION
## Summary
- mark ADE-QRE-016H done with PR #390 and post-merge gate evidence
- update queue tests so no eligible next item remains after 016H
- preserve the selected ADE-QRE-017 direction as future-only, not started

## Validation
- pytest tests\\unit\\test_ade_queue_status_self_audit.py tests\\unit\\test_ade_qre_014_queue_lifecycle.py -q
- git diff --check
- python -m reporting.architecture_import_scan --format summary
- python scripts\\governance_lint.py
- protected/frozen diff check: empty
- queue self-audit reports no eligible ready items