### PR TITLE
fix: surface promotion criteria blockers in screening evidence

### DIFF
--- a/research/screening_evidence.py
+++ b/research/screening_evidence.py
@@ -672,6 +672,26 @@ def _coerce_metrics(raw: dict[str, Any]) -> dict[str, float | None]:
     }
 
 
+def _criteria_check_blockers(raw: dict[str, Any]) -> list[str]:
+    """Return operator-facing blockers for failed metric criteria checks.
+
+    The screening evidence schema keeps ``promotion_guard`` as a two-key
+    block. Failed criteria are therefore surfaced as additional
+    ``blocked_by`` reasons instead of adding a new schema key.
+    """
+    criteria_checks = raw.get("criteria_checks")
+    if not isinstance(criteria_checks, dict):
+        return []
+
+    blockers: list[str] = []
+    for key in sorted(criteria_checks):
+        if criteria_checks.get(key) is False:
+            bounded_key = _bounded_str(key, max_len=80)
+            if bounded_key:
+                blockers.append(f"criteria_{bounded_key}_failed")
+    return blockers
+
+
 def _criteria_split(
     *,
     screening_phase: str | None,
@@ -729,7 +749,8 @@ def _build_candidate_record(
     else:
         candidate_id = str(raw_id)
 
-    metrics = _coerce_metrics(screening_record.get("diagnostic_metrics") or {})
+    diagnostic_metrics_raw = screening_record.get("diagnostic_metrics") or {}
+    metrics = _coerce_metrics(diagnostic_metrics_raw)
     failure_reasons: list[str] = []
     reason_code = screening_record.get("reason_code")
     if reason_code:
@@ -782,11 +803,18 @@ def _build_candidate_record(
 
     sampling = dict(screening_record.get("sampling") or {})
 
+    criteria_blockers = _criteria_check_blockers(diagnostic_metrics_raw)
+    promotion_guard_blockers = (
+        list(paper_blocking_reasons) if paper_blocking_reasons else []
+    )
+    promotion_guard_blockers.extend(criteria_blockers)
     promotion_guard = {
         "promotion_allowed": (
-            stage_result == STAGE_RESULT_DOWNSTREAM_PROMOTION and not paper_blocked
+            stage_result == STAGE_RESULT_DOWNSTREAM_PROMOTION
+            and not paper_blocked
+            and not criteria_blockers
         ),
-        "blocked_by": list(paper_blocking_reasons) if paper_blocking_reasons else [],
+        "blocked_by": promotion_guard_blockers,
     }
 
     hypothesis_id = (

--- a/research/screening_runtime.py
+++ b/research/screening_runtime.py
@@ -1995,6 +1995,10 @@ def execute_screening_candidate_samples(
         if legacy_decision["status"] == SCREENING_PROMOTED and promoted_metrics is not None
         else last_metrics
     )
+    selected_criteria_checks = build_exploratory_criteria_checks(
+        selected_metrics,
+        int(getattr(engine, "min_trades", 0) or 0),
+    )
     diagnostic_metrics = {
         "expectancy": float(selected_metrics.get("expectancy", 0.0)),
         "profit_factor": float(selected_metrics.get("profit_factor", 0.0)),
@@ -2002,6 +2006,7 @@ def execute_screening_candidate_samples(
         "max_drawdown": float(selected_metrics.get("max_drawdown", 0.0)),
         "totaal_trades": float(selected_metrics.get("totaal_trades", 0.0) or 0.0),
         "trades_per_maand": float(selected_metrics.get("trades_per_maand", 0.0) or 0.0),
+        "criteria_checks": dict(selected_criteria_checks or {}),
     }
     return {
         "legacy_decision": legacy_decision,

--- a/tests/unit/test_screening_runtime.py
+++ b/tests/unit/test_screening_runtime.py
@@ -502,6 +502,7 @@ def test_execute_screening_candidate_keeps_promoted_sample_when_later_sample_ins
     assert outcome["diagnostic_metrics"]["win_rate"] == 0.6
     assert outcome["diagnostic_metrics"]["totaal_trades"] == 12.0
     assert outcome["diagnostic_metrics"]["trades_per_maand"] == 1.0
+    assert outcome["diagnostic_metrics"]["criteria_checks"]
     assert outcome["sample_diagnostics_summary"] == {
         "sample_count": 2,
         "promoted_sample_count": 1,

--- a/tests/unit/test_v3_15_9_paper_blocked_graceful_degradation.py
+++ b/tests/unit/test_v3_15_9_paper_blocked_graceful_degradation.py
@@ -67,6 +67,39 @@ def test_empty_paper_blocked_index_does_not_block_artifact() -> None:
     assert payload["candidates"][0]["promotion_guard"]["blocked_by"] == []
 
 
+def test_failed_criteria_checks_surface_as_promotion_guard_blockers() -> None:
+    record = _passing_record()
+    record["diagnostic_metrics"]["criteria_checks"] = {
+        "consistentie": False,
+        "deflated_sharpe": True,
+        "max_drawdown": True,
+        "trades_per_maand": False,
+        "win_rate": False,
+    }
+
+    payload = build_screening_evidence_payload(
+        run_id="run-1",
+        as_of_utc=datetime(2026, 4, 26, tzinfo=UTC),
+        git_revision="abc",
+        campaign_id="cmp-1",
+        col_campaign_id="cmp-1",
+        preset_name="preset_a",
+        screening_phase="exploratory",
+        candidates=[_candidate()],
+        screening_records=[record],
+        screening_pass_kinds={"s1": "promotion_grade"},
+        paper_blocked_index={},
+    )
+
+    guard = payload["candidates"][0]["promotion_guard"]
+    assert guard["promotion_allowed"] is False
+    assert guard["blocked_by"] == [
+        "criteria_consistentie_failed",
+        "criteria_trades_per_maand_failed",
+        "criteria_win_rate_failed",
+    ]
+
+
 def test_missing_sidecar_returns_empty_dict(tmp_path, monkeypatch) -> None:
     monkeypatch.chdir(tmp_path)
     # No file exists at research/paper_readiness_latest.v1.json


### PR DESCRIPTION
## Summary
- Surface failed metric criteria checks as operator-facing promotion_guard.blocked_by reasons in screening evidence.
- Carry deterministic selected-sample criteria_checks into diagnostic_metrics.
- Preserve the existing promotion_guard schema: still exactly promotion_allowed and locked_by.
- Do not relax thresholds or change strategy/preset/campaign behavior.

## Evidence
- python -m pytest tests/unit/test_v3_15_9_paper_blocked_graceful_degradation.py tests/unit/test_v3_15_9_per_candidate_schema_pin.py tests/unit/test_screening_runtime.py -q
  - 35 passed
- python -m pytest tests/unit/test_v3_15_9_paper_blocked_graceful_degradation.py tests/unit/test_v3_15_9_per_candidate_schema_pin.py tests/unit/test_screening_runtime.py tests/unit/test_v3_15_9_fingerprints_and_json_safety.py tests/unit/test_v3_15_9_summary_aggregation.py tests/regression/test_v3_15_9_screening_evidence_schema_pin.py tests/architecture -q
  - 212 passed
- Extra contract/debug:
  - python -m pytest tests/unit/test_qre_hypothesis_validation_results.py tests/unit/test_v3_15_9_paper_blocked_graceful_degradation.py tests/unit/test_v3_15_9_per_candidate_schema_pin.py tests/unit/test_screening_runtime.py tests/regression/test_v3_15_9_screening_evidence_schema_pin.py tests/architecture -q
  - 210 passed
- Smoke proof:
  - HD-like sufficient-OOS candidate emits:
    - criteria_consistentie_failed
    - criteria_trades_per_maand_failed
    - criteria_win_rate_failed

## Out of scope
- No threshold changes.
- No strategy or preset mutation.
- No campaign queue mutation.
- No paper/shadow/live/broker/risk/execution changes.
- No QRE-linkage behavior change; #454 already handled catalog linkage.