### PR TITLE
fix: annotate validation evidence status

### DIFF
--- a/research/batch_execution.py
+++ b/research/batch_execution.py
@@ -11,6 +11,7 @@ from research.candidate_pipeline import (
     SCREENING_PROMOTED,
     sampling_plan_for_param_grid,
 )
+from research.promotion import DEFAULT_PROMOTION_CONFIG
 from research.registry import get_enabled_strategies
 from research.results import make_result_row
 from research.screening_process import execute_screening_candidate_isolated
@@ -60,6 +61,47 @@ def _sidecar_strategy_entry(
         "folds": folds,
         "leakage_checks_ok": report.get("leakage_checks_ok", False),
         "robustness": _compute_robustness(folds),
+    }
+
+
+
+def build_validation_evidence_status(
+    evaluation_report: dict[str, Any] | None,
+    *,
+    result_success: bool,
+) -> dict[str, Any]:
+    """Classify whether a technically completed validation has usable OOS evidence.
+
+    ``validation.status == "validated"`` means the validation pipeline completed.
+    This additive evidence status distinguishes that technical completion from
+    research-grade evidence sufficiency without changing the frozen status value.
+    """
+    min_oos_trades = int(DEFAULT_PROMOTION_CONFIG["min_oos_trades"])
+    if not result_success:
+        return {
+            "evidence_status": "validation_error",
+            "oos_trade_count": 0,
+            "min_oos_trades": min_oos_trades,
+        }
+
+    oos_summary = {}
+    if isinstance(evaluation_report, dict):
+        raw_oos_summary = evaluation_report.get("oos_summary")
+        if isinstance(raw_oos_summary, dict):
+            oos_summary = raw_oos_summary
+
+    oos_trade_count = int(oos_summary.get("totaal_trades") or 0)
+    if oos_trade_count <= 0:
+        evidence_status = "no_oos_trades"
+    elif oos_trade_count < min_oos_trades:
+        evidence_status = "insufficient_oos_trades"
+    else:
+        evidence_status = "sufficient_oos_evidence"
+
+    return {
+        "evidence_status": evidence_status,
+        "oos_trade_count": oos_trade_count,
+        "min_oos_trades": min_oos_trades,
     }
 
 
@@ -476,12 +518,17 @@ def execute_validation_batch(
 
             provenance_events.extend(getattr(engine, "_provenance_events", []))
             rows.append(row)
+            validation_evidence = build_validation_evidence_status(
+                evaluation_report if isinstance(evaluation_report, dict) else None,
+                result_success=bool(row["success"]),
+            )
             candidate_updates.append(
                 {
                     "candidate_id": str(candidate["candidate_id"]),
                     "validation": {
                         "status": "validated",
                         "result_success": bool(row["success"]),
+                        **validation_evidence,
                     },
                     "current_status": "validated",
                 }

--- a/research/run_research.py
+++ b/research/run_research.py
@@ -58,7 +58,11 @@ from research.batching import (
     build_run_batches_payload,
     partition_execution_batches,
 )
-from research.batch_execution import execute_screening_batch, execute_validation_batch
+from research.batch_execution import (
+    build_validation_evidence_status,
+    execute_screening_batch,
+    execute_validation_batch,
+)
 from research.campaigns import (
     build_campaign_id,
     build_run_campaign_payload,
@@ -3115,9 +3119,14 @@ def run_research(
                     for item in candidates:
                         if item["candidate_id"] != candidate["candidate_id"]:
                             continue
+                        validation_evidence = build_validation_evidence_status(
+                            evaluation_report if isinstance(evaluation_report, dict) else None,
+                            result_success=bool(row["success"]),
+                        )
                         item["validation"] = {
                             "status": "validated",
                             "result_success": bool(row["success"]),
+                            **validation_evidence,
                         }
                         item["current_status"] = "validated"
                         break

--- a/tests/unit/test_validation_evidence_status.py
+++ b/tests/unit/test_validation_evidence_status.py
@@ -1,0 +1,50 @@
+from research.batch_execution import build_validation_evidence_status
+
+
+def test_validation_evidence_status_no_oos_trades() -> None:
+    payload = build_validation_evidence_status(
+        {"oos_summary": {"totaal_trades": 0}},
+        result_success=True,
+    )
+
+    assert payload == {
+        "evidence_status": "no_oos_trades",
+        "oos_trade_count": 0,
+        "min_oos_trades": 10,
+    }
+
+
+def test_validation_evidence_status_insufficient_oos_trades() -> None:
+    payload = build_validation_evidence_status(
+        {"oos_summary": {"totaal_trades": 3}},
+        result_success=True,
+    )
+
+    assert payload == {
+        "evidence_status": "insufficient_oos_trades",
+        "oos_trade_count": 3,
+        "min_oos_trades": 10,
+    }
+
+
+def test_validation_evidence_status_sufficient_oos_evidence() -> None:
+    payload = build_validation_evidence_status(
+        {"oos_summary": {"totaal_trades": 10}},
+        result_success=True,
+    )
+
+    assert payload == {
+        "evidence_status": "sufficient_oos_evidence",
+        "oos_trade_count": 10,
+        "min_oos_trades": 10,
+    }
+
+
+def test_validation_evidence_status_validation_error() -> None:
+    payload = build_validation_evidence_status(None, result_success=False)
+
+    assert payload == {
+        "evidence_status": "validation_error",
+        "oos_trade_count": 0,
+        "min_oos_trades": 10,
+    }


### PR DESCRIPTION
﻿## Summary
- Add an additive validation evidence status next to the existing technical validation status.
- Keep validation.status="validated" unchanged for compatibility.
- Add evidence_status, oos_trade_count, and min_oos_trades to candidate validation payloads.
- Classify successful validations with zero OOS trades as no_oos_trades and thin OOS samples as insufficient_oos_trades.
- Reuse DEFAULT_PROMOTION_CONFIG min_oos_trades threshold.

## Validation
- git diff --check
- python -m py_compile research/batch_execution.py research/run_research.py
- python -m pytest tests/unit/test_validation_evidence_status.py tests/unit/test_candidate_promotion.py tests/unit/test_research_recovery.py -q
- python -m pytest tests/unit/test_candidate_pipeline.py tests/unit/test_evaluation_integrity.py tests/unit/test_empty_run_reporting.py -q
- python -m research.run_research --preset trend_pullback_equities_4h

## Run Evidence
- trend_pullback_equities_4h completed successfully.
- Screening produced 2 validation candidates: NVDA and TSM.
- Validation completed with 2 technically validated candidates.
- Both validated candidates now carry evidence_status=no_oos_trades, oos_trade_count=0, min_oos_trades=10.
- Runtime artifacts were reverted/removed from the worktree before commit.

## Safety
- Additive metadata only.
- No strategy logic changed.
- No live/paper/shadow/risk/broker/execution paths changed.
- No change to validation.status semantics.
- No frozen public output schema rename.
