### PR TITLE
feat: add QRE historical accounting foundation

### DIFF
--- a/packages/qre_data/historical_accounting.py
+++ b/packages/qre_data/historical_accounting.py
@@ -1,0 +1,147 @@
+"""Deterministic read-only historical accounting snapshot contracts."""
+
+from __future__ import annotations
+
+from typing import Any, Final, Mapping
+
+
+SCHEMA_VERSION: Final[str] = "1.0"
+SNAPSHOT_GATE_NAMES: Final[tuple[str, ...]] = (
+    "point_in_time_policy_declared",
+    "report_lag_policy_supported",
+    "restatement_policy_supported",
+    "historical_lineage_reproducible",
+    "no_lookahead_snapshot_contract",
+)
+SNAPSHOT_STATUS_VOCABULARY: Final[tuple[str, ...]] = (
+    "NOT_REQUIRED",
+    "BLOCKED",
+    "READY",
+)
+_UNKNOWN_TEXT: Final[frozenset[str]] = frozenset({"", "unknown", "none", "null", "nan"})
+_FAIL_CLOSED_POLICY_STATUSES: Final[frozenset[str]] = frozenset(
+    {
+        "FAIL_CLOSED",
+        "POLICY_MISSING",
+        "UNSUPPORTED",
+        "UNKNOWN",
+        "REQUIRED",
+        "REVIEW_REQUIRED",
+    }
+)
+_STATIC_REPRO_MARKERS: Final[frozenset[str]] = frozenset(
+    {
+        "",
+        "unknown",
+        "static_registry_stub_only",
+        "manual_only",
+    }
+)
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value]
+
+
+def _supports_historical_accounting(manifest: Mapping[str, Any]) -> bool:
+    source_type = _text(manifest.get("source_type"))
+    return source_type in {"fundamental_statement_data", "fundamental_connector", "fundamentals"}
+
+
+def _pit_policy_declared(manifest: Mapping[str, Any]) -> bool:
+    activation_requirements = [item.lower() for item in _string_list(manifest.get("activation_requirements"))]
+    required_quality_gates = [item.lower() for item in _string_list(manifest.get("required_quality_gates"))]
+    return (
+        "point_in_time_policy_defined" in activation_requirements
+        or "point_in_time_policy_defined" in required_quality_gates
+    )
+
+
+def _lineage_reproducible(manifest: Mapping[str, Any]) -> bool:
+    method = _text(manifest.get("reproducibility_method")).lower()
+    return method not in _STATIC_REPRO_MARKERS
+
+
+def _policy_gate(policy_row: Mapping[str, Any]) -> bool:
+    status = _text(policy_row.get("policy_status")).upper()
+    return status in {"SUPPORTED", "PARTIALLY_SUPPORTED"}
+
+
+def evaluate_historical_accounting_snapshot(
+    manifest: Mapping[str, Any],
+    *,
+    report_lag_policy_row: Mapping[str, Any],
+    restatement_policy_row: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Evaluate read-only PIT/report-lag/restatement snapshot readiness."""
+
+    required = _supports_historical_accounting(manifest)
+    gate_statuses = {
+        "point_in_time_policy_declared": _pit_policy_declared(manifest),
+        "report_lag_policy_supported": _policy_gate(report_lag_policy_row),
+        "restatement_policy_supported": _policy_gate(restatement_policy_row),
+        "historical_lineage_reproducible": _lineage_reproducible(manifest),
+        "no_lookahead_snapshot_contract": False,
+    }
+    gate_statuses["no_lookahead_snapshot_contract"] = all(
+        gate_statuses[name]
+        for name in (
+            "point_in_time_policy_declared",
+            "report_lag_policy_supported",
+            "restatement_policy_supported",
+            "historical_lineage_reproducible",
+        )
+    )
+
+    blocked_gates = [name for name in SNAPSHOT_GATE_NAMES if not gate_statuses[name]]
+    snapshot_status = "NOT_REQUIRED"
+    if required:
+        snapshot_status = "READY" if not blocked_gates else "BLOCKED"
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "source_id": _text(manifest.get("source_id")),
+        "provider_id": _text(manifest.get("provider_id")),
+        "source_type": _text(manifest.get("source_type")),
+        "requires_historical_accounting": required,
+        "report_lag_policy_status": _text(report_lag_policy_row.get("policy_status")).upper() or "UNKNOWN",
+        "restatement_policy_status": _text(restatement_policy_row.get("policy_status")).upper() or "UNKNOWN",
+        "report_lag_support_status": _text(report_lag_policy_row.get("support_status")).upper() or "UNKNOWN",
+        "restatement_support_status": _text(restatement_policy_row.get("support_status")).upper() or "UNKNOWN",
+        "point_in_time_policy_declared": gate_statuses["point_in_time_policy_declared"],
+        "historical_lineage_reproducible": gate_statuses["historical_lineage_reproducible"],
+        "gate_statuses": gate_statuses,
+        "snapshot_contract_status": snapshot_status,
+        "blocking_reasons": [] if snapshot_status != "BLOCKED" else blocked_gates,
+        "operator_explanation": (
+            "Historical accounting snapshot contract is not required for this source type."
+            if not required
+            else "Historical accounting remains fail-closed until point-in-time policy, "
+            "report-lag, restatement, and reproducible lineage are all explicit."
+            if blocked_gates
+            else "Historical accounting snapshot contract is explicit and no-lookahead safe."
+        ),
+        "safety_invariants": {
+            "read_only": True,
+            "fetches_external_data": False,
+            "mutates_runtime_state": False,
+            "mutates_frozen_contracts": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+            "lookahead_contamination_forbidden": True,
+        },
+    }
+
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "SNAPSHOT_GATE_NAMES",
+    "SNAPSHOT_STATUS_VOCABULARY",
+    "evaluate_historical_accounting_snapshot",
+]

--- a/research/qre_historical_accounting_foundation.py
+++ b/research/qre_historical_accounting_foundation.py
@@ -1,0 +1,194 @@
+"""Read-only QRE historical accounting foundation materialization."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+from packages.qre_data import historical_accounting
+from research.data_readiness import report_lag_policy
+from research.data_readiness import restatement_policy
+from research.external_intelligence import source_manifest_registry
+
+
+REPORT_KIND: Final[str] = "qre_historical_accounting_foundation"
+SCHEMA_VERSION: Final[str] = "1.0"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_historical_accounting_foundation")
+LATEST_NAME: Final[str] = "latest.json"
+SUMMARY_NAME: Final[str] = "operator_summary.md"
+WRITE_PREFIX: Final[str] = "logs/qre_historical_accounting_foundation/"
+
+
+def _table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> str:
+    head = "| " + " | ".join(headers) + " |"
+    divider = "| " + " | ".join(["---"] * len(headers)) + " |"
+    body = ["| " + " | ".join(row) + " |" for row in rows]
+    return "\n".join([head, divider, *body])
+
+
+def build_historical_accounting_foundation() -> dict[str, Any]:
+    registry = source_manifest_registry.build_source_manifest_registry()
+    report_lag = report_lag_policy.build_report_lag_policy()
+    restatement = restatement_policy.build_restatement_policy()
+    report_lag_by_source = {
+        str(row["source_id"]): row
+        for row in report_lag["rows"]
+        if isinstance(row, Mapping)
+    }
+    restatement_by_source = {
+        str(row["source_id"]): row
+        for row in restatement["rows"]
+        if isinstance(row, Mapping)
+    }
+
+    rows: list[dict[str, Any]] = []
+    for manifest in registry["rows"]:
+        source_id = str(manifest["source_id"])
+        row = historical_accounting.evaluate_historical_accounting_snapshot(
+            manifest,
+            report_lag_policy_row=report_lag_by_source[source_id],
+            restatement_policy_row=restatement_by_source[source_id],
+        )
+        rows.append(row)
+    rows.sort(key=lambda row: (str(row["provider_id"]), str(row["source_id"])))
+
+    status_counts = Counter(str(row["snapshot_contract_status"]) for row in rows)
+    blocked_counts = Counter(reason for row in rows for reason in row["blocking_reasons"])
+    required_rows = [row for row in rows if bool(row["requires_historical_accounting"])]
+    no_lookahead_ready_count = sum(
+        1 for row in required_rows if bool(row["gate_statuses"]["no_lookahead_snapshot_contract"])
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "summary": {
+            "source_count": len(rows),
+            "required_source_count": len(required_rows),
+            "snapshot_contract_status_counts": dict(sorted(status_counts.items())),
+            "blocking_reason_counts": dict(sorted(blocked_counts.items())),
+            "no_lookahead_ready_count": no_lookahead_ready_count,
+            "required_blocked_count": sum(
+                1 for row in required_rows if str(row["snapshot_contract_status"]) == "BLOCKED"
+            ),
+            "operator_summary": (
+                "Historical accounting remains read-only and fail-closed. "
+                "Fundamental sources need explicit PIT policy, report-lag, restatement, "
+                "and reproducible lineage before any snapshot can be treated as no-lookahead safe."
+            ),
+        },
+        "rows": rows,
+        "supporting_reports": {
+            "source_manifest_registry": {"report_kind": registry["report_kind"]},
+            "report_lag_policy": {"report_kind": report_lag["report_kind"]},
+            "restatement_policy": {"report_kind": restatement["report_kind"]},
+        },
+        "safety_invariants": {
+            "read_only": True,
+            "fetches_external_data": False,
+            "mutates_runtime_state": False,
+            "mutates_research_outputs": False,
+            "mutates_frozen_contracts": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+            "lookahead_contamination_forbidden": True,
+            "point_in_time_foundation_only": True,
+        },
+    }
+
+
+def render_operator_summary(report: Mapping[str, Any]) -> str:
+    summary = report.get("summary") if isinstance(report.get("summary"), Mapping) else {}
+    rows = report.get("rows") if isinstance(report.get("rows"), list) else []
+    status_table = _table(
+        ["Field", "Value"],
+        [
+            ["source_count", str(summary.get("source_count") or 0)],
+            ["required_source_count", str(summary.get("required_source_count") or 0)],
+            ["no_lookahead_ready_count", str(summary.get("no_lookahead_ready_count") or 0)],
+            ["required_blocked_count", str(summary.get("required_blocked_count") or 0)],
+        ],
+    )
+    row_table = _table(
+        ["source_id", "required", "snapshot_status", "report_lag", "restatement", "blocked_by"],
+        [
+            [
+                str(row.get("source_id") or ""),
+                str(row.get("requires_historical_accounting") or False),
+                str(row.get("snapshot_contract_status") or ""),
+                str(row.get("report_lag_policy_status") or ""),
+                str(row.get("restatement_policy_status") or ""),
+                ",".join(str(value) for value in row.get("blocking_reasons") or []) or "none",
+            ]
+            for row in rows
+            if isinstance(row, Mapping)
+        ],
+    )
+    return "\n".join(
+        [
+            "# QRE Historical Accounting Foundation",
+            "",
+            f"- {summary.get('operator_summary') or ''}",
+            "",
+            "## Status",
+            status_table,
+            "",
+            "## Source Rows",
+            row_table,
+        ]
+    )
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(
+            f"qre_historical_accounting_foundation: refusing write outside allowlist: {path!r}"
+        )
+
+
+def write_outputs(
+    report: Mapping[str, Any],
+    *,
+    repo_root: Path = Path("."),
+) -> dict[str, str]:
+    base = repo_root / DEFAULT_OUTPUT_DIR
+    base.mkdir(parents=True, exist_ok=True)
+    latest = base / LATEST_NAME
+    summary = base / SUMMARY_NAME
+    for target in (latest, summary):
+        _validate_write_target(target)
+
+    tmp_latest = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_latest.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp_latest, latest)
+
+    tmp_summary = summary.with_suffix(summary.suffix + ".tmp")
+    tmp_summary.write_text(render_operator_summary(report) + "\n", encoding="utf-8")
+    os.replace(tmp_summary, summary)
+
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "operator_summary": summary.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_historical_accounting_foundation",
+        description="Materialize the read-only QRE historical accounting foundation report.",
+    )
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    report = build_historical_accounting_foundation()
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/architecture/test_package_migration_001_target_layout.py
+++ b/tests/architecture/test_package_migration_001_target_layout.py
@@ -145,6 +145,7 @@ def test_package_migration_001_qre_data_has_only_bounded_read_only_seed() -> Non
         "__init__.py",
         "cache_manifest.py",
         "contracts.py",
