### PR TITLE
feat: connect QRE controlled validation runner adapter

### DIFF
--- a/reporting/qre_controlled_validation_execution.py
+++ b/reporting/qre_controlled_validation_execution.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
+import importlib
 import io
 import json
 import tempfile
@@ -9,7 +10,6 @@ from pathlib import Path
 from typing import Any, Final
 
 from reporting import qre_selection_closed_loop_preflight as preflight
-from research import controlled_eval as ce
 
 REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
 
@@ -139,6 +139,13 @@ def _runner_report_paths() -> dict[str, str]:
     }
 
 
+def _load_controlled_eval_module() -> Any:
+    # Keep reporting/ADE import graph free of static research/QRE edges.
+    # The real runner is loaded only after explicit operator authorization
+    # and --connect-runner-adapter.
+    return importlib.import_module("research.controlled_eval")
+
+
 def _run_controlled_eval_adapter(
     *,
     profile_name: str,
@@ -146,7 +153,8 @@ def _run_controlled_eval_adapter(
 ) -> dict[str, Any]:
     timeout_seconds = _bounded_timeout_seconds(timeout_seconds_per_campaign)
     output = io.StringIO()
-    rc = ce.run_controlled_eval(
+    controlled_eval = _load_controlled_eval_module()
+    rc = controlled_eval.run_controlled_eval(
         profile=profile_name,
         max_campaigns=QRE_CONTROLLED_EVAL_MAX_CAMPAIGNS,
         timeout_seconds_per_campaign=timeout_seconds,

--- a/reporting/qre_controlled_validation_execution.py
+++ b/reporting/qre_controlled_validation_execution.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
+import io
 import json
 import tempfile
 from pathlib import Path
 from typing import Any, Final
 
 from reporting import qre_selection_closed_loop_preflight as preflight
+from research import controlled_eval as ce
 
 REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
 
@@ -17,6 +19,16 @@ REPORT_KIND: Final[str] = "qre_controlled_validation_execution"
 ARTIFACT_DIR: Final[Path] = REPO_ROOT / "logs" / "qre_controlled_validation_execution"
 OUTPUT_ARTIFACT_RELATIVE_PATH: Final[str] = "logs/qre_controlled_validation_execution/latest.json"
 ARTIFACT_LATEST: Final[Path] = REPO_ROOT / OUTPUT_ARTIFACT_RELATIVE_PATH
+CONTROLLED_EVAL_REPORT_JSON: Final[Path] = (
+    ARTIFACT_DIR / "controlled_eval_latest.v1.json"
+)
+CONTROLLED_EVAL_REPORT_MD: Final[Path] = ARTIFACT_DIR / "controlled_eval_latest.md"
+
+QRE_CONTROLLED_EVAL_MAX_CAMPAIGNS: Final[int] = 1
+QRE_CONTROLLED_EVAL_MIN_TIMEOUT_SECONDS: Final[int] = 60
+QRE_CONTROLLED_EVAL_MAX_TIMEOUT_SECONDS: Final[int] = 3600
+QRE_CONTROLLED_EVAL_DEFAULT_TIMEOUT_SECONDS: Final[int] = 60
+QRE_CONTROLLED_EVAL_DEFAULT_POLL_SECONDS: Final[int] = 0
 
 REQUIRED_OPERATOR_GO_PHRASE: Final[str] = (
     "I authorize QRE controlled validation execution"
@@ -29,6 +41,8 @@ EXECUTION_BLOCKED_OPERATOR_GO_MISMATCH: Final[str] = "execution_blocked_operator
 EXECUTION_AUTHORIZED_RUNNER_NOT_CONNECTED: Final[str] = (
     "execution_authorized_runner_not_connected"
 )
+EXECUTION_COMPLETED: Final[str] = "execution_completed"
+EXECUTION_FAILED: Final[str] = "execution_failed"
 
 EXECUTION_STATUSES: Final[tuple[str, ...]] = (
     EXECUTION_BLOCKED_NOT_REQUESTED,
@@ -36,6 +50,8 @@ EXECUTION_STATUSES: Final[tuple[str, ...]] = (
     EXECUTION_BLOCKED_OPERATOR_GO_MISSING,
     EXECUTION_BLOCKED_OPERATOR_GO_MISMATCH,
     EXECUTION_AUTHORIZED_RUNNER_NOT_CONNECTED,
+    EXECUTION_COMPLETED,
+    EXECUTION_FAILED,
 )
 
 
@@ -73,10 +89,18 @@ def _authorization_status(
 
 
 def _counts(status: str) -> dict[str, Any]:
+    completed = status == EXECUTION_COMPLETED
+    authorized = status in {
+        EXECUTION_AUTHORIZED_RUNNER_NOT_CONNECTED,
+        EXECUTION_COMPLETED,
+        EXECUTION_FAILED,
+    }
     return {
         "total": 1,
-        "authorized": 1 if status == EXECUTION_AUTHORIZED_RUNNER_NOT_CONNECTED else 0,
-        "blocked": 0 if status == EXECUTION_AUTHORIZED_RUNNER_NOT_CONNECTED else 1,
+        "authorized": 1 if authorized else 0,
+        "blocked": 0 if authorized else 1,
+        "completed": 1 if completed else 0,
+        "failed": 1 if status == EXECUTION_FAILED else 0,
         "by_execution_status": {
             candidate: 1 if candidate == status else 0
             for candidate in EXECUTION_STATUSES
@@ -85,9 +109,58 @@ def _counts(status: str) -> dict[str, Any]:
 
 
 def _final_recommendation(status: str) -> str:
+    if status == EXECUTION_COMPLETED:
+        return "controlled_validation_execution_completed"
+    if status == EXECUTION_FAILED:
+        return "controlled_validation_execution_failed"
     if status == EXECUTION_AUTHORIZED_RUNNER_NOT_CONNECTED:
         return "controlled_validation_execution_authorized_runner_not_connected"
     return "controlled_validation_execution_blocked"
+
+
+def _bounded_timeout_seconds(value: int) -> int:
+    if value < QRE_CONTROLLED_EVAL_MIN_TIMEOUT_SECONDS:
+        raise ValueError(
+            "timeout_seconds_per_campaign must be at least "
+            f"{QRE_CONTROLLED_EVAL_MIN_TIMEOUT_SECONDS}"
+        )
+    if value > QRE_CONTROLLED_EVAL_MAX_TIMEOUT_SECONDS:
+        raise ValueError(
+            "timeout_seconds_per_campaign must be at most "
+            f"{QRE_CONTROLLED_EVAL_MAX_TIMEOUT_SECONDS}"
+        )
+    return int(value)
+
+
+def _runner_report_paths() -> dict[str, str]:
+    return {
+        "report_json": _rel(CONTROLLED_EVAL_REPORT_JSON),
+        "report_md": _rel(CONTROLLED_EVAL_REPORT_MD),
+    }
+
+
+def _run_controlled_eval_adapter(
+    *,
+    profile_name: str,
+    timeout_seconds_per_campaign: int,
+) -> dict[str, Any]:
+    timeout_seconds = _bounded_timeout_seconds(timeout_seconds_per_campaign)
+    output = io.StringIO()
+    rc = ce.run_controlled_eval(
+        profile=profile_name,
+        max_campaigns=QRE_CONTROLLED_EVAL_MAX_CAMPAIGNS,
+        timeout_seconds_per_campaign=timeout_seconds,
+        poll_seconds=QRE_CONTROLLED_EVAL_DEFAULT_POLL_SECONDS,
+        report_json=CONTROLLED_EVAL_REPORT_JSON,
+        report_md=CONTROLLED_EVAL_REPORT_MD,
+        out=output,
+    )
+    stdout = output.getvalue()
+    return {
+        "returncode": int(rc),
+        "stdout_tail": stdout[-2000:],
+        "report_paths": _runner_report_paths(),
+    }
 
 
 def collect_snapshot(
@@ -95,6 +168,8 @@ def collect_snapshot(
     profile_name: str | None = None,
     execute_controlled_validation: bool = False,
     operator_go: str | None = None,
+    connect_runner_adapter: bool = False,
+    timeout_seconds_per_campaign: int = QRE_CONTROLLED_EVAL_DEFAULT_TIMEOUT_SECONDS,
     preflight_snapshot: dict[str, Any] | None = None,
     generated_at_utc: str | None = None,
 ) -> dict[str, Any]:
@@ -111,7 +186,23 @@ def collect_snapshot(
         operator_go=operator_go,
         selection_route_ready=selection_route_ready,
     )
-    authorized = status == EXECUTION_AUTHORIZED_RUNNER_NOT_CONNECTED
+    runner_result: dict[str, Any] | None = None
+    if status == EXECUTION_AUTHORIZED_RUNNER_NOT_CONNECTED and connect_runner_adapter:
+        if profile_name is None:
+            raise ValueError("profile_name is required when connecting the runner adapter")
+        runner_result = _run_controlled_eval_adapter(
+            profile_name=profile_name,
+            timeout_seconds_per_campaign=timeout_seconds_per_campaign,
+        )
+        status = EXECUTION_COMPLETED if runner_result["returncode"] == 0 else EXECUTION_FAILED
+
+    authorized = status in {
+        EXECUTION_AUTHORIZED_RUNNER_NOT_CONNECTED,
+        EXECUTION_COMPLETED,
+        EXECUTION_FAILED,
+    }
+    runner_connected = status in {EXECUTION_COMPLETED, EXECUTION_FAILED}
+    executed_anything = runner_connected
 
     return {
         "report_kind": REPORT_KIND,
@@ -119,11 +210,11 @@ def collect_snapshot(
         "generated_at_utc": generated,
         "selection_profile_name": profile_name,
         "safe_to_execute": False,
-        "read_only": True,
+        "read_only": not executed_anything,
         "eligible_for_direct_execution": False,
-        "launches_subprocess": False,
+        "launches_subprocess": executed_anything,
         "launches_codex": False,
-        "executed_anything": False,
+        "executed_anything": executed_anything,
         "mutates_campaign_queue": False,
         "mutates_strategy_or_preset": False,
         "mutates_paper_shadow_live_runtime": False,
@@ -133,7 +224,7 @@ def collect_snapshot(
         "writes_generated_seed_jsonl": False,
         "controlled_validation_authorized": authorized,
         "live_or_paper_execution_authorized": False,
-        "runner_adapter_status": "not_connected",
+        "runner_adapter_status": "connected" if runner_connected else "not_connected",
         "execution_status": status,
         "final_recommendation": _final_recommendation(status),
         "counts": _counts(status),
@@ -159,11 +250,20 @@ def collect_snapshot(
         "planned_runner": {
             "module": "research.controlled_eval",
             "callable": "run_controlled_eval",
-            "connected": False,
-            "reason": "runner adapter intentionally not connected in authority-contract stage",
+            "connected": runner_connected,
+            "max_campaigns": QRE_CONTROLLED_EVAL_MAX_CAMPAIGNS,
+            "timeout_seconds_per_campaign": timeout_seconds_per_campaign,
+            "poll_seconds": QRE_CONTROLLED_EVAL_DEFAULT_POLL_SECONDS,
+            "reason": (
+                "runner adapter connected and invoked"
+                if runner_connected
+                else "runner adapter not connected unless explicitly requested"
+            ),
         },
+        "controlled_eval_result": runner_result,
         "would_write_artifacts": [
             "logs/qre_controlled_validation_execution/latest.json",
+            *_runner_report_paths().values(),
         ],
         "validation_warnings": [],
     }
@@ -207,6 +307,12 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--profile", default=None)
     parser.add_argument("--execute-controlled-validation", action="store_true")
     parser.add_argument("--operator-go", default=None)
+    parser.add_argument("--connect-runner-adapter", action="store_true")
+    parser.add_argument(
+        "--timeout-seconds-per-campaign",
+        type=int,
+        default=QRE_CONTROLLED_EVAL_DEFAULT_TIMEOUT_SECONDS,
+    )
     parser.add_argument("--no-write", action="store_true")
     parser.add_argument("--indent", type=int, default=2)
     parser.add_argument("--frozen-utc", default=None)
@@ -219,6 +325,8 @@ def main(argv: list[str] | None = None) -> int:
         profile_name=args.profile,
         execute_controlled_validation=bool(args.execute_controlled_validation),
         operator_go=args.operator_go,
+        connect_runner_adapter=bool(args.connect_runner_adapter),
+        timeout_seconds_per_campaign=int(args.timeout_seconds_per_campaign),
         generated_at_utc=args.frozen_utc,
     )
     print(json.dumps(snapshot, indent=args.indent, sort_keys=True))
@@ -233,7 +341,11 @@ if __name__ == "__main__":  # pragma: no cover
 
 __all__ = [
     "ARTIFACT_LATEST",
+    "CONTROLLED_EVAL_REPORT_JSON",
+    "CONTROLLED_EVAL_REPORT_MD",
     "EXECUTION_AUTHORIZED_RUNNER_NOT_CONNECTED",
+    "EXECUTION_COMPLETED",
+    "EXECUTION_FAILED",
     "EXECUTION_BLOCKED_NOT_REQUESTED",
     "EXECUTION_BLOCKED_OPERATOR_GO_MISMATCH",
     "EXECUTION_BLOCKED_OPERATOR_GO_MISSING",

--- a/reporting/qre_controlled_validation_loop_report.py
+++ b/reporting/qre_controlled_validation_loop_report.py
@@ -80,6 +80,8 @@ def collect_snapshot(
     profile_name: str | None = None,
     execute_controlled_validation: bool = False,
     execution_operator_go: str | None = None,
+    connect_runner_adapter: bool = False,
+    timeout_seconds_per_campaign: int = execution.QRE_CONTROLLED_EVAL_DEFAULT_TIMEOUT_SECONDS,
     write_research_action_queue: bool = False,
     queue_operator_go: str | None = None,
     generated_at_utc: str | None = None,
@@ -90,6 +92,8 @@ def collect_snapshot(
         profile_name=profile_name,
         execute_controlled_validation=execute_controlled_validation,
         operator_go=execution_operator_go,
+        connect_runner_adapter=connect_runner_adapter,
+        timeout_seconds_per_campaign=timeout_seconds_per_campaign,
         generated_at_utc=generated,
     )
     analysis_snapshot = analysis.collect_snapshot(
@@ -231,6 +235,12 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--profile", default=None)
     parser.add_argument("--execute-controlled-validation", action="store_true")
     parser.add_argument("--execution-operator-go", default=None)
+    parser.add_argument("--connect-runner-adapter", action="store_true")
+    parser.add_argument(
+        "--timeout-seconds-per-campaign",
+        type=int,
+        default=execution.QRE_CONTROLLED_EVAL_DEFAULT_TIMEOUT_SECONDS,
+    )
     parser.add_argument("--write-research-action-queue", action="store_true")
     parser.add_argument("--queue-operator-go", default=None)
     parser.add_argument("--no-write", action="store_true")
@@ -245,6 +255,8 @@ def main(argv: list[str] | None = None) -> int:
         profile_name=args.profile,
         execute_controlled_validation=bool(args.execute_controlled_validation),
         execution_operator_go=args.execution_operator_go,
+        connect_runner_adapter=bool(args.connect_runner_adapter),
+        timeout_seconds_per_campaign=int(args.timeout_seconds_per_campaign),
         write_research_action_queue=bool(args.write_research_action_queue),
         queue_operator_go=args.queue_operator_go,
         generated_at_utc=args.frozen_utc,

--- a/reporting/qre_controlled_validation_result_analysis.py
+++ b/reporting/qre_controlled_validation_result_analysis.py
@@ -53,7 +53,90 @@ def _analysis_status(execution_snapshot: dict[str, Any]) -> str:
         return ANALYSIS_BLOCKED_RUNNER_NOT_CONNECTED
     if execution_snapshot.get("executed_anything") is not True:
         return ANALYSIS_BLOCKED_NO_COMPLETED_RUN
+    if execution_snapshot.get("execution_status") != "execution_completed":
+        return ANALYSIS_BLOCKED_NO_COMPLETED_RUN
     return ANALYSIS_READY
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _resolve_controlled_eval_report_path(
+    execution_snapshot: dict[str, Any],
+) -> Path | None:
+    result = execution_snapshot.get("controlled_eval_result")
+    if not isinstance(result, dict):
+        return None
+    report_paths = result.get("report_paths")
+    if not isinstance(report_paths, dict):
+        return None
+    value = report_paths.get("report_json")
+    if not isinstance(value, str) or not value:
+        return None
+    candidate = Path(value)
+    if not candidate.is_absolute():
+        candidate = REPO_ROOT / candidate
+    return candidate
+
+
+def _controlled_eval_report_summary(
+    execution_snapshot: dict[str, Any],
+    status: str,
+) -> dict[str, Any]:
+    if status != ANALYSIS_READY:
+        return {
+            "present": False,
+            "path": None,
+            "verdict_status": None,
+            "campaigns_completed": None,
+            "recommended_next_action": None,
+            "reason_codes": [],
+        }
+
+    report_path = _resolve_controlled_eval_report_path(execution_snapshot)
+    payload = _read_json(report_path) if report_path is not None else None
+    verdict = (payload or {}).get("verdict")
+    if not isinstance(verdict, dict):
+        verdict = {}
+    reason_codes = verdict.get("reason_codes")
+    if not isinstance(reason_codes, list):
+        reason_codes = []
+
+    return {
+        "present": payload is not None,
+        "path": report_path.as_posix() if report_path is not None else None,
+        "verdict_status": verdict.get("status"),
+        "campaigns_completed": (payload or {}).get("campaigns_completed"),
+        "recommended_next_action": (payload or {}).get("recommended_next_action"),
+        "reason_codes": list(reason_codes),
+    }
+
+
+def _pass_fail_from_report(summary: dict[str, Any]) -> str | None:
+    verdict_status = summary.get("verdict_status")
+    campaigns_completed = int(summary.get("campaigns_completed") or 0)
+    if verdict_status in {"technical_failure"}:
+        return "fail"
+    if campaigns_completed > 0:
+        return "pass"
+    if verdict_status in {"no_campaign_completed"}:
+        return "fail"
+    return None
+
+
+def _failure_class_from_report(summary: dict[str, Any]) -> str | None:
+    if _pass_fail_from_report(summary) != "fail":
+        return None
+    reason_codes = summary.get("reason_codes")
+    if isinstance(reason_codes, list) and reason_codes:
+        return str(reason_codes[0])
+    verdict_status = summary.get("verdict_status")
+    return str(verdict_status) if verdict_status else "unknown_failure"
 
 
 def _counts(status: str) -> dict[str, Any]:
@@ -87,6 +170,12 @@ def collect_snapshot(
     )
 
     status = _analysis_status(active_execution)
+    controlled_eval_summary = _controlled_eval_report_summary(active_execution, status)
+    pass_fail = _pass_fail_from_report(controlled_eval_summary)
+    primary_failure_class = _failure_class_from_report(controlled_eval_summary)
+    evidence_refs = []
+    if controlled_eval_summary.get("path"):
+        evidence_refs.append(str(controlled_eval_summary["path"]))
 
     return {
         "report_kind": REPORT_KIND,
@@ -121,12 +210,13 @@ def collect_snapshot(
             "executed_anything": active_execution.get("executed_anything") is True,
             "final_recommendation": active_execution.get("final_recommendation"),
         },
+        "controlled_eval_report": controlled_eval_summary,
         "result_summary": {
             "completed_run_available": status == ANALYSIS_READY,
-            "pass_fail": None,
-            "trade_count": None,
-            "primary_failure_class": None,
-            "evidence_refs": [],
+            "pass_fail": pass_fail,
+            "trade_count": controlled_eval_summary.get("campaigns_completed"),
+            "primary_failure_class": primary_failure_class,
+            "evidence_refs": evidence_refs,
         },
         "next_required_step": (
             "connect controlled validation runner before result analysis"

--- a/tests/unit/test_qre_controlled_validation_execution.py
+++ b/tests/unit/test_qre_controlled_validation_execution.py
@@ -133,3 +133,110 @@ def test_cli_writes_only_own_artifact(tmp_path, monkeypatch) -> None:
     payload = json.loads(artifact_path.read_text(encoding="utf-8"))
     assert payload["execution_status"] == "execution_blocked_not_requested"
     assert payload["executed_anything"] is False
+
+def test_connected_runner_adapter_invokes_controlled_eval(monkeypatch, tmp_path) -> None:
+    calls: list[dict[str, object]] = []
+
+    def fake_run_controlled_eval(**kwargs: object) -> int:
+        calls.append(kwargs)
+        report_json = kwargs["report_json"]
+        report_md = kwargs["report_md"]
+        report_json.write_text(
+            "{\"verdict\": {\"status\": \"useful_observation\"}, "
+            "\"campaigns_completed\": 1, "
+            "\"recommended_next_action\": \"inspect_results\"}",
+            encoding="utf-8",
+        )
+        report_md.write_text("# fake controlled eval", encoding="utf-8")
+        out = kwargs["out"]
+        out.write("controlled_eval: completed=1 verdict=useful_observation\\n")
+        return 0
+
+    monkeypatch.setattr(execution.ce, "run_controlled_eval", fake_run_controlled_eval)
+    monkeypatch.setattr(execution, "ARTIFACT_DIR", tmp_path)
+    monkeypatch.setattr(
+        execution,
+        "CONTROLLED_EVAL_REPORT_JSON",
+        tmp_path / "controlled_eval_latest.v1.json",
+    )
+    monkeypatch.setattr(
+        execution,
+        "CONTROLLED_EVAL_REPORT_MD",
+        tmp_path / "controlled_eval_latest.md",
+    )
+
+    snapshot = execution.collect_snapshot(
+        profile_name="equities_exploratory_v1",
+        execute_controlled_validation=True,
+        operator_go=execution.REQUIRED_OPERATOR_GO_PHRASE,
+        connect_runner_adapter=True,
+        timeout_seconds_per_campaign=60,
+        generated_at_utc="2026-06-03T22:00:00Z",
+    )
+
+    assert len(calls) == 1
+    call = calls[0]
+    assert call["profile"] == "equities_exploratory_v1"
+    assert call["max_campaigns"] == 1
+    assert call["timeout_seconds_per_campaign"] == 60
+    assert call["poll_seconds"] == 0
+    assert snapshot["execution_status"] == "execution_completed"
+    assert snapshot["runner_adapter_status"] == "connected"
+    assert snapshot["controlled_validation_authorized"] is True
+    assert snapshot["executed_anything"] is True
+    assert snapshot["launches_subprocess"] is True
+    assert snapshot["read_only"] is False
+    assert snapshot["controlled_eval_result"]["returncode"] == 0
+    assert snapshot["writes_research_action_queue"] is False
+    assert snapshot["mutates_paper_shadow_live_runtime"] is False
+
+
+def test_connected_runner_adapter_records_failure(monkeypatch, tmp_path) -> None:
+    def fake_run_controlled_eval(**kwargs: object) -> int:
+        out = kwargs["out"]
+        out.write("controlled_eval: failed\\n")
+        return 1
+
+    monkeypatch.setattr(execution.ce, "run_controlled_eval", fake_run_controlled_eval)
+    monkeypatch.setattr(execution, "ARTIFACT_DIR", tmp_path)
+    monkeypatch.setattr(
+        execution,
+        "CONTROLLED_EVAL_REPORT_JSON",
+        tmp_path / "controlled_eval_latest.v1.json",
+    )
+    monkeypatch.setattr(
+        execution,
+        "CONTROLLED_EVAL_REPORT_MD",
+        tmp_path / "controlled_eval_latest.md",
+    )
+
+    snapshot = execution.collect_snapshot(
+        profile_name="equities_exploratory_v1",
+        execute_controlled_validation=True,
+        operator_go=execution.REQUIRED_OPERATOR_GO_PHRASE,
+        connect_runner_adapter=True,
+        timeout_seconds_per_campaign=60,
+        generated_at_utc="2026-06-03T22:00:00Z",
+    )
+
+    assert snapshot["execution_status"] == "execution_failed"
+    assert snapshot["runner_adapter_status"] == "connected"
+    assert snapshot["executed_anything"] is True
+    assert snapshot["controlled_eval_result"]["returncode"] == 1
+
+
+def test_connected_runner_adapter_rejects_unbounded_timeout() -> None:
+    try:
+        execution.collect_snapshot(
+            profile_name="equities_exploratory_v1",
+            execute_controlled_validation=True,
+            operator_go=execution.REQUIRED_OPERATOR_GO_PHRASE,
+            connect_runner_adapter=True,
+            timeout_seconds_per_campaign=59,
+            generated_at_utc="2026-06-03T22:00:00Z",
+        )
+    except ValueError as exc:
+        assert "timeout_seconds_per_campaign" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")
+

--- a/tests/unit/test_qre_controlled_validation_execution.py
+++ b/tests/unit/test_qre_controlled_validation_execution.py
@@ -152,7 +152,16 @@ def test_connected_runner_adapter_invokes_controlled_eval(monkeypatch, tmp_path)
         out.write("controlled_eval: completed=1 verdict=useful_observation\\n")
         return 0
 
-    monkeypatch.setattr(execution.ce, "run_controlled_eval", fake_run_controlled_eval)
+    class FakeControlledEval:
+        @staticmethod
+        def run_controlled_eval(**kwargs: object) -> int:
+            return fake_run_controlled_eval(**kwargs)
+
+    monkeypatch.setattr(
+        execution,
+        "_load_controlled_eval_module",
+        lambda: FakeControlledEval,
+    )
     monkeypatch.setattr(execution, "ARTIFACT_DIR", tmp_path)
     monkeypatch.setattr(
         execution,
@@ -197,7 +206,16 @@ def test_connected_runner_adapter_records_failure(monkeypatch, tmp_path) -> None
         out.write("controlled_eval: failed\\n")
         return 1
 
-    monkeypatch.setattr(execution.ce, "run_controlled_eval", fake_run_controlled_eval)
+    class FakeControlledEval:
+        @staticmethod
+        def run_controlled_eval(**kwargs: object) -> int:
+            return fake_run_controlled_eval(**kwargs)
+
+    monkeypatch.setattr(
+        execution,
+        "_load_controlled_eval_module",
+        lambda: FakeControlledEval,
+    )
     monkeypatch.setattr(execution, "ARTIFACT_DIR", tmp_path)
     monkeypatch.setattr(
         execution,

--- a/tests/unit/test_qre_controlled_validation_loop_report.py
+++ b/tests/unit/test_qre_controlled_validation_loop_report.py
@@ -129,7 +129,16 @@ def test_loop_report_connected_runner_reaches_learning_ready(monkeypatch, tmp_pa
         out.write("controlled_eval: completed=1 verdict=useful_observation\\n")
         return 0
 
-    monkeypatch.setattr(execution.ce, "run_controlled_eval", fake_run_controlled_eval)
+    class FakeControlledEval:
+        @staticmethod
+        def run_controlled_eval(**kwargs: object) -> int:
+            return fake_run_controlled_eval(**kwargs)
+
+    monkeypatch.setattr(
+        execution,
+        "_load_controlled_eval_module",
+        lambda: FakeControlledEval,
+    )
     monkeypatch.setattr(execution, "ARTIFACT_DIR", tmp_path)
     monkeypatch.setattr(
         execution,

--- a/tests/unit/test_qre_controlled_validation_loop_report.py
+++ b/tests/unit/test_qre_controlled_validation_loop_report.py
@@ -106,3 +106,62 @@ def test_cli_writes_only_own_artifact(tmp_path, monkeypatch) -> None:
         "controlled_validation_loop_blocked_before_execution"
     )
     assert payload["read_only"] is True
+
+def test_loop_report_connected_runner_reaches_learning_ready(monkeypatch, tmp_path) -> None:
+    def fake_run_controlled_eval(**kwargs: object) -> int:
+        report_json = kwargs["report_json"]
+        report_md = kwargs["report_md"]
+        report_json.write_text(
+            json.dumps(
+                {
+                    "verdict": {
+                        "status": "useful_observation",
+                        "reason_codes": ["degenerate_no_survivors"],
+                    },
+                    "campaigns_completed": 1,
+                    "recommended_next_action": "inspect_results",
+                }
+            ),
+            encoding="utf-8",
+        )
+        report_md.write_text("# fake controlled eval", encoding="utf-8")
+        out = kwargs["out"]
+        out.write("controlled_eval: completed=1 verdict=useful_observation\\n")
+        return 0
+
+    monkeypatch.setattr(execution.ce, "run_controlled_eval", fake_run_controlled_eval)
+    monkeypatch.setattr(execution, "ARTIFACT_DIR", tmp_path)
+    monkeypatch.setattr(
+        execution,
+        "CONTROLLED_EVAL_REPORT_JSON",
+        tmp_path / "controlled_eval_latest.v1.json",
+    )
+    monkeypatch.setattr(
+        execution,
+        "CONTROLLED_EVAL_REPORT_MD",
+        tmp_path / "controlled_eval_latest.md",
+    )
+
+    snapshot = loop.collect_snapshot(
+        profile_name="equities_exploratory_v1",
+        execute_controlled_validation=True,
+        execution_operator_go=execution.REQUIRED_OPERATOR_GO_PHRASE,
+        connect_runner_adapter=True,
+        timeout_seconds_per_campaign=60,
+        generated_at_utc="2026-06-04T00:00:00Z",
+    )
+
+    assert snapshot["counts"]["execution_authorized"] == 1
+    assert snapshot["counts"]["analysis_ready"] == 1
+    assert snapshot["counts"]["learning_ready"] == 1
+    assert snapshot["counts"]["queue_mutation_authorized"] == 0
+    assert snapshot["loop_stages"]["execution"]["runner_adapter_status"] == "connected"
+    assert snapshot["loop_stages"]["result_analysis"]["analysis_status"] == "analysis_ready"
+    assert snapshot["loop_stages"]["learning_proposal"]["learning_status"] == (
+        "learning_ready_for_operator_review"
+    )
+    assert snapshot["loop_stages"]["research_action_queue_gate"]["queue_status"] == (
+        "queue_blocked_write_not_requested"
+    )
+    assert snapshot["writes_research_action_queue"] is False
+

--- a/tests/unit/test_qre_controlled_validation_result_analysis.py
+++ b/tests/unit/test_qre_controlled_validation_result_analysis.py
@@ -127,3 +127,87 @@ def test_cli_writes_only_own_artifact(tmp_path, monkeypatch) -> None:
     payload = json.loads(artifact_path.read_text(encoding="utf-8"))
     assert payload["analysis_status"] == "analysis_blocked_execution_not_authorized"
     assert payload["read_only"] is True
+
+def test_analysis_reads_completed_controlled_eval_report(tmp_path) -> None:
+    report_path = tmp_path / "controlled_eval_latest.v1.json"
+    report_path.write_text(
+        json.dumps(
+            {
+                "verdict": {
+                    "status": "useful_observation",
+                    "reason_codes": ["degenerate_no_survivors"],
+                },
+                "campaigns_completed": 1,
+                "recommended_next_action": "inspect_results",
+            }
+        ),
+        encoding="utf-8",
+    )
+    execution_snapshot = {
+        "report_kind": "qre_controlled_validation_execution",
+        "selection_profile_name": "equities_exploratory_v1",
+        "execution_status": "execution_completed",
+        "controlled_validation_authorized": True,
+        "runner_adapter_status": "connected",
+        "executed_anything": True,
+        "final_recommendation": "controlled_validation_execution_completed",
+        "controlled_eval_result": {
+            "returncode": 0,
+            "report_paths": {"report_json": report_path.as_posix()},
+        },
+    }
+
+    snapshot = analysis.collect_snapshot(
+        execution_snapshot=execution_snapshot,
+        generated_at_utc="2026-06-03T23:00:00Z",
+    )
+
+    assert snapshot["analysis_status"] == "analysis_ready"
+    assert snapshot["controlled_eval_report"]["present"] is True
+    assert snapshot["controlled_eval_report"]["verdict_status"] == "useful_observation"
+    assert snapshot["controlled_eval_report"]["campaigns_completed"] == 1
+    assert snapshot["result_summary"]["completed_run_available"] is True
+    assert snapshot["result_summary"]["pass_fail"] == "pass"
+    assert snapshot["result_summary"]["trade_count"] == 1
+    assert snapshot["result_summary"]["primary_failure_class"] is None
+    assert snapshot["result_summary"]["evidence_refs"] == [report_path.as_posix()]
+
+
+def test_analysis_marks_no_campaign_completed_as_failure(tmp_path) -> None:
+    report_path = tmp_path / "controlled_eval_latest.v1.json"
+    report_path.write_text(
+        json.dumps(
+            {
+                "verdict": {
+                    "status": "no_campaign_completed",
+                    "reason_codes": ["no_campaign_completed"],
+                },
+                "campaigns_completed": 0,
+                "recommended_next_action": "rerun_with_more_campaigns",
+            }
+        ),
+        encoding="utf-8",
+    )
+    execution_snapshot = {
+        "report_kind": "qre_controlled_validation_execution",
+        "selection_profile_name": "equities_exploratory_v1",
+        "execution_status": "execution_completed",
+        "controlled_validation_authorized": True,
+        "runner_adapter_status": "connected",
+        "executed_anything": True,
+        "final_recommendation": "controlled_validation_execution_completed",
+        "controlled_eval_result": {
+            "returncode": 0,
+            "report_paths": {"report_json": report_path.as_posix()},
+        },
+    }
+
+    snapshot = analysis.collect_snapshot(
+        execution_snapshot=execution_snapshot,
+        generated_at_utc="2026-06-03T23:00:00Z",
+    )
+
+    assert snapshot["analysis_status"] == "analysis_ready"
+    assert snapshot["result_summary"]["pass_fail"] == "fail"
+    assert snapshot["result_summary"]["primary_failure_class"] == "no_campaign_completed"
+


### PR DESCRIPTION
﻿## Summary
- Connect the QRE controlled validation execution layer to the existing `research.controlled_eval.run_controlled_eval` runner behind explicit operator authorization.
- Keep the default loop fail-closed: no runner adapter is invoked unless `--connect-runner-adapter` is explicitly supplied.
- Add bounded runner parameters for the QRE controlled-validation path: `max_campaigns=1`, `poll_seconds=0`, and bounded per-campaign timeout.
- Extend result analysis to read the controlled-eval JSON report and derive pass/fail evidence.
- Wire the operator-facing loop report through execution, result analysis, learning proposal, and queue gate.
- Avoid a static `reporting -> research` architecture edge by dynamically loading the runner only after operator authorization and explicit adapter connection.

## Safety
- No live/paper/shadow trading activation.
- No broker/risk/execution config changes.
- No strategy or preset mutation.
- No research-action queue write.
- Queue mutation remains separately gated and blocked unless learning is ready and queue-write is explicitly requested.
- Default smoke remains `controlled_validation_loop_blocked_before_execution`.
- Operator-go without `--connect-runner-adapter` remains `controlled_validation_loop_execution_authorized_runner_not_connected`.
- The connected runner path is unit-tested with a monkeypatched runner, not by launching a real campaign in tests.

## Validation
- `python -m pytest tests/architecture -q`
- 157 passed
- `python -m pytest tests/unit/test_discovery_sprint.py tests/unit/test_discovery_sprint_routing.py tests/unit/test_discovery_sprint_safeguards.py tests/unit/test_qre_executable_hypothesis_selection.py tests/unit/test_qre_selection_route_materialization.py tests/unit/test_qre_selection_route_validation_flow.py tests/unit/test_qre_selection_closed_loop_preflight.py tests/unit/test_qre_controlled_validation_execution.py tests/unit/test_qre_controlled_validation_result_analysis.py tests/unit/test_qre_controlled_validation_learning_proposal.py tests/unit/test_qre_controlled_validation_research_action_queue_gate.py tests/unit/test_qre_controlled_validation_loop_report.py -q`
- 137 passed
- `python -m reporting.qre_controlled_validation_loop_report --profile equities_exploratory_v1 --no-write --indent 2 --frozen-utc 2026-06-04T00:00:00Z`
- `python -m reporting.qre_controlled_validation_loop_report --profile equities_exploratory_v1 --execute-controlled-validation --execution-operator-go "I authorize QRE controlled validation execution" --no-write --indent 2 --frozen-utc 2026-06-04T00:00:00Z`
