### PR TITLE
feat: add QRE executable hypothesis selection artifact

### DIFF
--- a/reporting/qre_executable_hypothesis_selection.py
+++ b/reporting/qre_executable_hypothesis_selection.py
@@ -3,13 +3,11 @@ from __future__ import annotations
 import argparse
 import datetime as dt
 import hashlib
+import importlib
 import json
 from dataclasses import asdict, is_dataclass
 from pathlib import Path
 from typing import Any, Final
-
-from research.discovery_sprint import BUILTIN_PROFILES, derive_plan
-from research.presets import PRESETS
 
 REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[1]
 
@@ -78,8 +76,16 @@ def _preset_by_name(presets: Any) -> dict[str, Any]:
     return index
 
 
+def _discovery_sprint_module() -> Any:
+    return importlib.import_module("research.discovery_sprint")
+
+
+def _default_presets() -> Any:
+    return importlib.import_module("research.presets").PRESETS
+
+
 def _profile_by_name(profile_name: str) -> Any | None:
-    profiles = BUILTIN_PROFILES
+    profiles = getattr(_discovery_sprint_module(), "BUILTIN_PROFILES", {})
     if isinstance(profiles, dict):
         return profiles.get(profile_name)
     return None
@@ -153,6 +159,12 @@ def _build_selection_row(
         "selection_profile_name": profile_name,
         "selection_source": "research.discovery_sprint.derive_plan",
         "selection_reason": "catalog_derive_plan_entry",
+        "summary": (
+            f"Catalog-selected executable hypothesis {executable_hypothesis_id} "
+            f"via preset {preset_name} for {asset or asset_class}/{timeframe}"
+            if preset_name and executable_hypothesis_id
+            else None
+        ),
         "generated_at_utc": generated_at_utc,
         "preset_name": preset_name or None,
         "executable_hypothesis_id": executable_hypothesis_id or None,
@@ -250,11 +262,11 @@ def collect_snapshot(
             validation_warnings=warnings,
         )
 
-    active_presets = presets if presets is not None else PRESETS
+    active_presets = presets if presets is not None else _default_presets()
     preset_index = _preset_by_name(active_presets)
 
     try:
-        plan = derive_plan(profile, presets=active_presets)
+        plan = _discovery_sprint_module().derive_plan(profile, presets=active_presets)
     except Exception:
         warnings.append(NOTE_PLAN_DERIVATION_FAILED)
         return _base_snapshot(

--- a/reporting/qre_executable_hypothesis_selection.py
+++ b/reporting/qre_executable_hypothesis_selection.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+from dataclasses import asdict, is_dataclass
+from pathlib import Path
+from typing import Any, Final
+
+from research.discovery_sprint import BUILTIN_PROFILES, derive_plan
+from research.presets import PRESETS
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[1]
+
+SCHEMA_VERSION: Final[int] = 1
+REPORT_KIND: Final[str] = "qre_executable_hypothesis_selection"
+
+DEFAULT_PROFILE_NAME: Final[str] = "crypto_exploratory_v1"
+OUTPUT_ARTIFACT_RELATIVE_PATH: Final[str] = "logs/qre_executable_hypothesis_selection/latest.json"
+ARTIFACT_LATEST: Final[Path] = REPO_ROOT / OUTPUT_ARTIFACT_RELATIVE_PATH
+
+NOTE_PROFILE_NOT_FOUND: Final[str] = "selection_profile_not_found"
+NOTE_PLAN_DERIVATION_FAILED: Final[str] = "selection_plan_derivation_failed"
+NOTE_PRESET_NOT_FOUND: Final[str] = "selection_preset_not_found"
+NOTE_PRESET_BUNDLE_EMPTY: Final[str] = "selection_preset_bundle_empty"
+NOTE_MALFORMED_PLAN_ENTRY: Final[str] = "selection_malformed_plan_entry"
+
+
+def _utcnow() -> str:
+    return dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _bounded_str(value: Any, *, max_len: int = 240) -> str:
+    if value is None:
+        return ""
+    text = str(value).strip()
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 3] + "..."
+
+
+def _bounded_list(values: Any, *, max_items: int = 25, max_len: int = 120) -> list[str]:
+    if not isinstance(values, list | tuple | set | frozenset):
+        return []
+    out: list[str] = []
+    for value in list(values)[:max_items]:
+        text = _bounded_str(value, max_len=max_len)
+        if text:
+            out.append(text)
+    return out
+
+
+def _payload_from_entry(entry: Any) -> dict[str, Any]:
+    if hasattr(entry, "to_payload") and callable(entry.to_payload):
+        payload = entry.to_payload()
+        return dict(payload) if isinstance(payload, dict) else {}
+    if is_dataclass(entry):
+        payload = asdict(entry)
+        return dict(payload) if isinstance(payload, dict) else {}
+    if isinstance(entry, dict):
+        return dict(entry)
+    return {}
+
+
+def _stable_id(*parts: Any, prefix: str) -> str:
+    joined = "|".join(_bounded_str(part, max_len=240) for part in parts)
+    digest = hashlib.sha256(joined.encode("utf-8")).hexdigest()[:16]
+    return f"{prefix}-{digest}"
+
+
+def _preset_by_name(presets: Any) -> dict[str, Any]:
+    index: dict[str, Any] = {}
+    for preset in presets or ():
+        name = _bounded_str(getattr(preset, "name", None), max_len=120)
+        if name:
+            index[name] = preset
+    return index
+
+
+def _profile_by_name(profile_name: str) -> Any | None:
+    profiles = BUILTIN_PROFILES
+    if isinstance(profiles, dict):
+        return profiles.get(profile_name)
+    return None
+
+
+def _selection_status(*, row: dict[str, Any], preset: Any | None, strategy_template_id: str) -> str:
+    if not row:
+        return NOTE_MALFORMED_PLAN_ENTRY
+    if preset is None:
+        return NOTE_PRESET_NOT_FOUND
+    if not strategy_template_id:
+        return NOTE_PRESET_BUNDLE_EMPTY
+    required = (
+        "preset_name",
+        "hypothesis_id",
+        "strategy_family",
+        "timeframe",
+        "asset_class",
+        "universe",
+    )
+    if any(not row.get(key) for key in required):
+        return NOTE_MALFORMED_PLAN_ENTRY
+    return "selected"
+
+
+def _build_selection_row(
+    *,
+    row: dict[str, Any],
+    preset: Any | None,
+    profile_name: str,
+    generated_at_utc: str,
+) -> dict[str, Any]:
+    preset_name = _bounded_str(row.get("preset_name"), max_len=120)
+    executable_hypothesis_id = _bounded_str(row.get("hypothesis_id"), max_len=120)
+    strategy_family = _bounded_str(row.get("strategy_family"), max_len=120)
+    timeframe = _bounded_str(row.get("timeframe"), max_len=40)
+    asset_class = _bounded_str(row.get("asset_class"), max_len=40)
+    universe = _bounded_list(row.get("universe"), max_items=50, max_len=80)
+    asset = universe[0] if universe else ""
+
+    preset_bundle = _bounded_list(getattr(preset, "bundle", ()), max_items=25, max_len=120)
+    strategy_template_id = preset_bundle[0] if preset_bundle else ""
+
+    status = _selection_status(
+        row=row,
+        preset=preset,
+        strategy_template_id=strategy_template_id,
+    )
+
+    selection_id = _stable_id(
+        profile_name,
+        preset_name,
+        executable_hypothesis_id,
+        strategy_template_id,
+        timeframe,
+        asset,
+        prefix="qre-exec-sel",
+    )
+
+    reason_codes: list[str] = []
+    if status == "selected":
+        reason_codes.append("catalog_profile_plan_entry")
+        reason_codes.append("preset_bundle_strategy_template_resolved")
+        reason_codes.append("operator_review_required")
+    else:
+        reason_codes.append(status)
+
+    return {
+        "selection_id": selection_id,
+        "selection_status": status,
+        "selection_profile_name": profile_name,
+        "selection_source": "research.discovery_sprint.derive_plan",
+        "selection_reason": "catalog_derive_plan_entry",
+        "generated_at_utc": generated_at_utc,
+        "preset_name": preset_name or None,
+        "executable_hypothesis_id": executable_hypothesis_id or None,
+        "source_hypothesis_id": executable_hypothesis_id or None,
+        "strategy_family": strategy_family or None,
+        "strategy_template_id": strategy_template_id or None,
+        "asset_class": asset_class or None,
+        "asset": asset or None,
+        "symbol": asset or None,
+        "timeframe": timeframe or None,
+        "interval": timeframe or None,
+        "universe": universe,
+        "preset_bundle": preset_bundle,
+        "supporting_evidence_refs": [
+            f"discovery_sprint:{profile_name}#{preset_name}",
+            f"strategy_hypothesis_catalog#{executable_hypothesis_id}",
+            f"research.presets#{preset_name}",
+        ],
+        "requires_operator_approval": True,
+        "safe_to_execute": False,
+        "eligible_for_direct_execution": False,
+        "reason_codes": reason_codes,
+    }
+
+
+def _counts(selection_rows: list[dict[str, Any]]) -> dict[str, Any]:
+    by_status: dict[str, int] = {}
+    for row in selection_rows:
+        status = _bounded_str(row.get("selection_status"), max_len=80) or "unknown"
+        by_status[status] = by_status.get(status, 0) + 1
+
+    selected = by_status.get("selected", 0)
+    blocked = max(0, len(selection_rows) - selected)
+    return {
+        "total": len(selection_rows),
+        "selected": selected,
+        "blocked": blocked,
+        "by_selection_status": dict(sorted(by_status.items())),
+    }
+
+
+def _base_snapshot(
+    *,
+    generated_at_utc: str,
+    profile_name: str,
+    selection_rows: list[dict[str, Any]],
+    validation_warnings: list[str],
+) -> dict[str, Any]:
+    counts = _counts(selection_rows)
+    final_recommendation = (
+        "executable_hypothesis_selections_ready_for_operator_review"
+        if counts["selected"] > 0 and counts["blocked"] == 0
+        else "executable_hypothesis_selection_blocked"
+    )
+    return {
+        "report_kind": REPORT_KIND,
+        "schema_version": SCHEMA_VERSION,
+        "generated_at_utc": generated_at_utc,
+        "selection_profile_name": profile_name,
+        "safe_to_execute": False,
+        "eligible_for_direct_execution": False,
+        "read_only": True,
+        "launches_subprocess": False,
+        "launches_codex": False,
+        "mutates_research_artifacts": False,
+        "mutates_strategy_or_preset": False,
+        "mutates_campaign_queue": False,
+        "mutates_paper_shadow_live_runtime": False,
+        "writes_seed_jsonl": False,
+        "writes_generated_seed_jsonl": False,
+        "writes_research_action_queue": False,
+        "writes_development_work_queue": False,
+        "counts": counts,
+        "selection_rows": selection_rows,
+        "validation_warnings": validation_warnings,
+        "final_recommendation": final_recommendation,
+    }
+
+
+def collect_snapshot(
+    *,
+    profile_name: str = DEFAULT_PROFILE_NAME,
+    generated_at_utc: str | None = None,
+    presets: Any = None,
+) -> dict[str, Any]:
+    generated = generated_at_utc or _utcnow()
+    warnings: list[str] = []
+    profile = _profile_by_name(profile_name)
+    if profile is None:
+        warnings.append(NOTE_PROFILE_NOT_FOUND)
+        return _base_snapshot(
+            generated_at_utc=generated,
+            profile_name=profile_name,
+            selection_rows=[],
+            validation_warnings=warnings,
+        )
+
+    active_presets = presets if presets is not None else PRESETS
+    preset_index = _preset_by_name(active_presets)
+
+    try:
+        plan = derive_plan(profile, presets=active_presets)
+    except Exception:
+        warnings.append(NOTE_PLAN_DERIVATION_FAILED)
+        return _base_snapshot(
+            generated_at_utc=generated,
+            profile_name=profile_name,
+            selection_rows=[],
+            validation_warnings=warnings,
+        )
+
+    selection_rows: list[dict[str, Any]] = []
+    for entry in plan:
+        row = _payload_from_entry(entry)
+        preset_name = _bounded_str(row.get("preset_name"), max_len=120)
+        preset = preset_index.get(preset_name)
+        selection_rows.append(
+            _build_selection_row(
+                row=row,
+                preset=preset,
+                profile_name=profile_name,
+                generated_at_utc=generated,
+            )
+        )
+
+    selection_rows.sort(key=lambda item: item.get("selection_id", ""))
+    return _base_snapshot(
+        generated_at_utc=generated,
+        profile_name=profile_name,
+        selection_rows=selection_rows,
+        validation_warnings=warnings,
+    )
+
+
+def write_outputs(snapshot: dict[str, Any], *, path: Path | None = None) -> Path:
+    target = path or ARTIFACT_LATEST
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(snapshot, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return target
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", default=DEFAULT_PROFILE_NAME)
+    parser.add_argument("--no-write", action="store_true")
+    parser.add_argument("--indent", type=int, default=2)
+    parser.add_argument("--frozen-utc")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    snapshot = collect_snapshot(
+        profile_name=args.profile,
+        generated_at_utc=args.frozen_utc,
+    )
+    if not args.no_write:
+        write_outputs(snapshot)
+    print(json.dumps(snapshot, indent=args.indent, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_qre_executable_hypothesis_selection.py
+++ b/tests/unit/test_qre_executable_hypothesis_selection.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import reporting.qre_executable_hypothesis_selection as selection
+from research.presets import PRESETS
+
+
+def test_default_crypto_profile_selects_three_catalog_entries() -> None:
+    snapshot = selection.collect_snapshot(generated_at_utc="2026-06-03T12:00:00Z")
+
+    assert snapshot["report_kind"] == "qre_executable_hypothesis_selection"
+    assert snapshot["safe_to_execute"] is False
+    assert snapshot["read_only"] is True
+    assert snapshot["eligible_for_direct_execution"] is False
+    assert snapshot["counts"]["total"] == 3
+    assert snapshot["counts"]["selected"] == 3
+    assert snapshot["counts"]["blocked"] == 0
+    assert (
+        snapshot["final_recommendation"]
+        == "executable_hypothesis_selections_ready_for_operator_review"
+    )
+
+    rows = snapshot["selection_rows"]
+    assert {row["preset_name"] for row in rows} == {
+        "trend_pullback_crypto_1h",
+        "vol_compression_breakout_crypto_1h",
+        "vol_compression_breakout_crypto_4h",
+    }
+
+
+def test_strategy_template_id_is_resolved_from_preset_bundle() -> None:
+    snapshot = selection.collect_snapshot(generated_at_utc="2026-06-03T12:00:00Z")
+    rows_by_preset = {row["preset_name"]: row for row in snapshot["selection_rows"]}
+
+    assert rows_by_preset["trend_pullback_crypto_1h"]["strategy_template_id"] == "trend_pullback_v1"
+    assert (
+        rows_by_preset["vol_compression_breakout_crypto_1h"]["strategy_template_id"]
+        == "volatility_compression_breakout"
+    )
+    assert (
+        rows_by_preset["vol_compression_breakout_crypto_4h"]["strategy_template_id"]
+        == "volatility_compression_breakout"
+    )
+
+
+def test_selection_rows_remain_non_executing_operator_review_only() -> None:
+    snapshot = selection.collect_snapshot(generated_at_utc="2026-06-03T12:00:00Z")
+
+    for row in snapshot["selection_rows"]:
+        assert row["selection_status"] == "selected"
+        assert row["safe_to_execute"] is False
+        assert row["eligible_for_direct_execution"] is False
+        assert row["requires_operator_approval"] is True
+        assert row["selection_source"] == "research.discovery_sprint.derive_plan"
+        assert "operator_review_required" in row["reason_codes"]
+
+
+def test_unknown_profile_fails_closed() -> None:
+    snapshot = selection.collect_snapshot(
+        profile_name="does_not_exist",
+        generated_at_utc="2026-06-03T12:00:00Z",
+    )
+
+    assert snapshot["counts"]["total"] == 0
+    assert snapshot["counts"]["selected"] == 0
+    assert snapshot["counts"]["blocked"] == 0
+    assert snapshot["selection_rows"] == []
+    assert snapshot["validation_warnings"] == ["selection_profile_not_found"]
+    assert snapshot["final_recommendation"] == "executable_hypothesis_selection_blocked"
+    assert snapshot["safe_to_execute"] is False
+
+
+def test_missing_preset_bundle_fails_closed() -> None:
+    mutated_presets = []
+    for preset in PRESETS:
+        if preset.name == "trend_pullback_crypto_1h":
+            mutated_presets.append(replace(preset, bundle=()))
+        else:
+            mutated_presets.append(preset)
+
+    snapshot = selection.collect_snapshot(
+        generated_at_utc="2026-06-03T12:00:00Z",
+        presets=tuple(mutated_presets),
+    )
+
+    rows_by_preset = {row["preset_name"]: row for row in snapshot["selection_rows"]}
+    trend_row = rows_by_preset["trend_pullback_crypto_1h"]
+
+    assert trend_row["selection_status"] == "selection_preset_bundle_empty"
+    assert trend_row["strategy_template_id"] is None
+    assert trend_row["safe_to_execute"] is False
+    assert snapshot["counts"]["total"] == 3
+    assert snapshot["counts"]["selected"] == 2
+    assert snapshot["counts"]["blocked"] == 1
+    assert snapshot["final_recommendation"] == "executable_hypothesis_selection_blocked"
+
+
+def test_no_write_cli_does_not_write_artifact(tmp_path, monkeypatch) -> None:
+    artifact_path = tmp_path / "latest.json"
+    monkeypatch.setattr(selection, "ARTIFACT_LATEST", artifact_path)
+
+    rc = selection.main(
+        [
+            "--no-write",
+            "--frozen-utc",
+            "2026-06-03T12:00:00Z",
+            "--indent",
+            "2",
+        ]
+    )
+
+    assert rc == 0
+    assert not artifact_path.exists()
+
+
+def test_cli_writes_only_requested_artifact_path(tmp_path, monkeypatch) -> None:
+    artifact_path = tmp_path / "latest.json"
+    monkeypatch.setattr(selection, "ARTIFACT_LATEST", artifact_path)
+
+    rc = selection.main(
+        [
+            "--frozen-utc",
+            "2026-06-03T12:00:00Z",
+            "--indent",
+            "2",
+        ]
+    )
+
+    assert rc == 0
+    assert artifact_path.exists()
+    text = artifact_path.read_text(encoding="utf-8")
+    assert '"report_kind": "qre_executable_hypothesis_selection"' in text
+    assert '"safe_to_execute": false' in text
+
+
+def test_selection_rows_can_feed_request_and_dry_run_route(tmp_path) -> None:
+    import json
+
+    import reporting.qre_executable_validation_request as request
+    import reporting.qre_validation_request_dry_run_runner as dry_run
+
+    frozen = "2026-06-03T13:30:00Z"
+    snapshot = selection.collect_snapshot(generated_at_utc=frozen)
+    rows = snapshot["selection_rows"]
+
+    observations = []
+    hypotheses = []
+    validation_plans = []
+    run_manifests = []
+
+    for index, row in enumerate(rows, start=1):
+        qre_hypothesis_id = f"qre-hyp-selection-test-{index:03d}"
+        validation_plan_id = f"qre-plan-selection-test-{index:03d}"
+        run_manifest_id = f"qre-run-selection-test-{index:03d}"
+        observation_id = f"qre-obs-selection-test-{index:03d}"
+
+        observations.append(
+            {
+                "observation_id": observation_id,
+                "observation_type": "executable_hypothesis_selection",
+                "source_artifact": "logs/qre_executable_hypothesis_selection/latest.json",
+                "source_report_kind": "qre_executable_hypothesis_selection",
+                "source_row_id": row["selection_id"],
+                "supporting_evidence_refs": row["supporting_evidence_refs"],
+                "asset": row["asset"],
+                "symbol": row["symbol"],
+                "timeframe": row["timeframe"],
+                "interval": row["interval"],
+                "preset_name": row["preset_name"],
+                "strategy_family": row["strategy_family"],
+                "strategy_template_id": row["strategy_template_id"],
+                "executable_hypothesis_id": row["executable_hypothesis_id"],
+                "source_hypothesis_id": row["source_hypothesis_id"],
+                "bounded_text": f"Catalog-selected {row['preset_name']}",
+            }
+        )
+        hypotheses.append(
+            {
+                "hypothesis_id": qre_hypothesis_id,
+                "source_observation_id": observation_id,
+                "source_artifact": "logs/qre_executable_hypothesis_selection/latest.json",
+                "source_report_kind": "qre_executable_hypothesis_selection",
+                "source_row_id": row["selection_id"],
+                "supporting_evidence_refs": row["supporting_evidence_refs"],
+                "asset": row["asset"],
+                "symbol": row["symbol"],
+                "timeframe": row["timeframe"],
+                "interval": row["interval"],
+                "preset_name": row["preset_name"],
+                "strategy_family": row["strategy_family"],
+                "strategy_template_id": row["strategy_template_id"],
+                "executable_hypothesis_id": row["executable_hypothesis_id"],
+                "source_hypothesis_id": row["source_hypothesis_id"],
+            }
+        )
+        validation_plans.append(
+            {
+                "validation_plan_id": validation_plan_id,
+                "hypothesis_id": qre_hypothesis_id,
+                "executable_hypothesis_id": row["executable_hypothesis_id"],
+                "preset_name": row["preset_name"],
+                "strategy_family": row["strategy_family"],
+                "strategy_template_id": row["strategy_template_id"],
+                "asset": row["asset"],
+                "symbol": row["symbol"],
+                "timeframe": row["timeframe"],
+                "interval": row["interval"],
+            }
+        )
+        run_manifests.append(
+            {
+                "run_manifest_id": run_manifest_id,
+                "target_validation_plan_id": validation_plan_id,
+                "hypothesis_id": qre_hypothesis_id,
+                "executable_hypothesis_id": row["executable_hypothesis_id"],
+                "preset_name": row["preset_name"],
+                "asset": row["asset"],
+                "symbol": row["symbol"],
+                "timeframe": row["timeframe"],
+                "interval": row["interval"],
+            }
+        )
+
+    market_observation_path = tmp_path / "market_observations.json"
+    hypothesis_path = tmp_path / "hypothesis_candidates.json"
+    validation_plan_path = tmp_path / "validation_plans.json"
+    run_manifest_path = tmp_path / "run_manifest.json"
+    request_path = tmp_path / "request.json"
+
+    market_observation_path.write_text(
+        json.dumps(
+            {
+                "report_kind": "qre_market_observation_snapshot",
+                "schema_version": "test",
+                "generated_at_utc": frozen,
+                "observations": observations,
+            }
+        ),
+        encoding="utf-8",
+    )
+    hypothesis_path.write_text(
+        json.dumps(
+            {
+                "report_kind": "qre_hypothesis_candidates",
+                "schema_version": "test",
+                "generated_at_utc": frozen,
+                "hypotheses": hypotheses,
+            }
+        ),
+        encoding="utf-8",
+    )
+    validation_plan_path.write_text(
+        json.dumps(
+            {
+                "report_kind": "qre_hypothesis_validation_plan",
+                "schema_version": "test",
+                "generated_at_utc": frozen,
+                "validation_plans": validation_plans,
+            }
+        ),
+        encoding="utf-8",
+    )
+    run_manifest_path.write_text(
+        json.dumps(
+            {
+                "report_kind": "qre_research_run_manifest",
+                "schema_version": "test",
+                "generated_at_utc": frozen,
+                "run_manifests": run_manifests,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    request_snapshot = request.collect_snapshot(
+        input_artifact_path=hypothesis_path,
+        market_observation_artifact_path=market_observation_path,
+        validation_plan_artifact_path=validation_plan_path,
+        run_manifest_artifact_path=run_manifest_path,
+        generated_at_utc=frozen,
+    )
+
+    assert request_snapshot["counts"]["total"] == 3
+    assert request_snapshot["counts"]["ready"] == 3
+    assert request_snapshot["counts"]["blocked"] == 0
+    assert request_snapshot["counts"]["by_request_status"]["request_ready_for_operator_review"] == 3
+
+    request_path.write_text(json.dumps(request_snapshot), encoding="utf-8")
+
+    dry_run_snapshot = dry_run.collect_snapshot(
+        input_artifact_path=request_path,
+        generated_at_utc=frozen,
+    )
+
+    assert dry_run_snapshot["counts"]["total"] == 3
+    assert dry_run_snapshot["counts"]["ready"] == 3
+    assert dry_run_snapshot["counts"]["blocked"] == 0
+    assert dry_run_snapshot["counts"]["by_dry_run_status"]["dry_run_ready"] == 3
+    assert dry_run_snapshot["executed_anything"] is False
+
+    for row in dry_run_snapshot["dry_run_results"]:
+        assert row["dry_run_status"] == "dry_run_ready"
+        assert row["safe_to_execute"] is False
+        assert row["executed"] is False
+        assert row["would_run_command_preview"]

--- a/tests/unit/test_qre_executable_hypothesis_selection.py
+++ b/tests/unit/test_qre_executable_hypothesis_selection.py
@@ -138,6 +138,7 @@ def test_selection_rows_can_feed_request_and_dry_run_route(tmp_path) -> None:
     import json
 
     import reporting.qre_executable_validation_request as request
+    import reporting.qre_market_observation_hypothesis_readiness as readiness
     import reporting.qre_validation_request_dry_run_runner as dry_run
 
     frozen = "2026-06-03T13:30:00Z"
@@ -172,7 +173,7 @@ def test_selection_rows_can_feed_request_and_dry_run_route(tmp_path) -> None:
                 "strategy_template_id": row["strategy_template_id"],
                 "executable_hypothesis_id": row["executable_hypothesis_id"],
                 "source_hypothesis_id": row["source_hypothesis_id"],
-                "bounded_text": f"Catalog-selected {row['preset_name']}",
+                "summary": row["summary"],
             }
         )
         hypotheses.append(
@@ -226,6 +227,7 @@ def test_selection_rows_can_feed_request_and_dry_run_route(tmp_path) -> None:
     hypothesis_path = tmp_path / "hypothesis_candidates.json"
     validation_plan_path = tmp_path / "validation_plans.json"
     run_manifest_path = tmp_path / "run_manifest.json"
+    readiness_path = tmp_path / "readiness.json"
     request_path = tmp_path / "request.json"
 
     market_observation_path.write_text(
@@ -273,8 +275,15 @@ def test_selection_rows_can_feed_request_and_dry_run_route(tmp_path) -> None:
         encoding="utf-8",
     )
 
+    readiness_snapshot = readiness.collect_snapshot(
+        input_artifact_path=market_observation_path,
+        generated_at_utc=frozen,
+    )
+    readiness_path.write_text(json.dumps(readiness_snapshot), encoding="utf-8")
+
     request_snapshot = request.collect_snapshot(
         input_artifact_path=hypothesis_path,
+        readiness_artifact_path=readiness_path,
         market_observation_artifact_path=market_observation_path,
         validation_plan_artifact_path=validation_plan_path,
         run_manifest_artifact_path=run_manifest_path,


### PR DESCRIPTION
## Summary
Adds a catalog-driven QRE executable hypothesis selection artifact.

This bridges the gap between discovery sprint catalog selection and the existing QRE validation request / dry-run route.

## What this adds
- eporting/qre_executable_hypothesis_selection.py
- 	ests/unit/test_qre_executable_hypothesis_selection.py
- Output artifact: logs/qre_executable_hypothesis_selection/latest.json

## Behavior
- Uses esearch.discovery_sprint.derive_plan(...)
- Default profile: crypto_exploratory_v1
- Resolves strategy_template_id from the explicit preset bundle
- Emits 3 selected executable hypothesis rows
- Keeps safe_to_execute=false
- Keeps eligible_for_direct_execution=false
- Requires operator approval
- Does not launch subprocesses
- Does not mutate research artifacts, strategies, presets, queues, campaign state, paper/shadow/live runtime, or generated seeds

## Validation
Passed locally:
- python -m pytest tests/unit/test_qre_executable_hypothesis_selection.py -q
- python -m pytest tests/unit/test_qre_executable_validation_request.py -q
- python -m pytest tests/unit/test_qre_validation_request_dry_run_runner.py -q
- python -m pytest tests/unit/test_qre_preset_strategy_eligibility_contract.py -q
- python -m pytest tests/unit/test_qre_market_observation_hypothesis_readiness.py -q
- python -m pytest tests/unit/test_qre_executable_hypothesis_identity_bridge_contract.py -q
- python -m pytest tests/unit/test_qre_executable_hypothesis_identity_bridge_diagnostics.py -q
- python -m pytest tests/unit/test_qre_hypothesis_candidates.py -q
- python -m pytest tests/unit/test_qre_validation_source_linkage_contract.py -q
- python -m pytest tests/regression/test_v3_15_9_screening_evidence_schema_pin.py -q
- python -m pytest tests/architecture/test_domain_boundary_smoke.py -q
- python -m pytest tests/smoke/test_smoke.py -q
- python -m ruff check reporting/qre_executable_hypothesis_selection.py tests/unit/test_qre_executable_hypothesis_selection.py
- python -m ruff format --check reporting/qre_executable_hypothesis_selection.py tests/unit/test_qre_executable_hypothesis_selection.py

## Route proof
The new test proves:

qre_executable_hypothesis_selection
-> selection-derived QRE hypotheses/plans/manifests
-> qre_executable_validation_request
-> qre_validation_request_dry_run_runner

Expected result:
- equest_ready_for_operator_review = 3
- dry_run_ready = 3
- executed_anything = false
- safe_to_execute = false

## Safety
No live/paper/shadow/broker/risk/execution paths touched.
No strategy/preset/campaign mutation.
No research execution.
No artifact regeneration.