### PR TITLE
fix: serialize execution events in recovery artifacts

### DIFF
--- a/research/recovery.py
+++ b/research/recovery.py
@@ -7,6 +7,8 @@ from json import JSONDecodeError
 from pathlib import Path
 from typing import Any
 
+from agent.backtesting.execution import ExecutionEvent, execution_event_to_dict
+
 
 BATCH_STATE_FILENAME = "run_batch_state.v1.json"
 FRESH_ATTEMPT_REASON = "fresh_run"
@@ -39,6 +41,27 @@ def _batch_sort_key(batch: dict[str, Any]) -> tuple[str, str, str]:
     )
 
 
+def _to_recovery_json_safe(value: Any) -> Any:
+    """Convert recovery payload values to explicit JSON-safe shapes.
+
+    Recovery artifacts may contain nested backtest runtime objects from
+    validation results. ExecutionEvent has a canonical serializer, so keep
+    the artifact inspectable instead of falling back to stringification.
+    Unknown object types remain loud failures at the JSON boundary.
+    """
+    if isinstance(value, ExecutionEvent):
+        return execution_event_to_dict(value)
+    if isinstance(value, dict):
+        return {str(key): _to_recovery_json_safe(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_to_recovery_json_safe(item) for item in value]
+    if isinstance(value, tuple):
+        return [_to_recovery_json_safe(item) for item in value]
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return value
+
+
 def build_batch_recovery_state_payload(
     *,
     source_run_id: str,
@@ -49,7 +72,7 @@ def build_batch_recovery_state_payload(
     evaluations: list[dict[str, Any]],
     walk_forward_reports: list[dict[str, Any]],
 ) -> dict[str, Any]:
-    return {
+    payload = {
         "version": "v1",
         "source_run_id": source_run_id,
         "batch_id": str(batch["batch_id"]),
@@ -88,6 +111,7 @@ def build_batch_recovery_state_payload(
             ),
         ),
     }
+    return _to_recovery_json_safe(payload)
 
 
 def load_batch_recovery_state(

--- a/tests/unit/test_research_recovery.py
+++ b/tests/unit/test_research_recovery.py
@@ -7,10 +7,12 @@ from types import SimpleNamespace
 
 import pytest
 
+from agent.backtesting.execution import ExecutionEvent
 from agent.backtesting.engine import EngineExecutionSnapshot, EngineInterrupted
 from research import batch_execution as batch_execution_module
 from research.candidate_resume import candidate_resume_state_path
 from research import run_research as run_research_module
+from research.recovery import build_batch_recovery_state_payload
 from tests.unit.test_run_research_observability import _HealthyEngine, _patch_common_runner
 
 
@@ -23,6 +25,79 @@ def _factory(name_hint: str):
         return SimpleNamespace(name_hint=name_hint)
 
     return _build
+
+
+def test_batch_recovery_payload_serializes_nested_execution_events() -> None:
+    event = ExecutionEvent.full_fill(
+        timestamp_utc="2026-05-29T00:00:00+00:00",
+        asset="BTC/EUR",
+        side="long",
+        sequence=1,
+        fold_index=0,
+        intended_price=100.0,
+        requested_size=2.0,
+        fill_price=101.0,
+        filled_size=2.0,
+        fee_amount=0.1,
+        slippage_bps=10.0,
+    )
+
+    payload = build_batch_recovery_state_payload(
+        source_run_id="run_json_safe",
+        batch={
+            "batch_id": "batch_json_safe",
+            "current_stage": "validation",
+            "candidate_ids": ["candidate_json_safe"],
+        },
+        candidate_snapshots=[
+            {
+                "candidate_id": "candidate_json_safe",
+                "strategy_name": "json_safe_strategy",
+                "asset": "BTC/EUR",
+                "interval": "1h",
+            }
+        ],
+        screening_records=[
+            {
+                "candidate_id": "candidate_json_safe",
+                "events": (event,),
+            }
+        ],
+        rows=[
+            {
+                "strategy_name": "json_safe_strategy",
+                "asset": "BTC/EUR",
+                "interval": "1h",
+            }
+        ],
+        evaluations=[
+            {
+                "row": {
+                    "strategy_name": "json_safe_strategy",
+                    "asset": "BTC/EUR",
+                    "interval": "1h",
+                },
+                "validation": {
+                    "execution_events": [event],
+                },
+            }
+        ],
+        walk_forward_reports=[
+            {
+                "strategy_name": "json_safe_strategy",
+                "asset": "BTC/EUR",
+                "interval": "1h",
+                "nested": {"event": event},
+            }
+        ],
+    )
+
+    json.dumps(payload)
+    serialized_event = payload["evaluations"][0]["validation"]["execution_events"][0]
+    assert serialized_event["asset"] == "BTC/EUR"
+    assert serialized_event["sequence"] == 1
+    assert payload["screening_records"][0]["events"][0]["kind"] == "full_fill"
+    assert payload["walk_forward_reports"][0]["nested"]["event"]["filled_size"] == 2.0
 
 
 class _RetryableFailureEngine(_HealthyEngine):


### PR DESCRIPTION
## Summary
- Convert nested ExecutionEvent objects in batch recovery payloads through the canonical execution_event_to_dict serializer.
- Keep unknown object types loud at the JSON boundary instead of using broad stringification.
- Add regression coverage for nested ExecutionEvent objects in recovery payloads.

## Validation
- python -m pytest tests/unit/test_research_recovery.py -q
- python -m pytest tests/regression/test_execution_event_roundtrip.py tests/unit/test_execution_event_scaffold.py -q
- python -m research.run_research --preset trend_equities_4h_baseline
- Recent run_batch_state.v1.json recovery artifacts loaded via ConvertFrom-Json

## Safety
- No strategy logic changed
- No frozen public contract schema changes
- No live/paper/shadow/risk/broker/execution paths changed