### PR TITLE
fix: add QRE D-stage diagnostics and hardening scaffolds

### DIFF
--- a/research/qre_null_model_baseline.py
+++ b/research/qre_null_model_baseline.py
@@ -1,0 +1,130 @@
+"""Deterministic QRE null-model baseline scaffold.
+
+This module provides context-only baseline comparison helpers for QRE research
+diagnostics. It does not promote candidates, register strategies, authorize
+paper/shadow/live activation, or perform broker/risk/execution actions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from statistics import mean
+from typing import Any, Iterable, Mapping
+
+
+SCHEMA_VERSION = "1.0"
+
+
+BASELINE_TYPES: tuple[str, ...] = (
+    "zero_return",
+    "buy_and_hold",
+    "median_candidate",
+    "randomized_label_placeholder",
+    "unknown",
+)
+
+
+@dataclass(frozen=True)
+class NullBaselineResult:
+    baseline_type: str
+    candidate_metric: float | None
+    baseline_metric: float | None
+    delta_vs_baseline: float | None
+    comparison_state: str
+    explanation: str
+
+
+def _to_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def compare_metric_to_baseline(
+    *,
+    candidate_metric: Any,
+    baseline_metric: Any,
+    baseline_type: str = "unknown",
+) -> NullBaselineResult:
+    """Compare a candidate metric to a deterministic null baseline.
+
+    This is diagnostic context only. A favorable delta never authorizes
+    promotion, routing, paper/shadow/live, or execution.
+    """
+
+    candidate = _to_float(candidate_metric)
+    baseline = _to_float(baseline_metric)
+    normalized_baseline_type = baseline_type if baseline_type in BASELINE_TYPES else "unknown"
+
+    if candidate is None or baseline is None:
+        return NullBaselineResult(
+            baseline_type=normalized_baseline_type,
+            candidate_metric=candidate,
+            baseline_metric=baseline,
+            delta_vs_baseline=None,
+            comparison_state="insufficient_metric_data",
+            explanation="Candidate and baseline metrics must both be numeric.",
+        )
+
+    delta = candidate - baseline
+    if delta > 0:
+        state = "candidate_above_baseline"
+    elif delta < 0:
+        state = "candidate_below_baseline"
+    else:
+        state = "candidate_equal_to_baseline"
+
+    return NullBaselineResult(
+        baseline_type=normalized_baseline_type,
+        candidate_metric=candidate,
+        baseline_metric=baseline,
+        delta_vs_baseline=delta,
+        comparison_state=state,
+        explanation="Deterministic metric-vs-baseline comparison; context only, not authority.",
+    )
+
+
+def median_candidate_baseline(
+    rows: Iterable[Mapping[str, Any]],
+    *,
+    metric_field: str,
+) -> float | None:
+    """Return a deterministic median-like baseline using sorted numeric values.
+
+    For even counts this returns the arithmetic mean of the two middle values.
+    """
+
+    values = sorted(
+        value
+        for row in rows
+        if isinstance(row, Mapping)
+        for value in [_to_float(row.get(metric_field))]
+        if value is not None
+    )
+    if not values:
+        return None
+
+    mid = len(values) // 2
+    if len(values) % 2:
+        return values[mid]
+    return mean((values[mid - 1], values[mid]))
+
+
+def null_model_manifest() -> dict[str, object]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "baseline_types": list(BASELINE_TYPES),
+        "authority": {
+            "null_model_is_context_only": True,
+            "not_alpha_authority": True,
+            "not_candidate_promotion": True,
+            "not_strategy_registration": True,
+            "not_paper_shadow_live": True,
+            "not_broker_execution": True,
+            "does_not_fetch_data": True,
+            "does_not_mutate_frozen_contracts": True,
+        },
+    }

--- a/research/qre_null_model_baseline_report.py
+++ b/research/qre_null_model_baseline_report.py
@@ -1,0 +1,166 @@
+"""QRE null-model baseline report surface.
+
+This report materializes a read-only, context-only null-model readiness surface.
+It is diagnostic only and cannot promote candidates, register strategies,
+fetch data, or authorize paper/shadow/live execution.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Final
+
+from research.qre_null_model_baseline import (
+    compare_metric_to_baseline,
+    median_candidate_baseline,
+    null_model_manifest,
+)
+
+
+REPORT_KIND: Final[str] = "qre_null_model_baseline_report"
+SCHEMA_VERSION: Final[str] = "1.0"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_null_model_baseline")
+LATEST_NAME: Final[str] = "latest.json"
+OPERATOR_SUMMARY_NAME: Final[str] = "operator_summary.md"
+WRITE_PREFIX: Final[str] = "logs/qre_null_model_baseline/"
+
+
+def build_null_model_baseline_report(*, repo_root: Path = Path(".")) -> dict[str, Any]:
+    manifest = null_model_manifest()
+
+    sample_rows = [
+        {"candidate_id": "sample:below", "score": -0.01},
+        {"candidate_id": "sample:baseline", "score": 0.00},
+        {"candidate_id": "sample:above", "score": 0.02},
+    ]
+    baseline_metric = median_candidate_baseline(sample_rows, metric_field="score")
+    sample_comparisons = [
+        compare_metric_to_baseline(
+            candidate_metric=row.get("score"),
+            baseline_metric=baseline_metric,
+            baseline_type="median_candidate",
+        )
+        for row in sample_rows
+    ]
+
+    comparison_counts: dict[str, int] = {}
+    for comparison in sample_comparisons:
+        comparison_counts[comparison.comparison_state] = (
+            comparison_counts.get(comparison.comparison_state, 0) + 1
+        )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "summary": {
+            "null_model_baseline_ready": True,
+            "baseline_type_count": len(manifest["baseline_types"]),
+            "sample_row_count": len(sample_rows),
+            "sample_baseline_metric": baseline_metric,
+            "sample_comparison_counts": dict(sorted(comparison_counts.items())),
+            "final_recommendation": "null_model_baseline_scaffold_ready",
+            "operator_summary": (
+                "Null-model baseline scaffold is available as deterministic, read-only "
+                "diagnostic context only. It does not promote candidates or authorize execution."
+            ),
+        },
+        "manifest": manifest,
+        "sample_rows": sample_rows,
+        "sample_comparisons": [
+            {
+                "baseline_type": item.baseline_type,
+                "candidate_metric": item.candidate_metric,
+                "baseline_metric": item.baseline_metric,
+                "delta_vs_baseline": item.delta_vs_baseline,
+                "comparison_state": item.comparison_state,
+                "explanation": item.explanation,
+            }
+            for item in sample_comparisons
+        ],
+        "safety_invariants": {
+            "read_only": True,
+            "uses_network": False,
+            "uses_external_data": False,
+            "uses_embeddings": False,
+            "uses_vector_db": False,
+            "uses_llm_authority": False,
+            "mutates_candidates": False,
+            "mutates_strategies": False,
+            "mutates_frozen_contracts": False,
+            "promotion_forbidden": True,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+        },
+    }
+
+
+def render_operator_summary(report: Mapping[str, Any]) -> str:
+    summary = report.get("summary") if isinstance(report.get("summary"), Mapping) else {}
+    return "\n".join(
+        [
+            "# QRE Null Model Baseline",
+            "",
+            f"- {summary.get('operator_summary') or ''}",
+            "",
+            "## Current Status",
+            "",
+            f"- null_model_baseline_ready: {summary.get('null_model_baseline_ready')}",
+            f"- baseline_type_count: {summary.get('baseline_type_count')}",
+            f"- sample_row_count: {summary.get('sample_row_count')}",
+            f"- sample_baseline_metric: {summary.get('sample_baseline_metric')}",
+            f"- final_recommendation: {summary.get('final_recommendation')}",
+            "",
+        ]
+    )
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(f"qre_null_model_baseline_report: refusing write outside allowlist: {path!r}")
+
+
+def write_outputs(report: Mapping[str, Any], *, repo_root: Path = Path(".")) -> dict[str, str]:
+    base = repo_root / DEFAULT_OUTPUT_DIR
+    base.mkdir(parents=True, exist_ok=True)
+    latest = base / LATEST_NAME
+    summary_path = base / OPERATOR_SUMMARY_NAME
+
+    for target in (latest, summary_path):
+        _validate_write_target(target)
+
+    tmp_json = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp_json, latest)
+
+    tmp_md = summary_path.with_suffix(summary_path.suffix + ".tmp")
+    tmp_md.write_text(render_operator_summary(report), encoding="utf-8")
+    os.replace(tmp_md, summary_path)
+
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "operator_summary": summary_path.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_null_model_baseline_report",
+        description="Build read-only QRE null-model baseline report.",
+    )
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+
+    report = build_null_model_baseline_report()
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/research/qre_state_transition_diagnostics.py
+++ b/research/qre_state_transition_diagnostics.py
@@ -1,0 +1,165 @@
+"""Deterministic QRE state-transition diagnostics scaffold.
+
+This module explains candidate/research state transitions as read-only context.
+It does not mutate candidates, promote strategies, fetch data, or authorize
+paper/shadow/live/broker execution.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+SCHEMA_VERSION = "1.0"
+
+
+STATE_NAMES: tuple[str, ...] = (
+    "unknown",
+    "candidate_discovered",
+    "screened",
+    "validation_candidate",
+    "validated",
+    "rejected",
+    "blocked",
+    "fail_closed",
+)
+
+
+TRANSITION_REASONS: tuple[str, ...] = (
+    "criteria_passed",
+    "criteria_failed",
+    "insufficient_evidence",
+    "missing_required_field",
+    "data_readiness_blocked",
+    "identity_ambiguous",
+    "lineage_missing",
+    "null_model_required",
+    "tail_risk_required",
+    "operator_review_required",
+    "unknown",
+)
+
+
+TERMINAL_NEGATIVE_STATES: tuple[str, ...] = (
+    "rejected",
+    "blocked",
+    "fail_closed",
+)
+
+
+POSITIVE_PROGRESS_STATES: tuple[str, ...] = (
+    "screened",
+    "validation_candidate",
+    "validated",
+)
+
+
+@dataclass(frozen=True)
+class StateTransitionDiagnostic:
+    subject_id: str
+    prior_state: str
+    new_state: str
+    transition_reason: str
+    blocker_class: str | None
+    evidence_ref: str | None
+    artifact_ref: str | None
+    transition_state: str
+    explanation: str
+
+
+def _normalize(value: Any, allowed: tuple[str, ...], *, fallback: str = "unknown") -> str:
+    if value is None:
+        return fallback
+    text = str(value).strip()
+    return text if text in allowed else fallback
+
+
+def diagnose_state_transition(
+    *,
+    subject_id: Any,
+    prior_state: Any,
+    new_state: Any,
+    transition_reason: Any = None,
+    blocker_class: Any = None,
+    evidence_ref: Any = None,
+    artifact_ref: Any = None,
+) -> StateTransitionDiagnostic:
+    """Create a deterministic diagnostic for one state transition.
+
+    The diagnostic is context only. It does not authorize promotion or execution.
+    """
+
+    normalized_prior = _normalize(prior_state, STATE_NAMES)
+    normalized_new = _normalize(new_state, STATE_NAMES)
+    normalized_reason = _normalize(transition_reason, TRANSITION_REASONS)
+
+    clean_subject_id = str(subject_id or "").strip() or "unknown"
+    clean_blocker = str(blocker_class).strip() if blocker_class is not None else None
+    clean_evidence = str(evidence_ref).strip() if evidence_ref is not None else None
+    clean_artifact = str(artifact_ref).strip() if artifact_ref is not None else None
+
+    if normalized_prior == "unknown" or normalized_new == "unknown":
+        transition_state = "insufficient_state_data"
+        explanation = "Prior and new state must both be known before transition trust can be assessed."
+    elif normalized_prior == normalized_new:
+        transition_state = "no_state_change"
+        explanation = "Prior and new state are identical; this is a stable/no-op transition."
+    elif normalized_new in TERMINAL_NEGATIVE_STATES:
+        transition_state = "terminal_negative_transition"
+        explanation = "Transition ends in a negative or fail-closed state and requires blocker/evidence context."
+    elif normalized_new in POSITIVE_PROGRESS_STATES:
+        transition_state = "positive_progress_transition"
+        explanation = "Transition progresses to a more advanced research state; this remains diagnostic only."
+    else:
+        transition_state = "other_transition"
+        explanation = "Transition is recognized but does not map to a positive or terminal-negative class."
+
+    return StateTransitionDiagnostic(
+        subject_id=clean_subject_id,
+        prior_state=normalized_prior,
+        new_state=normalized_new,
+        transition_reason=normalized_reason,
+        blocker_class=clean_blocker,
+        evidence_ref=clean_evidence,
+        artifact_ref=clean_artifact,
+        transition_state=transition_state,
+        explanation=explanation,
+    )
+
+
+def diagnose_transition_rows(rows: list[Mapping[str, Any]]) -> list[StateTransitionDiagnostic]:
+    return [
+        diagnose_state_transition(
+            subject_id=row.get("subject_id"),
+            prior_state=row.get("prior_state"),
+            new_state=row.get("new_state"),
+            transition_reason=row.get("transition_reason"),
+            blocker_class=row.get("blocker_class"),
+            evidence_ref=row.get("evidence_ref"),
+            artifact_ref=row.get("artifact_ref"),
+        )
+        for row in rows
+        if isinstance(row, Mapping)
+    ]
+
+
+def transition_diagnostic_manifest() -> dict[str, object]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "state_names": list(STATE_NAMES),
+        "transition_reasons": list(TRANSITION_REASONS),
+        "terminal_negative_states": list(TERMINAL_NEGATIVE_STATES),
+        "positive_progress_states": list(POSITIVE_PROGRESS_STATES),
+        "authority": {
+            "state_transition_diagnostics_are_context_only": True,
+            "not_alpha_authority": True,
+            "not_candidate_promotion": True,
+            "not_strategy_registration": True,
+            "not_paper_shadow_live": True,
+            "not_broker_execution": True,
+            "does_not_fetch_data": True,
+            "does_not_mutate_candidates": True,
+            "does_not_mutate_frozen_contracts": True,
+        },
+    }

--- a/research/qre_state_transition_diagnostics_report.py
+++ b/research/qre_state_transition_diagnostics_report.py
@@ -1,0 +1,191 @@
+"""QRE state-transition diagnostics report surface.
+
+This report materializes deterministic, read-only state-transition diagnostics.
+It is diagnostic context only and cannot mutate candidates, promote strategies,
+fetch data, or authorize paper/shadow/live/broker execution.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections import Counter
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Final
+
+from research.qre_state_transition_diagnostics import (
+    diagnose_transition_rows,
+    transition_diagnostic_manifest,
+)
+
+
+REPORT_KIND: Final[str] = "qre_state_transition_diagnostics_report"
+SCHEMA_VERSION: Final[str] = "1.0"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_state_transition_diagnostics")
+LATEST_NAME: Final[str] = "latest.json"
+OPERATOR_SUMMARY_NAME: Final[str] = "operator_summary.md"
+WRITE_PREFIX: Final[str] = "logs/qre_state_transition_diagnostics/"
+
+
+def _sample_transition_rows() -> list[dict[str, Any]]:
+    return [
+        {
+            "subject_id": "sample:candidate:discovered_to_screened",
+            "prior_state": "candidate_discovered",
+            "new_state": "screened",
+            "transition_reason": "criteria_passed",
+            "evidence_ref": "logs/qre_state_transition_diagnostics/sample.json",
+            "artifact_ref": "logs/qre_state_transition_diagnostics/latest.json",
+        },
+        {
+            "subject_id": "sample:candidate:screened_to_validation",
+            "prior_state": "screened",
+            "new_state": "validation_candidate",
+            "transition_reason": "null_model_required",
+            "evidence_ref": "logs/qre_null_model_baseline/latest.json",
+            "artifact_ref": "logs/qre_state_transition_diagnostics/latest.json",
+        },
+        {
+            "subject_id": "sample:candidate:screened_to_blocked",
+            "prior_state": "screened",
+            "new_state": "blocked",
+            "transition_reason": "data_readiness_blocked",
+            "blocker_class": "missing_required_field",
+            "evidence_ref": "research/factor_field_coverage_manifest.json",
+            "artifact_ref": "logs/qre_state_transition_diagnostics/latest.json",
+        },
+    ]
+
+
+def build_state_transition_diagnostics_report(
+    *,
+    repo_root: Path = Path("."),
+    transition_rows: list[Mapping[str, Any]] | None = None,
+) -> dict[str, Any]:
+    manifest = transition_diagnostic_manifest()
+    rows = list(transition_rows) if transition_rows is not None else _sample_transition_rows()
+    diagnostics = diagnose_transition_rows(rows)
+
+    transition_state_counts = Counter(item.transition_state for item in diagnostics)
+    new_state_counts = Counter(item.new_state for item in diagnostics)
+    reason_counts = Counter(item.transition_reason for item in diagnostics)
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "summary": {
+            "state_transition_diagnostics_ready": True,
+            "transition_row_count": len(rows),
+            "diagnostic_count": len(diagnostics),
+            "transition_state_counts": dict(sorted(transition_state_counts.items())),
+            "new_state_counts": dict(sorted(new_state_counts.items())),
+            "transition_reason_counts": dict(sorted(reason_counts.items())),
+            "final_recommendation": "state_transition_diagnostics_scaffold_ready",
+            "operator_summary": (
+                "State-transition diagnostics are available as deterministic, read-only "
+                "context. They explain transitions but do not mutate candidate state."
+            ),
+        },
+        "manifest": manifest,
+        "transition_rows": rows,
+        "diagnostics": [
+            {
+                "subject_id": item.subject_id,
+                "prior_state": item.prior_state,
+                "new_state": item.new_state,
+                "transition_reason": item.transition_reason,
+                "blocker_class": item.blocker_class,
+                "evidence_ref": item.evidence_ref,
+                "artifact_ref": item.artifact_ref,
+                "transition_state": item.transition_state,
+                "explanation": item.explanation,
+            }
+            for item in diagnostics
+        ],
+        "safety_invariants": {
+            "read_only": True,
+            "uses_network": False,
+            "uses_external_data": False,
+            "uses_embeddings": False,
+            "uses_vector_db": False,
+            "uses_llm_authority": False,
+            "mutates_candidates": False,
+            "mutates_candidate_state": False,
+            "mutates_strategies": False,
+            "mutates_frozen_contracts": False,
+            "promotion_forbidden": True,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+        },
+    }
+
+
+def render_operator_summary(report: Mapping[str, Any]) -> str:
+    summary = report.get("summary") if isinstance(report.get("summary"), Mapping) else {}
+    return "\n".join(
+        [
+            "# QRE State Transition Diagnostics",
+            "",
+            f"- {summary.get('operator_summary') or ''}",
+            "",
+            "## Current Status",
+            "",
+            f"- state_transition_diagnostics_ready: {summary.get('state_transition_diagnostics_ready')}",
+            f"- transition_row_count: {summary.get('transition_row_count')}",
+            f"- diagnostic_count: {summary.get('diagnostic_count')}",
+            f"- final_recommendation: {summary.get('final_recommendation')}",
+            "",
+        ]
+    )
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(
+            f"qre_state_transition_diagnostics_report: refusing write outside allowlist: {path!r}"
+        )
+
+
+def write_outputs(report: Mapping[str, Any], *, repo_root: Path = Path(".")) -> dict[str, str]:
+    base = repo_root / DEFAULT_OUTPUT_DIR
+    base.mkdir(parents=True, exist_ok=True)
+    latest = base / LATEST_NAME
+    summary_path = base / OPERATOR_SUMMARY_NAME
+
+    for target in (latest, summary_path):
+        _validate_write_target(target)
+
+    tmp_json = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp_json, latest)
+
+    tmp_md = summary_path.with_suffix(summary_path.suffix + ".tmp")
+    tmp_md.write_text(render_operator_summary(report), encoding="utf-8")
+    os.replace(tmp_md, summary_path)
+
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "operator_summary": summary_path.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_state_transition_diagnostics_report",
+        description="Build read-only QRE state-transition diagnostics report.",
+    )
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+
+    report = build_state_transition_diagnostics_report()
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/research/qre_tail_entropy_hardening.py
+++ b/research/qre_tail_entropy_hardening.py
@@ -1,0 +1,178 @@
+"""Deterministic QRE tail/entropy hardening scaffold.
+
+This module provides read-only diagnostics for fragile candidate distributions:
+tail losses, drawdown concentration, entropy, and single-trade concentration.
+It does not promote candidates, register strategies, fetch data, or authorize
+paper/shadow/live/broker execution.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import log2
+from typing import Any, Iterable
+
+
+SCHEMA_VERSION = "1.0"
+
+
+RISK_STATES: tuple[str, ...] = (
+    "insufficient_return_data",
+    "tail_entropy_clear",
+    "tail_entropy_watch",
+    "tail_entropy_blocked",
+)
+
+
+@dataclass(frozen=True)
+class TailEntropyDiagnostic:
+    observation_count: int
+    negative_observation_count: int
+    worst_observation: float | None
+    best_observation: float | None
+    mean_observation: float | None
+    largest_abs_contribution_share: float | None
+    negative_contribution_share: float | None
+    sign_entropy_bits: float | None
+    risk_state: str
+    explanation: str
+
+
+def _to_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _numeric_values(values: Iterable[Any]) -> list[float]:
+    return [value for raw in values for value in [_to_float(raw)] if value is not None]
+
+
+def _mean(values: list[float]) -> float | None:
+    if not values:
+        return None
+    return sum(values) / len(values)
+
+
+def _largest_abs_contribution_share(values: list[float]) -> float | None:
+    total_abs = sum(abs(value) for value in values)
+    if total_abs == 0:
+        return 0.0
+    return max(abs(value) for value in values) / total_abs
+
+
+def _negative_contribution_share(values: list[float]) -> float | None:
+    total_abs = sum(abs(value) for value in values)
+    if total_abs == 0:
+        return 0.0
+    return sum(abs(value) for value in values if value < 0) / total_abs
+
+
+def _sign_entropy_bits(values: list[float]) -> float | None:
+    if not values:
+        return None
+
+    positive_count = sum(1 for value in values if value > 0)
+    negative_count = sum(1 for value in values if value < 0)
+    zero_count = sum(1 for value in values if value == 0)
+    total = positive_count + negative_count + zero_count
+    if total == 0:
+        return None
+
+    entropy = 0.0
+    for count in (positive_count, negative_count, zero_count):
+        if count == 0:
+            continue
+        probability = count / total
+        entropy -= probability * log2(probability)
+    return entropy
+
+
+def diagnose_tail_entropy(
+    observations: Iterable[Any],
+    *,
+    min_observations: int = 5,
+    max_single_abs_share: float = 0.50,
+    max_negative_abs_share: float = 0.70,
+    min_sign_entropy_bits: float = 0.70,
+) -> TailEntropyDiagnostic:
+    """Diagnose tail/entropy fragility for a sequence of numeric observations.
+
+    Favorable diagnostics are context only and never authorize promotion or execution.
+    """
+
+    values = _numeric_values(observations)
+    observation_count = len(values)
+    negative_count = sum(1 for value in values if value < 0)
+
+    worst = min(values) if values else None
+    best = max(values) if values else None
+    average = _mean(values)
+    largest_share = _largest_abs_contribution_share(values) if values else None
+    negative_share = _negative_contribution_share(values) if values else None
+    entropy = _sign_entropy_bits(values)
+
+    if observation_count < min_observations:
+        risk_state = "insufficient_return_data"
+        explanation = "Not enough numeric observations to assess tail/entropy fragility."
+    elif (
+        largest_share is not None
+        and negative_share is not None
+        and entropy is not None
+        and (
+            largest_share > max_single_abs_share
+            or negative_share > max_negative_abs_share
+            or entropy < min_sign_entropy_bits
+        )
+    ):
+        risk_state = "tail_entropy_blocked"
+        explanation = "Tail/entropy concentration exceeds configured hardening thresholds."
+    elif (
+        largest_share is not None
+        and negative_share is not None
+        and entropy is not None
+        and (
+            largest_share > max_single_abs_share * 0.8
+            or negative_share > max_negative_abs_share * 0.8
+            or entropy < min_sign_entropy_bits * 1.2
+        )
+    ):
+        risk_state = "tail_entropy_watch"
+        explanation = "Tail/entropy concentration is near configured thresholds."
+    else:
+        risk_state = "tail_entropy_clear"
+        explanation = "Tail/entropy diagnostics are within configured context-only thresholds."
+
+    return TailEntropyDiagnostic(
+        observation_count=observation_count,
+        negative_observation_count=negative_count,
+        worst_observation=worst,
+        best_observation=best,
+        mean_observation=average,
+        largest_abs_contribution_share=largest_share,
+        negative_contribution_share=negative_share,
+        sign_entropy_bits=entropy,
+        risk_state=risk_state,
+        explanation=explanation,
+    )
+
+
+def tail_entropy_manifest() -> dict[str, object]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "risk_states": list(RISK_STATES),
+        "authority": {
+            "tail_entropy_diagnostics_are_context_only": True,
+            "not_alpha_authority": True,
+            "not_candidate_promotion": True,
+            "not_strategy_registration": True,
+            "not_paper_shadow_live": True,
+            "not_broker_execution": True,
+            "does_not_fetch_data": True,
+            "does_not_mutate_candidates": True,
+            "does_not_mutate_frozen_contracts": True,
+        },
+    }

--- a/research/qre_tail_entropy_hardening_report.py
+++ b/research/qre_tail_entropy_hardening_report.py
@@ -1,0 +1,184 @@
+"""QRE tail/entropy hardening report surface.
+
+This report materializes deterministic, read-only tail/entropy diagnostics.
+It is diagnostic context only and cannot mutate candidates, promote strategies,
+fetch data, or authorize paper/shadow/live/broker execution.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections import Counter
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Final
+
+from research.qre_tail_entropy_hardening import (
+    diagnose_tail_entropy,
+    tail_entropy_manifest,
+)
+
+
+REPORT_KIND: Final[str] = "qre_tail_entropy_hardening_report"
+SCHEMA_VERSION: Final[str] = "1.0"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_tail_entropy_hardening")
+LATEST_NAME: Final[str] = "latest.json"
+OPERATOR_SUMMARY_NAME: Final[str] = "operator_summary.md"
+WRITE_PREFIX: Final[str] = "logs/qre_tail_entropy_hardening/"
+
+
+def _sample_observation_sets() -> list[dict[str, Any]]:
+    return [
+        {
+            "subject_id": "sample:balanced",
+            "observations": [0.01, -0.01, 0.02, -0.02, 0.015, -0.015],
+            "description": "Balanced positive/negative sample.",
+        },
+        {
+            "subject_id": "sample:single_trade_concentration",
+            "observations": [0.90, 0.01, -0.01, 0.01, -0.01, 0.01],
+            "description": "One observation dominates total absolute contribution.",
+        },
+        {
+            "subject_id": "sample:insufficient",
+            "observations": [0.01, -0.01],
+            "description": "Insufficient observations for trusted tail/entropy assessment.",
+        },
+    ]
+
+
+def build_tail_entropy_hardening_report(
+    *,
+    repo_root: Path = Path("."),
+    observation_sets: list[Mapping[str, Any]] | None = None,
+) -> dict[str, Any]:
+    manifest = tail_entropy_manifest()
+    rows = list(observation_sets) if observation_sets is not None else _sample_observation_sets()
+
+    diagnostics = []
+    for row in rows:
+        observations = row.get("observations") if isinstance(row, Mapping) else []
+        diagnostic = diagnose_tail_entropy(observations if isinstance(observations, list) else [])
+        diagnostics.append(
+            {
+                "subject_id": str(row.get("subject_id") or "unknown"),
+                "description": str(row.get("description") or ""),
+                "observation_count": diagnostic.observation_count,
+                "negative_observation_count": diagnostic.negative_observation_count,
+                "worst_observation": diagnostic.worst_observation,
+                "best_observation": diagnostic.best_observation,
+                "mean_observation": diagnostic.mean_observation,
+                "largest_abs_contribution_share": diagnostic.largest_abs_contribution_share,
+                "negative_contribution_share": diagnostic.negative_contribution_share,
+                "sign_entropy_bits": diagnostic.sign_entropy_bits,
+                "risk_state": diagnostic.risk_state,
+                "explanation": diagnostic.explanation,
+            }
+        )
+
+    risk_state_counts = Counter(item["risk_state"] for item in diagnostics)
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "summary": {
+            "tail_entropy_hardening_ready": True,
+            "observation_set_count": len(rows),
+            "diagnostic_count": len(diagnostics),
+            "risk_state_counts": dict(sorted(risk_state_counts.items())),
+            "final_recommendation": "tail_entropy_hardening_scaffold_ready",
+            "operator_summary": (
+                "Tail/entropy hardening diagnostics are available as deterministic, "
+                "read-only context. They identify fragility but do not mutate candidates."
+            ),
+        },
+        "manifest": manifest,
+        "observation_sets": rows,
+        "diagnostics": diagnostics,
+        "safety_invariants": {
+            "read_only": True,
+            "uses_network": False,
+            "uses_external_data": False,
+            "uses_embeddings": False,
+            "uses_vector_db": False,
+            "uses_llm_authority": False,
+            "mutates_candidates": False,
+            "mutates_candidate_state": False,
+            "mutates_strategies": False,
+            "mutates_frozen_contracts": False,
+            "promotion_forbidden": True,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+        },
+    }
+
+
+def render_operator_summary(report: Mapping[str, Any]) -> str:
+    summary = report.get("summary") if isinstance(report.get("summary"), Mapping) else {}
+    return "\n".join(
+        [
+            "# QRE Tail Entropy Hardening",
+            "",
+            f"- {summary.get('operator_summary') or ''}",
+            "",
+            "## Current Status",
+            "",
+            f"- tail_entropy_hardening_ready: {summary.get('tail_entropy_hardening_ready')}",
+            f"- observation_set_count: {summary.get('observation_set_count')}",
+            f"- diagnostic_count: {summary.get('diagnostic_count')}",
+            f"- final_recommendation: {summary.get('final_recommendation')}",
+            "",
+        ]
+    )
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(
+            f"qre_tail_entropy_hardening_report: refusing write outside allowlist: {path!r}"
+        )
+
+
+def write_outputs(report: Mapping[str, Any], *, repo_root: Path = Path(".")) -> dict[str, str]:
+    base = repo_root / DEFAULT_OUTPUT_DIR
+    base.mkdir(parents=True, exist_ok=True)
+    latest = base / LATEST_NAME
+    summary_path = base / OPERATOR_SUMMARY_NAME
+
+    for target in (latest, summary_path):
+        _validate_write_target(target)
+
+    tmp_json = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp_json, latest)
+
+    tmp_md = summary_path.with_suffix(summary_path.suffix + ".tmp")
+    tmp_md.write_text(render_operator_summary(report), encoding="utf-8")
+    os.replace(tmp_md, summary_path)
+
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "operator_summary": summary_path.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_tail_entropy_hardening_report",
+        description="Build read-only QRE tail/entropy hardening report.",
+    )
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+
+    report = build_tail_entropy_hardening_report()
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/unit/test_qre_null_model_baseline.py
+++ b/tests/unit/test_qre_null_model_baseline.py
@@ -1,0 +1,119 @@
+from research.qre_null_model_baseline import (
+    compare_metric_to_baseline,
+    median_candidate_baseline,
+    null_model_manifest,
+)
+
+
+def test_null_model_manifest_is_context_only():
+    manifest = null_model_manifest()
+
+    assert manifest["schema_version"] == "1.0"
+    assert "zero_return" in manifest["baseline_types"]
+    assert "buy_and_hold" in manifest["baseline_types"]
+    assert "median_candidate" in manifest["baseline_types"]
+
+    authority = manifest["authority"]
+    assert authority["null_model_is_context_only"] is True
+    assert authority["not_alpha_authority"] is True
+    assert authority["not_candidate_promotion"] is True
+    assert authority["not_strategy_registration"] is True
+    assert authority["not_paper_shadow_live"] is True
+    assert authority["not_broker_execution"] is True
+    assert authority["does_not_fetch_data"] is True
+    assert authority["does_not_mutate_frozen_contracts"] is True
+
+
+def test_compare_metric_above_baseline():
+    result = compare_metric_to_baseline(
+        candidate_metric=0.12,
+        baseline_metric=0.05,
+        baseline_type="zero_return",
+    )
+
+    assert result.comparison_state == "candidate_above_baseline"
+    assert round(result.delta_vs_baseline or 0.0, 10) == 0.07
+    assert result.baseline_type == "zero_return"
+
+
+def test_compare_metric_below_baseline():
+    result = compare_metric_to_baseline(
+        candidate_metric=-0.02,
+        baseline_metric=0.03,
+        baseline_type="buy_and_hold",
+    )
+
+    assert result.comparison_state == "candidate_below_baseline"
+    assert round(result.delta_vs_baseline or 0.0, 10) == -0.05
+
+
+def test_compare_metric_equal_baseline():
+    result = compare_metric_to_baseline(
+        candidate_metric=0.03,
+        baseline_metric=0.03,
+        baseline_type="median_candidate",
+    )
+
+    assert result.comparison_state == "candidate_equal_to_baseline"
+    assert result.delta_vs_baseline == 0.0
+
+
+def test_compare_metric_fail_closed_on_missing_metrics():
+    result = compare_metric_to_baseline(
+        candidate_metric=None,
+        baseline_metric=0.03,
+        baseline_type="buy_and_hold",
+    )
+
+    assert result.comparison_state == "insufficient_metric_data"
+    assert result.delta_vs_baseline is None
+
+
+def test_unknown_baseline_type_is_normalized():
+    result = compare_metric_to_baseline(
+        candidate_metric=1,
+        baseline_metric=0,
+        baseline_type="not_real",
+    )
+
+    assert result.baseline_type == "unknown"
+
+
+def test_median_candidate_baseline_odd_count():
+    rows = [
+        {"score": 0.1},
+        {"score": 0.3},
+        {"score": 0.2},
+    ]
+
+    assert median_candidate_baseline(rows, metric_field="score") == 0.2
+
+
+def test_median_candidate_baseline_even_count():
+    rows = [
+        {"score": 0.1},
+        {"score": 0.4},
+        {"score": 0.2},
+        {"score": 0.3},
+    ]
+
+    assert median_candidate_baseline(rows, metric_field="score") == 0.25
+
+
+def test_median_candidate_baseline_ignores_non_numeric_values():
+    rows = [
+        {"score": "bad"},
+        {"score": None},
+        {"score": 0.2},
+    ]
+
+    assert median_candidate_baseline(rows, metric_field="score") == 0.2
+
+
+def test_median_candidate_baseline_returns_none_without_numeric_values():
+    rows = [
+        {"score": "bad"},
+        {"score": None},
+    ]
+
+    assert median_candidate_baseline(rows, metric_field="score") is None

