### PR TITLE
feat: add controlled QRE 328 discovery grid scan

### DIFF
--- a/docs/qre_controlled_328_discovery_grid_vps_runbook.md
+++ b/docs/qre_controlled_328_discovery_grid_vps_runbook.md
@@ -1,0 +1,118 @@
+# QRE Controlled 328 Discovery Grid VPS Runbook
+
+## 1. Doel
+
+Deze run evalueert alle 328 instrument x behavior-preset combinations uit de read-only discovery catalog.
+Dit is research evidence generation.
+Dit activeert geen paper/shadow/live.
+
+Huidige nuance:
+- de planner, chunking, resume en sidecar-only artifacts zijn klaar voor VPS-gebruik;
+- directe controlled execution integration is nog deferred;
+- de huidige runner markeert dat expliciet in de artifacts in plaats van echte market evidence te faken.
+
+## 2. VPS voorbereiding
+
+```bash
+cd /root/trading-agent
+git fetch origin
+git switch main
+git pull --ff-only
+python --version
+git status --short
+```
+
+## 3. Plan controleren
+
+```bash
+python -m reporting.qre_controlled_discovery_grid_runner --plan-only
+```
+
+Verwachte output:
+
+```text
+total_combinations: 328
+paper_activation_allowed: false
+shadow_activation_allowed: false
+live_activation_allowed: false
+```
+
+## 4. Scan starten
+
+Bij voorkeur chunked:
+
+```bash
+python -m reporting.qre_controlled_discovery_grid_runner --run --start 1 --end 50 --output-dir research/controlled_discovery_grid_runs --run-id vps-grid-001
+python -m reporting.qre_controlled_discovery_grid_runner --run --start 51 --end 100 --output-dir research/controlled_discovery_grid_runs --run-id vps-grid-001 --resume
+python -m reporting.qre_controlled_discovery_grid_runner --run --start 101 --end 150 --output-dir research/controlled_discovery_grid_runs --run-id vps-grid-001 --resume
+python -m reporting.qre_controlled_discovery_grid_runner --run --start 151 --end 200 --output-dir research/controlled_discovery_grid_runs --run-id vps-grid-001 --resume
+python -m reporting.qre_controlled_discovery_grid_runner --run --start 201 --end 250 --output-dir research/controlled_discovery_grid_runs --run-id vps-grid-001 --resume
+python -m reporting.qre_controlled_discovery_grid_runner --run --start 251 --end 300 --output-dir research/controlled_discovery_grid_runs --run-id vps-grid-001 --resume
+python -m reporting.qre_controlled_discovery_grid_runner --run --start 301 --end 328 --output-dir research/controlled_discovery_grid_runs --run-id vps-grid-001 --resume
+```
+
+De huidige runner schrijft per chunk sidecar-only artifacts en houdt expliciet bij dat execution integration nog deferred is.
+
+## 5. Samenvatting maken
+
+```bash
+python -m reporting.qre_controlled_discovery_grid_analysis --input-dir research/controlled_discovery_grid_runs/vps-grid-001 --write-summary
+```
+
+## 6. Output ophalen
+
+Kijk hier:
+
+```text
+research/controlled_discovery_grid_runs/<run_id>/operator_summary.md
+research/controlled_discovery_grid_runs/<run_id>/summary_latest.v1.json
+research/controlled_discovery_grid_runs/<run_id>/combination_results.v1.jsonl
+```
+
+## 7. Wat de operator moet terugplakken
+
+Plak alleen deze outputs terug:
+
+```text
+operator_summary.md
+summary_latest.v1.json
+eventuele failed/unknown rows
+```
+
+## 8. Stopcondities
+
+Stop de VPS-run bij:
+
+```text
+paper_activation_allowed true
+shadow_activation_allowed true
+live_activation_allowed true
+broker/risk/execution path touched
+frozen contract mutation
+unexpected generated file outside output-dir
+unknown error rate > 20%
+data coverage failures > 80%
+runtime crash loop
+```
+
+## 9. Wat deze scan wel/niet bewijst
+
+Wel:
+
+```text
+distribution of blockers/outcomes across 328 combinations
+which assets/presets deserve follow-up
+which failure modes dominate
+whether the discovery catalog is useful enough for routing/sampling
+```
+
+Niet:
+
+```text
+real alpha
+paper readiness
+shadow readiness
+live readiness
+strategy synthesis approval
+capital allocation approval
+```

