### PR TITLE
fix: harden exit reason pnl impact diagnostics

### DIFF
--- a/research/report_agent.py
+++ b/research/report_agent.py
@@ -784,6 +784,36 @@ def _bucket_counts_text(value: Any) -> str:
     )
 
 
+def _impact_totals_text(value: Any) -> str:
+    if not isinstance(value, dict) or not value:
+        return "n/a"
+
+    parts: list[str] = []
+    for key, summary in sorted(value.items()):
+        if not isinstance(summary, dict):
+            continue
+        parts.append(f"{key}={_pct(summary.get('total_pnl'))}")
+    return ", ".join(parts) if parts else "n/a"
+
+
+def _worst_total_pnl_text(value: Any) -> str:
+    if not isinstance(value, dict) or not value:
+        return "n/a"
+
+    candidates: list[tuple[str, float]] = []
+    for key, summary in value.items():
+        if not isinstance(summary, dict):
+            continue
+        try:
+            candidates.append((str(key), float(summary.get("total_pnl", 0.0))))
+        except (TypeError, ValueError):
+            continue
+    if not candidates:
+        return "n/a"
+    key, total_pnl = min(candidates, key=lambda item: item[1])
+    return f"{key}={_pct(total_pnl)}"
+
+
 def _build_trend_pullback_exit_impact(
     screening_candidates: dict[str, Any] | None,
 ) -> list[dict[str, Any]]:
