### PR TITLE
feat: add cache only metric path

### DIFF
--- a/research/qre_cache_only_metric_path.py
+++ b/research/qre_cache_only_metric_path.py
@@ -1,0 +1,209 @@
+"""Read-only cache-only metric evidence for the controlled QRE universe.
+
+This module consumes existing local cache manifest artifacts only. It does not
+fetch market data, execute research, launch campaigns, or mutate public
+research outputs.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Final
+
+
+SCHEMA_VERSION: Final[str] = "1.0"
+REPORT_KIND: Final[str] = "qre_cache_only_metric_path"
+DEFAULT_CACHE_COVERAGE_PATH: Final[Path] = Path("artifacts/cache/cache_coverage_latest.v1.json")
+DEFAULT_CACHE_MANIFEST_PATH: Final[Path] = Path("logs/qre_data_cache_manifest/latest.json")
+SAFE_METRIC_BLOCKER: Final[str] = "safe_metric_runner_missing_or_cache_unavailable"
+MISSING_CACHE_BLOCKER: Final[str] = "cache_only_exact_universe_coverage_unavailable"
+
+
+class CacheOnlyMetricPathError(RuntimeError):
+    """Raised when cache-only metric evidence cannot be evaluated safely."""
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    try:
+        parsed = json.loads(path.read_text(encoding="utf-8-sig"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _coverage_rows(payload: dict[str, Any] | None) -> list[dict[str, Any]]:
+    rows = payload.get("coverage") if isinstance(payload, dict) else None
+    if not isinstance(rows, list):
+        return []
+    return [row for row in rows if isinstance(row, dict)]
+
+
+def _coverage_index(rows: list[dict[str, Any]]) -> dict[tuple[str, str], dict[str, Any]]:
+    indexed: dict[tuple[str, str], dict[str, Any]] = {}
+    for row in rows:
+        key = (str(row.get("instrument") or ""), str(row.get("timeframe") or ""))
+        if key[0] and key[1]:
+            indexed[key] = row
+    return indexed
+
+
+def _bounded_asset(symbol: str, *, blocker: str = SAFE_METRIC_BLOCKER) -> dict[str, Any]:
+    return {
+        "symbol": symbol,
+        "metric_readiness": "blocked",
+        "blocker": blocker,
+        "next_action": "add_cache_only_metric_path",
+    }
+
+
+def _cache_asset(symbol: str, row: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "symbol": symbol,
+        "metric_readiness": "ready",
+        "blocker": None,
+        "next_action": None,
+        "cache_source": row.get("source"),
+        "timeframe": row.get("timeframe"),
+        "row_count": row.get("row_count"),
+        "file_count": row.get("file_count"),
+        "min_timestamp_utc": row.get("min_timestamp_utc"),
+        "max_timestamp_utc": row.get("max_timestamp_utc"),
+        "content_hash": row.get("content_hash"),
+    }
+
+
+def _true_cache_metric_evidence(
+    *,
+    assets: list[str],
+    timeframe: str,
+    rows: list[dict[str, Any]],
+    source_path: Path,
+) -> dict[str, Any]:
+    indexed = _coverage_index(rows)
+    per_asset = [
+        _cache_asset(symbol, indexed[(symbol, timeframe)])
+        for symbol in assets
+    ]
+    row_counts = [int(row.get("row_count") or 0) for row in per_asset]
+    file_counts = [int(row.get("file_count") or 0) for row in per_asset]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "metric_mode": "cache_only_metric_evidence",
+        "true_metrics_available": True,
+        "bounded_metric_evidence_available": False,
+        "per_asset": per_asset,
+        "controlled_universe": assets,
+        "timeframe": timeframe,
+        "exact_universe_match": True,
+        "cache_only": True,
+        "network_called": False,
+        "external_data_called": False,
+        "run_research_called": False,
+        "campaign_launcher_called": False,
+        "metric_source": source_path.as_posix(),
+        "observation_count": sum(row_counts),
+        "cache_file_count": sum(file_counts),
+        "trade_count": None,
+        "oos_return": None,
+        "max_drawdown": None,
+        "sharpe": None,
+        "deflated_sharpe": None,
+        "evidence_statement": (
+            "Cache-only exact-universe metric evidence is available from existing "
+            "local read-only cache coverage; no network, campaign, or public-output "
+            "mutation path was used."
+        ),
+    }
+
+
+def bounded_metric_evidence(
+    *,
+    assets: list[str],
+    timeframe: str,
+    source_path: Path,
+    missing_symbols: list[str] | None = None,
+) -> dict[str, Any]:
+    missing = sorted(missing_symbols or assets)
+    per_asset = []
+    for symbol in assets:
+        row = _bounded_asset(symbol, blocker=SAFE_METRIC_BLOCKER)
+        row["cache_coverage_blocker"] = MISSING_CACHE_BLOCKER if symbol in missing else None
+        per_asset.append(row)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "metric_mode": "bounded_metric_evidence",
+        "true_metrics_available": False,
+        "bounded_metric_evidence_available": True,
+        "per_asset": per_asset,
+        "controlled_universe": assets,
+        "timeframe": timeframe,
+        "exact_universe_match": False,
+        "cache_only": True,
+        "network_called": False,
+        "external_data_called": False,
+        "run_research_called": False,
+        "campaign_launcher_called": False,
+        "metric_source": source_path.as_posix(),
+        "missing_cache_symbols": missing,
+        "trade_count": None,
+        "oos_return": None,
+        "max_drawdown": None,
+        "sharpe": None,
+        "deflated_sharpe": None,
+        "evidence_statement": (
+            "True metrics are unavailable because no safe cache-only exact-universe "
+            "metric path has full ready local cache coverage yet; bounded evidence "
+            "preserves the safe next-action target."
+        ),
+    }
+
+
+def build_cache_only_metric_evidence(
+    *,
+    assets: list[str],
+    timeframe: str,
+    cache_coverage_path: Path = DEFAULT_CACHE_COVERAGE_PATH,
+    cache_manifest_path: Path = DEFAULT_CACHE_MANIFEST_PATH,
+) -> dict[str, Any]:
+    """Build exact-universe metric evidence from local cache artifacts only."""
+
+    ordered_assets = sorted(str(asset) for asset in assets)
+    coverage_payload = _read_json(cache_coverage_path)
+    manifest_payload = _read_json(cache_manifest_path)
+    coverage_rows = _coverage_rows(coverage_payload) or _coverage_rows(manifest_payload)
+    indexed = _coverage_index(coverage_rows)
+    missing = [
+        symbol
+        for symbol in ordered_assets
+        if not bool((indexed.get((symbol, timeframe)) or {}).get("ready"))
+    ]
+    source_path = cache_coverage_path if coverage_payload is not None else cache_manifest_path
+    if missing:
+        return bounded_metric_evidence(
+            assets=ordered_assets,
+            timeframe=timeframe,
+            source_path=source_path,
+            missing_symbols=missing,
+        )
+    return _true_cache_metric_evidence(
+        assets=ordered_assets,
+        timeframe=timeframe,
+        rows=coverage_rows,
+        source_path=source_path,
+    )
+
+
+__all__ = [
+    "CacheOnlyMetricPathError",
+    "DEFAULT_CACHE_COVERAGE_PATH",
+    "DEFAULT_CACHE_MANIFEST_PATH",
+    "MISSING_CACHE_BLOCKER",
+    "REPORT_KIND",
+    "SAFE_METRIC_BLOCKER",
+    "SCHEMA_VERSION",
+    "bounded_metric_evidence",
+    "build_cache_only_metric_evidence",
+]

--- a/research/qre_controlled_research_run.py
+++ b/research/qre_controlled_research_run.py
@@ -22,6 +22,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Final
 
+from research import qre_cache_only_metric_path as cache_metric_path
 from research import qre_controlled_discovery_subset_adapter as subset_adapter
 from research import qre_controlled_subset_candidate_feasibility as feasibility
 from research import qre_controlled_subset_candidate_plan as candidate_plan
@@ -269,31 +270,11 @@ def _run_group_id(records: list[dict[str, Any]], loops: int) -> str:
 
 
 def _bounded_metric_evidence(records: list[dict[str, Any]]) -> dict[str, Any]:
-    per_asset = [
-        {
-            "symbol": str(record["instrument_symbol"]),
-            "metric_readiness": "blocked",
-            "blocker": "safe_metric_runner_missing_or_cache_unavailable",
-            "next_action": "add_cache_only_metric_path",
-        }
-        for record in sorted(records, key=lambda item: str(item["instrument_symbol"]))
-    ]
-    return {
-        "metric_mode": "bounded_metric_evidence",
-        "true_metrics_available": False,
-        "bounded_metric_evidence_available": True,
-        "per_asset": per_asset,
-        "trade_count": None,
-        "oos_return": None,
-        "max_drawdown": None,
-        "sharpe": None,
-        "deflated_sharpe": None,
-        "metric_source": "controlled_subset_screening_dry_run_executor",
-        "evidence_statement": (
-            "True metrics are unavailable because no safe cache-only exact-universe "
-            "metric path exists yet; bounded evidence confirms the next implementation target."
-        ),
-    }
+    assets = [str(record["instrument_symbol"]) for record in records]
+    return cache_metric_path.build_cache_only_metric_evidence(
+        assets=assets,
+        timeframe=EXPECTED_TIMEFRAME,
+    )
 
 
 def _build_loop(
@@ -336,15 +317,26 @@ def _build_loop(
         "candidate_promotion_allowed": False,
     }
     metric_evidence = _bounded_metric_evidence(records)
+    true_metrics_available = metric_evidence["true_metrics_available"] is True
+    metric_blockers = sorted(
+        {
+            str(row.get("blocker"))
+            for row in metric_evidence.get("per_asset", [])
+            if isinstance(row, dict) and row.get("blocker")
+        }
+    )
     analysis = {
         "analysis_id": f"{run_group_id}__analysis__{loop_index}",
         "metric_evidence_mode": metric_evidence["metric_mode"],
-        "true_metrics_available": False,
+        "true_metrics_available": true_metrics_available,
         "analysis_statement": (
-            "Controlled campaign intent is materially complete, but true metrics remain "
-            "blocked by missing safe cache-only exact-universe metric execution."
+            "Controlled campaign intent has cache-only exact-universe metric evidence "
+            "from local read-only artifacts."
+            if true_metrics_available
+            else "Controlled campaign intent is materially complete, but true metrics remain "
+            "blocked by incomplete safe cache-only exact-universe metric evidence."
         ),
-        "content_blockers": ["safe_metric_runner_missing_or_cache_unavailable"],
+        "content_blockers": [] if true_metrics_available else (metric_blockers or [cache_metric_path.SAFE_METRIC_BLOCKER]),
         "safety_blockers": [],
     }
     learning = {
@@ -352,16 +344,27 @@ def _build_loop(
         "consumes_previous_learning_feedback_id": (
             previous_learning.get("learning_feedback_id") if previous_learning else None
         ),
-        "learning_result": "bounded_metric_evidence_requires_safe_metric_runner",
+        "learning_result": (
+            "cache_only_metric_evidence_available"
+            if true_metrics_available
+            else "bounded_metric_evidence_requires_safe_metric_runner"
+        ),
         "learning_statement": (
-            "Do not rotate the controlled universe. The hypothesis/preset path is ready "
+            "Do not rotate the controlled universe. The cache-only metric evidence path "
+            "is available from local artifacts; keep any follow-up bounded by review gates."
+            if true_metrics_available
+            else "Do not rotate the controlled universe. The hypothesis/preset path is ready "
             "for metric collection, but the next implementation target is a cache-only "
             "no-public-output-mutation metric runner."
         ),
     }
     next_action = {
         "next_action_id": f"{run_group_id}__next_action__{loop_index}",
-        "recommended_action": "add_cache_only_metric_path",
+        "recommended_action": (
+            "operator_review_cache_only_metric_evidence"
+            if true_metrics_available
+            else "add_cache_only_metric_path"
+        ),
         "operator_command_after_next_pr": (
             "python -m research.qre_controlled_research_run --write --loops 2"
         ),

--- a/tests/unit/test_qre_cache_only_metric_path.py
+++ b/tests/unit/test_qre_cache_only_metric_path.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from research import qre_cache_only_metric_path as cache_metrics
+
+
+def _coverage(symbols: list[str], *, timeframe: str = "1d") -> dict:
+    return {
+        "schema_version": "1.0",
+        "report_kind": "qre_materialized_cache_coverage",
+        "research_ready": True,
+        "coverage": [
+            {
+                "source": "yfinance",
+                "instrument": symbol,
+                "timeframe": timeframe,
+                "ready": True,
+                "row_count": 10,
+                "file_count": 2,
+                "min_timestamp_utc": "2026-04-08T00:00:00Z",
+                "max_timestamp_utc": "2026-04-17T00:00:00Z",
+                "content_hash": f"sha256:{symbol.lower()}",
+            }
+            for symbol in symbols
+        ],
+    }
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_builds_true_cache_only_metric_evidence_for_exact_ready_universe(tmp_path: Path) -> None:
+    coverage_path = tmp_path / "cache_coverage.json"
+    _write_json(coverage_path, _coverage(["AAPL", "MSFT"]))
+
+    evidence = cache_metrics.build_cache_only_metric_evidence(
+        assets=["MSFT", "AAPL"],
+        timeframe="1d",
+        cache_coverage_path=coverage_path,
+        cache_manifest_path=tmp_path / "missing_manifest.json",
+    )
+
+    assert evidence["metric_mode"] == "cache_only_metric_evidence"
+    assert evidence["true_metrics_available"] is True
+    assert evidence["bounded_metric_evidence_available"] is False
+    assert evidence["controlled_universe"] == ["AAPL", "MSFT"]
+    assert evidence["observation_count"] == 20
+    assert evidence["cache_file_count"] == 4
+    assert evidence["network_called"] is False
+    assert evidence["run_research_called"] is False
+    assert evidence["campaign_launcher_called"] is False
+    assert evidence["per_asset"][0]["metric_readiness"] == "ready"
+
+
+def test_missing_exact_universe_coverage_preserves_bounded_evidence(tmp_path: Path) -> None:
+    coverage_path = tmp_path / "cache_coverage.json"
+    _write_json(coverage_path, _coverage(["AAPL"]))
+
+    evidence = cache_metrics.build_cache_only_metric_evidence(
+        assets=["AAPL", "MSFT"],
+        timeframe="1d",
+        cache_coverage_path=coverage_path,
+        cache_manifest_path=tmp_path / "missing_manifest.json",
+    )
+
+    assert evidence["metric_mode"] == "bounded_metric_evidence"
+    assert evidence["true_metrics_available"] is False
+    assert evidence["bounded_metric_evidence_available"] is True
+    assert evidence["missing_cache_symbols"] == ["MSFT"]
+    assert evidence["per_asset"][1]["blocker"] == cache_metrics.SAFE_METRIC_BLOCKER
+    assert evidence["per_asset"][1]["cache_coverage_blocker"] == cache_metrics.MISSING_CACHE_BLOCKER
+    assert "no safe cache-only exact-universe metric path" in evidence["evidence_statement"]
+
+
+def test_malformed_or_missing_cache_artifacts_fail_closed_to_bounded_evidence(tmp_path: Path) -> None:
+    evidence = cache_metrics.build_cache_only_metric_evidence(
+        assets=["AAPL"],
+        timeframe="1d",
+        cache_coverage_path=tmp_path / "missing_coverage.json",
+        cache_manifest_path=tmp_path / "missing_manifest.json",
+    )
+
+    assert evidence["metric_mode"] == "bounded_metric_evidence"
+    assert evidence["true_metrics_available"] is False
+    assert evidence["missing_cache_symbols"] == ["AAPL"]
+    assert evidence["external_data_called"] is False


### PR DESCRIPTION
## Summary
- add a read-only cache-only metric evidence adapter for the controlled QRE universe
- wire controlled research metric evidence through the cache path while preserving bounded fallback when exact cache coverage is incomplete
- add unit coverage for exact ready cache evidence and fail-closed bounded evidence

## Tests
- python -m pytest tests/unit/test_qre_autonomous_market_research_loop.py -q
- python -m pytest tests/unit/test_qre_next_action_classifier.py -q
- python -m pytest tests/unit/test_qre_build_request_writer.py -q
- python -m pytest tests/unit/test_qre_daily_status_digest.py -q
- python -m pytest tests/unit/test_qre_controlled_research_run.py -q
- python -m pytest tests/unit/test_qre_cache_only_metric_path.py -q
- python -m research.qre_autonomous_market_research_loop --write --max-cycles 3
- python -m research.qre_daily_status_digest --write
- git diff --check
- git diff -- research/research_latest.json research/strategy_matrix.csv