### PR TITLE
feat: add QRE controlled validation loop gates

### DIFF
--- a/reporting/qre_controlled_validation_execution.py
+++ b/reporting/qre_controlled_validation_execution.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import argparse
 import datetime as dt

--- a/reporting/qre_controlled_validation_execution.py
+++ b/reporting/qre_controlled_validation_execution.py
@@ -1,0 +1,246 @@
+﻿from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import tempfile
+from pathlib import Path
+from typing import Any, Final
+
+from reporting import qre_selection_closed_loop_preflight as preflight
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[int] = 1
+REPORT_KIND: Final[str] = "qre_controlled_validation_execution"
+
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "qre_controlled_validation_execution"
+OUTPUT_ARTIFACT_RELATIVE_PATH: Final[str] = "logs/qre_controlled_validation_execution/latest.json"
+ARTIFACT_LATEST: Final[Path] = REPO_ROOT / OUTPUT_ARTIFACT_RELATIVE_PATH
+
+REQUIRED_OPERATOR_GO_PHRASE: Final[str] = (
+    "I authorize QRE controlled validation execution"
+)
+
+EXECUTION_BLOCKED_NOT_REQUESTED: Final[str] = "execution_blocked_not_requested"
+EXECUTION_BLOCKED_PREFLIGHT_NOT_READY: Final[str] = "execution_blocked_preflight_not_ready"
+EXECUTION_BLOCKED_OPERATOR_GO_MISSING: Final[str] = "execution_blocked_operator_go_missing"
+EXECUTION_BLOCKED_OPERATOR_GO_MISMATCH: Final[str] = "execution_blocked_operator_go_mismatch"
+EXECUTION_AUTHORIZED_RUNNER_NOT_CONNECTED: Final[str] = (
+    "execution_authorized_runner_not_connected"
+)
+
+EXECUTION_STATUSES: Final[tuple[str, ...]] = (
+    EXECUTION_BLOCKED_NOT_REQUESTED,
+    EXECUTION_BLOCKED_PREFLIGHT_NOT_READY,
+    EXECUTION_BLOCKED_OPERATOR_GO_MISSING,
+    EXECUTION_BLOCKED_OPERATOR_GO_MISMATCH,
+    EXECUTION_AUTHORIZED_RUNNER_NOT_CONNECTED,
+)
+
+
+def _utcnow() -> str:
+    return (
+        dt.datetime.now(dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _rel(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(REPO_ROOT.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _authorization_status(
+    *,
+    execute_controlled_validation: bool,
+    operator_go: str | None,
+    selection_route_ready: bool,
+) -> str:
+    if not execute_controlled_validation:
+        return EXECUTION_BLOCKED_NOT_REQUESTED
+    if not selection_route_ready:
+        return EXECUTION_BLOCKED_PREFLIGHT_NOT_READY
+    if operator_go is None or operator_go.strip() == "":
+        return EXECUTION_BLOCKED_OPERATOR_GO_MISSING
+    if operator_go.strip() != REQUIRED_OPERATOR_GO_PHRASE:
+        return EXECUTION_BLOCKED_OPERATOR_GO_MISMATCH
+    return EXECUTION_AUTHORIZED_RUNNER_NOT_CONNECTED
+
+
+def _counts(status: str) -> dict[str, Any]:
+    return {
+        "total": 1,
+        "authorized": 1 if status == EXECUTION_AUTHORIZED_RUNNER_NOT_CONNECTED else 0,
+        "blocked": 0 if status == EXECUTION_AUTHORIZED_RUNNER_NOT_CONNECTED else 1,
+        "by_execution_status": {
+            candidate: 1 if candidate == status else 0
+            for candidate in EXECUTION_STATUSES
+        },
+    }
+
+
+def _final_recommendation(status: str) -> str:
+    if status == EXECUTION_AUTHORIZED_RUNNER_NOT_CONNECTED:
+        return "controlled_validation_execution_authorized_runner_not_connected"
+    return "controlled_validation_execution_blocked"
+
+
+def collect_snapshot(
+    *,
+    profile_name: str | None = None,
+    execute_controlled_validation: bool = False,
+    operator_go: str | None = None,
+    preflight_snapshot: dict[str, Any] | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    generated = generated_at_utc or _utcnow()
+    active_preflight = preflight_snapshot or preflight.collect_snapshot(
+        profile_name=profile_name,
+        generated_at_utc=generated,
+    )
+
+    selection_route = active_preflight.get("selection_route") or {}
+    selection_route_ready = selection_route.get("ready") is True
+    status = _authorization_status(
+        execute_controlled_validation=execute_controlled_validation,
+        operator_go=operator_go,
+        selection_route_ready=selection_route_ready,
+    )
+    authorized = status == EXECUTION_AUTHORIZED_RUNNER_NOT_CONNECTED
+
+    return {
+        "report_kind": REPORT_KIND,
+        "schema_version": SCHEMA_VERSION,
+        "generated_at_utc": generated,
+        "selection_profile_name": profile_name,
+        "safe_to_execute": False,
+        "read_only": True,
+        "eligible_for_direct_execution": False,
+        "launches_subprocess": False,
+        "launches_codex": False,
+        "executed_anything": False,
+        "mutates_campaign_queue": False,
+        "mutates_strategy_or_preset": False,
+        "mutates_paper_shadow_live_runtime": False,
+        "writes_research_action_queue": False,
+        "writes_development_work_queue": False,
+        "writes_seed_jsonl": False,
+        "writes_generated_seed_jsonl": False,
+        "controlled_validation_authorized": authorized,
+        "live_or_paper_execution_authorized": False,
+        "runner_adapter_status": "not_connected",
+        "execution_status": status,
+        "final_recommendation": _final_recommendation(status),
+        "counts": _counts(status),
+        "operator_authorization": {
+            "required": True,
+            "provided": operator_go is not None and operator_go.strip() != "",
+            "matched": operator_go is not None
+            and operator_go.strip() == REQUIRED_OPERATOR_GO_PHRASE,
+            "required_phrase": REQUIRED_OPERATOR_GO_PHRASE,
+        },
+        "preflight": {
+            "report_kind": active_preflight.get("report_kind"),
+            "final_recommendation": active_preflight.get("final_recommendation"),
+            "selection_route_ready": selection_route_ready,
+            "selection_route_counts": selection_route.get("counts") or {},
+            "controlled_regeneration_can_be_considered": (
+                (active_preflight.get("controlled_regeneration_preflight") or {}).get(
+                    "can_be_considered"
+                )
+                is True
+            ),
+        },
+        "planned_runner": {
+            "module": "research.controlled_eval",
+            "callable": "run_controlled_eval",
+            "connected": False,
+            "reason": "runner adapter intentionally not connected in authority-contract stage",
+        },
+        "would_write_artifacts": [
+            "logs/qre_controlled_validation_execution/latest.json",
+        ],
+        "validation_warnings": [],
+    }
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    if not path.resolve().is_relative_to(ARTIFACT_DIR.resolve()):
+        raise ValueError(f"refusing write outside QRE controlled validation dir: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".qre_controlled_validation_execution.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with open(fd, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(text)
+        Path(tmp_name).replace(path)
+    finally:
+        tmp_path = Path(tmp_name)
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+def write_outputs(
+    snapshot: dict[str, Any],
+    *,
+    output_path: Path | None = None,
+) -> Path:
+    target = output_path or ARTIFACT_LATEST
+    _atomic_write_json(target, snapshot)
+    return target
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="reporting.qre_controlled_validation_execution",
+        description="Authorize QRE controlled validation execution without connecting a runner.",
+    )
+    parser.add_argument("--profile", default=None)
+    parser.add_argument("--execute-controlled-validation", action="store_true")
+    parser.add_argument("--operator-go", default=None)
+    parser.add_argument("--no-write", action="store_true")
+    parser.add_argument("--indent", type=int, default=2)
+    parser.add_argument("--frozen-utc", default=None)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    snapshot = collect_snapshot(
+        profile_name=args.profile,
+        execute_controlled_validation=bool(args.execute_controlled_validation),
+        operator_go=args.operator_go,
+        generated_at_utc=args.frozen_utc,
+    )
+    print(json.dumps(snapshot, indent=args.indent, sort_keys=True))
+    if not args.no_write:
+        write_outputs(snapshot)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())
+
+
+__all__ = [
+    "ARTIFACT_LATEST",
+    "EXECUTION_AUTHORIZED_RUNNER_NOT_CONNECTED",
+    "EXECUTION_BLOCKED_NOT_REQUESTED",
+    "EXECUTION_BLOCKED_OPERATOR_GO_MISMATCH",
+    "EXECUTION_BLOCKED_OPERATOR_GO_MISSING",
+    "EXECUTION_BLOCKED_PREFLIGHT_NOT_READY",
+    "REPORT_KIND",
+    "REQUIRED_OPERATOR_GO_PHRASE",
+    "collect_snapshot",
+    "main",
+    "write_outputs",
+]

--- a/reporting/qre_controlled_validation_learning_proposal.py
+++ b/reporting/qre_controlled_validation_learning_proposal.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import argparse
 import datetime as dt

--- a/reporting/qre_controlled_validation_learning_proposal.py
+++ b/reporting/qre_controlled_validation_learning_proposal.py
@@ -1,0 +1,231 @@
+﻿from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import tempfile
+from pathlib import Path
+from typing import Any, Final
+
+from reporting import qre_controlled_validation_result_analysis as analysis
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[int] = 1
+REPORT_KIND: Final[str] = "qre_controlled_validation_learning_proposal"
+
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "qre_controlled_validation_learning_proposal"
+OUTPUT_ARTIFACT_RELATIVE_PATH: Final[str] = (
+    "logs/qre_controlled_validation_learning_proposal/latest.json"
+)
+ARTIFACT_LATEST: Final[Path] = REPO_ROOT / OUTPUT_ARTIFACT_RELATIVE_PATH
+
+LEARNING_BLOCKED_ANALYSIS_NOT_READY: Final[str] = "learning_blocked_analysis_not_ready"
+LEARNING_READY_FOR_OPERATOR_REVIEW: Final[str] = "learning_ready_for_operator_review"
+
+LEARNING_STATUSES: Final[tuple[str, ...]] = (
+    LEARNING_BLOCKED_ANALYSIS_NOT_READY,
+    LEARNING_READY_FOR_OPERATOR_REVIEW,
+)
+
+
+def _utcnow() -> str:
+    return (
+        dt.datetime.now(dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _learning_status(analysis_snapshot: dict[str, Any]) -> str:
+    if analysis_snapshot.get("analysis_status") != "analysis_ready":
+        return LEARNING_BLOCKED_ANALYSIS_NOT_READY
+    return LEARNING_READY_FOR_OPERATOR_REVIEW
+
+
+def _counts(status: str) -> dict[str, Any]:
+    return {
+        "total": 1,
+        "ready": 1 if status == LEARNING_READY_FOR_OPERATOR_REVIEW else 0,
+        "blocked": 0 if status == LEARNING_READY_FOR_OPERATOR_REVIEW else 1,
+        "by_learning_status": {
+            candidate: 1 if candidate == status else 0
+            for candidate in LEARNING_STATUSES
+        },
+    }
+
+
+def _final_recommendation(status: str) -> str:
+    if status == LEARNING_READY_FOR_OPERATOR_REVIEW:
+        return "controlled_validation_learning_proposal_ready_for_operator_review"
+    return "controlled_validation_learning_proposal_blocked"
+
+
+def _proposal_from_analysis(analysis_snapshot: dict[str, Any], status: str) -> dict[str, Any]:
+    result_summary = analysis_snapshot.get("result_summary") or {}
+    evidence_refs = result_summary.get("evidence_refs")
+    if not isinstance(evidence_refs, list):
+        evidence_refs = []
+
+    if status != LEARNING_READY_FOR_OPERATOR_REVIEW:
+        return {
+            "available": False,
+            "outcome": None,
+            "hypothesis_action": None,
+            "next_research_action": None,
+            "evidence_refs": [],
+            "reason": "result analysis is not ready",
+        }
+
+    pass_fail = result_summary.get("pass_fail")
+    primary_failure_class = result_summary.get("primary_failure_class")
+    if pass_fail == "pass":
+        hypothesis_action = "continue_validation"
+        next_research_action = "consider_bounded_followup_validation"
+    elif pass_fail == "fail":
+        hypothesis_action = "do_not_promote"
+        next_research_action = "investigate_failure_class"
+    else:
+        hypothesis_action = "hold_for_operator_review"
+        next_research_action = "review_inconclusive_result"
+
+    return {
+        "available": True,
+        "outcome": pass_fail,
+        "hypothesis_action": hypothesis_action,
+        "next_research_action": next_research_action,
+        "primary_failure_class": primary_failure_class,
+        "evidence_refs": list(evidence_refs),
+        "reason": "derived from controlled validation result analysis",
+    }
+
+
+def collect_snapshot(
+    *,
+    profile_name: str | None = None,
+    analysis_snapshot: dict[str, Any] | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    generated = generated_at_utc or _utcnow()
+    active_analysis = analysis_snapshot or analysis.collect_snapshot(
+        profile_name=profile_name,
+        generated_at_utc=generated,
+    )
+
+    status = _learning_status(active_analysis)
+    proposal = _proposal_from_analysis(active_analysis, status)
+
+    return {
+        "report_kind": REPORT_KIND,
+        "schema_version": SCHEMA_VERSION,
+        "generated_at_utc": generated,
+        "selection_profile_name": (
+            profile_name or active_analysis.get("selection_profile_name")
+        ),
+        "safe_to_execute": False,
+        "read_only": True,
+        "eligible_for_direct_execution": False,
+        "launches_subprocess": False,
+        "launches_codex": False,
+        "executed_anything": False,
+        "mutates_campaign_queue": False,
+        "mutates_strategy_or_preset": False,
+        "mutates_paper_shadow_live_runtime": False,
+        "writes_research_action_queue": False,
+        "writes_development_work_queue": False,
+        "writes_seed_jsonl": False,
+        "writes_generated_seed_jsonl": False,
+        "learning_status": status,
+        "final_recommendation": _final_recommendation(status),
+        "counts": _counts(status),
+        "analysis_summary": {
+            "report_kind": active_analysis.get("report_kind"),
+            "analysis_status": active_analysis.get("analysis_status"),
+            "final_recommendation": active_analysis.get("final_recommendation"),
+            "completed_run_available": (
+                (active_analysis.get("result_summary") or {}).get(
+                    "completed_run_available"
+                )
+                is True
+            ),
+        },
+        "learning_proposal": proposal,
+        "next_required_step": (
+            "complete controlled validation result analysis before learning proposal"
+            if status == LEARNING_BLOCKED_ANALYSIS_NOT_READY
+            else "operator review learning proposal before any queue mutation"
+        ),
+        "validation_warnings": [],
+    }
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    if not path.resolve().is_relative_to(ARTIFACT_DIR.resolve()):
+        raise ValueError(
+            f"refusing write outside QRE controlled validation learning proposal dir: {path}"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".qre_controlled_validation_learning_proposal.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with open(fd, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(text)
+        Path(tmp_name).replace(path)
+    finally:
+        tmp_path = Path(tmp_name)
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+def write_outputs(
+    snapshot: dict[str, Any],
+    *,
+    output_path: Path | None = None,
+) -> Path:
+    target = output_path or ARTIFACT_LATEST
+    _atomic_write_json(target, snapshot)
+    return target
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="reporting.qre_controlled_validation_learning_proposal",
+        description="Build a deterministic QRE learning proposal after result analysis.",
+    )
+    parser.add_argument("--profile", default=None)
+    parser.add_argument("--no-write", action="store_true")
+    parser.add_argument("--indent", type=int, default=2)
+    parser.add_argument("--frozen-utc", default=None)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    snapshot = collect_snapshot(
+        profile_name=args.profile,
+        generated_at_utc=args.frozen_utc,
+    )
+    print(json.dumps(snapshot, indent=args.indent, sort_keys=True))
+    if not args.no_write:
+        write_outputs(snapshot)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())
+
+
+__all__ = [
+    "ARTIFACT_LATEST",
+    "LEARNING_BLOCKED_ANALYSIS_NOT_READY",
+    "LEARNING_READY_FOR_OPERATOR_REVIEW",
+    "REPORT_KIND",
+    "collect_snapshot",
+    "main",
+    "write_outputs",
+]

--- a/reporting/qre_controlled_validation_loop_report.py
+++ b/reporting/qre_controlled_validation_loop_report.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import argparse
 import datetime as dt

--- a/reporting/qre_controlled_validation_loop_report.py
+++ b/reporting/qre_controlled_validation_loop_report.py
@@ -1,0 +1,268 @@
+﻿from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import tempfile
+from pathlib import Path
+from typing import Any, Final
+
+from reporting import qre_controlled_validation_execution as execution
+from reporting import qre_controlled_validation_learning_proposal as learning
+from reporting import qre_controlled_validation_research_action_queue_gate as queue_gate
+from reporting import qre_controlled_validation_result_analysis as analysis
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[int] = 1
+REPORT_KIND: Final[str] = "qre_controlled_validation_loop_report"
+
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "qre_controlled_validation_loop_report"
+OUTPUT_ARTIFACT_RELATIVE_PATH: Final[str] = "logs/qre_controlled_validation_loop_report/latest.json"
+ARTIFACT_LATEST: Final[Path] = REPO_ROOT / OUTPUT_ARTIFACT_RELATIVE_PATH
+
+
+def _utcnow() -> str:
+    return (
+        dt.datetime.now(dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _final_recommendation(
+    *,
+    execution_snapshot: dict[str, Any],
+    analysis_snapshot: dict[str, Any],
+    learning_snapshot: dict[str, Any],
+    queue_snapshot: dict[str, Any],
+) -> str:
+    if queue_snapshot.get("queue_mutation_authorized") is True:
+        return "controlled_validation_loop_queue_mutation_authorized_writer_not_connected"
+    if learning_snapshot.get("learning_status") == "learning_ready_for_operator_review":
+        return "controlled_validation_loop_learning_ready_for_operator_review"
+    if analysis_snapshot.get("analysis_status") == "analysis_ready":
+        return "controlled_validation_loop_analysis_ready"
+    if execution_snapshot.get("controlled_validation_authorized") is True:
+        return "controlled_validation_loop_execution_authorized_runner_not_connected"
+    return "controlled_validation_loop_blocked_before_execution"
+
+
+def _counts(
+    *,
+    execution_snapshot: dict[str, Any],
+    analysis_snapshot: dict[str, Any],
+    learning_snapshot: dict[str, Any],
+    queue_snapshot: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "execution_authorized": (
+            1 if execution_snapshot.get("controlled_validation_authorized") is True else 0
+        ),
+        "analysis_ready": (
+            1 if analysis_snapshot.get("analysis_status") == "analysis_ready" else 0
+        ),
+        "learning_ready": (
+            1
+            if learning_snapshot.get("learning_status")
+            == "learning_ready_for_operator_review"
+            else 0
+        ),
+        "queue_mutation_authorized": (
+            1 if queue_snapshot.get("queue_mutation_authorized") is True else 0
+        ),
+    }
+
+
+def collect_snapshot(
+    *,
+    profile_name: str | None = None,
+    execute_controlled_validation: bool = False,
+    execution_operator_go: str | None = None,
+    write_research_action_queue: bool = False,
+    queue_operator_go: str | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    generated = generated_at_utc or _utcnow()
+
+    execution_snapshot = execution.collect_snapshot(
+        profile_name=profile_name,
+        execute_controlled_validation=execute_controlled_validation,
+        operator_go=execution_operator_go,
+        generated_at_utc=generated,
+    )
+    analysis_snapshot = analysis.collect_snapshot(
+        profile_name=profile_name,
+        execution_snapshot=execution_snapshot,
+        generated_at_utc=generated,
+    )
+    learning_snapshot = learning.collect_snapshot(
+        profile_name=profile_name,
+        analysis_snapshot=analysis_snapshot,
+        generated_at_utc=generated,
+    )
+    queue_snapshot = queue_gate.collect_snapshot(
+        profile_name=profile_name,
+        learning_snapshot=learning_snapshot,
+        write_research_action_queue=write_research_action_queue,
+        operator_go=queue_operator_go,
+        generated_at_utc=generated,
+    )
+
+    final_recommendation = _final_recommendation(
+        execution_snapshot=execution_snapshot,
+        analysis_snapshot=analysis_snapshot,
+        learning_snapshot=learning_snapshot,
+        queue_snapshot=queue_snapshot,
+    )
+
+    return {
+        "report_kind": REPORT_KIND,
+        "schema_version": SCHEMA_VERSION,
+        "generated_at_utc": generated,
+        "selection_profile_name": profile_name,
+        "safe_to_execute": False,
+        "read_only": True,
+        "eligible_for_direct_execution": False,
+        "launches_subprocess": False,
+        "launches_codex": False,
+        "executed_anything": False,
+        "mutates_campaign_queue": False,
+        "mutates_strategy_or_preset": False,
+        "mutates_paper_shadow_live_runtime": False,
+        "writes_research_action_queue": False,
+        "writes_development_work_queue": False,
+        "writes_seed_jsonl": False,
+        "writes_generated_seed_jsonl": False,
+        "final_recommendation": final_recommendation,
+        "counts": _counts(
+            execution_snapshot=execution_snapshot,
+            analysis_snapshot=analysis_snapshot,
+            learning_snapshot=learning_snapshot,
+            queue_snapshot=queue_snapshot,
+        ),
+        "loop_stages": {
+            "execution": {
+                "report_kind": execution_snapshot.get("report_kind"),
+                "execution_status": execution_snapshot.get("execution_status"),
+                "controlled_validation_authorized": (
+                    execution_snapshot.get("controlled_validation_authorized") is True
+                ),
+                "runner_adapter_status": execution_snapshot.get("runner_adapter_status"),
+                "final_recommendation": execution_snapshot.get("final_recommendation"),
+            },
+            "result_analysis": {
+                "report_kind": analysis_snapshot.get("report_kind"),
+                "analysis_status": analysis_snapshot.get("analysis_status"),
+                "final_recommendation": analysis_snapshot.get("final_recommendation"),
+            },
+            "learning_proposal": {
+                "report_kind": learning_snapshot.get("report_kind"),
+                "learning_status": learning_snapshot.get("learning_status"),
+                "proposal_available": (
+                    (learning_snapshot.get("learning_proposal") or {}).get("available")
+                    is True
+                ),
+                "final_recommendation": learning_snapshot.get("final_recommendation"),
+            },
+            "research_action_queue_gate": {
+                "report_kind": queue_snapshot.get("report_kind"),
+                "queue_status": queue_snapshot.get("queue_status"),
+                "queue_mutation_authorized": (
+                    queue_snapshot.get("queue_mutation_authorized") is True
+                ),
+                "queue_writer_adapter_status": queue_snapshot.get(
+                    "queue_writer_adapter_status"
+                ),
+                "final_recommendation": queue_snapshot.get("final_recommendation"),
+            },
+        },
+        "next_required_step": (
+            "connect controlled validation runner adapter"
+            if execution_snapshot.get("controlled_validation_authorized") is True
+            else "authorize controlled validation execution with exact operator-go"
+        ),
+        "operator_authorizations": {
+            "controlled_validation_execution": execution_snapshot.get(
+                "operator_authorization"
+            ),
+            "research_action_queue_mutation": queue_snapshot.get("operator_authorization"),
+        },
+        "validation_warnings": [],
+    }
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    if not path.resolve().is_relative_to(ARTIFACT_DIR.resolve()):
+        raise ValueError(f"refusing write outside QRE controlled validation loop dir: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".qre_controlled_validation_loop_report.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with open(fd, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(text)
+        Path(tmp_name).replace(path)
+    finally:
+        tmp_path = Path(tmp_name)
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+def write_outputs(
+    snapshot: dict[str, Any],
+    *,
+    output_path: Path | None = None,
+) -> Path:
+    target = output_path or ARTIFACT_LATEST
+    _atomic_write_json(target, snapshot)
+    return target
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="reporting.qre_controlled_validation_loop_report",
+        description="Summarize QRE controlled validation execution, analysis, learning, and queue gates.",
+    )
+    parser.add_argument("--profile", default=None)
+    parser.add_argument("--execute-controlled-validation", action="store_true")
+    parser.add_argument("--execution-operator-go", default=None)
+    parser.add_argument("--write-research-action-queue", action="store_true")
+    parser.add_argument("--queue-operator-go", default=None)
+    parser.add_argument("--no-write", action="store_true")
+    parser.add_argument("--indent", type=int, default=2)
+    parser.add_argument("--frozen-utc", default=None)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    snapshot = collect_snapshot(
+        profile_name=args.profile,
+        execute_controlled_validation=bool(args.execute_controlled_validation),
+        execution_operator_go=args.execution_operator_go,
+        write_research_action_queue=bool(args.write_research_action_queue),
+        queue_operator_go=args.queue_operator_go,
+        generated_at_utc=args.frozen_utc,
+    )
+    print(json.dumps(snapshot, indent=args.indent, sort_keys=True))
+    if not args.no_write:
+        write_outputs(snapshot)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())
+
+
+__all__ = [
+    "ARTIFACT_LATEST",
+    "REPORT_KIND",
+    "collect_snapshot",
+    "main",
+    "write_outputs",
+]

--- a/reporting/qre_controlled_validation_research_action_queue_gate.py
+++ b/reporting/qre_controlled_validation_research_action_queue_gate.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import argparse
 import datetime as dt

--- a/reporting/qre_controlled_validation_research_action_queue_gate.py
+++ b/reporting/qre_controlled_validation_research_action_queue_gate.py
@@ -1,0 +1,264 @@
+﻿from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import tempfile
+from pathlib import Path
+from typing import Any, Final
+
+from reporting import qre_controlled_validation_learning_proposal as learning
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[int] = 1
+REPORT_KIND: Final[str] = "qre_controlled_validation_research_action_queue_gate"
+
+ARTIFACT_DIR: Final[Path] = (
+    REPO_ROOT / "logs" / "qre_controlled_validation_research_action_queue_gate"
+)
+OUTPUT_ARTIFACT_RELATIVE_PATH: Final[str] = (
+    "logs/qre_controlled_validation_research_action_queue_gate/latest.json"
+)
+ARTIFACT_LATEST: Final[Path] = REPO_ROOT / OUTPUT_ARTIFACT_RELATIVE_PATH
+
+REQUIRED_QUEUE_GO_PHRASE: Final[str] = (
+    "I authorize QRE research action queue mutation"
+)
+
+QUEUE_BLOCKED_LEARNING_NOT_READY: Final[str] = "queue_blocked_learning_not_ready"
+QUEUE_BLOCKED_WRITE_NOT_REQUESTED: Final[str] = "queue_blocked_write_not_requested"
+QUEUE_BLOCKED_OPERATOR_GO_MISSING: Final[str] = "queue_blocked_operator_go_missing"
+QUEUE_BLOCKED_OPERATOR_GO_MISMATCH: Final[str] = "queue_blocked_operator_go_mismatch"
+QUEUE_AUTHORIZED_WRITER_NOT_CONNECTED: Final[str] = "queue_authorized_writer_not_connected"
+
+QUEUE_STATUSES: Final[tuple[str, ...]] = (
+    QUEUE_BLOCKED_LEARNING_NOT_READY,
+    QUEUE_BLOCKED_WRITE_NOT_REQUESTED,
+    QUEUE_BLOCKED_OPERATOR_GO_MISSING,
+    QUEUE_BLOCKED_OPERATOR_GO_MISMATCH,
+    QUEUE_AUTHORIZED_WRITER_NOT_CONNECTED,
+)
+
+
+def _utcnow() -> str:
+    return (
+        dt.datetime.now(dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _queue_status(
+    *,
+    learning_snapshot: dict[str, Any],
+    write_research_action_queue: bool,
+    operator_go: str | None,
+) -> str:
+    if learning_snapshot.get("learning_status") != "learning_ready_for_operator_review":
+        return QUEUE_BLOCKED_LEARNING_NOT_READY
+    if not write_research_action_queue:
+        return QUEUE_BLOCKED_WRITE_NOT_REQUESTED
+    if operator_go is None or operator_go.strip() == "":
+        return QUEUE_BLOCKED_OPERATOR_GO_MISSING
+    if operator_go.strip() != REQUIRED_QUEUE_GO_PHRASE:
+        return QUEUE_BLOCKED_OPERATOR_GO_MISMATCH
+    return QUEUE_AUTHORIZED_WRITER_NOT_CONNECTED
+
+
+def _counts(status: str) -> dict[str, Any]:
+    return {
+        "total": 1,
+        "authorized": 1 if status == QUEUE_AUTHORIZED_WRITER_NOT_CONNECTED else 0,
+        "blocked": 0 if status == QUEUE_AUTHORIZED_WRITER_NOT_CONNECTED else 1,
+        "by_queue_status": {
+            candidate: 1 if candidate == status else 0
+            for candidate in QUEUE_STATUSES
+        },
+    }
+
+
+def _final_recommendation(status: str) -> str:
+    if status == QUEUE_AUTHORIZED_WRITER_NOT_CONNECTED:
+        return "research_action_queue_mutation_authorized_writer_not_connected"
+    return "research_action_queue_mutation_blocked"
+
+
+def _candidate_queue_item(learning_snapshot: dict[str, Any], status: str) -> dict[str, Any] | None:
+    proposal = learning_snapshot.get("learning_proposal") or {}
+    if status != QUEUE_AUTHORIZED_WRITER_NOT_CONNECTED:
+        return None
+    return {
+        "source": REPORT_KIND,
+        "selection_profile_name": learning_snapshot.get("selection_profile_name"),
+        "next_research_action": proposal.get("next_research_action"),
+        "hypothesis_action": proposal.get("hypothesis_action"),
+        "outcome": proposal.get("outcome"),
+        "primary_failure_class": proposal.get("primary_failure_class"),
+        "evidence_refs": list(proposal.get("evidence_refs") or []),
+        "requires_operator_review": True,
+    }
+
+
+def collect_snapshot(
+    *,
+    profile_name: str | None = None,
+    learning_snapshot: dict[str, Any] | None = None,
+    write_research_action_queue: bool = False,
+    operator_go: str | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    generated = generated_at_utc or _utcnow()
+    active_learning = learning_snapshot or learning.collect_snapshot(
+        profile_name=profile_name,
+        generated_at_utc=generated,
+    )
+
+    status = _queue_status(
+        learning_snapshot=active_learning,
+        write_research_action_queue=write_research_action_queue,
+        operator_go=operator_go,
+    )
+    authorized = status == QUEUE_AUTHORIZED_WRITER_NOT_CONNECTED
+
+    return {
+        "report_kind": REPORT_KIND,
+        "schema_version": SCHEMA_VERSION,
+        "generated_at_utc": generated,
+        "selection_profile_name": (
+            profile_name or active_learning.get("selection_profile_name")
+        ),
+        "safe_to_execute": False,
+        "read_only": True,
+        "eligible_for_direct_execution": False,
+        "launches_subprocess": False,
+        "launches_codex": False,
+        "executed_anything": False,
+        "mutates_campaign_queue": False,
+        "mutates_strategy_or_preset": False,
+        "mutates_paper_shadow_live_runtime": False,
+        "writes_research_action_queue": False,
+        "writes_development_work_queue": False,
+        "writes_seed_jsonl": False,
+        "writes_generated_seed_jsonl": False,
+        "queue_mutation_authorized": authorized,
+        "queue_writer_adapter_status": "not_connected",
+        "queue_status": status,
+        "final_recommendation": _final_recommendation(status),
+        "counts": _counts(status),
+        "operator_authorization": {
+            "required": True,
+            "provided": operator_go is not None and operator_go.strip() != "",
+            "matched": operator_go is not None
+            and operator_go.strip() == REQUIRED_QUEUE_GO_PHRASE,
+            "required_phrase": REQUIRED_QUEUE_GO_PHRASE,
+        },
+        "learning_summary": {
+            "report_kind": active_learning.get("report_kind"),
+            "learning_status": active_learning.get("learning_status"),
+            "final_recommendation": active_learning.get("final_recommendation"),
+            "proposal_available": (
+                (active_learning.get("learning_proposal") or {}).get("available")
+                is True
+            ),
+        },
+        "candidate_queue_item": _candidate_queue_item(active_learning, status),
+        "next_required_step": (
+            "complete learning proposal before queue mutation"
+            if status == QUEUE_BLOCKED_LEARNING_NOT_READY
+            else (
+                "request queue mutation explicitly after learning proposal review"
+                if status == QUEUE_BLOCKED_WRITE_NOT_REQUESTED
+                else (
+                    "provide exact operator-go phrase for queue mutation"
+                    if status
+                    in {
+                        QUEUE_BLOCKED_OPERATOR_GO_MISSING,
+                        QUEUE_BLOCKED_OPERATOR_GO_MISMATCH,
+                    }
+                    else "connect bounded queue writer adapter"
+                )
+            )
+        ),
+        "validation_warnings": [],
+    }
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    if not path.resolve().is_relative_to(ARTIFACT_DIR.resolve()):
+        raise ValueError(
+            f"refusing write outside QRE research action queue gate dir: {path}"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".qre_controlled_validation_research_action_queue_gate.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with open(fd, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(text)
+        Path(tmp_name).replace(path)
+    finally:
+        tmp_path = Path(tmp_name)
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+def write_outputs(
+    snapshot: dict[str, Any],
+    *,
+    output_path: Path | None = None,
+) -> Path:
+    target = output_path or ARTIFACT_LATEST
+    _atomic_write_json(target, snapshot)
+    return target
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="reporting.qre_controlled_validation_research_action_queue_gate",
+        description="Gate QRE research action queue mutation after learning proposal review.",
+    )
+    parser.add_argument("--profile", default=None)
+    parser.add_argument("--write-research-action-queue", action="store_true")
+    parser.add_argument("--operator-go", default=None)
+    parser.add_argument("--no-write", action="store_true")
+    parser.add_argument("--indent", type=int, default=2)
+    parser.add_argument("--frozen-utc", default=None)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    snapshot = collect_snapshot(
+        profile_name=args.profile,
+        write_research_action_queue=bool(args.write_research_action_queue),
+        operator_go=args.operator_go,
+        generated_at_utc=args.frozen_utc,
+    )
+    print(json.dumps(snapshot, indent=args.indent, sort_keys=True))
+    if not args.no_write:
+        write_outputs(snapshot)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())
+
+
+__all__ = [
+    "ARTIFACT_LATEST",
+    "QUEUE_AUTHORIZED_WRITER_NOT_CONNECTED",
+    "QUEUE_BLOCKED_LEARNING_NOT_READY",
+    "QUEUE_BLOCKED_OPERATOR_GO_MISMATCH",
+    "QUEUE_BLOCKED_OPERATOR_GO_MISSING",
+    "QUEUE_BLOCKED_WRITE_NOT_REQUESTED",
+    "REPORT_KIND",
+    "REQUIRED_QUEUE_GO_PHRASE",
+    "collect_snapshot",
+    "main",
+    "write_outputs",
+]

--- a/reporting/qre_controlled_validation_result_analysis.py
+++ b/reporting/qre_controlled_validation_result_analysis.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import argparse
 import datetime as dt

--- a/reporting/qre_controlled_validation_result_analysis.py
+++ b/reporting/qre_controlled_validation_result_analysis.py
@@ -1,0 +1,218 @@
+﻿from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import tempfile
+from pathlib import Path
+from typing import Any, Final
+
+from reporting import qre_controlled_validation_execution as execution
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+
+SCHEMA_VERSION: Final[int] = 1
+REPORT_KIND: Final[str] = "qre_controlled_validation_result_analysis"
+
+ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "qre_controlled_validation_result_analysis"
+OUTPUT_ARTIFACT_RELATIVE_PATH: Final[str] = (
+    "logs/qre_controlled_validation_result_analysis/latest.json"
+)
+ARTIFACT_LATEST: Final[Path] = REPO_ROOT / OUTPUT_ARTIFACT_RELATIVE_PATH
+
+ANALYSIS_BLOCKED_EXECUTION_NOT_AUTHORIZED: Final[str] = (
+    "analysis_blocked_execution_not_authorized"
+)
+ANALYSIS_BLOCKED_RUNNER_NOT_CONNECTED: Final[str] = (
+    "analysis_blocked_runner_not_connected"
+)
+ANALYSIS_BLOCKED_NO_COMPLETED_RUN: Final[str] = "analysis_blocked_no_completed_run"
+ANALYSIS_READY: Final[str] = "analysis_ready"
+
+ANALYSIS_STATUSES: Final[tuple[str, ...]] = (
+    ANALYSIS_BLOCKED_EXECUTION_NOT_AUTHORIZED,
+    ANALYSIS_BLOCKED_RUNNER_NOT_CONNECTED,
+    ANALYSIS_BLOCKED_NO_COMPLETED_RUN,
+    ANALYSIS_READY,
+)
+
+
+def _utcnow() -> str:
+    return (
+        dt.datetime.now(dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _analysis_status(execution_snapshot: dict[str, Any]) -> str:
+    if execution_snapshot.get("controlled_validation_authorized") is not True:
+        return ANALYSIS_BLOCKED_EXECUTION_NOT_AUTHORIZED
+    if execution_snapshot.get("runner_adapter_status") != "connected":
+        return ANALYSIS_BLOCKED_RUNNER_NOT_CONNECTED
+    if execution_snapshot.get("executed_anything") is not True:
+        return ANALYSIS_BLOCKED_NO_COMPLETED_RUN
+    return ANALYSIS_READY
+
+
+def _counts(status: str) -> dict[str, Any]:
+    return {
+        "total": 1,
+        "ready": 1 if status == ANALYSIS_READY else 0,
+        "blocked": 0 if status == ANALYSIS_READY else 1,
+        "by_analysis_status": {
+            candidate: 1 if candidate == status else 0
+            for candidate in ANALYSIS_STATUSES
+        },
+    }
+
+
+def _final_recommendation(status: str) -> str:
+    if status == ANALYSIS_READY:
+        return "controlled_validation_result_analysis_ready"
+    return "controlled_validation_result_analysis_blocked"
+
+
+def collect_snapshot(
+    *,
+    profile_name: str | None = None,
+    execution_snapshot: dict[str, Any] | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    generated = generated_at_utc or _utcnow()
+    active_execution = execution_snapshot or execution.collect_snapshot(
+        profile_name=profile_name,
+        generated_at_utc=generated,
+    )
+
+    status = _analysis_status(active_execution)
+
+    return {
+        "report_kind": REPORT_KIND,
+        "schema_version": SCHEMA_VERSION,
+        "generated_at_utc": generated,
+        "selection_profile_name": (
+            profile_name or active_execution.get("selection_profile_name")
+        ),
+        "safe_to_execute": False,
+        "read_only": True,
+        "eligible_for_direct_execution": False,
+        "launches_subprocess": False,
+        "launches_codex": False,
+        "executed_anything": False,
+        "mutates_campaign_queue": False,
+        "mutates_strategy_or_preset": False,
+        "mutates_paper_shadow_live_runtime": False,
+        "writes_research_action_queue": False,
+        "writes_development_work_queue": False,
+        "writes_seed_jsonl": False,
+        "writes_generated_seed_jsonl": False,
+        "analysis_status": status,
+        "final_recommendation": _final_recommendation(status),
+        "counts": _counts(status),
+        "execution_summary": {
+            "report_kind": active_execution.get("report_kind"),
+            "execution_status": active_execution.get("execution_status"),
+            "controlled_validation_authorized": (
+                active_execution.get("controlled_validation_authorized") is True
+            ),
+            "runner_adapter_status": active_execution.get("runner_adapter_status"),
+            "executed_anything": active_execution.get("executed_anything") is True,
+            "final_recommendation": active_execution.get("final_recommendation"),
+        },
+        "result_summary": {
+            "completed_run_available": status == ANALYSIS_READY,
+            "pass_fail": None,
+            "trade_count": None,
+            "primary_failure_class": None,
+            "evidence_refs": [],
+        },
+        "next_required_step": (
+            "connect controlled validation runner before result analysis"
+            if status == ANALYSIS_BLOCKED_RUNNER_NOT_CONNECTED
+            else (
+                "authorize and complete controlled validation execution"
+                if status == ANALYSIS_BLOCKED_EXECUTION_NOT_AUTHORIZED
+                else (
+                    "materialize completed controlled validation run artifacts"
+                    if status == ANALYSIS_BLOCKED_NO_COMPLETED_RUN
+                    else "review controlled validation result analysis"
+                )
+            )
+        ),
+        "validation_warnings": [],
+    }
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    if not path.resolve().is_relative_to(ARTIFACT_DIR.resolve()):
+        raise ValueError(
+            f"refusing write outside QRE controlled validation result analysis dir: {path}"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".qre_controlled_validation_result_analysis.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with open(fd, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(text)
+        Path(tmp_name).replace(path)
+    finally:
+        tmp_path = Path(tmp_name)
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+def write_outputs(
+    snapshot: dict[str, Any],
+    *,
+    output_path: Path | None = None,
+) -> Path:
+    target = output_path or ARTIFACT_LATEST
+    _atomic_write_json(target, snapshot)
+    return target
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="reporting.qre_controlled_validation_result_analysis",
+        description="Analyze QRE controlled validation results when a completed run exists.",
+    )
+    parser.add_argument("--profile", default=None)
+    parser.add_argument("--no-write", action="store_true")
+    parser.add_argument("--indent", type=int, default=2)
+    parser.add_argument("--frozen-utc", default=None)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    snapshot = collect_snapshot(
+        profile_name=args.profile,
+        generated_at_utc=args.frozen_utc,
+    )
+    print(json.dumps(snapshot, indent=args.indent, sort_keys=True))
+    if not args.no_write:
+        write_outputs(snapshot)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())
+
+
+__all__ = [
+    "ANALYSIS_BLOCKED_EXECUTION_NOT_AUTHORIZED",
+    "ANALYSIS_BLOCKED_NO_COMPLETED_RUN",
+    "ANALYSIS_BLOCKED_RUNNER_NOT_CONNECTED",
+    "ANALYSIS_READY",
+    "ARTIFACT_LATEST",
+    "REPORT_KIND",
+    "collect_snapshot",
+    "main",
+    "write_outputs",
+]

--- a/tests/unit/test_qre_controlled_validation_execution.py
+++ b/tests/unit/test_qre_controlled_validation_execution.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import json
 

--- a/tests/unit/test_qre_controlled_validation_execution.py
+++ b/tests/unit/test_qre_controlled_validation_execution.py
@@ -1,0 +1,135 @@
+﻿from __future__ import annotations
+
+import json
+
+from reporting import qre_controlled_validation_execution as execution
+
+
+def test_default_controlled_validation_execution_is_blocked() -> None:
+    snapshot = execution.collect_snapshot(
+        profile_name="equities_exploratory_v1",
+        generated_at_utc="2026-06-03T17:00:00Z",
+    )
+
+    assert snapshot["report_kind"] == "qre_controlled_validation_execution"
+    assert snapshot["safe_to_execute"] is False
+    assert snapshot["read_only"] is True
+    assert snapshot["eligible_for_direct_execution"] is False
+    assert snapshot["launches_subprocess"] is False
+    assert snapshot["executed_anything"] is False
+    assert snapshot["controlled_validation_authorized"] is False
+    assert snapshot["live_or_paper_execution_authorized"] is False
+    assert snapshot["execution_status"] == "execution_blocked_not_requested"
+    assert snapshot["final_recommendation"] == "controlled_validation_execution_blocked"
+    assert snapshot["preflight"]["selection_route_ready"] is True
+
+
+def test_execute_flag_without_operator_go_is_blocked() -> None:
+    snapshot = execution.collect_snapshot(
+        profile_name="equities_exploratory_v1",
+        execute_controlled_validation=True,
+        generated_at_utc="2026-06-03T17:00:00Z",
+    )
+
+    assert snapshot["execution_status"] == "execution_blocked_operator_go_missing"
+    assert snapshot["controlled_validation_authorized"] is False
+    assert snapshot["operator_authorization"]["provided"] is False
+    assert snapshot["operator_authorization"]["matched"] is False
+
+
+def test_execute_flag_with_wrong_operator_go_is_blocked() -> None:
+    snapshot = execution.collect_snapshot(
+        profile_name="equities_exploratory_v1",
+        execute_controlled_validation=True,
+        operator_go="wrong",
+        generated_at_utc="2026-06-03T17:00:00Z",
+    )
+
+    assert snapshot["execution_status"] == "execution_blocked_operator_go_mismatch"
+    assert snapshot["controlled_validation_authorized"] is False
+    assert snapshot["operator_authorization"]["provided"] is True
+    assert snapshot["operator_authorization"]["matched"] is False
+
+
+def test_exact_operator_go_authorizes_contract_but_runner_is_not_connected() -> None:
+    snapshot = execution.collect_snapshot(
+        profile_name="equities_exploratory_v1",
+        execute_controlled_validation=True,
+        operator_go=execution.REQUIRED_OPERATOR_GO_PHRASE,
+        generated_at_utc="2026-06-03T17:00:00Z",
+    )
+
+    assert snapshot["execution_status"] == "execution_authorized_runner_not_connected"
+    assert snapshot["controlled_validation_authorized"] is True
+    assert snapshot["runner_adapter_status"] == "not_connected"
+    assert snapshot["planned_runner"]["module"] == "research.controlled_eval"
+    assert snapshot["planned_runner"]["connected"] is False
+    assert snapshot["launches_subprocess"] is False
+    assert snapshot["executed_anything"] is False
+    assert snapshot["mutates_campaign_queue"] is False
+    assert snapshot["writes_research_action_queue"] is False
+
+
+def test_preflight_not_ready_blocks_even_with_operator_go() -> None:
+    preflight_snapshot = {
+        "report_kind": "qre_selection_closed_loop_preflight",
+        "final_recommendation": "selection_route_preflight_blocked",
+        "selection_route": {"ready": False, "counts": {}},
+        "controlled_regeneration_preflight": {"can_be_considered": False},
+    }
+
+    snapshot = execution.collect_snapshot(
+        profile_name="equities_exploratory_v1",
+        execute_controlled_validation=True,
+        operator_go=execution.REQUIRED_OPERATOR_GO_PHRASE,
+        preflight_snapshot=preflight_snapshot,
+        generated_at_utc="2026-06-03T17:00:00Z",
+    )
+
+    assert snapshot["execution_status"] == "execution_blocked_preflight_not_ready"
+    assert snapshot["controlled_validation_authorized"] is False
+
+
+def test_cli_no_write_does_not_create_artifact(tmp_path, monkeypatch, capsys) -> None:
+    artifact_path = tmp_path / "latest.json"
+    monkeypatch.setattr(execution, "ARTIFACT_LATEST", artifact_path)
+
+    rc = execution.main(
+        [
+            "--profile",
+            "equities_exploratory_v1",
+            "--execute-controlled-validation",
+            "--operator-go",
+            execution.REQUIRED_OPERATOR_GO_PHRASE,
+            "--no-write",
+            "--frozen-utc",
+            "2026-06-03T17:00:00Z",
+        ]
+    )
+
+    assert rc == 0
+    assert not artifact_path.exists()
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["controlled_validation_authorized"] is True
+
+
+def test_cli_writes_only_own_artifact(tmp_path, monkeypatch) -> None:
+    artifact_dir = tmp_path / "qre_controlled_validation_execution"
+    artifact_path = artifact_dir / "latest.json"
+    monkeypatch.setattr(execution, "ARTIFACT_DIR", artifact_dir)
+    monkeypatch.setattr(execution, "ARTIFACT_LATEST", artifact_path)
+
+    rc = execution.main(
+        [
+            "--profile",
+            "equities_exploratory_v1",
+            "--frozen-utc",
+            "2026-06-03T17:00:00Z",
+        ]
+    )
+
+    assert rc == 0
+    assert artifact_path.exists()
+    payload = json.loads(artifact_path.read_text(encoding="utf-8"))
+    assert payload["execution_status"] == "execution_blocked_not_requested"
+    assert payload["executed_anything"] is False

--- a/tests/unit/test_qre_controlled_validation_learning_proposal.py
+++ b/tests/unit/test_qre_controlled_validation_learning_proposal.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import json
 

--- a/tests/unit/test_qre_controlled_validation_learning_proposal.py
+++ b/tests/unit/test_qre_controlled_validation_learning_proposal.py
@@ -1,0 +1,121 @@
+﻿from __future__ import annotations
+
+import json
+
+from reporting import qre_controlled_validation_learning_proposal as learning
+
+
+def test_learning_blocks_when_analysis_not_ready() -> None:
+    snapshot = learning.collect_snapshot(
+        profile_name="equities_exploratory_v1",
+        generated_at_utc="2026-06-03T19:00:00Z",
+    )
+
+    assert snapshot["report_kind"] == "qre_controlled_validation_learning_proposal"
+    assert snapshot["safe_to_execute"] is False
+    assert snapshot["read_only"] is True
+    assert snapshot["learning_status"] == "learning_blocked_analysis_not_ready"
+    assert snapshot["counts"]["blocked"] == 1
+    assert snapshot["learning_proposal"]["available"] is False
+    assert snapshot["writes_research_action_queue"] is False
+
+
+def test_learning_ready_for_pass_result() -> None:
+    analysis_snapshot = {
+        "report_kind": "qre_controlled_validation_result_analysis",
+        "selection_profile_name": "equities_exploratory_v1",
+        "analysis_status": "analysis_ready",
+        "final_recommendation": "controlled_validation_result_analysis_ready",
+        "result_summary": {
+            "completed_run_available": True,
+            "pass_fail": "pass",
+            "trade_count": 12,
+            "primary_failure_class": None,
+            "evidence_refs": ["research/history/run-a/screening_evidence.v1.json"],
+        },
+    }
+
+    snapshot = learning.collect_snapshot(
+        analysis_snapshot=analysis_snapshot,
+        generated_at_utc="2026-06-03T19:00:00Z",
+    )
+
+    assert snapshot["learning_status"] == "learning_ready_for_operator_review"
+    assert snapshot["counts"]["ready"] == 1
+    assert snapshot["learning_proposal"]["available"] is True
+    assert snapshot["learning_proposal"]["outcome"] == "pass"
+    assert snapshot["learning_proposal"]["hypothesis_action"] == "continue_validation"
+    assert snapshot["learning_proposal"]["next_research_action"] == (
+        "consider_bounded_followup_validation"
+    )
+    assert snapshot["writes_research_action_queue"] is False
+
+
+def test_learning_ready_for_fail_result() -> None:
+    analysis_snapshot = {
+        "report_kind": "qre_controlled_validation_result_analysis",
+        "selection_profile_name": "equities_exploratory_v1",
+        "analysis_status": "analysis_ready",
+        "final_recommendation": "controlled_validation_result_analysis_ready",
+        "result_summary": {
+            "completed_run_available": True,
+            "pass_fail": "fail",
+            "trade_count": 3,
+            "primary_failure_class": "insufficient_trades",
+            "evidence_refs": ["research/history/run-b/screening_evidence.v1.json"],
+        },
+    }
+
+    snapshot = learning.collect_snapshot(
+        analysis_snapshot=analysis_snapshot,
+        generated_at_utc="2026-06-03T19:00:00Z",
+    )
+
+    assert snapshot["learning_status"] == "learning_ready_for_operator_review"
+    assert snapshot["learning_proposal"]["hypothesis_action"] == "do_not_promote"
+    assert snapshot["learning_proposal"]["next_research_action"] == (
+        "investigate_failure_class"
+    )
+    assert snapshot["learning_proposal"]["primary_failure_class"] == "insufficient_trades"
+
+
+def test_cli_no_write_does_not_create_artifact(tmp_path, monkeypatch, capsys) -> None:
+    artifact_path = tmp_path / "latest.json"
+    monkeypatch.setattr(learning, "ARTIFACT_LATEST", artifact_path)
+
+    rc = learning.main(
+        [
+            "--profile",
+            "equities_exploratory_v1",
+            "--no-write",
+            "--frozen-utc",
+            "2026-06-03T19:00:00Z",
+        ]
+    )
+
+    assert rc == 0
+    assert not artifact_path.exists()
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["learning_status"] == "learning_blocked_analysis_not_ready"
+
+
+def test_cli_writes_only_own_artifact(tmp_path, monkeypatch) -> None:
+    artifact_dir = tmp_path / "qre_controlled_validation_learning_proposal"
+    artifact_path = artifact_dir / "latest.json"
+    monkeypatch.setattr(learning, "ARTIFACT_DIR", artifact_dir)
+    monkeypatch.setattr(learning, "ARTIFACT_LATEST", artifact_path)
+
+    rc = learning.main(
+        [
+            "--profile",
+            "equities_exploratory_v1",
+            "--frozen-utc",
+            "2026-06-03T19:00:00Z",
+        ]
+    )
+
+    assert rc == 0
+    assert artifact_path.exists()
+    payload = json.loads(artifact_path.read_text(encoding="utf-8"))
+    assert payload["learning_status"] == "learning_blocked_analysis_not_ready"
+    assert payload["read_only"] is True

--- a/tests/unit/test_qre_controlled_validation_loop_report.py
+++ b/tests/unit/test_qre_controlled_validation_loop_report.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import json
 

--- a/tests/unit/test_qre_controlled_validation_loop_report.py
+++ b/tests/unit/test_qre_controlled_validation_loop_report.py
@@ -1,0 +1,108 @@
+﻿from __future__ import annotations
+
+import json
+
+from reporting import qre_controlled_validation_execution as execution
+from reporting import qre_controlled_validation_loop_report as loop
+
+
+def test_loop_report_blocks_before_execution_by_default() -> None:
+    snapshot = loop.collect_snapshot(
+        profile_name="equities_exploratory_v1",
+        generated_at_utc="2026-06-03T21:00:00Z",
+    )
+
+    assert snapshot["report_kind"] == "qre_controlled_validation_loop_report"
+    assert snapshot["safe_to_execute"] is False
+    assert snapshot["read_only"] is True
+    assert snapshot["final_recommendation"] == (
+        "controlled_validation_loop_blocked_before_execution"
+    )
+    assert snapshot["counts"]["execution_authorized"] == 0
+    assert snapshot["loop_stages"]["execution"]["execution_status"] == (
+        "execution_blocked_not_requested"
+    )
+    assert snapshot["writes_research_action_queue"] is False
+
+
+def test_loop_report_authorizes_execution_but_stops_at_runner_not_connected() -> None:
+    snapshot = loop.collect_snapshot(
+        profile_name="equities_exploratory_v1",
+        execute_controlled_validation=True,
+        execution_operator_go=execution.REQUIRED_OPERATOR_GO_PHRASE,
+        generated_at_utc="2026-06-03T21:00:00Z",
+    )
+
+    assert snapshot["final_recommendation"] == (
+        "controlled_validation_loop_execution_authorized_runner_not_connected"
+    )
+    assert snapshot["counts"]["execution_authorized"] == 1
+    assert snapshot["counts"]["analysis_ready"] == 0
+    assert snapshot["loop_stages"]["execution"]["controlled_validation_authorized"] is True
+    assert snapshot["loop_stages"]["execution"]["runner_adapter_status"] == "not_connected"
+    assert snapshot["loop_stages"]["result_analysis"]["analysis_status"] == (
+        "analysis_blocked_runner_not_connected"
+    )
+    assert snapshot["executed_anything"] is False
+
+
+def test_loop_report_queue_flags_do_not_bypass_learning_gate() -> None:
+    snapshot = loop.collect_snapshot(
+        profile_name="equities_exploratory_v1",
+        write_research_action_queue=True,
+        queue_operator_go="I authorize QRE research action queue mutation",
+        generated_at_utc="2026-06-03T21:00:00Z",
+    )
+
+    assert snapshot["counts"]["queue_mutation_authorized"] == 0
+    assert snapshot["loop_stages"]["research_action_queue_gate"]["queue_status"] == (
+        "queue_blocked_learning_not_ready"
+    )
+    assert snapshot["writes_research_action_queue"] is False
+
+
+def test_cli_no_write_does_not_create_artifact(tmp_path, monkeypatch, capsys) -> None:
+    artifact_path = tmp_path / "latest.json"
+    monkeypatch.setattr(loop, "ARTIFACT_LATEST", artifact_path)
+
+    rc = loop.main(
+        [
+            "--profile",
+            "equities_exploratory_v1",
+            "--execute-controlled-validation",
+            "--execution-operator-go",
+            execution.REQUIRED_OPERATOR_GO_PHRASE,
+            "--no-write",
+            "--frozen-utc",
+            "2026-06-03T21:00:00Z",
+        ]
+    )
+
+    assert rc == 0
+    assert not artifact_path.exists()
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["counts"]["execution_authorized"] == 1
+
+
+def test_cli_writes_only_own_artifact(tmp_path, monkeypatch) -> None:
+    artifact_dir = tmp_path / "qre_controlled_validation_loop_report"
+    artifact_path = artifact_dir / "latest.json"
+    monkeypatch.setattr(loop, "ARTIFACT_DIR", artifact_dir)
+    monkeypatch.setattr(loop, "ARTIFACT_LATEST", artifact_path)
+
+    rc = loop.main(
+        [
+            "--profile",
+            "equities_exploratory_v1",
+            "--frozen-utc",
+            "2026-06-03T21:00:00Z",
+        ]
+    )
+
+    assert rc == 0
+    assert artifact_path.exists()
+    payload = json.loads(artifact_path.read_text(encoding="utf-8"))
+    assert payload["final_recommendation"] == (
+        "controlled_validation_loop_blocked_before_execution"
+    )
+    assert payload["read_only"] is True

--- a/tests/unit/test_qre_controlled_validation_research_action_queue_gate.py
+++ b/tests/unit/test_qre_controlled_validation_research_action_queue_gate.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import json
 

--- a/tests/unit/test_qre_controlled_validation_research_action_queue_gate.py
+++ b/tests/unit/test_qre_controlled_validation_research_action_queue_gate.py
@@ -1,0 +1,133 @@
+﻿from __future__ import annotations
+
+import json
+
+from reporting import qre_controlled_validation_research_action_queue_gate as gate
+
+
+_READY_LEARNING = {
+    "report_kind": "qre_controlled_validation_learning_proposal",
+    "selection_profile_name": "equities_exploratory_v1",
+    "learning_status": "learning_ready_for_operator_review",
+    "final_recommendation": "controlled_validation_learning_proposal_ready_for_operator_review",
+    "learning_proposal": {
+        "available": True,
+        "outcome": "pass",
+        "hypothesis_action": "continue_validation",
+        "next_research_action": "consider_bounded_followup_validation",
+        "primary_failure_class": None,
+        "evidence_refs": ["research/history/run-a/screening_evidence.v1.json"],
+    },
+}
+
+
+def test_queue_gate_blocks_when_learning_not_ready() -> None:
+    snapshot = gate.collect_snapshot(
+        profile_name="equities_exploratory_v1",
+        generated_at_utc="2026-06-03T20:00:00Z",
+    )
+
+    assert snapshot["report_kind"] == "qre_controlled_validation_research_action_queue_gate"
+    assert snapshot["safe_to_execute"] is False
+    assert snapshot["read_only"] is True
+    assert snapshot["queue_status"] == "queue_blocked_learning_not_ready"
+    assert snapshot["queue_mutation_authorized"] is False
+    assert snapshot["writes_research_action_queue"] is False
+    assert snapshot["candidate_queue_item"] is None
+
+
+def test_queue_gate_blocks_when_write_not_requested() -> None:
+    snapshot = gate.collect_snapshot(
+        learning_snapshot=_READY_LEARNING,
+        generated_at_utc="2026-06-03T20:00:00Z",
+    )
+
+    assert snapshot["queue_status"] == "queue_blocked_write_not_requested"
+    assert snapshot["queue_mutation_authorized"] is False
+    assert snapshot["learning_summary"]["proposal_available"] is True
+
+
+def test_queue_gate_blocks_missing_operator_go() -> None:
+    snapshot = gate.collect_snapshot(
+        learning_snapshot=_READY_LEARNING,
+        write_research_action_queue=True,
+        generated_at_utc="2026-06-03T20:00:00Z",
+    )
+
+    assert snapshot["queue_status"] == "queue_blocked_operator_go_missing"
+    assert snapshot["queue_mutation_authorized"] is False
+    assert snapshot["operator_authorization"]["provided"] is False
+
+
+def test_queue_gate_blocks_wrong_operator_go() -> None:
+    snapshot = gate.collect_snapshot(
+        learning_snapshot=_READY_LEARNING,
+        write_research_action_queue=True,
+        operator_go="wrong",
+        generated_at_utc="2026-06-03T20:00:00Z",
+    )
+
+    assert snapshot["queue_status"] == "queue_blocked_operator_go_mismatch"
+    assert snapshot["queue_mutation_authorized"] is False
+    assert snapshot["operator_authorization"]["provided"] is True
+    assert snapshot["operator_authorization"]["matched"] is False
+
+
+def test_exact_operator_go_authorizes_but_writer_is_not_connected() -> None:
+    snapshot = gate.collect_snapshot(
+        learning_snapshot=_READY_LEARNING,
+        write_research_action_queue=True,
+        operator_go=gate.REQUIRED_QUEUE_GO_PHRASE,
+        generated_at_utc="2026-06-03T20:00:00Z",
+    )
+
+    assert snapshot["queue_status"] == "queue_authorized_writer_not_connected"
+    assert snapshot["queue_mutation_authorized"] is True
+    assert snapshot["queue_writer_adapter_status"] == "not_connected"
+    assert snapshot["writes_research_action_queue"] is False
+    assert snapshot["candidate_queue_item"]["next_research_action"] == (
+        "consider_bounded_followup_validation"
+    )
+    assert snapshot["candidate_queue_item"]["requires_operator_review"] is True
+
+
+def test_cli_no_write_does_not_create_artifact(tmp_path, monkeypatch, capsys) -> None:
+    artifact_path = tmp_path / "latest.json"
+    monkeypatch.setattr(gate, "ARTIFACT_LATEST", artifact_path)
+
+    rc = gate.main(
+        [
+            "--profile",
+            "equities_exploratory_v1",
+            "--no-write",
+            "--frozen-utc",
+            "2026-06-03T20:00:00Z",
+        ]
+    )
+
+    assert rc == 0
+    assert not artifact_path.exists()
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["queue_status"] == "queue_blocked_learning_not_ready"
+
+
+def test_cli_writes_only_own_artifact(tmp_path, monkeypatch) -> None:
+    artifact_dir = tmp_path / "qre_controlled_validation_research_action_queue_gate"
+    artifact_path = artifact_dir / "latest.json"
+    monkeypatch.setattr(gate, "ARTIFACT_DIR", artifact_dir)
+    monkeypatch.setattr(gate, "ARTIFACT_LATEST", artifact_path)
+
+    rc = gate.main(
+        [
+            "--profile",
+            "equities_exploratory_v1",
+            "--frozen-utc",
+            "2026-06-03T20:00:00Z",
+        ]
+    )
+
+    assert rc == 0
+    assert artifact_path.exists()
+    payload = json.loads(artifact_path.read_text(encoding="utf-8"))
+    assert payload["queue_status"] == "queue_blocked_learning_not_ready"
+    assert payload["read_only"] is True

--- a/tests/unit/test_qre_controlled_validation_result_analysis.py
+++ b/tests/unit/test_qre_controlled_validation_result_analysis.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import json
 

--- a/tests/unit/test_qre_controlled_validation_result_analysis.py
+++ b/tests/unit/test_qre_controlled_validation_result_analysis.py
@@ -1,0 +1,129 @@
+﻿from __future__ import annotations
+
+import json
+
+from reporting import qre_controlled_validation_execution as execution
+from reporting import qre_controlled_validation_result_analysis as analysis
+
+
+def test_analysis_blocks_when_execution_not_authorized() -> None:
+    snapshot = analysis.collect_snapshot(
+        profile_name="equities_exploratory_v1",
+        generated_at_utc="2026-06-03T18:00:00Z",
+    )
+
+    assert snapshot["report_kind"] == "qre_controlled_validation_result_analysis"
+    assert snapshot["safe_to_execute"] is False
+    assert snapshot["read_only"] is True
+    assert snapshot["analysis_status"] == "analysis_blocked_execution_not_authorized"
+    assert snapshot["counts"]["blocked"] == 1
+    assert snapshot["result_summary"]["completed_run_available"] is False
+    assert snapshot["writes_research_action_queue"] is False
+
+
+def test_analysis_blocks_when_runner_not_connected_even_if_authorized() -> None:
+    execution_snapshot = execution.collect_snapshot(
+        profile_name="equities_exploratory_v1",
+        execute_controlled_validation=True,
+        operator_go=execution.REQUIRED_OPERATOR_GO_PHRASE,
+        generated_at_utc="2026-06-03T17:00:00Z",
+    )
+
+    snapshot = analysis.collect_snapshot(
+        profile_name="equities_exploratory_v1",
+        execution_snapshot=execution_snapshot,
+        generated_at_utc="2026-06-03T18:00:00Z",
+    )
+
+    assert snapshot["analysis_status"] == "analysis_blocked_runner_not_connected"
+    assert snapshot["execution_summary"]["controlled_validation_authorized"] is True
+    assert snapshot["execution_summary"]["runner_adapter_status"] == "not_connected"
+    assert snapshot["result_summary"]["completed_run_available"] is False
+    assert snapshot["next_required_step"] == (
+        "connect controlled validation runner before result analysis"
+    )
+
+
+def test_analysis_blocks_when_connected_runner_has_no_completed_run() -> None:
+    execution_snapshot = {
+        "report_kind": "qre_controlled_validation_execution",
+        "selection_profile_name": "equities_exploratory_v1",
+        "execution_status": "execution_authorized_runner_connected",
+        "controlled_validation_authorized": True,
+        "runner_adapter_status": "connected",
+        "executed_anything": False,
+        "final_recommendation": "controlled_validation_execution_ready",
+    }
+
+    snapshot = analysis.collect_snapshot(
+        execution_snapshot=execution_snapshot,
+        generated_at_utc="2026-06-03T18:00:00Z",
+    )
+
+    assert snapshot["analysis_status"] == "analysis_blocked_no_completed_run"
+    assert snapshot["execution_summary"]["runner_adapter_status"] == "connected"
+    assert snapshot["execution_summary"]["executed_anything"] is False
+
+
+def test_analysis_ready_when_execution_completed() -> None:
+    execution_snapshot = {
+        "report_kind": "qre_controlled_validation_execution",
+        "selection_profile_name": "equities_exploratory_v1",
+        "execution_status": "execution_completed",
+        "controlled_validation_authorized": True,
+        "runner_adapter_status": "connected",
+        "executed_anything": True,
+        "final_recommendation": "controlled_validation_execution_completed",
+    }
+
+    snapshot = analysis.collect_snapshot(
+        execution_snapshot=execution_snapshot,
+        generated_at_utc="2026-06-03T18:00:00Z",
+    )
+
+    assert snapshot["analysis_status"] == "analysis_ready"
+    assert snapshot["counts"]["ready"] == 1
+    assert snapshot["result_summary"]["completed_run_available"] is True
+    assert snapshot["final_recommendation"] == "controlled_validation_result_analysis_ready"
+
+
+def test_cli_no_write_does_not_create_artifact(tmp_path, monkeypatch, capsys) -> None:
+    artifact_path = tmp_path / "latest.json"
+    monkeypatch.setattr(analysis, "ARTIFACT_LATEST", artifact_path)
+
+    rc = analysis.main(
+        [
+            "--profile",
+            "equities_exploratory_v1",
+            "--no-write",
+            "--frozen-utc",
+            "2026-06-03T18:00:00Z",
+        ]
+    )
+
+    assert rc == 0
+    assert not artifact_path.exists()
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["analysis_status"] == "analysis_blocked_execution_not_authorized"
+
+
+def test_cli_writes_only_own_artifact(tmp_path, monkeypatch) -> None:
+    artifact_dir = tmp_path / "qre_controlled_validation_result_analysis"
+    artifact_path = artifact_dir / "latest.json"
+    monkeypatch.setattr(analysis, "ARTIFACT_DIR", artifact_dir)
+    monkeypatch.setattr(analysis, "ARTIFACT_LATEST", artifact_path)
+
+    rc = analysis.main(
+        [
+            "--profile",
+            "equities_exploratory_v1",
+            "--frozen-utc",
+            "2026-06-03T18:00:00Z",
+        ]
+    )
+
+    assert rc == 0
+    assert artifact_path.exists()
+    payload = json.loads(artifact_path.read_text(encoding="utf-8"))
+    assert payload["analysis_status"] == "analysis_blocked_execution_not_authorized"
+    assert payload["read_only"] is True


### PR DESCRIPTION
﻿## Summary
- Add a QRE controlled validation execution contract with exact operator-go authorization.
- Add result-analysis, learning-proposal, and research-action queue mutation gate scaffolds.
- Add an operator-facing controlled validation loop report that summarizes execution, result analysis, learning, and queue gates.

## Safety
- No real controlled_eval/run_research runner is connected yet.
- No subprocess launch.
- No Codex launch.
- No campaign queue mutation.
- No strategy/preset mutation.
- No paper/shadow/live activation.
- No research-action queue write.
- All reports remain safe_to_execute=false and read_only=true.
- Queue mutation remains blocked until learning is ready and a future bounded writer adapter is connected.

## Current behavior
- Default loop is blocked before execution.
- With exact controlled-validation operator-go, execution becomes authorized but stops at runner_adapter_status=not_connected.
- With exact queue operator-go, queue mutation still remains blocked unless learning is ready.
- The next required step is to connect the controlled validation runner adapter.

## Validation
- `python -m pytest tests/unit/test_discovery_sprint.py tests/unit/test_discovery_sprint_routing.py tests/unit/test_discovery_sprint_safeguards.py tests/unit/test_qre_executable_hypothesis_selection.py tests/unit/test_qre_selection_route_materialization.py tests/unit/test_qre_selection_route_validation_flow.py tests/unit/test_qre_selection_closed_loop_preflight.py tests/unit/test_qre_controlled_validation_execution.py tests/unit/test_qre_controlled_validation_result_analysis.py tests/unit/test_qre_controlled_validation_learning_proposal.py tests/unit/test_qre_controlled_validation_research_action_queue_gate.py tests/unit/test_qre_controlled_validation_loop_report.py -q`
- 131 passed
- `python -m reporting.qre_controlled_validation_loop_report --profile equities_exploratory_v1 --no-write --indent 2 --frozen-utc 2026-06-03T21:00:00Z`
- `python -m reporting.qre_controlled_validation_loop_report --profile equities_exploratory_v1 --execute-controlled-validation --execution-operator-go "I authorize QRE controlled validation execution" --write-research-action-queue --queue-operator-go "I authorize QRE research action queue mutation" --no-write --indent 2 --frozen-utc 2026-06-03T21:00:00Z`
