### PR TITLE
fix: add qre fundamental data readiness gate

### DIFF
--- a/artifacts/data_readiness/factor_field_coverage_latest.v1.json
+++ b/artifacts/data_readiness/factor_field_coverage_latest.v1.json
@@ -1,0 +1,602 @@
+{
+  "field_coverage_status_vocabulary": [
+    "COVERED",
+    "MISSING",
+    "PARTIAL",
+    "UNKNOWN"
+  ],
+  "report_kind": "factor_field_coverage",
+  "rows": [
+    {
+      "currency_normalization_required": false,
+      "factor_id": "accruals_ratio",
+      "field_coverage": [
+        {
+          "coverage_status": "MISSING",
+          "field_name": "net_income_ttm"
+        },
+        {
+          "coverage_status": "MISSING",
+          "field_name": "operating_cash_flow_ttm"
+        },
+        {
+          "coverage_status": "MISSING",
+          "field_name": "average_total_assets"
+        }
+      ],
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "report_lag_required": true,
+      "required_fields": [
+        "net_income_ttm",
+        "operating_cash_flow_ttm",
+        "average_total_assets"
+      ],
+      "source_manifest_required": true
+    },
+    {
+      "currency_normalization_required": false,
+      "factor_id": "adjusted_slope",
+      "field_coverage": [
+        {
+          "coverage_status": "MISSING",
+          "field_name": "price_history_12m"
+        },
+        {
+          "coverage_status": "MISSING",
+          "field_name": "volatility_12m"
+        }
+      ],
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": false,
+      "report_lag_required": false,
+      "required_fields": [
+        "price_history_12m",
+        "volatility_12m"
+      ],
+      "source_manifest_required": true
+    },
+    {
+      "currency_normalization_required": false,
+      "factor_id": "altman_z_score",
+      "field_coverage": [
+        {
+          "coverage_status": "MISSING",
+          "field_name": "working_capital"
+        },
+        {
+          "coverage_status": "MISSING",
+          "field_name": "retained_earnings"
+        },
+        {
+          "coverage_status": "MISSING",
+          "field_name": "ebit_ttm"
+        },
+        {
+          "coverage_status": "MISSING",
+          "field_name": "market_cap"
+        },
+        {
+          "coverage_status": "MISSING",
+          "field_name": "total_assets"
+        },
+        {
+          "coverage_status": "MISSING",
+          "field_name": "total_liabilities"
+        }
+      ],
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "report_lag_required": true,
+      "required_fields": [
+        "working_capital",
+        "retained_earnings",
+        "ebit_ttm",
+        "market_cap",
+        "total_assets",
+        "total_liabilities"
+      ],
+      "source_manifest_required": true
+    },
+    {
+      "currency_normalization_required": false,
+      "factor_id": "average_daily_value_traded",
+      "field_coverage": [
+        {
+          "coverage_status": "MISSING",
+          "field_name": "average_daily_value_traded_90d"
+        }
+      ],
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": false,
+      "report_lag_required": false,
+      "required_fields": [
+        "average_daily_value_traded_90d"
+      ],
+      "source_manifest_required": true
+    },
+    {
+      "currency_normalization_required": false,
+      "factor_id": "beneish_m_score",
+      "field_coverage": [
+        {
+          "coverage_status": "MISSING",
+          "field_name": "days_sales_receivables"
+        },
+        {
+          "coverage_status": "MISSING",
+          "field_name": "gross_margin_index"
+        },
+        {
+          "coverage_status": "MISSING",
+          "field_name": "asset_quality_index"
+        },
+        {
+          "coverage_status": "MISSING",
+          "field_name": "sales_growth_index"
+        },
+        {
+          "coverage_status": "MISSING",
+          "field_name": "depreciation_index"
+        },
+        {
+          "coverage_status": "MISSING",
+          "field_name": "sgai"
+        },
+        {
+          "coverage_status": "MISSING",
+          "field_name": "leverage_index"
+        },
+        {
+          "coverage_status": "MISSING",
+          "field_name": "total_accruals_to_assets"
+        }
+      ],
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "report_lag_required": true,
+      "required_fields": [
+        "days_sales_receivables",
+        "gross_margin_index",
+        "asset_quality_index",
+        "sales_growth_index",
+        "depreciation_index",
+        "sgai",
+        "leverage_index",
+        "total_accruals_to_assets"
+      ],
+      "source_manifest_required": true
+    },
+    {
+      "currency_normalization_required": false,
+      "factor_id": "book_to_market",
+      "field_coverage": [
+        {
+          "coverage_status": "MISSING",
+          "field_name": "book_value_equity"
+        },
+        {
+          "coverage_status": "MISSING",
+          "field_name": "market_cap"
+        }
+      ],
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "report_lag_required": true,
+      "required_fields": [
+        "book_value_equity",
+        "market_cap"
+      ],
+      "source_manifest_required": true
+    },
+    {
+      "currency_normalization_required": false,
+      "factor_id": "buyback_yield",
+      "field_coverage": [
+        {
+          "coverage_status": "MISSING",
+          "field_name": "net_buybacks_ttm"
+        },
+        {
+          "coverage_status": "MISSING",
+          "field_name": "market_cap"
+        }
+      ],
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "report_lag_required": true,
+      "required_fields": [
+        "net_buybacks_ttm",
+        "market_cap"
+      ],
+      "source_manifest_required": true
+    },
+    {
+      "currency_normalization_required": false,
+      "factor_id": "debt_to_equity",
+      "field_coverage": [
+        {
+          "coverage_status": "MISSING",
+          "field_name": "total_debt"
+        },
+        {
+          "coverage_status": "MISSING",
+          "field_name": "book_value_equity"
+        }
+      ],
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "report_lag_required": true,
+      "required_fields": [
+        "total_debt",
+        "book_value_equity"
+      ],
+      "source_manifest_required": true
+    },
+    {
+      "currency_normalization_required": false,
+      "factor_id": "dividend_yield",
+      "field_coverage": [
+        {
+          "coverage_status": "MISSING",
+          "field_name": "dividends_paid_ttm"
+        },
+        {
+          "coverage_status": "MISSING",
+          "field_name": "market_cap"
+        }
+      ],
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "report_lag_required": true,
+      "required_fields": [
+        "dividends_paid_ttm",
+        "market_cap"
+      ],
+      "source_manifest_required": true
+    },
+    {
+      "currency_normalization_required": true,
+      "factor_id": "earnings_yield",
+      "field_coverage": [
+        {
+          "coverage_status": "MISSING",
+          "field_name": "market_cap"
+        },
+        {
+          "coverage_status": "MISSING",
+          "field_name": "net_income_ttm"
+        }
+      ],
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "report_lag_required": true,
+      "required_fields": [
+        "market_cap",
+        "net_income_ttm"
+      ],
+      "source_manifest_required": true
+    },
+    {
+      "currency_normalization_required": false,
+      "factor_id": "enterprise_value_to_ebit",
+      "field_coverage": [
+        {
+          "coverage_status": "MISSING",
+          "field_name": "enterprise_value"
+        },
+        {
+          "coverage_status": "MISSING",
+          "field_name": "ebit_ttm"
+        }
+      ],
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "report_lag_required": true,
+      "required_fields": [
+        "enterprise_value",
+        "ebit_ttm"
+      ],
+      "source_manifest_required": true
+    },
+    {
+      "currency_normalization_required": false,
+      "factor_id": "fcf_yield",
+      "field_coverage": [
+        {
+          "coverage_status": "MISSING",
+          "field_name": "market_cap"
+        },
+        {
+          "coverage_status": "MISSING",
+          "field_name": "free_cash_flow_ttm"
+        }
+      ],
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "report_lag_required": true,
+      "required_fields": [
+        "market_cap",
+        "free_cash_flow_ttm"
+      ],
+      "source_manifest_required": true
+    },
+    {
+      "currency_normalization_required": false,
+      "factor_id": "gross_profitability",
+      "field_coverage": [
+        {
+          "coverage_status": "MISSING",
+          "field_name": "gross_profit_ttm"
+        },
+        {
+          "coverage_status": "MISSING",
+          "field_name": "total_assets"
+        }
+      ],
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "report_lag_required": true,
+      "required_fields": [
+        "gross_profit_ttm",
+        "total_assets"
+      ],
+      "source_manifest_required": true
+    },
+    {
+      "currency_normalization_required": false,
+      "factor_id": "montier_c_score",
+      "field_coverage": [
+        {
+          "coverage_status": "MISSING",
+          "field_name": "dsri"
+        },
+        {
+          "coverage_status": "MISSING",
+          "field_name": "gmi"
+        },
+        {
+          "coverage_status": "MISSING",
+          "field_name": "aqi"
+        },
+        {
+          "coverage_status": "MISSING",
+          "field_name": "sgi"
+        },
+        {
+          "coverage_status": "MISSING",
+          "field_name": "depi"
+        },
+        {
+          "coverage_status": "MISSING",
+          "field_name": "lvgi"
+        },
+        {
+          "coverage_status": "MISSING",
+          "field_name": "tata"
+        }
+      ],
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "report_lag_required": true,
+      "required_fields": [
+        "dsri",
+        "gmi",
+        "aqi",
+        "sgi",
+        "depi",
+        "lvgi",
+        "tata"
+      ],
+      "source_manifest_required": true
+    },
+    {
+      "currency_normalization_required": false,
+      "factor_id": "net_debt_to_ebitda",
+      "field_coverage": [
+        {
+          "coverage_status": "MISSING",
+          "field_name": "net_debt"
+        },
+        {
+          "coverage_status": "MISSING",
+          "field_name": "ebitda_ttm"
+        }
+      ],
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "report_lag_required": true,
+      "required_fields": [
+        "net_debt",
+        "ebitda_ttm"
+      ],
+      "source_manifest_required": true
+    },
+    {
+      "currency_normalization_required": false,
+      "factor_id": "piotroski_f_score",
+      "field_coverage": [
+        {
+          "coverage_status": "MISSING",
+          "field_name": "roa"
+        },
+        {
+          "coverage_status": "MISSING",
+          "field_name": "operating_cash_flow"
+        },
+        {
+          "coverage_status": "MISSING",
+          "field_name": "gross_margin"
+        },
+        {
+          "coverage_status": "MISSING",
+          "field_name": "asset_turnover"
+        },
+        {
+          "coverage_status": "MISSING",
+          "field_name": "leverage_ratio"
+        }
+      ],
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "report_lag_required": true,
+      "required_fields": [
+        "roa",
+        "operating_cash_flow",
+        "gross_margin",
+        "asset_turnover",
+        "leverage_ratio"
+      ],
+      "source_manifest_required": true
+    },
+    {
+      "currency_normalization_required": false,
+      "factor_id": "price_to_sales",
+      "field_coverage": [
+        {
+          "coverage_status": "MISSING",
+          "field_name": "market_cap"
+        },
+        {
+          "coverage_status": "MISSING",
+          "field_name": "revenue_ttm"
+        }
+      ],
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "report_lag_required": true,
+      "required_fields": [
+        "market_cap",
+        "revenue_ttm"
+      ],
+      "source_manifest_required": true
+    },
+    {
+      "currency_normalization_required": false,
+      "factor_id": "return_on_assets",
+      "field_coverage": [
+        {
+          "coverage_status": "MISSING",
+          "field_name": "net_income_ttm"
+        },
+        {
+          "coverage_status": "MISSING",
+          "field_name": "total_assets"
+        }
+      ],
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "report_lag_required": true,
+      "required_fields": [
+        "net_income_ttm",
+        "total_assets"
+      ],
+      "source_manifest_required": true
+    },
+    {
+      "currency_normalization_required": false,
+      "factor_id": "roic",
+      "field_coverage": [
+        {
+          "coverage_status": "MISSING",
+          "field_name": "nopat_ttm"
+        },
+        {
+          "coverage_status": "MISSING",
+          "field_name": "invested_capital"
+        }
+      ],
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "report_lag_required": true,
+      "required_fields": [
+        "nopat_ttm",
+        "invested_capital"
+      ],
+      "source_manifest_required": true
+    },
+    {
+      "currency_normalization_required": false,
+      "factor_id": "shareholder_yield",
+      "field_coverage": [
+        {
+          "coverage_status": "MISSING",
+          "field_name": "dividends_paid_ttm"
+        },
+        {
+          "coverage_status": "MISSING",
+          "field_name": "net_buybacks_ttm"
+        },
+        {
+          "coverage_status": "MISSING",
+          "field_name": "net_debt_change_ttm"
+        },
+        {
+          "coverage_status": "MISSING",
+          "field_name": "market_cap"
+        }
+      ],
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "report_lag_required": true,
+      "required_fields": [
+        "dividends_paid_ttm",
+        "net_buybacks_ttm",
+        "net_debt_change_ttm",
+        "market_cap"
+      ],
+      "source_manifest_required": true
+    },
+    {
+      "currency_normalization_required": false,
+      "factor_id": "six_month_momentum",
+      "field_coverage": [
+        {
+          "coverage_status": "MISSING",
+          "field_name": "price_history_6m"
+        }
+      ],
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": false,
+      "report_lag_required": false,
+      "required_fields": [
+        "price_history_6m"
+      ],
+      "source_manifest_required": true
+    },
+    {
+      "currency_normalization_required": false,
+      "factor_id": "twelve_month_momentum",
+      "field_coverage": [
+        {
+          "coverage_status": "MISSING",
+          "field_name": "price_history_12m"
+        }
+      ],
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": false,
+      "report_lag_required": false,
+      "required_fields": [
+        "price_history_12m"
+      ],
+      "source_manifest_required": true
+    }
+  ],
+  "safety_invariants": {
+    "broker_risk_execution_forbidden": true,
+    "mutates_frozen_contracts": false,
+    "mutates_registry": false,
+    "not_trade_signal": true,
+    "paper_shadow_live_forbidden": true,
+    "research_only": true
+  },
+  "schema_version": "1.0",
+  "summary": {
+    "covered_count": 0,
+    "factor_count": 22,
+    "missing_count": 22,
+    "operator_summary": "Field coverage is fail-closed until a deterministic source manifest exists. This report does not claim any real fundamental field availability.",
+    "partial_count": 0,
+    "unknown_count": 0
+  }
+}