@@ -819,11 +849,23 @@ def _build_trend_pullback_exit_impact(
             continue
 
         pnl = exit_summary.get("exit_reason_pnl_summary") or {}
+        realized = exit_summary.get("realized_pnl_impact") or {}
+        exit_reason_impact = realized.get("by_exit_reason") or pnl
+        unknown_subtype_impact = (
+            realized.get("by_unknown_subcategory")
+            or exit_summary.get("signal_change_unknown_subcategory_pnl_summary")
+            or {}
+        )
+        boundary_bucket_impact = (
+            realized.get("by_boundary_proximity_bucket") or {}
+        )
+        asset_impact = realized.get("by_asset") or {}
+        fold_impact = realized.get("by_fold_index") or {}
         counts = exit_summary.get("exit_reason_counts") or {}
         boundary = exit_summary.get("boundary_proximity_summary") or {}
-        pullback = pnl.get("pullback_resolved") or {}
-        trend_break = pnl.get("trend_break") or {}
-        window_end = pnl.get("window_end") or {}
+        pullback = exit_reason_impact.get("pullback_resolved") or {}
+        trend_break = exit_reason_impact.get("trend_break") or {}
+        window_end = exit_reason_impact.get("window_end") or {}
         invalidation = best.get("trend_break_invalidation_summary") or {}
 
         rows.append(
@@ -836,11 +878,19 @@ def _build_trend_pullback_exit_impact(
                     counts.get("pullback_resolved", 0) or 0
                 ),
                 "pullback_resolved_avg_pnl": pullback.get("avg_pnl"),
+                "pullback_resolved_total_pnl": pullback.get("total_pnl"),
                 "trend_break_count": int(counts.get("trend_break", 0) or 0),
                 "trend_break_avg_pnl": trend_break.get("avg_pnl"),
+                "trend_break_total_pnl": trend_break.get("total_pnl"),
                 "trend_break_largest_loss": trend_break.get("largest_loss"),
                 "window_end_count": int(counts.get("window_end", 0) or 0),
                 "window_end_avg_pnl": window_end.get("avg_pnl"),
+                "window_end_total_pnl": window_end.get("total_pnl"),
+                "exit_reason_realized_pnl_impact": exit_reason_impact,
+                "unknown_subtype_realized_pnl_impact": unknown_subtype_impact,
+                "boundary_bucket_realized_pnl_impact": boundary_bucket_impact,
+                "asset_realized_pnl_impact": asset_impact,
+                "fold_realized_pnl_impact": fold_impact,
                 "boundary_proximity_bucket_counts": boundary.get(
                     "bucket_counts"
                 )
@@ -1113,26 +1163,34 @@ def _append_trend_pullback_exit_impact_section(
 
     lines.append("## Trend-pullback exit impact (diagnostic only)")
     lines.append(
-        "| Asset | Decision | Pullback count | Pullback avg PnL | "
-        "Trend-break count | Trend-break avg PnL | Trend-break largest loss | "
-        "Window-end count | Window-end avg PnL | Boundary buckets | "
+        "| Asset | Decision | Pullback count | Pullback total PnL | "
+        "Pullback avg PnL | Trend-break count | Trend-break total PnL | "
+        "Trend-break avg PnL | Trend-break largest loss | Window-end count | "
+        "Window-end total PnL | Window-end avg PnL | Worst exit reason | "
+        "Unknown subtype totals | Boundary buckets | Boundary totals | "
         "TB avg MAE | TB avg MFE | TB zero-MFE | TB adverse-dominant | "
         "TB avg hold bars | TB avg exit-lag bars |"
     )
     lines.append(
-        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|---:|---:|---:|---:|---:|"
+        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|---|---|---|---:|---:|---:|---:|---:|---:|"
     )
     for row in rows:
         lines.append(
             f"| `{row.get('asset')}` | {row.get('decision')} | "
             f"{row.get('pullback_resolved_count')} | "
+            f"{_pct(row.get('pullback_resolved_total_pnl'))} | "
             f"{_pct(row.get('pullback_resolved_avg_pnl'))} | "
             f"{row.get('trend_break_count')} | "
+            f"{_pct(row.get('trend_break_total_pnl'))} | "
             f"{_pct(row.get('trend_break_avg_pnl'))} | "
             f"{_pct(row.get('trend_break_largest_loss'))} | "
             f"{row.get('window_end_count')} | "
+            f"{_pct(row.get('window_end_total_pnl'))} | "
             f"{_pct(row.get('window_end_avg_pnl'))} | "
+            f"{_worst_total_pnl_text(row.get('exit_reason_realized_pnl_impact'))} | "
+            f"{_impact_totals_text(row.get('unknown_subtype_realized_pnl_impact'))} | "
             f"{_bucket_counts_text(row.get('boundary_proximity_bucket_counts'))} | "
+            f"{_impact_totals_text(row.get('boundary_bucket_realized_pnl_impact'))} | "
             f"{_pct(row.get('trend_break_avg_mae'))} | "
             f"{_pct(row.get('trend_break_avg_mfe'))} | "
             f"{row.get('trend_break_zero_mfe_count')} | "

--- a/research/screening_runtime.py
+++ b/research/screening_runtime.py
@@ -354,16 +354,30 @@ def _boundary_proximity_for_trade(
     }
 
 
-def _boundary_metric_summary(values: list[float]) -> dict[str, Any]:
+def _pnl_impact_summary(values: list[float]) -> dict[str, Any]:
     losses = [value for value in values if value < 0.0]
     winners = [value for value in values if value > 0.0]
     total_pnl = float(sum(values))
+    sorted_values = sorted(values)
+    if not sorted_values:
+        median_pnl = 0.0
+    elif len(sorted_values) % 2 == 1:
+        median_pnl = float(sorted_values[len(sorted_values) // 2])
+    else:
+        hi = len(sorted_values) // 2
+        median_pnl = float((sorted_values[hi - 1] + sorted_values[hi]) / 2.0)
+
     return {
         "trade_count": int(len(values)),
         "total_pnl": total_pnl,
         "avg_pnl": float(total_pnl / len(values)) if values else 0.0,
+        "median_pnl": median_pnl,
         "loss_count": int(len(losses)),
         "winner_count": int(len(winners)),
+        "loss_pnl_total": float(sum(losses)),
+        "winner_pnl_total": float(sum(winners)),
+        "loss_rate": float(len(losses) / len(values)) if values else 0.0,
+        "win_rate": float(len(winners) / len(values)) if values else 0.0,
         "largest_loss": float(min(losses)) if losses else 0.0,
         "largest_win": float(max(winners)) if winners else 0.0,
     }
@@ -376,9 +390,18 @@ def _bucket_summary(values_by_bucket: dict[str, list[float]]) -> dict[str, Any]:
             for bucket, values in sorted(values_by_bucket.items())
         },
         "bucket_pnl_summary": {
-            bucket: _boundary_metric_summary(values)
+            bucket: _pnl_impact_summary(values)
             for bucket, values in sorted(values_by_bucket.items())
         },
+    }
+
+
+def _pnl_impact_by_dimension(
+    values_by_key: dict[str, list[float]],
+) -> dict[str, dict[str, Any]]:
+    return {
+        key: _pnl_impact_summary(values)
+        for key, values in sorted(values_by_key.items())
     }
 
 
@@ -394,6 +417,8 @@ def _trend_pullback_exit_reason_summary(
     pnl_by_unknown_subcategory: dict[str, list[float]] = {}
     boundary_lookup = boundary_by_trade_key or {}
     pnl_by_boundary_bucket: dict[str, list[float]] = {}
+    pnl_by_asset: dict[str, list[float]] = {}
+    pnl_by_fold_index: dict[str, list[float]] = {}
     boundary_by_reason: dict[str, dict[str, list[float]]] = {}
     boundary_by_unknown_subcategory: dict[str, dict[str, list[float]]] = {}
     boundary_by_asset: dict[str, dict[str, list[float]]] = {}
@@ -430,10 +455,14 @@ def _trend_pullback_exit_reason_summary(
         ).append(pnl)
         asset = str(trade.get("asset") or "")
         if asset:
+            pnl_by_asset.setdefault(asset, []).append(pnl)
             boundary_by_asset.setdefault(asset, {}).setdefault(
                 boundary_bucket,
                 [],
             ).append(pnl)
+        fold_index = trade.get("fold_index")
+        if fold_index is not None:
+            pnl_by_fold_index.setdefault(str(fold_index), []).append(pnl)
         if reason == "signal_change_unknown":
             unknown_subcategory = _classify_signal_change_unknown_subcategory(
                 trade=trade,
@@ -449,18 +478,6 @@ def _trend_pullback_exit_reason_summary(
                 unknown_subcategory,
                 {},
             ).setdefault(boundary_bucket, []).append(pnl)
-
-    def _pnl_summary(values: list[float]) -> dict[str, Any]:
-        losses = [value for value in values if value < 0.0]
-        winners = [value for value in values if value > 0.0]
-        return {
-            "trade_count": int(len(values)),
-            "avg_pnl": float(sum(values) / len(values)) if values else 0.0,
-            "loss_count": int(len(losses)),
-            "winner_count": int(len(winners)),
-            "largest_loss": float(min(values)) if values else 0.0,
-            "largest_win": float(max(values)) if values else 0.0,
-        }
 
     trade_count = sum(reason_counts.values())
     boundary_summary = _bucket_summary(pnl_by_boundary_bucket)
@@ -483,15 +500,26 @@ def _trend_pullback_exit_reason_summary(
         "trade_count": int(trade_count),
         "exit_reason_counts": dict(sorted(reason_counts.items())),
         "exit_reason_pnl_summary": {
-            reason: _pnl_summary(values)
+            reason: _pnl_impact_summary(values)
             for reason, values in sorted(pnl_by_reason.items())
         },
         "signal_change_unknown_subcategory_counts": dict(
             sorted(unknown_subcategory_counts.items())
         ),
         "signal_change_unknown_subcategory_pnl_summary": {
-            reason: _pnl_summary(values)
+            reason: _pnl_impact_summary(values)
             for reason, values in sorted(pnl_by_unknown_subcategory.items())
+        },
+        "realized_pnl_impact": {
+            "by_exit_reason": _pnl_impact_by_dimension(pnl_by_reason),
+            "by_unknown_subcategory": _pnl_impact_by_dimension(
+                pnl_by_unknown_subcategory
+            ),
+            "by_boundary_proximity_bucket": _pnl_impact_by_dimension(
+                pnl_by_boundary_bucket
+            ),
+            "by_asset": _pnl_impact_by_dimension(pnl_by_asset),
+            "by_fold_index": _pnl_impact_by_dimension(pnl_by_fold_index),
         },
         "boundary_proximity_summary": boundary_summary,
         "pullback_resolved_count": int(reason_counts.get("pullback_resolved", 0)),

--- a/tests/unit/test_report_agent.py
+++ b/tests/unit/test_report_agent.py
@@ -421,10 +421,64 @@ def test_trend_pullback_exit_impact_carries_boundary_proximity_evidence():
                                 },
                                 "exit_reason_pnl_summary": {
                                     "trend_break": {
+                                        "total_pnl": -0.05,
                                         "avg_pnl": -0.05,
                                         "largest_loss": -0.05,
                                     },
-                                    "window_end": {"avg_pnl": 0.01},
+                                    "window_end": {
+                                        "total_pnl": 0.01,
+                                        "avg_pnl": 0.01,
+                                    },
+                                },
+                                "signal_change_unknown_subcategory_pnl_summary": {
+                                    "signal_change_ambiguous_transition": {
+                                        "total_pnl": -0.02,
+                                        "avg_pnl": -0.02,
+                                    },
+                                },
+                                "realized_pnl_impact": {
+                                    "by_exit_reason": {
+                                        "trend_break": {
+                                            "trade_count": 1,
+                                            "total_pnl": -0.05,
+                                            "avg_pnl": -0.05,
+                                            "largest_loss": -0.05,
+                                        },
+                                        "window_end": {
+                                            "trade_count": 1,
+                                            "total_pnl": 0.01,
+                                            "avg_pnl": 0.01,
+                                        },
+                                    },
+                                    "by_unknown_subcategory": {
+                                        "signal_change_ambiguous_transition": {
+                                            "trade_count": 1,
+                                            "total_pnl": -0.02,
+                                            "avg_pnl": -0.02,
+                                        },
+                                    },
+                                    "by_boundary_proximity_bucket": {
+                                        "near_window_end_1_bar": {
+                                            "trade_count": 1,
+                                            "total_pnl": -0.05,
+                                        },
+                                        "window_end": {
+                                            "trade_count": 1,
+                                            "total_pnl": 0.01,
+                                        },
+                                    },
+                                    "by_asset": {
+                                        "TEST": {
+                                            "trade_count": 2,
+                                            "total_pnl": -0.04,
+                                        },
+                                    },
+                                    "by_fold_index": {
+                                        "0": {
+                                            "trade_count": 2,
+                                            "total_pnl": -0.04,
+                                        },
+                                    },
                                 },
                                 "boundary_proximity_summary": {
                                     "bucket_counts": {
@@ -452,7 +506,15 @@ def test_trend_pullback_exit_impact_carries_boundary_proximity_evidence():
                                     },
                                 },
                             },
-                            "trend_break_invalidation_summary": {},
+                            "trend_break_invalidation_summary": {
+                                "avg_mae": 0.11,
+                                "avg_mfe": 0.02,
+                            },
+                            "trend_break_invalidation_simulation_summary": {
+                                "avoided_loss": 0.99,
+                                "sacrificed_profit": 0.88,
+                                "net_pnl_delta": 0.11,
+                            },
                         },
                     ],
                 },
@@ -467,6 +529,19 @@ def test_trend_pullback_exit_impact_carries_boundary_proximity_evidence():
     assert rows[0]["boundary_proximity_by_exit_reason"]["trend_break"][
         "bucket_counts"
     ] == {"near_window_end_1_bar": 1}
+    assert rows[0]["trend_break_total_pnl"] == -0.05
+    assert rows[0]["trend_break_avg_mae"] == 0.11
+    assert rows[0]["exit_reason_realized_pnl_impact"]["trend_break"][
+        "total_pnl"
+    ] == -0.05
+    assert rows[0]["unknown_subtype_realized_pnl_impact"][
+        "signal_change_ambiguous_transition"
+    ]["total_pnl"] == -0.02
+    assert rows[0]["boundary_bucket_realized_pnl_impact"][
+        "near_window_end_1_bar"
+    ]["total_pnl"] == -0.05
+    assert rows[0]["asset_realized_pnl_impact"]["TEST"]["total_pnl"] == -0.04
+    assert rows[0]["fold_realized_pnl_impact"]["0"]["trade_count"] == 2
 
     markdown = render_markdown(
         {
@@ -498,3 +573,6 @@ def test_trend_pullback_exit_impact_carries_boundary_proximity_evidence():
     )
     assert "Boundary buckets" in markdown
     assert "near_window_end_1_bar=1" in markdown
+    assert "Trend-break total PnL" in markdown
+    assert "trend_break=-5.00%" in markdown
+    assert "signal_change_ambiguous_transition=-2.00%" in markdown

--- a/tests/unit/test_screening_runtime.py
+++ b/tests/unit/test_screening_runtime.py
@@ -120,6 +120,16 @@ def _expected_empty_boundary_summary() -> dict[str, object]:
     }
 
 
+def _expected_empty_realized_pnl_impact() -> dict[str, object]:
+    return {
+        "by_exit_reason": {},
+        "by_unknown_subcategory": {},
+        "by_boundary_proximity_bucket": {},
+        "by_asset": {},
+        "by_fold_index": {},
+    }
+
+
 def _capture_engine_plain_feature_calls(monkeypatch) -> list[dict[str, object]]:
     feature_calls: list[dict[str, object]] = []
     real_engine_build_features_for = engine_module.build_features_for
@@ -539,6 +549,7 @@ def test_execute_screening_candidate_keeps_promoted_sample_when_later_sample_ins
                 "exit_reason_pnl_summary": {},
                 "signal_change_unknown_subcategory_counts": {},
                 "signal_change_unknown_subcategory_pnl_summary": {},
+                "realized_pnl_impact": _expected_empty_realized_pnl_impact(),
                 "boundary_proximity_summary": _expected_empty_boundary_summary(),
                 "pullback_resolved_count": 0,
                 "trend_break_count": 0,
@@ -594,6 +605,7 @@ def test_execute_screening_candidate_keeps_promoted_sample_when_later_sample_ins
                 "exit_reason_pnl_summary": {},
                 "signal_change_unknown_subcategory_counts": {},
                 "signal_change_unknown_subcategory_pnl_summary": {},
+                "realized_pnl_impact": _expected_empty_realized_pnl_impact(),
                 "boundary_proximity_summary": _expected_empty_boundary_summary(),
                 "pullback_resolved_count": 0,
                 "trend_break_count": 0,
@@ -703,185 +715,48 @@ def test_trend_pullback_exit_reason_summary_counts_decision_reasons() -> None:
         },
     }
 
