### PR TITLE
fix: improve QRE controlled validation operability

### DIFF
--- a/docs/qre_equities_universe_preset_expansion_plan.md
+++ b/docs/qre_equities_universe_preset_expansion_plan.md
@@ -1,0 +1,204 @@
+# QRE Equities Universe And Preset Expansion Plan
+
+## Status
+
+This document is planning-only.
+
+It does not authorize:
+
+- strategy mutation
+- preset mutation
+- threshold relaxation
+- paper trading activation
+- shadow trading activation
+- live trading activation
+
+Current phase remains controlled validation and evidence review only.
+
+## Why This Plan Exists
+
+`equities_exploratory_v1` currently gives bounded diagnostic value, but its candidate set is too narrow to answer the broader user goal of equity research across:
+
+- Netherlands
+- Europe
+- United States
+- Asia
+
+The next expansion must improve research breadth without weakening discipline.
+
+## Current Known Limits
+
+Current diagnostics show:
+
+- one preset family dominates the exploratory run
+- 4h interval coverage is useful but narrow
+- linkage is working for catalog-authorized hypotheses
+- OOS evidence can exist without promotion
+- promotion is blocked by concrete criteria, not by missing linkage
+
+Operationally, the system is now able to distinguish:
+
+1. runtime gate failures
+2. public-result criteria failures
+3. OOS-evidence sufficiency
+4. stale runtime artifact interference
+
+That means the next expansion can be evidence-led instead of guess-led.
+
+## Expansion Axes
+
+The work must stay split across five separate questions.
+
+### 1. Universe Expansion
+
+Add more equities only after each candidate universe passes data and liquidity review.
+
+Candidate regional buckets:
+
+- Netherlands: `ASML`, `ADYEN`, `INGA`, `PHIA`, `SHELL`
+- Europe ex-NL: `SAP`, `SIE`, `MC`, `AIR`, `SU`, `NESN`
+- United States: `AAPL`, `MSFT`, `NVDA`, `AMD`, `AMZN`, `META`, `GOOGL`, `JPM`, `XOM`, `HD`, `COST`
+- Asia: `TSM`, `SONY`, `7203.T`, `9988.HK`, `005930.KS`
+
+These are planning candidates, not approved runtime defaults.
+
+### 2. Interval Expansion
+
+Intervals must be assessed separately from universe growth.
+
+Recommended review order:
+
+1. keep `4h` as the baseline comparison point
+2. evaluate whether `1d` adds cleaner trend structure
+3. consider `1h` only after higher-timeframe equity evidence is stable
+
+Do not add multiple new intervals in the same hypothesis test unless the test goal explicitly requires it.
+
+### 3. Strategy Family Expansion
+
+Trend remains the primary research direction.
+
+Safe order:
+
+1. strengthen the current trend family diagnosis
+2. add one adjacent trend family only if it tests a distinct hypothesis
+3. keep mean reversion deprioritized for this track unless new equity evidence justifies reopening it
+
+No new family should be added merely to increase candidate count.
+
+### 4. Threshold Review
+
+Thresholds may be reviewed analytically, but not relaxed by default.
+
+The review should answer:
+
+- which criteria block most often
+- whether the blockers reflect poor strategy quality or poor universe fit
+- whether any criterion is structurally mismatched to slower equity trend strategies
+
+Any threshold change must be its own scoped decision with isolated evidence.
+
+### 5. Liquidity And Data Availability
+
+Assets must satisfy both market quality and reproducibility constraints.
+
+Admission criteria:
+
+- reliable historical data source availability
+- stable ticker mapping across providers
+- sufficient traded volume for the selected interval
+- low risk of frequent splits, symbol changes, or missing-session artifacts corrupting comparisons
+- reproducible retrieval through the existing data boundary
+
+If a region cannot meet these requirements, it stays out until data readiness is proven.
+
+## Universe Admission Rules
+
+A candidate equity or ETF should only enter an exploratory universe when all conditions below are met:
+
+1. the symbol is easy to map deterministically
+2. historical bars are available over the required OOS window
+3. trading sessions and timezone handling are understood
+4. liquidity is high enough that trade counts are meaningful
+5. the asset adds diversity rather than duplicating an already-covered exposure
+
+Preferred early composition:
+
+- broad US large caps
+- a small Europe sample
+- a small Asia sample
+- Netherlands as a distinct local bucket, not merged away
+
+## Preset Expansion Rules
+
+Preset expansion is not approved in this document.
+
+When preset work begins later, it should follow:
+
+1. preserve the registry and package authority boundaries
+2. create one new exploratory preset at a time
+3. tie each preset to a written hypothesis
+4. compare against the existing `equities_exploratory_v1` baseline
+5. preserve negative results
+
+## Overfitting Controls
+
+The expansion must avoid turning the exploratory preset into a hidden parameter sweep.
+
+Controls:
+
+- no brute-force parameter search
+- no region-specific tuning before cross-region evidence exists
+- no interval-specific threshold loosening without a separate review
+- no adding assets solely because they improve one recent run
+- no silent exclusion of failing assets from diagnostics
+
+Failure memory must remain visible in reports and fixtures.
+
+## Hypothesis Selector Guardrails
+
+When later work allows broader hypothesis selection, the selector may draw from approved universes only.
+
+It must not:
+
+- invent unapproved assets
+- promote paper/live capability
+- treat this plan as execution authority
+- bypass catalog, registry, or controlled validation policy
+
+## Safe Rollout Sequence
+
+The default rollout order is:
+
+1. diagnostic only
+2. controlled validation
+3. evidence review
+4. paper-readiness review only if gates pass
+5. never live trading under this plan
+
+Paper-readiness remains future-gated and does not follow automatically from better exploratory evidence.
+
+## Explicit Non-Goals
+
+This plan does not:
+
+- activate paper, shadow, or live runtime
+- authorize broker, risk, or execution changes
+- mutate frozen contracts
+- approve threshold changes
+- approve preset changes
+- promise region coverage by a fixed date
+
+## Next Research Step After This PR
+
+The next research-facing branch should stay diagnostic:
+
+`diagnose/equities-exploratory-v1-blockers`
+
+That branch can decide, with evidence, whether the next move is:
+
+- universe expansion
+- interval expansion
+- preset expansion
+- strategy-family expansion
+- threshold analysis only

--- a/reporting/qre_controlled_validation_execution.py
+++ b/reporting/qre_controlled_validation_execution.py
@@ -35,6 +35,21 @@ REQUIRED_OPERATOR_GO_PHRASE: Final[str] = (
     "I authorize QRE controlled validation execution"
 )
 
+STALE_RUNTIME_ARTIFACT_RELATIVE_PATHS: Final[tuple[str, ...]] = (
+    "research/campaign_registry_latest.v1.json",
+    "research/campaign_queue_latest.v1.json",
+    "research/campaign_digest_latest.v1.json",
+    "research/screening_evidence_latest.v1.json",
+    "research/run_candidates_latest.v1.json",
+    "research/run_campaign_latest.v1.json",
+    "research/run_campaign_progress_latest.v1.json",
+    "research/run_state.v1.json",
+    "research/paper_readiness_latest.v1.json",
+    "logs/qre_controlled_validation_execution/controlled_eval_latest.v1.json",
+    "logs/qre_controlled_validation_execution/controlled_eval_latest.md",
+    "logs/qre_controlled_validation_execution/latest.json",
+)
+
 EXECUTION_BLOCKED_NOT_REQUESTED: Final[str] = "execution_blocked_not_requested"
 EXECUTION_BLOCKED_PREFLIGHT_NOT_READY: Final[str] = "execution_blocked_preflight_not_ready"
 EXECUTION_BLOCKED_BRIDGE_NOT_READY: Final[str] = "execution_blocked_bridge_not_ready"
@@ -153,6 +168,107 @@ def _runner_report_paths() -> dict[str, str]:
     }
 
 
