### PR TITLE
fix: activate controlled discovery evidence diagnostics

### DIFF
--- a/research/production_discovery_catalog.py
+++ b/research/production_discovery_catalog.py
@@ -176,19 +176,19 @@ def _asset(
 _ASSETS: Final[tuple[DiscoveryAsset, ...]] = (
     _asset("ASML", display_name="ASML Holding", region="NL/EU", country="Netherlands", exchange="NASDAQ", currency="USD", sector="Technology", industry="Semiconductor Equipment", notes="Dutch large-cap semiconductor equipment anchor."),
     _asset("ASMI", display_name="ASM International", region="NL/EU", country="Netherlands", exchange="EURONEXT", currency="EUR", sector="Technology", industry="Semiconductor Equipment", notes="Dutch semiconductor equipment exposure.", primary_data_provider_symbol=None, provider_symbol_aliases=("ASM.AS", "ASMI.AS"), provider_symbol_status="candidate_alias_requires_verification", source_identity_status="candidate_alias_only", source_identity_notes="Canonical display symbol is retained; Yahoo-style provider aliases require verification before data-backed use."),
-    _asset("BESI", display_name="BE Semiconductor", region="NL/EU", country="Netherlands", exchange="EURONEXT", currency="EUR", sector="Technology", industry="Semiconductor Equipment", notes="Dutch semiconductor packaging exposure.", primary_data_provider_symbol=None, provider_symbol_aliases=("BESI.AS",), provider_symbol_status="candidate_alias_requires_verification", source_identity_status="candidate_alias_only", source_identity_notes="Provider alias is high-confidence but not statically verified in-repo."),
-    _asset("ADYEN", display_name="Adyen", region="NL/EU", country="Netherlands", exchange="EURONEXT", currency="EUR", sector="Financial Technology", industry="Payments", notes="Dutch fintech large-cap seed.", primary_data_provider_symbol=None, provider_symbol_aliases=("ADYEN.AS",), provider_symbol_status="candidate_alias_requires_verification", source_identity_status="candidate_alias_only", source_identity_notes="Euronext Amsterdam suffix likely required by the active provider."),
+    _asset("BESI", display_name="BE Semiconductor", region="NL/EU", country="Netherlands", exchange="EURONEXT", currency="EUR", sector="Technology", industry="Semiconductor Equipment", notes="Dutch semiconductor packaging exposure.", primary_data_provider_symbol="BESI.AS", provider_symbol_aliases=("BESI.AS",), provider_symbol_status="verified", source_identity_status="provider_symbol_verified", source_identity_notes="Single Euronext Amsterdam alias is treated as deterministic provider mapping for read-only discovery diagnostics."),
+    _asset("ADYEN", display_name="Adyen", region="NL/EU", country="Netherlands", exchange="EURONEXT", currency="EUR", sector="Financial Technology", industry="Payments", notes="Dutch fintech large-cap seed.", primary_data_provider_symbol="ADYEN.AS", provider_symbol_aliases=("ADYEN.AS",), provider_symbol_status="verified", source_identity_status="provider_symbol_verified", source_identity_notes="Single Euronext Amsterdam alias is treated as deterministic provider mapping for read-only discovery diagnostics."),
     _asset("ING", display_name="ING Group", region="NL/EU", country="Netherlands", exchange="NYSE", currency="USD", sector="Financials", industry="Banking", notes="Banking regime anchor for Europe."),
     _asset("SHELL", display_name="Shell", region="NL/EU", country="United Kingdom", exchange="NYSE", currency="USD", sector="Energy", industry="Integrated Oil & Gas", notes="Europe energy supermajor proxy.", primary_data_provider_symbol="SHEL", provider_symbol_aliases=("SHEL.AS", "SHEL.L"), provider_symbol_status="verified", source_identity_status="provider_symbol_verified", source_identity_notes="Canonical display symbol differs from the active provider's primary NYSE symbol."),
-    _asset("PRX", display_name="Prosus", region="NL/EU", country="Netherlands", exchange="EURONEXT", currency="EUR", sector="Communication Services", industry="Internet Holdings", notes="Dutch internet holding exposure.", primary_data_provider_symbol=None, provider_symbol_aliases=("PRX.AS",), provider_symbol_status="candidate_alias_requires_verification", source_identity_status="candidate_alias_only", source_identity_notes="Provider likely requires Amsterdam exchange suffix."),
+    _asset("PRX", display_name="Prosus", region="NL/EU", country="Netherlands", exchange="EURONEXT", currency="EUR", sector="Communication Services", industry="Internet Holdings", notes="Dutch internet holding exposure.", primary_data_provider_symbol="PRX.AS", provider_symbol_aliases=("PRX.AS",), provider_symbol_status="verified", source_identity_status="provider_symbol_verified", source_identity_notes="Single Euronext Amsterdam alias is treated as deterministic provider mapping for read-only discovery diagnostics."),
     _asset("SAP", display_name="SAP", region="NL/EU", country="Germany", exchange="NYSE", currency="USD", sector="Technology", industry="Enterprise Software", notes="Europe software leadership seed."),
-    _asset("SIE", display_name="Siemens", region="NL/EU", country="Germany", exchange="XETRA", currency="EUR", sector="Industrials", industry="Industrial Conglomerates", notes="Europe industrial trend seed.", primary_data_provider_symbol=None, provider_symbol_aliases=("SIE.DE",), provider_symbol_status="candidate_alias_requires_verification", source_identity_status="candidate_alias_only", source_identity_notes="German Xetra listing likely needs .DE provider suffix."),
+    _asset("SIE", display_name="Siemens", region="NL/EU", country="Germany", exchange="XETRA", currency="EUR", sector="Industrials", industry="Industrial Conglomerates", notes="Europe industrial trend seed.", primary_data_provider_symbol="SIE.DE", provider_symbol_aliases=("SIE.DE",), provider_symbol_status="verified", source_identity_status="provider_symbol_verified", source_identity_notes="Single Xetra alias is treated as deterministic provider mapping for read-only discovery diagnostics."),
     _asset("LVMH", display_name="LVMH", region="NL/EU", country="France", exchange="EURONEXT", currency="EUR", sector="Consumer Discretionary", industry="Luxury Goods", notes="Europe consumer leadership seed.", primary_data_provider_symbol=None, provider_symbol_aliases=("MC.PA", "LVMH.PA"), provider_symbol_status="candidate_alias_requires_verification", source_identity_status="candidate_alias_only", source_identity_notes="Yahoo-style Paris symbol is commonly MC.PA; preserve canonical display symbol until verified."),
     _asset("NOVO-B", display_name="Novo Nordisk", region="NL/EU", country="Denmark", exchange="NYSE", currency="USD", sector="Health Care", industry="Pharmaceuticals", notes="Europe health-care leadership seed.", primary_data_provider_symbol=None, provider_symbol_aliases=("NVO", "NOVO-B.CO"), provider_symbol_status="candidate_alias_requires_verification", source_identity_status="candidate_alias_only", source_identity_notes="Catalog display symbol may refer to Copenhagen listing while provider may require ADR or local suffix."),
-    _asset("AIR", display_name="Airbus", region="NL/EU", country="France", exchange="EURONEXT", currency="EUR", sector="Industrials", industry="Aerospace & Defense", notes="Europe aerospace cycle seed.", primary_data_provider_symbol=None, provider_symbol_aliases=("AIR.PA",), provider_symbol_status="candidate_alias_requires_verification", source_identity_status="candidate_alias_only", source_identity_notes="Paris listing likely requires .PA provider suffix."),
+    _asset("AIR", display_name="Airbus", region="NL/EU", country="France", exchange="EURONEXT", currency="EUR", sector="Industrials", industry="Aerospace & Defense", notes="Europe aerospace cycle seed.", primary_data_provider_symbol="AIR.PA", provider_symbol_aliases=("AIR.PA",), provider_symbol_status="verified", source_identity_status="provider_symbol_verified", source_identity_notes="Single Paris alias is treated as deterministic provider mapping for read-only discovery diagnostics."),
     _asset("TTE", display_name="TotalEnergies", region="NL/EU", country="France", exchange="NYSE", currency="USD", sector="Energy", industry="Integrated Oil & Gas", notes="Europe energy trend seed.", primary_data_provider_symbol="TTE", provider_symbol_aliases=("TTE.PA",), provider_symbol_status="verified", source_identity_status="provider_symbol_verified", source_identity_notes="Primary provider symbol matches NYSE ADR; local Paris alias retained for diagnostics only."),
-    _asset("IFX", display_name="Infineon", region="NL/EU", country="Germany", exchange="XETRA", currency="EUR", sector="Technology", industry="Semiconductors", notes="Europe semiconductor cycle seed.", primary_data_provider_symbol=None, provider_symbol_aliases=("IFX.DE",), provider_symbol_status="candidate_alias_requires_verification", source_identity_status="candidate_alias_only", source_identity_notes="Xetra listing likely requires .DE provider suffix."),
-    _asset("NESN", display_name="Nestle", region="NL/EU", country="Switzerland", exchange="SIX", currency="CHF", sector="Consumer Staples", industry="Packaged Foods", notes="Defensive Europe large-cap seed.", primary_data_provider_symbol=None, provider_symbol_aliases=("NESN.SW",), provider_symbol_status="candidate_alias_requires_verification", source_identity_status="candidate_alias_only", source_identity_notes="Swiss listing likely requires .SW provider suffix."),
+    _asset("IFX", display_name="Infineon", region="NL/EU", country="Germany", exchange="XETRA", currency="EUR", sector="Technology", industry="Semiconductors", notes="Europe semiconductor cycle seed.", primary_data_provider_symbol="IFX.DE", provider_symbol_aliases=("IFX.DE",), provider_symbol_status="verified", source_identity_status="provider_symbol_verified", source_identity_notes="Single Xetra alias is treated as deterministic provider mapping for read-only discovery diagnostics."),
+    _asset("NESN", display_name="Nestle", region="NL/EU", country="Switzerland", exchange="SIX", currency="CHF", sector="Consumer Staples", industry="Packaged Foods", notes="Defensive Europe large-cap seed.", primary_data_provider_symbol="NESN.SW", provider_symbol_aliases=("NESN.SW",), provider_symbol_status="verified", source_identity_status="provider_symbol_verified", source_identity_notes="Single SIX alias is treated as deterministic provider mapping for read-only discovery diagnostics."),
     _asset("AAPL", display_name="Apple", region="US", country="United States", exchange="NASDAQ", currency="USD", sector="Technology", industry="Consumer Electronics", notes="US mega-cap leadership anchor."),
     _asset("MSFT", display_name="Microsoft", region="US", country="United States", exchange="NASDAQ", currency="USD", sector="Technology", industry="Software", notes="US mega-cap software anchor."),
     _asset("NVDA", display_name="NVIDIA", region="US", country="United States", exchange="NASDAQ", currency="USD", sector="Technology", industry="Semiconductors", notes="US semiconductor momentum seed."),
@@ -407,15 +407,38 @@ def source_identity_diagnostics() -> list[dict[str, object]]:
                 "canonical_symbol": asset.symbol,
                 "canonical_instrument_id": asset.canonical_instrument_id,
                 "provider_symbol": provider_symbol,
+                "selected_provider_symbol": provider_symbol or (aliases[0] if aliases else None),
                 "candidate_aliases": aliases,
                 "provider_symbol_status": provider_status,
                 "source_identity_status": source_identity_status,
                 "source_identity_notes": str(payload["source_identity_notes"]),
+                "identity_confidence": (
+                    "high"
+                    if provider_status == "verified"
+                    else "medium"
+                    if len(aliases) == 1
+                    else "low"
+                ),
+                "ambiguity_warning": (
+                    ""
+                    if provider_status == "verified"
+                    else "multiple_candidate_aliases"
+                    if len(aliases) > 1
+                    else "candidate_alias_requires_verification"
+                ),
+                "verification_basis": (
+                    "deterministic_catalog_mapping"
+                    if provider_status == "verified"
+                    else "candidate_alias_only"
+                ),
                 "has_primary_provider_symbol": bool(provider_symbol),
                 "has_provider_aliases": bool(aliases),
                 "is_provider_symbol_verified": provider_status == "verified",
                 "is_candidate_alias_only": provider_status
                 == "candidate_alias_requires_verification",
+                "next_action": (
+                    "allow_grid_join" if provider_status == "verified" else "require_alias_verification"
+                ),
                 "source_identity_blocker_class": blocker_class,
             }
         )

