### PR TITLE
fix: add QRE E-stage sampling and routing calibration

### DIFF
--- a/research/qre_routing_calibration.py
+++ b/research/qre_routing_calibration.py
@@ -1,0 +1,162 @@
+"""Deterministic QRE routing calibration scaffold.
+
+This module recommends read-only evidence routing targets from existing context.
+It does not mutate queues, candidates, campaigns, strategies, presets, or
+execution state.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+SCHEMA_VERSION = "1.0"
+
+
+ROUTING_TARGETS: tuple[str, ...] = (
+    "sampling_calibration",
+    "data_readiness",
+    "source_quality",
+    "identity_resolution",
+    "factor_coverage",
+    "null_model_baseline",
+    "state_transition_diagnostics",
+    "tail_entropy_hardening",
+    "failure_retrieval",
+    "operator_review",
+    "excluded_scope_archive",
+)
+
+
+@dataclass(frozen=True)
+class RoutingCalibration:
+    subject_id: str
+    routing_targets: tuple[str, ...]
+    routing_priority: int
+    routing_decision: str
+    explanation: str
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip().lower()
+
+
+def _contains_any(text: str, markers: tuple[str, ...]) -> bool:
+    return any(marker in text for marker in markers)
+
+
+def calibrate_routing_context(record: Mapping[str, Any]) -> RoutingCalibration:
+    """Recommend deterministic read-only routing targets for one context row."""
+
+    subject_id = str(record.get("subject_id") or record.get("candidate_id") or "unknown")
+    ontology = record.get("ontology_classification")
+    ontology = ontology if isinstance(ontology, Mapping) else {}
+
+    asset_class = _text(record.get("asset_class") or ontology.get("asset_class"))
+    research_scope = _text(record.get("research_scope") or ontology.get("research_scope"))
+    readiness_state = _text(record.get("readiness_state") or ontology.get("readiness_state"))
+    blocker_class = _text(record.get("blocker_class") or record.get("blocker_code"))
+    record_kind = _text(record.get("record_kind"))
+    title = _text(record.get("title"))
+    text_preview = _text(record.get("text_preview"))
+    artifact_id = _text(record.get("artifact_id"))
+    metadata_text = " ".join([title, text_preview, artifact_id, str(record.get("metadata") or "").lower()])
+
+    targets: set[str] = set()
+    priority = 0
+
+    if asset_class == "crypto_legacy" or research_scope in {
+        "excluded_from_current_research_scope",
+        "legacy_non_target_reference",
+    }:
+        return RoutingCalibration(
+            subject_id=subject_id,
+            routing_targets=("excluded_scope_archive",),
+            routing_priority=0,
+            routing_decision="route_to_archive_only",
+            explanation="Excluded/legacy context is routed to archive only, not active research calibration.",
+        )
+
+    targets.add("sampling_calibration")
+    priority += 10
+
+    if readiness_state in {"blocked", "not_ready", "fail_closed"} or _contains_any(
+        blocker_class, ("missing", "blocked", "unknown")
+    ):
+        targets.add("data_readiness")
+        targets.add("failure_retrieval")
+        priority += 30
+
+    if _contains_any(metadata_text, ("source_manifest", "provider", "companyfacts", "openfigi", "source_quality")):
+        targets.add("source_quality")
+        priority += 20
+
+    if _contains_any(metadata_text, ("identity", "symbol", "figi", "isin", "ticker", "ambiguous")):
+        targets.add("identity_resolution")
+        priority += 20
+
+    if _contains_any(metadata_text, ("factor", "field_coverage", "fundamental", "metric")):
+        targets.add("factor_coverage")
+        priority += 20
+
+    if _contains_any(metadata_text, ("null_model", "baseline", "above_baseline", "below_baseline")):
+        targets.add("null_model_baseline")
+        priority += 15
+
+    if _contains_any(metadata_text, ("transition", "state", "screened", "validation_candidate", "blocked")):
+        targets.add("state_transition_diagnostics")
+        priority += 15
+
+    if _contains_any(metadata_text, ("tail", "entropy", "drawdown", "concentration", "risk_state")):
+        targets.add("tail_entropy_hardening")
+        priority += 15
+
+    if record_kind in {"failure_action", "reason_record"}:
+        targets.add("failure_retrieval")
+        priority += 20
+
+    if not targets:
+        targets.add("operator_review")
+
+    if priority >= 60:
+        decision = "route_high_priority"
+    elif priority >= 25:
+        decision = "route_standard"
+    else:
+        decision = "route_low_priority"
+
+    return RoutingCalibration(
+        subject_id=subject_id,
+        routing_targets=tuple(sorted(targets)),
+        routing_priority=priority,
+        routing_decision=decision,
+        explanation="Deterministic routing calibration context only; no queue or campaign mutation authority.",
+    )
+
+
+def calibrate_routing_rows(rows: list[Mapping[str, Any]]) -> list[RoutingCalibration]:
+    return [calibrate_routing_context(row) for row in rows if isinstance(row, Mapping)]
+
+
+def routing_calibration_manifest() -> dict[str, object]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "routing_targets": list(ROUTING_TARGETS),
+        "authority": {
+            "routing_calibration_is_context_only": True,
+            "not_queue_mutation": True,
+            "not_candidate_promotion": True,
+            "not_campaign_mutation": True,
+            "not_strategy_registration": True,
+            "not_paper_shadow_live": True,
+            "not_broker_execution": True,
+            "does_not_fetch_data": True,
+            "does_not_mutate_queues": True,
+            "does_not_mutate_candidates": True,
+            "does_not_mutate_campaigns": True,
+            "does_not_mutate_strategies": True,
+            "does_not_mutate_presets": True,
+            "does_not_mutate_frozen_contracts": True,
+        },
+    }

--- a/research/qre_routing_calibration_report.py
+++ b/research/qre_routing_calibration_report.py
@@ -1,0 +1,197 @@
+"""QRE routing calibration report surface.
+
+This report materializes deterministic, read-only routing calibration context.
+It does not mutate queues, candidates, campaigns, strategies, presets, or execution state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections import Counter
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Final
+
+from research.qre_routing_calibration import (
+    calibrate_routing_rows,
+    routing_calibration_manifest,
+)
+
+
+REPORT_KIND: Final[str] = "qre_routing_calibration_report"
+SCHEMA_VERSION: Final[str] = "1.0"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_routing_calibration")
+LATEST_NAME: Final[str] = "latest.json"
+OPERATOR_SUMMARY_NAME: Final[str] = "operator_summary.md"
+WRITE_PREFIX: Final[str] = "logs/qre_routing_calibration/"
+
+
+def _sample_rows() -> list[dict[str, Any]]:
+    return [
+        {
+            "subject_id": "sample:crypto_archive",
+            "ontology_classification": {
+                "asset_class": "crypto_legacy",
+                "research_scope": "excluded_from_current_research_scope",
+            },
+            "title": "BTC-USD crypto legacy archive context",
+        },
+        {
+            "subject_id": "sample:source_identity",
+            "asset_class": "equity",
+            "research_scope": "target_source_data_research",
+            "title": "OpenFIGI provider source_manifest identity ticker ambiguity",
+        },
+        {
+            "subject_id": "sample:factor_null",
+            "asset_class": "fundamental_equity",
+            "research_scope": "target_factor_research",
+            "title": "fundamental factor field_coverage null_model baseline",
+        },
+        {
+            "subject_id": "sample:state_tail",
+            "asset_class": "equity",
+            "research_scope": "target_equity_research",
+            "title": "state transition blocked tail entropy drawdown concentration",
+        },
+        {
+            "subject_id": "sample:blocked_failure",
+            "asset_class": "equity",
+            "research_scope": "target_equity_research",
+            "readiness_state": "blocked",
+            "blocker_class": "missing_required_field",
+            "record_kind": "failure_action",
+        },
+    ]
+
+
+def build_routing_calibration_report(
+    *,
+    repo_root: Path = Path("."),
+    rows: list[Mapping[str, Any]] | None = None,
+) -> dict[str, Any]:
+    manifest = routing_calibration_manifest()
+    input_rows = list(rows) if rows is not None else _sample_rows()
+    calibrations = calibrate_routing_rows(input_rows)
+
+    decision_counts = Counter(item.routing_decision for item in calibrations)
+    target_counts = Counter(target for item in calibrations for target in item.routing_targets)
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "summary": {
+            "routing_calibration_ready": True,
+            "input_row_count": len(input_rows),
+            "calibration_count": len(calibrations),
+            "routing_decision_counts": dict(sorted(decision_counts.items())),
+            "routing_target_counts": dict(sorted(target_counts.items())),
+            "excluded_scope_archive_count": target_counts.get("excluded_scope_archive", 0),
+            "final_recommendation": "routing_calibration_scaffold_ready",
+            "operator_summary": (
+                "Routing calibration is available as deterministic, read-only context. "
+                "It recommends diagnostic routing targets without mutating queues or campaigns."
+            ),
+        },
+        "manifest": manifest,
+        "input_rows": input_rows,
+        "calibrations": [
+            {
+                "subject_id": item.subject_id,
+                "routing_targets": list(item.routing_targets),
+                "routing_priority": item.routing_priority,
+                "routing_decision": item.routing_decision,
+                "explanation": item.explanation,
+            }
+            for item in calibrations
+        ],
+        "safety_invariants": {
+            "read_only": True,
+            "uses_network": False,
+            "uses_external_data": False,
+            "uses_embeddings": False,
+            "uses_vector_db": False,
+            "uses_llm_authority": False,
+            "mutates_queues": False,
+            "mutates_candidates": False,
+            "mutates_campaigns": False,
+            "mutates_strategies": False,
+            "mutates_presets": False,
+            "mutates_frozen_contracts": False,
+            "queue_mutation_forbidden": True,
+            "promotion_forbidden": True,
+            "campaign_mutation_forbidden": True,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+        },
+    }
+
+
+def render_operator_summary(report: Mapping[str, Any]) -> str:
+    summary = report.get("summary") if isinstance(report.get("summary"), Mapping) else {}
+    return "\n".join(
+        [
+            "# QRE Routing Calibration",
+            "",
+            f"- {summary.get('operator_summary') or ''}",
+            "",
+            "## Current Status",
+            "",
+            f"- routing_calibration_ready: {summary.get('routing_calibration_ready')}",
+            f"- input_row_count: {summary.get('input_row_count')}",
+            f"- calibration_count: {summary.get('calibration_count')}",
+            f"- excluded_scope_archive_count: {summary.get('excluded_scope_archive_count')}",
+            f"- final_recommendation: {summary.get('final_recommendation')}",
+            "",
+        ]
+    )
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(f"qre_routing_calibration_report: refusing write outside allowlist: {path!r}")
+
+
+def write_outputs(report: Mapping[str, Any], *, repo_root: Path = Path(".")) -> dict[str, str]:
+    base = repo_root / DEFAULT_OUTPUT_DIR
+    base.mkdir(parents=True, exist_ok=True)
+    latest = base / LATEST_NAME
+    summary_path = base / OPERATOR_SUMMARY_NAME
+
+    for target in (latest, summary_path):
+        _validate_write_target(target)
+
+    tmp_json = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp_json, latest)
+
+    tmp_md = summary_path.with_suffix(summary_path.suffix + ".tmp")
+    tmp_md.write_text(render_operator_summary(report), encoding="utf-8")
+    os.replace(tmp_md, summary_path)
+
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "operator_summary": summary_path.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_routing_calibration_report",
+        description="Build read-only QRE routing calibration report.",
+    )
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+
+    report = build_routing_calibration_report()
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/research/qre_sampling_calibration.py
+++ b/research/qre_sampling_calibration.py
@@ -1,0 +1,209 @@
+"""Deterministic QRE sampling calibration scaffold.
+
+This module scores research sampling context using existing evidence metadata.
+It is read-only and cannot mutate candidates, campaigns, strategies, presets,
+or execution state.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+SCHEMA_VERSION = "1.0"
+
+
+SAMPLING_DECISIONS: tuple[str, ...] = (
+    "prefer_sampling",
+    "allow_sampling",
+    "deprioritize_sampling",
+    "exclude_sampling",
+)
+
+
+PREFERRED_REGIONS: tuple[str, ...] = (
+    "netherlands",
+    "europe",
+    "united_states",
+    "asia",
+)
+
+
+PREFERRED_ASSET_CLASSES: tuple[str, ...] = (
+    "equity",
+    "fundamental_equity",
+    "index",
+)
+
+
+EXCLUDED_ASSET_CLASSES: tuple[str, ...] = (
+    "crypto_legacy",
+)
+
+
+PREFERRED_RESEARCH_SCOPES: tuple[str, ...] = (
+    "target_equity_research",
+    "target_source_data_research",
+    "target_factor_research",
+)
+
+
+EXCLUDED_RESEARCH_SCOPES: tuple[str, ...] = (
+    "excluded_from_current_research_scope",
+    "legacy_non_target_reference",
+)
+
+
+@dataclass(frozen=True)
+class SamplingCalibration:
+    subject_id: str
+    sampling_score: int
+    sampling_decision: str
+    preferred_axes: tuple[str, ...]
+    penalty_axes: tuple[str, ...]
+    explanation: str
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip().lower()
+
+
+def _contains_any(text: str, markers: tuple[str, ...]) -> bool:
+    return any(marker in text for marker in markers)
+
+
+def _region_axis(metadata_text: str) -> str | None:
+    if _contains_any(metadata_text, ("netherlands", "nederland", "aex", "amsterdam", "euronext amsterdam")):
+        return "region:netherlands"
+    if _contains_any(metadata_text, ("europe", "europa", "euronext", "stoxx", "dax", "cac", "ftse")):
+        return "region:europe"
+    if _contains_any(metadata_text, ("united_states", "usa", "us equity", "nyse", "nasdaq", "s&p", "sp500")):
+        return "region:united_states"
+    if _contains_any(metadata_text, ("asia", "japan", "hong kong", "singapore", "nikkei", "topix")):
+        return "region:asia"
+    return None
+
+
+def calibrate_sampling_context(record: Mapping[str, Any]) -> SamplingCalibration:
+    """Calibrate sampling priority for one evidence/candidate context row.
+
+    This is advisory context only. It does not schedule or mutate campaigns.
+    """
+
+    subject_id = str(record.get("subject_id") or record.get("candidate_id") or "unknown")
+    ontology = record.get("ontology_classification")
+    ontology = ontology if isinstance(ontology, Mapping) else {}
+
+    asset_class = _text(record.get("asset_class") or ontology.get("asset_class"))
+    research_scope = _text(record.get("research_scope") or ontology.get("research_scope"))
+    readiness_state = _text(record.get("readiness_state") or ontology.get("readiness_state"))
+    title = _text(record.get("title"))
+    text_preview = _text(record.get("text_preview"))
+    artifact_id = _text(record.get("artifact_id"))
+    metadata_text = " ".join([title, text_preview, artifact_id, str(record.get("metadata") or "").lower()])
+
+    score = 0
+    preferred_axes: list[str] = []
+    penalty_axes: list[str] = []
+
+    if asset_class in EXCLUDED_ASSET_CLASSES:
+        penalty_axes.append(f"asset_class:{asset_class}")
+        return SamplingCalibration(
+            subject_id=subject_id,
+            sampling_score=-100,
+            sampling_decision="exclude_sampling",
+            preferred_axes=tuple(preferred_axes),
+            penalty_axes=tuple(penalty_axes),
+            explanation="Crypto legacy/non-target asset class is excluded from current sampling scope.",
+        )
+
+    if research_scope in EXCLUDED_RESEARCH_SCOPES:
+        penalty_axes.append(f"research_scope:{research_scope}")
+        return SamplingCalibration(
+            subject_id=subject_id,
+            sampling_score=-100,
+            sampling_decision="exclude_sampling",
+            preferred_axes=tuple(preferred_axes),
+            penalty_axes=tuple(penalty_axes),
+            explanation="Research scope is excluded from current sampling scope.",
+        )
+
+    if asset_class in PREFERRED_ASSET_CLASSES:
+        score += 30
+        preferred_axes.append(f"asset_class:{asset_class}")
+
+    if research_scope in PREFERRED_RESEARCH_SCOPES:
+        score += 30
+        preferred_axes.append(f"research_scope:{research_scope}")
+
+    if _contains_any(metadata_text, ("fundamental", "factor", "companyfacts", "source_manifest", "openfigi", "field_coverage")):
+        score += 20
+        preferred_axes.append("evidence:fundamental_source_or_factor")
+
+    region = _region_axis(metadata_text)
+    if region is not None:
+        score += 15
+        preferred_axes.append(region)
+
+    if readiness_state in {"blocked", "fail_closed", "not_ready"}:
+        score -= 40
+        penalty_axes.append(f"readiness_state:{readiness_state}")
+    elif readiness_state in {"partial", "unknown"}:
+        score -= 10
+        penalty_axes.append(f"readiness_state:{readiness_state}")
+    elif readiness_state == "ready":
+        score += 10
+        preferred_axes.append("readiness_state:ready")
+
+    if _contains_any(metadata_text, ("crypto", "btc-usd", "eth-usd", "sol-usd")):
+        score -= 80
+        penalty_axes.append("content:crypto_marker")
+
+    if score >= 60:
+        decision = "prefer_sampling"
+    elif score >= 20:
+        decision = "allow_sampling"
+    elif score > -50:
+        decision = "deprioritize_sampling"
+    else:
+        decision = "exclude_sampling"
+
+    return SamplingCalibration(
+        subject_id=subject_id,
+        sampling_score=score,
+        sampling_decision=decision,
+        preferred_axes=tuple(sorted(set(preferred_axes))),
+        penalty_axes=tuple(sorted(set(penalty_axes))),
+        explanation="Deterministic sampling calibration context only; no campaign mutation authority.",
+    )
+
+
+def calibrate_sampling_rows(rows: list[Mapping[str, Any]]) -> list[SamplingCalibration]:
+    return [calibrate_sampling_context(row) for row in rows if isinstance(row, Mapping)]
+
+
+def sampling_calibration_manifest() -> dict[str, object]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "sampling_decisions": list(SAMPLING_DECISIONS),
+        "preferred_regions": list(PREFERRED_REGIONS),
+        "preferred_asset_classes": list(PREFERRED_ASSET_CLASSES),
+        "excluded_asset_classes": list(EXCLUDED_ASSET_CLASSES),
+        "preferred_research_scopes": list(PREFERRED_RESEARCH_SCOPES),
+        "excluded_research_scopes": list(EXCLUDED_RESEARCH_SCOPES),
+        "authority": {
+            "sampling_calibration_is_context_only": True,
+            "not_alpha_authority": True,
+            "not_candidate_promotion": True,
+            "not_campaign_mutation": True,
+            "not_strategy_registration": True,
+            "not_paper_shadow_live": True,
+            "not_broker_execution": True,
+            "does_not_fetch_data": True,
+            "does_not_mutate_candidates": True,
+            "does_not_mutate_campaigns": True,
+            "does_not_mutate_strategies": True,
+            "does_not_mutate_frozen_contracts": True,
+        },
+    }

--- a/research/qre_sampling_calibration_report.py
+++ b/research/qre_sampling_calibration_report.py
@@ -1,0 +1,205 @@
+"""QRE sampling calibration report surface.
+
+This report materializes deterministic, read-only sampling calibration context.
+It does not mutate candidates, campaigns, strategies, presets, or execution state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections import Counter
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Final
+
+from research.qre_sampling_calibration import (
+    calibrate_sampling_rows,
+    sampling_calibration_manifest,
+)
+
+
+REPORT_KIND: Final[str] = "qre_sampling_calibration_report"
+SCHEMA_VERSION: Final[str] = "1.0"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_sampling_calibration")
+LATEST_NAME: Final[str] = "latest.json"
+OPERATOR_SUMMARY_NAME: Final[str] = "operator_summary.md"
+WRITE_PREFIX: Final[str] = "logs/qre_sampling_calibration/"
+
+
+def _sample_rows() -> list[dict[str, Any]]:
+    return [
+        {
+            "subject_id": "sample:crypto_legacy",
+            "ontology_classification": {
+                "asset_class": "crypto_legacy",
+                "research_scope": "excluded_from_current_research_scope",
+                "readiness_state": "blocked",
+            },
+            "title": "BTC-USD crypto legacy candidate",
+        },
+        {
+            "subject_id": "sample:netherlands_fundamental",
+            "asset_class": "fundamental_equity",
+            "research_scope": "target_equity_research",
+            "readiness_state": "ready",
+            "title": "AEX Netherlands fundamental factor field_coverage source_manifest",
+            "metadata": {"provider": "openfigi", "exchange": "euronext amsterdam"},
+        },
+        {
+            "subject_id": "sample:us_source_quality",
+            "asset_class": "equity",
+            "research_scope": "target_source_data_research",
+            "readiness_state": "partial",
+            "title": "NASDAQ US equity source_manifest provider quality",
+        },
+        {
+            "subject_id": "sample:asia_factor",
+            "asset_class": "index",
+            "research_scope": "target_factor_research",
+            "readiness_state": "ready",
+            "title": "Asia Japan Nikkei factor coverage",
+        },
+        {
+            "subject_id": "sample:blocked_unknown",
+            "asset_class": "equity",
+            "research_scope": "target_equity_research",
+            "readiness_state": "blocked",
+            "title": "equity candidate missing source lineage",
+        },
+    ]
+
+
+def build_sampling_calibration_report(
+    *,
+    repo_root: Path = Path("."),
+    rows: list[Mapping[str, Any]] | None = None,
+) -> dict[str, Any]:
+    manifest = sampling_calibration_manifest()
+    input_rows = list(rows) if rows is not None else _sample_rows()
+    calibrations = calibrate_sampling_rows(input_rows)
+
+    decision_counts = Counter(item.sampling_decision for item in calibrations)
+    preferred_axis_counts = Counter(
+        axis for item in calibrations for axis in item.preferred_axes
+    )
+    penalty_axis_counts = Counter(axis for item in calibrations for axis in item.penalty_axes)
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "summary": {
+            "sampling_calibration_ready": True,
+            "input_row_count": len(input_rows),
+            "calibration_count": len(calibrations),
+            "sampling_decision_counts": dict(sorted(decision_counts.items())),
+            "preferred_axis_counts": dict(sorted(preferred_axis_counts.items())),
+            "penalty_axis_counts": dict(sorted(penalty_axis_counts.items())),
+            "crypto_legacy_excluded_count": penalty_axis_counts.get("asset_class:crypto_legacy", 0),
+            "final_recommendation": "sampling_calibration_scaffold_ready",
+            "operator_summary": (
+                "Sampling calibration is available as deterministic, read-only context. "
+                "Crypto legacy is excluded, while equity/fundamental/source/factor and "
+                "regional diversity axes are preferred."
+            ),
+        },
+        "manifest": manifest,
+        "input_rows": input_rows,
+        "calibrations": [
+            {
+                "subject_id": item.subject_id,
+                "sampling_score": item.sampling_score,
+                "sampling_decision": item.sampling_decision,
+                "preferred_axes": list(item.preferred_axes),
+                "penalty_axes": list(item.penalty_axes),
+                "explanation": item.explanation,
+            }
+            for item in calibrations
+        ],
+        "safety_invariants": {
+            "read_only": True,
+            "uses_network": False,
+            "uses_external_data": False,
+            "uses_embeddings": False,
+            "uses_vector_db": False,
+            "uses_llm_authority": False,
+            "mutates_candidates": False,
+            "mutates_campaigns": False,
+            "mutates_strategies": False,
+            "mutates_presets": False,
+            "mutates_frozen_contracts": False,
+            "promotion_forbidden": True,
+            "campaign_mutation_forbidden": True,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+        },
+    }
+
+
+def render_operator_summary(report: Mapping[str, Any]) -> str:
+    summary = report.get("summary") if isinstance(report.get("summary"), Mapping) else {}
+    return "\n".join(
+        [
+            "# QRE Sampling Calibration",
+            "",
+            f"- {summary.get('operator_summary') or ''}",
+            "",
+            "## Current Status",
+            "",
+            f"- sampling_calibration_ready: {summary.get('sampling_calibration_ready')}",
+            f"- input_row_count: {summary.get('input_row_count')}",
+            f"- calibration_count: {summary.get('calibration_count')}",
+            f"- crypto_legacy_excluded_count: {summary.get('crypto_legacy_excluded_count')}",
+            f"- final_recommendation: {summary.get('final_recommendation')}",
+            "",
+        ]
+    )
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(f"qre_sampling_calibration_report: refusing write outside allowlist: {path!r}")
+
+
+def write_outputs(report: Mapping[str, Any], *, repo_root: Path = Path(".")) -> dict[str, str]:
+    base = repo_root / DEFAULT_OUTPUT_DIR
+    base.mkdir(parents=True, exist_ok=True)
+    latest = base / LATEST_NAME
+    summary_path = base / OPERATOR_SUMMARY_NAME
+
+    for target in (latest, summary_path):
+        _validate_write_target(target)
+
+    tmp_json = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp_json, latest)
+
+    tmp_md = summary_path.with_suffix(summary_path.suffix + ".tmp")
+    tmp_md.write_text(render_operator_summary(report), encoding="utf-8")
+    os.replace(tmp_md, summary_path)
+
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "operator_summary": summary_path.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_sampling_calibration_report",
+        description="Build read-only QRE sampling calibration report.",
+    )
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+
+    report = build_sampling_calibration_report()
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/unit/test_qre_routing_calibration.py
+++ b/tests/unit/test_qre_routing_calibration.py
@@ -1,0 +1,132 @@
+from research.qre_routing_calibration import (
+    calibrate_routing_context,
+    calibrate_routing_rows,
+    routing_calibration_manifest,
+)
+
+
+def test_routing_manifest_is_context_only():
+    manifest = routing_calibration_manifest()
+
+    assert manifest["schema_version"] == "1.0"
+    assert "sampling_calibration" in manifest["routing_targets"]
+    assert "excluded_scope_archive" in manifest["routing_targets"]
+
+    authority = manifest["authority"]
+    assert authority["routing_calibration_is_context_only"] is True
+    assert authority["not_queue_mutation"] is True
+    assert authority["not_candidate_promotion"] is True
+    assert authority["not_campaign_mutation"] is True
+    assert authority["not_strategy_registration"] is True
+    assert authority["not_paper_shadow_live"] is True
+    assert authority["not_broker_execution"] is True
+    assert authority["does_not_fetch_data"] is True
+    assert authority["does_not_mutate_queues"] is True
+    assert authority["does_not_mutate_candidates"] is True
+    assert authority["does_not_mutate_campaigns"] is True
+    assert authority["does_not_mutate_strategies"] is True
+    assert authority["does_not_mutate_presets"] is True
+    assert authority["does_not_mutate_frozen_contracts"] is True
+
+
+def test_crypto_legacy_routes_to_archive_only():
+    result = calibrate_routing_context(
+        {
+            "subject_id": "candidate:crypto",
+            "ontology_classification": {
+                "asset_class": "crypto_legacy",
+                "research_scope": "excluded_from_current_research_scope",
+            },
+        }
+    )
+
+    assert result.routing_targets == ("excluded_scope_archive",)
+    assert result.routing_decision == "route_to_archive_only"
+
+
+def test_source_quality_and_identity_route_targets():
+    result = calibrate_routing_context(
+        {
+            "subject_id": "candidate:source",
+            "asset_class": "equity",
+            "research_scope": "target_source_data_research",
+            "title": "OpenFIGI provider source_manifest identity ticker ambiguity",
+        }
+    )
+
+    assert "sampling_calibration" in result.routing_targets
+    assert "source_quality" in result.routing_targets
+    assert "identity_resolution" in result.routing_targets
+    assert result.routing_decision in {"route_standard", "route_high_priority"}
+
+
+def test_factor_and_null_model_route_targets():
+    result = calibrate_routing_context(
+        {
+            "subject_id": "candidate:factor",
+            "asset_class": "fundamental_equity",
+            "research_scope": "target_factor_research",
+            "title": "fundamental factor field_coverage null_model baseline",
+        }
+    )
+
+    assert "factor_coverage" in result.routing_targets
+    assert "null_model_baseline" in result.routing_targets
+
+
+def test_state_and_tail_route_targets():
+    result = calibrate_routing_context(
+        {
+            "subject_id": "candidate:risk",
+            "asset_class": "equity",
+            "research_scope": "target_equity_research",
+            "title": "state transition blocked tail entropy drawdown concentration",
+        }
+    )
+
+    assert "state_transition_diagnostics" in result.routing_targets
+    assert "tail_entropy_hardening" in result.routing_targets
+
+
+def test_blocked_readiness_routes_to_data_readiness_and_failure_retrieval():
+    result = calibrate_routing_context(
+        {
+            "subject_id": "candidate:blocked",
+            "asset_class": "equity",
+            "research_scope": "target_equity_research",
+            "readiness_state": "blocked",
+            "blocker_class": "missing_required_field",
+        }
+    )
+
+    assert "data_readiness" in result.routing_targets
+    assert "failure_retrieval" in result.routing_targets
+
+
+def test_failure_record_kind_routes_to_failure_retrieval():
+    result = calibrate_routing_context(
+        {
+            "subject_id": "failure:1",
+            "record_kind": "failure_action",
+            "asset_class": "equity",
+            "research_scope": "target_equity_research",
+        }
+    )
+
+    assert "failure_retrieval" in result.routing_targets
+
+
+def test_rows_ignore_non_mappings():
+    rows = [
+        {
+            "subject_id": "candidate:1",
+            "asset_class": "equity",
+            "research_scope": "target_equity_research",
+        },
+        "bad",
+    ]
+
+    results = calibrate_routing_rows(rows)  # type: ignore[arg-type]
+
+    assert len(results) == 1
+    assert results[0].subject_id == "candidate:1"

