### PR TITLE
fix: add research action queue emitter

### DIFF
--- a/research/report_agent.py
+++ b/research/report_agent.py
@@ -1696,18 +1696,32 @@ def build_report_payload(
             )
         ),
         "paper_engine_divergence_component_diagnosis": (
-            _paper_engine_divergence_component_diagnosis(
-                _load_json(_PAPER_DIVERGENCE_SIDECAR),
-                paper_readiness_blocker_diagnosis,
+            paper_engine_divergence_component_diagnosis := (
+                _paper_engine_divergence_component_diagnosis(
+                    _load_json(_PAPER_DIVERGENCE_SIDECAR),
+                    paper_readiness_blocker_diagnosis,
+                )
             )
         ),
-        "candidate_shadow_readiness_report": _candidate_shadow_readiness_report(
-            _load_json(_PAPER_READINESS_SIDECAR),
-            _build_trend_pullback_exit_quality(screening_candidates_payload),
+        "candidate_shadow_readiness_report": (
+            candidate_shadow_readiness_report := _candidate_shadow_readiness_report(
+                _load_json(_PAPER_READINESS_SIDECAR),
+                _build_trend_pullback_exit_quality(screening_candidates_payload),
+            )
         ),
-        "no_paper_candidate_next_action_plan": _next_research_action_from_paper_diagnosis(
-            preset_name=preset_name,
-            paper_diagnosis=paper_readiness_blocker_diagnosis,
+        "no_paper_candidate_next_action_plan": (
+            no_paper_candidate_next_action_plan := (
+                _next_research_action_from_paper_diagnosis(
+                    preset_name=preset_name,
+                    paper_diagnosis=paper_readiness_blocker_diagnosis,
+                )
+            )
+        ),
+        "research_action_queue_items": _build_research_action_queue_items(
+            paper_readiness_diagnosis=paper_readiness_blocker_diagnosis,
+            paper_engine_divergence_diagnosis=paper_engine_divergence_component_diagnosis,
+            no_paper_candidate_next_action_plan=no_paper_candidate_next_action_plan,
+            candidate_shadow_readiness_report=candidate_shadow_readiness_report,
         ),
     }
 
@@ -2345,6 +2359,10 @@ def render_markdown(report: dict[str, Any]) -> str:
         lines,
         report.get("no_paper_candidate_next_action_plan"),
     )
+    _append_research_action_queue_items_section(
+        lines,
+        report.get("research_action_queue_items"),
+    )
 
     red_flags = report.get("red_flags") or []
     if red_flags:
@@ -2643,6 +2661,59 @@ def _append_paper_engine_divergence_component_diagnosis_section(
         "- advisory: this explains divergence components only; it does not change "
         "paper-readiness thresholds, divergence math, presets, strategies, campaign "
         "queues, or paper/shadow/live runtime."
+    )
+    lines.append("")
+
+
+
+
+def _append_research_action_queue_items_section(
+    lines: list[str], items: list[dict[str, Any]] | None
+) -> None:
+    """Render advisory research action queue items."""
+    if not items:
+        return
+
+    lines.append("## Research Action Queue Items (emitter only)")
+    lines.append(
+        "- status: emitted_machine_readable_actions_only; "
+        "execution_enabled=False; no campaign/ADE/runtime mutation"
+    )
+    lines.append("")
+    lines.append(
+        "| Priority | Action | Source | Target candidate | Operator approval | Bounded next step |"
+    )
+    lines.append("|---|---|---|---|---:|---|")
+
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        lines.append(
+            f"| {item.get('priority')} | "
+            f"`{item.get('action_id')}` | "
+            f"{item.get('source_section')} | "
+            f"{item.get('target_candidate_id') or 'n/a'} | "
+            f"{item.get('operator_approval_required')} | "
+            f"{item.get('bounded_next_step')} |"
+        )
+
+    forbidden = sorted(
+        {
+            str(action)
+            for item in items
+            if isinstance(item, dict)
+            for action in (item.get("forbidden_actions") or [])
+        }
+    )
+    lines.append("")
+    lines.append(
+        "- forbidden_actions: "
+        + (", ".join(forbidden) if forbidden else "none")
+    )
+    lines.append(
+        "- advisory: queue items are report-only intent; they do not execute, "
+        "write an ADE queue, mutate campaigns, change strategies/presets, alter "
+        "thresholds, or activate paper/shadow/live runtime."
     )
     lines.append("")
 

--- a/research/report_agent.py
+++ b/research/report_agent.py
@@ -815,6 +815,223 @@ def _paper_engine_divergence_component_diagnosis(
 
 
 
+
+_RESEARCH_ACTION_FORBIDDEN_ACTIONS: list[str] = [
+    "automatic_strategy_change",
+    "automatic_preset_change",
+    "automatic_campaign_queue_mutation",
+    "threshold_change",
+    "readiness_threshold_change",
+    "paper_runtime_activation",
+    "shadow_runtime_activation",
+    "live_trading",
+]
+
+
+def _research_action_queue_item(
+    *,
+    action_id: str,
+    source_section: str,
+    target_candidate_id: Any = None,
+    priority: str = "medium",
+    reason_codes: list[str] | None = None,
+    bounded_next_step: str | None = None,
+    scope: str = "report_only",
+    operator_approval_required: bool = False,
+    evidence: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a machine-readable advisory research action queue item.
+
+    This does not enqueue, execute, mutate campaigns, mutate presets, mutate
+    strategies, or activate paper/shadow/live runtime.
+    """
+    return {
+        "schema_version": "research_action_queue_item.v1",
+        "advisory_only": True,
+        "authoritative": False,
+        "diagnostic_only": True,
+        "queue_emitter_only": True,
+        "execution_enabled": False,
+        "live_eligible": False,
+        "paper_runtime_enabled": False,
+        "shadow_runtime_enabled": False,
+        "action_id": action_id,
+        "queue_item_type": action_id,
+        "source_section": source_section,
+        "target_candidate_id": target_candidate_id,
+        "priority": priority,
+        "scope": scope,
+        "operator_approval_required": operator_approval_required,
+        "bounded_next_step": bounded_next_step or action_id,
+        "reason_codes": list(reason_codes or []),
+        "forbidden_actions": list(_RESEARCH_ACTION_FORBIDDEN_ACTIONS),
+        "evidence": dict(evidence or {}),
+    }
+
+
+def _build_research_action_queue_items(
+    *,
+    paper_readiness_diagnosis: dict[str, Any] | None = None,
+    paper_engine_divergence_diagnosis: dict[str, Any] | None = None,
+    no_paper_candidate_next_action_plan: dict[str, Any] | None = None,
+    candidate_shadow_readiness_report: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    """Emit advisory next-action queue items from report diagnostics.
+
+    The output is machine-readable intent only. It is not a persisted queue,
+    not an ADE command, and not a campaign mutation.
+    """
+    items: list[dict[str, Any]] = []
+
+    if isinstance(paper_engine_divergence_diagnosis, dict):
+        closest = (
+            paper_engine_divergence_diagnosis.get(
+                "closest_candidate_component_diagnosis"
+            )
+            or {}
+        )
+        action = paper_engine_divergence_diagnosis.get("recommended_next_action")
+        if action:
+            items.append(
+                _research_action_queue_item(
+                    action_id=str(action),
+                    source_section="paper_engine_divergence_component_diagnosis",
+                    target_candidate_id=closest.get("candidate_id")
+                    if isinstance(closest, dict)
+                    else None,
+                    priority="high"
+                    if paper_engine_divergence_diagnosis.get(
+                        "high_divergence_candidate_count"
+                    )
+                    else "medium",
+                    reason_codes=[
+                        str(closest.get("divergence_component_driver"))
+                    ]
+                    if isinstance(closest, dict)
+                    and closest.get("divergence_component_driver")
+                    else [],
+                    bounded_next_step=str(action),
+                    scope="report_only",
+                    operator_approval_required=False,
+                    evidence={
+                        "divergence_severity": closest.get("divergence_severity")
+                        if isinstance(closest, dict)
+                        else None,
+                        "n_full_fills": closest.get("n_full_fills")
+                        if isinstance(closest, dict)
+                        else None,
+                        "metrics_delta": closest.get("metrics_delta")
+                        if isinstance(closest, dict)
+                        else None,
+                        "venue_cost_delta": closest.get("venue_cost_delta")
+                        if isinstance(closest, dict)
+                        else None,
+                    },
+                )
+            )
+
+    if isinstance(no_paper_candidate_next_action_plan, dict):
+        action = no_paper_candidate_next_action_plan.get("bounded_next_step")
+        closest = no_paper_candidate_next_action_plan.get("closest_candidate") or {}
+        if action:
+            items.append(
+                _research_action_queue_item(
+                    action_id=str(
+                        no_paper_candidate_next_action_plan.get(
+                            "recommended_action_id"
+                        )
+                        or action
+                    ),
+                    source_section="no_paper_candidate_next_action_plan",
+                    target_candidate_id=closest.get("candidate_id")
+                    if isinstance(closest, dict)
+                    else None,
+                    priority="high"
+                    if no_paper_candidate_next_action_plan.get(
+                        "paper_candidate_search_status"
+                    )
+                    == "no_ready_candidate"
+                    else "medium",
+                    reason_codes=[
+                        str(reason)
+                        for reason in (
+                            no_paper_candidate_next_action_plan.get(
+                                "reason_codes"
+                            )
+                            or []
+                        )
+                    ],
+                    bounded_next_step=str(action),
+                    scope="report_only",
+                    operator_approval_required=False,
+                    evidence={
+                        "regular_asset_scope": no_paper_candidate_next_action_plan.get(
+                            "regular_asset_scope"
+                        ),
+                        "paper_candidate_search_status": no_paper_candidate_next_action_plan.get(
+                            "paper_candidate_search_status"
+                        ),
+                        "hypothesis_preset_proposal_gate": no_paper_candidate_next_action_plan.get(
+                            "hypothesis_preset_proposal_gate"
+                        ),
+                    },
+                )
+            )
+
+    if isinstance(paper_readiness_diagnosis, dict):
+        status = paper_readiness_diagnosis.get("paper_candidate_search_status")
+        if status == "missing_paper_readiness":
+            items.append(
+                _research_action_queue_item(
+                    action_id="run_or_repair_paper_readiness_sidecar_generation",
+                    source_section="paper_readiness_blocker_diagnosis",
+                    priority="high",
+                    reason_codes=["paper_readiness_artifact_missing"],
+                    bounded_next_step="run_or_repair_paper_readiness_sidecar_generation",
+                    operator_approval_required=False,
+                    evidence={"paper_candidate_search_status": status},
+                )
+            )
+
+    if isinstance(candidate_shadow_readiness_report, dict):
+        readiness = candidate_shadow_readiness_report.get("readiness_status")
+        if readiness == "ready_for_operator_shadow_review":
+            items.append(
+                _research_action_queue_item(
+                    action_id="operator_review_candidate_shadow_readiness",
+                    source_section="candidate_shadow_readiness_report",
+                    priority="high",
+                    reason_codes=["candidate_shadow_readiness_ready"],
+                    bounded_next_step="operator_review_candidate_shadow_readiness",
+                    operator_approval_required=True,
+                    evidence={
+                        "paper_ready_candidate_count": candidate_shadow_readiness_report.get(
+                            "paper_ready_candidate_count"
+                        ),
+                        "operator_go_required": candidate_shadow_readiness_report.get(
+                            "operator_go_required"
+                        ),
+                    },
+                )
+            )
+
+    deduped: list[dict[str, Any]] = []
+    seen: set[tuple[str, str, str]] = set()
+    for item in items:
+        key = (
+            str(item.get("action_id")),
+            str(item.get("source_section")),
+            str(item.get("target_candidate_id")),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(item)
+
+    return deduped
+
+
+
 def _candidate_shadow_readiness_report(
     paper_readiness: dict[str, Any] | None,
     exit_quality_rows: list[dict[str, Any]],

--- a/tests/unit/test_report_agent.py
+++ b/tests/unit/test_report_agent.py
@@ -1269,3 +1269,67 @@ def test_paper_engine_divergence_component_diagnosis_renders_markdown():
     assert "slippage_drag=2.96%" in markdown
     assert "it does not change paper-readiness thresholds" in markdown
 
+def test_research_action_queue_builder_emits_divergence_action_item():
+    from research.report_agent import _build_research_action_queue_items
+
+    items = _build_research_action_queue_items(
+        paper_engine_divergence_diagnosis={
+            "high_divergence_candidate_count": 1,
+            "recommended_next_action": (
+                "inspect_engine_vs_venue_fee_model_before_strategy_or_threshold_changes"
+            ),
+            "closest_candidate_component_diagnosis": {
+                "candidate_id": "strategy|HD|4h|{}",
+                "divergence_severity": "high",
+                "divergence_component_driver": "fee_model_delta_dominant",
+                "n_full_fills": 30,
+                "metrics_delta": {"final_equity_delta_bps": 305.32},
+                "venue_cost_delta": {
+                    "fee_drag_engine_baseline": 0.0723,
+                    "fee_drag_venue": 0.0149,
+                },
+            },
+        }
+    )
+
+    assert len(items) == 1
+    item = items[0]
+    assert item["schema_version"] == "research_action_queue_item.v1"
+    assert item["queue_emitter_only"] is True
+    assert item["execution_enabled"] is False
+    assert item["action_id"] == (
+        "inspect_engine_vs_venue_fee_model_before_strategy_or_threshold_changes"
+    )
+    assert item["source_section"] == "paper_engine_divergence_component_diagnosis"
+    assert item["target_candidate_id"] == "strategy|HD|4h|{}"
+    assert item["priority"] == "high"
+    assert item["operator_approval_required"] is False
+    assert item["reason_codes"] == ["fee_model_delta_dominant"]
+    assert item["evidence"]["n_full_fills"] == 30
+    assert "automatic_campaign_queue_mutation" in item["forbidden_actions"]
+    assert "paper_runtime_activation" in item["forbidden_actions"]
+    assert item["paper_runtime_enabled"] is False
+    assert item["shadow_runtime_enabled"] is False
+    assert item["live_eligible"] is False
+
+
+def test_research_action_queue_builder_emits_operator_gated_shadow_review_item():
+    from research.report_agent import _build_research_action_queue_items
+
+    items = _build_research_action_queue_items(
+        candidate_shadow_readiness_report={
+            "readiness_status": "ready_for_operator_shadow_review",
+            "paper_ready_candidate_count": 1,
+            "operator_go_required": True,
+        }
+    )
+
+    assert len(items) == 1
+    item = items[0]
+    assert item["action_id"] == "operator_review_candidate_shadow_readiness"
+    assert item["source_section"] == "candidate_shadow_readiness_report"
+    assert item["operator_approval_required"] is True
+    assert item["execution_enabled"] is False
+    assert item["evidence"]["paper_ready_candidate_count"] == 1
+    assert item["evidence"]["operator_go_required"] is True
+

--- a/tests/unit/test_report_agent.py
+++ b/tests/unit/test_report_agent.py
@@ -1333,3 +1333,68 @@ def test_research_action_queue_builder_emits_operator_gated_shadow_review_item()
     assert item["evidence"]["paper_ready_candidate_count"] == 1
     assert item["evidence"]["operator_go_required"] is True
 
+def test_research_action_queue_items_render_markdown_surface():
+    from research.report_agent import _build_research_action_queue_items
+
+    items = _build_research_action_queue_items(
+        paper_engine_divergence_diagnosis={
+            "high_divergence_candidate_count": 1,
+            "recommended_next_action": (
+                "inspect_engine_vs_venue_fee_model_before_strategy_or_threshold_changes"
+            ),
+            "closest_candidate_component_diagnosis": {
+                "candidate_id": "strategy|HD|4h|{}",
+                "divergence_severity": "high",
+                "divergence_component_driver": "fee_model_delta_dominant",
+                "n_full_fills": 30,
+            },
+        },
+        no_paper_candidate_next_action_plan={
+            "paper_candidate_search_status": "no_ready_candidate",
+            "recommended_action_id": "inspect_paper_engine_divergence",
+            "bounded_next_step": (
+                "inspect_paper_engine_divergence_components_before_new_hypothesis_or_preset"
+            ),
+            "reason_codes": ["closest_candidate_has_execution_events_but_high_divergence"],
+            "closest_candidate": {"candidate_id": "strategy|HD|4h|{}"},
+            "regular_asset_scope": True,
+        },
+    )
+
+    markdown = render_markdown(
+        {
+            "run_id": "run-queue-items",
+            "generated_at_utc": "2026-06-01T12:00:00+00:00",
+            "preset": "trend_pullback_equities_4h",
+            "verdict": VERDICT_PROMOTED,
+            "summary": {
+                "raw": 1,
+                "screened": 1,
+                "validated": 1,
+                "rejected": 0,
+                "promoted": 1,
+            },
+            "candidates": [],
+            "top_rejection_reasons": [],
+            "top_rejection_reasons_by_layer": {
+                "screening_layer": [],
+                "promotion_layer": [],
+            },
+            "per_candidate_diagnostics": [],
+            "join_stats": {},
+            "red_flags": [],
+            "regime_diagnostics": {},
+            "statistical_diagnostics": {},
+            "research_action_queue_items": items,
+            "next_experiment": "Review queue items.",
+        }
+    )
+
+    assert "Research Action Queue Items (emitter only)" in markdown
+    assert "execution_enabled=False" in markdown
+    assert "`inspect_engine_vs_venue_fee_model_before_strategy_or_threshold_changes`" in markdown
+    assert "`inspect_paper_engine_divergence`" in markdown
+    assert "strategy|HD|4h|{}" in markdown
+    assert "forbidden_actions:" in markdown
+    assert "write an ADE queue" in markdown
+


### PR DESCRIPTION
## Summary
- adds a generic research action queue item builder
- converts existing QRE diagnostics into machine-readable bounded action intent
- exposes research_action_queue_items in report_latest.json
- renders Research Action Queue Items in report_latest.md
- keeps queue output emitter-only and report-only

## Commits
1. fix: add research action queue item builder
2. fix: expose research action queue items in reports

## E2E Evidence
On trend_pullback_equities_4h:
- research_action_queue_items emitted 2 items
- item 1: inspect_engine_vs_venue_fee_model_before_strategy_or_threshold_changes
- item 2: inspect_paper_engine_divergence
- both target HD as closest candidate
- both are priority=high
- execution_enabled=False
- queue_emitter_only=True
- paper_runtime_enabled=False
- shadow_runtime_enabled=False
- live_eligible=False

## Tests
- python -m ruff check research/report_agent.py tests/unit/test_report_agent.py
- python -m pytest tests/unit/test_report_agent.py -q
- python -m pytest tests/unit/test_screening_runtime.py -q
- python -m pytest tests/unit/test_execution_event_emission.py tests/unit/test_exit_diagnostics.py -q
- python -m pytest tests/unit/test_paper_readiness.py -q
- python -m pytest tests/architecture/test_domain_boundary_smoke.py -q

## Safety
- report-only / advisory-only
- emitter-only; does not execute actions
- does not write an ADE queue
- no divergence math changes
- no readiness threshold changes
- no strategy changes
- no preset changes
- no campaign queue mutation
- no candidate selection changes
- no paper, shadow, broker, risk, execution, or live runtime changes
- frozen contracts unchanged