### PR TITLE
feat: add QRE source lifecycle quality gate contract

### DIFF
--- a/packages/qre_data/source_lifecycle.py
+++ b/packages/qre_data/source_lifecycle.py
@@ -1,0 +1,223 @@
+"""Deterministic read-only source lifecycle and transition gates."""
+
+from __future__ import annotations
+
+from typing import Any, Final, Mapping
+
+
+SCHEMA_VERSION: Final[str] = "1.0"
+LIFECYCLE_STATES: Final[tuple[str, ...]] = (
+    "candidate",
+    "manual_research_only",
+    "staging",
+    "quality_gated",
+    "active_read_only",
+    "deprecated",
+    "blocked",
+)
+
+ACTIVE_READ_ONLY_GATE_NAMES: Final[tuple[str, ...]] = (
+    "manifest_completeness",
+    "allowed_use_declared",
+    "forbidden_use_declared",
+    "quality_gates_declared",
+    "quality_gates_passed",
+    "identity_mapping_present",
+    "historical_lineage_present",
+)
+
+_UNKNOWN_TEXT: Final[frozenset[str]] = frozenset({"", "unknown", "none", "null", "nan"})
+_IDENTITY_MARKERS: Final[tuple[str, ...]] = (
+    "identity_mapping",
+    "issuer_to_symbol_mapping",
+    "symbol_mapping",
+    "alias_resolution",
+    "figi",
+    "isin",
+    "ticker",
+)
+_STATIC_REPRO_MARKERS: Final[frozenset[str]] = frozenset(
+    {
+        "",
+        "unknown",
+        "static_registry_stub_only",
+        "manual_only",
+    }
+)
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _known_text(value: Any) -> bool:
+    return _text(value).lower() not in _UNKNOWN_TEXT
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value]
+
+
+def _manifest_completeness(manifest: Mapping[str, Any]) -> bool:
+    return (
+        _text(manifest.get("manifest_status")) == "VALID"
+        and _known_text(manifest.get("source_id"))
+        and _known_text(manifest.get("provider_id"))
+        and _known_text(manifest.get("license_terms_reference"))
+        and _known_text(manifest.get("schema_version"))
+        and bool(_string_list(manifest.get("required_quality_gates")))
+        and bool(_string_list(manifest.get("activation_requirements")))
+        and len(_string_list(manifest.get("manifest_block_reasons"))) == 0
+    )
+
+
+def _identity_mapping_present(manifest: Mapping[str, Any]) -> bool:
+    texts = (
+        _string_list(manifest.get("allowed_use"))
+        + _string_list(manifest.get("required_quality_gates"))
+        + _string_list(manifest.get("activation_requirements"))
+        + _string_list(manifest.get("factor_field_coverage_claims"))
+    )
+    lowered = " ".join(item.lower() for item in texts)
+    return any(marker in lowered for marker in _IDENTITY_MARKERS)
+
+
+def _historical_lineage_present(manifest: Mapping[str, Any]) -> bool:
+    method = _text(manifest.get("reproducibility_method")).lower()
+    return method not in _STATIC_REPRO_MARKERS
+
+
+def _required_forbidden_use_present(
+    manifest: Mapping[str, Any],
+    *,
+    required_forbidden_use: tuple[str, ...],
+) -> bool:
+    forbidden = set(_string_list(manifest.get("forbidden_use")))
+    return set(required_forbidden_use).issubset(forbidden)
+
+
+def evaluate_source_lifecycle(
+    manifest: Mapping[str, Any],
+    *,
+    required_forbidden_use: tuple[str, ...],
+    source_quality_ready: bool,
+    license_allows_quality_gate: bool,
+    license_allows_active_read_only: bool,
+) -> dict[str, Any]:
+    """Evaluate deterministic lifecycle gates for one source manifest row."""
+
+    current_state = _text(manifest.get("source_status")) or "unknown"
+    if current_state not in LIFECYCLE_STATES:
+        current_state = "blocked"
+
+    gate_statuses = {
+        "manifest_completeness": _manifest_completeness(manifest),
+        "allowed_use_declared": bool(_string_list(manifest.get("allowed_use"))),
+        "forbidden_use_declared": _required_forbidden_use_present(
+            manifest,
+            required_forbidden_use=required_forbidden_use,
+        ),
+        "quality_gates_declared": bool(_string_list(manifest.get("required_quality_gates"))),
+        "quality_gates_passed": bool(source_quality_ready and license_allows_quality_gate),
+        "identity_mapping_present": _identity_mapping_present(manifest),
+        "historical_lineage_present": _historical_lineage_present(manifest),
+    }
+
+    blocked_gate_reasons = [
+        gate_name for gate_name in ACTIVE_READ_ONLY_GATE_NAMES if not gate_statuses[gate_name]
+    ]
+
+    quality_gated_allowed = (
+        current_state in {"candidate", "manual_research_only", "staging", "quality_gated", "active_read_only"}
+        and gate_statuses["manifest_completeness"]
+        and gate_statuses["allowed_use_declared"]
+        and gate_statuses["forbidden_use_declared"]
+        and gate_statuses["quality_gates_declared"]
+        and license_allows_quality_gate
+    )
+
+    active_read_only_allowed = (
+        current_state in {"quality_gated", "active_read_only"}
+        and not blocked_gate_reasons
+        and license_allows_active_read_only
+    )
+
+    transition_targets = {
+        "quality_gated": {
+            "allowed": bool(quality_gated_allowed),
+            "blocking_reasons": [] if quality_gated_allowed else sorted(
+                {
+                    *(
+                        reason
+                        for reason in (
+                            "manifest_completeness",
+                            "allowed_use_declared",
+                            "forbidden_use_declared",
+                            "quality_gates_declared",
+                        )
+                        if not gate_statuses[reason]
+                    ),
+                    *([] if license_allows_quality_gate else ["license_allows_quality_gate"]),
+                }
+            ),
+        },
+        "active_read_only": {
+            "allowed": bool(active_read_only_allowed),
+            "blocking_reasons": [] if active_read_only_allowed else sorted(
+                {
+                    *blocked_gate_reasons,
+                    *(
+                        []
+                        if current_state in {"quality_gated", "active_read_only"}
+                        else ["transition_requires_quality_gated_state"]
+                    ),
+                    *([] if license_allows_active_read_only else ["license_allows_active_read_only"]),
+                }
+            ),
+        },
+    }
+
+    lifecycle_status = (
+        "active_read_only_ready"
+        if transition_targets["active_read_only"]["allowed"]
+        else "quality_gated_ready"
+        if transition_targets["quality_gated"]["allowed"]
+        else "blocked"
+    )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "source_id": _text(manifest.get("source_id")),
+        "provider_id": _text(manifest.get("provider_id")),
+        "current_state": current_state,
+        "lifecycle_status": lifecycle_status,
+        "gate_statuses": gate_statuses,
+        "transition_targets": transition_targets,
+        "license_allows_quality_gate": bool(license_allows_quality_gate),
+        "license_allows_active_read_only": bool(license_allows_active_read_only),
+        "source_quality_ready": bool(source_quality_ready),
+        "operator_explanation": (
+            "Source lifecycle gates are satisfied for active_read_only."
+            if transition_targets["active_read_only"]["allowed"]
+            else "Source lifecycle remains fail-closed until manifest, quality, identity, "
+            "and historical lineage gates are explicit."
+        ),
+        "safety_invariants": {
+            "read_only": True,
+            "fetches_external_data": False,
+            "mutates_runtime_state": False,
+            "promotes_candidates": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+        },
+    }
+
+
+__all__ = [
+    "ACTIVE_READ_ONLY_GATE_NAMES",
+    "LIFECYCLE_STATES",
+    "SCHEMA_VERSION",
+    "evaluate_source_lifecycle",
+]

