### PR TITLE
feat: add QRE research-development flywheel

### DIFF
--- a/research/qre_autonomous_market_research_loop.py
+++ b/research/qre_autonomous_market_research_loop.py
@@ -1,0 +1,527 @@
+"""Bounded autonomous QRE market-research loop controller.
+
+The controller composes the existing controlled research run into a V1/V2/V3
+foundation:
+
+* V1: market-intake -> analysis -> hypothesis -> preset -> campaign intent ->
+  metric evidence -> result analysis -> learning -> next seed -> next action.
+* V2: code-required next actions create ADE/Codex build-request artifacts.
+* V3: post-merge continuation is represented as a data contract only.
+
+It never executes builds, opens PRs, merges, trades, calls run_research, calls
+campaign_launcher, or mutates protected public research outputs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Final
+
+from research import qre_build_request_writer as build_requests
+from research import qre_controlled_research_run as controlled_run
+from research import qre_next_action_classifier as action_classifier
+
+
+SCHEMA_VERSION: Final[str] = "1.0"
+REPORT_KIND: Final[str] = "qre_autonomous_market_research_loop"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_autonomous_market_research_loop")
+DEFAULT_CONTROLLED_LATEST: Final[Path] = Path("logs/qre_controlled_research_run/latest.json")
+PROTECTED_PUBLIC_OUTPUTS: Final[tuple[Path, ...]] = (
+    Path("research/research_latest.json"),
+    Path("research/strategy_matrix.csv"),
+)
+CONTROLLED_UNIVERSE: Final[tuple[str, ...]] = controlled_run.CONTROLLED_ASSETS
+EXPECTED_PRESET: Final[str] = controlled_run.EXPECTED_PRESET
+EXPECTED_TIMEFRAME: Final[str] = controlled_run.EXPECTED_TIMEFRAME
+
+
+class AutonomousMarketResearchLoopError(RuntimeError):
+    """Raised when the autonomous controller cannot proceed safely."""
+
+
+def _utcnow() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _json_dumps(payload: Any) -> str:
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _file_fingerprint(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {"exists": False, "sha256": None}
+    return {"exists": True, "sha256": _sha256_bytes(path.read_bytes())}
+
+
+def _protected_fingerprints() -> dict[str, dict[str, Any]]:
+    return {path.as_posix(): _file_fingerprint(path) for path in PROTECTED_PUBLIC_OUTPUTS}
+
+
+def _assert_protected_unchanged(before: dict[str, dict[str, Any]]) -> None:
+    if before != _protected_fingerprints():
+        raise AutonomousMarketResearchLoopError("protected public research artifacts changed")
+
+
+def _assert_inside(root: Path, path: Path) -> None:
+    resolved_root = root.resolve()
+    resolved_path = path.resolve()
+    if resolved_path != resolved_root and resolved_root not in resolved_path.parents:
+        raise AutonomousMarketResearchLoopError(f"refusing write outside output dir: {path}")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        parsed = json.loads(path.read_text(encoding="utf-8-sig"))
+    except OSError as exc:
+        raise AutonomousMarketResearchLoopError(f"input artifact unavailable: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise AutonomousMarketResearchLoopError(f"input artifact malformed: {path}") from exc
+    if not isinstance(parsed, dict):
+        raise AutonomousMarketResearchLoopError("input artifact must be a JSON object")
+    return parsed
+
+
+def _load_or_build_controlled_packet(path: Path | None = None) -> dict[str, Any]:
+    source = path or DEFAULT_CONTROLLED_LATEST
+    if source.exists():
+        packet = _read_json(source)
+    else:
+        packet = controlled_run.run_controlled_research(write=False)
+    if packet.get("report_kind") != controlled_run.REPORT_KIND:
+        raise AutonomousMarketResearchLoopError("controlled research packet has unexpected kind")
+    summary = packet.get("summary") if isinstance(packet.get("summary"), dict) else {}
+    forbidden_true = (
+        "run_research_called",
+        "campaign_launcher_called",
+        "validation_executed",
+        "execution_performed",
+        "paper_shadow_live_allowed",
+        "research_latest_mutated",
+        "strategy_matrix_mutated",
+    )
+    for key in forbidden_true:
+        if summary.get(key) is not False:
+            raise AutonomousMarketResearchLoopError(f"controlled packet safety flag not false: {key}")
+    return packet
+
+
+def _cycle_id(run_group_id: str, cycle_index: int) -> str:
+    seed = f"{run_group_id}|{cycle_index}|{','.join(CONTROLLED_UNIVERSE)}"
+    digest = hashlib.sha256(seed.encode("utf-8")).hexdigest()[:16]
+    return f"qre-auto-cycle-{cycle_index:04d}-{digest}"
+
+
+def _latest_inner_run(controlled_packet: dict[str, Any]) -> dict[str, Any]:
+    runs = controlled_packet.get("runs")
+    if not isinstance(runs, list) or not runs:
+        raise AutonomousMarketResearchLoopError("controlled packet has no runs")
+    run = runs[-1]
+    if not isinstance(run, dict):
+        raise AutonomousMarketResearchLoopError("controlled run row malformed")
+    return run
+
+
+def _market_intake(cycle_index: int, previous_seed: dict[str, Any] | None) -> dict[str, Any]:
+    if previous_seed is None:
+        return {
+            "source": "controlled_default",
+            "statement": (
+                "Start from the exact controlled non-crypto universe and daily "
+                "trend-continuation preset; no external market fetch is allowed."
+            ),
+            "universe": list(CONTROLLED_UNIVERSE),
+            "preset": EXPECTED_PRESET,
+            "timeframe": EXPECTED_TIMEFRAME,
+        }
+    return {
+        "source": "previous_learning_seed",
+        "statement": str(previous_seed.get("statement") or ""),
+        "universe": list(previous_seed.get("universe") or CONTROLLED_UNIVERSE),
+        "preset": str(previous_seed.get("preset") or EXPECTED_PRESET),
+        "timeframe": str(previous_seed.get("timeframe") or EXPECTED_TIMEFRAME),
+        "previous_seed_id": previous_seed.get("seed_id"),
+        "cycle_index": cycle_index,
+    }
+
+
+def _validate_market_intake(intake: dict[str, Any]) -> list[str]:
+    blockers: list[str] = []
+    symbols = intake.get("universe")
+    if not isinstance(symbols, list):
+        return ["market_intake_universe_not_list"]
+    if sorted(str(item) for item in symbols) != sorted(CONTROLLED_UNIVERSE):
+        blockers.append("controlled_universe_mismatch")
+    for symbol in symbols:
+        upper = str(symbol).upper()
+        if upper.endswith("-USD") or upper in {"BTC", "ETH", "SOL", "DOGE", "XRP"}:
+            blockers.append(f"crypto_symbol_rejected:{symbol}")
+    if intake.get("preset") != EXPECTED_PRESET:
+        blockers.append("preset_drift")
+    if intake.get("timeframe") != EXPECTED_TIMEFRAME:
+        blockers.append("timeframe_drift")
+    return blockers
+
+
+def _build_cycle(
+    *,
+    controlled_packet: dict[str, Any],
+    cycle_index: int,
+    previous_seed: dict[str, Any] | None,
+    build_request_pending: bool,
+) -> dict[str, Any]:
+    inner = _latest_inner_run(controlled_packet)
+    run_group_id = str(controlled_packet.get("run_group_id") or "controlled-research")
+    cycle_id = _cycle_id(run_group_id, cycle_index)
+    market_intake = _market_intake(cycle_index, previous_seed)
+    intake_blockers = _validate_market_intake(market_intake)
+
+    metric_evidence = inner.get("metric_evidence") if isinstance(inner.get("metric_evidence"), dict) else {}
+    analysis = inner.get("analysis") if isinstance(inner.get("analysis"), dict) else {}
+    learning = inner.get("learning_feedback") if isinstance(inner.get("learning_feedback"), dict) else {}
+    next_action_source = inner.get("next_hypothesis_or_action")
+    if not isinstance(next_action_source, dict):
+        next_action_source = {}
+    next_action = str(
+        next_action_source.get("recommended_action")
+        or (controlled_packet.get("summary") or {}).get("final_recommendation")
+        or "operator_review_required"
+    )
+    classification = action_classifier.classify_next_action(next_action)
+    content_blockers = analysis.get("content_blockers")
+    if not isinstance(content_blockers, list):
+        content_blockers = []
+
+    market_analysis = {
+        "analysis_statement": (
+            "Controlled market intake remains fixed; current blocker is interpreted "
+            "as research infrastructure, not evidence to rotate the universe."
+        ),
+        "detected_constraints": [
+            "exact_controlled_universe",
+            "timeframe_1d",
+            "preset_trend_continuation_daily_v1",
+            "no_external_data_fetch",
+        ],
+        "detected_blockers": intake_blockers + [str(item) for item in content_blockers],
+    }
+    seed_id = f"{cycle_id}__next_market_intake_seed"
+    next_seed = {
+        "seed_id": seed_id,
+        "source_cycle_id": cycle_id,
+        "source_learning_feedback_id": learning.get("learning_feedback_id"),
+        "statement": (
+            "Keep the same market universe and preset. Feed back that the current "
+            "blocker is infrastructure/metric evidence availability, not asset quality."
+        ),
+        "universe": list(CONTROLLED_UNIVERSE),
+        "preset": EXPECTED_PRESET,
+        "timeframe": EXPECTED_TIMEFRAME,
+        "blocker_to_check": content_blockers[0] if content_blockers else None,
+        "next_action": next_action,
+    }
+    waiting_for_build = classification.get("ade_build_allowed") is True and build_request_pending
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "cycle_id": cycle_id,
+        "cycle_index": cycle_index,
+        "created_at_utc": _utcnow(),
+        "source_research_run_id": inner.get("run_id"),
+        "source_research_run_group_id": run_group_id,
+        "flow": [
+            "market_intake",
+            "market_analysis",
+            "hypothesis_generation",
+            "preset_selection",
+            "controlled_campaign_intent",
+            "metric_evidence",
+            "result_analysis",
+            "learning_feedback",
+            "next_market_intake_seed",
+            "next_action",
+        ],
+        "market_intake": market_intake,
+        "market_analysis": market_analysis,
+        "hypothesis_generation": inner.get("hypothesis") or {},
+        "preset_selection": inner.get("preset_selection") or {},
+        "controlled_campaign_intent": inner.get("controlled_campaign_intent") or {},
+        "metric_evidence": metric_evidence,
+        "result_analysis": {
+            "analysis_id": analysis.get("analysis_id"),
+            "analysis_statement": analysis.get("analysis_statement"),
+            "metric_evidence_mode": analysis.get("metric_evidence_mode"),
+            "true_metrics_available": analysis.get("true_metrics_available") is True,
+            "content_blockers": content_blockers,
+            "safety_blockers": analysis.get("safety_blockers") or [],
+        },
+        "learning_feedback": learning,
+        "next_market_intake_seed": next_seed,
+        "next_action": {
+            "recommended_action": next_action,
+            "classification": classification,
+            "build_request_required": classification.get("ade_build_allowed") is True,
+            "build_request_pending": waiting_for_build,
+            "execution_allowed": False,
+        },
+        "safety": {
+            "paper_shadow_live_allowed": False,
+            "broker_risk_allowed": False,
+            "execution_allowed": False,
+            "campaign_launcher_called": False,
+            "run_research_called": False,
+            "validation_executed": False,
+            "protected_outputs_mutated": False,
+            "build_executed_by_this_controller": False,
+            "candidate_promotion_allowed": False,
+            "strategy_registry_mutated": False,
+            "preset_registry_mutated": False,
+            "campaign_mutation_allowed": False,
+            "external_data_or_network_fetch": False,
+        },
+    }
+
+
+def build_autonomous_loop_packet(
+    *,
+    controlled_packet: dict[str, Any] | None = None,
+    max_cycles: int = 3,
+    until_build_request: bool = False,
+    existing_build_request_pending: bool = False,
+) -> dict[str, Any]:
+    if max_cycles < 1 or max_cycles > 1000:
+        raise AutonomousMarketResearchLoopError("--max-cycles must be between 1 and 1000")
+    source_packet = controlled_packet or _load_or_build_controlled_packet()
+    cycles: list[dict[str, Any]] = []
+    previous_seed: dict[str, Any] | None = None
+    build_request_needed = False
+    for index in range(1, max_cycles + 1):
+        cycle = _build_cycle(
+            controlled_packet=source_packet,
+            cycle_index=index,
+            previous_seed=previous_seed,
+            build_request_pending=existing_build_request_pending or build_request_needed,
+        )
+        cycles.append(cycle)
+        previous_seed = cycle["next_market_intake_seed"]
+        if cycle["next_action"]["build_request_required"]:
+            build_request_needed = True
+            if until_build_request:
+                break
+
+    action_classes = [
+        str(cycle["next_action"]["classification"]["action_class"]) for cycle in cycles
+    ]
+    metric_modes = [str(cycle["metric_evidence"].get("metric_mode") or "") for cycle in cycles]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "created_at_utc": _utcnow(),
+        "source_controlled_report_kind": source_packet.get("report_kind"),
+        "source_controlled_run_group_id": source_packet.get("run_group_id"),
+        "summary": {
+            "autonomous_loop_ready": True,
+            "cycle_count": len(cycles),
+            "market_intake_cycle_count": len(cycles),
+            "controlled_research_inner_loop_count": int(
+                (source_packet.get("summary") or {}).get("loop_count") or 0
+            )
+            * len(cycles),
+            "build_request_required_count": sum(
+                1 for cycle in cycles if cycle["next_action"]["build_request_required"]
+            ),
+            "unsafe_actions_blocked": action_classes.count("blocked"),
+            "unknown_actions": action_classes.count("unknown"),
+            "latest_metric_mode": metric_modes[-1] if metric_modes else "",
+            "latest_recommendation": cycles[-1]["next_action"]["recommended_action"],
+            "paper_shadow_live_allowed": False,
+            "broker_risk_allowed": False,
+            "execution_allowed": False,
+            "campaign_launcher_called": False,
+            "run_research_called": False,
+            "validation_executed": False,
+            "protected_outputs_mutated": False,
+            "build_executed_by_this_controller": False,
+            "auto_merge_allowed": False,
+            "auto_trade_allowed": False,
+        },
+        "authority_boundaries": {
+            "writes_only_qre_autonomous_market_research_loop_logs": True,
+            "does_not_call_run_research": True,
+            "does_not_call_campaign_launcher": True,
+            "does_not_call_subprocess": True,
+            "does_not_call_network": True,
+            "does_not_execute_builds": True,
+            "does_not_open_or_merge_prs": True,
+            "does_not_activate_paper_shadow_live": True,
+            "does_not_call_broker_or_risk": True,
+            "does_not_mutate_protected_public_outputs": True,
+        },
+        "cycles": cycles,
+    }
+
+
+def render_operator_summary(packet: dict[str, Any]) -> str:
+    summary = packet["summary"]
+    latest = packet["cycles"][-1]
+    blockers = latest["result_analysis"].get("content_blockers") or []
+    build_paths = packet.get("_build_request_paths") or {}
+    lines = [
+        "# QRE Autonomous Market-Research Loop",
+        "",
+        f"- Autonomous cycles: {summary['cycle_count']}.",
+        f"- Market-intake cycles: {summary['market_intake_cycle_count']}.",
+        f"- Controlled research inner loops: {summary['controlled_research_inner_loop_count']}.",
+        "- Flow preserved: market_intake -> market_analysis -> hypothesis_generation -> preset_selection -> controlled_campaign_intent -> metric_evidence -> result_analysis -> learning_feedback -> next_market_intake_seed -> next_action.",
+        f"- Latest universe: {', '.join(latest['market_intake']['universe'])}.",
+        f"- Latest preset: {latest['preset_selection'].get('preset_id')}.",
+        f"- Latest metric mode: {latest['metric_evidence'].get('metric_mode')}.",
+        f"- Latest blocker: {blockers[0] if blockers else 'none'}.",
+        f"- Latest recommendation: {summary['latest_recommendation']}.",
+        f"- Build request: {build_paths.get('request_id', 'not_created')}.",
+        "- No paper/shadow/live.",
+        "- No broker/risk/execution authority.",
+        "- No protected artifact mutation.",
+        "- No Codex/ADE build execution by this controller.",
+        "",
+        "## Next System Action",
+        "- If a build request exists, ADE/Codex may consume it in a later PR under normal review gates.",
+        "- After merge/update, rerun `python -m research.qre_autonomous_market_research_loop --write --max-cycles 3`.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def write_outputs(packet: dict[str, Any], *, output_dir: Path = DEFAULT_OUTPUT_DIR) -> dict[str, Any]:
+    latest_path = output_dir / "latest.json"
+    summary_path = output_dir / "operator_summary.md"
+    ledger_path = output_dir / "ledger.jsonl"
+    runs_dir = output_dir / "runs"
+    for path in (latest_path, summary_path, ledger_path, runs_dir):
+        _assert_inside(output_dir, path)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    runs_dir.mkdir(parents=True, exist_ok=True)
+
+    build_request_paths: dict[str, Any] = {}
+    for cycle in packet["cycles"]:
+        classification = cycle["next_action"]["classification"]
+        if classification.get("ade_build_allowed") is True and not build_request_paths:
+            build_packet = build_requests.build_request_packet(
+                source_cycle=cycle,
+                classification=classification,
+            )
+            build_request_paths = build_requests.write_build_request(
+                build_packet,
+                output_dir=output_dir,
+                overwrite=False,
+            )
+
+    if build_request_paths:
+        packet["_build_request_paths"] = build_request_paths
+    latest_path.write_text(_json_dumps(packet), encoding="utf-8", newline="\n")
+    summary_path.write_text(render_operator_summary(packet), encoding="utf-8", newline="\n")
+
+    ledger_lines: list[str] = []
+    for cycle in packet["cycles"]:
+        run_path = runs_dir / f"{cycle['cycle_id']}.json"
+        _assert_inside(output_dir, run_path)
+        run_path.write_text(_json_dumps(cycle), encoding="utf-8", newline="\n")
+        ledger_lines.append(
+            json.dumps(
+                {
+                    "schema_version": SCHEMA_VERSION,
+                    "report_kind": REPORT_KIND,
+                    "cycle_id": cycle["cycle_id"],
+                    "cycle_index": cycle["cycle_index"],
+                    "metric_mode": cycle["metric_evidence"].get("metric_mode"),
+                    "next_action": cycle["next_action"]["recommended_action"],
+                    "action_class": cycle["next_action"]["classification"]["action_class"],
+                },
+                sort_keys=True,
+            )
+        )
+    with ledger_path.open("a", encoding="utf-8", newline="\n") as handle:
+        for line in ledger_lines:
+            handle.write(line + "\n")
+    return {
+        "latest": latest_path.as_posix(),
+        "operator_summary": summary_path.as_posix(),
+        "ledger": ledger_path.as_posix(),
+        "runs_dir": runs_dir.as_posix(),
+        "build_request": build_request_paths,
+    }
+
+
+def run_autonomous_loop(
+    *,
+    controlled_packet: dict[str, Any] | None = None,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    max_cycles: int = 3,
+    until_build_request: bool = False,
+    write: bool = False,
+    report_only: bool = False,
+) -> dict[str, Any]:
+    before = _protected_fingerprints()
+    if report_only:
+        latest = output_dir / "latest.json"
+        packet = _read_json(latest)
+        if write:
+            summary_path = output_dir / "operator_summary.md"
+            _assert_inside(output_dir, summary_path)
+            summary_path.write_text(render_operator_summary(packet), encoding="utf-8", newline="\n")
+        _assert_protected_unchanged(before)
+        return packet
+
+    packet = build_autonomous_loop_packet(
+        controlled_packet=controlled_packet,
+        max_cycles=max_cycles,
+        until_build_request=until_build_request,
+        existing_build_request_pending=(output_dir / "latest_build_request.json").exists(),
+    )
+    if write:
+        packet["_artifact_paths"] = write_outputs(packet, output_dir=output_dir)
+    _assert_protected_unchanged(before)
+    return packet
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run bounded QRE autonomous market-research loop.")
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument("--max-cycles", type=int, default=3)
+    parser.add_argument("--until-build-request", action="store_true")
+    parser.add_argument("--report-only", action="store_true")
+    parser.add_argument("--output-dir", default=DEFAULT_OUTPUT_DIR.as_posix())
+    args = parser.parse_args(argv)
+    packet = run_autonomous_loop(
+        output_dir=Path(args.output_dir),
+        max_cycles=args.max_cycles,
+        until_build_request=args.until_build_request,
+        write=args.write,
+        report_only=args.report_only,
+    )
+    print(json.dumps(packet["summary"], indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "AutonomousMarketResearchLoopError",
+    "CONTROLLED_UNIVERSE",
+    "DEFAULT_OUTPUT_DIR",
+    "REPORT_KIND",
+    "SCHEMA_VERSION",
+    "build_autonomous_loop_packet",
+    "render_operator_summary",
+    "run_autonomous_loop",
+    "write_outputs",
+]

--- a/research/qre_build_request_consumer.py
+++ b/research/qre_build_request_consumer.py
@@ -1,0 +1,277 @@
+"""QRE build-request consumer.
+
+The consumer reads QRE build-request artifacts and optionally invokes an
+explicit operator-configured build backend. Default behavior is fail-closed:
+no backend, no branch, no PR, no code execution.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+from collections.abc import Callable
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Final
+
+
+SCHEMA_VERSION: Final[str] = "1.0"
+REPORT_KIND: Final[str] = "qre_build_request_consumer"
+DEFAULT_BUILD_REQUEST_PATH: Final[Path] = Path(
+    "logs/qre_autonomous_market_research_loop/latest_build_request.json"
+)
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_build_request_consumer")
+SUPPORTED_BACKENDS: Final[tuple[str, ...]] = (
+    "codex_cli",
+    "claude_cli",
+    "gh_workflow_dispatch",
+    "repo_native_ade",
+    "dry_run_only",
+)
+
+
+CommandRunner = Callable[[list[str], dict[str, str]], tuple[int, str, str]]
+
+
+class BuildRequestConsumerError(RuntimeError):
+    """Raised when build-request consumption cannot be evaluated safely."""
+
+
+def _utcnow() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _json_dumps(payload: Any) -> str:
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        parsed = json.loads(path.read_text(encoding="utf-8-sig"))
+    except OSError as exc:
+        raise BuildRequestConsumerError(f"build request unavailable: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise BuildRequestConsumerError(f"build request malformed: {path}") from exc
+    if not isinstance(parsed, dict):
+        raise BuildRequestConsumerError("build request must be a JSON object")
+    return parsed
+
+
+def _assert_inside(root: Path, path: Path) -> None:
+    resolved_root = root.resolve()
+    resolved_path = path.resolve()
+    if resolved_path != resolved_root and resolved_root not in resolved_path.parents:
+        raise BuildRequestConsumerError(f"refusing write outside output dir: {path}")
+
+
+def _default_command_runner(cmd: list[str], env: dict[str, str]) -> tuple[int, str, str]:
+    try:
+        result = subprocess.run(
+            cmd,
+            env={**os.environ, **env},
+            capture_output=True,
+            text=True,
+            timeout=3600,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return (-1, "", repr(exc))
+    return (result.returncode, result.stdout or "", result.stderr or "")
+
+
+def _backend_config(env: dict[str, str] | None = None) -> dict[str, Any]:
+    source = env if env is not None else os.environ
+    backend = str(source.get("QRE_BUILD_BACKEND") or "dry_run_only").strip()
+    command = str(source.get("QRE_BUILD_COMMAND") or "").strip()
+    auto_pr = str(source.get("QRE_AUTO_PR") or "").lower() == "true"
+    return {
+        "backend": backend,
+        "command": command,
+        "auto_pr": auto_pr,
+        "configured": bool(command) and backend in SUPPORTED_BACKENDS and backend != "dry_run_only",
+    }
+
+
+def _parse_backend_stdout(stdout: str) -> dict[str, Any]:
+    text = stdout.strip()
+    if not text:
+        return {}
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        return {"raw_stdout": text[:2000]}
+    return parsed if isinstance(parsed, dict) else {"raw_stdout": text[:2000]}
+
+
+def build_consumption_snapshot(
+    *,
+    build_request_path: Path = DEFAULT_BUILD_REQUEST_PATH,
+    env: dict[str, str] | None = None,
+    command_runner: CommandRunner | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    generated = generated_at_utc or _utcnow()
+    request = _read_json(build_request_path)
+    config = _backend_config(env)
+    base = {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": generated,
+        "build_request_path": build_request_path.as_posix(),
+        "request_id": request.get("request_id"),
+        "next_action": request.get("next_action"),
+        "backend": config["backend"],
+        "build_request_consumed": False,
+        "build_started": False,
+        "branch_created": False,
+        "code_changed": False,
+        "tests_run": False,
+        "pr_created": False,
+        "execution_allowed": False,
+        "paper_shadow_live_allowed": False,
+        "broker_risk_allowed": False,
+        "campaign_launcher_called": False,
+        "run_research_called": False,
+        "protected_outputs_mutated": False,
+        "build_backend_available": False,
+        "build_executed_by_this_controller": False,
+        "auto_pr_requested": config["auto_pr"],
+        "pr_metadata": None,
+        "missing_capability": None,
+        "blocked_reason": None,
+    }
+    if request.get("safe_for_ade_build") is not True or request.get("execution_allowed") is True:
+        return {
+            **base,
+            "blocked_reason": "build_request_not_safe_for_ade_build",
+            "missing_capability": "safe_build_request",
+            "final_recommendation": "build_request_blocked",
+        }
+    if not config["configured"]:
+        return {
+            **base,
+            "missing_capability": "safe_build_backend",
+            "blocked_reason": "no_safe_build_backend_configured",
+            "final_recommendation": "build_request_ready_but_not_consumed",
+        }
+
+    runner = command_runner or _default_command_runner
+    command = str(config["command"]).replace("%QRE_BUILD_REQUEST_PATH%", build_request_path.as_posix())
+    cmd = shlex.split(command)
+    if not cmd:
+        return {
+            **base,
+            "missing_capability": "safe_build_backend",
+            "blocked_reason": "empty_build_command",
+            "final_recommendation": "build_request_ready_but_not_consumed",
+        }
+    rc, stdout, stderr = runner(
+        cmd,
+        {
+            "QRE_BUILD_REQUEST_PATH": build_request_path.as_posix(),
+            "QRE_BUILD_REQUEST_ID": str(request.get("request_id") or ""),
+        },
+    )
+    backend_result = _parse_backend_stdout(stdout)
+    pr_metadata = backend_result.get("pr_metadata")
+    if not isinstance(pr_metadata, dict):
+        pr_metadata = None
+    success = rc == 0 and backend_result.get("build_request_consumed") is True
+    return {
+        **base,
+        "build_backend_available": True,
+        "build_backend": config["backend"],
+        "build_command_configured": True,
+        "build_executed_by_this_controller": True,
+        "build_request_consumed": success,
+        "build_started": success or bool(backend_result.get("build_started")),
+        "branch_created": bool(backend_result.get("branch_created")),
+        "code_changed": bool(backend_result.get("code_changed")),
+        "tests_run": bool(backend_result.get("tests_run")),
+        "pr_created": bool(backend_result.get("pr_created")),
+        "pr_metadata": pr_metadata,
+        "backend_returncode": rc,
+        "backend_stderr": stderr[:2000],
+        "blocked_reason": None if success else "build_backend_failed",
+        "final_recommendation": (
+            "build_request_consumed_pr_ready" if success else "build_backend_failed"
+        ),
+    }
+
+
+def render_operator_summary(snapshot: dict[str, Any]) -> str:
+    return "\n".join(
+        [
+            "# QRE Build Request Consumer",
+            "",
+            f"- Request ID: {snapshot.get('request_id')}",
+            f"- Backend: {snapshot.get('backend')}",
+            f"- Build backend available: {snapshot.get('build_backend_available')}",
+            f"- Build request consumed: {snapshot.get('build_request_consumed')}",
+            f"- Build started: {snapshot.get('build_started')}",
+            f"- Branch created: {snapshot.get('branch_created')}",
+            f"- Code changed: {snapshot.get('code_changed')}",
+            f"- Tests run: {snapshot.get('tests_run')}",
+            f"- PR created: {snapshot.get('pr_created')}",
+            f"- Missing capability: {snapshot.get('missing_capability')}",
+            f"- Blocked reason: {snapshot.get('blocked_reason')}",
+            "- Trading: disabled.",
+            "- No broker/risk/execution authority.",
+            "",
+        ]
+    )
+
+
+def write_outputs(snapshot: dict[str, Any], *, output_dir: Path = DEFAULT_OUTPUT_DIR) -> dict[str, str]:
+    run_id = str(snapshot.get("request_id") or "no-request") + "__" + str(snapshot["generated_at_utc"]).replace(":", "").replace("-", "")
+    latest = output_dir / "latest.json"
+    summary = output_dir / "operator_summary.md"
+    run_path = output_dir / "runs" / f"{run_id}.json"
+    for path in (latest, summary, run_path):
+        _assert_inside(output_dir, path)
+    run_path.parent.mkdir(parents=True, exist_ok=True)
+    latest.write_text(_json_dumps(snapshot), encoding="utf-8", newline="\n")
+    summary.write_text(render_operator_summary(snapshot), encoding="utf-8", newline="\n")
+    run_path.write_text(_json_dumps(snapshot), encoding="utf-8", newline="\n")
+    return {"latest": latest.as_posix(), "operator_summary": summary.as_posix(), "run": run_path.as_posix()}
+
+
+def run_consumer(
+    *,
+    build_request_path: Path = DEFAULT_BUILD_REQUEST_PATH,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    write: bool = False,
+    env: dict[str, str] | None = None,
+    command_runner: CommandRunner | None = None,
+) -> dict[str, Any]:
+    snapshot = build_consumption_snapshot(
+        build_request_path=build_request_path,
+        env=env,
+        command_runner=command_runner,
+    )
+    if write:
+        snapshot["_artifact_paths"] = write_outputs(snapshot, output_dir=output_dir)
+    return snapshot
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Consume QRE build request with an explicit backend.")
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument("--build-request", default=DEFAULT_BUILD_REQUEST_PATH.as_posix())
+    parser.add_argument("--output-dir", default=DEFAULT_OUTPUT_DIR.as_posix())
+    args = parser.parse_args(argv)
+    snapshot = run_consumer(
+        build_request_path=Path(args.build_request),
+        output_dir=Path(args.output_dir),
+        write=args.write,
+    )
+    print(json.dumps(snapshot, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/research/qre_build_request_writer.py
+++ b/research/qre_build_request_writer.py
@@ -1,0 +1,177 @@
+"""QRE build-request artifact writer.
+
+Build requests are machine-readable and human-readable handoff artifacts for
+ADE/Codex. They do not execute code, create branches, open PRs, merge PRs, or
+mutate development queues.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Final
+
+
+SCHEMA_VERSION: Final[str] = "1.0"
+REPORT_KIND: Final[str] = "qre_build_request"
+DEFAULT_POST_MERGE_RESEARCH_COMMAND: Final[str] = (
+    "python -m research.qre_autonomous_market_research_loop --write --max-cycles 3"
+)
+
+
+class BuildRequestWriterError(RuntimeError):
+    """Raised when build-request writing would violate its output boundary."""
+
+
+def _utcnow() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _json_dumps(payload: Any) -> str:
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def _request_id(*, next_action: str, blocker: str, source_run_group_id: str) -> str:
+    seed = "|".join(["qre_build_request", next_action, blocker, source_run_group_id])
+    digest = hashlib.sha256(seed.encode("utf-8")).hexdigest()[:16]
+    return f"build-request-{digest}"
+
+
+def _assert_inside(root: Path, path: Path) -> None:
+    resolved_root = root.resolve()
+    resolved_path = path.resolve()
+    if resolved_path != resolved_root and resolved_root not in resolved_path.parents:
+        raise BuildRequestWriterError(f"refusing write outside output dir: {path}")
+
+
+def build_request_packet(
+    *,
+    source_cycle: dict[str, Any],
+    classification: dict[str, Any],
+    created_at_utc: str | None = None,
+) -> dict[str, Any]:
+    next_action = str(classification.get("next_action") or "")
+    result_analysis = source_cycle.get("result_analysis")
+    if not isinstance(result_analysis, dict):
+        result_analysis = {}
+    blockers = result_analysis.get("content_blockers")
+    blocker = str(blockers[0]) if isinstance(blockers, list) and blockers else ""
+    source_market_seed = source_cycle.get("next_market_intake_seed")
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "request_id": _request_id(
+            next_action=next_action,
+            blocker=blocker,
+            source_run_group_id=str(source_cycle.get("source_research_run_group_id") or ""),
+        ),
+        "created_at_utc": created_at_utc or _utcnow(),
+        "source_cycle_id": source_cycle.get("cycle_id"),
+        "source_research_run_id": source_cycle.get("source_research_run_id"),
+        "source_research_run_group_id": source_cycle.get("source_research_run_group_id"),
+        "source_market_intake_seed": source_market_seed,
+        "next_action": next_action,
+        "action_class": classification.get("action_class"),
+        "safety_class": classification.get("safety_class"),
+        "safe_for_ade_build": classification.get("ade_build_allowed") is True,
+        "execution_allowed": False,
+        "build_executed_by_this_controller": False,
+        "recommended_branch": classification.get("recommended_branch"),
+        "recommended_pr_title": classification.get("recommended_pr_title"),
+        "implementation_scope": classification.get("implementation_scope") or [],
+        "forbidden_actions": classification.get("forbidden_actions") or [],
+        "acceptance_commands": classification.get("acceptance_commands") or [],
+        "post_merge_research_command": DEFAULT_POST_MERGE_RESEARCH_COMMAND,
+        "future_build_result_contract": {
+            "artifact_dir": "logs/qre_autonomous_market_research_loop/build_results",
+            "required_statuses": ["pending", "merged", "blocked", "superseded"],
+            "post_merge_research_required": True,
+            "blocker_to_check": blocker,
+        },
+    }
+
+
+def render_build_request_markdown(packet: dict[str, Any]) -> str:
+    scope = "\n".join(f"- {item}" for item in packet.get("implementation_scope") or [])
+    forbidden = "\n".join(f"- {item}" for item in packet.get("forbidden_actions") or [])
+    commands = "\n".join(f"- `{item}`" for item in packet.get("acceptance_commands") or [])
+    return "\n".join(
+        [
+            "# QRE Build Request",
+            "",
+            f"- Request ID: `{packet['request_id']}`",
+            f"- Next action: `{packet['next_action']}`",
+            f"- Action class: `{packet['action_class']}`",
+            f"- Safe for ADE build: `{packet['safe_for_ade_build']}`",
+            "- Execution allowed: `False`",
+            "- Build executed by this controller: `False`",
+            f"- Recommended branch: `{packet['recommended_branch']}`",
+            f"- Recommended PR title: `{packet['recommended_pr_title']}`",
+            "",
+            "## Implementation Scope",
+            scope or "- Operator review required before scope is defined.",
+            "",
+            "## Forbidden Actions",
+            forbidden,
+            "",
+            "## Acceptance Commands",
+            commands,
+            "",
+            "## Post-Merge Research",
+            f"- `{packet['post_merge_research_command']}`",
+            "",
+            "## Stop Condition",
+            "- Stop if protected public research artifacts change, any paper/shadow/live authority appears, or the build needs broker/risk/execution access.",
+            "",
+        ]
+    )
+
+
+def write_build_request(
+    packet: dict[str, Any],
+    *,
+    output_dir: Path,
+    overwrite: bool = True,
+) -> dict[str, str | bool]:
+    build_dir = output_dir / "build_requests"
+    request_id = str(packet["request_id"])
+    json_path = build_dir / f"{request_id}.json"
+    md_path = build_dir / f"{request_id}.md"
+    latest_path = output_dir / "latest_build_request.json"
+    for path in (json_path, md_path, latest_path):
+        _assert_inside(output_dir, path)
+
+    existed = json_path.exists()
+    if existed and not overwrite:
+        return {
+            "request_id": request_id,
+            "json": json_path.as_posix(),
+            "markdown": md_path.as_posix(),
+            "latest": latest_path.as_posix(),
+            "created": False,
+        }
+
+    build_dir.mkdir(parents=True, exist_ok=True)
+    json_path.write_text(_json_dumps(packet), encoding="utf-8", newline="\n")
+    md_path.write_text(render_build_request_markdown(packet), encoding="utf-8", newline="\n")
+    latest_path.write_text(_json_dumps(packet), encoding="utf-8", newline="\n")
+    return {
+        "request_id": request_id,
+        "json": json_path.as_posix(),
+        "markdown": md_path.as_posix(),
+        "latest": latest_path.as_posix(),
+        "created": not existed,
+    }
+
+
+__all__ = [
+    "BuildRequestWriterError",
+    "DEFAULT_POST_MERGE_RESEARCH_COMMAND",
+    "REPORT_KIND",
+    "SCHEMA_VERSION",
+    "build_request_packet",
+    "render_build_request_markdown",
+    "write_build_request",
+]

--- a/research/qre_daily_status_digest.py
+++ b/research/qre_daily_status_digest.py
@@ -1,0 +1,322 @@
+"""Daily QRE autonomous market-research status digest."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Final
+
+
+SCHEMA_VERSION: Final[str] = "1.0"
+REPORT_KIND: Final[str] = "qre_daily_status"
+DEFAULT_LOOP_LATEST: Final[Path] = Path("logs/qre_autonomous_market_research_loop/latest.json")
+DEFAULT_FLYWHEEL_LATEST: Final[Path] = Path("logs/qre_research_development_flywheel/latest.json")
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_daily_status")
+
+
+class DailyStatusDigestError(RuntimeError):
+    """Raised when daily status cannot be built."""
+
+
+def _utcnow() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _json_dumps(payload: Any) -> str:
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        parsed = json.loads(path.read_text(encoding="utf-8-sig"))
+    except OSError as exc:
+        raise DailyStatusDigestError(f"loop artifact unavailable: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise DailyStatusDigestError(f"loop artifact malformed: {path}") from exc
+    if not isinstance(parsed, dict):
+        raise DailyStatusDigestError("loop artifact must be a JSON object")
+    return parsed
+
+
+def _assert_inside(root: Path, path: Path) -> None:
+    resolved_root = root.resolve()
+    resolved_path = path.resolve()
+    if resolved_path != resolved_root and resolved_root not in resolved_path.parents:
+        raise DailyStatusDigestError(f"refusing write outside output dir: {path}")
+
+
+def _discover_build_requests(loop_output_dir: Path) -> list[dict[str, Any]]:
+    build_dir = loop_output_dir / "build_requests"
+    if not build_dir.exists():
+        return []
+    requests: list[dict[str, Any]] = []
+    for path in sorted(build_dir.glob("build-request-*.json")):
+        try:
+            parsed = json.loads(path.read_text(encoding="utf-8-sig"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(parsed, dict):
+            requests.append(parsed)
+    return requests
+
+
+def _discover_build_results(loop_output_dir: Path) -> list[dict[str, Any]]:
+    results_dir = loop_output_dir / "build_results"
+    if not results_dir.exists():
+        return []
+    results: list[dict[str, Any]] = []
+    for path in sorted(results_dir.glob("*.json")):
+        try:
+            parsed = json.loads(path.read_text(encoding="utf-8-sig"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(parsed, dict):
+            results.append(parsed)
+    return results
+
+
+def _read_optional_json(path: Path) -> dict[str, Any] | None:
+    try:
+        parsed = json.loads(path.read_text(encoding="utf-8-sig"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def build_daily_status_packet(
+    *,
+    loop_latest_path: Path = DEFAULT_LOOP_LATEST,
+    flywheel_latest_path: Path = DEFAULT_FLYWHEEL_LATEST,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    loop_packet = _read_json(loop_latest_path)
+    cycles = loop_packet.get("cycles")
+    if not isinstance(cycles, list) or not cycles:
+        raise DailyStatusDigestError("loop artifact has no cycles")
+    latest_cycle = cycles[-1]
+    if not isinstance(latest_cycle, dict):
+        raise DailyStatusDigestError("latest cycle malformed")
+
+    loop_output_dir = loop_latest_path.parent
+    build_requests = _discover_build_requests(loop_output_dir)
+    build_results = _discover_build_results(loop_output_dir)
+    flywheel = _read_optional_json(flywheel_latest_path)
+    flywheel_summary = flywheel.get("summary") if isinstance(flywheel, dict) and isinstance(flywheel.get("summary"), dict) else {}
+    completed_ids = {
+        str(item.get("request_id"))
+        for item in build_results
+        if item.get("status") in {"merged", "completed"}
+    }
+    pending = [
+        item for item in build_requests if str(item.get("request_id")) not in completed_ids
+    ]
+    result_analysis = latest_cycle.get("result_analysis") if isinstance(latest_cycle.get("result_analysis"), dict) else {}
+    blockers = result_analysis.get("content_blockers")
+    if not isinstance(blockers, list):
+        blockers = []
+    summary = loop_packet.get("summary") if isinstance(loop_packet.get("summary"), dict) else {}
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": generated_at_utc or _utcnow(),
+        "period_covered": "latest_autonomous_loop_artifact",
+        "source_loop_latest": loop_latest_path.as_posix(),
+        "summary": {
+            "autonomous_cycles": len(cycles),
+            "controlled_research_inner_loops": summary.get("controlled_research_inner_loop_count"),
+            "market_intake_cycles": summary.get("market_intake_cycle_count"),
+            "build_requests_created": len(build_requests),
+            "build_requests_consumed": flywheel_summary.get("build_requests_consumed", 0),
+            "build_requests_pending": len(pending),
+            "build_requests_completed_or_merged": len(completed_ids),
+            "prs_opened": flywheel_summary.get("prs_opened", 0),
+            "prs_green": flywheel_summary.get("prs_green", 0),
+            "prs_merged": flywheel_summary.get("prs_merged", 0),
+            "runtime_updates_completed": flywheel_summary.get("runtime_updates_completed", 0),
+            "research_continuations_started": flywheel_summary.get("research_continuations_started", 0),
+            "manual_governance_blockers": flywheel_summary.get("manual_governance_blockers", []),
+            "unsafe_actions_blocked": summary.get("unsafe_actions_blocked", 0),
+            "trading_status": "disabled",
+            "protected_artifact_mutation": "none"
+            if summary.get("protected_outputs_mutated") is False
+            else "unknown_or_detected",
+            "latest_universe": latest_cycle.get("market_intake", {}).get("universe"),
+            "latest_hypothesis": latest_cycle.get("hypothesis_generation", {}).get("statement"),
+            "latest_preset": latest_cycle.get("preset_selection", {}).get("preset_id"),
+            "latest_metric_mode": latest_cycle.get("metric_evidence", {}).get("metric_mode"),
+            "latest_blocker": blockers[0] if blockers else "none",
+            "latest_recommendation": latest_cycle.get("next_action", {}).get("recommended_action"),
+        },
+        "build_requests": build_requests,
+        "build_results": build_results,
+        "flywheel": flywheel,
+        "latest_cycle": {
+            "cycle_id": latest_cycle.get("cycle_id"),
+            "learning_feedback": latest_cycle.get("learning_feedback"),
+            "next_market_intake_seed": latest_cycle.get("next_market_intake_seed"),
+            "next_action": latest_cycle.get("next_action"),
+        },
+        "next_system_action": (
+            "Await build result for pending ADE/Codex request, then rerun market-intake "
+            "-> analysis -> controlled research loop."
+            if pending
+            else "Continue bounded autonomous market-research cycles."
+        ),
+        "safety": {
+            "paper_shadow_live_allowed": False,
+            "broker_risk_allowed": False,
+            "execution_allowed": False,
+            "campaign_launcher_called": False,
+            "run_research_called": False,
+            "validation_executed": False,
+            "protected_outputs_mutated": False,
+        },
+    }
+
+
+def render_daily_status(packet: dict[str, Any]) -> str:
+    summary = packet["summary"]
+    build_lines = [
+        f"- {item.get('request_id')}: {item.get('next_action')}, safe_for_ade_build={item.get('safe_for_ade_build')}, pending"
+        for item in packet.get("build_requests", [])
+    ]
+    if not build_lines:
+        build_lines = ["- No build requests currently present."]
+    return "\n".join(
+        [
+            "# QRE Daily Status",
+            "",
+            f"Period covered: {packet['period_covered']}",
+            f"Autonomous cycles: {summary['autonomous_cycles']}",
+            f"Controlled research inner loops: {summary['controlled_research_inner_loops']}",
+            f"Market-intake cycles: {summary['market_intake_cycles']}",
+            f"Build requests created: {summary['build_requests_created']}",
+            f"Build requests consumed: {summary['build_requests_consumed']}",
+            f"Build requests pending: {summary['build_requests_pending']}",
+            f"Build requests completed/merged if known: {summary['build_requests_completed_or_merged']}",
+            f"PRs opened: {summary['prs_opened']}",
+            f"PRs green: {summary['prs_green']}",
+            f"PRs merged: {summary['prs_merged']}",
+            f"Runtime updates completed: {summary['runtime_updates_completed']}",
+            f"Research continuations started: {summary['research_continuations_started']}",
+            f"Unsafe actions blocked: {summary['unsafe_actions_blocked']}",
+            f"Manual governance blockers: {', '.join(summary['manual_governance_blockers']) if summary['manual_governance_blockers'] else 'none'}",
+            f"Trading status: {summary['trading_status']}",
+            f"Protected artifact mutation: {summary['protected_artifact_mutation']}",
+            f"Latest universe: {', '.join(summary['latest_universe'] or [])}",
+            f"Latest hypothesis: {summary['latest_hypothesis']}",
+            f"Latest preset: {summary['latest_preset']}",
+            f"Latest metric mode: {summary['latest_metric_mode']}",
+            f"Latest blocker: {summary['latest_blocker']}",
+            f"Latest recommendation: {summary['latest_recommendation']}",
+            "",
+            "Research intelligence progress:",
+            "- Learning is feeding back into the next market-intake seed.",
+            "- The system does not rotate assets when the blocker is infrastructure rather than asset quality.",
+            "",
+            "ADE/build progress:",
+            *build_lines,
+            "",
+            "Next system action:",
+            f"- {packet['next_system_action']}",
+            "",
+        ]
+    )
+
+
+def render_scheduler_setup() -> str:
+    return "\n".join(
+        [
+            "# QRE Scheduler Setup Examples",
+            "",
+            "No scheduler is installed by this module. Use these commands from an operator-controlled scheduler.",
+            "",
+            "## VPS",
+            "```bash",
+            "cd /root/trading-agent",
+            "python3 -m research.qre_autonomous_market_research_loop --write --max-cycles 40",
+            "python3 -m research.qre_daily_status_digest --write",
+            "```",
+            "",
+            "## Local PowerShell",
+            "```powershell",
+            "cd C:\\Users\\joery.van.rooij\\trading-agent",
+            "python -m research.qre_autonomous_market_research_loop --write --max-cycles 40",
+            "python -m research.qre_daily_status_digest --write",
+            "```",
+            "",
+        ]
+    )
+
+
+def write_outputs(packet: dict[str, Any], *, output_dir: Path = DEFAULT_OUTPUT_DIR) -> dict[str, str]:
+    latest_path = output_dir / "latest.json"
+    daily_path = output_dir / "daily_status.md"
+    summary_path = output_dir / "operator_summary.md"
+    scheduler_path = output_dir / "scheduler_setup.md"
+    for path in (latest_path, daily_path, summary_path, scheduler_path):
+        _assert_inside(output_dir, path)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    latest_path.write_text(_json_dumps(packet), encoding="utf-8", newline="\n")
+    rendered = render_daily_status(packet)
+    daily_path.write_text(rendered, encoding="utf-8", newline="\n")
+    summary_path.write_text(rendered, encoding="utf-8", newline="\n")
+    scheduler_path.write_text(render_scheduler_setup(), encoding="utf-8", newline="\n")
+    return {
+        "latest": latest_path.as_posix(),
+        "daily_status": daily_path.as_posix(),
+        "operator_summary": summary_path.as_posix(),
+        "scheduler_setup": scheduler_path.as_posix(),
+    }
+
+
+def run_daily_status_digest(
+    *,
+    loop_latest_path: Path = DEFAULT_LOOP_LATEST,
+    flywheel_latest_path: Path = DEFAULT_FLYWHEEL_LATEST,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    write: bool = False,
+) -> dict[str, Any]:
+    packet = build_daily_status_packet(
+        loop_latest_path=loop_latest_path,
+        flywheel_latest_path=flywheel_latest_path,
+    )
+    if write:
+        packet["_artifact_paths"] = write_outputs(packet, output_dir=output_dir)
+    return packet
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Write QRE daily status digest.")
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument("--loop-latest", default=DEFAULT_LOOP_LATEST.as_posix())
+    parser.add_argument("--flywheel-latest", default=DEFAULT_FLYWHEEL_LATEST.as_posix())
+    parser.add_argument("--output-dir", default=DEFAULT_OUTPUT_DIR.as_posix())
+    args = parser.parse_args(argv)
+    packet = run_daily_status_digest(
+        loop_latest_path=Path(args.loop_latest),
+        flywheel_latest_path=Path(args.flywheel_latest),
+        output_dir=Path(args.output_dir),
+        write=args.write,
+    )
+    print(json.dumps(packet["summary"], indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "DailyStatusDigestError",
+    "DEFAULT_LOOP_LATEST",
+    "DEFAULT_OUTPUT_DIR",
+    "REPORT_KIND",
+    "SCHEMA_VERSION",
+    "build_daily_status_packet",
+    "render_daily_status",
+    "run_daily_status_digest",
+    "write_outputs",
+]

--- a/research/qre_next_action_classifier.py
+++ b/research/qre_next_action_classifier.py
@@ -1,0 +1,233 @@
+"""QRE next-action classifier.
+
+This module classifies controlled-research ``next_action`` strings into
+operator/ADE-safe routing decisions. It is deliberately planning-only:
+no execution authority is granted here.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import re
+from dataclasses import dataclass
+from typing import Final
+
+
+SCHEMA_VERSION: Final[str] = "1.0"
+REPORT_KIND: Final[str] = "qre_next_action_classification"
+
+BLOCKED_AUTHORITIES: Final[tuple[str, ...]] = (
+    "paper_shadow_live",
+    "broker_risk_execution",
+    "campaign_mutation",
+    "candidate_promotion",
+    "strategy_or_preset_registry_mutation",
+    "public_research_output_mutation",
+    "broad_run_research",
+    "campaign_launcher_direct_execution",
+    "external_data_or_network_fetch",
+)
+
+ACCEPTANCE_COMMANDS: Final[tuple[str, ...]] = (
+    "python -m pytest tests/unit/test_qre_autonomous_market_research_loop.py -q",
+    "python -m pytest tests/unit/test_qre_next_action_classifier.py -q",
+    "python -m pytest tests/unit/test_qre_build_request_writer.py -q",
+    "python -m pytest tests/unit/test_qre_daily_status_digest.py -q",
+    "python -m pytest tests/unit/test_qre_controlled_research_run.py -q",
+    "python -m research.qre_autonomous_market_research_loop --write --max-cycles 3",
+    "python -m research.qre_daily_status_digest --write",
+    "git diff --check",
+    "git diff -- research/research_latest.json research/strategy_matrix.csv",
+)
+
+
+@dataclass(frozen=True)
+class ActionRule:
+    rule_id: str
+    patterns: tuple[str, ...]
+    action_class: str
+    safety_class: str
+    ade_build_allowed: bool
+    human_review_required: bool
+
+
+RULES: Final[tuple[ActionRule, ...]] = (
+    ActionRule(
+        rule_id="unsafe_blocked",
+        patterns=(
+            "activate_live*",
+            "enable_shadow*",
+            "enable_paper*",
+            "promote_candidate*",
+            "launch_campaign*",
+            "mutate_strategy*",
+            "mutate_preset*",
+            "increase_risk*",
+            "broker*",
+            "execution*",
+            "place_order*",
+            "trade*",
+        ),
+        action_class="blocked",
+        safety_class="unsafe_requires_explicit_separate_governance",
+        ade_build_allowed=False,
+        human_review_required=True,
+    ),
+    ActionRule(
+        rule_id="hold_or_review",
+        patterns=("hold_do_not_build", "operator_review_required", "human_review_required"),
+        action_class="review_required",
+        safety_class="human_review_required",
+        ade_build_allowed=False,
+        human_review_required=True,
+    ),
+    ActionRule(
+        rule_id="safe_rerun_or_operator_instruction",
+        patterns=("rerun*", "keep_same_universe*", "do_not_rotate*", "adjust_threshold*"),
+        action_class="safe_rerun_or_operator_instruction",
+        safety_class="safe_to_plan_requires_runtime_gate",
+        ade_build_allowed=False,
+        human_review_required=True,
+    ),
+    ActionRule(
+        rule_id="metric_data_research_infrastructure",
+        patterns=(
+            "add_*metric*",
+            "*cache_only*",
+            "*oos*",
+            "*drawdown*",
+            "*sharpe*",
+            "*trade_count*",
+            "add_source_identity*",
+            "add_data_freshness*",
+            "add_metric_readiness*",
+            "add_result_to_market_intake_feedback*",
+            "repair_cache_or_add_safe_metric_input",
+            "add_preset_metric_adapter",
+            "add_safe_oos_splitter",
+        ),
+        action_class="code_required",
+        safety_class="safe_to_plan_requires_pr",
+        ade_build_allowed=True,
+        human_review_required=True,
+    ),
+    ActionRule(
+        rule_id="reporting_or_ux",
+        patterns=(
+            "add_*report*",
+            "add_operator_summary*",
+            "add_blocker_diagnosis*",
+            "add_universe_coverage_report",
+            "add_research_run_comparison_report",
+        ),
+        action_class="reporting_or_ux_code_required",
+        safety_class="safe_to_plan_requires_pr",
+        ade_build_allowed=True,
+        human_review_required=True,
+    ),
+)
+
+
+def _normalize_action(action: str) -> str:
+    value = str(action or "").strip().lower()
+    value = re.sub(r"[^a-z0-9_*-]+", "_", value)
+    return value.strip("_")
+
+
+def _slug(value: str, *, max_len: int = 56) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", _normalize_action(value)).strip("-")
+    return (slug[:max_len].strip("-") or "qre-next-action")
+
+
+def _title(value: str) -> str:
+    words = _slug(value).replace("-", " ")
+    return f"feat: {words}"
+
+
+def _scope_for(action: str, action_class: str) -> list[str]:
+    if action_class == "code_required":
+        return [
+            "inspect existing cache-only and controlled metric readers",
+            "add or wire a no-network exact-universe metric evidence path if no safe path exists",
+            "preserve bounded metric evidence when true metrics remain unavailable",
+            "prove protected public research artifacts remain unchanged",
+        ]
+    if action_class == "reporting_or_ux_code_required":
+        return [
+            "add the requested report or operator-summary projection",
+            "keep output logs-only and safe_to_execute=false",
+            "prove no protected public research artifacts are mutated",
+        ]
+    if action_class == "safe_rerun_or_operator_instruction":
+        return [
+            "prepare operator rerun instructions only",
+            "do not execute runtime changes without an explicit gate",
+        ]
+    return ["operator review required before implementation scope is defined"]
+
+
+def classify_next_action(next_action: str) -> dict[str, object]:
+    """Classify one next action using denylist-first pattern families."""
+
+    normalized = _normalize_action(next_action)
+    matched_rule: ActionRule | None = None
+    matched_pattern = ""
+    for rule in RULES:
+        for pattern in rule.patterns:
+            if fnmatch.fnmatchcase(normalized, pattern):
+                matched_rule = rule
+                matched_pattern = pattern
+                break
+        if matched_rule is not None:
+            break
+
+    if matched_rule is None:
+        action_class = "unknown"
+        safety_class = "fail_closed_human_review_required"
+        ade_build_allowed = False
+        human_review_required = True
+        rule_id = "unknown_fail_closed"
+    else:
+        action_class = matched_rule.action_class
+        safety_class = matched_rule.safety_class
+        ade_build_allowed = matched_rule.ade_build_allowed
+        human_review_required = matched_rule.human_review_required
+        rule_id = matched_rule.rule_id
+
+    recommended_branch = f"feat/qre-{_slug(normalized)}"
+    recommended_pr_title = _title(normalized)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "next_action": normalized,
+        "original_next_action": str(next_action or ""),
+        "rule_id": rule_id,
+        "matched_pattern": matched_pattern,
+        "action_class": action_class,
+        "safety_class": safety_class,
+        "execution_allowed": False,
+        "ade_build_allowed": ade_build_allowed,
+        "safe_for_ade_build": ade_build_allowed,
+        "human_review_required": human_review_required,
+        "recommended_branch": recommended_branch,
+        "recommended_pr_title": recommended_pr_title,
+        "implementation_scope": _scope_for(normalized, action_class),
+        "blocked_authorities": list(BLOCKED_AUTHORITIES),
+        "forbidden_actions": list(BLOCKED_AUTHORITIES),
+        "acceptance_commands": list(ACCEPTANCE_COMMANDS),
+        "operator_approval": {
+            "required": human_review_required,
+            "approval_status": "not_requested",
+            "approval_scope": "planning_only_not_execution",
+        },
+    }
+
+
+__all__ = [
+    "ACCEPTANCE_COMMANDS",
+    "BLOCKED_AUTHORITIES",
+    "REPORT_KIND",
+    "RULES",
+    "SCHEMA_VERSION",
+    "classify_next_action",
+]

--- a/research/qre_pr_auto_merge_gate.py
+++ b/research/qre_pr_auto_merge_gate.py
@@ -1,0 +1,266 @@
+"""QRE PR auto-merge gate.
+
+The gate can evaluate PR metadata from a mocked/configured backend and, only
+when explicitly enabled, call an injected or real merge command. Default CLI
+behavior is observation/fail-closed; unsafe PRs are never merged.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+from collections.abc import Callable
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Final
+
+
+SCHEMA_VERSION: Final[str] = "1.0"
+REPORT_KIND: Final[str] = "qre_pr_auto_merge_gate"
+DEFAULT_BUILD_REQUEST_PATH: Final[Path] = Path(
+    "logs/qre_autonomous_market_research_loop/latest_build_request.json"
+)
+DEFAULT_CONSUMER_LATEST: Final[Path] = Path("logs/qre_build_request_consumer/latest.json")
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_pr_auto_merge_gate")
+FORBIDDEN_PATH_PREFIXES: Final[tuple[str, ...]] = (
+    "broker/",
+    "execution/",
+    "risk/",
+    "paper/",
+    "shadow/",
+    "live/",
+    "automation/live",
+    ".github/workflows/",
+    ".github/CODEOWNERS",
+    ".claude/",
+)
+FORBIDDEN_EXACT_PATHS: Final[tuple[str, ...]] = (
+    "research/research_latest.json",
+    "research/strategy_matrix.csv",
+)
+
+
+CommandRunner = Callable[[list[str]], tuple[int, str, str]]
+
+
+class PrAutoMergeGateError(RuntimeError):
+    """Raised when PR gate inputs are malformed."""
+
+
+def _utcnow() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _json_dumps(payload: Any) -> str:
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    try:
+        parsed = json.loads(path.read_text(encoding="utf-8-sig"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _assert_inside(root: Path, path: Path) -> None:
+    resolved_root = root.resolve()
+    resolved_path = path.resolve()
+    if resolved_path != resolved_root and resolved_root not in resolved_path.parents:
+        raise PrAutoMergeGateError(f"refusing write outside output dir: {path}")
+
+
+def _default_command_runner(cmd: list[str]) -> tuple[int, str, str]:
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=600, check=False)
+    except (OSError, subprocess.SubprocessError) as exc:
+        return (-1, "", repr(exc))
+    return (result.returncode, result.stdout or "", result.stderr or "")
+
+
+def _path_forbidden(path: str) -> bool:
+    normalized = path.replace("\\", "/").lstrip("./")
+    return normalized in FORBIDDEN_EXACT_PATHS or any(
+        normalized.startswith(prefix) for prefix in FORBIDDEN_PATH_PREFIXES
+    )
+
+
+def _metadata_from_sources(
+    *,
+    consumer_latest_path: Path,
+    pr_metadata: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    if pr_metadata is not None:
+        return pr_metadata
+    consumer = _read_json(consumer_latest_path)
+    if not consumer:
+        return None
+    metadata = consumer.get("pr_metadata")
+    return metadata if isinstance(metadata, dict) else None
+
+
+def evaluate_pr_gate(
+    *,
+    build_request_path: Path = DEFAULT_BUILD_REQUEST_PATH,
+    consumer_latest_path: Path = DEFAULT_CONSUMER_LATEST,
+    pr_metadata: dict[str, Any] | None = None,
+    env: dict[str, str] | None = None,
+    command_runner: CommandRunner | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    generated = generated_at_utc or _utcnow()
+    build_request = _read_json(build_request_path)
+    metadata = _metadata_from_sources(
+        consumer_latest_path=consumer_latest_path,
+        pr_metadata=pr_metadata,
+    )
+    source_env = env if env is not None else os.environ
+    auto_merge_requested = str(source_env.get("QRE_AUTO_MERGE_GREEN") or "").lower() == "true"
+    blockers: list[str] = []
+    if not build_request:
+        blockers.append("build_request_missing")
+        build_request = {}
+    if metadata is None:
+        blockers.append("pr_metadata_missing")
+        metadata = {}
+    changed_files = [str(item) for item in metadata.get("changed_files") or []]
+    forbidden_paths = sorted(path for path in changed_files if _path_forbidden(path))
+    if build_request.get("safe_for_ade_build") is not True:
+        blockers.append("build_request_not_safe_for_ade_build")
+    if build_request.get("execution_allowed") is True:
+        blockers.append("build_request_execution_allowed_true")
+    if metadata.get("ci_status") != "green":
+        blockers.append("ci_not_green")
+    if metadata.get("mergeable") is not True:
+        blockers.append("pr_not_mergeable")
+    if not str(metadata.get("branch") or "").startswith("feat/qre-"):
+        blockers.append("branch_not_automated_qre_pattern")
+    if metadata.get("title") != build_request.get("recommended_pr_title"):
+        blockers.append("pr_title_mismatch")
+    if forbidden_paths:
+        blockers.append("forbidden_paths_touched")
+    if not auto_merge_requested:
+        blockers.append("auto_merge_not_enabled")
+
+    auto_merge_allowed = not blockers
+    merge_performed = False
+    merge_result: dict[str, Any] | None = None
+    if auto_merge_allowed:
+        runner = command_runner or _default_command_runner
+        pr_number = str(metadata.get("number") or metadata.get("pr_number") or "")
+        if not pr_number:
+            blockers.append("pr_number_missing")
+            auto_merge_allowed = False
+        else:
+            rc, stdout, stderr = runner(["gh", "pr", "merge", pr_number, "--squash", "--delete-branch"])
+            merge_performed = rc == 0
+            merge_result = {"returncode": rc, "stdout": stdout[:2000], "stderr": stderr[:2000]}
+            if not merge_performed:
+                blockers.append("merge_command_failed")
+                auto_merge_allowed = False
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": generated,
+        "request_id": build_request.get("request_id"),
+        "pr_number": metadata.get("number") or metadata.get("pr_number"),
+        "ci_observed": bool(metadata),
+        "pr_green": metadata.get("ci_status") == "green",
+        "auto_merge_requested": auto_merge_requested,
+        "auto_merge_allowed": auto_merge_allowed,
+        "manual_governance_required": bool(blockers),
+        "pr_auto_merged": merge_performed,
+        "merge_result": merge_result,
+        "forbidden_paths_touched": forbidden_paths,
+        "blocked_reasons": blockers,
+        "paper_shadow_live_allowed": False,
+        "broker_risk_allowed": False,
+        "execution_allowed": False,
+        "campaign_launcher_called": False,
+        "run_research_called": False,
+        "protected_outputs_mutated": False,
+        "final_recommendation": (
+            "pr_auto_merged" if merge_performed else "manual_governance_required_or_not_green"
+        ),
+    }
+
+
+def render_operator_summary(snapshot: dict[str, Any]) -> str:
+    reasons = ", ".join(snapshot.get("blocked_reasons") or []) or "none"
+    return "\n".join(
+        [
+            "# QRE PR Auto-Merge Gate",
+            "",
+            f"- PR: {snapshot.get('pr_number')}",
+            f"- CI observed: {snapshot.get('ci_observed')}",
+            f"- PR green: {snapshot.get('pr_green')}",
+            f"- Auto-merge allowed: {snapshot.get('auto_merge_allowed')}",
+            f"- PR auto-merged: {snapshot.get('pr_auto_merged')}",
+            f"- Manual governance required: {snapshot.get('manual_governance_required')}",
+            f"- Blocked reasons: {reasons}",
+            "- Trading: disabled.",
+            "- Protected public research outputs: not mutated.",
+            "",
+        ]
+    )
+
+
+def write_outputs(snapshot: dict[str, Any], *, output_dir: Path = DEFAULT_OUTPUT_DIR) -> dict[str, str]:
+    run_id = f"pr-{snapshot.get('pr_number') or 'none'}__{str(snapshot['generated_at_utc']).replace(':', '').replace('-', '')}"
+    latest = output_dir / "latest.json"
+    summary = output_dir / "operator_summary.md"
+    run_path = output_dir / "runs" / f"{run_id}.json"
+    for path in (latest, summary, run_path):
+        _assert_inside(output_dir, path)
+    run_path.parent.mkdir(parents=True, exist_ok=True)
+    latest.write_text(_json_dumps(snapshot), encoding="utf-8", newline="\n")
+    summary.write_text(render_operator_summary(snapshot), encoding="utf-8", newline="\n")
+    run_path.write_text(_json_dumps(snapshot), encoding="utf-8", newline="\n")
+    return {"latest": latest.as_posix(), "operator_summary": summary.as_posix(), "run": run_path.as_posix()}
+
+
+def run_gate(
+    *,
+    build_request_path: Path = DEFAULT_BUILD_REQUEST_PATH,
+    consumer_latest_path: Path = DEFAULT_CONSUMER_LATEST,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    write: bool = False,
+    env: dict[str, str] | None = None,
+    command_runner: CommandRunner | None = None,
+    pr_metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    snapshot = evaluate_pr_gate(
+        build_request_path=build_request_path,
+        consumer_latest_path=consumer_latest_path,
+        pr_metadata=pr_metadata,
+        env=env,
+        command_runner=command_runner,
+    )
+    if write:
+        snapshot["_artifact_paths"] = write_outputs(snapshot, output_dir=output_dir)
+    return snapshot
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Evaluate QRE PR auto-merge gate.")
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument("--build-request", default=DEFAULT_BUILD_REQUEST_PATH.as_posix())
+    parser.add_argument("--consumer-latest", default=DEFAULT_CONSUMER_LATEST.as_posix())
+    parser.add_argument("--output-dir", default=DEFAULT_OUTPUT_DIR.as_posix())
+    args = parser.parse_args(argv)
+    snapshot = run_gate(
+        build_request_path=Path(args.build_request),
+        consumer_latest_path=Path(args.consumer_latest),
+        output_dir=Path(args.output_dir),
+        write=args.write,
+    )
+    print(json.dumps(snapshot, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/research/qre_research_development_flywheel.py
+++ b/research/qre_research_development_flywheel.py
@@ -121,6 +121,7 @@ def run_flywheel(
                     env=env,
                     command_runner=runtime_command_runner,
                     skip_git_update=skip_runtime_git_update,
+                    controlled_packet=controlled_packet,
                 )
 
     states = {
@@ -284,4 +285,3 @@ def main(argv: list[str] | None = None) -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/research/qre_research_development_flywheel.py
+++ b/research/qre_research_development_flywheel.py
@@ -1,0 +1,287 @@
+"""Top-level QRE research-development flywheel."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Final
+
+from research import qre_autonomous_market_research_loop as research_loop
+from research import qre_build_request_consumer as consumer
+from research import qre_pr_auto_merge_gate as merge_gate
+from research import qre_runtime_update_and_continue as continuation
+
+
+SCHEMA_VERSION: Final[str] = "1.0"
+REPORT_KIND: Final[str] = "qre_research_development_flywheel"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_research_development_flywheel")
+PROTECTED_PUBLIC_OUTPUTS: Final[tuple[Path, ...]] = (
+    Path("research/research_latest.json"),
+    Path("research/strategy_matrix.csv"),
+)
+
+
+class ResearchDevelopmentFlywheelError(RuntimeError):
+    """Raised when the flywheel cannot write safely."""
+
+
+def _utcnow() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _json_dumps(payload: Any) -> str:
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def _file_fingerprint(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {"exists": False, "content": None}
+    return {"exists": True, "content": path.read_bytes().hex()}
+
+
+def _protected_fingerprints() -> dict[str, dict[str, Any]]:
+    return {path.as_posix(): _file_fingerprint(path) for path in PROTECTED_PUBLIC_OUTPUTS}
+
+
+def _assert_protected_unchanged(before: dict[str, dict[str, Any]]) -> None:
+    if before != _protected_fingerprints():
+        raise ResearchDevelopmentFlywheelError("protected public research artifacts changed")
+
+
+def _assert_inside(root: Path, path: Path) -> None:
+    resolved_root = root.resolve()
+    resolved_path = path.resolve()
+    if resolved_path != resolved_root and resolved_root not in resolved_path.parents:
+        raise ResearchDevelopmentFlywheelError(f"refusing write outside output dir: {path}")
+
+
+def _copy_snapshot(snapshot: dict[str, Any], *, output_dir: Path, subdir: str) -> str:
+    target = output_dir / subdir / "latest.json"
+    _assert_inside(output_dir, target)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(_json_dumps(snapshot), encoding="utf-8", newline="\n")
+    return target.as_posix()
+
+
+def run_flywheel(
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    max_cycles: int = 40,
+    max_builds: int = 5,
+    write: bool = False,
+    env: dict[str, str] | None = None,
+    build_command_runner: consumer.CommandRunner | None = None,
+    merge_command_runner: merge_gate.CommandRunner | None = None,
+    runtime_command_runner: continuation.CommandRunner | None = None,
+    skip_runtime_git_update: bool = False,
+    controlled_packet: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if max_cycles < 1:
+        raise ResearchDevelopmentFlywheelError("--max-cycles must be positive")
+    if max_builds < 0:
+        raise ResearchDevelopmentFlywheelError("--max-builds must be non-negative")
+    before = _protected_fingerprints()
+    generated = _utcnow()
+
+    research_packet = research_loop.run_autonomous_loop(
+        controlled_packet=controlled_packet,
+        max_cycles=max_cycles,
+        until_build_request=max_builds > 0,
+        write=write,
+    )
+    build_request = research_packet.get("_artifact_paths", {}).get("build_request", {})
+    build_request_path = Path(build_request.get("latest") or "logs/qre_autonomous_market_research_loop/latest_build_request.json")
+
+    build_snapshot: dict[str, Any] | None = None
+    pr_snapshot: dict[str, Any] | None = None
+    continuation_snapshot: dict[str, Any] | None = None
+    if max_builds > 0 and build_request_path.exists():
+        build_snapshot = consumer.run_consumer(
+            build_request_path=build_request_path,
+            write=write,
+            env=env,
+            command_runner=build_command_runner,
+        )
+        if build_snapshot.get("pr_created") is True:
+            pr_snapshot = merge_gate.run_gate(
+                build_request_path=build_request_path,
+                write=write,
+                env=env,
+                command_runner=merge_command_runner,
+                pr_metadata=build_snapshot.get("pr_metadata")
+                if isinstance(build_snapshot.get("pr_metadata"), dict)
+                else None,
+            )
+            if pr_snapshot.get("pr_auto_merged") is True:
+                continuation_snapshot = continuation.run_continuation(
+                    max_cycles=min(3, max_cycles),
+                    write=write,
+                    env=env,
+                    command_runner=runtime_command_runner,
+                    skip_git_update=skip_runtime_git_update,
+                )
+
+    states = {
+        "build_request_created": bool(build_request),
+        "build_request_consumed": bool(build_snapshot and build_snapshot.get("build_request_consumed")),
+        "build_started": bool(build_snapshot and build_snapshot.get("build_started")),
+        "branch_created": bool(build_snapshot and build_snapshot.get("branch_created")),
+        "code_changed": bool(build_snapshot and build_snapshot.get("code_changed")),
+        "tests_run": bool(build_snapshot and build_snapshot.get("tests_run")),
+        "pr_created": bool(build_snapshot and build_snapshot.get("pr_created")),
+        "ci_observed": bool(pr_snapshot and pr_snapshot.get("ci_observed")),
+        "pr_green": bool(pr_snapshot and pr_snapshot.get("pr_green")),
+        "pr_auto_merged": bool(pr_snapshot and pr_snapshot.get("pr_auto_merged")),
+        "runtime_updated": bool(continuation_snapshot and continuation_snapshot.get("runtime_updated")),
+        "research_continuation_started": bool(
+            continuation_snapshot and continuation_snapshot.get("research_continuation_started")
+        ),
+        "research_blocked": not bool(research_packet.get("summary", {}).get("autonomous_loop_ready")),
+        "unsafe_action_blocked": bool(research_packet.get("summary", {}).get("unsafe_actions_blocked")),
+    }
+    blocked_reasons: list[str] = []
+    for snapshot in (build_snapshot, pr_snapshot, continuation_snapshot):
+        if not snapshot:
+            continue
+        if snapshot.get("blocked_reason"):
+            blocked_reasons.append(str(snapshot["blocked_reason"]))
+        for reason in snapshot.get("blocked_reasons") or []:
+            blocked_reasons.append(str(reason))
+    summary = {
+        "flywheel_ready": True,
+        "max_cycles": max_cycles,
+        "max_builds": max_builds,
+        "research_cycles_completed": research_packet.get("summary", {}).get("cycle_count"),
+        "market_intake_cycles_completed": research_packet.get("summary", {}).get("market_intake_cycle_count"),
+        "build_requests_created": 1 if build_request else 0,
+        "build_requests_consumed": 1 if states["build_request_consumed"] else 0,
+        "prs_opened": 1 if states["pr_created"] else 0,
+        "prs_green": 1 if states["pr_green"] else 0,
+        "prs_merged": 1 if states["pr_auto_merged"] else 0,
+        "runtime_updates_completed": 1 if states["runtime_updated"] else 0,
+        "research_continuations_started": 1 if states["research_continuation_started"] else 0,
+        "manual_governance_blockers": blocked_reasons,
+        "paper_shadow_live_allowed": False,
+        "broker_risk_allowed": False,
+        "execution_allowed": False,
+        "campaign_launcher_called": False,
+        "run_research_called": False,
+        "protected_outputs_mutated": False,
+        "auto_trade_allowed": False,
+        "final_recommendation": (
+            "flywheel_continuation_started"
+            if states["research_continuation_started"]
+            else "flywheel_waiting_or_blocked"
+        ),
+    }
+    packet = {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": generated,
+        "summary": summary,
+        "states": states,
+        "research_loop": research_packet,
+        "build_consumption": build_snapshot,
+        "pr_status": pr_snapshot,
+        "runtime_continuation": continuation_snapshot,
+    }
+    if write:
+        packet["_artifact_paths"] = write_outputs(packet, output_dir=output_dir)
+    _assert_protected_unchanged(before)
+    return packet
+
+
+def render_operator_summary(packet: dict[str, Any]) -> str:
+    summary = packet["summary"]
+    states = packet["states"]
+    blockers = ", ".join(summary.get("manual_governance_blockers") or []) or "none"
+    return "\n".join(
+        [
+            "# QRE Research-Development Flywheel",
+            "",
+            f"- Research cycles completed: {summary.get('research_cycles_completed')}",
+            f"- Market-intake cycles completed: {summary.get('market_intake_cycles_completed')}",
+            f"- Build requests created: {summary.get('build_requests_created')}",
+            f"- Build requests consumed: {summary.get('build_requests_consumed')}",
+            f"- PRs opened: {summary.get('prs_opened')}",
+            f"- PRs green: {summary.get('prs_green')}",
+            f"- PRs merged: {summary.get('prs_merged')}",
+            f"- Runtime updates completed: {summary.get('runtime_updates_completed')}",
+            f"- Research continuations started: {summary.get('research_continuations_started')}",
+            f"- Current states: {json.dumps(states, sort_keys=True)}",
+            f"- Manual governance blockers: {blockers}",
+            "- Trading: disabled.",
+            "- Protected public research outputs: not mutated.",
+            "",
+        ]
+    )
+
+
+def write_outputs(packet: dict[str, Any], *, output_dir: Path = DEFAULT_OUTPUT_DIR) -> dict[str, Any]:
+    latest = output_dir / "latest.json"
+    summary = output_dir / "operator_summary.md"
+    ledger = output_dir / "ledger.jsonl"
+    for path in (latest, summary, ledger):
+        _assert_inside(output_dir, path)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    latest.write_text(_json_dumps(packet), encoding="utf-8", newline="\n")
+    summary.write_text(render_operator_summary(packet), encoding="utf-8", newline="\n")
+    with ledger.open("a", encoding="utf-8", newline="\n") as handle:
+        handle.write(
+            json.dumps(
+                {
+                    "schema_version": SCHEMA_VERSION,
+                    "report_kind": REPORT_KIND,
+                    "generated_at_utc": packet["generated_at_utc"],
+                    "states": packet["states"],
+                    "final_recommendation": packet["summary"]["final_recommendation"],
+                },
+                sort_keys=True,
+            )
+            + "\n"
+        )
+    paths: dict[str, Any] = {
+        "latest": latest.as_posix(),
+        "operator_summary": summary.as_posix(),
+        "ledger": ledger.as_posix(),
+    }
+    if packet.get("build_consumption"):
+        paths["build_consumption"] = _copy_snapshot(
+            packet["build_consumption"], output_dir=output_dir, subdir="build_consumption"
+        )
+    if packet.get("pr_status"):
+        paths["pr_status"] = _copy_snapshot(packet["pr_status"], output_dir=output_dir, subdir="pr_status")
+    if packet.get("runtime_continuation"):
+        paths["continuation"] = _copy_snapshot(
+            packet["runtime_continuation"], output_dir=output_dir, subdir="continuations"
+        )
+    merge_dir = output_dir / "merge_results"
+    _assert_inside(output_dir, merge_dir)
+    merge_dir.mkdir(parents=True, exist_ok=True)
+    return paths
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run QRE research-development flywheel.")
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument("--max-cycles", type=int, default=40)
+    parser.add_argument("--max-builds", type=int, default=5)
+    parser.add_argument("--output-dir", default=DEFAULT_OUTPUT_DIR.as_posix())
+    parser.add_argument("--skip-runtime-git-update", action="store_true")
+    args = parser.parse_args(argv)
+    packet = run_flywheel(
+        output_dir=Path(args.output_dir),
+        max_cycles=args.max_cycles,
+        max_builds=args.max_builds,
+        write=args.write,
+        skip_runtime_git_update=args.skip_runtime_git_update,
+    )
+    print(json.dumps(packet["summary"], indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/research/qre_runtime_update_and_continue.py
+++ b/research/qre_runtime_update_and_continue.py
@@ -1,0 +1,215 @@
+"""QRE runtime update and research continuation.
+
+After a safe merge signal, this module can update main and run bounded
+autonomous research again. By default it refuses runtime mutation unless
+``QRE_RUNTIME_UPDATE=true`` or tests inject a command runner.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+from collections.abc import Callable
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Final
+
+from research import qre_autonomous_market_research_loop as research_loop
+
+
+SCHEMA_VERSION: Final[str] = "1.0"
+REPORT_KIND: Final[str] = "qre_runtime_update_and_continue"
+DEFAULT_MERGE_RESULT_PATH: Final[Path] = Path("logs/qre_pr_auto_merge_gate/latest.json")
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_runtime_update_and_continue")
+PROTECTED_PUBLIC_OUTPUTS: Final[tuple[Path, ...]] = (
+    Path("research/research_latest.json"),
+    Path("research/strategy_matrix.csv"),
+)
+
+
+CommandRunner = Callable[[list[str]], tuple[int, str, str]]
+
+
+class RuntimeUpdateAndContinueError(RuntimeError):
+    """Raised when continuation cannot be evaluated safely."""
+
+
+def _utcnow() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _json_dumps(payload: Any) -> str:
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    try:
+        parsed = json.loads(path.read_text(encoding="utf-8-sig"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _file_fingerprint(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {"exists": False, "content": None}
+    return {"exists": True, "content": path.read_bytes().hex()}
+
+
+def _protected_fingerprints() -> dict[str, dict[str, Any]]:
+    return {path.as_posix(): _file_fingerprint(path) for path in PROTECTED_PUBLIC_OUTPUTS}
+
+
+def _assert_protected_unchanged(before: dict[str, dict[str, Any]]) -> None:
+    if before != _protected_fingerprints():
+        raise RuntimeUpdateAndContinueError("protected public research artifacts changed")
+
+
+def _assert_inside(root: Path, path: Path) -> None:
+    resolved_root = root.resolve()
+    resolved_path = path.resolve()
+    if resolved_path != resolved_root and resolved_root not in resolved_path.parents:
+        raise RuntimeUpdateAndContinueError(f"refusing write outside output dir: {path}")
+
+
+def _default_command_runner(cmd: list[str]) -> tuple[int, str, str]:
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=600, check=False)
+    except (OSError, subprocess.SubprocessError) as exc:
+        return (-1, "", repr(exc))
+    return (result.returncode, result.stdout or "", result.stderr or "")
+
+
+def run_continuation(
+    *,
+    merge_result_path: Path = DEFAULT_MERGE_RESULT_PATH,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    max_cycles: int = 3,
+    write: bool = False,
+    env: dict[str, str] | None = None,
+    command_runner: CommandRunner | None = None,
+    skip_git_update: bool = False,
+) -> dict[str, Any]:
+    before = _protected_fingerprints()
+    generated = _utcnow()
+    merge_result = _read_json(merge_result_path)
+    blockers: list[str] = []
+    if not merge_result:
+        blockers.append("merge_result_missing")
+    elif merge_result.get("pr_auto_merged") is not True:
+        blockers.append("pr_not_auto_merged")
+
+    source_env = env if env is not None else os.environ
+    runtime_update_enabled = str(source_env.get("QRE_RUNTIME_UPDATE") or "").lower() == "true"
+    update_results: list[dict[str, Any]] = []
+    runtime_updated = False
+    if not blockers:
+        if not runtime_update_enabled and not skip_git_update and command_runner is None:
+            blockers.append("runtime_update_not_enabled")
+        elif not skip_git_update:
+            runner = command_runner or _default_command_runner
+            for cmd in (["git", "checkout", "main"], ["git", "pull", "--ff-only", "origin", "main"]):
+                rc, stdout, stderr = runner(cmd)
+                update_results.append(
+                    {"cmd": cmd, "returncode": rc, "stdout": stdout[:2000], "stderr": stderr[:2000]}
+                )
+                if rc != 0:
+                    blockers.append("runtime_update_command_failed")
+                    break
+            runtime_updated = not blockers
+        else:
+            runtime_updated = True
+
+    continuation_packet: dict[str, Any] | None = None
+    if not blockers:
+        continuation_packet = research_loop.run_autonomous_loop(max_cycles=max_cycles, write=write)
+
+    _assert_protected_unchanged(before)
+    snapshot = {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": generated,
+        "merge_result_path": merge_result_path.as_posix(),
+        "runtime_updated": runtime_updated,
+        "research_continuation_started": continuation_packet is not None,
+        "research_cycles_started": (
+            (continuation_packet.get("summary") or {}).get("cycle_count")
+            if continuation_packet
+            else 0
+        ),
+        "blocked_reasons": blockers,
+        "update_results": update_results,
+        "latest_research_recommendation": (
+            (continuation_packet.get("summary") or {}).get("latest_recommendation")
+            if continuation_packet
+            else None
+        ),
+        "paper_shadow_live_allowed": False,
+        "broker_risk_allowed": False,
+        "execution_allowed": False,
+        "campaign_launcher_called": False,
+        "run_research_called": False,
+        "protected_outputs_mutated": False,
+        "final_recommendation": (
+            "research_continuation_started" if continuation_packet else "research_continuation_blocked"
+        ),
+    }
+    if write:
+        snapshot["_artifact_paths"] = write_outputs(snapshot, output_dir=output_dir)
+    return snapshot
+
+
+def render_operator_summary(snapshot: dict[str, Any]) -> str:
+    return "\n".join(
+        [
+            "# QRE Runtime Update And Continue",
+            "",
+            f"- Runtime updated: {snapshot.get('runtime_updated')}",
+            f"- Research continuation started: {snapshot.get('research_continuation_started')}",
+            f"- Research cycles started: {snapshot.get('research_cycles_started')}",
+            f"- Blocked reasons: {', '.join(snapshot.get('blocked_reasons') or []) or 'none'}",
+            "- Trading: disabled.",
+            "- Protected public research outputs: not mutated.",
+            "",
+        ]
+    )
+
+
+def write_outputs(snapshot: dict[str, Any], *, output_dir: Path = DEFAULT_OUTPUT_DIR) -> dict[str, str]:
+    run_id = "continuation__" + str(snapshot["generated_at_utc"]).replace(":", "").replace("-", "")
+    latest = output_dir / "latest.json"
+    summary = output_dir / "operator_summary.md"
+    run_path = output_dir / "runs" / f"{run_id}.json"
+    for path in (latest, summary, run_path):
+        _assert_inside(output_dir, path)
+    run_path.parent.mkdir(parents=True, exist_ok=True)
+    latest.write_text(_json_dumps(snapshot), encoding="utf-8", newline="\n")
+    summary.write_text(render_operator_summary(snapshot), encoding="utf-8", newline="\n")
+    run_path.write_text(_json_dumps(snapshot), encoding="utf-8", newline="\n")
+    return {"latest": latest.as_posix(), "operator_summary": summary.as_posix(), "run": run_path.as_posix()}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Update runtime after merge and continue QRE research.")
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument("--max-cycles", type=int, default=3)
+    parser.add_argument("--merge-result", default=DEFAULT_MERGE_RESULT_PATH.as_posix())
+    parser.add_argument("--output-dir", default=DEFAULT_OUTPUT_DIR.as_posix())
+    parser.add_argument("--skip-git-update", action="store_true")
+    args = parser.parse_args(argv)
+    snapshot = run_continuation(
+        merge_result_path=Path(args.merge_result),
+        output_dir=Path(args.output_dir),
+        max_cycles=args.max_cycles,
+        write=args.write,
+        skip_git_update=args.skip_git_update,
+    )
+    print(json.dumps(snapshot, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/research/qre_runtime_update_and_continue.py
+++ b/research/qre_runtime_update_and_continue.py
@@ -91,6 +91,7 @@ def run_continuation(
     env: dict[str, str] | None = None,
     command_runner: CommandRunner | None = None,
     skip_git_update: bool = False,
+    controlled_packet: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     before = _protected_fingerprints()
     generated = _utcnow()
@@ -124,7 +125,11 @@ def run_continuation(
 
     continuation_packet: dict[str, Any] | None = None
     if not blockers:
-        continuation_packet = research_loop.run_autonomous_loop(max_cycles=max_cycles, write=write)
+        continuation_packet = research_loop.run_autonomous_loop(
+            controlled_packet=controlled_packet,
+            max_cycles=max_cycles,
+            write=write,
+        )
 
     _assert_protected_unchanged(before)
     snapshot = {
@@ -212,4 +217,3 @@ def main(argv: list[str] | None = None) -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/tests/unit/test_qre_autonomous_market_research_loop.py
+++ b/tests/unit/test_qre_autonomous_market_research_loop.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from research import qre_autonomous_market_research_loop as loop
+from research.qre_controlled_research_run import CONTROLLED_ASSETS
+
+
+def _controlled_packet(next_action: str = "add_cache_only_metric_path") -> dict:
+    run_group_id = "controlled-research-test"
+    return {
+        "schema_version": "1.0",
+        "report_kind": "qre_controlled_research_run",
+        "run_group_id": run_group_id,
+        "summary": {
+            "loop_count": 2,
+            "run_research_called": False,
+            "campaign_launcher_called": False,
+            "validation_executed": False,
+            "execution_performed": False,
+            "paper_shadow_live_allowed": False,
+            "research_latest_mutated": False,
+            "strategy_matrix_mutated": False,
+            "final_recommendation": next_action,
+        },
+        "runs": [
+            {
+                "run_id": f"{run_group_id}__loop__2",
+                "hypothesis": {
+                    "statement": "controlled hypothesis",
+                    "not_alpha_claim": True,
+                    "not_trade_signal": True,
+                },
+                "preset_selection": {
+                    "preset_id": "trend_continuation_daily_v1",
+                    "timeframe": "1d",
+                    "preset_mutated": False,
+                },
+                "controlled_campaign_intent": {
+                    "campaign_intent_id": "campaign-intent",
+                    "campaign_launcher_called": False,
+                    "campaign_registry_mutated": False,
+                    "candidate_promotion_allowed": False,
+                    "controlled_universe": list(CONTROLLED_ASSETS),
+                },
+                "metric_evidence": {
+                    "metric_mode": "bounded_metric_evidence",
+                    "true_metrics_available": False,
+                    "bounded_metric_evidence_available": True,
+                    "per_asset": [
+                        {
+                            "symbol": symbol,
+                            "metric_readiness": "blocked",
+                            "blocker": "safe_metric_runner_missing_or_cache_unavailable",
+                            "next_action": next_action,
+                        }
+                        for symbol in CONTROLLED_ASSETS
+                    ],
+                },
+                "analysis": {
+                    "analysis_id": "analysis-2",
+                    "analysis_statement": "metrics blocked",
+                    "metric_evidence_mode": "bounded_metric_evidence",
+                    "true_metrics_available": False,
+                    "content_blockers": ["safe_metric_runner_missing_or_cache_unavailable"],
+                    "safety_blockers": [],
+                },
+                "learning_feedback": {
+                    "learning_feedback_id": "learning-2",
+                    "learning_statement": "do not rotate assets",
+                },
+                "next_hypothesis_or_action": {
+                    "recommended_action": next_action,
+                    "operator_command_after_next_pr": (
+                        "python -m research.qre_controlled_research_run --write --loops 2"
+                    ),
+                },
+            }
+        ],
+    }
+
+
+def test_controller_can_run_bounded_max_cycles_and_preserve_full_flow() -> None:
+    packet = loop.build_autonomous_loop_packet(
+        controlled_packet=_controlled_packet(),
+        max_cycles=3,
+    )
+
+    assert packet["summary"]["cycle_count"] == 3
+    assert packet["summary"]["market_intake_cycle_count"] == 3
+    assert packet["summary"]["controlled_research_inner_loop_count"] == 6
+    cycle = packet["cycles"][0]
+    assert cycle["flow"] == [
+        "market_intake",
+        "market_analysis",
+        "hypothesis_generation",
+        "preset_selection",
+        "controlled_campaign_intent",
+        "metric_evidence",
+        "result_analysis",
+        "learning_feedback",
+        "next_market_intake_seed",
+        "next_action",
+    ]
+    assert cycle["safety"]["paper_shadow_live_allowed"] is False
+    assert cycle["safety"]["broker_risk_allowed"] is False
+    assert cycle["safety"]["execution_allowed"] is False
+    assert cycle["safety"]["run_research_called"] is False
+    assert cycle["safety"]["campaign_launcher_called"] is False
+
+
+def test_next_cycle_consumes_prior_next_market_intake_seed() -> None:
+    packet = loop.build_autonomous_loop_packet(
+        controlled_packet=_controlled_packet(),
+        max_cycles=2,
+    )
+    first, second = packet["cycles"]
+
+    assert second["market_intake"]["source"] == "previous_learning_seed"
+    assert second["market_intake"]["previous_seed_id"] == first["next_market_intake_seed"]["seed_id"]
+    assert "infrastructure/metric evidence" in second["market_intake"]["statement"]
+
+
+def test_controller_creates_build_request_without_manual_copy_paste(tmp_path: Path) -> None:
+    packet = loop.run_autonomous_loop(
+        controlled_packet=_controlled_packet(),
+        output_dir=tmp_path,
+        max_cycles=3,
+        write=True,
+    )
+
+    paths = packet["_artifact_paths"]["build_request"]
+    assert paths["request_id"].startswith("build-request-")
+    latest = json.loads((tmp_path / "latest_build_request.json").read_text(encoding="utf-8"))
+    assert latest["next_action"] == "add_cache_only_metric_path"
+    assert latest["build_executed_by_this_controller"] is False
+    assert (tmp_path / "operator_summary.md").exists()
+    assert (tmp_path / "latest.json").exists()
+    assert len(list((tmp_path / "runs").glob("*.json"))) == 3
+
+
+def test_until_build_request_stops_after_first_code_required_action() -> None:
+    packet = loop.build_autonomous_loop_packet(
+        controlled_packet=_controlled_packet(),
+        max_cycles=40,
+        until_build_request=True,
+    )
+
+    assert packet["summary"]["cycle_count"] == 1
+    assert packet["summary"]["build_request_required_count"] == 1
+
+
+def test_can_model_forty_cycles_without_infinite_loop() -> None:
+    packet = loop.build_autonomous_loop_packet(
+        controlled_packet=_controlled_packet(),
+        max_cycles=40,
+    )
+
+    assert packet["summary"]["cycle_count"] == 40
+    assert packet["cycles"][-1]["cycle_index"] == 40
+
+
+def test_unsafe_action_is_blocked_and_unknown_fails_closed() -> None:
+    unsafe = loop.build_autonomous_loop_packet(
+        controlled_packet=_controlled_packet("enable_paper_runtime"),
+        max_cycles=1,
+    )
+    unknown = loop.build_autonomous_loop_packet(
+        controlled_packet=_controlled_packet("invent_future_action"),
+        max_cycles=1,
+    )
+
+    assert unsafe["cycles"][0]["next_action"]["classification"]["action_class"] == "blocked"
+    assert unsafe["summary"]["unsafe_actions_blocked"] == 1
+    assert unknown["cycles"][0]["next_action"]["classification"]["action_class"] == "unknown"
+    assert unknown["summary"]["unknown_actions"] == 1
+
+
+def test_invalid_cycle_count_rejected() -> None:
+    with pytest.raises(loop.AutonomousMarketResearchLoopError, match="between 1 and 1000"):
+        loop.build_autonomous_loop_packet(controlled_packet=_controlled_packet(), max_cycles=0)
+
+
+def test_report_only_rewrites_summary_from_existing_latest(tmp_path: Path) -> None:
+    loop.run_autonomous_loop(
+        controlled_packet=_controlled_packet(),
+        output_dir=tmp_path,
+        max_cycles=1,
+        write=True,
+    )
+
+    packet = loop.run_autonomous_loop(output_dir=tmp_path, write=True, report_only=True)
+
+    assert packet["summary"]["cycle_count"] == 1
+    assert "# QRE Autonomous Market-Research Loop" in (
+        tmp_path / "operator_summary.md"
+    ).read_text(encoding="utf-8")
+

--- a/tests/unit/test_qre_build_request_consumer.py
+++ b/tests/unit/test_qre_build_request_consumer.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from research import qre_build_request_consumer as consumer
+from research.qre_build_request_writer import build_request_packet, write_build_request
+from research.qre_next_action_classifier import classify_next_action
+
+
+def _build_request(tmp_path: Path) -> Path:
+    cycle = {
+        "cycle_id": "cycle-1",
+        "source_research_run_id": "research-run-2",
+        "source_research_run_group_id": "research-group",
+        "next_market_intake_seed": {"seed_id": "seed-1"},
+        "result_analysis": {"content_blockers": ["safe_metric_runner_missing_or_cache_unavailable"]},
+    }
+    packet = build_request_packet(
+        source_cycle=cycle,
+        classification=classify_next_action("add_cache_only_metric_path"),
+        created_at_utc="2026-06-13T00:00:00Z",
+    )
+    write_build_request(packet, output_dir=tmp_path)
+    return tmp_path / "latest_build_request.json"
+
+
+def test_consumer_reads_latest_build_request_and_fails_closed_without_backend(tmp_path: Path) -> None:
+    snapshot = consumer.run_consumer(
+        build_request_path=_build_request(tmp_path),
+        output_dir=tmp_path / "out",
+        write=True,
+        env={},
+    )
+
+    assert snapshot["build_backend_available"] is False
+    assert snapshot["build_request_consumed"] is False
+    assert snapshot["missing_capability"] == "safe_build_backend"
+    assert snapshot["execution_allowed"] is False
+    assert (tmp_path / "out" / "latest.json").exists()
+
+
+def test_consumer_uses_mocked_safe_backend_and_records_consumption(tmp_path: Path) -> None:
+    def runner(cmd: list[str], env: dict[str, str]) -> tuple[int, str, str]:
+        assert env["QRE_BUILD_REQUEST_PATH"].endswith("latest_build_request.json")
+        return (
+            0,
+            json.dumps(
+                {
+                    "build_request_consumed": True,
+                    "build_started": True,
+                    "branch_created": True,
+                    "code_changed": True,
+                    "tests_run": True,
+                    "pr_created": True,
+                    "pr_metadata": {
+                        "number": 524,
+                        "branch": "feat/qre-add-cache-only-metric-path",
+                        "title": "feat: add cache only metric path",
+                        "ci_status": "green",
+                        "mergeable": True,
+                        "changed_files": [
+                            "research/qre_cache_only_metric_path.py",
+                            "tests/unit/test_qre_cache_only_metric_path.py",
+                        ],
+                    },
+                }
+            ),
+            "",
+        )
+
+    snapshot = consumer.run_consumer(
+        build_request_path=_build_request(tmp_path),
+        env={
+            "QRE_BUILD_BACKEND": "codex_cli",
+            "QRE_BUILD_COMMAND": "codex exec %QRE_BUILD_REQUEST_PATH%",
+            "QRE_AUTO_PR": "true",
+        },
+        command_runner=runner,
+    )
+
+    assert snapshot["build_backend_available"] is True
+    assert snapshot["build_request_consumed"] is True
+    assert snapshot["build_started"] is True
+    assert snapshot["branch_created"] is True
+    assert snapshot["code_changed"] is True
+    assert snapshot["tests_run"] is True
+    assert snapshot["pr_created"] is True
+    assert snapshot["pr_metadata"]["number"] == 524
+

--- a/tests/unit/test_qre_build_request_writer.py
+++ b/tests/unit/test_qre_build_request_writer.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from research.qre_build_request_writer import build_request_packet, write_build_request
+from research.qre_next_action_classifier import classify_next_action
+
+
+def _cycle() -> dict:
+    return {
+        "cycle_id": "cycle-1",
+        "source_research_run_id": "research-run-2",
+        "source_research_run_group_id": "research-group",
+        "next_market_intake_seed": {
+            "seed_id": "seed-1",
+            "statement": "keep same universe",
+        },
+        "result_analysis": {
+            "content_blockers": ["safe_metric_runner_missing_or_cache_unavailable"]
+        },
+    }
+
+
+def test_build_request_packet_is_artifact_only_and_actionable() -> None:
+    packet = build_request_packet(
+        source_cycle=_cycle(),
+        classification=classify_next_action("add_cache_only_metric_path"),
+        created_at_utc="2026-06-13T00:00:00Z",
+    )
+
+    assert packet["request_id"].startswith("build-request-")
+    assert packet["safe_for_ade_build"] is True
+    assert packet["execution_allowed"] is False
+    assert packet["build_executed_by_this_controller"] is False
+    assert packet["recommended_branch"] == "feat/qre-add-cache-only-metric-path"
+    assert "public_research_output_mutation" in packet["forbidden_actions"]
+    assert packet["post_merge_research_command"] == (
+        "python -m research.qre_autonomous_market_research_loop --write --max-cycles 3"
+    )
+
+
+def test_write_build_request_writes_required_files(tmp_path: Path) -> None:
+    packet = build_request_packet(
+        source_cycle=_cycle(),
+        classification=classify_next_action("add_cache_only_metric_path"),
+        created_at_utc="2026-06-13T00:00:00Z",
+    )
+
+    paths = write_build_request(packet, output_dir=tmp_path)
+
+    assert Path(paths["json"]).exists()
+    assert Path(paths["markdown"]).exists()
+    assert Path(paths["latest"]).name == "latest_build_request.json"
+    parsed = json.loads(Path(paths["latest"]).read_text(encoding="utf-8"))
+    assert parsed["request_id"] == packet["request_id"]
+    assert "QRE Build Request" in Path(paths["markdown"]).read_text(encoding="utf-8")
+
+
+def test_existing_build_request_is_not_recreated_when_overwrite_false(tmp_path: Path) -> None:
+    packet = build_request_packet(
+        source_cycle=_cycle(),
+        classification=classify_next_action("add_cache_only_metric_path"),
+        created_at_utc="2026-06-13T00:00:00Z",
+    )
+
+    first = write_build_request(packet, output_dir=tmp_path, overwrite=False)
+    second = write_build_request(packet, output_dir=tmp_path, overwrite=False)
+
+    assert first["created"] is True
+    assert second["created"] is False
+

--- a/tests/unit/test_qre_daily_status_digest.py
+++ b/tests/unit/test_qre_daily_status_digest.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from research import qre_autonomous_market_research_loop as loop
+from research import qre_daily_status_digest as digest
+from tests.unit.test_qre_autonomous_market_research_loop import _controlled_packet
+
+
+def test_daily_digest_summarizes_many_cycles_and_build_lane(tmp_path: Path) -> None:
+    loop.run_autonomous_loop(
+        controlled_packet=_controlled_packet(),
+        output_dir=tmp_path / "loop",
+        max_cycles=40,
+        write=True,
+    )
+
+    packet = digest.run_daily_status_digest(
+        loop_latest_path=tmp_path / "loop" / "latest.json",
+        output_dir=tmp_path / "daily",
+        write=True,
+    )
+
+    assert packet["summary"]["autonomous_cycles"] == 40
+    assert packet["summary"]["market_intake_cycles"] == 40
+    assert packet["summary"]["controlled_research_inner_loops"] == 80
+    assert packet["summary"]["build_requests_created"] == 1
+    assert packet["summary"]["build_requests_pending"] == 1
+    assert packet["summary"]["trading_status"] == "disabled"
+    assert packet["safety"]["paper_shadow_live_allowed"] is False
+    assert packet["safety"]["broker_risk_allowed"] is False
+    assert packet["safety"]["execution_allowed"] is False
+
+    daily = (tmp_path / "daily" / "daily_status.md").read_text(encoding="utf-8")
+    assert "# QRE Daily Status" in daily
+    assert "Research intelligence progress:" in daily
+    assert "ADE/build progress:" in daily
+    assert "Latest recommendation: add_cache_only_metric_path" in daily
+    assert "The system does not rotate assets" in daily
+    assert (tmp_path / "daily" / "scheduler_setup.md").exists()
+
+
+def test_daily_digest_recognizes_merged_build_result(tmp_path: Path) -> None:
+    loop_packet = loop.run_autonomous_loop(
+        controlled_packet=_controlled_packet(),
+        output_dir=tmp_path / "loop",
+        max_cycles=1,
+        write=True,
+    )
+    request_id = loop_packet["_artifact_paths"]["build_request"]["request_id"]
+    results_dir = tmp_path / "loop" / "build_results"
+    results_dir.mkdir()
+    (results_dir / f"{request_id}.json").write_text(
+        json.dumps(
+            {
+                "request_id": request_id,
+                "pr_number": 524,
+                "merge_commit": "abc123",
+                "status": "merged",
+                "created_at_utc": "2026-06-13T00:00:00Z",
+                "updated_main_commit": "abc123",
+                "post_merge_research_required": True,
+                "blocker_to_check": "safe_metric_runner_missing_or_cache_unavailable",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    packet = digest.build_daily_status_packet(loop_latest_path=tmp_path / "loop" / "latest.json")
+
+    assert packet["summary"]["build_requests_pending"] == 0
+    assert packet["summary"]["build_requests_completed_or_merged"] == 1
+    assert packet["next_system_action"] == "Continue bounded autonomous market-research cycles."
+

--- a/tests/unit/test_qre_next_action_classifier.py
+++ b/tests/unit/test_qre_next_action_classifier.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from research.qre_next_action_classifier import classify_next_action
+
+
+def test_metric_action_is_code_required_safe_to_plan_not_execute() -> None:
+    result = classify_next_action("add_cache_only_metric_path")
+
+    assert result["action_class"] == "code_required"
+    assert result["safety_class"] == "safe_to_plan_requires_pr"
+    assert result["ade_build_allowed"] is True
+    assert result["execution_allowed"] is False
+    assert result["recommended_branch"] == "feat/qre-add-cache-only-metric-path"
+    assert "paper_shadow_live" in result["blocked_authorities"]
+
+
+def test_metric_rule_is_pattern_based_not_one_off() -> None:
+    for action in (
+        "add_safe_trade_count_metric",
+        "add_safe_drawdown_metric",
+        "add_safe_deflated_sharpe_metric",
+        "repair_cache_or_add_safe_metric_input",
+        "add_result_to_market_intake_feedback",
+    ):
+        result = classify_next_action(action)
+        assert result["action_class"] == "code_required"
+        assert result["ade_build_allowed"] is True
+        assert result["execution_allowed"] is False
+
+
+def test_reporting_action_is_reporting_or_ux_code_required() -> None:
+    result = classify_next_action("add_universe_coverage_report")
+
+    assert result["action_class"] == "reporting_or_ux_code_required"
+    assert result["safety_class"] == "safe_to_plan_requires_pr"
+    assert result["ade_build_allowed"] is True
+
+
+def test_unsafe_actions_are_blocked_denylist_first() -> None:
+    for action in (
+        "enable_paper_runtime",
+        "enable_shadow_mode",
+        "activate_live_runtime",
+        "broker_order_path",
+        "execution_router",
+        "place_order_now",
+        "trade_signal_emit",
+        "promote_candidate_alpha",
+        "launch_campaign_direct",
+        "mutate_preset_registry",
+    ):
+        result = classify_next_action(action)
+        assert result["action_class"] == "blocked"
+        assert result["safety_class"] == "unsafe_requires_explicit_separate_governance"
+        assert result["ade_build_allowed"] is False
+        assert result["execution_allowed"] is False
+
+
+def test_hold_and_unknown_fail_closed() -> None:
+    hold = classify_next_action("operator_review_required")
+    unknown = classify_next_action("invent_new_autonomy_mode")
+
+    assert hold["action_class"] == "review_required"
+    assert hold["ade_build_allowed"] is False
+    assert unknown["action_class"] == "unknown"
+    assert unknown["safety_class"] == "fail_closed_human_review_required"
+    assert unknown["ade_build_allowed"] is False
+    assert unknown["execution_allowed"] is False
+

--- a/tests/unit/test_qre_pr_auto_merge_gate.py
+++ b/tests/unit/test_qre_pr_auto_merge_gate.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from research import qre_pr_auto_merge_gate as gate
+from tests.unit.test_qre_build_request_consumer import _build_request
+
+
+def _safe_pr() -> dict:
+    return {
+        "number": 524,
+        "branch": "feat/qre-add-cache-only-metric-path",
+        "title": "feat: add cache only metric path",
+        "ci_status": "green",
+        "mergeable": True,
+        "changed_files": [
+            "research/qre_cache_only_metric_path.py",
+            "tests/unit/test_qre_cache_only_metric_path.py",
+        ],
+    }
+
+
+def test_pr_gate_blocks_unsafe_path_changes(tmp_path: Path) -> None:
+    pr = _safe_pr()
+    pr["changed_files"] = ["broker/live_adapter.py"]
+
+    snapshot = gate.run_gate(
+        build_request_path=_build_request(tmp_path),
+        pr_metadata=pr,
+        env={"QRE_AUTO_MERGE_GREEN": "true"},
+    )
+
+    assert snapshot["auto_merge_allowed"] is False
+    assert snapshot["manual_governance_required"] is True
+    assert "forbidden_paths_touched" in snapshot["blocked_reasons"]
+
+
+def test_pr_gate_blocks_non_green_ci(tmp_path: Path) -> None:
+    pr = _safe_pr()
+    pr["ci_status"] = "failure"
+
+    snapshot = gate.run_gate(
+        build_request_path=_build_request(tmp_path),
+        pr_metadata=pr,
+        env={"QRE_AUTO_MERGE_GREEN": "true"},
+    )
+
+    assert snapshot["auto_merge_allowed"] is False
+    assert "ci_not_green" in snapshot["blocked_reasons"]
+
+
+def test_pr_gate_allows_auto_merge_only_for_safe_mocked_green_pr(tmp_path: Path) -> None:
+    calls: list[list[str]] = []
+
+    def runner(cmd: list[str]) -> tuple[int, str, str]:
+        calls.append(cmd)
+        return (0, "merged", "")
+
+    snapshot = gate.run_gate(
+        build_request_path=_build_request(tmp_path),
+        pr_metadata=_safe_pr(),
+        env={"QRE_AUTO_MERGE_GREEN": "true"},
+        command_runner=runner,
+        write=True,
+        output_dir=tmp_path / "gate",
+    )
+
+    assert snapshot["auto_merge_allowed"] is True
+    assert snapshot["pr_auto_merged"] is True
+    assert calls == [["gh", "pr", "merge", "524", "--squash", "--delete-branch"]]
+    assert (tmp_path / "gate" / "latest.json").exists()
+
+
+def test_pr_gate_requires_explicit_auto_merge_flag(tmp_path: Path) -> None:
+    snapshot = gate.run_gate(
+        build_request_path=_build_request(tmp_path),
+        pr_metadata=_safe_pr(),
+        env={},
+    )
+
+    assert snapshot["auto_merge_allowed"] is False
+    assert "auto_merge_not_enabled" in snapshot["blocked_reasons"]
+

--- a/tests/unit/test_qre_research_development_flywheel.py
+++ b/tests/unit/test_qre_research_development_flywheel.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from research import qre_daily_status_digest as digest
+from research import qre_research_development_flywheel as flywheel
+from tests.unit.test_qre_autonomous_market_research_loop import _controlled_packet
+
+
+def _build_runner(cmd: list[str], env: dict[str, str]) -> tuple[int, str, str]:
+    return (
+        0,
+        json.dumps(
+            {
+                "build_request_consumed": True,
+                "build_started": True,
+                "branch_created": True,
+                "code_changed": True,
+                "tests_run": True,
+                "pr_created": True,
+                "pr_metadata": {
+                    "number": 524,
+                    "branch": "feat/qre-add-cache-only-metric-path",
+                    "title": "feat: add cache only metric path",
+                    "ci_status": "green",
+                    "mergeable": True,
+                    "changed_files": [
+                        "research/qre_cache_only_metric_path.py",
+                        "tests/unit/test_qre_cache_only_metric_path.py",
+                    ],
+                },
+            }
+        ),
+        "",
+    )
+
+
+def _merge_runner(cmd: list[str]) -> tuple[int, str, str]:
+    return (0, "merged", "")
+
+
+def _runtime_runner(cmd: list[str]) -> tuple[int, str, str]:
+    return (0, "ok", "")
+
+
+def test_flywheel_no_backend_fails_closed_at_build_consumption(tmp_path: Path) -> None:
+    packet = flywheel.run_flywheel(
+        output_dir=tmp_path / "flywheel",
+        max_cycles=3,
+        max_builds=1,
+        write=True,
+        env={},
+        controlled_packet=_controlled_packet(),
+    )
+
+    assert packet["states"]["build_request_created"] is True
+    assert packet["states"]["build_request_consumed"] is False
+    assert packet["summary"]["build_requests_created"] == 1
+    assert packet["summary"]["build_requests_consumed"] == 0
+    assert "no_safe_build_backend_configured" in packet["summary"]["manual_governance_blockers"]
+    assert packet["summary"]["protected_outputs_mutated"] is False
+
+
+def test_flywheel_full_mocked_research_build_merge_continuation_path(tmp_path: Path) -> None:
+    packet = flywheel.run_flywheel(
+        output_dir=tmp_path / "flywheel",
+        max_cycles=3,
+        max_builds=1,
+        write=True,
+        env={
+            "QRE_BUILD_BACKEND": "codex_cli",
+            "QRE_BUILD_COMMAND": "codex exec %QRE_BUILD_REQUEST_PATH%",
+            "QRE_AUTO_PR": "true",
+            "QRE_AUTO_MERGE_GREEN": "true",
+            "QRE_RUNTIME_UPDATE": "true",
+        },
+        build_command_runner=_build_runner,
+        merge_command_runner=_merge_runner,
+        runtime_command_runner=_runtime_runner,
+        controlled_packet=_controlled_packet(),
+    )
+
+    assert packet["states"] == {
+        "build_request_created": True,
+        "build_request_consumed": True,
+        "build_started": True,
+        "branch_created": True,
+        "code_changed": True,
+        "tests_run": True,
+        "pr_created": True,
+        "ci_observed": True,
+        "pr_green": True,
+        "pr_auto_merged": True,
+        "runtime_updated": True,
+        "research_continuation_started": True,
+        "research_blocked": False,
+        "unsafe_action_blocked": False,
+    }
+    assert packet["summary"]["prs_merged"] == 1
+    assert packet["summary"]["research_continuations_started"] == 1
+    assert packet["summary"]["execution_allowed"] is False
+    assert packet["summary"]["paper_shadow_live_allowed"] is False
+    assert packet["summary"]["broker_risk_allowed"] is False
+
+
+def test_flywheel_respects_zero_max_builds(tmp_path: Path) -> None:
+    packet = flywheel.run_flywheel(
+        output_dir=tmp_path / "flywheel",
+        max_cycles=2,
+        max_builds=0,
+        write=True,
+        controlled_packet=_controlled_packet(),
+    )
+
+    assert packet["summary"]["research_cycles_completed"] == 2
+    assert packet["states"]["build_request_created"] is True
+    assert packet["states"]["build_request_consumed"] is False
+
+
+def test_daily_digest_includes_flywheel_state(tmp_path: Path) -> None:
+    flywheel.run_flywheel(
+        output_dir=tmp_path / "flywheel",
+        max_cycles=3,
+        max_builds=1,
+        write=True,
+        env={},
+        controlled_packet=_controlled_packet(),
+    )
+    packet = digest.run_daily_status_digest(
+        loop_latest_path=Path("logs/qre_autonomous_market_research_loop/latest.json"),
+        flywheel_latest_path=tmp_path / "flywheel" / "latest.json",
+        output_dir=tmp_path / "daily",
+        write=True,
+    )
+    text = (tmp_path / "daily" / "daily_status.md").read_text(encoding="utf-8")
+
+    assert packet["summary"]["build_requests_consumed"] == 0
+    assert packet["summary"]["prs_opened"] == 0
+    assert "Build requests consumed:" in text
+    assert "PRs merged:" in text
+    assert "Manual governance blockers:" in text

--- a/tests/unit/test_qre_runtime_update_and_continue.py
+++ b/tests/unit/test_qre_runtime_update_and_continue.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 from research import qre_runtime_update_and_continue as cont
+from tests.unit.test_qre_autonomous_market_research_loop import _controlled_packet
 
 
 def _merge_result(tmp_path: Path) -> Path:
@@ -34,6 +35,7 @@ def test_runtime_continuation_runs_research_after_mocked_merge_update(tmp_path: 
         max_cycles=1,
         write=True,
         command_runner=runner,
+        controlled_packet=_controlled_packet(),
     )
 
     assert snapshot["runtime_updated"] is True
@@ -55,4 +57,3 @@ def test_runtime_continuation_fails_closed_without_merge_result(tmp_path: Path) 
     assert snapshot["runtime_updated"] is False
     assert snapshot["research_continuation_started"] is False
     assert "merge_result_missing" in snapshot["blocked_reasons"]
-

--- a/tests/unit/test_qre_runtime_update_and_continue.py
+++ b/tests/unit/test_qre_runtime_update_and_continue.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from research import qre_runtime_update_and_continue as cont
+
+
+def _merge_result(tmp_path: Path) -> Path:
+    path = tmp_path / "merge.json"
+    path.write_text(
+        json.dumps(
+            {
+                "report_kind": "qre_pr_auto_merge_gate",
+                "pr_number": 524,
+                "pr_auto_merged": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_runtime_continuation_runs_research_after_mocked_merge_update(tmp_path: Path) -> None:
+    calls: list[list[str]] = []
+
+    def runner(cmd: list[str]) -> tuple[int, str, str]:
+        calls.append(cmd)
+        return (0, "ok", "")
+
+    snapshot = cont.run_continuation(
+        merge_result_path=_merge_result(tmp_path),
+        output_dir=tmp_path / "out",
+        max_cycles=1,
+        write=True,
+        command_runner=runner,
+    )
+
+    assert snapshot["runtime_updated"] is True
+    assert snapshot["research_continuation_started"] is True
+    assert snapshot["research_cycles_started"] == 1
+    assert calls == [["git", "checkout", "main"], ["git", "pull", "--ff-only", "origin", "main"]]
+    assert snapshot["paper_shadow_live_allowed"] is False
+    assert snapshot["broker_risk_allowed"] is False
+    assert snapshot["execution_allowed"] is False
+
+
+def test_runtime_continuation_fails_closed_without_merge_result(tmp_path: Path) -> None:
+    snapshot = cont.run_continuation(
+        merge_result_path=tmp_path / "missing.json",
+        output_dir=tmp_path / "out",
+        write=True,
+    )
+
+    assert snapshot["runtime_updated"] is False
+    assert snapshot["research_continuation_started"] is False
+    assert "merge_result_missing" in snapshot["blocked_reasons"]
+

--- a/tools/qre_build_backend_adapter.py
+++ b/tools/qre_build_backend_adapter.py
@@ -1,0 +1,300 @@
+"""Adapter for QRE build-request backends.
+
+This script is intentionally thin: it receives a build-request JSON path,
+invokes an explicitly selected local backend (Codex or Claude), queries git/gh
+for the resulting branch/PR metadata, writes one backend-result JSON artifact,
+and prints the same JSON to stdout for ``qre_build_request_consumer``.
+
+It does not trade, call QRE runtime execution paths, or bypass repository gates.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Final
+
+
+SCHEMA_VERSION: Final[str] = "1.0"
+REPORT_KIND: Final[str] = "qre_build_backend_adapter_result"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_build_request_consumer/backend_results")
+BACKENDS: Final[tuple[str, ...]] = ("codex_cli", "claude_cli")
+
+
+class AdapterError(RuntimeError):
+    """Raised when adapter inputs are invalid."""
+
+
+def _utcnow() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _json_dumps(payload: Any) -> str:
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        parsed = json.loads(path.read_text(encoding="utf-8-sig"))
+    except OSError as exc:
+        raise AdapterError(f"build request unavailable: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise AdapterError(f"build request malformed: {path}") from exc
+    if not isinstance(parsed, dict):
+        raise AdapterError("build request must be a JSON object")
+    return parsed
+
+
+def _run(cmd: list[str], *, timeout: int = 3600) -> tuple[int, str, str]:
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return (-1, "", repr(exc))
+    return (result.returncode, result.stdout or "", result.stderr or "")
+
+
+def _prompt(request: dict[str, Any], request_path: Path) -> str:
+    acceptance = "\n".join(f"- {item}" for item in request.get("acceptance_commands") or [])
+    forbidden = "\n".join(f"- {item}" for item in request.get("forbidden_actions") or [])
+    scope = "\n".join(f"- {item}" for item in request.get("implementation_scope") or [])
+    return "\n".join(
+        [
+            "You are implementing a QRE build request in the current repository.",
+            "",
+            f"Build request path: {request_path.as_posix()}",
+            f"Request ID: {request.get('request_id')}",
+            f"Next action: {request.get('next_action')}",
+            f"Recommended branch: {request.get('recommended_branch')}",
+            f"Recommended PR title: {request.get('recommended_pr_title')}",
+            "",
+            "Implementation scope:",
+            scope,
+            "",
+            "Forbidden actions:",
+            forbidden,
+            "",
+            "Required acceptance commands:",
+            acceptance,
+            "",
+            "Requirements:",
+            "- Create/use the recommended branch.",
+            "- Implement only the requested safe development change.",
+            "- Run the listed tests/commands.",
+            "- Open a PR with the recommended title.",
+            "- Do not activate paper, shadow, live, broker, risk, or execution.",
+            "- Do not mutate research/research_latest.json or research/strategy_matrix.csv.",
+            "- Do not call broad run_research or campaign_launcher.",
+            "- Leave a concise final note with PR number/URL and tests run.",
+        ]
+    )
+
+
+def _backend_command(backend: str, prompt: str) -> list[str]:
+    if backend == "codex_cli":
+        return ["codex", "exec", "--sandbox", "danger-full-access", prompt]
+    if backend == "claude_cli":
+        return [
+            "claude",
+            "--print",
+            "--permission-mode",
+            "bypassPermissions",
+            "--output-format",
+            "text",
+            prompt,
+        ]
+    raise AdapterError(f"unsupported backend: {backend}")
+
+
+def _current_branch() -> str:
+    rc, out, _ = _run(["git", "branch", "--show-current"], timeout=60)
+    return out.strip() if rc == 0 else ""
+
+
+def _changed_paths(branch: str) -> list[str]:
+    if not branch:
+        return []
+    _run(["git", "fetch", "origin", "main"], timeout=120)
+    rc, out, _ = _run(["git", "diff", "--name-only", f"origin/main...{branch}"], timeout=120)
+    if rc != 0:
+        rc, out, _ = _run(["git", "diff", "--name-only", "origin/main...HEAD"], timeout=120)
+    return [line.strip().replace("\\", "/") for line in out.splitlines() if line.strip()] if rc == 0 else []
+
+
+def _pr_metadata(branch: str) -> dict[str, Any] | None:
+    if not branch:
+        return None
+    rc, out, _ = _run(
+        [
+            "gh",
+            "pr",
+            "view",
+            branch,
+            "--json",
+            "number,url,title,headRefName,statusCheckRollup,mergeable,changedFiles",
+        ],
+        timeout=120,
+    )
+    if rc != 0:
+        return None
+    try:
+        parsed = json.loads(out)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    checks = parsed.get("statusCheckRollup")
+    ci_status = "unknown"
+    if isinstance(checks, list) and checks:
+        conclusions = {str(item.get("conclusion") or item.get("status") or "").upper() for item in checks if isinstance(item, dict)}
+        if conclusions and conclusions <= {"SUCCESS", "COMPLETED", "NEUTRAL", "SKIPPED"}:
+            ci_status = "green"
+        elif any(item in conclusions for item in {"FAILURE", "CANCELLED", "TIMED_OUT", "ACTION_REQUIRED"}):
+            ci_status = "failure"
+        else:
+            ci_status = "pending"
+    return {
+        "number": parsed.get("number"),
+        "pr_number": parsed.get("number"),
+        "url": parsed.get("url"),
+        "pr_url": parsed.get("url"),
+        "title": parsed.get("title"),
+        "branch": parsed.get("headRefName") or branch,
+        "ci_status": ci_status,
+        "mergeable": parsed.get("mergeable") in {True, "MERGEABLE"},
+        "changed_files_count": parsed.get("changedFiles"),
+    }
+
+
+def _safe_for_auto_merge(request: dict[str, Any], changed_paths: list[str]) -> bool:
+    forbidden_prefixes = (
+        "broker/",
+        "execution/",
+        "risk/",
+        "paper/",
+        "shadow/",
+        "live/",
+        "automation/live",
+        ".github/workflows/",
+        ".github/CODEOWNERS",
+        ".claude/",
+    )
+    forbidden_exact = {"research/research_latest.json", "research/strategy_matrix.csv"}
+    if request.get("safe_for_ade_build") is not True or request.get("execution_allowed") is True:
+        return False
+    for path in changed_paths:
+        normalized = path.replace("\\", "/").lstrip("./")
+        if normalized in forbidden_exact or any(normalized.startswith(prefix) for prefix in forbidden_prefixes):
+            return False
+    return True
+
+
+def build_backend_result(
+    *,
+    build_request_path: Path,
+    backend: str,
+    execute: bool = True,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+) -> dict[str, Any]:
+    request = _read_json(build_request_path)
+    started_at = _utcnow()
+    backend_rc = 0
+    backend_stdout = ""
+    backend_stderr = ""
+    if execute:
+        backend_rc, backend_stdout, backend_stderr = _run(
+            _backend_command(backend, _prompt(request, build_request_path)),
+            timeout=7200,
+        )
+
+    branch = _current_branch()
+    changed = _changed_paths(branch)
+    metadata = _pr_metadata(branch)
+    pr_created = metadata is not None
+    if metadata is None:
+        metadata = {
+            "branch": branch,
+            "title": request.get("recommended_pr_title"),
+            "ci_status": "unknown",
+            "mergeable": False,
+            "changed_files": changed,
+        }
+    else:
+        metadata["changed_files"] = changed
+
+    tests_passed = bool(execute and backend_rc == 0)
+    safe_for_auto_merge = bool(
+        pr_created
+        and tests_passed
+        and metadata.get("branch") == request.get("recommended_branch")
+        and metadata.get("title") == request.get("recommended_pr_title")
+        and _safe_for_auto_merge(request, changed)
+    )
+    result = {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "created_at_utc": started_at,
+        "backend": backend,
+        "request_id": request.get("request_id"),
+        "build_request_path": build_request_path.as_posix(),
+        "build_request_consumed": backend_rc == 0 and pr_created,
+        "build_started": execute,
+        "branch_created": bool(branch and branch == request.get("recommended_branch")),
+        "code_changed": bool(changed),
+        "tests_run": bool(execute),
+        "pr_created": pr_created,
+        "pr_metadata": metadata,
+        "pr_number": metadata.get("number") or metadata.get("pr_number"),
+        "pr_url": metadata.get("url") or metadata.get("pr_url"),
+        "branch": metadata.get("branch"),
+        "pr_title": metadata.get("title"),
+        "tests_passed": tests_passed,
+        "safe_for_auto_merge": safe_for_auto_merge,
+        "changed_paths": changed,
+        "backend_returncode": backend_rc,
+        "backend_stdout_tail": backend_stdout[-4000:],
+        "backend_stderr_tail": backend_stderr[-4000:],
+        "paper_shadow_live_allowed": False,
+        "broker_risk_allowed": False,
+        "execution_allowed": False,
+        "campaign_launcher_called": False,
+        "run_research_called": False,
+    }
+    output_dir.mkdir(parents=True, exist_ok=True)
+    out_path = output_dir / f"{request.get('request_id')}.json"
+    out_path.write_text(_json_dumps(result), encoding="utf-8", newline="\n")
+    result["backend_result_path"] = out_path.as_posix()
+    out_path.write_text(_json_dumps(result), encoding="utf-8", newline="\n")
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run QRE build backend and emit consumer-compatible JSON.")
+    parser.add_argument("build_request", nargs="?", default=os.environ.get("QRE_BUILD_REQUEST_PATH", ""))
+    parser.add_argument("--backend", choices=BACKENDS, default=os.environ.get("QRE_BUILD_BACKEND", "codex_cli"))
+    parser.add_argument("--output-dir", default=DEFAULT_OUTPUT_DIR.as_posix())
+    parser.add_argument("--no-execute", action="store_true")
+    args = parser.parse_args(argv)
+    if not args.build_request:
+        raise SystemExit("build request path required")
+    result = build_backend_result(
+        build_request_path=Path(args.build_request),
+        backend=args.backend,
+        output_dir=Path(args.output_dir),
+        execute=not args.no_execute,
+    )
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds autonomous market-research loop controller.
Adds next-action classifier.
Adds build-request writer.
Adds build-request consumer.
Adds Codex/Claude backend adapter.
Adds PR auto-merge gate.
Adds runtime update and research continuation.
Adds daily status digest.

Default mode fails closed if no backend is configured.
Real backend support requires QRE_BUILD_BACKEND and QRE_BUILD_COMMAND.

Safety:
- No paper/shadow/live.
- No broker/risk/execution.
- No broad run_research.
- No campaign_launcher.
- No protected public output mutation.

Mocked tests prove research -> build -> PR -> merge -> continuation.

Validation run locally:
- python -m pytest tests/unit/test_qre_next_action_classifier.py -q
- python -m pytest tests/unit/test_qre_build_request_writer.py -q
- python -m pytest tests/unit/test_qre_autonomous_market_research_loop.py -q
- python -m pytest tests/unit/test_qre_daily_status_digest.py -q
- python -m pytest tests/unit/test_qre_build_request_consumer.py -q
- python -m pytest tests/unit/test_qre_pr_auto_merge_gate.py -q
- python -m pytest tests/unit/test_qre_runtime_update_and_continue.py -q
- python -m pytest tests/unit/test_qre_research_development_flywheel.py -q
- python -m pytest tests/unit/test_qre_controlled_research_run.py -q
- python -m research.qre_research_development_flywheel --write --max-cycles 3 --max-builds 1
- python -m research.qre_daily_status_digest --write
- git diff --check
- git diff -- research/research_latest.json research/strategy_matrix.csv
