### PR TITLE
fix: add QRE final trusted loop review packet

### DIFF
--- a/research/qre_trusted_loop_review_packet.py
+++ b/research/qre_trusted_loop_review_packet.py
@@ -1,0 +1,280 @@
+"""QRE final trusted-loop review packet.
+
+This module materializes a deterministic, read-only review packet for the
+Roadmap v6 trusted-loop state. It summarizes available capabilities, report
+surfaces, safety invariants, and remaining authority boundaries.
+
+It does not mutate candidates, campaigns, strategies, presets, frozen contracts,
+broker/risk/execution state, or paper/shadow/live activation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Final
+
+
+REPORT_KIND: Final[str] = "qre_trusted_loop_review_packet"
+SCHEMA_VERSION: Final[str] = "1.0"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_trusted_loop_review")
+LATEST_NAME: Final[str] = "latest.json"
+OPERATOR_SUMMARY_NAME: Final[str] = "operator_summary.md"
+WRITE_PREFIX: Final[str] = "logs/qre_trusted_loop_review/"
+
+
+CAPABILITY_ROWS: tuple[dict[str, Any], ...] = (
+    {
+        "capability_id": "A",
+        "name": "source_identity_and_data_readiness_foundation",
+        "status": "implemented",
+        "authority": "read_only_context_and_fail_closed_readiness",
+    },
+    {
+        "capability_id": "B",
+        "name": "controlled_grid_and_evidence_closure",
+        "status": "implemented",
+        "authority": "read_only_artifact_materialization_and_diagnostics",
+    },
+    {
+        "capability_id": "C",
+        "name": "research_memory_ontology_entity_failure_context",
+        "status": "implemented",
+        "authority": "context_only_memory_and_retrieval_enrichment",
+    },
+    {
+        "capability_id": "D",
+        "name": "null_model_state_transition_tail_entropy_hardening",
+        "status": "implemented",
+        "authority": "context_only_diagnostics_and_report_surfaces",
+    },
+    {
+        "capability_id": "E",
+        "name": "sampling_and_routing_calibration",
+        "status": "implemented",
+        "authority": "context_only_calibration_no_queue_or_campaign_mutation",
+    },
+    {
+        "capability_id": "F",
+        "name": "trusted_loop_review_packet",
+        "status": "implemented_by_this_packet",
+        "authority": "operator_review_only",
+    },
+)
+
+
+REPORT_SURFACES: tuple[dict[str, str], ...] = (
+    {
+        "report_kind": "qre_research_memory_coverage",
+        "path_hint": "logs/qre_research_memory_coverage/",
+        "purpose": "research memory coverage and ontology/entity context",
+    },
+    {
+        "report_kind": "qre_null_model_baseline_report",
+        "path_hint": "logs/qre_null_model_baseline/",
+        "purpose": "null-model baseline diagnostics",
+    },
+    {
+        "report_kind": "qre_state_transition_diagnostics_report",
+        "path_hint": "logs/qre_state_transition_diagnostics/",
+        "purpose": "state-transition diagnostics",
+    },
+    {
+        "report_kind": "qre_tail_entropy_hardening_report",
+        "path_hint": "logs/qre_tail_entropy_hardening/",
+        "purpose": "tail/entropy hardening diagnostics",
+    },
+    {
+        "report_kind": "qre_sampling_calibration_report",
+        "path_hint": "logs/qre_sampling_calibration/",
+        "purpose": "sampling calibration context",
+    },
+    {
+        "report_kind": "qre_routing_calibration_report",
+        "path_hint": "logs/qre_routing_calibration/",
+        "purpose": "routing calibration context",
+    },
+    {
+        "report_kind": "qre_trusted_loop_review_packet",
+        "path_hint": "logs/qre_trusted_loop_review/",
+        "purpose": "final trusted-loop operator review packet",
+    },
+)
+
+
+def _path_state(repo_root: Path, relative_path: str) -> dict[str, Any]:
+    path = repo_root / relative_path
+    return {
+        "path": relative_path,
+        "exists": path.exists(),
+        "is_file": path.is_file(),
+        "is_dir": path.is_dir(),
+    }
+
+
+def build_trusted_loop_review_packet(*, repo_root: Path = Path(".")) -> dict[str, Any]:
+    protected_artifacts = [
+        _path_state(repo_root, "research/research_latest.json"),
+        _path_state(repo_root, "research/strategy_matrix.csv"),
+    ]
+
+    implemented_count = sum(1 for row in CAPABILITY_ROWS if str(row.get("status", "")).startswith("implemented"))
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "summary": {
+            "trusted_loop_review_ready": True,
+            "capability_count": len(CAPABILITY_ROWS),
+            "implemented_capability_count": implemented_count,
+            "report_surface_count": len(REPORT_SURFACES),
+            "final_recommendation": "trusted_loop_ready_for_operator_review_not_execution",
+            "operator_summary": (
+                "Roadmap A-E trusted-loop scaffolds and report surfaces are present as "
+                "deterministic, read-only/context-only diagnostics. The system is ready "
+                "for operator review of research-loop evidence, not for paper/shadow/live "
+                "or broker/risk/execution activation."
+            ),
+        },
+        "capabilities": list(CAPABILITY_ROWS),
+        "report_surfaces": list(REPORT_SURFACES),
+        "protected_artifacts": protected_artifacts,
+        "current_scope_policy": {
+            "crypto_legacy": "excluded_from_current_research_scope_and_archive_only",
+            "preferred_sampling_axes": [
+                "equity",
+                "fundamental_equity",
+                "index",
+                "target_equity_research",
+                "target_source_data_research",
+                "target_factor_research",
+                "netherlands",
+                "europe",
+                "united_states",
+                "asia",
+            ],
+            "routing_context_targets": [
+                "sampling_calibration",
+                "data_readiness",
+                "source_quality",
+                "identity_resolution",
+                "factor_coverage",
+                "null_model_baseline",
+                "state_transition_diagnostics",
+                "tail_entropy_hardening",
+                "failure_retrieval",
+                "operator_review",
+                "excluded_scope_archive",
+            ],
+        },
+        "authority_boundaries": {
+            "review_packet_is_context_only": True,
+            "not_alpha_authority": True,
+            "not_queue_mutation": True,
+            "not_candidate_promotion": True,
+            "not_campaign_mutation": True,
+            "not_strategy_registration": True,
+            "not_preset_mutation": True,
+            "not_trade_signal_generation": True,
+            "not_provider_activation": True,
+            "not_data_fetching": True,
+            "not_paper_shadow_live": True,
+            "not_broker_execution": True,
+            "not_risk_authority": True,
+            "does_not_mutate_frozen_contracts": True,
+            "does_not_mutate_research_latest": True,
+            "does_not_mutate_strategy_matrix": True,
+        },
+        "safety_invariants": {
+            "read_only": True,
+            "uses_network": False,
+            "uses_external_data": False,
+            "uses_embeddings": False,
+            "uses_vector_db": False,
+            "uses_llm_authority": False,
+            "mutates_queues": False,
+            "mutates_candidates": False,
+            "mutates_campaigns": False,
+            "mutates_strategies": False,
+            "mutates_presets": False,
+            "mutates_frozen_contracts": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+        },
+    }
+
+
+def render_operator_summary(packet: Mapping[str, Any]) -> str:
+    summary = packet.get("summary") if isinstance(packet.get("summary"), Mapping) else {}
+    return "\n".join(
+        [
+            "# QRE Trusted Loop Review Packet",
+            "",
+            f"- {summary.get('operator_summary') or ''}",
+            "",
+            "## Current Status",
+            "",
+            f"- trusted_loop_review_ready: {summary.get('trusted_loop_review_ready')}",
+            f"- capability_count: {summary.get('capability_count')}",
+            f"- implemented_capability_count: {summary.get('implemented_capability_count')}",
+            f"- report_surface_count: {summary.get('report_surface_count')}",
+            f"- final_recommendation: {summary.get('final_recommendation')}",
+            "",
+            "## Authority Boundary",
+            "",
+            "- This packet is operator-review context only.",
+            "- It does not authorize paper, shadow, live trading, broker execution, risk changes, queue mutation, campaign mutation, strategy registration, or preset mutation.",
+            "",
+        ]
+    )
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(f"qre_trusted_loop_review_packet: refusing write outside allowlist: {path!r}")
+
+
+def write_outputs(packet: Mapping[str, Any], *, repo_root: Path = Path(".")) -> dict[str, str]:
+    base = repo_root / DEFAULT_OUTPUT_DIR
+    base.mkdir(parents=True, exist_ok=True)
+    latest = base / LATEST_NAME
+    summary_path = base / OPERATOR_SUMMARY_NAME
+
+    for target in (latest, summary_path):
+        _validate_write_target(target)
+
+    tmp_json = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_json.write_text(json.dumps(packet, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp_json, latest)
+
+    tmp_md = summary_path.with_suffix(summary_path.suffix + ".tmp")
+    tmp_md.write_text(render_operator_summary(packet), encoding="utf-8")
+    os.replace(tmp_md, summary_path)
+
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "operator_summary": summary_path.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_trusted_loop_review_packet",
+        description="Build read-only QRE trusted-loop review packet.",
+    )
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+
+    packet = build_trusted_loop_review_packet()
+    if args.write:
+        packet["_artifact_paths"] = write_outputs(packet)
+
+    print(json.dumps(packet, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/unit/test_qre_trusted_loop_review_packet.py
+++ b/tests/unit/test_qre_trusted_loop_review_packet.py
@@ -1,0 +1,107 @@
+from pathlib import Path
+
+import pytest
+
+from research.qre_trusted_loop_review_packet import (
+    build_trusted_loop_review_packet,
+    render_operator_summary,
+    write_outputs,
+)
+
+
+def test_trusted_loop_review_packet_is_ready_and_context_only():
+    packet = build_trusted_loop_review_packet()
+
+    assert packet["schema_version"] == "1.0"
+    assert packet["report_kind"] == "qre_trusted_loop_review_packet"
+    assert packet["summary"]["trusted_loop_review_ready"] is True
+    assert packet["summary"]["final_recommendation"] == "trusted_loop_ready_for_operator_review_not_execution"
+
+    boundaries = packet["authority_boundaries"]
+    assert boundaries["review_packet_is_context_only"] is True
+    assert boundaries["not_alpha_authority"] is True
+    assert boundaries["not_queue_mutation"] is True
+    assert boundaries["not_candidate_promotion"] is True
+    assert boundaries["not_campaign_mutation"] is True
+    assert boundaries["not_strategy_registration"] is True
+    assert boundaries["not_preset_mutation"] is True
+    assert boundaries["not_trade_signal_generation"] is True
+    assert boundaries["not_provider_activation"] is True
+    assert boundaries["not_data_fetching"] is True
+    assert boundaries["not_paper_shadow_live"] is True
+    assert boundaries["not_broker_execution"] is True
+    assert boundaries["not_risk_authority"] is True
+    assert boundaries["does_not_mutate_frozen_contracts"] is True
+    assert boundaries["does_not_mutate_research_latest"] is True
+    assert boundaries["does_not_mutate_strategy_matrix"] is True
+
+
+def test_trusted_loop_review_packet_lists_all_capability_stages():
+    packet = build_trusted_loop_review_packet()
+
+    capability_ids = {row["capability_id"] for row in packet["capabilities"]}
+    assert capability_ids == {"A", "B", "C", "D", "E", "F"}
+    assert packet["summary"]["capability_count"] == 6
+    assert packet["summary"]["implemented_capability_count"] == 6
+
+
+def test_trusted_loop_review_packet_lists_expected_report_surfaces():
+    packet = build_trusted_loop_review_packet()
+
+    report_kinds = {row["report_kind"] for row in packet["report_surfaces"]}
+
+    assert "qre_null_model_baseline_report" in report_kinds
+    assert "qre_state_transition_diagnostics_report" in report_kinds
+    assert "qre_tail_entropy_hardening_report" in report_kinds
+    assert "qre_sampling_calibration_report" in report_kinds
+    assert "qre_routing_calibration_report" in report_kinds
+    assert "qre_trusted_loop_review_packet" in report_kinds
+
+
+def test_trusted_loop_review_packet_scope_policy_excludes_crypto_and_prefers_equity():
+    packet = build_trusted_loop_review_packet()
+    policy = packet["current_scope_policy"]
+
+    assert policy["crypto_legacy"] == "excluded_from_current_research_scope_and_archive_only"
+    assert "fundamental_equity" in policy["preferred_sampling_axes"]
+    assert "netherlands" in policy["preferred_sampling_axes"]
+    assert "united_states" in policy["preferred_sampling_axes"]
+    assert "asia" in policy["preferred_sampling_axes"]
+    assert "excluded_scope_archive" in policy["routing_context_targets"]
+
+
+def test_trusted_loop_review_packet_tracks_protected_artifacts():
+    packet = build_trusted_loop_review_packet()
+
+    paths = {row["path"] for row in packet["protected_artifacts"]}
+    assert "research/research_latest.json" in paths
+    assert "research/strategy_matrix.csv" in paths
+
+
+def test_trusted_loop_review_packet_operator_summary_renders():
+    packet = build_trusted_loop_review_packet()
+    text = render_operator_summary(packet)
+
+    assert "# QRE Trusted Loop Review Packet" in text
+    assert "trusted_loop_ready_for_operator_review_not_execution" in text
+    assert "Authority Boundary" in text
+
+
+def test_trusted_loop_review_packet_write_outputs_stays_in_allowlist(tmp_path: Path):
+    packet = build_trusted_loop_review_packet(repo_root=tmp_path)
+    paths = write_outputs(packet, repo_root=tmp_path)
+
+    assert paths["latest"] == "logs/qre_trusted_loop_review/latest.json"
+    assert paths["operator_summary"] == "logs/qre_trusted_loop_review/operator_summary.md"
+    assert (tmp_path / paths["latest"]).exists()
+    assert (tmp_path / paths["operator_summary"]).exists()
+
+
+def test_trusted_loop_review_packet_write_rejects_non_allowlisted_path(monkeypatch, tmp_path: Path):
+    from research import qre_trusted_loop_review_packet as packet_module
+
+    monkeypatch.setattr(packet_module, "DEFAULT_OUTPUT_DIR", Path("bad"))
+    packet = build_trusted_loop_review_packet(repo_root=tmp_path)
+
+    with pytest.raises(ValueError):
+        write_outputs(packet, repo_root=tmp_path)


### PR DESCRIPTION
Implements F01 Final v3.x Trusted Loop Review Packet.

Adds:
- deterministic read-only trusted-loop review packet
- operator summary renderer
- allowlisted write surface under logs/qre_trusted_loop_review/
- tests for capability coverage, report surfaces, authority boundaries, protected artifacts, scope policy, and write allowlist

Packet summary:
- A-E trusted-loop scaffolds and report surfaces are present
- crypto_legacy is excluded from current research scope and archive-only
- preferred sampling axes include equity, fundamental equity, index, Netherlands, Europe, United States, and Asia
- routing context targets include sampling, data readiness, source quality, identity resolution, factor coverage, null model, state transition, tail entropy, failure retrieval, operator review, and excluded-scope archive
- final recommendation is operator review only, not execution

Safety:
- deterministic read-only review only
- no frozen contract mutation
- no research/research_latest.json or research/strategy_matrix.csv mutation
- no queue mutation
- no candidate promotion
- no campaign mutation
- no strategy registration
- no preset mutation
- no trade signals
- no provider activation
- no data fetching
- no paper/shadow/live
- no broker/risk/execution
- no risk authority

Local validation:
- trusted loop review packet tests passed
- architecture tests passed
- governance/no_touch/frozen_contract/execution_authority slice passed
- governance_lint passed
- smoke tests passed