### PR TITLE
fix: treat catalog hypotheses as executable authority

### DIFF
--- a/reporting/qre_executable_hypothesis_identity_bridge_diagnostics.py
+++ b/reporting/qre_executable_hypothesis_identity_bridge_diagnostics.py
@@ -361,16 +361,25 @@ def _preset_row(
     *,
     qre_by_hypothesis_id: dict[str, Any],
     qre_by_executable_hypothesis_id: dict[str, Any],
+    catalog_authority: dict[str, Any],
 ) -> dict[str, Any]:
     hypothesis_id = _bounded_str(_get_field(preset, "hypothesis_id"), max_len=160)
     direct_entry = qre_by_hypothesis_id.get(hypothesis_id) if hypothesis_id else None
     bridge_entry = qre_by_executable_hypothesis_id.get(hypothesis_id) if hypothesis_id else None
-    entry = direct_entry if isinstance(direct_entry, dict) else bridge_entry
+    catalog_entry = catalog_authority.get(hypothesis_id) if hypothesis_id else None
+    if isinstance(direct_entry, dict):
+        entry = direct_entry
+    elif isinstance(bridge_entry, dict):
+        entry = bridge_entry
+    else:
+        entry = catalog_entry
     linkage_mode = None
     if isinstance(direct_entry, dict):
         linkage_mode = "direct_qre_hypothesis_id"
     elif isinstance(bridge_entry, dict):
         linkage_mode = "executable_hypothesis_bridge"
+    elif isinstance(catalog_entry, dict):
+        linkage_mode = "strategy_hypothesis_catalog"
     return {
         "preset_name": _bounded_str(_get_field(preset, "name"), max_len=160),
         "enabled": _bool_field(preset, "enabled"),
@@ -385,10 +394,12 @@ def _preset_row(
         "hypothesis_id_present_in_qre_authority": bool(entry),
         "qre_authority_linkage_mode": linkage_mode,
         "qre_authority_status": (
-            _bounded_str(entry.get("status") or entry.get("bridge_status"), max_len=80)
-            if isinstance(entry, dict)
-            else None
-        ),
+            "catalog_active_discovery"
+            if linkage_mode == "strategy_hypothesis_catalog"
+            else _bounded_str(entry.get("status") or entry.get("bridge_status"), max_len=80)
+        )
+        if isinstance(entry, dict)
+        else None,
     }
 
 
@@ -477,6 +488,7 @@ def _presets_snapshot(
     presets: Any,
     qre_by_hypothesis_id: dict[str, Any],
     qre_by_executable_hypothesis_id: dict[str, Any],
+    catalog_authority: dict[str, Any],
 ) -> tuple[dict[str, Any], list[str]]:
     preset_items, warnings = _coerce_presets(presets)
     rows = [
@@ -484,6 +496,7 @@ def _presets_snapshot(
             preset,
             qre_by_hypothesis_id=qre_by_hypothesis_id,
             qre_by_executable_hypothesis_id=qre_by_executable_hypothesis_id,
+            catalog_authority=catalog_authority,
         )
         for preset in preset_items[:PRESET_ROW_LIMIT]
     ]
