### PR TITLE
feat: add QRE selection closed-loop E2E route

### DIFF
--- a/reporting/qre_operator_closed_loop_report.py
+++ b/reporting/qre_operator_closed_loop_report.py
@@ -48,6 +48,12 @@ DEFAULT_PROMOTION_INTENT_PATH: Final[Path] = (
 DEFAULT_AUDIT_PATH: Final[Path] = (
     REPO_ROOT / "logs" / "qre_post_run_evidence_promotion_audit" / "latest.json"
 )
+DEFAULT_SELECTION_ROUTE_VALIDATION_FLOW_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_selection_route_validation_flow" / "latest.json"
+)
+DEFAULT_SELECTION_CLOSED_LOOP_PREFLIGHT_PATH: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_selection_closed_loop_preflight" / "latest.json"
+)
 
 LOOP_CLOSED_READY: Final[str] = "loop_closed_ready_for_operator_review"
 LOOP_BLOCKED_IDENTITY: Final[str] = "loop_blocked_identity_missing"
@@ -192,6 +198,8 @@ def _operator_summary(
     evidence: dict[str, Any] | None,
     promotion: dict[str, Any] | None,
     audit: dict[str, Any] | None,
+    selection_route_validation_flow: dict[str, Any] | None = None,
+    selection_closed_loop_preflight: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     return {
         "market_observations": {
@@ -261,6 +269,10 @@ def _operator_summary(
             "rows": _count_field(promotion, "promotion_intents"),
             "counts": _safe_counts(promotion),
         },
+        "selection_route": _selection_route_summary(
+            selection_route_validation_flow,
+            selection_closed_loop_preflight,
+        ),
         "post_run_audit": {
             "final_recommendation": _bounded_str(
                 audit.get("final_recommendation") if audit else "", max_len=160
@@ -268,6 +280,58 @@ def _operator_summary(
             "next_action": _bounded_str(audit.get("next_action") if audit else "", max_len=160),
             "blockers": audit.get("blockers", []) if isinstance(audit, dict) else [],
         },
+    }
+
+
+def _selection_route_summary(
+    selection_route_validation_flow: dict[str, Any] | None,
+    selection_closed_loop_preflight: dict[str, Any] | None,
+) -> dict[str, Any]:
+    flow_counts = (
+        selection_route_validation_flow.get("counts", {})
+        if isinstance(selection_route_validation_flow, dict)
+        else {}
+    )
+    preflight_route = (
+        selection_closed_loop_preflight.get("selection_route", {})
+        if isinstance(selection_closed_loop_preflight, dict)
+        else {}
+    )
+    preflight_gate = (
+        selection_closed_loop_preflight.get("controlled_regeneration_preflight", {})
+        if isinstance(selection_closed_loop_preflight, dict)
+        else {}
+    )
+
+    request_ready = int(flow_counts.get("request_ready_for_operator_review", 0) or 0)
+    dry_run_ready = int(flow_counts.get("dry_run_ready", 0) or 0)
+    route_ready = bool(preflight_route.get("ready"))
+    can_consider_regeneration = bool(preflight_gate.get("can_be_considered"))
+
+    return {
+        "available": isinstance(selection_route_validation_flow, dict)
+        and isinstance(selection_closed_loop_preflight, dict),
+        "ready": route_ready,
+        "counts": {
+            "materialized_route_ready": int(flow_counts.get("materialized_route_ready", 0) or 0),
+            "hypothesis_ready": int(flow_counts.get("hypothesis_ready", 0) or 0),
+            "request_ready_for_operator_review": request_ready,
+            "dry_run_ready": dry_run_ready,
+            "selection_validation_flow_ready": int(
+                flow_counts.get("selection_validation_flow_ready", 0) or 0
+            ),
+        },
+        "controlled_regeneration_can_be_considered": can_consider_regeneration,
+        "requires_operator_approval": bool(preflight_gate.get("requires_operator_approval", True)),
+        "requires_backup_plan": bool(preflight_gate.get("requires_backup_plan", True)),
+        "requires_explicit_regeneration_flag": bool(
+            preflight_gate.get("requires_explicit_regeneration_flag", True)
+        ),
+        "final_recommendation": (
+            selection_closed_loop_preflight.get("final_recommendation")
+            if isinstance(selection_closed_loop_preflight, dict)
+            else None
+        ),
     }
 
 
@@ -282,6 +346,8 @@ def collect_snapshot(
     evidence_quality_path: Path | None = None,
     promotion_intent_path: Path | None = None,
     audit_path: Path | None = None,
+    selection_route_validation_flow_path: Path | None = None,
+    selection_closed_loop_preflight_path: Path | None = None,
     generated_at_utc: str | None = None,
 ) -> dict[str, Any]:
     generated = generated_at_utc or _utcnow()
@@ -330,6 +396,16 @@ def collect_snapshot(
         expected_kind="qre_post_run_evidence_promotion_audit",
         label="post_run_audit",
     )
+    selection_route_validation_flow, meta_j, warnings_j = _load(
+        selection_route_validation_flow_path or DEFAULT_SELECTION_ROUTE_VALIDATION_FLOW_PATH,
+        expected_kind="qre_selection_route_validation_flow",
+        label="selection_route_validation_flow",
+    )
+    selection_closed_loop_preflight, meta_k, warnings_k = _load(
+        selection_closed_loop_preflight_path or DEFAULT_SELECTION_CLOSED_LOOP_PREFLIGHT_PATH,
+        expected_kind="qre_selection_closed_loop_preflight",
+        label="selection_closed_loop_preflight",
+    )
     status = _loop_status(
         readiness=readiness,
         requests=requests,
@@ -347,6 +423,8 @@ def collect_snapshot(
         evidence=evidence,
         promotion=promotion,
         audit=audit,
+        selection_route_validation_flow=selection_route_validation_flow,
+        selection_closed_loop_preflight=selection_closed_loop_preflight,
     )
     warnings = (
         warnings_a
@@ -358,6 +436,8 @@ def collect_snapshot(
         + warnings_g
         + warnings_h
         + warnings_i
+        + warnings_j
+        + warnings_k
     )
     actions = _recommended_actions(status, audit)
     return {
@@ -391,6 +471,8 @@ def collect_snapshot(
             "evidence_quality": meta_g,
             "promotion_intent": meta_h,
             "post_run_audit": meta_i,
+            "selection_route_validation_flow": meta_j,
+            "selection_closed_loop_preflight": meta_k,
         },
         "blockers": summary["post_run_audit"]["blockers"] + warnings,
         "validation_warnings": warnings,
@@ -494,6 +576,8 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--evidence-quality-source", type=Path, default=None)
     parser.add_argument("--promotion-intent-source", type=Path, default=None)
     parser.add_argument("--audit-source", type=Path, default=None)
+    parser.add_argument("--selection-route-validation-flow-source", type=Path, default=None)
+    parser.add_argument("--selection-closed-loop-preflight-source", type=Path, default=None)
     parser.add_argument("--frozen-utc", default=None)
     parser.add_argument("--indent", type=int, default=2)
     return parser
@@ -511,6 +595,8 @@ def main(argv: list[str] | None = None) -> int:
         evidence_quality_path=args.evidence_quality_source,
         promotion_intent_path=args.promotion_intent_source,
         audit_path=args.audit_source,
+        selection_route_validation_flow_path=args.selection_route_validation_flow_source,
+        selection_closed_loop_preflight_path=args.selection_closed_loop_preflight_source,
         generated_at_utc=args.frozen_utc,
     )
     if not args.no_write:

--- a/reporting/qre_selection_closed_loop_preflight.py
+++ b/reporting/qre_selection_closed_loop_preflight.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+from pathlib import Path
+from typing import Any, Final
+
+import reporting.qre_executable_hypothesis_identity_bridge_diagnostics as bridge
+import reporting.qre_selection_route_validation_flow as validation_flow
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[1]
+
+SCHEMA_VERSION: Final[int] = 1
+REPORT_KIND: Final[str] = "qre_selection_closed_loop_preflight"
+
+OUTPUT_ARTIFACT_RELATIVE_PATH: Final[str] = "logs/qre_selection_closed_loop_preflight/latest.json"
+ARTIFACT_LATEST: Final[Path] = REPO_ROOT / OUTPUT_ARTIFACT_RELATIVE_PATH
+
+
+def _utcnow() -> str:
+    return dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _counts(snapshot: dict[str, Any]) -> dict[str, Any]:
+    counts = snapshot.get("counts")
+    return counts if isinstance(counts, dict) else {}
+
+
+def _bridge_summary(snapshot: dict[str, Any]) -> dict[str, Any]:
+    bridge_payload = snapshot.get("bridge")
+    return bridge_payload if isinstance(bridge_payload, dict) else {}
+
+
+def _base_snapshot(
+    *,
+    generated_at_utc: str,
+    flow_snapshot: dict[str, Any],
+    bridge_snapshot: dict[str, Any],
+) -> dict[str, Any]:
+    flow_counts = _counts(flow_snapshot)
+    bridge_payload = _bridge_summary(bridge_snapshot)
+
+    flow_ready = int(flow_counts.get("selection_validation_flow_ready", 0) or 0)
+    request_ready = int(flow_counts.get("request_ready_for_operator_review", 0) or 0)
+    dry_run_ready = int(flow_counts.get("dry_run_ready", 0) or 0)
+
+    legacy_regeneration_expected = bool(bridge_payload.get("regeneration_linkage_expected"))
+    legacy_deterministic_mapping_possible = bool(
+        bridge_payload.get("deterministic_mapping_possible")
+    )
+    legacy_primary_blocker = bridge_payload.get("primary_blocker")
+
+    selection_route_ready = flow_ready > 0 and request_ready > 0 and dry_run_ready > 0
+
+    controlled_regeneration_can_be_considered = (
+        selection_route_ready
+        and not legacy_regeneration_expected
+        and not legacy_deterministic_mapping_possible
+    )
+
+    return {
+        "report_kind": REPORT_KIND,
+        "schema_version": SCHEMA_VERSION,
+        "generated_at_utc": generated_at_utc,
+        "safe_to_execute": False,
+        "eligible_for_direct_execution": False,
+        "read_only": True,
+        "launches_subprocess": False,
+        "launches_codex": False,
+        "mutates_research_artifacts": False,
+        "mutates_strategy_or_preset": False,
+        "mutates_campaign_queue": False,
+        "mutates_paper_shadow_live_runtime": False,
+        "writes_seed_jsonl": False,
+        "writes_generated_seed_jsonl": False,
+        "writes_research_action_queue": False,
+        "writes_development_work_queue": False,
+        "selection_route": {
+            "ready": selection_route_ready,
+            "counts": flow_counts,
+            "final_recommendation": flow_snapshot.get("final_recommendation"),
+        },
+        "legacy_bridge": {
+            "regeneration_linkage_expected": legacy_regeneration_expected,
+            "deterministic_mapping_possible": legacy_deterministic_mapping_possible,
+            "primary_blocker": legacy_primary_blocker,
+            "final_recommendation": bridge_snapshot.get("final_recommendation"),
+        },
+        "controlled_regeneration_preflight": {
+            "can_be_considered": controlled_regeneration_can_be_considered,
+            "requires_operator_approval": True,
+            "requires_backup_plan": True,
+            "requires_explicit_regeneration_flag": True,
+            "reason_codes": [
+                *(
+                    ["selection_route_validation_flow_ready"]
+                    if selection_route_ready
+                    else ["selection_route_validation_flow_not_ready"]
+                ),
+                *(
+                    ["legacy_bridge_still_blocked_but_bypassed_by_selection_route"]
+                    if legacy_primary_blocker
+                    else []
+                ),
+                "controlled_regeneration_not_executed_by_preflight",
+            ],
+        },
+        "validation_warnings": [
+            *list(flow_snapshot.get("validation_warnings") or []),
+            *list(bridge_snapshot.get("validation_warnings") or []),
+        ],
+        "final_recommendation": (
+            "selection_route_ready_controlled_regeneration_can_be_considered"
+            if controlled_regeneration_can_be_considered
+            else "selection_route_preflight_blocked"
+        ),
+    }
+
+
+def collect_snapshot(
+    *,
+    flow_snapshot: dict[str, Any] | None = None,
+    bridge_snapshot: dict[str, Any] | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    generated = generated_at_utc or _utcnow()
+    active_flow = flow_snapshot or validation_flow.collect_snapshot(generated_at_utc=generated)
+    active_bridge = bridge_snapshot or bridge.collect_snapshot(generated_at_utc=generated)
+
+    return _base_snapshot(
+        generated_at_utc=generated,
+        flow_snapshot=active_flow,
+        bridge_snapshot=active_bridge,
+    )
+
+
+def write_outputs(snapshot: dict[str, Any], *, output_path: Path | None = None) -> Path:
+    target = output_path or ARTIFACT_LATEST
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(snapshot, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return target
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--no-write", action="store_true")
+    parser.add_argument("--indent", type=int, default=2)
+    parser.add_argument("--frozen-utc")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    snapshot = collect_snapshot(generated_at_utc=args.frozen_utc)
+    if not args.no_write:
+        write_outputs(snapshot)
+    print(json.dumps(snapshot, indent=args.indent, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/reporting/qre_selection_route_materialization.py
+++ b/reporting/qre_selection_route_materialization.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Final
+
+import reporting.qre_executable_hypothesis_selection as selection
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[1]
+
+SCHEMA_VERSION: Final[int] = 1
+REPORT_KIND: Final[str] = "qre_selection_route_materialization"
+
+OUTPUT_ARTIFACT_RELATIVE_PATH: Final[str] = "logs/qre_selection_route_materialization/latest.json"
+ARTIFACT_LATEST: Final[Path] = REPO_ROOT / OUTPUT_ARTIFACT_RELATIVE_PATH
+
+NOTE_SELECTION_INPUT_UNAVAILABLE: Final[str] = "selection_input_unavailable"
+NOTE_SELECTION_ROW_NOT_SELECTED: Final[str] = "selection_row_not_selected"
+
+
+def _utcnow() -> str:
+    return dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _bounded_str(value: Any, *, max_len: int = 240) -> str:
+    if value is None or isinstance(value, bool):
+        return ""
+    text = str(value).strip()
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 3].rstrip() + "..."
+
+
+def _str_list(values: Any, *, max_items: int = 50, max_len: int = 180) -> list[str]:
+    if not isinstance(values, list | tuple | set | frozenset):
+        return []
+    out: list[str] = []
+    for value in list(values)[:max_items]:
+        text = _bounded_str(value, max_len=max_len)
+        if text:
+            out.append(text)
+    return out
+
+
+def _stable_id(prefix: str, *parts: Any) -> str:
+    joined = "|".join(_bounded_str(part, max_len=240) for part in parts)
+    digest = hashlib.sha256(joined.encode("utf-8")).hexdigest()[:16]
+    return f"{prefix}-{digest}"
+
+
+def _selection_rows(selection_snapshot: dict[str, Any]) -> list[dict[str, Any]]:
+    rows = selection_snapshot.get("selection_rows")
+    if not isinstance(rows, list):
+        return []
+    return [row for row in rows if isinstance(row, dict)]
+
+
+def _build_route_rows(
+    *,
+    selection_snapshot: dict[str, Any],
+    generated_at_utc: str,
+) -> tuple[
+    list[dict[str, Any]],
+    list[dict[str, Any]],
+    list[dict[str, Any]],
+    list[dict[str, Any]],
+    list[str],
+]:
+    observations: list[dict[str, Any]] = []
+    hypotheses: list[dict[str, Any]] = []
+    validation_plans: list[dict[str, Any]] = []
+    run_manifests: list[dict[str, Any]] = []
+    warnings: list[str] = []
+
+    for row in _selection_rows(selection_snapshot):
+        selection_id = _bounded_str(row.get("selection_id"), max_len=160)
+        status = _bounded_str(row.get("selection_status"), max_len=80)
+        if status != "selected":
+            warnings.append(f"{NOTE_SELECTION_ROW_NOT_SELECTED}:{selection_id or 'unknown'}")
+            continue
+
+        preset_name = _bounded_str(row.get("preset_name"), max_len=160)
+        executable_hypothesis_id = _bounded_str(
+            row.get("executable_hypothesis_id"),
+            max_len=160,
+        )
+        strategy_family = _bounded_str(row.get("strategy_family"), max_len=160)
+        strategy_template_id = _bounded_str(row.get("strategy_template_id"), max_len=160)
+        asset = _bounded_str(row.get("asset"), max_len=80)
+        symbol = _bounded_str(row.get("symbol"), max_len=80) or asset
+        timeframe = _bounded_str(row.get("timeframe"), max_len=40)
+        interval = _bounded_str(row.get("interval"), max_len=40) or timeframe
+        summary = _bounded_str(row.get("summary"), max_len=360)
+        source_hypothesis_id = (
+            _bounded_str(
+                row.get("source_hypothesis_id"),
+                max_len=160,
+            )
+            or executable_hypothesis_id
+        )
+        evidence_refs = _str_list(
+            row.get("supporting_evidence_refs"),
+            max_items=24,
+            max_len=180,
+        )
+        universe = _str_list(row.get("universe"), max_items=50, max_len=80)
+        asset_class = _bounded_str(row.get("asset_class"), max_len=80)
+        profile_name = _bounded_str(row.get("selection_profile_name"), max_len=120)
+
+        observation_id = _stable_id("qre-obs-sel", selection_id, preset_name, asset, timeframe)
+        qre_hypothesis_id = _stable_id(
+            "qre-hyp-sel",
+            selection_id,
+            executable_hypothesis_id,
+            preset_name,
+            asset,
+            timeframe,
+        )
+        validation_plan_id = _stable_id("qre-plan-sel", qre_hypothesis_id, preset_name)
+        run_manifest_id = _stable_id("qre-run-sel", validation_plan_id, qre_hypothesis_id)
+
+        source_artifact = OUTPUT_ARTIFACT_RELATIVE_PATH
+        source_report_kind = REPORT_KIND
+        source_row_id = selection_id
+
+        observations.append(
+            {
+                "observation_id": observation_id,
+                "observation_type": "executable_hypothesis_selection",
+                "source_artifact": source_artifact,
+                "source_report_kind": source_report_kind,
+                "source_row_id": source_row_id,
+                "supporting_evidence_refs": evidence_refs,
+                "asset": asset,
+                "symbol": symbol,
+                "timeframe": timeframe,
+                "interval": interval,
+                "summary": summary,
+                "preset_name": preset_name,
+                "strategy_family": strategy_family,
+                "strategy_template_id": strategy_template_id,
+                "executable_hypothesis_id": executable_hypothesis_id,
+                "source_hypothesis_id": source_hypothesis_id,
+                "market_context": {
+                    "asset_class": asset_class,
+                    "universe": universe,
+                    "selection_profile_name": profile_name,
+                    "selection_source": _bounded_str(row.get("selection_source"), max_len=160),
+                },
+                "generated_at_utc": generated_at_utc,
+            }
+        )
+
+        hypotheses.append(
+            {
+                "hypothesis_id": qre_hypothesis_id,
+                "source_observation_id": observation_id,
+                "source_artifact": source_artifact,
+                "source_report_kind": source_report_kind,
+                "source_row_id": source_row_id,
+                "supporting_evidence_refs": evidence_refs,
+                "asset": asset,
+                "symbol": symbol,
+                "timeframe": timeframe,
+                "interval": interval,
+                "summary": summary,
+                "preset_name": preset_name,
+                "strategy_family": strategy_family,
+                "strategy_template_id": strategy_template_id,
+                "executable_hypothesis_id": executable_hypothesis_id,
+                "source_hypothesis_id": source_hypothesis_id,
+                "status": "proposed",
+                "generated_at_utc": generated_at_utc,
+            }
+        )
+
+        validation_plans.append(
+            {
+                "validation_plan_id": validation_plan_id,
+                "hypothesis_id": qre_hypothesis_id,
+                "executable_hypothesis_id": executable_hypothesis_id,
+                "preset_name": preset_name,
+                "strategy_family": strategy_family,
+                "strategy_template_id": strategy_template_id,
+                "asset": asset,
+                "symbol": symbol,
+                "timeframe": timeframe,
+                "interval": interval,
+                "status": "planned",
+                "generated_at_utc": generated_at_utc,
+            }
+        )
+
+        run_manifests.append(
+            {
+                "run_manifest_id": run_manifest_id,
+                "target_validation_plan_id": validation_plan_id,
+                "hypothesis_id": qre_hypothesis_id,
+                "executable_hypothesis_id": executable_hypothesis_id,
+                "preset_name": preset_name,
+                "asset": asset,
+                "symbol": symbol,
+                "timeframe": timeframe,
+                "interval": interval,
+                "status": "operator_review_required",
+                "generated_at_utc": generated_at_utc,
+            }
+        )
+
+    return observations, hypotheses, validation_plans, run_manifests, warnings
+
+
+def _counts(
+    *,
+    observations: list[dict[str, Any]],
+    hypotheses: list[dict[str, Any]],
+    validation_plans: list[dict[str, Any]],
+    run_manifests: list[dict[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "observations": len(observations),
+        "hypotheses": len(hypotheses),
+        "validation_plans": len(validation_plans),
+        "run_manifests": len(run_manifests),
+        "materialized_route_ready": min(
+            len(observations),
+            len(hypotheses),
+            len(validation_plans),
+            len(run_manifests),
+        ),
+    }
+
+
+def _base_snapshot(
+    *,
+    generated_at_utc: str,
+    selection_snapshot: dict[str, Any],
+    observations: list[dict[str, Any]],
+    hypotheses: list[dict[str, Any]],
+    validation_plans: list[dict[str, Any]],
+    run_manifests: list[dict[str, Any]],
+    validation_warnings: list[str],
+) -> dict[str, Any]:
+    counts = _counts(
+        observations=observations,
+        hypotheses=hypotheses,
+        validation_plans=validation_plans,
+        run_manifests=run_manifests,
+    )
+    ready = counts["materialized_route_ready"]
+    return {
+        "report_kind": REPORT_KIND,
+        "schema_version": SCHEMA_VERSION,
+        "generated_at_utc": generated_at_utc,
+        "safe_to_execute": False,
+        "eligible_for_direct_execution": False,
+        "read_only": True,
+        "launches_subprocess": False,
+        "launches_codex": False,
+        "mutates_research_artifacts": False,
+        "mutates_strategy_or_preset": False,
+        "mutates_campaign_queue": False,
+        "mutates_paper_shadow_live_runtime": False,
+        "writes_seed_jsonl": False,
+        "writes_generated_seed_jsonl": False,
+        "writes_research_action_queue": False,
+        "writes_development_work_queue": False,
+        "selection_summary": {
+            "report_kind": selection_snapshot.get("report_kind"),
+            "selected": (selection_snapshot.get("counts") or {}).get("selected", 0),
+            "blocked": (selection_snapshot.get("counts") or {}).get("blocked", 0),
+            "total": (selection_snapshot.get("counts") or {}).get("total", 0),
+            "final_recommendation": selection_snapshot.get("final_recommendation"),
+        },
+        "counts": counts,
+        "market_observation_payload": {
+            "report_kind": "qre_market_observation_snapshot",
+            "schema_version": "selection-route-v1",
+            "generated_at_utc": generated_at_utc,
+            "observations": observations,
+        },
+        "hypothesis_candidates_payload": {
+            "report_kind": "qre_hypothesis_candidates",
+            "schema_version": "selection-route-v1",
+            "generated_at_utc": generated_at_utc,
+            "hypotheses": hypotheses,
+        },
+        "validation_plans_payload": {
+            "report_kind": "qre_hypothesis_validation_plan",
+            "schema_version": "selection-route-v1",
+            "generated_at_utc": generated_at_utc,
+            "validation_plans": validation_plans,
+        },
+        "run_manifest_payload": {
+            "report_kind": "qre_research_run_manifest",
+            "schema_version": "selection-route-v1",
+            "generated_at_utc": generated_at_utc,
+            "run_manifests": run_manifests,
+        },
+        "validation_warnings": validation_warnings,
+        "final_recommendation": (
+            "selection_route_materialized_for_validation_request"
+            if ready > 0 and not validation_warnings
+            else "selection_route_materialization_blocked"
+        ),
+    }
+
+
+def collect_snapshot(
+    *,
+    selection_snapshot: dict[str, Any] | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    generated = generated_at_utc or _utcnow()
+    warnings: list[str] = []
+    active_selection_snapshot = selection_snapshot or selection.collect_snapshot(
+        generated_at_utc=generated,
+    )
+    if not isinstance(active_selection_snapshot, dict):
+        active_selection_snapshot = {}
+        warnings.append(NOTE_SELECTION_INPUT_UNAVAILABLE)
+
+    observations, hypotheses, validation_plans, run_manifests, row_warnings = _build_route_rows(
+        selection_snapshot=active_selection_snapshot,
+        generated_at_utc=generated,
+    )
+    warnings.extend(row_warnings)
+
+    return _base_snapshot(
+        generated_at_utc=generated,
+        selection_snapshot=active_selection_snapshot,
+        observations=observations,
+        hypotheses=hypotheses,
+        validation_plans=validation_plans,
+        run_manifests=run_manifests,
+        validation_warnings=warnings,
+    )
+
+
+def write_outputs(snapshot: dict[str, Any], *, output_path: Path | None = None) -> Path:
+    target = output_path or ARTIFACT_LATEST
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(snapshot, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return target
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--no-write", action="store_true")
+    parser.add_argument("--indent", type=int, default=2)
+    parser.add_argument("--frozen-utc")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    snapshot = collect_snapshot(generated_at_utc=args.frozen_utc)
+    if not args.no_write:
+        write_outputs(snapshot)
+    print(json.dumps(snapshot, indent=args.indent, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/reporting/qre_selection_route_validation_flow.py
+++ b/reporting/qre_selection_route_validation_flow.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any, Final
+
+import reporting.qre_executable_validation_request as validation_request
+import reporting.qre_market_observation_hypothesis_readiness as readiness
+import reporting.qre_selection_route_materialization as materialization
+import reporting.qre_validation_request_dry_run_runner as dry_run
+
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[1]
+
+SCHEMA_VERSION: Final[int] = 1
+REPORT_KIND: Final[str] = "qre_selection_route_validation_flow"
+
+OUTPUT_ARTIFACT_RELATIVE_PATH: Final[str] = "logs/qre_selection_route_validation_flow/latest.json"
+ARTIFACT_LATEST: Final[Path] = REPO_ROOT / OUTPUT_ARTIFACT_RELATIVE_PATH
+
+
+def _utcnow() -> str:
+    return dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _request_counts(snapshot: dict[str, Any]) -> dict[str, Any]:
+    counts = snapshot.get("counts")
+    return counts if isinstance(counts, dict) else {}
+
+
+def _dry_run_counts(snapshot: dict[str, Any]) -> dict[str, Any]:
+    counts = snapshot.get("counts")
+    return counts if isinstance(counts, dict) else {}
+
+
+def _readiness_counts(snapshot: dict[str, Any]) -> dict[str, Any]:
+    counts = snapshot.get("counts")
+    return counts if isinstance(counts, dict) else {}
+
+
+def _base_snapshot(
+    *,
+    generated_at_utc: str,
+    materialization_snapshot: dict[str, Any],
+    readiness_snapshot: dict[str, Any],
+    validation_request_snapshot: dict[str, Any],
+    dry_run_snapshot: dict[str, Any],
+) -> dict[str, Any]:
+    mat_counts = materialization_snapshot.get("counts") or {}
+    readiness_counts = _readiness_counts(readiness_snapshot)
+    request_counts = _request_counts(validation_request_snapshot)
+    dry_run_counts = _dry_run_counts(dry_run_snapshot)
+
+    materialized_route_ready = int(mat_counts.get("materialized_route_ready", 0) or 0)
+    hypothesis_ready = int(readiness_counts.get("hypothesis_ready", 0) or 0)
+    request_ready = int(request_counts.get("ready", 0) or 0)
+    dry_run_ready = int(dry_run_counts.get("ready", 0) or 0)
+
+    flow_ready = min(
+        materialized_route_ready,
+        hypothesis_ready,
+        request_ready,
+        dry_run_ready,
+    )
+
+    return {
+        "report_kind": REPORT_KIND,
+        "schema_version": SCHEMA_VERSION,
+        "generated_at_utc": generated_at_utc,
+        "safe_to_execute": False,
+        "eligible_for_direct_execution": False,
+        "read_only": True,
+        "launches_subprocess": False,
+        "launches_codex": False,
+        "mutates_research_artifacts": False,
+        "mutates_strategy_or_preset": False,
+        "mutates_campaign_queue": False,
+        "mutates_paper_shadow_live_runtime": False,
+        "writes_seed_jsonl": False,
+        "writes_generated_seed_jsonl": False,
+        "writes_research_action_queue": False,
+        "writes_development_work_queue": False,
+        "counts": {
+            "materialized_route_ready": materialized_route_ready,
+            "hypothesis_ready": hypothesis_ready,
+            "request_ready_for_operator_review": request_ready,
+            "dry_run_ready": dry_run_ready,
+            "selection_validation_flow_ready": flow_ready,
+        },
+        "materialization": {
+            "counts": mat_counts,
+            "final_recommendation": materialization_snapshot.get("final_recommendation"),
+        },
+        "readiness": {
+            "counts": readiness_counts,
+            "by_readiness_class": readiness_snapshot.get("by_readiness_class", {}),
+            "final_recommendation": readiness_snapshot.get("final_recommendation"),
+        },
+        "validation_request": {
+            "counts": request_counts,
+            "final_recommendation": validation_request_snapshot.get("final_recommendation"),
+        },
+        "dry_run": {
+            "counts": dry_run_counts,
+            "executed_anything": dry_run_snapshot.get("executed_anything", False),
+            "final_recommendation": dry_run_snapshot.get("final_recommendation"),
+        },
+        "validation_warnings": [
+            *list(materialization_snapshot.get("validation_warnings") or []),
+            *list(readiness_snapshot.get("validation_warnings") or []),
+            *list(validation_request_snapshot.get("validation_warnings") or []),
+            *list(dry_run_snapshot.get("validation_warnings") or []),
+        ],
+        "final_recommendation": (
+            "selection_route_validation_flow_ready_for_operator_review"
+            if flow_ready > 0
+            else "selection_route_validation_flow_blocked"
+        ),
+    }
+
+
+def collect_snapshot(
+    *,
+    materialization_snapshot: dict[str, Any] | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    generated = generated_at_utc or _utcnow()
+    active_materialization = materialization_snapshot or materialization.collect_snapshot(
+        generated_at_utc=generated,
+    )
+
+    with TemporaryDirectory(prefix="qre_selection_route_validation_flow_") as tmp_name:
+        tmp = Path(tmp_name)
+
+        market_path = tmp / "market_observations.json"
+        hypotheses_path = tmp / "hypothesis_candidates.json"
+        plans_path = tmp / "validation_plans.json"
+        manifests_path = tmp / "run_manifest.json"
+        readiness_path = tmp / "readiness.json"
+        request_path = tmp / "validation_request.json"
+
+        _write_json(
+            market_path,
+            active_materialization.get("market_observation_payload") or {},
+        )
+        _write_json(
+            hypotheses_path,
+            active_materialization.get("hypothesis_candidates_payload") or {},
+        )
+        _write_json(
+            plans_path,
+            active_materialization.get("validation_plans_payload") or {},
+        )
+        _write_json(
+            manifests_path,
+            active_materialization.get("run_manifest_payload") or {},
+        )
+
+        readiness_snapshot = readiness.collect_snapshot(
+            input_artifact_path=market_path,
+            generated_at_utc=generated,
+        )
+        _write_json(readiness_path, readiness_snapshot)
+
+        request_snapshot = validation_request.collect_snapshot(
+            input_artifact_path=hypotheses_path,
+            readiness_artifact_path=readiness_path,
+            market_observation_artifact_path=market_path,
+            validation_plan_artifact_path=plans_path,
+            run_manifest_artifact_path=manifests_path,
+            generated_at_utc=generated,
+        )
+        _write_json(request_path, request_snapshot)
+
+        dry_run_snapshot = dry_run.collect_snapshot(
+            input_artifact_path=request_path,
+            generated_at_utc=generated,
+        )
+
+    return _base_snapshot(
+        generated_at_utc=generated,
+        materialization_snapshot=active_materialization,
+        readiness_snapshot=readiness_snapshot,
+        validation_request_snapshot=request_snapshot,
+        dry_run_snapshot=dry_run_snapshot,
+    )
+
+
+def write_outputs(snapshot: dict[str, Any], *, output_path: Path | None = None) -> Path:
+    target = output_path or ARTIFACT_LATEST
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(snapshot, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return target
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--no-write", action="store_true")
+    parser.add_argument("--indent", type=int, default=2)
+    parser.add_argument("--frozen-utc")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    snapshot = collect_snapshot(generated_at_utc=args.frozen_utc)
+    if not args.no_write:
+        write_outputs(snapshot)
+    print(json.dumps(snapshot, indent=args.indent, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/reporting/qre_selection_route_validation_flow.py
+++ b/reporting/qre_selection_route_validation_flow.py
@@ -12,7 +12,6 @@ import reporting.qre_market_observation_hypothesis_readiness as readiness
 import reporting.qre_selection_route_materialization as materialization
 import reporting.qre_validation_request_dry_run_runner as dry_run
 
-
 REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[1]
 
 SCHEMA_VERSION: Final[int] = 1

--- a/scripts/qre_closed_loop_e2e_verify.ps1
+++ b/scripts/qre_closed_loop_e2e_verify.ps1
@@ -54,6 +54,17 @@ Invoke-QreCommand "Validation request dry-run runner" @(
 Invoke-QreCommand "Executable hypothesis identity bridge diagnostics" @(
     "-m", "reporting.qre_executable_hypothesis_identity_bridge_diagnostics", "--no-write", "--indent", "2"
 )
+
+Invoke-QreCommand "Selection route materialization" @(
+    "-m", "reporting.qre_selection_route_materialization"
+)
+Invoke-QreCommand "Selection route validation flow" @(
+    "-m", "reporting.qre_selection_route_validation_flow"
+)
+Invoke-QreCommand "Selection closed-loop preflight" @(
+    "-m", "reporting.qre_selection_closed_loop_preflight"
+)
+
 Invoke-QreCommand "Controlled artifact regeneration backup plan" @(
     "-m", "reporting.qre_controlled_artifact_regeneration_backup_plan"
 )
@@ -78,12 +89,22 @@ Invoke-QreCommand "Operator closed-loop report" @(
 $controlled = Read-QreJson "logs/qre_controlled_artifact_regeneration/latest.json"
 $audit = Read-QreJson "logs/qre_post_run_evidence_promotion_audit/latest.json"
 $operator = Read-QreJson "logs/qre_operator_closed_loop_report/latest.json"
+$selectionFlow = Read-QreJson "logs/qre_selection_route_validation_flow/latest.json"
+$selectionPreflight = Read-QreJson "logs/qre_selection_closed_loop_preflight/latest.json"
 
 Write-Host ""
 Write-Host "=== QRE Closed-Loop E2E Summary ==="
 if ($operator -ne $null) {
     Write-Host "loop_status: $($operator.loop_status)"
     Write-Host "next_operator_action: $($operator.next_operator_action)"
+}
+if ($selectionFlow -ne $null) {
+    Write-Host "selection_request_ready_for_operator_review: $($selectionFlow.counts.request_ready_for_operator_review)"
+    Write-Host "selection_dry_run_ready: $($selectionFlow.counts.dry_run_ready)"
+}
+if ($selectionPreflight -ne $null) {
+    Write-Host "selection_route_ready: $($selectionPreflight.selection_route.ready)"
+    Write-Host "selection_controlled_regeneration_can_be_considered: $($selectionPreflight.controlled_regeneration_preflight.can_be_considered)"
 }
 if ($controlled -ne $null) {
     Write-Host "controlled_regeneration_mode: $($controlled.mode)"

--- a/tests/unit/test_qre_operator_closed_loop_report.py
+++ b/tests/unit/test_qre_operator_closed_loop_report.py
@@ -253,3 +253,70 @@ def test_source_has_no_runtime_launch_or_mutating_queue_calls() -> None:
     )
     for token in forbidden:
         assert token not in src, token
+
+
+def test_operator_report_includes_selection_route_summary(tmp_path: Path) -> None:
+    paths = _fixtures(tmp_path)
+
+    selection_flow = tmp_path / "selection-flow.json"
+    selection_preflight = tmp_path / "selection-preflight.json"
+
+    _write(
+        selection_flow,
+        {
+            "report_kind": "qre_selection_route_validation_flow",
+            "counts": {
+                "materialized_route_ready": 3,
+                "hypothesis_ready": 3,
+                "request_ready_for_operator_review": 3,
+                "dry_run_ready": 3,
+                "selection_validation_flow_ready": 3,
+            },
+        },
+    )
+    _write(
+        selection_preflight,
+        {
+            "report_kind": "qre_selection_closed_loop_preflight",
+            "selection_route": {
+                "ready": True,
+            },
+            "controlled_regeneration_preflight": {
+                "can_be_considered": True,
+                "requires_operator_approval": True,
+                "requires_backup_plan": True,
+                "requires_explicit_regeneration_flag": True,
+            },
+            "final_recommendation": (
+                "selection_route_ready_controlled_regeneration_can_be_considered"
+            ),
+        },
+    )
+
+    snap = report.collect_snapshot(
+        market_observations_path=paths["observations"],
+        readiness_path=paths["readiness"],
+        validation_request_path=paths["request"],
+        dry_run_path=paths["dry"],
+        controlled_regeneration_path=paths["controlled"],
+        validation_results_path=paths["results"],
+        evidence_quality_path=paths["evidence"],
+        promotion_intent_path=paths["promotion"],
+        audit_path=paths["audit"],
+        selection_route_validation_flow_path=selection_flow,
+        selection_closed_loop_preflight_path=selection_preflight,
+        generated_at_utc=FROZEN,
+    )
+
+    selection_route = snap["operator_summary"]["selection_route"]
+
+    assert selection_route["available"] is True
+    assert selection_route["ready"] is True
+    assert selection_route["counts"]["request_ready_for_operator_review"] == 3
+    assert selection_route["counts"]["dry_run_ready"] == 3
+    assert selection_route["controlled_regeneration_can_be_considered"] is True
+    assert selection_route["requires_operator_approval"] is True
+    assert selection_route["requires_backup_plan"] is True
+    assert selection_route["requires_explicit_regeneration_flag"] is True
+    assert snap["artifact_refs"]["selection_route_validation_flow"]["valid"] is True
+    assert snap["artifact_refs"]["selection_closed_loop_preflight"]["valid"] is True

--- a/tests/unit/test_qre_selection_closed_loop_preflight.py
+++ b/tests/unit/test_qre_selection_closed_loop_preflight.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import json
+
+import reporting.qre_selection_closed_loop_preflight as preflight
+
+
+def test_preflight_allows_considering_controlled_regeneration_from_selection_route() -> None:
+    snapshot = preflight.collect_snapshot(generated_at_utc="2026-06-03T16:00:00Z")
+
+    assert snapshot["report_kind"] == "qre_selection_closed_loop_preflight"
+    assert snapshot["safe_to_execute"] is False
+    assert snapshot["read_only"] is True
+    assert snapshot["eligible_for_direct_execution"] is False
+
+    assert snapshot["selection_route"]["ready"] is True
+    assert snapshot["selection_route"]["counts"]["request_ready_for_operator_review"] == 3
+    assert snapshot["selection_route"]["counts"]["dry_run_ready"] == 3
+
+    assert snapshot["legacy_bridge"]["regeneration_linkage_expected"] is False
+    assert snapshot["legacy_bridge"]["primary_blocker"]
+
+    assert snapshot["controlled_regeneration_preflight"]["can_be_considered"] is True
+    assert (
+        "selection_route_validation_flow_ready"
+        in snapshot["controlled_regeneration_preflight"]["reason_codes"]
+    )
+    assert (
+        snapshot["final_recommendation"]
+        == "selection_route_ready_controlled_regeneration_can_be_considered"
+    )
+
+
+def test_preflight_blocks_when_selection_flow_not_ready() -> None:
+    flow_snapshot = {
+        "report_kind": "qre_selection_route_validation_flow",
+        "counts": {
+            "materialized_route_ready": 0,
+            "hypothesis_ready": 0,
+            "request_ready_for_operator_review": 0,
+            "dry_run_ready": 0,
+            "selection_validation_flow_ready": 0,
+        },
+        "final_recommendation": "selection_route_validation_flow_blocked",
+        "validation_warnings": [],
+    }
+    bridge_snapshot = {
+        "report_kind": "qre_executable_hypothesis_identity_bridge_diagnostics",
+        "bridge": {
+            "regeneration_linkage_expected": False,
+            "deterministic_mapping_possible": False,
+            "primary_blocker": "executable_hypothesis_id_not_in_qre_authority",
+        },
+        "final_recommendation": "executable_hypothesis_identity_bridge_required_before_regeneration",
+        "validation_warnings": [],
+    }
+
+    snapshot = preflight.collect_snapshot(
+        flow_snapshot=flow_snapshot,
+        bridge_snapshot=bridge_snapshot,
+        generated_at_utc="2026-06-03T16:00:00Z",
+    )
+
+    assert snapshot["selection_route"]["ready"] is False
+    assert snapshot["controlled_regeneration_preflight"]["can_be_considered"] is False
+    assert (
+        "selection_route_validation_flow_not_ready"
+        in snapshot["controlled_regeneration_preflight"]["reason_codes"]
+    )
+    assert snapshot["final_recommendation"] == "selection_route_preflight_blocked"
+
+
+def test_preflight_blocks_when_legacy_bridge_already_expects_regeneration() -> None:
+    flow_snapshot = {
+        "report_kind": "qre_selection_route_validation_flow",
+        "counts": {
+            "materialized_route_ready": 3,
+            "hypothesis_ready": 3,
+            "request_ready_for_operator_review": 3,
+            "dry_run_ready": 3,
+            "selection_validation_flow_ready": 3,
+        },
+        "final_recommendation": "selection_route_validation_flow_ready_for_operator_review",
+        "validation_warnings": [],
+    }
+    bridge_snapshot = {
+        "report_kind": "qre_executable_hypothesis_identity_bridge_diagnostics",
+        "bridge": {
+            "regeneration_linkage_expected": True,
+            "deterministic_mapping_possible": True,
+            "primary_blocker": None,
+        },
+        "final_recommendation": "legacy_bridge_ready",
+        "validation_warnings": [],
+    }
+
+    snapshot = preflight.collect_snapshot(
+        flow_snapshot=flow_snapshot,
+        bridge_snapshot=bridge_snapshot,
+        generated_at_utc="2026-06-03T16:00:00Z",
+    )
+
+    assert snapshot["selection_route"]["ready"] is True
+    assert snapshot["legacy_bridge"]["regeneration_linkage_expected"] is True
+    assert snapshot["controlled_regeneration_preflight"]["can_be_considered"] is False
+    assert snapshot["final_recommendation"] == "selection_route_preflight_blocked"
+
+
+def test_preflight_cli_write_and_no_write(tmp_path, monkeypatch) -> None:
+    artifact_path = tmp_path / "preflight.json"
+    monkeypatch.setattr(preflight, "ARTIFACT_LATEST", artifact_path)
+
+    rc = preflight.main(
+        [
+            "--no-write",
+            "--frozen-utc",
+            "2026-06-03T16:00:00Z",
+            "--indent",
+            "2",
+        ]
+    )
+    assert rc == 0
+    assert not artifact_path.exists()
+
+    rc = preflight.main(
+        [
+            "--frozen-utc",
+            "2026-06-03T16:00:00Z",
+            "--indent",
+            "2",
+        ]
+    )
+    assert rc == 0
+    assert artifact_path.exists()
+
+    payload = json.loads(artifact_path.read_text(encoding="utf-8"))
+    assert payload["report_kind"] == "qre_selection_closed_loop_preflight"
+    assert payload["safe_to_execute"] is False
+    assert payload["controlled_regeneration_preflight"]["can_be_considered"] is True

--- a/tests/unit/test_qre_selection_route_materialization.py
+++ b/tests/unit/test_qre_selection_route_materialization.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import json
+
+import reporting.qre_selection_route_materialization as materialization
+
+
+def test_materializes_selection_route_artifacts() -> None:
+    snapshot = materialization.collect_snapshot(generated_at_utc="2026-06-03T14:00:00Z")
+
+    assert snapshot["report_kind"] == "qre_selection_route_materialization"
+    assert snapshot["safe_to_execute"] is False
+    assert snapshot["read_only"] is True
+    assert snapshot["eligible_for_direct_execution"] is False
+    assert snapshot["counts"]["observations"] == 3
+    assert snapshot["counts"]["hypotheses"] == 3
+    assert snapshot["counts"]["validation_plans"] == 3
+    assert snapshot["counts"]["run_manifests"] == 3
+    assert snapshot["counts"]["materialized_route_ready"] == 3
+    assert snapshot["final_recommendation"] == "selection_route_materialized_for_validation_request"
+
+
+def test_payloads_have_qre_report_kinds_and_required_rows() -> None:
+    snapshot = materialization.collect_snapshot(generated_at_utc="2026-06-03T14:00:00Z")
+
+    assert (
+        snapshot["market_observation_payload"]["report_kind"] == "qre_market_observation_snapshot"
+    )
+    assert snapshot["hypothesis_candidates_payload"]["report_kind"] == "qre_hypothesis_candidates"
+    assert snapshot["validation_plans_payload"]["report_kind"] == "qre_hypothesis_validation_plan"
+    assert snapshot["run_manifest_payload"]["report_kind"] == "qre_research_run_manifest"
+
+    observations = snapshot["market_observation_payload"]["observations"]
+    hypotheses = snapshot["hypothesis_candidates_payload"]["hypotheses"]
+    plans = snapshot["validation_plans_payload"]["validation_plans"]
+    manifests = snapshot["run_manifest_payload"]["run_manifests"]
+
+    assert len(observations) == len(hypotheses) == len(plans) == len(manifests) == 3
+
+
+def test_materialized_rows_preserve_executable_identity_and_linkage() -> None:
+    snapshot = materialization.collect_snapshot(generated_at_utc="2026-06-03T14:00:00Z")
+
+    observations = snapshot["market_observation_payload"]["observations"]
+    hypotheses = snapshot["hypothesis_candidates_payload"]["hypotheses"]
+    plans = snapshot["validation_plans_payload"]["validation_plans"]
+    manifests = snapshot["run_manifest_payload"]["run_manifests"]
+
+    observations_by_id = {row["observation_id"]: row for row in observations}
+    plans_by_hypothesis = {row["hypothesis_id"]: row for row in plans}
+    manifests_by_plan = {row["target_validation_plan_id"]: row for row in manifests}
+
+    for hypothesis in hypotheses:
+        observation = observations_by_id[hypothesis["source_observation_id"]]
+        plan = plans_by_hypothesis[hypothesis["hypothesis_id"]]
+        manifest = manifests_by_plan[plan["validation_plan_id"]]
+
+        assert hypothesis["executable_hypothesis_id"]
+        assert hypothesis["source_hypothesis_id"] == hypothesis["executable_hypothesis_id"]
+        assert hypothesis["preset_name"]
+        assert hypothesis["strategy_family"]
+        assert hypothesis["strategy_template_id"]
+        assert hypothesis["asset"]
+        assert hypothesis["timeframe"]
+        assert hypothesis["summary"]
+        assert hypothesis["supporting_evidence_refs"]
+
+        assert observation["executable_hypothesis_id"] == hypothesis["executable_hypothesis_id"]
+        assert observation["preset_name"] == hypothesis["preset_name"]
+        assert observation["strategy_template_id"] == hypothesis["strategy_template_id"]
+
+        assert plan["hypothesis_id"] == hypothesis["hypothesis_id"]
+        assert plan["executable_hypothesis_id"] == hypothesis["executable_hypothesis_id"]
+        assert plan["preset_name"] == hypothesis["preset_name"]
+
+        assert manifest["hypothesis_id"] == hypothesis["hypothesis_id"]
+        assert manifest["run_manifest_id"]
+        assert manifest["executable_hypothesis_id"] == hypothesis["executable_hypothesis_id"]
+
+
+def test_materialized_observations_are_hypothesis_ready() -> None:
+    import reporting.qre_market_observation_hypothesis_readiness as readiness
+
+    snapshot = materialization.collect_snapshot(generated_at_utc="2026-06-03T14:00:00Z")
+    observations = snapshot["market_observation_payload"]["observations"]
+
+    classifications = [readiness.classify_observation(row) for row in observations]
+
+    assert {row["readiness_class"] for row in classifications} == {"hypothesis_ready"}
+
+
+def test_materialized_route_feeds_request_and_dry_run(tmp_path) -> None:
+    import reporting.qre_executable_validation_request as request
+    import reporting.qre_market_observation_hypothesis_readiness as readiness
+    import reporting.qre_validation_request_dry_run_runner as dry_run
+
+    frozen = "2026-06-03T14:00:00Z"
+    snapshot = materialization.collect_snapshot(generated_at_utc=frozen)
+
+    market_path = tmp_path / "market.json"
+    hypotheses_path = tmp_path / "hypotheses.json"
+    plans_path = tmp_path / "plans.json"
+    manifests_path = tmp_path / "manifests.json"
+    readiness_path = tmp_path / "readiness.json"
+    request_path = tmp_path / "request.json"
+
+    market_path.write_text(
+        json.dumps(snapshot["market_observation_payload"]),
+        encoding="utf-8",
+    )
+    hypotheses_path.write_text(
+        json.dumps(snapshot["hypothesis_candidates_payload"]),
+        encoding="utf-8",
+    )
+    plans_path.write_text(
+        json.dumps(snapshot["validation_plans_payload"]),
+        encoding="utf-8",
+    )
+    manifests_path.write_text(
+        json.dumps(snapshot["run_manifest_payload"]),
+        encoding="utf-8",
+    )
+
+    readiness_snapshot = readiness.collect_snapshot(
+        input_artifact_path=market_path,
+        generated_at_utc=frozen,
+    )
+    readiness_path.write_text(json.dumps(readiness_snapshot), encoding="utf-8")
+
+    request_snapshot = request.collect_snapshot(
+        input_artifact_path=hypotheses_path,
+        readiness_artifact_path=readiness_path,
+        market_observation_artifact_path=market_path,
+        validation_plan_artifact_path=plans_path,
+        run_manifest_artifact_path=manifests_path,
+        generated_at_utc=frozen,
+    )
+    request_path.write_text(json.dumps(request_snapshot), encoding="utf-8")
+
+    assert request_snapshot["counts"]["total"] == 3
+    assert request_snapshot["counts"]["ready"] == 3
+    assert request_snapshot["counts"]["blocked"] == 0
+    assert request_snapshot["counts"]["by_request_status"]["request_ready_for_operator_review"] == 3
+
+    dry_run_snapshot = dry_run.collect_snapshot(
+        input_artifact_path=request_path,
+        generated_at_utc=frozen,
+    )
+
+    assert dry_run_snapshot["counts"]["total"] == 3
+    assert dry_run_snapshot["counts"]["ready"] == 3
+    assert dry_run_snapshot["counts"]["blocked"] == 0
+    assert dry_run_snapshot["counts"]["by_dry_run_status"]["dry_run_ready"] == 3
+    assert dry_run_snapshot["executed_anything"] is False
+
+
+def test_unselected_rows_fail_closed() -> None:
+    selection_snapshot = {
+        "report_kind": "qre_executable_hypothesis_selection",
+        "counts": {"selected": 0, "blocked": 1, "total": 1},
+        "selection_rows": [
+            {
+                "selection_id": "sel-blocked",
+                "selection_status": "selection_preset_bundle_empty",
+            }
+        ],
+    }
+
+    snapshot = materialization.collect_snapshot(
+        selection_snapshot=selection_snapshot,
+        generated_at_utc="2026-06-03T14:00:00Z",
+    )
+
+    assert snapshot["counts"]["materialized_route_ready"] == 0
+    assert snapshot["validation_warnings"] == ["selection_row_not_selected:sel-blocked"]
+    assert snapshot["final_recommendation"] == "selection_route_materialization_blocked"
+
+
+def test_no_write_cli_does_not_write_artifact(tmp_path, monkeypatch) -> None:
+    artifact_path = tmp_path / "latest.json"
+    monkeypatch.setattr(materialization, "ARTIFACT_LATEST", artifact_path)
+
+    rc = materialization.main(
+        [
+            "--no-write",
+            "--frozen-utc",
+            "2026-06-03T14:00:00Z",
+            "--indent",
+            "2",
+        ]
+    )
+
+    assert rc == 0
+    assert not artifact_path.exists()
+
+
+def test_cli_writes_only_own_artifact(tmp_path, monkeypatch) -> None:
+    artifact_path = tmp_path / "latest.json"
+    monkeypatch.setattr(materialization, "ARTIFACT_LATEST", artifact_path)
+
+    rc = materialization.main(
+        [
+            "--frozen-utc",
+            "2026-06-03T14:00:00Z",
+            "--indent",
+            "2",
+        ]
+    )
+
+    assert rc == 0
+    assert artifact_path.exists()
+    payload = json.loads(artifact_path.read_text(encoding="utf-8"))
+    assert payload["report_kind"] == "qre_selection_route_materialization"
+    assert payload["safe_to_execute"] is False
+    assert payload["counts"]["materialized_route_ready"] == 3

--- a/tests/unit/test_qre_selection_route_validation_flow.py
+++ b/tests/unit/test_qre_selection_route_validation_flow.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import json
+
+import reporting.qre_selection_route_materialization as materialization
+import reporting.qre_selection_route_validation_flow as flow
+
+
+def test_selection_route_validation_flow_is_ready() -> None:
+    snapshot = flow.collect_snapshot(generated_at_utc="2026-06-03T15:00:00Z")
+
+    assert snapshot["report_kind"] == "qre_selection_route_validation_flow"
+    assert snapshot["safe_to_execute"] is False
+    assert snapshot["read_only"] is True
+    assert snapshot["eligible_for_direct_execution"] is False
+    assert snapshot["counts"]["materialized_route_ready"] == 3
+    assert snapshot["counts"]["hypothesis_ready"] == 3
+    assert snapshot["counts"]["request_ready_for_operator_review"] == 3
+    assert snapshot["counts"]["dry_run_ready"] == 3
+    assert snapshot["counts"]["selection_validation_flow_ready"] == 3
+    assert (
+        snapshot["final_recommendation"]
+        == "selection_route_validation_flow_ready_for_operator_review"
+    )
+
+
+def test_flow_preserves_child_summary_counts() -> None:
+    snapshot = flow.collect_snapshot(generated_at_utc="2026-06-03T15:00:00Z")
+
+    assert snapshot["materialization"]["counts"]["materialized_route_ready"] == 3
+    assert snapshot["readiness"]["counts"]["hypothesis_ready"] == 3
+    assert snapshot["validation_request"]["counts"]["ready"] == 3
+    assert snapshot["dry_run"]["counts"]["ready"] == 3
+    assert snapshot["dry_run"]["executed_anything"] is False
+
+
+def test_flow_fails_closed_when_materialization_has_no_ready_rows() -> None:
+    materialization_snapshot = materialization.collect_snapshot(
+        selection_snapshot={
+            "report_kind": "qre_executable_hypothesis_selection",
+            "counts": {"selected": 0, "blocked": 1, "total": 1},
+            "selection_rows": [
+                {
+                    "selection_id": "blocked-row",
+                    "selection_status": "selection_preset_bundle_empty",
+                }
+            ],
+        },
+        generated_at_utc="2026-06-03T15:00:00Z",
+    )
+
+    snapshot = flow.collect_snapshot(
+        materialization_snapshot=materialization_snapshot,
+        generated_at_utc="2026-06-03T15:00:00Z",
+    )
+
+    assert snapshot["counts"]["materialized_route_ready"] == 0
+    assert snapshot["counts"]["hypothesis_ready"] == 0
+    assert snapshot["counts"]["request_ready_for_operator_review"] == 0
+    assert snapshot["counts"]["dry_run_ready"] == 0
+    assert snapshot["counts"]["selection_validation_flow_ready"] == 0
+    assert snapshot["final_recommendation"] == "selection_route_validation_flow_blocked"
+
+
+def test_flow_uses_temp_files_without_mutating_legacy_artifacts(tmp_path, monkeypatch) -> None:
+    artifact_path = tmp_path / "flow.json"
+    monkeypatch.setattr(flow, "ARTIFACT_LATEST", artifact_path)
+
+    rc = flow.main(
+        [
+            "--frozen-utc",
+            "2026-06-03T15:00:00Z",
+            "--indent",
+            "2",
+        ]
+    )
+
+    assert rc == 0
+    assert artifact_path.exists()
+    payload = json.loads(artifact_path.read_text(encoding="utf-8"))
+    assert payload["report_kind"] == "qre_selection_route_validation_flow"
+    assert payload["safe_to_execute"] is False
+    assert payload["counts"]["selection_validation_flow_ready"] == 3
+
+
+def test_no_write_cli_does_not_write_artifact(tmp_path, monkeypatch) -> None:
+    artifact_path = tmp_path / "flow.json"
+    monkeypatch.setattr(flow, "ARTIFACT_LATEST", artifact_path)
+
+    rc = flow.main(
+        [
+            "--no-write",
+            "--frozen-utc",
+            "2026-06-03T15:00:00Z",
+            "--indent",
+            "2",
+        ]
+    )
+
+    assert rc == 0
+    assert not artifact_path.exists()


### PR DESCRIPTION
Adds a safe selection-route-aware QRE closed-loop E2E layer. Legacy route remains visible and blocked, while selection route reports request_ready_for_operator_review=3, dry_run_ready=3, selection_route_ready=True, and controlled regeneration can be considered only as an operator-gated follow-up. Default verifier does not call live, paper, shadow, broker, risk, execution, scheduler, Codex, or research.run_research paths.