### PR TITLE
feat: add QRE closed-loop hypothesis planning scaffold

### DIFF
--- a/reporting/qre_hypothesis_candidates.py
+++ b/reporting/qre_hypothesis_candidates.py
@@ -1,0 +1,326 @@
+"""Read-only QRE hypothesis candidate projector."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import hashlib
+import json
+import os
+import tempfile
+from collections import Counter
+from pathlib import Path
+from typing import Any, Final
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[int] = 1
+REPORT_KIND: Final[str] = "qre_hypothesis_candidates"
+INPUT_REPORT_KIND: Final[str] = "qre_market_observation_snapshot"
+
+INPUT_ARTIFACT_RELATIVE_PATH: Final[str] = "logs/qre_market_observations/latest.json"
+INPUT_ARTIFACT_PATH: Final[Path] = REPO_ROOT / INPUT_ARTIFACT_RELATIVE_PATH
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "qre_hypothesis_candidates"
+OUTPUT_ARTIFACT_RELATIVE_PATH: Final[str] = "logs/qre_hypothesis_candidates/latest.json"
+ARTIFACT_LATEST: Final[Path] = REPO_ROOT / OUTPUT_ARTIFACT_RELATIVE_PATH
+
+STATUS_PROPOSED: Final[str] = "proposed"
+
+NOTE_INPUT_ABSENT: Final[str] = "market_observation_artifact_absent"
+NOTE_INPUT_UNPARSEABLE: Final[str] = "market_observation_artifact_unparseable"
+NOTE_NO_HYPOTHESES: Final[str] = "no_hypotheses_projected"
+NOTE_HYPOTHESES_PRESENT: Final[str] = "hypothesis_candidates_present"
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _rel(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(REPO_ROOT.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _read_json(path: Path) -> tuple[bool, dict[str, Any] | None]:
+    try:
+        raw = path.read_text(encoding="utf-8-sig")
+    except OSError:
+        return (False, None)
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return (True, None)
+    return (True, parsed if isinstance(parsed, dict) else None)
+
+
+def _bounded_str(value: Any, *, max_len: int = 240) -> str:
+    text = str(value or "").strip()
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 3].rstrip() + "..."
+
+
+def _str_list(value: Any, *, max_items: int = 16, max_len: int = 160) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    out: list[str] = []
+    for item in value[:max_items]:
+        text = _bounded_str(item, max_len=max_len)
+        if text:
+            out.append(text)
+    return out
+
+
+def _hypothesis_id(observation: dict[str, Any]) -> str:
+    seed = "|".join(
+        [
+            _bounded_str(observation.get("observation_id"), max_len=160),
+            _bounded_str(observation.get("observation_type"), max_len=80),
+            ",".join(_str_list(observation.get("asset_scope"))),
+            ",".join(_str_list(observation.get("timeframe_scope"))),
+        ]
+    )
+    return "qre-hyp-" + hashlib.sha256(seed.encode("utf-8")).hexdigest()[:16]
+
+
+def _template_for_type(observation_type: str) -> dict[str, str]:
+    templates = {
+        "exit_failure_pattern": {
+            "title": "Exit and invalidation rule quality",
+            "claim": "Observed exit weakness may be caused by invalidation logic rather than entry signal quality.",
+            "expected_edge": "Cleaner exits should reduce adverse hold time without changing strategy definitions.",
+            "falsification_criteria": "The exit-focused diagnostic shows no improvement in drawdown, hold-time, or loss clustering.",
+        },
+        "low_trade_count": {
+            "title": "Sample and liquidity sufficiency",
+            "claim": "The observation may be underpowered because trade count or liquidity support is too low.",
+            "expected_edge": "A broader or better-sampled validation should separate weak evidence from genuine absence of edge.",
+            "falsification_criteria": "Expanded validation still produces insufficient sample support or unstable metrics.",
+        },
+        "high_window_end_impact": {
+            "title": "Fold and window-boundary sensitivity",
+            "claim": "The observation may be driven by fold timing or window-end effects instead of durable market behavior.",
+            "expected_edge": "Boundary-robust validation should reduce metric variance across folds.",
+            "falsification_criteria": "Walk-forward and boundary-shift checks show the same instability.",
+        },
+        "source_quality_issue": {
+            "title": "Data source quality and artifact integrity",
+            "claim": "The observation may be caused by malformed or low-quality source data rather than market behavior.",
+            "expected_edge": "Data-quality triage should either repair evidence quality or block downstream interpretation.",
+            "falsification_criteria": "Source-quality checks pass while the same observation persists.",
+        },
+        "paper_divergence": {
+            "title": "Research engine and paper parity",
+            "claim": "Paper/runtime divergence may invalidate direct interpretation of the research result.",
+            "expected_edge": "Parity diagnostics should isolate whether the signal survives engine differences.",
+            "falsification_criteria": "Parity checks show no material difference between research and paper semantics.",
+        },
+        "unknown": {
+            "title": "Unclassified market observation",
+            "claim": "The observation requires human review before it can become an executable research idea.",
+            "expected_edge": "Manual classification should turn the observation into a bounded validation question.",
+            "falsification_criteria": "No clear falsifiable hypothesis can be derived from the evidence.",
+        },
+    }
+    return templates.get(observation_type, templates["unknown"])
+
+
+def _build_hypothesis(observation: dict[str, Any]) -> dict[str, Any]:
+    observation_type = _bounded_str(observation.get("observation_type"), max_len=80)
+    template = _template_for_type(observation_type)
+    return {
+        "hypothesis_id": _hypothesis_id(observation),
+        "source_observation_id": _bounded_str(
+            observation.get("observation_id"), max_len=160
+        ),
+        "title": template["title"],
+        "claim": template["claim"],
+        "asset_scope": _str_list(observation.get("asset_scope")) or ["unknown"],
+        "timeframe_scope": _str_list(observation.get("timeframe_scope")) or ["unknown"],
+        "regime_tags": _str_list(observation.get("regime_tags")),
+        "expected_edge": template["expected_edge"],
+        "falsification_criteria": template["falsification_criteria"],
+        "validation_plan_required": True,
+        "supporting_evidence_refs": _str_list(
+            observation.get("supporting_evidence_refs"), max_items=24, max_len=180
+        ),
+        "contradicting_evidence_refs": _str_list(
+            observation.get("contradicting_evidence_refs"), max_items=24, max_len=180
+        ),
+        "status": STATUS_PROPOSED,
+        "safe_to_execute": False,
+    }
+
+
+def _empty_counts() -> dict[str, Any]:
+    return {"total": 0, "by_status": {STATUS_PROPOSED: 0}}
+
+
+def _counts(hypotheses: list[dict[str, Any]]) -> dict[str, Any]:
+    counter = Counter(str(item.get("status") or STATUS_PROPOSED) for item in hypotheses)
+    out = _empty_counts()
+    out["total"] = len(hypotheses)
+    out["by_status"][STATUS_PROPOSED] = counter.get(STATUS_PROPOSED, 0)
+    return out
+
+
+def _base_snapshot(
+    *,
+    generated_at_utc: str,
+    input_artifact_path: Path,
+    input_artifact_available: bool,
+    note: str,
+    hypotheses: list[dict[str, Any]],
+    validation_warnings: list[str],
+) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": generated_at_utc,
+        "input_artifact_path": _rel(input_artifact_path),
+        "input_artifact_available": input_artifact_available,
+        "note": note,
+        "hypotheses": hypotheses,
+        "counts": _counts(hypotheses),
+        "validation_warnings": validation_warnings,
+        "final_recommendation": (
+            "hypothesis_candidates_ready_for_validation_planning"
+            if hypotheses
+            else "no_hypothesis_candidates_available"
+        ),
+        "safe_to_execute": False,
+        "writes_development_work_queue": False,
+        "writes_seed_jsonl": False,
+        "writes_generated_seed_jsonl": False,
+        "mutates_campaign_queue": False,
+        "mutates_strategy_or_preset": False,
+        "mutates_paper_shadow_live_runtime": False,
+        "launches_codex": False,
+        "eligible_for_direct_execution": False,
+    }
+
+
+def collect_snapshot(
+    *,
+    input_artifact_path: Path | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    generated = generated_at_utc or _utcnow()
+    source = input_artifact_path or INPUT_ARTIFACT_PATH
+    available, payload = _read_json(source)
+    if payload is None:
+        note = NOTE_INPUT_UNPARSEABLE if available else NOTE_INPUT_ABSENT
+        return _base_snapshot(
+            generated_at_utc=generated,
+            input_artifact_path=source,
+            input_artifact_available=available,
+            note=note,
+            hypotheses=[],
+            validation_warnings=[note],
+        )
+
+    raw_observations = payload.get("observations")
+    if payload.get("report_kind") != INPUT_REPORT_KIND or not isinstance(
+        raw_observations, list
+    ) or not all(isinstance(item, dict) for item in raw_observations):
+        return _base_snapshot(
+            generated_at_utc=generated,
+            input_artifact_path=source,
+            input_artifact_available=True,
+            note=NOTE_INPUT_UNPARSEABLE,
+            hypotheses=[],
+            validation_warnings=[NOTE_INPUT_UNPARSEABLE],
+        )
+
+    hypotheses = [_build_hypothesis(item) for item in raw_observations]
+    hypotheses.sort(key=lambda item: item["hypothesis_id"])
+    return _base_snapshot(
+        generated_at_utc=generated,
+        input_artifact_path=source,
+        input_artifact_available=True,
+        note=NOTE_HYPOTHESES_PRESENT if hypotheses else NOTE_NO_HYPOTHESES,
+        hypotheses=hypotheses,
+        validation_warnings=[],
+    )
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    if not path.resolve().is_relative_to(ARTIFACT_DIR.resolve()):
+        raise ValueError(f"refusing write outside QRE hypothesis candidate dir: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".qre_hypothesis_candidates.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_outputs(
+    snapshot: dict[str, Any],
+    *,
+    output_path: Path | None = None,
+) -> Path:
+    target = output_path or ARTIFACT_LATEST
+    _atomic_write_json(target, snapshot)
+    return target
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="reporting.qre_hypothesis_candidates",
+        description="Project QRE market observations into proposed hypotheses.",
+    )
+    parser.add_argument("--no-write", action="store_true")
+    parser.add_argument("--source", type=Path, default=None)
+    parser.add_argument("--frozen-utc", default=None)
+    parser.add_argument("--indent", type=int, default=2)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    snapshot = collect_snapshot(
+        input_artifact_path=args.source,
+        generated_at_utc=args.frozen_utc,
+    )
+    if not args.no_write:
+        write_outputs(snapshot)
+    print(json.dumps(snapshot, indent=args.indent, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "ARTIFACT_DIR",
+    "ARTIFACT_LATEST",
+    "INPUT_ARTIFACT_PATH",
+    "INPUT_ARTIFACT_RELATIVE_PATH",
+    "OUTPUT_ARTIFACT_RELATIVE_PATH",
+    "REPORT_KIND",
+    "SCHEMA_VERSION",
+    "STATUS_PROPOSED",
+    "collect_snapshot",
+    "main",
+    "write_outputs",
+]

--- a/reporting/qre_hypothesis_validation_plan.py
+++ b/reporting/qre_hypothesis_validation_plan.py
@@ -1,0 +1,327 @@
+"""Read-only QRE hypothesis validation-plan projector."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import hashlib
+import json
+import os
+import tempfile
+from collections import Counter
+from pathlib import Path
+from typing import Any, Final
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[int] = 1
+REPORT_KIND: Final[str] = "qre_hypothesis_validation_plan"
+INPUT_REPORT_KIND: Final[str] = "qre_hypothesis_candidates"
+
+INPUT_ARTIFACT_RELATIVE_PATH: Final[str] = "logs/qre_hypothesis_candidates/latest.json"
+INPUT_ARTIFACT_PATH: Final[Path] = REPO_ROOT / INPUT_ARTIFACT_RELATIVE_PATH
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "qre_hypothesis_validation_plans"
+OUTPUT_ARTIFACT_RELATIVE_PATH: Final[str] = (
+    "logs/qre_hypothesis_validation_plans/latest.json"
+)
+ARTIFACT_LATEST: Final[Path] = REPO_ROOT / OUTPUT_ARTIFACT_RELATIVE_PATH
+
+STATUS_PLANNED: Final[str] = "planned"
+
+NOTE_INPUT_ABSENT: Final[str] = "hypothesis_candidate_artifact_absent"
+NOTE_INPUT_UNPARSEABLE: Final[str] = "hypothesis_candidate_artifact_unparseable"
+NOTE_NO_PLANS: Final[str] = "no_validation_plans_projected"
+NOTE_PLANS_PRESENT: Final[str] = "validation_plans_present"
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _rel(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(REPO_ROOT.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _read_json(path: Path) -> tuple[bool, dict[str, Any] | None]:
+    try:
+        raw = path.read_text(encoding="utf-8-sig")
+    except OSError:
+        return (False, None)
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return (True, None)
+    return (True, parsed if isinstance(parsed, dict) else None)
+
+
+def _bounded_str(value: Any, *, max_len: int = 240) -> str:
+    text = str(value or "").strip()
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 3].rstrip() + "..."
+
+
+def _str_list(value: Any, *, max_items: int = 16, max_len: int = 160) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    out: list[str] = []
+    for item in value[:max_items]:
+        text = _bounded_str(item, max_len=max_len)
+        if text:
+            out.append(text)
+    return out
+
+
+def _minimum_trade_count(timeframes: list[str]) -> int:
+    normalized = {item.lower() for item in timeframes}
+    if any(item in {"1m", "5m", "15m", "30m", "1h"} for item in normalized):
+        return 100
+    if any(item in {"2h", "4h"} for item in normalized):
+        return 60
+    return 50
+
+
+def _experiments_for_claim(claim: str) -> list[str]:
+    lowered = claim.lower()
+    if "exit" in lowered or "invalidation" in lowered:
+        return [
+            "exit_diagnostic_replay_plan",
+            "loss_cluster_review_plan",
+            "hold_time_distribution_check_plan",
+        ]
+    if "underpowered" in lowered or "liquidity" in lowered or "sample" in lowered:
+        return [
+            "sample_size_sufficiency_check_plan",
+            "liquidity_filter_sensitivity_plan",
+            "asset_timeframe_expansion_feasibility_plan",
+        ]
+    if "window" in lowered or "fold" in lowered:
+        return [
+            "walk_forward_boundary_shift_plan",
+            "fold_metric_stability_plan",
+            "window_end_sensitivity_plan",
+        ]
+    if "source" in lowered or "data" in lowered:
+        return [
+            "source_schema_quality_check_plan",
+            "missingness_and_duplicate_scan_plan",
+            "artifact_integrity_review_plan",
+        ]
+    if "paper" in lowered or "parity" in lowered or "engine" in lowered:
+        return [
+            "research_paper_parity_review_plan",
+            "fill_semantics_comparison_plan",
+            "runtime_assumption_diff_plan",
+        ]
+    return [
+        "manual_hypothesis_classification_plan",
+        "evidence_completeness_review_plan",
+    ]
+
+
+def _validation_plan_id(hypothesis_id: str, required_experiments: list[str]) -> str:
+    seed = hypothesis_id + "|" + ",".join(required_experiments)
+    return "qre-plan-" + hashlib.sha256(seed.encode("utf-8")).hexdigest()[:16]
+
+
+def _build_plan(hypothesis: dict[str, Any]) -> dict[str, Any]:
+    hypothesis_id = _bounded_str(hypothesis.get("hypothesis_id"), max_len=160)
+    asset_scope = _str_list(hypothesis.get("asset_scope")) or ["unknown"]
+    timeframe_scope = _str_list(hypothesis.get("timeframe_scope")) or ["unknown"]
+    required_experiments = _experiments_for_claim(
+        _bounded_str(hypothesis.get("claim"), max_len=600)
+    )
+    return {
+        "validation_plan_id": _validation_plan_id(hypothesis_id, required_experiments),
+        "hypothesis_id": hypothesis_id,
+        "required_experiments": required_experiments,
+        "asset_scope": asset_scope,
+        "timeframe_scope": timeframe_scope,
+        "minimum_trade_count": _minimum_trade_count(timeframe_scope),
+        "primary_metrics": [
+            "deflated_sharpe",
+            "max_drawdown",
+            "trade_count",
+            "fold_consistency",
+        ],
+        "falsification_criteria": _bounded_str(
+            hypothesis.get("falsification_criteria"), max_len=600
+        ),
+        "status": STATUS_PLANNED,
+        "safe_to_execute": False,
+    }
+
+
+def _empty_counts() -> dict[str, Any]:
+    return {"total": 0, "by_status": {STATUS_PLANNED: 0}}
+
+
+def _counts(plans: list[dict[str, Any]]) -> dict[str, Any]:
+    counter = Counter(str(item.get("status") or STATUS_PLANNED) for item in plans)
+    out = _empty_counts()
+    out["total"] = len(plans)
+    out["by_status"][STATUS_PLANNED] = counter.get(STATUS_PLANNED, 0)
+    return out
+
+
+def _base_snapshot(
+    *,
+    generated_at_utc: str,
+    input_artifact_path: Path,
+    input_artifact_available: bool,
+    note: str,
+    validation_plans: list[dict[str, Any]],
+    validation_warnings: list[str],
+) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": generated_at_utc,
+        "input_artifact_path": _rel(input_artifact_path),
+        "input_artifact_available": input_artifact_available,
+        "note": note,
+        "validation_plans": validation_plans,
+        "counts": _counts(validation_plans),
+        "validation_warnings": validation_warnings,
+        "final_recommendation": (
+            "validation_plans_ready_for_action_candidate_projection"
+            if validation_plans
+            else "no_validation_plans_available"
+        ),
+        "safe_to_execute": False,
+        "writes_development_work_queue": False,
+        "writes_seed_jsonl": False,
+        "writes_generated_seed_jsonl": False,
+        "mutates_campaign_queue": False,
+        "mutates_strategy_or_preset": False,
+        "mutates_paper_shadow_live_runtime": False,
+        "launches_codex": False,
+        "eligible_for_direct_execution": False,
+    }
+
+
+def collect_snapshot(
+    *,
+    input_artifact_path: Path | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    generated = generated_at_utc or _utcnow()
+    source = input_artifact_path or INPUT_ARTIFACT_PATH
+    available, payload = _read_json(source)
+    if payload is None:
+        note = NOTE_INPUT_UNPARSEABLE if available else NOTE_INPUT_ABSENT
+        return _base_snapshot(
+            generated_at_utc=generated,
+            input_artifact_path=source,
+            input_artifact_available=available,
+            note=note,
+            validation_plans=[],
+            validation_warnings=[note],
+        )
+
+    raw_hypotheses = payload.get("hypotheses")
+    if payload.get("report_kind") != INPUT_REPORT_KIND or not isinstance(
+        raw_hypotheses, list
+    ) or not all(isinstance(item, dict) for item in raw_hypotheses):
+        return _base_snapshot(
+            generated_at_utc=generated,
+            input_artifact_path=source,
+            input_artifact_available=True,
+            note=NOTE_INPUT_UNPARSEABLE,
+            validation_plans=[],
+            validation_warnings=[NOTE_INPUT_UNPARSEABLE],
+        )
+
+    validation_plans = [_build_plan(item) for item in raw_hypotheses]
+    validation_plans.sort(key=lambda item: item["validation_plan_id"])
+    return _base_snapshot(
+        generated_at_utc=generated,
+        input_artifact_path=source,
+        input_artifact_available=True,
+        note=NOTE_PLANS_PRESENT if validation_plans else NOTE_NO_PLANS,
+        validation_plans=validation_plans,
+        validation_warnings=[],
+    )
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    if not path.resolve().is_relative_to(ARTIFACT_DIR.resolve()):
+        raise ValueError(f"refusing write outside QRE validation plan dir: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".qre_hypothesis_validation_plans.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_outputs(
+    snapshot: dict[str, Any],
+    *,
+    output_path: Path | None = None,
+) -> Path:
+    target = output_path or ARTIFACT_LATEST
+    _atomic_write_json(target, snapshot)
+    return target
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="reporting.qre_hypothesis_validation_plan",
+        description="Project QRE hypotheses into read-only validation plans.",
+    )
+    parser.add_argument("--no-write", action="store_true")
+    parser.add_argument("--source", type=Path, default=None)
+    parser.add_argument("--frozen-utc", default=None)
+    parser.add_argument("--indent", type=int, default=2)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    snapshot = collect_snapshot(
+        input_artifact_path=args.source,
+        generated_at_utc=args.frozen_utc,
+    )
+    if not args.no_write:
+        write_outputs(snapshot)
+    print(json.dumps(snapshot, indent=args.indent, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "ARTIFACT_DIR",
+    "ARTIFACT_LATEST",
+    "INPUT_ARTIFACT_PATH",
+    "INPUT_ARTIFACT_RELATIVE_PATH",
+    "OUTPUT_ARTIFACT_RELATIVE_PATH",
+    "REPORT_KIND",
+    "SCHEMA_VERSION",
+    "STATUS_PLANNED",
+    "collect_snapshot",
+    "main",
+    "write_outputs",
+]

--- a/reporting/qre_market_observation_snapshot.py
+++ b/reporting/qre_market_observation_snapshot.py
@@ -1,0 +1,514 @@
+"""Read-only QRE market observation snapshot projector.
+
+This module projects local research artifacts into durable market observations.
+It is intentionally non-executing: it does not run research, launch tools,
+mutate strategies or presets, write queues, or activate runtime paths.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import hashlib
+import json
+import os
+import tempfile
+from collections import Counter
+from pathlib import Path
+from typing import Any, Final
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[int] = 1
+REPORT_KIND: Final[str] = "qre_market_observation_snapshot"
+
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "qre_market_observations"
+OUTPUT_ARTIFACT_RELATIVE_PATH: Final[str] = "logs/qre_market_observations/latest.json"
+ARTIFACT_LATEST: Final[Path] = REPO_ROOT / OUTPUT_ARTIFACT_RELATIVE_PATH
+
+DEFAULT_SOURCE_CANDIDATES: Final[tuple[Path, ...]] = (
+    REPO_ROOT / "research" / "research_latest.json",
+)
+
+OBSERVATION_TYPES: Final[tuple[str, ...]] = (
+    "exit_failure_pattern",
+    "low_trade_count",
+    "high_window_end_impact",
+    "source_quality_issue",
+    "paper_divergence",
+    "unknown",
+)
+
+NOTE_INPUT_ABSENT: Final[str] = "market_source_artifact_absent"
+NOTE_INPUT_UNPARSEABLE: Final[str] = "market_source_artifact_unparseable"
+NOTE_NO_OBSERVATIONS: Final[str] = "no_market_observations_projected"
+NOTE_OBSERVATIONS_PRESENT: Final[str] = "market_observations_present"
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _rel(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(REPO_ROOT.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _read_json(path: Path) -> tuple[bool, dict[str, Any] | None]:
+    try:
+        raw = path.read_text(encoding="utf-8-sig")
+    except OSError:
+        return (False, None)
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return (True, None)
+    return (True, parsed if isinstance(parsed, dict) else None)
+
+
+def _bounded_str(value: Any, *, max_len: int = 240) -> str:
+    text = str(value or "").strip()
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 3].rstrip() + "..."
+
+
+def _str_list(value: Any, *, max_items: int = 12, max_len: int = 120) -> list[str]:
+    if value is None:
+        return []
+    raw_items = value if isinstance(value, list) else [value]
+    out: list[str] = []
+    for item in raw_items[:max_items]:
+        text = _bounded_str(item, max_len=max_len)
+        if text:
+            out.append(text)
+    return out
+
+
+def _float_or_none(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _bool_true(value: Any) -> bool:
+    return value is True
+
+
+def _observation_id(
+    *,
+    source_artifact: str,
+    observation_type: str,
+    asset_scope: list[str],
+    timeframe_scope: list[str],
+    summary: str,
+) -> str:
+    seed = "|".join(
+        [
+            source_artifact,
+            observation_type,
+            ",".join(asset_scope),
+            ",".join(timeframe_scope),
+            summary,
+        ]
+    )
+    return "qre-obs-" + hashlib.sha256(seed.encode("utf-8")).hexdigest()[:16]
+
+
+def _normalise_fixture_observation(
+    raw: dict[str, Any],
+    *,
+    source_artifact: str,
+) -> dict[str, Any]:
+    observation_type = _bounded_str(raw.get("observation_type"), max_len=80)
+    if observation_type not in OBSERVATION_TYPES:
+        observation_type = "unknown"
+    asset_scope = _str_list(raw.get("asset_scope")) or ["unknown"]
+    timeframe_scope = _str_list(raw.get("timeframe_scope")) or ["unknown"]
+    summary = _bounded_str(raw.get("summary"), max_len=360) or "Unspecified observation."
+    observation_id = _bounded_str(raw.get("observation_id"), max_len=120)
+    if not observation_id:
+        observation_id = _observation_id(
+            source_artifact=source_artifact,
+            observation_type=observation_type,
+            asset_scope=asset_scope,
+            timeframe_scope=timeframe_scope,
+            summary=summary,
+        )
+
+    confidence = _float_or_none(raw.get("confidence"))
+    if confidence is None:
+        confidence = 0.5
+
+    return {
+        "observation_id": observation_id,
+        "source_artifact": source_artifact,
+        "observation_type": observation_type,
+        "asset_scope": asset_scope,
+        "timeframe_scope": timeframe_scope,
+        "regime_tags": _str_list(raw.get("regime_tags"), max_items=16),
+        "metric_refs": _str_list(raw.get("metric_refs"), max_items=24, max_len=180),
+        "summary": summary,
+        "confidence": max(0.0, min(1.0, confidence)),
+        "supporting_evidence_refs": _str_list(
+            raw.get("supporting_evidence_refs"), max_items=24, max_len=180
+        ),
+        "contradicting_evidence_refs": _str_list(
+            raw.get("contradicting_evidence_refs"), max_items=24, max_len=180
+        ),
+        "safe_to_execute": False,
+    }
+
+
+def _metric_ref(name: str, value: Any) -> str:
+    return f"{name}:{_bounded_str(value, max_len=80)}"
+
+
+def _row_identity(row: dict[str, Any]) -> str:
+    strategy = _bounded_str(row.get("strategy_name"), max_len=80) or "unknown_strategy"
+    asset = _bounded_str(row.get("asset"), max_len=80) or "unknown_asset"
+    interval = _bounded_str(row.get("interval"), max_len=40) or "unknown_timeframe"
+    return f"{strategy}|{asset}|{interval}"
+
+
+def _build_research_observations(
+    payload: dict[str, Any],
+    *,
+    source_artifact: str,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    raw_results = payload.get("results")
+    if not isinstance(raw_results, list):
+        return ([], [NOTE_INPUT_UNPARSEABLE])
+
+    observations: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    for index, raw in enumerate(raw_results, start=1):
+        if not isinstance(raw, dict):
+            warnings.append(f"result_{index}:not_object")
+            continue
+
+        asset_scope = [_bounded_str(raw.get("asset"), max_len=80) or "unknown"]
+        timeframe_scope = [_bounded_str(raw.get("interval"), max_len=40) or "unknown"]
+        family = _bounded_str(raw.get("family"), max_len=80)
+        regime_tags = [family] if family else []
+        row_ref = _row_identity(raw)
+        metric_refs = [
+            _metric_ref("win_rate", raw.get("win_rate")),
+            _metric_ref("sharpe", raw.get("sharpe")),
+            _metric_ref("deflated_sharpe", raw.get("deflated_sharpe")),
+            _metric_ref("trades_per_month", raw.get("trades_per_maand")),
+            _metric_ref("total_trades", raw.get("totaal_trades")),
+            _metric_ref("consistency", raw.get("consistentie")),
+        ]
+        supporting_refs = [f"{source_artifact}#{row_ref}"]
+        contradicting_refs: list[str] = []
+
+        success = raw.get("success")
+        error = _bounded_str(raw.get("error"), max_len=160)
+        total_trades = _float_or_none(raw.get("totaal_trades"))
+        trades_per_month = _float_or_none(raw.get("trades_per_maand"))
+        sharpe = _float_or_none(raw.get("sharpe"))
+        consistency = _float_or_none(raw.get("consistentie"))
+
+        projected: list[tuple[str, str, float]] = []
+        if success is False or error:
+            projected.append(
+                (
+                    "source_quality_issue",
+                    f"Research row {row_ref} reports a failed or error-bearing source result.",
+                    0.85,
+                )
+            )
+        if (
+            (total_trades is not None and total_trades < 30)
+            or (trades_per_month is not None and trades_per_month < 1.0)
+        ):
+            projected.append(
+                (
+                    "low_trade_count",
+                    f"Research row {row_ref} has limited sample support for validation.",
+                    0.8,
+                )
+            )
+        if (
+            (consistency is not None and consistency == 0.0)
+            and (total_trades is not None and total_trades < 40)
+        ):
+            projected.append(
+                (
+                    "high_window_end_impact",
+                    f"Research row {row_ref} may be sensitive to fold or window boundaries.",
+                    0.65,
+                )
+            )
+        if "tp_sl" in _bounded_str(raw.get("strategy_name"), max_len=120) and (
+            sharpe is not None and sharpe < 0.0
+        ):
+            projected.append(
+                (
+                    "exit_failure_pattern",
+                    f"Research row {row_ref} suggests exit management may be degrading edge.",
+                    0.7,
+                )
+            )
+        if _bool_true(raw.get("paper_divergence")) or _bool_true(
+            raw.get("paper_engine_divergence")
+        ):
+            projected.append(
+                (
+                    "paper_divergence",
+                    f"Research row {row_ref} indicates a paper or engine parity divergence.",
+                    0.9,
+                )
+            )
+        if not projected and raw_results:
+            projected.append(
+                (
+                    "unknown",
+                    f"Research row {row_ref} has no specific closed-loop observation rule.",
+                    0.4,
+                )
+            )
+
+        for observation_type, summary, confidence in projected:
+            observation_id = _observation_id(
+                source_artifact=source_artifact,
+                observation_type=observation_type,
+                asset_scope=asset_scope,
+                timeframe_scope=timeframe_scope,
+                summary=summary,
+            )
+            observations.append(
+                {
+                    "observation_id": observation_id,
+                    "source_artifact": source_artifact,
+                    "observation_type": observation_type,
+                    "asset_scope": asset_scope,
+                    "timeframe_scope": timeframe_scope,
+                    "regime_tags": regime_tags,
+                    "metric_refs": metric_refs,
+                    "summary": summary,
+                    "confidence": confidence,
+                    "supporting_evidence_refs": supporting_refs,
+                    "contradicting_evidence_refs": contradicting_refs,
+                    "safe_to_execute": False,
+                }
+            )
+
+    observations.sort(key=lambda item: item["observation_id"])
+    return (observations, warnings)
+
+
+def _select_default_source() -> Path:
+    for path in DEFAULT_SOURCE_CANDIDATES:
+        if path.exists():
+            return path
+    return DEFAULT_SOURCE_CANDIDATES[0]
+
+
+def _empty_counts() -> dict[str, Any]:
+    return {
+        "total": 0,
+        "by_observation_type": {kind: 0 for kind in OBSERVATION_TYPES},
+    }
+
+
+def _counts(observations: list[dict[str, Any]]) -> dict[str, Any]:
+    counter = Counter(str(item.get("observation_type") or "unknown") for item in observations)
+    out = _empty_counts()
+    out["total"] = len(observations)
+    for kind in OBSERVATION_TYPES:
+        out["by_observation_type"][kind] = counter.get(kind, 0)
+    return out
+
+
+def _final_recommendation(observations: list[dict[str, Any]]) -> str:
+    if observations:
+        return "market_observations_ready_for_hypothesis_projection"
+    return "no_market_observations_available"
+
+
+def _base_snapshot(
+    *,
+    generated_at_utc: str,
+    input_artifact_path: Path,
+    input_artifact_available: bool,
+    note: str,
+    observations: list[dict[str, Any]],
+    validation_warnings: list[str],
+) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": generated_at_utc,
+        "input_artifact_path": _rel(input_artifact_path),
+        "input_artifact_available": input_artifact_available,
+        "note": note,
+        "supported_observation_types": list(OBSERVATION_TYPES),
+        "observations": observations,
+        "counts": _counts(observations),
+        "validation_warnings": validation_warnings,
+        "final_recommendation": _final_recommendation(observations),
+        "safe_to_execute": False,
+        "writes_development_work_queue": False,
+        "writes_seed_jsonl": False,
+        "writes_generated_seed_jsonl": False,
+        "mutates_campaign_queue": False,
+        "mutates_strategy_or_preset": False,
+        "mutates_paper_shadow_live_runtime": False,
+        "launches_codex": False,
+        "eligible_for_direct_execution": False,
+    }
+
+
+def collect_snapshot(
+    *,
+    source_path: Path | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    generated = generated_at_utc or _utcnow()
+    source = source_path or _select_default_source()
+    available, payload = _read_json(source)
+    if payload is None:
+        note = NOTE_INPUT_UNPARSEABLE if available else NOTE_INPUT_ABSENT
+        return _base_snapshot(
+            generated_at_utc=generated,
+            input_artifact_path=source,
+            input_artifact_available=available,
+            note=note,
+            observations=[],
+            validation_warnings=[note],
+        )
+
+    source_artifact = _rel(source)
+    if "observations" in payload:
+        raw_observations = payload.get("observations")
+        if not isinstance(raw_observations, list) or not all(
+            isinstance(item, dict) for item in raw_observations
+        ):
+            return _base_snapshot(
+                generated_at_utc=generated,
+                input_artifact_path=source,
+                input_artifact_available=True,
+                note=NOTE_INPUT_UNPARSEABLE,
+                observations=[],
+                validation_warnings=[NOTE_INPUT_UNPARSEABLE],
+            )
+        observations = [
+            _normalise_fixture_observation(item, source_artifact=source_artifact)
+            for item in raw_observations
+        ]
+        observations.sort(key=lambda item: item["observation_id"])
+        return _base_snapshot(
+            generated_at_utc=generated,
+            input_artifact_path=source,
+            input_artifact_available=True,
+            note=NOTE_OBSERVATIONS_PRESENT if observations else NOTE_NO_OBSERVATIONS,
+            observations=observations,
+            validation_warnings=[],
+        )
+
+    observations, warnings = _build_research_observations(
+        payload,
+        source_artifact=source_artifact,
+    )
+    if NOTE_INPUT_UNPARSEABLE in warnings:
+        return _base_snapshot(
+            generated_at_utc=generated,
+            input_artifact_path=source,
+            input_artifact_available=True,
+            note=NOTE_INPUT_UNPARSEABLE,
+            observations=[],
+            validation_warnings=warnings,
+        )
+
+    return _base_snapshot(
+        generated_at_utc=generated,
+        input_artifact_path=source,
+        input_artifact_available=True,
+        note=NOTE_OBSERVATIONS_PRESENT if observations else NOTE_NO_OBSERVATIONS,
+        observations=observations,
+        validation_warnings=warnings,
+    )
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    if not path.resolve().is_relative_to(ARTIFACT_DIR.resolve()):
+        raise ValueError(f"refusing write outside QRE market observation dir: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".qre_market_observations.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_outputs(
+    snapshot: dict[str, Any],
+    *,
+    output_path: Path | None = None,
+) -> Path:
+    target = output_path or ARTIFACT_LATEST
+    _atomic_write_json(target, snapshot)
+    return target
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="reporting.qre_market_observation_snapshot",
+        description="Project local research artifacts into read-only QRE observations.",
+    )
+    parser.add_argument("--no-write", action="store_true")
+    parser.add_argument("--source", type=Path, default=None)
+    parser.add_argument("--frozen-utc", default=None)
+    parser.add_argument("--indent", type=int, default=2)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    snapshot = collect_snapshot(
+        source_path=args.source,
+        generated_at_utc=args.frozen_utc,
+    )
+    if not args.no_write:
+        write_outputs(snapshot)
+    print(json.dumps(snapshot, indent=args.indent, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "ARTIFACT_DIR",
+    "ARTIFACT_LATEST",
+    "DEFAULT_SOURCE_CANDIDATES",
+    "OBSERVATION_TYPES",
+    "OUTPUT_ARTIFACT_RELATIVE_PATH",
+    "REPORT_KIND",
+    "SCHEMA_VERSION",
+    "collect_snapshot",
+    "main",
+    "write_outputs",
+]

--- a/reporting/qre_observation_hypothesis_projector.py
+++ b/reporting/qre_observation_hypothesis_projector.py
@@ -1,0 +1,293 @@
+"""Read-only QRE observation-to-hypothesis projection rows."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import hashlib
+import json
+import os
+import tempfile
+from collections import Counter
+from pathlib import Path
+from typing import Any, Final
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[int] = 1
+REPORT_KIND: Final[str] = "qre_observation_hypothesis_projector"
+INPUT_REPORT_KIND: Final[str] = "qre_market_observation_snapshot"
+
+INPUT_ARTIFACT_RELATIVE_PATH: Final[str] = "logs/qre_market_observations/latest.json"
+INPUT_ARTIFACT_PATH: Final[Path] = REPO_ROOT / INPUT_ARTIFACT_RELATIVE_PATH
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "qre_observation_hypothesis_projection"
+OUTPUT_ARTIFACT_RELATIVE_PATH: Final[str] = (
+    "logs/qre_observation_hypothesis_projection/latest.json"
+)
+ARTIFACT_LATEST: Final[Path] = REPO_ROOT / OUTPUT_ARTIFACT_RELATIVE_PATH
+
+NOTE_INPUT_ABSENT: Final[str] = "market_observation_artifact_absent"
+NOTE_INPUT_UNPARSEABLE: Final[str] = "market_observation_artifact_unparseable"
+NOTE_NO_ROWS: Final[str] = "no_observation_hypothesis_projection_rows"
+NOTE_ROWS_PRESENT: Final[str] = "observation_hypothesis_projection_rows_present"
+
+RULES: Final[dict[str, tuple[str, str]]] = {
+    "exit_failure_pattern": ("exit_invalidation_hypothesis", "exit_or_invalidation"),
+    "low_trade_count": ("sample_liquidity_hypothesis", "sample_or_liquidity"),
+    "high_window_end_impact": ("fold_window_boundary_hypothesis", "fold_boundary"),
+    "source_quality_issue": ("data_quality_hypothesis", "data_quality"),
+    "paper_divergence": ("engine_parity_hypothesis", "engine_or_parity"),
+    "unknown": ("manual_classification_hypothesis", "manual_review"),
+}
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _rel(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(REPO_ROOT.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _read_json(path: Path) -> tuple[bool, dict[str, Any] | None]:
+    try:
+        raw = path.read_text(encoding="utf-8-sig")
+    except OSError:
+        return (False, None)
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return (True, None)
+    return (True, parsed if isinstance(parsed, dict) else None)
+
+
+def _bounded_str(value: Any, *, max_len: int = 240) -> str:
+    text = str(value or "").strip()
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 3].rstrip() + "..."
+
+
+def _str_list(value: Any, *, max_items: int = 16, max_len: int = 160) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    out: list[str] = []
+    for item in value[:max_items]:
+        text = _bounded_str(item, max_len=max_len)
+        if text:
+            out.append(text)
+    return out
+
+
+def _hypothesis_id(observation: dict[str, Any]) -> str:
+    seed = "|".join(
+        [
+            _bounded_str(observation.get("observation_id"), max_len=160),
+            _bounded_str(observation.get("observation_type"), max_len=80),
+            ",".join(_str_list(observation.get("asset_scope"))),
+            ",".join(_str_list(observation.get("timeframe_scope"))),
+        ]
+    )
+    return "qre-hyp-" + hashlib.sha256(seed.encode("utf-8")).hexdigest()[:16]
+
+
+def _projection_id(observation_id: str, hypothesis_id: str) -> str:
+    seed = f"{observation_id}|{hypothesis_id}"
+    return "qre-proj-" + hashlib.sha256(seed.encode("utf-8")).hexdigest()[:16]
+
+
+def _build_row(observation: dict[str, Any]) -> dict[str, Any]:
+    observation_type = _bounded_str(observation.get("observation_type"), max_len=80)
+    rule_name, family = RULES.get(observation_type, RULES["unknown"])
+    observation_id = _bounded_str(observation.get("observation_id"), max_len=160)
+    hypothesis_id = _hypothesis_id(observation)
+    return {
+        "projection_id": _projection_id(observation_id, hypothesis_id),
+        "observation_id": observation_id,
+        "proposed_hypothesis_id": hypothesis_id,
+        "observation_type": observation_type or "unknown",
+        "projection_rule": rule_name,
+        "hypothesis_family": family,
+        "asset_scope": _str_list(observation.get("asset_scope")) or ["unknown"],
+        "timeframe_scope": _str_list(observation.get("timeframe_scope")) or ["unknown"],
+        "regime_tags": _str_list(observation.get("regime_tags")),
+        "status": "proposed",
+        "safe_to_execute": False,
+        "eligible_for_direct_execution": False,
+    }
+
+
+def _empty_counts() -> dict[str, Any]:
+    return {"total": 0, "by_projection_rule": {rule[0]: 0 for rule in RULES.values()}}
+
+
+def _counts(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    counter = Counter(str(row.get("projection_rule") or "") for row in rows)
+    out = _empty_counts()
+    out["total"] = len(rows)
+    for rule_name, _family in RULES.values():
+        out["by_projection_rule"][rule_name] = counter.get(rule_name, 0)
+    return out
+
+
+def _base_snapshot(
+    *,
+    generated_at_utc: str,
+    input_artifact_path: Path,
+    input_artifact_available: bool,
+    note: str,
+    rows: list[dict[str, Any]],
+    validation_warnings: list[str],
+) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": generated_at_utc,
+        "input_artifact_path": _rel(input_artifact_path),
+        "input_artifact_available": input_artifact_available,
+        "note": note,
+        "projection_rows": rows,
+        "counts": _counts(rows),
+        "validation_warnings": validation_warnings,
+        "final_recommendation": (
+            "projection_rows_ready_for_validation_planning"
+            if rows
+            else "no_projection_rows_available"
+        ),
+        "safe_to_execute": False,
+        "writes_development_work_queue": False,
+        "writes_seed_jsonl": False,
+        "writes_generated_seed_jsonl": False,
+        "mutates_campaign_queue": False,
+        "mutates_strategy_or_preset": False,
+        "mutates_paper_shadow_live_runtime": False,
+        "launches_codex": False,
+        "eligible_for_direct_execution": False,
+    }
+
+
+def collect_snapshot(
+    *,
+    input_artifact_path: Path | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    generated = generated_at_utc or _utcnow()
+    source = input_artifact_path or INPUT_ARTIFACT_PATH
+    available, payload = _read_json(source)
+    if payload is None:
+        note = NOTE_INPUT_UNPARSEABLE if available else NOTE_INPUT_ABSENT
+        return _base_snapshot(
+            generated_at_utc=generated,
+            input_artifact_path=source,
+            input_artifact_available=available,
+            note=note,
+            rows=[],
+            validation_warnings=[note],
+        )
+
+    raw_observations = payload.get("observations")
+    if payload.get("report_kind") != INPUT_REPORT_KIND or not isinstance(
+        raw_observations, list
+    ) or not all(isinstance(item, dict) for item in raw_observations):
+        return _base_snapshot(
+            generated_at_utc=generated,
+            input_artifact_path=source,
+            input_artifact_available=True,
+            note=NOTE_INPUT_UNPARSEABLE,
+            rows=[],
+            validation_warnings=[NOTE_INPUT_UNPARSEABLE],
+        )
+
+    rows = [_build_row(item) for item in raw_observations]
+    rows.sort(key=lambda item: item["projection_id"])
+    return _base_snapshot(
+        generated_at_utc=generated,
+        input_artifact_path=source,
+        input_artifact_available=True,
+        note=NOTE_ROWS_PRESENT if rows else NOTE_NO_ROWS,
+        rows=rows,
+        validation_warnings=[],
+    )
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    if not path.resolve().is_relative_to(ARTIFACT_DIR.resolve()):
+        raise ValueError(f"refusing write outside QRE projection dir: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".qre_observation_hypothesis_projection.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_outputs(
+    snapshot: dict[str, Any],
+    *,
+    output_path: Path | None = None,
+) -> Path:
+    target = output_path or ARTIFACT_LATEST
+    _atomic_write_json(target, snapshot)
+    return target
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="reporting.qre_observation_hypothesis_projector",
+        description="Project QRE observations into non-executable hypothesis links.",
+    )
+    parser.add_argument("--no-write", action="store_true")
+    parser.add_argument("--source", type=Path, default=None)
+    parser.add_argument("--frozen-utc", default=None)
+    parser.add_argument("--indent", type=int, default=2)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    snapshot = collect_snapshot(
+        input_artifact_path=args.source,
+        generated_at_utc=args.frozen_utc,
+    )
+    if not args.no_write:
+        write_outputs(snapshot)
+    print(json.dumps(snapshot, indent=args.indent, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "ARTIFACT_DIR",
+    "ARTIFACT_LATEST",
+    "INPUT_ARTIFACT_PATH",
+    "INPUT_ARTIFACT_RELATIVE_PATH",
+    "OUTPUT_ARTIFACT_RELATIVE_PATH",
+    "REPORT_KIND",
+    "RULES",
+    "SCHEMA_VERSION",
+    "collect_snapshot",
+    "main",
+    "write_outputs",
+]

--- a/reporting/qre_validation_research_action_candidates.py
+++ b/reporting/qre_validation_research_action_candidates.py
@@ -1,0 +1,297 @@
+"""Read-only QRE validation research-action candidate projector."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import hashlib
+import json
+import os
+import tempfile
+from collections import Counter
+from pathlib import Path
+from typing import Any, Final
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[int] = 1
+REPORT_KIND: Final[str] = "qre_validation_research_action_candidates"
+INPUT_REPORT_KIND: Final[str] = "qre_hypothesis_validation_plan"
+
+INPUT_ARTIFACT_RELATIVE_PATH: Final[str] = (
+    "logs/qre_hypothesis_validation_plans/latest.json"
+)
+INPUT_ARTIFACT_PATH: Final[Path] = REPO_ROOT / INPUT_ARTIFACT_RELATIVE_PATH
+ARTIFACT_DIR: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_validation_research_action_candidates"
+)
+OUTPUT_ARTIFACT_RELATIVE_PATH: Final[str] = (
+    "logs/qre_validation_research_action_candidates/latest.json"
+)
+ARTIFACT_LATEST: Final[Path] = REPO_ROOT / OUTPUT_ARTIFACT_RELATIVE_PATH
+
+STATUS_PENDING: Final[str] = "pending"
+OUTCOME_NOT_RECORDED: Final[str] = "not_recorded"
+
+FORBIDDEN_ACTIONS: Final[tuple[str, ...]] = (
+    "paper_runtime_activation",
+    "shadow_runtime_activation",
+    "live_runtime_activation",
+    "broker_execution",
+    "strategy_or_preset_mutation",
+    "campaign_queue_mutation",
+    "codex_execution",
+)
+
+NOTE_INPUT_ABSENT: Final[str] = "validation_plan_artifact_absent"
+NOTE_INPUT_UNPARSEABLE: Final[str] = "validation_plan_artifact_unparseable"
+NOTE_NO_CANDIDATES: Final[str] = "no_validation_action_candidates_projected"
+NOTE_CANDIDATES_PRESENT: Final[str] = "validation_action_candidates_present"
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _rel(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(REPO_ROOT.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _read_json(path: Path) -> tuple[bool, dict[str, Any] | None]:
+    try:
+        raw = path.read_text(encoding="utf-8-sig")
+    except OSError:
+        return (False, None)
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return (True, None)
+    return (True, parsed if isinstance(parsed, dict) else None)
+
+
+def _bounded_str(value: Any, *, max_len: int = 240) -> str:
+    text = str(value or "").strip()
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 3].rstrip() + "..."
+
+
+def _int_or_default(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _action_id(plan: dict[str, Any]) -> str:
+    seed = "|".join(
+        [
+            _bounded_str(plan.get("validation_plan_id"), max_len=160),
+            _bounded_str(plan.get("hypothesis_id"), max_len=160),
+            _bounded_str(plan.get("status"), max_len=40),
+        ]
+    )
+    return "qre-action-" + hashlib.sha256(seed.encode("utf-8")).hexdigest()[:16]
+
+
+def _priority(plan: dict[str, Any]) -> str:
+    minimum_trade_count = _int_or_default(plan.get("minimum_trade_count"), 0)
+    if minimum_trade_count >= 100:
+        return "high"
+    if minimum_trade_count >= 60:
+        return "medium"
+    return "low"
+
+
+def _build_candidate(plan: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "action_id": _action_id(plan),
+        "source_section": "qre_hypothesis_validation_plan",
+        "target_hypothesis_id": _bounded_str(plan.get("hypothesis_id"), max_len=160),
+        "target_validation_plan_id": _bounded_str(
+            plan.get("validation_plan_id"), max_len=160
+        ),
+        "priority": _priority(plan),
+        "status": STATUS_PENDING,
+        "outcome_status": OUTCOME_NOT_RECORDED,
+        "operator_approval_required": True,
+        "forbidden_actions": list(FORBIDDEN_ACTIONS),
+        "safe_to_execute": False,
+        "eligible_for_direct_execution": False,
+    }
+
+
+def _empty_counts() -> dict[str, Any]:
+    return {"total": 0, "by_status": {STATUS_PENDING: 0}}
+
+
+def _counts(candidates: list[dict[str, Any]]) -> dict[str, Any]:
+    counter = Counter(str(item.get("status") or STATUS_PENDING) for item in candidates)
+    out = _empty_counts()
+    out["total"] = len(candidates)
+    out["by_status"][STATUS_PENDING] = counter.get(STATUS_PENDING, 0)
+    return out
+
+
+def _base_snapshot(
+    *,
+    generated_at_utc: str,
+    input_artifact_path: Path,
+    input_artifact_available: bool,
+    note: str,
+    action_candidates: list[dict[str, Any]],
+    validation_warnings: list[str],
+) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": generated_at_utc,
+        "input_artifact_path": _rel(input_artifact_path),
+        "input_artifact_available": input_artifact_available,
+        "note": note,
+        "action_candidates": action_candidates,
+        "counts": _counts(action_candidates),
+        "validation_warnings": validation_warnings,
+        "final_recommendation": (
+            "validation_action_candidates_ready_for_operator_review"
+            if action_candidates
+            else "no_validation_action_candidates_available"
+        ),
+        "safe_to_execute": False,
+        "writes_development_work_queue": False,
+        "writes_seed_jsonl": False,
+        "writes_generated_seed_jsonl": False,
+        "writes_research_action_queue": False,
+        "mutates_campaign_queue": False,
+        "mutates_strategy_or_preset": False,
+        "mutates_paper_shadow_live_runtime": False,
+        "launches_codex": False,
+        "eligible_for_direct_execution": False,
+    }
+
+
+def collect_snapshot(
+    *,
+    input_artifact_path: Path | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    generated = generated_at_utc or _utcnow()
+    source = input_artifact_path or INPUT_ARTIFACT_PATH
+    available, payload = _read_json(source)
+    if payload is None:
+        note = NOTE_INPUT_UNPARSEABLE if available else NOTE_INPUT_ABSENT
+        return _base_snapshot(
+            generated_at_utc=generated,
+            input_artifact_path=source,
+            input_artifact_available=available,
+            note=note,
+            action_candidates=[],
+            validation_warnings=[note],
+        )
+
+    raw_plans = payload.get("validation_plans")
+    if payload.get("report_kind") != INPUT_REPORT_KIND or not isinstance(
+        raw_plans, list
+    ) or not all(isinstance(item, dict) for item in raw_plans):
+        return _base_snapshot(
+            generated_at_utc=generated,
+            input_artifact_path=source,
+            input_artifact_available=True,
+            note=NOTE_INPUT_UNPARSEABLE,
+            action_candidates=[],
+            validation_warnings=[NOTE_INPUT_UNPARSEABLE],
+        )
+
+    action_candidates = [_build_candidate(item) for item in raw_plans]
+    action_candidates.sort(key=lambda item: item["action_id"])
+    return _base_snapshot(
+        generated_at_utc=generated,
+        input_artifact_path=source,
+        input_artifact_available=True,
+        note=NOTE_CANDIDATES_PRESENT if action_candidates else NOTE_NO_CANDIDATES,
+        action_candidates=action_candidates,
+        validation_warnings=[],
+    )
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    if not path.resolve().is_relative_to(ARTIFACT_DIR.resolve()):
+        raise ValueError(f"refusing write outside QRE validation action dir: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".qre_validation_research_action_candidates.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_outputs(
+    snapshot: dict[str, Any],
+    *,
+    output_path: Path | None = None,
+) -> Path:
+    target = output_path or ARTIFACT_LATEST
+    _atomic_write_json(target, snapshot)
+    return target
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="reporting.qre_validation_research_action_candidates",
+        description="Project validation plans into read-only research action candidates.",
+    )
+    parser.add_argument("--no-write", action="store_true")
+    parser.add_argument("--source", type=Path, default=None)
+    parser.add_argument("--frozen-utc", default=None)
+    parser.add_argument("--indent", type=int, default=2)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    snapshot = collect_snapshot(
+        input_artifact_path=args.source,
+        generated_at_utc=args.frozen_utc,
+    )
+    if not args.no_write:
+        write_outputs(snapshot)
+    print(json.dumps(snapshot, indent=args.indent, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "ARTIFACT_DIR",
+    "ARTIFACT_LATEST",
+    "FORBIDDEN_ACTIONS",
+    "INPUT_ARTIFACT_PATH",
+    "INPUT_ARTIFACT_RELATIVE_PATH",
+    "OUTPUT_ARTIFACT_RELATIVE_PATH",
+    "REPORT_KIND",
+    "SCHEMA_VERSION",
+    "collect_snapshot",
+    "main",
+    "write_outputs",
+]

--- a/tests/unit/test_qre_hypothesis_candidates.py
+++ b/tests/unit/test_qre_hypothesis_candidates.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from reporting import qre_hypothesis_candidates as hyp
+
+
+FROZEN = "2026-06-01T12:00:00Z"
+
+
+def _observation(**overrides) -> dict:
+    base = {
+        "observation_id": "qre-obs-fixture-001",
+        "source_artifact": "fixture.json",
+        "observation_type": "exit_failure_pattern",
+        "asset_scope": ["BTC-USD"],
+        "timeframe_scope": ["1h"],
+        "regime_tags": ["trend"],
+        "metric_refs": ["sharpe:-1.0"],
+        "summary": "Exit rules appear to degrade the trend edge.",
+        "confidence": 0.7,
+        "supporting_evidence_refs": ["fixture#1"],
+        "contradicting_evidence_refs": [],
+        "safe_to_execute": False,
+    }
+    base.update(overrides)
+    return base
+
+
+def _write_observations(path: Path, observations: list[dict], **overrides) -> Path:
+    payload = {
+        "schema_version": 1,
+        "report_kind": "qre_market_observation_snapshot",
+        "generated_at_utc": FROZEN,
+        "observations": observations,
+        "safe_to_execute": False,
+    }
+    payload.update(overrides)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return path
+
+
+def test_missing_input_fails_closed(tmp_path: Path) -> None:
+    snap = hyp.collect_snapshot(
+        input_artifact_path=tmp_path / "missing.json",
+        generated_at_utc=FROZEN,
+    )
+
+    assert snap["input_artifact_available"] is False
+    assert snap["hypotheses"] == []
+    assert snap["safe_to_execute"] is False
+    assert snap["launches_codex"] is False
+    assert hyp.NOTE_INPUT_ABSENT in snap["validation_warnings"]
+
+
+def test_malformed_input_fails_closed(tmp_path: Path) -> None:
+    source = _write_observations(tmp_path / "obs.json", [], report_kind="wrong")
+
+    snap = hyp.collect_snapshot(input_artifact_path=source, generated_at_utc=FROZEN)
+
+    assert snap["input_artifact_available"] is True
+    assert snap["hypotheses"] == []
+    assert hyp.NOTE_INPUT_UNPARSEABLE in snap["validation_warnings"]
+    assert snap["safe_to_execute"] is False
+
+
+def test_deterministic_output_with_injected_timestamp(tmp_path: Path) -> None:
+    source = _write_observations(tmp_path / "obs.json", [_observation()])
+
+    snap_a = hyp.collect_snapshot(input_artifact_path=source, generated_at_utc=FROZEN)
+    snap_b = hyp.collect_snapshot(input_artifact_path=source, generated_at_utc=FROZEN)
+
+    assert json.dumps(snap_a, sort_keys=True) == json.dumps(snap_b, sort_keys=True)
+    row = snap_a["hypotheses"][0]
+    assert row["hypothesis_id"].startswith("qre-hyp-")
+    assert row["source_observation_id"] == "qre-obs-fixture-001"
+    assert row["status"] == "proposed"
+    assert row["validation_plan_required"] is True
+    assert row["safe_to_execute"] is False
+
+
+def test_atomic_write_refuses_outside_artifact_dir(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        hyp._atomic_write_json(tmp_path / "latest.json", {"x": 1})
+
+
+def test_cli_no_write_outputs_json_without_writing(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    source = _write_observations(tmp_path / "obs.json", [_observation()])
+    artifact_dir = tmp_path / "logs" / "qre_hypothesis_candidates"
+    latest = artifact_dir / "latest.json"
+    monkeypatch.setattr(hyp, "ARTIFACT_DIR", artifact_dir)
+    monkeypatch.setattr(hyp, "ARTIFACT_LATEST", latest)
+
+    rc = hyp.main(
+        ["--no-write", "--source", str(source), "--frozen-utc", FROZEN, "--indent", "0"]
+    )
+
+    assert rc == 0
+    assert latest.exists() is False
+    parsed = json.loads(capsys.readouterr().out)
+    assert parsed["hypotheses"][0]["status"] == "proposed"
+
+
+def test_source_has_no_runtime_launch_or_network_calls() -> None:
+    src = Path(hyp.__file__).read_text(encoding="utf-8")
+    forbidden = (
+        "import subprocess",
+        "from subprocess",
+        "subprocess.",
+        "import socket",
+        "from socket",
+        "import requests",
+        "import httpx",
+        "import aiohttp",
+        "import urllib",
+        "from urllib",
+        "os.system",
+        "os.popen",
+        "shell=True",
+        "git ",
+        "gh ",
+        "codex ",
+    )
+    for token in forbidden:
+        assert token not in src, token
+
+
+def test_source_does_not_write_active_or_mutating_paths() -> None:
+    src = Path(hyp.__file__).read_text(encoding="utf-8")
+    forbidden = (
+        "seed.jsonl",
+        "generated_seed.jsonl",
+        "logs/development_work_queue/latest.json",
+        "research/research_action_queue_latest.v1.json",
+        "agent/backtesting/strategies.py",
+        "registry.py",
+        "paper/",
+        "shadow/",
+        "live/",
+    )
+    for token in forbidden:
+        assert token not in src, token

--- a/tests/unit/test_qre_hypothesis_validation_plan.py
+++ b/tests/unit/test_qre_hypothesis_validation_plan.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from reporting import qre_hypothesis_validation_plan as plan
+
+
+FROZEN = "2026-06-01T12:00:00Z"
+
+
+def _hypothesis(**overrides) -> dict:
+    base = {
+        "hypothesis_id": "qre-hyp-fixture-001",
+        "source_observation_id": "qre-obs-fixture-001",
+        "title": "Sample and liquidity sufficiency",
+        "claim": "The observation may be underpowered because trade count is too low.",
+        "asset_scope": ["BTC-USD"],
+        "timeframe_scope": ["4h"],
+        "regime_tags": ["trend"],
+        "expected_edge": "A better-sampled validation can separate weak evidence.",
+        "falsification_criteria": "Expanded validation remains unstable.",
+        "validation_plan_required": True,
+        "supporting_evidence_refs": ["fixture#1"],
+        "contradicting_evidence_refs": [],
+        "status": "proposed",
+        "safe_to_execute": False,
+    }
+    base.update(overrides)
+    return base
+
+
+def _write_hypotheses(path: Path, hypotheses: list[dict], **overrides) -> Path:
+    payload = {
+        "schema_version": 1,
+        "report_kind": "qre_hypothesis_candidates",
+        "generated_at_utc": FROZEN,
+        "hypotheses": hypotheses,
+        "safe_to_execute": False,
+    }
+    payload.update(overrides)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return path
+
+
+def test_missing_input_fails_closed(tmp_path: Path) -> None:
+    snap = plan.collect_snapshot(
+        input_artifact_path=tmp_path / "missing.json",
+        generated_at_utc=FROZEN,
+    )
+
+    assert snap["input_artifact_available"] is False
+    assert snap["validation_plans"] == []
+    assert snap["safe_to_execute"] is False
+    assert snap["launches_codex"] is False
+    assert plan.NOTE_INPUT_ABSENT in snap["validation_warnings"]
+
+
+def test_malformed_input_fails_closed(tmp_path: Path) -> None:
+    source = _write_hypotheses(tmp_path / "hyp.json", [], report_kind="wrong")
+
+    snap = plan.collect_snapshot(input_artifact_path=source, generated_at_utc=FROZEN)
+
+    assert snap["input_artifact_available"] is True
+    assert snap["validation_plans"] == []
+    assert plan.NOTE_INPUT_UNPARSEABLE in snap["validation_warnings"]
+
+
+def test_deterministic_output_with_injected_timestamp(tmp_path: Path) -> None:
+    source = _write_hypotheses(tmp_path / "hyp.json", [_hypothesis()])
+
+    snap_a = plan.collect_snapshot(input_artifact_path=source, generated_at_utc=FROZEN)
+    snap_b = plan.collect_snapshot(input_artifact_path=source, generated_at_utc=FROZEN)
+
+    assert json.dumps(snap_a, sort_keys=True) == json.dumps(snap_b, sort_keys=True)
+    row = snap_a["validation_plans"][0]
+    assert row["validation_plan_id"].startswith("qre-plan-")
+    assert row["hypothesis_id"] == "qre-hyp-fixture-001"
+    assert row["minimum_trade_count"] == 60
+    assert row["status"] == "planned"
+    assert row["safe_to_execute"] is False
+
+
+def test_validation_plan_does_not_run_experiments(tmp_path: Path) -> None:
+    source = _write_hypotheses(tmp_path / "hyp.json", [_hypothesis()])
+
+    snap = plan.collect_snapshot(input_artifact_path=source, generated_at_utc=FROZEN)
+
+    row = snap["validation_plans"][0]
+    assert all(item.endswith("_plan") for item in row["required_experiments"])
+    assert snap["eligible_for_direct_execution"] is False
+
+
+def test_atomic_write_refuses_outside_artifact_dir(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        plan._atomic_write_json(tmp_path / "latest.json", {"x": 1})
+
+
+def test_cli_no_write_outputs_json_without_writing(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    source = _write_hypotheses(tmp_path / "hyp.json", [_hypothesis()])
+    artifact_dir = tmp_path / "logs" / "qre_hypothesis_validation_plans"
+    latest = artifact_dir / "latest.json"
+    monkeypatch.setattr(plan, "ARTIFACT_DIR", artifact_dir)
+    monkeypatch.setattr(plan, "ARTIFACT_LATEST", latest)
+
+    rc = plan.main(
+        ["--no-write", "--source", str(source), "--frozen-utc", FROZEN, "--indent", "0"]
+    )
+
+    assert rc == 0
+    assert latest.exists() is False
+    parsed = json.loads(capsys.readouterr().out)
+    assert parsed["validation_plans"][0]["status"] == "planned"
+
+
+def test_source_has_no_runtime_launch_or_network_calls() -> None:
+    src = Path(plan.__file__).read_text(encoding="utf-8")
+    forbidden = (
+        "import subprocess",
+        "from subprocess",
+        "subprocess.",
+        "import socket",
+        "from socket",
+        "import requests",
+        "import httpx",
+        "import aiohttp",
+        "import urllib",
+        "from urllib",
+        "os.system",
+        "os.popen",
+        "shell=True",
+        "git ",
+        "gh ",
+        "codex ",
+    )
+    for token in forbidden:
+        assert token not in src, token
+
+
+def test_source_does_not_write_active_or_mutating_paths() -> None:
+    src = Path(plan.__file__).read_text(encoding="utf-8")
+    forbidden = (
+        "seed.jsonl",
+        "generated_seed.jsonl",
+        "logs/development_work_queue/latest.json",
+        "research/research_action_queue_latest.v1.json",
+        "agent/backtesting/strategies.py",
+        "registry.py",
+        "paper/",
+        "shadow/",
+        "live/",
+    )
+    for token in forbidden:
+        assert token not in src, token

--- a/tests/unit/test_qre_market_observation_snapshot.py
+++ b/tests/unit/test_qre_market_observation_snapshot.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from reporting import qre_market_observation_snapshot as market
+
+
+FROZEN = "2026-06-01T12:00:00Z"
+
+
+def _write_source(path: Path, observations: list[dict]) -> Path:
+    path.write_text(
+        json.dumps({"observations": observations}, indent=2),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _observation(**overrides) -> dict:
+    base = {
+        "observation_type": "low_trade_count",
+        "asset_scope": ["BTC-USD"],
+        "timeframe_scope": ["4h"],
+        "regime_tags": ["trend"],
+        "metric_refs": ["total_trades:19"],
+        "summary": "Trend pullback has limited sample support on BTC-USD 4h.",
+        "confidence": 0.8,
+        "supporting_evidence_refs": ["fixture#btc-4h"],
+        "contradicting_evidence_refs": [],
+    }
+    base.update(overrides)
+    return base
+
+
+def test_missing_input_fails_closed(tmp_path: Path) -> None:
+    snap = market.collect_snapshot(
+        source_path=tmp_path / "missing.json",
+        generated_at_utc=FROZEN,
+    )
+
+    assert snap["input_artifact_available"] is False
+    assert snap["observations"] == []
+    assert snap["safe_to_execute"] is False
+    assert snap["launches_codex"] is False
+    assert snap["eligible_for_direct_execution"] is False
+    assert market.NOTE_INPUT_ABSENT in snap["validation_warnings"]
+
+
+def test_malformed_input_fails_closed(tmp_path: Path) -> None:
+    source = tmp_path / "bad.json"
+    source.write_text("{", encoding="utf-8")
+
+    snap = market.collect_snapshot(source_path=source, generated_at_utc=FROZEN)
+
+    assert snap["input_artifact_available"] is True
+    assert snap["observations"] == []
+    assert market.NOTE_INPUT_UNPARSEABLE in snap["validation_warnings"]
+    assert snap["safe_to_execute"] is False
+
+
+def test_deterministic_output_with_injected_timestamp(tmp_path: Path) -> None:
+    source = _write_source(tmp_path / "source.json", [_observation()])
+
+    snap_a = market.collect_snapshot(source_path=source, generated_at_utc=FROZEN)
+    snap_b = market.collect_snapshot(source_path=source, generated_at_utc=FROZEN)
+
+    assert json.dumps(snap_a, sort_keys=True) == json.dumps(snap_b, sort_keys=True)
+    observation = snap_a["observations"][0]
+    assert observation["observation_id"].startswith("qre-obs-")
+    assert observation["observation_type"] == "low_trade_count"
+    assert observation["safe_to_execute"] is False
+
+
+def test_research_latest_input_projects_observations(tmp_path: Path) -> None:
+    source = tmp_path / "research_latest.json"
+    source.write_text(
+        json.dumps(
+            {
+                "results": [
+                    {
+                        "success": True,
+                        "strategy_name": "trend_pullback_tp_sl",
+                        "family": "trend",
+                        "asset": "BTC-USD",
+                        "interval": "4h",
+                        "win_rate": 0.3,
+                        "sharpe": -0.5,
+                        "deflated_sharpe": -0.4,
+                        "trades_per_maand": 0.5,
+                        "totaal_trades": 19,
+                        "consistentie": 0.0,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    snap = market.collect_snapshot(source_path=source, generated_at_utc=FROZEN)
+
+    types = {row["observation_type"] for row in snap["observations"]}
+    assert {
+        "exit_failure_pattern",
+        "low_trade_count",
+        "high_window_end_impact",
+    } <= types
+
+
+def test_atomic_write_refuses_outside_artifact_dir(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        market._atomic_write_json(tmp_path / "latest.json", {"x": 1})
+
+
+def test_cli_no_write_outputs_json_without_writing(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    source = _write_source(tmp_path / "source.json", [_observation()])
+    artifact_dir = tmp_path / "logs" / "qre_market_observations"
+    latest = artifact_dir / "latest.json"
+    monkeypatch.setattr(market, "ARTIFACT_DIR", artifact_dir)
+    monkeypatch.setattr(market, "ARTIFACT_LATEST", latest)
+
+    rc = market.main(
+        ["--no-write", "--source", str(source), "--frozen-utc", FROZEN, "--indent", "0"]
+    )
+
+    assert rc == 0
+    assert latest.exists() is False
+    parsed = json.loads(capsys.readouterr().out)
+    assert parsed["report_kind"] == market.REPORT_KIND
+
+
+def test_source_has_no_runtime_launch_or_network_calls() -> None:
+    src = Path(market.__file__).read_text(encoding="utf-8")
+    forbidden = (
+        "import subprocess",
+        "from subprocess",
+        "subprocess.",
+        "import socket",
+        "from socket",
+        "import requests",
+        "import httpx",
+        "import aiohttp",
+        "import urllib",
+        "from urllib",
+        "os.system",
+        "os.popen",
+        "shell=True",
+        "git ",
+        "gh ",
+        "codex ",
+    )
+    for token in forbidden:
+        assert token not in src, token
+
+
+def test_source_does_not_write_active_or_mutating_paths() -> None:
+    src = Path(market.__file__).read_text(encoding="utf-8")
+    forbidden = (
+        "seed.jsonl",
+        "generated_seed.jsonl",
+        "logs/development_work_queue/latest.json",
+        "research/research_action_queue_latest.v1.json",
+        "agent/backtesting/strategies.py",
+        "registry.py",
+        "paper/",
+        "shadow/",
+        "live/",
+    )
+    for token in forbidden:
+        assert token not in src, token

--- a/tests/unit/test_qre_observation_hypothesis_projector.py
+++ b/tests/unit/test_qre_observation_hypothesis_projector.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from reporting import qre_observation_hypothesis_projector as proj
+
+
+FROZEN = "2026-06-01T12:00:00Z"
+
+
+def _observation(**overrides) -> dict:
+    base = {
+        "observation_id": "qre-obs-fixture-002",
+        "source_artifact": "fixture.json",
+        "observation_type": "paper_divergence",
+        "asset_scope": ["ETH-USD"],
+        "timeframe_scope": ["4h"],
+        "regime_tags": ["trend"],
+        "metric_refs": ["paper_delta:material"],
+        "summary": "Research and paper semantics appear divergent.",
+        "confidence": 0.9,
+        "supporting_evidence_refs": ["fixture#2"],
+        "contradicting_evidence_refs": [],
+        "safe_to_execute": False,
+    }
+    base.update(overrides)
+    return base
+
+
+def _write_observations(path: Path, observations: list[dict], **overrides) -> Path:
+    payload = {
+        "schema_version": 1,
+        "report_kind": "qre_market_observation_snapshot",
+        "generated_at_utc": FROZEN,
+        "observations": observations,
+        "safe_to_execute": False,
+    }
+    payload.update(overrides)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return path
+
+
+def test_missing_input_fails_closed(tmp_path: Path) -> None:
+    snap = proj.collect_snapshot(
+        input_artifact_path=tmp_path / "missing.json",
+        generated_at_utc=FROZEN,
+    )
+
+    assert snap["input_artifact_available"] is False
+    assert snap["projection_rows"] == []
+    assert snap["safe_to_execute"] is False
+    assert snap["eligible_for_direct_execution"] is False
+    assert proj.NOTE_INPUT_ABSENT in snap["validation_warnings"]
+
+
+def test_malformed_input_fails_closed(tmp_path: Path) -> None:
+    source = _write_observations(tmp_path / "obs.json", [], report_kind="wrong")
+
+    snap = proj.collect_snapshot(input_artifact_path=source, generated_at_utc=FROZEN)
+
+    assert snap["input_artifact_available"] is True
+    assert snap["projection_rows"] == []
+    assert proj.NOTE_INPUT_UNPARSEABLE in snap["validation_warnings"]
+
+
+def test_deterministic_output_with_injected_timestamp(tmp_path: Path) -> None:
+    source = _write_observations(tmp_path / "obs.json", [_observation()])
+
+    snap_a = proj.collect_snapshot(input_artifact_path=source, generated_at_utc=FROZEN)
+    snap_b = proj.collect_snapshot(input_artifact_path=source, generated_at_utc=FROZEN)
+
+    assert json.dumps(snap_a, sort_keys=True) == json.dumps(snap_b, sort_keys=True)
+    row = snap_a["projection_rows"][0]
+    assert row["projection_rule"] == "engine_parity_hypothesis"
+    assert row["proposed_hypothesis_id"].startswith("qre-hyp-")
+    assert row["status"] == "proposed"
+    assert row["safe_to_execute"] is False
+
+
+def test_rule_mapping_covers_required_observation_types(tmp_path: Path) -> None:
+    observations = [
+        _observation(observation_id=f"obs-{kind}", observation_type=kind)
+        for kind in [
+            "exit_failure_pattern",
+            "low_trade_count",
+            "high_window_end_impact",
+            "source_quality_issue",
+            "paper_divergence",
+        ]
+    ]
+    source = _write_observations(tmp_path / "obs.json", observations)
+
+    snap = proj.collect_snapshot(input_artifact_path=source, generated_at_utc=FROZEN)
+
+    rules = {row["projection_rule"] for row in snap["projection_rows"]}
+    assert {
+        "exit_invalidation_hypothesis",
+        "sample_liquidity_hypothesis",
+        "fold_window_boundary_hypothesis",
+        "data_quality_hypothesis",
+        "engine_parity_hypothesis",
+    } == rules
+
+
+def test_atomic_write_refuses_outside_artifact_dir(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        proj._atomic_write_json(tmp_path / "latest.json", {"x": 1})
+
+
+def test_cli_no_write_outputs_json_without_writing(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    source = _write_observations(tmp_path / "obs.json", [_observation()])
+    artifact_dir = tmp_path / "logs" / "qre_observation_hypothesis_projection"
+    latest = artifact_dir / "latest.json"
+    monkeypatch.setattr(proj, "ARTIFACT_DIR", artifact_dir)
+    monkeypatch.setattr(proj, "ARTIFACT_LATEST", latest)
+
+    rc = proj.main(
+        ["--no-write", "--source", str(source), "--frozen-utc", FROZEN, "--indent", "0"]
+    )
+
+    assert rc == 0
+    assert latest.exists() is False
+    parsed = json.loads(capsys.readouterr().out)
+    assert parsed["projection_rows"][0]["safe_to_execute"] is False
+
+
+def test_source_has_no_runtime_launch_or_network_calls() -> None:
+    src = Path(proj.__file__).read_text(encoding="utf-8")
+    forbidden = (
+        "import subprocess",
+        "from subprocess",
+        "subprocess.",
+        "import socket",
+        "from socket",
+        "import requests",
+        "import httpx",
+        "import aiohttp",
+        "import urllib",
+        "from urllib",
+        "os.system",
+        "os.popen",
+        "shell=True",
+        "git ",
+        "gh ",
+        "codex ",
+    )
+    for token in forbidden:
+        assert token not in src, token
+
+
+def test_source_does_not_write_active_or_mutating_paths() -> None:
+    src = Path(proj.__file__).read_text(encoding="utf-8")
+    forbidden = (
+        "seed.jsonl",
+        "generated_seed.jsonl",
+        "logs/development_work_queue/latest.json",
+        "research/research_action_queue_latest.v1.json",
+        "agent/backtesting/strategies.py",
+        "registry.py",
+        "paper/",
+        "shadow/",
+        "live/",
+    )
+    for token in forbidden:
+        assert token not in src, token

--- a/tests/unit/test_qre_validation_research_action_candidates.py
+++ b/tests/unit/test_qre_validation_research_action_candidates.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from reporting import qre_hypothesis_candidates as hyp
+from reporting import qre_hypothesis_validation_plan as plan
+from reporting import qre_market_observation_snapshot as market
+from reporting import qre_observation_hypothesis_projector as proj
+from reporting import qre_validation_research_action_candidates as action
+
+
+FROZEN = "2026-06-01T12:00:00Z"
+
+
+def _plan(**overrides) -> dict:
+    base = {
+        "validation_plan_id": "qre-plan-fixture-001",
+        "hypothesis_id": "qre-hyp-fixture-001",
+        "required_experiments": ["sample_size_sufficiency_check_plan"],
+        "asset_scope": ["BTC-USD"],
+        "timeframe_scope": ["1h"],
+        "minimum_trade_count": 100,
+        "primary_metrics": ["deflated_sharpe", "trade_count"],
+        "falsification_criteria": "Insufficient sample after expansion.",
+        "status": "planned",
+        "safe_to_execute": False,
+    }
+    base.update(overrides)
+    return base
+
+
+def _write_plans(path: Path, plans: list[dict], **overrides) -> Path:
+    payload = {
+        "schema_version": 1,
+        "report_kind": "qre_hypothesis_validation_plan",
+        "generated_at_utc": FROZEN,
+        "validation_plans": plans,
+        "safe_to_execute": False,
+    }
+    payload.update(overrides)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return path
+
+
+def _assert_safety_flags_false(snapshot: dict) -> None:
+    for key in (
+        "safe_to_execute",
+        "writes_development_work_queue",
+        "writes_seed_jsonl",
+        "writes_generated_seed_jsonl",
+        "mutates_campaign_queue",
+        "mutates_strategy_or_preset",
+        "mutates_paper_shadow_live_runtime",
+        "launches_codex",
+        "eligible_for_direct_execution",
+    ):
+        assert snapshot[key] is False
+
+
+def test_missing_input_fails_closed(tmp_path: Path) -> None:
+    snap = action.collect_snapshot(
+        input_artifact_path=tmp_path / "missing.json",
+        generated_at_utc=FROZEN,
+    )
+
+    assert snap["input_artifact_available"] is False
+    assert snap["action_candidates"] == []
+    assert snap["safe_to_execute"] is False
+    assert snap["writes_research_action_queue"] is False
+    assert action.NOTE_INPUT_ABSENT in snap["validation_warnings"]
+
+
+def test_malformed_input_fails_closed(tmp_path: Path) -> None:
+    source = _write_plans(tmp_path / "plans.json", [], report_kind="wrong")
+
+    snap = action.collect_snapshot(input_artifact_path=source, generated_at_utc=FROZEN)
+
+    assert snap["input_artifact_available"] is True
+    assert snap["action_candidates"] == []
+    assert action.NOTE_INPUT_UNPARSEABLE in snap["validation_warnings"]
+
+
+def test_deterministic_output_with_injected_timestamp(tmp_path: Path) -> None:
+    source = _write_plans(tmp_path / "plans.json", [_plan()])
+
+    snap_a = action.collect_snapshot(input_artifact_path=source, generated_at_utc=FROZEN)
+    snap_b = action.collect_snapshot(input_artifact_path=source, generated_at_utc=FROZEN)
+
+    assert json.dumps(snap_a, sort_keys=True) == json.dumps(snap_b, sort_keys=True)
+    row = snap_a["action_candidates"][0]
+    assert row["action_id"].startswith("qre-action-")
+    assert row["target_hypothesis_id"] == "qre-hyp-fixture-001"
+    assert row["target_validation_plan_id"] == "qre-plan-fixture-001"
+    assert row["status"] == "pending"
+    assert row["outcome_status"] == "not_recorded"
+    assert row["operator_approval_required"] is True
+    assert row["safe_to_execute"] is False
+    assert row["eligible_for_direct_execution"] is False
+    assert set(action.FORBIDDEN_ACTIONS) <= set(row["forbidden_actions"])
+
+
+def test_atomic_write_refuses_outside_artifact_dir(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        action._atomic_write_json(tmp_path / "latest.json", {"x": 1})
+
+
+def test_cli_no_write_outputs_json_without_writing(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    source = _write_plans(tmp_path / "plans.json", [_plan()])
+    artifact_dir = tmp_path / "logs" / "qre_validation_research_action_candidates"
+    latest = artifact_dir / "latest.json"
+    monkeypatch.setattr(action, "ARTIFACT_DIR", artifact_dir)
+    monkeypatch.setattr(action, "ARTIFACT_LATEST", latest)
+
+    rc = action.main(
+        ["--no-write", "--source", str(source), "--frozen-utc", FROZEN, "--indent", "0"]
+    )
+
+    assert rc == 0
+    assert latest.exists() is False
+    parsed = json.loads(capsys.readouterr().out)
+    assert parsed["action_candidates"][0]["operator_approval_required"] is True
+
+
+def test_source_has_no_runtime_launch_or_network_calls() -> None:
+    src = Path(action.__file__).read_text(encoding="utf-8")
+    forbidden = (
+        "import subprocess",
+        "from subprocess",
+        "subprocess.",
+        "import socket",
+        "from socket",
+        "import requests",
+        "import httpx",
+        "import aiohttp",
+        "import urllib",
+        "from urllib",
+        "os.system",
+        "os.popen",
+        "shell=True",
+        "git ",
+        "gh ",
+        "codex ",
+    )
+    for token in forbidden:
+        assert token not in src, token
+
+
+def test_source_does_not_write_active_or_mutating_paths() -> None:
+    src = Path(action.__file__).read_text(encoding="utf-8")
+    forbidden = (
+        "seed.jsonl",
+        "generated_seed.jsonl",
+        "logs/development_work_queue/latest.json",
+        "research/research_action_queue_latest.v1.json",
+        "agent/backtesting/strategies.py",
+        "registry.py",
+        "paper/",
+        "shadow/",
+        "live/",
+    )
+    for token in forbidden:
+        assert token not in src, token
+
+
+def test_integration_synthetic_observation_to_action_candidate(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    logs_dir = tmp_path / "logs"
+    market_dir = logs_dir / "qre_market_observations"
+    hyp_dir = logs_dir / "qre_hypothesis_candidates"
+    proj_dir = logs_dir / "qre_observation_hypothesis_projection"
+    plan_dir = logs_dir / "qre_hypothesis_validation_plans"
+    action_dir = logs_dir / "qre_validation_research_action_candidates"
+    monkeypatch.setattr(market, "ARTIFACT_DIR", market_dir)
+    monkeypatch.setattr(market, "ARTIFACT_LATEST", market_dir / "latest.json")
+    monkeypatch.setattr(hyp, "ARTIFACT_DIR", hyp_dir)
+    monkeypatch.setattr(hyp, "ARTIFACT_LATEST", hyp_dir / "latest.json")
+    monkeypatch.setattr(proj, "ARTIFACT_DIR", proj_dir)
+    monkeypatch.setattr(proj, "ARTIFACT_LATEST", proj_dir / "latest.json")
+    monkeypatch.setattr(plan, "ARTIFACT_DIR", plan_dir)
+    monkeypatch.setattr(plan, "ARTIFACT_LATEST", plan_dir / "latest.json")
+    monkeypatch.setattr(action, "ARTIFACT_DIR", action_dir)
+    monkeypatch.setattr(action, "ARTIFACT_LATEST", action_dir / "latest.json")
+
+    source = tmp_path / "synthetic_market_source.json"
+    source.write_text(
+        json.dumps(
+            {
+                "observations": [
+                    {
+                        "observation_type": "low_trade_count",
+                        "asset_scope": ["BTC-USD"],
+                        "timeframe_scope": ["4h"],
+                        "regime_tags": ["trend"],
+                        "metric_refs": ["total_trades:19"],
+                        "summary": "The fold has too few trades for durable validation.",
+                        "confidence": 0.8,
+                        "supporting_evidence_refs": ["fixture#low-count"],
+                        "contradicting_evidence_refs": [],
+                    }
+                ]
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    market_snap = market.collect_snapshot(source_path=source, generated_at_utc=FROZEN)
+    market.write_outputs(market_snap)
+    hyp_snap = hyp.collect_snapshot(
+        input_artifact_path=market.ARTIFACT_LATEST,
+        generated_at_utc=FROZEN,
+    )
+    hyp.write_outputs(hyp_snap)
+    proj_snap = proj.collect_snapshot(
+        input_artifact_path=market.ARTIFACT_LATEST,
+        generated_at_utc=FROZEN,
+    )
+    proj.write_outputs(proj_snap)
+    plan_snap = plan.collect_snapshot(
+        input_artifact_path=hyp.ARTIFACT_LATEST,
+        generated_at_utc=FROZEN,
+    )
+    plan.write_outputs(plan_snap)
+    action_snap = action.collect_snapshot(
+        input_artifact_path=plan.ARTIFACT_LATEST,
+        generated_at_utc=FROZEN,
+    )
+    action.write_outputs(action_snap)
+
+    for snap in [market_snap, hyp_snap, proj_snap, plan_snap, action_snap]:
+        _assert_safety_flags_false(snap)
+
+    observation = market_snap["observations"][0]
+    hypothesis = hyp_snap["hypotheses"][0]
+    projection = proj_snap["projection_rows"][0]
+    validation_plan = plan_snap["validation_plans"][0]
+    candidate = action_snap["action_candidates"][0]
+
+    assert hypothesis["source_observation_id"] == observation["observation_id"]
+    assert projection["observation_id"] == observation["observation_id"]
+    assert projection["proposed_hypothesis_id"] == hypothesis["hypothesis_id"]
+    assert validation_plan["hypothesis_id"] == hypothesis["hypothesis_id"]
+    assert candidate["target_hypothesis_id"] == hypothesis["hypothesis_id"]
+    assert candidate["target_validation_plan_id"] == validation_plan["validation_plan_id"]
+    assert candidate["operator_approval_required"] is True
+    assert candidate["eligible_for_direct_execution"] is False
+
+    allowed_dirs = {
+        "qre_market_observations",
+        "qre_hypothesis_candidates",
+        "qre_observation_hypothesis_projection",
+        "qre_hypothesis_validation_plans",
+        "qre_validation_research_action_candidates",
+    }
+    written = [path for path in logs_dir.rglob("*") if path.is_file()]
+    assert {path.parent.name for path in written} <= allowed_dirs
+    assert {path.name for path in written} == {"latest.json"}


### PR DESCRIPTION
Adds the read-only planning half of the QRE closed-loop research scaffold.

Summary:
- Adds reporting/qre_market_observation_snapshot.py
- Adds reporting/qre_hypothesis_candidates.py
- Adds reporting/qre_observation_hypothesis_projector.py
- Adds reporting/qre_hypothesis_validation_plan.py
- Adds reporting/qre_validation_research_action_candidates.py
- Adds unit tests for all five modules
- Converts market/research observations into hypothesis candidates, validation plans, and staged research action candidates
- Keeps all outputs non-executing and read-only
- Does not write logs artifacts into git
- Does not mutate development work queue, seed files, generated seed files, research action queue, campaigns, strategies, presets, paper/shadow/live runtime, broker/risk/execution, or Codex automation

Validation:
- python -m pytest tests/unit/test_qre_market_observation_snapshot.py tests/unit/test_qre_hypothesis_candidates.py tests/unit/test_qre_observation_hypothesis_projector.py tests/unit/test_qre_hypothesis_validation_plan.py tests/unit/test_qre_validation_research_action_candidates.py -q
  - 39 passed
- python -m pytest tests/unit/test_qre_research_action_consumer_gate.py tests/unit/test_qre_development_intake_promotion.py tests/unit/test_qre_development_queue_admission_policy.py -q
  - 53 passed
- import smoke for all five new reporting modules
- .gitignore restored; generated logs are not included