### PR TITLE
fix: add qre operator universe report

### DIFF
--- a/artifacts/universe/equity_universe_operator_report_latest.json
+++ b/artifacts/universe/equity_universe_operator_report_latest.json
@@ -1,0 +1,517 @@
+{
+  "asia_by_country": {
+    "Australia": 6,
+    "Hong Kong": 6,
+    "Japan": 12,
+    "Singapore": 5
+  },
+  "available_artifacts": [
+    "artifacts/equity_factors/equity_factor_calculation_contracts_latest.v1.json",
+    "artifacts/equity_factors/equity_factor_catalog_latest.v1.json",
+    "artifacts/equity_factors/equity_factor_recipes_latest.v1.json",
+    "artifacts/identity/instrument_identity_latest.v1.json",
+    "artifacts/universe/equity_universe_catalog_latest.v1.json",
+    "artifacts/universe/equity_universe_quality_latest.v1.json",
+    "artifacts/universe/equity_universe_summary_latest.v1.json"
+  ],
+  "currency_counts": {
+    "AUD": 6,
+    "CHF": 10,
+    "DKK": 5,
+    "EUR": 50,
+    "GBP": 10,
+    "HKD": 6,
+    "JPY": 12,
+    "NOK": 3,
+    "SEK": 6,
+    "SGD": 5,
+    "USD": 45
+  },
+  "disclaimer": "Research-only report. No buy/sell recommendations, no trade signals, no strategy registration, no paper/shadow/live activation, and no broker/risk/execution authority.",
+  "europe_by_country": {
+    "Belgium": 6,
+    "Denmark": 6,
+    "Finland": 3,
+    "France": 12,
+    "Germany": 13,
+    "Italy": 2,
+    "Netherlands": 16,
+    "Norway": 4,
+    "Spain": 2,
+    "Sweden": 6,
+    "Switzerland": 10,
+    "United Kingdom": 10
+  },
+  "exchange_counts": {
+    "ASX": 6,
+    "Bolsa de Madrid": 2,
+    "Borsa Italiana": 2,
+    "Dual Listing": 1,
+    "Euronext Amsterdam": 15,
+    "Euronext Brussels": 5,
+    "Euronext Paris": 10,
+    "HKEX": 6,
+    "LSE": 10,
+    "NASDAQ": 12,
+    "NASDAQ ADR": 2,
+    "NYSE": 27,
+    "NYSE ADR": 4,
+    "Nasdaq Copenhagen": 5,
+    "Nasdaq Helsinki": 3,
+    "Nasdaq Stockholm": 6,
+    "Oslo Bors": 3,
+    "SGX": 5,
+    "SIX Swiss Exchange": 10,
+    "TSE": 12,
+    "Xetra": 12
+  },
+  "identity_summary": {
+    "ambiguous_mappings": 16,
+    "blocked_for_hypothesis_seed": 16,
+    "duplicate_canonical_ids": 0,
+    "duplicate_provider_symbols": 0,
+    "duplicate_symbols": 0,
+    "eligible_for_hypothesis_seed": 142,
+    "fail_instruments": 0,
+    "instrument_count": 158,
+    "ok_instruments": 142,
+    "operator_summary": "Instrument identity is deterministic metadata only. Ambiguity, missing mappings, and duplicate identifiers remain visible and block escalation to hypothesis seeds.",
+    "unknown_instruments": 0,
+    "warn_instruments": 16
+  },
+  "largest_universes": [
+    {
+      "count": 158,
+      "countries_covered": [
+        "Australia",
+        "Belgium",
+        "Canada",
+        "Denmark",
+        "Finland",
+        "France",
+        "Germany",
+        "Hong Kong",
+        "Italy",
+        "Japan",
+        "Netherlands",
+        "Norway",
+        "Singapore",
+        "Spain",
+        "Sweden",
+        "Switzerland",
+        "United Kingdom",
+        "United States"
+      ],
+      "primary_currencies": [
+        "AUD",
+        "CHF",
+        "DKK",
+        "EUR",
+        "GBP",
+        "HKD",
+        "JPY",
+        "NOK",
+        "SEK",
+        "SGD",
+        "USD"
+      ],
+      "universe_id": "global_developed_liquid"
+    },
+    {
+      "count": 158,
+      "countries_covered": [
+        "Australia",
+        "Belgium",
+        "Canada",
+        "Denmark",
+        "Finland",
+        "France",
+        "Germany",
+        "Hong Kong",
+        "Italy",
+        "Japan",
+        "Netherlands",
+        "Norway",
+        "Singapore",
+        "Spain",
+        "Sweden",
+        "Switzerland",
+        "United Kingdom",
+        "United States"
+      ],
+      "primary_currencies": [
+        "AUD",
+        "CHF",
+        "DKK",
+        "EUR",
+        "GBP",
+        "HKD",
+        "JPY",
+        "NOK",
+        "SEK",
+        "SGD",
+        "USD"
+      ],
+      "universe_id": "global_ex_crypto_research_universe"
+    },
+    {
+      "count": 73,
+      "countries_covered": [
+        "Belgium",
+        "Denmark",
+        "Finland",
+        "France",
+        "Germany",
+        "Italy",
+        "Netherlands",
+        "Norway",
+        "Spain",
+        "Sweden",
+        "Switzerland",
+        "United Kingdom"
+      ],
+      "primary_currencies": [
+        "CHF",
+        "DKK",
+        "EUR",
+        "GBP",
+        "NOK",
+        "SEK",
+        "USD"
+      ],
+      "universe_id": "europe_large_mid"
+    },
+    {
+      "count": 33,
+      "countries_covered": [
+        "United States"
+      ],
+      "primary_currencies": [
+        "USD"
+      ],
+      "universe_id": "us_large_mid"
+    },
+    {
+      "count": 29,
+      "countries_covered": [
+        "Australia",
+        "Hong Kong",
+        "Japan",
+        "Singapore"
+      ],
+      "primary_currencies": [
+        "AUD",
+        "HKD",
+        "JPY",
+        "SGD"
+      ],
+      "universe_id": "asia_developed_liquid"
+    },
+    {
+      "count": 25,
+      "countries_covered": [
+        "United States"
+      ],
+      "primary_currencies": [
+        "USD"
+      ],
+      "universe_id": "us_quality_liquid"
+    },
+    {
+      "count": 19,
+      "countries_covered": [
+        "Denmark",
+        "Finland",
+        "Norway",
+        "Sweden"
+      ],
+      "primary_currencies": [
+        "DKK",
+        "EUR",
+        "NOK",
+        "SEK",
+        "USD"
+      ],
+      "universe_id": "nordics_equities"
+    },
+    {
+      "count": 17,
+      "countries_covered": [
+        "Belgium",
+        "Denmark",
+        "France",
+        "Germany",
+        "Netherlands",
+        "Norway",
+        "Sweden",
+        "Switzerland"
+      ],
+      "primary_currencies": [
+        "CHF",
+        "EUR",
+        "NOK",
+        "SEK",
+        "USD"
+      ],
+      "universe_id": "europe_small_mid"
+    },
+    {
+      "count": 16,
+      "countries_covered": [
+        "Netherlands"
+      ],
+      "primary_currencies": [
+        "EUR",
+        "USD"
+      ],
+      "universe_id": "nl_equities"
+    },
+    {
+      "count": 13,
+      "countries_covered": [
+        "Germany"
+      ],
+      "primary_currencies": [
+        "EUR",
+        "USD"
+      ],
+      "universe_id": "germany_equities"
+    }
+  ],
+  "missing_artifacts": [
+    "artifacts/data_readiness/fundamental_readiness_latest.v1.json",
+    "artifacts/hypothesis_discovery/equity_factor_hypothesis_seeds_latest.v1.json"
+  ],
+  "nl_instruments": [
+    "ABN",
+    "AD",
+    "ADYEN",
+    "AKZA",
+    "ASMI",
+    "ASML",
+    "BESI",
+    "DSFIR",
+    "HEIA",
+    "INGA",
+    "PHIA",
+    "PRX",
+    "REN",
+    "SHELL",
+    "UNA",
+    "WKL"
+  ],
+  "recipes_by_target_universe": {
+    "asia_developed_liquid": 1,
+    "europe_large_mid": 2,
+    "europe_small_mid": 2,
+    "global_developed_liquid": 6,
+    "nl_equities": 1,
+    "nordics_equities": 1,
+    "switzerland_equities": 1,
+    "us_large_mid": 2,
+    "us_quality_liquid": 2
+  },
+  "report_kind": "qre_equity_universe_operator_report",
+  "required_universe_ids_present": {
+    "asia_developed_liquid": true,
+    "europe_large_mid": true,
+    "europe_small_mid": true,
+    "global_developed_liquid": true,
+    "global_ex_crypto_research_universe": true,
+    "nl_equities": true,
+    "nordics_equities": true,
+    "switzerland_equities": true,
+    "us_large_mid": true,
+    "us_quality_liquid": true
+  },
+  "safety_invariants": {
+    "broker_risk_execution_forbidden": true,
+    "mutates_frozen_contracts": false,
+    "mutates_registry": false,
+    "not_trade_signal": true,
+    "paper_shadow_live_forbidden": true,
+    "research_only": true
+  },
+  "schema_version": "1.0",
+  "summary": {
+    "ambiguous_mappings": 16,
+    "blocked_recipes": 15,
+    "duplicate_canonical_ids": 0,
+    "factor_definitions": 22,
+    "factor_families": 8,
+    "fail_instruments": 0,
+    "feasible_recipes": 0,
+    "ok_instruments": 142,
+    "recipe_count": 15,
+    "total_countries": 18,
+    "total_currencies": 11,
+    "total_exchanges": 21,
+    "total_instruments": 158,
+    "unknown_instruments": 0,
+    "warn_instruments": 16
+  },
+  "universe_inventory": [
+    {
+      "asset_class": "equity",
+      "instrument_count": 29,
+      "notes": "research_only",
+      "readiness": "WARN",
+      "region": "Asia Developed",
+      "universe_id": "asia_developed_liquid"
+    },
+    {
+      "asset_class": "equity",
+      "instrument_count": 6,
+      "notes": "research_only",
+      "readiness": "WARN",
+      "region": "Australia",
+      "universe_id": "australia_liquid_equities"
+    },
+    {
+      "asset_class": "equity",
+      "instrument_count": 6,
+      "notes": "research_only",
+      "readiness": "WARN",
+      "region": "Belgium",
+      "universe_id": "belgium_equities"
+    },
+    {
+      "asset_class": "equity",
+      "instrument_count": 6,
+      "notes": "research_only",
+      "readiness": "WARN",
+      "region": "Canada",
+      "universe_id": "canada_liquid_equities"
+    },
+    {
+      "asset_class": "equity",
+      "instrument_count": 73,
+      "notes": "research_only",
+      "readiness": "WARN",
+      "region": "Europe",
+      "universe_id": "europe_large_mid"
+    },
+    {
+      "asset_class": "equity",
+      "instrument_count": 17,
+      "notes": "research_only",
+      "readiness": "WARN",
+      "region": "Europe",
+      "universe_id": "europe_small_mid"
+    },
+    {
+      "asset_class": "equity",
+      "instrument_count": 12,
+      "notes": "research_only",
+      "readiness": "WARN",
+      "region": "France",
+      "universe_id": "france_equities"
+    },
+    {
+      "asset_class": "equity",
+      "instrument_count": 13,
+      "notes": "research_only",
+      "readiness": "WARN",
+      "region": "Germany",
+      "universe_id": "germany_equities"
+    },
+    {
+      "asset_class": "equity",
+      "instrument_count": 158,
+      "notes": "research_only",
+      "readiness": "WARN",
+      "region": "Global Developed",
+      "universe_id": "global_developed_liquid"
+    },
+    {
+      "asset_class": "equity",
+      "instrument_count": 158,
+      "notes": "research_only",
+      "readiness": "WARN",
+      "region": "Global",
+      "universe_id": "global_ex_crypto_research_universe"
+    },
+    {
+      "asset_class": "equity",
+      "instrument_count": 6,
+      "notes": "research_only",
+      "readiness": "WARN",
+      "region": "Hong Kong",
+      "universe_id": "hong_kong_liquid_equities"
+    },
+    {
+      "asset_class": "equity",
+      "instrument_count": 12,
+      "notes": "research_only",
+      "readiness": "WARN",
+      "region": "Japan",
+      "universe_id": "japan_large_mid"
+    },
+    {
+      "asset_class": "equity",
+      "instrument_count": 16,
+      "notes": "research_only",
+      "readiness": "WARN",
+      "region": "Netherlands",
+      "universe_id": "nl_equities"
+    },
+    {
+      "asset_class": "equity",
+      "instrument_count": 19,
+      "notes": "research_only",
+      "readiness": "WARN",
+      "region": "Nordics",
+      "universe_id": "nordics_equities"
+    },
+    {
+      "asset_class": "equity",
+      "instrument_count": 5,
+      "notes": "research_only",
+      "readiness": "WARN",
+      "region": "Singapore",
+      "universe_id": "singapore_liquid_equities"
+    },
+    {
+      "asset_class": "equity",
+      "instrument_count": 10,
+      "notes": "research_only",
+      "readiness": "WARN",
+      "region": "Switzerland",
+      "universe_id": "switzerland_equities"
+    },
+    {
+      "asset_class": "equity",
+      "instrument_count": 10,
+      "notes": "research_only",
+      "readiness": "WARN",
+      "region": "United Kingdom",
+      "universe_id": "uk_equities"
+    },
+    {
+      "asset_class": "equity",
+      "instrument_count": 33,
+      "notes": "research_only",
+      "readiness": "WARN",
+      "region": "United States",
+      "universe_id": "us_large_mid"
+    },
+    {
+      "asset_class": "equity",
+      "instrument_count": 25,
+      "notes": "research_only",
+      "readiness": "WARN",
+      "region": "United States",
+      "universe_id": "us_quality_liquid"
+    }
+  ],
+  "us_by_sector": {
+    "Communication Services": 2,
+    "Consumer Discretionary": 3,
+    "Consumer Staples": 5,
+    "Energy": 2,
+    "Financials": 7,
+    "Health Care": 4,
+    "Industrials": 3,
+    "Technology": 7
+  }
+}

