### PR TITLE
fix: add window-end proximity diagnostics

### DIFF
--- a/research/report_agent.py
+++ b/research/report_agent.py
@@ -775,6 +775,15 @@ def _num(value: Any) -> str:
         return "n/a"
 
 
+def _bucket_counts_text(value: Any) -> str:
+    if not isinstance(value, dict) or not value:
+        return "n/a"
+    return ", ".join(
+        f"{key}={int(count or 0)}"
+        for key, count in sorted(value.items())
+    )
+
+
 def _build_trend_pullback_exit_impact(
     screening_candidates: dict[str, Any] | None,
 ) -> list[dict[str, Any]]:
@@ -811,6 +820,7 @@ def _build_trend_pullback_exit_impact(
 
         pnl = exit_summary.get("exit_reason_pnl_summary") or {}
         counts = exit_summary.get("exit_reason_counts") or {}
+        boundary = exit_summary.get("boundary_proximity_summary") or {}
         pullback = pnl.get("pullback_resolved") or {}
         trend_break = pnl.get("trend_break") or {}
         window_end = pnl.get("window_end") or {}
@@ -831,6 +841,19 @@ def _build_trend_pullback_exit_impact(
                 "trend_break_largest_loss": trend_break.get("largest_loss"),
                 "window_end_count": int(counts.get("window_end", 0) or 0),
                 "window_end_avg_pnl": window_end.get("avg_pnl"),
+                "boundary_proximity_bucket_counts": boundary.get(
+                    "bucket_counts"
+                )
+                or {},
+                "boundary_proximity_by_exit_reason": boundary.get(
+                    "by_exit_reason"
+                )
+                or {},
+                "boundary_proximity_by_unknown_subcategory": boundary.get(
+                    "by_unknown_subcategory"
+                )
+                or {},
+                "boundary_proximity_by_asset": boundary.get("by_asset") or {},
                 "trend_break_avg_mae": invalidation.get("avg_mae"),
                 "trend_break_avg_mfe": invalidation.get("avg_mfe"),
                 "trend_break_zero_mfe_count": invalidation.get("zero_mfe_count"),
@@ -1092,12 +1115,12 @@ def _append_trend_pullback_exit_impact_section(
     lines.append(
         "| Asset | Decision | Pullback count | Pullback avg PnL | "
         "Trend-break count | Trend-break avg PnL | Trend-break largest loss | "
-        "Window-end count | Window-end avg PnL | "
+        "Window-end count | Window-end avg PnL | Boundary buckets | "
         "TB avg MAE | TB avg MFE | TB zero-MFE | TB adverse-dominant | "
         "TB avg hold bars | TB avg exit-lag bars |"
     )
     lines.append(
-        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|"
+        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|---:|---:|---:|---:|---:|"
     )
     for row in rows:
         lines.append(
@@ -1109,6 +1132,7 @@ def _append_trend_pullback_exit_impact_section(
             f"{_pct(row.get('trend_break_largest_loss'))} | "
             f"{row.get('window_end_count')} | "
             f"{_pct(row.get('window_end_avg_pnl'))} | "
+            f"{_bucket_counts_text(row.get('boundary_proximity_bucket_counts'))} | "
             f"{_pct(row.get('trend_break_avg_mae'))} | "
             f"{_pct(row.get('trend_break_avg_mfe'))} | "
             f"{row.get('trend_break_zero_mfe_count')} | "

--- a/research/screening_runtime.py
+++ b/research/screening_runtime.py
@@ -304,15 +304,99 @@ def _classify_signal_change_unknown_subcategory(
     return "signal_change_ambiguous_transition"
 
 
+def _boundary_proximity_bucket(
+    *,
+    bars_to_window_end: int | None,
+    is_window_end_exit: bool,
+) -> str:
+    if bars_to_window_end is None:
+        return "unknown_boundary_distance"
+    if is_window_end_exit or bars_to_window_end == 0:
+        return "window_end"
+    if bars_to_window_end == 1:
+        return "near_window_end_1_bar"
+    if 2 <= bars_to_window_end <= 3:
+        return "near_window_end_2_to_3_bars"
+    return "not_near_window_end"
+
+
+def _boundary_trade_key(trade: dict[str, Any]) -> tuple[str, Any, str]:
+    return (
+        str(trade.get("asset") or ""),
+        trade.get("fold_index"),
+        str(trade.get("exit_decision_timestamp_utc") or ""),
+    )
+
+
+def _boundary_proximity_for_trade(
+    *,
+    trade: dict[str, Any],
+    boundary_by_trade_key: dict[tuple[str, Any, str], dict[str, Any]],
+) -> dict[str, Any]:
+    boundary = boundary_by_trade_key.get(_boundary_trade_key(trade), {})
+    try:
+        bars_to_window_end = int(boundary["bars_to_window_end"])
+    except (KeyError, TypeError, ValueError):
+        bars_to_window_end = None
+
+    is_window_end_exit = str(trade.get("exit_kind") or "") == "window_end"
+    return {
+        "bars_to_window_end": bars_to_window_end,
+        "is_window_end_exit": bool(is_window_end_exit),
+        "is_near_window_end": bool(
+            bars_to_window_end is not None
+            and 0 <= bars_to_window_end <= 3
+        ),
+        "boundary_proximity_bucket": _boundary_proximity_bucket(
+            bars_to_window_end=bars_to_window_end,
+            is_window_end_exit=is_window_end_exit,
+        ),
+    }
+
+
+def _boundary_metric_summary(values: list[float]) -> dict[str, Any]:
+    losses = [value for value in values if value < 0.0]
+    winners = [value for value in values if value > 0.0]
+    total_pnl = float(sum(values))
+    return {
+        "trade_count": int(len(values)),
+        "total_pnl": total_pnl,
+        "avg_pnl": float(total_pnl / len(values)) if values else 0.0,
+        "loss_count": int(len(losses)),
+        "winner_count": int(len(winners)),
+        "largest_loss": float(min(losses)) if losses else 0.0,
+        "largest_win": float(max(winners)) if winners else 0.0,
+    }
+
+
+def _bucket_summary(values_by_bucket: dict[str, list[float]]) -> dict[str, Any]:
+    return {
+        "bucket_counts": {
+            bucket: int(len(values))
+            for bucket, values in sorted(values_by_bucket.items())
+        },
+        "bucket_pnl_summary": {
+            bucket: _boundary_metric_summary(values)
+            for bucket, values in sorted(values_by_bucket.items())
+        },
+    }
+
+
 def _trend_pullback_exit_reason_summary(
     *,
     trade_events: list[Any],
     features_by_timestamp: dict[str, dict[str, Any]],
+    boundary_by_trade_key: dict[tuple[str, Any, str], dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     reason_counts = Counter()
     pnl_by_reason: dict[str, list[float]] = {}
     unknown_subcategory_counts = Counter()
     pnl_by_unknown_subcategory: dict[str, list[float]] = {}
+    boundary_lookup = boundary_by_trade_key or {}
+    pnl_by_boundary_bucket: dict[str, list[float]] = {}
+    boundary_by_reason: dict[str, dict[str, list[float]]] = {}
+    boundary_by_unknown_subcategory: dict[str, dict[str, list[float]]] = {}
+    boundary_by_asset: dict[str, dict[str, list[float]]] = {}
 
     for trade in trade_events:
         if not isinstance(trade, dict):
@@ -334,6 +418,22 @@ def _trend_pullback_exit_reason_summary(
         except (TypeError, ValueError):
             pnl = 0.0
         pnl_by_reason.setdefault(reason, []).append(pnl)
+        boundary = _boundary_proximity_for_trade(
+            trade=trade,
+            boundary_by_trade_key=boundary_lookup,
+        )
+        boundary_bucket = str(boundary["boundary_proximity_bucket"])
+        pnl_by_boundary_bucket.setdefault(boundary_bucket, []).append(pnl)
+        boundary_by_reason.setdefault(reason, {}).setdefault(
+            boundary_bucket,
+            [],
+        ).append(pnl)
+        asset = str(trade.get("asset") or "")
+        if asset:
+            boundary_by_asset.setdefault(asset, {}).setdefault(
+                boundary_bucket,
+                [],
+            ).append(pnl)
         if reason == "signal_change_unknown":
             unknown_subcategory = _classify_signal_change_unknown_subcategory(
                 trade=trade,
@@ -345,6 +445,10 @@ def _trend_pullback_exit_reason_summary(
                 unknown_subcategory,
                 [],
             ).append(pnl)
+            boundary_by_unknown_subcategory.setdefault(
+                unknown_subcategory,
+                {},
+            ).setdefault(boundary_bucket, []).append(pnl)
 
     def _pnl_summary(values: list[float]) -> dict[str, Any]:
         losses = [value for value in values if value < 0.0]
@@ -359,6 +463,22 @@ def _trend_pullback_exit_reason_summary(
         }
 
     trade_count = sum(reason_counts.values())
+    boundary_summary = _bucket_summary(pnl_by_boundary_bucket)
+    boundary_summary["trade_count"] = int(trade_count)
+    boundary_summary["by_exit_reason"] = {
+        reason: _bucket_summary(values_by_bucket)
+        for reason, values_by_bucket in sorted(boundary_by_reason.items())
+    }
+    boundary_summary["by_unknown_subcategory"] = {
+        reason: _bucket_summary(values_by_bucket)
+        for reason, values_by_bucket in sorted(
+            boundary_by_unknown_subcategory.items()
+        )
+    }
+    boundary_summary["by_asset"] = {
+        asset: _bucket_summary(values_by_bucket)
+        for asset, values_by_bucket in sorted(boundary_by_asset.items())
+    }
     return {
         "trade_count": int(trade_count),
         "exit_reason_counts": dict(sorted(reason_counts.items())),
@@ -373,6 +493,7 @@ def _trend_pullback_exit_reason_summary(
             reason: _pnl_summary(values)
             for reason, values in sorted(pnl_by_unknown_subcategory.items())
         },
+        "boundary_proximity_summary": boundary_summary,
         "pullback_resolved_count": int(reason_counts.get("pullback_resolved", 0)),
         "trend_break_count": int(reason_counts.get("trend_break", 0)),
         "pullback_resolved_and_trend_break_count": int(
@@ -458,6 +579,66 @@ def _trend_pullback_features_by_timestamp(
             }
 
     return by_timestamp
+
+
+def _trend_pullback_boundary_by_trade_key(
+    *,
+    engine: Any,
+    candidate: dict[str, Any],
+    evaluation_report: dict[str, Any],
+) -> dict[tuple[str, Any, str], dict[str, Any]]:
+    load_data = getattr(engine, "_laad_data", None)
+    timestamp_to_utc_iso = getattr(engine, "_timestamp_to_utc_iso", None)
+    if load_data is None or timestamp_to_utc_iso is None:
+        return {}
+
+    asset = str(candidate.get("asset") or "")
+    interval = str(candidate.get("interval") or "")
+    if not asset or not interval:
+        return {}
+
+    try:
+        frame = load_data(asset, interval)
+        if frame is None:
+            return {}
+    except Exception:
+        return {}
+
+    folds_by_asset = evaluation_report.get("folds_by_asset") or {}
+    folds = folds_by_asset.get(asset) or evaluation_report.get("folds") or []
+    if not folds:
+        return {}
+
+    by_key: dict[tuple[str, Any, str], dict[str, Any]] = {}
+    for fold_index, fold in enumerate(folds):
+        test_bounds = fold.get("test") if isinstance(fold, dict) else None
+        if not isinstance(test_bounds, list) or len(test_bounds) != 2:
+            continue
+
+        try:
+            test_start = int(test_bounds[0])
+            test_end = int(test_bounds[1])
+        except (TypeError, ValueError):
+            continue
+
+        if test_start < 0 or test_end < test_start or test_end >= len(frame):
+            continue
+
+        fold_frame = frame.iloc[test_start : test_end + 1]
+        for offset, timestamp in enumerate(fold_frame.index):
+            bars_to_window_end = int((len(fold_frame) - 1) - offset)
+            timestamp_utc = str(timestamp_to_utc_iso(timestamp))
+            key = (asset, int(fold_index), timestamp_utc)
+            by_key[key] = {
+                "bars_to_window_end": bars_to_window_end,
+                "is_near_window_end": bool(0 <= bars_to_window_end <= 3),
+                "boundary_proximity_bucket": _boundary_proximity_bucket(
+                    bars_to_window_end=bars_to_window_end,
+                    is_window_end_exit=False,
+                ),
+            }
+
+    return by_key
 
 
 def _safe_mean(values: list[float]) -> float:
@@ -1099,6 +1280,9 @@ def _sample_diagnostic(
     trade_pnls: list[Any],
     trade_events: list[Any],
     trend_pullback_features_by_timestamp: dict[str, dict[str, Any]] | None = None,
+    trend_pullback_boundary_by_trade_key: (
+        dict[tuple[str, Any, str], dict[str, Any]] | None
+    ) = None,
     exit_diagnostics: dict[str, Any] | None = None,
     bar_return_stream: list[Any] | None = None,
 ) -> dict[str, Any]:
@@ -1115,6 +1299,7 @@ def _sample_diagnostic(
             _trend_pullback_exit_reason_summary(
                 trade_events=trade_events,
                 features_by_timestamp=trend_pullback_features_by_timestamp or {},
+                boundary_by_trade_key=trend_pullback_boundary_by_trade_key or {},
             )
             if trend_pullback_features_by_timestamp is not None
             else None
@@ -1377,6 +1562,11 @@ def execute_screening_candidate_samples(
             candidate=candidate,
             evaluation_report=report,
         )
+        trend_pullback_boundary_by_trade_key = _trend_pullback_boundary_by_trade_key(
+            engine=engine,
+            candidate=candidate,
+            evaluation_report=report,
+        )
         sample_diagnostics.append(
             _sample_diagnostic(
                 sample_index=sample_index,
@@ -1388,6 +1578,7 @@ def execute_screening_candidate_samples(
                 trade_pnls=list(trade_pnls),
                 trade_events=list(trade_events),
                 trend_pullback_features_by_timestamp=trend_pullback_features_by_timestamp,
+                trend_pullback_boundary_by_trade_key=trend_pullback_boundary_by_trade_key,
                 exit_diagnostics=exit_diagnostics,
                 bar_return_stream=list(bar_return_stream),
             )

--- a/tests/unit/test_report_agent.py
+++ b/tests/unit/test_report_agent.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
-
 from research.presets import get_preset
 from research.report_agent import (
     REPORT_JSON_PATH,
@@ -14,6 +12,7 @@ from research.report_agent import (
     VERDICT_CANDIDATES_NO_PROMOTION,
     VERDICT_NIETS_BRUIKBAARS,
     VERDICT_PROMOTED,
+    _build_trend_pullback_exit_impact,
     build_report_payload,
     classify_verdict,
     generate_post_run_report,
@@ -21,8 +20,8 @@ from research.report_agent import (
     suggest_next_experiment,
 )
 from research.run_meta import (
-    build_run_meta_payload,
     build_candidate_summary,
+    build_run_meta_payload,
     write_run_meta_sidecar,
 )
 
@@ -195,8 +194,8 @@ def test_suggest_next_experiment_covers_known_shapes():
 
 
 def test_default_report_paths_live_inside_research_folder():
-    assert REPORT_MARKDOWN_PATH == Path("research/report_latest.md")
-    assert REPORT_JSON_PATH == Path("research/report_latest.json")
+    assert Path("research/report_latest.md") == REPORT_MARKDOWN_PATH
+    assert Path("research/report_latest.json") == REPORT_JSON_PATH
 
 
 # ---------------------------------------------------------------------------
@@ -336,7 +335,7 @@ def test_markdown_shows_hypothesis_and_waarom_sections(tmp_path: Path, monkeypat
     )
     _write_meta(meta_path)
 
-    from research.report_agent import render_markdown, build_report_payload
+    from research.report_agent import build_report_payload, render_markdown
 
     report = build_report_payload(
         run_id="run-md",
@@ -402,3 +401,100 @@ def test_next_experiment_steers_to_hypothesis_when_screening_dominant():
         rejection_reasons_by_layer=reasons_by_layer,
     )
     assert "hypothese" in msg.lower() or "family" in msg.lower()
+
+
+def test_trend_pullback_exit_impact_carries_boundary_proximity_evidence():
+    rows = _build_trend_pullback_exit_impact(
+        {
+            "candidates": [
+                {
+                    "asset": "TEST",
+                    "interval": "1d",
+                    "decision": "promoted_to_validation",
+                    "sample_diagnostics_summary": {"best_sample_index": 0},
+                    "sample_diagnostics": [
+                        {
+                            "trend_pullback_exit_reason_summary": {
+                                "exit_reason_counts": {
+                                    "trend_break": 1,
+                                    "window_end": 1,
+                                },
+                                "exit_reason_pnl_summary": {
+                                    "trend_break": {
+                                        "avg_pnl": -0.05,
+                                        "largest_loss": -0.05,
+                                    },
+                                    "window_end": {"avg_pnl": 0.01},
+                                },
+                                "boundary_proximity_summary": {
+                                    "bucket_counts": {
+                                        "window_end": 1,
+                                        "near_window_end_1_bar": 1,
+                                    },
+                                    "by_exit_reason": {
+                                        "trend_break": {
+                                            "bucket_counts": {
+                                                "near_window_end_1_bar": 1,
+                                            },
+                                        },
+                                        "window_end": {
+                                            "bucket_counts": {"window_end": 1},
+                                        },
+                                    },
+                                    "by_unknown_subcategory": {},
+                                    "by_asset": {
+                                        "TEST": {
+                                            "bucket_counts": {
+                                                "window_end": 1,
+                                                "near_window_end_1_bar": 1,
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                            "trend_break_invalidation_summary": {},
+                        },
+                    ],
+                },
+            ],
+        }
+    )
+
+    assert rows[0]["boundary_proximity_bucket_counts"] == {
+        "near_window_end_1_bar": 1,
+        "window_end": 1,
+    }
+    assert rows[0]["boundary_proximity_by_exit_reason"]["trend_break"][
+        "bucket_counts"
+    ] == {"near_window_end_1_bar": 1}
+
+    markdown = render_markdown(
+        {
+            "run_id": "run-boundary",
+            "generated_at_utc": "2026-06-01T08:30:00+00:00",
+            "preset": "trend_equities_4h_baseline",
+            "verdict": VERDICT_PROMOTED,
+            "summary": {
+                "raw": 1,
+                "screened": 1,
+                "validated": 1,
+                "rejected": 0,
+                "promoted": 1,
+            },
+            "candidates": [],
+            "top_rejection_reasons": [],
+            "top_rejection_reasons_by_layer": {
+                "screening_layer": [],
+                "promotion_layer": [],
+            },
+            "per_candidate_diagnostics": [],
+            "join_stats": {},
+            "red_flags": [],
+            "trend_pullback_exit_impact": rows,
+            "regime_diagnostics": {},
+            "statistical_diagnostics": {},
+            "next_experiment": "Review boundary diagnostics.",
+        }
+    )
+    assert "Boundary buckets" in markdown
+    assert "near_window_end_1_bar=1" in markdown

--- a/tests/unit/test_screening_runtime.py
+++ b/tests/unit/test_screening_runtime.py
@@ -22,10 +22,12 @@ from research.screening_runtime import (
     FINAL_STATUS_TIMED_OUT,
     ScreeningCandidateInterrupted,
     _classify_trend_pullback_exit_reason,
+    _sample_diagnostics_summary,
     _trend_break_bar_path_simulation_summary,
     _trend_break_bar_path_threshold_comparison_summary,
     _trend_break_invalidation_simulation_summary,
     _trend_break_invalidation_summary,
+    _trend_pullback_boundary_by_trade_key,
     _trend_pullback_exit_reason_summary,
     _trend_pullback_features_by_timestamp,
     build_screening_runtime_records,
@@ -105,6 +107,17 @@ def _assert_diagnostic_row_matches_engine_features(
             diagnostic_row[alias],
             engine_features[alias].get(timestamp),
         )
+
+
+def _expected_empty_boundary_summary() -> dict[str, object]:
+    return {
+        "trade_count": 0,
+        "bucket_counts": {},
+        "bucket_pnl_summary": {},
+        "by_exit_reason": {},
+        "by_unknown_subcategory": {},
+        "by_asset": {},
+    }
 
 
 def _capture_engine_plain_feature_calls(monkeypatch) -> list[dict[str, object]]:
@@ -526,6 +539,7 @@ def test_execute_screening_candidate_keeps_promoted_sample_when_later_sample_ins
                 "exit_reason_pnl_summary": {},
                 "signal_change_unknown_subcategory_counts": {},
                 "signal_change_unknown_subcategory_pnl_summary": {},
+                "boundary_proximity_summary": _expected_empty_boundary_summary(),
                 "pullback_resolved_count": 0,
                 "trend_break_count": 0,
                 "pullback_resolved_and_trend_break_count": 0,
@@ -580,6 +594,7 @@ def test_execute_screening_candidate_keeps_promoted_sample_when_later_sample_ins
                 "exit_reason_pnl_summary": {},
                 "signal_change_unknown_subcategory_counts": {},
                 "signal_change_unknown_subcategory_pnl_summary": {},
+                "boundary_proximity_summary": _expected_empty_boundary_summary(),
                 "pullback_resolved_count": 0,
                 "trend_break_count": 0,
                 "pullback_resolved_and_trend_break_count": 0,
@@ -755,6 +770,112 @@ def test_trend_pullback_exit_reason_summary_counts_decision_reasons() -> None:
                 "largest_win": 0.0,
             },
         },
+        "boundary_proximity_summary": {
+            "trade_count": 5,
+            "bucket_counts": {
+                "unknown_boundary_distance": 5,
+            },
+            "bucket_pnl_summary": {
+                "unknown_boundary_distance": {
+                    "trade_count": 5,
+                    "total_pnl": 0.0,
+                    "avg_pnl": 0.0,
+                    "loss_count": 0,
+                    "winner_count": 0,
+                    "largest_loss": 0.0,
+                    "largest_win": 0.0,
+                },
+            },
+            "by_exit_reason": {
+                "pullback_resolved": {
+                    "bucket_counts": {"unknown_boundary_distance": 1},
+                    "bucket_pnl_summary": {
+                        "unknown_boundary_distance": {
+                            "trade_count": 1,
+                            "total_pnl": 0.0,
+                            "avg_pnl": 0.0,
+                            "loss_count": 0,
+                            "winner_count": 0,
+                            "largest_loss": 0.0,
+                            "largest_win": 0.0,
+                        },
+                    },
+                },
+                "pullback_resolved_and_trend_break": {
+                    "bucket_counts": {"unknown_boundary_distance": 1},
+                    "bucket_pnl_summary": {
+                        "unknown_boundary_distance": {
+                            "trade_count": 1,
+                            "total_pnl": 0.0,
+                            "avg_pnl": 0.0,
+                            "loss_count": 0,
+                            "winner_count": 0,
+                            "largest_loss": 0.0,
+                            "largest_win": 0.0,
+                        },
+                    },
+                },
+                "signal_change_unknown": {
+                    "bucket_counts": {"unknown_boundary_distance": 1},
+                    "bucket_pnl_summary": {
+                        "unknown_boundary_distance": {
+                            "trade_count": 1,
+                            "total_pnl": 0.0,
+                            "avg_pnl": 0.0,
+                            "loss_count": 0,
+                            "winner_count": 0,
+                            "largest_loss": 0.0,
+                            "largest_win": 0.0,
+                        },
+                    },
+                },
+                "trend_break": {
+                    "bucket_counts": {"unknown_boundary_distance": 1},
+                    "bucket_pnl_summary": {
+                        "unknown_boundary_distance": {
+                            "trade_count": 1,
+                            "total_pnl": 0.0,
+                            "avg_pnl": 0.0,
+                            "loss_count": 0,
+                            "winner_count": 0,
+                            "largest_loss": 0.0,
+                            "largest_win": 0.0,
+                        },
+                    },
+                },
+                "window_end": {
+                    "bucket_counts": {"unknown_boundary_distance": 1},
+                    "bucket_pnl_summary": {
+                        "unknown_boundary_distance": {
+                            "trade_count": 1,
+                            "total_pnl": 0.0,
+                            "avg_pnl": 0.0,
+                            "loss_count": 0,
+                            "winner_count": 0,
+                            "largest_loss": 0.0,
+                            "largest_win": 0.0,
+                        },
+                    },
+                },
+            },
+            "by_unknown_subcategory": {
+                "signal_change_missing_feature_timestamp": {
+                    "bucket_counts": {"unknown_boundary_distance": 1},
+                    "bucket_pnl_summary": {
+                        "unknown_boundary_distance": {
+                            "trade_count": 1,
+                            "total_pnl": 0.0,
+                            "avg_pnl": 0.0,
+                            "loss_count": 0,
+                            "winner_count": 0,
+                            "largest_loss": 0.0,
+                            "largest_win": 0.0,
+                        },
+                    },
+                },
+            },
+            "by_asset": {},
+        },
         "pullback_resolved_count": 1,
         "trend_break_count": 1,
         "pullback_resolved_and_trend_break_count": 1,
@@ -858,6 +979,201 @@ def test_trend_pullback_exit_reason_summary_explains_unknown_subcategories() -> 
             "largest_win": -0.01,
         },
     }
+
+
+def test_trend_pullback_boundary_proximity_summary_is_report_only() -> None:
+    index = pd.date_range(
+        "2025-01-01",
+        periods=6,
+        freq="1D",
+        tz=UTC,
+    )
+    frame = pd.DataFrame({"close": [100, 101, 102, 103, 104, 105]}, index=index)
+    engine = SimpleNamespace(
+        _laad_data=lambda asset, interval: frame.copy(),
+        _timestamp_to_utc_iso=lambda timestamp: pd.Timestamp(timestamp)
+        .tz_convert(UTC)
+        .isoformat(),
+    )
+    candidate = {"asset": "TEST", "interval": "1d"}
+    boundary_by_trade_key = _trend_pullback_boundary_by_trade_key(
+        engine=engine,
+        candidate=candidate,
+        evaluation_report={
+            "folds_by_asset": {
+                "TEST": [
+                    {"test": [0, 5]},
+                ],
+            },
+        },
+    )
+
+    timestamps = [pd.Timestamp(ts).tz_convert(UTC).isoformat() for ts in index]
+    assert boundary_by_trade_key[("TEST", 0, timestamps[5])][
+        "bars_to_window_end"
+    ] == 0
+    assert boundary_by_trade_key[("TEST", 0, timestamps[4])][
+        "bars_to_window_end"
+    ] == 1
+    assert boundary_by_trade_key[("TEST", 0, timestamps[3])][
+        "bars_to_window_end"
+    ] == 2
+
+    trade_events = [
+        {
+            "asset": "TEST",
+            "fold_index": 0,
+            "exit_decision_timestamp_utc": timestamps[5],
+            "exit_kind": "signal_change",
+            "pnl": -0.05,
+        },
+        {
+            "asset": "TEST",
+            "fold_index": 0,
+            "exit_decision_timestamp_utc": timestamps[4],
+            "exit_kind": "signal_change",
+            "pnl": 0.03,
+        },
+        {
+            "asset": "TEST",
+            "fold_index": 0,
+            "exit_decision_timestamp_utc": timestamps[3],
+            "exit_kind": "signal_change",
+            "pnl": -0.02,
+        },
+        {
+            "asset": "TEST",
+            "fold_index": 0,
+            "exit_decision_timestamp_utc": timestamps[0],
+            "exit_kind": "signal_change",
+            "pnl": 0.04,
+        },
+        {
+            "asset": "TEST",
+            "fold_index": 0,
+            "exit_decision_timestamp_utc": timestamps[4],
+            "exit_kind": "window_end",
+            "pnl": 0.01,
+        },
+        {
+            "exit_kind": "signal_change",
+            "pnl": -0.06,
+        },
+    ]
+    features_by_timestamp = {
+        timestamps[5]: {
+            "pullback_distance": -1.0,
+            "ema_fast": 99.0,
+            "ema_slow": 100.0,
+        },
+        timestamps[4]: {
+            "pullback_distance": 1.0,
+            "ema_fast": 101.0,
+            "ema_slow": 100.0,
+        },
+        timestamps[3]: {
+            "pullback_distance": -1.0,
+            "ema_fast": 101.0,
+            "ema_slow": 100.0,
+        },
+        timestamps[0]: {
+            "pullback_distance": 1.0,
+            "ema_fast": 99.0,
+            "ema_slow": 100.0,
+        },
+    }
+
+    summary = _trend_pullback_exit_reason_summary(
+        trade_events=trade_events,
+        features_by_timestamp=features_by_timestamp,
+        boundary_by_trade_key=boundary_by_trade_key,
+    )
+
+    assert summary["exit_reason_counts"] == {
+        "pullback_resolved": 1,
+        "pullback_resolved_and_trend_break": 1,
+        "signal_change_unknown": 2,
+        "trend_break": 1,
+        "window_end": 1,
+    }
+    boundary = summary["boundary_proximity_summary"]
+    assert boundary["bucket_counts"] == {
+        "near_window_end_1_bar": 1,
+        "near_window_end_2_to_3_bars": 1,
+        "not_near_window_end": 1,
+        "unknown_boundary_distance": 1,
+        "window_end": 2,
+    }
+    assert boundary["bucket_pnl_summary"]["window_end"] == {
+        "trade_count": 2,
+        "total_pnl": -0.04,
+        "avg_pnl": -0.02,
+        "loss_count": 1,
+        "winner_count": 1,
+        "largest_loss": -0.05,
+        "largest_win": 0.01,
+    }
+    assert boundary["by_exit_reason"]["trend_break"]["bucket_counts"] == {
+        "window_end": 1,
+    }
+    assert boundary["by_exit_reason"]["window_end"]["bucket_counts"] == {
+        "window_end": 1,
+    }
+    assert boundary["by_unknown_subcategory"][
+        "signal_change_ambiguous_transition"
+    ]["bucket_counts"] == {
+        "near_window_end_2_to_3_bars": 1,
+    }
+    assert boundary["by_unknown_subcategory"][
+        "signal_change_missing_metadata"
+    ]["bucket_counts"] == {
+        "unknown_boundary_distance": 1,
+    }
+    assert boundary["by_asset"]["TEST"]["bucket_counts"] == {
+        "near_window_end_1_bar": 1,
+        "near_window_end_2_to_3_bars": 1,
+        "not_near_window_end": 1,
+        "window_end": 2,
+    }
+
+
+def test_sample_selection_ignores_boundary_proximity_diagnostics() -> None:
+    sample_diagnostics = [
+        {
+            "sample_index": 0,
+            "criteria_checks": {"sufficient_trades": True},
+            "status": "promoted_to_validation",
+            "reason": None,
+            "metrics": {
+                "expectancy": 0.02,
+                "profit_factor": 1.5,
+                "totaal_trades": 10,
+            },
+            "trend_pullback_exit_reason_summary": {
+                "boundary_proximity_summary": {
+                    "bucket_counts": {"window_end": 10},
+                },
+            },
+        },
+        {
+            "sample_index": 1,
+            "criteria_checks": {"sufficient_trades": True},
+            "status": "promoted_to_validation",
+            "reason": None,
+            "metrics": {
+                "expectancy": 0.01,
+                "profit_factor": 5.0,
+                "totaal_trades": 100,
+            },
+            "trend_pullback_exit_reason_summary": {
+                "boundary_proximity_summary": {
+                    "bucket_counts": {"not_near_window_end": 100},
+                },
+            },
+        },
+    ]
+
+    assert _sample_diagnostics_summary(sample_diagnostics)["best_sample_index"] == 0
 
 
 def test_trend_pullback_diagnostic_features_match_engine_fold_local_features(


### PR DESCRIPTION
## Summary
- add report-only trend-pullback boundary proximity buckets by fold/window distance
- aggregate boundary counts and PnL by exit reason, unknown subtype, and asset
- surface best-sample boundary evidence in the trend-pullback exit impact report

## Tests
- python -m ruff check research/screening_runtime.py tests/unit/test_screening_runtime.py research/report_agent.py tests/unit/test_report_agent.py
- python -m pytest tests/unit/test_screening_runtime.py -q
- python -m pytest tests/unit/test_report_agent.py -q
- python -m pytest tests/unit/test_execution_event_emission.py tests/unit/test_exit_diagnostics.py -q
- python -m pytest tests/architecture/test_domain_boundary_smoke.py -q

## Scope
Report-only diagnostics. No strategy behavior, exit policy, best-sample selection, dashboard mutation route, frontend business logic, or frozen contract change.