### PR TITLE
fix: add QRE failure recurrence learning metrics

### DIFF
--- a/research/qre_failure_recurrence_learning.py
+++ b/research/qre_failure_recurrence_learning.py
@@ -1,0 +1,448 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections import Counter, defaultdict
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+from research import production_discovery_catalog as discovery_catalog
+from research import qre_failure_action_from_basket as failure_action
+from research import qre_hypothesis_seed_feasibility as hypothesis_feasibility
+from research import qre_real_basket_evidence_coverage as evidence_coverage
+from research import qre_routing_decision_quality as routing_quality
+from research import qre_sampling_decision_quality as sampling_quality
+
+
+REPORT_KIND: Final[str] = "qre_failure_recurrence_learning"
+SOURCE_REPORT_KIND: Final[str] = "qre_source_usefulness_v0"
+SCHEMA_VERSION: Final[str] = "1.0"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_failure_recurrence_learning")
+SOURCE_OUTPUT_DIR: Final[Path] = Path("logs/qre_source_usefulness_v0")
+LATEST_NAME: Final[str] = "latest.json"
+_WRITE_PREFIX: Final[str] = "logs/qre_failure_recurrence_learning/"
+_SOURCE_WRITE_PREFIX: Final[str] = "logs/qre_source_usefulness_v0/"
+
+
+def _top_counts(values: Sequence[str], *, limit: int = 5) -> list[dict[str, Any]]:
+    counts = Counter(value for value in values if value)
+    return [
+        {"value": key, "count": counts[key]}
+        for key in sorted(counts, key=lambda item: (-counts[item], item))[:limit]
+    ]
+
+
+def _read_only_recommendation(
+    *,
+    source_blocker_count: int,
+    missing_evidence_count: int,
+    false_ready_count: int,
+    dead_zone_count: int,
+) -> str:
+    if false_ready_count > 0:
+        return "preserve_fail_closed_policy"
+    if source_blocker_count > 0:
+        return "require_identity_or_source_readiness"
+    if dead_zone_count >= 2:
+        return "suppress_dead_zone_repeats_until_new_evidence"
+    if missing_evidence_count > 0:
+        return "collect_more_evidence_before_seed_expansion"
+    return "sustain_current_readonly_path"
+
+
+def _aggregate_dimension(
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    key_name: str,
+    label: str,
+    extractor: Callable[[Mapping[str, Any]], str],
+) -> list[dict[str, Any]]:
+    grouped: dict[str, list[Mapping[str, Any]]] = defaultdict(list)
+    for row in rows:
+        key = extractor(row).strip() or "unknown"
+        grouped[key].append(row)
+
+    out: list[dict[str, Any]] = []
+    for key, members in sorted(grouped.items()):
+        dead_zone_count = sum(1 for row in members if bool(row.get("dead_zone")))
+        false_ready_count = sum(1 for row in members if bool(row.get("false_ready")))
+        source_blocker_count = sum(1 for row in members if bool(row.get("source_blocker")))
+        missing_evidence_count = sum(1 for row in members if bool(row.get("missing_evidence")))
+        out.append(
+            {
+                key_name: key,
+                "label": label,
+                "row_count": len(members),
+                "dead_zone_count": dead_zone_count,
+                "false_ready_count": false_ready_count,
+                "source_blocker_count": source_blocker_count,
+                "missing_evidence_count": missing_evidence_count,
+                "recommended_actions_top": _top_counts(
+                    [str(row.get("recommended_action") or "") for row in members]
+                ),
+                "read_only_recommendation": _read_only_recommendation(
+                    source_blocker_count=source_blocker_count,
+                    missing_evidence_count=missing_evidence_count,
+                    false_ready_count=false_ready_count,
+                    dead_zone_count=dead_zone_count,
+                ),
+            }
+        )
+    return out
+
+
+def build_failure_recurrence_learning(
+    *,
+    repo_root: Path = Path("."),
+    max_candidates: int = 15,
+) -> dict[str, Any]:
+    coverage_report = evidence_coverage.build_real_basket_evidence_coverage(
+        repo_root=repo_root,
+        max_candidates=max_candidates,
+    )
+    failure_report = failure_action.build_failure_action_from_basket(
+        repo_root=repo_root,
+        max_candidates=max_candidates,
+    )
+    routing_report = routing_quality.build_routing_decision_quality(
+        repo_root=repo_root,
+        max_candidates=max_candidates,
+    )
+    sampling_report = sampling_quality.build_sampling_decision_quality(
+        repo_root=repo_root,
+        max_candidates=max_candidates,
+    )
+    feasibility_report = hypothesis_feasibility.build_hypothesis_seed_feasibility(
+        repo_root=repo_root,
+        max_candidates=max_candidates,
+    )
+
+    coverage_rows = coverage_report.get("rows")
+    if not isinstance(coverage_rows, list):
+        coverage_rows = []
+    failure_rows = failure_report.get("rows")
+    if not isinstance(failure_rows, list):
+        failure_rows = []
+    routing_rows = routing_report.get("rows")
+    if not isinstance(routing_rows, list):
+        routing_rows = []
+    sampling_rows = sampling_report.get("rows")
+    if not isinstance(sampling_rows, list):
+        sampling_rows = []
+    feasibility_rows = feasibility_report.get("rows")
+    if not isinstance(feasibility_rows, list):
+        feasibility_rows = []
+
+    failure_by_subject = {
+        str(row.get("candidate_id") or ""): row
+        for row in failure_rows
+        if isinstance(row, Mapping)
+    }
+    routing_by_subject = {
+        str(row.get("candidate_id") or ""): row
+        for row in routing_rows
+        if isinstance(row, Mapping)
+    }
+    sampling_by_subject = {
+        str(row.get("candidate_id") or ""): row
+        for row in sampling_rows
+        if isinstance(row, Mapping)
+    }
+    feasibility_by_hypothesis = {
+        str(row.get("hypothesis_id") or ""): row
+        for row in feasibility_rows
+        if isinstance(row, Mapping)
+    }
+    asset_catalog = {
+        asset.symbol: asset.to_payload() for asset in discovery_catalog.list_assets()
+    }
+
+    learning_rows: list[dict[str, Any]] = []
+    for row in coverage_rows:
+        if not isinstance(row, Mapping):
+            continue
+        subject_id = str(row.get("candidate_id") or "")
+        failure_row = failure_by_subject.get(subject_id, {})
+        routing_row = routing_by_subject.get(subject_id, {})
+        sampling_row = sampling_by_subject.get(subject_id, {})
+        hypothesis_row = feasibility_by_hypothesis.get(str(row.get("hypothesis_id") or ""), {})
+        asset_payload = asset_catalog.get(str(row.get("symbol") or ""), {})
+        blocker_code = str(failure_row.get("blocker_code") or "")
+        recommended_action = str(failure_row.get("recommended_action") or "keep_blocked")
+        source_blocker = blocker_code in {
+            "source_identity_blocked",
+            "source_or_cache_not_ready",
+            "source_or_cache_coverage_missing",
+        }
+        missing_evidence = blocker_code in {
+            "source_or_cache_coverage_missing",
+            "screening_evidence_missing",
+            "oos_evidence_missing",
+            "sampling_oos_window_unknown",
+            "lineage_missing",
+        }
+        false_ready = bool(routing_row.get("routing_false_ready")) or bool(
+            sampling_row.get("sampling_false_ready")
+        )
+        dead_zone = (
+            recommended_action
+            in {
+                "collect_more_evidence",
+                "expand_basket_coverage",
+                "suppress_until_new_evidence",
+                "defer_as_duplicate",
+            }
+            and str(row.get("diagnosis_class") or "") != "diagnosable"
+            and not false_ready
+        )
+        timeframes = row.get("timeframes")
+        if not isinstance(timeframes, list) or not timeframes:
+            timeframes = ["unknown"]
+        learning_rows.append(
+            {
+                "candidate_id": subject_id,
+                "symbol": row.get("symbol"),
+                "preset_id": row.get("preset_id"),
+                "behavior_family": row.get("behavior_family"),
+                "hypothesis_id": row.get("hypothesis_id"),
+                "timeframe": str(timeframes[0]),
+                "data_source": str(asset_payload.get("data_source") or "unknown"),
+                "recommended_action": recommended_action,
+                "blocker_code": blocker_code,
+                "dead_zone": dead_zone,
+                "false_ready": false_ready,
+                "source_blocker": source_blocker,
+                "missing_evidence": missing_evidence,
+                "hypothesis_feasibility_state": hypothesis_row.get("feasibility_state"),
+            }
+        )
+
+    learning_rows.sort(key=lambda row: (str(row["symbol"]), str(row["preset_id"])))
+    asset_rows = _aggregate_dimension(
+        learning_rows,
+        key_name="symbol",
+        label="asset",
+        extractor=lambda row: str(row.get("symbol") or ""),
+    )
+    timeframe_rows = _aggregate_dimension(
+        learning_rows,
+        key_name="timeframe",
+        label="timeframe",
+        extractor=lambda row: str(row.get("timeframe") or ""),
+    )
+    preset_rows = _aggregate_dimension(
+        learning_rows,
+        key_name="preset_id",
+        label="preset",
+        extractor=lambda row: str(row.get("preset_id") or ""),
+    )
+    behavior_rows = _aggregate_dimension(
+        learning_rows,
+        key_name="behavior_family",
+        label="behavior_family",
+        extractor=lambda row: str(row.get("behavior_family") or ""),
+    )
+    source_rows = _aggregate_dimension(
+        learning_rows,
+        key_name="data_source",
+        label="source",
+        extractor=lambda row: str(row.get("data_source") or ""),
+    )
+
+    false_ready_count = sum(1 for row in learning_rows if bool(row.get("false_ready")))
+    source_blocker_recurrence_count = sum(
+        1 for row in source_rows if int(row.get("source_blocker_count") or 0) > 0
+    )
+    missing_evidence_recurrence_count = sum(
+        1 for row in preset_rows if int(row.get("missing_evidence_count") or 0) > 0
+    )
+    repeated_dead_zone_count = sum(
+        1 for row in behavior_rows if int(row.get("dead_zone_count") or 0) >= 2
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "max_candidates": max_candidates,
+        "summary": {
+            "learning_row_count": len(learning_rows),
+            "false_ready_count": false_ready_count,
+            "source_blocker_recurrence_count": source_blocker_recurrence_count,
+            "missing_evidence_recurrence_count": missing_evidence_recurrence_count,
+            "repeated_dead_zone_count": repeated_dead_zone_count,
+            "read_only_recommendations_top": _top_counts(
+                [str(row.get("read_only_recommendation") or "") for row in behavior_rows + source_rows]
+            ),
+            "final_recommendation": (
+                "failure_recurrence_learning_ready"
+                if learning_rows
+                else "failure_recurrence_learning_missing"
+            ),
+            "operator_summary": (
+                "Failure recurrence learning counts repeated blocked patterns across asset, "
+                "timeframe, preset, behavior family, and source without adapting policy."
+            ),
+        },
+        "learning_rows": learning_rows,
+        "asset_recurrence_rows": asset_rows,
+        "timeframe_recurrence_rows": timeframe_rows,
+        "preset_recurrence_rows": preset_rows,
+        "behavior_family_recurrence_rows": behavior_rows,
+        "source_recurrence_rows": source_rows,
+        "safety_invariants": {
+            "read_only": True,
+            "uses_ml": False,
+            "policy_mutation": False,
+            "automatic_reroute": False,
+            "mutates_frozen_contracts": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+        },
+    }
+
+
+def build_source_usefulness_v0(
+    learning_report: Mapping[str, Any],
+    *,
+    repo_root: Path = Path("."),
+) -> dict[str, Any]:
+    learning_rows = learning_report.get("learning_rows")
+    if not isinstance(learning_rows, list):
+        learning_rows = []
+    asset_catalog = {
+        asset.symbol: asset.to_payload() for asset in discovery_catalog.list_assets()
+    }
+
+    grouped: dict[str, list[Mapping[str, Any]]] = defaultdict(list)
+    for row in learning_rows:
+        if not isinstance(row, Mapping):
+            continue
+        grouped[str(row.get("symbol") or "")].append(row)
+
+    rows: list[dict[str, Any]] = []
+    for symbol, members in sorted(grouped.items()):
+        asset = asset_catalog.get(symbol, {})
+        source_blocker_count = sum(1 for row in members if bool(row.get("source_blocker")))
+        false_ready_count = sum(1 for row in members if bool(row.get("false_ready")))
+        dead_zone_count = sum(1 for row in members if bool(row.get("dead_zone")))
+        ready_path_count = sum(
+            1
+            for row in members
+            if str(row.get("hypothesis_feasibility_state") or "")
+            == "feasible_for_readonly_research"
+        )
+        if ready_path_count > 0:
+            usefulness_state = "useful_for_readonly_research"
+        elif str(asset.get("source_identity_status") or "") == "candidate_alias_only":
+            usefulness_state = "blocked_by_source_identity"
+        elif source_blocker_count > 0:
+            usefulness_state = "blocked_by_source_or_cache"
+        else:
+            usefulness_state = "needs_more_evidence"
+        rows.append(
+            {
+                "symbol": symbol,
+                "data_source": asset.get("data_source"),
+                "provider_symbol_status": asset.get("provider_symbol_status"),
+                "source_identity_status": asset.get("source_identity_status"),
+                "mapped_basket_count": len(members),
+                "source_blocker_count": source_blocker_count,
+                "false_ready_count": false_ready_count,
+                "dead_zone_count": dead_zone_count,
+                "ready_path_count": ready_path_count,
+                "usefulness_state": usefulness_state,
+                "recommended_action": _read_only_recommendation(
+                    source_blocker_count=source_blocker_count,
+                    missing_evidence_count=sum(
+                        1 for row in members if bool(row.get("missing_evidence"))
+                    ),
+                    false_ready_count=false_ready_count,
+                    dead_zone_count=dead_zone_count,
+                ),
+            }
+        )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": SOURCE_REPORT_KIND,
+        "summary": {
+            "source_row_count": len(rows),
+            "usefulness_state_counts": dict(
+                sorted(Counter(str(row["usefulness_state"]) for row in rows).items())
+            ),
+            "final_recommendation": (
+                "source_usefulness_v0_ready" if rows else "source_usefulness_v0_missing"
+            ),
+            "operator_summary": (
+                "Source usefulness v0 summarizes which mapped symbols currently help "
+                "read-only research versus staying blocked by identity, cache, or thin evidence."
+            ),
+        },
+        "rows": rows,
+        "safety_invariants": {
+            "read_only": True,
+            "policy_mutation": False,
+            "source_lifecycle_automation": False,
+            "mutates_frozen_contracts": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+        },
+    }
+
+
+def _validate_write_target(path: Path, prefix: str, *, label: str) -> None:
+    if prefix not in path.as_posix():
+        raise ValueError(f"{label}: refusing write outside allowlist: {path!r}")
+
+
+def write_outputs(
+    report: Mapping[str, Any],
+    *,
+    repo_root: Path = Path("."),
+) -> dict[str, str]:
+    source_report = build_source_usefulness_v0(report, repo_root=repo_root)
+    main_dir = repo_root / DEFAULT_OUTPUT_DIR
+    source_dir = repo_root / SOURCE_OUTPUT_DIR
+    main_dir.mkdir(parents=True, exist_ok=True)
+    source_dir.mkdir(parents=True, exist_ok=True)
+    latest = main_dir / LATEST_NAME
+    source_latest = source_dir / LATEST_NAME
+    _validate_write_target(latest, _WRITE_PREFIX, label="qre_failure_recurrence_learning")
+    _validate_write_target(
+        source_latest,
+        _SOURCE_WRITE_PREFIX,
+        label="qre_source_usefulness_v0",
+    )
+    tmp_latest = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_latest.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp_latest, latest)
+    tmp_source = source_latest.with_suffix(source_latest.suffix + ".tmp")
+    tmp_source.write_text(
+        json.dumps(source_report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    os.replace(tmp_source, source_latest)
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "source_usefulness_v0": source_latest.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_failure_recurrence_learning",
+        description="Build read-only QRE failure recurrence learning metrics.",
+    )
+    parser.add_argument("--max-candidates", type=int, default=15)
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    report = build_failure_recurrence_learning(max_candidates=args.max_candidates)
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/research/qre_hypothesis_seed_feasibility.py
+++ b/research/qre_hypothesis_seed_feasibility.py
@@ -1,0 +1,465 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections import Counter, defaultdict
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+from research import production_discovery_catalog as discovery_catalog
+from research import qre_failure_action_from_basket as failure_action
+from research import qre_real_basket_evidence_coverage as evidence_coverage
+from research import qre_routing_readiness_from_basket as routing_readiness
+from research import qre_sampling_readiness_from_basket as sampling_readiness
+from research.hypothesis_discovery import behavior_hypotheses
+
+
+REPORT_KIND: Final[str] = "qre_hypothesis_seed_feasibility"
+BEHAVIOR_REPORT_KIND: Final[str] = "qre_behavior_family_coverage"
+SCHEMA_VERSION: Final[str] = "1.0"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_hypothesis_seed_feasibility")
+BEHAVIOR_OUTPUT_DIR: Final[Path] = Path("logs/qre_behavior_family_coverage")
+LATEST_NAME: Final[str] = "latest.json"
+_WRITE_PREFIX: Final[str] = "logs/qre_hypothesis_seed_feasibility/"
+_BEHAVIOR_WRITE_PREFIX: Final[str] = "logs/qre_behavior_family_coverage/"
+
+
+def _bounded_list(value: Any) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, str | bytes):
+        return []
+    out: list[str] = []
+    for item in value:
+        text = str(item or "").strip()
+        if text and text not in out:
+            out.append(text[:160])
+    return out
+
+
+def _top_counts(values: Sequence[str], *, limit: int = 5) -> list[dict[str, Any]]:
+    counts = Counter(value for value in values if value)
+    return [
+        {"value": key, "count": counts[key]}
+        for key in sorted(counts, key=lambda item: (-counts[item], item))[:limit]
+    ]
+
+
+def _reasoned_follow_up(actions: Sequence[str]) -> str:
+    priority = (
+        "eligible_for_readonly_routing",
+        "require_identity_resolution",
+        "require_source_readiness",
+        "collect_more_evidence",
+        "expand_basket_coverage",
+        "route_to_manual_review",
+        "suppress_until_new_evidence",
+        "defer_as_duplicate",
+        "keep_blocked",
+    )
+    available = {action for action in actions if action}
+    for action in priority:
+        if action in available:
+            return action
+    return "keep_blocked"
+
+
+def _feasibility_state(
+    *,
+    maps_to_basket_count: int,
+    source_ready_count: int,
+    data_ready_count: int,
+    screening_visible_count: int,
+    oos_visible_count: int,
+    routing_ready_count: int,
+    sampling_ready_count: int,
+    source_identity_blocked_count: int,
+    prior_failure_count: int,
+) -> tuple[str, str]:
+    if maps_to_basket_count == 0:
+        return (
+            "blocked_missing_basket_mapping",
+            "No bounded discovery basket currently maps this hypothesis seed to a real read-only basket.",
+        )
+    if sampling_ready_count > 0 or routing_ready_count > 0:
+        return (
+            "feasible_for_readonly_research",
+            "At least one mapped basket is routing/sampling-ready, so the seed is feasible for read-only research only.",
+        )
+    if source_identity_blocked_count >= maps_to_basket_count and source_identity_blocked_count > 0:
+        return (
+            "blocked_source_identity",
+            "All mapped baskets are blocked by source identity, so feasibility stays blocked until provider identity is resolved.",
+        )
+    if data_ready_count == 0:
+        return (
+            "blocked_source_or_cache",
+            "Mapped baskets exist, but none has source-plus-cache readiness yet.",
+        )
+    if screening_visible_count == 0 or oos_visible_count == 0:
+        return (
+            "blocked_missing_evidence_path",
+            "Mapped baskets lack screening or OOS visibility, so there is no sufficient evidence path yet.",
+        )
+    if source_ready_count == 0:
+        return (
+            "blocked_source_readiness",
+            "Mapped baskets have some data signals but no fully source-ready basket.",
+        )
+    if prior_failure_count > 0:
+        return (
+            "blocked_by_observed_failures",
+            "Observed bounded failures exist, so the seed remains blocked until new evidence changes the read-only picture.",
+        )
+    return (
+        "blocked_insufficient_readiness_signal",
+        "The seed maps to real baskets, but current evidence is still too thin for read-only feasibility.",
+    )
+
+
+def build_hypothesis_seed_feasibility(
+    *,
+    repo_root: Path = Path("."),
+    max_candidates: int = 15,
+) -> dict[str, Any]:
+    presets = discovery_catalog.list_presets()
+    active_behavior_map = {
+        row.behavior_family: row.to_payload()
+        for row in behavior_hypotheses.build_behavior_hypotheses()
+    }
+    coverage_report = evidence_coverage.build_real_basket_evidence_coverage(
+        repo_root=repo_root,
+        max_candidates=max_candidates,
+    )
+    routing_report = routing_readiness.build_routing_readiness_from_basket(
+        repo_root=repo_root,
+        max_candidates=max_candidates,
+    )
+    sampling_report = sampling_readiness.build_sampling_readiness_from_basket(
+        repo_root=repo_root,
+        max_candidates=max_candidates,
+    )
+    failure_report = failure_action.build_failure_action_from_basket(
+        repo_root=repo_root,
+        max_candidates=max_candidates,
+    )
+
+    coverage_rows = coverage_report.get("rows")
+    if not isinstance(coverage_rows, list):
+        coverage_rows = []
+    routing_rows = routing_report.get("rows")
+    if not isinstance(routing_rows, list):
+        routing_rows = []
+    sampling_rows = sampling_report.get("rows")
+    if not isinstance(sampling_rows, list):
+        sampling_rows = []
+    failure_rows = failure_report.get("rows")
+    if not isinstance(failure_rows, list):
+        failure_rows = []
+
+    routing_by_subject = {
+        str(row.get("candidate_id") or ""): row
+        for row in routing_rows
+        if isinstance(row, Mapping)
+    }
+    sampling_by_subject = {
+        str(row.get("candidate_id") or ""): row
+        for row in sampling_rows
+        if isinstance(row, Mapping)
+    }
+    failure_by_subject = {
+        str(row.get("candidate_id") or ""): row
+        for row in failure_rows
+        if isinstance(row, Mapping)
+    }
+
+    presets_by_hypothesis: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for preset in presets:
+        payload = preset.to_payload()
+        presets_by_hypothesis[str(payload["hypothesis_id"])].append(payload)
+
+    rows: list[dict[str, Any]] = []
+    for hypothesis_id, hypothesis_presets in sorted(presets_by_hypothesis.items()):
+        behavior_family = str(hypothesis_presets[0].get("behavior_family") or "")
+        mapped_coverage = [
+            row
+            for row in coverage_rows
+            if isinstance(row, Mapping) and str(row.get("hypothesis_id") or "") == hypothesis_id
+        ]
+        mapped_subject_ids = [str(row.get("candidate_id") or "") for row in mapped_coverage]
+
+        source_ready_count = 0
+        data_ready_count = 0
+        screening_visible_count = 0
+        oos_visible_count = 0
+        routing_ready_count = 0
+        sampling_ready_count = 0
+        diagnosable_basket_count = 0
+        source_identity_blocked_count = 0
+        blocker_codes: list[str] = []
+        recommended_actions: list[str] = []
+
+        for row in mapped_coverage:
+            evidence = row.get("evidence_presence")
+            if not isinstance(evidence, Mapping):
+                evidence = {}
+            if str(row.get("diagnosis_class") or "") == "diagnosable":
+                diagnosable_basket_count += 1
+            if bool(evidence.get("source_identity_ready")) and bool(evidence.get("source_quality_ready")):
+                source_ready_count += 1
+            if (
+                bool(evidence.get("source_identity_ready"))
+                and bool(evidence.get("source_quality_ready"))
+                and bool(evidence.get("cache_ready"))
+            ):
+                data_ready_count += 1
+            if bool(evidence.get("screening_evidence_present")):
+                screening_visible_count += 1
+            if bool(evidence.get("oos_evidence_known")):
+                oos_visible_count += 1
+            if str(row.get("source_identity_status") or "") == "candidate_alias_only":
+                source_identity_blocked_count += 1
+            subject_id = str(row.get("candidate_id") or "")
+            routing_row = routing_by_subject.get(subject_id, {})
+            sampling_row = sampling_by_subject.get(subject_id, {})
+            failure_row = failure_by_subject.get(subject_id, {})
+            if str(routing_row.get("routing_readiness_state") or "") == "ready":
+                routing_ready_count += 1
+            if str(sampling_row.get("sampling_readiness_state") or "") == "ready":
+                sampling_ready_count += 1
+            blocker = str(failure_row.get("blocker_code") or "")
+            if blocker:
+                blocker_codes.append(blocker)
+            action = str(failure_row.get("recommended_action") or "")
+            if action:
+                recommended_actions.append(action)
+
+        prior_failure_count = sum(
+            1 for action in recommended_actions if action and action != "eligible_for_readonly_routing"
+        )
+        sufficient_evidence_path = sampling_ready_count > 0 or routing_ready_count > 0
+        feasibility_state, explanation = _feasibility_state(
+            maps_to_basket_count=len(mapped_coverage),
+            source_ready_count=source_ready_count,
+            data_ready_count=data_ready_count,
+            screening_visible_count=screening_visible_count,
+            oos_visible_count=oos_visible_count,
+            routing_ready_count=routing_ready_count,
+            sampling_ready_count=sampling_ready_count,
+            source_identity_blocked_count=source_identity_blocked_count,
+            prior_failure_count=prior_failure_count,
+        )
+        catalog_bridge = active_behavior_map.get(behavior_family)
+        rows.append(
+            {
+                "hypothesis_id": hypothesis_id,
+                "behavior_family": behavior_family,
+                "supported_preset_mapping": [str(row.get("preset_id") or "") for row in hypothesis_presets],
+                "supported_preset_mapping_count": len(hypothesis_presets),
+                "catalog_bridge_status": (
+                    "linked_catalog_active_discovery"
+                    if catalog_bridge
+                    else "seed_only_no_executable_hypothesis"
+                ),
+                "catalog_hypothesis_id": (
+                    str(catalog_bridge.get("hypothesis_id") or "") if catalog_bridge else ""
+                ),
+                "maps_to_basket": len(mapped_coverage) > 0,
+                "maps_to_basket_count": len(mapped_coverage),
+                "mapped_candidate_ids": mapped_subject_ids,
+                "diagnosable_basket_count": diagnosable_basket_count,
+                "source_ready": source_ready_count > 0,
+                "source_ready_basket_count": source_ready_count,
+                "data_ready": data_ready_count > 0,
+                "data_ready_basket_count": data_ready_count,
+                "screening_visible_basket_count": screening_visible_count,
+                "oos_visible_basket_count": oos_visible_count,
+                "routing_ready_basket_count": routing_ready_count,
+                "sampling_ready_basket_count": sampling_ready_count,
+                "prior_failure_count": prior_failure_count,
+                "sufficient_evidence_path": sufficient_evidence_path,
+                "feasibility_state": feasibility_state,
+                "top_blockers": _top_counts(blocker_codes),
+                "recommended_follow_up": _reasoned_follow_up(recommended_actions),
+                "operator_explanation": explanation,
+            }
+        )
+
+    feasible_count = sum(
+        1 for row in rows if str(row.get("feasibility_state") or "") == "feasible_for_readonly_research"
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "max_candidates": max_candidates,
+        "summary": {
+            "hypothesis_seed_count": len(rows),
+            "feasible_seed_count": feasible_count,
+            "blocked_seed_count": len(rows) - feasible_count,
+            "catalog_active_discovery_link_count": sum(
+                1
+                for row in rows
+                if str(row.get("catalog_bridge_status") or "") == "linked_catalog_active_discovery"
+            ),
+            "seed_only_count": sum(
+                1
+                for row in rows
+                if str(row.get("catalog_bridge_status") or "") == "seed_only_no_executable_hypothesis"
+            ),
+            "feasibility_state_counts": dict(
+                sorted(Counter(str(row["feasibility_state"]) for row in rows).items())
+            ),
+            "final_recommendation": (
+                "hypothesis_seed_feasibility_ready" if rows else "hypothesis_seed_feasibility_missing"
+            ),
+            "operator_summary": (
+                "Hypothesis seed feasibility maps discovery-seed hypotheses to real basket, "
+                "source, evidence, routing, sampling, and failure-action state without "
+                "unlocking executable strategy changes."
+            ),
+        },
+        "rows": rows,
+        "safety_invariants": {
+            "read_only": True,
+            "mutates_registry": False,
+            "mutates_presets": False,
+            "mutates_frozen_contracts": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+        },
+    }
+
+
+def build_behavior_family_coverage(
+    report: Mapping[str, Any],
+) -> dict[str, Any]:
+    rows = report.get("rows")
+    if not isinstance(rows, list):
+        rows = []
+    grouped: dict[str, list[Mapping[str, Any]]] = defaultdict(list)
+    for row in rows:
+        if isinstance(row, Mapping):
+            grouped[str(row.get("behavior_family") or "unknown")].append(row)
+
+    coverage_rows: list[dict[str, Any]] = []
+    for behavior_family, members in sorted(grouped.items()):
+        coverage_rows.append(
+            {
+                "behavior_family": behavior_family,
+                "seed_count": len(members),
+                "feasible_seed_count": sum(
+                    1
+                    for row in members
+                    if str(row.get("feasibility_state") or "") == "feasible_for_readonly_research"
+                ),
+                "blocked_seed_count": sum(
+                    1
+                    for row in members
+                    if str(row.get("feasibility_state") or "") != "feasible_for_readonly_research"
+                ),
+                "mapped_basket_count": sum(int(row.get("maps_to_basket_count") or 0) for row in members),
+                "routing_ready_basket_count": sum(
+                    int(row.get("routing_ready_basket_count") or 0) for row in members
+                ),
+                "sampling_ready_basket_count": sum(
+                    int(row.get("sampling_ready_basket_count") or 0) for row in members
+                ),
+                "source_ready_basket_count": sum(
+                    int(row.get("source_ready_basket_count") or 0) for row in members
+                ),
+                "catalog_active_discovery_link_count": sum(
+                    1
+                    for row in members
+                    if str(row.get("catalog_bridge_status") or "") == "linked_catalog_active_discovery"
+                ),
+                "top_blockers": _top_counts(
+                    [str(blocker.get("value") or "") for row in members for blocker in row.get("top_blockers") or []]
+                ),
+            }
+        )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": BEHAVIOR_REPORT_KIND,
+        "summary": {
+            "behavior_family_count": len(coverage_rows),
+            "behavior_family_with_feasible_seed_count": sum(
+                1 for row in coverage_rows if int(row.get("feasible_seed_count") or 0) > 0
+            ),
+            "behavior_family_with_only_blocked_seed_count": sum(
+                1 for row in coverage_rows if int(row.get("feasible_seed_count") or 0) == 0
+            ),
+            "final_recommendation": (
+                "behavior_family_coverage_ready" if coverage_rows else "behavior_family_coverage_missing"
+            ),
+            "operator_summary": (
+                "Behavior family coverage summarizes which discovery-seed behavior families "
+                "currently have feasible versus blocked read-only hypothesis paths."
+            ),
+        },
+        "rows": coverage_rows,
+        "safety_invariants": {
+            "read_only": True,
+            "mutates_registry": False,
+            "mutates_frozen_contracts": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+        },
+    }
+
+
+def _validate_write_target(path: Path, prefix: str, *, label: str) -> None:
+    if prefix not in path.as_posix():
+        raise ValueError(f"{label}: refusing write outside allowlist: {path!r}")
+
+
+def write_outputs(
+    report: Mapping[str, Any],
+    *,
+    repo_root: Path = Path("."),
+) -> dict[str, str]:
+    behavior_report = build_behavior_family_coverage(report)
+    main_dir = repo_root / DEFAULT_OUTPUT_DIR
+    behavior_dir = repo_root / BEHAVIOR_OUTPUT_DIR
+    main_dir.mkdir(parents=True, exist_ok=True)
+    behavior_dir.mkdir(parents=True, exist_ok=True)
+    latest = main_dir / LATEST_NAME
+    behavior_latest = behavior_dir / LATEST_NAME
+    _validate_write_target(latest, _WRITE_PREFIX, label="qre_hypothesis_seed_feasibility")
+    _validate_write_target(
+        behavior_latest,
+        _BEHAVIOR_WRITE_PREFIX,
+        label="qre_behavior_family_coverage",
+    )
+    tmp_latest = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_latest.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp_latest, latest)
+    tmp_behavior = behavior_latest.with_suffix(behavior_latest.suffix + ".tmp")
+    tmp_behavior.write_text(
+        json.dumps(behavior_report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    os.replace(tmp_behavior, behavior_latest)
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "behavior_family_coverage": behavior_latest.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_hypothesis_seed_feasibility",
+        description="Build read-only QRE hypothesis seed feasibility from real basket evidence.",
+    )
+    parser.add_argument("--max-candidates", type=int, default=15)
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    report = build_hypothesis_seed_feasibility(max_candidates=args.max_candidates)
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/unit/test_qre_failure_recurrence_learning.py
+++ b/tests/unit/test_qre_failure_recurrence_learning.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from research import qre_failure_recurrence_learning as learning
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _seed_complete_aapl_repo(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "logs" / "qre_data_cache_manifest" / "latest.json",
+        {"coverage": [{"instrument": "AAPL", "timeframe": "1d", "ready": True}]},
+    )
+    _write_json(
+        tmp_path / "logs" / "qre_data_source_quality_readiness" / "latest.json",
+        {"rows": [{"instrument": "AAPL", "timeframe": "1d", "quality_status": "ready"}]},
+    )
+    _write_json(
+        tmp_path / "research" / "screening_evidence_latest.v1.json",
+        {
+            "candidates": [
+                {
+                    "asset": "AAPL",
+                    "hypothesis_id": "trend_pullback_behavior_v1",
+                    "stage_result": "screening_pass",
+                    "validation_evidence": {
+                        "status": "sufficient_oos_evidence",
+                        "oos_trade_count": 12,
+                    },
+                }
+            ]
+        },
+    )
+    _write_json(
+        tmp_path / "research" / "campaign_registry_latest.v1.json",
+        {
+            "campaigns": {
+                "cmp-1": {
+                    "preset_name": "trend_pullback_continuation_daily_v1",
+                    "hypothesis_id": "trend_pullback_behavior_v1",
+                    "state": "completed",
+                }
+            }
+        },
+    )
+    _write_json(
+        tmp_path / "research" / "candidate_registry_latest.v1.json",
+        {"candidates": [{"asset": "AAPL", "status": "candidate"}]},
+    )
+
+
+def test_build_failure_recurrence_learning_tracks_blocker_recurrence(tmp_path: Path) -> None:
+    _seed_complete_aapl_repo(tmp_path)
+
+    report = learning.build_failure_recurrence_learning(
+        repo_root=tmp_path,
+        max_candidates=15,
+    )
+
+    assert report["summary"]["false_ready_count"] == 0
+    assert report["summary"]["source_blocker_recurrence_count"] >= 1
+    assert report["summary"]["missing_evidence_recurrence_count"] >= 1
+
+
+def test_build_failure_recurrence_learning_counts_false_ready_when_reported(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_complete_aapl_repo(tmp_path)
+
+    baseline = learning.build_failure_recurrence_learning(
+        repo_root=tmp_path,
+        max_candidates=15,
+    )
+    aapl_id = next(
+        row["candidate_id"] for row in baseline["learning_rows"] if row["symbol"] == "AAPL"
+    )
+
+    def _patched_routing(*, repo_root: Path = Path("."), max_candidates: int = 15) -> dict:
+        return {
+            "rows": [
+                {
+                    "candidate_id": aapl_id,
+                    "symbol": "AAPL",
+                    "preset_id": "trend_pullback_continuation_daily_v1",
+                    "routing_false_ready": True,
+                }
+            ]
+        }
+
+    monkeypatch.setattr(
+        learning.routing_quality,
+        "build_routing_decision_quality",
+        _patched_routing,
+    )
+
+    report = learning.build_failure_recurrence_learning(
+        repo_root=tmp_path,
+        max_candidates=15,
+    )
+
+    assert report["summary"]["false_ready_count"] >= 1
+
+
+def test_build_source_usefulness_v0_distinguishes_useful_and_blocked_symbols(
+    tmp_path: Path,
+) -> None:
+    _seed_complete_aapl_repo(tmp_path)
+
+    report = learning.build_failure_recurrence_learning(
+        repo_root=tmp_path,
+        max_candidates=15,
+    )
+    usefulness = learning.build_source_usefulness_v0(report, repo_root=tmp_path)
+
+    rows = {row["symbol"]: row for row in usefulness["rows"]}
+    assert rows["AAPL"]["usefulness_state"] == "useful_for_readonly_research"
+    assert rows["ADYEN"]["usefulness_state"] == "blocked_by_source_identity"
+
+
+def test_write_outputs_materializes_learning_and_source_reports(tmp_path: Path) -> None:
+    _seed_complete_aapl_repo(tmp_path)
+
+    report = learning.build_failure_recurrence_learning(
+        repo_root=tmp_path,
+        max_candidates=15,
+    )
+    paths = learning.write_outputs(report, repo_root=tmp_path)
+
+    assert paths["latest"] == "logs/qre_failure_recurrence_learning/latest.json"
+    assert paths["source_usefulness_v0"] == "logs/qre_source_usefulness_v0/latest.json"

--- a/tests/unit/test_qre_hypothesis_seed_feasibility.py
+++ b/tests/unit/test_qre_hypothesis_seed_feasibility.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from research import qre_hypothesis_seed_feasibility as feasibility
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _seed_complete_aapl_repo(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "logs" / "qre_data_cache_manifest" / "latest.json",
+        {"coverage": [{"instrument": "AAPL", "timeframe": "1d", "ready": True}]},
+    )
+    _write_json(
+        tmp_path / "logs" / "qre_data_source_quality_readiness" / "latest.json",
+        {"rows": [{"instrument": "AAPL", "timeframe": "1d", "quality_status": "ready"}]},
+    )
+    _write_json(
+        tmp_path / "research" / "screening_evidence_latest.v1.json",
+        {
+            "candidates": [
+                {
+                    "asset": "AAPL",
+                    "hypothesis_id": "trend_pullback_behavior_v1",
+                    "stage_result": "screening_pass",
+                    "validation_evidence": {
+                        "status": "sufficient_oos_evidence",
+                        "oos_trade_count": 12,
+                    },
+                }
+            ]
+        },
+    )
+    _write_json(
+        tmp_path / "research" / "campaign_registry_latest.v1.json",
+        {
+            "campaigns": {
+                "cmp-1": {
+                    "preset_name": "trend_pullback_continuation_daily_v1",
+                    "hypothesis_id": "trend_pullback_behavior_v1",
+                    "state": "completed",
+                }
+            }
+        },
+    )
+    _write_json(
+        tmp_path / "research" / "candidate_registry_latest.v1.json",
+        {"candidates": [{"asset": "AAPL", "status": "candidate"}]},
+    )
+
+
+def test_build_hypothesis_seed_feasibility_marks_trend_pullback_as_feasible(
+    tmp_path: Path,
+) -> None:
+    _seed_complete_aapl_repo(tmp_path)
+
+    report = feasibility.build_hypothesis_seed_feasibility(
+        repo_root=tmp_path,
+        max_candidates=15,
+    )
+
+    rows = {row["hypothesis_id"]: row for row in report["rows"]}
+    row = rows["trend_pullback_behavior_v1"]
+    assert row["feasibility_state"] == "feasible_for_readonly_research"
+    assert row["maps_to_basket"] is True
+    assert row["data_ready"] is True
+    assert row["source_ready"] is True
+    assert row["catalog_bridge_status"] == "linked_catalog_active_discovery"
+
+
+def test_build_hypothesis_seed_feasibility_keeps_source_identity_blocked_seed_explicit(
+    tmp_path: Path,
+) -> None:
+    _seed_complete_aapl_repo(tmp_path)
+
+    report = feasibility.build_hypothesis_seed_feasibility(
+        repo_root=tmp_path,
+        max_candidates=15,
+    )
+
+    rows = {row["hypothesis_id"]: row for row in report["rows"]}
+    row = rows["relative_strength_sector_behavior_v1"]
+    assert row["feasibility_state"] == "blocked_source_identity"
+    assert row["recommended_follow_up"] == "require_identity_resolution"
+
+
+def test_build_hypothesis_seed_feasibility_distinguishes_seed_only_hypotheses(
+    tmp_path: Path,
+) -> None:
+    _seed_complete_aapl_repo(tmp_path)
+
+    report = feasibility.build_hypothesis_seed_feasibility(
+        repo_root=tmp_path,
+        max_candidates=15,
+    )
+
+    rows = {row["hypothesis_id"]: row for row in report["rows"]}
+    row = rows["relative_strength_region_behavior_v1"]
+    assert row["catalog_bridge_status"] == "seed_only_no_executable_hypothesis"
+    assert row["maps_to_basket"] is True
+
+
+def test_build_behavior_family_coverage_summarizes_feasible_and_blocked_families(
+    tmp_path: Path,
+) -> None:
+    _seed_complete_aapl_repo(tmp_path)
+
+    report = feasibility.build_hypothesis_seed_feasibility(
+        repo_root=tmp_path,
+        max_candidates=15,
+    )
+    coverage = feasibility.build_behavior_family_coverage(report)
+
+    rows = {row["behavior_family"]: row for row in coverage["rows"]}
+    assert rows["trend_pullback"]["feasible_seed_count"] == 1
+    assert rows["relative_strength_sector"]["blocked_seed_count"] == 1
+
+
+def test_write_outputs_materializes_feasibility_and_behavior_reports(tmp_path: Path) -> None:
+    _seed_complete_aapl_repo(tmp_path)
+
+    report = feasibility.build_hypothesis_seed_feasibility(
+        repo_root=tmp_path,
+        max_candidates=15,
+    )
+    paths = feasibility.write_outputs(report, repo_root=tmp_path)
+
+    assert paths["latest"] == "logs/qre_hypothesis_seed_feasibility/latest.json"
+    assert paths["behavior_family_coverage"] == "logs/qre_behavior_family_coverage/latest.json"


### PR DESCRIPTION
Adds deterministic read-only failure-recurrence learning metrics and source usefulness v0 over existing QRE evidence, readiness, failure-action, and feasibility artifacts. The PR does not adapt policy, does not reroute automatically, and does not touch paper/shadow/live, broker/risk/execution, or frozen contracts.