### PR TITLE
fix: add fundamental data provider candidate registry

### DIFF
--- a/artifacts/external_intelligence/fundamental_provider_candidates_latest.v1.json
+++ b/artifacts/external_intelligence/fundamental_provider_candidates_latest.v1.json
@@ -1,0 +1,942 @@
+{
+  "allowed_use_vocabulary": [
+    "source_candidate_research",
+    "identity_mapping",
+    "metadata_context",
+    "fundamental_field_candidate",
+    "manual_research_context",
+    "connector_discovery",
+    "operator_explanation"
+  ],
+  "forbidden_use_vocabulary": [
+    "trade_signal",
+    "buy_list",
+    "sell_list",
+    "strategy_registration",
+    "candidate_promotion",
+    "paper_activation",
+    "shadow_activation",
+    "live_activation",
+    "capital_allocation",
+    "broker_execution"
+  ],
+  "report_kind": "fundamental_provider_candidates",
+  "rows": [
+    {
+      "activation_requirements": [
+        "license_reviewed",
+        "point_in_time_policy_defined",
+        "quality_gate_signed_off",
+        "report_lag_policy_defined",
+        "restatement_policy_defined",
+        "source_manifest_defined"
+      ],
+      "allowed_use": [
+        "fundamental_field_candidate",
+        "operator_explanation",
+        "source_candidate_research"
+      ],
+      "asset_coverage": [
+        "equities",
+        "etfs"
+      ],
+      "authentication_required": true,
+      "cost_model": "freemium_candidate",
+      "currency_normalization_support": "unknown",
+      "expected_freshness": "daily_or_slower_unknown",
+      "expected_latency": "api_latency_unknown",
+      "factor_field_coverage_potential": [
+        "balance_sheet_ready",
+        "cash_flow_statement_ready",
+        "income_statement_ready",
+        "price_history_complete"
+      ],
+      "forbidden_use": [
+        "trade_signal",
+        "buy_list",
+        "sell_list",
+        "strategy_registration",
+        "candidate_promotion",
+        "paper_activation",
+        "shadow_activation",
+        "live_activation",
+        "capital_allocation",
+        "broker_execution"
+      ],
+      "implementation_priority": 7,
+      "known_limitations": [
+        "license_terms_not_reviewed",
+        "point_in_time_semantics_unknown",
+        "rate_limits_not_modeled"
+      ],
+      "license_terms_reference": "provider_public_terms_reference_required",
+      "license_terms_status": "manual_review_required",
+      "operator_notes": "Candidate only. No keys, no fetching, no trust assignment in this phase.",
+      "point_in_time_support": "unknown",
+      "provider_category": "fundamental_api_candidate",
+      "provider_id": "alpha_vantage_candidate",
+      "provider_name": "Alpha Vantage",
+      "region_coverage": [
+        "Asia",
+        "Europe",
+        "US"
+      ],
+      "report_lag_support": "unknown",
+      "required_quality_gates": [
+        "field_coverage_manifest_defined",
+        "license_reviewed",
+        "point_in_time_policy_defined",
+        "report_lag_policy_defined",
+        "restatement_policy_defined",
+        "source_manifest_defined"
+      ],
+      "restatement_history_support": "unknown",
+      "risk_level": "medium",
+      "source_status": "candidate"
+    },
+    {
+      "activation_requirements": [
+        "operator_manual_review",
+        "source_manifest_defined"
+      ],
+      "allowed_use": [
+        "manual_research_context",
+        "metadata_context",
+        "operator_explanation"
+      ],
+      "asset_coverage": [
+        "uk_equities_metadata"
+      ],
+      "authentication_required": false,
+      "cost_model": "public_manual_research",
+      "currency_normalization_support": "not_applicable",
+      "expected_freshness": "issuer_registry_schedule_unknown",
+      "expected_latency": "manual_lookup",
+      "factor_field_coverage_potential": [
+        "filing_presence_context",
+        "issuer_identity_context"
+      ],
+      "forbidden_use": [
+        "trade_signal",
+        "buy_list",
+        "sell_list",
+        "strategy_registration",
+        "candidate_promotion",
+        "paper_activation",
+        "shadow_activation",
+        "live_activation",
+        "capital_allocation",
+        "broker_execution"
+      ],
+      "implementation_priority": 11,
+      "known_limitations": [
+        "manual_context_only",
+        "not_a_fundamental_dataset"
+      ],
+      "license_terms_reference": "companies_house_terms_manual_review_required",
+      "license_terms_status": "public_site_review_required",
+      "operator_notes": "Useful for issuer metadata context only; not a direct factor source.",
+      "point_in_time_support": "metadata_only",
+      "provider_category": "issuer_registry_metadata",
+      "provider_id": "companies_house_metadata",
+      "provider_name": "Companies House",
+      "region_coverage": [
+        "United Kingdom"
+      ],
+      "report_lag_support": "unknown",
+      "required_quality_gates": [
+        "license_reviewed",
+        "source_manifest_defined"
+      ],
+      "restatement_history_support": "unknown",
+      "risk_level": "low",
+      "source_status": "manual_research_only"
+    },
+    {
+      "activation_requirements": [
+        "license_reviewed",
+        "point_in_time_policy_defined",
+        "quality_gate_signed_off",
+        "report_lag_policy_defined",
+        "restatement_policy_defined",
+        "source_manifest_defined"
+      ],
+      "allowed_use": [
+        "fundamental_field_candidate",
+        "metadata_context",
+        "operator_explanation",
+        "source_candidate_research"
+      ],
+      "asset_coverage": [
+        "equities",
+        "etfs"
+      ],
+      "authentication_required": true,
+      "cost_model": "paid_candidate",
+      "currency_normalization_support": "unknown",
+      "expected_freshness": "daily_or_vendor_defined",
+      "expected_latency": "api_latency_unknown",
+      "factor_field_coverage_potential": [
+        "balance_sheet_ready",
+        "cash_flow_statement_ready",
+        "dividend_history_context",
+        "income_statement_ready",
+        "price_history_complete"
+      ],
+      "forbidden_use": [
+        "trade_signal",
+        "buy_list",
+        "sell_list",
+        "strategy_registration",
+        "candidate_promotion",
+        "paper_activation",
+        "shadow_activation",
+        "live_activation",
+        "capital_allocation",
+        "broker_execution"
+      ],
+      "implementation_priority": 6,
+      "known_limitations": [
+        "license_terms_not_reviewed",
+        "paid_vendor_candidate_only",
+        "point_in_time_semantics_unknown"
+      ],
+      "license_terms_reference": "provider_public_terms_reference_required",
+      "license_terms_status": "manual_review_required",
+      "operator_notes": "Candidate only. Paid/vendor status alone does not imply trust or readiness.",
+      "point_in_time_support": "unknown",
+      "provider_category": "fundamental_api_candidate",
+      "provider_id": "eodhd_candidate",
+      "provider_name": "EOD Historical Data",
+      "region_coverage": [
+        "Asia",
+        "Europe",
+        "Global",
+        "US"
+      ],
+      "report_lag_support": "unknown",
+      "required_quality_gates": [
+        "field_coverage_manifest_defined",
+        "license_reviewed",
+        "point_in_time_policy_defined",
+        "source_manifest_defined"
+      ],
+      "restatement_history_support": "unknown",
+      "risk_level": "medium",
+      "source_status": "candidate"
+    },
+    {
+      "activation_requirements": [
+        "identity_mapping_quality_gate",
+        "license_reviewed",
+        "source_manifest_defined"
+      ],
+      "allowed_use": [
+        "identity_mapping",
+        "metadata_context",
+        "operator_explanation",
+        "source_candidate_research"
+      ],
+      "asset_coverage": [
+        "europe_equities_metadata"
+      ],
+      "authentication_required": false,
+      "cost_model": "public_metadata_candidate",
+      "currency_normalization_support": "metadata_only",
+      "expected_freshness": "exchange_maintenance_schedule_unknown",
+      "expected_latency": "manual_or_http_metadata",
+      "factor_field_coverage_potential": [
+        "issuer_metadata",
+        "listing_metadata",
+        "venue_context"
+      ],
+      "forbidden_use": [
+        "trade_signal",
+        "buy_list",
+        "sell_list",
+        "strategy_registration",
+        "candidate_promotion",
+        "paper_activation",
+        "shadow_activation",
+        "live_activation",
+        "capital_allocation",
+        "broker_execution"
+      ],
+      "implementation_priority": 3,
+      "known_limitations": [
+        "license_terms_not_reviewed",
+        "metadata_not_fundamentals"
+      ],
+      "license_terms_reference": "euronext_public_terms_manual_review_required",
+      "license_terms_status": "manual_review_required",
+      "operator_notes": "High-value identity context candidate for EU listings; not a factor field source.",
+      "point_in_time_support": "metadata_only",
+      "provider_category": "exchange_metadata_candidate",
+      "provider_id": "euronext_issuer_metadata",
+      "provider_name": "Euronext Public Issuer Metadata",
+      "region_coverage": [
+        "Belgium",
+        "France",
+        "Ireland",
+        "Netherlands",
+        "Portugal"
+      ],
+      "report_lag_support": "not_applicable",
+      "required_quality_gates": [
+        "identity_mapping_quality_gate",
+        "license_reviewed",
+        "source_manifest_defined"
+      ],
+      "restatement_history_support": "not_applicable",
+      "risk_level": "low",
+      "source_status": "candidate"
+    },
+    {
+      "activation_requirements": [
+        "license_reviewed",
+        "point_in_time_policy_defined",
+        "quality_gate_signed_off",
+        "report_lag_policy_defined",
+        "restatement_policy_defined",
+        "source_manifest_defined"
+      ],
+      "allowed_use": [
+        "connector_discovery",
+        "operator_explanation",
+        "source_candidate_research"
+      ],
+      "asset_coverage": [
+        "unknown_until_manifested"
+      ],
+      "authentication_required": "unknown",
+      "cost_model": "unknown",
+      "currency_normalization_support": "unknown",
+      "expected_freshness": "unknown",
+      "expected_latency": "unknown",
+      "factor_field_coverage_potential": [
+        "unknown_until_manifested"
+      ],
+      "forbidden_use": [
+        "trade_signal",
+        "buy_list",
+        "sell_list",
+        "strategy_registration",
+        "candidate_promotion",
+        "paper_activation",
+        "shadow_activation",
+        "live_activation",
+        "capital_allocation",
+        "broker_execution"
+      ],
+      "implementation_priority": 12,
+      "known_limitations": [
+        "connector_only",
+        "no_license_review",
+        "no_source_manifest"
+      ],
+      "license_terms_reference": "operator_manifest_required",
+      "license_terms_status": "unknown",
+      "operator_notes": "Staging only. Connector discovery does not imply data trust or source authority.",
+      "point_in_time_support": "unknown",
+      "provider_category": "connector_candidate",
+      "provider_id": "financial_datasets_mcp",
+      "provider_name": "Financial Datasets MCP",
+      "region_coverage": [
+        "unknown_until_manifested"
+      ],
+      "report_lag_support": "unknown",
+      "required_quality_gates": [
+        "connector_contract_reviewed",
+        "license_reviewed",
+        "source_manifest_defined"
+      ],
+      "restatement_history_support": "unknown",
+      "risk_level": "medium",
+      "source_status": "staging"
+    },
+    {
+      "activation_requirements": [
+        "license_reviewed",
+        "point_in_time_policy_defined",
+        "quality_gate_signed_off",
+        "report_lag_policy_defined",
+        "restatement_policy_defined",
+        "source_manifest_defined"
+      ],
+      "allowed_use": [
+        "fundamental_field_candidate",
+        "operator_explanation",
+        "source_candidate_research"
+      ],
+      "asset_coverage": [
+        "equities",
+        "etfs"
+      ],
+      "authentication_required": true,
+      "cost_model": "freemium_or_paid_candidate",
+      "currency_normalization_support": "unknown",
+      "expected_freshness": "vendor_defined_unknown",
+      "expected_latency": "api_latency_unknown",
+      "factor_field_coverage_potential": [
+        "balance_sheet_ready",
+        "cash_flow_statement_ready",
+        "enterprise_value_ready",
+        "income_statement_ready",
+        "price_history_complete"
+      ],
+      "forbidden_use": [
+        "trade_signal",
+        "buy_list",
+        "sell_list",
+        "strategy_registration",
+        "candidate_promotion",
+        "paper_activation",
+        "shadow_activation",
+        "live_activation",
+        "capital_allocation",
+        "broker_execution"
+      ],
+      "implementation_priority": 5,
+      "known_limitations": [
+        "license_terms_not_reviewed",
+        "point_in_time_semantics_unknown",
+        "restatement_support_unknown"
+      ],
+      "license_terms_reference": "provider_public_terms_reference_required",
+      "license_terms_status": "manual_review_required",
+      "operator_notes": "Candidate only. No API integration or key management in this PR.",
+      "point_in_time_support": "unknown",
+      "provider_category": "fundamental_api_candidate",
+      "provider_id": "financial_modeling_prep_candidate",
+      "provider_name": "Financial Modeling Prep",
+      "region_coverage": [
+        "Asia",
+        "Europe",
+        "Global",
+        "US"
+      ],
+      "report_lag_support": "unknown",
+      "required_quality_gates": [
+        "field_coverage_manifest_defined",
+        "license_reviewed",
+        "point_in_time_policy_defined",
+        "source_manifest_defined"
+      ],
+      "restatement_history_support": "unknown",
+      "risk_level": "medium",
+      "source_status": "candidate"
+    },
+    {
+      "activation_requirements": [
+        "identity_mapping_quality_gate",
+        "license_reviewed",
+        "source_manifest_defined"
+      ],
+      "allowed_use": [
+        "identity_mapping",
+        "metadata_context",
+        "operator_explanation",
+        "source_candidate_research"
+      ],
+      "asset_coverage": [
+        "us_listings_metadata"
+      ],
+      "authentication_required": false,
+      "cost_model": "public_metadata_candidate",
+      "currency_normalization_support": "metadata_only",
+      "expected_freshness": "listing_file_schedule_unknown",
+      "expected_latency": "manual_or_http_metadata",
+      "factor_field_coverage_potential": [
+        "issuer_metadata",
+        "listing_metadata",
+        "venue_context"
+      ],
+      "forbidden_use": [
+        "trade_signal",
+        "buy_list",
+        "sell_list",
+        "strategy_registration",
+        "candidate_promotion",
+        "paper_activation",
+        "shadow_activation",
+        "live_activation",
+        "capital_allocation",
+        "broker_execution"
+      ],
+      "implementation_priority": 4,
+      "known_limitations": [
+        "license_terms_not_reviewed",
+        "metadata_not_fundamentals"
+      ],
+      "license_terms_reference": "nasdaq_public_terms_manual_review_required",
+      "license_terms_status": "manual_review_required",
+      "operator_notes": "Useful for US symbology/listing metadata only; not a valuation source.",
+      "point_in_time_support": "metadata_only",
+      "provider_category": "exchange_metadata_candidate",
+      "provider_id": "nasdaq_listings_metadata",
+      "provider_name": "Nasdaq Listings Metadata",
+      "region_coverage": [
+        "United States"
+      ],
+      "report_lag_support": "not_applicable",
+      "required_quality_gates": [
+        "identity_mapping_quality_gate",
+        "license_reviewed",
+        "source_manifest_defined"
+      ],
+      "restatement_history_support": "not_applicable",
+      "risk_level": "low",
+      "source_status": "candidate"
+    },
+    {
+      "activation_requirements": [
+        "identity_mapping_quality_gate",
+        "license_reviewed",
+        "source_manifest_defined"
+      ],
+      "allowed_use": [
+        "identity_mapping",
+        "metadata_context",
+        "operator_explanation",
+        "source_candidate_research"
+      ],
+      "asset_coverage": [
+        "us_listings_metadata"
+      ],
+      "authentication_required": false,
+      "cost_model": "public_metadata_candidate",
+      "currency_normalization_support": "metadata_only",
+      "expected_freshness": "listing_file_schedule_unknown",
+      "expected_latency": "manual_or_http_metadata",
+      "factor_field_coverage_potential": [
+        "issuer_metadata",
+        "listing_metadata",
+        "venue_context"
+      ],
+      "forbidden_use": [
+        "trade_signal",
+        "buy_list",
+        "sell_list",
+        "strategy_registration",
+        "candidate_promotion",
+        "paper_activation",
+        "shadow_activation",
+        "live_activation",
+        "capital_allocation",
+        "broker_execution"
+      ],
+      "implementation_priority": 4,
+      "known_limitations": [
+        "license_terms_not_reviewed",
+        "metadata_not_fundamentals"
+      ],
+      "license_terms_reference": "nyse_public_terms_manual_review_required",
+      "license_terms_status": "manual_review_required",
+      "operator_notes": "Useful for US venue metadata only; no trust assignment to fundamentals.",
+      "point_in_time_support": "metadata_only",
+      "provider_category": "exchange_metadata_candidate",
+      "provider_id": "nyse_listings_metadata",
+      "provider_name": "NYSE Listings Metadata",
+      "region_coverage": [
+        "United States"
+      ],
+      "report_lag_support": "not_applicable",
+      "required_quality_gates": [
+        "identity_mapping_quality_gate",
+        "license_reviewed",
+        "source_manifest_defined"
+      ],
+      "restatement_history_support": "not_applicable",
+      "risk_level": "low",
+      "source_status": "candidate"
+    },
+    {
+      "activation_requirements": [
+        "license_reviewed",
+        "point_in_time_policy_defined",
+        "quality_gate_signed_off",
+        "report_lag_policy_defined",
+        "restatement_policy_defined",
+        "source_manifest_defined"
+      ],
+      "allowed_use": [
+        "connector_discovery",
+        "operator_explanation",
+        "source_candidate_research"
+      ],
+      "asset_coverage": [
+        "multi_asset_connector_surface"
+      ],
+      "authentication_required": "unknown",
+      "cost_model": "connector_only_unknown",
+      "currency_normalization_support": "unknown",
+      "expected_freshness": "depends_on_downstream_provider",
+      "expected_latency": "depends_on_downstream_provider",
+      "factor_field_coverage_potential": [
+        "connector_surface_only"
+      ],
+      "forbidden_use": [
+        "trade_signal",
+        "buy_list",
+        "sell_list",
+        "strategy_registration",
+        "candidate_promotion",
+        "paper_activation",
+        "shadow_activation",
+        "live_activation",
+        "capital_allocation",
+        "broker_execution"
+      ],
+      "implementation_priority": 13,
+      "known_limitations": [
+        "connector_only",
+        "downstream_license_status_unknown",
+        "not_a_trusted_source"
+      ],
+      "license_terms_reference": "operator_manifest_required",
+      "license_terms_status": "unknown",
+      "operator_notes": "Staging only. Connector indirection cannot bypass source manifest and licensing policy.",
+      "point_in_time_support": "unknown",
+      "provider_category": "connector_candidate",
+      "provider_id": "openbb_connector",
+      "provider_name": "OpenBB",
+      "region_coverage": [
+        "Global"
+      ],
+      "report_lag_support": "unknown",
+      "required_quality_gates": [
+        "downstream_provider_manifest_defined",
+        "license_reviewed",
+        "source_manifest_defined"
+      ],
+      "restatement_history_support": "unknown",
+      "risk_level": "medium",
+      "source_status": "staging"
+    },
+    {
+      "activation_requirements": [
+        "identity_mapping_quality_gate",
+        "license_reviewed",
+        "source_manifest_defined"
+      ],
+      "allowed_use": [
+        "identity_mapping",
+        "metadata_context",
+        "operator_explanation",
+        "source_candidate_research"
+      ],
+      "asset_coverage": [
+        "equities",
+        "etfs",
+        "multi_listing_symbology"
+      ],
+      "authentication_required": false,
+      "cost_model": "public_or_limited_use_candidate",
+      "currency_normalization_support": "metadata_only",
+      "expected_freshness": "symbology_reference_schedule_unknown",
+      "expected_latency": "api_or_manual_lookup_unknown",
+      "factor_field_coverage_potential": [
+        "identity_only_not_fundamentals"
+      ],
+      "forbidden_use": [
+        "trade_signal",
+        "buy_list",
+        "sell_list",
+        "strategy_registration",
+        "candidate_promotion",
+        "paper_activation",
+        "shadow_activation",
+        "live_activation",
+        "capital_allocation",
+        "broker_execution"
+      ],
+      "implementation_priority": 2,
+      "known_limitations": [
+        "not_a_fundamental_source",
+        "symbology_only"
+      ],
+      "license_terms_reference": "openfigi_terms_manual_review_required",
+      "license_terms_status": "manual_review_required",
+      "operator_notes": "High-priority symbology candidate. Useful for canonical identity, not for factor fields.",
+      "point_in_time_support": "identity_only",
+      "provider_category": "symbology_candidate",
+      "provider_id": "openfigi_symbology",
+      "provider_name": "OpenFIGI",
+      "region_coverage": [
+        "Global"
+      ],
+      "report_lag_support": "not_applicable",
+      "required_quality_gates": [
+        "identity_mapping_quality_gate",
+        "license_reviewed",
+        "source_manifest_defined"
+      ],
+      "restatement_history_support": "not_applicable",
+      "risk_level": "low",
+      "source_status": "candidate"
+    },
+    {
+      "activation_requirements": [
+        "license_reviewed",
+        "point_in_time_policy_defined",
+        "quality_gate_signed_off",
+        "report_lag_policy_defined",
+        "restatement_policy_defined",
+        "source_manifest_defined"
+      ],
+      "allowed_use": [
+        "fundamental_field_candidate",
+        "metadata_context",
+        "operator_explanation",
+        "source_candidate_research"
+      ],
+      "asset_coverage": [
+        "us_equities"
+      ],
+      "authentication_required": false,
+      "cost_model": "public_access_candidate",
+      "currency_normalization_support": "mostly_usd_but_policy_required",
+      "expected_freshness": "filing_driven",
+      "expected_latency": "public_endpoint_latency_unknown",
+      "factor_field_coverage_potential": [
+        "balance_sheet_ready",
+        "cash_flow_statement_ready",
+        "income_statement_ready",
+        "multi_period_fundamentals"
+      ],
+      "forbidden_use": [
+        "trade_signal",
+        "buy_list",
+        "sell_list",
+        "strategy_registration",
+        "candidate_promotion",
+        "paper_activation",
+        "shadow_activation",
+        "live_activation",
+        "capital_allocation",
+        "broker_execution"
+      ],
+      "implementation_priority": 1,
+      "known_limitations": [
+        "point_in_time_policy_not_defined",
+        "restatement_policy_not_defined",
+        "us_only"
+      ],
+      "license_terms_reference": "sec_edgar_terms_manual_review_required",
+      "license_terms_status": "public_source_review_required",
+      "operator_notes": "Highest-priority public candidate for US fundamentals, but still untrusted until full source-manifest and policy gates exist.",
+      "point_in_time_support": "candidate_with_policy_required",
+      "provider_category": "public_fundamental_filings",
+      "provider_id": "sec_companyfacts",
+      "provider_name": "SEC EDGAR Company Facts",
+      "region_coverage": [
+        "United States"
+      ],
+      "report_lag_support": "candidate_with_policy_required",
+      "required_quality_gates": [
+        "field_coverage_manifest_defined",
+        "license_reviewed",
+        "point_in_time_policy_defined",
+        "report_lag_policy_defined",
+        "restatement_policy_defined",
+        "source_manifest_defined"
+      ],
+      "restatement_history_support": "candidate_with_policy_required",
+      "risk_level": "low",
+      "source_status": "candidate"
+    },
+    {
+      "activation_requirements": [
+        "operator_manual_review",
+        "source_manifest_defined"
+      ],
+      "allowed_use": [
+        "manual_research_context",
+        "metadata_context",
+        "operator_explanation"
+      ],
+      "asset_coverage": [
+        "public_price_context"
+      ],
+      "authentication_required": false,
+      "cost_model": "public_manual_research",
+      "currency_normalization_support": "unknown",
+      "expected_freshness": "unknown",
+      "expected_latency": "manual_lookup",
+      "factor_field_coverage_potential": [
+        "price_context_only"
+      ],
+      "forbidden_use": [
+        "trade_signal",
+        "buy_list",
+        "sell_list",
+        "strategy_registration",
+        "candidate_promotion",
+        "paper_activation",
+        "shadow_activation",
+        "live_activation",
+        "capital_allocation",
+        "broker_execution"
+      ],
+      "implementation_priority": 14,
+      "known_limitations": [
+        "manual_context_only",
+        "not_a_fundamental_source"
+      ],
+      "license_terms_reference": "stooq_terms_manual_review_required",
+      "license_terms_status": "manual_review_required",
+      "operator_notes": "Only relevant as manual price context. It does not address fundamental field coverage.",
+      "point_in_time_support": "unknown",
+      "provider_category": "public_price_context",
+      "provider_id": "stooq_price_context",
+      "provider_name": "Stooq",
+      "region_coverage": [
+        "Europe",
+        "Global",
+        "US"
+      ],
+      "report_lag_support": "not_applicable",
+      "required_quality_gates": [
+        "license_reviewed",
+        "source_manifest_defined"
+      ],
+      "restatement_history_support": "not_applicable",
+      "risk_level": "low",
+      "source_status": "manual_research_only"
+    },
+    {
+      "activation_requirements": [
+        "license_reviewed",
+        "point_in_time_policy_defined",
+        "quality_gate_signed_off",
+        "report_lag_policy_defined",
+        "restatement_policy_defined",
+        "source_manifest_defined"
+      ],
+      "allowed_use": [
+        "manual_research_context",
+        "metadata_context",
+        "operator_explanation"
+      ],
+      "asset_coverage": [
+        "equities",
+        "etfs",
+        "price_context"
+      ],
+      "authentication_required": false,
+      "cost_model": "public_convenience_candidate",
+      "currency_normalization_support": "unknown",
+      "expected_freshness": "unknown",
+      "expected_latency": "library_dependent",
+      "factor_field_coverage_potential": [
+        "convenience_only_untrusted"
+      ],
+      "forbidden_use": [
+        "trade_signal",
+        "buy_list",
+        "sell_list",
+        "strategy_registration",
+        "candidate_promotion",
+        "paper_activation",
+        "shadow_activation",
+        "live_activation",
+        "capital_allocation",
+        "broker_execution"
+      ],
+      "implementation_priority": 15,
+      "known_limitations": [
+        "licensing_uncertainty",
+        "point_in_time_semantics_unknown",
+        "restatement_semantics_unknown"
+      ],
+      "license_terms_reference": "manual_license_review_required_before_any_manifest",
+      "license_terms_status": "licensing_warning",
+      "operator_notes": "Manual-research-only with explicit licensing warning. Not trusted for gated factor evaluation.",
+      "point_in_time_support": "unknown",
+      "provider_category": "public_convenience_dataset",
+      "provider_id": "yahoo_finance_yfinance",
+      "provider_name": "Yahoo Finance / yfinance",
+      "region_coverage": [
+        "Global"
+      ],
+      "report_lag_support": "unknown",
+      "required_quality_gates": [
+        "license_reviewed",
+        "point_in_time_policy_defined",
+        "source_manifest_defined"
+      ],
+      "restatement_history_support": "unknown",
+      "risk_level": "high",
+      "source_status": "manual_research_only"
+    }
+  ],
+  "safety_invariants": {
+    "broker_risk_execution_forbidden": true,
+    "mutates_frozen_contracts": false,
+    "mutates_registry": false,
+    "no_api_integration": true,
+    "no_data_fetch": true,
+    "no_vendor_activation": true,
+    "not_trade_signal": true,
+    "paper_shadow_live_forbidden": true,
+    "research_only": true
+  },
+  "schema_version": "1.0",
+  "source_status_vocabulary": [
+    "candidate",
+    "manual_research_only",
+    "staging",
+    "quality_gated",
+    "active_read_only",
+    "deprecated",
+    "blocked"
+  ],
+  "summary": {
+    "active_read_only_count": 0,
+    "blocked_count": 0,
+    "candidate_count": 8,
+    "deprecated_count": 0,
+    "highest_priority_candidates": [
+      {
+        "implementation_priority": 1,
+        "provider_id": "sec_companyfacts",
+        "provider_name": "SEC EDGAR Company Facts",
+        "reason": "Highest-priority public candidate for US fundamentals, but still untrusted until full source-manifest and policy gates exist.",
+        "source_status": "candidate"
+      },
+      {
+        "implementation_priority": 2,
+        "provider_id": "openfigi_symbology",
+        "provider_name": "OpenFIGI",
+        "reason": "High-priority symbology candidate. Useful for canonical identity, not for factor fields.",
+        "source_status": "candidate"
+      },
+      {
+        "implementation_priority": 3,
+        "provider_id": "euronext_issuer_metadata",
+        "provider_name": "Euronext Public Issuer Metadata",
+        "reason": "High-value identity context candidate for EU listings; not a factor field source.",
+        "source_status": "candidate"
+      },
+      {
+        "implementation_priority": 4,
+        "provider_id": "nasdaq_listings_metadata",
+        "provider_name": "Nasdaq Listings Metadata",
+        "reason": "Useful for US symbology/listing metadata only; not a valuation source.",
+        "source_status": "candidate"
+      },
+      {
+        "implementation_priority": 4,
+        "provider_id": "nyse_listings_metadata",
+        "provider_name": "NYSE Listings Metadata",
+        "reason": "Useful for US venue metadata only; no trust assignment to fundamentals.",
+        "source_status": "candidate"
+      }
+    ],
+    "manual_research_only_count": 3,
+    "operator_summary": "Provider registry is research-only candidate governance. No data has been fetched, no provider is trusted by default, and no source becomes active without license review, source manifests, quality gates, and point-in-time policy.",
+    "quality_gated_count": 0,
+    "staging_count": 2,
+    "total_providers": 13
+  }
+}

