### PR TITLE
feat: add QRE symbology resolver foundation

### DIFF
--- a/packages/qre_data/symbology_resolver.py
+++ b/packages/qre_data/symbology_resolver.py
@@ -1,0 +1,93 @@
+"""Deterministic read-only symbology resolver foundation."""
+
+from __future__ import annotations
+
+from typing import Any, Final, Mapping
+
+
+SCHEMA_VERSION: Final[str] = "1.0"
+RESOLUTION_STATUS_VOCABULARY: Final[tuple[str, ...]] = (
+    "VERIFIED",
+    "AMBIGUOUS_BLOCKED",
+    "MISSING_BLOCKED",
+)
+AMBIGUITY_REASON_VOCABULARY: Final[tuple[str, ...]] = (
+    "multiple_candidate_aliases",
+    "candidate_alias_requires_verification",
+    "missing_primary_provider_symbol",
+    "provider_symbol_unresolved",
+)
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value]
+
+
+def resolve_symbology_row(asset_row: Mapping[str, Any]) -> dict[str, Any]:
+    """Resolve canonical/provider symbol identity without granting authority."""
+
+    canonical_id = _text(asset_row.get("canonical_instrument_id"))
+    instrument_symbol = _text(asset_row.get("symbol"))
+    provider_symbol = _text(asset_row.get("primary_data_provider_symbol"))
+    aliases = _string_list(asset_row.get("provider_symbol_aliases"))
+    provider_status = _text(asset_row.get("provider_symbol_status"))
+    identity_status = _text(asset_row.get("source_identity_status"))
+
+    blocking_reasons: list[str] = []
+    if not provider_symbol:
+        blocking_reasons.append("missing_primary_provider_symbol")
+    if provider_status == "candidate_alias_requires_verification":
+        blocking_reasons.append("candidate_alias_requires_verification")
+        if len(aliases) > 1:
+            blocking_reasons.append("multiple_candidate_aliases")
+    elif provider_status not in {"verified", "provider_lookup_failed"}:
+        blocking_reasons.append("provider_symbol_unresolved")
+    if identity_status not in {"provider_symbol_verified"} and "candidate_alias_requires_verification" not in blocking_reasons:
+        blocking_reasons.append("provider_symbol_unresolved")
+
+    resolution_status = (
+        "VERIFIED"
+        if not blocking_reasons
+        else "MISSING_BLOCKED"
+        if "missing_primary_provider_symbol" in blocking_reasons
+        else "AMBIGUOUS_BLOCKED"
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "instrument_symbol": instrument_symbol,
+        "canonical_instrument_id": canonical_id,
+        "provider_symbol": provider_symbol or None,
+        "provider_symbol_aliases": aliases,
+        "provider_symbol_status": provider_status or "unknown",
+        "source_identity_status": identity_status or "unknown",
+        "resolution_status": resolution_status,
+        "ambiguity_blocked": bool(blocking_reasons),
+        "blocking_reasons": blocking_reasons,
+        "operator_explanation": (
+            "Canonical instrument ID and provider symbol are verified for read-only use."
+            if not blocking_reasons
+            else "Symbology resolution remains blocked until provider-symbol ambiguity is explicitly resolved."
+        ),
+        "safety_invariants": {
+            "read_only": True,
+            "identity_is_infrastructure_only": True,
+            "not_alpha_authority": True,
+            "candidate_promotion_forbidden": True,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+        },
+    }
+
+
+__all__ = [
+    "AMBIGUITY_REASON_VOCABULARY",
+    "RESOLUTION_STATUS_VOCABULARY",
+    "SCHEMA_VERSION",
+    "resolve_symbology_row",
+]

