### PR TITLE
feat: simulate trend break early invalidation impact

### DIFF
--- a/research/presets.py
+++ b/research/presets.py
@@ -131,6 +131,7 @@ class ResearchPreset:
 
 _TREND_EQUITIES_UNIVERSE: tuple[str, ...] = (
     "NVDA", "AMD", "ASML", "MSFT", "META", "AMZN", "TSM",
+    "AAPL", "GOOGL", "AVGO", "JPM", "XOM", "LLY", "COST", "HD",
 )
 
 _PAIRS_EQUITIES_UNIVERSE: tuple[str, ...] = (

--- a/research/report_agent.py
+++ b/research/report_agent.py
@@ -733,6 +733,9 @@ def build_report_payload(
         "trend_pullback_exit_impact": _build_trend_pullback_exit_impact(
             screening_candidates_payload
         ),
+        "trend_break_threshold_comparison": _build_trend_break_threshold_comparison(
+            screening_candidates_payload
+        ),
         "join_stats": join_stats,
         "red_flags": red_flags,
         "regime_diagnostics": _regime_diagnostics(),
@@ -839,6 +842,128 @@ def _build_trend_pullback_exit_impact(
     return rows
 
 
+def _build_trend_break_threshold_comparison(
+    screening_candidates_payload: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    if not isinstance(screening_candidates_payload, dict):
+        return []
+
+    totals: dict[str, dict[str, Any]] = {}
+    for candidate in screening_candidates_payload.get("candidates") or []:
+        if not isinstance(candidate, dict):
+            continue
+
+        diagnostics = candidate.get("sample_diagnostics") or []
+        summary = candidate.get("sample_diagnostics_summary") or {}
+        if not diagnostics:
+            continue
+
+        best_index = int(summary.get("best_sample_index") or 0)
+        if best_index < 0 or best_index >= len(diagnostics):
+            best_index = 0
+
+        best = diagnostics[best_index] or {}
+        comparison = (
+            best.get("trend_break_bar_path_threshold_comparison_summary") or {}
+        )
+        rules = comparison.get("rules") or {}
+
+        for rule_name, result in rules.items():
+            if not isinstance(result, dict):
+                continue
+
+            row = totals.setdefault(
+                str(rule_name),
+                {
+                    "rule": str(rule_name),
+                    "asset_count": 0,
+                    "positive_count": 0,
+                    "negative_count": 0,
+                    "net_pnl_delta": 0.0,
+                    "avoided_loss": 0.0,
+                    "sacrificed_profit": 0.0,
+                    "other_pnl_delta": 0.0,
+                    "triggered_trend_break": 0,
+                    "triggered_pullback": 0,
+                    "triggered_other": 0,
+                },
+            )
+
+            net = float(result.get("net_pnl_delta") or 0.0)
+            row["asset_count"] += 1
+            if net > 0.0:
+                row["positive_count"] += 1
+            elif net < 0.0:
+                row["negative_count"] += 1
+
+            row["net_pnl_delta"] += net
+            row["avoided_loss"] += float(result.get("avoided_loss") or 0.0)
+            row["sacrificed_profit"] += float(
+                result.get("sacrificed_profit") or 0.0
+            )
+            row["other_pnl_delta"] += float(result.get("other_pnl_delta") or 0.0)
+            row["triggered_trend_break"] += int(
+                result.get("triggered_trend_break_trades") or 0
+            )
+            row["triggered_pullback"] += int(
+                result.get("triggered_pullback_resolved_trades") or 0
+            )
+            row["triggered_other"] += int(result.get("triggered_other_trades") or 0)
+
+    return sorted(
+        [
+            {
+                "rule": row["rule"],
+                "asset_count": int(row["asset_count"]),
+                "positive_count": int(row["positive_count"]),
+                "negative_count": int(row["negative_count"]),
+                "net_pnl_delta": float(row["net_pnl_delta"]),
+                "avoided_loss": float(row["avoided_loss"]),
+                "sacrificed_profit": float(row["sacrificed_profit"]),
+                "other_pnl_delta": float(row["other_pnl_delta"]),
+                "triggered_trend_break": int(row["triggered_trend_break"]),
+                "triggered_pullback": int(row["triggered_pullback"]),
+                "triggered_other": int(row["triggered_other"]),
+            }
+            for row in totals.values()
+        ],
+        key=lambda row: row["net_pnl_delta"],
+        reverse=True,
+    )
+
+
+def _append_trend_break_threshold_comparison_section(
+    lines: list[str],
+    rows: list[dict[str, Any]],
+) -> None:
+    if not rows:
+        return
+
+    lines.append("## Trend-break early invalidation threshold comparison")
+    lines.append("")
+    lines.append(
+        "| Rule | Net PnL delta | Avoided loss | Sacrificed profit | "
+        "Other PnL delta | +Assets | -Assets | TB hit | Pullbacks hit | Other hit |"
+    )
+    lines.append("|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|")
+
+    for row in rows:
+        lines.append(
+            f"| `{row.get('rule')}` | "
+            f"{_pct(row.get('net_pnl_delta'))} | "
+            f"{_pct(row.get('avoided_loss'))} | "
+            f"{_pct(row.get('sacrificed_profit'))} | "
+            f"{_pct(row.get('other_pnl_delta'))} | "
+            f"{row.get('positive_count')} | "
+            f"{row.get('negative_count')} | "
+            f"{row.get('triggered_trend_break')} | "
+            f"{row.get('triggered_pullback')} | "
+            f"{row.get('triggered_other')} |"
+        )
+
+    lines.append("")
+
+
 def _append_trend_pullback_exit_impact_section(
     lines: list[str],
     rows: list[dict[str, Any]],
@@ -906,6 +1031,10 @@ def render_markdown(report: dict[str, Any]) -> str:
     _append_trend_pullback_exit_impact_section(
         lines,
         report.get("trend_pullback_exit_impact") or [],
+    )
+    _append_trend_break_threshold_comparison_section(
+        lines,
+        report.get("trend_break_threshold_comparison") or [],
     )
     _append_lifecycle_breakdown_section(lines, report.get("lifecycle_breakdown"))
     _append_portfolio_layer_section(lines, report.get("portfolio_layer_summary"))

--- a/research/screening_runtime.py
+++ b/research/screening_runtime.py
@@ -435,6 +435,162 @@ def _exit_diagnostics_by_trade_key(
     return by_key
 
 
+def _classify_trade_reason(
+    *,
+    trade: dict[str, Any],
+    features_by_timestamp: dict[str, dict[str, Any]],
+) -> str:
+    decision_ts = trade.get("exit_decision_timestamp_utc")
+    feature_row = features_by_timestamp.get(str(decision_ts), {})
+    return _classify_trend_pullback_exit_reason(
+        pullback_distance=feature_row.get("pullback_distance"),
+        ema_fast=feature_row.get("ema_fast"),
+        ema_slow=feature_row.get("ema_slow"),
+        exit_kind=trade.get("exit_kind"),
+    )
+
+
+def _early_invalidation_rule_specs() -> dict[str, dict[str, float]]:
+    return {
+        "zero_mfe_holding_ge_3": {
+            "max_mfe": 0.0,
+            "min_holding_bars": 3.0,
+        },
+        "mae_gt_2pct_mfe_lt_025pct": {
+            "min_mae": 0.02,
+            "max_mfe": 0.0025,
+        },
+        "adverse_dominant_holding_ge_4": {
+            "adverse_dominant": 1.0,
+            "min_holding_bars": 4.0,
+        },
+    }
+
+
+def _rule_matches_diagnostic(
+    *,
+    diagnostic: dict[str, Any],
+    spec: dict[str, float],
+) -> bool:
+    try:
+        mae = float(diagnostic.get("mae", 0.0))
+    except (TypeError, ValueError):
+        mae = 0.0
+    try:
+        mfe = float(diagnostic.get("mfe", 0.0))
+    except (TypeError, ValueError):
+        mfe = 0.0
+    try:
+        holding_bars = float(diagnostic.get("holding_bars", 0.0))
+    except (TypeError, ValueError):
+        holding_bars = 0.0
+
+    if "min_mae" in spec and mae <= float(spec["min_mae"]):
+        return False
+    if "max_mfe" in spec and mfe > float(spec["max_mfe"]):
+        return False
+    if "min_holding_bars" in spec and holding_bars < float(spec["min_holding_bars"]):
+        return False
+    if spec.get("adverse_dominant") and mae <= mfe:
+        return False
+    return True
+
+
+def _empty_simulation_rule_result() -> dict[str, Any]:
+    return {
+        "affected_trades": 0,
+        "affected_trend_break_trades": 0,
+        "affected_pullback_resolved_trades": 0,
+        "affected_other_trades": 0,
+        "trend_break_loss_at_risk": 0.0,
+        "pullback_profit_at_risk": 0.0,
+        "other_pnl_at_risk": 0.0,
+        "net_loss_reduction_upper_bound": 0.0,
+    }
+
+
+def _trend_break_invalidation_simulation_summary(
+    *,
+    trade_events: list[Any],
+    features_by_timestamp: dict[str, dict[str, Any]],
+    exit_diagnostics: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    diagnostic_by_key = _exit_diagnostics_by_trade_key(exit_diagnostics)
+    if not diagnostic_by_key:
+        return None
+
+    rules = {
+        name: _empty_simulation_rule_result()
+        for name in _early_invalidation_rule_specs()
+    }
+
+    matched_trade_count = 0
+    for trade in trade_events:
+        if not isinstance(trade, dict):
+            continue
+        diagnostic = diagnostic_by_key.get(_trade_key(trade))
+        if diagnostic is None:
+            continue
+
+        matched_trade_count += 1
+        reason = _classify_trade_reason(
+            trade=trade,
+            features_by_timestamp=features_by_timestamp,
+        )
+        try:
+            pnl = float(trade.get("pnl", 0.0))
+        except (TypeError, ValueError):
+            pnl = 0.0
+
+        for rule_name, spec in _early_invalidation_rule_specs().items():
+            if not _rule_matches_diagnostic(diagnostic=diagnostic, spec=spec):
+                continue
+
+            result = rules[rule_name]
+            result["affected_trades"] += 1
+
+            if reason == "trend_break":
+                result["affected_trend_break_trades"] += 1
+                if pnl < 0.0:
+                    result["trend_break_loss_at_risk"] += abs(pnl)
+                    result["net_loss_reduction_upper_bound"] += abs(pnl)
+            elif reason == "pullback_resolved":
+                result["affected_pullback_resolved_trades"] += 1
+                if pnl > 0.0:
+                    result["pullback_profit_at_risk"] += pnl
+                    result["net_loss_reduction_upper_bound"] -= pnl
+            else:
+                result["affected_other_trades"] += 1
+                result["other_pnl_at_risk"] += pnl
+
+    return {
+        "matched_trade_count": int(matched_trade_count),
+        "rules": {
+            name: {
+                "affected_trades": int(values["affected_trades"]),
+                "affected_trend_break_trades": int(
+                    values["affected_trend_break_trades"]
+                ),
+                "affected_pullback_resolved_trades": int(
+                    values["affected_pullback_resolved_trades"]
+                ),
+                "affected_other_trades": int(values["affected_other_trades"]),
+                "trend_break_loss_at_risk": float(
+                    values["trend_break_loss_at_risk"]
+                ),
+                "pullback_profit_at_risk": float(
+                    values["pullback_profit_at_risk"]
+                ),
+                "other_pnl_at_risk": float(values["other_pnl_at_risk"]),
+                "net_loss_reduction_upper_bound": float(
+                    values["net_loss_reduction_upper_bound"]
+                ),
+            }
+            for name, values in sorted(rules.items())
+        },
+    }
+
+
 def _trend_break_invalidation_summary(
     *,
     trade_events: list[Any],
@@ -597,6 +753,15 @@ def _sample_diagnostic(
         ),
         "trend_break_invalidation_summary": (
             _trend_break_invalidation_summary(
+                trade_events=trade_events,
+                features_by_timestamp=trend_pullback_features_by_timestamp or {},
+                exit_diagnostics=exit_diagnostics,
+            )
+            if trend_pullback_features_by_timestamp is not None
+            else None
+        ),
+        "trend_break_invalidation_simulation_summary": (
+            _trend_break_invalidation_simulation_summary(
                 trade_events=trade_events,
                 features_by_timestamp=trend_pullback_features_by_timestamp or {},
                 exit_diagnostics=exit_diagnostics,

--- a/research/screening_runtime.py
+++ b/research/screening_runtime.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 from typing import Any, Callable, Iterable
 
 from agent.backtesting.engine import EngineInterrupted, EngineResumeInvalid
+from agent.backtesting.exit_diagnostics import extract_interior_bar_returns
 from agent.backtesting.thin_strategy import build_features_for, is_thin_strategy
 from research.candidate_resume import CandidateResumeState
 from research.candidate_pipeline import (
@@ -591,6 +592,125 @@ def _trend_break_invalidation_simulation_summary(
     }
 
 
+def _side_sign(side: Any) -> float:
+    return 1.0 if str(side).lower() == "long" else -1.0
+
+
+def _bar_path_trigger_for_rule(
+    *,
+    trade: dict[str, Any],
+    interior_returns: list[float],
+    max_mfe: float = 0.0025,
+    min_mae: float = 0.02,
+) -> dict[str, Any] | None:
+    side_sign = _side_sign(trade.get("side"))
+    cumulative_raw = 1.0
+    path: list[float] = [0.0]
+
+    for bar_offset, raw_return in enumerate(interior_returns, start=1):
+        try:
+            rf = float(raw_return)
+        except (TypeError, ValueError):
+            continue
+        cumulative_raw *= 1.0 + rf * side_sign
+        path_value = (cumulative_raw - 1.0) * side_sign
+        path.append(path_value)
+
+        running_mfe = max(max(path), 0.0)
+        running_mae = max(-min(path), 0.0)
+        if running_mae > min_mae and running_mfe < max_mfe:
+            return {
+                "bars_to_trigger": int(bar_offset),
+                "hypothetical_pnl": float(path_value),
+                "running_mae": float(running_mae),
+                "running_mfe": float(running_mfe),
+            }
+
+    return None
+
+
+def _trend_break_bar_path_simulation_summary(
+    *,
+    trade_events: list[Any],
+    features_by_timestamp: dict[str, dict[str, Any]],
+    bar_return_stream: list[Any],
+) -> dict[str, Any] | None:
+    if not bar_return_stream:
+        return None
+
+    matched_trade_count = 0
+    triggered_trade_count = 0
+    triggered_trend_break_trades = 0
+    triggered_pullback_resolved_trades = 0
+    triggered_other_trades = 0
+    avoided_loss = 0.0
+    sacrificed_profit = 0.0
+    other_pnl_delta = 0.0
+    bars_to_trigger: list[float] = []
+
+    for trade in trade_events:
+        if not isinstance(trade, dict):
+            continue
+
+        try:
+            interior_returns = extract_interior_bar_returns(
+                trade=trade,
+                bar_return_stream=bar_return_stream,
+            )
+        except (KeyError, ValueError):
+            continue
+
+        matched_trade_count += 1
+        trigger = _bar_path_trigger_for_rule(
+            trade=trade,
+            interior_returns=interior_returns,
+        )
+        if trigger is None:
+            continue
+
+        triggered_trade_count += 1
+        bars_to_trigger.append(float(trigger["bars_to_trigger"]))
+
+        reason = _classify_trade_reason(
+            trade=trade,
+            features_by_timestamp=features_by_timestamp,
+        )
+        try:
+            actual_pnl = float(trade.get("pnl", 0.0))
+        except (TypeError, ValueError):
+            actual_pnl = 0.0
+        hypothetical_pnl = float(trigger["hypothetical_pnl"])
+        pnl_delta = hypothetical_pnl - actual_pnl
+
+        if reason == "trend_break":
+            triggered_trend_break_trades += 1
+            if pnl_delta > 0.0:
+                avoided_loss += pnl_delta
+        elif reason == "pullback_resolved":
+            triggered_pullback_resolved_trades += 1
+            if pnl_delta < 0.0:
+                sacrificed_profit += abs(pnl_delta)
+        else:
+            triggered_other_trades += 1
+            other_pnl_delta += pnl_delta
+
+    return {
+        "rule": "mae_gt_2pct_mfe_lt_025pct",
+        "matched_trade_count": int(matched_trade_count),
+        "triggered_trade_count": int(triggered_trade_count),
+        "triggered_trend_break_trades": int(triggered_trend_break_trades),
+        "triggered_pullback_resolved_trades": int(
+            triggered_pullback_resolved_trades
+        ),
+        "triggered_other_trades": int(triggered_other_trades),
+        "avoided_loss": float(avoided_loss),
+        "sacrificed_profit": float(sacrificed_profit),
+        "other_pnl_delta": float(other_pnl_delta),
+        "net_pnl_delta": float(avoided_loss - sacrificed_profit + other_pnl_delta),
+        "avg_bars_to_trigger": _safe_mean(bars_to_trigger),
+    }
+
+
 def _trend_break_invalidation_summary(
     *,
     trade_events: list[Any],
@@ -733,6 +853,7 @@ def _sample_diagnostic(
     trade_events: list[Any],
     trend_pullback_features_by_timestamp: dict[str, dict[str, Any]] | None = None,
     exit_diagnostics: dict[str, Any] | None = None,
+    bar_return_stream: list[Any] | None = None,
 ) -> dict[str, Any]:
     criteria_checks = build_exploratory_criteria_checks(metrics, min_trades)
     return {
@@ -765,6 +886,15 @@ def _sample_diagnostic(
                 trade_events=trade_events,
                 features_by_timestamp=trend_pullback_features_by_timestamp or {},
                 exit_diagnostics=exit_diagnostics,
+            )
+            if trend_pullback_features_by_timestamp is not None
+            else None
+        ),
+        "trend_break_bar_path_simulation_summary": (
+            _trend_break_bar_path_simulation_summary(
+                trade_events=trade_events,
+                features_by_timestamp=trend_pullback_features_by_timestamp or {},
+                bar_return_stream=list(bar_return_stream or []),
             )
             if trend_pullback_features_by_timestamp is not None
             else None
@@ -955,6 +1085,7 @@ def execute_screening_candidate_samples(
         trade_pnls = evaluation_samples.get("trade_pnls") or []
         evaluation_streams = report.get("evaluation_streams") or {}
         trade_events = evaluation_streams.get("oos_trade_events") or []
+        bar_return_stream = evaluation_streams.get("oos_bar_returns") or []
         build_exit_diagnostics = getattr(engine, "build_exit_diagnostics", None)
         if callable(build_exit_diagnostics):
             try:
@@ -1002,6 +1133,7 @@ def execute_screening_candidate_samples(
                 trade_events=list(trade_events),
                 trend_pullback_features_by_timestamp=trend_pullback_features_by_timestamp,
                 exit_diagnostics=exit_diagnostics,
+                bar_return_stream=list(bar_return_stream),
             )
         )
         if on_checkpoint is not None:

--- a/research/screening_runtime.py
+++ b/research/screening_runtime.py
@@ -629,6 +629,197 @@ def _bar_path_trigger_for_rule(
     return None
 
 
+def _bar_path_threshold_specs() -> dict[str, dict[str, float]]:
+    return {
+        "mae_gt_2pct_mfe_lt_025pct": {
+            "min_mae": 0.02,
+            "max_mfe": 0.0025,
+            "min_bars_to_trigger": 1.0,
+        },
+        "mae_gt_3pct_mfe_lt_025pct": {
+            "min_mae": 0.03,
+            "max_mfe": 0.0025,
+            "min_bars_to_trigger": 1.0,
+        },
+        "mae_gt_2pct_zero_mfe": {
+            "min_mae": 0.02,
+            "max_mfe": 0.0,
+            "min_bars_to_trigger": 1.0,
+        },
+        "mae_gt_3pct_zero_mfe": {
+            "min_mae": 0.03,
+            "max_mfe": 0.0,
+            "min_bars_to_trigger": 1.0,
+        },
+        "mae_gt_2pct_mfe_lt_025pct_trigger_ge_2": {
+            "min_mae": 0.02,
+            "max_mfe": 0.0025,
+            "min_bars_to_trigger": 2.0,
+        },
+        "mae_gt_3pct_mfe_lt_025pct_trigger_ge_2": {
+            "min_mae": 0.03,
+            "max_mfe": 0.0025,
+            "min_bars_to_trigger": 2.0,
+        },
+    }
+
+
+def _bar_path_trigger_for_spec(
+    *,
+    trade: dict[str, Any],
+    interior_returns: list[float],
+    spec: dict[str, float],
+) -> dict[str, Any] | None:
+    side_sign = _side_sign(trade.get("side"))
+    cumulative_raw = 1.0
+    path: list[float] = [0.0]
+
+    min_mae = float(spec["min_mae"])
+    max_mfe = float(spec["max_mfe"])
+    min_bars_to_trigger = float(spec.get("min_bars_to_trigger", 1.0))
+
+    for bar_offset, raw_return in enumerate(interior_returns, start=1):
+        try:
+            rf = float(raw_return)
+        except (TypeError, ValueError):
+            continue
+
+        cumulative_raw *= 1.0 + rf * side_sign
+        path_value = (cumulative_raw - 1.0) * side_sign
+        path.append(path_value)
+
+        running_mfe = max(max(path), 0.0)
+        running_mae = max(-min(path), 0.0)
+
+        if float(bar_offset) < min_bars_to_trigger:
+            continue
+
+        if running_mae > min_mae and running_mfe <= max_mfe:
+            return {
+                "bars_to_trigger": int(bar_offset),
+                "hypothetical_pnl": float(path_value),
+                "running_mae": float(running_mae),
+                "running_mfe": float(running_mfe),
+            }
+
+    return None
+
+
+def _empty_bar_path_rule_result() -> dict[str, Any]:
+    return {
+        "triggered_trade_count": 0,
+        "triggered_trend_break_trades": 0,
+        "triggered_pullback_resolved_trades": 0,
+        "triggered_other_trades": 0,
+        "avoided_loss": 0.0,
+        "sacrificed_profit": 0.0,
+        "other_pnl_delta": 0.0,
+        "net_pnl_delta": 0.0,
+        "avg_bars_to_trigger": 0.0,
+        "_bars_to_trigger": [],
+    }
+
+
+def _finalize_bar_path_rule_result(values: dict[str, Any]) -> dict[str, Any]:
+    bars = values.get("_bars_to_trigger") or []
+    return {
+        "triggered_trade_count": int(values["triggered_trade_count"]),
+        "triggered_trend_break_trades": int(
+            values["triggered_trend_break_trades"]
+        ),
+        "triggered_pullback_resolved_trades": int(
+            values["triggered_pullback_resolved_trades"]
+        ),
+        "triggered_other_trades": int(values["triggered_other_trades"]),
+        "avoided_loss": float(values["avoided_loss"]),
+        "sacrificed_profit": float(values["sacrificed_profit"]),
+        "other_pnl_delta": float(values["other_pnl_delta"]),
+        "net_pnl_delta": float(values["net_pnl_delta"]),
+        "avg_bars_to_trigger": _safe_mean([float(v) for v in bars]),
+    }
+
+
+def _trend_break_bar_path_threshold_comparison_summary(
+    *,
+    trade_events: list[Any],
+    features_by_timestamp: dict[str, dict[str, Any]],
+    bar_return_stream: list[Any],
+) -> dict[str, Any] | None:
+    if not bar_return_stream:
+        return None
+
+    specs = _bar_path_threshold_specs()
+    rules = {
+        name: _empty_bar_path_rule_result()
+        for name in specs
+    }
+    matched_trade_count = 0
+
+    for trade in trade_events:
+        if not isinstance(trade, dict):
+            continue
+
+        try:
+            interior_returns = extract_interior_bar_returns(
+                trade=trade,
+                bar_return_stream=bar_return_stream,
+            )
+        except (KeyError, ValueError):
+            continue
+
+        matched_trade_count += 1
+        reason = _classify_trade_reason(
+            trade=trade,
+            features_by_timestamp=features_by_timestamp,
+        )
+        try:
+            actual_pnl = float(trade.get("pnl", 0.0))
+        except (TypeError, ValueError):
+            actual_pnl = 0.0
+
+        for rule_name, spec in specs.items():
+            trigger = _bar_path_trigger_for_spec(
+                trade=trade,
+                interior_returns=interior_returns,
+                spec=spec,
+            )
+            if trigger is None:
+                continue
+
+            values = rules[rule_name]
+            values["triggered_trade_count"] += 1
+            values["_bars_to_trigger"].append(float(trigger["bars_to_trigger"]))
+
+            hypothetical_pnl = float(trigger["hypothetical_pnl"])
+            pnl_delta = hypothetical_pnl - actual_pnl
+
+            if reason == "trend_break":
+                values["triggered_trend_break_trades"] += 1
+                if pnl_delta > 0.0:
+                    values["avoided_loss"] += pnl_delta
+            elif reason == "pullback_resolved":
+                values["triggered_pullback_resolved_trades"] += 1
+                if pnl_delta < 0.0:
+                    values["sacrificed_profit"] += abs(pnl_delta)
+            else:
+                values["triggered_other_trades"] += 1
+                values["other_pnl_delta"] += pnl_delta
+
+            values["net_pnl_delta"] = (
+                values["avoided_loss"]
+                - values["sacrificed_profit"]
+                + values["other_pnl_delta"]
+            )
+
+    return {
+        "matched_trade_count": int(matched_trade_count),
+        "rules": {
+            name: _finalize_bar_path_rule_result(values)
+            for name, values in sorted(rules.items())
+        },
+    }
+
+
 def _trend_break_bar_path_simulation_summary(
     *,
     trade_events: list[Any],
@@ -892,6 +1083,15 @@ def _sample_diagnostic(
         ),
         "trend_break_bar_path_simulation_summary": (
             _trend_break_bar_path_simulation_summary(
+                trade_events=trade_events,
+                features_by_timestamp=trend_pullback_features_by_timestamp or {},
+                bar_return_stream=list(bar_return_stream or []),
+            )
+            if trend_pullback_features_by_timestamp is not None
+            else None
+        ),
+        "trend_break_bar_path_threshold_comparison_summary": (
+            _trend_break_bar_path_threshold_comparison_summary(
                 trade_events=trade_events,
                 features_by_timestamp=trend_pullback_features_by_timestamp or {},
                 bar_return_stream=list(bar_return_stream or []),

--- a/tests/unit/test_screening_runtime.py
+++ b/tests/unit/test_screening_runtime.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from agent.backtesting.engine import EngineExecutionSnapshot, EngineInterrupted
 from research.candidate_resume import CandidateResumeState
 from research.screening_runtime import (
+    _trend_break_invalidation_simulation_summary,
     _trend_break_invalidation_summary,
     _trend_pullback_exit_reason_summary,
     _classify_trend_pullback_exit_reason,
@@ -433,6 +434,7 @@ def test_execute_screening_candidate_keeps_promoted_sample_when_later_sample_ins
                 "signal_change_unknown_count": 0,
             },
             "trend_break_invalidation_summary": None,
+            "trend_break_invalidation_simulation_summary": None,
             "metrics": {
                 "expectancy": 0.02,
                 "profit_factor": 2.0,
@@ -482,6 +484,7 @@ def test_execute_screening_candidate_keeps_promoted_sample_when_later_sample_ins
                 "signal_change_unknown_count": 0,
             },
             "trend_break_invalidation_summary": None,
+            "trend_break_invalidation_simulation_summary": None,
             "metrics": {
                 "expectancy": 0.0,
                 "profit_factor": 0.0,
@@ -722,4 +725,83 @@ def test_trend_break_invalidation_summary_aggregates_trend_break_only() -> None:
         "avg_exit_lag_bars": 4.0,
         "zero_mfe_count": 0,
         "adverse_dominant_count": 1,
+    }
+
+def test_trend_break_invalidation_simulation_estimates_rule_impact() -> None:
+    trade_events = [
+        {
+            "asset": "AMD",
+            "fold_index": 0,
+            "entry_timestamp_utc": "entry-1",
+            "exit_decision_timestamp_utc": "decision-1",
+            "exit_timestamp_utc": "exit-1",
+            "exit_kind": "signal_change",
+            "pnl": -0.10,
+        },
+        {
+            "asset": "AMD",
+            "fold_index": 0,
+            "entry_timestamp_utc": "entry-2",
+            "exit_decision_timestamp_utc": "decision-2",
+            "exit_timestamp_utc": "exit-2",
+            "exit_kind": "signal_change",
+            "pnl": 0.04,
+        },
+    ]
+    features_by_timestamp = {
+        "decision-1": {
+            "pullback_distance": -1.0,
+            "ema_fast": 99.0,
+            "ema_slow": 100.0,
+        },
+        "decision-2": {
+            "pullback_distance": 1.0,
+            "ema_fast": 101.0,
+            "ema_slow": 100.0,
+        },
+    }
+    exit_diagnostics = {
+        "per_window": [
+            {
+                "per_trade": [
+                    {
+                        "asset": "AMD",
+                        "fold_index": 0,
+                        "entry_timestamp_utc": "entry-1",
+                        "exit_timestamp_utc": "exit-1",
+                        "mae": 0.05,
+                        "mfe": 0.0,
+                        "holding_bars": 5,
+                    },
+                    {
+                        "asset": "AMD",
+                        "fold_index": 0,
+                        "entry_timestamp_utc": "entry-2",
+                        "exit_timestamp_utc": "exit-2",
+                        "mae": 0.03,
+                        "mfe": 0.0,
+                        "holding_bars": 5,
+                    },
+                ]
+            }
+        ]
+    }
+
+    summary = _trend_break_invalidation_simulation_summary(
+        trade_events=trade_events,
+        features_by_timestamp=features_by_timestamp,
+        exit_diagnostics=exit_diagnostics,
+    )
+
+    assert summary["matched_trade_count"] == 2
+    zero_mfe = summary["rules"]["zero_mfe_holding_ge_3"]
+    assert zero_mfe == {
+        "affected_trades": 2,
+        "affected_trend_break_trades": 1,
+        "affected_pullback_resolved_trades": 1,
+        "affected_other_trades": 0,
+        "trend_break_loss_at_risk": 0.1,
+        "pullback_profit_at_risk": 0.04,
+        "other_pnl_at_risk": 0.0,
+        "net_loss_reduction_upper_bound": 0.060000000000000005,
     }

--- a/tests/unit/test_screening_runtime.py
+++ b/tests/unit/test_screening_runtime.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+import pytest
 from types import SimpleNamespace
 
 from agent.backtesting.engine import EngineExecutionSnapshot, EngineInterrupted
 from research.candidate_resume import CandidateResumeState
 from research.screening_runtime import (
+    _trend_break_bar_path_simulation_summary,
     _trend_break_invalidation_simulation_summary,
     _trend_break_invalidation_summary,
     _trend_pullback_exit_reason_summary,
@@ -435,6 +437,7 @@ def test_execute_screening_candidate_keeps_promoted_sample_when_later_sample_ins
             },
             "trend_break_invalidation_summary": None,
             "trend_break_invalidation_simulation_summary": None,
+            "trend_break_bar_path_simulation_summary": None,
             "metrics": {
                 "expectancy": 0.02,
                 "profit_factor": 2.0,
@@ -485,6 +488,7 @@ def test_execute_screening_candidate_keeps_promoted_sample_when_later_sample_ins
             },
             "trend_break_invalidation_summary": None,
             "trend_break_invalidation_simulation_summary": None,
+            "trend_break_bar_path_simulation_summary": None,
             "metrics": {
                 "expectancy": 0.0,
                 "profit_factor": 0.0,
@@ -805,3 +809,95 @@ def test_trend_break_invalidation_simulation_estimates_rule_impact() -> None:
         "other_pnl_at_risk": 0.0,
         "net_loss_reduction_upper_bound": 0.060000000000000005,
     }
+
+def test_trend_break_bar_path_simulation_estimates_timed_exit_delta() -> None:
+    trade_events = [
+        {
+            "asset": "AMD",
+            "fold_index": 0,
+            "entry_timestamp_utc": "entry-1",
+            "exit_decision_timestamp_utc": "decision-1",
+            "exit_timestamp_utc": "exit-1",
+            "exit_kind": "signal_change",
+            "side": "long",
+            "pnl": -0.10,
+        },
+        {
+            "asset": "AMD",
+            "fold_index": 0,
+            "entry_timestamp_utc": "entry-2",
+            "exit_decision_timestamp_utc": "decision-2",
+            "exit_timestamp_utc": "exit-2",
+            "exit_kind": "signal_change",
+            "side": "long",
+            "pnl": 0.04,
+        },
+    ]
+    features_by_timestamp = {
+        "decision-1": {
+            "pullback_distance": -1.0,
+            "ema_fast": 99.0,
+            "ema_slow": 100.0,
+        },
+        "decision-2": {
+            "pullback_distance": 1.0,
+            "ema_fast": 101.0,
+            "ema_slow": 100.0,
+        },
+    }
+    bar_return_stream = [
+        {
+            "asset": "AMD",
+            "fold_index": 0,
+            "timestamp_utc": "entry-1",
+            "return": 0.0,
+        },
+        {
+            "asset": "AMD",
+            "fold_index": 0,
+            "timestamp_utc": "mid-1",
+            "return": -0.03,
+        },
+        {
+            "asset": "AMD",
+            "fold_index": 0,
+            "timestamp_utc": "exit-1",
+            "return": 0.0,
+        },
+        {
+            "asset": "AMD",
+            "fold_index": 0,
+            "timestamp_utc": "entry-2",
+            "return": 0.0,
+        },
+        {
+            "asset": "AMD",
+            "fold_index": 0,
+            "timestamp_utc": "mid-2",
+            "return": -0.03,
+        },
+        {
+            "asset": "AMD",
+            "fold_index": 0,
+            "timestamp_utc": "exit-2",
+            "return": 0.0,
+        },
+    ]
+
+    summary = _trend_break_bar_path_simulation_summary(
+        trade_events=trade_events,
+        features_by_timestamp=features_by_timestamp,
+        bar_return_stream=bar_return_stream,
+    )
+
+    assert summary["rule"] == "mae_gt_2pct_mfe_lt_025pct"
+    assert summary["matched_trade_count"] == 2
+    assert summary["triggered_trade_count"] == 2
+    assert summary["triggered_trend_break_trades"] == 1
+    assert summary["triggered_pullback_resolved_trades"] == 1
+    assert summary["triggered_other_trades"] == 0
+    assert summary["avoided_loss"] == pytest.approx(0.07)
+    assert summary["sacrificed_profit"] == pytest.approx(0.07)
+    assert summary["other_pnl_delta"] == pytest.approx(0.0)
+    assert summary["net_pnl_delta"] == pytest.approx(0.0)
+    assert summary["avg_bars_to_trigger"] == pytest.approx(1.0)

--- a/tests/unit/test_screening_runtime.py
+++ b/tests/unit/test_screening_runtime.py
@@ -8,6 +8,7 @@ from agent.backtesting.engine import EngineExecutionSnapshot, EngineInterrupted
 from research.candidate_resume import CandidateResumeState
 from research.screening_runtime import (
     _trend_break_bar_path_simulation_summary,
+    _trend_break_bar_path_threshold_comparison_summary,
     _trend_break_invalidation_simulation_summary,
     _trend_break_invalidation_summary,
     _trend_pullback_exit_reason_summary,
@@ -438,6 +439,7 @@ def test_execute_screening_candidate_keeps_promoted_sample_when_later_sample_ins
             "trend_break_invalidation_summary": None,
             "trend_break_invalidation_simulation_summary": None,
             "trend_break_bar_path_simulation_summary": None,
+            "trend_break_bar_path_threshold_comparison_summary": None,
             "metrics": {
                 "expectancy": 0.02,
                 "profit_factor": 2.0,
@@ -489,6 +491,7 @@ def test_execute_screening_candidate_keeps_promoted_sample_when_later_sample_ins
             "trend_break_invalidation_summary": None,
             "trend_break_invalidation_simulation_summary": None,
             "trend_break_bar_path_simulation_summary": None,
+            "trend_break_bar_path_threshold_comparison_summary": None,
             "metrics": {
                 "expectancy": 0.0,
                 "profit_factor": 0.0,
@@ -901,3 +904,108 @@ def test_trend_break_bar_path_simulation_estimates_timed_exit_delta() -> None:
     assert summary["other_pnl_delta"] == pytest.approx(0.0)
     assert summary["net_pnl_delta"] == pytest.approx(0.0)
     assert summary["avg_bars_to_trigger"] == pytest.approx(1.0)
+
+def test_trend_break_bar_path_threshold_comparison_ranks_multiple_rules() -> None:
+    trade_events = [
+        {
+            "asset": "AMD",
+            "fold_index": 0,
+            "entry_timestamp_utc": "entry-1",
+            "exit_decision_timestamp_utc": "decision-1",
+            "exit_timestamp_utc": "exit-1",
+            "exit_kind": "signal_change",
+            "side": "long",
+            "pnl": -0.10,
+        },
+        {
+            "asset": "AMD",
+            "fold_index": 0,
+            "entry_timestamp_utc": "entry-2",
+            "exit_decision_timestamp_utc": "decision-2",
+            "exit_timestamp_utc": "exit-2",
+            "exit_kind": "signal_change",
+            "side": "long",
+            "pnl": 0.04,
+        },
+    ]
+    features_by_timestamp = {
+        "decision-1": {
+            "pullback_distance": -1.0,
+            "ema_fast": 99.0,
+            "ema_slow": 100.0,
+        },
+        "decision-2": {
+            "pullback_distance": 1.0,
+            "ema_fast": 101.0,
+            "ema_slow": 100.0,
+        },
+    }
+    bar_return_stream = [
+        {
+            "asset": "AMD",
+            "fold_index": 0,
+            "timestamp_utc": "entry-1",
+            "return": 0.0,
+        },
+        {
+            "asset": "AMD",
+            "fold_index": 0,
+            "timestamp_utc": "mid-1",
+            "return": -0.025,
+        },
+        {
+            "asset": "AMD",
+            "fold_index": 0,
+            "timestamp_utc": "mid-1b",
+            "return": -0.01,
+        },
+        {
+            "asset": "AMD",
+            "fold_index": 0,
+            "timestamp_utc": "exit-1",
+            "return": 0.0,
+        },
+        {
+            "asset": "AMD",
+            "fold_index": 0,
+            "timestamp_utc": "entry-2",
+            "return": 0.0,
+        },
+        {
+            "asset": "AMD",
+            "fold_index": 0,
+            "timestamp_utc": "mid-2",
+            "return": -0.025,
+        },
+        {
+            "asset": "AMD",
+            "fold_index": 0,
+            "timestamp_utc": "exit-2",
+            "return": 0.0,
+        },
+    ]
+
+    summary = _trend_break_bar_path_threshold_comparison_summary(
+        trade_events=trade_events,
+        features_by_timestamp=features_by_timestamp,
+        bar_return_stream=bar_return_stream,
+    )
+
+    assert summary["matched_trade_count"] == 2
+    rules = summary["rules"]
+
+    loose = rules["mae_gt_2pct_mfe_lt_025pct"]
+    assert loose["triggered_trade_count"] == 2
+    assert loose["triggered_trend_break_trades"] == 1
+    assert loose["triggered_pullback_resolved_trades"] == 1
+    assert loose["net_pnl_delta"] == pytest.approx(0.01)
+
+    strict = rules["mae_gt_3pct_mfe_lt_025pct"]
+    assert strict["triggered_trade_count"] == 1
+    assert strict["triggered_trend_break_trades"] == 1
+    assert strict["triggered_pullback_resolved_trades"] == 0
+    assert strict["net_pnl_delta"] > loose["net_pnl_delta"]
+
+    zero_mfe = rules["mae_gt_3pct_zero_mfe"]
+    assert zero_mfe["triggered_trade_count"] == 1
+    assert zero_mfe["triggered_trend_break_trades"] == 1


### PR DESCRIPTION
## Summary
- add trade-level upper-bound early invalidation simulation for trend-break diagnostics
- add bar-path early invalidation simulation using existing OOS bar return streams
- expand the trend-pullback equities research universe from 7 to 15 assets
- compare multiple MAE/MFE threshold variants, including trigger confirmation variants
- surface threshold-comparison totals in report_latest.md and report_latest.json

## Key finding
The simple MAE > 2% and MFE < 0.25% rule is not robust enough as a universal strategy exit rule.

The best tested variant was:
MAE > 2%, MFE < 0.25%, trigger after at least 2 bars.

Across 15 assets, this produced:
- net_pnl_delta: +2.95%
- avoided_loss: 49.55%
- sacrificed_profit: 39.46%
- other_pnl_delta: -7.13%
- positive assets: 7
- negative assets: 7
- triggered trend-break trades: 25
- triggered pullback-resolved trades: 16

Conclusion: keep this as research evidence and simulation capability; do not activate as strategy behavior.

## Validation
- python -m py_compile .\research\report_agent.py
- python -m pytest .\tests\unit\test_screening_runtime.py .\tests\unit\test_report_agent.py .\tests\unit\test_report_agent_paper_layer.py .\tests\unit\test_report_agent_v312_enrichment.py .\tests\unit\test_v3_15_9_per_candidate_schema_pin.py .\tests\regression\test_v3_15_9_screening_evidence_schema_pin.py -q
- python -m research.run_research --preset trend_pullback_equities_4h

## Scope
- Research/simulation/reporting only
- No broker behavior changed
- No paper/shadow/live behavior changed
- No screening criteria changed
- No strategy exit rule activated