### PR TITLE
fix: add qre screener recipe library

### DIFF
--- a/artifacts/equity_factors/equity_factor_recipes_latest.v1.json
+++ b/artifacts/equity_factors/equity_factor_recipes_latest.v1.json
@@ -1,0 +1,923 @@
+{
+  "policy_vocabulary": {
+    "blocked_reason_codes": [
+      "FEASIBLE",
+      "BLOCKED_MISSING_UNIVERSE",
+      "BLOCKED_MISSING_FACTOR",
+      "BLOCKED_UNIVERSE_QUALITY_FAIL",
+      "BLOCKED_IDENTITY_AMBIGUITY",
+      "BLOCKED_DATA_READINESS_MISSING",
+      "BLOCKED_FACTOR_FIELD_COVERAGE_MISSING",
+      "BLOCKED_UNKNOWN"
+    ],
+    "forbidden_outputs": [
+      "buy_list",
+      "sell_list",
+      "trade_signal",
+      "strategy_registration",
+      "executable_strategy",
+      "candidate_promotion",
+      "paper_candidate",
+      "shadow_candidate",
+      "live_candidate",
+      "capital_allocation",
+      "broker_execution"
+    ],
+    "output_type": [
+      "hypothesis_seed_candidates"
+    ]
+  },
+  "report_kind": "equity_factor_recipes",
+  "rows": [
+    {
+      "blocked_reason_codes": [
+        "BLOCKED_DATA_READINESS_MISSING"
+      ],
+      "data_readiness_required": "fundamental_manifest_required",
+      "description": "Research-intake recipe for quality and valuation behaviors in Asia developed liquid equities.",
+      "display_name": "Asia Developed Quality Value v0",
+      "exclusion_rules": [
+        "identity_ambiguity",
+        "universe_quality_fail",
+        "missing_required_factor_field"
+      ],
+      "feasibility_status": "BLOCKED_DATA_READINESS_MISSING",
+      "forbidden_outputs": [
+        "buy_list",
+        "sell_list",
+        "trade_signal",
+        "strategy_registration",
+        "executable_strategy",
+        "candidate_promotion",
+        "paper_candidate",
+        "shadow_candidate",
+        "live_candidate",
+        "capital_allocation",
+        "broker_execution"
+      ],
+      "identity_readiness_required": "OK",
+      "liquidity_gate": "high_or_medium",
+      "live_activation_allowed": false,
+      "not_trade_signal": true,
+      "operator_explanation": "Research-only recipe for testing whether quality-plus-value behaviors deserve hypothesis intake in Asia developed universes.",
+      "optional_factor_ids": [
+        "six_month_momentum",
+        "average_daily_value_traded"
+      ],
+      "output_type": "hypothesis_seed_candidates",
+      "paper_activation_allowed": false,
+      "ranking_components": [
+        "quality_rank",
+        "valuation_rank",
+        "liquidity_guardrail"
+      ],
+      "recipe_id": "asia_developed_quality_value_v0",
+      "required_factor_ids": [
+        "roic",
+        "gross_profitability",
+        "book_to_market",
+        "earnings_yield"
+      ],
+      "research_only": true,
+      "shadow_activation_allowed": false,
+      "size_gate": "large_mid",
+      "target_universe_ids": [
+        "asia_developed_liquid"
+      ],
+      "universe_readiness_allowed": [
+        "OK",
+        "WARN"
+      ]
+    },
+    {
+      "blocked_reason_codes": [
+        "BLOCKED_DATA_READINESS_MISSING"
+      ],
+      "data_readiness_required": "fundamental_manifest_required",
+      "description": "Quality and defensive-stability intake recipe with momentum confirmation.",
+      "display_name": "Defensive Quality Momentum v0",
+      "exclusion_rules": [
+        "identity_ambiguity",
+        "universe_quality_fail",
+        "data_readiness_missing"
+      ],
+      "feasibility_status": "BLOCKED_DATA_READINESS_MISSING",
+      "forbidden_outputs": [
+        "buy_list",
+        "sell_list",
+        "trade_signal",
+        "strategy_registration",
+        "executable_strategy",
+        "candidate_promotion",
+        "paper_candidate",
+        "shadow_candidate",
+        "live_candidate",
+        "capital_allocation",
+        "broker_execution"
+      ],
+      "identity_readiness_required": "OK",
+      "liquidity_gate": "high",
+      "live_activation_allowed": false,
+      "not_trade_signal": true,
+      "operator_explanation": "Research-only recipe for defensive compounder behavior; not a buy list.",
+      "optional_factor_ids": [
+        "dividend_yield",
+        "average_daily_value_traded"
+      ],
+      "output_type": "hypothesis_seed_candidates",
+      "paper_activation_allowed": false,
+      "ranking_components": [
+        "quality_rank",
+        "momentum_rank",
+        "defensive_overlay"
+      ],
+      "recipe_id": "defensive_quality_momentum_v0",
+      "required_factor_ids": [
+        "return_on_assets",
+        "gross_profitability",
+        "twelve_month_momentum"
+      ],
+      "research_only": true,
+      "shadow_activation_allowed": false,
+      "size_gate": "large_mid",
+      "target_universe_ids": [
+        "global_developed_liquid"
+      ],
+      "universe_readiness_allowed": [
+        "OK",
+        "WARN"
+      ]
+    },
+    {
+      "blocked_reason_codes": [
+        "BLOCKED_DATA_READINESS_MISSING"
+      ],
+      "data_readiness_required": "fundamental_manifest_required",
+      "description": "Broad Europe large/mid research recipe combining quality, value, and momentum components.",
+      "display_name": "Europe Quality Value Momentum v0",
+      "exclusion_rules": [
+        "identity_ambiguity",
+        "source_manifest_missing",
+        "currency_normalization_missing"
+      ],
+      "feasibility_status": "BLOCKED_DATA_READINESS_MISSING",
+      "forbidden_outputs": [
+        "buy_list",
+        "sell_list",
+        "trade_signal",
+        "strategy_registration",
+        "executable_strategy",
+        "candidate_promotion",
+        "paper_candidate",
+        "shadow_candidate",
+        "live_candidate",
+        "capital_allocation",
+        "broker_execution"
+      ],
+      "identity_readiness_required": "OK",
+      "liquidity_gate": "high_or_medium",
+      "live_activation_allowed": false,
+      "not_trade_signal": true,
+      "operator_explanation": "Research-only intake recipe for Europe quality/value/momentum interactions.",
+      "optional_factor_ids": [
+        "gross_profitability",
+        "adjusted_slope"
+      ],
+      "output_type": "hypothesis_seed_candidates",
+      "paper_activation_allowed": false,
+      "ranking_components": [
+        "quality_rank",
+        "valuation_rank",
+        "momentum_rank"
+      ],
+      "recipe_id": "eu_quality_value_momentum_v0",
+      "required_factor_ids": [
+        "roic",
+        "earnings_yield",
+        "twelve_month_momentum"
+      ],
+      "research_only": true,
+      "shadow_activation_allowed": false,
+      "size_gate": "large_mid",
+      "target_universe_ids": [
+        "europe_large_mid"
+      ],
+      "universe_readiness_allowed": [
+        "OK",
+        "WARN"
+      ]
+    },
+    {
+      "blocked_reason_codes": [
+        "BLOCKED_DATA_READINESS_MISSING"
+      ],
+      "data_readiness_required": "fundamental_manifest_required",
+      "description": "Deep-value research intake with a financial-health guardrail for Europe.",
+      "display_name": "Europe Deep Value Financial Health v0",
+      "exclusion_rules": [
+        "identity_ambiguity",
+        "universe_quality_fail",
+        "restatement_policy_missing"
+      ],
+      "feasibility_status": "BLOCKED_DATA_READINESS_MISSING",
+      "forbidden_outputs": [
+        "buy_list",
+        "sell_list",
+        "trade_signal",
+        "strategy_registration",
+        "executable_strategy",
+        "candidate_promotion",
+        "paper_candidate",
+        "shadow_candidate",
+        "live_candidate",
+        "capital_allocation",
+        "broker_execution"
+      ],
+      "identity_readiness_required": "OK",
+      "liquidity_gate": "medium_or_high",
+      "live_activation_allowed": false,
+      "not_trade_signal": true,
+      "operator_explanation": "Research-only deep-value intake recipe that blocks on weak accounting readiness.",
+      "optional_factor_ids": [
+        "debt_to_equity",
+        "net_debt_to_ebitda"
+      ],
+      "output_type": "hypothesis_seed_candidates",
+      "paper_activation_allowed": false,
+      "ranking_components": [
+        "deep_value_rank",
+        "financial_health_rank"
+      ],
+      "recipe_id": "europe_deep_value_financial_health_v0",
+      "required_factor_ids": [
+        "book_to_market",
+        "price_to_sales",
+        "piotroski_f_score",
+        "altman_z_score"
+      ],
+      "research_only": true,
+      "shadow_activation_allowed": false,
+      "size_gate": "large_small_mid",
+      "target_universe_ids": [
+        "europe_large_mid",
+        "europe_small_mid"
+      ],
+      "universe_readiness_allowed": [
+        "OK",
+        "WARN"
+      ]
+    },
+    {
+      "blocked_reason_codes": [
+        "BLOCKED_DATA_READINESS_MISSING"
+      ],
+      "data_readiness_required": "fundamental_manifest_required",
+      "description": "Europe small/mid quality-plus-value intake recipe for later hypothesis screening.",
+      "display_name": "Europe Small Mid Quality Value v0",
+      "exclusion_rules": [
+        "identity_ambiguity",
+        "field_coverage_missing"
+      ],
+      "feasibility_status": "BLOCKED_DATA_READINESS_MISSING",
+      "forbidden_outputs": [
+        "buy_list",
+        "sell_list",
+        "trade_signal",
+        "strategy_registration",
+        "executable_strategy",
+        "candidate_promotion",
+        "paper_candidate",
+        "shadow_candidate",
+        "live_candidate",
+        "capital_allocation",
+        "broker_execution"
+      ],
+      "identity_readiness_required": "OK",
+      "liquidity_gate": "medium_or_high",
+      "live_activation_allowed": false,
+      "not_trade_signal": true,
+      "operator_explanation": "Research-only small/midcap intake recipe; no trade output is allowed.",
+      "optional_factor_ids": [
+        "return_on_assets",
+        "average_daily_value_traded"
+      ],
+      "output_type": "hypothesis_seed_candidates",
+      "paper_activation_allowed": false,
+      "ranking_components": [
+        "quality_rank",
+        "value_rank",
+        "accounting_cleanliness_rank"
+      ],
+      "recipe_id": "europe_small_mid_quality_value_v0",
+      "required_factor_ids": [
+        "gross_profitability",
+        "book_to_market",
+        "accruals_ratio"
+      ],
+      "research_only": true,
+      "shadow_activation_allowed": false,
+      "size_gate": "small_mid",
+      "target_universe_ids": [
+        "europe_small_mid"
+      ],
+      "universe_readiness_allowed": [
+        "OK",
+        "WARN"
+      ]
+    },
+    {
+      "blocked_reason_codes": [
+        "BLOCKED_DATA_READINESS_MISSING"
+      ],
+      "data_readiness_required": "fundamental_manifest_required",
+      "description": "Global developed quality and momentum intake recipe.",
+      "display_name": "Global Developed Quality Momentum v0",
+      "exclusion_rules": [
+        "identity_ambiguity",
+        "data_readiness_missing"
+      ],
+      "feasibility_status": "BLOCKED_DATA_READINESS_MISSING",
+      "forbidden_outputs": [
+        "buy_list",
+        "sell_list",
+        "trade_signal",
+        "strategy_registration",
+        "executable_strategy",
+        "candidate_promotion",
+        "paper_candidate",
+        "shadow_candidate",
+        "live_candidate",
+        "capital_allocation",
+        "broker_execution"
+      ],
+      "identity_readiness_required": "OK",
+      "liquidity_gate": "high",
+      "live_activation_allowed": false,
+      "not_trade_signal": true,
+      "operator_explanation": "Research-only global developed quality/momentum intake definition.",
+      "optional_factor_ids": [
+        "adjusted_slope",
+        "average_daily_value_traded"
+      ],
+      "output_type": "hypothesis_seed_candidates",
+      "paper_activation_allowed": false,
+      "ranking_components": [
+        "quality_rank",
+        "momentum_rank"
+      ],
+      "recipe_id": "global_developed_quality_momentum_v0",
+      "required_factor_ids": [
+        "roic",
+        "gross_profitability",
+        "twelve_month_momentum"
+      ],
+      "research_only": true,
+      "shadow_activation_allowed": false,
+      "size_gate": "large_mid",
+      "target_universe_ids": [
+        "global_developed_liquid"
+      ],
+      "universe_readiness_allowed": [
+        "OK",
+        "WARN"
+      ]
+    },
+    {
+      "blocked_reason_codes": [
+        "BLOCKED_DATA_READINESS_MISSING"
+      ],
+      "data_readiness_required": "fundamental_manifest_required",
+      "description": "Global developed value-plus-quality intake recipe.",
+      "display_name": "Global Developed Value Quality v0",
+      "exclusion_rules": [
+        "identity_ambiguity",
+        "point_in_time_policy_missing"
+      ],
+      "feasibility_status": "BLOCKED_DATA_READINESS_MISSING",
+      "forbidden_outputs": [
+        "buy_list",
+        "sell_list",
+        "trade_signal",
+        "strategy_registration",
+        "executable_strategy",
+        "candidate_promotion",
+        "paper_candidate",
+        "shadow_candidate",
+        "live_candidate",
+        "capital_allocation",
+        "broker_execution"
+      ],
+      "identity_readiness_required": "OK",
+      "liquidity_gate": "high_or_medium",
+      "live_activation_allowed": false,
+      "not_trade_signal": true,
+      "operator_explanation": "Research-only value/quality intake recipe for global developed equities.",
+      "optional_factor_ids": [
+        "fcf_yield",
+        "gross_profitability"
+      ],
+      "output_type": "hypothesis_seed_candidates",
+      "paper_activation_allowed": false,
+      "ranking_components": [
+        "value_rank",
+        "quality_rank"
+      ],
+      "recipe_id": "global_developed_value_quality_v0",
+      "required_factor_ids": [
+        "book_to_market",
+        "earnings_yield",
+        "return_on_assets"
+      ],
+      "research_only": true,
+      "shadow_activation_allowed": false,
+      "size_gate": "large_mid",
+      "target_universe_ids": [
+        "global_developed_liquid"
+      ],
+      "universe_readiness_allowed": [
+        "OK",
+        "WARN"
+      ]
+    },
+    {
+      "blocked_reason_codes": [
+        "BLOCKED_DATA_READINESS_MISSING"
+      ],
+      "data_readiness_required": "fundamental_manifest_required",
+      "description": "Accounting-quality intake recipe using low accruals and profitability signals.",
+      "display_name": "Low Accrual Quality v0",
+      "exclusion_rules": [
+        "identity_ambiguity",
+        "restatement_policy_missing"
+      ],
+      "feasibility_status": "BLOCKED_DATA_READINESS_MISSING",
+      "forbidden_outputs": [
+        "buy_list",
+        "sell_list",
+        "trade_signal",
+        "strategy_registration",
+        "executable_strategy",
+        "candidate_promotion",
+        "paper_candidate",
+        "shadow_candidate",
+        "live_candidate",
+        "capital_allocation",
+        "broker_execution"
+      ],
+      "identity_readiness_required": "OK",
+      "liquidity_gate": "high_or_medium",
+      "live_activation_allowed": false,
+      "not_trade_signal": true,
+      "operator_explanation": "Research-only low-accrual quality intake recipe; blocked until accounting field coverage is known.",
+      "optional_factor_ids": [
+        "piotroski_f_score"
+      ],
+      "output_type": "hypothesis_seed_candidates",
+      "paper_activation_allowed": false,
+      "ranking_components": [
+        "accounting_cleanliness_rank",
+        "quality_rank"
+      ],
+      "recipe_id": "low_accrual_quality_v0",
+      "required_factor_ids": [
+        "accruals_ratio",
+        "gross_profitability",
+        "return_on_assets"
+      ],
+      "research_only": true,
+      "shadow_activation_allowed": false,
+      "size_gate": "large_mid",
+      "target_universe_ids": [
+        "global_developed_liquid"
+      ],
+      "universe_readiness_allowed": [
+        "OK",
+        "WARN"
+      ]
+    },
+    {
+      "blocked_reason_codes": [
+        "BLOCKED_DATA_READINESS_MISSING"
+      ],
+      "data_readiness_required": "fundamental_manifest_required",
+      "description": "Research-only recipe inspired by EBIT yield plus return on capital ranking.",
+      "display_name": "Magic Formula Style v0",
+      "exclusion_rules": [
+        "identity_ambiguity",
+        "enterprise_value_field_missing"
+      ],
+      "feasibility_status": "BLOCKED_DATA_READINESS_MISSING",
+      "forbidden_outputs": [
+        "buy_list",
+        "sell_list",
+        "trade_signal",
+        "strategy_registration",
+        "executable_strategy",
+        "candidate_promotion",
+        "paper_candidate",
+        "shadow_candidate",
+        "live_candidate",
+        "capital_allocation",
+        "broker_execution"
+      ],
+      "identity_readiness_required": "OK",
+      "liquidity_gate": "high_or_medium",
+      "live_activation_allowed": false,
+      "not_trade_signal": true,
+      "operator_explanation": "Research-only intake recipe capturing magic-formula style behavior without creating tradable output.",
+      "optional_factor_ids": [
+        "average_daily_value_traded"
+      ],
+      "output_type": "hypothesis_seed_candidates",
+      "paper_activation_allowed": false,
+      "ranking_components": [
+        "value_rank",
+        "quality_rank"
+      ],
+      "recipe_id": "magic_formula_style_v0",
+      "required_factor_ids": [
+        "enterprise_value_to_ebit",
+        "roic"
+      ],
+      "research_only": true,
+      "shadow_activation_allowed": false,
+      "size_gate": "large_mid",
+      "target_universe_ids": [
+        "global_developed_liquid"
+      ],
+      "universe_readiness_allowed": [
+        "OK",
+        "WARN"
+      ]
+    },
+    {
+      "blocked_reason_codes": [
+        "BLOCKED_DATA_READINESS_MISSING"
+      ],
+      "data_readiness_required": "fundamental_manifest_required",
+      "description": "Netherlands quality and liquidity intake recipe for large liquid names.",
+      "display_name": "NL Quality Large Liquid v0",
+      "exclusion_rules": [
+        "identity_ambiguity",
+        "universe_quality_fail"
+      ],
+      "feasibility_status": "BLOCKED_DATA_READINESS_MISSING",
+      "forbidden_outputs": [
+        "buy_list",
+        "sell_list",
+        "trade_signal",
+        "strategy_registration",
+        "executable_strategy",
+        "candidate_promotion",
+        "paper_candidate",
+        "shadow_candidate",
+        "live_candidate",
+        "capital_allocation",
+        "broker_execution"
+      ],
+      "identity_readiness_required": "OK",
+      "liquidity_gate": "high",
+      "live_activation_allowed": false,
+      "not_trade_signal": true,
+      "operator_explanation": "Research-only Dutch large/liquid intake recipe. Universe membership is not a signal.",
+      "optional_factor_ids": [
+        "return_on_assets",
+        "dividend_yield"
+      ],
+      "output_type": "hypothesis_seed_candidates",
+      "paper_activation_allowed": false,
+      "ranking_components": [
+        "quality_rank",
+        "liquidity_rank"
+      ],
+      "recipe_id": "nl_quality_large_liquid_v0",
+      "required_factor_ids": [
+        "roic",
+        "gross_profitability",
+        "average_daily_value_traded"
+      ],
+      "research_only": true,
+      "shadow_activation_allowed": false,
+      "size_gate": "large",
+      "target_universe_ids": [
+        "nl_equities"
+      ],
+      "universe_readiness_allowed": [
+        "OK",
+        "WARN"
+      ]
+    },
+    {
+      "blocked_reason_codes": [
+        "BLOCKED_DATA_READINESS_MISSING"
+      ],
+      "data_readiness_required": "fundamental_manifest_required",
+      "description": "Nordics quality-compounder intake recipe.",
+      "display_name": "Nordics Quality Compounders v0",
+      "exclusion_rules": [
+        "identity_ambiguity",
+        "report_lag_policy_missing"
+      ],
+      "feasibility_status": "BLOCKED_DATA_READINESS_MISSING",
+      "forbidden_outputs": [
+        "buy_list",
+        "sell_list",
+        "trade_signal",
+        "strategy_registration",
+        "executable_strategy",
+        "candidate_promotion",
+        "paper_candidate",
+        "shadow_candidate",
+        "live_candidate",
+        "capital_allocation",
+        "broker_execution"
+      ],
+      "identity_readiness_required": "OK",
+      "liquidity_gate": "high_or_medium",
+      "live_activation_allowed": false,
+      "not_trade_signal": true,
+      "operator_explanation": "Research-only Nordics quality-compounder intake definition.",
+      "optional_factor_ids": [
+        "dividend_yield",
+        "accruals_ratio"
+      ],
+      "output_type": "hypothesis_seed_candidates",
+      "paper_activation_allowed": false,
+      "ranking_components": [
+        "quality_rank",
+        "momentum_rank",
+        "compounder_stability_rank"
+      ],
+      "recipe_id": "nordics_quality_compounders_v0",
+      "required_factor_ids": [
+        "roic",
+        "gross_profitability",
+        "twelve_month_momentum"
+      ],
+      "research_only": true,
+      "shadow_activation_allowed": false,
+      "size_gate": "large_mid",
+      "target_universe_ids": [
+        "nordics_equities"
+      ],
+      "universe_readiness_allowed": [
+        "OK",
+        "WARN"
+      ]
+    },
+    {
+      "blocked_reason_codes": [
+        "BLOCKED_DATA_READINESS_MISSING"
+      ],
+      "data_readiness_required": "fundamental_manifest_required",
+      "description": "Research-only value style recipe requiring Piotroski support.",
+      "display_name": "Piotroski Value Style v0",
+      "exclusion_rules": [
+        "identity_ambiguity",
+        "multi_period_fundamentals_missing"
+      ],
+      "feasibility_status": "BLOCKED_DATA_READINESS_MISSING",
+      "forbidden_outputs": [
+        "buy_list",
+        "sell_list",
+        "trade_signal",
+        "strategy_registration",
+        "executable_strategy",
+        "candidate_promotion",
+        "paper_candidate",
+        "shadow_candidate",
+        "live_candidate",
+        "capital_allocation",
+        "broker_execution"
+      ],
+      "identity_readiness_required": "OK",
+      "liquidity_gate": "high_or_medium",
+      "live_activation_allowed": false,
+      "not_trade_signal": true,
+      "operator_explanation": "Research-only Piotroski-style intake recipe.",
+      "optional_factor_ids": [
+        "altman_z_score",
+        "debt_to_equity"
+      ],
+      "output_type": "hypothesis_seed_candidates",
+      "paper_activation_allowed": false,
+      "ranking_components": [
+        "value_rank",
+        "financial_health_rank"
+      ],
+      "recipe_id": "piotroski_value_style_v0",
+      "required_factor_ids": [
+        "book_to_market",
+        "piotroski_f_score"
+      ],
+      "research_only": true,
+      "shadow_activation_allowed": false,
+      "size_gate": "large_mid",
+      "target_universe_ids": [
+        "global_developed_liquid"
+      ],
+      "universe_readiness_allowed": [
+        "OK",
+        "WARN"
+      ]
+    },
+    {
+      "blocked_reason_codes": [
+        "BLOCKED_DATA_READINESS_MISSING"
+      ],
+      "data_readiness_required": "fundamental_manifest_required",
+      "description": "Defensive quality intake recipe over Swiss equities.",
+      "display_name": "Switzerland Defensive Quality v0",
+      "exclusion_rules": [
+        "identity_ambiguity",
+        "currency_normalization_missing"
+      ],
+      "feasibility_status": "BLOCKED_DATA_READINESS_MISSING",
+      "forbidden_outputs": [
+        "buy_list",
+        "sell_list",
+        "trade_signal",
+        "strategy_registration",
+        "executable_strategy",
+        "candidate_promotion",
+        "paper_candidate",
+        "shadow_candidate",
+        "live_candidate",
+        "capital_allocation",
+        "broker_execution"
+      ],
+      "identity_readiness_required": "OK",
+      "liquidity_gate": "high_or_medium",
+      "live_activation_allowed": false,
+      "not_trade_signal": true,
+      "operator_explanation": "Research-only Swiss defensive-quality intake definition.",
+      "optional_factor_ids": [
+        "six_month_momentum"
+      ],
+      "output_type": "hypothesis_seed_candidates",
+      "paper_activation_allowed": false,
+      "ranking_components": [
+        "defensive_quality_rank",
+        "income_support_rank"
+      ],
+      "recipe_id": "switzerland_defensive_quality_v0",
+      "required_factor_ids": [
+        "return_on_assets",
+        "gross_profitability",
+        "dividend_yield"
+      ],
+      "research_only": true,
+      "shadow_activation_allowed": false,
+      "size_gate": "large_mid",
+      "target_universe_ids": [
+        "switzerland_equities"
+      ],
+      "universe_readiness_allowed": [
+        "OK",
+        "WARN"
+      ]
+    },
+    {
+      "blocked_reason_codes": [
+        "BLOCKED_DATA_READINESS_MISSING"
+      ],
+      "data_readiness_required": "fundamental_manifest_required",
+      "description": "US quality and momentum intake recipe for liquid large/mid equities.",
+      "display_name": "US Quality Momentum Large Mid v0",
+      "exclusion_rules": [
+        "identity_ambiguity",
+        "field_coverage_missing"
+      ],
+      "feasibility_status": "BLOCKED_DATA_READINESS_MISSING",
+      "forbidden_outputs": [
+        "buy_list",
+        "sell_list",
+        "trade_signal",
+        "strategy_registration",
+        "executable_strategy",
+        "candidate_promotion",
+        "paper_candidate",
+        "shadow_candidate",
+        "live_candidate",
+        "capital_allocation",
+        "broker_execution"
+      ],
+      "identity_readiness_required": "OK",
+      "liquidity_gate": "high",
+      "live_activation_allowed": false,
+      "not_trade_signal": true,
+      "operator_explanation": "Research-only US quality/momentum intake definition.",
+      "optional_factor_ids": [
+        "adjusted_slope",
+        "average_daily_value_traded"
+      ],
+      "output_type": "hypothesis_seed_candidates",
+      "paper_activation_allowed": false,
+      "ranking_components": [
+        "quality_rank",
+        "momentum_rank",
+        "liquidity_guardrail"
+      ],
+      "recipe_id": "us_quality_momentum_large_mid_v0",
+      "required_factor_ids": [
+        "roic",
+        "gross_profitability",
+        "twelve_month_momentum"
+      ],
+      "research_only": true,
+      "shadow_activation_allowed": false,
+      "size_gate": "large_mid",
+      "target_universe_ids": [
+        "us_large_mid",
+        "us_quality_liquid"
+      ],
+      "universe_readiness_allowed": [
+        "OK",
+        "WARN"
+      ]
+    },
+    {
+      "blocked_reason_codes": [
+        "BLOCKED_DATA_READINESS_MISSING"
+      ],
+      "data_readiness_required": "fundamental_manifest_required",
+      "description": "US shareholder-yield plus quality intake recipe.",
+      "display_name": "US Shareholder Yield Quality v0",
+      "exclusion_rules": [
+        "identity_ambiguity",
+        "capital_returns_data_missing"
+      ],
+      "feasibility_status": "BLOCKED_DATA_READINESS_MISSING",
+      "forbidden_outputs": [
+        "buy_list",
+        "sell_list",
+        "trade_signal",
+        "strategy_registration",
+        "executable_strategy",
+        "candidate_promotion",
+        "paper_candidate",
+        "shadow_candidate",
+        "live_candidate",
+        "capital_allocation",
+        "broker_execution"
+      ],
+      "identity_readiness_required": "OK",
+      "liquidity_gate": "high",
+      "live_activation_allowed": false,
+      "not_trade_signal": true,
+      "operator_explanation": "Research-only shareholder-yield intake recipe for US large/mid equities.",
+      "optional_factor_ids": [
+        "buyback_yield",
+        "dividend_yield"
+      ],
+      "output_type": "hypothesis_seed_candidates",
+      "paper_activation_allowed": false,
+      "ranking_components": [
+        "shareholder_return_rank",
+        "quality_rank"
+      ],
+      "recipe_id": "us_shareholder_yield_quality_v0",
+      "required_factor_ids": [
+        "shareholder_yield",
+        "return_on_assets",
+        "gross_profitability"
+      ],
+      "research_only": true,
+      "shadow_activation_allowed": false,
+      "size_gate": "large_mid",
+      "target_universe_ids": [
+        "us_large_mid",
+        "us_quality_liquid"
+      ],
+      "universe_readiness_allowed": [
+        "OK",
+        "WARN"
+      ]
+    }
+  ],
+  "safety_invariants": {
+    "broker_risk_execution_forbidden": true,
+    "mutates_frozen_contracts": false,
+    "mutates_registry": false,
+    "not_trade_signal": true,
+    "paper_shadow_live_forbidden": true,
+    "research_only": true
+  },
+  "schema_version": "1.0",
+  "summary": {
+    "blocked_reason_counts": {
+      "BLOCKED_DATA_READINESS_MISSING": 15,
+      "BLOCKED_FACTOR_FIELD_COVERAGE_MISSING": 0,
+      "BLOCKED_IDENTITY_AMBIGUITY": 0,
+      "BLOCKED_MISSING_FACTOR": 0,
+      "BLOCKED_MISSING_UNIVERSE": 0,
+      "BLOCKED_UNIVERSE_QUALITY_FAIL": 0,
+      "BLOCKED_UNKNOWN": 0,
+      "FEASIBLE": 0
+    },
+    "blocked_recipe_count": 15,
+    "feasible_recipe_count": 0,
+    "operator_summary": "Screener recipes are deterministic research-intake definitions only. They can emit blocked visibility for hypothesis intake, but never trade, promote, or execute.",
+    "recipe_count": 15
+  }
+}