--- a/tests/unit/test_qre_null_model_baseline_report.py
+++ b/tests/unit/test_qre_null_model_baseline_report.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+
+import pytest
+
+from research.qre_null_model_baseline_report import (
+    build_null_model_baseline_report,
+    render_operator_summary,
+    write_outputs,
+)
+
+
+def test_null_model_baseline_report_is_ready_and_context_only():
+    report = build_null_model_baseline_report()
+
+    assert report["schema_version"] == "1.0"
+    assert report["report_kind"] == "qre_null_model_baseline_report"
+    assert report["summary"]["null_model_baseline_ready"] is True
+    assert report["summary"]["final_recommendation"] == "null_model_baseline_scaffold_ready"
+
+    safety = report["safety_invariants"]
+    assert safety["read_only"] is True
+    assert safety["uses_network"] is False
+    assert safety["uses_external_data"] is False
+    assert safety["mutates_candidates"] is False
+    assert safety["mutates_strategies"] is False
+    assert safety["mutates_frozen_contracts"] is False
+    assert safety["promotion_forbidden"] is True
+    assert safety["paper_shadow_live_forbidden"] is True
+    assert safety["broker_risk_execution_forbidden"] is True
+
+
+def test_null_model_baseline_report_has_sample_comparisons():
+    report = build_null_model_baseline_report()
+
+    assert report["summary"]["sample_row_count"] == 3
+    assert len(report["sample_comparisons"]) == 3
+    assert "sample_comparison_counts" in report["summary"]
+
+
+def test_null_model_baseline_operator_summary_renders():
+    report = build_null_model_baseline_report()
+    text = render_operator_summary(report)
+
+    assert "# QRE Null Model Baseline" in text
+    assert "final_recommendation" in text
+    assert "null_model_baseline_scaffold_ready" in text
+
+
+def test_null_model_baseline_write_outputs_stays_in_allowlist(tmp_path: Path):
+    report = build_null_model_baseline_report()
+    paths = write_outputs(report, repo_root=tmp_path)
+
+    assert paths["latest"] == "logs/qre_null_model_baseline/latest.json"
+    assert paths["operator_summary"] == "logs/qre_null_model_baseline/operator_summary.md"
+    assert (tmp_path / paths["latest"]).exists()
+    assert (tmp_path / paths["operator_summary"]).exists()
+
+
+def test_null_model_baseline_write_rejects_non_allowlisted_path(monkeypatch, tmp_path: Path):
+    from research import qre_null_model_baseline_report as report_module
+
+    monkeypatch.setattr(report_module, "DEFAULT_OUTPUT_DIR", Path("bad"))
+    report = build_null_model_baseline_report()
+
+    with pytest.raises(ValueError):
+        write_outputs(report, repo_root=tmp_path)

