### PR TITLE
Implement QRE executable hypothesis identity bridge contract

### DIFF
--- a/reporting/qre_executable_hypothesis_identity_bridge_contract.py
+++ b/reporting/qre_executable_hypothesis_identity_bridge_contract.py
@@ -1,0 +1,246 @@
+"""Pure contract for explicit executable-to-QRE hypothesis identity bridges."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any, Final
+
+BRIDGE_STATUS_EXACT: Final[str] = "bridge_exact"
+BRIDGE_STATUS_MISSING_EXECUTABLE_HYPOTHESIS_ID: Final[str] = (
+    "bridge_missing_executable_hypothesis_id"
+)
+BRIDGE_STATUS_MISSING_QRE_HYPOTHESIS_ID: Final[str] = "bridge_missing_qre_hypothesis_id"
+BRIDGE_STATUS_MISSING_VALIDATION_PLAN_ID: Final[str] = "bridge_missing_validation_plan_id"
+BRIDGE_STATUS_MISSING_RUN_MANIFEST_ID: Final[str] = "bridge_missing_run_manifest_id"
+BRIDGE_STATUS_AMBIGUOUS_EXECUTABLE_HYPOTHESIS_ID: Final[str] = (
+    "bridge_ambiguous_executable_hypothesis_id"
+)
+BRIDGE_STATUS_QRE_HYPOTHESIS_ID_NOT_IN_AUTHORITY: Final[str] = (
+    "bridge_qre_hypothesis_id_not_in_authority"
+)
+BRIDGE_STATUS_VALIDATION_PLAN_MISMATCH: Final[str] = "bridge_validation_plan_mismatch"
+BRIDGE_STATUS_RUN_MANIFEST_MISMATCH: Final[str] = "bridge_run_manifest_mismatch"
+BRIDGE_STATUS_MALFORMED: Final[str] = "bridge_malformed"
+
+CANONICAL_BRIDGE_FIELDS: Final[tuple[str, ...]] = (
+    "executable_hypothesis_id",
+    "qre_hypothesis_id",
+    "source_hypothesis_id",
+    "strategy_family",
+    "strategy_template_id",
+    "preset_name",
+    "validation_plan_id",
+    "run_manifest_id",
+)
+
+MAX_FIELD_LEN: Final[int] = 160
+MAX_WARNING_LEN: Final[int] = 160
+MAX_WARNINGS: Final[int] = 8
+
+
+def _bounded_str(value: Any, *, max_len: int = MAX_FIELD_LEN) -> str:
+    text = str(value or "").strip()
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 3].rstrip() + "..."
+
+
+def _bridge_fields(row: dict[str, Any]) -> dict[str, str | None]:
+    return {
+        field: _bounded_str(row.get(field), max_len=MAX_FIELD_LEN) or None
+        for field in CANONICAL_BRIDGE_FIELDS
+    }
+
+
+def _warning(value: str) -> str:
+    return _bounded_str(value, max_len=MAX_WARNING_LEN)
+
+
+def _result(
+    *,
+    fields: dict[str, str | None],
+    bridge_status: str,
+    warnings: list[str] | None = None,
+) -> dict[str, Any]:
+    warning_values = [_warning(item) for item in warnings or [] if _warning(item)]
+    return {
+        **fields,
+        "safe_to_bridge": bridge_status == BRIDGE_STATUS_EXACT,
+        "bridge_status": bridge_status,
+        "bridge_warnings": warning_values[:MAX_WARNINGS],
+    }
+
+
+def _authority_entry(
+    *,
+    qre_hypothesis_id: str,
+    qre_authority: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    if qre_authority is None:
+        return None
+    if not isinstance(qre_authority, dict):
+        return {}
+    by_hypothesis = qre_authority.get("by_hypothesis_id")
+    if not isinstance(by_hypothesis, dict):
+        return {}
+    entry = by_hypothesis.get(qre_hypothesis_id)
+    return entry if isinstance(entry, dict) else {}
+
+
+def validate_bridge_row(
+    row: dict[str, Any],
+    qre_authority: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Validate one explicit bridge row and fail closed on every uncertainty."""
+    if not isinstance(row, dict):
+        return _result(
+            fields={field: None for field in CANONICAL_BRIDGE_FIELDS},
+            bridge_status=BRIDGE_STATUS_MALFORMED,
+            warnings=["bridge_row_malformed"],
+        )
+
+    fields = _bridge_fields(row)
+    if not fields["executable_hypothesis_id"]:
+        return _result(
+            fields=fields,
+            bridge_status=BRIDGE_STATUS_MISSING_EXECUTABLE_HYPOTHESIS_ID,
+            warnings=["bridge_row_missing_executable_hypothesis_id"],
+        )
+    if not fields["qre_hypothesis_id"]:
+        return _result(
+            fields=fields,
+            bridge_status=BRIDGE_STATUS_MISSING_QRE_HYPOTHESIS_ID,
+            warnings=["bridge_row_missing_qre_hypothesis_id"],
+        )
+    if not fields["validation_plan_id"]:
+        return _result(
+            fields=fields,
+            bridge_status=BRIDGE_STATUS_MISSING_VALIDATION_PLAN_ID,
+            warnings=["bridge_row_missing_validation_plan_id"],
+        )
+    if not fields["run_manifest_id"]:
+        return _result(
+            fields=fields,
+            bridge_status=BRIDGE_STATUS_MISSING_RUN_MANIFEST_ID,
+            warnings=["bridge_row_missing_run_manifest_id"],
+        )
+
+    qre_hypothesis_id = fields["qre_hypothesis_id"]
+    assert qre_hypothesis_id is not None
+    entry = _authority_entry(qre_hypothesis_id=qre_hypothesis_id, qre_authority=qre_authority)
+    if entry == {}:
+        return _result(
+            fields=fields,
+            bridge_status=BRIDGE_STATUS_QRE_HYPOTHESIS_ID_NOT_IN_AUTHORITY,
+            warnings=["bridge_qre_hypothesis_id_not_in_authority"],
+        )
+    if entry is not None:
+        expected_validation_plan_id = _bounded_str(
+            entry.get("validation_plan_id"), max_len=MAX_FIELD_LEN
+        )
+        if fields["validation_plan_id"] != expected_validation_plan_id:
+            return _result(
+                fields=fields,
+                bridge_status=BRIDGE_STATUS_VALIDATION_PLAN_MISMATCH,
+                warnings=["bridge_validation_plan_id_not_authoritative"],
+            )
+        expected_run_manifest_id = _bounded_str(entry.get("run_manifest_id"), max_len=MAX_FIELD_LEN)
+        if fields["run_manifest_id"] != expected_run_manifest_id:
+            return _result(
+                fields=fields,
+                bridge_status=BRIDGE_STATUS_RUN_MANIFEST_MISMATCH,
+                warnings=["bridge_run_manifest_id_not_authoritative"],
+            )
+
+    return _result(fields=fields, bridge_status=BRIDGE_STATUS_EXACT)
+
+
+def _ambiguous_entry(executable_hypothesis_id: str, rows: list[dict[str, Any]]) -> dict[str, Any]:
+    qre_ids = sorted(
+        {
+            _bounded_str(row.get("qre_hypothesis_id"), max_len=MAX_FIELD_LEN)
+            for row in rows
+            if _bounded_str(row.get("qre_hypothesis_id"), max_len=MAX_FIELD_LEN)
+        }
+    )
+    return {
+        "executable_hypothesis_id": executable_hypothesis_id,
+        "qre_hypothesis_id": None,
+        "source_hypothesis_id": None,
+        "strategy_family": None,
+        "strategy_template_id": None,
+        "preset_name": None,
+        "validation_plan_id": None,
+        "run_manifest_id": None,
+        "safe_to_bridge": False,
+        "bridge_status": BRIDGE_STATUS_AMBIGUOUS_EXECUTABLE_HYPOTHESIS_ID,
+        "bridge_warnings": ["bridge_executable_hypothesis_id_maps_to_multiple_qre_ids"],
+        "conflicting_qre_hypothesis_ids": qre_ids[:MAX_WARNINGS],
+    }
+
+
+def build_bridge_index(
+    rows: list[dict[str, Any]],
+    qre_authority: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a deterministic executable-hypothesis bridge index."""
+    if not isinstance(rows, list):
+        return {
+            "available": False,
+            "warnings": ["bridge_rows_malformed"],
+            "by_executable_hypothesis_id": {},
+            "bridge_summary": {
+                "exact_bridge_count": 0,
+                "ambiguous_bridge_count": 0,
+                "unsafe_bridge_count": 1,
+            },
+        }
+
+    validated_rows = [
+        validate_bridge_row(row, qre_authority=qre_authority)
+        for row in rows
+        if isinstance(row, dict)
+    ]
+    grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    unsafe_without_executable = 0
+    for row in validated_rows:
+        executable_id = row.get("executable_hypothesis_id")
+        if isinstance(executable_id, str) and executable_id:
+            grouped[executable_id].append(row)
+        elif row.get("bridge_status") != BRIDGE_STATUS_EXACT:
+            unsafe_without_executable += 1
+
+    by_executable: dict[str, dict[str, Any]] = {}
+    exact_count = 0
+    ambiguous_count = 0
+    unsafe_count = unsafe_without_executable
+
+    for executable_id in sorted(grouped):
+        group = grouped[executable_id]
+        qre_ids = {
+            str(row.get("qre_hypothesis_id")) for row in group if row.get("qre_hypothesis_id")
+        }
+        if len(qre_ids) > 1:
+            by_executable[executable_id] = _ambiguous_entry(executable_id, group)
+            ambiguous_count += 1
+            unsafe_count += 1
+            continue
+
+        exact_rows = [row for row in group if row.get("bridge_status") == BRIDGE_STATUS_EXACT]
+        selected = exact_rows[0] if exact_rows else group[0]
+        by_executable[executable_id] = dict(selected)
+        if selected.get("bridge_status") == BRIDGE_STATUS_EXACT:
+            exact_count += 1
+        else:
+            unsafe_count += 1
+
+    return {
+        "available": True,
+        "warnings": [],
+        "by_executable_hypothesis_id": by_executable,
+        "bridge_summary": {
+            "exact_bridge_count": exact_count,
+            "ambiguous_bridge_count": ambiguous_count,
+            "unsafe_bridge_count": unsafe_count,
+        },
+    }

--- a/reporting/qre_executable_hypothesis_identity_bridge_diagnostics.py
+++ b/reporting/qre_executable_hypothesis_identity_bridge_diagnostics.py
@@ -13,6 +13,11 @@ from contextlib import suppress
 from pathlib import Path
 from typing import Any, Final
 
+from reporting.qre_executable_hypothesis_identity_bridge_contract import (
+    BRIDGE_STATUS_EXACT,
+    build_bridge_index,
+)
+
 REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
 
 SCHEMA_VERSION: Final[int] = 1
@@ -47,12 +52,15 @@ FINAL_RECOMMENDATION_BRIDGE_REQUIRED: Final[str] = (
 FINAL_RECOMMENDATION_REGENERATION_LINKAGE_EXPECTED: Final[str] = (
     "runtime_regeneration_linkage_expected_for_executable_hypothesis_ids"
 )
+FINAL_RECOMMENDATION_BRIDGE_READY: Final[str] = (
+    "executable_hypothesis_identity_bridge_ready_for_regeneration"
+)
 FINAL_RECOMMENDATION_INPUTS_FAILED_CLOSED: Final[str] = "inputs_failed_closed_before_regeneration"
 
 PRIMARY_BLOCKER_EXECUTABLE_ID_MISSING: Final[str] = "executable_hypothesis_id_not_in_qre_authority"
 PRIMARY_BLOCKER_QRE_AUTHORITY_UNAVAILABLE: Final[str] = "qre_authority_unavailable"
 PRIMARY_BLOCKER_NO_EXECUTABLE_IDS: Final[str] = "no_executable_hypothesis_ids"
-PRIMARY_BLOCKER_NONE: Final[str] = "none"
+PRIMARY_BLOCKER_NONE: Final[str] = "no_primary_blocker"
 
 RECOMMENDED_BRIDGE_KEYS: Final[tuple[str, ...]] = (
     "executable_hypothesis_id",
@@ -156,6 +164,12 @@ def _build_qre_validation_linkage_authority(
             "available": False,
             "warnings": warnings,
             "by_hypothesis_id": {},
+            "by_executable_hypothesis_id": {},
+            "bridge_summary": {
+                "exact_bridge_count": 0,
+                "ambiguous_bridge_count": 0,
+                "unsafe_bridge_count": 0,
+            },
         }
 
     hypothesis_ids = {
@@ -222,10 +236,52 @@ def _build_qre_validation_linkage_authority(
             "warnings": [],
         }
 
+    bridge_rows: list[dict[str, Any]] = []
+    for item in hypotheses or []:
+        executable_hypothesis_id = _bounded_str(item.get("executable_hypothesis_id"), max_len=160)
+        qre_hypothesis_id = _bounded_str(item.get("hypothesis_id"), max_len=160)
+        entry = by_hypothesis_id.get(qre_hypothesis_id)
+        if not executable_hypothesis_id or not qre_hypothesis_id:
+            continue
+        entry = entry if isinstance(entry, dict) else {}
+        bridge_rows.append(
+            {
+                "executable_hypothesis_id": executable_hypothesis_id,
+                "qre_hypothesis_id": qre_hypothesis_id,
+                "source_hypothesis_id": item.get("source_hypothesis_id"),
+                "strategy_family": item.get("strategy_family"),
+                "strategy_template_id": item.get("strategy_template_id"),
+                "preset_name": item.get("preset_name"),
+                "validation_plan_id": entry.get("validation_plan_id"),
+                "run_manifest_id": entry.get("run_manifest_id"),
+            }
+        )
+    bridge_index = build_bridge_index(
+        bridge_rows,
+        qre_authority={"by_hypothesis_id": by_hypothesis_id},
+    )
+    raw_by_executable = bridge_index.get("by_executable_hypothesis_id")
+    by_executable_hypothesis_id = {
+        key: value
+        for key, value in (raw_by_executable.items() if isinstance(raw_by_executable, dict) else [])
+        if isinstance(value, dict)
+        and value.get("safe_to_bridge") is True
+        and value.get("bridge_status") == BRIDGE_STATUS_EXACT
+    }
+
     return {
         "available": True,
         "warnings": [],
         "by_hypothesis_id": by_hypothesis_id,
+        "by_executable_hypothesis_id": by_executable_hypothesis_id,
+        "bridge_summary": bridge_index.get(
+            "bridge_summary",
+            {
+                "exact_bridge_count": 0,
+                "ambiguous_bridge_count": 0,
+                "unsafe_bridge_count": 0,
+            },
+        ),
     }
 
 
@@ -304,9 +360,17 @@ def _preset_row(
     preset: Any,
     *,
     qre_by_hypothesis_id: dict[str, Any],
+    qre_by_executable_hypothesis_id: dict[str, Any],
 ) -> dict[str, Any]:
     hypothesis_id = _bounded_str(_get_field(preset, "hypothesis_id"), max_len=160)
-    entry = qre_by_hypothesis_id.get(hypothesis_id) if hypothesis_id else None
+    direct_entry = qre_by_hypothesis_id.get(hypothesis_id) if hypothesis_id else None
+    bridge_entry = qre_by_executable_hypothesis_id.get(hypothesis_id) if hypothesis_id else None
+    entry = direct_entry if isinstance(direct_entry, dict) else bridge_entry
+    linkage_mode = None
+    if isinstance(direct_entry, dict):
+        linkage_mode = "direct_qre_hypothesis_id"
+    elif isinstance(bridge_entry, dict):
+        linkage_mode = "executable_hypothesis_bridge"
     return {
         "preset_name": _bounded_str(_get_field(preset, "name"), max_len=160),
         "enabled": _bool_field(preset, "enabled"),
@@ -319,8 +383,11 @@ def _preset_row(
         "preset_class": _bounded_str(_get_field(preset, "preset_class"), max_len=80),
         "hypothesis_id": hypothesis_id or None,
         "hypothesis_id_present_in_qre_authority": bool(entry),
+        "qre_authority_linkage_mode": linkage_mode,
         "qre_authority_status": (
-            _bounded_str(entry.get("status"), max_len=80) if isinstance(entry, dict) else None
+            _bounded_str(entry.get("status") or entry.get("bridge_status"), max_len=80)
+            if isinstance(entry, dict)
+            else None
         ),
     }
 
@@ -341,7 +408,7 @@ def _authority_snapshot(
     hypothesis_artifact_path: Path,
     plan_artifact_path: Path,
     run_manifest_artifact_path: Path,
-) -> tuple[dict[str, Any], dict[str, Any], list[str]]:
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], list[str]]:
     warnings: list[str] = []
     _hyp_available, hypothesis_payload, hyp_warning = _read_json(hypothesis_artifact_path)
     _plan_available, plan_payload, plan_warning = _read_json(plan_artifact_path)
@@ -364,6 +431,8 @@ def _authority_snapshot(
 
     by_hypothesis_id_raw = authority.get("by_hypothesis_id")
     by_hypothesis_id = by_hypothesis_id_raw if isinstance(by_hypothesis_id_raw, dict) else {}
+    by_executable_raw = authority.get("by_executable_hypothesis_id")
+    by_executable_hypothesis_id = by_executable_raw if isinstance(by_executable_raw, dict) else {}
     status_counter: Counter[str] = Counter()
     for entry in by_hypothesis_id.values():
         if isinstance(entry, dict):
@@ -374,25 +443,48 @@ def _authority_snapshot(
 
     qre_ids = sorted(_bounded_str(value, max_len=160) for value in by_hypothesis_id)
     qre_ids = [value for value in qre_ids if value]
+    executable_ids = sorted(
+        _bounded_str(value, max_len=160) for value in by_executable_hypothesis_id
+    )
+    executable_ids = [value for value in executable_ids if value]
+    bridge_summary = authority.get("bridge_summary")
+    if not isinstance(bridge_summary, dict):
+        bridge_summary = {
+            "exact_bridge_count": 0,
+            "ambiguous_bridge_count": 0,
+            "unsafe_bridge_count": 0,
+        }
     snapshot = {
         "available": bool(authority.get("available")),
         "warnings": _bounded_unique(authority_warnings, max_items=WARNING_LIMIT),
         "total_hypotheses": len(by_hypothesis_id),
         "linked_exact_ids": status_counter.get("linked_exact_ids", 0),
+        "executable_bridge_summary": bridge_summary,
+        "sample_executable_hypothesis_ids": executable_ids[:SAMPLE_LIMIT],
         "status_counts": dict(sorted(status_counter.items())),
         "sample_qre_hypothesis_ids": qre_ids[:SAMPLE_LIMIT],
     }
-    return (snapshot, by_hypothesis_id, _bounded_unique(warnings, max_items=WARNING_LIMIT))
+    return (
+        snapshot,
+        by_hypothesis_id,
+        by_executable_hypothesis_id,
+        _bounded_unique(warnings, max_items=WARNING_LIMIT),
+    )
 
 
 def _presets_snapshot(
     *,
     presets: Any,
     qre_by_hypothesis_id: dict[str, Any],
+    qre_by_executable_hypothesis_id: dict[str, Any],
 ) -> tuple[dict[str, Any], list[str]]:
     preset_items, warnings = _coerce_presets(presets)
     rows = [
-        _preset_row(preset, qre_by_hypothesis_id=qre_by_hypothesis_id)
+        _preset_row(
+            preset,
+            qre_by_hypothesis_id=qre_by_hypothesis_id,
+            qre_by_executable_hypothesis_id=qre_by_executable_hypothesis_id,
+        )
         for preset in preset_items[:PRESET_ROW_LIMIT]
     ]
     executable_ids = _bounded_unique(
@@ -551,7 +643,7 @@ def _bridge_snapshot_from_rows(
 
 def _final_recommendation(bridge: dict[str, Any]) -> str:
     if bridge["primary_blocker"] == PRIMARY_BLOCKER_NONE:
-        return FINAL_RECOMMENDATION_REGENERATION_LINKAGE_EXPECTED
+        return FINAL_RECOMMENDATION_BRIDGE_READY
     if bridge["primary_blocker"] == PRIMARY_BLOCKER_EXECUTABLE_ID_MISSING:
         return FINAL_RECOMMENDATION_BRIDGE_REQUIRED
     return FINAL_RECOMMENDATION_INPUTS_FAILED_CLOSED
@@ -566,7 +658,12 @@ def collect_snapshot(
     presets: Any = None,
 ) -> dict[str, Any]:
     generated = generated_at_utc or _utcnow()
-    qre_authority, qre_by_hypothesis_id, authority_warnings = _authority_snapshot(
+    (
+        qre_authority,
+        qre_by_hypothesis_id,
+        qre_by_executable_hypothesis_id,
+        authority_warnings,
+    ) = _authority_snapshot(
         hypothesis_artifact_path=hypothesis_artifact_path or DEFAULT_HYPOTHESIS_ARTIFACT_PATH,
         plan_artifact_path=plan_artifact_path or DEFAULT_PLAN_ARTIFACT_PATH,
         run_manifest_artifact_path=run_manifest_artifact_path or DEFAULT_RUN_MANIFEST_ARTIFACT_PATH,
@@ -574,6 +671,7 @@ def collect_snapshot(
     executable_presets, preset_warnings = _presets_snapshot(
         presets=presets,
         qre_by_hypothesis_id=qre_by_hypothesis_id,
+        qre_by_executable_hypothesis_id=qre_by_executable_hypothesis_id,
     )
     bridge = _bridge_snapshot_from_rows(
         qre_authority=qre_authority,

--- a/reporting/qre_hypothesis_candidates.py
+++ b/reporting/qre_hypothesis_candidates.py
@@ -9,6 +9,7 @@ import json
 import os
 import tempfile
 from collections import Counter
+from contextlib import suppress
 from pathlib import Path
 from typing import Any, Final
 
@@ -26,6 +27,14 @@ ARTIFACT_LATEST: Final[Path] = REPO_ROOT / OUTPUT_ARTIFACT_RELATIVE_PATH
 
 STATUS_PROPOSED: Final[str] = "proposed"
 
+OPTIONAL_BRIDGE_FIELDS: Final[tuple[str, ...]] = (
+    "executable_hypothesis_id",
+    "source_hypothesis_id",
+    "strategy_family",
+    "strategy_template_id",
+    "preset_name",
+)
+
 NOTE_INPUT_ABSENT: Final[str] = "market_observation_artifact_absent"
 NOTE_INPUT_UNPARSEABLE: Final[str] = "market_observation_artifact_unparseable"
 NOTE_NO_HYPOTHESES: Final[str] = "no_hypotheses_projected"
@@ -33,12 +42,7 @@ NOTE_HYPOTHESES_PRESENT: Final[str] = "hypothesis_candidates_present"
 
 
 def _utcnow() -> str:
-    return (
-        _dt.datetime.now(_dt.UTC)
-        .replace(microsecond=0)
-        .isoformat()
-        .replace("+00:00", "Z")
-    )
+    return _dt.datetime.now(_dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
 def _rel(path: Path) -> str:
@@ -135,11 +139,9 @@ def _template_for_type(observation_type: str) -> dict[str, str]:
 def _build_hypothesis(observation: dict[str, Any]) -> dict[str, Any]:
     observation_type = _bounded_str(observation.get("observation_type"), max_len=80)
     template = _template_for_type(observation_type)
-    return {
+    hypothesis = {
         "hypothesis_id": _hypothesis_id(observation),
-        "source_observation_id": _bounded_str(
-            observation.get("observation_id"), max_len=160
-        ),
+        "source_observation_id": _bounded_str(observation.get("observation_id"), max_len=160),
         "title": template["title"],
         "claim": template["claim"],
         "asset_scope": _str_list(observation.get("asset_scope")) or ["unknown"],
@@ -157,6 +159,11 @@ def _build_hypothesis(observation: dict[str, Any]) -> dict[str, Any]:
         "status": STATUS_PROPOSED,
         "safe_to_execute": False,
     }
+    for field in OPTIONAL_BRIDGE_FIELDS:
+        value = _bounded_str(observation.get(field), max_len=160)
+        if value:
+            hypothesis[field] = value
+    return hypothesis
 
 
 def _empty_counts() -> dict[str, Any]:
@@ -227,9 +234,11 @@ def collect_snapshot(
         )
 
     raw_observations = payload.get("observations")
-    if payload.get("report_kind") != INPUT_REPORT_KIND or not isinstance(
-        raw_observations, list
-    ) or not all(isinstance(item, dict) for item in raw_observations):
+    if (
+        payload.get("report_kind") != INPUT_REPORT_KIND
+        or not isinstance(raw_observations, list)
+        or not all(isinstance(item, dict) for item in raw_observations)
+    ):
         return _base_snapshot(
             generated_at_utc=generated,
             input_artifact_path=source,
@@ -266,10 +275,8 @@ def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
             handle.write(text)
         os.replace(tmp_name, path)
     except Exception:
-        try:
+        with suppress(OSError):
             os.unlink(tmp_name)
-        except OSError:
-            pass
         raise
 
 

--- a/research/candidate_pipeline.py
+++ b/research/candidate_pipeline.py
@@ -9,6 +9,9 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Final
 
+from reporting.qre_executable_hypothesis_identity_bridge_contract import (
+    BRIDGE_STATUS_EXACT,
+)
 from research.asset_typing import normalize_asset_type
 from research.registry import count_param_combinations, expand_param_grid
 
@@ -99,10 +102,7 @@ def _canonical_param_dump(samples: list[dict[str, Any]]) -> str:
     ``allow_nan=False`` is explicit: any unsanitised NaN/inf
     reaching this call is a programmer bug and raises immediately.
     """
-    safe = [
-        {key: _json_safe_param_value(val) for key, val in sample.items()}
-        for sample in samples
-    ]
+    safe = [{key: _json_safe_param_value(val) for key, val in sample.items()} for sample in samples]
     return json.dumps(
         safe,
         sort_keys=True,
@@ -113,9 +113,7 @@ def _canonical_param_dump(samples: list[dict[str, Any]]) -> str:
 
 
 def _compute_sampled_parameter_digest(samples: list[dict[str, Any]]) -> str:
-    return hashlib.sha1(
-        _canonical_param_dump(samples).encode("utf-8")
-    ).hexdigest()
+    return hashlib.sha1(_canonical_param_dump(samples).encode("utf-8")).hexdigest()
 
 
 def _stratified_indices(grid_size: int) -> list[int]:
@@ -137,10 +135,7 @@ def _stratified_indices(grid_size: int) -> list[int]:
         math.ceil(grid_size * MIN_STRATIFIED_COVERAGE_PCT),
     )
     sample_size = min(sample_size, grid_size)
-    raw = [
-        round(i * (grid_size - 1) / (sample_size - 1))
-        for i in range(sample_size)
-    ]
+    raw = [round(i * (grid_size - 1) / (sample_size - 1)) for i in range(sample_size)]
     deduped = sorted({0, grid_size - 1, *raw})
     while len(deduped) < sample_size:
         for candidate in range(grid_size):
@@ -340,9 +335,8 @@ def _normalized_asset_type(candidate: dict[str, Any]) -> str:
 
 def assess_fit_prior(candidate: dict[str, Any]) -> tuple[str, str]:
     requirements = candidate.get("strategy_requirements") or {}
-    if (
-        requirements.get("position_structure") == POSITION_SPREAD
-        and not requirements.get("reference_asset")
+    if requirements.get("position_structure") == POSITION_SPREAD and not requirements.get(
+        "reference_asset"
     ):
         return FIT_BLOCKED, "requires_spread_not_outright"
     if requirements.get("initial_lane_support") == BLOCKED_INITIAL_LANE:
@@ -392,10 +386,7 @@ def apply_fit_prior(
 def index_readiness(
     pair_diagnostics: list[dict[str, Any]],
 ) -> dict[tuple[str, str], dict[str, Any]]:
-    return {
-        (str(item["asset"]), str(item["interval"])): item
-        for item in pair_diagnostics
-    }
+    return {(str(item["asset"]), str(item["interval"])): item for item in pair_diagnostics}
 
 
 def apply_eligibility(
@@ -613,9 +604,7 @@ def sampling_plan_for_param_grid(
     # remains honoured here so external callers that explicitly
     # constrain the legacy regime still get the smaller cap.
     legacy_cap = max(1, int(max_samples_for_legacy))
-    selected_indices = sorted(
-        {0, grid_size // 2, grid_size - 1}
-    )
+    selected_indices = sorted({0, grid_size // 2, grid_size - 1})
     samples = [combinations[i] for i in selected_indices][:legacy_cap]
     coverage_pct = len(samples) / grid_size
     return SamplingPlan(
@@ -647,9 +636,7 @@ def screening_param_samples(
     Callers that need coverage metadata should use
     ``sampling_plan_for_param_grid`` directly.
     """
-    return sampling_plan_for_param_grid(
-        param_grid, max_samples_for_legacy=max_samples
-    ).samples
+    return sampling_plan_for_param_grid(param_grid, max_samples_for_legacy=max_samples).samples
 
 
 def normalize_screening_decision(sample_results: list[dict[str, Any]]) -> dict[str, Any]:
@@ -733,6 +720,7 @@ def _run_candidate_validation_linkage_fields(
     hypothesis_id = _bounded_str(candidate.get("hypothesis_id"), max_len=160) or None
     fields: dict[str, Any] = {
         "hypothesis_id": hypothesis_id,
+        "executable_hypothesis_id": None,
         "validation_plan_id": None,
         "run_manifest_id": None,
         "source_artifact": RUN_CANDIDATES_SOURCE_ARTIFACT,
@@ -765,6 +753,29 @@ def _run_candidate_validation_linkage_fields(
         return fields
     entry = by_hypothesis.get(hypothesis_id)
     if not isinstance(entry, dict):
+        by_executable = qre_validation_linkage_authority.get("by_executable_hypothesis_id")
+        bridge_entry = by_executable.get(hypothesis_id) if isinstance(by_executable, dict) else None
+        if (
+            isinstance(bridge_entry, dict)
+            and bridge_entry.get("safe_to_bridge") is True
+            and bridge_entry.get("bridge_status") == BRIDGE_STATUS_EXACT
+        ):
+            qre_hypothesis_id = (
+                _bounded_str(bridge_entry.get("qre_hypothesis_id"), max_len=160) or None
+            )
+            validation_plan_id = (
+                _bounded_str(bridge_entry.get("validation_plan_id"), max_len=160) or None
+            )
+            run_manifest_id = _bounded_str(bridge_entry.get("run_manifest_id"), max_len=160) or None
+            if qre_hypothesis_id and validation_plan_id and run_manifest_id:
+                fields["hypothesis_id"] = qre_hypothesis_id
+                fields["executable_hypothesis_id"] = hypothesis_id
+                fields["validation_plan_id"] = validation_plan_id
+                fields["run_manifest_id"] = run_manifest_id
+                fields["qre_validation_linkage_status"] = "linked_executable_hypothesis_bridge"
+                fields["qre_validation_linkage_warnings"] = []
+                return fields
+
         fields["qre_validation_linkage_status"] = "unlinked_unknown_hypothesis_id"
         fields["qre_validation_linkage_warnings"] = [
             "run_candidate_hypothesis_id_not_in_qre_authority"

--- a/research/screening_evidence.py
+++ b/research/screening_evidence.py
@@ -43,6 +43,10 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Final
 
+from reporting.qre_executable_hypothesis_identity_bridge_contract import (
+    BRIDGE_STATUS_EXACT,
+    build_bridge_index,
+)
 from research.screening_criteria import (
     EXPLORATORY_MAX_DRAWDOWN,
     EXPLORATORY_MIN_EXPECTANCY,
@@ -115,6 +119,7 @@ PER_CANDIDATE_KEYS: Final[frozenset[str]] = frozenset(
         "asset",
         "interval",
         "hypothesis_id",
+        "executable_hypothesis_id",
         "validation_plan_id",
         "run_manifest_id",
         "source_artifact",
@@ -384,6 +389,12 @@ def build_qre_validation_linkage_authority(
             "available": False,
             "warnings": warnings,
             "by_hypothesis_id": {},
+            "by_executable_hypothesis_id": {},
+            "bridge_summary": {
+                "exact_bridge_count": 0,
+                "ambiguous_bridge_count": 0,
+                "unsafe_bridge_count": 0,
+            },
         }
 
     hypothesis_ids = {
@@ -450,10 +461,52 @@ def build_qre_validation_linkage_authority(
             "warnings": [],
         }
 
+    bridge_rows: list[dict[str, Any]] = []
+    for item in hypotheses or []:
+        executable_hypothesis_id = _bounded_str(item.get("executable_hypothesis_id"), max_len=160)
+        qre_hypothesis_id = _bounded_str(item.get("hypothesis_id"), max_len=160)
+        entry = by_hypothesis_id.get(qre_hypothesis_id)
+        if not executable_hypothesis_id or not qre_hypothesis_id:
+            continue
+        entry = entry if isinstance(entry, dict) else {}
+        bridge_rows.append(
+            {
+                "executable_hypothesis_id": executable_hypothesis_id,
+                "qre_hypothesis_id": qre_hypothesis_id,
+                "source_hypothesis_id": item.get("source_hypothesis_id"),
+                "strategy_family": item.get("strategy_family"),
+                "strategy_template_id": item.get("strategy_template_id"),
+                "preset_name": item.get("preset_name"),
+                "validation_plan_id": entry.get("validation_plan_id"),
+                "run_manifest_id": entry.get("run_manifest_id"),
+            }
+        )
+    bridge_index = build_bridge_index(
+        bridge_rows,
+        qre_authority={"by_hypothesis_id": by_hypothesis_id},
+    )
+    raw_by_executable = bridge_index.get("by_executable_hypothesis_id")
+    by_executable_hypothesis_id = {
+        key: value
+        for key, value in (raw_by_executable.items() if isinstance(raw_by_executable, dict) else [])
+        if isinstance(value, dict)
+        and value.get("safe_to_bridge") is True
+        and value.get("bridge_status") == BRIDGE_STATUS_EXACT
+    }
+
     return {
         "available": True,
         "warnings": [],
         "by_hypothesis_id": by_hypothesis_id,
+        "by_executable_hypothesis_id": by_executable_hypothesis_id,
+        "bridge_summary": bridge_index.get(
+            "bridge_summary",
+            {
+                "exact_bridge_count": 0,
+                "ambiguous_bridge_count": 0,
+                "unsafe_bridge_count": 0,
+            },
+        ),
     }
 
 
@@ -464,6 +517,8 @@ def _qre_validation_linkage_fields(
     qre_validation_linkage_authority: dict[str, Any] | None,
 ) -> dict[str, Any]:
     fields: dict[str, Any] = {
+        "hypothesis_id": hypothesis_id,
+        "executable_hypothesis_id": None,
         "validation_plan_id": None,
         "run_manifest_id": None,
         "source_artifact": SCREENING_EVIDENCE_SOURCE_ARTIFACT,
@@ -496,6 +551,29 @@ def _qre_validation_linkage_fields(
         return fields
     entry = by_hypothesis.get(hypothesis_id)
     if not isinstance(entry, dict):
+        by_executable = qre_validation_linkage_authority.get("by_executable_hypothesis_id")
+        bridge_entry = by_executable.get(hypothesis_id) if isinstance(by_executable, dict) else None
+        if (
+            isinstance(bridge_entry, dict)
+            and bridge_entry.get("safe_to_bridge") is True
+            and bridge_entry.get("bridge_status") == BRIDGE_STATUS_EXACT
+        ):
+            qre_hypothesis_id = (
+                _bounded_str(bridge_entry.get("qre_hypothesis_id"), max_len=160) or None
+            )
+            validation_plan_id = (
+                _bounded_str(bridge_entry.get("validation_plan_id"), max_len=160) or None
+            )
+            run_manifest_id = _bounded_str(bridge_entry.get("run_manifest_id"), max_len=160) or None
+            if qre_hypothesis_id and validation_plan_id and run_manifest_id:
+                fields["hypothesis_id"] = qre_hypothesis_id
+                fields["executable_hypothesis_id"] = hypothesis_id
+                fields["validation_plan_id"] = validation_plan_id
+                fields["run_manifest_id"] = run_manifest_id
+                fields["qre_validation_linkage_status"] = "linked_executable_hypothesis_bridge"
+                fields["qre_validation_linkage_warnings"] = []
+                return fields
+
         fields["qre_validation_linkage_status"] = "unlinked_unknown_hypothesis_id"
         fields["qre_validation_linkage_warnings"] = [
             "screening_row_hypothesis_id_not_in_qre_authority"

--- a/tests/regression/test_v3_15_9_screening_evidence_schema_pin.py
+++ b/tests/regression/test_v3_15_9_screening_evidence_schema_pin.py
@@ -42,6 +42,7 @@ _EXPECTED_PER_CANDIDATE_KEYS = frozenset(
         "asset",
         "interval",
         "hypothesis_id",
+        "executable_hypothesis_id",
         "validation_plan_id",
         "run_manifest_id",
         "source_artifact",

--- a/tests/unit/test_qre_executable_hypothesis_identity_bridge_contract.py
+++ b/tests/unit/test_qre_executable_hypothesis_identity_bridge_contract.py
@@ -1,0 +1,212 @@
+import ast
+from pathlib import Path
+
+from reporting.qre_executable_hypothesis_identity_bridge_contract import (
+    build_bridge_index,
+    validate_bridge_row,
+)
+
+
+def _authority() -> dict:
+    return {
+        "available": True,
+        "by_hypothesis_id": {
+            "qre-hyp-fixture": {
+                "status": "linked_exact_ids",
+                "hypothesis_id": "qre-hyp-fixture",
+                "validation_plan_id": "qre-plan-fixture",
+                "run_manifest_id": "qre-run-fixture",
+                "warnings": [],
+            }
+        },
+    }
+
+
+def _row(**overrides: str | None) -> dict:
+    row = {
+        "executable_hypothesis_id": "trend_pullback_v1",
+        "qre_hypothesis_id": "qre-hyp-fixture",
+        "source_hypothesis_id": "source-fixture",
+        "strategy_family": "trend",
+        "strategy_template_id": "trend_pullback",
+        "preset_name": "trend_pullback_v1",
+        "validation_plan_id": "qre-plan-fixture",
+        "run_manifest_id": "qre-run-fixture",
+    }
+    row.update(overrides)
+    return row
+
+
+def test_exact_bridge_row_validates_safe() -> None:
+    result = validate_bridge_row(_row(), qre_authority=_authority())
+
+    assert result["safe_to_bridge"] is True
+    assert result["bridge_status"] == "bridge_exact"
+    assert result["bridge_warnings"] == []
+
+
+def test_missing_executable_hypothesis_id_fails_closed() -> None:
+    result = validate_bridge_row(
+        _row(executable_hypothesis_id=""),
+        qre_authority=_authority(),
+    )
+
+    assert result["safe_to_bridge"] is False
+    assert result["bridge_status"] == "bridge_missing_executable_hypothesis_id"
+
+
+def test_missing_qre_hypothesis_id_fails_closed() -> None:
+    result = validate_bridge_row(
+        _row(qre_hypothesis_id=None),
+        qre_authority=_authority(),
+    )
+
+    assert result["safe_to_bridge"] is False
+    assert result["bridge_status"] == "bridge_missing_qre_hypothesis_id"
+
+
+def test_missing_validation_plan_id_fails_closed() -> None:
+    result = validate_bridge_row(
+        _row(validation_plan_id=""),
+        qre_authority=_authority(),
+    )
+
+    assert result["safe_to_bridge"] is False
+    assert result["bridge_status"] == "bridge_missing_validation_plan_id"
+
+
+def test_missing_run_manifest_id_fails_closed() -> None:
+    result = validate_bridge_row(
+        _row(run_manifest_id=""),
+        qre_authority=_authority(),
+    )
+
+    assert result["safe_to_bridge"] is False
+    assert result["bridge_status"] == "bridge_missing_run_manifest_id"
+
+
+def test_qre_hypothesis_id_not_in_authority_fails_closed() -> None:
+    result = validate_bridge_row(
+        _row(qre_hypothesis_id="qre-hyp-missing"),
+        qre_authority=_authority(),
+    )
+
+    assert result["safe_to_bridge"] is False
+    assert result["bridge_status"] == "bridge_qre_hypothesis_id_not_in_authority"
+
+
+def test_validation_plan_id_mismatch_fails_closed() -> None:
+    result = validate_bridge_row(
+        _row(validation_plan_id="qre-plan-other"),
+        qre_authority=_authority(),
+    )
+
+    assert result["safe_to_bridge"] is False
+    assert result["bridge_status"] == "bridge_validation_plan_mismatch"
+
+
+def test_run_manifest_id_mismatch_fails_closed() -> None:
+    result = validate_bridge_row(
+        _row(run_manifest_id="qre-run-other"),
+        qre_authority=_authority(),
+    )
+
+    assert result["safe_to_bridge"] is False
+    assert result["bridge_status"] == "bridge_run_manifest_mismatch"
+
+
+def test_duplicate_executable_hypothesis_id_with_same_qre_id_is_deterministic() -> None:
+    index = build_bridge_index(
+        [
+            _row(preset_name="a"),
+            _row(preset_name="b"),
+        ],
+        qre_authority=_authority(),
+    )
+
+    bridge = index["by_executable_hypothesis_id"]["trend_pullback_v1"]
+    assert bridge["safe_to_bridge"] is True
+    assert bridge["bridge_status"] == "bridge_exact"
+    assert bridge["qre_hypothesis_id"] == "qre-hyp-fixture"
+    assert index["bridge_summary"] == {
+        "exact_bridge_count": 1,
+        "ambiguous_bridge_count": 0,
+        "unsafe_bridge_count": 0,
+    }
+
+
+def test_duplicate_executable_hypothesis_id_with_different_qre_id_is_ambiguous() -> None:
+    authority = _authority()
+    authority["by_hypothesis_id"]["qre-hyp-other"] = {
+        "status": "linked_exact_ids",
+        "hypothesis_id": "qre-hyp-other",
+        "validation_plan_id": "qre-plan-other",
+        "run_manifest_id": "qre-run-other",
+        "warnings": [],
+    }
+
+    index = build_bridge_index(
+        [
+            _row(),
+            _row(
+                qre_hypothesis_id="qre-hyp-other",
+                validation_plan_id="qre-plan-other",
+                run_manifest_id="qre-run-other",
+            ),
+        ],
+        qre_authority=authority,
+    )
+
+    bridge = index["by_executable_hypothesis_id"]["trend_pullback_v1"]
+    assert bridge["safe_to_bridge"] is False
+    assert bridge["bridge_status"] == "bridge_ambiguous_executable_hypothesis_id"
+    assert bridge["conflicting_qre_hypothesis_ids"] == [
+        "qre-hyp-fixture",
+        "qre-hyp-other",
+    ]
+    assert index["bridge_summary"]["ambiguous_bridge_count"] == 1
+    assert index["bridge_summary"]["unsafe_bridge_count"] == 1
+
+
+def test_contract_output_is_bounded() -> None:
+    result = validate_bridge_row(
+        _row(source_hypothesis_id="x" * 500),
+        qre_authority=_authority(),
+    )
+
+    assert result["safe_to_bridge"] is True
+    assert len(result["source_hypothesis_id"]) <= 160
+    assert set(result) <= {
+        "executable_hypothesis_id",
+        "qre_hypothesis_id",
+        "source_hypothesis_id",
+        "strategy_family",
+        "strategy_template_id",
+        "preset_name",
+        "validation_plan_id",
+        "run_manifest_id",
+        "safe_to_bridge",
+        "bridge_status",
+        "bridge_warnings",
+    }
+
+
+def test_contract_has_no_forbidden_calls_or_writes() -> None:
+    source_path = (
+        Path(__file__).resolve().parents[2]
+        / "reporting"
+        / "qre_executable_hypothesis_identity_bridge_contract.py"
+    )
+    source = source_path.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    forbidden_names = {"open", "exec", "eval", "__import__"}
+    forbidden_attrs = {"write", "replace", "unlink", "mkdir", "run", "Popen"}
+
+    assert "subprocess" not in source
+    assert "research.run_research" not in source
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                assert node.func.id not in forbidden_names
+            if isinstance(node.func, ast.Attribute):
+                assert node.func.attr not in forbidden_attrs

--- a/tests/unit/test_qre_executable_hypothesis_identity_bridge_diagnostics.py
+++ b/tests/unit/test_qre_executable_hypothesis_identity_bridge_diagnostics.py
@@ -16,14 +16,32 @@ def _write_json(path: Path, payload: dict) -> Path:
     return path
 
 
-def _write_authorities(tmp_path: Path, hypothesis_ids: list[str]) -> dict[str, Path]:
+def _write_authorities(
+    tmp_path: Path,
+    hypothesis_ids: list[str],
+    *,
+    executable_bridge_by_hypothesis_id: dict[str, str] | None = None,
+) -> dict[str, Path]:
+    bridge = executable_bridge_by_hypothesis_id or {}
     hypotheses = []
     plans = []
     manifests = []
     for index, hypothesis_id in enumerate(hypothesis_ids, start=1):
         plan_id = f"qre-plan-fixture-{index:03d}"
         run_id = f"qre-run-fixture-{index:03d}"
-        hypotheses.append({"hypothesis_id": hypothesis_id})
+        hypothesis = {"hypothesis_id": hypothesis_id}
+        executable_hypothesis_id = bridge.get(hypothesis_id)
+        if executable_hypothesis_id:
+            hypothesis.update(
+                {
+                    "executable_hypothesis_id": executable_hypothesis_id,
+                    "source_hypothesis_id": f"source-{index:03d}",
+                    "strategy_family": "trend",
+                    "strategy_template_id": "trend_pullback",
+                    "preset_name": f"preset-{index:03d}",
+                }
+            )
+        hypotheses.append(hypothesis)
         plans.append(
             {
                 "hypothesis_id": hypothesis_id,
@@ -90,8 +108,13 @@ def _snapshot(
     *,
     authority_ids: list[str],
     presets: list[dict],
+    executable_bridge_by_hypothesis_id: dict[str, str] | None = None,
 ) -> dict:
-    authorities = _write_authorities(tmp_path, authority_ids)
+    authorities = _write_authorities(
+        tmp_path,
+        authority_ids,
+        executable_bridge_by_hypothesis_id=executable_bridge_by_hypothesis_id,
+    )
     return diag.collect_snapshot(
         hypothesis_artifact_path=authorities["hypotheses"],
         plan_artifact_path=authorities["plans"],
@@ -190,8 +213,74 @@ def test_exact_match_expects_regeneration_linkage(tmp_path: Path) -> None:
     assert snap["bridge"]["executable_to_qre_authority_match_count"] == 2
     assert snap["bridge"]["regeneration_linkage_expected"] is True
     assert snap["bridge"]["deterministic_mapping_possible"] is True
-    assert snap["bridge"]["primary_blocker"] == "none"
+    assert snap["bridge"]["primary_blocker"] == "no_primary_blocker"
     _assert_safety(snap)
+
+
+def test_explicit_bridge_reports_regeneration_linkage_ready(tmp_path: Path) -> None:
+    snap = _snapshot(
+        tmp_path,
+        authority_ids=["qre-hyp-fixture-001", "qre-hyp-fixture-002"],
+        executable_bridge_by_hypothesis_id={
+            "qre-hyp-fixture-001": "trend_pullback_v1",
+            "qre-hyp-fixture-002": "volatility_compression_breakout_v0",
+        },
+        presets=[
+            _preset("trend_pullback_crypto_1h", "trend_pullback_v1"),
+            _preset(
+                "vol_compression_breakout_crypto_1h",
+                "volatility_compression_breakout_v0",
+            ),
+        ],
+    )
+
+    assert snap["qre_authority"]["executable_bridge_summary"] == {
+        "exact_bridge_count": 2,
+        "ambiguous_bridge_count": 0,
+        "unsafe_bridge_count": 0,
+    }
+    assert snap["qre_authority"]["sample_executable_hypothesis_ids"] == [
+        "trend_pullback_v1",
+        "volatility_compression_breakout_v0",
+    ]
+    assert snap["bridge"]["executable_ids_missing_from_qre_authority"] == []
+    assert snap["bridge"]["regeneration_linkage_expected"] is True
+    assert snap["bridge"]["deterministic_mapping_possible"] is True
+    assert snap["bridge"]["primary_blocker"] == "no_primary_blocker"
+    assert snap["final_recommendation"] == (
+        "executable_hypothesis_identity_bridge_ready_for_regeneration"
+    )
+    assert {
+        row["qre_authority_linkage_mode"] for row in snap["executable_presets"]["per_preset"]
+    } == {"executable_hypothesis_bridge"}
+    _assert_safety(snap)
+
+
+def test_explicit_bridge_reports_false_when_one_executable_id_is_missing(
+    tmp_path: Path,
+) -> None:
+    snap = _snapshot(
+        tmp_path,
+        authority_ids=["qre-hyp-fixture-001", "qre-hyp-fixture-002"],
+        executable_bridge_by_hypothesis_id={
+            "qre-hyp-fixture-001": "trend_pullback_v1",
+        },
+        presets=[
+            _preset("trend_pullback_crypto_1h", "trend_pullback_v1"),
+            _preset(
+                "vol_compression_breakout_crypto_1h",
+                "volatility_compression_breakout_v0",
+            ),
+        ],
+    )
+
+    assert snap["bridge"]["executable_ids_present_in_qre_authority"] == ["trend_pullback_v1"]
+    assert snap["bridge"]["executable_ids_missing_from_qre_authority"] == [
+        "volatility_compression_breakout_v0"
+    ]
+    assert snap["bridge"]["regeneration_linkage_expected"] is False
+    assert snap["bridge"]["deterministic_mapping_possible"] is False
+    assert snap["bridge"]["primary_blocker"] == "executable_hypothesis_id_not_in_qre_authority"
 
 
 def test_partial_match_fails_closed_and_reports_missing_id(tmp_path: Path) -> None:
@@ -293,6 +382,7 @@ def test_per_preset_rows_are_bounded_and_include_required_fields(tmp_path: Path)
         "hypothesis_id",
         "hypothesis_id_present_in_qre_authority",
         "qre_authority_status",
+        "qre_authority_linkage_mode",
     }
     assert required <= set(rows[0])
     assert rows[0]["hypothesis_id_present_in_qre_authority"] is True
@@ -457,5 +547,9 @@ def test_forbidden_calls_imports_and_mutating_paths_absent() -> None:
         "registry.py",
         "strategy_matrix.csv",
         "research/research_latest.json",
+        "import difflib",
+        "SequenceMatcher",
+        "fuzzy",
+        "levenshtein",
     ):
         assert token not in src

--- a/tests/unit/test_qre_hypothesis_candidates.py
+++ b/tests/unit/test_qre_hypothesis_candidates.py
@@ -7,7 +7,6 @@ import pytest
 
 from reporting import qre_hypothesis_candidates as hyp
 
-
 FROZEN = "2026-06-01T12:00:00Z"
 
 
@@ -82,6 +81,42 @@ def test_deterministic_output_with_injected_timestamp(tmp_path: Path) -> None:
     assert row["safe_to_execute"] is False
 
 
+def test_explicit_executable_bridge_fields_are_preserved_when_present(
+    tmp_path: Path,
+) -> None:
+    source = _write_observations(
+        tmp_path / "obs.json",
+        [
+            _observation(
+                executable_hypothesis_id="trend_pullback_v1",
+                source_hypothesis_id="source-trend-pullback",
+                strategy_family="trend",
+                strategy_template_id="trend_pullback",
+                preset_name="trend_pullback_crypto_1h",
+            )
+        ],
+    )
+
+    snap = hyp.collect_snapshot(input_artifact_path=source, generated_at_utc=FROZEN)
+
+    row = snap["hypotheses"][0]
+    assert row["executable_hypothesis_id"] == "trend_pullback_v1"
+    assert row["source_hypothesis_id"] == "source-trend-pullback"
+    assert row["strategy_family"] == "trend"
+    assert row["strategy_template_id"] == "trend_pullback"
+    assert row["preset_name"] == "trend_pullback_crypto_1h"
+
+
+def test_executable_bridge_fields_are_not_invented_when_absent(tmp_path: Path) -> None:
+    source = _write_observations(tmp_path / "obs.json", [_observation()])
+
+    snap = hyp.collect_snapshot(input_artifact_path=source, generated_at_utc=FROZEN)
+
+    row = snap["hypotheses"][0]
+    for field in hyp.OPTIONAL_BRIDGE_FIELDS:
+        assert field not in row
+
+
 def test_atomic_write_refuses_outside_artifact_dir(tmp_path: Path) -> None:
     with pytest.raises(ValueError):
         hyp._atomic_write_json(tmp_path / "latest.json", {"x": 1})
@@ -98,9 +133,7 @@ def test_cli_no_write_outputs_json_without_writing(
     monkeypatch.setattr(hyp, "ARTIFACT_DIR", artifact_dir)
     monkeypatch.setattr(hyp, "ARTIFACT_LATEST", latest)
 
-    rc = hyp.main(
-        ["--no-write", "--source", str(source), "--frozen-utc", FROZEN, "--indent", "0"]
-    )
+    rc = hyp.main(["--no-write", "--source", str(source), "--frozen-utc", FROZEN, "--indent", "0"])
 
     assert rc == 0
     assert latest.exists() is False

--- a/tests/unit/test_run_candidates_validation_linkage.py
+++ b/tests/unit/test_run_candidates_validation_linkage.py
@@ -14,6 +14,7 @@ from research.screening_evidence import build_qre_validation_linkage_authority
 
 FROZEN = datetime(2026, 6, 1, 12, 0, 0, tzinfo=UTC)
 HYPOTHESIS_ID = "qre-hyp-fixture-001"
+EXECUTABLE_HYPOTHESIS_ID = "trend_pullback_v1"
 PLAN_ID = "qre-plan-fixture-001"
 RUN_MANIFEST_ID = "qre-run-fixture-001"
 _DEFAULT = object()
@@ -61,6 +62,24 @@ def _authority(
                 ],
             }
         ),
+    )
+
+
+def _bridge_authority() -> dict:
+    return _authority(
+        hypotheses={
+            "report_kind": "qre_hypothesis_candidates",
+            "hypotheses": [
+                {
+                    "hypothesis_id": HYPOTHESIS_ID,
+                    "executable_hypothesis_id": EXECUTABLE_HYPOTHESIS_ID,
+                    "source_hypothesis_id": "source-trend-pullback",
+                    "strategy_family": "trend",
+                    "strategy_template_id": "trend_pullback",
+                    "preset_name": "trend_pullback_crypto_1h",
+                }
+            ],
+        },
     )
 
 
@@ -120,6 +139,99 @@ def test_exact_qre_authority_adds_all_strict_linkage_fields() -> None:
     assert row["run_manifest_id"] == RUN_MANIFEST_ID
     assert row["qre_validation_linkage_status"] == "linked_exact_ids"
     assert row["qre_validation_linkage_warnings"] == []
+
+
+def test_qre_hypothesis_row_with_executable_id_builds_safe_bridge_authority() -> None:
+    authority = _bridge_authority()
+
+    bridge = authority["by_executable_hypothesis_id"][EXECUTABLE_HYPOTHESIS_ID]
+    assert bridge["safe_to_bridge"] is True
+    assert bridge["bridge_status"] == "bridge_exact"
+    assert bridge["qre_hypothesis_id"] == HYPOTHESIS_ID
+    assert bridge["validation_plan_id"] == PLAN_ID
+    assert bridge["run_manifest_id"] == RUN_MANIFEST_ID
+    assert authority["bridge_summary"] == {
+        "exact_bridge_count": 1,
+        "ambiguous_bridge_count": 0,
+        "unsafe_bridge_count": 0,
+    }
+
+
+def test_trend_pullback_v1_bridges_safely_to_qre_fixture() -> None:
+    bridge = _bridge_authority()["by_executable_hypothesis_id"][EXECUTABLE_HYPOTHESIS_ID]
+
+    assert bridge["executable_hypothesis_id"] == EXECUTABLE_HYPOTHESIS_ID
+    assert bridge["qre_hypothesis_id"] == HYPOTHESIS_ID
+    assert bridge["source_hypothesis_id"] == "source-trend-pullback"
+
+
+def test_run_candidate_executable_hypothesis_id_links_through_bridge() -> None:
+    row = _row(
+        candidate=_candidate(hypothesis_id=EXECUTABLE_HYPOTHESIS_ID),
+        authority=_bridge_authority(),
+    )
+
+    assert row["hypothesis_id"] == HYPOTHESIS_ID
+    assert row["executable_hypothesis_id"] == EXECUTABLE_HYPOTHESIS_ID
+    assert row["validation_plan_id"] == PLAN_ID
+    assert row["run_manifest_id"] == RUN_MANIFEST_ID
+    assert row["qre_validation_linkage_status"] == "linked_executable_hypothesis_bridge"
+    assert row["qre_validation_linkage_warnings"] == []
+
+
+def test_ambiguous_executable_bridge_fails_closed_for_run_candidates() -> None:
+    authority = _authority(
+        hypotheses={
+            "report_kind": "qre_hypothesis_candidates",
+            "hypotheses": [
+                {
+                    "hypothesis_id": HYPOTHESIS_ID,
+                    "executable_hypothesis_id": EXECUTABLE_HYPOTHESIS_ID,
+                },
+                {
+                    "hypothesis_id": "qre-hyp-fixture-002",
+                    "executable_hypothesis_id": EXECUTABLE_HYPOTHESIS_ID,
+                },
+            ],
+        },
+        plans={
+            "report_kind": "qre_hypothesis_validation_plan",
+            "validation_plans": [
+                {
+                    "hypothesis_id": HYPOTHESIS_ID,
+                    "validation_plan_id": PLAN_ID,
+                },
+                {
+                    "hypothesis_id": "qre-hyp-fixture-002",
+                    "validation_plan_id": "qre-plan-fixture-002",
+                },
+            ],
+        },
+        manifests={
+            "report_kind": "qre_research_run_manifest",
+            "run_manifests": [
+                {
+                    "run_manifest_id": RUN_MANIFEST_ID,
+                    "target_validation_plan_id": PLAN_ID,
+                },
+                {
+                    "run_manifest_id": "qre-run-fixture-002",
+                    "target_validation_plan_id": "qre-plan-fixture-002",
+                },
+            ],
+        },
+    )
+
+    row = _row(
+        candidate=_candidate(hypothesis_id=EXECUTABLE_HYPOTHESIS_ID),
+        authority=authority,
+    )
+
+    assert EXECUTABLE_HYPOTHESIS_ID not in authority["by_executable_hypothesis_id"]
+    assert authority["bridge_summary"]["ambiguous_bridge_count"] == 1
+    assert row["hypothesis_id"] == EXECUTABLE_HYPOTHESIS_ID
+    assert row["executable_hypothesis_id"] is None
+    assert row["qre_validation_linkage_status"] == "unlinked_unknown_hypothesis_id"
 
 
 def test_emitted_strict_linked_run_candidate_passes_source_linkage_contract() -> None:

--- a/tests/unit/test_screening_evidence_validation_linkage.py
+++ b/tests/unit/test_screening_evidence_validation_linkage.py
@@ -14,6 +14,7 @@ from research.screening_evidence import (
 
 FROZEN = datetime(2026, 6, 1, 12, 0, 0, tzinfo=UTC)
 HYPOTHESIS_ID = "qre-hyp-fixture-001"
+EXECUTABLE_HYPOTHESIS_ID = "trend_pullback_v1"
 PLAN_ID = "qre-plan-fixture-001"
 RUN_MANIFEST_ID = "qre-run-fixture-001"
 _DEFAULT = object()
@@ -61,6 +62,24 @@ def _authority(
                 ],
             }
         ),
+    )
+
+
+def _bridge_authority() -> dict:
+    return _authority(
+        hypotheses={
+            "report_kind": "qre_hypothesis_candidates",
+            "hypotheses": [
+                {
+                    "hypothesis_id": HYPOTHESIS_ID,
+                    "executable_hypothesis_id": EXECUTABLE_HYPOTHESIS_ID,
+                    "source_hypothesis_id": "source-trend-pullback",
+                    "strategy_family": "trend",
+                    "strategy_template_id": "trend_pullback",
+                    "preset_name": "trend_pullback_crypto_1h",
+                }
+            ],
+        },
     )
 
 
@@ -114,6 +133,75 @@ def test_exact_qre_authority_adds_all_strict_linkage_fields() -> None:
     assert row["run_manifest_id"] == RUN_MANIFEST_ID
     assert row["qre_validation_linkage_status"] == "linked_exact_ids"
     assert row["qre_validation_linkage_warnings"] == []
+
+
+def test_screening_evidence_executable_hypothesis_id_links_through_bridge() -> None:
+    row = _payload(
+        candidate={"hypothesis_id": EXECUTABLE_HYPOTHESIS_ID},
+        authority=_bridge_authority(),
+    )["candidates"][0]
+
+    assert row["hypothesis_id"] == HYPOTHESIS_ID
+    assert row["executable_hypothesis_id"] == EXECUTABLE_HYPOTHESIS_ID
+    assert row["validation_plan_id"] == PLAN_ID
+    assert row["run_manifest_id"] == RUN_MANIFEST_ID
+    assert row["qre_validation_linkage_status"] == "linked_executable_hypothesis_bridge"
+    assert row["qre_validation_linkage_warnings"] == []
+
+
+def test_ambiguous_executable_bridge_fails_closed_for_screening_evidence() -> None:
+    authority = _authority(
+        hypotheses={
+            "report_kind": "qre_hypothesis_candidates",
+            "hypotheses": [
+                {
+                    "hypothesis_id": HYPOTHESIS_ID,
+                    "executable_hypothesis_id": EXECUTABLE_HYPOTHESIS_ID,
+                },
+                {
+                    "hypothesis_id": "qre-hyp-fixture-002",
+                    "executable_hypothesis_id": EXECUTABLE_HYPOTHESIS_ID,
+                },
+            ],
+        },
+        plans={
+            "report_kind": "qre_hypothesis_validation_plan",
+            "validation_plans": [
+                {
+                    "hypothesis_id": HYPOTHESIS_ID,
+                    "validation_plan_id": PLAN_ID,
+                },
+                {
+                    "hypothesis_id": "qre-hyp-fixture-002",
+                    "validation_plan_id": "qre-plan-fixture-002",
+                },
+            ],
+        },
+        manifests={
+            "report_kind": "qre_research_run_manifest",
+            "run_manifests": [
+                {
+                    "run_manifest_id": RUN_MANIFEST_ID,
+                    "target_validation_plan_id": PLAN_ID,
+                },
+                {
+                    "run_manifest_id": "qre-run-fixture-002",
+                    "target_validation_plan_id": "qre-plan-fixture-002",
+                },
+            ],
+        },
+    )
+
+    row = _payload(
+        candidate={"hypothesis_id": EXECUTABLE_HYPOTHESIS_ID},
+        authority=authority,
+    )["candidates"][0]
+
+    assert EXECUTABLE_HYPOTHESIS_ID not in authority["by_executable_hypothesis_id"]
+    assert authority["bridge_summary"]["ambiguous_bridge_count"] == 1
+    assert row["hypothesis_id"] == EXECUTABLE_HYPOTHESIS_ID
+    assert row["executable_hypothesis_id"] is None
+    assert row["qre_validation_linkage_status"] == "unlinked_unknown_hypothesis_id"
 
 
 def test_emitted_strict_linked_row_passes_source_linkage_contract() -> None:


### PR DESCRIPTION
## Summary
- Add pure executable-to-QRE hypothesis identity bridge contract with fail-closed validation and deterministic indexing.
- Enrich QRE validation linkage authority with safe explicit executable bridge rows and bridge summary.
- Link run candidates and screening evidence through explicit bridge IDs while preserving executable_hypothesis_id and canonicalizing hypothesis_id to the QRE ID.
- Update diagnostics to report bridge-ready regeneration only when all executable IDs are explicitly bridged.

## Safety
- No research.run_research invocation.
- No artifact regeneration; diagnostic was run with --no-write.
- No queue, seed, generated_seed, strategy, preset, campaign, approval, dashboard, frozen-contract, paper, shadow, live, broker, risk, or execution mutations.
- No fuzzy/name-similarity matching.

## Validation
- python -m pytest tests/unit/test_qre_executable_hypothesis_identity_bridge_contract.py -q
- python -m pytest tests/unit/test_qre_executable_hypothesis_identity_bridge_diagnostics.py -q
- python -m pytest tests/unit/test_qre_hypothesis_candidates.py -q
- python -m pytest tests/unit/test_run_candidates_validation_linkage.py -q
- python -m pytest tests/unit/test_qre_hypothesis_validation_results.py -q
- python -m pytest tests/unit/test_qre_validation_result_linkage_diagnostics.py -q
- python -m pytest tests/unit/test_qre_validation_source_linkage_contract.py -q
- python -m pytest tests/unit/test_screening_evidence_validation_linkage.py -q
- python -m ruff check <changed files>
- python -m ruff format --check <changed files>
- python -m pytest tests/architecture/test_domain_boundary_smoke.py -q
- python -m pytest tests/smoke/test_smoke.py -q
- python -m reporting.qre_executable_hypothesis_identity_bridge_diagnostics --no-write --indent 0