--- a/reporting/qre_controlled_discovery_grid_analysis.py
+++ b/reporting/qre_controlled_discovery_grid_analysis.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+
+SUMMARY_FILENAME = "summary_latest.v1.json"
+OPERATOR_SUMMARY_FILENAME = "operator_summary.md"
+RESULTS_FILENAME = "combination_results.v1.jsonl"
+
+
+def _table(headers: list[str], rows: list[list[str]]) -> str:
+    head = "| " + " | ".join(headers) + " |"
+    divider = "| " + " | ".join(["---"] * len(headers)) + " |"
+    body = ["| " + " | ".join(row) + " |" for row in rows]
+    return "\n".join([head, divider, *body])
+
+
+def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        text = line.strip()
+        if not text:
+            continue
+        payload = json.loads(text)
+        if isinstance(payload, dict):
+            rows.append(payload)
+    return rows
+
+
+def _group_counts(rows: list[dict[str, Any]], field: str) -> list[dict[str, Any]]:
+    counts: defaultdict[str, int] = defaultdict(int)
+    for row in rows:
+        counts[str(row.get(field) or "unknown")] += 1
+    return [
+        {"value": key, "count": counts[key]}
+        for key in sorted(counts)
+    ]
+
+
+def build_summary(*, run_dir: Path, results: list[dict[str, Any]]) -> dict[str, Any]:
+    blocker_counter = Counter(str(row.get("blocker_class") or "unknown") for row in results)
+    outcome_counter = Counter(str(row.get("outcome_class") or "unknown") for row in results)
+    status_counter = Counter(str(row.get("status") or "unknown") for row in results)
+
+    deferred_count = status_counter.get("execution_integration_deferred", 0)
+    summary = {
+        "report_kind": "qre_controlled_discovery_grid_analysis",
+        "run_dir": run_dir.as_posix(),
+        "result_count": len(results),
+        "counts": {
+            "total_combinations_planned": len(results),
+            "total_completed": status_counter.get("completed", 0),
+            "total_skipped": sum(
+                status_counter.get(name, 0)
+                for name in ("skipped_invalid_metadata", "blocked_by_safety")
+            ),
+            "execution_integration_deferred": deferred_count,
+            "insufficient_trades": blocker_counter.get("insufficient_trades", 0),
+            "no_oos_evidence": blocker_counter.get("no_oos_evidence", 0),
+            "criteria_win_rate_failed": blocker_counter.get("criteria_win_rate_failed", 0),
+            "criteria_trades_per_maand_failed": blocker_counter.get(
+                "criteria_trades_per_maand_failed", 0
+            ),
+            "criteria_consistentie_failed": blocker_counter.get(
+                "criteria_consistentie_failed", 0
+            ),
+            "data_coverage_blocker": blocker_counter.get("data_coverage_blocker", 0),
+            "near_pass": outcome_counter.get("near_pass", 0),
+            "promotion_candidate": outcome_counter.get("promotion_candidate", 0),
+            "unknown": outcome_counter.get("unknown", 0),
+        },
+        "by_region": _group_counts(results, "region"),
+        "by_asset": _group_counts(results, "instrument_symbol"),
+        "by_behavior_preset": _group_counts(results, "behavior_preset_id"),
+        "by_outcome_class": _group_counts(results, "outcome_class"),
+        "by_blocker_class": _group_counts(results, "blocker_class"),
+        "next_action": "DEFER_EXECUTION_INTEGRATION"
+        if deferred_count
+        else "MERGE_AND_RUN_ON_VPS",
+    }
+    return summary
+
+
+def render_operator_summary(summary: dict[str, Any]) -> str:
+    counts = summary["counts"]
+    evidence_table = _table(
+        ["Field", "Count"],
+        [
+            ["total combinations planned", str(counts["total_combinations_planned"])],
+            ["total completed", str(counts["total_completed"])],
+            ["total skipped", str(counts["total_skipped"])],
+            ["execution integration deferred", str(counts["execution_integration_deferred"])],
+            ["insufficient trades", str(counts["insufficient_trades"])],
+            ["no OOS evidence", str(counts["no_oos_evidence"])],
+            ["criteria win-rate failed", str(counts["criteria_win_rate_failed"])],
+            [
+                "criteria trades-per-month failed",
+                str(counts["criteria_trades_per_maand_failed"]),
+            ],
+            ["criteria consistentie failed", str(counts["criteria_consistentie_failed"])],
+            ["data coverage blocker", str(counts["data_coverage_blocker"])],
+            ["near pass", str(counts["near_pass"])],
+            ["promotion candidate", str(counts["promotion_candidate"])],
+            ["unknown", str(counts["unknown"])],
+        ],
+    )
+    region_table = _table(
+        ["Region", "Count"],
+        [[row["value"], str(row["count"])] for row in summary["by_region"]],
+    )
+    preset_table = _table(
+        ["Behavior preset", "Count"],
+        [[row["value"], str(row["count"])] for row in summary["by_behavior_preset"]],
+    )
+    return "\n".join(
+        [
+            "# QRE Controlled Discovery Grid Operator Summary",
+            "",
+            "## 1. Korte conclusie",
+            "- This run prepared a deterministic controlled discovery grid over the read-only production discovery catalog.",
+            "- Planning, chunking, resume, and sidecar-only artifact writing are ready for VPS use.",
+            "- Direct controlled execution integration is still deferred; current result rows make that explicit instead of pretending market evidence exists.",
+            "",
+            "## 2. Outcome counts",
+            evidence_table,
+            "",
+            "## 3. Region coverage",
+            region_table,
+            "",
+            "## 4. Behavior preset coverage",
+            preset_table,
+            "",
+            "## 5. Next action",
+            f"- NEXT_ACTION: {summary['next_action']}",
+        ]
+    )
+
+
+def _resolve_run_dir(input_dir: Path) -> Path:
+    if (input_dir / RESULTS_FILENAME).exists():
+        return input_dir
+    run_dirs = sorted(
+        [path for path in input_dir.iterdir() if path.is_dir()],
+        key=lambda path: path.name,
+    )
+    if not run_dirs:
+        raise FileNotFoundError(f"no run directories found under {input_dir}")
+    return run_dirs[-1]
+
+
+def summarize_run(
+    *,
+    input_dir: Path,
+    write_summary: bool,
+) -> dict[str, Any]:
+    run_dir = _resolve_run_dir(input_dir)
+    results = _load_jsonl(run_dir / RESULTS_FILENAME)
+    summary = build_summary(run_dir=run_dir, results=results)
+    if write_summary:
+        (run_dir / SUMMARY_FILENAME).write_text(
+            json.dumps(summary, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+        (run_dir / OPERATOR_SUMMARY_FILENAME).write_text(
+            render_operator_summary(summary) + "\n",
+            encoding="utf-8",
+        )
+    return summary
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m reporting.qre_controlled_discovery_grid_analysis",
+        description="Summarize controlled discovery grid sidecar artifacts.",
+    )
+    parser.add_argument("--input-dir", required=True)
+    parser.add_argument("--write-summary", action="store_true")
+    args = parser.parse_args(argv)
+
+    summary = summarize_run(
+        input_dir=Path(args.input_dir),
+        write_summary=bool(args.write_summary),
+    )
+    print(json.dumps(summary, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/reporting/qre_controlled_discovery_grid_runner.py
+++ b/reporting/qre_controlled_discovery_grid_runner.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import importlib
+import json
+from pathlib import Path
+from typing import Any
+
+from reporting import qre_controlled_discovery_grid_analysis as analysis
+
+
+OUTPUT_DIR_DEFAULT = Path("research/controlled_discovery_grid_runs")
+PLAN_FILENAME = "grid_plan.v1.json"
+RESULTS_FILENAME = "combination_results.v1.jsonl"
+SUMMARY_FILENAME = "summary_latest.v1.json"
+OPERATOR_SUMMARY_FILENAME = "operator_summary.md"
+
+
+def _utcnow_stamp() -> str:
+    return dt.datetime.now(dt.UTC).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _planner_module():
+    return importlib.import_module("research.controlled_discovery_grid")
+
+
+def _plan_payload() -> dict[str, Any]:
+    planner = _planner_module()
+    return planner.controlled_discovery_grid_payload()
+
+
+def _selected_combinations(
+    *,
+    start: int,
+    end: int,
+) -> list[dict[str, Any]]:
+    combinations = list(_plan_payload()["combinations"])
+    if start < 1 or end < start or end > len(combinations):
+        raise ValueError(
+            f"invalid range start={start} end={end}; total={len(combinations)}"
+        )
+    return combinations[start - 1 : end]
+
+
+def _run_dir(*, output_dir: Path, run_id: str) -> Path:
+    return output_dir / run_id
+
+
+def _result_row(
+    combination: dict[str, Any],
+    *,
+    run_id: str,
+    run_dir: Path,
+) -> dict[str, Any]:
+    row = dict(combination)
+    row.update(
+        {
+            "run_id": run_id,
+            "status": "execution_integration_deferred",
+            "result_path": (
+                f"{run_dir.as_posix()}/combination_{combination['sequence_number']:03d}.json"
+            ),
+            "blocker_class": "execution_integration_deferred",
+            "outcome_class": "unknown",
+            "execution_notes": [
+                "planner_ready",
+                "chunking_ready",
+                "resume_ready",
+                "sidecar_only_artifacts",
+                "no_paper_activation",
+                "no_shadow_activation",
+                "no_live_activation",
+                "execution_integration_deferred",
+            ],
+        }
+    )
+    return row
+
+
+def _load_existing_sequence_numbers(results_path: Path) -> set[int]:
+    if not results_path.exists():
+        return set()
+    sequence_numbers: set[int] = set()
+    for line in results_path.read_text(encoding="utf-8").splitlines():
+        text = line.strip()
+        if not text:
+            continue
+        payload = json.loads(text)
+        if isinstance(payload, dict) and payload.get("sequence_number") is not None:
+            sequence_numbers.add(int(payload["sequence_number"]))
+    return sequence_numbers
+
+
+def plan_snapshot() -> dict[str, Any]:
+    payload = _plan_payload()
+    return {
+        "report_kind": "qre_controlled_discovery_grid_runner_plan",
+        "grid_kind": payload["grid_kind"],
+        "instrument_count": payload["instrument_count"],
+        "behavior_preset_count": payload["behavior_preset_count"],
+        "total_combinations": payload["total_combinations"],
+        "paper_activation_allowed": payload["paper_activation_allowed"],
+        "shadow_activation_allowed": payload["shadow_activation_allowed"],
+        "live_activation_allowed": payload["live_activation_allowed"],
+        "read_only": payload["read_only"],
+        "not_alpha_claim": payload["not_alpha_claim"],
+    }
+
+
+def execute_range(
+    *,
+    start: int,
+    end: int,
+    output_dir: Path,
+    run_id: str | None,
+    resume: bool,
+) -> dict[str, Any]:
+    payload = _plan_payload()
+    selected = _selected_combinations(start=start, end=end)
+    resolved_run_id = run_id or _utcnow_stamp()
+    run_dir = _run_dir(output_dir=output_dir, run_id=resolved_run_id)
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    plan_path = run_dir / PLAN_FILENAME
+    results_path = run_dir / RESULTS_FILENAME
+
+    if not plan_path.exists():
+        plan_path.write_text(
+            json.dumps(payload, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+
+    existing_sequence_numbers = _load_existing_sequence_numbers(results_path) if resume else set()
+    rows_to_write = [
+        _result_row(item, run_id=resolved_run_id, run_dir=run_dir)
+        for item in selected
+        if int(item["sequence_number"]) not in existing_sequence_numbers
+    ]
+    if rows_to_write:
+        with results_path.open("a", encoding="utf-8") as handle:
+            for row in rows_to_write:
+                handle.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+    summary = analysis.summarize_run(input_dir=run_dir, write_summary=True)
+    return {
+        "report_kind": "qre_controlled_discovery_grid_runner_execution",
+        "run_id": resolved_run_id,
+        "run_dir": run_dir.as_posix(),
+        "selected_range": {"start": start, "end": end},
+        "selected_count": len(selected),
+        "written_count": len(rows_to_write),
+        "resume": resume,
+        "execution_integration_deferred": True,
+        "deferred_reason": (
+            "RUNNER_EXECUTION_INTEGRATION_DEFERRED: planner and runbook are ready, "
+            "execution integration needs next PR"
+        ),
+        "artifacts": {
+            "grid_plan": plan_path.as_posix(),
+            "combination_results": results_path.as_posix(),
+            "summary": (run_dir / SUMMARY_FILENAME).as_posix(),
+            "operator_summary": (run_dir / OPERATOR_SUMMARY_FILENAME).as_posix(),
+        },
+        "summary": summary,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m reporting.qre_controlled_discovery_grid_runner",
+        description="Plan or stage a controlled QRE discovery grid run.",
+    )
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--plan-only", action="store_true")
+    mode.add_argument("--run", action="store_true")
+    parser.add_argument("--start", type=int)
+    parser.add_argument("--end", type=int)
+    parser.add_argument("--output-dir", default=str(OUTPUT_DIR_DEFAULT))
+    parser.add_argument("--run-id")
+    parser.add_argument("--resume", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.plan_only:
+        print(json.dumps(plan_snapshot(), indent=2, ensure_ascii=False))
+        return 0
+
+    if args.start is None or args.end is None:
+        raise SystemExit("--run requires --start and --end")
+
+    payload = execute_range(
+        start=int(args.start),
+        end=int(args.end),
+        output_dir=Path(args.output_dir),
+        run_id=args.run_id,
+        resume=bool(args.resume),
+    )
+    print(json.dumps(payload, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/research/controlled_discovery_grid.py
+++ b/research/controlled_discovery_grid.py
@@ -1,0 +1,227 @@
+"""Deterministic controlled discovery grid planner for QRE.
+
+This module materializes the full enabled instrument x enabled preset
+grid from the read-only production discovery catalog. It does not
+launch research execution and does not grant paper/shadow/live
+authority.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Final
+
+from research import production_discovery_catalog as catalog
+
+
+SCHEMA_VERSION: Final[int] = 1
+GRID_KIND: Final[str] = "qre_controlled_discovery_grid"
+PLANNED_STATUS: Final[str] = "planned"
+SKIPPED_INVALID_METADATA_STATUS: Final[str] = "skipped_invalid_metadata"
+BLOCKED_BY_SAFETY_STATUS: Final[str] = "blocked_by_safety"
+ALLOWED_STATUSES: Final[tuple[str, ...]] = (
+    PLANNED_STATUS,
+    SKIPPED_INVALID_METADATA_STATUS,
+    BLOCKED_BY_SAFETY_STATUS,
+)
+
+REQUIRED_ASSET_FIELDS: Final[tuple[str, ...]] = (
+    "symbol",
+    "canonical_instrument_id",
+    "region",
+    "asset_class",
+    "enabled_for_discovery",
+    "enabled_for_validation",
+)
+REQUIRED_PRESET_FIELDS: Final[tuple[str, ...]] = (
+    "preset_id",
+    "hypothesis_id",
+    "allowed_timeframes",
+    "enabled_for_discovery",
+    "enabled_for_validation",
+)
+
+
+@dataclass(frozen=True)
+class GridCombination:
+    grid_id: str
+    sequence_number: int
+    instrument_symbol: str
+    canonical_instrument_id: str
+    region: str
+    asset_class: str
+    behavior_preset_id: str
+    hypothesis_id: str
+    timeframe: str
+    enabled_for_discovery: bool
+    enabled_for_validation: bool
+    not_alpha_claim: bool
+    paper_activation_allowed: bool
+    shadow_activation_allowed: bool
+    live_activation_allowed: bool
+    status: str
+    result_path: str | None
+    blocker_class: str | None
+    outcome_class: str | None
+    metadata_warnings: tuple[str, ...]
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "grid_id": self.grid_id,
+            "sequence_number": self.sequence_number,
+            "instrument_symbol": self.instrument_symbol,
+            "canonical_instrument_id": self.canonical_instrument_id,
+            "region": self.region,
+            "asset_class": self.asset_class,
+            "behavior_preset_id": self.behavior_preset_id,
+            "hypothesis_id": self.hypothesis_id,
+            "timeframe": self.timeframe,
+            "enabled_for_discovery": self.enabled_for_discovery,
+            "enabled_for_validation": self.enabled_for_validation,
+            "not_alpha_claim": self.not_alpha_claim,
+            "paper_activation_allowed": self.paper_activation_allowed,
+            "shadow_activation_allowed": self.shadow_activation_allowed,
+            "live_activation_allowed": self.live_activation_allowed,
+            "status": self.status,
+            "result_path": self.result_path,
+            "blocker_class": self.blocker_class,
+            "outcome_class": self.outcome_class,
+            "metadata_warnings": list(self.metadata_warnings),
+        }
+
+
+def _payload_has_required_fields(
+    payload: dict[str, Any],
+    required_fields: tuple[str, ...],
+) -> tuple[bool, list[str]]:
+    warnings: list[str] = []
+    for field in required_fields:
+        value = payload.get(field)
+        if value in (None, "", []):
+            warnings.append(f"missing_{field}")
+    return (not warnings, warnings)
+
+
+def _safety_is_blocked(
+    asset_payload: dict[str, Any],
+    preset_payload: dict[str, Any],
+) -> bool:
+    return any(
+        bool(source.get(flag))
+        for source in (asset_payload, preset_payload)
+        for flag in (
+            "paper_activation_allowed",
+            "shadow_activation_allowed",
+            "live_activation_allowed",
+        )
+    )
+
+
+def _combination_status(
+    asset_payload: dict[str, Any],
+    preset_payload: dict[str, Any],
+) -> tuple[str, list[str]]:
+    asset_valid, asset_warnings = _payload_has_required_fields(
+        asset_payload, REQUIRED_ASSET_FIELDS
+    )
+    preset_valid, preset_warnings = _payload_has_required_fields(
+        preset_payload, REQUIRED_PRESET_FIELDS
+    )
+    warnings = [*asset_warnings, *preset_warnings]
+    if not asset_valid or not preset_valid:
+        return SKIPPED_INVALID_METADATA_STATUS, warnings
+    if _safety_is_blocked(asset_payload, preset_payload):
+        return BLOCKED_BY_SAFETY_STATUS, ["discovery_grid_safety_blocked"]
+    return PLANNED_STATUS, warnings
+
+
+def _timeframe_for_preset(preset_payload: dict[str, Any]) -> str:
+    allowed_timeframes = preset_payload.get("allowed_timeframes")
+    if isinstance(allowed_timeframes, list) and allowed_timeframes:
+        return str(allowed_timeframes[0])
+    return "unknown"
+
+
+def list_enabled_assets() -> list[dict[str, Any]]:
+    assets = [
+        asset.to_payload()
+        for asset in catalog.list_assets()
+        if asset.enabled_for_discovery and asset.enabled_for_validation
+    ]
+    region_order = {region: index for index, region in enumerate(catalog.REGION_ORDER)}
+    return sorted(
+        assets,
+        key=lambda item: (
+            region_order.get(str(item["region"]), len(region_order)),
+            str(item["symbol"]),
+        ),
+    )
+
+
+def list_enabled_presets() -> list[dict[str, Any]]:
+    presets = [
+        preset.to_payload()
+        for preset in catalog.list_presets()
+        if preset.enabled_for_discovery and preset.enabled_for_validation
+    ]
+    return sorted(presets, key=lambda item: str(item["preset_id"]))
+
+
+def build_controlled_discovery_grid() -> list[dict[str, Any]]:
+    combinations: list[dict[str, Any]] = []
+    sequence_number = 1
+    for asset_payload in list_enabled_assets():
+        for preset_payload in list_enabled_presets():
+            status, warnings = _combination_status(asset_payload, preset_payload)
+            combination = GridCombination(
+                grid_id=(
+                    "qre-grid::"
+                    f'{sequence_number:03d}::'
+                    f'{asset_payload["symbol"]}::'
+                    f'{preset_payload["preset_id"]}'
+                ),
+                sequence_number=sequence_number,
+                instrument_symbol=str(asset_payload["symbol"]),
+                canonical_instrument_id=str(asset_payload["canonical_instrument_id"]),
+                region=str(asset_payload["region"]),
+                asset_class=str(asset_payload["asset_class"]),
+                behavior_preset_id=str(preset_payload["preset_id"]),
+                hypothesis_id=str(preset_payload["hypothesis_id"]),
+                timeframe=_timeframe_for_preset(preset_payload),
+                enabled_for_discovery=True,
+                enabled_for_validation=True,
+                not_alpha_claim=bool(asset_payload["not_alpha_claim"])
+                and bool(preset_payload["not_alpha_claim"]),
+                paper_activation_allowed=False,
+                shadow_activation_allowed=False,
+                live_activation_allowed=False,
+                status=status,
+                result_path=None,
+                blocker_class="safety_blocker"
+                if status == BLOCKED_BY_SAFETY_STATUS
+                else "metadata_incomplete"
+                if status == SKIPPED_INVALID_METADATA_STATUS
+                else None,
+                outcome_class="not_started",
+                metadata_warnings=tuple(warnings),
+            )
+            combinations.append(combination.to_payload())
+            sequence_number += 1
+    return combinations
+
+
+def controlled_discovery_grid_payload() -> dict[str, Any]:
+    combinations = build_controlled_discovery_grid()
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "grid_kind": GRID_KIND,
+        "read_only": True,
+        "not_alpha_claim": True,
+        "paper_activation_allowed": False,
+        "shadow_activation_allowed": False,
+        "live_activation_allowed": False,
+        "instrument_count": len(list_enabled_assets()),
+        "behavior_preset_count": len(list_enabled_presets()),
+        "total_combinations": len(combinations),
+        "combinations": combinations,
+    }

--- a/tests/unit/test_qre_controlled_discovery_grid.py
+++ b/tests/unit/test_qre_controlled_discovery_grid.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from research import controlled_discovery_grid as grid
+
+
+def test_controlled_discovery_grid_builds_expected_328_combinations() -> None:
+    payload = grid.controlled_discovery_grid_payload()
+
+    assert payload["schema_version"] == 1
+    assert payload["grid_kind"] == "qre_controlled_discovery_grid"
+    assert payload["instrument_count"] == 41
+    assert payload["behavior_preset_count"] == 8
+    assert payload["total_combinations"] == 328
+    assert len(payload["combinations"]) == 328
+
+
+def test_controlled_discovery_grid_ordering_is_stable() -> None:
+    combinations = grid.build_controlled_discovery_grid()
+
+    assert combinations[0]["sequence_number"] == 1
+    assert combinations[0]["instrument_symbol"] == "ADYEN"
+    assert combinations[0]["behavior_preset_id"] == "index_regime_filter_daily_v1"
+    assert combinations[0]["grid_id"] == (
+        "qre-grid::001::ADYEN::index_regime_filter_daily_v1"
+    )
+    assert combinations[-1]["sequence_number"] == 328
+    assert combinations[-1]["instrument_symbol"] == "VGK"
+    assert combinations[-1]["behavior_preset_id"] == "vol_compression_breakout_daily_v1"
+    assert combinations[-1]["grid_id"] == (
+        "qre-grid::328::VGK::vol_compression_breakout_daily_v1"
+    )
+
+
+def test_controlled_discovery_grid_safety_flags_are_hard_false() -> None:
+    for row in grid.build_controlled_discovery_grid():
+        assert row["enabled_for_discovery"] is True
+        assert row["enabled_for_validation"] is True
+        assert row["not_alpha_claim"] is True
+        assert row["paper_activation_allowed"] is False
+        assert row["shadow_activation_allowed"] is False
+        assert row["live_activation_allowed"] is False
+        assert row["status"] == "planned"
+        assert row["result_path"] is None
+        assert row["blocker_class"] is None
+        assert row["outcome_class"] == "not_started"
+        assert row["metadata_warnings"] == []
+
+
+def test_controlled_discovery_grid_rows_expose_required_metadata() -> None:
+    row = grid.build_controlled_discovery_grid()[0]
+
+    assert row["canonical_instrument_id"]
+    assert row["region"] in {"NL/EU", "US", "Asia/proxies", "ETFs/context"}
+    assert row["asset_class"] in {"equity", "etf"}
+    assert row["hypothesis_id"]
+    assert row["timeframe"] in {"1d", "4h"}
+
+
+def test_controlled_discovery_grid_does_not_mutate_frozen_contracts() -> None:
+    assert Path("research/research_latest.json").exists()
+    assert Path("research/strategy_matrix.csv").exists()

--- a/tests/unit/test_qre_controlled_discovery_grid_analysis.py
+++ b/tests/unit/test_qre_controlled_discovery_grid_analysis.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from reporting import qre_controlled_discovery_grid_analysis as analysis
+
+
+def test_build_summary_counts_deferred_rows_as_unknown() -> None:
+    summary = analysis.build_summary(
+        run_dir=Path("research/controlled_discovery_grid_runs/run-001"),
+        results=[
+            {
+                "status": "execution_integration_deferred",
+                "blocker_class": "execution_integration_deferred",
+                "outcome_class": "unknown",
+                "region": "NL/EU",
+                "instrument_symbol": "ASML",
+                "behavior_preset_id": "trend_continuation_daily_v1",
+            },
+            {
+                "status": "execution_integration_deferred",
+                "blocker_class": "execution_integration_deferred",
+                "outcome_class": "unknown",
+                "region": "US",
+                "instrument_symbol": "AAPL",
+                "behavior_preset_id": "trend_continuation_daily_v1",
+            },
+        ],
+    )
+
+    assert summary["counts"]["total_combinations_planned"] == 2
+    assert summary["counts"]["execution_integration_deferred"] == 2
+    assert summary["counts"]["unknown"] == 2
+    assert summary["next_action"] == "DEFER_EXECUTION_INTEGRATION"
+
+
+def test_summarize_run_writes_summary_and_operator_markdown(tmp_path) -> None:
+    run_dir = tmp_path / "run-003"
+    run_dir.mkdir()
+    (run_dir / "combination_results.v1.jsonl").write_text(
+        json.dumps(
+            {
+                "status": "execution_integration_deferred",
+                "blocker_class": "execution_integration_deferred",
+                "outcome_class": "unknown",
+                "region": "Asia/proxies",
+                "instrument_symbol": "TSM",
+                "behavior_preset_id": "post_shock_stabilization_daily_v1",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    summary = analysis.summarize_run(input_dir=run_dir, write_summary=True)
+
+    assert summary["result_count"] == 1
+    assert (run_dir / "summary_latest.v1.json").exists()
+    assert (run_dir / "operator_summary.md").exists()
+    assert "NEXT_ACTION: DEFER_EXECUTION_INTEGRATION" in (
+        run_dir / "operator_summary.md"
+    ).read_text(encoding="utf-8")

--- a/tests/unit/test_qre_controlled_discovery_grid_runner.py
+++ b/tests/unit/test_qre_controlled_discovery_grid_runner.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+
+from reporting import qre_controlled_discovery_grid_runner as runner
+
+
+def test_plan_snapshot_reports_expected_328_grid() -> None:
+    snapshot = runner.plan_snapshot()
+
+    assert snapshot["instrument_count"] == 41
+    assert snapshot["behavior_preset_count"] == 8
+    assert snapshot["total_combinations"] == 328
+    assert snapshot["paper_activation_allowed"] is False
+    assert snapshot["shadow_activation_allowed"] is False
+    assert snapshot["live_activation_allowed"] is False
+
+
+def test_execute_range_writes_sidecar_only_artifacts(tmp_path) -> None:
+    payload = runner.execute_range(
+        start=1,
+        end=5,
+        output_dir=tmp_path,
+        run_id="run-001",
+        resume=False,
+    )
+
+    run_dir = tmp_path / "run-001"
+    assert payload["selected_count"] == 5
+    assert payload["written_count"] == 5
+    assert payload["execution_integration_deferred"] is True
+    assert (run_dir / "grid_plan.v1.json").exists()
+    assert (run_dir / "combination_results.v1.jsonl").exists()
+    assert (run_dir / "summary_latest.v1.json").exists()
+    assert (run_dir / "operator_summary.md").exists()
+    results = [
+        json.loads(line)
+        for line in (run_dir / "combination_results.v1.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+        if line.strip()
+    ]
+    assert len(results) == 5
+    assert {row["status"] for row in results} == {"execution_integration_deferred"}
+    assert {row["blocker_class"] for row in results} == {"execution_integration_deferred"}
+    assert {row["outcome_class"] for row in results} == {"unknown"}
+
+
+def test_execute_range_resume_skips_existing_sequence_numbers(tmp_path) -> None:
+    first = runner.execute_range(
+        start=1,
+        end=3,
+        output_dir=tmp_path,
+        run_id="run-002",
+        resume=False,
+    )
+    second = runner.execute_range(
+        start=1,
+        end=5,
+        output_dir=tmp_path,
+        run_id="run-002",
+        resume=True,
+    )
+
+    assert first["written_count"] == 3
+    assert second["selected_count"] == 5
+    assert second["written_count"] == 2


### PR DESCRIPTION
﻿## Summary
Adds a controlled 328-combination discovery grid scan over the read-only production discovery catalog.

## What this enables
- deterministic 41 instruments × 8 behavior presets planning
- bounded chunked VPS execution
- sidecar-only result artifacts
- operator-readable blocker/outcome summary

## What this does not enable
- no paper runtime
- no shadow runtime
- no live runtime
- no broker/risk/execution changes
- no strategy synthesis
- no frozen contract mutation

## Validation
- targeted tests: python -m pytest tests/unit/test_qre_controlled_discovery_grid.py -q; python -m pytest tests/unit/test_qre_controlled_discovery_grid_runner.py -q; python -m pytest tests/unit/test_qre_controlled_discovery_grid_analysis.py -q; python -m pytest tests/unit/test_qre_controlled_validation_result_analysis.py -q; python -m pytest tests/unit/test_qre_controlled_validation_equities_blocker_diagnosis_fixture.py -q; python -m pytest tests/unit/test_qre_controlled_validation_sprint_rerun_smoke_contract.py -q; python -m pytest tests -q -k "controlled_discovery_grid or production_discovery or discovery_catalog"
- architecture tests: python -m pytest tests/architecture -q
- git diff --check: clean
- frozen contracts: untouched (esearch/research_latest.json, esearch/strategy_matrix.csv)
- protected execution paths: untouched (no paper/shadow/live/broker/risk/execution changes)