--- a/tests/unit/test_qre_state_transition_diagnostics.py
+++ b/tests/unit/test_qre_state_transition_diagnostics.py
@@ -1,0 +1,138 @@
+from research.qre_state_transition_diagnostics import (
+    diagnose_state_transition,
+    diagnose_transition_rows,
+    transition_diagnostic_manifest,
+)
+
+
+def test_transition_manifest_is_context_only():
+    manifest = transition_diagnostic_manifest()
+
+    assert manifest["schema_version"] == "1.0"
+    assert "candidate_discovered" in manifest["state_names"]
+    assert "validated" in manifest["state_names"]
+    assert "fail_closed" in manifest["state_names"]
+    assert "null_model_required" in manifest["transition_reasons"]
+
+    authority = manifest["authority"]
+    assert authority["state_transition_diagnostics_are_context_only"] is True
+    assert authority["not_alpha_authority"] is True
+    assert authority["not_candidate_promotion"] is True
+    assert authority["not_strategy_registration"] is True
+    assert authority["not_paper_shadow_live"] is True
+    assert authority["not_broker_execution"] is True
+    assert authority["does_not_fetch_data"] is True
+    assert authority["does_not_mutate_candidates"] is True
+    assert authority["does_not_mutate_frozen_contracts"] is True
+
+
+def test_positive_progress_transition():
+    diagnostic = diagnose_state_transition(
+        subject_id="candidate:1",
+        prior_state="screened",
+        new_state="validation_candidate",
+        transition_reason="criteria_passed",
+        evidence_ref="research/example.json",
+        artifact_ref="logs/example/latest.json",
+    )
+
+    assert diagnostic.subject_id == "candidate:1"
+    assert diagnostic.prior_state == "screened"
+    assert diagnostic.new_state == "validation_candidate"
+    assert diagnostic.transition_reason == "criteria_passed"
+    assert diagnostic.transition_state == "positive_progress_transition"
+    assert diagnostic.evidence_ref == "research/example.json"
+    assert diagnostic.artifact_ref == "logs/example/latest.json"
+
+
+def test_terminal_negative_transition():
+    diagnostic = diagnose_state_transition(
+        subject_id="candidate:2",
+        prior_state="screened",
+        new_state="blocked",
+        transition_reason="data_readiness_blocked",
+        blocker_class="missing_required_field",
+    )
+
+    assert diagnostic.transition_state == "terminal_negative_transition"
+    assert diagnostic.blocker_class == "missing_required_field"
+
+
+def test_fail_closed_transition_is_terminal_negative():
+    diagnostic = diagnose_state_transition(
+        subject_id="candidate:3",
+        prior_state="validation_candidate",
+        new_state="fail_closed",
+        transition_reason="lineage_missing",
+    )
+
+    assert diagnostic.transition_state == "terminal_negative_transition"
+
+
+def test_no_state_change_transition():
+    diagnostic = diagnose_state_transition(
+        subject_id="candidate:4",
+        prior_state="screened",
+        new_state="screened",
+        transition_reason="operator_review_required",
+    )
+
+    assert diagnostic.transition_state == "no_state_change"
+
+
+def test_unknown_states_fail_closed_to_insufficient_state_data():
+    diagnostic = diagnose_state_transition(
+        subject_id="candidate:5",
+        prior_state="not_real",
+        new_state="validated",
+        transition_reason="criteria_passed",
+    )
+
+    assert diagnostic.prior_state == "unknown"
+    assert diagnostic.transition_state == "insufficient_state_data"
+
+
+def test_unknown_reason_is_normalized():
+    diagnostic = diagnose_state_transition(
+        subject_id="candidate:6",
+        prior_state="candidate_discovered",
+        new_state="screened",
+        transition_reason="not_real",
+    )
+
+    assert diagnostic.transition_reason == "unknown"
+    assert diagnostic.transition_state == "positive_progress_transition"
+
+
+def test_missing_subject_id_is_normalized():
+    diagnostic = diagnose_state_transition(
+        subject_id="",
+        prior_state="candidate_discovered",
+        new_state="screened",
+    )
+
+    assert diagnostic.subject_id == "unknown"
+
+
+def test_diagnose_transition_rows_ignores_non_mappings():
+    rows = [
+        {
+            "subject_id": "candidate:1",
+            "prior_state": "candidate_discovered",
+            "new_state": "screened",
+            "transition_reason": "criteria_passed",
+        },
+        "bad",
+        {
+            "subject_id": "candidate:2",
+            "prior_state": "screened",
+            "new_state": "rejected",
+            "transition_reason": "criteria_failed",
+        },
+    ]
+
+    diagnostics = diagnose_transition_rows(rows)  # type: ignore[arg-type]
+
+    assert len(diagnostics) == 2
+    assert diagnostics[0].transition_state == "positive_progress_transition"
+    assert diagnostics[1].transition_state == "terminal_negative_transition"