-    assert _trend_pullback_exit_reason_summary(
+    summary = _trend_pullback_exit_reason_summary(
         trade_events=trade_events,
         features_by_timestamp=features_by_timestamp,
-    ) == {
-        "trade_count": 5,
-        "exit_reason_counts": {
-            "pullback_resolved": 1,
-            "pullback_resolved_and_trend_break": 1,
-            "signal_change_unknown": 1,
-            "trend_break": 1,
-            "window_end": 1,
-        },
-        "exit_reason_pnl_summary": {
-            "pullback_resolved": {
-                "trade_count": 1,
-                "avg_pnl": 0.0,
-                "loss_count": 0,
-                "winner_count": 0,
-                "largest_loss": 0.0,
-                "largest_win": 0.0,
-            },
-            "pullback_resolved_and_trend_break": {
-                "trade_count": 1,
-                "avg_pnl": 0.0,
-                "loss_count": 0,
-                "winner_count": 0,
-                "largest_loss": 0.0,
-                "largest_win": 0.0,
-            },
-            "signal_change_unknown": {
-                "trade_count": 1,
-                "avg_pnl": 0.0,
-                "loss_count": 0,
-                "winner_count": 0,
-                "largest_loss": 0.0,
-                "largest_win": 0.0,
-            },
-            "trend_break": {
-                "trade_count": 1,
-                "avg_pnl": 0.0,
-                "loss_count": 0,
-                "winner_count": 0,
-                "largest_loss": 0.0,
-                "largest_win": 0.0,
-            },
-            "window_end": {
-                "trade_count": 1,
-                "avg_pnl": 0.0,
-                "loss_count": 0,
-                "winner_count": 0,
-                "largest_loss": 0.0,
-                "largest_win": 0.0,
-            },
-        },
-        "signal_change_unknown_subcategory_counts": {
-            "signal_change_missing_feature_timestamp": 1,
-        },
-        "signal_change_unknown_subcategory_pnl_summary": {
-            "signal_change_missing_feature_timestamp": {
-                "trade_count": 1,
-                "avg_pnl": 0.0,
-                "loss_count": 0,
-                "winner_count": 0,
-                "largest_loss": 0.0,
-                "largest_win": 0.0,
-            },
-        },
-        "boundary_proximity_summary": {
-            "trade_count": 5,
-            "bucket_counts": {
-                "unknown_boundary_distance": 5,
-            },
-            "bucket_pnl_summary": {
-                "unknown_boundary_distance": {
-                    "trade_count": 5,
-                    "total_pnl": 0.0,
-                    "avg_pnl": 0.0,
-                    "loss_count": 0,
-                    "winner_count": 0,
-                    "largest_loss": 0.0,
-                    "largest_win": 0.0,
-                },
-            },
-            "by_exit_reason": {
-                "pullback_resolved": {
-                    "bucket_counts": {"unknown_boundary_distance": 1},
-                    "bucket_pnl_summary": {
-                        "unknown_boundary_distance": {
-                            "trade_count": 1,
-                            "total_pnl": 0.0,
-                            "avg_pnl": 0.0,
-                            "loss_count": 0,
-                            "winner_count": 0,
-                            "largest_loss": 0.0,
-                            "largest_win": 0.0,
-                        },
-                    },
-                },
-                "pullback_resolved_and_trend_break": {
-                    "bucket_counts": {"unknown_boundary_distance": 1},
-                    "bucket_pnl_summary": {
-                        "unknown_boundary_distance": {
-                            "trade_count": 1,
-                            "total_pnl": 0.0,
-                            "avg_pnl": 0.0,
-                            "loss_count": 0,
-                            "winner_count": 0,
-                            "largest_loss": 0.0,
-                            "largest_win": 0.0,
-                        },
-                    },
-                },
-                "signal_change_unknown": {
-                    "bucket_counts": {"unknown_boundary_distance": 1},
-                    "bucket_pnl_summary": {
-                        "unknown_boundary_distance": {
-                            "trade_count": 1,
-                            "total_pnl": 0.0,
-                            "avg_pnl": 0.0,
-                            "loss_count": 0,
-                            "winner_count": 0,
-                            "largest_loss": 0.0,
-                            "largest_win": 0.0,
-                        },
-                    },
-                },
-                "trend_break": {
-                    "bucket_counts": {"unknown_boundary_distance": 1},
-                    "bucket_pnl_summary": {
-                        "unknown_boundary_distance": {
-                            "trade_count": 1,
-                            "total_pnl": 0.0,
-                            "avg_pnl": 0.0,
-                            "loss_count": 0,
-                            "winner_count": 0,
-                            "largest_loss": 0.0,
-                            "largest_win": 0.0,
-                        },
-                    },
-                },
-                "window_end": {
-                    "bucket_counts": {"unknown_boundary_distance": 1},
-                    "bucket_pnl_summary": {
-                        "unknown_boundary_distance": {
-                            "trade_count": 1,
-                            "total_pnl": 0.0,
-                            "avg_pnl": 0.0,
-                            "loss_count": 0,
-                            "winner_count": 0,
-                            "largest_loss": 0.0,
-                            "largest_win": 0.0,
-                        },
-                    },
-                },
-            },
-            "by_unknown_subcategory": {
-                "signal_change_missing_feature_timestamp": {
-                    "bucket_counts": {"unknown_boundary_distance": 1},
-                    "bucket_pnl_summary": {
-                        "unknown_boundary_distance": {
-                            "trade_count": 1,
-                            "total_pnl": 0.0,
-                            "avg_pnl": 0.0,
-                            "loss_count": 0,
-                            "winner_count": 0,
-                            "largest_loss": 0.0,
-                            "largest_win": 0.0,
-                        },
-                    },
-                },
-            },
-            "by_asset": {},
-        },
-        "pullback_resolved_count": 1,
-        "trend_break_count": 1,
-        "pullback_resolved_and_trend_break_count": 1,
-        "window_end_count": 1,
-        "signal_change_unknown_count": 1,
+    )
+
+    assert summary["trade_count"] == 5
+    assert summary["exit_reason_counts"] == {
+        "pullback_resolved": 1,
+        "pullback_resolved_and_trend_break": 1,
+        "signal_change_unknown": 1,
+        "trend_break": 1,
+        "window_end": 1,
     }
+    assert summary["signal_change_unknown_subcategory_counts"] == {
+        "signal_change_missing_feature_timestamp": 1,
+    }
+    assert summary["pullback_resolved_count"] == 1
+    assert summary["trend_break_count"] == 1
+    assert summary["pullback_resolved_and_trend_break_count"] == 1
+    assert summary["window_end_count"] == 1
+    assert summary["signal_change_unknown_count"] == 1
+
+    impact = summary["realized_pnl_impact"]
+    assert impact["by_exit_reason"]["trend_break"]["trade_count"] == 1
+    assert impact["by_exit_reason"]["trend_break"]["total_pnl"] == 0.0
+    assert impact["by_exit_reason"]["trend_break"]["median_pnl"] == 0.0
+    assert impact["by_unknown_subcategory"][
+        "signal_change_missing_feature_timestamp"
+    ]["total_pnl"] == 0.0
+    assert impact["by_boundary_proximity_bucket"][
+        "unknown_boundary_distance"
+    ]["trade_count"] == 5
+
+    boundary = summary["boundary_proximity_summary"]
+    assert boundary["trade_count"] == 5
+    assert boundary["bucket_counts"] == {"unknown_boundary_distance": 5}
+    assert boundary["by_exit_reason"]["trend_break"]["bucket_counts"] == {
+        "unknown_boundary_distance": 1,
+    }
+    assert boundary["by_unknown_subcategory"][
+        "signal_change_missing_feature_timestamp"
+    ]["bucket_counts"] == {"unknown_boundary_distance": 1}
 
 
 def test_trend_pullback_exit_reason_summary_explains_unknown_subcategories() -> None:
@@ -945,40 +820,130 @@ def test_trend_pullback_exit_reason_summary_explains_unknown_subcategories() -> 
         "signal_change_missing_feature_timestamp": 1,
         "signal_change_missing_metadata": 1,
     }