--- a/research/qre_controlled_discovery_metric_consistency_audit.py
+++ b/research/qre_controlled_discovery_metric_consistency_audit.py
@@ -1,0 +1,334 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+from research import production_discovery_catalog as catalog
+
+
+REPORT_KIND: Final[str] = "qre_controlled_discovery_metric_consistency_audit"
+SCHEMA_VERSION: Final[str] = "1.0"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_controlled_discovery_metric_consistency_audit")
+LATEST_NAME: Final[str] = "latest.json"
+OPERATOR_SUMMARY_NAME: Final[str] = "operator_summary.md"
+WRITE_PREFIX: Final[str] = "logs/qre_controlled_discovery_metric_consistency_audit/"
+GRID_RUNS_DIR: Final[Path] = Path("research/controlled_discovery_grid_runs")
+
+
+def _table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> str:
+    head = "| " + " | ".join(headers) + " |"
+    divider = "| " + " | ".join(["---"] * len(headers)) + " |"
+    body = ["| " + " | ".join(row) + " |" for row in rows]
+    return "\n".join([head, divider, *body])
+
+
+def _coerce_number(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, int | float):
+        return float(value)
+    try:
+        return float(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _load_jsonl(path: Path) -> tuple[list[dict[str, Any]], bool]:
+    if not path.is_file():
+        return [], False
+    rows: list[dict[str, Any]] = []
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            text = line.strip()
+            if not text:
+                continue
+            payload = json.loads(text)
+            if isinstance(payload, dict):
+                rows.append(payload)
+    except (OSError, json.JSONDecodeError):
+        return [], False
+    return rows, True
+
+
+def _latest_rows(rows: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    latest_by_sequence: dict[int, dict[str, Any]] = {}
+    ordered: list[int] = []
+    for row in rows:
+        sequence_number = int(row.get("sequence_number") or 0)
+        if sequence_number not in latest_by_sequence:
+            ordered.append(sequence_number)
+        latest_by_sequence[sequence_number] = dict(row)
+    return [latest_by_sequence[sequence_number] for sequence_number in ordered]
+
+
+def _scan_grid_rows(repo_root: Path) -> list[dict[str, Any]]:
+    root = repo_root / GRID_RUNS_DIR
+    if not root.is_dir():
+        return []
+    rows: list[dict[str, Any]] = []
+    for run_dir in sorted(path for path in root.iterdir() if path.is_dir()):
+        run_rows, ok = _load_jsonl(run_dir / "combination_results.v1.jsonl")
+        if not ok:
+            continue
+        for row in _latest_rows(run_rows):
+            rows.append({**row, "run_id": run_dir.name})
+    rows.sort(
+        key=lambda row: (
+            str(row.get("run_id") or ""),
+            int(row.get("sequence_number") or 0),
+        )
+    )
+    return rows
+
+
+def _basket_index(max_candidates: int) -> dict[tuple[str, str], str]:
+    return {
+        (str(row.get("symbol") or ""), str(row.get("preset_id") or "")): str(row.get("candidate_id") or "")
+        for row in catalog.build_bounded_candidate_basket(max_candidates=max_candidates)
+    }
+
+
+def _classify_row(row: Mapping[str, Any]) -> tuple[str, list[str], str]:
+    trades_raw = row.get("trades_total")
+    oos_raw = row.get("oos_trades")
+    hd_raw = row.get("hd_trades")
+    warnings: list[str] = []
+    if trades_raw not in (None, "") and _coerce_number(trades_raw) is None:
+        return "non_numeric_metric", ["non_numeric_trades_total"], "trades_total is not numeric"
+    if oos_raw not in (None, "") and _coerce_number(oos_raw) is None:
+        return "non_numeric_metric", ["non_numeric_oos_trades"], "oos_trades is not numeric"
+    if hd_raw not in (None, "") and _coerce_number(hd_raw) is None:
+        return "non_numeric_metric", ["non_numeric_hd_trades"], "hd_trades is not numeric"
+
+    trades_total = _coerce_number(trades_raw)
+    oos_trades = _coerce_number(oos_raw)
+    hd_trades = _coerce_number(hd_raw)
+    scope_hint = str(row.get("metric_scope_note") or row.get("aggregation_scope_hint") or "")
+
+    if trades_total is None and (oos_trades is not None or hd_trades is not None):
+        return "missing_total_trades", ["missing_total_trades"], "trades_total is missing"
+    if oos_trades is None and trades_total is not None:
+        return "missing_oos_trades", ["missing_oos_trades"], "oos_trades is missing"
+    if trades_total is None and oos_trades is None:
+        return "unknown_fail_closed", ["no_trade_metrics_present"], "trade metrics missing"
+    if scope_hint == "aggregation_scope_mismatch":
+        warnings.append("aggregation_scope_mismatch")
+        return (
+            "aggregation_scope_mismatch",
+            warnings,
+            "explicit aggregation scope hint prevents clean interpretation",
+        )
+    if (
+        trades_total is not None
+        and oos_trades is not None
+        and oos_trades > trades_total + 0.5
+    ):
+        warnings.append("oos_trades_exceeds_trades_total")
+        return (
+            "inconsistent_oos_gt_total",
+            warnings,
+            "oos_trades exceeds trades_total and cannot count as clean evidence",
+        )
+    return "clean_consistent", warnings, "trade metrics are internally consistent"
+
+
+def build_metric_consistency_audit(
+    *,
+    repo_root: Path = Path("."),
+    max_candidates: int = 15,
+) -> dict[str, Any]:
+    rows = _scan_grid_rows(repo_root)
+    basket_ids = _basket_index(max_candidates)
+    audit_rows: list[dict[str, Any]] = []
+    counts: Counter[str] = Counter()
+    affected_symbols: set[str] = set()
+    affected_presets: set[str] = set()
+    affected_baskets: set[str] = set()
+    for row in rows:
+        symbol = str(row.get("instrument_symbol") or "")
+        preset = str(row.get("behavior_preset_id") or "")
+        classification, warnings, explanation = _classify_row(row)
+        counts.update([classification])
+        if classification != "clean_consistent":
+            affected_symbols.add(symbol)
+            affected_presets.add(preset)
+            basket_id = basket_ids.get((symbol, preset))
+            if basket_id:
+                affected_baskets.add(basket_id)
+        audit_rows.append(
+            {
+                "run_id": str(row.get("run_id") or ""),
+                "sequence_number": int(row.get("sequence_number") or 0),
+                "instrument_symbol": symbol,
+                "behavior_preset_id": preset,
+                "trades_total": row.get("trades_total"),
+                "oos_trades": row.get("oos_trades"),
+                "hd_trades": row.get("hd_trades"),
+                "classification": classification,
+                "warnings": warnings,
+                "explanation": explanation,
+                "no_alpha_interpretation": classification != "clean_consistent",
+                "affected_basket_ids": [basket_ids[(symbol, preset)]]
+                if (symbol, preset) in basket_ids
+                else [],
+            }
+        )
+    audit_rows.sort(
+        key=lambda row: (
+            0 if row["classification"] != "clean_consistent" else 1,
+            str(row["instrument_symbol"]),
+            str(row["behavior_preset_id"]),
+            int(row["sequence_number"]),
+        )
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "summary": {
+            "total_rows_checked": len(audit_rows),
+            "rows_consistent": counts.get("clean_consistent", 0),
+            "rows_inconsistent": len(audit_rows) - counts.get("clean_consistent", 0),
+            "inconsistent_oos_gt_total_count": counts.get("inconsistent_oos_gt_total", 0),
+            "aggregation_scope_mismatch_count": counts.get("aggregation_scope_mismatch", 0),
+            "no_alpha_interpretation_count": sum(
+                bool(row["no_alpha_interpretation"]) for row in audit_rows
+            ),
+            "affected_symbols": sorted(affected_symbols),
+            "affected_presets": sorted(affected_presets),
+            "affected_baskets": sorted(affected_baskets),
+            "top_inconsistent_rows": [
+                {
+                    "instrument_symbol": row["instrument_symbol"],
+                    "behavior_preset_id": row["behavior_preset_id"],
+                    "classification": row["classification"],
+                    "trades_total": row["trades_total"],
+                    "oos_trades": row["oos_trades"],
+                }
+                for row in audit_rows
+                if row["classification"] != "clean_consistent"
+            ][:10],
+            "exact_next_action": "inspect_metric_consistency",
+            "operator_summary": (
+                "Controlled discovery metric audit classifies whether trade counts are clean, "
+                "scope-mismatched, or inconsistent. Inconsistent rows remain diagnostic-only and "
+                "cannot be treated as clean OOS evidence."
+            ),
+        },
+        "rows": audit_rows,
+        "safety_invariants": {
+            "read_only": True,
+            "mutates_frozen_contracts": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+            "promotion_forbidden": True,
+        },
+    }
+
+
+def render_operator_summary(report: Mapping[str, Any]) -> str:
+    summary = report.get("summary") or {}
+    rows = report.get("rows") if isinstance(report.get("rows"), list) else []
+    count_table = _table(
+        ["Field", "Count"],
+        [
+            ["total rows checked", str(summary.get("total_rows_checked") or 0)],
+            ["rows consistent", str(summary.get("rows_consistent") or 0)],
+            ["rows inconsistent", str(summary.get("rows_inconsistent") or 0)],
+            [
+                "inconsistent oos > total",
+                str(summary.get("inconsistent_oos_gt_total_count") or 0),
+            ],
+            [
+                "aggregation scope mismatch",
+                str(summary.get("aggregation_scope_mismatch_count") or 0),
+            ],
+            [
+                "no alpha interpretation",
+                str(summary.get("no_alpha_interpretation_count") or 0),
+            ],
+        ],
+    )
+    row_table = _table(
+        ["Instrument", "Preset", "Trades total", "OOS trades", "HD trades", "Classification", "Warnings"],
+        [
+            [
+                str(row.get("instrument_symbol") or ""),
+                str(row.get("behavior_preset_id") or ""),
+                str(row.get("trades_total") or ""),
+                str(row.get("oos_trades") or ""),
+                str(row.get("hd_trades") or ""),
+                str(row.get("classification") or ""),
+                ", ".join(str(value) for value in row.get("warnings") or []) or "-",
+            ]
+            for row in rows
+        ],
+    )
+    return "\n".join(
+        [
+            "# QRE Controlled Discovery Metric Consistency Audit",
+            "",
+            "## 1. Korte conclusie",
+            f"- {summary.get('operator_summary') or ''}",
+            "",
+            "## 2. Aggregate counts",
+            count_table,
+            "",
+            "## 3. Affected rows",
+            row_table,
+        ]
+    )
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(
+            f"qre_controlled_discovery_metric_consistency_audit: refusing write outside allowlist: {path!r}"
+        )
+
+
+def write_outputs(
+    report: Mapping[str, Any],
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = Path("."),
+) -> dict[str, str]:
+    base = repo_root / output_dir
+    base.mkdir(parents=True, exist_ok=True)
+    latest = base / LATEST_NAME
+    summary_path = base / OPERATOR_SUMMARY_NAME
+    for target in (latest, summary_path):
+        _validate_write_target(target)
+    tmp_json = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp_json, latest)
+    tmp_summary = summary_path.with_suffix(summary_path.suffix + ".tmp")
+    tmp_summary.write_text(render_operator_summary(report) + "\n", encoding="utf-8")
+    os.replace(tmp_summary, summary_path)
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "operator_summary": summary_path.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_controlled_discovery_metric_consistency_audit",
+        description="Audit trade-metric consistency for controlled discovery grid rows.",
+    )
+    parser.add_argument("--max-candidates", type=int, default=15)
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    report = build_metric_consistency_audit(max_candidates=args.max_candidates)
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/research/qre_controlled_discovery_preset_executability.py
+++ b/research/qre_controlled_discovery_preset_executability.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+from research import controlled_discovery_grid
+from research import controlled_discovery_grid_execution as execution
+from research import production_discovery_catalog as catalog
+
+
+REPORT_KIND: Final[str] = "qre_controlled_discovery_preset_executability"
+SCHEMA_VERSION: Final[str] = "1.0"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_controlled_discovery_preset_executability")
+LATEST_NAME: Final[str] = "latest.json"
+OPERATOR_SUMMARY_NAME: Final[str] = "operator_summary.md"
+WRITE_PREFIX: Final[str] = "logs/qre_controlled_discovery_preset_executability/"
+
+
+def _table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> str:
+    head = "| " + " | ".join(headers) + " |"
+    divider = "| " + " | ".join(["---"] * len(headers)) + " |"
+    body = ["| " + " | ".join(row) + " |" for row in rows]
+    return "\n".join([head, divider, *body])
+
+
+def _basket_index(max_candidates: int) -> dict[tuple[str, str], str]:
+    return {
+        (str(row.get("symbol") or ""), str(row.get("preset_id") or "")): str(row.get("candidate_id") or "")
+        for row in catalog.build_bounded_candidate_basket(max_candidates=max_candidates)
+    }
+
+
+def _classify_row(
+    row: Mapping[str, Any],
+    mapping: execution.GridExecutionMapping,
+) -> tuple[str, str]:
+    source_identity_status = str(row.get("source_identity_status") or "")
+    provider_symbol_status = str(row.get("provider_symbol_status") or "")
+    provider_symbol = row.get("primary_data_provider_symbol")
+    if source_identity_status == "candidate_alias_only":
+        return "source_identity_blocked", "candidate alias remains unresolved for discovery use"
+    if not provider_symbol:
+        return "provider_symbol_unresolved", "primary provider symbol missing"
+    if mapping.status == "ready":
+        return "executable", "existing executable mapping is available"
+    blocker = str(mapping.blocker_class or "")
+    if blocker == execution.BLOCKER_MISSING_METADATA:
+        return "mapping_missing", "required mapping metadata is missing"
+    if blocker == execution.BLOCKER_REGION_MISMATCH:
+        return "region_constraint_mismatch", "preset mapping excludes the asset region"
+    if blocker == execution.BLOCKER_ASSET_CLASS_MISMATCH:
+        return "asset_class_constraint_mismatch", "preset mapping excludes the asset class"
+    if blocker == "preset_not_executable":
+        return "intentionally_non_executable", "preset is seed-only and has no executable mapping"
+    if blocker == execution.BLOCKER_UNSUPPORTED_MAPPING:
+        return "mapping_missing", "no supported executable mapping exists"
+    if blocker == execution.BLOCKER_SAFETY_VIOLATION:
+        return "unknown_fail_closed", "safety invariants block execution"
+    if not row.get("timeframe"):
+        return "timeframe_constraint_mismatch", "timeframe metadata missing"
+    return "unsupported_combination", "combination stays blocked by bounded mapping rules"
+
+
+def build_preset_executability_report(*, max_candidates: int = 15) -> dict[str, Any]:
+    grid_rows = controlled_discovery_grid.build_controlled_discovery_grid()
+    basket_ids = _basket_index(max_candidates)
+    rows: list[dict[str, Any]] = []
+    counts: Counter[str] = Counter()
+    affected_assets: set[str] = set()
+    affected_presets: set[str] = set()
+    for row in grid_rows:
+        mapping = execution.map_grid_row_to_execution(dict(row))
+        classification, explanation = _classify_row(row, mapping)
+        counts.update([classification])
+        symbol = str(row.get("instrument_symbol") or "")
+        preset = str(row.get("behavior_preset_id") or "")
+        if classification != "executable":
+            affected_assets.add(symbol)
+            affected_presets.add(preset)
+        rows.append(
+            {
+                "sequence_number": int(row.get("sequence_number") or 0),
+                "instrument_symbol": symbol,
+                "behavior_preset_id": preset,
+                "classification": classification,
+                "mapping_status": mapping.status,
+                "blocker_class": mapping.blocker_class,
+                "region": row.get("region"),
+                "asset_class": row.get("asset_class"),
+                "timeframe": row.get("timeframe"),
+                "provider_symbol_status": row.get("provider_symbol_status"),
+                "source_identity_status": row.get("source_identity_status"),
+                "primary_data_provider_symbol": row.get("primary_data_provider_symbol"),
+                "affected_basket_ids": [basket_ids[(symbol, preset)]]
+                if (symbol, preset) in basket_ids
+                else [],
+                "explanation": explanation,
+            }
+        )
+    rows.sort(
+        key=lambda row: (
+            0 if row["classification"] != "executable" else 1,
+            str(row["classification"]),
+            str(row["instrument_symbol"]),
+            str(row["behavior_preset_id"]),
+        )
+    )
+    top_mapping_gaps = [
+        {
+            "instrument_symbol": row["instrument_symbol"],
+            "behavior_preset_id": row["behavior_preset_id"],
+            "classification": row["classification"],
+        }
+        for row in rows
+        if row["classification"] in {"mapping_missing", "provider_symbol_unresolved", "source_identity_blocked"}
+    ][:10]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "summary": {
+            "total_combinations": len(rows),
+            "executable_count": counts.get("executable", 0),
+            "intentionally_non_executable_count": counts.get("intentionally_non_executable", 0),
+            "mapping_missing_count": counts.get("mapping_missing", 0),
+            "preset_not_executable_count": counts.get("preset_not_executable", 0),
+            "region_constraint_mismatch_count": counts.get("region_constraint_mismatch", 0),
+            "asset_class_constraint_mismatch_count": counts.get("asset_class_constraint_mismatch", 0),
+            "unsupported_combination_count": counts.get("unsupported_combination", 0),
+            "unknown_fail_closed_count": counts.get("unknown_fail_closed", 0),
+            "affected_presets": sorted(affected_presets),
+            "affected_assets": sorted(affected_assets),
+            "top_mapping_gaps": top_mapping_gaps,
+            "next_action_counts": dict(
+                sorted(
+                    Counter(
+                        "keep_blocked" if row["classification"] != "executable" else "already_bounded"
+                        for row in rows
+                    ).items()
+                )
+            ),
+            "operator_summary": (
+                "Preset executability classification shows whether a discovery-grid row is already "
+                "supported by the bounded execution adapter or safely blocked by seed-only, region, "
+                "asset-class, timeframe, or source-identity constraints."
+            ),
+        },
+        "rows": rows,
+        "safety_invariants": {
+            "read_only": True,
+            "registry_mutation": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+            "promotion_forbidden": True,
+        },
+    }
+
+
+def render_operator_summary(report: Mapping[str, Any]) -> str:
+    summary = report.get("summary") or {}
+    rows = report.get("rows") if isinstance(report.get("rows"), list) else []
+    count_table = _table(
+        ["Field", "Count"],
+        [
+            ["total combinations", str(summary.get("total_combinations") or 0)],
+            ["executable", str(summary.get("executable_count") or 0)],
+            [
+                "intentionally non-executable",
+                str(summary.get("intentionally_non_executable_count") or 0),
+            ],
+            ["mapping missing", str(summary.get("mapping_missing_count") or 0)],
+            [
+                "region constraint mismatch",
+                str(summary.get("region_constraint_mismatch_count") or 0),
+            ],
+            [
+                "asset class constraint mismatch",
+                str(summary.get("asset_class_constraint_mismatch_count") or 0),
+            ],
+            [
+                "unsupported combination",
+                str(summary.get("unsupported_combination_count") or 0),
+            ],
+        ],
+    )
+    row_table = _table(
+        ["Instrument", "Preset", "Classification", "Mapping status", "Blocker", "Explanation"],
+        [
+            [
+                str(row.get("instrument_symbol") or ""),
+                str(row.get("behavior_preset_id") or ""),
+                str(row.get("classification") or ""),
+                str(row.get("mapping_status") or ""),
+                str(row.get("blocker_class") or "-"),
+                str(row.get("explanation") or ""),
+            ]
+            for row in rows
+        ],
+    )
+    return "\n".join(
+        [
+            "# QRE Controlled Discovery Preset Executability",
+            "",
+            "## 1. Korte conclusie",
+            f"- {summary.get('operator_summary') or ''}",
+            "",
+            "## 2. Aggregate counts",
+            count_table,
+            "",
+            "## 3. Row classification",
+            row_table,
+        ]
+    )
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(
+            f"qre_controlled_discovery_preset_executability: refusing write outside allowlist: {path!r}"
+        )
+
+
+def write_outputs(
+    report: Mapping[str, Any],
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = Path("."),
+) -> dict[str, str]:
+    base = repo_root / output_dir
+    base.mkdir(parents=True, exist_ok=True)
+    latest = base / LATEST_NAME
+    summary_path = base / OPERATOR_SUMMARY_NAME
+    for target in (latest, summary_path):
+        _validate_write_target(target)
+    tmp_json = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp_json, latest)
+    tmp_summary = summary_path.with_suffix(summary_path.suffix + ".tmp")
+    tmp_summary.write_text(render_operator_summary(report) + "\n", encoding="utf-8")
+    os.replace(tmp_summary, summary_path)
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "operator_summary": summary_path.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_controlled_discovery_preset_executability",
+        description="Classify discovery-grid preset executability without activating execution.",
+    )
+    parser.add_argument("--max-candidates", type=int, default=15)
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    report = build_preset_executability_report(max_candidates=args.max_candidates)
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/research/qre_controlled_discovery_survivor_stage_attribution.py
+++ b/research/qre_controlled_discovery_survivor_stage_attribution.py
@@ -1,0 +1,404 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+from research import qre_controlled_discovery_metric_consistency_audit as metric_audit
+from research import qre_controlled_discovery_preset_executability as executability
+
+
+REPORT_KIND: Final[str] = "qre_controlled_discovery_survivor_stage_attribution"
+SCHEMA_VERSION: Final[str] = "1.0"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_controlled_discovery_survivor_stage_attribution")
+LATEST_NAME: Final[str] = "latest.json"
+OPERATOR_SUMMARY_NAME: Final[str] = "operator_summary.md"
+WRITE_PREFIX: Final[str] = "logs/qre_controlled_discovery_survivor_stage_attribution/"
+GRID_RUNS_DIR: Final[Path] = Path("research/controlled_discovery_grid_runs")
+METRIC_AUDIT_PATH: Final[Path] = Path("logs/qre_controlled_discovery_metric_consistency_audit/latest.json")
+PRESET_EXECUTABILITY_PATH: Final[Path] = Path("logs/qre_controlled_discovery_preset_executability/latest.json")
+DEGENERATE_STAGE_CLASSES: Final[set[str]] = {
+    "no_candidates_generated",
+    "screening_stage_no_survivors",
+    "oos_stage_no_survivors",
+    "criteria_stage_no_survivors",
+    "metric_consistency_stage_no_survivors",
+    "source_identity_stage_blocked",
+    "preset_mapping_stage_blocked",
+    "artifact_missing_stage_blocked",
+    "adapter_join_stage_blocked",
+    "degenerate_legitimate_no_survivors",
+    "unknown_fail_closed",
+}
+
+
+def _table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> str:
+    head = "| " + " | ".join(headers) + " |"
+    divider = "| " + " | ".join(["---"] * len(headers)) + " |"
+    body = ["| " + " | ".join(row) + " |" for row in rows]
+    return "\n".join([head, divider, *body])
+
+
+def _load_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.is_file():
+        return []
+    rows: list[dict[str, Any]] = []
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            text = line.strip()
+            if not text:
+                continue
+            payload = json.loads(text)
+            if isinstance(payload, dict):
+                rows.append(payload)
+    except (OSError, json.JSONDecodeError):
+        return []
+    return rows
+
+
+def _latest_rows(rows: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    latest_by_sequence: dict[int, dict[str, Any]] = {}
+    ordered_sequences: list[int] = []
+    for row in rows:
+        sequence_number = int(row.get("sequence_number") or 0)
+        if sequence_number not in latest_by_sequence:
+            ordered_sequences.append(sequence_number)
+        latest_by_sequence[sequence_number] = dict(row)
+    return [latest_by_sequence[sequence_number] for sequence_number in ordered_sequences]
+
+
+def _scan_rows(repo_root: Path) -> list[dict[str, Any]]:
+    root = repo_root / GRID_RUNS_DIR
+    if not root.is_dir():
+        return []
+    rows: list[dict[str, Any]] = []
+    for run_dir in sorted(path for path in root.iterdir() if path.is_dir()):
+        run_rows = _load_jsonl(run_dir / "combination_results.v1.jsonl")
+        for row in _latest_rows(run_rows):
+            rows.append({**row, "run_id": run_dir.name})
+    rows.sort(
+        key=lambda row: (
+            str(row.get("run_id") or ""),
+            int(row.get("sequence_number") or 0),
+        )
+    )
+    return rows
+
+
+def _execution_sidecar(repo_root: Path, row: Mapping[str, Any]) -> dict[str, Any] | None:
+    artifact_paths = row.get("artifact_paths")
+    if isinstance(artifact_paths, Mapping):
+        execution_path = artifact_paths.get("execution_result")
+        if isinstance(execution_path, str) and execution_path:
+            payload = _load_json(repo_root / execution_path)
+            if payload:
+                return payload
+    result_path = row.get("result_path")
+    if isinstance(result_path, str) and result_path:
+        return _load_json(repo_root / result_path)
+    return None
+
+
+def _metric_index(repo_root: Path) -> dict[tuple[str, str], dict[str, Any]]:
+    report = _load_json(repo_root / METRIC_AUDIT_PATH) or metric_audit.build_metric_consistency_audit(
+        repo_root=repo_root
+    )
+    rows = report.get("rows") if isinstance(report.get("rows"), list) else []
+    return {
+        (str(row.get("instrument_symbol") or ""), str(row.get("behavior_preset_id") or "")): row
+        for row in rows
+    }
+
+
+def _preset_index(repo_root: Path) -> dict[tuple[str, str], dict[str, Any]]:
+    report = _load_json(repo_root / PRESET_EXECUTABILITY_PATH) or executability.build_preset_executability_report(
+        max_candidates=15
+    )
+    rows = report.get("rows") if isinstance(report.get("rows"), list) else []
+    return {
+        (str(row.get("instrument_symbol") or ""), str(row.get("behavior_preset_id") or "")): row
+        for row in rows
+    }
+
+
+def _classify_stage(
+    *,
+    row: Mapping[str, Any],
+    sidecar: Mapping[str, Any] | None,
+    metric_row: Mapping[str, Any] | None,
+    preset_row: Mapping[str, Any] | None,
+) -> tuple[str, str]:
+    hint = str(row.get("degenerate_stage_hint") or "")
+    if hint in DEGENERATE_STAGE_CLASSES:
+        return hint, "explicit degenerate stage hint present"
+
+    preset_classification = str((preset_row or {}).get("classification") or "")
+    if preset_classification in {"source_identity_blocked", "provider_symbol_unresolved"}:
+        return "source_identity_stage_blocked", "source identity prevented survivorship"
+    if preset_classification in {
+        "mapping_missing",
+        "intentionally_non_executable",
+        "region_constraint_mismatch",
+        "asset_class_constraint_mismatch",
+        "timeframe_constraint_mismatch",
+        "unsupported_combination",
+    }:
+        return "preset_mapping_stage_blocked", "preset mapping prevented survivorship"
+
+    metric_classification = str((metric_row or {}).get("classification") or "")
+    if metric_classification in {
+        "inconsistent_oos_gt_total",
+        "missing_total_trades",
+        "missing_oos_trades",
+        "non_numeric_metric",
+        "aggregation_scope_mismatch",
+    }:
+        return "metric_consistency_stage_no_survivors", "metric audit prevents clean survivor interpretation"
+
+    if sidecar is None:
+        return "artifact_missing_stage_blocked", "execution sidecar is missing"
+
+    observation = sidecar.get("observation") if isinstance(sidecar.get("observation"), Mapping) else {}
+    artifact_snapshot = (
+        sidecar.get("artifact_snapshot") if isinstance(sidecar.get("artifact_snapshot"), Mapping) else {}
+    )
+    matching_rows = (
+        artifact_snapshot.get("matching_screening_rows")
+        if isinstance(artifact_snapshot.get("matching_screening_rows"), list)
+        else []
+    )
+    candidate_count = int(observation.get("candidate_count") or 0)
+
+    join_status = str(sidecar.get("adapter_join_status") or "")
+    if join_status == "blocked":
+        return "adapter_join_stage_blocked", "adapter join remained blocked despite available artifacts"
+    if candidate_count == 0 and not matching_rows:
+        return "no_candidates_generated", "execution completed without any matching candidate rows"
+    if not matching_rows:
+        return "screening_stage_no_survivors", "screening produced no surviving rows"
+
+    validation_statuses = {
+        str((item.get("validation_evidence") or {}).get("status") or "")
+        for item in matching_rows
+        if isinstance(item, Mapping)
+    }
+    blocked_by = {
+        str(blocker)
+        for item in matching_rows
+        if isinstance(item, Mapping)
+        for blocker in list((item.get("promotion_guard") or {}).get("blocked_by") or [])
+    }
+    stage_results = {
+        str(item.get("stage_result") or "")
+        for item in matching_rows
+        if isinstance(item, Mapping)
+    }
+    if blocked_by:
+        return "criteria_stage_no_survivors", "criteria filters removed all surviving rows"
+    if validation_statuses & {"no_oos_trades", "insufficient_oos_trades"}:
+        return "oos_stage_no_survivors", "OOS validation removed all surviving rows"
+    if "screening_reject" in stage_results:
+        return "screening_stage_no_survivors", "screening rejected all rows"
+    return "degenerate_legitimate_no_survivors", "no explicit earlier stage blocker was found"
+
+
+def build_survivor_stage_attribution(*, repo_root: Path = Path(".")) -> dict[str, Any]:
+    grid_rows = _scan_rows(repo_root)
+    metric_index = _metric_index(repo_root)
+    preset_index = _preset_index(repo_root)
+    rows: list[dict[str, Any]] = []
+    stage_counts: Counter[str] = Counter()
+    affected_symbols: set[str] = set()
+    affected_presets: set[str] = set()
+    affected_baskets: set[str] = set()
+
+    for row in grid_rows:
+        blocker_class = str(row.get("blocker_class") or "")
+        hint = str(row.get("degenerate_stage_hint") or "")
+        if blocker_class != "degenerate_no_survivors" and hint not in DEGENERATE_STAGE_CLASSES:
+            continue
+        symbol = str(row.get("instrument_symbol") or "")
+        preset = str(row.get("behavior_preset_id") or "")
+        sidecar = _execution_sidecar(repo_root, row)
+        metric_row = metric_index.get((symbol, preset))
+        preset_row = preset_index.get((symbol, preset))
+        stage_classification, explanation = _classify_stage(
+            row=row,
+            sidecar=sidecar,
+            metric_row=metric_row,
+            preset_row=preset_row,
+        )
+        stage_counts.update([stage_classification])
+        affected_symbols.add(symbol)
+        affected_presets.add(preset)
+        for basket_id in list((metric_row or {}).get("affected_basket_ids") or []) + list(
+            (preset_row or {}).get("affected_basket_ids") or []
+        ):
+            if basket_id:
+                affected_baskets.add(str(basket_id))
+        rows.append(
+            {
+                "run_id": str(row.get("run_id") or ""),
+                "sequence_number": int(row.get("sequence_number") or 0),
+                "instrument_symbol": symbol,
+                "behavior_preset_id": preset,
+                "stage_classification": stage_classification,
+                "explanation": explanation,
+                "metric_classification": str((metric_row or {}).get("classification") or ""),
+                "preset_classification": str((preset_row or {}).get("classification") or ""),
+                "affected_basket_ids": sorted(affected_baskets),
+            }
+        )
+    rows.sort(
+        key=lambda row: (
+            str(row["stage_classification"]),
+            str(row["instrument_symbol"]),
+            str(row["behavior_preset_id"]),
+            int(row["sequence_number"]),
+        )
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "summary": {
+            "total_degenerate_rows": len(rows),
+            "attributed_degenerate_rows": sum(
+                row["stage_classification"] != "unknown_fail_closed" for row in rows
+            ),
+            "unknown_degenerate_rows": stage_counts.get("unknown_fail_closed", 0),
+            "stage_counts": dict(sorted(stage_counts.items())),
+            "affected_symbols": sorted(affected_symbols),
+            "affected_presets": sorted(affected_presets),
+            "affected_baskets": sorted(affected_baskets),
+            "top_stage_blockers": [
+                {"stage_classification": key, "count": value}
+                for key, value in stage_counts.most_common(10)
+            ],
+            "next_action_counts": dict(
+                sorted(
+                    Counter(
+                        "inspect_stage_blocker"
+                        if row["stage_classification"] != "degenerate_legitimate_no_survivors"
+                        else "keep_blocked"
+                        for row in rows
+                    ).items()
+                )
+            ),
+            "operator_summary": (
+                "Degenerate no-survivor attribution shows which stage removed the remaining rows "
+                "instead of collapsing every case into a single coarse blocker."
+            ),
+        },
+        "rows": rows,
+        "safety_invariants": {
+            "read_only": True,
+            "mutates_frozen_contracts": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+            "promotion_forbidden": True,
+        },
+    }
+
+
+def render_operator_summary(report: Mapping[str, Any]) -> str:
+    summary = report.get("summary") or {}
+    rows = report.get("rows") if isinstance(report.get("rows"), list) else []
+    count_table = _table(
+        ["Field", "Count"],
+        [
+            ["total degenerate rows", str(summary.get("total_degenerate_rows") or 0)],
+            ["attributed", str(summary.get("attributed_degenerate_rows") or 0)],
+            ["unknown", str(summary.get("unknown_degenerate_rows") or 0)],
+        ],
+    )
+    row_table = _table(
+        ["Instrument", "Preset", "Stage classification", "Metric", "Preset", "Explanation"],
+        [
+            [
+                str(row.get("instrument_symbol") or ""),
+                str(row.get("behavior_preset_id") or ""),
+                str(row.get("stage_classification") or ""),
+                str(row.get("metric_classification") or "-"),
+                str(row.get("preset_classification") or "-"),
+                str(row.get("explanation") or ""),
+            ]
+            for row in rows
+        ],
+    )
+    return "\n".join(
+        [
+            "# QRE Controlled Discovery Survivor Stage Attribution",
+            "",
+            "## 1. Korte conclusie",
+            f"- {summary.get('operator_summary') or ''}",
+            "",
+            "## 2. Aggregate counts",
+            count_table,
+            "",
+            "## 3. Stage attribution",
+            row_table,
+        ]
+    )
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(
+            f"qre_controlled_discovery_survivor_stage_attribution: refusing write outside allowlist: {path!r}"
+        )
+
+
+def write_outputs(
+    report: Mapping[str, Any],
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = Path("."),
+) -> dict[str, str]:
+    base = repo_root / output_dir
+    base.mkdir(parents=True, exist_ok=True)
+    latest = base / LATEST_NAME
+    summary_path = base / OPERATOR_SUMMARY_NAME
+    for target in (latest, summary_path):
+        _validate_write_target(target)
+    tmp_json = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp_json, latest)
+    tmp_summary = summary_path.with_suffix(summary_path.suffix + ".tmp")
+    tmp_summary.write_text(render_operator_summary(report) + "\n", encoding="utf-8")
+    os.replace(tmp_summary, summary_path)
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "operator_summary": summary_path.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_controlled_discovery_survivor_stage_attribution",
+        description="Attribute degenerate no-survivor rows to explicit research stages.",
+    )
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    report = build_survivor_stage_attribution()
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/research/qre_discovery_basket_grid_evidence_materialization.py
+++ b/research/qre_discovery_basket_grid_evidence_materialization.py
@@ -237,7 +237,14 @@ def _exact_blocker_category(
         return "grid_artifact_missing"
     if str(basket_row.get("source_identity_status") or "") == "candidate_alias_only":
         return "source_identity_blocked"
-    if metric_status == "metric_inconsistent":
+    if metric_status in {
+        "metric_inconsistent",
+        "inconsistent_oos_gt_total",
+        "missing_total_trades",
+        "missing_oos_trades",
+        "non_numeric_metric",
+        "aggregation_scope_mismatch",
+    }:
         return "metric_inconsistent"
     if preset_classification in {
         "mapping_missing",

--- a/research/qre_discovery_basket_grid_evidence_materialization.py
+++ b/research/qre_discovery_basket_grid_evidence_materialization.py
@@ -1,0 +1,755 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+from reporting import qre_controlled_discovery_grid_analysis as grid_analysis
+from research import production_discovery_catalog as catalog
+from research import qre_real_basket_evidence_coverage as coverage
+
+
+REPORT_KIND: Final[str] = "qre_discovery_basket_grid_evidence_materialization"
+SCHEMA_VERSION: Final[str] = "1.0"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_discovery_basket_grid_evidence_materialization")
+LATEST_NAME: Final[str] = "latest.json"
+OPERATOR_SUMMARY_NAME: Final[str] = "operator_summary.md"
+WRITE_PREFIX: Final[str] = "logs/qre_discovery_basket_grid_evidence_materialization/"
+GRID_RUNS_DIR: Final[Path] = Path("research/controlled_discovery_grid_runs")
+METRIC_AUDIT_PATH: Final[Path] = Path(
+    "logs/qre_controlled_discovery_metric_consistency_audit/latest.json"
+)
+PRESET_EXECUTABILITY_PATH: Final[Path] = Path(
+    "logs/qre_controlled_discovery_preset_executability/latest.json"
+)
+SURVIVOR_STAGE_PATH: Final[Path] = Path(
+    "logs/qre_controlled_discovery_survivor_stage_attribution/latest.json"
+)
+
+
+def _table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> str:
+    head = "| " + " | ".join(headers) + " |"
+    divider = "| " + " | ".join(["---"] * len(headers)) + " |"
+    body = ["| " + " | ".join(row) + " |" for row in rows]
+    return "\n".join([head, divider, *body])
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _load_jsonl(path: Path) -> tuple[list[dict[str, Any]], str | None]:
+    if not path.is_file():
+        return [], "grid_artifact_missing"
+    rows: list[dict[str, Any]] = []
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            text = line.strip()
+            if not text:
+                continue
+            payload = json.loads(text)
+            if isinstance(payload, dict):
+                rows.append(payload)
+    except (OSError, json.JSONDecodeError):
+        return [], "grid_artifact_missing"
+    return rows, None
+
+
+def _latest_result_rows(rows: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    latest_by_sequence: dict[int, dict[str, Any]] = {}
+    ordered_sequences: list[int] = []
+    for row in rows:
+        sequence_number = int(row.get("sequence_number") or 0)
+        if sequence_number not in latest_by_sequence:
+            ordered_sequences.append(sequence_number)
+        latest_by_sequence[sequence_number] = dict(row)
+    return [latest_by_sequence[sequence_number] for sequence_number in ordered_sequences]
+
+
+def _load_optional_rows(path: Path, field: str) -> list[dict[str, Any]]:
+    payload = _read_json(path)
+    rows = payload.get(field) if isinstance(payload, Mapping) else None
+    return [dict(row) for row in rows] if isinstance(rows, list) else []
+
+
+def _audit_indexes(repo_root: Path) -> dict[str, dict[tuple[str, str], dict[str, Any]]]:
+    metric_rows = _load_optional_rows(repo_root / METRIC_AUDIT_PATH, "rows")
+    preset_rows = _load_optional_rows(repo_root / PRESET_EXECUTABILITY_PATH, "rows")
+    survivor_rows = _load_optional_rows(repo_root / SURVIVOR_STAGE_PATH, "rows")
+    return {
+        "metric": {
+            (str(row.get("instrument_symbol") or ""), str(row.get("behavior_preset_id") or "")): row
+            for row in metric_rows
+        },
+        "preset": {
+            (str(row.get("instrument_symbol") or ""), str(row.get("behavior_preset_id") or "")): row
+            for row in preset_rows
+        },
+        "survivor": {
+            (str(row.get("instrument_symbol") or ""), str(row.get("behavior_preset_id") or "")): row
+            for row in survivor_rows
+        },
+    }
+
+
+def _coverage_indexes(
+    row: Mapping[str, Any],
+) -> tuple[set[str], set[str], str, str, set[str]]:
+    symbol = str(row.get("symbol") or "")
+    provider_symbol = str(row.get("provider_symbol") or "")
+    preset_id = str(row.get("preset_id") or "")
+    hypothesis_id = str(row.get("hypothesis_id") or "")
+    aliases = {symbol}
+    if provider_symbol:
+        aliases.add(provider_symbol)
+    timeframes = {str(value) for value in row.get("timeframes") or [] if str(value)}
+    return aliases, set(), preset_id, hypothesis_id, timeframes
+
+
+def _match_reasons(
+    basket_row: Mapping[str, Any],
+    grid_row: Mapping[str, Any],
+    *,
+    basket_aliases: Sequence[str],
+) -> tuple[bool, list[str]]:
+    reasons: list[str] = []
+    basket_symbol = str(basket_row.get("symbol") or "")
+    provider_symbol = str(basket_row.get("provider_symbol") or "")
+    preset_id = str(basket_row.get("preset_id") or "")
+    hypothesis_id = str(basket_row.get("hypothesis_id") or "")
+    basket_timeframes = {str(value) for value in basket_row.get("timeframes") or [] if str(value)}
+    grid_symbol = str(grid_row.get("instrument_symbol") or "")
+    grid_provider_symbol = str(grid_row.get("primary_data_provider_symbol") or "")
+    grid_aliases = {str(value) for value in grid_row.get("provider_symbol_aliases") or [] if str(value)}
+
+    if str(grid_row.get("behavior_preset_id") or "") != preset_id:
+        reasons.append("preset_mismatch")
+    if basket_timeframes and str(grid_row.get("timeframe") or "") not in basket_timeframes:
+        reasons.append("timeframe_mismatch")
+    grid_hypothesis = str(grid_row.get("hypothesis_id") or "")
+    if hypothesis_id and grid_hypothesis and grid_hypothesis != hypothesis_id:
+        reasons.append("hypothesis_mismatch")
+
+    symbol_match = False
+    if basket_symbol and basket_symbol == grid_symbol:
+        symbol_match = True
+    elif provider_symbol and provider_symbol == grid_symbol:
+        symbol_match = True
+        reasons.append("matched_via_provider_symbol")
+    elif provider_symbol and provider_symbol == grid_provider_symbol:
+        symbol_match = True
+        reasons.append("matched_via_primary_provider_symbol")
+    elif provider_symbol and provider_symbol in grid_aliases:
+        symbol_match = True
+        reasons.append("matched_via_grid_alias")
+    elif basket_aliases and any(alias == grid_symbol for alias in basket_aliases):
+        symbol_match = True
+        reasons.append("matched_basket_alias_to_grid_symbol")
+    elif basket_aliases and any(alias == grid_provider_symbol for alias in basket_aliases):
+        symbol_match = True
+        reasons.append("matched_basket_alias_to_grid_provider_symbol")
+    elif basket_aliases and any(alias in grid_aliases for alias in basket_aliases):
+        symbol_match = True
+        reasons.append("matched_alias_to_alias")
+    elif basket_symbol and basket_symbol == grid_provider_symbol:
+        symbol_match = True
+        reasons.append("matched_symbol_to_provider_symbol")
+    elif basket_symbol and basket_symbol in grid_aliases:
+        symbol_match = True
+        reasons.append("matched_symbol_to_grid_alias")
+    if not symbol_match:
+        reasons.append("symbol_mismatch")
+    return (not any(reason.endswith("mismatch") for reason in reasons), reasons)
+
+
+def _screening_status(matched_rows: Sequence[Mapping[str, Any]], visible: bool) -> str:
+    if visible:
+        return "visible_in_readiness_loop"
+    if not matched_rows:
+        return "missing"
+    if any(str(row.get("status") or "") == "completed" for row in matched_rows):
+        return "grid_only"
+    return "grid_blocked"
+
+
+def _oos_status(matched_rows: Sequence[Mapping[str, Any]]) -> str:
+    if not matched_rows:
+        return "missing"
+    if any(str(row.get("outcome_class") or "") == "sufficient_oos_evidence" for row in matched_rows):
+        return "sufficient_oos_evidence_present"
+    if any(str(row.get("blocker_class") or "") == "no_oos_evidence" for row in matched_rows):
+        return "no_oos_evidence"
+    if any(str(row.get("status") or "") == "completed" for row in matched_rows):
+        return "completed_without_sufficient_oos"
+    return "blocked_or_skipped"
+
+
+def _candidate_lineage_status(basket_row: Mapping[str, Any]) -> str:
+    counts = basket_row.get("evidence_counts") or {}
+    candidate_rows = int(counts.get("candidate_lineage_rows") or 0)
+    campaign_rows = int(counts.get("campaign_lineage_rows") or 0)
+    if candidate_rows > 0 and campaign_rows > 0:
+        return "visible"
+    if candidate_rows > 0:
+        return "candidate_visible_campaign_missing"
+    if campaign_rows > 0:
+        return "campaign_visible_candidate_missing"
+    return "missing"
+
+
+def _local_metric_status(rows: Sequence[Mapping[str, Any]]) -> tuple[str, list[str]]:
+    warnings: list[str] = []
+    status = "unknown_fail_closed"
+    for row in rows:
+        diagnostic = grid_analysis._derive_row_diagnostics(dict(row))
+        current_status = str(diagnostic.get("metric_consistency_status") or "unknown_fail_closed")
+        current_warnings = [str(value) for value in diagnostic.get("metric_consistency_warnings") or []]
+        if current_status == "inconsistent":
+            return "metric_inconsistent", current_warnings
+        if current_status == "consistent":
+            status = "clean_consistent"
+        warnings.extend(current_warnings)
+    return status, sorted(set(warnings))
+
+
+def _exact_blocker_category(
+    *,
+    basket_row: Mapping[str, Any],
+    matched_rows: Sequence[Mapping[str, Any]],
+    join_failure_reason: str | None,
+    metric_status: str,
+    preset_classification: str | None,
+    survivor_stage: str | None,
+) -> str:
+    if join_failure_reason == "no_grid_run_found":
+        return "no_grid_run_found"
+    if join_failure_reason == "grid_artifact_missing":
+        return "grid_artifact_missing"
+    if str(basket_row.get("source_identity_status") or "") == "candidate_alias_only":
+        return "source_identity_blocked"
+    if metric_status == "metric_inconsistent":
+        return "metric_inconsistent"
+    if preset_classification in {
+        "mapping_missing",
+        "preset_not_executable",
+        "region_constraint_mismatch",
+        "asset_class_constraint_mismatch",
+        "timeframe_constraint_mismatch",
+        "provider_symbol_unresolved",
+        "source_identity_blocked",
+        "unsupported_combination",
+    }:
+        return preset_classification
+    if survivor_stage and survivor_stage not in {
+        "degenerate_legitimate_no_survivors",
+        "unknown_fail_closed",
+    }:
+        return survivor_stage
+    if any(str(row.get("blocker_class") or "") == "degenerate_no_survivors" for row in matched_rows):
+        return "degenerate_no_survivors"
+    if any(str(row.get("outcome_class") or "") == "sufficient_oos_evidence" for row in matched_rows):
+        if any(grid_analysis._derive_row_diagnostics(dict(row)).get("criteria_failure_classes") for row in matched_rows):
+            return "criteria_failed"
+        return "sufficient_oos_but_not_promotion_ready"
+    if any(str(row.get("blocker_class") or "") == "no_oos_evidence" for row in matched_rows):
+        return "no_oos_evidence"
+    if join_failure_reason == "join_key_mismatch":
+        return "join_key_mismatch"
+    if join_failure_reason == "grid_row_match_not_found":
+        return "grid_row_match_not_found"
+    if int((basket_row.get("evidence_counts") or {}).get("candidate_lineage_rows") or 0) == 0:
+        return "candidate_lineage_missing"
+    if int((basket_row.get("evidence_counts") or {}).get("campaign_lineage_rows") or 0) == 0:
+        return "campaign_lineage_missing"
+    if matched_rows:
+        return "evidence_complete_or_near_complete"
+    return "unknown_fail_closed"
+
+
+def _next_action(blocker: str, *, readiness_adapter_gap: bool) -> str:
+    if readiness_adapter_gap:
+        return "bridge_grid_evidence_into_readiness_surfaces"
+    mapping = {
+        "no_grid_run_found": "run_controlled_discovery_grid",
+        "grid_artifact_missing": "restore_grid_run_artifacts",
+        "join_key_mismatch": "inspect_join_key_mapping",
+        "grid_row_match_not_found": "inspect_basket_to_grid_mapping",
+        "source_identity_blocked": "require_identity_resolution",
+        "metric_inconsistent": "inspect_metric_consistency",
+        "preset_not_executable": "keep_blocked",
+        "mapping_missing": "classify_mapping_gap",
+        "region_constraint_mismatch": "keep_blocked",
+        "asset_class_constraint_mismatch": "keep_blocked",
+        "timeframe_constraint_mismatch": "keep_blocked",
+        "provider_symbol_unresolved": "require_identity_resolution",
+        "unsupported_combination": "keep_blocked",
+        "degenerate_no_survivors": "inspect_survivor_stage",
+        "criteria_failed": "review_criteria_failures",
+        "no_oos_evidence": "collect_more_evidence",
+        "candidate_lineage_missing": "materialize_candidate_lineage",
+        "campaign_lineage_missing": "materialize_campaign_lineage",
+        "evidence_complete_or_near_complete": "eligible_for_readonly_routing_review",
+    }
+    return mapping.get(blocker, "keep_fail_closed")
+
+
+def _scan_grid_runs(repo_root: Path) -> tuple[list[dict[str, Any]], int, int, int]:
+    root = repo_root / GRID_RUNS_DIR
+    if not root.is_dir():
+        return [], 0, 0, 0
+    run_dirs = sorted(path for path in root.iterdir() if path.is_dir())
+    all_rows: list[dict[str, Any]] = []
+    artifact_failures = 0
+    for run_dir in run_dirs:
+        rows, error = _load_jsonl(run_dir / "combination_results.v1.jsonl")
+        if error:
+            artifact_failures += 1
+            continue
+        for row in _latest_result_rows(rows):
+            all_rows.append(
+                {
+                    **row,
+                    "_run_id": run_dir.name,
+                    "_run_dir": run_dir.as_posix(),
+                }
+            )
+    all_rows.sort(
+        key=lambda row: (
+            str(row.get("_run_id") or ""),
+            int(row.get("sequence_number") or 0),
+        )
+    )
+    return all_rows, len(run_dirs), len(all_rows), artifact_failures
+
+
+def build_discovery_basket_grid_evidence_materialization(
+    *,
+    repo_root: Path = Path("."),
+    max_candidates: int = 15,
+) -> dict[str, Any]:
+    base = coverage.build_real_basket_evidence_coverage(
+        repo_root=repo_root,
+        max_candidates=max_candidates,
+    )
+    basket_rows = base.get("rows")
+    if not isinstance(basket_rows, list):
+        basket_rows = []
+    grid_rows, run_count, grid_row_count, artifact_failures = _scan_grid_runs(repo_root)
+    audit_indexes = _audit_indexes(repo_root)
+    source_identity_index = {
+        str(row.get("instrument_symbol") or ""): row for row in catalog.source_identity_diagnostics()
+    }
+
+    materialized_rows: list[dict[str, Any]] = []
+    next_action_counts: Counter[str] = Counter()
+    blocker_counts: Counter[str] = Counter()
+
+    for basket_row in basket_rows:
+        if not isinstance(basket_row, Mapping):
+            continue
+        join_keys_attempted = [
+            "symbol+preset+timeframe+hypothesis",
+            "provider_symbol+preset+timeframe+hypothesis",
+            "symbol_to_grid_alias+preset+timeframe+hypothesis",
+            "provider_symbol_to_grid_alias+preset+timeframe+hypothesis",
+        ]
+        matched_rows: list[dict[str, Any]] = []
+        saw_same_preset = False
+        join_failure_reason: str | None = None
+        if run_count == 0:
+            join_failure_reason = "no_grid_run_found"
+        elif artifact_failures and not grid_rows:
+            join_failure_reason = "grid_artifact_missing"
+        else:
+            saw_same_symbol_or_provider = False
+            basket_aliases = [
+                str(value)
+                for value in (
+                    source_identity_index.get(str(basket_row.get("symbol") or ""), {}).get("candidate_aliases")
+                    or []
+                )
+                if str(value)
+            ]
+            for grid_row in grid_rows:
+                if str(grid_row.get("behavior_preset_id") or "") == str(basket_row.get("preset_id") or ""):
+                    saw_same_preset = True
+                basket_symbol = str(basket_row.get("symbol") or "")
+                basket_provider = str(basket_row.get("provider_symbol") or "")
+                grid_symbol = str(grid_row.get("instrument_symbol") or "")
+                grid_provider = str(grid_row.get("primary_data_provider_symbol") or "")
+                grid_aliases = {str(value) for value in grid_row.get("provider_symbol_aliases") or [] if str(value)}
+                if basket_symbol in {grid_symbol, grid_provider} or basket_provider in {
+                    grid_symbol,
+                    grid_provider,
+                }:
+                    saw_same_symbol_or_provider = True
+                elif basket_symbol and basket_symbol in grid_aliases:
+                    saw_same_symbol_or_provider = True
+                elif basket_provider and basket_provider in grid_aliases:
+                    saw_same_symbol_or_provider = True
+                elif any(alias in {grid_symbol, grid_provider} for alias in basket_aliases):
+                    saw_same_symbol_or_provider = True
+                elif any(alias in grid_aliases for alias in basket_aliases):
+                    saw_same_symbol_or_provider = True
+                matched, reasons = _match_reasons(
+                    basket_row,
+                    grid_row,
+                    basket_aliases=basket_aliases,
+                )
+                if matched:
+                    matched_rows.append(
+                        {
+                            "run_id": str(grid_row.get("_run_id") or ""),
+                            "sequence_number": int(grid_row.get("sequence_number") or 0),
+                            "instrument_symbol": str(grid_row.get("instrument_symbol") or ""),
+                            "behavior_preset_id": str(grid_row.get("behavior_preset_id") or ""),
+                            "status": str(grid_row.get("status") or ""),
+                            "outcome_class": str(grid_row.get("outcome_class") or ""),
+                            "blocker_class": str(grid_row.get("blocker_class") or ""),
+                            "provider_symbol_status": str(grid_row.get("provider_symbol_status") or ""),
+                            "source_identity_status": str(grid_row.get("source_identity_status") or ""),
+                            "primary_data_provider_symbol": grid_row.get("primary_data_provider_symbol"),
+                            "provider_symbol_aliases": list(grid_row.get("provider_symbol_aliases") or []),
+                            "result_path": grid_row.get("result_path"),
+                            "trades_total": grid_row.get("trades_total"),
+                            "oos_trades": grid_row.get("oos_trades"),
+                            "hd_trades": grid_row.get("hd_trades"),
+                            "criteria_status": grid_row.get("criteria_status"),
+                            "join_reasons": reasons,
+                        }
+                    )
+            if not matched_rows:
+                join_failure_reason = (
+                    "join_key_mismatch"
+                    if (saw_same_preset or saw_same_symbol_or_provider)
+                    else "grid_row_match_not_found"
+                )
+
+        matched_rows.sort(key=lambda row: (str(row["run_id"]), int(row["sequence_number"])))
+        evidence_visible = bool(
+            int((basket_row.get("evidence_counts") or {}).get("screening_rows") or 0) > 0
+            or int(
+                (basket_row.get("validation_evidence_status_counts") or {}).get("sufficient_oos_evidence")
+                or 0
+            )
+            > 0
+        )
+        readiness_adapter_gap = bool(matched_rows) and not evidence_visible
+        basket_symbol = str(basket_row.get("symbol") or "")
+        basket_preset = str(basket_row.get("preset_id") or "")
+        metric_row = audit_indexes["metric"].get((basket_symbol, basket_preset))
+        if metric_row:
+            metric_status = str(metric_row.get("classification") or "unknown_fail_closed")
+            metric_warnings = [str(value) for value in metric_row.get("warnings") or []]
+        else:
+            metric_status, metric_warnings = _local_metric_status(matched_rows)
+        preset_row = audit_indexes["preset"].get((basket_symbol, basket_preset))
+        preset_classification = str(preset_row.get("classification") or "") if preset_row else ""
+        survivor_row = audit_indexes["survivor"].get((basket_symbol, basket_preset))
+        survivor_stage = str(survivor_row.get("stage_classification") or "") if survivor_row else ""
+        oos_blocker_class = ""
+        candidate_blocker_class = ""
+        for row in matched_rows:
+            diagnostic = grid_analysis._derive_row_diagnostics(
+                {
+                    **row,
+                    "provider_symbol_aliases": row.get("provider_symbol_aliases") or [],
+                    "primary_data_provider_symbol": row.get("primary_data_provider_symbol"),
+                }
+            )
+            if not oos_blocker_class and diagnostic.get("oos_evidence_blocker_class"):
+                oos_blocker_class = str(diagnostic["oos_evidence_blocker_class"])
+            if not candidate_blocker_class and diagnostic.get("primary_blocker"):
+                candidate_blocker_class = str(diagnostic["primary_blocker"])
+        exact_blocker = _exact_blocker_category(
+            basket_row=basket_row,
+            matched_rows=matched_rows,
+            join_failure_reason=join_failure_reason,
+            metric_status=metric_status,
+            preset_classification=preset_classification or None,
+            survivor_stage=survivor_stage or None,
+        )
+        blocker_counts.update([exact_blocker])
+        next_action = _next_action(exact_blocker, readiness_adapter_gap=readiness_adapter_gap)
+        next_action_counts.update([next_action])
+        closest = bool(matched_rows) and exact_blocker in {
+            "criteria_failed",
+            "sufficient_oos_but_not_promotion_ready",
+            "evidence_complete_or_near_complete",
+        }
+
+        materialized_rows.append(
+            {
+                "basket_id": basket_row.get("candidate_id"),
+                "asset": basket_symbol,
+                "canonical_symbol": basket_symbol,
+                "provider_symbol": basket_row.get("provider_symbol"),
+                "timeframe": ",".join(str(value) for value in basket_row.get("timeframes") or []),
+                "preset": basket_preset,
+                "behavior_family": basket_row.get("behavior_family"),
+                "hypothesis_id": basket_row.get("hypothesis_id"),
+                "source_identity_status": basket_row.get("source_identity_status"),
+                "source_identity_blocker": (
+                    "source_identity_blocked"
+                    if str(basket_row.get("source_identity_status") or "") == "candidate_alias_only"
+                    else ""
+                ),
+                "expected_campaign_artifact_ref": "research/campaign_registry_latest.v1.json",
+                "expected_screening_evidence_ref": "research/screening_evidence_latest.v1.json",
+                "expected_oos_evidence_ref": "research/screening_evidence_latest.v1.json",
+                "expected_candidate_lineage_ref": "research/candidate_registry_latest.v1.json",
+                "controlled_grid_run_id": matched_rows[0]["run_id"] if matched_rows else "",
+                "matched_grid_rows_count": len(matched_rows),
+                "matched_grid_rows": matched_rows,
+                "join_keys_attempted": join_keys_attempted,
+                "join_key_status": "grid_row_match_found" if matched_rows else (join_failure_reason or "unknown_fail_closed"),
+                "join_failure_reason": join_failure_reason or "",
+                "evidence_exists_in_grid": bool(matched_rows),
+                "evidence_visible_to_readiness_loop": evidence_visible,
+                "readiness_adapter_gap": readiness_adapter_gap,
+                "screening_evidence_status": _screening_status(matched_rows, evidence_visible),
+                "oos_evidence_status": _oos_status(matched_rows),
+                "sufficient_oos_evidence_status": (
+                    "present"
+                    if any(str(row.get("outcome_class") or "") == "sufficient_oos_evidence" for row in matched_rows)
+                    else "missing"
+                ),
+                "candidate_lineage_status": _candidate_lineage_status(basket_row),
+                "metric_consistency_status": metric_status,
+                "metric_consistency_warnings": metric_warnings,
+                "oos_blocker_class": oos_blocker_class,
+                "candidate_blocker_class": candidate_blocker_class,
+                "preset_executability_classification": preset_classification or "unknown_fail_closed",
+                "survivor_stage_classification": survivor_stage or "unknown_fail_closed",
+                "closest_to_routing_sampling_ready": closest,
+                "exact_blocker_category": exact_blocker,
+                "exact_next_action": next_action,
+            }
+        )
+
+    materialized_rows.sort(
+        key=lambda row: (
+            0 if row["closest_to_routing_sampling_ready"] else 1,
+            str(row["exact_blocker_category"]),
+            str(row["asset"]),
+            str(row["preset"]),
+        )
+    )
+    closest = [
+        {
+            "basket_id": row["basket_id"],
+            "asset": row["asset"],
+            "preset": row["preset"],
+            "blocker": row["exact_blocker_category"],
+            "next_action": row["exact_next_action"],
+        }
+        for row in materialized_rows
+        if row["closest_to_routing_sampling_ready"]
+    ][:10]
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": "deterministic_read_only",
+        "input_basket_count": len(materialized_rows),
+        "grid_runs_scanned_count": run_count,
+        "grid_rows_scanned_count": grid_row_count,
+        "baskets_with_matched_grid_rows": sum(bool(row["matched_grid_rows_count"]) for row in materialized_rows),
+        "baskets_with_sufficient_oos_in_grid": sum(
+            row["sufficient_oos_evidence_status"] == "present" for row in materialized_rows
+        ),
+        "baskets_where_grid_evidence_not_visible_to_readiness": sum(
+            bool(row["readiness_adapter_gap"]) for row in materialized_rows
+        ),
+        "baskets_blocked_by_source_identity": blocker_counts.get("source_identity_blocked", 0),
+        "baskets_blocked_by_metric_inconsistency": blocker_counts.get("metric_inconsistent", 0),
+        "baskets_blocked_by_preset_mapping": sum(
+            blocker_counts.get(value, 0)
+            for value in (
+                "mapping_missing",
+                "preset_not_executable",
+                "region_constraint_mismatch",
+                "asset_class_constraint_mismatch",
+                "timeframe_constraint_mismatch",
+                "provider_symbol_unresolved",
+                "unsupported_combination",
+            )
+        ),
+        "baskets_blocked_by_degenerate_no_survivors": blocker_counts.get("degenerate_no_survivors", 0)
+        + sum(1 for row in materialized_rows if str(row["survivor_stage_classification"]).endswith("_no_survivors")),
+        "closest_baskets_to_readiness": closest,
+        "next_action_counts": dict(sorted(next_action_counts.items())),
+        "summary": {
+            "blocker_category_counts": dict(sorted(blocker_counts.items())),
+            "operator_summary": (
+                "Discovery basket x controlled-grid materialization shows whether grid evidence exists, "
+                "whether readiness can see it, and which deterministic blocker still keeps each basket "
+                "out of routing/sampling readiness."
+            ),
+        },
+        "rows": materialized_rows,
+        "safety_invariants": {
+            "read_only": True,
+            "mutates_research_outputs": False,
+            "mutates_frozen_contracts": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+            "promotion_forbidden": True,
+        },
+    }
+
+
+def render_operator_summary(report: Mapping[str, Any]) -> str:
+    rows = report.get("rows") if isinstance(report.get("rows"), list) else []
+    summary = report.get("summary") or {}
+    counts = summary.get("blocker_category_counts") or {}
+    count_table = _table(
+        ["Field", "Count"],
+        [
+            ["input basket count", str(report.get("input_basket_count") or 0)],
+            ["grid runs scanned", str(report.get("grid_runs_scanned_count") or 0)],
+            ["grid rows scanned", str(report.get("grid_rows_scanned_count") or 0)],
+            ["matched baskets", str(report.get("baskets_with_matched_grid_rows") or 0)],
+            [
+                "sufficient OOS in grid",
+                str(report.get("baskets_with_sufficient_oos_in_grid") or 0),
+            ],
+            [
+                "grid evidence not visible to readiness",
+                str(report.get("baskets_where_grid_evidence_not_visible_to_readiness") or 0),
+            ],
+        ],
+    )
+    blocker_table = _table(
+        ["Blocker", "Count"],
+        [[str(key), str(value)] for key, value in counts.items()] or [["none", "0"]],
+    )
+    basket_table = _table(
+        [
+            "Basket",
+            "Asset",
+            "Preset",
+            "Matched rows",
+            "Join status",
+            "OOS",
+            "Metric",
+            "Blocker",
+            "Closest",
+            "Next action",
+        ],
+        [
+            [
+                str(row.get("basket_id") or ""),
+                str(row.get("asset") or ""),
+                str(row.get("preset") or ""),
+                str(row.get("matched_grid_rows_count") or 0),
+                str(row.get("join_key_status") or ""),
+                str(row.get("sufficient_oos_evidence_status") or ""),
+                str(row.get("metric_consistency_status") or ""),
+                str(row.get("exact_blocker_category") or ""),
+                "yes" if row.get("closest_to_routing_sampling_ready") else "no",
+                str(row.get("exact_next_action") or ""),
+            ]
+            for row in rows
+        ],
+    )
+    closest_rows = report.get("closest_baskets_to_readiness") if isinstance(
+        report.get("closest_baskets_to_readiness"), list
+    ) else []
+    closest_table = _table(
+        ["Basket", "Asset", "Preset", "Blocker", "Next action"],
+        [
+            [
+                str(row.get("basket_id") or ""),
+                str(row.get("asset") or ""),
+                str(row.get("preset") or ""),
+                str(row.get("blocker") or ""),
+                str(row.get("next_action") or ""),
+            ]
+            for row in closest_rows
+        ]
+        or [["none", "-", "-", "-", "-"]],
+    )
+    return "\n".join(
+        [
+            "# QRE Discovery Basket Grid Evidence Materialization",
+            "",
+            "## 1. Korte conclusie",
+            f"- {summary.get('operator_summary') or ''}",
+            "",
+            "## 2. Aggregate counts",
+            count_table,
+            "",
+            "## 3. Top blockers",
+            blocker_table,
+            "",
+            "## 4. Basket materialization",
+            basket_table,
+            "",
+            "## 5. Closest baskets to readiness",
+            closest_table,
+        ]
+    )
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(
+            f"qre_discovery_basket_grid_evidence_materialization: refusing write outside allowlist: {path!r}"
+        )
+
+
+def write_outputs(
+    report: Mapping[str, Any],
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = Path("."),
+) -> dict[str, str]:
+    base = repo_root / output_dir
+    base.mkdir(parents=True, exist_ok=True)
+    latest = base / LATEST_NAME
+    summary_path = base / OPERATOR_SUMMARY_NAME
+    for target in (latest, summary_path):
+        _validate_write_target(target)
+    latest_payload = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    tmp_json = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_json.write_text(latest_payload, encoding="utf-8")
+    os.replace(tmp_json, latest)
+    tmp_summary = summary_path.with_suffix(summary_path.suffix + ".tmp")
+    tmp_summary.write_text(render_operator_summary(report) + "\n", encoding="utf-8")
+    os.replace(tmp_summary, summary_path)
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "operator_summary": summary_path.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_discovery_basket_grid_evidence_materialization",
+        description="Bridge production discovery baskets to controlled discovery grid evidence.",
+    )
+    parser.add_argument("--max-candidates", type=int, default=15)
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    report = build_discovery_basket_grid_evidence_materialization(
+        max_candidates=args.max_candidates
+    )
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/research/qre_discovery_source_identity_diagnostics.py
+++ b/research/qre_discovery_source_identity_diagnostics.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+from research import controlled_discovery_grid
+from research import production_discovery_catalog as catalog
+
+
+REPORT_KIND: Final[str] = "qre_discovery_source_identity_diagnostics"
+SCHEMA_VERSION: Final[str] = "1.0"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_discovery_source_identity_diagnostics")
+LATEST_NAME: Final[str] = "latest.json"
+OPERATOR_SUMMARY_NAME: Final[str] = "operator_summary.md"
+WRITE_PREFIX: Final[str] = "logs/qre_discovery_source_identity_diagnostics/"
+
+
+def _table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> str:
+    head = "| " + " | ".join(headers) + " |"
+    divider = "| " + " | ".join(["---"] * len(headers)) + " |"
+    body = ["| " + " | ".join(row) + " |" for row in rows]
+    return "\n".join([head, divider, *body])
+
+
+def build_source_identity_diagnostics(*, max_candidates: int = 15) -> dict[str, Any]:
+    grid_rows = controlled_discovery_grid.build_controlled_discovery_grid()
+    basket = catalog.build_bounded_candidate_basket(max_candidates=max_candidates)
+    basket_symbols = {str(row.get("symbol") or "") for row in basket}
+    rows: list[dict[str, Any]] = []
+    for row in catalog.source_identity_diagnostics():
+        symbol = str(row.get("instrument_symbol") or "")
+        affected_grid_rows = sum(
+            1 for grid_row in grid_rows if str(grid_row.get("instrument_symbol") or "") == symbol
+        )
+        affected_baskets = sum(1 for basket_row in basket if str(basket_row.get("symbol") or "") == symbol)
+        rows.append(
+            {
+                **row,
+                "affected_grid_rows": affected_grid_rows,
+                "affected_baskets": affected_baskets,
+                "included_in_bounded_basket": symbol in basket_symbols,
+            }
+        )
+    rows.sort(
+        key=lambda row: (
+            0 if str(row.get("provider_symbol_status") or "") != "verified" else 1,
+            str(row.get("region") or ""),
+            str(row.get("instrument_symbol") or ""),
+        )
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "summary": {
+            "instrument_count": len(rows),
+            "verified_count": sum(bool(row.get("is_provider_symbol_verified")) for row in rows),
+            "candidate_alias_only_count": sum(bool(row.get("is_candidate_alias_only")) for row in rows),
+            "basket_symbols_with_identity_blockers": sum(
+                bool(row.get("included_in_bounded_basket")) and not bool(row.get("is_provider_symbol_verified"))
+                for row in rows
+            ),
+            "operator_summary": (
+                "Source identity diagnostics classify deterministic provider-symbol mappings "
+                "for the discovery grid and keep ambiguous aliases blocked until explicit verification exists."
+            ),
+        },
+        "rows": rows,
+        "safety_invariants": {
+            "read_only": True,
+            "mutates_frozen_contracts": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+        },
+    }
+
+
+def render_operator_summary(report: Mapping[str, Any]) -> str:
+    rows = report.get("rows") if isinstance(report.get("rows"), list) else []
+    summary = report.get("summary") or {}
+    count_table = _table(
+        ["Field", "Count"],
+        [
+            ["instrument count", str(summary.get("instrument_count") or 0)],
+            ["verified", str(summary.get("verified_count") or 0)],
+            ["candidate alias only", str(summary.get("candidate_alias_only_count") or 0)],
+            [
+                "basket symbols with identity blockers",
+                str(summary.get("basket_symbols_with_identity_blockers") or 0),
+            ],
+        ],
+    )
+    detail_table = _table(
+        [
+            "Symbol",
+            "Canonical symbol",
+            "Candidate aliases",
+            "Selected provider symbol",
+            "Provider status",
+            "Identity confidence",
+            "Ambiguity warning",
+            "Affected grid rows",
+            "Affected baskets",
+            "Next action",
+        ],
+        [
+            [
+                str(row.get("instrument_symbol") or ""),
+                str(row.get("canonical_symbol") or ""),
+                ", ".join(str(value) for value in row.get("candidate_aliases") or []) or "-",
+                str(row.get("selected_provider_symbol") or "-"),
+                str(row.get("provider_symbol_status") or ""),
+                str(row.get("identity_confidence") or ""),
+                str(row.get("ambiguity_warning") or "-"),
+                str(row.get("affected_grid_rows") or 0),
+                str(row.get("affected_baskets") or 0),
+                str(row.get("next_action") or ""),
+            ]
+            for row in rows
+        ],
+    )
+    return "\n".join(
+        [
+            "# QRE Discovery Source Identity Diagnostics",
+            "",
+            "## 1. Korte conclusie",
+            f"- {summary.get('operator_summary') or ''}",
+            "",
+            "## 2. Aggregate counts",
+            count_table,
+            "",
+            "## 3. Source identity diagnostics",
+            detail_table,
+        ]
+    )
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(
+            f"qre_discovery_source_identity_diagnostics: refusing write outside allowlist: {path!r}"
+        )
+
+
+def write_outputs(
+    report: Mapping[str, Any],
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = Path("."),
+) -> dict[str, str]:
+    base = repo_root / output_dir
+    base.mkdir(parents=True, exist_ok=True)
+    latest = base / LATEST_NAME
+    summary_path = base / OPERATOR_SUMMARY_NAME
+    for target in (latest, summary_path):
+        _validate_write_target(target)
+    tmp_json = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp_json, latest)
+    tmp_summary = summary_path.with_suffix(summary_path.suffix + ".tmp")
+    tmp_summary.write_text(render_operator_summary(report) + "\n", encoding="utf-8")
+    os.replace(tmp_summary, summary_path)
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "operator_summary": summary_path.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_discovery_source_identity_diagnostics",
+        description="Render read-only provider symbol diagnostics for the discovery grid.",
+    )
+    parser.add_argument("--max-candidates", type=int, default=15)
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    report = build_source_identity_diagnostics(max_candidates=args.max_candidates)
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/unit/test_qre_controlled_discovery_metric_consistency_audit.py
+++ b/tests/unit/test_qre_controlled_discovery_metric_consistency_audit.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from research import qre_controlled_discovery_metric_consistency_audit as audit
+from research import qre_discovery_basket_grid_evidence_materialization as materialization
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
+
+
+def _seed_grid_rows(tmp_path: Path, rows: list[dict]) -> None:
+    _write_jsonl(
+        tmp_path / "research" / "controlled_discovery_grid_runs" / "run-001" / "combination_results.v1.jsonl",
+        rows,
+    )
+
+
+def _seed_materialization_support(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "logs" / "qre_data_cache_manifest" / "latest.json",
+        {"coverage": [{"instrument": "AAPL", "timeframe": "1d", "ready": True}]},
+    )
+    _write_json(
+        tmp_path / "logs" / "qre_data_source_quality_readiness" / "latest.json",
+        {"rows": [{"instrument": "AAPL", "timeframe": "1d", "quality_status": "ready"}]},
+    )
+    _write_json(
+        tmp_path / "research" / "screening_evidence_latest.v1.json",
+        {"candidates": []},
+    )
+    _write_json(tmp_path / "research" / "campaign_registry_latest.v1.json", {"campaigns": {}})
+    _write_json(tmp_path / "research" / "candidate_registry_latest.v1.json", {"candidates": []})
+
+
+def test_oos_trades_greater_than_total_is_inconsistent(tmp_path: Path) -> None:
+    _seed_grid_rows(
+        tmp_path,
+        [
+            {
+                "sequence_number": 1,
+                "instrument_symbol": "AAPL",
+                "behavior_preset_id": "trend_continuation_daily_v1",
+                "trades_total": 15,
+                "oos_trades": 20,
+                "hd_trades": 0,
+            }
+        ],
+    )
+
+    report = audit.build_metric_consistency_audit(repo_root=tmp_path)
+
+    row = report["rows"][0]
+    assert row["classification"] == "inconsistent_oos_gt_total"
+    assert row["no_alpha_interpretation"] is True
+
+
+def test_missing_and_non_numeric_metrics_are_classified(tmp_path: Path) -> None:
+    _seed_grid_rows(
+        tmp_path,
+        [
+            {
+                "sequence_number": 1,
+                "instrument_symbol": "AAPL",
+                "behavior_preset_id": "trend_continuation_daily_v1",
+                "trades_total": "",
+                "oos_trades": 10,
+            },
+            {
+                "sequence_number": 2,
+                "instrument_symbol": "MSFT",
+                "behavior_preset_id": "trend_continuation_daily_v1",
+                "trades_total": "abc",
+                "oos_trades": 5,
+            },
+        ],
+    )
+
+    report = audit.build_metric_consistency_audit(repo_root=tmp_path)
+
+    classifications = {row["instrument_symbol"]: row["classification"] for row in report["rows"]}
+    assert classifications["AAPL"] == "missing_total_trades"
+    assert classifications["MSFT"] == "non_numeric_metric"
+
+
+def test_clean_consistent_and_aggregation_scope_mismatch_are_distinct(tmp_path: Path) -> None:
+    _seed_grid_rows(
+        tmp_path,
+        [
+            {
+                "sequence_number": 1,
+                "instrument_symbol": "AAPL",
+                "behavior_preset_id": "trend_continuation_daily_v1",
+                "trades_total": 20,
+                "oos_trades": 10,
+                "hd_trades": 10,
+            },
+            {
+                "sequence_number": 2,
+                "instrument_symbol": "MSFT",
+                "behavior_preset_id": "trend_continuation_daily_v1",
+                "trades_total": 10,
+                "oos_trades": 12,
+                "hd_trades": 0,
+                "aggregation_scope_hint": "aggregation_scope_mismatch",
+            },
+        ],
+    )
+
+    report = audit.build_metric_consistency_audit(repo_root=tmp_path)
+
+    classifications = {row["instrument_symbol"]: row["classification"] for row in report["rows"]}
+    assert classifications["AAPL"] == "clean_consistent"
+    assert classifications["MSFT"] == "aggregation_scope_mismatch"
+
+
+def test_deterministic_output_ordering_and_write_outputs(tmp_path: Path) -> None:
+    _seed_grid_rows(
+        tmp_path,
+        [
+            {"sequence_number": 2, "instrument_symbol": "MSFT", "behavior_preset_id": "trend_continuation_daily_v1"},
+            {"sequence_number": 1, "instrument_symbol": "AAPL", "behavior_preset_id": "trend_continuation_daily_v1", "trades_total": 10, "oos_trades": 12},
+        ],
+    )
+
+    report = audit.build_metric_consistency_audit(repo_root=tmp_path)
+    assert [row["instrument_symbol"] for row in report["rows"]] == ["AAPL", "MSFT"]
+
+    paths = audit.write_outputs(report, repo_root=tmp_path)
+    assert paths["latest"] == "logs/qre_controlled_discovery_metric_consistency_audit/latest.json"
+    assert (tmp_path / paths["latest"]).is_file()
+
+
+def test_materialization_consumes_metric_audit_and_marks_row_not_clean(tmp_path: Path) -> None:
+    _seed_materialization_support(tmp_path)
+    _seed_grid_rows(
+        tmp_path,
+        [
+            {
+                "sequence_number": 1,
+                "instrument_symbol": "AAPL",
+                "behavior_preset_id": "trend_pullback_continuation_daily_v1",
+                "hypothesis_id": "trend_pullback_behavior_v1",
+                "timeframe": "1d",
+                "status": "completed",
+                "outcome_class": "sufficient_oos_evidence",
+                "trades_total": 15,
+                "oos_trades": 20,
+                "hd_trades": 0,
+            }
+        ],
+    )
+    report = audit.build_metric_consistency_audit(repo_root=tmp_path)
+    audit.write_outputs(report, repo_root=tmp_path)
+
+    materialized = materialization.build_discovery_basket_grid_evidence_materialization(
+        repo_root=tmp_path,
+        max_candidates=2,
+    )
+    row = next(item for item in materialized["rows"] if item["asset"] == "AAPL")
+    assert row["metric_consistency_status"] == "inconsistent_oos_gt_total"
+    assert row["exact_blocker_category"] == "metric_inconsistent"

