### PR TITLE
fix: add QRE research ontology, entity, and retrieval scaffolds

### DIFF
--- a/research/qre_entity_resolution.py
+++ b/research/qre_entity_resolution.py
@@ -1,0 +1,175 @@
+"""Deterministic QRE entity resolution scaffold.
+
+This module provides lightweight, fail-closed entity classification for research
+memory entries. It does not establish truth authority, does not override source
+identity gates, and does not authorize candidate promotion or execution.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Iterable
+
+
+SCHEMA_VERSION = "1.0"
+
+
+ENTITY_TYPES: tuple[str, ...] = (
+    "asset",
+    "provider",
+    "source",
+    "factor",
+    "recipe",
+    "universe",
+    "basket",
+    "campaign",
+    "candidate",
+    "hypothesis",
+    "artifact",
+    "policy",
+    "diagnostic",
+    "unknown",
+)
+
+
+CRYPTO_SYMBOLS: tuple[str, ...] = (
+    "BTC-USD",
+    "ETH-USD",
+    "SOL-USD",
+    "ADA-USD",
+    "DOGE-USD",
+    "XRP-USD",
+    "BNB-USD",
+    "AVAX-USD",
+    "MATIC-USD",
+    "DOT-USD",
+)
+
+
+PROVIDER_MARKERS: dict[str, str] = {
+    "sec_companyfacts": "provider:sec_companyfacts",
+    "companyfacts": "provider:sec_companyfacts",
+    "openfigi": "provider:openfigi_symbology",
+    "euronext": "provider:euronext_issuer_metadata",
+    "nasdaq": "provider:nasdaq_listings_metadata",
+    "nyse": "provider:nyse_listings_metadata",
+    "yfinance": "provider:yfinance_context",
+    "yahoo": "provider:yfinance_context",
+}
+
+
+@dataclass(frozen=True)
+class ResolvedEntity:
+    entity_id: str
+    entity_type: str
+    label: str
+    confidence: str
+    ambiguity_status: str
+    evidence: tuple[str, ...]
+
+
+def _combined_text(*parts: str) -> str:
+    return " ".join(part for part in parts if part)
+
+
+def _add_unique(entities: list[ResolvedEntity], entity: ResolvedEntity) -> None:
+    existing_ids = {item.entity_id for item in entities}
+    if entity.entity_id not in existing_ids:
+        entities.append(entity)
+
+
+def resolve_entities_from_text(
+    *,
+    title: str = "",
+    artifact_path: str = "",
+    text_preview: str = "",
+    ontology_tags: Iterable[str] | None = None,
+) -> tuple[ResolvedEntity, ...]:
+    """Resolve deterministic entities from research-memory text.
+
+    Resolution is intentionally conservative. Ambiguity remains visible and no
+    resolved entity becomes source-of-truth authority.
+    """
+
+    text = _combined_text(title, artifact_path, text_preview)
+    lower_text = text.lower()
+    entities: list[ResolvedEntity] = []
+
+    for symbol in CRYPTO_SYMBOLS:
+        if symbol.lower() in lower_text:
+            _add_unique(
+                entities,
+                ResolvedEntity(
+                    entity_id=f"asset:{symbol}",
+                    entity_type="asset",
+                    label=symbol,
+                    confidence="HIGH",
+                    ambiguity_status="resolved",
+                    evidence=(f"matched_symbol:{symbol}",),
+                ),
+            )
+
+    for marker, entity_id in PROVIDER_MARKERS.items():
+        if marker in lower_text:
+            _add_unique(
+                entities,
+                ResolvedEntity(
+                    entity_id=entity_id,
+                    entity_type="provider",
+                    label=entity_id.split(":", 1)[1],
+                    confidence="MEDIUM",
+                    ambiguity_status="resolved",
+                    evidence=(f"matched_marker:{marker}",),
+                ),
+            )
+
+    artifact_match = re.search(
+        r"(research/[^\s]+|artifacts/[^\s]+|logs/[^\s]+|docs/[^\s]+)",
+        text,
+    )
+    if artifact_match:
+        artifact_path_match = artifact_match.group(1).rstrip(".,)")
+        _add_unique(
+            entities,
+            ResolvedEntity(
+                entity_id=f"artifact:{artifact_path_match}",
+                entity_type="artifact",
+                label=artifact_path_match,
+                confidence="HIGH",
+                ambiguity_status="resolved",
+                evidence=(f"matched_artifact_path:{artifact_path_match}",),
+            ),
+        )
+
+    if ontology_tags:
+        for tag in sorted(set(ontology_tags)):
+            if tag in {"policy", "policy_action"}:
+                _add_unique(
+                    entities,
+                    ResolvedEntity(
+                        entity_id=f"policy:{tag}",
+                        entity_type="policy",
+                        label=tag,
+                        confidence="LOW",
+                        ambiguity_status="unresolved",
+                        evidence=(f"ontology_tag:{tag}",),
+                    ),
+                )
+
+    return tuple(entities)
+
+
+def entity_resolution_manifest() -> dict[str, object]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "entity_types": list(ENTITY_TYPES),
+        "authority": {
+            "entity_resolution_is_context_only": True,
+            "not_source_identity_authority": True,
+            "does_not_override_identity_gates": True,
+            "not_candidate_promotion": True,
+            "not_paper_shadow_live": True,
+            "not_broker_execution": True,
+        },
+    }

--- a/research/qre_research_memory_coverage.py
+++ b/research/qre_research_memory_coverage.py
@@ -12,6 +12,7 @@ from typing import Any, Final
 from research import qre_failure_action_from_basket as failure_action
 from research import qre_reason_records_v1 as reason_records
 from research import qre_real_basket_diagnosis as basket_diagnosis
+from research.qre_entity_resolution import resolve_entities_from_text
 from research.qre_research_ontology import classify_research_text
 
 
@@ -86,6 +87,12 @@ def _memory_entry(
         ontology_tags=ontology_tags,
         text_preview=text_preview,
     )
+    resolved_entities = resolve_entities_from_text(
+        title=title,
+        artifact_path=artifact_id,
+        text_preview=text_preview,
+        ontology_tags=classification.ontology_tags,
+    )
     return {
         "artifact_id": artifact_id,
         "record_kind": record_kind,
@@ -101,6 +108,17 @@ def _memory_entry(
             "blocker_classes": list(classification.blocker_classes),
             "explanation": classification.explanation,
         },
+        "resolved_entities": [
+            {
+                "entity_id": entity.entity_id,
+                "entity_type": entity.entity_type,
+                "label": entity.label,
+                "confidence": entity.confidence,
+                "ambiguity_status": entity.ambiguity_status,
+                "evidence": list(entity.evidence),
+            }
+            for entity in resolved_entities
+        ],
         "text_preview": text_preview[:280],
     }
 

--- a/research/qre_research_memory_coverage.py
+++ b/research/qre_research_memory_coverage.py
@@ -12,6 +12,7 @@ from typing import Any, Final
 from research import qre_failure_action_from_basket as failure_action
 from research import qre_reason_records_v1 as reason_records
 from research import qre_real_basket_diagnosis as basket_diagnosis
+from research.qre_research_ontology import classify_research_text
 
 
 MEMORY_REPORT_KIND: Final[str] = "qre_research_memory_coverage"
@@ -45,6 +46,30 @@ def _digest(payload: Mapping[str, Any]) -> str:
     return "sha256:" + hashlib.sha256(blob.encode("utf-8")).hexdigest()
 
 
+def _ontology_tags_for_record(*, record_kind: str, metadata: Mapping[str, Any]) -> tuple[str, ...]:
+    tags: set[str] = {"data_readiness", "evidence"}
+
+    if record_kind == "basket":
+        tags.update({"basket", "candidate", "diagnostic"})
+    elif record_kind == "failure_action":
+        tags.update({"failure", "policy_action", "readiness"})
+    elif record_kind == "reason_record":
+        tags.update({"diagnostic", "retrieval"})
+
+    if metadata.get("symbol"):
+        tags.add("identity")
+    if metadata.get("preset_id"):
+        tags.add("strategy_context")
+    if metadata.get("hypothesis_id"):
+        tags.add("hypothesis")
+    if metadata.get("blocker_code"):
+        tags.add("failure")
+    if metadata.get("reason_code") or metadata.get("reason_codes"):
+        tags.add("diagnostic")
+
+    return tuple(sorted(tags))
+
+
 def _memory_entry(
     *,
     artifact_id: str,
@@ -54,6 +79,13 @@ def _memory_entry(
     text_preview: str,
     metadata: Mapping[str, Any],
 ) -> dict[str, Any]:
+    ontology_tags = _ontology_tags_for_record(record_kind=record_kind, metadata=metadata)
+    classification = classify_research_text(
+        title=title,
+        artifact_path=artifact_id,
+        ontology_tags=ontology_tags,
+        text_preview=text_preview,
+    )
     return {
         "artifact_id": artifact_id,
         "record_kind": record_kind,
@@ -61,6 +93,14 @@ def _memory_entry(
         "title": title,
         "keywords": _tokenize(title, text_preview, metadata),
         "metadata": dict(sorted(metadata.items())),
+        "ontology_tags": list(classification.ontology_tags),
+        "ontology_classification": {
+            "asset_class": classification.asset_class,
+            "research_scope": classification.research_scope,
+            "readiness_state": classification.readiness_state,
+            "blocker_classes": list(classification.blocker_classes),
+            "explanation": classification.explanation,
+        },
         "text_preview": text_preview[:280],
     }
 
@@ -167,6 +207,23 @@ def build_research_memory_coverage(
 
     entries.sort(key=lambda row: (str(row["record_kind"]), str(row["artifact_id"])))
     kind_counts = Counter(str(row["record_kind"]) for row in entries)
+    research_scope_counts = Counter(
+        str((row.get("ontology_classification") or {}).get("research_scope") or "unknown")
+        for row in entries
+    )
+    asset_class_counts = Counter(
+        str((row.get("ontology_classification") or {}).get("asset_class") or "unknown")
+        for row in entries
+    )
+    readiness_state_counts = Counter(
+        str((row.get("ontology_classification") or {}).get("readiness_state") or "unknown")
+        for row in entries
+    )
+    ontology_tag_counts = Counter(
+        str(tag)
+        for row in entries
+        for tag in row.get("ontology_tags") or []
+    )
     candidate_ids = sorted(
         {
             str(row.get("subject_id") or "")
@@ -191,13 +248,18 @@ def build_research_memory_coverage(
             ),
             "indexed_candidate_count": len(candidate_ids),
             "record_kind_counts": dict(sorted(kind_counts.items())),
+            "ontology_research_scope_counts": dict(sorted(research_scope_counts.items())),
+            "ontology_asset_class_counts": dict(sorted(asset_class_counts.items())),
+            "ontology_readiness_state_counts": dict(sorted(readiness_state_counts.items())),
+            "ontology_tag_counts": dict(sorted(ontology_tag_counts.items())),
             "memory_content_hash": _digest({"entries": entries}),
             "final_recommendation": (
                 "research_memory_coverage_ready" if entries else "research_memory_coverage_missing"
             ),
             "operator_summary": (
                 "Research memory coverage indexes current read-only basket, failure-action, "
-                "and durable reason-record surfaces without adding authority or runtime behavior."
+                "and durable reason-record surfaces with context-only ontology classification "
+                "without adding authority or runtime behavior."
             ),
         },
         "entries": entries,
@@ -206,6 +268,7 @@ def build_research_memory_coverage(
             "uses_embeddings": False,
             "uses_vector_db": False,
             "uses_llm_authority": False,
+            "ontology_context_only": True,
             "paper_shadow_live_forbidden": True,
             "broker_risk_execution_forbidden": True,
         },

--- a/research/qre_research_memory_coverage.py
+++ b/research/qre_research_memory_coverage.py
@@ -312,6 +312,21 @@ def _failure_similarity(left: Mapping[str, Any], right: Mapping[str, Any]) -> in
     return score
 
 
+
+def _retrieval_match_payload(candidate: Mapping[str, Any], *, score: int) -> dict[str, Any]:
+    return {
+        "subject_id": candidate.get("subject_id"),
+        "artifact_id": candidate.get("artifact_id"),
+        "title": candidate.get("title"),
+        "score": score,
+        "record_kind": candidate.get("record_kind"),
+        "blocker_code": (candidate.get("metadata") or {}).get("blocker_code"),
+        "recommended_action": (candidate.get("metadata") or {}).get("recommended_action"),
+        "ontology_tags": list(candidate.get("ontology_tags") or []),
+        "ontology_classification": dict(candidate.get("ontology_classification") or {}),
+        "resolved_entities": list(candidate.get("resolved_entities") or []),
+        "metadata": dict(candidate.get("metadata") or {}),
+    }
 def build_failure_retrieval(
     memory: Mapping[str, Any],
     *,
@@ -340,18 +355,7 @@ def build_failure_retrieval(
             score = _failure_similarity(entry, candidate)
             if score <= 0:
                 continue
-            matches.append(
-                {
-                    "subject_id": other_subject,
-                    "artifact_id": candidate.get("artifact_id"),
-                    "title": candidate.get("title"),
-                    "score": score,
-                    "blocker_code": (candidate.get("metadata") or {}).get("blocker_code"),
-                    "recommended_action": (candidate.get("metadata") or {}).get(
-                        "recommended_action"
-                    ),
-                }
-            )
+            matches.append(_retrieval_match_payload(candidate, score=score))
         matches.sort(key=lambda row: (-int(row["score"]), str(row["subject_id"])))
         retrieval_rows.append(
             {
@@ -365,6 +369,15 @@ def build_failure_retrieval(
         )
 
     blocker_counts = Counter(str(row.get("blocker_code") or "") for row in retrieval_rows)
+    matched_subject_count = len(
+        {
+            str(match.get("subject_id") or "")
+            for row in retrieval_rows
+            for match in row.get("similar_failures", [])
+            if str(match.get("subject_id") or "")
+        }
+    )
+    unmatched_subject_count = len([row for row in retrieval_rows if not row.get("similar_failures")])
     return {
         "schema_version": SCHEMA_VERSION,
         "report_kind": FAILURE_REPORT_KIND,
@@ -373,6 +386,8 @@ def build_failure_retrieval(
             "retrievable_failure_subject_count": sum(
                 1 for row in retrieval_rows if row.get("similar_failures")
             ),
+            "matched_failure_subject_count": matched_subject_count,
+            "unmatched_failure_subject_count": unmatched_subject_count,
             "blocker_counts": dict(sorted(blocker_counts.items())),
             "final_recommendation": (
                 "failure_retrieval_ready" if retrieval_rows else "failure_retrieval_not_ready"

--- a/research/qre_research_ontology.py
+++ b/research/qre_research_ontology.py
@@ -1,0 +1,252 @@
+"""QRE research ontology scaffold.
+
+This module defines deterministic, closed-vocabulary ontology helpers for
+research-memory classification. It is intentionally non-authoritative:
+ontology labels provide context and filtering hints, not alpha confidence,
+promotion authority, strategy registration, or execution permission.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+
+SCHEMA_VERSION = "1.0"
+
+
+ONTOLOGY_TAGS: tuple[str, ...] = (
+    "artifact",
+    "basket",
+    "campaign",
+    "candidate",
+    "data_readiness",
+    "diagnostic",
+    "entity_resolution",
+    "evidence",
+    "factor",
+    "failure",
+    "field_coverage",
+    "hypothesis",
+    "hypothesis_seed",
+    "identity",
+    "lineage",
+    "manifest",
+    "null_model",
+    "operator_trust",
+    "policy",
+    "policy_action",
+    "provider",
+    "readiness",
+    "recipe",
+    "retrieval",
+    "routing",
+    "sampling",
+    "source_identity",
+    "source_quality",
+    "state_transition",
+    "strategy_context",
+    "universe",
+)
+
+
+ASSET_CLASSES: tuple[str, ...] = (
+    "equity",
+    "fundamental_equity",
+    "index",
+    "fx",
+    "commodity",
+    "rate",
+    "crypto_legacy",
+    "unknown",
+)
+
+
+RESEARCH_SCOPES: tuple[str, ...] = (
+    "target_equity_research",
+    "target_source_data_research",
+    "target_factor_research",
+    "legacy_non_target_reference",
+    "excluded_from_current_research_scope",
+    "unknown",
+)
+
+
+READINESS_STATES: tuple[str, ...] = (
+    "ready",
+    "partial",
+    "not_ready",
+    "blocked",
+    "unknown",
+    "fail_closed",
+)
+
+
+BLOCKER_CLASSES: tuple[str, ...] = (
+    "missing_source_manifest",
+    "missing_required_field",
+    "source_license_unknown",
+    "source_quality_unknown",
+    "missing_point_in_time_policy",
+    "missing_report_lag_policy",
+    "missing_restatement_policy",
+    "blocked_data_readiness",
+    "blocked_field_coverage",
+    "blocked_identity_ambiguity",
+    "lineage_missing",
+    "metric_inconsistent",
+    "no_survivors",
+    "criteria_failed",
+    "unknown",
+)
+
+
+CRYPTO_MARKERS: tuple[str, ...] = (
+    "BTC-USD",
+    "ETH-USD",
+    "SOL-USD",
+    "ADA-USD",
+    "DOGE-USD",
+    "XRP-USD",
+    "BNB-USD",
+    "AVAX-USD",
+    "MATIC-USD",
+    "DOT-USD",
+)
+
+
+EQUITY_CONTEXT_MARKERS: tuple[str, ...] = (
+    "equity",
+    "equities",
+    "factor",
+    "fundamental",
+    "provider",
+    "source_manifest",
+    "companyfacts",
+    "openfigi",
+    "euronext",
+    "nasdaq",
+    "nyse",
+    "universe",
+)
+
+
+@dataclass(frozen=True)
+class OntologyClassification:
+    """Deterministic ontology classification for a memory/document item."""
+
+    ontology_tags: tuple[str, ...]
+    asset_class: str
+    research_scope: str
+    readiness_state: str
+    blocker_classes: tuple[str, ...]
+    explanation: str
+
+
+def _contains_any(text: str, markers: Iterable[str]) -> bool:
+    upper_text = text.upper()
+    return any(marker.upper() in upper_text for marker in markers)
+
+
+def _normalize_tags(tags: Iterable[str] | None) -> tuple[str, ...]:
+    if not tags:
+        return tuple()
+
+    allowed = set(ONTOLOGY_TAGS)
+    return tuple(sorted({tag for tag in tags if tag in allowed}))
+
+
+def classify_research_text(
+    *,
+    title: str = "",
+    artifact_path: str = "",
+    ontology_tags: Iterable[str] | None = None,
+    text_preview: str = "",
+) -> OntologyClassification:
+    """Classify research-memory text into ontology context.
+
+    Crypto-related legacy records are not deleted and not hidden. They are
+    explicitly classified as crypto_legacy and excluded from the current
+    equity/fundamental research scope.
+
+    This is a research-context classifier only. It never authorizes strategy
+    promotion, paper/shadow/live activation, or execution.
+    """
+
+    combined = " ".join(part for part in (title, artifact_path, text_preview) if part)
+    normalized_tags = _normalize_tags(ontology_tags)
+
+    blocker_classes: list[str] = []
+    readiness_state = "unknown"
+
+    if _contains_any(combined, CRYPTO_MARKERS):
+        return OntologyClassification(
+            ontology_tags=tuple(sorted(set(normalized_tags + ("strategy_context",)))),
+            asset_class="crypto_legacy",
+            research_scope="excluded_from_current_research_scope",
+            readiness_state="blocked",
+            blocker_classes=("blocked_data_readiness",),
+            explanation=(
+                "Crypto appears only as legacy/historical research context and "
+                "is excluded from the current equity/fundamental research scope."
+            ),
+        )
+
+    if _contains_any(combined, EQUITY_CONTEXT_MARKERS):
+        scope = "target_equity_research"
+        asset_class = "fundamental_equity"
+        explanation = "Record is aligned with the current equity/fundamental research scope."
+    else:
+        scope = "unknown"
+        asset_class = "unknown"
+        explanation = "Record could not be mapped to a current target research scope."
+
+    lower_combined = combined.lower()
+    if "missing" in lower_combined or "blocked" in lower_combined:
+        readiness_state = "blocked"
+    elif "ready" in lower_combined:
+        readiness_state = "ready"
+
+    for blocker in BLOCKER_CLASSES:
+        if blocker != "unknown" and blocker in lower_combined:
+            blocker_classes.append(blocker)
+
+    if not blocker_classes and readiness_state == "blocked":
+        blocker_classes.append("unknown")
+
+    return OntologyClassification(
+        ontology_tags=normalized_tags,
+        asset_class=asset_class,
+        research_scope=scope,
+        readiness_state=readiness_state,
+        blocker_classes=tuple(sorted(set(blocker_classes))),
+        explanation=explanation,
+    )
+
+
+def ontology_manifest() -> dict[str, object]:
+    """Return deterministic ontology manifest."""
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "ontology_tags": list(ONTOLOGY_TAGS),
+        "asset_classes": list(ASSET_CLASSES),
+        "research_scopes": list(RESEARCH_SCOPES),
+        "readiness_states": list(READINESS_STATES),
+        "blocker_classes": list(BLOCKER_CLASSES),
+        "crypto_policy": {
+            "classification": "crypto_legacy",
+            "research_scope": "excluded_from_current_research_scope",
+            "behavior": "preserve_historical_records_but_do_not_target_for_current_equity_research",
+            "does_not_delete_frozen_contracts": True,
+            "does_not_authorize_trading": True,
+        },
+        "authority": {
+            "ontology_is_context_only": True,
+            "not_alpha_authority": True,
+            "not_strategy_registration": True,
+            "not_candidate_promotion": True,
+            "not_paper_shadow_live": True,
+            "not_broker_execution": True,
+        },
+    }

