### PR TITLE
feat: add QRE audit gap closure plan

### DIFF
--- a/docs/roadmap/qre_audit_gap_closure_plan.md
+++ b/docs/roadmap/qre_audit_gap_closure_plan.md
@@ -1,0 +1,111 @@
+# QRE Audit Gap Closure Plan
+
+Generated at UTC: `2026-06-15T00:00:00Z`
+
+## Summary
+
+PR0 records the audit gap closure roadmap only. It keeps QRE in research-only planning mode and does not unlock strategy synthesis, paper, shadow, live, broker, risk, or execution behavior.
+
+This artifact is PR0 of the roadmap. It is a deterministic, read-only planning surface and is not evidence that QRE is operator-trusted.
+
+## Current-To-Target Matrix
+
+| # | Audit item | Current maturity | Target maturity | Closure PRs | Target capability |
+| --- | --- | --- | --- | --- | --- |
+| 1 | PIT/report-lag/restatement | SCAFFOLD | OPERATOR_TRUSTED | PR2, PR8, PR18 | multi-source historical accounting engine |
+| 2 | Factor field coverage | SCAFFOLD | OPERATOR_TRUSTED | PR4, PR5, PR8, PR18 | approved-provider factor coverage matrix |
+| 3 | SEC Companyfacts manifest | SCAFFOLD | WORKING_CAPABILITY | PR1, PR5, PR7 | active read-only SEC source candidate with gates |
+| 4 | OpenFIGI identity manifest | SCAFFOLD | WORKING_CAPABILITY | PR1, PR3, PR5, PR10 | production-grade symbology resolver input |
+| 5 | Grid lineage bridge | WORKING_CAPABILITY | OPERATOR_TRUSTED | PR8, PR9, PR17, PR18 | source to hypothesis to campaign to evidence graph |
+| 6 | Source/cache sidecars | WORKING_CAPABILITY | OPERATOR_TRUSTED | PR1, PR6, PR8, PR18 | deterministic sidecar materialization |
+| 7 | Local grid refresh | WORKING_CAPABILITY | WORKING_CAPABILITY | PR6, PR8 | controlled refresh discipline |
+| 8 | Targeted readiness rerun | WORKING_CAPABILITY | OPERATOR_TRUSTED | PR8, PR15, PR16, PR18 | real-data readiness rerun gate |
+| 9 | Candidate blockers | WORKING_CAPABILITY | OPERATOR_TRUSTED | PR8, PR17, PR18 | high-density actionable blockers |
+| 10 | Basket closure | WORKING_CAPABILITY | OPERATOR_TRUSTED | PR8, PR17, PR18 | evidence-complete closure gate |
+| 11 | Research memory | WORKING_CAPABILITY | OPERATOR_TRUSTED | PR9, PR11, PR18 | graph-backed research memory |
+| 12 | Ontology | SCAFFOLD | WORKING_CAPABILITY | PR9, PR10, PR11 | mature canonical ontology |
+| 13 | Entity resolution | SCAFFOLD | OPERATOR_TRUSTED | PR3, PR9, PR10, PR18 | canonical identity resolution |
+| 14 | Related failure retrieval | WORKING_CAPABILITY | OPERATOR_TRUSTED | PR9, PR11, PR17, PR18 | deterministic RRF/hybrid retrieval |
+| 15 | Null model baseline | SCAFFOLD | OPERATOR_TRUSTED | PR12, PR13, PR14, PR18 | broader no-edge baseline suite |
+| 16 | State transitions | SCAFFOLD | WORKING_CAPABILITY | PR12, PR13 | state/sequence/regime-duration diagnostics |
+| 17 | Tail/entropy | SCAFFOLD | WORKING_CAPABILITY | PR12, PR14 | evidence-dense tail/entropy diagnostics |
+| 18 | Routing calibration | SCAFFOLD | OPERATOR_TRUSTED | PR8, PR12, PR13, PR14, PR15, PR18 | real-evidence routing calibration |
+| 19 | Sampling calibration | SCAFFOLD | OPERATOR_TRUSTED | PR8, PR12, PR13, PR14, PR16, PR18 | real-evidence sampling calibration |
+| 20 | Trusted-loop packet | WORKING_CAPABILITY | OPERATOR_TRUSTED | PR17, PR18 | evidence-backed operator-trust verdict |
+
+## PR Sequence
+
+| PR | Title | Objective | Depends on | Approval |
+| --- | --- | --- | --- | --- |
+| PR0 | Audit gap closure plan and maturity matrix | Add generated roadmap artifact aligned with repo inspection. | none | normal PR |
+| PR1 | Source lifecycle and quality gate contract | Implement strict source lifecycle and transition gates. | PR0 | operator review for lifecycle semantics |
+| PR2 | Historical accounting foundation | PIT/report-lag/restatement snapshot contracts. | PR1 | operator review |
+| PR3 | Symbology resolver foundation | Canonical IDs, aliases, and ambiguity blocking. | PR1 | normal PR |
+| PR4 | Factor coverage matrix | Provider to field to factor coverage and freshness. | PR1, PR2, PR3 | normal PR |
+| PR5 | SEC/OpenFIGI manifest hardening | Promote manifests to quality-gated readiness inputs, not alpha. | PR1, PR2, PR3, PR4 | operator source review |
+| PR6 | Cache and throughput manifests | Parquet snapshot contract, DuckDB catalog manifest, Polars-use policy. | PR1, PR2, PR3, PR4, PR5 | normal PR |
+| PR7 | Source usefulness ledger | Track source usefulness, failures, and cost savings. | PR5, PR6 | normal PR |
+| PR8 | Lineage graph v1 | Source to normalized data to factor to hypothesis to campaign to evidence lineage. | PR2, PR3, PR4, PR5, PR6, PR7 | normal PR |
+| PR9 | Knowledge graph and contradiction visibility | Add research memory graph and contradiction edges. | PR8 | normal PR |
+| PR10 | Entity resolution hardening | Canonical cross-artifact entity resolver. | PR3, PR9 | normal PR |
+| PR11 | Retrieval maturity | Keyword plus metadata plus graph-neighbor retrieval with RRF scaffold. | PR9, PR10 | normal PR |
+| PR12 | Null/no-edge baseline suite | Random walk, shuffled/surrogate, martingale-like baseline reports. | PR8, PR11 | normal PR |
+| PR13 | State/sequence/regime duration | State transition and dwell-time diagnostics. | PR12 | normal PR |
+| PR14 | Tail/entropy evidence density | Expand diagnostics with real evidence density and null challenges. | PR12, PR13 | normal PR |
+| PR15 | Routing calibration on real evidence | Use source/data/readiness/diagnostic evidence for routing recommendations. | PR8, PR9, PR10, PR11, PR12, PR13, PR14 | normal PR |
+| PR16 | Sampling calibration on real evidence | Coverage/source/null/regime-aware sampling recommendations. | PR8, PR9, PR10, PR11, PR12, PR13, PR14, PR15 | normal PR |
+| PR17 | Evidence-complete basket closure | High-density blockers, reason records, and closure criteria. | PR8, PR9, PR10, PR11, PR12, PR13, PR14, PR15, PR16 | operator review |
+| PR18 | Operator-trust review packet v3 | Evidence-backed Level 1/2/3 verdict and exact next action. | PR17 | operator trust decision |
+
+## Dependency Graph
+
+- source_lifecycle_before_active_sources: Source lifecycle and quality gates must pass before active read-only source usage.
+- symbology_before_factor_agreement: Symbology resolver must exist before broad factor coverage and cross-source agreement.
+- historical_accounting_before_pit_factors: Historical accounting must exist before PIT-aware factor evaluation.
+- cache_manifest_before_throughput_metrics: Cache manifest must exist before throughput metrics.
+- usefulness_after_quality_and_cache: Source usefulness ledger follows source quality and cache manifests.
+- lineage_before_trust_packet: Lineage graph must precede contradiction visibility and operator-trust packet.
+- entity_resolution_before_retrieval_confidence: Entity resolution must precede mature retrieval and lineage confidence.
+- null_baselines_before_diagnostic_influence: Null baselines must precede state/tail/entropy influence on routing or sampling.
+- real_evidence_before_operator_trusted_calibration: Real evidence runs must precede operator-trusted routing or sampling calibration.
+- reason_density_before_final_verdict: Reason-record density and basket closure must precede final operator-trust verdict.
+
+## Blocked Shortcuts
+
+- source_to_alpha
+- cache_to_trade
+- diagnostic_to_trade
+- retrieval_to_authority
+- knowledge_graph_to_truth
+- identity_ambiguity_to_escalation
+- throughput_bypasses_source_quality
+- null_baseline_promotes_candidate_alone
+- routing_mutates_queue_or_campaign
+- sampling_uses_stochastic_bruteforce
+
+## Forbidden Paths
+
+- strategy_synthesis
+- shadow_activation
+- paper_activation
+- live_activation
+- broker_integration
+- risk_authority
+- execution_behavior
+- dashboard_mutation_routes
+- hidden_ml_rl_selectors
+- stochastic_mutation
+- generated_strategy_code
+
+## Safety Flags
+
+- safe_to_strategy_synthesis: False
+- safe_to_shadow: False
+- safe_to_paper: False
+- safe_to_live: False
+
+## Recommended Next PR
+
+After PR0, build PR1: `feat: add QRE source lifecycle and quality gate contract`.
+
+Reason: source lifecycle and quality gates are the dependency root for approved providers, symbology, factor coverage, PIT accounting, cache trust, routing/sampling evidence, and final operator trust.