--- a/artifacts/universe/equity_universe_operator_report_latest.md
+++ b/artifacts/universe/equity_universe_operator_report_latest.md
@@ -1,0 +1,48 @@
+# QRE Equity Universe Summary
+
+Research-only report. No buy/sell recommendations, no trade signals, no strategy registration, no paper/shadow/live activation, and no broker/risk/execution authority.
+
+## Totals
+- instruments: 158
+- countries: 18
+- exchanges: 21
+- currencies: 11
+- OK instruments: 142
+- WARN instruments: 16
+- FAIL instruments: 0
+- ambiguous mappings: 16
+
+## Universes
+- asia_developed_liquid: 29 (WARN, Asia Developed)
+- australia_liquid_equities: 6 (WARN, Australia)
+- belgium_equities: 6 (WARN, Belgium)
+- canada_liquid_equities: 6 (WARN, Canada)
+- europe_large_mid: 73 (WARN, Europe)
+- europe_small_mid: 17 (WARN, Europe)
+- france_equities: 12 (WARN, France)
+- germany_equities: 13 (WARN, Germany)
+- global_developed_liquid: 158 (WARN, Global Developed)
+- global_ex_crypto_research_universe: 158 (WARN, Global)
+- hong_kong_liquid_equities: 6 (WARN, Hong Kong)
+- japan_large_mid: 12 (WARN, Japan)
+- nl_equities: 16 (WARN, Netherlands)
+- nordics_equities: 19 (WARN, Nordics)
+- singapore_liquid_equities: 5 (WARN, Singapore)
+- switzerland_equities: 10 (WARN, Switzerland)
+- uk_equities: 10 (WARN, United Kingdom)
+- us_large_mid: 33 (WARN, United States)
+- us_quality_liquid: 25 (WARN, United States)
+
+## Factor Catalog
+- factor definitions: 22
+- factor families: 8
+- recipes: 15
+- feasible recipes: 0
+- blocked recipes: 15
+
+## NL Instruments
+- ABN, AD, ADYEN, AKZA, ASMI, ASML, BESI, DSFIR, HEIA, INGA, PHIA, PRX, REN, SHELL, UNA, WKL
+
+## Missing Artifacts
+- artifacts/data_readiness/fundamental_readiness_latest.v1.json
+- artifacts/hypothesis_discovery/equity_factor_hypothesis_seeds_latest.v1.json

