### PR TITLE
feat: add qre run candidates validation linkage

### DIFF
--- a/research/candidate_pipeline.py
+++ b/research/candidate_pipeline.py
@@ -39,6 +39,9 @@ SAMPLING_POLICY_EMPTY_GRID: Final[str] = "empty_grid"
 COVERAGE_WARNING_BELOW_THRESHOLD: Final[str] = "below_threshold_for_small_grid"
 COVERAGE_WARNING_GRID_UNAVAILABLE: Final[str] = "grid_size_unavailable"
 
+RUN_CANDIDATES_SOURCE_ARTIFACT: Final[str] = "research/run_candidates_latest.v1.json"
+RUN_CANDIDATES_SOURCE_REPORT_KIND: Final[str] = "run_candidates"
+
 
 @dataclass(frozen=True)
 class SamplingPlan:
@@ -81,7 +84,7 @@ def _json_safe_param_value(value: Any) -> Any:
     hashing can rely on ``allow_nan=False``. Non-primitive values
     are stringified deterministically.
     """
-    if value is None or isinstance(value, (int, str, bool)):
+    if value is None or isinstance(value, int | str | bool):
         return value
     if isinstance(value, float):
         if math.isnan(value) or math.isinf(value):
@@ -185,6 +188,15 @@ def _hash_payload(payload: Any) -> str:
     return hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()
 
 
+def _bounded_str(value: Any, *, max_len: int) -> str:
+    if value is None:
+        return ""
+    text = str(value).strip()
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 3].rstrip() + "..."
+
+
 def _asset_metadata(asset: Any) -> tuple[str, str, str]:
     raw_asset_type = str(getattr(asset, "asset_type", "") or "")
     raw_asset_class = str(getattr(asset, "asset_class", "") or "")
@@ -218,6 +230,7 @@ def plan_candidates(
     for strategy in sorted(strategies, key=lambda item: str(item["name"])):
         strategy_name = str(strategy["name"])
         strategy_family = _strategy_family(strategy)
+        hypothesis_id = _bounded_str(strategy.get("hypothesis_id"), max_len=160) or None
         param_grid = copy.deepcopy(strategy.get("params") or {})
         param_grid_hash = _hash_payload(param_grid)
         combination_count = count_param_combinations(strategy)
@@ -285,11 +298,15 @@ def plan_candidates(
                         "result_success": None,
                     },
                 }
+                if hypothesis_id is not None:
+                    candidate["hypothesis_id"] = hypothesis_id
                 candidates.append(candidate)
     return sorted(candidates, key=_candidate_sort_key)
 
 
-def deduplicate_candidates(candidates: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], dict[str, int]]:
+def deduplicate_candidates(
+    candidates: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], dict[str, int]]:
     unique_by_id: dict[str, dict[str, Any]] = {}
     for candidate in sorted(candidates, key=_candidate_sort_key):
         candidate_id = str(candidate["candidate_id"])
@@ -323,9 +340,11 @@ def _normalized_asset_type(candidate: dict[str, Any]) -> str:
 
 def assess_fit_prior(candidate: dict[str, Any]) -> tuple[str, str]:
     requirements = candidate.get("strategy_requirements") or {}
-    if requirements.get("position_structure") == POSITION_SPREAD:
-        if not requirements.get("reference_asset"):
-            return FIT_BLOCKED, "requires_spread_not_outright"
+    if (
+        requirements.get("position_structure") == POSITION_SPREAD
+        and not requirements.get("reference_asset")
+    ):
+        return FIT_BLOCKED, "requires_spread_not_outright"
     if requirements.get("initial_lane_support") == BLOCKED_INITIAL_LANE:
         return FIT_BLOCKED, "unsupported_for_initial_lane"
 
@@ -339,7 +358,9 @@ def assess_fit_prior(candidate: dict[str, Any]) -> tuple[str, str]:
     return FIT_ALLOWED, "empirical_fit_mixed"
 
 
-def apply_fit_prior(candidates: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+def apply_fit_prior(
+    candidates: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
     updated: list[dict[str, Any]] = []
     blocked_reasons: Counter[str] = Counter()
     counts = {
@@ -368,7 +389,9 @@ def apply_fit_prior(candidates: list[dict[str, Any]]) -> tuple[list[dict[str, An
     }
 
 
-def index_readiness(pair_diagnostics: list[dict[str, Any]]) -> dict[tuple[str, str], dict[str, Any]]:
+def index_readiness(
+    pair_diagnostics: list[dict[str, Any]],
+) -> dict[tuple[str, str], dict[str, Any]]:
     return {
         (str(item["asset"]), str(item["interval"])): item
         for item in pair_diagnostics
@@ -637,7 +660,9 @@ def normalize_screening_decision(sample_results: list[dict[str, Any]]) -> dict[s
             "sampled_combination_count": len(sample_results),
         }
 
-    reason_counts = Counter(str(result.get("reason") or "screening_error") for result in sample_results)
+    reason_counts = Counter(
+        str(result.get("reason") or "screening_error") for result in sample_results
+    )
     reason = sorted(
         reason_counts.items(),
         key=lambda item: (-item[1], item[0]),
@@ -669,7 +694,9 @@ def summarize_candidates(candidates: list[dict[str, Any]]) -> dict[str, int]:
     raw_count = sum(int(candidate["dedupe"]["raw_occurrences"]) for candidate in candidates)
     deduplicated_count = len(candidates)
     fit_statuses = Counter(str(candidate["fit_prior"]["status"]) for candidate in candidates)
-    eligibility_statuses = Counter(str(candidate["eligibility"]["status"]) for candidate in candidates)
+    eligibility_statuses = Counter(
+        str(candidate["eligibility"]["status"]) for candidate in candidates
+    )
     screening_statuses = Counter(str(candidate["screening"]["status"]) for candidate in candidates)
     validated_count = sum(
         1
@@ -691,13 +718,104 @@ def summarize_candidates(candidates: list[dict[str, Any]]) -> dict[str, int]:
     }
 
 
+def _source_row_id(candidate: dict[str, Any]) -> str:
+    candidate_id = _bounded_str(candidate.get("candidate_id"), max_len=160)
+    if candidate_id:
+        return candidate_id
+    return f"row_{_hash_payload(candidate)[:24]}"
+
+
+def _run_candidate_validation_linkage_fields(
+    *,
+    candidate: dict[str, Any],
+    qre_validation_linkage_authority: dict[str, Any] | None,
+) -> dict[str, Any]:
+    hypothesis_id = _bounded_str(candidate.get("hypothesis_id"), max_len=160) or None
+    fields: dict[str, Any] = {
+        "hypothesis_id": hypothesis_id,
+        "validation_plan_id": None,
+        "run_manifest_id": None,
+        "source_artifact": RUN_CANDIDATES_SOURCE_ARTIFACT,
+        "source_report_kind": RUN_CANDIDATES_SOURCE_REPORT_KIND,
+        "source_row_id": _source_row_id(candidate),
+        "qre_validation_linkage_status": "unlinked_authority_absent",
+        "qre_validation_linkage_warnings": ["qre_validation_linkage_authority_absent"],
+    }
+    if not isinstance(qre_validation_linkage_authority, dict):
+        return fields
+
+    authority_warnings = [
+        _bounded_str(item, max_len=120)
+        for item in qre_validation_linkage_authority.get("warnings", [])
+        if _bounded_str(item, max_len=120)
+    ]
+    if not qre_validation_linkage_authority.get("available"):
+        fields["qre_validation_linkage_warnings"] = authority_warnings or [
+            "qre_validation_linkage_authority_unavailable"
+        ]
+        return fields
+
+    if not hypothesis_id:
+        fields["qre_validation_linkage_status"] = "unlinked_missing_hypothesis_id"
+        fields["qre_validation_linkage_warnings"] = ["run_candidate_missing_hypothesis_id"]
+        return fields
+
+    by_hypothesis = qre_validation_linkage_authority.get("by_hypothesis_id")
+    if not isinstance(by_hypothesis, dict):
+        return fields
+    entry = by_hypothesis.get(hypothesis_id)
+    if not isinstance(entry, dict):
+        fields["qre_validation_linkage_status"] = "unlinked_unknown_hypothesis_id"
+        fields["qre_validation_linkage_warnings"] = [
+            "run_candidate_hypothesis_id_not_in_qre_authority"
+        ]
+        return fields
+
+    fields["qre_validation_linkage_status"] = (
+        _bounded_str(entry.get("status"), max_len=80) or "unlinked_incomplete_qre_authority"
+    )
+    fields["qre_validation_linkage_warnings"] = [
+        _bounded_str(item, max_len=120)
+        for item in entry.get("warnings", [])
+        if _bounded_str(item, max_len=120)
+    ]
+    if fields["qre_validation_linkage_status"] != "linked_exact_ids":
+        return fields
+
+    fields["validation_plan_id"] = (
+        _bounded_str(entry.get("validation_plan_id"), max_len=160) or None
+    )
+    fields["run_manifest_id"] = _bounded_str(entry.get("run_manifest_id"), max_len=160) or None
+    if not fields["validation_plan_id"] or not fields["run_manifest_id"]:
+        fields["validation_plan_id"] = None
+        fields["run_manifest_id"] = None
+        fields["qre_validation_linkage_status"] = "unlinked_incomplete_qre_authority"
+        fields["qre_validation_linkage_warnings"] = [
+            "qre_validation_authority_missing_required_exact_id"
+        ]
+    return fields
+
+
 def build_candidate_artifact_payload(
     *,
     run_id: str,
     as_of_utc: datetime,
     candidates: list[dict[str, Any]],
+    qre_validation_linkage_authority: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    ordered_candidates = sorted((copy.deepcopy(candidate) for candidate in candidates), key=_candidate_sort_key)
+    ordered_candidates = sorted(
+        (copy.deepcopy(candidate) for candidate in candidates), key=_candidate_sort_key
+    )
+    ordered_candidates = [
+        {
+            **candidate,
+            **_run_candidate_validation_linkage_fields(
+                candidate=candidate,
+                qre_validation_linkage_authority=qre_validation_linkage_authority,
+            ),
+        }
+        for candidate in ordered_candidates
+    ]
     return {
         "version": "v1",
         "run_id": run_id,

--- a/research/run_research.py
+++ b/research/run_research.py
@@ -995,10 +995,22 @@ def _persist_candidate_pipeline_sidecars(
     as_of_utc: datetime,
     candidates: list[dict],
 ) -> tuple[dict, dict]:
+    qre_validation_linkage_authority = build_qre_validation_linkage_authority(
+        hypothesis_candidates_payload=_read_json_if_exists(
+            QRE_HYPOTHESIS_CANDIDATES_PATH
+        ),
+        validation_plans_payload=_read_json_if_exists(
+            QRE_HYPOTHESIS_VALIDATION_PLANS_PATH
+        ),
+        run_manifest_payload=_read_json_if_exists(
+            QRE_RESEARCH_RUN_MANIFEST_PATH
+        ),
+    )
     candidate_payload = build_candidate_artifact_payload(
         run_id=run_id,
         as_of_utc=as_of_utc,
         candidates=candidates,
+        qre_validation_linkage_authority=qre_validation_linkage_authority,
     )
     filter_payload = build_filter_summary_payload(
         run_id=run_id,
@@ -2192,6 +2204,14 @@ def run_research(
                 build_research_universe_from_preset(preset_obj, research_config)
             )
             strategies = resolve_preset_bundle(preset_obj)
+            if preset_obj.hypothesis_id is not None:
+                strategies = [
+                    {
+                        **strategy,
+                        "hypothesis_id": str(preset_obj.hypothesis_id),
+                    }
+                    for strategy in strategies
+                ]
             if not strategies:
                 raise RuntimeError(
                     f"preset {preset_obj.name!r} has no executable strategies"

--- a/tests/unit/test_run_candidates_validation_linkage.py
+++ b/tests/unit/test_run_candidates_validation_linkage.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from reporting.qre_validation_source_linkage_contract import (
+    validate_source_linkage_contract,
+)
+from research.candidate_pipeline import (
+    RUN_CANDIDATES_SOURCE_ARTIFACT,
+    RUN_CANDIDATES_SOURCE_REPORT_KIND,
+    build_candidate_artifact_payload,
+)
+from research.screening_evidence import build_qre_validation_linkage_authority
+
+FROZEN = datetime(2026, 6, 1, 12, 0, 0, tzinfo=UTC)
+HYPOTHESIS_ID = "qre-hyp-fixture-001"
+PLAN_ID = "qre-plan-fixture-001"
+RUN_MANIFEST_ID = "qre-run-fixture-001"
+_DEFAULT = object()
+
+
+def _authority(
+    *,
+    hypotheses: dict | None | object = _DEFAULT,
+    plans: dict | None | object = _DEFAULT,
+    manifests: dict | None | object = _DEFAULT,
+) -> dict:
+    return build_qre_validation_linkage_authority(
+        hypothesis_candidates_payload=(
+            hypotheses
+            if hypotheses is not _DEFAULT
+            else {
+                "report_kind": "qre_hypothesis_candidates",
+                "hypotheses": [{"hypothesis_id": HYPOTHESIS_ID}],
+            }
+        ),
+        validation_plans_payload=(
+            plans
+            if plans is not _DEFAULT
+            else {
+                "report_kind": "qre_hypothesis_validation_plan",
+                "validation_plans": [
+                    {
+                        "hypothesis_id": HYPOTHESIS_ID,
+                        "validation_plan_id": PLAN_ID,
+                    }
+                ],
+            }
+        ),
+        run_manifest_payload=(
+            manifests
+            if manifests is not _DEFAULT
+            else {
+                "report_kind": "qre_research_run_manifest",
+                "run_manifests": [
+                    {
+                        "run_manifest_id": RUN_MANIFEST_ID,
+                        "target_hypothesis_id": HYPOTHESIS_ID,
+                        "target_validation_plan_id": PLAN_ID,
+                    }
+                ],
+            }
+        ),
+    )
+
+
+def _candidate(**overrides: object) -> dict:
+    row: dict[str, object] = {
+        "candidate_id": "candidate-001",
+        "current_status": "planned",
+        "strategy_name": "strategy-a",
+        "family": "trend",
+        "strategy_family": "trend_following",
+        "asset": "BTC-USD",
+        "asset_type": "crypto",
+        "asset_class": "crypto",
+        "interval": "1h",
+        "hypothesis_id": HYPOTHESIS_ID,
+        "parameter_space_identity": {
+            "param_grid_hash": "hash",
+            "combination_count": 1,
+        },
+        "strategy_requirements": {
+            "position_structure": "outright",
+            "initial_lane_support": "supported",
+        },
+        "fit_prior": {"status": "allowed", "reason": None},
+        "dedupe": {"duplicate_removed": False, "raw_occurrences": 1},
+        "eligibility": {"status": "eligible", "reason": None},
+        "screening": {"status": "promoted_to_validation", "reason": None},
+        "validation": {"status": "pending", "result_success": None},
+    }
+    row.update(overrides)
+    return row
+
+
+def _row(*, candidate: dict | None = None, authority: dict | None = None) -> dict:
+    payload = build_candidate_artifact_payload(
+        run_id="run-1",
+        as_of_utc=FROZEN,
+        candidates=[candidate or _candidate()],
+        qre_validation_linkage_authority=authority,
+    )
+    return payload["candidates"][0]
+
+
+def test_run_candidates_rows_include_source_artifact_kind_and_stable_row_id() -> None:
+    row = _row(authority=_authority())
+
+    assert row["source_artifact"] == RUN_CANDIDATES_SOURCE_ARTIFACT
+    assert row["source_report_kind"] == RUN_CANDIDATES_SOURCE_REPORT_KIND
+    assert row["source_row_id"] == "candidate-001"
+
+
+def test_exact_qre_authority_adds_all_strict_linkage_fields() -> None:
+    row = _row(authority=_authority())
+
+    assert row["hypothesis_id"] == HYPOTHESIS_ID
+    assert row["validation_plan_id"] == PLAN_ID
+    assert row["run_manifest_id"] == RUN_MANIFEST_ID
+    assert row["qre_validation_linkage_status"] == "linked_exact_ids"
+    assert row["qre_validation_linkage_warnings"] == []
+
+
+def test_emitted_strict_linked_run_candidate_passes_source_linkage_contract() -> None:
+    row = _row(authority=_authority())
+
+    result = validate_source_linkage_contract(row)
+
+    assert result["is_contract_compliant"] is True
+    assert result["safe_to_link"] is True
+    assert "contract_compliant_exact_ids" in result["reason_codes"]
+
+
+def test_source_row_id_is_deterministic_across_repeated_generation() -> None:
+    authority = _authority()
+    row_a = _row(authority=authority)
+    row_b = _row(authority=authority)
+
+    assert row_a["source_row_id"] == row_b["source_row_id"] == "candidate-001"
+
+
+def test_candidate_id_only_row_is_not_strict_compliant() -> None:
+    row = _row(candidate=_candidate(hypothesis_id=None), authority=_authority())
+
+    emitted_result = validate_source_linkage_contract(row)
+    candidate_only_result = validate_source_linkage_contract({"candidate_id": "candidate-001"})
+
+    assert row["qre_validation_linkage_status"] == "unlinked_missing_hypothesis_id"
+    assert emitted_result["safe_to_link"] is False
+    assert candidate_only_result["safe_to_link"] is False
+    assert "candidate_id_context_only_not_allowed" in candidate_only_result["reason_codes"]
+
+
+def test_asset_timeframe_only_linkage_is_not_accepted() -> None:
+    result = validate_source_linkage_contract({"asset": "BTC-USD", "timeframe": "1h"})
+
+    assert result["safe_to_link"] is False
+    assert "asset_timeframe_only_not_allowed" in result["reason_codes"]
+
+
+def test_reference_artifacts_missing_do_not_fabricate_ids() -> None:
+    row = _row(authority=_authority(hypotheses=None, plans=None, manifests=None))
+
+    assert row["validation_plan_id"] is None
+    assert row["run_manifest_id"] is None
+    assert row["qre_validation_linkage_status"] == "unlinked_authority_absent"
+
+
+def test_missing_hypothesis_authority_fails_closed() -> None:
+    row = _row(authority=_authority(hypotheses={"report_kind": "wrong"}))
+
+    assert row["validation_plan_id"] is None
+    assert row["run_manifest_id"] is None
+    assert (
+        "qre_hypothesis_authority_absent_or_unparseable" in row["qre_validation_linkage_warnings"]
+    )
+
+
+def test_missing_validation_plan_authority_fails_closed() -> None:
+    row = _row(authority=_authority(plans={"report_kind": "wrong"}))
+
+    assert row["validation_plan_id"] is None
+    assert row["run_manifest_id"] is None
+    assert (
+        "qre_validation_plan_authority_absent_or_unparseable"
+        in row["qre_validation_linkage_warnings"]
+    )
+
+
+def test_missing_run_manifest_authority_fails_closed() -> None:
+    row = _row(authority=_authority(manifests={"report_kind": "wrong"}))
+
+    assert row["validation_plan_id"] is None
+    assert row["run_manifest_id"] is None
+    assert (
+        "qre_run_manifest_authority_absent_or_unparseable" in row["qre_validation_linkage_warnings"]
+    )
+
+
+def test_missing_validation_plan_for_hypothesis_fails_closed() -> None:
+    row = _row(
+        authority=_authority(
+            plans={
+                "report_kind": "qre_hypothesis_validation_plan",
+                "validation_plans": [],
+            }
+        )
+    )
+
+    assert row["validation_plan_id"] is None
+    assert row["run_manifest_id"] is None
+    assert row["qre_validation_linkage_status"] == "unlinked_missing_validation_plan_id"
+
+
+def test_missing_run_manifest_for_validation_plan_fails_closed() -> None:
+    row = _row(
+        authority=_authority(
+            manifests={
+                "report_kind": "qre_research_run_manifest",
+                "run_manifests": [],
+            }
+        )
+    )
+
+    assert row["validation_plan_id"] is None
+    assert row["run_manifest_id"] is None
+    assert row["qre_validation_linkage_status"] == "unlinked_missing_run_manifest_id"
+
+
+def test_ambiguous_validation_plan_authority_fails_closed() -> None:
+    row = _row(
+        authority=_authority(
+            plans={
+                "report_kind": "qre_hypothesis_validation_plan",
+                "validation_plans": [
+                    {
+                        "hypothesis_id": HYPOTHESIS_ID,
+                        "validation_plan_id": PLAN_ID,
+                    },
+                    {
+                        "hypothesis_id": HYPOTHESIS_ID,
+                        "validation_plan_id": "qre-plan-fixture-002",
+                    },
+                ],
+            }
+        )
+    )
+
+    assert row["validation_plan_id"] is None
+    assert row["run_manifest_id"] is None
+    assert row["qre_validation_linkage_status"] == "unlinked_ambiguous_validation_plan_id"
+
+
+def test_ambiguous_run_manifest_authority_fails_closed() -> None:
+    row = _row(
+        authority=_authority(
+            manifests={
+                "report_kind": "qre_research_run_manifest",
+                "run_manifests": [
+                    {
+                        "run_manifest_id": RUN_MANIFEST_ID,
+                        "target_validation_plan_id": PLAN_ID,
+                    },
+                    {
+                        "run_manifest_id": "qre-run-fixture-002",
+                        "target_validation_plan_id": PLAN_ID,
+                    },
+                ],
+            }
+        )
+    )
+
+    assert row["validation_plan_id"] is None
+    assert row["run_manifest_id"] is None
+    assert row["qre_validation_linkage_status"] == "unlinked_ambiguous_run_manifest_id"


### PR DESCRIPTION
## Summary
- add strict QRE validation source metadata to generated run_candidates rows
- propagate exact hypothesis_id from strategy/preset context without changing candidate-id hashing or selection
- link validation_plan_id and run_manifest_id only through the canonical QRE authority chain

## Validation
- python -m pytest tests/unit/test_run_candidates_validation_linkage.py -q
- python -m pytest tests/unit/test_qre_validation_source_linkage_contract.py -q
- python -m pytest tests/unit/test_candidate_pipeline.py -q
- python -m pytest tests/unit/test_qre_validation_result_linkage_diagnostics.py -q
- python -m pytest tests/unit/test_qre_hypothesis_validation_results.py -q
- python -m pytest tests/unit/test_screening_evidence_validation_linkage.py -q
- python -m pytest tests/regression/test_v3_15_9_screening_evidence_schema_pin.py -q
- python -m pytest tests/unit/test_run_research_observability.py -q
- python -m pytest tests/architecture/test_domain_boundary_smoke.py -q
- python -m pytest tests/smoke/test_smoke.py -q
- python -m reporting.qre_validation_source_linkage_contract
- python -m reporting.qre_validation_result_linkage_diagnostics

## Known local validation note
- ruff check/format on the changed-file set still fails on existing research/run_research.py lint and formatting debt outside this change.