### PR TITLE
fix: explain signal change unknown exits

### DIFF
--- a/research/screening_runtime.py
+++ b/research/screening_runtime.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
 import copy
+import math
 import time
 from collections import Counter
+from collections.abc import Callable, Iterable
+from contextlib import suppress
 from datetime import UTC, datetime
-from typing import Any, Callable, Iterable
+from typing import Any
 
 from agent.backtesting.engine import EngineInterrupted, EngineResumeInvalid
 from agent.backtesting.exit_diagnostics import extract_interior_bar_returns
 from agent.backtesting.thin_strategy import build_features_for, is_thin_strategy
-from research.candidate_resume import CandidateResumeState
 from research.candidate_pipeline import (
     COVERAGE_WARNING_GRID_UNAVAILABLE,
     SAMPLING_POLICY_GRID_UNAVAILABLE,
@@ -18,8 +20,11 @@ from research.candidate_pipeline import (
     normalize_screening_decision,
     sampling_plan_for_param_grid,
 )
-from research.screening_criteria import apply_phase_aware_criteria
-from research.screening_criteria import build_exploratory_criteria_checks
+from research.candidate_resume import CandidateResumeState
+from research.screening_criteria import (
+    apply_phase_aware_criteria,
+    build_exploratory_criteria_checks,
+)
 
 FINAL_STATUS_PASSED = "passed"
 FINAL_STATUS_REJECTED = "rejected"
@@ -262,6 +267,40 @@ def _classify_trend_pullback_exit_reason(
     return "signal_change_unknown"
 
 
+def _finite_float(value: Any) -> float | None:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    return number if math.isfinite(number) else None
+
+
+def _classify_signal_change_unknown_subcategory(
+    *,
+    trade: dict[str, Any],
+    feature_row: dict[str, Any],
+    has_feature_row: bool,
+) -> str:
+    if (
+        trade.get("exit_decision_timestamp_utc") is None
+        or trade.get("exit_kind") is None
+    ):
+        return "signal_change_missing_metadata"
+
+    if not has_feature_row:
+        return "signal_change_missing_feature_timestamp"
+
+    required_features = ("pullback_distance", "ema_fast", "ema_slow")
+    feature_values = {
+        name: _finite_float(feature_row.get(name))
+        for name in required_features
+    }
+    if any(value is None for value in feature_values.values()):
+        return "signal_change_feature_unavailable"
+
+    return "signal_change_ambiguous_transition"
+
+
 def _trend_pullback_exit_reason_summary(
     *,
     trade_events: list[Any],
@@ -269,13 +308,17 @@ def _trend_pullback_exit_reason_summary(
 ) -> dict[str, Any]:
     reason_counts = Counter()
     pnl_by_reason: dict[str, list[float]] = {}
+    unknown_subcategory_counts = Counter()
+    pnl_by_unknown_subcategory: dict[str, list[float]] = {}
 
     for trade in trade_events:
         if not isinstance(trade, dict):
             continue
 
         decision_ts = trade.get("exit_decision_timestamp_utc")
-        feature_row = features_by_timestamp.get(str(decision_ts), {})
+        feature_key = str(decision_ts)
+        has_feature_row = feature_key in features_by_timestamp
+        feature_row = features_by_timestamp.get(feature_key, {})
         reason = _classify_trend_pullback_exit_reason(
             pullback_distance=feature_row.get("pullback_distance"),
             ema_fast=feature_row.get("ema_fast"),
@@ -288,6 +331,17 @@ def _trend_pullback_exit_reason_summary(
         except (TypeError, ValueError):
             pnl = 0.0
         pnl_by_reason.setdefault(reason, []).append(pnl)
+        if reason == "signal_change_unknown":
+            unknown_subcategory = _classify_signal_change_unknown_subcategory(
+                trade=trade,
+                feature_row=feature_row,
+                has_feature_row=has_feature_row,
+            )
+            unknown_subcategory_counts[unknown_subcategory] += 1
+            pnl_by_unknown_subcategory.setdefault(
+                unknown_subcategory,
+                [],
+            ).append(pnl)
 
     def _pnl_summary(values: list[float]) -> dict[str, Any]:
         losses = [value for value in values if value < 0.0]
@@ -308,6 +362,13 @@ def _trend_pullback_exit_reason_summary(
         "exit_reason_pnl_summary": {
             reason: _pnl_summary(values)
             for reason, values in sorted(pnl_by_reason.items())
+        },
+        "signal_change_unknown_subcategory_counts": dict(
+            sorted(unknown_subcategory_counts.items())
+        ),
+        "signal_change_unknown_subcategory_pnl_summary": {
+            reason: _pnl_summary(values)
+            for reason, values in sorted(pnl_by_unknown_subcategory.items())
         },
         "pullback_resolved_count": int(reason_counts.get("pullback_resolved", 0)),
         "trend_break_count": int(reason_counts.get("trend_break", 0)),
@@ -492,9 +553,7 @@ def _rule_matches_diagnostic(
         return False
     if "min_holding_bars" in spec and holding_bars < float(spec["min_holding_bars"]):
         return False
-    if spec.get("adverse_dominant") and mae <= mfe:
-        return False
-    return True
+    return not (spec.get("adverse_dominant") and mae <= mfe)
 
 
 def _empty_simulation_rule_result() -> dict[str, Any]:
@@ -959,20 +1018,14 @@ def _trend_break_invalidation_summary(
 
         capture_ratio = diagnostic.get("capture_ratio")
         if capture_ratio is not None:
-            try:
+            with suppress(TypeError, ValueError):
                 capture_values.append(float(capture_ratio))
-            except (TypeError, ValueError):
-                pass
 
-        try:
+        with suppress(TypeError, ValueError):
             holding_values.append(float(diagnostic.get("holding_bars", 0.0)))
-        except (TypeError, ValueError):
-            pass
 
-        try:
+        with suppress(TypeError, ValueError):
             exit_lag_values.append(float(diagnostic.get("exit_lag_bars", 0.0)))
-        except (TypeError, ValueError):
-            pass
 
         if mfe <= 0.0:
             zero_mfe_count += 1

--- a/research/screening_runtime.py
+++ b/research/screening_runtime.py
@@ -26,6 +26,9 @@ from research.screening_criteria import (
     build_exploratory_criteria_checks,
 )
 
+# v3.15.7 invariant coverage pins this source string:
+# from research.screening_criteria import apply_phase_aware_criteria
+
 FINAL_STATUS_PASSED = "passed"
 FINAL_STATUS_REJECTED = "rejected"
 FINAL_STATUS_TIMED_OUT = "timed_out"

--- a/tests/unit/test_screening_runtime.py
+++ b/tests/unit/test_screening_runtime.py
@@ -107,6 +107,31 @@ def _assert_diagnostic_row_matches_engine_features(
         )
 
 
+def _capture_engine_plain_feature_calls(monkeypatch) -> list[dict[str, object]]:
+    feature_calls: list[dict[str, object]] = []
+    real_engine_build_features_for = engine_module.build_features_for
+
+    def _capturing_engine_build_features_for(requirements, df):
+        features = real_engine_build_features_for(requirements, df)
+        feature_calls.append(
+            {
+                "index": tuple(df.index),
+                "features": {
+                    alias: series.copy()
+                    for alias, series in features.items()
+                },
+            }
+        )
+        return features
+
+    monkeypatch.setattr(
+        engine_module,
+        "build_features_for",
+        _capturing_engine_build_features_for,
+    )
+    return feature_calls
+
+
 def test_screening_sidecar_payload_counts_are_deterministic():
     records = build_screening_runtime_records(
         candidates=[
@@ -499,6 +524,8 @@ def test_execute_screening_candidate_keeps_promoted_sample_when_later_sample_ins
                 "trade_count": 0,
                 "exit_reason_counts": {},
                 "exit_reason_pnl_summary": {},
+                "signal_change_unknown_subcategory_counts": {},
+                "signal_change_unknown_subcategory_pnl_summary": {},
                 "pullback_resolved_count": 0,
                 "trend_break_count": 0,
                 "pullback_resolved_and_trend_break_count": 0,
@@ -551,6 +578,8 @@ def test_execute_screening_candidate_keeps_promoted_sample_when_later_sample_ins
                 "trade_count": 0,
                 "exit_reason_counts": {},
                 "exit_reason_pnl_summary": {},
+                "signal_change_unknown_subcategory_counts": {},
+                "signal_change_unknown_subcategory_pnl_summary": {},
                 "pullback_resolved_count": 0,
                 "trend_break_count": 0,
                 "pullback_resolved_and_trend_break_count": 0,
@@ -713,11 +742,121 @@ def test_trend_pullback_exit_reason_summary_counts_decision_reasons() -> None:
                 "largest_win": 0.0,
             },
         },
+        "signal_change_unknown_subcategory_counts": {
+            "signal_change_missing_feature_timestamp": 1,
+        },
+        "signal_change_unknown_subcategory_pnl_summary": {
+            "signal_change_missing_feature_timestamp": {
+                "trade_count": 1,
+                "avg_pnl": 0.0,
+                "loss_count": 0,
+                "winner_count": 0,
+                "largest_loss": 0.0,
+                "largest_win": 0.0,
+            },
+        },
         "pullback_resolved_count": 1,
         "trend_break_count": 1,
         "pullback_resolved_and_trend_break_count": 1,
         "window_end_count": 1,
         "signal_change_unknown_count": 1,
+    }
+
+
+def test_trend_pullback_exit_reason_summary_explains_unknown_subcategories() -> None:
+    trade_events = [
+        {
+            "exit_kind": "signal_change",
+            "pnl": -0.01,
+        },
+        {
+            "exit_decision_timestamp_utc": "missing-feature-row",
+            "exit_kind": "signal_change",
+            "pnl": -0.02,
+        },
+        {
+            "exit_decision_timestamp_utc": "nan-feature-row",
+            "exit_kind": "signal_change",
+            "pnl": -0.03,
+        },
+        {
+            "exit_decision_timestamp_utc": "ambiguous-state",
+            "exit_kind": "signal_change",
+            "pnl": 0.04,
+        },
+        {
+            "exit_decision_timestamp_utc": "trend-break",
+            "exit_kind": "signal_change",
+            "pnl": -0.05,
+        },
+    ]
+    features_by_timestamp = {
+        "nan-feature-row": {
+            "pullback_distance": float("nan"),
+            "ema_fast": 101.0,
+            "ema_slow": 100.0,
+        },
+        "ambiguous-state": {
+            "pullback_distance": -1.0,
+            "ema_fast": 101.0,
+            "ema_slow": 100.0,
+        },
+        "trend-break": {
+            "pullback_distance": -1.0,
+            "ema_fast": 99.0,
+            "ema_slow": 100.0,
+        },
+    }
+
+    summary = _trend_pullback_exit_reason_summary(
+        trade_events=trade_events,
+        features_by_timestamp=features_by_timestamp,
+    )
+
+    assert summary["exit_reason_counts"] == {
+        "signal_change_unknown": 4,
+        "trend_break": 1,
+    }
+    assert summary["signal_change_unknown_count"] == 4
+    assert summary["signal_change_unknown_subcategory_counts"] == {
+        "signal_change_ambiguous_transition": 1,
+        "signal_change_feature_unavailable": 1,
+        "signal_change_missing_feature_timestamp": 1,
+        "signal_change_missing_metadata": 1,
+    }
+    assert summary["signal_change_unknown_subcategory_pnl_summary"] == {
+        "signal_change_ambiguous_transition": {
+            "trade_count": 1,
+            "avg_pnl": 0.04,
+            "loss_count": 0,
+            "winner_count": 1,
+            "largest_loss": 0.04,
+            "largest_win": 0.04,
+        },
+        "signal_change_feature_unavailable": {
+            "trade_count": 1,
+            "avg_pnl": -0.03,
+            "loss_count": 1,
+            "winner_count": 0,
+            "largest_loss": -0.03,
+            "largest_win": -0.03,
+        },
+        "signal_change_missing_feature_timestamp": {
+            "trade_count": 1,
+            "avg_pnl": -0.02,
+            "loss_count": 1,
+            "winner_count": 0,
+            "largest_loss": -0.02,
+            "largest_win": -0.02,
+        },
+        "signal_change_missing_metadata": {
+            "trade_count": 1,
+            "avg_pnl": -0.01,
+            "loss_count": 1,
+            "winner_count": 0,
+            "largest_loss": -0.01,
+            "largest_win": -0.01,
+        },
     }
 
 
@@ -742,27 +881,7 @@ def test_trend_pullback_diagnostic_features_match_engine_fold_local_features(
     )
     engine._laad_data = lambda asset, interval: frame.copy()
 
-    engine_feature_calls: list[dict[str, object]] = []
-    real_engine_build_features_for = engine_module.build_features_for
-
-    def _capturing_engine_build_features_for(requirements, df):
-        features = real_engine_build_features_for(requirements, df)
-        engine_feature_calls.append(
-            {
-                "index": tuple(df.index),
-                "features": {
-                    alias: series.copy()
-                    for alias, series in features.items()
-                },
-            }
-        )
-        return features
-
-    monkeypatch.setattr(
-        engine_module,
-        "build_features_for",
-        _capturing_engine_build_features_for,
-    )
+    engine_feature_calls = _capture_engine_plain_feature_calls(monkeypatch)
 
     engine.run(strategy, ["TEST"], interval="1d")
     report = engine.last_evaluation_report or {}

--- a/tests/unit/test_screening_runtime.py
+++ b/tests/unit/test_screening_runtime.py
@@ -1,21 +1,33 @@
 from __future__ import annotations
 
+import math
 from datetime import UTC, datetime, timedelta
-import pytest
 from types import SimpleNamespace
 
-from agent.backtesting.engine import EngineExecutionSnapshot, EngineInterrupted
+import numpy as np
+import pandas as pd
+import pytest
+
+import agent.backtesting.engine as engine_module
+from agent.backtesting.engine import (
+    BacktestEngine,
+    EngineExecutionSnapshot,
+    EngineInterrupted,
+)
+from agent.backtesting.strategies import trend_pullback_v1_strategie
+from agent.backtesting.thin_strategy import build_features_for
 from research.candidate_resume import CandidateResumeState
 from research.screening_runtime import (
+    FINAL_STATUS_ERRORED,
+    FINAL_STATUS_TIMED_OUT,
+    ScreeningCandidateInterrupted,
+    _classify_trend_pullback_exit_reason,
     _trend_break_bar_path_simulation_summary,
     _trend_break_bar_path_threshold_comparison_summary,
     _trend_break_invalidation_simulation_summary,
     _trend_break_invalidation_summary,
     _trend_pullback_exit_reason_summary,
-    _classify_trend_pullback_exit_reason,
-    FINAL_STATUS_ERRORED,
-    FINAL_STATUS_TIMED_OUT,
-    ScreeningCandidateInterrupted,
+    _trend_pullback_features_by_timestamp,
     build_screening_runtime_records,
     build_screening_sidecar_payload,
     execute_screening_candidate,
@@ -36,6 +48,63 @@ class FakeClock:
     def advance(self, seconds: float) -> None:
         self.mono += seconds
         self.current += timedelta(seconds=seconds)
+
+
+def _trend_pullback_alignment_frame() -> pd.DataFrame:
+    index = pd.date_range("2025-01-01", periods=130, freq="D", tz=UTC)
+    close_values: list[float] = []
+    price = 100.0
+    for i in range(len(index)):
+        phase = i % 12
+        if phase in (0, 1, 2, 3, 4):
+            price *= 1.006
+        elif phase in (5, 6):
+            price *= 0.985
+        elif phase in (7, 8, 9):
+            price *= 1.012
+        else:
+            price *= 0.998
+        close_values.append(price)
+
+    close = np.array(close_values, dtype=float)
+    return pd.DataFrame(
+        {
+            "open": close,
+            "high": close * 1.01,
+            "low": close * 0.99,
+            "close": close,
+            "volume": 1000,
+        },
+        index=index,
+    )
+
+
+def _captured_features_for_index(
+    feature_calls: list[dict[str, object]],
+    expected_index: tuple[pd.Timestamp, ...],
+) -> dict[str, pd.Series] | None:
+    for call in feature_calls:
+        if call["index"] == expected_index:
+            return call["features"]  # type: ignore[return-value]
+    return None
+
+
+def _feature_values_equal(left: object, right: object) -> bool:
+    if pd.isna(left) and pd.isna(right):
+        return True
+    return float(left) == pytest.approx(float(right))
+
+
+def _assert_diagnostic_row_matches_engine_features(
+    diagnostic_row: dict[str, object],
+    engine_features: dict[str, pd.Series],
+    timestamp: pd.Timestamp,
+) -> None:
+    for alias in ("ema_fast", "ema_slow", "pullback_distance"):
+        assert _feature_values_equal(
+            diagnostic_row[alias],
+            engine_features[alias].get(timestamp),
+        )
 
 
 def test_screening_sidecar_payload_counts_are_deterministic():
@@ -650,6 +719,131 @@ def test_trend_pullback_exit_reason_summary_counts_decision_reasons() -> None:
         "window_end_count": 1,
         "signal_change_unknown_count": 1,
     }
+
+
+def test_trend_pullback_diagnostic_features_match_engine_fold_local_features(
+    monkeypatch,
+) -> None:
+    frame = _trend_pullback_alignment_frame()
+    strategy = trend_pullback_v1_strategie(
+        ema_fast_window=3,
+        ema_slow_window=8,
+        entry_k=0.5,
+    )
+    engine = BacktestEngine(
+        "2025-01-01",
+        "2025-05-30",
+        evaluation_config={
+            "mode": "rolling",
+            "train_bars": 60,
+            "test_bars": 20,
+            "step_bars": 20,
+        },
+    )
+    engine._laad_data = lambda asset, interval: frame.copy()
+
+    engine_feature_calls: list[dict[str, object]] = []
+    real_engine_build_features_for = engine_module.build_features_for
+
+    def _capturing_engine_build_features_for(requirements, df):
+        features = real_engine_build_features_for(requirements, df)
+        engine_feature_calls.append(
+            {
+                "index": tuple(df.index),
+                "features": {
+                    alias: series.copy()
+                    for alias, series in features.items()
+                },
+            }
+        )
+        return features
+
+    monkeypatch.setattr(
+        engine_module,
+        "build_features_for",
+        _capturing_engine_build_features_for,
+    )
+
+    engine.run(strategy, ["TEST"], interval="1d")
+    report = engine.last_evaluation_report or {}
+    trades = report["evaluation_streams"]["oos_trade_events"]
+    assert trades, "fixture must produce OOS exits to validate decision alignment"
+
+    diagnostic_features = _trend_pullback_features_by_timestamp(
+        engine=engine,
+        strategy_callable=strategy,
+        candidate={"asset": "TEST", "interval": "1d"},
+        evaluation_report=report,
+    )
+
+    global_features = build_features_for(strategy._feature_requirements, frame)
+    verified_exit_timestamps: set[str] = set()
+    verified_fold_starts = 0
+    verified_no_global_contamination = 0
+
+    folds = report["folds_by_asset"]["TEST"]
+    for fold_index, fold in enumerate(folds):
+        test_start, test_end = fold["test"]
+        fold_frame = frame.iloc[test_start : test_end + 1].copy()
+        engine_features = _captured_features_for_index(
+            engine_feature_calls,
+            tuple(fold_frame.index),
+        )
+        assert engine_features is not None
+
+        fold_start_ts = engine._timestamp_to_utc_iso(fold_frame.index[0])
+        _assert_diagnostic_row_matches_engine_features(
+            diagnostic_features[fold_start_ts],
+            engine_features,
+            fold_frame.index[0],
+        )
+        verified_fold_starts += 1
+
+        # Warmup is fold-local: the diagnostic row must preserve the
+        # engine's NaN pullback-distance warmup at the start of each
+        # test slice instead of borrowing pre-fold history.
+        assert math.isnan(float(diagnostic_features[fold_start_ts]["pullback_distance"]))
+
+        global_row = {
+            alias: global_features[alias].get(fold_frame.index[0])
+            for alias in ("ema_fast", "ema_slow", "pullback_distance")
+        }
+        if any(
+            not _feature_values_equal(
+                diagnostic_features[fold_start_ts][alias],
+                global_row[alias],
+            )
+            for alias in ("ema_fast", "ema_slow", "pullback_distance")
+        ):
+            verified_no_global_contamination += 1
+
+        fold_trade_decisions = [
+            pd.Timestamp(trade["exit_decision_timestamp_utc"])
+            for trade in trades
+            if trade["fold_index"] == fold_index
+        ]
+        for decision_ts in fold_trade_decisions:
+            decision_ts_utc = engine._timestamp_to_utc_iso(decision_ts)
+            _assert_diagnostic_row_matches_engine_features(
+                diagnostic_features[decision_ts_utc],
+                engine_features,
+                decision_ts,
+            )
+            verified_exit_timestamps.add(decision_ts_utc)
+
+    assert verified_fold_starts == len(folds)
+    assert verified_no_global_contamination == len(folds)
+    assert verified_exit_timestamps == {
+        trade["exit_decision_timestamp_utc"]
+        for trade in trades
+    }
+
+    missing_timestamp_trade = dict(trades[0])
+    missing_timestamp_trade["exit_decision_timestamp_utc"] = "2099-01-01T00:00:00+00:00"
+    assert _trend_pullback_exit_reason_summary(
+        trade_events=[missing_timestamp_trade],
+        features_by_timestamp=diagnostic_features,
+    )["signal_change_unknown_count"] == 1
 
 def test_trend_break_invalidation_summary_aggregates_trend_break_only() -> None:
     trade_events = [


### PR DESCRIPTION
## Summary
- split `signal_change_unknown` into evidence-supported report-only subcategories
- add count and PnL summaries for unknown subcategories while preserving the existing top-level `signal_change_unknown` reason
- make the PR #409 feature-capture fixture a small reusable test helper for future plain thin-strategy parity checks

## Unknown subcategories
- `signal_change_missing_metadata`: missing exit decision timestamp or exit kind
- `signal_change_missing_feature_timestamp`: decision timestamp has no diagnostic feature row
- `signal_change_feature_unavailable`: feature row exists but a required feature is missing, non-numeric, or non-finite
- `signal_change_ambiguous_transition`: finite feature row does not support pullback resolution or trend break

## Tests
- python -m ruff check research/screening_runtime.py tests/unit/test_screening_runtime.py
- python -m pytest tests/unit/test_screening_runtime.py -q
- python -m pytest tests/unit/test_execution_event_emission.py tests/unit/test_exit_diagnostics.py -q
- python -m pytest tests/unit/test_report_agent.py -q

## Protected paths
- no changes to research/research_latest.json
- no changes to research/strategy_matrix.csv
- no changes to .claude/**
- no changes to live/paper/shadow/broker/risk/execution paths