--- a/artifacts/external_intelligence/fundamental_provider_operator_report_latest.md
+++ b/artifacts/external_intelligence/fundamental_provider_operator_report_latest.md
@@ -1,0 +1,45 @@
+# QRE Fundamental Provider Candidate Registry
+
+Research-only provider registry. No data has been fetched, no API integration was activated, and no provider is trusted or active by default.
+
+## Status Counts
+- total providers: 13
+- candidate: 8
+- manual_research_only: 3
+- staging: 2
+- quality_gated: 0
+- active_read_only: 0
+- deprecated: 0
+- blocked: 0
+
+## Highest Priority Candidates
+- sec_companyfacts: priority 1 [candidate] - Highest-priority public candidate for US fundamentals, but still untrusted until full source-manifest and policy gates exist.
+- openfigi_symbology: priority 2 [candidate] - High-priority symbology candidate. Useful for canonical identity, not for factor fields.
+- euronext_issuer_metadata: priority 3 [candidate] - High-value identity context candidate for EU listings; not a factor field source.
+- nasdaq_listings_metadata: priority 4 [candidate] - Useful for US symbology/listing metadata only; not a valuation source.
+- nyse_listings_metadata: priority 4 [candidate] - Useful for US venue metadata only; no trust assignment to fundamentals.
+
+## Providers By Status
+### candidate
+- sec_companyfacts: SEC EDGAR Company Facts (public_fundamental_filings, license=public_source_review_required, risk=low)
+- openfigi_symbology: OpenFIGI (symbology_candidate, license=manual_review_required, risk=low)
+- euronext_issuer_metadata: Euronext Public Issuer Metadata (exchange_metadata_candidate, license=manual_review_required, risk=low)
+- nasdaq_listings_metadata: Nasdaq Listings Metadata (exchange_metadata_candidate, license=manual_review_required, risk=low)
+- nyse_listings_metadata: NYSE Listings Metadata (exchange_metadata_candidate, license=manual_review_required, risk=low)
+- financial_modeling_prep_candidate: Financial Modeling Prep (fundamental_api_candidate, license=manual_review_required, risk=medium)
+- eodhd_candidate: EOD Historical Data (fundamental_api_candidate, license=manual_review_required, risk=medium)
+- alpha_vantage_candidate: Alpha Vantage (fundamental_api_candidate, license=manual_review_required, risk=medium)
+### manual_research_only
+- companies_house_metadata: Companies House (issuer_registry_metadata, license=public_site_review_required, risk=low)
+- stooq_price_context: Stooq (public_price_context, license=manual_review_required, risk=low)
+- yahoo_finance_yfinance: Yahoo Finance / yfinance (public_convenience_dataset, license=licensing_warning, risk=high)
+### staging
+- financial_datasets_mcp: Financial Datasets MCP (connector_candidate, license=unknown, risk=medium)
+- openbb_connector: OpenBB (connector_candidate, license=unknown, risk=medium)
+
+## Safety
+- No buy/sell recommendations
+- No trade signals
+- No strategy registration
+- No paper/shadow/live activation
+- No broker/risk/execution authority