--- a/tests/unit/test_qre_entity_resolution.py
+++ b/tests/unit/test_qre_entity_resolution.py
@@ -1,0 +1,67 @@
+from research.qre_entity_resolution import (
+    entity_resolution_manifest,
+    resolve_entities_from_text,
+)
+
+
+def test_entity_resolution_manifest_is_context_only():
+    manifest = entity_resolution_manifest()
+
+    assert manifest["schema_version"] == "1.0"
+    assert "asset" in manifest["entity_types"]
+    assert "provider" in manifest["entity_types"]
+    assert manifest["authority"]["entity_resolution_is_context_only"] is True
+    assert manifest["authority"]["not_source_identity_authority"] is True
+    assert manifest["authority"]["does_not_override_identity_gates"] is True
+    assert manifest["authority"]["not_candidate_promotion"] is True
+
+
+def test_resolves_crypto_asset_as_context_only_entity():
+    entities = resolve_entities_from_text(
+        title="rsi BTC-USD 1h",
+        artifact_path="research/research_latest.json",
+    )
+
+    ids = {entity.entity_id for entity in entities}
+    assert "asset:BTC-USD" in ids
+
+
+def test_resolves_sec_companyfacts_provider_marker():
+    entities = resolve_entities_from_text(
+        title="SEC Companyfacts factor coverage",
+        artifact_path="artifacts/external_intelligence/source_manifests_latest.v1.json",
+    )
+
+    ids = {entity.entity_id for entity in entities}
+    assert "provider:sec_companyfacts" in ids
+
+
+def test_resolves_openfigi_provider_marker():
+    entities = resolve_entities_from_text(title="OpenFIGI identity mapping")
+
+    ids = {entity.entity_id for entity in entities}
+    assert "provider:openfigi_symbology" in ids
+
+
+def test_resolves_artifact_path():
+    entities = resolve_entities_from_text(
+        title="logs/qre_data_cache_manifest/latest.json",
+        artifact_path="logs/qre_data_cache_manifest/latest.json",
+    )
+
+    assert any(entity.entity_type == "artifact" for entity in entities)
+
+
+def test_unknown_text_returns_empty_entities():
+    entities = resolve_entities_from_text(title="unclassified text")
+    assert entities == ()
+
+
+def test_policy_tag_is_unresolved_context_not_authority():
+    entities = resolve_entities_from_text(
+        title="policy action",
+        ontology_tags=["policy_action"],
+    )
+
+    assert any(entity.entity_type == "policy" for entity in entities)
+    assert any(entity.ambiguity_status == "unresolved" for entity in entities)

