### PR TITLE
config: add equity trend active discovery route

### DIFF
--- a/research/campaign_templates.py
+++ b/research/campaign_templates.py
@@ -274,6 +274,7 @@ _BASELINE_PRESETS: tuple[str, ...] = (
 # contract).
 _HYPOTHESIS_AWARE_PRESETS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("trend_pullback_crypto_1h", ("active_discovery",)),
+    ("trend_pullback_equities_4h", ("active_discovery",)),
     ("vol_compression_breakout_crypto_1h", ("active_discovery",)),
     ("vol_compression_breakout_crypto_4h", ("active_discovery",)),
 )

--- a/research/presets.py
+++ b/research/presets.py
@@ -362,6 +362,59 @@ PRESETS: tuple[ResearchPreset, ...] = (
         ),
     ),
     ResearchPreset(
+        name="trend_pullback_equities_4h",
+        hypothesis=(
+            "Equity 4h controlled active_discovery route for the "
+            "trend_pullback_v1 thin strategy. This tests whether a "
+            "vol-normalised pullback inside an established EMA trend can "
+            "produce bounded exploratory evidence on liquid large-cap "
+            "equities without changing the legacy promotion-grade "
+            "trend_equities_4h_baseline."
+        ),
+        universe=_TREND_EQUITIES_UNIVERSE,
+        timeframe="4h",
+        bundle=("trend_pullback_v1",),
+        hypothesis_id="trend_pullback_v1",
+        screening_mode="strict",
+        screening_phase="exploratory",
+        cost_mode="realistic",
+        status="stable",
+        enabled=True,
+        diagnostic_only=False,
+        excluded_from_daily_scheduler=False,
+        preset_class="experimental",
+        rationale=(
+            "The existing equity trend baseline is a promotion-grade "
+            "legacy route. This preset adds a catalog-driven equity "
+            "active-discovery path so the campaign layer can exercise "
+            "hypothesis_id -> template -> launcher -> run_research -> "
+            "screening/evidence/follow-up without relaxing the baseline."
+        ),
+        expected_behavior=(
+            "Per fold: long entries only when the controlled "
+            "trend_pullback_v1 conditions hold on 4h equity data. "
+            "Exploratory passes should become needs_investigation rather "
+            "than promotion candidates, and downstream confirmation must "
+            "remain explicit."
+        ),
+        falsification=(
+            "Three consecutive daily_primary runs fail on insufficient_trades "
+            "across the large-cap equity universe.",
+            "Realistic costs eliminate exploratory passes across all "
+            "asset/parameter combinations.",
+            "Candidate evidence is parameter-fragile or isolated to a "
+            "single asset across repeated controlled runs.",
+        ),
+        enablement_criteria=(
+            "trend_pullback_v1 remains active_discovery in the hypothesis "
+            "catalog.",
+            "The preset remains hypothesis-aware via hypothesis_id and "
+            "campaign template eligibility.",
+            "The legacy trend_equities_4h_baseline remains promotion-grade "
+            "and unchanged.",
+        ),
+    ),
+    ResearchPreset(
         name="vol_compression_breakout_crypto_1h",
         hypothesis=(
             "v3.15.4 controlled active_discovery: een volatility "

--- a/tests/regression/test_v3_15_2_campaign_templates_byte_identity.py
+++ b/tests/regression/test_v3_15_2_campaign_templates_byte_identity.py
@@ -102,9 +102,11 @@ def test_legacy_template_count_unchanged() -> None:
     v3.15.3 adds trend_pullback_crypto_1h * 5 = 5 more, total 20.
     v3.15.15 adds vol_compression_breakout_crypto_1h and
     vol_compression_breakout_crypto_4h * 5 each = 10 more, total 30.
+    The equity trend active-discovery route adds
+    trend_pullback_equities_4h * 5 = 5 more, total 35.
     The legacy 15 baseline rows remain byte-identical (covered by
     the byte-identity test above)."""
-    assert len(CAMPAIGN_TEMPLATES) == 30
+    assert len(CAMPAIGN_TEMPLATES) == 35
     legacy_count = sum(
         1 for t in CAMPAIGN_TEMPLATES
         if t.preset_name in _LEGACY_BASELINE_PRESETS

--- a/tests/unit/test_dashboard_api_v310.py
+++ b/tests/unit/test_dashboard_api_v310.py
@@ -39,11 +39,10 @@ def test_presets_requires_auth(client):
 
 
 def test_presets_authed_returns_full_catalog(authed_client):
-    """v3.15.4 adds ``vol_compression_breakout_crypto_1h``;
-    v3.15.15 adds ``vol_compression_breakout_crypto_4h`` so the
-    crypto_exploratory_v1 sprint profile can route the full
-    (1h, 4h) × (trend_pullback_v1, volatility_compression_breakout_v0)
-    matrix without any new strategy or hypothesis."""
+    """The catalog includes baseline routes and controlled
+    active-discovery bridges. The equity trend bridge keeps the
+    promotion-grade baseline unchanged while exposing an explicit
+    trend_pullback_v1 equity route."""
     resp = authed_client.get("/api/presets")
     assert resp.status_code == 200
     data = resp.get_json()
@@ -53,6 +52,7 @@ def test_presets_authed_returns_full_catalog(authed_client):
         "pairs_equities_daily_baseline",
         "trend_regime_filtered_equities_4h",
         "trend_pullback_crypto_1h",
+        "trend_pullback_equities_4h",
         "vol_compression_breakout_crypto_1h",
         "vol_compression_breakout_crypto_4h",
         "crypto_diagnostic_1h",

--- a/tests/unit/test_hypothesis_discovery_minimal.py
+++ b/tests/unit/test_hypothesis_discovery_minimal.py
@@ -61,8 +61,13 @@ def test_behavior_hypotheses_are_active_discovery_only() -> None:
 def test_preset_feasibility_uses_existing_preset_bridge() -> None:
     feasible = pf.evaluate_preset_feasibility("trend_pullback_v1")
     assert feasible.feasible is True
-    assert feasible.preset_names == ("trend_pullback_crypto_1h",)
-    assert feasible.preset_feasibility_ref == "preset:trend_pullback_crypto_1h"
+    assert feasible.preset_names == (
+        "trend_pullback_crypto_1h",
+        "trend_pullback_equities_4h",
+    )
+    assert feasible.preset_feasibility_ref == (
+        "preset:trend_pullback_crypto_1h,trend_pullback_equities_4h"
+    )
 
     missing = pf.evaluate_preset_feasibility("unknown_hypothesis")
     assert missing.feasible is False

--- a/tests/unit/test_presets.py
+++ b/tests/unit/test_presets.py
@@ -24,20 +24,17 @@ from research.presets import (
 )
 
 
-def test_seven_presets_registered():
-    """v3.15.4 added ``vol_compression_breakout_crypto_1h`` as the
-    executable bridge for the second active_discovery catalog row
-    (volatility_compression_breakout_v0). v3.15.15 adds the 4h
-    timeframe variant ``vol_compression_breakout_crypto_4h`` so the
-    crypto_exploratory_v1 sprint profile can route the full
-    (1h, 4h) × (trend_pullback_v1, volatility_compression_breakout_v0)
-    matrix. Earlier presets keep their original positions to preserve
-    downstream consumers that snapshot the order."""
+def test_eight_presets_registered():
+    """The catalog keeps legacy baseline ordering while adding explicit
+    active-discovery bridges. The equity trend bridge is inserted next to
+    the existing trend_pullback crypto bridge so downstream snapshots can
+    detect intentional catalog growth."""
     assert [p.name for p in PRESETS] == [
         "trend_equities_4h_baseline",
         "pairs_equities_daily_baseline",
         "trend_regime_filtered_equities_4h",
         "trend_pullback_crypto_1h",
+        "trend_pullback_equities_4h",
         "vol_compression_breakout_crypto_1h",
         "vol_compression_breakout_crypto_4h",
         "crypto_diagnostic_1h",

--- a/tests/unit/test_v3_15_6_preset_phase_assignments.py
+++ b/tests/unit/test_v3_15_6_preset_phase_assignments.py
@@ -12,6 +12,7 @@ EXPECTED_PHASE_BY_NAME: dict[str, str] = {
     "pairs_equities_daily_baseline": "promotion_grade",
     "trend_regime_filtered_equities_4h": "promotion_grade",
     "trend_pullback_crypto_1h": "exploratory",
+    "trend_pullback_equities_4h": "exploratory",
     "vol_compression_breakout_crypto_1h": "exploratory",
     # v3.15.15 — 4h timeframe variant of the existing
     # volatility_compression_breakout_v0 hypothesis. Same screening


### PR DESCRIPTION
## Summary
- Add trend_pullback_equities_4h as a hypothesis-aware equity active-discovery preset for trend_pullback_v1.
- Add campaign templates for the new equity route by registering it in _HYPOTHESIS_AWARE_PRESETS.
- Keep trend_equities_4h_baseline unchanged as the existing promotion-grade baseline route.
- Update the campaign template count regression from 30 to 35 to account for the new five template rows.

## Validation
- python -m pytest tests/unit/test_v3_15_6_preset_phase_explicitness.py tests/unit/test_active_discovery_preset_bridge.py -q
- python -m pytest tests/regression/test_v3_15_2_campaign_templates_byte_identity.py tests/unit/test_campaign_policy.py tests/unit/test_campaign_policy_eligibility.py tests/unit/test_campaign_policy_hypothesis_status.py tests/unit/test_campaign_launcher_metadata_resolver.py tests/unit/test_campaign_os_artifacts.py tests/smoke/test_daily_preset_smoke.py -q
- python -m research.run_research --preset trend_pullback_equities_4h

## Run Evidence
- Planning produced 7 equity candidates.
- Screening completed with 5 rejected and 2 validation candidates.
- Validation completed with 2 validated candidates.
- Outputs were written and the run completed successfully.
- Runtime artifacts were reverted/removed from the worktree before commit.

## Safety
- No live/paper/shadow/risk/broker/execution paths changed.
- No changes to trend_equities_4h_baseline.
- No discovery_sprint changes.
- No strategy implementation changes.
- Config/template/test-only change.