### PR TITLE
test: add QRE controlled validation candidate diversity harness

### DIFF
--- a/docs/qre_candidate_diversity_validation_operator_report.md
+++ b/docs/qre_candidate_diversity_validation_operator_report.md
@@ -1,0 +1,31 @@
+# QRE Candidate Diversity Validation Operator Report
+
+## Purpose
+
+This document separates three different concerns that were previously easy to blur together:
+
+1. controlled validation pipeline testing;
+2. true QRE autonomous candidate discovery;
+3. production discovery universe/preset seeding.
+
+## What Changed
+
+- A controlled validation diversity harness now proves that reporting can explain a bounded multi-candidate basket with multiple presets, hypotheses, regions, and blocker classes.
+- A read-only production discovery catalog now defines which assets and behavior presets QRE may investigate later.
+- An operator-facing report helper now explains what is proven, what is not proven, and which safe next step remains.
+
+## What This Does Not Mean
+
+- It does not prove real alpha.
+- It does not activate paper, shadow, or live runtime.
+- It does not add executable strategies.
+- It does not authorize strategy synthesis.
+- It does not claim that the seeded discovery presets already have market evidence.
+
+## Safe Interpretation
+
+Use the diversity harness to validate reporting and governance behavior.
+
+Use the discovery catalog as a read-only seed of researchable assets and behavior presets.
+
+Do not interpret either of those as production trading authority.