--- a/tests/unit/test_qre_research_memory_current_artifacts.py
+++ b/tests/unit/test_qre_research_memory_current_artifacts.py
@@ -97,3 +97,15 @@ def test_current_artifacts_write_outputs_also_materializes_coverage_and_retrieva
     markdown = (tmp_path / paths["operator_summary"]).read_text(encoding="utf-8")
     assert paths["latest"] == "logs/qre_research_memory_current_artifacts/latest.json"
     assert "# QRE Research Memory Current Artifacts" in markdown
+
+def test_memory_coverage_entries_include_resolved_entities():
+    from pathlib import Path
+
+    from research import qre_research_memory_coverage as coverage
+
+    report = coverage.build_research_memory_coverage(repo_root=Path("."), max_candidates=3)
+    entries = report["entries"]
+
+    assert entries
+    assert all("resolved_entities" in entry for entry in entries)
+    assert all(isinstance(entry["resolved_entities"], list) for entry in entries)

--- a/tests/unit/test_qre_research_memory_current_artifacts.py
+++ b/tests/unit/test_qre_research_memory_current_artifacts.py
@@ -109,3 +109,23 @@ def test_memory_coverage_entries_include_resolved_entities():
     assert entries
     assert all("resolved_entities" in entry for entry in entries)
     assert all(isinstance(entry["resolved_entities"], list) for entry in entries)