--- a/reporting/qre_universe_report.py
+++ b/reporting/qre_universe_report.py
@@ -1,0 +1,268 @@
+"""Read-only operator summary for the QRE equity research front door."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Final
+
+from research.equity_factor_manifest import DEFAULT_OUTPUT_DIR as FACTOR_ARTIFACT_DIR
+from research.equity_factors.factor_catalog import build_equity_factor_catalog
+from research.equity_factors.recipe_catalog import build_equity_factor_recipe_catalog
+from research.equity_universe_catalog import build_equity_universe_catalog, build_equity_universe_summary
+from research.equity_universe_identity import build_instrument_identity_report
+from research.equity_universe_quality import build_equity_universe_quality
+
+
+REPO_ROOT: Final[Path] = Path(".")
+OUTPUT_DIR: Final[Path] = Path("artifacts/universe")
+JSON_NAME: Final[str] = "equity_universe_operator_report_latest.json"
+MD_NAME: Final[str] = "equity_universe_operator_report_latest.md"
+WRITE_PREFIX: Final[str] = "artifacts/universe/"
+DISCLAIMER: Final[str] = (
+    "Research-only report. No buy/sell recommendations, no trade signals, no strategy registration, "
+    "no paper/shadow/live activation, and no broker/risk/execution authority."
+)
+EXPECTED_UNIVERSE_IDS: Final[tuple[str, ...]] = (
+    "nl_equities",
+    "europe_large_mid",
+    "europe_small_mid",
+    "us_large_mid",
+    "asia_developed_liquid",
+    "global_developed_liquid",
+    "global_ex_crypto_research_universe",
+    "us_quality_liquid",
+    "nordics_equities",
+    "switzerland_equities",
+)
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(f"qre_universe_report: refusing write outside allowlist: {path!r}")
+
+
+def _write_text(path: Path, content: str) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(content, encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def _available_artifacts() -> tuple[list[str], list[str]]:
+    expected = [
+        "artifacts/universe/equity_universe_catalog_latest.v1.json",
+        "artifacts/universe/equity_universe_summary_latest.v1.json",
+        "artifacts/universe/equity_universe_quality_latest.v1.json",
+        "artifacts/identity/instrument_identity_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_catalog_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_calculation_contracts_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_recipes_latest.v1.json",
+        "artifacts/data_readiness/fundamental_readiness_latest.v1.json",
+        "artifacts/hypothesis_discovery/equity_factor_hypothesis_seeds_latest.v1.json",
+    ]
+    available = sorted(path for path in expected if (REPO_ROOT / path).exists())
+    missing = sorted(path for path in expected if path not in available)
+    return available, missing
+
+
+def collect_snapshot() -> dict[str, object]:
+    catalog = build_equity_universe_catalog()
+    summary = build_equity_universe_summary()
+    quality = build_equity_universe_quality()
+    identity = build_instrument_identity_report()
+    factor_catalog = build_equity_factor_catalog()
+    recipe_catalog = build_equity_factor_recipe_catalog()
+    available_artifacts, missing_artifacts = _available_artifacts()
+
+    quality_summary = quality["summary"]
+    summary_counts = summary["summary"]
+    universe_counts = summary["universe_counts"]
+    country_counts = summary["country_counts"]
+    exchange_counts = summary["exchange_counts"]
+    currency_counts = summary["currency_counts"]
+    universe_rows = {row["universe_id"]: row for row in catalog["universes"]}
+    nl_instruments = sorted(
+        row["symbol"] for row in catalog["instruments"] if "nl_equities" in row["universe_ids"]
+    )
+    asia_country_counts = {
+        country: count
+        for country, count in country_counts.items()
+        if country in {"Japan", "Hong Kong", "Singapore", "Australia"}
+    }
+    sector_counts: dict[str, int] = {}
+    for row in catalog["instruments"]:
+        if row["country"] == "United States":
+            sector = str(row["sector"])
+            sector_counts[sector] = sector_counts.get(sector, 0) + 1
+    recipes_by_universe: dict[str, int] = {}
+    for row in recipe_catalog["rows"]:
+        for universe_id in row["target_universe_ids"]:
+            recipes_by_universe[universe_id] = recipes_by_universe.get(universe_id, 0) + 1
+
+    inventory = []
+    for universe_id in sorted(universe_counts):
+        inventory.append(
+            {
+                "universe_id": universe_id,
+                "region": universe_rows[universe_id]["region"],
+                "asset_class": "equity",
+                "instrument_count": universe_counts[universe_id],
+                "readiness": "WARN" if quality_summary["warn_instruments"] else "OK",
+                "notes": "research_only",
+            }
+        )
+
+    largest = [
+        {
+            "universe_id": row["universe_id"],
+            "count": row["instrument_count"],
+            "countries_covered": row["countries"],
+            "primary_currencies": row["primary_currencies"],
+        }
+        for row in summary["largest_universes"]
+    ]
+
+    return {
+        "report_kind": "qre_equity_universe_operator_report",
+        "schema_version": "1.0",
+        "disclaimer": DISCLAIMER,
+        "summary": {
+            "total_instruments": summary_counts["total_instruments"],
+            "total_countries": summary_counts["total_countries"],
+            "total_exchanges": summary_counts["total_exchanges"],
+            "total_currencies": summary_counts["total_currencies"],
+            "ok_instruments": quality_summary["ok_instruments"],
+            "warn_instruments": quality_summary["warn_instruments"],
+            "fail_instruments": quality_summary["fail_instruments"],
+            "unknown_instruments": quality_summary["unknown_instruments"],
+            "ambiguous_mappings": quality_summary["ambiguous_mappings"],
+            "duplicate_canonical_ids": quality_summary["duplicate_canonical_ids"],
+            "factor_definitions": factor_catalog["summary"]["factor_definition_count"],
+            "factor_families": factor_catalog["summary"]["factor_family_count"],
+            "recipe_count": recipe_catalog["summary"]["recipe_count"],
+            "feasible_recipes": recipe_catalog["summary"]["feasible_recipe_count"],
+            "blocked_recipes": recipe_catalog["summary"]["blocked_recipe_count"],
+        },
+        "universe_inventory": inventory,
+        "required_universe_ids_present": {
+            universe_id: universe_id in universe_counts for universe_id in EXPECTED_UNIVERSE_IDS
+        },
+        "largest_universes": largest,
+        "nl_instruments": nl_instruments,
+        "europe_by_country": {
+            country: country_counts[country]
+            for country in sorted(country_counts)
+            if country in {
+                "Netherlands",
+                "Belgium",
+                "Germany",
+                "France",
+                "Switzerland",
+                "United Kingdom",
+                "Italy",
+                "Spain",
+                "Denmark",
+                "Sweden",
+                "Norway",
+                "Finland",
+            }
+        },
+        "us_by_sector": dict(sorted(sector_counts.items())),
+        "asia_by_country": dict(sorted(asia_country_counts.items())),
+        "recipes_by_target_universe": dict(sorted(recipes_by_universe.items())),
+        "available_artifacts": available_artifacts,
+        "missing_artifacts": missing_artifacts,
+        "exchange_counts": exchange_counts,
+        "currency_counts": currency_counts,
+        "identity_summary": identity["summary"],
+        "safety_invariants": {
+            "research_only": True,
+            "not_trade_signal": True,
+            "mutates_registry": False,
+            "mutates_frozen_contracts": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+        },
+    }
+
+
+def render_markdown(snapshot: dict[str, object]) -> str:
+    summary = snapshot["summary"]
+    inventory = snapshot["universe_inventory"]
+    lines = [
+        "# QRE Equity Universe Summary",
+        "",
+        DISCLAIMER,
+        "",
+        "## Totals",
+        f"- instruments: {summary['total_instruments']}",
+        f"- countries: {summary['total_countries']}",
+        f"- exchanges: {summary['total_exchanges']}",
+        f"- currencies: {summary['total_currencies']}",
+        f"- OK instruments: {summary['ok_instruments']}",
+        f"- WARN instruments: {summary['warn_instruments']}",
+        f"- FAIL instruments: {summary['fail_instruments']}",
+        f"- ambiguous mappings: {summary['ambiguous_mappings']}",
+        "",
+        "## Universes",
+    ]
+    for row in inventory:
+        lines.append(
+            f"- {row['universe_id']}: {row['instrument_count']} ({row['readiness']}, {row['region']})"
+        )
+    lines.extend(
+        [
+            "",
+            "## Factor Catalog",
+            f"- factor definitions: {summary['factor_definitions']}",
+            f"- factor families: {summary['factor_families']}",
+            f"- recipes: {summary['recipe_count']}",
+            f"- feasible recipes: {summary['feasible_recipes']}",
+            f"- blocked recipes: {summary['blocked_recipes']}",
+            "",
+            "## NL Instruments",
+            f"- {', '.join(snapshot['nl_instruments'])}",
+            "",
+            "## Missing Artifacts",
+        ]
+    )
+    for path in snapshot["missing_artifacts"]:
+        lines.append(f"- {path}")
+    return "\n".join(lines) + "\n"
+
+
+def write_outputs(*, repo_root: Path = REPO_ROOT, output_dir: Path = OUTPUT_DIR) -> dict[str, str]:
+    base = repo_root / output_dir
+    base.mkdir(parents=True, exist_ok=True)
+    json_path = base / JSON_NAME
+    md_path = base / MD_NAME
+    for path in (json_path, md_path):
+        _validate_write_target(path)
+    snapshot = collect_snapshot()
+    _write_text(json_path, json.dumps(snapshot, indent=2, sort_keys=True) + "\n")
+    _write_text(md_path, render_markdown(snapshot))
+    return {
+        "json": json_path.relative_to(repo_root).as_posix(),
+        "markdown": md_path.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m reporting.qre_universe_report",
+        description="Write read-only QRE equity universe operator reports.",
+    )
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    snapshot = collect_snapshot()
+    payload = {"report": snapshot, "markdown": render_markdown(snapshot)}
+    if args.write:
+        payload["_artifact_paths"] = write_outputs()
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/research/qre_universe_report.py
+++ b/research/qre_universe_report.py
@@ -8,7 +8,6 @@ import os
 from pathlib import Path
 from typing import Final
 
-from research.equity_factor_manifest import DEFAULT_OUTPUT_DIR as FACTOR_ARTIFACT_DIR
 from research.equity_factors.factor_catalog import build_equity_factor_catalog
 from research.equity_factors.recipe_catalog import build_equity_factor_recipe_catalog
 from research.equity_universe_catalog import build_equity_universe_catalog, build_equity_universe_summary
@@ -251,7 +250,7 @@ def write_outputs(*, repo_root: Path = REPO_ROOT, output_dir: Path = OUTPUT_DIR)
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
-        prog="python -m reporting.qre_universe_report",
+        prog="python -m research.qre_universe_report",
         description="Write read-only QRE equity universe operator reports.",
     )
     parser.add_argument("--write", action="store_true")

--- a/tests/unit/test_qre_universe_report.py
+++ b/tests/unit/test_qre_universe_report.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from reporting import qre_universe_report
+
+
+def test_universe_report_is_deterministic_and_contains_required_ids() -> None:
+    left = qre_universe_report.collect_snapshot()
+    right = qre_universe_report.collect_snapshot()
+    assert left == right
+    for universe_id in (
+        "nl_equities",
+        "europe_large_mid",
+        "europe_small_mid",
+        "us_large_mid",
+        "asia_developed_liquid",
+        "global_developed_liquid",
+        "global_ex_crypto_research_universe",
+    ):
+        assert left["required_universe_ids_present"][universe_id] is True
+    assert "No buy/sell recommendations, no trade signals" in left["disclaimer"]
+
+
+def test_universe_report_write_outputs_match_counts(tmp_path: Path) -> None:
+    paths = qre_universe_report.write_outputs(repo_root=tmp_path)
+    payload = json.loads((tmp_path / paths["json"]).read_text(encoding="utf-8"))
+    markdown = (tmp_path / paths["markdown"]).read_text(encoding="utf-8")
+    assert payload["report_kind"] == "qre_equity_universe_operator_report"
+    assert payload["summary"]["recipe_count"] >= 10
+    assert payload["summary"]["total_instruments"] == 158
+    assert "Research-only report." in markdown

--- a/tests/unit/test_qre_universe_report.py
+++ b/tests/unit/test_qre_universe_report.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from reporting import qre_universe_report
+from research import qre_universe_report
 
 
 def test_universe_report_is_deterministic_and_contains_required_ids() -> None:


### PR DESCRIPTION
﻿## Summary
- add a read-only operator universe report over the existing universe, identity, quality, factor, and recipe foundations
- emit deterministic JSON and Markdown artifacts under `artifacts/universe/`
- make missing downstream readiness artifacts explicit without adding dashboard routes or runtime actions

## Why PR #482 exposed this slice
The recipe library now exists, but operators still need one explicit report that answers what universes exist, how large they are, how identity/readiness looks, and which artifacts are still missing.

## What readiness surfaces now consume
- universe catalog and summary counts
- universe quality and identity summaries
- factor catalog counts
- recipe catalog counts and blocked states
- available vs missing sidecar artifacts

## What remains blocked
- fundamental/data readiness
- hypothesis seeds
- controlled factor evaluation
- any trade, candidate, paper, shadow, or live escalation

## Tests run
- `python -m pytest tests/unit/test_qre_universe_report.py -q`
- `python -m pytest tests/unit/test_equity_factor_recipe_manifest.py -q`
- `python -m pytest tests/unit/test_equity_universe_catalog.py -q`
- `python -m pytest tests/unit/test_equity_universe_quality.py -q`
- `python -m pytest tests/unit/test_equity_factor_catalog.py -q`
- `python -m pytest tests/architecture -q`
- `python -m pytest tests -q -k "governance or no_touch or frozen_contract or execution_authority"`
- `python -m reporting.qre_universe_report --write`
- `git diff --check`
- `git diff -- research/research_latest.json research/strategy_matrix.csv`

## Frozen contract status
Unchanged.

## Protected paths status
Untouched.

## Paper/shadow/live status
Still inactive. The report is read-only and explicitly says so.

## Known limitations
- report shows missing fundamental readiness and hypothesis seed artifacts because those slices do not exist yet
- no dashboard/API mutation route was added

## Next recommended action
Implement the fail-closed fundamental/data readiness gate so recipe feasibility can move from generic blocked visibility to explicit data-policy blockers.
