### PR TITLE
feat: add QRE lineage graph v1

### DIFF
--- a/research/qre_lineage_graph_v1.py
+++ b/research/qre_lineage_graph_v1.py
@@ -1,0 +1,599 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+
+REPORT_KIND: Final[str] = "qre_lineage_graph_v1"
+SCHEMA_VERSION: Final[str] = "1.0"
+DEFAULT_OUTPUT_DIR: Final[Path] = Path("logs/qre_lineage_graph_v1")
+LATEST_NAME: Final[str] = "latest.json"
+SUMMARY_NAME: Final[str] = "operator_summary.md"
+WRITE_PREFIX: Final[str] = "logs/qre_lineage_graph_v1/"
+
+SOURCE_LIFECYCLE_PATH: Final[Path] = Path("logs/qre_source_lifecycle_quality_gate/latest.json")
+HISTORICAL_ACCOUNTING_PATH: Final[Path] = Path("logs/qre_historical_accounting_foundation/latest.json")
+FACTOR_COVERAGE_PATH: Final[Path] = Path("logs/qre_factor_coverage_matrix/latest.json")
+GRID_BRIDGE_PATH: Final[Path] = Path("logs/qre_grid_candidate_campaign_lineage_bridge/latest.json")
+SOURCE_USEFULNESS_PATH: Final[Path] = Path("logs/qre_source_usefulness_ledger/latest.json")
+SOURCE_QUALITY_PATH: Final[Path] = Path("logs/qre_data_source_quality_readiness/latest.json")
+HYPOTHESIS_CATALOG_PATH: Final[Path] = Path("research/strategy_hypothesis_catalog_latest.v1.json")
+CAMPAIGN_REGISTRY_PATH: Final[Path] = Path("research/campaign_registry_latest.v1.json")
+CAMPAIGN_DIGEST_PATH: Final[Path] = Path("research/campaign_digest_latest.v1.json")
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> str:
+    head = "| " + " | ".join(headers) + " |"
+    divider = "| " + " | ".join(["---"] * len(headers)) + " |"
+    body = ["| " + " | ".join(row) + " |" for row in rows]
+    return "\n".join([head, divider, *body])
+
+
+def _canon(text: str) -> str:
+    parts = re.findall(r"[a-z0-9]+", text.lower())
+    return "_".join(parts)
+
+
+def _same_key(left: str, right: str) -> bool:
+    left_canon = _canon(left)
+    right_canon = _canon(right)
+    return (
+        left_canon == right_canon
+        or left_canon in right_canon
+        or right_canon in left_canon
+        or left_canon.replace("_manifest", "") == right_canon.replace("_manifest", "")
+        or right_canon.replace("_manifest", "") in left_canon
+    )
+
+
+def _add_node(nodes: dict[str, dict[str, Any]], node: dict[str, Any]) -> None:
+    node_id = str(node["node_id"])
+    if node_id in nodes:
+        return
+    nodes[node_id] = node
+
+
+def _add_edge(edges: list[dict[str, Any]], source: str, target: str, relation: str, *, evidence_refs: Sequence[str] = ()) -> None:
+    edges.append(
+        {
+            "edge_id": f"{source}->{target}:{relation}",
+            "source": source,
+            "target": target,
+            "relation": relation,
+            "evidence_refs": list(evidence_refs),
+        }
+    )
+
+
+def _group_by_alias(rows: Sequence[Mapping[str, Any]], alias_field: str, targets: Sequence[str]) -> dict[str, list[Mapping[str, Any]]]:
+    grouped: dict[str, list[Mapping[str, Any]]] = {target: [] for target in targets}
+    for row in rows:
+        raw = str(row.get(alias_field) or "")
+        for target in targets:
+            if _same_key(raw, target):
+                grouped[target].append(row)
+                break
+    return grouped
+
+
+def _load_reports(repo_root: Path) -> tuple[dict[str, Any], list[str]]:
+    report_paths = {
+        "source_lifecycle": SOURCE_LIFECYCLE_PATH,
+        "historical_accounting": HISTORICAL_ACCOUNTING_PATH,
+        "factor_coverage": FACTOR_COVERAGE_PATH,
+        "grid_bridge": GRID_BRIDGE_PATH,
+        "source_usefulness": SOURCE_USEFULNESS_PATH,
+        "source_quality": SOURCE_QUALITY_PATH,
+        "hypothesis_catalog": HYPOTHESIS_CATALOG_PATH,
+        "campaign_registry": CAMPAIGN_REGISTRY_PATH,
+        "campaign_digest": CAMPAIGN_DIGEST_PATH,
+    }
+    reports: dict[str, Any] = {}
+    missing: list[str] = []
+    for name, relpath in report_paths.items():
+        payload = _read_json(repo_root / relpath)
+        if payload is None:
+            missing.append(relpath.as_posix())
+        else:
+            reports[name] = payload
+    return reports, missing
+
+
+def _rows_from_report(report: Mapping[str, Any], key: str) -> list[dict[str, Any]]:
+    rows = report.get(key) if isinstance(report.get(key), list) else []
+    return [row for row in rows if isinstance(row, Mapping)]
+
+
+def _campaign_rows(report: Mapping[str, Any]) -> list[dict[str, Any]]:
+    campaigns = report.get("campaigns")
+    rows = list(campaigns.values()) if isinstance(campaigns, Mapping) else []
+    return [row for row in rows if isinstance(row, Mapping)]
+
+
+def build_qre_lineage_graph_v1(*, repo_root: Path = Path(".")) -> dict[str, Any]:
+    reports, missing_reports = _load_reports(repo_root)
+
+    source_lifecycle_rows = _rows_from_report(reports.get("source_lifecycle", {}), "rows")
+    historical_rows = _rows_from_report(reports.get("historical_accounting", {}), "rows")
+    factor_rows = _rows_from_report(reports.get("factor_coverage", {}), "factor_rows")
+    grid_rows = _rows_from_report(reports.get("grid_bridge", {}), "rows")
+    source_usefulness_rows = _rows_from_report(reports.get("source_usefulness", {}), "rows")
+    source_quality_rows = _rows_from_report(reports.get("source_quality", {}), "rows")
+    hypotheses = _rows_from_report(reports.get("hypothesis_catalog", {}), "hypotheses")
+    campaigns = _campaign_rows(reports.get("campaign_registry", {}))
+    digest = reports.get("campaign_digest", {})
+    digest_by_lineage_root = (
+        digest.get("compute_by_lineage_root")
+        if isinstance(digest.get("compute_by_lineage_root"), Mapping)
+        else {}
+    )
+
+    nodes: dict[str, dict[str, Any]] = {}
+    edges: list[dict[str, Any]] = []
+    orphan_nodes: list[dict[str, Any]] = []
+    contradictions: list[dict[str, Any]] = []
+
+    source_node_ids: list[str] = []
+    normalized_node_ids: list[str] = []
+    factor_node_ids: list[str] = []
+    hypothesis_node_ids: list[str] = []
+    campaign_node_ids: list[str] = []
+
+    source_quality_groups = _group_by_alias(
+        source_quality_rows,
+        "source",
+        [str(row.get("provider_id") or "") for row in source_lifecycle_rows],
+    )
+    historical_groups = _group_by_alias(
+        historical_rows,
+        "source_id",
+        [str(row.get("provider_id") or "") for row in source_lifecycle_rows],
+    )
+    usefulness_groups = _group_by_alias(
+        source_usefulness_rows,
+        "source",
+        [str(row.get("provider_id") or "") for row in source_lifecycle_rows],
+    )
+
+    for row in sorted(source_lifecycle_rows, key=lambda item: (str(item.get("provider_id") or ""), str(item.get("source_id") or ""))):
+        provider_id = str(row.get("provider_id") or "")
+        source_id = str(row.get("source_id") or "")
+        source_node_id = f"source::{provider_id}"
+        normalized_node_id = f"normalized::{provider_id}"
+        source_node_ids.append(source_node_id)
+        normalized_node_ids.append(normalized_node_id)
+        _add_node(
+            nodes,
+            {
+                "node_id": source_node_id,
+                "node_type": "source",
+                "lineage_layer": "source",
+                "label": provider_id,
+                "source_id": source_id,
+                "provider_id": provider_id,
+                "current_state": row.get("current_state"),
+                "lifecycle_status": row.get("lifecycle_status"),
+                "source_quality_ready": bool(row.get("source_quality_ready")),
+            },
+        )
+        source_quality_group = source_quality_groups.get(provider_id, [])
+        historical_group = historical_groups.get(provider_id, [])
+        usefulness_group = usefulness_groups.get(provider_id, [])
+        _add_node(
+            nodes,
+            {
+                "node_id": normalized_node_id,
+                "node_type": "normalized_data",
+                "lineage_layer": "normalized_data",
+                "label": provider_id,
+                "provider_id": provider_id,
+                "source_ids": [source_id],
+                "source_quality_row_count": len(source_quality_group),
+                "source_quality_ready_row_count": sum(
+                    1 for item in source_quality_group if str(item.get("quality_status") or "") == "ready"
+                ),
+                "historical_accounting_row_count": len(historical_group),
+                "source_usefulness_row_count": len(usefulness_group),
+                "source_usefulness_state": (
+                    str(usefulness_group[0].get("usefulness_state") or "")
+                    if usefulness_group
+                    else "unknown"
+                ),
+            },
+        )
+        _add_edge(edges, source_node_id, normalized_node_id, "normalizes_into", evidence_refs=[SOURCE_LIFECYCLE_PATH.as_posix(), SOURCE_QUALITY_PATH.as_posix()])
+
+    factor_provider_sets: dict[str, set[str]] = {}
+    for row in sorted(factor_rows, key=lambda item: str(item.get("factor_id") or "")):
+        factor_id = str(row.get("factor_id") or "")
+        factor_node_id = f"factor::{factor_id}"
+        factor_node_ids.append(factor_node_id)
+        provider_rows = [item for item in row.get("provider_rows", []) if isinstance(item, Mapping)]
+        provider_ids = sorted({str(item.get("provider_id") or "") for item in provider_rows if str(item.get("provider_id") or "")})
+        factor_provider_sets[factor_id] = set(provider_ids)
+        _add_node(
+            nodes,
+            {
+                "node_id": factor_node_id,
+                "node_type": "factor",
+                "lineage_layer": "factor",
+                "label": factor_id,
+                "field_coverage_status": row.get("field_coverage_status"),
+                "provider_coverage_count": row.get("provider_coverage_count"),
+                "coverage_block_reasons": row.get("coverage_block_reasons"),
+                "supporting_provider_ids": provider_ids,
+            },
+        )
+        for provider_id in sorted({str(item.get("provider_id") or "") for item in source_lifecycle_rows if str(item.get("provider_id") or "")}):
+            normalized_node_id = f"normalized::{provider_id}"
+            _add_edge(
+                edges,
+                normalized_node_id,
+                factor_node_id,
+                "layer_adjacency_context",
+                evidence_refs=[FACTOR_COVERAGE_PATH.as_posix()],
+            )
+
+    for row in sorted(hypotheses, key=lambda item: str(item.get("hypothesis_id") or "")):
+        hypothesis_id = str(row.get("hypothesis_id") or "")
+        hypothesis_node_id = f"hypothesis::{hypothesis_id}"
+        hypothesis_node_ids.append(hypothesis_node_id)
+        _add_node(
+            nodes,
+            {
+                "node_id": hypothesis_node_id,
+                "node_type": "hypothesis",
+                "lineage_layer": "hypothesis",
+                "label": hypothesis_id,
+                "status": row.get("status"),
+                "strategy_family": row.get("strategy_family"),
+                "feature_dependencies": list(row.get("feature_dependencies") or []),
+                "baseline_reference": row.get("baseline_reference"),
+            },
+        )
+        for factor_node_id in factor_node_ids:
+            _add_edge(
+                edges,
+                factor_node_id,
+                hypothesis_node_id,
+                "layer_adjacency_context",
+                evidence_refs=[FACTOR_COVERAGE_PATH.as_posix(), HYPOTHESIS_CATALOG_PATH.as_posix()],
+            )
+
+    hypothesis_ids = {str(row.get("hypothesis_id") or "") for row in hypotheses}
+    campaign_by_id = {str(row.get("campaign_id") or ""): row for row in campaigns}
+    for row in sorted(campaigns, key=lambda item: str(item.get("campaign_id") or "")):
+        campaign_id = str(row.get("campaign_id") or "")
+        campaign_node_id = f"campaign::{campaign_id}"
+        campaign_node_ids.append(campaign_node_id)
+        hypothesis_id = str(row.get("hypothesis_id") or "")
+        _add_node(
+            nodes,
+            {
+                "node_id": campaign_node_id,
+                "node_type": "campaign",
+                "lineage_layer": "campaign",
+                "label": campaign_id,
+                "hypothesis_id": hypothesis_id,
+                "state": row.get("state"),
+                "outcome": row.get("outcome"),
+                "lineage_root_campaign_id": row.get("lineage_root_campaign_id"),
+                "meaningful_classification": row.get("meaningful_classification"),
+            },
+        )
+        if hypothesis_id in hypothesis_ids:
+            _add_edge(
+                edges,
+                f"hypothesis::{hypothesis_id}",
+                campaign_node_id,
+                "registry_reference",
+                evidence_refs=[CAMPAIGN_REGISTRY_PATH.as_posix()],
+            )
+        else:
+            contradictions.append(
+                {
+                    "contradiction_id": f"missing_hypothesis::{campaign_id}",
+                    "kind": "missing_hypothesis_reference",
+                    "campaign_id": campaign_id,
+                    "hypothesis_id": hypothesis_id,
+                    "detail": "Campaign references a hypothesis that is absent from the catalog.",
+                }
+            )
+
+    evidence_nodes: list[str] = []
+    report_evidence_specs = [
+        ("source_lifecycle_quality_gate", SOURCE_LIFECYCLE_PATH, reports.get("source_lifecycle", {})),
+        ("historical_accounting_foundation", HISTORICAL_ACCOUNTING_PATH, reports.get("historical_accounting", {})),
+        ("factor_coverage_matrix", FACTOR_COVERAGE_PATH, reports.get("factor_coverage", {})),
+        ("grid_candidate_campaign_lineage_bridge", GRID_BRIDGE_PATH, reports.get("grid_bridge", {})),
+        ("source_usefulness_ledger", SOURCE_USEFULNESS_PATH, reports.get("source_usefulness", {})),
+        ("source_quality_readiness", SOURCE_QUALITY_PATH, reports.get("source_quality", {})),
+        ("strategy_hypothesis_catalog", HYPOTHESIS_CATALOG_PATH, reports.get("hypothesis_catalog", {})),
+        ("campaign_registry", CAMPAIGN_REGISTRY_PATH, reports.get("campaign_registry", {})),
+    ]
+    for report_name, path, payload in report_evidence_specs:
+        evidence_node_id = f"evidence::{report_name}"
+        evidence_nodes.append(evidence_node_id)
+        _add_node(
+            nodes,
+            {
+                "node_id": evidence_node_id,
+                "node_type": "evidence",
+                "lineage_layer": "evidence",
+                "label": report_name,
+                "report_kind": str(payload.get("report_kind") or report_name),
+                "path": path.as_posix(),
+            },
+        )
+
+    for campaign_row in campaigns:
+        campaign_id = str(campaign_row.get("campaign_id") or "")
+        campaign_node_id = f"campaign::{campaign_id}"
+        digest_row = digest_by_lineage_root.get(campaign_id)
+        if isinstance(digest_row, Mapping):
+            digest_node_id = f"evidence::campaign_digest::{campaign_id}"
+            evidence_nodes.append(digest_node_id)
+            _add_node(
+                nodes,
+                {
+                    "node_id": digest_node_id,
+                    "node_type": "evidence",
+                    "lineage_layer": "evidence",
+                    "label": f"campaign_digest::{campaign_id}",
+                    "report_kind": "campaign_digest_lineage_root",
+                    "lineage_root_campaign_id": campaign_id,
+                    "actual_compute_seconds": digest_row.get("actual_compute_seconds"),
+                    "children_count": digest_row.get("children_count"),
+                    "meaningful_classifications": list(digest_row.get("meaningful_classifications") or []),
+                },
+            )
+            _add_edge(
+                edges,
+                campaign_node_id,
+                digest_node_id,
+                "documented_by",
+                evidence_refs=[CAMPAIGN_DIGEST_PATH.as_posix()],
+            )
+        else:
+            contradictions.append(
+                {
+                    "contradiction_id": f"missing_digest::{campaign_id}",
+                    "kind": "missing_campaign_digest_root",
+                    "campaign_id": campaign_id,
+                    "detail": "Campaign has no lineage-root digest evidence.",
+                }
+            )
+
+        for evidence_node_id in (
+            "evidence::source_lifecycle_quality_gate",
+            "evidence::historical_accounting_foundation",
+            "evidence::factor_coverage_matrix",
+            "evidence::grid_candidate_campaign_lineage_bridge",
+            "evidence::source_usefulness_ledger",
+            "evidence::source_quality_readiness",
+            "evidence::campaign_registry",
+        ):
+            _add_edge(
+                edges,
+                campaign_node_id,
+                evidence_node_id,
+                "documented_by",
+                evidence_refs=[CAMPAIGN_DIGEST_PATH.as_posix(), GRID_BRIDGE_PATH.as_posix()],
+            )
+
+    orphan_layer_counts = Counter()
+    for node_id, node in nodes.items():
+        layer = str(node.get("lineage_layer") or "unknown")
+        if layer == "hypothesis":
+            hypothesis_id = str(node.get("label") or "")
+            if not any(edge["source"] == node_id and edge["target"].startswith("campaign::") for edge in edges):
+                orphan_nodes.append(
+                    {
+                        "node_id": node_id,
+                        "lineage_layer": layer,
+                        "reason": "hypothesis_has_no_campaign_reference",
+                    }
+                )
+                orphan_layer_counts[layer] += 1
+        elif layer == "campaign":
+            if not any(edge["source"] == node_id and edge["target"].startswith("evidence::") for edge in edges):
+                orphan_nodes.append(
+                    {
+                        "node_id": node_id,
+                        "lineage_layer": layer,
+                        "reason": "campaign_has_no_evidence_reference",
+                    }
+                )
+                orphan_layer_counts[layer] += 1
+
+    source_count = sum(1 for node in nodes.values() if node.get("lineage_layer") == "source")
+    normalized_count = sum(1 for node in nodes.values() if node.get("lineage_layer") == "normalized_data")
+    factor_count = sum(1 for node in nodes.values() if node.get("lineage_layer") == "factor")
+    hypothesis_count = sum(1 for node in nodes.values() if node.get("lineage_layer") == "hypothesis")
+    campaign_count = sum(1 for node in nodes.values() if node.get("lineage_layer") == "campaign")
+    evidence_count = sum(1 for node in nodes.values() if node.get("lineage_layer") == "evidence")
+    edge_counts = Counter(edge["relation"] for edge in edges)
+
+    if missing_reports or contradictions:
+        graph_status = "blocked"
+    elif orphan_nodes:
+        graph_status = "partial"
+    else:
+        graph_status = "ready"
+
+    summary = {
+        "source_count": source_count,
+        "normalized_data_count": normalized_count,
+        "factor_count": factor_count,
+        "hypothesis_count": hypothesis_count,
+        "campaign_count": campaign_count,
+        "evidence_count": evidence_count,
+        "edge_count": len(edges),
+        "orphan_count": len(orphan_nodes),
+        "contradiction_count": len(contradictions),
+        "graph_status": graph_status,
+        "orphan_layer_counts": dict(sorted(orphan_layer_counts.items())),
+        "edge_relation_counts": dict(sorted(edge_counts.items())),
+        "operator_summary": (
+            "Deterministic lineage graph stays read-only and report-only. Layer-adjacency edges show how source, "
+            "normalized data, factor, hypothesis, campaign, and evidence surfaces are connected without granting "
+            "alpha authority or mutation permission."
+        ),
+    }
+
+    nodes_list = sorted(nodes.values(), key=lambda row: (str(row.get("lineage_layer") or ""), str(row.get("node_id") or "")))
+    edges.sort(key=lambda row: (str(row["source"]), str(row["target"]), str(row["relation"])))
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_kind": REPORT_KIND,
+        "summary": summary,
+        "nodes": nodes_list,
+        "edges": edges,
+        "checks": {
+            "missing_reports": sorted(missing_reports),
+            "orphan_nodes": orphan_nodes,
+            "contradictions": contradictions,
+        },
+        "supporting_reports": {
+            "source_lifecycle_quality_gate": SOURCE_LIFECYCLE_PATH.as_posix(),
+            "historical_accounting_foundation": HISTORICAL_ACCOUNTING_PATH.as_posix(),
+            "factor_coverage_matrix": FACTOR_COVERAGE_PATH.as_posix(),
+            "grid_candidate_campaign_lineage_bridge": GRID_BRIDGE_PATH.as_posix(),
+            "source_usefulness_ledger": SOURCE_USEFULNESS_PATH.as_posix(),
+            "source_quality_readiness": SOURCE_QUALITY_PATH.as_posix(),
+            "strategy_hypothesis_catalog": HYPOTHESIS_CATALOG_PATH.as_posix(),
+            "campaign_registry": CAMPAIGN_REGISTRY_PATH.as_posix(),
+            "campaign_digest": CAMPAIGN_DIGEST_PATH.as_posix(),
+        },
+        "safety_invariants": {
+            "read_only": True,
+            "fetches_external_data": False,
+            "mutates_runtime_state": False,
+            "mutates_research_outputs": False,
+            "mutates_frozen_contracts": False,
+            "paper_shadow_live_forbidden": True,
+            "broker_risk_execution_forbidden": True,
+            "promotion_forbidden": True,
+            "trading_authority_forbidden": True,
+        },
+    }
+
+
+def render_operator_summary(report: Mapping[str, Any]) -> str:
+    summary = report.get("summary") if isinstance(report.get("summary"), Mapping) else {}
+    checks = report.get("checks") if isinstance(report.get("checks"), Mapping) else {}
+    orphan_rows = checks.get("orphan_nodes") if isinstance(checks.get("orphan_nodes"), list) else []
+    contradiction_rows = checks.get("contradictions") if isinstance(checks.get("contradictions"), list) else []
+    return "\n".join(
+        [
+            "# QRE Lineage Graph v1",
+            "",
+            f"- {summary.get('operator_summary') or ''}",
+            "",
+            "## Summary",
+            _table(
+                ["Field", "Value"],
+                [
+                    ["graph_status", str(summary.get("graph_status") or "")],
+                    ["source_count", str(summary.get("source_count") or 0)],
+                    ["normalized_data_count", str(summary.get("normalized_data_count") or 0)],
+                    ["factor_count", str(summary.get("factor_count") or 0)],
+                    ["hypothesis_count", str(summary.get("hypothesis_count") or 0)],
+                    ["campaign_count", str(summary.get("campaign_count") or 0)],
+                    ["evidence_count", str(summary.get("evidence_count") or 0)],
+                    ["orphan_count", str(summary.get("orphan_count") or 0)],
+                    ["contradiction_count", str(summary.get("contradiction_count") or 0)],
+                ],
+            ),
+            "",
+            "## Orphans",
+            _table(
+                ["node_id", "layer", "reason"],
+                [
+                    [
+                        str(row.get("node_id") or ""),
+                        str(row.get("lineage_layer") or ""),
+                        str(row.get("reason") or ""),
+                    ]
+                    for row in orphan_rows
+                    if isinstance(row, Mapping)
+                ],
+            ),
+            "",
+            "## Contradictions",
+            _table(
+                ["contradiction_id", "kind", "detail"],
+                [
+                    [
+                        str(row.get("contradiction_id") or ""),
+                        str(row.get("kind") or ""),
+                        str(row.get("detail") or ""),
+                    ]
+                    for row in contradiction_rows
+                    if isinstance(row, Mapping)
+                ],
+            ),
+            "",
+        ]
+    )
+
+
+def _validate_write_target(path: Path) -> None:
+    if WRITE_PREFIX not in path.as_posix():
+        raise ValueError(f"qre_lineage_graph_v1: refusing write outside allowlist: {path!r}")
+
+
+def write_outputs(report: Mapping[str, Any], *, repo_root: Path = Path(".")) -> dict[str, str]:
+    base = repo_root / DEFAULT_OUTPUT_DIR
+    base.mkdir(parents=True, exist_ok=True)
+    latest = base / LATEST_NAME
+    summary = base / SUMMARY_NAME
+    for target in (latest, summary):
+        _validate_write_target(target)
+
+    tmp_latest = latest.with_suffix(latest.suffix + ".tmp")
+    tmp_latest.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp_latest, latest)
+
+    tmp_summary = summary.with_suffix(summary.suffix + ".tmp")
+    tmp_summary.write_text(render_operator_summary(report), encoding="utf-8")
+    os.replace(tmp_summary, summary)
+    return {
+        "latest": latest.relative_to(repo_root).as_posix(),
+        "operator_summary": summary.relative_to(repo_root).as_posix(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m research.qre_lineage_graph_v1",
+        description="Materialize the read-only QRE lineage graph report.",
+    )
+    parser.add_argument("--write", action="store_true")
+    args = parser.parse_args(argv)
+    report = build_qre_lineage_graph_v1()
+    if args.write:
+        report["_artifact_paths"] = write_outputs(report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/unit/test_qre_lineage_graph_v1.py
+++ b/tests/unit/test_qre_lineage_graph_v1.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from research import qre_lineage_graph_v1 as lineage_graph
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _source_lifecycle_row(**overrides: object) -> dict[str, object]:
+    row: dict[str, object] = {
+        "current_state": "candidate",
+        "gate_statuses": {
+            "allowed_use_declared": True,
+            "forbidden_use_declared": True,
+            "historical_lineage_present": True,
+            "identity_mapping_present": True,
+            "manifest_completeness": True,
+            "quality_gates_declared": True,
+            "quality_gates_passed": True,
+        },
+        "license_block_reasons": [],
+        "license_policy_status": "READY",
+        "lifecycle_status": "ready",
+        "operator_explanation": "fixture",
+        "provider_id": "alpha_vantage_candidate",
+        "source_id": "alpha_vantage_candidate_manifest",
+        "source_quality_ready": True,
+        "transition_targets": {
+            "active_read_only": {"allowed": True, "blocking_reasons": []},
+            "quality_gated": {"allowed": True, "blocking_reasons": []},
+        },
+    }
+    row.update(overrides)
+    return row
+
+
+def _factor_row(**overrides: object) -> dict[str, object]:
+    row: dict[str, object] = {
+        "factor_id": "factor_alpha",
+        "field_coverage_status": "COVERED",
+        "provider_coverage_count": 1,
+        "coverage_block_reasons": [],
+        "provider_rows": [
+            {
+                "provider_id": "alpha_vantage_candidate",
+                "provider_name": "Alpha Vantage",
+                "manifest_status": "VALID",
+                "approval_status": "APPROVED_READ_ONLY",
+                "freshness_status": "DECLARED",
+            }
+        ],
+    }
+    row.update(overrides)
+    return row
+
+
+def _campaign_row(**overrides: object) -> dict[str, object]:
+    row: dict[str, object] = {
+        "campaign_id": "col-1",
+        "hypothesis_id": "hyp-1",
+        "state": "completed",
+        "outcome": "completed_no_survivor",
+        "lineage_root_campaign_id": "col-1",
+        "meaningful_classification": "duplicate_low_value_run",
+    }
+    row.update(overrides)
+    return row
+
+
+def _write_required_fixture_set(
+    tmp_path: Path,
+    *,
+    catalog_hypothesis_id: str = "hyp-1",
+    campaign_hypothesis_id: str = "hyp-1",
+) -> None:
+    _write_json(
+        tmp_path / "logs" / "qre_source_lifecycle_quality_gate" / "latest.json",
+        {"report_kind": "qre_source_lifecycle_quality_gate", "rows": [_source_lifecycle_row()]},
+    )
+    _write_json(
+        tmp_path / "logs" / "qre_historical_accounting_foundation" / "latest.json",
+        {
+            "report_kind": "qre_historical_accounting_foundation",
+            "rows": [
+                {
+                    "provider_id": "alpha_vantage_candidate",
+                    "source_id": "alpha_vantage_candidate_manifest",
+                    "snapshot_contract_status": "READY",
+                }
+            ],
+        },
+    )
+    _write_json(
+        tmp_path / "logs" / "qre_factor_coverage_matrix" / "latest.json",
+        {"report_kind": "qre_factor_coverage_matrix", "factor_rows": [_factor_row()], "rows": [_factor_row()]},
+    )
+    _write_json(
+        tmp_path / "logs" / "qre_grid_candidate_campaign_lineage_bridge" / "latest.json",
+        {
+            "report_kind": "qre_grid_candidate_campaign_lineage_bridge",
+            "rows": [
+                {
+                    "asset": "AAPL",
+                    "basket_id": "seed::AAPL",
+                    "campaign_lineage_status": "visible",
+                    "candidate_lineage_status": "visible",
+                    "exact_next_action": "keep_fail_closed",
+                    "join_key_status": "grid_row_match_found",
+                    "lineage_bridge_status": "lineage_visible",
+                    "matched_grid_rows_count": 1,
+                    "operator_explanation": "fixture",
+                    "preset": "trend_pullback",
+                }
+            ],
+        },
+    )
+    _write_json(
+        tmp_path / "logs" / "qre_source_usefulness_ledger" / "latest.json",
+        {
+            "report_kind": "qre_source_usefulness_ledger",
+            "rows": [
+                {
+                    "source": "alpha_vantage_candidate",
+                    "usefulness_state": "useful",
+                    "ready_ratio": 1.0,
+                }
+            ],
+        },
+    )
+    _write_json(
+        tmp_path / "logs" / "qre_data_source_quality_readiness" / "latest.json",
+        {
+            "report_kind": "qre_data_source_quality_readiness",
+            "rows": [
+                {
+                    "source": "alpha_vantage_candidate",
+                    "instrument": "AAPL",
+                    "timeframe": "1d",
+                    "quality_status": "ready",
+                    "manifest_status": "ready",
+                    "identity_confidence": "high",
+                }
+            ],
+        },
+    )
+    _write_json(
+        tmp_path / "research" / "strategy_hypothesis_catalog_latest.v1.json",
+        {
+            "report_kind": "strategy_hypothesis_catalog",
+            "hypotheses": [
+                {
+                    "hypothesis_id": catalog_hypothesis_id,
+                    "status": "active_discovery",
+                    "strategy_family": "trend_pullback",
+                    "feature_dependencies": ["ema_fast", "ema_slow"],
+                    "baseline_reference": "ema_trend_baseline",
+                }
+            ],
+        },
+    )
+    _write_json(
+        tmp_path / "research" / "campaign_registry_latest.v1.json",
+        {
+            "report_kind": "campaign_registry",
+            "campaigns": {
+                "col-1": _campaign_row(hypothesis_id=campaign_hypothesis_id),
+            },
+        },
+    )
+    _write_json(
+        tmp_path / "research" / "campaign_digest_latest.v1.json",
+        {
+            "report_kind": "campaign_digest",
+            "compute_by_lineage_root": {
+                "col-1": {"actual_compute_seconds": 10, "children_count": 1, "meaningful_classifications": ["duplicate_low_value_run"]}
+            },
+        },
+    )
+
+
+def test_lineage_graph_builds_complete_read_only_graph(tmp_path: Path) -> None:
+    _write_required_fixture_set(tmp_path)
+    report = lineage_graph.build_qre_lineage_graph_v1(repo_root=tmp_path)
+    summary = report["summary"]
+    checks = report["checks"]
+    assert summary["graph_status"] == "ready"
+    assert summary["source_count"] == 1
+    assert summary["normalized_data_count"] == 1
+    assert summary["factor_count"] == 1
+    assert summary["hypothesis_count"] == 1
+    assert summary["campaign_count"] == 1
+    assert summary["evidence_count"] >= 8
+    assert checks["missing_reports"] == []
+    assert checks["orphan_nodes"] == []
+    assert checks["contradictions"] == []
+    node_types = {str(node["node_type"]) for node in report["nodes"]}
+    assert {"source", "normalized_data", "factor", "hypothesis", "campaign", "evidence"} <= node_types
+
+
+def test_lineage_graph_flags_missing_hypothesis_as_contradiction(tmp_path: Path) -> None:
+    _write_required_fixture_set(tmp_path, catalog_hypothesis_id="hyp-1", campaign_hypothesis_id="missing_hypothesis")
+    report = lineage_graph.build_qre_lineage_graph_v1(repo_root=tmp_path)
+    checks = report["checks"]
+    assert report["summary"]["graph_status"] == "blocked"
+    assert any(row["kind"] == "missing_hypothesis_reference" for row in checks["contradictions"])
+    assert any(row["lineage_layer"] == "hypothesis" for row in checks["orphan_nodes"])
+
+
+def test_lineage_graph_blocks_when_required_report_missing(tmp_path: Path) -> None:
+    _write_required_fixture_set(tmp_path)
+    missing = tmp_path / "research" / "campaign_digest_latest.v1.json"
+    missing.unlink()
+    report = lineage_graph.build_qre_lineage_graph_v1(repo_root=tmp_path)
+    assert report["summary"]["graph_status"] == "blocked"
+    assert "research/campaign_digest_latest.v1.json" in report["checks"]["missing_reports"]
+
+
+def test_lineage_graph_writes_outputs(tmp_path: Path) -> None:
+    _write_required_fixture_set(tmp_path)
+    report = lineage_graph.build_qre_lineage_graph_v1(repo_root=tmp_path)
+    paths = lineage_graph.write_outputs(report, repo_root=tmp_path)
+    summary = (tmp_path / paths["operator_summary"]).read_text(encoding="utf-8")
+    assert paths["latest"] == "logs/qre_lineage_graph_v1/latest.json"
+    assert "# QRE Lineage Graph v1" in summary


### PR DESCRIPTION
PR8 implements the deterministic read-only lineage graph baseline.

Scope:
- research/qre_lineage_graph_v1.py
- tests/unit/test_qre_lineage_graph_v1.py

Validation:
- python -m pytest tests/unit/test_qre_lineage_graph_v1.py -q
- python -m pytest tests/unit/test_qre_lineage_graph_v1.py tests/unit/test_qre_grid_candidate_campaign_lineage_bridge.py tests/unit/test_qre_local_grid_artifact_refresh.py tests/unit/test_qre_historical_accounting_foundation.py tests/unit/test_qre_factor_coverage_matrix.py tests/unit/test_qre_source_usefulness_ledger.py tests/unit/test_qre_source_lifecycle_quality_gate.py -q
- python scripts/governance_lint.py
- python -m pytest tests/smoke -q
- python -m pytest tests/architecture/test_domain_import_scanner.py -q
- git diff --check
- frozen contract diff unchanged

Operator pre-approval: routine NEEDS_HUMAN path-scope classification is covered for PR1-PR18 research/data/readiness/report-only paths.