### PR TITLE
feat: add QRE executable hypothesis bridge diagnostics

### DIFF
--- a/reporting/qre_executable_hypothesis_identity_bridge_diagnostics.py
+++ b/reporting/qre_executable_hypothesis_identity_bridge_diagnostics.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import ast
 import datetime as _dt
 import json
 import os
@@ -11,8 +12,6 @@ from collections import Counter
 from contextlib import suppress
 from pathlib import Path
 from typing import Any, Final
-
-from research.screening_evidence import build_qre_validation_linkage_authority
 
 REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
 
@@ -39,6 +38,8 @@ SAMPLE_LIMIT: Final[int] = 20
 PRESET_ROW_LIMIT: Final[int] = 100
 ID_LIMIT: Final[int] = 100
 WARNING_LIMIT: Final[int] = 50
+
+PRESETS_SOURCE_PATH: Final[Path] = REPO_ROOT / "research" / "presets.py"
 
 FINAL_RECOMMENDATION_BRIDGE_REQUIRED: Final[str] = (
     "executable_hypothesis_identity_bridge_required_before_regeneration"
@@ -111,13 +112,182 @@ def _read_json(path: Path) -> tuple[bool, dict[str, Any] | None, str | None]:
     return (True, parsed, None)
 
 
-def _load_default_presets() -> tuple[Any, list[str]]:
+def _safe_dict_rows(payload: dict[str, Any] | None, field: str) -> list[dict[str, Any]] | None:
+    if not isinstance(payload, dict):
+        return None
+    rows = payload.get(field)
+    if not isinstance(rows, list) or not all(isinstance(item, dict) for item in rows):
+        return None
+    return rows
+
+
+def _build_qre_validation_linkage_authority(
+    *,
+    hypothesis_candidates_payload: dict[str, Any] | None,
+    validation_plans_payload: dict[str, Any] | None,
+    run_manifest_payload: dict[str, Any] | None,
+) -> dict[str, Any]:
+    warnings: list[str] = []
+    hypotheses = _safe_dict_rows(hypothesis_candidates_payload, "hypotheses")
+    plans = _safe_dict_rows(validation_plans_payload, "validation_plans")
+    manifests = _safe_dict_rows(run_manifest_payload, "run_manifests")
+
+    if (
+        not isinstance(hypothesis_candidates_payload, dict)
+        or hypothesis_candidates_payload.get("report_kind") != "qre_hypothesis_candidates"
+        or hypotheses is None
+    ):
+        warnings.append("qre_hypothesis_authority_absent_or_unparseable")
+    if (
+        not isinstance(validation_plans_payload, dict)
+        or validation_plans_payload.get("report_kind") != "qre_hypothesis_validation_plan"
+        or plans is None
+    ):
+        warnings.append("qre_validation_plan_authority_absent_or_unparseable")
+    if (
+        not isinstance(run_manifest_payload, dict)
+        or run_manifest_payload.get("report_kind") != "qre_research_run_manifest"
+        or manifests is None
+    ):
+        warnings.append("qre_run_manifest_authority_absent_or_unparseable")
+
+    if warnings:
+        return {
+            "available": False,
+            "warnings": warnings,
+            "by_hypothesis_id": {},
+        }
+
+    hypothesis_ids = {
+        _bounded_str(item.get("hypothesis_id"), max_len=160)
+        for item in hypotheses or []
+        if _bounded_str(item.get("hypothesis_id"), max_len=160)
+    }
+    plans_by_hypothesis: dict[str, list[str]] = {}
+    for item in plans or []:
+        hypothesis_id = _bounded_str(item.get("hypothesis_id"), max_len=160)
+        plan_id = _bounded_str(item.get("validation_plan_id"), max_len=160)
+        if hypothesis_id in hypothesis_ids and plan_id:
+            plans_by_hypothesis.setdefault(hypothesis_id, []).append(plan_id)
+    for values in plans_by_hypothesis.values():
+        values.sort()
+
+    manifests_by_plan: dict[str, list[str]] = {}
+    for item in manifests or []:
+        plan_id = _bounded_str(item.get("target_validation_plan_id"), max_len=160)
+        manifest_id = _bounded_str(item.get("run_manifest_id"), max_len=160)
+        if plan_id and manifest_id:
+            manifests_by_plan.setdefault(plan_id, []).append(manifest_id)
+    for values in manifests_by_plan.values():
+        values.sort()
+
+    by_hypothesis_id: dict[str, dict[str, Any]] = {}
+    for hypothesis_id in sorted(hypothesis_ids):
+        plan_ids = plans_by_hypothesis.get(hypothesis_id, [])
+        if not plan_ids:
+            by_hypothesis_id[hypothesis_id] = {
+                "status": "unlinked_missing_validation_plan_id",
+                "warnings": ["qre_validation_plan_id_not_found_for_hypothesis"],
+            }
+            continue
+        if len(plan_ids) != 1:
+            by_hypothesis_id[hypothesis_id] = {
+                "status": "unlinked_ambiguous_validation_plan_id",
+                "warnings": ["qre_validation_plan_id_not_unique_for_hypothesis"],
+            }
+            continue
+
+        plan_id = plan_ids[0]
+        manifest_ids = manifests_by_plan.get(plan_id, [])
+        if not manifest_ids:
+            by_hypothesis_id[hypothesis_id] = {
+                "status": "unlinked_missing_run_manifest_id",
+                "validation_plan_id": plan_id,
+                "warnings": ["qre_run_manifest_id_not_found_for_validation_plan"],
+            }
+            continue
+        if len(manifest_ids) != 1:
+            by_hypothesis_id[hypothesis_id] = {
+                "status": "unlinked_ambiguous_run_manifest_id",
+                "validation_plan_id": plan_id,
+                "warnings": ["qre_run_manifest_id_not_unique_for_validation_plan"],
+            }
+            continue
+
+        by_hypothesis_id[hypothesis_id] = {
+            "status": "linked_exact_ids",
+            "hypothesis_id": hypothesis_id,
+            "validation_plan_id": plan_id,
+            "run_manifest_id": manifest_ids[0],
+            "warnings": [],
+        }
+
+    return {
+        "available": True,
+        "warnings": [],
+        "by_hypothesis_id": by_hypothesis_id,
+    }
+
+
+def _literal(node: ast.AST) -> Any:
     try:
-        from research.presets import PRESETS
-    except Exception as exc:  # pragma: no cover - exercised via monkeypatchable helper
-        detail = _bounded_str(exc, max_len=120)
-        return ((), [f"presets_import_failed:{detail}" if detail else "presets_import_failed"])
-    return (PRESETS, [])
+        return ast.literal_eval(node)
+    except (ValueError, TypeError):
+        return None
+
+
+def _research_preset_from_call(node: ast.Call) -> dict[str, Any]:
+    defaults: dict[str, Any] = {
+        "enabled": True,
+        "diagnostic_only": False,
+        "excluded_from_daily_scheduler": False,
+        "excluded_from_candidate_promotion": False,
+        "status": "stable",
+        "preset_class": "experimental",
+        "hypothesis_id": None,
+    }
+    fields = dict(defaults)
+    for keyword in node.keywords:
+        if keyword.arg in fields or keyword.arg == "name":
+            fields[str(keyword.arg)] = _literal(keyword.value)
+    return fields
+
+
+def _presets_from_source(path: Path) -> tuple[list[dict[str, Any]], list[str]]:
+    try:
+        source = path.read_text(encoding="utf-8")
+    except OSError:
+        return ([], [f"presets_source_missing:{_rel(path)}"])
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return ([], [f"presets_source_malformed:{_rel(path)}"])
+
+    presets: list[dict[str, Any]] = []
+    for node in tree.body:
+        is_presets_assign = isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == "PRESETS" for target in node.targets
+        )
+        is_presets_ann_assign = isinstance(node, ast.AnnAssign) and (
+            isinstance(node.target, ast.Name) and node.target.id == "PRESETS"
+        )
+        if not is_presets_assign and not is_presets_ann_assign:
+            continue
+        value = node.value
+        if not isinstance(value, ast.Tuple):
+            return ([], [f"presets_source_malformed:{_rel(path)}"])
+        for item in value.elts:
+            if not isinstance(item, ast.Call):
+                continue
+            func = item.func
+            if isinstance(func, ast.Name) and func.id == "ResearchPreset":
+                presets.append(_research_preset_from_call(item))
+        return (presets, [])
+    return ([], [f"presets_source_malformed:{_rel(path)}"])
+
+
+def _load_default_presets() -> tuple[Any, list[str]]:
+    return _presets_from_source(PRESETS_SOURCE_PATH)
 
 
 def _get_field(preset: Any, field: str, default: Any = None) -> Any:
@@ -180,7 +350,7 @@ def _authority_snapshot(
         if warning:
             warnings.append(warning)
 
-    authority = build_qre_validation_linkage_authority(
+    authority = _build_qre_validation_linkage_authority(
         hypothesis_candidates_payload=hypothesis_payload,
         validation_plans_payload=plan_payload,
         run_manifest_payload=run_payload,

--- a/reporting/qre_executable_hypothesis_identity_bridge_diagnostics.py
+++ b/reporting/qre_executable_hypothesis_identity_bridge_diagnostics.py
@@ -1,0 +1,510 @@
+"""Read-only diagnostics for executable/QRE hypothesis identity gaps."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import tempfile
+from collections import Counter
+from contextlib import suppress
+from pathlib import Path
+from typing import Any, Final
+
+from research.screening_evidence import build_qre_validation_linkage_authority
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[int] = 1
+REPORT_KIND: Final[str] = "qre_executable_hypothesis_identity_bridge_diagnostics"
+
+DEFAULT_HYPOTHESIS_ARTIFACT_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_hypothesis_candidates" / "latest.json"
+)
+DEFAULT_PLAN_ARTIFACT_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_hypothesis_validation_plans" / "latest.json"
+)
+DEFAULT_RUN_MANIFEST_ARTIFACT_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_research_run_manifest" / "latest.json"
+)
+
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "qre_executable_hypothesis_identity_bridge"
+OUTPUT_ARTIFACT_RELATIVE_PATH: Final[str] = (
+    "logs/qre_executable_hypothesis_identity_bridge/latest.json"
+)
+ARTIFACT_LATEST: Final[Path] = REPO_ROOT / OUTPUT_ARTIFACT_RELATIVE_PATH
+
+SAMPLE_LIMIT: Final[int] = 20
+PRESET_ROW_LIMIT: Final[int] = 100
+ID_LIMIT: Final[int] = 100
+WARNING_LIMIT: Final[int] = 50
+
+FINAL_RECOMMENDATION_BRIDGE_REQUIRED: Final[str] = (
+    "executable_hypothesis_identity_bridge_required_before_regeneration"
+)
+FINAL_RECOMMENDATION_REGENERATION_LINKAGE_EXPECTED: Final[str] = (
+    "runtime_regeneration_linkage_expected_for_executable_hypothesis_ids"
+)
+FINAL_RECOMMENDATION_INPUTS_FAILED_CLOSED: Final[str] = "inputs_failed_closed_before_regeneration"
+
+PRIMARY_BLOCKER_EXECUTABLE_ID_MISSING: Final[str] = "executable_hypothesis_id_not_in_qre_authority"
+PRIMARY_BLOCKER_QRE_AUTHORITY_UNAVAILABLE: Final[str] = "qre_authority_unavailable"
+PRIMARY_BLOCKER_NO_EXECUTABLE_IDS: Final[str] = "no_executable_hypothesis_ids"
+PRIMARY_BLOCKER_NONE: Final[str] = "none"
+
+RECOMMENDED_BRIDGE_KEYS: Final[tuple[str, ...]] = (
+    "executable_hypothesis_id",
+    "qre_hypothesis_id",
+    "source_hypothesis_id",
+    "strategy_family",
+    "strategy_template_id",
+    "preset_name",
+    "validation_plan_id",
+    "run_manifest_id",
+)
+
+
+def _utcnow() -> str:
+    return _dt.datetime.now(_dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _rel(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(REPO_ROOT.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _bounded_str(value: Any, *, max_len: int = 240) -> str:
+    text = str(value or "").strip()
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 3].rstrip() + "..."
+
+
+def _bounded_unique(values: list[str], *, max_items: int) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for value in values:
+        text = _bounded_str(value, max_len=160)
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        out.append(text)
+        if len(out) >= max_items:
+            break
+    return out
+
+
+def _read_json(path: Path) -> tuple[bool, dict[str, Any] | None, str | None]:
+    try:
+        raw = path.read_text(encoding="utf-8-sig")
+    except OSError:
+        return (False, None, f"qre_artifact_missing:{_rel(path)}")
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return (True, None, f"qre_artifact_malformed:{_rel(path)}")
+    if not isinstance(parsed, dict):
+        return (True, None, f"qre_artifact_malformed:{_rel(path)}")
+    return (True, parsed, None)
+
+
+def _load_default_presets() -> tuple[Any, list[str]]:
+    try:
+        from research.presets import PRESETS
+    except Exception as exc:  # pragma: no cover - exercised via monkeypatchable helper
+        detail = _bounded_str(exc, max_len=120)
+        return ((), [f"presets_import_failed:{detail}" if detail else "presets_import_failed"])
+    return (PRESETS, [])
+
+
+def _get_field(preset: Any, field: str, default: Any = None) -> Any:
+    if isinstance(preset, dict):
+        return preset.get(field, default)
+    return getattr(preset, field, default)
+
+
+def _bool_field(preset: Any, field: str) -> bool:
+    return bool(_get_field(preset, field, False))
+
+
+def _preset_row(
+    preset: Any,
+    *,
+    qre_by_hypothesis_id: dict[str, Any],
+) -> dict[str, Any]:
+    hypothesis_id = _bounded_str(_get_field(preset, "hypothesis_id"), max_len=160)
+    entry = qre_by_hypothesis_id.get(hypothesis_id) if hypothesis_id else None
+    return {
+        "preset_name": _bounded_str(_get_field(preset, "name"), max_len=160),
+        "enabled": _bool_field(preset, "enabled"),
+        "diagnostic_only": _bool_field(preset, "diagnostic_only"),
+        "excluded_from_daily_scheduler": _bool_field(preset, "excluded_from_daily_scheduler"),
+        "excluded_from_candidate_promotion": _bool_field(
+            preset, "excluded_from_candidate_promotion"
+        ),
+        "status": _bounded_str(_get_field(preset, "status"), max_len=80),
+        "preset_class": _bounded_str(_get_field(preset, "preset_class"), max_len=80),
+        "hypothesis_id": hypothesis_id or None,
+        "hypothesis_id_present_in_qre_authority": bool(entry),
+        "qre_authority_status": (
+            _bounded_str(entry.get("status"), max_len=80) if isinstance(entry, dict) else None
+        ),
+    }
+
+
+def _coerce_presets(presets: Any) -> tuple[list[Any], list[str]]:
+    if presets is None:
+        loaded, warnings = _load_default_presets()
+        presets = loaded
+    else:
+        warnings = []
+    if isinstance(presets, str) or not hasattr(presets, "__iter__"):
+        return ([], [*warnings, "presets_unavailable_or_malformed"])
+    return (list(presets), warnings)
+
+
+def _authority_snapshot(
+    *,
+    hypothesis_artifact_path: Path,
+    plan_artifact_path: Path,
+    run_manifest_artifact_path: Path,
+) -> tuple[dict[str, Any], dict[str, Any], list[str]]:
+    warnings: list[str] = []
+    _hyp_available, hypothesis_payload, hyp_warning = _read_json(hypothesis_artifact_path)
+    _plan_available, plan_payload, plan_warning = _read_json(plan_artifact_path)
+    _run_available, run_payload, run_warning = _read_json(run_manifest_artifact_path)
+    for warning in (hyp_warning, plan_warning, run_warning):
+        if warning:
+            warnings.append(warning)
+
+    authority = build_qre_validation_linkage_authority(
+        hypothesis_candidates_payload=hypothesis_payload,
+        validation_plans_payload=plan_payload,
+        run_manifest_payload=run_payload,
+    )
+    authority_warnings = [
+        _bounded_str(item, max_len=160)
+        for item in authority.get("warnings", [])
+        if _bounded_str(item, max_len=160)
+    ]
+    warnings.extend(authority_warnings)
+
+    by_hypothesis_id_raw = authority.get("by_hypothesis_id")
+    by_hypothesis_id = by_hypothesis_id_raw if isinstance(by_hypothesis_id_raw, dict) else {}
+    status_counter: Counter[str] = Counter()
+    for entry in by_hypothesis_id.values():
+        if isinstance(entry, dict):
+            status = _bounded_str(entry.get("status"), max_len=80) or "unknown"
+        else:
+            status = "malformed_authority_entry"
+        status_counter[status] += 1
+
+    qre_ids = sorted(_bounded_str(value, max_len=160) for value in by_hypothesis_id)
+    qre_ids = [value for value in qre_ids if value]
+    snapshot = {
+        "available": bool(authority.get("available")),
+        "warnings": _bounded_unique(authority_warnings, max_items=WARNING_LIMIT),
+        "total_hypotheses": len(by_hypothesis_id),
+        "linked_exact_ids": status_counter.get("linked_exact_ids", 0),
+        "status_counts": dict(sorted(status_counter.items())),
+        "sample_qre_hypothesis_ids": qre_ids[:SAMPLE_LIMIT],
+    }
+    return (snapshot, by_hypothesis_id, _bounded_unique(warnings, max_items=WARNING_LIMIT))
+
+
+def _presets_snapshot(
+    *,
+    presets: Any,
+    qre_by_hypothesis_id: dict[str, Any],
+) -> tuple[dict[str, Any], list[str]]:
+    preset_items, warnings = _coerce_presets(presets)
+    rows = [
+        _preset_row(preset, qre_by_hypothesis_id=qre_by_hypothesis_id)
+        for preset in preset_items[:PRESET_ROW_LIMIT]
+    ]
+    executable_ids = _bounded_unique(
+        [str(row["hypothesis_id"]) for row in rows if row["enabled"] and row["hypothesis_id"]],
+        max_items=ID_LIMIT,
+    )
+    return (
+        {
+            "total_presets": len(preset_items),
+            "enabled_presets": sum(1 for row in rows if row["enabled"]),
+            "executable_presets_with_hypothesis_id": sum(
+                1 for row in rows if row["enabled"] and row["hypothesis_id"]
+            ),
+            "executable_hypothesis_ids": executable_ids,
+            "per_preset": rows,
+            "per_preset_truncated": len(preset_items) > PRESET_ROW_LIMIT,
+        },
+        warnings,
+    )
+
+
+def _reason_codes(
+    *,
+    qre_authority: dict[str, Any],
+    executable_ids: list[str],
+    present_ids: list[str],
+    missing_ids: list[str],
+    all_statuses_linked: bool,
+) -> list[str]:
+    codes: list[str] = []
+    if qre_authority["available"]:
+        codes.append("qre_authority_available")
+    else:
+        codes.append("qre_authority_unavailable")
+    if all_statuses_linked and qre_authority["total_hypotheses"] > 0:
+        codes.append("qre_authority_all_linked_exact_ids")
+    if executable_ids:
+        codes.append("executable_hypothesis_ids_discovered")
+    else:
+        codes.append("no_executable_hypothesis_ids_discovered")
+    if present_ids:
+        codes.append("executable_hypothesis_id_present_in_qre_authority")
+    if missing_ids:
+        codes.append("executable_hypothesis_id_not_in_qre_authority")
+        codes.append("runtime_regeneration_expected_unlinked_unknown_hypothesis_id")
+        codes.append("deterministic_mapping_not_supported_without_explicit_bridge")
+    elif executable_ids and qre_authority["available"]:
+        codes.append("runtime_regeneration_expected_strict_linked_hypothesis_id")
+    return codes
+
+
+def _bridge_snapshot(
+    *,
+    qre_authority: dict[str, Any],
+    executable_hypothesis_ids: list[str],
+) -> dict[str, Any]:
+    qre_ids = set(qre_authority["sample_qre_hypothesis_ids"])
+    status_counts = qre_authority["status_counts"]
+    total = qre_authority["total_hypotheses"]
+    if total > len(qre_ids):
+        # The sample is intentionally bounded; exact membership must use the full
+        # authority map supplied by the caller via executable row annotations.
+        qre_ids = set()
+    present = []
+    missing = []
+    for hypothesis_id in executable_hypothesis_ids:
+        if qre_ids and hypothesis_id in qre_ids:
+            present.append(hypothesis_id)
+        else:
+            missing.append(hypothesis_id)
+    all_statuses_linked = (
+        qre_authority["available"] and total > 0 and status_counts == {"linked_exact_ids": total}
+    )
+    regeneration_expected = (
+        qre_authority["available"] and bool(executable_hypothesis_ids) and not missing
+    )
+    if not qre_authority["available"]:
+        primary_blocker = PRIMARY_BLOCKER_QRE_AUTHORITY_UNAVAILABLE
+    elif not executable_hypothesis_ids:
+        primary_blocker = PRIMARY_BLOCKER_NO_EXECUTABLE_IDS
+    elif missing:
+        primary_blocker = PRIMARY_BLOCKER_EXECUTABLE_ID_MISSING
+    else:
+        primary_blocker = PRIMARY_BLOCKER_NONE
+    reason_codes = _reason_codes(
+        qre_authority=qre_authority,
+        executable_ids=executable_hypothesis_ids,
+        present_ids=present,
+        missing_ids=missing,
+        all_statuses_linked=all_statuses_linked,
+    )
+    return {
+        "executable_ids_present_in_qre_authority": present,
+        "executable_ids_missing_from_qre_authority": missing,
+        "executable_to_qre_authority_match_count": len(present),
+        "regeneration_linkage_expected": regeneration_expected,
+        "primary_blocker": primary_blocker,
+        "deterministic_mapping_possible": regeneration_expected,
+        "reason_codes": reason_codes,
+    }
+
+
+def _bridge_snapshot_from_rows(
+    *,
+    qre_authority: dict[str, Any],
+    executable_hypothesis_ids: list[str],
+    per_preset: list[dict[str, Any]],
+) -> dict[str, Any]:
+    present_set = {
+        str(row["hypothesis_id"])
+        for row in per_preset
+        if row["enabled"] and row["hypothesis_id"] and row["hypothesis_id_present_in_qre_authority"]
+    }
+    bridge = _bridge_snapshot(
+        qre_authority=qre_authority,
+        executable_hypothesis_ids=executable_hypothesis_ids,
+    )
+    present = [item for item in executable_hypothesis_ids if item in present_set]
+    missing = [item for item in executable_hypothesis_ids if item not in present_set]
+    regeneration_expected = (
+        qre_authority["available"] and bool(executable_hypothesis_ids) and not missing
+    )
+    if not qre_authority["available"]:
+        primary_blocker = PRIMARY_BLOCKER_QRE_AUTHORITY_UNAVAILABLE
+    elif not executable_hypothesis_ids:
+        primary_blocker = PRIMARY_BLOCKER_NO_EXECUTABLE_IDS
+    elif missing:
+        primary_blocker = PRIMARY_BLOCKER_EXECUTABLE_ID_MISSING
+    else:
+        primary_blocker = PRIMARY_BLOCKER_NONE
+    status_counts = qre_authority["status_counts"]
+    all_statuses_linked = (
+        qre_authority["available"]
+        and qre_authority["total_hypotheses"] > 0
+        and status_counts == {"linked_exact_ids": qre_authority["total_hypotheses"]}
+    )
+    bridge.update(
+        {
+            "executable_ids_present_in_qre_authority": present,
+            "executable_ids_missing_from_qre_authority": missing,
+            "executable_to_qre_authority_match_count": len(present),
+            "regeneration_linkage_expected": regeneration_expected,
+            "primary_blocker": primary_blocker,
+            "deterministic_mapping_possible": regeneration_expected,
+            "reason_codes": _reason_codes(
+                qre_authority=qre_authority,
+                executable_ids=executable_hypothesis_ids,
+                present_ids=present,
+                missing_ids=missing,
+                all_statuses_linked=all_statuses_linked,
+            ),
+        }
+    )
+    return bridge
+
+
+def _final_recommendation(bridge: dict[str, Any]) -> str:
+    if bridge["primary_blocker"] == PRIMARY_BLOCKER_NONE:
+        return FINAL_RECOMMENDATION_REGENERATION_LINKAGE_EXPECTED
+    if bridge["primary_blocker"] == PRIMARY_BLOCKER_EXECUTABLE_ID_MISSING:
+        return FINAL_RECOMMENDATION_BRIDGE_REQUIRED
+    return FINAL_RECOMMENDATION_INPUTS_FAILED_CLOSED
+
+
+def collect_snapshot(
+    *,
+    hypothesis_artifact_path: Path | None = None,
+    plan_artifact_path: Path | None = None,
+    run_manifest_artifact_path: Path | None = None,
+    generated_at_utc: str | None = None,
+    presets: Any = None,
+) -> dict[str, Any]:
+    generated = generated_at_utc or _utcnow()
+    qre_authority, qre_by_hypothesis_id, authority_warnings = _authority_snapshot(
+        hypothesis_artifact_path=hypothesis_artifact_path or DEFAULT_HYPOTHESIS_ARTIFACT_PATH,
+        plan_artifact_path=plan_artifact_path or DEFAULT_PLAN_ARTIFACT_PATH,
+        run_manifest_artifact_path=run_manifest_artifact_path or DEFAULT_RUN_MANIFEST_ARTIFACT_PATH,
+    )
+    executable_presets, preset_warnings = _presets_snapshot(
+        presets=presets,
+        qre_by_hypothesis_id=qre_by_hypothesis_id,
+    )
+    bridge = _bridge_snapshot_from_rows(
+        qre_authority=qre_authority,
+        executable_hypothesis_ids=executable_presets["executable_hypothesis_ids"],
+        per_preset=executable_presets["per_preset"],
+    )
+    validation_warnings = _bounded_unique(
+        [*authority_warnings, *preset_warnings],
+        max_items=WARNING_LIMIT,
+    )
+    return {
+        "report_kind": REPORT_KIND,
+        "schema_version": SCHEMA_VERSION,
+        "generated_at_utc": generated,
+        "output_artifact_path": OUTPUT_ARTIFACT_RELATIVE_PATH,
+        "safe_to_execute": False,
+        "read_only": True,
+        "final_recommendation": _final_recommendation(bridge),
+        "validation_warnings": validation_warnings,
+        "qre_authority": qre_authority,
+        "executable_presets": executable_presets,
+        "bridge": bridge,
+        "recommended_bridge_keys": list(RECOMMENDED_BRIDGE_KEYS),
+        "writes_development_work_queue": False,
+        "writes_seed_jsonl": False,
+        "writes_generated_seed_jsonl": False,
+        "writes_research_action_queue": False,
+        "mutates_campaign_queue": False,
+        "mutates_strategy_or_preset": False,
+        "mutates_research_artifacts": False,
+        "mutates_paper_shadow_live_runtime": False,
+        "launches_codex": False,
+        "launches_subprocess": False,
+        "eligible_for_direct_execution": False,
+    }
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    if not path.resolve().is_relative_to(ARTIFACT_DIR.resolve()):
+        raise ValueError(f"refusing write outside QRE executable bridge diagnostics dir: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".qre_executable_hypothesis_identity_bridge.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        with suppress(OSError):
+            os.unlink(tmp_name)
+        raise
+
+
+def write_snapshot(
+    snapshot: dict[str, Any],
+    *,
+    output_path: Path | None = None,
+) -> Path:
+    target = output_path or ARTIFACT_LATEST
+    _atomic_write_json(target, snapshot)
+    return target
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="reporting.qre_executable_hypothesis_identity_bridge_diagnostics",
+        description="Explain executable preset hypothesis IDs versus QRE generated IDs.",
+    )
+    parser.add_argument("--no-write", action="store_true")
+    parser.add_argument("--frozen-utc", default=None)
+    parser.add_argument("--indent", type=int, default=2)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    snapshot = collect_snapshot(generated_at_utc=args.frozen_utc)
+    if not args.no_write:
+        write_snapshot(snapshot)
+    print(json.dumps(snapshot, indent=args.indent, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "ARTIFACT_DIR",
+    "ARTIFACT_LATEST",
+    "DEFAULT_HYPOTHESIS_ARTIFACT_PATH",
+    "DEFAULT_PLAN_ARTIFACT_PATH",
+    "DEFAULT_RUN_MANIFEST_ARTIFACT_PATH",
+    "OUTPUT_ARTIFACT_RELATIVE_PATH",
+    "REPORT_KIND",
+    "SCHEMA_VERSION",
+    "collect_snapshot",
+    "main",
+    "write_snapshot",
+]

--- a/tests/unit/test_qre_executable_hypothesis_identity_bridge_diagnostics.py
+++ b/tests/unit/test_qre_executable_hypothesis_identity_bridge_diagnostics.py
@@ -333,6 +333,40 @@ def test_presets_malformed_fails_closed(tmp_path: Path) -> None:
     assert "presets_unavailable_or_malformed" in snap["validation_warnings"]
 
 
+def test_presets_source_parser_handles_annotated_presets_assignment(tmp_path: Path) -> None:
+    presets_source = tmp_path / "presets.py"
+    presets_source.write_text(
+        """
+PRESETS: tuple[ResearchPreset, ...] = (
+    ResearchPreset(
+        name="trend_pullback_crypto_1h",
+        enabled=True,
+        status="stable",
+        preset_class="experimental",
+        hypothesis_id="trend_pullback_v1",
+    ),
+)
+""",
+        encoding="utf-8",
+    )
+
+    presets, warnings = diag._presets_from_source(presets_source)
+
+    assert warnings == []
+    assert presets == [
+        {
+            "enabled": True,
+            "diagnostic_only": False,
+            "excluded_from_daily_scheduler": False,
+            "excluded_from_candidate_promotion": False,
+            "status": "stable",
+            "preset_class": "experimental",
+            "hypothesis_id": "trend_pullback_v1",
+            "name": "trend_pullback_crypto_1h",
+        }
+    ]
+
+
 def test_write_snapshot_only_allows_diagnostic_latest_path(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/unit/test_qre_executable_hypothesis_identity_bridge_diagnostics.py
+++ b/tests/unit/test_qre_executable_hypothesis_identity_bridge_diagnostics.py
@@ -1,0 +1,427 @@
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+from reporting import qre_executable_hypothesis_identity_bridge_diagnostics as diag
+
+FROZEN = "2026-06-01T12:00:00Z"
+
+
+def _write_json(path: Path, payload: dict) -> Path:
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return path
+
+
+def _write_authorities(tmp_path: Path, hypothesis_ids: list[str]) -> dict[str, Path]:
+    hypotheses = []
+    plans = []
+    manifests = []
+    for index, hypothesis_id in enumerate(hypothesis_ids, start=1):
+        plan_id = f"qre-plan-fixture-{index:03d}"
+        run_id = f"qre-run-fixture-{index:03d}"
+        hypotheses.append({"hypothesis_id": hypothesis_id})
+        plans.append(
+            {
+                "hypothesis_id": hypothesis_id,
+                "validation_plan_id": plan_id,
+            }
+        )
+        manifests.append(
+            {
+                "run_manifest_id": run_id,
+                "target_hypothesis_id": hypothesis_id,
+                "target_validation_plan_id": plan_id,
+            }
+        )
+    return {
+        "hypotheses": _write_json(
+            tmp_path / "hypotheses.json",
+            {
+                "report_kind": "qre_hypothesis_candidates",
+                "hypotheses": hypotheses,
+            },
+        ),
+        "plans": _write_json(
+            tmp_path / "plans.json",
+            {
+                "report_kind": "qre_hypothesis_validation_plan",
+                "validation_plans": plans,
+            },
+        ),
+        "manifests": _write_json(
+            tmp_path / "run_manifests.json",
+            {
+                "report_kind": "qre_research_run_manifest",
+                "run_manifests": manifests,
+            },
+        ),
+    }
+
+
+def _preset(
+    name: str,
+    hypothesis_id: str | None,
+    *,
+    enabled: bool = True,
+    diagnostic_only: bool = False,
+    excluded_from_daily_scheduler: bool = False,
+    excluded_from_candidate_promotion: bool = False,
+    status: str = "stable",
+    preset_class: str = "experimental",
+) -> dict:
+    return {
+        "name": name,
+        "enabled": enabled,
+        "diagnostic_only": diagnostic_only,
+        "excluded_from_daily_scheduler": excluded_from_daily_scheduler,
+        "excluded_from_candidate_promotion": excluded_from_candidate_promotion,
+        "status": status,
+        "preset_class": preset_class,
+        "hypothesis_id": hypothesis_id,
+    }
+
+
+def _snapshot(
+    tmp_path: Path,
+    *,
+    authority_ids: list[str],
+    presets: list[dict],
+) -> dict:
+    authorities = _write_authorities(tmp_path, authority_ids)
+    return diag.collect_snapshot(
+        hypothesis_artifact_path=authorities["hypotheses"],
+        plan_artifact_path=authorities["plans"],
+        run_manifest_artifact_path=authorities["manifests"],
+        generated_at_utc=FROZEN,
+        presets=presets,
+    )
+
+
+def _assert_safety(snapshot: dict) -> None:
+    assert snapshot["safe_to_execute"] is False
+    assert snapshot["read_only"] is True
+    assert (
+        snapshot["bridge"]["regeneration_linkage_expected"]
+        is snapshot["bridge"]["deterministic_mapping_possible"]
+    )
+    for key in (
+        "writes_development_work_queue",
+        "writes_seed_jsonl",
+        "writes_generated_seed_jsonl",
+        "writes_research_action_queue",
+        "mutates_campaign_queue",
+        "mutates_strategy_or_preset",
+        "mutates_research_artifacts",
+        "mutates_paper_shadow_live_runtime",
+        "launches_codex",
+        "eligible_for_direct_execution",
+    ):
+        assert snapshot[key] is False
+
+
+def test_current_like_mismatch_reports_bridge_required(tmp_path: Path) -> None:
+    snap = _snapshot(
+        tmp_path,
+        authority_ids=["qre-hyp-04f4d1cd9a515176", "qre-hyp-21f9405cde762bc3"],
+        presets=[
+            _preset("trend_pullback_crypto_1h", "trend_pullback_v1"),
+            _preset(
+                "vol_compression_breakout_crypto_1h",
+                "volatility_compression_breakout_v0",
+            ),
+        ],
+    )
+
+    assert snap["qre_authority"]["available"] is True
+    assert snap["qre_authority"]["linked_exact_ids"] == 2
+    assert snap["qre_authority"]["status_counts"] == {"linked_exact_ids": 2}
+    assert snap["executable_presets"]["executable_hypothesis_ids"] == [
+        "trend_pullback_v1",
+        "volatility_compression_breakout_v0",
+    ]
+    assert snap["bridge"]["executable_ids_present_in_qre_authority"] == []
+    assert snap["bridge"]["executable_ids_missing_from_qre_authority"] == [
+        "trend_pullback_v1",
+        "volatility_compression_breakout_v0",
+    ]
+    assert snap["bridge"]["executable_to_qre_authority_match_count"] == 0
+    assert snap["bridge"]["regeneration_linkage_expected"] is False
+    assert snap["bridge"]["deterministic_mapping_possible"] is False
+    assert snap["bridge"]["primary_blocker"] == ("executable_hypothesis_id_not_in_qre_authority")
+    assert snap["final_recommendation"] == (
+        "executable_hypothesis_identity_bridge_required_before_regeneration"
+    )
+    assert "qre_authority_available" in snap["bridge"]["reason_codes"]
+    assert "qre_authority_all_linked_exact_ids" in snap["bridge"]["reason_codes"]
+    assert "executable_hypothesis_ids_discovered" in snap["bridge"]["reason_codes"]
+    assert (
+        "runtime_regeneration_expected_unlinked_unknown_hypothesis_id"
+        in snap["bridge"]["reason_codes"]
+    )
+    assert (
+        "deterministic_mapping_not_supported_without_explicit_bridge"
+        in snap["bridge"]["reason_codes"]
+    )
+    _assert_safety(snap)
+
+
+def test_exact_match_expects_regeneration_linkage(tmp_path: Path) -> None:
+    snap = _snapshot(
+        tmp_path,
+        authority_ids=["trend_pullback_v1", "volatility_compression_breakout_v0"],
+        presets=[
+            _preset("trend_pullback_crypto_1h", "trend_pullback_v1"),
+            _preset(
+                "vol_compression_breakout_crypto_1h",
+                "volatility_compression_breakout_v0",
+            ),
+        ],
+    )
+
+    assert snap["bridge"]["executable_ids_present_in_qre_authority"] == [
+        "trend_pullback_v1",
+        "volatility_compression_breakout_v0",
+    ]
+    assert snap["bridge"]["executable_ids_missing_from_qre_authority"] == []
+    assert snap["bridge"]["executable_to_qre_authority_match_count"] == 2
+    assert snap["bridge"]["regeneration_linkage_expected"] is True
+    assert snap["bridge"]["deterministic_mapping_possible"] is True
+    assert snap["bridge"]["primary_blocker"] == "none"
+    _assert_safety(snap)
+
+
+def test_partial_match_fails_closed_and_reports_missing_id(tmp_path: Path) -> None:
+    snap = _snapshot(
+        tmp_path,
+        authority_ids=["trend_pullback_v1", "qre-hyp-generated"],
+        presets=[
+            _preset("trend_pullback_crypto_1h", "trend_pullback_v1"),
+            _preset(
+                "vol_compression_breakout_crypto_1h",
+                "volatility_compression_breakout_v0",
+            ),
+        ],
+    )
+
+    assert snap["bridge"]["executable_ids_present_in_qre_authority"] == ["trend_pullback_v1"]
+    assert snap["bridge"]["executable_ids_missing_from_qre_authority"] == [
+        "volatility_compression_breakout_v0"
+    ]
+    assert snap["bridge"]["executable_to_qre_authority_match_count"] == 1
+    assert snap["bridge"]["regeneration_linkage_expected"] is False
+    assert snap["bridge"]["primary_blocker"] == ("executable_hypothesis_id_not_in_qre_authority")
+
+
+def test_missing_qre_authority_artifacts_fail_closed(tmp_path: Path) -> None:
+    snap = diag.collect_snapshot(
+        hypothesis_artifact_path=tmp_path / "missing-hypotheses.json",
+        plan_artifact_path=tmp_path / "missing-plans.json",
+        run_manifest_artifact_path=tmp_path / "missing-runs.json",
+        generated_at_utc=FROZEN,
+        presets=[_preset("trend_pullback_crypto_1h", "trend_pullback_v1")],
+    )
+
+    assert snap["qre_authority"]["available"] is False
+    assert snap["bridge"]["regeneration_linkage_expected"] is False
+    assert snap["bridge"]["deterministic_mapping_possible"] is False
+    assert snap["bridge"]["primary_blocker"] == "qre_authority_unavailable"
+    assert any("qre_artifact_missing" in item for item in snap["validation_warnings"])
+    _assert_safety(snap)
+
+
+def test_malformed_qre_authority_artifacts_fail_closed(tmp_path: Path) -> None:
+    hypotheses = tmp_path / "hypotheses.json"
+    hypotheses.write_text("{", encoding="utf-8")
+    plans = _write_json(
+        tmp_path / "plans.json",
+        {"report_kind": "qre_hypothesis_validation_plan", "validation_plans": []},
+    )
+    manifests = _write_json(
+        tmp_path / "run_manifests.json",
+        {"report_kind": "qre_research_run_manifest", "run_manifests": []},
+    )
+
+    snap = diag.collect_snapshot(
+        hypothesis_artifact_path=hypotheses,
+        plan_artifact_path=plans,
+        run_manifest_artifact_path=manifests,
+        generated_at_utc=FROZEN,
+        presets=[_preset("trend_pullback_crypto_1h", "trend_pullback_v1")],
+    )
+
+    assert snap["qre_authority"]["available"] is False
+    assert snap["bridge"]["regeneration_linkage_expected"] is False
+    assert any("qre_artifact_malformed" in item for item in snap["validation_warnings"])
+
+
+def test_no_executable_hypothesis_ids_fails_closed(tmp_path: Path) -> None:
+    snap = _snapshot(
+        tmp_path,
+        authority_ids=["trend_pullback_v1"],
+        presets=[
+            _preset("baseline_without_id", None),
+            _preset("disabled_with_id", "trend_pullback_v1", enabled=False),
+        ],
+    )
+
+    assert snap["executable_presets"]["executable_hypothesis_ids"] == []
+    assert snap["bridge"]["regeneration_linkage_expected"] is False
+    assert snap["bridge"]["deterministic_mapping_possible"] is False
+    assert snap["bridge"]["primary_blocker"] == "no_executable_hypothesis_ids"
+    assert "no_executable_hypothesis_ids_discovered" in snap["bridge"]["reason_codes"]
+
+
+def test_per_preset_rows_are_bounded_and_include_required_fields(tmp_path: Path) -> None:
+    presets = [_preset(f"preset-{index:03d}", f"hyp-{index:03d}") for index in range(125)]
+    snap = _snapshot(tmp_path, authority_ids=["hyp-000"], presets=presets)
+
+    rows = snap["executable_presets"]["per_preset"]
+    assert len(rows) == 100
+    assert snap["executable_presets"]["per_preset_truncated"] is True
+    required = {
+        "preset_name",
+        "enabled",
+        "diagnostic_only",
+        "excluded_from_daily_scheduler",
+        "excluded_from_candidate_promotion",
+        "status",
+        "preset_class",
+        "hypothesis_id",
+        "hypothesis_id_present_in_qre_authority",
+        "qre_authority_status",
+    }
+    assert required <= set(rows[0])
+    assert rows[0]["hypothesis_id_present_in_qre_authority"] is True
+    assert rows[0]["qre_authority_status"] == "linked_exact_ids"
+
+
+def test_recommended_bridge_keys_present(tmp_path: Path) -> None:
+    snap = _snapshot(
+        tmp_path,
+        authority_ids=["qre-hyp-generated"],
+        presets=[_preset("trend_pullback_crypto_1h", "trend_pullback_v1")],
+    )
+
+    assert snap["recommended_bridge_keys"] == [
+        "executable_hypothesis_id",
+        "qre_hypothesis_id",
+        "source_hypothesis_id",
+        "strategy_family",
+        "strategy_template_id",
+        "preset_name",
+        "validation_plan_id",
+        "run_manifest_id",
+    ]
+
+
+def test_presets_malformed_fails_closed(tmp_path: Path) -> None:
+    authorities = _write_authorities(tmp_path, ["trend_pullback_v1"])
+    snap = diag.collect_snapshot(
+        hypothesis_artifact_path=authorities["hypotheses"],
+        plan_artifact_path=authorities["plans"],
+        run_manifest_artifact_path=authorities["manifests"],
+        generated_at_utc=FROZEN,
+        presets="not-a-preset-sequence",
+    )
+
+    assert snap["executable_presets"]["executable_hypothesis_ids"] == []
+    assert snap["bridge"]["regeneration_linkage_expected"] is False
+    assert "presets_unavailable_or_malformed" in snap["validation_warnings"]
+
+
+def test_write_snapshot_only_allows_diagnostic_latest_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    artifact_dir = tmp_path / "logs" / "qre_executable_hypothesis_identity_bridge"
+    latest = artifact_dir / "latest.json"
+    monkeypatch.setattr(diag, "ARTIFACT_DIR", artifact_dir)
+    monkeypatch.setattr(diag, "ARTIFACT_LATEST", latest)
+    snap = diag.collect_snapshot(
+        hypothesis_artifact_path=tmp_path / "missing-hyp.json",
+        plan_artifact_path=tmp_path / "missing-plan.json",
+        run_manifest_artifact_path=tmp_path / "missing-run.json",
+        generated_at_utc=FROZEN,
+        presets=[],
+    )
+
+    written = diag.write_snapshot(snap)
+
+    assert written == latest
+    assert latest.exists()
+    assert [path.relative_to(tmp_path).as_posix() for path in tmp_path.rglob("*.json")] == [
+        "logs/qre_executable_hypothesis_identity_bridge/latest.json"
+    ]
+    with pytest.raises(ValueError):
+        diag.write_snapshot(snap, output_path=tmp_path / "outside.json")
+
+
+def test_main_writes_only_latest_json(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    authorities = _write_authorities(tmp_path, ["qre-hyp-generated"])
+    artifact_dir = tmp_path / "logs" / "qre_executable_hypothesis_identity_bridge"
+    latest = artifact_dir / "latest.json"
+    monkeypatch.setattr(diag, "DEFAULT_HYPOTHESIS_ARTIFACT_PATH", authorities["hypotheses"])
+    monkeypatch.setattr(diag, "DEFAULT_PLAN_ARTIFACT_PATH", authorities["plans"])
+    monkeypatch.setattr(diag, "DEFAULT_RUN_MANIFEST_ARTIFACT_PATH", authorities["manifests"])
+    monkeypatch.setattr(diag, "ARTIFACT_DIR", artifact_dir)
+    monkeypatch.setattr(diag, "ARTIFACT_LATEST", latest)
+    monkeypatch.setattr(
+        diag,
+        "_load_default_presets",
+        lambda: ([_preset("trend_pullback_crypto_1h", "trend_pullback_v1")], []),
+    )
+
+    assert diag.main(["--frozen-utc", FROZEN]) == 0
+
+    assert latest.exists()
+    assert [path.relative_to(tmp_path).as_posix() for path in tmp_path.rglob("latest.json")] == [
+        "logs/qre_executable_hypothesis_identity_bridge/latest.json"
+    ]
+    payload = json.loads(latest.read_text(encoding="utf-8"))
+    assert payload["safe_to_execute"] is False
+    assert payload["read_only"] is True
+
+
+def test_forbidden_calls_imports_and_mutating_paths_absent() -> None:
+    src = Path(diag.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    imported_modules: set[str] = set()
+    forbidden_runtime_modules = (
+        "broker",
+        "live",
+        "paper",
+        "shadow",
+        "risk",
+        "trading",
+        "execution",
+    )
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported_modules.add(node.module)
+        elif isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
+                assert (func.value.id, func.attr) != ("os", "system")
+                assert func.value.id != "subprocess"
+
+    assert "subprocess" not in imported_modules
+    for module in imported_modules:
+        root = module.split(".")[0]
+        assert root not in forbidden_runtime_modules
+    for token in (
+        "generated_seed.jsonl",
+        "seed.jsonl",
+        "logs/development_work_queue/latest.json",
+        "research/research_action_queue_latest.v1.json",
+        "research.run_research",
+        "agent/backtesting/strategies.py",
+        "registry.py",
+        "strategy_matrix.csv",
+        "research/research_latest.json",
+    ):
+        assert token not in src


### PR DESCRIPTION
## Summary
- add read-only QRE executable hypothesis identity bridge diagnostics
- report executable preset hypothesis IDs versus current QRE generated authority IDs
- add unit coverage for mismatch, exact match, partial match, fail-closed inputs, bounded output, and CLI write guards

## Validation
- python -m pytest tests/unit/test_qre_executable_hypothesis_identity_bridge_diagnostics.py -q
- python -m pytest tests/unit/test_qre_validation_result_linkage_diagnostics.py -q
- python -m pytest tests/unit/test_qre_hypothesis_validation_results.py -q
- python -m pytest tests/unit/test_run_candidates_validation_linkage.py -q
- python -m pytest tests/unit/test_qre_validation_source_linkage_contract.py -q
- python -m ruff check reporting/qre_executable_hypothesis_identity_bridge_diagnostics.py tests/unit/test_qre_executable_hypothesis_identity_bridge_diagnostics.py
- python -m ruff format --check reporting/qre_executable_hypothesis_identity_bridge_diagnostics.py tests/unit/test_qre_executable_hypothesis_identity_bridge_diagnostics.py
- python -m pytest tests/architecture/test_domain_boundary_smoke.py -q
- python -m pytest tests/smoke/test_smoke.py -q
- python -m reporting.qre_executable_hypothesis_identity_bridge_diagnostics