### PR TITLE
fix: include flywheel artifacts in QRE daily status

### DIFF
--- a/research/qre_daily_status_digest.py
+++ b/research/qre_daily_status_digest.py
@@ -8,10 +8,14 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Final
 
-
 SCHEMA_VERSION: Final[str] = "1.0"
 REPORT_KIND: Final[str] = "qre_daily_status"
 DEFAULT_LOOP_LATEST: Final[Path] = Path("logs/qre_autonomous_market_research_loop/latest.json")
+DEFAULT_BUILD_REQUEST_LATEST: Final[Path] = Path("logs/qre_autonomous_market_research_loop/latest_build_request.json")
+DEFAULT_BUILD_CONSUMER_LATEST: Final[Path] = Path("logs/qre_build_request_consumer/latest.json")
+DEFAULT_BUILD_BACKEND_RESULTS_DIR: Final[Path] = Path("logs/qre_build_request_consumer/backend_results")
+DEFAULT_PR_AUTO_MERGE_LATEST: Final[Path] = Path("logs/qre_pr_auto_merge_gate/latest.json")
+DEFAULT_RUNTIME_CONTINUATION_LATEST: Final[Path] = Path("logs/qre_runtime_update_and_continue/latest.json")
 DEFAULT_FLYWHEEL_LATEST: Final[Path] = Path("logs/qre_research_development_flywheel/latest.json")
 DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_daily_status")
 
@@ -85,9 +89,82 @@ def _read_optional_json(path: Path) -> dict[str, Any] | None:
     return parsed if isinstance(parsed, dict) else None
 
 