--- a/research/equity_factors/__init__.py
+++ b/research/equity_factors/__init__.py
@@ -4,8 +4,10 @@ from research.equity_factors.factor_catalog import (
     build_equity_factor_calculation_contracts,
     build_equity_factor_catalog,
 )
+from research.equity_factors.recipe_catalog import build_equity_factor_recipe_catalog
 
 __all__ = [
     "build_equity_factor_calculation_contracts",
     "build_equity_factor_catalog",
+    "build_equity_factor_recipe_catalog",
 ]

--- a/research/equity_factors/recipe_catalog.py
+++ b/research/equity_factors/recipe_catalog.py
@@ -1,0 +1,358 @@
+"""Deterministic research-only screener recipe catalog."""
+
+from __future__ import annotations
+
+from typing import Final
+
+from research.equity_factors.factor_catalog import build_equity_factor_catalog
+from research.equity_regions import UNIVERSE_DEFINITIONS
+
+
+SCHEMA_VERSION: Final[str] = "1.0"
+REPORT_KIND: Final[str] = "equity_factor_recipes"
+OUTPUT_TYPE: Final[str] = "hypothesis_seed_candidates"
+FORBIDDEN_OUTPUTS: Final[tuple[str, ...]] = (
+    "buy_list",
+    "sell_list",
+    "trade_signal",
+    "strategy_registration",
+    "executable_strategy",
+    "candidate_promotion",
+    "paper_candidate",
+    "shadow_candidate",
+    "live_candidate",
+    "capital_allocation",
+    "broker_execution",
+)
+BLOCK_REASON_VOCABULARY: Final[tuple[str, ...]] = (
+    "FEASIBLE",
+    "BLOCKED_MISSING_UNIVERSE",
+    "BLOCKED_MISSING_FACTOR",
+    "BLOCKED_UNIVERSE_QUALITY_FAIL",
+    "BLOCKED_IDENTITY_AMBIGUITY",
+    "BLOCKED_DATA_READINESS_MISSING",
+    "BLOCKED_FACTOR_FIELD_COVERAGE_MISSING",
+    "BLOCKED_UNKNOWN",
+)
+
+RECIPE_ROWS: Final[tuple[dict[str, object], ...]] = (
+    {
+        "recipe_id": "asia_developed_quality_value_v0",
+        "display_name": "Asia Developed Quality Value v0",
+        "description": "Research-intake recipe for quality and valuation behaviors in Asia developed liquid equities.",
+        "target_universe_ids": ["asia_developed_liquid"],
+        "required_factor_ids": ["roic", "gross_profitability", "book_to_market", "earnings_yield"],
+        "optional_factor_ids": ["six_month_momentum", "average_daily_value_traded"],
+        "liquidity_gate": "high_or_medium",
+        "size_gate": "large_mid",
+        "identity_readiness_required": "OK",
+        "universe_readiness_allowed": ["OK", "WARN"],
+        "data_readiness_required": "fundamental_manifest_required",
+        "ranking_components": ["quality_rank", "valuation_rank", "liquidity_guardrail"],
+        "exclusion_rules": ["identity_ambiguity", "universe_quality_fail", "missing_required_factor_field"],
+        "operator_explanation": "Research-only recipe for testing whether quality-plus-value behaviors deserve hypothesis intake in Asia developed universes.",
+    },
+    {
+        "recipe_id": "defensive_quality_momentum_v0",
+        "display_name": "Defensive Quality Momentum v0",
+        "description": "Quality and defensive-stability intake recipe with momentum confirmation.",
+        "target_universe_ids": ["global_developed_liquid"],
+        "required_factor_ids": ["return_on_assets", "gross_profitability", "twelve_month_momentum"],
+        "optional_factor_ids": ["dividend_yield", "average_daily_value_traded"],
+        "liquidity_gate": "high",
+        "size_gate": "large_mid",
+        "identity_readiness_required": "OK",
+        "universe_readiness_allowed": ["OK", "WARN"],
+        "data_readiness_required": "fundamental_manifest_required",
+        "ranking_components": ["quality_rank", "momentum_rank", "defensive_overlay"],
+        "exclusion_rules": ["identity_ambiguity", "universe_quality_fail", "data_readiness_missing"],
+        "operator_explanation": "Research-only recipe for defensive compounder behavior; not a buy list.",
+    },
+    {
+        "recipe_id": "eu_quality_value_momentum_v0",
+        "display_name": "Europe Quality Value Momentum v0",
+        "description": "Broad Europe large/mid research recipe combining quality, value, and momentum components.",
+        "target_universe_ids": ["europe_large_mid"],
+        "required_factor_ids": ["roic", "earnings_yield", "twelve_month_momentum"],
+        "optional_factor_ids": ["gross_profitability", "adjusted_slope"],
+        "liquidity_gate": "high_or_medium",
+        "size_gate": "large_mid",
+        "identity_readiness_required": "OK",
+        "universe_readiness_allowed": ["OK", "WARN"],
+        "data_readiness_required": "fundamental_manifest_required",
+        "ranking_components": ["quality_rank", "valuation_rank", "momentum_rank"],
+        "exclusion_rules": ["identity_ambiguity", "source_manifest_missing", "currency_normalization_missing"],
+        "operator_explanation": "Research-only intake recipe for Europe quality/value/momentum interactions.",
+    },
+    {
+        "recipe_id": "europe_deep_value_financial_health_v0",
+        "display_name": "Europe Deep Value Financial Health v0",
+        "description": "Deep-value research intake with a financial-health guardrail for Europe.",
+        "target_universe_ids": ["europe_large_mid", "europe_small_mid"],
+        "required_factor_ids": ["book_to_market", "price_to_sales", "piotroski_f_score", "altman_z_score"],
+        "optional_factor_ids": ["debt_to_equity", "net_debt_to_ebitda"],
+        "liquidity_gate": "medium_or_high",
+        "size_gate": "large_small_mid",
+        "identity_readiness_required": "OK",
+        "universe_readiness_allowed": ["OK", "WARN"],
+        "data_readiness_required": "fundamental_manifest_required",
+        "ranking_components": ["deep_value_rank", "financial_health_rank"],
+        "exclusion_rules": ["identity_ambiguity", "universe_quality_fail", "restatement_policy_missing"],
+        "operator_explanation": "Research-only deep-value intake recipe that blocks on weak accounting readiness.",
+    },
+    {
+        "recipe_id": "europe_small_mid_quality_value_v0",
+        "display_name": "Europe Small Mid Quality Value v0",
+        "description": "Europe small/mid quality-plus-value intake recipe for later hypothesis screening.",
+        "target_universe_ids": ["europe_small_mid"],
+        "required_factor_ids": ["gross_profitability", "book_to_market", "accruals_ratio"],
+        "optional_factor_ids": ["return_on_assets", "average_daily_value_traded"],
+        "liquidity_gate": "medium_or_high",
+        "size_gate": "small_mid",
+        "identity_readiness_required": "OK",
+        "universe_readiness_allowed": ["OK", "WARN"],
+        "data_readiness_required": "fundamental_manifest_required",
+        "ranking_components": ["quality_rank", "value_rank", "accounting_cleanliness_rank"],
+        "exclusion_rules": ["identity_ambiguity", "field_coverage_missing"],
+        "operator_explanation": "Research-only small/midcap intake recipe; no trade output is allowed.",
+    },
+    {
+        "recipe_id": "global_developed_quality_momentum_v0",
+        "display_name": "Global Developed Quality Momentum v0",
+        "description": "Global developed quality and momentum intake recipe.",
+        "target_universe_ids": ["global_developed_liquid"],
+        "required_factor_ids": ["roic", "gross_profitability", "twelve_month_momentum"],
+        "optional_factor_ids": ["adjusted_slope", "average_daily_value_traded"],
+        "liquidity_gate": "high",
+        "size_gate": "large_mid",
+        "identity_readiness_required": "OK",
+        "universe_readiness_allowed": ["OK", "WARN"],
+        "data_readiness_required": "fundamental_manifest_required",
+        "ranking_components": ["quality_rank", "momentum_rank"],
+        "exclusion_rules": ["identity_ambiguity", "data_readiness_missing"],
+        "operator_explanation": "Research-only global developed quality/momentum intake definition.",
+    },
+    {
+        "recipe_id": "global_developed_value_quality_v0",
+        "display_name": "Global Developed Value Quality v0",
+        "description": "Global developed value-plus-quality intake recipe.",
+        "target_universe_ids": ["global_developed_liquid"],
+        "required_factor_ids": ["book_to_market", "earnings_yield", "return_on_assets"],
+        "optional_factor_ids": ["fcf_yield", "gross_profitability"],
+        "liquidity_gate": "high_or_medium",
+        "size_gate": "large_mid",
+        "identity_readiness_required": "OK",
+        "universe_readiness_allowed": ["OK", "WARN"],
+        "data_readiness_required": "fundamental_manifest_required",
+        "ranking_components": ["value_rank", "quality_rank"],
+        "exclusion_rules": ["identity_ambiguity", "point_in_time_policy_missing"],
+        "operator_explanation": "Research-only value/quality intake recipe for global developed equities.",
+    },
+    {
+        "recipe_id": "low_accrual_quality_v0",
+        "display_name": "Low Accrual Quality v0",
+        "description": "Accounting-quality intake recipe using low accruals and profitability signals.",
+        "target_universe_ids": ["global_developed_liquid"],
+        "required_factor_ids": ["accruals_ratio", "gross_profitability", "return_on_assets"],
+        "optional_factor_ids": ["piotroski_f_score"],
+        "liquidity_gate": "high_or_medium",
+        "size_gate": "large_mid",
+        "identity_readiness_required": "OK",
+        "universe_readiness_allowed": ["OK", "WARN"],
+        "data_readiness_required": "fundamental_manifest_required",
+        "ranking_components": ["accounting_cleanliness_rank", "quality_rank"],
+        "exclusion_rules": ["identity_ambiguity", "restatement_policy_missing"],
+        "operator_explanation": "Research-only low-accrual quality intake recipe; blocked until accounting field coverage is known.",
+    },
+    {
+        "recipe_id": "magic_formula_style_v0",
+        "display_name": "Magic Formula Style v0",
+        "description": "Research-only recipe inspired by EBIT yield plus return on capital ranking.",
+        "target_universe_ids": ["global_developed_liquid"],
+        "required_factor_ids": ["enterprise_value_to_ebit", "roic"],
+        "optional_factor_ids": ["average_daily_value_traded"],
+        "liquidity_gate": "high_or_medium",
+        "size_gate": "large_mid",
+        "identity_readiness_required": "OK",
+        "universe_readiness_allowed": ["OK", "WARN"],
+        "data_readiness_required": "fundamental_manifest_required",
+        "ranking_components": ["value_rank", "quality_rank"],
+        "exclusion_rules": ["identity_ambiguity", "enterprise_value_field_missing"],
+        "operator_explanation": "Research-only intake recipe capturing magic-formula style behavior without creating tradable output.",
+    },
+    {
+        "recipe_id": "nl_quality_large_liquid_v0",
+        "display_name": "NL Quality Large Liquid v0",
+        "description": "Netherlands quality and liquidity intake recipe for large liquid names.",
+        "target_universe_ids": ["nl_equities"],
+        "required_factor_ids": ["roic", "gross_profitability", "average_daily_value_traded"],
+        "optional_factor_ids": ["return_on_assets", "dividend_yield"],
+        "liquidity_gate": "high",
+        "size_gate": "large",
+        "identity_readiness_required": "OK",
+        "universe_readiness_allowed": ["OK", "WARN"],
+        "data_readiness_required": "fundamental_manifest_required",
+        "ranking_components": ["quality_rank", "liquidity_rank"],
+        "exclusion_rules": ["identity_ambiguity", "universe_quality_fail"],
+        "operator_explanation": "Research-only Dutch large/liquid intake recipe. Universe membership is not a signal.",
+    },
+    {
+        "recipe_id": "nordics_quality_compounders_v0",
+        "display_name": "Nordics Quality Compounders v0",
+        "description": "Nordics quality-compounder intake recipe.",
+        "target_universe_ids": ["nordics_equities"],
+        "required_factor_ids": ["roic", "gross_profitability", "twelve_month_momentum"],
+        "optional_factor_ids": ["dividend_yield", "accruals_ratio"],
+        "liquidity_gate": "high_or_medium",
+        "size_gate": "large_mid",
+        "identity_readiness_required": "OK",
+        "universe_readiness_allowed": ["OK", "WARN"],
+        "data_readiness_required": "fundamental_manifest_required",
+        "ranking_components": ["quality_rank", "momentum_rank", "compounder_stability_rank"],
+        "exclusion_rules": ["identity_ambiguity", "report_lag_policy_missing"],
+        "operator_explanation": "Research-only Nordics quality-compounder intake definition.",
+    },
+    {
+        "recipe_id": "piotroski_value_style_v0",
+        "display_name": "Piotroski Value Style v0",
+        "description": "Research-only value style recipe requiring Piotroski support.",
+        "target_universe_ids": ["global_developed_liquid"],
+        "required_factor_ids": ["book_to_market", "piotroski_f_score"],
+        "optional_factor_ids": ["altman_z_score", "debt_to_equity"],
+        "liquidity_gate": "high_or_medium",
+        "size_gate": "large_mid",
+        "identity_readiness_required": "OK",
+        "universe_readiness_allowed": ["OK", "WARN"],
+        "data_readiness_required": "fundamental_manifest_required",
+        "ranking_components": ["value_rank", "financial_health_rank"],
+        "exclusion_rules": ["identity_ambiguity", "multi_period_fundamentals_missing"],
+        "operator_explanation": "Research-only Piotroski-style intake recipe.",
+    },
+    {
+        "recipe_id": "switzerland_defensive_quality_v0",
+        "display_name": "Switzerland Defensive Quality v0",
+        "description": "Defensive quality intake recipe over Swiss equities.",
+        "target_universe_ids": ["switzerland_equities"],
+        "required_factor_ids": ["return_on_assets", "gross_profitability", "dividend_yield"],
+        "optional_factor_ids": ["six_month_momentum"],
+        "liquidity_gate": "high_or_medium",
+        "size_gate": "large_mid",
+        "identity_readiness_required": "OK",
+        "universe_readiness_allowed": ["OK", "WARN"],
+        "data_readiness_required": "fundamental_manifest_required",
+        "ranking_components": ["defensive_quality_rank", "income_support_rank"],
+        "exclusion_rules": ["identity_ambiguity", "currency_normalization_missing"],
+        "operator_explanation": "Research-only Swiss defensive-quality intake definition.",
+    },
+    {
+        "recipe_id": "us_quality_momentum_large_mid_v0",
+        "display_name": "US Quality Momentum Large Mid v0",
+        "description": "US quality and momentum intake recipe for liquid large/mid equities.",
+        "target_universe_ids": ["us_large_mid", "us_quality_liquid"],
+        "required_factor_ids": ["roic", "gross_profitability", "twelve_month_momentum"],
+        "optional_factor_ids": ["adjusted_slope", "average_daily_value_traded"],
+        "liquidity_gate": "high",
+        "size_gate": "large_mid",
+        "identity_readiness_required": "OK",
+        "universe_readiness_allowed": ["OK", "WARN"],
+        "data_readiness_required": "fundamental_manifest_required",
+        "ranking_components": ["quality_rank", "momentum_rank", "liquidity_guardrail"],
+        "exclusion_rules": ["identity_ambiguity", "field_coverage_missing"],
+        "operator_explanation": "Research-only US quality/momentum intake definition.",
+    },
+    {
+        "recipe_id": "us_shareholder_yield_quality_v0",
+        "display_name": "US Shareholder Yield Quality v0",
+        "description": "US shareholder-yield plus quality intake recipe.",
+        "target_universe_ids": ["us_large_mid", "us_quality_liquid"],
+        "required_factor_ids": ["shareholder_yield", "return_on_assets", "gross_profitability"],
+        "optional_factor_ids": ["buyback_yield", "dividend_yield"],
+        "liquidity_gate": "high",
+        "size_gate": "large_mid",
+        "identity_readiness_required": "OK",
+        "universe_readiness_allowed": ["OK", "WARN"],
+        "data_readiness_required": "fundamental_manifest_required",
+        "ranking_components": ["shareholder_return_rank", "quality_rank"],
+        "exclusion_rules": ["identity_ambiguity", "capital_returns_data_missing"],
+        "operator_explanation": "Research-only shareholder-yield intake recipe for US large/mid equities.",
+    },
+)
+
+
+def _known_universe_ids() -> set[str]:
+    return {str(row["universe_id"]) for row in UNIVERSE_DEFINITIONS}
+
+
+def _known_factor_ids() -> set[str]:
+    snapshot = build_equity_factor_catalog()
+    return {str(row["factor_id"]) for row in snapshot["rows"]}
+
+
+def _evaluate_recipe(raw_row: dict[str, object]) -> dict[str, object]:
+    universe_ids = [str(item) for item in raw_row["target_universe_ids"]]
+    required_factor_ids = [str(item) for item in raw_row["required_factor_ids"]]
+    optional_factor_ids = [str(item) for item in raw_row["optional_factor_ids"]]
+    missing_universes = sorted(set(universe_ids) - _known_universe_ids())
+    missing_factors = sorted(set(required_factor_ids + optional_factor_ids) - _known_factor_ids())
+    blocked_reason_codes: list[str]
+    feasibility_status: str
+    if missing_universes:
+        feasibility_status = "BLOCKED_MISSING_UNIVERSE"
+        blocked_reason_codes = ["BLOCKED_MISSING_UNIVERSE"]
+    elif missing_factors:
+        feasibility_status = "BLOCKED_MISSING_FACTOR"
+        blocked_reason_codes = ["BLOCKED_MISSING_FACTOR"]
+    else:
+        feasibility_status = "BLOCKED_DATA_READINESS_MISSING"
+        blocked_reason_codes = ["BLOCKED_DATA_READINESS_MISSING"]
+    return {
+        **raw_row,
+        "target_universe_ids": universe_ids,
+        "required_factor_ids": required_factor_ids,
+        "optional_factor_ids": optional_factor_ids,
+        "output_type": OUTPUT_TYPE,
+        "forbidden_outputs": list(FORBIDDEN_OUTPUTS),
+        "feasibility_status": feasibility_status,
+        "blocked_reason_codes": blocked_reason_codes,
+        "research_only": True,
+        "not_trade_signal": True,
+        "paper_activation_allowed": False,
+        "shadow_activation_allowed": False,
+        "live_activation_allowed": False,
+    }
+
+
+def build_equity_factor_recipe_catalog() -> dict[str, object]:
+    rows = [_evaluate_recipe(dict(row)) for row in RECIPE_ROWS]
+    rows.sort(key=lambda row: str(row["recipe_id"]))
+    blocked_counts: dict[str, int] = {}
+    for reason in BLOCK_REASON_VOCABULARY:
+        blocked_counts[reason] = sum(reason in row["blocked_reason_codes"] for row in rows)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "summary": {
+            "recipe_count": len(rows),
+            "feasible_recipe_count": sum(row["feasibility_status"] == "FEASIBLE" for row in rows),
+            "blocked_recipe_count": sum(row["feasibility_status"] != "FEASIBLE" for row in rows),
+            "blocked_reason_counts": blocked_counts,
+            "operator_summary": (
+                "Screener recipes are deterministic research-intake definitions only. "
+                "They can emit blocked visibility for hypothesis intake, but never trade, promote, or execute."
+            ),
+        },
+        "rows": rows,
+        "policy_vocabulary": {
+            "output_type": [OUTPUT_TYPE],
+            "forbidden_outputs": list(FORBIDDEN_OUTPUTS),
+            "blocked_reason_codes": list(BLOCK_REASON_VOCABULARY),
+        },
+        "safety_invariants": {
+            "research_only": True,
+            "not_trade_signal": True,
+            "mutates_registry": False,
+            "mutates_frozen_contracts": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+        },
+    }

