### PR TITLE
Preserve executable identity in QRE market observations

### DIFF
--- a/reporting/qre_market_observation_snapshot.py
+++ b/reporting/qre_market_observation_snapshot.py
@@ -11,9 +11,11 @@ import argparse
 import datetime as _dt
 import hashlib
 import json
+import math
 import os
 import tempfile
 from collections import Counter
+from contextlib import suppress
 from pathlib import Path
 from typing import Any, Final
 
@@ -39,6 +41,16 @@ OBSERVATION_TYPES: Final[tuple[str, ...]] = (
     "unknown",
 )
 
+OPTIONAL_EXECUTABLE_IDENTITY_FIELDS: Final[tuple[str, ...]] = (
+    "executable_hypothesis_id",
+    "source_hypothesis_id",
+    "strategy_family",
+    "strategy_template_id",
+    "preset_name",
+    "candidate_id",
+    "strategy_id",
+)
+
 NOTE_INPUT_ABSENT: Final[str] = "market_source_artifact_absent"
 NOTE_INPUT_UNPARSEABLE: Final[str] = "market_source_artifact_unparseable"
 NOTE_NO_OBSERVATIONS: Final[str] = "no_market_observations_projected"
@@ -46,12 +58,7 @@ NOTE_OBSERVATIONS_PRESENT: Final[str] = "market_observations_present"
 
 
 def _utcnow() -> str:
-    return (
-        _dt.datetime.now(_dt.UTC)
-        .replace(microsecond=0)
-        .isoformat()
-        .replace("+00:00", "Z")
-    )
+    return _dt.datetime.now(_dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
 def _rel(path: Path) -> str:
@@ -78,6 +85,24 @@ def _bounded_str(value: Any, *, max_len: int = 240) -> str:
     if len(text) <= max_len:
         return text
     return text[: max_len - 3].rstrip() + "..."
+
+
+def _bounded_identity_str(value: Any, *, max_len: int = 160) -> str:
+    if value is None or isinstance(value, bool):
+        return ""
+    if isinstance(value, float) and not math.isfinite(value):
+        return ""
+    if not isinstance(value, str | int | float):
+        return ""
+    return _bounded_str(value, max_len=max_len)
+
+
+def _explicit_identity_fields(raw: dict[str, Any]) -> dict[str, str]:
+    return {
+        field: value
+        for field in OPTIONAL_EXECUTABLE_IDENTITY_FIELDS
+        if (value := _bounded_identity_str(raw.get(field)))
+    }
 
 
 def _str_list(value: Any, *, max_items: int = 12, max_len: int = 120) -> list[str]:
@@ -165,6 +190,7 @@ def _normalise_fixture_observation(
             raw.get("contradicting_evidence_refs"), max_items=24, max_len=180
         ),
         "safe_to_execute": False,
+        **_explicit_identity_fields(raw),
     }
 
 
