### PR TITLE
fix: add controlled subset screening dry run plan

### DIFF
--- a/research/qre_controlled_subset_screening_dry_run_plan.py
+++ b/research/qre_controlled_subset_screening_dry_run_plan.py
@@ -1,0 +1,365 @@
+"""Screening dry-run plan for controlled subset local runner envelopes.
+
+This module consumes local runner harness envelopes and materializes screening
+dry-run plan records. It deliberately does not run screening, validation,
+run_research, campaign_launcher, subprocesses, network, broker execution,
+paper/shadow/live, or mutate research_latest.json / strategy_matrix.csv.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any, Final
+
+
+SCHEMA_VERSION: Final[str] = "1.0"
+REPORT_KIND: Final[str] = "qre_controlled_subset_screening_dry_run_plan"
+
+DEFAULT_INPUT_PATH: Final[Path] = Path(
+    "logs/qre_controlled_subset_local_runner_harness/latest.json"
+)
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_controlled_subset_screening_dry_run_plan")
+
+FORBIDDEN_ASSET_CLASSES: Final[set[str]] = {"crypto", "crypto_legacy"}
+REQUIRED_ENVELOPE_FIELDS: Final[tuple[str, ...]] = (
+    "local_runner_envelope_id",
+    "runner_dry_run_intent_id",
+    "candidate_plan_id",
+    "instrument_symbol",
+    "asset_class",
+    "region",
+    "behavior_preset_id",
+    "timeframe",
+    "primary_data_provider_symbol",
+    "envelope_status",
+)
+
+
+class ScreeningDryRunPlanError(RuntimeError):
+    """Raised when screening dry-run plan input cannot be read."""
+
+
+def _read_json(path: Path) -> Any:
+    if not path.exists():
+        raise ScreeningDryRunPlanError(
+            f"local runner harness packet does not exist: {path.as_posix()}"
+        )
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def _require_packet(payload: Any) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise ScreeningDryRunPlanError("local runner harness input must be a JSON object")
+    return payload
+
+
+def _envelopes(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    raw_envelopes = payload.get("local_runner_envelopes")
+    if not isinstance(raw_envelopes, list):
+        raise ScreeningDryRunPlanError("local_runner_envelopes must be a list")
+    envelopes: list[dict[str, Any]] = []
+    for index, envelope in enumerate(raw_envelopes, start=1):
+        if not isinstance(envelope, dict):
+            raise ScreeningDryRunPlanError(f"local_runner_envelopes[{index}] is not an object")
+        envelopes.append(envelope)
+    return envelopes
+
+
+def _input_packet_ready(payload: dict[str, Any]) -> bool:
+    summary = payload.get("summary")
+    if not isinstance(summary, dict):
+        return False
+    return (
+        payload.get("report_kind") == "qre_controlled_subset_local_runner_harness"
+        and summary.get("local_runner_harness_ready") is True
+        and int(summary.get("blocker_count") or 0) == 0
+        and summary.get("execution_performed") is False
+        and summary.get("subprocess_called") is False
+        and summary.get("network_called") is False
+        and summary.get("run_research_called") is False
+        and summary.get("campaign_launcher_called") is False
+        and summary.get("screening_called") is False
+        and summary.get("validation_called") is False
+        and summary.get("safe_to_execute_research") is False
+    )
+
+
+def _envelope_blockers(envelope: dict[str, Any], *, index: int) -> list[str]:
+    blockers: list[str] = []
+
+    for field in REQUIRED_ENVELOPE_FIELDS:
+        if envelope.get(field) in (None, "", []):
+            blockers.append(f"missing_required_field:{field}")
+
+    symbol = str(envelope.get("instrument_symbol") or "")
+    asset_class = str(envelope.get("asset_class") or "").lower()
+
+    if asset_class in FORBIDDEN_ASSET_CLASSES:
+        blockers.append(f"forbidden_asset_class:{asset_class}")
+    if "-USD" in symbol.upper() or symbol.upper() in {"BTC", "ETH", "SOL", "DOGE", "XRP"}:
+        blockers.append("crypto_symbol_marker_detected")
+
+    if str(envelope.get("envelope_status")) != "local_harness_envelope_materialized_not_executed":
+        blockers.append("envelope_status_not_materialized_not_executed")
+
+    for field in (
+        "execution_performed",
+        "subprocess_called",
+        "network_called",
+        "run_research_called",
+        "campaign_launcher_called",
+        "screening_called",
+        "validation_called",
+        "candidate_registry_mutated",
+        "campaign_artifacts_mutated",
+        "queue_mutated",
+        "strategy_registered",
+        "preset_mutated",
+        "research_latest_mutated",
+        "strategy_matrix_mutated",
+        "paper_activation_allowed",
+        "shadow_activation_allowed",
+        "live_activation_allowed",
+        "broker_execution_allowed",
+        "risk_authority_allowed",
+    ):
+        if bool(envelope.get(field, False)):
+            blockers.append(f"{field}_true")
+
+    return [f"envelope_{index}:{blocker}" for blocker in blockers]
+
+
+def _screening_plan_record(envelope: dict[str, Any], *, index: int) -> dict[str, Any]:
+    envelope_id = str(envelope.get("local_runner_envelope_id"))
+    return {
+        "screening_dry_run_plan_id": f"screening-dryrun-plan::{envelope_id}",
+        "plan_sequence_number": index,
+        "local_runner_envelope_id": envelope_id,
+        "runner_dry_run_intent_id": str(envelope.get("runner_dry_run_intent_id")),
+        "candidate_plan_id": str(envelope.get("candidate_plan_id")),
+        "instrument_symbol": str(envelope.get("instrument_symbol")),
+        "asset_class": str(envelope.get("asset_class")),
+        "region": str(envelope.get("region")),
+        "behavior_preset_id": str(envelope.get("behavior_preset_id")),
+        "timeframe": str(envelope.get("timeframe")),
+        "primary_data_provider_symbol": str(envelope.get("primary_data_provider_symbol")),
+        "plan_status": "screening_dry_run_planned_not_executed",
+        "screening_mode": "local_dry_run_no_subprocess_no_network_no_mutation",
+        "expected_artifact_scope": "logs_only",
+        "not_alpha_claim": True,
+        "screening_executed": False,
+        "validation_executed": False,
+        "execution_performed": False,
+        "subprocess_called": False,
+        "network_called": False,
+        "run_research_called": False,
+        "campaign_launcher_called": False,
+        "candidate_registry_mutated": False,
+        "campaign_artifacts_mutated": False,
+        "queue_mutated": False,
+        "strategy_registered": False,
+        "preset_mutated": False,
+        "research_latest_mutated": False,
+        "strategy_matrix_mutated": False,
+        "candidate_promotion_allowed": False,
+        "paper_activation_allowed": False,
+        "shadow_activation_allowed": False,
+        "live_activation_allowed": False,
+        "broker_execution_allowed": False,
+        "risk_authority_allowed": False,
+    }
+
+
+def build_screening_dry_run_plan(input_path: Path = DEFAULT_INPUT_PATH) -> dict[str, Any]:
+    packet = _require_packet(_read_json(input_path))
+    envelopes = _envelopes(packet)
+
+    blockers: list[str] = []
+    if not _input_packet_ready(packet):
+        blockers.append("input_local_runner_harness_packet_not_ready")
+
+    envelope_ids = [str(envelope.get("local_runner_envelope_id")) for envelope in envelopes]
+    duplicate_envelope_ids = sorted(
+        envelope_id
+        for envelope_id, count in Counter(envelope_ids).items()
+        if count > 1
+    )
+    for envelope_id in duplicate_envelope_ids:
+        blockers.append(f"duplicate_local_runner_envelope_id:{envelope_id}")
+
+    for index, envelope in enumerate(envelopes, start=1):
+        blockers.extend(_envelope_blockers(envelope, index=index))
+
+    plan_records = [
+        _screening_plan_record(envelope, index=index)
+        for index, envelope in enumerate(envelopes, start=1)
+    ]
+
+    region_counts = Counter(record["region"] for record in plan_records)
+    asset_class_counts = Counter(record["asset_class"] for record in plan_records)
+    preset_counts = Counter(record["behavior_preset_id"] for record in plan_records)
+    timeframe_counts = Counter(record["timeframe"] for record in plan_records)
+
+    plan_ready = not blockers
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "input_path": input_path.as_posix(),
+        "authority_boundaries": {
+            "screening_plan_only": True,
+            "not_alpha_authority": True,
+            "not_trade_signal_generation": True,
+            "not_data_fetching": True,
+            "not_screening_execution": True,
+            "not_validation_execution": True,
+            "not_campaign_launch": True,
+            "not_queue_mutation": True,
+            "not_candidate_promotion": True,
+            "not_strategy_registration": True,
+            "not_preset_mutation": True,
+            "not_paper_shadow_live": True,
+            "not_broker_execution": True,
+            "not_risk_authority": True,
+            "does_not_call_subprocess": True,
+            "does_not_call_network": True,
+            "does_not_call_run_research": True,
+            "does_not_call_campaign_launcher": True,
+            "does_not_mutate_research_latest": True,
+            "does_not_mutate_strategy_matrix": True,
+        },
+        "safety_invariants": {
+            "writes_logs_only": True,
+            "uses_network": False,
+            "uses_external_data": False,
+            "uses_subprocess": False,
+            "uses_embeddings": False,
+            "uses_vector_db": False,
+            "uses_llm_authority": False,
+            "mutates_campaigns": False,
+            "mutates_candidates": False,
+            "mutates_queues": False,
+            "mutates_strategies": False,
+            "mutates_presets": False,
+            "mutates_frozen_contracts": False,
+            "screening_validation_forbidden": True,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+        },
+        "summary": {
+            "screening_dry_run_plan_ready": plan_ready,
+            "envelope_count": len(envelopes),
+            "screening_plan_count": len(plan_records),
+            "blocker_count": len(blockers),
+            "duplicate_local_runner_envelope_id_count": len(duplicate_envelope_ids),
+            "screening_executed": False,
+            "validation_executed": False,
+            "execution_performed": False,
+            "subprocess_called": False,
+            "network_called": False,
+            "run_research_called": False,
+            "campaign_launcher_called": False,
+            "safe_to_execute_research": False,
+            "final_recommendation": (
+                "screening_dry_run_plan_ready_not_executed"
+                if plan_ready
+                else "screening_dry_run_plan_blocked"
+            ),
+            "operator_summary": (
+                "Controlled screening dry-run plan is materialized as logs-only records. "
+                "No screening, validation, subprocess, network, run_research, "
+                "campaign_launcher, paper/shadow/live, broker, or risk authority was invoked."
+                if plan_ready
+                else "Controlled screening dry-run plan has blockers and must not be used."
+            ),
+            "region_counts": dict(sorted(region_counts.items())),
+            "asset_class_counts": dict(sorted(asset_class_counts.items())),
+            "preset_counts": dict(sorted(preset_counts.items())),
+            "timeframe_counts": dict(sorted(timeframe_counts.items())),
+        },
+        "blockers": blockers,
+        "screening_dry_run_plan_records": plan_records,
+    }
+
+
+def render_operator_summary(packet: dict[str, Any]) -> str:
+    summary = packet["summary"]
+    lines = [
+        "# QRE Controlled Subset Screening Dry-Run Plan",
+        "",
+        f"- {summary['operator_summary']}",
+        "",
+        "## Current Status",
+        "",
+        f"- screening_dry_run_plan_ready: {summary['screening_dry_run_plan_ready']}",
+        f"- envelope_count: {summary['envelope_count']}",
+        f"- screening_plan_count: {summary['screening_plan_count']}",
+        f"- blocker_count: {summary['blocker_count']}",
+        f"- screening_executed: {summary['screening_executed']}",
+        f"- validation_executed: {summary['validation_executed']}",
+        f"- execution_performed: {summary['execution_performed']}",
+        f"- subprocess_called: {summary['subprocess_called']}",
+        f"- network_called: {summary['network_called']}",
+        f"- run_research_called: {summary['run_research_called']}",
+        f"- campaign_launcher_called: {summary['campaign_launcher_called']}",
+        f"- safe_to_execute_research: {summary['safe_to_execute_research']}",
+        f"- final_recommendation: {summary['final_recommendation']}",
+        "",
+        "## Region Counts",
+        "",
+    ]
+    for key, value in summary["region_counts"].items():
+        lines.append(f"- {key}: {value}")
+
+    if packet["blockers"]:
+        lines.extend(["", "## Blockers", ""])
+        for blocker in packet["blockers"]:
+            lines.append(f"- {blocker}")
+
+    lines.extend(
+        [
+            "",
+            "## Authority Boundary",
+            "",
+            "- This module only materializes screening dry-run plan records.",
+            "- It does not execute screening, validation, subprocess, network, run_research, campaign_launcher, paper/shadow/live, broker execution, risk changes, queue mutation, candidate promotion, strategy registration, or preset mutation.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def write_outputs(packet: dict[str, Any], output_dir: Path = DEFAULT_OUTPUT_DIR) -> dict[str, str]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    latest_path = output_dir / "latest.json"
+    summary_path = output_dir / "operator_summary.md"
+
+    latest_path.write_text(json.dumps(packet, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    summary_path.write_text(render_operator_summary(packet), encoding="utf-8")
+
+    return {
+        "latest": latest_path.as_posix(),
+        "operator_summary": summary_path.as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Build screening dry-run plan from controlled subset local runner envelopes."
+    )
+    parser.add_argument("--input", default=DEFAULT_INPUT_PATH.as_posix())
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+
+    packet = build_screening_dry_run_plan(Path(args.input))
+    if args.write:
+        packet["_artifact_paths"] = write_outputs(packet)
+
+    print(json.dumps(packet, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_qre_controlled_subset_screening_dry_run_plan.py
+++ b/tests/unit/test_qre_controlled_subset_screening_dry_run_plan.py
@@ -1,0 +1,194 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from research.qre_controlled_subset_screening_dry_run_plan import (
+    ScreeningDryRunPlanError,
+    build_screening_dry_run_plan,
+    render_operator_summary,
+    write_outputs,
+)
+
+
+def _envelope(symbol: str = "AAPL") -> dict:
+    return {
+        "local_runner_envelope_id": f"local-harness::runner-dryrun::qre-dryrun::{symbol}::trend_continuation_daily_v1::1d",
+        "runner_dry_run_intent_id": f"runner-dryrun::qre-dryrun::{symbol}::trend_continuation_daily_v1::1d",
+        "candidate_plan_id": f"qre-dryrun::{symbol}::trend_continuation_daily_v1::1d",
+        "instrument_symbol": symbol,
+        "asset_class": "equity",
+        "region": "US",
+        "behavior_preset_id": "trend_continuation_daily_v1",
+        "timeframe": "1d",
+        "primary_data_provider_symbol": symbol,
+        "envelope_status": "local_harness_envelope_materialized_not_executed",
+        "execution_performed": False,
+        "subprocess_called": False,
+        "network_called": False,
+        "run_research_called": False,
+        "campaign_launcher_called": False,
+        "screening_called": False,
+        "validation_called": False,
+        "candidate_registry_mutated": False,
+        "campaign_artifacts_mutated": False,
+        "queue_mutated": False,
+        "strategy_registered": False,
+        "preset_mutated": False,
+        "research_latest_mutated": False,
+        "strategy_matrix_mutated": False,
+        "paper_activation_allowed": False,
+        "shadow_activation_allowed": False,
+        "live_activation_allowed": False,
+        "broker_execution_allowed": False,
+        "risk_authority_allowed": False,
+    }
+
+
+def _packet(envelopes: list[dict]) -> dict:
+    return {
+        "schema_version": "1.0",
+        "report_kind": "qre_controlled_subset_local_runner_harness",
+        "summary": {
+            "local_runner_harness_ready": True,
+            "envelope_count": len(envelopes),
+            "blocker_count": 0,
+            "execution_performed": False,
+            "subprocess_called": False,
+            "network_called": False,
+            "run_research_called": False,
+            "campaign_launcher_called": False,
+            "screening_called": False,
+            "validation_called": False,
+            "safe_to_execute_research": False,
+        },
+        "local_runner_envelopes": envelopes,
+    }
+
+
+def _write_packet(tmp_path: Path, payload: dict, *, bom: bool = False) -> Path:
+    path = tmp_path / "local_harness.json"
+    path.write_text(json.dumps(payload), encoding="utf-8-sig" if bom else "utf-8")
+    return path
+
+
+def test_screening_dry_run_plan_ready_for_clean_envelopes(tmp_path: Path) -> None:
+    path = _write_packet(tmp_path, _packet([_envelope("AAPL"), _envelope("MSFT")]))
+
+    packet = build_screening_dry_run_plan(path)
+
+    assert packet["report_kind"] == "qre_controlled_subset_screening_dry_run_plan"
+    assert packet["summary"]["screening_dry_run_plan_ready"] is True
+    assert packet["summary"]["envelope_count"] == 2
+    assert packet["summary"]["screening_plan_count"] == 2
+    assert packet["summary"]["blocker_count"] == 0
+    assert packet["summary"]["screening_executed"] is False
+    assert packet["summary"]["validation_executed"] is False
+    assert packet["summary"]["subprocess_called"] is False
+    assert packet["summary"]["run_research_called"] is False
+    assert packet["authority_boundaries"]["not_screening_execution"] is True
+    assert packet["authority_boundaries"]["does_not_call_run_research"] is True
+
+
+def test_screening_plan_record_fields(tmp_path: Path) -> None:
+    path = _write_packet(tmp_path, _packet([_envelope("ADYEN")]))
+
+    packet = build_screening_dry_run_plan(path)
+    record = packet["screening_dry_run_plan_records"][0]
+
+    assert record["screening_dry_run_plan_id"] == (
+        "screening-dryrun-plan::local-harness::runner-dryrun::qre-dryrun::ADYEN::trend_continuation_daily_v1::1d"
+    )
+    assert record["instrument_symbol"] == "ADYEN"
+    assert record["plan_status"] == "screening_dry_run_planned_not_executed"
+    assert record["screening_mode"] == "local_dry_run_no_subprocess_no_network_no_mutation"
+    assert record["screening_executed"] is False
+    assert record["validation_executed"] is False
+    assert record["candidate_registry_mutated"] is False
+
+
+def test_counts_regions_assets_presets_timeframes(tmp_path: Path) -> None:
+    envelopes = [
+        {**_envelope("ADYEN"), "region": "NL/EU"},
+        {**_envelope("AAPL"), "region": "US"},
+        {**_envelope("SPY"), "asset_class": "etf", "region": "ETFs/context"},
+    ]
+    path = _write_packet(tmp_path, _packet(envelopes))
+
+    packet = build_screening_dry_run_plan(path)
+
+    assert packet["summary"]["region_counts"] == {"ETFs/context": 1, "NL/EU": 1, "US": 1}
+    assert packet["summary"]["asset_class_counts"] == {"equity": 2, "etf": 1}
+    assert packet["summary"]["preset_counts"] == {"trend_continuation_daily_v1": 3}
+    assert packet["summary"]["timeframe_counts"] == {"1d": 3}
+
+
+def test_blocks_not_ready_input(tmp_path: Path) -> None:
+    payload = _packet([_envelope("AAPL")])
+    payload["summary"]["local_runner_harness_ready"] = False
+    path = _write_packet(tmp_path, payload)
+
+    packet = build_screening_dry_run_plan(path)
+
+    assert packet["summary"]["screening_dry_run_plan_ready"] is False
+    assert "input_local_runner_harness_packet_not_ready" in packet["blockers"]
+
+
+def test_blocks_crypto_envelope(tmp_path: Path) -> None:
+    path = _write_packet(
+        tmp_path,
+        _packet([{**_envelope("BTC-USD"), "asset_class": "crypto_legacy"}]),
+    )
+
+    packet = build_screening_dry_run_plan(path)
+
+    assert packet["summary"]["screening_dry_run_plan_ready"] is False
+    assert any("forbidden_asset_class:crypto_legacy" in item for item in packet["blockers"])
+    assert any("crypto_symbol_marker_detected" in item for item in packet["blockers"])
+
+
+def test_blocks_any_true_execution_flag(tmp_path: Path) -> None:
+    path = _write_packet(tmp_path, _packet([{**_envelope("AAPL"), "screening_called": True}]))
+
+    packet = build_screening_dry_run_plan(path)
+
+    assert packet["summary"]["screening_dry_run_plan_ready"] is False
+    assert any("screening_called_true" in item for item in packet["blockers"])
+
+
+def test_blocks_duplicate_envelopes(tmp_path: Path) -> None:
+    path = _write_packet(tmp_path, _packet([_envelope("AAPL"), _envelope("AAPL")]))
+
+    packet = build_screening_dry_run_plan(path)
+
+    assert packet["summary"]["screening_dry_run_plan_ready"] is False
+    assert packet["summary"]["duplicate_local_runner_envelope_id_count"] == 1
+    assert any("duplicate_local_runner_envelope_id" in item for item in packet["blockers"])
+
+
+def test_accepts_bom_input(tmp_path: Path) -> None:
+    path = _write_packet(tmp_path, _packet([_envelope("AAPL")]), bom=True)
+
+    packet = build_screening_dry_run_plan(path)
+
+    assert packet["summary"]["screening_dry_run_plan_ready"] is True
+    assert packet["screening_dry_run_plan_records"][0]["instrument_symbol"] == "AAPL"
+
+
+def test_operator_summary_and_outputs(tmp_path: Path) -> None:
+    path = _write_packet(tmp_path, _packet([_envelope("AAPL")]))
+    packet = build_screening_dry_run_plan(path)
+
+    summary = render_operator_summary(packet)
+    outputs = write_outputs(packet, tmp_path / "out")
+
+    assert "screening_dry_run_plan_ready: True" in summary
+    assert "does not execute screening" in summary
+    assert Path(outputs["latest"]).exists()
+    assert Path(outputs["operator_summary"]).exists()
+    assert json.loads(Path(outputs["latest"]).read_text(encoding="utf-8"))["summary"]["screening_plan_count"] == 1
+
+
+def test_missing_input_raises() -> None:
+    with pytest.raises(ScreeningDryRunPlanError):
+        build_screening_dry_run_plan(Path("does/not/exist.json"))


### PR DESCRIPTION
## Summary
- add screening dry-run plan materialization for controlled subset local runner envelopes
- consume exactly the 8 controlled non-crypto local runner envelopes
- keep screening execution, validation, subprocess, network, run_research, campaign_launcher, campaigns, paper/shadow/live, broker/risk, queue mutation, candidate promotion, strategy registration, and preset mutation forbidden

## Validation
- python -m pytest tests/unit/test_qre_controlled_subset_screening_dry_run_plan.py -q
- python -m research.qre_controlled_discovery_subset_adapter --write
- python -m research.qre_controlled_subset_candidate_plan --write
- python -m research.qre_controlled_subset_candidate_feasibility --write
- python -m research.qre_controlled_subset_runner_dry_run --write
- python -m research.qre_controlled_subset_local_runner_harness --write
- python -m research.qre_controlled_subset_screening_dry_run_plan --write
- git diff --check
- git diff -- research/research_latest.json research/strategy_matrix.csv