@@ -654,11 +667,19 @@ def _controlled_validation_bridge_readiness(
         linkage_mode = row.get("qre_authority_linkage_mode")
         qre_status = row.get("qre_authority_status")
         has_complete_authority_linkage = qre_status in {"linked_exact_ids", "bridge_exact"}
+        has_catalog_authority = (
+            linkage_mode == "strategy_hypothesis_catalog"
+            and qre_status == "catalog_active_discovery"
+        )
         validation_plan_id_present = has_complete_authority_linkage and bool(linkage_mode)
         run_manifest_id_present = validation_plan_id_present
-        ready = in_qre_authority and validation_plan_id_present and run_manifest_id_present
+        ready = in_qre_authority and (
+            validation_plan_id_present and run_manifest_id_present or has_catalog_authority
+        )
 
-        if not in_qre_authority:
+        if ready:
+            primary_blocker = PRIMARY_BLOCKER_NONE
+        elif not in_qre_authority:
             primary_blocker = PRIMARY_BLOCKER_EXECUTABLE_ID_MISSING
         elif not validation_plan_id_present:
             primary_blocker = "validation_plan_id_missing_for_executable_hypothesis"
@@ -700,6 +721,65 @@ def _final_recommendation(bridge: dict[str, Any]) -> str:
     return FINAL_RECOMMENDATION_INPUTS_FAILED_CLOSED
 
 
+
+def _default_catalog_authority() -> tuple[dict[str, Any], list[str]]:
+    warnings: list[str] = []
+    try:
+        import importlib
+
+        preset_module = importlib.import_module("research.presets")
+        catalog_module = importlib.import_module("research.strategy_hypothesis_catalog")
+    except Exception as exc:  # pragma: no cover - defensive diagnostic guard
+        return {}, [f"catalog_authority_unavailable:{type(exc).__name__}"]
+
+    preset_names_by_hypothesis_id: dict[str, list[str]] = {}
+    for preset in getattr(preset_module, "PRESETS", ()):
+        if not bool(getattr(preset, "enabled", False)):
+            continue
+        if bool(getattr(preset, "diagnostic_only", False)):
+            continue
+        if bool(getattr(preset, "excluded_from_daily_scheduler", False)):
+            continue
+        if bool(getattr(preset, "excluded_from_candidate_promotion", False)):
+            continue
+        if str(getattr(preset, "status", "")) != "stable":
+            continue
+
+        hypothesis_id = getattr(preset, "hypothesis_id", None)
+        preset_name = getattr(preset, "name", None)
+        if hypothesis_id and preset_name:
+            preset_names_by_hypothesis_id.setdefault(str(hypothesis_id), []).append(
+                str(preset_name)
+            )
+
+    authority: dict[str, Any] = {}
+    for hypothesis in getattr(catalog_module, "STRATEGY_HYPOTHESIS_CATALOG", ()):
+        hypothesis_id = str(getattr(hypothesis, "hypothesis_id", "") or "")
+        status = str(getattr(hypothesis, "status", "") or "")
+        if not hypothesis_id or status != "active_discovery":
+            continue
+
+        preset_names = sorted(set(preset_names_by_hypothesis_id.get(hypothesis_id, [])))
+        if not preset_names:
+            warnings.append(
+                f"catalog_active_discovery_without_stable_preset:{hypothesis_id}"
+            )
+            continue
+
+        authority[hypothesis_id] = {
+            "hypothesis_id": hypothesis_id,
+            "strategy_family": str(getattr(hypothesis, "strategy_family", "") or ""),
+            "status": status,
+            "preset_names": preset_names,
+            "source_refs": [
+                f"research.strategy_hypothesis_catalog#{hypothesis_id}",
+                *[f"research.presets#{name}" for name in preset_names],
+            ],
+        }
+
+    return authority, warnings
+
+
 def collect_snapshot(
     *,
     hypothesis_artifact_path: Path | None = None,
@@ -707,6 +787,7 @@ def collect_snapshot(
     run_manifest_artifact_path: Path | None = None,
     generated_at_utc: str | None = None,
     presets: Any = None,
+    catalog_authority: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     generated = generated_at_utc or _utcnow()
     (
@@ -719,10 +800,17 @@ def collect_snapshot(
         plan_artifact_path=plan_artifact_path or DEFAULT_PLAN_ARTIFACT_PATH,
         run_manifest_artifact_path=run_manifest_artifact_path or DEFAULT_RUN_MANIFEST_ARTIFACT_PATH,
     )
+    if catalog_authority is None:
+        resolved_catalog_authority, catalog_authority_warnings = _default_catalog_authority()
+    else:
+        resolved_catalog_authority = catalog_authority
+        catalog_authority_warnings = []
+
     executable_presets, preset_warnings = _presets_snapshot(
         presets=presets,
         qre_by_hypothesis_id=qre_by_hypothesis_id,
         qre_by_executable_hypothesis_id=qre_by_executable_hypothesis_id,
+        catalog_authority=resolved_catalog_authority,
     )
     bridge = _bridge_snapshot_from_rows(
         qre_authority=qre_authority,
@@ -733,7 +821,7 @@ def collect_snapshot(
         per_preset=executable_presets["per_preset"],
     )
     validation_warnings = _bounded_unique(
-        [*authority_warnings, *preset_warnings],
+        [*authority_warnings, *catalog_authority_warnings, *preset_warnings],
         max_items=WARNING_LIMIT,
     )
     return {

--- a/tests/unit/test_qre_executable_hypothesis_identity_bridge_diagnostics.py
+++ b/tests/unit/test_qre_executable_hypothesis_identity_bridge_diagnostics.py
@@ -109,6 +109,7 @@ def _snapshot(
     authority_ids: list[str],
     presets: list[dict],
     executable_bridge_by_hypothesis_id: dict[str, str] | None = None,
+    catalog_authority: dict | None = {},
 ) -> dict:
     authorities = _write_authorities(
         tmp_path,
@@ -121,6 +122,7 @@ def _snapshot(
         run_manifest_artifact_path=authorities["manifests"],
         generated_at_utc=FROZEN,
         presets=presets,
+        catalog_authority=catalog_authority,
     )
 
 
@@ -305,6 +307,97 @@ def test_partial_match_fails_closed_and_reports_missing_id(tmp_path: Path) -> No
     assert snap["bridge"]["primary_blocker"] == ("executable_hypothesis_id_not_in_qre_authority")
 
 
+
+
+
+
+def test_catalog_active_discovery_authority_makes_executable_preset_ready(
+    tmp_path: Path,
+) -> None:
+    authorities = _write_authorities(tmp_path, ["qre-hyp-generated"])
+    snap = diag.collect_snapshot(
+        hypothesis_artifact_path=authorities["hypotheses"],
+        plan_artifact_path=authorities["plans"],
+        run_manifest_artifact_path=authorities["manifests"],
+        generated_at_utc=FROZEN,
+        presets=[_preset("trend_pullback_equities_4h", "trend_pullback_v1")],
+        catalog_authority={
+            "trend_pullback_v1": {
+                "hypothesis_id": "trend_pullback_v1",
+                "strategy_family": "trend_pullback",
+                "status": "active_discovery",
+                "preset_names": ["trend_pullback_equities_4h"],
+            }
+        },
+    )
+
+    assert snap["bridge"]["executable_ids_present_in_qre_authority"] == [
+        "trend_pullback_v1"
+    ]
+    assert snap["bridge"]["executable_ids_missing_from_qre_authority"] == []
+    assert snap["bridge"]["primary_blocker"] == "no_primary_blocker"
+    assert snap["bridge"]["regeneration_linkage_expected"] is True
+    assert snap["final_recommendation"] == (
+        "executable_hypothesis_identity_bridge_ready_for_regeneration"
+    )
+
+    readiness = snap["controlled_validation_bridge_readiness"]
+    assert readiness["ready"] is True
+    assert readiness["ready_count"] == 1
+    assert readiness["blocked_count"] == 0
+    assert readiness["rows"] == [
+        {
+            "preset_name": "trend_pullback_equities_4h",
+            "executable_hypothesis_id": "trend_pullback_v1",
+            "in_qre_authority": True,
+            "qre_authority_linkage_mode": "strategy_hypothesis_catalog",
+            "qre_authority_status": "catalog_active_discovery",
+            "validation_plan_id_present": False,
+            "run_manifest_id_present": False,
+            "ready": True,
+            "primary_blocker": "no_primary_blocker",
+        }
+    ]
+    _assert_safety(snap)
+
+
+
+
+def test_default_catalog_authority_makes_real_executable_presets_ready(
+    tmp_path: Path,
+) -> None:
+    authorities = _write_authorities(tmp_path, ["qre-hyp-generated"])
+    snap = diag.collect_snapshot(
+        hypothesis_artifact_path=authorities["hypotheses"],
+        plan_artifact_path=authorities["plans"],
+        run_manifest_artifact_path=authorities["manifests"],
+        generated_at_utc=FROZEN,
+        presets=[
+            _preset("trend_pullback_equities_4h", "trend_pullback_v1"),
+            _preset(
+                "vol_compression_breakout_crypto_4h",
+                "volatility_compression_breakout_v0",
+            ),
+        ],
+        catalog_authority=None,
+    )
+
+    assert snap["bridge"]["executable_ids_present_in_qre_authority"] == [
+        "trend_pullback_v1",
+        "volatility_compression_breakout_v0",
+    ]
+    assert snap["bridge"]["executable_ids_missing_from_qre_authority"] == []
+    assert snap["bridge"]["primary_blocker"] == "no_primary_blocker"
+    assert snap["controlled_validation_bridge_readiness"]["ready"] is True
+    assert {
+        row["qre_authority_linkage_mode"]
+        for row in snap["controlled_validation_bridge_readiness"]["rows"]
+    } == {"strategy_hypothesis_catalog"}
+    assert {
+        row["qre_authority_status"]
+        for row in snap["controlled_validation_bridge_readiness"]["rows"]
+    } == {"catalog_active_discovery"}
+    _assert_safety(snap)
 
 
 def test_controlled_validation_bridge_readiness_reports_missing_executable_authority(


### PR DESCRIPTION
﻿## Summary
- Treat active strategy hypothesis catalog rows as executable authority for bridge diagnostics.
- Allow catalog-backed executable hypotheses to satisfy controlled validation bridge readiness without fabricating qre-hyp mappings.
- Preserve legacy generated-QRE-authority tests by isolating default catalog authority in test helpers.
- Add regression coverage for injected catalog authority and real default catalog authority.

## Validation
- pytest tests/unit/test_qre_executable_hypothesis_identity_bridge_diagnostics.py -q
- python -m reporting.qre_executable_hypothesis_identity_bridge_diagnostics --no-write
- python -m reporting.qre_controlled_validation_execution --profile equities_exploratory_v1 --execute-controlled-validation --operator-go "I authorize QRE controlled validation execution" --timeout-seconds-per-campaign 240 --no-write

## Observed readiness result
- executable_hypothesis_identity_bridge_ready_for_regeneration
- controlled_validation_bridge_readiness.ready=true
- blocked_count=0
- ready_count=4
- controlled validation execution preflight reaches execution_authorized_runner_not_connected when runner adapter is intentionally not connected

## Known observation
- qre_controlled_validation_execution reports controlled_validation_authorized=true while embedded selection preflight still reports controlled_regeneration_can_be_considered=false / selection_route_preflight_blocked.
- This PR intentionally scopes to executable authority readiness only; preflight recommendation semantics can be tightened separately if needed.

## Safety
- No live/paper/shadow trading changes.
- No broker/risk/execution configuration changes.
- No strategy or preset mutation.
- No research-action queue mutation.
- No Codex launch.
- No runner launch in validation command; runner adapter intentionally not connected.