--- a/artifacts/data_readiness/fundamental_readiness_latest.v1.json
+++ b/artifacts/data_readiness/fundamental_readiness_latest.v1.json
@@ -1,0 +1,1005 @@
+{
+  "block_reason_vocabulary": [
+    "MISSING_SOURCE_MANIFEST",
+    "MISSING_POINT_IN_TIME_POLICY",
+    "MISSING_REQUIRED_FIELD",
+    "MISSING_CURRENCY_NORMALIZATION",
+    "MISSING_REPORT_LAG_POLICY",
+    "MISSING_RESTATEMENT_POLICY",
+    "FACTOR_FIELD_COVERAGE_UNKNOWN",
+    "UNIVERSE_IDENTITY_NOT_READY",
+    "SOURCE_LICENSE_UNKNOWN",
+    "SOURCE_QUALITY_UNKNOWN",
+    "UNKNOWN"
+  ],
+  "factor_rows": [
+    {
+      "currency_normalization_required": false,
+      "factor_id": "accruals_ratio",
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "readiness_block_reasons": [
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "readiness_status": "NOT_READY",
+      "report_lag_required": true,
+      "required_fields": [
+        "net_income_ttm",
+        "operating_cash_flow_ttm",
+        "average_total_assets"
+      ],
+      "restatement_risk": "medium",
+      "source_manifest_required": true
+    },
+    {
+      "currency_normalization_required": false,
+      "factor_id": "adjusted_slope",
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": false,
+      "readiness_block_reasons": [
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "readiness_status": "NOT_READY",
+      "report_lag_required": false,
+      "required_fields": [
+        "price_history_12m",
+        "volatility_12m"
+      ],
+      "restatement_risk": "low",
+      "source_manifest_required": true
+    },
+    {
+      "currency_normalization_required": false,
+      "factor_id": "altman_z_score",
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "readiness_block_reasons": [
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "readiness_status": "NOT_READY",
+      "report_lag_required": true,
+      "required_fields": [
+        "working_capital",
+        "retained_earnings",
+        "ebit_ttm",
+        "market_cap",
+        "total_assets",
+        "total_liabilities"
+      ],
+      "restatement_risk": "high",
+      "source_manifest_required": true
+    },
+    {
+      "currency_normalization_required": false,
+      "factor_id": "average_daily_value_traded",
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": false,
+      "readiness_block_reasons": [
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "readiness_status": "NOT_READY",
+      "report_lag_required": false,
+      "required_fields": [
+        "average_daily_value_traded_90d"
+      ],
+      "restatement_risk": "low",
+      "source_manifest_required": true
+    },
+    {
+      "currency_normalization_required": false,
+      "factor_id": "beneish_m_score",
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "readiness_block_reasons": [
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "readiness_status": "NOT_READY",
+      "report_lag_required": true,
+      "required_fields": [
+        "days_sales_receivables",
+        "gross_margin_index",
+        "asset_quality_index",
+        "sales_growth_index",
+        "depreciation_index",
+        "sgai",
+        "leverage_index",
+        "total_accruals_to_assets"
+      ],
+      "restatement_risk": "high",
+      "source_manifest_required": true
+    },
+    {
+      "currency_normalization_required": false,
+      "factor_id": "book_to_market",
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "readiness_block_reasons": [
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "readiness_status": "NOT_READY",
+      "report_lag_required": true,
+      "required_fields": [
+        "book_value_equity",
+        "market_cap"
+      ],
+      "restatement_risk": "medium",
+      "source_manifest_required": true
+    },
+    {
+      "currency_normalization_required": false,
+      "factor_id": "buyback_yield",
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "readiness_block_reasons": [
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "readiness_status": "NOT_READY",
+      "report_lag_required": true,
+      "required_fields": [
+        "net_buybacks_ttm",
+        "market_cap"
+      ],
+      "restatement_risk": "medium",
+      "source_manifest_required": true
+    },
+    {
+      "currency_normalization_required": false,
+      "factor_id": "debt_to_equity",
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "readiness_block_reasons": [
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "readiness_status": "NOT_READY",
+      "report_lag_required": true,
+      "required_fields": [
+        "total_debt",
+        "book_value_equity"
+      ],
+      "restatement_risk": "medium",
+      "source_manifest_required": true
+    },
+    {
+      "currency_normalization_required": false,
+      "factor_id": "dividend_yield",
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "readiness_block_reasons": [
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "readiness_status": "NOT_READY",
+      "report_lag_required": true,
+      "required_fields": [
+        "dividends_paid_ttm",
+        "market_cap"
+      ],
+      "restatement_risk": "low",
+      "source_manifest_required": true
+    },
+    {
+      "currency_normalization_required": true,
+      "factor_id": "earnings_yield",
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "readiness_block_reasons": [
+        "MISSING_CURRENCY_NORMALIZATION",
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "readiness_status": "NOT_READY",
+      "report_lag_required": true,
+      "required_fields": [
+        "market_cap",
+        "net_income_ttm"
+      ],
+      "restatement_risk": "medium",
+      "source_manifest_required": true
+    },
+    {
+      "currency_normalization_required": false,
+      "factor_id": "enterprise_value_to_ebit",
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "readiness_block_reasons": [
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "readiness_status": "NOT_READY",
+      "report_lag_required": true,
+      "required_fields": [
+        "enterprise_value",
+        "ebit_ttm"
+      ],
+      "restatement_risk": "medium",
+      "source_manifest_required": true
+    },
+    {
+      "currency_normalization_required": false,
+      "factor_id": "fcf_yield",
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "readiness_block_reasons": [
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "readiness_status": "NOT_READY",
+      "report_lag_required": true,
+      "required_fields": [
+        "market_cap",
+        "free_cash_flow_ttm"
+      ],
+      "restatement_risk": "medium",
+      "source_manifest_required": true
+    },
+    {
+      "currency_normalization_required": false,
+      "factor_id": "gross_profitability",
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "readiness_block_reasons": [
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "readiness_status": "NOT_READY",
+      "report_lag_required": true,
+      "required_fields": [
+        "gross_profit_ttm",
+        "total_assets"
+      ],
+      "restatement_risk": "medium",
+      "source_manifest_required": true
+    },
+    {
+      "currency_normalization_required": false,
+      "factor_id": "montier_c_score",
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "readiness_block_reasons": [
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "readiness_status": "NOT_READY",
+      "report_lag_required": true,
+      "required_fields": [
+        "dsri",
+        "gmi",
+        "aqi",
+        "sgi",
+        "depi",
+        "lvgi",
+        "tata"
+      ],
+      "restatement_risk": "high",
+      "source_manifest_required": true
+    },
+    {
+      "currency_normalization_required": false,
+      "factor_id": "net_debt_to_ebitda",
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "readiness_block_reasons": [
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "readiness_status": "NOT_READY",
+      "report_lag_required": true,
+      "required_fields": [
+        "net_debt",
+        "ebitda_ttm"
+      ],
+      "restatement_risk": "medium",
+      "source_manifest_required": true
+    },
+    {
+      "currency_normalization_required": false,
+      "factor_id": "piotroski_f_score",
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "readiness_block_reasons": [
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "readiness_status": "NOT_READY",
+      "report_lag_required": true,
+      "required_fields": [
+        "roa",
+        "operating_cash_flow",
+        "gross_margin",
+        "asset_turnover",
+        "leverage_ratio"
+      ],
+      "restatement_risk": "high",
+      "source_manifest_required": true
+    },
+    {
+      "currency_normalization_required": false,
+      "factor_id": "price_to_sales",
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "readiness_block_reasons": [
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "readiness_status": "NOT_READY",
+      "report_lag_required": true,
+      "required_fields": [
+        "market_cap",
+        "revenue_ttm"
+      ],
+      "restatement_risk": "medium",
+      "source_manifest_required": true
+    },
+    {
+      "currency_normalization_required": false,
+      "factor_id": "return_on_assets",
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "readiness_block_reasons": [
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "readiness_status": "NOT_READY",
+      "report_lag_required": true,
+      "required_fields": [
+        "net_income_ttm",
+        "total_assets"
+      ],
+      "restatement_risk": "medium",
+      "source_manifest_required": true
+    },
+    {
+      "currency_normalization_required": false,
+      "factor_id": "roic",
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "readiness_block_reasons": [
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "readiness_status": "NOT_READY",
+      "report_lag_required": true,
+      "required_fields": [
+        "nopat_ttm",
+        "invested_capital"
+      ],
+      "restatement_risk": "high",
+      "source_manifest_required": true
+    },
+    {
+      "currency_normalization_required": false,
+      "factor_id": "shareholder_yield",
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "readiness_block_reasons": [
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "readiness_status": "NOT_READY",
+      "report_lag_required": true,
+      "required_fields": [
+        "dividends_paid_ttm",
+        "net_buybacks_ttm",
+        "net_debt_change_ttm",
+        "market_cap"
+      ],
+      "restatement_risk": "medium",
+      "source_manifest_required": true
+    },
+    {
+      "currency_normalization_required": false,
+      "factor_id": "six_month_momentum",
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": false,
+      "readiness_block_reasons": [
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "readiness_status": "NOT_READY",
+      "report_lag_required": false,
+      "required_fields": [
+        "price_history_6m"
+      ],
+      "restatement_risk": "low",
+      "source_manifest_required": true
+    },
+    {
+      "currency_normalization_required": false,
+      "factor_id": "twelve_month_momentum",
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": false,
+      "readiness_block_reasons": [
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "readiness_status": "NOT_READY",
+      "report_lag_required": false,
+      "required_fields": [
+        "price_history_12m"
+      ],
+      "restatement_risk": "low",
+      "source_manifest_required": true
+    }
+  ],
+  "readiness_status_vocabulary": [
+    "READY",
+    "NOT_READY",
+    "PARTIAL",
+    "UNKNOWN"
+  ],
+  "recipe_rows": [
+    {
+      "currency_normalization_required": true,
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "readiness_block_reasons": [
+        "MISSING_CURRENCY_NORMALIZATION",
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "readiness_status": "NOT_READY",
+      "recipe_id": "asia_developed_quality_value_v0",
+      "report_lag_required": true,
+      "required_factor_ids": [
+        "roic",
+        "gross_profitability",
+        "book_to_market",
+        "earnings_yield"
+      ],
+      "restatement_risk": "present",
+      "source_manifest_dependency": true,
+      "target_universe_ids": [
+        "asia_developed_liquid"
+      ],
+      "universe_identity_dependency": true
+    },
+    {
+      "currency_normalization_required": false,
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "readiness_block_reasons": [
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN",
+        "UNIVERSE_IDENTITY_NOT_READY"
+      ],
+      "readiness_status": "NOT_READY",
+      "recipe_id": "defensive_quality_momentum_v0",
+      "report_lag_required": true,
+      "required_factor_ids": [
+        "return_on_assets",
+        "gross_profitability",
+        "twelve_month_momentum"
+      ],
+      "restatement_risk": "present",
+      "source_manifest_dependency": true,
+      "target_universe_ids": [
+        "global_developed_liquid"
+      ],
+      "universe_identity_dependency": true
+    },
+    {
+      "currency_normalization_required": true,
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "readiness_block_reasons": [
+        "MISSING_CURRENCY_NORMALIZATION",
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN",
+        "UNIVERSE_IDENTITY_NOT_READY"
+      ],
+      "readiness_status": "NOT_READY",
+      "recipe_id": "eu_quality_value_momentum_v0",
+      "report_lag_required": true,
+      "required_factor_ids": [
+        "roic",
+        "earnings_yield",
+        "twelve_month_momentum"
+      ],
+      "restatement_risk": "present",
+      "source_manifest_dependency": true,
+      "target_universe_ids": [
+        "europe_large_mid"
+      ],
+      "universe_identity_dependency": true
+    },
+    {
+      "currency_normalization_required": false,
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "readiness_block_reasons": [
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN",
+        "UNIVERSE_IDENTITY_NOT_READY"
+      ],
+      "readiness_status": "NOT_READY",
+      "recipe_id": "europe_deep_value_financial_health_v0",
+      "report_lag_required": true,
+      "required_factor_ids": [
+        "book_to_market",
+        "price_to_sales",
+        "piotroski_f_score",
+        "altman_z_score"
+      ],
+      "restatement_risk": "present",
+      "source_manifest_dependency": true,
+      "target_universe_ids": [
+        "europe_large_mid",
+        "europe_small_mid"
+      ],
+      "universe_identity_dependency": true
+    },
+    {
+      "currency_normalization_required": false,
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "readiness_block_reasons": [
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN",
+        "UNIVERSE_IDENTITY_NOT_READY"
+      ],
+      "readiness_status": "NOT_READY",
+      "recipe_id": "europe_small_mid_quality_value_v0",
+      "report_lag_required": true,
+      "required_factor_ids": [
+        "gross_profitability",
+        "book_to_market",
+        "accruals_ratio"
+      ],
+      "restatement_risk": "present",
+      "source_manifest_dependency": true,
+      "target_universe_ids": [
+        "europe_small_mid"
+      ],
+      "universe_identity_dependency": true
+    },
+    {
+      "currency_normalization_required": false,
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "readiness_block_reasons": [
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN",
+        "UNIVERSE_IDENTITY_NOT_READY"
+      ],
+      "readiness_status": "NOT_READY",
+      "recipe_id": "global_developed_quality_momentum_v0",
+      "report_lag_required": true,
+      "required_factor_ids": [
+        "roic",
+        "gross_profitability",
+        "twelve_month_momentum"
+      ],
+      "restatement_risk": "present",
+      "source_manifest_dependency": true,
+      "target_universe_ids": [
+        "global_developed_liquid"
+      ],
+      "universe_identity_dependency": true
+    },
+    {
+      "currency_normalization_required": true,
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "readiness_block_reasons": [
+        "MISSING_CURRENCY_NORMALIZATION",
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN",
+        "UNIVERSE_IDENTITY_NOT_READY"
+      ],
+      "readiness_status": "NOT_READY",
+      "recipe_id": "global_developed_value_quality_v0",
+      "report_lag_required": true,
+      "required_factor_ids": [
+        "book_to_market",
+        "earnings_yield",
+        "return_on_assets"
+      ],
+      "restatement_risk": "present",
+      "source_manifest_dependency": true,
+      "target_universe_ids": [
+        "global_developed_liquid"
+      ],
+      "universe_identity_dependency": true
+    },
+    {
+      "currency_normalization_required": false,
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "readiness_block_reasons": [
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN",
+        "UNIVERSE_IDENTITY_NOT_READY"
+      ],
+      "readiness_status": "NOT_READY",
+      "recipe_id": "low_accrual_quality_v0",
+      "report_lag_required": true,
+      "required_factor_ids": [
+        "accruals_ratio",
+        "gross_profitability",
+        "return_on_assets"
+      ],
+      "restatement_risk": "present",
+      "source_manifest_dependency": true,
+      "target_universe_ids": [
+        "global_developed_liquid"
+      ],
+      "universe_identity_dependency": true
+    },
+    {
+      "currency_normalization_required": false,
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "readiness_block_reasons": [
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN",
+        "UNIVERSE_IDENTITY_NOT_READY"
+      ],
+      "readiness_status": "NOT_READY",
+      "recipe_id": "magic_formula_style_v0",
+      "report_lag_required": true,
+      "required_factor_ids": [
+        "enterprise_value_to_ebit",
+        "roic"
+      ],
+      "restatement_risk": "present",
+      "source_manifest_dependency": true,
+      "target_universe_ids": [
+        "global_developed_liquid"
+      ],
+      "universe_identity_dependency": true
+    },
+    {
+      "currency_normalization_required": false,
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "readiness_block_reasons": [
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN",
+        "UNIVERSE_IDENTITY_NOT_READY"
+      ],
+      "readiness_status": "NOT_READY",
+      "recipe_id": "nl_quality_large_liquid_v0",
+      "report_lag_required": true,
+      "required_factor_ids": [
+        "roic",
+        "gross_profitability",
+        "average_daily_value_traded"
+      ],
+      "restatement_risk": "present",
+      "source_manifest_dependency": true,
+      "target_universe_ids": [
+        "nl_equities"
+      ],
+      "universe_identity_dependency": true
+    },
+    {
+      "currency_normalization_required": false,
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "readiness_block_reasons": [
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN",
+        "UNIVERSE_IDENTITY_NOT_READY"
+      ],
+      "readiness_status": "NOT_READY",
+      "recipe_id": "nordics_quality_compounders_v0",
+      "report_lag_required": true,
+      "required_factor_ids": [
+        "roic",
+        "gross_profitability",
+        "twelve_month_momentum"
+      ],
+      "restatement_risk": "present",
+      "source_manifest_dependency": true,
+      "target_universe_ids": [
+        "nordics_equities"
+      ],
+      "universe_identity_dependency": true
+    },
+    {
+      "currency_normalization_required": false,
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "readiness_block_reasons": [
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN",
+        "UNIVERSE_IDENTITY_NOT_READY"
+      ],
+      "readiness_status": "NOT_READY",
+      "recipe_id": "piotroski_value_style_v0",
+      "report_lag_required": true,
+      "required_factor_ids": [
+        "book_to_market",
+        "piotroski_f_score"
+      ],
+      "restatement_risk": "present",
+      "source_manifest_dependency": true,
+      "target_universe_ids": [
+        "global_developed_liquid"
+      ],
+      "universe_identity_dependency": true
+    },
+    {
+      "currency_normalization_required": false,
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "readiness_block_reasons": [
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "readiness_status": "NOT_READY",
+      "recipe_id": "switzerland_defensive_quality_v0",
+      "report_lag_required": true,
+      "required_factor_ids": [
+        "return_on_assets",
+        "gross_profitability",
+        "dividend_yield"
+      ],
+      "restatement_risk": "present",
+      "source_manifest_dependency": true,
+      "target_universe_ids": [
+        "switzerland_equities"
+      ],
+      "universe_identity_dependency": true
+    },
+    {
+      "currency_normalization_required": false,
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "readiness_block_reasons": [
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "readiness_status": "NOT_READY",
+      "recipe_id": "us_quality_momentum_large_mid_v0",
+      "report_lag_required": true,
+      "required_factor_ids": [
+        "roic",
+        "gross_profitability",
+        "twelve_month_momentum"
+      ],
+      "restatement_risk": "present",
+      "source_manifest_dependency": true,
+      "target_universe_ids": [
+        "us_large_mid",
+        "us_quality_liquid"
+      ],
+      "universe_identity_dependency": true
+    },
+    {
+      "currency_normalization_required": false,
+      "field_coverage_status": "MISSING",
+      "point_in_time_required": true,
+      "readiness_block_reasons": [
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "readiness_status": "NOT_READY",
+      "recipe_id": "us_shareholder_yield_quality_v0",
+      "report_lag_required": true,
+      "required_factor_ids": [
+        "shareholder_yield",
+        "return_on_assets",
+        "gross_profitability"
+      ],
+      "restatement_risk": "present",
+      "source_manifest_dependency": true,
+      "target_universe_ids": [
+        "us_large_mid",
+        "us_quality_liquid"
+      ],
+      "universe_identity_dependency": true
+    }
+  ],
+  "report_kind": "fundamental_readiness",
+  "safety_invariants": {
+    "broker_risk_execution_forbidden": true,
+    "mutates_frozen_contracts": false,
+    "mutates_registry": false,
+    "not_trade_signal": true,
+    "paper_shadow_live_forbidden": true,
+    "research_only": true
+  },
+  "schema_version": "1.0",
+  "summary": {
+    "factor_rows": 22,
+    "not_ready_count": 37,
+    "operator_summary": "Fundamental readiness is fail-closed until source manifests, point-in-time policy, report-lag policy, and field coverage manifests exist.",
+    "partial_count": 0,
+    "ready_count": 0,
+    "recipe_rows": 15,
+    "top_block_reasons": {
+      "MISSING_CURRENCY_NORMALIZATION": 4,
+      "MISSING_POINT_IN_TIME_POLICY": 33,
+      "MISSING_REPORT_LAG_POLICY": 33,
+      "MISSING_REQUIRED_FIELD": 37,
+      "MISSING_RESTATEMENT_POLICY": 33,
+      "MISSING_SOURCE_MANIFEST": 37,
+      "SOURCE_LICENSE_UNKNOWN": 37,
+      "SOURCE_QUALITY_UNKNOWN": 37,
+      "UNIVERSE_IDENTITY_NOT_READY": 11
+    },
+    "unknown_count": 0
+  }
+}

--- a/research/data_readiness/__init__.py
+++ b/research/data_readiness/__init__.py
@@ -1,0 +1,9 @@
+"""Fail-closed fundamental data readiness surfaces for equity-factor research."""
+
+from research.data_readiness.factor_field_coverage import build_factor_field_coverage
+from research.data_readiness.fundamental_readiness import build_fundamental_readiness
+
+__all__ = [
+    "build_factor_field_coverage",
+    "build_fundamental_readiness",
+]

--- a/research/data_readiness/factor_field_coverage.py
+++ b/research/data_readiness/factor_field_coverage.py
@@ -1,0 +1,60 @@
+"""Deterministic fail-closed factor field coverage projection."""
+
+from __future__ import annotations
+
+from typing import Final
+
+from research.equity_factors.factor_catalog import build_equity_factor_calculation_contracts
+
+
+SCHEMA_VERSION: Final[str] = "1.0"
+FIELD_COVERAGE_VOCABULARY: Final[tuple[str, ...]] = ("COVERED", "MISSING", "PARTIAL", "UNKNOWN")
+
+
+def build_factor_field_coverage() -> dict[str, object]:
+    contracts = build_equity_factor_calculation_contracts()["rows"]
+    rows: list[dict[str, object]] = []
+    for row in contracts:
+        required_fields = [str(field) for field in row["required_fields"]]
+        rows.append(
+            {
+                "factor_id": row["factor_id"],
+                "required_fields": required_fields,
+                "field_coverage": [
+                    {"field_name": field_name, "coverage_status": "MISSING"}
+                    for field_name in required_fields
+                ],
+                "field_coverage_status": "MISSING",
+                "source_manifest_required": True,
+                "point_in_time_required": bool(row["point_in_time_required"]),
+                "report_lag_required": bool(row["point_in_time_required"]),
+                "currency_normalization_required": "currency_consistent"
+                in row["quality_gate_requirements"],
+            }
+        )
+    rows.sort(key=lambda item: str(item["factor_id"]))
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": "factor_field_coverage",
+        "summary": {
+            "factor_count": len(rows),
+            "covered_count": sum(row["field_coverage_status"] == "COVERED" for row in rows),
+            "missing_count": sum(row["field_coverage_status"] == "MISSING" for row in rows),
+            "partial_count": sum(row["field_coverage_status"] == "PARTIAL" for row in rows),
+            "unknown_count": sum(row["field_coverage_status"] == "UNKNOWN" for row in rows),
+            "operator_summary": (
+                "Field coverage is fail-closed until a deterministic source manifest exists. "
+                "This report does not claim any real fundamental field availability."
+            ),
+        },
+        "field_coverage_status_vocabulary": list(FIELD_COVERAGE_VOCABULARY),
+        "rows": rows,
+        "safety_invariants": {
+            "research_only": True,
+            "not_trade_signal": True,
+            "mutates_registry": False,
+            "mutates_frozen_contracts": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+        },
+    }

--- a/research/data_readiness/fundamental_readiness.py
+++ b/research/data_readiness/fundamental_readiness.py
@@ -1,0 +1,163 @@
+"""Fail-closed fundamental readiness gate for equity-factor research intake."""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Final
+
+from research.data_readiness.factor_field_coverage import build_factor_field_coverage
+from research.equity_factors.factor_catalog import build_equity_factor_catalog
+from research.equity_factors.recipe_catalog import build_equity_factor_recipe_catalog
+from research.equity_universe_catalog import build_equity_universe_catalog
+from research.equity_universe_quality import build_equity_universe_quality
+
+
+SCHEMA_VERSION: Final[str] = "1.0"
+READINESS_VOCABULARY: Final[tuple[str, ...]] = ("READY", "NOT_READY", "PARTIAL", "UNKNOWN")
+BLOCK_REASON_VOCABULARY: Final[tuple[str, ...]] = (
+    "MISSING_SOURCE_MANIFEST",
+    "MISSING_POINT_IN_TIME_POLICY",
+    "MISSING_REQUIRED_FIELD",
+    "MISSING_CURRENCY_NORMALIZATION",
+    "MISSING_REPORT_LAG_POLICY",
+    "MISSING_RESTATEMENT_POLICY",
+    "FACTOR_FIELD_COVERAGE_UNKNOWN",
+    "UNIVERSE_IDENTITY_NOT_READY",
+    "SOURCE_LICENSE_UNKNOWN",
+    "SOURCE_QUALITY_UNKNOWN",
+    "UNKNOWN",
+)
+
+
+def _factor_row(
+    factor_row: dict[str, object],
+    coverage_row: dict[str, object],
+) -> dict[str, object]:
+    block_reasons = [
+        "MISSING_SOURCE_MANIFEST",
+        "MISSING_REQUIRED_FIELD",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN",
+    ]
+    if factor_row["point_in_time_required"]:
+        block_reasons.extend(
+            ["MISSING_POINT_IN_TIME_POLICY", "MISSING_REPORT_LAG_POLICY", "MISSING_RESTATEMENT_POLICY"]
+        )
+    if coverage_row["currency_normalization_required"]:
+        block_reasons.append("MISSING_CURRENCY_NORMALIZATION")
+    return {
+        "factor_id": factor_row["factor_id"],
+        "required_fields": list(factor_row["required_fields"]),
+        "point_in_time_required": bool(factor_row["point_in_time_required"]),
+        "report_lag_required": bool(factor_row["point_in_time_required"]),
+        "restatement_risk": factor_row["restatement_risk"],
+        "currency_normalization_required": bool(coverage_row["currency_normalization_required"]),
+        "source_manifest_required": True,
+        "field_coverage_status": coverage_row["field_coverage_status"],
+        "readiness_status": "NOT_READY",
+        "readiness_block_reasons": sorted(set(block_reasons)),
+    }
+
+
+def build_fundamental_readiness() -> dict[str, object]:
+    factor_catalog = build_equity_factor_catalog()["rows"]
+    factor_coverage_rows = {
+        row["factor_id"]: row for row in build_factor_field_coverage()["rows"]
+    }
+    quality_rows = build_equity_universe_quality()["rows"]
+    recipe_rows = build_equity_factor_recipe_catalog()["rows"]
+    instrument_universes = {
+        instrument["symbol"]: list(instrument["universe_ids"])
+        for instrument in build_equity_universe_catalog()["instruments"]
+    }
+    universe_quality_by_universe: dict[str, str] = {}
+    for quality_row in quality_rows:
+        readiness = str(quality_row["universe_readiness_status"])
+        for universe_id in instrument_universes.get(str(quality_row["symbol"]), []):
+            previous = universe_quality_by_universe.get(universe_id, "OK")
+            universe_quality_by_universe[universe_id] = "WARN" if "WARN" in {previous, readiness} else previous
+            if readiness == "FAIL":
+                universe_quality_by_universe[universe_id] = "FAIL"
+    factor_rows = [
+        _factor_row(row, factor_coverage_rows[str(row["factor_id"])]) for row in factor_catalog
+    ]
+    factor_rows.sort(key=lambda item: str(item["factor_id"]))
+    factor_readiness = {row["factor_id"]: row for row in factor_rows}
+
+    recipe_readiness_rows: list[dict[str, object]] = []
+    for row in recipe_rows:
+        block_reasons = {"MISSING_SOURCE_MANIFEST", "SOURCE_LICENSE_UNKNOWN", "SOURCE_QUALITY_UNKNOWN"}
+        if any(
+            factor_readiness[factor_id]["point_in_time_required"] for factor_id in row["required_factor_ids"]
+        ):
+            block_reasons.update(
+                {"MISSING_POINT_IN_TIME_POLICY", "MISSING_REPORT_LAG_POLICY", "MISSING_RESTATEMENT_POLICY"}
+            )
+        if any(
+            factor_readiness[factor_id]["currency_normalization_required"]
+            for factor_id in row["required_factor_ids"]
+        ):
+            block_reasons.add("MISSING_CURRENCY_NORMALIZATION")
+        if any(
+            universe_quality_by_universe.get(universe_id, "UNKNOWN") != "OK"
+            for universe_id in row["target_universe_ids"]
+        ):
+            block_reasons.add("UNIVERSE_IDENTITY_NOT_READY")
+        block_reasons.add("MISSING_REQUIRED_FIELD")
+        recipe_readiness_rows.append(
+            {
+                "recipe_id": row["recipe_id"],
+                "target_universe_ids": list(row["target_universe_ids"]),
+                "required_factor_ids": list(row["required_factor_ids"]),
+                "source_manifest_dependency": True,
+                "universe_identity_dependency": True,
+                "point_in_time_required": any(
+                    factor_readiness[factor_id]["point_in_time_required"]
+                    for factor_id in row["required_factor_ids"]
+                ),
+                "report_lag_required": any(
+                    factor_readiness[factor_id]["report_lag_required"]
+                    for factor_id in row["required_factor_ids"]
+                ),
+                "restatement_risk": "present",
+                "currency_normalization_required": any(
+                    factor_readiness[factor_id]["currency_normalization_required"]
+                    for factor_id in row["required_factor_ids"]
+                ),
+                "field_coverage_status": "MISSING",
+                "readiness_status": "NOT_READY",
+                "readiness_block_reasons": sorted(block_reasons),
+            }
+        )
+    recipe_readiness_rows.sort(key=lambda item: str(item["recipe_id"]))
+    readiness_counts = Counter(row["readiness_status"] for row in factor_rows + recipe_readiness_rows)
+    block_counts = Counter(reason for row in recipe_readiness_rows + factor_rows for reason in row["readiness_block_reasons"])
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": "fundamental_readiness",
+        "readiness_status_vocabulary": list(READINESS_VOCABULARY),
+        "block_reason_vocabulary": list(BLOCK_REASON_VOCABULARY),
+        "summary": {
+            "factor_rows": len(factor_rows),
+            "recipe_rows": len(recipe_readiness_rows),
+            "ready_count": readiness_counts.get("READY", 0),
+            "partial_count": readiness_counts.get("PARTIAL", 0),
+            "not_ready_count": readiness_counts.get("NOT_READY", 0),
+            "unknown_count": readiness_counts.get("UNKNOWN", 0),
+            "top_block_reasons": dict(sorted(block_counts.items())),
+            "operator_summary": (
+                "Fundamental readiness is fail-closed until source manifests, point-in-time policy, report-lag policy, "
+                "and field coverage manifests exist."
+            ),
+        },
+        "factor_rows": factor_rows,
+        "recipe_rows": recipe_readiness_rows,
+        "safety_invariants": {
+            "research_only": True,
+            "not_trade_signal": True,
+            "mutates_registry": False,
+            "mutates_frozen_contracts": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+        },
+    }

--- a/research/data_readiness/fundamental_readiness_manifest.py
+++ b/research/data_readiness/fundamental_readiness_manifest.py
@@ -1,0 +1,65 @@
+"""Artifact writer for fail-closed fundamental readiness sidecars."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Final
+
+from research.data_readiness.factor_field_coverage import build_factor_field_coverage
+from research.data_readiness.fundamental_readiness import build_fundamental_readiness
+
+
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("artifacts/data_readiness")
+WRITE_PREFIX: Final[str] = "artifacts/data_readiness/"
+READINESS_NAME: Final[str] = "fundamental_readiness_latest.v1.json"
+COVERAGE_NAME: Final[str] = "factor_field_coverage_latest.v1.json"
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(f"fundamental_readiness_manifest: refusing write outside allowlist: {path!r}")
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def write_outputs(*, repo_root: Path = Path("."), output_dir: Path = DEFAULT_OUTPUT_DIR) -> dict[str, str]:
+    base = repo_root / output_dir
+    base.mkdir(parents=True, exist_ok=True)
+    readiness_path = base / READINESS_NAME
+    coverage_path = base / COVERAGE_NAME
+    for path in (readiness_path, coverage_path):
+        _validate_write_target(path)
+    _write_json(readiness_path, build_fundamental_readiness())
+    _write_json(coverage_path, build_factor_field_coverage())
+    return {
+        "fundamental_readiness": readiness_path.relative_to(repo_root).as_posix(),
+        "factor_field_coverage": coverage_path.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.data_readiness.fundamental_readiness_manifest",
+        description="Write deterministic fail-closed fundamental readiness artifacts.",
+    )
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    payload = {
+        "fundamental_readiness": build_fundamental_readiness(),
+        "factor_field_coverage": build_factor_field_coverage(),
+    }
+    if args.write:
+        payload["_artifact_paths"] = write_outputs()
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/unit/test_factor_field_coverage.py
+++ b/tests/unit/test_factor_field_coverage.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from research.data_readiness.factor_field_coverage import build_factor_field_coverage
+
+
+def test_factor_field_coverage_is_fail_closed_and_deterministic() -> None:
+    left = build_factor_field_coverage()
+    right = build_factor_field_coverage()
+    assert left == right
+    assert left["summary"]["missing_count"] >= 20
+    assert all(row["field_coverage_status"] == "MISSING" for row in left["rows"])
+

--- a/tests/unit/test_fundamental_readiness.py
+++ b/tests/unit/test_fundamental_readiness.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from research.data_readiness.fundamental_readiness import build_fundamental_readiness
+
+
+def test_missing_source_manifest_and_required_fields_block_readiness() -> None:
+    report = build_fundamental_readiness()
+    assert report["summary"]["ready_count"] == 0
+    assert report["summary"]["not_ready_count"] == report["summary"]["factor_rows"] + report["summary"]["recipe_rows"]
+    first_factor = report["factor_rows"][0]
+    assert "MISSING_SOURCE_MANIFEST" in first_factor["readiness_block_reasons"]
+    assert "MISSING_REQUIRED_FIELD" in first_factor["readiness_block_reasons"]
+
+
+def test_point_in_time_and_report_lag_requirements_fail_closed() -> None:
+    report = build_fundamental_readiness()
+    point_in_time_rows = [row for row in report["factor_rows"] if row["point_in_time_required"]]
+    assert point_in_time_rows
+    for row in point_in_time_rows:
+        assert "MISSING_POINT_IN_TIME_POLICY" in row["readiness_block_reasons"]
+        assert "MISSING_REPORT_LAG_POLICY" in row["readiness_block_reasons"]
+

--- a/tests/unit/test_fundamental_readiness_manifest.py
+++ b/tests/unit/test_fundamental_readiness_manifest.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from research.data_readiness import fundamental_readiness_manifest as manifest
+
+
+def test_fundamental_readiness_manifest_writes_expected_sidecars(tmp_path: Path) -> None:
+    paths = manifest.write_outputs(repo_root=tmp_path)
+    readiness = json.loads((tmp_path / paths["fundamental_readiness"]).read_text(encoding="utf-8"))
+    coverage = json.loads((tmp_path / paths["factor_field_coverage"]).read_text(encoding="utf-8"))
+    assert readiness["report_kind"] == "fundamental_readiness"
+    assert coverage["report_kind"] == "factor_field_coverage"
+
+
+def test_fundamental_readiness_manifest_is_research_only() -> None:
+    payload = manifest.build_fundamental_readiness()
+    assert payload["safety_invariants"]["research_only"] is True
+    assert payload["safety_invariants"]["paper_shadow_live_forbidden"] is True


### PR DESCRIPTION
﻿## Summary
- add a deterministic fail-closed fundamental readiness gate for equity-factor research intake
- add factor field coverage sidecars and fundamental readiness sidecars under `artifacts/data_readiness/`
- keep all factor and recipe readiness records blocked until source manifests and data policies actually exist

## Why this slice is needed
The screener recipe library and operator report now exist, but recipe feasibility was still only generically blocked. This PR turns that into explicit blockers for source manifests, point-in-time policy, report lag, restatement policy, currency normalization, and universe identity readiness.

## What changed
- `research/data_readiness/factor_field_coverage.py`
- `research/data_readiness/fundamental_readiness.py`
- `research/data_readiness/fundamental_readiness_manifest.py`
- new tests and deterministic artifacts

## Safety constraints honored
- no vendor fetches, no scraping, no network calls
- no factor return computation
- no strategy registration
- no candidate promotion
- no paper/shadow/live activation
- no frozen contract mutation

## Tests run
- `python -m pytest tests/unit/test_fundamental_readiness.py -q`
- `python -m pytest tests/unit/test_factor_field_coverage.py -q`
- `python -m pytest tests/unit/test_fundamental_readiness_manifest.py -q`
- `python -m pytest tests/unit/test_equity_factor_recipe_manifest.py -q`
- `python -m pytest tests/unit/test_qre_universe_report.py -q`
- `python -m pytest tests/architecture -q`
- `python -m pytest tests -q -k "governance or no_touch or frozen_contract or execution_authority"`
- `python -m research.data_readiness.fundamental_readiness_manifest --write`
- `git diff --check`
- `git diff -- research/research_latest.json research/strategy_matrix.csv`

## Known limitations
- all factor and recipe readiness rows remain `NOT_READY`, which is expected and correct
- no source manifest integration exists yet
- no factor evaluation is performed

## Next recommended action
Use this readiness gate to materialize blocked and feasible hypothesis seeds in a read-only seed adapter.
