### PR TITLE
Add QRE validation request foundation

### DIFF
--- a/reporting/qre_executable_validation_request.py
+++ b/reporting/qre_executable_validation_request.py
@@ -1,0 +1,466 @@
+"""Read-only QRE executable validation request artifact builder."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import hashlib
+import json
+import os
+import tempfile
+from collections import Counter
+from contextlib import suppress
+from pathlib import Path
+from typing import Any, Final
+
+from reporting import qre_market_observation_hypothesis_readiness as readiness
+from reporting.qre_preset_strategy_eligibility_contract import validate_request
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[int] = 1
+REPORT_KIND: Final[str] = "qre_executable_validation_request"
+INPUT_REPORT_KIND: Final[str] = "qre_hypothesis_candidates"
+READINESS_REPORT_KIND: Final[str] = "qre_market_observation_hypothesis_readiness"
+
+INPUT_ARTIFACT_RELATIVE_PATH: Final[str] = "logs/qre_hypothesis_candidates/latest.json"
+INPUT_ARTIFACT_PATH: Final[Path] = REPO_ROOT / INPUT_ARTIFACT_RELATIVE_PATH
+READINESS_ARTIFACT_RELATIVE_PATH: Final[str] = (
+    "logs/qre_market_observation_hypothesis_readiness/latest.json"
+)
+READINESS_ARTIFACT_PATH: Final[Path] = REPO_ROOT / READINESS_ARTIFACT_RELATIVE_PATH
+MARKET_OBSERVATION_ARTIFACT_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_market_observations" / "latest.json"
+)
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "qre_executable_validation_request"
+OUTPUT_ARTIFACT_RELATIVE_PATH: Final[str] = "logs/qre_executable_validation_request/latest.json"
+ARTIFACT_LATEST: Final[Path] = REPO_ROOT / OUTPUT_ARTIFACT_RELATIVE_PATH
+
+REQUEST_READY: Final[str] = "request_ready_for_operator_review"
+REQUEST_BLOCKED_IDENTITY_MISSING: Final[str] = "request_blocked_identity_missing"
+REQUEST_BLOCKED_PRESET_INELIGIBLE: Final[str] = "request_blocked_preset_ineligible"
+REQUEST_BLOCKED_MARKET_CONTEXT_MISSING: Final[str] = "request_blocked_market_context_missing"
+REQUEST_BLOCKED_VALIDATION_PLAN_MISSING: Final[str] = "request_blocked_validation_plan_missing"
+REQUEST_BLOCKED_RUN_MANIFEST_MISSING: Final[str] = "request_blocked_run_manifest_missing"
+REQUEST_MALFORMED: Final[str] = "request_malformed"
+
+REQUEST_STATUSES: Final[tuple[str, ...]] = (
+    REQUEST_READY,
+    REQUEST_BLOCKED_IDENTITY_MISSING,
+    REQUEST_BLOCKED_PRESET_INELIGIBLE,
+    REQUEST_BLOCKED_MARKET_CONTEXT_MISSING,
+    REQUEST_BLOCKED_VALIDATION_PLAN_MISSING,
+    REQUEST_BLOCKED_RUN_MANIFEST_MISSING,
+    REQUEST_MALFORMED,
+)
+
+NOTE_INPUT_ABSENT: Final[str] = "hypothesis_candidate_artifact_absent"
+NOTE_INPUT_UNPARSEABLE: Final[str] = "hypothesis_candidate_artifact_unparseable"
+
+
+def _utcnow() -> str:
+    return _dt.datetime.now(_dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _rel(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(REPO_ROOT.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _read_json(path: Path) -> tuple[bool, dict[str, Any] | None]:
+    try:
+        raw = path.read_text(encoding="utf-8-sig")
+    except OSError:
+        return (False, None)
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return (True, None)
+    return (True, parsed if isinstance(parsed, dict) else None)
+
+
+def _bounded_str(value: Any, *, max_len: int = 240) -> str:
+    if value is None or isinstance(value, bool):
+        return ""
+    text = str(value).strip()
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 3].rstrip() + "..."
+
+
+def _str_list(value: Any, *, max_items: int = 16, max_len: int = 160) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    out: list[str] = []
+    for item in value[:max_items]:
+        text = _bounded_str(item, max_len=max_len)
+        if text:
+            out.append(text)
+    return out
+
+
+def _first_scope(value: Any, *, max_len: int = 80) -> str:
+    values = _str_list(value, max_items=1, max_len=max_len)
+    return values[0] if values else ""
+
+
+def _request_id(row: dict[str, Any]) -> str:
+    seed = "|".join(
+        [
+            _bounded_str(row.get("hypothesis_id"), max_len=160),
+            _bounded_str(row.get("executable_hypothesis_id"), max_len=160),
+            _bounded_str(row.get("preset_name"), max_len=160),
+            _bounded_str(row.get("validation_plan_id"), max_len=160),
+            _bounded_str(row.get("run_manifest_id"), max_len=160),
+        ]
+    )
+    return "qre-req-" + hashlib.sha256(seed.encode("utf-8")).hexdigest()[:16]
+
+
+def _readiness_rows(
+    *,
+    readiness_path: Path,
+    market_observation_path: Path,
+    generated_at_utc: str,
+) -> tuple[dict[str, dict[str, Any]], list[str]]:
+    _available, payload = _read_json(readiness_path)
+    if (
+        isinstance(payload, dict)
+        and payload.get("report_kind") == READINESS_REPORT_KIND
+        and isinstance(payload.get("readiness_rows"), list)
+    ):
+        rows = payload.get("readiness_rows")
+        return (
+            {
+                _bounded_str(item.get("observation_id"), max_len=160): item
+                for item in rows
+                if isinstance(item, dict) and _bounded_str(item.get("observation_id"), max_len=160)
+            },
+            [],
+        )
+
+    collected = readiness.collect_snapshot(
+        input_artifact_path=market_observation_path,
+        generated_at_utc=generated_at_utc,
+    )
+    rows = collected.get("readiness_rows")
+    warnings = [
+        _bounded_str(item, max_len=160)
+        for item in collected.get("validation_warnings", [])
+        if _bounded_str(item, max_len=160)
+    ]
+    if not isinstance(rows, list):
+        return ({}, warnings)
+    return (
+        {
+            _bounded_str(item.get("observation_id"), max_len=160): item
+            for item in rows
+            if isinstance(item, dict) and _bounded_str(item.get("observation_id"), max_len=160)
+        },
+        warnings,
+    )
+
+
+def _market_context_available(
+    hypothesis: dict[str, Any], readiness_row: dict[str, Any] | None
+) -> bool:
+    asset = _bounded_str(hypothesis.get("asset"), max_len=80) or _first_scope(
+        hypothesis.get("asset_scope"),
+        max_len=80,
+    )
+    timeframe = _bounded_str(hypothesis.get("timeframe"), max_len=40) or _first_scope(
+        hypothesis.get("timeframe_scope"),
+        max_len=40,
+    )
+    if not asset or asset == "unknown" or not timeframe or timeframe == "unknown":
+        return False
+    if readiness_row is None:
+        return True
+    readiness_class = _bounded_str(readiness_row.get("readiness_class"), max_len=80)
+    return readiness_class == "hypothesis_ready"
+
+
+def _allowed_command_preview(row: dict[str, Any]) -> str:
+    return (
+        "Operator-reviewed validation request for "
+        f"preset={row['preset_name']} "
+        f"hypothesis={row['executable_hypothesis_id']} "
+        f"asset_or_symbol={row.get('asset') or row.get('symbol') or 'unknown'} "
+        f"timeframe_or_interval={row.get('timeframe') or row.get('interval') or 'unknown'}"
+    )
+
+
+def _build_request(
+    hypothesis: Any,
+    *,
+    readiness_by_observation_id: dict[str, dict[str, Any]],
+    presets: Any = None,
+) -> dict[str, Any]:
+    if not isinstance(hypothesis, dict):
+        return {
+            "request_id": "",
+            "request_status": REQUEST_MALFORMED,
+            "eligibility_status": "malformed_request",
+            "safe_to_execute": False,
+            "requires_operator_approval": True,
+            "allowed_command_preview": None,
+        }
+
+    qre_hypothesis_id = _bounded_str(hypothesis.get("hypothesis_id"), max_len=160)
+    source_observation_id = _bounded_str(hypothesis.get("source_observation_id"), max_len=160)
+    executable_hypothesis_id = _bounded_str(
+        hypothesis.get("executable_hypothesis_id"),
+        max_len=160,
+    )
+    asset = _bounded_str(hypothesis.get("asset"), max_len=80) or _first_scope(
+        hypothesis.get("asset_scope"),
+        max_len=80,
+    )
+    timeframe = _bounded_str(hypothesis.get("timeframe"), max_len=40) or _first_scope(
+        hypothesis.get("timeframe_scope"),
+        max_len=40,
+    )
+    row = {
+        "request_id": _request_id(hypothesis),
+        "qre_hypothesis_id": qre_hypothesis_id,
+        "executable_hypothesis_id": executable_hypothesis_id,
+        "source_hypothesis_id": _bounded_str(hypothesis.get("source_hypothesis_id"), max_len=160),
+        "validation_plan_id": _bounded_str(hypothesis.get("validation_plan_id"), max_len=160),
+        "run_manifest_id": _bounded_str(hypothesis.get("run_manifest_id"), max_len=160),
+        "preset_name": _bounded_str(hypothesis.get("preset_name"), max_len=160),
+        "strategy_family": _bounded_str(hypothesis.get("strategy_family"), max_len=160),
+        "strategy_template_id": _bounded_str(
+            hypothesis.get("strategy_template_id"),
+            max_len=160,
+        ),
+        "asset": asset,
+        "symbol": _bounded_str(hypothesis.get("symbol"), max_len=80),
+        "timeframe": timeframe,
+        "interval": _bounded_str(hypothesis.get("interval"), max_len=40),
+        "supporting_evidence_refs": _str_list(
+            hypothesis.get("supporting_evidence_refs"),
+            max_items=24,
+            max_len=180,
+        ),
+        "safe_to_execute": False,
+        "requires_operator_approval": True,
+    }
+    row = {key: value for key, value in row.items() if value not in ("", [])}
+    readiness_row = readiness_by_observation_id.get(source_observation_id)
+    eligibility = validate_request(row, presets=presets)
+    row["eligibility_status"] = eligibility["eligibility_status"]
+    row["eligibility_reason_codes"] = eligibility["reason_codes"]
+
+    if not qre_hypothesis_id:
+        status = REQUEST_MALFORMED
+    elif not executable_hypothesis_id:
+        status = REQUEST_BLOCKED_IDENTITY_MISSING
+    elif not _market_context_available(hypothesis, readiness_row):
+        status = REQUEST_BLOCKED_MARKET_CONTEXT_MISSING
+    elif not eligibility["safe_to_request"]:
+        status = REQUEST_BLOCKED_PRESET_INELIGIBLE
+    elif not row.get("validation_plan_id"):
+        status = REQUEST_BLOCKED_VALIDATION_PLAN_MISSING
+    elif not row.get("run_manifest_id"):
+        status = REQUEST_BLOCKED_RUN_MANIFEST_MISSING
+    else:
+        status = REQUEST_READY
+
+    row["request_status"] = status
+    row["allowed_command_preview"] = (
+        _allowed_command_preview(row) if status == REQUEST_READY else None
+    )
+    return row
+
+
+def _counts(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    counter = Counter(row.get("request_status") for row in rows)
+    return {
+        "total": len(rows),
+        "ready": counter.get(REQUEST_READY, 0),
+        "blocked": len(rows) - counter.get(REQUEST_READY, 0),
+        "by_request_status": {status: counter.get(status, 0) for status in REQUEST_STATUSES},
+    }
+
+
+def _final_recommendation(rows: list[dict[str, Any]]) -> str:
+    if any(row.get("request_status") == REQUEST_READY for row in rows):
+        return "executable_validation_requests_ready_for_operator_review"
+    if rows:
+        return "executable_validation_requests_blocked_before_operator_review"
+    return "no_executable_validation_requests_available"
+
+
+def _base_snapshot(
+    *,
+    generated_at_utc: str,
+    input_artifact_path: Path,
+    input_artifact_available: bool,
+    validation_requests: list[dict[str, Any]],
+    validation_warnings: list[str],
+) -> dict[str, Any]:
+    return {
+        "report_kind": REPORT_KIND,
+        "schema_version": SCHEMA_VERSION,
+        "generated_at_utc": generated_at_utc,
+        "input_artifact_path": _rel(input_artifact_path),
+        "input_artifact_available": input_artifact_available,
+        "safe_to_execute": False,
+        "read_only": True,
+        "launches_subprocess": False,
+        "mutates_research_artifacts": False,
+        "final_recommendation": _final_recommendation(validation_requests),
+        "counts": _counts(validation_requests),
+        "validation_requests": validation_requests,
+        "validation_warnings": validation_warnings,
+        "writes_development_work_queue": False,
+        "writes_seed_jsonl": False,
+        "writes_generated_seed_jsonl": False,
+        "writes_research_action_queue": False,
+        "mutates_campaign_queue": False,
+        "mutates_strategy_or_preset": False,
+        "mutates_paper_shadow_live_runtime": False,
+        "launches_codex": False,
+        "eligible_for_direct_execution": False,
+    }
+
+
+def collect_snapshot(
+    *,
+    input_artifact_path: Path | None = None,
+    readiness_artifact_path: Path | None = None,
+    market_observation_artifact_path: Path | None = None,
+    generated_at_utc: str | None = None,
+    presets: Any = None,
+) -> dict[str, Any]:
+    generated = generated_at_utc or _utcnow()
+    source = input_artifact_path or INPUT_ARTIFACT_PATH
+    available, payload = _read_json(source)
+    if payload is None:
+        warning = NOTE_INPUT_UNPARSEABLE if available else NOTE_INPUT_ABSENT
+        return _base_snapshot(
+            generated_at_utc=generated,
+            input_artifact_path=source,
+            input_artifact_available=available,
+            validation_requests=[],
+            validation_warnings=[warning],
+        )
+
+    raw_hypotheses = payload.get("hypotheses")
+    if payload.get("report_kind") != INPUT_REPORT_KIND or not isinstance(raw_hypotheses, list):
+        return _base_snapshot(
+            generated_at_utc=generated,
+            input_artifact_path=source,
+            input_artifact_available=True,
+            validation_requests=[],
+            validation_warnings=[NOTE_INPUT_UNPARSEABLE],
+        )
+
+    readiness_by_observation_id, readiness_warnings = _readiness_rows(
+        readiness_path=readiness_artifact_path or READINESS_ARTIFACT_PATH,
+        market_observation_path=market_observation_artifact_path
+        or MARKET_OBSERVATION_ARTIFACT_PATH,
+        generated_at_utc=generated,
+    )
+    validation_requests = [
+        _build_request(
+            item,
+            readiness_by_observation_id=readiness_by_observation_id,
+            presets=presets,
+        )
+        for item in raw_hypotheses
+    ]
+    validation_requests.sort(key=lambda row: row.get("request_id", ""))
+    return _base_snapshot(
+        generated_at_utc=generated,
+        input_artifact_path=source,
+        input_artifact_available=True,
+        validation_requests=validation_requests,
+        validation_warnings=readiness_warnings,
+    )
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    if not path.resolve().is_relative_to(ARTIFACT_DIR.resolve()):
+        raise ValueError(f"refusing write outside QRE executable validation request dir: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".qre_executable_validation_request.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        with suppress(OSError):
+            os.unlink(tmp_name)
+        raise
+
+
+def write_outputs(
+    snapshot: dict[str, Any],
+    *,
+    output_path: Path | None = None,
+) -> Path:
+    target = output_path or ARTIFACT_LATEST
+    _atomic_write_json(target, snapshot)
+    return target
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="reporting.qre_executable_validation_request",
+        description="Build non-executing QRE executable validation requests.",
+    )
+    parser.add_argument("--no-write", action="store_true")
+    parser.add_argument("--source", type=Path, default=None)
+    parser.add_argument("--readiness-source", type=Path, default=None)
+    parser.add_argument("--market-observation-source", type=Path, default=None)
+    parser.add_argument("--frozen-utc", default=None)
+    parser.add_argument("--indent", type=int, default=2)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    snapshot = collect_snapshot(
+        input_artifact_path=args.source,
+        readiness_artifact_path=args.readiness_source,
+        market_observation_artifact_path=args.market_observation_source,
+        generated_at_utc=args.frozen_utc,
+    )
+    if not args.no_write:
+        write_outputs(snapshot)
+    print(json.dumps(snapshot, indent=args.indent, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "ARTIFACT_DIR",
+    "ARTIFACT_LATEST",
+    "INPUT_ARTIFACT_PATH",
+    "INPUT_ARTIFACT_RELATIVE_PATH",
+    "OUTPUT_ARTIFACT_RELATIVE_PATH",
+    "REPORT_KIND",
+    "REQUEST_BLOCKED_IDENTITY_MISSING",
+    "REQUEST_BLOCKED_MARKET_CONTEXT_MISSING",
+    "REQUEST_BLOCKED_PRESET_INELIGIBLE",
+    "REQUEST_BLOCKED_RUN_MANIFEST_MISSING",
+    "REQUEST_BLOCKED_VALIDATION_PLAN_MISSING",
+    "REQUEST_MALFORMED",
+    "REQUEST_READY",
+    "REQUEST_STATUSES",
+    "SCHEMA_VERSION",
+    "collect_snapshot",
+    "main",
+    "write_outputs",
+]

--- a/reporting/qre_market_observation_hypothesis_readiness.py
+++ b/reporting/qre_market_observation_hypothesis_readiness.py
@@ -1,0 +1,421 @@
+"""Read-only QRE market observation hypothesis-readiness diagnostic."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import tempfile
+from collections import Counter
+from contextlib import suppress
+from pathlib import Path
+from typing import Any, Final
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[int] = 1
+REPORT_KIND: Final[str] = "qre_market_observation_hypothesis_readiness"
+INPUT_REPORT_KIND: Final[str] = "qre_market_observation_snapshot"
+
+INPUT_ARTIFACT_RELATIVE_PATH: Final[str] = "logs/qre_market_observations/latest.json"
+INPUT_ARTIFACT_PATH: Final[Path] = REPO_ROOT / INPUT_ARTIFACT_RELATIVE_PATH
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "qre_market_observation_hypothesis_readiness"
+OUTPUT_ARTIFACT_RELATIVE_PATH: Final[str] = (
+    "logs/qre_market_observation_hypothesis_readiness/latest.json"
+)
+ARTIFACT_LATEST: Final[Path] = REPO_ROOT / OUTPUT_ARTIFACT_RELATIVE_PATH
+
+EXAMPLE_LIMIT: Final[int] = 20
+WARNING_LIMIT: Final[int] = 50
+
+BRIDGE_FIELDS: Final[tuple[str, ...]] = (
+    "executable_hypothesis_id",
+    "source_hypothesis_id",
+    "strategy_family",
+    "strategy_template_id",
+    "preset_name",
+)
+
+READINESS_CLASSES: Final[tuple[str, ...]] = (
+    "hypothesis_ready",
+    "identity_missing",
+    "execution_identity_missing",
+    "insufficient_market_context",
+    "insufficient_evidence_refs",
+    "unsupported_observation_schema",
+    "malformed_observation",
+)
+
+NOTE_INPUT_ABSENT: Final[str] = "market_observation_artifact_absent"
+NOTE_INPUT_UNPARSEABLE: Final[str] = "market_observation_artifact_unparseable"
+
+
+def _utcnow() -> str:
+    return _dt.datetime.now(_dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _rel(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(REPO_ROOT.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _read_json(path: Path) -> tuple[bool, dict[str, Any] | None]:
+    try:
+        raw = path.read_text(encoding="utf-8-sig")
+    except OSError:
+        return (False, None)
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return (True, None)
+    return (True, parsed if isinstance(parsed, dict) else None)
+
+
+def _bounded_str(value: Any, *, max_len: int = 240) -> str:
+    if value is None or isinstance(value, bool):
+        return ""
+    text = str(value).strip()
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 3].rstrip() + "..."
+
+
+def _str_list(value: Any, *, max_items: int = 16, max_len: int = 160) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    out: list[str] = []
+    for item in value[:max_items]:
+        text = _bounded_str(item, max_len=max_len)
+        if text:
+            out.append(text)
+    return out
+
+
+def _scope_present(row: dict[str, Any], *fields: str) -> bool:
+    for field in fields:
+        if field in {"asset_scope", "timeframe_scope"}:
+            continue
+        if _bounded_str(row.get(field), max_len=120):
+            return True
+    for field in ("asset_scope", "timeframe_scope"):
+        if field in fields:
+            values = [
+                value.lower()
+                for value in _str_list(row.get(field), max_items=8, max_len=80)
+                if value
+            ]
+            if values and any(value != "unknown" for value in values):
+                return True
+    return False
+
+
+def _has_evidence_refs(row: dict[str, Any]) -> bool:
+    return bool(_str_list(row.get("supporting_evidence_refs"), max_items=1, max_len=120))
+
+
+def _dimension_flags(row: dict[str, Any]) -> dict[str, bool]:
+    return {
+        "has_observation_id": bool(_bounded_str(row.get("observation_id"), max_len=160)),
+        "has_observation_type": bool(_bounded_str(row.get("observation_type"), max_len=80)),
+        "has_supporting_evidence_refs": _has_evidence_refs(row),
+        "has_source_artifact": bool(_bounded_str(row.get("source_artifact"), max_len=240)),
+        "has_executable_hypothesis_id": bool(
+            _bounded_str(row.get("executable_hypothesis_id"), max_len=160)
+        ),
+        "has_strategy_family": bool(_bounded_str(row.get("strategy_family"), max_len=160)),
+        "has_strategy_template_id": bool(
+            _bounded_str(row.get("strategy_template_id"), max_len=160)
+        ),
+        "has_preset_name": bool(_bounded_str(row.get("preset_name"), max_len=160)),
+        "has_asset_or_symbol": _scope_present(row, "asset", "symbol", "asset_scope"),
+        "has_timeframe_or_interval": _scope_present(
+            row,
+            "timeframe",
+            "interval",
+            "timeframe_scope",
+        ),
+        "bounded_text_available": bool(
+            _bounded_str(row.get("summary"), max_len=360)
+            or _bounded_str(row.get("title"), max_len=240)
+            or _bounded_str(row.get("claim"), max_len=360)
+        ),
+    }
+
+
+def classify_observation(row: Any) -> dict[str, Any]:
+    if not isinstance(row, dict):
+        return {
+            "observation_id": "",
+            "readiness_class": "malformed_observation",
+            "dimensions": {
+                "has_observation_id": False,
+                "has_observation_type": False,
+                "has_supporting_evidence_refs": False,
+                "has_source_artifact": False,
+                "has_executable_hypothesis_id": False,
+                "has_strategy_family": False,
+                "has_strategy_template_id": False,
+                "has_preset_name": False,
+                "has_asset_or_symbol": False,
+                "has_timeframe_or_interval": False,
+                "bounded_text_available": False,
+            },
+            "reason_codes": ["observation_row_not_object"],
+        }
+
+    dimensions = _dimension_flags(row)
+    reason_codes = [key for key, present in dimensions.items() if not present]
+    if not (
+        dimensions["has_observation_id"]
+        and dimensions["has_observation_type"]
+        and dimensions["has_source_artifact"]
+    ):
+        readiness_class = "unsupported_observation_schema"
+    elif not dimensions["has_supporting_evidence_refs"]:
+        readiness_class = "insufficient_evidence_refs"
+    elif not dimensions["has_executable_hypothesis_id"]:
+        readiness_class = "execution_identity_missing"
+    elif not (
+        dimensions["has_strategy_family"]
+        and dimensions["has_strategy_template_id"]
+        and dimensions["has_preset_name"]
+    ):
+        readiness_class = "identity_missing"
+    elif not (
+        dimensions["has_asset_or_symbol"]
+        and dimensions["has_timeframe_or_interval"]
+        and dimensions["bounded_text_available"]
+    ):
+        readiness_class = "insufficient_market_context"
+    else:
+        readiness_class = "hypothesis_ready"
+        reason_codes = []
+    return {
+        "observation_id": _bounded_str(row.get("observation_id"), max_len=160),
+        "readiness_class": readiness_class,
+        "dimensions": dimensions,
+        "reason_codes": reason_codes,
+    }
+
+
+def _bridge_field_counts(observations: list[Any]) -> dict[str, int]:
+    counts = {field: 0 for field in BRIDGE_FIELDS}
+    for row in observations:
+        if not isinstance(row, dict):
+            continue
+        for field in BRIDGE_FIELDS:
+            if _bounded_str(row.get(field), max_len=160):
+                counts[field] += 1
+    return counts
+
+
+def _counts(readiness_rows: list[dict[str, Any]], observations: list[Any]) -> dict[str, Any]:
+    counter = Counter(row["readiness_class"] for row in readiness_rows)
+    return {
+        "total_observations": len(observations),
+        "readiness_rows": len(readiness_rows),
+        "hypothesis_ready": counter.get("hypothesis_ready", 0),
+        "not_ready": len(readiness_rows) - counter.get("hypothesis_ready", 0),
+    }
+
+
+def _by_readiness_class(readiness_rows: list[dict[str, Any]]) -> dict[str, int]:
+    counter = Counter(row["readiness_class"] for row in readiness_rows)
+    return {status: counter.get(status, 0) for status in READINESS_CLASSES}
+
+
+def _examples(readiness_rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {
+            "observation_id": row["observation_id"],
+            "readiness_class": row["readiness_class"],
+            "reason_codes": row["reason_codes"][:12],
+        }
+        for row in readiness_rows[:EXAMPLE_LIMIT]
+    ]
+
+
+def _final_recommendation(readiness_rows: list[dict[str, Any]]) -> str:
+    if readiness_rows and all(
+        row["readiness_class"] == "hypothesis_ready" for row in readiness_rows
+    ):
+        return "market_observations_ready_for_executable_hypothesis_projection"
+    if any(row["readiness_class"] == "execution_identity_missing" for row in readiness_rows):
+        return "explicit_executable_hypothesis_identity_required"
+    if readiness_rows:
+        return "market_observations_require_operator_triage"
+    return "no_market_observations_available"
+
+
+def _recommended_next_action(readiness_rows: list[dict[str, Any]]) -> str:
+    classes = {row["readiness_class"] for row in readiness_rows}
+    if "execution_identity_missing" in classes:
+        return "add_explicit_executable_hypothesis_id_to_upstream_source"
+    if "identity_missing" in classes:
+        return "add_explicit_strategy_and_preset_identity_fields_to_upstream_source"
+    if "insufficient_market_context" in classes:
+        return "add_explicit_asset_or_timeframe_context_to_observations"
+    if "insufficient_evidence_refs" in classes:
+        return "add_supporting_evidence_refs_to_observations"
+    if "hypothesis_ready" in classes and len(classes) == 1:
+        return "build_executable_validation_request_artifact"
+    return "review_market_observation_schema_before_projection"
+
+
+def _base_snapshot(
+    *,
+    generated_at_utc: str,
+    input_artifact_path: Path,
+    input_artifact_available: bool,
+    observations: list[Any],
+    readiness_rows: list[dict[str, Any]],
+    validation_warnings: list[str],
+) -> dict[str, Any]:
+    return {
+        "report_kind": REPORT_KIND,
+        "schema_version": SCHEMA_VERSION,
+        "generated_at_utc": generated_at_utc,
+        "input_artifact_path": _rel(input_artifact_path),
+        "input_artifact_available": input_artifact_available,
+        "safe_to_execute": False,
+        "read_only": True,
+        "final_recommendation": _final_recommendation(readiness_rows),
+        "recommended_next_action": _recommended_next_action(readiness_rows),
+        "counts": _counts(readiness_rows, observations),
+        "by_readiness_class": _by_readiness_class(readiness_rows),
+        "bridge_field_counts": _bridge_field_counts(observations),
+        "readiness_rows": readiness_rows,
+        "examples": _examples(readiness_rows),
+        "validation_warnings": validation_warnings[:WARNING_LIMIT],
+        "writes_development_work_queue": False,
+        "writes_seed_jsonl": False,
+        "writes_generated_seed_jsonl": False,
+        "writes_research_action_queue": False,
+        "mutates_campaign_queue": False,
+        "mutates_strategy_or_preset": False,
+        "mutates_research_artifacts": False,
+        "mutates_paper_shadow_live_runtime": False,
+        "launches_codex": False,
+        "launches_subprocess": False,
+        "eligible_for_direct_execution": False,
+    }
+
+
+def collect_snapshot(
+    *,
+    input_artifact_path: Path | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    generated = generated_at_utc or _utcnow()
+    source = input_artifact_path or INPUT_ARTIFACT_PATH
+    available, payload = _read_json(source)
+    if payload is None:
+        warning = NOTE_INPUT_UNPARSEABLE if available else NOTE_INPUT_ABSENT
+        return _base_snapshot(
+            generated_at_utc=generated,
+            input_artifact_path=source,
+            input_artifact_available=available,
+            observations=[],
+            readiness_rows=[],
+            validation_warnings=[warning],
+        )
+
+    raw_observations = payload.get("observations")
+    if payload.get("report_kind") != INPUT_REPORT_KIND or not isinstance(raw_observations, list):
+        return _base_snapshot(
+            generated_at_utc=generated,
+            input_artifact_path=source,
+            input_artifact_available=True,
+            observations=[],
+            readiness_rows=[],
+            validation_warnings=[NOTE_INPUT_UNPARSEABLE],
+        )
+
+    readiness_rows = [classify_observation(row) for row in raw_observations]
+    readiness_rows.sort(key=lambda row: (row["readiness_class"], row["observation_id"]))
+    return _base_snapshot(
+        generated_at_utc=generated,
+        input_artifact_path=source,
+        input_artifact_available=True,
+        observations=raw_observations,
+        readiness_rows=readiness_rows,
+        validation_warnings=[],
+    )
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    if not path.resolve().is_relative_to(ARTIFACT_DIR.resolve()):
+        raise ValueError(f"refusing write outside QRE readiness dir: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".qre_market_observation_hypothesis_readiness.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        with suppress(OSError):
+            os.unlink(tmp_name)
+        raise
+
+
+def write_outputs(
+    snapshot: dict[str, Any],
+    *,
+    output_path: Path | None = None,
+) -> Path:
+    target = output_path or ARTIFACT_LATEST
+    _atomic_write_json(target, snapshot)
+    return target
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="reporting.qre_market_observation_hypothesis_readiness",
+        description="Diagnose whether QRE market observations can become executable hypotheses.",
+    )
+    parser.add_argument("--no-write", action="store_true")
+    parser.add_argument("--source", type=Path, default=None)
+    parser.add_argument("--frozen-utc", default=None)
+    parser.add_argument("--indent", type=int, default=2)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    snapshot = collect_snapshot(
+        input_artifact_path=args.source,
+        generated_at_utc=args.frozen_utc,
+    )
+    if not args.no_write:
+        write_outputs(snapshot)
+    print(json.dumps(snapshot, indent=args.indent, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "ARTIFACT_DIR",
+    "ARTIFACT_LATEST",
+    "BRIDGE_FIELDS",
+    "INPUT_ARTIFACT_PATH",
+    "INPUT_ARTIFACT_RELATIVE_PATH",
+    "OUTPUT_ARTIFACT_RELATIVE_PATH",
+    "READINESS_CLASSES",
+    "REPORT_KIND",
+    "SCHEMA_VERSION",
+    "classify_observation",
+    "collect_snapshot",
+    "main",
+    "write_outputs",
+]

--- a/reporting/qre_preset_strategy_eligibility_contract.py
+++ b/reporting/qre_preset_strategy_eligibility_contract.py
@@ -1,0 +1,254 @@
+"""Pure QRE preset/strategy eligibility contract for validation requests."""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any, Final
+
+from research.presets import PRESETS
+
+SCHEMA_VERSION: Final[int] = 1
+
+STATUS_ELIGIBLE: Final[str] = "eligible"
+STATUS_MISSING_PRESET_NAME: Final[str] = "missing_preset_name"
+STATUS_PRESET_NOT_FOUND: Final[str] = "preset_not_found"
+STATUS_PRESET_DISABLED: Final[str] = "preset_disabled"
+STATUS_PRESET_DIAGNOSTIC_ONLY: Final[str] = "preset_diagnostic_only"
+STATUS_PRESET_EXCLUDED_FROM_PROMOTION: Final[str] = "preset_excluded_from_promotion"
+STATUS_EXECUTABLE_HYPOTHESIS_ID_MISMATCH: Final[str] = "executable_hypothesis_id_mismatch"
+STATUS_TIMEFRAME_MISMATCH: Final[str] = "timeframe_mismatch"
+STATUS_ASSET_NOT_IN_UNIVERSE: Final[str] = "asset_not_in_universe"
+STATUS_STRATEGY_TEMPLATE_NOT_IN_BUNDLE: Final[str] = "strategy_template_not_in_bundle"
+STATUS_MALFORMED_REQUEST: Final[str] = "malformed_request"
+STATUS_AMBIGUOUS_REQUEST: Final[str] = "ambiguous_request"
+
+ELIGIBILITY_STATUSES: Final[tuple[str, ...]] = (
+    STATUS_ELIGIBLE,
+    STATUS_MISSING_PRESET_NAME,
+    STATUS_PRESET_NOT_FOUND,
+    STATUS_PRESET_DISABLED,
+    STATUS_PRESET_DIAGNOSTIC_ONLY,
+    STATUS_PRESET_EXCLUDED_FROM_PROMOTION,
+    STATUS_EXECUTABLE_HYPOTHESIS_ID_MISMATCH,
+    STATUS_TIMEFRAME_MISMATCH,
+    STATUS_ASSET_NOT_IN_UNIVERSE,
+    STATUS_STRATEGY_TEMPLATE_NOT_IN_BUNDLE,
+    STATUS_MALFORMED_REQUEST,
+    STATUS_AMBIGUOUS_REQUEST,
+)
+
+REQUEST_FIELD_LIMITS: Final[dict[str, int]] = {
+    "preset_name": 160,
+    "executable_hypothesis_id": 160,
+    "timeframe": 40,
+    "interval": 40,
+    "asset": 80,
+    "symbol": 80,
+    "strategy_template_id": 160,
+}
+
+
+def _bounded_str(value: Any, *, max_len: int = 160) -> str:
+    if value is None or isinstance(value, bool):
+        return ""
+    text = str(value).strip()
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 3].rstrip() + "..."
+
+
+def _get_field(obj: Any, field: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(field, default)
+    return getattr(obj, field, default)
+
+
+def _bool_field(obj: Any, field: str) -> bool:
+    return bool(_get_field(obj, field, False))
+
+
+def _tuple_field(obj: Any, field: str) -> tuple[str, ...]:
+    raw = _get_field(obj, field, ())
+    if not isinstance(raw, tuple | list):
+        return ()
+    return tuple(_bounded_str(item, max_len=160) for item in raw if _bounded_str(item))
+
+
+def _request_summary(row: dict[str, Any]) -> dict[str, str]:
+    return {
+        field: text
+        for field, limit in REQUEST_FIELD_LIMITS.items()
+        if (text := _bounded_str(row.get(field), max_len=limit))
+    }
+
+
+def _preset_summary(preset: Any) -> dict[str, Any]:
+    return {
+        "preset_name": _bounded_str(_get_field(preset, "name"), max_len=160),
+        "enabled": _bool_field(preset, "enabled"),
+        "diagnostic_only": _bool_field(preset, "diagnostic_only"),
+        "excluded_from_candidate_promotion": _bool_field(
+            preset,
+            "excluded_from_candidate_promotion",
+        ),
+        "hypothesis_id": _bounded_str(_get_field(preset, "hypothesis_id"), max_len=160),
+        "timeframe": _bounded_str(_get_field(preset, "timeframe"), max_len=40),
+        "universe": list(_tuple_field(preset, "universe"))[:50],
+        "bundle": list(_tuple_field(preset, "bundle"))[:50],
+    }
+
+
+def _coerce_presets(presets: Any | None) -> list[Any]:
+    if presets is None:
+        return list(PRESETS)
+    if isinstance(presets, str) or not hasattr(presets, "__iter__"):
+        return []
+    return list(presets)
+
+
+def _preset_matches(presets: list[Any], preset_name: str) -> list[Any]:
+    return [
+        preset
+        for preset in presets
+        if _bounded_str(_get_field(preset, "name"), max_len=160) == preset_name
+    ]
+
+
+def _requested_timeframe(row: dict[str, Any]) -> str:
+    return _bounded_str(row.get("timeframe"), max_len=40) or _bounded_str(
+        row.get("interval"),
+        max_len=40,
+    )
+
+
+def _requested_asset(row: dict[str, Any]) -> str:
+    return _bounded_str(row.get("asset"), max_len=80) or _bounded_str(
+        row.get("symbol"),
+        max_len=80,
+    )
+
+
+def _requested_promotion(row: dict[str, Any]) -> bool:
+    return row.get("promotion_path_requested") is True
+
+
+def _first_status(reason_codes: list[str]) -> str:
+    if not reason_codes:
+        return STATUS_ELIGIBLE
+    for status in ELIGIBILITY_STATUSES:
+        if status in reason_codes:
+            return status
+    return STATUS_MALFORMED_REQUEST
+
+
+def validate_request(
+    row: Any,
+    *,
+    presets: Any | None = None,
+    allow_diagnostic_only: bool = False,
+) -> dict[str, Any]:
+    if not isinstance(row, dict):
+        return {
+            "safe_to_request": False,
+            "eligibility_status": STATUS_MALFORMED_REQUEST,
+            "reason_codes": [STATUS_MALFORMED_REQUEST],
+            "request": {},
+            "matched_preset": None,
+        }
+
+    request = _request_summary(row)
+    preset_name = _bounded_str(row.get("preset_name"), max_len=160)
+    if not preset_name:
+        return {
+            "safe_to_request": False,
+            "eligibility_status": STATUS_MISSING_PRESET_NAME,
+            "reason_codes": [STATUS_MISSING_PRESET_NAME],
+            "request": request,
+            "matched_preset": None,
+        }
+
+    preset_items = _coerce_presets(presets)
+    matches = _preset_matches(preset_items, preset_name)
+    if not matches:
+        return {
+            "safe_to_request": False,
+            "eligibility_status": STATUS_PRESET_NOT_FOUND,
+            "reason_codes": [STATUS_PRESET_NOT_FOUND],
+            "request": request,
+            "matched_preset": None,
+        }
+    if len(matches) != 1:
+        return {
+            "safe_to_request": False,
+            "eligibility_status": STATUS_AMBIGUOUS_REQUEST,
+            "reason_codes": [STATUS_AMBIGUOUS_REQUEST],
+            "request": request,
+            "matched_preset": None,
+        }
+
+    preset = matches[0]
+    reason_codes: list[str] = []
+    if not _bool_field(preset, "enabled"):
+        reason_codes.append(STATUS_PRESET_DISABLED)
+    if _bool_field(preset, "diagnostic_only") and not allow_diagnostic_only:
+        reason_codes.append(STATUS_PRESET_DIAGNOSTIC_ONLY)
+    if _requested_promotion(row) and _bool_field(preset, "excluded_from_candidate_promotion"):
+        reason_codes.append(STATUS_PRESET_EXCLUDED_FROM_PROMOTION)
+
+    requested_hypothesis_id = _bounded_str(row.get("executable_hypothesis_id"), max_len=160)
+    preset_hypothesis_id = _bounded_str(_get_field(preset, "hypothesis_id"), max_len=160)
+    if (
+        requested_hypothesis_id
+        and preset_hypothesis_id
+        and requested_hypothesis_id != preset_hypothesis_id
+    ):
+        reason_codes.append(STATUS_EXECUTABLE_HYPOTHESIS_ID_MISMATCH)
+
+    requested_timeframe = _requested_timeframe(row)
+    preset_timeframe = _bounded_str(_get_field(preset, "timeframe"), max_len=40)
+    if requested_timeframe and preset_timeframe and requested_timeframe != preset_timeframe:
+        reason_codes.append(STATUS_TIMEFRAME_MISMATCH)
+
+    requested_asset = _requested_asset(row)
+    preset_universe = set(_tuple_field(preset, "universe"))
+    if requested_asset and preset_universe and requested_asset not in preset_universe:
+        reason_codes.append(STATUS_ASSET_NOT_IN_UNIVERSE)
+
+    requested_strategy = _bounded_str(row.get("strategy_template_id"), max_len=160)
+    preset_bundle = set(_tuple_field(preset, "bundle"))
+    if requested_strategy and preset_bundle and requested_strategy not in preset_bundle:
+        reason_codes.append(STATUS_STRATEGY_TEMPLATE_NOT_IN_BUNDLE)
+
+    status = _first_status(reason_codes)
+    return {
+        "safe_to_request": status == STATUS_ELIGIBLE,
+        "eligibility_status": status,
+        "reason_codes": reason_codes,
+        "request": request,
+        "matched_preset": _preset_summary(preset),
+    }
+
+
+def summarize_eligibility(rows: list[dict[str, Any]]) -> dict[str, int]:
+    counter = Counter(row.get("eligibility_status") for row in rows)
+    return {status: counter.get(status, 0) for status in ELIGIBILITY_STATUSES}
+
+
+__all__ = [
+    "ELIGIBILITY_STATUSES",
+    "SCHEMA_VERSION",
+    "STATUS_AMBIGUOUS_REQUEST",
+    "STATUS_ASSET_NOT_IN_UNIVERSE",
+    "STATUS_ELIGIBLE",
+    "STATUS_EXECUTABLE_HYPOTHESIS_ID_MISMATCH",
+    "STATUS_MALFORMED_REQUEST",
+    "STATUS_MISSING_PRESET_NAME",
+    "STATUS_PRESET_DIAGNOSTIC_ONLY",
+    "STATUS_PRESET_DISABLED",
+    "STATUS_PRESET_EXCLUDED_FROM_PROMOTION",
+    "STATUS_PRESET_NOT_FOUND",
+    "STATUS_STRATEGY_TEMPLATE_NOT_IN_BUNDLE",
+    "STATUS_TIMEFRAME_MISMATCH",
+    "summarize_eligibility",
+    "validate_request",
+]

--- a/reporting/qre_preset_strategy_eligibility_contract.py
+++ b/reporting/qre_preset_strategy_eligibility_contract.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import ast
 from collections import Counter
+from pathlib import Path
 from typing import Any, Final
 
-from research.presets import PRESETS
-
 SCHEMA_VERSION: Final[int] = 1
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+PRESETS_SOURCE_PATH: Final[Path] = REPO_ROOT / "research" / "presets.py"
 
 STATUS_ELIGIBLE: Final[str] = "eligible"
 STATUS_MISSING_PRESET_NAME: Final[str] = "missing_preset_name"
@@ -63,6 +65,63 @@ def _get_field(obj: Any, field: str, default: Any = None) -> Any:
     return getattr(obj, field, default)
 
 
+def _literal(node: ast.AST) -> Any:
+    try:
+        return ast.literal_eval(node)
+    except (TypeError, ValueError):
+        return None
+
+
+def _research_preset_from_call(node: ast.Call) -> dict[str, Any]:
+    fields: dict[str, Any] = {
+        "enabled": True,
+        "diagnostic_only": False,
+        "excluded_from_candidate_promotion": False,
+        "hypothesis_id": None,
+        "timeframe": "",
+        "universe": (),
+        "bundle": (),
+        "name": "",
+    }
+    for keyword in node.keywords:
+        if keyword.arg in fields:
+            fields[str(keyword.arg)] = _literal(keyword.value)
+    return fields
+
+
+def _presets_from_source(path: Path = PRESETS_SOURCE_PATH) -> list[dict[str, Any]]:
+    try:
+        source = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+
+    for node in tree.body:
+        is_presets_assign = isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == "PRESETS" for target in node.targets
+        )
+        is_presets_ann_assign = isinstance(node, ast.AnnAssign) and (
+            isinstance(node.target, ast.Name) and node.target.id == "PRESETS"
+        )
+        if not is_presets_assign and not is_presets_ann_assign:
+            continue
+        if not isinstance(node.value, ast.Tuple):
+            return []
+        presets: list[dict[str, Any]] = []
+        for item in node.value.elts:
+            if (
+                isinstance(item, ast.Call)
+                and isinstance(item.func, ast.Name)
+                and item.func.id == "ResearchPreset"
+            ):
+                presets.append(_research_preset_from_call(item))
+        return presets
+    return []
+
+
 def _bool_field(obj: Any, field: str) -> bool:
     return bool(_get_field(obj, field, False))
 
@@ -100,7 +159,7 @@ def _preset_summary(preset: Any) -> dict[str, Any]:
 
 def _coerce_presets(presets: Any | None) -> list[Any]:
     if presets is None:
-        return list(PRESETS)
+        return list(_presets_from_source())
     if isinstance(presets, str) or not hasattr(presets, "__iter__"):
         return []
     return list(presets)

--- a/reporting/qre_validation_request_dry_run_runner.py
+++ b/reporting/qre_validation_request_dry_run_runner.py
@@ -1,0 +1,307 @@
+"""Non-executing QRE validation request dry-run runner."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import tempfile
+from collections import Counter
+from contextlib import suppress
+from pathlib import Path
+from typing import Any, Final
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[int] = 1
+REPORT_KIND: Final[str] = "qre_validation_request_dry_run"
+INPUT_REPORT_KIND: Final[str] = "qre_executable_validation_request"
+
+INPUT_ARTIFACT_RELATIVE_PATH: Final[str] = "logs/qre_executable_validation_request/latest.json"
+INPUT_ARTIFACT_PATH: Final[Path] = REPO_ROOT / INPUT_ARTIFACT_RELATIVE_PATH
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "qre_validation_request_dry_run"
+OUTPUT_ARTIFACT_RELATIVE_PATH: Final[str] = "logs/qre_validation_request_dry_run/latest.json"
+ARTIFACT_LATEST: Final[Path] = REPO_ROOT / OUTPUT_ARTIFACT_RELATIVE_PATH
+
+DRY_RUN_READY: Final[str] = "dry_run_ready"
+DRY_RUN_BLOCKED_REQUEST_NOT_READY: Final[str] = "dry_run_blocked_request_not_ready"
+DRY_RUN_BLOCKED_MISSING_OPERATOR_APPROVAL: Final[str] = "dry_run_blocked_missing_operator_approval"
+DRY_RUN_BLOCKED_MISSING_COMMAND_PREVIEW: Final[str] = "dry_run_blocked_missing_command_preview"
+DRY_RUN_MALFORMED: Final[str] = "dry_run_malformed"
+
+DRY_RUN_STATUSES: Final[tuple[str, ...]] = (
+    DRY_RUN_READY,
+    DRY_RUN_BLOCKED_REQUEST_NOT_READY,
+    DRY_RUN_BLOCKED_MISSING_OPERATOR_APPROVAL,
+    DRY_RUN_BLOCKED_MISSING_COMMAND_PREVIEW,
+    DRY_RUN_MALFORMED,
+)
+
+REQUEST_READY: Final[str] = "request_ready_for_operator_review"
+NOTE_INPUT_ABSENT: Final[str] = "executable_validation_request_artifact_absent"
+NOTE_INPUT_UNPARSEABLE: Final[str] = "executable_validation_request_artifact_unparseable"
+
+FUTURE_OUTPUTS: Final[tuple[str, ...]] = (
+    "research/run_candidates_latest.v1.json",
+    "research/screening_evidence_latest.v1.json",
+    "research/history/<run_id>/...",
+)
+
+
+def _utcnow() -> str:
+    return _dt.datetime.now(_dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _rel(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(REPO_ROOT.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _read_json(path: Path) -> tuple[bool, dict[str, Any] | None]:
+    try:
+        raw = path.read_text(encoding="utf-8-sig")
+    except OSError:
+        return (False, None)
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return (True, None)
+    return (True, parsed if isinstance(parsed, dict) else None)
+
+
+def _bounded_str(value: Any, *, max_len: int = 240) -> str:
+    if value is None or isinstance(value, bool):
+        return ""
+    text = str(value).strip()
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 3].rstrip() + "..."
+
+
+def _base_row(request: dict[str, Any]) -> dict[str, Any]:
+    row = {
+        "request_id": _bounded_str(request.get("request_id"), max_len=160),
+        "qre_hypothesis_id": _bounded_str(request.get("qre_hypothesis_id"), max_len=160),
+        "executable_hypothesis_id": _bounded_str(
+            request.get("executable_hypothesis_id"),
+            max_len=160,
+        ),
+        "preset_name": _bounded_str(request.get("preset_name"), max_len=160),
+        "strategy_template_id": _bounded_str(request.get("strategy_template_id"), max_len=160),
+        "asset": _bounded_str(request.get("asset"), max_len=80),
+        "symbol": _bounded_str(request.get("symbol"), max_len=80),
+        "timeframe": _bounded_str(request.get("timeframe"), max_len=40),
+        "interval": _bounded_str(request.get("interval"), max_len=40),
+    }
+    return {key: value for key, value in row.items() if value}
+
+
+def _build_dry_run_row(request: Any) -> dict[str, Any]:
+    if not isinstance(request, dict):
+        return {
+            "dry_run_status": DRY_RUN_MALFORMED,
+            "would_run_command_preview": None,
+            "would_write_artifacts": list(FUTURE_OUTPUTS),
+            "backup_required": True,
+            "safe_to_execute": False,
+            "executed": False,
+        }
+
+    row = _base_row(request)
+    command_preview = _bounded_str(request.get("allowed_command_preview"), max_len=600)
+    if request.get("request_status") != REQUEST_READY:
+        status = DRY_RUN_BLOCKED_REQUEST_NOT_READY
+    elif (
+        request.get("requires_operator_approval") is True
+        and request.get("operator_approved") is not True
+    ):
+        status = DRY_RUN_BLOCKED_MISSING_OPERATOR_APPROVAL
+    elif not command_preview:
+        status = DRY_RUN_BLOCKED_MISSING_COMMAND_PREVIEW
+    else:
+        status = DRY_RUN_READY
+
+    row.update(
+        {
+            "dry_run_status": status,
+            "would_run_command_preview": command_preview if command_preview else None,
+            "would_write_artifacts": list(FUTURE_OUTPUTS),
+            "backup_required": True,
+            "safe_to_execute": False,
+            "executed": False,
+        }
+    )
+    return row
+
+
+def _counts(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    counter = Counter(row.get("dry_run_status") for row in rows)
+    return {
+        "total": len(rows),
+        "ready": counter.get(DRY_RUN_READY, 0),
+        "blocked": len(rows) - counter.get(DRY_RUN_READY, 0),
+        "by_dry_run_status": {status: counter.get(status, 0) for status in DRY_RUN_STATUSES},
+    }
+
+
+def _final_recommendation(rows: list[dict[str, Any]]) -> str:
+    if any(row.get("dry_run_status") == DRY_RUN_READY for row in rows):
+        return "validation_request_dry_run_ready_for_operator_review"
+    if rows:
+        return "validation_request_dry_run_blocked_before_execution"
+    return "no_validation_request_dry_run_rows_available"
+
+
+def _base_snapshot(
+    *,
+    generated_at_utc: str,
+    input_artifact_path: Path,
+    input_artifact_available: bool,
+    dry_run_results: list[dict[str, Any]],
+    validation_warnings: list[str],
+) -> dict[str, Any]:
+    return {
+        "report_kind": REPORT_KIND,
+        "schema_version": SCHEMA_VERSION,
+        "generated_at_utc": generated_at_utc,
+        "input_artifact_path": _rel(input_artifact_path),
+        "input_artifact_available": input_artifact_available,
+        "safe_to_execute": False,
+        "read_only": True,
+        "launches_subprocess": False,
+        "executed_anything": False,
+        "final_recommendation": _final_recommendation(dry_run_results),
+        "counts": _counts(dry_run_results),
+        "dry_run_results": dry_run_results,
+        "validation_warnings": validation_warnings,
+        "writes_development_work_queue": False,
+        "writes_seed_jsonl": False,
+        "writes_generated_seed_jsonl": False,
+        "writes_research_action_queue": False,
+        "mutates_campaign_queue": False,
+        "mutates_strategy_or_preset": False,
+        "mutates_research_artifacts": False,
+        "mutates_paper_shadow_live_runtime": False,
+        "launches_codex": False,
+        "eligible_for_direct_execution": False,
+    }
+
+
+def collect_snapshot(
+    *,
+    input_artifact_path: Path | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    generated = generated_at_utc or _utcnow()
+    source = input_artifact_path or INPUT_ARTIFACT_PATH
+    available, payload = _read_json(source)
+    if payload is None:
+        warning = NOTE_INPUT_UNPARSEABLE if available else NOTE_INPUT_ABSENT
+        return _base_snapshot(
+            generated_at_utc=generated,
+            input_artifact_path=source,
+            input_artifact_available=available,
+            dry_run_results=[],
+            validation_warnings=[warning],
+        )
+
+    raw_requests = payload.get("validation_requests")
+    if payload.get("report_kind") != INPUT_REPORT_KIND or not isinstance(raw_requests, list):
+        return _base_snapshot(
+            generated_at_utc=generated,
+            input_artifact_path=source,
+            input_artifact_available=True,
+            dry_run_results=[],
+            validation_warnings=[NOTE_INPUT_UNPARSEABLE],
+        )
+
+    dry_run_results = [_build_dry_run_row(row) for row in raw_requests]
+    dry_run_results.sort(key=lambda row: row.get("request_id", ""))
+    return _base_snapshot(
+        generated_at_utc=generated,
+        input_artifact_path=source,
+        input_artifact_available=True,
+        dry_run_results=dry_run_results,
+        validation_warnings=[],
+    )
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    if not path.resolve().is_relative_to(ARTIFACT_DIR.resolve()):
+        raise ValueError(f"refusing write outside QRE validation request dry-run dir: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".qre_validation_request_dry_run.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        with suppress(OSError):
+            os.unlink(tmp_name)
+        raise
+
+
+def write_outputs(
+    snapshot: dict[str, Any],
+    *,
+    output_path: Path | None = None,
+) -> Path:
+    target = output_path or ARTIFACT_LATEST
+    _atomic_write_json(target, snapshot)
+    return target
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="reporting.qre_validation_request_dry_run_runner",
+        description="Build a non-executing dry-run plan for QRE validation requests.",
+    )
+    parser.add_argument("--no-write", action="store_true")
+    parser.add_argument("--source", type=Path, default=None)
+    parser.add_argument("--frozen-utc", default=None)
+    parser.add_argument("--indent", type=int, default=2)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    snapshot = collect_snapshot(
+        input_artifact_path=args.source,
+        generated_at_utc=args.frozen_utc,
+    )
+    if not args.no_write:
+        write_outputs(snapshot)
+    print(json.dumps(snapshot, indent=args.indent, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "ARTIFACT_DIR",
+    "ARTIFACT_LATEST",
+    "DRY_RUN_BLOCKED_MISSING_COMMAND_PREVIEW",
+    "DRY_RUN_BLOCKED_MISSING_OPERATOR_APPROVAL",
+    "DRY_RUN_BLOCKED_REQUEST_NOT_READY",
+    "DRY_RUN_MALFORMED",
+    "DRY_RUN_READY",
+    "DRY_RUN_STATUSES",
+    "INPUT_ARTIFACT_PATH",
+    "INPUT_ARTIFACT_RELATIVE_PATH",
+    "OUTPUT_ARTIFACT_RELATIVE_PATH",
+    "REPORT_KIND",
+    "SCHEMA_VERSION",
+    "collect_snapshot",
+    "main",
+    "write_outputs",
+]

--- a/tests/unit/test_qre_executable_validation_request.py
+++ b/tests/unit/test_qre_executable_validation_request.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from reporting import qre_executable_validation_request as req
+
+FROZEN = "2026-06-01T12:00:00Z"
+
+
+@dataclass(frozen=True)
+class PresetFixture:
+    name: str = "trend_pullback_crypto_1h"
+    hypothesis_id: str | None = "trend_pullback_v1"
+    enabled: bool = True
+    diagnostic_only: bool = False
+    excluded_from_candidate_promotion: bool = False
+    timeframe: str = "1h"
+    universe: tuple[str, ...] = ("BTC-EUR",)
+    bundle: tuple[str, ...] = ("trend_pullback_v1",)
+
+
+def _hypothesis(**overrides) -> dict:
+    base = {
+        "hypothesis_id": "qre-hyp-fixture",
+        "source_observation_id": "qre-obs-fixture",
+        "executable_hypothesis_id": "trend_pullback_v1",
+        "source_hypothesis_id": "source-trend-pullback",
+        "validation_plan_id": "qre-plan-fixture",
+        "run_manifest_id": "qre-run-fixture",
+        "preset_name": "trend_pullback_crypto_1h",
+        "strategy_family": "trend_pullback",
+        "strategy_template_id": "trend_pullback_v1",
+        "asset_scope": ["BTC-EUR"],
+        "timeframe_scope": ["1h"],
+        "supporting_evidence_refs": ["fixture#1"],
+    }
+    base.update(overrides)
+    return base
+
+
+def _write_hypotheses(path: Path, hypotheses: list) -> Path:
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "report_kind": "qre_hypothesis_candidates",
+                "generated_at_utc": FROZEN,
+                "hypotheses": hypotheses,
+                "safe_to_execute": False,
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _write_readiness(path: Path, readiness_class: str = "hypothesis_ready") -> Path:
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "report_kind": "qre_market_observation_hypothesis_readiness",
+                "generated_at_utc": FROZEN,
+                "readiness_rows": [
+                    {
+                        "observation_id": "qre-obs-fixture",
+                        "readiness_class": readiness_class,
+                        "reason_codes": [],
+                    }
+                ],
+                "safe_to_execute": False,
+                "read_only": True,
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_ready_request_requires_operator_review_and_has_descriptive_preview(
+    tmp_path: Path,
+) -> None:
+    source = _write_hypotheses(tmp_path / "hypotheses.json", [_hypothesis()])
+    readiness = _write_readiness(tmp_path / "readiness.json")
+
+    snap = req.collect_snapshot(
+        input_artifact_path=source,
+        readiness_artifact_path=readiness,
+        generated_at_utc=FROZEN,
+        presets=[PresetFixture()],
+    )
+
+    row = snap["validation_requests"][0]
+    assert row["request_status"] == "request_ready_for_operator_review"
+    assert row["allowed_command_preview"].startswith("Operator-reviewed validation request")
+    assert row["safe_to_execute"] is False
+    assert row["requires_operator_approval"] is True
+    assert snap["counts"]["ready"] == 1
+    assert snap["safe_to_execute"] is False
+
+
+def test_missing_executable_hypothesis_id_blocks_request(tmp_path: Path) -> None:
+    source = _write_hypotheses(
+        tmp_path / "hypotheses.json",
+        [_hypothesis(executable_hypothesis_id="")],
+    )
+    readiness = _write_readiness(tmp_path / "readiness.json")
+
+    snap = req.collect_snapshot(
+        input_artifact_path=source,
+        readiness_artifact_path=readiness,
+        generated_at_utc=FROZEN,
+        presets=[PresetFixture()],
+    )
+
+    row = snap["validation_requests"][0]
+    assert row["request_status"] == "request_blocked_identity_missing"
+    assert row["allowed_command_preview"] is None
+
+
+def test_preset_ineligible_blocks_request(tmp_path: Path) -> None:
+    source = _write_hypotheses(
+        tmp_path / "hypotheses.json",
+        [_hypothesis(strategy_template_id="breakout_momentum")],
+    )
+    readiness = _write_readiness(tmp_path / "readiness.json")
+
+    snap = req.collect_snapshot(
+        input_artifact_path=source,
+        readiness_artifact_path=readiness,
+        generated_at_utc=FROZEN,
+        presets=[PresetFixture()],
+    )
+
+    row = snap["validation_requests"][0]
+    assert row["request_status"] == "request_blocked_preset_ineligible"
+    assert row["eligibility_status"] == "strategy_template_not_in_bundle"
+
+
+def test_market_context_not_ready_blocks_request(tmp_path: Path) -> None:
+    source = _write_hypotheses(tmp_path / "hypotheses.json", [_hypothesis()])
+    readiness = _write_readiness(tmp_path / "readiness.json", "execution_identity_missing")
+
+    snap = req.collect_snapshot(
+        input_artifact_path=source,
+        readiness_artifact_path=readiness,
+        generated_at_utc=FROZEN,
+        presets=[PresetFixture()],
+    )
+
+    assert snap["validation_requests"][0]["request_status"] == (
+        "request_blocked_market_context_missing"
+    )
+
+
+def test_missing_validation_plan_or_run_manifest_blocks_request(tmp_path: Path) -> None:
+    readiness = _write_readiness(tmp_path / "readiness.json")
+    no_plan = _write_hypotheses(
+        tmp_path / "no-plan.json",
+        [_hypothesis(validation_plan_id="")],
+    )
+    no_manifest = _write_hypotheses(
+        tmp_path / "no-manifest.json",
+        [_hypothesis(run_manifest_id="")],
+    )
+
+    plan_snap = req.collect_snapshot(
+        input_artifact_path=no_plan,
+        readiness_artifact_path=readiness,
+        generated_at_utc=FROZEN,
+        presets=[PresetFixture()],
+    )
+    manifest_snap = req.collect_snapshot(
+        input_artifact_path=no_manifest,
+        readiness_artifact_path=readiness,
+        generated_at_utc=FROZEN,
+        presets=[PresetFixture()],
+    )
+
+    assert plan_snap["validation_requests"][0]["request_status"] == (
+        "request_blocked_validation_plan_missing"
+    )
+    assert manifest_snap["validation_requests"][0]["request_status"] == (
+        "request_blocked_run_manifest_missing"
+    )
+
+
+def test_malformed_candidate_row_fails_closed(tmp_path: Path) -> None:
+    source = _write_hypotheses(tmp_path / "hypotheses.json", ["not-a-row"])
+    readiness = _write_readiness(tmp_path / "readiness.json")
+
+    snap = req.collect_snapshot(
+        input_artifact_path=source,
+        readiness_artifact_path=readiness,
+        generated_at_utc=FROZEN,
+        presets=[PresetFixture()],
+    )
+
+    assert snap["validation_requests"][0]["request_status"] == "request_malformed"
+    assert snap["validation_requests"][0]["safe_to_execute"] is False
+
+
+def test_missing_and_malformed_inputs_fail_closed(tmp_path: Path) -> None:
+    missing = req.collect_snapshot(
+        input_artifact_path=tmp_path / "missing.json",
+        generated_at_utc=FROZEN,
+        presets=[PresetFixture()],
+    )
+    malformed_path = tmp_path / "malformed.json"
+    malformed_path.write_text("{", encoding="utf-8")
+    malformed = req.collect_snapshot(
+        input_artifact_path=malformed_path,
+        generated_at_utc=FROZEN,
+        presets=[PresetFixture()],
+    )
+
+    assert req.NOTE_INPUT_ABSENT in missing["validation_warnings"]
+    assert req.NOTE_INPUT_UNPARSEABLE in malformed["validation_warnings"]
+    assert missing["safe_to_execute"] is False
+    assert malformed["safe_to_execute"] is False
+
+
+def test_collects_readiness_directly_when_readiness_artifact_absent(tmp_path: Path) -> None:
+    source = _write_hypotheses(tmp_path / "hypotheses.json", [_hypothesis()])
+    market_observations = tmp_path / "observations.json"
+    market_observations.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "report_kind": "qre_market_observation_snapshot",
+                "observations": [
+                    {
+                        "observation_id": "qre-obs-fixture",
+                        "source_artifact": "fixture.json",
+                        "observation_type": "exit_failure_pattern",
+                        "asset_scope": ["BTC-EUR"],
+                        "timeframe_scope": ["1h"],
+                        "summary": "Ready.",
+                        "supporting_evidence_refs": ["fixture#1"],
+                        "executable_hypothesis_id": "trend_pullback_v1",
+                        "strategy_family": "trend_pullback",
+                        "strategy_template_id": "trend_pullback_v1",
+                        "preset_name": "trend_pullback_crypto_1h",
+                    }
+                ],
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    snap = req.collect_snapshot(
+        input_artifact_path=source,
+        readiness_artifact_path=tmp_path / "missing-readiness.json",
+        market_observation_artifact_path=market_observations,
+        generated_at_utc=FROZEN,
+        presets=[PresetFixture()],
+    )
+
+    assert snap["validation_requests"][0]["request_status"] == ("request_ready_for_operator_review")
+
+
+def test_cli_no_write_does_not_write_artifact(monkeypatch, tmp_path: Path, capsys) -> None:
+    source = _write_hypotheses(tmp_path / "hypotheses.json", [_hypothesis()])
+    readiness = _write_readiness(tmp_path / "readiness.json")
+    artifact_dir = tmp_path / "logs" / "qre_executable_validation_request"
+    latest = artifact_dir / "latest.json"
+    monkeypatch.setattr(req, "ARTIFACT_DIR", artifact_dir)
+    monkeypatch.setattr(req, "ARTIFACT_LATEST", latest)
+
+    rc = req.main(
+        [
+            "--no-write",
+            "--source",
+            str(source),
+            "--readiness-source",
+            str(readiness),
+            "--frozen-utc",
+            FROZEN,
+            "--indent",
+            "0",
+        ]
+    )
+
+    assert rc == 0
+    assert latest.exists() is False
+    parsed = json.loads(capsys.readouterr().out)
+    assert parsed["report_kind"] == req.REPORT_KIND
+
+
+def test_write_outputs_only_allows_request_artifact_dir(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    artifact_dir = tmp_path / "logs" / "qre_executable_validation_request"
+    latest = artifact_dir / "latest.json"
+    source = _write_hypotheses(tmp_path / "hypotheses.json", [_hypothesis()])
+    readiness = _write_readiness(tmp_path / "readiness.json")
+    monkeypatch.setattr(req, "ARTIFACT_DIR", artifact_dir)
+    monkeypatch.setattr(req, "ARTIFACT_LATEST", latest)
+    snap = req.collect_snapshot(
+        input_artifact_path=source,
+        readiness_artifact_path=readiness,
+        generated_at_utc=FROZEN,
+        presets=[PresetFixture()],
+    )
+
+    assert req.write_outputs(snap) == latest
+    assert latest.exists()
+    with pytest.raises(ValueError):
+        req.write_outputs(snap, output_path=tmp_path / "outside.json")
+
+
+def test_source_has_no_forbidden_calls_or_writes() -> None:
+    src = Path(req.__file__).read_text(encoding="utf-8")
+    forbidden = (
+        "import subprocess",
+        "from subprocess",
+        "subprocess.",
+        "os.system",
+        "os.popen",
+        "shell=True",
+        "research.run_research",
+        "strategy_matrix.csv",
+        "research/research_latest.json",
+        "seed.jsonl",
+        "generated_seed.jsonl",
+        "campaigns/",
+        "paper/",
+        "shadow/",
+        "live/",
+        "SequenceMatcher",
+        "difflib",
+        "fuzzy",
+    )
+    for token in forbidden:
+        assert token not in src, token

--- a/tests/unit/test_qre_market_observation_hypothesis_readiness.py
+++ b/tests/unit/test_qre_market_observation_hypothesis_readiness.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from reporting import qre_market_observation_hypothesis_readiness as readiness
+
+FROZEN = "2026-06-01T12:00:00Z"
+
+
+def _observation(**overrides) -> dict:
+    base = {
+        "observation_id": "qre-obs-fixture-001",
+        "source_artifact": "fixture.json",
+        "observation_type": "exit_failure_pattern",
+        "asset_scope": ["BTC-EUR"],
+        "timeframe_scope": ["1h"],
+        "summary": "Exit rules appear to degrade the trend edge.",
+        "supporting_evidence_refs": ["fixture#1"],
+        "executable_hypothesis_id": "trend_pullback_v1",
+        "strategy_family": "trend_pullback",
+        "strategy_template_id": "trend_pullback_v1",
+        "preset_name": "trend_pullback_crypto_1h",
+    }
+    base.update(overrides)
+    return base
+
+
+def _write_observations(path: Path, observations: list, **overrides) -> Path:
+    payload = {
+        "schema_version": 1,
+        "report_kind": "qre_market_observation_snapshot",
+        "generated_at_utc": FROZEN,
+        "observations": observations,
+        "safe_to_execute": False,
+    }
+    payload.update(overrides)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return path
+
+
+def test_ready_observation_classifies_hypothesis_ready(tmp_path: Path) -> None:
+    source = _write_observations(tmp_path / "observations.json", [_observation()])
+
+    snap = readiness.collect_snapshot(input_artifact_path=source, generated_at_utc=FROZEN)
+
+    assert snap["counts"]["total_observations"] == 1
+    assert snap["by_readiness_class"]["hypothesis_ready"] == 1
+    assert snap["readiness_rows"][0]["readiness_class"] == "hypothesis_ready"
+    assert snap["bridge_field_counts"]["executable_hypothesis_id"] == 1
+    assert snap["safe_to_execute"] is False
+    assert snap["read_only"] is True
+
+
+def test_missing_executable_hypothesis_id_fails_closed(tmp_path: Path) -> None:
+    source = _write_observations(
+        tmp_path / "observations.json",
+        [_observation(executable_hypothesis_id="")],
+    )
+
+    snap = readiness.collect_snapshot(input_artifact_path=source, generated_at_utc=FROZEN)
+
+    assert snap["by_readiness_class"]["execution_identity_missing"] == 1
+    assert snap["final_recommendation"] == "explicit_executable_hypothesis_identity_required"
+    assert snap["recommended_next_action"] == (
+        "add_explicit_executable_hypothesis_id_to_upstream_source"
+    )
+
+
+def test_missing_strategy_or_preset_identity_reports_identity_missing(tmp_path: Path) -> None:
+    source = _write_observations(
+        tmp_path / "observations.json",
+        [_observation(strategy_template_id="", preset_name="")],
+    )
+
+    snap = readiness.collect_snapshot(input_artifact_path=source, generated_at_utc=FROZEN)
+
+    assert snap["by_readiness_class"]["identity_missing"] == 1
+    assert "has_strategy_template_id" in snap["readiness_rows"][0]["reason_codes"]
+    assert "has_preset_name" in snap["readiness_rows"][0]["reason_codes"]
+
+
+def test_missing_market_context_reports_insufficient_market_context(tmp_path: Path) -> None:
+    source = _write_observations(
+        tmp_path / "observations.json",
+        [
+            _observation(
+                asset_scope=["unknown"],
+                timeframe_scope=["unknown"],
+                summary="",
+            )
+        ],
+    )
+
+    snap = readiness.collect_snapshot(input_artifact_path=source, generated_at_utc=FROZEN)
+
+    assert snap["by_readiness_class"]["insufficient_market_context"] == 1
+    assert set(snap["readiness_rows"][0]["reason_codes"]) >= {
+        "has_asset_or_symbol",
+        "has_timeframe_or_interval",
+        "bounded_text_available",
+    }
+
+
+def test_missing_evidence_refs_reports_insufficient_evidence_refs(tmp_path: Path) -> None:
+    source = _write_observations(
+        tmp_path / "observations.json",
+        [_observation(supporting_evidence_refs=[])],
+    )
+
+    snap = readiness.collect_snapshot(input_artifact_path=source, generated_at_utc=FROZEN)
+
+    assert snap["by_readiness_class"]["insufficient_evidence_refs"] == 1
+
+
+def test_unsupported_schema_and_malformed_rows_fail_closed(tmp_path: Path) -> None:
+    source = _write_observations(
+        tmp_path / "observations.json",
+        [
+            _observation(observation_id="", observation_type=""),
+            "not-a-row",
+        ],
+    )
+
+    snap = readiness.collect_snapshot(input_artifact_path=source, generated_at_utc=FROZEN)
+
+    assert snap["by_readiness_class"]["unsupported_observation_schema"] == 1
+    assert snap["by_readiness_class"]["malformed_observation"] == 1
+    assert snap["counts"]["not_ready"] == 2
+
+
+def test_examples_are_bounded_to_twenty(tmp_path: Path) -> None:
+    observations = [
+        _observation(observation_id=f"qre-obs-fixture-{index:03d}") for index in range(25)
+    ]
+    source = _write_observations(tmp_path / "observations.json", observations)
+
+    snap = readiness.collect_snapshot(input_artifact_path=source, generated_at_utc=FROZEN)
+
+    assert len(snap["examples"]) == 20
+    assert snap["counts"]["total_observations"] == 25
+
+
+def test_missing_and_malformed_inputs_fail_closed(tmp_path: Path) -> None:
+    missing = readiness.collect_snapshot(
+        input_artifact_path=tmp_path / "missing.json",
+        generated_at_utc=FROZEN,
+    )
+    malformed_path = tmp_path / "malformed.json"
+    malformed_path.write_text("{", encoding="utf-8")
+    malformed = readiness.collect_snapshot(
+        input_artifact_path=malformed_path,
+        generated_at_utc=FROZEN,
+    )
+
+    assert readiness.NOTE_INPUT_ABSENT in missing["validation_warnings"]
+    assert readiness.NOTE_INPUT_UNPARSEABLE in malformed["validation_warnings"]
+    assert missing["safe_to_execute"] is False
+    assert malformed["safe_to_execute"] is False
+
+
+def test_cli_no_write_does_not_write_artifact(monkeypatch, tmp_path: Path, capsys) -> None:
+    source = _write_observations(tmp_path / "observations.json", [_observation()])
+    artifact_dir = tmp_path / "logs" / "qre_market_observation_hypothesis_readiness"
+    latest = artifact_dir / "latest.json"
+    monkeypatch.setattr(readiness, "ARTIFACT_DIR", artifact_dir)
+    monkeypatch.setattr(readiness, "ARTIFACT_LATEST", latest)
+
+    rc = readiness.main(
+        ["--no-write", "--source", str(source), "--frozen-utc", FROZEN, "--indent", "0"]
+    )
+
+    assert rc == 0
+    assert latest.exists() is False
+    parsed = json.loads(capsys.readouterr().out)
+    assert parsed["report_kind"] == readiness.REPORT_KIND
+
+
+def test_write_outputs_only_allows_readiness_artifact_dir(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    artifact_dir = tmp_path / "logs" / "qre_market_observation_hypothesis_readiness"
+    latest = artifact_dir / "latest.json"
+    monkeypatch.setattr(readiness, "ARTIFACT_DIR", artifact_dir)
+    monkeypatch.setattr(readiness, "ARTIFACT_LATEST", latest)
+    snap = readiness.collect_snapshot(
+        input_artifact_path=_write_observations(tmp_path / "observations.json", [_observation()]),
+        generated_at_utc=FROZEN,
+    )
+
+    assert readiness.write_outputs(snap) == latest
+    assert latest.exists()
+    with pytest.raises(ValueError):
+        readiness.write_outputs(snap, output_path=tmp_path / "outside.json")
+
+
+def test_source_has_no_forbidden_calls_or_writes() -> None:
+    src = Path(readiness.__file__).read_text(encoding="utf-8")
+    forbidden = (
+        "import subprocess",
+        "from subprocess",
+        "subprocess.",
+        "os.system",
+        "os.popen",
+        "shell=True",
+        "research.run_research",
+        "strategy_matrix.csv",
+        "research/research_latest.json",
+        "seed.jsonl",
+        "generated_seed.jsonl",
+        "campaigns/",
+        "paper/",
+        "shadow/",
+        "live/",
+        "SequenceMatcher",
+        "difflib",
+        "fuzzy",
+    )
+    for token in forbidden:
+        assert token not in src, token

--- a/tests/unit/test_qre_preset_strategy_eligibility_contract.py
+++ b/tests/unit/test_qre_preset_strategy_eligibility_contract.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from reporting import qre_preset_strategy_eligibility_contract as eligibility
+
+
+@dataclass(frozen=True)
+class PresetFixture:
+    name: str
+    hypothesis_id: str | None = "trend_pullback_v1"
+    enabled: bool = True
+    diagnostic_only: bool = False
+    excluded_from_candidate_promotion: bool = False
+    timeframe: str = "1h"
+    universe: tuple[str, ...] = ("BTC-EUR", "ETH-EUR")
+    bundle: tuple[str, ...] = ("trend_pullback_v1",)
+
+
+def _preset(**overrides) -> PresetFixture:
+    return PresetFixture(**overrides)
+
+
+def _request(**overrides) -> dict:
+    base = {
+        "preset_name": "trend_pullback_crypto_1h",
+        "executable_hypothesis_id": "trend_pullback_v1",
+        "timeframe": "1h",
+        "asset": "BTC-EUR",
+        "strategy_template_id": "trend_pullback_v1",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_exact_request_is_eligible() -> None:
+    result = eligibility.validate_request(
+        _request(),
+        presets=[_preset(name="trend_pullback_crypto_1h")],
+    )
+
+    assert result["safe_to_request"] is True
+    assert result["eligibility_status"] == "eligible"
+    assert result["reason_codes"] == []
+    assert result["matched_preset"]["preset_name"] == "trend_pullback_crypto_1h"
+
+
+def test_missing_preset_name_fails_closed() -> None:
+    result = eligibility.validate_request(_request(preset_name=""), presets=[])
+
+    assert result["safe_to_request"] is False
+    assert result["eligibility_status"] == "missing_preset_name"
+
+
+def test_unknown_preset_fails_closed_without_similarity_matching() -> None:
+    result = eligibility.validate_request(
+        _request(preset_name="trend_pullback_crypto"),
+        presets=[_preset(name="trend_pullback_crypto_1h")],
+    )
+
+    assert result["safe_to_request"] is False
+    assert result["eligibility_status"] == "preset_not_found"
+
+
+def test_duplicate_preset_names_are_ambiguous_and_unsafe() -> None:
+    result = eligibility.validate_request(
+        _request(),
+        presets=[
+            _preset(name="trend_pullback_crypto_1h"),
+            _preset(name="trend_pullback_crypto_1h"),
+        ],
+    )
+
+    assert result["safe_to_request"] is False
+    assert result["eligibility_status"] == "ambiguous_request"
+
+
+def test_disabled_preset_fails_closed() -> None:
+    result = eligibility.validate_request(
+        _request(),
+        presets=[_preset(name="trend_pullback_crypto_1h", enabled=False)],
+    )
+
+    assert result["eligibility_status"] == "preset_disabled"
+
+
+def test_diagnostic_only_preset_requires_explicit_allowance() -> None:
+    preset = _preset(name="trend_pullback_crypto_1h", diagnostic_only=True)
+
+    blocked = eligibility.validate_request(_request(), presets=[preset])
+    allowed = eligibility.validate_request(
+        _request(),
+        presets=[preset],
+        allow_diagnostic_only=True,
+    )
+
+    assert blocked["eligibility_status"] == "preset_diagnostic_only"
+    assert blocked["safe_to_request"] is False
+    assert allowed["eligibility_status"] == "eligible"
+
+
+def test_promotion_request_blocks_excluded_preset() -> None:
+    result = eligibility.validate_request(
+        _request(promotion_path_requested=True),
+        presets=[
+            _preset(
+                name="trend_pullback_crypto_1h",
+                excluded_from_candidate_promotion=True,
+            )
+        ],
+    )
+
+    assert result["eligibility_status"] == "preset_excluded_from_promotion"
+
+
+def test_executable_hypothesis_id_mismatch_fails_closed() -> None:
+    result = eligibility.validate_request(
+        _request(executable_hypothesis_id="volatility_compression_breakout_v0"),
+        presets=[_preset(name="trend_pullback_crypto_1h")],
+    )
+
+    assert result["eligibility_status"] == "executable_hypothesis_id_mismatch"
+
+
+def test_timeframe_asset_and_strategy_mismatches_fail_closed() -> None:
+    timeframe = eligibility.validate_request(
+        _request(timeframe="4h"),
+        presets=[_preset(name="trend_pullback_crypto_1h")],
+    )
+    asset = eligibility.validate_request(
+        _request(asset="SOL-EUR"),
+        presets=[_preset(name="trend_pullback_crypto_1h")],
+    )
+    strategy = eligibility.validate_request(
+        _request(strategy_template_id="breakout_momentum"),
+        presets=[_preset(name="trend_pullback_crypto_1h")],
+    )
+
+    assert timeframe["eligibility_status"] == "timeframe_mismatch"
+    assert asset["eligibility_status"] == "asset_not_in_universe"
+    assert strategy["eligibility_status"] == "strategy_template_not_in_bundle"
+
+
+def test_optional_fields_are_checked_only_when_present() -> None:
+    request = {"preset_name": "trend_pullback_crypto_1h"}
+
+    result = eligibility.validate_request(
+        request,
+        presets=[_preset(name="trend_pullback_crypto_1h")],
+    )
+
+    assert result["safe_to_request"] is True
+    assert result["eligibility_status"] == "eligible"
+
+
+def test_malformed_request_fails_closed() -> None:
+    result = eligibility.validate_request("not-a-row", presets=[])
+
+    assert result["safe_to_request"] is False
+    assert result["eligibility_status"] == "malformed_request"
+
+
+def test_output_is_bounded_and_summary_counts_are_closed() -> None:
+    long_name = "preset-" + ("x" * 240)
+    result = eligibility.validate_request(
+        _request(preset_name=long_name),
+        presets=[_preset(name=long_name)],
+    )
+    summary = eligibility.summarize_eligibility([result])
+
+    assert len(result["request"]["preset_name"]) <= 160
+    assert set(summary) == set(eligibility.ELIGIBILITY_STATUSES)
+    assert summary["eligible"] == 1
+
+
+def test_source_has_no_forbidden_calls_or_matching_heuristics() -> None:
+    src = Path(eligibility.__file__).read_text(encoding="utf-8")
+    forbidden = (
+        "import subprocess",
+        "from subprocess",
+        "subprocess.",
+        "os.system",
+        "os.popen",
+        "shell=True",
+        "research.run_research",
+        "SequenceMatcher",
+        "difflib",
+        "levenshtein",
+        "fuzzy",
+        "strategy_matrix.csv",
+        "research/research_latest.json",
+        "seed.jsonl",
+        "generated_seed.jsonl",
+        "campaigns/",
+        "paper/",
+        "shadow/",
+        "live/",
+    )
+    for token in forbidden:
+        assert token not in src, token

--- a/tests/unit/test_qre_preset_strategy_eligibility_contract.py
+++ b/tests/unit/test_qre_preset_strategy_eligibility_contract.py
@@ -154,6 +154,44 @@ def test_optional_fields_are_checked_only_when_present() -> None:
     assert result["eligibility_status"] == "eligible"
 
 
+def test_default_preset_source_parser_reads_explicit_fields(tmp_path: Path) -> None:
+    source = tmp_path / "presets.py"
+    source.write_text(
+        """
+PRESETS: tuple[ResearchPreset, ...] = (
+    ResearchPreset(
+        name="trend_pullback_crypto_1h",
+        enabled=True,
+        diagnostic_only=False,
+        excluded_from_candidate_promotion=False,
+        hypothesis_id="trend_pullback_v1",
+        timeframe="1h",
+        universe=("BTC-EUR",),
+        bundle=("trend_pullback_v1",),
+    ),
+)
+""",
+        encoding="utf-8",
+    )
+
+    presets = eligibility._presets_from_source(source)
+    result = eligibility.validate_request(_request(), presets=presets)
+
+    assert presets == [
+        {
+            "enabled": True,
+            "diagnostic_only": False,
+            "excluded_from_candidate_promotion": False,
+            "hypothesis_id": "trend_pullback_v1",
+            "timeframe": "1h",
+            "universe": ("BTC-EUR",),
+            "bundle": ("trend_pullback_v1",),
+            "name": "trend_pullback_crypto_1h",
+        }
+    ]
+    assert result["safe_to_request"] is True
+
+
 def test_malformed_request_fails_closed() -> None:
     result = eligibility.validate_request("not-a-row", presets=[])
 
@@ -183,6 +221,8 @@ def test_source_has_no_forbidden_calls_or_matching_heuristics() -> None:
         "os.system",
         "os.popen",
         "shell=True",
+        "from research.presets",
+        "import research.presets",
         "research.run_research",
         "SequenceMatcher",
         "difflib",

--- a/tests/unit/test_qre_validation_request_dry_run_runner.py
+++ b/tests/unit/test_qre_validation_request_dry_run_runner.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from reporting import qre_validation_request_dry_run_runner as dry_run
+
+FROZEN = "2026-06-01T12:00:00Z"
+
+
+def _request(**overrides) -> dict:
+    base = {
+        "request_id": "qre-req-fixture",
+        "qre_hypothesis_id": "qre-hyp-fixture",
+        "executable_hypothesis_id": "trend_pullback_v1",
+        "preset_name": "trend_pullback_crypto_1h",
+        "strategy_template_id": "trend_pullback_v1",
+        "asset": "BTC-EUR",
+        "timeframe": "1h",
+        "request_status": "request_ready_for_operator_review",
+        "requires_operator_approval": True,
+        "allowed_command_preview": "Operator-reviewed validation request for fixture",
+        "safe_to_execute": False,
+    }
+    base.update(overrides)
+    return base
+
+
+def _write_requests(path: Path, requests: list) -> Path:
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "report_kind": "qre_executable_validation_request",
+                "generated_at_utc": FROZEN,
+                "validation_requests": requests,
+                "safe_to_execute": False,
+                "read_only": True,
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_ready_request_with_operator_approval_produces_dry_run_ready(tmp_path: Path) -> None:
+    source = _write_requests(tmp_path / "requests.json", [_request(operator_approved=True)])
+
+    snap = dry_run.collect_snapshot(input_artifact_path=source, generated_at_utc=FROZEN)
+
+    row = snap["dry_run_results"][0]
+    assert row["dry_run_status"] == "dry_run_ready"
+    assert row["would_run_command_preview"].startswith("Operator-reviewed")
+    assert row["would_write_artifacts"] == list(dry_run.FUTURE_OUTPUTS)
+    assert row["backup_required"] is True
+    assert row["safe_to_execute"] is False
+    assert row["executed"] is False
+    assert snap["executed_anything"] is False
+
+
+def test_request_not_ready_blocks_dry_run(tmp_path: Path) -> None:
+    source = _write_requests(
+        tmp_path / "requests.json",
+        [_request(request_status="request_blocked_identity_missing")],
+    )
+
+    snap = dry_run.collect_snapshot(input_artifact_path=source, generated_at_utc=FROZEN)
+
+    assert snap["dry_run_results"][0]["dry_run_status"] == ("dry_run_blocked_request_not_ready")
+
+
+def test_missing_operator_approval_blocks_dry_run(tmp_path: Path) -> None:
+    source = _write_requests(tmp_path / "requests.json", [_request()])
+
+    snap = dry_run.collect_snapshot(input_artifact_path=source, generated_at_utc=FROZEN)
+
+    assert snap["dry_run_results"][0]["dry_run_status"] == (
+        "dry_run_blocked_missing_operator_approval"
+    )
+
+
+def test_missing_command_preview_blocks_dry_run(tmp_path: Path) -> None:
+    source = _write_requests(
+        tmp_path / "requests.json",
+        [_request(operator_approved=True, allowed_command_preview="")],
+    )
+
+    snap = dry_run.collect_snapshot(input_artifact_path=source, generated_at_utc=FROZEN)
+
+    assert snap["dry_run_results"][0]["dry_run_status"] == (
+        "dry_run_blocked_missing_command_preview"
+    )
+
+
+def test_malformed_request_row_fails_closed(tmp_path: Path) -> None:
+    source = _write_requests(tmp_path / "requests.json", ["not-a-row"])
+
+    snap = dry_run.collect_snapshot(input_artifact_path=source, generated_at_utc=FROZEN)
+
+    row = snap["dry_run_results"][0]
+    assert row["dry_run_status"] == "dry_run_malformed"
+    assert row["safe_to_execute"] is False
+    assert row["executed"] is False
+
+
+def test_missing_and_malformed_inputs_fail_closed(tmp_path: Path) -> None:
+    missing = dry_run.collect_snapshot(
+        input_artifact_path=tmp_path / "missing.json",
+        generated_at_utc=FROZEN,
+    )
+    malformed_path = tmp_path / "malformed.json"
+    malformed_path.write_text("{", encoding="utf-8")
+    malformed = dry_run.collect_snapshot(
+        input_artifact_path=malformed_path,
+        generated_at_utc=FROZEN,
+    )
+
+    assert dry_run.NOTE_INPUT_ABSENT in missing["validation_warnings"]
+    assert dry_run.NOTE_INPUT_UNPARSEABLE in malformed["validation_warnings"]
+    assert missing["safe_to_execute"] is False
+    assert malformed["safe_to_execute"] is False
+
+
+def test_cli_no_write_does_not_write_artifact(monkeypatch, tmp_path: Path, capsys) -> None:
+    source = _write_requests(tmp_path / "requests.json", [_request()])
+    artifact_dir = tmp_path / "logs" / "qre_validation_request_dry_run"
+    latest = artifact_dir / "latest.json"
+    monkeypatch.setattr(dry_run, "ARTIFACT_DIR", artifact_dir)
+    monkeypatch.setattr(dry_run, "ARTIFACT_LATEST", latest)
+
+    rc = dry_run.main(
+        ["--no-write", "--source", str(source), "--frozen-utc", FROZEN, "--indent", "0"]
+    )
+
+    assert rc == 0
+    assert latest.exists() is False
+    parsed = json.loads(capsys.readouterr().out)
+    assert parsed["report_kind"] == dry_run.REPORT_KIND
+
+
+def test_write_outputs_only_allows_dry_run_artifact_dir(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    artifact_dir = tmp_path / "logs" / "qre_validation_request_dry_run"
+    latest = artifact_dir / "latest.json"
+    monkeypatch.setattr(dry_run, "ARTIFACT_DIR", artifact_dir)
+    monkeypatch.setattr(dry_run, "ARTIFACT_LATEST", latest)
+    source = _write_requests(tmp_path / "requests.json", [_request()])
+    snap = dry_run.collect_snapshot(input_artifact_path=source, generated_at_utc=FROZEN)
+
+    assert dry_run.write_outputs(snap) == latest
+    assert latest.exists()
+    with pytest.raises(ValueError):
+        dry_run.write_outputs(snap, output_path=tmp_path / "outside.json")
+
+
+def test_source_has_no_forbidden_calls_or_mutating_writes() -> None:
+    src = Path(dry_run.__file__).read_text(encoding="utf-8")
+    forbidden = (
+        "import subprocess",
+        "from subprocess",
+        "subprocess.",
+        "os.system",
+        "os.popen",
+        "shell=True",
+        "research.run_research",
+        "strategy_matrix.csv",
+        "research/research_latest.json",
+        "seed.jsonl",
+        "generated_seed.jsonl",
+        "campaigns/",
+        "paper/",
+        "shadow/",
+        "live/",
+        "SequenceMatcher",
+        "difflib",
+        "fuzzy",
+    )
+    for token in forbidden:
+        assert token not in src, token


### PR DESCRIPTION
## Summary
- add QRE market observation hypothesis-readiness diagnostic
- add pure preset/strategy eligibility contract
- add read-only executable validation request artifact
- add non-executing validation request dry-run runner

## Safety
- safe_to_execute remains false across new reports
- no research execution, subprocess launch, queue write, strategy/preset mutation, or protected artifact mutation
- executable validation requests remain blocked on current live artifacts because executable_hypothesis_id is still absent upstream

## Validation
- python -m pytest tests/unit/test_qre_market_observation_hypothesis_readiness.py -q
- python -m pytest tests/unit/test_qre_preset_strategy_eligibility_contract.py -q
- python -m pytest tests/unit/test_qre_executable_validation_request.py -q
- python -m pytest tests/unit/test_qre_validation_request_dry_run_runner.py -q
- existing QRE linkage tests, schema pin, architecture smoke, smoke
- ruff check and format --check on changed files
- manual QRE artifact commands and no-write diagnostics