--- a/artifacts/external_intelligence/fundamental_provider_summary_latest.v1.json
+++ b/artifacts/external_intelligence/fundamental_provider_summary_latest.v1.json
@@ -1,0 +1,63 @@
+{
+  "report_kind": "fundamental_provider_summary",
+  "safety_invariants": {
+    "broker_risk_execution_forbidden": true,
+    "mutates_frozen_contracts": false,
+    "mutates_registry": false,
+    "no_api_integration": true,
+    "no_data_fetch": true,
+    "no_vendor_activation": true,
+    "not_trade_signal": true,
+    "paper_shadow_live_forbidden": true,
+    "research_only": true
+  },
+  "schema_version": "1.0",
+  "summary": {
+    "active_read_only": 0,
+    "blocked": 0,
+    "candidate": 8,
+    "deprecated": 0,
+    "highest_priority_candidates": [
+      {
+        "implementation_priority": 1,
+        "provider_id": "sec_companyfacts",
+        "provider_name": "SEC EDGAR Company Facts",
+        "reason": "Highest-priority public candidate for US fundamentals, but still untrusted until full source-manifest and policy gates exist.",
+        "source_status": "candidate"
+      },
+      {
+        "implementation_priority": 2,
+        "provider_id": "openfigi_symbology",
+        "provider_name": "OpenFIGI",
+        "reason": "High-priority symbology candidate. Useful for canonical identity, not for factor fields.",
+        "source_status": "candidate"
+      },
+      {
+        "implementation_priority": 3,
+        "provider_id": "euronext_issuer_metadata",
+        "provider_name": "Euronext Public Issuer Metadata",
+        "reason": "High-value identity context candidate for EU listings; not a factor field source.",
+        "source_status": "candidate"
+      },
+      {
+        "implementation_priority": 4,
+        "provider_id": "nasdaq_listings_metadata",
+        "provider_name": "Nasdaq Listings Metadata",
+        "reason": "Useful for US symbology/listing metadata only; not a valuation source.",
+        "source_status": "candidate"
+      },
+      {
+        "implementation_priority": 4,
+        "provider_id": "nyse_listings_metadata",
+        "provider_name": "NYSE Listings Metadata",
+        "reason": "Useful for US venue metadata only; no trust assignment to fundamentals.",
+        "source_status": "candidate"
+      }
+    ],
+    "manual_research_only": 3,
+    "operator_summary": "Provider registry is research-only candidate governance. No data has been fetched, no provider is trusted by default, and no source becomes active without license review, source manifests, quality gates, and point-in-time policy.",
+    "quality_gated": 0,
+    "staging": 2,
+    "total_providers": 13
+  }
+}

