### PR TITLE
fix: classify QRE launcher invariant violations

### DIFF
--- a/research/controlled_eval.py
+++ b/research/controlled_eval.py
@@ -390,6 +390,26 @@ def _classify_verdict(
             },
             "operator_review_required",
         )
+    launcher_invariant_violations = [
+        tick
+        for tick in ticks
+        if tick.returncode not in (None, 0)
+        and "campaign invariant violation" in tick.stderr_tail.lower()
+    ]
+    if launcher_invariant_violations:
+        reason_codes.append("launcher_invariant_violation")
+        return (
+            {
+                "status": "technical_failure",
+                "reason_codes": reason_codes,
+                "human_summary": (
+                    "Campaign launcher reported a campaign invariant violation "
+                    "before campaign-level completion evidence could be trusted."
+                ),
+            },
+            "operator_review_required",
+        )
+
     if not completed:
         reason_codes.append("no_campaign_completed")
         if (

--- a/tests/unit/test_controlled_eval.py
+++ b/tests/unit/test_controlled_eval.py
@@ -459,3 +459,65 @@ def test_cli_smoke_with_mocked_launcher_invocation(
     assert launcher_calls == [[ce.sys.executable, "-m", "research.campaign_launcher"]]
     assert (tmp_path / "controlled.json").exists()
     assert (tmp_path / "controlled.md").exists()
+
+def test_launcher_invariant_violation_is_technical_failure() -> None:
+    payload = ce.build_report_payload(
+        profile="equities_exploratory_v1",
+        max_campaigns=1,
+        sprint_started_by_harness=True,
+        sprint_reused=False,
+        observed_total_before=0,
+        observed_total_after=0,
+        campaigns_attempted=1,
+        sprint_registry={},
+        sprint_progress={},
+        registry={},
+        ledger_events=[],
+        run_campaign_payload={},
+        latest_policy_decision_payload={
+            "action": "spawn",
+            "reason": "cron_tick",
+            "candidates_considered": [{"id": "candidate-1"}],
+            "rules_summary": {
+                "R4_R7_filtering": {
+                    "result": "candidates",
+                    "surviving": 1,
+                    "rejected": 0,
+                }
+            },
+        },
+        queue_payload={"items": [{"state": "terminal"}]},
+        intelligence_artifact_status={
+            "information_gain": "missing",
+            "viability": "missing",
+            "stop_conditions": "missing",
+            "spawn_proposals": "missing",
+        },
+        ticks=[
+            ce.LauncherTick(
+                tick_index=1,
+                returncode=2,
+                timed_out=False,
+                elapsed_seconds=1,
+                stdout_tail="",
+                stderr_tail=(
+                    "campaign invariant violation: I5 violation: completed campaign "
+                    "'col-example' lacks campaign_completed ledger event"
+                ),
+                completed_campaign_ids=(),
+            )
+        ],
+    )
+
+    assert payload["campaigns_completed"] == 0
+    assert payload["campaign_level_evidence_valid"] is False
+    assert payload["verdict"]["status"] == "technical_failure"
+    assert "launcher_invariant_violation" in payload["verdict"]["reason_codes"]
+    assert payload["recommended_next_action"] == "operator_review_required"
+    assert payload["launcher_ticks"][0]["returncode"] == 2
+    assert "campaign invariant violation" in payload["launcher_ticks"][0]["stderr_tail"]
+
+    markdown = ce.render_markdown_report(payload)
+    assert "technical_failure" in markdown
+    assert "launcher_invariant_violation" in markdown
+


### PR DESCRIPTION
﻿## Summary
- Classify QRE controlled-eval launcher invariant violations as `technical_failure`.
- Add `launcher_invariant_violation` as an explicit reason code.
- Keep the recommended next action as `operator_review_required`.
- Add regression coverage for a launcher tick with non-zero return code and `campaign invariant violation` stderr.

## Why
A bounded controlled-validation follow-up run produced:
- `returncode=2`
- `stderr_tail` containing `campaign invariant violation`
- no trusted campaign completion evidence

Before this fix, the report classified that as `no_campaign_completed` with `rerun_with_more_campaigns`, which is too optimistic. This hotfix makes the operator-facing report fail closed when launcher invariants are violated.

## Safety
- No trading activation.
- No broker/risk/execution changes.
- No queue mutation.
- No strategy or preset mutation.
- No generated research artifacts included.
- This only changes controlled-eval classification/reporting.

## Validation
- `python -m pytest tests/unit/test_controlled_eval.py -q`
- 9 passed
- `python -m pytest tests/unit/test_controlled_eval.py tests/unit/test_qre_controlled_validation_execution.py tests/unit/test_qre_controlled_validation_result_analysis.py tests/unit/test_qre_controlled_validation_learning_proposal.py tests/unit/test_qre_controlled_validation_research_action_queue_gate.py tests/unit/test_qre_controlled_validation_loop_report.py -q`
- 46 passed
- `python -m pytest tests/architecture -q`
- 157 passed
