### PR TITLE
fix: add controlled discovery subset adapter

### DIFF
--- a/research/qre_controlled_discovery_subset_adapter.py
+++ b/research/qre_controlled_discovery_subset_adapter.py
@@ -1,0 +1,287 @@
+"""Read-only adapter for a bounded controlled-discovery executable subset.
+
+This module converts a previously selected executable discovery-grid subset
+into an operator-review request packet. It does not run research execution,
+launch campaigns, mutate queues, register strategies, or authorize
+paper/shadow/live trading.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any, Final
+
+
+SCHEMA_VERSION: Final[str] = "1.0"
+REPORT_KIND: Final[str] = "qre_controlled_discovery_subset_adapter"
+
+DEFAULT_INPUT_PATH: Final[Path] = Path(
+    "logs/qre_controlled_discovery_grid_inspection/safe_executable_subset.json"
+)
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_controlled_discovery_subset_adapter")
+
+ALLOWED_ASSET_CLASSES: Final[set[str]] = {"equity", "etf", "fundamental_equity", "index"}
+FORBIDDEN_ASSET_CLASSES: Final[set[str]] = {"crypto", "crypto_legacy"}
+REQUIRED_ROW_FIELDS: Final[tuple[str, ...]] = (
+    "instrument_symbol",
+    "asset_class",
+    "region",
+    "behavior_preset_id",
+    "timeframe",
+    "classification",
+    "mapping_status",
+    "source_identity_status",
+)
+
+
+class SubsetAdapterError(RuntimeError):
+    """Raised when a controlled-discovery subset is unsafe or malformed."""
+
+
+def _read_json(path: Path) -> Any:
+    if not path.exists():
+        raise SubsetAdapterError(f"input subset does not exist: {path.as_posix()}")
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def _as_rows(payload: Any) -> list[dict[str, Any]]:
+    if not isinstance(payload, list):
+        raise SubsetAdapterError("input subset must be a JSON array")
+    rows: list[dict[str, Any]] = []
+    for index, row in enumerate(payload, start=1):
+        if not isinstance(row, dict):
+            raise SubsetAdapterError(f"subset row {index} is not an object")
+        rows.append(row)
+    return rows
+
+
+def _missing_fields(row: dict[str, Any]) -> list[str]:
+    missing: list[str] = []
+    for field in REQUIRED_ROW_FIELDS:
+        value = row.get(field)
+        if value in (None, "", []):
+            missing.append(field)
+    return missing
+
+
+def _validate_row(row: dict[str, Any], *, index: int) -> list[str]:
+    blockers: list[str] = []
+
+    missing = _missing_fields(row)
+    if missing:
+        blockers.append("missing_required_fields:" + ",".join(sorted(missing)))
+
+    asset_class = str(row.get("asset_class") or "").lower()
+    if asset_class in FORBIDDEN_ASSET_CLASSES:
+        blockers.append(f"forbidden_asset_class:{asset_class}")
+    if asset_class and asset_class not in ALLOWED_ASSET_CLASSES:
+        blockers.append(f"unsupported_asset_class:{asset_class}")
+
+    if str(row.get("classification")) != "executable":
+        blockers.append("classification_not_executable")
+    if str(row.get("mapping_status")) != "ready":
+        blockers.append("mapping_status_not_ready")
+    if str(row.get("source_identity_status")) != "provider_symbol_verified":
+        blockers.append("source_identity_not_provider_verified")
+
+    for activation_field in (
+        "paper_activation_allowed",
+        "shadow_activation_allowed",
+        "live_activation_allowed",
+    ):
+        if bool(row.get(activation_field, False)):
+            blockers.append(f"{activation_field}_true")
+
+    symbol = str(row.get("instrument_symbol") or "")
+    if "-USD" in symbol.upper() or symbol.upper() in {"BTC", "ETH", "SOL", "DOGE", "XRP"}:
+        blockers.append("crypto_symbol_marker_detected")
+
+    if blockers:
+        return [f"row_{index}:{blocker}" for blocker in blockers]
+    return []
+
+
+def _normalized_row(row: dict[str, Any], *, index: int) -> dict[str, Any]:
+    return {
+        "subset_sequence_number": index,
+        "source_sequence_number": row.get("sequence_number"),
+        "instrument_symbol": str(row.get("instrument_symbol")),
+        "asset_class": str(row.get("asset_class")),
+        "region": str(row.get("region")),
+        "behavior_preset_id": str(row.get("behavior_preset_id")),
+        "timeframe": str(row.get("timeframe")),
+        "classification": str(row.get("classification")),
+        "mapping_status": str(row.get("mapping_status")),
+        "source_identity_status": str(row.get("source_identity_status")),
+        "primary_data_provider_symbol": row.get("primary_data_provider_symbol"),
+        "provider_symbol_status": row.get("provider_symbol_status"),
+        "blocker_class": row.get("blocker_class"),
+        "explanation": row.get("explanation"),
+        "not_alpha_claim": True,
+        "paper_activation_allowed": False,
+        "shadow_activation_allowed": False,
+        "live_activation_allowed": False,
+        "execution_allowed": False,
+        "campaign_launch_allowed": False,
+        "candidate_promotion_allowed": False,
+    }
+
+
+def build_subset_adapter_packet(input_path: Path = DEFAULT_INPUT_PATH) -> dict[str, Any]:
+    rows = _as_rows(_read_json(input_path))
+
+    validation_blockers: list[str] = []
+    for index, row in enumerate(rows, start=1):
+        validation_blockers.extend(_validate_row(row, index=index))
+
+    normalized_rows = [
+        _normalized_row(row, index=index)
+        for index, row in enumerate(rows, start=1)
+    ]
+
+    safe_to_execute_research = False
+    subset_safe_for_operator_review = not validation_blockers
+
+    region_counts = Counter(row["region"] for row in normalized_rows)
+    asset_class_counts = Counter(row["asset_class"] for row in normalized_rows)
+    preset_counts = Counter(row["behavior_preset_id"] for row in normalized_rows)
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "input_path": input_path.as_posix(),
+        "authority_boundaries": {
+            "adapter_is_read_only": True,
+            "not_alpha_authority": True,
+            "not_trade_signal_generation": True,
+            "not_data_fetching": True,
+            "not_campaign_launch": True,
+            "not_queue_mutation": True,
+            "not_candidate_promotion": True,
+            "not_strategy_registration": True,
+            "not_preset_mutation": True,
+            "not_paper_shadow_live": True,
+            "not_broker_execution": True,
+            "not_risk_authority": True,
+            "does_not_mutate_research_latest": True,
+            "does_not_mutate_strategy_matrix": True,
+        },
+        "safety_invariants": {
+            "read_only": True,
+            "uses_network": False,
+            "uses_external_data": False,
+            "uses_embeddings": False,
+            "uses_vector_db": False,
+            "uses_llm_authority": False,
+            "mutates_campaigns": False,
+            "mutates_candidates": False,
+            "mutates_queues": False,
+            "mutates_strategies": False,
+            "mutates_presets": False,
+            "mutates_frozen_contracts": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+        },
+        "summary": {
+            "subset_adapter_ready": subset_safe_for_operator_review,
+            "subset_row_count": len(normalized_rows),
+            "validation_blocker_count": len(validation_blockers),
+            "safe_to_execute_research": safe_to_execute_research,
+            "final_recommendation": (
+                "subset_ready_for_operator_review_not_execution"
+                if subset_safe_for_operator_review
+                else "subset_blocked_for_operator_review"
+            ),
+            "operator_summary": (
+                "Controlled discovery subset is validated as a bounded, non-crypto, "
+                "read-only operator-review packet. It does not authorize research "
+                "execution, campaigns, paper/shadow/live, broker execution, or risk changes."
+                if subset_safe_for_operator_review
+                else "Controlled discovery subset has validation blockers and must not be used."
+            ),
+            "region_counts": dict(sorted(region_counts.items())),
+            "asset_class_counts": dict(sorted(asset_class_counts.items())),
+            "preset_counts": dict(sorted(preset_counts.items())),
+        },
+        "validation_blockers": validation_blockers,
+        "rows": normalized_rows,
+    }
+
+
+def render_operator_summary(packet: dict[str, Any]) -> str:
+    summary = packet["summary"]
+    lines = [
+        "# QRE Controlled Discovery Subset Adapter",
+        "",
+        f"- {summary['operator_summary']}",
+        "",
+        "## Current Status",
+        "",
+        f"- subset_adapter_ready: {summary['subset_adapter_ready']}",
+        f"- subset_row_count: {summary['subset_row_count']}",
+        f"- validation_blocker_count: {summary['validation_blocker_count']}",
+        f"- safe_to_execute_research: {summary['safe_to_execute_research']}",
+        f"- final_recommendation: {summary['final_recommendation']}",
+        "",
+        "## Region Counts",
+        "",
+    ]
+    for key, value in summary["region_counts"].items():
+        lines.append(f"- {key}: {value}")
+
+    lines.extend(["", "## Preset Counts", ""])
+    for key, value in summary["preset_counts"].items():
+        lines.append(f"- {key}: {value}")
+
+    if packet["validation_blockers"]:
+        lines.extend(["", "## Validation Blockers", ""])
+        for blocker in packet["validation_blockers"]:
+            lines.append(f"- {blocker}")
+
+    lines.extend(
+        [
+            "",
+            "## Authority Boundary",
+            "",
+            "- This packet is operator-review context only.",
+            "- It does not launch research, campaigns, paper/shadow/live, broker execution, risk changes, queue mutation, candidate promotion, strategy registration, or preset mutation.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def write_outputs(packet: dict[str, Any], output_dir: Path = DEFAULT_OUTPUT_DIR) -> dict[str, str]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    latest_path = output_dir / "latest.json"
+    summary_path = output_dir / "operator_summary.md"
+
+    latest_path.write_text(json.dumps(packet, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    summary_path.write_text(render_operator_summary(packet), encoding="utf-8")
+
+    return {
+        "latest": latest_path.as_posix(),
+        "operator_summary": summary_path.as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Build a read-only controlled-discovery subset operator packet."
+    )
+    parser.add_argument("--input", default=DEFAULT_INPUT_PATH.as_posix())
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+
+    packet = build_subset_adapter_packet(Path(args.input))
+    if args.write:
+        packet["_artifact_paths"] = write_outputs(packet)
+
+    print(json.dumps(packet, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_qre_controlled_discovery_subset_adapter.py
+++ b/tests/unit/test_qre_controlled_discovery_subset_adapter.py
@@ -1,0 +1,141 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from research.qre_controlled_discovery_subset_adapter import (
+    SubsetAdapterError,
+    build_subset_adapter_packet,
+    render_operator_summary,
+    write_outputs,
+)
+
+
+def _safe_row(symbol: str = "AAPL") -> dict:
+    return {
+        "sequence_number": 1,
+        "instrument_symbol": symbol,
+        "asset_class": "equity",
+        "region": "US",
+        "behavior_preset_id": "trend_continuation_daily_v1",
+        "timeframe": "1d",
+        "classification": "executable",
+        "mapping_status": "ready",
+        "source_identity_status": "provider_symbol_verified",
+        "primary_data_provider_symbol": symbol,
+        "provider_symbol_status": "verified",
+    }
+
+
+def _write_subset(tmp_path: Path, rows: list[dict]) -> Path:
+    path = tmp_path / "safe_executable_subset.json"
+    path.write_text(json.dumps(rows), encoding="utf-8")
+    return path
+
+
+def test_build_subset_adapter_packet_is_operator_review_only(tmp_path: Path) -> None:
+    path = _write_subset(tmp_path, [_safe_row("AAPL"), _safe_row("MSFT")])
+
+    packet = build_subset_adapter_packet(path)
+
+    assert packet["report_kind"] == "qre_controlled_discovery_subset_adapter"
+    assert packet["summary"]["subset_adapter_ready"] is True
+    assert packet["summary"]["subset_row_count"] == 2
+    assert packet["summary"]["safe_to_execute_research"] is False
+    assert packet["authority_boundaries"]["not_campaign_launch"] is True
+    assert packet["authority_boundaries"]["not_paper_shadow_live"] is True
+    assert packet["authority_boundaries"]["does_not_mutate_research_latest"] is True
+    assert packet["authority_boundaries"]["does_not_mutate_strategy_matrix"] is True
+    assert packet["safety_invariants"]["read_only"] is True
+    assert packet["safety_invariants"]["broker_risk_execution_forbidden"] is True
+
+
+def test_build_subset_adapter_packet_counts_regions_and_presets(tmp_path: Path) -> None:
+    rows = [
+        {**_safe_row("ADYEN"), "region": "NL/EU"},
+        {**_safe_row("AAPL"), "region": "US"},
+        {**_safe_row("SPY"), "asset_class": "etf", "region": "ETFs/context"},
+    ]
+    path = _write_subset(tmp_path, rows)
+
+    packet = build_subset_adapter_packet(path)
+
+    assert packet["summary"]["region_counts"] == {
+        "ETFs/context": 1,
+        "NL/EU": 1,
+        "US": 1,
+    }
+    assert packet["summary"]["asset_class_counts"] == {"equity": 2, "etf": 1}
+    assert packet["summary"]["preset_counts"] == {"trend_continuation_daily_v1": 3}
+
+
+def test_build_subset_adapter_packet_blocks_crypto(tmp_path: Path) -> None:
+    path = _write_subset(tmp_path, [{**_safe_row("BTC-USD"), "asset_class": "crypto_legacy"}])
+
+    packet = build_subset_adapter_packet(path)
+
+    assert packet["summary"]["subset_adapter_ready"] is False
+    assert packet["summary"]["validation_blocker_count"] >= 1
+    assert any("forbidden_asset_class:crypto_legacy" in item for item in packet["validation_blockers"])
+
+
+def test_build_subset_adapter_packet_blocks_non_executable_rows(tmp_path: Path) -> None:
+    path = _write_subset(tmp_path, [{**_safe_row("AAPL"), "classification": "seed_only"}])
+
+    packet = build_subset_adapter_packet(path)
+
+    assert packet["summary"]["subset_adapter_ready"] is False
+    assert any("classification_not_executable" in item for item in packet["validation_blockers"])
+
+
+def test_build_subset_adapter_packet_requires_provider_verified_identity(tmp_path: Path) -> None:
+    path = _write_subset(
+        tmp_path,
+        [{**_safe_row("ASMI"), "source_identity_status": "candidate_alias_only"}],
+    )
+
+    packet = build_subset_adapter_packet(path)
+
+    assert packet["summary"]["subset_adapter_ready"] is False
+    assert any("source_identity_not_provider_verified" in item for item in packet["validation_blockers"])
+
+
+def test_render_operator_summary_contains_authority_boundary(tmp_path: Path) -> None:
+    path = _write_subset(tmp_path, [_safe_row("AAPL")])
+    packet = build_subset_adapter_packet(path)
+
+    summary = render_operator_summary(packet)
+
+    assert "subset_adapter_ready: True" in summary
+    assert "safe_to_execute_research: False" in summary
+    assert "operator-review context only" in summary
+    assert "does not launch research" in summary
+
+
+def test_write_outputs_writes_latest_and_operator_summary(tmp_path: Path) -> None:
+    path = _write_subset(tmp_path, [_safe_row("AAPL")])
+    packet = build_subset_adapter_packet(path)
+
+    outputs = write_outputs(packet, tmp_path / "out")
+
+    latest = Path(outputs["latest"])
+    summary = Path(outputs["operator_summary"])
+    assert latest.exists()
+    assert summary.exists()
+    assert json.loads(latest.read_text(encoding="utf-8"))["summary"]["subset_row_count"] == 1
+    assert "QRE Controlled Discovery Subset Adapter" in summary.read_text(encoding="utf-8")
+
+
+def test_missing_input_raises() -> None:
+    with pytest.raises(SubsetAdapterError):
+        build_subset_adapter_packet(Path("does/not/exist.json"))
+def test_build_subset_adapter_packet_accepts_utf8_bom_input(tmp_path: Path) -> None:
+    path = tmp_path / "safe_executable_subset_bom.json"
+    payload = json.dumps([_safe_row("AAPL")])
+    path.write_text(payload, encoding="utf-8-sig")
+
+    packet = build_subset_adapter_packet(path)
+
+    assert packet["summary"]["subset_adapter_ready"] is True
+    assert packet["summary"]["subset_row_count"] == 1
+    assert packet["rows"][0]["instrument_symbol"] == "AAPL"


### PR DESCRIPTION
## Summary
- add read-only controlled discovery subset adapter
- validate selected executable subset as non-crypto, provider-verified, bounded operator-review packet
- keep research execution, campaign launch, paper/shadow/live, broker/risk, candidate promotion, strategy registration, and preset mutation forbidden

## Validation
- python -m pytest tests/unit/test_qre_controlled_discovery_subset_adapter.py -q
- python -m research.qre_controlled_discovery_subset_adapter --write
- git diff --check
- git diff -- research/research_latest.json research/strategy_matrix.csv