+        "historical_accounting.py",
         "source_lifecycle.py",
         "source_quality_readiness.py",
     ], target
@@ -177,6 +178,7 @@ def test_package_migration_001_scanner_classifies_target_paths() -> None:
     assert classify_path("packages/qre_data/README.md") == DOMAIN_QRE
     assert classify_path("packages/qre_data/cache_manifest.py") == DOMAIN_QRE
     assert classify_path("packages/qre_data/contracts.py") == DOMAIN_QRE
+    assert classify_path("packages/qre_data/historical_accounting.py") == DOMAIN_QRE
     assert classify_path("packages/qre_data/source_lifecycle.py") == DOMAIN_QRE
     assert classify_path("packages/qre_data/source_quality_readiness.py") == DOMAIN_QRE
     assert classify_path("packages/qre_artifacts/README.md") == DOMAIN_QRE
@@ -194,6 +196,7 @@ def test_package_migration_001_scanner_classifies_target_paths() -> None:
     assert classify_module("packages.qre_research.universe") == DOMAIN_QRE
     assert classify_module("packages.qre_data.cache_manifest") == DOMAIN_QRE
     assert classify_module("packages.qre_data.contracts") == DOMAIN_QRE
+    assert classify_module("packages.qre_data.historical_accounting") == DOMAIN_QRE
     assert classify_module("packages.qre_data.source_lifecycle") == DOMAIN_QRE
     assert classify_module("packages.qre_data.source_quality_readiness") == DOMAIN_QRE
     assert classify_module("packages.qre_artifacts.public_outputs") == DOMAIN_QRE

