### PR TITLE
feat: add QRE factor coverage matrix

### DIFF
--- a/research/data_readiness/factor_field_coverage.py
+++ b/research/data_readiness/factor_field_coverage.py
@@ -6,11 +6,23 @@ from collections import Counter
 from typing import Final
 
 from research.equity_factors.factor_catalog import build_equity_factor_calculation_contracts
+from research.external_intelligence.fundamental_provider_registry import (
+    build_fundamental_provider_registry,
+)
 from research.external_intelligence.source_manifest_registry import build_source_manifest_registry
 
 
 SCHEMA_VERSION: Final[str] = "1.0"
 FIELD_COVERAGE_VOCABULARY: Final[tuple[str, ...]] = ("COVERED", "MISSING", "PARTIAL", "UNKNOWN")
+PROVIDER_APPROVAL_VOCABULARY: Final[tuple[str, ...]] = (
+    "APPROVED_READ_ONLY",
+    "QUALITY_GATED_ONLY",
+    "CANDIDATE_ONLY",
+    "MANUAL_RESEARCH_ONLY",
+    "STAGING_ONLY",
+    "BLOCKED",
+)
+FRESHNESS_STATUS_VOCABULARY: Final[tuple[str, ...]] = ("DECLARED", "UNKNOWN", "NOT_APPLICABLE")
 FIELD_REQUIREMENT_CLAIMS: Final[dict[str, tuple[str, ...]]] = {
     "aqi": ("multi_period_fundamentals",),
     "asset_quality_index": ("multi_period_fundamentals",),
@@ -62,43 +74,166 @@ FIELD_REQUIREMENT_CLAIMS: Final[dict[str, tuple[str, ...]]] = {
 }
 
 
-def _fundamental_claim_index() -> tuple[dict[str, list[str]], dict[str, list[str]]]:
+def _provider_approval_status(
+    *,
+    source_status: str,
+    manifest_status: str,
+    license_allows_quality_gate: bool,
+    license_allows_active_read_only: bool,
+) -> str:
+    if (
+        source_status == "active_read_only"
+        and manifest_status == "VALID"
+        and license_allows_active_read_only
+    ):
+        return "APPROVED_READ_ONLY"
+    if (
+        source_status == "quality_gated"
+        and manifest_status == "VALID"
+        and license_allows_quality_gate
+    ):
+        return "QUALITY_GATED_ONLY"
+    if source_status == "manual_research_only":
+        return "MANUAL_RESEARCH_ONLY"
+    if source_status == "staging":
+        return "STAGING_ONLY"
+    if source_status == "candidate":
+        return "CANDIDATE_ONLY"
+    return "BLOCKED"
+
+
+def _freshness_status(expected_freshness: str) -> str:
+    normalized = expected_freshness.strip().lower()
+    if normalized in {"metadata_only", "not_applicable", "unsupported"}:
+        return "NOT_APPLICABLE"
+    if not normalized or "unknown" in normalized or "depends_on" in normalized:
+        return "UNKNOWN"
+    return "DECLARED"
+
+
+def _fundamental_claim_index() -> tuple[
+    dict[str, list[str]],
+    dict[str, list[str]],
+    dict[str, dict[str, object]],
+]:
     snapshot = build_source_manifest_registry()
+    providers = build_fundamental_provider_registry()
+    provider_rows = {
+        str(row["provider_id"]): row for row in providers["rows"]
+    }
     claimed_by_family: dict[str, list[str]] = {}
     active_by_family: dict[str, list[str]] = {}
+    provider_claim_rows: dict[str, dict[str, object]] = {}
     for row in snapshot["rows"]:
         source_id = str(row["source_id"])
+        provider_id = str(row["provider_id"])
         claims = [str(item) for item in row["factor_field_coverage_claims"]]
         policy = snapshot["policy_by_source"][source_id]
-        active = bool(policy["allowed_for_quality_gate"]) or str(row["source_status"]) in {
-            "quality_gated",
-            "active_read_only",
+        approval_status = _provider_approval_status(
+            source_status=str(row["source_status"]),
+            manifest_status=str(row["manifest_status"]),
+            license_allows_quality_gate=bool(policy["allowed_for_quality_gate"]),
+            license_allows_active_read_only=bool(policy["allowed_for_active_read_only"]),
+        )
+        freshness = _freshness_status(str(row["expected_freshness"]))
+        provider_claim_rows[provider_id] = {
+            "provider_id": provider_id,
+            "provider_name": str(provider_rows[provider_id]["provider_name"]),
+            "provider_source_status": str(provider_rows[provider_id]["source_status"]),
+            "manifest_source_id": source_id,
+            "manifest_source_status": str(row["source_status"]),
+            "manifest_status": str(row["manifest_status"]),
+            "approval_status": approval_status,
+            "expected_freshness": str(row["expected_freshness"]),
+            "freshness_status": freshness,
+            "allowed_use": list(row["allowed_use"]),
+            "forbidden_use": list(row["forbidden_use"]),
+            "required_quality_gates": list(row["required_quality_gates"]),
+            "manifest_block_reasons": list(row["manifest_block_reasons"]),
+            "provider_alpha_authority": False,
+            "provider_factor_authority": False,
+            "provider_coverage_claims": claims,
         }
+        active = approval_status in {"APPROVED_READ_ONLY", "QUALITY_GATED_ONLY"} and freshness == "DECLARED"
         for claim in claims:
-            claimed_by_family.setdefault(claim, []).append(source_id)
+            claimed_by_family.setdefault(claim, []).append(provider_id)
             if active:
-                active_by_family.setdefault(claim, []).append(source_id)
+                active_by_family.setdefault(claim, []).append(provider_id)
     for mapping in (claimed_by_family, active_by_family):
-        for claim_family, source_ids in mapping.items():
-            mapping[claim_family] = sorted(set(source_ids))
-    return claimed_by_family, active_by_family
+        for claim_family, provider_ids in mapping.items():
+            mapping[claim_family] = sorted(set(provider_ids))
+    return claimed_by_family, active_by_family, provider_claim_rows
 
 
-def _field_row(field_name: str, *, claimed_by_family: dict[str, list[str]], active_by_family: dict[str, list[str]]) -> dict[str, object]:
+def _provider_field_rows(
+    *,
+    field_name: str,
+    requirement_claims: list[str],
+    claimed_by_family: dict[str, list[str]],
+    provider_claim_rows: dict[str, dict[str, object]],
+) -> list[dict[str, object]]:
+    provider_ids = sorted(
+        {
+            provider_id
+            for claim_family in requirement_claims
+            for provider_id in claimed_by_family.get(claim_family, [])
+        }
+    )
+    rows: list[dict[str, object]] = []
+    for provider_id in provider_ids:
+        provider_row = dict(provider_claim_rows[provider_id])
+        blocking_reasons: list[str] = []
+        if provider_row["approval_status"] != "APPROVED_READ_ONLY":
+            blocking_reasons.append("provider_not_approved_for_read_only_factor_use")
+        if provider_row["freshness_status"] == "UNKNOWN":
+            blocking_reasons.append("provider_freshness_unknown")
+        if provider_row["manifest_status"] != "VALID":
+            blocking_reasons.append("provider_manifest_not_valid")
+        rows.append(
+            {
+                **provider_row,
+                "field_name": field_name,
+                "required_claim_families": requirement_claims,
+                "satisfies_field_for_research": not blocking_reasons,
+                "blocking_reasons": blocking_reasons,
+                "operator_explanation": (
+                    f"{provider_row['provider_id']} can support {field_name} only after read-only approval, "
+                    "manifest validity, and declared freshness exist."
+                    if blocking_reasons
+                    else f"{provider_row['provider_id']} is approved to satisfy {field_name}."
+                ),
+            }
+        )
+    return rows
+
+
+def _field_row(
+    field_name: str,
+    *,
+    claimed_by_family: dict[str, list[str]],
+    active_by_family: dict[str, list[str]],
+    provider_claim_rows: dict[str, dict[str, object]],
+) -> dict[str, object]:
     requirement_claims = list(FIELD_REQUIREMENT_CLAIMS.get(field_name, ("unknown_field_mapping",)))
     candidate_sources = sorted(
         {
-            source_id
+            provider_id
             for claim_family in requirement_claims
-            for source_id in claimed_by_family.get(claim_family, [])
+            for provider_id in claimed_by_family.get(claim_family, [])
         }
     )
     active_sources = sorted(
         {
-            source_id
+            provider_id
             for claim_family in requirement_claims
-            for source_id in active_by_family.get(claim_family, [])
+            for provider_id in active_by_family.get(claim_family, [])
         }
+    )
+    provider_rows = _provider_field_rows(
+        field_name=field_name,
+        requirement_claims=requirement_claims,
+        claimed_by_family=claimed_by_family,
+        provider_claim_rows=provider_claim_rows,
     )
     if active_sources:
         coverage_status = "COVERED"
@@ -114,14 +249,26 @@ def _field_row(field_name: str, *, claimed_by_family: dict[str, list[str]], acti
         "coverage_status": coverage_status,
         "coverage_reason": coverage_reason,
         "required_claim_families": requirement_claims,
-        "candidate_source_ids": candidate_sources,
-        "active_source_ids": active_sources,
+        "candidate_provider_ids": candidate_sources,
+        "approved_provider_ids": active_sources,
+        "provider_field_matrix": provider_rows,
+        "freshness_status": (
+            "DECLARED"
+            if any(str(row["freshness_status"]) == "DECLARED" for row in provider_rows)
+            else "UNKNOWN"
+            if provider_rows
+            else "NOT_APPLICABLE"
+        ),
     }
 
 
 def build_factor_field_coverage() -> dict[str, object]:
     contracts = build_equity_factor_calculation_contracts()["rows"]
-    claimed_by_family, active_by_family = _fundamental_claim_index()
+    (
+        claimed_by_family,
+        active_by_family,
+        provider_claim_rows,
+    ) = _fundamental_claim_index()
     rows: list[dict[str, object]] = []
     for row in contracts:
         required_fields = [str(field) for field in row["required_fields"]]
@@ -130,6 +277,7 @@ def build_factor_field_coverage() -> dict[str, object]:
                 field_name,
                 claimed_by_family=claimed_by_family,
                 active_by_family=active_by_family,
+                provider_claim_rows=provider_claim_rows,
             )
             for field_name in required_fields
         ]
