### PR TITLE
fix: harden QRE controlled validation evidence readiness diagnostics

### DIFF
--- a/reporting/qre_controlled_validation_execution.py
+++ b/reporting/qre_controlled_validation_execution.py
@@ -9,6 +9,7 @@ import tempfile
 from pathlib import Path
 from typing import Any, Final
 
+from reporting import qre_executable_hypothesis_identity_bridge_diagnostics as bridge_diagnostics
 from reporting import qre_selection_closed_loop_preflight as preflight
 
 REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
@@ -36,6 +37,7 @@ REQUIRED_OPERATOR_GO_PHRASE: Final[str] = (
 
 EXECUTION_BLOCKED_NOT_REQUESTED: Final[str] = "execution_blocked_not_requested"
 EXECUTION_BLOCKED_PREFLIGHT_NOT_READY: Final[str] = "execution_blocked_preflight_not_ready"
+EXECUTION_BLOCKED_BRIDGE_NOT_READY: Final[str] = "execution_blocked_bridge_not_ready"
 EXECUTION_BLOCKED_OPERATOR_GO_MISSING: Final[str] = "execution_blocked_operator_go_missing"
 EXECUTION_BLOCKED_OPERATOR_GO_MISMATCH: Final[str] = "execution_blocked_operator_go_mismatch"
 EXECUTION_AUTHORIZED_RUNNER_NOT_CONNECTED: Final[str] = (
@@ -47,6 +49,7 @@ EXECUTION_FAILED: Final[str] = "execution_failed"
 EXECUTION_STATUSES: Final[tuple[str, ...]] = (
     EXECUTION_BLOCKED_NOT_REQUESTED,
     EXECUTION_BLOCKED_PREFLIGHT_NOT_READY,
+    EXECUTION_BLOCKED_BRIDGE_NOT_READY,
     EXECUTION_BLOCKED_OPERATOR_GO_MISSING,
     EXECUTION_BLOCKED_OPERATOR_GO_MISMATCH,
     EXECUTION_AUTHORIZED_RUNNER_NOT_CONNECTED,
@@ -76,6 +79,7 @@ def _authorization_status(
     execute_controlled_validation: bool,
     operator_go: str | None,
     selection_route_ready: bool,
+    controlled_validation_bridge_ready: bool,
 ) -> str:
     if not execute_controlled_validation:
         return EXECUTION_BLOCKED_NOT_REQUESTED
@@ -85,6 +89,8 @@ def _authorization_status(
         return EXECUTION_BLOCKED_OPERATOR_GO_MISSING
     if operator_go.strip() != REQUIRED_OPERATOR_GO_PHRASE:
         return EXECUTION_BLOCKED_OPERATOR_GO_MISMATCH
+    if not controlled_validation_bridge_ready:
+        return EXECUTION_BLOCKED_BRIDGE_NOT_READY
     return EXECUTION_AUTHORIZED_RUNNER_NOT_CONNECTED
 
 
@@ -115,6 +121,8 @@ def _final_recommendation(status: str) -> str:
         return "controlled_validation_execution_failed"
     if status == EXECUTION_AUTHORIZED_RUNNER_NOT_CONNECTED:
         return "controlled_validation_execution_authorized_runner_not_connected"
+    if status == EXECUTION_BLOCKED_BRIDGE_NOT_READY:
+        return "controlled_validation_execution_blocked_bridge_not_ready"
     return "controlled_validation_execution_blocked"
 
 
@@ -179,6 +187,7 @@ def collect_snapshot(
     connect_runner_adapter: bool = False,
     timeout_seconds_per_campaign: int = QRE_CONTROLLED_EVAL_DEFAULT_TIMEOUT_SECONDS,
     preflight_snapshot: dict[str, Any] | None = None,
+    controlled_validation_bridge_snapshot: dict[str, Any] | None = None,
     generated_at_utc: str | None = None,
 ) -> dict[str, Any]:
     generated = generated_at_utc or _utcnow()
@@ -187,12 +196,26 @@ def collect_snapshot(
         generated_at_utc=generated,
     )
 
+    active_bridge_snapshot = (
+        controlled_validation_bridge_snapshot
+        or bridge_diagnostics.collect_snapshot(generated_at_utc=generated)
+    )
+    bridge_readiness = (
+        active_bridge_snapshot.get("controlled_validation_bridge_readiness")
+        if isinstance(active_bridge_snapshot, dict)
+        else {}
+    )
+    if not isinstance(bridge_readiness, dict):
+        bridge_readiness = {}
+    controlled_validation_bridge_ready = bridge_readiness.get("ready") is True
+
     selection_route = active_preflight.get("selection_route") or {}
     selection_route_ready = selection_route.get("ready") is True
     status = _authorization_status(
         execute_controlled_validation=execute_controlled_validation,
         operator_go=operator_go,
         selection_route_ready=selection_route_ready,
+        controlled_validation_bridge_ready=controlled_validation_bridge_ready,
     )
     runner_result: dict[str, Any] | None = None
     if status == EXECUTION_AUTHORIZED_RUNNER_NOT_CONNECTED and connect_runner_adapter:
@@ -242,6 +265,16 @@ def collect_snapshot(
             "matched": operator_go is not None
             and operator_go.strip() == REQUIRED_OPERATOR_GO_PHRASE,
             "required_phrase": REQUIRED_OPERATOR_GO_PHRASE,
+        },
+        "controlled_validation_bridge": {
+            "report_kind": active_bridge_snapshot.get("report_kind")
+            if isinstance(active_bridge_snapshot, dict)
+            else None,
+            "final_recommendation": active_bridge_snapshot.get("final_recommendation")
+            if isinstance(active_bridge_snapshot, dict)
+            else None,
+            "ready": controlled_validation_bridge_ready,
+            "readiness": bridge_readiness,
         },
         "preflight": {
             "report_kind": active_preflight.get("report_kind"),

--- a/reporting/qre_controlled_validation_result_analysis.py
+++ b/reporting/qre_controlled_validation_result_analysis.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import datetime as dt
 import json
+import subprocess
 import tempfile
 from pathlib import Path
 from typing import Any, Final
@@ -58,6 +59,59 @@ def _analysis_status(execution_snapshot: dict[str, Any]) -> str:
     return ANALYSIS_READY
 
 
+def _current_git_revision() -> str | None:
+    try:
+        completed = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=REPO_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    value = completed.stdout.strip()
+    return value or None
+
+
+def _artifact_freshness(
+    payload: dict[str, Any] | None,
+    *,
+    current_git_revision: str | None,
+) -> dict[str, Any]:
+    artifact_git_revision = (
+        payload.get("git_revision") if isinstance(payload, dict) else None
+    )
+    if not isinstance(artifact_git_revision, str) or not artifact_git_revision:
+        artifact_git_revision = None
+
+    reason_codes: list[str] = []
+    artifact_may_be_stale = False
+
+    if artifact_git_revision is None:
+        reason_codes.append("artifact_git_revision_missing")
+        artifact_may_be_stale = True
+    if current_git_revision is None:
+        reason_codes.append("current_git_revision_unavailable")
+        artifact_may_be_stale = True
+    if (
+        artifact_git_revision is not None
+        and current_git_revision is not None
+        and artifact_git_revision != current_git_revision
+    ):
+        reason_codes.append("artifact_git_revision_differs_from_current_head")
+        artifact_may_be_stale = True
+    if not reason_codes:
+        reason_codes.append("artifact_git_revision_matches_current_head")
+
+    return {
+        "artifact_git_revision": artifact_git_revision,
+        "current_git_revision": current_git_revision,
+        "artifact_may_be_stale": artifact_may_be_stale,
+        "reason_codes": reason_codes,
+    }
+
+
 def _read_json(path: Path) -> dict[str, Any] | None:
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
@@ -87,6 +141,8 @@ def _resolve_controlled_eval_report_path(
 def _controlled_eval_report_summary(
     execution_snapshot: dict[str, Any],
     status: str,
+    *,
+    current_git_revision: str | None = None,
 ) -> dict[str, Any]:
     report_path = _resolve_controlled_eval_report_path(execution_snapshot)
     payload = _read_json(report_path) if report_path is not None else None
@@ -101,9 +157,15 @@ def _controlled_eval_report_summary(
     if not isinstance(screening_evidence_summary, dict):
         screening_evidence_summary = {}
 
+    freshness = _artifact_freshness(
+        payload,
+        current_git_revision=current_git_revision,
+    )
+
     return {
         "present": payload is not None,
         "path": report_path.as_posix() if report_path is not None else None,
+        "artifact_freshness": freshness,
         "verdict_status": verdict.get("status"),
         "campaigns_completed": (payload or {}).get("campaigns_completed"),
         "campaign_level_evidence_valid": (payload or {}).get(
@@ -160,15 +222,25 @@ def collect_snapshot(
     profile_name: str | None = None,
     execution_snapshot: dict[str, Any] | None = None,
     generated_at_utc: str | None = None,
+    current_git_revision: str | None = None,
 ) -> dict[str, Any]:
     generated = generated_at_utc or _utcnow()
     active_execution = execution_snapshot or execution.collect_snapshot(
         profile_name=profile_name,
         generated_at_utc=generated,
     )
+    resolved_current_git_revision = (
+        current_git_revision
+        if current_git_revision is not None
+        else _current_git_revision()
+    )
 
     status = _analysis_status(active_execution)
-    controlled_eval_summary = _controlled_eval_report_summary(active_execution, status)
+    controlled_eval_summary = _controlled_eval_report_summary(
+        active_execution,
+        status,
+        current_git_revision=resolved_current_git_revision,
+    )
     campaigns_completed = int(controlled_eval_summary.get("campaigns_completed") or 0)
     evidence_valid = controlled_eval_summary.get("campaign_level_evidence_valid") is True
     if status == ANALYSIS_READY and (campaigns_completed < 1 or not evidence_valid):
@@ -218,6 +290,9 @@ def collect_snapshot(
             "pass_fail": pass_fail,
             "trade_count": controlled_eval_summary.get("campaigns_completed"),
             "primary_failure_class": primary_failure_class,
+            "artifact_freshness": controlled_eval_summary.get(
+                "artifact_freshness", {}
+            ),
             "screening_evidence_summary": controlled_eval_summary.get(
                 "screening_evidence_summary", {}
             ),

--- a/reporting/qre_controlled_validation_result_analysis.py
+++ b/reporting/qre_controlled_validation_result_analysis.py
@@ -177,6 +177,84 @@ def _controlled_eval_report_summary(
     }
 
 
+def _evidence_quality_bottleneck(
+    *,
+    controlled_eval_summary: dict[str, Any],
+) -> dict[str, Any]:
+    artifact_freshness = controlled_eval_summary.get("artifact_freshness")
+    if not isinstance(artifact_freshness, dict):
+        artifact_freshness = {}
+    screening_summary = controlled_eval_summary.get("screening_evidence_summary")
+    if not isinstance(screening_summary, dict):
+        screening_summary = {}
+    reason_codes = controlled_eval_summary.get("reason_codes")
+    if not isinstance(reason_codes, list):
+        reason_codes = []
+
+    bottleneck_reason_codes: list[str] = []
+
+    if artifact_freshness.get("artifact_may_be_stale") is True:
+        bottleneck_reason_codes.append("controlled_eval_artifact_may_be_stale")
+        return {
+            "primary_bottleneck": "stale_artifact",
+            "reason_codes": bottleneck_reason_codes,
+            "artifact_freshness": artifact_freshness,
+            "screening_evidence_summary": screening_summary,
+        }
+
+    if "registry_ledger_invariant_violation" in reason_codes:
+        bottleneck_reason_codes.append("registry_ledger_invariant_violation")
+        return {
+            "primary_bottleneck": "registry_ledger_invariant_violation",
+            "reason_codes": bottleneck_reason_codes,
+            "artifact_freshness": artifact_freshness,
+            "screening_evidence_summary": screening_summary,
+        }
+
+    sufficient_oos_but_unlinked = int(
+        screening_summary.get("sufficient_oos_but_unlinked_candidates") or 0
+    )
+    qre_linkage_blocked = int(screening_summary.get("qre_linkage_blocked_candidates") or 0)
+    sufficient_oos = int(screening_summary.get("sufficient_oos_evidence_candidates") or 0)
+    passed_screening = int(screening_summary.get("passed_screening") or 0)
+    rejected_screening = int(screening_summary.get("rejected_screening") or 0)
+
+    if sufficient_oos_but_unlinked > 0 or qre_linkage_blocked > 0:
+        bottleneck_reason_codes.append("sufficient_oos_evidence_blocked_by_qre_linkage")
+        return {
+            "primary_bottleneck": "linkage_blocker",
+            "reason_codes": bottleneck_reason_codes,
+            "artifact_freshness": artifact_freshness,
+            "screening_evidence_summary": screening_summary,
+        }
+
+    if passed_screening > 0 and sufficient_oos == 0:
+        bottleneck_reason_codes.append("screening_passed_without_sufficient_oos_evidence")
+        return {
+            "primary_bottleneck": "no_oos_evidence",
+            "reason_codes": bottleneck_reason_codes,
+            "artifact_freshness": artifact_freshness,
+            "screening_evidence_summary": screening_summary,
+        }
+
+    if rejected_screening > 0 and passed_screening == 0:
+        bottleneck_reason_codes.append("screening_rejected_candidates_before_validation")
+        return {
+            "primary_bottleneck": "insufficient_trades",
+            "reason_codes": bottleneck_reason_codes,
+            "artifact_freshness": artifact_freshness,
+            "screening_evidence_summary": screening_summary,
+        }
+
+    bottleneck_reason_codes.append("no_evidence_quality_bottleneck_detected")
+    return {
+        "primary_bottleneck": "no_bottleneck_detected",
+        "reason_codes": bottleneck_reason_codes,
+        "artifact_freshness": artifact_freshness,
+        "screening_evidence_summary": screening_summary,
+    }
+
+
 def _pass_fail_from_report(summary: dict[str, Any]) -> str | None:
     verdict_status = summary.get("verdict_status")
     campaigns_completed = int(summary.get("campaigns_completed") or 0)
@@ -247,6 +325,9 @@ def collect_snapshot(
         status = ANALYSIS_BLOCKED_NO_COMPLETED_RUN
     pass_fail = _pass_fail_from_report(controlled_eval_summary)
     primary_failure_class = _failure_class_from_report(controlled_eval_summary)
+    evidence_quality_bottleneck = _evidence_quality_bottleneck(
+        controlled_eval_summary=controlled_eval_summary
+    )
     evidence_refs = []
     if controlled_eval_summary.get("path"):
         evidence_refs.append(str(controlled_eval_summary["path"]))
@@ -296,6 +377,7 @@ def collect_snapshot(
             "screening_evidence_summary": controlled_eval_summary.get(
                 "screening_evidence_summary", {}
             ),
+            "evidence_quality_bottleneck": evidence_quality_bottleneck,
             "evidence_refs": evidence_refs,
         },
         "next_required_step": (

--- a/reporting/qre_executable_hypothesis_identity_bridge_diagnostics.py
+++ b/reporting/qre_executable_hypothesis_identity_bridge_diagnostics.py
@@ -641,6 +641,57 @@ def _bridge_snapshot_from_rows(
     return bridge
 
 
+def _controlled_validation_bridge_readiness(
+    *,
+    per_preset: list[dict[str, Any]],
+) -> dict[str, Any]:
+    rows: list[dict[str, Any]] = []
+    for row in per_preset:
+        if not row.get("enabled") or not row.get("hypothesis_id"):
+            continue
+
+        in_qre_authority = row.get("hypothesis_id_present_in_qre_authority") is True
+        linkage_mode = row.get("qre_authority_linkage_mode")
+        qre_status = row.get("qre_authority_status")
+        has_complete_authority_linkage = qre_status in {"linked_exact_ids", "bridge_exact"}
+        validation_plan_id_present = has_complete_authority_linkage and bool(linkage_mode)
+        run_manifest_id_present = validation_plan_id_present
+        ready = in_qre_authority and validation_plan_id_present and run_manifest_id_present
+
+        if not in_qre_authority:
+            primary_blocker = PRIMARY_BLOCKER_EXECUTABLE_ID_MISSING
+        elif not validation_plan_id_present:
+            primary_blocker = "validation_plan_id_missing_for_executable_hypothesis"
+        elif not run_manifest_id_present:
+            primary_blocker = "run_manifest_id_missing_for_executable_hypothesis"
+        else:
+            primary_blocker = PRIMARY_BLOCKER_NONE
+
+        rows.append(
+            {
+                "preset_name": row.get("preset_name"),
+                "executable_hypothesis_id": row.get("hypothesis_id"),
+                "in_qre_authority": in_qre_authority,
+                "qre_authority_linkage_mode": linkage_mode,
+                "qre_authority_status": qre_status,
+                "validation_plan_id_present": validation_plan_id_present,
+                "run_manifest_id_present": run_manifest_id_present,
+                "ready": ready,
+                "primary_blocker": primary_blocker,
+            }
+        )
+
+    ready_count = sum(1 for row in rows if row["ready"])
+    blocked_count = len(rows) - ready_count
+    return {
+        "ready": bool(rows) and blocked_count == 0,
+        "executable_hypothesis_count": len(rows),
+        "ready_count": ready_count,
+        "blocked_count": blocked_count,
+        "rows": rows,
+    }
+
+
 def _final_recommendation(bridge: dict[str, Any]) -> str:
     if bridge["primary_blocker"] == PRIMARY_BLOCKER_NONE:
         return FINAL_RECOMMENDATION_BRIDGE_READY
@@ -678,6 +729,9 @@ def collect_snapshot(
         executable_hypothesis_ids=executable_presets["executable_hypothesis_ids"],
         per_preset=executable_presets["per_preset"],
     )
+    controlled_validation_bridge_readiness = _controlled_validation_bridge_readiness(
+        per_preset=executable_presets["per_preset"],
+    )
     validation_warnings = _bounded_unique(
         [*authority_warnings, *preset_warnings],
         max_items=WARNING_LIMIT,
@@ -694,6 +748,7 @@ def collect_snapshot(
         "qre_authority": qre_authority,
         "executable_presets": executable_presets,
         "bridge": bridge,
+        "controlled_validation_bridge_readiness": controlled_validation_bridge_readiness,
         "recommended_bridge_keys": list(RECOMMENDED_BRIDGE_KEYS),
         "writes_development_work_queue": False,
         "writes_seed_jsonl": False,

--- a/research/controlled_eval.py
+++ b/research/controlled_eval.py
@@ -235,6 +235,42 @@ def summarize_campaign_records(
     return records
 
 
+def summarize_registry_ledger_invariants(
+    *,
+    campaign_records: list[dict[str, Any]],
+    ledger_events: list[dict[str, Any]],
+) -> dict[str, Any]:
+    completed_campaign_ids = {
+        str(record.get("campaign_id"))
+        for record in campaign_records
+        if record.get("state") == "completed" and record.get("campaign_id")
+    }
+    ledger_completed_campaign_ids = {
+        str(event.get("campaign_id"))
+        for event in ledger_events
+        if isinstance(event, dict)
+        and event.get("event_type") == "campaign_completed"
+        and event.get("campaign_id")
+    }
+    missing_completed_ledger_event_ids = sorted(
+        completed_campaign_ids - ledger_completed_campaign_ids
+    )
+    status = "failed" if missing_completed_ledger_event_ids else "passed"
+    reason_codes = (
+        ["completed_campaign_missing_campaign_completed_ledger_event"]
+        if missing_completed_ledger_event_ids
+        else []
+    )
+    return {
+        "status": status,
+        "reason_codes": reason_codes,
+        "operator_review_required": bool(missing_completed_ledger_event_ids),
+        "completed_campaign_count": len(completed_campaign_ids),
+        "campaign_completed_ledger_event_count": len(ledger_completed_campaign_ids),
+        "missing_completed_ledger_event_ids": missing_completed_ledger_event_ids,
+    }
+
+
 def summarize_screening_evidence(
     screening_evidence_payload: dict[str, Any] | None,
 ) -> dict[str, Any]:
@@ -403,6 +439,7 @@ def _classify_verdict(
     ticks: list[LauncherTick],
     intelligence_artifact_status: dict[str, str],
     latest_policy_summary: dict[str, Any],
+    registry_ledger_invariant_summary: dict[str, Any],
 ) -> tuple[dict[str, Any], str]:
     reason_codes: list[str] = []
     timed_out = any(tick.timed_out for tick in ticks)
@@ -413,6 +450,26 @@ def _classify_verdict(
                 "status": "timeout",
                 "reason_codes": reason_codes,
                 "human_summary": "Campaign launcher timed out before the bounded evaluation completed.",
+            },
+            "operator_review_required",
+        )
+
+    if registry_ledger_invariant_summary.get("status") == "failed":
+        reason_codes.append("registry_ledger_invariant_violation")
+        reason_codes.extend(
+            str(code)
+            for code in registry_ledger_invariant_summary.get("reason_codes", [])
+            if code
+        )
+        return (
+            {
+                "status": "technical_failure",
+                "reason_codes": reason_codes,
+                "human_summary": (
+                    "Campaign registry and evidence ledger disagree about completed "
+                    "campaign evidence; operator review is required before results "
+                    "can be trusted."
+                ),
             },
             "operator_review_required",
         )
@@ -569,11 +626,16 @@ def build_report_payload(
     latest_policy_summary = summarize_latest_policy_decision(latest_policy_decision_payload)
     active_campaign_summary = summarize_active_campaigns(registry)
     queue_summary = summarize_queue_state(queue_payload)
+    registry_ledger_invariant_summary = summarize_registry_ledger_invariants(
+        campaign_records=campaign_records,
+        ledger_events=ledger_events,
+    )
     verdict, next_action = _classify_verdict(
         campaign_records=campaign_records,
         ticks=ticks,
         intelligence_artifact_status=intelligence_artifact_status,
         latest_policy_summary=latest_policy_summary,
+        registry_ledger_invariant_summary=registry_ledger_invariant_summary,
     )
     return {
         "schema_version": CONTROLLED_EVAL_SCHEMA_VERSION,
@@ -592,6 +654,7 @@ def build_report_payload(
         "campaigns_by_preset": dict(sorted(by_preset.items())),
         "campaigns_by_outcome": dict(sorted(by_outcome.items())),
         "campaign_records": campaign_records,
+        "registry_ledger_invariant_summary": registry_ledger_invariant_summary,
         "latest_run_summary": summarize_latest_run(run_campaign_payload),
         "screening_evidence_summary": summarize_screening_evidence(
             screening_evidence_payload
@@ -603,7 +666,8 @@ def build_report_payload(
         "launcher_ticks": [tick.to_payload() for tick in ticks],
         "verdict": verdict,
         "recommended_next_action": next_action,
-        "campaign_level_evidence_valid": bool(completed_records),
+        "campaign_level_evidence_valid": bool(completed_records)
+        and registry_ledger_invariant_summary.get("status") == "passed",
         "strategy_synthesis_sandbox_needed": "not_enough_evidence_not_yet",
     }
 
@@ -921,4 +985,5 @@ __all__ = [
     "summarize_screening_evidence",
     "summarize_latest_policy_decision",
     "summarize_queue_state",
+    "summarize_registry_ledger_invariants",
 ]

--- a/tests/unit/test_controlled_eval.py
+++ b/tests/unit/test_controlled_eval.py
@@ -247,6 +247,88 @@ def test_missing_intelligence_artifacts_are_reported_as_observability_gap() -> N
     assert payload["intelligence_artifact_status"]["information_gain"] == "missing"
 
 
+
+
+def test_completed_registry_campaign_without_completed_ledger_event_fails_closed() -> None:
+    payload = ce.build_report_payload(
+        profile="crypto_exploratory_v1",
+        max_campaigns=1,
+        sprint_started_by_harness=True,
+        sprint_reused=False,
+        observed_total_before=0,
+        observed_total_after=1,
+        campaigns_attempted=1,
+        sprint_registry=_sprint_registry(),
+        sprint_progress={"state": "active"},
+        registry=_registry(_completed_campaign()),
+        ledger_events=[],
+        run_campaign_payload=None,
+        intelligence_artifact_status={
+            "information_gain": "present",
+            "viability": "present",
+            "stop_conditions": "present",
+            "spawn_proposals": "present",
+        },
+        latest_policy_decision_payload=None,
+        queue_payload={"queue": []},
+        ticks=[],
+    )
+
+    assert payload["campaigns_completed"] == 1
+    assert payload["campaign_level_evidence_valid"] is False
+    assert payload["registry_ledger_invariant_summary"] == {
+        "status": "failed",
+        "reason_codes": ["completed_campaign_missing_campaign_completed_ledger_event"],
+        "operator_review_required": True,
+        "completed_campaign_count": 1,
+        "campaign_completed_ledger_event_count": 0,
+        "missing_completed_ledger_event_ids": ["col-1"],
+    }
+    assert payload["verdict"]["status"] == "technical_failure"
+    assert payload["verdict"]["reason_codes"] == [
+        "registry_ledger_invariant_violation",
+        "completed_campaign_missing_campaign_completed_ledger_event",
+    ]
+    assert payload["recommended_next_action"] == "operator_review_required"
+
+
+def test_completed_registry_campaign_with_completed_ledger_event_passes_invariant() -> None:
+    payload = ce.build_report_payload(
+        profile="crypto_exploratory_v1",
+        max_campaigns=1,
+        sprint_started_by_harness=True,
+        sprint_reused=False,
+        observed_total_before=0,
+        observed_total_after=1,
+        campaigns_attempted=1,
+        sprint_registry=_sprint_registry(),
+        sprint_progress={"state": "active"},
+        registry=_registry(_completed_campaign()),
+        ledger_events=[_ledger_event()],
+        run_campaign_payload=None,
+        intelligence_artifact_status={
+            "information_gain": "present",
+            "viability": "present",
+            "stop_conditions": "present",
+            "spawn_proposals": "present",
+        },
+        latest_policy_decision_payload=None,
+        queue_payload={"queue": []},
+        ticks=[],
+    )
+
+    assert payload["registry_ledger_invariant_summary"] == {
+        "status": "passed",
+        "reason_codes": [],
+        "operator_review_required": False,
+        "completed_campaign_count": 1,
+        "campaign_completed_ledger_event_count": 1,
+        "missing_completed_ledger_event_ids": [],
+    }
+    assert payload["campaign_level_evidence_valid"] is True
+    assert payload["verdict"]["status"] == "useful_observation"
+
+
 def test_no_completed_campaign_with_no_candidates_policy_is_diagnostic() -> None:
     payload = ce.build_report_payload(
         profile="crypto_exploratory_v1",

--- a/tests/unit/test_qre_controlled_validation_execution.py
+++ b/tests/unit/test_qre_controlled_validation_execution.py
@@ -5,6 +5,37 @@ import json
 from reporting import qre_controlled_validation_execution as execution
 
 
+
+
+def _bridge_snapshot(*, ready: bool = True) -> dict:
+    return {
+        "report_kind": "qre_executable_hypothesis_identity_bridge_diagnostics",
+        "final_recommendation": (
+            "executable_hypothesis_identity_bridge_ready_for_regeneration"
+            if ready
+            else "executable_hypothesis_identity_bridge_required_before_regeneration"
+        ),
+        "controlled_validation_bridge_readiness": {
+            "ready": ready,
+            "executable_hypothesis_count": 1,
+            "ready_count": 1 if ready else 0,
+            "blocked_count": 0 if ready else 1,
+            "rows": [
+                {
+                    "preset_name": "trend_pullback_equities_4h",
+                    "executable_hypothesis_id": "trend_pullback_v1",
+                    "in_qre_authority": ready,
+                    "ready": ready,
+                    "primary_blocker": (
+                        "no_primary_blocker"
+                        if ready
+                        else "executable_hypothesis_id_not_in_qre_authority"
+                    ),
+                }
+            ],
+        },
+    }
+
 def test_default_controlled_validation_execution_is_blocked() -> None:
     snapshot = execution.collect_snapshot(
         profile_name="equities_exploratory_v1",
@@ -56,6 +87,7 @@ def test_exact_operator_go_authorizes_contract_but_runner_is_not_connected() -> 
         profile_name="equities_exploratory_v1",
         execute_controlled_validation=True,
         operator_go=execution.REQUIRED_OPERATOR_GO_PHRASE,
+        controlled_validation_bridge_snapshot=_bridge_snapshot(ready=True),
         generated_at_utc="2026-06-03T17:00:00Z",
     )
 
@@ -70,6 +102,47 @@ def test_exact_operator_go_authorizes_contract_but_runner_is_not_connected() -> 
     assert snapshot["writes_research_action_queue"] is False
 
 
+
+
+def test_bridge_not_ready_blocks_even_with_operator_go_and_runner_adapter(
+    monkeypatch,
+) -> None:
+    calls: list[object] = []
+
+    class FakeControlledEval:
+        @staticmethod
+        def run_controlled_eval(**kwargs: object) -> int:
+            calls.append(kwargs)
+            return 0
+
+    monkeypatch.setattr(
+        execution,
+        "_load_controlled_eval_module",
+        lambda: FakeControlledEval,
+    )
+
+    snapshot = execution.collect_snapshot(
+        profile_name="equities_exploratory_v1",
+        execute_controlled_validation=True,
+        operator_go=execution.REQUIRED_OPERATOR_GO_PHRASE,
+        connect_runner_adapter=True,
+        timeout_seconds_per_campaign=60,
+        controlled_validation_bridge_snapshot=_bridge_snapshot(ready=False),
+        generated_at_utc="2026-06-03T22:00:00Z",
+    )
+
+    assert calls == []
+    assert snapshot["execution_status"] == "execution_blocked_bridge_not_ready"
+    assert snapshot["final_recommendation"] == (
+        "controlled_validation_execution_blocked_bridge_not_ready"
+    )
+    assert snapshot["controlled_validation_authorized"] is False
+    assert snapshot["executed_anything"] is False
+    assert snapshot["launches_subprocess"] is False
+    assert snapshot["runner_adapter_status"] == "not_connected"
+    assert snapshot["controlled_validation_bridge"]["ready"] is False
+    assert snapshot["controlled_validation_bridge"]["readiness"]["blocked_count"] == 1
+
 def test_preflight_not_ready_blocks_even_with_operator_go() -> None:
     preflight_snapshot = {
         "report_kind": "qre_selection_closed_loop_preflight",
@@ -83,6 +156,7 @@ def test_preflight_not_ready_blocks_even_with_operator_go() -> None:
         execute_controlled_validation=True,
         operator_go=execution.REQUIRED_OPERATOR_GO_PHRASE,
         preflight_snapshot=preflight_snapshot,
+        controlled_validation_bridge_snapshot=_bridge_snapshot(ready=True),
         generated_at_utc="2026-06-03T17:00:00Z",
     )
 
@@ -93,6 +167,11 @@ def test_preflight_not_ready_blocks_even_with_operator_go() -> None:
 def test_cli_no_write_does_not_create_artifact(tmp_path, monkeypatch, capsys) -> None:
     artifact_path = tmp_path / "latest.json"
     monkeypatch.setattr(execution, "ARTIFACT_LATEST", artifact_path)
+    monkeypatch.setattr(
+        execution.bridge_diagnostics,
+        "collect_snapshot",
+        lambda generated_at_utc=None: _bridge_snapshot(ready=True),
+    )
 
     rc = execution.main(
         [
@@ -180,6 +259,7 @@ def test_connected_runner_adapter_invokes_controlled_eval(monkeypatch, tmp_path)
         operator_go=execution.REQUIRED_OPERATOR_GO_PHRASE,
         connect_runner_adapter=True,
         timeout_seconds_per_campaign=60,
+        controlled_validation_bridge_snapshot=_bridge_snapshot(ready=True),
         generated_at_utc="2026-06-03T22:00:00Z",
     )
 
@@ -234,6 +314,7 @@ def test_connected_runner_adapter_records_failure(monkeypatch, tmp_path) -> None
         operator_go=execution.REQUIRED_OPERATOR_GO_PHRASE,
         connect_runner_adapter=True,
         timeout_seconds_per_campaign=60,
+        controlled_validation_bridge_snapshot=_bridge_snapshot(ready=True),
         generated_at_utc="2026-06-03T22:00:00Z",
     )
 
@@ -251,6 +332,7 @@ def test_connected_runner_adapter_rejects_unbounded_timeout() -> None:
             operator_go=execution.REQUIRED_OPERATOR_GO_PHRASE,
             connect_runner_adapter=True,
             timeout_seconds_per_campaign=59,
+            controlled_validation_bridge_snapshot=_bridge_snapshot(ready=True),
             generated_at_utc="2026-06-03T22:00:00Z",
         )
     except ValueError as exc:

--- a/tests/unit/test_qre_controlled_validation_loop_report.py
+++ b/tests/unit/test_qre_controlled_validation_loop_report.py
@@ -25,7 +25,40 @@ def test_loop_report_blocks_before_execution_by_default() -> None:
     assert snapshot["writes_research_action_queue"] is False
 
 
-def test_loop_report_authorizes_execution_but_stops_at_runner_not_connected() -> None:
+
+def _ready_bridge_snapshot() -> dict:
+    return {
+        "report_kind": "qre_executable_hypothesis_identity_bridge_diagnostics",
+        "final_recommendation": "executable_hypothesis_identity_bridge_ready_for_regeneration",
+        "controlled_validation_bridge_readiness": {
+            "ready": True,
+            "executable_hypothesis_count": 1,
+            "ready_count": 1,
+            "blocked_count": 0,
+            "rows": [
+                {
+                    "preset_name": "trend_pullback_equities_4h",
+                    "executable_hypothesis_id": "trend_pullback_v1",
+                    "ready": True,
+                    "primary_blocker": "no_primary_blocker",
+                }
+            ],
+        },
+    }
+
+
+def _patch_ready_bridge(monkeypatch) -> None:
+    monkeypatch.setattr(
+        execution.bridge_diagnostics,
+        "collect_snapshot",
+        lambda generated_at_utc=None: _ready_bridge_snapshot(),
+    )
+
+
+def test_loop_report_authorizes_execution_but_stops_at_runner_not_connected(
+    monkeypatch,
+) -> None:
+    _patch_ready_bridge(monkeypatch)
     snapshot = loop.collect_snapshot(
         profile_name="equities_exploratory_v1",
         execute_controlled_validation=True,
@@ -64,6 +97,7 @@ def test_loop_report_queue_flags_do_not_bypass_learning_gate() -> None:
 def test_cli_no_write_does_not_create_artifact(tmp_path, monkeypatch, capsys) -> None:
     artifact_path = tmp_path / "latest.json"
     monkeypatch.setattr(loop, "ARTIFACT_LATEST", artifact_path)
+    _patch_ready_bridge(monkeypatch)
 
     rc = loop.main(
         [
@@ -108,6 +142,8 @@ def test_cli_writes_only_own_artifact(tmp_path, monkeypatch) -> None:
     assert payload["read_only"] is True
 
 def test_loop_report_connected_runner_reaches_learning_ready(monkeypatch, tmp_path) -> None:
+    _patch_ready_bridge(monkeypatch)
+
     def fake_run_controlled_eval(**kwargs: object) -> int:
         report_json = kwargs["report_json"]
         report_md = kwargs["report_md"]

--- a/tests/unit/test_qre_controlled_validation_result_analysis.py
+++ b/tests/unit/test_qre_controlled_validation_result_analysis.py
@@ -141,6 +141,7 @@ def test_analysis_reads_completed_controlled_eval_report(tmp_path) -> None:
                 "campaigns_completed": 1,
                 "campaign_level_evidence_valid": True,
                 "recommended_next_action": "inspect_results",
+                "git_revision": "abc123",
                 "screening_evidence_summary": {
                     "present": True,
                     "total_candidates": 15,
@@ -172,6 +173,7 @@ def test_analysis_reads_completed_controlled_eval_report(tmp_path) -> None:
     snapshot = analysis.collect_snapshot(
         execution_snapshot=execution_snapshot,
         generated_at_utc="2026-06-03T23:00:00Z",
+        current_git_revision="abc123",
     )
 
     assert snapshot["analysis_status"] == "analysis_ready"
@@ -182,6 +184,18 @@ def test_analysis_reads_completed_controlled_eval_report(tmp_path) -> None:
     assert snapshot["result_summary"]["pass_fail"] == "pass"
     assert snapshot["result_summary"]["trade_count"] == 1
     assert snapshot["result_summary"]["primary_failure_class"] is None
+    assert snapshot["controlled_eval_report"]["artifact_freshness"] == {
+        "artifact_git_revision": "abc123",
+        "current_git_revision": "abc123",
+        "artifact_may_be_stale": False,
+        "reason_codes": ["artifact_git_revision_matches_current_head"],
+    }
+    assert snapshot["result_summary"]["artifact_freshness"] == {
+        "artifact_git_revision": "abc123",
+        "current_git_revision": "abc123",
+        "artifact_may_be_stale": False,
+        "reason_codes": ["artifact_git_revision_matches_current_head"],
+    }
     assert snapshot["result_summary"]["screening_evidence_summary"] == {
         "present": True,
         "total_candidates": 15,
@@ -282,3 +296,100 @@ def test_analysis_blocks_timeout_without_completed_campaign_evidence(tmp_path) -
     assert snapshot["result_summary"]["pass_fail"] is None
     assert snapshot["result_summary"]["trade_count"] == 0
 
+
+
+def test_analysis_marks_controlled_eval_report_stale_when_git_revision_differs(
+    tmp_path,
+) -> None:
+    report_path = tmp_path / "controlled_eval_latest.v1.json"
+    report_path.write_text(
+        json.dumps(
+            {
+                "git_revision": "old123",
+                "verdict": {
+                    "status": "useful_observation",
+                    "reason_codes": ["degenerate_no_survivors"],
+                },
+                "campaigns_completed": 1,
+                "campaign_level_evidence_valid": True,
+                "recommended_next_action": "inspect_results",
+            }
+        ),
+        encoding="utf-8",
+    )
+    execution_snapshot = {
+        "report_kind": "qre_controlled_validation_execution",
+        "selection_profile_name": "equities_exploratory_v1",
+        "execution_status": "execution_completed",
+        "controlled_validation_authorized": True,
+        "runner_adapter_status": "connected",
+        "executed_anything": True,
+        "final_recommendation": "controlled_validation_execution_completed",
+        "controlled_eval_result": {
+            "returncode": 0,
+            "report_paths": {"report_json": report_path.as_posix()},
+        },
+    }
+
+    snapshot = analysis.collect_snapshot(
+        execution_snapshot=execution_snapshot,
+        generated_at_utc="2026-06-03T23:00:00Z",
+        current_git_revision="new456",
+    )
+
+    assert snapshot["analysis_status"] == "analysis_ready"
+    assert snapshot["controlled_eval_report"]["artifact_freshness"] == {
+        "artifact_git_revision": "old123",
+        "current_git_revision": "new456",
+        "artifact_may_be_stale": True,
+        "reason_codes": ["artifact_git_revision_differs_from_current_head"],
+    }
+    assert snapshot["result_summary"]["artifact_freshness"] == snapshot[
+        "controlled_eval_report"
+    ]["artifact_freshness"]
+
+
+def test_analysis_marks_controlled_eval_report_stale_when_git_revision_missing(
+    tmp_path,
+) -> None:
+    report_path = tmp_path / "controlled_eval_latest.v1.json"
+    report_path.write_text(
+        json.dumps(
+            {
+                "verdict": {
+                    "status": "useful_observation",
+                    "reason_codes": ["degenerate_no_survivors"],
+                },
+                "campaigns_completed": 1,
+                "campaign_level_evidence_valid": True,
+                "recommended_next_action": "inspect_results",
+            }
+        ),
+        encoding="utf-8",
+    )
+    execution_snapshot = {
+        "report_kind": "qre_controlled_validation_execution",
+        "selection_profile_name": "equities_exploratory_v1",
+        "execution_status": "execution_completed",
+        "controlled_validation_authorized": True,
+        "runner_adapter_status": "connected",
+        "executed_anything": True,
+        "final_recommendation": "controlled_validation_execution_completed",
+        "controlled_eval_result": {
+            "returncode": 0,
+            "report_paths": {"report_json": report_path.as_posix()},
+        },
+    }
+
+    snapshot = analysis.collect_snapshot(
+        execution_snapshot=execution_snapshot,
+        generated_at_utc="2026-06-03T23:00:00Z",
+        current_git_revision="new456",
+    )
+
+    assert snapshot["controlled_eval_report"]["artifact_freshness"] == {
+        "artifact_git_revision": None,
+        "current_git_revision": "new456",
+        "artifact_may_be_stale": True,
+        "reason_codes": ["artifact_git_revision_missing"],
+    }

--- a/tests/unit/test_qre_controlled_validation_result_analysis.py
+++ b/tests/unit/test_qre_controlled_validation_result_analysis.py
@@ -6,6 +6,28 @@ from reporting import qre_controlled_validation_execution as execution
 from reporting import qre_controlled_validation_result_analysis as analysis
 
 
+
+
+def _ready_bridge_snapshot() -> dict:
+    return {
+        "report_kind": "qre_executable_hypothesis_identity_bridge_diagnostics",
+        "final_recommendation": "executable_hypothesis_identity_bridge_ready_for_regeneration",
+        "controlled_validation_bridge_readiness": {
+            "ready": True,
+            "executable_hypothesis_count": 1,
+            "ready_count": 1,
+            "blocked_count": 0,
+            "rows": [
+                {
+                    "preset_name": "trend_pullback_equities_4h",
+                    "executable_hypothesis_id": "trend_pullback_v1",
+                    "ready": True,
+                    "primary_blocker": "no_primary_blocker",
+                }
+            ],
+        },
+    }
+
 def test_analysis_blocks_when_execution_not_authorized() -> None:
     snapshot = analysis.collect_snapshot(
         profile_name="equities_exploratory_v1",
@@ -26,6 +48,7 @@ def test_analysis_blocks_when_runner_not_connected_even_if_authorized() -> None:
         profile_name="equities_exploratory_v1",
         execute_controlled_validation=True,
         operator_go=execution.REQUIRED_OPERATOR_GO_PHRASE,
+        controlled_validation_bridge_snapshot=_ready_bridge_snapshot(),
         generated_at_utc="2026-06-03T17:00:00Z",
     )
 
@@ -205,6 +228,26 @@ def test_analysis_reads_completed_controlled_eval_report(tmp_path) -> None:
         "sufficient_oos_evidence_candidates": 1,
         "qre_linkage_blocked_candidates": 1,
         "sufficient_oos_but_unlinked_candidates": 1,
+    }
+    assert snapshot["result_summary"]["evidence_quality_bottleneck"] == {
+        "primary_bottleneck": "linkage_blocker",
+        "reason_codes": ["sufficient_oos_evidence_blocked_by_qre_linkage"],
+        "artifact_freshness": {
+            "artifact_git_revision": "abc123",
+            "current_git_revision": "abc123",
+            "artifact_may_be_stale": False,
+            "reason_codes": ["artifact_git_revision_matches_current_head"],
+        },
+        "screening_evidence_summary": {
+            "present": True,
+            "total_candidates": 15,
+            "passed_screening": 6,
+            "rejected_screening": 9,
+            "promotion_grade_candidates": 0,
+            "sufficient_oos_evidence_candidates": 1,
+            "qre_linkage_blocked_candidates": 1,
+            "sufficient_oos_but_unlinked_candidates": 1,
+        },
     }
     assert snapshot["result_summary"]["evidence_refs"] == [report_path.as_posix()]
 
@@ -393,3 +436,164 @@ def test_analysis_marks_controlled_eval_report_stale_when_git_revision_missing(
         "artifact_may_be_stale": True,
         "reason_codes": ["artifact_git_revision_missing"],
     }
+
+
+def test_evidence_quality_bottleneck_prioritizes_stale_artifact(tmp_path) -> None:
+    report_path = tmp_path / "controlled_eval_latest.v1.json"
+    report_path.write_text(
+        json.dumps(
+            {
+                "git_revision": "old123",
+                "verdict": {
+                    "status": "useful_observation",
+                    "reason_codes": ["degenerate_no_survivors"],
+                },
+                "campaigns_completed": 1,
+                "campaign_level_evidence_valid": True,
+                "recommended_next_action": "inspect_results",
+                "screening_evidence_summary": {
+                    "passed_screening": 6,
+                    "rejected_screening": 9,
+                    "sufficient_oos_evidence_candidates": 1,
+                    "qre_linkage_blocked_candidates": 1,
+                    "sufficient_oos_but_unlinked_candidates": 1,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    execution_snapshot = {
+        "report_kind": "qre_controlled_validation_execution",
+        "selection_profile_name": "equities_exploratory_v1",
+        "execution_status": "execution_completed",
+        "controlled_validation_authorized": True,
+        "runner_adapter_status": "connected",
+        "executed_anything": True,
+        "final_recommendation": "controlled_validation_execution_completed",
+        "controlled_eval_result": {
+            "returncode": 0,
+            "report_paths": {"report_json": report_path.as_posix()},
+        },
+    }
+
+    snapshot = analysis.collect_snapshot(
+        execution_snapshot=execution_snapshot,
+        generated_at_utc="2026-06-03T23:00:00Z",
+        current_git_revision="new456",
+    )
+
+    assert snapshot["result_summary"]["evidence_quality_bottleneck"]["primary_bottleneck"] == (
+        "stale_artifact"
+    )
+    assert snapshot["result_summary"]["evidence_quality_bottleneck"]["reason_codes"] == [
+        "controlled_eval_artifact_may_be_stale"
+    ]
+
+
+def test_evidence_quality_bottleneck_classifies_no_oos_evidence(tmp_path) -> None:
+    report_path = tmp_path / "controlled_eval_latest.v1.json"
+    report_path.write_text(
+        json.dumps(
+            {
+                "git_revision": "abc123",
+                "verdict": {
+                    "status": "insufficient_data",
+                    "reason_codes": ["campaign_completed_without_decisive_evidence"],
+                },
+                "campaigns_completed": 1,
+                "campaign_level_evidence_valid": True,
+                "recommended_next_action": "continue_sprint",
+                "screening_evidence_summary": {
+                    "passed_screening": 6,
+                    "rejected_screening": 9,
+                    "sufficient_oos_evidence_candidates": 0,
+                    "qre_linkage_blocked_candidates": 0,
+                    "sufficient_oos_but_unlinked_candidates": 0,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    execution_snapshot = {
+        "report_kind": "qre_controlled_validation_execution",
+        "selection_profile_name": "equities_exploratory_v1",
+        "execution_status": "execution_completed",
+        "controlled_validation_authorized": True,
+        "runner_adapter_status": "connected",
+        "executed_anything": True,
+        "final_recommendation": "controlled_validation_execution_completed",
+        "controlled_eval_result": {
+            "returncode": 0,
+            "report_paths": {"report_json": report_path.as_posix()},
+        },
+    }
+
+    snapshot = analysis.collect_snapshot(
+        execution_snapshot=execution_snapshot,
+        generated_at_utc="2026-06-03T23:00:00Z",
+        current_git_revision="abc123",
+    )
+
+    assert snapshot["result_summary"]["evidence_quality_bottleneck"]["primary_bottleneck"] == (
+        "no_oos_evidence"
+    )
+    assert snapshot["result_summary"]["evidence_quality_bottleneck"]["reason_codes"] == [
+        "screening_passed_without_sufficient_oos_evidence"
+    ]
+
+
+def test_evidence_quality_bottleneck_classifies_registry_ledger_invariant_failure(
+    tmp_path,
+) -> None:
+    report_path = tmp_path / "controlled_eval_latest.v1.json"
+    report_path.write_text(
+        json.dumps(
+            {
+                "git_revision": "abc123",
+                "verdict": {
+                    "status": "technical_failure",
+                    "reason_codes": [
+                        "registry_ledger_invariant_violation",
+                        "completed_campaign_missing_campaign_completed_ledger_event",
+                    ],
+                },
+                "campaigns_completed": 1,
+                "campaign_level_evidence_valid": False,
+                "recommended_next_action": "operator_review_required",
+                "screening_evidence_summary": {
+                    "passed_screening": 6,
+                    "rejected_screening": 9,
+                    "sufficient_oos_evidence_candidates": 1,
+                    "qre_linkage_blocked_candidates": 1,
+                    "sufficient_oos_but_unlinked_candidates": 1,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    execution_snapshot = {
+        "report_kind": "qre_controlled_validation_execution",
+        "selection_profile_name": "equities_exploratory_v1",
+        "execution_status": "execution_completed",
+        "controlled_validation_authorized": True,
+        "runner_adapter_status": "connected",
+        "executed_anything": True,
+        "final_recommendation": "controlled_validation_execution_completed",
+        "controlled_eval_result": {
+            "returncode": 0,
+            "report_paths": {"report_json": report_path.as_posix()},
+        },
+    }
+
+    snapshot = analysis.collect_snapshot(
+        execution_snapshot=execution_snapshot,
+        generated_at_utc="2026-06-03T23:00:00Z",
+        current_git_revision="abc123",
+    )
+
+    assert snapshot["result_summary"]["evidence_quality_bottleneck"]["primary_bottleneck"] == (
+        "registry_ledger_invariant_violation"
+    )
+    assert snapshot["result_summary"]["evidence_quality_bottleneck"]["reason_codes"] == [
+        "registry_ledger_invariant_violation"
+    ]

--- a/tests/unit/test_qre_executable_hypothesis_identity_bridge_diagnostics.py
+++ b/tests/unit/test_qre_executable_hypothesis_identity_bridge_diagnostics.py
@@ -305,6 +305,73 @@ def test_partial_match_fails_closed_and_reports_missing_id(tmp_path: Path) -> No
     assert snap["bridge"]["primary_blocker"] == ("executable_hypothesis_id_not_in_qre_authority")
 
 
+
+
+def test_controlled_validation_bridge_readiness_reports_missing_executable_authority(
+    tmp_path: Path,
+) -> None:
+    snap = _snapshot(
+        tmp_path,
+        authority_ids=["qre-hyp-04f4d1cd9a515176"],
+        presets=[_preset("trend_pullback_equities_4h", "trend_pullback_v1")],
+    )
+
+    readiness = snap["controlled_validation_bridge_readiness"]
+
+    assert readiness["ready"] is False
+    assert readiness["executable_hypothesis_count"] == 1
+    assert readiness["ready_count"] == 0
+    assert readiness["blocked_count"] == 1
+    assert readiness["rows"] == [
+        {
+            "preset_name": "trend_pullback_equities_4h",
+            "executable_hypothesis_id": "trend_pullback_v1",
+            "in_qre_authority": False,
+            "qre_authority_linkage_mode": None,
+            "qre_authority_status": None,
+            "validation_plan_id_present": False,
+            "run_manifest_id_present": False,
+            "ready": False,
+            "primary_blocker": "executable_hypothesis_id_not_in_qre_authority",
+        }
+    ]
+    _assert_safety(snap)
+
+
+def test_controlled_validation_bridge_readiness_reports_exact_bridge_ready(
+    tmp_path: Path,
+) -> None:
+    snap = _snapshot(
+        tmp_path,
+        authority_ids=["qre-hyp-fixture-001"],
+        executable_bridge_by_hypothesis_id={
+            "qre-hyp-fixture-001": "trend_pullback_v1",
+        },
+        presets=[_preset("trend_pullback_equities_4h", "trend_pullback_v1")],
+    )
+
+    readiness = snap["controlled_validation_bridge_readiness"]
+
+    assert readiness["ready"] is True
+    assert readiness["executable_hypothesis_count"] == 1
+    assert readiness["ready_count"] == 1
+    assert readiness["blocked_count"] == 0
+    assert readiness["rows"] == [
+        {
+            "preset_name": "trend_pullback_equities_4h",
+            "executable_hypothesis_id": "trend_pullback_v1",
+            "in_qre_authority": True,
+            "qre_authority_linkage_mode": "executable_hypothesis_bridge",
+            "qre_authority_status": "bridge_exact",
+            "validation_plan_id_present": True,
+            "run_manifest_id_present": True,
+            "ready": True,
+            "primary_blocker": "no_primary_blocker",
+        }
+    ]
+    _assert_safety(snap)
+
+
 def test_missing_qre_authority_artifacts_fail_closed(tmp_path: Path) -> None:
     snap = diag.collect_snapshot(
         hypothesis_artifact_path=tmp_path / "missing-hypotheses.json",


### PR DESCRIPTION
﻿## Summary
- Detect stale controlled validation artifacts by comparing artifact and current git revision.
- Fail closed on registry/ledger completed-campaign invariant mismatches.
- Add controlled-validation bridge readiness diagnostics for executable hypothesis IDs.
- Block controlled validation runner launch when executable hypothesis bridge readiness is missing.
- Classify evidence-quality bottlenecks across stale artifacts, registry/ledger mismatch, QRE linkage blockers, no-OOS evidence, and insufficient-trade screening.

## Validation
- pytest tests/unit/test_qre_controlled_validation_execution.py tests/unit/test_qre_controlled_validation_result_analysis.py tests/unit/test_controlled_eval.py tests/unit/test_qre_executable_hypothesis_identity_bridge_diagnostics.py tests/unit/test_screening_evidence_validation_linkage.py tests/unit/test_run_candidates_validation_linkage.py tests/unit/test_qre_validation_result_linkage_diagnostics.py tests/unit/test_qre_executable_hypothesis_identity_bridge_contract.py tests/unit/test_qre_executable_hypothesis_selection.py tests/unit/test_qre_selection_route_materialization.py tests/unit/test_qre_selection_route_validation_flow.py tests/unit/test_qre_controlled_validation_learning_proposal.py tests/unit/test_qre_controlled_validation_research_action_queue_gate.py -q
- pytest tests/regression -q -k "pin or deterministic or digest or invariant"

## Safety
- No live/paper/shadow trading changes.
- No broker/risk/execution configuration changes.
- No strategy or preset mutation.
- No research-action queue mutation.
- No Codex launch.
- Runner execution is more constrained: controlled validation is now blocked unless bridge readiness is explicit.