--- a/tests/unit/test_qre_state_transition_diagnostics_report.py
+++ b/tests/unit/test_qre_state_transition_diagnostics_report.py
@@ -1,0 +1,85 @@
+from pathlib import Path
+
+import pytest
+
+from research.qre_state_transition_diagnostics_report import (
+    build_state_transition_diagnostics_report,
+    render_operator_summary,
+    write_outputs,
+)
+
+
+def test_state_transition_report_is_ready_and_context_only():
+    report = build_state_transition_diagnostics_report()
+
+    assert report["schema_version"] == "1.0"
+    assert report["report_kind"] == "qre_state_transition_diagnostics_report"
+    assert report["summary"]["state_transition_diagnostics_ready"] is True
+    assert report["summary"]["final_recommendation"] == "state_transition_diagnostics_scaffold_ready"
+
+    safety = report["safety_invariants"]
+    assert safety["read_only"] is True
+    assert safety["uses_network"] is False
+    assert safety["uses_external_data"] is False
+    assert safety["mutates_candidates"] is False
+    assert safety["mutates_candidate_state"] is False
+    assert safety["mutates_strategies"] is False
+    assert safety["mutates_frozen_contracts"] is False
+    assert safety["promotion_forbidden"] is True
+    assert safety["paper_shadow_live_forbidden"] is True
+    assert safety["broker_risk_execution_forbidden"] is True
+
+
+def test_state_transition_report_has_diagnostics_and_counts():
+    report = build_state_transition_diagnostics_report()
+
+    assert report["summary"]["transition_row_count"] == 3
+    assert report["summary"]["diagnostic_count"] == 3
+    assert len(report["diagnostics"]) == 3
+    assert "positive_progress_transition" in report["summary"]["transition_state_counts"]
+    assert "terminal_negative_transition" in report["summary"]["transition_state_counts"]
+
+
+def test_state_transition_report_accepts_custom_rows():
+    report = build_state_transition_diagnostics_report(
+        transition_rows=[
+            {
+                "subject_id": "candidate:custom",
+                "prior_state": "screened",
+                "new_state": "fail_closed",
+                "transition_reason": "lineage_missing",
+            }
+        ]
+    )
+
+    assert report["summary"]["transition_row_count"] == 1
+    assert report["diagnostics"][0]["transition_state"] == "terminal_negative_transition"
+
+
+def test_state_transition_operator_summary_renders():
+    report = build_state_transition_diagnostics_report()
+    text = render_operator_summary(report)
+
+    assert "# QRE State Transition Diagnostics" in text
+    assert "final_recommendation" in text
+    assert "state_transition_diagnostics_scaffold_ready" in text
+
+
+def test_state_transition_write_outputs_stays_in_allowlist(tmp_path: Path):
+    report = build_state_transition_diagnostics_report()
+    paths = write_outputs(report, repo_root=tmp_path)
+
+    assert paths["latest"] == "logs/qre_state_transition_diagnostics/latest.json"
+    assert paths["operator_summary"] == "logs/qre_state_transition_diagnostics/operator_summary.md"
+    assert (tmp_path / paths["latest"]).exists()
+    assert (tmp_path / paths["operator_summary"]).exists()
+
+
+def test_state_transition_write_rejects_non_allowlisted_path(monkeypatch, tmp_path: Path):
+    from research import qre_state_transition_diagnostics_report as report_module
+
+    monkeypatch.setattr(report_module, "DEFAULT_OUTPUT_DIR", Path("bad"))
+    report = build_state_transition_diagnostics_report()
+
+    with pytest.raises(ValueError):
+        write_outputs(report, repo_root=tmp_path)

