### PR TITLE
fix: link catalog active discovery candidates in validation evidence

### DIFF
--- a/research/screening_evidence.py
+++ b/research/screening_evidence.py
@@ -47,6 +47,7 @@ from reporting.qre_executable_hypothesis_identity_bridge_contract import (
     BRIDGE_STATUS_EXACT,
     build_bridge_index,
 )
+from research.strategy_hypothesis_catalog import list_active_discovery
 from research.screening_criteria import (
     EXPLORATORY_MAX_DRAWDOWN,
     EXPLORATORY_MIN_EXPECTANCY,
@@ -373,10 +374,14 @@ def build_qre_validation_linkage_authority(
 ) -> dict[str, Any]:
     """Build exact QRE validation-linkage authority for screening rows.
 
-    The authority is intentionally strict: it only links by an existing
-    ``hypothesis_id`` that is present in the QRE hypothesis artifact and
-    resolves to exactly one validation plan and exactly one run manifest.
-    Asset, symbol, timeframe, strategy, filename, and candidate-only
+    The authority is intentionally strict for exact QRE validation links:
+    exact linkage still requires a ``hypothesis_id`` present in the QRE
+    hypothesis artifact that resolves to exactly one validation plan and
+    exactly one run manifest.
+
+    Catalog ``active_discovery`` hypotheses are also exposed as bounded
+    lineage authority without fabricating validation-plan or run-manifest
+    IDs. Asset, symbol, timeframe, strategy, filename, and candidate-only
     matching are not used.
     """
     warnings: list[str] = []
@@ -477,6 +482,30 @@ def build_qre_validation_linkage_authority(
             "hypothesis_id": hypothesis_id,
             "validation_plan_id": plan_id,
             "run_manifest_id": manifest_ids[0],
+            "warnings": [],
+        }
+
+    qre_executable_hypothesis_ids = {
+        _bounded_str(item.get("executable_hypothesis_id"), max_len=160)
+        for item in hypotheses or []
+        if _bounded_str(item.get("executable_hypothesis_id"), max_len=160)
+    }
+    for active_row in list_active_discovery():
+        catalog_hypothesis_id = _bounded_str(
+            getattr(active_row, "hypothesis_id", None),
+            max_len=160,
+        )
+        if (
+            not catalog_hypothesis_id
+            or catalog_hypothesis_id in by_hypothesis_id
+            or catalog_hypothesis_id in qre_executable_hypothesis_ids
+        ):
+            continue
+        by_hypothesis_id[catalog_hypothesis_id] = {
+            "status": "linked_catalog_active_discovery",
+            "hypothesis_id": catalog_hypothesis_id,
+            "qre_authority_linkage_mode": "strategy_hypothesis_catalog",
+            "qre_authority_status": "catalog_active_discovery",
             "warnings": [],
         }
 

--- a/tests/unit/test_run_candidates_validation_linkage.py
+++ b/tests/unit/test_run_candidates_validation_linkage.py
@@ -179,6 +179,46 @@ def test_run_candidate_executable_hypothesis_id_links_through_bridge() -> None:
     assert row["qre_validation_linkage_warnings"] == []
 
 
+
+
+def test_catalog_active_discovery_run_candidate_links_without_exact_qre_ids() -> None:
+    row = _row(
+        candidate=_candidate(hypothesis_id=EXECUTABLE_HYPOTHESIS_ID),
+        authority=_authority(
+            hypotheses={
+                "report_kind": "qre_hypothesis_candidates",
+                "hypotheses": [{"hypothesis_id": HYPOTHESIS_ID}],
+            },
+            plans={
+                "report_kind": "qre_hypothesis_validation_plan",
+                "validation_plans": [
+                    {
+                        "hypothesis_id": HYPOTHESIS_ID,
+                        "validation_plan_id": PLAN_ID,
+                    }
+                ],
+            },
+            manifests={
+                "report_kind": "qre_research_run_manifest",
+                "run_manifests": [
+                    {
+                        "run_manifest_id": RUN_MANIFEST_ID,
+                        "target_hypothesis_id": HYPOTHESIS_ID,
+                        "target_validation_plan_id": PLAN_ID,
+                    }
+                ],
+            },
+        ),
+    )
+
+    assert row["hypothesis_id"] == EXECUTABLE_HYPOTHESIS_ID
+    assert row["executable_hypothesis_id"] == EXECUTABLE_HYPOTHESIS_ID
+    assert row["validation_plan_id"] is None
+    assert row["run_manifest_id"] is None
+    assert row["qre_validation_linkage_status"] == "linked_catalog_active_discovery"
+    assert row["qre_validation_linkage_warnings"] == []
+
+
 def test_ambiguous_executable_bridge_fails_closed_for_run_candidates() -> None:
     authority = _authority(
         hypotheses={

--- a/tests/unit/test_screening_evidence_validation_linkage.py
+++ b/tests/unit/test_screening_evidence_validation_linkage.py
@@ -149,6 +149,46 @@ def test_screening_evidence_executable_hypothesis_id_links_through_bridge() -> N
     assert row["qre_validation_linkage_warnings"] == []
 
 
+
+
+def test_catalog_active_discovery_hypothesis_links_without_exact_qre_ids() -> None:
+    row = _payload(
+        candidate={"hypothesis_id": EXECUTABLE_HYPOTHESIS_ID},
+        authority=_authority(
+            hypotheses={
+                "report_kind": "qre_hypothesis_candidates",
+                "hypotheses": [{"hypothesis_id": HYPOTHESIS_ID}],
+            },
+            plans={
+                "report_kind": "qre_hypothesis_validation_plan",
+                "validation_plans": [
+                    {
+                        "hypothesis_id": HYPOTHESIS_ID,
+                        "validation_plan_id": PLAN_ID,
+                    }
+                ],
+            },
+            manifests={
+                "report_kind": "qre_research_run_manifest",
+                "run_manifests": [
+                    {
+                        "run_manifest_id": RUN_MANIFEST_ID,
+                        "target_hypothesis_id": HYPOTHESIS_ID,
+                        "target_validation_plan_id": PLAN_ID,
+                    }
+                ],
+            },
+        ),
+    )["candidates"][0]
+
+    assert row["hypothesis_id"] == EXECUTABLE_HYPOTHESIS_ID
+    assert row["executable_hypothesis_id"] == EXECUTABLE_HYPOTHESIS_ID
+    assert row["validation_plan_id"] is None
+    assert row["run_manifest_id"] is None
+    assert row["qre_validation_linkage_status"] == "linked_catalog_active_discovery"
+    assert row["qre_validation_linkage_warnings"] == []
+
+
 def test_ambiguous_executable_bridge_fails_closed_for_screening_evidence() -> None:
     authority = _authority(
         hypotheses={
@@ -206,7 +246,7 @@ def test_ambiguous_executable_bridge_fails_closed_for_screening_evidence() -> No
 
 
 
-def test_summary_surfaces_sufficient_oos_candidate_blocked_by_qre_linkage() -> None:
+def test_summary_no_longer_counts_catalog_linked_sufficient_oos_as_qre_blocked() -> None:
     payload = _payload(
         candidate={
             "candidate_id": "hd-candidate",
@@ -227,13 +267,13 @@ def test_summary_surfaces_sufficient_oos_candidate_blocked_by_qre_linkage() -> N
     row = payload["candidates"][0]
     summary = payload["summary"]
 
-    assert row["qre_validation_linkage_status"] == "unlinked_unknown_hypothesis_id"
+    assert row["qre_validation_linkage_status"] == "linked_catalog_active_discovery"
     assert row["validation_evidence"]["status"] == "sufficient_oos_evidence"
     assert row["validation_evidence"]["oos_trade_count"] == 14
     assert row["validation_evidence"]["min_oos_trades"] == 10
     assert summary["sufficient_oos_evidence_candidates"] == 1
-    assert summary["sufficient_oos_but_unlinked_candidates"] == 1
-    assert summary["qre_linkage_blocked_candidates"] == 1
+    assert summary["sufficient_oos_but_unlinked_candidates"] == 0
+    assert summary["qre_linkage_blocked_candidates"] == 0
     assert summary["promotion_grade_candidates"] == 0
 
 


### PR DESCRIPTION
## Summary
- Treat strategy_hypothesis_catalog active-discovery hypotheses as bounded QRE linkage authority in validation evidence.
- Emit linked_catalog_active_discovery for catalog-authorized executable hypotheses when exact validation-plan/run-manifest IDs are absent.
- Preserve exact-id precedence and ambiguous executable bridge fail-closed behavior.
- Do not fabricate alidation_plan_id or un_manifest_id.

## Evidence
- python -m pytest tests/unit/test_screening_evidence_validation_linkage.py tests/unit/test_run_candidates_validation_linkage.py tests/architecture -q
  - 195 passed
- Runtime smoke:
  - un_candidates: 15 x linked_catalog_active_discovery
  - HD: linked_catalog_active_discovery
  - HD: oos_trade_count=14, min_oos_trades=10, esult_success=true
  - HD: alidation_plan_id=null, un_manifest_id=null

## Out of scope
- No strategy or preset mutation.
- No paper/shadow/live activation.
- No broker/risk/execution changes.
- Does not relax promotion criteria.
- Follow-up recommended: surface metric-level criteria_checks_json blockers in screening evidence / controlled-validation reports.