--- a/research/qre_source_lifecycle_quality_gate.py
+++ b/research/qre_source_lifecycle_quality_gate.py
@@ -1,0 +1,216 @@
+"""Read-only QRE source lifecycle and quality gate materialization."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+from packages.qre_data import source_lifecycle
+from packages.qre_data import source_quality_readiness
+from research.external_intelligence import source_license_policy
+from research.external_intelligence import source_manifest_registry
+from research.external_intelligence.source_manifest_schema import (
+    FORBIDDEN_USE_VOCABULARY,
+)
+
+
+REPORT_KIND: Final[str] = "qre_source_lifecycle_quality_gate"
+SCHEMA_VERSION: Final[str] = "1.0"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_source_lifecycle_quality_gate")
+LATEST_NAME: Final[str] = "latest.json"
+SUMMARY_NAME: Final[str] = "operator_summary.md"
+WRITE_PREFIX: Final[str] = "logs/qre_source_lifecycle_quality_gate/"
+
+
+def _table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> str:
+    head = "| " + " | ".join(headers) + " |"
+    divider = "| " + " | ".join(["---"] * len(headers)) + " |"
+    body = ["| " + " | ".join(row) + " |" for row in rows]
+    return "\n".join([head, divider, *body])
+
+
+def build_source_lifecycle_quality_gate(
+    *,
+    repo_root: Path = Path("."),
+) -> dict[str, Any]:
+    registry = source_manifest_registry.build_source_manifest_registry()
+    source_quality_status = source_quality_readiness.read_source_quality_status(repo_root=repo_root)
+    source_quality_ready = bool(source_quality_status.get("research_ready"))
+
+    rows: list[dict[str, Any]] = []
+    for manifest in registry["rows"]:
+        policy = source_license_policy.evaluate_license_policy(manifest)
+        lifecycle = source_lifecycle.evaluate_source_lifecycle(
+            manifest,
+            required_forbidden_use=FORBIDDEN_USE_VOCABULARY,
+            source_quality_ready=source_quality_ready,
+            license_allows_quality_gate=bool(policy["allowed_for_quality_gate"]),
+            license_allows_active_read_only=bool(policy["allowed_for_active_read_only"]),
+        )
+        row = {
+            "source_id": lifecycle["source_id"],
+            "provider_id": lifecycle["provider_id"],
+            "current_state": lifecycle["current_state"],
+            "lifecycle_status": lifecycle["lifecycle_status"],
+            "gate_statuses": lifecycle["gate_statuses"],
+            "transition_targets": lifecycle["transition_targets"],
+            "license_policy_status": policy["license_policy_status"],
+            "license_block_reasons": policy["block_reasons"],
+            "source_quality_ready": lifecycle["source_quality_ready"],
+            "operator_explanation": lifecycle["operator_explanation"],
+        }
+        rows.append(row)
+    rows.sort(key=lambda row: (str(row["provider_id"]), str(row["source_id"])))
+
+    lifecycle_counts = Counter(str(row["lifecycle_status"]) for row in rows)
+    current_state_counts = Counter(str(row["current_state"]) for row in rows)
+    blocked_active_counts = Counter(
+        reason
+        for row in rows
+        for reason in row["transition_targets"]["active_read_only"]["blocking_reasons"]
+    )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "summary": {
+            "source_count": len(rows),
+            "current_state_counts": dict(sorted(current_state_counts.items())),
+            "lifecycle_status_counts": dict(sorted(lifecycle_counts.items())),
+            "active_read_only_ready_count": sum(
+                1 for row in rows if bool(row["transition_targets"]["active_read_only"]["allowed"])
+            ),
+            "quality_gated_ready_count": sum(
+                1 for row in rows if bool(row["transition_targets"]["quality_gated"]["allowed"])
+            ),
+            "active_read_only_blocking_reason_counts": dict(sorted(blocked_active_counts.items())),
+            "source_quality_report_status": str(source_quality_status.get("status") or "missing"),
+            "source_quality_report_ready": source_quality_ready,
+            "operator_summary": (
+                "Source lifecycle promotion remains fail-closed. Candidate, manual, and staging "
+                "sources cannot become active_read_only until manifest completeness, declared "
+                "allowed/forbidden use, quality gates, identity mapping, and historical lineage "
+                "or reproducibility are all explicit."
+            ),
+        },
+        "rows": rows,
+        "supporting_reports": {
+            "source_manifest_registry": {
+                "report_kind": registry["report_kind"],
+                "active_read_only_eligible_providers": registry["summary"][
+                    "active_read_only_eligible_providers"
+                ],
+                "quality_gated_eligible_providers": registry["summary"][
+                    "quality_gated_eligible_providers"
+                ],
+            },
+            "source_quality_status": source_quality_status,
+        },
+        "safety_invariants": {
+            "read_only": True,
+            "fetches_external_data": False,
+            "mutates_runtime_state": False,
+            "mutates_research_outputs": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+            "promotion_forbidden": True,
+        },
+    }
+
+
+def render_operator_summary(report: Mapping[str, Any]) -> str:
+    summary = report.get("summary") if isinstance(report.get("summary"), Mapping) else {}
+    rows = report.get("rows") if isinstance(report.get("rows"), list) else []
+    state_table = _table(
+        ["Field", "Value"],
+        [
+            ["source_count", str(summary.get("source_count") or 0)],
+            ["source_quality_report_status", str(summary.get("source_quality_report_status") or "")],
+            ["source_quality_report_ready", str(summary.get("source_quality_report_ready") or False)],
+            ["quality_gated_ready_count", str(summary.get("quality_gated_ready_count") or 0)],
+            ["active_read_only_ready_count", str(summary.get("active_read_only_ready_count") or 0)],
+        ],
+    )
+    row_table = _table(
+        ["source_id", "current_state", "quality_gated", "active_read_only", "license_policy_status"],
+        [
+            [
+                str(row.get("source_id") or ""),
+                str(row.get("current_state") or ""),
+                str((row.get("transition_targets") or {}).get("quality_gated", {}).get("allowed") or False),
+                str((row.get("transition_targets") or {}).get("active_read_only", {}).get("allowed") or False),
+                str(row.get("license_policy_status") or ""),
+            ]
+            for row in rows
+            if isinstance(row, Mapping)
+        ],
+    )
+    return "\n".join(
+        [
+            "# QRE Source Lifecycle and Quality Gate",
+            "",
+            f"- {summary.get('operator_summary') or ''}",
+            "",
+            "## Status",
+            state_table,
+            "",
+            "## Source Rows",
+            row_table,
+        ]
+    )
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(
+            f"qre_source_lifecycle_quality_gate: refusing write outside allowlist: {path!r}"
+        )
+
+
+def write_outputs(
+    report: Mapping[str, Any],
+    *,
+    repo_root: Path = Path("."),
+) -> dict[str, str]:
+    base = repo_root / DEFAULT_OUTPUT_DIR
+    base.mkdir(parents=True, exist_ok=True)
+    latest = base / LATEST_NAME
+    summary = base / SUMMARY_NAME
+    for target in (latest, summary):
+        _validate_write_target(target)
+
+    tmp_latest = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_latest.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp_latest, latest)
+
+    tmp_summary = summary.with_suffix(summary.suffix + ".tmp")
+    tmp_summary.write_text(render_operator_summary(report) + "\n", encoding="utf-8")
+    os.replace(tmp_summary, summary)
+
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "operator_summary": summary.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_source_lifecycle_quality_gate",
+        description="Materialize the read-only QRE source lifecycle quality gate report.",
+    )
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    report = build_source_lifecycle_quality_gate()
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/architecture/test_package_migration_001_target_layout.py
+++ b/tests/architecture/test_package_migration_001_target_layout.py
@@ -145,6 +145,7 @@ def test_package_migration_001_qre_data_has_only_bounded_read_only_seed() -> Non
         "__init__.py",
         "cache_manifest.py",
         "contracts.py",
+        "source_lifecycle.py",
         "source_quality_readiness.py",
     ], target
 
@@ -176,6 +177,7 @@ def test_package_migration_001_scanner_classifies_target_paths() -> None:
     assert classify_path("packages/qre_data/README.md") == DOMAIN_QRE
     assert classify_path("packages/qre_data/cache_manifest.py") == DOMAIN_QRE
     assert classify_path("packages/qre_data/contracts.py") == DOMAIN_QRE
+    assert classify_path("packages/qre_data/source_lifecycle.py") == DOMAIN_QRE
     assert classify_path("packages/qre_data/source_quality_readiness.py") == DOMAIN_QRE
     assert classify_path("packages/qre_artifacts/README.md") == DOMAIN_QRE
     assert classify_path("packages/qre_artifacts/public_outputs.py") == DOMAIN_QRE
@@ -192,6 +194,7 @@ def test_package_migration_001_scanner_classifies_target_paths() -> None:
     assert classify_module("packages.qre_research.universe") == DOMAIN_QRE
     assert classify_module("packages.qre_data.cache_manifest") == DOMAIN_QRE
     assert classify_module("packages.qre_data.contracts") == DOMAIN_QRE
+    assert classify_module("packages.qre_data.source_lifecycle") == DOMAIN_QRE
     assert classify_module("packages.qre_data.source_quality_readiness") == DOMAIN_QRE
     assert classify_module("packages.qre_artifacts.public_outputs") == DOMAIN_QRE
     assert classify_module("packages.qre_diagnostics.research_diagnostics_loop") == DOMAIN_QRE

--- a/tests/architecture/test_package_migration_010_closure_decision.py
+++ b/tests/architecture/test_package_migration_010_closure_decision.py
@@ -43,6 +43,7 @@ BOUNDED_PACKAGE_CONTENTS = {
         "__init__.py",
         "cache_manifest.py",
         "contracts.py",
+        "source_lifecycle.py",
         "source_quality_readiness.py",
     ],
     "qre_artifacts": ["README.md", "__init__.py", "public_outputs.py"],

--- a/tests/unit/test_qre_data_source_lifecycle.py
+++ b/tests/unit/test_qre_data_source_lifecycle.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from packages.qre_data import source_lifecycle
+
+
+REQUIRED_FORBIDDEN = (
+    "trade_signal",
+    "buy_list",
+    "sell_list",
+    "strategy_registration",
+    "candidate_promotion",
+    "paper_activation",
+    "shadow_activation",
+    "live_activation",
+    "capital_allocation",
+    "broker_execution",
+    "fundamental_field_readiness",
+)
+
+
+def _manifest(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "source_id": "fixture_source",
+        "provider_id": "fixture_provider",
+        "source_status": "candidate",
+        "manifest_status": "VALID",
+        "license_terms_reference": "fixture_terms",
+        "schema_version": "1.0",
+        "allowed_use": ["identity_mapping", "operator_explanation", "source_candidate_research"],
+        "forbidden_use": list(REQUIRED_FORBIDDEN),
+        "required_quality_gates": ["identity_mapping_quality_gate", "source_manifest_quality_pass"],
+        "activation_requirements": [
+            "identity_mapping_quality_gate",
+            "source_manifest_quality_pass",
+            "historical_lineage_present",
+        ],
+        "factor_field_coverage_claims": ["identity_mapping"],
+        "manifest_block_reasons": [],
+        "reproducibility_method": "snapshot_lineage_manifest_v1",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_candidate_cannot_jump_directly_to_active_read_only() -> None:
+    result = source_lifecycle.evaluate_source_lifecycle(
+        _manifest(),
+        required_forbidden_use=REQUIRED_FORBIDDEN,
+        source_quality_ready=True,
+        license_allows_quality_gate=True,
+        license_allows_active_read_only=True,
+    )
+
+    assert result["transition_targets"]["quality_gated"]["allowed"] is True
+    assert result["transition_targets"]["active_read_only"]["allowed"] is False
+    assert result["transition_targets"]["active_read_only"]["blocking_reasons"] == [
+        "transition_requires_quality_gated_state"
+    ]
+
+
+def test_active_read_only_requires_historical_lineage_and_identity_mapping() -> None:
+    result = source_lifecycle.evaluate_source_lifecycle(
+        _manifest(
+            source_status="quality_gated",
+            reproducibility_method="static_registry_stub_only",
+            allowed_use=["operator_explanation", "source_candidate_research"],
+            required_quality_gates=["source_manifest_quality_pass"],
+            activation_requirements=["historical_lineage_present"],
+            factor_field_coverage_claims=["fundamental_field_candidate"],
+        ),
+        required_forbidden_use=REQUIRED_FORBIDDEN,
+        source_quality_ready=True,
+        license_allows_quality_gate=True,
+        license_allows_active_read_only=True,
+    )
+
+    assert result["transition_targets"]["active_read_only"]["allowed"] is False
+    assert result["gate_statuses"]["identity_mapping_present"] is False
+    assert result["gate_statuses"]["historical_lineage_present"] is False
+    assert "identity_mapping_present" in result["transition_targets"]["active_read_only"][
+        "blocking_reasons"
+    ]
+    assert "historical_lineage_present" in result["transition_targets"]["active_read_only"][
+        "blocking_reasons"
+    ]
+
+
+def test_active_read_only_requires_all_declared_gates_to_pass() -> None:
+    result = source_lifecycle.evaluate_source_lifecycle(
+        _manifest(source_status="quality_gated"),
+        required_forbidden_use=REQUIRED_FORBIDDEN,
+        source_quality_ready=False,
+        license_allows_quality_gate=True,
+        license_allows_active_read_only=False,
+    )
+
+    assert result["transition_targets"]["active_read_only"]["allowed"] is False
+    assert result["gate_statuses"]["quality_gates_passed"] is False
+    assert result["transition_targets"]["active_read_only"]["blocking_reasons"] == [
+        "license_allows_active_read_only",
+        "quality_gates_passed",
+    ]
+
+
+def test_quality_gated_and_active_read_only_are_allowed_only_when_all_gates_are_explicit() -> None:
+    result = source_lifecycle.evaluate_source_lifecycle(
+        _manifest(source_status="active_read_only"),
+        required_forbidden_use=REQUIRED_FORBIDDEN,
+        source_quality_ready=True,
+        license_allows_quality_gate=True,
+        license_allows_active_read_only=True,
+    )
+
+    assert result["lifecycle_status"] == "active_read_only_ready"
+    assert result["transition_targets"]["quality_gated"]["allowed"] is True
+    assert result["transition_targets"]["active_read_only"]["allowed"] is True
+    assert all(result["gate_statuses"].values()) is True

--- a/tests/unit/test_qre_source_lifecycle_quality_gate.py
+++ b/tests/unit/test_qre_source_lifecycle_quality_gate.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from packages.qre_data import source_quality_readiness
+from research import qre_source_lifecycle_quality_gate as report
+
+
+def _manifest_payload() -> dict[str, object]:
+    return {
+        "schema_version": "1.0",
+        "summary": {"research_ready": True},
+        "files": [
+            {
+                "path": "data/cache/market/yfinance__AAPL__1d__20260401__20260402__abc123.parquet",
+                "cache_kind": "market",
+                "source": "yfinance",
+                "instrument": "AAPL",
+                "timeframe": "1d",
+                "status": "ready",
+                "row_count": 1,
+                "min_timestamp_utc": "2026-04-01T00:00:00Z",
+                "max_timestamp_utc": "2026-04-01T00:00:00Z",
+                "content_hash": "sha256:abc123",
+            }
+        ],
+    }
+
+
+def _seed_source_quality(tmp_path: Path) -> None:
+    manifest_payload = _manifest_payload()
+    source_payload = source_quality_readiness.build_source_quality_report(
+        manifest_payload,
+        generated_at_utc="2026-06-15T00:00:00Z",
+    )
+    source_quality_readiness.write_source_quality_outputs(
+        source_payload,
+        output_dir=Path("logs/qre_data_source_quality_readiness"),
+        repo_root=tmp_path,
+    )
+
+
+def test_report_fails_closed_without_source_quality_status(tmp_path: Path) -> None:
+    payload = report.build_source_lifecycle_quality_gate(repo_root=tmp_path)
+
+    assert payload["summary"]["source_quality_report_ready"] is False
+    assert payload["summary"]["active_read_only_ready_count"] == 0
+    assert payload["summary"]["quality_gated_ready_count"] == 0
+    assert payload["summary"]["active_read_only_blocking_reason_counts"][
+        "quality_gates_passed"
+    ] > 0
+    assert "transition_requires_quality_gated_state" in payload["summary"][
+        "active_read_only_blocking_reason_counts"
+    ]
+
+
+def test_report_keeps_current_manifests_fail_closed_even_with_ready_source_quality(
+    tmp_path: Path,
+) -> None:
+    _seed_source_quality(tmp_path)
+
+    payload = report.build_source_lifecycle_quality_gate(repo_root=tmp_path)
+    paths = report.write_outputs(payload, repo_root=tmp_path)
+
+    assert payload["summary"]["source_quality_report_ready"] is True
+    assert payload["summary"]["active_read_only_ready_count"] == 0
+    assert payload["summary"]["quality_gated_ready_count"] == 0
+    assert payload["summary"]["lifecycle_status_counts"]["blocked"] == payload["summary"][
+        "source_count"
+    ]
+    assert payload["supporting_reports"]["source_manifest_registry"][
+        "active_read_only_eligible_providers"
+    ] == []
+    assert paths["latest"] == "logs/qre_source_lifecycle_quality_gate/latest.json"
+    assert paths["operator_summary"] == "logs/qre_source_lifecycle_quality_gate/operator_summary.md"
+    assert (tmp_path / paths["latest"]).is_file()
+    assert (tmp_path / paths["operator_summary"]).is_file()
+
+
+def test_source_has_no_runtime_launch_or_network_calls() -> None:
+    src = Path(report.__file__).read_text(encoding="utf-8")
+    forbidden = (
+        "import subprocess",
+        "from subprocess",
+        "subprocess.",
+        "import socket",
+        "from socket",
+        "import requests",
+        "import httpx",
+        "import aiohttp",
+        "import urllib",
+        "from urllib",
+        "os.system",
+        "os.popen",
+        "shell=True",
+        "git ",
+        "gh ",
+        "codex ",
+    )
+    for token in forbidden:
+        assert token not in src, token


### PR DESCRIPTION
## Summary
- add a deterministic source lifecycle evaluator under packages/qre_data
- add a read-only PR1 lifecycle gate report under esearch/
- add deterministic tests that block candidate/manual_research_only/staging promotion to ctive_read_only without explicit gates

## Queue Item
- PR1 — Source lifecycle and quality gate contract

## NEEDS_HUMAN Override
- classifier result for the touched packages/qre_data/..., esearch/..., and 	ests/unit/... paths was NEEDS_HUMAN
- this PR remains inside the operator pre-approved PR1–PR18 QRE audit gap-closure scope: read-only/report-only/source-quality/data-readiness infrastructure only
- no frozen contract mutation, no live/paper/shadow/risk/broker/execution changes, no strategy synthesis, no campaign launcher

## Validation
- python -m pytest tests/unit/test_qre_data_source_lifecycle.py tests/unit/test_qre_source_lifecycle_quality_gate.py -q
- python -m pytest tests/unit/test_source_manifest_registry.py tests/unit/test_source_manifest_schema.py tests/unit/test_source_license_policy.py tests/unit/test_qre_data_source_quality_readiness.py tests/unit/test_qre_source_cache_readiness_materialization.py tests/unit/test_sec_companyfacts_manifest.py tests/unit/test_openfigi_identity_manifest.py -q
- python -m research.qre_source_lifecycle_quality_gate --write
- python scripts/governance_lint.py
- python -m pytest tests/smoke -q
- git diff --check
- git diff -- research/research_latest.json research/strategy_matrix.csv

## Scope Notes
- current manifests remain fail-closed; ctive_read_only_ready_count stays zero
- lifecycle promotion stays report-only and does not activate any source adapter

## Rollback
- revert the squash merge if post-merge gates or deploy/path-guard checks fail