### PR TITLE
fix: surface QRE linkage blockers in validation evidence

### DIFF
--- a/reporting/qre_controlled_validation_result_analysis.py
+++ b/reporting/qre_controlled_validation_result_analysis.py
@@ -97,6 +97,10 @@ def _controlled_eval_report_summary(
     if not isinstance(reason_codes, list):
         reason_codes = []
 
+    screening_evidence_summary = (payload or {}).get("screening_evidence_summary")
+    if not isinstance(screening_evidence_summary, dict):
+        screening_evidence_summary = {}
+
     return {
         "present": payload is not None,
         "path": report_path.as_posix() if report_path is not None else None,
@@ -107,6 +111,7 @@ def _controlled_eval_report_summary(
         ),
         "recommended_next_action": (payload or {}).get("recommended_next_action"),
         "reason_codes": list(reason_codes),
+        "screening_evidence_summary": screening_evidence_summary,
     }
 
 
@@ -213,6 +218,9 @@ def collect_snapshot(
             "pass_fail": pass_fail,
             "trade_count": controlled_eval_summary.get("campaigns_completed"),
             "primary_failure_class": primary_failure_class,
+            "screening_evidence_summary": controlled_eval_summary.get(
+                "screening_evidence_summary", {}
+            ),
             "evidence_refs": evidence_refs,
         },
         "next_required_step": (

--- a/research/controlled_eval.py
+++ b/research/controlled_eval.py
@@ -45,6 +45,7 @@ MAX_POLL_SECONDS: Final[int] = 300
 
 LEDGER_PATH: Final[Path] = Path("research/campaign_evidence_ledger_latest.v1.jsonl")
 RUN_CAMPAIGN_PATH: Final[Path] = Path("research/run_campaign_latest.v1.json")
+SCREENING_EVIDENCE_PATH: Final[Path] = Path("research/screening_evidence_latest.v1.json")
 INFORMATION_GAIN_PATH: Final[Path] = Path(
     "research/campaigns/evidence/information_gain_latest.v1.json"
 )
@@ -232,6 +233,44 @@ def summarize_campaign_records(
             }
         )
     return records
+
+
+def summarize_screening_evidence(
+    screening_evidence_payload: dict[str, Any] | None,
+) -> dict[str, Any]:
+    summary = (
+        screening_evidence_payload.get("summary")
+        if isinstance(screening_evidence_payload, dict)
+        else None
+    )
+    if not isinstance(summary, dict):
+        return {
+            "present": False,
+            "total_candidates": 0,
+            "passed_screening": 0,
+            "rejected_screening": 0,
+            "promotion_grade_candidates": 0,
+            "sufficient_oos_evidence_candidates": 0,
+            "qre_linkage_blocked_candidates": 0,
+            "sufficient_oos_but_unlinked_candidates": 0,
+        }
+
+    return {
+        "present": True,
+        "total_candidates": int(summary.get("total_candidates") or 0),
+        "passed_screening": int(summary.get("passed_screening") or 0),
+        "rejected_screening": int(summary.get("rejected_screening") or 0),
+        "promotion_grade_candidates": int(summary.get("promotion_grade_candidates") or 0),
+        "sufficient_oos_evidence_candidates": int(
+            summary.get("sufficient_oos_evidence_candidates") or 0
+        ),
+        "qre_linkage_blocked_candidates": int(
+            summary.get("qre_linkage_blocked_candidates") or 0
+        ),
+        "sufficient_oos_but_unlinked_candidates": int(
+            summary.get("sufficient_oos_but_unlinked_candidates") or 0
+        ),
+    }
 
 
 def summarize_latest_run(run_campaign_payload: dict[str, Any] | None) -> dict[str, Any]:
@@ -515,6 +554,7 @@ def build_report_payload(
     queue_payload: dict[str, Any] | None,
     intelligence_artifact_status: dict[str, str],
     ticks: list[LauncherTick],
+    screening_evidence_payload: dict[str, Any] | None = None,
     generated_at_utc: datetime | None = None,
 ) -> dict[str, Any]:
     generated = generated_at_utc or _now_utc()
@@ -553,6 +593,9 @@ def build_report_payload(
         "campaigns_by_outcome": dict(sorted(by_outcome.items())),
         "campaign_records": campaign_records,
         "latest_run_summary": summarize_latest_run(run_campaign_payload),
+        "screening_evidence_summary": summarize_screening_evidence(
+            screening_evidence_payload
+        ),
         **latest_policy_summary,
         **active_campaign_summary,
         **queue_summary,
@@ -764,6 +807,7 @@ def run_controlled_eval(
         registry=campaign_registry,
         ledger_events=ledger_events,
         run_campaign_payload=_read_json(RUN_CAMPAIGN_PATH),
+        screening_evidence_payload=_read_json(SCREENING_EVIDENCE_PATH),
         latest_policy_decision_payload=_read_json(POLICY_DECISION_PATH),
         queue_payload=load_queue(QUEUE_ARTIFACT_PATH),
         intelligence_artifact_status=build_intelligence_artifact_status(),
@@ -874,6 +918,7 @@ __all__ = [
     "summarize_active_campaigns",
     "summarize_campaign_records",
     "summarize_latest_run",
+    "summarize_screening_evidence",
     "summarize_latest_policy_decision",
     "summarize_queue_state",
 ]

--- a/research/screening_evidence.py
+++ b/research/screening_evidence.py
@@ -813,6 +813,9 @@ def _summarise(
         "near_passes": 0,
         "coverage_warnings": 0,
         "identity_fallbacks": 0,
+        "sufficient_oos_evidence_candidates": 0,
+        "qre_linkage_blocked_candidates": 0,
+        "sufficient_oos_but_unlinked_candidates": 0,
         "dominant_failure_reasons": dominant_failure_reasons(candidates),
     }
     for record in candidates:
@@ -839,6 +842,21 @@ def _summarise(
             summary["coverage_warnings"] += 1
         if record.get("identity_fallback_used"):
             summary["identity_fallbacks"] += 1
+
+        validation_evidence = record.get("validation_evidence") or {}
+        validation_status = (
+            validation_evidence.get("status") if isinstance(validation_evidence, dict) else None
+        )
+        linkage_status = str(record.get("qre_validation_linkage_status") or "")
+        linked = linkage_status.startswith("linked_")
+
+        if validation_status == "sufficient_oos_evidence":
+            summary["sufficient_oos_evidence_candidates"] += 1
+            if not linked:
+                summary["sufficient_oos_but_unlinked_candidates"] += 1
+
+        if linkage_status.startswith("unlinked_"):
+            summary["qre_linkage_blocked_candidates"] += 1
     return summary
 
 

--- a/tests/regression/test_v3_15_9_screening_evidence_schema_pin.py
+++ b/tests/regression/test_v3_15_9_screening_evidence_schema_pin.py
@@ -76,6 +76,9 @@ _EXPECTED_SUMMARY_KEYS = frozenset(
         "near_passes",
         "coverage_warnings",
         "identity_fallbacks",
+    "sufficient_oos_evidence_candidates",
+    "qre_linkage_blocked_candidates",
+    "sufficient_oos_but_unlinked_candidates",
         "dominant_failure_reasons",
     }
 )

--- a/tests/unit/test_controlled_eval.py
+++ b/tests/unit/test_controlled_eval.py
@@ -126,6 +126,63 @@ def test_report_summarization_from_fake_payloads() -> None:
     assert payload["latest_run_summary"]["screening_rejected_count"] == 4
 
 
+
+
+def test_report_includes_screening_evidence_summary_linkage_counters() -> None:
+    payload = ce.build_report_payload(
+        profile="equities_exploratory_v1",
+        max_campaigns=1,
+        sprint_started_by_harness=True,
+        sprint_reused=False,
+        observed_total_before=0,
+        observed_total_after=1,
+        campaigns_attempted=1,
+        sprint_registry=_sprint_registry(),
+        sprint_progress={"state": "active"},
+        registry=_registry(_completed_campaign()),
+        ledger_events=[_ledger_event()],
+        run_campaign_payload={
+            "run_id": "run-1",
+            "status": "completed",
+            "summary": {
+                "screening_rejected_count": 9,
+                "validation_candidate_count": 6,
+            },
+        },
+        screening_evidence_payload={
+            "summary": {
+                "total_candidates": 15,
+                "passed_screening": 6,
+                "rejected_screening": 9,
+                "promotion_grade_candidates": 0,
+                "sufficient_oos_evidence_candidates": 1,
+                "qre_linkage_blocked_candidates": 1,
+                "sufficient_oos_but_unlinked_candidates": 1,
+            }
+        },
+        latest_policy_decision_payload=None,
+        queue_payload={"queue": []},
+        intelligence_artifact_status={
+            "information_gain": "present",
+            "viability": "present",
+            "stop_conditions": "present",
+            "spawn_proposals": "present",
+        },
+        ticks=[],
+    )
+
+    assert payload["screening_evidence_summary"] == {
+        "present": True,
+        "total_candidates": 15,
+        "passed_screening": 6,
+        "rejected_screening": 9,
+        "promotion_grade_candidates": 0,
+        "sufficient_oos_evidence_candidates": 1,
+        "qre_linkage_blocked_candidates": 1,
+        "sufficient_oos_but_unlinked_candidates": 1,
+    }
+
+
 def test_degenerate_no_survivors_is_useful_meaningful_failure() -> None:
     payload = ce.build_report_payload(
         profile="crypto_exploratory_v1",

--- a/tests/unit/test_qre_controlled_validation_result_analysis.py
+++ b/tests/unit/test_qre_controlled_validation_result_analysis.py
@@ -141,6 +141,16 @@ def test_analysis_reads_completed_controlled_eval_report(tmp_path) -> None:
                 "campaigns_completed": 1,
                 "campaign_level_evidence_valid": True,
                 "recommended_next_action": "inspect_results",
+                "screening_evidence_summary": {
+                    "present": True,
+                    "total_candidates": 15,
+                    "passed_screening": 6,
+                    "rejected_screening": 9,
+                    "promotion_grade_candidates": 0,
+                    "sufficient_oos_evidence_candidates": 1,
+                    "qre_linkage_blocked_candidates": 1,
+                    "sufficient_oos_but_unlinked_candidates": 1,
+                },
             }
         ),
         encoding="utf-8",
@@ -172,6 +182,16 @@ def test_analysis_reads_completed_controlled_eval_report(tmp_path) -> None:
     assert snapshot["result_summary"]["pass_fail"] == "pass"
     assert snapshot["result_summary"]["trade_count"] == 1
     assert snapshot["result_summary"]["primary_failure_class"] is None
+    assert snapshot["result_summary"]["screening_evidence_summary"] == {
+        "present": True,
+        "total_candidates": 15,
+        "passed_screening": 6,
+        "rejected_screening": 9,
+        "promotion_grade_candidates": 0,
+        "sufficient_oos_evidence_candidates": 1,
+        "qre_linkage_blocked_candidates": 1,
+        "sufficient_oos_but_unlinked_candidates": 1,
+    }
     assert snapshot["result_summary"]["evidence_refs"] == [report_path.as_posix()]
 
 

--- a/tests/unit/test_screening_evidence_validation_linkage.py
+++ b/tests/unit/test_screening_evidence_validation_linkage.py
@@ -204,6 +204,39 @@ def test_ambiguous_executable_bridge_fails_closed_for_screening_evidence() -> No
     assert row["qre_validation_linkage_status"] == "unlinked_unknown_hypothesis_id"
 
 
+
+
+def test_summary_surfaces_sufficient_oos_candidate_blocked_by_qre_linkage() -> None:
+    payload = _payload(
+        candidate={
+            "candidate_id": "hd-candidate",
+            "strategy_id": "trend_pullback_v1",
+            "strategy_name": "trend_pullback_v1",
+            "asset": "HD",
+            "interval": "4h",
+            "hypothesis_id": EXECUTABLE_HYPOTHESIS_ID,
+            "validation": {
+                "evidence_status": "sufficient_oos_evidence",
+                "oos_trade_count": 14,
+                "min_oos_trades": 10,
+            },
+        },
+        authority=_authority(),
+    )
+
+    row = payload["candidates"][0]
+    summary = payload["summary"]
+
+    assert row["qre_validation_linkage_status"] == "unlinked_unknown_hypothesis_id"
+    assert row["validation_evidence"]["status"] == "sufficient_oos_evidence"
+    assert row["validation_evidence"]["oos_trade_count"] == 14
+    assert row["validation_evidence"]["min_oos_trades"] == 10
+    assert summary["sufficient_oos_evidence_candidates"] == 1
+    assert summary["sufficient_oos_but_unlinked_candidates"] == 1
+    assert summary["qre_linkage_blocked_candidates"] == 1
+    assert summary["promotion_grade_candidates"] == 0
+
+
 def test_emitted_strict_linked_row_passes_source_linkage_contract() -> None:
     row = _payload(authority=_authority())["candidates"][0]
 

--- a/tests/unit/test_v3_15_9_artifact_top_level_schema_pin.py
+++ b/tests/unit/test_v3_15_9_artifact_top_level_schema_pin.py
@@ -57,6 +57,9 @@ def test_summary_keys_are_present() -> None:
         "near_passes",
         "coverage_warnings",
         "identity_fallbacks",
+    "sufficient_oos_evidence_candidates",
+    "qre_linkage_blocked_candidates",
+    "sufficient_oos_but_unlinked_candidates",
         "dominant_failure_reasons",
     }
     assert set(summary.keys()) == expected


### PR DESCRIPTION
## Summary
- Add screening evidence summary counters for sufficient-OOS candidates blocked by QRE linkage.
- Propagate screening evidence summary into controlled eval reports.
- Surface screening evidence summary in controlled validation result analysis.
- Add regression coverage for sufficient OOS evidence with unlinked QRE authority.

## Validation
- pytest tests/unit/test_screening_evidence_validation_linkage.py tests/unit/test_qre_executable_hypothesis_identity_bridge_contract.py tests/unit/test_qre_executable_hypothesis_identity_bridge_diagnostics.py tests/unit/test_qre_executable_hypothesis_selection.py tests/unit/test_qre_selection_route_materialization.py tests/unit/test_qre_selection_route_validation_flow.py tests/unit/test_qre_validation_result_linkage_diagnostics.py tests/unit/test_run_candidates_validation_linkage.py tests/unit/test_controlled_eval.py tests/unit/test_qre_controlled_validation_result_analysis.py tests/unit/test_qre_controlled_validation_learning_proposal.py tests/unit/test_qre_controlled_validation_research_action_queue_gate.py -q

## Safety
- No live/paper/shadow trading changes.
- No broker/risk/execution config changes.
- No strategy or preset mutation.
- No research-action queue mutation.
- Reporting/diagnostic observability only.