### PR TITLE
fix: route validation evidence through follow-up loop

### DIFF
--- a/research/campaign_funnel_policy.py
+++ b/research/campaign_funnel_policy.py
@@ -73,6 +73,12 @@ FUNNEL_DECISION_COVERAGE_FOLLOWUP: Final[str] = (
 )
 FUNNEL_DECISION_COOLDOWN_REPEAT: Final[str] = "cooldown_from_repeat_rejection"
 FUNNEL_DECISION_NO_ACTION_TECHNICAL: Final[str] = "no_action_technical_failure"
+FUNNEL_DECISION_NO_OOS_VALIDATION_FOLLOWUP: Final[str] = (
+    "follow_up_from_no_oos_validation_evidence"
+)
+FUNNEL_DECISION_INSUFFICIENT_OOS_VALIDATION_FOLLOWUP: Final[str] = (
+    "follow_up_from_insufficient_validation_evidence"
+)
 
 
 DECISION_PRIORITY: Final[dict[str, int]] = {
@@ -81,7 +87,9 @@ DECISION_PRIORITY: Final[dict[str, int]] = {
     FUNNEL_DECISION_ALT_TIMEFRAME:       30,
     FUNNEL_DECISION_COVERAGE_FOLLOWUP:   40,
     FUNNEL_DECISION_COOLDOWN_REPEAT:     50,
-    FUNNEL_DECISION_NO_ACTION_TECHNICAL: 60,
+    FUNNEL_DECISION_NO_OOS_VALIDATION_FOLLOWUP:          35,
+    FUNNEL_DECISION_INSUFFICIENT_OOS_VALIDATION_FOLLOWUP: 36,
+    FUNNEL_DECISION_NO_ACTION_TECHNICAL:                  60,
 }
 
 
@@ -431,6 +439,12 @@ def derive_funnel_decisions(
         stage_result = str(record.get("stage_result") or "")
         failure_reasons = list(record.get("failure_reasons") or [])
         near_pass_block = record.get("near_pass") or {}
+        validation_evidence = record.get("validation_evidence") or {}
+        validation_evidence_status = (
+            str(validation_evidence.get("status") or "")
+            if isinstance(validation_evidence, dict)
+            else ""
+        )
 
         # 1) Confirmation from exploratory pass
         if stage_result == _EXPLORATORY_PASS_STAGE_RESULT:
@@ -496,7 +510,34 @@ def derive_funnel_decisions(
             )
             continue
 
-        # 3) Insufficient trades — alt-timeframe never supported today
+        # 3) Validation evidence follow-up signal.
+        if validation_evidence_status in {
+            "no_oos_trades",
+            "insufficient_oos_trades",
+        }:
+            decision_code = (
+                FUNNEL_DECISION_NO_OOS_VALIDATION_FOLLOWUP
+                if validation_evidence_status == "no_oos_trades"
+                else FUNNEL_DECISION_INSUFFICIENT_OOS_VALIDATION_FOLLOWUP
+            )
+            decisions.append(
+                FunnelDecision(
+                    decision_code=decision_code,
+                    candidate_id=candidate_id,
+                    strategy_id=strategy_id,
+                    preset_name=preset_name,
+                    priority=DECISION_PRIORITY[decision_code],
+                    spawn_request=None,
+                    rationale={
+                        "validation_evidence_status": validation_evidence_status,
+                        "oos_trade_count": validation_evidence.get("oos_trade_count"),
+                        "min_oos_trades": validation_evidence.get("min_oos_trades"),
+                    },
+                )
+            )
+            continue
+
+        # 4) Insufficient trades — alt-timeframe never supported today
         if (
             len(failure_reasons) == 1
             and failure_reasons[0] == "insufficient_trades"
@@ -521,7 +562,7 @@ def derive_funnel_decisions(
                 )
                 continue
 
-        # 4) Low coverage signal (sampling defect; no spawn)
+        # 5) Low coverage signal (sampling defect; no spawn)
         if _coverage_warning_signals_low(sampling):
             decisions.append(
                 FunnelDecision(
@@ -605,7 +646,9 @@ __all__ = [
     "FUNNEL_DECISION_COOLDOWN_REPEAT",
     "FUNNEL_DECISION_COVERAGE_FOLLOWUP",
     "FUNNEL_DECISION_NEAR_PASS_FOLLOWUP",
+    "FUNNEL_DECISION_INSUFFICIENT_OOS_VALIDATION_FOLLOWUP",
     "FUNNEL_DECISION_NO_ACTION_TECHNICAL",
+    "FUNNEL_DECISION_NO_OOS_VALIDATION_FOLLOWUP",
     "FunnelDecision",
     "LOW_COVERAGE_TRIGGER_PCT",
     "REPEAT_REJECTION_STREAK_THRESHOLD",

--- a/research/candidate_registry_v2.py
+++ b/research/candidate_registry_v2.py
@@ -77,13 +77,29 @@ def _asset_type(asset: str) -> str:
 def _lookup_run_candidate(
     run_candidates: dict[str, Any] | None,
     candidate_id: str,
+    *,
+    strategy_name: str | None = None,
+    asset: str | None = None,
+    interval: str | None = None,
 ) -> dict[str, Any] | None:
     if run_candidates is None:
         return None
+
+    fallback_match: dict[str, Any] | None = None
     for entry in run_candidates.get("candidates") or []:
         if entry.get("candidate_id") == candidate_id:
             return entry
-    return None
+        if (
+            fallback_match is None
+            and strategy_name is not None
+            and asset is not None
+            and interval is not None
+            and str(entry.get("strategy_name") or "") == str(strategy_name)
+            and str(entry.get("asset") or "") == str(asset)
+            and str(entry.get("interval") or "") == str(interval)
+        ):
+            fallback_match = entry
+    return fallback_match
 
 
 def _lookup_defensibility(
@@ -295,7 +311,13 @@ def build_registry_v2_payload(
             v1_entry.get("selected_params") or {},
         )
         research_row = research_rows_index.get(candidate_id)
-        run_candidate_entry = _lookup_run_candidate(run_candidates, candidate_id)
+        run_candidate_entry = _lookup_run_candidate(
+            run_candidates,
+            candidate_id,
+            strategy_name=str(v1_entry.get("strategy_name") or ""),
+            asset=str(v1_entry.get("asset") or ""),
+            interval=str(v1_entry.get("interval") or ""),
+        )
         entries.append(
             build_registry_v2_entry(
                 v1_entry={**v1_entry, "strategy_id": candidate_id},

--- a/research/candidate_registry_v2.py
+++ b/research/candidate_registry_v2.py
@@ -171,6 +171,13 @@ def build_registry_v2_entry(
         (run_candidate_entry or {}).get("current_status") or "validation"
     )
 
+    validation = (run_candidate_entry or {}).get("validation") or {}
+    validation_evidence = {
+        "status": validation.get("evidence_status"),
+        "oos_trade_count": validation.get("oos_trade_count"),
+        "min_oos_trades": validation.get("min_oos_trades"),
+    }
+
     strategy_family = (run_candidate_entry or {}).get("strategy_family") or v1_entry.get(
         "strategy_family"
     )
@@ -187,6 +194,7 @@ def build_registry_v2_entry(
         "interval": interval,
         "asset_universe": list(asset_universe or []),
         "processing_state": processing_state,
+        "validation_evidence": validation_evidence,
         "lifecycle_status": lifecycle_status.value,
         "legacy_verdict": legacy_verdict,
         "mapping_reason": mapping_reason,
@@ -220,15 +228,25 @@ def build_candidate_id(
 def _summarize(entries: list[dict[str, Any]]) -> dict[str, Any]:
     by_lifecycle: dict[str, int] = {}
     by_processing: dict[str, int] = {}
+    by_validation_evidence: dict[str, int] = {}
     for entry in entries:
         lc = entry.get("lifecycle_status", "unknown")
         ps = entry.get("processing_state", "unknown")
+        validation_evidence = entry.get("validation_evidence")
+        if isinstance(validation_evidence, dict):
+            evidence_status = validation_evidence.get("status") or "unknown"
+        else:
+            evidence_status = "unknown"
         by_lifecycle[lc] = by_lifecycle.get(lc, 0) + 1
         by_processing[ps] = by_processing.get(ps, 0) + 1
+        by_validation_evidence[str(evidence_status)] = (
+            by_validation_evidence.get(str(evidence_status), 0) + 1
+        )
     return {
         "total": len(entries),
         "by_lifecycle_status": by_lifecycle,
         "by_processing_state": by_processing,
+        "by_validation_evidence_status": by_validation_evidence,
     }
 
 

--- a/research/screening_evidence.py
+++ b/research/screening_evidence.py
@@ -125,6 +125,7 @@ PER_CANDIDATE_KEYS: Final[frozenset[str]] = frozenset(
         "criteria",
         "failure_reasons",
         "near_pass",
+        "validation_evidence",
         "sampling",
         "promotion_guard",
         "evidence_fingerprint",
@@ -417,6 +418,20 @@ def _build_candidate_record(
             near_payload.get("nearest_failed_criterion")
         )
 
+    validation = candidate.get("validation") or {}
+    if isinstance(validation, dict):
+        validation_evidence = {
+            "status": validation.get("evidence_status"),
+            "oos_trade_count": validation.get("oos_trade_count"),
+            "min_oos_trades": validation.get("min_oos_trades"),
+        }
+    else:
+        validation_evidence = {
+            "status": None,
+            "oos_trade_count": None,
+            "min_oos_trades": None,
+        }
+
     paper_blocked = bool(paper_blocking_reasons)
     stage_result = resolve_stage_result(
         screening_promoted=screening_promoted,
@@ -466,6 +481,7 @@ def _build_candidate_record(
         ),
         "failure_reasons": failure_reasons,
         "near_pass": near_block,
+        "validation_evidence": validation_evidence,
         "sampling": sampling,
         "promotion_guard": promotion_guard,
     }

--- a/tests/regression/test_v3_15_9_screening_evidence_schema_pin.py
+++ b/tests/regression/test_v3_15_9_screening_evidence_schema_pin.py
@@ -52,6 +52,7 @@ _EXPECTED_PER_CANDIDATE_KEYS = frozenset(
         "criteria",
         "failure_reasons",
         "near_pass",
+        "validation_evidence",
         "sampling",
         "promotion_guard",
         "evidence_fingerprint",
@@ -101,3 +102,45 @@ def test_emitted_payload_top_level_keys_match() -> None:
     )
     assert set(payload.keys()) == _EXPECTED_TOP_LEVEL_KEYS
     assert set(payload["summary"].keys()) == _EXPECTED_SUMMARY_KEYS
+
+def test_screening_evidence_carries_validation_evidence_status() -> None:
+    payload = build_screening_evidence_payload(
+        run_id="run-1",
+        as_of_utc=datetime(2026, 4, 26, 12, 0, 0, tzinfo=UTC),
+        git_revision="abc123",
+        campaign_id="cmp-1",
+        col_campaign_id="cmp-1",
+        preset_name="trend_pullback_equities_4h",
+        screening_phase="exploratory",
+        candidates=[
+            {
+                "candidate_id": "candidate-1",
+                "strategy_id": "trend_pullback_v1",
+                "strategy_name": "trend_pullback_v1",
+                "asset": "NVDA",
+                "interval": "4h",
+                "validation": {
+                    "status": "validated",
+                    "evidence_status": "no_oos_trades",
+                    "oos_trade_count": 0,
+                    "min_oos_trades": 10,
+                },
+            }
+        ],
+        screening_records=[
+            {
+                "candidate_id": "candidate-1",
+                "final_status": "passed",
+                "decision": "promoted_to_validation",
+                "diagnostic_metrics": {},
+            }
+        ],
+        screening_pass_kinds={"trend_pullback_v1": "exploratory"},
+        paper_blocked_index={},
+    )
+
+    assert payload["candidates"][0]["validation_evidence"] == {
+        "status": "no_oos_trades",
+        "oos_trade_count": 0,
+        "min_oos_trades": 10,
+    }

--- a/tests/unit/test_candidate_registry_v2.py
+++ b/tests/unit/test_candidate_registry_v2.py
@@ -108,6 +108,45 @@ def _run_meta() -> dict:
     }
 
 
+def _run_candidates(candidates: list[dict]) -> dict:
+    return {
+        "version": "v1",
+        "run_id": RUN_ID,
+        "candidates": candidates,
+    }
+
+
+def _run_candidate(
+    strategy_name: str = "sma_crossover",
+    asset: str = "NVDA",
+    interval: str = "4h",
+    evidence_status: str | None = "no_oos_trades",
+    oos_trade_count: int | None = 0,
+    min_oos_trades: int | None = 10,
+    candidate_id: str | None = None,
+) -> dict:
+    candidate_id = candidate_id or build_candidate_id(
+        strategy_name,
+        asset,
+        interval,
+        {"short": 10},
+    )
+    return {
+        "candidate_id": candidate_id,
+        "strategy_name": strategy_name,
+        "asset": asset,
+        "interval": interval,
+        "current_status": "validated",
+        "validation": {
+            "status": "validated",
+            "result_success": True,
+            "evidence_status": evidence_status,
+            "oos_trade_count": oos_trade_count,
+            "min_oos_trades": min_oos_trades,
+        },
+    }
+
+
 def test_payload_top_level_shape() -> None:
     payload = build_registry_v2_payload(
         candidate_registry_v1=_v1_registry([_v1_candidate()]),
@@ -436,3 +475,57 @@ def test_preset_origin_and_universe_populated_from_run_meta() -> None:
     (entry,) = payload["entries"]
     assert entry["preset_origin"] == "trend_equities_4h_baseline"
     assert entry["asset_universe"] == ["NVDA", "AMD", "ASML"]
+
+def test_entry_surfaces_validation_evidence_from_run_candidate() -> None:
+    v1_candidate = _v1_candidate()
+    payload = build_registry_v2_payload(
+        candidate_registry_v1=_v1_registry([v1_candidate]),
+        research_latest=_research_latest([_research_row()]),
+        run_candidates=_run_candidates([
+            _run_candidate(candidate_id=v1_candidate["strategy_id"]),
+        ]),
+        run_meta=_run_meta(),
+        defensibility=None,
+        regime=None,
+        cost_sens=None,
+        breadth_context=None,
+        run_id=RUN_ID,
+        git_revision=GIT,
+        generated_at_utc=NOW,
+    )
+
+    entry = payload["entries"][0]
+    assert entry["validation_evidence"] == {
+        "status": "no_oos_trades",
+        "oos_trade_count": 0,
+        "min_oos_trades": 10,
+    }
+    assert payload["summary"]["by_validation_evidence_status"] == {
+        "no_oos_trades": 1,
+    }
+
+
+def test_summary_counts_unknown_validation_evidence_when_run_candidate_missing() -> None:
+    payload = build_registry_v2_payload(
+        candidate_registry_v1=_v1_registry([_v1_candidate()]),
+        research_latest=_research_latest([_research_row()]),
+        run_candidates=None,
+        run_meta=_run_meta(),
+        defensibility=None,
+        regime=None,
+        cost_sens=None,
+        breadth_context=None,
+        run_id=RUN_ID,
+        git_revision=GIT,
+        generated_at_utc=NOW,
+    )
+
+    entry = payload["entries"][0]
+    assert entry["validation_evidence"] == {
+        "status": None,
+        "oos_trade_count": None,
+        "min_oos_trades": None,
+    }
+    assert payload["summary"]["by_validation_evidence_status"] == {
+        "unknown": 1,
+    }

--- a/tests/unit/test_candidate_registry_v2.py
+++ b/tests/unit/test_candidate_registry_v2.py
@@ -529,3 +529,31 @@ def test_summary_counts_unknown_validation_evidence_when_run_candidate_missing()
     assert payload["summary"]["by_validation_evidence_status"] == {
         "unknown": 1,
     }
+
+def test_entry_surfaces_validation_evidence_from_run_candidate_fallback_identity() -> None:
+    v1_candidate = _v1_candidate()
+    payload = build_registry_v2_payload(
+        candidate_registry_v1=_v1_registry([v1_candidate]),
+        research_latest=_research_latest([_research_row()]),
+        run_candidates=_run_candidates([
+            _run_candidate(candidate_id="different-runtime-id"),
+        ]),
+        run_meta=_run_meta(),
+        defensibility=None,
+        regime=None,
+        cost_sens=None,
+        breadth_context=None,
+        run_id=RUN_ID,
+        git_revision=GIT,
+        generated_at_utc=NOW,
+    )
+
+    entry = payload["entries"][0]
+    assert entry["validation_evidence"] == {
+        "status": "no_oos_trades",
+        "oos_trade_count": 0,
+        "min_oos_trades": 10,
+    }
+    assert payload["summary"]["by_validation_evidence_status"] == {
+        "no_oos_trades": 1,
+    }

--- a/tests/unit/test_v3_15_10_funnel_decisions.py
+++ b/tests/unit/test_v3_15_10_funnel_decisions.py
@@ -8,6 +8,8 @@ fallback.
 from __future__ import annotations
 
 from research.campaign_funnel_policy import (
+    FUNNEL_DECISION_INSUFFICIENT_OOS_VALIDATION_FOLLOWUP,
+    FUNNEL_DECISION_NO_OOS_VALIDATION_FOLLOWUP,
     ACTIVE_CAMPAIGN_STATES,
     DECISION_PRIORITY,
     FUNNEL_DECISION_CONFIRMATION,
@@ -426,3 +428,72 @@ def test_dedupe_returns_false_on_empty_registry() -> None:
         decision_code=FUNNEL_DECISION_CONFIRMATION,
         lineage_candidate_id="c", evidence_fingerprint="f",
     ) is False
+
+def test_no_oos_validation_evidence_emits_followup_decision() -> None:
+    decisions = derive_funnel_decisions(
+        evidence=_evidence(candidates=[
+            {
+                **_candidate(
+                    candidate_id="candidate-1",
+                    strategy_id="strategy-1",
+                    stage_result="validated",
+                    fp="fp-1",
+                ),
+                "validation_evidence": {
+                    "status": "no_oos_trades",
+                    "oos_trade_count": 0,
+                    "min_oos_trades": 10,
+                },
+            }
+        ]),
+        expected_campaign_id="cmp-1",
+        parent_campaign_record=_parent(),
+        registry={"campaigns": {}},
+        ledger_events=[],
+        preset_catalog={},
+    )
+
+    assert [d.decision_code for d in decisions] == [
+        FUNNEL_DECISION_NO_OOS_VALIDATION_FOLLOWUP,
+    ]
+    assert decisions[0].spawn_request is None
+    assert decisions[0].rationale == {
+        "validation_evidence_status": "no_oos_trades",
+        "oos_trade_count": 0,
+        "min_oos_trades": 10,
+    }
+
+
+def test_insufficient_oos_validation_evidence_emits_followup_decision() -> None:
+    decisions = derive_funnel_decisions(
+        evidence=_evidence(candidates=[
+            {
+                **_candidate(
+                    candidate_id="candidate-2",
+                    strategy_id="strategy-2",
+                    stage_result="validated",
+                    fp="fp-2",
+                ),
+                "validation_evidence": {
+                    "status": "insufficient_oos_trades",
+                    "oos_trade_count": 3,
+                    "min_oos_trades": 10,
+                },
+            }
+        ]),
+        expected_campaign_id="cmp-1",
+        parent_campaign_record=_parent(),
+        registry={"campaigns": {}},
+        ledger_events=[],
+        preset_catalog={},
+    )
+
+    assert [d.decision_code for d in decisions] == [
+        FUNNEL_DECISION_INSUFFICIENT_OOS_VALIDATION_FOLLOWUP,
+    ]
+    assert decisions[0].spawn_request is None
+    assert decisions[0].rationale == {
+        "validation_evidence_status": "insufficient_oos_trades",
+        "oos_trade_count": 3,
+        "min_oos_trades": 10,
+    }

--- a/tests/unit/test_v3_15_10_launcher_integration.py
+++ b/tests/unit/test_v3_15_10_launcher_integration.py
@@ -192,3 +192,46 @@ def test_dedupe_skips_already_recorded_funnel_decision(
     )
     types = [ev.event_type for ev in new_events]
     assert "funnel_decision_emitted" not in types
+
+def test_validation_evidence_followup_decision_is_emitted_to_ledger(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    Path("research").mkdir(parents=True, exist_ok=True)
+    import json
+
+    candidate = _exploratory_pass_candidate()
+    candidate.update({
+        "stage_result": "validated",
+        "pass_kind": None,
+        "validation_evidence": {
+            "status": "no_oos_trades",
+            "oos_trade_count": 0,
+            "min_oos_trades": 10,
+        },
+    })
+    Path("research/screening_evidence_latest.v1.json").write_text(
+        json.dumps(_evidence_payload(candidates=[candidate])),
+        encoding="utf-8",
+    )
+
+    new_events = campaign_launcher._apply_funnel_decisions(
+        registry=_registry_with_owner(),
+        events=[],
+        now_utc=datetime(2026, 4, 26, 12, 0, 0, tzinfo=UTC),
+    )
+
+    decision_event = next(
+        ev for ev in new_events if ev.event_type == "funnel_decision_emitted"
+    )
+    assert decision_event.extra["decision_code"] == (
+        "follow_up_from_no_oos_validation_evidence"
+    )
+    assert decision_event.extra["candidate_id"] == "c1"
+    assert decision_event.extra["strategy_id"] == "s1"
+    assert decision_event.extra["rationale"] == {
+        "validation_evidence_status": "no_oos_trades",
+        "oos_trade_count": 0,
+        "min_oos_trades": 10,
+    }
+    assert "spawn_request_pending" not in decision_event.extra


### PR DESCRIPTION
﻿## Summary
- Surface validation evidence status in candidate registry v2 entries and summary counts.
- Derive pure funnel decisions from validation evidence statuses:
  - no_oos_trades -> follow_up_from_no_oos_validation_evidence
  - insufficient_oos_trades -> follow_up_from_insufficient_validation_evidence
- Cover ledger/advisory visibility for validation-evidence funnel decisions.
- Carry validation evidence from run candidates into registry v2 and screening evidence artifacts.

## Scope
- Reporting/registry visibility: included.
- Pure funnel decision: included.
- Advisory ledger event coverage: included.
- Runtime data plumbing: included.
- Automatic campaign spawning: intentionally not included.

## Manual Run Evidence
- Ran: python -m research.run_research --preset trend_pullback_equities_4h
- Planning produced 7 equity candidates.
- Screening produced 5 rejected / near-pass candidates and 2 validation candidates.
- Validation completed with 2 technically validated candidates: NVDA and TSM.
- run_candidates_latest.v1.json showed NVDA and TSM with evidence_status=no_oos_trades, oos_trade_count=0, min_oos_trades=10.
- candidate_registry_latest.v2.json summary showed by_validation_evidence_status.no_oos_trades = 2.
- screening_evidence_latest.v1.json carried validation_evidence.status=no_oos_trades on the 2 screening_pass candidates.
- Runtime artifacts were reverted/removed from the worktree before commit.

## Validation
- git diff --check
- python -m py_compile research/candidate_registry_v2.py research/screening_evidence.py research/campaign_funnel_policy.py research/campaign_launcher.py
- python -m pytest tests/unit/test_candidate_registry_v2.py tests/regression/test_v3_15_9_screening_evidence_schema_pin.py tests/unit/test_v3_15_10_funnel_decisions.py tests/unit/test_v3_15_10_launcher_integration.py -q
- python -m pytest tests/unit/test_candidate_sidecars_facade.py tests/integration/test_v312_sidecars_e2e.py tests/integration/test_v3_15_12_funnel_spawn_proposer_pipeline.py tests/unit/test_v3_15_12_funnel_spawn_proposer.py -q

## Safety
- No live/paper/shadow/risk/broker/execution paths changed.
- No automatic campaign spawn added.
- Funnel validation-evidence decisions are advisory/ledger-visible only.
- Existing validation.status semantics remain unchanged.
- Existing funnel SpawnRequest behavior for exploratory pass and near-pass remains unchanged.
- Additive artifact fields only.