--- a/tests/architecture/test_package_migration_010_closure_decision.py
+++ b/tests/architecture/test_package_migration_010_closure_decision.py
@@ -43,6 +43,7 @@ BOUNDED_PACKAGE_CONTENTS = {
         "__init__.py",
         "cache_manifest.py",
         "contracts.py",
+        "historical_accounting.py",
         "source_lifecycle.py",
         "source_quality_readiness.py",
     ],

--- a/tests/unit/test_qre_data_historical_accounting.py
+++ b/tests/unit/test_qre_data_historical_accounting.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from packages.qre_data import historical_accounting
+
+
+def _manifest(**overrides: object) -> dict[str, object]:
+    row: dict[str, object] = {
+        "source_id": "sec_companyfacts_manifest",
+        "provider_id": "sec",
+        "source_type": "fundamentals",
+        "activation_requirements": [
+            "operator_license_approval",
+            "point_in_time_policy_defined",
+            "source_manifest_quality_pass",
+        ],
+        "reproducibility_method": "versioned_quarterly_snapshot",
+    }
+    row.update(overrides)
+    return row
+
+
+def _policy_row(status: str, support: str) -> dict[str, object]:
+    return {
+        "policy_status": status,
+        "support_status": support,
+    }
+
+
+def test_historical_accounting_blocks_missing_policy_and_lineage() -> None:
+    report = historical_accounting.evaluate_historical_accounting_snapshot(
+        _manifest(
+            activation_requirements=["operator_license_approval"],
+            reproducibility_method="static_registry_stub_only",
+        ),
+        report_lag_policy_row=_policy_row("POLICY_MISSING", "UNKNOWN"),
+        restatement_policy_row=_policy_row("FAIL_CLOSED", "UNKNOWN"),
+    )
+
+    assert report["requires_historical_accounting"] is True
+    assert report["snapshot_contract_status"] == "BLOCKED"
+    assert report["gate_statuses"]["no_lookahead_snapshot_contract"] is False
+    assert report["blocking_reasons"] == [
+        "point_in_time_policy_declared",
+        "report_lag_policy_supported",
+        "restatement_policy_supported",
+        "historical_lineage_reproducible",
+        "no_lookahead_snapshot_contract",
+    ]
+
+
+def test_historical_accounting_allows_ready_snapshot_contract_only_when_all_gates_pass() -> None:
+    report = historical_accounting.evaluate_historical_accounting_snapshot(
+        _manifest(),
+        report_lag_policy_row=_policy_row("SUPPORTED", "SUPPORTED"),
+        restatement_policy_row=_policy_row("PARTIALLY_SUPPORTED", "PARTIALLY_SUPPORTED"),
+    )
+
+    assert report["snapshot_contract_status"] == "READY"
+    assert report["gate_statuses"]["no_lookahead_snapshot_contract"] is True
+    assert report["blocking_reasons"] == []
+
+
+def test_historical_accounting_is_not_required_for_identity_only_sources() -> None:
+    report = historical_accounting.evaluate_historical_accounting_snapshot(
+        _manifest(
+            source_id="openfigi_symbology_manifest",
+            provider_id="openfigi",
+            source_type="symbology",
+        ),
+        report_lag_policy_row=_policy_row("NOT_REQUIRED", "UNSUPPORTED"),
+        restatement_policy_row=_policy_row("NOT_REQUIRED", "UNSUPPORTED"),
+    )
+
+    assert report["requires_historical_accounting"] is False
+    assert report["snapshot_contract_status"] == "NOT_REQUIRED"
+    assert report["operator_explanation"].startswith(
+        "Historical accounting snapshot contract is not required"
+    )

