### PR TITLE
fix: bridge controlled grid evidence into readiness surfaces

### DIFF
--- a/research/qre_candidate_explanation_rows.py
+++ b/research/qre_candidate_explanation_rows.py
@@ -149,6 +149,20 @@ def build_candidate_explanation_rows(
             {},
         )
         paper_status = str(paper_row.get("readiness_status") or "not_available_fail_closed")
+        bridge_status = str(
+            ((row.get("grid_readiness_bridge") or {}).get("readiness_bridge_status"))
+            or "blocked_no_grid_match"
+        )
+        primary_blocker = (
+            bridge_status
+            if bridge_status.startswith("blocked_")
+            else str(
+                failure_row.get("blocker_code")
+                or ((row.get("grid_readiness_bridge") or {}).get("readiness_blocker_category"))
+                or row.get("diagnosis_reason_code")
+                or "unknown"
+            )
+        )
         rows.append(
             {
                 "candidate_id": candidate_id,
@@ -167,6 +181,13 @@ def build_candidate_explanation_rows(
                     else "missing"
                 ),
                 "oos_status": _oos_status(row),
+                "grid_readiness_bridge_status": str(
+                    ((row.get("grid_readiness_bridge") or {}).get("readiness_bridge_status"))
+                    or "blocked_no_grid_match"
+                ),
+                "grid_readiness_bridge_explanation": str(
+                    ((row.get("grid_readiness_bridge") or {}).get("bridge_explanation")) or ""
+                ),
                 "paper_readiness_status": paper_status,
                 "paper_readiness_blockers": list(paper_row.get("blocking_reasons") or []),
                 "synthesis_gate_state": synthesis_state,
@@ -178,9 +199,7 @@ def build_candidate_explanation_rows(
                 "safe_next_action": str(
                     failure_row.get("recommended_action") or "keep_blocked"
                 ),
-                "primary_blocker": str(
-                    failure_row.get("blocker_code") or row.get("diagnosis_reason_code") or "unknown"
-                ),
+                "primary_blocker": primary_blocker,
                 "operator_explanation": (
                     f"{row.get('symbol')} remains {paper_status} for paper and "
                     f"{synthesis_state} for synthesis; next action is "

--- a/research/qre_grid_evidence_readiness_bridge.py
+++ b/research/qre_grid_evidence_readiness_bridge.py
@@ -1,0 +1,405 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+
+REPORT_KIND: Final[str] = "qre_grid_evidence_readiness_bridge"
+SCHEMA_VERSION: Final[str] = "1.0"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_grid_evidence_readiness_bridge")
+LATEST_NAME: Final[str] = "latest.json"
+OPERATOR_SUMMARY_NAME: Final[str] = "operator_summary.md"
+WRITE_PREFIX: Final[str] = "logs/qre_grid_evidence_readiness_bridge/"
+MATERIALIZATION_PATH: Final[Path] = Path(
+    "logs/qre_discovery_basket_grid_evidence_materialization/latest.json"
+)
+_CLEAN_METRIC_STATUSES: Final[set[str]] = {"clean_consistent", "consistent"}
+_BLOCKED_METRIC_STATUSES: Final[set[str]] = {
+    "metric_inconsistent",
+    "inconsistent_oos_gt_total",
+    "missing_total_trades",
+    "missing_oos_trades",
+    "non_numeric_metric",
+    "aggregation_scope_mismatch",
+}
+_BLOCKED_PRESET_CLASSES: Final[set[str]] = {
+    "mapping_missing",
+    "preset_not_executable",
+    "region_constraint_mismatch",
+    "asset_class_constraint_mismatch",
+    "timeframe_constraint_mismatch",
+    "provider_symbol_unresolved",
+    "source_identity_blocked",
+    "unsupported_combination",
+}
+
+
+def _table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> str:
+    head = "| " + " | ".join(headers) + " |"
+    divider = "| " + " | ".join(["---"] * len(headers)) + " |"
+    body = ["| " + " | ".join(row) + " |" for row in rows]
+    return "\n".join([head, divider, *body])
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _criteria_failure_classes(matched_rows: Sequence[Mapping[str, Any]]) -> list[str]:
+    values: list[str] = []
+    for row in matched_rows:
+        criteria_status = str(row.get("criteria_status") or "")
+        for part in criteria_status.split(","):
+            item = part.strip()
+            if item and item not in values:
+                values.append(item)
+    return values
+
+
+def _grid_screening_present(matched_rows: Sequence[Mapping[str, Any]]) -> bool:
+    for row in matched_rows:
+        outcome = str(row.get("outcome_class") or "")
+        status = str(row.get("status") or "")
+        if outcome in {
+            "screening_pass_no_oos",
+            "sufficient_oos_evidence",
+            "source_identity_provider_lookup_failed",
+            "source_identity_provider_symbol_verified",
+        }:
+            return True
+        if status == "completed":
+            return True
+    return False
+
+
+def _grid_oos_present(
+    matched_rows: Sequence[Mapping[str, Any]],
+    *,
+    oos_evidence_status: str,
+) -> bool:
+    if oos_evidence_status in {
+        "sufficient_oos_evidence_present",
+        "completed_without_sufficient_oos",
+        "no_oos_evidence",
+    }:
+        return True
+    return _grid_screening_present(matched_rows)
+
+
+def _source_identity_blocked(row: Mapping[str, Any]) -> bool:
+    return str(row.get("source_identity_status") or "") in {
+        "candidate_alias_only",
+        "missing_provider_symbol",
+    } or str(row.get("source_identity_blocker") or "").startswith("source_identity")
+
+
+def _metric_clean_for_readiness(metric_status: str) -> bool:
+    return metric_status in _CLEAN_METRIC_STATUSES
+
+
+def _preset_executable_for_readiness(preset_status: str) -> bool:
+    return preset_status == "executable"
+
+
+def _bridge_status(row: Mapping[str, Any]) -> tuple[str, str]:
+    matched_rows = row.get("matched_grid_rows")
+    if not isinstance(matched_rows, list):
+        matched_rows = []
+    join_status = str(row.get("join_key_status") or "")
+    metric_status = str(row.get("metric_consistency_status") or "unknown_fail_closed")
+    preset_status = str(row.get("preset_executability_classification") or "unknown_fail_closed")
+    candidate_lineage_status = str(row.get("candidate_lineage_status") or "missing")
+    criteria_failures = _criteria_failure_classes(matched_rows)
+    sufficient_oos_present = bool(row.get("grid_sufficient_oos_evidence_present"))
+    oos_present = bool(row.get("grid_oos_evidence_present"))
+    screening_present = bool(row.get("grid_screening_evidence_present"))
+
+    if join_status == "grid_artifact_missing":
+        return ("blocked_malformed_artifact", "grid artifact missing or unreadable")
+    if join_status in {"no_grid_run_found", "grid_row_match_not_found", "join_key_mismatch"} or not bool(
+        row.get("grid_evidence_present")
+    ):
+        return ("blocked_no_grid_match", "no matching controlled-grid evidence was found")
+    if _source_identity_blocked(row):
+        return ("blocked_source_identity", "source identity remains unresolved")
+    if metric_status in _BLOCKED_METRIC_STATUSES or not _metric_clean_for_readiness(metric_status):
+        return ("blocked_metric_inconsistent", "metric consistency blocks clean readiness evidence")
+    if preset_status == "intentionally_non_executable":
+        return (
+            "blocked_intentionally_non_executable",
+            "preset is intentionally non-executable for bounded discovery",
+        )
+    if preset_status in _BLOCKED_PRESET_CLASSES:
+        return ("blocked_preset_not_executable", "preset mapping blocks clean readiness evidence")
+    if sufficient_oos_present:
+        if candidate_lineage_status == "missing":
+            return ("blocked_candidate_lineage_missing", "candidate lineage is still missing")
+        if candidate_lineage_status in {
+            "candidate_visible_campaign_missing",
+            "campaign_visible_candidate_missing",
+        }:
+            return ("blocked_campaign_lineage_missing", "campaign lineage is still missing")
+        if criteria_failures:
+            return (
+                "bridged_sufficient_oos_but_not_promotion_ready",
+                "sufficient OOS evidence is visible, but criteria still block promotion",
+            )
+        return (
+            "bridged_sufficient_oos_but_not_promotion_ready",
+            "sufficient OOS evidence is visible for readiness only; promotion remains governed elsewhere",
+        )
+    if oos_present:
+        if str(row.get("oos_evidence_status") or "") == "no_oos_evidence":
+            return ("blocked_no_oos_evidence", "screening evidence exists but no OOS evidence is present")
+        return ("bridged_clean_oos_evidence", "clean OOS evidence is visible to readiness surfaces")
+    if screening_present:
+        return (
+            "bridged_clean_screening_evidence",
+            "clean screening evidence is visible to readiness surfaces",
+        )
+    return ("unknown_fail_closed", "bridge could not classify the readiness evidence state")
+
+
+def build_grid_evidence_readiness_bridge(
+    *,
+    repo_root: Path = Path("."),
+    max_candidates: int = 15,
+) -> dict[str, Any]:
+    materialization = _read_json(repo_root / MATERIALIZATION_PATH)
+    rows = materialization.get("rows") if isinstance(materialization, Mapping) else None
+    if not isinstance(rows, list):
+        rows = []
+
+    bridged_rows: list[dict[str, Any]] = []
+    status_counts: Counter[str] = Counter()
+    next_action_counts: Counter[str] = Counter()
+
+    for row in rows[:max_candidates]:
+        if not isinstance(row, Mapping):
+            continue
+        matched_rows = row.get("matched_grid_rows")
+        if not isinstance(matched_rows, list):
+            matched_rows = []
+        metric_status = str(row.get("metric_consistency_status") or "unknown_fail_closed")
+        preset_status = str(row.get("preset_executability_classification") or "unknown_fail_closed")
+        grid_screening_present = _grid_screening_present(matched_rows)
+        grid_oos_present = _grid_oos_present(
+            matched_rows,
+            oos_evidence_status=str(row.get("oos_evidence_status") or ""),
+        )
+        grid_sufficient_oos_present = str(row.get("sufficient_oos_evidence_status") or "") == "present"
+        clean_for_readiness = (
+            _metric_clean_for_readiness(metric_status)
+            and not _source_identity_blocked(row)
+            and _preset_executable_for_readiness(preset_status)
+        )
+        candidate_lineage_status = str(row.get("candidate_lineage_status") or "missing")
+        readiness_screening_visible = grid_screening_present and clean_for_readiness
+        readiness_oos_visible = grid_oos_present and clean_for_readiness
+        readiness_sufficient_visible = (
+            grid_sufficient_oos_present
+            and clean_for_readiness
+            and candidate_lineage_status == "visible"
+        )
+
+        bridged_row = {
+            "basket_id": row.get("basket_id"),
+            "asset": row.get("asset"),
+            "canonical_symbol": row.get("canonical_symbol"),
+            "provider_symbol": row.get("provider_symbol"),
+            "timeframe": row.get("timeframe"),
+            "preset": row.get("preset"),
+            "matched_grid_rows_count": int(row.get("matched_grid_rows_count") or 0),
+            "matched_grid_rows": matched_rows,
+            "grid_evidence_present": bool(row.get("evidence_exists_in_grid")),
+            "grid_screening_evidence_present": grid_screening_present,
+            "grid_oos_evidence_present": grid_oos_present,
+            "grid_sufficient_oos_evidence_present": grid_sufficient_oos_present,
+            "readiness_screening_evidence_visible": readiness_screening_visible,
+            "readiness_oos_evidence_visible": readiness_oos_visible,
+            "readiness_sufficient_oos_visible": readiness_sufficient_visible,
+            "candidate_lineage_status": candidate_lineage_status,
+            "candidate_lineage_available": candidate_lineage_status == "visible",
+            "campaign_lineage_available": candidate_lineage_status == "visible",
+            "source_identity_status": row.get("source_identity_status"),
+            "source_identity_blocker": row.get("source_identity_blocker"),
+            "metric_consistency_status": metric_status,
+            "metric_clean_for_readiness": clean_for_readiness and _metric_clean_for_readiness(metric_status),
+            "preset_executability_status": preset_status,
+            "survivor_stage_attribution": row.get("survivor_stage_classification"),
+            "criteria_status": ",".join(_criteria_failure_classes(matched_rows)),
+            "criteria_failure_classes": _criteria_failure_classes(matched_rows),
+            "promotion_candidate_from_grid": False,
+            "near_pass_from_grid": False,
+            "promotion_allowed": False,
+            "readiness_evidence_status": (
+                "sufficient_oos_visible"
+                if readiness_sufficient_visible
+                else "oos_visible"
+                if readiness_oos_visible
+                else "screening_visible"
+                if readiness_screening_visible
+                else "blocked"
+            ),
+            "readiness_blocker_category": "",
+            "readiness_bridge_status": "",
+            "exact_next_action": row.get("exact_next_action") or "keep_fail_closed",
+        }
+        status, explanation = _bridge_status(bridged_row)
+        bridged_row["readiness_bridge_status"] = status
+        bridged_row["readiness_blocker_category"] = status
+        bridged_row["bridge_explanation"] = explanation
+        status_counts.update([status])
+        next_action_counts.update([str(bridged_row["exact_next_action"])])
+        bridged_rows.append(bridged_row)
+
+    bridged_rows.sort(
+        key=lambda row: (
+            0 if str(row["readiness_bridge_status"]).startswith("bridged_") else 1,
+            str(row["readiness_bridge_status"]),
+            str(row["asset"]),
+            str(row["preset"]),
+        )
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "summary": {
+            "basket_count": len(bridged_rows),
+            "readiness_bridge_status_counts": dict(sorted(status_counts.items())),
+            "grid_screening_visible_count": sum(
+                1 for row in bridged_rows if row["readiness_screening_evidence_visible"]
+            ),
+            "grid_oos_visible_count": sum(
+                1 for row in bridged_rows if row["readiness_oos_evidence_visible"]
+            ),
+            "grid_sufficient_oos_visible_count": sum(
+                1 for row in bridged_rows if row["readiness_sufficient_oos_visible"]
+            ),
+            "next_action_counts": dict(sorted(next_action_counts.items())),
+            "operator_summary": (
+                "Grid-evidence readiness bridge exposes which controlled-grid findings can safely "
+                "count as readiness-visible screening or OOS evidence without relaxing promotion gates."
+            ),
+        },
+        "rows": bridged_rows,
+        "safety_invariants": {
+            "read_only": True,
+            "mutates_frozen_contracts": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+            "promotion_forbidden": True,
+        },
+    }
+
+
+def render_operator_summary(report: Mapping[str, Any]) -> str:
+    summary = report.get("summary") or {}
+    rows = report.get("rows") if isinstance(report.get("rows"), list) else []
+    count_table = _table(
+        ["Field", "Count"],
+        [
+            ["basket count", str(summary.get("basket_count") or 0)],
+            ["screening visible", str(summary.get("grid_screening_visible_count") or 0)],
+            ["OOS visible", str(summary.get("grid_oos_visible_count") or 0)],
+            ["sufficient OOS visible", str(summary.get("grid_sufficient_oos_visible_count") or 0)],
+        ],
+    )
+    bridge_table = _table(
+        [
+            "Asset",
+            "Preset",
+            "Bridge status",
+            "Screening visible",
+            "OOS visible",
+            "Sufficient OOS visible",
+            "Next action",
+        ],
+        [
+            [
+                str(row.get("asset") or ""),
+                str(row.get("preset") or ""),
+                str(row.get("readiness_bridge_status") or ""),
+                "yes" if row.get("readiness_screening_evidence_visible") else "no",
+                "yes" if row.get("readiness_oos_evidence_visible") else "no",
+                "yes" if row.get("readiness_sufficient_oos_visible") else "no",
+                str(row.get("exact_next_action") or ""),
+            ]
+            for row in rows
+        ],
+    )
+    return "\n".join(
+        [
+            "# QRE Grid Evidence Readiness Bridge",
+            "",
+            "## 1. Korte conclusie",
+            f"- {summary.get('operator_summary') or ''}",
+            "",
+            "## 2. Aggregate counts",
+            count_table,
+            "",
+            "## 3. Basket bridge status",
+            bridge_table,
+        ]
+    )
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(
+            f"qre_grid_evidence_readiness_bridge: refusing write outside allowlist: {path!r}"
+        )
+
+
+def write_outputs(
+    report: Mapping[str, Any],
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path = Path("."),
+) -> dict[str, str]:
+    base = repo_root / output_dir
+    base.mkdir(parents=True, exist_ok=True)
+    latest = base / LATEST_NAME
+    summary_path = base / OPERATOR_SUMMARY_NAME
+    for target in (latest, summary_path):
+        _validate_write_target(target)
+    tmp_json = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp_json, latest)
+    tmp_summary = summary_path.with_suffix(summary_path.suffix + ".tmp")
+    tmp_summary.write_text(render_operator_summary(report) + "\n", encoding="utf-8")
+    os.replace(tmp_summary, summary_path)
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "operator_summary": summary_path.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_grid_evidence_readiness_bridge",
+        description="Bridge controlled discovery grid evidence into read-only readiness surfaces.",
+    )
+    parser.add_argument("--max-candidates", type=int, default=15)
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    report = build_grid_evidence_readiness_bridge(max_candidates=args.max_candidates)
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/research/qre_pre_shadow_paper_research_readiness.py
+++ b/research/qre_pre_shadow_paper_research_readiness.py
@@ -39,6 +39,34 @@ def _all_true(*values: bool) -> bool:
     return all(bool(value) for value in values)
 
 
+def _source_readiness_note(
+    *,
+    coverage_summary: Mapping[str, Any],
+    diagnosis_summary: Mapping[str, Any],
+    source_readiness_linked: bool,
+) -> str:
+    if source_readiness_linked:
+        return "Source/cache readiness sidecars are present and at least one basket is source-ready."
+    artifact_availability = diagnosis_summary.get("artifact_availability")
+    if not isinstance(artifact_availability, Mapping):
+        artifact_availability = {}
+    source_quality_present = bool(artifact_availability.get("source_quality"))
+    cache_manifest_present = bool(artifact_availability.get("cache_manifest"))
+    if not source_quality_present and not cache_manifest_present:
+        return "Source quality and cache manifest sidecars are missing or not generated in this environment."
+    if not source_quality_present:
+        return "Source quality readiness sidecar is missing, stale, or not deployed in this environment."
+    if not cache_manifest_present:
+        return "Cache manifest sidecar is missing, stale, or not deployed in this environment."
+    sidecar_status = coverage_summary.get("source_cache_sidecar_status")
+    if isinstance(sidecar_status, Mapping):
+        if str(sidecar_status.get("source_quality_sidecar_status") or "") != "present":
+            return "Source quality readiness sidecar is not present for the current readiness write."
+        if str(sidecar_status.get("cache_manifest_sidecar_status") or "") != "present":
+            return "Cache manifest sidecar is not present for the current readiness write."
+    return "Source/cache sidecars are present, but no basket currently qualifies as source-ready."
+
+
 def _readiness_state(
     *,
     diagnosis_exists: bool,
@@ -166,6 +194,8 @@ def build_pre_shadow_paper_research_readiness(
     failure_summary = failure.get("summary") or {}
     reason_meta = reasons.get("meta") or {}
     kpi_summary = kpis.get("summary") or {}
+    coverage_summary = coverage.get("summary") or {}
+    diagnosis_summary = diagnosis.get("summary") or {}
 
     diagnosis_exists = len(diagnosis_rows) > 0
     routing_evidence_backed = bool(routing_summary.get("routing_ready_count")) or bool(
@@ -180,6 +210,11 @@ def build_pre_shadow_paper_research_readiness(
         or int(failure_summary.get("non_actionable_count") or 0) > 0
     )
     source_readiness_linked = float(kpi_summary.get("source_ready_basket_pct") or 0.0) > 0.0
+    source_readiness_note = _source_readiness_note(
+        coverage_summary=coverage_summary,
+        diagnosis_summary=diagnosis_summary,
+        source_readiness_linked=source_readiness_linked,
+    )
     candidate_blockers_explainable = len(candidate_rows_list) > 0 and float(
         kpi_summary.get("unknown_failure_rate") or 100.0
     ) < 100.0
@@ -239,6 +274,7 @@ def build_pre_shadow_paper_research_readiness(
             "reason_record_count": int(reason_meta.get("record_count") or 0),
             "failure_action_present": failure_action_present,
             "source_readiness_linked": source_readiness_linked,
+            "source_readiness_note": source_readiness_note,
             "candidate_blockers_explainable": candidate_blockers_explainable,
             "oos_blockers_explainable": oos_blockers_explainable,
             "operator_report_complete": operator_report_complete,
@@ -254,7 +290,7 @@ def build_pre_shadow_paper_research_readiness(
         },
         "supporting_reports": {
             "diagnosis": diagnosis.get("summary"),
-            "coverage": coverage.get("summary"),
+            "coverage": coverage_summary,
             "routing": routing_summary,
             "sampling": sampling_summary,
             "reason_records": reason_meta,
@@ -289,6 +325,7 @@ def render_operator_summary(report: Mapping[str, Any]) -> str:
             ["reason_records_traceable", str(summary.get("reason_records_traceable") or False)],
             ["failure_action_present", str(summary.get("failure_action_present") or False)],
             ["source_readiness_linked", str(summary.get("source_readiness_linked") or False)],
+            ["source_readiness_note", str(summary.get("source_readiness_note") or "")],
             ["candidate_blockers_explainable", str(summary.get("candidate_blockers_explainable") or False)],
             ["oos_blockers_explainable", str(summary.get("oos_blockers_explainable") or False)],
             ["operator_report_complete", str(summary.get("operator_report_complete") or False)],

--- a/research/qre_real_basket_evidence_coverage.py
+++ b/research/qre_real_basket_evidence_coverage.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, Final
 
 from research import qre_real_basket_diagnosis as diagnosis
+from research import qre_grid_evidence_readiness_bridge as grid_bridge
 
 
 REPORT_KIND: Final[str] = "qre_real_basket_evidence_coverage"
@@ -141,6 +142,25 @@ def _completeness_status(score_pct: int) -> str:
     return "missing"
 
 
+def _source_cache_artifact_status(
+    supporting_artifacts: Mapping[str, Any],
+) -> dict[str, str]:
+    source_quality = supporting_artifacts.get("source_quality")
+    cache_manifest = supporting_artifacts.get("cache_manifest")
+    screening_evidence = supporting_artifacts.get("screening_evidence")
+    return {
+        "source_quality_sidecar_status": (
+            "present" if isinstance(source_quality, Mapping) else "missing"
+        ),
+        "cache_manifest_sidecar_status": (
+            "present" if isinstance(cache_manifest, Mapping) else "missing"
+        ),
+        "screening_evidence_sidecar_status": (
+            "present" if isinstance(screening_evidence, Mapping) else "missing"
+        ),
+    }
+
+
 def build_real_basket_evidence_coverage(
     *,
     repo_root: Path = Path("."),
@@ -151,14 +171,27 @@ def build_real_basket_evidence_coverage(
         repo_root=repo_root,
         max_candidates=max_candidates,
     )
+    bridge_report = grid_bridge.build_grid_evidence_readiness_bridge(
+        repo_root=repo_root,
+        max_candidates=max_candidates,
+    )
     rows = base.get("rows")
     if not isinstance(rows, list):
         rows = []
+    bridge_rows = bridge_report.get("rows")
+    if not isinstance(bridge_rows, list):
+        bridge_rows = []
+    bridge_by_candidate = {
+        str(row.get("basket_id") or ""): row
+        for row in bridge_rows
+        if isinstance(row, Mapping)
+    }
 
     coverage_rows: list[dict[str, Any]] = []
     taxonomy_counter: Counter[str] = Counter()
     completeness_counter: Counter[str] = Counter()
     evidence_backed_zero = True
+    source_cache_status = _source_cache_artifact_status(supporting_artifacts)
 
     for row in rows:
         if not isinstance(row, Mapping):
@@ -166,13 +199,29 @@ def build_real_basket_evidence_coverage(
         evidence = row.get("current_evidence")
         if not isinstance(evidence, Mapping):
             evidence = {}
+        candidate_id = str(row.get("candidate_id") or "")
+        bridge_row = bridge_by_candidate.get(candidate_id, {})
         screening_rows = diagnosis._matching_screening_rows(  # type: ignore[attr-defined]
             supporting_artifacts.get("screening_evidence"),
             symbol=str(row.get("symbol") or ""),
             hypothesis_id=str(row.get("hypothesis_id") or ""),
         )
         validation_statuses = _validation_statuses(screening_rows)
+        bridge_screening_visible = bool(bridge_row.get("readiness_screening_evidence_visible"))
+        bridge_oos_visible = bool(bridge_row.get("readiness_oos_evidence_visible"))
+        bridge_sufficient_visible = bool(bridge_row.get("readiness_sufficient_oos_visible"))
+        if bridge_screening_visible and not validation_statuses:
+            if bridge_sufficient_visible:
+                validation_statuses = ["sufficient_oos_evidence"]
+            elif bridge_oos_visible:
+                validation_statuses = ["grid_oos_evidence_present"]
+            else:
+                validation_statuses = ["grid_screening_evidence_present"]
         flags = _completeness_flags(row=row, validation_statuses=validation_statuses)
+        if bridge_screening_visible:
+            flags["screening_evidence_present"] = True
+        if bridge_oos_visible or bridge_sufficient_visible:
+            flags["oos_evidence_known"] = True
         score = round(100 * sum(flags.values()) / len(_COMPLETENESS_FIELDS))
         status = _completeness_status(score)
         missing = _missing_evidence_taxonomy(
@@ -183,11 +232,20 @@ def build_real_basket_evidence_coverage(
             source_quality_ready=flags["source_quality_ready"],
             cache_rows=int(evidence.get("cache_coverage_rows") or 0),
             cache_ready=flags["cache_ready"],
-            screening_rows=int(evidence.get("screening_rows") or 0),
+            screening_rows=max(
+                int(evidence.get("screening_rows") or 0),
+                1 if bridge_screening_visible else 0,
+            ),
             validation_statuses=validation_statuses,
             campaign_rows=int(evidence.get("campaign_rows") or 0),
             candidate_rows=int(evidence.get("candidate_rows") or 0),
         )
+        if bridge_screening_visible and "screening_evidence_missing" in missing:
+            missing.remove("screening_evidence_missing")
+        if (bridge_oos_visible or bridge_sufficient_visible) and "oos_evidence_missing" in missing:
+            missing.remove("oos_evidence_missing")
+        if (bridge_oos_visible or bridge_sufficient_visible) and "oos_evidence_unknown" in missing:
+            missing.remove("oos_evidence_unknown")
         if flags["screening_evidence_present"] or flags["oos_evidence_known"]:
             evidence_backed_zero = False
         taxonomy_counter.update(missing)
@@ -210,11 +268,18 @@ def build_real_basket_evidence_coverage(
                 "evidence_counts": {
                     "campaign_lineage_rows": int(evidence.get("campaign_rows") or 0),
                     "candidate_lineage_rows": int(evidence.get("candidate_rows") or 0),
-                    "screening_rows": int(evidence.get("screening_rows") or 0),
+                    "screening_rows": max(
+                        int(evidence.get("screening_rows") or 0),
+                        1 if bridge_screening_visible else 0,
+                    ),
                     "source_quality_rows": int(evidence.get("source_quality_rows") or 0),
                     "cache_coverage_rows": int(evidence.get("cache_coverage_rows") or 0),
                     "cache_ready_rows": int(evidence.get("cache_ready_count") or 0),
                     "oos_trade_count_max": _oos_trade_count(screening_rows),
+                    "grid_matched_rows": int(bridge_row.get("matched_grid_rows_count") or 0),
+                    "grid_screening_visible_rows": 1 if bridge_screening_visible else 0,
+                    "grid_oos_visible_rows": 1 if bridge_oos_visible else 0,
+                    "grid_sufficient_oos_visible_rows": 1 if bridge_sufficient_visible else 0,
                 },
                 "screening_stage_result_counts": dict(
                     evidence.get("screening_stage_result_counts") or {}
@@ -226,6 +291,25 @@ def build_real_basket_evidence_coverage(
                 "evidence_completeness_score_pct": score,
                 "evidence_completeness_status": status,
                 "missing_evidence_taxonomy": missing,
+                "grid_readiness_bridge": {
+                    "readiness_bridge_status": str(
+                        bridge_row.get("readiness_bridge_status") or "blocked_no_grid_match"
+                    ),
+                    "readiness_evidence_status": str(
+                        bridge_row.get("readiness_evidence_status") or "blocked"
+                    ),
+                    "readiness_blocker_category": str(
+                        bridge_row.get("readiness_blocker_category") or "blocked_no_grid_match"
+                    ),
+                    "grid_evidence_present": bool(bridge_row.get("grid_evidence_present")),
+                    "grid_screening_evidence_present": bridge_screening_visible,
+                    "grid_oos_evidence_present": bridge_oos_visible,
+                    "grid_sufficient_oos_evidence_present": bridge_sufficient_visible,
+                    "criteria_failure_classes": list(
+                        bridge_row.get("criteria_failure_classes") or []
+                    ),
+                    "bridge_explanation": str(bridge_row.get("bridge_explanation") or ""),
+                },
                 "follow_up": (
                     "eligible_for_readonly_routing"
                     if score >= 85
@@ -274,10 +358,17 @@ def build_real_basket_evidence_coverage(
                 for row in coverage_rows
             ),
             "evidence_backed_zero_screening": evidence_backed_zero,
+            "source_cache_sidecar_status": source_cache_status,
+            "grid_readiness_bridge_status_counts": dict(
+                Counter(
+                    str((row.get("grid_readiness_bridge") or {}).get("readiness_bridge_status") or "")
+                    for row in coverage_rows
+                )
+            ),
             "operator_summary": (
                 "Real basket evidence coverage maps each production discovery basket to "
-                "lineage, screening, OOS, source, and cache readiness without mutating "
-                "campaigns or promotion state."
+                "lineage, screening, OOS, source, cache, and controlled-grid bridge readiness "
+                "without mutating campaigns or promotion state."
             ),
         },
         "rows": coverage_rows,

--- a/tests/unit/test_qre_candidate_explanation_rows.py
+++ b/tests/unit/test_qre_candidate_explanation_rows.py
@@ -112,6 +112,58 @@ def test_build_candidate_explanation_rows_fail_closed_when_optional_artifacts_mi
     assert aapl["synthesis_gate_state"] == "not_available_fail_closed"
 
 
+def test_candidate_explanations_surface_grid_bridge_blockers(
+    tmp_path: Path,
+) -> None:
+    _seed_complete_aapl_repo(tmp_path)
+    (tmp_path / "research" / "screening_evidence_latest.v1.json").write_text(
+        json.dumps({"candidates": []}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    _write_json(
+        tmp_path / "logs" / "qre_discovery_basket_grid_evidence_materialization" / "latest.json",
+        {
+            "rows": [
+                {
+                    "basket_id": "seed::trend_pullback_continuation_daily_v1::AAPL",
+                    "asset": "AAPL",
+                    "provider_symbol": "AAPL",
+                    "preset": "trend_pullback_continuation_daily_v1",
+                    "matched_grid_rows_count": 1,
+                    "matched_grid_rows": [
+                        {
+                            "run_id": "grid-run-1",
+                            "sequence_number": 1,
+                            "instrument_symbol": "AAPL",
+                            "behavior_preset_id": "trend_pullback_continuation_daily_v1",
+                            "status": "completed",
+                            "outcome_class": "sufficient_oos_evidence",
+                            "criteria_status": "criteria_consistentie_failed",
+                        }
+                    ],
+                    "evidence_exists_in_grid": True,
+                    "source_identity_status": "provider_symbol_verified",
+                    "source_identity_blocker": "",
+                    "metric_consistency_status": "clean_consistent",
+                    "preset_executability_classification": "executable",
+                    "candidate_lineage_status": "missing",
+                    "oos_evidence_status": "sufficient_oos_evidence_present",
+                    "sufficient_oos_evidence_status": "present",
+                    "join_key_status": "grid_row_match_found",
+                    "exact_next_action": "materialize_candidate_lineage",
+                }
+            ]
+        },
+    )
+
+    report = candidate_rows.build_candidate_explanation_rows(repo_root=tmp_path, max_candidates=2)
+
+    rows = {row["symbol"]: row for row in report["rows"]}
+    aapl = rows["AAPL"]
+    assert aapl["grid_readiness_bridge_status"] == "blocked_candidate_lineage_missing"
+    assert aapl["primary_blocker"] == "blocked_candidate_lineage_missing"
+
+
 def test_build_oos_evidence_blockers_classifies_sufficient_and_missing_oos_states(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_qre_grid_evidence_readiness_bridge.py
+++ b/tests/unit/test_qre_grid_evidence_readiness_bridge.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from research import qre_grid_evidence_readiness_bridge as bridge
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _materialization_row(**overrides: object) -> dict[str, object]:
+    row: dict[str, object] = {
+        "basket_id": "seed::trend_pullback_continuation_daily_v1::AAPL",
+        "asset": "AAPL",
+        "canonical_symbol": "AAPL",
+        "provider_symbol": "AAPL",
+        "timeframe": "1d",
+        "preset": "trend_pullback_continuation_daily_v1",
+        "matched_grid_rows_count": 1,
+        "matched_grid_rows": [
+            {
+                "run_id": "grid-run-1",
+                "sequence_number": 1,
+                "instrument_symbol": "AAPL",
+                "behavior_preset_id": "trend_pullback_continuation_daily_v1",
+                "status": "completed",
+                "outcome_class": "sufficient_oos_evidence",
+                "criteria_status": "criteria_consistentie_failed",
+            }
+        ],
+        "evidence_exists_in_grid": True,
+        "source_identity_status": "provider_symbol_verified",
+        "source_identity_blocker": "",
+        "metric_consistency_status": "clean_consistent",
+        "preset_executability_classification": "executable",
+        "candidate_lineage_status": "visible",
+        "oos_evidence_status": "sufficient_oos_evidence_present",
+        "sufficient_oos_evidence_status": "present",
+        "join_key_status": "grid_row_match_found",
+        "exact_next_action": "review_criteria_failures",
+        "survivor_stage_classification": "degenerate_legitimate_no_survivors",
+    }
+    row.update(overrides)
+    return row
+
+
+def test_bridge_marks_clean_sufficient_oos_as_readiness_visible_not_promotable(
+    tmp_path: Path,
+) -> None:
+    _write_json(
+        tmp_path / "logs" / "qre_discovery_basket_grid_evidence_materialization" / "latest.json",
+        {"rows": [_materialization_row()]},
+    )
+
+    report = bridge.build_grid_evidence_readiness_bridge(repo_root=tmp_path, max_candidates=1)
+
+    row = report["rows"][0]
+    assert row["readiness_screening_evidence_visible"] is True
+    assert row["readiness_oos_evidence_visible"] is True
+    assert row["readiness_sufficient_oos_visible"] is True
+    assert row["readiness_bridge_status"] == "bridged_sufficient_oos_but_not_promotion_ready"
+    assert row["promotion_allowed"] is False
+    assert row["promotion_candidate_from_grid"] is False
+
+
+def test_bridge_blocks_metric_inconsistent_grid_rows(
+    tmp_path: Path,
+) -> None:
+    _write_json(
+        tmp_path / "logs" / "qre_discovery_basket_grid_evidence_materialization" / "latest.json",
+        {
+            "rows": [
+                _materialization_row(
+                    metric_consistency_status="inconsistent_oos_gt_total",
+                    exact_next_action="inspect_metric_consistency",
+                )
+            ]
+        },
+    )
+
+    report = bridge.build_grid_evidence_readiness_bridge(repo_root=tmp_path, max_candidates=1)
+
+    row = report["rows"][0]
+    assert row["readiness_oos_evidence_visible"] is False
+    assert row["readiness_sufficient_oos_visible"] is False
+    assert row["readiness_bridge_status"] == "blocked_metric_inconsistent"
+
+
+def test_bridge_blocks_missing_lineage_even_when_sufficient_oos_exists(
+    tmp_path: Path,
+) -> None:
+    _write_json(
+        tmp_path / "logs" / "qre_discovery_basket_grid_evidence_materialization" / "latest.json",
+        {"rows": [_materialization_row(candidate_lineage_status="missing")]},
+    )
+
+    report = bridge.build_grid_evidence_readiness_bridge(repo_root=tmp_path, max_candidates=1)
+
+    row = report["rows"][0]
+    assert row["readiness_screening_evidence_visible"] is True
+    assert row["readiness_oos_evidence_visible"] is True
+    assert row["readiness_sufficient_oos_visible"] is False
+    assert row["readiness_bridge_status"] == "blocked_candidate_lineage_missing"
+
+
+def test_bridge_fails_closed_when_no_grid_match_exists(
+    tmp_path: Path,
+) -> None:
+    _write_json(
+        tmp_path / "logs" / "qre_discovery_basket_grid_evidence_materialization" / "latest.json",
+        {
+            "rows": [
+                _materialization_row(
+                    matched_grid_rows_count=0,
+                    matched_grid_rows=[],
+                    evidence_exists_in_grid=False,
+                    join_key_status="grid_row_match_not_found",
+                    oos_evidence_status="missing",
+                    sufficient_oos_evidence_status="missing",
+                )
+            ]
+        },
+    )
+
+    report = bridge.build_grid_evidence_readiness_bridge(repo_root=tmp_path, max_candidates=1)
+
+    row = report["rows"][0]
+    assert row["readiness_bridge_status"] == "blocked_no_grid_match"
+    assert row["readiness_screening_evidence_visible"] is False
+
+
+def test_bridge_render_and_write_outputs_are_deterministic(
+    tmp_path: Path,
+) -> None:
+    _write_json(
+        tmp_path / "logs" / "qre_discovery_basket_grid_evidence_materialization" / "latest.json",
+        {"rows": [_materialization_row()]},
+    )
+    report = bridge.build_grid_evidence_readiness_bridge(repo_root=tmp_path, max_candidates=1)
+    markdown = bridge.render_operator_summary(report)
+    paths = bridge.write_outputs(report, repo_root=tmp_path)
+
+    assert "# QRE Grid Evidence Readiness Bridge" in markdown
+    assert paths["latest"] == "logs/qre_grid_evidence_readiness_bridge/latest.json"
+    assert paths["operator_summary"] == "logs/qre_grid_evidence_readiness_bridge/operator_summary.md"

--- a/tests/unit/test_qre_pre_shadow_paper_research_readiness.py
+++ b/tests/unit/test_qre_pre_shadow_paper_research_readiness.py
@@ -146,3 +146,19 @@ def test_render_operator_summary_and_write_outputs(tmp_path: Path) -> None:
         paths["operator_summary"]
         == "logs/qre_pre_shadow_paper_research_readiness/operator_summary.md"
     )
+
+
+def test_pre_shadow_readiness_reports_missing_source_sidecars_explicitly(
+    tmp_path: Path,
+) -> None:
+    _seed_complete_aapl_repo(tmp_path)
+    (tmp_path / "logs" / "qre_data_cache_manifest" / "latest.json").unlink()
+    (tmp_path / "logs" / "qre_data_source_quality_readiness" / "latest.json").unlink()
+
+    report = readiness.build_pre_shadow_paper_research_readiness(
+        repo_root=tmp_path,
+        max_candidates=2,
+    )
+
+    assert report["summary"]["source_readiness_linked"] is False
+    assert "missing" in str(report["summary"]["source_readiness_note"]).lower()

--- a/tests/unit/test_qre_real_basket_evidence_coverage.py
+++ b/tests/unit/test_qre_real_basket_evidence_coverage.py
@@ -11,6 +11,13 @@ def _write_json(path: Path, payload: dict) -> None:
     path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 
 
+def _write_bridge_row(tmp_path: Path, row: dict) -> None:
+    _write_json(
+        tmp_path / "logs" / "qre_discovery_basket_grid_evidence_materialization" / "latest.json",
+        {"rows": [row]},
+    )
+
+
 def test_build_real_basket_evidence_coverage_maps_lineage_and_oos_evidence(
     tmp_path: Path,
 ) -> None:
@@ -157,6 +164,132 @@ def test_render_operator_summary_includes_coverage_table(tmp_path: Path) -> None
     assert "## 3. Basket evidence coverage" in markdown
     assert "| AAPL | trend_pullback_continuation_daily_v1 | diagnosable |" in markdown
     assert "no_oos_trades" in markdown
+
+
+def test_grid_bridge_can_make_clean_sufficient_oos_readiness_visible(
+    tmp_path: Path,
+) -> None:
+    _write_json(
+        tmp_path / "logs" / "qre_data_cache_manifest" / "latest.json",
+        {"coverage": [{"instrument": "AAPL", "timeframe": "1d", "ready": True}]},
+    )
+    _write_json(
+        tmp_path / "logs" / "qre_data_source_quality_readiness" / "latest.json",
+        {"rows": [{"instrument": "AAPL", "timeframe": "1d", "quality_status": "ready"}]},
+    )
+    _write_json(tmp_path / "research" / "screening_evidence_latest.v1.json", {"candidates": []})
+    _write_json(
+        tmp_path / "research" / "campaign_registry_latest.v1.json",
+        {
+            "campaigns": {
+                "cmp-1": {
+                    "preset_name": "trend_pullback_continuation_daily_v1",
+                    "hypothesis_id": "trend_pullback_behavior_v1",
+                }
+            }
+        },
+    )
+    _write_json(
+        tmp_path / "research" / "candidate_registry_latest.v1.json",
+        {"candidates": [{"asset": "AAPL", "status": "candidate"}]},
+    )
+    _write_bridge_row(
+        tmp_path,
+        {
+            "basket_id": "seed::trend_pullback_continuation_daily_v1::AAPL",
+            "asset": "AAPL",
+            "provider_symbol": "AAPL",
+            "preset": "trend_pullback_continuation_daily_v1",
+            "matched_grid_rows_count": 1,
+            "matched_grid_rows": [
+                {
+                    "run_id": "grid-run-1",
+                    "sequence_number": 1,
+                    "instrument_symbol": "AAPL",
+                    "behavior_preset_id": "trend_pullback_continuation_daily_v1",
+                    "status": "completed",
+                    "outcome_class": "sufficient_oos_evidence",
+                    "criteria_status": "criteria_consistentie_failed",
+                }
+            ],
+            "evidence_exists_in_grid": True,
+            "source_identity_status": "provider_symbol_verified",
+            "source_identity_blocker": "",
+            "metric_consistency_status": "clean_consistent",
+            "preset_executability_classification": "executable",
+            "candidate_lineage_status": "visible",
+            "oos_evidence_status": "sufficient_oos_evidence_present",
+            "sufficient_oos_evidence_status": "present",
+            "join_key_status": "grid_row_match_found",
+            "exact_next_action": "review_criteria_failures",
+        },
+    )
+
+    report = coverage.build_real_basket_evidence_coverage(repo_root=tmp_path, max_candidates=2)
+
+    rows = {row["symbol"]: row for row in report["rows"]}
+    aapl = rows["AAPL"]
+    assert aapl["validation_evidence_status_counts"] == {"sufficient_oos_evidence": 1}
+    assert aapl["grid_readiness_bridge"]["readiness_bridge_status"] == (
+        "bridged_sufficient_oos_but_not_promotion_ready"
+    )
+    assert report["summary"]["screening_evidence_rows_total"] >= 1
+    assert report["summary"]["sufficient_oos_evidence_rows_total"] == 1
+
+
+def test_grid_bridge_keeps_sufficient_oos_blocked_when_candidate_lineage_missing(
+    tmp_path: Path,
+) -> None:
+    _write_json(
+        tmp_path / "logs" / "qre_data_cache_manifest" / "latest.json",
+        {"coverage": [{"instrument": "AAPL", "timeframe": "1d", "ready": True}]},
+    )
+    _write_json(
+        tmp_path / "logs" / "qre_data_source_quality_readiness" / "latest.json",
+        {"rows": [{"instrument": "AAPL", "timeframe": "1d", "quality_status": "ready"}]},
+    )
+    _write_json(tmp_path / "research" / "screening_evidence_latest.v1.json", {"candidates": []})
+    _write_json(tmp_path / "research" / "campaign_registry_latest.v1.json", {"campaigns": {}})
+    _write_json(tmp_path / "research" / "candidate_registry_latest.v1.json", {"candidates": []})
+    _write_bridge_row(
+        tmp_path,
+        {
+            "basket_id": "seed::trend_pullback_continuation_daily_v1::AAPL",
+            "asset": "AAPL",
+            "provider_symbol": "AAPL",
+            "preset": "trend_pullback_continuation_daily_v1",
+            "matched_grid_rows_count": 1,
+            "matched_grid_rows": [
+                {
+                    "run_id": "grid-run-1",
+                    "sequence_number": 1,
+                    "instrument_symbol": "AAPL",
+                    "behavior_preset_id": "trend_pullback_continuation_daily_v1",
+                    "status": "completed",
+                    "outcome_class": "sufficient_oos_evidence",
+                    "criteria_status": "criteria_consistentie_failed",
+                }
+            ],
+            "evidence_exists_in_grid": True,
+            "source_identity_status": "provider_symbol_verified",
+            "source_identity_blocker": "",
+            "metric_consistency_status": "clean_consistent",
+            "preset_executability_classification": "executable",
+            "candidate_lineage_status": "missing",
+            "oos_evidence_status": "sufficient_oos_evidence_present",
+            "sufficient_oos_evidence_status": "present",
+            "join_key_status": "grid_row_match_found",
+            "exact_next_action": "materialize_candidate_lineage",
+        },
+    )
+
+    report = coverage.build_real_basket_evidence_coverage(repo_root=tmp_path, max_candidates=2)
+
+    rows = {row["symbol"]: row for row in report["rows"]}
+    aapl = rows["AAPL"]
+    assert aapl["grid_readiness_bridge"]["readiness_bridge_status"] == "blocked_candidate_lineage_missing"
+    assert aapl["validation_evidence_status_counts"] == {"grid_oos_evidence_present": 1}
+    assert report["summary"]["sufficient_oos_evidence_rows_total"] == 0
 
 
 def test_write_outputs_writes_only_inside_allowlisted_log_dir(tmp_path: Path) -> None:

--- a/tests/unit/test_qre_routing_readiness_from_basket.py
+++ b/tests/unit/test_qre_routing_readiness_from_basket.py
@@ -133,3 +133,59 @@ def test_render_operator_summary_and_write_outputs(tmp_path: Path) -> None:
     assert "## 2. Routing readiness counts" in markdown
     assert paths["latest"] == "logs/qre_routing_readiness_from_basket/latest.json"
     assert paths["operator_summary"] == "logs/qre_routing_readiness_from_basket/operator_summary.md"
+
+
+def test_grid_bridge_visible_oos_without_lineage_keeps_routing_deferred(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "logs" / "qre_data_cache_manifest" / "latest.json",
+        {"coverage": [{"instrument": "AAPL", "timeframe": "1d", "ready": True}]},
+    )
+    _write_json(
+        tmp_path / "logs" / "qre_data_source_quality_readiness" / "latest.json",
+        {"rows": [{"instrument": "AAPL", "timeframe": "1d", "quality_status": "ready"}]},
+    )
+    _write_json(tmp_path / "research" / "screening_evidence_latest.v1.json", {"candidates": []})
+    _write_json(tmp_path / "research" / "campaign_registry_latest.v1.json", {"campaigns": {}})
+    _write_json(tmp_path / "research" / "candidate_registry_latest.v1.json", {"candidates": []})
+    _write_json(
+        tmp_path / "logs" / "qre_discovery_basket_grid_evidence_materialization" / "latest.json",
+        {
+            "rows": [
+                {
+                    "basket_id": "seed::trend_pullback_continuation_daily_v1::AAPL",
+                    "asset": "AAPL",
+                    "provider_symbol": "AAPL",
+                    "preset": "trend_pullback_continuation_daily_v1",
+                    "matched_grid_rows_count": 1,
+                    "matched_grid_rows": [
+                        {
+                            "run_id": "grid-run-1",
+                            "sequence_number": 1,
+                            "instrument_symbol": "AAPL",
+                            "behavior_preset_id": "trend_pullback_continuation_daily_v1",
+                            "status": "completed",
+                            "outcome_class": "sufficient_oos_evidence",
+                            "criteria_status": "criteria_consistentie_failed",
+                        }
+                    ],
+                    "evidence_exists_in_grid": True,
+                    "source_identity_status": "provider_symbol_verified",
+                    "source_identity_blocker": "",
+                    "metric_consistency_status": "clean_consistent",
+                    "preset_executability_classification": "executable",
+                    "candidate_lineage_status": "missing",
+                    "oos_evidence_status": "sufficient_oos_evidence_present",
+                    "sufficient_oos_evidence_status": "present",
+                    "join_key_status": "grid_row_match_found",
+                    "exact_next_action": "materialize_candidate_lineage",
+                }
+            ]
+        },
+    )
+
+    report = routing.build_routing_readiness_from_basket(repo_root=tmp_path, max_candidates=2)
+
+    rows = {row["symbol"]: row for row in report["rows"]}
+    aapl = rows["AAPL"]
+    assert aapl["routing_readiness_state"] == "deferred"
+    assert aapl["primary_reason_code"] == "lineage_missing"


### PR DESCRIPTION
﻿## Summary
This PR bridges controlled discovery grid evidence into the existing read-only readiness surfaces so basket evidence coverage, routing/sampling inputs, candidate explanations, and pre-shadow/paper readiness can consume clean grid evidence without relaxing promotion standards.

## Why PR #477 showed the gap
PR #477 proved that controlled-grid evidence existed and was diagnosable, but it also showed that 15/15 baskets matched grid rows while 14/15 still had evidence that was invisible to the readiness loop. The readiness surfaces were still reading only direct screening/source/cache/lineage artifacts and had no deterministic bridge from grid materialization into readiness-visible screening/OOS evidence.

## What readiness surfaces now consume from grid evidence
- `research/qre_grid_evidence_readiness_bridge.py` converts materialized grid evidence into deterministic basket-level readiness bridge statuses.
- `research/qre_real_basket_evidence_coverage.py` now consumes clean bridge output so readiness-visible screening/OOS/sufficient-OOS evidence can appear without mutating promotion logic.
- `research/qre_candidate_explanation_rows.py` now surfaces explicit bridge blockers when they are more precise than generic failure-action blockers.
- `research/qre_pre_shadow_paper_research_readiness.py` now reports explicit source/cache sidecar-missing reasons when source readiness is zero because required sidecars are absent or stale.

## What remains blocked
- Metric-inconsistent grid rows remain excluded from clean readiness evidence.
- Source-identity-blocked rows remain excluded.
- Intentionally non-executable and other preset-blocked rows remain excluded.
- Candidate/campaign lineage blockers remain explicit and can still keep sufficient-OOS rows out of readiness-visible sufficient-OOS status.
- Promotion candidates remain governed by existing criteria only.

## Tests run
- `python -m pytest tests/unit/test_qre_grid_evidence_readiness_bridge.py -q`
- `python -m pytest tests/unit/test_qre_discovery_basket_grid_evidence_materialization.py -q`
- `python -m pytest tests/unit/test_qre_controlled_discovery_metric_consistency_audit.py tests/unit/test_qre_controlled_discovery_preset_executability.py tests/unit/test_qre_controlled_discovery_survivor_stage_attribution.py tests/unit/test_qre_discovery_source_identity_diagnostics.py -q`
- `python -m pytest tests/unit/test_qre_real_basket_evidence_coverage.py tests/unit/test_qre_routing_readiness_from_basket.py tests/unit/test_qre_sampling_readiness_from_basket.py tests/unit/test_qre_pre_shadow_paper_research_readiness.py tests/unit/test_qre_hypothesis_seed_feasibility.py tests/unit/test_qre_candidate_explanation_rows.py tests/unit/test_qre_trusted_loop_operator_kpis.py -q`
- `python -m pytest tests -q -k 'controlled_discovery or discovery_grid or source_identity or metric_consistency or preset_executability or survivor_stage'`
- `python -m pytest tests/architecture -q`
- `python -m pytest tests -q -k 'governance or no_touch or frozen_contract or execution_authority'`
- `git diff --check`

## Frozen contracts status
- `research/research_latest.json`: unchanged
- `research/strategy_matrix.csv`: unchanged

## Protected paths status
- `registry.py`: untouched
- `agent/backtesting/strategies.py`: untouched
- broker/risk/execution/order/live/paper/shadow paths: untouched
- dashboard mutation routes: not added
- approval inbox: untouched
- `.claude/**`: untouched

## Paper/shadow/live status
No paper runtime, shadow runtime, or live runtime activation was added. This remains a read-only evidence activation/materialization PR only.

## Known limitations
- Local readiness remains fail-closed when the controlled-grid rerun artifacts are absent from the local checkout.
- The bridge can make clean grid evidence readiness-visible, but it does not fabricate candidate/campaign lineage and does not create promotion candidates.
- Source readiness is still not faked when source/cache sidecars are missing; it is now explicitly diagnosed instead.

## Next recommended action
Follow the bridge with a dedicated lineage/materialization step so candidate/campaign lineage can be made explicit for the known sufficient-OOS grid basket without relaxing promotion gates.