--- a/tests/unit/test_qre_tail_entropy_hardening.py
+++ b/tests/unit/test_qre_tail_entropy_hardening.py
@@ -1,0 +1,84 @@
+from research.qre_tail_entropy_hardening import (
+    diagnose_tail_entropy,
+    tail_entropy_manifest,
+)
+
+
+def test_tail_entropy_manifest_is_context_only():
+    manifest = tail_entropy_manifest()
+
+    assert manifest["schema_version"] == "1.0"
+    assert "tail_entropy_clear" in manifest["risk_states"]
+    assert "tail_entropy_blocked" in manifest["risk_states"]
+
+    authority = manifest["authority"]
+    assert authority["tail_entropy_diagnostics_are_context_only"] is True
+    assert authority["not_alpha_authority"] is True
+    assert authority["not_candidate_promotion"] is True
+    assert authority["not_strategy_registration"] is True
+    assert authority["not_paper_shadow_live"] is True
+    assert authority["not_broker_execution"] is True
+    assert authority["does_not_fetch_data"] is True
+    assert authority["does_not_mutate_candidates"] is True
+    assert authority["does_not_mutate_frozen_contracts"] is True
+
+
+def test_tail_entropy_clear_for_balanced_observations():
+    diagnostic = diagnose_tail_entropy([0.01, -0.01, 0.02, -0.02, 0.015, -0.015])
+
+    assert diagnostic.observation_count == 6
+    assert diagnostic.negative_observation_count == 3
+    assert diagnostic.risk_state == "tail_entropy_clear"
+
+
+def test_tail_entropy_blocked_for_single_trade_concentration():
+    diagnostic = diagnose_tail_entropy([0.90, 0.01, -0.01, 0.01, -0.01, 0.01])
+
+    assert diagnostic.risk_state == "tail_entropy_blocked"
+    assert diagnostic.largest_abs_contribution_share is not None
+    assert diagnostic.largest_abs_contribution_share > 0.50
+
+
+def test_tail_entropy_blocked_for_negative_contribution_concentration():
+    diagnostic = diagnose_tail_entropy([-0.50, -0.20, -0.10, 0.02, 0.02, 0.01])
+
+    assert diagnostic.risk_state == "tail_entropy_blocked"
+    assert diagnostic.negative_contribution_share is not None
+    assert diagnostic.negative_contribution_share > 0.70
+
+
+def test_tail_entropy_blocked_for_low_sign_entropy():
+    diagnostic = diagnose_tail_entropy([0.01, 0.02, 0.03, 0.04, 0.05, 0.06])
+
+    assert diagnostic.risk_state == "tail_entropy_blocked"
+    assert diagnostic.sign_entropy_bits == 0.0
+
+
+def test_tail_entropy_watch_near_threshold():
+    diagnostic = diagnose_tail_entropy(
+        [0.40, 0.10, -0.10, 0.10, -0.10, 0.10],
+        max_single_abs_share=0.55,
+    )
+
+    assert diagnostic.risk_state in {"tail_entropy_watch", "tail_entropy_blocked"}
+
+
+def test_tail_entropy_insufficient_data():
+    diagnostic = diagnose_tail_entropy([0.01, -0.01], min_observations=5)
+
+    assert diagnostic.risk_state == "insufficient_return_data"
+    assert diagnostic.observation_count == 2
+
+
+def test_tail_entropy_ignores_non_numeric_values():
+    diagnostic = diagnose_tail_entropy([0.01, "bad", None, -0.01, 0.02, -0.02, 0.03])
+
+    assert diagnostic.observation_count == 5
+
+
+def test_tail_entropy_handles_all_zero_values():
+    diagnostic = diagnose_tail_entropy([0, 0, 0, 0, 0])
+
+    assert diagnostic.observation_count == 5
+    assert diagnostic.largest_abs_contribution_share == 0.0
+    assert diagnostic.negative_contribution_share == 0.0