--- a/research/qre_audit_gap_closure_plan.py
+++ b/research/qre_audit_gap_closure_plan.py
@@ -1,0 +1,719 @@
+"""Deterministic QRE audit gap closure plan.
+
+This module materializes the PR0 roadmap artifact for closing the current
+QRE audit gaps. It is intentionally static, read-only, and planning-only:
+it does not fetch data, launch campaigns, synthesize strategies, or mutate
+research outputs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+
+REPORT_KIND: Final[str] = "qre_audit_gap_closure_plan"
+SCHEMA_VERSION: Final[str] = "1.0"
+GENERATED_AT_UTC: Final[str] = "2026-06-15T00:00:00Z"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_audit_gap_closure_plan")
+DOC_PATH: Final[Path] = Path("docs/roadmap/qre_audit_gap_closure_plan.md")
+LATEST_NAME: Final[str] = "latest.json"
+WRITE_PREFIXES: Final[tuple[str, ...]] = (
+    "logs/qre_audit_gap_closure_plan/",
+    "docs/roadmap/qre_audit_gap_closure_plan.md",
+)
+
+
+AUDIT_ITEMS: tuple[dict[str, Any], ...] = (
+    {
+        "id": 1,
+        "audit_item": "PIT/report-lag/restatement",
+        "current_maturity": "SCAFFOLD",
+        "repo_evidence": [
+            "research/data_readiness/*policy.py",
+            "tests for restatement policy",
+        ],
+        "target_capability": "multi-source historical accounting engine",
+        "target_maturity": "OPERATOR_TRUSTED",
+        "closure_prs": [2, 8, 18],
+    },
+    {
+        "id": 2,
+        "audit_item": "Factor field coverage",
+        "current_maturity": "SCAFFOLD",
+        "repo_evidence": ["factor_field_coverage.py", "factor coverage tests"],
+        "target_capability": "approved-provider factor coverage matrix",
+        "target_maturity": "OPERATOR_TRUSTED",
+        "closure_prs": [4, 5, 8, 18],
+    },
+    {
+        "id": 3,
+        "audit_item": "SEC Companyfacts manifest",
+        "current_maturity": "SCAFFOLD",
+        "repo_evidence": ["source manifest registry/tests"],
+        "target_capability": "active read-only SEC source candidate with gates",
+        "target_maturity": "WORKING_CAPABILITY",
+        "closure_prs": [1, 5, 7],
+    },
+    {
+        "id": 4,
+        "audit_item": "OpenFIGI identity manifest",
+        "current_maturity": "SCAFFOLD",
+        "repo_evidence": ["OpenFIGI tests", "identity modules"],
+        "target_capability": "production-grade symbology resolver input",
+        "target_maturity": "WORKING_CAPABILITY",
+        "closure_prs": [1, 3, 5, 10],
+    },
+    {
+        "id": 5,
+        "audit_item": "Grid lineage bridge",
+        "current_maturity": "WORKING_CAPABILITY",
+        "repo_evidence": ["research/qre_grid_candidate_campaign_lineage_bridge.py"],
+        "target_capability": "source to hypothesis to campaign to evidence graph",
+        "target_maturity": "OPERATOR_TRUSTED",
+        "closure_prs": [8, 9, 17, 18],
+    },
+    {
+        "id": 6,
+        "audit_item": "Source/cache sidecars",
+        "current_maturity": "WORKING_CAPABILITY",
+        "repo_evidence": ["research/qre_source_cache_readiness_materialization.py"],
+        "target_capability": "deterministic sidecar materialization",
+        "target_maturity": "OPERATOR_TRUSTED",
+        "closure_prs": [1, 6, 8, 18],
+    },
+    {
+        "id": 7,
+        "audit_item": "Local grid refresh",
+        "current_maturity": "WORKING_CAPABILITY",
+        "repo_evidence": ["research/qre_local_grid_artifact_refresh.py"],
+        "target_capability": "controlled refresh discipline",
+        "target_maturity": "WORKING_CAPABILITY",
+        "closure_prs": [6, 8],
+    },
+    {
+        "id": 8,
+        "audit_item": "Targeted readiness rerun",
+        "current_maturity": "WORKING_CAPABILITY",
+        "repo_evidence": ["research/qre_targeted_readiness_rerun.py"],
+        "target_capability": "real-data readiness rerun gate",
+        "target_maturity": "OPERATOR_TRUSTED",
+        "closure_prs": [8, 15, 16, 18],
+    },
+    {
+        "id": 9,
+        "audit_item": "Candidate blockers",
+        "current_maturity": "WORKING_CAPABILITY",
+        "repo_evidence": ["research/qre_candidate_explanation_rows.py"],
+        "target_capability": "high-density actionable blockers",
+        "target_maturity": "OPERATOR_TRUSTED",
+        "closure_prs": [8, 17, 18],
+    },
+    {
+        "id": 10,
+        "audit_item": "Basket closure",
+        "current_maturity": "WORKING_CAPABILITY",
+        "repo_evidence": ["research/qre_evidence_complete_basket_closure.py"],
+        "target_capability": "evidence-complete closure gate",
+        "target_maturity": "OPERATOR_TRUSTED",
+        "closure_prs": [8, 17, 18],
+    },
+    {
+        "id": 11,
+        "audit_item": "Research memory",
+        "current_maturity": "WORKING_CAPABILITY",
+        "repo_evidence": [
+            "research/qre_research_memory_current_artifacts.py",
+            "packages/qre_research/*",
+        ],
+        "target_capability": "graph-backed research memory",
+        "target_maturity": "OPERATOR_TRUSTED",
+        "closure_prs": [9, 11, 18],
+    },
+    {
+        "id": 12,
+        "audit_item": "Ontology",
+        "current_maturity": "SCAFFOLD",
+        "repo_evidence": ["research/qre_research_ontology.py"],
+        "target_capability": "mature canonical ontology",
+        "target_maturity": "WORKING_CAPABILITY",
+        "closure_prs": [9, 10, 11],
+    },
+    {
+        "id": 13,
+        "audit_item": "Entity resolution",
+        "current_maturity": "SCAFFOLD",
+        "repo_evidence": ["research/qre_entity_resolution.py"],
+        "target_capability": "canonical identity resolution",
+        "target_maturity": "OPERATOR_TRUSTED",
+        "closure_prs": [3, 9, 10, 18],
+    },
+    {
+        "id": 14,
+        "audit_item": "Related failure retrieval",
+        "current_maturity": "WORKING_CAPABILITY",
+        "repo_evidence": ["memory/retrieval tests"],
+        "target_capability": "deterministic RRF/hybrid retrieval",
+        "target_maturity": "OPERATOR_TRUSTED",
+        "closure_prs": [9, 11, 17, 18],
+    },
+    {
+        "id": 15,
+        "audit_item": "Null model baseline",
+        "current_maturity": "SCAFFOLD",
+        "repo_evidence": ["research/qre_null_model_baseline.py"],
+        "target_capability": "broader no-edge baseline suite",
+        "target_maturity": "OPERATOR_TRUSTED",
+        "closure_prs": [12, 13, 14, 18],
+    },
+    {
+        "id": 16,
+        "audit_item": "State transitions",
+        "current_maturity": "SCAFFOLD",
+        "repo_evidence": ["research/qre_state_transition_diagnostics.py"],
+        "target_capability": "state/sequence/regime-duration diagnostics",
+        "target_maturity": "WORKING_CAPABILITY",
+        "closure_prs": [12, 13],
+    },
+    {
+        "id": 17,
+        "audit_item": "Tail/entropy",
+        "current_maturity": "SCAFFOLD",
+        "repo_evidence": ["research/qre_tail_entropy_hardening.py"],
+        "target_capability": "evidence-dense tail/entropy diagnostics",
+        "target_maturity": "WORKING_CAPABILITY",
+        "closure_prs": [12, 14],
+    },
+    {
+        "id": 18,
+        "audit_item": "Routing calibration",
+        "current_maturity": "SCAFFOLD",
+        "repo_evidence": ["research/qre_routing_calibration.py"],
+        "target_capability": "real-evidence routing calibration",
+        "target_maturity": "OPERATOR_TRUSTED",
+        "closure_prs": [8, 12, 13, 14, 15, 18],
+    },
+    {
+        "id": 19,
+        "audit_item": "Sampling calibration",
+        "current_maturity": "SCAFFOLD",
+        "repo_evidence": ["research/qre_sampling_calibration.py"],
+        "target_capability": "real-evidence sampling calibration",
+        "target_maturity": "OPERATOR_TRUSTED",
+        "closure_prs": [8, 12, 13, 14, 16, 18],
+    },
+    {
+        "id": 20,
+        "audit_item": "Trusted-loop packet",
+        "current_maturity": "WORKING_CAPABILITY",
+        "repo_evidence": ["research/qre_trusted_loop_review_packet.py"],
+        "target_capability": "evidence-backed operator-trust verdict",
+        "target_maturity": "OPERATOR_TRUSTED",
+        "closure_prs": [17, 18],
+    },
+)
+
+
+GAP_CLOSURE_PRS: tuple[dict[str, Any], ...] = (
+    {
+        "pr": 0,
+        "title": "Audit gap closure plan and maturity matrix",
+        "objective": "Add generated roadmap artifact aligned with repo inspection.",
+        "depends_on": [],
+        "main_artifacts_tests": [
+            "docs/roadmap/qre_audit_gap_closure_plan.md",
+            "research/qre_audit_gap_closure_plan.py",
+            "logs/qre_audit_gap_closure_plan/latest.json",
+            "tests/unit/test_qre_audit_gap_closure_plan.py",
+        ],
+        "risk": "Low",
+        "approval": "normal PR",
+    },
+    {
+        "pr": 1,
+        "title": "Source lifecycle and quality gate contract",
+        "objective": "Implement strict source lifecycle and transition gates.",
+        "depends_on": [0],
+        "main_artifacts_tests": [
+            "source lifecycle sidecar",
+            "tests blocking candidate to active_read_only jumps",
+        ],
+        "required_gates": [
+            "manifest_completeness",
+            "allowed_use_declared",
+            "forbidden_use_declared",
+            "quality_gates_passed",
+            "identity_mapping_present",
+            "historical_lineage_present",
+        ],
+        "risk": "Medium",
+        "approval": "operator review for lifecycle semantics",
+    },
+    {
+        "pr": 2,
+        "title": "Historical accounting foundation",
+        "objective": "PIT/report-lag/restatement snapshot contracts.",
+        "depends_on": [1],
+        "main_artifacts_tests": ["accounting sidecar", "stale/revised detection tests"],
+        "risk": "Medium",
+        "approval": "operator review",
+    },
+    {
+        "pr": 3,
+        "title": "Symbology resolver foundation",
+        "objective": "Canonical IDs, aliases, and ambiguity blocking.",
+        "depends_on": [1],
+        "main_artifacts_tests": ["identity sidecar", "ambiguity blocks escalation tests"],
+        "risk": "Medium",
+        "approval": "normal PR",
+    },
+    {
+        "pr": 4,
+        "title": "Factor coverage matrix",
+        "objective": "Provider to field to factor coverage and freshness.",
+        "depends_on": [1, 2, 3],
+        "main_artifacts_tests": [
+            "factor coverage report",
+            "tests no provider as alpha authority",
+        ],
+        "risk": "Medium",
+        "approval": "normal PR",
+    },
+    {
+        "pr": 5,
+        "title": "SEC/OpenFIGI manifest hardening",
+        "objective": "Promote manifests to quality-gated readiness inputs, not alpha.",
+        "depends_on": [1, 2, 3, 4],
+        "main_artifacts_tests": [
+            "manifest completeness reports",
+            "license/allowed-use tests",
+        ],
+        "risk": "Medium",
+        "approval": "operator source review",
+    },
+    {
+        "pr": 6,
+        "title": "Cache and throughput manifests",
+        "objective": "Parquet snapshot contract, DuckDB catalog manifest, Polars-use policy.",
+        "depends_on": [1, 2, 3, 4, 5],
+        "main_artifacts_tests": [
+            "cache quality/coverage reports",
+            "tests throughput cannot skip gates",
+        ],
+        "required_gates": ["source_quality_ready", "cache_manifest_ready"],
+        "risk": "Medium",
+        "approval": "normal PR",
+    },
+    {
+        "pr": 7,
+        "title": "Source usefulness ledger",
+        "objective": "Track source usefulness, failures, and cost savings.",
+        "depends_on": [5, 6],
+        "main_artifacts_tests": [
+            "usefulness ledger",
+            "false-positive and quality-failure tests",
+        ],
+        "risk": "Medium",
+        "approval": "normal PR",
+    },
+    {
+        "pr": 8,
+        "title": "Lineage graph v1",
+        "objective": "Source to normalized data to factor to hypothesis to campaign to evidence lineage.",
+        "depends_on": [2, 3, 4, 5, 6, 7],
+        "main_artifacts_tests": ["deterministic graph JSON", "orphan/contradiction tests"],
+        "risk": "Medium",
+        "approval": "normal PR",
+    },
+    {
+        "pr": 9,
+        "title": "Knowledge graph and contradiction visibility",
+        "objective": "Add research memory graph and contradiction edges.",
+        "depends_on": [8],
+        "main_artifacts_tests": ["KG sidecar", "tests graph is context not truth"],
+        "risk": "Medium",
+        "approval": "normal PR",
+    },
+    {
+        "pr": 10,
+        "title": "Entity resolution hardening",
+        "objective": "Canonical cross-artifact entity resolver.",
+        "depends_on": [3, 9],
+        "main_artifacts_tests": ["canonical ID report", "ambiguity blocks escalation tests"],
+        "risk": "Medium",
+        "approval": "normal PR",
+    },
+    {
+        "pr": 11,
+        "title": "Retrieval maturity",
+        "objective": "Keyword plus metadata plus graph-neighbor retrieval with RRF scaffold.",
+        "depends_on": [9, 10],
+        "main_artifacts_tests": ["retrieval quality report", "tests retrieval is context only"],
+        "risk": "Medium",
+        "approval": "normal PR",
+    },
+    {
+        "pr": 12,
+        "title": "Null/no-edge baseline suite",
+        "objective": "Random walk, shuffled/surrogate, martingale-like baseline reports.",
+        "depends_on": [8, 11],
+        "main_artifacts_tests": [
+            "baseline sidecars",
+            "tests no baseline promotes candidates alone",
+        ],
+        "risk": "Medium",
+        "approval": "normal PR",
+    },
+    {
+        "pr": 13,
+        "title": "State/sequence/regime duration",
+        "objective": "State transition and dwell-time diagnostics.",
+        "depends_on": [12],
+        "main_artifacts_tests": ["state/regime reports", "sparse data fail-closed tests"],
+        "risk": "Medium",
+        "approval": "normal PR",
+    },
+    {
+        "pr": 14,
+        "title": "Tail/entropy evidence density",
+        "objective": "Expand diagnostics with real evidence density and null challenges.",
+        "depends_on": [12, 13],
+        "main_artifacts_tests": [
+            "tail/entropy report",
+            "tests diagnostics do not trade",
+        ],
+        "risk": "Medium",
+        "approval": "normal PR",
+    },
+    {
+        "pr": 15,
+        "title": "Routing calibration on real evidence",
+        "objective": "Use source/data/readiness/diagnostic evidence for routing recommendations.",
+        "depends_on": [8, 9, 10, 11, 12, 13, 14],
+        "main_artifacts_tests": [
+            "routing calibration report",
+            "tests no queue/campaign mutation",
+        ],
+        "risk": "Medium",
+        "approval": "normal PR",
+    },
+    {
+        "pr": 16,
+        "title": "Sampling calibration on real evidence",
+        "objective": "Coverage/source/null/regime-aware sampling recommendations.",
+        "depends_on": [8, 9, 10, 11, 12, 13, 14, 15],
+        "main_artifacts_tests": [
+            "sampling report",
+            "tests no stochastic/bruteforce shortcut",
+        ],
+        "risk": "Medium",
+        "approval": "normal PR",
+    },
+    {
+        "pr": 17,
+        "title": "Evidence-complete basket closure",
+        "objective": "High-density blockers, reason records, and closure criteria.",
+        "depends_on": [8, 9, 10, 11, 12, 13, 14, 15, 16],
+        "main_artifacts_tests": [
+            "basket closure packet",
+            "tests negative results preserved",
+        ],
+        "risk": "Medium",
+        "approval": "operator review",
+    },
+    {
+        "pr": 18,
+        "title": "Operator-trust review packet v3",
+        "objective": "Evidence-backed Level 1/2/3 verdict and exact next action.",
+        "depends_on": [17],
+        "main_artifacts_tests": [
+            "final trust packet",
+            "tests missing evidence fails closed",
+        ],
+        "risk": "Low",
+        "approval": "operator trust decision",
+    },
+)
+
+
+DEPENDENCIES: tuple[dict[str, str], ...] = (
+    {
+        "dependency": "source_lifecycle_before_active_sources",
+        "rule": "Source lifecycle and quality gates must pass before active read-only source usage.",
+    },
+    {
+        "dependency": "symbology_before_factor_agreement",
+        "rule": "Symbology resolver must exist before broad factor coverage and cross-source agreement.",
+    },
+    {
+        "dependency": "historical_accounting_before_pit_factors",
+        "rule": "Historical accounting must exist before PIT-aware factor evaluation.",
+    },
+    {
+        "dependency": "cache_manifest_before_throughput_metrics",
+        "rule": "Cache manifest must exist before throughput metrics.",
+    },
+    {
+        "dependency": "usefulness_after_quality_and_cache",
+        "rule": "Source usefulness ledger follows source quality and cache manifests.",
+    },
+    {
+        "dependency": "lineage_before_trust_packet",
+        "rule": "Lineage graph must precede contradiction visibility and operator-trust packet.",
+    },
+    {
+        "dependency": "entity_resolution_before_retrieval_confidence",
+        "rule": "Entity resolution must precede mature retrieval and lineage confidence.",
+    },
+    {
+        "dependency": "null_baselines_before_diagnostic_influence",
+        "rule": "Null baselines must precede state/tail/entropy influence on routing or sampling.",
+    },
+    {
+        "dependency": "real_evidence_before_operator_trusted_calibration",
+        "rule": "Real evidence runs must precede operator-trusted routing or sampling calibration.",
+    },
+    {
+        "dependency": "reason_density_before_final_verdict",
+        "rule": "Reason-record density and basket closure must precede final operator-trust verdict.",
+    },
+)
+
+
+BLOCKED_SHORTCUTS: tuple[str, ...] = (
+    "source_to_alpha",
+    "cache_to_trade",
+    "diagnostic_to_trade",
+    "retrieval_to_authority",
+    "knowledge_graph_to_truth",
+    "identity_ambiguity_to_escalation",
+    "throughput_bypasses_source_quality",
+    "null_baseline_promotes_candidate_alone",
+    "routing_mutates_queue_or_campaign",
+    "sampling_uses_stochastic_bruteforce",
+)
+
+FORBIDDEN_PATHS: tuple[str, ...] = (
+    "strategy_synthesis",
+    "shadow_activation",
+    "paper_activation",
+    "live_activation",
+    "broker_integration",
+    "risk_authority",
+    "execution_behavior",
+    "dashboard_mutation_routes",
+    "hidden_ml_rl_selectors",
+    "stochastic_mutation",
+    "generated_strategy_code",
+)
+
+
+def _table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> str:
+    head = "| " + " | ".join(headers) + " |"
+    divider = "| " + " | ".join(["---"] * len(headers)) + " |"
+    body = ["| " + " | ".join(row) + " |" for row in rows]
+    return "\n".join([head, divider, *body])
+
+
+def build_audit_gap_closure_plan(
+    *,
+    generated_at_utc: str = GENERATED_AT_UTC,
+) -> dict[str, Any]:
+    current_counts = Counter(str(row["current_maturity"]) for row in AUDIT_ITEMS)
+    target_counts = Counter(str(row["target_maturity"]) for row in AUDIT_ITEMS)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "generated_at_utc": generated_at_utc,
+        "audit_items": [dict(row) for row in AUDIT_ITEMS],
+        "current_maturity": dict(sorted(current_counts.items())),
+        "target_maturity": dict(sorted(target_counts.items())),
+        "gap_closure_prs": [dict(row) for row in GAP_CLOSURE_PRS],
+        "dependencies": [dict(row) for row in DEPENDENCIES],
+        "blocked_shortcuts": list(BLOCKED_SHORTCUTS),
+        "forbidden_paths": list(FORBIDDEN_PATHS),
+        "safe_to_strategy_synthesis": False,
+        "safe_to_shadow": False,
+        "safe_to_paper": False,
+        "safe_to_live": False,
+        "summary": {
+            "audit_item_count": len(AUDIT_ITEMS),
+            "gap_closure_pr_count": len(GAP_CLOSURE_PRS),
+            "operator_summary": (
+                "PR0 records the audit gap closure roadmap only. It keeps QRE in "
+                "research-only planning mode and does not unlock strategy synthesis, "
+                "paper, shadow, live, broker, risk, or execution behavior."
+            ),
+        },
+        "safety_invariants": {
+            "read_only": True,
+            "uses_network": False,
+            "fetches_external_data": False,
+            "runs_research": False,
+            "launches_campaigns": False,
+            "mutates_candidates": False,
+            "mutates_campaigns": False,
+            "mutates_strategies": False,
+            "mutates_research_outputs": False,
+            "mutates_frozen_contracts": False,
+            "operator_review_only": True,
+        },
+    }
+
+
+def render_markdown(plan: Mapping[str, Any]) -> str:
+    audit_items = plan.get("audit_items")
+    audit_items = audit_items if isinstance(audit_items, list) else []
+    prs = plan.get("gap_closure_prs")
+    prs = prs if isinstance(prs, list) else []
+    dependencies = plan.get("dependencies")
+    dependencies = dependencies if isinstance(dependencies, list) else []
+
+    audit_table = _table(
+        [
+            "#",
+            "Audit item",
+            "Current maturity",
+            "Target maturity",
+            "Closure PRs",
+            "Target capability",
+        ],
+        [
+            [
+                str(row.get("id") or ""),
+                str(row.get("audit_item") or ""),
+                str(row.get("current_maturity") or ""),
+                str(row.get("target_maturity") or ""),
+                ", ".join(f"PR{value}" for value in row.get("closure_prs", [])),
+                str(row.get("target_capability") or ""),
+            ]
+            for row in audit_items
+            if isinstance(row, Mapping)
+        ],
+    )
+    pr_table = _table(
+        ["PR", "Title", "Objective", "Depends on", "Approval"],
+        [
+            [
+                f"PR{row.get('pr')}",
+                str(row.get("title") or ""),
+                str(row.get("objective") or ""),
+                ", ".join(f"PR{value}" for value in row.get("depends_on", [])) or "none",
+                str(row.get("approval") or ""),
+            ]
+            for row in prs
+            if isinstance(row, Mapping)
+        ],
+    )
+    dependency_lines = [
+        f"- {row.get('dependency')}: {row.get('rule')}"
+        for row in dependencies
+        if isinstance(row, Mapping)
+    ]
+    blocked_lines = [f"- {value}" for value in plan.get("blocked_shortcuts", [])]
+    forbidden_lines = [f"- {value}" for value in plan.get("forbidden_paths", [])]
+
+    return "\n".join(
+        [
+            "# QRE Audit Gap Closure Plan",
+            "",
+            f"Generated at UTC: `{plan.get('generated_at_utc')}`",
+            "",
+            "## Summary",
+            "",
+            str((plan.get("summary") or {}).get("operator_summary") or ""),
+            "",
+            "This artifact is PR0 of the roadmap. It is a deterministic, read-only "
+            "planning surface and is not evidence that QRE is operator-trusted.",
+            "",
+            "## Current-To-Target Matrix",
+            "",
+            audit_table,
+            "",
+            "## PR Sequence",
+            "",
+            pr_table,
+            "",
+            "## Dependency Graph",
+            "",
+            *dependency_lines,
+            "",
+            "## Blocked Shortcuts",
+            "",
+            *blocked_lines,
+            "",
+            "## Forbidden Paths",
+            "",
+            *forbidden_lines,
+            "",
+            "## Safety Flags",
+            "",
+            f"- safe_to_strategy_synthesis: {plan.get('safe_to_strategy_synthesis')}",
+            f"- safe_to_shadow: {plan.get('safe_to_shadow')}",
+            f"- safe_to_paper: {plan.get('safe_to_paper')}",
+            f"- safe_to_live: {plan.get('safe_to_live')}",
+            "",
+            "## Recommended Next PR",
+            "",
+            "After PR0, build PR1: `feat: add QRE source lifecycle and quality gate contract`.",
+            "",
+            "Reason: source lifecycle and quality gates are the dependency root for "
+            "approved providers, symbology, factor coverage, PIT accounting, cache "
+            "trust, routing/sampling evidence, and final operator trust.",
+        ]
+    )
+
+
+def _validate_write_target(path: Path) -> None:
+    normalized = path.as_posix()
+    if not any(prefix in normalized for prefix in WRITE_PREFIXES):
+        raise ValueError(f"qre_audit_gap_closure_plan: refusing write outside allowlist: {path!r}")
+
+
+def write_outputs(
+    plan: Mapping[str, Any],
+    *,
+    repo_root: Path = Path("."),
+) -> dict[str, str]:
+    latest = repo_root / DEFAULT_OUTPUT_DIR / LATEST_NAME
+    doc = repo_root / DOC_PATH
+    for target in (latest, doc):
+        _validate_write_target(target)
+        target.parent.mkdir(parents=True, exist_ok=True)
+
+    latest_payload = json.dumps(plan, indent=2, sort_keys=True) + "\n"
+    tmp_latest = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_latest.write_text(latest_payload, encoding="utf-8")
+    os.replace(tmp_latest, latest)
+
+    tmp_doc = doc.with_suffix(doc.suffix + ".tmp")
+    tmp_doc.write_text(render_markdown(plan) + "\n", encoding="utf-8")
+    os.replace(tmp_doc, doc)
+
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "operator_plan": doc.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_audit_gap_closure_plan",
+        description="Materialize the deterministic QRE audit gap closure plan.",
+    )
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    plan = build_audit_gap_closure_plan()
+    if args.write:
+        plan["_artifact_paths"] = write_outputs(plan)
+    print(json.dumps(plan, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/unit/test_qre_audit_gap_closure_plan.py
+++ b/tests/unit/test_qre_audit_gap_closure_plan.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from research import qre_audit_gap_closure_plan as plan
+
+
+FROZEN = "2026-06-15T00:00:00Z"
+
+
+def _built() -> dict:
+    return plan.build_audit_gap_closure_plan(generated_at_utc=FROZEN)
+
+
+def test_plan_contains_all_20_audit_items_and_required_fields() -> None:
+    payload = _built()
+
+    assert payload["schema_version"] == "1.0"
+    assert payload["generated_at_utc"] == FROZEN
+    assert len(payload["audit_items"]) == 20
+    assert [row["id"] for row in payload["audit_items"]] == list(range(1, 21))
+
+    required = {
+        "id",
+        "audit_item",
+        "current_maturity",
+        "repo_evidence",
+        "target_capability",
+        "target_maturity",
+        "closure_prs",
+    }
+    for row in payload["audit_items"]:
+        assert required <= set(row)
+        assert row["repo_evidence"]
+        assert row["closure_prs"]
+
+
+def test_maturity_matrix_counts_are_deterministic() -> None:
+    payload_a = _built()
+    payload_b = _built()
+
+    assert json.dumps(payload_a, sort_keys=True) == json.dumps(payload_b, sort_keys=True)
+    assert payload_a["current_maturity"] == {"SCAFFOLD": 11, "WORKING_CAPABILITY": 9}
+    assert payload_a["target_maturity"] == {
+        "OPERATOR_TRUSTED": 14,
+        "WORKING_CAPABILITY": 6,
+    }
+
+
+def test_pr_sequence_covers_pr0_through_pr18_and_all_audit_items() -> None:
+    payload = _built()
+    prs = payload["gap_closure_prs"]
+    pr_ids = {row["pr"] for row in prs}
+
+    assert pr_ids == set(range(19))
+    assert prs[0]["title"] == "Audit gap closure plan and maturity matrix"
+    for item in payload["audit_items"]:
+        assert set(item["closure_prs"]) <= pr_ids
+        assert item["closure_prs"], item["audit_item"]
+
+
+def test_forbidden_shortcuts_and_safety_flags_stay_fail_closed() -> None:
+    payload = _built()
+
+    for shortcut in {
+        "source_to_alpha",
+        "cache_to_trade",
+        "diagnostic_to_trade",
+        "retrieval_to_authority",
+        "knowledge_graph_to_truth",
+        "identity_ambiguity_to_escalation",
+        "throughput_bypasses_source_quality",
+    }:
+        assert shortcut in payload["blocked_shortcuts"]
+
+    for key in (
+        "safe_to_strategy_synthesis",
+        "safe_to_shadow",
+        "safe_to_paper",
+        "safe_to_live",
+    ):
+        assert payload[key] is False
+
+    assert payload["safety_invariants"]["runs_research"] is False
+    assert payload["safety_invariants"]["launches_campaigns"] is False
+    assert payload["safety_invariants"]["mutates_research_outputs"] is False
+
+
+def test_source_lifecycle_gates_block_candidate_to_active_jump() -> None:
+    payload = _built()
+    pr1 = next(row for row in payload["gap_closure_prs"] if row["pr"] == 1)
+
+    assert pr1["depends_on"] == [0]
+    assert "tests blocking candidate to active_read_only jumps" in pr1["main_artifacts_tests"]
+    assert set(pr1["required_gates"]) == {
+        "manifest_completeness",
+        "allowed_use_declared",
+        "forbidden_use_declared",
+        "quality_gates_passed",
+        "identity_mapping_present",
+        "historical_lineage_present",
+    }
+
+
+def test_identity_ambiguity_blocks_escalation() -> None:
+    payload = _built()
+    pr3 = next(row for row in payload["gap_closure_prs"] if row["pr"] == 3)
+    pr10 = next(row for row in payload["gap_closure_prs"] if row["pr"] == 10)
+
+    assert "ambiguity blocks escalation tests" in pr3["main_artifacts_tests"]
+    assert "ambiguity blocks escalation tests" in pr10["main_artifacts_tests"]
+    assert "identity_ambiguity_to_escalation" in payload["blocked_shortcuts"]
+
+
+def test_throughput_depends_on_source_quality_gates() -> None:
+    payload = _built()
+    pr6 = next(row for row in payload["gap_closure_prs"] if row["pr"] == 6)
+
+    assert set(pr6["required_gates"]) == {"source_quality_ready", "cache_manifest_ready"}
+    assert 1 in pr6["depends_on"]
+    assert "throughput_bypasses_source_quality" in payload["blocked_shortcuts"]
+
+
+def test_rendered_markdown_contains_operator_sections() -> None:
+    rendered = plan.render_markdown(_built())
+
+    assert "# QRE Audit Gap Closure Plan" in rendered
+    assert "## Current-To-Target Matrix" in rendered
+    assert "## PR Sequence" in rendered
+    assert "## Blocked Shortcuts" in rendered
+    assert "PR1" in rendered
+    assert "safe_to_live: False" in rendered
+
+
+def test_write_outputs_are_allowlisted(tmp_path: Path) -> None:
+    payload = _built()
+
+    paths = plan.write_outputs(payload, repo_root=tmp_path)
+
+    assert paths == {
+        "latest": "logs/qre_audit_gap_closure_plan/latest.json",
+        "operator_plan": "docs/roadmap/qre_audit_gap_closure_plan.md",
+    }
+    assert (tmp_path / paths["latest"]).is_file()
+    assert (tmp_path / paths["operator_plan"]).is_file()
+    written = json.loads((tmp_path / paths["latest"]).read_text(encoding="utf-8"))
+    assert written["summary"]["audit_item_count"] == 20
+
+
+def test_validate_write_target_refuses_unexpected_path(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        plan._validate_write_target(tmp_path / "research" / "research_latest.json")
+
+
+def test_cli_no_write_outputs_json_without_writing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(plan, "DEFAULT_OUTPUT_DIR", Path("logs/qre_audit_gap_closure_plan"))
+    monkeypatch.chdir(tmp_path)
+
+    rc = plan.main([])
+
+    assert rc == 0
+    assert not (tmp_path / "logs/qre_audit_gap_closure_plan/latest.json").exists()
+    parsed = json.loads(capsys.readouterr().out)
+    assert parsed["summary"]["audit_item_count"] == 20
+
+
+def test_source_has_no_runtime_launch_or_network_calls() -> None:
+    src = Path(plan.__file__).read_text(encoding="utf-8")
+    forbidden = (
+        "import subprocess",
+        "from subprocess",
+        "subprocess.",
+        "import socket",
+        "from socket",
+        "import requests",
+        "import httpx",
+        "import aiohttp",
+        "import urllib",
+        "from urllib",
+        "os.system",
+        "os.popen",
+        "shell=True",
+        "git ",
+        "gh ",
+        "codex ",
+    )
+    for token in forbidden:
+        assert token not in src, token


### PR DESCRIPTION
## Summary
- add a deterministic PR0 audit gap closure planner in esearch/
- add unit coverage for roadmap completeness, gates, and fail-closed safety
- add the generated operator roadmap document under docs/roadmap/

## Scope
- queue item: PR0 — Audit gap closure plan and maturity matrix
- operator approval: explicit PR0-only path-scope approval granted in-session for these files:
  - esearch/qre_audit_gap_closure_plan.py
  - 	ests/unit/test_qre_audit_gap_closure_plan.py
  - docs/roadmap/qre_audit_gap_closure_plan.md

## Validation
- python -m pytest tests/unit/test_qre_audit_gap_closure_plan.py -q
- python scripts/governance_lint.py
- python -m pytest tests/smoke -q
- git diff --check
- git diff -- research/research_latest.json research/strategy_matrix.csv

## Forbidden Scope Confirmation
- no direct push to main
- no test weakening
- no mutation of esearch/research_latest.json
- no mutation of esearch/strategy_matrix.csv
- no live/paper/shadow/risk/broker/execution changes
- no strategy synthesis or campaign launcher

## Rollback
- revert the squash merge for this PR if any post-merge gate or deploy gate fails.