--- a/research/qre_symbology_resolver_foundation.py
+++ b/research/qre_symbology_resolver_foundation.py
@@ -1,0 +1,165 @@
+"""Read-only QRE symbology resolver foundation materialization."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+from packages.qre_data import symbology_resolver
+from research import production_discovery_catalog as catalog
+from research.external_intelligence import source_manifest_registry
+
+
+REPORT_KIND: Final[str] = "qre_symbology_resolver_foundation"
+SCHEMA_VERSION: Final[str] = "1.0"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_symbology_resolver_foundation")
+LATEST_NAME: Final[str] = "latest.json"
+SUMMARY_NAME: Final[str] = "operator_summary.md"
+WRITE_PREFIX: Final[str] = "logs/qre_symbology_resolver_foundation/"
+
+
+def _table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> str:
+    head = "| " + " | ".join(headers) + " |"
+    divider = "| " + " | ".join(["---"] * len(headers) + []) + " |"
+    body = ["| " + " | ".join(row) + " |" for row in rows]
+    return "\n".join([head, divider, *body])
+
+
+def build_symbology_resolver_foundation() -> dict[str, Any]:
+    assets = [asset.to_payload() for asset in catalog.list_assets()]
+    rows = [symbology_resolver.resolve_symbology_row(asset) for asset in assets]
+    rows.sort(key=lambda row: str(row["instrument_symbol"]))
+    status_counts = Counter(str(row["resolution_status"]) for row in rows)
+    blocking_counts = Counter(reason for row in rows for reason in row["blocking_reasons"])
+    openfigi_row = next(
+        row
+        for row in source_manifest_registry.build_source_manifest_registry()["rows"]
+        if row["source_id"] == "openfigi_symbology_manifest"
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "summary": {
+            "instrument_count": len(rows),
+            "verified_count": sum(str(row["resolution_status"]) == "VERIFIED" for row in rows),
+            "ambiguity_blocked_count": sum(bool(row["ambiguity_blocked"]) for row in rows),
+            "resolution_status_counts": dict(sorted(status_counts.items())),
+            "blocking_reason_counts": dict(sorted(blocking_counts.items())),
+            "operator_summary": (
+                "Symbology resolution remains read-only infrastructure. Canonical IDs and verified provider "
+                "symbols are surfaced, while alias ambiguity blocks escalation until explicit resolution exists."
+            ),
+        },
+        "rows": rows,
+        "supporting_reports": {
+            "production_discovery_catalog": {
+                "schema_version": catalog.SCHEMA_VERSION,
+                "module_version": catalog.MODULE_VERSION,
+            },
+            "openfigi_manifest": {
+                "source_id": openfigi_row["source_id"],
+                "source_status": openfigi_row["source_status"],
+                "allowed_use": openfigi_row["allowed_use"],
+                "required_quality_gates": openfigi_row["required_quality_gates"],
+            },
+        },
+        "safety_invariants": {
+            "read_only": True,
+            "identity_is_infrastructure_only": True,
+            "not_alpha_authority": True,
+            "candidate_promotion_forbidden": True,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+        },
+    }
+
+
+def render_operator_summary(report: Mapping[str, Any]) -> str:
+    summary = report.get("summary") if isinstance(report.get("summary"), Mapping) else {}
+    rows = report.get("rows") if isinstance(report.get("rows"), list) else []
+    status_table = _table(
+        ["Field", "Value"],
+        [
+            ["instrument_count", str(summary.get("instrument_count") or 0)],
+            ["verified_count", str(summary.get("verified_count") or 0)],
+            ["ambiguity_blocked_count", str(summary.get("ambiguity_blocked_count") or 0)],
+        ],
+    )
+    row_table = _table(
+        ["symbol", "canonical_id", "provider_symbol", "status", "blocked_by"],
+        [
+            [
+                str(row.get("instrument_symbol") or ""),
+                str(row.get("canonical_instrument_id") or ""),
+                str(row.get("provider_symbol") or "-"),
+                str(row.get("resolution_status") or ""),
+                ",".join(str(value) for value in row.get("blocking_reasons") or []) or "none",
+            ]
+            for row in rows
+            if isinstance(row, Mapping)
+        ],
+    )
+    return "\n".join(
+        [
+            "# QRE Symbology Resolver Foundation",
+            "",
+            f"- {summary.get('operator_summary') or ''}",
+            "",
+            "## Status",
+            status_table,
+            "",
+            "## Symbol Rows",
+            row_table,
+        ]
+    )
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(
+            f"qre_symbology_resolver_foundation: refusing write outside allowlist: {path!r}"
+        )
+
+
+def write_outputs(report: Mapping[str, Any], *, repo_root: Path = Path(".")) -> dict[str, str]:
+    base = repo_root / DEFAULT_OUTPUT_DIR
+    base.mkdir(parents=True, exist_ok=True)
+    latest = base / LATEST_NAME
+    summary = base / SUMMARY_NAME
+    for target in (latest, summary):
+        _validate_write_target(target)
+
+    tmp_latest = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_latest.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp_latest, latest)
+
+    tmp_summary = summary.with_suffix(summary.suffix + ".tmp")
+    tmp_summary.write_text(render_operator_summary(report) + "\n", encoding="utf-8")
+    os.replace(tmp_summary, summary)
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "operator_summary": summary.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_symbology_resolver_foundation",
+        description="Materialize the read-only QRE symbology resolver foundation report.",
+    )
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    report = build_symbology_resolver_foundation()
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/architecture/test_package_migration_001_target_layout.py
+++ b/tests/architecture/test_package_migration_001_target_layout.py
@@ -148,6 +148,7 @@ def test_package_migration_001_qre_data_has_only_bounded_read_only_seed() -> Non
         "historical_accounting.py",
         "source_lifecycle.py",
         "source_quality_readiness.py",
+        "symbology_resolver.py",
     ], target
 
 
@@ -179,6 +180,7 @@ def test_package_migration_001_scanner_classifies_target_paths() -> None:
     assert classify_path("packages/qre_data/cache_manifest.py") == DOMAIN_QRE
     assert classify_path("packages/qre_data/contracts.py") == DOMAIN_QRE
     assert classify_path("packages/qre_data/historical_accounting.py") == DOMAIN_QRE
+    assert classify_path("packages/qre_data/symbology_resolver.py") == DOMAIN_QRE
     assert classify_path("packages/qre_data/source_lifecycle.py") == DOMAIN_QRE
     assert classify_path("packages/qre_data/source_quality_readiness.py") == DOMAIN_QRE
     assert classify_path("packages/qre_artifacts/README.md") == DOMAIN_QRE
@@ -197,6 +199,7 @@ def test_package_migration_001_scanner_classifies_target_paths() -> None:
     assert classify_module("packages.qre_data.cache_manifest") == DOMAIN_QRE
     assert classify_module("packages.qre_data.contracts") == DOMAIN_QRE
     assert classify_module("packages.qre_data.historical_accounting") == DOMAIN_QRE
+    assert classify_module("packages.qre_data.symbology_resolver") == DOMAIN_QRE
     assert classify_module("packages.qre_data.source_lifecycle") == DOMAIN_QRE
     assert classify_module("packages.qre_data.source_quality_readiness") == DOMAIN_QRE
     assert classify_module("packages.qre_artifacts.public_outputs") == DOMAIN_QRE

--- a/tests/architecture/test_package_migration_010_closure_decision.py
+++ b/tests/architecture/test_package_migration_010_closure_decision.py
@@ -46,6 +46,7 @@ BOUNDED_PACKAGE_CONTENTS = {
         "historical_accounting.py",
         "source_lifecycle.py",
         "source_quality_readiness.py",
+        "symbology_resolver.py",
     ],
     "qre_artifacts": ["README.md", "__init__.py", "public_outputs.py"],
     "qre_diagnostics": [

--- a/tests/unit/test_qre_data_symbology_resolver.py
+++ b/tests/unit/test_qre_data_symbology_resolver.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from packages.qre_data import symbology_resolver
+
+
+def test_symbology_resolver_verifies_single_provider_symbol() -> None:
+    row = symbology_resolver.resolve_symbology_row(
+        {
+            "symbol": "ADYEN",
+            "canonical_instrument_id": "EURONEXT:ADYEN",
+            "primary_data_provider_symbol": "ADYEN.AS",
+            "provider_symbol_aliases": ["ADYEN.AS"],
+            "provider_symbol_status": "verified",
+            "source_identity_status": "provider_symbol_verified",
+        }
+    )
+
+    assert row["resolution_status"] == "VERIFIED"
+    assert row["ambiguity_blocked"] is False
+    assert row["blocking_reasons"] == []
+
+
+def test_symbology_resolver_blocks_candidate_alias_ambiguity() -> None:
+    row = symbology_resolver.resolve_symbology_row(
+        {
+            "symbol": "ASMI",
+            "canonical_instrument_id": "EURONEXT:ASMI",
+            "primary_data_provider_symbol": None,
+            "provider_symbol_aliases": ["ASM.AS", "ASMI.AS"],
+            "provider_symbol_status": "candidate_alias_requires_verification",
+            "source_identity_status": "candidate_alias_only",
+        }
+    )
+
+    assert row["resolution_status"] == "MISSING_BLOCKED"
+    assert row["ambiguity_blocked"] is True
+    assert row["blocking_reasons"] == [
+        "missing_primary_provider_symbol",
+        "candidate_alias_requires_verification",
+        "multiple_candidate_aliases",
+    ]

--- a/tests/unit/test_qre_symbology_resolver_foundation.py
+++ b/tests/unit/test_qre_symbology_resolver_foundation.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from research import qre_symbology_resolver_foundation as foundation
+
+
+def test_symbology_resolver_foundation_is_deterministic_and_blocks_ambiguity() -> None:
+    left = foundation.build_symbology_resolver_foundation()
+    right = foundation.build_symbology_resolver_foundation()
+
+    assert left == right
+    assert left["summary"]["instrument_count"] >= 1
+    assert left["summary"]["ambiguity_blocked_count"] >= 1
+
+
+def test_symbology_resolver_foundation_keeps_candidate_aliases_blocked() -> None:
+    rows = {row["instrument_symbol"]: row for row in foundation.build_symbology_resolver_foundation()["rows"]}
+
+    assert rows["ADYEN"]["resolution_status"] == "VERIFIED"
+    assert rows["ASMI"]["ambiguity_blocked"] is True
+    assert "candidate_alias_requires_verification" in rows["ASMI"]["blocking_reasons"]
+    assert "multiple_candidate_aliases" in rows["ASMI"]["blocking_reasons"]
+    assert rows["NOVO-B"]["ambiguity_blocked"] is True
+
+
+def test_symbology_resolver_safety_invariants_keep_identity_non_authoritative() -> None:
+    report = foundation.build_symbology_resolver_foundation()
+
+    assert report["safety_invariants"] == {
+        "read_only": True,
+        "identity_is_infrastructure_only": True,
+        "not_alpha_authority": True,
+        "candidate_promotion_forbidden": True,
+        "paper_shadow_live_forbidden": True,
+        "broker_risk_execution_forbidden": True,
+    }


### PR DESCRIPTION
## Summary
- add a deterministic QRE symbology resolver that normalizes canonical IDs and blocks ambiguous identity rows from escalation
- add a read-only research report that materializes resolver coverage, blocked reasons, and OpenFIGI manifest support metadata
- extend unit and architecture coverage for the new qre_data boundary files

## Queue Item
- PR3 — Symbology resolver foundation

## Operator NEEDS_HUMAN Override
The execution classifier returned NEEDS_HUMAN for the expected PR3 paths under packages/qre_data/..., esearch/..., 	ests/unit/..., and architecture tests. This PR remains inside the operator pre-approved PR1–PR18 scope:
- read-only/report-only QRE research infrastructure only
- no frozen contract mutation
- no live/paper/shadow/risk/broker/execution changes
- no strategy synthesis or promotion authority

## Validation
- python -m pytest tests/unit/test_qre_data_symbology_resolver.py tests/unit/test_qre_symbology_resolver_foundation.py -q
- python -m pytest tests/unit/test_qre_entity_resolution.py tests/unit/test_openfigi_identity_manifest.py tests/unit/test_qre_production_discovery_catalog.py -q
- python -m pytest tests/architecture -q
- python scripts/governance_lint.py
- python -m pytest tests/smoke -q
- python -m research.qre_symbology_resolver_foundation --write
- git diff --check
- git diff -- research/research_latest.json research/strategy_matrix.csv

## Scope Guards
- identity remains infrastructure only, not alpha authority
- ambiguity blocks escalation
- no queue/campaign/live path mutation