--- a/tests/unit/test_qre_controlled_discovery_preset_executability.py
+++ b/tests/unit/test_qre_controlled_discovery_preset_executability.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from research import qre_controlled_discovery_preset_executability as executability
+
+
+def _row(symbol: str, preset_id: str) -> dict[str, object]:
+    rows = executability.build_preset_executability_report(max_candidates=15)["rows"]
+    return next(
+        row
+        for row in rows
+        if row["instrument_symbol"] == symbol and row["behavior_preset_id"] == preset_id
+    )
+
+
+def test_executable_row_is_classified_as_executable() -> None:
+    row = _row("AAPL", "trend_continuation_daily_v1")
+    assert row["classification"] == "executable"
+
+
+def test_intentionally_non_executable_row_is_classified() -> None:
+    row = _row("AAPL", "relative_strength_vs_sector_daily_v1")
+    assert row["classification"] == "intentionally_non_executable"
+
+
+def test_region_and_asset_class_mismatches_are_classified() -> None:
+    region_row = _row("ASML", "vol_compression_breakout_4h_v1")
+    asset_row = _row("SPY", "trend_pullback_continuation_daily_v1")
+
+    assert region_row["classification"] == "region_constraint_mismatch"
+    assert asset_row["classification"] == "asset_class_constraint_mismatch"
+
+
+def test_source_identity_block_can_preempt_executability() -> None:
+    row = _row("ASMI", "trend_continuation_daily_v1")
+    assert row["classification"] == "source_identity_blocked"
+
+
+def test_deterministic_order_and_write_outputs() -> None:
+    report = executability.build_preset_executability_report(max_candidates=15)
+
+    assert report["rows"][0]["classification"] != "executable"
+    assert report["summary"]["total_combinations"] == 328

