### PR TITLE
fix: add paper engine divergence component diagnosis

### DIFF
--- a/research/report_agent.py
+++ b/research/report_agent.py
@@ -624,6 +624,197 @@ def _next_research_action_from_paper_diagnosis(
 
 
 
+
+def _safe_float_or_none(value: Any) -> float | None:
+    try:
+        if value is None:
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _paper_engine_divergence_driver(
+    *,
+    final_equity_delta_bps: float | None,
+    fee_drag_delta_vs_baseline: float | None,
+    slippage_drag: float | None,
+    n_full_fills: int,
+) -> str:
+    if final_equity_delta_bps is None:
+        return "missing_metrics_delta"
+    if n_full_fills <= 0:
+        return "no_full_fills"
+
+    fee_abs = abs(fee_drag_delta_vs_baseline or 0.0)
+    slip_abs = abs(slippage_drag or 0.0)
+
+    if fee_abs == 0.0 and slip_abs == 0.0:
+        return "metrics_delta_without_cost_component_breakdown"
+    if slip_abs > fee_abs * 1.5:
+        return "slippage_drag_dominant"
+    if fee_abs > slip_abs * 1.5:
+        return "fee_model_delta_dominant"
+    return "mixed_fee_and_slippage_effects"
+
+
+def _paper_engine_divergence_next_action(driver: str) -> str:
+    mapping = {
+        "missing_metrics_delta": "repair_paper_divergence_metrics_before_threshold_review",
+        "no_full_fills": "inspect_execution_event_coverage_before_divergence_review",
+        "slippage_drag_dominant": "inspect_venue_slippage_assumptions_before_strategy_or_threshold_changes",
+        "fee_model_delta_dominant": "inspect_engine_vs_venue_fee_model_before_strategy_or_threshold_changes",
+        "mixed_fee_and_slippage_effects": "inspect_combined_fee_and_slippage_model_before_strategy_or_threshold_changes",
+        "metrics_delta_without_cost_component_breakdown": "inspect_paper_divergence_payload_completeness",
+    }
+    return mapping.get(driver, "inspect_paper_engine_divergence_components")
+
+
+def _paper_engine_divergence_component_diagnosis(
+    paper_divergence: dict[str, Any] | None,
+    paper_diagnosis: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    """Explain paper-engine divergence components using existing sidecar fields.
+
+    Report-only: does not change divergence math, readiness thresholds,
+    strategy behavior, presets, campaign queues, or runtime activation.
+    """
+    if not paper_divergence:
+        return None
+
+    per_candidate = paper_divergence.get("per_candidate")
+    if not isinstance(per_candidate, list):
+        per_candidate = []
+
+    closest_candidate_id = None
+    if isinstance(paper_diagnosis, dict):
+        closest = paper_diagnosis.get("closest_candidate") or {}
+        if isinstance(closest, dict):
+            closest_candidate_id = closest.get("candidate_id")
+
+    rows: list[dict[str, Any]] = []
+    driver_counts: dict[str, int] = {}
+    high_count = 0
+
+    for entry in per_candidate:
+        if not isinstance(entry, dict):
+            continue
+
+        metrics = entry.get("metrics_delta") if isinstance(entry.get("metrics_delta"), dict) else {}
+        costs = entry.get("venue_cost_delta") if isinstance(entry.get("venue_cost_delta"), dict) else {}
+
+        severity = entry.get("divergence_severity")
+        final_bps = _safe_float_or_none(metrics.get("final_equity_delta_bps"))
+        cumulative_adjustment = _safe_float_or_none(metrics.get("cumulative_adjustment"))
+        sharpe_proxy_delta = _safe_float_or_none(metrics.get("sharpe_proxy_delta"))
+
+        venue_fee = _safe_float_or_none(costs.get("venue_fee_per_side"))
+        venue_slippage = _safe_float_or_none(costs.get("venue_slippage_bps"))
+        per_fill_adjustment = _safe_float_or_none(costs.get("per_fill_adjustment"))
+        fee_drag_venue = _safe_float_or_none(costs.get("fee_drag_venue"))
+        fee_drag_engine = _safe_float_or_none(costs.get("fee_drag_engine_baseline"))
+        fee_delta = _safe_float_or_none(costs.get("fee_drag_delta_vs_baseline"))
+        slippage_drag = _safe_float_or_none(costs.get("slippage_drag"))
+
+        n_full_fills = int(entry.get("n_full_fills") or 0)
+
+        driver = _paper_engine_divergence_driver(
+            final_equity_delta_bps=final_bps,
+            fee_drag_delta_vs_baseline=fee_delta,
+            slippage_drag=slippage_drag,
+            n_full_fills=n_full_fills,
+        )
+        driver_counts[driver] = driver_counts.get(driver, 0) + 1
+        if severity == "high":
+            high_count += 1
+
+        rows.append(
+            {
+                "candidate_id": entry.get("candidate_id"),
+                "asset_hint": _candidate_id_asset_hint(entry.get("candidate_id")),
+                "asset_type": entry.get("asset_type"),
+                "sleeve_id": entry.get("sleeve_id"),
+                "venue": entry.get("venue"),
+                "included_in_portfolio": entry.get("included_in_portfolio"),
+                "reason_excluded": entry.get("reason_excluded"),
+                "divergence_severity": severity,
+                "n_full_fills": n_full_fills,
+                "metrics_delta": {
+                    "final_equity_delta_bps": final_bps,
+                    "cumulative_adjustment": cumulative_adjustment,
+                    "sharpe_proxy_delta": sharpe_proxy_delta,
+                },
+                "venue_cost_delta": {
+                    "venue_fee_per_side": venue_fee,
+                    "venue_slippage_bps": venue_slippage,
+                    "per_fill_adjustment": per_fill_adjustment,
+                    "fee_drag_venue": fee_drag_venue,
+                    "fee_drag_engine_baseline": fee_drag_engine,
+                    "fee_drag_delta_vs_baseline": fee_delta,
+                    "slippage_drag": slippage_drag,
+                },
+                "divergence_component_driver": driver,
+                "recommended_next_action": _paper_engine_divergence_next_action(driver),
+                "is_closest_paper_candidate": (
+                    closest_candidate_id is not None
+                    and entry.get("candidate_id") == closest_candidate_id
+                ),
+            }
+        )
+
+    if not rows:
+        return {
+            "schema_version": "paper_engine_divergence_component_diagnosis.v1",
+            "advisory_only": True,
+            "authoritative": False,
+            "diagnostic_only": True,
+            "live_eligible": False,
+            "paper_runtime_enabled": False,
+            "shadow_runtime_enabled": False,
+            "candidate_count": 0,
+            "high_divergence_candidate_count": 0,
+            "component_driver_counts": {},
+            "closest_candidate_component_diagnosis": None,
+            "recommended_next_action": "run_or_repair_paper_divergence_sidecar_generation",
+            "candidates": [],
+        }
+
+    closest_row = None
+    for row in rows:
+        if row.get("is_closest_paper_candidate"):
+            closest_row = row
+            break
+
+    if closest_row is None:
+        # Prefer high-divergence rows, then rows with largest absolute equity delta.
+        closest_row = max(
+            rows,
+            key=lambda row: (
+                1 if row.get("divergence_severity") == "high" else 0,
+                abs((row.get("metrics_delta") or {}).get("final_equity_delta_bps") or 0.0),
+                int(row.get("n_full_fills") or 0),
+            ),
+        )
+
+    return {
+        "schema_version": "paper_engine_divergence_component_diagnosis.v1",
+        "advisory_only": True,
+        "authoritative": False,
+        "diagnostic_only": True,
+        "live_eligible": False,
+        "paper_runtime_enabled": False,
+        "shadow_runtime_enabled": False,
+        "candidate_count": len(rows),
+        "high_divergence_candidate_count": high_count,
+        "component_driver_counts": dict(sorted(driver_counts.items())),
+        "severity_counts": paper_divergence.get("severity_counts") or {},
+        "closest_candidate_component_diagnosis": closest_row,
+        "recommended_next_action": closest_row.get("recommended_next_action"),
+        "candidates": rows,
+    }
+
+
+
 def _candidate_shadow_readiness_report(
     paper_readiness: dict[str, Any] | None,
     exit_quality_rows: list[dict[str, Any]],
@@ -1280,10 +1471,18 @@ def build_report_payload(
             _load_json(_PAPER_DIVERGENCE_SIDECAR),
             _load_json(_PAPER_READINESS_SIDECAR),
         ),
-        "paper_readiness_blocker_diagnosis": _paper_readiness_blocker_diagnosis(
-            _load_json(_PAPER_READINESS_SIDECAR),
-            _load_json(_PAPER_LEDGER_SIDECAR),
-            _load_json(_PAPER_DIVERGENCE_SIDECAR),
+        "paper_readiness_blocker_diagnosis": (
+            paper_readiness_blocker_diagnosis := _paper_readiness_blocker_diagnosis(
+                _load_json(_PAPER_READINESS_SIDECAR),
+                _load_json(_PAPER_LEDGER_SIDECAR),
+                _load_json(_PAPER_DIVERGENCE_SIDECAR),
+            )
+        ),
+        "paper_engine_divergence_component_diagnosis": (
+            _paper_engine_divergence_component_diagnosis(
+                _load_json(_PAPER_DIVERGENCE_SIDECAR),
+                paper_readiness_blocker_diagnosis,
+            )
         ),
         "candidate_shadow_readiness_report": _candidate_shadow_readiness_report(
             _load_json(_PAPER_READINESS_SIDECAR),
@@ -1291,11 +1490,7 @@ def build_report_payload(
         ),
         "no_paper_candidate_next_action_plan": _next_research_action_from_paper_diagnosis(
             preset_name=preset_name,
-            paper_diagnosis=_paper_readiness_blocker_diagnosis(
-                _load_json(_PAPER_READINESS_SIDECAR),
-                _load_json(_PAPER_LEDGER_SIDECAR),
-                _load_json(_PAPER_DIVERGENCE_SIDECAR),
-            ),
+            paper_diagnosis=paper_readiness_blocker_diagnosis,
         ),
     }
 
@@ -1921,6 +2116,10 @@ def render_markdown(report: dict[str, Any]) -> str:
         lines,
         report.get("paper_readiness_blocker_diagnosis"),
     )
+    _append_paper_engine_divergence_component_diagnosis_section(
+        lines,
+        report.get("paper_engine_divergence_component_diagnosis"),
+    )
     _append_candidate_shadow_readiness_section(
         lines,
         report.get("candidate_shadow_readiness_report"),
@@ -2161,6 +2360,72 @@ def _append_no_paper_candidate_next_action_section(
     lines.append(
         "- advisory: QRE should explain missing paper candidates before more manual "
         "preset attempts; any new hypothesis or preset proposal remains operator-gated."
+    )
+    lines.append("")
+
+
+
+
+def _append_paper_engine_divergence_component_diagnosis_section(
+    lines: list[str], summary: dict[str, Any] | None
+) -> None:
+    """Render paper-engine divergence component diagnosis."""
+    if not summary:
+        return
+
+    lines.append("## Paper Engine Divergence Component Diagnosis (advisory only)")
+    lines.append(
+        "- candidates: "
+        f"total={summary.get('candidate_count')}, "
+        f"high_divergence={summary.get('high_divergence_candidate_count')}"
+    )
+    driver_counts = summary.get("component_driver_counts") or {}
+    lines.append(
+        "- component_driver_counts: "
+        + (
+            ", ".join(f"{key}={value}" for key, value in sorted(driver_counts.items()))
+            if driver_counts
+            else "none"
+        )
+    )
+
+    closest = summary.get("closest_candidate_component_diagnosis") or {}
+    if closest:
+        metrics = closest.get("metrics_delta") or {}
+        costs = closest.get("venue_cost_delta") or {}
+        lines.append(
+            "- closest_candidate: "
+            f"{closest.get('candidate_id')} "
+            f"severity={closest.get('divergence_severity')} "
+            f"driver={closest.get('divergence_component_driver')} "
+            f"fills={closest.get('n_full_fills')} "
+            f"final_equity_delta_bps={_num(metrics.get('final_equity_delta_bps'))}"
+        )
+        lines.append(
+            "- closest_candidate_cost_components: "
+            f"fee_drag_engine_baseline={_pct(costs.get('fee_drag_engine_baseline'))}, "
+            f"fee_drag_venue={_pct(costs.get('fee_drag_venue'))}, "
+            f"fee_drag_delta_vs_baseline={_pct(costs.get('fee_drag_delta_vs_baseline'))}, "
+            f"slippage_drag={_pct(costs.get('slippage_drag'))}, "
+            f"venue_fee_per_side={_pct(costs.get('venue_fee_per_side'))}, "
+            f"venue_slippage_bps={_num(costs.get('venue_slippage_bps'))}"
+        )
+        lines.append(
+            "- closest_candidate_adjustment: "
+            f"per_fill_adjustment={_num(costs.get('per_fill_adjustment'))}, "
+            f"cumulative_adjustment={_num(metrics.get('cumulative_adjustment'))}, "
+            f"sharpe_proxy_delta={_num(metrics.get('sharpe_proxy_delta'))}"
+        )
+    else:
+        lines.append("- closest_candidate: none")
+
+    lines.append(
+        f"- recommended_next_action: {summary.get('recommended_next_action')}"
+    )
+    lines.append(
+        "- advisory: this explains divergence components only; it does not change "
+        "paper-readiness thresholds, divergence math, presets, strategies, campaign "
+        "queues, or paper/shadow/live runtime."
     )
     lines.append("")
 

--- a/tests/unit/test_report_agent.py
+++ b/tests/unit/test_report_agent.py
@@ -1116,3 +1116,156 @@ def test_no_paper_candidate_next_action_renders_markdown_gate():
     assert "automatic_preset_mutation_allowed=False" in markdown
     assert "any new hypothesis or preset proposal remains operator-gated" in markdown
 
+def test_paper_engine_divergence_component_diagnosis_explains_closest_candidate():
+    from research.report_agent import _paper_engine_divergence_component_diagnosis
+
+    diagnosis = _paper_engine_divergence_component_diagnosis(
+        {
+            "severity_counts": {"low": 1, "medium": 0, "high": 1},
+            "per_candidate": [
+                {
+                    "candidate_id": "strategy|AAPL|4h|{}",
+                    "asset_type": "equity",
+                    "sleeve_id": None,
+                    "venue": "equity_ibkr",
+                    "n_full_fills": 0,
+                    "included_in_portfolio": True,
+                    "reason_excluded": None,
+                    "metrics_delta": {
+                        "final_equity_delta_bps": 0.0,
+                        "cumulative_adjustment": 1.0,
+                        "sharpe_proxy_delta": None,
+                    },
+                    "venue_cost_delta": {
+                        "venue_fee_per_side": 0.0005,
+                        "venue_slippage_bps": 10.0,
+                        "per_fill_adjustment": 1.0,
+                        "fee_drag_venue": 0.0,
+                        "fee_drag_engine_baseline": 0.0,
+                        "fee_drag_delta_vs_baseline": 0.0,
+                        "slippage_drag": 0.0,
+                    },
+                    "divergence_severity": "low",
+                },
+                {
+                    "candidate_id": "strategy|HD|4h|{}",
+                    "asset_type": "equity",
+                    "sleeve_id": None,
+                    "venue": "equity_ibkr",
+                    "n_full_fills": 30,
+                    "included_in_portfolio": True,
+                    "reason_excluded": None,
+                    "metrics_delta": {
+                        "final_equity_delta_bps": 305.32,
+                        "cumulative_adjustment": 1.030532,
+                        "sharpe_proxy_delta": 0.001,
+                    },
+                    "venue_cost_delta": {
+                        "venue_fee_per_side": 0.0005,
+                        "venue_slippage_bps": 10.0,
+                        "per_fill_adjustment": 1.001,
+                        "fee_drag_venue": 0.0149,
+                        "fee_drag_engine_baseline": 0.0723,
+                        "fee_drag_delta_vs_baseline": -0.0574,
+                        "slippage_drag": 0.0296,
+                    },
+                    "divergence_severity": "high",
+                },
+            ],
+        },
+        {
+            "closest_candidate": {
+                "candidate_id": "strategy|HD|4h|{}",
+            }
+        },
+    )
+
+    assert diagnosis is not None
+    assert diagnosis["candidate_count"] == 2
+    assert diagnosis["high_divergence_candidate_count"] == 1
+    assert diagnosis["closest_candidate_component_diagnosis"]["candidate_id"] == (
+        "strategy|HD|4h|{}"
+    )
+    assert diagnosis["closest_candidate_component_diagnosis"][
+        "divergence_component_driver"
+    ] == "fee_model_delta_dominant"
+    assert diagnosis["recommended_next_action"] == (
+        "inspect_engine_vs_venue_fee_model_before_strategy_or_threshold_changes"
+    )
+    assert diagnosis["paper_runtime_enabled"] is False
+    assert diagnosis["shadow_runtime_enabled"] is False
+    assert diagnosis["live_eligible"] is False
+
+
+def test_paper_engine_divergence_component_diagnosis_renders_markdown():
+    from research.report_agent import _paper_engine_divergence_component_diagnosis
+
+    diagnosis = _paper_engine_divergence_component_diagnosis(
+        {
+            "severity_counts": {"high": 1},
+            "per_candidate": [
+                {
+                    "candidate_id": "strategy|HD|4h|{}",
+                    "asset_type": "equity",
+                    "venue": "equity_ibkr",
+                    "n_full_fills": 30,
+                    "included_in_portfolio": True,
+                    "reason_excluded": None,
+                    "metrics_delta": {
+                        "final_equity_delta_bps": 305.32,
+                        "cumulative_adjustment": 1.030532,
+                        "sharpe_proxy_delta": 0.001,
+                    },
+                    "venue_cost_delta": {
+                        "venue_fee_per_side": 0.0005,
+                        "venue_slippage_bps": 10.0,
+                        "per_fill_adjustment": 1.001,
+                        "fee_drag_venue": 0.0149,
+                        "fee_drag_engine_baseline": 0.0723,
+                        "fee_drag_delta_vs_baseline": -0.0574,
+                        "slippage_drag": 0.0296,
+                    },
+                    "divergence_severity": "high",
+                }
+            ],
+        },
+        None,
+    )
+
+    markdown = render_markdown(
+        {
+            "run_id": "run-divergence-components",
+            "generated_at_utc": "2026-06-01T12:00:00+00:00",
+            "preset": "trend_pullback_equities_4h",
+            "verdict": VERDICT_PROMOTED,
+            "summary": {
+                "raw": 1,
+                "screened": 1,
+                "validated": 1,
+                "rejected": 0,
+                "promoted": 1,
+            },
+            "candidates": [],
+            "top_rejection_reasons": [],
+            "top_rejection_reasons_by_layer": {
+                "screening_layer": [],
+                "promotion_layer": [],
+            },
+            "per_candidate_diagnostics": [],
+            "join_stats": {},
+            "red_flags": [],
+            "regime_diagnostics": {},
+            "statistical_diagnostics": {},
+            "paper_engine_divergence_component_diagnosis": diagnosis,
+            "next_experiment": "Review divergence components.",
+        }
+    )
+
+    assert "Paper Engine Divergence Component Diagnosis (advisory only)" in markdown
+    assert "component_driver_counts: fee_model_delta_dominant=1" in markdown
+    assert "final_equity_delta_bps=305.32" in markdown
+    assert "fee_drag_engine_baseline=7.23%" in markdown
+    assert "fee_drag_venue=1.49%" in markdown
+    assert "slippage_drag=2.96%" in markdown
+    assert "it does not change paper-readiness thresholds" in markdown
+


### PR DESCRIPTION
## Summary
- adds a generic paper-engine divergence component diagnosis report
- explains high divergence using existing paper_divergence sidecar fields
- identifies component drivers such as fee_model_delta_dominant, slippage_drag_dominant, mixed_fee_and_slippage_effects, and no_full_fills
- surfaces closest-candidate cost components in JSON and Markdown
- keeps the output advisory-only/report-only

## E2E Evidence
On trend_pullback_equities_4h:
- candidate_count=4
- high_divergence_candidate_count=1
- closest candidate=HD
- divergence_component_driver=fee_model_delta_dominant
- recommended_next_action=inspect_engine_vs_venue_fee_model_before_strategy_or_threshold_changes

## Tests
- python -m ruff check research/report_agent.py tests/unit/test_report_agent.py
- python -m pytest tests/unit/test_report_agent.py -q
- python -m pytest tests/unit/test_screening_runtime.py -q
- python -m pytest tests/unit/test_execution_event_emission.py tests/unit/test_exit_diagnostics.py -q
- python -m pytest tests/unit/test_paper_readiness.py -q
- python -m pytest tests/architecture/test_domain_boundary_smoke.py -q

## Safety
- report-only / advisory-only
- no divergence math changes
- no readiness threshold changes
- no strategy changes
- no preset changes
- no campaign queue mutation
- no candidate selection changes
- no paper, shadow, broker, risk, execution, or live runtime changes
- frozen contracts unchanged