### PR TITLE
feat: add screening sample diagnostics

### DIFF
--- a/research/screening_criteria.py
+++ b/research/screening_criteria.py
@@ -1,35 +1,35 @@
-"""v3.15.7 — phase-aware screening criteria dispatch.
+"""v3.15.7 â€” phase-aware screening criteria dispatch.
 
 Pure module, no IO. Called from
 ``research.screening_runtime.execute_screening_candidate_samples``
 after each engine sample. The caller owns the trade-count
 pre-check (``engine.min_trades``) and the OOS-data pre-check
-(``no_oos_samples``) — this helper assumes data validity and only
+(``no_oos_samples``) â€” this helper assumes data validity and only
 performs phase-specific gating on the metrics dict.
 
 Funnel discipline:
 
-- Screening zoekt — exploratory criteria minimaliseren false
+- Screening zoekt â€” exploratory criteria minimaliseren false
   negatives so trend/momentum candidates with positive expectancy
   but low win_rate can pass for shortlist.
-- Promotion bewijst — promotion_grade keeps the strict v3.15.6
+- Promotion bewijst â€” promotion_grade keeps the strict v3.15.6
   gates byte-identical (delegated to the engine ``goedgekeurd``
   AND-gate).
-- Paper valideert — exploratory passes are downgraded to
+- Paper valideert â€” exploratory passes are downgraded to
   ``needs_investigation`` by ``promotion.classify_candidate`` so
   they NEVER auto-promote to paper.
 
 Phase semantics:
 
-- ``screening_phase == "exploratory"`` → exploratory criteria;
+- ``screening_phase == "exploratory"`` â†’ exploratory criteria;
   win_rate is diagnostic-only (not a hard gate).
 - ``screening_phase`` in {``"standard"``, ``"promotion_grade"``,
-  ``None``} → legacy ``goedgekeurd`` AND-gate; behavior is
+  ``None``} â†’ legacy ``goedgekeurd`` AND-gate; behavior is
   byte-identical to pre-v3.15.7.
 
 Threshold values are start-points; v3.15.8+ may recalibrate based
 on empirical evidence. v3.15.7 introduces no
