### PR TITLE
fix: resolve Codex backend command on Windows

### DIFF
--- a/tests/unit/test_qre_build_backend_adapter.py
+++ b/tests/unit/test_qre_build_backend_adapter.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from tools import qre_build_backend_adapter as adapter
+
+
+def _build_request(tmp_path: Path) -> Path:
+    path = tmp_path / "latest_build_request.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0",
+                "report_kind": "qre_build_request",
+                "request_id": "build-request-test",
+                "safe_for_ade_build": True,
+                "execution_allowed": False,
+                "recommended_branch": "feat/qre-add-cache-only-metric-path",
+                "recommended_pr_title": "feat: add cache only metric path",
+                "acceptance_commands": [
+                    "python -m pytest tests/unit/test_qre_build_request_consumer.py -q"
+                ],
+                "forbidden_actions": ["paper_shadow_live", "broker_risk_execution"],
+                "implementation_scope": ["add safe cache-only metric path"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _runner(calls: list[list[str]]) -> Any:
+    def run(cmd: list[str], *, timeout: int = 3600) -> tuple[int, str, str]:
+        calls.append(cmd)
+        if cmd[:3] == ["git", "branch", "--show-current"]:
+            return (0, "main\n", "")
+        if cmd[:3] == ["git", "fetch", "origin"]:
+            return (0, "", "")
+        if cmd[:3] == ["git", "diff", "--name-only"]:
+            return (0, "", "")
+        if cmd[:3] == ["gh", "pr", "view"]:
+            return (1, "", "no pr")
+        return (0, "backend ok", "")
+
+    return run
+
+
+def _protected_bytes() -> dict[str, bytes | None]:
+    paths = [Path("research/research_latest.json"), Path("research/strategy_matrix.csv")]
+    return {path.as_posix(): path.read_bytes() if path.exists() else None for path in paths}
+
+
+def test_codex_command_override_is_used(monkeypatch: Any, tmp_path: Path) -> None:
+    calls: list[list[str]] = []
+    monkeypatch.setenv("QRE_CODEX_COMMAND", "custom-codex --profile qre")
+    monkeypatch.setattr(adapter, "_run", _runner(calls))
+
+    result = adapter.build_backend_result(
+        build_request_path=_build_request(tmp_path),
+        backend="codex_cli",
+        output_dir=tmp_path / "out",
+    )
+
+    assert calls[0][:2] == ["custom-codex", "--profile"]
+    assert "exec" in calls[0]
+    assert result["backend_command_resolved"] is True
+    assert result["backend_command_source"] == "command_env"
+    assert result["backend_command_path"] == "custom-codex"
+
+
+def test_codex_path_override_is_used(monkeypatch: Any, tmp_path: Path) -> None:
+    codex_path = tmp_path / "codex.cmd"
+    codex_path.write_text("@echo off\n", encoding="utf-8")
+    calls: list[list[str]] = []
+    monkeypatch.setenv("QRE_CODEX_PATH", str(codex_path))
+    monkeypatch.setattr(adapter, "_run", _runner(calls))
+
+    result = adapter.build_backend_result(
+        build_request_path=_build_request(tmp_path),
+        backend="codex_cli",
+        output_dir=tmp_path / "out",
+    )
+
+    assert calls[0][0] == str(codex_path)
+    assert result["backend_command_resolved"] is True
+    assert result["backend_command_source"] == "path_env"
+    assert result["backend_command_kind"] == "cmd"
+    assert result["backend_command_path"] == str(codex_path)
+
+
+def test_ps1_codex_path_is_wrapped_with_powershell(monkeypatch: Any, tmp_path: Path) -> None:
+    codex_path = tmp_path / "codex.ps1"
+    codex_path.write_text("Write-Output codex\n", encoding="utf-8")
+    calls: list[list[str]] = []
+    monkeypatch.setenv("QRE_CODEX_PATH", str(codex_path))
+    monkeypatch.setattr(adapter, "_run", _runner(calls))
+
+    result = adapter.build_backend_result(
+        build_request_path=_build_request(tmp_path),
+        backend="codex_cli",
+        output_dir=tmp_path / "out",
+    )
+
+    assert calls[0][:6] == [
+        "powershell",
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        str(codex_path),
+    ]
+    assert "exec" in calls[0]
+    assert result["backend_command_kind"] == "powershell_ps1"
+
+
+def test_missing_codex_fails_closed(monkeypatch: Any, tmp_path: Path) -> None:
+    monkeypatch.delenv("QRE_CODEX_COMMAND", raising=False)
+    monkeypatch.delenv("QRE_CODEX_PATH", raising=False)
+    monkeypatch.setattr(adapter.shutil, "which", lambda _: None)
+    monkeypatch.setattr(adapter, "KNOWN_WINDOWS_CODEX_PS1", tmp_path / "missing" / "codex.ps1")
+    calls: list[list[str]] = []
+    monkeypatch.setattr(adapter, "_run", _runner(calls))
+
+    result = adapter.build_backend_result(
+        build_request_path=_build_request(tmp_path),
+        backend="codex_cli",
+        output_dir=tmp_path / "out",
+    )
+
+    assert result["backend_command_resolved"] is False
+    assert result["blocked_reason"] == "codex_cli_not_found"
+    assert result["backend_returncode"] == -1
+    assert result["build_started"] is False
+    assert calls[0][:3] == ["git", "branch", "--show-current"]
+
+
+def test_adapter_emits_consumer_compatible_json(monkeypatch: Any, tmp_path: Path) -> None:
+    codex_path = tmp_path / "codex.exe"
+    codex_path.write_text("", encoding="utf-8")
+    monkeypatch.setenv("QRE_CODEX_PATH", str(codex_path))
+    monkeypatch.setattr(adapter, "_run", _runner([]))
+
+    result = adapter.build_backend_result(
+        build_request_path=_build_request(tmp_path),
+        backend="codex_cli",
+        output_dir=tmp_path / "out",
+        execute=False,
+    )
+    persisted = json.loads((tmp_path / "out" / "build-request-test.json").read_text(encoding="utf-8"))
+
+    for key in (
+        "build_request_consumed",
+        "build_started",
+        "branch_created",
+        "code_changed",
+        "tests_run",
+        "pr_created",
+        "pr_metadata",
+    ):
+        assert key in result
+        assert key in persisted
+    assert persisted["backend_command_resolved"] is True
+    assert persisted["backend_command_kind"] == "exe"
+
+
+def test_adapter_does_not_mutate_protected_artifacts(monkeypatch: Any, tmp_path: Path) -> None:
+    before = _protected_bytes()
+    codex_path = tmp_path / "codex.cmd"
+    codex_path.write_text("@echo off\n", encoding="utf-8")
+    monkeypatch.setenv("QRE_CODEX_PATH", str(codex_path))
+    monkeypatch.setattr(adapter, "_run", _runner([]))
+
+    adapter.build_backend_result(
+        build_request_path=_build_request(tmp_path),
+        backend="codex_cli",
+        output_dir=tmp_path / "out",
+        execute=False,
+    )
+
+    assert _protected_bytes() == before

--- a/tools/qre_build_backend_adapter.py
+++ b/tools/qre_build_backend_adapter.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shlex
+import shutil
 import subprocess
 from datetime import UTC, datetime
 from pathlib import Path
@@ -23,6 +25,7 @@ SCHEMA_VERSION: Final[str] = "1.0"
 REPORT_KIND: Final[str] = "qre_build_backend_adapter_result"
 DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_build_request_consumer/backend_results")
 BACKENDS: Final[tuple[str, ...]] = ("codex_cli", "claude_cli")
+KNOWN_WINDOWS_CODEX_PS1: Final[Path] = Path(r"C:\Users\joery.van.rooij\node\codex.ps1")
 
 
 class AdapterError(RuntimeError):
@@ -63,6 +66,128 @@ def _run(cmd: list[str], *, timeout: int = 3600) -> tuple[int, str, str]:
     return (result.returncode, result.stdout or "", result.stderr or "")
 
 
+def _command_parts(value: str) -> list[str]:
+    return shlex.split(value, posix=os.name != "nt")
+
+
+def _path_exists(path: str) -> bool:
+    try:
+        return Path(path).exists()
+    except OSError:
+        return False
+
+
+def _command_kind(path_or_command: str) -> str:
+    suffix = Path(path_or_command).suffix.lower()
+    if suffix == ".ps1":
+        return "powershell_ps1"
+    if suffix == ".cmd":
+        return "cmd"
+    if suffix == ".bat":
+        return "bat"
+    if suffix == ".exe":
+        return "exe"
+    return "executable"
+
+
+def _wrap_backend_command(base_command: list[str], backend_args: list[str]) -> list[str]:
+    if not base_command:
+        return []
+    command_path = base_command[0]
+    if Path(command_path).suffix.lower() == ".ps1":
+        return [
+            "powershell",
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            command_path,
+            *base_command[1:],
+            *backend_args,
+        ]
+    return [*base_command, *backend_args]
+
+
+def _resolve_backend_command(backend: str) -> dict[str, Any]:
+    if backend == "codex_cli":
+        command_override = os.environ.get("QRE_CODEX_COMMAND", "").strip()
+        path_override = os.environ.get("QRE_CODEX_PATH", "").strip()
+        executable = "codex"
+        missing_reason = "codex_cli_not_found"
+        known_fallback = KNOWN_WINDOWS_CODEX_PS1
+    elif backend == "claude_cli":
+        command_override = os.environ.get("QRE_CLAUDE_COMMAND", "").strip()
+        path_override = os.environ.get("QRE_CLAUDE_PATH", "").strip()
+        executable = "claude"
+        missing_reason = "claude_cli_not_found"
+        known_fallback = None
+    else:
+        raise AdapterError(f"unsupported backend: {backend}")
+
+    source = ""
+    base_command: list[str] = []
+    command_path = ""
+    if command_override:
+        source = "command_env"
+        base_command = _command_parts(command_override)
+        command_path = base_command[0] if base_command else command_override
+    elif path_override:
+        source = "path_env"
+        command_path = path_override
+        if not _path_exists(command_path):
+            return {
+                "resolved": False,
+                "source": source,
+                "kind": "missing",
+                "path": command_path,
+                "base_command": [],
+                "blocked_reason": missing_reason,
+                "stderr": f"{backend} path not found: {command_path}",
+            }
+        base_command = [command_path]
+    else:
+        discovered = shutil.which(executable)
+        if discovered:
+            source = "path_lookup"
+            command_path = discovered
+            base_command = [discovered]
+        elif known_fallback is not None and known_fallback.exists():
+            source = "known_windows_fallback"
+            command_path = str(known_fallback)
+            base_command = [command_path]
+        else:
+            return {
+                "resolved": False,
+                "source": "not_found",
+                "kind": "missing",
+                "path": "",
+                "base_command": [],
+                "blocked_reason": missing_reason,
+                "stderr": f"{backend} command not found",
+            }
+
+    if not base_command:
+        return {
+            "resolved": False,
+            "source": source,
+            "kind": "missing",
+            "path": command_path,
+            "base_command": [],
+            "blocked_reason": missing_reason,
+            "stderr": f"{backend} command was empty",
+        }
+
+    return {
+        "resolved": True,
+        "source": source,
+        "kind": _command_kind(command_path),
+        "path": command_path,
+        "base_command": base_command,
+        "blocked_reason": None,
+        "stderr": "",
+    }
+
+
 def _prompt(request: dict[str, Any], request_path: Path) -> str:
     acceptance = "\n".join(f"- {item}" for item in request.get("acceptance_commands") or [])
     forbidden = "\n".join(f"- {item}" for item in request.get("forbidden_actions") or [])
@@ -99,12 +224,11 @@ def _prompt(request: dict[str, Any], request_path: Path) -> str:
     )
 
 
