### PR TITLE
feat: integrate controlled discovery grid execution

### DIFF
--- a/docs/qre_controlled_328_discovery_grid_vps_runbook.md
+++ b/docs/qre_controlled_328_discovery_grid_vps_runbook.md
@@ -5,11 +5,8 @@
 Deze run evalueert alle 328 instrument x behavior-preset combinations uit de read-only discovery catalog.
 Dit is research evidence generation.
 Dit activeert geen paper/shadow/live.
-
-Huidige nuance:
-- de planner, chunking, resume en sidecar-only artifacts zijn klaar voor VPS-gebruik;
-- directe controlled execution integration is nog deferred;
-- de huidige runner markeert dat expliciet in de artifacts in plaats van echte market evidence te faken.
+De runner doet nu echte per-combination attempts via bestaande research/validation codepaden waar een executable mapping bestaat.
+Niet-uitvoerbare combinations worden niet gecrasht maar expliciet als `skipped` met een concrete blocker weggeschreven.
 
 ## 2. VPS voorbereiding
 
@@ -42,24 +39,44 @@ live_activation_allowed: false
 Bij voorkeur chunked:
 
 ```bash
-python -m reporting.qre_controlled_discovery_grid_runner --run --start 1 --end 50 --output-dir research/controlled_discovery_grid_runs --run-id vps-grid-001
-python -m reporting.qre_controlled_discovery_grid_runner --run --start 51 --end 100 --output-dir research/controlled_discovery_grid_runs --run-id vps-grid-001 --resume
-python -m reporting.qre_controlled_discovery_grid_runner --run --start 101 --end 150 --output-dir research/controlled_discovery_grid_runs --run-id vps-grid-001 --resume
-python -m reporting.qre_controlled_discovery_grid_runner --run --start 151 --end 200 --output-dir research/controlled_discovery_grid_runs --run-id vps-grid-001 --resume
-python -m reporting.qre_controlled_discovery_grid_runner --run --start 201 --end 250 --output-dir research/controlled_discovery_grid_runs --run-id vps-grid-001 --resume
-python -m reporting.qre_controlled_discovery_grid_runner --run --start 251 --end 300 --output-dir research/controlled_discovery_grid_runs --run-id vps-grid-001 --resume
-python -m reporting.qre_controlled_discovery_grid_runner --run --start 301 --end 328 --output-dir research/controlled_discovery_grid_runs --run-id vps-grid-001 --resume
+RUN_ID="vps-grid-$(date -u +%Y%m%d-%H%M%S)"
+OUT="research/controlled_discovery_grid_runs/$RUN_ID"
+
+python -m reporting.qre_controlled_discovery_grid_runner --run --start 1 --end 50 --output-dir "$OUT"
+python -m reporting.qre_controlled_discovery_grid_runner --run --start 51 --end 100 --output-dir "$OUT" --resume
+python -m reporting.qre_controlled_discovery_grid_runner --run --start 101 --end 150 --output-dir "$OUT" --resume
+python -m reporting.qre_controlled_discovery_grid_runner --run --start 151 --end 200 --output-dir "$OUT" --resume
+python -m reporting.qre_controlled_discovery_grid_runner --run --start 201 --end 250 --output-dir "$OUT" --resume
+python -m reporting.qre_controlled_discovery_grid_runner --run --start 251 --end 300 --output-dir "$OUT" --resume
+python -m reporting.qre_controlled_discovery_grid_runner --run --start 301 --end 328 --output-dir "$OUT" --resume
 ```
 
-De huidige runner schrijft per chunk sidecar-only artifacts en houdt expliciet bij dat execution integration nog deferred is.
+Volledige one-shot resume is ook mogelijk:
+
+```bash
+python -m reporting.qre_controlled_discovery_grid_runner --run --start 1 --end 328 --output-dir "$OUT" --resume
+```
 
 ## 5. Samenvatting maken
 
 ```bash
-python -m reporting.qre_controlled_discovery_grid_analysis --input-dir research/controlled_discovery_grid_runs/vps-grid-001 --write-summary
+python -m reporting.qre_controlled_discovery_grid_runner --summarize --output-dir "$OUT"
+cat "$OUT/operator_summary.md"
 ```
 
-## 6. Output ophalen
+## 6. Live volgen
+
+```bash
+tail -f "$OUT/combination_results.v1.jsonl"
+```
+
+Of periodiek de summary verversen:
+
+```bash
+watch -n 10 "python -m reporting.qre_controlled_discovery_grid_runner --summarize --output-dir '$OUT' && cat '$OUT/operator_summary.md'"
+```
+
+## 7. Output ophalen
 
 Kijk hier:
 
@@ -69,7 +86,18 @@ research/controlled_discovery_grid_runs/<run_id>/summary_latest.v1.json
 research/controlled_discovery_grid_runs/<run_id>/combination_results.v1.jsonl
 ```
 
-## 7. Wat de operator moet terugplakken
+Vanaf Windows:
+
+```powershell
+$KEY = "$HOME\.ssh\github_actions_vps_deploy"
+$HOSTNAME = "root@23.88.110.92"
+$RUN = "<run_id>"
+
+ssh -i $KEY $HOSTNAME "cd /root/trading-agent && cat research/controlled_discovery_grid_runs/$RUN/operator_summary.md"
+ssh -i $KEY $HOSTNAME "cd /root/trading-agent && cat research/controlled_discovery_grid_runs/$RUN/summary_latest.v1.json"
+```
+
+## 8. Wat de operator moet terugplakken
 
 Plak alleen deze outputs terug:
 
@@ -79,7 +107,7 @@ summary_latest.v1.json
 eventuele failed/unknown rows
 ```
 
-## 8. Stopcondities
+## 9. Stopcondities
 
 Stop de VPS-run bij:
 
@@ -90,20 +118,22 @@ live_activation_allowed true
 broker/risk/execution path touched
 frozen contract mutation
 unexpected generated file outside output-dir
-unknown error rate > 20%
-data coverage failures > 80%
+unknown_execution_error > 20%
 runtime crash loop
+disk usage risk
 ```
 
-## 9. Wat deze scan wel/niet bewijst
+## 10. Wat deze scan wel/niet bewijst
 
 Wel:
 
 ```text
