### PR TITLE
feat: add QRE closed-loop evidence report readiness scaffold

### DIFF
--- a/reporting/qre_closed_loop_operator_report.py
+++ b/reporting/qre_closed_loop_operator_report.py
@@ -1,0 +1,405 @@
+"""Read-only QRE closed-loop operator report."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Final
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[int] = 1
+REPORT_KIND: Final[str] = "qre_closed_loop_operator_report"
+
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "qre_closed_loop_operator_report"
+OUTPUT_ARTIFACT_RELATIVE_PATH: Final[str] = (
+    "logs/qre_closed_loop_operator_report/latest.json"
+)
+ARTIFACT_LATEST: Final[Path] = REPO_ROOT / OUTPUT_ARTIFACT_RELATIVE_PATH
+
+DEFAULT_OBSERVATIONS_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_market_observations" / "latest.json"
+)
+DEFAULT_HYPOTHESES_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_hypothesis_candidates" / "latest.json"
+)
+DEFAULT_PLANS_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_hypothesis_validation_plans" / "latest.json"
+)
+DEFAULT_ACTIONS_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_validation_research_action_candidates" / "latest.json"
+)
+DEFAULT_RUN_MANIFESTS_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_research_run_manifest" / "latest.json"
+)
+DEFAULT_RESULTS_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_hypothesis_validation_results" / "latest.json"
+)
+DEFAULT_EVIDENCE_UPDATES_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_hypothesis_evidence_updates" / "latest.json"
+)
+
+NOTE_INPUT_ISSUES: Final[str] = "closed_loop_inputs_missing_or_unparseable"
+NOTE_REPORT_READY: Final[str] = "closed_loop_operator_report_ready"
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _rel(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(REPO_ROOT.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _read_json(path: Path) -> tuple[bool, dict[str, Any] | None]:
+    try:
+        raw = path.read_text(encoding="utf-8-sig")
+    except OSError:
+        return (False, None)
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return (True, None)
+    return (True, parsed if isinstance(parsed, dict) else None)
+
+
+def _bounded_str(value: Any, *, max_len: int = 240) -> str:
+    text = str(value or "").strip()
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 3].rstrip() + "..."
+
+
+def _safe_rows(payload: dict[str, Any] | None, field: str) -> list[dict[str, Any]]:
+    if payload is None:
+        return []
+    rows = payload.get(field)
+    if not isinstance(rows, list) or not all(isinstance(item, dict) for item in rows):
+        return []
+    return rows
+
+
+def _load(
+    path: Path,
+    *,
+    expected_kind: str,
+    field: str,
+    label: str,
+) -> tuple[list[dict[str, Any]], list[str], dict[str, Any]]:
+    available, payload = _read_json(path)
+    meta = {"path": _rel(path), "available": available, "valid": False}
+    if payload is None or payload.get("report_kind") != expected_kind:
+        return ([], [f"{label}:missing_or_unparseable"], meta)
+    raw_rows = payload.get(field)
+    if (
+        field not in payload
+        or not isinstance(raw_rows, list)
+        or not all(isinstance(item, dict) for item in raw_rows)
+    ):
+        return ([], [f"{label}:missing_field"], meta)
+    rows = _safe_rows(payload, field)
+    meta["valid"] = True
+    return (rows, [], meta)
+
+
+def _blocked_links(
+    hypotheses: list[dict[str, Any]],
+    plans: list[dict[str, Any]],
+    actions: list[dict[str, Any]],
+    run_manifests: list[dict[str, Any]],
+    results: list[dict[str, Any]],
+    evidence_updates: list[dict[str, Any]],
+) -> list[str]:
+    blockers: list[str] = []
+    hypothesis_ids = {_bounded_str(item.get("hypothesis_id"), max_len=160) for item in hypotheses}
+    plan_hypothesis_ids = {
+        _bounded_str(item.get("hypothesis_id"), max_len=160) for item in plans
+    }
+    action_plan_ids = {
+        _bounded_str(item.get("target_validation_plan_id"), max_len=160) for item in actions
+    }
+    plan_ids = {_bounded_str(item.get("validation_plan_id"), max_len=160) for item in plans}
+    manifest_action_ids = {
+        _bounded_str(item.get("source_action_id"), max_len=160) for item in run_manifests
+    }
+    action_ids = {_bounded_str(item.get("action_id"), max_len=160) for item in actions}
+    result_hypothesis_ids = {
+        _bounded_str(item.get("hypothesis_id"), max_len=160) for item in results
+    }
+    update_hypothesis_ids = {
+        _bounded_str(item.get("hypothesis_id"), max_len=160) for item in evidence_updates
+    }
+    if hypothesis_ids - plan_hypothesis_ids:
+        blockers.append("hypothesis_without_validation_plan")
+    if plan_ids - action_plan_ids:
+        blockers.append("validation_plan_without_action_candidate")
+    if action_ids - manifest_action_ids:
+        blockers.append("action_candidate_without_run_manifest")
+    if hypothesis_ids - result_hypothesis_ids:
+        blockers.append("hypothesis_without_validation_result")
+    if hypothesis_ids - update_hypothesis_ids:
+        blockers.append("hypothesis_without_evidence_update")
+    return blockers
+
+
+def _operator_decisions_required(
+    run_manifests: list[dict[str, Any]],
+    evidence_updates: list[dict[str, Any]],
+    blocked_links: list[str],
+) -> list[str]:
+    decisions: list[str] = []
+    if run_manifests:
+        decisions.append("approve_or_reject_pending_run_manifests")
+    if any(
+        item.get("evidence_decision") in {"contradiction_detected", "needs_more_data"}
+        for item in evidence_updates
+    ):
+        decisions.append("resolve_evidence_update_decisions")
+    if blocked_links:
+        decisions.append("repair_or_accept_blocked_closed_loop_links")
+    return decisions
+
+
+def _base_snapshot(
+    *,
+    generated_at_utc: str,
+    operator_report: dict[str, Any],
+    input_artifacts: dict[str, dict[str, Any]],
+    validation_warnings: list[str],
+) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": generated_at_utc,
+        "input_artifacts": input_artifacts,
+        "note": NOTE_INPUT_ISSUES if validation_warnings else NOTE_REPORT_READY,
+        "operator_report": operator_report,
+        "validation_warnings": validation_warnings,
+        "final_recommendation": operator_report["final_recommendation"],
+        "safe_to_execute": False,
+        "writes_development_work_queue": False,
+        "writes_seed_jsonl": False,
+        "writes_generated_seed_jsonl": False,
+        "writes_research_action_queue": False,
+        "mutates_campaign_queue": False,
+        "mutates_strategy_or_preset": False,
+        "mutates_paper_shadow_live_runtime": False,
+        "launches_codex": False,
+        "eligible_for_direct_execution": False,
+    }
+
+
+def collect_snapshot(
+    *,
+    observations_path: Path | None = None,
+    hypotheses_path: Path | None = None,
+    validation_plans_path: Path | None = None,
+    action_candidates_path: Path | None = None,
+    run_manifests_path: Path | None = None,
+    validation_results_path: Path | None = None,
+    evidence_updates_path: Path | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    generated = generated_at_utc or _utcnow()
+    paths = {
+        "observations": observations_path or DEFAULT_OBSERVATIONS_PATH,
+        "hypotheses": hypotheses_path or DEFAULT_HYPOTHESES_PATH,
+        "validation_plans": validation_plans_path or DEFAULT_PLANS_PATH,
+        "action_candidates": action_candidates_path or DEFAULT_ACTIONS_PATH,
+        "run_manifests": run_manifests_path or DEFAULT_RUN_MANIFESTS_PATH,
+        "validation_results": validation_results_path or DEFAULT_RESULTS_PATH,
+        "evidence_updates": evidence_updates_path or DEFAULT_EVIDENCE_UPDATES_PATH,
+    }
+    observations, warnings_a, meta_a = _load(
+        paths["observations"],
+        expected_kind="qre_market_observation_snapshot",
+        field="observations",
+        label="observations",
+    )
+    hypotheses, warnings_b, meta_b = _load(
+        paths["hypotheses"],
+        expected_kind="qre_hypothesis_candidates",
+        field="hypotheses",
+        label="hypotheses",
+    )
+    plans, warnings_c, meta_c = _load(
+        paths["validation_plans"],
+        expected_kind="qre_hypothesis_validation_plan",
+        field="validation_plans",
+        label="validation_plans",
+    )
+    actions, warnings_d, meta_d = _load(
+        paths["action_candidates"],
+        expected_kind="qre_validation_research_action_candidates",
+        field="action_candidates",
+        label="action_candidates",
+    )
+    run_manifests, warnings_e, meta_e = _load(
+        paths["run_manifests"],
+        expected_kind="qre_research_run_manifest",
+        field="run_manifests",
+        label="run_manifests",
+    )
+    results, warnings_f, meta_f = _load(
+        paths["validation_results"],
+        expected_kind="qre_hypothesis_validation_results",
+        field="validation_results",
+        label="validation_results",
+    )
+    updates, warnings_g, meta_g = _load(
+        paths["evidence_updates"],
+        expected_kind="qre_hypothesis_evidence_update",
+        field="evidence_updates",
+        label="evidence_updates",
+    )
+    validation_warnings = (
+        warnings_a
+        + warnings_b
+        + warnings_c
+        + warnings_d
+        + warnings_e
+        + warnings_f
+        + warnings_g
+    )
+    blocked_links = _blocked_links(hypotheses, plans, actions, run_manifests, results, updates)
+    decisions = _operator_decisions_required(run_manifests, updates, blocked_links)
+    active_hypotheses = [
+        item
+        for item in hypotheses
+        if _bounded_str(item.get("status"), max_len=80) not in {"rejected", "closed"}
+    ]
+    operator_report = {
+        "active_hypotheses": active_hypotheses,
+        "proposed_hypotheses": hypotheses,
+        "validation_plans": plans,
+        "pending_run_manifests": [
+            item
+            for item in run_manifests
+            if item.get("status") == "operator_review_required"
+        ],
+        "validation_results": results,
+        "evidence_updates": updates,
+        "blocked_or_missing_links": blocked_links + validation_warnings,
+        "operator_decisions_required": decisions,
+        "summary": (
+            f"Closed-loop report: {len(observations)} observations, "
+            f"{len(hypotheses)} hypotheses, {len(results)} validation results."
+        ),
+        "final_recommendation": (
+            "operator_review_required"
+            if decisions or validation_warnings
+            else "closed_loop_evidence_ready_for_readiness_review"
+        ),
+        "safe_to_execute": False,
+    }
+    input_artifacts = {
+        "observations": meta_a,
+        "hypotheses": meta_b,
+        "validation_plans": meta_c,
+        "action_candidates": meta_d,
+        "run_manifests": meta_e,
+        "validation_results": meta_f,
+        "evidence_updates": meta_g,
+    }
+    return _base_snapshot(
+        generated_at_utc=generated,
+        operator_report=operator_report,
+        input_artifacts=input_artifacts,
+        validation_warnings=validation_warnings,
+    )
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    if not path.resolve().is_relative_to(ARTIFACT_DIR.resolve()):
+        raise ValueError(f"refusing write outside QRE operator report dir: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".qre_closed_loop_operator_report.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_outputs(
+    snapshot: dict[str, Any],
+    *,
+    output_path: Path | None = None,
+) -> Path:
+    target = output_path or ARTIFACT_LATEST
+    _atomic_write_json(target, snapshot)
+    return target
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="reporting.qre_closed_loop_operator_report",
+        description="Build a read-only closed-loop operator report.",
+    )
+    parser.add_argument("--no-write", action="store_true")
+    parser.add_argument("--observations-source", type=Path, default=None)
+    parser.add_argument("--hypotheses-source", type=Path, default=None)
+    parser.add_argument("--plans-source", type=Path, default=None)
+    parser.add_argument("--actions-source", type=Path, default=None)
+    parser.add_argument("--run-manifests-source", type=Path, default=None)
+    parser.add_argument("--results-source", type=Path, default=None)
+    parser.add_argument("--evidence-updates-source", type=Path, default=None)
+    parser.add_argument("--frozen-utc", default=None)
+    parser.add_argument("--indent", type=int, default=2)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    snapshot = collect_snapshot(
+        observations_path=args.observations_source,
+        hypotheses_path=args.hypotheses_source,
+        validation_plans_path=args.plans_source,
+        action_candidates_path=args.actions_source,
+        run_manifests_path=args.run_manifests_source,
+        validation_results_path=args.results_source,
+        evidence_updates_path=args.evidence_updates_source,
+        generated_at_utc=args.frozen_utc,
+    )
+    if not args.no_write:
+        write_outputs(snapshot)
+    print(json.dumps(snapshot, indent=args.indent, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "ARTIFACT_DIR",
+    "ARTIFACT_LATEST",
+    "OUTPUT_ARTIFACT_RELATIVE_PATH",
+    "REPORT_KIND",
+    "SCHEMA_VERSION",
+    "collect_snapshot",
+    "main",
+    "write_outputs",
+]

--- a/reporting/qre_hypothesis_evidence_update.py
+++ b/reporting/qre_hypothesis_evidence_update.py
@@ -1,0 +1,398 @@
+"""Read-only QRE hypothesis evidence update projector."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import hashlib
+import json
+import os
+import tempfile
+from collections import Counter
+from pathlib import Path
+from typing import Any, Final
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[int] = 1
+REPORT_KIND: Final[str] = "qre_hypothesis_evidence_update"
+HYPOTHESIS_INPUT_REPORT_KIND: Final[str] = "qre_hypothesis_candidates"
+RESULT_INPUT_REPORT_KIND: Final[str] = "qre_hypothesis_validation_results"
+
+HYPOTHESIS_INPUT_ARTIFACT_RELATIVE_PATH: Final[str] = (
+    "logs/qre_hypothesis_candidates/latest.json"
+)
+RESULT_INPUT_ARTIFACT_RELATIVE_PATH: Final[str] = (
+    "logs/qre_hypothesis_validation_results/latest.json"
+)
+HYPOTHESIS_INPUT_ARTIFACT_PATH: Final[Path] = (
+    REPO_ROOT / HYPOTHESIS_INPUT_ARTIFACT_RELATIVE_PATH
+)
+RESULT_INPUT_ARTIFACT_PATH: Final[Path] = REPO_ROOT / RESULT_INPUT_ARTIFACT_RELATIVE_PATH
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "qre_hypothesis_evidence_updates"
+OUTPUT_ARTIFACT_RELATIVE_PATH: Final[str] = (
+    "logs/qre_hypothesis_evidence_updates/latest.json"
+)
+ARTIFACT_LATEST: Final[Path] = REPO_ROOT / OUTPUT_ARTIFACT_RELATIVE_PATH
+
+DECISIONS: Final[tuple[str, ...]] = (
+    "supported",
+    "weakened",
+    "falsified",
+    "inconclusive",
+    "needs_more_data",
+    "contradiction_detected",
+)
+
+NOTE_INPUT_ABSENT: Final[str] = "evidence_update_input_artifact_absent"
+NOTE_INPUT_UNPARSEABLE: Final[str] = "evidence_update_input_artifact_unparseable"
+NOTE_NO_UPDATES: Final[str] = "no_evidence_updates_projected"
+NOTE_UPDATES_PRESENT: Final[str] = "evidence_updates_present"
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _rel(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(REPO_ROOT.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _read_json(path: Path) -> tuple[bool, dict[str, Any] | None]:
+    try:
+        raw = path.read_text(encoding="utf-8-sig")
+    except OSError:
+        return (False, None)
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return (True, None)
+    return (True, parsed if isinstance(parsed, dict) else None)
+
+
+def _bounded_str(value: Any, *, max_len: int = 240) -> str:
+    text = str(value or "").strip()
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 3].rstrip() + "..."
+
+
+def _str_list(value: Any, *, max_items: int = 24, max_len: int = 180) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    out: list[str] = []
+    for item in value[:max_items]:
+        text = _bounded_str(item, max_len=max_len)
+        if text:
+            out.append(text)
+    return out
+
+
+def _evidence_update_id(hypothesis_id: str, result_id: str, decision: str) -> str:
+    seed = f"{hypothesis_id}|{result_id}|{decision}"
+    return "qre-evidence-" + hashlib.sha256(seed.encode("utf-8")).hexdigest()[:16]
+
+
+def _result_for_hypothesis(
+    hypothesis_id: str,
+    validation_results: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    matches = [
+        item
+        for item in validation_results
+        if _bounded_str(item.get("hypothesis_id"), max_len=160) == hypothesis_id
+    ]
+    if not matches:
+        return None
+    matches.sort(key=lambda item: _bounded_str(item.get("result_id"), max_len=160))
+    return matches[0]
+
+
+def _decision(result: dict[str, Any] | None) -> tuple[str, str, str, list[str]]:
+    if result is None:
+        return (
+            "needs_more_data",
+            "needs_more_data",
+            "No validation result is linked to this hypothesis.",
+            ["operator_review_missing_validation_result"],
+        )
+
+    status = _bounded_str(result.get("status"), max_len=40)
+    falsification_hits = _str_list(result.get("falsification_hits"))
+    supporting_refs = _str_list(result.get("supporting_evidence_refs"))
+    contradicting_refs = _str_list(result.get("contradicting_evidence_refs"))
+
+    if supporting_refs and contradicting_refs:
+        return (
+            "contradiction_detected",
+            "operator_review_required",
+            "Validation evidence contains both support and contradiction references.",
+            ["operator_review_contradiction"],
+        )
+    if status == "failed" or falsification_hits:
+        return (
+            "falsified",
+            "falsified",
+            "Validation failed or triggered falsification criteria.",
+            ["preserve_negative_result"],
+        )
+    if status == "passed":
+        return (
+            "supported",
+            "supported",
+            "Validation passed without recorded falsification hits.",
+            ["consider_repeatability_review"],
+        )
+    if status == "inconclusive":
+        return (
+            "inconclusive",
+            "needs_more_data",
+            "Validation result is inconclusive.",
+            ["collect_additional_evidence"],
+        )
+    return (
+        "needs_more_data",
+        "needs_more_data",
+        "Validation result is missing or incomplete.",
+        ["collect_validation_result"],
+    )
+
+
+def _build_update(
+    hypothesis: dict[str, Any],
+    result: dict[str, Any] | None,
+) -> dict[str, Any]:
+    hypothesis_id = _bounded_str(hypothesis.get("hypothesis_id"), max_len=160)
+    result_id = _bounded_str(result.get("result_id"), max_len=160) if result else ""
+    decision, next_status, reason, next_actions = _decision(result)
+    supporting_refs = _str_list(result.get("supporting_evidence_refs")) if result else []
+    contradicting_refs = (
+        _str_list(result.get("contradicting_evidence_refs")) if result else []
+    )
+    return {
+        "evidence_update_id": _evidence_update_id(
+            hypothesis_id,
+            result_id or "missing",
+            decision,
+        ),
+        "hypothesis_id": hypothesis_id,
+        "previous_status": _bounded_str(hypothesis.get("status"), max_len=80)
+        or "unknown",
+        "evidence_decision": decision,
+        "recommended_next_status": next_status,
+        "supporting_evidence_refs": supporting_refs,
+        "contradicting_evidence_refs": contradicting_refs,
+        "reason": reason,
+        "next_actions": next_actions,
+        "safe_to_execute": False,
+    }
+
+
+def _empty_counts() -> dict[str, Any]:
+    return {"total": 0, "by_decision": {decision: 0 for decision in DECISIONS}}
+
+
+def _counts(evidence_updates: list[dict[str, Any]]) -> dict[str, Any]:
+    counter = Counter(
+        str(item.get("evidence_decision") or "needs_more_data")
+        for item in evidence_updates
+    )
+    out = _empty_counts()
+    out["total"] = len(evidence_updates)
+    for decision in DECISIONS:
+        out["by_decision"][decision] = counter.get(decision, 0)
+    return out
+
+
+def _base_snapshot(
+    *,
+    generated_at_utc: str,
+    hypothesis_input_artifact_path: Path,
+    result_input_artifact_path: Path,
+    hypothesis_input_artifact_available: bool,
+    result_input_artifact_available: bool,
+    note: str,
+    evidence_updates: list[dict[str, Any]],
+    validation_warnings: list[str],
+) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": generated_at_utc,
+        "hypothesis_input_artifact_path": _rel(hypothesis_input_artifact_path),
+        "result_input_artifact_path": _rel(result_input_artifact_path),
+        "hypothesis_input_artifact_available": hypothesis_input_artifact_available,
+        "result_input_artifact_available": result_input_artifact_available,
+        "note": note,
+        "evidence_updates": evidence_updates,
+        "counts": _counts(evidence_updates),
+        "validation_warnings": validation_warnings,
+        "final_recommendation": (
+            "evidence_updates_ready_for_operator_report"
+            if evidence_updates
+            else "no_evidence_updates_available"
+        ),
+        "safe_to_execute": False,
+        "writes_development_work_queue": False,
+        "writes_seed_jsonl": False,
+        "writes_generated_seed_jsonl": False,
+        "writes_research_action_queue": False,
+        "mutates_campaign_queue": False,
+        "mutates_strategy_or_preset": False,
+        "mutates_paper_shadow_live_runtime": False,
+        "launches_codex": False,
+        "eligible_for_direct_execution": False,
+    }
+
+
+def collect_snapshot(
+    *,
+    hypothesis_input_artifact_path: Path | None = None,
+    result_input_artifact_path: Path | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    generated = generated_at_utc or _utcnow()
+    hypothesis_source = hypothesis_input_artifact_path or HYPOTHESIS_INPUT_ARTIFACT_PATH
+    result_source = result_input_artifact_path or RESULT_INPUT_ARTIFACT_PATH
+    hypothesis_available, hypothesis_payload = _read_json(hypothesis_source)
+    result_available, result_payload = _read_json(result_source)
+
+    if hypothesis_payload is None or result_payload is None:
+        return _base_snapshot(
+            generated_at_utc=generated,
+            hypothesis_input_artifact_path=hypothesis_source,
+            result_input_artifact_path=result_source,
+            hypothesis_input_artifact_available=hypothesis_available,
+            result_input_artifact_available=result_available,
+            note=NOTE_INPUT_UNPARSEABLE
+            if hypothesis_available or result_available
+            else NOTE_INPUT_ABSENT,
+            evidence_updates=[],
+            validation_warnings=[NOTE_INPUT_ABSENT]
+            if not hypothesis_available or not result_available
+            else [NOTE_INPUT_UNPARSEABLE],
+        )
+
+    raw_hypotheses = hypothesis_payload.get("hypotheses")
+    raw_results = result_payload.get("validation_results")
+    if (
+        hypothesis_payload.get("report_kind") != HYPOTHESIS_INPUT_REPORT_KIND
+        or result_payload.get("report_kind") != RESULT_INPUT_REPORT_KIND
+        or not isinstance(raw_hypotheses, list)
+        or not isinstance(raw_results, list)
+        or not all(isinstance(item, dict) for item in raw_hypotheses)
+        or not all(isinstance(item, dict) for item in raw_results)
+    ):
+        return _base_snapshot(
+            generated_at_utc=generated,
+            hypothesis_input_artifact_path=hypothesis_source,
+            result_input_artifact_path=result_source,
+            hypothesis_input_artifact_available=True,
+            result_input_artifact_available=True,
+            note=NOTE_INPUT_UNPARSEABLE,
+            evidence_updates=[],
+            validation_warnings=[NOTE_INPUT_UNPARSEABLE],
+        )
+
+    evidence_updates = [
+        _build_update(item, _result_for_hypothesis(_bounded_str(item.get("hypothesis_id"), max_len=160), raw_results))
+        for item in raw_hypotheses
+    ]
+    evidence_updates.sort(key=lambda item: item["evidence_update_id"])
+    return _base_snapshot(
+        generated_at_utc=generated,
+        hypothesis_input_artifact_path=hypothesis_source,
+        result_input_artifact_path=result_source,
+        hypothesis_input_artifact_available=True,
+        result_input_artifact_available=True,
+        note=NOTE_UPDATES_PRESENT if evidence_updates else NOTE_NO_UPDATES,
+        evidence_updates=evidence_updates,
+        validation_warnings=[],
+    )
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    if not path.resolve().is_relative_to(ARTIFACT_DIR.resolve()):
+        raise ValueError(f"refusing write outside QRE evidence update dir: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".qre_hypothesis_evidence_updates.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_outputs(
+    snapshot: dict[str, Any],
+    *,
+    output_path: Path | None = None,
+) -> Path:
+    target = output_path or ARTIFACT_LATEST
+    _atomic_write_json(target, snapshot)
+    return target
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="reporting.qre_hypothesis_evidence_update",
+        description="Project validation results into read-only evidence decisions.",
+    )
+    parser.add_argument("--no-write", action="store_true")
+    parser.add_argument("--hypotheses-source", type=Path, default=None)
+    parser.add_argument("--results-source", type=Path, default=None)
+    parser.add_argument("--frozen-utc", default=None)
+    parser.add_argument("--indent", type=int, default=2)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    snapshot = collect_snapshot(
+        hypothesis_input_artifact_path=args.hypotheses_source,
+        result_input_artifact_path=args.results_source,
+        generated_at_utc=args.frozen_utc,
+    )
+    if not args.no_write:
+        write_outputs(snapshot)
+    print(json.dumps(snapshot, indent=args.indent, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "ARTIFACT_DIR",
+    "ARTIFACT_LATEST",
+    "DECISIONS",
+    "HYPOTHESIS_INPUT_ARTIFACT_PATH",
+    "HYPOTHESIS_INPUT_ARTIFACT_RELATIVE_PATH",
+    "OUTPUT_ARTIFACT_RELATIVE_PATH",
+    "REPORT_KIND",
+    "RESULT_INPUT_ARTIFACT_PATH",
+    "RESULT_INPUT_ARTIFACT_RELATIVE_PATH",
+    "SCHEMA_VERSION",
+    "collect_snapshot",
+    "main",
+    "write_outputs",
+]

--- a/reporting/qre_hypothesis_validation_results.py
+++ b/reporting/qre_hypothesis_validation_results.py
@@ -1,0 +1,310 @@
+"""Read-only QRE hypothesis validation result snapshot normalizer."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import hashlib
+import json
+import os
+import tempfile
+from collections import Counter
+from pathlib import Path
+from typing import Any, Final
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[int] = 1
+REPORT_KIND: Final[str] = "qre_hypothesis_validation_results"
+ACCEPTED_INPUT_REPORT_KINDS: Final[tuple[str, ...]] = (
+    REPORT_KIND,
+    "synthetic_validation_result_fixture",
+    "qre_hypothesis_validation_result_fixture",
+)
+
+INPUT_ARTIFACT_RELATIVE_PATH: Final[str] = "logs/qre_validation_result_fixtures/latest.json"
+INPUT_ARTIFACT_PATH: Final[Path] = REPO_ROOT / INPUT_ARTIFACT_RELATIVE_PATH
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "qre_hypothesis_validation_results"
+OUTPUT_ARTIFACT_RELATIVE_PATH: Final[str] = (
+    "logs/qre_hypothesis_validation_results/latest.json"
+)
+ARTIFACT_LATEST: Final[Path] = REPO_ROOT / OUTPUT_ARTIFACT_RELATIVE_PATH
+
+STATUSES: Final[tuple[str, ...]] = ("passed", "failed", "inconclusive", "missing")
+
+NOTE_INPUT_ABSENT: Final[str] = "validation_result_artifact_absent"
+NOTE_INPUT_UNPARSEABLE: Final[str] = "validation_result_artifact_unparseable"
+NOTE_NO_RESULTS: Final[str] = "no_validation_results_normalized"
+NOTE_RESULTS_PRESENT: Final[str] = "validation_results_present"
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _rel(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(REPO_ROOT.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _read_json(path: Path) -> tuple[bool, dict[str, Any] | None]:
+    try:
+        raw = path.read_text(encoding="utf-8-sig")
+    except OSError:
+        return (False, None)
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return (True, None)
+    return (True, parsed if isinstance(parsed, dict) else None)
+
+
+def _bounded_str(value: Any, *, max_len: int = 240) -> str:
+    text = str(value or "").strip()
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 3].rstrip() + "..."
+
+
+def _str_list(value: Any, *, max_items: int = 24, max_len: int = 180) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    out: list[str] = []
+    for item in value[:max_items]:
+        text = _bounded_str(item, max_len=max_len)
+        if text:
+            out.append(text)
+    return out
+
+
+def _metric_results(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    out: dict[str, Any] = {}
+    for key in sorted(value):
+        name = _bounded_str(key, max_len=80)
+        if not name:
+            continue
+        raw = value[key]
+        if isinstance(raw, (str, int, float, bool)) or raw is None:
+            out[name] = raw
+        else:
+            out[name] = _bounded_str(raw, max_len=160)
+    return out
+
+
+def _status(value: Any) -> str:
+    text = _bounded_str(value, max_len=40).lower()
+    return text if text in STATUSES else "missing"
+
+
+def _result_id(result: dict[str, Any]) -> str:
+    supplied = _bounded_str(result.get("result_id"), max_len=160)
+    if supplied:
+        return supplied
+    seed = "|".join(
+        [
+            _bounded_str(result.get("hypothesis_id"), max_len=160),
+            _bounded_str(result.get("validation_plan_id"), max_len=160),
+            _bounded_str(result.get("run_manifest_id"), max_len=160),
+            _status(result.get("status")),
+        ]
+    )
+    return "qre-result-" + hashlib.sha256(seed.encode("utf-8")).hexdigest()[:16]
+
+
+def _build_result(result: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "result_id": _result_id(result),
+        "hypothesis_id": _bounded_str(result.get("hypothesis_id"), max_len=160),
+        "validation_plan_id": _bounded_str(result.get("validation_plan_id"), max_len=160),
+        "run_manifest_id": _bounded_str(result.get("run_manifest_id"), max_len=160),
+        "status": _status(result.get("status")),
+        "metric_results": _metric_results(result.get("metric_results")),
+        "falsification_hits": _str_list(result.get("falsification_hits")),
+        "supporting_evidence_refs": _str_list(result.get("supporting_evidence_refs")),
+        "contradicting_evidence_refs": _str_list(
+            result.get("contradicting_evidence_refs")
+        ),
+        "safe_to_execute": False,
+    }
+
+
+def _empty_counts() -> dict[str, Any]:
+    return {"total": 0, "by_status": {status: 0 for status in STATUSES}}
+
+
+def _counts(validation_results: list[dict[str, Any]]) -> dict[str, Any]:
+    counter = Counter(str(item.get("status") or "missing") for item in validation_results)
+    out = _empty_counts()
+    out["total"] = len(validation_results)
+    for status in STATUSES:
+        out["by_status"][status] = counter.get(status, 0)
+    return out
+
+
+def _base_snapshot(
+    *,
+    generated_at_utc: str,
+    input_artifact_path: Path,
+    input_artifact_available: bool,
+    note: str,
+    validation_results: list[dict[str, Any]],
+    validation_warnings: list[str],
+) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": generated_at_utc,
+        "input_artifact_path": _rel(input_artifact_path),
+        "input_artifact_available": input_artifact_available,
+        "note": note,
+        "validation_results": validation_results,
+        "counts": _counts(validation_results),
+        "validation_warnings": validation_warnings,
+        "final_recommendation": (
+            "validation_results_ready_for_evidence_update"
+            if validation_results
+            else "no_validation_results_available"
+        ),
+        "safe_to_execute": False,
+        "writes_development_work_queue": False,
+        "writes_seed_jsonl": False,
+        "writes_generated_seed_jsonl": False,
+        "writes_research_action_queue": False,
+        "mutates_campaign_queue": False,
+        "mutates_strategy_or_preset": False,
+        "mutates_paper_shadow_live_runtime": False,
+        "launches_codex": False,
+        "eligible_for_direct_execution": False,
+    }
+
+
+def collect_snapshot(
+    *,
+    input_artifact_path: Path | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    generated = generated_at_utc or _utcnow()
+    source = input_artifact_path or INPUT_ARTIFACT_PATH
+    available, payload = _read_json(source)
+    if payload is None:
+        note = NOTE_INPUT_UNPARSEABLE if available else NOTE_INPUT_ABSENT
+        return _base_snapshot(
+            generated_at_utc=generated,
+            input_artifact_path=source,
+            input_artifact_available=available,
+            note=note,
+            validation_results=[],
+            validation_warnings=[note],
+        )
+
+    input_report_kind = _bounded_str(payload.get("report_kind"), max_len=120)
+    raw_results = payload.get("validation_results")
+    if (
+        (input_report_kind and input_report_kind not in ACCEPTED_INPUT_REPORT_KINDS)
+        or not isinstance(raw_results, list)
+        or not all(isinstance(item, dict) for item in raw_results)
+    ):
+        return _base_snapshot(
+            generated_at_utc=generated,
+            input_artifact_path=source,
+            input_artifact_available=True,
+            note=NOTE_INPUT_UNPARSEABLE,
+            validation_results=[],
+            validation_warnings=[NOTE_INPUT_UNPARSEABLE],
+        )
+
+    validation_results = [_build_result(item) for item in raw_results]
+    validation_results.sort(key=lambda item: item["result_id"])
+    return _base_snapshot(
+        generated_at_utc=generated,
+        input_artifact_path=source,
+        input_artifact_available=True,
+        note=NOTE_RESULTS_PRESENT if validation_results else NOTE_NO_RESULTS,
+        validation_results=validation_results,
+        validation_warnings=[],
+    )
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    if not path.resolve().is_relative_to(ARTIFACT_DIR.resolve()):
+        raise ValueError(f"refusing write outside QRE validation result dir: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".qre_hypothesis_validation_results.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_outputs(
+    snapshot: dict[str, Any],
+    *,
+    output_path: Path | None = None,
+) -> Path:
+    target = output_path or ARTIFACT_LATEST
+    _atomic_write_json(target, snapshot)
+    return target
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="reporting.qre_hypothesis_validation_results",
+        description="Normalize local validation result fixtures into read-only snapshots.",
+    )
+    parser.add_argument("--no-write", action="store_true")
+    parser.add_argument("--source", type=Path, default=None)
+    parser.add_argument("--frozen-utc", default=None)
+    parser.add_argument("--indent", type=int, default=2)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    snapshot = collect_snapshot(
+        input_artifact_path=args.source,
+        generated_at_utc=args.frozen_utc,
+    )
+    if not args.no_write:
+        write_outputs(snapshot)
+    print(json.dumps(snapshot, indent=args.indent, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "ARTIFACT_DIR",
+    "ARTIFACT_LATEST",
+    "ACCEPTED_INPUT_REPORT_KINDS",
+    "INPUT_ARTIFACT_PATH",
+    "INPUT_ARTIFACT_RELATIVE_PATH",
+    "OUTPUT_ARTIFACT_RELATIVE_PATH",
+    "REPORT_KIND",
+    "SCHEMA_VERSION",
+    "STATUSES",
+    "collect_snapshot",
+    "main",
+    "write_outputs",
+]

--- a/reporting/qre_research_run_manifest.py
+++ b/reporting/qre_research_run_manifest.py
@@ -1,0 +1,302 @@
+"""Read-only QRE research run manifest projector."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import hashlib
+import json
+import os
+import tempfile
+from collections import Counter
+from pathlib import Path
+from typing import Any, Final
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[int] = 1
+REPORT_KIND: Final[str] = "qre_research_run_manifest"
+INPUT_REPORT_KIND: Final[str] = "qre_validation_research_action_candidates"
+
+INPUT_ARTIFACT_RELATIVE_PATH: Final[str] = (
+    "logs/qre_validation_research_action_candidates/latest.json"
+)
+INPUT_ARTIFACT_PATH: Final[Path] = REPO_ROOT / INPUT_ARTIFACT_RELATIVE_PATH
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "qre_research_run_manifest"
+OUTPUT_ARTIFACT_RELATIVE_PATH: Final[str] = "logs/qre_research_run_manifest/latest.json"
+ARTIFACT_LATEST: Final[Path] = REPO_ROOT / OUTPUT_ARTIFACT_RELATIVE_PATH
+
+STATUS_OPERATOR_REVIEW_REQUIRED: Final[str] = "operator_review_required"
+
+FORBIDDEN_ACTIONS: Final[tuple[str, ...]] = (
+    "runtime_activation",
+    "broker_execution",
+    "strategy_or_preset_mutation",
+    "campaign_queue_mutation",
+    "tool_execution",
+)
+
+NOTE_INPUT_ABSENT: Final[str] = "validation_action_candidate_artifact_absent"
+NOTE_INPUT_UNPARSEABLE: Final[str] = "validation_action_candidate_artifact_unparseable"
+NOTE_NO_MANIFESTS: Final[str] = "no_research_run_manifests_projected"
+NOTE_MANIFESTS_PRESENT: Final[str] = "research_run_manifests_present"
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _rel(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(REPO_ROOT.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _read_json(path: Path) -> tuple[bool, dict[str, Any] | None]:
+    try:
+        raw = path.read_text(encoding="utf-8-sig")
+    except OSError:
+        return (False, None)
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return (True, None)
+    return (True, parsed if isinstance(parsed, dict) else None)
+
+
+def _bounded_str(value: Any, *, max_len: int = 240) -> str:
+    text = str(value or "").strip()
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 3].rstrip() + "..."
+
+
+def _str_list(value: Any, *, max_items: int = 16, max_len: int = 160) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    out: list[str] = []
+    for item in value[:max_items]:
+        text = _bounded_str(item, max_len=max_len)
+        if text:
+            out.append(text)
+    return out
+
+
+def _manifest_id(action: dict[str, Any]) -> str:
+    seed = "|".join(
+        [
+            _bounded_str(action.get("action_id"), max_len=160),
+            _bounded_str(action.get("target_hypothesis_id"), max_len=160),
+            _bounded_str(action.get("target_validation_plan_id"), max_len=160),
+        ]
+    )
+    return "qre-run-" + hashlib.sha256(seed.encode("utf-8")).hexdigest()[:16]
+
+
+def _build_manifest(action: dict[str, Any]) -> dict[str, Any]:
+    action_id = _bounded_str(action.get("action_id"), max_len=160)
+    plan_id = _bounded_str(action.get("target_validation_plan_id"), max_len=160)
+    hypothesis_id = _bounded_str(action.get("target_hypothesis_id"), max_len=160)
+    forbidden_actions = _str_list(action.get("forbidden_actions")) or list(
+        FORBIDDEN_ACTIONS
+    )
+    return {
+        "run_manifest_id": _manifest_id(action),
+        "source_action_id": action_id,
+        "target_hypothesis_id": hypothesis_id,
+        "target_validation_plan_id": plan_id,
+        "status": STATUS_OPERATOR_REVIEW_REQUIRED,
+        "suggested_command": (
+            "Informational only: operator may prepare a validation research run "
+            f"for plan {plan_id or 'unknown'} after explicit approval."
+        ),
+        "expected_outputs": [
+            "validation_result_snapshot",
+            "metric_results",
+            "falsification_review",
+        ],
+        "operator_approval_required": True,
+        "forbidden_actions": forbidden_actions,
+        "safe_to_execute": False,
+        "eligible_for_direct_execution": False,
+    }
+
+
+def _empty_counts() -> dict[str, Any]:
+    return {"total": 0, "by_status": {STATUS_OPERATOR_REVIEW_REQUIRED: 0}}
+
+
+def _counts(run_manifests: list[dict[str, Any]]) -> dict[str, Any]:
+    counter = Counter(
+        str(item.get("status") or STATUS_OPERATOR_REVIEW_REQUIRED)
+        for item in run_manifests
+    )
+    out = _empty_counts()
+    out["total"] = len(run_manifests)
+    out["by_status"][STATUS_OPERATOR_REVIEW_REQUIRED] = counter.get(
+        STATUS_OPERATOR_REVIEW_REQUIRED, 0
+    )
+    return out
+
+
+def _base_snapshot(
+    *,
+    generated_at_utc: str,
+    input_artifact_path: Path,
+    input_artifact_available: bool,
+    note: str,
+    run_manifests: list[dict[str, Any]],
+    validation_warnings: list[str],
+) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": generated_at_utc,
+        "input_artifact_path": _rel(input_artifact_path),
+        "input_artifact_available": input_artifact_available,
+        "note": note,
+        "run_manifests": run_manifests,
+        "counts": _counts(run_manifests),
+        "validation_warnings": validation_warnings,
+        "final_recommendation": (
+            "research_run_manifests_ready_for_operator_review"
+            if run_manifests
+            else "no_research_run_manifests_available"
+        ),
+        "safe_to_execute": False,
+        "writes_development_work_queue": False,
+        "writes_seed_jsonl": False,
+        "writes_generated_seed_jsonl": False,
+        "writes_research_action_queue": False,
+        "mutates_campaign_queue": False,
+        "mutates_strategy_or_preset": False,
+        "mutates_paper_shadow_live_runtime": False,
+        "launches_codex": False,
+        "eligible_for_direct_execution": False,
+    }
+
+
+def collect_snapshot(
+    *,
+    input_artifact_path: Path | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    generated = generated_at_utc or _utcnow()
+    source = input_artifact_path or INPUT_ARTIFACT_PATH
+    available, payload = _read_json(source)
+    if payload is None:
+        note = NOTE_INPUT_UNPARSEABLE if available else NOTE_INPUT_ABSENT
+        return _base_snapshot(
+            generated_at_utc=generated,
+            input_artifact_path=source,
+            input_artifact_available=available,
+            note=note,
+            run_manifests=[],
+            validation_warnings=[note],
+        )
+
+    raw_candidates = payload.get("action_candidates")
+    if payload.get("report_kind") != INPUT_REPORT_KIND or not isinstance(
+        raw_candidates, list
+    ) or not all(isinstance(item, dict) for item in raw_candidates):
+        return _base_snapshot(
+            generated_at_utc=generated,
+            input_artifact_path=source,
+            input_artifact_available=True,
+            note=NOTE_INPUT_UNPARSEABLE,
+            run_manifests=[],
+            validation_warnings=[NOTE_INPUT_UNPARSEABLE],
+        )
+
+    run_manifests = [_build_manifest(item) for item in raw_candidates]
+    run_manifests.sort(key=lambda item: item["run_manifest_id"])
+    return _base_snapshot(
+        generated_at_utc=generated,
+        input_artifact_path=source,
+        input_artifact_available=True,
+        note=NOTE_MANIFESTS_PRESENT if run_manifests else NOTE_NO_MANIFESTS,
+        run_manifests=run_manifests,
+        validation_warnings=[],
+    )
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    if not path.resolve().is_relative_to(ARTIFACT_DIR.resolve()):
+        raise ValueError(f"refusing write outside QRE research run manifest dir: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".qre_research_run_manifest.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_outputs(
+    snapshot: dict[str, Any],
+    *,
+    output_path: Path | None = None,
+) -> Path:
+    target = output_path or ARTIFACT_LATEST
+    _atomic_write_json(target, snapshot)
+    return target
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="reporting.qre_research_run_manifest",
+        description="Project validation action candidates into operator-gated manifests.",
+    )
+    parser.add_argument("--no-write", action="store_true")
+    parser.add_argument("--source", type=Path, default=None)
+    parser.add_argument("--frozen-utc", default=None)
+    parser.add_argument("--indent", type=int, default=2)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    snapshot = collect_snapshot(
+        input_artifact_path=args.source,
+        generated_at_utc=args.frozen_utc,
+    )
+    if not args.no_write:
+        write_outputs(snapshot)
+    print(json.dumps(snapshot, indent=args.indent, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "ARTIFACT_DIR",
+    "ARTIFACT_LATEST",
+    "FORBIDDEN_ACTIONS",
+    "INPUT_ARTIFACT_PATH",
+    "INPUT_ARTIFACT_RELATIVE_PATH",
+    "OUTPUT_ARTIFACT_RELATIVE_PATH",
+    "REPORT_KIND",
+    "SCHEMA_VERSION",
+    "STATUS_OPERATOR_REVIEW_REQUIRED",
+    "collect_snapshot",
+    "main",
+    "write_outputs",
+]

--- a/reporting/qre_trusted_loop_readiness.py
+++ b/reporting/qre_trusted_loop_readiness.py
@@ -1,0 +1,455 @@
+"""Read-only QRE trusted-loop readiness gate."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Final
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[int] = 1
+REPORT_KIND: Final[str] = "qre_trusted_loop_readiness"
+
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "qre_trusted_loop_readiness"
+OUTPUT_ARTIFACT_RELATIVE_PATH: Final[str] = "logs/qre_trusted_loop_readiness/latest.json"
+ARTIFACT_LATEST: Final[Path] = REPO_ROOT / OUTPUT_ARTIFACT_RELATIVE_PATH
+
+DEFAULT_OBSERVATIONS_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_market_observations" / "latest.json"
+)
+DEFAULT_HYPOTHESES_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_hypothesis_candidates" / "latest.json"
+)
+DEFAULT_PLANS_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_hypothesis_validation_plans" / "latest.json"
+)
+DEFAULT_ACTIONS_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_validation_research_action_candidates" / "latest.json"
+)
+DEFAULT_RUN_MANIFESTS_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_research_run_manifest" / "latest.json"
+)
+DEFAULT_RESULTS_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_hypothesis_validation_results" / "latest.json"
+)
+DEFAULT_EVIDENCE_UPDATES_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_hypothesis_evidence_updates" / "latest.json"
+)
+DEFAULT_OPERATOR_REPORT_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_closed_loop_operator_report" / "latest.json"
+)
+
+READINESS_STATES: Final[tuple[str, ...]] = (
+    "scaffold",
+    "working_capability",
+    "operator_trusted_candidate",
+    "operator_trusted",
+)
+
+NOTE_READINESS_EVALUATED: Final[str] = "trusted_loop_readiness_evaluated"
+
+
+def _utcnow() -> str:
+    return (
+        _dt.datetime.now(_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _rel(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(REPO_ROOT.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _read_json(path: Path) -> tuple[bool, dict[str, Any] | None]:
+    try:
+        raw = path.read_text(encoding="utf-8-sig")
+    except OSError:
+        return (False, None)
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return (True, None)
+    return (True, parsed if isinstance(parsed, dict) else None)
+
+
+def _safe_rows(payload: dict[str, Any] | None, field: str) -> list[dict[str, Any]]:
+    if payload is None:
+        return []
+    rows = payload.get(field)
+    if not isinstance(rows, list) or not all(isinstance(item, dict) for item in rows):
+        return []
+    return rows
+
+
+def _load(
+    path: Path,
+    *,
+    expected_kind: str,
+    field: str | None,
+    label: str,
+) -> tuple[list[dict[str, Any]], dict[str, Any], list[str], dict[str, Any] | None]:
+    available, payload = _read_json(path)
+    meta = {"path": _rel(path), "available": available, "valid": False}
+    if payload is None or payload.get("report_kind") != expected_kind:
+        return ([], meta, [f"{label}:missing_or_unparseable"], payload)
+    meta["valid"] = True
+    if field is None:
+        return ([], meta, [], payload)
+    raw_rows = payload.get(field)
+    if (
+        field not in payload
+        or not isinstance(raw_rows, list)
+        or not all(isinstance(item, dict) for item in raw_rows)
+    ):
+        meta["valid"] = False
+        return ([], meta, [f"{label}:missing_or_unparseable"], payload)
+    return (_safe_rows(payload, field), meta, [], payload)
+
+
+def _evidence_density(
+    observations: list[dict[str, Any]],
+    hypotheses: list[dict[str, Any]],
+    plans: list[dict[str, Any]],
+    actions: list[dict[str, Any]],
+    run_manifests: list[dict[str, Any]],
+    results: list[dict[str, Any]],
+    updates: list[dict[str, Any]],
+) -> dict[str, int]:
+    return {
+        "observations": len(observations),
+        "hypotheses": len(hypotheses),
+        "validation_plans": len(plans),
+        "action_candidates": len(actions),
+        "run_manifests": len(run_manifests),
+        "validation_results": len(results),
+        "evidence_updates": len(updates),
+    }
+
+
+def _contradiction_visibility(updates: list[dict[str, Any]]) -> dict[str, Any]:
+    if not updates:
+        return {"status": "missing", "contradiction_count": 0}
+    contradiction_count = sum(
+        1
+        for item in updates
+        if item.get("evidence_decision") == "contradiction_detected"
+        or bool(item.get("contradicting_evidence_refs"))
+    )
+    visible_fields = all("contradicting_evidence_refs" in item for item in updates)
+    return {
+        "status": "visible" if visible_fields else "incomplete",
+        "contradiction_count": contradiction_count,
+    }
+
+
+def _repeatability_status(
+    results: list[dict[str, Any]],
+    operator_payload: dict[str, Any] | None,
+) -> str:
+    approved = bool(
+        operator_payload
+        and operator_payload.get("operator_report", {}).get(
+            "operator_approved_for_trusted_loop"
+        )
+    )
+    repeatability_refs = [
+        item.get("repeatability_evidence_refs")
+        for item in results
+        if isinstance(item.get("repeatability_evidence_refs"), list)
+        and item.get("repeatability_evidence_refs")
+    ]
+    if approved and repeatability_refs:
+        return "operator_approved_repeatability_evidence_present"
+    if repeatability_refs:
+        return "repeatability_evidence_present"
+    return "no_repeatability_evidence"
+
+
+def _state(
+    *,
+    input_warnings: list[str],
+    density: dict[str, int],
+    contradiction_visibility: dict[str, Any],
+    operator_report_available: bool,
+    repeatability_status: str,
+) -> tuple[str, list[str], list[str]]:
+    blockers: list[str] = []
+    warnings: list[str] = []
+    planning_present = all(
+        density[key] > 0
+        for key in (
+            "observations",
+            "hypotheses",
+            "validation_plans",
+            "action_candidates",
+        )
+    )
+    evidence_present = density["validation_results"] > 0 and density["evidence_updates"] > 0
+    contradiction_visible = contradiction_visibility["status"] == "visible"
+
+    if input_warnings:
+        blockers.extend(input_warnings)
+        return ("scaffold", blockers, warnings)
+    if not planning_present:
+        blockers.append("planning_chain_incomplete")
+        return ("scaffold", blockers, warnings)
+    if not evidence_present:
+        if operator_report_available:
+            blockers.append("validation_results_or_evidence_updates_absent")
+            return ("working_capability", blockers, warnings)
+        blockers.append("operator_report_absent")
+        return ("scaffold", blockers, warnings)
+    if not operator_report_available:
+        blockers.append("operator_report_absent")
+        return ("scaffold", blockers, warnings)
+    if not contradiction_visible:
+        blockers.append("contradiction_visibility_incomplete")
+        return ("working_capability", blockers, warnings)
+    if repeatability_status == "operator_approved_repeatability_evidence_present":
+        return ("operator_trusted", blockers, warnings)
+    warnings.append("repeatability_or_explicit_operator_approval_absent")
+    return ("operator_trusted_candidate", blockers, warnings)
+
+
+def collect_snapshot(
+    *,
+    observations_path: Path | None = None,
+    hypotheses_path: Path | None = None,
+    validation_plans_path: Path | None = None,
+    action_candidates_path: Path | None = None,
+    run_manifests_path: Path | None = None,
+    validation_results_path: Path | None = None,
+    evidence_updates_path: Path | None = None,
+    operator_report_path: Path | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    generated = generated_at_utc or _utcnow()
+    observations, meta_a, warnings_a, _payload_a = _load(
+        observations_path or DEFAULT_OBSERVATIONS_PATH,
+        expected_kind="qre_market_observation_snapshot",
+        field="observations",
+        label="observations",
+    )
+    hypotheses, meta_b, warnings_b, _payload_b = _load(
+        hypotheses_path or DEFAULT_HYPOTHESES_PATH,
+        expected_kind="qre_hypothesis_candidates",
+        field="hypotheses",
+        label="hypotheses",
+    )
+    plans, meta_c, warnings_c, _payload_c = _load(
+        validation_plans_path or DEFAULT_PLANS_PATH,
+        expected_kind="qre_hypothesis_validation_plan",
+        field="validation_plans",
+        label="validation_plans",
+    )
+    actions, meta_d, warnings_d, _payload_d = _load(
+        action_candidates_path or DEFAULT_ACTIONS_PATH,
+        expected_kind="qre_validation_research_action_candidates",
+        field="action_candidates",
+        label="action_candidates",
+    )
+    run_manifests, meta_e, warnings_e, _payload_e = _load(
+        run_manifests_path or DEFAULT_RUN_MANIFESTS_PATH,
+        expected_kind="qre_research_run_manifest",
+        field="run_manifests",
+        label="run_manifests",
+    )
+    results, meta_f, warnings_f, _payload_f = _load(
+        validation_results_path or DEFAULT_RESULTS_PATH,
+        expected_kind="qre_hypothesis_validation_results",
+        field="validation_results",
+        label="validation_results",
+    )
+    updates, meta_g, warnings_g, _payload_g = _load(
+        evidence_updates_path or DEFAULT_EVIDENCE_UPDATES_PATH,
+        expected_kind="qre_hypothesis_evidence_update",
+        field="evidence_updates",
+        label="evidence_updates",
+    )
+    _report_rows, meta_h, warnings_h, operator_payload = _load(
+        operator_report_path or DEFAULT_OPERATOR_REPORT_PATH,
+        expected_kind="qre_closed_loop_operator_report",
+        field=None,
+        label="operator_report",
+    )
+    input_warnings = (
+        warnings_a
+        + warnings_b
+        + warnings_c
+        + warnings_d
+        + warnings_e
+        + warnings_f
+        + warnings_g
+        + warnings_h
+    )
+    density = _evidence_density(
+        observations,
+        hypotheses,
+        plans,
+        actions,
+        run_manifests,
+        results,
+        updates,
+    )
+    contradiction = _contradiction_visibility(updates)
+    repeatability = _repeatability_status(results, operator_payload)
+    operator_report_available = bool(meta_h["valid"])
+    readiness_state, blockers, warnings = _state(
+        input_warnings=input_warnings,
+        density=density,
+        contradiction_visibility=contradiction,
+        operator_report_available=operator_report_available,
+        repeatability_status=repeatability,
+    )
+    criteria = {
+        "planning_chain_present": all(
+            density[key] > 0
+            for key in (
+                "observations",
+                "hypotheses",
+                "validation_plans",
+                "action_candidates",
+            )
+        ),
+        "result_evidence_present": density["validation_results"] > 0
+        and density["evidence_updates"] > 0,
+        "operator_report_available": operator_report_available,
+        "contradiction_visibility_available": contradiction["status"] == "visible",
+        "repeatability_status": repeatability,
+    }
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": generated,
+        "note": NOTE_READINESS_EVALUATED,
+        "readiness_state": readiness_state,
+        "criteria": criteria,
+        "blockers": blockers,
+        "warnings": warnings,
+        "evidence_density": density,
+        "contradiction_visibility": contradiction,
+        "repeatability_status": repeatability,
+        "operator_report_available": operator_report_available,
+        "input_artifacts": {
+            "observations": meta_a,
+            "hypotheses": meta_b,
+            "validation_plans": meta_c,
+            "action_candidates": meta_d,
+            "run_manifests": meta_e,
+            "validation_results": meta_f,
+            "evidence_updates": meta_g,
+            "operator_report": meta_h,
+        },
+        "final_recommendation": (
+            "trusted_loop_ready_for_operator_use"
+            if readiness_state == "operator_trusted"
+            else "operator_review_required_before_trusted_loop_use"
+        ),
+        "safe_to_execute": False,
+        "writes_development_work_queue": False,
+        "writes_seed_jsonl": False,
+        "writes_generated_seed_jsonl": False,
+        "writes_research_action_queue": False,
+        "mutates_campaign_queue": False,
+        "mutates_strategy_or_preset": False,
+        "mutates_paper_shadow_live_runtime": False,
+        "launches_codex": False,
+        "eligible_for_direct_execution": False,
+    }
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    if not path.resolve().is_relative_to(ARTIFACT_DIR.resolve()):
+        raise ValueError(f"refusing write outside QRE trusted readiness dir: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".qre_trusted_loop_readiness.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_outputs(
+    snapshot: dict[str, Any],
+    *,
+    output_path: Path | None = None,
+) -> Path:
+    target = output_path or ARTIFACT_LATEST
+    _atomic_write_json(target, snapshot)
+    return target
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="reporting.qre_trusted_loop_readiness",
+        description="Evaluate read-only QRE trusted-loop readiness.",
+    )
+    parser.add_argument("--no-write", action="store_true")
+    parser.add_argument("--observations-source", type=Path, default=None)
+    parser.add_argument("--hypotheses-source", type=Path, default=None)
+    parser.add_argument("--plans-source", type=Path, default=None)
+    parser.add_argument("--actions-source", type=Path, default=None)
+    parser.add_argument("--run-manifests-source", type=Path, default=None)
+    parser.add_argument("--results-source", type=Path, default=None)
+    parser.add_argument("--evidence-updates-source", type=Path, default=None)
+    parser.add_argument("--operator-report-source", type=Path, default=None)
+    parser.add_argument("--frozen-utc", default=None)
+    parser.add_argument("--indent", type=int, default=2)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    snapshot = collect_snapshot(
+        observations_path=args.observations_source,
+        hypotheses_path=args.hypotheses_source,
+        validation_plans_path=args.plans_source,
+        action_candidates_path=args.actions_source,
+        run_manifests_path=args.run_manifests_source,
+        validation_results_path=args.results_source,
+        evidence_updates_path=args.evidence_updates_source,
+        operator_report_path=args.operator_report_source,
+        generated_at_utc=args.frozen_utc,
+    )
+    if not args.no_write:
+        write_outputs(snapshot)
+    print(json.dumps(snapshot, indent=args.indent, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "ARTIFACT_DIR",
+    "ARTIFACT_LATEST",
+    "OUTPUT_ARTIFACT_RELATIVE_PATH",
+    "READINESS_STATES",
+    "REPORT_KIND",
+    "SCHEMA_VERSION",
+    "collect_snapshot",
+    "main",
+    "write_outputs",
+]

--- a/tests/unit/test_qre_closed_loop_operator_report.py
+++ b/tests/unit/test_qre_closed_loop_operator_report.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from reporting import qre_closed_loop_operator_report as report
+
+
+FROZEN = "2026-06-01T12:00:00Z"
+
+
+def _write_payload(path: Path, report_kind: str, field: str, rows: list[dict]) -> Path:
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "report_kind": report_kind,
+                "generated_at_utc": FROZEN,
+                field: rows,
+                "safe_to_execute": False,
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _artifact_set(tmp_path: Path) -> dict[str, Path]:
+    paths = {
+        "observations": _write_payload(
+            tmp_path / "observations.json",
+            "qre_market_observation_snapshot",
+            "observations",
+            [
+                {
+                    "observation_id": "qre-obs-fixture-001",
+                    "safe_to_execute": False,
+                }
+            ],
+        ),
+        "hypotheses": _write_payload(
+            tmp_path / "hypotheses.json",
+            "qre_hypothesis_candidates",
+            "hypotheses",
+            [
+                {
+                    "hypothesis_id": "qre-hyp-fixture-001",
+                    "status": "proposed",
+                    "safe_to_execute": False,
+                }
+            ],
+        ),
+        "plans": _write_payload(
+            tmp_path / "plans.json",
+            "qre_hypothesis_validation_plan",
+            "validation_plans",
+            [
+                {
+                    "validation_plan_id": "qre-plan-fixture-001",
+                    "hypothesis_id": "qre-hyp-fixture-001",
+                    "safe_to_execute": False,
+                }
+            ],
+        ),
+        "actions": _write_payload(
+            tmp_path / "actions.json",
+            "qre_validation_research_action_candidates",
+            "action_candidates",
+            [
+                {
+                    "action_id": "qre-action-fixture-001",
+                    "target_validation_plan_id": "qre-plan-fixture-001",
+                    "safe_to_execute": False,
+                }
+            ],
+        ),
+        "run_manifests": _write_payload(
+            tmp_path / "run_manifests.json",
+            "qre_research_run_manifest",
+            "run_manifests",
+            [
+                {
+                    "run_manifest_id": "qre-run-fixture-001",
+                    "source_action_id": "qre-action-fixture-001",
+                    "status": "operator_review_required",
+                    "safe_to_execute": False,
+                }
+            ],
+        ),
+        "results": _write_payload(
+            tmp_path / "results.json",
+            "qre_hypothesis_validation_results",
+            "validation_results",
+            [
+                {
+                    "result_id": "qre-result-fixture-001",
+                    "hypothesis_id": "qre-hyp-fixture-001",
+                    "safe_to_execute": False,
+                }
+            ],
+        ),
+        "updates": _write_payload(
+            tmp_path / "updates.json",
+            "qre_hypothesis_evidence_update",
+            "evidence_updates",
+            [
+                {
+                    "evidence_update_id": "qre-evidence-fixture-001",
+                    "hypothesis_id": "qre-hyp-fixture-001",
+                    "evidence_decision": "supported",
+                    "contradicting_evidence_refs": [],
+                    "safe_to_execute": False,
+                }
+            ],
+        ),
+    }
+    return paths
+
+
+def _collect(paths: dict[str, Path], **overrides) -> dict:
+    args = {
+        "observations_path": paths["observations"],
+        "hypotheses_path": paths["hypotheses"],
+        "validation_plans_path": paths["plans"],
+        "action_candidates_path": paths["actions"],
+        "run_manifests_path": paths["run_manifests"],
+        "validation_results_path": paths["results"],
+        "evidence_updates_path": paths["updates"],
+        "generated_at_utc": FROZEN,
+    }
+    args.update(overrides)
+    return report.collect_snapshot(**args)
+
+
+def _assert_safety_flags_false(snapshot: dict) -> None:
+    for key in (
+        "safe_to_execute",
+        "writes_development_work_queue",
+        "writes_seed_jsonl",
+        "writes_generated_seed_jsonl",
+        "writes_research_action_queue",
+        "mutates_campaign_queue",
+        "mutates_strategy_or_preset",
+        "mutates_paper_shadow_live_runtime",
+        "launches_codex",
+        "eligible_for_direct_execution",
+    ):
+        assert snapshot[key] is False
+
+
+def test_missing_input_fails_closed(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.json"
+    paths = {
+        key: missing
+        for key in (
+            "observations",
+            "hypotheses",
+            "plans",
+            "actions",
+            "run_manifests",
+            "results",
+            "updates",
+        )
+    }
+
+    snap = _collect(paths)
+
+    assert snap["operator_report"]["safe_to_execute"] is False
+    assert snap["operator_report"]["active_hypotheses"] == []
+    assert snap["validation_warnings"]
+    _assert_safety_flags_false(snap)
+
+
+def test_malformed_input_fails_closed(tmp_path: Path) -> None:
+    paths = _artifact_set(tmp_path)
+    paths["hypotheses"].write_text(
+        json.dumps({"report_kind": "wrong", "hypotheses": []}),
+        encoding="utf-8",
+    )
+
+    snap = _collect(paths)
+
+    assert "hypotheses:missing_or_unparseable" in snap["validation_warnings"]
+    assert snap["operator_report"]["final_recommendation"] == "operator_review_required"
+    _assert_safety_flags_false(snap)
+
+
+def test_deterministic_output_with_injected_timestamp(tmp_path: Path) -> None:
+    paths = _artifact_set(tmp_path)
+
+    snap_a = _collect(paths)
+    snap_b = _collect(paths)
+
+    assert json.dumps(snap_a, sort_keys=True) == json.dumps(snap_b, sort_keys=True)
+    op = snap_a["operator_report"]
+    assert op["active_hypotheses"][0]["hypothesis_id"] == "qre-hyp-fixture-001"
+    assert op["pending_run_manifests"][0]["run_manifest_id"] == "qre-run-fixture-001"
+    assert op["validation_results"][0]["result_id"] == "qre-result-fixture-001"
+    assert op["evidence_updates"][0]["evidence_decision"] == "supported"
+    assert "approve_or_reject_pending_run_manifests" in op["operator_decisions_required"]
+
+
+def test_atomic_write_refuses_outside_artifact_dir(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        report._atomic_write_json(tmp_path / "latest.json", {"x": 1})
+
+
+def test_cli_no_write_outputs_json_without_writing(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    paths = _artifact_set(tmp_path)
+    artifact_dir = tmp_path / "logs" / "qre_closed_loop_operator_report"
+    latest = artifact_dir / "latest.json"
+    monkeypatch.setattr(report, "ARTIFACT_DIR", artifact_dir)
+    monkeypatch.setattr(report, "ARTIFACT_LATEST", latest)
+
+    rc = report.main(
+        [
+            "--no-write",
+            "--observations-source",
+            str(paths["observations"]),
+            "--hypotheses-source",
+            str(paths["hypotheses"]),
+            "--plans-source",
+            str(paths["plans"]),
+            "--actions-source",
+            str(paths["actions"]),
+            "--run-manifests-source",
+            str(paths["run_manifests"]),
+            "--results-source",
+            str(paths["results"]),
+            "--evidence-updates-source",
+            str(paths["updates"]),
+            "--frozen-utc",
+            FROZEN,
+            "--indent",
+            "0",
+        ]
+    )
+
+    assert rc == 0
+    assert latest.exists() is False
+    parsed = json.loads(capsys.readouterr().out)
+    assert parsed["operator_report"]["safe_to_execute"] is False
+
+
+def test_source_has_no_runtime_launch_or_network_calls() -> None:
+    src = Path(report.__file__).read_text(encoding="utf-8")
+    forbidden = (
+        "import subprocess",
+        "from subprocess",
+        "subprocess.",
+        "import socket",
+        "from socket",
+        "import requests",
+        "import httpx",
+        "import aiohttp",
+        "import urllib",
+        "from urllib",
+        "os.system",
+        "os.popen",
+        "shell=True",
+        "git ",
+        "gh ",
+        "codex ",
+    )
+    for token in forbidden:
+        assert token not in src, token
+
+
+def test_source_does_not_write_active_or_mutating_paths() -> None:
+    src = Path(report.__file__).read_text(encoding="utf-8")
+    forbidden = (
+        "seed.jsonl",
+        "generated_seed.jsonl",
+        "logs/development_work_queue/latest.json",
+        "research/research_action_queue_latest.v1.json",
+        "agent/backtesting/strategies.py",
+        "registry.py",
+        "paper/",
+        "shadow/",
+        "live/",
+    )
+    for token in forbidden:
+        assert token not in src, token

--- a/tests/unit/test_qre_hypothesis_evidence_update.py
+++ b/tests/unit/test_qre_hypothesis_evidence_update.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from reporting import qre_hypothesis_evidence_update as evidence
+
+
+FROZEN = "2026-06-01T12:00:00Z"
+
+
+def _hypothesis(**overrides) -> dict:
+    base = {
+        "hypothesis_id": "qre-hyp-fixture-001",
+        "status": "proposed",
+        "safe_to_execute": False,
+    }
+    base.update(overrides)
+    return base
+
+
+def _result(**overrides) -> dict:
+    base = {
+        "result_id": "qre-result-fixture-001",
+        "hypothesis_id": "qre-hyp-fixture-001",
+        "validation_plan_id": "qre-plan-fixture-001",
+        "run_manifest_id": "qre-run-fixture-001",
+        "status": "passed",
+        "metric_results": {"trade_count": 120},
+        "falsification_hits": [],
+        "supporting_evidence_refs": ["fixture#support"],
+        "contradicting_evidence_refs": [],
+        "safe_to_execute": False,
+    }
+    base.update(overrides)
+    return base
+
+
+def _write_hypotheses(path: Path, rows: list[dict], **overrides) -> Path:
+    payload = {
+        "schema_version": 1,
+        "report_kind": "qre_hypothesis_candidates",
+        "generated_at_utc": FROZEN,
+        "hypotheses": rows,
+        "safe_to_execute": False,
+    }
+    payload.update(overrides)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return path
+
+
+def _write_results(path: Path, rows: list[dict], **overrides) -> Path:
+    payload = {
+        "schema_version": 1,
+        "report_kind": "qre_hypothesis_validation_results",
+        "generated_at_utc": FROZEN,
+        "validation_results": rows,
+        "safe_to_execute": False,
+    }
+    payload.update(overrides)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return path
+
+
+def _assert_safety_flags_false(snapshot: dict) -> None:
+    for key in (
+        "safe_to_execute",
+        "writes_development_work_queue",
+        "writes_seed_jsonl",
+        "writes_generated_seed_jsonl",
+        "writes_research_action_queue",
+        "mutates_campaign_queue",
+        "mutates_strategy_or_preset",
+        "mutates_paper_shadow_live_runtime",
+        "launches_codex",
+        "eligible_for_direct_execution",
+    ):
+        assert snapshot[key] is False
+
+
+def test_missing_input_fails_closed(tmp_path: Path) -> None:
+    snap = evidence.collect_snapshot(
+        hypothesis_input_artifact_path=tmp_path / "missing-hyp.json",
+        result_input_artifact_path=tmp_path / "missing-results.json",
+        generated_at_utc=FROZEN,
+    )
+
+    assert snap["evidence_updates"] == []
+    assert evidence.NOTE_INPUT_ABSENT in snap["validation_warnings"]
+    _assert_safety_flags_false(snap)
+
+
+def test_malformed_input_fails_closed(tmp_path: Path) -> None:
+    hyp_source = _write_hypotheses(tmp_path / "hypotheses.json", [_hypothesis()])
+    result_source = _write_results(
+        tmp_path / "results.json",
+        [_result()],
+        report_kind="wrong",
+    )
+
+    snap = evidence.collect_snapshot(
+        hypothesis_input_artifact_path=hyp_source,
+        result_input_artifact_path=result_source,
+        generated_at_utc=FROZEN,
+    )
+
+    assert snap["evidence_updates"] == []
+    assert evidence.NOTE_INPUT_UNPARSEABLE in snap["validation_warnings"]
+    _assert_safety_flags_false(snap)
+
+
+def test_deterministic_output_with_injected_timestamp(tmp_path: Path) -> None:
+    hyp_source = _write_hypotheses(tmp_path / "hypotheses.json", [_hypothesis()])
+    result_source = _write_results(tmp_path / "results.json", [_result()])
+
+    snap_a = evidence.collect_snapshot(
+        hypothesis_input_artifact_path=hyp_source,
+        result_input_artifact_path=result_source,
+        generated_at_utc=FROZEN,
+    )
+    snap_b = evidence.collect_snapshot(
+        hypothesis_input_artifact_path=hyp_source,
+        result_input_artifact_path=result_source,
+        generated_at_utc=FROZEN,
+    )
+
+    assert json.dumps(snap_a, sort_keys=True) == json.dumps(snap_b, sort_keys=True)
+    row = snap_a["evidence_updates"][0]
+    assert row["evidence_update_id"].startswith("qre-evidence-")
+    assert row["hypothesis_id"] == "qre-hyp-fixture-001"
+    assert row["previous_status"] == "proposed"
+    assert row["evidence_decision"] == "supported"
+    assert row["recommended_next_status"] == "supported"
+    assert row["supporting_evidence_refs"] == ["fixture#support"]
+    assert row["safe_to_execute"] is False
+
+
+def test_decision_mapping_failed_and_contradiction_and_no_result(tmp_path: Path) -> None:
+    hyp_source = _write_hypotheses(
+        tmp_path / "hypotheses.json",
+        [
+            _hypothesis(hypothesis_id="qre-hyp-failed"),
+            _hypothesis(hypothesis_id="qre-hyp-contradiction"),
+            _hypothesis(hypothesis_id="qre-hyp-missing"),
+        ],
+    )
+    result_source = _write_results(
+        tmp_path / "results.json",
+        [
+            _result(
+                result_id="qre-result-failed",
+                hypothesis_id="qre-hyp-failed",
+                status="failed",
+            ),
+            _result(
+                result_id="qre-result-contradiction",
+                hypothesis_id="qre-hyp-contradiction",
+                status="passed",
+                supporting_evidence_refs=["fixture#support"],
+                contradicting_evidence_refs=["fixture#contradiction"],
+            ),
+        ],
+    )
+
+    snap = evidence.collect_snapshot(
+        hypothesis_input_artifact_path=hyp_source,
+        result_input_artifact_path=result_source,
+        generated_at_utc=FROZEN,
+    )
+
+    decisions = {
+        row["hypothesis_id"]: row["evidence_decision"]
+        for row in snap["evidence_updates"]
+    }
+    assert decisions == {
+        "qre-hyp-failed": "falsified",
+        "qre-hyp-contradiction": "contradiction_detected",
+        "qre-hyp-missing": "needs_more_data",
+    }
+
+
+def test_atomic_write_refuses_outside_artifact_dir(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        evidence._atomic_write_json(tmp_path / "latest.json", {"x": 1})
+
+
+def test_cli_no_write_outputs_json_without_writing(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    hyp_source = _write_hypotheses(tmp_path / "hypotheses.json", [_hypothesis()])
+    result_source = _write_results(tmp_path / "results.json", [_result()])
+    artifact_dir = tmp_path / "logs" / "qre_hypothesis_evidence_updates"
+    latest = artifact_dir / "latest.json"
+    monkeypatch.setattr(evidence, "ARTIFACT_DIR", artifact_dir)
+    monkeypatch.setattr(evidence, "ARTIFACT_LATEST", latest)
+
+    rc = evidence.main(
+        [
+            "--no-write",
+            "--hypotheses-source",
+            str(hyp_source),
+            "--results-source",
+            str(result_source),
+            "--frozen-utc",
+            FROZEN,
+            "--indent",
+            "0",
+        ]
+    )
+
+    assert rc == 0
+    assert latest.exists() is False
+    parsed = json.loads(capsys.readouterr().out)
+    assert parsed["evidence_updates"][0]["evidence_decision"] == "supported"
+
+
+def test_source_has_no_runtime_launch_or_network_calls() -> None:
+    src = Path(evidence.__file__).read_text(encoding="utf-8")
+    forbidden = (
+        "import subprocess",
+        "from subprocess",
+        "subprocess.",
+        "import socket",
+        "from socket",
+        "import requests",
+        "import httpx",
+        "import aiohttp",
+        "import urllib",
+        "from urllib",
+        "os.system",
+        "os.popen",
+        "shell=True",
+        "git ",
+        "gh ",
+        "codex ",
+    )
+    for token in forbidden:
+        assert token not in src, token
+
+
+def test_source_does_not_write_active_or_mutating_paths() -> None:
+    src = Path(evidence.__file__).read_text(encoding="utf-8")
+    forbidden = (
+        "seed.jsonl",
+        "generated_seed.jsonl",
+        "logs/development_work_queue/latest.json",
+        "research/research_action_queue_latest.v1.json",
+        "agent/backtesting/strategies.py",
+        "registry.py",
+        "paper/",
+        "shadow/",
+        "live/",
+    )
+    for token in forbidden:
+        assert token not in src, token

--- a/tests/unit/test_qre_hypothesis_validation_results.py
+++ b/tests/unit/test_qre_hypothesis_validation_results.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from reporting import qre_hypothesis_validation_results as results
+
+
+FROZEN = "2026-06-01T12:00:00Z"
+
+
+def _result(**overrides) -> dict:
+    base = {
+        "hypothesis_id": "qre-hyp-fixture-001",
+        "validation_plan_id": "qre-plan-fixture-001",
+        "run_manifest_id": "qre-run-fixture-001",
+        "status": "passed",
+        "metric_results": {"deflated_sharpe": 1.2, "trade_count": 120},
+        "falsification_hits": [],
+        "supporting_evidence_refs": ["fixture#support"],
+        "contradicting_evidence_refs": [],
+    }
+    base.update(overrides)
+    return base
+
+
+def _write_results(path: Path, rows: list[dict], **overrides) -> Path:
+    payload = {
+        "schema_version": 1,
+        "report_kind": "synthetic_validation_result_fixture",
+        "generated_at_utc": FROZEN,
+        "validation_results": rows,
+        "safe_to_execute": False,
+    }
+    payload.update(overrides)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return path
+
+
+def _assert_safety_flags_false(snapshot: dict) -> None:
+    for key in (
+        "safe_to_execute",
+        "writes_development_work_queue",
+        "writes_seed_jsonl",
+        "writes_generated_seed_jsonl",
+        "writes_research_action_queue",
+        "mutates_campaign_queue",
+        "mutates_strategy_or_preset",
+        "mutates_paper_shadow_live_runtime",
+        "launches_codex",
+        "eligible_for_direct_execution",
+    ):
+        assert snapshot[key] is False
+
+
+def test_missing_input_fails_closed(tmp_path: Path) -> None:
+    snap = results.collect_snapshot(
+        input_artifact_path=tmp_path / "missing.json",
+        generated_at_utc=FROZEN,
+    )
+
+    assert snap["input_artifact_available"] is False
+    assert snap["validation_results"] == []
+    assert results.NOTE_INPUT_ABSENT in snap["validation_warnings"]
+    _assert_safety_flags_false(snap)
+
+
+def test_malformed_input_fails_closed(tmp_path: Path) -> None:
+    source = _write_results(tmp_path / "bad.json", [_result()], report_kind="wrong")
+
+    snap = results.collect_snapshot(input_artifact_path=source, generated_at_utc=FROZEN)
+
+    assert snap["validation_results"] == []
+    assert results.NOTE_INPUT_UNPARSEABLE in snap["validation_warnings"]
+    _assert_safety_flags_false(snap)
+
+
+def test_deterministic_output_with_injected_timestamp(tmp_path: Path) -> None:
+    source = _write_results(tmp_path / "results.json", [_result()])
+
+    snap_a = results.collect_snapshot(input_artifact_path=source, generated_at_utc=FROZEN)
+    snap_b = results.collect_snapshot(input_artifact_path=source, generated_at_utc=FROZEN)
+
+    assert json.dumps(snap_a, sort_keys=True) == json.dumps(snap_b, sort_keys=True)
+    row = snap_a["validation_results"][0]
+    assert row["result_id"].startswith("qre-result-")
+    assert row["hypothesis_id"] == "qre-hyp-fixture-001"
+    assert row["validation_plan_id"] == "qre-plan-fixture-001"
+    assert row["run_manifest_id"] == "qre-run-fixture-001"
+    assert row["status"] == "passed"
+    assert row["metric_results"]["trade_count"] == 120
+    assert row["supporting_evidence_refs"] == ["fixture#support"]
+    assert row["safe_to_execute"] is False
+
+
+def test_atomic_write_refuses_outside_artifact_dir(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        results._atomic_write_json(tmp_path / "latest.json", {"x": 1})
+
+
+def test_cli_no_write_outputs_json_without_writing(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    source = _write_results(tmp_path / "results.json", [_result()])
+    artifact_dir = tmp_path / "logs" / "qre_hypothesis_validation_results"
+    latest = artifact_dir / "latest.json"
+    monkeypatch.setattr(results, "ARTIFACT_DIR", artifact_dir)
+    monkeypatch.setattr(results, "ARTIFACT_LATEST", latest)
+
+    rc = results.main(
+        ["--no-write", "--source", str(source), "--frozen-utc", FROZEN, "--indent", "0"]
+    )
+
+    assert rc == 0
+    assert latest.exists() is False
+    parsed = json.loads(capsys.readouterr().out)
+    assert parsed["validation_results"][0]["status"] == "passed"
+
+
+def test_source_has_no_runtime_launch_or_network_calls() -> None:
+    src = Path(results.__file__).read_text(encoding="utf-8")
+    forbidden = (
+        "import subprocess",
+        "from subprocess",
+        "subprocess.",
+        "import socket",
+        "from socket",
+        "import requests",
+        "import httpx",
+        "import aiohttp",
+        "import urllib",
+        "from urllib",
+        "os.system",
+        "os.popen",
+        "shell=True",
+        "git ",
+        "gh ",
+        "codex ",
+    )
+    for token in forbidden:
+        assert token not in src, token
+
+
+def test_source_does_not_write_active_or_mutating_paths() -> None:
+    src = Path(results.__file__).read_text(encoding="utf-8")
+    forbidden = (
+        "seed.jsonl",
+        "generated_seed.jsonl",
+        "logs/development_work_queue/latest.json",
+        "research/research_action_queue_latest.v1.json",
+        "agent/backtesting/strategies.py",
+        "registry.py",
+        "paper/",
+        "shadow/",
+        "live/",
+    )
+    for token in forbidden:
+        assert token not in src, token

--- a/tests/unit/test_qre_research_run_manifest.py
+++ b/tests/unit/test_qre_research_run_manifest.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from reporting import qre_research_run_manifest as manifest
+
+
+FROZEN = "2026-06-01T12:00:00Z"
+
+
+def _action(**overrides) -> dict:
+    base = {
+        "action_id": "qre-action-fixture-001",
+        "target_hypothesis_id": "qre-hyp-fixture-001",
+        "target_validation_plan_id": "qre-plan-fixture-001",
+        "status": "pending",
+        "forbidden_actions": ["strategy_or_preset_mutation"],
+        "safe_to_execute": False,
+        "eligible_for_direct_execution": False,
+    }
+    base.update(overrides)
+    return base
+
+
+def _write_actions(path: Path, actions: list[dict], **overrides) -> Path:
+    payload = {
+        "schema_version": 1,
+        "report_kind": "qre_validation_research_action_candidates",
+        "generated_at_utc": FROZEN,
+        "action_candidates": actions,
+        "safe_to_execute": False,
+    }
+    payload.update(overrides)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return path
+
+
+def _assert_safety_flags_false(snapshot: dict) -> None:
+    for key in (
+        "safe_to_execute",
+        "writes_development_work_queue",
+        "writes_seed_jsonl",
+        "writes_generated_seed_jsonl",
+        "writes_research_action_queue",
+        "mutates_campaign_queue",
+        "mutates_strategy_or_preset",
+        "mutates_paper_shadow_live_runtime",
+        "launches_codex",
+        "eligible_for_direct_execution",
+    ):
+        assert snapshot[key] is False
+
+
+def test_missing_input_fails_closed(tmp_path: Path) -> None:
+    snap = manifest.collect_snapshot(
+        input_artifact_path=tmp_path / "missing.json",
+        generated_at_utc=FROZEN,
+    )
+
+    assert snap["input_artifact_available"] is False
+    assert snap["run_manifests"] == []
+    assert manifest.NOTE_INPUT_ABSENT in snap["validation_warnings"]
+    _assert_safety_flags_false(snap)
+
+
+def test_malformed_input_fails_closed(tmp_path: Path) -> None:
+    source = _write_actions(tmp_path / "actions.json", [], report_kind="wrong")
+
+    snap = manifest.collect_snapshot(input_artifact_path=source, generated_at_utc=FROZEN)
+
+    assert snap["run_manifests"] == []
+    assert manifest.NOTE_INPUT_UNPARSEABLE in snap["validation_warnings"]
+    _assert_safety_flags_false(snap)
+
+
+def test_deterministic_output_with_injected_timestamp(tmp_path: Path) -> None:
+    source = _write_actions(tmp_path / "actions.json", [_action()])
+
+    snap_a = manifest.collect_snapshot(input_artifact_path=source, generated_at_utc=FROZEN)
+    snap_b = manifest.collect_snapshot(input_artifact_path=source, generated_at_utc=FROZEN)
+
+    assert json.dumps(snap_a, sort_keys=True) == json.dumps(snap_b, sort_keys=True)
+    row = snap_a["run_manifests"][0]
+    assert row["run_manifest_id"].startswith("qre-run-")
+    assert row["source_action_id"] == "qre-action-fixture-001"
+    assert row["target_hypothesis_id"] == "qre-hyp-fixture-001"
+    assert row["target_validation_plan_id"] == "qre-plan-fixture-001"
+    assert row["status"] == "operator_review_required"
+    assert row["operator_approval_required"] is True
+    assert row["safe_to_execute"] is False
+    assert row["eligible_for_direct_execution"] is False
+    assert "Informational only" in row["suggested_command"]
+
+
+def test_atomic_write_refuses_outside_artifact_dir(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        manifest._atomic_write_json(tmp_path / "latest.json", {"x": 1})
+
+
+def test_cli_no_write_outputs_json_without_writing(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    source = _write_actions(tmp_path / "actions.json", [_action()])
+    artifact_dir = tmp_path / "logs" / "qre_research_run_manifest"
+    latest = artifact_dir / "latest.json"
+    monkeypatch.setattr(manifest, "ARTIFACT_DIR", artifact_dir)
+    monkeypatch.setattr(manifest, "ARTIFACT_LATEST", latest)
+
+    rc = manifest.main(
+        ["--no-write", "--source", str(source), "--frozen-utc", FROZEN, "--indent", "0"]
+    )
+
+    assert rc == 0
+    assert latest.exists() is False
+    parsed = json.loads(capsys.readouterr().out)
+    assert parsed["run_manifests"][0]["operator_approval_required"] is True
+
+
+def test_source_has_no_runtime_launch_or_network_calls() -> None:
+    src = Path(manifest.__file__).read_text(encoding="utf-8")
+    forbidden = (
+        "import subprocess",
+        "from subprocess",
+        "subprocess.",
+        "import socket",
+        "from socket",
+        "import requests",
+        "import httpx",
+        "import aiohttp",
+        "import urllib",
+        "from urllib",
+        "os.system",
+        "os.popen",
+        "shell=True",
+        "git ",
+        "gh ",
+        "codex ",
+    )
+    for token in forbidden:
+        assert token not in src, token
+
+
+def test_source_does_not_write_active_or_mutating_paths() -> None:
+    src = Path(manifest.__file__).read_text(encoding="utf-8")
+    forbidden = (
+        "seed.jsonl",
+        "generated_seed.jsonl",
+        "logs/development_work_queue/latest.json",
+        "research/research_action_queue_latest.v1.json",
+        "agent/backtesting/strategies.py",
+        "registry.py",
+        "paper/",
+        "shadow/",
+        "live/",
+    )
+    for token in forbidden:
+        assert token not in src, token

--- a/tests/unit/test_qre_trusted_loop_readiness.py
+++ b/tests/unit/test_qre_trusted_loop_readiness.py
@@ -1,0 +1,516 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from reporting import qre_closed_loop_operator_report as operator_report
+from reporting import qre_hypothesis_candidates as hyp
+from reporting import qre_hypothesis_evidence_update as evidence
+from reporting import qre_hypothesis_validation_plan as plan
+from reporting import qre_hypothesis_validation_results as results
+from reporting import qre_market_observation_snapshot as market
+from reporting import qre_research_run_manifest as manifest
+from reporting import qre_trusted_loop_readiness as readiness
+from reporting import qre_validation_research_action_candidates as action
+
+
+FROZEN = "2026-06-01T12:00:00Z"
+
+
+def _write_payload(path: Path, report_kind: str, field: str, rows: list[dict]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "report_kind": report_kind,
+                "generated_at_utc": FROZEN,
+                field: rows,
+                "safe_to_execute": False,
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _artifact_set(tmp_path: Path, *, with_results: bool = True) -> dict[str, Path]:
+    paths = {
+        "observations": _write_payload(
+            tmp_path / "observations.json",
+            "qre_market_observation_snapshot",
+            "observations",
+            [{"observation_id": "qre-obs-fixture-001", "safe_to_execute": False}],
+        ),
+        "hypotheses": _write_payload(
+            tmp_path / "hypotheses.json",
+            "qre_hypothesis_candidates",
+            "hypotheses",
+            [{"hypothesis_id": "qre-hyp-fixture-001", "safe_to_execute": False}],
+        ),
+        "plans": _write_payload(
+            tmp_path / "plans.json",
+            "qre_hypothesis_validation_plan",
+            "validation_plans",
+            [
+                {
+                    "validation_plan_id": "qre-plan-fixture-001",
+                    "hypothesis_id": "qre-hyp-fixture-001",
+                    "safe_to_execute": False,
+                }
+            ],
+        ),
+        "actions": _write_payload(
+            tmp_path / "actions.json",
+            "qre_validation_research_action_candidates",
+            "action_candidates",
+            [
+                {
+                    "action_id": "qre-action-fixture-001",
+                    "target_validation_plan_id": "qre-plan-fixture-001",
+                    "safe_to_execute": False,
+                }
+            ],
+        ),
+        "run_manifests": _write_payload(
+            tmp_path / "run_manifests.json",
+            "qre_research_run_manifest",
+            "run_manifests",
+            [{"run_manifest_id": "qre-run-fixture-001", "safe_to_execute": False}],
+        ),
+        "results": _write_payload(
+            tmp_path / "results.json",
+            "qre_hypothesis_validation_results",
+            "validation_results",
+            [
+                {
+                    "result_id": "qre-result-fixture-001",
+                    "hypothesis_id": "qre-hyp-fixture-001",
+                    "safe_to_execute": False,
+                }
+            ]
+            if with_results
+            else [],
+        ),
+        "updates": _write_payload(
+            tmp_path / "updates.json",
+            "qre_hypothesis_evidence_update",
+            "evidence_updates",
+            [
+                {
+                    "evidence_update_id": "qre-evidence-fixture-001",
+                    "hypothesis_id": "qre-hyp-fixture-001",
+                    "evidence_decision": "supported",
+                    "contradicting_evidence_refs": [],
+                    "safe_to_execute": False,
+                }
+            ]
+            if with_results
+            else [],
+        ),
+        "operator_report": tmp_path / "operator_report.json",
+    }
+    paths["operator_report"].write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "report_kind": "qre_closed_loop_operator_report",
+                "operator_report": {
+                    "operator_decisions_required": [],
+                    "safe_to_execute": False,
+                },
+                "safe_to_execute": False,
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return paths
+
+
+def _collect(paths: dict[str, Path], **overrides) -> dict:
+    args = {
+        "observations_path": paths["observations"],
+        "hypotheses_path": paths["hypotheses"],
+        "validation_plans_path": paths["plans"],
+        "action_candidates_path": paths["actions"],
+        "run_manifests_path": paths["run_manifests"],
+        "validation_results_path": paths["results"],
+        "evidence_updates_path": paths["updates"],
+        "operator_report_path": paths["operator_report"],
+        "generated_at_utc": FROZEN,
+    }
+    args.update(overrides)
+    return readiness.collect_snapshot(**args)
+
+
+def _assert_safety_flags_false(snapshot: dict) -> None:
+    for key in (
+        "safe_to_execute",
+        "writes_development_work_queue",
+        "writes_seed_jsonl",
+        "writes_generated_seed_jsonl",
+        "writes_research_action_queue",
+        "mutates_campaign_queue",
+        "mutates_strategy_or_preset",
+        "mutates_paper_shadow_live_runtime",
+        "launches_codex",
+        "eligible_for_direct_execution",
+    ):
+        assert snapshot[key] is False
+
+
+def test_missing_input_fails_closed(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.json"
+    paths = {
+        key: missing
+        for key in (
+            "observations",
+            "hypotheses",
+            "plans",
+            "actions",
+            "run_manifests",
+            "results",
+            "updates",
+            "operator_report",
+        )
+    }
+
+    snap = _collect(paths)
+
+    assert snap["readiness_state"] == "scaffold"
+    assert snap["blockers"]
+    assert snap["operator_report_available"] is False
+    _assert_safety_flags_false(snap)
+
+
+def test_malformed_input_fails_closed(tmp_path: Path) -> None:
+    paths = _artifact_set(tmp_path)
+    paths["results"].write_text(
+        json.dumps({"report_kind": "wrong", "validation_results": []}),
+        encoding="utf-8",
+    )
+
+    snap = _collect(paths)
+
+    assert snap["readiness_state"] == "scaffold"
+    assert any("validation_results" in item for item in snap["blockers"])
+    _assert_safety_flags_false(snap)
+
+
+def test_deterministic_output_with_injected_timestamp(tmp_path: Path) -> None:
+    paths = _artifact_set(tmp_path)
+
+    snap_a = _collect(paths)
+    snap_b = _collect(paths)
+
+    assert json.dumps(snap_a, sort_keys=True) == json.dumps(snap_b, sort_keys=True)
+    assert snap_a["readiness_state"] == "operator_trusted_candidate"
+    assert snap_a["evidence_density"]["validation_results"] == 1
+    assert snap_a["contradiction_visibility"]["status"] == "visible"
+    assert snap_a["operator_report_available"] is True
+
+
+def test_working_capability_when_planning_exists_without_results(tmp_path: Path) -> None:
+    paths = _artifact_set(tmp_path, with_results=False)
+
+    snap = _collect(paths)
+
+    assert snap["readiness_state"] == "working_capability"
+    assert "validation_results_or_evidence_updates_absent" in snap["blockers"]
+
+
+def test_operator_trusted_requires_repeatability_and_approval(tmp_path: Path) -> None:
+    paths = _artifact_set(tmp_path)
+    paths["results"].write_text(
+        json.dumps(
+            {
+                "report_kind": "qre_hypothesis_validation_results",
+                "validation_results": [
+                    {
+                        "result_id": "qre-result-fixture-001",
+                        "hypothesis_id": "qre-hyp-fixture-001",
+                        "repeatability_evidence_refs": ["fixture#repeatability"],
+                        "safe_to_execute": False,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    paths["operator_report"].write_text(
+        json.dumps(
+            {
+                "report_kind": "qre_closed_loop_operator_report",
+                "operator_report": {
+                    "operator_approved_for_trusted_loop": True,
+                    "safe_to_execute": False,
+                },
+                "safe_to_execute": False,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    snap = _collect(paths)
+
+    assert snap["readiness_state"] == "operator_trusted"
+    assert snap["repeatability_status"] == "operator_approved_repeatability_evidence_present"
+
+
+def test_atomic_write_refuses_outside_artifact_dir(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        readiness._atomic_write_json(tmp_path / "latest.json", {"x": 1})
+
+
+def test_cli_no_write_outputs_json_without_writing(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    paths = _artifact_set(tmp_path)
+    artifact_dir = tmp_path / "logs" / "qre_trusted_loop_readiness"
+    latest = artifact_dir / "latest.json"
+    monkeypatch.setattr(readiness, "ARTIFACT_DIR", artifact_dir)
+    monkeypatch.setattr(readiness, "ARTIFACT_LATEST", latest)
+
+    rc = readiness.main(
+        [
+            "--no-write",
+            "--observations-source",
+            str(paths["observations"]),
+            "--hypotheses-source",
+            str(paths["hypotheses"]),
+            "--plans-source",
+            str(paths["plans"]),
+            "--actions-source",
+            str(paths["actions"]),
+            "--run-manifests-source",
+            str(paths["run_manifests"]),
+            "--results-source",
+            str(paths["results"]),
+            "--evidence-updates-source",
+            str(paths["updates"]),
+            "--operator-report-source",
+            str(paths["operator_report"]),
+            "--frozen-utc",
+            FROZEN,
+            "--indent",
+            "0",
+        ]
+    )
+
+    assert rc == 0
+    assert latest.exists() is False
+    parsed = json.loads(capsys.readouterr().out)
+    assert parsed["readiness_state"] == "operator_trusted_candidate"
+
+
+def test_source_has_no_runtime_launch_or_network_calls() -> None:
+    src = Path(readiness.__file__).read_text(encoding="utf-8")
+    forbidden = (
+        "import subprocess",
+        "from subprocess",
+        "subprocess.",
+        "import socket",
+        "from socket",
+        "import requests",
+        "import httpx",
+        "import aiohttp",
+        "import urllib",
+        "from urllib",
+        "os.system",
+        "os.popen",
+        "shell=True",
+        "git ",
+        "gh ",
+        "codex ",
+    )
+    for token in forbidden:
+        assert token not in src, token
+
+
+def test_source_does_not_write_active_or_mutating_paths() -> None:
+    src = Path(readiness.__file__).read_text(encoding="utf-8")
+    forbidden = (
+        "seed.jsonl",
+        "generated_seed.jsonl",
+        "logs/development_work_queue/latest.json",
+        "research/research_action_queue_latest.v1.json",
+        "agent/backtesting/strategies.py",
+        "registry.py",
+        "paper/",
+        "shadow/",
+        "live/",
+    )
+    for token in forbidden:
+        assert token not in src, token
+
+
+def test_integration_synthetic_closed_loop_to_readiness(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    logs_dir = tmp_path / "logs"
+    market_dir = logs_dir / "qre_market_observations"
+    hyp_dir = logs_dir / "qre_hypothesis_candidates"
+    plan_dir = logs_dir / "qre_hypothesis_validation_plans"
+    action_dir = logs_dir / "qre_validation_research_action_candidates"
+    manifest_dir = logs_dir / "qre_research_run_manifest"
+    result_dir = logs_dir / "qre_hypothesis_validation_results"
+    evidence_dir = logs_dir / "qre_hypothesis_evidence_updates"
+    report_dir = logs_dir / "qre_closed_loop_operator_report"
+    readiness_dir = logs_dir / "qre_trusted_loop_readiness"
+    monkeypatch.setattr(market, "ARTIFACT_DIR", market_dir)
+    monkeypatch.setattr(market, "ARTIFACT_LATEST", market_dir / "latest.json")
+    monkeypatch.setattr(hyp, "ARTIFACT_DIR", hyp_dir)
+    monkeypatch.setattr(hyp, "ARTIFACT_LATEST", hyp_dir / "latest.json")
+    monkeypatch.setattr(plan, "ARTIFACT_DIR", plan_dir)
+    monkeypatch.setattr(plan, "ARTIFACT_LATEST", plan_dir / "latest.json")
+    monkeypatch.setattr(action, "ARTIFACT_DIR", action_dir)
+    monkeypatch.setattr(action, "ARTIFACT_LATEST", action_dir / "latest.json")
+    monkeypatch.setattr(manifest, "ARTIFACT_DIR", manifest_dir)
+    monkeypatch.setattr(manifest, "ARTIFACT_LATEST", manifest_dir / "latest.json")
+    monkeypatch.setattr(results, "ARTIFACT_DIR", result_dir)
+    monkeypatch.setattr(results, "ARTIFACT_LATEST", result_dir / "latest.json")
+    monkeypatch.setattr(evidence, "ARTIFACT_DIR", evidence_dir)
+    monkeypatch.setattr(evidence, "ARTIFACT_LATEST", evidence_dir / "latest.json")
+    monkeypatch.setattr(operator_report, "ARTIFACT_DIR", report_dir)
+    monkeypatch.setattr(operator_report, "ARTIFACT_LATEST", report_dir / "latest.json")
+    monkeypatch.setattr(readiness, "ARTIFACT_DIR", readiness_dir)
+    monkeypatch.setattr(readiness, "ARTIFACT_LATEST", readiness_dir / "latest.json")
+
+    market_source = tmp_path / "synthetic_market_source.json"
+    market_source.write_text(
+        json.dumps(
+            {
+                "observations": [
+                    {
+                        "observation_type": "low_trade_count",
+                        "asset_scope": ["BTC-USD"],
+                        "timeframe_scope": ["4h"],
+                        "regime_tags": ["trend"],
+                        "metric_refs": ["total_trades:19"],
+                        "summary": "The fold has too few trades for durable validation.",
+                        "confidence": 0.8,
+                        "supporting_evidence_refs": ["fixture#low-count"],
+                        "contradicting_evidence_refs": [],
+                    }
+                ]
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    market_snap = market.collect_snapshot(
+        source_path=market_source,
+        generated_at_utc=FROZEN,
+    )
+    market.write_outputs(market_snap)
+    hyp_snap = hyp.collect_snapshot(
+        input_artifact_path=market.ARTIFACT_LATEST,
+        generated_at_utc=FROZEN,
+    )
+    hyp.write_outputs(hyp_snap)
+    plan_snap = plan.collect_snapshot(
+        input_artifact_path=hyp.ARTIFACT_LATEST,
+        generated_at_utc=FROZEN,
+    )
+    plan.write_outputs(plan_snap)
+    action_snap = action.collect_snapshot(
+        input_artifact_path=plan.ARTIFACT_LATEST,
+        generated_at_utc=FROZEN,
+    )
+    action.write_outputs(action_snap)
+    manifest_snap = manifest.collect_snapshot(
+        input_artifact_path=action.ARTIFACT_LATEST,
+        generated_at_utc=FROZEN,
+    )
+    manifest.write_outputs(manifest_snap)
+
+    hypothesis_id = hyp_snap["hypotheses"][0]["hypothesis_id"]
+    validation_plan_id = plan_snap["validation_plans"][0]["validation_plan_id"]
+    run_manifest_id = manifest_snap["run_manifests"][0]["run_manifest_id"]
+    result_source = tmp_path / "synthetic_validation_results.json"
+    result_source.write_text(
+        json.dumps(
+            {
+                "validation_results": [
+                    {
+                        "hypothesis_id": hypothesis_id,
+                        "validation_plan_id": validation_plan_id,
+                        "run_manifest_id": run_manifest_id,
+                        "status": "passed",
+                        "metric_results": {"trade_count": 120},
+                        "falsification_hits": [],
+                        "supporting_evidence_refs": ["fixture#validation-pass"],
+                        "contradicting_evidence_refs": [],
+                    }
+                ]
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    result_snap = results.collect_snapshot(
+        input_artifact_path=result_source,
+        generated_at_utc=FROZEN,
+    )
+    results.write_outputs(result_snap)
+    evidence_snap = evidence.collect_snapshot(
+        hypothesis_input_artifact_path=hyp.ARTIFACT_LATEST,
+        result_input_artifact_path=results.ARTIFACT_LATEST,
+        generated_at_utc=FROZEN,
+    )
+    evidence.write_outputs(evidence_snap)
+    report_snap = operator_report.collect_snapshot(
+        observations_path=market.ARTIFACT_LATEST,
+        hypotheses_path=hyp.ARTIFACT_LATEST,
+        validation_plans_path=plan.ARTIFACT_LATEST,
+        action_candidates_path=action.ARTIFACT_LATEST,
+        run_manifests_path=manifest.ARTIFACT_LATEST,
+        validation_results_path=results.ARTIFACT_LATEST,
+        evidence_updates_path=evidence.ARTIFACT_LATEST,
+        generated_at_utc=FROZEN,
+    )
+    operator_report.write_outputs(report_snap)
+    readiness_snap = readiness.collect_snapshot(
+        observations_path=market.ARTIFACT_LATEST,
+        hypotheses_path=hyp.ARTIFACT_LATEST,
+        validation_plans_path=plan.ARTIFACT_LATEST,
+        action_candidates_path=action.ARTIFACT_LATEST,
+        run_manifests_path=manifest.ARTIFACT_LATEST,
+        validation_results_path=results.ARTIFACT_LATEST,
+        evidence_updates_path=evidence.ARTIFACT_LATEST,
+        operator_report_path=operator_report.ARTIFACT_LATEST,
+        generated_at_utc=FROZEN,
+    )
+    readiness.write_outputs(readiness_snap)
+
+    for snap in [manifest_snap, result_snap, evidence_snap, report_snap, readiness_snap]:
+        _assert_safety_flags_false(snap)
+    assert manifest_snap["run_manifests"][0]["safe_to_execute"] is False
+    assert result_snap["validation_results"][0]["safe_to_execute"] is False
+    assert evidence_snap["evidence_updates"][0]["safe_to_execute"] is False
+    assert report_snap["operator_report"]["safe_to_execute"] is False
+    assert readiness_snap["readiness_state"] == "operator_trusted_candidate"
+    assert readiness_snap["readiness_state"] != "operator_trusted"
+
+    allowed_dirs = {
+        "qre_market_observations",
+        "qre_hypothesis_candidates",
+        "qre_hypothesis_validation_plans",
+        "qre_validation_research_action_candidates",
+        "qre_research_run_manifest",
+        "qre_hypothesis_validation_results",
+        "qre_hypothesis_evidence_updates",
+        "qre_closed_loop_operator_report",
+        "qre_trusted_loop_readiness",
+    }
+    written = [path for path in logs_dir.rglob("*") if path.is_file()]
+    assert {path.parent.name for path in written} <= allowed_dirs
+    assert {path.name for path in written} == {"latest.json"}


### PR DESCRIPTION
Adds the read-only result/evidence half of the QRE closed-loop research scaffold.

Summary:
- Adds reporting/qre_research_run_manifest.py
- Adds reporting/qre_hypothesis_validation_results.py
- Adds reporting/qre_hypothesis_evidence_update.py
- Adds reporting/qre_closed_loop_operator_report.py
- Adds reporting/qre_trusted_loop_readiness.py
- Adds unit tests for all five modules
- Converts validation research action candidates into operator-gated run manifests
- Normalizes validation result snapshots
- Projects hypothesis evidence updates
- Produces a closed-loop operator report
- Adds trusted-loop readiness classification
- Keeps all outputs non-executing and read-only
- Does not commit generated logs artifacts
- Does not mutate development work queue, seed files, generated seed files, research action queue, campaigns, strategies, presets, paper/shadow/live runtime, broker/risk/execution, or Codex automation

Validation:
- python -m pytest tests/unit/test_qre_research_run_manifest.py tests/unit/test_qre_hypothesis_validation_results.py tests/unit/test_qre_hypothesis_evidence_update.py tests/unit/test_qre_closed_loop_operator_report.py tests/unit/test_qre_trusted_loop_readiness.py -q
  - 39 passed
- python -m pytest tests/unit/test_qre_market_observation_snapshot.py tests/unit/test_qre_hypothesis_candidates.py tests/unit/test_qre_observation_hypothesis_projector.py tests/unit/test_qre_hypothesis_validation_plan.py tests/unit/test_qre_validation_research_action_candidates.py -q
  - 39 passed
- python -m pytest tests/unit/test_qre_research_action_consumer_gate.py tests/unit/test_qre_development_intake_promotion.py tests/unit/test_qre_development_queue_admission_policy.py -q
  - 53 passed
- import smoke for all five new reporting modules
- safety scan found only expected forbidden-action strings and false mutation flags