-def _backend_command(backend: str, prompt: str) -> list[str]:
+def _backend_args(backend: str, prompt: str) -> list[str]:
     if backend == "codex_cli":
-        return ["codex", "exec", "--sandbox", "danger-full-access", prompt]
+        return ["exec", "--sandbox", "danger-full-access", prompt]
     if backend == "claude_cli":
         return [
-            "claude",
             "--print",
             "--permission-mode",
             "bypassPermissions",
@@ -210,11 +334,19 @@ def build_backend_result(
     backend_rc = 0
     backend_stdout = ""
     backend_stderr = ""
-    if execute:
-        backend_rc, backend_stdout, backend_stderr = _run(
-            _backend_command(backend, _prompt(request, build_request_path)),
-            timeout=7200,
+    backend_resolution = _resolve_backend_command(backend)
+    backend_command: list[str] = []
+    blocked_reason = backend_resolution.get("blocked_reason")
+    if backend_resolution["resolved"]:
+        backend_command = _wrap_backend_command(
+            list(backend_resolution["base_command"]),
+            _backend_args(backend, _prompt(request, build_request_path)),
         )
+        if execute:
+            backend_rc, backend_stdout, backend_stderr = _run(backend_command, timeout=7200)
+    else:
+        backend_rc = -1
+        backend_stderr = str(backend_resolution.get("stderr") or blocked_reason or "")
 
     branch = _current_branch()
     changed = _changed_paths(branch)
@@ -231,7 +363,7 @@ def build_backend_result(
     else:
         metadata["changed_files"] = changed
 
-    tests_passed = bool(execute and backend_rc == 0)
+    tests_passed = bool(execute and backend_resolution["resolved"] and backend_rc == 0)
     safe_for_auto_merge = bool(
         pr_created
         and tests_passed
@@ -246,11 +378,15 @@ def build_backend_result(
         "backend": backend,
         "request_id": request.get("request_id"),
         "build_request_path": build_request_path.as_posix(),
-        "build_request_consumed": backend_rc == 0 and pr_created,
-        "build_started": execute,
+        "build_request_consumed": backend_resolution["resolved"] and backend_rc == 0 and pr_created,
+        "build_started": bool(execute and backend_resolution["resolved"]),
+        "backend_command_resolved": backend_resolution["resolved"],
+        "backend_command_source": backend_resolution["source"],
+        "backend_command_kind": backend_resolution["kind"],
+        "backend_command_path": backend_resolution["path"],
         "branch_created": bool(branch and branch == request.get("recommended_branch")),
         "code_changed": bool(changed),
-        "tests_run": bool(execute),
+        "tests_run": bool(execute and backend_resolution["resolved"]),
         "pr_created": pr_created,
         "pr_metadata": metadata,
         "pr_number": metadata.get("number") or metadata.get("pr_number"),
@@ -263,6 +399,7 @@ def build_backend_result(
         "backend_returncode": backend_rc,
         "backend_stdout_tail": backend_stdout[-4000:],
         "backend_stderr_tail": backend_stderr[-4000:],
+        "blocked_reason": blocked_reason,
         "paper_shadow_live_allowed": False,
         "broker_risk_allowed": False,
         "execution_allowed": False,


### PR DESCRIPTION
## Summary
- resolve Codex/Claude backend commands through explicit env overrides, PATH lookup, and Windows codex.ps1 fallback
- wrap PowerShell shims with powershell -NoProfile -ExecutionPolicy Bypass -File
- emit backend command diagnostics and fail closed with codex_cli_not_found when unavailable

## Tests
- python -m pytest tests/unit/test_qre_build_backend_adapter.py -q
- python -m pytest tests/unit/test_qre_build_request_consumer.py -q
- python -m pytest tests/unit/test_qre_research_development_flywheel.py -q
- python -m research.qre_autonomous_market_research_loop --write --max-cycles 3
- git diff --check
- git diff -- research/research_latest.json research/strategy_matrix.csv
- QRE_CODEX_PATH no-execute adapter check

## Safety
- No paper/shadow/live
- No broker/risk/execution
- No broad run_research or campaign_launcher execution
- Protected public research outputs unchanged