@@ -200,6 +226,7 @@ def _build_research_observations(
         family = _bounded_str(raw.get("family"), max_len=80)
         regime_tags = [family] if family else []
         row_ref = _row_identity(raw)
+        identity_fields = _explicit_identity_fields(raw)
         metric_refs = [
             _metric_ref("win_rate", raw.get("win_rate")),
             _metric_ref("sharpe", raw.get("sharpe")),
@@ -227,9 +254,8 @@ def _build_research_observations(
                     0.85,
                 )
             )
-        if (
-            (total_trades is not None and total_trades < 30)
-            or (trades_per_month is not None and trades_per_month < 1.0)
+        if (total_trades is not None and total_trades < 30) or (
+            trades_per_month is not None and trades_per_month < 1.0
         ):
             projected.append(
                 (
@@ -238,9 +264,8 @@ def _build_research_observations(
                     0.8,
                 )
             )
-        if (
-            (consistency is not None and consistency == 0.0)
-            and (total_trades is not None and total_trades < 40)
+        if (consistency is not None and consistency == 0.0) and (
+            total_trades is not None and total_trades < 40
         ):
             projected.append(
                 (
@@ -300,6 +325,7 @@ def _build_research_observations(
                     "supporting_evidence_refs": supporting_refs,
                     "contradicting_evidence_refs": contradicting_refs,
                     "safe_to_execute": False,
+                    **identity_fields,
                 }
             )
 
@@ -455,10 +481,8 @@ def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
             handle.write(text)
         os.replace(tmp_name, path)
     except Exception:
-        try:
+        with suppress(OSError):
             os.unlink(tmp_name)
-        except OSError:
-            pass
         raise
 
 
@@ -504,6 +528,7 @@ __all__ = [
     "ARTIFACT_DIR",
     "ARTIFACT_LATEST",
     "DEFAULT_SOURCE_CANDIDATES",
+    "OPTIONAL_EXECUTABLE_IDENTITY_FIELDS",
     "OBSERVATION_TYPES",
     "OUTPUT_ARTIFACT_RELATIVE_PATH",
     "REPORT_KIND",

--- a/tests/unit/test_qre_market_observation_snapshot.py
+++ b/tests/unit/test_qre_market_observation_snapshot.py
@@ -5,8 +5,9 @@ from pathlib import Path
 
 import pytest
 
+from reporting import qre_hypothesis_candidates as hyp
 from reporting import qre_market_observation_snapshot as market
-
+from research.screening_evidence import build_qre_validation_linkage_authority
 
 FROZEN = "2026-06-01T12:00:00Z"
 
@@ -72,6 +73,98 @@ def test_deterministic_output_with_injected_timestamp(tmp_path: Path) -> None:
     assert observation["observation_id"].startswith("qre-obs-")
     assert observation["observation_type"] == "low_trade_count"
     assert observation["safe_to_execute"] is False
+    assert "executable_hypothesis_id" not in observation
+
+
+def test_fixture_observation_preserves_explicit_executable_identity_fields(
+    tmp_path: Path,
+) -> None:
+    source = _write_source(
+        tmp_path / "source.json",
+        [
+            _observation(
+                executable_hypothesis_id="trend_pullback_v1",
+                source_hypothesis_id="source-trend-pullback",
+                strategy_family="trend_pullback",
+                strategy_template_id="trend_pullback_template",
+                preset_name="trend_pullback_crypto_1h",
+                candidate_id="candidate-001",
+                strategy_id="strategy-001",
+            )
+        ],
+    )
+
+    snap = market.collect_snapshot(source_path=source, generated_at_utc=FROZEN)
+
+    observation = snap["observations"][0]
+    assert observation["executable_hypothesis_id"] == "trend_pullback_v1"
+    assert observation["source_hypothesis_id"] == "source-trend-pullback"
+    assert observation["strategy_family"] == "trend_pullback"
+    assert observation["strategy_template_id"] == "trend_pullback_template"
+    assert observation["preset_name"] == "trend_pullback_crypto_1h"
+    assert observation["candidate_id"] == "candidate-001"
+    assert observation["strategy_id"] == "strategy-001"
+
+
+def test_fixture_observation_does_not_infer_identity_from_alias_like_fields(
+    tmp_path: Path,
+) -> None:
+    source = _write_source(
+        tmp_path / "source.json",
+        [
+            _observation(
+                family="trend",
+                strategy_name="trend_pullback_v1",
+                hypothesis_id="runtime-hypothesis-id",
+            )
+        ],
+    )
+
+    snap = market.collect_snapshot(source_path=source, generated_at_utc=FROZEN)
+
+    observation = snap["observations"][0]
+    assert "strategy_family" not in observation
+    assert "strategy_template_id" not in observation
+    assert "executable_hypothesis_id" not in observation
+    assert "hypothesis_id" not in observation
+
+
+def test_fixture_observation_drops_malformed_identity_fields(tmp_path: Path) -> None:
+    source = _write_source(
+        tmp_path / "source.json",
+        [
+            _observation(
+                executable_hypothesis_id={"not": "scalar"},
+                source_hypothesis_id=["not-scalar"],
+                strategy_family=True,
+                strategy_template_id=None,
+            )
+        ],
+    )
+
+    snap = market.collect_snapshot(source_path=source, generated_at_utc=FROZEN)
+
+    observation = snap["observations"][0]
+    for field in market.OPTIONAL_EXECUTABLE_IDENTITY_FIELDS:
+        assert field not in observation
+
+
+def test_fixture_observation_bounds_identity_field_values(tmp_path: Path) -> None:
+    source = _write_source(
+        tmp_path / "source.json",
+        [
+            _observation(
+                executable_hypothesis_id="x" * 500,
+                preset_name="p" * 500,
+            )
+        ],
+    )
+
+    snap = market.collect_snapshot(source_path=source, generated_at_utc=FROZEN)
+
+    observation = snap["observations"][0]
+    assert len(observation["executable_hypothesis_id"]) <= 160
+    assert len(observation["preset_name"]) <= 160
 
 
 def test_research_latest_input_projects_observations(tmp_path: Path) -> None:
@@ -107,6 +200,143 @@ def test_research_latest_input_projects_observations(tmp_path: Path) -> None:
         "low_trade_count",
         "high_window_end_impact",
     } <= types
+
+
+def test_research_latest_input_preserves_only_explicit_identity_fields(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "research_latest.json"
+    source.write_text(
+        json.dumps(
+            {
+                "results": [
+                    {
+                        "success": True,
+                        "strategy_name": "trend_pullback_tp_sl",
+                        "family": "trend",
+                        "asset": "BTC-USD",
+                        "interval": "4h",
+                        "win_rate": 0.3,
+                        "sharpe": -0.5,
+                        "deflated_sharpe": -0.4,
+                        "trades_per_maand": 0.5,
+                        "totaal_trades": 19,
+                        "consistentie": 0.0,
+                        "executable_hypothesis_id": "trend_pullback_v1",
+                        "source_hypothesis_id": "source-trend-pullback",
+                        "strategy_family": "trend_pullback",
+                        "strategy_template_id": "trend_pullback_template",
+                        "preset_name": "trend_pullback_crypto_1h",
+                        "candidate_id": "candidate-001",
+                        "strategy_id": "strategy-001",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    snap = market.collect_snapshot(source_path=source, generated_at_utc=FROZEN)
+
+    assert snap["observations"]
+    for observation in snap["observations"]:
+        assert observation["executable_hypothesis_id"] == "trend_pullback_v1"
+        assert observation["source_hypothesis_id"] == "source-trend-pullback"
+        assert observation["strategy_family"] == "trend_pullback"
+        assert observation["strategy_template_id"] == "trend_pullback_template"
+        assert observation["preset_name"] == "trend_pullback_crypto_1h"
+        assert observation["candidate_id"] == "candidate-001"
+        assert observation["strategy_id"] == "strategy-001"
+
+
+def test_research_latest_input_does_not_infer_strategy_family_or_template(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "research_latest.json"
+    source.write_text(
+        json.dumps(
+            {
+                "results": [
+                    {
+                        "success": True,
+                        "strategy_name": "trend_pullback_v1",
+                        "family": "trend",
+                        "asset": "BTC-USD",
+                        "interval": "4h",
+                        "trades_per_maand": 0.5,
+                        "totaal_trades": 19,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    snap = market.collect_snapshot(source_path=source, generated_at_utc=FROZEN)
+
+    assert snap["observations"]
+    for observation in snap["observations"]:
+        assert "strategy_family" not in observation
+        assert "strategy_template_id" not in observation
+        assert "executable_hypothesis_id" not in observation
+
+
+def test_explicit_identity_fixture_chain_reaches_hypothesis_bridge_authority(
+    tmp_path: Path,
+) -> None:
+    source = _write_source(
+        tmp_path / "source.json",
+        [
+            _observation(
+                executable_hypothesis_id="trend_pullback_v1",
+                source_hypothesis_id="source-trend-pullback",
+                strategy_family="trend_pullback",
+                strategy_template_id="trend_pullback_template",
+                preset_name="trend_pullback_crypto_1h",
+            )
+        ],
+    )
+
+    market_snap = market.collect_snapshot(source_path=source, generated_at_utc=FROZEN)
+    market_artifact = tmp_path / "market_observations.json"
+    market_artifact.write_text(json.dumps(market_snap), encoding="utf-8")
+    hyp_snap = hyp.collect_snapshot(
+        input_artifact_path=market_artifact,
+        generated_at_utc=FROZEN,
+    )
+    hypothesis = hyp_snap["hypotheses"][0]
+    plan_id = "qre-plan-fixture"
+    run_id = "qre-run-fixture"
+
+    authority = build_qre_validation_linkage_authority(
+        hypothesis_candidates_payload=hyp_snap,
+        validation_plans_payload={
+            "report_kind": "qre_hypothesis_validation_plan",
+            "validation_plans": [
+                {
+                    "hypothesis_id": hypothesis["hypothesis_id"],
+                    "validation_plan_id": plan_id,
+                }
+            ],
+        },
+        run_manifest_payload={
+            "report_kind": "qre_research_run_manifest",
+            "run_manifests": [
+                {
+                    "run_manifest_id": run_id,
+                    "target_validation_plan_id": plan_id,
+                }
+            ],
+        },
+    )
+
+    assert market_snap["observations"][0]["executable_hypothesis_id"] == ("trend_pullback_v1")
+    assert hypothesis["executable_hypothesis_id"] == "trend_pullback_v1"
+    bridge = authority["by_executable_hypothesis_id"]["trend_pullback_v1"]
+    assert bridge["bridge_status"] == "bridge_exact"
+    assert bridge["qre_hypothesis_id"] == hypothesis["hypothesis_id"]
+    assert bridge["validation_plan_id"] == plan_id
+    assert bridge["run_manifest_id"] == run_id
 
 
 def test_atomic_write_refuses_outside_artifact_dir(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add exact explicit executable identity preservation to QRE market observations.
- Preserve only explicit scalar identity fields; no aliasing from `family`, `strategy_name`, or `hypothesis_id`.
- Add fixture and research-source tests, including a chain into QRE hypothesis candidates and bridge authority.

## Pre-PR Read-Only Audit
- `main` was up to date with `origin/main` at `f1f77a0` before branch creation.
- Closed-loop materialization `--no-write` still produced 32 market observations and 32 hypothesis candidates.
- Live/current sources had zero `executable_hypothesis_id` fields in market observations, hypothesis candidates, and `research/research_latest.json`.
- Existing market observation tests did not cover executable identity preservation; the module dropped explicit bridge fields before this PR.
- This PR enables preservation when explicit fields are present, but current live diagnostics are still expected to remain blocked until a real upstream source emits `executable_hypothesis_id`.

## Safety
- No `research.run_research` invocation.
- No artifact regeneration with write.
- No queue, seed, generated_seed, strategy, preset, campaign, approval, dashboard, paper, shadow, live, broker, risk, or execution mutation.
- No fuzzy/name-similarity matching or heuristic bridge.

## Validation
- `python -m pytest tests/unit/test_qre_market_observation_snapshot.py -q`
- `python -m pytest tests/unit/test_qre_hypothesis_candidates.py -q`
- `python -m pytest tests/unit/test_qre_executable_hypothesis_identity_bridge_contract.py -q`
- `python -m pytest tests/unit/test_qre_executable_hypothesis_identity_bridge_diagnostics.py -q`
- `python -m pytest tests/unit/test_run_candidates_validation_linkage.py -q`
- `python -m pytest tests/unit/test_qre_hypothesis_validation_results.py -q`
- `python -m pytest tests/regression/test_v3_15_9_screening_evidence_schema_pin.py -q`
- `python -m ruff check reporting/qre_market_observation_snapshot.py tests/unit/test_qre_market_observation_snapshot.py`
- `python -m ruff format --check reporting/qre_market_observation_snapshot.py tests/unit/test_qre_market_observation_snapshot.py`
- `python -m reporting.qre_closed_loop_materialization_runner --no-write --indent 2`
- `python -m reporting.qre_executable_hypothesis_identity_bridge_diagnostics --no-write --indent 2`