### PR TITLE
fix: explain discovery OOS blockers and symbol identity diagnostics

### DIFF
--- a/reporting/qre_controlled_discovery_grid_analysis.py
+++ b/reporting/qre_controlled_discovery_grid_analysis.py
@@ -156,16 +156,31 @@ def _artifact_status(row: dict[str, Any]) -> str:
 
 def _source_identity_blocker(row: dict[str, Any]) -> str | None:
     blocker_class = str(row.get("source_identity_blocker_class") or "").strip()
-    if blocker_class:
-        return blocker_class
     source_identity_status = str(row.get("source_identity_status") or "").strip()
     provider_symbol_status = str(row.get("provider_symbol_status") or "").strip()
+    lookup_failure_fields = {
+        "missing_data",
+        "data_coverage_blocker",
+        "degenerate_no_survivors",
+        "no_oos_evidence",
+    }
+    row_blocker_class = str(row.get("blocker_class") or "").strip()
     if source_identity_status == "missing_provider_symbol":
         return "source_identity_missing_provider_symbol"
+    if provider_symbol_status == "provider_lookup_failed" or source_identity_status == "provider_lookup_failed":
+        return "source_identity_provider_lookup_failed"
+    if (
+        blocker_class == "source_identity_provider_lookup_failed"
+        or (
+            row_blocker_class in lookup_failure_fields
+            and provider_symbol_status == "candidate_alias_requires_verification"
+        )
+    ):
+        return "source_identity_provider_lookup_failed"
     if provider_symbol_status == "candidate_alias_requires_verification":
         return "source_identity_candidate_alias_unverified"
-    if provider_symbol_status == "provider_lookup_failed":
-        return "source_identity_provider_lookup_failed"
+    if blocker_class:
+        return blocker_class
     return None
 
 
@@ -286,6 +301,45 @@ def _top_oos_follow_up_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return top_rows
 
 
+def _source_identity_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    latest_by_instrument: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        symbol = str(row.get("instrument_symbol") or "")
+        if not symbol:
+            continue
+        latest_by_instrument[symbol] = row
+    selected = sorted(
+        latest_by_instrument.values(),
+        key=lambda row: (
+            0
+            if row.get("source_identity_blocker_class")
+            in {
+                "source_identity_missing_provider_symbol",
+                "source_identity_candidate_alias_unverified",
+                "source_identity_provider_lookup_failed",
+            }
+            else 1,
+            str(row.get("region") or ""),
+            str(row.get("instrument_symbol") or ""),
+        ),
+    )
+    return [
+        {
+            "instrument_symbol": str(row.get("instrument_symbol") or ""),
+            "region": str(row.get("region") or ""),
+            "canonical_symbol": str(row.get("instrument_symbol") or ""),
+            "provider_symbol": row.get("primary_data_provider_symbol"),
+            "status": str(row.get("source_identity_status") or ""),
+            "candidate_aliases": list(row.get("provider_symbol_aliases") or []),
+            "blocker": str(
+                row.get("source_identity_blocker_class")
+                or "source_identity_provider_symbol_verified"
+            ),
+        }
+        for row in selected
+    ]
+
+
 def build_summary(
     *,
     run_dir: Path,
@@ -393,6 +447,7 @@ def build_summary(
             if row.get("oos_evidence_blocker_class")
         ],
         "top_oos_follow_up_diagnostics": _top_oos_follow_up_rows(diagnostic_rows),
+        "source_identity_diagnostics": _source_identity_rows(diagnostic_rows),
         "next_action": "DEFER_EXECUTION_INTEGRATION"
         if deferred_count
         else "MERGE_AND_RUN_ON_VPS",
@@ -530,6 +585,32 @@ def render_operator_summary(summary: dict[str, Any]) -> str:
             for row in follow_up_rows
         ],
     )
+    source_identity_rows = summary["source_identity_diagnostics"] or [
+        {
+            "instrument_symbol": "-",
+            "region": "-",
+            "canonical_symbol": "-",
+            "provider_symbol": "-",
+            "status": "-",
+            "candidate_aliases": [],
+            "blocker": "-",
+        }
+    ]
+    source_identity_table = _table(
+        ["Instrument", "Region", "Canonical symbol", "Provider symbol", "Status", "Candidate aliases", "Blocker"],
+        [
+            [
+                str(row["instrument_symbol"]),
+                str(row["region"]),
+                str(row["canonical_symbol"]),
+                str(row["provider_symbol"]),
+                str(row["status"]),
+                ", ".join(str(value) for value in row["candidate_aliases"]) or "-",
+                str(row["blocker"]),
+            ]
+            for row in source_identity_rows
+        ],
+    )
     return "\n".join(
         [
             "# QRE Controlled Discovery Grid Operator Summary",
@@ -554,7 +635,10 @@ def render_operator_summary(summary: dict[str, Any]) -> str:
             "## 6. Top OOS follow-up diagnostics",
             follow_up_table,
             "",
-            "## 7. Next action",
+            "## 7. Source identity diagnostics",
+            source_identity_table,
+            "",
+            "## 8. Next action",
             f"- NEXT_ACTION: {summary['next_action']}",
         ]
     )

--- a/reporting/qre_controlled_discovery_grid_analysis.py
+++ b/reporting/qre_controlled_discovery_grid_analysis.py
@@ -10,6 +10,8 @@ from typing import Any
 SUMMARY_FILENAME = "summary_latest.v1.json"
 OPERATOR_SUMMARY_FILENAME = "operator_summary.md"
 RESULTS_FILENAME = "combination_results.v1.jsonl"
+OOS_EVIDENCE_OUTCOME = "sufficient_oos_evidence"
+UNKNOWN_REQUIRES_ARTIFACT_INSPECTION = "unknown_requires_artifact_inspection"
 
 
 def _table(headers: list[str], rows: list[list[str]]) -> str:
@@ -81,6 +83,209 @@ def _top_rows(
     ]
 
 