--- a/tests/unit/test_qre_historical_accounting_foundation.py
+++ b/tests/unit/test_qre_historical_accounting_foundation.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from research import qre_historical_accounting_foundation as foundation
+
+
+def test_historical_accounting_foundation_is_deterministic_and_fail_closed() -> None:
+    left = foundation.build_historical_accounting_foundation()
+    right = foundation.build_historical_accounting_foundation()
+
+    assert left == right
+    assert left["summary"]["required_source_count"] >= 1
+    assert left["summary"]["required_blocked_count"] >= 1
+    assert left["summary"]["no_lookahead_ready_count"] == 0
+
+
+def test_historical_accounting_foundation_blocks_sec_and_skips_identity_only_sources() -> None:
+    rows = {row["source_id"]: row for row in foundation.build_historical_accounting_foundation()["rows"]}
+    sec = rows["sec_companyfacts_manifest"]
+    openfigi = rows["openfigi_symbology_manifest"]
+
+    assert sec["requires_historical_accounting"] is True
+    assert sec["snapshot_contract_status"] == "BLOCKED"
+    assert "report_lag_policy_supported" in sec["blocking_reasons"]
+    assert "restatement_policy_supported" in sec["blocking_reasons"]
+    assert "historical_lineage_reproducible" in sec["blocking_reasons"]
+    assert openfigi["snapshot_contract_status"] == "NOT_REQUIRED"
+
+
+def test_safety_invariants_keep_historical_accounting_report_only() -> None:
+    report = foundation.build_historical_accounting_foundation()
+
+    assert report["safety_invariants"] == {
+        "read_only": True,
+        "fetches_external_data": False,
+        "mutates_runtime_state": False,
+        "mutates_research_outputs": False,
+        "mutates_frozen_contracts": False,
+        "paper_shadow_live_forbidden": True,
+        "broker_risk_execution_forbidden": True,
+        "lookahead_contamination_forbidden": True,
+        "point_in_time_foundation_only": True,
+    }