+
+def test_failure_retrieval_matches_include_context_fields():
+    from pathlib import Path
+
+    from research import qre_research_memory_coverage as coverage
+
+    memory = coverage.build_research_memory_coverage(repo_root=Path("."), max_candidates=15)
+    retrieval = coverage.build_failure_retrieval(memory)
+
+    assert "summary" in retrieval
+    assert "matched_failure_subject_count" in retrieval["summary"]
+    assert "unmatched_failure_subject_count" in retrieval["summary"]
+
+    rows = retrieval.get("rows") or []
+    for row in rows:
+        for match in row.get("similar_failures") or []:
+            assert "ontology_tags" in match
+            assert "ontology_classification" in match
+            assert "resolved_entities" in match
+            assert "metadata" in match

--- a/tests/unit/test_qre_research_ontology.py
+++ b/tests/unit/test_qre_research_ontology.py
@@ -1,0 +1,95 @@
+from research.qre_research_ontology import (
+    ASSET_CLASSES,
+    BLOCKER_CLASSES,
+    ONTOLOGY_TAGS,
+    RESEARCH_SCOPES,
+    classify_research_text,
+    ontology_manifest,
+)
+
+
+def test_ontology_manifest_contains_closed_vocabularies():
+    manifest = ontology_manifest()
+
+    assert manifest["schema_version"] == "1.0"
+    assert "data_readiness" in manifest["ontology_tags"]
+    assert "hypothesis" in manifest["ontology_tags"]
+    assert "source_identity" in manifest["ontology_tags"]
+    assert "crypto_legacy" in manifest["asset_classes"]
+    assert "excluded_from_current_research_scope" in manifest["research_scopes"]
+    assert "missing_source_manifest" in manifest["blocker_classes"]
+
+
+def test_closed_vocabularies_are_unique_and_sorted_enough():
+    assert len(ONTOLOGY_TAGS) == len(set(ONTOLOGY_TAGS))
+    assert len(ASSET_CLASSES) == len(set(ASSET_CLASSES))
+    assert len(RESEARCH_SCOPES) == len(set(RESEARCH_SCOPES))
+    assert len(BLOCKER_CLASSES) == len(set(BLOCKER_CLASSES))
+
+
+def test_crypto_research_records_are_legacy_excluded_not_deleted():
+    result = classify_research_text(
+        title="rsi BTC-USD 1h",
+        artifact_path="research/research_latest.json",
+        ontology_tags=["data_readiness", "hypothesis", "strategy_context"],
+    )
+
+    assert result.asset_class == "crypto_legacy"
+    assert result.research_scope == "excluded_from_current_research_scope"
+    assert result.readiness_state == "blocked"
+    assert "blocked_data_readiness" in result.blocker_classes
+    assert "strategy_context" in result.ontology_tags
+    assert "excluded" in result.explanation.lower()
+
+
+def test_eth_crypto_record_is_legacy_excluded():
+    result = classify_research_text(
+        title="bollinger_regime ETH-USD 4h",
+        artifact_path="research/research_latest.json",
+    )
+
+    assert result.asset_class == "crypto_legacy"
+    assert result.research_scope == "excluded_from_current_research_scope"
+    assert result.readiness_state == "blocked"
+
+
+def test_equity_context_maps_to_target_equity_research():
+    result = classify_research_text(
+        title="SEC Companyfacts factor field coverage",
+        artifact_path="artifacts/data_readiness/factor_field_coverage_latest.v1.json",
+        ontology_tags=["data_readiness", "provider", "field_coverage"],
+    )
+
+    assert result.asset_class == "fundamental_equity"
+    assert result.research_scope == "target_equity_research"
+    assert result.readiness_state in {"unknown", "ready", "blocked"}
+
+
+def test_unknown_context_remains_unknown_fail_closed_context():
+    result = classify_research_text(title="unclassified historical row")
+
+    assert result.asset_class == "unknown"
+    assert result.research_scope == "unknown"
+    assert result.readiness_state == "unknown"
+
+
+def test_unknown_tags_are_dropped():
+    result = classify_research_text(
+        title="SEC Companyfacts",
+        ontology_tags=["data_readiness", "not_a_real_tag"],
+    )
+
+    assert "data_readiness" in result.ontology_tags
+    assert "not_a_real_tag" not in result.ontology_tags
+
+
+def test_ontology_has_no_execution_authority():
+    manifest = ontology_manifest()
+    authority = manifest["authority"]
+
+    assert authority["ontology_is_context_only"] is True
+    assert authority["not_alpha_authority"] is True
+    assert authority["not_strategy_registration"] is True
+    assert authority["not_candidate_promotion"] is True
+    assert authority["not_paper_shadow_live"] is True
+    assert authority["not_broker_execution"] is True


### PR DESCRIPTION
Implements C02 plus bounded C02.5/C03/C04 on one branch with separate commits.

Adds:
- deterministic context-only QRE research ontology scaffold
- ontology classification on research memory coverage entries
- deterministic context-only entity resolution scaffold
- entity resolution enrichment on research memory coverage entries
- enriched failure retrieval context with ontology/entity metadata

Crypto records are preserved as historical context but classified as crypto_legacy/excluded from current equity/fundamental research scope.

Safety:
- no frozen contract mutation
- no research/research_latest.json or research/strategy_matrix.csv mutation
- no strategy registration
- no trade signals
- no provider activation
- no data fetching
- no paper/shadow/live
- no broker/risk/execution