### PR TITLE
feat: add qre screening evidence validation linkage

### DIFF
--- a/research/run_research.py
+++ b/research/run_research.py
@@ -165,6 +165,7 @@ from research.viability_metrics import write_viability_artifact
 from research.results import make_result_row, write_latest_json, write_results_to_csv
 from research.screening_evidence import (
     SCREENING_EVIDENCE_PATH,
+    build_qre_validation_linkage_authority,
     build_screening_evidence_payload,
 )
 from research.screening_process import execute_screening_candidate_isolated
@@ -215,6 +216,11 @@ RUN_CAMPAIGN_PROGRESS_PATH = Path("research/run_campaign_progress_latest.v1.json
 RUN_PROGRESS_PATH = Path("research/run_progress_latest.v1.json")
 RUN_STATE_PATH = Path("research/run_state.v1.json")
 RUN_MANIFEST_PATH = Path("research/run_manifest_latest.v1.json")
+QRE_HYPOTHESIS_CANDIDATES_PATH = Path("logs/qre_hypothesis_candidates/latest.json")
+QRE_HYPOTHESIS_VALIDATION_PLANS_PATH = Path(
+    "logs/qre_hypothesis_validation_plans/latest.json"
+)
+QRE_RESEARCH_RUN_MANIFEST_PATH = Path("logs/qre_research_run_manifest/latest.json")
 INTEGRITY_REPORT_PATH = Path("research/integrity_report_latest.v1.json")
 FALSIFICATION_GATES_PATH = Path("research/falsification_gates_latest.v1.json")
 RUN_LOG_DIR = Path("logs/research")
@@ -3645,6 +3651,17 @@ def run_research(
         screening_evidence_payload: dict[str, Any] | None = None
         try:
             paper_blocked_index = _read_paper_blocked_index()
+            qre_validation_linkage_authority = build_qre_validation_linkage_authority(
+                hypothesis_candidates_payload=_read_json_if_exists(
+                    QRE_HYPOTHESIS_CANDIDATES_PATH
+                ),
+                validation_plans_payload=_read_json_if_exists(
+                    QRE_HYPOTHESIS_VALIDATION_PLANS_PATH
+                ),
+                run_manifest_payload=_read_json_if_exists(
+                    QRE_RESEARCH_RUN_MANIFEST_PATH
+                ),
+            )
             screening_pass_kinds_by_strategy: dict[str, str | None] = {}
             for _candidate_for_evidence in candidates:
                 screening_block = (
@@ -3675,6 +3692,7 @@ def run_research(
                 screening_records=screening_records,
                 screening_pass_kinds=screening_pass_kinds_by_strategy,
                 paper_blocked_index=paper_blocked_index,
+                qre_validation_linkage_authority=qre_validation_linkage_authority,
             )
             write_sidecar_atomic(SCREENING_EVIDENCE_PATH, evidence_payload)
             screening_evidence_payload = evidence_payload

--- a/research/screening_evidence.py
+++ b/research/screening_evidence.py
@@ -49,11 +49,10 @@ from research.screening_criteria import (
     EXPLORATORY_MIN_PROFIT_FACTOR,
 )
 
-
-SCREENING_EVIDENCE_PATH: Final[Path] = Path(
-    "research/screening_evidence_latest.v1.json"
-)
-SCREENING_EVIDENCE_SCHEMA_VERSION: Final[str] = "1.0"
+SCREENING_EVIDENCE_PATH: Final[Path] = Path("research/screening_evidence_latest.v1.json")
+SCREENING_EVIDENCE_SCHEMA_VERSION: Final[str] = "1.1"
+SCREENING_EVIDENCE_SOURCE_ARTIFACT: Final[str] = "research/screening_evidence_latest.v1.json"
+SCREENING_EVIDENCE_SOURCE_REPORT_KIND: Final[str] = "screening_evidence"
 
 
 # v3.15.9 near-pass band constants (REV 3 §6.10).
@@ -116,6 +115,13 @@ PER_CANDIDATE_KEYS: Final[frozenset[str]] = frozenset(
         "asset",
         "interval",
         "hypothesis_id",
+        "validation_plan_id",
+        "run_manifest_id",
+        "source_artifact",
+        "source_report_kind",
+        "source_row_id",
+        "qre_validation_linkage_status",
+        "qre_validation_linkage_warnings",
         "preset_name",
         "screening_phase",
         "stage_result",
@@ -215,7 +221,10 @@ def is_near_pass(
     max_drawdown = to_json_safe_float(metrics.get("max_drawdown"))
 
     if reason == "expectancy_not_positive":
-        if expectancy is not None and -EXPLORATORY_EXPECTANCY_NEAR_BAND <= expectancy <= EXPLORATORY_MIN_EXPECTANCY:
+        if (
+            expectancy is not None
+            and -EXPLORATORY_EXPECTANCY_NEAR_BAND <= expectancy <= EXPLORATORY_MIN_EXPECTANCY
+        ):
             return True, {
                 "nearest_failed_criterion": reason,
                 "distance": abs(expectancy),
@@ -258,9 +267,9 @@ def dominant_failure_reasons(candidates: list[dict[str, Any]]) -> list[str]:
     for record in candidates:
         for reason in record.get("failure_reasons") or []:
             counter[str(reason)] += 1
-    return [reason for reason, _count in sorted(
-        counter.items(), key=lambda item: (-item[1], item[0])
-    )]
+    return [
+        reason for reason, _count in sorted(counter.items(), key=lambda item: (-item[1], item[0]))
+    ]
 
 
 def resolve_stage_result(
@@ -303,9 +312,7 @@ def _fallback_candidate_id(candidate: dict[str, Any]) -> str:
     base = json.dumps(
         {
             "strategy_id": str(
-                candidate.get("strategy_id")
-                or candidate.get("strategy_name")
-                or ""
+                candidate.get("strategy_id") or candidate.get("strategy_name") or ""
             ),
             "asset": str(candidate.get("asset") or ""),
             "interval": str(candidate.get("interval") or ""),
@@ -316,6 +323,208 @@ def _fallback_candidate_id(candidate: dict[str, Any]) -> str:
         allow_nan=False,
     )
     return "fb_" + hashlib.sha1(base.encode("utf-8")).hexdigest()[:16]
+
+
+def _bounded_str(value: Any, *, max_len: int = 240) -> str:
+    text = str(value or "").strip()
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 3].rstrip() + "..."
+
+
+def _safe_dict_rows(payload: dict[str, Any] | None, field: str) -> list[dict[str, Any]] | None:
+    if not isinstance(payload, dict):
+        return None
+    rows = payload.get(field)
+    if not isinstance(rows, list) or not all(isinstance(item, dict) for item in rows):
+        return None
+    return rows
+
+
+def build_qre_validation_linkage_authority(
+    *,
+    hypothesis_candidates_payload: dict[str, Any] | None,
+    validation_plans_payload: dict[str, Any] | None,
+    run_manifest_payload: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Build exact QRE validation-linkage authority for screening rows.
+
+    The authority is intentionally strict: it only links by an existing
+    ``hypothesis_id`` that is present in the QRE hypothesis artifact and
+    resolves to exactly one validation plan and exactly one run manifest.
+    Asset, symbol, timeframe, strategy, filename, and candidate-only
+    matching are not used.
+    """
+    warnings: list[str] = []
+    hypotheses = _safe_dict_rows(hypothesis_candidates_payload, "hypotheses")
+    plans = _safe_dict_rows(validation_plans_payload, "validation_plans")
+    manifests = _safe_dict_rows(run_manifest_payload, "run_manifests")
+
+    if (
+        not isinstance(hypothesis_candidates_payload, dict)
+        or hypothesis_candidates_payload.get("report_kind") != "qre_hypothesis_candidates"
+        or hypotheses is None
+    ):
+        warnings.append("qre_hypothesis_authority_absent_or_unparseable")
+    if (
+        not isinstance(validation_plans_payload, dict)
+        or validation_plans_payload.get("report_kind") != "qre_hypothesis_validation_plan"
+        or plans is None
+    ):
+        warnings.append("qre_validation_plan_authority_absent_or_unparseable")
+    if (
+        not isinstance(run_manifest_payload, dict)
+        or run_manifest_payload.get("report_kind") != "qre_research_run_manifest"
+        or manifests is None
+    ):
+        warnings.append("qre_run_manifest_authority_absent_or_unparseable")
+
+    if warnings:
+        return {
+            "available": False,
+            "warnings": warnings,
+            "by_hypothesis_id": {},
+        }
+
+    hypothesis_ids = {
+        _bounded_str(item.get("hypothesis_id"), max_len=160)
+        for item in hypotheses or []
+        if _bounded_str(item.get("hypothesis_id"), max_len=160)
+    }
+    plans_by_hypothesis: dict[str, list[str]] = {}
+    for item in plans or []:
+        hypothesis_id = _bounded_str(item.get("hypothesis_id"), max_len=160)
+        plan_id = _bounded_str(item.get("validation_plan_id"), max_len=160)
+        if hypothesis_id in hypothesis_ids and plan_id:
+            plans_by_hypothesis.setdefault(hypothesis_id, []).append(plan_id)
+    for values in plans_by_hypothesis.values():
+        values.sort()
+
+    manifests_by_plan: dict[str, list[str]] = {}
+    for item in manifests or []:
+        plan_id = _bounded_str(item.get("target_validation_plan_id"), max_len=160)
+        manifest_id = _bounded_str(item.get("run_manifest_id"), max_len=160)
+        if plan_id and manifest_id:
+            manifests_by_plan.setdefault(plan_id, []).append(manifest_id)
+    for values in manifests_by_plan.values():
+        values.sort()
+
+    by_hypothesis_id: dict[str, dict[str, Any]] = {}
+    for hypothesis_id in sorted(hypothesis_ids):
+        plan_ids = plans_by_hypothesis.get(hypothesis_id, [])
+        if not plan_ids:
+            by_hypothesis_id[hypothesis_id] = {
+                "status": "unlinked_missing_validation_plan_id",
+                "warnings": ["qre_validation_plan_id_not_found_for_hypothesis"],
+            }
+            continue
+        if len(plan_ids) != 1:
+            by_hypothesis_id[hypothesis_id] = {
+                "status": "unlinked_ambiguous_validation_plan_id",
+                "warnings": ["qre_validation_plan_id_not_unique_for_hypothesis"],
+            }
+            continue
+
+        plan_id = plan_ids[0]
+        manifest_ids = manifests_by_plan.get(plan_id, [])
+        if not manifest_ids:
+            by_hypothesis_id[hypothesis_id] = {
+                "status": "unlinked_missing_run_manifest_id",
+                "validation_plan_id": plan_id,
+                "warnings": ["qre_run_manifest_id_not_found_for_validation_plan"],
+            }
+            continue
+        if len(manifest_ids) != 1:
+            by_hypothesis_id[hypothesis_id] = {
+                "status": "unlinked_ambiguous_run_manifest_id",
+                "validation_plan_id": plan_id,
+                "warnings": ["qre_run_manifest_id_not_unique_for_validation_plan"],
+            }
+            continue
+
+        by_hypothesis_id[hypothesis_id] = {
+            "status": "linked_exact_ids",
+            "hypothesis_id": hypothesis_id,
+            "validation_plan_id": plan_id,
+            "run_manifest_id": manifest_ids[0],
+            "warnings": [],
+        }
+
+    return {
+        "available": True,
+        "warnings": [],
+        "by_hypothesis_id": by_hypothesis_id,
+    }
+
+
+def _qre_validation_linkage_fields(
+    *,
+    hypothesis_id: str | None,
+    source_row_id: str,
+    qre_validation_linkage_authority: dict[str, Any] | None,
+) -> dict[str, Any]:
+    fields: dict[str, Any] = {
+        "validation_plan_id": None,
+        "run_manifest_id": None,
+        "source_artifact": SCREENING_EVIDENCE_SOURCE_ARTIFACT,
+        "source_report_kind": SCREENING_EVIDENCE_SOURCE_REPORT_KIND,
+        "source_row_id": source_row_id,
+        "qre_validation_linkage_status": "unlinked_reference_authority_unavailable",
+        "qre_validation_linkage_warnings": ["qre_validation_linkage_authority_absent"],
+    }
+    if not isinstance(qre_validation_linkage_authority, dict):
+        return fields
+
+    authority_warnings = [
+        _bounded_str(item, max_len=120)
+        for item in qre_validation_linkage_authority.get("warnings", [])
+        if _bounded_str(item, max_len=120)
+    ]
+    if not qre_validation_linkage_authority.get("available"):
+        fields["qre_validation_linkage_warnings"] = authority_warnings or [
+            "qre_validation_linkage_authority_unavailable"
+        ]
+        return fields
+
+    if not hypothesis_id:
+        fields["qre_validation_linkage_status"] = "unlinked_missing_hypothesis_id"
+        fields["qre_validation_linkage_warnings"] = ["screening_row_missing_hypothesis_id"]
+        return fields
+
+    by_hypothesis = qre_validation_linkage_authority.get("by_hypothesis_id")
+    if not isinstance(by_hypothesis, dict):
+        return fields
+    entry = by_hypothesis.get(hypothesis_id)
+    if not isinstance(entry, dict):
+        fields["qre_validation_linkage_status"] = "unlinked_unknown_hypothesis_id"
+        fields["qre_validation_linkage_warnings"] = [
+            "screening_row_hypothesis_id_not_in_qre_authority"
+        ]
+        return fields
+
+    fields["qre_validation_linkage_status"] = (
+        _bounded_str(entry.get("status"), max_len=80) or "unlinked_incomplete_qre_authority"
+    )
+    fields["qre_validation_linkage_warnings"] = [
+        _bounded_str(item, max_len=120)
+        for item in entry.get("warnings", [])
+        if _bounded_str(item, max_len=120)
+    ]
+    if fields["qre_validation_linkage_status"] != "linked_exact_ids":
+        return fields
+
+    fields["validation_plan_id"] = (
+        _bounded_str(entry.get("validation_plan_id"), max_len=160) or None
+    )
+    fields["run_manifest_id"] = _bounded_str(entry.get("run_manifest_id"), max_len=160) or None
+    if not fields["validation_plan_id"] or not fields["run_manifest_id"]:
+        fields["validation_plan_id"] = None
+        fields["run_manifest_id"] = None
+        fields["qre_validation_linkage_status"] = "unlinked_incomplete_qre_authority"
+        fields["qre_validation_linkage_warnings"] = [
+            "qre_validation_authority_missing_required_exact_id"
+        ]
+    return fields
 
 
 def _coerce_metrics(raw: dict[str, Any]) -> dict[str, float | None]:
@@ -373,6 +582,7 @@ def _build_candidate_record(
     paper_blocking_reasons: list[str],
     preset_name: str | None,
     screening_phase: str | None,
+    qre_validation_linkage_authority: dict[str, Any] | None,
 ) -> dict[str, Any]:
     """Build one per-candidate evidence record (without fingerprint).
 
@@ -382,7 +592,7 @@ def _build_candidate_record(
     """
     raw_id = candidate.get("candidate_id")
     identity_fallback_used = False
-    if raw_id is None or not isinstance(raw_id, (str, int)) or str(raw_id).strip() == "":
+    if raw_id is None or not isinstance(raw_id, str | int) or str(raw_id).strip() == "":
         candidate_id = _fallback_candidate_id(candidate)
         identity_fallback_used = True
     else:
@@ -414,9 +624,7 @@ def _build_candidate_record(
     }
     if near_is_near and near_payload is not None:
         near_block["distance"] = to_json_safe_float(near_payload.get("distance"))
-        near_block["nearest_failed_criterion"] = str(
-            near_payload.get("nearest_failed_criterion")
-        )
+        near_block["nearest_failed_criterion"] = str(near_payload.get("nearest_failed_criterion"))
 
     validation = candidate.get("validation") or {}
     if isinstance(validation, dict):
@@ -445,35 +653,35 @@ def _build_candidate_record(
 
     promotion_guard = {
         "promotion_allowed": (
-            stage_result == STAGE_RESULT_DOWNSTREAM_PROMOTION
-            and not paper_blocked
+            stage_result == STAGE_RESULT_DOWNSTREAM_PROMOTION and not paper_blocked
         ),
         "blocked_by": list(paper_blocking_reasons) if paper_blocking_reasons else [],
     }
 
+    hypothesis_id = (
+        str(candidate.get("hypothesis_id")) if candidate.get("hypothesis_id") is not None else None
+    )
+    qre_linkage = _qre_validation_linkage_fields(
+        hypothesis_id=hypothesis_id,
+        source_row_id=candidate_id,
+        qre_validation_linkage_authority=qre_validation_linkage_authority,
+    )
+
     record: dict[str, Any] = {
         "candidate_id": candidate_id,
         "identity_fallback_used": identity_fallback_used,
-        "strategy_id": str(
-            candidate.get("strategy_id")
-            or candidate.get("strategy_name")
-            or ""
-        ) or None,
+        "strategy_id": str(candidate.get("strategy_id") or candidate.get("strategy_name") or "")
+        or None,
         "strategy_name": str(candidate.get("strategy_name") or "") or None,
         "asset": str(candidate.get("asset") or "") or None,
         "interval": str(candidate.get("interval") or "") or None,
-        "hypothesis_id": (
-            str(candidate.get("hypothesis_id"))
-            if candidate.get("hypothesis_id") is not None
-            else None
-        ),
+        "hypothesis_id": hypothesis_id,
+        **qre_linkage,
         "preset_name": preset_name,
         "screening_phase": screening_phase,
         "stage_result": stage_result,
         "pass_kind": pass_kind if isinstance(pass_kind, str) else None,
-        "screening_criteria_set": str(
-            screening_record.get("screening_criteria_set") or "legacy"
-        ),
+        "screening_criteria_set": str(screening_record.get("screening_criteria_set") or "legacy"),
         "metrics": metrics,
         "criteria": _criteria_split(
             screening_phase=screening_phase,
@@ -545,6 +753,7 @@ def build_screening_evidence_payload(
     screening_pass_kinds: dict[str, str | None],
     paper_blocked_index: dict[str, list[str]],
     promotion_status_index: dict[str, str] | None = None,
+    qre_validation_linkage_authority: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build the full ``screening_evidence_latest.v1.json`` payload.
 
@@ -569,23 +778,15 @@ def build_screening_evidence_payload(
     for candidate in candidates:
         raw_id = candidate.get("candidate_id")
         candidate_record: dict[str, Any] | None = (
-            screening_record_by_id.get(str(raw_id))
-            if raw_id is not None
-            else None
+            screening_record_by_id.get(str(raw_id)) if raw_id is not None else None
         )
         if candidate_record is None:
             candidate_record = {}
-        strategy_id = (
-            candidate.get("strategy_id")
-            or candidate.get("strategy_name")
-            or ""
-        )
+        strategy_id = candidate.get("strategy_id") or candidate.get("strategy_name") or ""
         pass_kind = screening_pass_kinds.get(str(strategy_id))
         promotion_status = promotion_index.get(str(strategy_id))
         paper_blocking_reasons = list(
-            paper_blocked_index.get(str(raw_id), [])
-            if raw_id is not None
-            else []
+            paper_blocked_index.get(str(raw_id), []) if raw_id is not None else []
         )
         candidate_records.append(
             _build_candidate_record(
@@ -596,6 +797,7 @@ def build_screening_evidence_payload(
                 paper_blocking_reasons=paper_blocking_reasons,
                 preset_name=preset_name,
                 screening_phase=screening_phase,
+                qre_validation_linkage_authority=qre_validation_linkage_authority,
             )
         )
 
@@ -605,9 +807,7 @@ def build_screening_evidence_payload(
         "git_revision": git_revision,
         "run_id": str(run_id),
         "campaign_id": str(campaign_id) if campaign_id is not None else None,
-        "col_campaign_id": (
-            str(col_campaign_id) if col_campaign_id is not None else None
-        ),
+        "col_campaign_id": (str(col_campaign_id) if col_campaign_id is not None else None),
         "preset_name": preset_name,
         "screening_phase": screening_phase,
         "summary": _summarise(candidate_records),

--- a/tests/regression/test_v3_15_9_screening_evidence_schema_pin.py
+++ b/tests/regression/test_v3_15_9_screening_evidence_schema_pin.py
@@ -18,7 +18,6 @@ from research.screening_evidence import (
     build_screening_evidence_payload,
 )
 
-
 _EXPECTED_TOP_LEVEL_KEYS = frozenset(
     {
         "schema_version",
@@ -43,6 +42,13 @@ _EXPECTED_PER_CANDIDATE_KEYS = frozenset(
         "asset",
         "interval",
         "hypothesis_id",
+        "validation_plan_id",
+        "run_manifest_id",
+        "source_artifact",
+        "source_report_kind",
+        "source_row_id",
+        "qre_validation_linkage_status",
+        "qre_validation_linkage_warnings",
         "preset_name",
         "screening_phase",
         "stage_result",
@@ -74,8 +80,8 @@ _EXPECTED_SUMMARY_KEYS = frozenset(
 )
 
 
-def test_schema_version_pinned_at_1_0() -> None:
-    assert SCREENING_EVIDENCE_SCHEMA_VERSION == "1.0"
+def test_schema_version_pinned_at_1_1() -> None:
+    assert SCREENING_EVIDENCE_SCHEMA_VERSION == "1.1"
 
 
 def test_module_constant_top_level_keys_match_pinned_set() -> None:
@@ -102,6 +108,7 @@ def test_emitted_payload_top_level_keys_match() -> None:
     )
     assert set(payload.keys()) == _EXPECTED_TOP_LEVEL_KEYS
     assert set(payload["summary"].keys()) == _EXPECTED_SUMMARY_KEYS
+
 
 def test_screening_evidence_carries_validation_evidence_status() -> None:
     payload = build_screening_evidence_payload(

--- a/tests/unit/test_screening_evidence_validation_linkage.py
+++ b/tests/unit/test_screening_evidence_validation_linkage.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from reporting.qre_validation_source_linkage_contract import (
+    validate_source_linkage_contract,
+)
+from research.screening_evidence import (
+    SCREENING_EVIDENCE_SOURCE_ARTIFACT,
+    SCREENING_EVIDENCE_SOURCE_REPORT_KIND,
+    build_qre_validation_linkage_authority,
+    build_screening_evidence_payload,
+)
+
+FROZEN = datetime(2026, 6, 1, 12, 0, 0, tzinfo=UTC)
+HYPOTHESIS_ID = "qre-hyp-fixture-001"
+PLAN_ID = "qre-plan-fixture-001"
+RUN_MANIFEST_ID = "qre-run-fixture-001"
+_DEFAULT = object()
+
+
+def _authority(
+    *,
+    hypotheses: dict | None | object = _DEFAULT,
+    plans: dict | None | object = _DEFAULT,
+    manifests: dict | None | object = _DEFAULT,
+) -> dict:
+    return build_qre_validation_linkage_authority(
+        hypothesis_candidates_payload=(
+            hypotheses
+            if hypotheses is not _DEFAULT
+            else {
+                "report_kind": "qre_hypothesis_candidates",
+                "hypotheses": [{"hypothesis_id": HYPOTHESIS_ID}],
+            }
+        ),
+        validation_plans_payload=(
+            plans
+            if plans is not _DEFAULT
+            else {
+                "report_kind": "qre_hypothesis_validation_plan",
+                "validation_plans": [
+                    {
+                        "hypothesis_id": HYPOTHESIS_ID,
+                        "validation_plan_id": PLAN_ID,
+                    }
+                ],
+            }
+        ),
+        run_manifest_payload=(
+            manifests
+            if manifests is not _DEFAULT
+            else {
+                "report_kind": "qre_research_run_manifest",
+                "run_manifests": [
+                    {
+                        "run_manifest_id": RUN_MANIFEST_ID,
+                        "target_hypothesis_id": HYPOTHESIS_ID,
+                        "target_validation_plan_id": PLAN_ID,
+                    }
+                ],
+            }
+        ),
+    )
+
+
+def _payload(*, candidate: dict | None = None, authority: dict | None = None) -> dict:
+    row = {
+        "candidate_id": "candidate-001",
+        "strategy_id": "strategy-a",
+        "strategy_name": "strategy-a",
+        "asset": "BTC-USD",
+        "interval": "1h",
+        "hypothesis_id": HYPOTHESIS_ID,
+    }
+    if candidate is not None:
+        row.update(candidate)
+    return build_screening_evidence_payload(
+        run_id="run-1",
+        as_of_utc=FROZEN,
+        git_revision="abc123",
+        campaign_id="cmp-1",
+        col_campaign_id="cmp-1",
+        preset_name="preset-a",
+        screening_phase="exploratory",
+        candidates=[row],
+        screening_records=[
+            {
+                "candidate_id": row["candidate_id"],
+                "final_status": "passed",
+                "decision": "promoted_to_validation",
+                "diagnostic_metrics": {"profit_factor": 1.4},
+            }
+        ],
+        screening_pass_kinds={"strategy-a": "exploratory"},
+        paper_blocked_index={},
+        qre_validation_linkage_authority=authority,
+    )
+
+
+def test_screening_rows_include_source_artifact_kind_and_stable_row_id() -> None:
+    row = _payload(authority=_authority())["candidates"][0]
+
+    assert row["source_artifact"] == SCREENING_EVIDENCE_SOURCE_ARTIFACT
+    assert row["source_report_kind"] == SCREENING_EVIDENCE_SOURCE_REPORT_KIND
+    assert row["source_row_id"] == "candidate-001"
+
+
+def test_exact_qre_authority_adds_all_strict_linkage_fields() -> None:
+    row = _payload(authority=_authority())["candidates"][0]
+
+    assert row["hypothesis_id"] == HYPOTHESIS_ID
+    assert row["validation_plan_id"] == PLAN_ID
+    assert row["run_manifest_id"] == RUN_MANIFEST_ID
+    assert row["qre_validation_linkage_status"] == "linked_exact_ids"
+    assert row["qre_validation_linkage_warnings"] == []
+
+
+def test_emitted_strict_linked_row_passes_source_linkage_contract() -> None:
+    row = _payload(authority=_authority())["candidates"][0]
+
+    result = validate_source_linkage_contract(row)
+
+    assert result["is_contract_compliant"] is True
+    assert result["safe_to_link"] is True
+    assert result["primary_linkage_mode"] == "exact_ids"
+
+
+def test_source_row_id_is_deterministic_across_repeated_generation() -> None:
+    authority = _authority()
+    row_a = _payload(authority=authority)["candidates"][0]
+    row_b = _payload(authority=authority)["candidates"][0]
+
+    assert row_a["source_row_id"] == row_b["source_row_id"] == "candidate-001"
+    assert row_a["source_artifact"] == row_b["source_artifact"]
+    assert row_a["source_report_kind"] == row_b["source_report_kind"]
+
+
+def test_asset_symbol_timeframe_only_linkage_is_not_contract_compliant() -> None:
+    result = validate_source_linkage_contract(
+        {"asset": "BTC-USD", "symbol": "BTC-USD", "timeframe": "1h"}
+    )
+
+    assert result["is_contract_compliant"] is False
+    assert result["safe_to_link"] is False
+    assert "asset_timeframe_only_not_allowed" in result["reason_codes"]
+    assert "symbol_timeframe_only_not_allowed" in result["reason_codes"]
+
+
+def test_missing_reference_artifacts_do_not_fabricate_plan_or_run_ids() -> None:
+    row = _payload(authority=_authority(hypotheses=None, plans=None, manifests=None))["candidates"][
+        0
+    ]
+
+    assert row["validation_plan_id"] is None
+    assert row["run_manifest_id"] is None
+    assert row["qre_validation_linkage_status"] != "linked_exact_ids"
+
+
+def test_missing_hypothesis_artifact_fails_closed() -> None:
+    row = _payload(authority=_authority(hypotheses={"report_kind": "wrong"}))["candidates"][0]
+
+    assert row["validation_plan_id"] is None
+    assert row["run_manifest_id"] is None
+    assert (
+        "qre_hypothesis_authority_absent_or_unparseable" in row["qre_validation_linkage_warnings"]
+    )
+
+
+def test_missing_validation_plan_artifact_fails_closed() -> None:
+    row = _payload(authority=_authority(plans={"report_kind": "wrong"}))["candidates"][0]
+
+    assert row["validation_plan_id"] is None
+    assert row["run_manifest_id"] is None
+    assert (
+        "qre_validation_plan_authority_absent_or_unparseable"
+        in row["qre_validation_linkage_warnings"]
+    )
+
+
+def test_missing_run_manifest_artifact_fails_closed() -> None:
+    row = _payload(authority=_authority(manifests={"report_kind": "wrong"}))["candidates"][0]
+
+    assert row["validation_plan_id"] is None
+    assert row["run_manifest_id"] is None
+    assert (
+        "qre_run_manifest_authority_absent_or_unparseable" in row["qre_validation_linkage_warnings"]
+    )
+
+
+def test_unknown_hypothesis_id_does_not_fabricate_ids() -> None:
+    row = _payload(
+        candidate={"hypothesis_id": "not-in-qre-authority"},
+        authority=_authority(),
+    )["candidates"][0]
+
+    assert row["validation_plan_id"] is None
+    assert row["run_manifest_id"] is None
+    assert row["qre_validation_linkage_status"] == "unlinked_unknown_hypothesis_id"
+
+
+def test_candidate_id_only_is_not_used_as_primary_linkage() -> None:
+    row = _payload(candidate={"hypothesis_id": None}, authority=_authority())["candidates"][0]
+
+    assert row["hypothesis_id"] is None
+    assert row["validation_plan_id"] is None
+    assert row["run_manifest_id"] is None
+    assert row["qre_validation_linkage_status"] == "unlinked_missing_hypothesis_id"

--- a/tests/unit/test_v3_15_9_artifact_top_level_schema_pin.py
+++ b/tests/unit/test_v3_15_9_artifact_top_level_schema_pin.py
@@ -33,10 +33,10 @@ def _empty_payload() -> dict:
     )
 
 
-def test_schema_version_is_1_0() -> None:
-    assert SCREENING_EVIDENCE_SCHEMA_VERSION == "1.0"
+def test_schema_version_is_1_1() -> None:
+    assert SCREENING_EVIDENCE_SCHEMA_VERSION == "1.1"
     payload = _empty_payload()
-    assert payload["schema_version"] == "1.0"
+    assert payload["schema_version"] == "1.1"
 
 
 def test_top_level_keys_are_closed_set() -> None:


### PR DESCRIPTION
## Summary
- Adds strict QRE validation linkage fields to screening evidence rows when exact QRE hypothesis, validation-plan, and run-manifest lineage exists.
- Emits deterministic source linkage context for screening evidence rows: `source_artifact`, `source_report_kind`, and `source_row_id`.
- Fails closed when QRE authority artifacts are missing, malformed, ambiguous, or when the row hypothesis is not an exact QRE hypothesis id.

## Validation
- `python -m pytest tests/unit/test_screening_evidence_validation_linkage.py tests/unit/test_v3_15_9_artifact_top_level_schema_pin.py tests/unit/test_v3_15_9_per_candidate_schema_pin.py tests/regression/test_v3_15_9_screening_evidence_schema_pin.py -q`
- `python -m pytest tests/unit/test_qre_validation_source_linkage_contract.py tests/unit/test_qre_validation_result_linkage_diagnostics.py tests/unit/test_qre_hypothesis_validation_results.py -q`
- `python -m pytest tests/architecture/test_domain_boundary_smoke.py tests/smoke/test_smoke.py -q`
- `python -m ruff check research/screening_evidence.py tests/unit/test_screening_evidence_validation_linkage.py tests/unit/test_v3_15_9_artifact_top_level_schema_pin.py tests/regression/test_v3_15_9_screening_evidence_schema_pin.py`
- `python -m ruff format --check research/screening_evidence.py tests/unit/test_screening_evidence_validation_linkage.py tests/unit/test_v3_15_9_artifact_top_level_schema_pin.py tests/regression/test_v3_15_9_screening_evidence_schema_pin.py`

## Notes
- Screening evidence generation was not run because it would execute research. Fixture/unit tests cover generation behavior.
- `python -m reporting.qre_validation_source_linkage_contract` and `python -m reporting.qre_validation_result_linkage_diagnostics` were run; both remain `safe_to_execute=false`, and diagnostics remain `deterministic_mapping_possible=false` for the current corpus because current source artifacts are still unlinked.
- `ruff check research/run_research.py` and `ruff format --check research/run_research.py` still fail on the existing runner lint/format baseline; this PR keeps the runner change to the narrow authority pass-through.