--- a/tests/unit/test_qre_tail_entropy_hardening_report.py
+++ b/tests/unit/test_qre_tail_entropy_hardening_report.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+
+import pytest
+
+from research.qre_tail_entropy_hardening_report import (
+    build_tail_entropy_hardening_report,
+    render_operator_summary,
+    write_outputs,
+)
+
+
+def test_tail_entropy_report_is_ready_and_context_only():
+    report = build_tail_entropy_hardening_report()
+
+    assert report["schema_version"] == "1.0"
+    assert report["report_kind"] == "qre_tail_entropy_hardening_report"
+    assert report["summary"]["tail_entropy_hardening_ready"] is True
+    assert report["summary"]["final_recommendation"] == "tail_entropy_hardening_scaffold_ready"
+
+    safety = report["safety_invariants"]
+    assert safety["read_only"] is True
+    assert safety["uses_network"] is False
+    assert safety["uses_external_data"] is False
+    assert safety["mutates_candidates"] is False
+    assert safety["mutates_candidate_state"] is False
+    assert safety["mutates_strategies"] is False
+    assert safety["mutates_frozen_contracts"] is False
+    assert safety["promotion_forbidden"] is True
+    assert safety["paper_shadow_live_forbidden"] is True
+    assert safety["broker_risk_execution_forbidden"] is True
+
+
+def test_tail_entropy_report_has_diagnostics_and_counts():
+    report = build_tail_entropy_hardening_report()
+
+    assert report["summary"]["observation_set_count"] == 3
+    assert report["summary"]["diagnostic_count"] == 3
+    assert len(report["diagnostics"]) == 3
+    assert "risk_state_counts" in report["summary"]
+    assert "tail_entropy_blocked" in report["summary"]["risk_state_counts"]
+
+
+def test_tail_entropy_report_accepts_custom_observation_sets():
+    report = build_tail_entropy_hardening_report(
+        observation_sets=[
+            {
+                "subject_id": "candidate:custom",
+                "observations": [0.90, 0.01, -0.01, 0.01, -0.01, 0.01],
+                "description": "custom concentrated sample",
+            }
+        ]
+    )
+
+    assert report["summary"]["observation_set_count"] == 1
+    assert report["diagnostics"][0]["risk_state"] == "tail_entropy_blocked"
+
+
+def test_tail_entropy_operator_summary_renders():
+    report = build_tail_entropy_hardening_report()
+    text = render_operator_summary(report)
+
+    assert "# QRE Tail Entropy Hardening" in text
+    assert "final_recommendation" in text
+    assert "tail_entropy_hardening_scaffold_ready" in text
+
+
+def test_tail_entropy_write_outputs_stays_in_allowlist(tmp_path: Path):
+    report = build_tail_entropy_hardening_report()
+    paths = write_outputs(report, repo_root=tmp_path)
+
+    assert paths["latest"] == "logs/qre_tail_entropy_hardening/latest.json"
+    assert paths["operator_summary"] == "logs/qre_tail_entropy_hardening/operator_summary.md"
+    assert (tmp_path / paths["latest"]).exists()
+    assert (tmp_path / paths["operator_summary"]).exists()
+
+
+def test_tail_entropy_write_rejects_non_allowlisted_path(monkeypatch, tmp_path: Path):
+    from research import qre_tail_entropy_hardening_report as report_module
+
+    monkeypatch.setattr(report_module, "DEFAULT_OUTPUT_DIR", Path("bad"))
+    report = build_tail_entropy_hardening_report()
+
+    with pytest.raises(ValueError):
+        write_outputs(report, repo_root=tmp_path)


### PR DESCRIPTION
Implements all D-stage roadmap blocks in one PR with separate commits.

Adds:
- D01 null-model baseline scaffold
- D01.5 null-model baseline report surface
- D02 state-transition diagnostics scaffold
- D02.5 state-transition diagnostics report surface
- D03 tail/entropy hardening scaffold
- D03.5 tail/entropy hardening report surface

Safety:
- deterministic read-only diagnostics only
- no frozen contract mutation
- no research/research_latest.json or research/strategy_matrix.csv mutation
- no candidate promotion
- no strategy registration
- no trade signals
- no provider activation
- no data fetching
- no paper/shadow/live
- no broker/risk/execution

Local validation:
- D01 unit tests: 10 passed
- D01 report tests: 5 passed
- D02 unit tests: 9 passed
- D02 report tests: 6 passed
- D03 unit tests: 9 passed
- D03 report tests: 6 passed
- architecture tests: 157 passed
- governance/no_touch/frozen_contract/execution_authority slice: 391 passed
- governance_lint: OK
- smoke tests: 18 passed