-    assert summary["signal_change_unknown_subcategory_pnl_summary"] == {
-        "signal_change_ambiguous_transition": {
-            "trade_count": 1,
-            "avg_pnl": 0.04,
-            "loss_count": 0,
-            "winner_count": 1,
-            "largest_loss": 0.04,
-            "largest_win": 0.04,
+    subtype_pnl = summary["signal_change_unknown_subcategory_pnl_summary"]
+    assert subtype_pnl["signal_change_ambiguous_transition"] == {
+        "trade_count": 1,
+        "total_pnl": 0.04,
+        "avg_pnl": 0.04,
+        "median_pnl": 0.04,
+        "loss_count": 0,
+        "winner_count": 1,
+        "loss_pnl_total": 0.0,
+        "winner_pnl_total": 0.04,
+        "loss_rate": 0.0,
+        "win_rate": 1.0,
+        "largest_loss": 0.0,
+        "largest_win": 0.04,
+    }
+    assert subtype_pnl["signal_change_feature_unavailable"] == {
+        "trade_count": 1,
+        "total_pnl": -0.03,
+        "avg_pnl": -0.03,
+        "median_pnl": -0.03,
+        "loss_count": 1,
+        "winner_count": 0,
+        "loss_pnl_total": -0.03,
+        "winner_pnl_total": 0.0,
+        "loss_rate": 1.0,
+        "win_rate": 0.0,
+        "largest_loss": -0.03,
+        "largest_win": 0.0,
+    }
+    assert summary["realized_pnl_impact"]["by_unknown_subcategory"] == subtype_pnl
+
+
+def test_trend_pullback_exit_reason_summary_hardens_realized_pnl_impact_dimensions() -> None:
+    trade_events = [
+        {
+            "asset": "LOW",
+            "fold_index": 0,
+            "exit_decision_timestamp_utc": f"pullback-{idx}",
+            "exit_kind": "signal_change",
+            "pnl": 0.001,
+        }
+        for idx in range(5)
+    ]
+    trade_events.extend(
+        [
+            {
+                "asset": "HIGH",
+                "fold_index": 1,
+                "exit_decision_timestamp_utc": "trend-break-damage",
+                "exit_kind": "signal_change",
+                "pnl": -0.12,
+            },
+            {
+                "asset": "HIGH",
+                "fold_index": 1,
+                "exit_decision_timestamp_utc": "ambiguous-unknown",
+                "exit_kind": "signal_change",
+                "pnl": -0.03,
+            },
+        ]
+    )
+    features_by_timestamp = {
+        **{
+            f"pullback-{idx}": {
+                "pullback_distance": 1.0,
+                "ema_fast": 101.0,
+                "ema_slow": 100.0,
+            }
+            for idx in range(5)
         },
-        "signal_change_feature_unavailable": {
-            "trade_count": 1,
-            "avg_pnl": -0.03,
-            "loss_count": 1,
-            "winner_count": 0,
-            "largest_loss": -0.03,
-            "largest_win": -0.03,
+        "trend-break-damage": {
+            "pullback_distance": -1.0,
+            "ema_fast": 99.0,
+            "ema_slow": 100.0,
         },
-        "signal_change_missing_feature_timestamp": {
-            "trade_count": 1,
-            "avg_pnl": -0.02,
-            "loss_count": 1,
-            "winner_count": 0,
-            "largest_loss": -0.02,
-            "largest_win": -0.02,
-        },
-        "signal_change_missing_metadata": {
-            "trade_count": 1,
-            "avg_pnl": -0.01,
-            "loss_count": 1,
-            "winner_count": 0,
-            "largest_loss": -0.01,
-            "largest_win": -0.01,
+        "ambiguous-unknown": {
+            "pullback_distance": -1.0,
+            "ema_fast": 101.0,
+            "ema_slow": 100.0,
         },
     }
+    boundary_by_trade_key = {
+        ("LOW", 0, f"pullback-{idx}"): {"bars_to_window_end": 4 + idx}
+        for idx in range(5)
+    }
+    boundary_by_trade_key[("HIGH", 1, "trend-break-damage")] = {
+        "bars_to_window_end": 1,
+    }
+    boundary_by_trade_key[("HIGH", 1, "ambiguous-unknown")] = {
+        "bars_to_window_end": 0,
+    }
+
+    summary = _trend_pullback_exit_reason_summary(
+        trade_events=trade_events,
+        features_by_timestamp=features_by_timestamp,
+        boundary_by_trade_key=boundary_by_trade_key,
+    )
+
+    assert summary["exit_reason_counts"] == {
+        "pullback_resolved": 5,
+        "signal_change_unknown": 1,
+        "trend_break": 1,
+    }
+    impact = summary["realized_pnl_impact"]
+    assert impact["by_exit_reason"]["pullback_resolved"]["trade_count"] == 5
+    assert impact["by_exit_reason"]["pullback_resolved"]["total_pnl"] == pytest.approx(
+        0.005
+    )
+    assert impact["by_exit_reason"]["trend_break"]["trade_count"] == 1
+    assert impact["by_exit_reason"]["trend_break"]["total_pnl"] == -0.12
+    assert impact["by_exit_reason"]["trend_break"]["loss_rate"] == 1.0
+    assert impact["by_unknown_subcategory"][
+        "signal_change_ambiguous_transition"
+    ]["total_pnl"] == -0.03
+    assert impact["by_boundary_proximity_bucket"][
+        "near_window_end_1_bar"
+    ]["total_pnl"] == -0.12
+    assert impact["by_boundary_proximity_bucket"]["window_end"]["total_pnl"] == -0.03
+    assert impact["by_asset"]["LOW"]["trade_count"] == 5
+    assert impact["by_asset"]["LOW"]["total_pnl"] == pytest.approx(0.005)
+    assert impact["by_asset"]["HIGH"]["trade_count"] == 2
+    assert impact["by_asset"]["HIGH"]["total_pnl"] == -0.15
+    assert impact["by_fold_index"]["0"]["total_pnl"] == pytest.approx(0.005)
+    assert impact["by_fold_index"]["1"]["total_pnl"] == -0.15
 
 
 def test_trend_pullback_boundary_proximity_summary_is_report_only() -> None:
@@ -1108,8 +1073,13 @@ def test_trend_pullback_boundary_proximity_summary_is_report_only() -> None:
         "trade_count": 2,
         "total_pnl": -0.04,
         "avg_pnl": -0.02,
+        "median_pnl": -0.02,
         "loss_count": 1,
         "winner_count": 1,
+        "loss_pnl_total": -0.05,
+        "winner_pnl_total": 0.01,
+        "loss_rate": 0.5,
+        "win_rate": 0.5,
         "largest_loss": -0.05,
         "largest_win": 0.01,
     }
@@ -1135,6 +1105,23 @@ def test_trend_pullback_boundary_proximity_summary_is_report_only() -> None:
         "not_near_window_end": 1,
         "window_end": 2,
     }
+    impact = summary["realized_pnl_impact"]
+    assert impact["by_boundary_proximity_bucket"]["window_end"] == {
+        "trade_count": 2,
+        "total_pnl": -0.04,
+        "avg_pnl": -0.02,
+        "median_pnl": -0.02,
+        "loss_count": 1,
+        "winner_count": 1,
+        "loss_pnl_total": -0.05,
+        "winner_pnl_total": 0.01,
+        "loss_rate": 0.5,
+        "win_rate": 0.5,
+        "largest_loss": -0.05,
+        "largest_win": 0.01,
+    }
+    assert impact["by_asset"]["TEST"]["total_pnl"] == pytest.approx(0.01)
+    assert impact["by_fold_index"]["0"]["trade_count"] == 5
 
 
 def test_sample_selection_ignores_boundary_proximity_diagnostics() -> None:


### PR DESCRIPTION
## Summary
- harden realized exit PnL impact summaries with total, median, loss/winner totals, and win/loss rates
- expose realized impact by exit reason, unknown subtype, boundary bucket, asset, and fold
- add best-sample report fields and Markdown columns for total realized PnL without mixing simulated invalidation deltas

## Tests
- python -m ruff check research/screening_runtime.py tests/unit/test_screening_runtime.py research/report_agent.py tests/unit/test_report_agent.py
- python -m pytest tests/unit/test_screening_runtime.py -q
- python -m pytest tests/unit/test_report_agent.py -q
- python -m pytest tests/unit/test_execution_event_emission.py tests/unit/test_exit_diagnostics.py -q
- python -m pytest tests/architecture/test_domain_boundary_smoke.py -q

## Scope
Report-only diagnostics. No strategy behavior, BacktestEngine trading behavior, exit policy, best-sample selection, dashboard route, frontend logic, or frozen contract change.