+def _read_text_if_possible(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return ""
+
+
+def _history_manifest_paths_for_campaign_id(campaign_id: str) -> list[Path]:
+    if not campaign_id:
+        return []
+    matches: list[Path] = []
+    history_root = REPO_ROOT / "research" / "history"
+    if not history_root.exists():
+        return matches
+    for candidate in history_root.glob("*/run_campaign_manifest.v1.json"):
+        text = _read_text_if_possible(candidate)
+        if campaign_id in text:
+            matches.append(candidate)
+    for candidate in history_root.glob("*/run_state.v1.json"):
+        text = _read_text_if_possible(candidate)
+        if campaign_id in text:
+            matches.append(candidate)
+    return matches
+
+
+def _stale_runtime_artifact_paths(missing_campaign_ids: list[str]) -> list[str]:
+    if not missing_campaign_ids:
+        return []
+
+    paths: list[str] = []
+    seen: set[str] = set()
+
+    for relative in STALE_RUNTIME_ARTIFACT_RELATIVE_PATHS:
+        path = REPO_ROOT / relative
+        if not path.is_file():
+            continue
+        text = _read_text_if_possible(path)
+        if any(campaign_id in text for campaign_id in missing_campaign_ids):
+            rel = _rel(path)
+            if rel not in seen:
+                seen.add(rel)
+                paths.append(rel)
+
+    for campaign_id in missing_campaign_ids:
+        for path in _history_manifest_paths_for_campaign_id(campaign_id):
+            rel = _rel(path)
+            if rel not in seen:
+                seen.add(rel)
+                paths.append(rel)
+
+    return sorted(paths)
+
+
+def _quarantine_runtime_artifact_command_preview(
+    stale_relative_paths: list[str],
+) -> list[str]:
+    if not stale_relative_paths:
+        return []
+    target_root = "logs/qre_controlled_validation_execution/quarantine/<timestamp>"
+    commands = [
+        f"$target = '{target_root}'",
+        "New-Item -ItemType Directory -Force -Path $target | Out-Null",
+    ]
+    for relative in stale_relative_paths:
+        destination = f"$target/{relative.replace('/', '__')}"
+        commands.append(
+            f"Move-Item -LiteralPath '{relative}' -Destination '{destination}' -Force"
+        )
+    return commands
+
+
+def _campaign_invariant_failure_diagnostics(
+    *,
+    completed_campaign_count: int,
+    campaign_completed_ledger_event_count: int,
+    missing_completed_ledger_event_ids: list[str],
+) -> dict[str, Any]:
+    stale_files = _stale_runtime_artifact_paths(missing_completed_ledger_event_ids)
+    return {
+        "stale_campaign_ids": list(missing_completed_ledger_event_ids),
+        "active_stale_files": stale_files,
+        "completed_campaign_count_per_source": {
+            "research/campaign_registry_latest.v1.json": completed_campaign_count,
+        },
+        "ledger_event_count_per_source": {
+            "research/campaign_evidence_ledger_latest.v1.jsonl": (
+                campaign_completed_ledger_event_count
+            ),
+        },
+        "suggested_operator_action": (
+            "Review the missing campaign_completed ledger events, then quarantine only "
+            "the listed generated runtime artifacts before re-running controlled validation."
+        ),
+        "safe_cleanup_available": bool(stale_files),
+        "safe_cleanup_mode": "operator_quarantine_only",
+        "quarantine_command_preview": _quarantine_runtime_artifact_command_preview(
+            stale_files
+        ),
+    }
+
+
 def _campaign_invariant_preflight() -> dict[str, Any]:
     try:
         import importlib
@@ -166,6 +282,7 @@ def _campaign_invariant_preflight() -> dict[str, Any]:
             "completed_campaign_count": 0,
             "campaign_completed_ledger_event_count": 0,
             "missing_completed_ledger_event_ids": [],
+            "diagnostics": {},
         }
 
     registry_path = getattr(registry_module, "REGISTRY_ARTIFACT_PATH", None)
@@ -178,6 +295,7 @@ def _campaign_invariant_preflight() -> dict[str, Any]:
             "completed_campaign_count": 0,
             "campaign_completed_ledger_event_count": 0,
             "missing_completed_ledger_event_ids": [],
+            "diagnostics": {},
         }
 
     try:
@@ -190,6 +308,7 @@ def _campaign_invariant_preflight() -> dict[str, Any]:
             "completed_campaign_count": 0,
             "campaign_completed_ledger_event_count": 0,
             "missing_completed_ledger_event_ids": [],
+            "diagnostics": {},
         }
 
     campaigns = registry.get("campaigns") if isinstance(registry, dict) else {}
@@ -217,11 +336,21 @@ def _campaign_invariant_preflight() -> dict[str, Any]:
         completed_campaign_ids - campaign_completed_ledger_ids
     )
     status = "failed" if missing_completed_ledger_event_ids else "passed"
+    diagnostics = (
+        _campaign_invariant_failure_diagnostics(
+            completed_campaign_count=len(completed_campaign_ids),
+            campaign_completed_ledger_event_count=len(campaign_completed_ledger_ids),
+            missing_completed_ledger_event_ids=missing_completed_ledger_event_ids,
+        )
+        if missing_completed_ledger_event_ids
+        else {}
+    )
     return {
         "status": status,
         "completed_campaign_count": len(completed_campaign_ids),
         "campaign_completed_ledger_event_count": len(campaign_completed_ledger_ids),
         "missing_completed_ledger_event_ids": missing_completed_ledger_event_ids,
+        "diagnostics": diagnostics,
     }
 
 