--- a/tests/unit/test_qre_routing_calibration_report.py
+++ b/tests/unit/test_qre_routing_calibration_report.py
@@ -1,0 +1,99 @@
+from pathlib import Path
+
+import pytest
+
+from research.qre_routing_calibration_report import (
+    build_routing_calibration_report,
+    render_operator_summary,
+    write_outputs,
+)
+
+
+def test_routing_calibration_report_is_ready_and_context_only():
+    report = build_routing_calibration_report()
+
+    assert report["schema_version"] == "1.0"
+    assert report["report_kind"] == "qre_routing_calibration_report"
+    assert report["summary"]["routing_calibration_ready"] is True
+    assert report["summary"]["final_recommendation"] == "routing_calibration_scaffold_ready"
+
+    safety = report["safety_invariants"]
+    assert safety["read_only"] is True
+    assert safety["uses_network"] is False
+    assert safety["uses_external_data"] is False
+    assert safety["mutates_queues"] is False
+    assert safety["mutates_candidates"] is False
+    assert safety["mutates_campaigns"] is False
+    assert safety["mutates_strategies"] is False
+    assert safety["mutates_presets"] is False
+    assert safety["mutates_frozen_contracts"] is False
+    assert safety["queue_mutation_forbidden"] is True
+    assert safety["promotion_forbidden"] is True
+    assert safety["campaign_mutation_forbidden"] is True
+    assert safety["paper_shadow_live_forbidden"] is True
+    assert safety["broker_risk_execution_forbidden"] is True
+
+
+def test_routing_calibration_report_has_expected_targets():
+    report = build_routing_calibration_report()
+
+    assert report["summary"]["input_row_count"] == 5
+    assert report["summary"]["calibration_count"] == 5
+    assert report["summary"]["excluded_scope_archive_count"] == 1
+
+    target_counts = report["summary"]["routing_target_counts"]
+    assert target_counts["excluded_scope_archive"] == 1
+    assert target_counts["sampling_calibration"] >= 4
+    assert target_counts["source_quality"] >= 1
+    assert target_counts["identity_resolution"] >= 1
+    assert target_counts["factor_coverage"] >= 1
+    assert target_counts["null_model_baseline"] >= 1
+    assert target_counts["state_transition_diagnostics"] >= 1
+    assert target_counts["tail_entropy_hardening"] >= 1
+    assert target_counts["failure_retrieval"] >= 1
+
+
+def test_routing_calibration_report_accepts_custom_rows():
+    report = build_routing_calibration_report(
+        rows=[
+            {
+                "subject_id": "candidate:custom",
+                "asset_class": "equity",
+                "research_scope": "target_equity_research",
+                "title": "tail entropy state transition",
+            }
+        ]
+    )
+
+    assert report["summary"]["input_row_count"] == 1
+    assert "tail_entropy_hardening" in report["calibrations"][0]["routing_targets"]
+    assert "state_transition_diagnostics" in report["calibrations"][0]["routing_targets"]
+
+
+def test_routing_calibration_operator_summary_renders():
+    report = build_routing_calibration_report()
+    text = render_operator_summary(report)
+
+    assert "# QRE Routing Calibration" in text
+    assert "excluded_scope_archive_count" in text
+    assert "routing_calibration_scaffold_ready" in text
+
+
+def test_routing_calibration_write_outputs_stays_in_allowlist(tmp_path: Path):
+    report = build_routing_calibration_report()
+    paths = write_outputs(report, repo_root=tmp_path)
+
+    assert paths["latest"] == "logs/qre_routing_calibration/latest.json"
+    assert paths["operator_summary"] == "logs/qre_routing_calibration/operator_summary.md"
+    assert (tmp_path / paths["latest"]).exists()
+    assert (tmp_path / paths["operator_summary"]).exists()
+
+
+def test_routing_calibration_write_rejects_non_allowlisted_path(monkeypatch, tmp_path: Path):
+    from research import qre_routing_calibration_report as report_module
+
+    monkeypatch.setattr(report_module, "DEFAULT_OUTPUT_DIR", Path("bad"))
+    report = build_routing_calibration_report()
+
+    with pytest.raises(ValueError):
+        write_outputs(report, repo_root=tmp_path)