--- a/research/external_intelligence/__init__.py
+++ b/research/external_intelligence/__init__.py
@@ -1,0 +1,1 @@
+"""Research-only external intelligence registry package."""

--- a/research/external_intelligence/fundamental_provider_manifest.py
+++ b/research/external_intelligence/fundamental_provider_manifest.py
@@ -1,0 +1,89 @@
+"""Artifact writer for the research-only fundamental provider candidate registry."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Final
+
+from research.external_intelligence.fundamental_provider_registry import (
+    build_fundamental_provider_registry,
+)
+
+
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("artifacts/external_intelligence")
+WRITE_PREFIX: Final[str] = "artifacts/external_intelligence/"
+CANDIDATES_NAME: Final[str] = "fundamental_provider_candidates_latest.v1.json"
+SUMMARY_NAME: Final[str] = "fundamental_provider_summary_latest.v1.json"
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(f"fundamental_provider_manifest: refusing write outside allowlist: {path!r}")
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def build_fundamental_provider_summary(snapshot: dict[str, object]) -> dict[str, object]:
+    summary = snapshot["summary"]
+    return {
+        "schema_version": snapshot["schema_version"],
+        "report_kind": "fundamental_provider_summary",
+        "summary": {
+            "total_providers": summary["total_providers"],
+            "candidate": summary["candidate_count"],
+            "manual_research_only": summary["manual_research_only_count"],
+            "staging": summary["staging_count"],
+            "quality_gated": summary["quality_gated_count"],
+            "active_read_only": summary["active_read_only_count"],
+            "deprecated": summary["deprecated_count"],
+            "blocked": summary["blocked_count"],
+            "highest_priority_candidates": summary["highest_priority_candidates"],
+            "operator_summary": summary["operator_summary"],
+        },
+        "safety_invariants": snapshot["safety_invariants"],
+    }
+
+
+def write_outputs(*, repo_root: Path = Path("."), output_dir: Path = DEFAULT_OUTPUT_DIR) -> dict[str, str]:
+    base = repo_root / output_dir
+    base.mkdir(parents=True, exist_ok=True)
+    candidates_path = base / CANDIDATES_NAME
+    summary_path = base / SUMMARY_NAME
+    for path in (candidates_path, summary_path):
+        _validate_write_target(path)
+    snapshot = build_fundamental_provider_registry()
+    _write_json(candidates_path, snapshot)
+    _write_json(summary_path, build_fundamental_provider_summary(snapshot))
+    return {
+        "candidates": candidates_path.relative_to(repo_root).as_posix(),
+        "summary": summary_path.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.external_intelligence.fundamental_provider_manifest",
+        description="Write deterministic research-only fundamental provider registry artifacts.",
+    )
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    snapshot = build_fundamental_provider_registry()
+    payload = {
+        "registry": snapshot,
+        "summary": build_fundamental_provider_summary(snapshot),
+    }
+    if args.write:
+        payload["_artifact_paths"] = write_outputs()
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/research/external_intelligence/fundamental_provider_registry.py
+++ b/research/external_intelligence/fundamental_provider_registry.py
@@ -1,0 +1,720 @@
+"""Deterministic research-only candidate registry for future fundamental providers."""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Final
+
+
+SCHEMA_VERSION: Final[str] = "1.0"
+REPORT_KIND: Final[str] = "fundamental_provider_candidates"
+SOURCE_STATUS_VOCABULARY: Final[tuple[str, ...]] = (
+    "candidate",
+    "manual_research_only",
+    "staging",
+    "quality_gated",
+    "active_read_only",
+    "deprecated",
+    "blocked",
+)
+ALLOWED_USE_VOCABULARY: Final[tuple[str, ...]] = (
+    "source_candidate_research",
+    "identity_mapping",
+    "metadata_context",
+    "fundamental_field_candidate",
+    "manual_research_context",
+    "connector_discovery",
+    "operator_explanation",
+)
+FORBIDDEN_USE: Final[tuple[str, ...]] = (
+    "trade_signal",
+    "buy_list",
+    "sell_list",
+    "strategy_registration",
+    "candidate_promotion",
+    "paper_activation",
+    "shadow_activation",
+    "live_activation",
+    "capital_allocation",
+    "broker_execution",
+)
+ACTIVE_READ_ONLY_REQUIREMENTS: Final[tuple[str, ...]] = (
+    "source_manifest_defined",
+    "license_reviewed",
+    "quality_gate_signed_off",
+    "point_in_time_policy_defined",
+    "report_lag_policy_defined",
+    "restatement_policy_defined",
+)
+
+
+PROVIDER_ROWS: Final[tuple[dict[str, object], ...]] = (
+    {
+        "provider_id": "alpha_vantage_candidate",
+        "provider_name": "Alpha Vantage",
+        "provider_category": "fundamental_api_candidate",
+        "source_status": "candidate",
+        "allowed_use": [
+            "source_candidate_research",
+            "fundamental_field_candidate",
+            "operator_explanation",
+        ],
+        "forbidden_use": list(FORBIDDEN_USE),
+        "asset_coverage": ["equities", "etfs"],
+        "region_coverage": ["US", "Europe", "Asia"],
+        "factor_field_coverage_potential": [
+            "income_statement_ready",
+            "balance_sheet_ready",
+            "cash_flow_statement_ready",
+            "price_history_complete",
+        ],
+        "point_in_time_support": "unknown",
+        "restatement_history_support": "unknown",
+        "report_lag_support": "unknown",
+        "currency_normalization_support": "unknown",
+        "authentication_required": True,
+        "cost_model": "freemium_candidate",
+        "license_terms_status": "manual_review_required",
+        "license_terms_reference": "provider_public_terms_reference_required",
+        "expected_freshness": "daily_or_slower_unknown",
+        "expected_latency": "api_latency_unknown",
+        "implementation_priority": 7,
+        "risk_level": "medium",
+        "known_limitations": [
+            "license_terms_not_reviewed",
+            "point_in_time_semantics_unknown",
+            "rate_limits_not_modeled",
+        ],
+        "required_quality_gates": [
+            "source_manifest_defined",
+            "license_reviewed",
+            "point_in_time_policy_defined",
+            "report_lag_policy_defined",
+            "restatement_policy_defined",
+            "field_coverage_manifest_defined",
+        ],
+        "activation_requirements": list(ACTIVE_READ_ONLY_REQUIREMENTS),
+        "operator_notes": "Candidate only. No keys, no fetching, no trust assignment in this phase.",
+    },
+    {
+        "provider_id": "companies_house_metadata",
+        "provider_name": "Companies House",
+        "provider_category": "issuer_registry_metadata",
+        "source_status": "manual_research_only",
+        "allowed_use": [
+            "manual_research_context",
+            "metadata_context",
+            "operator_explanation",
+        ],
+        "forbidden_use": list(FORBIDDEN_USE),
+        "asset_coverage": ["uk_equities_metadata"],
+        "region_coverage": ["United Kingdom"],
+        "factor_field_coverage_potential": ["issuer_identity_context", "filing_presence_context"],
+        "point_in_time_support": "metadata_only",
+        "restatement_history_support": "unknown",
+        "report_lag_support": "unknown",
+        "currency_normalization_support": "not_applicable",
+        "authentication_required": False,
+        "cost_model": "public_manual_research",
+        "license_terms_status": "public_site_review_required",
+        "license_terms_reference": "companies_house_terms_manual_review_required",
+        "expected_freshness": "issuer_registry_schedule_unknown",
+        "expected_latency": "manual_lookup",
+        "implementation_priority": 11,
+        "risk_level": "low",
+        "known_limitations": [
+            "not_a_fundamental_dataset",
+            "manual_context_only",
+        ],
+        "required_quality_gates": [
+            "source_manifest_defined",
+            "license_reviewed",
+        ],
+        "activation_requirements": [
+            "operator_manual_review",
+            "source_manifest_defined",
+        ],
+        "operator_notes": "Useful for issuer metadata context only; not a direct factor source.",
+    },
+    {
+        "provider_id": "eodhd_candidate",
+        "provider_name": "EOD Historical Data",
+        "provider_category": "fundamental_api_candidate",
+        "source_status": "candidate",
+        "allowed_use": [
+            "source_candidate_research",
+            "fundamental_field_candidate",
+            "metadata_context",
+            "operator_explanation",
+        ],
+        "forbidden_use": list(FORBIDDEN_USE),
+        "asset_coverage": ["equities", "etfs"],
+        "region_coverage": ["US", "Europe", "Asia", "Global"],
+        "factor_field_coverage_potential": [
+            "income_statement_ready",
+            "balance_sheet_ready",
+            "cash_flow_statement_ready",
+            "dividend_history_context",
+            "price_history_complete",
+        ],
+        "point_in_time_support": "unknown",
+        "restatement_history_support": "unknown",
+        "report_lag_support": "unknown",
+        "currency_normalization_support": "unknown",
+        "authentication_required": True,
+        "cost_model": "paid_candidate",
+        "license_terms_status": "manual_review_required",
+        "license_terms_reference": "provider_public_terms_reference_required",
+        "expected_freshness": "daily_or_vendor_defined",
+        "expected_latency": "api_latency_unknown",
+        "implementation_priority": 6,
+        "risk_level": "medium",
+        "known_limitations": [
+            "paid_vendor_candidate_only",
+            "license_terms_not_reviewed",
+            "point_in_time_semantics_unknown",
+        ],
+        "required_quality_gates": [
+            "source_manifest_defined",
+            "license_reviewed",
+            "point_in_time_policy_defined",
+            "field_coverage_manifest_defined",
+        ],
+        "activation_requirements": list(ACTIVE_READ_ONLY_REQUIREMENTS),
+        "operator_notes": "Candidate only. Paid/vendor status alone does not imply trust or readiness.",
+    },
+    {
+        "provider_id": "euronext_issuer_metadata",
+        "provider_name": "Euronext Public Issuer Metadata",
+        "provider_category": "exchange_metadata_candidate",
+        "source_status": "candidate",
+        "allowed_use": [
+            "source_candidate_research",
+            "identity_mapping",
+            "metadata_context",
+            "operator_explanation",
+        ],
+        "forbidden_use": list(FORBIDDEN_USE),
+        "asset_coverage": ["europe_equities_metadata"],
+        "region_coverage": ["Netherlands", "Belgium", "France", "Portugal", "Ireland"],
+        "factor_field_coverage_potential": ["issuer_metadata", "listing_metadata", "venue_context"],
+        "point_in_time_support": "metadata_only",
+        "restatement_history_support": "not_applicable",
+        "report_lag_support": "not_applicable",
+        "currency_normalization_support": "metadata_only",
+        "authentication_required": False,
+        "cost_model": "public_metadata_candidate",
+        "license_terms_status": "manual_review_required",
+        "license_terms_reference": "euronext_public_terms_manual_review_required",
+        "expected_freshness": "exchange_maintenance_schedule_unknown",
+        "expected_latency": "manual_or_http_metadata",
+        "implementation_priority": 3,
+        "risk_level": "low",
+        "known_limitations": [
+            "metadata_not_fundamentals",
+            "license_terms_not_reviewed",
+        ],
+        "required_quality_gates": [
+            "source_manifest_defined",
+            "license_reviewed",
+            "identity_mapping_quality_gate",
+        ],
+        "activation_requirements": [
+            "source_manifest_defined",
+            "license_reviewed",
+            "identity_mapping_quality_gate",
+        ],
+        "operator_notes": "High-value identity context candidate for EU listings; not a factor field source.",
+    },
+    {
+        "provider_id": "financial_datasets_mcp",
+        "provider_name": "Financial Datasets MCP",
+        "provider_category": "connector_candidate",
+        "source_status": "staging",
+        "allowed_use": [
+            "connector_discovery",
+            "source_candidate_research",
+            "operator_explanation",
+        ],
+        "forbidden_use": list(FORBIDDEN_USE),
+        "asset_coverage": ["unknown_until_manifested"],
+        "region_coverage": ["unknown_until_manifested"],
+        "factor_field_coverage_potential": ["unknown_until_manifested"],
+        "point_in_time_support": "unknown",
+        "restatement_history_support": "unknown",
+        "report_lag_support": "unknown",
+        "currency_normalization_support": "unknown",
+        "authentication_required": "unknown",
+        "cost_model": "unknown",
+        "license_terms_status": "unknown",
+        "license_terms_reference": "operator_manifest_required",
+        "expected_freshness": "unknown",
+        "expected_latency": "unknown",
+        "implementation_priority": 12,
+        "risk_level": "medium",
+        "known_limitations": [
+            "connector_only",
+            "no_license_review",
+            "no_source_manifest",
+        ],
+        "required_quality_gates": [
+            "source_manifest_defined",
+            "license_reviewed",
+            "connector_contract_reviewed",
+        ],
+        "activation_requirements": list(ACTIVE_READ_ONLY_REQUIREMENTS),
+        "operator_notes": "Staging only. Connector discovery does not imply data trust or source authority.",
+    },
+    {
+        "provider_id": "financial_modeling_prep_candidate",
+        "provider_name": "Financial Modeling Prep",
+        "provider_category": "fundamental_api_candidate",
+        "source_status": "candidate",
+        "allowed_use": [
+            "source_candidate_research",
+            "fundamental_field_candidate",
+            "operator_explanation",
+        ],
+        "forbidden_use": list(FORBIDDEN_USE),
+        "asset_coverage": ["equities", "etfs"],
+        "region_coverage": ["US", "Europe", "Asia", "Global"],
+        "factor_field_coverage_potential": [
+            "income_statement_ready",
+            "balance_sheet_ready",
+            "cash_flow_statement_ready",
+            "enterprise_value_ready",
+            "price_history_complete",
+        ],
+        "point_in_time_support": "unknown",
+        "restatement_history_support": "unknown",
+        "report_lag_support": "unknown",
+        "currency_normalization_support": "unknown",
+        "authentication_required": True,
+        "cost_model": "freemium_or_paid_candidate",
+        "license_terms_status": "manual_review_required",
+        "license_terms_reference": "provider_public_terms_reference_required",
+        "expected_freshness": "vendor_defined_unknown",
+        "expected_latency": "api_latency_unknown",
+        "implementation_priority": 5,
+        "risk_level": "medium",
+        "known_limitations": [
+            "license_terms_not_reviewed",
+            "point_in_time_semantics_unknown",
+            "restatement_support_unknown",
+        ],
+        "required_quality_gates": [
+            "source_manifest_defined",
+            "license_reviewed",
+            "point_in_time_policy_defined",
+            "field_coverage_manifest_defined",
+        ],
+        "activation_requirements": list(ACTIVE_READ_ONLY_REQUIREMENTS),
+        "operator_notes": "Candidate only. No API integration or key management in this PR.",
+    },
+    {
+        "provider_id": "nasdaq_listings_metadata",
+        "provider_name": "Nasdaq Listings Metadata",
+        "provider_category": "exchange_metadata_candidate",
+        "source_status": "candidate",
+        "allowed_use": [
+            "source_candidate_research",
+            "identity_mapping",
+            "metadata_context",
+            "operator_explanation",
+        ],
+        "forbidden_use": list(FORBIDDEN_USE),
+        "asset_coverage": ["us_listings_metadata"],
+        "region_coverage": ["United States"],
+        "factor_field_coverage_potential": ["listing_metadata", "issuer_metadata", "venue_context"],
+        "point_in_time_support": "metadata_only",
+        "restatement_history_support": "not_applicable",
+        "report_lag_support": "not_applicable",
+        "currency_normalization_support": "metadata_only",
+        "authentication_required": False,
+        "cost_model": "public_metadata_candidate",
+        "license_terms_status": "manual_review_required",
+        "license_terms_reference": "nasdaq_public_terms_manual_review_required",
+        "expected_freshness": "listing_file_schedule_unknown",
+        "expected_latency": "manual_or_http_metadata",
+        "implementation_priority": 4,
+        "risk_level": "low",
+        "known_limitations": [
+            "metadata_not_fundamentals",
+            "license_terms_not_reviewed",
+        ],
+        "required_quality_gates": [
+            "source_manifest_defined",
+            "license_reviewed",
+            "identity_mapping_quality_gate",
+        ],
+        "activation_requirements": [
+            "source_manifest_defined",
+            "license_reviewed",
+            "identity_mapping_quality_gate",
+        ],
+        "operator_notes": "Useful for US symbology/listing metadata only; not a valuation source.",
+    },
+    {
+        "provider_id": "nyse_listings_metadata",
+        "provider_name": "NYSE Listings Metadata",
+        "provider_category": "exchange_metadata_candidate",
+        "source_status": "candidate",
+        "allowed_use": [
+            "source_candidate_research",
+            "identity_mapping",
+            "metadata_context",
+            "operator_explanation",
+        ],
+        "forbidden_use": list(FORBIDDEN_USE),
+        "asset_coverage": ["us_listings_metadata"],
+        "region_coverage": ["United States"],
+        "factor_field_coverage_potential": ["listing_metadata", "issuer_metadata", "venue_context"],
+        "point_in_time_support": "metadata_only",
+        "restatement_history_support": "not_applicable",
+        "report_lag_support": "not_applicable",
+        "currency_normalization_support": "metadata_only",
+        "authentication_required": False,
+        "cost_model": "public_metadata_candidate",
+        "license_terms_status": "manual_review_required",
+        "license_terms_reference": "nyse_public_terms_manual_review_required",
+        "expected_freshness": "listing_file_schedule_unknown",
+        "expected_latency": "manual_or_http_metadata",
+        "implementation_priority": 4,
+        "risk_level": "low",
+        "known_limitations": [
+            "metadata_not_fundamentals",
+            "license_terms_not_reviewed",
+        ],
+        "required_quality_gates": [
+            "source_manifest_defined",
+            "license_reviewed",
+            "identity_mapping_quality_gate",
+        ],
+        "activation_requirements": [
+            "source_manifest_defined",
+            "license_reviewed",
+            "identity_mapping_quality_gate",
+        ],
+        "operator_notes": "Useful for US venue metadata only; no trust assignment to fundamentals.",
+    },
+    {
+        "provider_id": "openbb_connector",
+        "provider_name": "OpenBB",
+        "provider_category": "connector_candidate",
+        "source_status": "staging",
+        "allowed_use": [
+            "connector_discovery",
+            "source_candidate_research",
+            "operator_explanation",
+        ],
+        "forbidden_use": list(FORBIDDEN_USE),
+        "asset_coverage": ["multi_asset_connector_surface"],
+        "region_coverage": ["Global"],
+        "factor_field_coverage_potential": ["connector_surface_only"],
+        "point_in_time_support": "unknown",
+        "restatement_history_support": "unknown",
+        "report_lag_support": "unknown",
+        "currency_normalization_support": "unknown",
+        "authentication_required": "unknown",
+        "cost_model": "connector_only_unknown",
+        "license_terms_status": "unknown",
+        "license_terms_reference": "operator_manifest_required",
+        "expected_freshness": "depends_on_downstream_provider",
+        "expected_latency": "depends_on_downstream_provider",
+        "implementation_priority": 13,
+        "risk_level": "medium",
+        "known_limitations": [
+            "connector_only",
+            "not_a_trusted_source",
+            "downstream_license_status_unknown",
+        ],
+        "required_quality_gates": [
+            "source_manifest_defined",
+            "license_reviewed",
+            "downstream_provider_manifest_defined",
+        ],
+        "activation_requirements": list(ACTIVE_READ_ONLY_REQUIREMENTS),
+        "operator_notes": "Staging only. Connector indirection cannot bypass source manifest and licensing policy.",
+    },
+    {
+        "provider_id": "openfigi_symbology",
+        "provider_name": "OpenFIGI",
+        "provider_category": "symbology_candidate",
+        "source_status": "candidate",
+        "allowed_use": [
+            "source_candidate_research",
+            "identity_mapping",
+            "metadata_context",
+            "operator_explanation",
+        ],
+        "forbidden_use": list(FORBIDDEN_USE),
+        "asset_coverage": ["equities", "etfs", "multi_listing_symbology"],
+        "region_coverage": ["Global"],
+        "factor_field_coverage_potential": ["identity_only_not_fundamentals"],
+        "point_in_time_support": "identity_only",
+        "restatement_history_support": "not_applicable",
+        "report_lag_support": "not_applicable",
+        "currency_normalization_support": "metadata_only",
+        "authentication_required": False,
+        "cost_model": "public_or_limited_use_candidate",
+        "license_terms_status": "manual_review_required",
+        "license_terms_reference": "openfigi_terms_manual_review_required",
+        "expected_freshness": "symbology_reference_schedule_unknown",
+        "expected_latency": "api_or_manual_lookup_unknown",
+        "implementation_priority": 2,
+        "risk_level": "low",
+        "known_limitations": [
+            "not_a_fundamental_source",
+            "symbology_only",
+        ],
+        "required_quality_gates": [
+            "source_manifest_defined",
+            "license_reviewed",
+            "identity_mapping_quality_gate",
+        ],
+        "activation_requirements": [
+            "source_manifest_defined",
+            "license_reviewed",
+            "identity_mapping_quality_gate",
+        ],
+        "operator_notes": "High-priority symbology candidate. Useful for canonical identity, not for factor fields.",
+    },
+    {
+        "provider_id": "sec_companyfacts",
+        "provider_name": "SEC EDGAR Company Facts",
+        "provider_category": "public_fundamental_filings",
+        "source_status": "candidate",
+        "allowed_use": [
+            "source_candidate_research",
+            "fundamental_field_candidate",
+            "metadata_context",
+            "operator_explanation",
+        ],
+        "forbidden_use": list(FORBIDDEN_USE),
+        "asset_coverage": ["us_equities"],
+        "region_coverage": ["United States"],
+        "factor_field_coverage_potential": [
+            "income_statement_ready",
+            "balance_sheet_ready",
+            "cash_flow_statement_ready",
+            "multi_period_fundamentals",
+        ],
+        "point_in_time_support": "candidate_with_policy_required",
+        "restatement_history_support": "candidate_with_policy_required",
+        "report_lag_support": "candidate_with_policy_required",
+        "currency_normalization_support": "mostly_usd_but_policy_required",
+        "authentication_required": False,
+        "cost_model": "public_access_candidate",
+        "license_terms_status": "public_source_review_required",
+        "license_terms_reference": "sec_edgar_terms_manual_review_required",
+        "expected_freshness": "filing_driven",
+        "expected_latency": "public_endpoint_latency_unknown",
+        "implementation_priority": 1,
+        "risk_level": "low",
+        "known_limitations": [
+            "us_only",
+            "point_in_time_policy_not_defined",
+            "restatement_policy_not_defined",
+        ],
+        "required_quality_gates": [
+            "source_manifest_defined",
+            "license_reviewed",
+            "point_in_time_policy_defined",
+            "report_lag_policy_defined",
+            "restatement_policy_defined",
+            "field_coverage_manifest_defined",
+        ],
+        "activation_requirements": list(ACTIVE_READ_ONLY_REQUIREMENTS),
+        "operator_notes": "Highest-priority public candidate for US fundamentals, but still untrusted until full source-manifest and policy gates exist.",
+    },
+    {
+        "provider_id": "stooq_price_context",
+        "provider_name": "Stooq",
+        "provider_category": "public_price_context",
+        "source_status": "manual_research_only",
+        "allowed_use": [
+            "manual_research_context",
+            "metadata_context",
+            "operator_explanation",
+        ],
+        "forbidden_use": list(FORBIDDEN_USE),
+        "asset_coverage": ["public_price_context"],
+        "region_coverage": ["Europe", "US", "Global"],
+        "factor_field_coverage_potential": ["price_context_only"],
+        "point_in_time_support": "unknown",
+        "restatement_history_support": "not_applicable",
+        "report_lag_support": "not_applicable",
+        "currency_normalization_support": "unknown",
+        "authentication_required": False,
+        "cost_model": "public_manual_research",
+        "license_terms_status": "manual_review_required",
+        "license_terms_reference": "stooq_terms_manual_review_required",
+        "expected_freshness": "unknown",
+        "expected_latency": "manual_lookup",
+        "implementation_priority": 14,
+        "risk_level": "low",
+        "known_limitations": [
+            "not_a_fundamental_source",
+            "manual_context_only",
+        ],
+        "required_quality_gates": [
+            "source_manifest_defined",
+            "license_reviewed",
+        ],
+        "activation_requirements": [
+            "operator_manual_review",
+            "source_manifest_defined",
+        ],
+        "operator_notes": "Only relevant as manual price context. It does not address fundamental field coverage.",
+    },
+    {
+        "provider_id": "yahoo_finance_yfinance",
+        "provider_name": "Yahoo Finance / yfinance",
+        "provider_category": "public_convenience_dataset",
+        "source_status": "manual_research_only",
+        "allowed_use": [
+            "manual_research_context",
+            "metadata_context",
+            "operator_explanation",
+        ],
+        "forbidden_use": list(FORBIDDEN_USE),
+        "asset_coverage": ["equities", "etfs", "price_context"],
+        "region_coverage": ["Global"],
+        "factor_field_coverage_potential": ["convenience_only_untrusted"],
+        "point_in_time_support": "unknown",
+        "restatement_history_support": "unknown",
+        "report_lag_support": "unknown",
+        "currency_normalization_support": "unknown",
+        "authentication_required": False,
+        "cost_model": "public_convenience_candidate",
+        "license_terms_status": "licensing_warning",
+        "license_terms_reference": "manual_license_review_required_before_any_manifest",
+        "expected_freshness": "unknown",
+        "expected_latency": "library_dependent",
+        "implementation_priority": 15,
+        "risk_level": "high",
+        "known_limitations": [
+            "licensing_uncertainty",
+            "point_in_time_semantics_unknown",
+            "restatement_semantics_unknown",
+        ],
+        "required_quality_gates": [
+            "license_reviewed",
+            "source_manifest_defined",
+            "point_in_time_policy_defined",
+        ],
+        "activation_requirements": list(ACTIVE_READ_ONLY_REQUIREMENTS),
+        "operator_notes": "Manual-research-only with explicit licensing warning. Not trusted for gated factor evaluation.",
+    },
+)
+
+
+def validate_provider_rows(rows: list[dict[str, object]] | tuple[dict[str, object], ...]) -> list[dict[str, object]]:
+    validated: list[dict[str, object]] = []
+    seen_provider_ids: set[str] = set()
+    for row in rows:
+        provider_id = str(row["provider_id"])
+        if provider_id in seen_provider_ids:
+            raise ValueError(f"duplicate provider_id: {provider_id}")
+        seen_provider_ids.add(provider_id)
+        status = str(row["source_status"])
+        if status not in SOURCE_STATUS_VOCABULARY:
+            raise ValueError(f"invalid source_status for {provider_id}: {status}")
+        allowed_use = [str(item) for item in row["allowed_use"]]
+        for item in allowed_use:
+            if item not in ALLOWED_USE_VOCABULARY:
+                raise ValueError(f"invalid allowed_use for {provider_id}: {item}")
+        forbidden_use = [str(item) for item in row["forbidden_use"]]
+        missing_forbidden = sorted(set(FORBIDDEN_USE) - set(forbidden_use))
+        if missing_forbidden:
+            raise ValueError(f"{provider_id} missing forbidden_use entries: {missing_forbidden}")
+        license_status = str(row["license_terms_status"])
+        if license_status in {"unknown", "manual_review_required", "licensing_warning", "public_source_review_required"}:
+            if status in {"quality_gated", "active_read_only"}:
+                raise ValueError(
+                    f"{provider_id} cannot be {status} while license_terms_status={license_status}"
+                )
+        point_in_time_support = str(row["point_in_time_support"])
+        if point_in_time_support == "unknown" and status == "active_read_only":
+            raise ValueError(f"{provider_id} cannot be active_read_only with unknown point_in_time_support")
+        if status == "active_read_only":
+            activation_requirements = {str(item) for item in row["activation_requirements"]}
+            missing_requirements = sorted(set(ACTIVE_READ_ONLY_REQUIREMENTS) - activation_requirements)
+            if missing_requirements:
+                raise ValueError(
+                    f"{provider_id} missing active_read_only requirements: {missing_requirements}"
+                )
+        validated.append(
+            {
+                **row,
+                "allowed_use": sorted(allowed_use),
+                "forbidden_use": list(FORBIDDEN_USE),
+                "asset_coverage": sorted(str(item) for item in row["asset_coverage"]),
+                "region_coverage": sorted(str(item) for item in row["region_coverage"]),
+                "factor_field_coverage_potential": sorted(
+                    str(item) for item in row["factor_field_coverage_potential"]
+                ),
+                "known_limitations": sorted(str(item) for item in row["known_limitations"]),
+                "required_quality_gates": sorted(str(item) for item in row["required_quality_gates"]),
+                "activation_requirements": sorted(str(item) for item in row["activation_requirements"]),
+            }
+        )
+    validated.sort(key=lambda item: str(item["provider_id"]))
+    return validated
+
+
+def build_fundamental_provider_registry() -> dict[str, object]:
+    rows = validate_provider_rows(PROVIDER_ROWS)
+    status_counts = Counter(str(row["source_status"]) for row in rows)
+    priority_rows = sorted(
+        rows,
+        key=lambda item: (
+            int(item["implementation_priority"]),
+            str(item["risk_level"]),
+            str(item["provider_id"]),
+        ),
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "source_status_vocabulary": list(SOURCE_STATUS_VOCABULARY),
+        "allowed_use_vocabulary": list(ALLOWED_USE_VOCABULARY),
+        "forbidden_use_vocabulary": list(FORBIDDEN_USE),
+        "summary": {
+            "total_providers": len(rows),
+            "candidate_count": status_counts.get("candidate", 0),
+            "manual_research_only_count": status_counts.get("manual_research_only", 0),
+            "staging_count": status_counts.get("staging", 0),
+            "quality_gated_count": status_counts.get("quality_gated", 0),
+            "active_read_only_count": status_counts.get("active_read_only", 0),
+            "deprecated_count": status_counts.get("deprecated", 0),
+            "blocked_count": status_counts.get("blocked", 0),
+            "highest_priority_candidates": [
+                {
+                    "provider_id": row["provider_id"],
+                    "provider_name": row["provider_name"],
+                    "source_status": row["source_status"],
+                    "implementation_priority": row["implementation_priority"],
+                    "reason": row["operator_notes"],
+                }
+                for row in priority_rows[:5]
+            ],
+            "operator_summary": (
+                "Provider registry is research-only candidate governance. "
+                "No data has been fetched, no provider is trusted by default, and no source becomes active without "
+                "license review, source manifests, quality gates, and point-in-time policy."
+            ),
+        },
+        "rows": rows,
+        "safety_invariants": {
+            "research_only": True,
+            "not_trade_signal": True,
+            "no_data_fetch": True,
+            "no_api_integration": True,
+            "no_vendor_activation": True,
+            "mutates_registry": False,
+            "mutates_frozen_contracts": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+        },
+    }

--- a/research/qre_fundamental_provider_report.py
+++ b/research/qre_fundamental_provider_report.py
@@ -1,0 +1,139 @@
+"""Read-only operator report for the fundamental provider candidate registry."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Final
+
+from research.external_intelligence.fundamental_provider_registry import (
+    build_fundamental_provider_registry,
+)
+
+
+REPO_ROOT: Final[Path] = Path(".")
+OUTPUT_DIR: Final[Path] = Path("artifacts/external_intelligence")
+MD_NAME: Final[str] = "fundamental_provider_operator_report_latest.md"
+WRITE_PREFIX: Final[str] = "artifacts/external_intelligence/"
+DISCLAIMER: Final[str] = (
+    "Research-only provider registry. No data has been fetched, no API integration was activated, "
+    "and no provider is trusted or active by default."
+)
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(f"qre_fundamental_provider_report: refusing write outside allowlist: {path!r}")
+
+
+def _write_text(path: Path, content: str) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(content, encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def collect_snapshot() -> dict[str, object]:
+    registry = build_fundamental_provider_registry()
+    rows = registry["rows"]
+    by_status: dict[str, list[dict[str, object]]] = {}
+    for row in rows:
+        by_status.setdefault(str(row["source_status"]), []).append(row)
+    for items in by_status.values():
+        items.sort(key=lambda item: (int(item["implementation_priority"]), str(item["provider_id"])))
+    return {
+        "report_kind": "qre_fundamental_provider_report",
+        "schema_version": "1.0",
+        "disclaimer": DISCLAIMER,
+        "summary": registry["summary"],
+        "providers_by_status": {
+            key: [
+                {
+                    "provider_id": row["provider_id"],
+                    "provider_name": row["provider_name"],
+                    "provider_category": row["provider_category"],
+                    "implementation_priority": row["implementation_priority"],
+                    "risk_level": row["risk_level"],
+                    "license_terms_status": row["license_terms_status"],
+                }
+                for row in items
+            ]
+            for key, items in sorted(by_status.items())
+        },
+        "highest_priority_candidates": registry["summary"]["highest_priority_candidates"],
+        "all_provider_ids": [str(row["provider_id"]) for row in rows],
+        "safety_invariants": registry["safety_invariants"],
+    }
+
+
+def render_markdown(snapshot: dict[str, object]) -> str:
+    summary = snapshot["summary"]
+    lines = [
+        "# QRE Fundamental Provider Candidate Registry",
+        "",
+        DISCLAIMER,
+        "",
+        "## Status Counts",
+        f"- total providers: {summary['total_providers']}",
+        f"- candidate: {summary['candidate_count']}",
+        f"- manual_research_only: {summary['manual_research_only_count']}",
+        f"- staging: {summary['staging_count']}",
+        f"- quality_gated: {summary['quality_gated_count']}",
+        f"- active_read_only: {summary['active_read_only_count']}",
+        f"- deprecated: {summary['deprecated_count']}",
+        f"- blocked: {summary['blocked_count']}",
+        "",
+        "## Highest Priority Candidates",
+    ]
+    for row in snapshot["highest_priority_candidates"]:
+        lines.append(
+            f"- {row['provider_id']}: priority {row['implementation_priority']} [{row['source_status']}] - {row['reason']}"
+        )
+    lines.extend(["", "## Providers By Status"])
+    for status, rows in snapshot["providers_by_status"].items():
+        lines.append(f"### {status}")
+        for row in rows:
+            lines.append(
+                f"- {row['provider_id']}: {row['provider_name']} ({row['provider_category']}, license={row['license_terms_status']}, risk={row['risk_level']})"
+            )
+    lines.extend(
+        [
+            "",
+            "## Safety",
+            "- No buy/sell recommendations",
+            "- No trade signals",
+            "- No strategy registration",
+            "- No paper/shadow/live activation",
+            "- No broker/risk/execution authority",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def write_outputs(*, repo_root: Path = REPO_ROOT, output_dir: Path = OUTPUT_DIR) -> dict[str, str]:
+    base = repo_root / output_dir
+    base.mkdir(parents=True, exist_ok=True)
+    md_path = base / MD_NAME
+    _validate_write_target(md_path)
+    _write_text(md_path, render_markdown(collect_snapshot()))
+    return {"markdown": md_path.relative_to(repo_root).as_posix()}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_fundamental_provider_report",
+        description="Write read-only fundamental provider registry operator report.",
+    )
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    snapshot = collect_snapshot()
+    payload = {"report": snapshot, "markdown": render_markdown(snapshot)}
+    if args.write:
+        payload["_artifact_paths"] = write_outputs()
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/unit/test_fundamental_provider_manifest.py
+++ b/tests/unit/test_fundamental_provider_manifest.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from research.external_intelligence import fundamental_provider_manifest as manifest
+
+
+def test_manifest_writes_expected_sidecars(tmp_path: Path) -> None:
+    paths = manifest.write_outputs(repo_root=tmp_path)
+    candidates = json.loads((tmp_path / paths["candidates"]).read_text(encoding="utf-8"))
+    summary = json.loads((tmp_path / paths["summary"]).read_text(encoding="utf-8"))
+    assert candidates["report_kind"] == "fundamental_provider_candidates"
+    assert summary["report_kind"] == "fundamental_provider_summary"
+
+
+def test_manifest_summary_matches_registry_counts() -> None:
+    payload = manifest.build_fundamental_provider_summary(
+        manifest.build_fundamental_provider_registry()
+    )
+    assert payload["summary"]["total_providers"] >= 10
+    assert payload["summary"]["active_read_only"] == 0

--- a/tests/unit/test_fundamental_provider_registry.py
+++ b/tests/unit/test_fundamental_provider_registry.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import pytest
+
+from research.external_intelligence import fundamental_provider_registry as registry
+
+
+def test_provider_registry_is_deterministic_and_conservative() -> None:
+    left = registry.build_fundamental_provider_registry()
+    right = registry.build_fundamental_provider_registry()
+    assert left == right
+    assert left["summary"]["total_providers"] >= 10
+    assert left["summary"]["active_read_only_count"] == 0
+    assert left["summary"]["quality_gated_count"] == 0
+    assert left["safety_invariants"]["no_data_fetch"] is True
+
+
+def test_provider_registry_contains_required_candidates() -> None:
+    payload = registry.build_fundamental_provider_registry()
+    provider_ids = {row["provider_id"] for row in payload["rows"]}
+    assert "openfigi_symbology" in provider_ids
+    assert "sec_companyfacts" in provider_ids
+    assert "yahoo_finance_yfinance" in provider_ids
+    assert "openbb_connector" in provider_ids
+
+
+def test_unknown_license_cannot_be_active_read_only() -> None:
+    bad_row = {
+        **registry.PROVIDER_ROWS[0],
+        "provider_id": "bad_provider",
+        "source_status": "active_read_only",
+        "license_terms_status": "unknown",
+    }
+    with pytest.raises(ValueError, match="cannot be active_read_only"):
+        registry.validate_provider_rows([bad_row])
+
+
+def test_forbidden_use_is_complete_for_all_rows() -> None:
+    payload = registry.build_fundamental_provider_registry()
+    for row in payload["rows"]:
+        assert row["forbidden_use"] == list(registry.FORBIDDEN_USE)

--- a/tests/unit/test_qre_fundamental_provider_report.py
+++ b/tests/unit/test_qre_fundamental_provider_report.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from research import qre_fundamental_provider_report as report
+
+
+def test_provider_report_is_deterministic_and_contains_disclaimer() -> None:
+    left = report.collect_snapshot()
+    right = report.collect_snapshot()
+    assert left == right
+    assert "No data has been fetched" in left["disclaimer"]
+    assert left["summary"]["total_providers"] >= 10
+
+
+def test_provider_report_writes_markdown(tmp_path: Path) -> None:
+    paths = report.write_outputs(repo_root=tmp_path)
+    markdown = (tmp_path / paths["markdown"]).read_text(encoding="utf-8")
+    assert "QRE Fundamental Provider Candidate Registry" in markdown
+    assert "No trade signals" in markdown


### PR DESCRIPTION
## Summary
- add a deterministic research-only fundamental data provider candidate registry under `research/external_intelligence/`
- write read-only provider candidate and summary sidecars plus an operator-readable Markdown report
- keep all providers conservative: no fetching, no integrations, no trusted activation, and no change to recipe/seed/evaluation feasibility

## Why
The current equity research front door is fail-closed on source-manifest and provider-policy blockers:
- `MISSING_SOURCE_MANIFEST`
- `SOURCE_LICENSE_UNKNOWN`
- `SOURCE_QUALITY_UNKNOWN`
- `MISSING_POINT_IN_TIME_POLICY`
- `MISSING_REPORT_LAG_POLICY`
- `MISSING_RESTATEMENT_POLICY`

This PR starts the provider-selection layer without activating any source.

## What Changed
- added `research/external_intelligence/fundamental_provider_registry.py`
- added `research/external_intelligence/fundamental_provider_manifest.py`
- added `research/qre_fundamental_provider_report.py`
- added tests for registry, manifest, and report
- generated:
  - `artifacts/external_intelligence/fundamental_provider_candidates_latest.v1.json`
  - `artifacts/external_intelligence/fundamental_provider_summary_latest.v1.json`
  - `artifacts/external_intelligence/fundamental_provider_operator_report_latest.md`

## Safety Constraints Honored
- no data fetched
- no API integrations added
- no paid/vendor dependency activated
- no recipe feasibility unlocked
- no hypothesis seed feasibility unlocked
- no controlled evaluation readiness unlocked
- no strategy registration
- no paper/shadow/live activation
- no broker/risk/execution changes
- no frozen contract mutation

## Tests Run
- `python -m pytest tests/unit/test_fundamental_provider_registry.py -q`
- `python -m pytest tests/unit/test_fundamental_provider_manifest.py -q`
- `python -m pytest tests/unit/test_qre_fundamental_provider_report.py -q`
- `python -m pytest tests/unit/test_fundamental_readiness.py -q`
- `python -m pytest tests/unit/test_factor_field_coverage.py -q`
- `python -m pytest tests/unit/test_equity_factor_hypothesis_adapter.py -q`
- `python -m pytest tests/unit/test_controlled_factor_evaluation.py -q`
- `python -m pytest tests/architecture -q`
- `python -m pytest tests -q -k "governance or no_touch or frozen_contract or execution_authority"`
- `git diff --check`
- `git diff -- research/research_latest.json research/strategy_matrix.csv`

## Known Limitations
- every provider remains `candidate`, `manual_research_only`, or `staging`
- `quality_gated` and `active_read_only` remain zero by design
- this PR does not define source manifests yet
- this PR does not define point-in-time/report-lag/restatement policy yet

## Next Recommended Action
- continue with source manifest schema and license policy
