### PR TITLE
feat: add QRE evidence quality promotion intent

### DIFF
--- a/reporting/qre_closed_loop_materialization_runner.py
+++ b/reporting/qre_closed_loop_materialization_runner.py
@@ -12,6 +12,7 @@ from types import ModuleType
 from typing import Any, Final
 
 from reporting import qre_closed_loop_operator_report
+from reporting import qre_evidence_quality_gate
 from reporting import qre_hypothesis_candidates
 from reporting import qre_hypothesis_evidence_update
 from reporting import qre_hypothesis_validation_plan
@@ -20,6 +21,7 @@ from reporting import qre_market_observation_snapshot
 from reporting import qre_observation_hypothesis_projector
 from reporting import qre_research_run_manifest
 from reporting import qre_trusted_loop_readiness
+from reporting import qre_validated_hypothesis_promotion_intent
 from reporting import qre_validation_research_action_candidates
 
 REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
@@ -41,6 +43,8 @@ STEP_MODULES: Final[tuple[ModuleType, ...]] = (
     qre_hypothesis_evidence_update,
     qre_closed_loop_operator_report,
     qre_trusted_loop_readiness,
+    qre_evidence_quality_gate,
+    qre_validated_hypothesis_promotion_intent,
 )
 
 
@@ -67,6 +71,8 @@ def _counts(snapshot: dict[str, Any]) -> dict[str, Any]:
         "run_manifests",
         "validation_results",
         "evidence_updates",
+        "evidence_quality_rows",
+        "promotion_intents",
     ):
         rows = snapshot.get(key)
         if isinstance(rows, list):

