### PR TITLE
fix: reject zero-trade exploratory screening candidates

### DIFF
--- a/research/screening_runtime.py
+++ b/research/screening_runtime.py
@@ -350,6 +350,14 @@ def execute_screening_candidate_samples(
             )
 
     legacy_decision = normalize_screening_decision(sample_results)
+    min_trades = int(getattr(engine, "min_trades", 10))
+    last_trade_count = int(last_metrics.get("totaal_trades", 0) or 0)
+    if legacy_decision["status"] == SCREENING_PROMOTED and last_trade_count < min_trades:
+        legacy_decision = {
+            "status": SCREENING_REJECTED,
+            "reason": "insufficient_trades",
+            "sampled_combination_count": len(sample_results),
+        }
     final_status = FINAL_STATUS_PASSED if legacy_decision["status"] == SCREENING_PROMOTED else FINAL_STATUS_REJECTED
     reason_code = legacy_decision.get("reason")
     reason_detail = None
@@ -376,6 +384,8 @@ def execute_screening_candidate_samples(
         "profit_factor": float(last_metrics.get("profit_factor", 0.0)),
         "win_rate": float(last_metrics.get("win_rate", 0.0)),
         "max_drawdown": float(last_metrics.get("max_drawdown", 0.0)),
+        "totaal_trades": float(last_metrics.get("totaal_trades", 0.0) or 0.0),
+        "trades_per_maand": float(last_metrics.get("trades_per_maand", 0.0) or 0.0),
     }
     return {
         "legacy_decision": legacy_decision,

--- a/tests/unit/test_screening_runtime.py
+++ b/tests/unit/test_screening_runtime.py
@@ -213,3 +213,50 @@ def test_execute_screening_candidate_resume_matches_fresh_result():
         if key not in {"started_at", "finished_at"}
     }
     assert resumed_comparable == comparable_keys
+
+def test_execute_screening_candidate_blocks_zero_trade_promoted_sample() -> None:
+    class ZeroTradePassLikeEngine:
+        min_trades = 10
+
+        def __init__(self):
+            self.last_evaluation_report = None
+
+        def run(self, strategie_func, assets, interval="1d"):
+            self.last_evaluation_report = {
+                "evaluation_samples": {
+                    "daily_returns": [0.0, 0.0],
+                }
+            }
+            return {
+                "expectancy": 1.0,
+                "profit_factor": 2.0,
+                "win_rate": 1.0,
+                "max_drawdown": 0.0,
+                "totaal_trades": 0,
+                "trades_per_maand": 0.0,
+                "goedgekeurd": True,
+            }
+
+    outcome = execute_screening_candidate(
+        strategy={
+            "factory": lambda **params: SimpleNamespace(params=params),
+            "params": {"periode": [14]},
+        },
+        candidate={"asset": "NVDA", "interval": "4h"},
+        engine=ZeroTradePassLikeEngine(),
+        budget_seconds=30,
+        max_samples=1,
+        screening_phase="exploratory",
+    )
+
+    assert outcome["decision"] == "rejected_in_screening"
+    assert outcome["final_status"] == "rejected"
+    assert outcome["reason_code"] == "insufficient_trades"
+    assert outcome["legacy_decision"] == {
+        "status": "rejected_in_screening",
+        "reason": "insufficient_trades",
+        "sampled_combination_count": 1,
+    }
+    assert outcome["pass_kind"] is None
+    assert outcome["diagnostic_metrics"]["totaal_trades"] == 0.0
+    assert outcome["diagnostic_metrics"]["trades_per_maand"] == 0.0


### PR DESCRIPTION
﻿## Summary
- Reject exploratory screening candidates when the final candidate-level decision would promote a zero/thin-trade sample.
- Add a defensive aggregate safety gate in screening_runtime so promoted outcomes with last_metrics.totaal_trades below engine.min_trades are converted to rejected_in_screening / insufficient_trades.
- Surface totaal_trades and trades_per_maand in screening diagnostic_metrics.
- Add unit coverage for a zero-trade pass-like exploratory sample.

## Manual Run Evidence
- Ran: python -m research.run_research --preset trend_pullback_equities_4h
- Before this fix, NVDA and TSM were promoted to validation despite zero-trade metrics and later surfaced as no_oos_trades.
- After this fix:
  - screening_rejected_count = 7
  - validation_candidate_count = 0
  - promoted_to_validation = 0
  - rejected_in_screening = 7
  - NVDA and TSM are rejected in screening with reason_code=insufficient_trades
- The run then fails with DegenerateResearchRunError because there are no validation candidates, which is expected for this diagnostic route after the stricter screen.

## Validation
- git diff --check
- python -m py_compile research/screening_runtime.py
- python -m pytest tests/unit/test_screening_runtime.py tests/unit/test_v3_15_7_screening_reason_codes_extended.py tests/unit/test_v3_15_9_per_candidate_schema_pin.py tests/regression/test_v3_15_9_screening_evidence_schema_pin.py -q
- python -m pytest tests/unit/test_candidate_pipeline.py tests/unit/test_empty_run_reporting.py tests/unit/test_research_recovery.py -q

## Safety
- No live/paper/shadow/risk/broker/execution paths changed.
- Screening-only guard.
- Existing insufficient_trades reason code reused.
- No automatic campaign spawning added.
- Prevents zero-trade exploratory candidates from entering validation/follow-up loops.
