### PR TITLE
fix: add equity factor hypothesis seed adapter

### DIFF
--- a/artifacts/hypothesis_discovery/equity_factor_hypothesis_seeds_latest.v1.json
+++ b/artifacts/hypothesis_discovery/equity_factor_hypothesis_seeds_latest.v1.json
@@ -1,0 +1,995 @@
+{
+  "feasibility_status_vocabulary": [
+    "FEASIBLE",
+    "BLOCKED"
+  ],
+  "report_kind": "equity_factor_hypothesis_seeds",
+  "rows": [
+    {
+      "allowed_use": [
+        "research_prior"
+      ],
+      "behavior_family": "quality_value_screening",
+      "blocked_reason_codes": [
+        "BLOCKED_DATA_READINESS_MISSING",
+        "MISSING_CURRENCY_NORMALIZATION",
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "created_from_artifacts": [
+        "artifacts/universe/equity_universe_catalog_latest.v1.json",
+        "artifacts/universe/equity_universe_quality_latest.v1.json",
+        "artifacts/identity/instrument_identity_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_catalog_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_calculation_contracts_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_recipes_latest.v1.json",
+        "artifacts/data_readiness/fundamental_readiness_latest.v1.json"
+      ],
+      "deterministic_hash": "0e7d5fb0157fceef8f0064e5605f80bc8672c118134d3d50ae0d4816fa9910f5",
+      "expected_research_value_score": 0.49,
+      "factor_ids": [
+        "roic",
+        "gross_profitability",
+        "book_to_market",
+        "earnings_yield"
+      ],
+      "feasibility_status": "BLOCKED",
+      "forbidden_use": [
+        "strategy_signal",
+        "trade_signal",
+        "buy_list",
+        "sell_list",
+        "candidate_promotion",
+        "paper",
+        "shadow",
+        "live",
+        "capital_allocation",
+        "broker_execution"
+      ],
+      "hypothesis_seed_id": "equity_factor_seed::asia_developed_quality_value_v0",
+      "hypothesis_statement": "Research-only hypothesis seed from asia_developed_quality_value_v0 testing quality_value_screening across asia_developed_liquid using factors: roic, gross_profitability, book_to_market, earnings_yield. This is not a trade signal or strategy candidate.",
+      "required_next_action": "add_source_manifest",
+      "score_components": {
+        "blocked_penalty": -0.3,
+        "data_readiness_component": 0.0,
+        "expected_information_gain_placeholder": 0.1,
+        "factor_catalog_component": 0.2,
+        "identity_readiness_component": 0.18,
+        "recipe_structure_component": 0.15,
+        "universe_readiness_component": 0.22
+      },
+      "score_interpretation": "expected_research_value_only_not_alpha_confidence",
+      "source_recipe_id": "asia_developed_quality_value_v0",
+      "target_universe_ids": [
+        "asia_developed_liquid"
+      ]
+    },
+    {
+      "allowed_use": [
+        "research_prior"
+      ],
+      "behavior_family": "defensive_quality_drawdown_resilience",
+      "blocked_reason_codes": [
+        "BLOCKED_IDENTITY_AMBIGUITY",
+        "BLOCKED_DATA_READINESS_MISSING",
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN",
+        "UNIVERSE_IDENTITY_NOT_READY"
+      ],
+      "created_from_artifacts": [
+        "artifacts/universe/equity_universe_catalog_latest.v1.json",
+        "artifacts/universe/equity_universe_quality_latest.v1.json",
+        "artifacts/identity/instrument_identity_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_catalog_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_calculation_contracts_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_recipes_latest.v1.json",
+        "artifacts/data_readiness/fundamental_readiness_latest.v1.json"
+      ],
+      "deterministic_hash": "420bddf44b07b3fc15361f1e5b8c2cc3bd650b159b31e985b3b39b880667169d",
+      "expected_research_value_score": 0.37,
+      "factor_ids": [
+        "return_on_assets",
+        "gross_profitability",
+        "twelve_month_momentum"
+      ],
+      "feasibility_status": "BLOCKED",
+      "forbidden_use": [
+        "strategy_signal",
+        "trade_signal",
+        "buy_list",
+        "sell_list",
+        "candidate_promotion",
+        "paper",
+        "shadow",
+        "live",
+        "capital_allocation",
+        "broker_execution"
+      ],
+      "hypothesis_seed_id": "equity_factor_seed::defensive_quality_momentum_v0",
+      "hypothesis_statement": "Research-only hypothesis seed from defensive_quality_momentum_v0 testing defensive_quality_drawdown_resilience across global_developed_liquid using factors: return_on_assets, gross_profitability, twelve_month_momentum. This is not a trade signal or strategy candidate.",
+      "required_next_action": "add_source_manifest",
+      "score_components": {
+        "blocked_penalty": -0.3,
+        "data_readiness_component": 0.0,
+        "expected_information_gain_placeholder": 0.1,
+        "factor_catalog_component": 0.2,
+        "identity_readiness_component": 0.0,
+        "recipe_structure_component": 0.15,
+        "universe_readiness_component": 0.22
+      },
+      "score_interpretation": "expected_research_value_only_not_alpha_confidence",
+      "source_recipe_id": "defensive_quality_momentum_v0",
+      "target_universe_ids": [
+        "global_developed_liquid"
+      ]
+    },
+    {
+      "allowed_use": [
+        "research_prior"
+      ],
+      "behavior_family": "quality_value_momentum_persistence",
+      "blocked_reason_codes": [
+        "BLOCKED_IDENTITY_AMBIGUITY",
+        "BLOCKED_DATA_READINESS_MISSING",
+        "MISSING_CURRENCY_NORMALIZATION",
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN",
+        "UNIVERSE_IDENTITY_NOT_READY"
+      ],
+      "created_from_artifacts": [
+        "artifacts/universe/equity_universe_catalog_latest.v1.json",
+        "artifacts/universe/equity_universe_quality_latest.v1.json",
+        "artifacts/identity/instrument_identity_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_catalog_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_calculation_contracts_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_recipes_latest.v1.json",
+        "artifacts/data_readiness/fundamental_readiness_latest.v1.json"
+      ],
+      "deterministic_hash": "08cd2bdc69dcc4a479cc5b6da907bd9faa66d0e4b75547650f84c59e4842eb02",
+      "expected_research_value_score": 0.37,
+      "factor_ids": [
+        "roic",
+        "earnings_yield",
+        "twelve_month_momentum"
+      ],
+      "feasibility_status": "BLOCKED",
+      "forbidden_use": [
+        "strategy_signal",
+        "trade_signal",
+        "buy_list",
+        "sell_list",
+        "candidate_promotion",
+        "paper",
+        "shadow",
+        "live",
+        "capital_allocation",
+        "broker_execution"
+      ],
+      "hypothesis_seed_id": "equity_factor_seed::eu_quality_value_momentum_v0",
+      "hypothesis_statement": "Research-only hypothesis seed from eu_quality_value_momentum_v0 testing quality_value_momentum_persistence across europe_large_mid using factors: roic, earnings_yield, twelve_month_momentum. This is not a trade signal or strategy candidate.",
+      "required_next_action": "add_source_manifest",
+      "score_components": {
+        "blocked_penalty": -0.3,
+        "data_readiness_component": 0.0,
+        "expected_information_gain_placeholder": 0.1,
+        "factor_catalog_component": 0.2,
+        "identity_readiness_component": 0.0,
+        "recipe_structure_component": 0.15,
+        "universe_readiness_component": 0.22
+      },
+      "score_interpretation": "expected_research_value_only_not_alpha_confidence",
+      "source_recipe_id": "eu_quality_value_momentum_v0",
+      "target_universe_ids": [
+        "europe_large_mid"
+      ]
+    },
+    {
+      "allowed_use": [
+        "research_prior"
+      ],
+      "behavior_family": "financial_health_reversal",
+      "blocked_reason_codes": [
+        "BLOCKED_IDENTITY_AMBIGUITY",
+        "BLOCKED_DATA_READINESS_MISSING",
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN",
+        "UNIVERSE_IDENTITY_NOT_READY"
+      ],
+      "created_from_artifacts": [
+        "artifacts/universe/equity_universe_catalog_latest.v1.json",
+        "artifacts/universe/equity_universe_quality_latest.v1.json",
+        "artifacts/identity/instrument_identity_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_catalog_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_calculation_contracts_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_recipes_latest.v1.json",
+        "artifacts/data_readiness/fundamental_readiness_latest.v1.json"
+      ],
+      "deterministic_hash": "19be0cde4cf62700b532516bbf39ca8a07e26d0d4e7584ddd8130fd6b8e30ea3",
+      "expected_research_value_score": 0.37,
+      "factor_ids": [
+        "book_to_market",
+        "price_to_sales",
+        "piotroski_f_score",
+        "altman_z_score"
+      ],
+      "feasibility_status": "BLOCKED",
+      "forbidden_use": [
+        "strategy_signal",
+        "trade_signal",
+        "buy_list",
+        "sell_list",
+        "candidate_promotion",
+        "paper",
+        "shadow",
+        "live",
+        "capital_allocation",
+        "broker_execution"
+      ],
+      "hypothesis_seed_id": "equity_factor_seed::europe_deep_value_financial_health_v0",
+      "hypothesis_statement": "Research-only hypothesis seed from europe_deep_value_financial_health_v0 testing financial_health_reversal across europe_large_mid, europe_small_mid using factors: book_to_market, price_to_sales, piotroski_f_score, altman_z_score. This is not a trade signal or strategy candidate.",
+      "required_next_action": "add_source_manifest",
+      "score_components": {
+        "blocked_penalty": -0.3,
+        "data_readiness_component": 0.0,
+        "expected_information_gain_placeholder": 0.1,
+        "factor_catalog_component": 0.2,
+        "identity_readiness_component": 0.0,
+        "recipe_structure_component": 0.15,
+        "universe_readiness_component": 0.22
+      },
+      "score_interpretation": "expected_research_value_only_not_alpha_confidence",
+      "source_recipe_id": "europe_deep_value_financial_health_v0",
+      "target_universe_ids": [
+        "europe_large_mid",
+        "europe_small_mid"
+      ]
+    },
+    {
+      "allowed_use": [
+        "research_prior"
+      ],
+      "behavior_family": "quality_value_screening",
+      "blocked_reason_codes": [
+        "BLOCKED_IDENTITY_AMBIGUITY",
+        "BLOCKED_DATA_READINESS_MISSING",
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN",
+        "UNIVERSE_IDENTITY_NOT_READY"
+      ],
+      "created_from_artifacts": [
+        "artifacts/universe/equity_universe_catalog_latest.v1.json",
+        "artifacts/universe/equity_universe_quality_latest.v1.json",
+        "artifacts/identity/instrument_identity_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_catalog_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_calculation_contracts_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_recipes_latest.v1.json",
+        "artifacts/data_readiness/fundamental_readiness_latest.v1.json"
+      ],
+      "deterministic_hash": "922aea068ba20417d76dc78bb6b325420e26cb4ca7b633ca2d56aacbb2a1d06c",
+      "expected_research_value_score": 0.37,
+      "factor_ids": [
+        "gross_profitability",
+        "book_to_market",
+        "accruals_ratio"
+      ],
+      "feasibility_status": "BLOCKED",
+      "forbidden_use": [
+        "strategy_signal",
+        "trade_signal",
+        "buy_list",
+        "sell_list",
+        "candidate_promotion",
+        "paper",
+        "shadow",
+        "live",
+        "capital_allocation",
+        "broker_execution"
+      ],
+      "hypothesis_seed_id": "equity_factor_seed::europe_small_mid_quality_value_v0",
+      "hypothesis_statement": "Research-only hypothesis seed from europe_small_mid_quality_value_v0 testing quality_value_screening across europe_small_mid using factors: gross_profitability, book_to_market, accruals_ratio. This is not a trade signal or strategy candidate.",
+      "required_next_action": "add_source_manifest",
+      "score_components": {
+        "blocked_penalty": -0.3,
+        "data_readiness_component": 0.0,
+        "expected_information_gain_placeholder": 0.1,
+        "factor_catalog_component": 0.2,
+        "identity_readiness_component": 0.0,
+        "recipe_structure_component": 0.15,
+        "universe_readiness_component": 0.22
+      },
+      "score_interpretation": "expected_research_value_only_not_alpha_confidence",
+      "source_recipe_id": "europe_small_mid_quality_value_v0",
+      "target_universe_ids": [
+        "europe_small_mid"
+      ]
+    },
+    {
+      "allowed_use": [
+        "research_prior"
+      ],
+      "behavior_family": "quality_value_momentum_persistence",
+      "blocked_reason_codes": [
+        "BLOCKED_IDENTITY_AMBIGUITY",
+        "BLOCKED_DATA_READINESS_MISSING",
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN",
+        "UNIVERSE_IDENTITY_NOT_READY"
+      ],
+      "created_from_artifacts": [
+        "artifacts/universe/equity_universe_catalog_latest.v1.json",
+        "artifacts/universe/equity_universe_quality_latest.v1.json",
+        "artifacts/identity/instrument_identity_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_catalog_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_calculation_contracts_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_recipes_latest.v1.json",
+        "artifacts/data_readiness/fundamental_readiness_latest.v1.json"
+      ],
+      "deterministic_hash": "2c3ac83d39490c0d8924b0facaa84b7e7df01327cd658df087b1c4579ca399f0",
+      "expected_research_value_score": 0.37,
+      "factor_ids": [
+        "roic",
+        "gross_profitability",
+        "twelve_month_momentum"
+      ],
+      "feasibility_status": "BLOCKED",
+      "forbidden_use": [
+        "strategy_signal",
+        "trade_signal",
+        "buy_list",
+        "sell_list",
+        "candidate_promotion",
+        "paper",
+        "shadow",
+        "live",
+        "capital_allocation",
+        "broker_execution"
+      ],
+      "hypothesis_seed_id": "equity_factor_seed::global_developed_quality_momentum_v0",
+      "hypothesis_statement": "Research-only hypothesis seed from global_developed_quality_momentum_v0 testing quality_value_momentum_persistence across global_developed_liquid using factors: roic, gross_profitability, twelve_month_momentum. This is not a trade signal or strategy candidate.",
+      "required_next_action": "add_source_manifest",
+      "score_components": {
+        "blocked_penalty": -0.3,
+        "data_readiness_component": 0.0,
+        "expected_information_gain_placeholder": 0.1,
+        "factor_catalog_component": 0.2,
+        "identity_readiness_component": 0.0,
+        "recipe_structure_component": 0.15,
+        "universe_readiness_component": 0.22
+      },
+      "score_interpretation": "expected_research_value_only_not_alpha_confidence",
+      "source_recipe_id": "global_developed_quality_momentum_v0",
+      "target_universe_ids": [
+        "global_developed_liquid"
+      ]
+    },
+    {
+      "allowed_use": [
+        "research_prior"
+      ],
+      "behavior_family": "quality_value_screening",
+      "blocked_reason_codes": [
+        "BLOCKED_IDENTITY_AMBIGUITY",
+        "BLOCKED_DATA_READINESS_MISSING",
+        "MISSING_CURRENCY_NORMALIZATION",
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN",
+        "UNIVERSE_IDENTITY_NOT_READY"
+      ],
+      "created_from_artifacts": [
+        "artifacts/universe/equity_universe_catalog_latest.v1.json",
+        "artifacts/universe/equity_universe_quality_latest.v1.json",
+        "artifacts/identity/instrument_identity_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_catalog_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_calculation_contracts_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_recipes_latest.v1.json",
+        "artifacts/data_readiness/fundamental_readiness_latest.v1.json"
+      ],
+      "deterministic_hash": "946e4a952c1080b140d4f288739f3ddc754fa0151f5cfacdadf7404c0d2b747b",
+      "expected_research_value_score": 0.37,
+      "factor_ids": [
+        "book_to_market",
+        "earnings_yield",
+        "return_on_assets"
+      ],
+      "feasibility_status": "BLOCKED",
+      "forbidden_use": [
+        "strategy_signal",
+        "trade_signal",
+        "buy_list",
+        "sell_list",
+        "candidate_promotion",
+        "paper",
+        "shadow",
+        "live",
+        "capital_allocation",
+        "broker_execution"
+      ],
+      "hypothesis_seed_id": "equity_factor_seed::global_developed_value_quality_v0",
+      "hypothesis_statement": "Research-only hypothesis seed from global_developed_value_quality_v0 testing quality_value_screening across global_developed_liquid using factors: book_to_market, earnings_yield, return_on_assets. This is not a trade signal or strategy candidate.",
+      "required_next_action": "add_source_manifest",
+      "score_components": {
+        "blocked_penalty": -0.3,
+        "data_readiness_component": 0.0,
+        "expected_information_gain_placeholder": 0.1,
+        "factor_catalog_component": 0.2,
+        "identity_readiness_component": 0.0,
+        "recipe_structure_component": 0.15,
+        "universe_readiness_component": 0.22
+      },
+      "score_interpretation": "expected_research_value_only_not_alpha_confidence",
+      "source_recipe_id": "global_developed_value_quality_v0",
+      "target_universe_ids": [
+        "global_developed_liquid"
+      ]
+    },
+    {
+      "allowed_use": [
+        "research_prior"
+      ],
+      "behavior_family": "low_accrual_quality_screening",
+      "blocked_reason_codes": [
+        "BLOCKED_IDENTITY_AMBIGUITY",
+        "BLOCKED_DATA_READINESS_MISSING",
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN",
+        "UNIVERSE_IDENTITY_NOT_READY"
+      ],
+      "created_from_artifacts": [
+        "artifacts/universe/equity_universe_catalog_latest.v1.json",
+        "artifacts/universe/equity_universe_quality_latest.v1.json",
+        "artifacts/identity/instrument_identity_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_catalog_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_calculation_contracts_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_recipes_latest.v1.json",
+        "artifacts/data_readiness/fundamental_readiness_latest.v1.json"
+      ],
+      "deterministic_hash": "258302e1d7539e162ddd2e2982c7329beb6608e1d3e79184319eb0c504379015",
+      "expected_research_value_score": 0.37,
+      "factor_ids": [
+        "accruals_ratio",
+        "gross_profitability",
+        "return_on_assets"
+      ],
+      "feasibility_status": "BLOCKED",
+      "forbidden_use": [
+        "strategy_signal",
+        "trade_signal",
+        "buy_list",
+        "sell_list",
+        "candidate_promotion",
+        "paper",
+        "shadow",
+        "live",
+        "capital_allocation",
+        "broker_execution"
+      ],
+      "hypothesis_seed_id": "equity_factor_seed::low_accrual_quality_v0",
+      "hypothesis_statement": "Research-only hypothesis seed from low_accrual_quality_v0 testing low_accrual_quality_screening across global_developed_liquid using factors: accruals_ratio, gross_profitability, return_on_assets. This is not a trade signal or strategy candidate.",
+      "required_next_action": "add_source_manifest",
+      "score_components": {
+        "blocked_penalty": -0.3,
+        "data_readiness_component": 0.0,
+        "expected_information_gain_placeholder": 0.1,
+        "factor_catalog_component": 0.2,
+        "identity_readiness_component": 0.0,
+        "recipe_structure_component": 0.15,
+        "universe_readiness_component": 0.22
+      },
+      "score_interpretation": "expected_research_value_only_not_alpha_confidence",
+      "source_recipe_id": "low_accrual_quality_v0",
+      "target_universe_ids": [
+        "global_developed_liquid"
+      ]
+    },
+    {
+      "allowed_use": [
+        "research_prior"
+      ],
+      "behavior_family": "quality_value_efficiency",
+      "blocked_reason_codes": [
+        "BLOCKED_IDENTITY_AMBIGUITY",
+        "BLOCKED_DATA_READINESS_MISSING",
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN",
+        "UNIVERSE_IDENTITY_NOT_READY"
+      ],
+      "created_from_artifacts": [
+        "artifacts/universe/equity_universe_catalog_latest.v1.json",
+        "artifacts/universe/equity_universe_quality_latest.v1.json",
+        "artifacts/identity/instrument_identity_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_catalog_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_calculation_contracts_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_recipes_latest.v1.json",
+        "artifacts/data_readiness/fundamental_readiness_latest.v1.json"
+      ],
+      "deterministic_hash": "698e81990742136e6b7d63602bebd96fb675fd93b615bbd9eb112512e9141840",
+      "expected_research_value_score": 0.37,
+      "factor_ids": [
+        "enterprise_value_to_ebit",
+        "roic"
+      ],
+      "feasibility_status": "BLOCKED",
+      "forbidden_use": [
+        "strategy_signal",
+        "trade_signal",
+        "buy_list",
+        "sell_list",
+        "candidate_promotion",
+        "paper",
+        "shadow",
+        "live",
+        "capital_allocation",
+        "broker_execution"
+      ],
+      "hypothesis_seed_id": "equity_factor_seed::magic_formula_style_v0",
+      "hypothesis_statement": "Research-only hypothesis seed from magic_formula_style_v0 testing quality_value_efficiency across global_developed_liquid using factors: enterprise_value_to_ebit, roic. This is not a trade signal or strategy candidate.",
+      "required_next_action": "add_source_manifest",
+      "score_components": {
+        "blocked_penalty": -0.3,
+        "data_readiness_component": 0.0,
+        "expected_information_gain_placeholder": 0.1,
+        "factor_catalog_component": 0.2,
+        "identity_readiness_component": 0.0,
+        "recipe_structure_component": 0.15,
+        "universe_readiness_component": 0.22
+      },
+      "score_interpretation": "expected_research_value_only_not_alpha_confidence",
+      "source_recipe_id": "magic_formula_style_v0",
+      "target_universe_ids": [
+        "global_developed_liquid"
+      ]
+    },
+    {
+      "allowed_use": [
+        "research_prior"
+      ],
+      "behavior_family": "equity_factor_screening",
+      "blocked_reason_codes": [
+        "BLOCKED_IDENTITY_AMBIGUITY",
+        "BLOCKED_DATA_READINESS_MISSING",
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN",
+        "UNIVERSE_IDENTITY_NOT_READY"
+      ],
+      "created_from_artifacts": [
+        "artifacts/universe/equity_universe_catalog_latest.v1.json",
+        "artifacts/universe/equity_universe_quality_latest.v1.json",
+        "artifacts/identity/instrument_identity_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_catalog_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_calculation_contracts_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_recipes_latest.v1.json",
+        "artifacts/data_readiness/fundamental_readiness_latest.v1.json"
+      ],
+      "deterministic_hash": "3825a761dc223e3a0bb7dee01d58e8fd02a3135997c98cd57bb75581da749689",
+      "expected_research_value_score": 0.37,
+      "factor_ids": [
+        "roic",
+        "gross_profitability",
+        "average_daily_value_traded"
+      ],
+      "feasibility_status": "BLOCKED",
+      "forbidden_use": [
+        "strategy_signal",
+        "trade_signal",
+        "buy_list",
+        "sell_list",
+        "candidate_promotion",
+        "paper",
+        "shadow",
+        "live",
+        "capital_allocation",
+        "broker_execution"
+      ],
+      "hypothesis_seed_id": "equity_factor_seed::nl_quality_large_liquid_v0",
+      "hypothesis_statement": "Research-only hypothesis seed from nl_quality_large_liquid_v0 testing equity_factor_screening across nl_equities using factors: roic, gross_profitability, average_daily_value_traded. This is not a trade signal or strategy candidate.",
+      "required_next_action": "add_source_manifest",
+      "score_components": {
+        "blocked_penalty": -0.3,
+        "data_readiness_component": 0.0,
+        "expected_information_gain_placeholder": 0.1,
+        "factor_catalog_component": 0.2,
+        "identity_readiness_component": 0.0,
+        "recipe_structure_component": 0.15,
+        "universe_readiness_component": 0.22
+      },
+      "score_interpretation": "expected_research_value_only_not_alpha_confidence",
+      "source_recipe_id": "nl_quality_large_liquid_v0",
+      "target_universe_ids": [
+        "nl_equities"
+      ]
+    },
+    {
+      "allowed_use": [
+        "research_prior"
+      ],
+      "behavior_family": "equity_factor_screening",
+      "blocked_reason_codes": [
+        "BLOCKED_IDENTITY_AMBIGUITY",
+        "BLOCKED_DATA_READINESS_MISSING",
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN",
+        "UNIVERSE_IDENTITY_NOT_READY"
+      ],
+      "created_from_artifacts": [
+        "artifacts/universe/equity_universe_catalog_latest.v1.json",
+        "artifacts/universe/equity_universe_quality_latest.v1.json",
+        "artifacts/identity/instrument_identity_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_catalog_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_calculation_contracts_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_recipes_latest.v1.json",
+        "artifacts/data_readiness/fundamental_readiness_latest.v1.json"
+      ],
+      "deterministic_hash": "16142ac51bb66c5175fccb84319494603325042487b064cb54e9ac4ab1efe5f8",
+      "expected_research_value_score": 0.37,
+      "factor_ids": [
+        "roic",
+        "gross_profitability",
+        "twelve_month_momentum"
+      ],
+      "feasibility_status": "BLOCKED",
+      "forbidden_use": [
+        "strategy_signal",
+        "trade_signal",
+        "buy_list",
+        "sell_list",
+        "candidate_promotion",
+        "paper",
+        "shadow",
+        "live",
+        "capital_allocation",
+        "broker_execution"
+      ],
+      "hypothesis_seed_id": "equity_factor_seed::nordics_quality_compounders_v0",
+      "hypothesis_statement": "Research-only hypothesis seed from nordics_quality_compounders_v0 testing equity_factor_screening across nordics_equities using factors: roic, gross_profitability, twelve_month_momentum. This is not a trade signal or strategy candidate.",
+      "required_next_action": "add_source_manifest",
+      "score_components": {
+        "blocked_penalty": -0.3,
+        "data_readiness_component": 0.0,
+        "expected_information_gain_placeholder": 0.1,
+        "factor_catalog_component": 0.2,
+        "identity_readiness_component": 0.0,
+        "recipe_structure_component": 0.15,
+        "universe_readiness_component": 0.22
+      },
+      "score_interpretation": "expected_research_value_only_not_alpha_confidence",
+      "source_recipe_id": "nordics_quality_compounders_v0",
+      "target_universe_ids": [
+        "nordics_equities"
+      ]
+    },
+    {
+      "allowed_use": [
+        "research_prior"
+      ],
+      "behavior_family": "financial_health_value_recovery",
+      "blocked_reason_codes": [
+        "BLOCKED_IDENTITY_AMBIGUITY",
+        "BLOCKED_DATA_READINESS_MISSING",
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN",
+        "UNIVERSE_IDENTITY_NOT_READY"
+      ],
+      "created_from_artifacts": [
+        "artifacts/universe/equity_universe_catalog_latest.v1.json",
+        "artifacts/universe/equity_universe_quality_latest.v1.json",
+        "artifacts/identity/instrument_identity_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_catalog_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_calculation_contracts_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_recipes_latest.v1.json",
+        "artifacts/data_readiness/fundamental_readiness_latest.v1.json"
+      ],
+      "deterministic_hash": "1982c103312b873e3f384bc21319ac689045750a8b98d6ed6467841668bba28e",
+      "expected_research_value_score": 0.37,
+      "factor_ids": [
+        "book_to_market",
+        "piotroski_f_score"
+      ],
+      "feasibility_status": "BLOCKED",
+      "forbidden_use": [
+        "strategy_signal",
+        "trade_signal",
+        "buy_list",
+        "sell_list",
+        "candidate_promotion",
+        "paper",
+        "shadow",
+        "live",
+        "capital_allocation",
+        "broker_execution"
+      ],
+      "hypothesis_seed_id": "equity_factor_seed::piotroski_value_style_v0",
+      "hypothesis_statement": "Research-only hypothesis seed from piotroski_value_style_v0 testing financial_health_value_recovery across global_developed_liquid using factors: book_to_market, piotroski_f_score. This is not a trade signal or strategy candidate.",
+      "required_next_action": "add_source_manifest",
+      "score_components": {
+        "blocked_penalty": -0.3,
+        "data_readiness_component": 0.0,
+        "expected_information_gain_placeholder": 0.1,
+        "factor_catalog_component": 0.2,
+        "identity_readiness_component": 0.0,
+        "recipe_structure_component": 0.15,
+        "universe_readiness_component": 0.22
+      },
+      "score_interpretation": "expected_research_value_only_not_alpha_confidence",
+      "source_recipe_id": "piotroski_value_style_v0",
+      "target_universe_ids": [
+        "global_developed_liquid"
+      ]
+    },
+    {
+      "allowed_use": [
+        "research_prior"
+      ],
+      "behavior_family": "defensive_quality_drawdown_resilience",
+      "blocked_reason_codes": [
+        "BLOCKED_DATA_READINESS_MISSING",
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "created_from_artifacts": [
+        "artifacts/universe/equity_universe_catalog_latest.v1.json",
+        "artifacts/universe/equity_universe_quality_latest.v1.json",
+        "artifacts/identity/instrument_identity_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_catalog_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_calculation_contracts_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_recipes_latest.v1.json",
+        "artifacts/data_readiness/fundamental_readiness_latest.v1.json"
+      ],
+      "deterministic_hash": "0eda187b9a7371ca5c58733fa013961d2818ec12f74fcebcb4be6f0d63f6919d",
+      "expected_research_value_score": 0.49,
+      "factor_ids": [
+        "return_on_assets",
+        "gross_profitability",
+        "dividend_yield"
+      ],
+      "feasibility_status": "BLOCKED",
+      "forbidden_use": [
+        "strategy_signal",
+        "trade_signal",
+        "buy_list",
+        "sell_list",
+        "candidate_promotion",
+        "paper",
+        "shadow",
+        "live",
+        "capital_allocation",
+        "broker_execution"
+      ],
+      "hypothesis_seed_id": "equity_factor_seed::switzerland_defensive_quality_v0",
+      "hypothesis_statement": "Research-only hypothesis seed from switzerland_defensive_quality_v0 testing defensive_quality_drawdown_resilience across switzerland_equities using factors: return_on_assets, gross_profitability, dividend_yield. This is not a trade signal or strategy candidate.",
+      "required_next_action": "add_source_manifest",
+      "score_components": {
+        "blocked_penalty": -0.3,
+        "data_readiness_component": 0.0,
+        "expected_information_gain_placeholder": 0.1,
+        "factor_catalog_component": 0.2,
+        "identity_readiness_component": 0.18,
+        "recipe_structure_component": 0.15,
+        "universe_readiness_component": 0.22
+      },
+      "score_interpretation": "expected_research_value_only_not_alpha_confidence",
+      "source_recipe_id": "switzerland_defensive_quality_v0",
+      "target_universe_ids": [
+        "switzerland_equities"
+      ]
+    },
+    {
+      "allowed_use": [
+        "research_prior"
+      ],
+      "behavior_family": "quality_value_momentum_persistence",
+      "blocked_reason_codes": [
+        "BLOCKED_DATA_READINESS_MISSING",
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "created_from_artifacts": [
+        "artifacts/universe/equity_universe_catalog_latest.v1.json",
+        "artifacts/universe/equity_universe_quality_latest.v1.json",
+        "artifacts/identity/instrument_identity_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_catalog_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_calculation_contracts_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_recipes_latest.v1.json",
+        "artifacts/data_readiness/fundamental_readiness_latest.v1.json"
+      ],
+      "deterministic_hash": "c0d17fd906e8d79a2d0606542d7cf729f0f49dbe778289e848a92ec8603fd8d4",
+      "expected_research_value_score": 0.49,
+      "factor_ids": [
+        "roic",
+        "gross_profitability",
+        "twelve_month_momentum"
+      ],
+      "feasibility_status": "BLOCKED",
+      "forbidden_use": [
+        "strategy_signal",
+        "trade_signal",
+        "buy_list",
+        "sell_list",
+        "candidate_promotion",
+        "paper",
+        "shadow",
+        "live",
+        "capital_allocation",
+        "broker_execution"
+      ],
+      "hypothesis_seed_id": "equity_factor_seed::us_quality_momentum_large_mid_v0",
+      "hypothesis_statement": "Research-only hypothesis seed from us_quality_momentum_large_mid_v0 testing quality_value_momentum_persistence across us_large_mid, us_quality_liquid using factors: roic, gross_profitability, twelve_month_momentum. This is not a trade signal or strategy candidate.",
+      "required_next_action": "add_source_manifest",
+      "score_components": {
+        "blocked_penalty": -0.3,
+        "data_readiness_component": 0.0,
+        "expected_information_gain_placeholder": 0.1,
+        "factor_catalog_component": 0.2,
+        "identity_readiness_component": 0.18,
+        "recipe_structure_component": 0.15,
+        "universe_readiness_component": 0.22
+      },
+      "score_interpretation": "expected_research_value_only_not_alpha_confidence",
+      "source_recipe_id": "us_quality_momentum_large_mid_v0",
+      "target_universe_ids": [
+        "us_large_mid",
+        "us_quality_liquid"
+      ]
+    },
+    {
+      "allowed_use": [
+        "research_prior"
+      ],
+      "behavior_family": "shareholder_yield_quality_persistence",
+      "blocked_reason_codes": [
+        "BLOCKED_DATA_READINESS_MISSING",
+        "MISSING_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "MISSING_REQUIRED_FIELD",
+        "MISSING_RESTATEMENT_POLICY",
+        "MISSING_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "created_from_artifacts": [
+        "artifacts/universe/equity_universe_catalog_latest.v1.json",
+        "artifacts/universe/equity_universe_quality_latest.v1.json",
+        "artifacts/identity/instrument_identity_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_catalog_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_calculation_contracts_latest.v1.json",
+        "artifacts/equity_factors/equity_factor_recipes_latest.v1.json",
+        "artifacts/data_readiness/fundamental_readiness_latest.v1.json"
+      ],
+      "deterministic_hash": "e1780cad4432a537030ba6748fb808935a10df4ad36399c5377f0ce88d430d13",
+      "expected_research_value_score": 0.49,
+      "factor_ids": [
+        "shareholder_yield",
+        "return_on_assets",
+        "gross_profitability"
+      ],
+      "feasibility_status": "BLOCKED",
+      "forbidden_use": [
+        "strategy_signal",
+        "trade_signal",
+        "buy_list",
+        "sell_list",
+        "candidate_promotion",
+        "paper",
+        "shadow",
+        "live",
+        "capital_allocation",
+        "broker_execution"
+      ],
+      "hypothesis_seed_id": "equity_factor_seed::us_shareholder_yield_quality_v0",
+      "hypothesis_statement": "Research-only hypothesis seed from us_shareholder_yield_quality_v0 testing shareholder_yield_quality_persistence across us_large_mid, us_quality_liquid using factors: shareholder_yield, return_on_assets, gross_profitability. This is not a trade signal or strategy candidate.",
+      "required_next_action": "add_source_manifest",
+      "score_components": {
+        "blocked_penalty": -0.3,
+        "data_readiness_component": 0.0,
+        "expected_information_gain_placeholder": 0.1,
+        "factor_catalog_component": 0.2,
+        "identity_readiness_component": 0.18,
+        "recipe_structure_component": 0.15,
+        "universe_readiness_component": 0.22
+      },
+      "score_interpretation": "expected_research_value_only_not_alpha_confidence",
+      "source_recipe_id": "us_shareholder_yield_quality_v0",
+      "target_universe_ids": [
+        "us_large_mid",
+        "us_quality_liquid"
+      ]
+    }
+  ],
+  "safety_invariants": {
+    "broker_risk_execution_forbidden": true,
+    "mutates_frozen_contracts": false,
+    "mutates_registry": false,
+    "not_trade_signal": true,
+    "paper_shadow_live_forbidden": true,
+    "research_only": true
+  },
+  "schema_version": "1.0",
+  "summary": {
+    "blocked_seed_count": 15,
+    "feasible_seed_count": 0,
+    "hypothesis_seed_count": 15,
+    "operator_summary": "Equity-factor hypothesis seeds are read-only research priors. Blocked seeds remain visible for operator review and do not promote to candidates or strategies.",
+    "top_blocked_reasons": {
+      "BLOCKED_DATA_READINESS_MISSING": 15,
+      "BLOCKED_IDENTITY_AMBIGUITY": 11,
+      "MISSING_CURRENCY_NORMALIZATION": 3,
+      "MISSING_POINT_IN_TIME_POLICY": 15,
+      "MISSING_REPORT_LAG_POLICY": 15,
+      "MISSING_REQUIRED_FIELD": 15,
+      "MISSING_RESTATEMENT_POLICY": 15,
+      "MISSING_SOURCE_MANIFEST": 15,
+      "SOURCE_LICENSE_UNKNOWN": 15,
+      "SOURCE_QUALITY_UNKNOWN": 15,
+      "UNIVERSE_IDENTITY_NOT_READY": 11
+    }
+  }
+}

--- a/research/hypothesis_discovery/equity_factor_hypothesis_adapter.py
+++ b/research/hypothesis_discovery/equity_factor_hypothesis_adapter.py
@@ -1,0 +1,288 @@
+"""Read-only bridge from equity-factor recipes to hypothesis seed records."""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from hashlib import sha256
+from typing import Final
+
+from research.data_readiness.fundamental_readiness import build_fundamental_readiness
+from research.equity_factors.factor_catalog import build_equity_factor_catalog
+from research.equity_factor_manifest import CATALOG_NAME as FACTOR_CATALOG_NAME
+from research.equity_factor_manifest import CONTRACTS_NAME as FACTOR_CONTRACTS_NAME
+from research.equity_factors.recipe_catalog import build_equity_factor_recipe_catalog
+from research.equity_factors.recipe_manifest import RECIPES_NAME as RECIPE_NAME
+from research.equity_universe_catalog import build_equity_universe_catalog
+from research.equity_universe_manifest import CATALOG_NAME as UNIVERSE_CATALOG_NAME
+from research.equity_universe_manifest import IDENTITY_NAME as IDENTITY_ARTIFACT_NAME
+from research.equity_universe_quality import build_equity_universe_quality
+
+
+SCHEMA_VERSION: Final[str] = "1.0"
+REPORT_KIND: Final[str] = "equity_factor_hypothesis_seeds"
+ALLOWED_USE: Final[tuple[str, ...]] = ("research_prior",)
+FORBIDDEN_USE: Final[tuple[str, ...]] = (
+    "strategy_signal",
+    "trade_signal",
+    "buy_list",
+    "sell_list",
+    "candidate_promotion",
+    "paper",
+    "shadow",
+    "live",
+    "capital_allocation",
+    "broker_execution",
+)
+FEASIBILITY_VOCABULARY: Final[tuple[str, ...]] = ("FEASIBLE", "BLOCKED")
+DATA_READINESS_ARTIFACT_PATH: Final[str] = (
+    "artifacts/data_readiness/fundamental_readiness_latest.v1.json"
+)
+UNIVERSE_CATALOG_ARTIFACT_PATH: Final[str] = f"artifacts/universe/{UNIVERSE_CATALOG_NAME}"
+UNIVERSE_QUALITY_ARTIFACT_PATH: Final[str] = "artifacts/universe/equity_universe_quality_latest.v1.json"
+IDENTITY_ARTIFACT_PATH: Final[str] = f"artifacts/identity/{IDENTITY_ARTIFACT_NAME}"
+FACTOR_CATALOG_ARTIFACT_PATH: Final[str] = f"artifacts/equity_factors/{FACTOR_CATALOG_NAME}"
+CALCULATION_CONTRACT_ARTIFACT_PATH: Final[str] = (
+    f"artifacts/equity_factors/{FACTOR_CONTRACTS_NAME}"
+)
+RECIPE_ARTIFACT_PATH: Final[str] = f"artifacts/equity_factors/{RECIPE_NAME}"
+BLOCKED_SCORE_CAP: Final[float] = 0.49
+
+
+def _behavior_family(recipe_id: str) -> str:
+    recipe_id = recipe_id.lower()
+    if "shareholder_yield" in recipe_id:
+        return "shareholder_yield_quality_persistence"
+    if "deep_value" in recipe_id or "financial_health" in recipe_id:
+        return "financial_health_reversal"
+    if "low_accrual" in recipe_id:
+        return "low_accrual_quality_screening"
+    if "magic_formula" in recipe_id:
+        return "quality_value_efficiency"
+    if "piotroski" in recipe_id:
+        return "financial_health_value_recovery"
+    if "defensive" in recipe_id:
+        return "defensive_quality_drawdown_resilience"
+    if "quality" in recipe_id and "momentum" in recipe_id:
+        return "quality_value_momentum_persistence"
+    if "quality" in recipe_id and "value" in recipe_id:
+        return "quality_value_screening"
+    return "equity_factor_screening"
+
+
+def _hypothesis_statement(recipe: dict[str, object], behavior_family: str) -> str:
+    universes = ", ".join(str(item) for item in recipe["target_universe_ids"])
+    factors = ", ".join(str(item) for item in recipe["required_factor_ids"])
+    return (
+        f"Research-only hypothesis seed from {recipe['recipe_id']} testing "
+        f"{behavior_family} across {universes} using factors: {factors}. "
+        "This is not a trade signal or strategy candidate."
+    )
+
+
+def _deterministic_hash(row: dict[str, object]) -> str:
+    payload = "|".join(
+        [
+            str(row["hypothesis_seed_id"]),
+            str(row["source_recipe_id"]),
+            ",".join(str(item) for item in row["target_universe_ids"]),
+            ",".join(str(item) for item in row["factor_ids"]),
+            str(row["behavior_family"]),
+            str(row["feasibility_status"]),
+        ]
+    )
+    return sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _score_components(
+    *,
+    recipe_known: bool,
+    universes_known: bool,
+    factors_known: bool,
+    universe_quality_fail: bool,
+    identity_ambiguity: bool,
+    data_ready: bool,
+) -> dict[str, float]:
+    components = {
+        "universe_readiness_component": 0.22 if universes_known and not universe_quality_fail else 0.0,
+        "identity_readiness_component": 0.18 if not identity_ambiguity else 0.0,
+        "factor_catalog_component": 0.20 if factors_known else 0.0,
+        "recipe_structure_component": 0.15 if recipe_known else 0.0,
+        "data_readiness_component": 0.15 if data_ready else 0.0,
+        "expected_information_gain_placeholder": 0.10 if recipe_known and factors_known else 0.0,
+        "blocked_penalty": 0.0 if data_ready and not identity_ambiguity and not universe_quality_fail else -0.30,
+    }
+    return components
+
+
+def _expected_research_value_score(
+    components: dict[str, float],
+    *,
+    feasibility_status: str,
+) -> float:
+    total = sum(components.values())
+    bounded = max(0.0, min(1.0, total))
+    if feasibility_status == "BLOCKED":
+        bounded = min(bounded, BLOCKED_SCORE_CAP)
+    return round(bounded, 3)
+
+
+def build_equity_factor_hypothesis_seeds() -> dict[str, object]:
+    recipe_catalog = build_equity_factor_recipe_catalog()
+    factor_catalog = build_equity_factor_catalog()
+    universe_catalog = build_equity_universe_catalog()
+    universe_quality = build_equity_universe_quality()
+    fundamental_readiness = build_fundamental_readiness()
+
+    factor_ids = {str(row["factor_id"]) for row in factor_catalog.get("rows", [])}
+    readiness_by_factor = {
+        str(row["factor_id"]): row for row in fundamental_readiness.get("factor_rows", [])
+    }
+    factor_ids.update(readiness_by_factor.keys())
+    readiness_by_recipe = {
+        str(row["recipe_id"]): row for row in fundamental_readiness.get("recipe_rows", [])
+    }
+
+    universe_members: dict[str, list[str]] = defaultdict(list)
+    for instrument in universe_catalog.get("instruments", []):
+        canonical_id = str(instrument["canonical_id"])
+        for universe_id in instrument["universe_ids"]:
+            universe_members[str(universe_id)].append(canonical_id)
+
+    quality_by_canonical = {
+        str(row["canonical_id"]): row for row in universe_quality.get("rows", [])
+    }
+
+    rows: list[dict[str, object]] = []
+    for recipe in recipe_catalog.get("rows", []):
+        recipe_id = str(recipe["recipe_id"])
+        target_universe_ids = [str(item) for item in recipe["target_universe_ids"]]
+        required_factor_ids = [str(item) for item in recipe["required_factor_ids"]]
+        optional_factor_ids = [str(item) for item in recipe["optional_factor_ids"]]
+        missing_universes = sorted(
+            universe_id for universe_id in target_universe_ids if universe_id not in universe_members
+        )
+        missing_factors = sorted(
+            factor_id
+            for factor_id in required_factor_ids + optional_factor_ids
+            if factor_id not in factor_ids
+        )
+
+        target_quality_rows = [
+            quality_by_canonical[canonical_id]
+            for universe_id in target_universe_ids
+            for canonical_id in universe_members.get(universe_id, [])
+            if canonical_id in quality_by_canonical
+        ]
+        universe_quality_fail = any(
+            str(row["universe_readiness_status"]) == "FAIL" for row in target_quality_rows
+        )
+        identity_ambiguity = any(
+            bool(row["ambiguous_mapping_warning"]) or not bool(row["eligible_for_hypothesis_seed"])
+            for row in target_quality_rows
+        )
+
+        readiness_row = readiness_by_recipe.get(recipe_id, {})
+        data_ready = str(readiness_row.get("readiness_status", "UNKNOWN")) == "READY"
+        blocked_reason_codes: list[str] = []
+        if missing_universes:
+            blocked_reason_codes.append("BLOCKED_MISSING_UNIVERSE")
+        if missing_factors:
+            blocked_reason_codes.append("BLOCKED_MISSING_FACTOR")
+        if universe_quality_fail:
+            blocked_reason_codes.append("BLOCKED_UNIVERSE_QUALITY_FAIL")
+        if identity_ambiguity:
+            blocked_reason_codes.append("BLOCKED_IDENTITY_AMBIGUITY")
+        if not data_ready:
+            blocked_reason_codes.append("BLOCKED_DATA_READINESS_MISSING")
+            for reason in readiness_row.get("readiness_block_reasons", []):
+                text = str(reason)
+                if text and text not in blocked_reason_codes:
+                    blocked_reason_codes.append(text)
+        if not blocked_reason_codes and str(recipe.get("feasibility_status")) != "FEASIBLE":
+            for reason in recipe.get("blocked_reason_codes", []):
+                text = str(reason)
+                if text and text not in blocked_reason_codes:
+                    blocked_reason_codes.append(text)
+        feasibility_status = "FEASIBLE" if not blocked_reason_codes else "BLOCKED"
+
+        behavior_family = _behavior_family(recipe_id)
+        components = _score_components(
+            recipe_known=True,
+            universes_known=not missing_universes,
+            factors_known=not missing_factors,
+            universe_quality_fail=universe_quality_fail,
+            identity_ambiguity=identity_ambiguity,
+            data_ready=data_ready,
+        )
+        required_next_action = (
+            "add_source_manifest"
+            if "MISSING_SOURCE_MANIFEST" in blocked_reason_codes
+            else "resolve_identity_ambiguity"
+            if "BLOCKED_IDENTITY_AMBIGUITY" in blocked_reason_codes
+            else "fix_recipe_references"
+            if {"BLOCKED_MISSING_UNIVERSE", "BLOCKED_MISSING_FACTOR"} & set(blocked_reason_codes)
+            else "operator_review"
+            if blocked_reason_codes
+            else "eligible_for_readonly_hypothesis_intake"
+        )
+        row = {
+            "hypothesis_seed_id": f"equity_factor_seed::{recipe_id}",
+            "source_recipe_id": recipe_id,
+            "target_universe_ids": target_universe_ids,
+            "factor_ids": required_factor_ids,
+            "behavior_family": behavior_family,
+            "hypothesis_statement": _hypothesis_statement(recipe, behavior_family),
+            "expected_research_value_score": _expected_research_value_score(
+                components,
+                feasibility_status=feasibility_status,
+            ),
+            "score_components": components,
+            "score_interpretation": (
+                "expected_research_value_only_not_alpha_confidence"
+            ),
+            "feasibility_status": feasibility_status,
+            "blocked_reason_codes": blocked_reason_codes,
+            "required_next_action": required_next_action,
+            "allowed_use": list(ALLOWED_USE),
+            "forbidden_use": list(FORBIDDEN_USE),
+            "created_from_artifacts": [
+                UNIVERSE_CATALOG_ARTIFACT_PATH,
+                UNIVERSE_QUALITY_ARTIFACT_PATH,
+                IDENTITY_ARTIFACT_PATH,
+                FACTOR_CATALOG_ARTIFACT_PATH,
+                CALCULATION_CONTRACT_ARTIFACT_PATH,
+                RECIPE_ARTIFACT_PATH,
+                DATA_READINESS_ARTIFACT_PATH,
+            ],
+        }
+        row["deterministic_hash"] = _deterministic_hash(row)
+        rows.append(row)
+
+    rows.sort(key=lambda row: str(row["hypothesis_seed_id"]))
+    blocked_reason_counts = Counter(
+        reason for row in rows for reason in row["blocked_reason_codes"]
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "feasibility_status_vocabulary": list(FEASIBILITY_VOCABULARY),
+        "summary": {
+            "hypothesis_seed_count": len(rows),
+            "feasible_seed_count": sum(row["feasibility_status"] == "FEASIBLE" for row in rows),
+            "blocked_seed_count": sum(row["feasibility_status"] == "BLOCKED" for row in rows),
+            "top_blocked_reasons": dict(sorted(blocked_reason_counts.items())),
+            "operator_summary": (
+                "Equity-factor hypothesis seeds are read-only research priors. "
+                "Blocked seeds remain visible for operator review and do not promote to candidates or strategies."
+            ),
+        },
+        "rows": rows,
+        "safety_invariants": {
+            "research_only": True,
+            "not_trade_signal": True,
+            "mutates_registry": False,
+            "mutates_frozen_contracts": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+        },
+    }

--- a/research/hypothesis_discovery/equity_factor_seed_manifest.py
+++ b/research/hypothesis_discovery/equity_factor_seed_manifest.py
@@ -1,0 +1,56 @@
+"""Artifact writer for read-only equity-factor hypothesis seeds."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Final
+
+from research.hypothesis_discovery.equity_factor_hypothesis_adapter import (
+    build_equity_factor_hypothesis_seeds,
+)
+
+
+OUTPUT_DIR: Final[Path] = Path("artifacts/hypothesis_discovery")
+LATEST_NAME: Final[str] = "equity_factor_hypothesis_seeds_latest.v1.json"
+ARTIFACT_PATH: Final[str] = (OUTPUT_DIR / LATEST_NAME).as_posix()
+
+
+def _validate_write_target(path: Path) -> None:
+    if "artifacts/hypothesis_discovery/" not in path.as_posix():
+        raise ValueError(f"equity_factor_seed_manifest: refusing write outside allowlist: {path!r}")
+
+
+def write_outputs(
+    report: dict[str, object],
+    *,
+    repo_root: Path = Path("."),
+) -> dict[str, str]:
+    output_dir = repo_root / OUTPUT_DIR
+    output_dir.mkdir(parents=True, exist_ok=True)
+    latest = output_dir / LATEST_NAME
+    _validate_write_target(latest)
+    tmp_latest = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_latest.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp_latest, latest)
+    return {"latest": latest.relative_to(repo_root).as_posix()}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.hypothesis_discovery.equity_factor_seed_manifest",
+        description="Write read-only equity-factor hypothesis seed artifacts.",
+    )
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    report = build_equity_factor_hypothesis_seeds()
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/unit/test_equity_factor_hypothesis_adapter.py
+++ b/tests/unit/test_equity_factor_hypothesis_adapter.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import json
+
+from research.hypothesis_discovery import equity_factor_hypothesis_adapter as adapter
+
+
+def _base_recipe_row() -> dict[str, object]:
+    return {
+        "recipe_id": "test_recipe",
+        "target_universe_ids": ["test_universe"],
+        "required_factor_ids": ["roic"],
+        "optional_factor_ids": [],
+        "feasibility_status": "FEASIBLE",
+        "blocked_reason_codes": [],
+    }
+
+
+def _fake_catalog() -> dict[str, object]:
+    return {
+        "instruments": [
+            {
+                "canonical_id": "eq_test",
+                "symbol": "TEST",
+                "universe_ids": ["test_universe"],
+            }
+        ]
+    }
+
+
+def _fake_quality(*, ambiguous: bool = False, fail: bool = False) -> dict[str, object]:
+    return {
+        "rows": [
+            {
+                "canonical_id": "eq_test",
+                "ambiguous_mapping_warning": ambiguous,
+                "eligible_for_hypothesis_seed": not ambiguous and not fail,
+                "universe_readiness_status": "FAIL" if fail else "WARN" if ambiguous else "OK",
+            }
+        ]
+    }
+
+
+def _fake_readiness(*, ready: bool = True) -> dict[str, object]:
+    return {
+        "factor_rows": [{"factor_id": "roic"}],
+        "recipe_rows": [
+            {
+                "recipe_id": "test_recipe",
+                "readiness_status": "READY" if ready else "NOT_READY",
+                "readiness_block_reasons": [] if ready else ["MISSING_SOURCE_MANIFEST"],
+            }
+        ],
+    }
+
+
+def test_build_equity_factor_hypothesis_seeds_is_deterministic(monkeypatch) -> None:
+    monkeypatch.setattr(
+        adapter,
+        "build_equity_factor_recipe_catalog",
+        lambda: {"rows": [_base_recipe_row()]},
+    )
+    monkeypatch.setattr(adapter, "build_equity_universe_catalog", _fake_catalog)
+    monkeypatch.setattr(adapter, "build_equity_universe_quality", lambda: _fake_quality())
+    monkeypatch.setattr(adapter, "build_fundamental_readiness", lambda: _fake_readiness())
+
+    first = adapter.build_equity_factor_hypothesis_seeds()
+    second = adapter.build_equity_factor_hypothesis_seeds()
+
+    assert json.dumps(first, sort_keys=True) == json.dumps(second, sort_keys=True)
+    row = first["rows"][0]
+    assert row["feasibility_status"] == "FEASIBLE"
+    assert row["allowed_use"] == ["research_prior"]
+
+
+def test_build_equity_factor_hypothesis_seeds_blocks_missing_data_readiness(monkeypatch) -> None:
+    monkeypatch.setattr(
+        adapter,
+        "build_equity_factor_recipe_catalog",
+        lambda: {"rows": [_base_recipe_row()]},
+    )
+    monkeypatch.setattr(adapter, "build_equity_universe_catalog", _fake_catalog)
+    monkeypatch.setattr(adapter, "build_equity_universe_quality", lambda: _fake_quality())
+    monkeypatch.setattr(adapter, "build_fundamental_readiness", lambda: _fake_readiness(ready=False))
+
+    row = adapter.build_equity_factor_hypothesis_seeds()["rows"][0]
+
+    assert row["feasibility_status"] == "BLOCKED"
+    assert "BLOCKED_DATA_READINESS_MISSING" in row["blocked_reason_codes"]
+    assert "MISSING_SOURCE_MANIFEST" in row["blocked_reason_codes"]
+    assert row["expected_research_value_score"] <= 0.49
+
+
+def test_build_equity_factor_hypothesis_seeds_blocks_missing_factor_or_universe(monkeypatch) -> None:
+    monkeypatch.setattr(
+        adapter,
+        "build_equity_factor_recipe_catalog",
+        lambda: {
+            "rows": [
+                {
+                    **_base_recipe_row(),
+                    "target_universe_ids": ["missing_universe"],
+                    "required_factor_ids": ["missing_factor"],
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(adapter, "build_equity_universe_catalog", _fake_catalog)
+    monkeypatch.setattr(adapter, "build_equity_universe_quality", lambda: _fake_quality())
+    monkeypatch.setattr(adapter, "build_fundamental_readiness", lambda: {"factor_rows": [], "recipe_rows": []})
+
+    row = adapter.build_equity_factor_hypothesis_seeds()["rows"][0]
+
+    assert "BLOCKED_MISSING_UNIVERSE" in row["blocked_reason_codes"]
+    assert "BLOCKED_MISSING_FACTOR" in row["blocked_reason_codes"]
+
+
+def test_build_equity_factor_hypothesis_seeds_blocks_identity_ambiguity(monkeypatch) -> None:
+    monkeypatch.setattr(
+        adapter,
+        "build_equity_factor_recipe_catalog",
+        lambda: {"rows": [_base_recipe_row()]},
+    )
+    monkeypatch.setattr(adapter, "build_equity_universe_catalog", _fake_catalog)
+    monkeypatch.setattr(adapter, "build_equity_universe_quality", lambda: _fake_quality(ambiguous=True))
+    monkeypatch.setattr(adapter, "build_fundamental_readiness", lambda: _fake_readiness())
+
+    row = adapter.build_equity_factor_hypothesis_seeds()["rows"][0]
+
+    assert row["feasibility_status"] == "BLOCKED"
+    assert "BLOCKED_IDENTITY_AMBIGUITY" in row["blocked_reason_codes"]
+    assert row["required_next_action"] == "resolve_identity_ambiguity"
+
+
+def test_build_equity_factor_hypothesis_seeds_blocks_universe_quality_fail(monkeypatch) -> None:
+    monkeypatch.setattr(
+        adapter,
+        "build_equity_factor_recipe_catalog",
+        lambda: {"rows": [_base_recipe_row()]},
+    )
+    monkeypatch.setattr(adapter, "build_equity_universe_catalog", _fake_catalog)
+    monkeypatch.setattr(adapter, "build_equity_universe_quality", lambda: _fake_quality(fail=True))
+    monkeypatch.setattr(adapter, "build_fundamental_readiness", lambda: _fake_readiness())
+
+    row = adapter.build_equity_factor_hypothesis_seeds()["rows"][0]
+
+    assert row["feasibility_status"] == "BLOCKED"
+    assert "BLOCKED_UNIVERSE_QUALITY_FAIL" in row["blocked_reason_codes"]
+    assert "strategy_signal" in row["forbidden_use"]

--- a/tests/unit/test_equity_factor_seed_manifest.py
+++ b/tests/unit/test_equity_factor_seed_manifest.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from research.hypothesis_discovery import equity_factor_seed_manifest as manifest
+
+
+def test_write_outputs_materializes_hypothesis_seed_artifact(tmp_path: Path) -> None:
+    report = {
+        "schema_version": "1.0",
+        "report_kind": "equity_factor_hypothesis_seeds",
+        "rows": [],
+    }
+
+    paths = manifest.write_outputs(report, repo_root=tmp_path)
+
+    assert paths["latest"] == "artifacts/hypothesis_discovery/equity_factor_hypothesis_seeds_latest.v1.json"
+    payload = json.loads((tmp_path / paths["latest"]).read_text(encoding="utf-8"))
+    assert payload["report_kind"] == "equity_factor_hypothesis_seeds"
+
+
+def test_write_outputs_refuses_outside_allowlist(tmp_path: Path) -> None:
+    bad = tmp_path / "logs" / "bad.json"
+    try:
+        manifest._validate_write_target(bad)
+    except ValueError as exc:
+        assert "outside allowlist" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("expected ValueError")


### PR DESCRIPTION
## Summary
- add a read-only equity-factor hypothesis seed adapter over the existing recipe, universe-quality, identity, and fundamental-readiness surfaces
- materialize deterministic blocked-or-feasible seed records into a sidecar artifact for operator visibility
- keep hypothesis seeds explicitly research-only with forbidden trade/promotion/paper/shadow/live uses

## Why
PR #482 added recipe definitions and PR #484 added fail-closed data readiness. QRE still needed a bounded bridge that turns those inputs into inspectable hypothesis-intake records without becoming strategy synthesis or candidate promotion.

## What changed
- added `research/hypothesis_discovery/equity_factor_hypothesis_adapter.py`
- added `research/hypothesis_discovery/equity_factor_seed_manifest.py`
- added unit tests for deterministic seed IDs, blocked readiness, missing universe/factor refs, identity ambiguity, and universe quality fail
- generated `artifacts/hypothesis_discovery/equity_factor_hypothesis_seeds_latest.v1.json`

## Safety constraints honored
- research-only and sidecar-artifact only
- no `registry.py` changes
- no `research/run_research.py` changes
- no frozen contract changes
- no live/paper/shadow/risk/broker/execution changes
- no buy/sell recommendations or trade signals
- no strategy registration or candidate promotion

## Tests run
- `python -m pytest tests/unit/test_equity_factor_hypothesis_adapter.py -q`
- `python -m pytest tests/unit/test_equity_factor_seed_manifest.py -q`
- `python -m pytest tests/unit/test_equity_factor_recipe_manifest.py -q`
- `python -m pytest tests/unit/test_fundamental_readiness.py -q`
- `python -m pytest tests/unit/test_equity_universe_quality.py -q`
- `python -m pytest tests/architecture -q`
- `python -m pytest tests -q -k "governance or no_touch or frozen_contract or execution_authority"`
- `python -m research.hypothesis_discovery.equity_factor_seed_manifest --write`
- `git diff --check`
- `git diff -- research/research_latest.json research/strategy_matrix.csv`

## Current expected outcome
- hypothesis seeds are now materialized as deterministic research priors
- current seeds remain blocked by missing source manifests / fundamental readiness and, for some universes, identity ambiguity
- no seed is promoted to candidate or executable strategy

## Known limitations
- current `feasible_seed_count` is expected to remain `0` until source manifests, point-in-time policy, field coverage, and identity readiness are improved
- expected research value score is an explainable research-intake score only, not alpha confidence

## Next recommended action
PR #486 controlled factor evaluation scaffold