-``EXPLORATORY_MIN_TRADES`` constant — the trade-count gate lives
+``EXPLORATORY_MIN_TRADES`` constant â€” the trade-count gate lives
 upstream in ``screening_runtime`` via ``engine.min_trades`` to
 avoid duplicate-gate drift.
 """
@@ -83,3 +83,10 @@ def _exploratory_criteria(metrics: dict[str, Any]) -> tuple[bool, str | None]:
         return False, "drawdown_above_exploratory_limit"
 
     return True, None
+def build_exploratory_criteria_checks(metrics: dict[str, object], min_trades: int) -> dict[str, bool]:
+    return {
+        "sufficient_trades": float(metrics.get("totaal_trades", 0.0) or 0.0) >= float(min_trades),
+        "expectancy_above_zero": float(metrics.get("expectancy", 0.0)) > EXPLORATORY_MIN_EXPECTANCY,
+        "profit_factor_at_or_above_floor": float(metrics.get("profit_factor", 0.0)) >= EXPLORATORY_MIN_PROFIT_FACTOR,
+        "drawdown_within_limit": float(metrics.get("max_drawdown", 1.0)) <= EXPLORATORY_MAX_DRAWDOWN,
+    }

--- a/research/screening_runtime.py
+++ b/research/screening_runtime.py
@@ -230,6 +230,52 @@ def _sample_diagnostic(
         },
     }
 
+def _sample_diagnostics_summary(sample_diagnostics: list[dict[str, Any]]) -> dict[str, Any]:
+    reason_counts = Counter(
+        str(item.get("reason") or "passed")
+        for item in sample_diagnostics
+    )
+    promoted_count = sum(
+        1 for item in sample_diagnostics
+        if item.get("status") == SCREENING_PROMOTED
+    )
+    rejected_count = sum(
+        1 for item in sample_diagnostics
+        if item.get("status") == SCREENING_REJECTED
+    )
+    eligible_best_samples = [
+        item for item in sample_diagnostics
+        if item.get("criteria_checks", {}).get("sufficient_trades") is True
+    ]
+    best_sample_pool = eligible_best_samples or sample_diagnostics
+    best_sample = max(
+        best_sample_pool,
+        key=lambda item: (
+            float(item.get("metrics", {}).get("expectancy", 0.0)),
+            float(item.get("metrics", {}).get("profit_factor", 0.0)),
+            float(item.get("metrics", {}).get("totaal_trades", 0.0)),
+        ),
+        default=None,
+    )
+
+    if best_sample is None:
+        best_sample_index = None
+        best_metrics: dict[str, Any] = {}
+    else:
+        best_sample_index = int(best_sample["sample_index"])
+        best_metrics = dict(best_sample.get("metrics", {}))
+
+    return {
+        "sample_count": len(sample_diagnostics),
+        "promoted_sample_count": int(promoted_count),
+        "rejected_sample_count": int(rejected_count),
+        "rejection_reason_counts": dict(sorted(reason_counts.items())),
+        "best_sample_index": best_sample_index,
+        "best_expectancy": float(best_metrics.get("expectancy", 0.0)),
+        "best_profit_factor": float(best_metrics.get("profit_factor", 0.0)),
+        "best_totaal_trades": float(best_metrics.get("totaal_trades", 0.0)),
+    }
+
 def execute_screening_candidate_samples(
     *,
     candidate: dict[str, Any],
@@ -463,6 +509,7 @@ def execute_screening_candidate_samples(
         "screening_criteria_set": screening_criteria_set,
         "diagnostic_metrics": diagnostic_metrics,
         "sample_diagnostics": sample_diagnostics,
+        "sample_diagnostics_summary": _sample_diagnostics_summary(sample_diagnostics),
         # v3.15.8 additive -- sampling-policy metadata for the
         # screening evidence artifact (v3.15.9) and campaign
         # funnel policy (v3.15.10). Always present, even on

--- a/research/screening_runtime.py
+++ b/research/screening_runtime.py
@@ -16,7 +16,12 @@ from research.candidate_pipeline import (
     normalize_screening_decision,
     sampling_plan_for_param_grid,
 )
-from research.screening_criteria import apply_phase_aware_criteria
+from research.screening_criteria import (
+    EXPLORATORY_MAX_DRAWDOWN,
+    EXPLORATORY_MIN_EXPECTANCY,
+    EXPLORATORY_MIN_PROFIT_FACTOR,
+    apply_phase_aware_criteria,
+)
 
 FINAL_STATUS_PASSED = "passed"
 FINAL_STATUS_REJECTED = "rejected"
@@ -201,12 +206,20 @@ def _sample_diagnostic(
     status: str,
     reason: str | None,
     metrics: dict[str, Any],
+    min_trades: int,
 ) -> dict[str, Any]:
+    criteria_checks = {
+        "sufficient_trades": float(metrics.get("totaal_trades", 0.0) or 0.0) >= float(min_trades),
+        "expectancy_above_zero": float(metrics.get("expectancy", 0.0)) > EXPLORATORY_MIN_EXPECTANCY,
+        "profit_factor_at_or_above_floor": float(metrics.get("profit_factor", 0.0)) >= EXPLORATORY_MIN_PROFIT_FACTOR,
+        "drawdown_within_limit": float(metrics.get("max_drawdown", 1.0)) <= EXPLORATORY_MAX_DRAWDOWN,
+    }
     return {
         "sample_index": int(sample_index),
         "params": dict(params),
         "status": status,
         "reason": reason,
+        "criteria_checks": criteria_checks,
         "metrics": {
             "expectancy": float(metrics.get("expectancy", 0.0)),
             "profit_factor": float(metrics.get("profit_factor", 0.0)),
@@ -372,6 +385,7 @@ def execute_screening_candidate_samples(
                 status=sample_status,
                 reason=sample_reason,
                 metrics=last_metrics,
+                min_trades=int(getattr(engine, "min_trades", 10)),
             )
         )
         if on_checkpoint is not None:

--- a/research/screening_runtime.py
+++ b/research/screening_runtime.py
@@ -194,6 +194,29 @@ def build_screening_sidecar_payload(
     }
 
 
+def _sample_diagnostic(
+    *,
+    sample_index: int,
+    params: dict[str, Any],
+    status: str,
+    reason: str | None,
+    metrics: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "sample_index": int(sample_index),
+        "params": dict(params),
+        "status": status,
+        "reason": reason,
+        "metrics": {
+            "expectancy": float(metrics.get("expectancy", 0.0)),
+            "profit_factor": float(metrics.get("profit_factor", 0.0)),
+            "win_rate": float(metrics.get("win_rate", 0.0)),
+            "max_drawdown": float(metrics.get("max_drawdown", 0.0)),
+            "totaal_trades": float(metrics.get("totaal_trades", 0.0) or 0.0),
+            "trades_per_maand": float(metrics.get("trades_per_maand", 0.0) or 0.0),
+        },
+    }
+
 def execute_screening_candidate_samples(
     *,
     candidate: dict[str, Any],
@@ -272,6 +295,7 @@ def execute_screening_candidate_samples(
     # sample.
     last_metrics: dict[str, Any] = {}
     promoted_metrics: dict[str, Any] | None = None
+    sample_diagnostics: list[dict[str, Any]] = []
 
     for sample_index, (_params, strategy_callable) in enumerate(strategy_samples):
         if sample_index < len(sample_results):
@@ -320,22 +344,36 @@ def execute_screening_candidate_samples(
         report = getattr(engine, "last_evaluation_report", None) or {}
         evaluation_samples = report.get("evaluation_samples") or {}
         daily_returns = evaluation_samples.get("daily_returns") or []
+        sample_status = SCREENING_REJECTED
+        sample_reason: str | None = None
         if not isinstance(daily_returns, list) or not daily_returns:
-            sample_results.append({"status": SCREENING_REJECTED, "reason": "no_oos_samples"})
+            sample_reason = "no_oos_samples"
         else:
             min_trades = int(getattr(engine, "min_trades", 10))
             if int(metrics.get("totaal_trades", 0)) < min_trades:
-                sample_results.append({"status": SCREENING_REJECTED, "reason": "insufficient_trades"})
+                sample_reason = "insufficient_trades"
             else:
                 # v3.15.7: phase-aware criteria dispatch. Pre-checks
                 # above (no_oos_samples / insufficient_trades) are NOT
                 # duplicated inside ``apply_phase_aware_criteria``.
                 passed, reason = apply_phase_aware_criteria(metrics, screening_phase)
                 if passed:
+                    sample_status = SCREENING_PROMOTED
                     promoted_metrics = dict(metrics)
-                    sample_results.append({"status": SCREENING_PROMOTED, "reason": None})
+                    sample_reason = None
                 else:
-                    sample_results.append({"status": SCREENING_REJECTED, "reason": reason})
+                    sample_reason = reason
+
+        sample_results.append({"status": sample_status, "reason": sample_reason})
+        sample_diagnostics.append(
+            _sample_diagnostic(
+                sample_index=sample_index,
+                params=dict(_params),
+                status=sample_status,
+                reason=sample_reason,
+                metrics=last_metrics,
+            )
+        )
         if on_checkpoint is not None:
             on_checkpoint(sample_results)
 
@@ -368,7 +406,7 @@ def execute_screening_candidate_samples(
     # v3.15.7: additive outcome fields for phase-aware visibility.
     # ``pass_kind`` is set ONLY on screening pass (mirrors phase);
     # rejected -> None (failure semantics live in reason_code).
-    # NB: NO ``screening_phase`` key here ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã‚Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â v3.15.6 invariant.
+    # NB: NO ``screening_phase`` key here -- v3.15.6 invariant.
     pass_kind: str | None
     if legacy_decision["status"] == SCREENING_PROMOTED:
         pass_kind = screening_phase
@@ -410,6 +448,7 @@ def execute_screening_candidate_samples(
         "pass_kind": pass_kind,
         "screening_criteria_set": screening_criteria_set,
         "diagnostic_metrics": diagnostic_metrics,
+        "sample_diagnostics": sample_diagnostics,
         # v3.15.8 additive -- sampling-policy metadata for the
         # screening evidence artifact (v3.15.9) and campaign
         # funnel policy (v3.15.10). Always present, even on

--- a/research/screening_runtime.py
+++ b/research/screening_runtime.py
@@ -199,6 +199,42 @@ def build_screening_sidecar_payload(
     }
 
 
+def _trade_distribution(trade_pnls: list[Any]) -> dict[str, Any]:
+    values = [float(value) for value in trade_pnls]
+    wins = [value for value in values if value > 0.0]
+    losses = [value for value in values if value < 0.0]
+
+    def _avg(items: list[float]) -> float:
+        return float(sum(items) / len(items)) if items else 0.0
+
+    sorted_values = sorted(values)
+    if not sorted_values:
+        median = 0.0
+    elif len(sorted_values) % 2 == 1:
+        median = float(sorted_values[len(sorted_values) // 2])
+    else:
+        hi = len(sorted_values) // 2
+        median = float((sorted_values[hi - 1] + sorted_values[hi]) / 2.0)
+
+    avg_win = _avg(wins)
+    avg_loss = _avg(losses)
+    win_loss_ratio = (
+        float(avg_win / abs(avg_loss))
+        if avg_win > 0.0 and avg_loss < 0.0
+        else 0.0
+    )
+
+    return {
+        "trade_count": len(values),
+        "avg_trade_pnl": round(_avg(values), 6),
+        "median_trade_pnl": round(median, 6),
+        "avg_win": round(avg_win, 6),
+        "avg_loss": round(avg_loss, 6),
+        "largest_win": round(max(wins), 6) if wins else 0.0,
+        "largest_loss": round(min(losses), 6) if losses else 0.0,
+        "win_loss_ratio": round(win_loss_ratio, 6),
+    }
+
 def _sample_diagnostic(
     *,
     sample_index: int,
@@ -207,6 +243,7 @@ def _sample_diagnostic(
     reason: str | None,
     metrics: dict[str, Any],
     min_trades: int,
+    trade_pnls: list[Any],
 ) -> dict[str, Any]:
     criteria_checks = {
         "sufficient_trades": float(metrics.get("totaal_trades", 0.0) or 0.0) >= float(min_trades),
@@ -220,6 +257,7 @@ def _sample_diagnostic(
         "status": status,
         "reason": reason,
         "criteria_checks": criteria_checks,
+        "trade_distribution": _trade_distribution(trade_pnls),
         "metrics": {
             "expectancy": float(metrics.get("expectancy", 0.0)),
             "profit_factor": float(metrics.get("profit_factor", 0.0)),
@@ -403,6 +441,7 @@ def execute_screening_candidate_samples(
         report = getattr(engine, "last_evaluation_report", None) or {}
         evaluation_samples = report.get("evaluation_samples") or {}
         daily_returns = evaluation_samples.get("daily_returns") or []
+        trade_pnls = evaluation_samples.get("trade_pnls") or []
         sample_status = SCREENING_REJECTED
         sample_reason: str | None = None
         if not isinstance(daily_returns, list) or not daily_returns:
@@ -432,6 +471,7 @@ def execute_screening_candidate_samples(
                 reason=sample_reason,
                 metrics=last_metrics,
                 min_trades=int(getattr(engine, "min_trades", 10)),
+                trade_pnls=list(trade_pnls),
             )
         )
         if on_checkpoint is not None:

--- a/research/screening_runtime.py
+++ b/research/screening_runtime.py
@@ -16,12 +16,8 @@ from research.candidate_pipeline import (
     normalize_screening_decision,
     sampling_plan_for_param_grid,
 )
-from research.screening_criteria import (
-    EXPLORATORY_MAX_DRAWDOWN,
-    EXPLORATORY_MIN_EXPECTANCY,
-    EXPLORATORY_MIN_PROFIT_FACTOR,
-    apply_phase_aware_criteria,
-)
+from research.screening_criteria import apply_phase_aware_criteria
+from research.screening_criteria import build_exploratory_criteria_checks
 
 FINAL_STATUS_PASSED = "passed"
 FINAL_STATUS_REJECTED = "rejected"
@@ -245,12 +241,7 @@ def _sample_diagnostic(
     min_trades: int,
     trade_pnls: list[Any],
 ) -> dict[str, Any]:
-    criteria_checks = {
-        "sufficient_trades": float(metrics.get("totaal_trades", 0.0) or 0.0) >= float(min_trades),
-        "expectancy_above_zero": float(metrics.get("expectancy", 0.0)) > EXPLORATORY_MIN_EXPECTANCY,
-        "profit_factor_at_or_above_floor": float(metrics.get("profit_factor", 0.0)) >= EXPLORATORY_MIN_PROFIT_FACTOR,
-        "drawdown_within_limit": float(metrics.get("max_drawdown", 1.0)) <= EXPLORATORY_MAX_DRAWDOWN,
-    }
+    criteria_checks = build_exploratory_criteria_checks(metrics, min_trades)
     return {
         "sample_index": int(sample_index),
         "params": dict(params),

--- a/tests/unit/test_screening_runtime.py
+++ b/tests/unit/test_screening_runtime.py
@@ -205,12 +205,12 @@ def test_execute_screening_candidate_resume_matches_fresh_result():
     comparable_keys = {
         key: value
         for key, value in fresh_outcome.items()
-        if key not in {"started_at", "finished_at", "sample_diagnostics"}
+        if key not in {"started_at", "finished_at", "sample_diagnostics", "sample_diagnostics_summary"}
     }
     resumed_comparable = {
         key: value
         for key, value in resumed_outcome.items()
-        if key not in {"started_at", "finished_at", "sample_diagnostics"}
+        if key not in {"started_at", "finished_at", "sample_diagnostics", "sample_diagnostics_summary"}
     }
     assert resumed_comparable == comparable_keys
 
@@ -369,6 +369,19 @@ def test_execute_screening_candidate_keeps_promoted_sample_when_later_sample_ins
     assert outcome["diagnostic_metrics"]["win_rate"] == 0.6
     assert outcome["diagnostic_metrics"]["totaal_trades"] == 12.0
     assert outcome["diagnostic_metrics"]["trades_per_maand"] == 1.0
+    assert outcome["sample_diagnostics_summary"] == {
+        "sample_count": 2,
+        "promoted_sample_count": 1,
+        "rejected_sample_count": 1,
+        "rejection_reason_counts": {
+            "insufficient_trades": 1,
+            "passed": 1,
+        },
+        "best_sample_index": 0,
+        "best_expectancy": 0.02,
+        "best_profit_factor": 2.0,
+        "best_totaal_trades": 12.0,
+    }
     assert outcome["sample_diagnostics"] == [
         {
             "sample_index": 0,

--- a/tests/unit/test_screening_runtime.py
+++ b/tests/unit/test_screening_runtime.py
@@ -375,6 +375,12 @@ def test_execute_screening_candidate_keeps_promoted_sample_when_later_sample_ins
             "params": {"periode": 14},
             "status": "promoted_to_validation",
             "reason": None,
+            "criteria_checks": {
+                "sufficient_trades": True,
+                "expectancy_above_zero": True,
+                "profit_factor_at_or_above_floor": True,
+                "drawdown_within_limit": True,
+            },
             "metrics": {
                 "expectancy": 0.02,
                 "profit_factor": 2.0,
@@ -389,6 +395,12 @@ def test_execute_screening_candidate_keeps_promoted_sample_when_later_sample_ins
             "params": {"periode": 21},
             "status": "rejected_in_screening",
             "reason": "insufficient_trades",
+            "criteria_checks": {
+                "sufficient_trades": False,
+                "expectancy_above_zero": False,
+                "profit_factor_at_or_above_floor": False,
+                "drawdown_within_limit": True,
+            },
             "metrics": {
                 "expectancy": 0.0,
                 "profit_factor": 0.0,

--- a/tests/unit/test_screening_runtime.py
+++ b/tests/unit/test_screening_runtime.py
@@ -319,12 +319,13 @@ def test_execute_screening_candidate_keeps_promoted_sample_when_later_sample_ins
 
         def run(self, strategie_func, assets, interval="1d"):
             self.calls += 1
-            self.last_evaluation_report = {
-                "evaluation_samples": {
-                    "daily_returns": [0.01, -0.01],
-                }
-            }
             if self.calls == 1:
+                self.last_evaluation_report = {
+                    "evaluation_samples": {
+                        "daily_returns": [0.01, -0.01],
+                        "trade_pnls": [0.03, 0.01, -0.02],
+                    }
+                }
                 return {
                     "expectancy": 0.02,
                     "profit_factor": 2.0,
@@ -334,6 +335,12 @@ def test_execute_screening_candidate_keeps_promoted_sample_when_later_sample_ins
                     "trades_per_maand": 1.0,
                     "goedgekeurd": True,
                 }
+            self.last_evaluation_report = {
+                "evaluation_samples": {
+                    "daily_returns": [0.0, 0.0],
+                    "trade_pnls": [],
+                }
+            }
             return {
                 "expectancy": 0.0,
                 "profit_factor": 0.0,
@@ -394,6 +401,16 @@ def test_execute_screening_candidate_keeps_promoted_sample_when_later_sample_ins
                 "profit_factor_at_or_above_floor": True,
                 "drawdown_within_limit": True,
             },
+            "trade_distribution": {
+                "trade_count": 3,
+                "avg_trade_pnl": 0.006667,
+                "median_trade_pnl": 0.01,
+                "avg_win": 0.02,
+                "avg_loss": -0.02,
+                "largest_win": 0.03,
+                "largest_loss": -0.02,
+                "win_loss_ratio": 1.0,
+            },
             "metrics": {
                 "expectancy": 0.02,
                 "profit_factor": 2.0,
@@ -413,6 +430,16 @@ def test_execute_screening_candidate_keeps_promoted_sample_when_later_sample_ins
                 "expectancy_above_zero": False,
                 "profit_factor_at_or_above_floor": False,
                 "drawdown_within_limit": True,
+            },
+            "trade_distribution": {
+                "trade_count": 0,
+                "avg_trade_pnl": 0.0,
+                "median_trade_pnl": 0.0,
+                "avg_win": 0.0,
+                "avg_loss": 0.0,
+                "largest_win": 0.0,
+                "largest_loss": 0.0,
+                "win_loss_ratio": 0.0,
             },
             "metrics": {
                 "expectancy": 0.0,

--- a/tests/unit/test_screening_runtime.py
+++ b/tests/unit/test_screening_runtime.py
@@ -205,12 +205,12 @@ def test_execute_screening_candidate_resume_matches_fresh_result():
     comparable_keys = {
         key: value
         for key, value in fresh_outcome.items()
-        if key not in {"started_at", "finished_at"}
+        if key not in {"started_at", "finished_at", "sample_diagnostics"}
     }
     resumed_comparable = {
         key: value
         for key, value in resumed_outcome.items()
-        if key not in {"started_at", "finished_at"}
+        if key not in {"started_at", "finished_at", "sample_diagnostics"}
     }
     assert resumed_comparable == comparable_keys
 
@@ -369,3 +369,33 @@ def test_execute_screening_candidate_keeps_promoted_sample_when_later_sample_ins
     assert outcome["diagnostic_metrics"]["win_rate"] == 0.6
     assert outcome["diagnostic_metrics"]["totaal_trades"] == 12.0
     assert outcome["diagnostic_metrics"]["trades_per_maand"] == 1.0
+    assert outcome["sample_diagnostics"] == [
+        {
+            "sample_index": 0,
+            "params": {"periode": 14},
+            "status": "promoted_to_validation",
+            "reason": None,
+            "metrics": {
+                "expectancy": 0.02,
+                "profit_factor": 2.0,
+                "win_rate": 0.6,
+                "max_drawdown": 0.05,
+                "totaal_trades": 12.0,
+                "trades_per_maand": 1.0,
+            },
+        },
+        {
+            "sample_index": 1,
+            "params": {"periode": 21},
+            "status": "rejected_in_screening",
+            "reason": "insufficient_trades",
+            "metrics": {
+                "expectancy": 0.0,
+                "profit_factor": 0.0,
+                "win_rate": 0.0,
+                "max_drawdown": 0.0,
+                "totaal_trades": 0.0,
+                "trades_per_maand": 0.0,
+            },
+        },
+    ]


### PR DESCRIPTION
## Summary
- add per-sample diagnostics to screening runtime records
- include sampled params, sample status/reason, key metrics, and criteria checks for each sampled parameter combination
- add per-candidate sample_diagnostics_summary so rejected/promoted sample patterns are visible without manual artifact parsing
- add trade_distribution per sample to explain whether expectancy failures are caused by loss-size asymmetry
- keep v3.15.9 screening_evidence schema unchanged
- keep resume equality test focused on stable decision fields by excluding runtime-only sample diagnostics fields

## Validation
- python -m py_compile .\research\screening_runtime.py
- python -m pytest .\tests\unit\test_screening_runtime.py -q
- python -m pytest .\tests\unit\test_screening_runtime.py .\tests\unit\test_v3_15_7_screening_reason_codes_extended.py .\tests\unit\test_v3_15_9_per_candidate_schema_pin.py .\tests\regression\test_v3_15_9_screening_evidence_schema_pin.py -q
- python -m research.run_research --preset trend_pullback_equities_4h

## Runtime result
- run completed successfully
- screening_rejected_count=6
- validation_candidate_count=1
- validated_count=1
- results_written=1
- sample_diagnostics_count=8 for all 7 candidates
- rejected assets now show expectancy/profit-factor failures separately from trade-count failures
- sample_diagnostics_summary selects best sample from sufficient-trades samples first
- trade_distribution explains negative expectancy through win/loss asymmetry
- TSM promoted_to_validation with positive expectancy, profit_factor above floor, and balanced win/loss distribution

## Scope
- Observability only
- No strategy, engine, broker, risk, paper, shadow, or live behavior changed