### PR TITLE
fix: add controlled factor evaluation scaffold

### DIFF
--- a/artifacts/equity_factors/controlled_factor_evaluation_readiness_latest.v1.json
+++ b/artifacts/equity_factors/controlled_factor_evaluation_readiness_latest.v1.json
@@ -1,0 +1,848 @@
+{
+  "readiness_status_vocabulary": [
+    "READY_FOR_CONTROLLED_EVAL",
+    "NOT_READY",
+    "BLOCKED"
+  ],
+  "report_kind": "controlled_factor_evaluation_readiness",
+  "rows": [
+    {
+      "allowed_next_action": "add_source_manifest",
+      "blocked_reason_codes": [
+        "BLOCKED_DATA_READINESS",
+        "BLOCKED_CURRENCY_NORMALIZATION",
+        "BLOCKED_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "BLOCKED_FIELD_COVERAGE",
+        "MISSING_RESTATEMENT_POLICY",
+        "BLOCKED_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "evaluation_id": "controlled_factor_eval::equity_factor_seed::asia_developed_quality_value_v0",
+      "factor_ids": [
+        "roic",
+        "gross_profitability",
+        "book_to_market",
+        "earnings_yield"
+      ],
+      "forbidden_actions": [
+        "trade",
+        "buy_list",
+        "sell_list",
+        "strategy_registration",
+        "candidate_promotion",
+        "paper",
+        "shadow",
+        "live",
+        "capital_allocation"
+      ],
+      "operator_explanation": "Controlled factor evaluation remains blocked until source manifests, field coverage, point-in-time policy, OOS policy, cost model, and null model are all explicitly present.",
+      "readiness_status": "BLOCKED",
+      "required_cost_model": true,
+      "required_currency_normalization": true,
+      "required_data_fields": [
+        "book_value_equity",
+        "gross_profit_ttm",
+        "invested_capital",
+        "market_cap",
+        "net_income_ttm",
+        "nopat_ttm",
+        "total_assets"
+      ],
+      "required_null_model": true,
+      "required_oos_policy": true,
+      "required_point_in_time_policy": true,
+      "required_source_manifests": [
+        "fundamental_source_manifest_v1"
+      ],
+      "source_hypothesis_seed_id": "equity_factor_seed::asia_developed_quality_value_v0",
+      "source_recipe_id": "asia_developed_quality_value_v0",
+      "target_universe_ids": [
+        "asia_developed_liquid"
+      ]
+    },
+    {
+      "allowed_next_action": "add_source_manifest",
+      "blocked_reason_codes": [
+        "BLOCKED_IDENTITY_AMBIGUITY",
+        "BLOCKED_DATA_READINESS",
+        "BLOCKED_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "BLOCKED_FIELD_COVERAGE",
+        "MISSING_RESTATEMENT_POLICY",
+        "BLOCKED_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "evaluation_id": "controlled_factor_eval::equity_factor_seed::defensive_quality_momentum_v0",
+      "factor_ids": [
+        "return_on_assets",
+        "gross_profitability",
+        "twelve_month_momentum"
+      ],
+      "forbidden_actions": [
+        "trade",
+        "buy_list",
+        "sell_list",
+        "strategy_registration",
+        "candidate_promotion",
+        "paper",
+        "shadow",
+        "live",
+        "capital_allocation"
+      ],
+      "operator_explanation": "Controlled factor evaluation remains blocked until source manifests, field coverage, point-in-time policy, OOS policy, cost model, and null model are all explicitly present.",
+      "readiness_status": "BLOCKED",
+      "required_cost_model": true,
+      "required_currency_normalization": false,
+      "required_data_fields": [
+        "gross_profit_ttm",
+        "net_income_ttm",
+        "price_history_12m",
+        "total_assets"
+      ],
+      "required_null_model": true,
+      "required_oos_policy": true,
+      "required_point_in_time_policy": true,
+      "required_source_manifests": [
+        "fundamental_source_manifest_v1"
+      ],
+      "source_hypothesis_seed_id": "equity_factor_seed::defensive_quality_momentum_v0",
+      "source_recipe_id": "defensive_quality_momentum_v0",
+      "target_universe_ids": [
+        "global_developed_liquid"
+      ]
+    },
+    {
+      "allowed_next_action": "add_source_manifest",
+      "blocked_reason_codes": [
+        "BLOCKED_IDENTITY_AMBIGUITY",
+        "BLOCKED_DATA_READINESS",
+        "BLOCKED_CURRENCY_NORMALIZATION",
+        "BLOCKED_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "BLOCKED_FIELD_COVERAGE",
+        "MISSING_RESTATEMENT_POLICY",
+        "BLOCKED_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "evaluation_id": "controlled_factor_eval::equity_factor_seed::eu_quality_value_momentum_v0",
+      "factor_ids": [
+        "roic",
+        "earnings_yield",
+        "twelve_month_momentum"
+      ],
+      "forbidden_actions": [
+        "trade",
+        "buy_list",
+        "sell_list",
+        "strategy_registration",
+        "candidate_promotion",
+        "paper",
+        "shadow",
+        "live",
+        "capital_allocation"
+      ],
+      "operator_explanation": "Controlled factor evaluation remains blocked until source manifests, field coverage, point-in-time policy, OOS policy, cost model, and null model are all explicitly present.",
+      "readiness_status": "BLOCKED",
+      "required_cost_model": true,
+      "required_currency_normalization": true,
+      "required_data_fields": [
+        "invested_capital",
+        "market_cap",
+        "net_income_ttm",
+        "nopat_ttm",
+        "price_history_12m"
+      ],
+      "required_null_model": true,
+      "required_oos_policy": true,
+      "required_point_in_time_policy": true,
+      "required_source_manifests": [
+        "fundamental_source_manifest_v1"
+      ],
+      "source_hypothesis_seed_id": "equity_factor_seed::eu_quality_value_momentum_v0",
+      "source_recipe_id": "eu_quality_value_momentum_v0",
+      "target_universe_ids": [
+        "europe_large_mid"
+      ]
+    },
+    {
+      "allowed_next_action": "add_source_manifest",
+      "blocked_reason_codes": [
+        "BLOCKED_IDENTITY_AMBIGUITY",
+        "BLOCKED_DATA_READINESS",
+        "BLOCKED_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "BLOCKED_FIELD_COVERAGE",
+        "MISSING_RESTATEMENT_POLICY",
+        "BLOCKED_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "evaluation_id": "controlled_factor_eval::equity_factor_seed::europe_deep_value_financial_health_v0",
+      "factor_ids": [
+        "book_to_market",
+        "price_to_sales",
+        "piotroski_f_score",
+        "altman_z_score"
+      ],
+      "forbidden_actions": [
+        "trade",
+        "buy_list",
+        "sell_list",
+        "strategy_registration",
+        "candidate_promotion",
+        "paper",
+        "shadow",
+        "live",
+        "capital_allocation"
+      ],
+      "operator_explanation": "Controlled factor evaluation remains blocked until source manifests, field coverage, point-in-time policy, OOS policy, cost model, and null model are all explicitly present.",
+      "readiness_status": "BLOCKED",
+      "required_cost_model": true,
+      "required_currency_normalization": false,
+      "required_data_fields": [
+        "asset_turnover",
+        "book_value_equity",
+        "ebit_ttm",
+        "gross_margin",
+        "leverage_ratio",
+        "market_cap",
+        "operating_cash_flow",
+        "retained_earnings",
+        "revenue_ttm",
+        "roa",
+        "total_assets",
+        "total_liabilities",
+        "working_capital"
+      ],
+      "required_null_model": true,
+      "required_oos_policy": true,
+      "required_point_in_time_policy": true,
+      "required_source_manifests": [
+        "fundamental_source_manifest_v1"
+      ],
+      "source_hypothesis_seed_id": "equity_factor_seed::europe_deep_value_financial_health_v0",
+      "source_recipe_id": "europe_deep_value_financial_health_v0",
+      "target_universe_ids": [
+        "europe_large_mid",
+        "europe_small_mid"
+      ]
+    },
+    {
+      "allowed_next_action": "add_source_manifest",
+      "blocked_reason_codes": [
+        "BLOCKED_IDENTITY_AMBIGUITY",
+        "BLOCKED_DATA_READINESS",
+        "BLOCKED_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "BLOCKED_FIELD_COVERAGE",
+        "MISSING_RESTATEMENT_POLICY",
+        "BLOCKED_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "evaluation_id": "controlled_factor_eval::equity_factor_seed::europe_small_mid_quality_value_v0",
+      "factor_ids": [
+        "gross_profitability",
+        "book_to_market",
+        "accruals_ratio"
+      ],
+      "forbidden_actions": [
+        "trade",
+        "buy_list",
+        "sell_list",
+        "strategy_registration",
+        "candidate_promotion",
+        "paper",
+        "shadow",
+        "live",
+        "capital_allocation"
+      ],
+      "operator_explanation": "Controlled factor evaluation remains blocked until source manifests, field coverage, point-in-time policy, OOS policy, cost model, and null model are all explicitly present.",
+      "readiness_status": "BLOCKED",
+      "required_cost_model": true,
+      "required_currency_normalization": false,
+      "required_data_fields": [
+        "average_total_assets",
+        "book_value_equity",
+        "gross_profit_ttm",
+        "market_cap",
+        "net_income_ttm",
+        "operating_cash_flow_ttm",
+        "total_assets"
+      ],
+      "required_null_model": true,
+      "required_oos_policy": true,
+      "required_point_in_time_policy": true,
+      "required_source_manifests": [
+        "fundamental_source_manifest_v1"
+      ],
+      "source_hypothesis_seed_id": "equity_factor_seed::europe_small_mid_quality_value_v0",
+      "source_recipe_id": "europe_small_mid_quality_value_v0",
+      "target_universe_ids": [
+        "europe_small_mid"
+      ]
+    },
+    {
+      "allowed_next_action": "add_source_manifest",
+      "blocked_reason_codes": [
+        "BLOCKED_IDENTITY_AMBIGUITY",
+        "BLOCKED_DATA_READINESS",
+        "BLOCKED_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "BLOCKED_FIELD_COVERAGE",
+        "MISSING_RESTATEMENT_POLICY",
+        "BLOCKED_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "evaluation_id": "controlled_factor_eval::equity_factor_seed::global_developed_quality_momentum_v0",
+      "factor_ids": [
+        "roic",
+        "gross_profitability",
+        "twelve_month_momentum"
+      ],
+      "forbidden_actions": [
+        "trade",
+        "buy_list",
+        "sell_list",
+        "strategy_registration",
+        "candidate_promotion",
+        "paper",
+        "shadow",
+        "live",
+        "capital_allocation"
+      ],
+      "operator_explanation": "Controlled factor evaluation remains blocked until source manifests, field coverage, point-in-time policy, OOS policy, cost model, and null model are all explicitly present.",
+      "readiness_status": "BLOCKED",
+      "required_cost_model": true,
+      "required_currency_normalization": false,
+      "required_data_fields": [
+        "gross_profit_ttm",
+        "invested_capital",
+        "nopat_ttm",
+        "price_history_12m",
+        "total_assets"
+      ],
+      "required_null_model": true,
+      "required_oos_policy": true,
+      "required_point_in_time_policy": true,
+      "required_source_manifests": [
+        "fundamental_source_manifest_v1"
+      ],
+      "source_hypothesis_seed_id": "equity_factor_seed::global_developed_quality_momentum_v0",
+      "source_recipe_id": "global_developed_quality_momentum_v0",
+      "target_universe_ids": [
+        "global_developed_liquid"
+      ]
+    },
+    {
+      "allowed_next_action": "add_source_manifest",
+      "blocked_reason_codes": [
+        "BLOCKED_IDENTITY_AMBIGUITY",
+        "BLOCKED_DATA_READINESS",
+        "BLOCKED_CURRENCY_NORMALIZATION",
+        "BLOCKED_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "BLOCKED_FIELD_COVERAGE",
+        "MISSING_RESTATEMENT_POLICY",
+        "BLOCKED_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "evaluation_id": "controlled_factor_eval::equity_factor_seed::global_developed_value_quality_v0",
+      "factor_ids": [
+        "book_to_market",
+        "earnings_yield",
+        "return_on_assets"
+      ],
+      "forbidden_actions": [
+        "trade",
+        "buy_list",
+        "sell_list",
+        "strategy_registration",
+        "candidate_promotion",
+        "paper",
+        "shadow",
+        "live",
+        "capital_allocation"
+      ],
+      "operator_explanation": "Controlled factor evaluation remains blocked until source manifests, field coverage, point-in-time policy, OOS policy, cost model, and null model are all explicitly present.",
+      "readiness_status": "BLOCKED",
+      "required_cost_model": true,
+      "required_currency_normalization": true,
+      "required_data_fields": [
+        "book_value_equity",
+        "market_cap",
+        "net_income_ttm",
+        "total_assets"
+      ],
+      "required_null_model": true,
+      "required_oos_policy": true,
+      "required_point_in_time_policy": true,
+      "required_source_manifests": [
+        "fundamental_source_manifest_v1"
+      ],
+      "source_hypothesis_seed_id": "equity_factor_seed::global_developed_value_quality_v0",
+      "source_recipe_id": "global_developed_value_quality_v0",
+      "target_universe_ids": [
+        "global_developed_liquid"
+      ]
+    },
+    {
+      "allowed_next_action": "add_source_manifest",
+      "blocked_reason_codes": [
+        "BLOCKED_IDENTITY_AMBIGUITY",
+        "BLOCKED_DATA_READINESS",
+        "BLOCKED_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "BLOCKED_FIELD_COVERAGE",
+        "MISSING_RESTATEMENT_POLICY",
+        "BLOCKED_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "evaluation_id": "controlled_factor_eval::equity_factor_seed::low_accrual_quality_v0",
+      "factor_ids": [
+        "accruals_ratio",
+        "gross_profitability",
+        "return_on_assets"
+      ],
+      "forbidden_actions": [
+        "trade",
+        "buy_list",
+        "sell_list",
+        "strategy_registration",
+        "candidate_promotion",
+        "paper",
+        "shadow",
+        "live",
+        "capital_allocation"
+      ],
+      "operator_explanation": "Controlled factor evaluation remains blocked until source manifests, field coverage, point-in-time policy, OOS policy, cost model, and null model are all explicitly present.",
+      "readiness_status": "BLOCKED",
+      "required_cost_model": true,
+      "required_currency_normalization": false,
+      "required_data_fields": [
+        "average_total_assets",
+        "gross_profit_ttm",
+        "net_income_ttm",
+        "operating_cash_flow_ttm",
+        "total_assets"
+      ],
+      "required_null_model": true,
+      "required_oos_policy": true,
+      "required_point_in_time_policy": true,
+      "required_source_manifests": [
+        "fundamental_source_manifest_v1"
+      ],
+      "source_hypothesis_seed_id": "equity_factor_seed::low_accrual_quality_v0",
+      "source_recipe_id": "low_accrual_quality_v0",
+      "target_universe_ids": [
+        "global_developed_liquid"
+      ]
+    },
+    {
+      "allowed_next_action": "add_source_manifest",
+      "blocked_reason_codes": [
+        "BLOCKED_IDENTITY_AMBIGUITY",
+        "BLOCKED_DATA_READINESS",
+        "BLOCKED_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "BLOCKED_FIELD_COVERAGE",
+        "MISSING_RESTATEMENT_POLICY",
+        "BLOCKED_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "evaluation_id": "controlled_factor_eval::equity_factor_seed::magic_formula_style_v0",
+      "factor_ids": [
+        "enterprise_value_to_ebit",
+        "roic"
+      ],
+      "forbidden_actions": [
+        "trade",
+        "buy_list",
+        "sell_list",
+        "strategy_registration",
+        "candidate_promotion",
+        "paper",
+        "shadow",
+        "live",
+        "capital_allocation"
+      ],
+      "operator_explanation": "Controlled factor evaluation remains blocked until source manifests, field coverage, point-in-time policy, OOS policy, cost model, and null model are all explicitly present.",
+      "readiness_status": "BLOCKED",
+      "required_cost_model": true,
+      "required_currency_normalization": false,
+      "required_data_fields": [
+        "ebit_ttm",
+        "enterprise_value",
+        "invested_capital",
+        "nopat_ttm"
+      ],
+      "required_null_model": true,
+      "required_oos_policy": true,
+      "required_point_in_time_policy": true,
+      "required_source_manifests": [
+        "fundamental_source_manifest_v1"
+      ],
+      "source_hypothesis_seed_id": "equity_factor_seed::magic_formula_style_v0",
+      "source_recipe_id": "magic_formula_style_v0",
+      "target_universe_ids": [
+        "global_developed_liquid"
+      ]
+    },
+    {
+      "allowed_next_action": "add_source_manifest",
+      "blocked_reason_codes": [
+        "BLOCKED_IDENTITY_AMBIGUITY",
+        "BLOCKED_DATA_READINESS",
+        "BLOCKED_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "BLOCKED_FIELD_COVERAGE",
+        "MISSING_RESTATEMENT_POLICY",
+        "BLOCKED_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "evaluation_id": "controlled_factor_eval::equity_factor_seed::nl_quality_large_liquid_v0",
+      "factor_ids": [
+        "roic",
+        "gross_profitability",
+        "average_daily_value_traded"
+      ],
+      "forbidden_actions": [
+        "trade",
+        "buy_list",
+        "sell_list",
+        "strategy_registration",
+        "candidate_promotion",
+        "paper",
+        "shadow",
+        "live",
+        "capital_allocation"
+      ],
+      "operator_explanation": "Controlled factor evaluation remains blocked until source manifests, field coverage, point-in-time policy, OOS policy, cost model, and null model are all explicitly present.",
+      "readiness_status": "BLOCKED",
+      "required_cost_model": true,
+      "required_currency_normalization": false,
+      "required_data_fields": [
+        "average_daily_value_traded_90d",
+        "gross_profit_ttm",
+        "invested_capital",
+        "nopat_ttm",
+        "total_assets"
+      ],
+      "required_null_model": true,
+      "required_oos_policy": true,
+      "required_point_in_time_policy": true,
+      "required_source_manifests": [
+        "fundamental_source_manifest_v1"
+      ],
+      "source_hypothesis_seed_id": "equity_factor_seed::nl_quality_large_liquid_v0",
+      "source_recipe_id": "nl_quality_large_liquid_v0",
+      "target_universe_ids": [
+        "nl_equities"
+      ]
+    },
+    {
+      "allowed_next_action": "add_source_manifest",
+      "blocked_reason_codes": [
+        "BLOCKED_IDENTITY_AMBIGUITY",
+        "BLOCKED_DATA_READINESS",
+        "BLOCKED_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "BLOCKED_FIELD_COVERAGE",
+        "MISSING_RESTATEMENT_POLICY",
+        "BLOCKED_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "evaluation_id": "controlled_factor_eval::equity_factor_seed::nordics_quality_compounders_v0",
+      "factor_ids": [
+        "roic",
+        "gross_profitability",
+        "twelve_month_momentum"
+      ],
+      "forbidden_actions": [
+        "trade",
+        "buy_list",
+        "sell_list",
+        "strategy_registration",
+        "candidate_promotion",
+        "paper",
+        "shadow",
+        "live",
+        "capital_allocation"
+      ],
+      "operator_explanation": "Controlled factor evaluation remains blocked until source manifests, field coverage, point-in-time policy, OOS policy, cost model, and null model are all explicitly present.",
+      "readiness_status": "BLOCKED",
+      "required_cost_model": true,
+      "required_currency_normalization": false,
+      "required_data_fields": [
+        "gross_profit_ttm",
+        "invested_capital",
+        "nopat_ttm",
+        "price_history_12m",
+        "total_assets"
+      ],
+      "required_null_model": true,
+      "required_oos_policy": true,
+      "required_point_in_time_policy": true,
+      "required_source_manifests": [
+        "fundamental_source_manifest_v1"
+      ],
+      "source_hypothesis_seed_id": "equity_factor_seed::nordics_quality_compounders_v0",
+      "source_recipe_id": "nordics_quality_compounders_v0",
+      "target_universe_ids": [
+        "nordics_equities"
+      ]
+    },
+    {
+      "allowed_next_action": "add_source_manifest",
+      "blocked_reason_codes": [
+        "BLOCKED_IDENTITY_AMBIGUITY",
+        "BLOCKED_DATA_READINESS",
+        "BLOCKED_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "BLOCKED_FIELD_COVERAGE",
+        "MISSING_RESTATEMENT_POLICY",
+        "BLOCKED_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "evaluation_id": "controlled_factor_eval::equity_factor_seed::piotroski_value_style_v0",
+      "factor_ids": [
+        "book_to_market",
+        "piotroski_f_score"
+      ],
+      "forbidden_actions": [
+        "trade",
+        "buy_list",
+        "sell_list",
+        "strategy_registration",
+        "candidate_promotion",
+        "paper",
+        "shadow",
+        "live",
+        "capital_allocation"
+      ],
+      "operator_explanation": "Controlled factor evaluation remains blocked until source manifests, field coverage, point-in-time policy, OOS policy, cost model, and null model are all explicitly present.",
+      "readiness_status": "BLOCKED",
+      "required_cost_model": true,
+      "required_currency_normalization": false,
+      "required_data_fields": [
+        "asset_turnover",
+        "book_value_equity",
+        "gross_margin",
+        "leverage_ratio",
+        "market_cap",
+        "operating_cash_flow",
+        "roa"
+      ],
+      "required_null_model": true,
+      "required_oos_policy": true,
+      "required_point_in_time_policy": true,
+      "required_source_manifests": [
+        "fundamental_source_manifest_v1"
+      ],
+      "source_hypothesis_seed_id": "equity_factor_seed::piotroski_value_style_v0",
+      "source_recipe_id": "piotroski_value_style_v0",
+      "target_universe_ids": [
+        "global_developed_liquid"
+      ]
+    },
+    {
+      "allowed_next_action": "add_source_manifest",
+      "blocked_reason_codes": [
+        "BLOCKED_DATA_READINESS",
+        "BLOCKED_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "BLOCKED_FIELD_COVERAGE",
+        "MISSING_RESTATEMENT_POLICY",
+        "BLOCKED_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "evaluation_id": "controlled_factor_eval::equity_factor_seed::switzerland_defensive_quality_v0",
+      "factor_ids": [
+        "return_on_assets",
+        "gross_profitability",
+        "dividend_yield"
+      ],
+      "forbidden_actions": [
+        "trade",
+        "buy_list",
+        "sell_list",
+        "strategy_registration",
+        "candidate_promotion",
+        "paper",
+        "shadow",
+        "live",
+        "capital_allocation"
+      ],
+      "operator_explanation": "Controlled factor evaluation remains blocked until source manifests, field coverage, point-in-time policy, OOS policy, cost model, and null model are all explicitly present.",
+      "readiness_status": "BLOCKED",
+      "required_cost_model": true,
+      "required_currency_normalization": false,
+      "required_data_fields": [
+        "dividends_paid_ttm",
+        "gross_profit_ttm",
+        "market_cap",
+        "net_income_ttm",
+        "total_assets"
+      ],
+      "required_null_model": true,
+      "required_oos_policy": true,
+      "required_point_in_time_policy": true,
+      "required_source_manifests": [
+        "fundamental_source_manifest_v1"
+      ],
+      "source_hypothesis_seed_id": "equity_factor_seed::switzerland_defensive_quality_v0",
+      "source_recipe_id": "switzerland_defensive_quality_v0",
+      "target_universe_ids": [
+        "switzerland_equities"
+      ]
+    },
+    {
+      "allowed_next_action": "add_source_manifest",
+      "blocked_reason_codes": [
+        "BLOCKED_DATA_READINESS",
+        "BLOCKED_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "BLOCKED_FIELD_COVERAGE",
+        "MISSING_RESTATEMENT_POLICY",
+        "BLOCKED_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "evaluation_id": "controlled_factor_eval::equity_factor_seed::us_quality_momentum_large_mid_v0",
+      "factor_ids": [
+        "roic",
+        "gross_profitability",
+        "twelve_month_momentum"
+      ],
+      "forbidden_actions": [
+        "trade",
+        "buy_list",
+        "sell_list",
+        "strategy_registration",
+        "candidate_promotion",
+        "paper",
+        "shadow",
+        "live",
+        "capital_allocation"
+      ],
+      "operator_explanation": "Controlled factor evaluation remains blocked until source manifests, field coverage, point-in-time policy, OOS policy, cost model, and null model are all explicitly present.",
+      "readiness_status": "BLOCKED",
+      "required_cost_model": true,
+      "required_currency_normalization": false,
+      "required_data_fields": [
+        "gross_profit_ttm",
+        "invested_capital",
+        "nopat_ttm",
+        "price_history_12m",
+        "total_assets"
+      ],
+      "required_null_model": true,
+      "required_oos_policy": true,
+      "required_point_in_time_policy": true,
+      "required_source_manifests": [
+        "fundamental_source_manifest_v1"
+      ],
+      "source_hypothesis_seed_id": "equity_factor_seed::us_quality_momentum_large_mid_v0",
+      "source_recipe_id": "us_quality_momentum_large_mid_v0",
+      "target_universe_ids": [
+        "us_large_mid",
+        "us_quality_liquid"
+      ]
+    },
+    {
+      "allowed_next_action": "add_source_manifest",
+      "blocked_reason_codes": [
+        "BLOCKED_DATA_READINESS",
+        "BLOCKED_POINT_IN_TIME_POLICY",
+        "MISSING_REPORT_LAG_POLICY",
+        "BLOCKED_FIELD_COVERAGE",
+        "MISSING_RESTATEMENT_POLICY",
+        "BLOCKED_SOURCE_MANIFEST",
+        "SOURCE_LICENSE_UNKNOWN",
+        "SOURCE_QUALITY_UNKNOWN"
+      ],
+      "evaluation_id": "controlled_factor_eval::equity_factor_seed::us_shareholder_yield_quality_v0",
+      "factor_ids": [
+        "shareholder_yield",
+        "return_on_assets",
+        "gross_profitability"
+      ],
+      "forbidden_actions": [
+        "trade",
+        "buy_list",
+        "sell_list",
+        "strategy_registration",
+        "candidate_promotion",
+        "paper",
+        "shadow",
+        "live",
+        "capital_allocation"
+      ],
+      "operator_explanation": "Controlled factor evaluation remains blocked until source manifests, field coverage, point-in-time policy, OOS policy, cost model, and null model are all explicitly present.",
+      "readiness_status": "BLOCKED",
+      "required_cost_model": true,
+      "required_currency_normalization": false,
+      "required_data_fields": [
+        "dividends_paid_ttm",
+        "gross_profit_ttm",
+        "market_cap",
+        "net_buybacks_ttm",
+        "net_debt_change_ttm",
+        "net_income_ttm",
+        "total_assets"
+      ],
+      "required_null_model": true,
+      "required_oos_policy": true,
+      "required_point_in_time_policy": true,
+      "required_source_manifests": [
+        "fundamental_source_manifest_v1"
+      ],
+      "source_hypothesis_seed_id": "equity_factor_seed::us_shareholder_yield_quality_v0",
+      "source_recipe_id": "us_shareholder_yield_quality_v0",
+      "target_universe_ids": [
+        "us_large_mid",
+        "us_quality_liquid"
+      ]
+    }
+  ],
+  "safety_invariants": {
+    "broker_risk_execution_forbidden": true,
+    "mutates_frozen_contracts": false,
+    "mutates_registry": false,
+    "not_trade_signal": true,
+    "paper_shadow_live_forbidden": true,
+    "research_only": true
+  },
+  "schema_version": "1.0",
+  "summary": {
+    "blocked_count": 15,
+    "evaluation_count": 15,
+    "not_ready_count": 0,
+    "operator_summary": "Controlled factor evaluation is architecture-only at this stage. Rows stay blocked or not-ready until data and policy manifests are explicitly present.",
+    "ready_for_controlled_eval_count": 0,
+    "top_block_reasons": {
+      "BLOCKED_CURRENCY_NORMALIZATION": 3,
+      "BLOCKED_DATA_READINESS": 15,
+      "BLOCKED_FIELD_COVERAGE": 15,
+      "BLOCKED_IDENTITY_AMBIGUITY": 11,
+      "BLOCKED_POINT_IN_TIME_POLICY": 15,
+      "BLOCKED_SOURCE_MANIFEST": 15,
+      "MISSING_REPORT_LAG_POLICY": 15,
+      "MISSING_RESTATEMENT_POLICY": 15,
+      "SOURCE_LICENSE_UNKNOWN": 15,
+      "SOURCE_QUALITY_UNKNOWN": 15
+    }
+  }
+}

--- a/research/equity_factors/controlled_factor_evaluation.py
+++ b/research/equity_factors/controlled_factor_evaluation.py
@@ -1,0 +1,170 @@
+"""Read-only controlled factor evaluation readiness scaffold."""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Final
+
+from research.data_readiness.fundamental_readiness import build_fundamental_readiness
+from research.equity_factors.factor_catalog import build_equity_factor_calculation_contracts
+from research.hypothesis_discovery.equity_factor_hypothesis_adapter import (
+    build_equity_factor_hypothesis_seeds,
+)
+
+
+SCHEMA_VERSION: Final[str] = "1.0"
+REPORT_KIND: Final[str] = "controlled_factor_evaluation_readiness"
+READINESS_VOCABULARY: Final[tuple[str, ...]] = (
+    "READY_FOR_CONTROLLED_EVAL",
+    "NOT_READY",
+    "BLOCKED",
+)
+FORBIDDEN_ACTIONS: Final[tuple[str, ...]] = (
+    "trade",
+    "buy_list",
+    "sell_list",
+    "strategy_registration",
+    "candidate_promotion",
+    "paper",
+    "shadow",
+    "live",
+    "capital_allocation",
+)
+
+
+def _map_seed_block_reasons(seed_reasons: list[str]) -> list[str]:
+    mapped: list[str] = []
+    for reason in seed_reasons:
+        mapped_reason = {
+            "BLOCKED_DATA_READINESS_MISSING": "BLOCKED_DATA_READINESS",
+            "MISSING_SOURCE_MANIFEST": "BLOCKED_SOURCE_MANIFEST",
+            "MISSING_POINT_IN_TIME_POLICY": "BLOCKED_POINT_IN_TIME_POLICY",
+            "MISSING_REQUIRED_FIELD": "BLOCKED_FIELD_COVERAGE",
+            "FACTOR_FIELD_COVERAGE_UNKNOWN": "BLOCKED_FIELD_COVERAGE",
+            "BLOCKED_IDENTITY_AMBIGUITY": "BLOCKED_IDENTITY_AMBIGUITY",
+            "UNIVERSE_IDENTITY_NOT_READY": "BLOCKED_IDENTITY_AMBIGUITY",
+            "MISSING_CURRENCY_NORMALIZATION": "BLOCKED_CURRENCY_NORMALIZATION",
+        }.get(reason, reason)
+        if mapped_reason not in mapped:
+            mapped.append(mapped_reason)
+    return mapped
+
+
+def _allowed_next_action(blocked_reason_codes: list[str], readiness_status: str) -> str:
+    if "BLOCKED_SOURCE_MANIFEST" in blocked_reason_codes:
+        return "add_source_manifest"
+    if "BLOCKED_FIELD_COVERAGE" in blocked_reason_codes:
+        return "add_field_coverage_manifest"
+    if "BLOCKED_POINT_IN_TIME_POLICY" in blocked_reason_codes:
+        return "add_point_in_time_policy"
+    if "BLOCKED_CURRENCY_NORMALIZATION" in blocked_reason_codes:
+        return "add_currency_normalization_policy"
+    if "BLOCKED_OOS_POLICY" in blocked_reason_codes:
+        return "add_oos_policy"
+    if "BLOCKED_COST_MODEL" in blocked_reason_codes:
+        return "add_cost_model"
+    if "BLOCKED_NULL_MODEL" in blocked_reason_codes:
+        return "add_null_model"
+    return "operator_review" if readiness_status != "READY_FOR_CONTROLLED_EVAL" else "operator_review"
+
+
+def build_controlled_factor_evaluation_readiness() -> dict[str, object]:
+    seed_report = build_equity_factor_hypothesis_seeds()
+    readiness_report = build_fundamental_readiness()
+    factor_contracts = {
+        str(row["factor_id"]): row
+        for row in build_equity_factor_calculation_contracts().get("rows", [])
+    }
+    factor_readiness = {
+        str(row["factor_id"]): row for row in readiness_report.get("factor_rows", [])
+    }
+
+    rows: list[dict[str, object]] = []
+    for seed in seed_report.get("rows", []):
+        factor_ids = [str(item) for item in seed["factor_ids"]]
+        required_fields = sorted(
+            {
+                str(field)
+                for factor_id in factor_ids
+                for field in factor_contracts.get(factor_id, {}).get("required_fields", [])
+            }
+        )
+        point_in_time_required = any(
+            bool(factor_contracts.get(factor_id, {}).get("point_in_time_required"))
+            for factor_id in factor_ids
+        )
+        currency_normalization_required = any(
+            bool(factor_readiness.get(factor_id, {}).get("currency_normalization_required"))
+            for factor_id in factor_ids
+        )
+        blocked_reason_codes = _map_seed_block_reasons(
+            [str(reason) for reason in seed.get("blocked_reason_codes", [])]
+        )
+        if str(seed["feasibility_status"]) == "BLOCKED":
+            readiness_status = "BLOCKED"
+        else:
+            if point_in_time_required and "BLOCKED_POINT_IN_TIME_POLICY" not in blocked_reason_codes:
+                blocked_reason_codes.append("BLOCKED_POINT_IN_TIME_POLICY")
+            if currency_normalization_required and "BLOCKED_CURRENCY_NORMALIZATION" not in blocked_reason_codes:
+                blocked_reason_codes.append("BLOCKED_CURRENCY_NORMALIZATION")
+            for reason in ("BLOCKED_OOS_POLICY", "BLOCKED_COST_MODEL", "BLOCKED_NULL_MODEL"):
+                if reason not in blocked_reason_codes:
+                    blocked_reason_codes.append(reason)
+            readiness_status = "READY_FOR_CONTROLLED_EVAL" if not blocked_reason_codes else "NOT_READY"
+
+        operator_explanation = (
+            "Controlled factor evaluation remains blocked until source manifests, field coverage, "
+            "point-in-time policy, OOS policy, cost model, and null model are all explicitly present."
+            if readiness_status != "READY_FOR_CONTROLLED_EVAL"
+            else "Controlled factor evaluation scaffold is ready for bounded read-only evaluation only."
+        )
+        rows.append(
+            {
+                "evaluation_id": f"controlled_factor_eval::{seed['hypothesis_seed_id']}",
+                "source_hypothesis_seed_id": seed["hypothesis_seed_id"],
+                "source_recipe_id": seed["source_recipe_id"],
+                "target_universe_ids": list(seed["target_universe_ids"]),
+                "factor_ids": factor_ids,
+                "readiness_status": readiness_status,
+                "blocked_reason_codes": blocked_reason_codes,
+                "required_data_fields": required_fields,
+                "required_source_manifests": ["fundamental_source_manifest_v1"],
+                "required_point_in_time_policy": point_in_time_required,
+                "required_currency_normalization": currency_normalization_required,
+                "required_oos_policy": True,
+                "required_cost_model": True,
+                "required_null_model": True,
+                "allowed_next_action": _allowed_next_action(blocked_reason_codes, readiness_status),
+                "forbidden_actions": list(FORBIDDEN_ACTIONS),
+                "operator_explanation": operator_explanation,
+            }
+        )
+
+    rows.sort(key=lambda row: str(row["evaluation_id"]))
+    readiness_counts = Counter(str(row["readiness_status"]) for row in rows)
+    block_counts = Counter(reason for row in rows for reason in row["blocked_reason_codes"])
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "readiness_status_vocabulary": list(READINESS_VOCABULARY),
+        "summary": {
+            "evaluation_count": len(rows),
+            "ready_for_controlled_eval_count": readiness_counts.get("READY_FOR_CONTROLLED_EVAL", 0),
+            "not_ready_count": readiness_counts.get("NOT_READY", 0),
+            "blocked_count": readiness_counts.get("BLOCKED", 0),
+            "top_block_reasons": dict(sorted(block_counts.items())),
+            "operator_summary": (
+                "Controlled factor evaluation is architecture-only at this stage. "
+                "Rows stay blocked or not-ready until data and policy manifests are explicitly present."
+            ),
+        },
+        "rows": rows,
+        "safety_invariants": {
+            "research_only": True,
+            "not_trade_signal": True,
+            "mutates_registry": False,
+            "mutates_frozen_contracts": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+        },
+    }

--- a/research/equity_factors/controlled_factor_evaluation_manifest.py
+++ b/research/equity_factors/controlled_factor_evaluation_manifest.py
@@ -1,0 +1,57 @@
+"""Artifact writer for controlled factor evaluation readiness."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Final
+
+from research.equity_factors.controlled_factor_evaluation import (
+    build_controlled_factor_evaluation_readiness,
+)
+
+
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("artifacts/equity_factors")
+WRITE_PREFIX: Final[str] = "artifacts/equity_factors/"
+LATEST_NAME: Final[str] = "controlled_factor_evaluation_readiness_latest.v1.json"
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(
+            f"controlled_factor_evaluation_manifest: refusing write outside allowlist: {path!r}"
+        )
+
+
+def write_outputs(*, repo_root: Path = Path("."), output_dir: Path = DEFAULT_OUTPUT_DIR) -> dict[str, str]:
+    base = repo_root / output_dir
+    base.mkdir(parents=True, exist_ok=True)
+    latest = base / LATEST_NAME
+    _validate_write_target(latest)
+    tmp_latest = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_latest.write_text(
+        json.dumps(build_controlled_factor_evaluation_readiness(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    os.replace(tmp_latest, latest)
+    return {"latest": latest.relative_to(repo_root).as_posix()}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.equity_factors.controlled_factor_evaluation_manifest",
+        description="Write deterministic controlled factor evaluation readiness artifacts.",
+    )
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    payload = build_controlled_factor_evaluation_readiness()
+    if args.write:
+        payload["_artifact_paths"] = write_outputs()
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/unit/test_controlled_factor_evaluation.py
+++ b/tests/unit/test_controlled_factor_evaluation.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from research.equity_factors import controlled_factor_evaluation as evaluation
+
+
+def _seed_row(*, feasibility_status: str = "FEASIBLE", blocked_reason_codes: list[str] | None = None) -> dict[str, object]:
+    return {
+        "hypothesis_seed_id": "equity_factor_seed::test_recipe",
+        "source_recipe_id": "test_recipe",
+        "target_universe_ids": ["test_universe"],
+        "factor_ids": ["roic"],
+        "feasibility_status": feasibility_status,
+        "blocked_reason_codes": blocked_reason_codes or [],
+    }
+
+
+def _factor_contracts(point_in_time_required: bool = True) -> dict[str, object]:
+    return {
+        "rows": [
+            {
+                "factor_id": "roic",
+                "required_fields": ["nopat_ttm", "invested_capital"],
+                "point_in_time_required": point_in_time_required,
+            }
+        ]
+    }
+
+
+def _factor_readiness(currency_normalization_required: bool = False) -> dict[str, object]:
+    return {
+        "factor_rows": [
+            {
+                "factor_id": "roic",
+                "currency_normalization_required": currency_normalization_required,
+            }
+        ]
+    }
+
+
+def test_controlled_factor_evaluation_blocks_when_seed_is_blocked(monkeypatch) -> None:
+    monkeypatch.setattr(
+        evaluation,
+        "build_equity_factor_hypothesis_seeds",
+        lambda: {"rows": [_seed_row(feasibility_status="BLOCKED", blocked_reason_codes=["MISSING_SOURCE_MANIFEST"])]},
+    )
+    monkeypatch.setattr(evaluation, "build_fundamental_readiness", lambda: _factor_readiness())
+    monkeypatch.setattr(
+        evaluation,
+        "build_equity_factor_calculation_contracts",
+        lambda: _factor_contracts(),
+    )
+
+    row = evaluation.build_controlled_factor_evaluation_readiness()["rows"][0]
+    assert row["readiness_status"] == "BLOCKED"
+    assert "BLOCKED_SOURCE_MANIFEST" in row["blocked_reason_codes"]
+    assert row["allowed_next_action"] == "add_source_manifest"
+
+
+def test_controlled_factor_evaluation_not_ready_when_point_in_time_policy_missing(monkeypatch) -> None:
+    monkeypatch.setattr(
+        evaluation,
+        "build_equity_factor_hypothesis_seeds",
+        lambda: {"rows": [_seed_row()]},
+    )
+    monkeypatch.setattr(evaluation, "build_fundamental_readiness", lambda: _factor_readiness())
+    monkeypatch.setattr(
+        evaluation,
+        "build_equity_factor_calculation_contracts",
+        lambda: _factor_contracts(point_in_time_required=True),
+    )
+
+    row = evaluation.build_controlled_factor_evaluation_readiness()["rows"][0]
+    assert row["readiness_status"] == "NOT_READY"
+    assert "BLOCKED_POINT_IN_TIME_POLICY" in row["blocked_reason_codes"]
+    assert "BLOCKED_OOS_POLICY" in row["blocked_reason_codes"]
+
+
+def test_controlled_factor_evaluation_not_ready_when_cost_and_null_models_missing(monkeypatch) -> None:
+    monkeypatch.setattr(
+        evaluation,
+        "build_equity_factor_hypothesis_seeds",
+        lambda: {"rows": [_seed_row()]},
+    )
+    monkeypatch.setattr(evaluation, "build_fundamental_readiness", lambda: _factor_readiness())
+    monkeypatch.setattr(
+        evaluation,
+        "build_equity_factor_calculation_contracts",
+        lambda: _factor_contracts(point_in_time_required=False),
+    )
+
+    row = evaluation.build_controlled_factor_evaluation_readiness()["rows"][0]
+    assert row["readiness_status"] == "NOT_READY"
+    assert "BLOCKED_COST_MODEL" in row["blocked_reason_codes"]
+    assert "BLOCKED_NULL_MODEL" in row["blocked_reason_codes"]
+
+
+def test_controlled_factor_evaluation_is_deterministic(monkeypatch) -> None:
+    monkeypatch.setattr(
+        evaluation,
+        "build_equity_factor_hypothesis_seeds",
+        lambda: {"rows": [_seed_row()]},
+    )
+    monkeypatch.setattr(evaluation, "build_fundamental_readiness", lambda: _factor_readiness())
+    monkeypatch.setattr(
+        evaluation,
+        "build_equity_factor_calculation_contracts",
+        lambda: _factor_contracts(point_in_time_required=False),
+    )
+
+    first = evaluation.build_controlled_factor_evaluation_readiness()
+    second = evaluation.build_controlled_factor_evaluation_readiness()
+    assert json.dumps(first, sort_keys=True) == json.dumps(second, sort_keys=True)
+
+
+def test_controlled_factor_evaluation_source_has_no_performance_claims() -> None:
+    source = Path(evaluation.__file__).read_text(encoding="utf-8").lower()
+    assert "performance claim" not in source
+    assert "alpha certainty" not in source
+    assert "buy_list" in source

--- a/tests/unit/test_controlled_factor_evaluation_manifest.py
+++ b/tests/unit/test_controlled_factor_evaluation_manifest.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from research.equity_factors import controlled_factor_evaluation_manifest as manifest
+
+
+def test_controlled_factor_evaluation_manifest_writes_artifact(tmp_path: Path) -> None:
+    paths = manifest.write_outputs(repo_root=tmp_path)
+    assert (
+        paths["latest"]
+        == "artifacts/equity_factors/controlled_factor_evaluation_readiness_latest.v1.json"
+    )
+    payload = json.loads((tmp_path / paths["latest"]).read_text(encoding="utf-8"))
+    assert payload["report_kind"] == "controlled_factor_evaluation_readiness"
+
+
+def test_controlled_factor_evaluation_manifest_refuses_outside_allowlist(tmp_path: Path) -> None:
+    bad = tmp_path / "logs" / "bad.json"
+    try:
+        manifest._validate_write_target(bad)
+    except ValueError as exc:
+        assert "outside allowlist" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("expected ValueError")


### PR DESCRIPTION
## Summary
- add a read-only controlled factor evaluation readiness scaffold over hypothesis seeds, factor contracts, and fundamental readiness
- materialize deterministic evaluation-readiness rows without performing factor backtests or performance claims
- keep all rows blocked/not-ready until source/data/policy manifests truly exist

## Why
PR #485 materialized research-only equity-factor hypothesis seeds. QRE still needed a bounded next-stage scaffold that explains what would be required before any future controlled factor evaluation could even be considered.

## What changed
- added `research/equity_factors/controlled_factor_evaluation.py`
- added `research/equity_factors/controlled_factor_evaluation_manifest.py`
- added unit tests for blocked/not-ready readiness semantics and deterministic artifact output
- generated `artifacts/equity_factors/controlled_factor_evaluation_readiness_latest.v1.json`

## Safety constraints honored
- research-only and sidecar-artifact only
- no backtests or factor return claims
- no `registry.py` changes
- no `research/run_research.py` changes
- no frozen contract changes
- no live/paper/shadow/risk/broker/execution changes
- no buy/sell recommendations or strategy registration

## Tests run
- `python -m pytest tests/unit/test_controlled_factor_evaluation.py -q`
- `python -m pytest tests/unit/test_controlled_factor_evaluation_manifest.py -q`
- `python -m pytest tests/unit/test_equity_factor_hypothesis_adapter.py -q`
- `python -m pytest tests/unit/test_fundamental_readiness.py -q`
- `python -m pytest tests/unit/test_equity_factor_recipe_manifest.py -q`
- `python -m pytest tests/architecture -q`
- `python -m pytest tests -q -k "governance or no_touch or frozen_contract or execution_authority"`
- `python -m research.equity_factors.controlled_factor_evaluation_manifest --write`
- `git diff --check`
- `git diff -- research/research_latest.json research/strategy_matrix.csv`

## Current expected outcome
- current evaluation rows remain `BLOCKED`
- `READY_FOR_CONTROLLED_EVAL` remains `0`
- blockers are now explicit: source manifest, field coverage, point-in-time policy, and related policy/data gaps

## Known limitations
- this PR deliberately does not perform real factor evaluation
- current scaffold does not assert evidence exists; it only states what is still required before evaluation can be authorized

## Next recommended action
Final cross-PR validation and VPS deploy for the equity research front door slices