--- a/tests/unit/test_qre_controlled_discovery_survivor_stage_attribution.py
+++ b/tests/unit/test_qre_controlled_discovery_survivor_stage_attribution.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from research import qre_controlled_discovery_survivor_stage_attribution as survivor
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
+
+
+def _seed_run_row(tmp_path: Path, row: dict, sidecar: dict | None = None) -> None:
+    row = dict(row)
+    if sidecar is not None:
+        row["artifact_paths"] = {
+            "execution_result": "research/controlled_discovery_grid_runs/run-001/combination_001/execution_result.v1.json"
+        }
+        _write_json(
+            tmp_path
+            / "research"
+            / "controlled_discovery_grid_runs"
+            / "run-001"
+            / "combination_001"
+            / "execution_result.v1.json",
+            sidecar,
+        )
+    _write_jsonl(
+        tmp_path / "research" / "controlled_discovery_grid_runs" / "run-001" / "combination_results.v1.jsonl",
+        [row],
+    )
+
+
+def _seed_metric_and_preset_sidecars(tmp_path: Path, *, metric: str = "", preset: str = "") -> None:
+    _write_json(
+        tmp_path / "logs" / "qre_controlled_discovery_metric_consistency_audit" / "latest.json",
+        {
+            "rows": [
+                {
+                    "instrument_symbol": "AAPL",
+                    "behavior_preset_id": "trend_continuation_daily_v1",
+                    "classification": metric or "clean_consistent",
+                    "affected_basket_ids": [],
+                }
+            ]
+        },
+    )
+    _write_json(
+        tmp_path / "logs" / "qre_controlled_discovery_preset_executability" / "latest.json",
+        {
+            "rows": [
+                {
+                    "instrument_symbol": "AAPL",
+                    "behavior_preset_id": "trend_continuation_daily_v1",
+                    "classification": preset or "executable",
+                    "affected_basket_ids": [],
+                }
+            ]
+        },
+    )
+
+
+def test_no_candidates_generated_and_oos_stage_are_attributed(tmp_path: Path) -> None:
+    _seed_metric_and_preset_sidecars(tmp_path)
+    _seed_run_row(
+        tmp_path,
+        {
+            "sequence_number": 1,
+            "instrument_symbol": "AAPL",
+            "behavior_preset_id": "trend_continuation_daily_v1",
+            "blocker_class": "degenerate_no_survivors",
+        },
+        {
+            "observation": {"candidate_count": 0},
+            "artifact_snapshot": {"matching_screening_rows": []},
+        },
+    )
+
+    report = survivor.build_survivor_stage_attribution(repo_root=tmp_path)
+    assert report["rows"][0]["stage_classification"] == "no_candidates_generated"
+
+    _seed_run_row(
+        tmp_path,
+        {
+            "sequence_number": 1,
+            "instrument_symbol": "AAPL",
+            "behavior_preset_id": "trend_continuation_daily_v1",
+            "blocker_class": "degenerate_no_survivors",
+        },
+        {
+            "observation": {"candidate_count": 1},
+            "artifact_snapshot": {
+                "matching_screening_rows": [
+                    {"validation_evidence": {"status": "no_oos_trades"}}
+                ]
+            },
+        },
+    )
+    report = survivor.build_survivor_stage_attribution(repo_root=tmp_path)
+    assert report["rows"][0]["stage_classification"] == "oos_stage_no_survivors"
+
+
+def test_criteria_metric_source_identity_and_preset_mapping_are_attributed(tmp_path: Path) -> None:
+    _seed_metric_and_preset_sidecars(tmp_path)
+    _seed_run_row(
+        tmp_path,
+        {
+            "sequence_number": 1,
+            "instrument_symbol": "AAPL",
+            "behavior_preset_id": "trend_continuation_daily_v1",
+            "blocker_class": "degenerate_no_survivors",
+        },
+        {
+            "observation": {"candidate_count": 1},
+            "artifact_snapshot": {
+                "matching_screening_rows": [
+                    {"promotion_guard": {"blocked_by": ["consistentie"]}}
+                ]
+            },
+        },
+    )
+    report = survivor.build_survivor_stage_attribution(repo_root=tmp_path)
+    assert report["rows"][0]["stage_classification"] == "criteria_stage_no_survivors"
+
+    _seed_metric_and_preset_sidecars(tmp_path, metric="inconsistent_oos_gt_total")
+    report = survivor.build_survivor_stage_attribution(repo_root=tmp_path)
+    assert report["rows"][0]["stage_classification"] == "metric_consistency_stage_no_survivors"
+
+    _seed_metric_and_preset_sidecars(tmp_path, metric="clean_consistent", preset="source_identity_blocked")
+    report = survivor.build_survivor_stage_attribution(repo_root=tmp_path)
+    assert report["rows"][0]["stage_classification"] == "source_identity_stage_blocked"
+
+    _seed_metric_and_preset_sidecars(tmp_path, metric="clean_consistent", preset="mapping_missing")
+    report = survivor.build_survivor_stage_attribution(repo_root=tmp_path)
+    assert report["rows"][0]["stage_classification"] == "preset_mapping_stage_blocked"
+
+
+def test_artifact_missing_adapter_join_and_unknown_fail_closed_are_supported(tmp_path: Path) -> None:
+    _seed_metric_and_preset_sidecars(tmp_path)
+    _seed_run_row(
+        tmp_path,
+        {
+            "sequence_number": 1,
+            "instrument_symbol": "AAPL",
+            "behavior_preset_id": "trend_continuation_daily_v1",
+            "blocker_class": "degenerate_no_survivors",
+        },
+    )
+    report = survivor.build_survivor_stage_attribution(repo_root=tmp_path)
+    assert report["rows"][0]["stage_classification"] == "artifact_missing_stage_blocked"
+
+    _seed_run_row(
+        tmp_path,
+        {
+            "sequence_number": 1,
+            "instrument_symbol": "AAPL",
+            "behavior_preset_id": "trend_continuation_daily_v1",
+            "blocker_class": "degenerate_no_survivors",
+            "degenerate_stage_hint": "adapter_join_stage_blocked",
+        },
+        {"observation": {"candidate_count": 1}, "artifact_snapshot": {"matching_screening_rows": []}},
+    )
+    report = survivor.build_survivor_stage_attribution(repo_root=tmp_path)
+    assert report["rows"][0]["stage_classification"] == "adapter_join_stage_blocked"
+
+    _seed_run_row(
+        tmp_path,
+        {
+            "sequence_number": 1,
+            "instrument_symbol": "AAPL",
+            "behavior_preset_id": "trend_continuation_daily_v1",
+            "blocker_class": "degenerate_no_survivors",
+            "degenerate_stage_hint": "unknown_fail_closed",
+        },
+        {"observation": {"candidate_count": 1}, "artifact_snapshot": {"matching_screening_rows": []}},
+    )
+    report = survivor.build_survivor_stage_attribution(repo_root=tmp_path)
+    assert report["rows"][0]["stage_classification"] == "unknown_fail_closed"

