### PR TITLE
fix: add no paper candidate diagnosis action plan

### DIFF
--- a/research/report_agent.py
+++ b/research/report_agent.py
@@ -469,6 +469,161 @@ def _paper_readiness_blocker_diagnosis(
 
 
 
+
+def _infer_regular_asset_scope_from_report(
+    *,
+    preset_name: Any,
+    diagnosis: dict[str, Any] | None,
+) -> bool:
+    preset = str(preset_name or "").lower()
+    if any(token in preset for token in ("equities", "equity", "stocks", "stock")):
+        return True
+    if any(token in preset for token in ("crypto", "btc", "eth")):
+        return False
+
+    rows = (diagnosis or {}).get("candidates") if isinstance(diagnosis, dict) else []
+    if not isinstance(rows, list) or not rows:
+        return False
+    asset_types = {
+        str(row.get("asset_type") or "").lower()
+        for row in rows
+        if isinstance(row, dict)
+    }
+    return bool(asset_types) and asset_types.issubset({"equity", "stock"})
+
+
+def _next_research_action_from_paper_diagnosis(
+    *,
+    preset_name: Any,
+    paper_diagnosis: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Translate paper-readiness diagnosis into a bounded next action plan.
+
+    This is an advisory/report-only gate. It can recommend diagnostics or
+    operator-gated proposal review, but it never mutates presets, campaigns,
+    strategies, paper runtime, shadow runtime, or live state.
+    """
+    if not paper_diagnosis:
+        return None
+
+    search_status = str(
+        paper_diagnosis.get("paper_candidate_search_status") or "unknown"
+    )
+    regular_asset_scope = _infer_regular_asset_scope_from_report(
+        preset_name=preset_name,
+        diagnosis=paper_diagnosis,
+    )
+    dominant_diagnoses = [
+        str(row.get("diagnosis_class"))
+        for row in (paper_diagnosis.get("dominant_diagnoses") or [])
+        if isinstance(row, dict) and row.get("diagnosis_class")
+    ]
+    dominant_blockers = [
+        str(row.get("reason"))
+        for row in (paper_diagnosis.get("dominant_blockers") or [])
+        if isinstance(row, dict) and row.get("reason")
+    ]
+    closest = paper_diagnosis.get("closest_candidate") or {}
+    closest_diagnosis = (
+        str(closest.get("diagnosis_class") or "") if isinstance(closest, dict) else ""
+    )
+
+    if search_status == "ready_candidate_found":
+        action_id = "review_ready_paper_candidate"
+        proposal_gate_status = "not_needed_ready_candidate_exists"
+        action_mode = "operator_review"
+        reason_codes = ["paper_ready_candidate_exists"]
+        bounded_next_step = "review_ready_candidate_for_operator_shadow_or_paper_followup"
+    elif closest_diagnosis == "paper_engine_divergence_gap":
+        action_id = "inspect_paper_engine_divergence"
+        proposal_gate_status = "blocked_until_divergence_explained"
+        action_mode = "automatic_diagnostic"
+        reason_codes = ["closest_candidate_has_execution_events_but_high_divergence"]
+        bounded_next_step = (
+            "inspect_paper_engine_divergence_components_before_new_hypothesis_or_preset"
+        )
+    elif "execution_event_coverage_gap" in dominant_diagnoses:
+        action_id = "inspect_execution_event_coverage"
+        proposal_gate_status = "blocked_until_execution_coverage_explained"
+        action_mode = "automatic_diagnostic"
+        reason_codes = ["dominant_blocker_missing_execution_events"]
+        bounded_next_step = (
+            "inspect_validated_candidates_without_reconstructed_execution_events"
+        )
+    elif search_status == "no_ready_candidate":
+        action_id = "diagnose_no_paper_candidate"
+        proposal_gate_status = "blocked_pending_blocker_attribution"
+        action_mode = "automatic_diagnostic"
+        reason_codes = ["no_ready_paper_candidate"]
+        bounded_next_step = "diagnose_paper_readiness_blockers_before_more_preset_runs"
+    elif search_status == "missing_paper_readiness":
+        action_id = "repair_paper_readiness_artifacts"
+        proposal_gate_status = "blocked_missing_readiness_artifact"
+        action_mode = "automatic_diagnostic"
+        reason_codes = ["paper_readiness_artifact_missing"]
+        bounded_next_step = "run_or_repair_paper_readiness_sidecar_generation"
+    else:
+        action_id = "inspect_paper_candidate_search_state"
+        proposal_gate_status = "blocked_unknown_paper_candidate_state"
+        action_mode = "automatic_diagnostic"
+        reason_codes = ["paper_candidate_search_state_unknown"]
+        bounded_next_step = "inspect_latest_paper_candidate_search_artifacts"
+
+    hypothesis_preset_proposal_gate = {
+        "gate_status": proposal_gate_status,
+        "regular_asset_scope": regular_asset_scope,
+        "automatic_preset_mutation_allowed": False,
+        "automatic_strategy_mutation_allowed": False,
+        "automatic_campaign_queue_mutation_allowed": False,
+        "operator_approval_required_for_new_hypothesis_or_preset": True,
+        "allowed_after": [
+            "paper_readiness_blockers_explained",
+            "execution_event_coverage_or_divergence_diagnosed",
+            "operator_approves_bounded_hypothesis_or_preset_review",
+        ],
+    }
+
+    if regular_asset_scope and proposal_gate_status.startswith("blocked"):
+        hypothesis_preset_proposal_gate["regular_asset_research_direction"] = (
+            "do_not_try_more_regular_asset_presets_blindly"
+        )
+    elif regular_asset_scope:
+        hypothesis_preset_proposal_gate["regular_asset_research_direction"] = (
+            "operator_review_ready_candidate_before_new_regular_asset_preset"
+        )
+
+    return {
+        "schema_version": "no_paper_candidate_next_action_plan.v1",
+        "advisory_only": True,
+        "authoritative": False,
+        "diagnostic_only": True,
+        "live_eligible": False,
+        "paper_runtime_enabled": False,
+        "shadow_runtime_enabled": False,
+        "preset_name": preset_name,
+        "paper_candidate_search_status": search_status,
+        "regular_asset_scope": regular_asset_scope,
+        "dominant_blockers": dominant_blockers,
+        "dominant_diagnoses": dominant_diagnoses,
+        "closest_candidate": closest,
+        "recommended_action_id": action_id,
+        "recommended_action_mode": action_mode,
+        "reason_codes": reason_codes,
+        "bounded_next_step": bounded_next_step,
+        "hypothesis_preset_proposal_gate": hypothesis_preset_proposal_gate,
+        "forbidden_actions": [
+            "blind_regular_asset_preset_search",
+            "automatic_strategy_change",
+            "automatic_preset_change",
+            "automatic_campaign_queue_mutation",
+            "paper_runtime_activation",
+            "shadow_runtime_activation",
+            "live_trading",
+        ],
+    }
+
+
+
 def _candidate_shadow_readiness_report(
     paper_readiness: dict[str, Any] | None,
     exit_quality_rows: list[dict[str, Any]],
@@ -1134,6 +1289,14 @@ def build_report_payload(
             _load_json(_PAPER_READINESS_SIDECAR),
             _build_trend_pullback_exit_quality(screening_candidates_payload),
         ),
+        "no_paper_candidate_next_action_plan": _next_research_action_from_paper_diagnosis(
+            preset_name=preset_name,
+            paper_diagnosis=_paper_readiness_blocker_diagnosis(
+                _load_json(_PAPER_READINESS_SIDECAR),
+                _load_json(_PAPER_LEDGER_SIDECAR),
+                _load_json(_PAPER_DIVERGENCE_SIDECAR),
+            ),
+        ),
     }
 
 
@@ -1762,6 +1925,10 @@ def render_markdown(report: dict[str, Any]) -> str:
         lines,
         report.get("candidate_shadow_readiness_report"),
     )
+    _append_no_paper_candidate_next_action_section(
+        lines,
+        report.get("no_paper_candidate_next_action_plan"),
+    )
 
     red_flags = report.get("red_flags") or []
     if red_flags:
@@ -1941,6 +2108,59 @@ def _append_paper_readiness_blocker_diagnosis_section(
         "- advisory: this diagnosis explains why paper candidates are absent; "
         "it does not change readiness thresholds, presets, strategies, campaign queues, "
         "or paper/shadow/live runtime."
+    )
+    lines.append("")
+
+
+
+
+def _append_no_paper_candidate_next_action_section(
+    lines: list[str], summary: dict[str, Any] | None
+) -> None:
+    """Render bounded next action plan when no paper candidate is available."""
+    if not summary:
+        return
+    lines.append("## No Paper Candidate Next Action Plan (advisory only)")
+    lines.append(
+        f"- paper_candidate_search_status: {summary.get('paper_candidate_search_status')}"
+    )
+    lines.append(f"- regular_asset_scope: {summary.get('regular_asset_scope')}")
+    lines.append(f"- recommended_action_id: {summary.get('recommended_action_id')}")
+    lines.append(f"- recommended_action_mode: {summary.get('recommended_action_mode')}")
+    lines.append(
+        "- reason_codes: "
+        + (
+            ", ".join(str(code) for code in (summary.get("reason_codes") or []))
+            if summary.get("reason_codes")
+            else "none"
+        )
+    )
+    lines.append(f"- bounded_next_step: {summary.get('bounded_next_step')}")
+    gate = summary.get("hypothesis_preset_proposal_gate") or {}
+    lines.append(
+        "- hypothesis_preset_proposal_gate: "
+        f"status={gate.get('gate_status')}, "
+        f"operator_approval_required="
+        f"{gate.get('operator_approval_required_for_new_hypothesis_or_preset')}, "
+        f"automatic_preset_mutation_allowed="
+        f"{gate.get('automatic_preset_mutation_allowed')}, "
+        f"automatic_strategy_mutation_allowed="
+        f"{gate.get('automatic_strategy_mutation_allowed')}, "
+        f"automatic_campaign_queue_mutation_allowed="
+        f"{gate.get('automatic_campaign_queue_mutation_allowed')}"
+    )
+    if gate.get("regular_asset_research_direction"):
+        lines.append(
+            "- regular_asset_research_direction: "
+            f"{gate.get('regular_asset_research_direction')}"
+        )
+    lines.append(
+        "- forbidden_actions: "
+        + ", ".join(str(item) for item in (summary.get("forbidden_actions") or []))
+    )
+    lines.append(
+        "- advisory: QRE should explain missing paper candidates before more manual "
+        "preset attempts; any new hypothesis or preset proposal remains operator-gated."
     )
     lines.append("")
 

--- a/research/report_agent.py
+++ b/research/report_agent.py
@@ -236,6 +236,239 @@ def _paper_layer_summary(
 
 
 
+
+def _candidate_id_asset_hint(candidate_id: Any) -> str | None:
+    if not isinstance(candidate_id, str) or not candidate_id:
+        return None
+    parts = candidate_id.split("|")
+    if len(parts) >= 2 and parts[1]:
+        return parts[1]
+    return None
+
+
+def _paper_readiness_diagnosis_class(
+    *,
+    status: str | None,
+    blocking_reasons: list[str],
+    warnings: list[str],
+    evidence: dict[str, Any],
+) -> str:
+    if status == "ready_for_paper_promotion":
+        return "ready_candidate_found"
+    if "missing_execution_events" in blocking_reasons:
+        return "execution_event_coverage_gap"
+    if "excessive_divergence" in blocking_reasons:
+        return "paper_engine_divergence_gap"
+    if "insufficient_oos_days" in blocking_reasons:
+        return "insufficient_return_evidence"
+    if "no_candidate_returns" in blocking_reasons:
+        return "missing_return_evidence"
+    if "malformed_return_stream" in blocking_reasons:
+        return "malformed_return_evidence"
+    if "insufficient_venue_mapping" in blocking_reasons:
+        return "venue_mapping_gap"
+    if "negative_paper_sharpe" in warnings:
+        return "weak_paper_performance_signal"
+    if status == "insufficient_evidence":
+        return "insufficient_evidence"
+    if not evidence:
+        return "missing_candidate_evidence"
+    return "paper_readiness_blocked_unknown"
+
+
+def _paper_readiness_next_action_for_diagnosis(diagnosis_class: str) -> str:
+    mapping = {
+        "ready_candidate_found": "review_ready_candidate_for_operator_shadow_or_paper_followup",
+        "execution_event_coverage_gap": "inspect_validated_candidate_execution_event_coverage",
+        "paper_engine_divergence_gap": "inspect_paper_engine_divergence_components_before_threshold_or_strategy_changes",
+        "insufficient_return_evidence": "collect_more_oos_return_evidence_before_paper_review",
+        "missing_return_evidence": "repair_candidate_return_stream_before_paper_review",
+        "malformed_return_evidence": "repair_malformed_candidate_return_stream_before_paper_review",
+        "venue_mapping_gap": "inspect_venue_mapping_before_paper_review",
+        "weak_paper_performance_signal": "keep_candidate_blocked_until_paper_performance_signal_improves",
+        "insufficient_evidence": "collect_more_candidate_evidence_before_paper_review",
+        "missing_candidate_evidence": "run_or_repair_paper_readiness_sidecar_generation",
+    }
+    return mapping.get(
+        diagnosis_class,
+        "inspect_paper_readiness_blockers_before_new_strategy_or_preset_changes",
+    )
+
+
+def _paper_candidate_evidence_score(row: dict[str, Any]) -> tuple[int, int, int, int, int]:
+    status = str(row.get("readiness_status") or "")
+    blockers = row.get("blocking_reasons") if isinstance(row.get("blocking_reasons"), list) else []
+
+    event_count = int(row.get("paper_ledger_event_count") or 0)
+    status_score = 3 if status == "ready_for_paper_promotion" else 0
+
+    # A blocked candidate with real reconstructed paper events is closer to
+    # paper readiness than a candidate with low divergence caused by zero events.
+    event_presence_score = 1 if event_count > 0 else 0
+    event_score = event_count
+
+    divergence_score = 0
+    severity = row.get("divergence_severity")
+    if severity == "low":
+        divergence_score = 2
+    elif severity == "medium":
+        divergence_score = 1
+
+    obs_score = int(row.get("timestamped_returns_n_obs") or 0)
+
+    # Fewer blockers should win only after evidence coverage and quality.
+    blocker_penalty = -len(blockers)
+    return (
+        status_score,
+        event_presence_score,
+        event_score,
+        divergence_score,
+        obs_score + blocker_penalty,
+    )
+
+
+def _paper_readiness_blocker_diagnosis(
+    paper_readiness: dict[str, Any] | None,
+    paper_ledger: dict[str, Any] | None,
+    paper_divergence: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Build a generic paper-readiness blocker diagnosis.
+
+    This is report-only and does not alter readiness thresholds, strategy
+    behavior, preset behavior, campaign queues, or runtime activation.
+    """
+    if not paper_readiness and not paper_ledger and not paper_divergence:
+        return None
+
+    readiness = paper_readiness or {}
+    entries = readiness.get("entries") if isinstance(readiness, dict) else []
+    if not isinstance(entries, list):
+        entries = []
+
+    ledger = paper_ledger or {}
+    divergence = paper_divergence or {}
+
+    blocker_counts: dict[str, int] = {}
+    warning_counts: dict[str, int] = {}
+    diagnosis_counts: dict[str, int] = {}
+    candidate_rows: list[dict[str, Any]] = []
+
+    ready_count = 0
+    blocked_count = 0
+    insufficient_count = 0
+
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+
+        status = str(entry.get("readiness_status") or "unknown")
+        if status == "ready_for_paper_promotion":
+            ready_count += 1
+        elif status == "blocked":
+            blocked_count += 1
+        elif status == "insufficient_evidence":
+            insufficient_count += 1
+
+        blocking_reasons = list(entry.get("blocking_reasons") or [])
+        warnings = list(entry.get("warnings") or [])
+        evidence = entry.get("evidence") if isinstance(entry.get("evidence"), dict) else {}
+
+        for reason in blocking_reasons:
+            blocker_counts[str(reason)] = blocker_counts.get(str(reason), 0) + 1
+        for warning in warnings:
+            warning_counts[str(warning)] = warning_counts.get(str(warning), 0) + 1
+
+        diagnosis_class = _paper_readiness_diagnosis_class(
+            status=status,
+            blocking_reasons=[str(reason) for reason in blocking_reasons],
+            warnings=[str(warning) for warning in warnings],
+            evidence=evidence,
+        )
+        diagnosis_counts[diagnosis_class] = diagnosis_counts.get(diagnosis_class, 0) + 1
+
+        candidate_rows.append(
+            {
+                "candidate_id": entry.get("candidate_id"),
+                "asset_hint": _candidate_id_asset_hint(entry.get("candidate_id")),
+                "asset_type": entry.get("asset_type"),
+                "sleeve_id": entry.get("sleeve_id"),
+                "readiness_status": status,
+                "blocking_reasons": blocking_reasons,
+                "warnings": warnings,
+                "paper_ledger_event_count": int(evidence.get("paper_ledger_event_count") or 0),
+                "timestamped_returns_n_obs": int(evidence.get("timestamped_returns_n_obs") or 0),
+                "divergence_severity": evidence.get("divergence_severity"),
+                "paper_sharpe_proxy": evidence.get("paper_sharpe_proxy"),
+                "diagnosis_class": diagnosis_class,
+                "recommended_next_action": _paper_readiness_next_action_for_diagnosis(
+                    diagnosis_class
+                ),
+            }
+        )
+
+    if ready_count > 0:
+        search_status = "ready_candidate_found"
+    elif entries:
+        search_status = "no_ready_candidate"
+    elif paper_readiness:
+        search_status = "insufficient_evidence"
+    else:
+        search_status = "missing_paper_readiness"
+
+    closest = None
+    if candidate_rows:
+        closest = max(candidate_rows, key=_paper_candidate_evidence_score)
+
+    dominant_blockers = [
+        {"reason": reason, "count": count}
+        for reason, count in sorted(
+            blocker_counts.items(),
+            key=lambda item: (-item[1], item[0]),
+        )
+    ]
+    dominant_diagnoses = [
+        {"diagnosis_class": reason, "count": count}
+        for reason, count in sorted(
+            diagnosis_counts.items(),
+            key=lambda item: (-item[1], item[0]),
+        )
+    ]
+
+    if ready_count > 0:
+        recommended = "review_ready_candidate_for_operator_shadow_or_paper_followup"
+    elif closest:
+        recommended = closest["recommended_next_action"]
+    elif not paper_readiness:
+        recommended = "run_or_repair_paper_readiness_sidecar_generation"
+    else:
+        recommended = "inspect_paper_readiness_blockers_before_new_strategy_or_preset_changes"
+
+    return {
+        "schema_version": "paper_readiness_blocker_diagnosis.v1",
+        "advisory_only": True,
+        "authoritative": False,
+        "diagnostic_only": True,
+        "live_eligible": False,
+        "paper_runtime_enabled": False,
+        "shadow_runtime_enabled": False,
+        "paper_candidate_search_status": search_status,
+        "candidate_count": len(candidate_rows),
+        "ready_candidate_count": ready_count,
+        "blocked_candidate_count": blocked_count,
+        "insufficient_evidence_candidate_count": insufficient_count,
+        "dominant_blockers": dominant_blockers,
+        "warning_counts": dict(sorted(warning_counts.items())),
+        "diagnosis_counts": dict(sorted(diagnosis_counts.items())),
+        "dominant_diagnoses": dominant_diagnoses,
+        "closest_candidate": closest,
+        "recommended_next_action": recommended,
+        "ledger_event_counts": ledger.get("overall_event_counts") or {},
+        "divergence_severity_counts": divergence.get("severity_counts") or {},
+        "candidates": candidate_rows,
+    }
+
+
+
 def _candidate_shadow_readiness_report(
     paper_readiness: dict[str, Any] | None,
     exit_quality_rows: list[dict[str, Any]],
@@ -892,6 +1125,11 @@ def build_report_payload(
             _load_json(_PAPER_DIVERGENCE_SIDECAR),
             _load_json(_PAPER_READINESS_SIDECAR),
         ),
+        "paper_readiness_blocker_diagnosis": _paper_readiness_blocker_diagnosis(
+            _load_json(_PAPER_READINESS_SIDECAR),
+            _load_json(_PAPER_LEDGER_SIDECAR),
+            _load_json(_PAPER_DIVERGENCE_SIDECAR),
+        ),
         "candidate_shadow_readiness_report": _candidate_shadow_readiness_report(
             _load_json(_PAPER_READINESS_SIDECAR),
             _build_trend_pullback_exit_quality(screening_candidates_payload),
@@ -1516,6 +1754,10 @@ def render_markdown(report: dict[str, Any]) -> str:
     _append_lifecycle_breakdown_section(lines, report.get("lifecycle_breakdown"))
     _append_portfolio_layer_section(lines, report.get("portfolio_layer_summary"))
     _append_paper_layer_section(lines, report.get("paper_layer_summary"))
+    _append_paper_readiness_blocker_diagnosis_section(
+        lines,
+        report.get("paper_readiness_blocker_diagnosis"),
+    )
     _append_candidate_shadow_readiness_section(
         lines,
         report.get("candidate_shadow_readiness_report"),
@@ -1631,6 +1873,74 @@ def _append_paper_layer_section(
     )
     lines.append(
         f"- live_eligible: {summary.get('live_eligible')} (v3.15 is research-only)"
+    )
+    lines.append("")
+
+
+
+
+def _append_paper_readiness_blocker_diagnosis_section(
+    lines: list[str], summary: dict[str, Any] | None
+) -> None:
+    """Render generic paper-readiness blocker diagnosis."""
+    if not summary:
+        return
+    lines.append("## Paper Readiness Blocker Diagnosis (advisory only)")
+    lines.append(
+        f"- paper_candidate_search_status: {summary.get('paper_candidate_search_status')}"
+    )
+    lines.append(
+        "- candidates: "
+        f"total={summary.get('candidate_count')}, "
+        f"ready={summary.get('ready_candidate_count')}, "
+        f"blocked={summary.get('blocked_candidate_count')}, "
+        f"insufficient_evidence={summary.get('insufficient_evidence_candidate_count')}"
+    )
+    blockers = summary.get("dominant_blockers") or []
+    lines.append(
+        "- dominant_blockers: "
+        + (
+            ", ".join(
+                f"{row.get('reason')}={row.get('count')}"
+                for row in blockers
+                if isinstance(row, dict)
+            )
+            if blockers
+            else "none"
+        )
+    )
+    diagnoses = summary.get("dominant_diagnoses") or []
+    lines.append(
+        "- dominant_diagnoses: "
+        + (
+            ", ".join(
+                f"{row.get('diagnosis_class')}={row.get('count')}"
+                for row in diagnoses
+                if isinstance(row, dict)
+            )
+            if diagnoses
+            else "none"
+        )
+    )
+    closest = summary.get("closest_candidate") or {}
+    if closest:
+        lines.append(
+            "- closest_candidate: "
+            f"{closest.get('candidate_id')} "
+            f"status={closest.get('readiness_status')} "
+            f"diagnosis={closest.get('diagnosis_class')} "
+            f"events={closest.get('paper_ledger_event_count')} "
+            f"divergence={closest.get('divergence_severity')}"
+        )
+    else:
+        lines.append("- closest_candidate: none")
+    lines.append(
+        f"- recommended_next_action: {summary.get('recommended_next_action')}"
+    )
+    lines.append(
+        "- advisory: this diagnosis explains why paper candidates are absent; "
+        "it does not change readiness thresholds, presets, strategies, campaign queues, "
+        "or paper/shadow/live runtime."
     )
     lines.append("")
 

--- a/tests/unit/test_report_agent.py
+++ b/tests/unit/test_report_agent.py
@@ -977,3 +977,142 @@ def test_paper_readiness_blocker_diagnosis_renders_markdown_advisory_section():
     assert "recommended_next_action: review_ready_candidate_for_operator_shadow_or_paper_followup" in markdown
     assert "it does not change readiness thresholds" in markdown
 
+def test_no_paper_candidate_next_action_blocks_blind_regular_asset_preset_search():
+    from research.report_agent import _next_research_action_from_paper_diagnosis
+
+    plan = _next_research_action_from_paper_diagnosis(
+        preset_name="trend_pullback_equities_4h",
+        paper_diagnosis={
+            "paper_candidate_search_status": "no_ready_candidate",
+            "dominant_blockers": [{"reason": "missing_execution_events", "count": 3}],
+            "dominant_diagnoses": [
+                {"diagnosis_class": "execution_event_coverage_gap", "count": 3}
+            ],
+            "closest_candidate": {
+                "candidate_id": "strategy|AAPL|4h|{}",
+                "asset_type": "equity",
+                "diagnosis_class": "execution_event_coverage_gap",
+                "paper_ledger_event_count": 0,
+            },
+            "candidates": [
+                {"candidate_id": "strategy|AAPL|4h|{}", "asset_type": "equity"}
+            ],
+        },
+    )
+
+    assert plan is not None
+    assert plan["regular_asset_scope"] is True
+    assert plan["recommended_action_id"] == "inspect_execution_event_coverage"
+    assert plan["recommended_action_mode"] == "automatic_diagnostic"
+    assert plan["bounded_next_step"] == (
+        "inspect_validated_candidates_without_reconstructed_execution_events"
+    )
+    gate = plan["hypothesis_preset_proposal_gate"]
+    assert gate["gate_status"] == "blocked_until_execution_coverage_explained"
+    assert gate["regular_asset_research_direction"] == (
+        "do_not_try_more_regular_asset_presets_blindly"
+    )
+    assert gate["automatic_preset_mutation_allowed"] is False
+    assert gate["automatic_strategy_mutation_allowed"] is False
+    assert gate["automatic_campaign_queue_mutation_allowed"] is False
+    assert gate["operator_approval_required_for_new_hypothesis_or_preset"] is True
+    assert "blind_regular_asset_preset_search" in plan["forbidden_actions"]
+    assert plan["paper_runtime_enabled"] is False
+    assert plan["shadow_runtime_enabled"] is False
+    assert plan["live_eligible"] is False
+
+
+def test_no_paper_candidate_next_action_prioritizes_divergence_for_closest_candidate():
+    from research.report_agent import _next_research_action_from_paper_diagnosis
+
+    plan = _next_research_action_from_paper_diagnosis(
+        preset_name="trend_pullback_equities_4h",
+        paper_diagnosis={
+            "paper_candidate_search_status": "no_ready_candidate",
+            "dominant_blockers": [
+                {"reason": "missing_execution_events", "count": 3},
+                {"reason": "excessive_divergence", "count": 1},
+            ],
+            "dominant_diagnoses": [
+                {"diagnosis_class": "execution_event_coverage_gap", "count": 3},
+                {"diagnosis_class": "paper_engine_divergence_gap", "count": 1},
+            ],
+            "closest_candidate": {
+                "candidate_id": "strategy|HD|4h|{}",
+                "asset_type": "equity",
+                "diagnosis_class": "paper_engine_divergence_gap",
+                "paper_ledger_event_count": 180,
+            },
+            "candidates": [
+                {"candidate_id": "strategy|HD|4h|{}", "asset_type": "equity"}
+            ],
+        },
+    )
+
+    assert plan is not None
+    assert plan["recommended_action_id"] == "inspect_paper_engine_divergence"
+    assert plan["bounded_next_step"] == (
+        "inspect_paper_engine_divergence_components_before_new_hypothesis_or_preset"
+    )
+    assert plan["hypothesis_preset_proposal_gate"]["gate_status"] == (
+        "blocked_until_divergence_explained"
+    )
+
+
+def test_no_paper_candidate_next_action_renders_markdown_gate():
+    from research.report_agent import _next_research_action_from_paper_diagnosis
+
+    plan = _next_research_action_from_paper_diagnosis(
+        preset_name="trend_pullback_equities_4h",
+        paper_diagnosis={
+            "paper_candidate_search_status": "no_ready_candidate",
+            "dominant_blockers": [{"reason": "missing_execution_events", "count": 1}],
+            "dominant_diagnoses": [
+                {"diagnosis_class": "execution_event_coverage_gap", "count": 1}
+            ],
+            "closest_candidate": {
+                "candidate_id": "strategy|AAPL|4h|{}",
+                "asset_type": "equity",
+                "diagnosis_class": "execution_event_coverage_gap",
+            },
+            "candidates": [
+                {"candidate_id": "strategy|AAPL|4h|{}", "asset_type": "equity"}
+            ],
+        },
+    )
+
+    markdown = render_markdown(
+        {
+            "run_id": "run-next-action",
+            "generated_at_utc": "2026-06-01T12:00:00+00:00",
+            "preset": "trend_pullback_equities_4h",
+            "verdict": VERDICT_PROMOTED,
+            "summary": {
+                "raw": 1,
+                "screened": 1,
+                "validated": 1,
+                "rejected": 0,
+                "promoted": 1,
+            },
+            "candidates": [],
+            "top_rejection_reasons": [],
+            "top_rejection_reasons_by_layer": {
+                "screening_layer": [],
+                "promotion_layer": [],
+            },
+            "per_candidate_diagnostics": [],
+            "join_stats": {},
+            "red_flags": [],
+            "regime_diagnostics": {},
+            "statistical_diagnostics": {},
+            "no_paper_candidate_next_action_plan": plan,
+            "next_experiment": "Review next action.",
+        }
+    )
+
+    assert "No Paper Candidate Next Action Plan (advisory only)" in markdown
+    assert "recommended_action_id: inspect_execution_event_coverage" in markdown
+    assert "do_not_try_more_regular_asset_presets_blindly" in markdown
+    assert "automatic_preset_mutation_allowed=False" in markdown
+    assert "any new hypothesis or preset proposal remains operator-gated" in markdown
+

--- a/tests/unit/test_report_agent.py
+++ b/tests/unit/test_report_agent.py
@@ -856,3 +856,124 @@ def test_candidate_shadow_readiness_report_can_recommend_operator_review_default
     assert report["operator_go_required"] is True
     assert report["candidates"][0]["eligible_for_operator_shadow_review"] is True
 
+def test_paper_readiness_blocker_diagnosis_selects_closest_candidate_by_evidence():
+    from research.report_agent import _paper_readiness_blocker_diagnosis
+
+    paper_readiness = {
+        "entries": [
+            {
+                "candidate_id": "strategy|AAPL|4h|{}",
+                "asset_type": "equity",
+                "sleeve_id": None,
+                "readiness_status": "blocked",
+                "blocking_reasons": ["missing_execution_events"],
+                "warnings": ["negative_paper_sharpe"],
+                "evidence": {
+                    "paper_ledger_event_count": 0,
+                    "timestamped_returns_n_obs": 197,
+                    "divergence_severity": "low",
+                    "paper_sharpe_proxy": 0.0,
+                },
+            },
+            {
+                "candidate_id": "strategy|HD|4h|{}",
+                "asset_type": "equity",
+                "sleeve_id": None,
+                "readiness_status": "blocked",
+                "blocking_reasons": ["excessive_divergence"],
+                "warnings": [],
+                "evidence": {
+                    "paper_ledger_event_count": 180,
+                    "timestamped_returns_n_obs": 197,
+                    "divergence_severity": "high",
+                    "paper_sharpe_proxy": 0.715,
+                },
+            },
+        ]
+    }
+
+    report = _paper_readiness_blocker_diagnosis(
+        paper_readiness,
+        {"overall_event_counts": {"signal": 60, "order": 60, "fill": 30}},
+        {"severity_counts": {"low": 1, "medium": 0, "high": 1}},
+    )
+
+    assert report is not None
+    assert report["paper_candidate_search_status"] == "no_ready_candidate"
+    assert report["ready_candidate_count"] == 0
+    assert report["blocked_candidate_count"] == 2
+    assert report["dominant_blockers"] == [
+        {"reason": "excessive_divergence", "count": 1},
+        {"reason": "missing_execution_events", "count": 1},
+    ]
+    assert report["diagnosis_counts"]["execution_event_coverage_gap"] == 1
+    assert report["diagnosis_counts"]["paper_engine_divergence_gap"] == 1
+    assert report["closest_candidate"]["candidate_id"] == "strategy|HD|4h|{}"
+    assert report["closest_candidate"]["diagnosis_class"] == "paper_engine_divergence_gap"
+    assert report["recommended_next_action"] == (
+        "inspect_paper_engine_divergence_components_before_threshold_or_strategy_changes"
+    )
+    assert report["paper_runtime_enabled"] is False
+    assert report["shadow_runtime_enabled"] is False
+    assert report["live_eligible"] is False
+
+
+def test_paper_readiness_blocker_diagnosis_renders_markdown_advisory_section():
+    from research.report_agent import _paper_readiness_blocker_diagnosis
+
+    report = _paper_readiness_blocker_diagnosis(
+        {
+            "entries": [
+                {
+                    "candidate_id": "strategy|MSFT|4h|{}",
+                    "asset_type": "equity",
+                    "sleeve_id": None,
+                    "readiness_status": "ready_for_paper_promotion",
+                    "blocking_reasons": [],
+                    "warnings": [],
+                    "evidence": {
+                        "paper_ledger_event_count": 12,
+                        "timestamped_returns_n_obs": 90,
+                        "divergence_severity": "low",
+                    },
+                }
+            ]
+        },
+        {"overall_event_counts": {"signal": 12}},
+        {"severity_counts": {"low": 1}},
+    )
+
+    markdown = render_markdown(
+        {
+            "run_id": "run-paper-diagnosis",
+            "generated_at_utc": "2026-06-01T12:00:00+00:00",
+            "preset": "trend_equities_4h_baseline",
+            "verdict": VERDICT_PROMOTED,
+            "summary": {
+                "raw": 1,
+                "screened": 1,
+                "validated": 1,
+                "rejected": 0,
+                "promoted": 1,
+            },
+            "candidates": [],
+            "top_rejection_reasons": [],
+            "top_rejection_reasons_by_layer": {
+                "screening_layer": [],
+                "promotion_layer": [],
+            },
+            "per_candidate_diagnostics": [],
+            "join_stats": {},
+            "red_flags": [],
+            "regime_diagnostics": {},
+            "statistical_diagnostics": {},
+            "paper_readiness_blocker_diagnosis": report,
+            "next_experiment": "Review paper diagnosis.",
+        }
+    )
+
+    assert "Paper Readiness Blocker Diagnosis (advisory only)" in markdown
+    assert "paper_candidate_search_status: ready_candidate_found" in markdown
+    assert "recommended_next_action: review_ready_candidate_for_operator_shadow_or_paper_followup" in markdown
+    assert "it does not change readiness thresholds" in markdown
+


### PR DESCRIPTION
## Summary
- adds a generic paper-readiness blocker diagnosis report
- selects the closest paper candidate by evidence coverage, not by asset-specific logic
- adds a no-paper-candidate next action plan for bounded follow-up
- blocks blind regular-asset preset searching until paper-readiness blockers are explained
- keeps hypothesis/preset proposal review operator-gated

## Commits
1. fix: add paper readiness blocker diagnosis
2. fix: add no paper candidate next action plan

## Tests
- python -m ruff check research/report_agent.py tests/unit/test_report_agent.py
- python -m pytest tests/unit/test_report_agent.py -q
- python -m pytest tests/unit/test_screening_runtime.py -q
- python -m pytest tests/unit/test_execution_event_emission.py tests/unit/test_exit_diagnostics.py -q
- python -m pytest tests/unit/test_paper_readiness.py -q
- python -m pytest tests/architecture/test_domain_boundary_smoke.py -q

## Safety
- report-only / advisory-only
- no strategy changes
- no preset changes
- no campaign queue mutation
- no candidate selection changes
- no paper, shadow, broker, risk, execution, or live runtime changes
- frozen contracts unchanged