--- a/tests/unit/test_qre_sampling_calibration.py
+++ b/tests/unit/test_qre_sampling_calibration.py
@@ -1,0 +1,138 @@
+from research.qre_sampling_calibration import (
+    calibrate_sampling_context,
+    calibrate_sampling_rows,
+    sampling_calibration_manifest,
+)
+
+
+def test_sampling_manifest_is_context_only():
+    manifest = sampling_calibration_manifest()
+
+    assert manifest["schema_version"] == "1.0"
+    assert "prefer_sampling" in manifest["sampling_decisions"]
+    assert "crypto_legacy" in manifest["excluded_asset_classes"]
+    assert "target_equity_research" in manifest["preferred_research_scopes"]
+
+    authority = manifest["authority"]
+    assert authority["sampling_calibration_is_context_only"] is True
+    assert authority["not_candidate_promotion"] is True
+    assert authority["not_campaign_mutation"] is True
+    assert authority["not_strategy_registration"] is True
+    assert authority["not_paper_shadow_live"] is True
+    assert authority["not_broker_execution"] is True
+    assert authority["does_not_fetch_data"] is True
+    assert authority["does_not_mutate_candidates"] is True
+    assert authority["does_not_mutate_campaigns"] is True
+    assert authority["does_not_mutate_strategies"] is True
+    assert authority["does_not_mutate_frozen_contracts"] is True
+
+
+def test_crypto_legacy_is_excluded():
+    result = calibrate_sampling_context(
+        {
+            "subject_id": "candidate:crypto",
+            "ontology_classification": {
+                "asset_class": "crypto_legacy",
+                "research_scope": "excluded_from_current_research_scope",
+            },
+        }
+    )
+
+    assert result.sampling_decision == "exclude_sampling"
+    assert result.sampling_score == -100
+    assert "asset_class:crypto_legacy" in result.penalty_axes
+
+
+def test_excluded_research_scope_is_excluded():
+    result = calibrate_sampling_context(
+        {
+            "subject_id": "candidate:legacy",
+            "asset_class": "equity",
+            "research_scope": "legacy_non_target_reference",
+        }
+    )
+
+    assert result.sampling_decision == "exclude_sampling"
+    assert result.sampling_score == -100
+
+
+def test_fundamental_equity_ready_europe_is_preferred():
+    result = calibrate_sampling_context(
+        {
+            "subject_id": "candidate:equity:europe",
+            "asset_class": "fundamental_equity",
+            "research_scope": "target_equity_research",
+            "readiness_state": "ready",
+            "title": "Europe fundamental factor source_manifest field_coverage",
+            "metadata": {"provider": "openfigi", "exchange": "euronext"},
+        }
+    )
+
+    assert result.sampling_decision == "prefer_sampling"
+    assert result.sampling_score >= 60
+    assert "asset_class:fundamental_equity" in result.preferred_axes
+    assert "research_scope:target_equity_research" in result.preferred_axes
+    assert "region:europe" in result.preferred_axes
+
+
+def test_us_equity_provider_context_is_allowed_or_preferred():
+    result = calibrate_sampling_context(
+        {
+            "subject_id": "candidate:us",
+            "asset_class": "equity",
+            "research_scope": "target_source_data_research",
+            "readiness_state": "partial",
+            "title": "NASDAQ equity provider source_manifest",
+        }
+    )
+
+    assert result.sampling_decision in {"allow_sampling", "prefer_sampling"}
+    assert "region:united_states" in result.preferred_axes
+
+
+def test_blocked_readiness_deprioritizes_otherwise_good_context():
+    result = calibrate_sampling_context(
+        {
+            "subject_id": "candidate:blocked",
+            "asset_class": "fundamental_equity",
+            "research_scope": "target_equity_research",
+            "readiness_state": "blocked",
+            "title": "fundamental factor Europe",
+        }
+    )
+
+    assert result.sampling_decision in {"allow_sampling", "deprioritize_sampling"}
+    assert "readiness_state:blocked" in result.penalty_axes
+
+
+def test_crypto_marker_penalizes_text_even_without_crypto_asset_class():
+    result = calibrate_sampling_context(
+        {
+            "subject_id": "candidate:textcrypto",
+            "asset_class": "equity",
+            "research_scope": "target_equity_research",
+            "readiness_state": "ready",
+            "title": "BTC-USD crypto carry legacy",
+        }
+    )
+
+    assert result.sampling_decision in {"deprioritize_sampling", "exclude_sampling"}
+    assert "content:crypto_marker" in result.penalty_axes
+
+
+def test_rows_ignore_non_mappings():
+    rows = [
+        {
+            "subject_id": "candidate:1",
+            "asset_class": "fundamental_equity",
+            "research_scope": "target_equity_research",
+            "title": "AEX Netherlands fundamental factor",
+        },
+        "bad",
+    ]
+
+    results = calibrate_sampling_rows(rows)  # type: ignore[arg-type]
+
+    assert len(results) == 1
+    assert results[0].subject_id == "candidate:1"
+    assert "region:netherlands" in results[0].preferred_axes

