### PR TITLE
fix: preserve screening diagnostics for promoted samples

### DIFF
--- a/research/screening_runtime.py
+++ b/research/screening_runtime.py
@@ -271,6 +271,7 @@ def execute_screening_candidate_samples(
     # observability even when the loop terminates without a winning
     # sample.
     last_metrics: dict[str, Any] = {}
+    promoted_metrics: dict[str, Any] | None = None
 
     for sample_index, (_params, strategy_callable) in enumerate(strategy_samples):
         if sample_index < len(sample_results):
@@ -331,6 +332,7 @@ def execute_screening_candidate_samples(
                 # duplicated inside ``apply_phase_aware_criteria``.
                 passed, reason = apply_phase_aware_criteria(metrics, screening_phase)
                 if passed:
+                    promoted_metrics = dict(metrics)
                     sample_results.append({"status": SCREENING_PROMOTED, "reason": None})
                 else:
                     sample_results.append({"status": SCREENING_REJECTED, "reason": reason})
@@ -352,7 +354,7 @@ def execute_screening_candidate_samples(
     legacy_decision = normalize_screening_decision(sample_results)
     min_trades = int(getattr(engine, "min_trades", 10))
     last_trade_count = int(last_metrics.get("totaal_trades", 0) or 0)
-    if last_trade_count < min_trades:
+    if legacy_decision["status"] != SCREENING_PROMOTED and last_trade_count < min_trades:
         legacy_decision = {
             "status": SCREENING_REJECTED,
             "reason": "insufficient_trades",
@@ -365,8 +367,8 @@ def execute_screening_candidate_samples(
         reason_detail = f"screening rejected after {len(sample_results)} sampled parameter combinations"
     # v3.15.7: additive outcome fields for phase-aware visibility.
     # ``pass_kind`` is set ONLY on screening pass (mirrors phase);
-    # rejected â†’ None (failure semantics live in reason_code).
-    # NB: NO ``screening_phase`` key here â€” v3.15.6 invariant.
+    # rejected -> None (failure semantics live in reason_code).
+    # NB: NO ``screening_phase`` key here ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã‚Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â v3.15.6 invariant.
     pass_kind: str | None
     if legacy_decision["status"] == SCREENING_PROMOTED:
         pass_kind = screening_phase
@@ -377,15 +379,20 @@ def execute_screening_candidate_samples(
     )
     # JSON-safe finite floats (engine.profit_factor uses
     # PROFIT_FACTOR_NO_LOSS_CAP; expectancy is a finite mean).
-    # ``last_metrics`` holds the most recent sample's metrics dict
-    # (or {} when no sample produced metrics yet).
+    # `selected_metrics` reports the sample that explains the aggregate decision:
+    # promoted sample metrics for passes, last sample metrics for rejections.
+    selected_metrics = (
+        promoted_metrics
+        if legacy_decision["status"] == SCREENING_PROMOTED and promoted_metrics is not None
+        else last_metrics
+    )
     diagnostic_metrics = {
-        "expectancy": float(last_metrics.get("expectancy", 0.0)),
-        "profit_factor": float(last_metrics.get("profit_factor", 0.0)),
-        "win_rate": float(last_metrics.get("win_rate", 0.0)),
-        "max_drawdown": float(last_metrics.get("max_drawdown", 0.0)),
-        "totaal_trades": float(last_metrics.get("totaal_trades", 0.0) or 0.0),
-        "trades_per_maand": float(last_metrics.get("trades_per_maand", 0.0) or 0.0),
+        "expectancy": float(selected_metrics.get("expectancy", 0.0)),
+        "profit_factor": float(selected_metrics.get("profit_factor", 0.0)),
+        "win_rate": float(selected_metrics.get("win_rate", 0.0)),
+        "max_drawdown": float(selected_metrics.get("max_drawdown", 0.0)),
+        "totaal_trades": float(selected_metrics.get("totaal_trades", 0.0) or 0.0),
+        "trades_per_maand": float(selected_metrics.get("trades_per_maand", 0.0) or 0.0),
     }
     return {
         "legacy_decision": legacy_decision,
@@ -399,11 +406,11 @@ def execute_screening_candidate_samples(
         "decision": legacy_decision["status"],
         "reason_code": reason_code,
         "reason_detail": reason_detail,
-        # v3.15.7 additive â€” non-frozen screening sidecar surfaces only.
+        # v3.15.7 additive -- non-frozen screening sidecar surfaces only.
         "pass_kind": pass_kind,
         "screening_criteria_set": screening_criteria_set,
         "diagnostic_metrics": diagnostic_metrics,
-        # v3.15.8 additive â€” sampling-policy metadata for the
+        # v3.15.8 additive -- sampling-policy metadata for the
         # screening evidence artifact (v3.15.9) and campaign
         # funnel policy (v3.15.10). Always present, even on
         # legacy/no-engine/error/timeout paths.

--- a/research/screening_runtime.py
+++ b/research/screening_runtime.py
@@ -352,7 +352,7 @@ def execute_screening_candidate_samples(
     legacy_decision = normalize_screening_decision(sample_results)
     min_trades = int(getattr(engine, "min_trades", 10))
     last_trade_count = int(last_metrics.get("totaal_trades", 0) or 0)
-    if legacy_decision["status"] == SCREENING_PROMOTED and last_trade_count < min_trades:
+    if last_trade_count < min_trades:
         legacy_decision = {
             "status": SCREENING_REJECTED,
             "reason": "insufficient_trades",
@@ -365,8 +365,8 @@ def execute_screening_candidate_samples(
         reason_detail = f"screening rejected after {len(sample_results)} sampled parameter combinations"
     # v3.15.7: additive outcome fields for phase-aware visibility.
     # ``pass_kind`` is set ONLY on screening pass (mirrors phase);
-    # rejected → None (failure semantics live in reason_code).
-    # NB: NO ``screening_phase`` key here — v3.15.6 invariant.
+    # rejected â†’ None (failure semantics live in reason_code).
+    # NB: NO ``screening_phase`` key here â€” v3.15.6 invariant.
     pass_kind: str | None
     if legacy_decision["status"] == SCREENING_PROMOTED:
         pass_kind = screening_phase
@@ -399,11 +399,11 @@ def execute_screening_candidate_samples(
         "decision": legacy_decision["status"],
         "reason_code": reason_code,
         "reason_detail": reason_detail,
-        # v3.15.7 additive — non-frozen screening sidecar surfaces only.
+        # v3.15.7 additive â€” non-frozen screening sidecar surfaces only.
         "pass_kind": pass_kind,
         "screening_criteria_set": screening_criteria_set,
         "diagnostic_metrics": diagnostic_metrics,
-        # v3.15.8 additive — sampling-policy metadata for the
+        # v3.15.8 additive â€” sampling-policy metadata for the
         # screening evidence artifact (v3.15.9) and campaign
         # funnel policy (v3.15.10). Always present, even on
         # legacy/no-engine/error/timeout paths.

--- a/tests/unit/test_screening_runtime.py
+++ b/tests/unit/test_screening_runtime.py
@@ -260,3 +260,50 @@ def test_execute_screening_candidate_blocks_zero_trade_promoted_sample() -> None
     assert outcome["pass_kind"] is None
     assert outcome["diagnostic_metrics"]["totaal_trades"] == 0.0
     assert outcome["diagnostic_metrics"]["trades_per_maand"] == 0.0
+
+
+def test_execute_screening_candidate_relabels_zero_trade_rejected_sample() -> None:
+    class ZeroTradeRejectedLikeEngine:
+        min_trades = 10
+
+        def __init__(self):
+            self.last_evaluation_report = None
+
+        def run(self, strategie_func, assets, interval="1d"):
+            self.last_evaluation_report = {
+                "evaluation_samples": {
+                    "daily_returns": [0.0, 0.0],
+                }
+            }
+            return {
+                "expectancy": 0.0,
+                "profit_factor": 0.0,
+                "win_rate": 0.0,
+                "max_drawdown": 0.0,
+                "totaal_trades": 0,
+                "trades_per_maand": 0.0,
+                "goedgekeurd": False,
+            }
+
+    outcome = execute_screening_candidate(
+        strategy={
+            "factory": lambda **params: SimpleNamespace(params=params),
+            "params": {"periode": [14]},
+        },
+        candidate={"asset": "AMD", "interval": "4h"},
+        engine=ZeroTradeRejectedLikeEngine(),
+        budget_seconds=30,
+        max_samples=1,
+        screening_phase="exploratory",
+    )
+
+    assert outcome["decision"] == "rejected_in_screening"
+    assert outcome["final_status"] == "rejected"
+    assert outcome["reason_code"] == "insufficient_trades"
+    assert outcome["legacy_decision"] == {
+        "status": "rejected_in_screening",
+        "reason": "insufficient_trades",
+        "sampled_combination_count": 1,
+    }
+    assert outcome["diagnostic_metrics"]["totaal_trades"] == 0.0
+    assert outcome["diagnostic_metrics"]["trades_per_maand"] == 0.0

--- a/tests/unit/test_screening_runtime.py
+++ b/tests/unit/test_screening_runtime.py
@@ -307,3 +307,65 @@ def test_execute_screening_candidate_relabels_zero_trade_rejected_sample() -> No
     }
     assert outcome["diagnostic_metrics"]["totaal_trades"] == 0.0
     assert outcome["diagnostic_metrics"]["trades_per_maand"] == 0.0
+
+
+def test_execute_screening_candidate_keeps_promoted_sample_when_later_sample_insufficient() -> None:
+    class MixedSampleEngine:
+        min_trades = 10
+
+        def __init__(self):
+            self.last_evaluation_report = None
+            self.calls = 0
+
+        def run(self, strategie_func, assets, interval="1d"):
+            self.calls += 1
+            self.last_evaluation_report = {
+                "evaluation_samples": {
+                    "daily_returns": [0.01, -0.01],
+                }
+            }
+            if self.calls == 1:
+                return {
+                    "expectancy": 0.02,
+                    "profit_factor": 2.0,
+                    "win_rate": 0.6,
+                    "max_drawdown": 0.05,
+                    "totaal_trades": 12,
+                    "trades_per_maand": 1.0,
+                    "goedgekeurd": True,
+                }
+            return {
+                "expectancy": 0.0,
+                "profit_factor": 0.0,
+                "win_rate": 0.0,
+                "max_drawdown": 0.0,
+                "totaal_trades": 0,
+                "trades_per_maand": 0.0,
+                "goedgekeurd": False,
+            }
+
+    outcome = execute_screening_candidate(
+        strategy={
+            "factory": lambda **params: SimpleNamespace(params=params),
+            "params": {"periode": [14, 21]},
+        },
+        candidate={"asset": "NVDA", "interval": "4h"},
+        engine=MixedSampleEngine(),
+        budget_seconds=30,
+        max_samples=2,
+        screening_phase="exploratory",
+    )
+
+    assert outcome["decision"] == "promoted_to_validation"
+    assert outcome["final_status"] == "passed"
+    assert outcome["reason_code"] is None
+    assert outcome["legacy_decision"] == {
+        "status": "promoted_to_validation",
+        "reason": None,
+        "sampled_combination_count": 2,
+    }
+    assert outcome["diagnostic_metrics"]["expectancy"] == 0.02
+    assert outcome["diagnostic_metrics"]["profit_factor"] == 2.0
+    assert outcome["diagnostic_metrics"]["win_rate"] == 0.6
+    assert outcome["diagnostic_metrics"]["totaal_trades"] == 12.0
+    assert outcome["diagnostic_metrics"]["trades_per_maand"] == 1.0


### PR DESCRIPTION
## Summary
- classify rejected below-min-trade aggregate screening outcomes as insufficient_trades without overriding promoted aggregate decisions
- keep promoted screening decisions when later sampled parameter combinations are insufficient
- report diagnostic_metrics from the promoted sample instead of the last sampled combination
- add regression coverage for zero-trade rejected samples and promoted-then-insufficient mixed samples

## Validation
- python -m py_compile .\research\screening_runtime.py
- python -m pytest .\tests\unit\test_screening_runtime.py -q
- python -m pytest .\tests\unit\test_screening_runtime.py .\tests\unit\test_v3_15_7_screening_reason_codes_extended.py .\tests\unit\test_v3_15_9_per_candidate_schema_pin.py .\tests\regression\test_v3_15_9_screening_evidence_schema_pin.py -q
- python -m research.run_research --preset trend_pullback_equities_4h

## Runtime result
- trend_pullback_equities_4h completed successfully
- screening_rejected_count=5
- validation_candidate_count=2
- validated_count=2
- results_written=2
- NVDA promoted with diagnostic_metrics.totaal_trades=18.0
- TSM promoted with diagnostic_metrics.totaal_trades=26.0
- no paper/shadow/live/risk/broker/execution behavior changed