### PR TITLE
fix: add exit quality interpretation report

### DIFF
--- a/research/report_agent.py
+++ b/research/report_agent.py
@@ -733,6 +733,9 @@ def build_report_payload(
         "trend_pullback_exit_impact": _build_trend_pullback_exit_impact(
             screening_candidates_payload
         ),
+        "trend_pullback_exit_quality": _build_trend_pullback_exit_quality(
+            screening_candidates_payload
+        ),
         "trend_break_threshold_comparison": (
             trend_break_threshold_comparison := _build_trend_break_threshold_comparison(
                 screening_candidates_payload
@@ -814,6 +817,27 @@ def _worst_total_pnl_text(value: Any) -> str:
     return f"{key}={_pct(total_pnl)}"
 
 
+def _best_sample_diagnostic(
+    candidate: dict[str, Any],
+) -> tuple[int, dict[str, Any], dict[str, Any]] | None:
+    diagnostics = candidate.get("sample_diagnostics")
+    summary = candidate.get("sample_diagnostics_summary") or {}
+    if not isinstance(diagnostics, list) or not diagnostics:
+        return None
+
+    try:
+        best_index = int(summary.get("best_sample_index", 0))
+    except (TypeError, ValueError):
+        best_index = 0
+    if best_index < 0 or best_index >= len(diagnostics):
+        return None
+
+    best = diagnostics[best_index]
+    if not isinstance(best, dict):
+        return None
+    return best_index, best, summary
+
+
 def _build_trend_pullback_exit_impact(
     screening_candidates: dict[str, Any] | None,
 ) -> list[dict[str, Any]]:
@@ -828,21 +852,10 @@ def _build_trend_pullback_exit_impact(
         if not isinstance(candidate, dict):
             continue
 
-        diagnostics = candidate.get("sample_diagnostics")
-        summary = candidate.get("sample_diagnostics_summary") or {}
-        if not isinstance(diagnostics, list) or not diagnostics:
+        best_result = _best_sample_diagnostic(candidate)
+        if best_result is None:
             continue
-
-        try:
-            best_index = int(summary.get("best_sample_index", 0))
-        except (TypeError, ValueError):
-            best_index = 0
-        if best_index < 0 or best_index >= len(diagnostics):
-            continue
-
-        best = diagnostics[best_index]
-        if not isinstance(best, dict):
-            continue
+        best_index, best, _summary = best_result
 
         exit_summary = best.get("trend_pullback_exit_reason_summary")
         if not isinstance(exit_summary, dict):
@@ -914,6 +927,76 @@ def _build_trend_pullback_exit_impact(
                 "trend_break_avg_exit_lag_bars": invalidation.get(
                     "avg_exit_lag_bars"
                 ),
+            }
+        )
+
+    return rows
+
+
+def _build_trend_pullback_exit_quality(
+    screening_candidates: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    if not isinstance(screening_candidates, dict):
+        return []
+    candidates = screening_candidates.get("candidates")
+    if not isinstance(candidates, list):
+        return []
+
+    rows: list[dict[str, Any]] = []
+    for candidate in candidates:
+        if not isinstance(candidate, dict):
+            continue
+
+        best_result = _best_sample_diagnostic(candidate)
+        if best_result is None:
+            continue
+        best_index, best, sample_summary = best_result
+
+        exit_summary = best.get("trend_pullback_exit_reason_summary")
+        if not isinstance(exit_summary, dict):
+            continue
+
+        health = exit_summary.get("exit_health_summary") or {}
+        overall_health = health.get("overall") or {}
+        realized = exit_summary.get("realized_pnl_impact") or {}
+        boundary = exit_summary.get("boundary_proximity_summary") or {}
+        audit = sample_summary.get("best_sample_exit_quality_audit") or {}
+        rows.append(
+            {
+                "asset": candidate.get("asset"),
+                "interval": candidate.get("interval"),
+                "decision": candidate.get("decision"),
+                "best_sample_index": best_index,
+                "advisory_only": True,
+                "exit_health_summary": health,
+                "exit_health_counts": overall_health.get("health_class_counts")
+                or {},
+                "exit_health_by_class": overall_health.get("by_health_class") or {},
+                "exit_health_by_asset": health.get("by_asset") or {},
+                "exit_health_by_reason": health.get("by_exit_reason") or {},
+                "exit_health_by_unknown_subcategory": health.get(
+                    "by_unknown_subcategory"
+                )
+                or {},
+                "exit_health_by_boundary_bucket": health.get(
+                    "by_boundary_proximity_bucket"
+                )
+                or {},
+                "exit_reason_semantics": exit_summary.get("exit_reason_semantics")
+                or {},
+                "exit_reason_realized_pnl_impact": realized.get("by_exit_reason")
+                or {},
+                "unknown_subtype_realized_pnl_impact": realized.get(
+                    "by_unknown_subcategory"
+                )
+                or {},
+                "boundary_bucket_realized_pnl_impact": realized.get(
+                    "by_boundary_proximity_bucket"
+                )
+                or {},
+                "boundary_proximity_bucket_counts": boundary.get("bucket_counts")
+                or {},
+                "best_sample_exit_quality_audit": audit,
             }
         )
 
@@ -1201,6 +1284,58 @@ def _append_trend_pullback_exit_impact_section(
     lines.append("")
 
 
+def _health_share_text(row: dict[str, Any], health_class: str) -> str:
+    summary = row.get("exit_health_by_class") or {}
+    if not isinstance(summary, dict):
+        return "n/a"
+    return _pct((summary.get(health_class) or {}).get("trade_share"))
+
+
+def _append_trend_pullback_exit_quality_section(
+    lines: list[str],
+    rows: list[dict[str, Any]],
+) -> None:
+    if not rows:
+        return
+
+    lines.append("## Trend-pullback exit quality (advisory only)")
+    lines.append(
+        "- Health classes are diagnostic context only; they do not change "
+        "exit reasons, strategy behavior, or sample selection."
+    )
+    lines.append(
+        "- Boundary proximity is context, not reclassification; realized PnL "
+        "impact remains separate from simulated invalidation deltas."
+    )
+    lines.append(
+        "- `pullback_resolved_and_trend_break` is treated as ambiguous late/choppy "
+        "evidence until further research proves otherwise."
+    )
+    lines.append("")
+    lines.append(
+        "| Asset | Decision | Best sample | Health counts | Risk share | "
+        "Unknown share | Boundary share | Late/choppy share | Selected score | "
+        "Exit-quality best | Disagreement | Advisory message |"
+    )
+    lines.append("|---|---|---:|---|---:|---:|---:|---:|---:|---:|---|---|")
+    for row in rows:
+        audit = row.get("best_sample_exit_quality_audit") or {}
+        lines.append(
+            f"| `{row.get('asset')}` | {row.get('decision')} | "
+            f"{row.get('best_sample_index')} | "
+            f"{_bucket_counts_text(row.get('exit_health_counts'))} | "
+            f"{_health_share_text(row, 'risk_exit')} | "
+            f"{_health_share_text(row, 'unknown_exit')} | "
+            f"{_health_share_text(row, 'boundary_exit')} | "
+            f"{_health_share_text(row, 'late_or_choppy_exit')} | "
+            f"{_num(audit.get('selected_sample_health_score'))} | "
+            f"{audit.get('exit_quality_best_sample_index')} | "
+            f"{audit.get('exit_quality_disagreement')} | "
+            f"{audit.get('advisory_message') or 'n/a'} |"
+        )
+    lines.append("")
+
+
 def render_markdown(report: dict[str, Any]) -> str:
     lines: list[str] = []
     preset = report.get("preset") or "(no preset)"
@@ -1230,6 +1365,10 @@ def render_markdown(report: dict[str, Any]) -> str:
     _append_trend_pullback_exit_impact_section(
         lines,
         report.get("trend_pullback_exit_impact") or [],
+    )
+    _append_trend_pullback_exit_quality_section(
+        lines,
+        report.get("trend_pullback_exit_quality") or [],
     )
     _append_trend_break_threshold_comparison_section(
         lines,

--- a/research/screening_runtime.py
+++ b/research/screening_runtime.py
@@ -304,6 +304,67 @@ def _classify_signal_change_unknown_subcategory(
     return "signal_change_ambiguous_transition"
 
 
+def _exit_semantic_metadata(exit_reason: str) -> dict[str, str]:
+    semantic_by_reason = {
+        "pullback_resolved": {
+            "exit_semantic_class": "clean_resolution_exit",
+            "exit_semantic_label": "clean pullback resolution",
+            "exit_semantic_warning": "",
+            "exit_semantic_explanation": (
+                "Pullback resolved without simultaneous trend-break evidence."
+            ),
+        },
+        "trend_break": {
+            "exit_semantic_class": "trend_break_risk_exit",
+            "exit_semantic_label": "trend break",
+            "exit_semantic_warning": "risk exit",
+            "exit_semantic_explanation": (
+                "Trend-following state broke before or at the exit decision."
+            ),
+        },
+        "pullback_resolved_and_trend_break": {
+            "exit_semantic_class": "ambiguous_late_or_choppy_exit",
+            "exit_semantic_label": "simultaneous pullback resolution and trend break",
+            "exit_semantic_warning": "not automatically healthy",
+            "exit_semantic_explanation": (
+                "Pullback resolution and trend-break evidence appeared together; "
+                "keep separate from clean pullback resolution until reviewed."
+            ),
+        },
+        "signal_change_unknown": {
+            "exit_semantic_class": "unknown_exit",
+            "exit_semantic_label": "unknown signal-change exit",
+            "exit_semantic_warning": "requires diagnostic explanation",
+            "exit_semantic_explanation": (
+                "Signal-change exit could not be classified from available "
+                "fold-local features or metadata."
+            ),
+        },
+        "window_end": {
+            "exit_semantic_class": "boundary_exit",
+            "exit_semantic_label": "window-end exit",
+            "exit_semantic_warning": "boundary context",
+            "exit_semantic_explanation": (
+                "Exit occurred because the fold/window ended; treat as boundary "
+                "context rather than strategy exit quality."
+            ),
+        },
+    }
+    return dict(
+        semantic_by_reason.get(
+            exit_reason,
+            {
+                "exit_semantic_class": "unsupported_exit_reason",
+                "exit_semantic_label": str(exit_reason or "unknown"),
+                "exit_semantic_warning": "unsupported exit reason",
+                "exit_semantic_explanation": (
+                    "No advisory semantic mapping exists for this exit reason."
+                ),
+            },
+        )
+    )
+
+
 def _boundary_proximity_bucket(
     *,
     bars_to_window_end: int | None,
@@ -499,6 +560,10 @@ def _trend_pullback_exit_reason_summary(
     return {
         "trade_count": int(trade_count),
         "exit_reason_counts": dict(sorted(reason_counts.items())),
+        "exit_reason_semantics": {
+            reason: _exit_semantic_metadata(reason)
+            for reason in sorted(reason_counts)
+        },
         "exit_reason_pnl_summary": {
             reason: _pnl_impact_summary(values)
             for reason, values in sorted(pnl_by_reason.items())

--- a/research/screening_runtime.py
+++ b/research/screening_runtime.py
@@ -1547,6 +1547,167 @@ def _sample_diagnostic(
         },
     }
 
+
+def _health_class_share(
+    health_summary: dict[str, Any],
+    health_class: str,
+) -> float:
+    try:
+        return float(
+            health_summary["overall"]["by_health_class"]
+            .get(health_class, {})
+            .get("trade_share", 0.0)
+        )
+    except (AttributeError, KeyError, TypeError, ValueError):
+        return 0.0
+
+
+def _health_class_total_pnl(
+    health_summary: dict[str, Any],
+    health_class: str,
+) -> float:
+    try:
+        return float(
+            health_summary["overall"]["by_health_class"]
+            .get(health_class, {})
+            .get("total_pnl", 0.0)
+        )
+    except (AttributeError, KeyError, TypeError, ValueError):
+        return 0.0
+
+
+def _sample_exit_quality_score(sample: dict[str, Any]) -> float:
+    exit_summary = sample.get("trend_pullback_exit_reason_summary") or {}
+    health_summary = exit_summary.get("exit_health_summary") or {}
+    healthy = _health_class_share(health_summary, "healthy_exit")
+    risk = _health_class_share(health_summary, "risk_exit")
+    late = _health_class_share(health_summary, "late_or_choppy_exit")
+    unknown = _health_class_share(health_summary, "unknown_exit")
+    boundary = _health_class_share(health_summary, "boundary_exit")
+    return float(healthy - risk - late - unknown - boundary)
+
+
+def _sample_exit_quality_audit(
+    *,
+    sample_diagnostics: list[dict[str, Any]],
+    selected_best_sample_index: int | None,
+) -> dict[str, Any]:
+    if not sample_diagnostics:
+        return {
+            "advisory_only": True,
+            "selected_best_sample_index": selected_best_sample_index,
+            "performance_best_sample_index": selected_best_sample_index,
+            "exit_quality_best_sample_index": None,
+            "exit_quality_disagreement": False,
+            "selected_sample_health_score": 0.0,
+            "exit_quality_best_health_score": 0.0,
+            "selected_sample_risk_exit_share": 0.0,
+            "selected_sample_unknown_exit_share": 0.0,
+            "selected_sample_boundary_exit_share": 0.0,
+            "selected_sample_late_or_choppy_exit_share": 0.0,
+            "selected_sample_total_pnl": 0.0,
+            "selected_sample_risk_exit_total_pnl": 0.0,
+            "advisory_message": "No sample diagnostics available for exit-quality audit.",
+        }
+
+    scored = [
+        (int(sample.get("sample_index", index)), _sample_exit_quality_score(sample))
+        for index, sample in enumerate(sample_diagnostics)
+    ]
+    exit_quality_best_index, exit_quality_best_score = max(
+        scored,
+        key=lambda item: (item[1], -item[0]),
+    )
+    selected_sample = next(
+        (
+            sample
+            for sample in sample_diagnostics
+            if sample.get("sample_index") == selected_best_sample_index
+        ),
+        None,
+    )
+    selected_health = (
+        (selected_sample.get("trend_pullback_exit_reason_summary") or {}).get(
+            "exit_health_summary"
+        )
+        or {}
+        if isinstance(selected_sample, dict)
+        else {}
+    )
+    selected_impact = (
+        (selected_sample.get("trend_pullback_exit_reason_summary") or {}).get(
+            "realized_pnl_impact"
+        )
+        or {}
+        if isinstance(selected_sample, dict)
+        else {}
+    )
+
+    selected_score = (
+        _sample_exit_quality_score(selected_sample)
+        if isinstance(selected_sample, dict)
+        else 0.0
+    )
+    selected_total_pnl = 0.0
+    try:
+        selected_total_pnl = float(
+            sum(
+                item.get("total_pnl", 0.0)
+                for item in (selected_impact.get("by_exit_reason") or {}).values()
+                if isinstance(item, dict)
+            )
+        )
+    except (AttributeError, TypeError, ValueError):
+        selected_total_pnl = 0.0
+
+    disagreement = (
+        selected_best_sample_index is not None
+        and int(selected_best_sample_index) != int(exit_quality_best_index)
+    )
+    if disagreement:
+        message = (
+            "Selected performance-best sample differs from advisory "
+            "exit-quality-best sample; review before trusting exit quality."
+        )
+    else:
+        message = (
+            "Selected performance-best sample matches advisory exit-quality-best "
+            "sample."
+        )
+
+    return {
+        "advisory_only": True,
+        "selected_best_sample_index": selected_best_sample_index,
+        "performance_best_sample_index": selected_best_sample_index,
+        "exit_quality_best_sample_index": int(exit_quality_best_index),
+        "exit_quality_disagreement": bool(disagreement),
+        "selected_sample_health_score": float(selected_score),
+        "exit_quality_best_health_score": float(exit_quality_best_score),
+        "selected_sample_risk_exit_share": _health_class_share(
+            selected_health,
+            "risk_exit",
+        ),
+        "selected_sample_unknown_exit_share": _health_class_share(
+            selected_health,
+            "unknown_exit",
+        ),
+        "selected_sample_boundary_exit_share": _health_class_share(
+            selected_health,
+            "boundary_exit",
+        ),
+        "selected_sample_late_or_choppy_exit_share": _health_class_share(
+            selected_health,
+            "late_or_choppy_exit",
+        ),
+        "selected_sample_total_pnl": float(selected_total_pnl),
+        "selected_sample_risk_exit_total_pnl": _health_class_total_pnl(
+            selected_health,
+            "risk_exit",
+        ),
+        "advisory_message": message,
+    }
+
+
 def _sample_diagnostics_summary(sample_diagnostics: list[dict[str, Any]]) -> dict[str, Any]:
     reason_counts = Counter(
         str(item.get("reason") or "passed")
@@ -1591,6 +1752,10 @@ def _sample_diagnostics_summary(sample_diagnostics: list[dict[str, Any]]) -> dic
         "best_expectancy": float(best_metrics.get("expectancy", 0.0)),
         "best_profit_factor": float(best_metrics.get("profit_factor", 0.0)),
         "best_totaal_trades": float(best_metrics.get("totaal_trades", 0.0)),
+        "best_sample_exit_quality_audit": _sample_exit_quality_audit(
+            sample_diagnostics=sample_diagnostics,
+            selected_best_sample_index=best_sample_index,
+        ),
     }
 
 def execute_screening_candidate_samples(

--- a/research/screening_runtime.py
+++ b/research/screening_runtime.py
@@ -365,6 +365,17 @@ def _exit_semantic_metadata(exit_reason: str) -> dict[str, str]:
     )
 
 
+def _exit_health_class(exit_reason: str) -> str:
+    health_by_reason = {
+        "pullback_resolved": "healthy_exit",
+        "trend_break": "risk_exit",
+        "pullback_resolved_and_trend_break": "late_or_choppy_exit",
+        "signal_change_unknown": "unknown_exit",
+        "window_end": "boundary_exit",
+    }
+    return health_by_reason.get(exit_reason, "neutral_exit")
+
+
 def _boundary_proximity_bucket(
     *,
     bars_to_window_end: int | None,
@@ -466,6 +477,41 @@ def _pnl_impact_by_dimension(
     }
 
 
+def _exit_health_ratio_summary(
+    pnl_by_health_class: dict[str, list[float]],
+) -> dict[str, Any]:
+    total_trades = sum(len(values) for values in pnl_by_health_class.values())
+    total_pnl = float(
+        sum(sum(values) for values in pnl_by_health_class.values())
+    )
+    if abs(total_pnl) < 1e-12:
+        total_pnl = 0.0
+    by_health_class: dict[str, dict[str, Any]] = {}
+    for health_class, values in sorted(pnl_by_health_class.items()):
+        summary = _pnl_impact_summary(values)
+        summary["trade_share"] = (
+            float(summary["trade_count"] / total_trades)
+            if total_trades
+            else 0.0
+        )
+        summary["pnl_share"] = (
+            float(summary["total_pnl"] / total_pnl)
+            if total_pnl
+            else 0.0
+        )
+        by_health_class[health_class] = summary
+
+    return {
+        "trade_count": int(total_trades),
+        "total_pnl": total_pnl,
+        "health_class_counts": {
+            health_class: int(len(values))
+            for health_class, values in sorted(pnl_by_health_class.items())
+        },
+        "by_health_class": by_health_class,
+    }
+
+
 def _trend_pullback_exit_reason_summary(
     *,
     trade_events: list[Any],
@@ -480,6 +526,11 @@ def _trend_pullback_exit_reason_summary(
     pnl_by_boundary_bucket: dict[str, list[float]] = {}
     pnl_by_asset: dict[str, list[float]] = {}
     pnl_by_fold_index: dict[str, list[float]] = {}
+    pnl_by_health_class: dict[str, list[float]] = {}
+    health_by_asset: dict[str, dict[str, list[float]]] = {}
+    health_by_exit_reason: dict[str, dict[str, list[float]]] = {}
+    health_by_unknown_subcategory: dict[str, dict[str, list[float]]] = {}
+    health_by_boundary_bucket: dict[str, dict[str, list[float]]] = {}
     boundary_by_reason: dict[str, dict[str, list[float]]] = {}
     boundary_by_unknown_subcategory: dict[str, dict[str, list[float]]] = {}
     boundary_by_asset: dict[str, dict[str, list[float]]] = {}
@@ -504,12 +555,22 @@ def _trend_pullback_exit_reason_summary(
         except (TypeError, ValueError):
             pnl = 0.0
         pnl_by_reason.setdefault(reason, []).append(pnl)
+        health_class = _exit_health_class(reason)
+        pnl_by_health_class.setdefault(health_class, []).append(pnl)
+        health_by_exit_reason.setdefault(reason, {}).setdefault(
+            health_class,
+            [],
+        ).append(pnl)
         boundary = _boundary_proximity_for_trade(
             trade=trade,
             boundary_by_trade_key=boundary_lookup,
         )
         boundary_bucket = str(boundary["boundary_proximity_bucket"])
         pnl_by_boundary_bucket.setdefault(boundary_bucket, []).append(pnl)
+        health_by_boundary_bucket.setdefault(boundary_bucket, {}).setdefault(
+            health_class,
+            [],
+        ).append(pnl)
         boundary_by_reason.setdefault(reason, {}).setdefault(
             boundary_bucket,
             [],
@@ -517,6 +578,10 @@ def _trend_pullback_exit_reason_summary(
         asset = str(trade.get("asset") or "")
         if asset:
             pnl_by_asset.setdefault(asset, []).append(pnl)
+            health_by_asset.setdefault(asset, {}).setdefault(
+                health_class,
+                [],
+            ).append(pnl)
             boundary_by_asset.setdefault(asset, {}).setdefault(
                 boundary_bucket,
                 [],
@@ -535,6 +600,10 @@ def _trend_pullback_exit_reason_summary(
                 unknown_subcategory,
                 [],
             ).append(pnl)
+            health_by_unknown_subcategory.setdefault(
+                unknown_subcategory,
+                {},
+            ).setdefault(health_class, []).append(pnl)
             boundary_by_unknown_subcategory.setdefault(
                 unknown_subcategory,
                 {},
@@ -585,6 +654,41 @@ def _trend_pullback_exit_reason_summary(
             ),
             "by_asset": _pnl_impact_by_dimension(pnl_by_asset),
             "by_fold_index": _pnl_impact_by_dimension(pnl_by_fold_index),
+        },
+        "exit_health_summary": {
+            "advisory_only": True,
+            "taxonomy": [
+                "healthy_exit",
+                "risk_exit",
+                "late_or_choppy_exit",
+                "boundary_exit",
+                "unknown_exit",
+                "neutral_exit",
+            ],
+            "overall": _exit_health_ratio_summary(pnl_by_health_class),
+            "by_asset": {
+                asset: _exit_health_ratio_summary(values_by_class)
+                for asset, values_by_class in sorted(health_by_asset.items())
+            },
+            "by_exit_reason": {
+                reason: {
+                    "exit_health_class": _exit_health_class(reason),
+                    "summary": _exit_health_ratio_summary(values_by_class),
+                }
+                for reason, values_by_class in sorted(health_by_exit_reason.items())
+            },
+            "by_unknown_subcategory": {
+                subcategory: _exit_health_ratio_summary(values_by_class)
+                for subcategory, values_by_class in sorted(
+                    health_by_unknown_subcategory.items()
+                )
+            },
+            "by_boundary_proximity_bucket": {
+                bucket: _exit_health_ratio_summary(values_by_class)
+                for bucket, values_by_class in sorted(
+                    health_by_boundary_bucket.items()
+                )
+            },
         },
         "boundary_proximity_summary": boundary_summary,
         "pullback_resolved_count": int(reason_counts.get("pullback_resolved", 0)),

--- a/tests/unit/test_report_agent.py
+++ b/tests/unit/test_report_agent.py
@@ -13,6 +13,7 @@ from research.report_agent import (
     VERDICT_NIETS_BRUIKBAARS,
     VERDICT_PROMOTED,
     _build_trend_pullback_exit_impact,
+    _build_trend_pullback_exit_quality,
     build_report_payload,
     classify_verdict,
     generate_post_run_report,
@@ -576,3 +577,169 @@ def test_trend_pullback_exit_impact_carries_boundary_proximity_evidence():
     assert "Trend-break total PnL" in markdown
     assert "trend_break=-5.00%" in markdown
     assert "signal_change_ambiguous_transition=-2.00%" in markdown
+
+
+def test_trend_pullback_exit_quality_renders_advisory_sections():
+    rows = _build_trend_pullback_exit_quality(
+        {
+            "candidates": [
+                {
+                    "asset": "TEST",
+                    "interval": "1d",
+                    "decision": "promoted_to_validation",
+                    "sample_diagnostics_summary": {
+                        "best_sample_index": 0,
+                        "best_sample_exit_quality_audit": {
+                            "advisory_only": True,
+                            "selected_best_sample_index": 0,
+                            "performance_best_sample_index": 0,
+                            "exit_quality_best_sample_index": 1,
+                            "exit_quality_disagreement": True,
+                            "selected_sample_health_score": -0.6,
+                            "advisory_message": (
+                                "Selected performance-best sample differs from "
+                                "advisory exit-quality-best sample."
+                            ),
+                        },
+                    },
+                    "sample_diagnostics": [
+                        {
+                            "trend_pullback_exit_reason_summary": {
+                                "exit_reason_semantics": {
+                                    "pullback_resolved_and_trend_break": {
+                                        "exit_semantic_class": (
+                                            "ambiguous_late_or_choppy_exit"
+                                        ),
+                                        "exit_semantic_warning": (
+                                            "not automatically healthy"
+                                        ),
+                                    },
+                                },
+                                "exit_health_summary": {
+                                    "overall": {
+                                        "health_class_counts": {
+                                            "healthy_exit": 1,
+                                            "late_or_choppy_exit": 1,
+                                            "risk_exit": 1,
+                                        },
+                                        "by_health_class": {
+                                            "risk_exit": {"trade_share": 0.33},
+                                            "unknown_exit": {"trade_share": 0.0},
+                                            "boundary_exit": {"trade_share": 0.0},
+                                            "late_or_choppy_exit": {
+                                                "trade_share": 0.33,
+                                            },
+                                        },
+                                    },
+                                    "by_asset": {
+                                        "TEST": {
+                                            "overall": {
+                                                "trade_count": 3,
+                                                "total_pnl": -0.04,
+                                            },
+                                        },
+                                    },
+                                    "by_exit_reason": {
+                                        "pullback_resolved_and_trend_break": {
+                                            "exit_health_class": (
+                                                "late_or_choppy_exit"
+                                            ),
+                                        },
+                                    },
+                                    "by_unknown_subcategory": {},
+                                    "by_boundary_proximity_bucket": {
+                                        "not_near_window_end": {
+                                            "overall": {"trade_count": 3},
+                                        },
+                                    },
+                                },
+                                "realized_pnl_impact": {
+                                    "by_exit_reason": {
+                                        "trend_break": {"total_pnl": -0.05},
+                                        "pullback_resolved_and_trend_break": {
+                                            "total_pnl": -0.01,
+                                        },
+                                    },
+                                    "by_unknown_subcategory": {},
+                                    "by_boundary_proximity_bucket": {
+                                        "not_near_window_end": {
+                                            "total_pnl": -0.04,
+                                        },
+                                    },
+                                },
+                                "boundary_proximity_summary": {
+                                    "bucket_counts": {
+                                        "not_near_window_end": 3,
+                                    },
+                                },
+                            },
+                        },
+                    ],
+                },
+            ],
+        }
+    )
+
+    assert rows[0]["advisory_only"] is True
+    assert rows[0]["exit_health_counts"]["late_or_choppy_exit"] == 1
+    assert rows[0]["exit_health_by_reason"][
+        "pullback_resolved_and_trend_break"
+    ]["exit_health_class"] == "late_or_choppy_exit"
+    assert rows[0]["best_sample_exit_quality_audit"][
+        "exit_quality_disagreement"
+    ] is True
+
+    markdown = render_markdown(
+        {
+            "run_id": "run-quality",
+            "generated_at_utc": "2026-06-01T09:30:00+00:00",
+            "preset": "trend_equities_4h_baseline",
+            "verdict": VERDICT_PROMOTED,
+            "summary": {
+                "raw": 1,
+                "screened": 1,
+                "validated": 1,
+                "rejected": 0,
+                "promoted": 1,
+            },
+            "candidates": [],
+            "top_rejection_reasons": [],
+            "top_rejection_reasons_by_layer": {
+                "screening_layer": [],
+                "promotion_layer": [],
+            },
+            "per_candidate_diagnostics": [],
+            "join_stats": {},
+            "red_flags": [],
+            "trend_pullback_exit_quality": rows,
+            "regime_diagnostics": {},
+            "statistical_diagnostics": {},
+            "next_experiment": "Review exit quality.",
+        }
+    )
+    assert "Trend-pullback exit quality (advisory only)" in markdown
+    assert "Health classes are diagnostic context only" in markdown
+    assert "Boundary proximity is context, not reclassification" in markdown
+    assert "realized PnL impact remains separate" in markdown
+    assert "`pullback_resolved_and_trend_break` is treated as ambiguous" in markdown
+    assert "Selected performance-best sample differs" in markdown
+
+
+def test_trend_pullback_exit_quality_handles_missing_diagnostics_gracefully():
+    assert _build_trend_pullback_exit_quality({"candidates": [{}]}) == []
+    assert (
+        _build_trend_pullback_exit_quality(
+            {
+                "candidates": [
+                    {
+                        "asset": "ZERO",
+                        "sample_diagnostics_summary": {"best_sample_index": 0},
+                        "sample_diagnostics": [
+                            {"trend_pullback_exit_reason_summary": {}},
+                        ],
+                    }
+                ],
+            }
+        )[0]["exit_health_counts"]
+        == {}
+    )

--- a/tests/unit/test_screening_runtime.py
+++ b/tests/unit/test_screening_runtime.py
@@ -22,6 +22,7 @@ from research.screening_runtime import (
     FINAL_STATUS_TIMED_OUT,
     ScreeningCandidateInterrupted,
     _classify_trend_pullback_exit_reason,
+    _exit_semantic_metadata,
     _sample_diagnostics_summary,
     _trend_break_bar_path_simulation_summary,
     _trend_break_bar_path_threshold_comparison_summary,
@@ -546,6 +547,7 @@ def test_execute_screening_candidate_keeps_promoted_sample_when_later_sample_ins
             "trend_pullback_exit_reason_summary": {
                 "trade_count": 0,
                 "exit_reason_counts": {},
+                "exit_reason_semantics": {},
                 "exit_reason_pnl_summary": {},
                 "signal_change_unknown_subcategory_counts": {},
                 "signal_change_unknown_subcategory_pnl_summary": {},
@@ -602,6 +604,7 @@ def test_execute_screening_candidate_keeps_promoted_sample_when_later_sample_ins
             "trend_pullback_exit_reason_summary": {
                 "trade_count": 0,
                 "exit_reason_counts": {},
+                "exit_reason_semantics": {},
                 "exit_reason_pnl_summary": {},
                 "signal_change_unknown_subcategory_counts": {},
                 "signal_change_unknown_subcategory_pnl_summary": {},
@@ -665,6 +668,47 @@ def test_classify_trend_pullback_exit_reason_from_decision_features() -> None:
         )
         == "signal_change_unknown"
     )
+
+
+def test_pullback_resolved_and_trend_break_has_ambiguous_advisory_semantics() -> None:
+    reason = _classify_trend_pullback_exit_reason(
+        pullback_distance=1.0,
+        ema_fast=99.0,
+        ema_slow=100.0,
+        exit_kind="signal_change",
+    )
+
+    assert reason == "pullback_resolved_and_trend_break"
+    assert reason != "pullback_resolved"
+
+    semantic = _exit_semantic_metadata(reason)
+    assert semantic["exit_semantic_class"] == "ambiguous_late_or_choppy_exit"
+    assert semantic["exit_semantic_label"] == (
+        "simultaneous pullback resolution and trend break"
+    )
+    assert semantic["exit_semantic_warning"] == "not automatically healthy"
+
+    summary = _trend_pullback_exit_reason_summary(
+        trade_events=[
+            {
+                "exit_decision_timestamp_utc": "decision",
+                "exit_kind": "signal_change",
+            },
+        ],
+        features_by_timestamp={
+            "decision": {
+                "pullback_distance": 1.0,
+                "ema_fast": 99.0,
+                "ema_slow": 100.0,
+            },
+        },
+    )
+    assert summary["exit_reason_counts"] == {
+        "pullback_resolved_and_trend_break": 1,
+    }
+    assert summary["exit_reason_semantics"][
+        "pullback_resolved_and_trend_break"
+    ]["exit_semantic_class"] == "ambiguous_late_or_choppy_exit"
     assert (
         _classify_trend_pullback_exit_reason(
             pullback_distance=-1.0,

--- a/tests/unit/test_screening_runtime.py
+++ b/tests/unit/test_screening_runtime.py
@@ -514,6 +514,25 @@ def test_execute_screening_candidate_keeps_promoted_sample_when_later_sample_ins
         "best_expectancy": 0.02,
         "best_profit_factor": 2.0,
         "best_totaal_trades": 12.0,
+        "best_sample_exit_quality_audit": {
+            "advisory_only": True,
+            "selected_best_sample_index": 0,
+            "performance_best_sample_index": 0,
+            "exit_quality_best_sample_index": 0,
+            "exit_quality_disagreement": False,
+            "selected_sample_health_score": 0.0,
+            "exit_quality_best_health_score": 0.0,
+            "selected_sample_risk_exit_share": 0.0,
+            "selected_sample_unknown_exit_share": 0.0,
+            "selected_sample_boundary_exit_share": 0.0,
+            "selected_sample_late_or_choppy_exit_share": 0.0,
+            "selected_sample_total_pnl": 0.0,
+            "selected_sample_risk_exit_total_pnl": 0.0,
+            "advisory_message": (
+                "Selected performance-best sample matches advisory "
+                "exit-quality-best sample."
+            ),
+        },
     }
     assert outcome["sample_diagnostics"] == [
         {
@@ -1378,6 +1397,90 @@ def test_sample_selection_ignores_boundary_proximity_diagnostics() -> None:
     ]
 
     assert _sample_diagnostics_summary(sample_diagnostics)["best_sample_index"] == 0
+
+
+def test_best_sample_exit_quality_audit_flags_disagreement_without_changing_selection() -> None:
+    sample_diagnostics = [
+        {
+            "sample_index": 0,
+            "criteria_checks": {"sufficient_trades": True},
+            "status": "promoted_to_validation",
+            "reason": None,
+            "metrics": {
+                "expectancy": 0.05,
+                "profit_factor": 2.0,
+                "totaal_trades": 20,
+            },
+            "trend_pullback_exit_reason_summary": {
+                "realized_pnl_impact": {
+                    "by_exit_reason": {
+                        "trend_break": {"total_pnl": -0.10},
+                    },
+                },
+                "exit_health_summary": {
+                    "overall": {
+                        "by_health_class": {
+                            "risk_exit": {
+                                "trade_share": 0.8,
+                                "total_pnl": -0.10,
+                            },
+                            "healthy_exit": {
+                                "trade_share": 0.2,
+                                "total_pnl": 0.02,
+                            },
+                        },
+                    },
+                },
+            },
+        },
+        {
+            "sample_index": 1,
+            "criteria_checks": {"sufficient_trades": True},
+            "status": "promoted_to_validation",
+            "reason": None,
+            "metrics": {
+                "expectancy": 0.01,
+                "profit_factor": 1.2,
+                "totaal_trades": 20,
+            },
+            "trend_pullback_exit_reason_summary": {
+                "realized_pnl_impact": {
+                    "by_exit_reason": {
+                        "pullback_resolved": {"total_pnl": 0.02},
+                    },
+                },
+                "exit_health_summary": {
+                    "overall": {
+                        "by_health_class": {
+                            "healthy_exit": {
+                                "trade_share": 0.9,
+                                "total_pnl": 0.02,
+                            },
+                            "unknown_exit": {
+                                "trade_share": 0.1,
+                                "total_pnl": 0.0,
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    ]
+
+    summary = _sample_diagnostics_summary(sample_diagnostics)
+
+    assert summary["best_sample_index"] == 0
+    audit = summary["best_sample_exit_quality_audit"]
+    assert audit["advisory_only"] is True
+    assert audit["performance_best_sample_index"] == 0
+    assert audit["selected_best_sample_index"] == 0
+    assert audit["exit_quality_best_sample_index"] == 1
+    assert audit["exit_quality_disagreement"] is True
+    assert audit["selected_sample_health_score"] == pytest.approx(-0.6)
+    assert audit["exit_quality_best_health_score"] == pytest.approx(0.8)
+    assert audit["selected_sample_risk_exit_share"] == 0.8
+    assert audit["selected_sample_risk_exit_total_pnl"] == -0.10
+    assert "differs" in audit["advisory_message"]
 
 
 def test_trend_pullback_diagnostic_features_match_engine_fold_local_features(

--- a/tests/unit/test_screening_runtime.py
+++ b/tests/unit/test_screening_runtime.py
@@ -22,6 +22,7 @@ from research.screening_runtime import (
     FINAL_STATUS_TIMED_OUT,
     ScreeningCandidateInterrupted,
     _classify_trend_pullback_exit_reason,
+    _exit_health_class,
     _exit_semantic_metadata,
     _sample_diagnostics_summary,
     _trend_break_bar_path_simulation_summary,
@@ -552,6 +553,7 @@ def test_execute_screening_candidate_keeps_promoted_sample_when_later_sample_ins
                 "signal_change_unknown_subcategory_counts": {},
                 "signal_change_unknown_subcategory_pnl_summary": {},
                 "realized_pnl_impact": _expected_empty_realized_pnl_impact(),
+                "exit_health_summary": _expected_empty_exit_health_summary(),
                 "boundary_proximity_summary": _expected_empty_boundary_summary(),
                 "pullback_resolved_count": 0,
                 "trend_break_count": 0,
@@ -609,6 +611,7 @@ def test_execute_screening_candidate_keeps_promoted_sample_when_later_sample_ins
                 "signal_change_unknown_subcategory_counts": {},
                 "signal_change_unknown_subcategory_pnl_summary": {},
                 "realized_pnl_impact": _expected_empty_realized_pnl_impact(),
+                "exit_health_summary": _expected_empty_exit_health_summary(),
                 "boundary_proximity_summary": _expected_empty_boundary_summary(),
                 "pullback_resolved_count": 0,
                 "trend_break_count": 0,
@@ -709,6 +712,176 @@ def test_pullback_resolved_and_trend_break_has_ambiguous_advisory_semantics() ->
     assert summary["exit_reason_semantics"][
         "pullback_resolved_and_trend_break"
     ]["exit_semantic_class"] == "ambiguous_late_or_choppy_exit"
+
+
+def _expected_empty_exit_health_summary() -> dict[str, object]:
+    return {
+        "advisory_only": True,
+        "taxonomy": [
+            "healthy_exit",
+            "risk_exit",
+            "late_or_choppy_exit",
+            "boundary_exit",
+            "unknown_exit",
+            "neutral_exit",
+        ],
+        "overall": {
+            "trade_count": 0,
+            "total_pnl": 0.0,
+            "health_class_counts": {},
+            "by_health_class": {},
+        },
+        "by_asset": {},
+        "by_exit_reason": {},
+        "by_unknown_subcategory": {},
+        "by_boundary_proximity_bucket": {},
+    }
+
+
+def test_exit_health_ratio_v1_maps_reasons_and_keeps_boundary_context_separate() -> None:
+    assert _exit_health_class("pullback_resolved") == "healthy_exit"
+    assert _exit_health_class("trend_break") == "risk_exit"
+    assert (
+        _exit_health_class("pullback_resolved_and_trend_break")
+        == "late_or_choppy_exit"
+    )
+    assert _exit_health_class("signal_change_unknown") == "unknown_exit"
+    assert _exit_health_class("window_end") == "boundary_exit"
+    assert _exit_health_class("unsupported_reason") == "neutral_exit"
+
+    trade_events = [
+        {
+            "asset": "TEST",
+            "fold_index": 0,
+            "exit_decision_timestamp_utc": "healthy",
+            "exit_kind": "signal_change",
+            "pnl": 0.04,
+        },
+        {
+            "asset": "TEST",
+            "fold_index": 0,
+            "exit_decision_timestamp_utc": "risk",
+            "exit_kind": "signal_change",
+            "pnl": -0.03,
+        },
+        {
+            "asset": "TEST",
+            "fold_index": 0,
+            "exit_decision_timestamp_utc": "late",
+            "exit_kind": "signal_change",
+            "pnl": -0.01,
+        },
+        {
+            "asset": "TEST",
+            "fold_index": 0,
+            "exit_decision_timestamp_utc": "unknown",
+            "exit_kind": "signal_change",
+            "pnl": 0.0,
+        },
+        {
+            "asset": "TEST",
+            "fold_index": 0,
+            "exit_decision_timestamp_utc": "boundary",
+            "exit_kind": "window_end",
+            "pnl": 0.0,
+        },
+    ]
+    features_by_timestamp = {
+        "healthy": {
+            "pullback_distance": 1.0,
+            "ema_fast": 101.0,
+            "ema_slow": 100.0,
+        },
+        "risk": {
+            "pullback_distance": -1.0,
+            "ema_fast": 99.0,
+            "ema_slow": 100.0,
+        },
+        "late": {
+            "pullback_distance": 1.0,
+            "ema_fast": 99.0,
+            "ema_slow": 100.0,
+        },
+        "unknown": {
+            "pullback_distance": -1.0,
+            "ema_fast": 101.0,
+            "ema_slow": 100.0,
+        },
+        "boundary": {
+            "pullback_distance": 1.0,
+            "ema_fast": 101.0,
+            "ema_slow": 100.0,
+        },
+    }
+    summary = _trend_pullback_exit_reason_summary(
+        trade_events=trade_events,
+        features_by_timestamp=features_by_timestamp,
+        boundary_by_trade_key={
+            ("TEST", 0, "risk"): {"bars_to_window_end": 1},
+            ("TEST", 0, "boundary"): {"bars_to_window_end": 0},
+        },
+    )
+
+    health = summary["exit_health_summary"]
+    assert health["advisory_only"] is True
+    assert health["overall"]["health_class_counts"] == {
+        "boundary_exit": 1,
+        "healthy_exit": 1,
+        "late_or_choppy_exit": 1,
+        "risk_exit": 1,
+        "unknown_exit": 1,
+    }
+    assert health["overall"]["by_health_class"]["healthy_exit"][
+        "trade_share"
+    ] == 0.2
+    assert health["overall"]["by_health_class"]["risk_exit"]["total_pnl"] == -0.03
+    assert health["overall"]["by_health_class"]["risk_exit"]["pnl_share"] == 0.0
+    assert health["by_exit_reason"]["trend_break"]["exit_health_class"] == "risk_exit"
+    assert health["by_exit_reason"]["pullback_resolved_and_trend_break"][
+        "exit_health_class"
+    ] == "late_or_choppy_exit"
+    assert health["by_unknown_subcategory"]["signal_change_ambiguous_transition"][
+        "health_class_counts"
+    ] == {"unknown_exit": 1}
+    assert health["by_boundary_proximity_bucket"]["near_window_end_1_bar"][
+        "health_class_counts"
+    ] == {"risk_exit": 1}
+    assert health["by_boundary_proximity_bucket"]["window_end"][
+        "health_class_counts"
+    ] == {"boundary_exit": 1}
+
+
+def test_exit_health_ratio_handles_zero_total_pnl_safely() -> None:
+    summary = _trend_pullback_exit_reason_summary(
+        trade_events=[
+            {
+                "exit_decision_timestamp_utc": "healthy",
+                "exit_kind": "signal_change",
+                "pnl": 0.01,
+            },
+            {
+                "exit_decision_timestamp_utc": "risk",
+                "exit_kind": "signal_change",
+                "pnl": -0.01,
+            },
+        ],
+        features_by_timestamp={
+            "healthy": {
+                "pullback_distance": 1.0,
+                "ema_fast": 101.0,
+                "ema_slow": 100.0,
+            },
+            "risk": {
+                "pullback_distance": -1.0,
+                "ema_fast": 99.0,
+                "ema_slow": 100.0,
+            },
+        },
+    )
+
+    health = summary["exit_health_summary"]["overall"]["by_health_class"]
+    assert health["healthy_exit"]["pnl_share"] == 0.0
+    assert health["risk_exit"]["pnl_share"] == 0.0
     assert (
         _classify_trend_pullback_exit_reason(
             pullback_distance=-1.0,


### PR DESCRIPTION
## Summary
- add advisory semantics for pullback_resolved_and_trend_break without changing top-level exit reasons
- add report-only exit health ratio summaries and best-sample exit-quality audit
- expose exit quality interpretation in existing report JSON/Markdown surfaces

## Validation
- python -m ruff check research/screening_runtime.py tests/unit/test_screening_runtime.py research/report_agent.py tests/unit/test_report_agent.py
- python -m pytest tests/unit/test_screening_runtime.py -q
- python -m pytest tests/unit/test_report_agent.py -q
- python -m pytest tests/unit/test_execution_event_emission.py tests/unit/test_exit_diagnostics.py -q
- python -m pytest tests/architecture/test_domain_boundary_smoke.py -q
- python -m pytest tests/architecture/test_domain_import_scanner.py -q

## Scope
Report-only/advisory. No strategy behavior, best-sample selection, frozen contract, dashboard route, frontend, live/paper/shadow/broker/risk/execution, or .claude changes.