### PR TITLE
feat: add qre validation source linkage contract

### DIFF
--- a/reporting/qre_validation_result_linkage_diagnostics.py
+++ b/reporting/qre_validation_result_linkage_diagnostics.py
@@ -12,6 +12,8 @@ from contextlib import suppress
 from pathlib import Path
 from typing import Any, Final
 
+from reporting.qre_validation_source_linkage_contract import REQUIRED_LINKAGE_FIELDS
+
 REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
 
 SCHEMA_VERSION: Final[int] = 1
@@ -703,34 +705,39 @@ def _deterministic_mapping_assessment(
 
 
 def _recommended_linkage_keys() -> list[dict[str, Any]]:
-    return [
-        {
-            "source_field": "hypothesis_id",
+    targets = {
+        "hypothesis_id": {
             "target_artifact": "logs/qre_hypothesis_candidates/latest.json",
             "target_field": "hypotheses[].hypothesis_id",
             "requirement": "stable exact identifier",
         },
-        {
-            "source_field": "candidate_id",
-            "target_artifact": "logs/qre_hypothesis_candidates/latest.json",
-            "target_field": (
-                "hypotheses[].source_candidate_id or " "hypotheses[].source_observation_id"
-            ),
-            "requirement": "stable exact source-to-hypothesis identifier",
-        },
-        {
-            "source_field": "validation_plan_id",
+        "validation_plan_id": {
             "target_artifact": "logs/qre_hypothesis_validation_plans/latest.json",
             "target_field": "validation_plans[].validation_plan_id",
             "requirement": "stable exact validation plan identifier",
         },
-        {
-            "source_field": "run_manifest_id",
+        "run_manifest_id": {
             "target_artifact": "logs/qre_research_run_manifest/latest.json",
             "target_field": "run_manifests[].run_manifest_id",
             "requirement": "stable exact operator-gated run manifest identifier",
         },
-    ]
+        "source_artifact": {
+            "target_artifact": "source artifact path",
+            "target_field": "source_artifact",
+            "requirement": "stable exact source artifact identifier",
+        },
+        "source_report_kind": {
+            "target_artifact": "source artifact payload",
+            "target_field": "report_kind",
+            "requirement": "stable exact source report kind",
+        },
+        "source_row_id": {
+            "target_artifact": "source artifact row",
+            "target_field": "source_row_id",
+            "requirement": "stable exact source row identifier",
+        },
+    }
+    return [{"source_field": field, **targets[field]} for field in REQUIRED_LINKAGE_FIELDS]
 
 
 def collect_snapshot(

--- a/reporting/qre_validation_source_linkage_contract.py
+++ b/reporting/qre_validation_source_linkage_contract.py
@@ -1,0 +1,348 @@
+"""Read-only contract for QRE validation source-row linkage."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import math
+import os
+import tempfile
+from collections.abc import Mapping
+from contextlib import suppress
+from pathlib import Path
+from typing import Final
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[int] = 1
+CONTRACT_VERSION: Final[int] = 1
+REPORT_KIND: Final[str] = "qre_validation_source_linkage_contract"
+
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / REPORT_KIND
+OUTPUT_ARTIFACT_RELATIVE_PATH: Final[str] = f"logs/{REPORT_KIND}/latest.json"
+ARTIFACT_LATEST: Final[Path] = REPO_ROOT / OUTPUT_ARTIFACT_RELATIVE_PATH
+
+REQUIRED_LINKAGE_FIELDS: Final[tuple[str, ...]] = (
+    "hypothesis_id",
+    "validation_plan_id",
+    "run_manifest_id",
+    "source_artifact",
+    "source_report_kind",
+    "source_row_id",
+)
+CONTEXT_LINKAGE_FIELDS: Final[tuple[str, ...]] = (
+    "candidate_id",
+    "strategy_id",
+    "asset",
+    "symbol",
+    "timeframe",
+    "run_id",
+    "plan_id",
+)
+FORBIDDEN_PRIMARY_LINKAGE_FIELDS: Final[tuple[str, ...]] = (
+    "asset",
+    "symbol",
+    "timeframe",
+    "strategy_id",
+)
+REASON_CODE_VOCABULARY: Final[tuple[str, ...]] = (
+    "contract_compliant_exact_ids",
+    "missing_hypothesis_id",
+    "missing_validation_plan_id",
+    "missing_run_manifest_id",
+    "missing_source_artifact",
+    "missing_source_report_kind",
+    "missing_source_row_id",
+    "malformed_source_row",
+    "empty_required_field",
+    "asset_timeframe_only_not_allowed",
+    "symbol_timeframe_only_not_allowed",
+    "strategy_context_only_not_allowed",
+    "candidate_id_context_only_not_allowed",
+    "unsupported_primary_linkage_mode",
+)
+
+_SCALAR_SUMMARY_MAX_CHARS: Final[int] = 96
+_MAX_FIELD_SUMMARIES: Final[int] = len(REQUIRED_LINKAGE_FIELDS) + len(CONTEXT_LINKAGE_FIELDS)
+
+
+def _utcnow() -> str:
+    return _dt.datetime.now(_dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _is_supported_scalar(value: object) -> bool:
+    if value is None or isinstance(value, bool):
+        return False
+    if isinstance(value, str):
+        return True
+    if isinstance(value, int):
+        return True
+    if isinstance(value, float):
+        return math.isfinite(value)
+    return False
+
+
+def _scalar_text(value: object, *, max_len: int = _SCALAR_SUMMARY_MAX_CHARS) -> str:
+    if not _is_supported_scalar(value):
+        return ""
+    text = str(value).strip()
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 3].rstrip() + "..."
+
+
+def _field_summaries(row: Mapping[str, object]) -> dict[str, str]:
+    summaries: dict[str, str] = {}
+    for field in (*REQUIRED_LINKAGE_FIELDS, *CONTEXT_LINKAGE_FIELDS):
+        if field not in row:
+            continue
+        text = _scalar_text(row[field])
+        if text:
+            summaries[field] = text
+        elif not _is_supported_scalar(row[field]):
+            summaries[field] = "<malformed>"
+    if len(summaries) > _MAX_FIELD_SUMMARIES:
+        raise ValueError("internal error: field summaries exceeded bound")
+    return summaries
+
+
+def _missing_reason(field: str) -> str:
+    return f"missing_{field}"
+
+
+def _closed_reason_codes(reason_codes: list[str]) -> list[str]:
+    allowed = set(REASON_CODE_VOCABULARY)
+    ordered = [code for code in REASON_CODE_VOCABULARY if code in set(reason_codes)]
+    if not set(ordered) <= allowed:
+        raise ValueError("internal error: unsupported source linkage reason code")
+    return ordered
+
+
+def validate_source_linkage_contract(row: Mapping[str, object]) -> dict[str, object]:
+    """Return the strict source-linkage contract assessment for one row.
+
+    The contract fails closed. Context fields can help later producers explain
+    a row, but they never substitute for the six exact source-linkage fields.
+    """
+    if not isinstance(row, Mapping):
+        return {
+            "contract_version": CONTRACT_VERSION,
+            "is_contract_compliant": False,
+            "safe_to_link": False,
+            "missing_required_fields": list(REQUIRED_LINKAGE_FIELDS),
+            "present_required_fields": [],
+            "present_context_fields": [],
+            "forbidden_primary_only_fields": [],
+            "primary_linkage_mode": "malformed_source_row",
+            "reason_codes": ["malformed_source_row"],
+            "warnings": [],
+            "field_value_summaries": {},
+        }
+
+    reason_codes: list[str] = []
+    present_required_fields: list[str] = []
+    missing_required_fields: list[str] = []
+    malformed_required = False
+    empty_required = False
+
+    for field in REQUIRED_LINKAGE_FIELDS:
+        value = row.get(field)
+        if not _is_supported_scalar(value):
+            missing_required_fields.append(field)
+            if value is not None:
+                malformed_required = True
+            reason_codes.append(_missing_reason(field))
+            continue
+        if not _scalar_text(value):
+            missing_required_fields.append(field)
+            empty_required = True
+            reason_codes.append(_missing_reason(field))
+            continue
+        present_required_fields.append(field)
+
+    present_context_fields = [
+        field for field in CONTEXT_LINKAGE_FIELDS if _scalar_text(row.get(field))
+    ]
+    forbidden_present_fields = [
+        field for field in FORBIDDEN_PRIMARY_LINKAGE_FIELDS if _scalar_text(row.get(field))
+    ]
+    exact_complete = not missing_required_fields
+    has_required_context = bool(present_required_fields)
+    has_context = bool(present_context_fields)
+
+    if exact_complete:
+        reason_codes.append("contract_compliant_exact_ids")
+        primary_linkage_mode = "exact_ids"
+    else:
+        if malformed_required:
+            reason_codes.append("malformed_source_row")
+        if empty_required:
+            reason_codes.append("empty_required_field")
+        if (
+            not has_required_context
+            and ("asset" in forbidden_present_fields)
+            and ("timeframe" in forbidden_present_fields)
+        ):
+            reason_codes.append("asset_timeframe_only_not_allowed")
+        if (
+            not has_required_context
+            and ("symbol" in forbidden_present_fields)
+            and ("timeframe" in forbidden_present_fields)
+        ):
+            reason_codes.append("symbol_timeframe_only_not_allowed")
+        if not has_required_context and "strategy_id" in forbidden_present_fields:
+            reason_codes.append("strategy_context_only_not_allowed")
+        if not has_required_context and "candidate_id" in present_context_fields:
+            reason_codes.append("candidate_id_context_only_not_allowed")
+        reason_codes.append("unsupported_primary_linkage_mode")
+
+        if not has_required_context and forbidden_present_fields:
+            primary_linkage_mode = "forbidden_context_only"
+        elif not has_required_context and has_context:
+            primary_linkage_mode = "context_only"
+        elif present_required_fields:
+            primary_linkage_mode = "incomplete_exact_ids"
+        else:
+            primary_linkage_mode = "unsupported"
+
+    forbidden_primary_only_fields = (
+        forbidden_present_fields if not exact_complete and not has_required_context else []
+    )
+    closed_codes = _closed_reason_codes(reason_codes)
+    return {
+        "contract_version": CONTRACT_VERSION,
+        "is_contract_compliant": exact_complete,
+        "safe_to_link": exact_complete,
+        "missing_required_fields": missing_required_fields,
+        "present_required_fields": present_required_fields,
+        "present_context_fields": present_context_fields,
+        "forbidden_primary_only_fields": forbidden_primary_only_fields,
+        "primary_linkage_mode": primary_linkage_mode,
+        "reason_codes": closed_codes,
+        "warnings": [],
+        "field_value_summaries": _field_summaries(row),
+    }
+
+
+def _examples() -> dict[str, dict[str, object]]:
+    exact = {
+        "hypothesis_id": "qre-hyp-fixture-001",
+        "validation_plan_id": "qre-plan-fixture-001",
+        "run_manifest_id": "qre-run-fixture-001",
+        "source_artifact": "research/screening_evidence_latest.v1.json",
+        "source_report_kind": "screening_evidence",
+        "source_row_id": "candidate-001",
+    }
+    return {
+        "compliant_exact_ids": validate_source_linkage_contract(exact),
+        "rejected_asset_timeframe_only": validate_source_linkage_contract(
+            {"asset": "BTC-USD", "timeframe": "1h"}
+        ),
+        "rejected_candidate_id_only": validate_source_linkage_contract(
+            {"candidate_id": "candidate-001"}
+        ),
+        "rejected_missing_run_manifest_id": validate_source_linkage_contract(
+            {
+                "hypothesis_id": "qre-hyp-fixture-001",
+                "validation_plan_id": "qre-plan-fixture-001",
+                "source_artifact": "research/screening_evidence_latest.v1.json",
+                "source_report_kind": "screening_evidence",
+                "source_row_id": "candidate-001",
+            }
+        ),
+    }
+
+
+def build_source_linkage_contract_report(
+    *,
+    generated_at_utc: str | None = None,
+) -> dict[str, object]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "contract_version": CONTRACT_VERSION,
+        "generated_at_utc": generated_at_utc or _utcnow(),
+        "output_artifact_path": OUTPUT_ARTIFACT_RELATIVE_PATH,
+        "safe_to_execute": False,
+        "read_only": True,
+        "required_linkage_fields": list(REQUIRED_LINKAGE_FIELDS),
+        "context_linkage_fields": list(CONTEXT_LINKAGE_FIELDS),
+        "forbidden_primary_linkage_fields": list(FORBIDDEN_PRIMARY_LINKAGE_FIELDS),
+        "reason_code_vocabulary": list(REASON_CODE_VOCABULARY),
+        "examples": _examples(),
+    }
+
+
+def _atomic_write_json(path: Path, payload: Mapping[str, object]) -> None:
+    if not path.resolve().is_relative_to(ARTIFACT_DIR.resolve()):
+        raise ValueError(
+            f"refusing write outside QRE validation source linkage contract dir: {path}"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".qre_validation_source_linkage_contract.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        with suppress(OSError):
+            os.unlink(tmp_name)
+        raise
+
+
+def write_source_linkage_contract_report(
+    report: Mapping[str, object] | None = None,
+    *,
+    output_path: Path | None = None,
+) -> Path:
+    target = output_path or ARTIFACT_LATEST
+    _atomic_write_json(target, report or build_source_linkage_contract_report())
+    return target
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="reporting.qre_validation_source_linkage_contract",
+        description="Emit the read-only QRE validation source-linkage contract.",
+    )
+    parser.add_argument("--no-write", action="store_true")
+    parser.add_argument("--frozen-utc", default=None)
+    parser.add_argument("--indent", type=int, default=2)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    report = build_source_linkage_contract_report(generated_at_utc=args.frozen_utc)
+    if not args.no_write:
+        write_source_linkage_contract_report(report)
+    print(json.dumps(report, indent=args.indent, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "ARTIFACT_DIR",
+    "ARTIFACT_LATEST",
+    "CONTEXT_LINKAGE_FIELDS",
+    "CONTRACT_VERSION",
+    "FORBIDDEN_PRIMARY_LINKAGE_FIELDS",
+    "OUTPUT_ARTIFACT_RELATIVE_PATH",
+    "REASON_CODE_VOCABULARY",
+    "REPORT_KIND",
+    "REQUIRED_LINKAGE_FIELDS",
+    "SCHEMA_VERSION",
+    "build_source_linkage_contract_report",
+    "main",
+    "validate_source_linkage_contract",
+    "write_source_linkage_contract_report",
+]

--- a/tests/unit/test_qre_validation_source_linkage_contract.py
+++ b/tests/unit/test_qre_validation_source_linkage_contract.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+from reporting import qre_validation_source_linkage_contract as contract
+
+FROZEN = "2026-06-01T12:00:00Z"
+
+
+def _compliant_row(**overrides: object) -> dict[str, object]:
+    row: dict[str, object] = {
+        "hypothesis_id": "qre-hyp-fixture-001",
+        "validation_plan_id": "qre-plan-fixture-001",
+        "run_manifest_id": "qre-run-fixture-001",
+        "source_artifact": "research/screening_evidence_latest.v1.json",
+        "source_report_kind": "screening_evidence",
+        "source_row_id": "candidate-001",
+    }
+    row.update(overrides)
+    return row
+
+
+def _assert_fails_with(row: object, reason: str, missing_field: str | None = None) -> dict:
+    result = contract.validate_source_linkage_contract(row)  # type: ignore[arg-type]
+    assert result["is_contract_compliant"] is False
+    assert result["safe_to_link"] is False
+    assert reason in result["reason_codes"]
+    if missing_field is not None:
+        assert missing_field in result["missing_required_fields"]
+    return result
+
+
+def test_compliant_row_with_all_required_exact_ids_is_safe_to_link() -> None:
+    result = contract.validate_source_linkage_contract(_compliant_row(candidate_id="candidate-001"))
+
+    assert result["contract_version"] == contract.CONTRACT_VERSION
+    assert result["is_contract_compliant"] is True
+    assert result["safe_to_link"] is True
+    assert result["missing_required_fields"] == []
+    assert result["present_required_fields"] == list(contract.REQUIRED_LINKAGE_FIELDS)
+    assert result["present_context_fields"] == ["candidate_id"]
+    assert result["primary_linkage_mode"] == "exact_ids"
+    assert result["reason_codes"] == ["contract_compliant_exact_ids"]
+
+
+@pytest.mark.parametrize(
+    ("field", "reason"),
+    [
+        ("hypothesis_id", "missing_hypothesis_id"),
+        ("validation_plan_id", "missing_validation_plan_id"),
+        ("run_manifest_id", "missing_run_manifest_id"),
+        ("source_artifact", "missing_source_artifact"),
+        ("source_report_kind", "missing_source_report_kind"),
+        ("source_row_id", "missing_source_row_id"),
+    ],
+)
+def test_missing_required_exact_fields_fail_closed(field: str, reason: str) -> None:
+    row = _compliant_row()
+    row.pop(field)
+
+    result = _assert_fails_with(row, reason, field)
+
+    assert "unsupported_primary_linkage_mode" in result["reason_codes"]
+    assert result["primary_linkage_mode"] == "incomplete_exact_ids"
+
+
+@pytest.mark.parametrize("field", contract.REQUIRED_LINKAGE_FIELDS)
+def test_empty_required_fields_fail_closed(field: str) -> None:
+    result = _assert_fails_with(
+        _compliant_row(**{field: "   "}),
+        "empty_required_field",
+        field,
+    )
+
+    assert f"missing_{field}" in result["reason_codes"]
+
+
+def test_malformed_non_dict_row_fails_closed() -> None:
+    result = _assert_fails_with(["not", "a", "mapping"], "malformed_source_row")
+
+    assert result["missing_required_fields"] == list(contract.REQUIRED_LINKAGE_FIELDS)
+    assert result["primary_linkage_mode"] == "malformed_source_row"
+    assert result["field_value_summaries"] == {}
+
+
+def test_required_field_with_container_value_fails_closed() -> None:
+    result = _assert_fails_with(
+        _compliant_row(source_row_id={"nested": "not allowed"}),
+        "malformed_source_row",
+        "source_row_id",
+    )
+
+    assert result["field_value_summaries"]["source_row_id"] == "<malformed>"
+
+
+def test_candidate_id_only_row_is_not_compliant() -> None:
+    result = _assert_fails_with(
+        {"candidate_id": "candidate-001"},
+        "candidate_id_context_only_not_allowed",
+    )
+
+    assert result["present_context_fields"] == ["candidate_id"]
+    assert result["primary_linkage_mode"] == "context_only"
+
+
+def test_asset_timeframe_only_row_is_not_compliant() -> None:
+    result = _assert_fails_with(
+        {"asset": "BTC-USD", "timeframe": "1h"},
+        "asset_timeframe_only_not_allowed",
+    )
+
+    assert result["forbidden_primary_only_fields"] == ["asset", "timeframe"]
+    assert result["primary_linkage_mode"] == "forbidden_context_only"
+
+
+def test_symbol_timeframe_only_row_is_not_compliant() -> None:
+    result = _assert_fails_with(
+        {"symbol": "BTC-USD", "timeframe": "1h"},
+        "symbol_timeframe_only_not_allowed",
+    )
+
+    assert result["forbidden_primary_only_fields"] == ["symbol", "timeframe"]
+
+
+def test_strategy_id_only_row_is_not_compliant() -> None:
+    result = _assert_fails_with(
+        {"strategy_id": "trend_pullback"},
+        "strategy_context_only_not_allowed",
+    )
+
+    assert result["forbidden_primary_only_fields"] == ["strategy_id"]
+
+
+def test_plan_id_does_not_substitute_for_validation_plan_id() -> None:
+    row = _compliant_row()
+    row.pop("validation_plan_id")
+    row["plan_id"] = "qre-plan-fixture-001"
+
+    result = _assert_fails_with(row, "missing_validation_plan_id", "validation_plan_id")
+
+    assert "plan_id" in result["present_context_fields"]
+    assert "validation_plan_id" not in result["present_required_fields"]
+
+
+def test_run_id_does_not_substitute_for_run_manifest_id() -> None:
+    row = _compliant_row()
+    row.pop("run_manifest_id")
+    row["run_id"] = "qre-run-fixture-001"
+
+    result = _assert_fails_with(row, "missing_run_manifest_id", "run_manifest_id")
+
+    assert "run_id" in result["present_context_fields"]
+    assert "run_manifest_id" not in result["present_required_fields"]
+
+
+def test_output_uses_closed_reason_codes() -> None:
+    rows = [
+        _compliant_row(),
+        {},
+        {"candidate_id": "candidate-001"},
+        {"asset": "BTC-USD", "timeframe": "1h"},
+        {"symbol": "BTC-USD", "timeframe": "1h"},
+        {"strategy_id": "trend_pullback"},
+        _compliant_row(source_row_id=[]),
+    ]
+
+    allowed = set(contract.REASON_CODE_VOCABULARY)
+    for row in rows:
+        result = contract.validate_source_linkage_contract(row)
+        assert set(result["reason_codes"]) <= allowed
+
+
+def test_output_remains_bounded_and_truncated() -> None:
+    long_value = "x" * 1000
+    result = contract.validate_source_linkage_contract(
+        _compliant_row(
+            hypothesis_id=long_value,
+            candidate_id=long_value,
+            asset=long_value,
+        )
+    )
+
+    encoded = json.dumps(result, sort_keys=True)
+    assert len(encoded) < 2500
+    assert long_value not in encoded
+    assert result["field_value_summaries"]["hypothesis_id"].endswith("...")
+    assert len(result["field_value_summaries"]["hypothesis_id"]) <= 96
+
+
+def test_report_schema_and_examples_are_bounded() -> None:
+    report = contract.build_source_linkage_contract_report(generated_at_utc=FROZEN)
+
+    assert report["report_kind"] == contract.REPORT_KIND
+    assert report["schema_version"] == contract.SCHEMA_VERSION
+    assert report["contract_version"] == contract.CONTRACT_VERSION
+    assert report["safe_to_execute"] is False
+    assert report["read_only"] is True
+    assert report["required_linkage_fields"] == list(contract.REQUIRED_LINKAGE_FIELDS)
+    assert report["context_linkage_fields"] == list(contract.CONTEXT_LINKAGE_FIELDS)
+    assert report["forbidden_primary_linkage_fields"] == list(
+        contract.FORBIDDEN_PRIMARY_LINKAGE_FIELDS
+    )
+    assert report["reason_code_vocabulary"] == list(contract.REASON_CODE_VOCABULARY)
+    assert set(report["examples"]) == {
+        "compliant_exact_ids",
+        "rejected_asset_timeframe_only",
+        "rejected_candidate_id_only",
+        "rejected_missing_run_manifest_id",
+    }
+    assert len(json.dumps(report["examples"], sort_keys=True)) < 7000
+
+
+def test_report_writer_writes_only_contract_latest_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    artifact_dir = tmp_path / "logs" / contract.REPORT_KIND
+    latest = artifact_dir / "latest.json"
+    monkeypatch.setattr(contract, "ARTIFACT_DIR", artifact_dir)
+    monkeypatch.setattr(contract, "ARTIFACT_LATEST", latest)
+    report = contract.build_source_linkage_contract_report(generated_at_utc=FROZEN)
+
+    written = contract.write_source_linkage_contract_report(report)
+
+    assert written == latest
+    assert latest.exists()
+    assert [path.relative_to(tmp_path).as_posix() for path in tmp_path.rglob("*.json")] == [
+        "logs/qre_validation_source_linkage_contract/latest.json"
+    ]
+    payload = json.loads(latest.read_text(encoding="utf-8"))
+    assert payload["safe_to_execute"] is False
+    assert payload["read_only"] is True
+    assert "required_linkage_fields" in payload
+    assert "context_linkage_fields" in payload
+    assert "forbidden_primary_linkage_fields" in payload
+    assert "reason_code_vocabulary" in payload
+    with pytest.raises(ValueError):
+        contract.write_source_linkage_contract_report(report, output_path=tmp_path / "outside.json")
+
+
+def test_forbidden_calls_imports_and_mutating_paths_absent() -> None:
+    src = Path(contract.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    imported_modules: set[str] = set()
+    forbidden_runtime_modules = (
+        "broker",
+        "live",
+        "paper",
+        "shadow",
+        "risk",
+        "trading",
+        "execution",
+    )
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported_modules.add(node.module)
+        elif isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
+                assert (func.value.id, func.attr) != ("os", "system")
+                assert func.value.id != "subprocess"
+
+    assert "subprocess" not in imported_modules
+    for module in imported_modules:
+        root = module.split(".")[0]
+        assert root not in forbidden_runtime_modules
+    for token in (
+        "generated_seed.jsonl",
+        "seed.jsonl",
+        "logs/development_work_queue/latest.json",
+        "research/research_action_queue_latest.v1.json",
+        "agent/backtesting/strategies.py",
+        "registry.py",
+        "research/research_latest.json",
+        "strategy_matrix.csv",
+        "codex",
+    ):
+        assert token not in src


### PR DESCRIPTION
## Summary
- Add a read-only QRE validation source linkage contract module with strict exact-ID linkage requirements.
- Add bounded contract report generation for `logs/qre_validation_source_linkage_contract/latest.json` with `safe_to_execute=false` and `read_only=true`.
- Update linkage diagnostics recommended linkage keys to source the exact required fields from the new contract constants without changing diagnostic classification/materialization behavior.

## Validation
- `python -m pytest tests/unit/test_qre_validation_source_linkage_contract.py -q`
- `python -m pytest tests/unit/test_qre_validation_result_linkage_diagnostics.py -q`
- `python -m pytest tests/unit/test_qre_hypothesis_validation_results.py -q`
- `python -m ruff check reporting/qre_validation_source_linkage_contract.py reporting/qre_validation_result_linkage_diagnostics.py tests/unit/test_qre_validation_source_linkage_contract.py`
- `python -m ruff format --check reporting/qre_validation_source_linkage_contract.py reporting/qre_validation_result_linkage_diagnostics.py tests/unit/test_qre_validation_source_linkage_contract.py`
- `python -m pytest tests/architecture/test_domain_boundary_smoke.py -q`
- `python -m pytest tests/smoke/test_smoke.py -q`
- `python -m reporting.qre_validation_result_linkage_diagnostics --no-write --indent 0`
- `python -m reporting.qre_validation_source_linkage_contract`