### PR TITLE
fix: add controlled subset feasibility and runner dry run

### DIFF
--- a/research/qre_controlled_subset_candidate_feasibility.py
+++ b/research/qre_controlled_subset_candidate_feasibility.py
@@ -1,0 +1,320 @@
+"""Feasibility report for the controlled subset candidate plan.
+
+This module validates whether a dry-run candidate plan has enough explicit
+metadata to design a bounded runner dry-run. It does not execute screening,
+validation, campaigns, paper/shadow/live, broker execution, or mutate
+research_latest.json / strategy_matrix.csv.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any, Final
+
+
+SCHEMA_VERSION: Final[str] = "1.0"
+REPORT_KIND: Final[str] = "qre_controlled_subset_candidate_feasibility"
+
+DEFAULT_INPUT_PATH: Final[Path] = Path("logs/qre_controlled_subset_candidate_plan/latest.json")
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_controlled_subset_candidate_feasibility")
+
+FORBIDDEN_ASSET_CLASSES: Final[set[str]] = {"crypto", "crypto_legacy"}
+REQUIRED_RECORD_FIELDS: Final[tuple[str, ...]] = (
+    "candidate_plan_id",
+    "instrument_symbol",
+    "asset_class",
+    "region",
+    "behavior_preset_id",
+    "timeframe",
+    "classification",
+    "mapping_status",
+    "source_identity_status",
+    "primary_data_provider_symbol",
+    "plan_status",
+)
+
+
+class CandidateFeasibilityError(RuntimeError):
+    """Raised when candidate feasibility input cannot be read."""
+
+
+def _read_json(path: Path) -> Any:
+    if not path.exists():
+        raise CandidateFeasibilityError(f"candidate plan does not exist: {path.as_posix()}")
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def _require_packet(payload: Any) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise CandidateFeasibilityError("candidate plan input must be a JSON object")
+    return payload
+
+
+def _records(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    raw_records = payload.get("candidate_plan_records")
+    if not isinstance(raw_records, list):
+        raise CandidateFeasibilityError("candidate_plan_records must be a list")
+    records: list[dict[str, Any]] = []
+    for index, record in enumerate(raw_records, start=1):
+        if not isinstance(record, dict):
+            raise CandidateFeasibilityError(f"candidate_plan_records[{index}] is not an object")
+        records.append(record)
+    return records
+
+
+def _candidate_plan_ready(payload: dict[str, Any]) -> bool:
+    summary = payload.get("summary")
+    if not isinstance(summary, dict):
+        return False
+    return (
+        payload.get("report_kind") == "qre_controlled_subset_candidate_plan"
+        and summary.get("candidate_plan_ready") is True
+        and int(summary.get("validation_blocker_count") or 0) == 0
+        and summary.get("safe_to_execute_research") is False
+        and summary.get("screening_allowed") is False
+        and summary.get("validation_allowed") is False
+    )
+
+
+def _record_blockers(record: dict[str, Any], *, index: int) -> list[str]:
+    blockers: list[str] = []
+
+    for field in REQUIRED_RECORD_FIELDS:
+        if record.get(field) in (None, "", []):
+            blockers.append(f"missing_required_field:{field}")
+
+    symbol = str(record.get("instrument_symbol") or "")
+    asset_class = str(record.get("asset_class") or "").lower()
+
+    if asset_class in FORBIDDEN_ASSET_CLASSES:
+        blockers.append(f"forbidden_asset_class:{asset_class}")
+    if "-USD" in symbol.upper() or symbol.upper() in {"BTC", "ETH", "SOL", "DOGE", "XRP"}:
+        blockers.append("crypto_symbol_marker_detected")
+
+    if str(record.get("classification")) != "executable":
+        blockers.append("classification_not_executable")
+    if str(record.get("mapping_status")) != "ready":
+        blockers.append("mapping_status_not_ready")
+    if str(record.get("source_identity_status")) != "provider_symbol_verified":
+        blockers.append("source_identity_not_provider_verified")
+    if str(record.get("plan_status")) != "planned_not_executed":
+        blockers.append("plan_status_not_planned_not_executed")
+
+    for field in (
+        "screening_allowed",
+        "validation_allowed",
+        "execution_allowed",
+        "campaign_launch_allowed",
+        "candidate_promotion_allowed",
+        "paper_activation_allowed",
+        "shadow_activation_allowed",
+        "live_activation_allowed",
+    ):
+        if bool(record.get(field, False)):
+            blockers.append(f"{field}_true")
+
+    return [f"record_{index}:{blocker}" for blocker in blockers]
+
+
+def _feasibility_record(record: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "candidate_plan_id": str(record.get("candidate_plan_id")),
+        "instrument_symbol": str(record.get("instrument_symbol")),
+        "asset_class": str(record.get("asset_class")),
+        "region": str(record.get("region")),
+        "behavior_preset_id": str(record.get("behavior_preset_id")),
+        "timeframe": str(record.get("timeframe")),
+        "primary_data_provider_symbol": str(record.get("primary_data_provider_symbol")),
+        "source_identity_status": str(record.get("source_identity_status")),
+        "provider_symbol_status": record.get("provider_symbol_status"),
+        "feasibility_status": "runner_dry_run_design_ready",
+        "required_runner_inputs_present": True,
+        "missing_runner_inputs": [],
+        "safe_for_runner_dry_run_design": True,
+        "safe_to_execute_research": False,
+        "screening_allowed": False,
+        "validation_allowed": False,
+        "execution_allowed": False,
+        "campaign_launch_allowed": False,
+        "paper_activation_allowed": False,
+        "shadow_activation_allowed": False,
+        "live_activation_allowed": False,
+    }
+
+
+def build_feasibility_report(input_path: Path = DEFAULT_INPUT_PATH) -> dict[str, Any]:
+    packet = _require_packet(_read_json(input_path))
+    records = _records(packet)
+
+    hard_blockers: list[str] = []
+    if not _candidate_plan_ready(packet):
+        hard_blockers.append("input_candidate_plan_not_ready")
+
+    candidate_ids = [str(record.get("candidate_plan_id")) for record in records]
+    duplicate_ids = sorted(
+        candidate_id
+        for candidate_id, count in Counter(candidate_ids).items()
+        if count > 1
+    )
+    for candidate_id in duplicate_ids:
+        hard_blockers.append(f"duplicate_candidate_plan_id:{candidate_id}")
+
+    for index, record in enumerate(records, start=1):
+        hard_blockers.extend(_record_blockers(record, index=index))
+
+    feasibility_records = [_feasibility_record(record) for record in records]
+    region_counts = Counter(record["region"] for record in feasibility_records)
+    asset_class_counts = Counter(record["asset_class"] for record in feasibility_records)
+    preset_counts = Counter(record["behavior_preset_id"] for record in feasibility_records)
+    timeframe_counts = Counter(record["timeframe"] for record in feasibility_records)
+
+    report_ready = not hard_blockers
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "input_path": input_path.as_posix(),
+        "authority_boundaries": {
+            "feasibility_report_only": True,
+            "not_alpha_authority": True,
+            "not_trade_signal_generation": True,
+            "not_data_fetching": True,
+            "not_screening_execution": True,
+            "not_validation_execution": True,
+            "not_campaign_launch": True,
+            "not_queue_mutation": True,
+            "not_candidate_promotion": True,
+            "not_strategy_registration": True,
+            "not_preset_mutation": True,
+            "not_paper_shadow_live": True,
+            "not_broker_execution": True,
+            "not_risk_authority": True,
+            "does_not_mutate_research_latest": True,
+            "does_not_mutate_strategy_matrix": True,
+        },
+        "safety_invariants": {
+            "read_only_input": True,
+            "writes_logs_only": True,
+            "uses_network": False,
+            "uses_external_data": False,
+            "uses_embeddings": False,
+            "uses_vector_db": False,
+            "uses_llm_authority": False,
+            "mutates_campaigns": False,
+            "mutates_candidates": False,
+            "mutates_queues": False,
+            "mutates_strategies": False,
+            "mutates_presets": False,
+            "mutates_frozen_contracts": False,
+            "screening_validation_forbidden": True,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+        },
+        "summary": {
+            "feasibility_report_ready": report_ready,
+            "candidate_count": len(feasibility_records),
+            "hard_blocker_count": len(hard_blockers),
+            "duplicate_candidate_plan_id_count": len(duplicate_ids),
+            "runner_design_ready": report_ready,
+            "safe_to_execute_research": False,
+            "screening_allowed": False,
+            "validation_allowed": False,
+            "final_recommendation": (
+                "runner_dry_run_design_ready_not_execution"
+                if report_ready
+                else "runner_dry_run_design_blocked"
+            ),
+            "operator_summary": (
+                "Controlled subset candidates have complete dry-run runner-design metadata. "
+                "This report does not authorize screening, validation, campaigns, "
+                "paper/shadow/live, broker execution, or risk changes."
+                if report_ready
+                else "Controlled subset candidate feasibility has hard blockers."
+            ),
+            "region_counts": dict(sorted(region_counts.items())),
+            "asset_class_counts": dict(sorted(asset_class_counts.items())),
+            "preset_counts": dict(sorted(preset_counts.items())),
+            "timeframe_counts": dict(sorted(timeframe_counts.items())),
+        },
+        "hard_blockers": hard_blockers,
+        "feasibility_records": feasibility_records,
+    }
+
+
+def render_operator_summary(packet: dict[str, Any]) -> str:
+    summary = packet["summary"]
+    lines = [
+        "# QRE Controlled Subset Candidate Feasibility",
+        "",
+        f"- {summary['operator_summary']}",
+        "",
+        "## Current Status",
+        "",
+        f"- feasibility_report_ready: {summary['feasibility_report_ready']}",
+        f"- candidate_count: {summary['candidate_count']}",
+        f"- hard_blocker_count: {summary['hard_blocker_count']}",
+        f"- duplicate_candidate_plan_id_count: {summary['duplicate_candidate_plan_id_count']}",
+        f"- runner_design_ready: {summary['runner_design_ready']}",
+        f"- safe_to_execute_research: {summary['safe_to_execute_research']}",
+        f"- screening_allowed: {summary['screening_allowed']}",
+        f"- validation_allowed: {summary['validation_allowed']}",
+        f"- final_recommendation: {summary['final_recommendation']}",
+        "",
+        "## Region Counts",
+        "",
+    ]
+    for key, value in summary["region_counts"].items():
+        lines.append(f"- {key}: {value}")
+
+    if packet["hard_blockers"]:
+        lines.extend(["", "## Hard Blockers", ""])
+        for blocker in packet["hard_blockers"]:
+            lines.append(f"- {blocker}")
+
+    lines.extend(
+        [
+            "",
+            "## Authority Boundary",
+            "",
+            "- This report is feasibility context only.",
+            "- It does not run screening, validation, campaigns, paper/shadow/live, broker execution, risk changes, queue mutation, candidate promotion, strategy registration, or preset mutation.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def write_outputs(packet: dict[str, Any], output_dir: Path = DEFAULT_OUTPUT_DIR) -> dict[str, str]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    latest_path = output_dir / "latest.json"
+    summary_path = output_dir / "operator_summary.md"
+
+    latest_path.write_text(json.dumps(packet, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    summary_path.write_text(render_operator_summary(packet), encoding="utf-8")
+
+    return {
+        "latest": latest_path.as_posix(),
+        "operator_summary": summary_path.as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Build controlled subset candidate feasibility report."
+    )
+    parser.add_argument("--input", default=DEFAULT_INPUT_PATH.as_posix())
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+
+    packet = build_feasibility_report(Path(args.input))
+    if args.write:
+        packet["_artifact_paths"] = write_outputs(packet)
+
+    print(json.dumps(packet, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/research/qre_controlled_subset_runner_dry_run.py
+++ b/research/qre_controlled_subset_runner_dry_run.py
@@ -1,0 +1,288 @@
+"""Runner dry-run intent adapter for controlled subset candidates.
+
+This module converts a candidate feasibility report into runner dry-run intent
+records. It deliberately does not call run_research, campaign_launcher,
+screening, validation, broker execution, paper/shadow/live, or mutate
+research_latest.json / strategy_matrix.csv.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Final
+
+
+SCHEMA_VERSION: Final[str] = "1.0"
+REPORT_KIND: Final[str] = "qre_controlled_subset_runner_dry_run"
+
+DEFAULT_INPUT_PATH: Final[Path] = Path("logs/qre_controlled_subset_candidate_feasibility/latest.json")
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_controlled_subset_runner_dry_run")
+
+
+class RunnerDryRunError(RuntimeError):
+    """Raised when runner dry-run input cannot be read."""
+
+
+def _read_json(path: Path) -> Any:
+    if not path.exists():
+        raise RunnerDryRunError(f"feasibility report does not exist: {path.as_posix()}")
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def _require_packet(payload: Any) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise RunnerDryRunError("feasibility input must be a JSON object")
+    return payload
+
+
+def _records(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    raw_records = payload.get("feasibility_records")
+    if not isinstance(raw_records, list):
+        raise RunnerDryRunError("feasibility_records must be a list")
+    records: list[dict[str, Any]] = []
+    for index, record in enumerate(raw_records, start=1):
+        if not isinstance(record, dict):
+            raise RunnerDryRunError(f"feasibility_records[{index}] is not an object")
+        records.append(record)
+    return records
+
+
+def _feasibility_ready(payload: dict[str, Any]) -> bool:
+    summary = payload.get("summary")
+    if not isinstance(summary, dict):
+        return False
+    return (
+        payload.get("report_kind") == "qre_controlled_subset_candidate_feasibility"
+        and summary.get("feasibility_report_ready") is True
+        and summary.get("runner_design_ready") is True
+        and int(summary.get("hard_blocker_count") or 0) == 0
+        and summary.get("safe_to_execute_research") is False
+        and summary.get("screening_allowed") is False
+        and summary.get("validation_allowed") is False
+    )
+
+
+def _intent_blockers(record: dict[str, Any], *, index: int) -> list[str]:
+    blockers: list[str] = []
+
+    for field in (
+        "candidate_plan_id",
+        "instrument_symbol",
+        "asset_class",
+        "region",
+        "behavior_preset_id",
+        "timeframe",
+        "primary_data_provider_symbol",
+        "feasibility_status",
+    ):
+        if record.get(field) in (None, "", []):
+            blockers.append(f"missing_required_field:{field}")
+
+    if record.get("safe_for_runner_dry_run_design") is not True:
+        blockers.append("not_safe_for_runner_dry_run_design")
+    if record.get("required_runner_inputs_present") is not True:
+        blockers.append("required_runner_inputs_not_present")
+
+    if bool(record.get("screening_allowed", False)):
+        blockers.append("screening_allowed_true")
+    if bool(record.get("validation_allowed", False)):
+        blockers.append("validation_allowed_true")
+    if bool(record.get("execution_allowed", False)):
+        blockers.append("execution_allowed_true")
+    if bool(record.get("campaign_launch_allowed", False)):
+        blockers.append("campaign_launch_allowed_true")
+    if bool(record.get("paper_activation_allowed", False)):
+        blockers.append("paper_activation_allowed_true")
+    if bool(record.get("shadow_activation_allowed", False)):
+        blockers.append("shadow_activation_allowed_true")
+    if bool(record.get("live_activation_allowed", False)):
+        blockers.append("live_activation_allowed_true")
+
+    return [f"record_{index}:{blocker}" for blocker in blockers]
+
+
+def _runner_intent(record: dict[str, Any]) -> dict[str, Any]:
+    candidate_plan_id = str(record.get("candidate_plan_id"))
+    return {
+        "runner_dry_run_intent_id": f"runner-dryrun::{candidate_plan_id}",
+        "candidate_plan_id": candidate_plan_id,
+        "instrument_symbol": str(record.get("instrument_symbol")),
+        "asset_class": str(record.get("asset_class")),
+        "region": str(record.get("region")),
+        "behavior_preset_id": str(record.get("behavior_preset_id")),
+        "timeframe": str(record.get("timeframe")),
+        "primary_data_provider_symbol": str(record.get("primary_data_provider_symbol")),
+        "intent_status": "runner_dry_run_intent_materialized_not_executed",
+        "expected_runner_mode": "dry_run_no_subprocess_no_mutation",
+        "not_alpha_claim": True,
+        "run_research_called": False,
+        "campaign_launcher_called": False,
+        "screening_called": False,
+        "validation_called": False,
+        "network_allowed": False,
+        "external_data_allowed": False,
+        "screening_allowed": False,
+        "validation_allowed": False,
+        "execution_allowed": False,
+        "campaign_launch_allowed": False,
+        "candidate_promotion_allowed": False,
+        "paper_activation_allowed": False,
+        "shadow_activation_allowed": False,
+        "live_activation_allowed": False,
+        "expected_artifact_scope": "logs_only",
+    }
+
+
+def build_runner_dry_run_packet(input_path: Path = DEFAULT_INPUT_PATH) -> dict[str, Any]:
+    packet = _require_packet(_read_json(input_path))
+    records = _records(packet)
+
+    blockers: list[str] = []
+    if not _feasibility_ready(packet):
+        blockers.append("input_feasibility_report_not_ready")
+
+    for index, record in enumerate(records, start=1):
+        blockers.extend(_intent_blockers(record, index=index))
+
+    intents = [_runner_intent(record) for record in records]
+    packet_ready = not blockers
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "input_path": input_path.as_posix(),
+        "authority_boundaries": {
+            "runner_adapter_is_dry_run_only": True,
+            "not_alpha_authority": True,
+            "not_trade_signal_generation": True,
+            "not_data_fetching": True,
+            "not_screening_execution": True,
+            "not_validation_execution": True,
+            "not_campaign_launch": True,
+            "not_queue_mutation": True,
+            "not_candidate_promotion": True,
+            "not_strategy_registration": True,
+            "not_preset_mutation": True,
+            "not_paper_shadow_live": True,
+            "not_broker_execution": True,
+            "not_risk_authority": True,
+            "does_not_call_run_research": True,
+            "does_not_call_campaign_launcher": True,
+            "does_not_mutate_research_latest": True,
+            "does_not_mutate_strategy_matrix": True,
+        },
+        "safety_invariants": {
+            "writes_logs_only": True,
+            "uses_network": False,
+            "uses_external_data": False,
+            "uses_embeddings": False,
+            "uses_vector_db": False,
+            "uses_llm_authority": False,
+            "mutates_campaigns": False,
+            "mutates_candidates": False,
+            "mutates_queues": False,
+            "mutates_strategies": False,
+            "mutates_presets": False,
+            "mutates_frozen_contracts": False,
+            "screening_validation_forbidden": True,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+        },
+        "summary": {
+            "runner_dry_run_packet_ready": packet_ready,
+            "runner_dry_run_intent_count": len(intents),
+            "blocker_count": len(blockers),
+            "safe_to_execute_research": False,
+            "screening_allowed": False,
+            "validation_allowed": False,
+            "run_research_called": False,
+            "campaign_launcher_called": False,
+            "final_recommendation": (
+                "runner_dry_run_intents_ready_not_executed"
+                if packet_ready
+                else "runner_dry_run_intents_blocked"
+            ),
+            "operator_summary": (
+                "Runner dry-run intents are materialized as logs-only records. "
+                "No runner, screening, validation, campaign launcher, network, "
+                "paper/shadow/live, broker, or risk authority was invoked."
+                if packet_ready
+                else "Runner dry-run intents have blockers and must not be used."
+            ),
+        },
+        "blockers": blockers,
+        "runner_dry_run_intents": intents,
+    }
+
+
+def render_operator_summary(packet: dict[str, Any]) -> str:
+    summary = packet["summary"]
+    lines = [
+        "# QRE Controlled Subset Runner Dry-Run",
+        "",
+        f"- {summary['operator_summary']}",
+        "",
+        "## Current Status",
+        "",
+        f"- runner_dry_run_packet_ready: {summary['runner_dry_run_packet_ready']}",
+        f"- runner_dry_run_intent_count: {summary['runner_dry_run_intent_count']}",
+        f"- blocker_count: {summary['blocker_count']}",
+        f"- safe_to_execute_research: {summary['safe_to_execute_research']}",
+        f"- screening_allowed: {summary['screening_allowed']}",
+        f"- validation_allowed: {summary['validation_allowed']}",
+        f"- run_research_called: {summary['run_research_called']}",
+        f"- campaign_launcher_called: {summary['campaign_launcher_called']}",
+        f"- final_recommendation: {summary['final_recommendation']}",
+    ]
+
+    if packet["blockers"]:
+        lines.extend(["", "## Blockers", ""])
+        for blocker in packet["blockers"]:
+            lines.append(f"- {blocker}")
+
+    lines.extend(
+        [
+            "",
+            "## Authority Boundary",
+            "",
+            "- This is a runner dry-run intent packet only.",
+            "- It does not call run_research, campaign_launcher, screening, validation, paper/shadow/live, broker execution, risk changes, queue mutation, candidate promotion, strategy registration, or preset mutation.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def write_outputs(packet: dict[str, Any], output_dir: Path = DEFAULT_OUTPUT_DIR) -> dict[str, str]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    latest_path = output_dir / "latest.json"
+    summary_path = output_dir / "operator_summary.md"
+
+    latest_path.write_text(json.dumps(packet, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    summary_path.write_text(render_operator_summary(packet), encoding="utf-8")
+
+    return {
+        "latest": latest_path.as_posix(),
+        "operator_summary": summary_path.as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Build runner dry-run intent packet from controlled subset feasibility."
+    )
+    parser.add_argument("--input", default=DEFAULT_INPUT_PATH.as_posix())
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+
+    packet = build_runner_dry_run_packet(Path(args.input))
+    if args.write:
+        packet["_artifact_paths"] = write_outputs(packet)
+
+    print(json.dumps(packet, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_qre_controlled_subset_feasibility_runner_dryrun.py
+++ b/tests/unit/test_qre_controlled_subset_feasibility_runner_dryrun.py
@@ -1,0 +1,195 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from research.qre_controlled_subset_candidate_feasibility import (
+    CandidateFeasibilityError,
+    build_feasibility_report,
+    render_operator_summary as render_feasibility_summary,
+    write_outputs as write_feasibility_outputs,
+)
+from research.qre_controlled_subset_runner_dry_run import (
+    RunnerDryRunError,
+    build_runner_dry_run_packet,
+    render_operator_summary as render_runner_summary,
+    write_outputs as write_runner_outputs,
+)
+
+
+def _candidate_record(symbol: str = "AAPL") -> dict:
+    return {
+        "candidate_plan_id": f"qre-dryrun::{symbol}::trend_continuation_daily_v1::1d",
+        "subset_sequence_number": 1,
+        "source_sequence_number": 125,
+        "instrument_symbol": symbol,
+        "asset_class": "equity",
+        "region": "US",
+        "behavior_preset_id": "trend_continuation_daily_v1",
+        "timeframe": "1d",
+        "classification": "executable",
+        "mapping_status": "ready",
+        "source_identity_status": "provider_symbol_verified",
+        "primary_data_provider_symbol": symbol,
+        "provider_symbol_status": "verified",
+        "plan_status": "planned_not_executed",
+        "screening_allowed": False,
+        "validation_allowed": False,
+        "execution_allowed": False,
+        "campaign_launch_allowed": False,
+        "candidate_promotion_allowed": False,
+        "paper_activation_allowed": False,
+        "shadow_activation_allowed": False,
+        "live_activation_allowed": False,
+    }
+
+
+def _candidate_plan(records: list[dict]) -> dict:
+    return {
+        "schema_version": "1.0",
+        "report_kind": "qre_controlled_subset_candidate_plan",
+        "summary": {
+            "candidate_plan_ready": True,
+            "candidate_plan_count": len(records),
+            "validation_blocker_count": 0,
+            "safe_to_execute_research": False,
+            "screening_allowed": False,
+            "validation_allowed": False,
+        },
+        "candidate_plan_records": records,
+    }
+
+
+def _write_json(tmp_path: Path, payload: dict, *, name: str = "latest.json") -> Path:
+    path = tmp_path / name
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_feasibility_report_ready_for_clean_candidate_plan(tmp_path: Path) -> None:
+    path = _write_json(tmp_path, _candidate_plan([_candidate_record("AAPL"), _candidate_record("MSFT")]))
+
+    report = build_feasibility_report(path)
+
+    assert report["report_kind"] == "qre_controlled_subset_candidate_feasibility"
+    assert report["summary"]["feasibility_report_ready"] is True
+    assert report["summary"]["candidate_count"] == 2
+    assert report["summary"]["hard_blocker_count"] == 0
+    assert report["summary"]["runner_design_ready"] is True
+    assert report["summary"]["safe_to_execute_research"] is False
+    assert report["authority_boundaries"]["not_screening_execution"] is True
+    assert report["authority_boundaries"]["does_not_mutate_research_latest"] is True
+
+
+def test_feasibility_blocks_not_ready_candidate_plan(tmp_path: Path) -> None:
+    payload = _candidate_plan([_candidate_record("AAPL")])
+    payload["summary"]["candidate_plan_ready"] = False
+    path = _write_json(tmp_path, payload)
+
+    report = build_feasibility_report(path)
+
+    assert report["summary"]["feasibility_report_ready"] is False
+    assert "input_candidate_plan_not_ready" in report["hard_blockers"]
+
+
+def test_feasibility_blocks_crypto_candidate(tmp_path: Path) -> None:
+    record = {**_candidate_record("BTC-USD"), "asset_class": "crypto_legacy"}
+    path = _write_json(tmp_path, _candidate_plan([record]))
+
+    report = build_feasibility_report(path)
+
+    assert report["summary"]["feasibility_report_ready"] is False
+    assert any("forbidden_asset_class:crypto_legacy" in item for item in report["hard_blockers"])
+    assert any("crypto_symbol_marker_detected" in item for item in report["hard_blockers"])
+
+
+def test_feasibility_blocks_duplicate_candidate_ids(tmp_path: Path) -> None:
+    records = [_candidate_record("AAPL"), _candidate_record("AAPL")]
+    path = _write_json(tmp_path, _candidate_plan(records))
+
+    report = build_feasibility_report(path)
+
+    assert report["summary"]["duplicate_candidate_plan_id_count"] == 1
+    assert report["summary"]["feasibility_report_ready"] is False
+    assert any("duplicate_candidate_plan_id" in item for item in report["hard_blockers"])
+
+
+def test_feasibility_summary_and_outputs(tmp_path: Path) -> None:
+    path = _write_json(tmp_path, _candidate_plan([_candidate_record("AAPL")]))
+    report = build_feasibility_report(path)
+
+    summary = render_feasibility_summary(report)
+    outputs = write_feasibility_outputs(report, tmp_path / "feasibility")
+
+    assert "feasibility_report_ready: True" in summary
+    assert "runner_design_ready: True" in summary
+    assert Path(outputs["latest"]).exists()
+    assert Path(outputs["operator_summary"]).exists()
+
+
+def test_runner_dry_run_packet_ready_from_feasibility(tmp_path: Path) -> None:
+    plan_path = _write_json(tmp_path, _candidate_plan([_candidate_record("AAPL"), _candidate_record("MSFT")]))
+    feasibility = build_feasibility_report(plan_path)
+    feasibility_path = _write_json(tmp_path, feasibility, name="feasibility.json")
+
+    packet = build_runner_dry_run_packet(feasibility_path)
+
+    assert packet["report_kind"] == "qre_controlled_subset_runner_dry_run"
+    assert packet["summary"]["runner_dry_run_packet_ready"] is True
+    assert packet["summary"]["runner_dry_run_intent_count"] == 2
+    assert packet["summary"]["safe_to_execute_research"] is False
+    assert packet["summary"]["run_research_called"] is False
+    assert packet["summary"]["campaign_launcher_called"] is False
+    assert packet["authority_boundaries"]["does_not_call_run_research"] is True
+    assert packet["authority_boundaries"]["not_validation_execution"] is True
+
+
+def test_runner_dry_run_intent_fields(tmp_path: Path) -> None:
+    plan_path = _write_json(tmp_path, _candidate_plan([_candidate_record("ADYEN")]))
+    feasibility = build_feasibility_report(plan_path)
+    feasibility_path = _write_json(tmp_path, feasibility, name="feasibility.json")
+
+    packet = build_runner_dry_run_packet(feasibility_path)
+    intent = packet["runner_dry_run_intents"][0]
+
+    assert intent["runner_dry_run_intent_id"] == "runner-dryrun::qre-dryrun::ADYEN::trend_continuation_daily_v1::1d"
+    assert intent["instrument_symbol"] == "ADYEN"
+    assert intent["intent_status"] == "runner_dry_run_intent_materialized_not_executed"
+    assert intent["expected_runner_mode"] == "dry_run_no_subprocess_no_mutation"
+    assert intent["run_research_called"] is False
+    assert intent["screening_called"] is False
+    assert intent["validation_called"] is False
+
+
+def test_runner_dry_run_blocks_not_ready_feasibility(tmp_path: Path) -> None:
+    plan_path = _write_json(tmp_path, _candidate_plan([_candidate_record("AAPL")]))
+    feasibility = build_feasibility_report(plan_path)
+    feasibility["summary"]["feasibility_report_ready"] = False
+    feasibility_path = _write_json(tmp_path, feasibility, name="feasibility.json")
+
+    packet = build_runner_dry_run_packet(feasibility_path)
+
+    assert packet["summary"]["runner_dry_run_packet_ready"] is False
+    assert "input_feasibility_report_not_ready" in packet["blockers"]
+
+
+def test_runner_summary_and_outputs(tmp_path: Path) -> None:
+    plan_path = _write_json(tmp_path, _candidate_plan([_candidate_record("AAPL")]))
+    feasibility = build_feasibility_report(plan_path)
+    feasibility_path = _write_json(tmp_path, feasibility, name="feasibility.json")
+    packet = build_runner_dry_run_packet(feasibility_path)
+
+    summary = render_runner_summary(packet)
+    outputs = write_runner_outputs(packet, tmp_path / "runner")
+
+    assert "runner_dry_run_packet_ready: True" in summary
+    assert "does not call run_research" in summary
+    assert Path(outputs["latest"]).exists()
+    assert Path(outputs["operator_summary"]).exists()
+
+
+def test_missing_inputs_raise() -> None:
+    with pytest.raises(CandidateFeasibilityError):
+        build_feasibility_report(Path("does/not/exist.json"))
+    with pytest.raises(RunnerDryRunError):
+        build_runner_dry_run_packet(Path("does/not/exist.json"))


### PR DESCRIPTION
## Summary
- add controlled subset candidate feasibility report
- add controlled subset runner dry-run intent packet
- combine feasibility and runner dry-run design in one PR
- preserve the 8-row non-crypto provider-verified subset
- keep run_research, campaign_launcher, screening, validation, campaigns, paper/shadow/live, broker/risk, queue mutation, candidate promotion, strategy registration, and preset mutation forbidden

## Validation
- python -m pytest tests/unit/test_qre_controlled_subset_feasibility_runner_dryrun.py -q
- python -m research.qre_controlled_discovery_subset_adapter --write
- python -m research.qre_controlled_subset_candidate_plan --write
- python -m research.qre_controlled_subset_candidate_feasibility --write
- python -m research.qre_controlled_subset_runner_dry_run --write
- git diff --check
- git diff -- research/research_latest.json research/strategy_matrix.csv