+def _coerce_number(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _criteria_failure_classes(criteria_status: Any) -> list[str]:
+    if criteria_status is None:
+        return []
+    classes: list[str] = []
+    for token in str(criteria_status).split(","):
+        item = token.strip()
+        if not item:
+            continue
+        if item in {"promotion_allowed", "criteria_passed"}:
+            continue
+        classes.append(item)
+    return classes
+
+
+def _metric_consistency_diagnostics(row: dict[str, Any]) -> dict[str, Any]:
+    trades_total = _coerce_number(row.get("trades_total"))
+    oos_trades = _coerce_number(row.get("oos_trades"))
+    hd_trades = _coerce_number(row.get("hd_trades"))
+    warnings: list[str] = []
+    status = "consistent"
+    consistency = "consistent"
+    if trades_total is None and (oos_trades is not None or hd_trades is not None):
+        warnings.append("missing_total_trade_metric")
+        status = "inconsistent"
+        consistency = "missing_total_trade_metric"
+    elif (
+        trades_total is not None
+        and oos_trades is not None
+        and hd_trades is not None
+        and (oos_trades + hd_trades) > trades_total + 0.5
+    ):
+        warnings.append("oos_hd_exceeds_trades_total")
+        status = "inconsistent"
+        consistency = "oos_hd_exceeds_trades_total"
+    elif trades_total is not None and oos_trades is not None and oos_trades > trades_total + 0.5:
+        warnings.append("oos_trades_exceeds_trades_total")
+        status = "inconsistent"
+        consistency = "oos_trades_exceeds_trades_total"
+    elif trades_total is not None and hd_trades is not None and hd_trades > trades_total + 0.5:
+        warnings.append("hd_trades_exceeds_trades_total")
+        status = "inconsistent"
+        consistency = "hd_trades_exceeds_trades_total"
+
+    return {
+        "trades_total": trades_total,
+        "oos_trades": oos_trades,
+        "hd_trades": hd_trades,
+        "trades_total_vs_oos_hd_consistency": consistency,
+        "metric_consistency_status": status,
+        "metric_consistency_warnings": warnings,
+    }
+
+
+def _artifact_status(row: dict[str, Any]) -> str:
+    artifact_paths = row.get("artifact_paths")
+    has_artifact_paths = isinstance(artifact_paths, dict) and bool(artifact_paths)
+    has_result_path = bool(str(row.get("result_path") or "").strip())
+    if has_artifact_paths or has_result_path:
+        return "artifacts_present"
+    return "missing_artifacts"
+
+
+def _source_identity_blocker(row: dict[str, Any]) -> str | None:
+    blocker_class = str(row.get("source_identity_blocker_class") or "").strip()
+    if blocker_class:
+        return blocker_class
+    source_identity_status = str(row.get("source_identity_status") or "").strip()
+    provider_symbol_status = str(row.get("provider_symbol_status") or "").strip()
+    if source_identity_status == "missing_provider_symbol":
+        return "source_identity_missing_provider_symbol"
+    if provider_symbol_status == "candidate_alias_requires_verification":
+        return "source_identity_candidate_alias_unverified"
+    if provider_symbol_status == "provider_lookup_failed":
+        return "source_identity_provider_lookup_failed"
+    return None
+
+
+def _derive_row_diagnostics(row: dict[str, Any]) -> dict[str, Any]:
+    diagnostic = dict(row)
+    metric = _metric_consistency_diagnostics(row)
+    diagnostic.update(metric)
+    diagnostic["criteria_failure_classes"] = _criteria_failure_classes(
+        row.get("criteria_status")
+    )
+    diagnostic["artifact_status"] = _artifact_status(row)
+    diagnostic["source_identity_blocker_class"] = _source_identity_blocker(row)
+
+    blocker_class = str(row.get("blocker_class") or "").strip()
+    outcome_class = str(row.get("outcome_class") or "unknown").strip() or "unknown"
+    promotion_candidate = bool(row.get("promotion_candidate"))
+    oos_blocker = None
+    if outcome_class == OOS_EVIDENCE_OUTCOME and not promotion_candidate:
+        if metric["metric_consistency_status"] != "consistent":
+            oos_blocker = "oos_evidence_metric_inconsistent"
+        elif blocker_class == "degenerate_no_survivors":
+            oos_blocker = "oos_evidence_degenerate_no_survivors"
+        elif diagnostic["artifact_status"] == "missing_artifacts":
+            oos_blocker = "oos_evidence_missing_artifacts"
+        elif diagnostic["criteria_failure_classes"]:
+            oos_blocker = "oos_evidence_no_promotion_due_to_criteria"
+        elif blocker_class:
+            oos_blocker = "oos_evidence_quality_failed"
+        else:
+            oos_blocker = "oos_evidence_unknown_reason"
+    diagnostic["oos_evidence_blocker_class"] = oos_blocker
+    diagnostic["primary_blocker"] = (
+        oos_blocker
+        or blocker_class
+        or diagnostic["source_identity_blocker_class"]
+        or UNKNOWN_REQUIRES_ARTIFACT_INSPECTION
+    )
+    diagnostic["follow_up"] = (
+        "inspect_metric_consistency"
+        if oos_blocker == "oos_evidence_metric_inconsistent"
+        else "review_criteria_failures"
+        if oos_blocker == "oos_evidence_no_promotion_due_to_criteria"
+        else "inspect_missing_artifacts"
+        if oos_blocker == "oos_evidence_missing_artifacts"
+        else "resolve_source_identity"
+        if diagnostic["source_identity_blocker_class"]
+        else UNKNOWN_REQUIRES_ARTIFACT_INSPECTION
+        if outcome_class == "unknown"
+        else "bounded_follow_up"
+    )
+
+    derived_outcome_class = outcome_class
+    if outcome_class == "unknown":
+        if str(row.get("status") or "") == "execution_integration_deferred":
+            derived_outcome_class = "unknown"
+        elif diagnostic["source_identity_blocker_class"]:
+            derived_outcome_class = diagnostic["source_identity_blocker_class"]
+        elif blocker_class and blocker_class not in {
+            "execution_integration_deferred",
+            "controlled_validation_failed",
+            "unknown_execution_error",
+        }:
+            derived_outcome_class = blocker_class
+        else:
+            derived_outcome_class = UNKNOWN_REQUIRES_ARTIFACT_INSPECTION
+    diagnostic["derived_outcome_class"] = derived_outcome_class
+    diagnostic["safe_to_promote"] = False if outcome_class == OOS_EVIDENCE_OUTCOME else bool(
+        row.get("safe_to_promote")
+    )
+    diagnostic["near_pass"] = False if outcome_class == OOS_EVIDENCE_OUTCOME else bool(
+        row.get("near_pass")
+    )
+    diagnostic["promotion_candidate"] = False if outcome_class == OOS_EVIDENCE_OUTCOME else promotion_candidate
+    return diagnostic
+
+
+def _diagnostic_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [_derive_row_diagnostics(row) for row in rows]
+
+
+def _top_oos_follow_up_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    selected = [
+        row
+        for row in rows
+        if str(row.get("outcome_class") or "") == OOS_EVIDENCE_OUTCOME
+        and not bool(row.get("promotion_candidate"))
+    ]
+    selected.sort(
+        key=lambda row: (
+            0 if row.get("metric_consistency_status") == "consistent" else 1,
+            len(row.get("criteria_failure_classes") or []),
+            1 if row.get("source_identity_blocker_class") else 0,
+            -(row.get("trades_total") or 0.0),
+            -(row.get("oos_trades") or 0.0),
+            int(row.get("sequence_number") or 0),
+        )
+    )
+    top_rows: list[dict[str, Any]] = []
+    for row in selected[:10]:
+        top_rows.append(
+            {
+                "sequence_number": int(row.get("sequence_number") or 0),
+                "instrument_symbol": str(row.get("instrument_symbol") or ""),
+                "behavior_preset_id": str(row.get("behavior_preset_id") or ""),
+                "promotion_candidate": False,
+                "near_pass": False,
+                "safe_to_promote": False,
+                "primary_blocker": row.get("primary_blocker"),
+                "criteria_failure_classes": row.get("criteria_failure_classes"),
+                "metric_consistency_status": row.get("metric_consistency_status"),
+                "follow_up": row.get("follow_up"),
+                "trades_total": row.get("trades_total"),
+                "oos_trades": row.get("oos_trades"),
+                "hd_trades": row.get("hd_trades"),
+                "source_identity_blocker_class": row.get("source_identity_blocker_class"),
+            }
+        )
+    return top_rows
+
+
 def build_summary(
     *,
     run_dir: Path,
@@ -88,22 +293,26 @@ def build_summary(
     total_planned: int | None = None,
 ) -> dict[str, Any]:
     latest_results = _latest_result_rows(results)
+    diagnostic_rows = _diagnostic_rows(latest_results)
     blocker_counter = Counter(
-        str(row.get("blocker_class") or "unknown") for row in latest_results
+        str(row.get("blocker_class") or "unknown") for row in diagnostic_rows
     )
     outcome_counter = Counter(
-        str(row.get("outcome_class") or "unknown") for row in latest_results
+        str(row.get("derived_outcome_class") or "unknown") for row in diagnostic_rows
     )
-    status_counter = Counter(str(row.get("status") or "unknown") for row in latest_results)
+    status_counter = Counter(str(row.get("status") or "unknown") for row in diagnostic_rows)
+    oos_blocker_counter = Counter(
+        str(row.get("oos_evidence_blocker_class") or "none") for row in diagnostic_rows
+    )
 
     deferred_count = status_counter.get("execution_integration_deferred", 0)
     summary = {
         "report_kind": "qre_controlled_discovery_grid_analysis",
         "run_dir": run_dir.as_posix(),
-        "result_count": len(latest_results),
+        "result_count": len(diagnostic_rows),
         "counts": {
-            "total_combinations_planned": int(total_planned or len(latest_results)),
-            "total_attempted": len(latest_results),
+            "total_combinations_planned": int(total_planned or len(diagnostic_rows)),
+            "total_attempted": len(diagnostic_rows),
             "total_completed": status_counter.get("completed", 0),
             "total_skipped": status_counter.get("skipped", 0)
             + status_counter.get("skipped_invalid_metadata", 0)
@@ -120,24 +329,70 @@ def build_summary(
                 "criteria_consistentie_failed", 0
             ),
             "data_coverage_blocker": blocker_counter.get("data_coverage_blocker", 0),
+            "sufficient_oos_evidence": sum(
+                1
+                for row in diagnostic_rows
+                if str(row.get("outcome_class") or "") == OOS_EVIDENCE_OUTCOME
+            ),
+            "oos_evidence_quality_failed": oos_blocker_counter.get(
+                "oos_evidence_quality_failed", 0
+            ),
+            "oos_evidence_metric_inconsistent": oos_blocker_counter.get(
+                "oos_evidence_metric_inconsistent", 0
+            ),
+            "oos_evidence_no_promotion_due_to_criteria": oos_blocker_counter.get(
+                "oos_evidence_no_promotion_due_to_criteria", 0
+            ),
+            "oos_evidence_degenerate_no_survivors": oos_blocker_counter.get(
+                "oos_evidence_degenerate_no_survivors", 0
+            ),
+            "oos_evidence_missing_artifacts": oos_blocker_counter.get(
+                "oos_evidence_missing_artifacts", 0
+            ),
+            "oos_evidence_unknown_reason": oos_blocker_counter.get(
+                "oos_evidence_unknown_reason", 0
+            ),
             "near_pass": outcome_counter.get("near_pass", 0),
             "promotion_candidate": outcome_counter.get("promotion_candidate", 0),
             "unknown": outcome_counter.get("unknown", 0),
             "total_unknown": outcome_counter.get("unknown", 0),
         },
-        "by_region": _group_counts(latest_results, "region"),
-        "by_asset": _group_counts(latest_results, "instrument_symbol"),
-        "by_behavior_preset": _group_counts(latest_results, "behavior_preset_id"),
-        "by_outcome_class": _group_counts(latest_results, "outcome_class"),
-        "by_blocker_class": _group_counts(latest_results, "blocker_class"),
+        "by_region": _group_counts(diagnostic_rows, "region"),
+        "by_asset": _group_counts(diagnostic_rows, "instrument_symbol"),
+        "by_behavior_preset": _group_counts(diagnostic_rows, "behavior_preset_id"),
+        "by_outcome_class": _group_counts(diagnostic_rows, "derived_outcome_class"),
+        "by_blocker_class": _group_counts(diagnostic_rows, "blocker_class"),
+        "by_oos_evidence_blocker_class": _group_counts(
+            [row for row in diagnostic_rows if row.get("oos_evidence_blocker_class")],
+            "oos_evidence_blocker_class",
+        ),
         "top_near_pass": _top_rows(
-            latest_results,
+            diagnostic_rows,
             predicate=lambda row: bool(row.get("near_pass")),
         ),
         "top_promotion_candidates": _top_rows(
-            latest_results,
+            diagnostic_rows,
             predicate=lambda row: bool(row.get("promotion_candidate")),
         ),
+        "sufficient_oos_evidence_blockers": [
+            {
+                "sequence_number": int(row.get("sequence_number") or 0),
+                "instrument_symbol": str(row.get("instrument_symbol") or ""),
+                "behavior_preset_id": str(row.get("behavior_preset_id") or ""),
+                "oos_trades": row.get("oos_trades"),
+                "hd_trades": row.get("hd_trades"),
+                "trades_total": row.get("trades_total"),
+                "promotion_candidate": False,
+                "primary_blocker": row.get("primary_blocker"),
+                "criteria_failure_classes": row.get("criteria_failure_classes"),
+                "metric_consistency_status": row.get("metric_consistency_status"),
+                "metric_consistency_warnings": row.get("metric_consistency_warnings"),
+                "follow_up": row.get("follow_up"),
+            }
+            for row in diagnostic_rows
+            if row.get("oos_evidence_blocker_class")
+        ],
+        "top_oos_follow_up_diagnostics": _top_oos_follow_up_rows(diagnostic_rows),
         "next_action": "DEFER_EXECUTION_INTEGRATION"
         if deferred_count
         else "MERGE_AND_RUN_ON_VPS",
@@ -165,6 +420,31 @@ def render_operator_summary(summary: dict[str, Any]) -> str:
             ],
             ["criteria consistentie failed", str(counts["criteria_consistentie_failed"])],
             ["data coverage blocker", str(counts["data_coverage_blocker"])],
+            ["sufficient OOS evidence", str(counts["sufficient_oos_evidence"])],
+            [
+                "OOS blocker: quality failed",
+                str(counts["oos_evidence_quality_failed"]),
+            ],
+            [
+                "OOS blocker: metric inconsistent",
+                str(counts["oos_evidence_metric_inconsistent"]),
+            ],
+            [
+                "OOS blocker: no promotion due to criteria",
+                str(counts["oos_evidence_no_promotion_due_to_criteria"]),
+            ],
+            [
+                "OOS blocker: degenerate no survivors",
+                str(counts["oos_evidence_degenerate_no_survivors"]),
+            ],
+            [
+                "OOS blocker: missing artifacts",
+                str(counts["oos_evidence_missing_artifacts"]),
+            ],
+            [
+                "OOS blocker: unknown reason",
+                str(counts["oos_evidence_unknown_reason"]),
+            ],
             ["near pass", str(counts["near_pass"])],
             ["promotion candidate", str(counts["promotion_candidate"])],
             ["unknown", str(counts["unknown"])],
@@ -177,6 +457,78 @@ def render_operator_summary(summary: dict[str, Any]) -> str:
     preset_table = _table(
         ["Behavior preset", "Count"],
         [[row["value"], str(row["count"])] for row in summary["by_behavior_preset"]],
+    )
+    oos_rows = summary["sufficient_oos_evidence_blockers"] or [
+        {
+            "sequence_number": "-",
+            "instrument_symbol": "-",
+            "behavior_preset_id": "-",
+            "oos_trades": "-",
+            "hd_trades": "-",
+            "trades_total": "-",
+            "promotion_candidate": False,
+            "primary_blocker": "-",
+            "criteria_failure_classes": [],
+            "metric_consistency_status": "-",
+            "follow_up": "-",
+        }
+    ]
+    oos_table = _table(
+        [
+            "Sequence",
+            "Instrument",
+            "Preset",
+            "OOS trades",
+            "HD trades",
+            "Trades total",
+            "Promotion",
+            "Primary blocker",
+            "Criteria failures",
+            "Metric consistency",
+            "Follow-up",
+        ],
+        [
+            [
+                str(row["sequence_number"]),
+                str(row["instrument_symbol"]),
+                str(row["behavior_preset_id"]),
+                str(row["oos_trades"]),
+                str(row["hd_trades"]),
+                str(row["trades_total"]),
+                "false",
+                str(row["primary_blocker"]),
+                ", ".join(row["criteria_failure_classes"]) or "-",
+                str(row["metric_consistency_status"]),
+                str(row["follow_up"]),
+            ]
+            for row in oos_rows
+        ],
+    )
+    follow_up_rows = summary["top_oos_follow_up_diagnostics"] or [
+        {
+            "sequence_number": "-",
+            "instrument_symbol": "-",
+            "behavior_preset_id": "-",
+            "primary_blocker": "-",
+            "criteria_failure_classes": [],
+            "metric_consistency_status": "-",
+            "follow_up": "-",
+        }
+    ]
+    follow_up_table = _table(
+        ["Sequence", "Instrument", "Preset", "Primary blocker", "Criteria failures", "Metric consistency", "Follow-up"],
+        [
+            [
+                str(row["sequence_number"]),
+                str(row["instrument_symbol"]),
+                str(row["behavior_preset_id"]),
+                str(row["primary_blocker"]),
+                ", ".join(row["criteria_failure_classes"]) or "-",
+                str(row["metric_consistency_status"]),
+                str(row["follow_up"]),
+            ]
+            for row in follow_up_rows
+        ],
     )
     return "\n".join(
         [
@@ -196,7 +548,13 @@ def render_operator_summary(summary: dict[str, Any]) -> str:
             "## 4. Behavior preset coverage",
             preset_table,
             "",
-            "## 5. Next action",
+            "## 5. Sufficient OOS evidence blocker explanation",
+            oos_table,
+            "",
+            "## 6. Top OOS follow-up diagnostics",
+            follow_up_table,
+            "",
+            "## 7. Next action",
             f"- NEXT_ACTION: {summary['next_action']}",
         ]
     )

--- a/research/controlled_discovery_grid.py
+++ b/research/controlled_discovery_grid.py
@@ -50,6 +50,12 @@ class GridCombination:
     canonical_instrument_id: str
     region: str
     asset_class: str
+    primary_data_provider_symbol: str | None
+    provider_symbol_aliases: tuple[str, ...]
+    provider_symbol_status: str
+    source_identity_status: str
+    source_identity_notes: str
+    source_identity_blocker_class: str
     behavior_preset_id: str
     hypothesis_id: str
     timeframe: str
@@ -73,6 +79,12 @@ class GridCombination:
             "canonical_instrument_id": self.canonical_instrument_id,
             "region": self.region,
             "asset_class": self.asset_class,
+            "primary_data_provider_symbol": self.primary_data_provider_symbol,
+            "provider_symbol_aliases": list(self.provider_symbol_aliases),
+            "provider_symbol_status": self.provider_symbol_status,
+            "source_identity_status": self.source_identity_status,
+            "source_identity_notes": self.source_identity_notes,
+            "source_identity_blocker_class": self.source_identity_blocker_class,
             "behavior_preset_id": self.behavior_preset_id,
             "hypothesis_id": self.hypothesis_id,
             "timeframe": self.timeframe,
@@ -169,8 +181,12 @@ def list_enabled_presets() -> list[dict[str, Any]]:
 
 def build_controlled_discovery_grid() -> list[dict[str, Any]]:
     combinations: list[dict[str, Any]] = []
+    source_identity_by_symbol = {
+        str(row["instrument_symbol"]): row for row in catalog.source_identity_diagnostics()
+    }
     sequence_number = 1
     for asset_payload in list_enabled_assets():
+        source_identity = source_identity_by_symbol.get(str(asset_payload["symbol"]), {})
         for preset_payload in list_enabled_presets():
             status, warnings = _combination_status(asset_payload, preset_payload)
             combination = GridCombination(
@@ -185,6 +201,17 @@ def build_controlled_discovery_grid() -> list[dict[str, Any]]:
                 canonical_instrument_id=str(asset_payload["canonical_instrument_id"]),
                 region=str(asset_payload["region"]),
                 asset_class=str(asset_payload["asset_class"]),
+                primary_data_provider_symbol=asset_payload.get("primary_data_provider_symbol"),
+                provider_symbol_aliases=tuple(
+                    str(value) for value in (asset_payload.get("provider_symbol_aliases") or [])
+                ),
+                provider_symbol_status=str(asset_payload.get("provider_symbol_status") or "unknown"),
+                source_identity_status=str(asset_payload.get("source_identity_status") or "unknown"),
+                source_identity_notes=str(asset_payload.get("source_identity_notes") or ""),
+                source_identity_blocker_class=str(
+                    source_identity.get("source_identity_blocker_class")
+                    or "source_identity_missing_provider_symbol"
+                ),
                 behavior_preset_id=str(preset_payload["preset_id"]),
                 hypothesis_id=str(preset_payload["hypothesis_id"]),
                 timeframe=_timeframe_for_preset(preset_payload),

--- a/research/production_discovery_catalog.py
+++ b/research/production_discovery_catalog.py
@@ -36,6 +36,11 @@ class DiscoveryAsset:
     liquidity_tier: str
     data_source: str
     source_quality_status: str
+    primary_data_provider_symbol: str | None
+    provider_symbol_aliases: tuple[str, ...]
+    provider_symbol_status: str
+    source_identity_status: str
+    source_identity_notes: str
     enabled_for_discovery: bool
     enabled_for_validation: bool
     not_alpha_claim: bool
@@ -59,6 +64,11 @@ class DiscoveryAsset:
             "liquidity_tier": self.liquidity_tier,
             "data_source": self.data_source,
             "source_quality_status": self.source_quality_status,
+            "primary_data_provider_symbol": self.primary_data_provider_symbol,
+            "provider_symbol_aliases": list(self.provider_symbol_aliases),
+            "provider_symbol_status": self.provider_symbol_status,
+            "source_identity_status": self.source_identity_status,
+            "source_identity_notes": self.source_identity_notes,
             "enabled_for_discovery": self.enabled_for_discovery,
             "enabled_for_validation": self.enabled_for_validation,
             "not_alpha_claim": self.not_alpha_claim,
@@ -126,6 +136,11 @@ def _asset(
     liquidity_tier: str = "high",
     data_source: str = "existing_data_boundary",
     source_quality_status: str = "reviewed_seed_only",
+    primary_data_provider_symbol: str | None = "",
+    provider_symbol_aliases: tuple[str, ...] = (),
+    provider_symbol_status: str = "verified",
+    source_identity_status: str = "provider_symbol_verified",
+    source_identity_notes: str = "",
 ) -> DiscoveryAsset:
     return DiscoveryAsset(
         symbol=symbol,
@@ -141,6 +156,13 @@ def _asset(
         liquidity_tier=liquidity_tier,
         data_source=data_source,
         source_quality_status=source_quality_status,
+        primary_data_provider_symbol=symbol
+        if primary_data_provider_symbol == ""
+        else primary_data_provider_symbol,
+        provider_symbol_aliases=provider_symbol_aliases,
+        provider_symbol_status=provider_symbol_status,
+        source_identity_status=source_identity_status,
+        source_identity_notes=source_identity_notes or notes,
         enabled_for_discovery=True,
         enabled_for_validation=True,
         not_alpha_claim=True,
@@ -153,20 +175,20 @@ def _asset(
 
 _ASSETS: Final[tuple[DiscoveryAsset, ...]] = (
     _asset("ASML", display_name="ASML Holding", region="NL/EU", country="Netherlands", exchange="NASDAQ", currency="USD", sector="Technology", industry="Semiconductor Equipment", notes="Dutch large-cap semiconductor equipment anchor."),
-    _asset("ASMI", display_name="ASM International", region="NL/EU", country="Netherlands", exchange="EURONEXT", currency="EUR", sector="Technology", industry="Semiconductor Equipment", notes="Dutch semiconductor equipment exposure."),
-    _asset("BESI", display_name="BE Semiconductor", region="NL/EU", country="Netherlands", exchange="EURONEXT", currency="EUR", sector="Technology", industry="Semiconductor Equipment", notes="Dutch semiconductor packaging exposure."),
-    _asset("ADYEN", display_name="Adyen", region="NL/EU", country="Netherlands", exchange="EURONEXT", currency="EUR", sector="Financial Technology", industry="Payments", notes="Dutch fintech large-cap seed."),
+    _asset("ASMI", display_name="ASM International", region="NL/EU", country="Netherlands", exchange="EURONEXT", currency="EUR", sector="Technology", industry="Semiconductor Equipment", notes="Dutch semiconductor equipment exposure.", primary_data_provider_symbol=None, provider_symbol_aliases=("ASM.AS", "ASMI.AS"), provider_symbol_status="candidate_alias_requires_verification", source_identity_status="candidate_alias_only", source_identity_notes="Canonical display symbol is retained; Yahoo-style provider aliases require verification before data-backed use."),
+    _asset("BESI", display_name="BE Semiconductor", region="NL/EU", country="Netherlands", exchange="EURONEXT", currency="EUR", sector="Technology", industry="Semiconductor Equipment", notes="Dutch semiconductor packaging exposure.", primary_data_provider_symbol=None, provider_symbol_aliases=("BESI.AS",), provider_symbol_status="candidate_alias_requires_verification", source_identity_status="candidate_alias_only", source_identity_notes="Provider alias is high-confidence but not statically verified in-repo."),
+    _asset("ADYEN", display_name="Adyen", region="NL/EU", country="Netherlands", exchange="EURONEXT", currency="EUR", sector="Financial Technology", industry="Payments", notes="Dutch fintech large-cap seed.", primary_data_provider_symbol=None, provider_symbol_aliases=("ADYEN.AS",), provider_symbol_status="candidate_alias_requires_verification", source_identity_status="candidate_alias_only", source_identity_notes="Euronext Amsterdam suffix likely required by the active provider."),
     _asset("ING", display_name="ING Group", region="NL/EU", country="Netherlands", exchange="NYSE", currency="USD", sector="Financials", industry="Banking", notes="Banking regime anchor for Europe."),
-    _asset("SHELL", display_name="Shell", region="NL/EU", country="United Kingdom", exchange="NYSE", currency="USD", sector="Energy", industry="Integrated Oil & Gas", notes="Europe energy supermajor proxy."),
-    _asset("PRX", display_name="Prosus", region="NL/EU", country="Netherlands", exchange="EURONEXT", currency="EUR", sector="Communication Services", industry="Internet Holdings", notes="Dutch internet holding exposure."),
+    _asset("SHELL", display_name="Shell", region="NL/EU", country="United Kingdom", exchange="NYSE", currency="USD", sector="Energy", industry="Integrated Oil & Gas", notes="Europe energy supermajor proxy.", primary_data_provider_symbol="SHEL", provider_symbol_aliases=("SHEL.AS", "SHEL.L"), provider_symbol_status="verified", source_identity_status="provider_symbol_verified", source_identity_notes="Canonical display symbol differs from the active provider's primary NYSE symbol."),
+    _asset("PRX", display_name="Prosus", region="NL/EU", country="Netherlands", exchange="EURONEXT", currency="EUR", sector="Communication Services", industry="Internet Holdings", notes="Dutch internet holding exposure.", primary_data_provider_symbol=None, provider_symbol_aliases=("PRX.AS",), provider_symbol_status="candidate_alias_requires_verification", source_identity_status="candidate_alias_only", source_identity_notes="Provider likely requires Amsterdam exchange suffix."),
     _asset("SAP", display_name="SAP", region="NL/EU", country="Germany", exchange="NYSE", currency="USD", sector="Technology", industry="Enterprise Software", notes="Europe software leadership seed."),
-    _asset("SIE", display_name="Siemens", region="NL/EU", country="Germany", exchange="XETRA", currency="EUR", sector="Industrials", industry="Industrial Conglomerates", notes="Europe industrial trend seed."),
-    _asset("LVMH", display_name="LVMH", region="NL/EU", country="France", exchange="EURONEXT", currency="EUR", sector="Consumer Discretionary", industry="Luxury Goods", notes="Europe consumer leadership seed."),
-    _asset("NOVO-B", display_name="Novo Nordisk", region="NL/EU", country="Denmark", exchange="NYSE", currency="USD", sector="Health Care", industry="Pharmaceuticals", notes="Europe health-care leadership seed."),
-    _asset("AIR", display_name="Airbus", region="NL/EU", country="France", exchange="EURONEXT", currency="EUR", sector="Industrials", industry="Aerospace & Defense", notes="Europe aerospace cycle seed."),
-    _asset("TTE", display_name="TotalEnergies", region="NL/EU", country="France", exchange="NYSE", currency="USD", sector="Energy", industry="Integrated Oil & Gas", notes="Europe energy trend seed."),
-    _asset("IFX", display_name="Infineon", region="NL/EU", country="Germany", exchange="XETRA", currency="EUR", sector="Technology", industry="Semiconductors", notes="Europe semiconductor cycle seed."),
-    _asset("NESN", display_name="Nestle", region="NL/EU", country="Switzerland", exchange="SIX", currency="CHF", sector="Consumer Staples", industry="Packaged Foods", notes="Defensive Europe large-cap seed."),
+    _asset("SIE", display_name="Siemens", region="NL/EU", country="Germany", exchange="XETRA", currency="EUR", sector="Industrials", industry="Industrial Conglomerates", notes="Europe industrial trend seed.", primary_data_provider_symbol=None, provider_symbol_aliases=("SIE.DE",), provider_symbol_status="candidate_alias_requires_verification", source_identity_status="candidate_alias_only", source_identity_notes="German Xetra listing likely needs .DE provider suffix."),
+    _asset("LVMH", display_name="LVMH", region="NL/EU", country="France", exchange="EURONEXT", currency="EUR", sector="Consumer Discretionary", industry="Luxury Goods", notes="Europe consumer leadership seed.", primary_data_provider_symbol=None, provider_symbol_aliases=("MC.PA", "LVMH.PA"), provider_symbol_status="candidate_alias_requires_verification", source_identity_status="candidate_alias_only", source_identity_notes="Yahoo-style Paris symbol is commonly MC.PA; preserve canonical display symbol until verified."),
+    _asset("NOVO-B", display_name="Novo Nordisk", region="NL/EU", country="Denmark", exchange="NYSE", currency="USD", sector="Health Care", industry="Pharmaceuticals", notes="Europe health-care leadership seed.", primary_data_provider_symbol=None, provider_symbol_aliases=("NVO", "NOVO-B.CO"), provider_symbol_status="candidate_alias_requires_verification", source_identity_status="candidate_alias_only", source_identity_notes="Catalog display symbol may refer to Copenhagen listing while provider may require ADR or local suffix."),
+    _asset("AIR", display_name="Airbus", region="NL/EU", country="France", exchange="EURONEXT", currency="EUR", sector="Industrials", industry="Aerospace & Defense", notes="Europe aerospace cycle seed.", primary_data_provider_symbol=None, provider_symbol_aliases=("AIR.PA",), provider_symbol_status="candidate_alias_requires_verification", source_identity_status="candidate_alias_only", source_identity_notes="Paris listing likely requires .PA provider suffix."),
+    _asset("TTE", display_name="TotalEnergies", region="NL/EU", country="France", exchange="NYSE", currency="USD", sector="Energy", industry="Integrated Oil & Gas", notes="Europe energy trend seed.", primary_data_provider_symbol="TTE", provider_symbol_aliases=("TTE.PA",), provider_symbol_status="verified", source_identity_status="provider_symbol_verified", source_identity_notes="Primary provider symbol matches NYSE ADR; local Paris alias retained for diagnostics only."),
+    _asset("IFX", display_name="Infineon", region="NL/EU", country="Germany", exchange="XETRA", currency="EUR", sector="Technology", industry="Semiconductors", notes="Europe semiconductor cycle seed.", primary_data_provider_symbol=None, provider_symbol_aliases=("IFX.DE",), provider_symbol_status="candidate_alias_requires_verification", source_identity_status="candidate_alias_only", source_identity_notes="Xetra listing likely requires .DE provider suffix."),
+    _asset("NESN", display_name="Nestle", region="NL/EU", country="Switzerland", exchange="SIX", currency="CHF", sector="Consumer Staples", industry="Packaged Foods", notes="Defensive Europe large-cap seed.", primary_data_provider_symbol=None, provider_symbol_aliases=("NESN.SW",), provider_symbol_status="candidate_alias_requires_verification", source_identity_status="candidate_alias_only", source_identity_notes="Swiss listing likely requires .SW provider suffix."),
     _asset("AAPL", display_name="Apple", region="US", country="United States", exchange="NASDAQ", currency="USD", sector="Technology", industry="Consumer Electronics", notes="US mega-cap leadership anchor."),
     _asset("MSFT", display_name="Microsoft", region="US", country="United States", exchange="NASDAQ", currency="USD", sector="Technology", industry="Software", notes="US mega-cap software anchor."),
     _asset("NVDA", display_name="NVIDIA", region="US", country="United States", exchange="NASDAQ", currency="USD", sector="Technology", industry="Semiconductors", notes="US semiconductor momentum seed."),
@@ -360,6 +382,46 @@ def list_presets() -> list[DiscoveryPreset]:
     return list(_PRESETS)
 
 
+def source_identity_diagnostics() -> list[dict[str, object]]:
+    diagnostics: list[dict[str, object]] = []
+    for asset in list_assets():
+        payload = asset.to_payload()
+        provider_symbol = payload["primary_data_provider_symbol"]
+        aliases = list(payload["provider_symbol_aliases"])
+        provider_status = str(payload["provider_symbol_status"])
+        source_identity_status = str(payload["source_identity_status"])
+        if provider_status == "candidate_alias_requires_verification":
+            blocker_class = "source_identity_candidate_alias_unverified"
+        elif not provider_symbol:
+            blocker_class = "source_identity_missing_provider_symbol"
+        elif provider_status == "provider_lookup_failed":
+            blocker_class = "source_identity_provider_lookup_failed"
+        elif asset.region == "ETFs/context" and asset.asset_class == "etf":
+            blocker_class = "source_identity_provider_symbol_verified"
+        else:
+            blocker_class = "source_identity_provider_symbol_verified"
+        diagnostics.append(
+            {
+                "instrument_symbol": asset.symbol,
+                "region": asset.region,
+                "canonical_symbol": asset.symbol,
+                "canonical_instrument_id": asset.canonical_instrument_id,
+                "provider_symbol": provider_symbol,
+                "candidate_aliases": aliases,
+                "provider_symbol_status": provider_status,
+                "source_identity_status": source_identity_status,
+                "source_identity_notes": str(payload["source_identity_notes"]),
+                "has_primary_provider_symbol": bool(provider_symbol),
+                "has_provider_aliases": bool(aliases),
+                "is_provider_symbol_verified": provider_status == "verified",
+                "is_candidate_alias_only": provider_status
+                == "candidate_alias_requires_verification",
+                "source_identity_blocker_class": blocker_class,
+            }
+        )
+    return diagnostics
+
+
 def _asset_matches_preset(asset: DiscoveryAsset, preset: DiscoveryPreset) -> bool:
     return (
         asset.enabled_for_discovery
@@ -431,6 +493,9 @@ def build_bounded_candidate_basket(*, max_candidates: int = 15) -> list[dict[str
                 "symbol": selected.symbol,
                 "region": selected.region,
                 "asset_class": selected.asset_class,
+                "primary_data_provider_symbol": selected.primary_data_provider_symbol,
+                "provider_symbol_status": selected.provider_symbol_status,
+                "source_identity_status": selected.source_identity_status,
                 "preset_id": preset.preset_id,
                 "hypothesis_id": preset.hypothesis_id,
                 "behavior_family": preset.behavior_family,
@@ -455,6 +520,7 @@ def production_discovery_catalog_payload(*, max_candidates: int = 15) -> dict[st
         "module_version": MODULE_VERSION,
         "assets": [asset.to_payload() for asset in list_assets()],
         "presets": [preset.to_payload() for preset in list_presets()],
+        "source_identity_diagnostics": source_identity_diagnostics(),
         "bounded_candidate_basket": build_bounded_candidate_basket(
             max_candidates=max_candidates
         ),

--- a/tests/unit/test_qre_controlled_discovery_grid.py
+++ b/tests/unit/test_qre_controlled_discovery_grid.py
@@ -56,6 +56,12 @@ def test_controlled_discovery_grid_rows_expose_required_metadata() -> None:
     assert row["asset_class"] in {"equity", "etf"}
     assert row["hypothesis_id"]
     assert row["timeframe"] in {"1d", "4h"}
+    assert "primary_data_provider_symbol" in row
+    assert "provider_symbol_aliases" in row
+    assert "provider_symbol_status" in row
+    assert "source_identity_status" in row
+    assert "source_identity_notes" in row
+    assert "source_identity_blocker_class" in row
 
 
 def test_controlled_discovery_grid_does_not_mutate_frozen_contracts() -> None:

--- a/tests/unit/test_qre_controlled_discovery_grid_analysis.py
+++ b/tests/unit/test_qre_controlled_discovery_grid_analysis.py
@@ -264,5 +264,40 @@ def test_operator_summary_includes_oos_blocker_explanation_section() -> None:
 
     assert "## 5. Sufficient OOS evidence blocker explanation" in markdown
     assert "## 6. Top OOS follow-up diagnostics" in markdown
+    assert "## 7. Source identity diagnostics" in markdown
     assert "| Sequence | Instrument | Preset | OOS trades | HD trades | Trades total | Promotion | Primary blocker | Criteria failures | Metric consistency | Follow-up |" in markdown
     assert "| 13 | AMD | trend_continuation_daily_v1 | 13.0 | 0.0 | 13.0 | false | oos_evidence_no_promotion_due_to_criteria | criteria_consistentie_failed, criteria_win_rate_failed | consistent | review_criteria_failures |" in markdown
+
+
+def test_provider_lookup_failures_are_classified_as_source_identity_blockers() -> None:
+    summary = analysis.build_summary(
+        run_dir=Path("research/controlled_discovery_grid_runs/run-008"),
+        results=[
+            {
+                "sequence_number": 14,
+                "status": "completed",
+                "blocker_class": "missing_data",
+                "outcome_class": "unknown",
+                "near_pass": False,
+                "promotion_candidate": False,
+                "safe_to_promote": False,
+                "region": "NL/EU",
+                "instrument_symbol": "ADYEN",
+                "behavior_preset_id": "trend_continuation_daily_v1",
+                "primary_data_provider_symbol": None,
+                "provider_symbol_aliases": ["ADYEN.AS"],
+                "provider_symbol_status": "candidate_alias_requires_verification",
+                "source_identity_status": "candidate_alias_only",
+                "source_identity_notes": "Provider suffix likely required.",
+            }
+        ],
+    )
+
+    assert summary["counts"]["unknown"] == 0
+    assert summary["by_outcome_class"] == [
+        {"value": "source_identity_provider_lookup_failed", "count": 1}
+    ]
+    source_identity_row = summary["source_identity_diagnostics"][0]
+    assert source_identity_row["provider_symbol"] is None
+    assert source_identity_row["candidate_aliases"] == ["ADYEN.AS"]
+    assert source_identity_row["blocker"] == "source_identity_provider_lookup_failed"

--- a/tests/unit/test_qre_controlled_discovery_grid_analysis.py
+++ b/tests/unit/test_qre_controlled_discovery_grid_analysis.py
@@ -35,6 +35,7 @@ def test_build_summary_counts_deferred_rows_as_unknown() -> None:
     assert summary["counts"]["total_attempted"] == 2
     assert summary["counts"]["execution_integration_deferred"] == 2
     assert summary["counts"]["unknown"] == 2
+    assert summary["counts"]["promotion_candidate"] == 0
     assert summary["next_action"] == "DEFER_EXECUTION_INTEGRATION"
 
 
@@ -133,3 +134,135 @@ def test_build_summary_counts_completed_skipped_failed_and_dedupes_latest_rows()
     assert summary["counts"]["promotion_candidate"] == 1
     assert summary["next_action"] == "MERGE_AND_RUN_ON_VPS"
     assert summary["top_promotion_candidates"][0]["instrument_symbol"] == "MSFT"
+
+
+def test_sufficient_oos_evidence_rows_explain_criteria_blockers() -> None:
+    summary = analysis.build_summary(
+        run_dir=Path("research/controlled_discovery_grid_runs/run-004"),
+        results=[
+            {
+                "sequence_number": 10,
+                "status": "completed",
+                "blocker_class": "criteria_consistentie_failed",
+                "outcome_class": "sufficient_oos_evidence",
+                "near_pass": False,
+                "promotion_candidate": False,
+                "safe_to_promote": False,
+                "region": "FR/EU",
+                "instrument_symbol": "AIR",
+                "behavior_preset_id": "trend_continuation_daily_v1",
+                "trades_total": 30.0,
+                "oos_trades": 20,
+                "hd_trades": 10.0,
+                "criteria_status": "criteria_consistentie_failed,criteria_deflated_sharpe_failed,criteria_trades_per_maand_failed",
+                "artifact_paths": {"execution_result": "tmp/execution_result.v1.json"},
+                "result_path": "tmp/execution_result.v1.json",
+            }
+        ],
+    )
+
+    assert summary["counts"]["sufficient_oos_evidence"] == 1
+    assert summary["counts"]["oos_evidence_no_promotion_due_to_criteria"] == 1
+    row = summary["sufficient_oos_evidence_blockers"][0]
+    assert row["primary_blocker"] == "oos_evidence_no_promotion_due_to_criteria"
+    assert row["criteria_failure_classes"] == [
+        "criteria_consistentie_failed",
+        "criteria_deflated_sharpe_failed",
+        "criteria_trades_per_maand_failed",
+    ]
+    assert row["metric_consistency_status"] == "consistent"
+    assert row["follow_up"] == "review_criteria_failures"
+    assert summary["top_oos_follow_up_diagnostics"][0]["promotion_candidate"] is False
+    assert summary["top_oos_follow_up_diagnostics"][0]["safe_to_promote"] is False
+    assert summary["top_oos_follow_up_diagnostics"][0]["near_pass"] is False
+
+
+def test_oos_metric_inconsistency_is_flagged_explicitly() -> None:
+    summary = analysis.build_summary(
+        run_dir=Path("research/controlled_discovery_grid_runs/run-005"),
+        results=[
+            {
+                "sequence_number": 11,
+                "status": "completed",
+                "blocker_class": "criteria_trades_per_maand_failed",
+                "outcome_class": "sufficient_oos_evidence",
+                "near_pass": False,
+                "promotion_candidate": False,
+                "safe_to_promote": False,
+                "region": "FR/EU",
+                "instrument_symbol": "TTE",
+                "behavior_preset_id": "trend_pullback_continuation_daily_v1",
+                "trades_total": 11.0,
+                "oos_trades": 20,
+                "hd_trades": 0.0,
+                "criteria_status": "criteria_trades_per_maand_failed",
+                "artifact_paths": {"execution_result": "tmp/execution_result.v1.json"},
+                "result_path": "tmp/execution_result.v1.json",
+            }
+        ],
+    )
+
+    assert summary["counts"]["oos_evidence_metric_inconsistent"] == 1
+    row = summary["sufficient_oos_evidence_blockers"][0]
+    assert row["primary_blocker"] == "oos_evidence_metric_inconsistent"
+    assert row["metric_consistency_status"] == "inconsistent"
+    assert row["metric_consistency_warnings"] == ["oos_hd_exceeds_trades_total"]
+
+
+def test_unknown_rows_reduce_to_known_source_identity_reason_when_present() -> None:
+    summary = analysis.build_summary(
+        run_dir=Path("research/controlled_discovery_grid_runs/run-006"),
+        results=[
+            {
+                "sequence_number": 12,
+                "status": "completed",
+                "blocker_class": None,
+                "outcome_class": "unknown",
+                "near_pass": False,
+                "promotion_candidate": False,
+                "safe_to_promote": False,
+                "region": "NL/EU",
+                "instrument_symbol": "ADYEN",
+                "behavior_preset_id": "trend_continuation_daily_v1",
+                "provider_symbol_status": "candidate_alias_requires_verification",
+            }
+        ],
+    )
+
+    assert summary["counts"]["unknown"] == 0
+    assert summary["by_outcome_class"] == [
+        {"value": "source_identity_candidate_alias_unverified", "count": 1}
+    ]
+
+
+def test_operator_summary_includes_oos_blocker_explanation_section() -> None:
+    summary = analysis.build_summary(
+        run_dir=Path("research/controlled_discovery_grid_runs/run-007"),
+        results=[
+            {
+                "sequence_number": 13,
+                "status": "completed",
+                "blocker_class": "criteria_win_rate_failed",
+                "outcome_class": "sufficient_oos_evidence",
+                "near_pass": False,
+                "promotion_candidate": False,
+                "safe_to_promote": False,
+                "region": "US",
+                "instrument_symbol": "AMD",
+                "behavior_preset_id": "trend_continuation_daily_v1",
+                "trades_total": 13.0,
+                "oos_trades": 13,
+                "hd_trades": 0.0,
+                "criteria_status": "criteria_consistentie_failed,criteria_win_rate_failed",
+                "artifact_paths": {"execution_result": "tmp/execution_result.v1.json"},
+                "result_path": "tmp/execution_result.v1.json",
+            }
+        ],
+    )
+
+    markdown = analysis.render_operator_summary(summary)
+
+    assert "## 5. Sufficient OOS evidence blocker explanation" in markdown
+    assert "## 6. Top OOS follow-up diagnostics" in markdown
+    assert "| Sequence | Instrument | Preset | OOS trades | HD trades | Trades total | Promotion | Primary blocker | Criteria failures | Metric consistency | Follow-up |" in markdown
+    assert "| 13 | AMD | trend_continuation_daily_v1 | 13.0 | 0.0 | 13.0 | false | oos_evidence_no_promotion_due_to_criteria | criteria_consistentie_failed, criteria_win_rate_failed | consistent | review_criteria_failures |" in markdown

--- a/tests/unit/test_qre_production_discovery_catalog.py
+++ b/tests/unit/test_qre_production_discovery_catalog.py
@@ -24,6 +24,11 @@ def test_production_discovery_assets_are_regionally_diverse_and_read_only() -> N
         assert payload["source_quality_status"] == "reviewed_seed_only"
         assert isinstance(payload["canonical_instrument_id"], str)
         assert payload["canonical_instrument_id"]
+        assert "primary_data_provider_symbol" in payload
+        assert "provider_symbol_aliases" in payload
+        assert "provider_symbol_status" in payload
+        assert "source_identity_status" in payload
+        assert "source_identity_notes" in payload
 
 
 def test_production_discovery_presets_are_non_executable_seed_metadata() -> None:
@@ -80,4 +85,43 @@ def test_catalog_payload_exposes_seed_only_metadata_and_basket() -> None:
     assert payload["live_activation_allowed"] is False
     assert len(payload["assets"]) == 41
     assert len(payload["presets"]) == 8
+    assert len(payload["source_identity_diagnostics"]) == 41
     assert len(payload["bounded_candidate_basket"]) == 15
+
+
+def test_known_european_symbols_expose_candidate_provider_aliases_without_overclaiming() -> None:
+    assets = {asset.symbol: asset.to_payload() for asset in catalog.list_assets()}
+
+    assert assets["ADYEN"]["provider_symbol_aliases"] == ["ADYEN.AS"]
+    assert assets["ASMI"]["provider_symbol_aliases"] == ["ASM.AS", "ASMI.AS"]
+    assert assets["BESI"]["provider_symbol_aliases"] == ["BESI.AS"]
+    assert assets["IFX"]["provider_symbol_aliases"] == ["IFX.DE"]
+    assert assets["LVMH"]["provider_symbol_aliases"] == ["MC.PA", "LVMH.PA"]
+    assert assets["NESN"]["provider_symbol_aliases"] == ["NESN.SW"]
+    assert assets["NOVO-B"]["provider_symbol_aliases"] == ["NVO", "NOVO-B.CO"]
+    assert assets["PRX"]["provider_symbol_aliases"] == ["PRX.AS"]
+    assert assets["SIE"]["provider_symbol_aliases"] == ["SIE.DE"]
+    assert assets["ADYEN"]["provider_symbol_status"] == "candidate_alias_requires_verification"
+    assert assets["NOVO-B"]["provider_symbol_status"] == "candidate_alias_requires_verification"
+    assert assets["ADYEN"]["primary_data_provider_symbol"] is None
+    assert assets["NOVO-B"]["primary_data_provider_symbol"] is None
+
+
+def test_source_identity_diagnostics_classify_verified_and_unverified_symbols() -> None:
+    diagnostics = {
+        row["instrument_symbol"]: row for row in catalog.source_identity_diagnostics()
+    }
+
+    assert diagnostics["AAPL"]["source_identity_blocker_class"] == (
+        "source_identity_provider_symbol_verified"
+    )
+    assert diagnostics["ADYEN"]["source_identity_blocker_class"] == (
+        "source_identity_candidate_alias_unverified"
+    )
+    assert diagnostics["SHELL"]["provider_symbol"] == "SHEL"
+    assert diagnostics["SHELL"]["is_provider_symbol_verified"] is True
+    assert diagnostics["ADYEN"]["is_provider_symbol_verified"] is False
+    assert diagnostics["ADYEN"]["is_candidate_alias_only"] is True
+    assert diagnostics["SPY"]["source_identity_blocker_class"] == (
+        "source_identity_provider_symbol_verified"
+    )


### PR DESCRIPTION
Adds explicit sufficient-OOS blocker diagnostics, metric consistency checks, and read-only source identity / provider symbol mapping diagnostics for the QRE discovery grid. This PR does not relax thresholds, does not promote candidates, does not change strategy logic, and does not activate paper/shadow/live.