### PR TITLE
feat: summarize trend break invalidation diagnostics

### DIFF
--- a/research/report_agent.py
+++ b/research/report_agent.py
@@ -760,6 +760,13 @@ def _pct(value: Any) -> str:
         return "n/a"
 
 
+def _num(value: Any) -> str:
+    try:
+        return f"{float(value):.2f}"
+    except (TypeError, ValueError):
+        return "n/a"
+
+
 def _build_trend_pullback_exit_impact(
     screening_candidates: dict[str, Any] | None,
 ) -> list[dict[str, Any]]:
@@ -799,6 +806,7 @@ def _build_trend_pullback_exit_impact(
         pullback = pnl.get("pullback_resolved") or {}
         trend_break = pnl.get("trend_break") or {}
         window_end = pnl.get("window_end") or {}
+        invalidation = best.get("trend_break_invalidation_summary") or {}
 
         rows.append(
             {
@@ -815,6 +823,16 @@ def _build_trend_pullback_exit_impact(
                 "trend_break_largest_loss": trend_break.get("largest_loss"),
                 "window_end_count": int(counts.get("window_end", 0) or 0),
                 "window_end_avg_pnl": window_end.get("avg_pnl"),
+                "trend_break_avg_mae": invalidation.get("avg_mae"),
+                "trend_break_avg_mfe": invalidation.get("avg_mfe"),
+                "trend_break_zero_mfe_count": invalidation.get("zero_mfe_count"),
+                "trend_break_adverse_dominant_count": invalidation.get(
+                    "adverse_dominant_count"
+                ),
+                "trend_break_avg_holding_bars": invalidation.get("avg_holding_bars"),
+                "trend_break_avg_exit_lag_bars": invalidation.get(
+                    "avg_exit_lag_bars"
+                ),
             }
         )
 
@@ -832,9 +850,13 @@ def _append_trend_pullback_exit_impact_section(
     lines.append(
         "| Asset | Decision | Pullback count | Pullback avg PnL | "
         "Trend-break count | Trend-break avg PnL | Trend-break largest loss | "
-        "Window-end count | Window-end avg PnL |"
+        "Window-end count | Window-end avg PnL | "
+        "TB avg MAE | TB avg MFE | TB zero-MFE | TB adverse-dominant | "
+        "TB avg hold bars | TB avg exit-lag bars |"
     )
-    lines.append("|---|---:|---:|---:|---:|---:|---:|---:|---:|")
+    lines.append(
+        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|"
+    )
     for row in rows:
         lines.append(
             f"| `{row.get('asset')}` | {row.get('decision')} | "
@@ -844,7 +866,13 @@ def _append_trend_pullback_exit_impact_section(
             f"{_pct(row.get('trend_break_avg_pnl'))} | "
             f"{_pct(row.get('trend_break_largest_loss'))} | "
             f"{row.get('window_end_count')} | "
-            f"{_pct(row.get('window_end_avg_pnl'))} |"
+            f"{_pct(row.get('window_end_avg_pnl'))} | "
+            f"{_pct(row.get('trend_break_avg_mae'))} | "
+            f"{_pct(row.get('trend_break_avg_mfe'))} | "
+            f"{row.get('trend_break_zero_mfe_count')} | "
+            f"{row.get('trend_break_adverse_dominant_count')} | "
+            f"{_num(row.get('trend_break_avg_holding_bars'))} | "
+            f"{_num(row.get('trend_break_avg_exit_lag_bars'))} |"
         )
     lines.append("")
 

--- a/research/screening_runtime.py
+++ b/research/screening_runtime.py
@@ -395,6 +395,151 @@ def _trend_pullback_features_by_timestamp(
     return by_timestamp
 
 
+def _safe_mean(values: list[float]) -> float:
+    return float(sum(values) / len(values)) if values else 0.0
+
+
+def _trade_key(record: dict[str, Any]) -> tuple[str, Any, str, str]:
+    return (
+        str(record.get("asset") or ""),
+        record.get("fold_index"),
+        str(record.get("entry_timestamp_utc") or ""),
+        str(record.get("exit_timestamp_utc") or ""),
+    )
+
+
+def _exit_diagnostics_by_trade_key(
+    exit_diagnostics: dict[str, Any] | None,
+) -> dict[tuple[str, Any, str, str], dict[str, Any]]:
+    if not isinstance(exit_diagnostics, dict):
+        return {}
+
+    by_key: dict[tuple[str, Any, str, str], dict[str, Any]] = {}
+    per_window = exit_diagnostics.get("per_window")
+    if not isinstance(per_window, list):
+        return by_key
+
+    for window in per_window:
+        if not isinstance(window, dict):
+            continue
+        per_trade = window.get("per_trade")
+        if not isinstance(per_trade, list):
+            continue
+        for diagnostic in per_trade:
+            if not isinstance(diagnostic, dict):
+                continue
+            key = _trade_key(diagnostic)
+            if key[0] and key[2] and key[3]:
+                by_key[key] = diagnostic
+
+    return by_key
+
+
+def _trend_break_invalidation_summary(
+    *,
+    trade_events: list[Any],
+    features_by_timestamp: dict[str, dict[str, Any]],
+    exit_diagnostics: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    diagnostic_by_key = _exit_diagnostics_by_trade_key(exit_diagnostics)
+    if not diagnostic_by_key:
+        return None
+
+    pnl_values: list[float] = []
+    mae_values: list[float] = []
+    mfe_values: list[float] = []
+    capture_values: list[float] = []
+    holding_values: list[float] = []
+    exit_lag_values: list[float] = []
+    zero_mfe_count = 0
+    adverse_dominant_count = 0
+
+    for trade in trade_events:
+        if not isinstance(trade, dict):
+            continue
+
+        decision_ts = trade.get("exit_decision_timestamp_utc")
+        feature_row = features_by_timestamp.get(str(decision_ts), {})
+        reason = _classify_trend_pullback_exit_reason(
+            pullback_distance=feature_row.get("pullback_distance"),
+            ema_fast=feature_row.get("ema_fast"),
+            ema_slow=feature_row.get("ema_slow"),
+            exit_kind=trade.get("exit_kind"),
+        )
+        if reason != "trend_break":
+            continue
+
+        diagnostic = diagnostic_by_key.get(_trade_key(trade))
+        if diagnostic is None:
+            continue
+
+        try:
+            pnl_values.append(float(trade.get("pnl", 0.0)))
+        except (TypeError, ValueError):
+            pnl_values.append(0.0)
+
+        try:
+            mae = float(diagnostic.get("mae", 0.0))
+        except (TypeError, ValueError):
+            mae = 0.0
+        try:
+            mfe = float(diagnostic.get("mfe", 0.0))
+        except (TypeError, ValueError):
+            mfe = 0.0
+
+        mae_values.append(mae)
+        mfe_values.append(mfe)
+
+        capture_ratio = diagnostic.get("capture_ratio")
+        if capture_ratio is not None:
+            try:
+                capture_values.append(float(capture_ratio))
+            except (TypeError, ValueError):
+                pass
+
+        try:
+            holding_values.append(float(diagnostic.get("holding_bars", 0.0)))
+        except (TypeError, ValueError):
+            pass
+
+        try:
+            exit_lag_values.append(float(diagnostic.get("exit_lag_bars", 0.0)))
+        except (TypeError, ValueError):
+            pass
+
+        if mfe <= 0.0:
+            zero_mfe_count += 1
+        if mae > mfe:
+            adverse_dominant_count += 1
+
+    if not pnl_values:
+        return {
+            "trade_count": 0,
+            "avg_pnl": 0.0,
+            "largest_loss": 0.0,
+            "avg_mae": 0.0,
+            "avg_mfe": 0.0,
+            "avg_capture_ratio": 0.0,
+            "avg_holding_bars": 0.0,
+            "avg_exit_lag_bars": 0.0,
+            "zero_mfe_count": 0,
+            "adverse_dominant_count": 0,
+        }
+
+    return {
+        "trade_count": int(len(pnl_values)),
+        "avg_pnl": _safe_mean(pnl_values),
+        "largest_loss": float(min(pnl_values)),
+        "avg_mae": _safe_mean(mae_values),
+        "avg_mfe": _safe_mean(mfe_values),
+        "avg_capture_ratio": _safe_mean(capture_values),
+        "avg_holding_bars": _safe_mean(holding_values),
+        "avg_exit_lag_bars": _safe_mean(exit_lag_values),
+        "zero_mfe_count": int(zero_mfe_count),
+        "adverse_dominant_count": int(adverse_dominant_count),
+    }
+
+
 def _exit_metadata_summary(trade_events: list[Any]) -> dict[str, Any]:
     exit_kind_counts = Counter()
     decision_timestamp_count = 0
@@ -431,6 +576,7 @@ def _sample_diagnostic(
     trade_pnls: list[Any],
     trade_events: list[Any],
     trend_pullback_features_by_timestamp: dict[str, dict[str, Any]] | None = None,
+    exit_diagnostics: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     criteria_checks = build_exploratory_criteria_checks(metrics, min_trades)
     return {
@@ -445,6 +591,15 @@ def _sample_diagnostic(
             _trend_pullback_exit_reason_summary(
                 trade_events=trade_events,
                 features_by_timestamp=trend_pullback_features_by_timestamp or {},
+            )
+            if trend_pullback_features_by_timestamp is not None
+            else None
+        ),
+        "trend_break_invalidation_summary": (
+            _trend_break_invalidation_summary(
+                trade_events=trade_events,
+                features_by_timestamp=trend_pullback_features_by_timestamp or {},
+                exit_diagnostics=exit_diagnostics,
             )
             if trend_pullback_features_by_timestamp is not None
             else None
@@ -635,6 +790,14 @@ def execute_screening_candidate_samples(
         trade_pnls = evaluation_samples.get("trade_pnls") or []
         evaluation_streams = report.get("evaluation_streams") or {}
         trade_events = evaluation_streams.get("oos_trade_events") or []
+        build_exit_diagnostics = getattr(engine, "build_exit_diagnostics", None)
+        if callable(build_exit_diagnostics):
+            try:
+                exit_diagnostics = build_exit_diagnostics()
+            except Exception:
+                exit_diagnostics = None
+        else:
+            exit_diagnostics = None
         sample_status = SCREENING_REJECTED
         sample_reason: str | None = None
         if not isinstance(daily_returns, list) or not daily_returns:
@@ -673,6 +836,7 @@ def execute_screening_candidate_samples(
                 trade_pnls=list(trade_pnls),
                 trade_events=list(trade_events),
                 trend_pullback_features_by_timestamp=trend_pullback_features_by_timestamp,
+                exit_diagnostics=exit_diagnostics,
             )
         )
         if on_checkpoint is not None:

--- a/tests/unit/test_screening_runtime.py
+++ b/tests/unit/test_screening_runtime.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from agent.backtesting.engine import EngineExecutionSnapshot, EngineInterrupted
 from research.candidate_resume import CandidateResumeState
 from research.screening_runtime import (
+    _trend_break_invalidation_summary,
     _trend_pullback_exit_reason_summary,
     _classify_trend_pullback_exit_reason,
     FINAL_STATUS_ERRORED,
@@ -431,6 +432,7 @@ def test_execute_screening_candidate_keeps_promoted_sample_when_later_sample_ins
                 "window_end_count": 0,
                 "signal_change_unknown_count": 0,
             },
+            "trend_break_invalidation_summary": None,
             "metrics": {
                 "expectancy": 0.02,
                 "profit_factor": 2.0,
@@ -479,6 +481,7 @@ def test_execute_screening_candidate_keeps_promoted_sample_when_later_sample_ins
                 "window_end_count": 0,
                 "signal_change_unknown_count": 0,
             },
+            "trend_break_invalidation_summary": None,
             "metrics": {
                 "expectancy": 0.0,
                 "profit_factor": 0.0,
@@ -636,4 +639,87 @@ def test_trend_pullback_exit_reason_summary_counts_decision_reasons() -> None:
         "pullback_resolved_and_trend_break_count": 1,
         "window_end_count": 1,
         "signal_change_unknown_count": 1,
+    }
+
+def test_trend_break_invalidation_summary_aggregates_trend_break_only() -> None:
+    trade_events = [
+        {
+            "asset": "AMD",
+            "fold_index": 0,
+            "entry_timestamp_utc": "entry-1",
+            "exit_decision_timestamp_utc": "decision-1",
+            "exit_timestamp_utc": "exit-1",
+            "exit_kind": "signal_change",
+            "pnl": -0.10,
+        },
+        {
+            "asset": "AMD",
+            "fold_index": 0,
+            "entry_timestamp_utc": "entry-2",
+            "exit_decision_timestamp_utc": "decision-2",
+            "exit_timestamp_utc": "exit-2",
+            "exit_kind": "signal_change",
+            "pnl": 0.03,
+        },
+    ]
+    features_by_timestamp = {
+        "decision-1": {
+            "pullback_distance": -1.0,
+            "ema_fast": 99.0,
+            "ema_slow": 100.0,
+        },
+        "decision-2": {
+            "pullback_distance": 1.0,
+            "ema_fast": 101.0,
+            "ema_slow": 100.0,
+        },
+    }
+    exit_diagnostics = {
+        "per_window": [
+            {
+                "asset": "AMD",
+                "fold_index": 0,
+                "per_trade": [
+                    {
+                        "asset": "AMD",
+                        "fold_index": 0,
+                        "entry_timestamp_utc": "entry-1",
+                        "exit_timestamp_utc": "exit-1",
+                        "mae": 0.12,
+                        "mfe": 0.02,
+                        "capture_ratio": -5.0,
+                        "holding_bars": 6,
+                        "exit_lag_bars": 4,
+                    },
+                    {
+                        "asset": "AMD",
+                        "fold_index": 0,
+                        "entry_timestamp_utc": "entry-2",
+                        "exit_timestamp_utc": "exit-2",
+                        "mae": 0.01,
+                        "mfe": 0.05,
+                        "capture_ratio": 0.6,
+                        "holding_bars": 3,
+                        "exit_lag_bars": 1,
+                    },
+                ],
+            }
+        ]
+    }
+
+    assert _trend_break_invalidation_summary(
+        trade_events=trade_events,
+        features_by_timestamp=features_by_timestamp,
+        exit_diagnostics=exit_diagnostics,
+    ) == {
+        "trade_count": 1,
+        "avg_pnl": -0.1,
+        "largest_loss": -0.1,
+        "avg_mae": 0.12,
+        "avg_mfe": 0.02,
+        "avg_capture_ratio": -5.0,
+        "avg_holding_bars": 6.0,
+        "avg_exit_lag_bars": 4.0,
+        "zero_mfe_count": 0,
+        "adverse_dominant_count": 1,
     }


### PR DESCRIPTION
## Summary
- add trend_break_invalidation_summary to screening sample diagnostics
- aggregate trend-break MAE, MFE, capture ratio, holding bars, exit lag, zero-MFE count, and adverse-dominant count
- reuse existing engine.build_exit_diagnostics() output instead of recomputing excursion metrics
- surface trend-break invalidation diagnostics in report_latest.md and report_latest.json

## Validation
- python -m py_compile .\research\screening_runtime.py
- python -m py_compile .\research\report_agent.py
- python -m pytest .\tests\unit\test_screening_runtime.py .\tests\unit\test_v3_15_9_per_candidate_schema_pin.py .\tests\regression\test_v3_15_9_screening_evidence_schema_pin.py -q
- python -m pytest .\tests\unit\test_screening_runtime.py .\tests\unit\test_report_agent.py .\tests\unit\test_report_agent_paper_layer.py .\tests\unit\test_report_agent_v312_enrichment.py .\tests\unit\test_v3_15_9_per_candidate_schema_pin.py .\tests\regression\test_v3_15_9_screening_evidence_schema_pin.py -q
- python -m research.run_research --preset trend_pullback_equities_4h

## Debug evidence
- trend-break trades show high adverse excursion and low favorable excursion
- AMD: zero-MFE 5/6 and adverse-dominant 6/6
- AMZN: zero-MFE 6/6 and adverse-dominant 6/6
- TSM: zero-MFE 4/5 and adverse-dominant 5/5 despite promotion to validation
- report_latest.md now shows TB avg MAE, TB avg MFE, TB zero-MFE, TB adverse-dominant, avg holding bars, and avg exit-lag bars

## Scope
- Research/observability/reporting only
- No signal, fill, strategy, screening criteria, metric, broker, paper, shadow, or live behavior changed