+def _read_optional_artifact(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    parsed = _read_optional_json(path)
+    if parsed is None:
+        return None, None
+    return parsed, path.as_posix()
+
+
+def _discover_backend_results(results_dir: Path) -> list[tuple[Path, dict[str, Any]]]:
+    if not results_dir.exists():
+        return []
+    results: list[tuple[Path, dict[str, Any]]] = []
+    for path in sorted(results_dir.glob("*.json")):
+        parsed = _read_optional_json(path)
+        if parsed is not None:
+            results.append((path, parsed))
+    return results
+
+
+def _artifact_sort_key(item: tuple[Path, dict[str, Any]]) -> tuple[str, str]:
+    path, payload = item
+    timestamp = payload.get("generated_at_utc") or payload.get("created_at_utc") or ""
+    return str(timestamp), path.as_posix()
+
+
+def _has_value(value: Any) -> bool:
+    return value is not None and value != "" and value != []
+
+
+def _append_blocker(blockers: list[str], value: Any) -> None:
+    if isinstance(value, list):
+        for item in value:
+            _append_blocker(blockers, item)
+        return
+    if _has_value(value):
+        text = str(value)
+        if text not in blockers:
+            blockers.append(text)
+
+
+def _yes_no_unknown(value: Any) -> str:
+    if value is True:
+        return "yes"
+    if value is False:
+        return "no"
+    return "unknown"
+
+
+def _extract_pr_number(*artifacts: dict[str, Any] | None) -> int | None:
+    for artifact in artifacts:
+        if not isinstance(artifact, dict):
+            continue
+        for key in ("pr_number", "number"):
+            value = artifact.get(key)
+            if isinstance(value, int):
+                return value
+        metadata = artifact.get("pr_metadata")
+        if isinstance(metadata, dict):
+            for key in ("pr_number", "number"):
+                value = metadata.get(key)
+                if isinstance(value, int):
+                    return value
+    return None
+
+
+def _count_true(*values: Any) -> int:
+    return 1 if any(value is True for value in values) else 0
+
+
 def build_daily_status_packet(
     *,
     loop_latest_path: Path = DEFAULT_LOOP_LATEST,
+    build_request_latest_path: Path = DEFAULT_BUILD_REQUEST_LATEST,
+    build_consumer_latest_path: Path = DEFAULT_BUILD_CONSUMER_LATEST,
+    backend_results_dir: Path = DEFAULT_BUILD_BACKEND_RESULTS_DIR,
+    pr_auto_merge_latest_path: Path = DEFAULT_PR_AUTO_MERGE_LATEST,
+    runtime_continuation_latest_path: Path = DEFAULT_RUNTIME_CONTINUATION_LATEST,
     flywheel_latest_path: Path = DEFAULT_FLYWHEEL_LATEST,
     generated_at_utc: str | None = None,
 ) -> dict[str, Any]:
@@ -102,13 +179,50 @@ def build_daily_status_packet(
     loop_output_dir = loop_latest_path.parent
     build_requests = _discover_build_requests(loop_output_dir)
     build_results = _discover_build_results(loop_output_dir)
+    build_request_latest, build_request_latest_used = _read_optional_artifact(build_request_latest_path)
+    if build_request_latest is not None:
+        latest_request_id = build_request_latest.get("request_id")
+        known_request_ids = {item.get("request_id") for item in build_requests}
+        if latest_request_id not in known_request_ids:
+            build_requests.append(build_request_latest)
+
+    build_consumer_latest, build_consumer_latest_used = _read_optional_artifact(build_consumer_latest_path)
+    backend_results = _discover_backend_results(backend_results_dir)
+    latest_backend_result = max(backend_results, key=_artifact_sort_key)[1] if backend_results else None
+    backend_result_paths = [path.as_posix() for path, _payload in backend_results]
+    pr_auto_merge, pr_auto_merge_used = _read_optional_artifact(pr_auto_merge_latest_path)
+    runtime_continuation, runtime_continuation_used = _read_optional_artifact(runtime_continuation_latest_path)
     flywheel = _read_optional_json(flywheel_latest_path)
     flywheel_summary = flywheel.get("summary") if isinstance(flywheel, dict) and isinstance(flywheel.get("summary"), dict) else {}
+
+    build_consumed = _count_true(
+        build_consumer_latest.get("build_request_consumed") if isinstance(build_consumer_latest, dict) else None,
+        latest_backend_result.get("build_request_consumed") if isinstance(latest_backend_result, dict) else None,
+    )
+    pr_opened = _count_true(
+        build_consumer_latest.get("pr_created") if isinstance(build_consumer_latest, dict) else None,
+        latest_backend_result.get("pr_created") if isinstance(latest_backend_result, dict) else None,
+    )
+    pr_green = _count_true(pr_auto_merge.get("pr_green") if isinstance(pr_auto_merge, dict) else None)
+    pr_merged = _count_true(pr_auto_merge.get("pr_auto_merged") if isinstance(pr_auto_merge, dict) else None)
+    runtime_updated = _count_true(
+        runtime_continuation.get("runtime_updated") if isinstance(runtime_continuation, dict) else None
+    )
+    research_continuation_started = _count_true(
+        runtime_continuation.get("research_continuation_started")
+        if isinstance(runtime_continuation, dict)
+        else None
+    )
+
     completed_ids = {
         str(item.get("request_id"))
         for item in build_results
         if item.get("status") in {"merged", "completed"}
     }
+    if pr_merged:
+        for artifact in (pr_auto_merge, latest_backend_result, build_consumer_latest):
+            if isinstance(artifact, dict) and _has_value(artifact.get("request_id")):
+                completed_ids.add(str(artifact["request_id"]))
     pending = [
         item for item in build_requests if str(item.get("request_id")) not in completed_ids
     ]
@@ -117,41 +231,146 @@ def build_daily_status_packet(
     if not isinstance(blockers, list):
         blockers = []
     summary = loop_packet.get("summary") if isinstance(loop_packet.get("summary"), dict) else {}
+    active_manual_blockers: list[str] = []
+    backend_success_supersedes_consumer = (
+        isinstance(latest_backend_result, dict)
+        and latest_backend_result.get("build_request_consumed") is True
+        and latest_backend_result.get("pr_created") is True
+        and not _has_value(latest_backend_result.get("blocked_reason"))
+        and not _has_value(latest_backend_result.get("missing_capability"))
+    )
+    if isinstance(build_consumer_latest, dict) and not backend_success_supersedes_consumer:
+        _append_blocker(active_manual_blockers, build_consumer_latest.get("blocked_reason"))
+        _append_blocker(active_manual_blockers, build_consumer_latest.get("missing_capability"))
+    if isinstance(latest_backend_result, dict):
+        _append_blocker(active_manual_blockers, latest_backend_result.get("blocked_reason"))
+        _append_blocker(active_manual_blockers, latest_backend_result.get("missing_capability"))
+    if isinstance(pr_auto_merge, dict) and pr_auto_merge.get("pr_auto_merged") is not True:
+        _append_blocker(active_manual_blockers, pr_auto_merge.get("blocked_reasons"))
+        if pr_auto_merge.get("manual_governance_required") is True and not active_manual_blockers:
+            _append_blocker(active_manual_blockers, "manual_governance_required")
+    if isinstance(runtime_continuation, dict):
+        _append_blocker(active_manual_blockers, runtime_continuation.get("blocked_reasons"))
+        if runtime_continuation.get("runtime_updated") is False:
+            _append_blocker(active_manual_blockers, "runtime_update_failed")
+        if (
+            runtime_continuation.get("research_continuation_started") is False
+            and runtime_continuation.get("blocked_reasons")
+        ):
+            _append_blocker(active_manual_blockers, "continuation_blocked")
+
+    protected_outputs_mutated = any(
+        artifact.get("protected_outputs_mutated") is True
+        for artifact in (
+            summary,
+            build_consumer_latest or {},
+            latest_backend_result or {},
+            pr_auto_merge or {},
+            runtime_continuation or {},
+        )
+        if isinstance(artifact, dict)
+    )
+    artifact_paths_used = [
+        path
+        for path in [
+            loop_latest_path.as_posix(),
+            build_request_latest_used,
+            build_consumer_latest_used,
+            *backend_result_paths,
+            pr_auto_merge_used,
+            runtime_continuation_used,
+            flywheel_latest_path.as_posix() if flywheel is not None else None,
+        ]
+        if path is not None
+    ]
+    latest_pr_number = _extract_pr_number(latest_backend_result, build_consumer_latest, pr_auto_merge)
+    build_requests_consumed = max(build_consumed, flywheel_summary.get("build_requests_consumed", 0) or 0)
+    prs_opened = max(pr_opened, flywheel_summary.get("prs_opened", 0) or 0)
+    prs_green = max(pr_green, flywheel_summary.get("prs_green", 0) or 0)
+    prs_merged = max(pr_merged, flywheel_summary.get("prs_merged", 0) or 0)
+    runtime_updates_completed = max(runtime_updated, flywheel_summary.get("runtime_updates_completed", 0) or 0)
+    research_continuations_started = max(
+        research_continuation_started,
+        flywheel_summary.get("research_continuations_started", 0) or 0,
+    )
+    build_request_statuses = {
+        str(item.get("request_id")): "completed_or_merged"
+        if str(item.get("request_id")) in completed_ids
+        else "pending"
+        for item in build_requests
+    }
+    build_consumer_observation = dict(build_consumer_latest) if isinstance(build_consumer_latest, dict) else None
+    if build_consumer_observation is not None and backend_success_supersedes_consumer:
+        build_consumer_observation["blocked_reason"] = None
+        build_consumer_observation["missing_capability"] = None
+        build_consumer_observation["superseded_by_backend_result"] = True
     return {
         "schema_version": SCHEMA_VERSION,
         "report_kind": REPORT_KIND,
         "generated_at_utc": generated_at_utc or _utcnow(),
         "period_covered": "latest_autonomous_loop_artifact",
         "source_loop_latest": loop_latest_path.as_posix(),
+        "artifact_paths_used": artifact_paths_used,
         "summary": {
             "autonomous_cycles": len(cycles),
             "controlled_research_inner_loops": summary.get("controlled_research_inner_loop_count"),
             "market_intake_cycles": summary.get("market_intake_cycle_count"),
             "build_requests_created": len(build_requests),
-            "build_requests_consumed": flywheel_summary.get("build_requests_consumed", 0),
+            "build_requests_consumed": build_requests_consumed,
             "build_requests_pending": len(pending),
             "build_requests_completed_or_merged": len(completed_ids),
-            "prs_opened": flywheel_summary.get("prs_opened", 0),
-            "prs_green": flywheel_summary.get("prs_green", 0),
-            "prs_merged": flywheel_summary.get("prs_merged", 0),
-            "runtime_updates_completed": flywheel_summary.get("runtime_updates_completed", 0),
-            "research_continuations_started": flywheel_summary.get("research_continuations_started", 0),
-            "manual_governance_blockers": flywheel_summary.get("manual_governance_blockers", []),
+            "prs_opened": prs_opened,
+            "prs_green": prs_green,
+            "prs_merged": prs_merged,
+            "runtime_updates_completed": runtime_updates_completed,
+            "research_continuations_started": research_continuations_started,
+            "manual_governance_blockers": active_manual_blockers,
             "unsafe_actions_blocked": summary.get("unsafe_actions_blocked", 0),
             "trading_status": "disabled",
-            "protected_artifact_mutation": "none"
-            if summary.get("protected_outputs_mutated") is False
-            else "unknown_or_detected",
+            "protected_artifact_mutation": "detected" if protected_outputs_mutated else "none",
             "latest_universe": latest_cycle.get("market_intake", {}).get("universe"),
             "latest_hypothesis": latest_cycle.get("hypothesis_generation", {}).get("statement"),
             "latest_preset": latest_cycle.get("preset_selection", {}).get("preset_id"),
             "latest_metric_mode": latest_cycle.get("metric_evidence", {}).get("metric_mode"),
-            "latest_blocker": blockers[0] if blockers else "none",
-            "latest_recommendation": latest_cycle.get("next_action", {}).get("recommended_action"),
+            "latest_blocker": active_manual_blockers[0]
+            if active_manual_blockers
+            else (blockers[0] if blockers else "none"),
+            "latest_recommendation": (
+                runtime_continuation.get("final_recommendation")
+                if isinstance(runtime_continuation, dict)
+                else latest_cycle.get("next_action", {}).get("recommended_action")
+            ),
+            "flywheel_progress": {
+                "build_request_consumed": _yes_no_unknown(
+                    build_requests_consumed > 0 if build_requests_consumed else None
+                ),
+                "pr_opened": f"#{latest_pr_number}"
+                if prs_opened and latest_pr_number is not None
+                else _yes_no_unknown(prs_opened > 0 if prs_opened else None),
+                "pr_green": _yes_no_unknown(pr_auto_merge.get("pr_green") if isinstance(pr_auto_merge, dict) else None),
+                "pr_merged": _yes_no_unknown(pr_auto_merge.get("pr_auto_merged") if isinstance(pr_auto_merge, dict) else None),
+                "runtime_updated": _yes_no_unknown(
+                    runtime_continuation.get("runtime_updated") if isinstance(runtime_continuation, dict) else None
+                ),
+                "research_continuation_started": _yes_no_unknown(
+                    runtime_continuation.get("research_continuation_started")
+                    if isinstance(runtime_continuation, dict)
+                    else None
+                ),
+            },
         },
         "build_requests": build_requests,
+        "build_request_statuses": build_request_statuses,
         "build_results": build_results,
-        "flywheel": flywheel,
+        "build_consumer_latest": build_consumer_observation,
+        "build_backend_results": [payload for _path, payload in backend_results],
+        "pr_auto_merge": pr_auto_merge,
+        "runtime_continuation": runtime_continuation,
+        "flywheel_summary_fallback": {
+            key: value
+            for key, value in flywheel_summary.items()
+            if key != "manual_governance_blockers"
+        },
         "latest_cycle": {
             "cycle_id": latest_cycle.get("cycle_id"),
             "learning_feedback": latest_cycle.get("learning_feedback"),
@@ -178,8 +397,16 @@ def build_daily_status_packet(
 
 def render_daily_status(packet: dict[str, Any]) -> str:
     summary = packet["summary"]
+    flywheel_progress = summary.get("flywheel_progress") if isinstance(summary.get("flywheel_progress"), dict) else {}
+    build_request_statuses = packet.get("build_request_statuses")
+    if not isinstance(build_request_statuses, dict):
+        build_request_statuses = {}
     build_lines = [
-        f"- {item.get('request_id')}: {item.get('next_action')}, safe_for_ade_build={item.get('safe_for_ade_build')}, pending"
+        (
+            f"- {item.get('request_id')}: {item.get('next_action')}, "
+            f"safe_for_ade_build={item.get('safe_for_ade_build')}, "
+            f"{build_request_statuses.get(str(item.get('request_id')), 'pending')}"
+        )
         for item in packet.get("build_requests", [])
     ]
     if not build_lines:
@@ -215,6 +442,17 @@ def render_daily_status(packet: dict[str, Any]) -> str:
             "Research intelligence progress:",
             "- Learning is feeding back into the next market-intake seed.",
             "- The system does not rotate assets when the blocker is infrastructure rather than asset quality.",
+            "",
+            "Flywheel progress:",
+            f"- Build request consumed: {flywheel_progress.get('build_request_consumed', 'unknown')}",
+            f"- PR opened: {flywheel_progress.get('pr_opened', 'unknown')}",
+            f"- PR green: {flywheel_progress.get('pr_green', 'unknown')}",
+            f"- PR merged: {flywheel_progress.get('pr_merged', 'unknown')}",
+            f"- Runtime updated: {flywheel_progress.get('runtime_updated', 'unknown')}",
+            f"- Research continuation started: {flywheel_progress.get('research_continuation_started', 'unknown')}",
+            "",
+            "Artifact sources used:",
+            *[f"- {path}" for path in packet.get("artifact_paths_used", [])],
             "",
             "ADE/build progress:",
             *build_lines,
@@ -275,12 +513,22 @@ def write_outputs(packet: dict[str, Any], *, output_dir: Path = DEFAULT_OUTPUT_D
 def run_daily_status_digest(
     *,
     loop_latest_path: Path = DEFAULT_LOOP_LATEST,
+    build_request_latest_path: Path = DEFAULT_BUILD_REQUEST_LATEST,
+    build_consumer_latest_path: Path = DEFAULT_BUILD_CONSUMER_LATEST,
+    backend_results_dir: Path = DEFAULT_BUILD_BACKEND_RESULTS_DIR,
+    pr_auto_merge_latest_path: Path = DEFAULT_PR_AUTO_MERGE_LATEST,
+    runtime_continuation_latest_path: Path = DEFAULT_RUNTIME_CONTINUATION_LATEST,
     flywheel_latest_path: Path = DEFAULT_FLYWHEEL_LATEST,
     output_dir: Path = DEFAULT_OUTPUT_DIR,
     write: bool = False,
 ) -> dict[str, Any]:
     packet = build_daily_status_packet(
         loop_latest_path=loop_latest_path,
+        build_request_latest_path=build_request_latest_path,
+        build_consumer_latest_path=build_consumer_latest_path,
+        backend_results_dir=backend_results_dir,
+        pr_auto_merge_latest_path=pr_auto_merge_latest_path,
+        runtime_continuation_latest_path=runtime_continuation_latest_path,
         flywheel_latest_path=flywheel_latest_path,
     )
     if write:
@@ -292,11 +540,21 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Write QRE daily status digest.")
     parser.add_argument("--write", action="store_true")
     parser.add_argument("--loop-latest", default=DEFAULT_LOOP_LATEST.as_posix())
+    parser.add_argument("--build-request-latest", default=DEFAULT_BUILD_REQUEST_LATEST.as_posix())
+    parser.add_argument("--build-consumer-latest", default=DEFAULT_BUILD_CONSUMER_LATEST.as_posix())
+    parser.add_argument("--backend-results-dir", default=DEFAULT_BUILD_BACKEND_RESULTS_DIR.as_posix())
+    parser.add_argument("--pr-auto-merge-latest", default=DEFAULT_PR_AUTO_MERGE_LATEST.as_posix())
+    parser.add_argument("--runtime-continuation-latest", default=DEFAULT_RUNTIME_CONTINUATION_LATEST.as_posix())
     parser.add_argument("--flywheel-latest", default=DEFAULT_FLYWHEEL_LATEST.as_posix())
     parser.add_argument("--output-dir", default=DEFAULT_OUTPUT_DIR.as_posix())
     args = parser.parse_args(argv)
     packet = run_daily_status_digest(
         loop_latest_path=Path(args.loop_latest),
+        build_request_latest_path=Path(args.build_request_latest),
+        build_consumer_latest_path=Path(args.build_consumer_latest),
+        backend_results_dir=Path(args.backend_results_dir),
+        pr_auto_merge_latest_path=Path(args.pr_auto_merge_latest),
+        runtime_continuation_latest_path=Path(args.runtime_continuation_latest),
         flywheel_latest_path=Path(args.flywheel_latest),
         output_dir=Path(args.output_dir),
         write=args.write,

--- a/tests/unit/test_qre_daily_status_digest.py
+++ b/tests/unit/test_qre_daily_status_digest.py
@@ -3,28 +3,87 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from research import qre_autonomous_market_research_loop as loop
 from research import qre_daily_status_digest as digest
-from tests.unit.test_qre_autonomous_market_research_loop import _controlled_packet
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _write_loop_latest(root: Path, *, protected_outputs_mutated: bool = False) -> Path:
+    loop_dir = root / "loop"
+    latest_path = loop_dir / "latest.json"
+    _write_json(
+        latest_path,
+        {
+            "schema_version": "1.0",
+            "report_kind": "qre_autonomous_market_research_loop",
+            "summary": {
+                "controlled_research_inner_loop_count": 2,
+                "market_intake_cycle_count": 1,
+                "unsafe_actions_blocked": 0,
+                "protected_outputs_mutated": protected_outputs_mutated,
+            },
+            "cycles": [
+                {
+                    "cycle_id": "cycle-1",
+                    "market_intake": {"universe": ["AAPL", "MSFT"]},
+                    "hypothesis_generation": {"statement": "test hypothesis"},
+                    "preset_selection": {"preset_id": "trend_continuation_daily_v1"},
+                    "metric_evidence": {"metric_mode": "bounded_metric_evidence"},
+                    "result_analysis": {"content_blockers": ["safe_metric_runner_missing_or_cache_unavailable"]},
+                    "next_action": {"recommended_action": "add_cache_only_metric_path"},
+                }
+            ],
+        },
+    )
+    return latest_path
+
+
+def _run_digest(root: Path, **overrides) -> dict:
+    loop_latest_path = overrides.pop("loop_latest_path", None) or _write_loop_latest(root)
+    kwargs = {
+        "loop_latest_path": loop_latest_path,
+        "build_request_latest_path": root / "loop" / "latest_build_request.json",
+        "build_consumer_latest_path": root / "consumer" / "latest.json",
+        "backend_results_dir": root / "consumer" / "backend_results",
+        "pr_auto_merge_latest_path": root / "pr_gate" / "latest.json",
+        "runtime_continuation_latest_path": root / "runtime" / "latest.json",
+        "flywheel_latest_path": root / "flywheel" / "latest.json",
+        "output_dir": root / "daily",
+        "write": True,
+    }
+    kwargs.update(overrides)
+    return digest.run_daily_status_digest(**kwargs)
 
 
 def test_daily_digest_summarizes_many_cycles_and_build_lane(tmp_path: Path) -> None:
-    loop.run_autonomous_loop(
-        controlled_packet=_controlled_packet(),
-        output_dir=tmp_path / "loop",
-        max_cycles=40,
-        write=True,
+    loop_latest_path = _write_loop_latest(tmp_path)
+    _write_json(
+        tmp_path / "loop" / "build_requests" / "build-request-1.json",
+        {
+            "request_id": "build-request-1",
+            "next_action": "add_cache_only_metric_path",
+            "safe_for_ade_build": True,
+        },
     )
 
     packet = digest.run_daily_status_digest(
-        loop_latest_path=tmp_path / "loop" / "latest.json",
+        loop_latest_path=loop_latest_path,
+        build_request_latest_path=tmp_path / "loop" / "latest_build_request.json",
+        build_consumer_latest_path=tmp_path / "consumer" / "latest.json",
+        backend_results_dir=tmp_path / "consumer" / "backend_results",
+        pr_auto_merge_latest_path=tmp_path / "pr_gate" / "latest.json",
+        runtime_continuation_latest_path=tmp_path / "runtime" / "latest.json",
+        flywheel_latest_path=tmp_path / "flywheel" / "latest.json",
         output_dir=tmp_path / "daily",
         write=True,
     )
 
-    assert packet["summary"]["autonomous_cycles"] == 40
-    assert packet["summary"]["market_intake_cycles"] == 40
-    assert packet["summary"]["controlled_research_inner_loops"] == 80
+    assert packet["summary"]["autonomous_cycles"] == 1
+    assert packet["summary"]["market_intake_cycles"] == 1
+    assert packet["summary"]["controlled_research_inner_loops"] == 2
     assert packet["summary"]["build_requests_created"] == 1
     assert packet["summary"]["build_requests_pending"] == 1
     assert packet["summary"]["trading_status"] == "disabled"
@@ -36,19 +95,20 @@ def test_daily_digest_summarizes_many_cycles_and_build_lane(tmp_path: Path) -> N
     assert "# QRE Daily Status" in daily
     assert "Research intelligence progress:" in daily
     assert "ADE/build progress:" in daily
+    assert "Flywheel progress:" in daily
+    assert "Artifact sources used:" in daily
     assert "Latest recommendation: add_cache_only_metric_path" in daily
     assert "The system does not rotate assets" in daily
     assert (tmp_path / "daily" / "scheduler_setup.md").exists()
 
 
 def test_daily_digest_recognizes_merged_build_result(tmp_path: Path) -> None:
-    loop_packet = loop.run_autonomous_loop(
-        controlled_packet=_controlled_packet(),
-        output_dir=tmp_path / "loop",
-        max_cycles=1,
-        write=True,
+    loop_latest_path = _write_loop_latest(tmp_path)
+    request_id = "build-request-1"
+    _write_json(
+        tmp_path / "loop" / "build_requests" / f"{request_id}.json",
+        {"request_id": request_id, "next_action": "add_cache_only_metric_path", "safe_for_ade_build": True},
     )
-    request_id = loop_packet["_artifact_paths"]["build_request"]["request_id"]
     results_dir = tmp_path / "loop" / "build_results"
     results_dir.mkdir()
     (results_dir / f"{request_id}.json").write_text(
@@ -67,9 +127,189 @@ def test_daily_digest_recognizes_merged_build_result(tmp_path: Path) -> None:
         encoding="utf-8",
     )
 
-    packet = digest.build_daily_status_packet(loop_latest_path=tmp_path / "loop" / "latest.json")
+    packet = digest.build_daily_status_packet(
+        loop_latest_path=loop_latest_path,
+        build_request_latest_path=tmp_path / "loop" / "latest_build_request.json",
+        build_consumer_latest_path=tmp_path / "consumer" / "latest.json",
+        backend_results_dir=tmp_path / "consumer" / "backend_results",
+        pr_auto_merge_latest_path=tmp_path / "pr_gate" / "latest.json",
+        runtime_continuation_latest_path=tmp_path / "runtime" / "latest.json",
+        flywheel_latest_path=tmp_path / "flywheel" / "latest.json",
+    )
 
     assert packet["summary"]["build_requests_pending"] == 0
     assert packet["summary"]["build_requests_completed_or_merged"] == 1
     assert packet["next_system_action"] == "Continue bounded autonomous market-research cycles."
+
+
+def test_digest_reads_build_consumer_latest_and_counts_consumed_build_request(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "consumer" / "latest.json",
+        {
+            "build_request_consumed": True,
+            "pr_created": False,
+            "blocked_reason": None,
+            "missing_capability": None,
+            "protected_outputs_mutated": False,
+        },
+    )
+
+    packet = _run_digest(tmp_path)
+
+    assert packet["summary"]["build_requests_consumed"] == 1
+    assert packet["summary"]["manual_governance_blockers"] == []
+    assert packet["summary"]["flywheel_progress"]["build_request_consumed"] == "yes"
+
+
+def test_digest_reads_backend_result_and_counts_pr_opened(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "consumer" / "backend_results" / "build-request-1.json",
+        {
+            "created_at_utc": "2026-06-14T15:34:41Z",
+            "build_request_consumed": True,
+            "pr_created": True,
+            "pr_number": 527,
+            "pr_url": "https://github.com/roudjy/trading-agent/pull/527",
+            "safe_for_auto_merge": True,
+            "blocked_reason": None,
+            "missing_capability": None,
+            "protected_outputs_mutated": False,
+        },
+    )
+
+    packet = _run_digest(tmp_path)
+
+    assert packet["summary"]["build_requests_consumed"] == 1
+    assert packet["summary"]["prs_opened"] == 1
+    assert packet["summary"]["flywheel_progress"]["pr_opened"] == "#527"
+
+
+def test_digest_reads_pr_gate_latest_and_counts_pr_green_and_merged(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "pr_gate" / "latest.json",
+        {
+            "pr_number": 527,
+            "pr_green": True,
+            "pr_auto_merged": True,
+            "auto_merge_allowed": True,
+            "blocked_reasons": [],
+            "manual_governance_required": False,
+            "live_pr_status_queried": True,
+            "ci_source": "live_gh_pr_view",
+            "live_check_summary": {"success": 2, "failed": 0, "pending": 0},
+            "merge_result": {"returncode": 0, "stdout": "merged", "stderr": ""},
+            "protected_outputs_mutated": False,
+        },
+    )
+
+    packet = _run_digest(tmp_path)
+
+    assert packet["summary"]["prs_green"] == 1
+    assert packet["summary"]["prs_merged"] == 1
+    assert packet["summary"]["manual_governance_blockers"] == []
+    assert packet["summary"]["flywheel_progress"]["pr_green"] == "yes"
+    assert packet["summary"]["flywheel_progress"]["pr_merged"] == "yes"
+
+
+def test_digest_reads_runtime_latest_and_counts_update_and_continuation(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "runtime" / "latest.json",
+        {
+            "runtime_updated": True,
+            "research_continuation_started": True,
+            "research_cycles_started": 3,
+            "blocked_reasons": [],
+            "final_recommendation": "research_continuation_started",
+            "protected_outputs_mutated": False,
+        },
+    )
+
+    packet = _run_digest(tmp_path)
+
+    assert packet["summary"]["runtime_updates_completed"] == 1
+    assert packet["summary"]["research_continuations_started"] == 1
+    assert packet["summary"]["latest_recommendation"] == "research_continuation_started"
+    assert packet["summary"]["flywheel_progress"]["runtime_updated"] == "yes"
+    assert packet["summary"]["flywheel_progress"]["research_continuation_started"] == "yes"
+
+
+def test_stale_no_safe_build_backend_configured_is_suppressed_after_successful_backend_result(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "consumer" / "latest.json",
+        {
+            "build_backend_available": False,
+            "build_request_consumed": False,
+            "pr_created": False,
+            "blocked_reason": "no_safe_build_backend_configured",
+            "missing_capability": "safe_build_backend",
+            "protected_outputs_mutated": False,
+        },
+    )
+    _write_json(
+        tmp_path / "consumer" / "backend_results" / "build-request-1.json",
+        {
+            "created_at_utc": "2026-06-14T15:34:41Z",
+            "build_backend_available": True,
+            "build_request_consumed": True,
+            "pr_created": True,
+            "pr_number": 527,
+            "blocked_reason": None,
+            "missing_capability": None,
+            "protected_outputs_mutated": False,
+        },
+    )
+
+    packet = _run_digest(tmp_path)
+
+    assert packet["summary"]["manual_governance_blockers"] == []
+    assert packet["summary"]["prs_opened"] == 1
+
+
+def test_active_blockers_are_still_shown_when_latest_artifact_has_real_blocked_reason(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "consumer" / "latest.json",
+        {
+            "build_request_consumed": False,
+            "pr_created": False,
+            "blocked_reason": "build_backend_failed",
+            "missing_capability": None,
+            "protected_outputs_mutated": False,
+        },
+    )
+
+    packet = _run_digest(tmp_path)
+
+    assert packet["summary"]["manual_governance_blockers"] == ["build_backend_failed"]
+    assert packet["summary"]["latest_blocker"] == "build_backend_failed"
+
+
+def test_protected_artifact_mutation_remains_surfaced_if_present(tmp_path: Path) -> None:
+    loop_latest_path = _write_loop_latest(tmp_path, protected_outputs_mutated=True)
+
+    packet = _run_digest(tmp_path, loop_latest_path=loop_latest_path)
+
+    assert packet["summary"]["protected_artifact_mutation"] == "detected"
+
+
+def test_trading_status_remains_disabled(tmp_path: Path) -> None:
+    packet = _run_digest(tmp_path)
+
+    assert packet["summary"]["trading_status"] == "disabled"
+    assert packet["safety"]["paper_shadow_live_allowed"] is False
+    assert packet["safety"]["broker_risk_allowed"] is False
+    assert packet["safety"]["execution_allowed"] is False
+
+
+def test_missing_artifacts_fail_gracefully_with_unknown_pending_status(tmp_path: Path) -> None:
+    packet = _run_digest(tmp_path)
+
+    assert packet["summary"]["build_requests_consumed"] == 0
+    assert packet["summary"]["prs_opened"] == 0
+    assert packet["summary"]["prs_green"] == 0
+    assert packet["summary"]["prs_merged"] == 0
+    assert packet["summary"]["runtime_updates_completed"] == 0
+    assert packet["summary"]["research_continuations_started"] == 0
+    assert packet["summary"]["manual_governance_blockers"] == []
+    assert packet["summary"]["flywheel_progress"]["build_request_consumed"] == "unknown"
+    assert packet["summary"]["flywheel_progress"]["pr_opened"] == "unknown"
 

--- a/tests/unit/test_qre_research_development_flywheel.py
+++ b/tests/unit/test_qre_research_development_flywheel.py
@@ -152,6 +152,11 @@ def test_daily_digest_includes_flywheel_state(tmp_path: Path) -> None:
     )
     packet = digest.run_daily_status_digest(
         loop_latest_path=Path("logs/qre_autonomous_market_research_loop/latest.json"),
+        build_request_latest_path=tmp_path / "missing" / "latest_build_request.json",
+        build_consumer_latest_path=tmp_path / "missing" / "consumer_latest.json",
+        backend_results_dir=tmp_path / "missing" / "backend_results",
+        pr_auto_merge_latest_path=tmp_path / "missing" / "pr_gate_latest.json",
+        runtime_continuation_latest_path=tmp_path / "missing" / "runtime_latest.json",
         flywheel_latest_path=tmp_path / "flywheel" / "latest.json",
         output_dir=tmp_path / "daily",
         write=True,


### PR DESCRIPTION
## Summary
- Aggregate QRE daily status directly from build consumer, backend result, PR gate, and runtime continuation artifacts.
- Suppress stale manual governance blockers when later successful backend evidence exists.
- Add flywheel progress and artifact source reporting to daily markdown.

## Tests
- python -m pytest tests/unit/test_qre_daily_status_digest.py -q
- python -m pytest tests/unit/test_qre_build_request_consumer.py -q
- python -m pytest tests/unit/test_qre_pr_auto_merge_gate.py -q
- python -m pytest tests/unit/test_qre_runtime_update_and_continue.py -q
- python -m ruff check research/qre_daily_status_digest.py tests/unit/test_qre_daily_status_digest.py tests/unit/test_qre_research_development_flywheel.py