--- a/research/equity_factors/recipe_manifest.py
+++ b/research/equity_factors/recipe_manifest.py
@@ -1,0 +1,54 @@
+"""Artifact writer for research-only equity factor recipes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Final
+
+from research.equity_factors.recipe_catalog import build_equity_factor_recipe_catalog
+
+
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("artifacts/equity_factors")
+WRITE_PREFIX: Final[str] = "artifacts/equity_factors/"
+RECIPES_NAME: Final[str] = "equity_factor_recipes_latest.v1.json"
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(f"recipe_manifest: refusing write outside allowlist: {path!r}")
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def write_outputs(*, repo_root: Path = Path("."), output_dir: Path = DEFAULT_OUTPUT_DIR) -> dict[str, str]:
+    base = repo_root / output_dir
+    base.mkdir(parents=True, exist_ok=True)
+    recipes_path = base / RECIPES_NAME
+    _validate_write_target(recipes_path)
+    _write_json(recipes_path, build_equity_factor_recipe_catalog())
+    return {"recipes": recipes_path.relative_to(repo_root).as_posix()}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.equity_factors.recipe_manifest",
+        description="Write deterministic read-only equity factor recipe artifacts.",
+    )
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    payload = {"recipes": build_equity_factor_recipe_catalog()}
+    if args.write:
+        payload["_artifact_paths"] = write_outputs()
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/unit/test_equity_factor_recipe_catalog.py
+++ b/tests/unit/test_equity_factor_recipe_catalog.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from research.equity_factors import recipe_catalog
+
+
+def test_recipe_catalog_has_unique_ids_and_closed_vocabularies() -> None:
+    report = recipe_catalog.build_equity_factor_recipe_catalog()
+    rows = report["rows"]
+    recipe_ids = [row["recipe_id"] for row in rows]
+    assert len(recipe_ids) == len(set(recipe_ids))
+    assert report["policy_vocabulary"]["output_type"] == ["hypothesis_seed_candidates"]
+    blocked_vocab = set(report["policy_vocabulary"]["blocked_reason_codes"])
+    for row in rows:
+        assert row["output_type"] == "hypothesis_seed_candidates"
+        assert set(row["blocked_reason_codes"]).issubset(blocked_vocab)
+        assert row["feasibility_status"] in blocked_vocab
+
+
+def test_recipe_catalog_references_existing_universes_and_factors() -> None:
+    report = recipe_catalog.build_equity_factor_recipe_catalog()
+    for row in report["rows"]:
+        assert row["feasibility_status"] == "BLOCKED_DATA_READINESS_MISSING"
+        assert "trade_signal" in row["forbidden_outputs"]
+        assert "paper_candidate" in row["forbidden_outputs"]
+        assert "live_candidate" in row["forbidden_outputs"]
+        assert row["research_only"] is True
+

--- a/tests/unit/test_equity_factor_recipe_manifest.py
+++ b/tests/unit/test_equity_factor_recipe_manifest.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from research.equity_factors import recipe_manifest
+
+
+def test_recipe_manifest_writes_expected_artifact(tmp_path: Path) -> None:
+    paths = recipe_manifest.write_outputs(repo_root=tmp_path)
+    assert paths["recipes"] == "artifacts/equity_factors/equity_factor_recipes_latest.v1.json"
+    payload = json.loads((tmp_path / paths["recipes"]).read_text(encoding="utf-8"))
+    assert payload["report_kind"] == "equity_factor_recipes"
+    assert payload["safety_invariants"]["research_only"] is True
+
+
+def test_recipe_manifest_is_deterministic_and_safe() -> None:
+    left = recipe_manifest.build_equity_factor_recipe_catalog()
+    right = recipe_manifest.build_equity_factor_recipe_catalog()
+    assert left == right
+    assert left["summary"]["recipe_count"] >= 10


### PR DESCRIPTION
﻿## Summary
- add a deterministic research-only screener recipe catalog over the existing equity universes and factor definitions
- add a recipe manifest writer that produces `artifacts/equity_factors/equity_factor_recipes_latest.v1.json`
- keep every recipe fail-closed as `BLOCKED_DATA_READINESS_MISSING` until the fundamental readiness layer exists

## Why now
PR #479-#481 established the universe, identity, quality, and factor foundations. The missing next slice was a read-only recipe layer that can define research intake without creating signals, candidates, or strategies.

## What changed
- `research/equity_factors/recipe_catalog.py` defines 15 closed-vocabulary screener recipes
- `research/equity_factors/recipe_manifest.py` writes the deterministic sidecar artifact
- recipe policy explicitly forbids buy/sell lists, trade signals, strategy registration, candidate promotion, and paper/shadow/live escalation
- tests cover reference integrity, deterministic output, and safety invariants

## Safety constraints honored
- no `registry.py` changes
- no `research/run_research.py` changes
- no `research_latest.json` or `strategy_matrix.csv` changes
- no paper/shadow/live, broker, risk, execution, or dashboard mutation changes
- no strategy registration or executable strategy output

## Tests run
- `python -m pytest tests/unit/test_equity_factor_recipe_catalog.py -q`
- `python -m pytest tests/unit/test_equity_factor_recipe_manifest.py -q`
- `python -m pytest tests/unit/test_equity_universe_catalog.py -q`
- `python -m pytest tests/unit/test_equity_universe_quality.py -q`
- `python -m pytest tests/unit/test_equity_factor_catalog.py -q`
- `python -m pytest tests/architecture -q`
- `python -m pytest tests -q -k "governance or no_touch or frozen_contract or execution_authority"`
- `python -m research.equity_factors.recipe_manifest --write`
- `git diff --check`
- `git diff -- research/research_latest.json research/strategy_matrix.csv`

## Frozen contracts status
Unchanged.

## Protected paths status
Untouched.

## Paper/shadow/live status
Still inactive. Recipes are research-only metadata.

## Known limitations
- recipes are intentionally blocked on missing fundamental/data readiness
- no hypothesis seeds are emitted in this PR
- no operator report yet

## Next recommended action
Implement the operator universe report, then add the fundamental/data readiness gate that can safely evaluate recipe feasibility.