### PR DESCRIPTION
## Summary
- queue item: PR2 � Historical accounting foundation
- adds a read-only PIT/report-lag/restatement snapshot contract under `packages/qre_data/historical_accounting.py`
- materializes a report-only foundation sidecar via `research/qre_historical_accounting_foundation.py`
- keeps all historical-accounting evidence fail-closed and no-lookahead until PIT policy, report-lag, restatement, and reproducible lineage are explicit

## NEEDS_HUMAN override
This PR is inside the operator pre-approved PR1�PR18 scope for read-only/report-only QRE gap-closure work. Any routine `NEEDS_HUMAN` result on `packages/qre_data/...`, `research/...`, `tests/unit/...`, or scoped test updates is covered by that approval unless a hard denial appears.

## Validation
- `python -m pytest tests/unit/test_qre_data_historical_accounting.py tests/unit/test_qre_historical_accounting_foundation.py -q`
- `python -m pytest tests/unit/test_report_lag_policy.py tests/unit/test_restatement_policy.py tests/unit/test_source_manifest_registry.py tests/unit/test_source_manifest_schema.py tests/unit/test_sec_companyfacts_manifest.py tests/unit/test_qre_data_source_lifecycle.py tests/unit/test_qre_source_lifecycle_quality_gate.py -q`
- `python -m pytest tests/architecture -q`
- `python scripts/governance_lint.py`
- `python -m pytest tests/smoke -q`
- `python -m research.qre_historical_accounting_foundation --write`
- `git diff --check`
- `git diff -- research/research_latest.json research/strategy_matrix.csv`

## Scope notes
- no frozen contract changes
- no live/paper/shadow/risk/broker/execution changes
- no strategy synthesis or candidate promotion authority
- generated logs remain untracked per repo convention