--- a/reporting/qre_evidence_quality_gate.py
+++ b/reporting/qre_evidence_quality_gate.py
@@ -1,0 +1,553 @@
+"""Read-only QRE evidence quality gate."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import tempfile
+from collections import Counter
+from pathlib import Path
+from typing import Any, Final
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[int] = 1
+REPORT_KIND: Final[str] = "qre_evidence_quality_gate"
+
+DEFAULT_HYPOTHESES_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_hypothesis_candidates" / "latest.json"
+)
+DEFAULT_RESULTS_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_hypothesis_validation_results" / "latest.json"
+)
+DEFAULT_EVIDENCE_UPDATES_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_hypothesis_evidence_updates" / "latest.json"
+)
+DEFAULT_OPERATOR_REPORT_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_closed_loop_operator_report" / "latest.json"
+)
+DEFAULT_READINESS_PATH: Final[Path] = REPO_ROOT / "logs" / "qre_trusted_loop_readiness" / "latest.json"
+
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "qre_evidence_quality_gate"
+OUTPUT_ARTIFACT_RELATIVE_PATH: Final[str] = "logs/qre_evidence_quality_gate/latest.json"
+ARTIFACT_LATEST: Final[Path] = REPO_ROOT / OUTPUT_ARTIFACT_RELATIVE_PATH
+
+QUALITY_CLASSES: Final[tuple[str, ...]] = (
+    "insufficient",
+    "thin",
+    "usable",
+    "strong",
+    "contradictory",
+)
+
+NOTE_INPUT_ISSUES: Final[str] = "evidence_quality_inputs_missing_or_unparseable"
+NOTE_GATE_EVALUATED: Final[str] = "evidence_quality_gate_evaluated"
+
+
+def _utcnow() -> str:
+    return _dt.datetime.now(_dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _rel(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(REPO_ROOT.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _read_json(path: Path) -> tuple[bool, dict[str, Any] | None]:
+    try:
+        raw = path.read_text(encoding="utf-8-sig")
+    except OSError:
+        return (False, None)
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return (True, None)
+    return (True, parsed if isinstance(parsed, dict) else None)
+
+
+def _bounded_str(value: Any, *, max_len: int = 240) -> str:
+    text = str(value or "").strip()
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 3].rstrip() + "..."
+
+
+def _str_list(value: Any, *, max_items: int = 48, max_len: int = 220) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    out: list[str] = []
+    for item in value[:max_items]:
+        text = _bounded_str(item, max_len=max_len)
+        if text:
+            out.append(text)
+    return out
+
+
+def _safe_rows(payload: dict[str, Any] | None, field: str) -> list[dict[str, Any]]:
+    if payload is None:
+        return []
+    rows = payload.get(field)
+    if not isinstance(rows, list) or not all(isinstance(item, dict) for item in rows):
+        return []
+    return rows
+
+
+def _load(
+    path: Path,
+    *,
+    expected_kind: str,
+    field: str | None,
+    label: str,
+) -> tuple[list[dict[str, Any]], dict[str, Any], list[str], dict[str, Any] | None]:
+    available, payload = _read_json(path)
+    meta = {"path": _rel(path), "available": available, "valid": False}
+    if payload is None or payload.get("report_kind") != expected_kind:
+        return ([], meta, [f"{label}:missing_or_unparseable"], payload)
+    meta["valid"] = True
+    if field is None:
+        return ([], meta, [], payload)
+    raw_rows = payload.get(field)
+    if (
+        field not in payload
+        or not isinstance(raw_rows, list)
+        or not all(isinstance(item, dict) for item in raw_rows)
+    ):
+        meta["valid"] = False
+        return ([], meta, [f"{label}:missing_or_unparseable"], payload)
+    return (_safe_rows(payload, field), meta, [], payload)
+
+
+def _index_by_hypothesis(rows: list[dict[str, Any]], id_field: str) -> dict[str, list[dict[str, Any]]]:
+    indexed: dict[str, list[dict[str, Any]]] = {}
+    for row in rows:
+        hypothesis_id = _bounded_str(row.get("hypothesis_id"), max_len=160)
+        if hypothesis_id:
+            indexed.setdefault(hypothesis_id, []).append(row)
+    for items in indexed.values():
+        items.sort(key=lambda item: _bounded_str(item.get(id_field), max_len=180))
+    return indexed
+
+
+def _lineage_present(result: dict[str, Any] | None, update: dict[str, Any] | None) -> bool:
+    for row in (result, update):
+        if row is None:
+            continue
+        if (
+            row.get("source_artifact")
+            and row.get("source_report_kind")
+            and (row.get("source_row_id") or row.get("source_ref"))
+        ):
+            return True
+    return False
+
+
+def _metrics(result: dict[str, Any] | None) -> dict[str, Any]:
+    raw = result.get("metric_results") if result else None
+    return raw if isinstance(raw, dict) else {}
+
+
+def _has_trade_count(metrics: dict[str, Any]) -> bool:
+    trade_keys = {
+        "trade_count",
+        "total_trades",
+        "totaal_trades",
+        "trades",
+        "n_trades",
+        "num_trades",
+    }
+    for key, value in metrics.items():
+        normalized = str(key).lower()
+        if normalized in trade_keys and value not in (None, "", 0):
+            return True
+    return False
+
+
+def _has_primary_metrics(metrics: dict[str, Any]) -> bool:
+    primary_names = {
+        "win_rate",
+        "sharpe",
+        "deflated_sharpe",
+        "max_drawdown",
+        "return",
+        "total_return",
+        "expectancy",
+        "profit_factor",
+    }
+    return any(str(key).lower() in primary_names and value not in (None, "") for key, value in metrics.items())
+
+
+def _metric_completeness(metrics: dict[str, Any], trade_count_present: bool, primary_present: bool) -> str:
+    if trade_count_present and primary_present:
+        return "complete"
+    if metrics:
+        return "partial"
+    return "missing"
+
+
+def _refs(*rows: dict[str, Any] | None, field: str) -> list[str]:
+    refs: list[str] = []
+    for row in rows:
+        if row is not None:
+            refs.extend(_str_list(row.get(field)))
+    return sorted(set(refs))
+
+
+def _operator_approved_indicator_present(
+    operator_payload: dict[str, Any] | None,
+    result: dict[str, Any] | None,
+    update: dict[str, Any] | None,
+) -> bool:
+    candidates: list[Any] = []
+    for row in (result, update):
+        if row is not None:
+            candidates.append(row.get("operator_approved_indicator_present"))
+            candidates.append(row.get("operator_approved"))
+    if operator_payload is not None:
+        report = operator_payload.get("operator_report")
+        if isinstance(report, dict):
+            candidates.append(report.get("operator_approved_indicator_present"))
+            candidates.append(report.get("operator_approved_for_trusted_loop"))
+    return any(value is True for value in candidates)
+
+
+def _repeatability_status(result: dict[str, Any] | None, update: dict[str, Any] | None) -> str:
+    refs = _refs(result, update, field="repeatability_evidence_refs")
+    if refs:
+        return "repeatability_evidence_present"
+    return "no_repeatability_evidence"
+
+
+def _status(result: dict[str, Any] | None) -> str:
+    if result is None:
+        return "missing"
+    value = _bounded_str(result.get("status"), max_len=40).lower()
+    return value or "missing"
+
+
+def _decision(update: dict[str, Any] | None) -> str:
+    if update is None:
+        return "missing"
+    value = _bounded_str(update.get("evidence_decision"), max_len=80).lower()
+    return value or "missing"
+
+
+def _quality(
+    *,
+    result: dict[str, Any] | None,
+    update: dict[str, Any] | None,
+    source_lineage_present: bool,
+    trade_count_present: bool,
+    primary_metrics_present: bool,
+    supporting_count: int,
+    contradicting_count: int,
+    repeatability_status: str,
+    operator_approved_indicator_present: bool,
+) -> tuple[str, int, list[str]]:
+    reasons: list[str] = []
+    validation_status = _status(result)
+    evidence_decision = _decision(update)
+    falsification_hits = _str_list(result.get("falsification_hits")) if result else []
+
+    if result is None:
+        return ("insufficient", 0, ["validation_result_missing"])
+    if update is None:
+        return ("insufficient", 0, ["evidence_update_missing"])
+    if evidence_decision == "contradiction_detected" or (
+        supporting_count > 0 and contradicting_count > 0
+    ):
+        return ("contradictory", 10, ["contradictory_evidence_visible"])
+    if evidence_decision == "falsified" or validation_status == "failed" or falsification_hits:
+        return ("contradictory", 10, ["falsified_or_failed_validation"])
+    if validation_status in {"missing", ""}:
+        return ("insufficient", 0, ["validation_status_missing"])
+    if validation_status == "inconclusive" or evidence_decision in {"inconclusive", "needs_more_data"}:
+        if source_lineage_present:
+            return ("thin", 25, ["validation_inconclusive_or_needs_more_data"])
+        return ("insufficient", 0, ["validation_inconclusive_without_lineage"])
+    if validation_status != "passed" or evidence_decision != "supported":
+        return ("insufficient", 0, ["validation_not_supported"])
+
+    if not source_lineage_present:
+        reasons.append("source_lineage_missing")
+    if not primary_metrics_present:
+        reasons.append("primary_metrics_missing")
+    if not trade_count_present:
+        reasons.append("trade_count_missing")
+    if supporting_count == 0:
+        reasons.append("supporting_evidence_missing")
+    if reasons:
+        return ("thin", 35, reasons)
+    if (
+        repeatability_status == "repeatability_evidence_present"
+        and operator_approved_indicator_present
+    ):
+        return ("strong", 95, ["repeatability_and_operator_approval_indicator_present"])
+    return ("usable", 75, ["supported_evidence_meets_quality_floor"])
+
+
+def _build_row(
+    hypothesis: dict[str, Any],
+    result: dict[str, Any] | None,
+    update: dict[str, Any] | None,
+    operator_payload: dict[str, Any] | None,
+) -> dict[str, Any]:
+    metrics = _metrics(result)
+    source_lineage = _lineage_present(result, update)
+    trade_count = _has_trade_count(metrics)
+    primary_metrics = _has_primary_metrics(metrics)
+    metric_completeness = _metric_completeness(metrics, trade_count, primary_metrics)
+    supporting_refs = _refs(hypothesis, result, update, field="supporting_evidence_refs")
+    contradicting_refs = _refs(hypothesis, result, update, field="contradicting_evidence_refs")
+    repeatability = _repeatability_status(result, update)
+    operator_indicator = _operator_approved_indicator_present(operator_payload, result, update)
+    quality_class, quality_score, reasons = _quality(
+        result=result,
+        update=update,
+        source_lineage_present=source_lineage,
+        trade_count_present=trade_count,
+        primary_metrics_present=primary_metrics,
+        supporting_count=len(supporting_refs),
+        contradicting_count=len(contradicting_refs),
+        repeatability_status=repeatability,
+        operator_approved_indicator_present=operator_indicator,
+    )
+    validation_status = _status(result)
+    evidence_decision = _decision(update)
+    promotion_allowed = (
+        quality_class in {"usable", "strong"}
+        and evidence_decision == "supported"
+        and validation_status == "passed"
+        and len(supporting_refs) > 0
+    )
+    return {
+        "hypothesis_id": _bounded_str(hypothesis.get("hypothesis_id"), max_len=160),
+        "evidence_update_id": _bounded_str(update.get("evidence_update_id"), max_len=160)
+        if update
+        else "",
+        "result_id": _bounded_str(result.get("result_id"), max_len=160) if result else "",
+        "evidence_decision": evidence_decision,
+        "validation_status": validation_status,
+        "quality_class": quality_class,
+        "quality_score": quality_score,
+        "source_lineage_present": source_lineage,
+        "metric_completeness": metric_completeness,
+        "trade_count_present": trade_count,
+        "primary_metrics_present": primary_metrics,
+        "supporting_evidence_count": len(supporting_refs),
+        "contradicting_evidence_count": len(contradicting_refs),
+        "contradiction_visible": evidence_decision == "contradiction_detected"
+        or bool(contradicting_refs),
+        "repeatability_status": repeatability,
+        "operator_approved_indicator_present": operator_indicator,
+        "quality_reasons": reasons,
+        "promotion_allowed": promotion_allowed,
+        "safe_to_execute": False,
+    }
+
+
+def _counts(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    counter = Counter(str(row.get("quality_class") or "insufficient") for row in rows)
+    return {
+        "total": len(rows),
+        "by_quality_class": {name: counter.get(name, 0) for name in QUALITY_CLASSES},
+        "promotion_allowed": sum(1 for row in rows if row.get("promotion_allowed") is True),
+    }
+
+
+def _snapshot(
+    *,
+    generated_at_utc: str,
+    input_artifacts: dict[str, dict[str, Any]],
+    rows: list[dict[str, Any]],
+    validation_warnings: list[str],
+) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": generated_at_utc,
+        "input_artifacts": input_artifacts,
+        "evidence_quality_rows": rows,
+        "counts": _counts(rows),
+        "validation_warnings": validation_warnings,
+        "final_recommendation": (
+            "evidence_quality_ready_for_operator_promotion_review"
+            if any(row.get("promotion_allowed") is True for row in rows)
+            else "operator_review_required_or_more_evidence_needed"
+        ),
+        "safe_to_execute": False,
+        "writes_development_work_queue": False,
+        "writes_seed_jsonl": False,
+        "writes_generated_seed_jsonl": False,
+        "writes_research_action_queue": False,
+        "mutates_campaign_queue": False,
+        "mutates_strategy_or_preset": False,
+        "mutates_paper_shadow_live_runtime": False,
+        "launches_codex": False,
+        "eligible_for_direct_execution": False,
+    }
+
+
+def collect_snapshot(
+    *,
+    hypotheses_path: Path | None = None,
+    validation_results_path: Path | None = None,
+    evidence_updates_path: Path | None = None,
+    operator_report_path: Path | None = None,
+    readiness_path: Path | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    generated = generated_at_utc or _utcnow()
+    hypotheses, meta_a, warnings_a, _payload_a = _load(
+        hypotheses_path or DEFAULT_HYPOTHESES_PATH,
+        expected_kind="qre_hypothesis_candidates",
+        field="hypotheses",
+        label="hypotheses",
+    )
+    results, meta_b, warnings_b, _payload_b = _load(
+        validation_results_path or DEFAULT_RESULTS_PATH,
+        expected_kind="qre_hypothesis_validation_results",
+        field="validation_results",
+        label="validation_results",
+    )
+    updates, meta_c, warnings_c, _payload_c = _load(
+        evidence_updates_path or DEFAULT_EVIDENCE_UPDATES_PATH,
+        expected_kind="qre_hypothesis_evidence_update",
+        field="evidence_updates",
+        label="evidence_updates",
+    )
+    _report_rows, meta_d, warnings_d, operator_payload = _load(
+        operator_report_path or DEFAULT_OPERATOR_REPORT_PATH,
+        expected_kind="qre_closed_loop_operator_report",
+        field=None,
+        label="operator_report",
+    )
+    _readiness_rows, meta_e, warnings_e, _readiness_payload = _load(
+        readiness_path or DEFAULT_READINESS_PATH,
+        expected_kind="qre_trusted_loop_readiness",
+        field=None,
+        label="readiness",
+    )
+    warnings = warnings_a + warnings_b + warnings_c + warnings_d + warnings_e
+    input_artifacts = {
+        "hypotheses": meta_a,
+        "validation_results": meta_b,
+        "evidence_updates": meta_c,
+        "operator_report": meta_d,
+        "readiness": meta_e,
+    }
+    if warnings:
+        return _snapshot(
+            generated_at_utc=generated,
+            input_artifacts=input_artifacts,
+            rows=[],
+            validation_warnings=[NOTE_INPUT_ISSUES] + warnings,
+        )
+
+    results_by_hypothesis = _index_by_hypothesis(results, "result_id")
+    updates_by_hypothesis = _index_by_hypothesis(updates, "evidence_update_id")
+    rows = [
+        _build_row(
+            hypothesis,
+            (results_by_hypothesis.get(_bounded_str(hypothesis.get("hypothesis_id"), max_len=160)) or [None])[0],
+            (updates_by_hypothesis.get(_bounded_str(hypothesis.get("hypothesis_id"), max_len=160)) or [None])[0],
+            operator_payload,
+        )
+        for hypothesis in hypotheses
+    ]
+    rows.sort(key=lambda row: (row["hypothesis_id"], row["result_id"], row["evidence_update_id"]))
+    return _snapshot(
+        generated_at_utc=generated,
+        input_artifacts=input_artifacts,
+        rows=rows,
+        validation_warnings=[],
+    )
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    if not path.resolve().is_relative_to(ARTIFACT_DIR.resolve()):
+        raise ValueError(f"refusing write outside QRE evidence quality gate dir: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".qre_evidence_quality_gate.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_outputs(
+    snapshot: dict[str, Any],
+    *,
+    output_path: Path | None = None,
+) -> Path:
+    target = output_path or ARTIFACT_LATEST
+    _atomic_write_json(target, snapshot)
+    return target
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="reporting.qre_evidence_quality_gate",
+        description="Evaluate read-only QRE evidence quality.",
+    )
+    parser.add_argument("--no-write", action="store_true")
+    parser.add_argument("--hypotheses-source", type=Path, default=None)
+    parser.add_argument("--results-source", type=Path, default=None)
+    parser.add_argument("--evidence-updates-source", type=Path, default=None)
+    parser.add_argument("--operator-report-source", type=Path, default=None)
+    parser.add_argument("--readiness-source", type=Path, default=None)
+    parser.add_argument("--frozen-utc", default=None)
+    parser.add_argument("--indent", type=int, default=2)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    snapshot = collect_snapshot(
+        hypotheses_path=args.hypotheses_source,
+        validation_results_path=args.results_source,
+        evidence_updates_path=args.evidence_updates_source,
+        operator_report_path=args.operator_report_source,
+        readiness_path=args.readiness_source,
+        generated_at_utc=args.frozen_utc,
+    )
+    if not args.no_write:
+        write_outputs(snapshot)
+    print(json.dumps(snapshot, indent=args.indent, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "ARTIFACT_DIR",
+    "ARTIFACT_LATEST",
+    "DEFAULT_EVIDENCE_UPDATES_PATH",
+    "DEFAULT_HYPOTHESES_PATH",
+    "DEFAULT_OPERATOR_REPORT_PATH",
+    "DEFAULT_READINESS_PATH",
+    "DEFAULT_RESULTS_PATH",
+    "OUTPUT_ARTIFACT_RELATIVE_PATH",
+    "QUALITY_CLASSES",
+    "REPORT_KIND",
+    "SCHEMA_VERSION",
+    "collect_snapshot",
+    "main",
+    "write_outputs",
+]

--- a/reporting/qre_validated_hypothesis_promotion_intent.py
+++ b/reporting/qre_validated_hypothesis_promotion_intent.py
@@ -1,0 +1,411 @@
+"""Read-only QRE validated hypothesis promotion intent staging."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import hashlib
+import json
+import os
+import tempfile
+from collections import Counter
+from pathlib import Path
+from typing import Any, Final
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[int] = 1
+REPORT_KIND: Final[str] = "qre_validated_hypothesis_promotion_intent"
+
+DEFAULT_HYPOTHESES_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_hypothesis_candidates" / "latest.json"
+)
+DEFAULT_RESULTS_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_hypothesis_validation_results" / "latest.json"
+)
+DEFAULT_EVIDENCE_UPDATES_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_hypothesis_evidence_updates" / "latest.json"
+)
+DEFAULT_EVIDENCE_QUALITY_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_evidence_quality_gate" / "latest.json"
+)
+
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "qre_validated_hypothesis_promotion_intent"
+OUTPUT_ARTIFACT_RELATIVE_PATH: Final[str] = (
+    "logs/qre_validated_hypothesis_promotion_intent/latest.json"
+)
+ARTIFACT_LATEST: Final[Path] = REPO_ROOT / OUTPUT_ARTIFACT_RELATIVE_PATH
+
+FORBIDDEN_ACTIONS: Final[tuple[str, ...]] = (
+    "actual_research_action_queue_write_forbidden",
+    "development_work_queue_write_forbidden",
+    "generated_seed_write_forbidden",
+    "campaign_queue_mutation_forbidden",
+    "strategy_or_preset_mutation_forbidden",
+    "paper_shadow_live_activation_forbidden",
+    "broker_risk_execution_change_forbidden",
+    "codex_launch_forbidden",
+    "branch_pr_automation_forbidden",
+)
+
+LANE_NAMES: Final[tuple[str, ...]] = (
+    "research_action_queue_intent",
+    "generated_seed_intent",
+    "strategy_or_preset_intent",
+    "campaign_intent",
+)
+
+NOTE_INPUT_ISSUES: Final[str] = "promotion_intent_inputs_missing_or_unparseable"
+
+
+def _utcnow() -> str:
+    return _dt.datetime.now(_dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _rel(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(REPO_ROOT.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _read_json(path: Path) -> tuple[bool, dict[str, Any] | None]:
+    try:
+        raw = path.read_text(encoding="utf-8-sig")
+    except OSError:
+        return (False, None)
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return (True, None)
+    return (True, parsed if isinstance(parsed, dict) else None)
+
+
+def _bounded_str(value: Any, *, max_len: int = 240) -> str:
+    text = str(value or "").strip()
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 3].rstrip() + "..."
+
+
+def _safe_rows(payload: dict[str, Any] | None, field: str) -> list[dict[str, Any]]:
+    if payload is None:
+        return []
+    rows = payload.get(field)
+    if not isinstance(rows, list) or not all(isinstance(item, dict) for item in rows):
+        return []
+    return rows
+
+
+def _load(
+    path: Path,
+    *,
+    expected_kind: str,
+    field: str,
+    label: str,
+) -> tuple[list[dict[str, Any]], dict[str, Any], list[str]]:
+    available, payload = _read_json(path)
+    meta = {"path": _rel(path), "available": available, "valid": False}
+    if payload is None or payload.get("report_kind") != expected_kind:
+        return ([], meta, [f"{label}:missing_or_unparseable"])
+    raw_rows = payload.get(field)
+    if (
+        field not in payload
+        or not isinstance(raw_rows, list)
+        or not all(isinstance(item, dict) for item in raw_rows)
+    ):
+        return ([], meta, [f"{label}:missing_or_unparseable"])
+    meta["valid"] = True
+    return (_safe_rows(payload, field), meta, [])
+
+
+def _promotion_intent_id(row: dict[str, Any], promotion_target: str) -> str:
+    seed = "|".join(
+        [
+            _bounded_str(row.get("hypothesis_id"), max_len=160),
+            _bounded_str(row.get("evidence_update_id"), max_len=160),
+            _bounded_str(row.get("result_id"), max_len=160),
+            _bounded_str(row.get("quality_class"), max_len=40),
+            promotion_target,
+        ]
+    )
+    return "qre-promotion-" + hashlib.sha256(seed.encode("utf-8")).hexdigest()[:16]
+
+
+def _lane(name: str, status: str, hypothesis_id: str) -> dict[str, Any]:
+    return {
+        "lane": name,
+        "intent_status": status,
+        "hypothesis_id": hypothesis_id,
+        "operator_approval_required": True,
+        "actual_writes_enabled": False,
+        "safe_to_execute": False,
+        "eligible_for_direct_execution": False,
+    }
+
+
+def _intent_lanes(status: str, hypothesis_id: str) -> dict[str, dict[str, Any]]:
+    return {name: _lane(name, status, hypothesis_id) for name in LANE_NAMES}
+
+
+def _intent_status(row: dict[str, Any]) -> tuple[str, str, str, str, str]:
+    quality_class = _bounded_str(row.get("quality_class"), max_len=40)
+    evidence_decision = _bounded_str(row.get("evidence_decision"), max_len=80)
+    validation_status = _bounded_str(row.get("validation_status"), max_len=80)
+    allowed = row.get("promotion_allowed") is True
+    if allowed and quality_class in {"usable", "strong"} and evidence_decision == "supported":
+        target = (
+            "development_queue_candidate"
+            if quality_class == "strong"
+            else "qre_research_action_proposal_intake_candidate"
+        )
+        return (
+            "operator_review_required",
+            target,
+            "supported_evidence_quality_passed_manual_promotion_floor",
+            "",
+            "operator_review_promotion_intent",
+        )
+    if quality_class == "contradictory" or evidence_decision in {"falsified", "contradiction_detected"}:
+        return (
+            "blocked",
+            "none",
+            "",
+            "contradictory_or_falsified_evidence",
+            "preserve_negative_or_contradictory_result",
+        )
+    if validation_status in {"missing", ""} or evidence_decision in {"missing", ""}:
+        return (
+            "not_ready",
+            "none",
+            "",
+            "missing_validation_or_evidence_update",
+            "collect_validation_result_and_evidence_update",
+        )
+    return (
+        "not_ready",
+        "none",
+        "",
+        f"quality_class_{quality_class}_not_promotable",
+        "collect_more_evidence_or_operator_review",
+    )
+
+
+def _build_intent(row: dict[str, Any]) -> dict[str, Any]:
+    status, target, promotion_reason, blocked_reason, suggested_next_action = _intent_status(row)
+    hypothesis_id = _bounded_str(row.get("hypothesis_id"), max_len=160)
+    lane_status = "staged_for_operator_review" if status == "operator_review_required" else status
+    return {
+        "promotion_intent_id": _promotion_intent_id(row, target),
+        "hypothesis_id": hypothesis_id,
+        "evidence_update_id": _bounded_str(row.get("evidence_update_id"), max_len=160),
+        "result_id": _bounded_str(row.get("result_id"), max_len=160),
+        "quality_class": _bounded_str(row.get("quality_class"), max_len=40),
+        "evidence_decision": _bounded_str(row.get("evidence_decision"), max_len=80),
+        "validation_status": _bounded_str(row.get("validation_status"), max_len=80),
+        "intent_status": status,
+        "promotion_target": target,
+        "intent_lanes": _intent_lanes(lane_status, hypothesis_id),
+        "actual_writes_enabled": False,
+        "operator_approval_required": True,
+        "promotion_reason": promotion_reason,
+        "blocked_reason": blocked_reason,
+        "suggested_next_action": suggested_next_action,
+        "forbidden_actions": list(FORBIDDEN_ACTIONS),
+        "safe_to_execute": False,
+        "eligible_for_direct_execution": False,
+        "writes_development_work_queue": False,
+        "writes_research_action_queue": False,
+        "writes_generated_seed_jsonl": False,
+        "mutates_campaign_queue": False,
+        "mutates_strategy_or_preset": False,
+        "mutates_paper_shadow_live_runtime": False,
+    }
+
+
+def _counts(intents: list[dict[str, Any]]) -> dict[str, Any]:
+    counter = Counter(str(item.get("intent_status") or "not_ready") for item in intents)
+    return {
+        "total": len(intents),
+        "by_intent_status": {
+            "operator_review_required": counter.get("operator_review_required", 0),
+            "blocked": counter.get("blocked", 0),
+            "not_ready": counter.get("not_ready", 0),
+        },
+        "ready_for_operator_review": counter.get("operator_review_required", 0),
+    }
+
+
+def _snapshot(
+    *,
+    generated_at_utc: str,
+    input_artifacts: dict[str, dict[str, Any]],
+    intents: list[dict[str, Any]],
+    validation_warnings: list[str],
+) -> dict[str, Any]:
+    ready = any(item.get("intent_status") == "operator_review_required" for item in intents)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": generated_at_utc,
+        "input_artifacts": input_artifacts,
+        "promotion_intents": intents,
+        "counts": _counts(intents),
+        "validation_warnings": validation_warnings,
+        "final_recommendation": (
+            "operator_review_required_for_validated_hypothesis_promotion"
+            if ready
+            else "no_validated_hypothesis_promotion_intent_ready"
+        ),
+        "safe_to_execute": False,
+        "writes_development_work_queue": False,
+        "writes_seed_jsonl": False,
+        "writes_generated_seed_jsonl": False,
+        "writes_research_action_queue": False,
+        "mutates_campaign_queue": False,
+        "mutates_strategy_or_preset": False,
+        "mutates_paper_shadow_live_runtime": False,
+        "launches_codex": False,
+        "eligible_for_direct_execution": False,
+    }
+
+
+def collect_snapshot(
+    *,
+    hypotheses_path: Path | None = None,
+    validation_results_path: Path | None = None,
+    evidence_updates_path: Path | None = None,
+    evidence_quality_path: Path | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    generated = generated_at_utc or _utcnow()
+    _hypotheses, meta_a, warnings_a = _load(
+        hypotheses_path or DEFAULT_HYPOTHESES_PATH,
+        expected_kind="qre_hypothesis_candidates",
+        field="hypotheses",
+        label="hypotheses",
+    )
+    _results, meta_b, warnings_b = _load(
+        validation_results_path or DEFAULT_RESULTS_PATH,
+        expected_kind="qre_hypothesis_validation_results",
+        field="validation_results",
+        label="validation_results",
+    )
+    _updates, meta_c, warnings_c = _load(
+        evidence_updates_path or DEFAULT_EVIDENCE_UPDATES_PATH,
+        expected_kind="qre_hypothesis_evidence_update",
+        field="evidence_updates",
+        label="evidence_updates",
+    )
+    quality_rows, meta_d, warnings_d = _load(
+        evidence_quality_path or DEFAULT_EVIDENCE_QUALITY_PATH,
+        expected_kind="qre_evidence_quality_gate",
+        field="evidence_quality_rows",
+        label="evidence_quality",
+    )
+    warnings = warnings_a + warnings_b + warnings_c + warnings_d
+    input_artifacts = {
+        "hypotheses": meta_a,
+        "validation_results": meta_b,
+        "evidence_updates": meta_c,
+        "evidence_quality": meta_d,
+    }
+    if warnings:
+        return _snapshot(
+            generated_at_utc=generated,
+            input_artifacts=input_artifacts,
+            intents=[],
+            validation_warnings=[NOTE_INPUT_ISSUES] + warnings,
+        )
+    intents = [_build_intent(row) for row in quality_rows]
+    intents.sort(key=lambda item: item["promotion_intent_id"])
+    return _snapshot(
+        generated_at_utc=generated,
+        input_artifacts=input_artifacts,
+        intents=intents,
+        validation_warnings=[],
+    )
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    if not path.resolve().is_relative_to(ARTIFACT_DIR.resolve()):
+        raise ValueError(f"refusing write outside QRE promotion intent dir: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".qre_validated_hypothesis_promotion_intent.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_outputs(
+    snapshot: dict[str, Any],
+    *,
+    output_path: Path | None = None,
+) -> Path:
+    target = output_path or ARTIFACT_LATEST
+    _atomic_write_json(target, snapshot)
+    return target
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="reporting.qre_validated_hypothesis_promotion_intent",
+        description="Stage read-only validated hypothesis promotion intents.",
+    )
+    parser.add_argument("--no-write", action="store_true")
+    parser.add_argument("--hypotheses-source", type=Path, default=None)
+    parser.add_argument("--results-source", type=Path, default=None)
+    parser.add_argument("--evidence-updates-source", type=Path, default=None)
+    parser.add_argument("--evidence-quality-source", type=Path, default=None)
+    parser.add_argument("--frozen-utc", default=None)
+    parser.add_argument("--indent", type=int, default=2)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    snapshot = collect_snapshot(
+        hypotheses_path=args.hypotheses_source,
+        validation_results_path=args.results_source,
+        evidence_updates_path=args.evidence_updates_source,
+        evidence_quality_path=args.evidence_quality_source,
+        generated_at_utc=args.frozen_utc,
+    )
+    if not args.no_write:
+        write_outputs(snapshot)
+    print(json.dumps(snapshot, indent=args.indent, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "ARTIFACT_DIR",
+    "ARTIFACT_LATEST",
+    "DEFAULT_EVIDENCE_QUALITY_PATH",
+    "DEFAULT_EVIDENCE_UPDATES_PATH",
+    "DEFAULT_HYPOTHESES_PATH",
+    "DEFAULT_RESULTS_PATH",
+    "FORBIDDEN_ACTIONS",
+    "LANE_NAMES",
+    "OUTPUT_ARTIFACT_RELATIVE_PATH",
+    "REPORT_KIND",
+    "SCHEMA_VERSION",
+    "collect_snapshot",
+    "main",
+    "write_outputs",
+]

--- a/tests/unit/test_qre_closed_loop_materialization_runner.py
+++ b/tests/unit/test_qre_closed_loop_materialization_runner.py
@@ -52,6 +52,8 @@ def _fake_modules(tmp_path: Path, calls: list[str]):
         "qre_hypothesis_evidence_update",
         "qre_closed_loop_operator_report",
         "qre_trusted_loop_readiness",
+        "qre_evidence_quality_gate",
+        "qre_validated_hypothesis_promotion_intent",
     ]
     return tuple(
         _fake_module(f"reporting.{name}", name, tmp_path / "logs", calls) for name in names
@@ -95,6 +97,8 @@ def test_no_write_mode_collects_in_exact_step_order_without_module_writes(
         "qre_hypothesis_evidence_update",
         "qre_closed_loop_operator_report",
         "qre_trusted_loop_readiness",
+        "qre_evidence_quality_gate",
+        "qre_validated_hypothesis_promotion_intent",
     ]
     assert all(call.startswith("collect:") for call in calls)
     assert all(step["artifact_path"] is None for step in snap["steps"])

--- a/tests/unit/test_qre_evidence_quality_gate.py
+++ b/tests/unit/test_qre_evidence_quality_gate.py
@@ -1,0 +1,376 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from reporting import qre_evidence_quality_gate as gate
+
+
+FROZEN = "2026-06-01T12:00:00Z"
+
+
+def _hypothesis(**overrides) -> dict:
+    base = {
+        "hypothesis_id": "qre-hyp-fixture-001",
+        "supporting_evidence_refs": ["fixture#candidate-support"],
+        "contradicting_evidence_refs": [],
+        "safe_to_execute": False,
+    }
+    base.update(overrides)
+    return base
+
+
+def _result(**overrides) -> dict:
+    base = {
+        "result_id": "qre-result-fixture-001",
+        "hypothesis_id": "qre-hyp-fixture-001",
+        "status": "passed",
+        "metric_results": {"trade_count": 120, "sharpe": 1.2},
+        "falsification_hits": [],
+        "supporting_evidence_refs": ["fixture#result-support"],
+        "contradicting_evidence_refs": [],
+        "source_artifact": "fixture/results.json",
+        "source_report_kind": "fixture",
+        "source_row_id": "row-001",
+        "source_ref": "fixture/results.json#row-001",
+        "safe_to_execute": False,
+    }
+    base.update(overrides)
+    return base
+
+
+def _update(**overrides) -> dict:
+    base = {
+        "evidence_update_id": "qre-evidence-fixture-001",
+        "hypothesis_id": "qre-hyp-fixture-001",
+        "evidence_decision": "supported",
+        "supporting_evidence_refs": ["fixture#update-support"],
+        "contradicting_evidence_refs": [],
+        "source_artifact": "fixture/results.json",
+        "source_report_kind": "fixture",
+        "source_row_id": "row-001",
+        "source_ref": "fixture/results.json#row-001",
+        "safe_to_execute": False,
+    }
+    base.update(overrides)
+    return base
+
+
+def _write_payload(path: Path, report_kind: str, field: str | None, rows: list[dict]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema_version": 1,
+        "report_kind": report_kind,
+        "generated_at_utc": FROZEN,
+        "safe_to_execute": False,
+    }
+    if field is not None:
+        payload[field] = rows
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return path
+
+
+def _artifact_set(
+    tmp_path: Path,
+    *,
+    hypotheses: list[dict] | None = None,
+    results: list[dict] | None = None,
+    updates: list[dict] | None = None,
+    operator_report: dict | None = None,
+) -> dict[str, Path]:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    paths = {
+        "hypotheses": _write_payload(
+            tmp_path / "hypotheses.json",
+            "qre_hypothesis_candidates",
+            "hypotheses",
+            [_hypothesis()] if hypotheses is None else hypotheses,
+        ),
+        "results": _write_payload(
+            tmp_path / "results.json",
+            "qre_hypothesis_validation_results",
+            "validation_results",
+            [_result()] if results is None else results,
+        ),
+        "updates": _write_payload(
+            tmp_path / "updates.json",
+            "qre_hypothesis_evidence_update",
+            "evidence_updates",
+            [_update()] if updates is None else updates,
+        ),
+        "operator_report": tmp_path / "operator_report.json",
+        "readiness": _write_payload(
+            tmp_path / "readiness.json",
+            "qre_trusted_loop_readiness",
+            None,
+            [],
+        ),
+    }
+    operator_payload = {
+        "schema_version": 1,
+        "report_kind": "qre_closed_loop_operator_report",
+        "operator_report": {"safe_to_execute": False},
+        "safe_to_execute": False,
+    }
+    if operator_report is not None:
+        operator_payload["operator_report"].update(operator_report)
+    paths["operator_report"].write_text(json.dumps(operator_payload, indent=2), encoding="utf-8")
+    return paths
+
+
+def _collect(paths: dict[str, Path]) -> dict:
+    return gate.collect_snapshot(
+        hypotheses_path=paths["hypotheses"],
+        validation_results_path=paths["results"],
+        evidence_updates_path=paths["updates"],
+        operator_report_path=paths["operator_report"],
+        readiness_path=paths["readiness"],
+        generated_at_utc=FROZEN,
+    )
+
+
+def _assert_safety_flags_false(snapshot: dict) -> None:
+    for key in (
+        "safe_to_execute",
+        "writes_development_work_queue",
+        "writes_seed_jsonl",
+        "writes_generated_seed_jsonl",
+        "writes_research_action_queue",
+        "mutates_campaign_queue",
+        "mutates_strategy_or_preset",
+        "mutates_paper_shadow_live_runtime",
+        "launches_codex",
+        "eligible_for_direct_execution",
+    ):
+        assert snapshot[key] is False
+
+
+def test_missing_inputs_fail_closed_with_zero_rows(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.json"
+    paths = {
+        "hypotheses": missing,
+        "results": missing,
+        "updates": missing,
+        "operator_report": missing,
+        "readiness": missing,
+    }
+
+    snap = _collect(paths)
+
+    assert snap["evidence_quality_rows"] == []
+    assert gate.NOTE_INPUT_ISSUES in snap["validation_warnings"]
+    assert snap["final_recommendation"] == "operator_review_required_or_more_evidence_needed"
+    _assert_safety_flags_false(snap)
+
+
+def test_malformed_inputs_fail_closed(tmp_path: Path) -> None:
+    paths = _artifact_set(tmp_path)
+    paths["results"].write_text(json.dumps({"report_kind": "wrong"}), encoding="utf-8")
+
+    snap = _collect(paths)
+
+    assert snap["evidence_quality_rows"] == []
+    assert gate.NOTE_INPUT_ISSUES in snap["validation_warnings"]
+    _assert_safety_flags_false(snap)
+
+
+def test_supported_result_with_lineage_metrics_and_trade_count_is_usable(tmp_path: Path) -> None:
+    snap = _collect(_artifact_set(tmp_path))
+
+    row = snap["evidence_quality_rows"][0]
+    assert row["quality_class"] == "usable"
+    assert row["quality_score"] == 75
+    assert row["source_lineage_present"] is True
+    assert row["metric_completeness"] == "complete"
+    assert row["trade_count_present"] is True
+    assert row["primary_metrics_present"] is True
+    assert row["promotion_allowed"] is True
+    assert row["safe_to_execute"] is False
+
+
+def test_supported_result_with_repeatability_and_operator_indicator_is_strong(
+    tmp_path: Path,
+) -> None:
+    paths = _artifact_set(
+        tmp_path,
+        results=[_result(repeatability_evidence_refs=["fixture#repeatability"])],
+        operator_report={"operator_approved_for_trusted_loop": True},
+    )
+
+    snap = _collect(paths)
+
+    row = snap["evidence_quality_rows"][0]
+    assert row["quality_class"] == "strong"
+    assert row["repeatability_status"] == "repeatability_evidence_present"
+    assert row["operator_approved_indicator_present"] is True
+    assert row["promotion_allowed"] is True
+
+
+def test_supported_result_without_lineage_is_thin_at_best(tmp_path: Path) -> None:
+    paths = _artifact_set(
+        tmp_path,
+        results=[
+            _result(
+                source_artifact="",
+                source_report_kind="",
+                source_row_id="",
+                source_ref="",
+            )
+        ],
+        updates=[
+            _update(
+                source_artifact="",
+                source_report_kind="",
+                source_row_id="",
+                source_ref="",
+            )
+        ],
+    )
+
+    row = _collect(paths)["evidence_quality_rows"][0]
+
+    assert row["quality_class"] == "thin"
+    assert row["source_lineage_present"] is False
+    assert row["promotion_allowed"] is False
+
+
+def test_inconclusive_or_missing_result_is_not_promotable(tmp_path: Path) -> None:
+    inconclusive = _collect(
+        _artifact_set(tmp_path / "a", results=[_result(status="inconclusive")])
+    )["evidence_quality_rows"][0]
+    missing = _collect(
+        _artifact_set(tmp_path / "b", results=[], updates=[_update()])
+    )["evidence_quality_rows"][0]
+
+    assert inconclusive["quality_class"] in {"insufficient", "thin"}
+    assert inconclusive["promotion_allowed"] is False
+    assert missing["quality_class"] == "insufficient"
+    assert missing["validation_status"] == "missing"
+    assert missing["promotion_allowed"] is False
+
+
+def test_falsified_evidence_is_contradictory_and_never_promoted(tmp_path: Path) -> None:
+    row = _collect(
+        _artifact_set(
+            tmp_path,
+            results=[_result(status="failed", falsification_hits=["fixture#fail"])],
+            updates=[_update(evidence_decision="falsified")],
+        )
+    )["evidence_quality_rows"][0]
+
+    assert row["quality_class"] == "contradictory"
+    assert row["promotion_allowed"] is False
+
+
+def test_contradiction_detected_is_contradictory(tmp_path: Path) -> None:
+    row = _collect(
+        _artifact_set(
+            tmp_path,
+            results=[_result(contradicting_evidence_refs=["fixture#against"])],
+            updates=[_update(evidence_decision="contradiction_detected")],
+        )
+    )["evidence_quality_rows"][0]
+
+    assert row["quality_class"] == "contradictory"
+    assert row["contradiction_visible"] is True
+    assert row["promotion_allowed"] is False
+
+
+def test_deterministic_output_with_injected_timestamp(tmp_path: Path) -> None:
+    paths = _artifact_set(tmp_path)
+
+    snap_a = _collect(paths)
+    snap_b = _collect(paths)
+
+    assert json.dumps(snap_a, sort_keys=True) == json.dumps(snap_b, sort_keys=True)
+
+
+def test_cli_no_write_outputs_json_without_writing(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    paths = _artifact_set(tmp_path)
+    artifact_dir = tmp_path / "logs" / "qre_evidence_quality_gate"
+    latest = artifact_dir / "latest.json"
+    monkeypatch.setattr(gate, "ARTIFACT_DIR", artifact_dir)
+    monkeypatch.setattr(gate, "ARTIFACT_LATEST", latest)
+
+    rc = gate.main(
+        [
+            "--no-write",
+            "--hypotheses-source",
+            str(paths["hypotheses"]),
+            "--results-source",
+            str(paths["results"]),
+            "--evidence-updates-source",
+            str(paths["updates"]),
+            "--operator-report-source",
+            str(paths["operator_report"]),
+            "--readiness-source",
+            str(paths["readiness"]),
+            "--frozen-utc",
+            FROZEN,
+            "--indent",
+            "0",
+        ]
+    )
+
+    assert rc == 0
+    assert latest.exists() is False
+    parsed = json.loads(capsys.readouterr().out)
+    assert parsed["evidence_quality_rows"][0]["quality_class"] == "usable"
+
+
+def test_atomic_write_refuses_outside_artifact_dir(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        gate._atomic_write_json(tmp_path / "latest.json", {"x": 1})
+
+
+def test_source_has_no_runtime_launch_or_network_calls() -> None:
+    src = Path(gate.__file__).read_text(encoding="utf-8")
+    forbidden = (
+        "import subprocess",
+        "from subprocess",
+        "subprocess.",
+        "import socket",
+        "from socket",
+        "import requests",
+        "import httpx",
+        "import aiohttp",
+        "import urllib",
+        "from urllib",
+        "os.system",
+        "os.popen",
+        "shell=True",
+        "git ",
+        "gh ",
+        "codex ",
+    )
+    for token in forbidden:
+        assert token not in src, token
+
+
+def test_source_does_not_write_active_or_mutating_paths() -> None:
+    src = Path(gate.__file__).read_text(encoding="utf-8")
+    forbidden = (
+        "seed.jsonl",
+        "delegation_seed.jsonl",
+        "generated_seed.jsonl",
+        "logs/development_work_queue/latest.json",
+        "research/research_action_queue_latest.v1.json",
+        "campaigns/",
+        "agent/backtesting/strategies.py",
+        "registry.py",
+        "paper/",
+        "shadow/",
+        "live/",
+    )
+    for token in forbidden:
+        assert token not in src, token
+
+
+def test_all_top_level_mutation_flags_are_false(tmp_path: Path) -> None:
+    _assert_safety_flags_false(_collect(_artifact_set(tmp_path)))

--- a/tests/unit/test_qre_validated_hypothesis_promotion_intent.py
+++ b/tests/unit/test_qre_validated_hypothesis_promotion_intent.py
@@ -1,0 +1,314 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from reporting import qre_validated_hypothesis_promotion_intent as promotion
+
+
+FROZEN = "2026-06-01T12:00:00Z"
+
+
+def _write_payload(path: Path, report_kind: str, field: str, rows: list[dict]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "report_kind": report_kind,
+                "generated_at_utc": FROZEN,
+                field: rows,
+                "safe_to_execute": False,
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _quality_row(**overrides) -> dict:
+    base = {
+        "hypothesis_id": "qre-hyp-fixture-001",
+        "evidence_update_id": "qre-evidence-fixture-001",
+        "result_id": "qre-result-fixture-001",
+        "quality_class": "usable",
+        "evidence_decision": "supported",
+        "validation_status": "passed",
+        "promotion_allowed": True,
+        "safe_to_execute": False,
+    }
+    base.update(overrides)
+    return base
+
+
+def _artifact_set(tmp_path: Path, *, quality_rows: list[dict] | None = None) -> dict[str, Path]:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    return {
+        "hypotheses": _write_payload(
+            tmp_path / "hypotheses.json",
+            "qre_hypothesis_candidates",
+            "hypotheses",
+            [{"hypothesis_id": "qre-hyp-fixture-001", "safe_to_execute": False}],
+        ),
+        "results": _write_payload(
+            tmp_path / "results.json",
+            "qre_hypothesis_validation_results",
+            "validation_results",
+            [{"result_id": "qre-result-fixture-001", "safe_to_execute": False}],
+        ),
+        "updates": _write_payload(
+            tmp_path / "updates.json",
+            "qre_hypothesis_evidence_update",
+            "evidence_updates",
+            [{"evidence_update_id": "qre-evidence-fixture-001", "safe_to_execute": False}],
+        ),
+        "quality": _write_payload(
+            tmp_path / "quality.json",
+            "qre_evidence_quality_gate",
+            "evidence_quality_rows",
+            [_quality_row()] if quality_rows is None else quality_rows,
+        ),
+    }
+
+
+def _collect(paths: dict[str, Path]) -> dict:
+    return promotion.collect_snapshot(
+        hypotheses_path=paths["hypotheses"],
+        validation_results_path=paths["results"],
+        evidence_updates_path=paths["updates"],
+        evidence_quality_path=paths["quality"],
+        generated_at_utc=FROZEN,
+    )
+
+
+def _assert_safety_flags_false(snapshot: dict) -> None:
+    for key in (
+        "safe_to_execute",
+        "writes_development_work_queue",
+        "writes_seed_jsonl",
+        "writes_generated_seed_jsonl",
+        "writes_research_action_queue",
+        "mutates_campaign_queue",
+        "mutates_strategy_or_preset",
+        "mutates_paper_shadow_live_runtime",
+        "launches_codex",
+        "eligible_for_direct_execution",
+    ):
+        assert snapshot[key] is False
+
+
+def _assert_intent_is_never_executable(intent: dict) -> None:
+    assert intent["actual_writes_enabled"] is False
+    assert intent["operator_approval_required"] is True
+    assert intent["safe_to_execute"] is False
+    assert intent["eligible_for_direct_execution"] is False
+    assert intent["writes_development_work_queue"] is False
+    assert intent["writes_research_action_queue"] is False
+    assert intent["writes_generated_seed_jsonl"] is False
+    assert intent["mutates_campaign_queue"] is False
+    assert intent["mutates_strategy_or_preset"] is False
+    assert intent["mutates_paper_shadow_live_runtime"] is False
+
+
+def test_missing_evidence_quality_gate_fails_closed_with_zero_ready_intents(
+    tmp_path: Path,
+) -> None:
+    paths = _artifact_set(tmp_path)
+    paths["quality"] = tmp_path / "missing-quality.json"
+
+    snap = _collect(paths)
+
+    assert snap["promotion_intents"] == []
+    assert snap["counts"]["ready_for_operator_review"] == 0
+    assert promotion.NOTE_INPUT_ISSUES in snap["validation_warnings"]
+    _assert_safety_flags_false(snap)
+
+
+def test_usable_supported_hypothesis_produces_operator_review_intent(
+    tmp_path: Path,
+) -> None:
+    snap = _collect(_artifact_set(tmp_path, quality_rows=[_quality_row(quality_class="usable")]))
+
+    intent = snap["promotion_intents"][0]
+    assert intent["intent_status"] == "operator_review_required"
+    assert intent["promotion_target"] == "qre_research_action_proposal_intake_candidate"
+    assert intent["promotion_intent_id"].startswith("qre-promotion-")
+    _assert_intent_is_never_executable(intent)
+
+
+def test_strong_supported_hypothesis_requires_review_and_is_not_auto_executable(
+    tmp_path: Path,
+) -> None:
+    snap = _collect(_artifact_set(tmp_path, quality_rows=[_quality_row(quality_class="strong")]))
+
+    intent = snap["promotion_intents"][0]
+    assert intent["intent_status"] == "operator_review_required"
+    assert intent["promotion_target"] == "development_queue_candidate"
+    assert intent["safe_to_execute"] is False
+    assert intent["eligible_for_direct_execution"] is False
+    assert intent["actual_writes_enabled"] is False
+
+
+@pytest.mark.parametrize(
+    ("quality_class", "evidence_decision", "expected_status"),
+    [
+        ("thin", "supported", "not_ready"),
+        ("insufficient", "supported", "not_ready"),
+        ("contradictory", "contradiction_detected", "blocked"),
+        ("contradictory", "falsified", "blocked"),
+    ],
+)
+def test_unready_or_falsified_quality_rows_do_not_create_ready_intents(
+    tmp_path: Path,
+    quality_class: str,
+    evidence_decision: str,
+    expected_status: str,
+) -> None:
+    row = _quality_row(
+        quality_class=quality_class,
+        evidence_decision=evidence_decision,
+        promotion_allowed=False,
+    )
+
+    intent = _collect(_artifact_set(tmp_path, quality_rows=[row]))["promotion_intents"][0]
+
+    assert intent["intent_status"] == expected_status
+    assert intent["promotion_target"] == "none"
+    assert intent["actual_writes_enabled"] is False
+
+
+def test_intent_lanes_model_all_future_mutation_lanes_as_intent_only(
+    tmp_path: Path,
+) -> None:
+    intent = _collect(_artifact_set(tmp_path))["promotion_intents"][0]
+
+    assert set(intent["intent_lanes"]) == {
+        "research_action_queue_intent",
+        "generated_seed_intent",
+        "strategy_or_preset_intent",
+        "campaign_intent",
+    }
+    for lane in intent["intent_lanes"].values():
+        assert lane["operator_approval_required"] is True
+        assert lane["actual_writes_enabled"] is False
+        assert lane["safe_to_execute"] is False
+        assert lane["eligible_for_direct_execution"] is False
+
+
+def test_forbidden_actions_include_required_mutation_categories(tmp_path: Path) -> None:
+    intent = _collect(_artifact_set(tmp_path))["promotion_intents"][0]
+    forbidden = set(intent["forbidden_actions"])
+
+    assert "actual_research_action_queue_write_forbidden" in forbidden
+    assert "generated_seed_write_forbidden" in forbidden
+    assert "campaign_queue_mutation_forbidden" in forbidden
+    assert "strategy_or_preset_mutation_forbidden" in forbidden
+    assert "paper_shadow_live_activation_forbidden" in forbidden
+    assert "broker_risk_execution_change_forbidden" in forbidden
+    assert "codex_launch_forbidden" in forbidden
+    assert "branch_pr_automation_forbidden" in forbidden
+
+
+def test_deterministic_promotion_intent_id(tmp_path: Path) -> None:
+    paths = _artifact_set(tmp_path)
+
+    snap_a = _collect(paths)
+    snap_b = _collect(paths)
+
+    assert json.dumps(snap_a, sort_keys=True) == json.dumps(snap_b, sort_keys=True)
+    assert snap_a["promotion_intents"][0]["promotion_intent_id"] == snap_b["promotion_intents"][0][
+        "promotion_intent_id"
+    ]
+
+
+def test_cli_no_write_outputs_json_without_writing(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    paths = _artifact_set(tmp_path)
+    artifact_dir = tmp_path / "logs" / "qre_validated_hypothesis_promotion_intent"
+    latest = artifact_dir / "latest.json"
+    monkeypatch.setattr(promotion, "ARTIFACT_DIR", artifact_dir)
+    monkeypatch.setattr(promotion, "ARTIFACT_LATEST", latest)
+
+    rc = promotion.main(
+        [
+            "--no-write",
+            "--hypotheses-source",
+            str(paths["hypotheses"]),
+            "--results-source",
+            str(paths["results"]),
+            "--evidence-updates-source",
+            str(paths["updates"]),
+            "--evidence-quality-source",
+            str(paths["quality"]),
+            "--frozen-utc",
+            FROZEN,
+            "--indent",
+            "0",
+        ]
+    )
+
+    assert rc == 0
+    assert latest.exists() is False
+    parsed = json.loads(capsys.readouterr().out)
+    assert parsed["promotion_intents"][0]["intent_status"] == "operator_review_required"
+
+
+def test_atomic_write_refuses_outside_artifact_dir(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        promotion._atomic_write_json(tmp_path / "latest.json", {"x": 1})
+
+
+def test_source_has_no_runtime_launch_or_network_calls() -> None:
+    src = Path(promotion.__file__).read_text(encoding="utf-8")
+    forbidden = (
+        "import subprocess",
+        "from subprocess",
+        "subprocess.",
+        "import socket",
+        "from socket",
+        "import requests",
+        "import httpx",
+        "import aiohttp",
+        "import urllib",
+        "from urllib",
+        "os.system",
+        "os.popen",
+        "shell=True",
+        "git ",
+        "gh ",
+        "codex ",
+    )
+    for token in forbidden:
+        assert token not in src, token
+
+
+def test_source_does_not_write_active_or_mutating_paths() -> None:
+    src = Path(promotion.__file__).read_text(encoding="utf-8")
+    forbidden = (
+        "seed.jsonl",
+        "delegation_seed.jsonl",
+        "generated_seed.jsonl",
+        "logs/development_work_queue/latest.json",
+        "research/research_action_queue_latest.v1.json",
+        "campaigns/",
+        "agent/backtesting/strategies.py",
+        "registry.py",
+        "paper/",
+        "shadow/",
+        "live/",
+    )
+    for token in forbidden:
+        assert token not in src, token
+
+
+def test_all_top_level_mutation_flags_are_false(tmp_path: Path) -> None:
+    snap = _collect(_artifact_set(tmp_path))
+
+    _assert_safety_flags_false(snap)
+    _assert_intent_is_never_executable(snap["promotion_intents"][0])


### PR DESCRIPTION
Adds the final conservative trust and promotion-intent layer for the QRE closed-loop scaffold.

Summary:
- Adds reporting/qre_evidence_quality_gate.py
- Adds reporting/qre_validated_hypothesis_promotion_intent.py
- Adds tests for both new modules
- Extends qre_closed_loop_materialization_runner to include the quality and promotion-intent stages
- Classifies evidence quality as insufficient, thin, usable, strong, or contradictory
- Adds validated hypothesis promotion intents as staging-only artifacts
- Models future mutation lanes as intent-only fields:
  - research_action_queue_intent
  - generated_seed_intent
  - strategy_or_preset_intent
  - campaign_intent
- Keeps actual_writes_enabled=false, operator_approval_required=true, safe_to_execute=false, and eligible_for_direct_execution=false

Validation:
- python -m pytest tests/unit/test_qre_evidence_quality_gate.py tests/unit/test_qre_validated_hypothesis_promotion_intent.py -q
  - 29 passed
- python -m pytest tests/unit/test_qre_hypothesis_validation_results.py tests/unit/test_qre_hypothesis_evidence_update.py tests/unit/test_qre_closed_loop_operator_report.py tests/unit/test_qre_trusted_loop_readiness.py tests/unit/test_qre_closed_loop_materialization_runner.py -q
  - 44 passed
- python -m pytest tests/unit/test_qre_market_observation_snapshot.py tests/unit/test_qre_hypothesis_candidates.py tests/unit/test_qre_observation_hypothesis_projector.py tests/unit/test_qre_hypothesis_validation_plan.py tests/unit/test_qre_validation_research_action_candidates.py -q
  - 39 passed
- python -m pytest tests/unit/test_qre_research_action_consumer_gate.py tests/unit/test_qre_development_intake_promotion.py tests/unit/test_qre_development_queue_admission_policy.py -q
  - 53 passed
- Import smoke: imports_ok
- Evidence quality no-write smoke: rows=0, safe_to_execute=false, all mutation flags false
- Promotion intent no-write smoke: promotion_intents=0, safe_to_execute=false, all mutation flags false

Safety:
- No actual queue writes
- No generated seed writes
- No development work queue writes
- No research action queue writes
- No campaign mutation
- No strategy/preset mutation
- No paper/shadow/live activation
- No broker/risk/execution changes
- No Codex launch
- No branch/PR automation
- Future mutation lanes are modeled only as intent/staging fields