### PR TITLE
fix: preflight campaign invariant before controlled validation launch

### DIFF
--- a/reporting/qre_controlled_validation_execution.py
+++ b/reporting/qre_controlled_validation_execution.py
@@ -38,6 +38,9 @@ REQUIRED_OPERATOR_GO_PHRASE: Final[str] = (
 EXECUTION_BLOCKED_NOT_REQUESTED: Final[str] = "execution_blocked_not_requested"
 EXECUTION_BLOCKED_PREFLIGHT_NOT_READY: Final[str] = "execution_blocked_preflight_not_ready"
 EXECUTION_BLOCKED_BRIDGE_NOT_READY: Final[str] = "execution_blocked_bridge_not_ready"
+EXECUTION_BLOCKED_CAMPAIGN_INVARIANT_VIOLATION: Final[str] = (
+    "execution_blocked_campaign_invariant_violation"
+)
 EXECUTION_BLOCKED_OPERATOR_GO_MISSING: Final[str] = "execution_blocked_operator_go_missing"
 EXECUTION_BLOCKED_OPERATOR_GO_MISMATCH: Final[str] = "execution_blocked_operator_go_mismatch"
 EXECUTION_AUTHORIZED_RUNNER_NOT_CONNECTED: Final[str] = (
@@ -50,6 +53,7 @@ EXECUTION_STATUSES: Final[tuple[str, ...]] = (
     EXECUTION_BLOCKED_NOT_REQUESTED,
     EXECUTION_BLOCKED_PREFLIGHT_NOT_READY,
     EXECUTION_BLOCKED_BRIDGE_NOT_READY,
+    EXECUTION_BLOCKED_CAMPAIGN_INVARIANT_VIOLATION,
     EXECUTION_BLOCKED_OPERATOR_GO_MISSING,
     EXECUTION_BLOCKED_OPERATOR_GO_MISMATCH,
     EXECUTION_AUTHORIZED_RUNNER_NOT_CONNECTED,
@@ -123,6 +127,8 @@ def _final_recommendation(status: str) -> str:
         return "controlled_validation_execution_authorized_runner_not_connected"
     if status == EXECUTION_BLOCKED_BRIDGE_NOT_READY:
         return "controlled_validation_execution_blocked_bridge_not_ready"
+    if status == EXECUTION_BLOCKED_CAMPAIGN_INVARIANT_VIOLATION:
+        return "controlled_validation_execution_blocked_campaign_invariant_violation"
     return "controlled_validation_execution_blocked"
 
 
@@ -144,6 +150,78 @@ def _runner_report_paths() -> dict[str, str]:
     return {
         "report_json": _rel(CONTROLLED_EVAL_REPORT_JSON),
         "report_md": _rel(CONTROLLED_EVAL_REPORT_MD),
+    }
+
+
+def _campaign_invariant_preflight() -> dict[str, Any]:
+    try:
+        import importlib
+
+        registry_module = importlib.import_module("research.campaign_registry")
+        ledger_module = importlib.import_module("research.campaign_evidence_ledger")
+    except Exception as exc:  # pragma: no cover - defensive diagnostic guard
+        return {
+            "status": "unknown",
+            "reason": f"campaign_invariant_preflight_unavailable:{type(exc).__name__}",
+            "completed_campaign_count": 0,
+            "campaign_completed_ledger_event_count": 0,
+            "missing_completed_ledger_event_ids": [],
+        }
+
+    registry_path = getattr(registry_module, "REGISTRY_ARTIFACT_PATH", None)
+    load_registry = getattr(registry_module, "load_registry", None)
+    load_events = getattr(ledger_module, "load_events", None)
+    if registry_path is None or load_registry is None or load_events is None:
+        return {
+            "status": "unknown",
+            "reason": "campaign_invariant_preflight_api_unavailable",
+            "completed_campaign_count": 0,
+            "campaign_completed_ledger_event_count": 0,
+            "missing_completed_ledger_event_ids": [],
+        }
+
+    try:
+        registry = load_registry(registry_path)
+        ledger_events = load_events(Path("research/campaign_evidence_ledger_latest.v1.jsonl"))
+    except Exception as exc:  # pragma: no cover - defensive diagnostic guard
+        return {
+            "status": "unknown",
+            "reason": f"campaign_invariant_preflight_load_failed:{type(exc).__name__}",
+            "completed_campaign_count": 0,
+            "campaign_completed_ledger_event_count": 0,
+            "missing_completed_ledger_event_ids": [],
+        }
+
+    campaigns = registry.get("campaigns") if isinstance(registry, dict) else {}
+    if not isinstance(campaigns, dict):
+        campaigns = {}
+
+    completed_campaign_ids = {
+        str(campaign_id)
+        for campaign_id, record in campaigns.items()
+        if isinstance(record, dict) and record.get("state") == "completed"
+    }
+
+    campaign_completed_ledger_ids: set[str] = set()
+    for event in ledger_events:
+        if not isinstance(event, dict):
+            continue
+        event_type = event.get("event_type") or event.get("type")
+        if event_type != "campaign_completed":
+            continue
+        campaign_id = event.get("campaign_id")
+        if campaign_id:
+            campaign_completed_ledger_ids.add(str(campaign_id))
+
+    missing_completed_ledger_event_ids = sorted(
+        completed_campaign_ids - campaign_completed_ledger_ids
+    )
+    status = "failed" if missing_completed_ledger_event_ids else "passed"
+    return {
+        "status": status,
+        "completed_campaign_count": len(completed_campaign_ids),
+        "campaign_completed_ledger_event_count": len(campaign_completed_ledger_ids),
+        "missing_completed_ledger_event_ids": missing_completed_ledger_event_ids,
     }
 
 
@@ -217,15 +295,31 @@ def collect_snapshot(
         selection_route_ready=selection_route_ready,
         controlled_validation_bridge_ready=controlled_validation_bridge_ready,
     )
+    campaign_invariant_preflight: dict[str, Any] = {
+        "status": "not_checked",
+        "completed_campaign_count": 0,
+        "campaign_completed_ledger_event_count": 0,
+        "missing_completed_ledger_event_ids": [],
+    }
+
     runner_result: dict[str, Any] | None = None
     if status == EXECUTION_AUTHORIZED_RUNNER_NOT_CONNECTED and connect_runner_adapter:
         if profile_name is None:
             raise ValueError("profile_name is required when connecting the runner adapter")
-        runner_result = _run_controlled_eval_adapter(
-            profile_name=profile_name,
-            timeout_seconds_per_campaign=timeout_seconds_per_campaign,
-        )
-        status = EXECUTION_COMPLETED if runner_result["returncode"] == 0 else EXECUTION_FAILED
+        _bounded_timeout_seconds(timeout_seconds_per_campaign)
+        campaign_invariant_preflight = _campaign_invariant_preflight()
+        if campaign_invariant_preflight.get("status") == "failed":
+            status = EXECUTION_BLOCKED_CAMPAIGN_INVARIANT_VIOLATION
+        else:
+            runner_result = _run_controlled_eval_adapter(
+                profile_name=profile_name,
+                timeout_seconds_per_campaign=timeout_seconds_per_campaign,
+            )
+            status = (
+                EXECUTION_COMPLETED
+                if runner_result["returncode"] == 0
+                else EXECUTION_FAILED
+            )
 
     authorized = status in {
         EXECUTION_AUTHORIZED_RUNNER_NOT_CONNECTED,
@@ -302,6 +396,7 @@ def collect_snapshot(
             ),
         },
         "controlled_eval_result": runner_result,
+        "campaign_invariant_preflight": campaign_invariant_preflight,
         "would_write_artifacts": [
             "logs/qre_controlled_validation_execution/latest.json",
             *_runner_report_paths().values(),

--- a/tests/unit/test_qre_controlled_validation_execution.py
+++ b/tests/unit/test_qre_controlled_validation_execution.py
@@ -104,6 +104,108 @@ def test_exact_operator_go_authorizes_contract_but_runner_is_not_connected() -> 
 
 
 
+
+
+def test_campaign_invariant_violation_blocks_runner_before_launch(monkeypatch) -> None:
+    calls: list[object] = []
+
+    def fake_run_controlled_eval(**kwargs: object) -> int:
+        calls.append(kwargs)
+        return 0
+
+    monkeypatch.setattr(
+        execution,
+        "_run_controlled_eval_adapter",
+        fake_run_controlled_eval,
+    )
+    monkeypatch.setattr(
+        execution,
+        "_campaign_invariant_preflight",
+        lambda: {
+            "status": "failed",
+            "completed_campaign_count": 1,
+            "campaign_completed_ledger_event_count": 0,
+            "missing_completed_ledger_event_ids": [
+                "col-20260604T203711765074Z-trend_pullback_equities_4h-3e5f6de0b6"
+            ],
+        },
+    )
+
+    snapshot = execution.collect_snapshot(
+        profile_name="equities_exploratory_v1",
+        execute_controlled_validation=True,
+        operator_go=execution.REQUIRED_OPERATOR_GO_PHRASE,
+        connect_runner_adapter=True,
+        timeout_seconds_per_campaign=240,
+        controlled_validation_bridge_snapshot=_bridge_snapshot(ready=True),
+        generated_at_utc="2026-06-05T05:30:00Z",
+    )
+
+    assert calls == []
+    assert snapshot["execution_status"] == (
+        "execution_blocked_campaign_invariant_violation"
+    )
+    assert snapshot["final_recommendation"] == (
+        "controlled_validation_execution_blocked_campaign_invariant_violation"
+    )
+    assert snapshot["controlled_validation_authorized"] is False
+    assert snapshot["executed_anything"] is False
+    assert snapshot["launches_subprocess"] is False
+    assert snapshot["runner_adapter_status"] == "not_connected"
+    assert snapshot["campaign_invariant_preflight"] == {
+        "status": "failed",
+        "completed_campaign_count": 1,
+        "campaign_completed_ledger_event_count": 0,
+        "missing_completed_ledger_event_ids": [
+            "col-20260604T203711765074Z-trend_pullback_equities_4h-3e5f6de0b6"
+        ],
+    }
+
+
+def test_campaign_invariant_preflight_pass_allows_existing_runner_path(
+    monkeypatch,
+) -> None:
+    calls: list[object] = []
+
+    def fake_run_controlled_eval(**kwargs: object) -> dict[str, object]:
+        calls.append(kwargs)
+        return {
+            "returncode": 0,
+            "stdout_tail": "ok",
+            "report_paths": {"report_json": "x.json", "report_md": "x.md"},
+        }
+
+    monkeypatch.setattr(
+        execution,
+        "_run_controlled_eval_adapter",
+        fake_run_controlled_eval,
+    )
+    monkeypatch.setattr(
+        execution,
+        "_campaign_invariant_preflight",
+        lambda: {
+            "status": "passed",
+            "completed_campaign_count": 0,
+            "campaign_completed_ledger_event_count": 0,
+            "missing_completed_ledger_event_ids": [],
+        },
+    )
+
+    snapshot = execution.collect_snapshot(
+        profile_name="equities_exploratory_v1",
+        execute_controlled_validation=True,
+        operator_go=execution.REQUIRED_OPERATOR_GO_PHRASE,
+        connect_runner_adapter=True,
+        timeout_seconds_per_campaign=240,
+        controlled_validation_bridge_snapshot=_bridge_snapshot(ready=True),
+        generated_at_utc="2026-06-05T05:30:00Z",
+    )
+
+    assert len(calls) == 1
+    assert snapshot["execution_status"] == "execution_completed"
+    assert snapshot["campaign_invariant_preflight"]["status"] == "passed"
+
+
 def test_bridge_not_ready_blocks_even_with_operator_go_and_runner_adapter(
     monkeypatch,
 ) -> None:
@@ -253,6 +355,17 @@ def test_connected_runner_adapter_invokes_controlled_eval(monkeypatch, tmp_path)
         tmp_path / "controlled_eval_latest.md",
     )
 
+    monkeypatch.setattr(
+        execution,
+        "_campaign_invariant_preflight",
+        lambda: {
+            "status": "passed",
+            "completed_campaign_count": 0,
+            "campaign_completed_ledger_event_count": 0,
+            "missing_completed_ledger_event_ids": [],
+        },
+    )
+
     snapshot = execution.collect_snapshot(
         profile_name="equities_exploratory_v1",
         execute_controlled_validation=True,
@@ -306,6 +419,17 @@ def test_connected_runner_adapter_records_failure(monkeypatch, tmp_path) -> None
         execution,
         "CONTROLLED_EVAL_REPORT_MD",
         tmp_path / "controlled_eval_latest.md",
+    )
+
+    monkeypatch.setattr(
+        execution,
+        "_campaign_invariant_preflight",
+        lambda: {
+            "status": "passed",
+            "completed_campaign_count": 0,
+            "campaign_completed_ledger_event_count": 0,
+            "missing_completed_ledger_event_ids": [],
+        },
     )
 
     snapshot = execution.collect_snapshot(

--- a/tests/unit/test_qre_controlled_validation_loop_report.py
+++ b/tests/unit/test_qre_controlled_validation_loop_report.py
@@ -176,6 +176,16 @@ def test_loop_report_connected_runner_reaches_learning_ready(monkeypatch, tmp_pa
         "_load_controlled_eval_module",
         lambda: FakeControlledEval,
     )
+    monkeypatch.setattr(
+        execution,
+        "_campaign_invariant_preflight",
+        lambda: {
+            "status": "passed",
+            "completed_campaign_count": 0,
+            "campaign_completed_ledger_event_count": 0,
+            "missing_completed_ledger_event_ids": [],
+        },
+    )
     monkeypatch.setattr(execution, "ARTIFACT_DIR", tmp_path)
     monkeypatch.setattr(
         execution,


### PR DESCRIPTION
﻿## Summary
- Add a pre-run campaign registry/ledger invariant gate before controlled validation runner launch.
- Detect completed campaigns that lack campaign_completed ledger events.
- Block connected runner execution before subprocess launch when I5 campaign evidence invariants fail.
- Keep non-connected authorization preflight behavior unchanged.
- Update loop-report and execution tests to mock a passed invariant gate for clean connected-runner simulations.

## Validation
- pytest tests/architecture -q
- pytest tests/unit/test_qre_controlled_validation_execution.py -q
- pytest tests/unit/test_qre_controlled_validation_execution.py tests/unit/test_qre_controlled_validation_loop_report.py tests/unit/test_qre_controlled_validation_result_analysis.py tests/unit/test_controlled_eval.py -q
- python -m reporting.qre_controlled_validation_execution --profile equities_exploratory_v1 --execute-controlled-validation --operator-go "I authorize QRE controlled validation execution" --connect-runner-adapter --timeout-seconds-per-campaign 240 --no-write

## Observed safety result
- execution_status=execution_blocked_campaign_invariant_violation
- controlled_validation_authorized=false
- executed_anything=false
- launches_subprocess=false
- runner_adapter_status=not_connected
- offending campaign surfaced in campaign_invariant_preflight.missing_completed_ledger_event_ids

## Safety
- No live/paper/shadow trading changes.
- No broker/risk/execution configuration changes.
- No strategy or preset mutation.
- No research-action queue mutation.
- No ledger/registry repair or fabricated campaign_completed event.
- Connected runner launch is now more constrained: stale I5 state blocks before subprocess launch.
