### PR TITLE
feat: add QRE equities selection preflight route

### DIFF
--- a/reporting/qre_selection_closed_loop_preflight.py
+++ b/reporting/qre_selection_closed_loop_preflight.py
@@ -106,6 +106,38 @@ def _base_snapshot(
                 "controlled_regeneration_not_executed_by_preflight",
             ],
         },
+        "next_capability_gaps": {
+            "real_market_data_intake": {
+                "status": "not_implemented_in_this_preflight",
+                "required_next_step": "add quality-gated market observation intake",
+                "may_mutate_state": False,
+            },
+            "autonomous_hypothesis_generation": {
+                "status": "not_implemented_in_this_preflight",
+                "required_next_step": "add bounded market-data-derived hypothesis proposal",
+                "may_mutate_state": False,
+            },
+            "controlled_validation_execution": {
+                "status": "operator_go_required",
+                "required_next_step": "add explicit controlled validation execution flag and operator-go phrase",
+                "may_mutate_state": True,
+            },
+            "result_analysis": {
+                "status": "requires_completed_validation_run",
+                "required_next_step": "materialize post-run analysis from validation artifacts",
+                "may_mutate_state": False,
+            },
+            "learning_update": {
+                "status": "requires_completed_validation_run",
+                "required_next_step": "write deterministic learning proposal artifact after analysis",
+                "may_mutate_state": False,
+            },
+            "research_action_queue_mutation": {
+                "status": "blocked_without_explicit_operator_go",
+                "required_next_step": "add separate queue-write gate after learning proposal review",
+                "may_mutate_state": True,
+            },
+        },
         "validation_warnings": [
             *list(flow_snapshot.get("validation_warnings") or []),
             *list(bridge_snapshot.get("validation_warnings") or []),

--- a/reporting/qre_selection_closed_loop_preflight.py
+++ b/reporting/qre_selection_closed_loop_preflight.py
@@ -122,10 +122,14 @@ def collect_snapshot(
     *,
     flow_snapshot: dict[str, Any] | None = None,
     bridge_snapshot: dict[str, Any] | None = None,
+    profile_name: str | None = None,
     generated_at_utc: str | None = None,
 ) -> dict[str, Any]:
     generated = generated_at_utc or _utcnow()
-    active_flow = flow_snapshot or validation_flow.collect_snapshot(generated_at_utc=generated)
+    active_flow = flow_snapshot or validation_flow.collect_snapshot(
+        profile_name=profile_name,
+        generated_at_utc=generated,
+    )
     active_bridge = bridge_snapshot or bridge.collect_snapshot(generated_at_utc=generated)
 
     return _base_snapshot(
@@ -147,12 +151,16 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--no-write", action="store_true")
     parser.add_argument("--indent", type=int, default=2)
     parser.add_argument("--frozen-utc")
+    parser.add_argument("--profile")
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
-    snapshot = collect_snapshot(generated_at_utc=args.frozen_utc)
+    snapshot = collect_snapshot(
+        profile_name=args.profile,
+        generated_at_utc=args.frozen_utc,
+    )
     if not args.no_write:
         write_outputs(snapshot)
     print(json.dumps(snapshot, indent=args.indent, sort_keys=True))

--- a/reporting/qre_selection_route_materialization.py
+++ b/reporting/qre_selection_route_materialization.py
@@ -312,13 +312,22 @@ def _base_snapshot(
 def collect_snapshot(
     *,
     selection_snapshot: dict[str, Any] | None = None,
+    profile_name: str | None = None,
     generated_at_utc: str | None = None,
 ) -> dict[str, Any]:
     generated = generated_at_utc or _utcnow()
     warnings: list[str] = []
-    active_selection_snapshot = selection_snapshot or selection.collect_snapshot(
-        generated_at_utc=generated,
-    )
+    if selection_snapshot is not None:
+        active_selection_snapshot = selection_snapshot
+    elif profile_name is not None:
+        active_selection_snapshot = selection.collect_snapshot(
+            profile_name=profile_name,
+            generated_at_utc=generated,
+        )
+    else:
+        active_selection_snapshot = selection.collect_snapshot(
+            generated_at_utc=generated,
+        )
     if not isinstance(active_selection_snapshot, dict):
         active_selection_snapshot = {}
         warnings.append(NOTE_SELECTION_INPUT_UNAVAILABLE)
@@ -352,12 +361,16 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--no-write", action="store_true")
     parser.add_argument("--indent", type=int, default=2)
     parser.add_argument("--frozen-utc")
+    parser.add_argument("--profile")
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
-    snapshot = collect_snapshot(generated_at_utc=args.frozen_utc)
+    snapshot = collect_snapshot(
+        profile_name=args.profile,
+        generated_at_utc=args.frozen_utc,
+    )
     if not args.no_write:
         write_outputs(snapshot)
     print(json.dumps(snapshot, indent=args.indent, sort_keys=True))

--- a/reporting/qre_selection_route_validation_flow.py
+++ b/reporting/qre_selection_route_validation_flow.py
@@ -193,10 +193,12 @@ def _base_snapshot(
 def collect_snapshot(
     *,
     materialization_snapshot: dict[str, Any] | None = None,
+    profile_name: str | None = None,
     generated_at_utc: str | None = None,
 ) -> dict[str, Any]:
     generated = generated_at_utc or _utcnow()
     active_materialization = materialization_snapshot or materialization.collect_snapshot(
+        profile_name=profile_name,
         generated_at_utc=generated,
     )
 
@@ -269,12 +271,16 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--no-write", action="store_true")
     parser.add_argument("--indent", type=int, default=2)
     parser.add_argument("--frozen-utc")
+    parser.add_argument("--profile")
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
-    snapshot = collect_snapshot(generated_at_utc=args.frozen_utc)
+    snapshot = collect_snapshot(
+        profile_name=args.profile,
+        generated_at_utc=args.frozen_utc,
+    )
     if not args.no_write:
         write_outputs(snapshot)
     print(json.dumps(snapshot, indent=args.indent, sort_keys=True))

--- a/research/discovery_sprint.py
+++ b/research/discovery_sprint.py
@@ -5,7 +5,7 @@ the existing v3.15.2 Campaign Operating Layer (COL). It does NOT spawn,
 queue, lease, or otherwise mutate campaigns — COL keeps owning that.
 This module:
 
-1. Validates a closed built-in profile (currently ``crypto_exploratory_v1``).
+1. Validates a closed built-in profile such as ``crypto_exploratory_v1`` or ``equities_exploratory_v1``.
 2. Derives a deterministic plan from the existing
    ``research.strategy_hypothesis_catalog`` and ``research.presets``
    binding (no new strategies, no new presets).
@@ -32,6 +32,7 @@ Hard constraints honoured:
 CLI::
 
     python -m research.discovery_sprint plan   --profile crypto_exploratory_v1
+    python -m research.discovery_sprint plan   --profile equities_exploratory_v1
     python -m research.discovery_sprint run    --profile crypto_exploratory_v1
     python -m research.discovery_sprint status
     python -m research.discovery_sprint report
@@ -211,8 +212,21 @@ CRYPTO_EXPLORATORY_V1: Final[SprintProfile] = SprintProfile(
     exclude_promotion_grade=True,
 )
 
+EQUITIES_EXPLORATORY_V1: Final[SprintProfile] = SprintProfile(
+    name="equities_exploratory_v1",
+    target_campaigns=25,
+    max_days=5,
+    asset_class="equity",
+    timeframes=("4h",),
+    screening_phase="exploratory",
+    hypotheses=("trend_pullback_v1",),
+    exclude_equities=False,
+    exclude_promotion_grade=True,
+)
+
 BUILTIN_PROFILES: Final[dict[str, SprintProfile]] = {
     CRYPTO_EXPLORATORY_V1.name: CRYPTO_EXPLORATORY_V1,
+    EQUITIES_EXPLORATORY_V1.name: EQUITIES_EXPLORATORY_V1,
 }
 
 
@@ -1650,6 +1664,7 @@ __all__ = [
     "ASSET_CLASSES",
     "BUILTIN_PROFILES",
     "CRYPTO_EXPLORATORY_V1",
+    "EQUITIES_EXPLORATORY_V1",
     "INACTIVE_SPRINT_STATES",
     "INSUFFICIENT_TRADES_MIN_HISTORY",
     "INSUFFICIENT_TRADES_RATE_THRESHOLD",

--- a/tests/unit/test_discovery_sprint.py
+++ b/tests/unit/test_discovery_sprint.py
@@ -18,8 +18,11 @@ from research import discovery_sprint as ds
 # ---------------------------------------------------------------------------
 
 
-def test_builtin_profiles_only_contains_crypto_exploratory_v1() -> None:
-    assert set(ds.BUILTIN_PROFILES) == {"crypto_exploratory_v1"}
+def test_builtin_profiles_contains_expected_closed_profiles() -> None:
+    assert set(ds.BUILTIN_PROFILES) == {
+        "crypto_exploratory_v1",
+        "equities_exploratory_v1",
+    }
 
 
 def test_crypto_exploratory_v1_spec_is_exact() -> None:
@@ -34,6 +37,18 @@ def test_crypto_exploratory_v1_spec_is_exact() -> None:
         "volatility_compression_breakout_v0",
     )
     assert profile.exclude_equities is True
+    assert profile.exclude_promotion_grade is True
+
+
+def test_equities_exploratory_v1_spec_is_exact() -> None:
+    profile = ds.get_profile("equities_exploratory_v1")
+    assert profile.target_campaigns == 25
+    assert profile.max_days == 5
+    assert profile.asset_class == "equity"
+    assert profile.timeframes == ("4h",)
+    assert profile.screening_phase == "exploratory"
+    assert profile.hypotheses == ("trend_pullback_v1",)
+    assert profile.exclude_equities is False
     assert profile.exclude_promotion_grade is True
 
 
@@ -169,6 +184,16 @@ def test_plan_contains_both_target_presets() -> None:
     preset_names = {e.preset_name for e in plan}
     assert "trend_pullback_crypto_1h" in preset_names
     assert "vol_compression_breakout_crypto_1h" in preset_names
+
+
+def test_equities_plan_contains_only_trend_pullback_equities_4h() -> None:
+    profile = ds.get_profile("equities_exploratory_v1")
+    plan = ds.derive_plan(profile)
+
+    assert [entry.preset_name for entry in plan] == ["trend_pullback_equities_4h"]
+    assert [entry.asset_class for entry in plan] == ["equity"]
+    assert [entry.timeframe for entry in plan] == ["4h"]
+    assert [entry.hypothesis_id for entry in plan] == ["trend_pullback_v1"]
 
 
 def test_infer_asset_class_handles_known_universes() -> None:

--- a/tests/unit/test_qre_executable_hypothesis_selection.py
+++ b/tests/unit/test_qre_executable_hypothesis_selection.py
@@ -313,3 +313,42 @@ def test_selection_rows_can_feed_request_and_dry_run_route(tmp_path) -> None:
         assert row["safe_to_execute"] is False
         assert row["executed"] is False
         assert row["would_run_command_preview"]
+
+def test_equities_profile_selects_trend_pullback_equities_4h_only() -> None:
+    snapshot = selection.collect_snapshot(
+        profile_name="equities_exploratory_v1",
+        generated_at_utc="2026-06-03T12:00:00Z",
+    )
+
+    assert snapshot["report_kind"] == "qre_executable_hypothesis_selection"
+    assert snapshot["safe_to_execute"] is False
+    assert snapshot["read_only"] is True
+    assert snapshot["eligible_for_direct_execution"] is False
+    assert snapshot["launches_codex"] is False
+    assert snapshot["launches_subprocess"] is False
+    assert snapshot["mutates_strategy_or_preset"] is False
+    assert snapshot["mutates_campaign_queue"] is False
+    assert snapshot["mutates_paper_shadow_live_runtime"] is False
+
+    assert snapshot["selection_profile_name"] == "equities_exploratory_v1"
+    assert snapshot["counts"]["selected"] == 1
+    assert snapshot["counts"]["blocked"] == 0
+    assert snapshot["counts"]["total"] == 1
+    assert snapshot["final_recommendation"] == (
+        "executable_hypothesis_selections_ready_for_operator_review"
+    )
+
+    rows = snapshot["selection_rows"]
+    assert [row["preset_name"] for row in rows] == ["trend_pullback_equities_4h"]
+    row = rows[0]
+    assert row["source_hypothesis_id"] == "trend_pullback_v1"
+    assert row["executable_hypothesis_id"] == "trend_pullback_v1"
+    assert row["asset"] == "NVDA"
+    assert row["symbol"] == "NVDA"
+    assert row["timeframe"] == "4h"
+    assert row["interval"] == "4h"
+    assert row["asset_class"] == "equity"
+    assert row["selection_status"] == "selected"
+    assert row["requires_operator_approval"] is True
+    assert row["safe_to_execute"] is False
+

--- a/tests/unit/test_qre_selection_closed_loop_preflight.py
+++ b/tests/unit/test_qre_selection_closed_loop_preflight.py
@@ -137,3 +137,27 @@ def test_preflight_cli_write_and_no_write(tmp_path, monkeypatch) -> None:
     assert payload["report_kind"] == "qre_selection_closed_loop_preflight"
     assert payload["safe_to_execute"] is False
     assert payload["controlled_regeneration_preflight"]["can_be_considered"] is True
+
+def test_equities_preflight_allows_considering_controlled_regeneration() -> None:
+    snapshot = preflight.collect_snapshot(
+        profile_name="equities_exploratory_v1",
+        generated_at_utc="2026-06-03T16:00:00Z",
+    )
+
+    assert snapshot["report_kind"] == "qre_selection_closed_loop_preflight"
+    assert snapshot["safe_to_execute"] is False
+    assert snapshot["read_only"] is True
+    assert snapshot["eligible_for_direct_execution"] is False
+    assert snapshot["selection_route"]["ready"] is True
+    assert snapshot["selection_route"]["counts"]["request_ready_for_operator_review"] == 1
+    assert snapshot["selection_route"]["counts"]["dry_run_ready"] == 1
+    assert snapshot["controlled_regeneration_preflight"]["can_be_considered"] is True
+    assert (
+        "selection_route_validation_flow_ready"
+        in snapshot["controlled_regeneration_preflight"]["reason_codes"]
+    )
+    assert (
+        snapshot["final_recommendation"]
+        == "selection_route_ready_controlled_regeneration_can_be_considered"
+    )
+

--- a/tests/unit/test_qre_selection_closed_loop_preflight.py
+++ b/tests/unit/test_qre_selection_closed_loop_preflight.py
@@ -161,3 +161,31 @@ def test_equities_preflight_allows_considering_controlled_regeneration() -> None
         == "selection_route_ready_controlled_regeneration_can_be_considered"
     )
 
+def test_preflight_reports_next_capability_gaps() -> None:
+    snapshot = preflight.collect_snapshot(
+        profile_name="equities_exploratory_v1",
+        generated_at_utc="2026-06-03T16:00:00Z",
+    )
+
+    gaps = snapshot["next_capability_gaps"]
+
+    assert gaps["real_market_data_intake"]["status"] == (
+        "not_implemented_in_this_preflight"
+    )
+    assert gaps["autonomous_hypothesis_generation"]["status"] == (
+        "not_implemented_in_this_preflight"
+    )
+    assert gaps["controlled_validation_execution"]["status"] == "operator_go_required"
+    assert gaps["result_analysis"]["status"] == "requires_completed_validation_run"
+    assert gaps["learning_update"]["status"] == "requires_completed_validation_run"
+    assert gaps["research_action_queue_mutation"]["status"] == (
+        "blocked_without_explicit_operator_go"
+    )
+
+    assert gaps["real_market_data_intake"]["may_mutate_state"] is False
+    assert gaps["autonomous_hypothesis_generation"]["may_mutate_state"] is False
+    assert gaps["controlled_validation_execution"]["may_mutate_state"] is True
+    assert gaps["result_analysis"]["may_mutate_state"] is False
+    assert gaps["learning_update"]["may_mutate_state"] is False
+    assert gaps["research_action_queue_mutation"]["may_mutate_state"] is True
+

--- a/tests/unit/test_qre_selection_route_materialization.py
+++ b/tests/unit/test_qre_selection_route_materialization.py
@@ -213,3 +213,34 @@ def test_cli_writes_only_own_artifact(tmp_path, monkeypatch) -> None:
     assert payload["report_kind"] == "qre_selection_route_materialization"
     assert payload["safe_to_execute"] is False
     assert payload["counts"]["materialized_route_ready"] == 3
+
+def test_materializes_equities_profile_route_artifacts() -> None:
+    snapshot = materialization.collect_snapshot(
+        profile_name="equities_exploratory_v1",
+        generated_at_utc="2026-06-03T14:00:00Z",
+    )
+
+    assert snapshot["report_kind"] == "qre_selection_route_materialization"
+    assert snapshot["safe_to_execute"] is False
+    assert snapshot["read_only"] is True
+    assert snapshot["counts"]["observations"] == 1
+    assert snapshot["counts"]["hypotheses"] == 1
+    assert snapshot["counts"]["validation_plans"] == 1
+    assert snapshot["counts"]["run_manifests"] == 1
+    assert snapshot["counts"]["materialized_route_ready"] == 1
+    assert snapshot["final_recommendation"] == "selection_route_materialized_for_validation_request"
+
+    observations = snapshot["market_observation_payload"]["observations"]
+    hypotheses = snapshot["hypothesis_candidates_payload"]["hypotheses"]
+    plans = snapshot["validation_plans_payload"]["validation_plans"]
+    manifests = snapshot["run_manifest_payload"]["run_manifests"]
+
+    assert [row["asset"] for row in observations] == ["NVDA"]
+    assert [row["timeframe"] for row in observations] == ["4h"]
+    assert observations[0]["market_context"]["selection_profile_name"] == (
+        "equities_exploratory_v1"
+    )
+    assert [row["preset_name"] for row in hypotheses] == ["trend_pullback_equities_4h"]
+    assert [row["asset"] for row in plans] == ["NVDA"]
+    assert [row["timeframe"] for row in manifests] == ["4h"]
+

--- a/tests/unit/test_qre_selection_route_validation_flow.py
+++ b/tests/unit/test_qre_selection_route_validation_flow.py
@@ -137,3 +137,39 @@ def test_selection_route_validation_flow_includes_bounded_request_and_dry_run_ex
         assert example["backup_required"] is True
         assert example["executed"] is False
         assert example["safe_to_execute"] is False
+
+def test_equities_selection_route_validation_flow_is_ready() -> None:
+    snapshot = flow.collect_snapshot(
+        profile_name="equities_exploratory_v1",
+        generated_at_utc="2026-06-03T15:00:00Z",
+    )
+
+    assert snapshot["report_kind"] == "qre_selection_route_validation_flow"
+    assert snapshot["safe_to_execute"] is False
+    assert snapshot["read_only"] is True
+    assert snapshot["eligible_for_direct_execution"] is False
+    assert snapshot["counts"]["materialized_route_ready"] == 1
+    assert snapshot["counts"]["hypothesis_ready"] == 1
+    assert snapshot["counts"]["request_ready_for_operator_review"] == 1
+    assert snapshot["counts"]["dry_run_ready"] == 1
+    assert snapshot["counts"]["selection_validation_flow_ready"] == 1
+    assert (
+        snapshot["final_recommendation"]
+        == "selection_route_validation_flow_ready_for_operator_review"
+    )
+
+    request_examples = snapshot["validation_request"]["examples"]
+    dry_run_examples = snapshot["dry_run"]["examples"]
+
+    assert len(request_examples) == 1
+    assert len(dry_run_examples) == 1
+    assert request_examples[0]["preset_name"] == "trend_pullback_equities_4h"
+    assert request_examples[0]["asset"] == "NVDA"
+    assert request_examples[0]["timeframe"] == "4h"
+    assert request_examples[0]["requires_operator_approval"] is True
+    assert request_examples[0]["safe_to_execute"] is False
+    assert dry_run_examples[0]["asset"] == "NVDA"
+    assert dry_run_examples[0]["timeframe"] == "4h"
+    assert dry_run_examples[0]["executed"] is False
+    assert dry_run_examples[0]["safe_to_execute"] is False
+


### PR DESCRIPTION
## Summary
- Add equities_exploratory_v1 as a closed built-in QRE discovery profile.
- Route the profile through executable selection, route materialization, validation flow, and closed-loop preflight.
- Add operator-facing next_capability_gaps so the remaining steps toward real market-data intake, controlled validation execution, post-run analysis, learning updates, and research-action queue mutation are explicit.

## Safety
- No default profile change.
- No new strategy or preset.
- No campaign queue mutation.
- No Codex/runtime launch.
- No paper/shadow/live activation.
- No broker/risk/execution changes.
- No research-action queue writes.
- Preflight remains read-only and safe_to_execute=false.

## Validation
- python -m pytest tests/unit/test_discovery_sprint.py tests/unit/test_discovery_sprint_routing.py tests/unit/test_discovery_sprint_safeguards.py tests/unit/test_qre_executable_hypothesis_selection.py tests/unit/test_qre_selection_route_materialization.py tests/unit/test_qre_selection_route_validation_flow.py tests/unit/test_qre_selection_closed_loop_preflight.py -q
- 101 passed
- python -m reporting.qre_selection_closed_loop_preflight --profile equities_exploratory_v1 --no-write --indent 2 --frozen-utc 2026-06-03T16:00:00Z