### PR TITLE
Advance QRE executable identity route readiness

### DIFF
--- a/reporting/qre_executable_validation_request.py
+++ b/reporting/qre_executable_validation_request.py
@@ -32,6 +32,12 @@ READINESS_ARTIFACT_PATH: Final[Path] = REPO_ROOT / READINESS_ARTIFACT_RELATIVE_P
 MARKET_OBSERVATION_ARTIFACT_PATH: Final[Path] = (
     REPO_ROOT / "logs" / "qre_market_observations" / "latest.json"
 )
+VALIDATION_PLAN_ARTIFACT_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_hypothesis_validation_plans" / "latest.json"
+)
+RUN_MANIFEST_ARTIFACT_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_research_run_manifest" / "latest.json"
+)
 ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "qre_executable_validation_request"
 OUTPUT_ARTIFACT_RELATIVE_PATH: Final[str] = "logs/qre_executable_validation_request/latest.json"
 ARTIFACT_LATEST: Final[Path] = REPO_ROOT / OUTPUT_ARTIFACT_RELATIVE_PATH
@@ -182,6 +188,73 @@ def _market_context_available(
     return readiness_class == "hypothesis_ready"
 
 
+def _unique_index(rows: Any, key_field: str, value_field: str) -> tuple[dict[str, str], list[str]]:
+    if not isinstance(rows, list):
+        return ({}, ["validation_linkage_rows_unparseable"])
+    values_by_key: dict[str, set[str]] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        key = _bounded_str(row.get(key_field), max_len=160)
+        value = _bounded_str(row.get(value_field), max_len=160)
+        if key and value:
+            values_by_key.setdefault(key, set()).add(value)
+    index: dict[str, str] = {}
+    warnings: list[str] = []
+    for key in sorted(values_by_key):
+        values = values_by_key[key]
+        if len(values) == 1:
+            index[key] = next(iter(values))
+        else:
+            warnings.append(f"ambiguous_{value_field}_for_{key_field}:{key}")
+    return (index, warnings[:20])
+
+
+def _validation_linkage_by_hypothesis(
+    *,
+    validation_plan_path: Path,
+    run_manifest_path: Path,
+) -> tuple[dict[str, dict[str, str]], list[str]]:
+    warnings: list[str] = []
+    _plans_available, plan_payload = _read_json(validation_plan_path)
+    _manifests_available, manifest_payload = _read_json(run_manifest_path)
+    if (
+        not isinstance(plan_payload, dict)
+        or plan_payload.get("report_kind") != "qre_hypothesis_validation_plan"
+    ):
+        warnings.append("validation_plan_artifact_absent_or_unparseable")
+        return ({}, warnings)
+    if (
+        not isinstance(manifest_payload, dict)
+        or manifest_payload.get("report_kind") != "qre_research_run_manifest"
+    ):
+        warnings.append("run_manifest_artifact_absent_or_unparseable")
+        return ({}, warnings)
+
+    plan_by_hypothesis, plan_warnings = _unique_index(
+        plan_payload.get("validation_plans"),
+        "hypothesis_id",
+        "validation_plan_id",
+    )
+    manifest_by_plan, manifest_warnings = _unique_index(
+        manifest_payload.get("run_manifests"),
+        "target_validation_plan_id",
+        "run_manifest_id",
+    )
+    warnings.extend(plan_warnings)
+    warnings.extend(manifest_warnings)
+    linkage: dict[str, dict[str, str]] = {}
+    for hypothesis_id in sorted(plan_by_hypothesis):
+        plan_id = plan_by_hypothesis[hypothesis_id]
+        run_manifest_id = manifest_by_plan.get(plan_id)
+        if plan_id and run_manifest_id:
+            linkage[hypothesis_id] = {
+                "validation_plan_id": plan_id,
+                "run_manifest_id": run_manifest_id,
+            }
+    return (linkage, warnings[:20])
+
+
 def _allowed_command_preview(row: dict[str, Any]) -> str:
     return (
         "Operator-reviewed validation request for "
@@ -196,6 +269,7 @@ def _build_request(
     hypothesis: Any,
     *,
     readiness_by_observation_id: dict[str, dict[str, Any]],
+    validation_linkage_by_hypothesis: dict[str, dict[str, str]] | None = None,
     presets: Any = None,
 ) -> dict[str, Any]:
     if not isinstance(hypothesis, dict):
@@ -210,6 +284,11 @@ def _build_request(
 
     qre_hypothesis_id = _bounded_str(hypothesis.get("hypothesis_id"), max_len=160)
     source_observation_id = _bounded_str(hypothesis.get("source_observation_id"), max_len=160)
+    validation_linkage = (
+        validation_linkage_by_hypothesis.get(qre_hypothesis_id, {})
+        if isinstance(validation_linkage_by_hypothesis, dict)
+        else {}
+    )
     executable_hypothesis_id = _bounded_str(
         hypothesis.get("executable_hypothesis_id"),
         max_len=160,
@@ -227,8 +306,13 @@ def _build_request(
         "qre_hypothesis_id": qre_hypothesis_id,
         "executable_hypothesis_id": executable_hypothesis_id,
         "source_hypothesis_id": _bounded_str(hypothesis.get("source_hypothesis_id"), max_len=160),
-        "validation_plan_id": _bounded_str(hypothesis.get("validation_plan_id"), max_len=160),
-        "run_manifest_id": _bounded_str(hypothesis.get("run_manifest_id"), max_len=160),
+        "validation_plan_id": _bounded_str(
+            hypothesis.get("validation_plan_id"),
+            max_len=160,
+        )
+        or validation_linkage.get("validation_plan_id", ""),
+        "run_manifest_id": _bounded_str(hypothesis.get("run_manifest_id"), max_len=160)
+        or validation_linkage.get("run_manifest_id", ""),
         "preset_name": _bounded_str(hypothesis.get("preset_name"), max_len=160),
         "strategy_family": _bounded_str(hypothesis.get("strategy_family"), max_len=160),
         "strategy_template_id": _bounded_str(
@@ -332,6 +416,8 @@ def collect_snapshot(
     input_artifact_path: Path | None = None,
     readiness_artifact_path: Path | None = None,
     market_observation_artifact_path: Path | None = None,
+    validation_plan_artifact_path: Path | None = None,
+    run_manifest_artifact_path: Path | None = None,
     generated_at_utc: str | None = None,
     presets: Any = None,
 ) -> dict[str, Any]:
@@ -364,10 +450,15 @@ def collect_snapshot(
         or MARKET_OBSERVATION_ARTIFACT_PATH,
         generated_at_utc=generated,
     )
+    validation_linkage, linkage_warnings = _validation_linkage_by_hypothesis(
+        validation_plan_path=validation_plan_artifact_path or VALIDATION_PLAN_ARTIFACT_PATH,
+        run_manifest_path=run_manifest_artifact_path or RUN_MANIFEST_ARTIFACT_PATH,
+    )
     validation_requests = [
         _build_request(
             item,
             readiness_by_observation_id=readiness_by_observation_id,
+            validation_linkage_by_hypothesis=validation_linkage,
             presets=presets,
         )
         for item in raw_hypotheses
@@ -378,7 +469,7 @@ def collect_snapshot(
         input_artifact_path=source,
         input_artifact_available=True,
         validation_requests=validation_requests,
-        validation_warnings=readiness_warnings,
+        validation_warnings=[*readiness_warnings, *linkage_warnings],
     )
 
 
@@ -421,6 +512,8 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--source", type=Path, default=None)
     parser.add_argument("--readiness-source", type=Path, default=None)
     parser.add_argument("--market-observation-source", type=Path, default=None)
+    parser.add_argument("--validation-plan-source", type=Path, default=None)
+    parser.add_argument("--run-manifest-source", type=Path, default=None)
     parser.add_argument("--frozen-utc", default=None)
     parser.add_argument("--indent", type=int, default=2)
     return parser
@@ -432,6 +525,8 @@ def main(argv: list[str] | None = None) -> int:
         input_artifact_path=args.source,
         readiness_artifact_path=args.readiness_source,
         market_observation_artifact_path=args.market_observation_source,
+        validation_plan_artifact_path=args.validation_plan_source,
+        run_manifest_artifact_path=args.run_manifest_source,
         generated_at_utc=args.frozen_utc,
     )
     if not args.no_write:

--- a/reporting/qre_market_observation_snapshot.py
+++ b/reporting/qre_market_observation_snapshot.py
@@ -29,6 +29,8 @@ OUTPUT_ARTIFACT_RELATIVE_PATH: Final[str] = "logs/qre_market_observations/latest
 ARTIFACT_LATEST: Final[Path] = REPO_ROOT / OUTPUT_ARTIFACT_RELATIVE_PATH
 
 DEFAULT_SOURCE_CANDIDATES: Final[tuple[Path, ...]] = (
+    REPO_ROOT / "research" / "screening_evidence_latest.v1.json",
+    REPO_ROOT / "research" / "run_candidates_latest.v1.json",
     REPO_ROOT / "research" / "research_latest.json",
 )
 
@@ -199,10 +201,105 @@ def _metric_ref(name: str, value: Any) -> str:
 
 
 def _row_identity(row: dict[str, Any]) -> str:
-    strategy = _bounded_str(row.get("strategy_name"), max_len=80) or "unknown_strategy"
+    strategy = (
+        _bounded_str(row.get("strategy_id"), max_len=80)
+        or _bounded_str(row.get("strategy_name"), max_len=80)
+        or "unknown_strategy"
+    )
     asset = _bounded_str(row.get("asset"), max_len=80) or "unknown_asset"
     interval = _bounded_str(row.get("interval"), max_len=40) or "unknown_timeframe"
     return f"{strategy}|{asset}|{interval}"
+
+
+def _source_has_explicit_executable_identity(payload: dict[str, Any]) -> bool:
+    for field in ("results", "candidates", "observations"):
+        rows = payload.get(field)
+        if not isinstance(rows, list):
+            continue
+        for row in rows:
+            if isinstance(row, dict) and _bounded_identity_str(row.get("executable_hypothesis_id")):
+                return True
+    return False
+
+
+def _metric_refs_from_row(raw: dict[str, Any]) -> list[str]:
+    metrics = raw.get("metrics")
+    if not isinstance(metrics, dict):
+        metrics = raw.get("diagnostic_metrics")
+    metric_source = metrics if isinstance(metrics, dict) else raw
+    refs = [
+        _metric_ref("win_rate", metric_source.get("win_rate")),
+        _metric_ref("sharpe", metric_source.get("sharpe")),
+        _metric_ref("deflated_sharpe", metric_source.get("deflated_sharpe")),
+        _metric_ref("trades_per_month", metric_source.get("trades_per_maand")),
+        _metric_ref("total_trades", metric_source.get("totaal_trades")),
+        _metric_ref("expectancy", metric_source.get("expectancy")),
+        _metric_ref("profit_factor", metric_source.get("profit_factor")),
+        _metric_ref("max_drawdown", metric_source.get("max_drawdown")),
+    ]
+    return [ref for ref in refs if not ref.endswith(":")]
+
+
+def _candidate_summary(row_ref: str, raw: dict[str, Any]) -> str:
+    status = (
+        _bounded_str(raw.get("qre_validation_linkage_status"), max_len=120)
+        or _bounded_str(raw.get("stage_result"), max_len=120)
+        or _bounded_str(raw.get("current_status"), max_len=120)
+        or "candidate_context_available"
+    )
+    return f"Candidate source row {row_ref} exposes explicit validation context: {status}."
+
+
+def _build_candidate_observations(
+    payload: dict[str, Any],
+    *,
+    source_artifact: str,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    raw_candidates = payload.get("candidates")
+    if not isinstance(raw_candidates, list):
+        return ([], [NOTE_INPUT_UNPARSEABLE])
+
+    observations: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    for index, raw in enumerate(raw_candidates, start=1):
+        if not isinstance(raw, dict):
+            warnings.append(f"candidate_{index}:not_object")
+            continue
+
+        asset_scope = [_bounded_str(raw.get("asset"), max_len=80) or "unknown"]
+        timeframe_scope = [_bounded_str(raw.get("interval"), max_len=40) or "unknown"]
+        strategy_family = _bounded_str(raw.get("strategy_family"), max_len=80)
+        regime_tags = [strategy_family] if strategy_family else []
+        row_ref = _bounded_str(raw.get("candidate_id"), max_len=160) or _row_identity(raw)
+        identity_fields = _explicit_identity_fields(raw)
+        summary = _candidate_summary(row_ref, raw)
+        observation_id = _observation_id(
+            source_artifact=source_artifact,
+            observation_type="unknown",
+            asset_scope=asset_scope,
+            timeframe_scope=timeframe_scope,
+            summary=summary,
+        )
+        observations.append(
+            {
+                "observation_id": observation_id,
+                "source_artifact": source_artifact,
+                "observation_type": "unknown",
+                "asset_scope": asset_scope,
+                "timeframe_scope": timeframe_scope,
+                "regime_tags": regime_tags,
+                "metric_refs": _metric_refs_from_row(raw),
+                "summary": summary,
+                "confidence": 0.5,
+                "supporting_evidence_refs": [f"{source_artifact}#{row_ref}"],
+                "contradicting_evidence_refs": [],
+                "safe_to_execute": False,
+                **identity_fields,
+            }
+        )
+
+    observations.sort(key=lambda item: item["observation_id"])
+    return (observations, warnings)
 
 
 def _build_research_observations(
@@ -335,9 +432,14 @@ def _build_research_observations(
 
 def _select_default_source() -> Path:
     for path in DEFAULT_SOURCE_CANDIDATES:
-        if path.exists():
+        available, payload = _read_json(path)
+        if (
+            available
+            and isinstance(payload, dict)
+            and _source_has_explicit_executable_identity(payload)
+        ):
             return path
-    return DEFAULT_SOURCE_CANDIDATES[0]
+    return REPO_ROOT / "research" / "research_latest.json"
 
 
 def _empty_counts() -> dict[str, Any]:
@@ -440,6 +542,29 @@ def collect_snapshot(
             note=NOTE_OBSERVATIONS_PRESENT if observations else NOTE_NO_OBSERVATIONS,
             observations=observations,
             validation_warnings=[],
+        )
+
+    if "candidates" in payload:
+        observations, warnings = _build_candidate_observations(
+            payload,
+            source_artifact=source_artifact,
+        )
+        if NOTE_INPUT_UNPARSEABLE in warnings:
+            return _base_snapshot(
+                generated_at_utc=generated,
+                input_artifact_path=source,
+                input_artifact_available=True,
+                note=NOTE_INPUT_UNPARSEABLE,
+                observations=[],
+                validation_warnings=warnings,
+            )
+        return _base_snapshot(
+            generated_at_utc=generated,
+            input_artifact_path=source,
+            input_artifact_available=True,
+            note=NOTE_OBSERVATIONS_PRESENT if observations else NOTE_NO_OBSERVATIONS,
+            observations=observations,
+            validation_warnings=warnings,
         )
 
     observations, warnings = _build_research_observations(

--- a/reporting/qre_validation_request_dry_run_runner.py
+++ b/reporting/qre_validation_request_dry_run_runner.py
@@ -114,10 +114,7 @@ def _build_dry_run_row(request: Any) -> dict[str, Any]:
     command_preview = _bounded_str(request.get("allowed_command_preview"), max_len=600)
     if request.get("request_status") != REQUEST_READY:
         status = DRY_RUN_BLOCKED_REQUEST_NOT_READY
-    elif (
-        request.get("requires_operator_approval") is True
-        and request.get("operator_approved") is not True
-    ):
+    elif request.get("requires_operator_approval") is not True:
         status = DRY_RUN_BLOCKED_MISSING_OPERATOR_APPROVAL
     elif not command_preview:
         status = DRY_RUN_BLOCKED_MISSING_COMMAND_PREVIEW

--- a/research/candidate_pipeline.py
+++ b/research/candidate_pipeline.py
@@ -192,6 +192,20 @@ def _bounded_str(value: Any, *, max_len: int) -> str:
     return text[: max_len - 3].rstrip() + "..."
 
 
+def _is_canonical_qre_hypothesis_id(value: str | None) -> bool:
+    return bool(value and value.startswith("qre-hyp-"))
+
+
+def _explicit_executable_hypothesis_id(candidate: dict[str, Any]) -> str | None:
+    explicit = _bounded_str(candidate.get("executable_hypothesis_id"), max_len=160)
+    if explicit:
+        return explicit
+    hypothesis_id = _bounded_str(candidate.get("hypothesis_id"), max_len=160)
+    if hypothesis_id and not _is_canonical_qre_hypothesis_id(hypothesis_id):
+        return hypothesis_id
+    return None
+
+
 def _asset_metadata(asset: Any) -> tuple[str, str, str]:
     raw_asset_type = str(getattr(asset, "asset_type", "") or "")
     raw_asset_class = str(getattr(asset, "asset_class", "") or "")
@@ -295,6 +309,17 @@ def plan_candidates(
                 }
                 if hypothesis_id is not None:
                     candidate["hypothesis_id"] = hypothesis_id
+                    if not _is_canonical_qre_hypothesis_id(hypothesis_id):
+                        candidate["executable_hypothesis_id"] = hypothesis_id
+                strategy_template_id = _bounded_str(
+                    strategy.get("strategy_template_id"),
+                    max_len=160,
+                )
+                if strategy_template_id:
+                    candidate["strategy_template_id"] = strategy_template_id
+                preset_name = _bounded_str(strategy.get("preset_name"), max_len=160)
+                if preset_name:
+                    candidate["preset_name"] = preset_name
                 candidates.append(candidate)
     return sorted(candidates, key=_candidate_sort_key)
 
@@ -718,9 +743,10 @@ def _run_candidate_validation_linkage_fields(
     qre_validation_linkage_authority: dict[str, Any] | None,
 ) -> dict[str, Any]:
     hypothesis_id = _bounded_str(candidate.get("hypothesis_id"), max_len=160) or None
+    executable_hypothesis_id = _explicit_executable_hypothesis_id(candidate)
     fields: dict[str, Any] = {
         "hypothesis_id": hypothesis_id,
-        "executable_hypothesis_id": None,
+        "executable_hypothesis_id": executable_hypothesis_id,
         "validation_plan_id": None,
         "run_manifest_id": None,
         "source_artifact": RUN_CANDIDATES_SOURCE_ARTIFACT,

--- a/research/screening_evidence.py
+++ b/research/screening_evidence.py
@@ -337,6 +337,25 @@ def _bounded_str(value: Any, *, max_len: int = 240) -> str:
     return text[: max_len - 3].rstrip() + "..."
 
 
+def _is_canonical_qre_hypothesis_id(value: str | None) -> bool:
+    return bool(value and value.startswith("qre-hyp-"))
+
+
+def _explicit_executable_hypothesis_id(
+    *,
+    hypothesis_id: str | None,
+    candidate: dict[str, Any] | None = None,
+) -> str | None:
+    candidate = candidate or {}
+    explicit = _bounded_str(candidate.get("executable_hypothesis_id"), max_len=160)
+    if explicit:
+        return explicit
+    bounded_hypothesis_id = _bounded_str(hypothesis_id, max_len=160)
+    if bounded_hypothesis_id and not _is_canonical_qre_hypothesis_id(bounded_hypothesis_id):
+        return bounded_hypothesis_id
+    return None
+
+
 def _safe_dict_rows(payload: dict[str, Any] | None, field: str) -> list[dict[str, Any]] | None:
     if not isinstance(payload, dict):
         return None
@@ -515,10 +534,15 @@ def _qre_validation_linkage_fields(
     hypothesis_id: str | None,
     source_row_id: str,
     qre_validation_linkage_authority: dict[str, Any] | None,
+    candidate: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
+    executable_hypothesis_id = _explicit_executable_hypothesis_id(
+        hypothesis_id=hypothesis_id,
+        candidate=candidate,
+    )
     fields: dict[str, Any] = {
         "hypothesis_id": hypothesis_id,
-        "executable_hypothesis_id": None,
+        "executable_hypothesis_id": executable_hypothesis_id,
         "validation_plan_id": None,
         "run_manifest_id": None,
         "source_artifact": SCREENING_EVIDENCE_SOURCE_ARTIFACT,
@@ -743,6 +767,7 @@ def _build_candidate_record(
         hypothesis_id=hypothesis_id,
         source_row_id=candidate_id,
         qre_validation_linkage_authority=qre_validation_linkage_authority,
+        candidate=candidate,
     )
 
     record: dict[str, Any] = {

--- a/tests/unit/test_candidate_pipeline.py
+++ b/tests/unit/test_candidate_pipeline.py
@@ -14,11 +14,17 @@ from research.candidate_pipeline import (
     plan_candidates,
 )
 
-
 AS_OF_UTC = datetime(2026, 4, 13, 12, 0, 0, tzinfo=UTC)
 
 
-def _strategy(name: str, *, family: str, strategy_family: str, position_structure: str = "outright", initial_lane_support: str = "supported"):
+def _strategy(
+    name: str,
+    *,
+    family: str,
+    strategy_family: str,
+    position_structure: str = "outright",
+    initial_lane_support: str = "supported",
+):
     return {
         "name": name,
         "family": family,
@@ -50,6 +56,40 @@ def test_candidate_planning_is_deterministic():
     assert first[0]["asset"] == "BTC-USD"
     assert first[0]["interval"] == "1h"
     assert first[0]["asset_type"] == "crypto"
+
+
+def test_candidate_planning_preserves_explicit_executable_identity_fields():
+    strategies = [
+        {
+            **_strategy(name="trend_pullback_v1", family="trend", strategy_family="trend"),
+            "hypothesis_id": "trend_pullback_v1",
+            "strategy_template_id": "trend_pullback_v1",
+            "preset_name": "trend_pullback_crypto_1h",
+        }
+    ]
+    assets = [SimpleNamespace(symbol="BTC-USD", asset_type="crypto", asset_class="crypto")]
+
+    planned = plan_candidates(strategies=strategies, assets=assets, intervals=["1h"])
+
+    assert planned[0]["hypothesis_id"] == "trend_pullback_v1"
+    assert planned[0]["executable_hypothesis_id"] == "trend_pullback_v1"
+    assert planned[0]["strategy_template_id"] == "trend_pullback_v1"
+    assert planned[0]["preset_name"] == "trend_pullback_crypto_1h"
+
+
+def test_candidate_planning_does_not_treat_canonical_qre_id_as_executable_identity():
+    strategies = [
+        {
+            **_strategy(name="trend", family="trend", strategy_family="trend"),
+            "hypothesis_id": "qre-hyp-fixture",
+        }
+    ]
+    assets = [SimpleNamespace(symbol="BTC-USD", asset_type="crypto", asset_class="crypto")]
+
+    planned = plan_candidates(strategies=strategies, assets=assets, intervals=["1h"])
+
+    assert planned[0]["hypothesis_id"] == "qre-hyp-fixture"
+    assert "executable_hypothesis_id" not in planned[0]
 
 
 def test_deduplication_is_exact_and_reproducible():
@@ -107,7 +147,13 @@ def test_fit_prior_gating_is_deterministic_and_explicit():
 def test_candidate_sidecar_payloads_include_reduction_counts():
     strategies = [
         _strategy(name="trend", family="trend", strategy_family="trend_following"),
-        _strategy(name="pairs", family="stat_arb", strategy_family="stat_arb", position_structure="spread", initial_lane_support="blocked"),
+        _strategy(
+            name="pairs",
+            family="stat_arb",
+            strategy_family="stat_arb",
+            position_structure="spread",
+            initial_lane_support="blocked",
+        ),
     ]
     assets = [SimpleNamespace(symbol="BTC-USD", asset_type="crypto", asset_class="crypto")]
     planned = plan_candidates(strategies=strategies, assets=assets, intervals=["1h"])

--- a/tests/unit/test_qre_executable_validation_request.py
+++ b/tests/unit/test_qre_executable_validation_request.py
@@ -83,6 +83,40 @@ def _write_readiness(path: Path, readiness_class: str = "hypothesis_ready") -> P
     return path
 
 
+def _write_plans(path: Path, plans: list[dict]) -> Path:
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "report_kind": "qre_hypothesis_validation_plan",
+                "generated_at_utc": FROZEN,
+                "validation_plans": plans,
+                "safe_to_execute": False,
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _write_manifests(path: Path, manifests: list[dict]) -> Path:
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "report_kind": "qre_research_run_manifest",
+                "generated_at_utc": FROZEN,
+                "run_manifests": manifests,
+                "safe_to_execute": False,
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
 def test_ready_request_requires_operator_review_and_has_descriptive_preview(
     tmp_path: Path,
 ) -> None:
@@ -103,6 +137,95 @@ def test_ready_request_requires_operator_review_and_has_descriptive_preview(
     assert row["requires_operator_approval"] is True
     assert snap["counts"]["ready"] == 1
     assert snap["safe_to_execute"] is False
+
+
+def test_ready_request_can_use_exact_plan_and_manifest_artifacts(
+    tmp_path: Path,
+) -> None:
+    source = _write_hypotheses(
+        tmp_path / "hypotheses.json",
+        [_hypothesis(validation_plan_id="", run_manifest_id="")],
+    )
+    readiness = _write_readiness(tmp_path / "readiness.json")
+    plans = _write_plans(
+        tmp_path / "plans.json",
+        [
+            {
+                "hypothesis_id": "qre-hyp-fixture",
+                "validation_plan_id": "qre-plan-fixture",
+            }
+        ],
+    )
+    manifests = _write_manifests(
+        tmp_path / "manifests.json",
+        [
+            {
+                "run_manifest_id": "qre-run-fixture",
+                "target_validation_plan_id": "qre-plan-fixture",
+            }
+        ],
+    )
+
+    snap = req.collect_snapshot(
+        input_artifact_path=source,
+        readiness_artifact_path=readiness,
+        validation_plan_artifact_path=plans,
+        run_manifest_artifact_path=manifests,
+        generated_at_utc=FROZEN,
+        presets=[PresetFixture()],
+    )
+
+    row = snap["validation_requests"][0]
+    assert row["request_status"] == "request_ready_for_operator_review"
+    assert row["validation_plan_id"] == "qre-plan-fixture"
+    assert row["run_manifest_id"] == "qre-run-fixture"
+
+
+def test_ambiguous_plan_artifact_fails_closed(tmp_path: Path) -> None:
+    source = _write_hypotheses(
+        tmp_path / "hypotheses.json",
+        [_hypothesis(validation_plan_id="", run_manifest_id="")],
+    )
+    readiness = _write_readiness(tmp_path / "readiness.json")
+    plans = _write_plans(
+        tmp_path / "plans.json",
+        [
+            {
+                "hypothesis_id": "qre-hyp-fixture",
+                "validation_plan_id": "qre-plan-fixture",
+            },
+            {
+                "hypothesis_id": "qre-hyp-fixture",
+                "validation_plan_id": "qre-plan-fixture-2",
+            },
+        ],
+    )
+    manifests = _write_manifests(
+        tmp_path / "manifests.json",
+        [
+            {
+                "run_manifest_id": "qre-run-fixture",
+                "target_validation_plan_id": "qre-plan-fixture",
+            }
+        ],
+    )
+
+    snap = req.collect_snapshot(
+        input_artifact_path=source,
+        readiness_artifact_path=readiness,
+        validation_plan_artifact_path=plans,
+        run_manifest_artifact_path=manifests,
+        generated_at_utc=FROZEN,
+        presets=[PresetFixture()],
+    )
+
+    row = snap["validation_requests"][0]
+    assert row["request_status"] == "request_blocked_validation_plan_missing"
+    assert row["allowed_command_preview"] is None
+    assert (
+        "ambiguous_validation_plan_id_for_hypothesis_id:qre-hyp-fixture"
+        in (snap["validation_warnings"])
+    )
 
 
 def test_missing_executable_hypothesis_id_blocks_request(tmp_path: Path) -> None:

--- a/tests/unit/test_qre_market_observation_snapshot.py
+++ b/tests/unit/test_qre_market_observation_snapshot.py
@@ -281,6 +281,81 @@ def test_research_latest_input_does_not_infer_strategy_family_or_template(
         assert "executable_hypothesis_id" not in observation
 
 
+def test_candidate_source_input_preserves_explicit_executable_identity_fields(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "run_candidates_latest.v1.json"
+    source.write_text(
+        json.dumps(
+            {
+                "version": "v1",
+                "candidates": [
+                    {
+                        "candidate_id": "candidate-001",
+                        "current_status": "planned",
+                        "strategy_name": "trend_pullback_v1",
+                        "strategy_family": "trend_pullback",
+                        "strategy_template_id": "trend_pullback_v1",
+                        "preset_name": "trend_pullback_crypto_1h",
+                        "asset": "BTC-EUR",
+                        "interval": "1h",
+                        "executable_hypothesis_id": "trend_pullback_v1",
+                        "source_hypothesis_id": "source-trend-pullback",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    snap = market.collect_snapshot(source_path=source, generated_at_utc=FROZEN)
+
+    observation = snap["observations"][0]
+    assert observation["source_artifact"].endswith("run_candidates_latest.v1.json")
+    assert observation["supporting_evidence_refs"] == [
+        f"{observation['source_artifact']}#candidate-001"
+    ]
+    assert observation["asset_scope"] == ["BTC-EUR"]
+    assert observation["timeframe_scope"] == ["1h"]
+    assert observation["executable_hypothesis_id"] == "trend_pullback_v1"
+    assert observation["source_hypothesis_id"] == "source-trend-pullback"
+    assert observation["strategy_family"] == "trend_pullback"
+    assert observation["strategy_template_id"] == "trend_pullback_v1"
+    assert observation["preset_name"] == "trend_pullback_crypto_1h"
+    assert observation["candidate_id"] == "candidate-001"
+
+
+def test_candidate_source_input_does_not_infer_identity_from_alias_fields(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "run_candidates_latest.v1.json"
+    source.write_text(
+        json.dumps(
+            {
+                "version": "v1",
+                "candidates": [
+                    {
+                        "candidate_id": "candidate-001",
+                        "strategy_name": "trend_pullback_v1",
+                        "family": "trend",
+                        "hypothesis_id": "trend_pullback_v1",
+                        "asset": "BTC-EUR",
+                        "interval": "1h",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    snap = market.collect_snapshot(source_path=source, generated_at_utc=FROZEN)
+
+    observation = snap["observations"][0]
+    assert "executable_hypothesis_id" not in observation
+    assert "strategy_template_id" not in observation
+    assert "strategy_family" not in observation
+
+
 def test_explicit_identity_fixture_chain_reaches_hypothesis_bridge_authority(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_qre_validation_request_dry_run_runner.py
+++ b/tests/unit/test_qre_validation_request_dry_run_runner.py
@@ -46,8 +46,8 @@ def _write_requests(path: Path, requests: list) -> Path:
     return path
 
 
-def test_ready_request_with_operator_approval_produces_dry_run_ready(tmp_path: Path) -> None:
-    source = _write_requests(tmp_path / "requests.json", [_request(operator_approved=True)])
+def test_ready_request_produces_non_executing_dry_run_ready(tmp_path: Path) -> None:
+    source = _write_requests(tmp_path / "requests.json", [_request()])
 
     snap = dry_run.collect_snapshot(input_artifact_path=source, generated_at_utc=FROZEN)
 
@@ -61,6 +61,19 @@ def test_ready_request_with_operator_approval_produces_dry_run_ready(tmp_path: P
     assert snap["executed_anything"] is False
 
 
+def test_operator_approval_contract_must_be_visible_for_ready_dry_run(tmp_path: Path) -> None:
+    source = _write_requests(
+        tmp_path / "requests.json",
+        [_request(requires_operator_approval=False)],
+    )
+
+    snap = dry_run.collect_snapshot(input_artifact_path=source, generated_at_utc=FROZEN)
+
+    assert snap["dry_run_results"][0]["dry_run_status"] == (
+        "dry_run_blocked_missing_operator_approval"
+    )
+
+
 def test_request_not_ready_blocks_dry_run(tmp_path: Path) -> None:
     source = _write_requests(
         tmp_path / "requests.json",
@@ -72,20 +85,10 @@ def test_request_not_ready_blocks_dry_run(tmp_path: Path) -> None:
     assert snap["dry_run_results"][0]["dry_run_status"] == ("dry_run_blocked_request_not_ready")
 
 
-def test_missing_operator_approval_blocks_dry_run(tmp_path: Path) -> None:
-    source = _write_requests(tmp_path / "requests.json", [_request()])
-
-    snap = dry_run.collect_snapshot(input_artifact_path=source, generated_at_utc=FROZEN)
-
-    assert snap["dry_run_results"][0]["dry_run_status"] == (
-        "dry_run_blocked_missing_operator_approval"
-    )
-
-
 def test_missing_command_preview_blocks_dry_run(tmp_path: Path) -> None:
     source = _write_requests(
         tmp_path / "requests.json",
-        [_request(operator_approved=True, allowed_command_preview="")],
+        [_request(allowed_command_preview="")],
     )
 
     snap = dry_run.collect_snapshot(input_artifact_path=source, generated_at_utc=FROZEN)

--- a/tests/unit/test_run_candidates_validation_linkage.py
+++ b/tests/unit/test_run_candidates_validation_linkage.py
@@ -230,7 +230,7 @@ def test_ambiguous_executable_bridge_fails_closed_for_run_candidates() -> None:
     assert EXECUTABLE_HYPOTHESIS_ID not in authority["by_executable_hypothesis_id"]
     assert authority["bridge_summary"]["ambiguous_bridge_count"] == 1
     assert row["hypothesis_id"] == EXECUTABLE_HYPOTHESIS_ID
-    assert row["executable_hypothesis_id"] is None
+    assert row["executable_hypothesis_id"] == EXECUTABLE_HYPOTHESIS_ID
     assert row["qre_validation_linkage_status"] == "unlinked_unknown_hypothesis_id"
 
 
@@ -277,6 +277,23 @@ def test_reference_artifacts_missing_do_not_fabricate_ids() -> None:
     assert row["validation_plan_id"] is None
     assert row["run_manifest_id"] is None
     assert row["qre_validation_linkage_status"] == "unlinked_authority_absent"
+
+
+def test_runtime_hypothesis_id_is_preserved_as_executable_identity_without_authority() -> None:
+    row = _row(candidate=_candidate(hypothesis_id=EXECUTABLE_HYPOTHESIS_ID), authority=None)
+
+    assert row["hypothesis_id"] == EXECUTABLE_HYPOTHESIS_ID
+    assert row["executable_hypothesis_id"] == EXECUTABLE_HYPOTHESIS_ID
+    assert row["validation_plan_id"] is None
+    assert row["run_manifest_id"] is None
+    assert row["qre_validation_linkage_status"] == "unlinked_authority_absent"
+
+
+def test_canonical_qre_hypothesis_id_is_not_fabricated_as_executable_identity() -> None:
+    row = _row(candidate=_candidate(hypothesis_id=HYPOTHESIS_ID), authority=None)
+
+    assert row["hypothesis_id"] == HYPOTHESIS_ID
+    assert row["executable_hypothesis_id"] is None
 
 
 def test_missing_hypothesis_authority_fails_closed() -> None:

--- a/tests/unit/test_screening_evidence_validation_linkage.py
+++ b/tests/unit/test_screening_evidence_validation_linkage.py
@@ -200,7 +200,7 @@ def test_ambiguous_executable_bridge_fails_closed_for_screening_evidence() -> No
     assert EXECUTABLE_HYPOTHESIS_ID not in authority["by_executable_hypothesis_id"]
     assert authority["bridge_summary"]["ambiguous_bridge_count"] == 1
     assert row["hypothesis_id"] == EXECUTABLE_HYPOTHESIS_ID
-    assert row["executable_hypothesis_id"] is None
+    assert row["executable_hypothesis_id"] == EXECUTABLE_HYPOTHESIS_ID
     assert row["qre_validation_linkage_status"] == "unlinked_unknown_hypothesis_id"
 
 
@@ -243,6 +243,26 @@ def test_missing_reference_artifacts_do_not_fabricate_plan_or_run_ids() -> None:
     assert row["validation_plan_id"] is None
     assert row["run_manifest_id"] is None
     assert row["qre_validation_linkage_status"] != "linked_exact_ids"
+
+
+def test_runtime_hypothesis_id_is_preserved_as_executable_identity_without_authority() -> None:
+    row = _payload(
+        candidate={"hypothesis_id": EXECUTABLE_HYPOTHESIS_ID},
+        authority=None,
+    )["candidates"][0]
+
+    assert row["hypothesis_id"] == EXECUTABLE_HYPOTHESIS_ID
+    assert row["executable_hypothesis_id"] == EXECUTABLE_HYPOTHESIS_ID
+    assert row["validation_plan_id"] is None
+    assert row["run_manifest_id"] is None
+    assert row["qre_validation_linkage_status"] == "unlinked_reference_authority_unavailable"
+
+
+def test_canonical_qre_hypothesis_id_is_not_fabricated_as_executable_identity() -> None:
+    row = _payload(candidate={"hypothesis_id": HYPOTHESIS_ID}, authority=None)["candidates"][0]
+
+    assert row["hypothesis_id"] == HYPOTHESIS_ID
+    assert row["executable_hypothesis_id"] is None
 
 
 def test_missing_hypothesis_artifact_fails_closed() -> None:


### PR DESCRIPTION
Implements explicit upstream executable hypothesis identity preservation and advances the QRE validation-request route without executing research.\n\nCommits:\n- feat/research: emit explicit executable hypothesis identity from real candidate sources\n- feat/reporting: consume upstream executable identity in QRE market observations\n- feat/reporting: make validation requests ready from explicit executable identity\n- feat/reporting: validate route readiness with dry-run and bridge diagnostics\n\nSafety:\n- no research.run_research invocation\n- no real research execution\n- no strategy/preset/campaign mutation\n- no protected research artifacts changed\n- diagnostics/request/dry-run remain safe_to_execute=false\n\nLocal validation:\n- targeted QRE route/linkage tests passed\n- regression schema pin passed\n- architecture smoke passed\n- smoke tests passed\n- ruff check and format check passed on changed files\n\nLive route note:\nCurrent live artifacts remain stale and still lack executable_hypothesis_id, so readiness/bridge diagnostics remain blocked until controlled artifact regeneration with backups produces identity-rich source artifacts.