### PR TITLE
feat: add QRE closed-loop real-source materialization

### DIFF
--- a/reporting/qre_closed_loop_materialization_runner.py
+++ b/reporting/qre_closed_loop_materialization_runner.py
@@ -1,0 +1,218 @@
+"""Read-only QRE closed-loop materialization runner."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import tempfile
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Final
+
+from reporting import qre_closed_loop_operator_report
+from reporting import qre_hypothesis_candidates
+from reporting import qre_hypothesis_evidence_update
+from reporting import qre_hypothesis_validation_plan
+from reporting import qre_hypothesis_validation_results
+from reporting import qre_market_observation_snapshot
+from reporting import qre_observation_hypothesis_projector
+from reporting import qre_research_run_manifest
+from reporting import qre_trusted_loop_readiness
+from reporting import qre_validation_research_action_candidates
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[int] = 1
+REPORT_KIND: Final[str] = "qre_closed_loop_materialization"
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "qre_closed_loop_materialization"
+OUTPUT_ARTIFACT_RELATIVE_PATH: Final[str] = "logs/qre_closed_loop_materialization/latest.json"
+ARTIFACT_LATEST: Final[Path] = REPO_ROOT / OUTPUT_ARTIFACT_RELATIVE_PATH
+
+STEP_MODULES: Final[tuple[ModuleType, ...]] = (
+    qre_market_observation_snapshot,
+    qre_hypothesis_candidates,
+    qre_observation_hypothesis_projector,
+    qre_hypothesis_validation_plan,
+    qre_validation_research_action_candidates,
+    qre_research_run_manifest,
+    qre_hypothesis_validation_results,
+    qre_hypothesis_evidence_update,
+    qre_closed_loop_operator_report,
+    qre_trusted_loop_readiness,
+)
+
+
+def _utcnow() -> str:
+    return _dt.datetime.now(_dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _rel(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(REPO_ROOT.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _counts(snapshot: dict[str, Any]) -> dict[str, Any]:
+    counts = snapshot.get("counts")
+    if isinstance(counts, dict):
+        return counts
+    for key in (
+        "observations",
+        "hypotheses",
+        "validation_plans",
+        "action_candidates",
+        "run_manifests",
+        "validation_results",
+        "evidence_updates",
+    ):
+        rows = snapshot.get(key)
+        if isinstance(rows, list):
+            return {"total": len(rows)}
+    density = snapshot.get("evidence_density")
+    if isinstance(density, dict):
+        return dict(density)
+    return {}
+
+
+def _step_record(
+    *,
+    module: ModuleType,
+    snapshot: dict[str, Any],
+    artifact_path: Path | None,
+) -> dict[str, Any]:
+    return {
+        "module": module.__name__,
+        "report_kind": str(snapshot.get("report_kind") or ""),
+        "final_recommendation": str(snapshot.get("final_recommendation") or ""),
+        "safe_to_execute": False,
+        "counts": _counts(snapshot),
+        "artifact_path": _rel(artifact_path) if artifact_path is not None else None,
+    }
+
+
+def collect_snapshot(
+    *,
+    no_write: bool = False,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    generated = generated_at_utc or _utcnow()
+    steps: list[dict[str, Any]] = []
+    validation_warnings: list[str] = []
+    aggregate_counts: dict[str, Any] = {}
+
+    for module in STEP_MODULES:
+        snapshot = module.collect_snapshot(generated_at_utc=generated)
+        artifact_path: Path | None = None
+        if not no_write:
+            artifact_path = module.write_outputs(snapshot)
+        report_kind = str(snapshot.get("report_kind") or module.__name__.rsplit(".", 1)[-1])
+        aggregate_counts[report_kind] = _counts(snapshot)
+        warnings = snapshot.get("validation_warnings")
+        if isinstance(warnings, list):
+            validation_warnings.extend(str(item) for item in warnings if item)
+        steps.append(
+            _step_record(
+                module=module,
+                snapshot=snapshot,
+                artifact_path=artifact_path,
+            )
+        )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": generated,
+        "steps": steps,
+        "counts": aggregate_counts,
+        "validation_warnings": validation_warnings,
+        "final_recommendation": (
+            "operator_review_required_before_any_follow_up"
+            if validation_warnings
+            else "closed_loop_materialized_for_operator_review"
+        ),
+        "safe_to_execute": False,
+        "writes_development_work_queue": False,
+        "writes_seed_jsonl": False,
+        "writes_generated_seed_jsonl": False,
+        "writes_research_action_queue": False,
+        "mutates_campaign_queue": False,
+        "mutates_strategy_or_preset": False,
+        "mutates_paper_shadow_live_runtime": False,
+        "launches_codex": False,
+        "eligible_for_direct_execution": False,
+    }
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    if not path.resolve().is_relative_to(ARTIFACT_DIR.resolve()):
+        raise ValueError(f"refusing write outside QRE materialization dir: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".qre_closed_loop_materialization.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_outputs(
+    snapshot: dict[str, Any],
+    *,
+    output_path: Path | None = None,
+) -> Path:
+    target = output_path or ARTIFACT_LATEST
+    _atomic_write_json(target, snapshot)
+    return target
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="reporting.qre_closed_loop_materialization_runner",
+        description="Materialize read-only QRE closed-loop reports in sequence.",
+    )
+    parser.add_argument("--no-write", action="store_true")
+    parser.add_argument("--frozen-utc", default=None)
+    parser.add_argument("--indent", type=int, default=2)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    snapshot = collect_snapshot(
+        no_write=args.no_write,
+        generated_at_utc=args.frozen_utc,
+    )
+    if not args.no_write:
+        write_outputs(snapshot)
+    print(json.dumps(snapshot, indent=args.indent, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "ARTIFACT_DIR",
+    "ARTIFACT_LATEST",
+    "OUTPUT_ARTIFACT_RELATIVE_PATH",
+    "REPORT_KIND",
+    "SCHEMA_VERSION",
+    "STEP_MODULES",
+    "collect_snapshot",
+    "main",
+    "write_outputs",
+]

--- a/reporting/qre_closed_loop_operator_report.py
+++ b/reporting/qre_closed_loop_operator_report.py
@@ -16,9 +16,7 @@ SCHEMA_VERSION: Final[int] = 1
 REPORT_KIND: Final[str] = "qre_closed_loop_operator_report"
 
 ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "qre_closed_loop_operator_report"
-OUTPUT_ARTIFACT_RELATIVE_PATH: Final[str] = (
-    "logs/qre_closed_loop_operator_report/latest.json"
-)
+OUTPUT_ARTIFACT_RELATIVE_PATH: Final[str] = "logs/qre_closed_loop_operator_report/latest.json"
 ARTIFACT_LATEST: Final[Path] = REPO_ROOT / OUTPUT_ARTIFACT_RELATIVE_PATH
 
 DEFAULT_OBSERVATIONS_PATH: Final[Path] = (
@@ -48,12 +46,7 @@ NOTE_REPORT_READY: Final[str] = "closed_loop_operator_report_ready"
 
 
 def _utcnow() -> str:
-    return (
-        _dt.datetime.now(_dt.UTC)
-        .replace(microsecond=0)
-        .isoformat()
-        .replace("+00:00", "Z")
-    )
+    return _dt.datetime.now(_dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
 def _rel(path: Path) -> str:
@@ -91,6 +84,17 @@ def _safe_rows(payload: dict[str, Any] | None, field: str) -> list[dict[str, Any
     return rows
 
 
+def _str_list(value: Any, *, max_items: int = 24, max_len: int = 180) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    out: list[str] = []
+    for item in value[:max_items]:
+        text = _bounded_str(item, max_len=max_len)
+        if text:
+            out.append(text)
+    return out
+
+
 def _load(
     path: Path,
     *,
@@ -124,9 +128,7 @@ def _blocked_links(
 ) -> list[str]:
     blockers: list[str] = []
     hypothesis_ids = {_bounded_str(item.get("hypothesis_id"), max_len=160) for item in hypotheses}
-    plan_hypothesis_ids = {
-        _bounded_str(item.get("hypothesis_id"), max_len=160) for item in plans
-    }
+    plan_hypothesis_ids = {_bounded_str(item.get("hypothesis_id"), max_len=160) for item in plans}
     action_plan_ids = {
         _bounded_str(item.get("target_validation_plan_id"), max_len=160) for item in actions
     }
@@ -155,6 +157,7 @@ def _blocked_links(
 
 
 def _operator_decisions_required(
+    missing_validation_results: list[dict[str, Any]],
     run_manifests: list[dict[str, Any]],
     evidence_updates: list[dict[str, Any]],
     blocked_links: list[str],
@@ -167,9 +170,128 @@ def _operator_decisions_required(
         for item in evidence_updates
     ):
         decisions.append("resolve_evidence_update_decisions")
+    if missing_validation_results:
+        decisions.append("provide_or_accept_missing_validation_results")
     if blocked_links:
         decisions.append("repair_or_accept_blocked_closed_loop_links")
     return decisions
+
+
+def _result_index(results: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    by_hypothesis: dict[str, list[dict[str, Any]]] = {}
+    for item in results:
+        hypothesis_id = _bounded_str(item.get("hypothesis_id"), max_len=160)
+        if hypothesis_id:
+            by_hypothesis.setdefault(hypothesis_id, []).append(item)
+    for rows in by_hypothesis.values():
+        rows.sort(key=lambda row: _bounded_str(row.get("result_id"), max_len=160))
+    return by_hypothesis
+
+
+def _missing_validation_results(
+    hypotheses: list[dict[str, Any]],
+    results: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    result_by_hypothesis = _result_index(results)
+    missing: list[dict[str, Any]] = []
+    for hypothesis in hypotheses:
+        hypothesis_id = _bounded_str(hypothesis.get("hypothesis_id"), max_len=160)
+        if not hypothesis_id or hypothesis_id in result_by_hypothesis:
+            continue
+        missing.append(
+            {
+                "hypothesis_id": hypothesis_id,
+                "title": _bounded_str(hypothesis.get("title"), max_len=180),
+                "reason": "no_validation_result_linked",
+                "safe_to_execute": False,
+            }
+        )
+    missing.sort(key=lambda item: item["hypothesis_id"])
+    return missing
+
+
+def _bucketed_hypotheses(
+    hypotheses: list[dict[str, Any]],
+    evidence_updates: list[dict[str, Any]],
+) -> dict[str, list[dict[str, Any]]]:
+    hypotheses_by_id = {
+        _bounded_str(item.get("hypothesis_id"), max_len=160): item
+        for item in hypotheses
+        if _bounded_str(item.get("hypothesis_id"), max_len=160)
+    }
+    buckets = {
+        "top_supported_hypotheses": [],
+        "top_falsified_hypotheses": [],
+        "needs_more_data_hypotheses": [],
+        "contradiction_hypotheses": [],
+    }
+    bucket_by_decision = {
+        "supported": "top_supported_hypotheses",
+        "falsified": "top_falsified_hypotheses",
+        "needs_more_data": "needs_more_data_hypotheses",
+        "inconclusive": "needs_more_data_hypotheses",
+        "contradiction_detected": "contradiction_hypotheses",
+    }
+    for update in evidence_updates:
+        hypothesis_id = _bounded_str(update.get("hypothesis_id"), max_len=160)
+        bucket_name = bucket_by_decision.get(
+            _bounded_str(update.get("evidence_decision"), max_len=80)
+        )
+        if not hypothesis_id or bucket_name is None:
+            continue
+        hypothesis = hypotheses_by_id.get(hypothesis_id, {})
+        row = {
+            "hypothesis_id": hypothesis_id,
+            "title": _bounded_str(hypothesis.get("title"), max_len=180),
+            "evidence_update_id": _bounded_str(update.get("evidence_update_id"), max_len=160),
+            "evidence_decision": _bounded_str(update.get("evidence_decision"), max_len=80),
+            "supporting_evidence_refs": _str_list(update.get("supporting_evidence_refs")),
+            "contradicting_evidence_refs": _str_list(update.get("contradicting_evidence_refs")),
+            "source_artifact": _bounded_str(update.get("source_artifact"), max_len=240),
+            "safe_to_execute": False,
+        }
+        buckets[bucket_name].append(row)
+    for rows in buckets.values():
+        rows.sort(key=lambda item: (item["hypothesis_id"], item["evidence_update_id"]))
+    return buckets
+
+
+def _operator_guidance(
+    *,
+    missing_validation_results: list[dict[str, Any]],
+    evidence_updates: list[dict[str, Any]],
+    validation_warnings: list[str],
+) -> tuple[str, list[str], list[str]]:
+    if validation_warnings:
+        readiness = "Input artifacts are missing or malformed; the loop remains scaffold-level."
+    elif missing_validation_results:
+        readiness = "Some hypotheses have no validation result; the loop is not trusted."
+    elif any(
+        item.get("evidence_decision") == "contradiction_detected" for item in evidence_updates
+    ):
+        readiness = "Contradictory evidence is visible and requires operator resolution."
+    elif evidence_updates:
+        readiness = "Evidence updates are available for manual readiness review."
+    else:
+        readiness = "No evidence updates are available; the loop remains planning-only."
+    forbidden = [
+        "QRE closed-loop reports are read-only operator aids.",
+        "Research execution, queue writes, campaign mutation, and runtime activation require separate approved workflows.",
+        "All safe_to_execute flags remain false in this report.",
+    ]
+    manual_actions: list[str] = []
+    if missing_validation_results:
+        manual_actions.append("review_missing_validation_results")
+    if any(item.get("evidence_decision") == "contradiction_detected" for item in evidence_updates):
+        manual_actions.append("resolve_contradictory_evidence")
+    if any(
+        item.get("evidence_decision") in {"needs_more_data", "inconclusive"}
+        for item in evidence_updates
+    ):
+        manual_actions.append("decide_whether_more_data_is_required")
+    if not manual_actions:
+        manual_actions.append("review_evidence_lineage_before_any_follow_up")
+    return (readiness, forbidden, manual_actions)
 
 
 def _base_snapshot(
@@ -265,16 +387,22 @@ def collect_snapshot(
         label="evidence_updates",
     )
     validation_warnings = (
-        warnings_a
-        + warnings_b
-        + warnings_c
-        + warnings_d
-        + warnings_e
-        + warnings_f
-        + warnings_g
+        warnings_a + warnings_b + warnings_c + warnings_d + warnings_e + warnings_f + warnings_g
     )
     blocked_links = _blocked_links(hypotheses, plans, actions, run_manifests, results, updates)
-    decisions = _operator_decisions_required(run_manifests, updates, blocked_links)
+    missing_results = _missing_validation_results(hypotheses, results)
+    decisions = _operator_decisions_required(
+        missing_results,
+        run_manifests,
+        updates,
+        blocked_links,
+    )
+    buckets = _bucketed_hypotheses(hypotheses, updates)
+    readiness_explanation, forbidden_reasons, next_manual_actions = _operator_guidance(
+        missing_validation_results=missing_results,
+        evidence_updates=updates,
+        validation_warnings=validation_warnings,
+    )
     active_hypotheses = [
         item
         for item in hypotheses
@@ -285,14 +413,20 @@ def collect_snapshot(
         "proposed_hypotheses": hypotheses,
         "validation_plans": plans,
         "pending_run_manifests": [
-            item
-            for item in run_manifests
-            if item.get("status") == "operator_review_required"
+            item for item in run_manifests if item.get("status") == "operator_review_required"
         ],
         "validation_results": results,
         "evidence_updates": updates,
+        "top_supported_hypotheses": buckets["top_supported_hypotheses"],
+        "top_falsified_hypotheses": buckets["top_falsified_hypotheses"],
+        "needs_more_data_hypotheses": buckets["needs_more_data_hypotheses"],
+        "contradiction_hypotheses": buckets["contradiction_hypotheses"],
+        "missing_validation_results": missing_results,
         "blocked_or_missing_links": blocked_links + validation_warnings,
         "operator_decisions_required": decisions,
+        "readiness_explanation": readiness_explanation,
+        "why_auto_execution_is_forbidden": forbidden_reasons,
+        "next_manual_actions": next_manual_actions,
         "summary": (
             f"Closed-loop report: {len(observations)} observations, "
             f"{len(hypotheses)} hypotheses, {len(results)} validation results."

--- a/reporting/qre_hypothesis_evidence_update.py
+++ b/reporting/qre_hypothesis_evidence_update.py
@@ -19,20 +19,14 @@ REPORT_KIND: Final[str] = "qre_hypothesis_evidence_update"
 HYPOTHESIS_INPUT_REPORT_KIND: Final[str] = "qre_hypothesis_candidates"
 RESULT_INPUT_REPORT_KIND: Final[str] = "qre_hypothesis_validation_results"
 
-HYPOTHESIS_INPUT_ARTIFACT_RELATIVE_PATH: Final[str] = (
-    "logs/qre_hypothesis_candidates/latest.json"
-)
+HYPOTHESIS_INPUT_ARTIFACT_RELATIVE_PATH: Final[str] = "logs/qre_hypothesis_candidates/latest.json"
 RESULT_INPUT_ARTIFACT_RELATIVE_PATH: Final[str] = (
     "logs/qre_hypothesis_validation_results/latest.json"
 )
-HYPOTHESIS_INPUT_ARTIFACT_PATH: Final[Path] = (
-    REPO_ROOT / HYPOTHESIS_INPUT_ARTIFACT_RELATIVE_PATH
-)
+HYPOTHESIS_INPUT_ARTIFACT_PATH: Final[Path] = REPO_ROOT / HYPOTHESIS_INPUT_ARTIFACT_RELATIVE_PATH
 RESULT_INPUT_ARTIFACT_PATH: Final[Path] = REPO_ROOT / RESULT_INPUT_ARTIFACT_RELATIVE_PATH
 ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "qre_hypothesis_evidence_updates"
-OUTPUT_ARTIFACT_RELATIVE_PATH: Final[str] = (
-    "logs/qre_hypothesis_evidence_updates/latest.json"
-)
+OUTPUT_ARTIFACT_RELATIVE_PATH: Final[str] = "logs/qre_hypothesis_evidence_updates/latest.json"
 ARTIFACT_LATEST: Final[Path] = REPO_ROOT / OUTPUT_ARTIFACT_RELATIVE_PATH
 
 DECISIONS: Final[tuple[str, ...]] = (
@@ -51,12 +45,7 @@ NOTE_UPDATES_PRESENT: Final[str] = "evidence_updates_present"
 
 
 def _utcnow() -> str:
-    return (
-        _dt.datetime.now(_dt.UTC)
-        .replace(microsecond=0)
-        .isoformat()
-        .replace("+00:00", "Z")
-    )
+    return _dt.datetime.now(_dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
 def _rel(path: Path) -> str:
@@ -174,9 +163,13 @@ def _build_update(
     result_id = _bounded_str(result.get("result_id"), max_len=160) if result else ""
     decision, next_status, reason, next_actions = _decision(result)
     supporting_refs = _str_list(result.get("supporting_evidence_refs")) if result else []
-    contradicting_refs = (
-        _str_list(result.get("contradicting_evidence_refs")) if result else []
+    contradicting_refs = _str_list(result.get("contradicting_evidence_refs")) if result else []
+    source_artifact = _bounded_str(result.get("source_artifact"), max_len=240) if result else ""
+    source_report_kind = (
+        _bounded_str(result.get("source_report_kind"), max_len=120) if result else ""
     )
+    source_row_id = _bounded_str(result.get("source_row_id"), max_len=240) if result else ""
+    source_ref = _bounded_str(result.get("source_ref"), max_len=300) if result else ""
     return {
         "evidence_update_id": _evidence_update_id(
             hypothesis_id,
@@ -184,12 +177,15 @@ def _build_update(
             decision,
         ),
         "hypothesis_id": hypothesis_id,
-        "previous_status": _bounded_str(hypothesis.get("status"), max_len=80)
-        or "unknown",
+        "previous_status": _bounded_str(hypothesis.get("status"), max_len=80) or "unknown",
         "evidence_decision": decision,
         "recommended_next_status": next_status,
         "supporting_evidence_refs": supporting_refs,
         "contradicting_evidence_refs": contradicting_refs,
+        "source_artifact": source_artifact,
+        "source_report_kind": source_report_kind,
+        "source_row_id": source_row_id,
+        "source_ref": source_ref,
         "reason": reason,
         "next_actions": next_actions,
         "safe_to_execute": False,
@@ -202,8 +198,7 @@ def _empty_counts() -> dict[str, Any]:
 
 def _counts(evidence_updates: list[dict[str, Any]]) -> dict[str, Any]:
     counter = Counter(
-        str(item.get("evidence_decision") or "needs_more_data")
-        for item in evidence_updates
+        str(item.get("evidence_decision") or "needs_more_data") for item in evidence_updates
     )
     out = _empty_counts()
     out["total"] = len(evidence_updates)
@@ -303,7 +298,12 @@ def collect_snapshot(
         )
 
     evidence_updates = [
-        _build_update(item, _result_for_hypothesis(_bounded_str(item.get("hypothesis_id"), max_len=160), raw_results))
+        _build_update(
+            item,
+            _result_for_hypothesis(
+                _bounded_str(item.get("hypothesis_id"), max_len=160), raw_results
+            ),
+        )
         for item in raw_hypotheses
     ]
     evidence_updates.sort(key=lambda item: item["evidence_update_id"])

--- a/reporting/qre_hypothesis_validation_results.py
+++ b/reporting/qre_hypothesis_validation_results.py
@@ -21,13 +21,42 @@ ACCEPTED_INPUT_REPORT_KINDS: Final[tuple[str, ...]] = (
     "synthetic_validation_result_fixture",
     "qre_hypothesis_validation_result_fixture",
 )
+REAL_SOURCE_REPORT_KINDS: Final[tuple[str, ...]] = (
+    "screening_evidence",
+    "screening_results",
+    "exit_quality_diagnostics",
+    "candidate_readiness",
+    "qre_data_source_quality_readiness",
+    "source_quality_readiness",
+    "qre_research_diagnostics_loop",
+    "paper_divergence",
+    "trend_break_invalidation",
+    "no_paper_candidate_diagnostics",
+    "research_latest",
+    "run_candidates",
+)
 
 INPUT_ARTIFACT_RELATIVE_PATH: Final[str] = "logs/qre_validation_result_fixtures/latest.json"
 INPUT_ARTIFACT_PATH: Final[Path] = REPO_ROOT / INPUT_ARTIFACT_RELATIVE_PATH
-ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "qre_hypothesis_validation_results"
-OUTPUT_ARTIFACT_RELATIVE_PATH: Final[str] = (
-    "logs/qre_hypothesis_validation_results/latest.json"
+DEFAULT_HYPOTHESIS_ARTIFACT_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_hypothesis_candidates" / "latest.json"
 )
+DEFAULT_PLAN_ARTIFACT_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_hypothesis_validation_plans" / "latest.json"
+)
+DEFAULT_RUN_MANIFEST_ARTIFACT_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_research_run_manifest" / "latest.json"
+)
+DEFAULT_REAL_SOURCE_ARTIFACT_PATHS: Final[tuple[Path, ...]] = (
+    REPO_ROOT / "research" / "screening_evidence_latest.v1.json",
+    REPO_ROOT / "research" / "paper_divergence_latest.v1.json",
+    REPO_ROOT / "research" / "research_latest.json",
+    REPO_ROOT / "research" / "run_candidates_latest.v1.json",
+    REPO_ROOT / "logs" / "qre_data_source_quality_readiness" / "latest.json",
+    REPO_ROOT / "logs" / "qre_research_diagnostics_loop" / "latest.json",
+)
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "qre_hypothesis_validation_results"
+OUTPUT_ARTIFACT_RELATIVE_PATH: Final[str] = "logs/qre_hypothesis_validation_results/latest.json"
 ARTIFACT_LATEST: Final[Path] = REPO_ROOT / OUTPUT_ARTIFACT_RELATIVE_PATH
 
 STATUSES: Final[tuple[str, ...]] = ("passed", "failed", "inconclusive", "missing")
@@ -36,15 +65,12 @@ NOTE_INPUT_ABSENT: Final[str] = "validation_result_artifact_absent"
 NOTE_INPUT_UNPARSEABLE: Final[str] = "validation_result_artifact_unparseable"
 NOTE_NO_RESULTS: Final[str] = "no_validation_results_normalized"
 NOTE_RESULTS_PRESENT: Final[str] = "validation_results_present"
+NOTE_REAL_SOURCE_ROWS_SKIPPED: Final[str] = "real_source_rows_unlinked_skipped"
+NOTE_REAL_SOURCE_ARTIFACT_UNPARSEABLE: Final[str] = "real_source_artifact_unparseable"
 
 
 def _utcnow() -> str:
-    return (
-        _dt.datetime.now(_dt.UTC)
-        .replace(microsecond=0)
-        .isoformat()
-        .replace("+00:00", "Z")
-    )
+    return _dt.datetime.now(_dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
 def _rel(path: Path) -> str:
@@ -111,6 +137,12 @@ def _result_id(result: dict[str, Any]) -> str:
         return supplied
     seed = "|".join(
         [
+            _bounded_str(result.get("source_artifact"), max_len=240),
+            _bounded_str(result.get("source_report_kind"), max_len=120),
+            _bounded_str(
+                result.get("source_row_id") or result.get("source_ref"),
+                max_len=240,
+            ),
             _bounded_str(result.get("hypothesis_id"), max_len=160),
             _bounded_str(result.get("validation_plan_id"), max_len=160),
             _bounded_str(result.get("run_manifest_id"), max_len=160),
@@ -130,11 +162,341 @@ def _build_result(result: dict[str, Any]) -> dict[str, Any]:
         "metric_results": _metric_results(result.get("metric_results")),
         "falsification_hits": _str_list(result.get("falsification_hits")),
         "supporting_evidence_refs": _str_list(result.get("supporting_evidence_refs")),
-        "contradicting_evidence_refs": _str_list(
-            result.get("contradicting_evidence_refs")
-        ),
+        "contradicting_evidence_refs": _str_list(result.get("contradicting_evidence_refs")),
+        "source_artifact": _bounded_str(result.get("source_artifact"), max_len=240),
+        "source_report_kind": _bounded_str(result.get("source_report_kind"), max_len=120),
+        "source_row_id": _bounded_str(result.get("source_row_id"), max_len=240),
+        "source_ref": _bounded_str(result.get("source_ref"), max_len=300),
         "safe_to_execute": False,
     }
+
+
+def _safe_dict_rows(payload: dict[str, Any], field: str) -> list[dict[str, Any]] | None:
+    rows = payload.get(field)
+    if not isinstance(rows, list) or not all(isinstance(item, dict) for item in rows):
+        return None
+    return rows
+
+
+def _load_link_authorities(
+    *,
+    hypothesis_artifact_path: Path,
+    plan_artifact_path: Path,
+    run_manifest_artifact_path: Path,
+) -> tuple[dict[str, Any], list[str]]:
+    warnings: list[str] = []
+    hyp_available, hyp_payload = _read_json(hypothesis_artifact_path)
+    plan_available, plan_payload = _read_json(plan_artifact_path)
+    run_available, run_payload = _read_json(run_manifest_artifact_path)
+
+    hypotheses: list[dict[str, Any]] = []
+    plans: list[dict[str, Any]] = []
+    run_manifests: list[dict[str, Any]] = []
+    if hyp_payload is not None and hyp_payload.get("report_kind") == "qre_hypothesis_candidates":
+        hypotheses = _safe_dict_rows(hyp_payload, "hypotheses") or []
+    elif hyp_available:
+        warnings.append("hypothesis_authority_unparseable")
+    else:
+        warnings.append("hypothesis_authority_absent")
+    if (
+        plan_payload is not None
+        and plan_payload.get("report_kind") == "qre_hypothesis_validation_plan"
+    ):
+        plans = _safe_dict_rows(plan_payload, "validation_plans") or []
+    elif plan_available:
+        warnings.append("validation_plan_authority_unparseable")
+    else:
+        warnings.append("validation_plan_authority_absent")
+    if run_payload is not None and run_payload.get("report_kind") == "qre_research_run_manifest":
+        run_manifests = _safe_dict_rows(run_payload, "run_manifests") or []
+    elif run_available:
+        warnings.append("run_manifest_authority_unparseable")
+    else:
+        warnings.append("run_manifest_authority_absent")
+
+    hypothesis_ids = {
+        _bounded_str(item.get("hypothesis_id"), max_len=160)
+        for item in hypotheses
+        if _bounded_str(item.get("hypothesis_id"), max_len=160)
+    }
+    plan_by_hypothesis: dict[str, str] = {}
+    for item in plans:
+        hypothesis_id = _bounded_str(item.get("hypothesis_id"), max_len=160)
+        plan_id = _bounded_str(item.get("validation_plan_id"), max_len=160)
+        if hypothesis_id and plan_id:
+            plan_by_hypothesis.setdefault(hypothesis_id, plan_id)
+    run_by_plan: dict[str, str] = {}
+    for item in run_manifests:
+        plan_id = _bounded_str(item.get("target_validation_plan_id"), max_len=160)
+        run_id = _bounded_str(item.get("run_manifest_id"), max_len=160)
+        if plan_id and run_id:
+            run_by_plan.setdefault(plan_id, run_id)
+    return (
+        {
+            "hypothesis_ids": hypothesis_ids,
+            "plan_by_hypothesis": plan_by_hypothesis,
+            "run_by_plan": run_by_plan,
+        },
+        warnings,
+    )
+
+
+def _source_report_kind(payload: dict[str, Any], path: Path) -> str:
+    explicit = _bounded_str(payload.get("report_kind"), max_len=120)
+    if explicit:
+        return explicit
+    name = path.name
+    if name == "run_candidates_latest.v1.json":
+        return "run_candidates"
+    if isinstance(payload.get("candidates"), list):
+        return "screening_evidence"
+    if isinstance(payload.get("results"), list):
+        return "research_latest"
+    if isinstance(payload.get("per_candidate"), list) or payload.get("paper_divergence_version"):
+        return "paper_divergence"
+    return "unknown"
+
+
+def _rows_for_source(
+    payload: dict[str, Any], report_kind: str
+) -> tuple[str, list[dict[str, Any]] | None]:
+    if report_kind in {"screening_evidence", "run_candidates"}:
+        return ("candidates", _safe_dict_rows(payload, "candidates"))
+    if report_kind in {
+        "screening_results",
+        "exit_quality_diagnostics",
+        "candidate_readiness",
+        "source_quality_readiness",
+        "trend_break_invalidation",
+        "no_paper_candidate_diagnostics",
+    }:
+        for field in ("validation_results", "rows", "results", "diagnostics", "items"):
+            rows = _safe_dict_rows(payload, field)
+            if rows is not None:
+                return (field, rows)
+        return ("", None)
+    if report_kind == "qre_data_source_quality_readiness":
+        return ("rows", _safe_dict_rows(payload, "rows"))
+    if report_kind == "qre_research_diagnostics_loop":
+        return ("diagnostic_chain", _safe_dict_rows(payload, "diagnostic_chain"))
+    if report_kind == "paper_divergence":
+        return ("per_candidate", _safe_dict_rows(payload, "per_candidate"))
+    if report_kind == "research_latest":
+        return ("results", _safe_dict_rows(payload, "results"))
+    return ("", None)
+
+
+def _row_identity(row: dict[str, Any], *, index: int, row_field: str) -> str:
+    for key in (
+        "result_id",
+        "candidate_id",
+        "hypothesis_id",
+        "subject_id",
+        "path",
+        "strategy_id",
+    ):
+        value = _bounded_str(row.get(key), max_len=220)
+        if value:
+            return value
+    return f"{row_field}[{index}]"
+
+
+def _linked_ids(
+    row: dict[str, Any],
+    authorities: dict[str, Any],
+) -> tuple[str, str, str] | None:
+    hypothesis_id = _bounded_str(row.get("hypothesis_id"), max_len=160)
+    if not hypothesis_id:
+        hypothesis_id = _bounded_str(row.get("target_hypothesis_id"), max_len=160)
+    if hypothesis_id not in authorities["hypothesis_ids"]:
+        return None
+    plan_id = _bounded_str(row.get("validation_plan_id"), max_len=160)
+    if not plan_id:
+        plan_id = authorities["plan_by_hypothesis"].get(hypothesis_id, "")
+    if not plan_id:
+        return None
+    run_id = _bounded_str(row.get("run_manifest_id"), max_len=160)
+    if not run_id:
+        run_id = authorities["run_by_plan"].get(plan_id, "")
+    if not run_id:
+        return None
+    return (hypothesis_id, plan_id, run_id)
+
+
+def _status_from_source(row: dict[str, Any], report_kind: str) -> str:
+    explicit = _status(row.get("status"))
+    if explicit != "missing":
+        return explicit
+    lowered_values = {
+        _bounded_str(row.get(key), max_len=120).lower()
+        for key in (
+            "stage_result",
+            "quality_status",
+            "final_status",
+            "decision",
+            "verdict",
+            "divergence_severity",
+        )
+    }
+    if lowered_values & {
+        "screening_reject",
+        "paper_blocked",
+        "blocked",
+        "rejected",
+        "failed",
+        "high",
+    }:
+        return "failed"
+    if lowered_values & {"passed", "ready", "screening_pass", "promotion_candidate", "low"}:
+        return "passed"
+    if lowered_values & {"near_pass", "needs_investigation", "medium"}:
+        return "inconclusive"
+    if report_kind == "qre_data_source_quality_readiness":
+        return "passed" if row.get("quality_status") == "ready" else "failed"
+    return "inconclusive"
+
+
+def _metrics_from_source(row: dict[str, Any], report_kind: str) -> dict[str, Any]:
+    raw: dict[str, Any] = {}
+    if isinstance(row.get("metrics"), dict):
+        raw.update(row["metrics"])
+    if isinstance(row.get("metric_results"), dict):
+        raw.update(row["metric_results"])
+    if isinstance(row.get("summary"), dict):
+        raw.update({f"summary.{key}": value for key, value in row["summary"].items()})
+    for key in (
+        "stage_result",
+        "pass_kind",
+        "screening_phase",
+        "quality_status",
+        "identity_confidence",
+        "row_count",
+        "manifest_status",
+        "divergence_severity",
+        "n_full_fills",
+        "evidence_count",
+        "failure_classification",
+    ):
+        if key in row:
+            raw[key] = row.get(key)
+    if report_kind == "paper_divergence" and isinstance(row.get("metrics_delta"), dict):
+        for key, value in row["metrics_delta"].items():
+            raw[f"metrics_delta.{key}"] = value
+    return _metric_results(raw)
+
+
+def _falsification_hits_from_source(row: dict[str, Any]) -> list[str]:
+    hits: list[str] = []
+    for key in ("falsification_hits", "failure_reasons", "blocking_reasons"):
+        hits.extend(_str_list(row.get(key)))
+    promotion_guard = row.get("promotion_guard")
+    if isinstance(promotion_guard, dict):
+        hits.extend(_str_list(promotion_guard.get("blocked_by")))
+    near_pass = row.get("near_pass")
+    if isinstance(near_pass, dict) and near_pass.get("is_near_pass"):
+        nearest = _bounded_str(near_pass.get("nearest_failed_criterion"), max_len=120)
+        hits.append(nearest or "near_pass")
+    if row.get("divergence_severity") == "high":
+        hits.append("paper_divergence_high")
+    return sorted({hit for hit in hits if hit})
+
+
+def _refs_from_source(
+    row: dict[str, Any],
+    *,
+    source_artifact: str,
+    source_row_id: str,
+) -> tuple[list[str], list[str]]:
+    source_ref = f"{source_artifact}#{source_row_id}"
+    supporting = _str_list(row.get("supporting_evidence_refs"))
+    contradicting = _str_list(row.get("contradicting_evidence_refs"))
+    if not supporting:
+        supporting = [source_ref]
+    if _falsification_hits_from_source(row) and not contradicting:
+        contradicting = [source_ref]
+    return (supporting, contradicting)
+
+
+def _build_real_source_result(
+    row: dict[str, Any],
+    *,
+    row_index: int,
+    row_field: str,
+    source_artifact: str,
+    source_report_kind: str,
+    authorities: dict[str, Any],
+) -> dict[str, Any] | None:
+    linked = _linked_ids(row, authorities)
+    if linked is None:
+        return None
+    hypothesis_id, plan_id, run_id = linked
+    source_row_id = _row_identity(row, index=row_index, row_field=row_field)
+    supporting, contradicting = _refs_from_source(
+        row,
+        source_artifact=source_artifact,
+        source_row_id=source_row_id,
+    )
+    result = {
+        "hypothesis_id": hypothesis_id,
+        "validation_plan_id": plan_id,
+        "run_manifest_id": run_id,
+        "status": _status_from_source(row, source_report_kind),
+        "metric_results": _metrics_from_source(row, source_report_kind),
+        "falsification_hits": _falsification_hits_from_source(row),
+        "supporting_evidence_refs": supporting,
+        "contradicting_evidence_refs": contradicting,
+        "source_artifact": source_artifact,
+        "source_report_kind": source_report_kind,
+        "source_row_id": source_row_id,
+        "source_ref": f"{source_artifact}#{source_row_id}",
+    }
+    return _build_result(result)
+
+
+def _collect_real_source_results(
+    *,
+    source_artifact_paths: list[Path],
+    hypothesis_artifact_path: Path,
+    plan_artifact_path: Path,
+    run_manifest_artifact_path: Path,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    authorities, warnings = _load_link_authorities(
+        hypothesis_artifact_path=hypothesis_artifact_path,
+        plan_artifact_path=plan_artifact_path,
+        run_manifest_artifact_path=run_manifest_artifact_path,
+    )
+    validation_results: list[dict[str, Any]] = []
+    skipped_unlinked = 0
+    for source in source_artifact_paths:
+        available, payload = _read_json(source)
+        if payload is None:
+            if available:
+                warnings.append(f"{NOTE_REAL_SOURCE_ARTIFACT_UNPARSEABLE}:{_rel(source)}")
+            continue
+        report_kind = _source_report_kind(payload, source)
+        if report_kind not in REAL_SOURCE_REPORT_KINDS:
+            warnings.append(f"real_source_artifact_unsupported:{_rel(source)}")
+            continue
+        row_field, rows = _rows_for_source(payload, report_kind)
+        if rows is None:
+            warnings.append(f"{NOTE_REAL_SOURCE_ARTIFACT_UNPARSEABLE}:{_rel(source)}")
+            continue
+        for index, row in enumerate(rows):
+            result = _build_real_source_result(
+                row,
+                row_index=index,
+                row_field=row_field,
+                source_artifact=_rel(source),
+                source_report_kind=report_kind,
+                authorities=authorities,
+            )
+            if result is None:
+                skipped_unlinked += 1
+                continue
+            validation_results.append(result)
+    if skipped_unlinked:
+        warnings.append(f"{NOTE_REAL_SOURCE_ROWS_SKIPPED}:{skipped_unlinked}")
+    return (validation_results, warnings)
 
 
 def _empty_counts() -> dict[str, Any]:
@@ -190,12 +552,38 @@ def _base_snapshot(
 def collect_snapshot(
     *,
     input_artifact_path: Path | None = None,
+    source_artifact_paths: list[Path] | None = None,
+    hypothesis_artifact_path: Path | None = None,
+    plan_artifact_path: Path | None = None,
+    run_manifest_artifact_path: Path | None = None,
     generated_at_utc: str | None = None,
 ) -> dict[str, Any]:
     generated = generated_at_utc or _utcnow()
     source = input_artifact_path or INPUT_ARTIFACT_PATH
     available, payload = _read_json(source)
     if payload is None:
+        if input_artifact_path is None:
+            validation_results, validation_warnings = _collect_real_source_results(
+                source_artifact_paths=list(
+                    source_artifact_paths or DEFAULT_REAL_SOURCE_ARTIFACT_PATHS
+                ),
+                hypothesis_artifact_path=(
+                    hypothesis_artifact_path or DEFAULT_HYPOTHESIS_ARTIFACT_PATH
+                ),
+                plan_artifact_path=plan_artifact_path or DEFAULT_PLAN_ARTIFACT_PATH,
+                run_manifest_artifact_path=(
+                    run_manifest_artifact_path or DEFAULT_RUN_MANIFEST_ARTIFACT_PATH
+                ),
+            )
+            validation_results.sort(key=lambda item: item["result_id"])
+            return _base_snapshot(
+                generated_at_utc=generated,
+                input_artifact_path=source,
+                input_artifact_available=available,
+                note=NOTE_RESULTS_PRESENT if validation_results else NOTE_NO_RESULTS,
+                validation_results=validation_results,
+                validation_warnings=validation_warnings,
+            )
         note = NOTE_INPUT_UNPARSEABLE if available else NOTE_INPUT_ABSENT
         return _base_snapshot(
             generated_at_utc=generated,
@@ -298,9 +686,14 @@ __all__ = [
     "ARTIFACT_DIR",
     "ARTIFACT_LATEST",
     "ACCEPTED_INPUT_REPORT_KINDS",
+    "DEFAULT_HYPOTHESIS_ARTIFACT_PATH",
+    "DEFAULT_PLAN_ARTIFACT_PATH",
+    "DEFAULT_REAL_SOURCE_ARTIFACT_PATHS",
+    "DEFAULT_RUN_MANIFEST_ARTIFACT_PATH",
     "INPUT_ARTIFACT_PATH",
     "INPUT_ARTIFACT_RELATIVE_PATH",
     "OUTPUT_ARTIFACT_RELATIVE_PATH",
+    "REAL_SOURCE_REPORT_KINDS",
     "REPORT_KIND",
     "SCHEMA_VERSION",
     "STATUSES",

--- a/reporting/qre_trusted_loop_readiness.py
+++ b/reporting/qre_trusted_loop_readiness.py
@@ -55,12 +55,7 @@ NOTE_READINESS_EVALUATED: Final[str] = "trusted_loop_readiness_evaluated"
 
 
 def _utcnow() -> str:
-    return (
-        _dt.datetime.now(_dt.UTC)
-        .replace(microsecond=0)
-        .isoformat()
-        .replace("+00:00", "Z")
-    )
+    return _dt.datetime.now(_dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
 def _rel(path: Path) -> str:
@@ -158,9 +153,7 @@ def _repeatability_status(
 ) -> str:
     approved = bool(
         operator_payload
-        and operator_payload.get("operator_report", {}).get(
-            "operator_approved_for_trusted_loop"
-        )
+        and operator_payload.get("operator_report", {}).get("operator_approved_for_trusted_loop")
     )
     repeatability_refs = [
         item.get("repeatability_evidence_refs")
@@ -175,11 +168,51 @@ def _repeatability_status(
     return "no_repeatability_evidence"
 
 
+def _source_lineage_status(
+    results: list[dict[str, Any]],
+    updates: list[dict[str, Any]],
+) -> dict[str, Any]:
+    if not results and not updates:
+        return {
+            "status": "missing",
+            "results_with_lineage": 0,
+            "updates_with_lineage": 0,
+        }
+    results_with_lineage = sum(
+        1
+        for item in results
+        if item.get("source_artifact")
+        and item.get("source_report_kind")
+        and (item.get("source_row_id") or item.get("source_ref"))
+    )
+    updates_with_lineage = sum(
+        1
+        for item in updates
+        if item.get("source_artifact")
+        and item.get("source_report_kind")
+        and (item.get("source_row_id") or item.get("source_ref"))
+    )
+    status = (
+        "complete"
+        if results_with_lineage == len(results)
+        and updates_with_lineage == len(updates)
+        and bool(results)
+        and bool(updates)
+        else "incomplete"
+    )
+    return {
+        "status": status,
+        "results_with_lineage": results_with_lineage,
+        "updates_with_lineage": updates_with_lineage,
+    }
+
+
 def _state(
     *,
     input_warnings: list[str],
     density: dict[str, int],
     contradiction_visibility: dict[str, Any],
+    source_lineage: dict[str, Any],
     operator_report_available: bool,
     repeatability_status: str,
 ) -> tuple[str, list[str], list[str]]:
@@ -214,6 +247,9 @@ def _state(
         return ("scaffold", blockers, warnings)
     if not contradiction_visible:
         blockers.append("contradiction_visibility_incomplete")
+        return ("working_capability", blockers, warnings)
+    if source_lineage["status"] != "complete":
+        blockers.append("source_lineage_incomplete")
         return ("working_capability", blockers, warnings)
     if repeatability_status == "operator_approved_repeatability_evidence_present":
         return ("operator_trusted", blockers, warnings)
@@ -303,11 +339,13 @@ def collect_snapshot(
     )
     contradiction = _contradiction_visibility(updates)
     repeatability = _repeatability_status(results, operator_payload)
+    source_lineage = _source_lineage_status(results, updates)
     operator_report_available = bool(meta_h["valid"])
     readiness_state, blockers, warnings = _state(
         input_warnings=input_warnings,
         density=density,
         contradiction_visibility=contradiction,
+        source_lineage=source_lineage,
         operator_report_available=operator_report_available,
         repeatability_status=repeatability,
     )
@@ -325,6 +363,7 @@ def collect_snapshot(
         and density["evidence_updates"] > 0,
         "operator_report_available": operator_report_available,
         "contradiction_visibility_available": contradiction["status"] == "visible",
+        "source_lineage_status": source_lineage["status"],
         "repeatability_status": repeatability,
     }
     return {
@@ -338,6 +377,7 @@ def collect_snapshot(
         "warnings": warnings,
         "evidence_density": density,
         "contradiction_visibility": contradiction,
+        "source_lineage": source_lineage,
         "repeatability_status": repeatability,
         "operator_report_available": operator_report_available,
         "input_artifacts": {

--- a/tests/unit/test_qre_closed_loop_materialization_runner.py
+++ b/tests/unit/test_qre_closed_loop_materialization_runner.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from reporting import qre_closed_loop_materialization_runner as runner
+
+
+FROZEN = "2026-06-01T12:00:00Z"
+
+
+def _fake_module(name: str, report_kind: str, out_dir: Path, calls: list[str]):
+    latest = out_dir / report_kind / "latest.json"
+
+    def collect_snapshot(*, generated_at_utc: str | None = None) -> dict:
+        calls.append(f"collect:{report_kind}:{generated_at_utc}")
+        return {
+            "schema_version": 1,
+            "report_kind": report_kind,
+            "generated_at_utc": generated_at_utc,
+            "counts": {"total": 1},
+            "final_recommendation": f"{report_kind}_ready",
+            "validation_warnings": [],
+            "safe_to_execute": False,
+        }
+
+    def write_outputs(snapshot: dict) -> Path:
+        calls.append(f"write:{report_kind}")
+        latest.parent.mkdir(parents=True, exist_ok=True)
+        latest.write_text(json.dumps(snapshot), encoding="utf-8")
+        return latest
+
+    return SimpleNamespace(
+        __name__=name,
+        collect_snapshot=collect_snapshot,
+        write_outputs=write_outputs,
+    )
+
+
+def _fake_modules(tmp_path: Path, calls: list[str]):
+    names = [
+        "qre_market_observation_snapshot",
+        "qre_hypothesis_candidates",
+        "qre_observation_hypothesis_projector",
+        "qre_hypothesis_validation_plan",
+        "qre_validation_research_action_candidates",
+        "qre_research_run_manifest",
+        "qre_hypothesis_validation_results",
+        "qre_hypothesis_evidence_update",
+        "qre_closed_loop_operator_report",
+        "qre_trusted_loop_readiness",
+    ]
+    return tuple(
+        _fake_module(f"reporting.{name}", name, tmp_path / "logs", calls) for name in names
+    )
+
+
+def _assert_safety_flags_false(snapshot: dict) -> None:
+    for key in (
+        "safe_to_execute",
+        "writes_development_work_queue",
+        "writes_seed_jsonl",
+        "writes_generated_seed_jsonl",
+        "writes_research_action_queue",
+        "mutates_campaign_queue",
+        "mutates_strategy_or_preset",
+        "mutates_paper_shadow_live_runtime",
+        "launches_codex",
+        "eligible_for_direct_execution",
+    ):
+        assert snapshot[key] is False
+
+
+def test_no_write_mode_collects_in_exact_step_order_without_module_writes(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    calls: list[str] = []
+    fake_modules = _fake_modules(tmp_path, calls)
+    monkeypatch.setattr(runner, "STEP_MODULES", fake_modules)
+
+    snap = runner.collect_snapshot(no_write=True, generated_at_utc=FROZEN)
+
+    assert [step["report_kind"] for step in snap["steps"]] == [
+        "qre_market_observation_snapshot",
+        "qre_hypothesis_candidates",
+        "qre_observation_hypothesis_projector",
+        "qre_hypothesis_validation_plan",
+        "qre_validation_research_action_candidates",
+        "qre_research_run_manifest",
+        "qre_hypothesis_validation_results",
+        "qre_hypothesis_evidence_update",
+        "qre_closed_loop_operator_report",
+        "qre_trusted_loop_readiness",
+    ]
+    assert all(call.startswith("collect:") for call in calls)
+    assert all(step["artifact_path"] is None for step in snap["steps"])
+    _assert_safety_flags_false(snap)
+
+
+def test_write_mode_uses_module_write_outputs_and_runner_artifact_only_for_runner(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    calls: list[str] = []
+    fake_modules = _fake_modules(tmp_path, calls)
+    materialization_dir = tmp_path / "logs" / "qre_closed_loop_materialization"
+    monkeypatch.setattr(runner, "STEP_MODULES", fake_modules)
+    monkeypatch.setattr(runner, "ARTIFACT_DIR", materialization_dir)
+    monkeypatch.setattr(runner, "ARTIFACT_LATEST", materialization_dir / "latest.json")
+
+    snap = runner.collect_snapshot(no_write=False, generated_at_utc=FROZEN)
+    out = runner.write_outputs(snap)
+
+    assert out == materialization_dir / "latest.json"
+    assert out.exists()
+    assert calls.count("write:qre_market_observation_snapshot") == 1
+    written = sorted(path.relative_to(tmp_path).as_posix() for path in tmp_path.rglob("*.json"))
+    assert "logs/qre_closed_loop_materialization/latest.json" in written
+    assert all(path.startswith("logs/qre_") for path in written)
+    _assert_safety_flags_false(snap)
+
+
+def test_cli_no_write_does_not_write_runner_artifact(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    calls: list[str] = []
+    fake_modules = _fake_modules(tmp_path, calls)
+    materialization_dir = tmp_path / "logs" / "qre_closed_loop_materialization"
+    monkeypatch.setattr(runner, "STEP_MODULES", fake_modules)
+    monkeypatch.setattr(runner, "ARTIFACT_DIR", materialization_dir)
+    monkeypatch.setattr(runner, "ARTIFACT_LATEST", materialization_dir / "latest.json")
+
+    rc = runner.main(["--no-write", "--frozen-utc", FROZEN, "--indent", "0"])
+
+    assert rc == 0
+    assert (materialization_dir / "latest.json").exists() is False
+    parsed = json.loads(capsys.readouterr().out)
+    assert parsed["safe_to_execute"] is False
+    assert all(call.startswith("collect:") for call in calls)
+
+
+def test_atomic_write_refuses_outside_artifact_dir(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        runner._atomic_write_json(tmp_path / "latest.json", {"x": 1})
+
+
+def test_source_has_no_runtime_launch_or_network_calls() -> None:
+    src = Path(runner.__file__).read_text(encoding="utf-8")
+    forbidden = (
+        "import subprocess",
+        "from subprocess",
+        "subprocess.",
+        "import socket",
+        "from socket",
+        "import requests",
+        "import httpx",
+        "import aiohttp",
+        "import urllib",
+        "from urllib",
+        "os.system",
+        "os.popen",
+        "shell=True",
+        "git ",
+        "gh ",
+        "codex ",
+    )
+    for token in forbidden:
+        assert token not in src, token
+
+
+def test_source_does_not_write_active_or_mutating_paths() -> None:
+    src = Path(runner.__file__).read_text(encoding="utf-8")
+    forbidden = (
+        "seed.jsonl",
+        "generated_seed.jsonl",
+        "logs/development_work_queue/latest.json",
+        "research/research_action_queue_latest.v1.json",
+        "campaigns/",
+        "agent/backtesting/strategies.py",
+        "registry.py",
+        "paper/",
+        "shadow/",
+        "live/",
+    )
+    for token in forbidden:
+        assert token not in src, token

--- a/tests/unit/test_qre_closed_loop_operator_report.py
+++ b/tests/unit/test_qre_closed_loop_operator_report.py
@@ -201,6 +201,102 @@ def test_deterministic_output_with_injected_timestamp(tmp_path: Path) -> None:
     assert op["validation_results"][0]["result_id"] == "qre-result-fixture-001"
     assert op["evidence_updates"][0]["evidence_decision"] == "supported"
     assert "approve_or_reject_pending_run_manifests" in op["operator_decisions_required"]
+    assert op["top_supported_hypotheses"][0]["hypothesis_id"] == "qre-hyp-fixture-001"
+    assert op["top_falsified_hypotheses"] == []
+    assert op["needs_more_data_hypotheses"] == []
+    assert op["contradiction_hypotheses"] == []
+    assert op["missing_validation_results"] == []
+    assert op["why_auto_execution_is_forbidden"]
+    assert op["next_manual_actions"] == ["review_evidence_lineage_before_any_follow_up"]
+
+
+def test_operator_report_buckets_all_evidence_decisions(tmp_path: Path) -> None:
+    paths = _artifact_set(tmp_path)
+    paths["hypotheses"] = _write_payload(
+        tmp_path / "hypotheses_multi.json",
+        "qre_hypothesis_candidates",
+        "hypotheses",
+        [
+            {"hypothesis_id": "hyp-supported", "title": "Supported"},
+            {"hypothesis_id": "hyp-falsified", "title": "Falsified"},
+            {"hypothesis_id": "hyp-more", "title": "Needs more"},
+            {"hypothesis_id": "hyp-contradiction", "title": "Contradiction"},
+            {"hypothesis_id": "hyp-missing", "title": "Missing"},
+        ],
+    )
+    paths["plans"] = _write_payload(
+        tmp_path / "plans_multi.json",
+        "qre_hypothesis_validation_plan",
+        "validation_plans",
+        [
+            {"validation_plan_id": f"plan-{idx}", "hypothesis_id": hypothesis_id}
+            for idx, hypothesis_id in enumerate(
+                [
+                    "hyp-supported",
+                    "hyp-falsified",
+                    "hyp-more",
+                    "hyp-contradiction",
+                    "hyp-missing",
+                ]
+            )
+        ],
+    )
+    paths["results"] = _write_payload(
+        tmp_path / "results_multi.json",
+        "qre_hypothesis_validation_results",
+        "validation_results",
+        [
+            {"result_id": "result-supported", "hypothesis_id": "hyp-supported"},
+            {"result_id": "result-falsified", "hypothesis_id": "hyp-falsified"},
+            {"result_id": "result-more", "hypothesis_id": "hyp-more"},
+            {"result_id": "result-contradiction", "hypothesis_id": "hyp-contradiction"},
+        ],
+    )
+    paths["updates"] = _write_payload(
+        tmp_path / "updates_multi.json",
+        "qre_hypothesis_evidence_update",
+        "evidence_updates",
+        [
+            {
+                "evidence_update_id": "update-supported",
+                "hypothesis_id": "hyp-supported",
+                "evidence_decision": "supported",
+                "supporting_evidence_refs": ["source#supported"],
+                "contradicting_evidence_refs": [],
+            },
+            {
+                "evidence_update_id": "update-falsified",
+                "hypothesis_id": "hyp-falsified",
+                "evidence_decision": "falsified",
+                "supporting_evidence_refs": [],
+                "contradicting_evidence_refs": ["source#falsified"],
+            },
+            {
+                "evidence_update_id": "update-more",
+                "hypothesis_id": "hyp-more",
+                "evidence_decision": "needs_more_data",
+                "supporting_evidence_refs": [],
+                "contradicting_evidence_refs": [],
+            },
+            {
+                "evidence_update_id": "update-contradiction",
+                "hypothesis_id": "hyp-contradiction",
+                "evidence_decision": "contradiction_detected",
+                "supporting_evidence_refs": ["source#support"],
+                "contradicting_evidence_refs": ["source#contradiction"],
+            },
+        ],
+    )
+
+    snap = _collect(paths)
+    op = snap["operator_report"]
+
+    assert [row["hypothesis_id"] for row in op["top_supported_hypotheses"]] == ["hyp-supported"]
+    assert [row["hypothesis_id"] for row in op["top_falsified_hypotheses"]] == ["hyp-falsified"]
+    assert [row["hypothesis_id"] for row in op["needs_more_data_hypotheses"]] == ["hyp-more"]
+    assert [row["hypothesis_id"] for row in op["contradiction_hypotheses"]] == ["hyp-contradiction"]
+    assert [row["hypothesis_id"] for row in op["missing_validation_results"]] == ["hyp-missing"]
+    assert "provide_or_accept_missing_validation_results" in op["operator_decisions_required"]
 
 
 def test_atomic_write_refuses_outside_artifact_dir(tmp_path: Path) -> None:

--- a/tests/unit/test_qre_hypothesis_validation_results.py
+++ b/tests/unit/test_qre_hypothesis_validation_results.py
@@ -39,6 +39,50 @@ def _write_results(path: Path, rows: list[dict], **overrides) -> Path:
     return path
 
 
+def _write_authorities(tmp_path: Path) -> dict[str, Path]:
+    hypothesis_id = "qre-hyp-fixture-001"
+    plan_id = "qre-plan-fixture-001"
+    run_id = "qre-run-fixture-001"
+    hypotheses = tmp_path / "hypotheses.json"
+    plans = tmp_path / "plans.json"
+    manifests = tmp_path / "run_manifests.json"
+    hypotheses.write_text(
+        json.dumps(
+            {
+                "report_kind": "qre_hypothesis_candidates",
+                "hypotheses": [{"hypothesis_id": hypothesis_id}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    plans.write_text(
+        json.dumps(
+            {
+                "report_kind": "qre_hypothesis_validation_plan",
+                "validation_plans": [
+                    {"hypothesis_id": hypothesis_id, "validation_plan_id": plan_id}
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    manifests.write_text(
+        json.dumps(
+            {
+                "report_kind": "qre_research_run_manifest",
+                "run_manifests": [
+                    {
+                        "run_manifest_id": run_id,
+                        "target_validation_plan_id": plan_id,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return {"hypotheses": hypotheses, "plans": plans, "manifests": manifests}
+
+
 def _assert_safety_flags_false(snapshot: dict) -> None:
     for key in (
         "safe_to_execute",
@@ -93,6 +137,133 @@ def test_deterministic_output_with_injected_timestamp(tmp_path: Path) -> None:
     assert row["metric_results"]["trade_count"] == 120
     assert row["supporting_evidence_refs"] == ["fixture#support"]
     assert row["safe_to_execute"] is False
+
+
+def test_real_source_screening_evidence_maps_linked_rows(tmp_path: Path) -> None:
+    authorities = _write_authorities(tmp_path)
+    source = tmp_path / "screening_evidence_latest.v1.json"
+    source.write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0",
+                "candidates": [
+                    {
+                        "candidate_id": "candidate-001",
+                        "hypothesis_id": "qre-hyp-fixture-001",
+                        "stage_result": "screening_reject",
+                        "metrics": {"profit_factor": 0.8, "totaal_trades": 42},
+                        "failure_reasons": ["profit_factor_below_floor"],
+                    }
+                ],
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    snap = results.collect_snapshot(
+        source_artifact_paths=[source],
+        hypothesis_artifact_path=authorities["hypotheses"],
+        plan_artifact_path=authorities["plans"],
+        run_manifest_artifact_path=authorities["manifests"],
+        generated_at_utc=FROZEN,
+    )
+
+    row = snap["validation_results"][0]
+    assert row["hypothesis_id"] == "qre-hyp-fixture-001"
+    assert row["validation_plan_id"] == "qre-plan-fixture-001"
+    assert row["run_manifest_id"] == "qre-run-fixture-001"
+    assert row["status"] == "failed"
+    assert row["metric_results"]["profit_factor"] == 0.8
+    assert row["falsification_hits"] == ["profit_factor_below_floor"]
+    assert row["source_artifact"].endswith("screening_evidence_latest.v1.json")
+    assert row["source_report_kind"] == "screening_evidence"
+    assert row["source_row_id"] == "candidate-001"
+    assert row["source_ref"].endswith("#candidate-001")
+    assert row["safe_to_execute"] is False
+
+
+def test_real_source_unlinked_rows_are_skipped_with_warning(tmp_path: Path) -> None:
+    authorities = _write_authorities(tmp_path)
+    source = tmp_path / "screening_evidence_latest.v1.json"
+    source.write_text(
+        json.dumps({"candidates": [{"candidate_id": "candidate-001"}]}),
+        encoding="utf-8",
+    )
+
+    snap = results.collect_snapshot(
+        source_artifact_paths=[source],
+        hypothesis_artifact_path=authorities["hypotheses"],
+        plan_artifact_path=authorities["plans"],
+        run_manifest_artifact_path=authorities["manifests"],
+        generated_at_utc=FROZEN,
+    )
+
+    assert snap["validation_results"] == []
+    assert f"{results.NOTE_REAL_SOURCE_ROWS_SKIPPED}:1" in snap["validation_warnings"]
+
+
+def test_real_source_lineage_and_ids_are_deterministic(tmp_path: Path) -> None:
+    authorities = _write_authorities(tmp_path)
+    source = tmp_path / "screening_evidence_latest.v1.json"
+    source.write_text(
+        json.dumps(
+            {
+                "candidates": [
+                    {
+                        "candidate_id": "candidate-001",
+                        "hypothesis_id": "qre-hyp-fixture-001",
+                        "stage_result": "screening_pass",
+                        "metrics": {"profit_factor": 1.4},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    snap_a = results.collect_snapshot(
+        source_artifact_paths=[source],
+        hypothesis_artifact_path=authorities["hypotheses"],
+        plan_artifact_path=authorities["plans"],
+        run_manifest_artifact_path=authorities["manifests"],
+        generated_at_utc=FROZEN,
+    )
+    snap_b = results.collect_snapshot(
+        source_artifact_paths=[source],
+        hypothesis_artifact_path=authorities["hypotheses"],
+        plan_artifact_path=authorities["plans"],
+        run_manifest_artifact_path=authorities["manifests"],
+        generated_at_utc=FROZEN,
+    )
+
+    assert (
+        snap_a["validation_results"][0]["result_id"] == snap_b["validation_results"][0]["result_id"]
+    )
+    assert (
+        snap_a["validation_results"][0]["source_ref"]
+        == snap_b["validation_results"][0]["source_ref"]
+    )
+
+
+def test_real_source_malformed_artifact_fails_closed(tmp_path: Path) -> None:
+    authorities = _write_authorities(tmp_path)
+    source = tmp_path / "screening_evidence_latest.v1.json"
+    source.write_text("{", encoding="utf-8")
+
+    snap = results.collect_snapshot(
+        source_artifact_paths=[source],
+        hypothesis_artifact_path=authorities["hypotheses"],
+        plan_artifact_path=authorities["plans"],
+        run_manifest_artifact_path=authorities["manifests"],
+        generated_at_utc=FROZEN,
+    )
+
+    assert snap["validation_results"] == []
+    assert any(
+        results.NOTE_REAL_SOURCE_ARTIFACT_UNPARSEABLE in item
+        for item in snap["validation_warnings"]
+    )
 
 
 def test_atomic_write_refuses_outside_artifact_dir(tmp_path: Path) -> None:

--- a/tests/unit/test_qre_trusted_loop_readiness.py
+++ b/tests/unit/test_qre_trusted_loop_readiness.py
@@ -89,6 +89,10 @@ def _artifact_set(tmp_path: Path, *, with_results: bool = True) -> dict[str, Pat
                 {
                     "result_id": "qre-result-fixture-001",
                     "hypothesis_id": "qre-hyp-fixture-001",
+                    "source_artifact": "fixture/results.json",
+                    "source_report_kind": "fixture",
+                    "source_row_id": "result-001",
+                    "source_ref": "fixture/results.json#result-001",
                     "safe_to_execute": False,
                 }
             ]
@@ -105,6 +109,10 @@ def _artifact_set(tmp_path: Path, *, with_results: bool = True) -> dict[str, Pat
                     "hypothesis_id": "qre-hyp-fixture-001",
                     "evidence_decision": "supported",
                     "contradicting_evidence_refs": [],
+                    "source_artifact": "fixture/results.json",
+                    "source_report_kind": "fixture",
+                    "source_row_id": "result-001",
+                    "source_ref": "fixture/results.json#result-001",
                     "safe_to_execute": False,
                 }
             ]
@@ -211,6 +219,7 @@ def test_deterministic_output_with_injected_timestamp(tmp_path: Path) -> None:
     assert snap_a["readiness_state"] == "operator_trusted_candidate"
     assert snap_a["evidence_density"]["validation_results"] == 1
     assert snap_a["contradiction_visibility"]["status"] == "visible"
+    assert snap_a["source_lineage"]["status"] == "complete"
     assert snap_a["operator_report_available"] is True
 
 
@@ -233,6 +242,10 @@ def test_operator_trusted_requires_repeatability_and_approval(tmp_path: Path) ->
                     {
                         "result_id": "qre-result-fixture-001",
                         "hypothesis_id": "qre-hyp-fixture-001",
+                        "source_artifact": "fixture/results.json",
+                        "source_report_kind": "fixture",
+                        "source_row_id": "result-001",
+                        "source_ref": "fixture/results.json#result-001",
                         "repeatability_evidence_refs": ["fixture#repeatability"],
                         "safe_to_execute": False,
                     }
@@ -254,11 +267,73 @@ def test_operator_trusted_requires_repeatability_and_approval(tmp_path: Path) ->
         ),
         encoding="utf-8",
     )
+    paths["updates"].write_text(
+        json.dumps(
+            {
+                "report_kind": "qre_hypothesis_evidence_update",
+                "evidence_updates": [
+                    {
+                        "evidence_update_id": "qre-evidence-fixture-001",
+                        "hypothesis_id": "qre-hyp-fixture-001",
+                        "evidence_decision": "supported",
+                        "contradicting_evidence_refs": [],
+                        "source_artifact": "fixture/results.json",
+                        "source_report_kind": "fixture",
+                        "source_row_id": "result-001",
+                        "source_ref": "fixture/results.json#result-001",
+                        "safe_to_execute": False,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
 
     snap = _collect(paths)
 
     assert snap["readiness_state"] == "operator_trusted"
     assert snap["repeatability_status"] == "operator_approved_repeatability_evidence_present"
+
+
+def test_evidence_without_source_lineage_is_not_trusted(tmp_path: Path) -> None:
+    paths = _artifact_set(tmp_path)
+    paths["results"].write_text(
+        json.dumps(
+            {
+                "report_kind": "qre_hypothesis_validation_results",
+                "validation_results": [
+                    {
+                        "result_id": "qre-result-fixture-001",
+                        "hypothesis_id": "qre-hyp-fixture-001",
+                        "safe_to_execute": False,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    paths["updates"].write_text(
+        json.dumps(
+            {
+                "report_kind": "qre_hypothesis_evidence_update",
+                "evidence_updates": [
+                    {
+                        "evidence_update_id": "qre-evidence-fixture-001",
+                        "hypothesis_id": "qre-hyp-fixture-001",
+                        "evidence_decision": "supported",
+                        "contradicting_evidence_refs": [],
+                        "safe_to_execute": False,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    snap = _collect(paths)
+
+    assert snap["readiness_state"] == "working_capability"
+    assert "source_lineage_incomplete" in snap["blockers"]
 
 
 def test_atomic_write_refuses_outside_artifact_dir(tmp_path: Path) -> None:
@@ -497,7 +572,7 @@ def test_integration_synthetic_closed_loop_to_readiness(
     assert result_snap["validation_results"][0]["safe_to_execute"] is False
     assert evidence_snap["evidence_updates"][0]["safe_to_execute"] is False
     assert report_snap["operator_report"]["safe_to_execute"] is False
-    assert readiness_snap["readiness_state"] == "operator_trusted_candidate"
+    assert readiness_snap["readiness_state"] == "working_capability"
     assert readiness_snap["readiness_state"] != "operator_trusted"
 
     allowed_dirs = {


### PR DESCRIPTION
Adds real-source validation-result wiring, a closed-loop materialization runner, and operator usability hardening for the QRE closed-loop scaffold.

Summary:
- Extends qre_hypothesis_validation_results with conservative adapters for existing local research/diagnostic artifacts
- Preserves source lineage and deterministic validation-result IDs
- Adds reporting/qre_closed_loop_materialization_runner.py
- Adds tests/unit/test_qre_closed_loop_materialization_runner.py
- Hardens closed-loop operator report buckets and readiness explanations
- Keeps readiness conservative; no trusted state is introduced by thin/missing evidence
- Runner imports modules and calls collect_snapshot/write_outputs directly; it does not use subprocess or CLI execution
- Generated logs remain uncommitted

Validation:
- python -m pytest tests/unit/test_qre_hypothesis_validation_results.py tests/unit/test_qre_closed_loop_materialization_runner.py tests/unit/test_qre_closed_loop_operator_report.py tests/unit/test_qre_trusted_loop_readiness.py -q
  - 36 passed
- python -m pytest tests/unit/test_qre_market_observation_snapshot.py tests/unit/test_qre_hypothesis_candidates.py tests/unit/test_qre_observation_hypothesis_projector.py tests/unit/test_qre_hypothesis_validation_plan.py tests/unit/test_qre_validation_research_action_candidates.py -q
  - 39 passed
- python -m pytest tests/unit/test_qre_research_run_manifest.py tests/unit/test_qre_hypothesis_validation_results.py tests/unit/test_qre_hypothesis_evidence_update.py tests/unit/test_qre_closed_loop_operator_report.py tests/unit/test_qre_trusted_loop_readiness.py -q
  - 45 passed
- python -m pytest tests/unit/test_qre_research_action_consumer_gate.py tests/unit/test_qre_development_intake_promotion.py tests/unit/test_qre_development_queue_admission_policy.py -q
  - 53 passed
- Import smoke: imports_ok
- Runner no-write smoke: 10 steps, safe_to_execute=false, all mutation/write flags false

Safety:
- No research execution
- No subprocess/shell/os.system command runner
- No Codex launch
- No branch/PR automation
- No campaign mutation
- No strategy/preset mutation
- No paper/shadow/live activation
- No broker/risk/execution changes
- No development work queue seed write
- No generated seed write
- No research action queue write