-distribution of blockers/outcomes across 328 combinations
-which assets/presets deserve follow-up
-which failure modes dominate
-whether the discovery catalog is useful enough for routing/sampling
+328 per-combination research/validation attempts
+outcome distribution
+blocker distribution
+near-pass candidates
+candidate follow-up list
+region/preset/asset diagnostics
 ```
 
 Niet:

--- a/reporting/qre_controlled_discovery_grid_analysis.py
+++ b/reporting/qre_controlled_discovery_grid_analysis.py
@@ -33,6 +33,17 @@ def _load_jsonl(path: Path) -> list[dict[str, Any]]:
     return rows
 
 
+def _latest_result_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    latest_by_sequence: dict[int, dict[str, Any]] = {}
+    ordered_sequences: list[int] = []
+    for row in rows:
+        sequence_number = int(row.get("sequence_number") or 0)
+        if sequence_number not in latest_by_sequence:
+            ordered_sequences.append(sequence_number)
+        latest_by_sequence[sequence_number] = row
+    return [latest_by_sequence[sequence] for sequence in ordered_sequences]
+
+
 def _group_counts(rows: list[dict[str, Any]], field: str) -> list[dict[str, Any]]:
     counts: defaultdict[str, int] = defaultdict(int)
     for row in rows:
@@ -43,23 +54,61 @@ def _group_counts(rows: list[dict[str, Any]], field: str) -> list[dict[str, Any]
     ]
 
 
-def build_summary(*, run_dir: Path, results: list[dict[str, Any]]) -> dict[str, Any]:
-    blocker_counter = Counter(str(row.get("blocker_class") or "unknown") for row in results)
-    outcome_counter = Counter(str(row.get("outcome_class") or "unknown") for row in results)
-    status_counter = Counter(str(row.get("status") or "unknown") for row in results)
+def _top_rows(
+    rows: list[dict[str, Any]],
+    *,
+    predicate: Any,
+) -> list[dict[str, Any]]:
+    selected = [row for row in rows if predicate(row)]
+    selected.sort(
+        key=lambda row: (
+            float(row.get("oos_trades") or 0),
+            float(row.get("trades_total") or 0),
+            -int(row.get("sequence_number") or 0),
+        ),
+        reverse=True,
+    )
+    return [
+        {
+            "sequence_number": int(row.get("sequence_number") or 0),
+            "instrument_symbol": str(row.get("instrument_symbol") or ""),
+            "behavior_preset_id": str(row.get("behavior_preset_id") or ""),
+            "trades_total": row.get("trades_total"),
+            "oos_trades": row.get("oos_trades"),
+            "criteria_status": row.get("criteria_status"),
+        }
+        for row in selected[:10]
+    ]
+
+
+def build_summary(
+    *,
+    run_dir: Path,
+    results: list[dict[str, Any]],
+    total_planned: int | None = None,
+) -> dict[str, Any]:
+    latest_results = _latest_result_rows(results)
+    blocker_counter = Counter(
+        str(row.get("blocker_class") or "unknown") for row in latest_results
+    )
+    outcome_counter = Counter(
+        str(row.get("outcome_class") or "unknown") for row in latest_results
+    )
+    status_counter = Counter(str(row.get("status") or "unknown") for row in latest_results)
 
     deferred_count = status_counter.get("execution_integration_deferred", 0)
     summary = {
         "report_kind": "qre_controlled_discovery_grid_analysis",
         "run_dir": run_dir.as_posix(),
-        "result_count": len(results),
+        "result_count": len(latest_results),
         "counts": {
-            "total_combinations_planned": len(results),
+            "total_combinations_planned": int(total_planned or len(latest_results)),
+            "total_attempted": len(latest_results),
             "total_completed": status_counter.get("completed", 0),
-            "total_skipped": sum(
-                status_counter.get(name, 0)
-                for name in ("skipped_invalid_metadata", "blocked_by_safety")
-            ),
+            "total_skipped": status_counter.get("skipped", 0)
+            + status_counter.get("skipped_invalid_metadata", 0)
+            + status_counter.get("blocked_by_safety", 0),
+            "total_failed": status_counter.get("failed", 0),
             "execution_integration_deferred": deferred_count,
             "insufficient_trades": blocker_counter.get("insufficient_trades", 0),
             "no_oos_evidence": blocker_counter.get("no_oos_evidence", 0),
@@ -74,12 +123,21 @@ def build_summary(*, run_dir: Path, results: list[dict[str, Any]]) -> dict[str, 
             "near_pass": outcome_counter.get("near_pass", 0),
             "promotion_candidate": outcome_counter.get("promotion_candidate", 0),
             "unknown": outcome_counter.get("unknown", 0),
+            "total_unknown": outcome_counter.get("unknown", 0),
         },
-        "by_region": _group_counts(results, "region"),
-        "by_asset": _group_counts(results, "instrument_symbol"),
-        "by_behavior_preset": _group_counts(results, "behavior_preset_id"),
-        "by_outcome_class": _group_counts(results, "outcome_class"),
-        "by_blocker_class": _group_counts(results, "blocker_class"),
+        "by_region": _group_counts(latest_results, "region"),
+        "by_asset": _group_counts(latest_results, "instrument_symbol"),
+        "by_behavior_preset": _group_counts(latest_results, "behavior_preset_id"),
+        "by_outcome_class": _group_counts(latest_results, "outcome_class"),
+        "by_blocker_class": _group_counts(latest_results, "blocker_class"),
+        "top_near_pass": _top_rows(
+            latest_results,
+            predicate=lambda row: bool(row.get("near_pass")),
+        ),
+        "top_promotion_candidates": _top_rows(
+            latest_results,
+            predicate=lambda row: bool(row.get("promotion_candidate")),
+        ),
         "next_action": "DEFER_EXECUTION_INTEGRATION"
         if deferred_count
         else "MERGE_AND_RUN_ON_VPS",
@@ -93,8 +151,10 @@ def render_operator_summary(summary: dict[str, Any]) -> str:
         ["Field", "Count"],
         [
             ["total combinations planned", str(counts["total_combinations_planned"])],
+            ["executed combinations", str(counts["total_attempted"])],
             ["total completed", str(counts["total_completed"])],
             ["total skipped", str(counts["total_skipped"])],
+            ["total failed", str(counts["total_failed"])],
             ["execution integration deferred", str(counts["execution_integration_deferred"])],
             ["insufficient trades", str(counts["insufficient_trades"])],
             ["no OOS evidence", str(counts["no_oos_evidence"])],
@@ -123,9 +183,9 @@ def render_operator_summary(summary: dict[str, Any]) -> str:
             "# QRE Controlled Discovery Grid Operator Summary",
             "",
             "## 1. Korte conclusie",
-            "- This run prepared a deterministic controlled discovery grid over the read-only production discovery catalog.",
-            "- Planning, chunking, resume, and sidecar-only artifact writing are ready for VPS use.",
-            "- Direct controlled execution integration is still deferred; current result rows make that explicit instead of pretending market evidence exists.",
+            "- This run attempted controlled discovery-grid combinations through the existing research path whenever a concrete mapping existed.",
+            "- Unsupported or unsafe combinations were written as explicit skipped blockers instead of crashing the run.",
+            "- Completed, skipped, and failed counts below show the real attempt distribution for this run.",
             "",
             "## 2. Outcome counts",
             evidence_table,
@@ -161,7 +221,23 @@ def summarize_run(
 ) -> dict[str, Any]:
     run_dir = _resolve_run_dir(input_dir)
     results = _load_jsonl(run_dir / RESULTS_FILENAME)
-    summary = build_summary(run_dir=run_dir, results=results)
+    plan_payload = None
+    plan_path = run_dir / "grid_plan.v1.json"
+    if plan_path.exists():
+        try:
+            plan_payload = json.loads(plan_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            plan_payload = None
+    total_planned = (
+        int(plan_payload.get("total_combinations") or 0)
+        if isinstance(plan_payload, dict)
+        else None
+    )
+    summary = build_summary(
+        run_dir=run_dir,
+        results=results,
+        total_planned=total_planned,
+    )
     if write_summary:
         (run_dir / SUMMARY_FILENAME).write_text(
             json.dumps(summary, indent=2, ensure_ascii=False) + "\n",

--- a/reporting/qre_controlled_discovery_grid_runner.py
+++ b/reporting/qre_controlled_discovery_grid_runner.py
@@ -47,6 +47,19 @@ def _run_dir(*, output_dir: Path, run_id: str) -> Path:
     return output_dir / run_id
 
 
+def _resolved_run_location(
+    *,
+    output_dir: Path,
+    run_id: str | None,
+) -> tuple[str, Path]:
+    if run_id:
+        return run_id, _run_dir(output_dir=output_dir, run_id=run_id)
+    if output_dir == OUTPUT_DIR_DEFAULT:
+        resolved_run_id = _utcnow_stamp()
+        return resolved_run_id, _run_dir(output_dir=output_dir, run_id=resolved_run_id)
+    return output_dir.name, output_dir
+
+
 def _result_row(
     combination: dict[str, Any],
     *,
@@ -92,6 +105,10 @@ def _load_existing_sequence_numbers(results_path: Path) -> set[int]:
     return sequence_numbers
 
 
+def _execution_module():
+    return importlib.import_module("research.controlled_discovery_grid_execution")
+
+
 def plan_snapshot() -> dict[str, Any]:
     payload = _plan_payload()
     return {
@@ -118,8 +135,7 @@ def execute_range(
 ) -> dict[str, Any]:
     payload = _plan_payload()
     selected = _selected_combinations(start=start, end=end)
-    resolved_run_id = run_id or _utcnow_stamp()
-    run_dir = _run_dir(output_dir=output_dir, run_id=resolved_run_id)
+    resolved_run_id, run_dir = _resolved_run_location(output_dir=output_dir, run_id=run_id)
     run_dir.mkdir(parents=True, exist_ok=True)
 
     plan_path = run_dir / PLAN_FILENAME
@@ -132,11 +148,17 @@ def execute_range(
         )
 
     existing_sequence_numbers = _load_existing_sequence_numbers(results_path) if resume else set()
-    rows_to_write = [
-        _result_row(item, run_id=resolved_run_id, run_dir=run_dir)
-        for item in selected
-        if int(item["sequence_number"]) not in existing_sequence_numbers
-    ]
+    execution = _execution_module()
+    rows_to_write = []
+    for item in selected:
+        if int(item["sequence_number"]) in existing_sequence_numbers:
+            continue
+        row = execution.execute_grid_row(
+            item,
+            output_dir=run_dir / f"combination_{int(item['sequence_number']):03d}",
+        )
+        row["run_id"] = resolved_run_id
+        rows_to_write.append(row)
     if rows_to_write:
         with results_path.open("a", encoding="utf-8") as handle:
             for row in rows_to_write:
@@ -151,10 +173,8 @@ def execute_range(
         "selected_count": len(selected),
         "written_count": len(rows_to_write),
         "resume": resume,
-        "execution_integration_deferred": True,
-        "deferred_reason": (
-            "RUNNER_EXECUTION_INTEGRATION_DEFERRED: planner and runbook are ready, "
-            "execution integration needs next PR"
+        "execution_integration_deferred": (
+            int(summary["counts"]["execution_integration_deferred"]) > 0
         ),
         "artifacts": {
             "grid_plan": plan_path.as_posix(),
@@ -174,6 +194,7 @@ def main(argv: list[str] | None = None) -> int:
     mode = parser.add_mutually_exclusive_group(required=True)
     mode.add_argument("--plan-only", action="store_true")
     mode.add_argument("--run", action="store_true")
+    mode.add_argument("--summarize", action="store_true")
     parser.add_argument("--start", type=int)
     parser.add_argument("--end", type=int)
     parser.add_argument("--output-dir", default=str(OUTPUT_DIR_DEFAULT))
@@ -183,6 +204,13 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.plan_only:
         print(json.dumps(plan_snapshot(), indent=2, ensure_ascii=False))
+        return 0
+    if args.summarize:
+        summary = analysis.summarize_run(
+            input_dir=Path(args.output_dir),
+            write_summary=True,
+        )
+        print(json.dumps(summary, indent=2, ensure_ascii=False))
         return 0
 
     if args.start is None or args.end is None:

--- a/research/controlled_discovery_grid_execution.py
+++ b/research/controlled_discovery_grid_execution.py
@@ -9,7 +9,11 @@ do not raise as normal control flow; they return a deterministic
 
 from __future__ import annotations
 
+import datetime as dt
+import importlib
+import json
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Final
 
 from research.presets import ResearchPreset
@@ -32,6 +36,10 @@ BLOCKER_MISSING_METADATA: Final[str] = "missing_validation_input"
 BLOCKER_SAFETY_VIOLATION: Final[str] = "blocked_by_safety"
 BLOCKER_REGION_MISMATCH: Final[str] = "preset_region_constraint_mismatch"
 BLOCKER_ASSET_CLASS_MISMATCH: Final[str] = "preset_asset_class_constraint_mismatch"
+BLOCKER_CONTROLLED_VALIDATION_FAILED: Final[str] = "controlled_validation_failed"
+BLOCKER_UNKNOWN_EXECUTION_ERROR: Final[str] = "unknown_execution_error"
+
+RESULT_REPORT_KIND: Final[str] = "qre_controlled_discovery_grid_execution_result"
 
 
 @dataclass(frozen=True)
@@ -76,6 +84,27 @@ class GridExecutionMapping:
             "safety_flags": dict(self.safety_flags),
             "mapping_notes": list(self.mapping_notes),
         }
+
+
+@dataclass(frozen=True)
+class GridExecutionObservation:
+    status: str
+    outcome_class: str
+    blocker_class: str | None
+    error_class: str | None
+    trades_total: float | None
+    oos_trades: int | None
+    hd_trades: float | None
+    criteria_status: str | None
+    promotion_candidate: bool
+    near_pass: bool
+    safe_to_promote: bool
+    artifact_paths: dict[str, str]
+    candidate_count: int
+    started_at_utc: str
+    finished_at_utc: str
+    duration_seconds: float
+    execution_notes: tuple[str, ...]
 
 
 _CATALOG_PRESET_BY_ID: Final[dict[str, dict[str, Any]]] = {
@@ -386,3 +415,369 @@ def map_grid_row_to_execution(row: dict[str, Any]) -> GridExecutionMapping:
         mapping_notes=tuple(notes),
         preset_override=preset_override,
     )
+
+
+def _utcnow() -> dt.datetime:
+    return dt.datetime.now(dt.UTC)
+
+
+def _iso_utc(value: dt.datetime) -> str:
+    return value.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _latest_artifact_snapshot() -> dict[str, dict[str, Any] | None]:
+    return {
+        "run_manifest": _read_json(Path("research/run_manifest_latest.v1.json")),
+        "run_meta": _read_json(Path("research/run_meta_latest.v1.json")),
+        "screening_evidence": _read_json(Path("research/screening_evidence_latest.v1.json")),
+        "run_candidates": _read_json(Path("research/run_candidates_latest.v1.json")),
+        "run_campaign": _read_json(Path("research/run_campaign_latest.v1.json")),
+    }
+
+
+def _matching_screening_rows(
+    screening_payload: dict[str, Any] | None,
+    *,
+    asset_symbol: str,
+) -> list[dict[str, Any]]:
+    candidates = screening_payload.get("candidates") if isinstance(screening_payload, dict) else []
+    if not isinstance(candidates, list):
+        return []
+    return [
+        row
+        for row in candidates
+        if isinstance(row, dict) and str(row.get("asset") or "") == asset_symbol
+    ]
+
+
+def _stage_rank(row: dict[str, Any]) -> tuple[int, int, float]:
+    stage_result = str(row.get("stage_result") or "")
+    near_pass = bool((row.get("near_pass") or {}).get("is_near_pass"))
+    validation = row.get("validation_evidence") or {}
+    metrics = row.get("metrics") or {}
+    rank = {
+        "promotion_candidate": 6,
+        "needs_investigation": 5,
+        "near_pass": 4,
+        "screening_pass": 3,
+        "screening_reject": 2,
+        "unknown": 1,
+    }.get(stage_result, 0)
+    oos = int(validation.get("oos_trade_count") or 0)
+    trades = float(metrics.get("totaal_trades", 0.0) or 0.0)
+    return rank, 1 if near_pass else 0, oos + trades
+
+
+def _best_screening_row(rows: list[dict[str, Any]]) -> dict[str, Any] | None:
+    if not rows:
+        return None
+    return max(rows, key=_stage_rank)
+
+
+def _criteria_status(best_row: dict[str, Any] | None) -> str | None:
+    if not best_row:
+        return None
+    blocked = list((best_row.get("promotion_guard") or {}).get("blocked_by") or [])
+    if blocked:
+        return ",".join(sorted(str(item) for item in blocked))
+    if (best_row.get("promotion_guard") or {}).get("promotion_allowed") is True:
+        return "promotion_allowed"
+    failed = list((best_row.get("criteria") or {}).get("failed") or [])
+    if failed:
+        return ",".join(sorted(str(item) for item in failed))
+    passed = list((best_row.get("criteria") or {}).get("passed") or [])
+    if passed:
+        return "criteria_passed_without_promotion"
+    return None
+
+
+def _derive_blocker(best_row: dict[str, Any] | None) -> str | None:
+    if not best_row:
+        return "missing_data"
+    failure_reasons = [str(item) for item in list(best_row.get("failure_reasons") or [])]
+    if "insufficient_trades" in failure_reasons:
+        return "insufficient_trades"
+    validation = best_row.get("validation_evidence") or {}
+    validation_status = str(validation.get("status") or "")
+    if validation_status == "no_oos_trades":
+        return "no_oos_evidence"
+    if validation_status == "insufficient_oos_trades":
+        return "insufficient_trades"
+    blocked = list((best_row.get("promotion_guard") or {}).get("blocked_by") or [])
+    if blocked:
+        return str(sorted(str(item) for item in blocked)[0])
+    return None
+
+
+def _derive_outcome(best_row: dict[str, Any] | None) -> str:
+    if not best_row:
+        return "unknown"
+    if (best_row.get("promotion_guard") or {}).get("promotion_allowed") is True:
+        return "promotion_candidate"
+    if bool((best_row.get("near_pass") or {}).get("is_near_pass")):
+        return "near_pass"
+    validation = best_row.get("validation_evidence") or {}
+    status = str(validation.get("status") or "")
+    if status == "sufficient_oos_evidence":
+        return "sufficient_oos_evidence"
+    if status == "no_oos_trades":
+        return "screening_pass_no_oos"
+    return str(best_row.get("stage_result") or "unknown")
+
+
+def _run_existing_research_path(mapping: GridExecutionMapping) -> None:
+    run_research_module = importlib.import_module("research.run_research")
+    run_research_module.run_research(preset_override=mapping.preset_override)
+
+
+def _write_execution_summary_sidecar(
+    *,
+    row: dict[str, Any],
+    mapping: GridExecutionMapping,
+    observation: GridExecutionObservation,
+    output_dir: Path,
+    artifacts: dict[str, dict[str, Any] | None],
+    matching_rows: list[dict[str, Any]],
+) -> dict[str, str]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    summary_path = output_dir / "execution_result.v1.json"
+    payload = {
+        "report_kind": RESULT_REPORT_KIND,
+        "grid_row": {
+            "sequence_number": row["sequence_number"],
+            "instrument_symbol": row["instrument_symbol"],
+            "behavior_preset_id": row["behavior_preset_id"],
+            "hypothesis_id": row["hypothesis_id"],
+            "timeframe": row["timeframe"],
+            "region": row["region"],
+            "asset_class": row["asset_class"],
+        },
+        "mapping": mapping.to_payload(),
+        "observation": {
+            "status": observation.status,
+            "outcome_class": observation.outcome_class,
+            "blocker_class": observation.blocker_class,
+            "error_class": observation.error_class,
+            "trades_total": observation.trades_total,
+            "oos_trades": observation.oos_trades,
+            "hd_trades": observation.hd_trades,
+            "criteria_status": observation.criteria_status,
+            "promotion_candidate": observation.promotion_candidate,
+            "near_pass": observation.near_pass,
+            "safe_to_promote": observation.safe_to_promote,
+            "candidate_count": observation.candidate_count,
+            "started_at_utc": observation.started_at_utc,
+            "finished_at_utc": observation.finished_at_utc,
+            "duration_seconds": observation.duration_seconds,
+            "execution_notes": list(observation.execution_notes),
+        },
+        "artifact_snapshot": {
+            "run_manifest": artifacts["run_manifest"],
+            "run_meta": artifacts["run_meta"],
+            "run_campaign": artifacts["run_campaign"],
+            "matching_screening_rows": matching_rows,
+        },
+    }
+    summary_path.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return {
+        "execution_result": summary_path.as_posix(),
+        "run_manifest_latest": "research/run_manifest_latest.v1.json",
+        "run_meta_latest": "research/run_meta_latest.v1.json",
+        "screening_evidence_latest": "research/screening_evidence_latest.v1.json",
+        "run_candidates_latest": "research/run_candidates_latest.v1.json",
+        "run_campaign_latest": "research/run_campaign_latest.v1.json",
+    }
+
+
+def _skipped_observation(
+    *,
+    blocker_class: str,
+    started_at: dt.datetime,
+    finished_at: dt.datetime,
+    notes: tuple[str, ...],
+) -> GridExecutionObservation:
+    return GridExecutionObservation(
+        status="skipped",
+        outcome_class="skipped",
+        blocker_class=blocker_class,
+        error_class=None,
+        trades_total=None,
+        oos_trades=None,
+        hd_trades=None,
+        criteria_status=None,
+        promotion_candidate=False,
+        near_pass=False,
+        safe_to_promote=False,
+        artifact_paths={},
+        candidate_count=0,
+        started_at_utc=_iso_utc(started_at),
+        finished_at_utc=_iso_utc(finished_at),
+        duration_seconds=max((finished_at - started_at).total_seconds(), 0.0),
+        execution_notes=notes,
+    )
+
+
+def execute_grid_row(
+    row: dict[str, Any],
+    *,
+    output_dir: Path,
+    execution_runner: Any | None = None,
+) -> dict[str, Any]:
+    started_at = _utcnow()
+    mapping = map_grid_row_to_execution(row)
+    if mapping.status != "ready":
+        finished_at = _utcnow()
+        observation = _skipped_observation(
+            blocker_class=str(mapping.blocker_class),
+            started_at=started_at,
+            finished_at=finished_at,
+            notes=mapping.mapping_notes,
+        )
+        artifact_paths = _write_execution_summary_sidecar(
+            row=row,
+            mapping=mapping,
+            observation=observation,
+            output_dir=output_dir,
+            artifacts=_latest_artifact_snapshot(),
+            matching_rows=[],
+        )
+        return {
+            **row,
+            "status": observation.status,
+            "outcome_class": observation.outcome_class,
+            "blocker_class": observation.blocker_class,
+            "error_class": observation.error_class,
+            "trades_total": observation.trades_total,
+            "oos_trades": observation.oos_trades,
+            "hd_trades": observation.hd_trades,
+            "criteria_status": observation.criteria_status,
+            "promotion_candidate": observation.promotion_candidate,
+            "near_pass": observation.near_pass,
+            "safe_to_promote": observation.safe_to_promote,
+            "artifact_paths": artifact_paths,
+            "result_path": artifact_paths["execution_result"],
+            "validation_campaign_id": mapping.validation_campaign_id,
+            "strategy_or_preset_reference": mapping.strategy_or_preset_reference,
+            "run_label": mapping.run_label,
+            "output_subdir": mapping.output_subdir,
+            "started_at_utc": observation.started_at_utc,
+            "finished_at_utc": observation.finished_at_utc,
+            "duration_seconds": observation.duration_seconds,
+            "execution_notes": list(observation.execution_notes),
+        }
+
+    runner = execution_runner or _run_existing_research_path
+    try:
+        runner(mapping)
+        status = "completed"
+        error_class = None
+        blocker_class = None
+        execution_notes = ("existing_run_research_path_executed",)
+    except Exception as exc:  # pragma: no cover - exercised via tests with stubs
+        degenerate = type(exc).__name__ == "DegenerateResearchRunError"
+        status = "completed" if degenerate else "failed"
+        error_class = type(exc).__name__
+        blocker_class = (
+            "degenerate_no_survivors" if degenerate else BLOCKER_CONTROLLED_VALIDATION_FAILED
+        )
+        execution_notes = (
+            "existing_run_research_path_executed",
+            "exception_raised_during_execution",
+        )
+
+    finished_at = _utcnow()
+    artifacts = _latest_artifact_snapshot()
+    matching_rows = _matching_screening_rows(
+        artifacts["screening_evidence"],
+        asset_symbol=str(row["instrument_symbol"]),
+    )
+    best_row = _best_screening_row(matching_rows)
+    trades_total = (
+        float((best_row.get("metrics") or {}).get("totaal_trades", 0.0) or 0.0)
+        if best_row is not None
+        else None
+    )
+    oos_trades = (
+        int((best_row.get("validation_evidence") or {}).get("oos_trade_count") or 0)
+        if best_row is not None
+        else None
+    )
+    hd_trades = (
+        max(trades_total - float(oos_trades or 0), 0.0)
+        if trades_total is not None and oos_trades is not None
+        else None
+    )
+    promotion_candidate = bool(
+        best_row is not None
+        and (
+            (best_row.get("promotion_guard") or {}).get("promotion_allowed") is True
+            or str(best_row.get("stage_result") or "") == "promotion_candidate"
+        )
+    )
+    near_pass = bool(
+        best_row is not None and bool((best_row.get("near_pass") or {}).get("is_near_pass"))
+    )
+    observation = GridExecutionObservation(
+        status=status,
+        outcome_class=_derive_outcome(best_row),
+        blocker_class=blocker_class or _derive_blocker(best_row),
+        error_class=error_class if status == "failed" else None,
+        trades_total=trades_total,
+        oos_trades=oos_trades,
+        hd_trades=hd_trades,
+        criteria_status=_criteria_status(best_row),
+        promotion_candidate=promotion_candidate,
+        near_pass=near_pass,
+        safe_to_promote=promotion_candidate,
+        artifact_paths={},
+        candidate_count=len(matching_rows),
+        started_at_utc=_iso_utc(started_at),
+        finished_at_utc=_iso_utc(finished_at),
+        duration_seconds=max((finished_at - started_at).total_seconds(), 0.0),
+        execution_notes=execution_notes,
+    )
+    artifact_paths = _write_execution_summary_sidecar(
+        row=row,
+        mapping=mapping,
+        observation=observation,
+        output_dir=output_dir,
+        artifacts=artifacts,
+        matching_rows=matching_rows,
+    )
+    return {
+        **row,
+        "status": observation.status,
+        "outcome_class": observation.outcome_class,
+        "blocker_class": observation.blocker_class,
+        "error_class": observation.error_class,
+        "trades_total": observation.trades_total,
+        "oos_trades": observation.oos_trades,
+        "hd_trades": observation.hd_trades,
+        "criteria_status": observation.criteria_status,
+        "promotion_candidate": observation.promotion_candidate,
+        "near_pass": observation.near_pass,
+        "safe_to_promote": observation.safe_to_promote,
+        "artifact_paths": artifact_paths,
+        "result_path": artifact_paths["execution_result"],
+        "validation_campaign_id": mapping.validation_campaign_id,
+        "strategy_or_preset_reference": mapping.strategy_or_preset_reference,
+        "run_label": mapping.run_label,
+        "output_subdir": mapping.output_subdir,
+        "started_at_utc": observation.started_at_utc,
+        "finished_at_utc": observation.finished_at_utc,
+        "duration_seconds": observation.duration_seconds,
+        "execution_notes": list(observation.execution_notes),
+    }

--- a/research/controlled_discovery_grid_execution.py
+++ b/research/controlled_discovery_grid_execution.py
@@ -1,0 +1,388 @@
+"""Execution adapter for controlled discovery grid rows.
+
+This module maps a planned discovery-grid combination onto a bounded,
+single-asset research preset override that can be executed through the
+existing ``research.run_research`` path. Unsupported behavior families
+do not raise as normal control flow; they return a deterministic
+``skipped`` blocker result instead.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Final
+
+from research.presets import ResearchPreset
+from research.production_discovery_catalog import list_presets
+
+
+REQUIRED_GRID_FIELDS: Final[tuple[str, ...]] = (
+    "sequence_number",
+    "instrument_symbol",
+    "canonical_instrument_id",
+    "region",
+    "asset_class",
+    "behavior_preset_id",
+    "hypothesis_id",
+    "timeframe",
+)
+
+BLOCKER_UNSUPPORTED_MAPPING: Final[str] = "unsupported_grid_to_validation_mapping"
+BLOCKER_MISSING_METADATA: Final[str] = "missing_validation_input"
+BLOCKER_SAFETY_VIOLATION: Final[str] = "blocked_by_safety"
+BLOCKER_REGION_MISMATCH: Final[str] = "preset_region_constraint_mismatch"
+BLOCKER_ASSET_CLASS_MISMATCH: Final[str] = "preset_asset_class_constraint_mismatch"
+
+
+@dataclass(frozen=True)
+class ExecutionTemplate:
+    behavior_preset_id: str
+    preset_reference: str
+    bundle: tuple[str, ...]
+    screening_phase: str
+    executable_hypothesis_id: str | None
+    executable: bool
+    supported_asset_classes: tuple[str, ...]
+    supported_regions: tuple[str, ...]
+    unsupported_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class GridExecutionMapping:
+    status: str
+    blocker_class: str | None
+    validation_campaign_id: str
+    strategy_or_preset_reference: str | None
+    asset_symbol: str
+    timeframe: str | None
+    hypothesis_id: str | None
+    run_label: str
+    output_subdir: str
+    safety_flags: dict[str, bool]
+    mapping_notes: tuple[str, ...]
+    preset_override: ResearchPreset | None
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "blocker_class": self.blocker_class,
+            "validation_campaign_id": self.validation_campaign_id,
+            "strategy_or_preset_reference": self.strategy_or_preset_reference,
+            "asset_symbol": self.asset_symbol,
+            "timeframe": self.timeframe,
+            "hypothesis_id": self.hypothesis_id,
+            "run_label": self.run_label,
+            "output_subdir": self.output_subdir,
+            "safety_flags": dict(self.safety_flags),
+            "mapping_notes": list(self.mapping_notes),
+        }
+
+
+_CATALOG_PRESET_BY_ID: Final[dict[str, dict[str, Any]]] = {
+    str(preset.to_payload()["preset_id"]): preset.to_payload()
+    for preset in list_presets()
+}
+
+_EXECUTION_TEMPLATES: Final[dict[str, ExecutionTemplate]] = {
+    "trend_continuation_daily_v1": ExecutionTemplate(
+        behavior_preset_id="trend_continuation_daily_v1",
+        preset_reference="trend_equities_4h_baseline",
+        bundle=("sma_crossover", "breakout_momentum"),
+        screening_phase="exploratory",
+        executable_hypothesis_id=None,
+        executable=True,
+        supported_asset_classes=("equity", "etf"),
+        supported_regions=("NL/EU", "US", "Asia/proxies", "ETFs/context"),
+    ),
+    "trend_pullback_continuation_daily_v1": ExecutionTemplate(
+        behavior_preset_id="trend_pullback_continuation_daily_v1",
+        preset_reference="trend_pullback_equities_4h",
+        bundle=("trend_pullback_v1",),
+        screening_phase="exploratory",
+        executable_hypothesis_id="trend_pullback_v1",
+        executable=True,
+        supported_asset_classes=("equity",),
+        supported_regions=("NL/EU", "US", "Asia/proxies"),
+    ),
+    "vol_compression_breakout_daily_v1": ExecutionTemplate(
+        behavior_preset_id="vol_compression_breakout_daily_v1",
+        preset_reference="vol_compression_breakout_crypto_1h",
+        bundle=("volatility_compression_breakout",),
+        screening_phase="exploratory",
+        executable_hypothesis_id="volatility_compression_breakout_v0",
+        executable=True,
+        supported_asset_classes=("equity", "etf"),
+        supported_regions=("NL/EU", "US", "Asia/proxies", "ETFs/context"),
+    ),
+    "vol_compression_breakout_4h_v1": ExecutionTemplate(
+        behavior_preset_id="vol_compression_breakout_4h_v1",
+        preset_reference="vol_compression_breakout_crypto_4h",
+        bundle=("volatility_compression_breakout",),
+        screening_phase="exploratory",
+        executable_hypothesis_id="volatility_compression_breakout_v0",
+        executable=True,
+        supported_asset_classes=("equity", "etf"),
+        supported_regions=("US", "ETFs/context"),
+    ),
+    "relative_strength_vs_sector_daily_v1": ExecutionTemplate(
+        behavior_preset_id="relative_strength_vs_sector_daily_v1",
+        preset_reference=None,
+        bundle=(),
+        screening_phase="exploratory",
+        executable_hypothesis_id=None,
+        executable=False,
+        supported_asset_classes=("equity",),
+        supported_regions=("NL/EU", "US"),
+        unsupported_reason="preset_not_executable",
+    ),
+    "relative_strength_vs_region_daily_v1": ExecutionTemplate(
+        behavior_preset_id="relative_strength_vs_region_daily_v1",
+        preset_reference=None,
+        bundle=(),
+        screening_phase="exploratory",
+        executable_hypothesis_id=None,
+        executable=False,
+        supported_asset_classes=("equity", "etf"),
+        supported_regions=("NL/EU", "US", "Asia/proxies", "ETFs/context"),
+        unsupported_reason="preset_not_executable",
+    ),
+    "post_shock_stabilization_daily_v1": ExecutionTemplate(
+        behavior_preset_id="post_shock_stabilization_daily_v1",
+        preset_reference=None,
+        bundle=(),
+        screening_phase="exploratory",
+        executable_hypothesis_id=None,
+        executable=False,
+        supported_asset_classes=("equity", "etf"),
+        supported_regions=("NL/EU", "US", "Asia/proxies", "ETFs/context"),
+        unsupported_reason="preset_not_executable",
+    ),
+    "index_regime_filter_daily_v1": ExecutionTemplate(
+        behavior_preset_id="index_regime_filter_daily_v1",
+        preset_reference=None,
+        bundle=(),
+        screening_phase="exploratory",
+        executable_hypothesis_id=None,
+        executable=False,
+        supported_asset_classes=("equity", "etf"),
+        supported_regions=("NL/EU", "US", "Asia/proxies", "ETFs/context"),
+        unsupported_reason="preset_not_executable",
+    ),
+}
+
+
+def _missing_required_fields(row: dict[str, Any]) -> list[str]:
+    return [field for field in REQUIRED_GRID_FIELDS if row.get(field) in (None, "", [])]
+
+
+def _safety_flags(row: dict[str, Any]) -> dict[str, bool]:
+    return {
+        "not_alpha_claim": bool(row.get("not_alpha_claim") is True),
+        "paper_activation_allowed": bool(row.get("paper_activation_allowed") is True),
+        "shadow_activation_allowed": bool(row.get("shadow_activation_allowed") is True),
+        "live_activation_allowed": bool(row.get("live_activation_allowed") is True),
+    }
+
+
+def _deterministic_ids(row: dict[str, Any]) -> tuple[str, str, str]:
+    sequence = int(row["sequence_number"])
+    symbol = str(row["instrument_symbol"])
+    preset_id = str(row["behavior_preset_id"])
+    validation_campaign_id = (
+        f"qre-grid-validation-{sequence:03d}-{symbol.lower()}-{preset_id}"
+    )
+    run_label = f"qre_grid_seq_{sequence:03d}_{symbol}_{preset_id}"
+    output_subdir = f"combination_{sequence:03d}_{symbol}_{preset_id}"
+    return validation_campaign_id, run_label, output_subdir
+
+
+def _preset_override_for(
+    *,
+    row: dict[str, Any],
+    template: ExecutionTemplate,
+) -> ResearchPreset:
+    symbol = str(row["instrument_symbol"])
+    timeframe = str(row["timeframe"])
+    hypothesis_id = (
+        template.executable_hypothesis_id
+        if template.executable_hypothesis_id is not None
+        else None
+    )
+    return ResearchPreset(
+        name=f"qre_grid_exec__{row['sequence_number']:03d}__{symbol}__{template.behavior_preset_id}",
+        hypothesis=(
+            "Controlled discovery grid execution override. This is a "
+            "single-asset bounded research attempt; it is not an alpha claim "
+            "and grants no paper/shadow/live authority."
+        ),
+        universe=(symbol,),
+        timeframe=timeframe,
+        bundle=template.bundle,
+        screening_mode="strict",
+        screening_phase=template.screening_phase,  # type: ignore[arg-type]
+        cost_mode="realistic",
+        status="stable",
+        enabled=True,
+        diagnostic_only=False,
+        excluded_from_daily_scheduler=True,
+        excluded_from_candidate_promotion=False,
+        hypothesis_id=hypothesis_id,
+        preset_class="experimental",
+        rationale=(
+            "Bounded controlled discovery-grid execution over an existing "
+            "executable strategy bundle."
+        ),
+        expected_behavior=(
+            "Produces per-combination research evidence using the existing "
+            "run_research path with a single-asset universe override."
+        ),
+        falsification=(
+            "No executable candidates emerge for the mapped asset/timeframe.",
+            "Validation evidence remains insufficient or absent.",
+        ),
+        enablement_criteria=(
+            "not_alpha_claim remains true",
+            "paper_activation_allowed remains false",
+            "shadow_activation_allowed remains false",
+            "live_activation_allowed remains false",
+        ),
+    )
+
+
+def map_grid_row_to_execution(row: dict[str, Any]) -> GridExecutionMapping:
+    validation_campaign_id, run_label, output_subdir = _deterministic_ids(
+        {
+            **row,
+            "sequence_number": int(row.get("sequence_number") or 0),
+            "instrument_symbol": str(row.get("instrument_symbol") or "unknown"),
+            "behavior_preset_id": str(row.get("behavior_preset_id") or "unknown"),
+        }
+    )
+    safety_flags = _safety_flags(row)
+    missing = _missing_required_fields(row)
+    if missing:
+        return GridExecutionMapping(
+            status="skipped",
+            blocker_class=BLOCKER_MISSING_METADATA,
+            validation_campaign_id=validation_campaign_id,
+            strategy_or_preset_reference=None,
+            asset_symbol=str(row.get("instrument_symbol") or ""),
+            timeframe=str(row.get("timeframe") or "") or None,
+            hypothesis_id=str(row.get("hypothesis_id") or "") or None,
+            run_label=run_label,
+            output_subdir=output_subdir,
+            safety_flags=safety_flags,
+            mapping_notes=tuple(f"missing_{field}" for field in missing),
+            preset_override=None,
+        )
+    if (
+        not safety_flags["not_alpha_claim"]
+        or safety_flags["paper_activation_allowed"]
+        or safety_flags["shadow_activation_allowed"]
+        or safety_flags["live_activation_allowed"]
+    ):
+        return GridExecutionMapping(
+            status="skipped",
+            blocker_class=BLOCKER_SAFETY_VIOLATION,
+            validation_campaign_id=validation_campaign_id,
+            strategy_or_preset_reference=None,
+            asset_symbol=str(row["instrument_symbol"]),
+            timeframe=str(row["timeframe"]),
+            hypothesis_id=str(row["hypothesis_id"]),
+            run_label=run_label,
+            output_subdir=output_subdir,
+            safety_flags=safety_flags,
+            mapping_notes=("grid_row_failed_safety_invariants",),
+            preset_override=None,
+        )
+
+    behavior_preset_id = str(row["behavior_preset_id"])
+    template = _EXECUTION_TEMPLATES.get(behavior_preset_id)
+    if template is None:
+        return GridExecutionMapping(
+            status="skipped",
+            blocker_class=BLOCKER_UNSUPPORTED_MAPPING,
+            validation_campaign_id=validation_campaign_id,
+            strategy_or_preset_reference=None,
+            asset_symbol=str(row["instrument_symbol"]),
+            timeframe=str(row["timeframe"]),
+            hypothesis_id=str(row["hypothesis_id"]),
+            run_label=run_label,
+            output_subdir=output_subdir,
+            safety_flags=safety_flags,
+            mapping_notes=("unknown_behavior_preset_id",),
+            preset_override=None,
+        )
+
+    asset_class = str(row["asset_class"])
+    region = str(row["region"])
+    if asset_class not in template.supported_asset_classes:
+        return GridExecutionMapping(
+            status="skipped",
+            blocker_class=BLOCKER_ASSET_CLASS_MISMATCH,
+            validation_campaign_id=validation_campaign_id,
+            strategy_or_preset_reference=template.preset_reference,
+            asset_symbol=str(row["instrument_symbol"]),
+            timeframe=str(row["timeframe"]),
+            hypothesis_id=str(row["hypothesis_id"]),
+            run_label=run_label,
+            output_subdir=output_subdir,
+            safety_flags=safety_flags,
+            mapping_notes=("asset_class_not_supported_by_executable_mapping",),
+            preset_override=None,
+        )
+    if region not in template.supported_regions:
+        return GridExecutionMapping(
+            status="skipped",
+            blocker_class=BLOCKER_REGION_MISMATCH,
+            validation_campaign_id=validation_campaign_id,
+            strategy_or_preset_reference=template.preset_reference,
+            asset_symbol=str(row["instrument_symbol"]),
+            timeframe=str(row["timeframe"]),
+            hypothesis_id=str(row["hypothesis_id"]),
+            run_label=run_label,
+            output_subdir=output_subdir,
+            safety_flags=safety_flags,
+            mapping_notes=("region_not_supported_by_executable_mapping",),
+            preset_override=None,
+        )
+    if not template.executable or template.preset_reference is None:
+        return GridExecutionMapping(
+            status="skipped",
+            blocker_class=template.unsupported_reason or BLOCKER_UNSUPPORTED_MAPPING,
+            validation_campaign_id=validation_campaign_id,
+            strategy_or_preset_reference=template.preset_reference,
+            asset_symbol=str(row["instrument_symbol"]),
+            timeframe=str(row["timeframe"]),
+            hypothesis_id=str(row["hypothesis_id"]),
+            run_label=run_label,
+            output_subdir=output_subdir,
+            safety_flags=safety_flags,
+            mapping_notes=("no_existing_executable_preset_for_behavior_family",),
+            preset_override=None,
+        )
+
+    preset_override = _preset_override_for(row=row, template=template)
+    catalog_preset = _CATALOG_PRESET_BY_ID.get(behavior_preset_id) or {}
+    notes = [
+        f"mapped_from_catalog_preset={behavior_preset_id}",
+        f"strategy_or_preset_reference={template.preset_reference}",
+    ]
+    if catalog_preset:
+        notes.append(
+            f"catalog_required_data_quality={catalog_preset.get('required_data_quality')}"
+        )
+    return GridExecutionMapping(
+        status="ready",
+        blocker_class=None,
+        validation_campaign_id=validation_campaign_id,
+        strategy_or_preset_reference=template.preset_reference,
+        asset_symbol=str(row["instrument_symbol"]),
+        timeframe=str(row["timeframe"]),
+        hypothesis_id=str(row["hypothesis_id"]),
+        run_label=run_label,
+        output_subdir=output_subdir,
+        safety_flags=safety_flags,
+        mapping_notes=tuple(notes),
+        preset_override=preset_override,
+    )

--- a/research/run_research.py
+++ b/research/run_research.py
@@ -2053,6 +2053,7 @@ def run_research(
     retry_failed_batches: bool = False,
     continue_latest: bool = False,
     preset: str | None = None,
+    preset_override: ResearchPreset | None = None,
     col_campaign_id: str | None = None,
 ):
     if continue_latest and resume:
@@ -2062,7 +2063,16 @@ def run_research(
     global _COL_CAMPAIGN_ID
     _COL_CAMPAIGN_ID = col_campaign_id
     preset_obj: ResearchPreset | None = None
-    if preset is not None:
+    if preset is not None and preset_override is not None:
+        raise RuntimeError("preset and preset_override are mutually exclusive")
+    if preset_override is not None:
+        preset_obj = preset_override
+        if not preset_obj.enabled:
+            raise RuntimeError(
+                f"preset_override {preset_obj.name!r} is disabled "
+                f"(status={preset_obj.status!r})"
+            )
+    elif preset is not None:
         preset_obj = get_preset(preset)
         if not preset_obj.enabled:
             raise RuntimeError(

--- a/tests/unit/test_qre_controlled_discovery_grid_analysis.py
+++ b/tests/unit/test_qre_controlled_discovery_grid_analysis.py
@@ -11,6 +11,7 @@ def test_build_summary_counts_deferred_rows_as_unknown() -> None:
         run_dir=Path("research/controlled_discovery_grid_runs/run-001"),
         results=[
             {
+                "sequence_number": 1,
                 "status": "execution_integration_deferred",
                 "blocker_class": "execution_integration_deferred",
                 "outcome_class": "unknown",
@@ -19,6 +20,7 @@ def test_build_summary_counts_deferred_rows_as_unknown() -> None:
                 "behavior_preset_id": "trend_continuation_daily_v1",
             },
             {
+                "sequence_number": 2,
                 "status": "execution_integration_deferred",
                 "blocker_class": "execution_integration_deferred",
                 "outcome_class": "unknown",
@@ -30,6 +32,7 @@ def test_build_summary_counts_deferred_rows_as_unknown() -> None:
     )
 
     assert summary["counts"]["total_combinations_planned"] == 2
+    assert summary["counts"]["total_attempted"] == 2
     assert summary["counts"]["execution_integration_deferred"] == 2
     assert summary["counts"]["unknown"] == 2
     assert summary["next_action"] == "DEFER_EXECUTION_INTEGRATION"
@@ -61,3 +64,72 @@ def test_summarize_run_writes_summary_and_operator_markdown(tmp_path) -> None:
     assert "NEXT_ACTION: DEFER_EXECUTION_INTEGRATION" in (
         run_dir / "operator_summary.md"
     ).read_text(encoding="utf-8")
+
+
+def test_build_summary_counts_completed_skipped_failed_and_dedupes_latest_rows() -> None:
+    summary = analysis.build_summary(
+        run_dir=Path("research/controlled_discovery_grid_runs/run-002"),
+        total_planned=328,
+        results=[
+            {
+                "sequence_number": 1,
+                "status": "completed",
+                "blocker_class": None,
+                "outcome_class": "near_pass",
+                "near_pass": True,
+                "promotion_candidate": False,
+                "region": "NL/EU",
+                "instrument_symbol": "ASML",
+                "behavior_preset_id": "trend_continuation_daily_v1",
+                "trades_total": 12.0,
+                "oos_trades": 4,
+            },
+            {
+                "sequence_number": 2,
+                "status": "skipped",
+                "blocker_class": "preset_not_executable",
+                "outcome_class": "skipped",
+                "near_pass": False,
+                "promotion_candidate": False,
+                "region": "US",
+                "instrument_symbol": "AAPL",
+                "behavior_preset_id": "relative_strength_vs_sector_daily_v1",
+            },
+            {
+                "sequence_number": 3,
+                "status": "failed",
+                "blocker_class": "controlled_validation_failed",
+                "outcome_class": "unknown",
+                "near_pass": False,
+                "promotion_candidate": False,
+                "region": "US",
+                "instrument_symbol": "MSFT",
+                "behavior_preset_id": "vol_compression_breakout_daily_v1",
+            },
+            {
+                "sequence_number": 3,
+                "status": "completed",
+                "blocker_class": None,
+                "outcome_class": "promotion_candidate",
+                "near_pass": False,
+                "promotion_candidate": True,
+                "region": "US",
+                "instrument_symbol": "MSFT",
+                "behavior_preset_id": "vol_compression_breakout_daily_v1",
+                "trades_total": 18.0,
+                "oos_trades": 11,
+                "criteria_status": "promotion_allowed",
+            },
+        ],
+    )
+
+    assert summary["counts"]["total_combinations_planned"] == 328
+    assert summary["counts"]["total_attempted"] == 3
+    assert summary["counts"]["total_completed"] == 2
+    assert summary["counts"]["total_skipped"] == 1
+    assert summary["counts"]["total_failed"] == 0
+    assert summary["counts"]["execution_integration_deferred"] == 0
+    assert summary["counts"]["near_pass"] == 1
+    assert summary["counts"]["promotion_candidate"] == 1
+    assert summary["next_action"] == "MERGE_AND_RUN_ON_VPS"
+    assert summary["top_promotion_candidates"][0]["instrument_symbol"] == "MSFT"

--- a/tests/unit/test_qre_controlled_discovery_grid_execution.py
+++ b/tests/unit/test_qre_controlled_discovery_grid_execution.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 from research import controlled_discovery_grid as grid
 from research import controlled_discovery_grid_execution as execution
 
@@ -124,3 +126,112 @@ def test_mapping_is_deterministic_for_same_row() -> None:
     assert first.validation_campaign_id == second.validation_campaign_id
     assert first.run_label == second.run_label
     assert first.output_subdir == second.output_subdir
+
+
+def test_execute_grid_row_returns_skipped_result_without_crash(tmp_path) -> None:
+    row = _row(
+        instrument_symbol="QQQ",
+        region="ETFs/context",
+        asset_class="etf",
+        behavior_preset_id="trend_pullback_continuation_daily_v1",
+        hypothesis_id="trend_pullback_behavior_v1",
+        timeframe="1d",
+    )
+
+    result = execution.execute_grid_row(row, output_dir=tmp_path / "combination_001")
+
+    assert result["status"] == "skipped"
+    assert result["blocker_class"] == "preset_asset_class_constraint_mismatch"
+    assert result["result_path"]
+    payload = json.loads((tmp_path / "combination_001" / "execution_result.v1.json").read_text(encoding="utf-8"))
+    assert payload["observation"]["status"] == "skipped"
+
+
+def test_execute_grid_row_marks_completed_when_runner_and_artifacts_succeed(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    row = _row(
+        instrument_symbol="AAPL",
+        region="US",
+        asset_class="equity",
+        behavior_preset_id="trend_continuation_daily_v1",
+        hypothesis_id="trend_continuation_behavior_v1",
+        timeframe="1d",
+    )
+
+    def _fake_runner(mapping: execution.GridExecutionMapping) -> None:
+        assert mapping.preset_override is not None
+
+    monkeypatch.setattr(
+        execution,
+        "_latest_artifact_snapshot",
+        lambda: {
+            "run_manifest": {"run_id": "run-001"},
+            "run_meta": {"preset_name": "qre_grid_exec"},
+            "screening_evidence": {
+                "candidates": [
+                    {
+                        "asset": "AAPL",
+                        "stage_result": "near_pass",
+                        "near_pass": {"is_near_pass": True},
+                        "promotion_guard": {"promotion_allowed": False, "blocked_by": []},
+                        "metrics": {"totaal_trades": 12},
+                        "validation_evidence": {"oos_trade_count": 5, "status": "insufficient_oos_trades"},
+                        "criteria": {"failed": [], "passed": ["sufficient_trades"]},
+                        "failure_reasons": [],
+                    }
+                ]
+            },
+            "run_candidates": {"candidates": []},
+            "run_campaign": {"status": "completed"},
+        },
+    )
+
+    result = execution.execute_grid_row(
+        row,
+        output_dir=tmp_path / "combination_002",
+        execution_runner=_fake_runner,
+    )
+
+    assert result["status"] == "completed"
+    assert result["outcome_class"] == "near_pass"
+    assert result["near_pass"] is True
+    assert result["trades_total"] == 12.0
+    assert result["oos_trades"] == 5
+
+
+def test_execute_grid_row_marks_failed_when_runner_raises(tmp_path, monkeypatch) -> None:
+    row = _row(
+        instrument_symbol="AAPL",
+        region="US",
+        asset_class="equity",
+        behavior_preset_id="trend_continuation_daily_v1",
+        hypothesis_id="trend_continuation_behavior_v1",
+        timeframe="1d",
+    )
+
+    def _boom(_mapping: execution.GridExecutionMapping) -> None:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(
+        execution,
+        "_latest_artifact_snapshot",
+        lambda: {
+            "run_manifest": {"run_id": "run-001"},
+            "run_meta": {"preset_name": "qre_grid_exec"},
+            "screening_evidence": {"candidates": []},
+            "run_candidates": {"candidates": []},
+            "run_campaign": {"status": "failed"},
+        },
+    )
+
+    result = execution.execute_grid_row(
+        row,
+        output_dir=tmp_path / "combination_003",
+        execution_runner=_boom,
+    )
+
+    assert result["status"] == "failed"
+    assert result["blocker_class"] == "controlled_validation_failed"
+    assert result["error_class"] == "RuntimeError"

--- a/tests/unit/test_qre_controlled_discovery_grid_execution.py
+++ b/tests/unit/test_qre_controlled_discovery_grid_execution.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from research import controlled_discovery_grid as grid
+from research import controlled_discovery_grid_execution as execution
+
+
+def _row(**overrides: object) -> dict[str, object]:
+    row = grid.build_controlled_discovery_grid()[0]
+    row.update(overrides)
+    return row
+
+
+def test_valid_mapping_returns_ready_single_asset_override() -> None:
+    row = _row(
+        instrument_symbol="ASML",
+        region="NL/EU",
+        asset_class="equity",
+        behavior_preset_id="trend_continuation_daily_v1",
+        hypothesis_id="trend_continuation_behavior_v1",
+        timeframe="1d",
+    )
+
+    mapping = execution.map_grid_row_to_execution(row)
+
+    assert mapping.status == "ready"
+    assert mapping.blocker_class is None
+    assert mapping.strategy_or_preset_reference == "trend_equities_4h_baseline"
+    assert mapping.validation_campaign_id == (
+        "qre-grid-validation-001-asml-trend_continuation_daily_v1"
+    )
+    assert mapping.run_label == "qre_grid_seq_001_ASML_trend_continuation_daily_v1"
+    assert mapping.output_subdir == "combination_001_ASML_trend_continuation_daily_v1"
+    assert mapping.preset_override is not None
+    assert mapping.preset_override.universe == ("ASML",)
+    assert mapping.preset_override.timeframe == "1d"
+    assert mapping.safety_flags["not_alpha_claim"] is True
+    assert mapping.safety_flags["paper_activation_allowed"] is False
+    assert mapping.safety_flags["shadow_activation_allowed"] is False
+    assert mapping.safety_flags["live_activation_allowed"] is False
+
+
+def test_unsupported_behavior_family_returns_skipped_blocker() -> None:
+    row = _row(
+        instrument_symbol="ASML",
+        region="NL/EU",
+        asset_class="equity",
+        behavior_preset_id="relative_strength_vs_sector_daily_v1",
+        hypothesis_id="relative_strength_sector_behavior_v1",
+        timeframe="1d",
+    )
+
+    mapping = execution.map_grid_row_to_execution(row)
+
+    assert mapping.status == "skipped"
+    assert mapping.blocker_class == "preset_not_executable"
+    assert mapping.preset_override is None
+
+
+def test_missing_metadata_returns_missing_validation_input_blocker() -> None:
+    row = _row(hypothesis_id="")
+
+    mapping = execution.map_grid_row_to_execution(row)
+
+    assert mapping.status == "skipped"
+    assert mapping.blocker_class == "missing_validation_input"
+    assert "missing_hypothesis_id" in mapping.mapping_notes
+
+
+def test_safety_flag_violation_is_blocked_closed() -> None:
+    row = _row(paper_activation_allowed=True)
+
+    mapping = execution.map_grid_row_to_execution(row)
+
+    assert mapping.status == "skipped"
+    assert mapping.blocker_class == "blocked_by_safety"
+    assert mapping.preset_override is None
+
+
+def test_region_constraint_mismatch_is_classified_without_crash() -> None:
+    row = _row(
+        instrument_symbol="ASML",
+        region="NL/EU",
+        asset_class="equity",
+        behavior_preset_id="vol_compression_breakout_4h_v1",
+        hypothesis_id="vol_compression_expansion_behavior_v1",
+        timeframe="4h",
+    )
+
+    mapping = execution.map_grid_row_to_execution(row)
+
+    assert mapping.status == "skipped"
+    assert mapping.blocker_class == "preset_region_constraint_mismatch"
+
+
+def test_asset_class_constraint_mismatch_is_classified_without_crash() -> None:
+    row = _row(
+        instrument_symbol="SPY",
+        region="ETFs/context",
+        asset_class="etf",
+        behavior_preset_id="trend_pullback_continuation_daily_v1",
+        hypothesis_id="trend_pullback_behavior_v1",
+        timeframe="1d",
+    )
+
+    mapping = execution.map_grid_row_to_execution(row)
+
+    assert mapping.status == "skipped"
+    assert mapping.blocker_class == "preset_asset_class_constraint_mismatch"
+
+
+def test_mapping_is_deterministic_for_same_row() -> None:
+    row = _row(
+        instrument_symbol="AAPL",
+        region="US",
+        asset_class="equity",
+        behavior_preset_id="vol_compression_breakout_daily_v1",
+        hypothesis_id="vol_compression_expansion_behavior_v1",
+        timeframe="1d",
+    )
+
+    first = execution.map_grid_row_to_execution(dict(row))
+    second = execution.map_grid_row_to_execution(dict(row))
+
+    assert first.validation_campaign_id == second.validation_campaign_id
+    assert first.run_label == second.run_label
+    assert first.output_subdir == second.output_subdir

--- a/tests/unit/test_qre_controlled_discovery_grid_runner.py
+++ b/tests/unit/test_qre_controlled_discovery_grid_runner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 
 from reporting import qre_controlled_discovery_grid_runner as runner
 
@@ -17,6 +18,34 @@ def test_plan_snapshot_reports_expected_328_grid() -> None:
 
 
 def test_execute_range_writes_sidecar_only_artifacts(tmp_path) -> None:
+    fake_execution = SimpleNamespace(
+        execute_grid_row=lambda item, output_dir: {
+            **item,
+            "status": "completed",
+            "outcome_class": "promotion_candidate",
+            "blocker_class": None,
+            "error_class": None,
+            "trades_total": 12.0,
+            "oos_trades": 10,
+            "hd_trades": 2.0,
+            "criteria_status": "promotion_allowed",
+            "promotion_candidate": True,
+            "near_pass": False,
+            "safe_to_promote": True,
+            "artifact_paths": {"execution_result": (output_dir / "execution_result.v1.json").as_posix()},
+            "result_path": (output_dir / "execution_result.v1.json").as_posix(),
+            "validation_campaign_id": f"cmp-{item['sequence_number']}",
+            "strategy_or_preset_reference": "trend_equities_4h_baseline",
+            "run_label": f"run-{item['sequence_number']}",
+            "output_subdir": output_dir.name,
+            "started_at_utc": "2026-06-05T12:00:00Z",
+            "finished_at_utc": "2026-06-05T12:00:01Z",
+            "duration_seconds": 1.0,
+            "execution_notes": ["stubbed"],
+        }
+    )
+    runner._execution_module = lambda: fake_execution  # type: ignore[assignment]
+
     payload = runner.execute_range(
         start=1,
         end=5,
@@ -28,7 +57,7 @@ def test_execute_range_writes_sidecar_only_artifacts(tmp_path) -> None:
     run_dir = tmp_path / "run-001"
     assert payload["selected_count"] == 5
     assert payload["written_count"] == 5
-    assert payload["execution_integration_deferred"] is True
+    assert payload["execution_integration_deferred"] is False
     assert (run_dir / "grid_plan.v1.json").exists()
     assert (run_dir / "combination_results.v1.jsonl").exists()
     assert (run_dir / "summary_latest.v1.json").exists()
@@ -41,12 +70,39 @@ def test_execute_range_writes_sidecar_only_artifacts(tmp_path) -> None:
         if line.strip()
     ]
     assert len(results) == 5
-    assert {row["status"] for row in results} == {"execution_integration_deferred"}
-    assert {row["blocker_class"] for row in results} == {"execution_integration_deferred"}
-    assert {row["outcome_class"] for row in results} == {"unknown"}
+    assert {row["status"] for row in results} == {"completed"}
+    assert {row["outcome_class"] for row in results} == {"promotion_candidate"}
 
 
 def test_execute_range_resume_skips_existing_sequence_numbers(tmp_path) -> None:
+    fake_execution = SimpleNamespace(
+        execute_grid_row=lambda item, output_dir: {
+            **item,
+            "status": "skipped" if int(item["sequence_number"]) % 2 == 0 else "completed",
+            "outcome_class": "skipped" if int(item["sequence_number"]) % 2 == 0 else "screening_pass",
+            "blocker_class": "preset_not_executable" if int(item["sequence_number"]) % 2 == 0 else None,
+            "error_class": None,
+            "trades_total": 8.0,
+            "oos_trades": 0,
+            "hd_trades": 8.0,
+            "criteria_status": None,
+            "promotion_candidate": False,
+            "near_pass": False,
+            "safe_to_promote": False,
+            "artifact_paths": {"execution_result": (output_dir / "execution_result.v1.json").as_posix()},
+            "result_path": (output_dir / "execution_result.v1.json").as_posix(),
+            "validation_campaign_id": f"cmp-{item['sequence_number']}",
+            "strategy_or_preset_reference": "trend_pullback_equities_4h",
+            "run_label": f"run-{item['sequence_number']}",
+            "output_subdir": output_dir.name,
+            "started_at_utc": "2026-06-05T12:00:00Z",
+            "finished_at_utc": "2026-06-05T12:00:01Z",
+            "duration_seconds": 1.0,
+            "execution_notes": ["stubbed"],
+        }
+    )
+    runner._execution_module = lambda: fake_execution  # type: ignore[assignment]
+
     first = runner.execute_range(
         start=1,
         end=3,
@@ -65,3 +121,45 @@ def test_execute_range_resume_skips_existing_sequence_numbers(tmp_path) -> None:
     assert first["written_count"] == 3
     assert second["selected_count"] == 5
     assert second["written_count"] == 2
+
+
+def test_execute_range_accepts_output_dir_as_run_dir_without_explicit_run_id(tmp_path) -> None:
+    fake_execution = SimpleNamespace(
+        execute_grid_row=lambda item, output_dir: {
+            **item,
+            "status": "failed",
+            "outcome_class": "unknown",
+            "blocker_class": "controlled_validation_failed",
+            "error_class": "RuntimeError",
+            "trades_total": None,
+            "oos_trades": None,
+            "hd_trades": None,
+            "criteria_status": None,
+            "promotion_candidate": False,
+            "near_pass": False,
+            "safe_to_promote": False,
+            "artifact_paths": {"execution_result": (output_dir / "execution_result.v1.json").as_posix()},
+            "result_path": (output_dir / "execution_result.v1.json").as_posix(),
+            "validation_campaign_id": f"cmp-{item['sequence_number']}",
+            "strategy_or_preset_reference": "trend_equities_4h_baseline",
+            "run_label": f"run-{item['sequence_number']}",
+            "output_subdir": output_dir.name,
+            "started_at_utc": "2026-06-05T12:00:00Z",
+            "finished_at_utc": "2026-06-05T12:00:01Z",
+            "duration_seconds": 1.0,
+            "execution_notes": ["stubbed"],
+        }
+    )
+    runner._execution_module = lambda: fake_execution  # type: ignore[assignment]
+
+    output_dir = tmp_path / "vps-grid-test"
+    payload = runner.execute_range(
+        start=1,
+        end=2,
+        output_dir=output_dir,
+        run_id=None,
+        resume=False,
+    )
+
+    assert payload["run_id"] == "vps-grid-test"
+    assert (output_dir / "grid_plan.v1.json").exists()


### PR DESCRIPTION
﻿## Summary
Integrates the controlled discovery grid runner with per-combination controlled-validation execution attempts.

## What this enables
- 328 instrument × behavior-preset combinations can be attempted steadily
- chunked VPS execution
- per-combination JSONL result rows
- resumable or duplicate-safe result handling
- operator-readable summary with completed/skipped/failed counts

## What this does not enable
- no paper runtime
- no shadow runtime
- no live runtime
- no broker/risk/execution changes
- no strategy synthesis
- no frozen contract mutation
- no alpha approval

## Validation
- targeted tests: python -m pytest tests/unit/test_qre_controlled_discovery_grid.py -q; python -m pytest tests/unit/test_qre_controlled_discovery_grid_execution.py -q; python -m pytest tests/unit/test_qre_controlled_discovery_grid_runner.py -q; python -m pytest tests/unit/test_qre_controlled_discovery_grid_analysis.py -q; python -m pytest tests -q -k "controlled_discovery_grid or grid_execution or production_discovery or discovery_catalog"
- architecture tests: python -m pytest tests/architecture -q
- git diff --check: clean
- frozen contracts: untouched (esearch/research_latest.json, esearch/strategy_matrix.csv)
- protected execution paths: untouched (no paper/shadow/live/broker/risk/execution changes)