--- a/tests/unit/test_qre_discovery_basket_grid_evidence_materialization.py
+++ b/tests/unit/test_qre_discovery_basket_grid_evidence_materialization.py
@@ -139,9 +139,9 @@ def test_matches_grid_row_by_provider_alias_and_explains_adapter_gap(tmp_path: P
         [
                 {
                     "sequence_number": 2,
-                    "instrument_symbol": "ADYEN.AS",
-                    "primary_data_provider_symbol": "ADYEN.AS",
-                    "provider_symbol_aliases": ["ADYEN.AS"],
+                    "instrument_symbol": "ASM.AS",
+                    "primary_data_provider_symbol": "ASM.AS",
+                    "provider_symbol_aliases": ["ASM.AS", "ASMI.AS"],
                     "behavior_preset_id": "relative_strength_vs_sector_daily_v1",
                     "hypothesis_id": "relative_strength_sector_behavior_v1",
                     "timeframe": "1d",
@@ -163,7 +163,7 @@ def test_matches_grid_row_by_provider_alias_and_explains_adapter_gap(tmp_path: P
         max_candidates=15,
     )
 
-    row = next(item for item in report["rows"] if item["asset"] == "ADYEN")
+    row = next(item for item in report["rows"] if item["asset"] == "ASMI")
     assert row["join_key_status"] == "grid_row_match_found"
     assert row["readiness_adapter_gap"] is True
     assert row["source_identity_blocker"] == "source_identity_blocked"

--- a/tests/unit/test_qre_discovery_basket_grid_evidence_materialization.py
+++ b/tests/unit/test_qre_discovery_basket_grid_evidence_materialization.py
@@ -1,0 +1,323 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from research import qre_discovery_basket_grid_evidence_materialization as materialization
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\n".join(json.dumps(row) for row in rows) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _seed_supporting_artifacts(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "logs" / "qre_data_cache_manifest" / "latest.json",
+        {
+            "coverage": [
+                {"instrument": "AAPL", "timeframe": "1d", "ready": True},
+                {"instrument": "ADYEN.AS", "timeframe": "1d", "ready": True},
+            ]
+        },
+    )
+    _write_json(
+        tmp_path / "logs" / "qre_data_source_quality_readiness" / "latest.json",
+        {
+            "rows": [
+                {"instrument": "AAPL", "timeframe": "1d", "quality_status": "ready"},
+                {"instrument": "ADYEN.AS", "timeframe": "1d", "quality_status": "ready"},
+            ]
+        },
+    )
+    _write_json(
+        tmp_path / "research" / "screening_evidence_latest.v1.json",
+        {
+            "candidates": [
+                {
+                    "asset": "AAPL",
+                    "hypothesis_id": "trend_pullback_behavior_v1",
+                    "stage_result": "screening_pass",
+                    "validation_evidence": {
+                        "status": "sufficient_oos_evidence",
+                        "oos_trade_count": 20,
+                    },
+                }
+            ]
+        },
+    )
+    _write_json(
+        tmp_path / "research" / "campaign_registry_latest.v1.json",
+        {
+            "campaigns": {
+                "cmp-1": {
+                    "preset_name": "trend_pullback_continuation_daily_v1",
+                    "hypothesis_id": "trend_pullback_behavior_v1",
+                    "state": "completed",
+                }
+            }
+        },
+    )
+    _write_json(
+        tmp_path / "research" / "candidate_registry_latest.v1.json",
+        {"candidates": [{"asset": "AAPL", "status": "candidate"}]},
+    )
+
+
+def test_fail_closed_when_no_grid_run_artifacts_exist(tmp_path: Path) -> None:
+    _seed_supporting_artifacts(tmp_path)
+
+    report = materialization.build_discovery_basket_grid_evidence_materialization(
+        repo_root=tmp_path,
+        max_candidates=2,
+    )
+
+    assert report["grid_runs_scanned_count"] == 0
+    row = next(item for item in report["rows"] if item["asset"] == "AAPL")
+    assert row["join_key_status"] == "no_grid_run_found"
+    assert row["exact_blocker_category"] == "no_grid_run_found"
+
+
+def test_matches_grid_row_by_exact_key_and_preserves_no_promotion(tmp_path: Path) -> None:
+    _seed_supporting_artifacts(tmp_path)
+    _write_jsonl(
+        tmp_path
+        / "research"
+        / "controlled_discovery_grid_runs"
+        / "run-001"
+        / "combination_results.v1.jsonl",
+        [
+            {
+                "sequence_number": 1,
+                "instrument_symbol": "AAPL",
+                "behavior_preset_id": "trend_pullback_continuation_daily_v1",
+                "hypothesis_id": "trend_pullback_behavior_v1",
+                "timeframe": "1d",
+                "status": "completed",
+                "outcome_class": "sufficient_oos_evidence",
+                "blocker_class": "criteria_consistentie_failed",
+                "criteria_status": "consistentie,win_rate",
+                "trades_total": 20,
+                "oos_trades": 14,
+                "hd_trades": 6,
+                "provider_symbol_aliases": [],
+                "source_identity_status": "provider_symbol_verified",
+                "provider_symbol_status": "verified",
+            }
+        ],
+    )
+
+    report = materialization.build_discovery_basket_grid_evidence_materialization(
+        repo_root=tmp_path,
+        max_candidates=2,
+    )
+
+    row = next(item for item in report["rows"] if item["asset"] == "AAPL")
+    assert row["join_key_status"] == "grid_row_match_found"
+    assert row["matched_grid_rows_count"] == 1
+    assert row["sufficient_oos_evidence_status"] == "present"
+    assert row["exact_blocker_category"] == "criteria_failed"
+    assert row["closest_to_routing_sampling_ready"] is True
+
+
+def test_matches_grid_row_by_provider_alias_and_explains_adapter_gap(tmp_path: Path) -> None:
+    _seed_supporting_artifacts(tmp_path)
+    _write_jsonl(
+        tmp_path
+        / "research"
+        / "controlled_discovery_grid_runs"
+        / "run-002"
+        / "combination_results.v1.jsonl",
+        [
+                {
+                    "sequence_number": 2,
+                    "instrument_symbol": "ADYEN.AS",
+                    "primary_data_provider_symbol": "ADYEN.AS",
+                    "provider_symbol_aliases": ["ADYEN.AS"],
+                    "behavior_preset_id": "relative_strength_vs_sector_daily_v1",
+                    "hypothesis_id": "relative_strength_sector_behavior_v1",
+                    "timeframe": "1d",
+                    "status": "completed",
+                    "outcome_class": "screening_pass_no_oos",
+                "blocker_class": "no_oos_evidence",
+                "criteria_status": "",
+                "trades_total": 12,
+                "oos_trades": 0,
+                "hd_trades": 12,
+                "source_identity_status": "candidate_alias_only",
+                "provider_symbol_status": "candidate_alias_requires_verification",
+            }
+        ],
+    )
+
+    report = materialization.build_discovery_basket_grid_evidence_materialization(
+        repo_root=tmp_path,
+        max_candidates=15,
+    )
+
+    row = next(item for item in report["rows"] if item["asset"] == "ADYEN")
+    assert row["join_key_status"] == "grid_row_match_found"
+    assert row["readiness_adapter_gap"] is True
+    assert row["source_identity_blocker"] == "source_identity_blocked"
+    assert row["exact_next_action"] == "bridge_grid_evidence_into_readiness_surfaces"
+
+
+def test_join_mismatch_is_explained(tmp_path: Path) -> None:
+    _seed_supporting_artifacts(tmp_path)
+    _write_jsonl(
+        tmp_path
+        / "research"
+        / "controlled_discovery_grid_runs"
+        / "run-003"
+        / "combination_results.v1.jsonl",
+        [
+            {
+                "sequence_number": 3,
+                "instrument_symbol": "AAPL",
+                "behavior_preset_id": "trend_continuation_daily_v1",
+                "hypothesis_id": "trend_continuation_behavior_v1",
+                "timeframe": "1d",
+                "status": "completed",
+                "outcome_class": "screening_pass_no_oos",
+                "blocker_class": "no_oos_evidence",
+                "provider_symbol_aliases": [],
+                "source_identity_status": "provider_symbol_verified",
+                "provider_symbol_status": "verified",
+            }
+        ],
+    )
+
+    report = materialization.build_discovery_basket_grid_evidence_materialization(
+        repo_root=tmp_path,
+        max_candidates=2,
+    )
+
+    row = next(item for item in report["rows"] if item["asset"] == "AAPL")
+    assert row["join_key_status"] == "join_key_mismatch"
+    assert row["exact_blocker_category"] == "join_key_mismatch"
+
+
+def test_metric_inconsistent_rows_are_not_treated_as_clean_evidence(tmp_path: Path) -> None:
+    _seed_supporting_artifacts(tmp_path)
+    _write_jsonl(
+        tmp_path
+        / "research"
+        / "controlled_discovery_grid_runs"
+        / "run-004"
+        / "combination_results.v1.jsonl",
+        [
+            {
+                "sequence_number": 4,
+                "instrument_symbol": "AAPL",
+                "behavior_preset_id": "trend_pullback_continuation_daily_v1",
+                "hypothesis_id": "trend_pullback_behavior_v1",
+                "timeframe": "1d",
+                "status": "completed",
+                "outcome_class": "sufficient_oos_evidence",
+                "blocker_class": "",
+                "criteria_status": "",
+                "trades_total": 15,
+                "oos_trades": 20,
+                "hd_trades": 0,
+                "provider_symbol_aliases": [],
+                "source_identity_status": "provider_symbol_verified",
+                "provider_symbol_status": "verified",
+            }
+        ],
+    )
+
+    report = materialization.build_discovery_basket_grid_evidence_materialization(
+        repo_root=tmp_path,
+        max_candidates=2,
+    )
+
+    row = next(item for item in report["rows"] if item["asset"] == "AAPL")
+    assert row["metric_consistency_status"] == "metric_inconsistent"
+    assert row["exact_blocker_category"] == "metric_inconsistent"
+
+
+def test_operator_summary_includes_top_blockers_and_closest_baskets(tmp_path: Path) -> None:
+    _seed_supporting_artifacts(tmp_path)
+    _write_jsonl(
+        tmp_path
+        / "research"
+        / "controlled_discovery_grid_runs"
+        / "run-005"
+        / "combination_results.v1.jsonl",
+        [
+            {
+                "sequence_number": 5,
+                "instrument_symbol": "AAPL",
+                "behavior_preset_id": "trend_pullback_continuation_daily_v1",
+                "hypothesis_id": "trend_pullback_behavior_v1",
+                "timeframe": "1d",
+                "status": "completed",
+                "outcome_class": "sufficient_oos_evidence",
+                "blocker_class": "criteria_consistentie_failed",
+                "criteria_status": "consistentie",
+                "trades_total": 22,
+                "oos_trades": 12,
+                "hd_trades": 10,
+                "provider_symbol_aliases": [],
+                "source_identity_status": "provider_symbol_verified",
+                "provider_symbol_status": "verified",
+            }
+        ],
+    )
+
+    report = materialization.build_discovery_basket_grid_evidence_materialization(
+        repo_root=tmp_path,
+        max_candidates=2,
+    )
+    markdown = materialization.render_operator_summary(report)
+
+    assert "# QRE Discovery Basket Grid Evidence Materialization" in markdown
+    assert "## 3. Top blockers" in markdown
+    assert "## 5. Closest baskets to readiness" in markdown
+    assert "criteria_failed" in markdown
+    assert "AAPL" in markdown
+
+
+def test_malformed_jsonl_fails_closed(tmp_path: Path) -> None:
+    _seed_supporting_artifacts(tmp_path)
+    path = (
+        tmp_path
+        / "research"
+        / "controlled_discovery_grid_runs"
+        / "run-006"
+        / "combination_results.v1.jsonl"
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{bad json}\n", encoding="utf-8")
+
+    report = materialization.build_discovery_basket_grid_evidence_materialization(
+        repo_root=tmp_path,
+        max_candidates=2,
+    )
+
+    assert report["grid_runs_scanned_count"] == 1
+    row = next(item for item in report["rows"] if item["asset"] == "AAPL")
+    assert row["join_key_status"] == "grid_artifact_missing"
+
+
+def test_write_outputs_writes_only_inside_allowlisted_log_dir(tmp_path: Path) -> None:
+    _seed_supporting_artifacts(tmp_path)
+    report = materialization.build_discovery_basket_grid_evidence_materialization(
+        repo_root=tmp_path,
+        max_candidates=2,
+    )
+
+    paths = materialization.write_outputs(report, repo_root=tmp_path)
+
+    assert paths["latest"] == "logs/qre_discovery_basket_grid_evidence_materialization/latest.json"
+    assert paths["operator_summary"] == "logs/qre_discovery_basket_grid_evidence_materialization/operator_summary.md"
+    assert (tmp_path / paths["latest"]).is_file()
+    assert (tmp_path / paths["operator_summary"]).is_file()

--- a/tests/unit/test_qre_discovery_source_identity_diagnostics.py
+++ b/tests/unit/test_qre_discovery_source_identity_diagnostics.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from research import qre_discovery_source_identity_diagnostics as diagnostics
+
+
+def test_source_identity_diagnostics_expose_verified_and_ambiguous_symbols() -> None:
+    report = diagnostics.build_source_identity_diagnostics(max_candidates=15)
+
+    rows = {row["instrument_symbol"]: row for row in report["rows"]}
+    assert rows["ADYEN"]["selected_provider_symbol"] == "ADYEN.AS"
+    assert rows["ADYEN"]["provider_symbol_status"] == "verified"
+    assert rows["ADYEN"]["identity_confidence"] == "high"
+    assert rows["ADYEN"]["affected_grid_rows"] == 8
+    assert rows["ADYEN"]["affected_baskets"] == 1
+    assert rows["ASMI"]["provider_symbol_status"] == "candidate_alias_requires_verification"
+    assert rows["ASMI"]["ambiguity_warning"] == "multiple_candidate_aliases"
+    assert rows["ASMI"]["next_action"] == "require_alias_verification"
+
+
+def test_render_operator_summary_includes_required_identity_columns() -> None:
+    report = diagnostics.build_source_identity_diagnostics(max_candidates=15)
+
+    markdown = diagnostics.render_operator_summary(report)
+
+    assert "# QRE Discovery Source Identity Diagnostics" in markdown
+    assert "## 3. Source identity diagnostics" in markdown
+    assert "Selected provider symbol" in markdown
+    assert "Affected grid rows" in markdown
+    assert "ADYEN" in markdown

--- a/tests/unit/test_qre_failure_recurrence_learning.py
+++ b/tests/unit/test_qre_failure_recurrence_learning.py
@@ -122,7 +122,8 @@ def test_build_source_usefulness_v0_distinguishes_useful_and_blocked_symbols(
 
     rows = {row["symbol"]: row for row in usefulness["rows"]}
     assert rows["AAPL"]["usefulness_state"] == "useful_for_readonly_research"
-    assert rows["ADYEN"]["usefulness_state"] == "blocked_by_source_identity"
+    assert rows["ADYEN"]["usefulness_state"] == "blocked_by_source_or_cache"
+    assert rows["ADYEN"]["recommended_action"] == "require_identity_or_source_readiness"
 
 
 def test_write_outputs_materializes_learning_and_source_reports(tmp_path: Path) -> None:

--- a/tests/unit/test_qre_hypothesis_seed_feasibility.py
+++ b/tests/unit/test_qre_hypothesis_seed_feasibility.py
@@ -85,8 +85,9 @@ def test_build_hypothesis_seed_feasibility_keeps_source_identity_blocked_seed_ex
 
     rows = {row["hypothesis_id"]: row for row in report["rows"]}
     row = rows["relative_strength_sector_behavior_v1"]
-    assert row["feasibility_state"] == "blocked_source_identity"
+    assert row["feasibility_state"] == "blocked_source_or_cache"
     assert row["recommended_follow_up"] == "require_identity_resolution"
+    assert row["top_blockers"][0]["value"] == "source_identity_blocked"
 
 
 def test_build_hypothesis_seed_feasibility_distinguishes_seed_only_hypotheses(

--- a/tests/unit/test_qre_production_discovery_catalog.py
+++ b/tests/unit/test_qre_production_discovery_catalog.py
@@ -101,9 +101,17 @@ def test_known_european_symbols_expose_candidate_provider_aliases_without_overcl
     assert assets["NOVO-B"]["provider_symbol_aliases"] == ["NVO", "NOVO-B.CO"]
     assert assets["PRX"]["provider_symbol_aliases"] == ["PRX.AS"]
     assert assets["SIE"]["provider_symbol_aliases"] == ["SIE.DE"]
-    assert assets["ADYEN"]["provider_symbol_status"] == "candidate_alias_requires_verification"
+    assert assets["ADYEN"]["provider_symbol_status"] == "verified"
+    assert assets["BESI"]["provider_symbol_status"] == "verified"
+    assert assets["AIR"]["provider_symbol_status"] == "verified"
+    assert assets["IFX"]["provider_symbol_status"] == "verified"
+    assert assets["NESN"]["provider_symbol_status"] == "verified"
+    assert assets["PRX"]["provider_symbol_status"] == "verified"
+    assert assets["SIE"]["provider_symbol_status"] == "verified"
+    assert assets["ASMI"]["provider_symbol_status"] == "candidate_alias_requires_verification"
     assert assets["NOVO-B"]["provider_symbol_status"] == "candidate_alias_requires_verification"
-    assert assets["ADYEN"]["primary_data_provider_symbol"] is None
+    assert assets["ADYEN"]["primary_data_provider_symbol"] == "ADYEN.AS"
+    assert assets["BESI"]["primary_data_provider_symbol"] == "BESI.AS"
     assert assets["NOVO-B"]["primary_data_provider_symbol"] is None
 
 
@@ -116,12 +124,19 @@ def test_source_identity_diagnostics_classify_verified_and_unverified_symbols() 
         "source_identity_provider_symbol_verified"
     )
     assert diagnostics["ADYEN"]["source_identity_blocker_class"] == (
+        "source_identity_provider_symbol_verified"
+    )
+    assert diagnostics["ASMI"]["source_identity_blocker_class"] == (
         "source_identity_candidate_alias_unverified"
     )
     assert diagnostics["SHELL"]["provider_symbol"] == "SHEL"
     assert diagnostics["SHELL"]["is_provider_symbol_verified"] is True
-    assert diagnostics["ADYEN"]["is_provider_symbol_verified"] is False
-    assert diagnostics["ADYEN"]["is_candidate_alias_only"] is True
+    assert diagnostics["ADYEN"]["is_provider_symbol_verified"] is True
+    assert diagnostics["ADYEN"]["selected_provider_symbol"] == "ADYEN.AS"
+    assert diagnostics["ADYEN"]["identity_confidence"] == "high"
+    assert diagnostics["ASMI"]["is_provider_symbol_verified"] is False
+    assert diagnostics["ASMI"]["is_candidate_alias_only"] is True
+    assert diagnostics["ASMI"]["ambiguity_warning"] == "multiple_candidate_aliases"
     assert diagnostics["SPY"]["source_identity_blocker_class"] == (
         "source_identity_provider_symbol_verified"
     )


### PR DESCRIPTION
﻿Summary
- Activates a read-only evidence bridge between the 15-basket pre-readiness loop and controlled 328-grid artifacts.
- Hardens deterministic source identity/provider alias diagnostics for discovery-grid instruments.
- Adds explicit trade metric consistency auditing, preset executability classification, and degenerate no-survivor stage attribution.
- Preserves negative results and keeps promotion, paper, shadow, live, broker, risk, execution, and strategy synthesis blocked.

Commit A: materialize discovery basket grid evidence
- Adds esearch/qre_discovery_basket_grid_evidence_materialization.py.
- Joins bounded discovery baskets to controlled-grid runs when present and fail-closes when grid artifacts are absent or malformed.
- Explains readiness adapter gaps, source identity blockers, metric status, OOS visibility, candidate/campaign lineage, and next actions per basket.

Commit B: verify provider symbol aliases for discovery grid
- Hardens deterministic provider symbol metadata for unambiguous NL/EU aliases and keeps ambiguous aliases blocked.
- Adds esearch/qre_discovery_source_identity_diagnostics.py with operator-readable identity summaries.
- Surfaces identity confidence, ambiguity warnings, selected provider symbol, affected grid rows, and affected baskets.

Commit C: audit controlled discovery trade metric consistency
- Adds esearch/qre_controlled_discovery_metric_consistency_audit.py.
- Classifies clean_consistent, inconsistent_oos_gt_total, missing_total_trades, missing_oos_trades, 
on_numeric_metric, ggregation_scope_mismatch, and unknown_fail_closed.
- Ensures inconsistent rows remain diagnostic-only and are not treated as clean OOS evidence.

Commit D: classify controlled discovery preset executability
- Adds esearch/qre_controlled_discovery_preset_executability.py.
- Separates executable rows from intentionally non-executable, region mismatch, asset-class mismatch, source-identity blocked, and mapping-gap rows.
- Does not add strategies or mutate egistry.py.

Commit E: attribute degenerate no-survivor stages
- Adds esearch/qre_controlled_discovery_survivor_stage_attribution.py.
- Attributes degenerate survivors to explicit stage blockers such as source identity, preset mapping, metric consistency, screening/OOS, artifact missing, or adapter join issues.
- Integrates safely with the existing hypothesis-feasibility expectations after the source-identity hardening.

Safety constraints honored
- No paper/shadow/live activation.
- No strategy synthesis or automatic strategy invention.
- No threshold relaxation, no promotion unlock, no preset behavior mutation beyond read-only diagnostic metadata.
- No broker/risk/execution/order/capital allocation changes.
- No dashboard mutation routes, no approval inbox mutation, no .claude/** writes.

Tests run
- python -m pytest tests/unit/test_qre_discovery_basket_grid_evidence_materialization.py tests/unit/test_qre_discovery_source_identity_diagnostics.py tests/unit/test_qre_controlled_discovery_metric_consistency_audit.py tests/unit/test_qre_controlled_discovery_preset_executability.py tests/unit/test_qre_controlled_discovery_survivor_stage_attribution.py -q
- python -m pytest tests/unit/test_qre_real_basket_diagnosis.py tests/unit/test_qre_real_basket_evidence_coverage.py tests/unit/test_qre_routing_readiness_from_basket.py tests/unit/test_qre_sampling_readiness_from_basket.py tests/unit/test_qre_pre_shadow_paper_research_readiness.py -q
- python -m pytest tests/unit/test_qre_candidate_explanation_rows.py tests/unit/test_qre_trusted_loop_operator_kpis.py tests/unit/test_qre_hypothesis_seed_feasibility.py tests/unit/test_qre_trusted_loop_readiness.py -q
- python -m pytest tests/unit/test_qre_controlled_discovery_grid.py tests/unit/test_qre_controlled_discovery_grid_analysis.py tests/unit/test_qre_controlled_discovery_grid_execution.py tests/unit/test_qre_controlled_discovery_grid_runner.py tests/unit/test_qre_production_discovery_catalog.py -q
- python -m pytest tests -q -k "controlled_discovery or discovery_grid or source_identity or oos_blocker or metric_consistency"
- python -m pytest tests/architecture -q
- python -m pytest tests -q -k "governance or frozen_contract or no_touch or execution_authority"
- python -m pytest tests -q -k "smoke"
- git diff --check

Sidecar reports generated
- python -m research.qre_discovery_basket_grid_evidence_materialization --write
- python -m research.qre_discovery_source_identity_diagnostics --write
- python -m research.qre_controlled_discovery_metric_consistency_audit --write
- python -m research.qre_controlled_discovery_preset_executability --write
- python -m research.qre_controlled_discovery_survivor_stage_attribution --write
- python -m research.qre_pre_shadow_paper_research_readiness --write

Frozen contracts status
- esearch/research_latest.json unchanged.
- esearch/strategy_matrix.csv unchanged.

Protected paths status
- egistry.py untouched.
- gent/backtesting/strategies.py untouched.
- broker/risk/execution/order/live/paper/shadow paths untouched.
- dashboard mutation routes not added.
- approval inbox untouched.

Execution paths status
- No live, paper, or shadow readiness implementation was added.
- No broker, risk, execution, order placement, or capital allocation paths changed.

Known limitations
- Local repo state still has no controlled-grid run artifacts under esearch/controlled_discovery_grid_runs, so local materialization and metric/survivor reports fail closed or remain empty until a VPS run is pulled or rerun.
- Ambiguous aliases remain intentionally blocked: ASMI, LVMH, NOVO-B.
- This PR improves evidence activation and diagnostics only; it does not make any candidate promotion-ready.

Post-merge VPS rerun plan
- Pull/deploy merged main on the VPS.
- Run the canonical controlled discovery grid command with a new run id: RERUN_328_AFTER_SYMBOL_AND_METRIC_FIXES.
- Rebuild the new sidecar diagnostics on the VPS after the rerun and report the readiness delta.

Explicit statement
- No paper/shadow/live activation.
- No strategy synthesis.
- No threshold relaxation.
