### PR TITLE
fix: add QRE routing and sampling decision quality audit

### DIFF
--- a/research/qre_routing_decision_quality.py
+++ b/research/qre_routing_decision_quality.py
@@ -1,0 +1,372 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+from research import qre_failure_action_from_basket as failure_action
+from research import qre_reason_records_v1 as reason_records
+from research import qre_routing_readiness_from_basket as routing
+
+
+REPORT_KIND: Final[str] = "qre_routing_decision_quality"
+SCHEMA_VERSION: Final[str] = "1.0"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_routing_decision_quality")
+LATEST_NAME: Final[str] = "latest.json"
+OPERATOR_SUMMARY_NAME: Final[str] = "operator_summary.md"
+_WRITE_PREFIX: Final[str] = "logs/qre_routing_decision_quality/"
+
+
+def _table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> str:
+    head = "| " + " | ".join(headers) + " |"
+    divider = "| " + " | ".join(["---"] * len(headers)) + " |"
+    body = ["| " + " | ".join(row) + " |" for row in rows]
+    return "\n".join([head, divider, *body])
+
+
+def _reason_ref_index(records: Sequence[Mapping[str, Any]]) -> dict[str, dict[str, list[str]]]:
+    by_subject: dict[str, dict[str, list[str]]] = {}
+    for record in records:
+        subject_id = str(record.get("subject_id") or "")
+        if not subject_id:
+            continue
+        bucket = by_subject.setdefault(
+            subject_id,
+            {"record_ids": [], "record_families": [], "evidence_refs": []},
+        )
+        for key, values in (
+            ("record_ids", [record.get("record_id")]),
+            ("record_families", [record.get("record_family")]),
+            ("evidence_refs", record.get("evidence_refs") or []),
+        ):
+            for value in values:
+                text = str(value or "").strip()
+                if text and text not in bucket[key]:
+                    bucket[key].append(text[:160])
+    return by_subject
+
+
+def _decision_quality(
+    routing_row: Mapping[str, Any],
+    failure_row: Mapping[str, Any],
+    *,
+    has_reason_refs: bool,
+) -> tuple[str, bool, bool, bool, list[str], str]:
+    state = str(routing_row.get("routing_readiness_state") or "fail_closed")
+    follow_up = str(routing_row.get("follow_up") or "keep_fail_closed")
+    action = str(failure_row.get("recommended_action") or "keep_blocked")
+    action_status = str(
+        ((failure_row.get("actionability") or {}) if isinstance(failure_row, Mapping) else {}).get(
+            "status"
+        )
+        or "non_actionable"
+    )
+    diagnosis_class = str(routing_row.get("diagnosis_class") or "unknown_fail_closed")
+    reasons: list[str] = []
+
+    if state == "ready":
+        false_ready = (
+            not has_reason_refs
+            or action != "eligible_for_readonly_routing"
+            or action_status != "actionable"
+            or diagnosis_class != "diagnosable"
+            or follow_up != "eligible_for_readonly_routing"
+        )
+        if false_ready:
+            if not has_reason_refs:
+                reasons.append("missing_reason_refs")
+            if action != "eligible_for_readonly_routing":
+                reasons.append("routing_action_misaligned")
+            if action_status != "actionable":
+                reasons.append("routing_action_non_actionable")
+            if diagnosis_class != "diagnosable":
+                reasons.append("routing_ready_without_diagnosable_state")
+            if follow_up != "eligible_for_readonly_routing":
+                reasons.append("routing_follow_up_misaligned")
+            return (
+                "false_ready",
+                True,
+                False,
+                False,
+                reasons,
+                "Routing marked this basket ready, but downstream read-only evidence did not confirm the decision.",
+            )
+        return (
+            "ready_sound",
+            False,
+            False,
+            True,
+            ["ready_evidence_follow_through"],
+            "Routing readiness is supported by durable reason refs and an aligned read-only follow-up action.",
+        )
+
+    if state == "fail_closed":
+        correct = (
+            diagnosis_class == "unknown_fail_closed"
+            or action == "keep_blocked"
+            or "supporting_artifacts_missing"
+            in [str(code) for code in (failure_row.get("actionability") or {}).get("reason_codes") or []]
+        )
+        reasons.append("supporting_artifacts_missing" if correct else "fail_closed_without_support")
+        return (
+            "fail_closed_correct" if correct else "fail_closed_ambiguous",
+            False,
+            correct,
+            has_reason_refs,
+            reasons,
+            "Routing correctly fails closed when upstream artifacts are missing or non-deterministic."
+            if correct
+            else "Routing failed closed, but the downstream evidence trail is incomplete.",
+        )
+
+    if state == "blocked":
+        correct = action in {"require_identity_resolution", "require_source_readiness", "keep_blocked"}
+        reasons.append("blocked_alignment_ok" if correct else "blocked_alignment_missing")
+        return (
+            "blocked_correct" if correct else "blocked_ambiguous",
+            False,
+            correct,
+            has_reason_refs,
+            reasons,
+            "Routing blockers align with bounded source identity or readiness actions."
+            if correct
+            else "Routing blockers are present, but the bounded follow-up action is misaligned.",
+        )
+
+    correct = action in {"collect_more_evidence", "expand_basket_coverage", "route_to_manual_review", "defer_as_duplicate"}
+    reasons.append("deferred_alignment_ok" if correct else "deferred_alignment_missing")
+    return (
+        "deferred_correct" if correct else "deferred_ambiguous",
+        False,
+        correct,
+        has_reason_refs,
+        reasons,
+        "Deferred routing decisions align with bounded evidence-collection or review actions."
+        if correct
+        else "The routing decision is deferred, but the downstream action is not specific enough.",
+    )
+
+
+def build_routing_decision_quality(
+    *,
+    repo_root: Path = Path("."),
+    max_candidates: int = 15,
+) -> dict[str, Any]:
+    routing_report = routing.build_routing_readiness_from_basket(
+        repo_root=repo_root,
+        max_candidates=max_candidates,
+    )
+    failure_report = failure_action.build_failure_action_from_basket(
+        repo_root=repo_root,
+        max_candidates=max_candidates,
+    )
+    reason_snapshot = reason_records.build_reason_records_snapshot(
+        repo_root=repo_root,
+        max_candidates=max_candidates,
+    )
+
+    routing_rows = routing_report.get("rows")
+    if not isinstance(routing_rows, list):
+        routing_rows = []
+    failure_rows = failure_report.get("rows")
+    if not isinstance(failure_rows, list):
+        failure_rows = []
+    failure_by_subject = {
+        str(row.get("candidate_id") or ""): row
+        for row in failure_rows
+        if isinstance(row, Mapping)
+    }
+    reason_index = _reason_ref_index(
+        [row for row in reason_snapshot.get("records") or [] if isinstance(row, Mapping)]
+    )
+
+    rows: list[dict[str, Any]] = []
+    for routing_row in routing_rows:
+        if not isinstance(routing_row, Mapping):
+            continue
+        candidate_id = str(routing_row.get("candidate_id") or "")
+        failure_row = failure_by_subject.get(candidate_id, {})
+        reason_refs = reason_index.get(
+            candidate_id,
+            {"record_ids": [], "record_families": [], "evidence_refs": []},
+        )
+        quality_state, false_ready, fail_closed_correct, evidence_follow_through, quality_reasons, explanation = _decision_quality(
+            routing_row,
+            failure_row,
+            has_reason_refs=bool(reason_refs.get("record_ids")),
+        )
+        rows.append(
+            {
+                "candidate_id": candidate_id,
+                "symbol": routing_row.get("symbol"),
+                "preset_id": routing_row.get("preset_id"),
+                "routing_readiness_state": routing_row.get("routing_readiness_state"),
+                "routing_readiness_score_pct": int(routing_row.get("routing_readiness_score_pct") or 0),
+                "decision_quality_state": quality_state,
+                "routing_false_ready": false_ready,
+                "fail_closed_correct": fail_closed_correct,
+                "evidence_follow_through": evidence_follow_through,
+                "duplicate_avoidance_applied": str(failure_row.get("recommended_action") or "")
+                in {"suppress_until_new_evidence", "defer_as_duplicate"},
+                "recommended_action": failure_row.get("recommended_action"),
+                "actionability_status": str(
+                    ((failure_row.get("actionability") or {}) if isinstance(failure_row, Mapping) else {}).get(
+                        "status"
+                    )
+                    or "non_actionable"
+                ),
+                "reason_record_refs": reason_refs,
+                "quality_reason_codes": quality_reasons,
+                "operator_explanation": explanation,
+            }
+        )
+
+    rows.sort(key=lambda row: (str(row.get("symbol") or ""), str(row.get("preset_id") or "")))
+    counts = Counter(str(row["decision_quality_state"]) for row in rows)
+    false_ready_count = sum(1 for row in rows if bool(row.get("routing_false_ready")))
+    fail_closed_correct_count = sum(1 for row in rows if bool(row.get("fail_closed_correct")))
+    blocker_correct_count = sum(
+        1
+        for row in rows
+        if str(row.get("decision_quality_state") or "") in {"blocked_correct", "deferred_correct"}
+    )
+    duplicate_avoidance_count = sum(1 for row in rows if bool(row.get("duplicate_avoidance_applied")))
+    evidence_follow_through_count = sum(1 for row in rows if bool(row.get("evidence_follow_through")))
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "max_candidates": max_candidates,
+        "summary": {
+            "basket_count": len(rows),
+            "decision_quality_state_counts": dict(sorted(counts.items())),
+            "routing_false_ready_count": false_ready_count,
+            "routing_fail_closed_correct_count": fail_closed_correct_count,
+            "routing_blocker_correct_count": blocker_correct_count,
+            "duplicate_avoidance_count": duplicate_avoidance_count,
+            "evidence_follow_through_count": evidence_follow_through_count,
+            "final_recommendation": (
+                "routing_decisions_sound"
+                if false_ready_count == 0
+                else "routing_false_ready_items_present"
+            ),
+            "operator_summary": (
+                "Routing decision quality audits whether read-only routing readiness "
+                "states remain internally consistent with reason records and bounded "
+                "failure actions."
+            ),
+        },
+        "rows": rows,
+        "safety_invariants": {
+            "read_only": True,
+            "policy_adaptation": False,
+            "automatic_reroute": False,
+            "queue_mutation": False,
+            "mutates_frozen_contracts": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+        },
+    }
+
+
+def render_operator_summary(report: Mapping[str, Any]) -> str:
+    summary = report.get("summary") or {}
+    rows = report.get("rows") if isinstance(report.get("rows"), list) else []
+    counts = summary.get("decision_quality_state_counts") or {}
+    count_table = _table(
+        ["Field", "Count"],
+        [
+            ["basket count", str(summary.get("basket_count") or 0)],
+            ["false ready", str(summary.get("routing_false_ready_count") or 0)],
+            ["fail closed correct", str(summary.get("routing_fail_closed_correct_count") or 0)],
+            ["blocker correct", str(summary.get("routing_blocker_correct_count") or 0)],
+            ["duplicate avoidance", str(summary.get("duplicate_avoidance_count") or 0)],
+            ["evidence follow-through", str(summary.get("evidence_follow_through_count") or 0)],
+        ],
+    )
+    state_table = _table(
+        ["State", "Count"],
+        [[str(key), str(value)] for key, value in sorted(counts.items())],
+    )
+    row_table = _table(
+        ["Symbol", "Preset", "Routing state", "Quality state", "Action", "Reason codes"],
+        [
+            [
+                str(row.get("symbol") or ""),
+                str(row.get("preset_id") or ""),
+                str(row.get("routing_readiness_state") or ""),
+                str(row.get("decision_quality_state") or ""),
+                str(row.get("recommended_action") or ""),
+                ", ".join(str(code) for code in row.get("quality_reason_codes") or []),
+            ]
+            for row in rows
+        ],
+    )
+    return "\n".join(
+        [
+            "# QRE Routing Decision Quality Audit",
+            "",
+            "## 1. Korte conclusie",
+            f"- {summary.get('operator_summary') or ''}",
+            "",
+            "## 2. Routing decision quality counts",
+            count_table,
+            "",
+            "## 3. Routing decision quality states",
+            state_table,
+            "",
+            "## 4. Routing decision quality by basket",
+            row_table,
+        ]
+    )
+
+
+def _validate_write_target(path: Path) -> None:
+    if _WRITE_PREFIX not in path.as_posix():
+        raise ValueError(f"qre_routing_decision_quality: refusing write outside allowlist: {path!r}")
+
+
+def write_outputs(
+    report: Mapping[str, Any],
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = Path("."),
+) -> dict[str, str]:
+    base = repo_root / output_dir
+    base.mkdir(parents=True, exist_ok=True)
+    latest = base / LATEST_NAME
+    summary_path = base / OPERATOR_SUMMARY_NAME
+    for target in (latest, summary_path):
+        _validate_write_target(target)
+    tmp_json = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp_json, latest)
+    tmp_summary = summary_path.with_suffix(summary_path.suffix + ".tmp")
+    tmp_summary.write_text(render_operator_summary(report) + "\n", encoding="utf-8")
+    os.replace(tmp_summary, summary_path)
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "operator_summary": summary_path.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_routing_decision_quality",
+        description="Build read-only QRE routing decision quality diagnostics.",
+    )
+    parser.add_argument("--max-candidates", type=int, default=15)
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    report = build_routing_decision_quality(max_candidates=args.max_candidates)
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/research/qre_sampling_decision_quality.py
+++ b/research/qre_sampling_decision_quality.py
@@ -1,0 +1,358 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+from research import qre_failure_action_from_basket as failure_action
+from research import qre_oos_evidence_blockers as oos_blockers
+from research import qre_reason_records_v1 as reason_records
+from research import qre_sampling_readiness_from_basket as sampling
+
+
+REPORT_KIND: Final[str] = "qre_sampling_decision_quality"
+SCHEMA_VERSION: Final[str] = "1.0"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_sampling_decision_quality")
+LATEST_NAME: Final[str] = "latest.json"
+OPERATOR_SUMMARY_NAME: Final[str] = "operator_summary.md"
+_WRITE_PREFIX: Final[str] = "logs/qre_sampling_decision_quality/"
+
+
+def _table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> str:
+    head = "| " + " | ".join(headers) + " |"
+    divider = "| " + " | ".join(["---"] * len(headers)) + " |"
+    body = ["| " + " | ".join(row) + " |" for row in rows]
+    return "\n".join([head, divider, *body])
+
+
+def _reason_ref_index(records: Sequence[Mapping[str, Any]]) -> dict[str, dict[str, list[str]]]:
+    by_subject: dict[str, dict[str, list[str]]] = {}
+    for record in records:
+        subject_id = str(record.get("subject_id") or "")
+        if not subject_id:
+            continue
+        bucket = by_subject.setdefault(
+            subject_id,
+            {"record_ids": [], "record_families": [], "evidence_refs": []},
+        )
+        for key, values in (
+            ("record_ids", [record.get("record_id")]),
+            ("record_families", [record.get("record_family")]),
+            ("evidence_refs", record.get("evidence_refs") or []),
+        ):
+            for value in values:
+                text = str(value or "").strip()
+                if text and text not in bucket[key]:
+                    bucket[key].append(text[:160])
+    return by_subject
+
+
+def _decision_quality(
+    sampling_row: Mapping[str, Any],
+    failure_row: Mapping[str, Any],
+    oos_row: Mapping[str, Any],
+    *,
+    has_reason_refs: bool,
+) -> tuple[str, bool, bool, list[str], str]:
+    state = str(sampling_row.get("sampling_readiness_state") or "fail_closed")
+    action = str(failure_row.get("recommended_action") or "keep_blocked")
+    oos_status = str(oos_row.get("oos_status") or "oos_evidence_missing")
+    routing_state = str(sampling_row.get("routing_readiness_state") or "fail_closed")
+    reasons: list[str] = []
+
+    if state == "ready":
+        false_ready = (
+            routing_state != "ready"
+            or not has_reason_refs
+            or action != "eligible_for_readonly_routing"
+            or oos_status not in {"sufficient_oos_evidence", "insufficient_oos_evidence"}
+        )
+        if false_ready:
+            if routing_state != "ready":
+                reasons.append("sampling_ready_without_routing_ready")
+            if not has_reason_refs:
+                reasons.append("missing_reason_refs")
+            if action != "eligible_for_readonly_routing":
+                reasons.append("sampling_action_misaligned")
+            if oos_status not in {"sufficient_oos_evidence", "insufficient_oos_evidence"}:
+                reasons.append("sampling_ready_without_oos_visibility")
+            return (
+                "false_ready",
+                True,
+                False,
+                reasons,
+                "Sampling marked this basket ready, but the upstream routing, reason refs, or OOS visibility did not support the decision.",
+            )
+        return (
+            "ready_sound",
+            False,
+            True,
+            ["sampling_follow_through_ok"],
+            "Sampling readiness is supported by routing readiness, durable reason refs, and explicit OOS visibility.",
+        )
+
+    if state == "fail_closed":
+        correct = routing_state == "fail_closed" or action == "keep_blocked"
+        reasons.append("sampling_fail_closed_ok" if correct else "sampling_fail_closed_ambiguous")
+        return (
+            "fail_closed_correct" if correct else "fail_closed_ambiguous",
+            False,
+            has_reason_refs,
+            reasons,
+            "Sampling correctly fails closed when routing or supporting artifacts fail closed."
+            if correct
+            else "Sampling failed closed, but the downstream justification is incomplete.",
+        )
+
+    if state == "blocked":
+        correct = action in {"require_source_readiness", "require_identity_resolution", "keep_blocked"}
+        reasons.append("sampling_blocker_alignment_ok" if correct else "sampling_blocker_alignment_missing")
+        return (
+            "blocked_correct" if correct else "blocked_ambiguous",
+            False,
+            has_reason_refs,
+            reasons,
+            "Sampling blockers align with bounded source or identity remediation."
+            if correct
+            else "Sampling is blocked, but the bounded remediation path is unclear.",
+        )
+
+    correct = action in {"collect_more_evidence", "expand_basket_coverage", "route_to_manual_review", "suppress_until_new_evidence", "defer_as_duplicate"}
+    reasons.append("sampling_deferred_alignment_ok" if correct else "sampling_deferred_alignment_missing")
+    return (
+        "deferred_correct" if correct else "deferred_ambiguous",
+        False,
+        has_reason_refs,
+        reasons,
+        "Sampling deferrals align with bounded evidence collection or suppression actions."
+        if correct
+        else "Sampling is deferred, but the follow-up action is not specific enough.",
+    )
+
+
+def build_sampling_decision_quality(
+    *,
+    repo_root: Path = Path("."),
+    max_candidates: int = 15,
+) -> dict[str, Any]:
+    sampling_report = sampling.build_sampling_readiness_from_basket(
+        repo_root=repo_root,
+        max_candidates=max_candidates,
+    )
+    failure_report = failure_action.build_failure_action_from_basket(
+        repo_root=repo_root,
+        max_candidates=max_candidates,
+    )
+    oos_report = oos_blockers.build_oos_evidence_blockers(
+        repo_root=repo_root,
+        max_candidates=max_candidates,
+    )
+    reason_snapshot = reason_records.build_reason_records_snapshot(
+        repo_root=repo_root,
+        max_candidates=max_candidates,
+    )
+
+    sampling_rows = sampling_report.get("rows")
+    if not isinstance(sampling_rows, list):
+        sampling_rows = []
+    failure_rows = failure_report.get("rows")
+    if not isinstance(failure_rows, list):
+        failure_rows = []
+    oos_rows = oos_report.get("rows")
+    if not isinstance(oos_rows, list):
+        oos_rows = []
+    failure_by_subject = {
+        str(row.get("candidate_id") or ""): row
+        for row in failure_rows
+        if isinstance(row, Mapping)
+    }
+    oos_by_subject = {
+        str(row.get("candidate_id") or ""): row
+        for row in oos_rows
+        if isinstance(row, Mapping)
+    }
+    reason_index = _reason_ref_index(
+        [row for row in reason_snapshot.get("records") or [] if isinstance(row, Mapping)]
+    )
+
+    rows: list[dict[str, Any]] = []
+    for sampling_row in sampling_rows:
+        if not isinstance(sampling_row, Mapping):
+            continue
+        candidate_id = str(sampling_row.get("candidate_id") or "")
+        failure_row = failure_by_subject.get(candidate_id, {})
+        oos_row = oos_by_subject.get(candidate_id, {})
+        reason_refs = reason_index.get(
+            candidate_id,
+            {"record_ids": [], "record_families": [], "evidence_refs": []},
+        )
+        quality_state, false_ready, evidence_follow_through, quality_reasons, explanation = _decision_quality(
+            sampling_row,
+            failure_row,
+            oos_row,
+            has_reason_refs=bool(reason_refs.get("record_ids")),
+        )
+        rows.append(
+            {
+                "candidate_id": candidate_id,
+                "symbol": sampling_row.get("symbol"),
+                "preset_id": sampling_row.get("preset_id"),
+                "sampling_readiness_state": sampling_row.get("sampling_readiness_state"),
+                "sampling_readiness_score_pct": int(sampling_row.get("sampling_readiness_score_pct") or 0),
+                "decision_quality_state": quality_state,
+                "sampling_false_ready": false_ready,
+                "sampling_blocker_correct": quality_state in {"blocked_correct", "deferred_correct", "fail_closed_correct"},
+                "evidence_follow_through": evidence_follow_through,
+                "duplicate_avoidance_applied": str(failure_row.get("recommended_action") or "")
+                in {"suppress_until_new_evidence", "defer_as_duplicate"},
+                "recommended_action": failure_row.get("recommended_action"),
+                "oos_status": oos_row.get("oos_status"),
+                "oos_blocker_class": oos_row.get("oos_blocker_class"),
+                "reason_record_refs": reason_refs,
+                "quality_reason_codes": quality_reasons,
+                "operator_explanation": explanation,
+            }
+        )
+
+    rows.sort(key=lambda row: (str(row.get("symbol") or ""), str(row.get("preset_id") or "")))
+    counts = Counter(str(row["decision_quality_state"]) for row in rows)
+    false_ready_count = sum(1 for row in rows if bool(row.get("sampling_false_ready")))
+    blocker_correct_count = sum(1 for row in rows if bool(row.get("sampling_blocker_correct")))
+    duplicate_avoidance_count = sum(1 for row in rows if bool(row.get("duplicate_avoidance_applied")))
+    evidence_follow_through_count = sum(1 for row in rows if bool(row.get("evidence_follow_through")))
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "max_candidates": max_candidates,
+        "summary": {
+            "basket_count": len(rows),
+            "decision_quality_state_counts": dict(sorted(counts.items())),
+            "sampling_false_ready_count": false_ready_count,
+            "sampling_blocker_correct_count": blocker_correct_count,
+            "duplicate_avoidance_count": duplicate_avoidance_count,
+            "evidence_follow_through_count": evidence_follow_through_count,
+            "final_recommendation": (
+                "sampling_decisions_sound"
+                if false_ready_count == 0
+                else "sampling_false_ready_items_present"
+            ),
+            "operator_summary": (
+                "Sampling decision quality audits whether read-only sampling readiness "
+                "stays aligned with routing readiness, OOS blocker visibility, reason "
+                "records, and bounded failure actions."
+            ),
+        },
+        "rows": rows,
+        "safety_invariants": {
+            "read_only": True,
+            "policy_adaptation": False,
+            "automatic_reroute": False,
+            "queue_mutation": False,
+            "mutates_frozen_contracts": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+        },
+    }
+
+
+def render_operator_summary(report: Mapping[str, Any]) -> str:
+    summary = report.get("summary") or {}
+    rows = report.get("rows") if isinstance(report.get("rows"), list) else []
+    counts = summary.get("decision_quality_state_counts") or {}
+    count_table = _table(
+        ["Field", "Count"],
+        [
+            ["basket count", str(summary.get("basket_count") or 0)],
+            ["false ready", str(summary.get("sampling_false_ready_count") or 0)],
+            ["blocker correct", str(summary.get("sampling_blocker_correct_count") or 0)],
+            ["duplicate avoidance", str(summary.get("duplicate_avoidance_count") or 0)],
+            ["evidence follow-through", str(summary.get("evidence_follow_through_count") or 0)],
+        ],
+    )
+    state_table = _table(
+        ["State", "Count"],
+        [[str(key), str(value)] for key, value in sorted(counts.items())],
+    )
+    row_table = _table(
+        ["Symbol", "Preset", "Sampling state", "Quality state", "OOS status", "Action"],
+        [
+            [
+                str(row.get("symbol") or ""),
+                str(row.get("preset_id") or ""),
+                str(row.get("sampling_readiness_state") or ""),
+                str(row.get("decision_quality_state") or ""),
+                str(row.get("oos_status") or ""),
+                str(row.get("recommended_action") or ""),
+            ]
+            for row in rows
+        ],
+    )
+    return "\n".join(
+        [
+            "# QRE Sampling Decision Quality Audit",
+            "",
+            "## 1. Korte conclusie",
+            f"- {summary.get('operator_summary') or ''}",
+            "",
+            "## 2. Sampling decision quality counts",
+            count_table,
+            "",
+            "## 3. Sampling decision quality states",
+            state_table,
+            "",
+            "## 4. Sampling decision quality by basket",
+            row_table,
+        ]
+    )
+
+
+def _validate_write_target(path: Path) -> None:
+    if _WRITE_PREFIX not in path.as_posix():
+        raise ValueError(f"qre_sampling_decision_quality: refusing write outside allowlist: {path!r}")
+
+
+def write_outputs(
+    report: Mapping[str, Any],
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = Path("."),
+) -> dict[str, str]:
+    base = repo_root / output_dir
+    base.mkdir(parents=True, exist_ok=True)
+    latest = base / LATEST_NAME
+    summary_path = base / OPERATOR_SUMMARY_NAME
+    for target in (latest, summary_path):
+        _validate_write_target(target)
+    tmp_json = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp_json, latest)
+    tmp_summary = summary_path.with_suffix(summary_path.suffix + ".tmp")
+    tmp_summary.write_text(render_operator_summary(report) + "\n", encoding="utf-8")
+    os.replace(tmp_summary, summary_path)
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "operator_summary": summary_path.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_sampling_decision_quality",
+        description="Build read-only QRE sampling decision quality diagnostics.",
+    )
+    parser.add_argument("--max-candidates", type=int, default=15)
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    report = build_sampling_decision_quality(max_candidates=args.max_candidates)
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/unit/test_qre_routing_sampling_decision_quality.py
+++ b/tests/unit/test_qre_routing_sampling_decision_quality.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from research import qre_routing_decision_quality as routing_quality
+from research import qre_sampling_decision_quality as sampling_quality
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _seed_complete_aapl_repo(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "logs" / "qre_data_cache_manifest" / "latest.json",
+        {"coverage": [{"instrument": "AAPL", "timeframe": "1d", "ready": True}]},
+    )
+    _write_json(
+        tmp_path / "logs" / "qre_data_source_quality_readiness" / "latest.json",
+        {"rows": [{"instrument": "AAPL", "timeframe": "1d", "quality_status": "ready"}]},
+    )
+    _write_json(
+        tmp_path / "research" / "screening_evidence_latest.v1.json",
+        {
+            "candidates": [
+                {
+                    "asset": "AAPL",
+                    "hypothesis_id": "trend_pullback_behavior_v1",
+                    "stage_result": "screening_pass",
+                    "validation_evidence": {
+                        "status": "sufficient_oos_evidence",
+                        "oos_trade_count": 12,
+                    },
+                }
+            ]
+        },
+    )
+    _write_json(
+        tmp_path / "research" / "campaign_registry_latest.v1.json",
+        {
+            "campaigns": {
+                "cmp-1": {
+                    "preset_name": "trend_pullback_continuation_daily_v1",
+                    "hypothesis_id": "trend_pullback_behavior_v1",
+                    "state": "completed",
+                }
+            }
+        },
+    )
+    _write_json(
+        tmp_path / "research" / "candidate_registry_latest.v1.json",
+        {"candidates": [{"asset": "AAPL", "status": "candidate"}]},
+    )
+
+
+def test_build_routing_decision_quality_marks_ready_row_as_sound(tmp_path: Path) -> None:
+    _seed_complete_aapl_repo(tmp_path)
+
+    report = routing_quality.build_routing_decision_quality(
+        repo_root=tmp_path,
+        max_candidates=2,
+    )
+
+    rows = {row["symbol"]: row for row in report["rows"]}
+    row = rows["AAPL"]
+    assert row["decision_quality_state"] == "ready_sound"
+    assert row["routing_false_ready"] is False
+    assert row["evidence_follow_through"] is True
+    assert report["summary"]["routing_false_ready_count"] == 0
+
+
+def test_build_routing_decision_quality_counts_duplicate_avoidance(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_complete_aapl_repo(tmp_path)
+    baseline = routing_quality.build_routing_decision_quality(
+        repo_root=tmp_path,
+        max_candidates=2,
+    )
+    aapl_id = next(
+        row["candidate_id"] for row in baseline["rows"] if row["symbol"] == "AAPL"
+    )
+
+    def _patched_failure_action(*, repo_root: Path = Path("."), max_candidates: int = 15) -> dict:
+        return {
+            "rows": [
+                {
+                    "candidate_id": aapl_id,
+                    "symbol": "AAPL",
+                    "preset_id": "trend_pullback_continuation_daily_v1",
+                    "recommended_action": "defer_as_duplicate",
+                    "actionability": {"status": "actionable", "reason_codes": ["duplicate"]},
+                }
+            ]
+        }
+
+    monkeypatch.setattr(
+        routing_quality.failure_action,
+        "build_failure_action_from_basket",
+        _patched_failure_action,
+    )
+
+    report = routing_quality.build_routing_decision_quality(
+        repo_root=tmp_path,
+        max_candidates=2,
+    )
+
+    assert report["summary"]["duplicate_avoidance_count"] == 1
+
+
+def test_build_routing_decision_quality_fails_closed_without_reason_refs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_complete_aapl_repo(tmp_path)
+
+    def _empty_reason_records(*, repo_root: Path = Path("."), max_candidates: int = 15) -> dict:
+        return {"records": []}
+
+    monkeypatch.setattr(
+        routing_quality.reason_records,
+        "build_reason_records_snapshot",
+        _empty_reason_records,
+    )
+
+    report = routing_quality.build_routing_decision_quality(
+        repo_root=tmp_path,
+        max_candidates=2,
+    )
+
+    row = next(item for item in report["rows"] if item["symbol"] == "AAPL")
+    assert row["routing_false_ready"] is True
+    assert "missing_reason_refs" in row["quality_reason_codes"]
+    assert report["summary"]["final_recommendation"] == "routing_false_ready_items_present"
+
+
+def test_build_sampling_decision_quality_marks_ready_row_as_sound(tmp_path: Path) -> None:
+    _seed_complete_aapl_repo(tmp_path)
+
+    report = sampling_quality.build_sampling_decision_quality(
+        repo_root=tmp_path,
+        max_candidates=2,
+    )
+
+    rows = {row["symbol"]: row for row in report["rows"]}
+    row = rows["AAPL"]
+    assert row["decision_quality_state"] == "ready_sound"
+    assert row["sampling_false_ready"] is False
+    assert row["evidence_follow_through"] is True
+    assert report["summary"]["sampling_false_ready_count"] == 0
+
+
+def test_build_sampling_decision_quality_flags_missing_oos_visibility_as_false_ready(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_complete_aapl_repo(tmp_path)
+    baseline = sampling_quality.build_sampling_decision_quality(
+        repo_root=tmp_path,
+        max_candidates=2,
+    )
+    aapl_id = next(
+        row["candidate_id"] for row in baseline["rows"] if row["symbol"] == "AAPL"
+    )
+
+    def _patched_oos(*, repo_root: Path = Path("."), max_candidates: int = 15) -> dict:
+        return {
+            "rows": [
+                {
+                    "candidate_id": aapl_id,
+                    "symbol": "AAPL",
+                    "preset_id": "trend_pullback_continuation_daily_v1",
+                    "oos_status": "oos_evidence_missing",
+                    "oos_blocker_class": "oos_evidence_missing",
+                }
+            ]
+        }
+
+    monkeypatch.setattr(
+        sampling_quality.oos_blockers,
+        "build_oos_evidence_blockers",
+        _patched_oos,
+    )
+
+    report = sampling_quality.build_sampling_decision_quality(
+        repo_root=tmp_path,
+        max_candidates=2,
+    )
+
+    row = next(item for item in report["rows"] if item["symbol"] == "AAPL")
+    assert row["sampling_false_ready"] is True
+    assert "sampling_ready_without_oos_visibility" in row["quality_reason_codes"]
+
+
+def test_render_operator_summary_and_write_outputs(tmp_path: Path) -> None:
+    _seed_complete_aapl_repo(tmp_path)
+
+    routing_report = routing_quality.build_routing_decision_quality(
+        repo_root=tmp_path,
+        max_candidates=1,
+    )
+    routing_markdown = routing_quality.render_operator_summary(routing_report)
+    routing_paths = routing_quality.write_outputs(routing_report, repo_root=tmp_path)
+
+    sampling_report = sampling_quality.build_sampling_decision_quality(
+        repo_root=tmp_path,
+        max_candidates=1,
+    )
+    sampling_markdown = sampling_quality.render_operator_summary(sampling_report)
+    sampling_paths = sampling_quality.write_outputs(sampling_report, repo_root=tmp_path)
+
+    assert "# QRE Routing Decision Quality Audit" in routing_markdown
+    assert "## 2. Routing decision quality counts" in routing_markdown
+    assert routing_paths["latest"] == "logs/qre_routing_decision_quality/latest.json"
+    assert routing_paths["operator_summary"] == "logs/qre_routing_decision_quality/operator_summary.md"
+
+    assert "# QRE Sampling Decision Quality Audit" in sampling_markdown
+    assert "## 2. Sampling decision quality counts" in sampling_markdown
+    assert sampling_paths["latest"] == "logs/qre_sampling_decision_quality/latest.json"
+    assert sampling_paths["operator_summary"] == "logs/qre_sampling_decision_quality/operator_summary.md"


### PR DESCRIPTION
Adds read-only routing and sampling decision-quality audits over existing QRE basket/readiness/failure artifacts. The new reports measure false-ready counts, fail-closed correctness, blocker correctness, duplicate avoidance, and evidence follow-through without changing routing policy, sampling policy, queue state, paper/shadow/live behavior, or frozen contracts.