--- a/reporting/qre_candidate_diversity_validation_report.py
+++ b/reporting/qre_candidate_diversity_validation_report.py
@@ -1,0 +1,256 @@
+"""Operator-facing report for candidate diversity validation.
+
+This is a read-only report helper. It explains what the controlled
+validation harness proves, what the production discovery seed enables,
+and what remains unproven.
+"""
+
+from __future__ import annotations
+
+import json
+import importlib
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HARNESS_FIXTURE_PATH = (
+    REPO_ROOT
+    / "tests"
+    / "fixtures"
+    / "qre_controlled_validation"
+    / "candidate_diversity_harness.json"
+)
+
+
+def _read_fixture(path: Path = HARNESS_FIXTURE_PATH) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _expected_outcome_label(row: dict[str, Any]) -> str:
+    outcome = str(row.get("outcome_class") or "").strip()
+    mapping = {
+        "reject_insufficient_trades": "reject via insufficient trades",
+        "reject_no_oos_evidence": "reject via no OOS evidence",
+        "reject_criteria_consistentie_failed": "reject via consistentie criteria",
+        "reject_criteria_trades_per_maand_failed": "reject via trades-per-month criteria",
+        "reject_criteria_win_rate_failed": "reject via win-rate criteria",
+        "near_pass": "near pass",
+        "promotion_eligible_fixture_candidate": "fixture candidate reaches criteria path",
+        "sufficient_oos_but_not_promoted": "OOS evidence exists but promotion stays blocked",
+    }
+    return mapping.get(outcome, outcome or "unclassified fixture outcome")
+
+
+def _actual_outcome_label(row: dict[str, Any]) -> str:
+    if row.get("promotion_guard", {}).get("promotion_allowed") is True:
+        return "promotion_eligible_fixture_candidate"
+    if (row.get("near_pass") or {}).get("is_near_pass"):
+        return "near_pass"
+    failure_reasons = list(row.get("failure_reasons") or [])
+    if "insufficient_trades" in failure_reasons:
+        return "reject_insufficient_trades"
+    validation = row.get("validation_evidence") or {}
+    if validation.get("status") == "no_oos_trades":
+        return "reject_no_oos_evidence"
+    blocked_by = list((row.get("promotion_guard") or {}).get("blocked_by") or [])
+    if "criteria_consistentie_failed" in blocked_by:
+        return "reject_criteria_consistentie_failed"
+    if "criteria_trades_per_maand_failed" in blocked_by:
+        return "reject_criteria_trades_per_maand_failed"
+    if "criteria_win_rate_failed" in blocked_by:
+        return "reject_criteria_win_rate_failed"
+    if validation.get("status") == "sufficient_oos_evidence":
+        return "sufficient_oos_but_not_promoted"
+    return "unclassified"
+
+
+def _production_seed_groups(
+    assets: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    groups = [
+        ("NL/EU", "lokale/Europese large-cap research"),
+        ("US", "liquide trend/volatility research"),
+        ("Asia/proxies", "regionale diversificatie"),
+        ("ETFs/context", "benchmark/sector/context controle"),
+    ]
+    rows: list[dict[str, Any]] = []
+    for group, goal in groups:
+        matches = [asset["symbol"] for asset in assets if asset["region"] == group]
+        rows.append(
+            {
+                "group": group,
+                "count": len(matches),
+                "examples": ", ".join(matches[:5]),
+                "goal": goal,
+            }
+        )
+    return rows
+
+
+def collect_snapshot(
+    *,
+    branch: str,
+    commits: list[dict[str, str]],
+    tests: list[str],
+    architecture_tests: str,
+    git_diff_check: str,
+    harness_fixture: dict[str, Any] | None = None,
+    catalog_payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    fixture = harness_fixture or _read_fixture()
+    if catalog_payload is None:
+        discovery_catalog = importlib.import_module(
+            "research.production_discovery_catalog"
+        )
+        catalog = discovery_catalog.production_discovery_catalog_payload(
+            max_candidates=15
+        )
+    else:
+        catalog = catalog_payload
+    candidates = list(fixture["screening_evidence_payload"]["candidates"])
+    short_conclusion = [
+        "Controlled validation reporting now handles a bounded multi-candidate basket instead of explaining only one repeated preset.",
+        "A read-only production discovery universe/preset seed now exists for multiple regions, assets, and behavior families.",
+        "This proves research readiness only; it does not prove real alpha and it does not activate paper, shadow, or live runtime.",
+    ]
+    tested_rows = [
+        {
+            "candidate": row["asset"],
+            "asset_region": f'{row["asset"]} / {row["region"]}',
+            "preset_hypothesis": f'{row["preset_name"]} / {row["hypothesis_id"]}',
+            "expected_outcome": _expected_outcome_label(row),
+            "actual_outcome": _actual_outcome_label(row),
+        }
+        for row in sorted(candidates, key=lambda item: str(item["asset"]))
+    ]
+    evidence_rows = [
+        {
+            "proof": "Controlled validation harness reproduces 15 fixture candidates with multiple outcome classes.",
+            "file": "tests/unit/test_qre_controlled_validation_candidate_diversity_harness.py",
+            "why": "Shows the operator summary can explain more than one fixed preset.",
+        },
+        {
+            "proof": "Result analysis exposes candidate-level explanation rows and fixture safety labels.",
+            "file": "reporting/qre_controlled_validation_result_analysis.py",
+            "why": "Separates fixture evidence from real market evidence in the operator view.",
+        },
+        {
+            "proof": "Production discovery catalog stays read-only and regionally diverse.",
+            "file": "tests/unit/test_qre_production_discovery_catalog.py",
+            "why": "Proves the seed catalog does not grant paper/shadow/live authority.",
+        },
+        {
+            "proof": "Bounded candidate basket selection reaches four region groups within 15 combinations.",
+            "file": "research/production_discovery_catalog.py",
+            "why": "Shows later discovery can sample multiple assets/presets without broad runtime mutation.",
+        },
+    ]
+    return {
+        "title": "# QRE Candidate Diversity + Production Discovery Seed Report",
+        "short_conclusion": short_conclusion,
+        "tested_rows": tested_rows,
+        "production_seed_rows": _production_seed_groups(list(catalog["assets"])),
+        "evidence_rows": evidence_rows,
+        "proves": [
+            "de validatieketen kan meerdere candidate-uitkomsten verwerken",
+            "operator summary toont candidate-level uitleg",
+            "een fixture candidate kan de full criteria path halen",
+            "blockers worden per candidate zichtbaar",
+            "er is een veilige read-only discovery catalog voor meerdere assets/regio’s/presets",
+        ],
+        "not_proves": [
+            "dit bewijst geen echte alpha",
+            "dit activeert geen paper/shadow/live",
+            "dit betekent niet dat production strategies zijn toegevoegd",
+            "dit betekent niet dat strategy synthesis toegestaan is",
+            "dit betekent niet dat echte candidates al door market evidence zijn bewezen",
+        ],
+        "next_action": "READ_ONLY_REAL_BASKET_DIAGNOSIS",
+        "validation": {
+            "branch": branch,
+            "commits": commits,
+            "tests": tests,
+            "architecture_tests": architecture_tests,
+            "git_diff_check": git_diff_check,
+            "frozen_contracts_untouched": True,
+            "protected_execution_paths_untouched": True,
+        },
+    }
+
+
+def _table(headers: list[str], rows: list[list[str]]) -> str:
+    header = "| " + " | ".join(headers) + " |"
+    divider = "| " + " | ".join(["---"] * len(headers)) + " |"
+    body = ["| " + " | ".join(row) + " |" for row in rows]
+    return "\n".join([header, divider, *body])
+
+
+def render_markdown(snapshot: dict[str, Any]) -> str:
+    tested_table = _table(
+        ["Candidate", "Asset/regio", "Preset/hypothesis", "Verwachte uitkomst", "Werkelijke uitkomst"],
+        [
+            [
+                row["candidate"],
+                row["asset_region"],
+                row["preset_hypothesis"],
+                row["expected_outcome"],
+                row["actual_outcome"],
+            ]
+            for row in snapshot["tested_rows"]
+        ],
+    )
+    seed_table = _table(
+        ["Groep", "Voorbeelden", "Doel"],
+        [
+            [row["group"], row["examples"], row["goal"]]
+            for row in snapshot["production_seed_rows"]
+        ],
+    )
+    evidence_table = _table(
+        ["Bewijs", "Bestand/test", "Waarom belangrijk"],
+        [
+            [row["proof"], row["file"], row["why"]]
+            for row in snapshot["evidence_rows"]
+        ],
+    )
+    validation = snapshot["validation"]
+    commit_table = _table(
+        ["Commit", "SHA", "Doel"],
+        [[item["message"], item["sha"], item["purpose"]] for item in validation["commits"]],
+    )
+    return "\n".join(
+        [
+            snapshot["title"],
+            "",
+            "## 1. Korte conclusie",
+            *[f"- {line}" for line in snapshot["short_conclusion"]],
+            "",
+            "## 2. Wat is getest",
+            tested_table,
+            "",
+            "## 3. Production discovery seed",
+            seed_table,
+            "",
+            "## 4. Belangrijkste bewijs",
+            evidence_table,
+            "",
+            "## 5. Wat dit wel bewijst",
+            *[f"- {line}" for line in snapshot["proves"]],
+            "",
+            "## 6. Wat dit niet bewijst",
+            *[f"- {line}" for line in snapshot["not_proves"]],
+            "",
+            "## 7. Volgende veilige stap",
+            f"- NEXT_ACTION: {snapshot['next_action']}",
+            "",
+            "## 8. Validatie",
+            f"- branch: {validation['branch']}",
+            commit_table,
+            *[f"- test: {item}" for item in validation["tests"]],
+            f"- architecture tests: {validation['architecture_tests']}",
+            f"- git diff --check: {validation['git_diff_check']}",
+            f"- frozen contracts untouched: {str(validation['frozen_contracts_untouched']).lower()}",
+            f"- protected execution paths untouched: {str(validation['protected_execution_paths_untouched']).lower()}",
+        ]
+    )

--- a/reporting/qre_controlled_validation_result_analysis.py
+++ b/reporting/qre_controlled_validation_result_analysis.py
@@ -203,6 +203,37 @@ def _top_counts(values: list[str], *, limit: int = 5) -> list[dict[str, Any]]:
     return [{"reason": reason, "count": count} for reason, count in ordered[:limit]]
 
 
+def _candidate_outcome_class(
+    row: dict[str, Any],
+    *,
+    validation_status: str | None,
+    failure_reasons: list[str],
+    blocked_by: list[str],
+    near_pass: bool,
+    promotion_allowed: bool,
+) -> str:
+    explicit = row.get("outcome_class")
+    if isinstance(explicit, str) and explicit.strip():
+        return explicit
+    if promotion_allowed:
+        return "promotion_eligible_fixture_candidate"
+    if near_pass:
+        return "near_pass"
+    if "insufficient_trades" in failure_reasons:
+        return "reject_insufficient_trades"
+    if validation_status == "no_oos_trades":
+        return "reject_no_oos_evidence"
+    if "criteria_consistentie_failed" in blocked_by:
+        return "reject_criteria_consistentie_failed"
+    if "criteria_trades_per_maand_failed" in blocked_by:
+        return "reject_criteria_trades_per_maand_failed"
+    if "criteria_win_rate_failed" in blocked_by:
+        return "reject_criteria_win_rate_failed"
+    if validation_status == "sufficient_oos_evidence":
+        return "sufficient_oos_but_not_promoted"
+    return "unclassified_outcome"
+
+
 def _candidate_operator_row(row: dict[str, Any]) -> dict[str, Any]:
     validation = row.get("validation_evidence")
     if not isinstance(validation, dict):
@@ -216,20 +247,40 @@ def _candidate_operator_row(row: dict[str, Any]) -> dict[str, Any]:
     failure_reasons = row.get("failure_reasons")
     if not isinstance(failure_reasons, list):
         failure_reasons = []
+    blocked_by = list(promotion_guard.get("blocked_by") or [])
+    promotion_allowed = promotion_guard.get("promotion_allowed") is True
+    near_pass = bool((row.get("near_pass") or {}).get("is_near_pass"))
+    validation_status = validation.get("status")
     return {
         "asset": str(row.get("asset") or ""),
+        "asset_group": row.get("asset_group"),
+        "region": row.get("region"),
+        "hypothesis_id": row.get("hypothesis_id"),
         "preset_name": row.get("preset_name"),
         "strategy_name": row.get("strategy_name"),
         "interval": row.get("interval"),
         "stage_result": row.get("stage_result"),
         "qre_validation_linkage_status": row.get("qre_validation_linkage_status"),
-        "validation_evidence_status": validation.get("status"),
+        "validation_evidence_status": validation_status,
         "oos_trade_count": validation.get("oos_trade_count"),
         "min_oos_trades": validation.get("min_oos_trades"),
-        "promotion_allowed": promotion_guard.get("promotion_allowed") is True,
-        "blocked_by": list(promotion_guard.get("blocked_by") or []),
+        "promotion_allowed": promotion_allowed,
+        "blocked_by": blocked_by,
         "failure_reasons": list(failure_reasons),
-        "near_pass": bool((row.get("near_pass") or {}).get("is_near_pass")),
+        "near_pass": near_pass,
+        "outcome_class": _candidate_outcome_class(
+            row,
+            validation_status=validation_status,
+            failure_reasons=list(failure_reasons),
+            blocked_by=blocked_by,
+            near_pass=near_pass,
+            promotion_allowed=promotion_allowed,
+        ),
+        "fixture_candidate": row.get("fixture_candidate") is True,
+        "not_real_market_evidence": row.get("not_real_market_evidence") is True,
+        "no_paper_activation": row.get("no_paper_activation") is True,
+        "no_live_activation": row.get("no_live_activation") is True,
+        "no_shadow_activation": row.get("no_shadow_activation") is True,
         "metrics": {
             "win_rate": metrics.get("win_rate"),
             "trades_per_maand": metrics.get("trades_per_maand"),
@@ -260,6 +311,7 @@ def _operator_summary(
     runtime_gate_failed_assets: list[str] = []
     public_result_criteria_blocked_assets: list[str] = []
     near_pass_assets: list[str] = []
+    outcome_classes: list[str] = []
 
     for row in sorted(candidates, key=lambda item: str(item.get("asset") or "")):
         op_row = _candidate_operator_row(row)
@@ -284,6 +336,7 @@ def _operator_summary(
             near_pass_count += 1
             near_pass_assets.append(asset)
         failure_reasons.extend(str(reason) for reason in op_row["failure_reasons"])
+        outcome_classes.append(str(op_row["outcome_class"]))
 
     total_candidates = int(screening_summary.get("total_candidates") or len(candidates))
     promotion_blocked_count = max(total_candidates - promotion_allowed_count, 0)
@@ -295,6 +348,26 @@ def _operator_summary(
     freshness = controlled_eval_summary.get("artifact_freshness")
     if not isinstance(freshness, dict):
         freshness = {}
+    preset_names = {
+        str(row["preset_name"])
+        for row in asset_rows
+        if isinstance(row.get("preset_name"), str) and row["preset_name"]
+    }
+    hypothesis_ids = {
+        str(row["hypothesis_id"])
+        for row in asset_rows
+        if isinstance(row.get("hypothesis_id"), str) and row["hypothesis_id"]
+    }
+    regions = {
+        str(row["region"])
+        for row in asset_rows
+        if isinstance(row.get("region"), str) and row["region"]
+    }
+    fixture_candidate_count = sum(1 for row in asset_rows if row["fixture_candidate"])
+    promotion_eligible_fixture_candidate_count = sum(
+        1 for row in asset_rows if row["fixture_candidate"] and row["promotion_allowed"]
+    )
+    outcome_class_summary = _top_counts(outcome_classes, limit=10)
 
     return {
         "total_candidates": total_candidates,
@@ -303,6 +376,16 @@ def _operator_summary(
         "promotion_allowed_count": promotion_allowed_count,
         "promotion_blocked_count": promotion_blocked_count,
         "near_pass_count": near_pass_count,
+        "candidate_diversity": {
+            "preset_count": len(preset_names),
+            "hypothesis_count": len(hypothesis_ids),
+            "region_count": len(regions),
+            "fixture_candidate_count": fixture_candidate_count,
+            "promotion_eligible_fixture_candidate_count": (
+                promotion_eligible_fixture_candidate_count
+            ),
+            "outcome_class_summary": outcome_class_summary,
+        },
         "top_promotion_blockers": _top_counts(blocked_reasons),
         "top_failure_reasons": _top_counts(failure_reasons),
         "runtime_gate_failed_assets": runtime_gate_failed_assets,

--- a/research/production_discovery_catalog.py
+++ b/research/production_discovery_catalog.py
@@ -1,0 +1,466 @@
+"""Read-only production discovery seed for QRE candidate discovery.
+
+This module is catalog/scaffold only. It does not register executable
+strategies, launch campaigns, or grant paper/shadow/live authority.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import cycle
+from typing import Final
+
+
+SCHEMA_VERSION: Final[int] = 1
+MODULE_VERSION: Final[str] = "v1-production-discovery-seed-2026-06-05"
+REGION_ORDER: Final[tuple[str, ...]] = (
+    "NL/EU",
+    "US",
+    "Asia/proxies",
+    "ETFs/context",
+)
+
+
+@dataclass(frozen=True)
+class DiscoveryAsset:
+    symbol: str
+    canonical_instrument_id: str
+    display_name: str
+    region: str
+    country: str
+    exchange: str
+    asset_class: str
+    currency: str
+    sector: str
+    industry: str
+    liquidity_tier: str
+    data_source: str
+    source_quality_status: str
+    enabled_for_discovery: bool
+    enabled_for_validation: bool
+    not_alpha_claim: bool
+    paper_activation_allowed: bool
+    shadow_activation_allowed: bool
+    live_activation_allowed: bool
+    notes: str
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "symbol": self.symbol,
+            "canonical_instrument_id": self.canonical_instrument_id,
+            "display_name": self.display_name,
+            "region": self.region,
+            "country": self.country,
+            "exchange": self.exchange,
+            "asset_class": self.asset_class,
+            "currency": self.currency,
+            "sector": self.sector,
+            "industry": self.industry,
+            "liquidity_tier": self.liquidity_tier,
+            "data_source": self.data_source,
+            "source_quality_status": self.source_quality_status,
+            "enabled_for_discovery": self.enabled_for_discovery,
+            "enabled_for_validation": self.enabled_for_validation,
+            "not_alpha_claim": self.not_alpha_claim,
+            "paper_activation_allowed": self.paper_activation_allowed,
+            "shadow_activation_allowed": self.shadow_activation_allowed,
+            "live_activation_allowed": self.live_activation_allowed,
+            "notes": self.notes,
+        }
+
+
+@dataclass(frozen=True)
+class DiscoveryPreset:
+    preset_id: str
+    hypothesis_id: str
+    behavior_family: str
+    description: str
+    allowed_asset_classes: tuple[str, ...]
+    allowed_regions: tuple[str, ...]
+    allowed_timeframes: tuple[str, ...]
+    required_data_quality: str
+    min_history_bars: int
+    expected_failure_modes: tuple[str, ...]
+    selection_reason: str
+    enabled_for_discovery: bool
+    enabled_for_validation: bool
+    not_alpha_claim: bool
+    paper_activation_allowed: bool
+    shadow_activation_allowed: bool
+    live_activation_allowed: bool
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "preset_id": self.preset_id,
+            "hypothesis_id": self.hypothesis_id,
+            "behavior_family": self.behavior_family,
+            "description": self.description,
+            "allowed_asset_classes": list(self.allowed_asset_classes),
+            "allowed_regions": list(self.allowed_regions),
+            "allowed_timeframes": list(self.allowed_timeframes),
+            "required_data_quality": self.required_data_quality,
+            "min_history_bars": self.min_history_bars,
+            "expected_failure_modes": list(self.expected_failure_modes),
+            "selection_reason": self.selection_reason,
+            "enabled_for_discovery": self.enabled_for_discovery,
+            "enabled_for_validation": self.enabled_for_validation,
+            "not_alpha_claim": self.not_alpha_claim,
+            "paper_activation_allowed": self.paper_activation_allowed,
+            "shadow_activation_allowed": self.shadow_activation_allowed,
+            "live_activation_allowed": self.live_activation_allowed,
+        }
+
+
+def _asset(
+    symbol: str,
+    *,
+    display_name: str,
+    region: str,
+    country: str,
+    exchange: str,
+    currency: str,
+    sector: str,
+    industry: str,
+    notes: str,
+    asset_class: str = "equity",
+    liquidity_tier: str = "high",
+    data_source: str = "existing_data_boundary",
+    source_quality_status: str = "reviewed_seed_only",
+) -> DiscoveryAsset:
+    return DiscoveryAsset(
+        symbol=symbol,
+        canonical_instrument_id=f"{exchange}:{symbol}",
+        display_name=display_name,
+        region=region,
+        country=country,
+        exchange=exchange,
+        asset_class=asset_class,
+        currency=currency,
+        sector=sector,
+        industry=industry,
+        liquidity_tier=liquidity_tier,
+        data_source=data_source,
+        source_quality_status=source_quality_status,
+        enabled_for_discovery=True,
+        enabled_for_validation=True,
+        not_alpha_claim=True,
+        paper_activation_allowed=False,
+        shadow_activation_allowed=False,
+        live_activation_allowed=False,
+        notes=notes,
+    )
+
+
+_ASSETS: Final[tuple[DiscoveryAsset, ...]] = (
+    _asset("ASML", display_name="ASML Holding", region="NL/EU", country="Netherlands", exchange="NASDAQ", currency="USD", sector="Technology", industry="Semiconductor Equipment", notes="Dutch large-cap semiconductor equipment anchor."),
+    _asset("ASMI", display_name="ASM International", region="NL/EU", country="Netherlands", exchange="EURONEXT", currency="EUR", sector="Technology", industry="Semiconductor Equipment", notes="Dutch semiconductor equipment exposure."),
+    _asset("BESI", display_name="BE Semiconductor", region="NL/EU", country="Netherlands", exchange="EURONEXT", currency="EUR", sector="Technology", industry="Semiconductor Equipment", notes="Dutch semiconductor packaging exposure."),
+    _asset("ADYEN", display_name="Adyen", region="NL/EU", country="Netherlands", exchange="EURONEXT", currency="EUR", sector="Financial Technology", industry="Payments", notes="Dutch fintech large-cap seed."),
+    _asset("ING", display_name="ING Group", region="NL/EU", country="Netherlands", exchange="NYSE", currency="USD", sector="Financials", industry="Banking", notes="Banking regime anchor for Europe."),
+    _asset("SHELL", display_name="Shell", region="NL/EU", country="United Kingdom", exchange="NYSE", currency="USD", sector="Energy", industry="Integrated Oil & Gas", notes="Europe energy supermajor proxy."),
+    _asset("PRX", display_name="Prosus", region="NL/EU", country="Netherlands", exchange="EURONEXT", currency="EUR", sector="Communication Services", industry="Internet Holdings", notes="Dutch internet holding exposure."),
+    _asset("SAP", display_name="SAP", region="NL/EU", country="Germany", exchange="NYSE", currency="USD", sector="Technology", industry="Enterprise Software", notes="Europe software leadership seed."),
+    _asset("SIE", display_name="Siemens", region="NL/EU", country="Germany", exchange="XETRA", currency="EUR", sector="Industrials", industry="Industrial Conglomerates", notes="Europe industrial trend seed."),
+    _asset("LVMH", display_name="LVMH", region="NL/EU", country="France", exchange="EURONEXT", currency="EUR", sector="Consumer Discretionary", industry="Luxury Goods", notes="Europe consumer leadership seed."),
+    _asset("NOVO-B", display_name="Novo Nordisk", region="NL/EU", country="Denmark", exchange="NYSE", currency="USD", sector="Health Care", industry="Pharmaceuticals", notes="Europe health-care leadership seed."),
+    _asset("AIR", display_name="Airbus", region="NL/EU", country="France", exchange="EURONEXT", currency="EUR", sector="Industrials", industry="Aerospace & Defense", notes="Europe aerospace cycle seed."),
+    _asset("TTE", display_name="TotalEnergies", region="NL/EU", country="France", exchange="NYSE", currency="USD", sector="Energy", industry="Integrated Oil & Gas", notes="Europe energy trend seed."),
+    _asset("IFX", display_name="Infineon", region="NL/EU", country="Germany", exchange="XETRA", currency="EUR", sector="Technology", industry="Semiconductors", notes="Europe semiconductor cycle seed."),
+    _asset("NESN", display_name="Nestle", region="NL/EU", country="Switzerland", exchange="SIX", currency="CHF", sector="Consumer Staples", industry="Packaged Foods", notes="Defensive Europe large-cap seed."),
+    _asset("AAPL", display_name="Apple", region="US", country="United States", exchange="NASDAQ", currency="USD", sector="Technology", industry="Consumer Electronics", notes="US mega-cap leadership anchor."),
+    _asset("MSFT", display_name="Microsoft", region="US", country="United States", exchange="NASDAQ", currency="USD", sector="Technology", industry="Software", notes="US mega-cap software anchor."),
+    _asset("NVDA", display_name="NVIDIA", region="US", country="United States", exchange="NASDAQ", currency="USD", sector="Technology", industry="Semiconductors", notes="US semiconductor momentum seed."),
+    _asset("AMD", display_name="AMD", region="US", country="United States", exchange="NASDAQ", currency="USD", sector="Technology", industry="Semiconductors", notes="US semiconductor challenger seed."),
+    _asset("GOOGL", display_name="Alphabet", region="US", country="United States", exchange="NASDAQ", currency="USD", sector="Communication Services", industry="Internet Services", notes="US internet leadership seed."),
+    _asset("META", display_name="Meta Platforms", region="US", country="United States", exchange="NASDAQ", currency="USD", sector="Communication Services", industry="Internet Services", notes="US platform momentum seed."),
+    _asset("AMZN", display_name="Amazon", region="US", country="United States", exchange="NASDAQ", currency="USD", sector="Consumer Discretionary", industry="E-Commerce", notes="US consumer platform leadership seed."),
+    _asset("TSLA", display_name="Tesla", region="US", country="United States", exchange="NASDAQ", currency="USD", sector="Consumer Discretionary", industry="Automobiles", notes="US high-beta EV seed."),
+    _asset("AVGO", display_name="Broadcom", region="US", country="United States", exchange="NASDAQ", currency="USD", sector="Technology", industry="Semiconductors", notes="US infrastructure semiconductor seed."),
+    _asset("JPM", display_name="JPMorgan Chase", region="US", country="United States", exchange="NYSE", currency="USD", sector="Financials", industry="Banking", notes="US financial regime anchor."),
+    _asset("XOM", display_name="Exxon Mobil", region="US", country="United States", exchange="NYSE", currency="USD", sector="Energy", industry="Integrated Oil & Gas", notes="US energy large-cap seed."),
+    _asset("COST", display_name="Costco", region="US", country="United States", exchange="NASDAQ", currency="USD", sector="Consumer Staples", industry="Retail", notes="US defensive consumer leader."),
+    _asset("TSM", display_name="Taiwan Semiconductor", region="Asia/proxies", country="Taiwan", exchange="NYSE", currency="USD", sector="Technology", industry="Semiconductors", notes="Asia semiconductor foundry anchor."),
+    _asset("TM", display_name="Toyota Motor", region="Asia/proxies", country="Japan", exchange="NYSE", currency="USD", sector="Consumer Discretionary", industry="Automobiles", notes="Japan industrial/export proxy."),
+    _asset("SONY", display_name="Sony Group", region="Asia/proxies", country="Japan", exchange="NYSE", currency="USD", sector="Consumer Discretionary", industry="Consumer Electronics", notes="Japan electronics/media proxy."),
+    _asset("BABA", display_name="Alibaba", region="Asia/proxies", country="China", exchange="NYSE", currency="USD", sector="Consumer Discretionary", industry="E-Commerce", notes="China internet proxy."),
+    _asset("TCEHY", display_name="Tencent", region="Asia/proxies", country="China", exchange="OTC", currency="USD", sector="Communication Services", industry="Internet Services", notes="China platform proxy via ADR/OTC."),
+    _asset("INFY", display_name="Infosys", region="Asia/proxies", country="India", exchange="NYSE", currency="USD", sector="Technology", industry="IT Services", notes="India IT services proxy."),
+    _asset("SPY", display_name="SPDR S&P 500 ETF", region="ETFs/context", country="United States", exchange="NYSEARCA", currency="USD", sector="Multi-sector", industry="Broad Market ETF", notes="US benchmark context ETF.", asset_class="etf"),
+    _asset("QQQ", display_name="Invesco QQQ Trust", region="ETFs/context", country="United States", exchange="NASDAQ", currency="USD", sector="Technology", industry="Nasdaq 100 ETF", notes="US growth benchmark ETF.", asset_class="etf"),
+    _asset("SMH", display_name="VanEck Semiconductor ETF", region="ETFs/context", country="United States", exchange="NASDAQ", currency="USD", sector="Technology", industry="Semiconductor ETF", notes="Semiconductor context ETF.", asset_class="etf"),
+    _asset("VGK", display_name="Vanguard FTSE Europe ETF", region="ETFs/context", country="Europe", exchange="NYSEARCA", currency="USD", sector="Multi-sector", industry="Europe Equity ETF", notes="Europe benchmark context ETF.", asset_class="etf"),
+    _asset("EWJ", display_name="iShares MSCI Japan ETF", region="ETFs/context", country="Japan", exchange="NYSEARCA", currency="USD", sector="Multi-sector", industry="Japan Equity ETF", notes="Japan benchmark context ETF.", asset_class="etf"),
+    _asset("EWT", display_name="iShares MSCI Taiwan ETF", region="ETFs/context", country="Taiwan", exchange="NYSEARCA", currency="USD", sector="Multi-sector", industry="Taiwan Equity ETF", notes="Taiwan benchmark context ETF.", asset_class="etf"),
+    _asset("EWY", display_name="iShares MSCI South Korea ETF", region="ETFs/context", country="South Korea", exchange="NYSEARCA", currency="USD", sector="Multi-sector", industry="Korea Equity ETF", notes="Korea benchmark context ETF.", asset_class="etf"),
+    _asset("INDA", display_name="iShares MSCI India ETF", region="ETFs/context", country="India", exchange="NYSEARCA", currency="USD", sector="Multi-sector", industry="India Equity ETF", notes="India benchmark context ETF.", asset_class="etf"),
+)
+
+
+_PRESETS: Final[tuple[DiscoveryPreset, ...]] = (
+    DiscoveryPreset(
+        preset_id="trend_continuation_daily_v1",
+        hypothesis_id="trend_continuation_behavior_v1",
+        behavior_family="trend_continuation",
+        description="Persistent trend continuation after shallow pullbacks in liquid equities.",
+        allowed_asset_classes=("equity", "etf"),
+        allowed_regions=("NL/EU", "US", "Asia/proxies", "ETFs/context"),
+        allowed_timeframes=("1d",),
+        required_data_quality="reviewed_seed_only",
+        min_history_bars=750,
+        expected_failure_modes=("insufficient_trades", "late_trend_entry", "trend_break_reversal"),
+        selection_reason="Baseline trend research across liquid regions.",
+        enabled_for_discovery=True,
+        enabled_for_validation=True,
+        not_alpha_claim=True,
+        paper_activation_allowed=False,
+        shadow_activation_allowed=False,
+        live_activation_allowed=False,
+    ),
+    DiscoveryPreset(
+        preset_id="trend_pullback_continuation_daily_v1",
+        hypothesis_id="trend_pullback_behavior_v1",
+        behavior_family="trend_pullback",
+        description="Trend continuation after a volatility-normalized pullback.",
+        allowed_asset_classes=("equity",),
+        allowed_regions=("NL/EU", "US", "Asia/proxies"),
+        allowed_timeframes=("1d",),
+        required_data_quality="reviewed_seed_only",
+        min_history_bars=750,
+        expected_failure_modes=("insufficient_trades", "no_oos_trades", "weak_follow_through"),
+        selection_reason="Extends current trend-pullback research to broader regions without execution authority.",
+        enabled_for_discovery=True,
+        enabled_for_validation=True,
+        not_alpha_claim=True,
+        paper_activation_allowed=False,
+        shadow_activation_allowed=False,
+        live_activation_allowed=False,
+    ),
+    DiscoveryPreset(
+        preset_id="vol_compression_breakout_daily_v1",
+        hypothesis_id="vol_compression_expansion_behavior_v1",
+        behavior_family="volatility_compression_breakout",
+        description="Daily compression to expansion behavior in liquid leadership names.",
+        allowed_asset_classes=("equity", "etf"),
+        allowed_regions=("NL/EU", "US", "Asia/proxies", "ETFs/context"),
+        allowed_timeframes=("1d",),
+        required_data_quality="reviewed_seed_only",
+        min_history_bars=750,
+        expected_failure_modes=("false_breakout", "insufficient_trades", "post_breakout_mean_reversion"),
+        selection_reason="Provides a non-trend-only discovery family for autonomous research.",
+        enabled_for_discovery=True,
+        enabled_for_validation=True,
+        not_alpha_claim=True,
+        paper_activation_allowed=False,
+        shadow_activation_allowed=False,
+        live_activation_allowed=False,
+    ),
+    DiscoveryPreset(
+        preset_id="vol_compression_breakout_4h_v1",
+        hypothesis_id="vol_compression_expansion_behavior_v1",
+        behavior_family="volatility_compression_breakout",
+        description="4h compression to expansion behavior for liquid leadership and context ETFs.",
+        allowed_asset_classes=("equity", "etf"),
+        allowed_regions=("US", "ETFs/context"),
+        allowed_timeframes=("4h",),
+        required_data_quality="reviewed_seed_only",
+        min_history_bars=1200,
+        expected_failure_modes=("insufficient_trades", "microstructure_noise", "failed_breakout"),
+        selection_reason="Higher-frequency breakout companion for bounded controlled validation routing.",
+        enabled_for_discovery=True,
+        enabled_for_validation=True,
+        not_alpha_claim=True,
+        paper_activation_allowed=False,
+        shadow_activation_allowed=False,
+        live_activation_allowed=False,
+    ),
+    DiscoveryPreset(
+        preset_id="relative_strength_vs_sector_daily_v1",
+        hypothesis_id="relative_strength_sector_behavior_v1",
+        behavior_family="relative_strength_sector",
+        description="Leadership persistence versus sector peers in liquid equities.",
+        allowed_asset_classes=("equity",),
+        allowed_regions=("NL/EU", "US"),
+        allowed_timeframes=("1d",),
+        required_data_quality="reviewed_seed_only",
+        min_history_bars=750,
+        expected_failure_modes=("leader_rotation", "no_oos_trades", "sector_mean_reversion"),
+        selection_reason="Tests whether sector leadership can seed differentiated candidates.",
+        enabled_for_discovery=True,
+        enabled_for_validation=True,
+        not_alpha_claim=True,
+        paper_activation_allowed=False,
+        shadow_activation_allowed=False,
+        live_activation_allowed=False,
+    ),
+    DiscoveryPreset(
+        preset_id="relative_strength_vs_region_daily_v1",
+        hypothesis_id="relative_strength_region_behavior_v1",
+        behavior_family="relative_strength_region",
+        description="Persistent relative strength versus regional benchmarks and peers.",
+        allowed_asset_classes=("equity", "etf"),
+        allowed_regions=("NL/EU", "US", "Asia/proxies", "ETFs/context"),
+        allowed_timeframes=("1d",),
+        required_data_quality="reviewed_seed_only",
+        min_history_bars=750,
+        expected_failure_modes=("benchmark_reversal", "insufficient_trades", "relative_strength_decay"),
+        selection_reason="Adds cross-region leadership behavior without executable authority.",
+        enabled_for_discovery=True,
+        enabled_for_validation=True,
+        not_alpha_claim=True,
+        paper_activation_allowed=False,
+        shadow_activation_allowed=False,
+        live_activation_allowed=False,
+    ),
+    DiscoveryPreset(
+        preset_id="post_shock_stabilization_daily_v1",
+        hypothesis_id="post_shock_stabilization_behavior_v1",
+        behavior_family="post_shock_stabilization",
+        description="Recovery and stabilization behavior after sharp dislocations.",
+        allowed_asset_classes=("equity", "etf"),
+        allowed_regions=("NL/EU", "US", "Asia/proxies", "ETFs/context"),
+        allowed_timeframes=("1d",),
+        required_data_quality="reviewed_seed_only",
+        min_history_bars=900,
+        expected_failure_modes=("aftershock_instability", "no_oos_trades", "insufficient_trades"),
+        selection_reason="Supports research into post-dislocation recovery regimes.",
+        enabled_for_discovery=True,
+        enabled_for_validation=True,
+        not_alpha_claim=True,
+        paper_activation_allowed=False,
+        shadow_activation_allowed=False,
+        live_activation_allowed=False,
+    ),
+    DiscoveryPreset(
+        preset_id="index_regime_filter_daily_v1",
+        hypothesis_id="index_regime_filter_behavior_v1",
+        behavior_family="regime_context_filter",
+        description="Index and sector context filter for regime-aware candidate selection.",
+        allowed_asset_classes=("equity", "etf"),
+        allowed_regions=("NL/EU", "US", "Asia/proxies", "ETFs/context"),
+        allowed_timeframes=("1d",),
+        required_data_quality="reviewed_seed_only",
+        min_history_bars=900,
+        expected_failure_modes=("weak_signal_specificity", "regime_flip", "benchmark_noise"),
+        selection_reason="Provides read-only regime context alongside directional behaviors.",
+        enabled_for_discovery=True,
+        enabled_for_validation=True,
+        not_alpha_claim=True,
+        paper_activation_allowed=False,
+        shadow_activation_allowed=False,
+        live_activation_allowed=False,
+    ),
+)
+
+
+def list_assets() -> list[DiscoveryAsset]:
+    return list(_ASSETS)
+
+
+def list_presets() -> list[DiscoveryPreset]:
+    return list(_PRESETS)
+
+
+def _asset_matches_preset(asset: DiscoveryAsset, preset: DiscoveryPreset) -> bool:
+    return (
+        asset.enabled_for_discovery
+        and asset.asset_class in preset.allowed_asset_classes
+        and asset.region in preset.allowed_regions
+        and asset.source_quality_status == preset.required_data_quality
+    )
+
+
+def build_bounded_candidate_basket(*, max_candidates: int = 15) -> list[dict[str, object]]:
+    if max_candidates <= 0:
+        return []
+
+    presets = list_presets()
+    candidate_lists = [
+        [asset for asset in list_assets() if _asset_matches_preset(asset, preset)]
+        for preset in presets
+    ]
+    if not any(candidate_lists):
+        return []
+
+    counters = [0] * len(presets)
+    basket: list[dict[str, object]] = []
+    seen: set[tuple[str, str]] = set()
+    region_offsets = {region: 0 for region in REGION_ORDER}
+
+    for preset_index in cycle(range(len(presets))):
+        preset = presets[preset_index]
+        matches = candidate_lists[preset_index]
+        if not matches:
+            continue
+        selected: DiscoveryAsset | None = None
+        preferred_regions = REGION_ORDER[preset_index % len(REGION_ORDER) :] + REGION_ORDER[
+            : preset_index % len(REGION_ORDER)
+        ]
+        for region in preferred_regions:
+            region_matches = [asset for asset in matches if asset.region == region]
+            if not region_matches:
+                continue
+            start_index = region_offsets[region]
+            for offset in range(len(region_matches)):
+                asset = region_matches[(start_index + offset) % len(region_matches)]
+                key = (preset.preset_id, asset.symbol)
+                if key not in seen:
+                    selected = asset
+                    region_offsets[region] = start_index + offset + 1
+                    counters[preset_index] += 1
+                    seen.add(key)
+                    break
+            if selected is not None:
+                break
+        if selected is None:
+            start_index = counters[preset_index]
+            for offset in range(len(matches)):
+                asset = matches[(start_index + offset) % len(matches)]
+                key = (preset.preset_id, asset.symbol)
+                if key not in seen:
+                    selected = asset
+                    counters[preset_index] = start_index + offset + 1
+                    seen.add(key)
+                    break
+        if selected is None:
+            if len(seen) == sum(len(items) for items in candidate_lists):
+                break
+            continue
+        basket.append(
+            {
+                "candidate_id": f"seed::{preset.preset_id}::{selected.symbol}",
+                "symbol": selected.symbol,
+                "region": selected.region,
+                "asset_class": selected.asset_class,
+                "preset_id": preset.preset_id,
+                "hypothesis_id": preset.hypothesis_id,
+                "behavior_family": preset.behavior_family,
+                "timeframes": list(preset.allowed_timeframes),
+                "enabled_for_discovery": True,
+                "enabled_for_validation": True,
+                "not_alpha_claim": True,
+                "paper_activation_allowed": False,
+                "shadow_activation_allowed": False,
+                "live_activation_allowed": False,
+            }
+        )
+        if len(basket) >= max_candidates:
+            break
+
+    return basket
+
+
+def production_discovery_catalog_payload(*, max_candidates: int = 15) -> dict[str, object]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "module_version": MODULE_VERSION,
+        "assets": [asset.to_payload() for asset in list_assets()],
+        "presets": [preset.to_payload() for preset in list_presets()],
+        "bounded_candidate_basket": build_bounded_candidate_basket(
+            max_candidates=max_candidates
+        ),
+        "read_only": True,
+        "not_alpha_claim": True,
+        "paper_activation_allowed": False,
+        "shadow_activation_allowed": False,
+        "live_activation_allowed": False,
+    }

--- a/tests/fixtures/qre_controlled_validation/candidate_diversity_harness.json
+++ b/tests/fixtures/qre_controlled_validation/candidate_diversity_harness.json
@@ -1,0 +1,615 @@
+{
+  "execution_snapshot": {
+    "report_kind": "qre_controlled_validation_execution",
+    "selection_profile_name": "candidate_diversity_harness_v1",
+    "execution_status": "execution_completed",
+    "controlled_validation_authorized": true,
+    "runner_adapter_status": "connected",
+    "executed_anything": true,
+    "final_recommendation": "controlled_validation_execution_completed"
+  },
+  "controlled_eval_report": {
+    "verdict": {
+      "status": "useful_observation",
+      "reason_codes": []
+    },
+    "campaigns_completed": 1,
+    "campaign_level_evidence_valid": true,
+    "recommended_next_action": "inspect_results",
+    "git_revision": "abc123",
+    "screening_evidence_summary": {
+      "present": true,
+      "total_candidates": 15,
+      "passed_screening": 11,
+      "rejected_screening": 4,
+      "promotion_grade_candidates": 1,
+      "sufficient_oos_evidence_candidates": 4,
+      "qre_linkage_blocked_candidates": 0,
+      "sufficient_oos_but_unlinked_candidates": 0
+    }
+  },
+  "screening_evidence_payload": {
+    "candidates": [
+      {
+        "asset": "ADYEN",
+        "asset_group": "NL_EU",
+        "region": "NL/EU",
+        "hypothesis_id": "post_shock_stabilization_behavior_v1",
+        "preset_name": "post_shock_stabilization_daily_v1",
+        "strategy_name": "fixture_only_behavior_seed",
+        "interval": "1d",
+        "stage_result": "screening_reject",
+        "qre_validation_linkage_status": "linked_catalog_active_discovery",
+        "validation_evidence": {
+          "status": "no_oos_trades",
+          "oos_trade_count": 0,
+          "min_oos_trades": 10
+        },
+        "promotion_guard": {
+          "promotion_allowed": false,
+          "blocked_by": [
+            "criteria_expectancy_above_zero_failed",
+            "criteria_sufficient_trades_failed"
+          ]
+        },
+        "failure_reasons": [
+          "insufficient_trades"
+        ],
+        "near_pass": {
+          "is_near_pass": false
+        },
+        "metrics": {
+          "win_rate": 0.0,
+          "trades_per_maand": 0.0,
+          "consistentie": null,
+          "deflated_sharpe": null
+        },
+        "outcome_class": "reject_insufficient_trades",
+        "fixture_candidate": true,
+        "not_real_market_evidence": true,
+        "no_paper_activation": true,
+        "no_shadow_activation": true,
+        "no_live_activation": true
+      },
+      {
+        "asset": "AIR",
+        "asset_group": "NL_EU",
+        "region": "NL/EU",
+        "hypothesis_id": "vol_compression_expansion_behavior_v1",
+        "preset_name": "vol_compression_breakout_daily_v1",
+        "strategy_name": "fixture_only_behavior_seed",
+        "interval": "1d",
+        "stage_result": "screening_pass",
+        "qre_validation_linkage_status": "linked_catalog_active_discovery",
+        "validation_evidence": {
+          "status": "no_oos_trades",
+          "oos_trade_count": 0,
+          "min_oos_trades": 10
+        },
+        "promotion_guard": {
+          "promotion_allowed": false,
+          "blocked_by": [
+            "criteria_consistentie_failed"
+          ]
+        },
+        "failure_reasons": [],
+        "near_pass": {
+          "is_near_pass": false
+        },
+        "metrics": {
+          "win_rate": 0.48,
+          "trades_per_maand": 1.5,
+          "consistentie": 0.19,
+          "deflated_sharpe": 0.16
+        },
+        "outcome_class": "reject_criteria_consistentie_failed",
+        "fixture_candidate": true,
+        "not_real_market_evidence": true,
+        "no_paper_activation": true,
+        "no_shadow_activation": true,
+        "no_live_activation": true
+      },
+      {
+        "asset": "ASML",
+        "asset_group": "NL_EU",
+        "region": "NL/EU",
+        "hypothesis_id": "trend_pullback_behavior_v1",
+        "preset_name": "trend_pullback_continuation_daily_v1",
+        "strategy_name": "fixture_only_behavior_seed",
+        "interval": "1d",
+        "stage_result": "screening_pass",
+        "qre_validation_linkage_status": "linked_catalog_active_discovery",
+        "validation_evidence": {
+          "status": "no_oos_trades",
+          "oos_trade_count": 0,
+          "min_oos_trades": 10
+        },
+        "promotion_guard": {
+          "promotion_allowed": false,
+          "blocked_by": [
+            "criteria_trades_per_maand_failed"
+          ]
+        },
+        "failure_reasons": [],
+        "near_pass": {
+          "is_near_pass": false
+        },
+        "metrics": {
+          "win_rate": 0.5,
+          "trades_per_maand": 0.8,
+          "consistentie": 0.35,
+          "deflated_sharpe": 0.31
+        },
+        "outcome_class": "reject_criteria_trades_per_maand_failed",
+        "fixture_candidate": true,
+        "not_real_market_evidence": true,
+        "no_paper_activation": true,
+        "no_shadow_activation": true,
+        "no_live_activation": true
+      },
+      {
+        "asset": "BABA",
+        "asset_group": "ASIA",
+        "region": "Asia/proxies",
+        "hypothesis_id": "relative_strength_region_behavior_v1",
+        "preset_name": "relative_strength_vs_region_daily_v1",
+        "strategy_name": "fixture_only_behavior_seed",
+        "interval": "1d",
+        "stage_result": "screening_pass",
+        "qre_validation_linkage_status": "linked_catalog_active_discovery",
+        "validation_evidence": {
+          "status": "no_oos_trades",
+          "oos_trade_count": 0,
+          "min_oos_trades": 10
+        },
+        "promotion_guard": {
+          "promotion_allowed": false,
+          "blocked_by": [
+            "criteria_win_rate_failed"
+          ]
+        },
+        "failure_reasons": [],
+        "near_pass": {
+          "is_near_pass": false
+        },
+        "metrics": {
+          "win_rate": 0.43,
+          "trades_per_maand": 1.9,
+          "consistentie": 0.39,
+          "deflated_sharpe": 0.27
+        },
+        "outcome_class": "reject_criteria_win_rate_failed",
+        "fixture_candidate": true,
+        "not_real_market_evidence": true,
+        "no_paper_activation": true,
+        "no_shadow_activation": true,
+        "no_live_activation": true
+      },
+      {
+        "asset": "EWJ",
+        "asset_group": "ETF_CONTEXT",
+        "region": "ETFs/context",
+        "hypothesis_id": "index_regime_filter_behavior_v1",
+        "preset_name": "index_regime_filter_daily_v1",
+        "strategy_name": "fixture_only_behavior_seed",
+        "interval": "1d",
+        "stage_result": "screening_pass",
+        "qre_validation_linkage_status": "linked_catalog_active_discovery",
+        "validation_evidence": {
+          "status": "sufficient_oos_evidence",
+          "oos_trade_count": 12,
+          "min_oos_trades": 10
+        },
+        "promotion_guard": {
+          "promotion_allowed": false,
+          "blocked_by": [
+            "criteria_win_rate_failed"
+          ]
+        },
+        "failure_reasons": [],
+        "near_pass": {
+          "is_near_pass": true
+        },
+        "metrics": {
+          "win_rate": 0.49,
+          "trades_per_maand": 1.8,
+          "consistentie": 0.42,
+          "deflated_sharpe": 0.41
+        },
+        "outcome_class": "near_pass",
+        "fixture_candidate": true,
+        "not_real_market_evidence": true,
+        "no_paper_activation": true,
+        "no_shadow_activation": true,
+        "no_live_activation": true
+      },
+      {
+        "asset": "GOOGL",
+        "asset_group": "US",
+        "region": "US",
+        "hypothesis_id": "relative_strength_sector_behavior_v1",
+        "preset_name": "relative_strength_vs_sector_daily_v1",
+        "strategy_name": "fixture_only_behavior_seed",
+        "interval": "1d",
+        "stage_result": "screening_reject",
+        "qre_validation_linkage_status": "linked_catalog_active_discovery",
+        "validation_evidence": {
+          "status": "no_oos_trades",
+          "oos_trade_count": 0,
+          "min_oos_trades": 10
+        },
+        "promotion_guard": {
+          "promotion_allowed": false,
+          "blocked_by": [
+            "criteria_expectancy_above_zero_failed",
+            "criteria_sufficient_trades_failed"
+          ]
+        },
+        "failure_reasons": [
+          "insufficient_trades"
+        ],
+        "near_pass": {
+          "is_near_pass": false
+        },
+        "metrics": {
+          "win_rate": 0.0,
+          "trades_per_maand": 0.0,
+          "consistentie": null,
+          "deflated_sharpe": null
+        },
+        "outcome_class": "reject_insufficient_trades",
+        "fixture_candidate": true,
+        "not_real_market_evidence": true,
+        "no_paper_activation": true,
+        "no_shadow_activation": true,
+        "no_live_activation": true
+      },
+      {
+        "asset": "JPM",
+        "asset_group": "US",
+        "region": "US",
+        "hypothesis_id": "trend_continuation_behavior_v1",
+        "preset_name": "trend_continuation_daily_v1",
+        "strategy_name": "fixture_only_behavior_seed",
+        "interval": "1d",
+        "stage_result": "screening_pass",
+        "qre_validation_linkage_status": "linked_catalog_active_discovery",
+        "validation_evidence": {
+          "status": "no_oos_trades",
+          "oos_trade_count": 0,
+          "min_oos_trades": 10
+        },
+        "promotion_guard": {
+          "promotion_allowed": false,
+          "blocked_by": [
+            "criteria_consistentie_failed"
+          ]
+        },
+        "failure_reasons": [],
+        "near_pass": {
+          "is_near_pass": false
+        },
+        "metrics": {
+          "win_rate": 0.51,
+          "trades_per_maand": 1.6,
+          "consistentie": 0.22,
+          "deflated_sharpe": 0.19
+        },
+        "outcome_class": "reject_no_oos_evidence",
+        "fixture_candidate": true,
+        "not_real_market_evidence": true,
+        "no_paper_activation": true,
+        "no_shadow_activation": true,
+        "no_live_activation": true
+      },
+      {
+        "asset": "NESN",
+        "asset_group": "NL_EU",
+        "region": "NL/EU",
+        "hypothesis_id": "relative_strength_sector_behavior_v1",
+        "preset_name": "relative_strength_vs_sector_daily_v1",
+        "strategy_name": "fixture_only_behavior_seed",
+        "interval": "1d",
+        "stage_result": "screening_reject",
+        "qre_validation_linkage_status": "linked_catalog_active_discovery",
+        "validation_evidence": {
+          "status": "no_oos_trades",
+          "oos_trade_count": 0,
+          "min_oos_trades": 10
+        },
+        "promotion_guard": {
+          "promotion_allowed": false,
+          "blocked_by": [
+            "criteria_expectancy_above_zero_failed",
+            "criteria_sufficient_trades_failed"
+          ]
+        },
+        "failure_reasons": [
+          "insufficient_trades"
+        ],
+        "near_pass": {
+          "is_near_pass": false
+        },
+        "metrics": {
+          "win_rate": 0.0,
+          "trades_per_maand": 0.0,
+          "consistentie": null,
+          "deflated_sharpe": null
+        },
+        "outcome_class": "reject_insufficient_trades",
+        "fixture_candidate": true,
+        "not_real_market_evidence": true,
+        "no_paper_activation": true,
+        "no_shadow_activation": true,
+        "no_live_activation": true
+      },
+      {
+        "asset": "NVDA",
+        "asset_group": "US",
+        "region": "US",
+        "hypothesis_id": "vol_compression_expansion_behavior_v1",
+        "preset_name": "vol_compression_breakout_4h_v1",
+        "strategy_name": "fixture_only_behavior_seed",
+        "interval": "4h",
+        "stage_result": "screening_pass",
+        "qre_validation_linkage_status": "linked_catalog_active_discovery",
+        "validation_evidence": {
+          "status": "no_oos_trades",
+          "oos_trade_count": 0,
+          "min_oos_trades": 10
+        },
+        "promotion_guard": {
+          "promotion_allowed": false,
+          "blocked_by": [
+            "criteria_win_rate_failed"
+          ]
+        },
+        "failure_reasons": [],
+        "near_pass": {
+          "is_near_pass": false
+        },
+        "metrics": {
+          "win_rate": 0.44,
+          "trades_per_maand": 2.4,
+          "consistentie": 0.45,
+          "deflated_sharpe": 0.28
+        },
+        "outcome_class": "reject_no_oos_evidence",
+        "fixture_candidate": true,
+        "not_real_market_evidence": true,
+        "no_paper_activation": true,
+        "no_shadow_activation": true,
+        "no_live_activation": true
+      },
+      {
+        "asset": "PRX",
+        "asset_group": "NL_EU",
+        "region": "NL/EU",
+        "hypothesis_id": "trend_continuation_behavior_v1",
+        "preset_name": "trend_continuation_daily_v1",
+        "strategy_name": "fixture_only_behavior_seed",
+        "interval": "1d",
+        "stage_result": "screening_pass",
+        "qre_validation_linkage_status": "linked_catalog_active_discovery",
+        "validation_evidence": {
+          "status": "sufficient_oos_evidence",
+          "oos_trade_count": 15,
+          "min_oos_trades": 10
+        },
+        "promotion_guard": {
+          "promotion_allowed": true,
+          "blocked_by": []
+        },
+        "failure_reasons": [],
+        "near_pass": {
+          "is_near_pass": false
+        },
+        "metrics": {
+          "win_rate": 0.58,
+          "trades_per_maand": 2.8,
+          "consistentie": 0.63,
+          "deflated_sharpe": 0.78
+        },
+        "outcome_class": "promotion_eligible_fixture_candidate",
+        "fixture_candidate": true,
+        "not_real_market_evidence": true,
+        "no_paper_activation": true,
+        "no_shadow_activation": true,
+        "no_live_activation": true
+      },
+      {
+        "asset": "QQQ",
+        "asset_group": "ETF_CONTEXT",
+        "region": "ETFs/context",
+        "hypothesis_id": "relative_strength_region_behavior_v1",
+        "preset_name": "relative_strength_vs_region_daily_v1",
+        "strategy_name": "fixture_only_behavior_seed",
+        "interval": "1d",
+        "stage_result": "screening_pass",
+        "qre_validation_linkage_status": "linked_catalog_active_discovery",
+        "validation_evidence": {
+          "status": "sufficient_oos_evidence",
+          "oos_trade_count": 11,
+          "min_oos_trades": 10
+        },
+        "promotion_guard": {
+          "promotion_allowed": false,
+          "blocked_by": [
+            "criteria_trades_per_maand_failed"
+          ]
+        },
+        "failure_reasons": [],
+        "near_pass": {
+          "is_near_pass": false
+        },
+        "metrics": {
+          "win_rate": 0.54,
+          "trades_per_maand": 0.9,
+          "consistentie": 0.51,
+          "deflated_sharpe": 0.62
+        },
+        "outcome_class": "reject_criteria_trades_per_maand_failed",
+        "fixture_candidate": true,
+        "not_real_market_evidence": true,
+        "no_paper_activation": true,
+        "no_shadow_activation": true,
+        "no_live_activation": true
+      },
+      {
+        "asset": "SMH",
+        "asset_group": "ETF_CONTEXT",
+        "region": "ETFs/context",
+        "hypothesis_id": "vol_compression_expansion_behavior_v1",
+        "preset_name": "vol_compression_breakout_4h_v1",
+        "strategy_name": "fixture_only_behavior_seed",
+        "interval": "4h",
+        "stage_result": "screening_pass",
+        "qre_validation_linkage_status": "linked_catalog_active_discovery",
+        "validation_evidence": {
+          "status": "no_oos_trades",
+          "oos_trade_count": 0,
+          "min_oos_trades": 10
+        },
+        "promotion_guard": {
+          "promotion_allowed": false,
+          "blocked_by": [
+            "criteria_consistentie_failed"
+          ]
+        },
+        "failure_reasons": [],
+        "near_pass": {
+          "is_near_pass": false
+        },
+        "metrics": {
+          "win_rate": 0.53,
+          "trades_per_maand": 1.7,
+          "consistentie": 0.18,
+          "deflated_sharpe": 0.25
+        },
+        "outcome_class": "reject_criteria_consistentie_failed",
+        "fixture_candidate": true,
+        "not_real_market_evidence": true,
+        "no_paper_activation": true,
+        "no_shadow_activation": true,
+        "no_live_activation": true
+      },
+      {
+        "asset": "SONY",
+        "asset_group": "ASIA",
+        "region": "Asia/proxies",
+        "hypothesis_id": "post_shock_stabilization_behavior_v1",
+        "preset_name": "post_shock_stabilization_daily_v1",
+        "strategy_name": "fixture_only_behavior_seed",
+        "interval": "1d",
+        "stage_result": "screening_pass",
+        "qre_validation_linkage_status": "linked_catalog_active_discovery",
+        "validation_evidence": {
+          "status": "no_oos_trades",
+          "oos_trade_count": 0,
+          "min_oos_trades": 10
+        },
+        "promotion_guard": {
+          "promotion_allowed": false,
+          "blocked_by": [
+            "criteria_win_rate_failed"
+          ]
+        },
+        "failure_reasons": [],
+        "near_pass": {
+          "is_near_pass": false
+        },
+        "metrics": {
+          "win_rate": 0.41,
+          "trades_per_maand": 2.3,
+          "consistentie": 0.46,
+          "deflated_sharpe": 0.29
+        },
+        "outcome_class": "reject_criteria_win_rate_failed",
+        "fixture_candidate": true,
+        "not_real_market_evidence": true,
+        "no_paper_activation": true,
+        "no_shadow_activation": true,
+        "no_live_activation": true
+      },
+      {
+        "asset": "TSLA",
+        "asset_group": "US",
+        "region": "US",
+        "hypothesis_id": "trend_pullback_behavior_v1",
+        "preset_name": "trend_pullback_continuation_daily_v1",
+        "strategy_name": "fixture_only_behavior_seed",
+        "interval": "1d",
+        "stage_result": "screening_reject",
+        "qre_validation_linkage_status": "linked_catalog_active_discovery",
+        "validation_evidence": {
+          "status": "no_oos_trades",
+          "oos_trade_count": 0,
+          "min_oos_trades": 10
+        },
+        "promotion_guard": {
+          "promotion_allowed": false,
+          "blocked_by": [
+            "criteria_expectancy_above_zero_failed",
+            "criteria_sufficient_trades_failed"
+          ]
+        },
+        "failure_reasons": [
+          "insufficient_trades"
+        ],
+        "near_pass": {
+          "is_near_pass": false
+        },
+        "metrics": {
+          "win_rate": 0.0,
+          "trades_per_maand": 0.0,
+          "consistentie": null,
+          "deflated_sharpe": null
+        },
+        "outcome_class": "reject_insufficient_trades",
+        "fixture_candidate": true,
+        "not_real_market_evidence": true,
+        "no_paper_activation": true,
+        "no_shadow_activation": true,
+        "no_live_activation": true
+      },
+      {
+        "asset": "VGK",
+        "asset_group": "ETF_CONTEXT",
+        "region": "ETFs/context",
+        "hypothesis_id": "index_regime_filter_behavior_v1",
+        "preset_name": "index_regime_filter_daily_v1",
+        "strategy_name": "fixture_only_behavior_seed",
+        "interval": "1d",
+        "stage_result": "screening_pass",
+        "qre_validation_linkage_status": "linked_catalog_active_discovery",
+        "validation_evidence": {
+          "status": "sufficient_oos_evidence",
+          "oos_trade_count": 13,
+          "min_oos_trades": 10
+        },
+        "promotion_guard": {
+          "promotion_allowed": false,
+          "blocked_by": [
+            "criteria_consistentie_failed"
+          ]
+        },
+        "failure_reasons": [],
+        "near_pass": {
+          "is_near_pass": false
+        },
+        "metrics": {
+          "win_rate": 0.57,
+          "trades_per_maand": 2.2,
+          "consistentie": 0.24,
+          "deflated_sharpe": 0.66
+        },
+        "outcome_class": "sufficient_oos_but_not_promoted",
+        "fixture_candidate": true,
+        "not_real_market_evidence": true,
+        "no_paper_activation": true,
+        "no_shadow_activation": true,
+        "no_live_activation": true
+      }
+    ]
+  }
+}

--- a/tests/unit/test_qre_candidate_diversity_validation_report.py
+++ b/tests/unit/test_qre_candidate_diversity_validation_report.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from reporting import qre_candidate_diversity_validation_report as report
+
+
+def test_candidate_diversity_validation_report_is_operator_readable() -> None:
+    snapshot = report.collect_snapshot(
+        branch="test/qre-controlled-validation-candidate-diversity-harness",
+        commits=[
+            {
+                "message": "test: add controlled validation candidate diversity harness",
+                "sha": "ae266bd",
+                "purpose": "fixture + multiple candidate outcomes",
+            },
+            {
+                "message": "feat: add QRE production discovery universe seed",
+                "sha": "58920c5",
+                "purpose": "read-only multi-region discovery catalog",
+            },
+            {
+                "message": "docs: add operator report for candidate diversity validation",
+                "sha": "HEAD",
+                "purpose": "operator-facing explanation of scope and limits",
+            },
+        ],
+        tests=[
+            "python -m pytest tests/unit/test_qre_controlled_validation_candidate_diversity_harness.py -q",
+            "python -m pytest tests/unit/test_qre_production_discovery_catalog.py -q",
+        ],
+        architecture_tests="python -m pytest tests/architecture -q",
+        git_diff_check="clean",
+    )
+
+    assert snapshot["next_action"] == "READ_ONLY_REAL_BASKET_DIAGNOSIS"
+    assert len(snapshot["tested_rows"]) == 15
+    assert len(snapshot["production_seed_rows"]) == 4
+    assert snapshot["validation"]["frozen_contracts_untouched"] is True
+    assert snapshot["validation"]["protected_execution_paths_untouched"] is True
+
+    markdown = report.render_markdown(snapshot)
+    assert "# QRE Candidate Diversity + Production Discovery Seed Report" in markdown
+    assert "## 1. Korte conclusie" in markdown
+    assert "## 2. Wat is getest" in markdown
+    assert "## 3. Production discovery seed" in markdown
+    assert "## 6. Wat dit niet bewijst" in markdown
+    assert "- dit bewijst geen echte alpha" in markdown
+    assert "- dit activeert geen paper/shadow/live" in markdown
+    assert "- NEXT_ACTION: READ_ONLY_REAL_BASKET_DIAGNOSIS" in markdown
+    assert "test/qre-controlled-validation-candidate-diversity-harness" in markdown

--- a/tests/unit/test_qre_controlled_validation_candidate_diversity_harness.py
+++ b/tests/unit/test_qre_controlled_validation_candidate_diversity_harness.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from reporting import qre_controlled_validation_result_analysis as analysis
+
+
+FIXTURE_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "fixtures"
+    / "qre_controlled_validation"
+    / "candidate_diversity_harness.json"
+)
+
+
+def test_candidate_diversity_harness_proves_multiple_candidates_and_outcomes(
+    tmp_path: Path,
+) -> None:
+    fixture = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+    report_path = tmp_path / "controlled_eval_latest.v1.json"
+    report_path.write_text(
+        json.dumps(fixture["controlled_eval_report"]),
+        encoding="utf-8",
+    )
+    execution_snapshot = dict(fixture["execution_snapshot"])
+    execution_snapshot["controlled_eval_result"] = {
+        "returncode": 0,
+        "report_paths": {"report_json": report_path.as_posix()},
+    }
+
+    snapshot = analysis.collect_snapshot(
+        execution_snapshot=execution_snapshot,
+        generated_at_utc="2026-06-06T10:00:00Z",
+        current_git_revision="abc123",
+        screening_evidence_payload=fixture["screening_evidence_payload"],
+    )
+
+    summary = snapshot["operator_summary"]
+    assert summary["total_candidates"] == 15
+    assert summary["promotion_allowed_count"] == 1
+    assert summary["near_pass_count"] == 1
+    assert summary["candidate_diversity"] == {
+        "preset_count": 8,
+        "hypothesis_count": 7,
+        "region_count": 4,
+        "fixture_candidate_count": 15,
+        "promotion_eligible_fixture_candidate_count": 1,
+        "outcome_class_summary": [
+            {"reason": "reject_insufficient_trades", "count": 4},
+            {"reason": "reject_criteria_consistentie_failed", "count": 2},
+            {"reason": "reject_criteria_trades_per_maand_failed", "count": 2},
+            {"reason": "reject_criteria_win_rate_failed", "count": 2},
+            {"reason": "reject_no_oos_evidence", "count": 2},
+            {"reason": "near_pass", "count": 1},
+            {"reason": "promotion_eligible_fixture_candidate", "count": 1},
+            {"reason": "sufficient_oos_but_not_promoted", "count": 1},
+        ],
+    }
+
+    rows = summary["selected_asset_explanations"]
+    assert [row["asset"] for row in rows[:4]] == ["ADYEN", "AIR", "ASML", "BABA"]
+    assert len({row["preset_name"] for row in rows}) == 8
+    assert len({row["hypothesis_id"] for row in rows}) == 7
+    assert len({row["region"] for row in rows}) == 4
+
+    prx_row = next(row for row in rows if row["asset"] == "PRX")
+    assert prx_row["promotion_allowed"] is True
+    assert prx_row["outcome_class"] == "promotion_eligible_fixture_candidate"
+    assert prx_row["fixture_candidate"] is True
+    assert prx_row["not_real_market_evidence"] is True
+    assert prx_row["no_paper_activation"] is True
+    assert prx_row["no_live_activation"] is True
+    assert prx_row["no_shadow_activation"] is True
+
+    ewj_row = next(row for row in rows if row["asset"] == "EWJ")
+    assert ewj_row["near_pass"] is True
+    assert ewj_row["outcome_class"] == "near_pass"
+
+    assert summary["runtime_gate_failed_assets"] == [
+        "ADYEN",
+        "GOOGL",
+        "NESN",
+        "TSLA",
+    ]

--- a/tests/unit/test_qre_controlled_validation_result_analysis.py
+++ b/tests/unit/test_qre_controlled_validation_result_analysis.py
@@ -415,6 +415,9 @@ def test_operator_summary_surfaces_hd_blockers_and_candidate_rollup(tmp_path) ->
     )
     assert hd_row == {
         "asset": "HD",
+        "asset_group": None,
+        "region": None,
+        "hypothesis_id": None,
         "preset_name": "trend_pullback_equities_4h",
         "strategy_name": "trend_pullback_v1",
         "interval": "4h",
@@ -431,6 +434,12 @@ def test_operator_summary_surfaces_hd_blockers_and_candidate_rollup(tmp_path) ->
         ],
         "failure_reasons": [],
         "near_pass": False,
+        "outcome_class": "reject_criteria_consistentie_failed",
+        "fixture_candidate": False,
+        "not_real_market_evidence": False,
+        "no_paper_activation": False,
+        "no_live_activation": False,
+        "no_shadow_activation": False,
         "metrics": {
             "win_rate": 0.5,
             "trades_per_maand": 1.1,

--- a/tests/unit/test_qre_production_discovery_catalog.py
+++ b/tests/unit/test_qre_production_discovery_catalog.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from research import production_discovery_catalog as catalog
+
+
+def test_production_discovery_assets_are_regionally_diverse_and_read_only() -> None:
+    assets = catalog.list_assets()
+
+    assert len(assets) == 41
+    assert {asset.region for asset in assets} == {
+        "NL/EU",
+        "US",
+        "Asia/proxies",
+        "ETFs/context",
+    }
+    for asset in assets:
+        payload = asset.to_payload()
+        assert payload["enabled_for_discovery"] is True
+        assert payload["enabled_for_validation"] is True
+        assert payload["not_alpha_claim"] is True
+        assert payload["paper_activation_allowed"] is False
+        assert payload["shadow_activation_allowed"] is False
+        assert payload["live_activation_allowed"] is False
+        assert payload["source_quality_status"] == "reviewed_seed_only"
+        assert isinstance(payload["canonical_instrument_id"], str)
+        assert payload["canonical_instrument_id"]
+
+
+def test_production_discovery_presets_are_non_executable_seed_metadata() -> None:
+    presets = catalog.list_presets()
+
+    assert [preset.preset_id for preset in presets] == [
+        "trend_continuation_daily_v1",
+        "trend_pullback_continuation_daily_v1",
+        "vol_compression_breakout_daily_v1",
+        "vol_compression_breakout_4h_v1",
+        "relative_strength_vs_sector_daily_v1",
+        "relative_strength_vs_region_daily_v1",
+        "post_shock_stabilization_daily_v1",
+        "index_regime_filter_daily_v1",
+    ]
+    for preset in presets:
+        payload = preset.to_payload()
+        assert payload["enabled_for_discovery"] is True
+        assert payload["enabled_for_validation"] is True
+        assert payload["not_alpha_claim"] is True
+        assert payload["paper_activation_allowed"] is False
+        assert payload["shadow_activation_allowed"] is False
+        assert payload["live_activation_allowed"] is False
+        assert payload["expected_failure_modes"]
+        assert payload["allowed_timeframes"]
+        assert payload["min_history_bars"] >= 750
+
+
+def test_bounded_candidate_basket_supports_controlled_sprint_without_runtime_activation() -> None:
+    basket = catalog.build_bounded_candidate_basket(max_candidates=15)
+
+    assert len(basket) == 15
+    assert len({row["candidate_id"] for row in basket}) == 15
+    assert len({row["preset_id"] for row in basket}) >= 6
+    assert len({row["region"] for row in basket}) == 4
+    assert {row["asset_class"] for row in basket} == {"equity", "etf"}
+    for row in basket:
+        assert row["enabled_for_discovery"] is True
+        assert row["enabled_for_validation"] is True
+        assert row["not_alpha_claim"] is True
+        assert row["paper_activation_allowed"] is False
+        assert row["shadow_activation_allowed"] is False
+        assert row["live_activation_allowed"] is False
+
+
+def test_catalog_payload_exposes_seed_only_metadata_and_basket() -> None:
+    payload = catalog.production_discovery_catalog_payload(max_candidates=15)
+
+    assert payload["schema_version"] == 1
+    assert payload["read_only"] is True
+    assert payload["not_alpha_claim"] is True
+    assert payload["paper_activation_allowed"] is False
+    assert payload["shadow_activation_allowed"] is False
+    assert payload["live_activation_allowed"] is False
+    assert len(payload["assets"]) == 41
+    assert len(payload["presets"]) == 8
+    assert len(payload["bounded_candidate_basket"]) == 15


### PR DESCRIPTION
Adds a controlled validation candidate diversity harness, a read-only production discovery universe/preset seed, and an operator-facing report. This PR does not activate paper/shadow/live, does not add executable strategies, does not mutate frozen contracts, and does not change broker/risk/execution paths.