--- a/reporting/qre_controlled_validation_result_analysis.py
+++ b/reporting/qre_controlled_validation_result_analysis.py
@@ -257,10 +257,14 @@ def _operator_summary(
     blocked_reasons: list[str] = []
     failure_reasons: list[str] = []
     asset_rows: list[dict[str, Any]] = []
+    runtime_gate_failed_assets: list[str] = []
+    public_result_criteria_blocked_assets: list[str] = []
+    near_pass_assets: list[str] = []
 
     for row in sorted(candidates, key=lambda item: str(item.get("asset") or "")):
         op_row = _candidate_operator_row(row)
         asset_rows.append(op_row)
+        asset = op_row["asset"]
         if op_row["qre_validation_linkage_status"] == "linked_catalog_active_discovery":
             linked_count += 1
         if op_row["validation_evidence_status"] == "sufficient_oos_evidence":
@@ -269,8 +273,16 @@ def _operator_summary(
             promotion_allowed_count += 1
         else:
             blocked_reasons.extend(str(reason) for reason in op_row["blocked_by"])
+        if op_row["failure_reasons"]:
+            runtime_gate_failed_assets.append(asset)
+        if (
+            op_row["stage_result"] == "screening_pass"
+            and op_row["promotion_allowed"] is False
+        ):
+            public_result_criteria_blocked_assets.append(asset)
         if op_row["near_pass"]:
             near_pass_count += 1
+            near_pass_assets.append(asset)
         failure_reasons.extend(str(reason) for reason in op_row["failure_reasons"])
 
     total_candidates = int(screening_summary.get("total_candidates") or len(candidates))
@@ -293,6 +305,9 @@ def _operator_summary(
         "near_pass_count": near_pass_count,
         "top_promotion_blockers": _top_counts(blocked_reasons),
         "top_failure_reasons": _top_counts(failure_reasons),
+        "runtime_gate_failed_assets": runtime_gate_failed_assets,
+        "public_result_criteria_blocked_assets": public_result_criteria_blocked_assets,
+        "near_pass_assets": near_pass_assets,
         "selected_asset_explanations": asset_rows,
         "campaign_verdict": verdict_status,
         "next_recommendation": next_recommendation,

--- a/reporting/qre_controlled_validation_result_analysis.py
+++ b/reporting/qre_controlled_validation_result_analysis.py
@@ -11,6 +11,9 @@ from typing import Any, Final
 from reporting import qre_controlled_validation_execution as execution
 
 REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+SCREENING_EVIDENCE_LATEST: Final[Path] = (
+    REPO_ROOT / "research" / "screening_evidence_latest.v1.json"
+)
 
 SCHEMA_VERSION: Final[int] = 1
 REPORT_KIND: Final[str] = "qre_controlled_validation_result_analysis"
@@ -177,6 +180,135 @@ def _controlled_eval_report_summary(
     }
 
 
+def _screening_evidence_candidates(
+    screening_evidence_payload: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    payload = screening_evidence_payload
+    if payload is None:
+        payload = _read_json(SCREENING_EVIDENCE_LATEST)
+    candidates = (payload or {}).get("candidates")
+    if not isinstance(candidates, list):
+        return []
+    return [row for row in candidates if isinstance(row, dict)]
+
+
+def _top_counts(values: list[str], *, limit: int = 5) -> list[dict[str, Any]]:
+    counts: dict[str, int] = {}
+    for value in values:
+        key = str(value or "").strip()
+        if not key:
+            continue
+        counts[key] = counts.get(key, 0) + 1
+    ordered = sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+    return [{"reason": reason, "count": count} for reason, count in ordered[:limit]]
+
+
+def _candidate_operator_row(row: dict[str, Any]) -> dict[str, Any]:
+    validation = row.get("validation_evidence")
+    if not isinstance(validation, dict):
+        validation = {}
+    promotion_guard = row.get("promotion_guard")
+    if not isinstance(promotion_guard, dict):
+        promotion_guard = {}
+    metrics = row.get("metrics")
+    if not isinstance(metrics, dict):
+        metrics = {}
+    failure_reasons = row.get("failure_reasons")
+    if not isinstance(failure_reasons, list):
+        failure_reasons = []
+    return {
+        "asset": str(row.get("asset") or ""),
+        "preset_name": row.get("preset_name"),
+        "strategy_name": row.get("strategy_name"),
+        "interval": row.get("interval"),
+        "stage_result": row.get("stage_result"),
+        "qre_validation_linkage_status": row.get("qre_validation_linkage_status"),
+        "validation_evidence_status": validation.get("status"),
+        "oos_trade_count": validation.get("oos_trade_count"),
+        "min_oos_trades": validation.get("min_oos_trades"),
+        "promotion_allowed": promotion_guard.get("promotion_allowed") is True,
+        "blocked_by": list(promotion_guard.get("blocked_by") or []),
+        "failure_reasons": list(failure_reasons),
+        "near_pass": bool((row.get("near_pass") or {}).get("is_near_pass")),
+        "metrics": {
+            "win_rate": metrics.get("win_rate"),
+            "trades_per_maand": metrics.get("trades_per_maand"),
+            "consistentie": metrics.get("consistentie"),
+            "deflated_sharpe": metrics.get("deflated_sharpe"),
+        },
+    }
+
+
+def _operator_summary(
+    *,
+    controlled_eval_summary: dict[str, Any],
+    execution_summary: dict[str, Any],
+    screening_evidence_payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    candidates = _screening_evidence_candidates(screening_evidence_payload)
+    screening_summary = controlled_eval_summary.get("screening_evidence_summary")
+    if not isinstance(screening_summary, dict):
+        screening_summary = {}
+
+    linked_count = 0
+    sufficient_oos_count = 0
+    promotion_allowed_count = 0
+    near_pass_count = 0
+    blocked_reasons: list[str] = []
+    failure_reasons: list[str] = []
+    asset_rows: list[dict[str, Any]] = []
+
+    for row in sorted(candidates, key=lambda item: str(item.get("asset") or "")):
+        op_row = _candidate_operator_row(row)
+        asset_rows.append(op_row)
+        if op_row["qre_validation_linkage_status"] == "linked_catalog_active_discovery":
+            linked_count += 1
+        if op_row["validation_evidence_status"] == "sufficient_oos_evidence":
+            sufficient_oos_count += 1
+        if op_row["promotion_allowed"]:
+            promotion_allowed_count += 1
+        else:
+            blocked_reasons.extend(str(reason) for reason in op_row["blocked_by"])
+        if op_row["near_pass"]:
+            near_pass_count += 1
+        failure_reasons.extend(str(reason) for reason in op_row["failure_reasons"])
+
+    total_candidates = int(screening_summary.get("total_candidates") or len(candidates))
+    promotion_blocked_count = max(total_candidates - promotion_allowed_count, 0)
+    verdict_status = controlled_eval_summary.get("verdict_status")
+    next_recommendation = (
+        controlled_eval_summary.get("recommended_next_action")
+        or execution_summary.get("final_recommendation")
+    )
+    freshness = controlled_eval_summary.get("artifact_freshness")
+    if not isinstance(freshness, dict):
+        freshness = {}
+
+    return {
+        "total_candidates": total_candidates,
+        "linked_catalog_active_discovery_count": linked_count,
+        "sufficient_oos_evidence_count": sufficient_oos_count,
+        "promotion_allowed_count": promotion_allowed_count,
+        "promotion_blocked_count": promotion_blocked_count,
+        "near_pass_count": near_pass_count,
+        "top_promotion_blockers": _top_counts(blocked_reasons),
+        "top_failure_reasons": _top_counts(failure_reasons),
+        "selected_asset_explanations": asset_rows,
+        "campaign_verdict": verdict_status,
+        "next_recommendation": next_recommendation,
+        "safety_flags": {
+            "artifact_may_be_stale": freshness.get("artifact_may_be_stale") is True,
+            "controlled_validation_authorized": (
+                execution_summary.get("controlled_validation_authorized") is True
+            ),
+            "runner_adapter_status": execution_summary.get("runner_adapter_status"),
+            "mutates_paper_shadow_live_runtime": False,
+            "writes_development_work_queue": False,
+            "writes_research_action_queue": False,
+        },
+    }
+
+
 def _evidence_quality_bottleneck(
     *,
     controlled_eval_summary: dict[str, Any],
@@ -301,6 +433,7 @@ def collect_snapshot(
     execution_snapshot: dict[str, Any] | None = None,
     generated_at_utc: str | None = None,
     current_git_revision: str | None = None,
+    screening_evidence_payload: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     generated = generated_at_utc or _utcnow()
     active_execution = execution_snapshot or execution.collect_snapshot(
@@ -331,6 +464,21 @@ def collect_snapshot(
     evidence_refs = []
     if controlled_eval_summary.get("path"):
         evidence_refs.append(str(controlled_eval_summary["path"]))
+    execution_summary = {
+        "report_kind": active_execution.get("report_kind"),
+        "execution_status": active_execution.get("execution_status"),
+        "controlled_validation_authorized": (
+            active_execution.get("controlled_validation_authorized") is True
+        ),
+        "runner_adapter_status": active_execution.get("runner_adapter_status"),
+        "executed_anything": active_execution.get("executed_anything") is True,
+        "final_recommendation": active_execution.get("final_recommendation"),
+    }
+    operator_summary = _operator_summary(
+        controlled_eval_summary=controlled_eval_summary,
+        execution_summary=execution_summary,
+        screening_evidence_payload=screening_evidence_payload,
+    )
 
     return {
         "report_kind": REPORT_KIND,
@@ -355,16 +503,7 @@ def collect_snapshot(
         "analysis_status": status,
         "final_recommendation": _final_recommendation(status),
         "counts": _counts(status),
-        "execution_summary": {
-            "report_kind": active_execution.get("report_kind"),
-            "execution_status": active_execution.get("execution_status"),
-            "controlled_validation_authorized": (
-                active_execution.get("controlled_validation_authorized") is True
-            ),
-            "runner_adapter_status": active_execution.get("runner_adapter_status"),
-            "executed_anything": active_execution.get("executed_anything") is True,
-            "final_recommendation": active_execution.get("final_recommendation"),
-        },
+        "execution_summary": execution_summary,
         "controlled_eval_report": controlled_eval_summary,
         "result_summary": {
             "completed_run_available": status == ANALYSIS_READY,
@@ -380,6 +519,7 @@ def collect_snapshot(
             "evidence_quality_bottleneck": evidence_quality_bottleneck,
             "evidence_refs": evidence_refs,
         },
+        "operator_summary": operator_summary,
         "next_required_step": (
             "connect controlled validation runner before result analysis"
             if status == ANALYSIS_BLOCKED_RUNNER_NOT_CONNECTED

--- a/tests/fixtures/qre_controlled_validation/equities_exploratory_v1_blocker_diagnosis.json
+++ b/tests/fixtures/qre_controlled_validation/equities_exploratory_v1_blocker_diagnosis.json
@@ -1,0 +1,230 @@
+{
+  "execution_snapshot": {
+    "report_kind": "qre_controlled_validation_execution",
+    "selection_profile_name": "equities_exploratory_v1",
+    "execution_status": "execution_completed",
+    "controlled_validation_authorized": true,
+    "runner_adapter_status": "connected",
+    "executed_anything": true,
+    "final_recommendation": "controlled_validation_execution_completed"
+  },
+  "controlled_eval_report": {
+    "verdict": {
+      "status": "useful_observation",
+      "reason_codes": []
+    },
+    "campaigns_completed": 1,
+    "campaign_level_evidence_valid": true,
+    "recommended_next_action": "inspect_results",
+    "git_revision": "abc123",
+    "screening_evidence_summary": {
+      "present": true,
+      "total_candidates": 15,
+      "passed_screening": 6,
+      "rejected_screening": 9,
+      "promotion_grade_candidates": 0,
+      "sufficient_oos_evidence_candidates": 1,
+      "qre_linkage_blocked_candidates": 0,
+      "sufficient_oos_but_unlinked_candidates": 0
+    }
+  },
+  "screening_evidence_payload": {
+    "candidates": [
+      {
+        "asset": "AAPL",
+        "preset_name": "trend_pullback_equities_4h",
+        "strategy_name": "trend_pullback_v1",
+        "interval": "4h",
+        "stage_result": "screening_pass",
+        "qre_validation_linkage_status": "linked_catalog_active_discovery",
+        "validation_evidence": {"status": "no_oos_trades", "oos_trade_count": 0, "min_oos_trades": 10},
+        "promotion_guard": {"promotion_allowed": false, "blocked_by": ["criteria_consistentie_failed", "criteria_deflated_sharpe_failed", "criteria_trades_per_maand_failed", "criteria_win_rate_failed"]},
+        "failure_reasons": [],
+        "near_pass": {"is_near_pass": false},
+        "metrics": {"win_rate": 0.49, "trades_per_maand": 1.3, "consistentie": 0.2, "deflated_sharpe": 0.1}
+      },
+      {
+        "asset": "AMD",
+        "preset_name": "trend_pullback_equities_4h",
+        "strategy_name": "trend_pullback_v1",
+        "interval": "4h",
+        "stage_result": "screening_reject",
+        "qre_validation_linkage_status": "linked_catalog_active_discovery",
+        "validation_evidence": {"status": "no_oos_trades", "oos_trade_count": 0, "min_oos_trades": 10},
+        "promotion_guard": {"promotion_allowed": false, "blocked_by": ["criteria_expectancy_above_zero_failed", "criteria_profit_factor_at_or_above_floor_failed", "criteria_sufficient_trades_failed"]},
+        "failure_reasons": ["insufficient_trades"],
+        "near_pass": {"is_near_pass": false},
+        "metrics": {"win_rate": 0.0, "trades_per_maand": 0.0, "consistentie": null, "deflated_sharpe": null}
+      },
+      {
+        "asset": "AMZN",
+        "preset_name": "trend_pullback_equities_4h",
+        "strategy_name": "trend_pullback_v1",
+        "interval": "4h",
+        "stage_result": "screening_reject",
+        "qre_validation_linkage_status": "linked_catalog_active_discovery",
+        "validation_evidence": {"status": "no_oos_trades", "oos_trade_count": 0, "min_oos_trades": 10},
+        "promotion_guard": {"promotion_allowed": false, "blocked_by": ["criteria_expectancy_above_zero_failed", "criteria_profit_factor_at_or_above_floor_failed", "criteria_sufficient_trades_failed"]},
+        "failure_reasons": ["insufficient_trades"],
+        "near_pass": {"is_near_pass": false},
+        "metrics": {"win_rate": 0.0, "trades_per_maand": 0.0, "consistentie": null, "deflated_sharpe": null}
+      },
+      {
+        "asset": "ASML",
+        "preset_name": "trend_pullback_equities_4h",
+        "strategy_name": "trend_pullback_v1",
+        "interval": "4h",
+        "stage_result": "screening_pass",
+        "qre_validation_linkage_status": "linked_catalog_active_discovery",
+        "validation_evidence": {"status": "no_oos_trades", "oos_trade_count": 0, "min_oos_trades": 10},
+        "promotion_guard": {"promotion_allowed": false, "blocked_by": ["criteria_consistentie_failed", "criteria_deflated_sharpe_failed", "criteria_trades_per_maand_failed", "criteria_win_rate_failed"]},
+        "failure_reasons": [],
+        "near_pass": {"is_near_pass": false},
+        "metrics": {"win_rate": 0.47, "trades_per_maand": 1.0, "consistentie": 0.25, "deflated_sharpe": 0.2}
+      },
+      {
+        "asset": "AVGO",
+        "preset_name": "trend_pullback_equities_4h",
+        "strategy_name": "trend_pullback_v1",
+        "interval": "4h",
+        "stage_result": "screening_reject",
+        "qre_validation_linkage_status": "linked_catalog_active_discovery",
+        "validation_evidence": {"status": "no_oos_trades", "oos_trade_count": 0, "min_oos_trades": 10},
+        "promotion_guard": {"promotion_allowed": false, "blocked_by": ["criteria_expectancy_above_zero_failed", "criteria_profit_factor_at_or_above_floor_failed", "criteria_sufficient_trades_failed"]},
+        "failure_reasons": ["insufficient_trades"],
+        "near_pass": {"is_near_pass": false},
+        "metrics": {"win_rate": 0.0, "trades_per_maand": 0.0, "consistentie": null, "deflated_sharpe": null}
+      },
+      {
+        "asset": "COST",
+        "preset_name": "trend_pullback_equities_4h",
+        "strategy_name": "trend_pullback_v1",
+        "interval": "4h",
+        "stage_result": "screening_pass",
+        "qre_validation_linkage_status": "linked_catalog_active_discovery",
+        "validation_evidence": {"status": "no_oos_trades", "oos_trade_count": 0, "min_oos_trades": 10},
+        "promotion_guard": {"promotion_allowed": false, "blocked_by": ["criteria_consistentie_failed", "criteria_deflated_sharpe_failed", "criteria_trades_per_maand_failed", "criteria_win_rate_failed"]},
+        "failure_reasons": [],
+        "near_pass": {"is_near_pass": false},
+        "metrics": {"win_rate": 0.46, "trades_per_maand": 1.2, "consistentie": 0.3, "deflated_sharpe": 0.15}
+      },
+      {
+        "asset": "GOOGL",
+        "preset_name": "trend_pullback_equities_4h",
+        "strategy_name": "trend_pullback_v1",
+        "interval": "4h",
+        "stage_result": "screening_reject",
+        "qre_validation_linkage_status": "linked_catalog_active_discovery",
+        "validation_evidence": {"status": "no_oos_trades", "oos_trade_count": 0, "min_oos_trades": 10},
+        "promotion_guard": {"promotion_allowed": false, "blocked_by": ["criteria_expectancy_above_zero_failed", "criteria_profit_factor_at_or_above_floor_failed", "criteria_sufficient_trades_failed"]},
+        "failure_reasons": ["insufficient_trades"],
+        "near_pass": {"is_near_pass": false},
+        "metrics": {"win_rate": 0.0, "trades_per_maand": 0.0, "consistentie": null, "deflated_sharpe": null}
+      },
+      {
+        "asset": "HD",
+        "preset_name": "trend_pullback_equities_4h",
+        "strategy_name": "trend_pullback_v1",
+        "interval": "4h",
+        "stage_result": "screening_pass",
+        "qre_validation_linkage_status": "linked_catalog_active_discovery",
+        "validation_evidence": {"status": "sufficient_oos_evidence", "oos_trade_count": 14, "min_oos_trades": 10},
+        "promotion_guard": {"promotion_allowed": false, "blocked_by": ["criteria_consistentie_failed", "criteria_trades_per_maand_failed", "criteria_win_rate_failed"]},
+        "failure_reasons": [],
+        "near_pass": {"is_near_pass": false},
+        "metrics": {"win_rate": 0.5, "trades_per_maand": 1.1, "consistentie": 0.333, "deflated_sharpe": 0.534}
+      },
+      {
+        "asset": "JPM",
+        "preset_name": "trend_pullback_equities_4h",
+        "strategy_name": "trend_pullback_v1",
+        "interval": "4h",
+        "stage_result": "screening_pass",
+        "qre_validation_linkage_status": "linked_catalog_active_discovery",
+        "validation_evidence": {"status": "no_oos_trades", "oos_trade_count": 0, "min_oos_trades": 10},
+        "promotion_guard": {"promotion_allowed": false, "blocked_by": ["criteria_consistentie_failed", "criteria_deflated_sharpe_failed", "criteria_trades_per_maand_failed", "criteria_win_rate_failed"]},
+        "failure_reasons": [],
+        "near_pass": {"is_near_pass": false},
+        "metrics": {"win_rate": 0.48, "trades_per_maand": 1.4, "consistentie": 0.31, "deflated_sharpe": 0.18}
+      },
+      {
+        "asset": "LLY",
+        "preset_name": "trend_pullback_equities_4h",
+        "strategy_name": "trend_pullback_v1",
+        "interval": "4h",
+        "stage_result": "screening_reject",
+        "qre_validation_linkage_status": "linked_catalog_active_discovery",
+        "validation_evidence": {"status": "no_oos_trades", "oos_trade_count": 0, "min_oos_trades": 10},
+        "promotion_guard": {"promotion_allowed": false, "blocked_by": ["criteria_expectancy_above_zero_failed", "criteria_profit_factor_at_or_above_floor_failed", "criteria_sufficient_trades_failed"]},
+        "failure_reasons": ["insufficient_trades"],
+        "near_pass": {"is_near_pass": false},
+        "metrics": {"win_rate": 0.0, "trades_per_maand": 0.0, "consistentie": null, "deflated_sharpe": null}
+      },
+      {
+        "asset": "META",
+        "preset_name": "trend_pullback_equities_4h",
+        "strategy_name": "trend_pullback_v1",
+        "interval": "4h",
+        "stage_result": "screening_reject",
+        "qre_validation_linkage_status": "linked_catalog_active_discovery",
+        "validation_evidence": {"status": "no_oos_trades", "oos_trade_count": 0, "min_oos_trades": 10},
+        "promotion_guard": {"promotion_allowed": false, "blocked_by": ["criteria_expectancy_above_zero_failed", "criteria_profit_factor_at_or_above_floor_failed", "criteria_sufficient_trades_failed"]},
+        "failure_reasons": ["insufficient_trades"],
+        "near_pass": {"is_near_pass": false},
+        "metrics": {"win_rate": 0.0, "trades_per_maand": 0.0, "consistentie": null, "deflated_sharpe": null}
+      },
+      {
+        "asset": "MSFT",
+        "preset_name": "trend_pullback_equities_4h",
+        "strategy_name": "trend_pullback_v1",
+        "interval": "4h",
+        "stage_result": "screening_reject",
+        "qre_validation_linkage_status": "linked_catalog_active_discovery",
+        "validation_evidence": {"status": "no_oos_trades", "oos_trade_count": 0, "min_oos_trades": 10},
+        "promotion_guard": {"promotion_allowed": false, "blocked_by": ["criteria_expectancy_above_zero_failed", "criteria_profit_factor_at_or_above_floor_failed", "criteria_sufficient_trades_failed"]},
+        "failure_reasons": ["insufficient_trades"],
+        "near_pass": {"is_near_pass": false},
+        "metrics": {"win_rate": 0.0, "trades_per_maand": 0.0, "consistentie": null, "deflated_sharpe": null}
+      },
+      {
+        "asset": "NVDA",
+        "preset_name": "trend_pullback_equities_4h",
+        "strategy_name": "trend_pullback_v1",
+        "interval": "4h",
+        "stage_result": "screening_reject",
+        "qre_validation_linkage_status": "linked_catalog_active_discovery",
+        "validation_evidence": {"status": "no_oos_trades", "oos_trade_count": 0, "min_oos_trades": 10},
+        "promotion_guard": {"promotion_allowed": false, "blocked_by": ["criteria_expectancy_above_zero_failed", "criteria_profit_factor_at_or_above_floor_failed", "criteria_sufficient_trades_failed"]},
+        "failure_reasons": ["insufficient_trades"],
+        "near_pass": {"is_near_pass": false},
+        "metrics": {"win_rate": 0.0, "trades_per_maand": 0.0, "consistentie": null, "deflated_sharpe": null}
+      },
+      {
+        "asset": "TSM",
+        "preset_name": "trend_pullback_equities_4h",
+        "strategy_name": "trend_pullback_v1",
+        "interval": "4h",
+        "stage_result": "screening_reject",
+        "qre_validation_linkage_status": "linked_catalog_active_discovery",
+        "validation_evidence": {"status": "no_oos_trades", "oos_trade_count": 0, "min_oos_trades": 10},
+        "promotion_guard": {"promotion_allowed": false, "blocked_by": ["criteria_expectancy_above_zero_failed", "criteria_profit_factor_at_or_above_floor_failed", "criteria_sufficient_trades_failed"]},
+        "failure_reasons": ["insufficient_trades"],
+        "near_pass": {"is_near_pass": false},
+        "metrics": {"win_rate": 0.0, "trades_per_maand": 0.0, "consistentie": null, "deflated_sharpe": null}
+      },
+      {
+        "asset": "XOM",
+        "preset_name": "trend_pullback_equities_4h",
+        "strategy_name": "trend_pullback_v1",
+        "interval": "4h",
+        "stage_result": "screening_pass",
+        "qre_validation_linkage_status": "linked_catalog_active_discovery",
+        "validation_evidence": {"status": "no_oos_trades", "oos_trade_count": 0, "min_oos_trades": 10},
+        "promotion_guard": {"promotion_allowed": false, "blocked_by": ["criteria_consistentie_failed", "criteria_deflated_sharpe_failed", "criteria_trades_per_maand_failed", "criteria_win_rate_failed"]},
+        "failure_reasons": [],
+        "near_pass": {"is_near_pass": false},
+        "metrics": {"win_rate": 0.47, "trades_per_maand": 1.2, "consistentie": 0.29, "deflated_sharpe": 0.17}
+      }
+    ]
+  }
+}

--- a/tests/unit/test_qre_controlled_validation_equities_blocker_diagnosis_fixture.py
+++ b/tests/unit/test_qre_controlled_validation_equities_blocker_diagnosis_fixture.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from reporting import qre_controlled_validation_result_analysis as analysis
+
+
+FIXTURE_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "fixtures"
+    / "qre_controlled_validation"
+    / "equities_exploratory_v1_blocker_diagnosis.json"
+)
+
+
+def test_equities_exploratory_blocker_diagnosis_fixture_reproduces_known_summary(
+    tmp_path: Path,
+) -> None:
+    fixture = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+    report_path = tmp_path / "controlled_eval_latest.v1.json"
+    report_path.write_text(
+        json.dumps(fixture["controlled_eval_report"]),
+        encoding="utf-8",
+    )
+    execution_snapshot = dict(fixture["execution_snapshot"])
+    execution_snapshot["controlled_eval_result"] = {
+        "returncode": 0,
+        "report_paths": {"report_json": report_path.as_posix()},
+    }
+
+    snapshot = analysis.collect_snapshot(
+        execution_snapshot=execution_snapshot,
+        generated_at_utc="2026-06-05T23:30:00Z",
+        current_git_revision="abc123",
+        screening_evidence_payload=fixture["screening_evidence_payload"],
+    )
+
+    summary = snapshot["operator_summary"]
+    assert summary["total_candidates"] == 15
+    assert summary["linked_catalog_active_discovery_count"] == 15
+    assert summary["sufficient_oos_evidence_count"] == 1
+    assert summary["promotion_allowed_count"] == 0
+    assert summary["promotion_blocked_count"] == 15
+    assert summary["runtime_gate_failed_assets"] == [
+        "AMD",
+        "AMZN",
+        "AVGO",
+        "GOOGL",
+        "LLY",
+        "META",
+        "MSFT",
+        "NVDA",
+        "TSM",
+    ]
+    assert summary["public_result_criteria_blocked_assets"] == [
+        "AAPL",
+        "ASML",
+        "COST",
+        "HD",
+        "JPM",
+        "XOM",
+    ]
+    assert summary["near_pass_assets"] == []
+    assert summary["top_failure_reasons"] == [
+        {"reason": "insufficient_trades", "count": 9}
+    ]
+    assert summary["top_promotion_blockers"] == [
+        {"reason": "criteria_expectancy_above_zero_failed", "count": 9},
+        {"reason": "criteria_profit_factor_at_or_above_floor_failed", "count": 9},
+        {"reason": "criteria_sufficient_trades_failed", "count": 9},
+        {"reason": "criteria_consistentie_failed", "count": 6},
+        {"reason": "criteria_trades_per_maand_failed", "count": 6},
+    ]
+
+    hd_row = next(
+        row for row in summary["selected_asset_explanations"] if row["asset"] == "HD"
+    )
+    assert hd_row["qre_validation_linkage_status"] == "linked_catalog_active_discovery"
+    assert hd_row["validation_evidence_status"] == "sufficient_oos_evidence"
+    assert hd_row["oos_trade_count"] == 14
+    assert hd_row["promotion_allowed"] is False
+    assert hd_row["blocked_by"] == [
+        "criteria_consistentie_failed",
+        "criteria_trades_per_maand_failed",
+        "criteria_win_rate_failed",
+    ]

--- a/tests/unit/test_qre_controlled_validation_execution.py
+++ b/tests/unit/test_qre_controlled_validation_execution.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 from reporting import qre_controlled_validation_execution as execution
 
@@ -128,6 +129,27 @@ def test_campaign_invariant_violation_blocks_runner_before_launch(monkeypatch) -
             "missing_completed_ledger_event_ids": [
                 "col-20260604T203711765074Z-trend_pullback_equities_4h-3e5f6de0b6"
             ],
+            "diagnostics": {
+                "stale_campaign_ids": [
+                    "col-20260604T203711765074Z-trend_pullback_equities_4h-3e5f6de0b6"
+                ],
+                "active_stale_files": [
+                    "research/campaign_registry_latest.v1.json",
+                    "research/run_campaign_latest.v1.json",
+                ],
+                "completed_campaign_count_per_source": {
+                    "research/campaign_registry_latest.v1.json": 1,
+                },
+                "ledger_event_count_per_source": {
+                    "research/campaign_evidence_ledger_latest.v1.jsonl": 0,
+                },
+                "suggested_operator_action": "quarantine generated artifacts",
+                "safe_cleanup_available": True,
+                "safe_cleanup_mode": "operator_quarantine_only",
+                "quarantine_command_preview": [
+                    "$target = 'logs/qre_controlled_validation_execution/quarantine/<timestamp>'"
+                ],
+            },
         },
     )
 
@@ -159,7 +181,92 @@ def test_campaign_invariant_violation_blocks_runner_before_launch(monkeypatch) -
         "missing_completed_ledger_event_ids": [
             "col-20260604T203711765074Z-trend_pullback_equities_4h-3e5f6de0b6"
         ],
+        "diagnostics": {
+            "stale_campaign_ids": [
+                "col-20260604T203711765074Z-trend_pullback_equities_4h-3e5f6de0b6"
+            ],
+            "active_stale_files": [
+                "research/campaign_registry_latest.v1.json",
+                "research/run_campaign_latest.v1.json",
+            ],
+            "completed_campaign_count_per_source": {
+                "research/campaign_registry_latest.v1.json": 1,
+            },
+            "ledger_event_count_per_source": {
+                "research/campaign_evidence_ledger_latest.v1.jsonl": 0,
+            },
+            "suggested_operator_action": "quarantine generated artifacts",
+            "safe_cleanup_available": True,
+            "safe_cleanup_mode": "operator_quarantine_only",
+            "quarantine_command_preview": [
+                "$target = 'logs/qre_controlled_validation_execution/quarantine/<timestamp>'"
+            ],
+        },
     }
+
+
+def test_campaign_invariant_failure_diagnostics_surfaces_stale_runtime_files(
+    monkeypatch, tmp_path: Path
+) -> None:
+    repo_root = tmp_path
+    campaign_id = "col-20260604T203711765074Z-trend_pullback_equities_4h-3e5f6de0b6"
+
+    registry = repo_root / "research" / "campaign_registry_latest.v1.json"
+    registry.parent.mkdir(parents=True, exist_ok=True)
+    registry.write_text(
+        json.dumps({"campaigns": {campaign_id: {"state": "completed"}}}),
+        encoding="utf-8",
+    )
+
+    run_campaign = repo_root / "research" / "run_campaign_latest.v1.json"
+    run_campaign.write_text(
+        json.dumps({"campaign_id": campaign_id, "state": "completed"}),
+        encoding="utf-8",
+    )
+
+    history_manifest = (
+        repo_root
+        / "research"
+        / "history"
+        / "20260605T102349101321Z"
+        / "run_campaign_manifest.v1.json"
+    )
+    history_manifest.parent.mkdir(parents=True, exist_ok=True)
+    history_manifest.write_text(
+        json.dumps({"campaigns": [{"campaign_id": campaign_id}]}),
+        encoding="utf-8",
+    )
+
+    protected = repo_root / "registry.py"
+    protected.write_text("PROTECTED = True\n", encoding="utf-8")
+
+    monkeypatch.setattr(execution, "REPO_ROOT", repo_root)
+
+    diagnostics = execution._campaign_invariant_failure_diagnostics(
+        completed_campaign_count=1,
+        campaign_completed_ledger_event_count=0,
+        missing_completed_ledger_event_ids=[campaign_id],
+    )
+
+    assert diagnostics["stale_campaign_ids"] == [campaign_id]
+    assert diagnostics["active_stale_files"] == [
+        "research/campaign_registry_latest.v1.json",
+        "research/history/20260605T102349101321Z/run_campaign_manifest.v1.json",
+        "research/run_campaign_latest.v1.json",
+    ]
+    assert diagnostics["completed_campaign_count_per_source"] == {
+        "research/campaign_registry_latest.v1.json": 1,
+    }
+    assert diagnostics["ledger_event_count_per_source"] == {
+        "research/campaign_evidence_ledger_latest.v1.jsonl": 0,
+    }
+    assert diagnostics["safe_cleanup_available"] is True
+    assert diagnostics["safe_cleanup_mode"] == "operator_quarantine_only"
+    assert any(
+        "research/campaign_registry_latest.v1.json" in line
+        for line in diagnostics["quarantine_command_preview"]
+    )
+    assert all("registry.py" not in line for line in diagnostics["quarantine_command_preview"])
 
 
 def test_campaign_invariant_preflight_pass_allows_existing_runner_path(

--- a/tests/unit/test_qre_controlled_validation_result_analysis.py
+++ b/tests/unit/test_qre_controlled_validation_result_analysis.py
@@ -252,6 +252,194 @@ def test_analysis_reads_completed_controlled_eval_report(tmp_path) -> None:
     assert snapshot["result_summary"]["evidence_refs"] == [report_path.as_posix()]
 
 
+def test_operator_summary_surfaces_hd_blockers_and_candidate_rollup(tmp_path) -> None:
+    report_path = tmp_path / "controlled_eval_latest.v1.json"
+    report_path.write_text(
+        json.dumps(
+            {
+                "verdict": {
+                    "status": "useful_observation",
+                    "reason_codes": [],
+                },
+                "campaigns_completed": 1,
+                "campaign_level_evidence_valid": True,
+                "recommended_next_action": "inspect_results",
+                "git_revision": "abc123",
+                "screening_evidence_summary": {
+                    "present": True,
+                    "total_candidates": 3,
+                    "passed_screening": 2,
+                    "rejected_screening": 1,
+                    "promotion_grade_candidates": 0,
+                    "sufficient_oos_evidence_candidates": 1,
+                    "qre_linkage_blocked_candidates": 0,
+                    "sufficient_oos_but_unlinked_candidates": 0,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    execution_snapshot = {
+        "report_kind": "qre_controlled_validation_execution",
+        "selection_profile_name": "equities_exploratory_v1",
+        "execution_status": "execution_completed",
+        "controlled_validation_authorized": True,
+        "runner_adapter_status": "connected",
+        "executed_anything": True,
+        "final_recommendation": "controlled_validation_execution_completed",
+        "controlled_eval_result": {
+            "returncode": 0,
+            "report_paths": {"report_json": report_path.as_posix()},
+        },
+    }
+    screening_evidence_payload = {
+        "candidates": [
+            {
+                "asset": "HD",
+                "preset_name": "trend_pullback_equities_4h",
+                "strategy_name": "trend_pullback_v1",
+                "interval": "4h",
+                "stage_result": "screening_pass",
+                "qre_validation_linkage_status": "linked_catalog_active_discovery",
+                "validation_evidence": {
+                    "status": "sufficient_oos_evidence",
+                    "oos_trade_count": 14,
+                    "min_oos_trades": 10,
+                },
+                "promotion_guard": {
+                    "promotion_allowed": False,
+                    "blocked_by": [
+                        "criteria_consistentie_failed",
+                        "criteria_trades_per_maand_failed",
+                        "criteria_win_rate_failed",
+                    ],
+                },
+                "failure_reasons": [],
+                "near_pass": {"is_near_pass": False},
+                "metrics": {
+                    "win_rate": 0.5,
+                    "trades_per_maand": 1.1,
+                    "consistentie": 0.333,
+                    "deflated_sharpe": 0.534,
+                },
+            },
+            {
+                "asset": "NVDA",
+                "preset_name": "trend_pullback_equities_4h",
+                "strategy_name": "trend_pullback_v1",
+                "interval": "4h",
+                "stage_result": "screening_pass",
+                "qre_validation_linkage_status": "linked_catalog_active_discovery",
+                "validation_evidence": {
+                    "status": "no_oos_trades",
+                    "oos_trade_count": 0,
+                    "min_oos_trades": 10,
+                },
+                "promotion_guard": {
+                    "promotion_allowed": False,
+                    "blocked_by": ["criteria_deflated_sharpe_failed"],
+                },
+                "failure_reasons": [],
+                "near_pass": {"is_near_pass": True},
+                "metrics": {
+                    "win_rate": 0.52,
+                    "trades_per_maand": 1.8,
+                    "consistentie": 0.4,
+                    "deflated_sharpe": 0.1,
+                },
+            },
+            {
+                "asset": "AMD",
+                "preset_name": "trend_pullback_equities_4h",
+                "strategy_name": "trend_pullback_v1",
+                "interval": "4h",
+                "stage_result": "screening_reject",
+                "qre_validation_linkage_status": "linked_catalog_active_discovery",
+                "validation_evidence": {
+                    "status": "no_oos_trades",
+                    "oos_trade_count": 0,
+                    "min_oos_trades": 10,
+                },
+                "promotion_guard": {
+                    "promotion_allowed": False,
+                    "blocked_by": [
+                        "criteria_expectancy_above_zero_failed",
+                        "criteria_sufficient_trades_failed",
+                    ],
+                },
+                "failure_reasons": ["insufficient_trades"],
+                "near_pass": {"is_near_pass": False},
+                "metrics": {
+                    "win_rate": 0.0,
+                    "trades_per_maand": 0.0,
+                    "consistentie": None,
+                    "deflated_sharpe": None,
+                },
+            },
+        ]
+    }
+
+    snapshot = analysis.collect_snapshot(
+        execution_snapshot=execution_snapshot,
+        generated_at_utc="2026-06-05T23:00:00Z",
+        current_git_revision="abc123",
+        screening_evidence_payload=screening_evidence_payload,
+    )
+
+    summary = snapshot["operator_summary"]
+    assert summary["total_candidates"] == 3
+    assert summary["linked_catalog_active_discovery_count"] == 3
+    assert summary["sufficient_oos_evidence_count"] == 1
+    assert summary["promotion_allowed_count"] == 0
+    assert summary["promotion_blocked_count"] == 3
+    assert summary["near_pass_count"] == 1
+    assert summary["campaign_verdict"] == "useful_observation"
+    assert summary["next_recommendation"] == "inspect_results"
+    assert summary["safety_flags"] == {
+        "artifact_may_be_stale": False,
+        "controlled_validation_authorized": True,
+        "runner_adapter_status": "connected",
+        "mutates_paper_shadow_live_runtime": False,
+        "writes_development_work_queue": False,
+        "writes_research_action_queue": False,
+    }
+    assert summary["top_promotion_blockers"][0] == {
+        "reason": "criteria_consistentie_failed",
+        "count": 1,
+    }
+    assert summary["top_failure_reasons"] == [
+        {"reason": "insufficient_trades", "count": 1}
+    ]
+    hd_row = next(
+        row for row in summary["selected_asset_explanations"] if row["asset"] == "HD"
+    )
+    assert hd_row == {
+        "asset": "HD",
+        "preset_name": "trend_pullback_equities_4h",
+        "strategy_name": "trend_pullback_v1",
+        "interval": "4h",
+        "stage_result": "screening_pass",
+        "qre_validation_linkage_status": "linked_catalog_active_discovery",
+        "validation_evidence_status": "sufficient_oos_evidence",
+        "oos_trade_count": 14,
+        "min_oos_trades": 10,
+        "promotion_allowed": False,
+        "blocked_by": [
+            "criteria_consistentie_failed",
+            "criteria_trades_per_maand_failed",
+            "criteria_win_rate_failed",
+        ],
+        "failure_reasons": [],
+        "near_pass": False,
+        "metrics": {
+            "win_rate": 0.5,
+            "trades_per_maand": 1.1,
+            "consistentie": 0.333,
+            "deflated_sharpe": 0.534,
+        },
+    }
+
+
 def test_analysis_marks_no_campaign_completed_as_failure(tmp_path) -> None:
     report_path = tmp_path / "controlled_eval_latest.v1.json"
     report_path.write_text(

--- a/tests/unit/test_qre_controlled_validation_sprint_rerun_smoke_contract.py
+++ b/tests/unit/test_qre_controlled_validation_sprint_rerun_smoke_contract.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from reporting import qre_controlled_validation_execution as execution
+from reporting import qre_controlled_validation_result_analysis as analysis
+
+
+def _ready_bridge_snapshot() -> dict:
+    return {
+        "report_kind": "qre_executable_hypothesis_identity_bridge_diagnostics",
+        "final_recommendation": "executable_hypothesis_identity_bridge_ready_for_regeneration",
+        "controlled_validation_bridge_readiness": {
+            "ready": True,
+            "executable_hypothesis_count": 1,
+            "ready_count": 1,
+            "blocked_count": 0,
+            "rows": [
+                {
+                    "preset_name": "trend_pullback_equities_4h",
+                    "executable_hypothesis_id": "trend_pullback_v1",
+                    "ready": True,
+                    "primary_blocker": "no_primary_blocker",
+                }
+            ],
+        },
+    }
+
+
+def _screening_payload() -> dict:
+    return {
+        "candidates": [
+            {
+                "asset": "HD",
+                "preset_name": "trend_pullback_equities_4h",
+                "strategy_name": "trend_pullback_v1",
+                "interval": "4h",
+                "stage_result": "screening_pass",
+                "qre_validation_linkage_status": "linked_catalog_active_discovery",
+                "validation_evidence": {
+                    "status": "sufficient_oos_evidence",
+                    "oos_trade_count": 14,
+                    "min_oos_trades": 10,
+                },
+                "promotion_guard": {
+                    "promotion_allowed": False,
+                    "blocked_by": [
+                        "criteria_consistentie_failed",
+                        "criteria_trades_per_maand_failed",
+                        "criteria_win_rate_failed",
+                    ],
+                },
+                "failure_reasons": [],
+                "near_pass": {"is_near_pass": False},
+                "metrics": {
+                    "win_rate": 0.5,
+                    "trades_per_maand": 1.1,
+                    "consistentie": 0.333,
+                    "deflated_sharpe": 0.534,
+                },
+            }
+        ]
+    }
+
+
+def test_controlled_sprint_rerun_smoke_contract_stays_safety_bounded(
+    monkeypatch, tmp_path: Path
+) -> None:
+    screening_path = tmp_path / "research" / "screening_evidence_latest.v1.json"
+    screening_path.parent.mkdir(parents=True, exist_ok=True)
+    screening_path.write_text(json.dumps(_screening_payload()), encoding="utf-8")
+
+    def fake_run_controlled_eval(**kwargs: object) -> int:
+        report_json = kwargs["report_json"]
+        report_md = kwargs["report_md"]
+        report_json.parent.mkdir(parents=True, exist_ok=True)
+        report_json.write_text(
+            json.dumps(
+                {
+                    "verdict": {"status": "useful_observation", "reason_codes": []},
+                    "campaigns_completed": 1,
+                    "campaign_level_evidence_valid": True,
+                    "recommended_next_action": "inspect_results",
+                    "git_revision": "abc123",
+                    "screening_evidence_summary": {
+                        "present": True,
+                        "total_candidates": 1,
+                        "passed_screening": 1,
+                        "rejected_screening": 0,
+                        "promotion_grade_candidates": 0,
+                        "sufficient_oos_evidence_candidates": 1,
+                        "qre_linkage_blocked_candidates": 0,
+                        "sufficient_oos_but_unlinked_candidates": 0,
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        report_md.write_text("# controlled eval\n", encoding="utf-8")
+        kwargs["out"].write("controlled_eval: completed=1 verdict=useful_observation\n")
+        return 0
+
+    class FakeControlledEval:
+        @staticmethod
+        def run_controlled_eval(**kwargs: object) -> int:
+            return fake_run_controlled_eval(**kwargs)
+
+    monkeypatch.setattr(execution, "_load_controlled_eval_module", lambda: FakeControlledEval)
+    monkeypatch.setattr(
+        execution,
+        "_campaign_invariant_preflight",
+        lambda: {
+            "status": "passed",
+            "completed_campaign_count": 0,
+            "campaign_completed_ledger_event_count": 0,
+            "missing_completed_ledger_event_ids": [],
+            "diagnostics": {},
+        },
+    )
+    monkeypatch.setattr(execution, "ARTIFACT_DIR", tmp_path / "logs")
+    monkeypatch.setattr(
+        execution,
+        "CONTROLLED_EVAL_REPORT_JSON",
+        tmp_path / "logs" / "controlled_eval_latest.v1.json",
+    )
+    monkeypatch.setattr(
+        execution,
+        "CONTROLLED_EVAL_REPORT_MD",
+        tmp_path / "logs" / "controlled_eval_latest.md",
+    )
+    monkeypatch.setattr(analysis, "SCREENING_EVIDENCE_LATEST", screening_path)
+
+    execution_snapshot = execution.collect_snapshot(
+        profile_name="equities_exploratory_v1",
+        execute_controlled_validation=True,
+        operator_go=execution.REQUIRED_OPERATOR_GO_PHRASE,
+        connect_runner_adapter=True,
+        timeout_seconds_per_campaign=60,
+        controlled_validation_bridge_snapshot=_ready_bridge_snapshot(),
+        generated_at_utc="2026-06-05T23:45:00Z",
+    )
+    analysis_snapshot = analysis.collect_snapshot(
+        execution_snapshot=execution_snapshot,
+        generated_at_utc="2026-06-05T23:46:00Z",
+        current_git_revision="abc123",
+    )
+
+    assert execution_snapshot["execution_status"] == "execution_completed"
+    assert execution_snapshot["mutates_paper_shadow_live_runtime"] is False
+    assert execution_snapshot["writes_research_action_queue"] is False
+    assert execution_snapshot["writes_development_work_queue"] is False
+    report_paths = execution_snapshot["controlled_eval_result"]["report_paths"]
+    assert report_paths["report_json"].endswith("controlled_eval_latest.v1.json")
+    assert report_paths["report_md"].endswith("controlled_eval_latest.md")
+    assert (tmp_path / "logs" / "controlled_eval_latest.v1.json").exists()
+    assert (tmp_path / "logs" / "controlled_eval_latest.md").exists()
+
+    assert analysis_snapshot["analysis_status"] == "analysis_ready"
+    assert analysis_snapshot["mutates_paper_shadow_live_runtime"] is False
+    assert analysis_snapshot["writes_research_action_queue"] is False
+    assert analysis_snapshot["writes_development_work_queue"] is False
+    hd_row = analysis_snapshot["operator_summary"]["selected_asset_explanations"][0]
+    assert hd_row["asset"] == "HD"
+    assert hd_row["qre_validation_linkage_status"] == "linked_catalog_active_discovery"
+    assert hd_row["validation_evidence_status"] == "sufficient_oos_evidence"
+    assert hd_row["oos_trade_count"] == 14
+    assert hd_row["blocked_by"] == [
+        "criteria_consistentie_failed",
+        "criteria_trades_per_maand_failed",
+        "criteria_win_rate_failed",
+    ]
+
+
+def test_stale_artifact_blocking_contract_explains_exact_operator_action(monkeypatch) -> None:
+    stale_id = "col-20260604T203711765074Z-trend_pullback_equities_4h-3e5f6de0b6"
+    monkeypatch.setattr(
+        execution,
+        "_campaign_invariant_preflight",
+        lambda: {
+            "status": "failed",
+            "completed_campaign_count": 1,
+            "campaign_completed_ledger_event_count": 0,
+            "missing_completed_ledger_event_ids": [stale_id],
+            "diagnostics": {
+                "stale_campaign_ids": [stale_id],
+                "active_stale_files": [
+                    "research/campaign_registry_latest.v1.json",
+                    "research/run_campaign_latest.v1.json",
+                ],
+                "completed_campaign_count_per_source": {
+                    "research/campaign_registry_latest.v1.json": 1,
+                },
+                "ledger_event_count_per_source": {
+                    "research/campaign_evidence_ledger_latest.v1.jsonl": 0,
+                },
+                "suggested_operator_action": "quarantine generated runtime artifacts",
+                "safe_cleanup_available": True,
+                "safe_cleanup_mode": "operator_quarantine_only",
+                "quarantine_command_preview": [
+                    "$target = 'logs/qre_controlled_validation_execution/quarantine/<timestamp>'"
+                ],
+            },
+        },
+    )
+
+    snapshot = execution.collect_snapshot(
+        profile_name="equities_exploratory_v1",
+        execute_controlled_validation=True,
+        operator_go=execution.REQUIRED_OPERATOR_GO_PHRASE,
+        connect_runner_adapter=True,
+        timeout_seconds_per_campaign=60,
+        controlled_validation_bridge_snapshot=_ready_bridge_snapshot(),
+        generated_at_utc="2026-06-05T23:47:00Z",
+    )
+
+    assert snapshot["execution_status"] == "execution_blocked_campaign_invariant_violation"
+    assert snapshot["executed_anything"] is False
+    assert snapshot["mutates_paper_shadow_live_runtime"] is False
+    assert snapshot["writes_research_action_queue"] is False
+    assert snapshot["writes_development_work_queue"] is False
+    assert snapshot["campaign_invariant_preflight"]["diagnostics"] == {
+        "stale_campaign_ids": [stale_id],
+        "active_stale_files": [
+            "research/campaign_registry_latest.v1.json",
+            "research/run_campaign_latest.v1.json",
+        ],
+        "completed_campaign_count_per_source": {
+            "research/campaign_registry_latest.v1.json": 1,
+        },
+        "ledger_event_count_per_source": {
+            "research/campaign_evidence_ledger_latest.v1.jsonl": 0,
+        },
+        "suggested_operator_action": "quarantine generated runtime artifacts",
+        "safe_cleanup_available": True,
+        "safe_cleanup_mode": "operator_quarantine_only",
+        "quarantine_command_preview": [
+            "$target = 'logs/qre_controlled_validation_execution/quarantine/<timestamp>'"
+        ],
+    }


### PR DESCRIPTION
## Summary
- add stale runtime artifact cleanup diagnostics and quarantine preview for campaign invariant failures
- add controlled validation operator summary with candidate-level explanations and HD blocker visibility
- add an equities exploratory blocker diagnosis fixture plus rerun smoke coverage
- add a docs-only equities universe and preset expansion plan

## Commits
- A. fix: add stale runtime artifact cleanup diagnostics
- B. feat: add controlled validation operator summary
- C. test: add equities exploratory blocker diagnosis fixture
- D. docs: add equities universe and preset expansion plan
- E. test: add controlled sprint rerun smoke contract

## Validation
- python -m pytest tests/unit/test_qre_controlled_validation_execution.py tests/unit/test_qre_controlled_validation_result_analysis.py tests/unit/test_qre_controlled_validation_equities_blocker_diagnosis_fixture.py tests/unit/test_qre_controlled_validation_sprint_rerun_smoke_contract.py -q
- python -m pytest tests/architecture -q
- git diff --check

## Safety
- no live/paper/shadow activation
- no broker/risk/execution changes
- no strategy or preset mutation
- no threshold relaxation
- no generated runtime artifacts committed
- no ledger fabrication