### PR TITLE
feat: expose QRE selection validation flow examples

### DIFF
--- a/reporting/qre_selection_route_validation_flow.py
+++ b/reporting/qre_selection_route_validation_flow.py
@@ -45,6 +45,62 @@ def _readiness_counts(snapshot: dict[str, Any]) -> dict[str, Any]:
     return counts if isinstance(counts, dict) else {}
 
 
+def _bounded_examples(
+    rows: Any,
+    *,
+    max_items: int = 5,
+    allowed_fields: tuple[str, ...],
+) -> list[dict[str, Any]]:
+    if not isinstance(rows, list):
+        return []
+    examples: list[dict[str, Any]] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        item: dict[str, Any] = {}
+        for field in allowed_fields:
+            value = row.get(field)
+            if isinstance(value, list):
+                item[field] = value[:10]
+            elif isinstance(value, dict):
+                item[field] = dict(list(value.items())[:10])
+            else:
+                item[field] = value
+        examples.append(item)
+        if len(examples) >= max_items:
+            break
+    return examples
+
+
+_REQUEST_EXAMPLE_FIELDS: tuple[str, ...] = (
+    "request_id",
+    "request_status",
+    "qre_hypothesis_id",
+    "executable_hypothesis_id",
+    "preset_name",
+    "asset",
+    "timeframe",
+    "validation_plan_id",
+    "run_manifest_id",
+    "allowed_command_preview",
+    "requires_operator_approval",
+    "safe_to_execute",
+)
+
+_DRY_RUN_EXAMPLE_FIELDS: tuple[str, ...] = (
+    "request_id",
+    "dry_run_status",
+    "qre_hypothesis_id",
+    "asset",
+    "timeframe",
+    "would_run_command_preview",
+    "would_write_artifacts",
+    "backup_required",
+    "executed",
+    "safe_to_execute",
+)
+
+
 def _base_snapshot(
     *,
     generated_at_utc: str,
@@ -105,10 +161,18 @@ def _base_snapshot(
         },
         "validation_request": {
             "counts": request_counts,
+            "examples": _bounded_examples(
+                validation_request_snapshot.get("validation_requests"),
+                allowed_fields=_REQUEST_EXAMPLE_FIELDS,
+            ),
             "final_recommendation": validation_request_snapshot.get("final_recommendation"),
         },
         "dry_run": {
             "counts": dry_run_counts,
+            "examples": _bounded_examples(
+                dry_run_snapshot.get("dry_run_results"),
+                allowed_fields=_DRY_RUN_EXAMPLE_FIELDS,
+            ),
             "executed_anything": dry_run_snapshot.get("executed_anything", False),
             "final_recommendation": dry_run_snapshot.get("final_recommendation"),
         },

--- a/tests/unit/test_qre_selection_route_validation_flow.py
+++ b/tests/unit/test_qre_selection_route_validation_flow.py
@@ -99,3 +99,41 @@ def test_no_write_cli_does_not_write_artifact(tmp_path, monkeypatch) -> None:
 
     assert rc == 0
     assert not artifact_path.exists()
+
+
+def test_selection_route_validation_flow_includes_bounded_request_and_dry_run_examples() -> None:
+    snapshot = flow.collect_snapshot(generated_at_utc="2026-06-03T15:00:00Z")
+
+    request_examples = snapshot["validation_request"]["examples"]
+    dry_run_examples = snapshot["dry_run"]["examples"]
+
+    assert len(request_examples) == 3
+    assert len(dry_run_examples) == 3
+
+    for example in request_examples:
+        assert example["request_id"]
+        assert example["request_status"] == "request_ready_for_operator_review"
+        assert example["qre_hypothesis_id"].startswith("qre-hyp-sel-")
+        assert example["executable_hypothesis_id"]
+        assert example["preset_name"]
+        assert example["asset"] == "BTC-EUR"
+        assert example["timeframe"] in {"1h", "4h"}
+        assert example["allowed_command_preview"]
+        assert example["requires_operator_approval"] is True
+        assert example["safe_to_execute"] is False
+
+    for example in dry_run_examples:
+        assert example["request_id"]
+        assert example["dry_run_status"] == "dry_run_ready"
+        assert example["qre_hypothesis_id"].startswith("qre-hyp-sel-")
+        assert example["asset"] == "BTC-EUR"
+        assert example["timeframe"] in {"1h", "4h"}
+        assert example["would_run_command_preview"]
+        assert example["would_write_artifacts"] == [
+            "research/run_candidates_latest.v1.json",
+            "research/screening_evidence_latest.v1.json",
+            "research/history/<run_id>/...",
+        ]
+        assert example["backup_required"] is True
+        assert example["executed"] is False
+        assert example["safe_to_execute"] is False


### PR DESCRIPTION
Adds bounded operator-facing examples to qre_selection_route_validation_flow. The flow now exposes request examples and dry-run examples for the three selection-derived hypotheses, including request status, dry-run status, command previews, artifact write previews, backup requirement, executed=false, and safe_to_execute=false. This improves inspectability before any controlled regeneration step.