--- a/tests/unit/test_qre_sampling_calibration_report.py
+++ b/tests/unit/test_qre_sampling_calibration_report.py
@@ -1,0 +1,94 @@
+from pathlib import Path
+
+import pytest
+
+from research.qre_sampling_calibration_report import (
+    build_sampling_calibration_report,
+    render_operator_summary,
+    write_outputs,
+)
+
+
+def test_sampling_calibration_report_is_ready_and_context_only():
+    report = build_sampling_calibration_report()
+
+    assert report["schema_version"] == "1.0"
+    assert report["report_kind"] == "qre_sampling_calibration_report"
+    assert report["summary"]["sampling_calibration_ready"] is True
+    assert report["summary"]["final_recommendation"] == "sampling_calibration_scaffold_ready"
+
+    safety = report["safety_invariants"]
+    assert safety["read_only"] is True
+    assert safety["uses_network"] is False
+    assert safety["uses_external_data"] is False
+    assert safety["mutates_candidates"] is False
+    assert safety["mutates_campaigns"] is False
+    assert safety["mutates_strategies"] is False
+    assert safety["mutates_presets"] is False
+    assert safety["mutates_frozen_contracts"] is False
+    assert safety["promotion_forbidden"] is True
+    assert safety["campaign_mutation_forbidden"] is True
+    assert safety["paper_shadow_live_forbidden"] is True
+    assert safety["broker_risk_execution_forbidden"] is True
+
+
+def test_sampling_calibration_report_excludes_crypto_and_prefers_equity_axes():
+    report = build_sampling_calibration_report()
+
+    assert report["summary"]["input_row_count"] == 5
+    assert report["summary"]["calibration_count"] == 5
+    assert report["summary"]["crypto_legacy_excluded_count"] == 1
+
+    decision_counts = report["summary"]["sampling_decision_counts"]
+    assert decision_counts["exclude_sampling"] >= 1
+    assert decision_counts["prefer_sampling"] >= 1
+
+    preferred_axes = report["summary"]["preferred_axis_counts"]
+    assert preferred_axes["asset_class:fundamental_equity"] >= 1
+    assert preferred_axes["region:netherlands"] >= 1
+
+
+def test_sampling_calibration_report_accepts_custom_rows():
+    report = build_sampling_calibration_report(
+        rows=[
+            {
+                "subject_id": "candidate:custom",
+                "asset_class": "fundamental_equity",
+                "research_scope": "target_equity_research",
+                "readiness_state": "ready",
+                "title": "Europe factor source_manifest",
+            }
+        ]
+    )
+
+    assert report["summary"]["input_row_count"] == 1
+    assert report["calibrations"][0]["sampling_decision"] == "prefer_sampling"
+
+
+def test_sampling_calibration_operator_summary_renders():
+    report = build_sampling_calibration_report()
+    text = render_operator_summary(report)
+
+    assert "# QRE Sampling Calibration" in text
+    assert "crypto_legacy_excluded_count" in text
+    assert "sampling_calibration_scaffold_ready" in text
+
+
+def test_sampling_calibration_write_outputs_stays_in_allowlist(tmp_path: Path):
+    report = build_sampling_calibration_report()
+    paths = write_outputs(report, repo_root=tmp_path)
+
+    assert paths["latest"] == "logs/qre_sampling_calibration/latest.json"
+    assert paths["operator_summary"] == "logs/qre_sampling_calibration/operator_summary.md"
+    assert (tmp_path / paths["latest"]).exists()
+    assert (tmp_path / paths["operator_summary"]).exists()
+
+
+def test_sampling_calibration_write_rejects_non_allowlisted_path(monkeypatch, tmp_path: Path):
+    from research import qre_sampling_calibration_report as report_module
+
+    monkeypatch.setattr(report_module, "DEFAULT_OUTPUT_DIR", Path("bad"))
+    report = build_sampling_calibration_report()
+
+    with pytest.raises(ValueError):
+        write_outputs(report, repo_root=tmp_path)


### PR DESCRIPTION
Implements E-stage roadmap blocks in one PR with separate commits.

Adds:
- E02 sampling calibration scaffold
- E02.5 sampling calibration report surface
- E01 routing calibration scaffold
- E01.5 routing calibration report surface

Behavior:
- crypto_legacy is excluded from active sampling and routed to archive-only context
- equity/fundamental/source/factor contexts are preferred for sampling
- Netherlands/Europe/United States/Asia regional diversity axes are represented
- source quality, identity, factor coverage, null model, state transition, tail entropy, data readiness, and failure retrieval routing targets are represented

Safety:
- deterministic read-only calibration only
- no frozen contract mutation
- no research/research_latest.json or research/strategy_matrix.csv mutation
- no queue mutation
- no candidate promotion
- no campaign mutation
- no strategy registration
- no preset mutation
- no trade signals
- no provider activation
- no data fetching
- no paper/shadow/live
- no broker/risk/execution

Local validation:
- sampling calibration unit tests passed
- sampling calibration report tests passed
- routing calibration unit tests passed
- routing calibration report tests passed
- architecture tests passed
- governance/no_touch/frozen_contract/execution_authority slice passed
- governance_lint passed
- smoke tests passed