### PR TITLE
Add QRE controlled closed-loop E2E layer

### DIFF
--- a/reporting/qre_controlled_artifact_regeneration_backup_plan.py
+++ b/reporting/qre_controlled_artifact_regeneration_backup_plan.py
@@ -1,0 +1,290 @@
+"""Read-only QRE controlled artifact regeneration backup plan."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import hashlib
+import json
+import os
+import tempfile
+from contextlib import suppress
+from pathlib import Path
+from typing import Any, Final
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[int] = 1
+REPORT_KIND: Final[str] = "qre_controlled_artifact_regeneration_backup_plan"
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "qre_controlled_artifact_regeneration_backup_plan"
+OUTPUT_ARTIFACT_RELATIVE_PATH: Final[str] = (
+    "logs/qre_controlled_artifact_regeneration_backup_plan/latest.json"
+)
+ARTIFACT_LATEST: Final[Path] = REPO_ROOT / OUTPUT_ARTIFACT_RELATIVE_PATH
+
+DEFAULT_BACKUP_ROOT_RELATIVE: Final[str] = "logs/qre_controlled_artifact_regeneration/backups"
+
+DEFAULT_ARTIFACT_RELATIVE_PATHS: Final[tuple[str, ...]] = (
+    "research/run_candidates_latest.v1.json",
+    "research/screening_evidence_latest.v1.json",
+    "research/research_latest.json",
+    "research/run_filter_summary_latest.v1.json",
+    "research/run_screening_candidates_latest.v1.json",
+    "research/run_batches_latest.v1.json",
+    "research/run_state.v1.json",
+    "research/run_manifest_latest.v1.json",
+    "logs/qre_market_observations/latest.json",
+    "logs/qre_hypothesis_candidates/latest.json",
+    "logs/qre_hypothesis_validation_plans/latest.json",
+    "logs/qre_research_run_manifest/latest.json",
+    "logs/qre_hypothesis_validation_results/latest.json",
+    "logs/qre_evidence_quality_gate/latest.json",
+    "logs/qre_validated_hypothesis_promotion_intent/latest.json",
+)
+
+BLOCKED_REFERENCE_PATHS: Final[tuple[str, ...]] = (
+    "research/strategy_matrix.csv",
+    "research/presets.py",
+    "agent/backtesting/strategies.py",
+    "registry.py",
+    "logs/qre_shadow/latest.json",
+    "logs/qre_paper/latest.json",
+    "logs/qre_live/latest.json",
+    "logs/qre_broker/latest.json",
+    "logs/qre_risk/latest.json",
+    "logs/qre_execution/latest.json",
+)
+
+PROTECTED_SEGMENTS: Final[frozenset[str]] = frozenset(
+    {
+        "presets",
+        "strategy_matrix.csv",
+        "strategies.py",
+        "registry.py",
+        "shadow",
+        "paper",
+        "live",
+        "broker",
+        "risk",
+        "execution",
+    }
+)
+
+
+def _utcnow() -> str:
+    return _dt.datetime.now(_dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _rel(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(REPO_ROOT.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _bounded_str(value: Any, *, max_len: int = 240) -> str:
+    if value is None or isinstance(value, bool):
+        return ""
+    text = str(value).strip()
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 3].rstrip() + "..."
+
+
+def _sha256(path: Path) -> str | None:
+    if not path.exists() or not path.is_file():
+        return None
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _modified_utc(path: Path) -> str | None:
+    if not path.exists():
+        return None
+    return (
+        _dt.datetime.fromtimestamp(path.stat().st_mtime, _dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _segments(relative_path: str) -> set[str]:
+    path = Path(relative_path)
+    return {part.lower() for part in path.parts}
+
+
+def _classification(relative_path: str) -> str:
+    parts = _segments(relative_path)
+    if "research" in parts and Path(relative_path).name.endswith(".json"):
+        return "allowed_mutable_research_artifact"
+    if "logs" in parts and any(part.startswith("qre_") for part in parts):
+        return "allowed_qre_reporting_artifact"
+    if PROTECTED_SEGMENTS & parts:
+        return "blocked_protected_runtime_or_authority_path"
+    return "blocked_unknown_or_unapproved_path"
+
+
+def _safe_to_backup(relative_path: str) -> bool:
+    return _classification(relative_path).startswith("allowed_")
+
+
+def _backup_target(relative_path: str, *, backup_root: Path) -> Path:
+    return backup_root / relative_path.replace("/", "__")
+
+
+def _restore_preview(relative_path: str, target: Path) -> str:
+    return f"Copy-Item -LiteralPath '{_rel(target)}' -Destination '{relative_path}' -Force"
+
+
+def _artifact_row(relative_path: str, *, backup_root: Path) -> dict[str, Any]:
+    path = REPO_ROOT / relative_path
+    target = _backup_target(relative_path, backup_root=backup_root)
+    exists = path.exists() and path.is_file()
+    safe = _safe_to_backup(relative_path)
+    return {
+        "artifact_path": relative_path,
+        "artifact_exists": exists,
+        "size_bytes": path.stat().st_size if exists else None,
+        "fingerprint_sha256": _sha256(path),
+        "modified_utc": _modified_utc(path),
+        "backup_target_path": _rel(target),
+        "restore_command_preview": _restore_preview(relative_path, target),
+        "protected_path_classification": _classification(relative_path),
+        "safe_to_backup": safe,
+    }
+
+
+def _blocked_row(relative_path: str) -> dict[str, Any]:
+    path = REPO_ROOT / relative_path
+    exists = path.exists() and path.is_file()
+    return {
+        "artifact_path": relative_path,
+        "artifact_exists": exists,
+        "size_bytes": path.stat().st_size if exists else None,
+        "fingerprint_sha256": _sha256(path),
+        "modified_utc": _modified_utc(path),
+        "protected_path_classification": _classification(relative_path),
+        "safe_to_backup": False,
+    }
+
+
+def _final_recommendation(rows: list[dict[str, Any]], blocked: list[dict[str, Any]]) -> str:
+    unsafe = [row for row in rows if row["artifact_exists"] and not row["safe_to_backup"]]
+    blocked_existing = [row for row in blocked if row["artifact_exists"]]
+    if unsafe or blocked_existing:
+        return "backup_plan_ready_with_protected_paths_blocked"
+    if any(row["artifact_exists"] for row in rows):
+        return "backup_plan_ready_for_controlled_regeneration"
+    return "backup_plan_has_no_existing_artifacts_to_copy"
+
+
+def collect_snapshot(
+    *,
+    artifact_relative_paths: tuple[str, ...] | None = None,
+    backup_root: Path | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    generated = generated_at_utc or _utcnow()
+    root = backup_root or (REPO_ROOT / DEFAULT_BACKUP_ROOT_RELATIVE / "<timestamp>")
+    paths = artifact_relative_paths or DEFAULT_ARTIFACT_RELATIVE_PATHS
+    artifacts = [_artifact_row(_bounded_str(path), backup_root=root) for path in paths]
+    blocked_paths = [_blocked_row(path) for path in BLOCKED_REFERENCE_PATHS]
+    warnings = [
+        f"missing_artifact:{row['artifact_path']}"
+        for row in artifacts
+        if row["artifact_exists"] is False
+    ]
+    warnings.extend(
+        f"blocked_existing_path:{row['artifact_path']}"
+        for row in blocked_paths
+        if row["artifact_exists"] is True
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": generated,
+        "safe_to_execute": False,
+        "read_only": True,
+        "artifacts_to_backup": artifacts,
+        "blocked_paths": blocked_paths,
+        "validation_warnings": warnings,
+        "final_recommendation": _final_recommendation(artifacts, blocked_paths),
+        "writes_development_work_queue": False,
+        "writes_seed_jsonl": False,
+        "writes_generated_seed_jsonl": False,
+        "writes_research_action_queue": False,
+        "mutates_campaign_queue": False,
+        "mutates_strategy_or_preset": False,
+        "mutates_paper_shadow_live_runtime": False,
+        "launches_codex": False,
+        "launches_subprocess": False,
+        "eligible_for_direct_execution": False,
+    }
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    if not path.resolve().is_relative_to(ARTIFACT_DIR.resolve()):
+        raise ValueError(f"refusing write outside QRE backup plan dir: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".qre_controlled_artifact_regeneration_backup_plan.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        with suppress(OSError):
+            os.unlink(tmp_name)
+        raise
+
+
+def write_outputs(snapshot: dict[str, Any], *, output_path: Path | None = None) -> Path:
+    target = output_path or ARTIFACT_LATEST
+    _atomic_write_json(target, snapshot)
+    return target
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="reporting.qre_controlled_artifact_regeneration_backup_plan",
+        description="Create a read-only backup plan for controlled QRE artifact regeneration.",
+    )
+    parser.add_argument("--no-write", action="store_true")
+    parser.add_argument("--frozen-utc", default=None)
+    parser.add_argument("--indent", type=int, default=2)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    snapshot = collect_snapshot(generated_at_utc=args.frozen_utc)
+    if not args.no_write:
+        write_outputs(snapshot)
+    print(json.dumps(snapshot, indent=args.indent, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "ARTIFACT_DIR",
+    "ARTIFACT_LATEST",
+    "BLOCKED_REFERENCE_PATHS",
+    "DEFAULT_ARTIFACT_RELATIVE_PATHS",
+    "OUTPUT_ARTIFACT_RELATIVE_PATH",
+    "REPORT_KIND",
+    "SCHEMA_VERSION",
+    "collect_snapshot",
+    "main",
+    "write_outputs",
+]

--- a/reporting/qre_controlled_artifact_regeneration_runner.py
+++ b/reporting/qre_controlled_artifact_regeneration_runner.py
@@ -1,0 +1,349 @@
+"""Controlled QRE artifact regeneration runner with backup support."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import shutil
+import tempfile
+from contextlib import suppress
+from pathlib import Path
+from typing import Any, Final
+
+from reporting import (
+    qre_closed_loop_materialization_runner,
+    qre_executable_hypothesis_identity_bridge_diagnostics,
+    qre_executable_validation_request,
+    qre_market_observation_hypothesis_readiness,
+    qre_validation_request_dry_run_runner,
+)
+from reporting import qre_controlled_artifact_regeneration_backup_plan as backup_plan
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[int] = 1
+REPORT_KIND: Final[str] = "qre_controlled_artifact_regeneration"
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "qre_controlled_artifact_regeneration"
+OUTPUT_ARTIFACT_RELATIVE_PATH: Final[str] = "logs/qre_controlled_artifact_regeneration/latest.json"
+ARTIFACT_LATEST: Final[Path] = REPO_ROOT / OUTPUT_ARTIFACT_RELATIVE_PATH
+BACKUP_ROOT: Final[Path] = ARTIFACT_DIR / "backups"
+
+MODE_DRY_RUN: Final[str] = "dry_run"
+MODE_WRITE_REPORTING_ONLY: Final[str] = "write_reporting_only"
+MODE_ALLOW_RESEARCH_REGENERATION: Final[str] = "allow_research_regeneration"
+MODE_RESTORE_FROM_BACKUP: Final[str] = "restore_from_backup"
+
+
+def _utcnow() -> str:
+    return _dt.datetime.now(_dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _timestamp_dir(generated_at_utc: str) -> str:
+    return generated_at_utc.replace(":", "").replace("-", "").replace("+0000", "Z").replace("Z", "")
+
+
+def _rel(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(REPO_ROOT.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _read_json(path: Path) -> tuple[bool, dict[str, Any] | None]:
+    try:
+        raw = path.read_text(encoding="utf-8-sig")
+    except OSError:
+        return (False, None)
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return (True, None)
+    return (True, parsed if isinstance(parsed, dict) else None)
+
+
+def _counts(payload: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        return {}
+    counts = payload.get("counts")
+    return counts if isinstance(counts, dict) else {}
+
+
+def _route_snapshot(*, generated_at_utc: str) -> dict[str, Any]:
+    readiness = qre_market_observation_hypothesis_readiness.collect_snapshot(
+        generated_at_utc=generated_at_utc
+    )
+    requests = qre_executable_validation_request.collect_snapshot(generated_at_utc=generated_at_utc)
+    dry_run = qre_validation_request_dry_run_runner.collect_snapshot(
+        generated_at_utc=generated_at_utc
+    )
+    bridge = qre_executable_hypothesis_identity_bridge_diagnostics.collect_snapshot(
+        generated_at_utc=generated_at_utc,
+    )
+    return {
+        "hypothesis_readiness": {
+            "final_recommendation": readiness.get("final_recommendation"),
+            "counts": _counts(readiness),
+            "by_readiness_class": readiness.get("by_readiness_class", {}),
+        },
+        "executable_validation_request": {
+            "final_recommendation": requests.get("final_recommendation"),
+            "counts": _counts(requests),
+        },
+        "validation_request_dry_run": {
+            "final_recommendation": dry_run.get("final_recommendation"),
+            "counts": _counts(dry_run),
+            "executed_anything": dry_run.get("executed_anything") is True,
+        },
+        "identity_bridge": {
+            "final_recommendation": bridge.get("final_recommendation"),
+            "regeneration_linkage_expected": (
+                bridge.get("bridge", {}).get("regeneration_linkage_expected") is True
+                if isinstance(bridge.get("bridge"), dict)
+                else False
+            ),
+        },
+    }
+
+
+def _approved_backup_rows(plan_snapshot: dict[str, Any]) -> list[dict[str, Any]]:
+    rows = plan_snapshot.get("artifacts_to_backup")
+    if not isinstance(rows, list):
+        return []
+    return [
+        row
+        for row in rows
+        if isinstance(row, dict)
+        and row.get("safe_to_backup") is True
+        and row.get("artifact_exists") is True
+    ]
+
+
+def _copy_backups(plan_snapshot: dict[str, Any], *, backup_dir: Path) -> list[dict[str, Any]]:
+    backup_dir_resolved = backup_dir.resolve()
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    copied: list[dict[str, Any]] = []
+    for row in _approved_backup_rows(plan_snapshot):
+        relative = str(row.get("artifact_path") or "")
+        source = (REPO_ROOT / relative).resolve()
+        target = (backup_dir / relative.replace("/", "__")).resolve()
+        if not target.is_relative_to(backup_dir_resolved):
+            raise ValueError(f"refusing backup target outside backup dir: {target}")
+        shutil.copy2(source, target)
+        copied.append(
+            {
+                "artifact_path": relative,
+                "backup_path": _rel(target),
+                "restore_command": f"Copy-Item -LiteralPath '{_rel(target)}' -Destination '{relative}' -Force",
+            }
+        )
+    return copied
+
+
+def _restore_instructions_from_backup(backup_dir: Path) -> list[str]:
+    if not backup_dir.exists() or not backup_dir.is_dir():
+        return [f"backup_dir_missing:{backup_dir.as_posix()}"]
+    commands: list[str] = []
+    for item in sorted(backup_dir.glob("*")):
+        if not item.is_file():
+            continue
+        relative = item.name.replace("__", "/")
+        commands.append(f"Copy-Item -LiteralPath '{_rel(item)}' -Destination '{relative}' -Force")
+    return commands
+
+
+def _write_reporting_materialization(generated_at_utc: str) -> dict[str, Any]:
+    snapshot = qre_closed_loop_materialization_runner.collect_snapshot(
+        no_write=False,
+        generated_at_utc=generated_at_utc,
+    )
+    out = qre_closed_loop_materialization_runner.write_outputs(snapshot)
+    return {
+        "executed": True,
+        "artifact_path": _rel(out),
+        "final_recommendation": snapshot.get("final_recommendation"),
+        "counts": _counts(snapshot),
+    }
+
+
+def _final_recommendation(
+    *,
+    mode: str,
+    route_after: dict[str, Any],
+    executed_reporting_materialization: bool,
+) -> str:
+    request_counts = route_after.get("executable_validation_request", {}).get("counts", {})
+    dry_counts = route_after.get("validation_request_dry_run", {}).get("counts", {})
+    ready_requests = request_counts.get("ready", 0) if isinstance(request_counts, dict) else 0
+    dry_ready = dry_counts.get("ready", 0) if isinstance(dry_counts, dict) else 0
+    if mode == MODE_ALLOW_RESEARCH_REGENERATION:
+        return "controlled_regeneration_requires_operator_manual_command"
+    if ready_requests and dry_ready:
+        return "qre_route_ready_for_operator_review_after_reporting_materialization"
+    if executed_reporting_materialization:
+        return "reporting_materialized_but_qre_route_still_blocked"
+    return "dry_run_only_controlled_regeneration_not_executed"
+
+
+def collect_snapshot(
+    *,
+    dry_run: bool = True,
+    write_reporting_only: bool = False,
+    allow_research_regeneration: bool = False,
+    restore_from_backup: Path | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    generated = generated_at_utc or _utcnow()
+    mode = MODE_DRY_RUN
+    if restore_from_backup is not None:
+        mode = MODE_RESTORE_FROM_BACKUP
+    elif allow_research_regeneration:
+        mode = MODE_ALLOW_RESEARCH_REGENERATION
+    elif write_reporting_only:
+        mode = MODE_WRITE_REPORTING_ONLY
+    elif dry_run:
+        mode = MODE_DRY_RUN
+
+    backup_dir = BACKUP_ROOT / _timestamp_dir(generated)
+    plan_snapshot = backup_plan.collect_snapshot(
+        backup_root=backup_dir,
+        generated_at_utc=generated,
+    )
+    route_before = _route_snapshot(generated_at_utc=generated)
+    backups_created: list[dict[str, Any]] = []
+    executed_reporting_materialization: dict[str, Any] = {"executed": False}
+    research_regeneration = {
+        "executed": False,
+        "reason": "research_regeneration_not_requested",
+    }
+    restore_instructions = [
+        str(row.get("restore_command_preview") or "")
+        for row in plan_snapshot.get("artifacts_to_backup", [])
+        if isinstance(row, dict) and row.get("artifact_exists") is True
+    ]
+
+    if mode in {MODE_WRITE_REPORTING_ONLY, MODE_ALLOW_RESEARCH_REGENERATION}:
+        backups_created = _copy_backups(plan_snapshot, backup_dir=backup_dir)
+        restore_instructions = [row["restore_command"] for row in backups_created]
+
+    if mode == MODE_WRITE_REPORTING_ONLY:
+        executed_reporting_materialization = _write_reporting_materialization(generated)
+    elif mode == MODE_ALLOW_RESEARCH_REGENERATION:
+        research_regeneration = {
+            "executed": False,
+            "reason": "no_narrow_safe_research_regeneration_api_identified",
+            "blocked_recommendation": "controlled_regeneration_requires_operator_manual_command",
+        }
+    elif mode == MODE_RESTORE_FROM_BACKUP and restore_from_backup is not None:
+        restore_instructions = _restore_instructions_from_backup(restore_from_backup)
+
+    route_after = _route_snapshot(generated_at_utc=generated)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": generated,
+        "safe_to_execute": False,
+        "mode": mode,
+        "backups_created": backups_created,
+        "backup_dir": _rel(backup_dir) if backups_created else None,
+        "backup_plan": plan_snapshot,
+        "executed_research_regeneration": research_regeneration["executed"],
+        "research_regeneration": research_regeneration,
+        "executed_reporting_materialization": executed_reporting_materialization["executed"],
+        "reporting_materialization": executed_reporting_materialization,
+        "route_before": route_before,
+        "route_after": route_after,
+        "final_recommendation": _final_recommendation(
+            mode=mode,
+            route_after=route_after,
+            executed_reporting_materialization=executed_reporting_materialization["executed"],
+        ),
+        "restore_instructions": restore_instructions,
+        "validation_warnings": plan_snapshot.get("validation_warnings", []),
+        "writes_development_work_queue": False,
+        "writes_seed_jsonl": False,
+        "writes_generated_seed_jsonl": False,
+        "writes_research_action_queue": False,
+        "mutates_campaign_queue": False,
+        "mutates_strategy_or_preset": False,
+        "mutates_paper_shadow_live_runtime": False,
+        "launches_codex": False,
+        "launches_subprocess": False,
+        "eligible_for_direct_execution": False,
+    }
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    if not path.resolve().is_relative_to(ARTIFACT_DIR.resolve()):
+        raise ValueError(f"refusing write outside QRE controlled regeneration dir: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".qre_controlled_artifact_regeneration.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        with suppress(OSError):
+            os.unlink(tmp_name)
+        raise
+
+
+def write_outputs(snapshot: dict[str, Any], *, output_path: Path | None = None) -> Path:
+    target = output_path or ARTIFACT_LATEST
+    _atomic_write_json(target, snapshot)
+    return target
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="reporting.qre_controlled_artifact_regeneration_runner",
+        description="Run controlled QRE artifact regeneration in dry-run or explicit write modes.",
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--write-reporting-only", action="store_true")
+    parser.add_argument("--allow-research-regeneration", action="store_true")
+    parser.add_argument("--restore-from-backup", type=Path, default=None)
+    parser.add_argument("--frozen-utc", default=None)
+    parser.add_argument("--indent", type=int, default=2)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    snapshot = collect_snapshot(
+        dry_run=args.dry_run or not (args.write_reporting_only or args.allow_research_regeneration),
+        write_reporting_only=args.write_reporting_only,
+        allow_research_regeneration=args.allow_research_regeneration,
+        restore_from_backup=args.restore_from_backup,
+        generated_at_utc=args.frozen_utc,
+    )
+    write_outputs(snapshot)
+    print(json.dumps(snapshot, indent=args.indent, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "ARTIFACT_DIR",
+    "ARTIFACT_LATEST",
+    "BACKUP_ROOT",
+    "MODE_ALLOW_RESEARCH_REGENERATION",
+    "MODE_DRY_RUN",
+    "MODE_RESTORE_FROM_BACKUP",
+    "MODE_WRITE_REPORTING_ONLY",
+    "OUTPUT_ARTIFACT_RELATIVE_PATH",
+    "REPORT_KIND",
+    "SCHEMA_VERSION",
+    "collect_snapshot",
+    "main",
+    "write_outputs",
+]

--- a/reporting/qre_operator_closed_loop_report.py
+++ b/reporting/qre_operator_closed_loop_report.py
@@ -1,0 +1,538 @@
+"""Operator-facing QRE closed-loop completion report."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import tempfile
+from contextlib import suppress
+from pathlib import Path
+from typing import Any, Final
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[int] = 1
+REPORT_KIND: Final[str] = "qre_operator_closed_loop_report"
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "qre_operator_closed_loop_report"
+OUTPUT_ARTIFACT_RELATIVE_PATH: Final[str] = "logs/qre_operator_closed_loop_report/latest.json"
+OUTPUT_MARKDOWN_RELATIVE_PATH: Final[str] = "logs/qre_operator_closed_loop_report/latest.md"
+ARTIFACT_LATEST: Final[Path] = REPO_ROOT / OUTPUT_ARTIFACT_RELATIVE_PATH
+MARKDOWN_LATEST: Final[Path] = REPO_ROOT / OUTPUT_MARKDOWN_RELATIVE_PATH
+
+DEFAULT_MARKET_OBSERVATIONS_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_market_observations" / "latest.json"
+)
+DEFAULT_READINESS_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_market_observation_hypothesis_readiness" / "latest.json"
+)
+DEFAULT_VALIDATION_REQUEST_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_executable_validation_request" / "latest.json"
+)
+DEFAULT_DRY_RUN_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_validation_request_dry_run" / "latest.json"
+)
+DEFAULT_CONTROLLED_REGENERATION_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_controlled_artifact_regeneration" / "latest.json"
+)
+DEFAULT_VALIDATION_RESULTS_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_hypothesis_validation_results" / "latest.json"
+)
+DEFAULT_EVIDENCE_QUALITY_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_evidence_quality_gate" / "latest.json"
+)
+DEFAULT_PROMOTION_INTENT_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_validated_hypothesis_promotion_intent" / "latest.json"
+)
+DEFAULT_AUDIT_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_post_run_evidence_promotion_audit" / "latest.json"
+)
+
+LOOP_CLOSED_READY: Final[str] = "loop_closed_ready_for_operator_review"
+LOOP_BLOCKED_IDENTITY: Final[str] = "loop_blocked_identity_missing"
+LOOP_BLOCKED_NO_READY_REQUESTS: Final[str] = "loop_blocked_no_ready_requests"
+LOOP_BLOCKED_NO_VALIDATION_RESULTS: Final[str] = "loop_blocked_no_validation_results"
+LOOP_BLOCKED_EVIDENCE: Final[str] = "loop_blocked_evidence_insufficient"
+LOOP_BLOCKED_PROMOTION: Final[str] = "loop_blocked_promotion_not_ready"
+LOOP_REQUIRES_REGENERATION: Final[str] = "loop_requires_controlled_regeneration"
+
+
+def _utcnow() -> str:
+    return _dt.datetime.now(_dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _rel(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(REPO_ROOT.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _read_json(path: Path) -> tuple[bool, dict[str, Any] | None]:
+    try:
+        raw = path.read_text(encoding="utf-8-sig")
+    except OSError:
+        return (False, None)
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return (True, None)
+    return (True, parsed if isinstance(parsed, dict) else None)
+
+
+def _bounded_str(value: Any, *, max_len: int = 240) -> str:
+    if value is None or isinstance(value, bool):
+        return ""
+    text = str(value).strip()
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 3].rstrip() + "..."
+
+
+def _safe_counts(payload: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        return {}
+    counts = payload.get("counts")
+    return counts if isinstance(counts, dict) else {}
+
+
+def _rows(payload: dict[str, Any] | None, field: str) -> list[dict[str, Any]]:
+    if not isinstance(payload, dict):
+        return []
+    rows = payload.get(field)
+    if not isinstance(rows, list) or not all(isinstance(item, dict) for item in rows):
+        return []
+    return rows
+
+
+def _load(
+    path: Path, *, expected_kind: str, label: str
+) -> tuple[dict[str, Any] | None, dict[str, Any], list[str]]:
+    available, payload = _read_json(path)
+    meta = {"path": _rel(path), "available": available, "valid": False}
+    if payload is None or payload.get("report_kind") != expected_kind:
+        return (None, meta, [f"{label}:missing_or_unparseable"])
+    meta["valid"] = True
+    return (payload, meta, [])
+
+
+def _count_field(payload: dict[str, Any] | None, field: str) -> int:
+    return len(_rows(payload, field))
+
+
+def _loop_status(
+    *,
+    readiness: dict[str, Any] | None,
+    requests: dict[str, Any] | None,
+    dry_run: dict[str, Any] | None,
+    controlled: dict[str, Any] | None,
+    audit: dict[str, Any] | None,
+) -> str:
+    readiness_counts = _safe_counts(readiness)
+    by_readiness = readiness.get("by_readiness_class", {}) if isinstance(readiness, dict) else {}
+    request_counts = _safe_counts(requests)
+    dry_counts = _safe_counts(dry_run)
+    audit_recommendation = _bounded_str(
+        audit.get("final_recommendation") if audit else "", max_len=120
+    )
+    if isinstance(by_readiness, dict) and by_readiness.get("execution_identity_missing", 0):
+        return LOOP_BLOCKED_IDENTITY
+    if audit_recommendation == "identity_route_still_blocked":
+        return LOOP_BLOCKED_IDENTITY
+    if controlled is None:
+        return LOOP_REQUIRES_REGENERATION
+    if request_counts.get("ready", 0) == 0 or dry_counts.get("ready", 0) == 0:
+        return LOOP_BLOCKED_NO_READY_REQUESTS
+    if audit_recommendation == "no_validation_results":
+        return LOOP_BLOCKED_NO_VALIDATION_RESULTS
+    if audit_recommendation in {
+        "validation_results_present_but_insufficient",
+        "evidence_quality_insufficient",
+    }:
+        return LOOP_BLOCKED_EVIDENCE
+    if audit_recommendation == "promotion_not_ready":
+        return LOOP_BLOCKED_PROMOTION
+    if audit_recommendation == "promotion_ready_for_operator_review":
+        return LOOP_CLOSED_READY
+    if readiness_counts.get("hypothesis_ready", 0) == 0:
+        return LOOP_BLOCKED_NO_READY_REQUESTS
+    return LOOP_REQUIRES_REGENERATION
+
+
+def _recommended_actions(loop_status: str, audit: dict[str, Any] | None) -> list[str]:
+    audit_next = _bounded_str(audit.get("next_action") if audit else "", max_len=160)
+    actions = {
+        LOOP_BLOCKED_IDENTITY: ["repair_explicit_executable_identity_before_regeneration"],
+        LOOP_REQUIRES_REGENERATION: [
+            "run_controlled_regeneration_dry_run",
+            "operator_decides_whether_reporting_only_materialization_is_allowed",
+        ],
+        LOOP_BLOCKED_NO_READY_REQUESTS: ["review_qre_validation_request_blockers"],
+        LOOP_BLOCKED_NO_VALIDATION_RESULTS: [
+            "operator_must_provide_or_generate_validation_results"
+        ],
+        LOOP_BLOCKED_EVIDENCE: ["collect_more_evidence_before_promotion_review"],
+        LOOP_BLOCKED_PROMOTION: ["operator_review_or_more_evidence_required_before_promotion"],
+        LOOP_CLOSED_READY: ["operator_review_promotion_intents"],
+    }.get(loop_status, ["operator_review_required"])
+    if audit_next and audit_next not in actions:
+        actions.append(audit_next)
+    return actions
+
+
+def _operator_summary(
+    *,
+    observations: dict[str, Any] | None,
+    readiness: dict[str, Any] | None,
+    requests: dict[str, Any] | None,
+    dry_run: dict[str, Any] | None,
+    controlled: dict[str, Any] | None,
+    results: dict[str, Any] | None,
+    evidence: dict[str, Any] | None,
+    promotion: dict[str, Any] | None,
+    audit: dict[str, Any] | None,
+) -> dict[str, Any]:
+    return {
+        "market_observations": {
+            "count": _count_field(observations, "observations"),
+            "counts": _safe_counts(observations),
+            "final_recommendation": _bounded_str(
+                observations.get("final_recommendation") if observations else "", max_len=160
+            ),
+        },
+        "hypothesis_readiness": {
+            "counts": _safe_counts(readiness),
+            "by_readiness_class": readiness.get("by_readiness_class", {})
+            if isinstance(readiness, dict)
+            else {},
+            "final_recommendation": _bounded_str(
+                readiness.get("final_recommendation") if readiness else "", max_len=160
+            ),
+        },
+        "executable_validation_requests": {
+            "counts": _safe_counts(requests),
+            "final_recommendation": _bounded_str(
+                requests.get("final_recommendation") if requests else "", max_len=160
+            ),
+        },
+        "preset_strategy_eligibility": {
+            "source": "qre_executable_validation_request.eligibility_status",
+            "ready_requests": _safe_counts(requests).get("ready", 0),
+            "blocked_requests": _safe_counts(requests).get("blocked", 0),
+        },
+        "dry_run_plans": {
+            "counts": _safe_counts(dry_run),
+            "executed_anything": dry_run.get("executed_anything") is True
+            if isinstance(dry_run, dict)
+            else False,
+            "final_recommendation": _bounded_str(
+                dry_run.get("final_recommendation") if dry_run else "", max_len=160
+            ),
+        },
+        "controlled_regeneration": {
+            "mode": _bounded_str(controlled.get("mode") if controlled else "", max_len=80),
+            "backups_created_count": len(controlled.get("backups_created", []))
+            if isinstance(controlled, dict)
+            else 0,
+            "executed_research_regeneration": controlled.get("executed_research_regeneration")
+            is True
+            if isinstance(controlled, dict)
+            else False,
+            "executed_reporting_materialization": controlled.get(
+                "executed_reporting_materialization"
+            )
+            is True
+            if isinstance(controlled, dict)
+            else False,
+            "final_recommendation": _bounded_str(
+                controlled.get("final_recommendation") if controlled else "", max_len=160
+            ),
+        },
+        "validation_results": {
+            "count": _count_field(results, "validation_results"),
+            "counts": _safe_counts(results),
+        },
+        "evidence_quality": {
+            "rows": _count_field(evidence, "evidence_quality_rows"),
+            "counts": _safe_counts(evidence),
+        },
+        "promotion_intent": {
+            "rows": _count_field(promotion, "promotion_intents"),
+            "counts": _safe_counts(promotion),
+        },
+        "post_run_audit": {
+            "final_recommendation": _bounded_str(
+                audit.get("final_recommendation") if audit else "", max_len=160
+            ),
+            "next_action": _bounded_str(audit.get("next_action") if audit else "", max_len=160),
+            "blockers": audit.get("blockers", []) if isinstance(audit, dict) else [],
+        },
+    }
+
+
+def collect_snapshot(
+    *,
+    market_observations_path: Path | None = None,
+    readiness_path: Path | None = None,
+    validation_request_path: Path | None = None,
+    dry_run_path: Path | None = None,
+    controlled_regeneration_path: Path | None = None,
+    validation_results_path: Path | None = None,
+    evidence_quality_path: Path | None = None,
+    promotion_intent_path: Path | None = None,
+    audit_path: Path | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    generated = generated_at_utc or _utcnow()
+    observations, meta_a, warnings_a = _load(
+        market_observations_path or DEFAULT_MARKET_OBSERVATIONS_PATH,
+        expected_kind="qre_market_observation_snapshot",
+        label="market_observations",
+    )
+    readiness, meta_b, warnings_b = _load(
+        readiness_path or DEFAULT_READINESS_PATH,
+        expected_kind="qre_market_observation_hypothesis_readiness",
+        label="readiness",
+    )
+    requests, meta_c, warnings_c = _load(
+        validation_request_path or DEFAULT_VALIDATION_REQUEST_PATH,
+        expected_kind="qre_executable_validation_request",
+        label="validation_request",
+    )
+    dry_run, meta_d, warnings_d = _load(
+        dry_run_path or DEFAULT_DRY_RUN_PATH,
+        expected_kind="qre_validation_request_dry_run",
+        label="dry_run",
+    )
+    controlled, meta_e, warnings_e = _load(
+        controlled_regeneration_path or DEFAULT_CONTROLLED_REGENERATION_PATH,
+        expected_kind="qre_controlled_artifact_regeneration",
+        label="controlled_regeneration",
+    )
+    results, meta_f, warnings_f = _load(
+        validation_results_path or DEFAULT_VALIDATION_RESULTS_PATH,
+        expected_kind="qre_hypothesis_validation_results",
+        label="validation_results",
+    )
+    evidence, meta_g, warnings_g = _load(
+        evidence_quality_path or DEFAULT_EVIDENCE_QUALITY_PATH,
+        expected_kind="qre_evidence_quality_gate",
+        label="evidence_quality",
+    )
+    promotion, meta_h, warnings_h = _load(
+        promotion_intent_path or DEFAULT_PROMOTION_INTENT_PATH,
+        expected_kind="qre_validated_hypothesis_promotion_intent",
+        label="promotion_intent",
+    )
+    audit, meta_i, warnings_i = _load(
+        audit_path or DEFAULT_AUDIT_PATH,
+        expected_kind="qre_post_run_evidence_promotion_audit",
+        label="post_run_audit",
+    )
+    status = _loop_status(
+        readiness=readiness,
+        requests=requests,
+        dry_run=dry_run,
+        controlled=controlled,
+        audit=audit,
+    )
+    summary = _operator_summary(
+        observations=observations,
+        readiness=readiness,
+        requests=requests,
+        dry_run=dry_run,
+        controlled=controlled,
+        results=results,
+        evidence=evidence,
+        promotion=promotion,
+        audit=audit,
+    )
+    warnings = (
+        warnings_a
+        + warnings_b
+        + warnings_c
+        + warnings_d
+        + warnings_e
+        + warnings_f
+        + warnings_g
+        + warnings_h
+        + warnings_i
+    )
+    actions = _recommended_actions(status, audit)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": generated,
+        "safe_to_execute": False,
+        "read_only": True,
+        "final_recommendation": status,
+        "loop_status": status,
+        "operator_summary": summary,
+        "recommended_actions": actions,
+        "safety_summary": {
+            "live_paper_shadow_broker_risk_execution_touched": False,
+            "research_regeneration_executed": summary["controlled_regeneration"][
+                "executed_research_regeneration"
+            ],
+            "reporting_materialization_executed": summary["controlled_regeneration"][
+                "executed_reporting_materialization"
+            ],
+            "all_report_safe_to_execute_false": True,
+            "operator_approval_required": True,
+        },
+        "artifact_refs": {
+            "market_observations": meta_a,
+            "hypothesis_readiness": meta_b,
+            "validation_request": meta_c,
+            "dry_run": meta_d,
+            "controlled_regeneration": meta_e,
+            "validation_results": meta_f,
+            "evidence_quality": meta_g,
+            "promotion_intent": meta_h,
+            "post_run_audit": meta_i,
+        },
+        "blockers": summary["post_run_audit"]["blockers"] + warnings,
+        "validation_warnings": warnings,
+        "next_operator_action": actions[0],
+        "writes_development_work_queue": False,
+        "writes_seed_jsonl": False,
+        "writes_generated_seed_jsonl": False,
+        "writes_research_action_queue": False,
+        "mutates_campaign_queue": False,
+        "mutates_strategy_or_preset": False,
+        "mutates_paper_shadow_live_runtime": False,
+        "launches_codex": False,
+        "launches_subprocess": False,
+        "eligible_for_direct_execution": False,
+    }
+
+
+def render_markdown(snapshot: dict[str, Any]) -> str:
+    summary = snapshot.get("operator_summary", {})
+    actions = snapshot.get("recommended_actions", [])
+    blockers = snapshot.get("blockers", [])
+    return "\n".join(
+        [
+            "# QRE Closed-Loop Operator Report",
+            "",
+            f"Generated: {snapshot.get('generated_at_utc')}",
+            f"Loop status: {snapshot.get('loop_status')}",
+            f"Final recommendation: {snapshot.get('final_recommendation')}",
+            "",
+            "## Route Summary",
+            f"- Market observations: {summary.get('market_observations', {}).get('count', 0)}",
+            f"- Ready validation requests: {summary.get('executable_validation_requests', {}).get('counts', {}).get('ready', 0)}",
+            f"- Dry-run ready requests: {summary.get('dry_run_plans', {}).get('counts', {}).get('ready', 0)}",
+            f"- Validation results: {summary.get('validation_results', {}).get('count', 0)}",
+            f"- Evidence quality rows: {summary.get('evidence_quality', {}).get('rows', 0)}",
+            f"- Promotion intents: {summary.get('promotion_intent', {}).get('rows', 0)}",
+            "",
+            "## Safety",
+            "- safe_to_execute=false",
+            "- No live, paper, shadow, broker, risk, or execution path is activated by this report.",
+            "- Operator approval is required before any follow-up.",
+            "",
+            "## Blockers",
+            *[f"- {item}" for item in blockers[:20]],
+            "",
+            "## Next Operator Actions",
+            *[f"- {item}" for item in actions],
+            "",
+        ]
+    )
+
+
+def _atomic_write_text(path: Path, text: str, *, prefix: str) -> None:
+    if not path.resolve().is_relative_to(ARTIFACT_DIR.resolve()):
+        raise ValueError(f"refusing write outside QRE operator report dir: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=prefix, suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        with suppress(OSError):
+            os.unlink(tmp_name)
+        raise
+
+
+def write_outputs(
+    snapshot: dict[str, Any],
+    *,
+    output_path: Path | None = None,
+    markdown_path: Path | None = None,
+) -> Path:
+    json_target = output_path or ARTIFACT_LATEST
+    md_target = markdown_path or MARKDOWN_LATEST
+    _atomic_write_text(
+        json_target,
+        json.dumps(snapshot, indent=2, sort_keys=True) + "\n",
+        prefix=".qre_operator_closed_loop_report.",
+    )
+    _atomic_write_text(
+        md_target,
+        render_markdown(snapshot),
+        prefix=".qre_operator_closed_loop_report_md.",
+    )
+    return json_target
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="reporting.qre_operator_closed_loop_report",
+        description="Build the operator-facing QRE closed-loop report.",
+    )
+    parser.add_argument("--no-write", action="store_true")
+    parser.add_argument("--market-observations-source", type=Path, default=None)
+    parser.add_argument("--readiness-source", type=Path, default=None)
+    parser.add_argument("--validation-request-source", type=Path, default=None)
+    parser.add_argument("--dry-run-source", type=Path, default=None)
+    parser.add_argument("--controlled-regeneration-source", type=Path, default=None)
+    parser.add_argument("--results-source", type=Path, default=None)
+    parser.add_argument("--evidence-quality-source", type=Path, default=None)
+    parser.add_argument("--promotion-intent-source", type=Path, default=None)
+    parser.add_argument("--audit-source", type=Path, default=None)
+    parser.add_argument("--frozen-utc", default=None)
+    parser.add_argument("--indent", type=int, default=2)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    snapshot = collect_snapshot(
+        market_observations_path=args.market_observations_source,
+        readiness_path=args.readiness_source,
+        validation_request_path=args.validation_request_source,
+        dry_run_path=args.dry_run_source,
+        controlled_regeneration_path=args.controlled_regeneration_source,
+        validation_results_path=args.results_source,
+        evidence_quality_path=args.evidence_quality_source,
+        promotion_intent_path=args.promotion_intent_source,
+        audit_path=args.audit_source,
+        generated_at_utc=args.frozen_utc,
+    )
+    if not args.no_write:
+        write_outputs(snapshot)
+    print(json.dumps(snapshot, indent=args.indent, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "ARTIFACT_DIR",
+    "ARTIFACT_LATEST",
+    "MARKDOWN_LATEST",
+    "OUTPUT_ARTIFACT_RELATIVE_PATH",
+    "OUTPUT_MARKDOWN_RELATIVE_PATH",
+    "REPORT_KIND",
+    "SCHEMA_VERSION",
+    "collect_snapshot",
+    "main",
+    "render_markdown",
+    "write_outputs",
+]

--- a/reporting/qre_post_run_evidence_promotion_audit.py
+++ b/reporting/qre_post_run_evidence_promotion_audit.py
@@ -1,0 +1,385 @@
+"""Read-only QRE post-run evidence and promotion audit."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import tempfile
+from collections import Counter
+from contextlib import suppress
+from pathlib import Path
+from typing import Any, Final
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[int] = 1
+REPORT_KIND: Final[str] = "qre_post_run_evidence_promotion_audit"
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "qre_post_run_evidence_promotion_audit"
+OUTPUT_ARTIFACT_RELATIVE_PATH: Final[str] = "logs/qre_post_run_evidence_promotion_audit/latest.json"
+ARTIFACT_LATEST: Final[Path] = REPO_ROOT / OUTPUT_ARTIFACT_RELATIVE_PATH
+
+DEFAULT_RESULTS_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_hypothesis_validation_results" / "latest.json"
+)
+DEFAULT_EVIDENCE_QUALITY_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_evidence_quality_gate" / "latest.json"
+)
+DEFAULT_PROMOTION_INTENT_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_validated_hypothesis_promotion_intent" / "latest.json"
+)
+DEFAULT_REQUEST_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_executable_validation_request" / "latest.json"
+)
+DEFAULT_DRY_RUN_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_validation_request_dry_run" / "latest.json"
+)
+
+CLASS_NO_VALIDATION_RESULTS: Final[str] = "no_validation_results"
+CLASS_RESULTS_INSUFFICIENT: Final[str] = "validation_results_present_but_insufficient"
+CLASS_EVIDENCE_INSUFFICIENT: Final[str] = "evidence_quality_insufficient"
+CLASS_PROMOTION_NOT_READY: Final[str] = "promotion_not_ready"
+CLASS_PROMOTION_READY: Final[str] = "promotion_ready_for_operator_review"
+CLASS_IDENTITY_BLOCKED: Final[str] = "identity_route_still_blocked"
+CLASS_AUDIT_READY: Final[str] = "audit_ready_for_operator_report"
+
+
+def _utcnow() -> str:
+    return _dt.datetime.now(_dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _rel(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(REPO_ROOT.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _read_json(path: Path) -> tuple[bool, dict[str, Any] | None]:
+    try:
+        raw = path.read_text(encoding="utf-8-sig")
+    except OSError:
+        return (False, None)
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return (True, None)
+    return (True, parsed if isinstance(parsed, dict) else None)
+
+
+def _bounded_str(value: Any, *, max_len: int = 240) -> str:
+    if value is None or isinstance(value, bool):
+        return ""
+    text = str(value).strip()
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 3].rstrip() + "..."
+
+
+def _safe_rows(payload: dict[str, Any] | None, field: str) -> list[dict[str, Any]]:
+    if not isinstance(payload, dict):
+        return []
+    rows = payload.get(field)
+    if not isinstance(rows, list) or not all(isinstance(item, dict) for item in rows):
+        return []
+    return rows
+
+
+def _load(
+    path: Path, *, expected_kind: str, field: str, label: str
+) -> tuple[list[dict[str, Any]], dict[str, Any], list[str]]:
+    available, payload = _read_json(path)
+    meta = {"path": _rel(path), "available": available, "valid": False}
+    if payload is None or payload.get("report_kind") != expected_kind:
+        return ([], meta, [f"{label}:missing_or_unparseable"])
+    rows = _safe_rows(payload, field)
+    if field not in payload or not isinstance(payload.get(field), list):
+        return ([], meta, [f"{label}:missing_field"])
+    meta["valid"] = True
+    return (rows, meta, [])
+
+
+def _load_payload(
+    path: Path, *, expected_kind: str, label: str
+) -> tuple[dict[str, Any] | None, dict[str, Any], list[str]]:
+    available, payload = _read_json(path)
+    meta = {"path": _rel(path), "available": available, "valid": False}
+    if payload is None or payload.get("report_kind") != expected_kind:
+        return (None, meta, [f"{label}:missing_or_unparseable"])
+    meta["valid"] = True
+    return (payload, meta, [])
+
+
+def _count(rows: list[dict[str, Any]], field: str, names: tuple[str, ...] = ()) -> dict[str, int]:
+    counter = Counter(_bounded_str(row.get(field), max_len=80) or "missing" for row in rows)
+    if names:
+        return {name: counter.get(name, 0) for name in names}
+    return dict(sorted(counter.items()))
+
+
+def _ids(rows: list[dict[str, Any]], field: str) -> set[str]:
+    return {
+        _bounded_str(row.get(field), max_len=160)
+        for row in rows
+        if _bounded_str(row.get(field), max_len=160)
+    }
+
+
+def _route_blockers(
+    request_payload: dict[str, Any] | None,
+    dry_run_payload: dict[str, Any] | None,
+) -> list[str]:
+    blockers: list[str] = []
+    req_counts = request_payload.get("counts", {}) if isinstance(request_payload, dict) else {}
+    dry_counts = dry_run_payload.get("counts", {}) if isinstance(dry_run_payload, dict) else {}
+    by_request = req_counts.get("by_request_status", {}) if isinstance(req_counts, dict) else {}
+    by_dry = dry_counts.get("by_dry_run_status", {}) if isinstance(dry_counts, dict) else {}
+    if isinstance(by_request, dict) and by_request.get("request_blocked_identity_missing", 0):
+        blockers.append("identity_route_still_blocked")
+    if isinstance(by_request, dict) and by_request.get("request_ready_for_operator_review", 0) == 0:
+        blockers.append("no_requests_ready_for_operator_review")
+    if isinstance(by_dry, dict) and by_dry.get("dry_run_ready", 0) == 0:
+        blockers.append("no_dry_run_ready_requests")
+    return blockers
+
+
+def _backup_comparison(backup_dir: Path | None) -> dict[str, Any]:
+    if backup_dir is None:
+        return {"available": False, "reason": "backup_dir_not_provided"}
+    if not backup_dir.exists() or not backup_dir.is_dir():
+        return {"available": False, "reason": "backup_dir_missing", "backup_dir": _rel(backup_dir)}
+    files = sorted(path for path in backup_dir.glob("*") if path.is_file())
+    return {
+        "available": True,
+        "backup_dir": _rel(backup_dir),
+        "snapshot_files": [_rel(path) for path in files],
+        "snapshot_file_count": len(files),
+    }
+
+
+def _classification(
+    *,
+    validation_results: list[dict[str, Any]],
+    evidence_rows: list[dict[str, Any]],
+    promotion_intents: list[dict[str, Any]],
+    route_blockers: list[str],
+) -> str:
+    if "identity_route_still_blocked" in route_blockers:
+        return CLASS_IDENTITY_BLOCKED
+    if not validation_results:
+        return CLASS_NO_VALIDATION_RESULTS
+    status_counts = _count(validation_results, "status")
+    if status_counts.get("passed", 0) == 0:
+        return CLASS_RESULTS_INSUFFICIENT
+    quality_counts = _count(evidence_rows, "quality_class")
+    if quality_counts.get("usable", 0) == 0 and quality_counts.get("strong", 0) == 0:
+        return CLASS_EVIDENCE_INSUFFICIENT
+    intent_counts = _count(promotion_intents, "intent_status")
+    if intent_counts.get("operator_review_required", 0) > 0:
+        return CLASS_PROMOTION_READY
+    if promotion_intents:
+        return CLASS_PROMOTION_NOT_READY
+    return CLASS_AUDIT_READY
+
+
+def _next_action(classification: str) -> str:
+    return {
+        CLASS_IDENTITY_BLOCKED: "repair_explicit_executable_identity_before_regeneration",
+        CLASS_NO_VALIDATION_RESULTS: "operator_must_provide_or_generate_validation_results",
+        CLASS_RESULTS_INSUFFICIENT: "operator_review_required_for_insufficient_validation_results",
+        CLASS_EVIDENCE_INSUFFICIENT: "collect_more_evidence_before_promotion_review",
+        CLASS_PROMOTION_NOT_READY: "operator_review_or_more_evidence_required_before_promotion",
+        CLASS_PROMOTION_READY: "operator_review_promotion_intents",
+        CLASS_AUDIT_READY: "generate_operator_closed_loop_report",
+    }.get(classification, "operator_review_required")
+
+
+def collect_snapshot(
+    *,
+    validation_results_path: Path | None = None,
+    evidence_quality_path: Path | None = None,
+    promotion_intent_path: Path | None = None,
+    validation_request_path: Path | None = None,
+    dry_run_path: Path | None = None,
+    backup_dir: Path | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    generated = generated_at_utc or _utcnow()
+    results, meta_results, warnings_a = _load(
+        validation_results_path or DEFAULT_RESULTS_PATH,
+        expected_kind="qre_hypothesis_validation_results",
+        field="validation_results",
+        label="validation_results",
+    )
+    evidence, meta_evidence, warnings_b = _load(
+        evidence_quality_path or DEFAULT_EVIDENCE_QUALITY_PATH,
+        expected_kind="qre_evidence_quality_gate",
+        field="evidence_quality_rows",
+        label="evidence_quality",
+    )
+    promotion, meta_promotion, warnings_c = _load(
+        promotion_intent_path or DEFAULT_PROMOTION_INTENT_PATH,
+        expected_kind="qre_validated_hypothesis_promotion_intent",
+        field="promotion_intents",
+        label="promotion_intent",
+    )
+    request_payload, meta_request, warnings_d = _load_payload(
+        validation_request_path or DEFAULT_REQUEST_PATH,
+        expected_kind="qre_executable_validation_request",
+        label="validation_request",
+    )
+    dry_payload, meta_dry, warnings_e = _load_payload(
+        dry_run_path or DEFAULT_DRY_RUN_PATH,
+        expected_kind="qre_validation_request_dry_run",
+        label="dry_run",
+    )
+    route_blockers = _route_blockers(request_payload, dry_payload)
+    classification = _classification(
+        validation_results=results,
+        evidence_rows=evidence,
+        promotion_intents=promotion,
+        route_blockers=route_blockers,
+    )
+    result_ids = _ids(results, "hypothesis_id")
+    evidence_ids = _ids(evidence, "hypothesis_id")
+    promotion_ids = _ids(promotion, "hypothesis_id")
+    blockers = [*route_blockers]
+    if not results:
+        blockers.append(CLASS_NO_VALIDATION_RESULTS)
+    if evidence and not (evidence_ids <= (result_ids | evidence_ids)):
+        blockers.append("evidence_quality_linkage_unparseable")
+    if promotion and not (promotion_ids <= (evidence_ids | result_ids)):
+        blockers.append("promotion_intent_linkage_unparseable")
+    audit_summary = {
+        "validation_results_count": len(results),
+        "validation_status_counts": _count(
+            results, "status", ("passed", "failed", "inconclusive", "missing")
+        ),
+        "evidence_quality_rows": len(evidence),
+        "quality_class_counts": _count(
+            evidence,
+            "quality_class",
+            ("insufficient", "thin", "usable", "strong", "contradictory"),
+        ),
+        "promotion_intent_rows": len(promotion),
+        "promotion_readiness_counts": _count(
+            promotion,
+            "intent_status",
+            ("operator_review_required", "blocked", "not_ready"),
+        ),
+        "link_completeness": {
+            "result_hypothesis_ids": len(result_ids),
+            "evidence_hypothesis_ids": len(evidence_ids),
+            "promotion_hypothesis_ids": len(promotion_ids),
+            "evidence_without_result_ids": sorted(evidence_ids - result_ids)[:20],
+            "promotion_without_evidence_ids": sorted(promotion_ids - evidence_ids)[:20],
+        },
+        "blocked_or_missing_identity_reasons": route_blockers,
+        "before_after_comparison": _backup_comparison(backup_dir),
+    }
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": generated,
+        "safe_to_execute": False,
+        "read_only": True,
+        "input_artifacts": {
+            "validation_results": meta_results,
+            "evidence_quality": meta_evidence,
+            "promotion_intent": meta_promotion,
+            "validation_request": meta_request,
+            "dry_run": meta_dry,
+        },
+        "final_recommendation": classification,
+        "audit_summary": audit_summary,
+        "blockers": sorted(set(blockers)),
+        "next_action": _next_action(classification),
+        "validation_warnings": warnings_a + warnings_b + warnings_c + warnings_d + warnings_e,
+        "writes_development_work_queue": False,
+        "writes_seed_jsonl": False,
+        "writes_generated_seed_jsonl": False,
+        "writes_research_action_queue": False,
+        "mutates_campaign_queue": False,
+        "mutates_strategy_or_preset": False,
+        "mutates_paper_shadow_live_runtime": False,
+        "launches_codex": False,
+        "launches_subprocess": False,
+        "eligible_for_direct_execution": False,
+    }
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    if not path.resolve().is_relative_to(ARTIFACT_DIR.resolve()):
+        raise ValueError(f"refusing write outside QRE post-run audit dir: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".qre_post_run_evidence_promotion_audit.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        with suppress(OSError):
+            os.unlink(tmp_name)
+        raise
+
+
+def write_outputs(snapshot: dict[str, Any], *, output_path: Path | None = None) -> Path:
+    target = output_path or ARTIFACT_LATEST
+    _atomic_write_json(target, snapshot)
+    return target
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="reporting.qre_post_run_evidence_promotion_audit",
+        description="Audit QRE validation evidence and promotion readiness after controlled regeneration.",
+    )
+    parser.add_argument("--no-write", action="store_true")
+    parser.add_argument("--results-source", type=Path, default=None)
+    parser.add_argument("--evidence-quality-source", type=Path, default=None)
+    parser.add_argument("--promotion-intent-source", type=Path, default=None)
+    parser.add_argument("--validation-request-source", type=Path, default=None)
+    parser.add_argument("--dry-run-source", type=Path, default=None)
+    parser.add_argument("--backup-dir", type=Path, default=None)
+    parser.add_argument("--frozen-utc", default=None)
+    parser.add_argument("--indent", type=int, default=2)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    snapshot = collect_snapshot(
+        validation_results_path=args.results_source,
+        evidence_quality_path=args.evidence_quality_source,
+        promotion_intent_path=args.promotion_intent_source,
+        validation_request_path=args.validation_request_source,
+        dry_run_path=args.dry_run_source,
+        backup_dir=args.backup_dir,
+        generated_at_utc=args.frozen_utc,
+    )
+    if not args.no_write:
+        write_outputs(snapshot)
+    print(json.dumps(snapshot, indent=args.indent, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "ARTIFACT_DIR",
+    "ARTIFACT_LATEST",
+    "OUTPUT_ARTIFACT_RELATIVE_PATH",
+    "REPORT_KIND",
+    "SCHEMA_VERSION",
+    "collect_snapshot",
+    "main",
+    "write_outputs",
+]

--- a/scripts/qre_closed_loop_e2e_verify.ps1
+++ b/scripts/qre_closed_loop_e2e_verify.ps1
@@ -1,0 +1,100 @@
+param(
+    [switch]$WriteReportingOnly,
+    [switch]$AllowResearchRegeneration
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+function Invoke-QreCommand {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Title,
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments
+    )
+
+    Write-Host ""
+    Write-Host "=== $Title ==="
+    Write-Host ("python " + ($Arguments -join " "))
+    & python @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "Command failed: python $($Arguments -join ' ')"
+    }
+}
+
+function Read-QreJson {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return $null
+    }
+    return Get-Content -Raw -LiteralPath $Path | ConvertFrom-Json
+}
+
+if ($AllowResearchRegeneration) {
+    Write-Warning "AllowResearchRegeneration was requested. The verifier will only pass the explicit flag to reporting.qre_controlled_artifact_regeneration_runner; it will not call research.run_research directly."
+}
+
+Invoke-QreCommand "Closed-loop materialization dry check" @(
+    "-m", "reporting.qre_closed_loop_materialization_runner", "--no-write", "--indent", "2"
+)
+Invoke-QreCommand "Market observation hypothesis readiness" @(
+    "-m", "reporting.qre_market_observation_hypothesis_readiness"
+)
+Invoke-QreCommand "Executable validation request" @(
+    "-m", "reporting.qre_executable_validation_request"
+)
+Invoke-QreCommand "Validation request dry-run runner" @(
+    "-m", "reporting.qre_validation_request_dry_run_runner"
+)
+Invoke-QreCommand "Executable hypothesis identity bridge diagnostics" @(
+    "-m", "reporting.qre_executable_hypothesis_identity_bridge_diagnostics", "--no-write", "--indent", "2"
+)
+Invoke-QreCommand "Controlled artifact regeneration backup plan" @(
+    "-m", "reporting.qre_controlled_artifact_regeneration_backup_plan"
+)
+
+$runnerArgs = @("-m", "reporting.qre_controlled_artifact_regeneration_runner")
+if ($AllowResearchRegeneration) {
+    $runnerArgs += "--allow-research-regeneration"
+} elseif ($WriteReportingOnly) {
+    $runnerArgs += "--write-reporting-only"
+} else {
+    $runnerArgs += "--dry-run"
+}
+Invoke-QreCommand "Controlled artifact regeneration runner" $runnerArgs
+
+Invoke-QreCommand "Post-run evidence promotion audit" @(
+    "-m", "reporting.qre_post_run_evidence_promotion_audit"
+)
+Invoke-QreCommand "Operator closed-loop report" @(
+    "-m", "reporting.qre_operator_closed_loop_report"
+)
+
+$controlled = Read-QreJson "logs/qre_controlled_artifact_regeneration/latest.json"
+$audit = Read-QreJson "logs/qre_post_run_evidence_promotion_audit/latest.json"
+$operator = Read-QreJson "logs/qre_operator_closed_loop_report/latest.json"
+
+Write-Host ""
+Write-Host "=== QRE Closed-Loop E2E Summary ==="
+if ($operator -ne $null) {
+    Write-Host "loop_status: $($operator.loop_status)"
+    Write-Host "next_operator_action: $($operator.next_operator_action)"
+}
+if ($controlled -ne $null) {
+    Write-Host "controlled_regeneration_mode: $($controlled.mode)"
+    Write-Host "controlled_regeneration_recommendation: $($controlled.final_recommendation)"
+    Write-Host "backups_created_count: $(@($controlled.backups_created).Count)"
+    Write-Host "executed_research_regeneration: $($controlled.executed_research_regeneration)"
+}
+if ($audit -ne $null) {
+    Write-Host "audit_status: $($audit.final_recommendation)"
+    Write-Host "audit_next_action: $($audit.next_action)"
+}
+
+Write-Host ""
+Write-Host "Default verification does not call live, paper, shadow, broker, risk, execution, scheduler, Codex, or research.run_research paths."

--- a/tests/unit/test_qre_closed_loop_e2e_verify_script.py
+++ b/tests/unit/test_qre_closed_loop_e2e_verify_script.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+SCRIPT = Path("scripts/qre_closed_loop_e2e_verify.ps1")
+
+
+def test_qre_closed_loop_e2e_verify_script_exists_and_uses_safe_sequence() -> None:
+    assert SCRIPT.exists()
+    src = SCRIPT.read_text(encoding="utf-8")
+    expected = (
+        "reporting.qre_closed_loop_materialization_runner",
+        "reporting.qre_market_observation_hypothesis_readiness",
+        "reporting.qre_executable_validation_request",
+        "reporting.qre_validation_request_dry_run_runner",
+        "reporting.qre_executable_hypothesis_identity_bridge_diagnostics",
+        "reporting.qre_controlled_artifact_regeneration_backup_plan",
+        "reporting.qre_controlled_artifact_regeneration_runner",
+        "reporting.qre_post_run_evidence_promotion_audit",
+        "reporting.qre_operator_closed_loop_report",
+    )
+    command_block = src[src.index('Invoke-QreCommand "Closed-loop materialization dry check"') :]
+    positions = [command_block.index(item) for item in expected]
+    assert positions == sorted(positions)
+    assert "--dry-run" in src
+    assert "--write-reporting-only" in src
+    assert "--allow-research-regeneration" in src
+    assert "research.run_research directly" in src
+
+
+def test_qre_closed_loop_e2e_verify_script_has_no_direct_runtime_execution_calls() -> None:
+    src = SCRIPT.read_text(encoding="utf-8")
+    forbidden = (
+        "-m research.run_research",
+        "Start-Job",
+        "Start-Process",
+        "gh pr",
+        "git push",
+        "generated_seed.jsonl",
+        "seed.jsonl",
+    )
+    for token in forbidden:
+        assert token not in src, token

--- a/tests/unit/test_qre_controlled_artifact_regeneration_backup_plan.py
+++ b/tests/unit/test_qre_controlled_artifact_regeneration_backup_plan.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from reporting import qre_controlled_artifact_regeneration_backup_plan as plan
+
+FROZEN = "2026-06-01T12:00:00Z"
+
+
+def test_plan_hashes_existing_allowed_artifacts_and_emits_restore_preview(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path
+    artifact = repo / "research" / "run_candidates_latest.v1.json"
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text('{"rows":[]}', encoding="utf-8")
+    monkeypatch.setattr(plan, "REPO_ROOT", repo)
+
+    snap = plan.collect_snapshot(
+        artifact_relative_paths=("research/run_candidates_latest.v1.json",),
+        backup_root=repo / "logs" / "qre_controlled_artifact_regeneration" / "backups" / "x",
+        generated_at_utc=FROZEN,
+    )
+
+    row = snap["artifacts_to_backup"][0]
+    assert row["artifact_exists"] is True
+    assert row["size_bytes"] == len('{"rows":[]}')
+    assert len(row["fingerprint_sha256"]) == 64
+    assert row["backup_target_path"].endswith("research__run_candidates_latest.v1.json")
+    assert "Copy-Item -LiteralPath" in row["restore_command_preview"]
+    assert row["protected_path_classification"] == "allowed_mutable_research_artifact"
+    assert row["safe_to_backup"] is True
+    assert snap["safe_to_execute"] is False
+    assert snap["read_only"] is True
+
+
+def test_missing_artifacts_are_planned_but_warned(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(plan, "REPO_ROOT", tmp_path)
+
+    snap = plan.collect_snapshot(
+        artifact_relative_paths=("research/run_candidates_latest.v1.json",),
+        generated_at_utc=FROZEN,
+    )
+
+    row = snap["artifacts_to_backup"][0]
+    assert row["artifact_exists"] is False
+    assert row["fingerprint_sha256"] is None
+    assert row["safe_to_backup"] is True
+    assert "missing_artifact:research/run_candidates_latest.v1.json" in snap["validation_warnings"]
+
+
+def test_protected_paths_are_reported_but_not_safe_to_backup(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    matrix = tmp_path / "research" / "strategy_matrix.csv"
+    matrix.parent.mkdir(parents=True)
+    matrix.write_text("a,b\n", encoding="utf-8")
+    monkeypatch.setattr(plan, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(plan, "BLOCKED_REFERENCE_PATHS", ("research/strategy_matrix.csv",))
+
+    snap = plan.collect_snapshot(
+        artifact_relative_paths=("research/run_candidates_latest.v1.json",),
+        generated_at_utc=FROZEN,
+    )
+
+    blocked = snap["blocked_paths"][0]
+    assert blocked["artifact_exists"] is True
+    assert blocked["safe_to_backup"] is False
+    assert blocked["protected_path_classification"] == "blocked_protected_runtime_or_authority_path"
+    assert "blocked_existing_path:research/strategy_matrix.csv" in snap["validation_warnings"]
+    assert snap["final_recommendation"] == "backup_plan_ready_with_protected_paths_blocked"
+
+
+def test_write_outputs_only_allows_backup_plan_artifact_dir(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    artifact_dir = tmp_path / "logs" / "qre_controlled_artifact_regeneration_backup_plan"
+    latest = artifact_dir / "latest.json"
+    monkeypatch.setattr(plan, "ARTIFACT_DIR", artifact_dir)
+    monkeypatch.setattr(plan, "ARTIFACT_LATEST", latest)
+
+    snap = plan.collect_snapshot(artifact_relative_paths=(), generated_at_utc=FROZEN)
+
+    assert plan.write_outputs(snap) == latest
+    parsed = json.loads(latest.read_text(encoding="utf-8"))
+    assert parsed["report_kind"] == plan.REPORT_KIND
+    with pytest.raises(ValueError):
+        plan.write_outputs(snap, output_path=tmp_path / "outside.json")
+
+
+def test_cli_no_write_does_not_write_artifact(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    artifact_dir = tmp_path / "logs" / "qre_controlled_artifact_regeneration_backup_plan"
+    latest = artifact_dir / "latest.json"
+    monkeypatch.setattr(plan, "ARTIFACT_DIR", artifact_dir)
+    monkeypatch.setattr(plan, "ARTIFACT_LATEST", latest)
+
+    rc = plan.main(["--no-write", "--frozen-utc", FROZEN, "--indent", "0"])
+
+    assert rc == 0
+    assert latest.exists() is False
+    parsed = json.loads(capsys.readouterr().out)
+    assert parsed["safe_to_execute"] is False
+
+
+def test_source_has_no_runtime_launch_or_mutating_queue_calls() -> None:
+    src = Path(plan.__file__).read_text(encoding="utf-8")
+    forbidden = (
+        "import subprocess",
+        "from subprocess",
+        "subprocess.",
+        "os.system",
+        "os.popen",
+        "shell=True",
+        "research.run_research",
+        "seed.jsonl",
+        "generated_seed.jsonl",
+        "logs/development_work_queue/latest.json",
+        "research/research_action_queue_latest.v1.json",
+        "SequenceMatcher",
+        "difflib",
+        "fuzzy",
+    )
+    for token in forbidden:
+        assert token not in src, token

--- a/tests/unit/test_qre_controlled_artifact_regeneration_runner.py
+++ b/tests/unit/test_qre_controlled_artifact_regeneration_runner.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from reporting import qre_controlled_artifact_regeneration_runner as runner
+
+FROZEN = "2026-06-01T12:00:00Z"
+
+
+def _route(_: str | None = None) -> dict:
+    return {
+        "executable_validation_request": {"counts": {"ready": 0}},
+        "validation_request_dry_run": {"counts": {"ready": 0}},
+    }
+
+
+def _plan(row: dict | None = None) -> dict:
+    return {
+        "report_kind": "qre_controlled_artifact_regeneration_backup_plan",
+        "safe_to_execute": False,
+        "read_only": True,
+        "artifacts_to_backup": [row] if row else [],
+        "blocked_paths": [],
+        "validation_warnings": [],
+        "final_recommendation": "backup_plan_ready_for_controlled_regeneration",
+    }
+
+
+def test_default_dry_run_writes_only_runner_log_when_cli_invoked(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    artifact_dir = tmp_path / "logs" / "qre_controlled_artifact_regeneration"
+    latest = artifact_dir / "latest.json"
+    monkeypatch.setattr(runner, "ARTIFACT_DIR", artifact_dir)
+    monkeypatch.setattr(runner, "ARTIFACT_LATEST", latest)
+    monkeypatch.setattr(runner, "BACKUP_ROOT", artifact_dir / "backups")
+    monkeypatch.setattr(runner, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(runner.backup_plan, "collect_snapshot", lambda **_: _plan())
+    monkeypatch.setattr(runner, "_route_snapshot", lambda **_: _route())
+
+    rc = runner.main(["--frozen-utc", FROZEN, "--indent", "0"])
+
+    assert rc == 0
+    assert latest.exists()
+    assert list((artifact_dir / "backups").glob("*")) == []
+    parsed = json.loads(capsys.readouterr().out)
+    assert parsed["mode"] == runner.MODE_DRY_RUN
+    assert parsed["backups_created"] == []
+    assert parsed["executed_research_regeneration"] is False
+    assert parsed["executed_reporting_materialization"] is False
+
+
+def test_write_mode_uses_backup_plan_and_copies_only_approved_artifacts(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "research" / "run_candidates_latest.v1.json"
+    source.parent.mkdir(parents=True)
+    source.write_text('{"rows":[]}', encoding="utf-8")
+    backup_root = tmp_path / "logs" / "qre_controlled_artifact_regeneration" / "backups"
+    row = {
+        "artifact_path": "research/run_candidates_latest.v1.json",
+        "artifact_exists": True,
+        "safe_to_backup": True,
+        "restore_command_preview": "preview",
+    }
+    monkeypatch.setattr(runner, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(runner, "BACKUP_ROOT", backup_root)
+    monkeypatch.setattr(runner.backup_plan, "collect_snapshot", lambda **_: _plan(row))
+    monkeypatch.setattr(runner, "_route_snapshot", lambda **_: _route())
+    monkeypatch.setattr(
+        runner,
+        "_write_reporting_materialization",
+        lambda generated_at_utc: {"executed": True, "artifact_path": "logs/qre_x/latest.json"},
+    )
+
+    snap = runner.collect_snapshot(
+        dry_run=False,
+        write_reporting_only=True,
+        generated_at_utc=FROZEN,
+    )
+
+    assert snap["mode"] == runner.MODE_WRITE_REPORTING_ONLY
+    assert snap["backup_dir"] is not None
+    assert snap["backups_created"][0]["artifact_path"] == "research/run_candidates_latest.v1.json"
+    assert (backup_root / "20260601T120000" / "research__run_candidates_latest.v1.json").exists()
+    assert snap["executed_reporting_materialization"] is True
+
+
+def test_missing_and_protected_plan_rows_are_not_copied(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    backup_root = tmp_path / "logs" / "qre_controlled_artifact_regeneration" / "backups"
+    missing = {
+        "artifact_path": "research/missing.json",
+        "artifact_exists": False,
+        "safe_to_backup": True,
+    }
+    protected = {
+        "artifact_path": "research/strategy_matrix.csv",
+        "artifact_exists": True,
+        "safe_to_backup": False,
+    }
+    plan_snapshot = _plan()
+    plan_snapshot["artifacts_to_backup"] = [missing, protected]
+    plan_snapshot["blocked_paths"] = [protected]
+    monkeypatch.setattr(runner, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(runner, "BACKUP_ROOT", backup_root)
+    monkeypatch.setattr(runner.backup_plan, "collect_snapshot", lambda **_: plan_snapshot)
+    monkeypatch.setattr(runner, "_route_snapshot", lambda **_: _route())
+    monkeypatch.setattr(
+        runner,
+        "_write_reporting_materialization",
+        lambda generated_at_utc: {"executed": True},
+    )
+
+    snap = runner.collect_snapshot(
+        write_reporting_only=True, dry_run=False, generated_at_utc=FROZEN
+    )
+
+    assert snap["backups_created"] == []
+    assert not list(backup_root.rglob("*.*"))
+
+
+def test_allow_research_regeneration_fails_closed_after_backup(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "research" / "run_candidates_latest.v1.json"
+    source.parent.mkdir(parents=True)
+    source.write_text('{"rows":[]}', encoding="utf-8")
+    row = {
+        "artifact_path": "research/run_candidates_latest.v1.json",
+        "artifact_exists": True,
+        "safe_to_backup": True,
+    }
+    monkeypatch.setattr(runner, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(runner, "BACKUP_ROOT", tmp_path / "backups")
+    monkeypatch.setattr(runner.backup_plan, "collect_snapshot", lambda **_: _plan(row))
+    monkeypatch.setattr(runner, "_route_snapshot", lambda **_: _route())
+
+    snap = runner.collect_snapshot(
+        dry_run=False,
+        allow_research_regeneration=True,
+        generated_at_utc=FROZEN,
+    )
+
+    assert snap["mode"] == runner.MODE_ALLOW_RESEARCH_REGENERATION
+    assert snap["backups_created"]
+    assert snap["executed_research_regeneration"] is False
+    assert (
+        snap["research_regeneration"]["reason"]
+        == "no_narrow_safe_research_regeneration_api_identified"
+    )
+    assert (
+        snap["final_recommendation"] == "controlled_regeneration_requires_operator_manual_command"
+    )
+
+
+def test_restore_from_backup_emits_exact_copy_commands(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    backup_dir = tmp_path / "backups" / "x"
+    backup_dir.mkdir(parents=True)
+    (backup_dir / "research__run_candidates_latest.v1.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(runner, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(runner.backup_plan, "collect_snapshot", lambda **_: _plan())
+    monkeypatch.setattr(runner, "_route_snapshot", lambda **_: _route())
+
+    snap = runner.collect_snapshot(restore_from_backup=backup_dir, generated_at_utc=FROZEN)
+
+    assert snap["mode"] == runner.MODE_RESTORE_FROM_BACKUP
+    assert snap["restore_instructions"] == [
+        "Copy-Item -LiteralPath 'backups/x/research__run_candidates_latest.v1.json' "
+        "-Destination 'research/run_candidates_latest.v1.json' -Force"
+    ]
+
+
+def test_write_outputs_only_allows_runner_artifact_dir(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    artifact_dir = tmp_path / "logs" / "qre_controlled_artifact_regeneration"
+    latest = artifact_dir / "latest.json"
+    monkeypatch.setattr(runner, "ARTIFACT_DIR", artifact_dir)
+    monkeypatch.setattr(runner, "ARTIFACT_LATEST", latest)
+    monkeypatch.setattr(runner.backup_plan, "collect_snapshot", lambda **_: _plan())
+    monkeypatch.setattr(runner, "_route_snapshot", lambda **_: _route())
+    snap = runner.collect_snapshot(generated_at_utc=FROZEN)
+
+    assert runner.write_outputs(snap) == latest
+    with pytest.raises(ValueError):
+        runner.write_outputs(snap, output_path=tmp_path / "outside.json")
+
+
+def test_source_has_no_subprocess_or_direct_research_execution() -> None:
+    src = Path(runner.__file__).read_text(encoding="utf-8")
+    forbidden = (
+        "import subprocess",
+        "from subprocess",
+        "subprocess.",
+        "os.system",
+        "os.popen",
+        "shell=True",
+        "research.run_research",
+        "seed.jsonl",
+        "generated_seed.jsonl",
+        "logs/development_work_queue/latest.json",
+        "research/research_action_queue_latest.v1.json",
+        "SequenceMatcher",
+        "difflib",
+        "fuzzy",
+    )
+    for token in forbidden:
+        assert token not in src, token

--- a/tests/unit/test_qre_operator_closed_loop_report.py
+++ b/tests/unit/test_qre_operator_closed_loop_report.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from reporting import qre_operator_closed_loop_report as report
+
+FROZEN = "2026-06-01T12:00:00Z"
+
+
+def _write(path: Path, payload: dict) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return path
+
+
+def _fixtures(
+    tmp_path: Path,
+    *,
+    identity_blocked: bool = False,
+    audit_status: str = "promotion_ready_for_operator_review",
+) -> dict[str, Path]:
+    ready = 0 if identity_blocked else 1
+    return {
+        "observations": _write(
+            tmp_path / "observations.json",
+            {
+                "report_kind": "qre_market_observation_snapshot",
+                "observations": [{"observation_id": "qre-obs-1"}],
+                "counts": {"total": 1},
+                "safe_to_execute": False,
+            },
+        ),
+        "readiness": _write(
+            tmp_path / "readiness.json",
+            {
+                "report_kind": "qre_market_observation_hypothesis_readiness",
+                "counts": {"hypothesis_ready": ready, "not_ready": 1 - ready},
+                "by_readiness_class": {
+                    "execution_identity_missing": 1 if identity_blocked else 0,
+                    "hypothesis_ready": ready,
+                },
+                "safe_to_execute": False,
+            },
+        ),
+        "request": _write(
+            tmp_path / "request.json",
+            {
+                "report_kind": "qre_executable_validation_request",
+                "counts": {"ready": ready, "blocked": 1 - ready},
+                "validation_requests": [],
+                "safe_to_execute": False,
+            },
+        ),
+        "dry": _write(
+            tmp_path / "dry.json",
+            {
+                "report_kind": "qre_validation_request_dry_run",
+                "counts": {"ready": ready, "blocked": 1 - ready},
+                "dry_run_results": [],
+                "executed_anything": False,
+                "safe_to_execute": False,
+            },
+        ),
+        "controlled": _write(
+            tmp_path / "controlled.json",
+            {
+                "report_kind": "qre_controlled_artifact_regeneration",
+                "mode": "dry_run",
+                "backups_created": [],
+                "executed_research_regeneration": False,
+                "executed_reporting_materialization": False,
+                "final_recommendation": "dry_run_only_controlled_regeneration_not_executed",
+                "safe_to_execute": False,
+            },
+        ),
+        "results": _write(
+            tmp_path / "results.json",
+            {
+                "report_kind": "qre_hypothesis_validation_results",
+                "validation_results": [{"hypothesis_id": "qre-hyp-1", "status": "passed"}],
+                "counts": {"total": 1},
+                "safe_to_execute": False,
+            },
+        ),
+        "evidence": _write(
+            tmp_path / "evidence.json",
+            {
+                "report_kind": "qre_evidence_quality_gate",
+                "evidence_quality_rows": [
+                    {"hypothesis_id": "qre-hyp-1", "quality_class": "usable"}
+                ],
+                "counts": {"total": 1},
+                "safe_to_execute": False,
+            },
+        ),
+        "promotion": _write(
+            tmp_path / "promotion.json",
+            {
+                "report_kind": "qre_validated_hypothesis_promotion_intent",
+                "promotion_intents": [
+                    {"hypothesis_id": "qre-hyp-1", "intent_status": "operator_review_required"}
+                ],
+                "counts": {"total": 1},
+                "safe_to_execute": False,
+            },
+        ),
+        "audit": _write(
+            tmp_path / "audit.json",
+            {
+                "report_kind": "qre_post_run_evidence_promotion_audit",
+                "final_recommendation": audit_status,
+                "next_action": "operator_review_promotion_intents",
+                "blockers": [],
+                "safe_to_execute": False,
+            },
+        ),
+    }
+
+
+def _collect(paths: dict[str, Path]) -> dict:
+    return report.collect_snapshot(
+        market_observations_path=paths["observations"],
+        readiness_path=paths["readiness"],
+        validation_request_path=paths["request"],
+        dry_run_path=paths["dry"],
+        controlled_regeneration_path=paths["controlled"],
+        validation_results_path=paths["results"],
+        evidence_quality_path=paths["evidence"],
+        promotion_intent_path=paths["promotion"],
+        audit_path=paths["audit"],
+        generated_at_utc=FROZEN,
+    )
+
+
+def test_identity_missing_blocks_operator_report_loop_status(tmp_path: Path) -> None:
+    snap = _collect(
+        _fixtures(tmp_path, identity_blocked=True, audit_status="identity_route_still_blocked")
+    )
+
+    assert snap["loop_status"] == "loop_blocked_identity_missing"
+    assert snap["final_recommendation"] == "loop_blocked_identity_missing"
+    assert snap["next_operator_action"] == "repair_explicit_executable_identity_before_regeneration"
+    assert snap["safe_to_execute"] is False
+    assert snap["read_only"] is True
+
+
+def test_loop_closed_ready_for_operator_review_when_audit_promotable(tmp_path: Path) -> None:
+    snap = _collect(_fixtures(tmp_path))
+
+    assert snap["loop_status"] == "loop_closed_ready_for_operator_review"
+    assert snap["operator_summary"]["validation_results"]["count"] == 1
+    assert snap["operator_summary"]["promotion_intent"]["rows"] == 1
+    assert snap["safety_summary"]["live_paper_shadow_broker_risk_execution_touched"] is False
+    assert "operator_review_promotion_intents" in snap["recommended_actions"]
+
+
+def test_missing_controlled_regeneration_report_requires_regeneration(tmp_path: Path) -> None:
+    paths = _fixtures(tmp_path)
+    paths["controlled"] = tmp_path / "missing-controlled.json"
+
+    snap = _collect(paths)
+
+    assert snap["loop_status"] == "loop_requires_controlled_regeneration"
+    assert "controlled_regeneration:missing_or_unparseable" in snap["validation_warnings"]
+
+
+def test_write_outputs_writes_json_and_markdown_inside_artifact_dir(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    artifact_dir = tmp_path / "logs" / "qre_operator_closed_loop_report"
+    latest = artifact_dir / "latest.json"
+    latest_md = artifact_dir / "latest.md"
+    monkeypatch.setattr(report, "ARTIFACT_DIR", artifact_dir)
+    monkeypatch.setattr(report, "ARTIFACT_LATEST", latest)
+    monkeypatch.setattr(report, "MARKDOWN_LATEST", latest_md)
+    snap = _collect(_fixtures(tmp_path))
+
+    assert report.write_outputs(snap) == latest
+    assert latest.exists()
+    assert latest_md.exists()
+    assert "QRE Closed-Loop Operator Report" in latest_md.read_text(encoding="utf-8")
+    with pytest.raises(ValueError):
+        report.write_outputs(snap, output_path=tmp_path / "outside.json")
+
+
+def test_cli_no_write_does_not_write_artifacts(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    artifact_dir = tmp_path / "logs" / "qre_operator_closed_loop_report"
+    monkeypatch.setattr(report, "ARTIFACT_DIR", artifact_dir)
+    monkeypatch.setattr(report, "ARTIFACT_LATEST", artifact_dir / "latest.json")
+    monkeypatch.setattr(report, "MARKDOWN_LATEST", artifact_dir / "latest.md")
+    paths = _fixtures(tmp_path)
+
+    rc = report.main(
+        [
+            "--no-write",
+            "--market-observations-source",
+            str(paths["observations"]),
+            "--readiness-source",
+            str(paths["readiness"]),
+            "--validation-request-source",
+            str(paths["request"]),
+            "--dry-run-source",
+            str(paths["dry"]),
+            "--controlled-regeneration-source",
+            str(paths["controlled"]),
+            "--results-source",
+            str(paths["results"]),
+            "--evidence-quality-source",
+            str(paths["evidence"]),
+            "--promotion-intent-source",
+            str(paths["promotion"]),
+            "--audit-source",
+            str(paths["audit"]),
+            "--frozen-utc",
+            FROZEN,
+            "--indent",
+            "0",
+        ]
+    )
+
+    assert rc == 0
+    assert (artifact_dir / "latest.json").exists() is False
+    assert (artifact_dir / "latest.md").exists() is False
+    parsed = json.loads(capsys.readouterr().out)
+    assert parsed["report_kind"] == report.REPORT_KIND
+
+
+def test_source_has_no_runtime_launch_or_mutating_queue_calls() -> None:
+    src = Path(report.__file__).read_text(encoding="utf-8")
+    forbidden = (
+        "import subprocess",
+        "from subprocess",
+        "subprocess.",
+        "os.system",
+        "os.popen",
+        "shell=True",
+        "research.run_research",
+        "seed.jsonl",
+        "generated_seed.jsonl",
+        "logs/development_work_queue/latest.json",
+        "research/research_action_queue_latest.v1.json",
+        "SequenceMatcher",
+        "difflib",
+        "fuzzy",
+    )
+    for token in forbidden:
+        assert token not in src, token

--- a/tests/unit/test_qre_post_run_evidence_promotion_audit.py
+++ b/tests/unit/test_qre_post_run_evidence_promotion_audit.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from reporting import qre_post_run_evidence_promotion_audit as audit
+
+FROZEN = "2026-06-01T12:00:00Z"
+
+
+def _write(path: Path, payload: dict) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return path
+
+
+def _results(path: Path, rows: list[dict]) -> Path:
+    return _write(
+        path,
+        {
+            "report_kind": "qre_hypothesis_validation_results",
+            "validation_results": rows,
+            "safe_to_execute": False,
+        },
+    )
+
+
+def _evidence(path: Path, rows: list[dict]) -> Path:
+    return _write(
+        path,
+        {
+            "report_kind": "qre_evidence_quality_gate",
+            "evidence_quality_rows": rows,
+            "safe_to_execute": False,
+        },
+    )
+
+
+def _promotion(path: Path, rows: list[dict]) -> Path:
+    return _write(
+        path,
+        {
+            "report_kind": "qre_validated_hypothesis_promotion_intent",
+            "promotion_intents": rows,
+            "safe_to_execute": False,
+        },
+    )
+
+
+def _request(path: Path, ready: int = 0, identity_blocked: int = 0) -> Path:
+    return _write(
+        path,
+        {
+            "report_kind": "qre_executable_validation_request",
+            "counts": {
+                "ready": ready,
+                "by_request_status": {
+                    "request_ready_for_operator_review": ready,
+                    "request_blocked_identity_missing": identity_blocked,
+                },
+            },
+            "validation_requests": [],
+            "safe_to_execute": False,
+        },
+    )
+
+
+def _dry(path: Path, ready: int = 0) -> Path:
+    return _write(
+        path,
+        {
+            "report_kind": "qre_validation_request_dry_run",
+            "counts": {"ready": ready, "by_dry_run_status": {"dry_run_ready": ready}},
+            "dry_run_results": [],
+            "safe_to_execute": False,
+        },
+    )
+
+
+def test_identity_blocked_route_is_classified_before_validation_result_absence(
+    tmp_path: Path,
+) -> None:
+    snap = audit.collect_snapshot(
+        validation_results_path=_results(tmp_path / "results.json", []),
+        evidence_quality_path=_evidence(tmp_path / "evidence.json", []),
+        promotion_intent_path=_promotion(tmp_path / "promotion.json", []),
+        validation_request_path=_request(tmp_path / "request.json", identity_blocked=32),
+        dry_run_path=_dry(tmp_path / "dry.json"),
+        generated_at_utc=FROZEN,
+    )
+
+    assert snap["final_recommendation"] == "identity_route_still_blocked"
+    assert "identity_route_still_blocked" in snap["blockers"]
+    assert snap["audit_summary"]["validation_results_count"] == 0
+    assert snap["next_action"] == "repair_explicit_executable_identity_before_regeneration"
+
+
+def test_no_validation_results_classification_when_route_not_identity_blocked(
+    tmp_path: Path,
+) -> None:
+    snap = audit.collect_snapshot(
+        validation_results_path=_results(tmp_path / "results.json", []),
+        evidence_quality_path=_evidence(tmp_path / "evidence.json", []),
+        promotion_intent_path=_promotion(tmp_path / "promotion.json", []),
+        validation_request_path=_request(tmp_path / "request.json", ready=1),
+        dry_run_path=_dry(tmp_path / "dry.json", ready=1),
+        generated_at_utc=FROZEN,
+    )
+
+    assert snap["final_recommendation"] == "no_validation_results"
+    assert snap["safe_to_execute"] is False
+    assert snap["read_only"] is True
+
+
+def test_promotion_ready_for_operator_review(tmp_path: Path) -> None:
+    hypothesis_id = "qre-hyp-ready"
+    snap = audit.collect_snapshot(
+        validation_results_path=_results(
+            tmp_path / "results.json",
+            [{"hypothesis_id": hypothesis_id, "status": "passed"}],
+        ),
+        evidence_quality_path=_evidence(
+            tmp_path / "evidence.json",
+            [{"hypothesis_id": hypothesis_id, "quality_class": "usable"}],
+        ),
+        promotion_intent_path=_promotion(
+            tmp_path / "promotion.json",
+            [{"hypothesis_id": hypothesis_id, "intent_status": "operator_review_required"}],
+        ),
+        validation_request_path=_request(tmp_path / "request.json", ready=1),
+        dry_run_path=_dry(tmp_path / "dry.json", ready=1),
+        generated_at_utc=FROZEN,
+    )
+
+    assert snap["final_recommendation"] == "promotion_ready_for_operator_review"
+    assert snap["audit_summary"]["validation_status_counts"]["passed"] == 1
+    assert snap["audit_summary"]["quality_class_counts"]["usable"] == 1
+    assert snap["audit_summary"]["promotion_readiness_counts"]["operator_review_required"] == 1
+    assert snap["next_action"] == "operator_review_promotion_intents"
+
+
+def test_backup_comparison_is_included_when_available(tmp_path: Path) -> None:
+    backup_dir = tmp_path / "backup"
+    backup_dir.mkdir()
+    (backup_dir / "research__run_candidates_latest.v1.json").write_text("{}", encoding="utf-8")
+
+    snap = audit.collect_snapshot(
+        validation_results_path=_results(tmp_path / "results.json", []),
+        evidence_quality_path=_evidence(tmp_path / "evidence.json", []),
+        promotion_intent_path=_promotion(tmp_path / "promotion.json", []),
+        validation_request_path=_request(tmp_path / "request.json", ready=1),
+        dry_run_path=_dry(tmp_path / "dry.json", ready=1),
+        backup_dir=backup_dir,
+        generated_at_utc=FROZEN,
+    )
+
+    comparison = snap["audit_summary"]["before_after_comparison"]
+    assert comparison["available"] is True
+    assert comparison["snapshot_file_count"] == 1
+
+
+def test_write_outputs_only_allows_audit_artifact_dir(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    artifact_dir = tmp_path / "logs" / "qre_post_run_evidence_promotion_audit"
+    latest = artifact_dir / "latest.json"
+    monkeypatch.setattr(audit, "ARTIFACT_DIR", artifact_dir)
+    monkeypatch.setattr(audit, "ARTIFACT_LATEST", latest)
+    snap = audit.collect_snapshot(
+        validation_results_path=_results(tmp_path / "results.json", []),
+        evidence_quality_path=_evidence(tmp_path / "evidence.json", []),
+        promotion_intent_path=_promotion(tmp_path / "promotion.json", []),
+        validation_request_path=_request(tmp_path / "request.json", ready=1),
+        dry_run_path=_dry(tmp_path / "dry.json", ready=1),
+        generated_at_utc=FROZEN,
+    )
+
+    assert audit.write_outputs(snap) == latest
+    with pytest.raises(ValueError):
+        audit.write_outputs(snap, output_path=tmp_path / "outside.json")
+
+
+def test_cli_no_write_does_not_write_artifact(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    artifact_dir = tmp_path / "logs" / "qre_post_run_evidence_promotion_audit"
+    latest = artifact_dir / "latest.json"
+    monkeypatch.setattr(audit, "ARTIFACT_DIR", artifact_dir)
+    monkeypatch.setattr(audit, "ARTIFACT_LATEST", latest)
+
+    rc = audit.main(
+        [
+            "--no-write",
+            "--results-source",
+            str(_results(tmp_path / "results.json", [])),
+            "--evidence-quality-source",
+            str(_evidence(tmp_path / "evidence.json", [])),
+            "--promotion-intent-source",
+            str(_promotion(tmp_path / "promotion.json", [])),
+            "--validation-request-source",
+            str(_request(tmp_path / "request.json", ready=1)),
+            "--dry-run-source",
+            str(_dry(tmp_path / "dry.json", ready=1)),
+            "--frozen-utc",
+            FROZEN,
+            "--indent",
+            "0",
+        ]
+    )
+
+    assert rc == 0
+    assert latest.exists() is False
+    parsed = json.loads(capsys.readouterr().out)
+    assert parsed["report_kind"] == audit.REPORT_KIND
+
+
+def test_source_has_no_runtime_launch_or_mutating_queue_calls() -> None:
+    src = Path(audit.__file__).read_text(encoding="utf-8")
+    forbidden = (
+        "import subprocess",
+        "from subprocess",
+        "subprocess.",
+        "os.system",
+        "os.popen",
+        "shell=True",
+        "research.run_research",
+        "seed.jsonl",
+        "generated_seed.jsonl",
+        "logs/development_work_queue/latest.json",
+        "research/research_action_queue_latest.v1.json",
+        "SequenceMatcher",
+        "difflib",
+        "fuzzy",
+    )
+    for token in forbidden:
+        assert token not in src, token


### PR DESCRIPTION
## Summary
- add read-only controlled artifact regeneration backup planning with hashes and restore previews
- add controlled regeneration runner with dry-run default, explicit reporting-only mode, and fail-closed research regeneration mode
- add post-run evidence/promotion audit and operator-facing closed-loop report
- add one-command PowerShell verifier for the non-live QRE route

## Safety
- safe_to_execute=false in new QRE reports
- no live/paper/shadow/broker/risk/execution activation
- no direct research.run_research invocation
- no strategy, preset, campaign, queue, seed, or generated_seed mutation
- default verifier creates no backups and performs no controlled regeneration

## Validation
- python -m pytest tests/unit/test_qre_controlled_artifact_regeneration_backup_plan.py -q
- python -m pytest tests/unit/test_qre_controlled_artifact_regeneration_runner.py -q
- python -m pytest tests/unit/test_qre_post_run_evidence_promotion_audit.py -q
- python -m pytest tests/unit/test_qre_operator_closed_loop_report.py -q
- python -m pytest tests/unit/test_qre_closed_loop_e2e_verify_script.py -q
- existing QRE route tests requested in prompt
- regression/schema, architecture boundary, and smoke checks requested in prompt
- python -m ruff check <changed python files>
- python -m ruff format --check <changed python files>
- powershell -ExecutionPolicy Bypass -File .\scripts\qre_closed_loop_e2e_verify.ps1