@@ -159,30 +307,46 @@ def build_factor_field_coverage() -> dict[str, object]:
                 "report_lag_required": bool(row["point_in_time_required"]),
                 "currency_normalization_required": "currency_consistent"
                 in row["quality_gate_requirements"],
+                "provider_coverage_count": sum(
+                    len(list(item["provider_field_matrix"])) for item in field_coverage
+                ),
             }
         )
     rows.sort(key=lambda item: str(item["factor_id"]))
+    provider_rows = sorted(provider_claim_rows.values(), key=lambda item: str(item["provider_id"]))
     return {
         "schema_version": SCHEMA_VERSION,
         "report_kind": "factor_field_coverage",
         "summary": {
             "factor_count": len(rows),
+            "provider_count": len(provider_rows),
+            "approved_provider_count": sum(
+                str(row["approval_status"]) == "APPROVED_READ_ONLY" for row in provider_rows
+            ),
+            "quality_gated_only_provider_count": sum(
+                str(row["approval_status"]) == "QUALITY_GATED_ONLY" for row in provider_rows
+            ),
             "covered_count": sum(row["field_coverage_status"] == "COVERED" for row in rows),
             "missing_count": sum(row["field_coverage_status"] == "MISSING" for row in rows),
             "partial_count": sum(row["field_coverage_status"] == "PARTIAL" for row in rows),
             "unknown_count": sum(row["field_coverage_status"] == "UNKNOWN" for row in rows),
             "operator_summary": (
                 "Field coverage is fail-closed. Candidate manifest claims can make coverage more specific, "
-                "but no field is treated as covered until a quality-gated or active read-only source exists."
+                "but no provider becomes factor authority and no field is treated as covered until an approved "
+                "read-only provider has valid manifests and declared freshness."
             ),
         },
         "field_coverage_status_vocabulary": list(FIELD_COVERAGE_VOCABULARY),
+        "provider_approval_status_vocabulary": list(PROVIDER_APPROVAL_VOCABULARY),
+        "freshness_status_vocabulary": list(FRESHNESS_STATUS_VOCABULARY),
+        "provider_rows": provider_rows,
         "rows": rows,
         "safety_invariants": {
             "research_only": True,
             "not_trade_signal": True,
             "mutates_registry": False,
             "mutates_frozen_contracts": False,
+            "provider_alpha_authority_forbidden": True,
             "paper_shadow_live_forbidden": True,
             "broker_risk_execution_forbidden": True,
         },

--- a/research/qre_factor_coverage_matrix.py
+++ b/research/qre_factor_coverage_matrix.py
@@ -1,0 +1,180 @@
+"""Read-only QRE factor coverage matrix materialization."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+from research.data_readiness.factor_field_coverage import build_factor_field_coverage
+
+
+REPORT_KIND: Final[str] = "qre_factor_coverage_matrix"
+SCHEMA_VERSION: Final[str] = "1.0"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_factor_coverage_matrix")
+LATEST_NAME: Final[str] = "latest.json"
+SUMMARY_NAME: Final[str] = "operator_summary.md"
+WRITE_PREFIX: Final[str] = "logs/qre_factor_coverage_matrix/"
+
+
+def _table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> str:
+    head = "| " + " | ".join(headers) + " |"
+    divider = "| " + " | ".join(["---"] * len(headers)) + " |"
+    body = ["| " + " | ".join(row) + " |" for row in rows]
+    return "\n".join([head, divider, *body])
+
+
+def build_qre_factor_coverage_matrix() -> dict[str, Any]:
+    coverage = build_factor_field_coverage()
+    summary = coverage["summary"]
+    rows = coverage["rows"]
+    provider_rows = coverage["provider_rows"]
+    blocked_provider_count = sum(
+        str(row["approval_status"]) != "APPROVED_READ_ONLY" for row in provider_rows
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "factor_field_coverage_schema_version": coverage["schema_version"],
+        "summary": {
+            "factor_count": summary["factor_count"],
+            "provider_count": summary["provider_count"],
+            "approved_provider_count": summary["approved_provider_count"],
+            "quality_gated_only_provider_count": summary["quality_gated_only_provider_count"],
+            "blocked_provider_count": blocked_provider_count,
+            "covered_factor_count": summary["covered_count"],
+            "partial_factor_count": summary["partial_count"],
+            "unknown_factor_count": summary["unknown_count"],
+            "missing_factor_count": summary["missing_count"],
+            "operator_summary": (
+                "Factor coverage remains research-only. Providers can contribute deterministic field coverage "
+                "evidence, but provider presence, manifest claims, and freshness declarations do not create alpha "
+                "authority or direct trade permission."
+            ),
+        },
+        "provider_rows": provider_rows,
+        "factor_rows": rows,
+        "supporting_reports": {
+            "factor_field_coverage": {
+                "report_kind": coverage["report_kind"],
+                "provider_approval_status_vocabulary": coverage["provider_approval_status_vocabulary"],
+                "freshness_status_vocabulary": coverage["freshness_status_vocabulary"],
+            }
+        },
+        "safety_invariants": {
+            **coverage["safety_invariants"],
+            "provider_matrix_is_report_only": True,
+            "provider_is_not_alpha_authority": True,
+        },
+    }
+
+
+def render_operator_summary(report: Mapping[str, Any]) -> str:
+    summary = report.get("summary") if isinstance(report.get("summary"), Mapping) else {}
+    provider_rows = report.get("provider_rows") if isinstance(report.get("provider_rows"), list) else []
+    factor_rows = report.get("factor_rows") if isinstance(report.get("factor_rows"), list) else []
+    summary_table = _table(
+        ["Field", "Value"],
+        [
+            ["factor_count", str(summary.get("factor_count") or 0)],
+            ["provider_count", str(summary.get("provider_count") or 0)],
+            ["approved_provider_count", str(summary.get("approved_provider_count") or 0)],
+            ["quality_gated_only_provider_count", str(summary.get("quality_gated_only_provider_count") or 0)],
+            ["blocked_provider_count", str(summary.get("blocked_provider_count") or 0)],
+        ],
+    )
+    provider_table = _table(
+        ["provider_id", "approval_status", "freshness_status", "manifest_status"],
+        [
+            [
+                str(row.get("provider_id") or ""),
+                str(row.get("approval_status") or ""),
+                str(row.get("freshness_status") or ""),
+                str(row.get("manifest_status") or ""),
+            ]
+            for row in provider_rows
+            if isinstance(row, Mapping)
+        ],
+    )
+    factor_table = _table(
+        ["factor_id", "field_coverage_status", "provider_coverage_count"],
+        [
+            [
+                str(row.get("factor_id") or ""),
+                str(row.get("field_coverage_status") or ""),
+                str(row.get("provider_coverage_count") or 0),
+            ]
+            for row in factor_rows
+            if isinstance(row, Mapping)
+        ],
+    )
+    return "\n".join(
+        [
+            "# QRE Factor Coverage Matrix",
+            "",
+            f"- {summary.get('operator_summary') or ''}",
+            "",
+            "## Summary",
+            summary_table,
+            "",
+            "## Providers",
+            provider_table,
+            "",
+            "## Factors",
+            factor_table,
+        ]
+    )
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(
+            f"qre_factor_coverage_matrix: refusing write outside allowlist: {path!r}"
+        )
+
+
+def write_outputs(
+    report: Mapping[str, Any],
+    *,
+    repo_root: Path = Path("."),
+) -> dict[str, str]:
+    base = repo_root / DEFAULT_OUTPUT_DIR
+    base.mkdir(parents=True, exist_ok=True)
+    latest = base / LATEST_NAME
+    summary = base / SUMMARY_NAME
+    for target in (latest, summary):
+        _validate_write_target(target)
+
+    tmp_latest = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_latest.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp_latest, latest)
+
+    tmp_summary = summary.with_suffix(summary.suffix + ".tmp")
+    tmp_summary.write_text(render_operator_summary(report) + "\n", encoding="utf-8")
+    os.replace(tmp_summary, summary)
+
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "operator_summary": summary.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_factor_coverage_matrix",
+        description="Materialize the read-only QRE factor coverage matrix report.",
+    )
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    report = build_qre_factor_coverage_matrix()
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/unit/test_factor_field_coverage.py
+++ b/tests/unit/test_factor_field_coverage.py
@@ -8,6 +8,7 @@ def test_factor_field_coverage_is_fail_closed_and_deterministic() -> None:
     right = build_factor_field_coverage()
     assert left == right
     assert left["summary"]["covered_count"] == 0
+    assert left["summary"]["approved_provider_count"] == 0
     assert left["summary"]["partial_count"] > 0
     assert left["summary"]["unknown_count"] > 0
 
@@ -27,4 +28,27 @@ def test_factor_field_coverage_distinguishes_claimed_and_unclaimed_fields() -> N
 
     assert rows["twelve_month_momentum"]["field_coverage_status"] == "MISSING"
     assert rows["twelve_month_momentum"]["coverage_block_reasons"] == ["MISSING_REQUIRED_FIELD"]
+
+
+def test_factor_field_coverage_exposes_provider_matrix_without_authority() -> None:
+    report = build_factor_field_coverage()
+    rows = {row["factor_id"]: row for row in report["rows"]}
+    earnings_yield = rows["earnings_yield"]
+    market_cap = next(
+        field for field in earnings_yield["field_coverage"] if field["field_name"] == "market_cap"
+    )
+    net_income = next(
+        field for field in earnings_yield["field_coverage"] if field["field_name"] == "net_income_ttm"
+    )
+
+    assert market_cap["coverage_status"] == "MISSING"
+    assert net_income["coverage_status"] == "UNKNOWN"
+    assert {row["provider_id"] for row in net_income["provider_field_matrix"]} >= {
+        "alpha_vantage_candidate",
+        "eodhd_candidate",
+        "financial_modeling_prep_candidate",
+        "sec_companyfacts",
+    }
+    assert all(row["provider_alpha_authority"] is False for row in net_income["provider_field_matrix"])
+    assert all(row["provider_factor_authority"] is False for row in net_income["provider_field_matrix"])
 

--- a/tests/unit/test_qre_factor_coverage_matrix.py
+++ b/tests/unit/test_qre_factor_coverage_matrix.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from research import qre_factor_coverage_matrix as report_module
+
+
+def test_qre_factor_coverage_matrix_is_deterministic() -> None:
+    left = report_module.build_qre_factor_coverage_matrix()
+    right = report_module.build_qre_factor_coverage_matrix()
+    assert left == right
+    assert left["summary"]["approved_provider_count"] == 0
+    assert left["safety_invariants"]["provider_is_not_alpha_authority"] is True
+
+
+def test_qre_factor_coverage_matrix_preserves_report_only_provider_scope() -> None:
+    report = report_module.build_qre_factor_coverage_matrix()
+    provider_rows = {row["provider_id"]: row for row in report["provider_rows"]}
+
+    assert provider_rows["sec_companyfacts"]["approval_status"] == "CANDIDATE_ONLY"
+    assert provider_rows["sec_companyfacts"]["provider_alpha_authority"] is False
+    assert provider_rows["sec_companyfacts"]["freshness_status"] == "UNKNOWN"
+
+
+def test_qre_factor_coverage_matrix_write_outputs(tmp_path: Path) -> None:
+    report = report_module.build_qre_factor_coverage_matrix()
+    paths = report_module.write_outputs(report, repo_root=tmp_path)
+    payload = json.loads((tmp_path / paths["latest"]).read_text(encoding="utf-8"))
+    assert payload["report_kind"] == "qre_factor_coverage_matrix"
+    operator_summary = (tmp_path / paths["operator_summary"]).read_text(encoding="utf-8")
+    assert "# QRE Factor Coverage Matrix" in operator_summary
+    assert "provider_count" in operator_summary


### PR DESCRIPTION
## Summary
- upgrade the existing factor field coverage scaffold into a deterministic provider-to-field-to-factor matrix with freshness and approval status
- add a read-only QRE factor coverage matrix report with operator-facing summary output under logs
- keep provider coverage fail-closed so manifest claims inform readiness but never become alpha authority

## Queue Item
- PR4 — Factor coverage matrix

## Operator NEEDS_HUMAN Override
The execution classifier returned NEEDS_HUMAN for the expected PR4 paths under esearch/... and 	ests/unit/.... This PR stays inside the operator pre-approved PR1–PR18 scope:
- read-only/report-only QRE research infrastructure only
- no frozen contract mutation
- no live/paper/shadow/risk/broker/execution changes
- no strategy synthesis or provider promotion authority

## Validation
- python -m pytest tests/unit/test_factor_field_coverage.py tests/unit/test_factor_field_coverage_manifest.py tests/unit/test_qre_factor_coverage_matrix.py -q
- python -m pytest tests/unit/test_fundamental_provider_registry.py tests/unit/test_source_manifest_registry.py tests/unit/test_qre_source_lifecycle_quality_gate.py tests/unit/test_qre_historical_accounting_foundation.py tests/unit/test_qre_symbology_resolver_foundation.py -q
- python scripts/governance_lint.py
- python -m pytest tests/smoke -q
- python -m research.qre_factor_coverage_matrix --write
- git diff --check
- git diff -- research/research_latest.json research/strategy_matrix.csv

## Scope Guards
- provider coverage remains report-only and fail-closed
- no provider becomes alpha authority
- factor coverage still requires approved read-only providers plus declared freshness
- no queue/campaign/live path mutation